### PR TITLE
feat(erp): Glassbowl/Gravity links in graph HUD + Read→ERP.md

### DIFF
--- a/viewer/ad_ui.js
+++ b/viewer/ad_ui.js
@@ -1637,6 +1637,22 @@
     });
     container.appendChild(searchBtn);
 
+    // Companion links — sit in the HUD row next to Search/Max so they ride with the graph (never buried by
+    // min/max). 🫧 Glassbowl + ✦ Gravity (the engine-as-data views) + 📖 Read (the ERP.md narrative).
+    var gbHud = document.createElement('div');
+    gbHud.style.cssText = 'position:absolute;top:6px;right:74px;z-index:5;display:flex;gap:6px;';
+    [['🫧 Glassbowl', 'https://red1oon.github.io/BIMCompiler/glassbowl.html', 'glassbowl'],
+     ['✦ Gravity', 'https://red1oon.github.io/BIMCompiler/glassbowl_gravity.html', 'glassbowl'],
+     ['📖 Read', 'https://red1oon.github.io/BIMCompiler/ERP/', 'erpdoc']].forEach(function (L) {
+      var a = document.createElement('a');
+      a.href = L[1]; a.target = L[2]; a.rel = 'noopener'; a.textContent = L[0];
+      a.style.cssText = 'background:rgba(0,0,0,0.5);border:1px solid rgba(255,255,255,0.15);color:#cdd6e4;' +
+        'font-size:12px;font-weight:600;text-decoration:none;padding:5px 9px;border-radius:6px;line-height:1;white-space:nowrap;';
+      a.addEventListener('pointerup', function (e) { e.stopPropagation(); });
+      gbHud.appendChild(a);
+    });
+    container.appendChild(gbHud);
+
     _contentEl.appendChild(container);
 
     // Init graph — use initFromBubbles if DB not ready

--- a/viewer/erp.html
+++ b/viewer/erp.html
@@ -55,15 +55,6 @@
   ::-webkit-scrollbar { width: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
-  /* Companion Glassbowl views (served from BIMCompiler GitHub Pages) */
-  #gbviews { position: fixed; top: 9px; right: 12px; z-index: 11; display: flex; gap: 6px; }
-  #gbviews a {
-    font-size: 12px; font-weight: 600; color: #cdd6e4; text-decoration: none;
-    background: rgba(40,44,58,0.82); border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 14px; padding: 6px 11px; min-height: 0; line-height: 1;
-    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-  }
-  #gbviews a:hover { border-color: #56d6e0; color: #56d6e0; }
 </style>
 </head>
 <body>
@@ -72,14 +63,6 @@
   <div class="spinner"></div>
   <div>Loading ERP OOTB&hellip;</div>
   <div id="load-status" style="margin-top:8px;font-size:11px;color:#555;"></div>
-</div>
-
-<!-- Companion Glassbowl views — the same model, seen two ways (read-only) -->
-<div id="gbviews">
-  <a href="https://red1oon.github.io/BIMCompiler/glassbowl.html" target="_blank" rel="noopener"
-     title="Glassbowl — the engine mapped from its own data (FK spines, trace, dossier)">🫧 Glassbowl</a>
-  <a href="https://red1oon.github.io/BIMCompiler/glassbowl_gravity.html" target="_blank" rel="noopener"
-     title="Glassbowl Gravity — pivot &amp; weigh the model (live GROUP BY, AD↔GW depth dial)">✦ Gravity</a>
 </div>
 
 <div id="breadcrumb"></div>

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v554';
+const CACHE_VERSION = 'v555';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
The 🫧 Glassbowl / ✦ Gravity links were a fixed top-right overlay that got **buried** when the graph is maximised/minimised. This moves them into the graph **HUD row next to 🔍 Search / ⛶ Max** so they ride with the graph and stay reachable, and adds **📖 Read → the ERP.md narrative** (`/BIMCompiler/ERP/`). Old `#gbviews` overlay removed. `sw.js` v554→v555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)