### PR TITLE
fix(panels): release drag on pointerup even when a child stops propagation (no stick)

### DIFF
--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -43,8 +43,13 @@ function setupMeasure(A) {
       sx = rect.left; sy = rect.top;
       pid = e.pointerId;
     });
+    function _endDrag() {
+      if (pid != null) { try { if (el.hasPointerCapture(pid)) el.releasePointerCapture(pid); } catch (err) {} }
+      pending = false; dragging = false; moved = false; pid = null;
+    }
     el.addEventListener('pointermove', function(e) {
       if (!pending) return;
+      if (e.buttons === 0) { _endDrag(); return; }   // button already released — never hover-drag
       if (!moved) {
         if (Math.abs(e.clientX - ox) + Math.abs(e.clientY - oy) < 4) return;  // still a tap
         moved = true; dragging = true;
@@ -56,7 +61,10 @@ function setupMeasure(A) {
       el.style.right = 'auto';
       el.style.bottom = 'auto';
     });
-    el.addEventListener('pointerup', function() { pending = false; dragging = false; moved = false; });
+    // Capture phase so a child's stopPropagation (e.g. a section-header collapse handler)
+    // can't swallow the release — otherwise pending stays true and the panel sticks to the cursor.
+    el.addEventListener('pointerup', _endDrag, true);
+    el.addEventListener('pointercancel', _endDrag, true);
   };
 
   // ── Clash detection (bbox overlap from DB, rules from clash_rules.json) ──

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v553';
+const CACHE_VERSION = 'v554';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
Regression from the deferred-capture drag fix: a section header's `pointerup` calls `stopPropagation()` (its own collapse handler), which blocked `_makeDraggable`'s bubble-phase `pointerup` → `pending`/`dragging` never reset → the panel followed the cursor on hover ("sticks to the mouse, cannot let go").

**Fix:** reset via a **capture-phase** `pointerup`/`pointercancel` listener (fires before any child `stopPropagation`), explicitly `releasePointerCapture`, and bail out of `pointermove` when `e.buttons===0` (never hover-drag).

Verified locally (headless, real clicks/drags): fold `70vh→0px`; post-collapse hover **no move**; drag moves; post-drag hover **no move**. CI green. sw v553→v554.