### PR TITLE
fix(S285): city viewer apples-to-apples — no picking list, ground median, new-tab CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
     <div style="display:flex; align-items:center; gap:12px; margin-bottom:6px">
       <span data-trl="landing_complete_city" style="font-size:14px; font-weight:700; color:#0277bd; letter-spacing:1px">COMPLETE THE CITY</span>
       <span id="city-count" style="font-size:12px; color:#888">0 / 30 <span data-trl="landing_buildings_explored">buildings explored</span></span>
-      <a href="LargeCity.html" data-trl="landing_cannot_wait" style="margin-left:auto; font-size:14px; font-weight:700; color:#44cc44; letter-spacing:1px; text-decoration:none">I CANNOT WAIT!</a>
+      <a href="LargeCity.html" target="_blank" rel="noopener" data-trl="landing_cannot_wait" style="margin-left:auto; font-size:14px; font-weight:700; color:#44cc44; letter-spacing:1px; text-decoration:none">I CANNOT WAIT!</a>
     </div>
     <div style="height:8px; background:#222; border-radius:4px; overflow:hidden">
       <div id="city-bar" style="height:100%; width:0%; background:linear-gradient(90deg,#0277bd,#44cc44); border-radius:4px; transition:width 0.4s ease"></div>
@@ -1792,7 +1792,28 @@ async function packageLandingPage() {
       'window._MANIFEST_SNAPSHOT = ' + manifestJSON + ';\n' +
       'window._WORKER_SOURCES = ' + workerJSON + ';\n' +
       (sqlWasmJs ? 'window._SQL_WASM_JS = ' + JSON.stringify(sqlWasmJs) + ';\n' : '') +
-      (sqlWasmB64 ? 'window._SQL_WASM_B64 = "' + sqlWasmB64 + '";\n' : '');
+      (sqlWasmB64 ? 'window._SQL_WASM_B64 = "' + sqlWasmB64 + '";\n' : '') +
+      // §S284c: Blob viewer opener — same-origin as landing page → shares IndexedDB after IFC import
+      'window._openViewerBlob = function(qs) {\n' +
+      '  var el = document.getElementById("viewer-html-src");\n' +
+      '  if (!el) return null;\n' +
+      '  var vHtml = el.textContent.split("<\\/script>").join("</script>");\n' +
+      '  var blob = new Blob([vHtml], {type: "text/html"});\n' +
+      '  var bUrl = URL.createObjectURL(blob);\n' +
+      '  var win = (window._origOpen||window.open)(bUrl + qs, "_blank");\n' +
+      '  setTimeout(function(){URL.revokeObjectURL(bUrl);}, 20000);\n' +
+      '  return win;\n' +
+      '};\n' +
+      '(function(){\n' +
+      '  var _o=window.open; window._origOpen=_o;\n' +
+      '  window.open=function(url,t,f){\n' +
+      '    if(url&&typeof url==="string"&&url.indexOf("viewer/viewer.html")>=0){\n' +
+      '      var qs=url.indexOf("?")>=0?url.slice(url.indexOf("?")):"";\n' +
+      '      return window._openViewerBlob(qs)||_o.apply(this,arguments);\n' +
+      '    }\n' +
+      '    return _o.apply(this,arguments);\n' +
+      '  };\n' +
+      '})();\n';
     // §S284b: Use function replacement to avoid $' $& $` corruption in worker/WASM sources
     html = html.replace('// \u2500\u2500 Config \u2500\u2500', function() { return standaloneBlock + '// \u2500\u2500 Config \u2500\u2500'; });
 
@@ -1809,6 +1830,94 @@ async function packageLandingPage() {
       /const viewerFile = [^;]+;/,
       "const viewerFile = '" + ghBase + "viewer/viewer.html';"
     );
+
+    // 9b. Replace online CI badge with static "offline" badge
+    html = html.replace(
+      /<img[^>]*github\.com\/red1oon\/bim-ootb\/actions[^>]*>/g,
+      '<span style="display:inline-flex;align-items:center;padding:2px 7px;background:#2a7;border-radius:3px;font-size:10px;font-family:sans-serif;color:#fff;letter-spacing:.5px">&#10003; offline</span>'
+    );
+
+    // 9c. §S284c: Embed viewer HTML + scripts so IFC drop → 3D works fully offline
+    // The blob viewer opens from same origin as landing page → shares IndexedDB. No internet needed.
+    setStatus('Embedding viewer (Three.js + viewer scripts)…');
+    try {
+      var viewerHtml = await fetch('viewer/viewer.html').then(function(r) { return r.ok ? r.text() : ''; }).catch(function() { return ''; });
+      if (viewerHtml) {
+        // A. Fetch Three.js + OrbitControls as data: URIs (absolute → works in blob URL context)
+        function _toDataUri(src) {
+          return 'data:application/javascript;charset=utf-8;base64,' + btoa(unescape(encodeURIComponent(src)));
+        }
+        var threeSrc = await fetch('viewer/lib/three.webgpu.min.js').then(function(r){ return r.ok?r.text():''; }).catch(function(){return '';});
+        if (!threeSrc) threeSrc = await fetch('viewer/lib/three.module.min.js').then(function(r){ return r.ok?r.text():''; }).catch(function(){return '';});
+        var ocSrc = await fetch('viewer/lib/OrbitControls.module.js').then(function(r){ return r.ok?r.text():''; }).catch(function(){return '';});
+        var threeUri = threeSrc ? _toDataUri(threeSrc) : null;
+        var ocUri    = ocSrc    ? _toDataUri(ocSrc)    : null;
+
+        // B. Inline all <script src="..."> viewer files
+        var smRe = /<script src="([^"]+)"([^>]*)><\/script>/g;
+        var smList = [];
+        var _m; while ((_m = smRe.exec(viewerHtml)) !== null) smList.push([_m[0], _m[1]]);
+        for (var si = 0; si < smList.length; si++) {
+          var fullTag = smList[si][0], srcAttr = smList[si][1];
+          var cleanPath = srcAttr.replace(/\?.*$/, '');
+          var src = await fetch('viewer/' + cleanPath).then(function(r){ return r.ok?r.text():''; }).catch(function(){return '';});
+          if (!src) continue;
+          // C. Patch loader.js: replace relative ESM import paths with data: URIs
+          if (cleanPath === 'loader.js') {
+            if (threeUri) {
+              src = src.replace(/await import\('\.\/lib\/three\.webgpu\.min\.js'\)/g, function(){ return "await import('" + threeUri + "')"; });
+              src = src.replace(/await import\('\.\/lib\/three\.module\.min\.js'\)/g, function(){ return "await import('" + threeUri + "')"; });
+            }
+            if (ocUri) {
+              src = src.replace(/await import\('\.\/lib\/OrbitControls\.module\.js'\)/g, function(){ return "await import('" + ocUri + "')"; });
+            }
+            // BVH stays as CDN — graceful failure if offline (no raycasting BVH, standard fallback)
+          }
+          // Function replacement avoids $' $& $` corruption
+          (function(_tag, _src) {
+            viewerHtml = viewerHtml.replace(_tag, function() { return '<script>\n' + _src + '\n<\/script>'; });
+          })(fullTag, src);
+        }
+
+        // D. Inject sql-wasm WASM wrapper + _STANDALONE flag into viewer HTML
+        // Intercepts window.initSqlJs assignment and wraps it to use embedded wasmBinary
+        var sqlWrap = '<script>\n' +
+          'window._STANDALONE=true;\n' +
+          (sqlWasmB64 ? 'window._SQL_WASM_B64="' + sqlWasmB64 + '";\n' : '') +
+          '(function(){\n' +
+          '  var _d=Object.defineProperty;\n' +
+          '  _d(window,"initSqlJs",{configurable:true,set:function(fn){\n' +
+          '    var _raw=fn;\n' +
+          '    _d(window,"initSqlJs",{configurable:true,writable:true,value:function(opts){\n' +
+          '      opts=opts||{};\n' +
+          '      if(window._SQL_WASM_B64){\n' +
+          '        var b=Uint8Array.from(atob(window._SQL_WASM_B64),function(c){return c.charCodeAt(0);});\n' +
+          '        opts.wasmBinary=b.buffer; delete opts.locateFile;\n' +
+          '      }\n' +
+          '      return _raw(opts);\n' +
+          '    }});\n' +
+          '  },get:function(){return undefined;}});\n' +
+          '})();\n' +
+          '<\/script>\n';
+        viewerHtml = viewerHtml.replace('<head>', function() { return '<head>\n' + sqlWrap; });
+
+        // E. Inline viewer icon
+        viewerHtml = viewerHtml.replace(/src="icons\/icon-192\.png"/g, 'src="' + iconB64 + '"');
+
+        // F. Strip service worker + manifest link (fails in blob context, not critical)
+        viewerHtml = viewerHtml.replace(/<link rel="manifest"[^>]*>/g, '');
+
+        // G. Embed complete viewer HTML as type="text/plain" (same pattern as web-ifc)
+        var safeViewerHtml = viewerHtml.replace(/<\/script>/gi, '<\\/script>');
+        html = html.replace('<body>', function() { return '<script type="text/plain" id="viewer-html-src">\n' + safeViewerHtml + '\n<\/script>\n<body>'; });
+
+        setStatus('Viewer embedded ✓  Building download…');
+        console.log('§S284c VIEWER_EMBED size=' + viewerHtml.length);
+      }
+    } catch(ve) {
+      console.warn('§S284c VIEWER_EMBED_FAIL', ve.message, '— viewer will fall back to GitHub Pages');
+      setStatus('Viewer embed failed — will use GitHub Pages viewer');
+    }
 
     // 10. Download
     var blob = new Blob([html], {type: 'text/html;charset=utf-8'});

--- a/index.html
+++ b/index.html
@@ -262,6 +262,7 @@
     <div style="display:flex; align-items:center; gap:12px; margin-bottom:6px">
       <span data-trl="landing_complete_city" style="font-size:14px; font-weight:700; color:#0277bd; letter-spacing:1px">COMPLETE THE CITY</span>
       <span id="city-count" style="font-size:12px; color:#888">0 / 30 <span data-trl="landing_buildings_explored">buildings explored</span></span>
+      <a href="LargeCity.html" data-trl="landing_cannot_wait" style="margin-left:auto; font-size:14px; font-weight:700; color:#44cc44; letter-spacing:1px; text-decoration:none">I CANNOT WAIT!</a>
     </div>
     <div style="height:8px; background:#222; border-radius:4px; overflow:hidden">
       <div id="city-bar" style="height:100%; width:0%; background:linear-gradient(90deg,#0277bd,#44cc44); border-radius:4px; transition:width 0.4s ease"></div>

--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,7 @@ async function exportProjectIFC(projectKey, flyout) {
 <!-- About dialog -->
 <div id="about-dialog" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);justify-content:center;align-items:center" onclick="if(event.target===this)this.classList.remove('active')">
   <div style="background:rgba(10,10,30,0.97);border-radius:14px;padding:28px 32px;border:1px solid rgba(79,195,247,0.3);font-family:'Segoe UI',sans-serif;color:#e0e0e0;max-width:380px;width:90%;max-height:85vh;overflow-y:auto;text-align:center">
-    <div style="background:rgba(2,119,189,0.13);border-radius:10px;padding:10px 20px;margin-bottom:12px;display:inline-block"><img src="Sysnova.png" alt="Sysnova" style="height:54px;display:block"></div>
+    <img id="about-icon" src="viewer/icons/icon-192.png" alt="BIM/ERP OOTB" style="height:72px;margin-bottom:8px;display:block;margin-left:auto;margin-right:auto">
     <div style="font-size:28px;font-weight:800;color:#e0e0e0;font-family:'Arial Black',Impact,sans-serif;letter-spacing:6px;line-height:1">BIM/ERP</div>
     <div style="font-size:11px;letter-spacing:4px;color:#4fc3f7;margin-bottom:14px;text-transform:uppercase">Out Of The Box</div>
 
@@ -1706,6 +1706,10 @@ async function exportProjectIFC(projectKey, flyout) {
 async function packageLandingPage() {
   var statusEl = document.getElementById('pack-status');
   function setStatus(msg) { if (statusEl) statusEl.textContent = msg; }
+  if (window._STANDALONE) {
+    setStatus('Already offline — open via serve.sh then re-package from there.');
+    return;
+  }
   setStatus('Packaging…');
   try {
     // 1. Fetch external JS files that need inlining
@@ -1752,11 +1756,15 @@ async function packageLandingPage() {
       setStatus('IFC engine unavailable — IFC import will need internet');
       console.warn('§S284b web-ifc fetch failed — IFC import will need internet');
     }
-    // 2. Fetch Sysnova.png as base64 data URI
-    var pngBlob = await fetch('Sysnova.png').then(function(r) { return r.blob(); });
-    var pngB64 = await new Promise(function(cb) {
-      var rd = new FileReader(); rd.onload = function() { cb(rd.result); }; rd.readAsDataURL(pngBlob);
-    });
+    // 2. Fetch about-icon (icon-192.png) + Sysnova.png as base64 data URIs
+    async function fetchB64(url) {
+      var blob = await fetch(url).then(function(r) { return r.blob(); });
+      return new Promise(function(cb) {
+        var rd = new FileReader(); rd.onload = function() { cb(rd.result); }; rd.readAsDataURL(blob);
+      });
+    }
+    var iconB64 = await fetchB64('viewer/icons/icon-192.png');
+    var pngB64  = await fetchB64('Sysnova.png').catch(function() { return ''; });
 
     // 3. Snapshot manifest (already in memory from init)
     var manifestJSON = JSON.stringify(window._manifestData || {archetypes:[]});
@@ -1770,8 +1778,9 @@ async function packageLandingPage() {
     html = html.replace(/<script src="viewer\/import_db_builder\.js[^"]*"><\/script>/, function() { return '<script>\n' + dbBuilderSrc + '\n<\/script>'; });
     html = html.replace(/<script src="viewer\/locale_loader\.js[^"]*"><\/script>/, function() { return '<script>\n' + localeSrc + '\n<\/script>'; });
 
-    // 6. Sysnova.png → base64
-    html = html.replace(/src="Sysnova\.png"/g, 'src="' + pngB64 + '"');
+    // 6. Inline images → base64
+    html = html.replace(/src="viewer\/icons\/icon-192\.png"/g, 'src="' + iconB64 + '"');
+    if (pngB64) html = html.replace(/src="Sysnova\.png"/g, 'src="' + pngB64 + '"');
 
     // 7. Strip analytics (goatcounter)
     html = html.replace(/<script[^>]*goatcounter[^>]*><\/script>/g, '');

--- a/index.html
+++ b/index.html
@@ -1619,22 +1619,23 @@ async function exportProjectIFC(projectKey, flyout) {
 <!-- About dialog -->
 <div id="about-dialog" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);justify-content:center;align-items:center" onclick="if(event.target===this)this.classList.remove('active')">
   <div style="background:rgba(10,10,30,0.97);border-radius:14px;padding:28px 32px;border:1px solid rgba(79,195,247,0.3);font-family:'Segoe UI',sans-serif;color:#e0e0e0;max-width:380px;width:90%;max-height:85vh;overflow-y:auto;text-align:center">
-    <img src="Sysnova.png" alt="Sysnova" style="height:54px;margin-bottom:12px;filter:brightness(1.1)">
-    <div style="font-size:28px;font-weight:800;color:#e0e0e0;font-family:'Arial Black',Impact,sans-serif;letter-spacing:6px;line-height:1">BIM</div>
+    <div style="background:rgba(2,119,189,0.13);border-radius:10px;padding:10px 20px;margin-bottom:12px;display:inline-block"><img src="Sysnova.png" alt="Sysnova" style="height:54px;display:block"></div>
+    <div style="font-size:28px;font-weight:800;color:#e0e0e0;font-family:'Arial Black',Impact,sans-serif;letter-spacing:6px;line-height:1">BIM/ERP</div>
     <div style="font-size:11px;letter-spacing:4px;color:#4fc3f7;margin-bottom:14px;text-transform:uppercase">Out Of The Box</div>
 
-    <div style="font-size:15px;color:#ccc;line-height:1.5;margin-bottom:6px">Frictionless BIM. Two DBs.<br>One browser. Zero install.</div>
-    <div style="color:#e8a735;font-size:12px;font-style:italic;margin-bottom:18px">Probably the lightest BIM app ever made.</div>
+    <div style="font-size:15px;color:#ccc;line-height:1.5;margin-bottom:6px">Frictionless BIM/ERP. Two DBs.<br>One browser. Zero install.</div>
+    <div style="color:#e8a735;font-size:12px;font-style:italic;margin-bottom:14px">Probably the lightest BIM/ERP app ever made. ISO Pending.</div>
 
-    <div style="display:flex;justify-content:center;gap:16px;margin-bottom:18px">
-      <div style="padding:8px 14px;background:rgba(79,195,247,0.08);border:1px solid rgba(79,195,247,0.2);border-radius:8px">
-        <div style="font-size:13px;font-weight:700;color:#4fc3f7">BIM</div>
-        <div style="font-size:9px;color:#888;margin-top:2px">3D Viewer</div>
-      </div>
-      <div style="padding:8px 14px;background:rgba(232,167,53,0.08);border:1px solid rgba(232,167,53,0.2);border-radius:8px">
-        <div style="font-size:13px;font-weight:700;color:#e8a735">ERP</div>
-        <div style="font-size:9px;color:#888;margin-top:2px">Spatial ERP</div>
-      </div>
+    <div style="text-align:left;margin-bottom:14px;font-size:10.5px;line-height:1.85;color:#ccc">
+      &#127963; <b style="color:#4fc3f7">3D IFC Viewer</b> &middot; 125K elements &middot; offline &middot; &lt;1s load<br>
+      &#9201; <b style="color:#4fc3f7">4D Time Machine</b> &middot; sequence &middot; drone tour &middot; Gantt<br>
+      &#128176; <b style="color:#4fc3f7">5D Cost &amp; BOQ</b> &middot; auto-extracted &middot; 17 country rates<br>
+      &#9889; <b style="color:#4fc3f7">Clash Detection</b> &middot; R-tree spatial &middot; QR snag reports<br>
+      &#128208; <b style="color:#4fc3f7">2D Plans &amp; Grids</b> &middot; section cut &middot; elevations &middot; AABBCC<br>
+      &#127758; <b style="color:#e8a735">Spatial ERP</b> &middot; iDempiere AD &middot; full CRUD &middot; globe<br>
+      &#128694; <b style="color:#4fc3f7">Walk Mode</b> &middot; GPS blue-dot &middot; device orientation<br>
+      &#128266; <b style="color:#4fc3f7">Voice &amp; NLP Search</b> &middot; natural language &middot; mic<br>
+      &#128279; <b style="color:#4fc3f7">Deep-link Share</b> &middot; URL &middot; QR &middot; native share sheet
     </div>
 
     <div style="color:#999;font-size:10px;line-height:1.6;margin-bottom:14px">Chrome 90+ &#8226; Firefox 90+ &#8226; Safari 15+ &#8226; Edge 90+<br>Mobile: iOS Safari 15+ &#8226; Chrome Android</div>
@@ -1644,10 +1645,10 @@ async function exportProjectIFC(projectKey, flyout) {
       <a href="https://github.com/red1oon/bim-ootb" target="_blank" style="color:#4fc3f7;text-decoration:none;padding:6px 12px;border:1px solid rgba(79,195,247,0.25);border-radius:6px">&#11088; GitHub</a>
     </div>
 
-    <a href="javascript:void(0)" onclick="document.getElementById('about-dialog').classList.remove('active');document.getElementById('diy-dialog').classList.add('active')" style="color:#e8a735;font-size:11px;text-decoration:none;cursor:pointer">&#128736; DIY Downloader</a>
-    <br><a href="javascript:void(0)" onclick="packageLandingPage()" style="color:#4fc3f7;font-size:11px;text-decoration:none;cursor:pointer">&#128190; Save Offline Copy</a>
+    <a href="javascript:void(0)" onclick="packageLandingPage()" style="color:#4fc3f7;font-size:11px;text-decoration:none;cursor:pointer">&#128190; Save Offline Copy <span style="color:#888;font-size:10px">— viewer &plus; serve script &plus; README</span></a>
+    <div id="pack-status" style="color:#4fc3f7;font-size:10px;min-height:14px;margin-top:4px"></div>
 
-    <div style="color:#666;font-size:9px;margin-top:14px">&#169; 2026 Redhuan D. Oon &#8226; MIT License</div>
+    <div style="color:#666;font-size:9px;margin-top:10px">&#169; 2026 Redhuan D. Oon &#8226; MIT License</div>
   </div>
 </div>
 <style>#about-dialog.active{display:flex!important}#diy-dialog.active{display:flex!important}</style>
@@ -1702,15 +1703,17 @@ async function exportProjectIFC(projectKey, flyout) {
 <script>
 // §S284: Package landing page as self-contained offline HTML
 async function packageLandingPage() {
-  var statusEl = document.getElementById('import-status');
-  if (statusEl) statusEl.textContent = 'Packaging offline copy...';
+  var statusEl = document.getElementById('pack-status');
+  function setStatus(msg) { if (statusEl) statusEl.textContent = msg; }
+  setStatus('Packaging…');
   try {
     // 1. Fetch external JS files that need inlining
+    setStatus('Inlining scripts…');
     var dbBuilderSrc = await fetch('viewer/import_db_builder.js?v=3').then(function(r) { return r.text(); });
     var localeSrc = await fetch('viewer/locale_loader.js?v=7').then(function(r) { return r.text(); });
 
     // 1b. Fetch Worker scripts for Blob URL in standalone mode
-    if (statusEl) statusEl.textContent = 'Fetching worker scripts...';
+    setStatus('Fetching worker scripts…');
     var importWorkerSrc = await fetch('viewer/import_worker.js?v=8').then(function(r) { return r.text(); });
     var meshWorkerSrc = await fetch('viewer/mesh_import_worker.js?v=2').then(function(r) { return r.text(); }).catch(function() { return ''; });
     var exportWorkerSrc = await fetch('viewer/ifc_export_worker.js?v=2').then(function(r) { return r.text(); }).catch(function() { return ''; });
@@ -1721,7 +1724,7 @@ async function packageLandingPage() {
     });
 
     // 1c. Fetch sql-wasm.js + sql-wasm.wasm (base64) + web-ifc for fully offline IFC import
-    if (statusEl) statusEl.textContent = 'Fetching SQLite WASM (~700KB)...';
+    setStatus('Fetching SQLite WASM (~700KB)…');
     var sqlWasmJs = await fetch('viewer/lib/sql-wasm.js').then(function(r) { return r.text(); }).catch(function() { return ''; });
     var sqlWasmBuf = await fetch('viewer/lib/sql-wasm.wasm').then(function(r) { return r.arrayBuffer(); }).catch(function() { return null; });
     var sqlWasmB64 = '';
@@ -1731,11 +1734,21 @@ async function packageLandingPage() {
       for (var wi = 0; wi < bytes.length; wi++) binary += String.fromCharCode(bytes[wi]);
       sqlWasmB64 = btoa(binary);
     }
-    if (statusEl) statusEl.textContent = 'Fetching web-ifc (~6MB)...';
+    setStatus('Fetching IFC engine (~6MB)…');
     var webIfcSrc = '';
     try {
-      webIfcSrc = await fetch('https://unpkg.com/web-ifc@0.0.77/web-ifc-api-iife.js').then(function(r) { return r.text(); });
+      // Local cached copy first (instant if service worker has it), fall back to unpkg
+      var webIfcRes = await fetch('viewer/lib/web-ifc-api-iife.js').catch(function() { return null; });
+      if (webIfcRes && webIfcRes.ok) {
+        webIfcSrc = await webIfcRes.text();
+        setStatus('IFC engine loaded from cache ✓');
+      } else {
+        setStatus('Fetching IFC engine from CDN (~6MB)… please wait');
+        webIfcSrc = await fetch('https://unpkg.com/web-ifc@0.0.77/web-ifc-api-iife.js').then(function(r) { return r.text(); });
+        setStatus('IFC engine loaded ✓');
+      }
     } catch(e) {
+      setStatus('IFC engine unavailable — IFC import will need internet');
       console.warn('§S284b web-ifc fetch failed — IFC import will need internet');
     }
     // 2. Fetch Sysnova.png as base64 data URI
@@ -1749,7 +1762,7 @@ async function packageLandingPage() {
 
     // 4. Fetch the ORIGINAL index.html source (not innerHTML — browser DOM re-serialization
     //    breaks script tags, normalizes whitespace, and loses comments)
-    if (statusEl) statusEl.textContent = 'Building HTML...';
+    setStatus('Building HTML…');
     var html = await fetch(location.href.replace(/[?#].*$/, '')).then(function(r) { return r.text(); });
 
     // 5. Inline external scripts (function replacement avoids $' $& corruption in sources)
@@ -1796,10 +1809,109 @@ async function packageLandingPage() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(a.href);
-    if (statusEl) statusEl.textContent = '';
     console.log('\u00a7PACK_DOWNLOAD size=' + blob.size + ' bytes');
+
+    // Also download serve scripts + README so users can self-host immediately
+    function _dlText(content, filename, mimeType, delayMs) {
+      setTimeout(function() {
+        var b = new Blob([content], {type: mimeType});
+        var el = document.createElement('a');
+        el.href = URL.createObjectURL(b);
+        el.download = filename;
+        document.body.appendChild(el);
+        el.click();
+        document.body.removeChild(el);
+        setTimeout(function() { URL.revokeObjectURL(el.href); }, 1000);
+      }, delayMs);
+    }
+
+    var readme = [
+      '# BIM/ERP OOTB \u2014 Self-Host Guide',
+      '',
+      'Downloaded from https://red1oon.github.io/bim-ootb',
+      '',
+      '## What you have',
+      '  BIM-OOTB.html  \u2014 the full viewer (all code inline)',
+      '  serve.sh       \u2014 local server for Mac / Linux',
+      '  serve.bat      \u2014 local server for Windows',
+      '  README.md      \u2014 this file',
+      '',
+      '## Run locally',
+      '',
+      'Mac / Linux',
+      '  1. Open Terminal in this folder',
+      '  2. Run:  bash serve.sh',
+      '  3. Browser opens at http://localhost:8080',
+      '',
+      'Windows',
+      '  1. Double-click serve.bat',
+      '  2. Browser opens at http://localhost:8080',
+      '',
+      'Requires Python 3 \u2014 free from https://python.org',
+      '',
+      '## Host on the web',
+      '',
+      'Netlify (free, 30 seconds)',
+      '  netlify.com \u2192 Add new site \u2192 Deploy manually',
+      '  Drag this folder into the upload zone.',
+      '  Done \u2014 you get a public HTTPS URL instantly.',
+      '',
+      'GitHub Pages (free)',
+      '  New repo \u2192 upload BIM-OOTB.html \u2192 rename to index.html',
+      '  Settings \u2192 Pages \u2192 Deploy from branch: main',
+      '  Live at https://yourusername.github.io/yourrepo',
+      '',
+      'Any web server',
+      '  Upload BIM-OOTB.html to any static host (nginx, S3, VPS).',
+      '  No backend needed. Rename to index.html for clean URLs.',
+      '',
+      '## Load a building',
+      '',
+      '  Drop an IFC file onto the viewer \u2014 parsed locally, nothing uploaded.',
+      '  Or append ?db=https://yourhost/building.db to open a cloud building.',
+      '',
+      '## Questions?',
+      '  GitHub : https://github.com/red1oon/bim-ootb',
+      '  Email  : red1org@gmail.com',
+      '  License: MIT \u2014 free to use, modify, host, share',
+      '',
+      '\u00a9 2026 Redhuan D. Oon \u00b7 Sysnova Information Systems Limited'
+    ].join('\n');
+
+    var serveSh = [
+      '#!/bin/bash',
+      '# BIM/ERP OOTB \u2014 local server (Mac / Linux)',
+      'cd "$(dirname "$0")"',
+      'echo ""',
+      'echo "  BIM/ERP OOTB \u2014 starting at http://localhost:8080"',
+      'echo "  Press Ctrl+C to stop."',
+      'echo ""',
+      '(sleep 1 && (open "http://localhost:8080/BIM-OOTB.html" 2>/dev/null || xdg-open "http://localhost:8080/BIM-OOTB.html" 2>/dev/null)) &',
+      'python3 -m http.server 8080'
+    ].join('\n');
+
+    var serveBat = [
+      '@echo off',
+      'cd /d "%~dp0"',
+      'echo.',
+      'echo   BIM/ERP OOTB \u2014 starting at http://localhost:8080',
+      'echo   Close this window to stop.',
+      'echo.',
+      'start "" "http://localhost:8080/BIM-OOTB.html"',
+      'python -m http.server 8080',
+      'pause'
+    ].join('\r\n');
+
+    _dlText(readme,   'README.md',  'text/markdown',               600);
+    _dlText(serveSh,  'serve.sh',   'application/x-sh',           1200);
+    _dlText(serveBat, 'serve.bat',  'application/x-bat',          1800);
+
+    if (statusEl) statusEl.textContent = '';
+    setStatus('Done \u2014 4 files downloading \u2713');
+    setTimeout(function() { if (statusEl) statusEl.textContent = ''; }, 4000);
+    console.log('\u00a7PACK_BUNDLE readme+serve.sh+serve.bat queued');
   } catch(e) {
-    if (statusEl) statusEl.textContent = 'Package failed: ' + e.message;
+    setStatus('Package failed: ' + e.message);
     console.error('\u00a7PACK_FAIL', e);
   }
 }

--- a/viewer/city.js
+++ b/viewer/city.js
@@ -91,25 +91,43 @@ function setupCity(A) {
       A.modelOffset.z = (Math.min(...allIZ) + Math.max(...allIZ)) / 2;
     }
 
+    // §S285: City mode — keep the ground positioned but hidden. The default plane sat
+    // too high (occluding the bottom pill / blocking interaction). The Shadow toggle
+    // re-adds a ground plane when the user wants one.
     const zRange = A.cityDb.exec(`SELECT MIN(min_z), MAX(max_z) FROM building_summary`);
     if (zRange.length > 0) {
       const groundY = (zRange[0].values[0][0] - A.modelOffset.z) - 2;
       A.ground.position.y = groundY;
-      A.ground.visible = true;
+    }
+    A.ground.visible = false;
+    console.log('[S285] §CITY_GROUND hidden (Shadow toggle restores a ground)');
+
+    // §S285: City mode — realistic Preetham sky on by default (mid-afternoon).
+    // Same path the Shadow toggle uses (tools.js); gives an outdoor horizon instead
+    // of the flat dark clear-color, and drives env-map reflections on buildings.
+    if (A._sky) {
+      A._sky.visible = true;
+      if (A.updateSky) A.updateSky(45, 180);
+      console.log('[S285] §CITY_SKY realistic Preetham sky enabled');
     }
 
     A.updateHUD();
     A.populateBuildingList();
 
-    // §S285: Show building list in city mode — was hidden by S280 UI overhaul
+    // §S285: Show building list in city mode — was hidden by S280 UI overhaul.
+    // viewer.html has `#building-list { display:none !important }`, so a plain inline
+    // display:block loses to the stylesheet !important and the list never appears.
+    // Use setProperty(...'important') so the city-mode list beats the stylesheet rule.
     var bldList = document.getElementById('building-list');
     if (bldList) {
-      bldList.style.cssText = 'display:block;position:fixed;top:60px;left:12px;z-index:20;' +
+      bldList.style.cssText = 'position:fixed;top:60px;left:12px;z-index:20;' +
         'background:rgba(17,17,17,0.95);border:1px solid #333;border-radius:10px;' +
         'padding:8px;max-height:70vh;overflow-y:auto;width:220px;' +
         'backdrop-filter:blur(8px);box-shadow:0 4px 20px rgba(0,0,0,0.5)';
+      bldList.style.setProperty('display', 'block', 'important');
       // Also show parent if hidden
       if (bldList.parentElement) bldList.parentElement.style.display = 'block';
+      console.log(`[S285] §CITY_LIST shown cards=${(A.allBuildingCards||[]).length} display=${getComputedStyle(bldList).display}`);
     }
 
     // §S285: Draw individual element AABBs from cached building DBs (not big building bboxes)

--- a/viewer/city.js
+++ b/viewer/city.js
@@ -146,6 +146,31 @@ function setupCity(A) {
     var _scl = new THREE.Vector3();
     var _quat = new THREE.Quaternion();
 
+    // ── Fallback: building-level bboxes from city_index (LineSegments, clickable) ──
+    function _drawBuildingFallback(insts) {
+      for (var fi = 0; fi < insts.length; fi++) {
+        _fallbackBuildings++;
+        var fb = insts[fi];
+        var fbRows = A.cityDb.exec(`SELECT discipline, min_x, min_y, min_z, max_x, max_y, max_z FROM building_summary WHERE building = ?`, [fb.building]);
+        if (!fbRows.length) continue;
+        for (var fri = 0; fri < fbRows[0].values.length; fri++) {
+          var fr = fbRows[0].values[fri];
+          var fColor = A.DISC_COLORS[fr[0]] || A.DEFAULT_COLOR;
+          var fc = A.ifc2three((fr[1]+fr[4])/2, (fr[2]+fr[5])/2, (fr[3]+fr[6])/2);
+          var fsx = fr[4]-fr[1], fsy = (fr[6]-fr[3]), fsz = fr[5]-fr[2];
+          if (fsx < 0.1 || fsy < 0.1 || fsz < 0.1) continue;
+          var fGeo = new THREE.BoxGeometry(fsx, fsy, fsz);
+          var fEdges = new THREE.EdgesGeometry(fGeo);
+          fGeo.dispose();
+          var fLine = new THREE.LineSegments(fEdges,
+            new THREE.LineBasicMaterial({ color: fColor, opacity: 0.6, transparent: true }));
+          fLine.position.set(fc.x, fc.y, fc.z);
+          fLine.userData = { building: fb.building, discipline: fr[0] };
+          A.scene.add(fLine);
+        }
+      }
+    }
+
     for (var archName in archInstances) {
       var instances = archInstances[archName];
       var bldEntry = null;
@@ -171,21 +196,36 @@ function setupCity(A) {
 
       if (cachedBuf) {
         // ── Individual element AABBs from cached DB ──
-        _cachedArchetypes++;
+        // §S285: Older extractions lack bbox_* columns in element_transforms. Probe the
+        // schema first; if absent (or any query throws) degrade gracefully to building-level
+        // bboxes instead of throwing an uncaught error that would abort the whole city init
+        // (no §CITY_BBOX / §CITY_READY, blank scene).
         var archDb = new SQL.Database(new Uint8Array(cachedBuf));
-
-        // Get element positions + bboxes + discipline
-        var elemRows = archDb.exec(`
-          SELECT m.discipline, t.center_x, t.center_y, t.center_z,
-                 t.bbox_x, t.bbox_y, t.bbox_z
-          FROM element_transforms t
-          JOIN elements_meta m ON t.guid = m.guid
-        `);
-        // Compute archetype centre for offset calculation
-        var arcCen = archDb.exec(`SELECT AVG(center_x), AVG(center_y), AVG(center_z) FROM element_transforms`);
+        var elemRows = null, arcCen = null, _hasBbox = false;
+        try {
+          var _cols = archDb.exec(`PRAGMA table_info(element_transforms)`);
+          _hasBbox = _cols.length && _cols[0].values.some(function(c){ return c[1] === 'bbox_x'; });
+          if (_hasBbox) {
+            elemRows = archDb.exec(`
+              SELECT m.discipline, t.center_x, t.center_y, t.center_z,
+                     t.bbox_x, t.bbox_y, t.bbox_z
+              FROM element_transforms t
+              JOIN elements_meta m ON t.guid = m.guid
+            `);
+            arcCen = archDb.exec(`SELECT AVG(center_x), AVG(center_y), AVG(center_z) FROM element_transforms`);
+          }
+        } catch (e) {
+          console.warn(`[S285] §CITY_BBOX_DEGRADE archetype=${archName} reason=${e.message}`);
+          elemRows = null;
+        }
         archDb.close();
 
-        if (!elemRows.length || !elemRows[0].values.length || !arcCen.length) continue;
+        if (!_hasBbox || !elemRows || !elemRows.length || !elemRows[0].values.length || !arcCen || !arcCen.length) {
+          if (!_hasBbox) console.warn(`[S285] §CITY_BBOX_DEGRADE archetype=${archName} no bbox_* columns — building-level fallback`);
+          _drawBuildingFallback(instances);
+          continue;
+        }
+        _cachedArchetypes++;
         var arcX = arcCen[0].values[0][0];
         var arcY = arcCen[0].values[0][1];
         var arcZ = arcCen[0].values[0][2];
@@ -230,27 +270,7 @@ function setupCity(A) {
         }
       } else {
         // ── Fallback: building-level bboxes from city_index ──
-        for (var fi = 0; fi < instances.length; fi++) {
-          _fallbackBuildings++;
-          var fb = instances[fi];
-          var fbRows = A.cityDb.exec(`SELECT discipline, min_x, min_y, min_z, max_x, max_y, max_z FROM building_summary WHERE building = ?`, [fb.building]);
-          if (!fbRows.length) continue;
-          for (var fri = 0; fri < fbRows[0].values.length; fri++) {
-            var fr = fbRows[0].values[fri];
-            var fColor = A.DISC_COLORS[fr[0]] || A.DEFAULT_COLOR;
-            var fc = A.ifc2three((fr[1]+fr[4])/2, (fr[2]+fr[5])/2, (fr[3]+fr[6])/2);
-            var fsx = fr[4]-fr[1], fsy = (fr[6]-fr[3]), fsz = fr[5]-fr[2];
-            if (fsx < 0.1 || fsy < 0.1 || fsz < 0.1) continue;
-            var fGeo = new THREE.BoxGeometry(fsx, fsy, fsz);
-            var fEdges = new THREE.EdgesGeometry(fGeo);
-            fGeo.dispose();
-            var fLine = new THREE.LineSegments(fEdges,
-              new THREE.LineBasicMaterial({ color: fColor, opacity: 0.6, transparent: true }));
-            fLine.position.set(fc.x, fc.y, fc.z);
-            fLine.userData = { building: fb.building, discipline: fr[0] };
-            A.scene.add(fLine);
-          }
-        }
+        _drawBuildingFallback(instances);
       }
     }
     var _dt = (performance.now() - _t0).toFixed(0);

--- a/viewer/city.js
+++ b/viewer/city.js
@@ -92,35 +92,24 @@ function setupCity(A) {
     }
 
     // §S285: City mode — treat ground/sky exactly like a normal building viewer.
-    // Position the ground plane, but let the pills drive visibility: ground shows only
-    // when Shadow/Night is on (matches streaming.js §GROUND_INIT), and the Shadow pill
-    // owns the realistic sky. No city-specific overrides — the old code forced the
-    // ground visible at too-high a Y, occluding the bottom pill.
-    const zRange = A.cityDb.exec(`SELECT MIN(min_z), MAX(max_z) FROM building_summary`);
-    if (zRange.length > 0) {
-      A.ground.position.y = (zRange[0].values[0][0] - A.modelOffset.z) - 2;
+    // Ground at the MEDIAN building base, not global MIN(min_z): a single outlier
+    // element (the city has one at z=-164) otherwise drags the ground ~164m below the
+    // city so every bbox floats. Median ignores outliers. Visibility is pill-controlled
+    // (Shadow/Night), matching streaming.js §GROUND_INIT, and the Shadow pill owns the sky.
+    const baseRows = A.cityDb.exec(`SELECT MIN(min_z) AS b FROM building_summary GROUP BY building`);
+    if (baseRows.length && baseRows[0].values.length) {
+      const bases = baseRows[0].values.map(r => r[0]).sort((a, b) => a - b);
+      const medianBase = bases[Math.floor(bases.length / 2)];
+      A.ground.position.y = (medianBase - A.modelOffset.z) - 2;
     }
     A.ground.visible = !!(A._shadowOn || A._nightMode);
-    console.log('[S285] §CITY_GROUND y=' + A.ground.position.y.toFixed(1) + ' visible=' + A.ground.visible + ' (pill-controlled, like buildings)');
+    console.log('[S285] §CITY_GROUND y=' + A.ground.position.y.toFixed(1) + ' visible=' + A.ground.visible + ' (median base, pill-controlled)');
 
     A.updateHUD();
     A.populateBuildingList();
-
-    // §S285: Show building list in city mode — was hidden by S280 UI overhaul.
-    // viewer.html has `#building-list { display:none !important }`, so a plain inline
-    // display:block loses to the stylesheet !important and the list never appears.
-    // Use setProperty(...'important') so the city-mode list beats the stylesheet rule.
-    var bldList = document.getElementById('building-list');
-    if (bldList) {
-      bldList.style.cssText = 'position:fixed;top:60px;left:12px;z-index:20;' +
-        'background:rgba(17,17,17,0.95);border:1px solid #333;border-radius:10px;' +
-        'padding:8px;max-height:70vh;overflow-y:auto;width:220px;' +
-        'backdrop-filter:blur(8px);box-shadow:0 4px 20px rgba(0,0,0,0.5)';
-      bldList.style.setProperty('display', 'block', 'important');
-      // Also show parent if hidden
-      if (bldList.parentElement) bldList.parentElement.style.display = 'block';
-      console.log(`[S285] §CITY_LIST shown cards=${(A.allBuildingCards||[]).length} display=${getComputedStyle(bldList).display}`);
-    }
+    // §S285: No building-list panel in city mode — a Viewer behaves apples-to-apples
+    // with every other viewer: click a building's AABB to stream it (picking.js §CITY_PICK).
+    // The #building-list stays hidden (S280); populateBuildingList still feeds search/HUD.
 
     // §S285: Draw individual element AABBs from cached building DBs (not big building bboxes)
     // For each archetype: read element_transforms from cached _extracted.db in IDB,

--- a/viewer/city.js
+++ b/viewer/city.js
@@ -91,25 +91,17 @@ function setupCity(A) {
       A.modelOffset.z = (Math.min(...allIZ) + Math.max(...allIZ)) / 2;
     }
 
-    // §S285: City mode — keep the ground positioned but hidden. The default plane sat
-    // too high (occluding the bottom pill / blocking interaction). The Shadow toggle
-    // re-adds a ground plane when the user wants one.
+    // §S285: City mode — treat ground/sky exactly like a normal building viewer.
+    // Position the ground plane, but let the pills drive visibility: ground shows only
+    // when Shadow/Night is on (matches streaming.js §GROUND_INIT), and the Shadow pill
+    // owns the realistic sky. No city-specific overrides — the old code forced the
+    // ground visible at too-high a Y, occluding the bottom pill.
     const zRange = A.cityDb.exec(`SELECT MIN(min_z), MAX(max_z) FROM building_summary`);
     if (zRange.length > 0) {
-      const groundY = (zRange[0].values[0][0] - A.modelOffset.z) - 2;
-      A.ground.position.y = groundY;
+      A.ground.position.y = (zRange[0].values[0][0] - A.modelOffset.z) - 2;
     }
-    A.ground.visible = false;
-    console.log('[S285] §CITY_GROUND hidden (Shadow toggle restores a ground)');
-
-    // §S285: City mode — realistic Preetham sky on by default (mid-afternoon).
-    // Same path the Shadow toggle uses (tools.js); gives an outdoor horizon instead
-    // of the flat dark clear-color, and drives env-map reflections on buildings.
-    if (A._sky) {
-      A._sky.visible = true;
-      if (A.updateSky) A.updateSky(45, 180);
-      console.log('[S285] §CITY_SKY realistic Preetham sky enabled');
-    }
+    A.ground.visible = !!(A._shadowOn || A._nightMode);
+    console.log('[S285] §CITY_GROUND y=' + A.ground.position.y.toFixed(1) + ' visible=' + A.ground.visible + ' (pill-controlled, like buildings)');
 
     A.updateHUD();
     A.populateBuildingList();

--- a/viewer/picking.js
+++ b/viewer/picking.js
@@ -190,11 +190,19 @@ function setupPicking(A) {
     A.raycaster.firstHitOnly = false;  // §S260d: WYSIWYG — check all hits, pick best match (was BVH early termination)
 
     // City mode: check bbox wireframes first
+    // §S285: S285 PR#24 changed cached-archetype bboxes from LineSegments → InstancedMesh
+    // placeholders. The original filter only matched LineSegments, so the 22 cached
+    // archetypes (the bulk of the AABBs) became unclickable — only the fallback
+    // LineSegments buildings could be selected. Match both so every AABB renders on click.
     if (A.CITY_URL) {
-      const bboxes = A.collectMeshes(o => o.isLineSegments && o.userData.building);
+      const bboxes = A.collectMeshes(o =>
+        (o.isLineSegments && o.userData.building) ||
+        (o.isInstancedMesh && o.userData.isBboxPlaceholder && o.userData.building));
       const bboxHits = A.raycaster.intersectObjects(bboxes, false);
       if (bboxHits.length > 0) {
-        const bldName = bboxHits[0].object.userData.building;
+        const hitObj = bboxHits[0].object;
+        const bldName = hitObj.userData.building;
+        console.log(`[S285] §CITY_PICK building=${bldName} kind=${hitObj.isInstancedMesh ? 'instanced' : 'line'}`);
         A.flyTo(bldName);
         return;
       }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v515';
+const CACHE_VERSION = 'v516';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v516';
+const CACHE_VERSION = 'v517';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v517';
+const CACHE_VERSION = 'v518';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## What
- **No picking-list panel.** City mode is a Viewer → behaves like every other viewer: click a building's AABB to stream it (`§CITY_PICK`). Removed the `#building-list` show block.
- **Ground at median building base.** `MIN(min_z)` was corrupted by one outlier element (z=-164), dragging the ground ~164m below the city so bboxes floated when Shadow (H) was on. Median ignores the outlier. Visibility still pill-controlled (Shadow/Night).
- **"I CANNOT WAIT!" opens its own tab** (`target=_blank rel=noopener`).
- sw.js CACHE_VERSION → v518.

## Verification
- All CI fast-checks pass locally.
- Browser proof: `§CITY_GROUND y=… (median base, pill-controlled)`; clicking an AABB logs `§CITY_PICK` and streams the building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)