### PR TITLE
feat(4d): capture native IFC 4D in Drop-IFC importer (T1+T1b)

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@ window.addEventListener('error', function(e){
   <div class="tab-list" id="tab-list"></div>
 </div>
 
-<script src="viewer/import_db_builder.js?v=3"></script>
+<script src="viewer/import_db_builder.js?v=4"></script>
 <!-- wizard.js now loads in viewer via ?wizard=1 param (S230) -->
 <script>
 // ── Config ──
@@ -1199,7 +1199,7 @@ async function handleImportFile(file) {
 
   const arrayBuffer = await file.arrayBuffer();
   // S228: Route to IFC or mesh worker based on format
-  var workerFile = (fmt.route === 'ifc') ? 'viewer/import_worker.js?v=8' : 'viewer/mesh_import_worker.js?v=2';
+  var workerFile = (fmt.route === 'ifc') ? 'viewer/import_worker.js?v=9' : 'viewer/mesh_import_worker.js?v=2';
   var workerMsg = (fmt.route === 'ifc') ? { arrayBuffer, filename: file.name } : { arrayBuffer, filename: file.name, ext: fmt.ext };
   // §S284d: for the IFC route, fetch the wasm bytes (offline-safe) and transfer them into the
   // worker so emscripten never does its own fragile fetch. Honest error if truly unavailable.
@@ -1424,7 +1424,7 @@ async function handleImportMultiIFC(files) {
     try {
       var result = await new Promise(function(resolve, reject) {
         file.arrayBuffer().then(function(arrayBuffer) {
-          var worker = _createWorker('viewer/import_worker.js?v=8');
+          var worker = _createWorker('viewer/import_worker.js?v=9');
           worker.onmessage = function(e) {
             var msg = e.data;
             if (msg.type === 'progress') {
@@ -1830,12 +1830,12 @@ async function packageLandingPage() {
   try {
     // 1. Fetch external JS files that need inlining
     setStatus('Inlining scripts…');
-    var dbBuilderSrc = await fetch('viewer/import_db_builder.js?v=3').then(function(r) { return r.text(); });
+    var dbBuilderSrc = await fetch('viewer/import_db_builder.js?v=4').then(function(r) { return r.text(); });
     var localeSrc = await fetch('viewer/locale_loader.js?v=7').then(function(r) { return r.text(); });
 
     // 1b. Fetch Worker scripts for Blob URL in standalone mode
     setStatus('Fetching worker scripts…');
-    var importWorkerSrc = await fetch('viewer/import_worker.js?v=8').then(function(r) { return r.text(); });
+    var importWorkerSrc = await fetch('viewer/import_worker.js?v=9').then(function(r) { return r.text(); });
     var meshWorkerSrc = await fetch('viewer/mesh_import_worker.js?v=2').then(function(r) { return r.text(); }).catch(function() { return ''; });
     var exportWorkerSrc = await fetch('viewer/ifc_export_worker.js?v=2').then(function(r) { return r.text(); }).catch(function() { return ''; });
     var workerJSON = JSON.stringify({

--- a/viewer/import_db_builder.js
+++ b/viewer/import_db_builder.js
@@ -77,6 +77,67 @@ function buildImportDBs(SQL, data) {
     console.log('[S267] §BOM_TREE_TABLE rows=' + data.bomTree.length);
   }
 
+  // 4D_CAPTURE_AND_FALLBACK.md T1/T1b — native IFC 4D schedule (W-CAPTURE / W-VOCAB).
+  // Widened DDL (§5.2): CPM dates, float, is_critical, WBS (wbs_parent+is_summary),
+  // predefined_type, nullable resource (OUR template concept, captured=null), + a thin
+  // calendars carrier. schedule_*/float fields are RAW ISO-8601 strings (verbatim, never
+  // re-derived). Tables always created (empty if no programme) so Time Machine probes a
+  // stable schema. The split-DB path below copies these into metaDb automatically.
+  db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+  db.run('CREATE TABLE IF NOT EXISTS tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)');
+  db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+  db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+  db.run('CREATE TABLE IF NOT EXISTS calendars (name TEXT, recurrence_type TEXT, raw TEXT)');
+
+  var _schedId = (data.schedules && data.schedules[0] && data.schedules[0].id) || null;
+  var _nSched = 0, _nTask = 0, _nSeq = 0, _nTE = 0, _nCal = 0;
+  if (data.schedules && data.schedules.length) {
+    var stmtSc = db.prepare('INSERT OR IGNORE INTO schedules VALUES (?,?,?,?)');
+    for (var si = 0; si < data.schedules.length; si++) {
+      var sc = data.schedules[si];
+      stmtSc.run([sc.id, sc.name, sc.status, sc.created]); _nSched++;
+    }
+    stmtSc.free();
+  }
+  if (data.tasks && data.tasks.length) {
+    // Column order matches the widened DDL above. resource is always null on capture (§5.2).
+    var stmtTk = db.prepare('INSERT OR IGNORE INTO tasks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+    for (var ti2 = 0; ti2 < data.tasks.length; ti2++) {
+      var tk = data.tasks[ti2];
+      stmtTk.run([tk.id, _schedId, tk.wbsParent || null, tk.name, tk.predefinedType || null,
+        (tk.isSummary != null ? tk.isSummary : 0), tk.scheduleStart || null, tk.scheduleFinish || null,
+        tk.scheduleDuration || null, tk.earlyStart || null, tk.earlyFinish || null,
+        tk.lateStart || null, tk.lateFinish || null, tk.freeFloat || null, tk.totalFloat || null,
+        (tk.isCritical != null ? tk.isCritical : null), null, tk.status || null]); _nTask++;
+    }
+    stmtTk.free();
+  }
+  if (data.taskSequences && data.taskSequences.length) {
+    var stmtSq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    for (var qi = 0; qi < data.taskSequences.length; qi++) {
+      var sq = data.taskSequences[qi];
+      stmtSq.run([sq.predId, sq.succId, sq.type, sq.lag]); _nSeq++;
+    }
+    stmtSq.free();
+  }
+  if (data.taskElements && data.taskElements.length) {
+    var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
+    for (var tei = 0; tei < data.taskElements.length; tei++) {
+      var te = data.taskElements[tei];
+      stmtTe.run([te.taskId, te.guid]); _nTE++;
+    }
+    stmtTe.free();
+  }
+  if (data.calendars && data.calendars.length) {
+    var stmtCal = db.prepare('INSERT INTO calendars VALUES (?,?,?)');
+    for (var cli = 0; cli < data.calendars.length; cli++) {
+      var cal = data.calendars[cli];
+      stmtCal.run([cal.name || null, cal.recurrenceType || null, cal.raw || null]); _nCal++;
+    }
+    stmtCal.free();
+  }
+  console.log('[4D] §4D_TABLES schedules=' + _nSched + ' tasks=' + _nTask + ' sequences=' + _nSeq + ' taskElements=' + _nTE + ' calendars=' + _nCal);
+
   db.run('COMMIT');
 
   console.log('[S220] §DB_BUILD single_db: elements=' + data.elements.length + ' transforms=' + data.transforms.length + ' instances=' + data.geometries.length + ' geometries=' + data.geometries.length);

--- a/viewer/import_worker.js
+++ b/viewer/import_worker.js
@@ -627,6 +627,191 @@ self.onmessage = async function(e) {
     console.log('[S220] §GEOM_DONE elements=' + elements.length + ' withGeometry=' + geometries.length + ' skipped=' + (elements.length - geometries.length) + ' withMaterial=' + matCount);
     post('progress', 95, 'Packaging results...');
 
+    // ── 4D extraction (if present) ──────────────────────────────────────────
+    // Implementing 4D_CAPTURE_AND_FALLBACK.md T1/T1b — Witness W-CAPTURE / W-VOCAB.
+    // Dual-direction task↔element links (IfcRelAssignsToProduct is the Hospital/Bonsai fix).
+    // Widened (§5.2): CPM dates, float, is_critical, WBS (wbs_parent+is_summary), calendar.
+    // ifcApi + modelID are still valid here (S274: this worker never calls CloseModel).
+    var schedules = [], tasks = [], taskSequences = [], taskElements = [], calendars = [];
+    try {
+      var schedIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCWORKSCHEDULE);
+      for (var sci = 0; sci < schedIds.size(); sci++) {
+        try {
+          var sch = ifcApi.GetLine(modelID, schedIds.get(sci));
+          schedules.push({
+            id: sch.GlobalId ? sch.GlobalId.value : 'SCHED_' + sci,
+            name: sch.Name ? sch.Name.value : 'Schedule ' + sci,
+            status: sch.Status ? sch.Status.value : null,
+            created: sch.CreationDate ? sch.CreationDate.value : null,
+          });
+        } catch(e) {}
+      }
+    } catch(e) {}
+
+    // WBS hierarchy (§5.2): IfcRelNests parent→children. wbs_parent (parent GUID) +
+    // is_summary (a task that HAS children — NOT reliable from PredefinedType, per W-VOCAB).
+    var _childToParentEx = {}, _hasKids = {};
+    try {
+      var nestIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCRELNESTS);
+      for (var ni = 0; ni < nestIds.size(); ni++) {
+        try {
+          var nst = ifcApi.GetLine(modelID, nestIds.get(ni));
+          var parentEx = nst.RelatingObject ? nst.RelatingObject.value : null;
+          if (parentEx == null || !nst.RelatedObjects) continue;
+          _hasKids[parentEx] = true;
+          for (var nj = 0; nj < nst.RelatedObjects.length; nj++) {
+            var kidEx = nst.RelatedObjects[nj] ? nst.RelatedObjects[nj].value : null;
+            if (kidEx != null) _childToParentEx[kidEx] = parentEx;
+          }
+        } catch(e) {}
+      }
+    } catch(e) {}
+
+    var _exToGuid = {};
+    try {
+      var taskIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCTASK);
+      for (var tki = 0; tki < taskIds.size(); tki++) {
+        try {
+          var _ex = taskIds.get(tki);
+          var tsk = ifcApi.GetLine(modelID, _ex);
+          var taskTime = tsk.TaskTime ? ifcApi.GetLine(modelID, tsk.TaskTime.value) : null;
+          var _guid = tsk.GlobalId ? tsk.GlobalId.value : 'TASK_' + tki;
+          _exToGuid[_ex] = _guid;
+          tasks.push({
+            _ex: _ex,
+            id: _guid,
+            name: tsk.Name ? tsk.Name.value : 'Task ' + tki,
+            predefinedType: tsk.PredefinedType ? tsk.PredefinedType.value : null,
+            // EXTRACT VERBATIM — ISO-8601 durations/floats ("P15D"/"P0D"); never re-derive (PRIME RULE).
+            scheduleStart: taskTime && taskTime.ScheduleStart ? taskTime.ScheduleStart.value : null,
+            scheduleFinish: taskTime && taskTime.ScheduleFinish ? taskTime.ScheduleFinish.value : null,
+            scheduleDuration: taskTime && taskTime.ScheduleDuration ? taskTime.ScheduleDuration.value : null,
+            earlyStart: taskTime && taskTime.EarlyStart ? taskTime.EarlyStart.value : null,
+            earlyFinish: taskTime && taskTime.EarlyFinish ? taskTime.EarlyFinish.value : null,
+            lateStart: taskTime && taskTime.LateStart ? taskTime.LateStart.value : null,
+            lateFinish: taskTime && taskTime.LateFinish ? taskTime.LateFinish.value : null,
+            freeFloat: taskTime && taskTime.FreeFloat ? taskTime.FreeFloat.value : null,
+            totalFloat: taskTime && taskTime.TotalFloat ? taskTime.TotalFloat.value : null,
+            isCritical: (taskTime && taskTime.IsCritical != null) ? (taskTime.IsCritical.value ? 1 : 0) : null,
+            status: tsk.Status ? tsk.Status.value : null,
+          });
+        } catch(e) {}
+      }
+    } catch(e) {}
+    for (var twi = 0; twi < tasks.length; twi++) {
+      var _pex = _childToParentEx[tasks[twi]._ex];
+      tasks[twi].wbsParent = (_pex != null && _exToGuid[_pex]) ? _exToGuid[_pex] : null;
+      tasks[twi].isSummary = _hasKids[tasks[twi]._ex] ? 1 : 0;
+    }
+
+    try {
+      var seqIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCRELSEQUENCE);
+      for (var sqi = 0; sqi < seqIds.size(); sqi++) {
+        try {
+          var sq = ifcApi.GetLine(modelID, seqIds.get(sqi));
+          var pred = sq.RelatingProcess ? ifcApi.GetLine(modelID, sq.RelatingProcess.value) : null;
+          var succ = sq.RelatedProcess ? ifcApi.GetLine(modelID, sq.RelatedProcess.value) : null;
+          if (pred && succ) {
+            taskSequences.push({
+              predId: pred.GlobalId ? pred.GlobalId.value : null,
+              succId: succ.GlobalId ? succ.GlobalId.value : null,
+              type: sq.SequenceType ? sq.SequenceType.value : 'FINISH_START',
+              lag: sq.TimeLag ? (parseFloat(sq.TimeLag.value) || 0) : 0,
+            });
+          }
+        } catch(e) {}
+      }
+    } catch(e) {}
+
+    // Work calendar (§5.2): thin {name, recurrence_type, raw} carrier. Conversion DEFERRED
+    // (round-the-clock for now) — capture the carrier so a later Settings option can use it.
+    try {
+      var calIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCWORKCALENDAR);
+      for (var cIx = 0; cIx < calIds.size(); cIx++) {
+        try {
+          var cal = ifcApi.GetLine(modelID, calIds.get(cIx));
+          var calName = cal.Name ? cal.Name.value : null;
+          var wts = cal.WorkingTimes ? (Array.isArray(cal.WorkingTimes) ? cal.WorkingTimes : [cal.WorkingTimes]) : [];
+          var wtName = null, recType = null;
+          if (wts.length) {
+            try {
+              var wkt = ifcApi.GetLine(modelID, wts[0].value);
+              wtName = wkt.Name ? wkt.Name.value : null;
+              if (wkt.RecurrencePattern) {
+                var rp = ifcApi.GetLine(modelID, wkt.RecurrencePattern.value);
+                recType = (rp && rp.RecurrenceType) ? rp.RecurrenceType.value : null;
+              }
+            } catch(e) {}
+          }
+          calendars.push({
+            name: wtName || calName,
+            recurrenceType: recType,
+            raw: JSON.stringify({ calendarName: calName, workingTimeName: wtName, recurrenceType: recType, workingTimes: wts.length }),
+          });
+        } catch(e) {}
+      }
+    } catch(e) {}
+
+    // task→element links — read BOTH directions, dedupe on taskId|guid
+    var _seenTE = {};
+    var _pushTE = function(taskId, guid) {
+      if (!taskId || !guid) return;
+      var k = taskId + '|' + guid;
+      if (_seenTE[k]) return;
+      _seenTE[k] = 1;
+      taskElements.push({ taskId: taskId, guid: guid });
+    };
+    // Direction 1 — IfcRelAssignsToProcess: RelatingProcess=task, RelatedObjects=elements
+    try {
+      var assignIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCRELASSIGNSTOPROCESS);
+      for (var apx = 0; apx < assignIds.size(); apx++) {
+        try {
+          var asg = ifcApi.GetLine(modelID, assignIds.get(apx));
+          var process = asg.RelatingProcess ? ifcApi.GetLine(modelID, asg.RelatingProcess.value) : null;
+          if (process && process.GlobalId && asg.RelatedObjects) {
+            var taskGuid = process.GlobalId.value;
+            for (var aj = 0; aj < asg.RelatedObjects.length; aj++) {
+              try {
+                var obj = ifcApi.GetLine(modelID, asg.RelatedObjects[aj].value);
+                if (obj && obj.GlobalId) _pushTE(taskGuid, obj.GlobalId.value);
+              } catch(e) {}
+            }
+          }
+        } catch(e) {}
+      }
+    } catch(e) {}
+    // Direction 2 — IfcRelAssignsToProduct: RelatingProduct=element, RelatedObjects=tasks (Bonsai)
+    try {
+      var prodIds = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCRELASSIGNSTOPRODUCT);
+      for (var pri = 0; pri < prodIds.size(); pri++) {
+        try {
+          var rpr = ifcApi.GetLine(modelID, prodIds.get(pri));
+          var product = rpr.RelatingProduct ? ifcApi.GetLine(modelID, rpr.RelatingProduct.value) : null;
+          if (product && product.GlobalId && rpr.RelatedObjects) {
+            var elemGuid = product.GlobalId.value;
+            for (var pj = 0; pj < rpr.RelatedObjects.length; pj++) {
+              try {
+                var tobj = ifcApi.GetLine(modelID, rpr.RelatedObjects[pj].value);
+                if (tobj && tobj.GlobalId) _pushTE(tobj.GlobalId.value, elemGuid);
+              } catch(e) {}
+            }
+          }
+        } catch(e) {}
+      }
+    } catch(e) {}
+
+    if (schedules.length || tasks.length) {
+      console.log('§4D_FOUND schedules=' + schedules.length + ' tasks=' + tasks.length + ' sequences=' + taskSequences.length + ' taskElements=' + taskElements.length);
+      // T1b W-VOCAB witness — widened fields populated at the §5.2 evidence rates.
+      var _cnt4d = function(f) { var n = 0; for (var z = 0; z < tasks.length; z++) if (tasks[z][f] != null) n++; return n; };
+      var _nSummary = 0; for (var z2 = 0; z2 < tasks.length; z2++) if (tasks[z2].isSummary) _nSummary++;
+      console.log('§4D_WIDE earlyStart=' + _cnt4d('earlyStart') + ' totalFloat=' + _cnt4d('totalFloat') +
+        ' isCritical=' + _cnt4d('isCritical') + ' wbsParent=' + _cnt4d('wbsParent') +
+        ' summary=' + _nSummary + ' calendars=' + calendars.length);
+    } else {
+      console.log('§4D_NONE no scheduling data in this IFC');
+    }
+
     const result = {
       type: 'done',
       meta: {
@@ -641,6 +826,12 @@ self.onmessage = async function(e) {
       geometries: geometries,
       bomTree: bomTree,  // §S267: parent→child IFC relationships for bom_tree table
       transforms: transforms,
+      // 4D_CAPTURE_AND_FALLBACK.md T1/T1b — native IFC 4D schedule (W-CAPTURE / W-VOCAB)
+      schedules: schedules,
+      tasks: tasks,
+      taskSequences: taskSequences,
+      taskElements: taskElements,
+      calendars: calendars,  // T1b §5.2 — thin work-calendar carrier
     };
 
     // Transfer array buffers for zero-copy

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v539';
+const CACHE_VERSION = 'v540';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## What
Ports the bim-compiler **T1+T1b** 4D capture to the live viewer. The Drop-IFC importer now extracts the native IFC construction programme into the saved `.db`.

## Changes
- **`import_worker.js`** — walk `IfcWorkSchedule` / `IfcTask(+IfcTaskTime)` / `IfcRelSequence`; dual-direction task↔element links (`IfcRelAssignsToProcess` **+** `IfcRelAssignsToProduct` — the Bonsai/Hospital fix that yields 2900 links). Widened per §5.2: CPM early/late dates, free/total float, `is_critical`, WBS (`wbs_parent` + `is_summary` via `IfcRelNests`), `predefined_type`, thin `IfcWorkCalendar` carrier. ISO-8601 durations/floats kept **verbatim**.
- **`import_db_builder.js`** — 18-col `tasks` DDL + `schedules`/`task_sequences`/`task_elements`/`calendars`, always created (stable schema, empty if no programme). Split-DB path carries 4D into `meta.db` automatically; `geo.db` stays clean.
- **Cache-bust** — `sw.js` `v539→v540`; `import_worker.js ?v=8→9`; `import_db_builder.js ?v=3→4`.

## Evidence (witnessed in bim-compiler on `Hospital 2.0.ifc`)
```
§4D_FOUND  schedules=1 tasks=75 sequences=43 taskElements=2900
§4D_WIDE   earlyStart=45 totalFloat=44 isCritical=45 wbsParent=72 summary=23 calendars=1
§4D_DB_FIELDS schedule_duration=46 early_start=45 total_float=44 is_critical=45 wbs_parent=72 is_summary=23
```
Builder split-path also proven (full + meta carry 4D; geo clean). `test_import_worker_safety.js` 9/9 PASS.

## Scope notes
- **Multi-file merge** path intentionally not extended (cross-IFC schedule semantics need their own spec) — it produces stable **empty** 4D tables, no crash.
- **Time Machine** still *generates* (does not yet read these tables) — that's the next item (**T3**).

## Test plan (after merge → Pages)
Drop `Hospital 2.0.ifc` → Save DB → inspect `meta.db`: expect `schedules=1 / tasks=75 / task_elements=2900 / calendars=1` and populated CPM/float/WBS columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)