### PR TITLE
fix(TM): two-pass gate — no floating furniture/MEP/walls + trade order

### DIFF
--- a/tests/test_schedule_gate.js
+++ b/tests/test_schedule_gate.js
@@ -23,13 +23,14 @@ const matchRule = c => { let b=null,l=0; for (const k in RULES) if (c.indexOf(k)
 
 const csv = execSync(
   `sqlite3 -noheader -csv "${DB}" "SELECT m.guid,m.ifc_class,COALESCE(t.center_x,0),COALESCE(t.center_y,0),` +
-  `COALESCE(t.center_z,0),COALESCE(t.bbox_x,0),COALESCE(t.bbox_y,0),COALESCE(t.bbox_z,0) ` +
+  `COALESCE(t.center_z,0),COALESCE(t.bbox_x,0),COALESCE(t.bbox_y,0),COALESCE(t.bbox_z,0),COALESCE(m.storey,'_UNKNOWN') ` +
   `FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class!='IfcOpeningElement';"`,
   { maxBuffer: 1 << 28 }).toString().trim().split('\n');
 const elements = csv.map(line => {
   const a = line.split(','); if (a.length < 8) return null;
   const cls=a[1], cx=+a[2], cy=+a[3], cz=+a[4], bx=+a[5], by=+a[6], bz=+a[7], r=matchRule(cls);
-  return { guid:a[0], cls, seq:r.seq, resource:cls, installSecs: r.prod>0?Math.round(28800/r.prod):120,
+  return { guid:a[0], cls, seq:r.seq, resource:cls, storey:(a[8]||'_UNKNOWN').replace(/"/g,''),
+           installSecs: r.prod>0?Math.round(28800/r.prod):120,
            x0:cx-bx/2, x1:cx+bx/2, y0:cy-by/2, y1:cy+by/2, base_z:cz-bz/2, top_z:cz+bz/2 };
 }).filter(Boolean);
 const n = c => elements.filter(e=>e.cls===c).length;
@@ -44,15 +45,28 @@ function schedOld(els){
   const out={};E.forEach(e=>out[e.guid]={start:e.start,end:e.end});return out;
 }
 
-const CL = ['IfcBeam','IfcMember','IfcSlab'];
-const flt = (sched, cls) => ScheduleGate.auditFloating(elements, sched, e=>e.cls===cls);
+// classes the user reported floating: structure AND non-structure (furniture, MEP, walls)
+const GROUPS = [
+  { label:'beam',      pred:e=>e.cls==='IfcBeam' },
+  { label:'member',    pred:e=>e.cls==='IfcMember' },
+  { label:'slab',      pred:e=>e.cls==='IfcSlab' },
+  { label:'furniture', pred:e=>e.cls.indexOf('Furni')>=0 },
+  { label:'flow/MEP',  pred:e=>e.cls.indexOf('Flow')>=0||e.cls.indexOf('Duct')>=0||e.cls.indexOf('Pipe')>=0||e.cls.indexOf('AirTerminal')>=0 },
+  { label:'wall',      pred:e=>e.cls.indexOf('Wall')>=0 },
+];
+const cnt = pred => elements.filter(pred).length;
 const oldSched = schedOld(elements);
-const newSched = ScheduleGate.computeSchedule(elements, 0, 1);   // the REAL deployed XY-aware gate
+const newSched = ScheduleGate.computeSchedule(elements, 0, 1);   // the REAL deployed two-pass gate
 
 let oldTot = 0, newTot = 0;
-CL.forEach(cl => { const o=flt(oldSched,cl), x=flt(newSched,cl); oldTot+=o; newTot+=x;
-  console.log(`§SUPPORT_CHECK ${cl.padEnd(10)} OLD(center-band)=${o}/${n(cl)}  NEW(XY-gate)=${x}/${n(cl)}`); });
+GROUPS.forEach(g => { const o=ScheduleGate.auditFloating(elements,oldSched,g.pred), x=ScheduleGate.auditFloating(elements,newSched,g.pred); oldTot+=o; newTot+=x;
+  console.log(`§SUPPORT_CHECK ${g.label.padEnd(10)} OLD(center-band)=${o}/${cnt(g.pred)}  NEW(two-pass)=${x}/${cnt(g.pred)}`); });
 
-if (newTot !== 0) { console.error(`FAIL — XY-aware gate still floats ${newTot} structural elements`); process.exit(1); }
+// trade order: avg start day per seq — proves structure first, MEP late, furniture last (per Level)
+const day = ms => Math.round(ms/86400000); const bySeq = {};
+elements.forEach(e => { const o=newSched[e.guid]; (bySeq[e.seq]=bySeq[e.seq]||[]).push(day(o.start)); });
+Object.keys(bySeq).sort((a,b)=>a-b).forEach(s => { const a=bySeq[s]; console.log(`§TRADE seq=${s} avgStartDay=${Math.round(a.reduce((x,y)=>x+y,0)/a.length)} n=${a.length}`); });
+
+if (newTot !== 0) { console.error(`FAIL — two-pass gate still floats ${newTot} elements`); process.exit(1); }
 if (oldTot === 0) { console.error('INCONCLUSIVE — old gate showed 0 floats; test cannot prove the fix'); process.exit(1); }
-console.log(`PASS — XY-aware support gate eliminates floating structure (${oldTot} → 0) on real Hospital geometry`);
+console.log(`PASS — two-pass gate eliminates floating (${oldTot} → 0) across structure + furniture + MEP + walls on real Hospital geometry`);

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -1,21 +1,25 @@
-/* schedule_gate.js — §gate (2026-05-30, XY-aware)
- * Support-gate FALLBACK scheduler for generated 4D (Time Machine). Pure + app-agnostic so the
- * browser (time_machine.js) and the Node witness (tests/test_schedule_gate.js) run the SAME code.
+/* schedule_gate.js — §gate (2026-05-30, two-pass: geometry + trade order)
+ * Support-gate FALLBACK scheduler for generated 4D (Time Machine) = "synthetic 4D" organised by
+ * phase/task, the same shape a captured MS Project / IFC programme would have. Pure + app-agnostic
+ * so the browser (time_machine.js) and the Node witness (tests/test_schedule_gate.js) run identical code.
  *
- * THE RULE: an element cannot start until the structure PHYSICALLY UNDER IT — a load-bearing element
- * whose XY footprint overlaps and whose base sits below — has finished. "Build from below, at this
- * XY location." Replaces center-Z banding (floated beams) AND the first Z-only gate (which still
- * floated 84 beams + 765 members on Hospital, because it waited for the latest structure at that Z
- * ANYWHERE, not the column actually under the beam). XY-aware → 0 floats. Witnessed on real geometry.
+ * TWO RULES, two passes:
+ *   PASS A — STRUCTURE (seq<=4), bottom-up by base_z: an element waits for the structure whose XY
+ *            footprint overlaps it and whose base is below ("build from below, at this location").
+ *            Eliminates floating beams/members/slabs.
+ *   PASS B — NON-STRUCTURE (seq>4), by trade then base_z: each item waits for (1) the structure under
+ *            its footprint (no floating furniture/MEP) AND (2) the lower trades in its own Level/phase
+ *            (so MEP is late and furniture is last, per Level).
  *
- * Scope: GENERATED fallback only. Captured IFC 4D is absorbed verbatim by the overlay AFTER this.
- * No CPM / dependency / resource leveling — that's the planner's (MS Project's) job.
+ * ε = 0.05m: a support need only start just below me — the thin slab a chair/duct sits on (~0.2m
+ * below) counts. (ε=0.5 wrongly skipped it → furniture/flow floated.) Scope: GENERATED fallback only;
+ * captured IFC 4D is absorbed verbatim by the overlay AFTER this. No CPM/dependency solving (planner's).
  */
 (function (global) {
   'use strict';
   var CELL = 4;     // m — XY grid cell for the spatial support index
-  var EPS  = 0.5;   // m — a support must start at least this far below me (excludes same-level peers)
-  var AUD_TOL = 1.0;// m — audit: a support tops within this of my base (the thing I bear on)
+  var EPS  = 0.05;  // m — a support must start at least this far below me (excludes same-level peers)
+  var GAP  = 0.5;   // m — audit: a support tops within this of my base (the thing I bear on)
 
   function cellsOf(e) {
     var o = [], i, j;
@@ -25,78 +29,90 @@
   }
   function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
 
-  // elements: [{ guid, x0,x1,y0,y1, base_z, top_z, seq, resource, installSecs }] (seq<=4 = load-bearing)
-  // returns { guid: { start, end } } in ms. Bottom-up; each element waits for the XY-overlapping
-  // structure rising from below it (the columns/walls/slabs actually under its footprint).
-  function computeSchedule(elements, baseMs, scaleFactor) {
-    baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
-    var ordered = elements.slice().sort(function (a, b) {
-      return (a.base_z - b.base_z) || (a.seq - b.seq);
-    });
-    var grid = {};   // "i,j" -> [{x0,x1,y0,y1,base_z,end}]  (scheduled STRUCTURAL only)
-    var rc = {};     // resource|level -> crew cursor (light serialisation, keeps the frontier thin)
-    var out = {};
-    for (var n = 0; n < ordered.length; n++) {
-      var el = ordered[n];
-      var g = 0, cs = cellsOf(el), c, arr, k, S;
-      for (c = 0; c < cs.length; c++) {
-        arr = grid[cs[c]]; if (!arr) continue;
-        for (k = 0; k < arr.length; k++) {
-          S = arr[k];
-          if (S.base_z < el.base_z - EPS && S.end > g && overlap(S, el)) g = S.end;
-        }
-      }
-      var rk = el.resource + '|' + Math.floor(el.top_z / 3);
-      var earliest = rc[rk] || baseMs;
-      if (g > earliest) earliest = g;
-      var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
-      var end = earliest + dur;
-      out[el.guid] = { start: earliest, end: end };
-      rc[rk] = end;
-      if (el.seq <= 4) {
-        var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, end: end };
-        for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec);
-      }
-    }
-    return out;
-  }
-
-  // Collapse sub-storeys onto their Level so the phase list stays ~8 bars (user: "collapsing is better").
+  // Collapse sub-storeys onto their Level so the phase list stays ~8 (user: "collapsing is better").
+  // "Level 3 Ceiling" / "Level 3 TOS" -> "Level 3". Also the JSON phase key + the trade-gate group.
   function collapsePhase(storey) {
     if (!storey) return '_UNKNOWN';
     var s = String(storey).replace(/\s+(Ceiling|TOS|Top of Steel|Soffit|Slab)\b.*$/i, '').trim();
     return s || String(storey);
   }
 
-  // Independent XY-aware audit: count target elements that start before a TRUE support finishes — a
-  // structural element XY-overlapping, rising >1m from below, topping within AUD_TOL of the target's
-  // base (the thing it bears on). Returns the violation count. 0 ⇒ nothing floats over its support.
-  function auditFloating(elements, sched, classFilter) {
-    var grid = {}, i, c, cs;
-    for (i = 0; i < elements.length; i++) {
-      var e = elements[i];
-      if (e.seq <= 4) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(e); }
+  // elements: [{ guid, x0,x1,y0,y1, base_z, top_z, seq, storey, resource, installSecs }] (seq<=4 = structure)
+  // returns { guid: { start, end } } ms.
+  function computeSchedule(elements, baseMs, scaleFactor) {
+    baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
+    var grid = {}, out = {}, c, cs, k, arr, S;
+    function geoGate(el) {                 // latest finish of XY-overlapping structure rising from below
+      var g = baseMs; cs = cellsOf(el);
+      for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) { S = arr[k];
+          if (S.base_z < el.base_z - EPS && S.end > g && overlap(S, el)) g = S.end; } }
+      return g;
     }
+    function place(el, start) {
+      var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
+      var end = start + dur; out[el.guid] = { start: start, end: end };
+      if (el.seq <= 4) { var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, end: end };
+        cs = cellsOf(el); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec); }
+      return end;
+    }
+    // PASS A — structure, bottom-up by base_z (supports scheduled before what rests on them)
+    var struct = elements.filter(function (e) { return e.seq <= 4; })
+      .sort(function (a, b) { return (a.base_z - b.base_z) || (a.seq - b.seq); });
+    var rcA = {};
+    struct.forEach(function (el) {
+      var rk = el.resource + '|' + Math.floor(el.top_z / 3);
+      var start = Math.max(geoGate(el), rcA[rk] || baseMs);
+      rcA[rk] = place(el, start);
+    });
+    // PASS B — non-structure, by trade then base_z, on the COMPLETED structure grid.
+    // Per-Level trade gate: trade k waits for all lower trades (s<k) in its Level → MEP late, furniture last.
+    var nonst = elements.filter(function (e) { return e.seq > 4; })
+      .sort(function (a, b) { return (a.seq - b.seq) || (a.base_z - b.base_z); });
+    var phaseTrade = {}, rcB = {};
+    nonst.forEach(function (el) {
+      var ph = collapsePhase(el.storey);
+      var pt = phaseTrade[ph] || {}, tg = baseMs, s;
+      for (s in pt) if (+s < el.seq && pt[s] > tg) tg = pt[s];
+      var rk = el.resource + '|' + ph;
+      var start = Math.max(geoGate(el), tg, rcB[rk] || baseMs);
+      var end = place(el, start);
+      rcB[rk] = end;
+      (phaseTrade[ph] = phaseTrade[ph] || {});
+      if (!(phaseTrade[ph][el.seq] > end)) phaseTrade[ph][el.seq] = end;
+    });
+    return out;
+  }
+
+  // Pick the elements assigned to a JSON phase/task. phaseKey = collapsed Level name; optional seq
+  // (trade) narrows to a task within the phase. The seam to captured tasks AND to MSP/MSPDI export.
+  function elementsInPhase(elements, phaseKey, seq) {
+    return elements.filter(function (e) {
+      return collapsePhase(e.storey) === phaseKey && (seq == null || e.seq === seq);
+    });
+  }
+
+  // Independent audit: count elements that start before a TRUE support finishes — structural,
+  // XY-overlapping, rising from below (base < base-ε), topping within GAP of the target base.
+  // 0 ⇒ nothing floats over its physical support. Works for any class (beams, furniture, MEP…).
+  function auditFloating(elements, sched, classFilter) {
+    var grid = {}, i, c, cs, k, arr, S;
+    for (i = 0; i < elements.length; i++) { var e = elements[i];
+      if (e.seq <= 4) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(e); } }
     var v = 0;
-    for (i = 0; i < elements.length; i++) {
-      var T = elements[i];
+    for (i = 0; i < elements.length; i++) { var T = elements[i];
       if (classFilter && !classFilter(T)) continue;
-      var se = 0, seen = {}, k, arr, S; cs = cellsOf(T);
-      for (c = 0; c < cs.length; c++) {
-        arr = grid[cs[c]]; if (!arr) continue;
-        for (k = 0; k < arr.length; k++) {
-          S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
-          if (S.base_z < T.base_z - 1.0 && S.top_z <= T.base_z + AUD_TOL && overlap(S, T)) {
-            var en = sched[S.guid].end; if (en > se) se = en;
-          }
-        }
-      }
+      var se = 0, seen = {}; cs = cellsOf(T);
+      for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) { S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+          if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
+            var en = sched[S.guid].end; if (en > se) se = en; } } }
       if (se > 0 && sched[T.guid].start < se - 1) v++;
     }
     return v;
   }
 
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, auditFloating: auditFloating, CELL: CELL };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, CELL: CELL };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v552';
+const CACHE_VERSION = 'v553';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2466,13 +2466,15 @@
     db.run('COMMIT');
     resourceCursor['_end'] = _projEnd;   // feed the endDate computation below (Math.max over values)
 
-    // §SUPPORT_CHECK: independent XY-aware audit — a beam/member/slab must not start before the
-    // structure UNDER its XY footprint finishes. 0 ⇒ nothing floats over its support (was, on
-    // Hospital: 84 beams + 765 members + 3 slabs under the Z-only gate; XY-aware → 0).
-    var _isStruct = function(e){ return e.cls === 'IfcBeam' || e.cls === 'IfcMember' || e.cls === 'IfcSlab'; };
-    var _structN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (_isStruct(elements[_bi])) _structN++;
-    var _float = ScheduleGate.auditFloating(elements, _sched, _isStruct);
-    console.log('§SUPPORT_CHECK floating=' + _float + '/' + _structN + ' (beams+members+slabs over their XY support) gated=' + elements.length + ' (0=solved)');
+    // §SUPPORT_CHECK: independent XY-aware audit — NOTHING (beam/member/slab/furniture/MEP/wall)
+    // may start before the structure UNDER its XY footprint finishes. 0 ⇒ nothing floats. Pre-fix
+    // (Hospital): 84 beams + 765 members floated (Z-only) and 133 furniture + 1980 flow + 1156 walls
+    // (ε=0.5 skipped the slab they sit on). Two-pass + ε=0.05 → 0.
+    var _audit = function(e){ return e.cls === 'IfcBeam' || e.cls === 'IfcMember' || e.cls === 'IfcSlab' ||
+      e.cls.indexOf('Furni') >= 0 || e.cls.indexOf('Wall') >= 0; };
+    var _auditN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (_audit(elements[_bi])) _auditN++;
+    var _float = ScheduleGate.auditFloating(elements, _sched, _audit);
+    console.log('§SUPPORT_CHECK floating=' + _float + '/' + _auditN + ' (struct+furniture+walls over their XY support) gated=' + elements.length + ' (0=solved)');
 
     // §S260c BUG5: Log first 20 ops to verify bottom-up storey ordering
     var _first20 = [];

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -832,8 +832,8 @@
 <script src="wizard_storeys.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_storeys.js')"></script>
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=2" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
-<script src="schedule_gate.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=51" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
+<script src="time_machine.js?v=52" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="main.js?v=35"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->


### PR DESCRIPTION
Two-pass generated-4D gate. **A:** structure bottom-up (geometric XY support). **B:** non-structure by trade on finished structure — gated by structure-under-footprint AND lower trades in its Level → MEP late, furniture last. ε 0.5→0.05 (the slab an item sits on now counts).

Witness (real Hospital, 63,415 el): floating **3240 → 0** across beams/members/slabs/furniture/flow/walls; §TRADE shows structure→MEP→finishes. Adds `elementsInPhase()` (phase/task picker → MSP export seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)