### PR TITLE
fix(TM): XY-aware support gate + captured yellow-frame + pointer tooltip

### DIFF
--- a/tests/test_schedule_gate.js
+++ b/tests/test_schedule_gate.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
-/* ⚠ WITNESS — proves/disproves: "the GENERATED 4D fallback floats beams above unfinished columns."
- * Loads the REAL deployed scheduler (../schedule_gate.js) and runs it on REAL Hospital geometry.
- * Names the issue: counts floating beams under the OLD center-Z band gate vs the NEW support gate.
- * PASS iff NEW floatingBeams === 0. Read the §-log lines, not the exit code alone.
+/* ⚠ WITNESS — proves/disproves: "the GENERATED 4D fallback floats beams/members/slabs above the
+ * structure ACTUALLY under their XY footprint." Loads the REAL deployed scheduler
+ * (../viewer/schedule_gate.js) and runs it on REAL Hospital geometry. Names the issue: counts
+ * XY-floating structure under the OLD center-Z band gate vs the NEW XY-aware support gate.
+ * PASS iff NEW floating === 0 for beams, members AND slabs. Read the §-log lines, not exit code alone.
  *
  * DB: set SCHEDULE_TEST_DB, else defaults to the bim-compiler Hospital extract. SKIPs (exit 0) if absent.
  */
 const { execSync } = require('child_process');
 const fs = require('fs');
-const ScheduleGate = require("../viewer/schedule_gate.js");   // the REAL deployed module under test
+const ScheduleGate = require('../viewer/schedule_gate.js');   // the REAL deployed module under test
 
 const DB = process.env.SCHEDULE_TEST_DB || '/home/red1/bim-compiler/deploy/buildings/Hospital_extracted.db';
 if (!fs.existsSync(DB)) { console.log('§SUPPORT_CHECK SKIP — no test DB at ' + DB); process.exit(0); }
 
-// faithful rules mirror of rates.js SEQUENCE_RULES + LABOR_RATES productivity (seq<=4 = structure)
 const RULES = { IfcFooting:{seq:1,prod:6}, IfcPile:{seq:1,prod:4}, IfcReinforcingBar:{seq:1,prod:50},
   IfcColumn:{seq:2,prod:6}, IfcBeam:{seq:3,prod:8}, IfcMember:{seq:3,prod:10}, IfcSlab:{seq:4,prod:35},
   IfcPlate:{seq:4,prod:12}, IfcDuct:{seq:5,prod:18}, IfcPipe:{seq:5,prod:25}, IfcCableCarrier:{seq:5,prod:30},
@@ -22,35 +22,37 @@ const DEF = { seq:6, prod:10 };
 const matchRule = c => { let b=null,l=0; for (const k in RULES) if (c.indexOf(k)>=0 && k.length>l){b=k;l=k.length;} return b?RULES[b]:DEF; };
 
 const csv = execSync(
-  `sqlite3 -noheader -csv "${DB}" "SELECT m.guid,m.ifc_class,COALESCE(t.center_z,0),COALESCE(t.bbox_z,0) ` +
+  `sqlite3 -noheader -csv "${DB}" "SELECT m.guid,m.ifc_class,COALESCE(t.center_x,0),COALESCE(t.center_y,0),` +
+  `COALESCE(t.center_z,0),COALESCE(t.bbox_x,0),COALESCE(t.bbox_y,0),COALESCE(t.bbox_z,0) ` +
   `FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class!='IfcOpeningElement';"`,
   { maxBuffer: 1 << 28 }).toString().trim().split('\n');
 const elements = csv.map(line => {
-  const m = line.match(/^([^,]+),([^,]+),([^,]+),([^,]+)$/); if (!m) return null;
-  const cls = m[2], cz = parseFloat(m[3])||0, bz = parseFloat(m[4])||0, r = matchRule(cls);
-  return { guid:m[1], cls, base_z:cz-bz/2, top_z:cz+bz/2, cz, seq:r.seq, resource:cls,
-           installSecs: r.prod>0?Math.round(28800/r.prod):120 };
+  const a = line.split(','); if (a.length < 8) return null;
+  const cls=a[1], cx=+a[2], cy=+a[3], cz=+a[4], bx=+a[5], by=+a[6], bz=+a[7], r=matchRule(cls);
+  return { guid:a[0], cls, seq:r.seq, resource:cls, installSecs: r.prod>0?Math.round(28800/r.prod):120,
+           x0:cx-bx/2, x1:cx+bx/2, y0:cy-by/2, y1:cy+by/2, base_z:cz-bz/2, top_z:cz+bz/2 };
 }).filter(Boolean);
-const beamN = elements.filter(e=>e.cls==='IfcBeam').length;
-console.log(`§WITNESS_LOAD elements=${elements.length} beams=${beamN} cols=${elements.filter(e=>e.cls==='IfcColumn').length}`);
+const n = c => elements.filter(e=>e.cls===c).length;
+console.log(`§WITNESS_LOAD elements=${elements.length} beams=${n('IfcBeam')} members=${n('IfcMember')} slabs=${n('IfcSlab')}`);
 
 // OLD gate (center-Z band, "band N waits N-1") — inline, names the issue
 function schedOld(els){
-  const E=els.map(e=>({...e,band:Math.floor(e.cz/3)})).sort((a,b)=>(Math.floor(a.cz/3)-Math.floor(b.cz/3))||(a.seq-b.seq)||(a.cz-b.cz));
+  const E=els.map(e=>({...e,band:Math.floor(((e.base_z+e.top_z)/2)/3)})).sort((a,b)=>(a.band-b.band)||(a.seq-b.seq)||(a.base_z-b.base_z));
   const rc={},bsd={},bd={};
   const run=el=>{const rk=el.seq+'|'+el.band;let e=rc[rk]||0;for(let p=1;p<el.seq;p++){const k=el.band+'|'+p;if(bsd[k]>e)e=bsd[k];}if(el.band>0&&bd[el.band-1]>e)e=bd[el.band-1];const end=e+el.installSecs*1000;el.start=e;el.end=end;rc[rk]=end;const sk=el.band+'|'+el.seq;if(!(bsd[sk]>end))bsd[sk]=end;if(!(bd[el.band]>end))bd[el.band]=end;};
   E.filter(e=>e.seq<=4).forEach(run);E.filter(e=>e.seq>4).forEach(run);
   const out={};E.forEach(e=>out[e.guid]={start:e.start,end:e.end});return out;
 }
 
+const CL = ['IfcBeam','IfcMember','IfcSlab'];
+const flt = (sched, cls) => ScheduleGate.auditFloating(elements, sched, e=>e.cls===cls);
 const oldSched = schedOld(elements);
-const oldFloat = ScheduleGate.auditFloating(elements, oldSched, e=>e.cls==='IfcBeam');
-const newSched = ScheduleGate.computeSchedule(elements, 0, 1);            // the REAL deployed gate
-const newFloat = ScheduleGate.auditFloating(elements, newSched, e=>e.cls==='IfcBeam');
+const newSched = ScheduleGate.computeSchedule(elements, 0, 1);   // the REAL deployed XY-aware gate
 
-console.log(`§SUPPORT_CHECK OLD(center-band) floatingBeams=${oldFloat}/${beamN}`);
-console.log(`§SUPPORT_CHECK NEW(support-gate) floatingBeams=${newFloat}/${beamN}  (0 = Z solved)`);
+let oldTot = 0, newTot = 0;
+CL.forEach(cl => { const o=flt(oldSched,cl), x=flt(newSched,cl); oldTot+=o; newTot+=x;
+  console.log(`§SUPPORT_CHECK ${cl.padEnd(10)} OLD(center-band)=${o}/${n(cl)}  NEW(XY-gate)=${x}/${n(cl)}`); });
 
-if (newFloat !== 0) { console.error(`FAIL — support gate still floats ${newFloat} beams`); process.exit(1); }
-if (oldFloat === 0) { console.error('INCONCLUSIVE — old gate showed 0 floats; test cannot prove the fix'); process.exit(1); }
-console.log(`PASS — support gate eliminates floating beams (${oldFloat} → 0) on real Hospital geometry`);
+if (newTot !== 0) { console.error(`FAIL — XY-aware gate still floats ${newTot} structural elements`); process.exit(1); }
+if (oldTot === 0) { console.error('INCONCLUSIVE — old gate showed 0 floats; test cannot prove the fix'); process.exit(1); }
+console.log(`PASS — XY-aware support gate eliminates floating structure (${oldTot} → 0) on real Hospital geometry`);

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -1,83 +1,94 @@
-/* schedule_gate.js — §gate (2026-05-30)
+/* schedule_gate.js — §gate (2026-05-30, XY-aware)
  * Support-gate FALLBACK scheduler for generated 4D (Time Machine). Pure + app-agnostic so the
  * browser (time_machine.js) and the Node witness (tests/test_schedule_gate.js) run the SAME code.
  *
- * THE RULE: an element cannot start until the structure that physically holds it up — a load-bearing
- * element that TOPS OUT within ±TOL of the element's base_z and rises from below — has finished.
- * Replaces the old center-Z banding ("band N waits N-1") that floated beams above still-building
- * tall columns (Hospital columns avg 6.87m vs 3m bands → the band under a beam was often empty).
+ * THE RULE: an element cannot start until the structure PHYSICALLY UNDER IT — a load-bearing element
+ * whose XY footprint overlaps and whose base sits below — has finished. "Build from below, at this
+ * XY location." Replaces center-Z banding (floated beams) AND the first Z-only gate (which still
+ * floated 84 beams + 765 members on Hospital, because it waited for the latest structure at that Z
+ * ANYWHERE, not the column actually under the beam). XY-aware → 0 floats. Witnessed on real geometry.
  *
  * Scope: GENERATED fallback only. Captured IFC 4D is absorbed verbatim by the overlay AFTER this.
- * No CPM / dependency / resource leveling — that's the planner's (MS Project's) job, absorbed verbatim.
+ * No CPM / dependency / resource leveling — that's the planner's (MS Project's) job.
  */
 (function (global) {
   'use strict';
-  var TOL = 0.5;   // m — a support topping within ±TOL of my base_z carries me
-  var BW  = 0.5;   // m — top_z bucket width for the support index
+  var CELL = 4;     // m — XY grid cell for the spatial support index
+  var EPS  = 0.5;   // m — a support must start at least this far below me (excludes same-level peers)
+  var AUD_TOL = 1.0;// m — audit: a support tops within this of my base (the thing I bear on)
 
-  // elements: [{ guid, base_z, top_z, seq, resource, installSecs }]  (seq<=4 = load-bearing structure)
-  // returns { guid: { start, end } } in ms, gated bottom-up.
+  function cellsOf(e) {
+    var o = [], i, j;
+    for (i = Math.floor(e.x0 / CELL); i <= Math.floor(e.x1 / CELL); i++)
+      for (j = Math.floor(e.y0 / CELL); j <= Math.floor(e.y1 / CELL); j++) o.push(i + ',' + j);
+    return o;
+  }
+  function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
+
+  // elements: [{ guid, x0,x1,y0,y1, base_z, top_z, seq, resource, installSecs }] (seq<=4 = load-bearing)
+  // returns { guid: { start, end } } in ms. Bottom-up; each element waits for the XY-overlapping
+  // structure rising from below it (the columns/walls/slabs actually under its footprint).
   function computeSchedule(elements, baseMs, scaleFactor) {
     baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
-    // bottom-up: a support (lower base) is scheduled before what rests on it, so its finish is known
     var ordered = elements.slice().sort(function (a, b) {
-      return (a.base_z - b.base_z) || (a.seq - b.seq) || (a.top_z - b.top_z);
+      return (a.base_z - b.base_z) || (a.seq - b.seq);
     });
-    var bucketEnd = {};   // floor(top_z/BW) -> latest STRUCTURAL finish topping in that 0.5m slice
-    var rc = {};          // resource|level -> crew cursor (light serialisation, keeps frontier thin)
+    var grid = {};   // "i,j" -> [{x0,x1,y0,y1,base_z,end}]  (scheduled STRUCTURAL only)
+    var rc = {};     // resource|level -> crew cursor (light serialisation, keeps the frontier thin)
     var out = {};
-    function gate(baseZ) {  // latest finish among structure topping within ±TOL of baseZ
-      var g = 0, lo = Math.floor((baseZ - TOL) / BW), hi = Math.floor((baseZ + TOL) / BW);
-      for (var k = lo; k <= hi; k++) if (bucketEnd[k] > g) g = bucketEnd[k];
-      return g;
-    }
-    for (var i = 0; i < ordered.length; i++) {
-      var el = ordered[i];
+    for (var n = 0; n < ordered.length; n++) {
+      var el = ordered[n];
+      var g = 0, cs = cellsOf(el), c, arr, k, S;
+      for (c = 0; c < cs.length; c++) {
+        arr = grid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) {
+          S = arr[k];
+          if (S.base_z < el.base_z - EPS && S.end > g && overlap(S, el)) g = S.end;
+        }
+      }
       var rk = el.resource + '|' + Math.floor(el.top_z / 3);
       var earliest = rc[rk] || baseMs;
-      var g = gate(el.base_z); if (g > earliest) earliest = g;
+      if (g > earliest) earliest = g;
       var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
       var end = earliest + dur;
       out[el.guid] = { start: earliest, end: end };
       rc[rk] = end;
-      if (el.seq <= 4) {                       // only structure carries load
-        var bk = Math.floor(el.top_z / BW);
-        if (!(bucketEnd[bk] > end)) bucketEnd[bk] = end;
+      if (el.seq <= 4) {
+        var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, end: end };
+        for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec);
       }
     }
     return out;
   }
 
   // Collapse sub-storeys onto their Level so the phase list stays ~8 bars (user: "collapsing is better").
-  // "Level 3 Ceiling" / "Level 3 TOS" / "Level 3 Soffit" -> "Level 3".
   function collapsePhase(storey) {
     if (!storey) return '_UNKNOWN';
     var s = String(storey).replace(/\s+(Ceiling|TOS|Top of Steel|Soffit|Slab)\b.*$/i, '').trim();
     return s || String(storey);
   }
 
-  // Independent runtime audit: count target elements that start before a TRUE support finishes.
-  // A true support = structural element topping within ±TOL of the target base AND rising >1m from
-  // below (a column/wall, not a same-level peer). Returns the violation count. 0 ⇒ Z order solved.
+  // Independent XY-aware audit: count target elements that start before a TRUE support finishes — a
+  // structural element XY-overlapping, rising >1m from below, topping within AUD_TOL of the target's
+  // base (the thing it bears on). Returns the violation count. 0 ⇒ nothing floats over its support.
   function auditFloating(elements, sched, classFilter) {
-    var sup = {};   // floor(top_z/BW) -> [{ base_z, end, guid }]
-    for (var i = 0; i < elements.length; i++) {
+    var grid = {}, i, c, cs;
+    for (i = 0; i < elements.length; i++) {
       var e = elements[i];
-      if (e.seq <= 4) {
-        var bk = Math.floor(e.top_z / BW);
-        (sup[bk] = sup[bk] || []).push({ base_z: e.base_z, end: sched[e.guid].end, guid: e.guid });
-      }
+      if (e.seq <= 4) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(e); }
     }
     var v = 0;
-    for (var j = 0; j < elements.length; j++) {
-      var T = elements[j];
+    for (i = 0; i < elements.length; i++) {
+      var T = elements[i];
       if (classFilter && !classFilter(T)) continue;
-      var se = 0, lo = Math.floor((T.base_z - TOL) / BW), hi = Math.floor((T.base_z + TOL) / BW);
-      for (var k = lo; k <= hi; k++) {
-        var arr = sup[k]; if (!arr) continue;
-        for (var m = 0; m < arr.length; m++) {
-          var S = arr[m];
-          if (S.guid !== T.guid && S.base_z < T.base_z - 1.0 && S.end > se) se = S.end;
+      var se = 0, seen = {}, k, arr, S; cs = cellsOf(T);
+      for (c = 0; c < cs.length; c++) {
+        arr = grid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) {
+          S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+          if (S.base_z < T.base_z - 1.0 && S.top_z <= T.base_z + AUD_TOL && overlap(S, T)) {
+            var en = sched[S.guid].end; if (en > se) se = en;
+          }
         }
       }
       if (se > 0 && sched[T.guid].start < se - 1) v++;
@@ -85,7 +96,7 @@
     return v;
   }
 
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, auditFloating: auditFloating, TOL: TOL, BW: BW };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, auditFloating: auditFloating, CELL: CELL };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v548';
+const CACHE_VERSION = 'v549';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v549';
+const CACHE_VERSION = 'v550';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v550';
+const CACHE_VERSION = 'v551';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2010,8 +2010,14 @@
       if (bar) {
         var dayStart = Math.round((bar.startTs - _projectStart) / 86400000);
         var dayEnd = Math.round((bar.endTs - _projectStart) / 86400000);
-        tip.textContent = bar.storey + ' \u2014 ' + bar.phase + ' (' + bar.count + ' elements, Day ' + dayStart + '\u2013' + dayEnd + ')';
-        tip.style.left = Math.min(e.offsetX + 8, e.target.clientWidth - 200) + 'px';
+        // \u00a7gate: source label so you can tell preset IFC 4D from generated fallback
+        var src = (bar.cap === bar.count) ? 'IFC 4D' : (bar.cap > 0 ? (bar.cap + '/' + bar.count + ' IFC 4D') : 'generated');
+        tip.textContent = bar.storey + ' \u2014 ' + bar.phase + ' (' + bar.count + ' el, Day ' + dayStart + '\u2013' + dayEnd + ', ' + src + ')';
+        tip.style.left = Math.max(0, Math.min(e.offsetX + 8, e.target.clientWidth - 200)) + 'px';
+        // \u00a7gate: follow the pointer/touch Y so the tip stays visible when the Gantt is scrolled
+        // (was pinned at top:4px \u2192 off-screen once scrolled down). Just above the tip; flip below near the top.
+        var ty = e.offsetY - 22; if (ty < 2) ty = e.offsetY + 16;
+        tip.style.top = ty + 'px';
         tip.style.display = 'block';
       } else {
         tip.style.display = 'none';
@@ -2313,7 +2319,9 @@
     try {
       r = db.exec(
         'SELECT m.guid, m.ifc_class, m.element_name, m.storey, m.discipline, ' +
-        'COALESCE(t.center_z, 0) as cz, COALESCE(t.bbox_z, 0) as bz ' +
+        'COALESCE(t.center_z, 0) as cz, COALESCE(t.bbox_z, 0) as bz, ' +
+        'COALESCE(t.center_x, 0) as cx, COALESCE(t.center_y, 0) as cy, ' +
+        'COALESCE(t.bbox_x, 0) as bx, COALESCE(t.bbox_y, 0) as by ' +
         'FROM elements_meta m ' +
         'LEFT JOIN element_transforms t ON t.guid = m.guid ' +
         "WHERE m.ifc_class != 'IfcOpeningElement' " +
@@ -2357,6 +2365,7 @@
     var roofOverrides = 0;
     var elements = r[0].values.map(function(row) {
       var cls = row[1], storey = row[3] || '_UNKNOWN', cz = row[5] || 0, bz = row[6] || 0;
+      var cx = row[7] || 0, cy = row[8] || 0, bx = row[9] || 0, by = row[10] || 0;
       var rule = matchRule(cls);
       var seq = rule.sequence, phase = rule.phase;
 
@@ -2369,7 +2378,8 @@
       return {
         guid: row[0], cls: cls, name: row[2] || '', storey: storey,
         cz: cz, band: Math.floor(cz / 3),  // §S260e: Z-quantized band (3m = ~one floor)
-        base_z: cz - bz / 2, top_z: cz + bz / 2,  // §gate: support-gate geometry (base = underside, top = where it tops out)
+        base_z: cz - bz / 2, top_z: cz + bz / 2,  // §gate: Z geometry (base = underside, top = where it tops out)
+        x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,  // §gate: XY footprint for the support gate
         seq: seq, phase: phase,
         resource: rule.resource || '_DEFAULT',
         installSecs: getInstallSecs(cls)
@@ -2456,11 +2466,13 @@
     db.run('COMMIT');
     resourceCursor['_end'] = _projEnd;   // feed the endDate computation below (Math.max over values)
 
-    // §SUPPORT_CHECK: independent runtime audit — a beam must not start before the column topping
-    // within ±TOL of its base finishes. floatingBeams=0 ⇒ Z order solved (was ~1127/1970 pre-fix).
-    var _beamN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (elements[_bi].cls === 'IfcBeam') _beamN++;
-    var _float = ScheduleGate.auditFloating(elements, _sched, function(e){ return e.cls === 'IfcBeam'; });
-    console.log('§SUPPORT_CHECK floatingBeams=' + _float + '/' + _beamN + ' gated=' + elements.length + ' (0=Z solved)');
+    // §SUPPORT_CHECK: independent XY-aware audit — a beam/member/slab must not start before the
+    // structure UNDER its XY footprint finishes. 0 ⇒ nothing floats over its support (was, on
+    // Hospital: 84 beams + 765 members + 3 slabs under the Z-only gate; XY-aware → 0).
+    var _isStruct = function(e){ return e.cls === 'IfcBeam' || e.cls === 'IfcMember' || e.cls === 'IfcSlab'; };
+    var _structN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (_isStruct(elements[_bi])) _structN++;
+    var _float = ScheduleGate.auditFloating(elements, _sched, _isStruct);
+    console.log('§SUPPORT_CHECK floating=' + _float + '/' + _structN + ' (beams+members+slabs over their XY support) gated=' + elements.length + ' (0=solved)');
 
     // §S260c BUG5: Log first 20 ops to verify bottom-up storey ordering
     var _first20 = [];
@@ -2557,11 +2569,12 @@
       var storey = p.storey || '_UNKNOWN';
       var phase = p.phase || 'Architecture';
       var key = storey + '|' + phase;
-      if (!groups[key]) groups[key] = { storey: storey, phase: phase, startTs: op.start_ts, endTs: op.end_ts, count: 0 };
+      if (!groups[key]) groups[key] = { storey: storey, phase: phase, startTs: op.start_ts, endTs: op.end_ts, count: 0, cap: 0 };
       var g = groups[key];
       if (op.start_ts < g.startTs) g.startTs = op.start_ts;
       if (op.end_ts > g.endTs) g.endTs = op.end_ts;
       g.count++;
+      if (p._captured) g.cap++;   // §gate: captured = preset IFC 4D (verbatim) — drives the yellow frame
     }
 
     // Convert to array and sort by start time
@@ -2636,6 +2649,15 @@
       ctx.globalAlpha = 0.8;
       ctx.fillStyle = color;
       ctx.fillRect(x, y, w, barH);
+
+      // §gate: captured (preset IFC 4D) bars get a bright-yellow frame so you can tell the real
+      // programme from the generated fallback. cap = #captured ops in this storey|phase group.
+      if (task.cap > 0) {
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = '#ffeb3b';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(x + 0.5, y + 0.5, Math.max(1, w - 1), barH - 1);
+      }
 
       if (isActive) {
         ctx.globalAlpha = 1;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -832,8 +832,8 @@
 <script src="wizard_storeys.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_storeys.js')"></script>
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=2" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
-<script src="schedule_gate.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=50" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="schedule_gate.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
+<script src="time_machine.js?v=51" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="main.js?v=35"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->


### PR DESCRIPTION
## Floating beams — the real fix (XY)
The Z-only gate (#67) still floated **84 beams + 765 members** on Hospital: it waited for the latest structure at the beam's *Z* anywhere in the plan, not the column **under the beam's XY footprint**. Now the gate is **XY-aware** — an element waits for the structural elements whose XY footprint overlaps it and whose base is below ("build from below, at this location"), using `element_transforms` `center_x/y` + `bbox_x/y`.

**Witness** (`tests/test_schedule_gate.js`, real Hospital, 63,415 elements, runs the deployed module):
```
IfcBeam    OLD(center-band)=72/1970   NEW(XY-gate)=0/1970
IfcMember  OLD(center-band)=2245/7127 NEW(XY-gate)=0/7127
IfcSlab    OLD=0/35                    NEW=0/35
→ 2317 floating → 0
```

## Also on the Gantt
- **Preset 4D distinction:** captured bars (from IFC `IfcWorkSchedule`) get a **bright-yellow frame**; tooltip shows source (`IFC 4D` / `N/M IFC 4D` / `generated`). `drawGanttMini` tracks per-group captured count from `parameters._captured`.
- **Tooltip follows the pointer/touch Y** instead of pinning at the top (it scrolled off-screen before).

`§SUPPORT_CHECK floating=0` logged at runtime (beams+members+slabs, XY-aware). CI: full `node --check`, sw-precache 0 missing, script-tag 0 missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)