### PR TITLE
fix(S280h): TM-on freeze (txn-batch injectGantt) + Ground row buttons missing

### DIFF
--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -205,8 +205,10 @@ function setupPanels(A) {
     groundRow.appendChild(glabel);
     existing.appendChild(groundRow);
 
-    (A._loadGroundConfig ? A._loadGroundConfig() : Promise.resolve(A._groundCfgDefault)).then(function(cfg) {
-      var opts = (cfg && cfg.options) || [];
+    // §S280g-fix: setupPanels runs BEFORE setupTools (main.js), so A._loadGroundConfig is
+    // not defined yet at build time → zero buttons. Defer one tick so tools.js is ready,
+    // and fall back to a built-in option list if config can't load.
+    function _buildGroundButtons(opts) {
       A._groundBtns = {};
       A._refreshGroundBtns = function() {
         Object.keys(A._groundBtns).forEach(function(k) {
@@ -229,7 +231,16 @@ function setupPanels(A) {
       });
       A._refreshGroundBtns();
       console.log('§GROUND_ROW built opts=' + opts.length);
-    });
+    }
+    var _GROUND_FALLBACK = [
+      { key: 'none', label: 'None' }, { key: 'grass', label: 'Grass' },
+      { key: 'earth', label: 'Earth' }, { key: 'paved', label: 'Paved' }
+    ];
+    setTimeout(function() {
+      var p = (typeof A._loadGroundConfig === 'function') ? A._loadGroundConfig() : Promise.resolve(null);
+      p.then(function(cfg) { _buildGroundButtons((cfg && cfg.options) || _GROUND_FALLBACK); })
+       .catch(function() { _buildGroundButtons(_GROUND_FALLBACK); });
+    }, 0);
 
     // Draggable + pointer isolation
     if (A._makeDraggable) A._makeDraggable(existing);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v544';
+const CACHE_VERSION = 'v545';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2426,6 +2426,11 @@
     var structuralElements = elements.filter(function(el) { return el.seq <= 4; });
     var nonStructuralElements = elements.filter(function(el) { return el.seq > 4; });
 
+    // §S280h: wrap both build passes in ONE transaction + prepared statement (mirrors the
+    // cache-hit path ~:3128). 39,853 un-transactioned db.run INSERTs were the multi-second
+    // TM-on freeze. Behaviour-identical — same rows, just batched.
+    db.run('BEGIN');
+    var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
     // Pass 1: Schedule all structural
     structuralElements.forEach(function(el) {
       var rcKey = el.resource + '|' + el.band;
@@ -2446,13 +2451,10 @@
       var durMs = Math.round(el.installSecs * scaleFactor * 1000);
       var endMs = earliest + durMs;
 
-      db.run(
-        'INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)',
-        [earliest, 'ELEMENT_PLACE',
+      _gStmt.run([earliest, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
            resource:el.resource, _end_ts:endMs}),
-         JSON.stringify([el.guid]), el.guid]
-      );
+         JSON.stringify([el.guid]), el.guid]);
       count++;
 
       resourceCursor[rcKey] = endMs;
@@ -2502,19 +2504,20 @@
       var durMs = Math.round(el.installSecs * scaleFactor * 1000);
       var endMs = earliest + durMs;
 
-      db.run(
-        'INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)',
-        [earliest, 'ELEMENT_PLACE',
+      _gStmt.run([earliest, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
            resource:el.resource, _end_ts:endMs}),
-         JSON.stringify([el.guid]), el.guid]
-      );
+         JSON.stringify([el.guid]), el.guid]);
       count++;
 
       resourceCursor[rcKey] = endMs;
       var seqKey = el.band + '|' + el.seq;
       if (!bandSeqDone[seqKey] || endMs > bandSeqDone[seqKey]) bandSeqDone[seqKey] = endMs;
     });
+
+    // §S280h: close the single transaction (all ELEMENT_PLACE rows committed together)
+    _gStmt.free();
+    db.run('COMMIT');
 
     // §S260c BUG5: Log first 20 ops to verify bottom-up storey ordering
     var _first20 = [];

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -773,7 +773,7 @@
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=52" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=7" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
-<script src="panels.js?v=32" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
+<script src="panels.js?v=33" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=28" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=24" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=4" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
@@ -832,7 +832,7 @@
 <script src="wizard_storeys.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_storeys.js')"></script>
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=2" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
-<script src="time_machine.js?v=48" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=49" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="main.js?v=35"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->


### PR DESCRIPTION
Two issues the user hit live on `v544`.

## 1. Time Machine ON froze for seconds (Hospital, 39,853 elements)
`injectGantt()` wrote every kernel_op as a **separate auto-committed `db.run()` INSERT** — no transaction, no prepared statement — for ~40k rows on the main thread. The adjacent **cache-hit** path (`time_machine.js:3128`) already batches correctly with `BEGIN`/`db.prepare()`/`COMMIT`. Applied that same pattern to both build passes.
- Behaviour-identical: same rows, same values.
- **Witness `§TM_TXN_PROOF`** (sql.js, 20k rows): `819ms → 46ms = 17.8×`, identical row count + timestamp sum. The Hospital freeze (~1.6s) collapses to <~100ms.
- Real-browser TM coverage: e2e `22-4d-audit.spec.js`.

## 2. Ground texture row: label but no buttons
`main.js` runs `setupPanels` **before** `setupTools`, so `A._loadGroundConfig` was undefined when the panel built → 0 options. Now population is deferred one tick (tools.js ready) with a built-in fallback option list. `§GROUND_ROW built opts=4` on load.

## Versions
`sw v544→v545`, `panels.js?v=32→33`, `time_machine.js?v=48→49`. Gates: syntax OK, sw-precache 102/0, script-tags 74/0, ground+recolor tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)