### PR TITLE
feat(S282b+S284): PanelNav, ListBuilder, _isMobile registry, Save Offline Copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,20 +497,27 @@ window._TRL = window._TRL || {};
 async function loadManifest() {
   const loadingEl = document.getElementById('loading');
   try {
-    const url = (_base || '') + 'manifest.json';
-    const ctrl = new AbortController();
-    const tid = setTimeout(() => ctrl.abort(), 10000);
-    let resp;
-    try {
-      resp = await fetch(url, { signal: ctrl.signal });
-      clearTimeout(tid);
-    } catch(e) {
-      clearTimeout(tid);
-      throw new Error(e.name === 'AbortError' ? 'Timed out — check connection' : e.message);
+    var data;
+    // §S284: Use embedded snapshot if standalone (packaged HTML from file://)
+    if (window._MANIFEST_SNAPSHOT) {
+      data = window._MANIFEST_SNAPSHOT;
+    } else {
+      const url = (_base || '') + 'manifest.json';
+      const ctrl = new AbortController();
+      const tid = setTimeout(() => ctrl.abort(), 10000);
+      let resp;
+      try {
+        resp = await fetch(url, { signal: ctrl.signal });
+        clearTimeout(tid);
+      } catch(e) {
+        clearTimeout(tid);
+        throw new Error(e.name === 'AbortError' ? 'Timed out — check connection' : e.message);
+      }
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      data = await resp.json();
     }
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const data = await resp.json();
     if (!data || !Array.isArray(data.archetypes)) throw new Error('Manifest missing archetypes');
+    window._manifestData = data; // §S284: stash for packageLandingPage()
 
     clearInterval(timerInterval);
     document.getElementById('loading').style.display = 'none';
@@ -1621,6 +1628,7 @@ async function exportProjectIFC(projectKey, flyout) {
       <a href="javascript:void(0)" onclick="document.getElementById('about-dialog').classList.remove('active');if(window.APP&&APP.reportBug)APP.reportBug();else window.open('https://github.com/red1oon/bim-ootb/issues/new?labels=bug','_blank')" style="color:#ff8a65;text-decoration:none">&#128027; Report Bug</a>
     </div>
     <a href="javascript:void(0)" onclick="document.getElementById('about-dialog').classList.remove('active');document.getElementById('diy-dialog').classList.add('active')" style="color:#e8a735;font-size:11px;text-decoration:none;cursor:pointer">&#128736; DIY Downloader</a>
+    <br><a href="javascript:void(0)" onclick="packageLandingPage()" style="color:#4fc3f7;font-size:11px;text-decoration:none;cursor:pointer">&#128190; Save Offline Copy</a>
   </div>
 </div>
 <style>#about-dialog.active{display:flex!important}#diy-dialog.active{display:flex!important}</style>
@@ -1673,6 +1681,68 @@ async function exportProjectIFC(projectKey, flyout) {
 </div>
 
 <script>
+// §S284: Package landing page as self-contained offline HTML
+async function packageLandingPage() {
+  var statusEl = document.getElementById('import-status');
+  if (statusEl) statusEl.textContent = 'Packaging offline copy...';
+  try {
+    // 1. Fetch external JS files that need inlining
+    var dbBuilderSrc = await fetch('viewer/import_db_builder.js?v=3').then(function(r) { return r.text(); });
+    var localeSrc = await fetch('viewer/locale_loader.js?v=7').then(function(r) { return r.text(); });
+
+    // 2. Fetch Sysnova.png as base64 data URI
+    var pngBlob = await fetch('Sysnova.png').then(function(r) { return r.blob(); });
+    var pngB64 = await new Promise(function(cb) {
+      var rd = new FileReader(); rd.onload = function() { cb(rd.result); }; rd.readAsDataURL(pngBlob);
+    });
+
+    // 3. Snapshot manifest (already in memory from init)
+    var manifestJSON = JSON.stringify(window._manifestData || {archetypes:[]});
+
+    // 4. Get the full page HTML
+    var html = '<!DOCTYPE html>\n<html>' + document.documentElement.innerHTML + '</html>';
+
+    // 5. Inline external scripts
+    html = html.replace(/<script src="viewer\/import_db_builder\.js[^"]*"><\/script>/, '<script>\n' + dbBuilderSrc + '\n<\/script>');
+    html = html.replace(/<script src="viewer\/locale_loader\.js[^"]*"><\/script>/, '<script>\n' + localeSrc + '\n<\/script>');
+
+    // 6. Sysnova.png → base64
+    html = html.replace(/src="Sysnova\.png"/g, 'src="' + pngB64 + '"');
+
+    // 7. Strip analytics (goatcounter)
+    html = html.replace(/<script[^>]*goatcounter[^>]*><\/script>/g, '');
+
+    // 8. Inject standalone flag + manifest snapshot before first inline script body
+    // Find the config script block and inject after the opening <script>
+    var configTag = '<script>\n// \u2500\u2500 Config \u2500\u2500';
+    html = html.replace(configTag, '<script>\n// \u00a7S284: Standalone offline copy\nwindow._STANDALONE = true;\nwindow._MANIFEST_SNAPSHOT = ' + manifestJSON + ';\n// \u2500\u2500 Config \u2500\u2500');
+
+    // 9. Fix relative URLs to absolute GitHub Pages (so cards open viewer online)
+    var ghBase = 'https://red1oon.github.io/bim-ootb/';
+    // openViewer builds: viewerUrl + '?db=' + bldBase + bld.db
+    // _prodBase already absolute (OCI). viewerFile is relative — fix it.
+    html = html.replace(
+      /const viewerFile = [^;]+;/,
+      "const viewerFile = '" + ghBase + "viewer/viewer.html';"
+    );
+
+    // 10. Download
+    var blob = new Blob([html], {type: 'text/html;charset=utf-8'});
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'BIM-OOTB.html';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+    if (statusEl) statusEl.textContent = '';
+    console.log('\u00a7PACK_DOWNLOAD size=' + blob.size + ' bytes');
+  } catch(e) {
+    if (statusEl) statusEl.textContent = 'Package failed: ' + e.message;
+    console.error('\u00a7PACK_FAIL', e);
+  }
+}
+
 function downloadDIYScript() {
   var isWin = navigator.platform.indexOf('Win') > -1;
   var script, filename, mime;

--- a/tests/test_s282b_panel_nav.js
+++ b/tests/test_s282b_panel_nav.js
@@ -1184,6 +1184,89 @@ console.log('\n§S282b_TEST Shortcut function wiring — _shortcuts dispatch');
 
 
 // ══════════════════════════════════════════════
+// PART 7: _isMobile registry — single source in config.js, no re-detection
+// ══════════════════════════════════════════════
+console.log('\n§S282b_TEST _isMobile registry — single source, no re-detection');
+
+(function() {
+  var uiFiles = [
+    'pill_builder.js', 'clash_matrix.js', 'measure.js', 'navigate_controls.js',
+    'panels.js', 'time_machine.js', 'main.js'
+  ];
+  var rendererFiles = ['effects.js', 'streaming.js', 'scene.js'];
+
+  var configSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'config.js'), 'utf8');
+  var setMatches = configSrc.match(/window\._isMobile\s*=/g) || [];
+  check('21.1 config.js sets window._isMobile exactly once', setMatches.length === 1);
+  check('21.2 config.js uses ontouchstart', configSrc.indexOf('ontouchstart') >= 0);
+  check('21.3 config.js uses maxTouchPoints', configSrc.indexOf('maxTouchPoints') >= 0);
+
+  var reDetectPattern = /('ontouchstart'\s*in\s*window|navigator\.maxTouchPoints\s*>)/;
+  var violations = [];
+  uiFiles.forEach(function(f) {
+    var src;
+    try { src = fs.readFileSync(path.join(__dirname, '..', 'viewer', f), 'utf8'); } catch(e) { return; }
+    src.split('\n').forEach(function(line, idx) {
+      if (reDetectPattern.test(line)) {
+        violations.push(f + ':' + (idx + 1) + ' → ' + line.trim().slice(0, 80));
+      }
+    });
+  });
+  check('21.4 no UI file re-detects mobile (' + uiFiles.length + ' files checked)',
+    violations.length === 0,
+    violations.length ? violations.join(' | ') : '');
+
+  var localCopyPattern = /var\s+_isMobile\s*=/;
+  var copies = [];
+  uiFiles.forEach(function(f) {
+    var src;
+    try { src = fs.readFileSync(path.join(__dirname, '..', 'viewer', f), 'utf8'); } catch(e) { return; }
+    src.split('\n').forEach(function(line, idx) {
+      if (localCopyPattern.test(line)) {
+        copies.push(f + ':' + (idx + 1));
+      }
+    });
+  });
+  check('21.5 no UI file has var _isMobile local copy', copies.length === 0,
+    copies.length ? copies.join(', ') : '');
+
+  rendererFiles.forEach(function(f) {
+    var src;
+    try { src = fs.readFileSync(path.join(__dirname, '..', 'viewer', f), 'utf8'); } catch(e) { return; }
+    var hasScreenWidth = src.indexOf('screen.width') >= 0;
+    check('21.7.' + f + ' has screen.width threshold (renderer-specific)', hasScreenWidth);
+  });
+
+  var mainSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'main.js'), 'utf8');
+  var mainSets = (mainSrc.match(/window\._isMobile\s*=/g) || []);
+  check('21.8 main.js does NOT set window._isMobile', mainSets.length === 0);
+
+  var pbSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'pill_builder.js'), 'utf8');
+  check('21.9 pill_builder.js reads window._isMobile', pbSrc.indexOf('window._isMobile') >= 0);
+
+  var viewerHtml = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'viewer.html'), 'utf8');
+  var configPos = viewerHtml.indexOf('src="config.js');
+  var pillPos = viewerHtml.indexOf('src="pill_builder.js');
+  var panelsPos = viewerHtml.indexOf('src="panels.js');
+  var mainPos = viewerHtml.indexOf('src="main.js');
+  check('21.10 load order: config.js before pill_builder.js', configPos > 0 && configPos < pillPos);
+  check('21.11 load order: pill_builder.js before panels.js', pillPos > 0 && pillPos < panelsPos);
+  check('21.12 load order: panels.js before main.js', panelsPos > 0 && panelsPos < mainPos);
+
+  var sb = buildSandbox();
+  sb.window.ontouchstart = true;
+  sb.navigator = { maxTouchPoints: 5, userAgent: '' };
+  vm.runInContext(configSrc, sb);
+  check('21.13 mobile sim: window._isMobile = true', sb.window._isMobile === true);
+
+  var sb2 = buildSandbox();
+  sb2.navigator = { maxTouchPoints: 0, userAgent: '' };
+  vm.runInContext(configSrc, sb2);
+  check('21.14 desktop sim: window._isMobile = false', sb2.window._isMobile === false);
+})();
+
+
+// ══════════════════════════════════════════════
 // Summary
 // ══════════════════════════════════════════════
 console.log('\n' + pass + ' PASS, ' + fail + ' FAIL — ' + (pass + fail) + ' total');

--- a/viewer/clash_matrix.js
+++ b/viewer/clash_matrix.js
@@ -7,8 +7,7 @@
  */
 // Implementing S278_REFACTOR_CLASH_PANELS.md §Phase 2 — Witness: W-CLASH_MATRIX
 function setupClashMatrix(A) {
-  var _isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-  var _panelBgStrong = _isMobile ? 'background:rgba(15,45,80,0.95);' : 'background:rgba(20,60,100,0.65);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);';
+  var _panelBgStrong = window._isMobile ? 'background:rgba(15,45,80,0.95);' : 'background:rgba(20,60,100,0.65);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);';
 
   // §S278: Cache discipline element lists — reused across matrix count calls
   A._clashDiscCache = {};
@@ -139,8 +138,8 @@ function setupClashMatrix(A) {
 
     // Build table — pulsing sphere = pending check, green = clear
     // S251: mobile → true triangle: X top-right, export bottom-right, collapse green rows
-    var cellSz = _isMobile ? 28 : 36;
-    var triMode = _isMobile;
+    var cellSz = window._isMobile ? 28 : 36;
+    var triMode = window._isMobile;
     var activePairs = [];
     var _buildCellHtml = function(rowDisc, colDisc, sz) {
       var key = rowDisc + '|' + colDisc;
@@ -214,12 +213,12 @@ function setupClashMatrix(A) {
     }
 
     var matDiv = document.createElement('div');
-    matDiv.style.cssText = 'position:fixed;z-index:350;' + (_isMobile ? '' : _panelBgStrong) + 'color:#fff;padding:' + (_isMobile ? '0' : '10px') + ';border-radius:8px;' + (_isMobile ? 'background:transparent;border:none;pointer-events:none;' : 'border:1px solid rgba(79,195,247,0.5);pointer-events:auto;') + 'font-family:Segoe UI,sans-serif';
+    matDiv.style.cssText = 'position:fixed;z-index:350;' + (window._isMobile ? '' : _panelBgStrong) + 'color:#fff;padding:' + (window._isMobile ? '0' : '10px') + ';border-radius:8px;' + (window._isMobile ? 'background:transparent;border:none;pointer-events:none;' : 'border:1px solid rgba(79,195,247,0.5);pointer-events:auto;') + 'font-family:Segoe UI,sans-serif';
 
     // Position: mobile → left-side bottom corner (triangle layout, not draggable);
     //           desktop → below info card, draggable
     var anchorRect = anchorDiv.getBoundingClientRect();
-    if (_isMobile) {
+    if (window._isMobile) {
       matDiv.style.right = '4px';
       matDiv.style.bottom = '4px';
       matDiv.style.maxHeight = '60vh';
@@ -228,7 +227,7 @@ function setupClashMatrix(A) {
       matDiv.style.right = '10px';
     }
     var scopeLabel = storey ? storey : 'Whole Building';
-    if (_isMobile) {
+    if (window._isMobile) {
       // Mobile: X and export are inside the triangle layout itself
       matDiv.innerHTML = html;
     } else {
@@ -241,7 +240,7 @@ function setupClashMatrix(A) {
     }
     document.body.appendChild(matDiv);
     // Adjust vertical to fit (desktop only — mobile uses bottom:6px)
-    if (!_isMobile) {
+    if (!window._isMobile) {
       var matH = matDiv.offsetHeight;
       var topPos = anchorRect.bottom + 6;
       if (topPos + matH > window.innerHeight - 10) topPos = window.innerHeight - matH - 10;

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -145,7 +145,7 @@ async function initViewer() {
   if (APP.toggleNlp) window.toggleNlp = APP.toggleNlp;
   window.toggleVariance = function() { if (APP.toggleVariance) APP.toggleVariance(); };
   // 2D button: toggle grid overlay in same scene (no new tab)
-  window._isMobile = ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+  // §S282b: _isMobile now set in config.js (before pill_builder reads it)
   window.open2DPlans = function() {
     if (window._isMobile) { APP.status.textContent = '2D views are desktop-only'; console.log('§2D_GATE skip — mobile'); return; }
     // Block if Measure is active

--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -3,19 +3,18 @@
 function setupMeasure(A) {
   console.log('§MEASURE_VERSION S245e-v1');
 
-  // Mobile detection — disable backdrop-filter blur (GPU-expensive on mobile)
-  var _isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-  var _panelBg = _isMobile ? 'background:rgba(15,45,80,0.92);' : 'background:rgba(20,60,100,0.55);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);';
-  var _panelBgStrong = _isMobile ? 'background:rgba(15,45,80,0.95);' : 'background:rgba(20,60,100,0.65);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);';
+  // §S282b: window._isMobile set in config.js — no local copy
+  var _panelBg = window._isMobile ? 'background:rgba(15,45,80,0.92);' : 'background:rgba(20,60,100,0.55);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);';
+  var _panelBgStrong = window._isMobile ? 'background:rgba(15,45,80,0.95);' : 'background:rgba(20,60,100,0.65);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);';
 
   // ── Draggable panels ──
   A._makeDraggable = function(el) {
     var ox, oy, sx, sy, dragging = false;
-    var dragStrip = _isMobile ? 50 : 30;
+    var dragStrip = window._isMobile ? 50 : 30;
     el.style.cursor = 'grab';
     // On mobile, intercept touch BEFORE the browser claims it for scroll/pan.
     // Only preventDefault in the drag zone; elsewhere let browser handle normally.
-    if (_isMobile) {
+    if (window._isMobile) {
       el.addEventListener('touchstart', function(e) {
         if (e.target.tagName === 'INPUT') return;
         if (e.target.closest('[data-clash-idx]') || e.target.closest('[data-pair]')) return;
@@ -795,7 +794,7 @@ function setupMeasure(A) {
     var listDiv = document.createElement('div');
     listDiv.style.cssText = 'position:fixed;z-index:400;' + _panelBg + 'color:#fff;font-size:11px;padding:0;border-radius:8px;border:1px solid rgba(255,140,0,0.6);font-family:Segoe UI,sans-serif;line-height:1.5;min-width:180px;max-width:240px;max-height:40vh;display:flex;flex-direction:column;pointer-events:auto';
     // Position: right-aligned, above matrix corner on both mobile and desktop
-    listDiv.style.right = _isMobile ? '6px' : '10px';
+    listDiv.style.right = window._isMobile ? '6px' : '10px';
     if (A._clashMatrixDiv) {
       var matRect = A._clashMatrixDiv.getBoundingClientRect();
       listDiv.style.bottom = (window.innerHeight - matRect.top + 6) + 'px';
@@ -996,7 +995,7 @@ function setupMeasure(A) {
       }
       // §S278: Desktop click suppressed — pointerup already routed through ListKeyNav.
       // Without this guard, Ctrl+click would toggle twice (on→off = no change).
-      if (!_isMobile) {
+      if (!window._isMobile) {
         var target = ev.target.closest('[data-clash-idx]');
         if (target && !A._clashListNav) {
           A._flyToClash(parseInt(target.getAttribute('data-clash-idx')));
@@ -1099,9 +1098,8 @@ function setupMeasure(A) {
     // Grey out / restore 2D button
     var g2d = document.getElementById('grid-2d-btn');
     if (g2d) { g2d.style.opacity = A.measureActive ? '0.3' : '1'; }
-    var isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     A.status.textContent = A.measureActive
-      ? (isMobile ? (typeof _TRL!=='undefined'&&_TRL.ui_measure_hint_mobile||'Tap for dimensions. Long-press for Info. Tap here to exit.') : (typeof _TRL!=='undefined'&&_TRL.ui_measure_hint||'Click for dimensions. Right-click for Info'))
+      ? (window._isMobile ? (typeof _TRL!=='undefined'&&_TRL.ui_measure_hint_mobile||'Tap for dimensions. Long-press for Info. Tap here to exit.') : (typeof _TRL!=='undefined'&&_TRL.ui_measure_hint||'Click for dimensions. Right-click for Info'))
       : '';
     // Mobile: tap status bar to exit measure mode
     if (A.measureActive && isMobile) {
@@ -1494,7 +1492,7 @@ function setupMeasure(A) {
       var _openMatrix = function() { A._showClashMatrix(rules, cardDiv); };
       var _updateSphere = function(color) {
         clashEl.innerHTML = '<span id="clash-tap-trigger" style="cursor:pointer;padding:6px 0">' +
-          'CLASHES ' + _sphere(color, _isMobile ? 22 : 18) + '</span>';
+          'CLASHES ' + _sphere(color, window._isMobile ? 22 : 18) + '</span>';
         var trigger = cardDiv.querySelector('#clash-tap-trigger');
         if (trigger) {
           trigger.addEventListener('pointerup', _openMatrix);

--- a/viewer/navigate_controls.js
+++ b/viewer/navigate_controls.js
@@ -26,7 +26,7 @@
 
     // ── Desktop pointer lock (FPS mouse look) ──
     function setupPointerLock() {
-      if ('ontouchstart' in window) return;
+      if (window._isMobile) return;
       var canvas = document.getElementById('canvas') || document.querySelector('canvas');
       if (!canvas) return;
 

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1288,11 +1288,17 @@ async function setupScene(A) {
         : (cr.actual != null
           ? '<div style="color:#ff8a65;font-size:11px;margin-bottom:8px">\u26A0 ' + cr.actual + '/' + cr.expected + ' files cached</div>'
           : '');
-      statusEl.innerHTML = verifyLine +
-        '<div style="color:#4caf50;font-weight:700;margin-bottom:8px">Ready for offline use!</div>' +
-        '<div style="font-size:12px;color:#ccc;line-height:1.6">' +
-        'Look for the install icon <b style="color:#4fc3f7;font-size:16px">\u229E</b> in your browser\'s address bar.<br>' +
-        'Or close this tab, wait 30 seconds, and revisit to get the install prompt.</div>';
+      var _isFirefox = /Firefox\//.test(navigator.userAgent);
+      var instructionHtml = _isFirefox
+        ? '<div style="color:#4caf50;font-weight:700;margin-bottom:8px">Works offline in this tab!</div>' +
+          '<div style="font-size:12px;color:#ccc;line-height:1.6">' +
+          'Firefox does not support home screen install.<br>' +
+          'For home screen shortcut, open in <b style="color:#4fc3f7">Chrome</b> or <b style="color:#4fc3f7">Edge</b>.</div>'
+        : '<div style="color:#4caf50;font-weight:700;margin-bottom:8px">Ready for offline use!</div>' +
+          '<div style="font-size:12px;color:#ccc;line-height:1.6">' +
+          'Look for the install icon <b style="color:#4fc3f7;font-size:16px">\u229E</b> in your browser\'s address bar.<br>' +
+          'Or close this tab, wait 30 seconds, and revisit to get the install prompt.</div>';
+      statusEl.innerHTML = verifyLine + instructionHtml;
     }
     ov.showButtons(
       '<button id="pwa-fallback-ok" style="padding:8px 24px;background:#4fc3f7;color:#000;border:none;' +


### PR DESCRIPTION
## Summary
- **S282b PanelNav**: universal zone-based keyboard nav for panels. Fixes ArrowDown-from-input bug in Find. Settings panel navigable with arrows.
- **S282b ListBuilder**: reorderable list extraction from PillBuilder. Settings pill rows use it.
- **S282b _isMobile registry**: single source in config.js, no UI re-detection. Renderer files keep stricter screen.width checks.
- **S282b Status bar**: persists in maxed ([][]) mode.
- **S284 Save Offline Copy**: About box button packages landing page as self-contained BIM-OOTB.html (~250KB). Manifest snapshot embedded, viewer URLs absolute GitHub Pages.

## Test plan
- [x] 143 whitebox tests pass (test_s282b_panel_nav.js)
- [x] CI fast-checks green (syntax, SW precache, script tags, input registry)
- [x] CI e2e-tests green (golden path Playwright)
- [ ] Manual: About → Save Offline Copy → open BIM-OOTB.html from file://
- [ ] Manual: verify building cards render offline, click opens GH Pages viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)