### PR TITLE
fix(S283): PWA resume — last building from localStorage

### DIFF
--- a/viewer/config.js
+++ b/viewer/config.js
@@ -1,10 +1,19 @@
 // config.js — URL params, discipline colours, constants
+
+// §S282b: Platform detection — set once, before any UI module reads it.
+// pill_builder.js, scene.js, time_machine.js all read window._isMobile at init.
+window._isMobile = ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+
 function setupConfig(A) {
   const _params = new URLSearchParams(location.search);
   // Auto-resolve: if hosted on OCI Object Storage, use same bucket base for DB URLs
   const _ociMatch = location.href.match(/(https:\/\/objectstorage\.[^/]+\/n\/[^/]+\/b\/[^/]+\/o\/)/);
   const _base = _ociMatch ? _ociMatch[1] : '';
-  A.DB_URL = _params.get('db') || (_base ? _base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db');
+  // §S283: If no ?db= param, try last building from localStorage (PWA resume), then default
+  var _lastDb = null;
+  try { _lastDb = localStorage.getItem('pwa_last_db'); } catch(e) {}
+  A.DB_URL = _params.get('db') || _lastDb || (_base ? _base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db');
+  if (_lastDb && !_params.get('db')) console.log('§PWA_RESUME db=' + _lastDb);
   A.CITY_URL = _params.get('city') || null;
   A.BLD_BASE = _params.get('bldbase') || '';
 

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1512,6 +1512,8 @@ function setupStreaming(A) {
       var dbBuf = await A.cachedFetch(A.DB_URL);
       A.db = new SQL.Database(new Uint8Array(dbBuf));
       console.log(`[S192] §DB_LOADED size=${(dbBuf.byteLength/1024/1024).toFixed(0)}MB`);
+      // §S283: Remember last building URL for PWA resume
+      try { localStorage.setItem('pwa_last_db', A.DB_URL); } catch(e) {}
       A.status.textContent = (typeof _TRL!=='undefined'&&_TRL.ui_status_db_loaded||'DB loaded ({size}MB). Querying...').replace('{size}',(dbBuf.byteLength/1024/1024).toFixed(0));
     }
 


### PR DESCRIPTION
## Summary
- Save `DB_URL` to `localStorage` after successful building load (`streaming.js`)
- On launch without `?db=` param (installed PWA), restore from `localStorage` instead of defaulting to Duplex
- Fallback chain: `?db=` param → `localStorage pwa_last_db` → Duplex default

## Test plan
- [ ] Load SampleCastle in viewer, verify `pwa_last_db` saved in localStorage
- [ ] Open viewer without `?db=` param → should load SampleCastle, not Duplex
- [ ] `§PWA_RESUME db=` log tag appears
- [ ] With `?db=` param → still uses the param (override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)