### PR TITLE
fix(S284c): inline YT.png in offline package + missing-asset tripwire

### DIFF
--- a/index.html
+++ b/index.html
@@ -1804,6 +1804,8 @@ async function packageLandingPage() {
     }
     var iconB64 = await fetchB64('viewer/icons/icon-192.png');
     var pngB64  = await fetchB64('Sysnova.png').catch(function() { return ''; });
+    // §S284c W-284c-4: YT.png was never inlined → broken image offline. Inline it.
+    var ytB64   = await fetchB64('viewer/YT.png').catch(function() { return ''; });
 
     // 3. Snapshot manifest (already in memory from init)
     var manifestJSON = JSON.stringify(window._manifestData || {archetypes:[]});
@@ -1820,6 +1822,7 @@ async function packageLandingPage() {
     // 6. Inline images → base64
     html = html.replace(/src="viewer\/icons\/icon-192\.png"/g, 'src="' + iconB64 + '"');
     if (pngB64) html = html.replace(/src="Sysnova\.png"/g, 'src="' + pngB64 + '"');
+    if (ytB64) html = html.replace(/src="viewer\/YT\.png"/g, 'src="' + ytB64 + '"');
 
     // 7. Strip analytics (goatcounter)
     html = html.replace(/<script[^>]*goatcounter[^>]*><\/script>/g, '');
@@ -1946,6 +1949,8 @@ async function packageLandingPage() {
 
         // F. Strip service worker + manifest link (fails in blob context, not critical)
         viewerHtml = viewerHtml.replace(/<link rel="manifest"[^>]*>/g, '');
+        // §S284c: apple-touch-icon href is relative → 404 in blob:// viewer offline. Strip it.
+        viewerHtml = viewerHtml.replace(/<link rel="apple-touch-icon"[^>]*>/g, '');
 
         // G. Embed complete viewer HTML as type="text/plain" (same pattern as web-ifc)
         var safeViewerHtml = viewerHtml.replace(/<\/script>/gi, '<\\/script>');

--- a/tests/test_s284b_full_package.js
+++ b/tests/test_s284b_full_package.js
@@ -111,6 +111,18 @@ check('4.3 webifc-src block inserted before <body>',
 // ── Step 5: Strip analytics + fix URLs ──
 html = html.replace(/<script[^>]*goatcounter[^>]*><\/script>/g, '');
 html = html.replace(/src="Sysnova\.png"/g, 'src="data:image/png;base64,MOCK"');
+// §S284c: Inline icon-192 + YT.png as real base64 — mirrors the browser Save-Offline path
+// (index.html §S284c). Without this the Node test build leaves relative file:// refs that
+// 404 offline, masking whether the real saved file is asset-complete.
+function _imgDataUri(rel) {
+  var p = path.join(root, rel);
+  if (!fs.existsSync(p)) return '';
+  return 'data:image/png;base64,' + fs.readFileSync(p).toString('base64');
+}
+var iconUri = _imgDataUri('viewer/icons/icon-192.png');
+var ytUri   = _imgDataUri('viewer/YT.png');
+if (iconUri) html = html.replace(/src="viewer\/icons\/icon-192\.png"/g, 'src="' + iconUri + '"');
+if (ytUri)   html = html.replace(/src="viewer\/YT\.png"/g, 'src="' + ytUri + '"');
 var ghBase = 'https://red1oon.github.io/bim-ootb/';
 html = html.replace(
   /const viewerFile = [^;]+;/,

--- a/tests/test_s284b_sandbox.js
+++ b/tests/test_s284b_sandbox.js
@@ -34,6 +34,7 @@ const IFC_FILE = '/tmp/test_wall.ifc';
   const logs = [];
   const errors = [];
   const pageErrors = [];
+  const failedResources = [];  // §S284c: file:// resource loads that 404 (missing offline asset)
 
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext();
@@ -45,6 +46,13 @@ const IFC_FILE = '/tmp/test_wall.ifc';
     if (msg.type() === 'error') errors.push(text);
   });
   page.on('pageerror', err => pageErrors.push(err.message));
+  // §S284c: any file:// resource that fails to load offline = a missing embedded asset.
+  // The old leak-check (5.1) only matched "Fetch API cannot load file" and silently passed
+  // ERR_FILE_NOT_FOUND image/asset loads (icon-192.png, YT.png). This is the regression tripwire.
+  page.on('requestfailed', r => {
+    var err = (r.failure() && r.failure().errorText) || '';
+    if (r.url().startsWith('file://')) failedResources.push(r.url() + ' [' + err + ']');
+  });
 
   // ── Step 1: Open packaged HTML from file:// ──
   console.log('\n§S284b_SANDBOX Opening ' + OUTPUT + ' from file://');
@@ -227,6 +235,13 @@ const IFC_FILE = '/tmp/test_wall.ifc';
   check('5.1 no unexpected file:// fetch leaks',
     fetchErrors.length === 0,
     fetchErrors.length ? fetchErrors.join(' | ') : '');
+
+  // §S284c W-284c-4: zero missing offline assets — any file:// resource 404 fails the test.
+  // Locale JSONs are fetched-then-handled (standalone uses inline defaults), so exclude them.
+  var missingAssets = failedResources.filter(u => !/locales?\//.test(u) && !/\.json\b/.test(u));
+  check('5.1b no missing file:// assets (404)',
+    missingAssets.length === 0,
+    missingAssets.length ? missingAssets.join(' | ') : '');
 
   // Verify _STANDALONE guards are working
   check('5.2 health check skipped',


### PR DESCRIPTION
## What
Closes the last silent offline gap in the Save-Offline package, plus a CI tripwire so it can't regress.

**Bug (live in production):** the browser Save-Offline path inlined `icon-192.png` and `Sysnova.png` as base64 but **never `YT.png`**. A production-downloaded `BIM-OOTB.html` opened from `file://` shows exactly **1 asset 404 — `viewer/YT.png`** (broken YouTube icon offline). Also strips the embedded viewer's relative `apple-touch-icon` link (404s in `blob://` context offline).

## Changes (3 files, +32)
- **`index.html`** — inline `YT.png` in `packageLandingPage()`; strip viewer `apple-touch-icon`.
- **`tests/test_s284b_sandbox.js`** — new check `5.1b`: fail on **any** `file://` asset 404 (old `5.1` only matched `Fetch API cannot load file`, green-washing 404s). This is the regression tripwire.
- **`tests/test_s284b_full_package.js`** — inline `icon-192` + `YT.png` as real base64 so the Node-built test artifact matches the real browser download.

## Proof (§-logs)
- Production download (`~/Downloads/BIM-OOTB.html`): import pipeline all PASS, but `5.1b FAIL — YT.png` (exit 1) → bug confirmed live.
- After fix: real-browser `packageLandingPage()` output → 0 relative refs, 0 page errors, **0 file:// asset 404s**.
- Tripwire negative-control: injected missing asset → `5.1b FAIL` exit 1; inlined → PASS. Sandbox **19 PASS / 0 FAIL**; package build **33 PASS / 0 FAIL**.

## Deploy notes
- **No `sw.js` / CACHE_VERSION bump** — landing is served network-first (`viewer/sw.js`), so the fix reaches all users on next online visit. Deliberately avoids colliding with the concurrent **S285 city session** that owns `sw.js`.
- Branched from `main` (not the city branch) → PR contains only these 3 files.

Witness: **W-284c-4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)