### PR TITLE
feat(find): multi-select storeys/disciplines + exit keeps filter (sw v537)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Spec file paths audit
         run: node tests/audit_spec_paths.js
 
+      - name: Find multi-select logic (NAV_FIND_002)
+        run: node tests/test_find_multiselect.js
+
   e2e-tests:
     runs-on: ubuntu-latest
     needs: fast-checks

--- a/tests/test_find_multiselect.js
+++ b/tests/test_find_multiselect.js
@@ -1,0 +1,110 @@
+/**
+ * test_find_multiselect.js — §NAV_FIND_002 logic test
+ *
+ * Spec: prompts/NAV_FIND_002_multiselect.md (bim-compiler)
+ * Proves the pure logic behind Find-panel multi-select + storey visibility,
+ * and asserts the deployed source actually defines the contract functions.
+ *
+ * Each block names the issue it proves. Browser §-log verification (FIND_MULTISEL,
+ * STOREY_FILTER) is separate; this guards the algorithm against regression headlessly.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(cond, name) {
+  if (cond) { pass++; }
+  else { fail++; console.log('  §FM_TEST FAIL: ' + name); }
+}
+function eqArr(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+
+// ── Reference impls — MUST mirror the deployed code (panels.js / navigate_find.js) ──
+// _storeyVisible: panels.js §NAV_FIND_002
+function storeyVisible(f, s) {
+  if (f === null || f === undefined) return true;
+  if (Array.isArray(f)) return f.indexOf(s) >= 0;
+  return s === f;
+}
+// filterStorey arg normalization: panels.js §NAV_FIND_002
+function normStorey(arg) {
+  if (Array.isArray(arg)) return arg.length ? (arg.length === 1 ? arg[0] : arg.slice()) : null;
+  return arg;
+}
+// Multi-select transition: navigate_find.js _doTap §NAV_FIND_002
+// state = {sel:Set, anchor:string|null}; returns new state. labels = ordered parent labels.
+function tap(state, label, mod, labels) {
+  const sel = new Set(state.sel);
+  let anchor = state.anchor;
+  if (mod === 'shift' && anchor !== null) {
+    const ai = labels.indexOf(anchor), bi = labels.indexOf(label);
+    if (ai >= 0 && bi >= 0) {
+      sel.clear();
+      for (let k = Math.min(ai, bi); k <= Math.max(ai, bi); k++) sel.add(labels[k]);
+    } else { sel.clear(); sel.add(label); anchor = label; }
+  } else if (mod === 'ctrl') {
+    if (sel.has(label)) sel.delete(label); else sel.add(label);
+    anchor = label;
+  } else {
+    sel.clear(); sel.add(label); anchor = label;
+  }
+  return { sel, anchor };
+}
+// filterDiscs keep-set → hidden complement: panels.js §NAV_FIND_002
+function discHidden(allDiscs, list) {
+  const hidden = new Set();
+  if (list && list.length) {
+    const keep = new Set(list);
+    allDiscs.forEach(d => { if (!keep.has(d)) hidden.add(d); });
+  }
+  return hidden;
+}
+
+// ── Issue 1: storey visibility must be correct for null|string|array ──
+ok(storeyVisible(null, 'L1') === true, 'null filter → all visible');
+ok(storeyVisible(undefined, 'L1') === true, 'undefined filter → all visible');
+ok(storeyVisible('L1', 'L1') === true && storeyVisible('L1', 'L2') === false, 'single filter isolates one storey');
+ok(storeyVisible(['L1', 'L2'], 'L1') === true && storeyVisible(['L1', 'L2'], 'L2') === true, 'array filter shows all selected');
+ok(storeyVisible(['L1', 'L2'], 'L3') === false, 'array filter hides non-selected (regression: === would hide all)');
+
+// ── Issue 2: filterStorey normalizes its arg (empty→all, single→string, many→array) ──
+ok(normStorey([]) === null, 'empty selection → null (show all)');
+ok(normStorey(['L1']) === 'L1', 'single-element array collapses to string');
+ok(eqArr(normStorey(['L1', 'L2']), ['L1', 'L2']), 'multi array stays array');
+ok(normStorey(null) === null && normStorey('L1') === 'L1', 'null/string pass through');
+
+// ── Issue 3: multi-select transitions (plain replace / ctrl toggle / shift range) ──
+const labels = ['L1', 'L2', 'L3', 'L4'];
+let st = { sel: new Set(), anchor: null };
+st = tap(st, 'L2', 'plain', labels);
+ok(eqArr([...st.sel], ['L2']) && st.anchor === 'L2', 'plain tap = single select');
+st = tap(st, 'L4', 'ctrl', labels);
+ok(st.sel.has('L2') && st.sel.has('L4') && st.sel.size === 2, 'ctrl adds a second storey');
+st = tap(st, 'L4', 'ctrl', labels);
+ok(!st.sel.has('L4') && st.sel.has('L2'), 'ctrl on selected toggles it off');
+st = { sel: new Set(['L2']), anchor: 'L2' };
+st = tap(st, 'L4', 'shift', labels);
+ok(eqArr([...st.sel].sort(), ['L2', 'L3', 'L4']), 'shift selects contiguous range from anchor');
+st = tap(st, 'L1', 'shift', labels); // anchor still L2 (shift doesn't move anchor)
+ok(eqArr([...st.sel].sort(), ['L1', 'L2']), 'shift range works backward from anchor');
+st = tap(st, 'L3', 'plain', labels);
+ok(eqArr([...st.sel], ['L3']) && st.anchor === 'L3', 'plain tap after multi clears to single');
+
+// ── Issue 4: filterDiscs shows only listed disciplines (hidden = complement) ──
+const allDiscs = ['STR', 'ARC', 'MEP', 'ELEC'];
+ok(eqArr([...discHidden(allDiscs, ['STR', 'ARC'])].sort(), ['ELEC', 'MEP']), 'filterDiscs([STR,ARC]) hides the rest');
+ok(discHidden(allDiscs, []).size === 0, 'filterDiscs([]) → nothing hidden (all visible)');
+ok(discHidden(allDiscs, null).size === 0, 'filterDiscs(null) → nothing hidden (all visible)');
+ok(eqArr([...discHidden(allDiscs, ['MEP'])].sort(), ['ARC', 'ELEC', 'STR']), 'single disc isolates one discipline');
+
+// ── Issue 5: deployed source actually defines the contract (guards against drift) ──
+const panels = fs.readFileSync(path.resolve(__dirname, '..', 'viewer', 'panels.js'), 'utf8');
+const navfind = fs.readFileSync(path.resolve(__dirname, '..', 'viewer', 'navigate_find.js'), 'utf8');
+ok(/A\._storeyVisible\s*=\s*function/.test(panels), 'panels.js defines A._storeyVisible');
+ok(/A\.filterDiscs\s*=\s*function/.test(panels), 'panels.js defines A.filterDiscs');
+ok(/§FIND_MULTISEL/.test(navfind), 'navigate_find.js logs §FIND_MULTISEL');
+ok(/restored=none/.test(navfind), 'navigate_find.js: exit no longer restores (restored=none)');
+ok(!/if \(A\.filterStorey\) A\.filterStorey\(null\);\s*\n\s*if \(A\.filterDisc\) A\.filterDisc\(null\);[\s\S]{0,80}§FIND_CLOSE/.test(navfind), 'closeFindPanel does not reset filters');
+
+console.log('§FM_TEST_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail > 0 ? 1 : 0);

--- a/viewer/dlod.js
+++ b/viewer/dlod.js
@@ -126,7 +126,6 @@ function setupDLOD(A) {
     _frustum.setFromProjectionMatrix(_projScreenMatrix);
 
     var imVis = 0, imHid = 0, skipCount = 0;
-    var storeyFilter = A.activeStoreyFilter;
     var hiddenDiscs = A.hiddenDiscs;
 
     // ── BatchedMesh: Three.js r160 perObjectFrustumCulled handles per-slot frustum natively.
@@ -147,8 +146,7 @@ function setupDLOD(A) {
       for (var i = 0; i < meta.length; i++) {
         var m = meta[i];
 
-        if (storeyFilter !== null && storeyFilter !== undefined &&
-            m.storey !== storeyFilter) { skipCount++; continue; }
+        if (!A._storeyVisible(m.storey)) { skipCount++; continue; }
         if (hiddenDiscs && hiddenDiscs.size > 0 &&
             hiddenDiscs.has(m.disc)) { skipCount++; continue; }
         if (A._dlodPaused && m._dlodHid) { skipCount++; continue; }

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=13',
+        'navigate_find.js?v=14',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',
@@ -739,16 +739,10 @@ async function initViewer() {
           var storeyParam = hashParams.storey;
           if (storeyParam) {
             var storeys = decodeURIComponent(storeyParam).split(',');
-            APP.activeStoreyFilter = storeys.length === 1 ? storeys[0] : storeys;
-            // Re-apply visibility
-            APP.scene.traverse(function(obj) {
-              if (obj.isMesh && obj.userData && obj.userData.storey) {
-                var vis = Array.isArray(APP.activeStoreyFilter)
-                  ? APP.activeStoreyFilter.indexOf(obj.userData.storey) >= 0
-                  : obj.userData.storey === APP.activeStoreyFilter;
-                obj.visible = vis;
-              }
-            });
+            // §NAV_FIND_002: filterStorey now accepts an array and covers
+            // regular + instanced + batched meshes via A._storeyVisible.
+            if (APP.filterStorey) APP.filterStorey(storeys);
+            else APP.activeStoreyFilter = storeys.length === 1 ? storeys[0] : storeys;
             restored.push('storey=' + storeyParam);
           }
 

--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -1707,7 +1707,7 @@ function setupMeasure(A) {
     }).forEach(function(o) {
       delete o.userData._clashHidden;
       // Respect storey/disc filters
-      var storeyOk = A.activeStoreyFilter === null || o.userData.storey === A.activeStoreyFilter;
+      var storeyOk = A._storeyVisible(o.userData.storey);
       var discOk = !A.hiddenDiscs.has(o.userData.disc);
       o.visible = storeyOk && discOk;
     });

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -205,6 +205,38 @@
     var _treeMode = 'storey'; // 'storey' or 'disc'
     var _treeRevealed = false; // §S280d: tree hidden until mode toggle pressed
 
+    // §NAV_FIND_002: multi-select state (parent rows only). Plain=replace,
+    // Ctrl/Cmd=toggle, Shift=range. Sets cleared only on Storey/Disc toggle.
+    var _selStoreys = new Set();
+    var _selDiscs = new Set();
+    var _anchor = null; // last plain/ctrl-tapped label, for Shift-range
+    function _orderedParentLabels() {
+      return Array.prototype.map.call(
+        elTree ? elTree.querySelectorAll('[data-find-parent]') : [],
+        function(r) { return r.getAttribute('data-find-parent'); });
+    }
+    function _setParentRowStyle(row, active) {
+      var text = row.querySelector('span:nth-child(2)');
+      if (active) {
+        row.setAttribute('data-active', '1');
+        row.style.background = 'linear-gradient(180deg,rgba(79,195,247,0.2) 0%,rgba(79,195,247,0.08) 100%)';
+        row.style.borderLeftColor = '#4fc3f7';
+        if (text) text.style.color = '#4fc3f7';
+      } else {
+        row.removeAttribute('data-active');
+        row.style.background = 'linear-gradient(180deg,rgba(255,255,255,0.06) 0%,rgba(255,255,255,0.02) 100%)';
+        row.style.borderLeftColor = 'rgba(79,195,247,0.3)';
+        if (text) text.style.color = '#ddd';
+      }
+    }
+    function _applyParentHighlight() {
+      if (!elTree) return;
+      var sel = (_treeMode === 'storey') ? _selStoreys : _selDiscs;
+      elTree.querySelectorAll('[data-find-parent]').forEach(function(row) {
+        _setParentRowStyle(row, sel.has(row.getAttribute('data-find-parent')));
+      });
+    }
+
     // §S280: Audio thump — short click on mode toggle (lightweight, no file load)
     var _audioCtx = null;
     function _thump() {
@@ -225,6 +257,8 @@
       _treeMode = mode;
       if (elModeToggle) elModeToggle.textContent = mode === 'storey' ? 'Storey' : 'Discipline';
       // §S280d: Restore full scene visibility on toggle — reset both filters
+      // §NAV_FIND_002: toggling Storey/Disc is the ONLY restore path — also clear selection.
+      _selStoreys.clear(); _selDiscs.clear(); _anchor = null;
       if (A.filterStorey) A.filterStorey(null);
       if (A.filterDisc) A.filterDisc(null);
       _thump();
@@ -246,6 +280,8 @@
       try {
         if (_treeMode === 'storey') _buildStoreyTree(bld, filter);
         else _buildDiscTree(bld, filter);
+        // §NAV_FIND_002: re-apply multi-select highlight after rebuild (filter typing)
+        _applyParentHighlight();
       } catch(e) { console.warn('§FIND_TREE error', e); }
     }
 
@@ -273,6 +309,8 @@
       row.appendChild(arrow);
       row.appendChild(text);
       row.appendChild(badge);
+      // §NAV_FIND_002: tag parent rows so multi-select range/highlight can read DOM order
+      if (isParent) row.setAttribute('data-find-parent', label);
 
       // Hover
       row.addEventListener('pointerenter', function() {
@@ -314,21 +352,34 @@
           // Arrow never touches 3D — neutral action
         });
       }
-      // Click on label/badge = sticky filter (switching storeys replaces, no toggle-off)
+      // §NAV_FIND_002: parent rows = multi-select layer (storey/disc).
+      // Plain=replace, Ctrl/Cmd=toggle, Shift=range. Children → opts.onTap.
       function _doTap(e) {
         e.stopPropagation();
-        if (isParent && row.parentNode) {
-          // Deselect all siblings
-          row.parentNode.querySelectorAll('[data-active]').forEach(function(el) {
-            el.removeAttribute('data-active');
-            el.style.background = 'linear-gradient(180deg,rgba(255,255,255,0.06) 0%,rgba(255,255,255,0.02) 100%)';
-            el.style.borderLeftColor = 'rgba(79,195,247,0.3)';
-            el.querySelector('span:nth-child(2)').style.color = '#ddd';
-          });
-          row.setAttribute('data-active', '1');
-          row.style.background = 'linear-gradient(180deg,rgba(79,195,247,0.2) 0%,rgba(79,195,247,0.08) 100%)';
-          row.style.borderLeftColor = '#4fc3f7';
-          text.style.color = '#4fc3f7';
+        if (isParent && opts.multiSelect) {
+          var sel = (_treeMode === 'storey') ? _selStoreys : _selDiscs;
+          var ctrl = e.ctrlKey || e.metaKey;
+          var shift = e.shiftKey;
+          var mod = shift ? 'shift' : (ctrl ? 'ctrl' : 'plain');
+          if (shift && _anchor !== null) {
+            var labels = _orderedParentLabels();
+            var ai = labels.indexOf(_anchor), bi = labels.indexOf(label);
+            if (ai >= 0 && bi >= 0) {
+              sel.clear();
+              for (var k = Math.min(ai, bi); k <= Math.max(ai, bi); k++) sel.add(labels[k]);
+            } else { sel.clear(); sel.add(label); _anchor = label; }
+          } else if (ctrl) {
+            if (sel.has(label)) sel.delete(label); else sel.add(label);
+            _anchor = label;
+          } else {
+            sel.clear(); sel.add(label); _anchor = label;
+          }
+          _applyParentHighlight();
+          var arr = Array.from(sel);
+          if (_treeMode === 'storey') { if (A.filterStorey) A.filterStorey(arr.length ? arr : null); }
+          else { if (A.filterDiscs) A.filterDiscs(arr.length ? arr : null); }
+          console.log('§FIND_MULTISEL mode=' + _treeMode + ' sel=[' + arr.join(',') + '] n=' + arr.length + ' mod=' + mod);
+          return;
         }
         if (opts.onTap) opts.onTap();
       }
@@ -357,10 +408,7 @@
 
         var node = _treeNode(storey, storeyCnt, 0, {
           children: true, // signal: has children, loaded lazily
-          onTap: function() {
-            // §S280b: Storey tap = instant 3D filter. Sticky — close panel restores.
-            if (A.filterStorey) A.filterStorey(storey);
-          },
+          multiSelect: true, // §NAV_FIND_002: _doTap manages selection + filter
           onExpand: function(container) {
             if (container._loaded) return;
             container._loaded = true;
@@ -413,10 +461,7 @@
 
         var node = _treeNode(disc, discCnt, 0, {
           children: true,
-          onTap: function() {
-            // §S280d: Disc tap = show only this discipline (like storey). Sticky — close restores.
-            if (A.filterDisc) A.filterDisc(disc);
-          },
+          multiSelect: true, // §NAV_FIND_002: _doTap manages selection + filter
           onExpand: function(container) {
             if (container._loaded) return;
             container._loaded = true;
@@ -585,15 +630,15 @@
       panel.style.display = 'none';
       if (nav.active) { if (A.stopNavigation) A.stopNavigation(); }
       clearHighlight();
-      // §S280d: Restore full scene — clear storey + disc filters
-      if (A.filterStorey) A.filterStorey(null);
-      if (A.filterDisc) A.filterDisc(null);
+      // §NAV_FIND_002: exit KEEPS the storey/disc filter applied. Only the
+      // Storey/Disc toggle restores full scene. (was: filterStorey/Disc(null))
       // §S280d: Reset tree visibility for next open
       _treeRevealed = false;
       if (elTree) elTree.style.display = 'none';
       // S275: Release panel focus so other panels (Clash, etc.) work
       if (typeof window._blurPanel === 'function') window._blurPanel();
-      console.log('[S233] §FIND_CLOSE restored=full');
+      var _kept = Array.from(_treeMode === 'storey' ? _selStoreys : _selDiscs);
+      console.log('[S233] §FIND_CLOSE restored=none kept=[' + _kept.join(',') + ']');
     }
     A.closeFindPanel = closeFindPanel; // exposed for nlp.js bar close
     elClose.onclick = closeFindPanel;

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -422,24 +422,35 @@ function setupPanels(A) {
   A.activeStoreyFilter = null;
   A.storeyMeshGroups = {};
 
+  // §NAV_FIND_002: ONE storey-visibility predicate. activeStoreyFilter may be
+  // null (all) | string (one) | Array<string> (multi). All appliers route here.
+  A._storeyVisible = function(s) {
+    var f = A.activeStoreyFilter;
+    if (f === null || f === undefined) return true;
+    if (Array.isArray(f)) return f.indexOf(s) >= 0;
+    return s === f;
+  };
+
   // §S280: HUD removed — storey/disc now in Find outliner
   A.populateStoreys = function() {};
 
+  // §NAV_FIND_002: accepts null | string | Array<string>. Empty array → all.
   A.filterStorey = function(storey) {
+    if (Array.isArray(storey)) storey = storey.length ? (storey.length === 1 ? storey[0] : storey.slice()) : null;
     A.activeStoreyFilter = storey;
     // S239: Regular meshes — show/hide by storey
     A.collectMeshes(o => o.isMesh && o.userData.storey !== undefined).forEach(obj => {
-      obj.visible = storey === null || obj.userData.storey === storey;
+      obj.visible = A._storeyVisible(obj.userData.storey);
     });
     // S232/S239: InstancedMesh — per-instance storey filter via zero-scale matrix
     A.collectMeshes(o => o.isInstancedMesh).forEach(mesh => {
-      A.filterInstancedMesh(mesh, meta => storey === null || meta.storey === storey);
+      A.filterInstancedMesh(mesh, meta => A._storeyVisible(meta.storey));
     });
     // §S260: BatchedMesh — per-element storey filter via setVisibleAt
     A.collectMeshes(o => o.isBatchedMesh).forEach(mesh => {
-      A.filterBatchedMesh(mesh, meta => storey === null || meta.storey === storey);
+      A.filterBatchedMesh(mesh, meta => A._storeyVisible(meta.storey));
     });
-    console.log(`[S200] §STOREY_FILTER ${storey || 'ALL'}`);
+    console.log(`[S200] §STOREY_FILTER ${Array.isArray(storey) ? '[' + storey.join(',') + ']' : (storey || 'ALL')}`);
     if (A.markDirty) A.markDirty();
   };
 
@@ -459,34 +470,37 @@ function setupPanels(A) {
 
   // §S280d: Show only this discipline (null = show all). Counterpart to filterStorey.
   A.filterDisc = function(disc) {
+    A.filterDiscs(disc === null ? null : [disc]);
+  };
+
+  // §NAV_FIND_002: Show ONLY the disciplines in `list` (empty/null → all). Multi-select.
+  A.filterDiscs = function(list) {
     A.hiddenDiscs.clear();
-    if (disc !== null) {
-      // Build hiddenDiscs from scene — hide everything except target disc
+    if (list && list.length) {
+      var keep = new Set(list);
+      // Build hiddenDiscs from scene — hide everything not in the keep set
       A.collectMeshes(o => o.isMesh && o.userData.disc).forEach(obj => {
-        if (obj.userData.disc !== disc) A.hiddenDiscs.add(obj.userData.disc);
+        if (!keep.has(obj.userData.disc)) A.hiddenDiscs.add(obj.userData.disc);
       });
     }
     A._applyDiscVisibility();
-    console.log('[S200] §DISC_FILTER ' + (disc || 'ALL'));
+    console.log('[S200] §DISC_FILTER ' + (list && list.length ? '[' + list.join(',') + ']' : 'ALL'));
   };
 
   // §S280d: shared traversal for disc + storey combined visibility
   A._applyDiscVisibility = function() {
     A.collectMeshes(o => o.isMesh && o.userData.disc).forEach(obj => {
       const discVisible = !A.hiddenDiscs.has(obj.userData.disc);
-      const storeyVisible = A.activeStoreyFilter === null || obj.userData.storey === A.activeStoreyFilter;
-      obj.visible = discVisible && storeyVisible;
+      obj.visible = discVisible && A._storeyVisible(obj.userData.storey);
     });
     A.collectMeshes(o => o.isInstancedMesh).forEach(mesh => {
       A.filterInstancedMesh(mesh, meta => {
-        return !A.hiddenDiscs.has(meta.disc) &&
-          (A.activeStoreyFilter === null || meta.storey === A.activeStoreyFilter);
+        return !A.hiddenDiscs.has(meta.disc) && A._storeyVisible(meta.storey);
       });
     });
     A.collectMeshes(o => o.isBatchedMesh).forEach(mesh => {
       A.filterBatchedMesh(mesh, meta => {
-        return !A.hiddenDiscs.has(meta.disc) &&
-          (A.activeStoreyFilter === null || meta.storey === A.activeStoreyFilter);
+        return !A.hiddenDiscs.has(meta.disc) && A._storeyVisible(meta.storey);
       });
     });
     if (A.markDirty) A.markDirty();

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -827,7 +827,7 @@ function setupStreaming(A) {
 
           // Storey/disc visibility filter
           var vis = true;
-          if (A.activeStoreyFilter !== null && el.storey !== A.activeStoreyFilter) vis = false;
+          if (!A._storeyVisible(el.storey)) vis = false;
           if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(el.disc)) vis = false;
           if (!vis) bm.setVisibleAt(slotId, false);
 
@@ -856,7 +856,7 @@ function setupStreaming(A) {
           mesh.userData.storey = el.storey; mesh.userData.disc = el.disc;
           mesh.userData.guid = el.guid; mesh.userData.ifcClass = el.ifcClass || '';
           A.guidMap[mesh.id] = el.guid;
-          if (A.activeStoreyFilter !== null && el.storey !== A.activeStoreyFilter) mesh.visible = false;
+          if (!A._storeyVisible(el.storey)) mesh.visible = false;
           if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(el.disc)) mesh.visible = false;
           A.scene.add(mesh);
           batchedCount++;
@@ -952,7 +952,7 @@ function setupStreaming(A) {
         mesh.userData.disc = disc === '_' ? '' : disc;
         mesh.userData.isMerged = true;
         mesh.userData.mergedCount = items.length;
-        if (A.activeStoreyFilter !== null && mesh.userData.storey !== A.activeStoreyFilter) mesh.visible = false;
+        if (!A._storeyVisible(mesh.userData.storey)) mesh.visible = false;
         if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(mesh.userData.disc)) mesh.visible = false;
         A.scene.add(mesh);
         mergedCount += items.length;
@@ -1071,7 +1071,7 @@ function setupStreaming(A) {
           m.userData.storey = el.storey; m.userData.disc = el.disc;
           m.userData.guid = el.guid; m.userData.ifcClass = el.ifcClass || '';
           A.guidMap[m.id] = el.guid;
-          if (A.activeStoreyFilter !== null && el.storey !== A.activeStoreyFilter) m.visible = false;
+          if (!A._storeyVisible(el.storey)) m.visible = false;
           if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(el.disc)) m.visible = false;
           A.scene.add(m);
           drawCalls++;
@@ -1130,7 +1130,7 @@ function setupStreaming(A) {
 
         // Storey/disc visibility filter
         var vis = true;
-        if (A.activeStoreyFilter !== null && el.storey !== A.activeStoreyFilter) vis = false;
+        if (!A._storeyVisible(el.storey)) vis = false;
         if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(el.disc)) vis = false;
         if (!vis) bm.setVisibleAt(slotId, false);
 
@@ -1287,7 +1287,7 @@ function setupStreaming(A) {
         newBM.setMatrixAt(slotId, _m4);
 
         var vis = true;
-        if (A.activeStoreyFilter !== null && el.storey !== A.activeStoreyFilter) vis = false;
+        if (!A._storeyVisible(el.storey)) vis = false;
         if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(el.disc)) vis = false;
         if (!vis) newBM.setVisibleAt(slotId, false);
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v536';
+const CACHE_VERSION = 'v537';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -770,16 +770,16 @@
 <script src="scene.js?v=47" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=51" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
-<script src="dlod.js?v=6" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
-<script src="panels.js?v=28" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
+<script src="streaming.js?v=52" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="dlod.js?v=7" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
+<script src="panels.js?v=29" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=25" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=24" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=4" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>
-<script src="measure.js?v=45" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
+<script src="measure.js?v=46" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>
 <script src="share.js?v=2" onerror="console.warn('§LOAD_FAIL share.js')"></script>
 <script src="issues.js?v=5" onerror="console.warn('§LOAD_FAIL issues.js')"></script>
@@ -833,7 +833,7 @@
 <script src="precision_cam.js?v=2" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="time_machine.js?v=48" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
-<script src="main.js?v=34"></script>
+<script src="main.js?v=35"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>
 <script>


### PR DESCRIPTION
## §NAV_FIND_002 — Find panel multi-select

Find outliner parent rows (storeys / disciplines) now support **multi-select**:
- **Plain** tap = replace (single), as before
- **Ctrl/Cmd** + tap = toggle in/out
- **Shift** + tap = range from anchor

### Behavior changes
- **Exit keeps the filter** — `closeFindPanel` no longer restores (`restored=none`). Only the **Storey↔Disc toggle** restores full scene + clears selection.
- Search-result fly-to (`selectResult`) still clears filter deliberately, so the target isn't hidden.

### Pipeline
- New `A._storeyVisible(null|string|array)` — ONE predicate routed through **every** applier (`panels.js` ×3, `streaming.js` ×6, `measure.js`, `dlod.js`) so multi-storey holds through streaming/LOD (no hidden-everything bug).
- New `A.filterDiscs(list)`; `filterStorey` accepts a list; share-restore in `main.js` now routes through `filterStorey` (also covers IM/BM).

### Tests / verification
- `tests/test_find_multiselect.js` — 24 logic cases (storey predicate, arg normalization, plain/ctrl/shift transitions, disc keep-set), wired into CI.
- All CI fast-checks green locally; syntax clean on all touched files.
- Cache bump: sw `v536→v537`; `viewer.html` streaming/dlod/panels/measure/main `?v=`; `main.js` `navigate_find.js?v=14`.

§-witness logs in browser: `§FIND_MULTISEL`, `§STOREY_FILTER [..]`, `§DISC_FILTER [..]`, `§FIND_CLOSE restored=none kept=[..]`.

Spec: `prompts/NAV_FIND_002_multiselect.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)