### PR TITLE
fix(settings): reveal Settings panel on first open (was hidden, needed 2nd click)

### DIFF
--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1077,6 +1077,7 @@ function setupPanels(A) {
         content: content,
         onClose: function() { _syncPillHighlights(); } });
       document.body.appendChild(p);
+      p.style.display = '';   // createPanel returns hidden — reveal on first open (matches _openJsonEditor)
       if (window.InputReg) InputReg.register({ id: 'settings', el: p, kind: 'panel', release: function() { p.style.display = 'none'; } });
       // §S282b: PanelNav for Settings — arrows traverse pill rows, Enter toggles visibility
       if (typeof window.PanelNav === 'function') {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v549';
+const CACHE_VERSION = 'v550';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## Bug
On the live viewer, clicking **Settings once leaves the panel hidden** — `§PANEL_CREATE id=settings-panel` + `§PROPSHEET_RENDER` fire, but `settings-panel` stays `display:none`. A *second* click (the toggle at the top of `_openSettingsPanel`) reveals it.

**Cause:** `A.createPanel` returns the panel `display:none` (`panels.js:109`). `_openJsonEditor` compensates with `p.style.display=''`; `_openSettingsPanel` did not.

## Fix
One line after `document.body.appendChild(p)`:
```js
p.style.display = '';   // createPanel returns hidden — reveal on first open (matches _openJsonEditor)
```

## Verify
- Pre-fix (live, real single Playwright click): `settings-panel display = none`.
- Post-fix expectation: `display = block` after one click — will confirm on the deployed build.
- CI fast-checks green locally. `sw CACHE_VERSION v549→v550`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)