### PR TITLE
feat(settings): read-only 4D Schedule showcase (captured provider + recursive view)

### DIFF
--- a/tests/test_recursive_render.js
+++ b/tests/test_recursive_render.js
@@ -1,0 +1,82 @@
+/**
+ * test_recursive_render.js — proves the editor's RECURSIVE view handler: a row carrying a
+ * `children[]` array renders as a collapsed bar that expands to its child rows, to any depth.
+ *
+ * Issue proved: collapsed schedule bars (e.g. Level 3 → [Level 3 TOS, Level 3 Ceiling]) are
+ * rendered without flattening; child fields are present (and readonly when opts.readonly).
+ * Backward-compat: a flat schema (no children) is unaffected (covered by test_settings_editor_dom).
+ *
+ * Run: node tests/test_recursive_render.js   (exit 0 = pass). Same DOM shim, no jsdom.
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeEl(tag) {
+  return {
+    tagName: (tag || 'div').toUpperCase(),
+    style: { cssText: '' }, children: [], _listeners: {}, _text: '', _html: '',
+    get textContent() { return this._text; }, set textContent(v) { this._text = v; },
+    get innerHTML() { return this._html; }, set innerHTML(v) { this._html = v; if (v === '') this.children = []; },
+    appendChild(c) { this.children.push(c); return c; },
+    setAttribute() {}, getAttribute() { return null; },
+    addEventListener(ev, fn) { (this._listeners[ev] = this._listeners[ev] || []).push(fn); },
+    setPointerCapture() {}, getBoundingClientRect() { return { top: 0, height: 10 }; },
+    querySelectorAll() { return []; }
+  };
+}
+const documentShim = { createElement: makeEl };
+const store = {};
+const localStorageShim = { getItem(k){return store.hasOwnProperty(k)?store[k]:null;}, setItem(k,v){store[k]=String(v);}, removeItem(k){delete store[k];} };
+
+const src = fs.readFileSync(path.resolve(__dirname, '..', 'viewer', 'settings_editor.js'), 'utf8');
+const logs = [];
+const sandbox = { window: {}, document: documentShim, localStorage: localStorageShim, console: { log:(m)=>logs.push(m), warn:()=>{} } };
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox);
+const SettingsEditor = sandbox.window.SettingsEditor;
+
+let pass = 0, fail = 0;
+function check(name, cond, extra) { if (cond) { pass++; console.log('  PASS ' + name); } else { fail++; console.log('  FAIL ' + name + (extra?' :: '+extra:'')); } }
+function deepFindText(el, txt) {
+  if (el._text === txt) return el;
+  for (const c of (el.children || [])) { const r = deepFindText(c, txt); if (r) return r; }
+  return null;
+}
+function anyListener(el, ev) {
+  if (el._listeners && el._listeners[ev] && el._listeners[ev].length) return true;
+  return (el.children || []).some(c => anyListener(c, ev));
+}
+
+// nested schema: a collapsed Level bar whose children are sub-storeys (recursive WBS)
+const schema = [
+  { section: 'Phases', rows: [
+    { id: 'l3', label: 'Level 3', fields: [
+        { key: 'start', type: 'text', value: '2026-08-09' },
+        { key: 'weeks', type: 'number', value: 4 } ],
+      children: [
+        { id: 'l3tos', label: 'Level 3 TOS', fields: [{ key: 'weeks', type: 'number', value: 3 }],
+          children: [
+            { id: 'l3tos-task', label: 'Steel erection', fields: [{ key: 'elements', type: 'number', value: 464 }] }
+          ] },
+        { id: 'l3ceil', label: 'Level 3 Ceiling', fields: [{ key: 'weeks', type: 'number', value: 6 }] }
+      ] }
+  ]}
+];
+
+const container = makeEl('div');
+SettingsEditor({ container: container, storageKey: 'json_schedule', schema: schema, readonly: true, persist: false });
+
+const ro = logs.find(l => l.indexOf('§PROPSHEET_READONLY') === 0);
+check('§PROPSHEET_READONLY fired', !!ro, ro);
+// 2 (Level 3) + 1 (TOS) + 1 (TOS task) + 1 (Ceiling) = 5 fields across the whole tree
+check('readonly marked ALL nested fields (5, recursion reached depth 2)', !!ro && /fields=5 /.test(ro), ro);
+
+check('parent bar "Level 3" rendered', !!deepFindText(container, 'Level 3'));
+check('child bar "Level 3 TOS" rendered (depth 1)', !!deepFindText(container, 'Level 3 TOS'));
+check('grandchild "Steel erection" rendered (depth 2)', !!deepFindText(container, 'Steel erection'));
+check('collapsed bars are tappable (pointerup wired for expand)', anyListener(container, 'pointerup'));
+check('readonly: no editable input wired (no change listener even on nested numbers)', !anyListener(container, 'change'));
+
+console.log('§RECURSE_SUMMARY ' + pass + ' pass, ' + fail + ' fail');
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test_schedule_projector.js
+++ b/tests/test_schedule_projector.js
@@ -1,0 +1,135 @@
+// ⚠ DO NOT REMOVE — Scope: prove the CAPTURED provider (this session owns it) emits the
+// schedule_instance contract shape from Hospital's native IFC IfcWorkSchedule, verbatim.
+// Contract: internal/schedule_instance.template.json. Read the §-log after every run.
+//
+// Issue proved: Settings opens a per-building 4D instance COMPILED from captured IFC tasks
+// (NOT kernel_ops, NOT fabricated), collapsed to ~8 Z-ordered phases per the contract taxonomy
+// (Site Works, Substructure, Level N — Ceiling/TOS collapse into their Level), each phase span =
+// its own structural span (min start→max finish of its tasks), source='captured', elements=count.
+//
+// Run: node tests/test_schedule_projector.js "/home/red1/Downloads/Hospital 2.0_meta.db"
+
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+
+// ── projectCaptured(db): the SAME logic panels.js _projectSchedule runs in-browser ──
+// db = a sql.js Database (has .exec). Returns the schedule_instance JSON (captured provider).
+function projectCaptured(db) {
+  function rows(sql) {
+    var r; try { r = db.exec(sql); } catch (e) { return []; }
+    if (!r.length) return [];
+    var cols = r[0].columns, out = [];
+    r[0].values.forEach(function (v) { var o = {}; cols.forEach(function (c, i) { o[c] = v[i]; }); out.push(o); });
+    return out;
+  }
+  function meta(k, d) { var r = rows("SELECT value FROM project_metadata WHERE key='" + k + "'"); return r.length ? r[0].value : d; }
+  function day(iso) { return (iso || '').slice(0, 10); }
+  function weeksBetween(s, e) {                       // structural span → whole weeks, >=1
+    var ms = Date.parse(e) - Date.parse(s);
+    return Math.max(1, Math.round(ms / (7 * 86400000)));
+  }
+  function collapseLevel(name) {                      // "Level 3 Ceiling"/"Level 3 TOS" → "Level 3"
+    var m = /^(Level\s*\S+?)(?:\s+(?:Ceiling|TOS|Top of Steel))?$/i.exec(name || '');
+    return m ? m[1] : name;
+  }
+
+  var tasks = rows("SELECT task_id,wbs_parent,name,is_summary,schedule_start,schedule_finish FROM tasks");
+  if (!tasks.length) return null;                     // no native 4D → caller shows fallback note
+  var byId = {}; tasks.forEach(function (t) { byId[t.task_id] = t; });
+
+  // phase = the WBS ancestor that is a "Level N" node; else the root name (Site Works / Structures→Substructure)
+  function phaseOf(t) {
+    var cur = t, levelName = null, rootName = null, guard = 0;
+    while (cur && guard++ < 64) {
+      if (/^Level\b/i.test(cur.name)) levelName = collapseLevel(cur.name);
+      rootName = cur.name;
+      if (!cur.wbs_parent || !byId[cur.wbs_parent]) break;
+      cur = byId[cur.wbs_parent];
+    }
+    if (levelName) return levelName;
+    if (/site/i.test(rootName)) return 'Site Works';
+    if (/structure/i.test(rootName)) return 'Substructure';   // Structures-root direct children = foundations
+    return rootName || 'Other';
+  }
+
+  var teCount = {};
+  rows("SELECT task_id, COUNT(*) n FROM task_elements GROUP BY task_id").forEach(function (r) { teCount[r.task_id] = r.n; });
+
+  // aggregate dated leaf tasks into phases
+  var ph = {};                                        // phaseName → {start,finish,elements}
+  tasks.forEach(function (t) {
+    if (t.is_summary) return;
+    if (!t.schedule_start || !t.schedule_finish) return;
+    var name = phaseOf(t);
+    var p = ph[name] || (ph[name] = { phase: name, start: t.schedule_start, finish: t.schedule_finish, elements: 0 });
+    if (t.schedule_start < p.start) p.start = t.schedule_start;
+    if (t.schedule_finish > p.finish) p.finish = t.schedule_finish;
+    p.elements += (teCount[t.task_id] || 0);
+  });
+
+  // order bottom-up (captured builds chronologically = Z-order); assign stable ids
+  var ordered = Object.keys(ph).map(function (k) { return ph[k]; })
+    .sort(function (a, b) { return a.start < b.start ? -1 : a.start > b.start ? 1 : 0; });
+
+  var phases = ordered.map(function (p, i) {
+    return {
+      id: 'p' + i,
+      phase: p.phase,
+      start: day(p.start),
+      weeks: weeksBetween(p.start, p.finish),
+      elements: p.elements,
+      source: 'captured'
+    };
+  });
+
+  var minStart = ordered.length ? day(ordered[0].start) : '';
+  var cal = rows("SELECT name FROM calendars LIMIT 1")[0] || {};
+  var out = {
+    Project: {
+      building: meta('building_name', meta('project_name', '?')),
+      start: minStart,
+      calendar: cal.name || '',
+      source: 'captured'
+    },
+    Phases: phases
+  };
+
+  var totalEl = phases.reduce(function (s, p) { return s + p.elements; }, 0);
+  console.log('§SCHEDULE_INSTANCE building=' + out.Project.building + ' provider=captured phases=' +
+    phases.length + ' captured=' + totalEl + ' generated=0 start=' + out.Project.start);
+  return out;
+}
+
+(async function () {
+  var dbPath = process.argv[2] || '/home/red1/Downloads/Hospital 2.0_meta.db';
+  var sqljsDir = path.dirname(require.resolve('sql.js'));
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(sqljsDir, f); } });
+  var db = new SQL.Database(fs.readFileSync(dbPath));
+  var json = projectCaptured(db);
+  if (!json) { console.error('FAIL: no native 4D tables'); process.exit(1); }
+
+  var fail = 0;
+  function ok(cond, msg) { console.log((cond ? 'PASS' : 'FAIL') + ': ' + msg); if (!cond) fail++; }
+
+  // contract conformance — each assertion names the issue it proves
+  ok(json.Project && typeof json.Project.building === 'string', 'Project block present with building (contract §Project)');
+  ok(json.Project.source === 'captured', "Project.source='captured' — this provider extracts IFC verbatim");
+  ok(Array.isArray(json.Phases) && json.Phases.length >= 6 && json.Phases.length <= 10,
+    '~8 collapsed phases (got ' + json.Phases.length + ') — Ceiling/TOS folded into Level (contract §phase_taxonomy)');
+  ok(json.Phases.every(function (p) { return ['id', 'phase', 'start', 'weeks', 'elements', 'source'].every(function (k) { return k in p; }); }),
+    'every phase has exactly the contract fields');
+  ok(json.Phases.every(function (p) { return p.source === 'captured'; }), 'every phase source=captured');
+  ok(json.Phases.every(function (p) { return p.weeks >= 1 && Number.isInteger(p.weeks); }), 'weeks is integer >=1 (structural span)');
+  ok(!json.Phases.some(function (p) { return /Ceiling|TOS|Unknown/i.test(p.phase); }), 'no Ceiling/TOS/Unknown phase names leaked (collapse worked)');
+  var totalEl = json.Phases.reduce(function (s, p) { return s + p.elements; }, 0);
+  ok(totalEl === 2900, 'captured element coverage = 2900 (got ' + totalEl + ') — matches injectGantt absorb');
+  ok(json.Phases.some(function (p) { return p.phase === 'Site Works'; }), "Site Works phase present");
+  ok(json.Phases.some(function (p) { return p.phase === 'Substructure'; }), "Substructure phase present (Structures-root foundations)");
+
+  console.log('--- contract instance (captured provider) ---');
+  console.log(JSON.stringify(json, null, 2));
+
+  db.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/tests/test_schedule_readonly.js
+++ b/tests/test_schedule_readonly.js
@@ -1,0 +1,86 @@
+/**
+ * test_schedule_readonly.js — proves the Phase-1 schedule showcase opens READ-ONLY.
+ *
+ * Issue proved (SETTINGS_JSON_EDITOR.md §Whole-file read-only): a registry entry with
+ * readonly:true opens the schedule_instance contract JSON with EVERY field display-only
+ * and no write path. Witnesses:
+ *   §PROPSHEET_READONLY id=json_schedule fields=N writable=0   (no editable controls)
+ *   §PROPSHEET_RENDER sections=2 rows=M                         (Project + Phases render)
+ * and asserts no 'change'-wired input and no toggle button exist (pure spans).
+ *
+ * Run: node tests/test_schedule_readonly.js   (exit 0 = pass). Uses the same DOM shim
+ * as test_settings_editor_dom.js — no jsdom.
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeEl(tag) {
+  return {
+    tagName: (tag || 'div').toUpperCase(),
+    style: { cssText: '' }, children: [], _listeners: {}, _text: '', _html: '',
+    get textContent() { return this._text; }, set textContent(v) { this._text = v; },
+    get innerHTML() { return this._html; }, set innerHTML(v) { this._html = v; if (v === '') this.children = []; },
+    appendChild(c) { this.children.push(c); return c; },
+    setAttribute() {}, getAttribute() { return null; },
+    addEventListener(ev, fn) { (this._listeners[ev] = this._listeners[ev] || []).push(fn); },
+    setPointerCapture() {}, getBoundingClientRect() { return { top: 0, height: 10 }; },
+    querySelectorAll() { return []; }
+  };
+}
+const documentShim = { createElement: makeEl };
+const store = {};
+const localStorageShim = {
+  getItem(k) { return store.hasOwnProperty(k) ? store[k] : null; },
+  setItem(k, v) { store[k] = String(v); }, removeItem(k) { delete store[k]; }
+};
+
+const src = fs.readFileSync(path.resolve(__dirname, '..', 'viewer', 'settings_editor.js'), 'utf8');
+const logs = [];
+const sandbox = { window: {}, document: documentShim, localStorage: localStorageShim,
+  console: { log: (m) => { logs.push(m); }, warn: () => {} } };
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox);
+const SettingsEditor = sandbox.window.SettingsEditor;
+
+let pass = 0, fail = 0;
+function check(name, cond, extra) {
+  if (cond) { pass++; console.log('  PASS ' + name); }
+  else { fail++; console.log('  FAIL ' + name + (extra ? ' :: ' + extra : '')); }
+}
+function find(el, ev, tag) {
+  if (el._listeners && el._listeners[ev] && el._listeners[ev].length && (!tag || el.tagName === tag)) return el;
+  for (const c of (el.children || [])) { const r = find(c, ev, tag); if (r) return r; }
+  return null;
+}
+
+// schedule_instance contract JSON — captured provider (mirrors panels.js _projectSchedule output)
+const instance = {
+  Project: { building: 'Hospital 2.0', start: '2026-05-11', calendar: '9 - 5', source: 'captured' },
+  Phases: [
+    { id: 'p0', phase: 'Site Works',   start: '2026-05-11', weeks: 1, elements: 1,   source: 'captured' },
+    { id: 'p1', phase: 'Substructure', start: '2026-05-16', weeks: 3, elements: 607, source: 'captured' },
+    { id: 'p2', phase: 'Level 1',      start: '2026-06-10', weeks: 4, elements: 562, source: 'captured' },
+    { id: 'p3', phase: 'Level 2',      start: '2026-07-10', weeks: 4, elements: 418, source: 'captured' }
+  ]
+};
+
+const schema = SettingsEditor.jsonToSchema(instance, {});
+const container = makeEl('div');
+SettingsEditor({ container: container, storageKey: 'json_schedule', schema: schema,
+  readonly: true, persist: false, onChange: function () {} });
+
+const roLog = logs.find(l => l.indexOf('§PROPSHEET_READONLY') === 0);
+check('§PROPSHEET_READONLY fired', !!roLog, roLog);
+check('writable=0 (no write path)', !!roLog && /writable=0$/.test(roLog), roLog);
+
+const renderLog = logs.find(l => l.indexOf('§PROPSHEET_RENDER') === 0);
+check('§PROPSHEET_RENDER fired', !!renderLog, renderLog);
+check('2 sections render (Project + Phases)', !!renderLog && /sections=2 /.test(renderLog), renderLog);
+
+// read-only proof: no input wired with 'change' and no toggle BUTTON anywhere
+check('no editable text/number/choice control (no change listener)', !find(container, 'change'), 'found a change-wired input');
+check('no toggle button (would be editable)', !find(container, 'pointerup', 'BUTTON'), 'found a toggle button');
+
+console.log('§SCHEDULE_RO_SUMMARY ' + pass + ' pass, ' + fail + ' fail');
+process.exit(fail > 0 ? 1 : 0);

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1191,15 +1191,87 @@ function setupPanels(A) {
       });
     }
 
+    // \u00A7SETTINGS_JSON: CAPTURED provider \u2014 project the active building's native IFC
+    // IfcWorkSchedule (tasks/task_elements tables in A.db) into the schedule_instance
+    // contract shape (internal/schedule_instance.template.json): Project + Phases[].
+    // Phases collapse Ceiling/TOS into their Level; each span = its own structural span
+    // (min start\u2192max finish of its tasks). source='captured' (IFC verbatim). The generated
+    // provider (rules session) emits the SAME shape for elements IFC has no 4D for.
+    // Returns null when the building carries no native 4D \u2192 caller shows a fallback note.
+    function _projectSchedule() {
+      var db = A.db;
+      if (!db) return null;
+      function rows(sql) {
+        var r; try { r = db.exec(sql); } catch (e) { return []; }
+        if (!r.length) return [];
+        var cols = r[0].columns, out = [];
+        r[0].values.forEach(function(v) { var o = {}; cols.forEach(function(c, i) { o[c] = v[i]; }); out.push(o); });
+        return out;
+      }
+      function meta(k, d) { var r = rows("SELECT value FROM project_metadata WHERE key='" + k + "'"); return r.length ? r[0].value : d; }
+      function day(iso) { return (iso || '').slice(0, 10); }
+      function weeksBetween(s, e) { return Math.max(1, Math.round((Date.parse(e) - Date.parse(s)) / (7 * 86400000))); }
+      function collapseLevel(name) { var m = /^(Level\s*\S+?)(?:\s+(?:Ceiling|TOS|Top of Steel))?$/i.exec(name || ''); return m ? m[1] : name; }
+
+      var tasks = rows("SELECT task_id,wbs_parent,name,is_summary,schedule_start,schedule_finish FROM tasks");
+      if (!tasks.length) return null;
+      var byId = {}; tasks.forEach(function(t) { byId[t.task_id] = t; });
+      function phaseOf(t) {
+        var cur = t, levelName = null, rootName = null, guard = 0;
+        while (cur && guard++ < 64) {
+          if (/^Level\b/i.test(cur.name)) levelName = collapseLevel(cur.name);
+          rootName = cur.name;
+          if (!cur.wbs_parent || !byId[cur.wbs_parent]) break;
+          cur = byId[cur.wbs_parent];
+        }
+        if (levelName) return levelName;
+        if (/site/i.test(rootName)) return 'Site Works';
+        if (/structure/i.test(rootName)) return 'Substructure';
+        return rootName || 'Other';
+      }
+      var teCount = {};
+      rows("SELECT task_id, COUNT(*) n FROM task_elements GROUP BY task_id").forEach(function(r) { teCount[r.task_id] = r.n; });
+
+      var ph = {};
+      tasks.forEach(function(t) {
+        if (t.is_summary || !t.schedule_start || !t.schedule_finish) return;
+        var name = phaseOf(t);
+        var p = ph[name] || (ph[name] = { phase: name, start: t.schedule_start, finish: t.schedule_finish, elements: 0 });
+        if (t.schedule_start < p.start) p.start = t.schedule_start;
+        if (t.schedule_finish > p.finish) p.finish = t.schedule_finish;
+        p.elements += (teCount[t.task_id] || 0);
+      });
+      var ordered = Object.keys(ph).map(function(k) { return ph[k]; })
+        .sort(function(a, b) { return a.start < b.start ? -1 : a.start > b.start ? 1 : 0; });
+      if (!ordered.length) return null;
+      var phases = ordered.map(function(p, i) {
+        return { id: 'p' + i, phase: p.phase, start: day(p.start), weeks: weeksBetween(p.start, p.finish), elements: p.elements, source: 'captured' };
+      });
+      var cal = rows("SELECT name FROM calendars LIMIT 1")[0] || {};
+      var out = {
+        Project: { building: meta('building_name', meta('project_name', '?')), start: day(ordered[0].start), calendar: cal.name || '', source: 'captured' },
+        Phases: phases
+      };
+      var totalEl = phases.reduce(function(s, p) { return s + p.elements; }, 0);
+      console.log('\u00A7SCHEDULE_INSTANCE building=' + out.Project.building + ' provider=captured phases=' +
+        phases.length + ' captured=' + totalEl + ' generated=0 start=' + out.Project.start);
+      return out;
+    }
+
     // \u00A7S282c: registry of project JSONs editable from Settings (pure data).
     // overrides refine auto-inferred field types per file. manifest.json is
     // EXCLUDED (254KB machine-generated AD compile \u2014 not hand-editable).
+    // schedule = source:'db' READ-ONLY (Phase 1): projects the captured 4D for viewing.
     var _jsonRegistry = [
       { id: 'corporate',   label: 'Corporate / Branding', url: 'corporate.json',   storageKey: 'json_corporate' },
       { id: 'grid_rules',  label: 'Grid Rules',           url: 'grid_rules.json',  storageKey: 'json_grid_rules' },
       { id: 'clash_rules', label: 'Clash Rules',          url: 'clash_rules.json', storageKey: 'json_clash_rules' },
       { id: 'initbubble',  label: 'ERP Globe Bubbles',    url: 'initbubble.json',  storageKey: 'json_initbubble',
-        overrides: { color: { type: 'color' } } }
+        overrides: { color: { type: 'color' } } },
+      { id: 'schedule',    label: '4D Schedule (this building)', source: 'db', storageKey: 'json_schedule',
+        readonly: true, project: _projectSchedule,
+        // compact read-only view: phase name as row label + one "start · Nwk · elements" line
+        overrides: { __labelKey: 'phase', __summary: ['start', 'weeks', 'elements'] } }
     ];
 
     // Build the "Edit project JSON" hub: a picker that opens any registered file
@@ -1230,49 +1302,73 @@ function setupPanels(A) {
     }
 
     // Open one registered JSON in a SettingsEditor sub-panel.
+    // source:'url' (default) -> fetch + localStorage override (editable).
+    // source:'db'           -> entry.project() returns the JSON (e.g. captured 4D).
+    // readonly:true         -> whole-file viewer: no Download / no Reset, fields display-only.
     function _openJsonEditor(entry) {
       var id = 'json-editor-' + entry.id;
       var existing = document.getElementById(id);
       if (existing) { existing.style.display = ''; return; }
-      if (typeof window.loadJsonWithOverrides !== 'function') return;
 
-      loadJsonWithOverrides(entry.url, entry.storageKey).then(function(raw) {
-        var schema = SettingsEditor.jsonToSchema(raw, entry.overrides || {});
+      // resolve the raw JSON by source (db = projected, url = fetched+override)
+      var rawP;
+      if (entry.source === 'db') {
+        if (typeof entry.project !== 'function') return;
+        try { rawP = Promise.resolve(entry.project()); } catch (e) { rawP = Promise.reject(e); }
+      } else {
+        if (typeof window.loadJsonWithOverrides !== 'function') return;
+        rawP = loadJsonWithOverrides(entry.url, entry.storageKey);
+      }
+
+      rawP.then(function(raw) {
         var content = document.createElement('div');
         content.style.cssText = 'font-size:13px;color:#ccc;';
 
         var hdr = document.createElement('h3');
-        hdr.textContent = entry.label + ' — ' + entry.url;
+        hdr.textContent = entry.label + (entry.url ? ' — ' + entry.url : '');
         hdr.style.cssText = 'margin:0 0 10px;color:#4fc3f7;font-size:14px;';
         content.appendChild(hdr);
 
-        var box = document.createElement('div');
-        content.appendChild(box);
-        var editor = SettingsEditor({
-          container: box, schema: schema, storageKey: entry.storageKey,
-          onChange: function() {}   // editor write-through persists to storageKey
-        });
+        if (raw == null) {                            // building carries no native 4D
+          var note = document.createElement('div');
+          note.textContent = 'No 4D schedule captured for this building. Open Time Machine to generate one, or import an IFC IfcWorkSchedule / MS Project export.';
+          note.style.cssText = 'font-size:12px;color:#999;padding:8px 0;';
+          content.appendChild(note);
+          console.log('§JSON_EDITOR_EMPTY ' + entry.id);
+        } else {
+          var schema = SettingsEditor.jsonToSchema(raw, entry.overrides || {});
+          var box = document.createElement('div');
+          content.appendChild(box);
+          var editor = SettingsEditor({
+            container: box, schema: schema, storageKey: entry.storageKey,
+            readonly: !!entry.readonly,
+            persist: !entry.readonly,                 // read-only view never writes localStorage
+            onChange: function() {}
+          });
 
-        // Download edited JSON (so the user can commit it back to the repo)
-        var dl = document.createElement('button');
-        dl.textContent = '\u2B07 Download ' + entry.url;
-        dl.style.cssText = 'margin:12px 0 0;padding:8px 16px;border:1px solid rgba(108,159,255,0.2);border-radius:8px;background:transparent;color:#6c9fff;font-size:12px;cursor:pointer;width:100%;';
-        dl.addEventListener('pointerup', function(e) {
-          e.stopPropagation();
-          var blob = new Blob([JSON.stringify(editor.getState(), null, 2)], { type: 'application/json' });
-          var a = document.createElement('a');
-          a.href = URL.createObjectURL(blob); a.download = entry.url;
-          a.click(); URL.revokeObjectURL(a.href);
-          console.log('\u00A7JSON_DOWNLOAD ' + entry.url);
-        });
-        content.appendChild(dl);
+          if (!entry.readonly) {
+            // Download edited JSON (so the user can commit it back to the repo)
+            var dl = document.createElement('button');
+            dl.textContent = '⬇ Download ' + entry.url;
+            dl.style.cssText = 'margin:12px 0 0;padding:8px 16px;border:1px solid rgba(108,159,255,0.2);border-radius:8px;background:transparent;color:#6c9fff;font-size:12px;cursor:pointer;width:100%;';
+            dl.addEventListener('pointerup', function(e) {
+              e.stopPropagation();
+              var blob = new Blob([JSON.stringify(editor.getState(), null, 2)], { type: 'application/json' });
+              var a = document.createElement('a');
+              a.href = URL.createObjectURL(blob); a.download = entry.url;
+              a.click(); URL.revokeObjectURL(a.href);
+              console.log('§JSON_DOWNLOAD ' + entry.url);
+            });
+            content.appendChild(dl);
 
-        // Reset this file's overrides
-        var rs = document.createElement('button');
-        rs.textContent = 'Reset ' + entry.label;
-        rs.style.cssText = 'margin:8px 0 0;padding:8px 16px;border:1px solid rgba(255,255,255,0.1);border-radius:8px;background:transparent;color:#999;font-size:12px;cursor:pointer;width:100%;';
-        rs.addEventListener('pointerup', function(e) { e.stopPropagation(); editor.reset(); });
-        content.appendChild(rs);
+            // Reset this file's overrides
+            var rs = document.createElement('button');
+            rs.textContent = 'Reset ' + entry.label;
+            rs.style.cssText = 'margin:8px 0 0;padding:8px 16px;border:1px solid rgba(255,255,255,0.1);border-radius:8px;background:transparent;color:#999;font-size:12px;cursor:pointer;width:100%;';
+            rs.addEventListener('pointerup', function(e) { e.stopPropagation(); editor.reset(); });
+            content.appendChild(rs);
+          }
+        }
 
         var p = A.createPanel(id, { closable: true,
           style: { position:'fixed', top:'80px', right:'80px', zIndex:'1101', width:'320px', padding:'16px' },
@@ -1280,9 +1376,9 @@ function setupPanels(A) {
         document.body.appendChild(p);
         p.style.display = '';   // createPanel returns hidden; reveal this fresh panel
         if (window.InputReg) InputReg.register({ id: 'json-editor', el: p, kind: 'panel', release: function() { p.style.display = 'none'; } });
-        console.log('\u00A7JSON_EDITOR_OPEN ' + entry.id);
+        console.log('§JSON_EDITOR_OPEN ' + entry.id);
       }).catch(function(err) {
-        console.warn('\u00A7JSON_EDITOR_FAIL ' + entry.id + ' ' + err);
+        console.warn('§JSON_EDITOR_FAIL ' + entry.id + ' ' + err);
       });
     }
 

--- a/viewer/settings_editor.js
+++ b/viewer/settings_editor.js
@@ -96,11 +96,33 @@
     return fields;
   }
 
+  // Optional DISPLAY directives (pure data, any JSON may pass them in `overrides`):
+  //   __labelKey : field key whose value becomes the row label (and is hidden as a field)
+  //   __summary  : array of field keys combined into ONE readonly "a · b · c" line
+  //                (the other fields are dropped — a compact, read-only-friendly view)
+  //   __hide     : array of field keys to omit
+  // No __* directive -> behaves exactly as before (every key a field).
+  function fmtSummary(key, val) {
+    if (val == null) return '';
+    if (key === 'weeks') return val + 'wk';
+    return String(val);
+  }
   function arrayToSection(name, arr, overrides) {
+    var labelKey = overrides.__labelKey, summary = overrides.__summary, hide = overrides.__hide || [];
     var rows = arr.map(function(el, i) {
       var id = (el && el.id != null) ? String(el.id) : String(i);
-      var label = (el && (el.label || el.name)) || id;
-      return { id: id, label: label, _index: i, fields: rowToFields(el, overrides, id, '') };
+      var label = (labelKey && el && el[labelKey] != null) ? String(el[labelKey])
+        : ((el && (el.label || el.name)) || id);
+      var fields;
+      if (summary && summary.length) {
+        var parts = summary.map(function(k) { return fmtSummary(k, el[k]); });
+        fields = [{ key: 'summary', type: 'readonly', value: parts.join(' · '), _wide: true }];
+      } else {
+        fields = rowToFields(el, overrides, id, '').filter(function(f) {
+          return f.key !== labelKey && hide.indexOf(f.key) < 0;
+        });
+      }
+      return { id: id, label: label, _index: i, fields: fields };
     });
     return { section: name, reorderable: true, _key: name, _array: true, rows: rows };
   }
@@ -186,6 +208,16 @@
   // Each returns a DOM element and calls commit(newValue) on edit.
   function renderField(field, commit) {
     var t = field.type;
+    // readonly wins over the type branch — a display span, never an editable control.
+    // (Must precede number/toggle/choice/color, which would otherwise return an input.)
+    if (field.readonly || t === 'readonly') {
+      var ro = document.createElement('span');
+      ro.textContent = field._list ? field.value : String(field.value);
+      ro.style.cssText = 'font-size:12px;color:#888;font-family:monospace;max-width:' +
+        (field._wide ? '210px' : '140px') + ';overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+      ro.title = ro.textContent;
+      return ro;
+    }
     if (t === 'toggle') {
       var btn = document.createElement('button');
       var paint = function() {
@@ -234,13 +266,6 @@
       });
       return num;
     }
-    if (t === 'readonly' || field.readonly) {
-      var span = document.createElement('span');
-      span.textContent = field._list ? field.value : String(field.value);
-      span.style.cssText = 'font-size:12px;color:#888;font-family:monospace;max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
-      span.title = span.textContent;
-      return span;
-    }
     // text (default)
     var txt = document.createElement('input');
     txt.type = 'text';
@@ -258,9 +283,25 @@
     var persist = opts.persist !== false;        // default true (write-through)
     var onChange = opts.onChange || function() {};
     var onReset = opts.onReset;
+    var readonly = !!opts.readonly;              // §SETTINGS_JSON: whole-file view — no write path
 
     // Live model = a clone of the input schema; values + order mutate in place.
     var model = clone(input);
+
+    // Read-only mode: force every field display-only, kill reorder, log writable=0.
+    // renderField already renders a span for field.readonly (no input wiring).
+    if (readonly) {
+      var _fields = 0;
+      var markRow = function(r) {                 // recurse into nested children too
+        (r.fields || []).forEach(function(f) { _fields++; f.readonly = true; });
+        (r.children || []).forEach(markRow);
+      };
+      model.forEach(function(sec) {
+        sec.reorderable = false;
+        (sec.rows || []).forEach(markRow);
+      });
+      console.log('§PROPSHEET_READONLY id=' + (storageKey || '?') + ' fields=' + _fields + ' writable=0');
+    }
 
     function getState() { return schemaToJson(model); }
 
@@ -273,10 +314,17 @@
       onChange(rowId, fieldKey, value, full);
     }
 
-    function buildRow(row, reorderable) {
+    // depth = nesting level (0 = top). A row carrying a non-empty `children` array is a
+    // COLLAPSED bar: it renders a chevron and a default-collapsed container of its child
+    // rows, rendered RECURSIVELY (handles arbitrarily deep WBS — Level → sub-storey → task).
+    // Rows with no `children` render exactly as before (backward compatible).
+    function buildRow(row, reorderable, depth) {
+      depth = depth || 0;
+      var hasKids = !!(row.children && row.children.length);
       var el = document.createElement('div');
-      el.style.cssText = 'display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid rgba(255,255,255,0.04);user-select:none;' +
-        (reorderable ? 'cursor:grab;' : '');
+      el.style.cssText = 'display:flex;align-items:center;gap:8px;padding:8px 12px;padding-left:' +
+        (12 + depth * 16) + 'px;border-bottom:1px solid rgba(255,255,255,0.04);user-select:none;' +
+        (reorderable ? 'cursor:grab;' : (hasKids ? 'cursor:pointer;' : ''));
 
       // generic drag-handle affordance for reorderable sections (app-agnostic)
       if (reorderable) {
@@ -284,6 +332,14 @@
         handle.textContent = '≡';
         handle.style.cssText = 'font-size:16px;color:#555;cursor:grab;';
         el.appendChild(handle);
+      }
+      // collapse/expand chevron for a parent (collapsed) bar
+      var chev = null;
+      if (hasKids) {
+        chev = document.createElement('span');
+        chev.textContent = '▶';
+        chev.style.cssText = 'font-size:10px;color:#6c9fff;display:inline-block;transition:transform 200ms;';
+        el.appendChild(chev);
       }
       // optional per-row icon: a pure HTML string (e.g. <img> / <svg>) — any app may pass it
       if (row.icon) {
@@ -309,7 +365,23 @@
         }
         el.appendChild(renderField(field, function(v) { save(row.id, field.key, v); }));
       });
-      return el;
+      if (!hasKids) return el;
+
+      // wrapper = this bar + its default-collapsed children, rendered recursively
+      var wrap = document.createElement('div');
+      wrap.appendChild(el);
+      var kids = document.createElement('div');
+      kids.style.cssText = 'max-height:0;overflow:hidden;transition:max-height 300ms ease;';
+      row.children.forEach(function(child) { kids.appendChild(buildRow(child, false, depth + 1)); });
+      wrap.appendChild(kids);
+      var open = false;
+      el.addEventListener('pointerup', function(e) {
+        e.stopPropagation();
+        open = !open;
+        kids.style.maxHeight = open ? 'none' : '0';
+        if (chev) chev.style.transform = open ? 'rotate(90deg)' : 'rotate(0deg)';
+      });
+      return wrap;
     }
 
     function buildSection(sec) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v548';
+const CACHE_VERSION = 'v549';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v547';
+const CACHE_VERSION = 'v548';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## What
Phase 1 of `SETTINGS_JSON_EDITOR.md`: **Settings → "4D Schedule (this building)"** opens the active building's native IFC `IfcWorkSchedule` as a **read-only** `schedule_instance` (contract: `internal/schedule_instance.template.json`). This session owns the **captured** provider; the rules/gantt-support-gate session owns the **generated** provider — both emit the same shape.

Hospital 2.0 (real `_meta.db`): **captured = 2900 elements, 10 Z-ordered phases** (Site Works → Substructure → Level 1…7).

## How
**`panels.js`**
- `_projectSchedule()` reads `tasks`/`task_elements`/`calendars` from `A.db` → `Project{building,start,calendar,source:'captured'}` + `Phases[]`. Ceiling/TOS collapse into their Level; each span = its own structural span; `elements` = count (never a GUID list). Logs `§SCHEDULE_INSTANCE`.
- registry entry `{ id:'schedule', source:'db', readonly:true, project:_projectSchedule, overrides:{__labelKey:'phase', __summary:['start','weeks','elements']} }`.
- `_openJsonEditor`: `source:'db'` branch (project() vs fetch) + `readonly` branch (no Download/Reset, no persist) + honest "no 4D captured" fallback (never fabricates).

**`settings_editor.js`** (stays app-agnostic — grep test 21/21)
- `opts.readonly`: whole-file viewer; `§PROPSHEET_READONLY … writable=0`. Moved the readonly check to the top of `renderField` (fixes numeric fields staying editable).
- **recursive view handler**: a row with `children[]` renders a collapsed bar that expands to child rows, to any depth (ready for nested WBS); rows without children unchanged.
- `jsonToSchema` display directives (pure data): `__labelKey`, `__summary`, `__hide`.

## Witnesses (read the §-log)
- `test_schedule_projector` 10/10 on real `Hospital 2.0_meta.db` (`captured=2900`)
- `test_schedule_readonly` 6/6 (`writable=0`, zero editable controls)
- `test_recursive_render` 7/7 (depth-2 nesting)
- No regression: `test_json_to_schema` 21/21, `test_settings_editor_dom` 6/6, `test_override_roundtrip` 7/7
- All CI fast-checks green locally. `sw CACHE_VERSION v547→v548`.

## Notes
- Recursion is renderer-ready but **dormant**: driving it from JSON needs an optional `children[]` in the contract + a `jsonToSchema` mapping (held — contract is flat + jointly owned).
- Touches `panels.js` — coordinate merge order with the gantt-support-gate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)