### PR TITLE
fix(S284c): graceful image failsafe — hide any image that fails to load

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,19 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="theme-color" content="#ffffff">
 <title>BIM OOTB — DEV</title>
+<script>
+// §S284c image failsafe: a missing DECORATIVE image (logo, YouTube, Sysnova, CI badge)
+// must never show a broken-image icon — just hide it. The functional path (code/workers/
+// wasm/sql, the drop-IFC UI, the card→viewer flow) is not image-dependent, so hiding a
+// broken <img> is always safe. (img 'error' events don't bubble → capture phase.)
+window.addEventListener('error', function(e){
+  var t = e.target;
+  if (t && t.tagName === 'IMG') {
+    t.style.display = 'none';
+    console.warn('§IMG_FAILSAFE hid missing image: ' + (t.getAttribute('src') || '').slice(0, 80));
+  }
+}, true);
+</script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {


### PR DESCRIPTION
## What
Defensive complement to #44 (YT.png inline) and the missing-asset CI tripwire.

If a **decorative** image (logo, YouTube, Sysnova, CI badge) ever fails to load — offline, a typo'd path, a future asset — **hide it** instead of showing a broken-image icon, and log `§IMG_FAILSAFE`.

## How
One global capture-phase `error` listener in `<head>` (image `error` events don't bubble). 14 lines, `index.html` only.

The functional path — **code/workers/wasm/sql, the drop-IFC UI, the card→viewer flow** — is not image-dependent, so hiding a broken `<img>` is always safe. (Per scope: those are the only assets that must be protected; they aren't decorative images.)

## Proof
Served `index.html`, injected a broken `<img>` → `display:none` + `§IMG_FAILSAFE` log; the working YouTube image stayed visible. Verify exit 0.

## Layers
- CI tripwire (`5.1b`, #44) → catches missing assets at commit time so they don't ship.
- This failsafe → graceful degrade in production if anything slips through.

No `sw.js`/CACHE_VERSION bump (landing is network-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)