### PR TITLE
fix(panels): foldable Settings sections — draggable panels capture pointer only after moving

### DIFF
--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -9,7 +9,7 @@ function setupMeasure(A) {
 
   // ── Draggable panels ──
   A._makeDraggable = function(el) {
-    var ox, oy, sx, sy, dragging = false;
+    var ox, oy, sx, sy, dragging = false, pending = false, moved = false, pid = null;
     var dragStrip = window._isMobile ? 50 : 30;
     el.style.cursor = 'grab';
     // On mobile, intercept touch BEFORE the browser claims it for scroll/pan.
@@ -34,20 +34,29 @@ function setupMeasure(A) {
       if (e.target.closest('[data-clash-idx]') || e.target.closest('[data-pair]')) return;
       var rect = el.getBoundingClientRect();
       if (e.clientY - rect.top > dragStrip) return;
-      dragging = true;
+      // Arm a potential drag, but DON'T capture the pointer yet — a stationary tap
+      // in the drag strip must still reach child controls (e.g. a section-header
+      // collapse). Capture happens on first real move (pointermove below). Without
+      // this, setPointerCapture swallowed the header's pointerup → couldn't fold.
+      pending = true; moved = false; dragging = false;
       ox = e.clientX; oy = e.clientY;
       sx = rect.left; sy = rect.top;
-      el.setPointerCapture(e.pointerId);
-      e.preventDefault();
+      pid = e.pointerId;
     });
     el.addEventListener('pointermove', function(e) {
-      if (!dragging) return;
+      if (!pending) return;
+      if (!moved) {
+        if (Math.abs(e.clientX - ox) + Math.abs(e.clientY - oy) < 4) return;  // still a tap
+        moved = true; dragging = true;
+        try { el.setPointerCapture(pid); } catch (err) {}                      // now a real drag
+        e.preventDefault();
+      }
       el.style.left = (sx + e.clientX - ox) + 'px';
       el.style.top = (sy + e.clientY - oy) + 'px';
       el.style.right = 'auto';
       el.style.bottom = 'auto';
     });
-    el.addEventListener('pointerup', function() { dragging = false; });
+    el.addEventListener('pointerup', function() { pending = false; dragging = false; moved = false; });
   };
 
   // ── Clash detection (bbox overlap from DB, rules from clash_rules.json) ──

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v551';
+const CACHE_VERSION = 'v552';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
Tapping a section header (e.g. **Pill Icons**) inside the Settings panel did nothing, so the JSON hub below 24 rows was unreachable. `_makeDraggable` armed drag in the top ~30px strip and called `setPointerCapture` on `pointerdown`, swallowing the header's `pointerup`. Now it captures **only after the pointer moves >4px** — a stationary tap reaches child controls; a real drag still works. Applies to all draggable panels.

Pre-fix (live, real `.click()` on Pill Icons header): `70vh → 70vh`. Post-fix expectation: `→ 0px`. CI green locally (incl. test_s282b_panel_nav). sw v551→v552. Companion to #70 (auto-merged before this landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)