### PR TITLE
feat(erp): Phase A edge primitives LIVE — sign/replay/persist + Verify-ledger pill (sw v558)

### DIFF
--- a/viewer/ad_data.js
+++ b/viewer/ad_data.js
@@ -6,6 +6,175 @@
 (function () {
   'use strict';
 
+  // ── PB bridge state (docs/ERP.md §0) ────────────────────────────────
+  // Default OFF: legacy real-table CRUD (the shipped AD-faithful product).
+  // ADData.useBridge(map) flips every read/save/delete to route through the
+  // 5-table runtime via ad_table_map. Behavior-preserving until turned on.
+  var _bridge = null;       // the ad_table_map module when active
+  var _genSeq = 0;          // PB stopgap id source (real keys are supplied; GUIDs are P5)
+
+  function useBridge(map) {
+    _bridge = map;
+    console.log('§BRIDGE useBridge ON overrides=' +
+      (map && map.OVERRIDES ? Object.keys(map.OVERRIDES).length : '?'));
+  }
+  function legacyMode() { _bridge = null; }
+
+  function _keyCol(table) { return table + '_ID'; }
+
+  // Structural routing for one legacy column → real 5-table column, or null=>metadata.
+  function _routeCol(table, slot, fkMap, col) {
+    var keyCol = _keyCol(table);
+    if (col === keyCol) return 'id';
+    if (fkMap[col]) return fkMap[col];                       // explicit (source_id, document_id, …)
+    if (col === 'DocStatus' && slot === 'documents') return 'doc_status';
+    return null;                                              // → metadata[col]
+  }
+
+  // Split a legacy record into {struct, meta} per the slot's column shape.
+  function _split(table, t, record) {
+    var struct = {}, meta = { _table: table };
+    var keys = Object.keys(record);
+    for (var i = 0; i < keys.length; i++) {
+      var c = keys[i], v = record[c];
+      var dest = _routeCol(table, t.slot, t.fk_map, c);
+      if (dest === 'id') { struct.id = (v != null && v !== '') ? String(v) : null; }
+      else if (dest === 'line_no') { struct.line_no = (v == null || v === '') ? null : Number(v); }
+      else if (dest) { struct[dest] = (v != null && v !== '') ? String(v) : null; }
+      else { meta[c] = v; }
+    }
+    return { struct: struct, meta: meta };
+  }
+
+  function _newId(table) { _genSeq++; return table + '#' + _genSeq; }
+
+  // Reconstruct the legacy record from a 5-table row (inverse of _split).
+  function _rebuild(table, t, row) {
+    var rec = {};
+    var meta = {};
+    try { meta = JSON.parse(row.metadata || '{}'); } catch (e) { meta = {}; }
+    delete meta._table;
+    // metadata fields verbatim (keyed by ColumnName)
+    Object.keys(meta).forEach(function (k) { rec[k] = meta[k]; });
+    // key column from id
+    var keyCol = _keyCol(table);
+    rec[keyCol] = _numish(row.id);
+    // structural reverse-map
+    if (t.slot === 'documents' && row.doc_status != null) rec.DocStatus = row.doc_status;
+    var inv = {};
+    Object.keys(t.fk_map).forEach(function (col) { inv[t.fk_map[col]] = col; });
+    if (t.slot === 'documents') {
+      if (inv.source_id && row.source_id != null) rec[inv.source_id] = _numish(row.source_id);
+      if (inv.parent_id && row.parent_id != null) rec[inv.parent_id] = _numish(row.parent_id);
+      if (inv.container_id && row.container_id != null) rec[inv.container_id] = _numish(row.container_id);
+    } else if (t.slot === 'document_lines') {
+      if (inv.document_id && row.document_id != null) rec[inv.document_id] = _numish(row.document_id);
+      if (inv.source_line_id && row.source_line_id != null) rec[inv.source_line_id] = _numish(row.source_line_id);
+      if (inv.line_no && row.line_no != null) rec[inv.line_no] = row.line_no;
+    } else if (t.slot === 'items' || t.slot === 'containers') {
+      if (inv.parent_id && row.parent_id != null) rec[inv.parent_id] = _numish(row.parent_id);
+    }
+    return rec;
+  }
+  function _numish(v) { if (v == null) return v; var n = Number(v); return (!isNaN(n) && String(n) === String(v)) ? n : v; }
+
+  // Read one slot table as objects keyed by real column name.
+  function _rows(db, sql, params) {
+    var r = db.exec(sql, params || []);
+    if (!r.length) return [];
+    var cols = r[0].columns;
+    return r[0].values.map(function (row) {
+      var o = {}; for (var i = 0; i < cols.length; i++) o[cols[i]] = row[i]; return o;
+    });
+  }
+
+  // ── Bridge CRUD ──────────────────────────────────────────────────────
+  function _saveBridge(db, table, record) {
+    var t = _bridge.target(table);
+    var s = _split(table, t, record);
+    var action;
+    if (!s.struct.id) { s.struct.id = _newId(table); action = 'INSERT'; }
+    else {
+      var exists = _rows(db, 'SELECT id FROM ' + t.slot + ' WHERE id=?', [s.struct.id]).length > 0;
+      action = exists ? 'UPDATE' : 'INSERT';
+    }
+    var metaJson = JSON.stringify(s.meta);
+    if (t.slot === 'documents') {
+      _upsert(db, 'documents', s.struct.id, action,
+        { doc_type: t.docType, doc_status: s.struct.doc_status || 'DR',
+          source_id: s.struct.source_id || null, parent_id: s.struct.parent_id || null,
+          container_id: s.struct.container_id || null, metadata: metaJson });
+    } else if (t.slot === 'document_lines') {
+      _upsert(db, 'document_lines', s.struct.id, action,
+        { document_id: s.struct.document_id || null, source_line_id: s.struct.source_line_id || null,
+          line_no: (s.struct.line_no == null ? null : s.struct.line_no),
+          match_type: t.match_type || null, metadata: metaJson });
+    } else if (t.slot === 'journal') {
+      _upsert(db, 'journal', s.struct.id, action,
+        { batch_id: s.struct.batch_id || null, journal_id: s.struct.journal_id || null,
+          source: s.struct.source || null, metadata: metaJson });
+    } else { // items | containers
+      _upsert(db, t.slot, s.struct.id, action,
+        { parent_id: s.struct.parent_id || null, type: table, metadata: metaJson });
+    }
+    if (typeof KernelOps !== 'undefined') {
+      KernelOps.commitOp(db, 'AD_SAVE', { table: table, slot: t.slot, id: s.struct.id, action: action });
+    }
+    var legacyId = _numish(s.struct.id);
+    record[_keyCol(table)] = legacyId;
+    console.log('§BRIDGE save table=' + table + ' slot=' + t.slot + ' id=' + s.struct.id + ' action=' + action);
+    return { id: legacyId, action: action };
+  }
+
+  function _upsert(db, slot, id, action, cols) {
+    var names = Object.keys(cols);
+    if (action === 'INSERT') {
+      var all = ['id'].concat(names);
+      var vals = [id].concat(names.map(function (n) { return cols[n]; }));
+      db.run('INSERT INTO ' + slot + ' (' + all.join(',') + ') VALUES (' +
+        all.map(function () { return '?'; }).join(',') + ')', vals);
+    } else {
+      var sets = names.map(function (n) { return n + '=?'; });
+      var sv = names.map(function (n) { return cols[n]; }); sv.push(id);
+      db.run('UPDATE ' + slot + ' SET ' + sets.join(',') + ' WHERE id=?', sv);
+    }
+  }
+
+  // filter: optional {col, value} (legacy column) OR null for all rows of this table.
+  function _readBridge(db, table, filter) {
+    var t = _bridge.target(table);
+    var where = [], params = [];
+    // identity of the legacy table within its slot
+    if (t.slot === 'documents') { where.push('doc_type=?'); params.push(t.docType); }
+    else if (t.slot === 'items' || t.slot === 'containers') { where.push('type=?'); params.push(table); }
+    else { where.push("json_extract(metadata,'$._table')=?"); params.push(table); }
+    if (filter && filter.col != null) {
+      var dest = _routeCol(table, t.slot, t.fk_map, filter.col);
+      if (dest) { where.push(dest + '=?'); params.push(dest === 'line_no' ? Number(filter.value) : String(filter.value)); }
+      else { where.push("json_extract(metadata,'$." + filter.col + "')=?"); params.push(filter.value); }
+    }
+    var rows = _rows(db, 'SELECT * FROM ' + t.slot + ' WHERE ' + where.join(' AND '), params);
+    var out = rows.map(function (r) { return _rebuild(table, t, r); });
+    console.log('§BRIDGE read table=' + table + ' slot=' + t.slot + ' count=' + out.length);
+    return out;
+  }
+
+  function _deleteBridge(db, table, id) {
+    var t = _bridge.target(table);
+    db.run('DELETE FROM ' + t.slot + ' WHERE id=?', [String(id)]);
+    if (typeof KernelOps !== 'undefined') {
+      KernelOps.commitOp(db, 'AD_DELETE', { table: table, slot: t.slot, id: String(id) });
+    }
+    console.log('§BRIDGE delete table=' + table + ' slot=' + t.slot + ' id=' + id);
+  }
+
+  // Parse a simple "Col = value" / "Col=value" where clause into {col,value}.
+  function _parseWhere(where) {
+    if (!where) return null;
+    var m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*'?([^']*)'?\s*$/.exec(where);
+    return m ? { col: m[1], value: m[2] } : null;
+  }
+
   /**
    * Read records from any table.
    * @param {Object} db        sql.js database
@@ -15,6 +184,7 @@
    * @returns {Array} array of { colName: value } objects
    */
   function readRecords(db, tableName, where, orderBy) {
+    if (_bridge) return _readBridge(db, tableName, _parseWhere(where));
     var sql = 'SELECT * FROM ' + tableName;
     if (where) sql += ' WHERE ' + where;
     if (orderBy) sql += ' ORDER BY ' + orderBy;
@@ -60,6 +230,7 @@
    * @returns {{ id: number, action: string }}
    */
   function saveRecord(db, tableName, record, columns) {
+    if (_bridge) return _saveBridge(db, tableName, record);
     var keyCol = keyColumn(tableName);
     var id = record[keyCol];
     var action;
@@ -104,6 +275,7 @@
    * @param {*}      keyValue  key value
    */
   function deleteRecord(db, tableName, keyCol, keyValue) {
+    if (_bridge) return _deleteBridge(db, tableName, keyValue);
     console.log('§AD_DATA deleteRecord table=' + tableName + ' key=' + keyCol + '=' + keyValue);
     db.run('DELETE FROM ' + tableName + ' WHERE ' + keyCol + ' = ?', [keyValue]);
 
@@ -263,6 +435,8 @@
     readRecords:        readRecords,
     saveRecord:         saveRecord,
     deleteRecord:       deleteRecord,
+    useBridge:          useBridge,
+    legacyMode:         legacyMode,
     getNextId:          getNextId,
     countRecords:       countRecords,
     keyColumn:          keyColumn,

--- a/viewer/ad_parser.js
+++ b/viewer/ad_parser.js
@@ -27,6 +27,75 @@
     38: 'yesno'       // Yes-No (checkbox)
   };
 
+  // ── Compiled manifest (prompts/ERP_KERNEL_MONSTERS.md §4) ───────────
+  // When set, getWindow() / per-table field lookups for the 7 curated windows
+  // come from manifest.json (~17KB gz) instead of querying ad_seed.db.
+  // BEHAVIOR-PRESERVING: fields are mapped through the SAME REF_TYPES map used
+  // by getFields(), so rendering is byte-identical to the DB path. Windows and
+  // tables absent from the manifest fall through to the DB transparently.
+  var _manifest = null;
+  var _winById = {};        // windowId(Number) -> getWindow-shaped object
+  var _fieldsByTable = {};  // tableName -> getFields-shaped fields[]
+
+  function _mapField(mf) {
+    var ref = Number(mf.ref) || 10;
+    return {
+      id: null, name: mf.label, description: '', seqNo: mf.seq,
+      isDisplayed: true,
+      displayLogic: mf.dl || null,
+      isMandatory: !!mf.mandatory,
+      isReadOnly: !!mf.readonly,
+      defaultValue: mf.def || null,
+      columnId: null, columnName: mf.col,
+      referenceId: ref,
+      referenceType: REF_TYPES[ref] || 'string',
+      fieldLength: mf.len || null,
+      isKey: !!mf.key,
+      isIdentifier: !!mf.identifier
+    };
+  }
+
+  function _mapTab(mt) {
+    return {
+      id: null, name: mt.name, description: '', help: '',
+      tableId: null, tabLevel: mt.level, seqNo: mt.seq,
+      isSingleRow: !!mt.singleRow, isReadOnly: !!mt.readonly,
+      whereClause: mt.where || null, orderByClause: mt.orderBy || null,
+      tableName: mt.table,
+      fk: mt.fk || null,
+      fields: (mt.fields || []).map(_mapField)
+    };
+  }
+
+  function setManifest(m) {
+    if (!m || !m.windows) { console.log('§AD_PARSER setManifest: empty/invalid'); return; }
+    _manifest = m;
+    _winById = {};
+    _fieldsByTable = {};
+    var nWin = 0, nTab = 0, nFld = 0;
+    Object.keys(m.windows).forEach(function (id) {
+      var mw = m.windows[id];
+      var tabs = (mw.tabs || []).map(_mapTab);
+      _winById[Number(id)] = {
+        id: Number(id), name: mw.name, description: '', help: '',
+        windowType: 'M', tabs: tabs
+      };
+      nWin++;
+      tabs.forEach(function (t) {
+        nTab++; nFld += t.fields.length;
+        // header tab (level 0) wins over a child tab of the same table
+        if (!_fieldsByTable[t.tableName]) _fieldsByTable[t.tableName] = t.fields;
+      });
+    });
+    console.log('§AD_PARSER setManifest windows=' + nWin + ' tabs=' + nTab +
+                ' fields=' + nFld + ' v' + (m.version || '?'));
+  }
+
+  // getFields-shaped fields for a table from the manifest only (null if absent).
+  function getManifestFields(tableName) {
+    return _fieldsByTable[tableName] || null;
+  }
+
   /**
    * Init: log AD table counts.
    * @param {Object} db  sql.js database
@@ -108,7 +177,15 @@
    * @returns {Object|null} { id, name, description, windowType, tabs: [...] }
    */
   function getWindow(db, windowId) {
-    console.log('§AD_PARSER getWindow id=' + windowId);
+    // Manifest-first (curated windows) — clone so callers can't mutate the cache.
+    var mw = _winById[Number(windowId)];
+    if (mw) {
+      console.log('§AD_PARSER getWindow id=' + windowId + ' name=' + mw.name +
+                  ' tabs=' + mw.tabs.length + ' source=manifest');
+      return JSON.parse(JSON.stringify(mw));
+    }
+
+    console.log('§AD_PARSER getWindow id=' + windowId + ' source=db');
 
     var winR = db.exec(
       'SELECT AD_Window_ID, Name, Description, Help, WindowType ' +
@@ -325,6 +402,8 @@
 
   var ADParser = {
     init:                 init,
+    setManifest:          setManifest,
+    getManifestFields:    getManifestFields,
     getMenuTree:          getMenuTree,
     getWindow:            getWindow,
     getTabs:              getTabs,

--- a/viewer/ad_table_map.js
+++ b/viewer/ad_table_map.js
@@ -1,0 +1,138 @@
+// ad_table_map.js — PB bridge: every AD business table -> a 5-table slot.
+// Implementing docs/ERP.md §0 + §0.1 — Witness: PB gate §BRIDGE (scripts/test_bridge.js).
+//
+// Two responsibilities:
+//   1. slotOf(table, facts) — classify ANY AD table into one of
+//      {documents, document_lines, items, containers, journal, compiler}.
+//      OVERRIDES (the 32 residual tables, §0.1) win; else the PV heuristic
+//      (ported verbatim from test_5table_bom.js so the gate stays self-consistent).
+//   2. target(table) — for the curated hubs, the structural fk_map that tells
+//      ad_data which legacy column lands in which real column vs metadata.
+// EXTRACT, do not invent: every OVERRIDE resolves a logged unmappable edge.
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+(function () {
+  'use strict';
+
+  // ── §0.1 OVERRIDES — the 32 residuals the heuristic fallback mis-slotted ─────
+  // slot + (for settlement rows) match_type. Each comment = the edge it fixes.
+  var OVERRIDES = {
+    // sub-document headers (group lines / nodes under a parent doc; no DocStatus)
+    M_ProductionPlan:        { slot: 'documents' },   // M_ProductionLine->M_ProductionPlan = line->doc
+    PP_Order_Workflow:       { slot: 'documents' },   // PP_Order_Node->PP_Order_Workflow = doc->doc (2nd-order)
+
+    // child of a document (-> document_id) or of another line (-> source_line_id)
+    C_InvoicePaySchedule:    { slot: 'document_lines' },
+    C_OrderPaySchedule:      { slot: 'document_lines' },
+    C_OrderLandedCost:       { slot: 'document_lines' },
+    C_PaymentAllocate:       { slot: 'document_lines' },
+    C_POSPayment:            { slot: 'document_lines' },
+    M_Package:               { slot: 'document_lines' },
+    M_InOutLineConfirm:      { slot: 'document_lines' },
+    M_InOutLineMA:           { slot: 'document_lines' },
+    M_InventoryLineMA:       { slot: 'document_lines' },
+    M_MovementLineConfirm:   { slot: 'document_lines' },
+    M_MovementLineMA:        { slot: 'document_lines' },
+    M_ProductionLine:        { slot: 'document_lines' },
+    M_ProductionLineMA:      { slot: 'document_lines' },
+    PP_Cost_CollectorMA:     { slot: 'document_lines' },
+    PP_Order_BOM:            { slot: 'document_lines' },
+    PP_Order_Cost:           { slot: 'document_lines' },
+    PP_Order_Node_Asset:     { slot: 'document_lines' },
+    PP_Order_NodeNext:       { slot: 'document_lines' },
+    PP_Order_Node_Product:   { slot: 'document_lines' },
+    MP_Maintain_Task:        { slot: 'document_lines' },
+    MP_OT_Task:              { slot: 'document_lines' },
+    A_Depreciation_Exp:      { slot: 'document_lines' },
+    // 2nd-order: child lines of the document_lines rows above (-> source_line_id)
+    M_PackageLine:           { slot: 'document_lines' },   // -> M_Package
+    M_PackageMPS:            { slot: 'document_lines' },   // -> M_Package
+    PP_Order_BOMLine:        { slot: 'document_lines' },   // -> PP_Order_BOM
+    MP_Maintain_Resource:    { slot: 'document_lines' },   // -> MP_Maintain_Task
+    MP_OT_Resource:          { slot: 'document_lines' },   // -> MP_OT_Task
+    C_OrderLandedCostAllocation: { slot: 'document_lines' }, // -> C_OrderLandedCost
+
+    // §18.2 settlement / three-way match — a row LINKS >=2 lines (an edge, not content)
+    M_MatchInv:              { slot: 'document_lines', match_type: 'MATCH_INV' },
+    M_MatchPO:               { slot: 'document_lines', match_type: 'MATCH_PO' },
+    C_LandedCost:            { slot: 'document_lines', match_type: 'LANDED_COST' },
+    C_LandedCostAllocation:  { slot: 'document_lines', match_type: 'LANDED_COST' },
+
+    // master / link rows the /Project|Year|Period/ containers regex over-grabbed
+    R_IssueProject:          { slot: 'items' },
+    HR_Year:                 { slot: 'items' },
+    HR_Period:               { slot: 'items' }   // HR_Period->HR_Year = items->items (2nd-order)
+  };
+
+  // ── PV heuristic (ported verbatim from test_5table_bom.js slotOf) ────────────
+  // facts = { isDoc: {TableName:true}, contain: {'child>parent':true} }
+  function heuristic(t, facts) {
+    if (/^AD_/.test(t) || /_Trl$/.test(t) || /^RV_/.test(t)) return 'compiler';
+    if (/^Fact_Acct|^GL_Journal/.test(t)) return 'journal';
+    if (facts.isDoc[t]) return 'documents';
+    if (/(Line|Tax|Trx|Allocation(Line)?)$/.test(t) &&
+        Object.keys(facts.contain).some(function (k) {
+          return k.indexOf(t + '>') === 0 && facts.isDoc[k.split('>')[1]];
+        }))
+      return 'document_lines';
+    if (/(Warehouse|Locator|Project|Campaign|Region|Country|^AD_Org|^AD_Client|^M_Warehouse|Period|Year|Calendar)/.test(t))
+      return 'containers';
+    return 'items';
+  }
+
+  // slotOf: OVERRIDES win; else heuristic. `facts` optional — without it, only
+  // OVERRIDES + name-rule slots resolve (enough for the curated runtime tables).
+  function slotOf(t, facts) {
+    if (OVERRIDES[t]) return OVERRIDES[t].slot;
+    if (HUBS[t]) return HUBS[t].slot;
+    return heuristic(t, facts || { isDoc: {}, contain: {} });
+  }
+
+  function matchTypeOf(t) {
+    return (OVERRIDES[t] && OVERRIDES[t].match_type) || null;
+  }
+
+  // ── Curated-hub fk_map — structural columns vs metadata (extract-derived) ────
+  // fk_map values: a real 5-table column name, or omitted => metadata[ColumnName].
+  // The key column (<Table>_ID) defaults to 'id'; DocStatus defaults to 'doc_status'
+  // for document-slot tables. Only NON-default routings are listed.
+  var HUBS = {
+    C_Order:       { slot: 'documents',      docType: 'C_Order',     fk_map: {} },
+    C_Invoice:     { slot: 'documents',      docType: 'C_Invoice',   fk_map: { C_Order_ID: 'source_id' } },
+    C_Payment:     { slot: 'documents',      docType: 'C_Payment',   fk_map: { C_Invoice_ID: 'source_id' } },
+    M_InOut:       { slot: 'documents',      docType: 'M_InOut',     fk_map: { C_Order_ID: 'source_id' } },
+    C_OrderLine:   { slot: 'document_lines', docType: 'C_OrderLine', fk_map: { C_Order_ID: 'document_id', Line: 'line_no' } },
+    C_InvoiceLine: { slot: 'document_lines', docType: 'C_InvoiceLine', fk_map: { C_Invoice_ID: 'document_id', C_OrderLine_ID: 'source_line_id', Line: 'line_no' } },
+    M_InOutLine:   { slot: 'document_lines', docType: 'M_InOutLine', fk_map: { M_InOut_ID: 'document_id', C_OrderLine_ID: 'source_line_id', Line: 'line_no' } },
+    C_BPartner:    { slot: 'items',          docType: 'C_BPartner',  fk_map: {} },
+    M_Product:     { slot: 'items',          docType: 'M_Product',   fk_map: { M_Product_Category_ID: 'parent_id' } },
+    // settlement hub with explicit line refs: M_InOutLine is the structural lineage,
+    // C_InvoiceLine the counterpart kept in metadata (§0.1 rule b)
+    M_MatchInv:    { slot: 'document_lines', docType: 'M_MatchInv', match_type: 'MATCH_INV',
+                     fk_map: { M_InOutLine_ID: 'source_line_id' } }
+  };
+
+  // target(table): full routing spec for ad_data. Falls back to a generic
+  // documents/items/line spec for any non-curated table.
+  function target(table) {
+    if (HUBS[table]) {
+      var h = HUBS[table];
+      return { slot: h.slot, docType: h.docType || table, match_type: h.match_type || matchTypeOf(table), fk_map: h.fk_map || {} };
+    }
+    var slot = slotOf(table);
+    return { slot: slot, docType: table, match_type: matchTypeOf(table), fk_map: {} };
+  }
+
+  var ADTableMap = {
+    OVERRIDES:  OVERRIDES,
+    HUBS:       HUBS,
+    slotOf:     slotOf,
+    matchTypeOf: matchTypeOf,
+    target:     target
+  };
+
+  if (typeof window !== 'undefined') window.ADTableMap = ADTableMap;
+  if (typeof module !== 'undefined' && module.exports) module.exports = ADTableMap;
+
+  if (typeof console !== 'undefined') console.log('§ADTABLEMAP_LOADED overrides=' + Object.keys(OVERRIDES).length + ' hubs=' + Object.keys(HUBS).length);
+})();

--- a/viewer/ad_ui.js
+++ b/viewer/ad_ui.js
@@ -1365,6 +1365,16 @@
     16:'datetime',17:'list',19:'tableDirect',20:'table',22:'number',28:'button',
     29:'quantity',30:'search',38:'yesno'};
   function _getFieldsForTable(tableName) {
+    // Manifest-first (curated windows) — same fields the DB path would return,
+    // mapped through ADParser.REF_TYPES. Falls through to the DB query below.
+    if (typeof ADParser !== 'undefined' && ADParser.getManifestFields) {
+      var mfields = ADParser.getManifestFields(tableName);
+      if (mfields && mfields.length) {
+        console.log('§FIELDS table=' + tableName + ' count=' + mfields.length +
+                    ' source=manifest');
+        return mfields;
+      }
+    }
     try {
       var r = _db.exec(
         "SELECT DISTINCT f.Name, c.ColumnName, f.SeqNo, " +
@@ -3330,6 +3340,11 @@
     _db = db;
     _dbReady = true;
     ADParser.init(db);
+
+    // Wire the compiled manifest (curated windows render from manifest, not DB).
+    if (typeof window !== 'undefined' && window.AD_MANIFEST && ADParser.setManifest) {
+      ADParser.setManifest(window.AD_MANIFEST);
+    }
 
     // Upgrade graph with real DB — NO destroy/rebuild, just enable drill
     if (typeof ADGraph !== 'undefined' && ADGraph.graphHydrate) {

--- a/viewer/erp.html
+++ b/viewer/erp.html
@@ -55,6 +55,15 @@
   ::-webkit-scrollbar { width: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
+  /* Companion Glassbowl views (served from BIMCompiler GitHub Pages) */
+  #gbviews { position: fixed; top: 9px; right: 12px; z-index: 11; display: flex; gap: 6px; }
+  #gbviews a {
+    font-size: 12px; font-weight: 600; color: #cdd6e4; text-decoration: none;
+    background: rgba(40,44,58,0.82); border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 14px; padding: 6px 11px; min-height: 0; line-height: 1;
+    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+  }
+  #gbviews a:hover { border-color: #56d6e0; color: #56d6e0; }
 </style>
 </head>
 <body>
@@ -63,6 +72,14 @@
   <div class="spinner"></div>
   <div>Loading ERP OOTB&hellip;</div>
   <div id="load-status" style="margin-top:8px;font-size:11px;color:#555;"></div>
+</div>
+
+<!-- Companion Glassbowl views — the same model, seen two ways (read-only) -->
+<div id="gbviews">
+  <a href="https://red1oon.github.io/BIMCompiler/glassbowl.html" target="_blank" rel="noopener"
+     title="Glassbowl — the engine mapped from its own data (FK spines, trace, dossier)">🫧 Glassbowl</a>
+  <a href="https://red1oon.github.io/BIMCompiler/glassbowl_gravity.html" target="_blank" rel="noopener"
+     title="Glassbowl Gravity — pivot &amp; weigh the model (live GROUP BY, AD↔GW depth dial)">✦ Gravity</a>
 </div>
 
 <div id="breadcrumb"></div>
@@ -78,6 +95,12 @@ var _shellReady = false;
 (function () {
   'use strict';
   var _tBoot = performance.now();
+
+  // Compiled manifest — structure for the 7 curated windows (parallel, non-blocking).
+  fetch('manifest.json?v=22').then(function(r) { return r.json(); }).then(function(mf) {
+    window.AD_MANIFEST = mf;
+    console.log('§BENCH manifest loaded windows=' + Object.keys(mf.windows || {}).length);
+  }).catch(function(e) { console.log('§BENCH manifest fetch failed: ' + e.message); });
 
   fetch('initbubble.json?v=22').then(function(r) { return r.json(); }).then(function(data) {
     window.INIT_BUBBLES = data;
@@ -147,6 +170,9 @@ var _shellReady = false;
     'ad_data.js' + V,
     'ad_charts.js' + V,
     'erp_search.js' + V,
+    'erp_signer.js' + V,    // A2 W-SIGN — edge ECDSA-P256 signer (scripts/test_kernel_sign.js)
+    'erp_replay.js' + V,    // A3 W-OWNER/CAS — guarded ERP replay (scripts/test_kernel_owner.js)
+    'erp_persist.js' + V,   // A4 W-PERSIST — durable local + signed-snapshot hook (scripts/test_kernel_persist.js)
     'qrcode.min.js' + V
   ];
 
@@ -186,6 +212,14 @@ var _shellReady = false;
     await Promise.all([wasmPromise, modulesPromise]);
     _bench.parallel_load = Math.round(performance.now() - _t0);
     console.log('§BENCH parallel_load=' + _bench.parallel_load + 'ms (wasm+modules)');
+
+    // ── Phase A wiring (modules now loaded) — edge concerns, proven in scripts/test_kernel_*.js;
+    //    see prompts/ERP_PHASE_A_SETTLE.md. A2: install the edge signer on the live W-CHAIN.
+    //    A4: request durable storage. Both are best-effort + non-blocking (never fail hydrate).
+    if (window.ErpSigner && window.KernelOps) {
+      ErpSigner.installSigner(window.KernelOps).catch(function (e) { console.warn('§SIGN install error', e); });
+    }
+    if (window.ErpPersist) { ErpPersist.requestPersist(); }   // §PERSIST persisted=<granted>
 
     // ── Init SQL engine ─────────────────────────────────────────────
     _t0 = performance.now();
@@ -287,6 +321,9 @@ var _shellReady = false;
     console.log('§BENCH db_fetch=' + (_bench.db_fetch || 0) + 'ms source=' + (_bench.db_source || 'existing') +
                 ' size=' + (_bench.db_size || 0) + 'KB');
 
+    // A5: expose the live DB so the Verify-ledger control can read the kernel op-log (window.KernelOps).
+    window.__erpDb = db;
+
     // ── Wait for Phase 1 shell, then hydrate silently ────────────────
     function _waitAndHydrate() {
       if (typeof _shellReady !== 'undefined' && _shellReady) {
@@ -325,7 +362,7 @@ var _shellReady = false;
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=508')
+  navigator.serviceWorker.register('sw.js?v=558')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }
@@ -368,6 +405,46 @@ if('serviceWorker' in navigator){
   window.addEventListener('offline', function () { _offlineBadge(true); });
   window.addEventListener('online', function () { _offlineBadge(false); _onlineRestore(); });
   if (!navigator.onLine) _offlineBadge(true);
+})();
+</script>
+<script>
+// ── A5 Verify ledger — surface KernelOps.verifyChain() (W-CHAIN/W-SIGN). Reads the live kernel op-log
+//    on window.__erpDb; shows "Ledger OK — N ops" or "Tamper at op N". Logic proven in
+//    scripts/test_kernel_chain.js + test_kernel_sign.js. See prompts/ERP_PHASE_A_SETTLE.md §A5.
+(function () {
+  'use strict';
+  function _toast(msg, good) {
+    var t = document.createElement('div');
+    t.style.cssText = 'position:fixed;top:60px;left:50%;transform:translateX(-50%);z-index:9999;' +
+      'padding:10px 24px;border-radius:8px;font-size:13px;font-family:system-ui,sans-serif;transition:opacity .5s;' +
+      'background:' + (good ? 'rgba(39,174,96,0.92)' : 'rgba(200,30,30,0.92)') + ';color:#fff;pointer-events:none;';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function () { t.style.opacity = '0'; }, 3000);
+    setTimeout(function () { if (t.parentNode) t.remove(); }, 3500);
+  }
+  function verifyLedger() {
+    var db = window.__erpDb;
+    if (!db || !window.KernelOps || !KernelOps.verifyChain) { _toast('Ledger not ready', false); return; }
+    return KernelOps.verifyChain(db).then(function (r) {
+      console.log('§VERIFY_LEDGER ok=' + r.ok + (r.ok ? ' len=' + r.len : ' brokeAt=' + r.brokeAt + ' why=' + r.why));
+      _toast(r.ok ? ('Ledger OK — ' + r.len + ' ops sealed') : ('Tamper at op ' + r.brokeAt + ' (' + r.why + ')'), r.ok);
+      return r;
+    }).catch(function (e) { console.warn('§VERIFY_LEDGER error', e); _toast('Verify error', false); });
+  }
+  window.ErpVerifyLedger = verifyLedger;
+  // Unobtrusive control — bottom-left, clear of #gbviews (top-right) and the offline badge (top).
+  var b = document.createElement('button');
+  b.id = 'verify-ledger-pill';
+  b.type = 'button';
+  b.textContent = '⛓ Verify ledger';
+  b.style.cssText = 'position:fixed;bottom:10px;left:12px;z-index:9999;min-height:0;' +
+    'font-size:12px;font-weight:600;color:#cdd6e4;background:rgba(40,44,58,0.82);' +
+    'border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:6px 11px;line-height:1;' +
+    'backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);cursor:pointer;';
+  b.addEventListener('click', verifyLedger);
+  document.body.appendChild(b);
+  console.log('§VERIFY_LEDGER control mounted');
 })();
 </script>
 </body>

--- a/viewer/erp_persist.js
+++ b/viewer/erp_persist.js
@@ -1,0 +1,67 @@
+// erp_persist.js — W-PERSIST (A4): durable-local + the recoverable-signed-snapshot hook. Spec:
+// scripts/poc_persist.js + ERP.md §9-A, §5.2b. Doctrine: "secure the FACT, not the container" — the
+// local DB is DISPOSABLE (export→import round-trips byte-for-byte), and the recoverable log is a
+// SIGNED full snapshot (e.g. emailed), chosen by signed seq (not arrival order), forgery-rejecting.
+// Browser-pure (window-only, like kernel_ops.js). The full recovery flow is proven in poc_persist.js;
+// here the snapshot EMIT is a stub hook (the transport/sink is the caller's choice).
+(function () {
+  'use strict';
+
+  // requestPersist — ask the browser to make storage durable (survive eviction). erp.html never called
+  // this before (only scene.js did). Logs §PERSIST persisted=<granted|unsupported|error>.
+  function requestPersist() {
+    if (typeof navigator === 'undefined' || !navigator.storage || !navigator.storage.persist) {
+      console.log('§PERSIST persisted=unsupported');
+      return Promise.resolve(false);
+    }
+    return navigator.storage.persist().then(function (granted) {
+      console.log('§PERSIST persisted=' + granted);
+      return granted;
+    }).catch(function () { console.log('§PERSIST persisted=error'); return false; });
+  }
+
+  // ── disposable container: export → (wipe) → import round-trips ──
+  function exportBytes(db) { return db.export(); }                 // what goes to IndexedDB / a file
+  function importBytes(SQL, bytes) { return new SQL.Database(bytes); }
+
+  // roundTrip — export the live DB, drop it, re-import; logs sizes. The caller compares projection
+  // hashes (the local copy is disposable iff pre==post). Returns the re-imported DB.
+  function roundTrip(SQL, db) {
+    var bytes = exportBytes(db);
+    var restored = importBytes(SQL, bytes);
+    console.log('§PERSIST roundtrip size=' + (bytes.length / 1024).toFixed(1) + 'KB reimported=' + (!!restored));
+    return restored;
+  }
+
+  // ── the recoverable signed snapshot (the email hook) ──
+  // snapshotPayload(rows, seq) — the durable, signable state payload. recover() picks the highest-seq
+  // VALID snapshot (poc_persist.js proves the full seq-not-arrival, single-snapshot, forgery-rejecting
+  // recovery). Here emit is a STUB: sign the payload and hand {seq,snap,hash,sig} to a sink.
+  function _sha256Hex(str) {
+    if (typeof crypto !== 'undefined' && crypto.subtle) {
+      return crypto.subtle.digest('SHA-256', new TextEncoder().encode(str)).then(function (buf) {
+        return Array.from(new Uint8Array(buf)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+      });
+    }
+    return Promise.reject(new Error('crypto.subtle unavailable'));
+  }
+
+  // emitSnapshot(snapJson, seq, signer, sink) — STUB recovery hook. signer = ErpSigner.makeSigner(kp)
+  // (or any {sign}); sink defaults to a §-log line. Returns the signed envelope {seq,snap,hash,sig}.
+  function emitSnapshot(snapJson, seq, signer, sink) {
+    return _sha256Hex(seq + '|' + snapJson).then(function (hash) {
+      var signP = (signer && signer.sign) ? signer.sign(hash) : Promise.resolve(null);
+      return signP.then(function (sig) {
+        var env = { seq: seq, snap: snapJson, hash: hash, sig: sig };
+        if (typeof sink === 'function') sink(env);
+        else console.log('§PERSIST snapshot emitted seq=' + seq + ' hash=' + hash.slice(0, 12) + '… signed=' + (!!sig));
+        return env;
+      });
+    });
+  }
+
+  var API = { requestPersist: requestPersist, exportBytes: exportBytes, importBytes: importBytes,
+              roundTrip: roundTrip, emitSnapshot: emitSnapshot };
+  if (typeof window !== 'undefined') window.ErpPersist = API;   // browser-pure (window-only, no `module` global — keeps no-undef CI gate green)
+  console.log('§PERSIST_LOADED erp_persist.js (W-PERSIST durable + signed-snapshot hook)');
+})();

--- a/viewer/erp_replay.js
+++ b/viewer/erp_replay.js
@@ -1,0 +1,81 @@
+// erp_replay.js — W-OWNER + CAS (A3): the GUARDED replay path for the ERP `documents` projection.
+// Spec: scripts/poc_distributed.js (G-SINGLE-WRITER owner-gate + set-if-unset CAS) + ERP.md §9-C/D/E,
+// §4 (the guard set). This lives in the ERP layer — NOT in the BIM-shared kernel_ops.js — because
+// owner/status/claimed_by are ERP-projection concerns (separation of concern). It READS the kernel
+// op-log (kernel_ops, via KernelOps.replayOps) and folds it into the projection under the guards.
+//
+// Determinism (§7) / identity (§0.21, A1): actor, owner, op_uuid and timestamp are recorded INPUTS.
+// The merge orders by (timestamp, op_uuid) — op_uuid makes the cross-device union clash-free; the
+// owner-gate READS the recorded owner/actor, it never recomputes identity.
+(function () {
+  'use strict';
+  var PROJ =
+    'CREATE TABLE IF NOT EXISTS documents (' +
+    ' uuid TEXT PRIMARY KEY, doc_type TEXT, owner TEXT, status TEXT, claimed_by TEXT, amount REAL)';
+
+  function initProjection(db) { db.run(PROJ); }
+
+  // mergeLogs(logA, logB, …) — union device op-logs into ONE deterministic total order: (timestamp,
+  // op_uuid). op_uuid (A1) makes the union clash-free; both keys are recorded inputs → holder-irrelevant.
+  function mergeLogs() {
+    var all = [];
+    for (var i = 0; i < arguments.length; i++) all = all.concat(arguments[i]);
+    return all.slice().sort(function (a, b) {
+      return a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1
+           : (a.op_uuid < b.op_uuid ? -1 : a.op_uuid > b.op_uuid ? 1 : 0);
+    });
+  }
+
+  // normalize — flatten a kernel_ops row {op_uuid,timestamp,op_type,parameters} (parameters may be a
+  // JSON string OR an already-parsed object, as KernelOps.replayOps returns) into a flat ERP op.
+  function normalize(row) {
+    var p = (typeof row.parameters === 'string') ? JSON.parse(row.parameters) : (row.parameters || {});
+    return { op_uuid: row.op_uuid, timestamp: row.timestamp, op_type: row.op_type,
+             actor: p.actor, target: p.target, doc_type: p.doc_type, owner: p.owner, amount: p.amount };
+  }
+
+  // replayGuarded — fold the ordered ERP ops into `documents` under the guards. Mirrors
+  // poc_distributed.replay(). Returns { applied, rejected:[{op,why}] }.
+  //   CREATE   — INSERT OR IGNORE (idempotent; first writer of a uuid sets its owner)
+  //   ALLOCATE — owner-gate (G-SINGLE-WRITER): only actor === documents.owner may allocate
+  //   CLAIM    — CAS set-if-unset: first claim in total order wins; later claims rejected (no value lost)
+  //   (any non-ERP op types — BIM/AD ops sharing the log — are simply not projected here)
+  function replayGuarded(db, orderedOps) {
+    initProjection(db);
+    var applied = 0, rejected = [];
+    orderedOps.forEach(function (op) {
+      if (op.op_type === 'CREATE') {
+        db.run('INSERT OR IGNORE INTO documents (uuid,doc_type,owner,status,amount) VALUES (?,?,?,?,?)',
+               [op.target, op.doc_type, op.owner, 'drafted', op.amount || 0]);
+        applied++;
+      } else if (op.op_type === 'ALLOCATE') {
+        var o = db.exec('SELECT owner,status FROM documents WHERE uuid=?', [op.target]);
+        var row = o.length && o[0].values.length ? o[0].values[0] : null;
+        if (!row) { rejected.push({ op: op, why: 'no such doc' }); return; }
+        if (row[0] !== op.actor) { rejected.push({ op: op, why: 'non-owner (' + op.actor + '≠' + row[0] + ')' }); return; }
+        db.run("UPDATE documents SET status='allocated' WHERE uuid=?", [op.target]);
+        applied++;
+      } else if (op.op_type === 'CLAIM') {
+        var c = db.exec('SELECT claimed_by FROM documents WHERE uuid=?', [op.target]);
+        var cur = c.length && c[0].values.length ? c[0].values[0][0] : null;
+        if (cur) { rejected.push({ op: op, why: 'already claimed by ' + cur }); return; }
+        db.run('UPDATE documents SET claimed_by=? WHERE uuid=?', [op.actor, op.target]);
+        applied++;
+      }
+    });
+    console.log('§OWNER replay applied=' + applied + ' rejected=' + rejected.length +
+                (rejected.length ? ' [' + rejected.map(function (r) { return r.op.op_type + ':' + r.why; }).join('; ') + ']' : ''));
+    return { applied: applied, rejected: rejected };
+  }
+
+  // projectionRows — the sorted projection, for a holder-irrelevant equality hash (caller hashes).
+  function projectionRows(db) {
+    var r = db.exec('SELECT uuid,doc_type,owner,status,claimed_by,amount FROM documents ORDER BY uuid');
+    return r.length ? r[0].values : [];
+  }
+
+  var API = { initProjection: initProjection, mergeLogs: mergeLogs, normalize: normalize,
+              replayGuarded: replayGuarded, projectionRows: projectionRows };
+  if (typeof window !== 'undefined') window.ErpReplay = API;   // browser-pure (window-only, like kernel_ops.js — no `module` global, keeps the no-undef CI gate green)
+  console.log('§OWNER_LOADED erp_replay.js (owner-gate + CAS guarded replay)');
+})();

--- a/viewer/erp_signer.js
+++ b/viewer/erp_signer.js
@@ -1,0 +1,89 @@
+// erp_signer.js — W-SIGN (A2): the edge signer that turns the live W-CHAIN from tamper-EVIDENT
+// into un-FORGEABLE. Spec: scripts/poc_sign.js (ECDSA P-256 / SHA-256, present-but-not-forge) +
+// docs/ERP.md §0.20 / §9-B. The kernel (kernel_ops.js) only ever sees {sign, verify}; the private
+// key custody lives HERE, at the edge — a NON-EXTRACTABLE CryptoKey in IndexedDB, never serialised.
+//
+// Layering (matches poc_sign §CASE4): the signature attests OVER op_hash and is NOT part of the
+// hash, so the deterministic chain stays byte-identical across devices while sigs are per-issuer.
+// Keys are edge-minted INPUTS (§7) — one keypair per device, minted once, reused after reload.
+(function () {
+  'use strict';
+  var subtle = (typeof crypto !== 'undefined' && crypto.subtle) ? crypto.subtle : null;
+  var GEN_ALG  = { name: 'ECDSA', namedCurve: 'P-256' };
+  var SIGN_ALG = { name: 'ECDSA', hash: 'SHA-256' };
+  var DB_NAME = 'bim_erp_signer', STORE = 'keys', KEY_ID = 'edge';
+
+  // We sign over the op_hash HEX STRING's bytes (TextEncoder), mirroring poc_sign's
+  // Buffer.from(opHash) — ECDSA then SHA-256-hashes that input internally. sealChain hands us the
+  // hex op_hash; verifyChain hands us (hex, sigHex). Keep both ends identical.
+  function _bytes(hex) { return new TextEncoder().encode(hex); }
+  function _hex(buf) { return Array.from(new Uint8Array(buf)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join(''); }
+  function _unhex(h) { var a = new Uint8Array(h.length / 2); for (var i = 0; i < a.length; i++) a[i] = parseInt(h.substr(i * 2, 2), 16); return a; }
+
+  // mintKeypair — fresh edge keypair. extractable=false → the PRIVATE key is non-extractable
+  // (custody never leaves the device); per WebCrypto the generated PUBLIC key is still exportable
+  // (a shareable verifier). Returns a CryptoKeyPair.
+  function mintKeypair() {
+    if (!subtle) return Promise.reject(new Error('crypto.subtle unavailable — cannot mint signer key'));
+    return subtle.generateKey(GEN_ALG, false, ['sign', 'verify']);
+  }
+
+  // makeSigner — bind a keypair (or any {privateKey, publicKey}) to the kernel's signer contract.
+  // sign(hashHex) -> Promise<sigHex> ; verify(hashHex, sigHex) -> Promise<bool>.
+  function makeSigner(keyPair) {
+    return {
+      sign: function (hashHex) {
+        return subtle.sign(SIGN_ALG, keyPair.privateKey, _bytes(hashHex)).then(_hex);
+      },
+      verify: function (hashHex, sigHex) {
+        if (!sigHex) return Promise.resolve(false);
+        return subtle.verify(SIGN_ALG, keyPair.publicKey, _unhex(sigHex), _bytes(hashHex))
+                     .catch(function () { return false; });
+      }
+    };
+  }
+
+  // loadOrMint — edge custody: return the stored keypair, or mint+persist one. The CryptoKeyPair is
+  // stored by structured-clone (IDB stores CryptoKey objects natively); the non-extractable private
+  // key survives reload still unusable for export — only sign/verify. Mints exactly once per device.
+  function loadOrMint(dbName) {
+    dbName = dbName || DB_NAME;
+    return new Promise(function (resolve, reject) {
+      var req = indexedDB.open(dbName, 1);
+      req.onupgradeneeded = function () { req.result.createObjectStore(STORE); };
+      req.onerror = function () { reject(req.error || new Error('idb open failed')); };
+      req.onsuccess = function () {
+        var db = req.result;
+        var get = db.transaction(STORE, 'readonly').objectStore(STORE).get(KEY_ID);
+        get.onsuccess = function () {
+          if (get.result) { resolve(get.result); return; }   // {publicKey, privateKey}
+          mintKeypair().then(function (kp) {
+            var pair = { publicKey: kp.publicKey, privateKey: kp.privateKey };
+            var wtx = db.transaction(STORE, 'readwrite');
+            wtx.objectStore(STORE).put(pair, KEY_ID);
+            wtx.oncomplete = function () { resolve(kp); };
+            wtx.onerror = function () { reject(wtx.error || new Error('idb put failed')); };
+          }).catch(reject);
+        };
+        get.onerror = function () { reject(get.error || new Error('idb get failed')); };
+      };
+    });
+  }
+
+  // installSigner — the one call the page makes on load: load-or-mint the edge key and hand the
+  // kernel its signer. After this, sealChain signs each op_hash and verifyChain checks it.
+  function installSigner(KernelOps, opts) {
+    opts = opts || {};
+    return loadOrMint(opts.dbName).then(function (kp) {
+      KernelOps.setSigner(makeSigner(kp));
+      return subtle.exportKey('spki', kp.publicKey).then(function (pub) {
+        console.log('§SIGN installed alg=ECDSA-P256 pubkey=' + _hex(pub).slice(0, 16) + '… custody=idb-nonextractable');
+        return kp;
+      }).catch(function () { console.log('§SIGN installed alg=ECDSA-P256 custody=idb-nonextractable'); return kp; });
+    });
+  }
+
+  var API = { mintKeypair: mintKeypair, makeSigner: makeSigner, loadOrMint: loadOrMint, installSigner: installSigner };
+  if (typeof window !== 'undefined') window.ErpSigner = API;   // browser-pure (window-only, like kernel_ops.js — no `module` global, keeps the no-undef CI gate green)
+  console.log('§SIGN_LOADED erp_signer.js (W-SIGN edge keypair, ECDSA P-256)');
+})();

--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -12,7 +12,10 @@
     '  parameters TEXT NOT NULL,' +
     '  input_guids TEXT,' +
     '  output_guid TEXT,' +
-    '  undone INTEGER DEFAULT 0' +
+    '  undone INTEGER DEFAULT 0,' +
+    '  prev_hash TEXT,' +   // W-CHAIN: tip this op chains onto (NULL until sealed)
+    '  op_hash TEXT,' +     // W-CHAIN: SHA-256(prev_hash | canonical(op))
+    '  sig TEXT' +          // W-SIGN: edge signature over op_hash (NULL unless a signer is set)
     ')';
   var IDX_TYPE_SQL =
     'CREATE INDEX IF NOT EXISTS idx_kernel_ops_type ON kernel_ops(op_type)';
@@ -30,6 +33,10 @@
       // §2.3: add user_tag column (idempotent — ALTER fails silently if exists)
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN user_tag TEXT DEFAULT 'local'"); }
       catch (ignore) { /* column already exists */ }
+      // W-CHAIN/W-SIGN: chain + signature columns on pre-existing DBs (idempotent)
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN prev_hash TEXT"); } catch (ignore) {}
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN op_hash TEXT"); }  catch (ignore) {}
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN sig TEXT"); }      catch (ignore) {}
       _tableCreated = true;
     } catch (e) {
       console.log('§KERNEL_OP ensureTable ERROR: ' + e.message);
@@ -63,24 +70,97 @@
     return opId;
   }
 
-  // Debounced IDB write — avoids hammering IndexedDB on rapid ops (e.g. drag)
+  // Debounced IDB write — avoids hammering IndexedDB on rapid ops (e.g. drag).
+  // The at-rest copy is hash-chain SEALED first (W-CHAIN) so a persisted log is tamper-evident.
+  // Sealing happens HERE (the persistence seam, business-time) — never on the hot commit path,
+  // so the 0ms UI is untouched. See docs/DistributedERP.md §0 (the two-domain split).
   var _persistTimer = null;
   function _persistToIdb(db) {
     clearTimeout(_persistTimer);
     _persistTimer = setTimeout(function() {
-      try {
-        var dbUrl = window.APP && APP.DB_URL;
-        if (!dbUrl) return;
-        var buf = db.export().buffer;
-        var req = indexedDB.open('bim_ootb_cache', 1);
-        req.onupgradeneeded = function() { req.result.createObjectStore('dbs'); };
-        req.onsuccess = function() {
-          var tx = req.result.transaction('dbs', 'readwrite');
-          tx.objectStore('dbs').put(buf, dbUrl);
-          console.log('§KRN_PERSIST url=' + dbUrl + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB');
-        };
-      } catch(e) { console.warn('§KRN_PERSIST_ERR', e); }
+      sealChain(db).then(function() {
+        try {
+          var dbUrl = window.APP && APP.DB_URL;
+          if (!dbUrl) return;
+          var buf = db.export().buffer;
+          var req = indexedDB.open('bim_ootb_cache', 1);
+          req.onupgradeneeded = function() { req.result.createObjectStore('dbs'); };
+          req.onsuccess = function() {
+            var tx = req.result.transaction('dbs', 'readwrite');
+            tx.objectStore('dbs').put(buf, dbUrl);
+            console.log('§KRN_PERSIST url=' + dbUrl + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB');
+          };
+        } catch(e) { console.warn('§KRN_PERSIST_ERR', e); }
+      }).catch(function(e) { console.warn('§KRN_SEAL_ERR', e); });
     }, 2000);
+  }
+
+  // ── W-CHAIN / W-SIGN — tamper-evident, optionally-signed op-log ──────────────
+  // Proven in scripts/poc_chain.js (W-CHAIN) + scripts/poc_sign.js (W-SIGN). The hash chain
+  // is DETERMINISTIC (integrity + order); the signature attests OVER op_hash (authenticity) and
+  // is NOT part of the hash, so the chain stays byte-identical across devices while sigs vary.
+  var GENESIS = '0'.repeat(64);
+  var _signer = null;   // optional { sign: async(hashHex)->sigHex, verify: async(hashHex,sigHex)->bool }
+
+  // Set an edge signer to turn on W-SIGN. Key custody lives at the edge (the device/merchant),
+  // never in this module. Leave unset for W-CHAIN-only (tamper-evidence without signatures).
+  function setSigner(signer) { _signer = signer; }
+
+  function _canonical(op) {   // stable serialisation — every mutating field, fixed order
+    return op.id + '|' + op.timestamp + '|' + op.op_type + '|' +
+           (op.parameters || '') + '|' + (op.input_guids || '') + '|' + (op.output_guid || '');
+  }
+
+  async function _sha256(str) {
+    if (typeof crypto !== 'undefined' && crypto.subtle) {
+      var buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+      return Array.from(new Uint8Array(buf)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+    }
+    throw new Error('crypto.subtle unavailable — cannot seal chain');
+  }
+
+  // sealChain — (re)compute prev_hash/op_hash for the WHOLE log in id order, idempotently.
+  // Full recompute (not incremental) because compact() may delete/collapse ops; re-sealing after
+  // compaction keeps the chain correct over the current log. Signs ops lacking a sig if a signer is set.
+  async function sealChain(db) {
+    ensureTable(db);
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig FROM kernel_ops ORDER BY id');
+    if (!r.length) return { sealed: 0, tip: GENESIS };
+    var rows = r[0].values, prev = GENESIS, sealed = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+      var sig = rows[i][6];
+      var h = await _sha256(prev + '|' + _canonical(op));
+      if (_signer && !sig) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      db.run('UPDATE kernel_ops SET prev_hash=?, op_hash=?, sig=? WHERE id=?', [prev, h, sig || null, op.id]);
+      prev = h; sealed++;
+    }
+    console.log('§KRN_CHAIN sealed=' + sealed + ' tip=' + prev.slice(0, 12) + '…' + (_signer ? ' signed' : ''));
+    return { sealed: sealed, tip: prev };
+  }
+
+  // verifyChain — walk the ordered log, recompute each op_hash, check the prev_hash link, and (if a
+  // signer is set) the signature. Returns {ok, len, tip} or {ok:false, brokeAt, why} — proving
+  // "tamper at op N" exactly as scripts/poc_chain.js does.
+  async function verifyChain(db) {
+    ensureTable(db);
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig FROM kernel_ops ORDER BY id');
+    if (!r.length) return { ok: true, len: 0, tip: GENESIS };
+    var rows = r[0].values, prev = GENESIS;
+    for (var i = 0; i < rows.length; i++) {
+      var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+      var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8];
+      if (storedHash == null) { console.log('§KRN_CHAIN verify unsealed at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'unsealed' }; }
+      if (storedPrev !== prev) return { ok: false, brokeAt: op.id, why: 'prev_hash link' };
+      var h = await _sha256(prev + '|' + _canonical(op));
+      if (h !== storedHash) { console.log('§KRN_CHAIN tamper at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'payload altered' }; }
+      if (_signer && !(await _signer.verify(storedHash, sig))) return { ok: false, brokeAt: op.id, why: 'signature' };
+      prev = h;
+    }
+    console.log('§KRN_CHAIN verify OK len=' + rows.length + ' tip=' + prev.slice(0, 12) + '…');
+    return { ok: true, len: rows.length, tip: prev };
   }
 
   /**
@@ -220,8 +300,11 @@
     redoOp:       redoOp,
     replayOps:    replayOps,
     compact:      compact,
-    sessionStart: sessionStart
+    sessionStart: sessionStart,
+    sealChain:    sealChain,     // W-CHAIN: (re)seal the log's hash chain (async)
+    verifyChain:  verifyChain,   // W-CHAIN/W-SIGN: prove tamper-evidence (async)
+    setSigner:    setSigner      // W-SIGN: install an edge signer (opt-in)
   };
 
-  console.log('§KERNEL_OPS_LOADED v4');
+  console.log('§KERNEL_OPS_LOADED v5 (W-CHAIN/W-SIGN)');
 })();

--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -6,7 +6,8 @@
 
   var TABLE_SQL =
     'CREATE TABLE IF NOT EXISTS kernel_ops (' +
-    '  id INTEGER PRIMARY KEY,' +
+    '  id INTEGER PRIMARY KEY,' +       // local total-order — W-CHAIN seals/verifies in id order
+    '  op_uuid TEXT,' +                 // G-IDENTITY (§0.21): edge-minted cross-device id; NOT the PK
     '  timestamp INTEGER NOT NULL,' +
     '  op_type TEXT NOT NULL,' +
     '  parameters TEXT NOT NULL,' +
@@ -33,6 +34,8 @@
       // §2.3: add user_tag column (idempotent — ALTER fails silently if exists)
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN user_tag TEXT DEFAULT 'local'"); }
       catch (ignore) { /* column already exists */ }
+      // G-IDENTITY (§0.21): op_uuid identity column on pre-existing DBs (idempotent)
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN op_uuid TEXT"); } catch (ignore) {}
       // W-CHAIN/W-SIGN: chain + signature columns on pre-existing DBs (idempotent)
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN prev_hash TEXT"); } catch (ignore) {}
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN op_hash TEXT"); }  catch (ignore) {}
@@ -52,19 +55,26 @@
    * @param {string} [outputGuid] created/modified entity ID
    * @returns {number} op id
    */
-  function commitOp(db, opType, params, inputGuids, outputGuid) {
+  function commitOp(db, opType, params, inputGuids, outputGuid, opUuid) {
     ensureTable(db);
+    // G-IDENTITY (§0.21 D1/D4): identity is an edge-minted INPUT, recorded — never recomputed on
+    // replay (replayOps re-reads it). Honour a caller-supplied op_uuid verbatim (the New-doc seam);
+    // otherwise mint one here at COMMIT time. op_uuid is cross-device clash-free, unlike the local
+    // `id` rowid which collides 1,2,3… across devices. It is NOT part of _canonical, so W-CHAIN's
+    // hash stays byte-identical (the chain still totals over `id`).
+    var uuid = opUuid ||
+               ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : null);
     db.run(
-      'INSERT INTO kernel_ops (timestamp, op_type, parameters, input_guids, output_guid) ' +
-      'VALUES (?, ?, ?, ?, ?)',
-      [Date.now(), opType, JSON.stringify(params),
+      'INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid) ' +
+      'VALUES (?, ?, ?, ?, ?, ?)',
+      [uuid, Date.now(), opType, JSON.stringify(params),
        inputGuids ? JSON.stringify(inputGuids) : null,
        outputGuid || null]
     );
     var r = db.exec('SELECT last_insert_rowid()');
     var opId = r[0].values[0][0];
-    console.log('§KERNEL_OP committed id=' + opId + ' type=' + opType +
-                ' params=' + JSON.stringify(params));
+    console.log('§KERNEL_OP committed id=' + opId + ' uuid=' + (uuid ? uuid.slice(0, 8) : 'null') +
+                ' type=' + opType + ' params=' + JSON.stringify(params));
     // S243 §3.7: persist modified DB back to IndexedDB so refresh survives
     _persistToIdb(db);
     return opId;
@@ -204,14 +214,15 @@
    */
   function replayOps(db, opType) {
     ensureTable(db);
-    var sql = 'SELECT id, op_type, parameters FROM kernel_ops WHERE undone = 0';
+    // G-IDENTITY (§0.21 D2/D3): replay RE-READS the recorded op_uuid — identity is never recomputed.
+    var sql = 'SELECT id, op_uuid, op_type, parameters FROM kernel_ops WHERE undone = 0';
     var args = [];
     if (opType) { sql += ' AND op_type = ?'; args.push(opType); }
     sql += ' ORDER BY id';
     var r = db.exec(sql, args);
     if (!r.length) return [];
     var ops = r[0].values.map(function (row) {
-      return { id: row[0], op_type: row[1], parameters: JSON.parse(row[2]) };
+      return { id: row[0], op_uuid: row[1], op_type: row[2], parameters: JSON.parse(row[3]) };
     });
     console.log('§KERNEL_OP replay type=' + (opType || 'ALL') + ' count=' + ops.length);
     return ops;
@@ -306,5 +317,5 @@
     setSigner:    setSigner      // W-SIGN: install an edge signer (opt-in)
   };
 
-  console.log('§KERNEL_OPS_LOADED v5 (W-CHAIN/W-SIGN)');
+  console.log('§KERNEL_OPS_LOADED v6 (W-CHAIN/W-SIGN/G-IDENTITY)');
 })();

--- a/viewer/manifest.json
+++ b/viewer/manifest.json
@@ -1,0 +1,9334 @@
+{
+  "version": 2,
+  "generated": "2026-05-29T02:15:49.649Z",
+  "source": "ad_seed.db",
+  "windows": {
+    "123": {
+      "name": "Business Partner",
+      "table": "C_BPartner",
+      "tabs": [
+        {
+          "name": "Business Partner",
+          "table": "C_BPartner",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "Logo_ID",
+              "label": "Logo",
+              "ref": 32,
+              "type": "string",
+              "seq": 30,
+              "len": 10
+            },
+            {
+              "col": "Value",
+              "label": "Search Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "len": 40
+            },
+            {
+              "col": "C_BP_Group_ID",
+              "label": "Business Partner Group",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BP_Group"
+            },
+            {
+              "col": "IsCustomer",
+              "label": "Customer",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 60,
+              "mandatory": true,
+              "dl": "@_ParentIsSOTrx_@=Y & @C_BPartner_ID@>0 | @_QUICK_ENTRY_MODE_@!Y",
+              "len": 1
+            },
+            {
+              "col": "IsVendor",
+              "label": "Vendor",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 70,
+              "mandatory": true,
+              "dl": "@_ParentIsSOTrx_@=N & @C_BPartner_ID@>0 | @_QUICK_ENTRY_MODE_@!Y",
+              "len": 1
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "len": 120
+            },
+            {
+              "col": "IsEmployee",
+              "label": "Employee",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 90,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "IsProspect",
+              "label": "Prospect",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 100,
+              "mandatory": true,
+              "dl": "@IsEmployee@=N",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "Name2",
+              "label": "Name 2",
+              "ref": 10,
+              "type": "string",
+              "seq": 110,
+              "len": 60
+            },
+            {
+              "col": "IsSalesRep",
+              "label": "Sales Representative",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 120,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "ReferenceNo",
+              "label": "Reference No",
+              "ref": 10,
+              "type": "string",
+              "seq": 130,
+              "len": 40
+            },
+            {
+              "col": "Rating",
+              "label": "Rating",
+              "ref": 10,
+              "type": "string",
+              "seq": 140,
+              "len": 1
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Representative/Agent",
+              "ref": 18,
+              "type": "table",
+              "seq": 150,
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "SOCreditStatus",
+              "label": "Credit Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 160,
+              "len": 1
+            },
+            {
+              "col": "SO_CreditLimit",
+              "label": "Credit Limit",
+              "ref": 12,
+              "type": "amount",
+              "seq": 180,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "TotalOpenBalance",
+              "label": "Open Balance",
+              "ref": 12,
+              "type": "amount",
+              "seq": 190,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "TaxID",
+              "label": "Tax ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 200,
+              "len": 20
+            },
+            {
+              "col": "IsTaxExempt",
+              "label": "SO Tax exempt",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 220,
+              "len": 1
+            },
+            {
+              "col": "IsPOTaxExempt",
+              "label": "PO Tax exempt",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 230,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "URL",
+              "label": "URL",
+              "ref": 40,
+              "type": "url",
+              "seq": 240,
+              "len": 120
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 250,
+              "len": 255
+            },
+            {
+              "col": "IsSummary",
+              "label": "Summary Level",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 260,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "InvoiceRule",
+              "label": "Invoice Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 280,
+              "dl": "@IsCustomer@=Y",
+              "len": 1
+            },
+            {
+              "col": "C_InvoiceSchedule_ID",
+              "label": "Invoice Schedule",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "dl": "@IsCustomer@=Y",
+              "len": 22,
+              "fk": "C_InvoiceSchedule"
+            },
+            {
+              "col": "PaymentRule",
+              "label": "Payment Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 300,
+              "dl": "@IsCustomer@=Y",
+              "len": 1
+            },
+            {
+              "col": "C_PaymentTerm_ID",
+              "label": "Payment Term",
+              "ref": 18,
+              "type": "table",
+              "seq": 310,
+              "dl": "@IsCustomer@=Y",
+              "len": 22,
+              "fk": "C_PaymentTerm"
+            },
+            {
+              "col": "DeliveryRule",
+              "label": "Delivery Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 320,
+              "dl": "@IsCustomer@=Y",
+              "len": 1
+            },
+            {
+              "col": "DeliveryViaRule",
+              "label": "Delivery Via",
+              "ref": 17,
+              "type": "list",
+              "seq": 330,
+              "dl": "@IsCustomer@=Y",
+              "len": 1
+            },
+            {
+              "col": "M_PriceList_ID",
+              "label": "Price List",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 340,
+              "dl": "@IsCustomer@=Y",
+              "len": 22,
+              "fk": "M_PriceList"
+            },
+            {
+              "col": "M_DiscountSchema_ID",
+              "label": "Discount Schema",
+              "ref": 18,
+              "type": "table",
+              "seq": 350,
+              "dl": "@IsCustomer@=Y",
+              "len": 22,
+              "fk": "M_DiscountSchema"
+            },
+            {
+              "col": "FlatDiscount",
+              "label": "Flat Discount %",
+              "ref": 22,
+              "type": "number",
+              "seq": 360,
+              "dl": "@IsCustomer@=Y",
+              "len": 22
+            },
+            {
+              "col": "C_Dunning_ID",
+              "label": "Dunning",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 370,
+              "dl": "@IsCustomer@=Y",
+              "len": 22,
+              "fk": "C_Dunning"
+            },
+            {
+              "col": "DunningGrace",
+              "label": "Dunning Grace Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 380,
+              "dl": "@IsCustomer@=Y",
+              "len": 7
+            },
+            {
+              "col": "ShelfLifeMinPct",
+              "label": "Min Shelf Life %",
+              "ref": 11,
+              "type": "integer",
+              "seq": 390,
+              "dl": "@IsCustomer@=Y",
+              "len": 22
+            },
+            {
+              "col": "PaymentRulePO",
+              "label": "Payment Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 400,
+              "dl": "@IsVendor@=Y",
+              "len": 1
+            },
+            {
+              "col": "PO_PaymentTerm_ID",
+              "label": "PO Payment Term",
+              "ref": 18,
+              "type": "table",
+              "seq": 410,
+              "dl": "@IsVendor@=Y",
+              "len": 22,
+              "fk": "PO_PaymentTerm"
+            },
+            {
+              "col": "IsManufacturer",
+              "label": "Is Manufacturer",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 420,
+              "dl": "@IsVendor@=Y",
+              "def": "'N'",
+              "len": 1
+            },
+            {
+              "col": "PO_PriceList_ID",
+              "label": "Purchase Price List",
+              "ref": 18,
+              "type": "table",
+              "seq": 430,
+              "dl": "@IsVendor@=Y",
+              "len": 22,
+              "fk": "PO_PriceList"
+            },
+            {
+              "col": "PO_DiscountSchema_ID",
+              "label": "PO Discount Schema",
+              "ref": 18,
+              "type": "table",
+              "seq": 440,
+              "dl": "@IsVendor@=Y",
+              "len": 22,
+              "fk": "PO_DiscountSchema"
+            },
+            {
+              "col": "Is1099Vendor",
+              "label": "1099 Vendor",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 450,
+              "mandatory": true,
+              "dl": "@IsVendor@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "Default1099Box_ID",
+              "label": "Default 1099 Box",
+              "ref": 18,
+              "type": "table",
+              "seq": 460,
+              "dl": "@IsVendor@=Y&@Is1099Vendor@=Y",
+              "len": 10,
+              "fk": "Default1099Box"
+            },
+            {
+              "col": "POReference",
+              "label": "Order Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 470,
+              "len": 20
+            },
+            {
+              "col": "AD_Language",
+              "label": "Language",
+              "ref": 18,
+              "type": "table",
+              "seq": 480,
+              "len": 6
+            },
+            {
+              "col": "C_Greeting_ID",
+              "label": "Greeting",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 490,
+              "len": 22,
+              "fk": "C_Greeting"
+            },
+            {
+              "col": "SO_Description",
+              "label": "Order Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 500,
+              "len": 255
+            },
+            {
+              "col": "Invoice_PrintFormat_ID",
+              "label": "Invoice Print Format",
+              "ref": 18,
+              "type": "table",
+              "seq": 510,
+              "len": 22,
+              "fk": "Invoice_PrintFormat"
+            },
+            {
+              "col": "DocumentCopies",
+              "label": "Document Copies",
+              "ref": 11,
+              "type": "integer",
+              "seq": 520,
+              "len": 22
+            },
+            {
+              "col": "IsDiscountPrinted",
+              "label": "Discount Printed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 530,
+              "len": 1
+            },
+            {
+              "col": "ShareOfCustomer",
+              "label": "Share",
+              "ref": 11,
+              "type": "integer",
+              "seq": 540,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "DUNS",
+              "label": "D-U-N-S",
+              "ref": 10,
+              "type": "string",
+              "seq": 550,
+              "len": 11
+            },
+            {
+              "col": "NAICS",
+              "label": "NAICS/SIC",
+              "ref": 10,
+              "type": "string",
+              "seq": 560,
+              "len": 6
+            },
+            {
+              "col": "AcqusitionCost",
+              "label": "Acquisition Cost",
+              "ref": 37,
+              "type": "string",
+              "seq": 570,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "NumberEmployees",
+              "label": "Employees",
+              "ref": 11,
+              "type": "integer",
+              "seq": 580,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "SalesVolume",
+              "label": "Sales Volume in 1.000",
+              "ref": 11,
+              "type": "integer",
+              "seq": 590,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "PotentialLifeTimeValue",
+              "label": "Potential Life Time Value",
+              "ref": 12,
+              "type": "amount",
+              "seq": 600,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "ActualLifeTimeValue",
+              "label": "Actual Life Time Value",
+              "ref": 12,
+              "type": "amount",
+              "seq": 610,
+              "readonly": true,
+              "dl": "@IsEmployee@=N",
+              "len": 22
+            },
+            {
+              "col": "FirstSale",
+              "label": "First Sale",
+              "ref": 15,
+              "type": "date",
+              "seq": 620,
+              "len": 7
+            }
+          ],
+          "singleRow": true
+        },
+        {
+          "name": "Contact (User)",
+          "table": "AD_User",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "len": 255
+            },
+            {
+              "col": "Comments",
+              "label": "Comments",
+              "ref": 14,
+              "type": "text",
+              "seq": 60,
+              "len": 2000
+            },
+            {
+              "col": "EMail",
+              "label": "EMail Address",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "len": 60
+            },
+            {
+              "col": "Password",
+              "label": "Password",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "len": 1024
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 100,
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "IsShipTo",
+              "label": "Ship Contact",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 110,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsBillTo",
+              "label": "Invoice Contact",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 120,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "C_Greeting_ID",
+              "label": "Greeting",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 130,
+              "len": 22,
+              "fk": "C_Greeting"
+            },
+            {
+              "col": "Title",
+              "label": "Title",
+              "ref": 10,
+              "type": "string",
+              "seq": 140,
+              "len": 40
+            },
+            {
+              "col": "Birthday",
+              "label": "Birthday",
+              "ref": 15,
+              "type": "date",
+              "seq": 150,
+              "len": 7
+            },
+            {
+              "col": "Phone",
+              "label": "Phone",
+              "ref": 10,
+              "type": "string",
+              "seq": 160,
+              "len": 40
+            },
+            {
+              "col": "Phone2",
+              "label": "2nd Phone",
+              "ref": 10,
+              "type": "string",
+              "seq": 170,
+              "len": 40
+            },
+            {
+              "col": "Fax",
+              "label": "Fax",
+              "ref": 10,
+              "type": "string",
+              "seq": 180,
+              "len": 40
+            },
+            {
+              "col": "NotificationType",
+              "label": "Notification Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 190,
+              "mandatory": true,
+              "def": "X",
+              "len": 1
+            },
+            {
+              "col": "C_Job_ID",
+              "label": "Position",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 200,
+              "len": 1,
+              "fk": "C_Job"
+            },
+            {
+              "col": "IsFullBPAccess",
+              "label": "Full BP Access",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 210,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "EMailVerifyDate",
+              "label": "EMail Verify",
+              "ref": 16,
+              "type": "datetime",
+              "seq": 220,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "EMailVerify",
+              "label": "Verification Info",
+              "ref": 10,
+              "type": "string",
+              "seq": 230,
+              "readonly": true,
+              "len": 40
+            },
+            {
+              "col": "LastContact",
+              "label": "Last Contact",
+              "ref": 15,
+              "type": "date",
+              "seq": 240,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "LastResult",
+              "label": "Last Result",
+              "ref": 10,
+              "type": "string",
+              "seq": 250,
+              "readonly": true,
+              "len": 255
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        },
+        {
+          "name": "Location",
+          "table": "C_BPartner_Location",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "identifier": true,
+              "def": ".",
+              "len": 60
+            },
+            {
+              "col": "IsPreserveCustomName",
+              "label": "Preserve custom name",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 50,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "C_Location_ID",
+              "label": "Address",
+              "ref": 21,
+              "type": "location",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "Phone",
+              "label": "Phone",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 40
+            },
+            {
+              "col": "Phone2",
+              "label": "2nd Phone",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "len": 40
+            },
+            {
+              "col": "Fax",
+              "label": "Fax",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "len": 40
+            },
+            {
+              "col": "ISDN",
+              "label": "ISDN",
+              "ref": 10,
+              "type": "string",
+              "seq": 100,
+              "len": 40
+            },
+            {
+              "col": "IsShipTo",
+              "label": "Ship Address",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 110,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "IsBillTo",
+              "label": "Invoice Address",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 120,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "IsPayFrom",
+              "label": "Pay-From Address",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 130,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "IsRemitTo",
+              "label": "Remit-To Address",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 140,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "C_SalesRegion_ID",
+              "label": "Sales Region",
+              "ref": 18,
+              "type": "table",
+              "seq": 150,
+              "len": 22,
+              "fk": "C_SalesRegion"
+            },
+            {
+              "col": "CustomerAddressID",
+              "label": "Customer Address ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 160,
+              "readonly": true,
+              "len": 60
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        },
+        {
+          "name": "Bank Account",
+          "table": "C_BP_BankAccount",
+          "level": 1,
+          "seq": 60,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "AD_User_ID",
+              "label": "User/Contact",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "def": "-1",
+              "len": 22,
+              "fk": "AD_User"
+            },
+            {
+              "col": "IsACH",
+              "label": "ACH",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 60,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "BPBankAcctUse",
+              "label": "Account Usage",
+              "ref": 17,
+              "type": "list",
+              "seq": 70,
+              "dl": "@IsACH@=Y",
+              "def": "B",
+              "len": 1
+            },
+            {
+              "col": "C_Bank_ID",
+              "label": "Bank",
+              "ref": 30,
+              "type": "search",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "dl": "@IsACH@=Y",
+              "len": 22,
+              "fk": "C_Bank"
+            },
+            {
+              "col": "BankAccountType",
+              "label": "Bank Account Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 90,
+              "dl": "@IsACH@=Y",
+              "len": 1
+            },
+            {
+              "col": "RoutingNo",
+              "label": "Routing No",
+              "ref": 10,
+              "type": "string",
+              "seq": 100,
+              "dl": "@IsACH@=Y & @C_Bank_ID@=0",
+              "len": 20
+            },
+            {
+              "col": "AccountNo",
+              "label": "Account No",
+              "ref": 10,
+              "type": "string",
+              "seq": 110,
+              "identifier": true,
+              "dl": "@IsACH@=Y",
+              "len": 20
+            },
+            {
+              "col": "IBAN",
+              "label": "IBAN",
+              "ref": 10,
+              "type": "string",
+              "seq": 115,
+              "dl": "@IsACH@=Y",
+              "len": 40
+            },
+            {
+              "col": "CreditCardType",
+              "label": "Credit Card",
+              "ref": 17,
+              "type": "list",
+              "seq": 120,
+              "dl": "@IsACH@=N",
+              "len": 1
+            },
+            {
+              "col": "CreditCardNumber",
+              "label": "Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 130,
+              "dl": "@IsACH@=N",
+              "len": 20
+            },
+            {
+              "col": "CreditCardVV",
+              "label": "Verification Code",
+              "ref": 10,
+              "type": "string",
+              "seq": 140,
+              "dl": "@IsACH@=N",
+              "len": 4
+            },
+            {
+              "col": "CreditCardExpMM",
+              "label": "Exp. Month",
+              "ref": 11,
+              "type": "integer",
+              "seq": 150,
+              "dl": "@IsACH@=N",
+              "len": 22
+            },
+            {
+              "col": "CreditCardExpYY",
+              "label": "Exp. Year",
+              "ref": 11,
+              "type": "integer",
+              "seq": 160,
+              "dl": "@IsACH@=N",
+              "def": "2000",
+              "len": 22
+            },
+            {
+              "col": "A_Name",
+              "label": "Account Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 170,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "A_Street",
+              "label": "Account Street",
+              "ref": 10,
+              "type": "string",
+              "seq": 180,
+              "len": 60
+            },
+            {
+              "col": "A_City",
+              "label": "Account City",
+              "ref": 10,
+              "type": "string",
+              "seq": 190,
+              "len": 60
+            },
+            {
+              "col": "A_Zip",
+              "label": "Account Zip/Postal",
+              "ref": 10,
+              "type": "string",
+              "seq": 200,
+              "len": 20
+            },
+            {
+              "col": "A_State",
+              "label": "Account State",
+              "ref": 10,
+              "type": "string",
+              "seq": 210,
+              "len": 40
+            },
+            {
+              "col": "A_Country",
+              "label": "Account Country",
+              "ref": 10,
+              "type": "string",
+              "seq": 220,
+              "len": 40
+            },
+            {
+              "col": "A_Ident_DL",
+              "label": "Driver License",
+              "ref": 10,
+              "type": "string",
+              "seq": 230,
+              "len": 20
+            },
+            {
+              "col": "A_Ident_SSN",
+              "label": "Social Security No",
+              "ref": 10,
+              "type": "string",
+              "seq": 240,
+              "len": 20
+            },
+            {
+              "col": "A_EMail",
+              "label": "Account EMail",
+              "ref": 10,
+              "type": "string",
+              "seq": 250,
+              "len": 60
+            },
+            {
+              "col": "R_AvsAddr",
+              "label": "Address verified",
+              "ref": 17,
+              "type": "list",
+              "seq": 260,
+              "len": 1
+            },
+            {
+              "col": "R_AvsZip",
+              "label": "Zip verified",
+              "ref": 17,
+              "type": "list",
+              "seq": 270,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "CustomerPaymentProfileID",
+              "label": "Customer Payment Profile ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 280,
+              "readonly": true,
+              "len": 60
+            },
+            {
+              "col": "C_PaymentProcessor_ID",
+              "label": "Payment Processor",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_PaymentProcessor"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        },
+        {
+          "name": "Shipping Accounts",
+          "table": "C_BP_ShippingAcct",
+          "level": 1,
+          "seq": 70,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "ShipperAccount",
+              "label": "Shipper Account Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "len": 40
+            },
+            {
+              "col": "ShipperMeter",
+              "label": "Shipper Meter",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "len": 255
+            },
+            {
+              "col": "DutiesShipperAccount",
+              "label": "Duties Shipper Account",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 40
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 80,
+              "len": 10,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "M_ShippingProcessor_ID",
+              "label": "Shipping Processor",
+              "ref": 18,
+              "type": "table",
+              "seq": 90,
+              "len": 10,
+              "fk": "M_ShippingProcessor"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        },
+        {
+          "name": "Customer Accounting",
+          "table": "C_BP_Customer_Acct",
+          "level": 1,
+          "seq": 80,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_AcctSchema_ID",
+              "label": "Accounting Schema",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AcctSchema"
+            },
+            {
+              "col": "C_Receivable_Acct",
+              "label": "Customer Receivables",
+              "ref": 25,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "C_Prepayment_Acct",
+              "label": "Customer Prepayment",
+              "ref": 25,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        },
+        {
+          "name": "Vendor Accounting",
+          "table": "C_BP_Vendor_Acct",
+          "level": 1,
+          "seq": 90,
+          "fields": [
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_AcctSchema_ID",
+              "label": "Accounting Schema",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AcctSchema"
+            },
+            {
+              "col": "V_Liability_Acct",
+              "label": "Vendor Liability",
+              "ref": 25,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "V_Prepayment_Acct",
+              "label": "Vendor Prepayment",
+              "ref": 25,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_BPartner_ID"
+        }
+      ],
+      "node": "Partners"
+    },
+    "130": {
+      "name": "Project",
+      "table": "C_Project",
+      "tabs": [
+        {
+          "name": "Project",
+          "table": "C_Project",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "Value",
+              "label": "Search Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 40
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Sales Representative",
+              "ref": 18,
+              "type": "table",
+              "seq": 40,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 60,
+              "len": 255
+            },
+            {
+              "col": "IsSummary",
+              "label": "Summary Level",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 80,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "Note",
+              "label": "Note",
+              "ref": 14,
+              "type": "text",
+              "seq": 90,
+              "len": 2000
+            },
+            {
+              "col": "ProjectLineLevel",
+              "label": "Line Level",
+              "ref": 17,
+              "type": "list",
+              "seq": 100,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "def": "P",
+              "len": 1
+            },
+            {
+              "col": "C_Phase_ID",
+              "label": "Standard Phase",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 120,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "C_Phase"
+            },
+            {
+              "col": "DateContract",
+              "label": "Contract Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 130,
+              "dl": "@IsSummary@=N",
+              "len": 7
+            },
+            {
+              "col": "DateFinish",
+              "label": "Finish Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 140,
+              "dl": "@IsSummary@=N",
+              "len": 7
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 150,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_BPartnerSR_ID",
+              "label": "BPartner (Agent)",
+              "ref": 30,
+              "type": "search",
+              "seq": 160,
+              "dl": "@IsSummary@=N",
+              "len": 10,
+              "fk": "C_BPartnerSR"
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 170,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "AD_User_ID",
+              "label": "User/Contact",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 180,
+              "dl": "@IsSummary@=N",
+              "def": "-1",
+              "len": 22,
+              "fk": "AD_User"
+            },
+            {
+              "col": "C_PaymentTerm_ID",
+              "label": "Payment Term",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 190,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "C_PaymentTerm"
+            },
+            {
+              "col": "POReference",
+              "label": "Order Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 200,
+              "dl": "@IsSummary@=N",
+              "len": 20
+            },
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 210,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 220,
+              "dl": "@IsSummary@=N & @$Element_MC@=Y",
+              "len": 22,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "M_PriceList_Version_ID",
+              "label": "Price List Version",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 230,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "M_PriceList_Version"
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 240,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 250,
+              "dl": "@$Element_OT@=Y",
+              "len": 22,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 260,
+              "dl": "@$Element_AY@='Y'",
+              "len": 22,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "PlannedAmt",
+              "label": "Planned Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 270,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "PlannedQty",
+              "label": "Planned Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 280,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "PlannedMarginAmt",
+              "label": "Planned Margin",
+              "ref": 12,
+              "type": "amount",
+              "seq": 290,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "ProjInvoiceRule",
+              "label": "Invoice Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 300,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "def": "-",
+              "len": 1
+            },
+            {
+              "col": "CommittedAmt",
+              "label": "Committed Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 310,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "CommittedQty",
+              "label": "Committed Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 320,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "InvoicedAmt",
+              "label": "Invoiced Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 330,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "InvoicedQty",
+              "label": "Quantity Invoiced",
+              "ref": 29,
+              "type": "string",
+              "seq": 340,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            },
+            {
+              "col": "ProjectBalanceAmt",
+              "label": "Project Balance",
+              "ref": 12,
+              "type": "amount",
+              "seq": 350,
+              "mandatory": true,
+              "dl": "@IsSummary@=N",
+              "len": 22
+            }
+          ],
+          "singleRow": true
+        },
+        {
+          "name": "Project Line",
+          "table": "C_ProjectLine",
+          "level": 1,
+          "seq": 15,
+          "fields": [
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "Line",
+              "label": "Line No",
+              "ref": 11,
+              "type": "integer",
+              "seq": 40,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@SQL=SELECT NVL(MAX(Line),0)+10 AS DefaultValue FROM C_ProjectLine WHERE C_Project_ID=@C_Project_ID@",
+              "len": 22
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 60,
+              "len": 255
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 70,
+              "identifier": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_Product_Category_ID",
+              "label": "Product Category",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 80,
+              "dl": "@M_Product_ID@=0",
+              "len": 22,
+              "fk": "M_Product_Category"
+            },
+            {
+              "col": "PlannedPrice",
+              "label": "Planned Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 90,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PlannedQty",
+              "label": "Planned Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 100,
+              "mandatory": true,
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "PlannedAmt",
+              "label": "Planned Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "IsPrinted",
+              "label": "Printed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 130,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "PlannedMarginAmt",
+              "label": "Planned Margin",
+              "ref": 12,
+              "type": "amount",
+              "seq": 140,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "CommittedAmt",
+              "label": "Committed Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 150,
+              "dl": "@IsCommitment@=Y",
+              "len": 22
+            },
+            {
+              "col": "CommittedQty",
+              "label": "Committed Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 160,
+              "dl": "@IsCommitment@=Y",
+              "len": 22
+            },
+            {
+              "col": "InvoicedAmt",
+              "label": "Invoiced Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 170,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "InvoicedQty",
+              "label": "Quantity Invoiced",
+              "ref": 29,
+              "type": "string",
+              "seq": 180,
+              "mandatory": true,
+              "readonly": true,
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 190,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_OrderPO_ID",
+              "label": "Purchase Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 200,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_OrderPO"
+            },
+            {
+              "col": "C_ProjectIssue_ID",
+              "label": "Project Issue",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 210,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_ProjectIssue"
+            },
+            {
+              "col": "Processed",
+              "label": "Processed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 220,
+              "mandatory": true,
+              "readonly": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "M_Production_ID",
+              "label": "Production",
+              "ref": 30,
+              "type": "search",
+              "seq": 230,
+              "len": 22,
+              "fk": "M_Production"
+            }
+          ],
+          "singleRow": true,
+          "where": "COALESCE(C_ProjectLine.C_ProjectTask_ID,0)=0 AND COALESCE(C_ProjectLine.C_ProjectPhase_ID,0)=0",
+          "fk": "C_Project_ID"
+        },
+        {
+          "name": "Phase",
+          "table": "C_ProjectPhase",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Phase_ID",
+              "label": "Standard Phase",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Phase"
+            },
+            {
+              "col": "SeqNo",
+              "label": "Sequence",
+              "ref": 11,
+              "type": "integer",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@SQL=SELECT NVL(MAX(SeqNo),0)+10 AS DefaultValue FROM C_ProjectPhase WHERE C_Project_ID=@C_Project_ID@",
+              "len": 22
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 70,
+              "len": 255
+            },
+            {
+              "col": "Help",
+              "label": "Comment/Help",
+              "ref": 14,
+              "type": "text",
+              "seq": 80,
+              "len": 2000
+            },
+            {
+              "col": "IsComplete",
+              "label": "Complete",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 100,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "StartDate",
+              "label": "Start Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 110,
+              "len": 7
+            },
+            {
+              "col": "EndDate",
+              "label": "End Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 120,
+              "len": 7
+            },
+            {
+              "col": "ProjInvoiceRule",
+              "label": "Invoice Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 130,
+              "mandatory": true,
+              "def": "@ProjInvoiceRule@",
+              "len": 1
+            },
+            {
+              "col": "PlannedAmt",
+              "label": "Planned Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 140,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 150,
+              "dl": "@ProjInvoiceRule@=P",
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "Qty",
+              "label": "Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 160,
+              "dl": "@ProjInvoiceRule@=P",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "CommittedAmt",
+              "label": "Committed Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 170,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 190,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Project_ID"
+        },
+        {
+          "name": "Accounting",
+          "table": "C_Project_Acct",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_AcctSchema_ID",
+              "label": "Accounting Schema",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AcctSchema"
+            },
+            {
+              "col": "PJ_Asset_Acct",
+              "label": "Project Asset",
+              "ref": 25,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PJ_WIP_Acct",
+              "label": "Work In Progress",
+              "ref": 25,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Project_ID"
+        },
+        {
+          "name": "BIM",
+          "table": "C_Project",
+          "level": 0,
+          "seq": 900,
+          "fields": [],
+          "singleRow": true
+        }
+      ],
+      "node": "Projects"
+    },
+    "140": {
+      "name": "Product",
+      "table": "M_Product",
+      "tabs": [
+        {
+          "name": "Product",
+          "table": "M_Product",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "Value",
+              "label": "Search Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 510
+            },
+            {
+              "col": "VersionNo",
+              "label": "Version No",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "len": 20
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 255
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "len": 255
+            },
+            {
+              "col": "Help",
+              "label": "Comment/Help",
+              "ref": 14,
+              "type": "text",
+              "seq": 70,
+              "len": 2000
+            },
+            {
+              "col": "DocumentNote",
+              "label": "Document Note",
+              "ref": 14,
+              "type": "text",
+              "seq": 80,
+              "len": 2000
+            },
+            {
+              "col": "UPC",
+              "label": "UPC/EAN",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "len": 30
+            },
+            {
+              "col": "SKU",
+              "label": "SKU",
+              "ref": 10,
+              "type": "string",
+              "seq": 100,
+              "len": 30
+            },
+            {
+              "col": "IsSummary",
+              "label": "Summary Level",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 120,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "M_Product_Category_ID",
+              "label": "Product Category",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Product_Category"
+            },
+            {
+              "col": "Classification",
+              "label": "Classification",
+              "ref": 10,
+              "type": "string",
+              "seq": 140,
+              "len": 12
+            },
+            {
+              "col": "C_TaxCategory_ID",
+              "label": "Tax Category",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 150,
+              "mandatory": true,
+              "dl": "@IsSold@='Y' | @IsPurchased@='Y' & @IsSummary@='N'",
+              "len": 22,
+              "fk": "C_TaxCategory"
+            },
+            {
+              "col": "C_RevenueRecognition_ID",
+              "label": "Revenue Recognition",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 160,
+              "dl": "@IsSold@='Y'",
+              "len": 22,
+              "fk": "C_RevenueRecognition"
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 170,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Sales Representative",
+              "ref": 18,
+              "type": "table",
+              "seq": 180,
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "ProductType",
+              "label": "Product Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 190,
+              "mandatory": true,
+              "def": "I",
+              "len": 1
+            },
+            {
+              "col": "R_MailText_ID",
+              "label": "Mail Template",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 200,
+              "len": 22,
+              "fk": "R_MailText"
+            },
+            {
+              "col": "Weight",
+              "label": "Weight",
+              "ref": 12,
+              "type": "amount",
+              "seq": 210,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "len": 22
+            },
+            {
+              "col": "Volume",
+              "label": "Volume",
+              "ref": 12,
+              "type": "amount",
+              "seq": 220,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "len": 22
+            },
+            {
+              "col": "IsOwnBox",
+              "label": "Own Box",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 230,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "CustomsTariffNumber",
+              "label": "Customs Tariff Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 240,
+              "len": 20
+            },
+            {
+              "col": "M_FreightCategory_ID",
+              "label": "Freight Category",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 250,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "len": 22,
+              "fk": "M_FreightCategory"
+            },
+            {
+              "col": "IsDropShip",
+              "label": "Drop Shipment",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 260,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "len": 1
+            },
+            {
+              "col": "IsStocked",
+              "label": "Stocked",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 270,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & @ProductType@=I",
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "IsManufactured",
+              "label": "Manufactured",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 280,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsPhantom",
+              "label": "Phantom",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 290,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsKanban",
+              "label": "Kanban controlled",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 300,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "M_PartType_ID",
+              "label": "Part Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 310,
+              "len": 10,
+              "fk": "M_PartType"
+            },
+            {
+              "col": "M_Locator_ID",
+              "label": "Locator",
+              "ref": 31,
+              "type": "locator",
+              "seq": 320,
+              "dl": "@IsSummary@=N & @ProductType@=I & @IsStocked@=Y",
+              "len": 22
+            },
+            {
+              "col": "ShelfWidth",
+              "label": "Shelf Width",
+              "ref": 11,
+              "type": "integer",
+              "seq": 330,
+              "dl": "@IsSummary@='N' & @ProductType@=I & @IsStocked@=Y",
+              "len": 22
+            },
+            {
+              "col": "ShelfHeight",
+              "label": "Shelf Height",
+              "ref": 12,
+              "type": "amount",
+              "seq": 340,
+              "dl": "@IsSummary@='N' & @ProductType@=I & @IsStocked@=Y",
+              "len": 22
+            },
+            {
+              "col": "ShelfDepth",
+              "label": "Shelf Depth",
+              "ref": 11,
+              "type": "integer",
+              "seq": 350,
+              "dl": "@IsSummary@='N' & @ProductType@=I & @IsStocked@=Y",
+              "len": 22
+            },
+            {
+              "col": "UnitsPerPallet",
+              "label": "Units Per Pallet",
+              "ref": 37,
+              "type": "string",
+              "seq": 360,
+              "dl": "@IsSummary@='N' & @ProductType@=I & @IsStocked@=Y",
+              "len": 22
+            },
+            {
+              "col": "IsBOM",
+              "label": "Bill of Materials",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 370,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & (@ProductType@=I | @ProductType@=S)",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsVerified",
+              "label": "Verified",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 380,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@IsSummary@='N' & @IsBOM@='Y'",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsAutoProduce",
+              "label": "Auto Produce",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 400,
+              "mandatory": true,
+              "dl": "@IsBOM@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsInvoicePrintDetails",
+              "label": "Print detail records on invoice",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 410,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & @IsBOM@='Y'",
+              "len": 1
+            },
+            {
+              "col": "IsPickListPrintDetails",
+              "label": "Print detail records on pick list",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 420,
+              "mandatory": true,
+              "dl": "@IsSummary@='N' & @IsBOM@='Y'",
+              "len": 1
+            },
+            {
+              "col": "IsPurchased",
+              "label": "Purchased",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 430,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "IsSold",
+              "label": "Sold",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 440,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "Discontinued",
+              "label": "Discontinued",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 450,
+              "dl": "@IsSummary@='N'",
+              "len": 1
+            },
+            {
+              "col": "DiscontinuedAt",
+              "label": "Discontinued At",
+              "ref": 15,
+              "type": "date",
+              "seq": 460,
+              "dl": "@IsSummary@='N' & @Discontinued@='Y'",
+              "len": 7
+            },
+            {
+              "col": "S_ExpenseType_ID",
+              "label": "Expense Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 470,
+              "readonly": true,
+              "dl": "@ProductType@=E",
+              "len": 22,
+              "fk": "S_ExpenseType"
+            },
+            {
+              "col": "S_Resource_ID",
+              "label": "Resource",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 480,
+              "readonly": true,
+              "dl": "@ProductType@=R",
+              "len": 22,
+              "fk": "S_Resource"
+            },
+            {
+              "col": "IsExcludeAutoDelivery",
+              "label": "Exclude Auto Delivery",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 490,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "ImageURL",
+              "label": "Image URL",
+              "ref": 40,
+              "type": "url",
+              "seq": 510,
+              "dl": "@IsSummary@='N'",
+              "len": 120
+            },
+            {
+              "col": "DescriptionURL",
+              "label": "Description URL",
+              "ref": 40,
+              "type": "url",
+              "seq": 520,
+              "dl": "@IsSummary@='N'",
+              "len": 120
+            },
+            {
+              "col": "GuaranteeDays",
+              "label": "Guarantee Days",
+              "ref": 11,
+              "type": "integer",
+              "seq": 530,
+              "dl": "@IsSummary@='N'",
+              "len": 22
+            },
+            {
+              "col": "GuaranteeDaysMin",
+              "label": "Min Guarantee Days",
+              "ref": 11,
+              "type": "integer",
+              "seq": 540,
+              "dl": "@IsSummary@='N'",
+              "len": 22
+            },
+            {
+              "col": "M_AttributeSet_ID",
+              "label": "Attribute Set",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 550,
+              "dl": "@IsSummary@='N'",
+              "len": 22,
+              "fk": "M_AttributeSet"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 560,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "len": 22
+            },
+            {
+              "col": "IsWebStoreFeatured",
+              "label": "Featured in Web Store",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 580,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "len": 1
+            },
+            {
+              "col": "IsSelfService",
+              "label": "Self-Service",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 590,
+              "mandatory": true,
+              "dl": "@IsSummary@='N'",
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "Group1",
+              "label": "Group1",
+              "ref": 10,
+              "type": "string",
+              "seq": 600,
+              "len": 255
+            },
+            {
+              "col": "Group2",
+              "label": "Group2",
+              "ref": 10,
+              "type": "string",
+              "seq": 610,
+              "len": 255
+            }
+          ],
+          "singleRow": true
+        },
+        {
+          "name": "BOM",
+          "table": "PP_Product_BOM",
+          "level": 1,
+          "seq": 15,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 40,
+              "len": 22
+            },
+            {
+              "col": "Value",
+              "label": "Search Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 80
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 14,
+              "type": "text",
+              "seq": 60,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 255
+            },
+            {
+              "col": "Help",
+              "label": "Comment/Help",
+              "ref": 14,
+              "type": "text",
+              "seq": 80,
+              "len": 2000
+            },
+            {
+              "col": "Revision",
+              "label": "Revision",
+              "ref": 10,
+              "type": "string",
+              "seq": 100,
+              "len": 10
+            },
+            {
+              "col": "BOMType",
+              "label": "BOM Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 110,
+              "def": "A",
+              "len": 1
+            },
+            {
+              "col": "BOMUse",
+              "label": "BOM Use",
+              "ref": 17,
+              "type": "list",
+              "seq": 120,
+              "def": "A",
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Substitute",
+          "table": "M_Substitute",
+          "level": 1,
+          "seq": 30,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "identifier": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "len": 255
+            },
+            {
+              "col": "Substitute_ID",
+              "label": "Substitute",
+              "ref": 30,
+              "type": "search",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22,
+              "fk": "Substitute"
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Related",
+          "table": "M_RelatedProduct",
+          "level": 1,
+          "seq": 40,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "len": 60
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 50,
+              "len": 255
+            },
+            {
+              "col": "RelatedProductType",
+              "label": "Related Product Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 70,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "RelatedProduct_ID",
+              "label": "Related Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22,
+              "fk": "RelatedProduct"
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Replenish",
+          "table": "M_Replenish",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "M_Locator_ID",
+              "label": "Locator",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "len": 1,
+              "fk": "M_Locator"
+            },
+            {
+              "col": "ReplenishType",
+              "label": "Replenish Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 70,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "Level_Min",
+              "label": "Minimum Level",
+              "ref": 12,
+              "type": "amount",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "Level_Max",
+              "label": "Maximum Level",
+              "ref": 12,
+              "type": "amount",
+              "seq": 90,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "M_WarehouseSource_ID",
+              "label": "Source Warehouse",
+              "ref": 18,
+              "type": "table",
+              "seq": 100,
+              "len": 10,
+              "fk": "M_WarehouseSource"
+            },
+            {
+              "col": "QtyBatchSize",
+              "label": "Qty Batch Size",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "len": 10
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Purchasing",
+          "table": "M_Product_PO",
+          "level": 1,
+          "seq": 60,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "def": "@M_Product_ID@",
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "QualityRating",
+              "label": "Quality Rating",
+              "ref": 11,
+              "type": "integer",
+              "seq": 50,
+              "len": 22
+            },
+            {
+              "col": "IsCurrentVendor",
+              "label": "Current vendor",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 70,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "UPC",
+              "label": "UPC/EAN",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "len": 20
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 90,
+              "len": 22,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "PriceList",
+              "label": "List Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 100,
+              "len": 22
+            },
+            {
+              "col": "PriceEffective",
+              "label": "Price effective",
+              "ref": 15,
+              "type": "date",
+              "seq": 110,
+              "len": 7
+            },
+            {
+              "col": "PricePO",
+              "label": "PO Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 120,
+              "len": 22
+            },
+            {
+              "col": "RoyaltyAmt",
+              "label": "Royalty Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 130,
+              "len": 22
+            },
+            {
+              "col": "PriceLastPO",
+              "label": "Last PO Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 140,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "PriceLastInv",
+              "label": "Last Invoice Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 150,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 160,
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "Order_Min",
+              "label": "Minimum Order Qty",
+              "ref": 29,
+              "type": "string",
+              "seq": 170,
+              "len": 22
+            },
+            {
+              "col": "Order_Pack",
+              "label": "Order Pack Qty",
+              "ref": 29,
+              "type": "string",
+              "seq": 180,
+              "len": 22
+            },
+            {
+              "col": "DeliveryTime_Promised",
+              "label": "Promised Delivery Time",
+              "ref": 11,
+              "type": "integer",
+              "seq": 190,
+              "len": 22
+            },
+            {
+              "col": "DeliveryTime_Actual",
+              "label": "Actual Delivery Time",
+              "ref": 11,
+              "type": "integer",
+              "seq": 200,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "CostPerOrder",
+              "label": "Cost per Order",
+              "ref": 37,
+              "type": "string",
+              "seq": 210,
+              "len": 22
+            },
+            {
+              "col": "VendorProductNo",
+              "label": "Partner Product Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 220,
+              "mandatory": true,
+              "def": "@Value@",
+              "len": 40
+            },
+            {
+              "col": "VendorCategory",
+              "label": "Partner Category",
+              "ref": 10,
+              "type": "string",
+              "seq": 230,
+              "len": 30
+            },
+            {
+              "col": "Manufacturer",
+              "label": "Manufacturer",
+              "ref": 10,
+              "type": "string",
+              "seq": 240,
+              "len": 30
+            },
+            {
+              "col": "Discontinued",
+              "label": "Discontinued",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 250,
+              "len": 1
+            },
+            {
+              "col": "DiscontinuedAt",
+              "label": "Discontinued At",
+              "ref": 15,
+              "type": "date",
+              "seq": 260,
+              "dl": "@Discontinued@='Y'",
+              "len": 7
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Business Partner",
+          "table": "C_BPartner_Product",
+          "level": 1,
+          "seq": 70,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "len": 255
+            },
+            {
+              "col": "VendorProductNo",
+              "label": "Partner Product Key",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 30
+            },
+            {
+              "col": "VendorCategory",
+              "label": "Partner Category",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "len": 30
+            },
+            {
+              "col": "Manufacturer",
+              "label": "Manufacturer",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "len": 30
+            },
+            {
+              "col": "QualityRating",
+              "label": "Quality Rating",
+              "ref": 22,
+              "type": "number",
+              "seq": 100,
+              "len": 22
+            },
+            {
+              "col": "ShelfLifeMinPct",
+              "label": "Min Shelf Life %",
+              "ref": 11,
+              "type": "integer",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "ShelfLifeMinDays",
+              "label": "Min Shelf Life Days",
+              "ref": 11,
+              "type": "integer",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "IsManufacturer",
+              "label": "Is Manufacturer",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 130,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Price",
+          "table": "M_ProductPrice",
+          "level": 1,
+          "seq": 90,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_PriceList_Version_ID",
+              "label": "Price List Version",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_PriceList_Version"
+            },
+            {
+              "col": "PriceList",
+              "label": "List Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PriceStd",
+              "label": "Standard Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PriceLimit",
+              "label": "Limit Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Accounting",
+          "table": "M_Product_Acct",
+          "level": 1,
+          "seq": 100,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_AcctSchema_ID",
+              "label": "Accounting Schema",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AcctSchema"
+            },
+            {
+              "col": "P_Asset_Acct",
+              "label": "Product Asset",
+              "ref": 25,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_Expense_Acct",
+              "label": "Product Expense",
+              "ref": 25,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_CostAdjustment_Acct",
+              "label": "Cost Adjustment",
+              "ref": 25,
+              "type": "string",
+              "seq": 80,
+              "mandatory": true,
+              "len": 10
+            },
+            {
+              "col": "P_InventoryClearing_Acct",
+              "label": "Inventory Clearing",
+              "ref": 25,
+              "type": "string",
+              "seq": 90,
+              "mandatory": true,
+              "len": 10
+            },
+            {
+              "col": "P_COGS_Acct",
+              "label": "Product COGS",
+              "ref": 25,
+              "type": "string",
+              "seq": 100,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_Revenue_Acct",
+              "label": "Product Revenue",
+              "ref": 25,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_PurchasePriceVariance_Acct",
+              "label": "Purchase Price Variance",
+              "ref": 25,
+              "type": "string",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_InvoicePriceVariance_Acct",
+              "label": "Invoice Price Variance",
+              "ref": 25,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_TradeDiscountRec_Acct",
+              "label": "Trade Discount Received",
+              "ref": 25,
+              "type": "string",
+              "seq": 140,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_TradeDiscountGrant_Acct",
+              "label": "Trade Discount Granted",
+              "ref": 25,
+              "type": "string",
+              "seq": 150,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_RateVariance_Acct",
+              "label": "Rate Variance",
+              "ref": 25,
+              "type": "string",
+              "seq": 160,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "P_AverageCostVariance_Acct",
+              "label": "Average Cost Variance",
+              "ref": 25,
+              "type": "string",
+              "seq": 170,
+              "mandatory": true,
+              "len": 10
+            },
+            {
+              "col": "P_LandedCostClearing_Acct",
+              "label": "Landed Cost Clearing",
+              "ref": 25,
+              "type": "string",
+              "seq": 180,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Transactions",
+          "table": "M_Transaction",
+          "level": 1,
+          "seq": 110,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "M_Locator_ID",
+              "label": "Locator",
+              "ref": 31,
+              "type": "locator",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "MovementQty",
+              "label": "Movement Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "MovementDate",
+              "label": "Movement Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "len": 7
+            },
+            {
+              "col": "MovementType",
+              "label": "Movement Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 90,
+              "mandatory": true,
+              "identifier": true,
+              "len": 2
+            },
+            {
+              "col": "M_InOutLine_ID",
+              "label": "Shipment/Receipt Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 100,
+              "len": 22,
+              "fk": "M_InOutLine"
+            },
+            {
+              "col": "M_InventoryLine_ID",
+              "label": "Phys.Inventory Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 110,
+              "len": 22,
+              "fk": "M_InventoryLine"
+            },
+            {
+              "col": "M_MovementLine_ID",
+              "label": "Move Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 120,
+              "len": 22,
+              "fk": "M_MovementLine"
+            },
+            {
+              "col": "M_ProductionLine_ID",
+              "label": "Production Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 130,
+              "len": 22,
+              "fk": "M_ProductionLine"
+            },
+            {
+              "col": "C_ProjectIssue_ID",
+              "label": "Project Issue",
+              "ref": 30,
+              "type": "search",
+              "seq": 140,
+              "len": 22,
+              "fk": "C_ProjectIssue"
+            },
+            {
+              "col": "PP_Cost_Collector_ID",
+              "label": "Manufacturing Cost Collector",
+              "ref": 30,
+              "type": "search",
+              "seq": 150,
+              "len": 10,
+              "fk": "PP_Cost_Collector"
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Translation",
+          "table": "M_Product_Trl",
+          "level": 1,
+          "seq": 120,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "AD_Language",
+              "label": "Language",
+              "ref": 18,
+              "type": "table",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 6
+            },
+            {
+              "col": "Name",
+              "label": "Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 255
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "len": 255
+            },
+            {
+              "col": "DocumentNote",
+              "label": "Document Note",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 2000
+            },
+            {
+              "col": "IsTranslated",
+              "label": "Translated",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 90,
+              "mandatory": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "orderBy": "M_Product_Trl.AD_Language",
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Located at",
+          "table": "M_Storage",
+          "level": 1,
+          "seq": 130,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "DateMaterialPolicy",
+              "label": "Date  Material Policy",
+              "ref": 15,
+              "type": "date",
+              "seq": 40,
+              "len": 7
+            },
+            {
+              "col": "M_Locator_ID",
+              "label": "Locator",
+              "ref": 31,
+              "type": "locator",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "QtyOnHand",
+              "label": "On Hand Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "DateLastInventory",
+              "label": "Date Last Inventory Count",
+              "ref": 15,
+              "type": "date",
+              "seq": 90,
+              "len": 7
+            },
+            {
+              "col": "QtyOrdered",
+              "label": "Ordered Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 100,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "QtyReserved",
+              "label": "Reserved Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "orderBy": "M_Product_ID, M_AttributeSetInstance_ID, M_Locator_ID",
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "UOM Conversion",
+          "table": "C_UOM_Conversion",
+          "level": 1,
+          "seq": 140,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "C_UOM_To_ID",
+              "label": "UoM To",
+              "ref": 18,
+              "type": "table",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_UOM_To"
+            },
+            {
+              "col": "MultiplyRate",
+              "label": "Multiply Rate",
+              "ref": 22,
+              "type": "number",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "DivideRate",
+              "label": "Divide Rate",
+              "ref": 22,
+              "type": "number",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Costs",
+          "table": "M_Cost",
+          "level": 1,
+          "seq": 150,
+          "fields": [
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 10,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 40,
+              "mandatory": true,
+              "len": 10
+            },
+            {
+              "col": "C_AcctSchema_ID",
+              "label": "Accounting Schema",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "len": 10,
+              "fk": "C_AcctSchema"
+            },
+            {
+              "col": "M_CostType_ID",
+              "label": "Cost Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 60,
+              "mandatory": true,
+              "len": 10,
+              "fk": "M_CostType"
+            },
+            {
+              "col": "M_CostElement_ID",
+              "label": "Cost Element",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 70,
+              "mandatory": true,
+              "len": 10,
+              "fk": "M_CostElement"
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 80,
+              "len": 255
+            },
+            {
+              "col": "CostingMethod",
+              "label": "Costing Method",
+              "ref": 17,
+              "type": "list",
+              "seq": 100,
+              "readonly": true,
+              "dl": "1=2",
+              "def": "x",
+              "len": 1
+            },
+            {
+              "col": "CurrentCostPrice",
+              "label": "Current Cost Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "CurrentCostPriceLL",
+              "label": "Current Cost Price Lower Level",
+              "ref": 37,
+              "type": "string",
+              "seq": 120,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "FutureCostPrice",
+              "label": "Future Cost Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "dl": "@CostingMethod@=S",
+              "len": 22
+            },
+            {
+              "col": "FutureCostPriceLL",
+              "label": "Future Cost Price Lower Level",
+              "ref": 37,
+              "type": "string",
+              "seq": 140,
+              "readonly": true,
+              "dl": "@CostingMethod@=S",
+              "len": 22
+            },
+            {
+              "col": "Percent",
+              "label": "Percent",
+              "ref": 11,
+              "type": "integer",
+              "seq": 150,
+              "dl": "@CostingMethod@=x",
+              "len": 10
+            },
+            {
+              "col": "CurrentQty",
+              "label": "Current Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 160,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "IsCostFrozen",
+              "label": "Cost Frozen",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 170,
+              "readonly": true,
+              "dl": "@CostingMethod@=S",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "CumulatedAmt",
+              "label": "Accumulated Amt",
+              "ref": 12,
+              "type": "amount",
+              "seq": 180,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "CumulatedQty",
+              "label": "Accumulated Qty",
+              "ref": 29,
+              "type": "string",
+              "seq": 190,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "Processed",
+              "label": "Processed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 200,
+              "readonly": true,
+              "dl": "1=2",
+              "def": "N",
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Reserved Quantity Log",
+          "table": "M_StorageReservationLog",
+          "level": 1,
+          "seq": 160,
+          "fields": [
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 30,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 60,
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 255
+            },
+            {
+              "col": "LineNo",
+              "label": "Line",
+              "ref": 11,
+              "type": "integer",
+              "seq": 80,
+              "len": 10
+            },
+            {
+              "col": "AD_Table_ID",
+              "label": "Table",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 90,
+              "mandatory": true,
+              "len": 10,
+              "fk": "AD_Table"
+            },
+            {
+              "col": "Record_ID",
+              "label": "Record ID",
+              "ref": 200202,
+              "type": "string",
+              "seq": 100,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "OldQty",
+              "label": "Old Current Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "DeltaQty",
+              "label": "Delta Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "NewQty",
+              "label": "New Current Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "readonly": true,
+          "where": "M_StorageReservationLog.IsSOTrx='Y'",
+          "orderBy": "M_StorageReservationLog.M_Warehouse_ID, M_StorageReservationLog.M_AttributeSetInstance_ID, M_StorageReservationLog.M_StorageReservationLog_ID Desc",
+          "fk": "M_Product_ID"
+        },
+        {
+          "name": "Ordered Quantity Log",
+          "table": "M_StorageReservationLog",
+          "level": 1,
+          "seq": 170,
+          "fields": [
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 30,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 60,
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 255
+            },
+            {
+              "col": "LineNo",
+              "label": "Line",
+              "ref": 11,
+              "type": "integer",
+              "seq": 80,
+              "len": 10
+            },
+            {
+              "col": "AD_Table_ID",
+              "label": "Table",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 90,
+              "mandatory": true,
+              "len": 10,
+              "fk": "AD_Table"
+            },
+            {
+              "col": "Record_ID",
+              "label": "Record ID",
+              "ref": 200202,
+              "type": "string",
+              "seq": 100,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "OldQty",
+              "label": "Old Current Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "DeltaQty",
+              "label": "Delta Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "NewQty",
+              "label": "New Current Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22
+            }
+          ],
+          "readonly": true,
+          "where": "M_StorageReservationLog.IsSOTrx='N'",
+          "orderBy": "M_StorageReservationLog.M_Warehouse_ID, M_StorageReservationLog.M_AttributeSetInstance_ID, M_StorageReservationLog.M_StorageReservationLog_ID Desc",
+          "fk": "M_Product_ID"
+        }
+      ],
+      "node": "Products"
+    },
+    "143": {
+      "name": "Sales Order",
+      "table": "C_Order",
+      "tabs": [
+        {
+          "name": "Order",
+          "table": "C_Order",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 30
+            },
+            {
+              "col": "POReference",
+              "label": "Order Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 40,
+              "len": 20
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 50,
+              "len": 255
+            },
+            {
+              "col": "C_DocTypeTarget_ID",
+              "label": "Target Document Type",
+              "ref": 18,
+              "type": "table",
+              "seq": 60,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_DocTypeTarget"
+            },
+            {
+              "col": "IsSelfService",
+              "label": "Self-Service",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 70,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "DateOrdered",
+              "label": "Date Ordered",
+              "ref": 15,
+              "type": "date",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "DatePromised",
+              "label": "Date Promised",
+              "ref": 15,
+              "type": "date",
+              "seq": 90,
+              "mandatory": true,
+              "dl": "@OrderType@='SO' | @OrderType@='PR'",
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 100,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "Bill_BPartner_ID",
+              "label": "Invoice Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 110,
+              "len": 22,
+              "fk": "Bill_BPartner"
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "Bill_Location_ID",
+              "label": "Invoice Location",
+              "ref": 18,
+              "type": "table",
+              "seq": 130,
+              "len": 22,
+              "fk": "Bill_Location"
+            },
+            {
+              "col": "AD_User_ID",
+              "label": "User/Contact",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 140,
+              "def": "-1",
+              "len": 22,
+              "fk": "AD_User"
+            },
+            {
+              "col": "Bill_User_ID",
+              "label": "Invoice Contact",
+              "ref": 18,
+              "type": "table",
+              "seq": 150,
+              "len": 22,
+              "fk": "Bill_User"
+            },
+            {
+              "col": "DeliveryRule",
+              "label": "Delivery Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 160,
+              "mandatory": true,
+              "dl": "@OrderType@='PR' | @OrderType@='SO'",
+              "def": "F",
+              "len": 1
+            },
+            {
+              "col": "PriorityRule",
+              "label": "Priority",
+              "ref": 17,
+              "type": "list",
+              "seq": 170,
+              "mandatory": true,
+              "dl": "@OrderType@='PR' | @OrderType@='SO'",
+              "def": "5",
+              "len": 1
+            },
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 180,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "IsDropShip",
+              "label": "Drop Shipment",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 190,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DropShip_BPartner_ID",
+              "label": "Drop Ship Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 200,
+              "dl": "@IsDropShip@='Y'",
+              "len": 22,
+              "fk": "DropShip_BPartner"
+            },
+            {
+              "col": "DropShip_Location_ID",
+              "label": "Drop Shipment Location",
+              "ref": 18,
+              "type": "table",
+              "seq": 210,
+              "dl": "@IsDropShip@='Y'",
+              "len": 22,
+              "fk": "DropShip_Location"
+            },
+            {
+              "col": "DropShip_User_ID",
+              "label": "Drop Shipment Contact",
+              "ref": 18,
+              "type": "table",
+              "seq": 220,
+              "dl": "@IsDropShip@='Y'",
+              "len": 22,
+              "fk": "DropShip_User"
+            },
+            {
+              "col": "DeliveryViaRule",
+              "label": "Delivery Via",
+              "ref": 17,
+              "type": "list",
+              "seq": 230,
+              "mandatory": true,
+              "def": "P",
+              "len": 1
+            },
+            {
+              "col": "M_Shipper_ID",
+              "label": "Shipper",
+              "ref": 18,
+              "type": "table",
+              "seq": 240,
+              "dl": "@DeliveryViaRule@='S'",
+              "len": 22,
+              "fk": "M_Shipper"
+            },
+            {
+              "col": "FreightCostRule",
+              "label": "Freight Cost Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 250,
+              "mandatory": true,
+              "dl": "@OrderType@='SO'",
+              "def": "I",
+              "len": 1
+            },
+            {
+              "col": "M_FreightCategory_ID",
+              "label": "Freight Category",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 260,
+              "dl": "@DeliveryViaRule@='S'",
+              "len": 1,
+              "fk": "M_FreightCategory"
+            },
+            {
+              "col": "FreightAmt",
+              "label": "Freight Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 270,
+              "mandatory": true,
+              "dl": "@OrderType@='SO' & @FreightCostRule@='F'",
+              "len": 22
+            },
+            {
+              "col": "IsPriviledgedRate",
+              "label": "Privileged Rate",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 280,
+              "mandatory": true,
+              "dl": "@OrderType@='SO' & @FreightCostRule@='C'",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "InvoiceRule",
+              "label": "Invoice Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 300,
+              "mandatory": true,
+              "dl": "@OrderType@='SO' | @OrderType@='WP' | @OrderType@='PR'",
+              "def": "I",
+              "len": 1
+            },
+            {
+              "col": "M_PriceList_ID",
+              "label": "Price List",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 310,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_PriceList"
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 320,
+              "mandatory": true,
+              "readonly": true,
+              "def": "@C_Currency_ID@",
+              "len": 22,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "C_ConversionType_ID",
+              "label": "Currency Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 330,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@",
+              "len": 22,
+              "fk": "C_ConversionType"
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Sales Representative",
+              "ref": 18,
+              "type": "table",
+              "seq": 340,
+              "mandatory": true,
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "IsDiscountPrinted",
+              "label": "Discount Printed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 350,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 18,
+              "type": "table",
+              "seq": 360,
+              "dl": "@HasCharges@='Y'",
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "ChargeAmt",
+              "label": "Charge amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 370,
+              "dl": "@HasCharges@='Y'",
+              "len": 22
+            },
+            {
+              "col": "PaymentRule",
+              "label": "Payment Rule",
+              "ref": 200012,
+              "type": "string",
+              "seq": 380,
+              "mandatory": true,
+              "def": "B",
+              "len": 1
+            },
+            {
+              "col": "C_PaymentTerm_ID",
+              "label": "Payment Term",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 390,
+              "mandatory": true,
+              "dl": "@PaymentRule@='P' | @PaymentRule@='D'",
+              "len": 22,
+              "fk": "C_PaymentTerm"
+            },
+            {
+              "col": "PromotionCode",
+              "label": "Promotion Code",
+              "ref": 10,
+              "type": "string",
+              "seq": 400,
+              "len": 30
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 410,
+              "dl": "@$Element_PJ@='Y'",
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 420,
+              "dl": "@$Element_AY@='Y'",
+              "len": 22,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 430,
+              "dl": "@$Element_MC@=Y",
+              "len": 22,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 440,
+              "dl": "@$Element_OT@=Y",
+              "len": 22,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 450,
+              "dl": "@$Element_U1@=Y",
+              "len": 22,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 460,
+              "dl": "@$Element_U2@=Y",
+              "len": 22,
+              "fk": "User2"
+            },
+            {
+              "col": "TotalLines",
+              "label": "Total Lines",
+              "ref": 12,
+              "type": "amount",
+              "seq": 470,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "GrandTotal",
+              "label": "Grand Total",
+              "ref": 12,
+              "type": "amount",
+              "seq": 480,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "DocStatus",
+              "label": "Document Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 490,
+              "mandatory": true,
+              "readonly": true,
+              "def": "DR",
+              "len": 2
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 500,
+              "mandatory": true,
+              "readonly": true,
+              "def": "0",
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "IsPayScheduleValid",
+              "label": "Pay Schedule valid",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 510,
+              "mandatory": true,
+              "readonly": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "C_OrderSource_ID",
+              "label": "Order Source",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 540,
+              "len": 10,
+              "fk": "C_OrderSource"
+            },
+            {
+              "col": "C_CashPlanLine_ID",
+              "label": "Cash Plan Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 560,
+              "len": 10,
+              "fk": "C_CashPlanLine"
+            },
+            {
+              "col": "QuotationOrder_ID",
+              "label": "Quotation",
+              "ref": 30,
+              "type": "search",
+              "seq": 570,
+              "readonly": true,
+              "dl": "@QuotationOrder_ID@>0",
+              "len": 10,
+              "fk": "QuotationOrder"
+            },
+            {
+              "col": "Link_Order_ID",
+              "label": "Linked Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 580,
+              "readonly": true,
+              "dl": "@Link_Order_ID:0@>0",
+              "len": 22,
+              "fk": "Link_Order"
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 590,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 600,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            }
+          ],
+          "singleRow": true,
+          "where": "C_Order.IsSOTrx='Y'"
+        },
+        {
+          "name": "Order Line",
+          "table": "C_OrderLine",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "readonly": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @OrderType@='WP' | @Processed@='Y'\n",
+              "def": "@SQL=SELECT C_BPartner_ID AS DefaultValue FROM C_Order WHERE C_Order_ID=@C_Order_ID@",
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @OrderType@='WP' | @Processed@='Y'",
+              "def": "@C_BPartner_Location_ID@",
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "DatePromised",
+              "label": "Date Promised",
+              "ref": 15,
+              "type": "date",
+              "seq": 60,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @OrderType@='WP'",
+              "def": "@DatePromised@",
+              "len": 7
+            },
+            {
+              "col": "DateOrdered",
+              "label": "Date Ordered",
+              "ref": 15,
+              "type": "date",
+              "seq": 70,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @OrderType@='WP'",
+              "def": "@DateOrdered@",
+              "len": 7
+            },
+            {
+              "col": "Line",
+              "label": "Line No",
+              "ref": 11,
+              "type": "integer",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM C_OrderLine WHERE C_Order_ID=@C_Order_ID@",
+              "len": 22
+            },
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 18,
+              "type": "table",
+              "seq": 90,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @Processed@='Y'",
+              "def": "@M_Warehouse_ID@",
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 100,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 110,
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "S_ResourceAssignment_ID",
+              "label": "Resource Assignment",
+              "ref": 33,
+              "type": "assignment",
+              "seq": 130,
+              "len": 22
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 140,
+              "len": 255
+            },
+            {
+              "col": "QtyEntered",
+              "label": "Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 150,
+              "mandatory": true,
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 160,
+              "mandatory": true,
+              "def": "@#C_UOM_ID@",
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "QtyOrdered",
+              "label": "Ordered Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 170,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@UOMConversion@=Y | @Processed@='Y'",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "QtyDelivered",
+              "label": "Delivered Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 180,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @Processed@='Y'",
+              "len": 22
+            },
+            {
+              "col": "QtyReserved",
+              "label": "Reserved Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 190,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@OrderType@='OB' | @OrderType@='SO' | @Processed@='Y'",
+              "len": 22
+            },
+            {
+              "col": "QtyInvoiced",
+              "label": "Quantity Invoiced",
+              "ref": 29,
+              "type": "string",
+              "seq": 200,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@OrderType@='SO' | @Processed@=Y",
+              "len": 22
+            },
+            {
+              "col": "M_Shipper_ID",
+              "label": "Shipper",
+              "ref": 18,
+              "type": "table",
+              "seq": 210,
+              "dl": "@DeliveryViaRule@='S'",
+              "def": "@M_Shipper_ID@",
+              "len": 22,
+              "fk": "M_Shipper"
+            },
+            {
+              "col": "PriceEntered",
+              "label": "Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 220,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PriceActual",
+              "label": "Unit Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 230,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PriceList",
+              "label": "List Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 240,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "FreightAmt",
+              "label": "Freight Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 250,
+              "mandatory": true,
+              "dl": "@FreightCostRule@='L'",
+              "len": 22
+            },
+            {
+              "col": "C_Tax_ID",
+              "label": "Tax",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 260,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_Tax"
+            },
+            {
+              "col": "Discount",
+              "label": "Discount %",
+              "ref": 22,
+              "type": "number",
+              "seq": 270,
+              "len": 22
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 280,
+              "dl": "@$Element_PJ@='Y'",
+              "len": 10,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "dl": "@$Element_AY@='Y'",
+              "len": 10,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 300,
+              "dl": "@$Element_MC@='Y'",
+              "len": 10,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 310,
+              "dl": "@$Element_OT@=Y",
+              "len": 10,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 320,
+              "dl": "@$Element_U1@='Y'",
+              "len": 10,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 330,
+              "dl": "@$Element_U2@='Y'",
+              "len": 10,
+              "fk": "User2"
+            },
+            {
+              "col": "LineNetAmt",
+              "label": "Line Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 340,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "QtyLostSales",
+              "label": "Lost Sales Qty",
+              "ref": 29,
+              "type": "string",
+              "seq": 350,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@Processed@=Y",
+              "len": 22
+            },
+            {
+              "col": "Processed",
+              "label": "Processed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 360,
+              "mandatory": true,
+              "dl": "1=2",
+              "len": 1
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 390,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 400,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Order_ID"
+        },
+        {
+          "name": "Order Tax",
+          "table": "C_OrderTax",
+          "level": 1,
+          "seq": 30,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_Tax_ID",
+              "label": "Tax",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_Tax"
+            },
+            {
+              "col": "C_TaxProvider_ID",
+              "label": "Tax Provider",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "len": 22,
+              "fk": "C_TaxProvider"
+            },
+            {
+              "col": "TaxAmt",
+              "label": "Tax Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 60,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "TaxBaseAmt",
+              "label": "Tax base Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 70,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "IsTaxIncluded",
+              "label": "Price includes Tax",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 80,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "fk": "C_Order_ID"
+        },
+        {
+          "name": "Payment Schedule",
+          "table": "C_OrderPaySchedule",
+          "level": 1,
+          "seq": 40,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_PaySchedule_ID",
+              "label": "Payment Schedule",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "len": 22,
+              "fk": "C_PaySchedule"
+            },
+            {
+              "col": "DueDate",
+              "label": "Due Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 60,
+              "mandatory": true,
+              "len": 7
+            },
+            {
+              "col": "DueAmt",
+              "label": "Amount due",
+              "ref": 12,
+              "type": "amount",
+              "seq": 70,
+              "mandatory": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "DiscountDate",
+              "label": "Discount Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 80,
+              "mandatory": true,
+              "identifier": true,
+              "len": 7
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 90,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "IsValid",
+              "label": "Valid",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 110,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Order_ID"
+        },
+        {
+          "name": "POS Payment",
+          "table": "C_POSPayment",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "len": 10,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_Payment_ID",
+              "label": "Payment",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_Payment"
+            },
+            {
+              "col": "C_POSTenderType_ID",
+              "label": "POS Tender Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "len": 10,
+              "fk": "C_POSTenderType"
+            },
+            {
+              "col": "TenderType",
+              "label": "Tender type",
+              "ref": 17,
+              "type": "list",
+              "seq": 60,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "PayAmt",
+              "label": "Payment amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "A_Name",
+              "label": "Account Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "dl": "@TenderType@=C | @TenderType@=K",
+              "len": 60
+            },
+            {
+              "col": "RoutingNo",
+              "label": "Routing No",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "CheckNo",
+              "label": "Check No",
+              "ref": 10,
+              "type": "string",
+              "seq": 100,
+              "dl": "@TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "AccountNo",
+              "label": "Account No",
+              "ref": 10,
+              "type": "string",
+              "seq": 110,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "Micr",
+              "label": "Micr",
+              "ref": 10,
+              "type": "string",
+              "seq": 120,
+              "dl": "@TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "IsPostDated",
+              "label": "Post Dated",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 130,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@TenderType@=K",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DatePromised",
+              "label": "Date Promised",
+              "ref": 15,
+              "type": "date",
+              "seq": 140,
+              "dl": "@TenderType@=K & @IsPostDated@=Y",
+              "len": 10
+            },
+            {
+              "col": "CheckStatus",
+              "label": "Check Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 150,
+              "dl": "@TenderType@=K & @IsPostDated@=Y",
+              "len": 1
+            },
+            {
+              "col": "CreditCardType",
+              "label": "Credit Card",
+              "ref": 17,
+              "type": "list",
+              "seq": 160,
+              "dl": "@TenderType@=C",
+              "len": 1
+            },
+            {
+              "col": "CreditCardNumber",
+              "label": "Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 170,
+              "dl": "@TenderType@=C",
+              "len": 20
+            },
+            {
+              "col": "VoiceAuthCode",
+              "label": "Voice authorization code",
+              "ref": 10,
+              "type": "string",
+              "seq": 180,
+              "dl": "@TenderType@=C",
+              "len": 20
+            },
+            {
+              "col": "DepositGroup",
+              "label": "Deposit Group",
+              "ref": 10,
+              "type": "string",
+              "seq": 190,
+              "len": 20
+            },
+            {
+              "col": "Help",
+              "label": "Comment/Help",
+              "ref": 14,
+              "type": "text",
+              "seq": 200,
+              "len": 2000
+            },
+            {
+              "col": "Processed",
+              "label": "Processed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 210,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Order_ID"
+        }
+      ],
+      "node": "Orders"
+    },
+    "167": {
+      "name": "Sales Invoice and Credit/Debit Note",
+      "table": "C_Invoice",
+      "tabs": [
+        {
+          "name": "Invoice",
+          "table": "C_Invoice",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "DateOrdered",
+              "label": "Date Ordered",
+              "ref": 15,
+              "type": "date",
+              "seq": 40,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 30
+            },
+            {
+              "col": "POReference",
+              "label": "Order Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "len": 20
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 70,
+              "len": 255
+            },
+            {
+              "col": "C_DocTypeTarget_ID",
+              "label": "Target Document Type",
+              "ref": 18,
+              "type": "table",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_DocTypeTarget"
+            },
+            {
+              "col": "IsSelfService",
+              "label": "Self-Service",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 90,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "DateInvoiced",
+              "label": "Date Invoiced",
+              "ref": 15,
+              "type": "date",
+              "seq": 100,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "DateAcct",
+              "label": "Account Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 110,
+              "mandatory": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "AD_User_ID",
+              "label": "User/Contact",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 140,
+              "def": "-1",
+              "len": 22,
+              "fk": "AD_User"
+            },
+            {
+              "col": "M_PriceList_ID",
+              "label": "Price List",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 150,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_PriceList"
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 160,
+              "mandatory": true,
+              "readonly": true,
+              "def": "@C_Currency_ID@",
+              "len": 22,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "C_ConversionType_ID",
+              "label": "Currency Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 170,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@",
+              "len": 22,
+              "fk": "C_ConversionType"
+            },
+            {
+              "col": "IsOverrideCurrencyRate",
+              "label": "Override Currency Conversion Rate",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 180,
+              "mandatory": true,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "CurrencyRate",
+              "label": "Rate",
+              "ref": 22,
+              "type": "number",
+              "seq": 190,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@ & @IsOverrideCurrencyRate@=Y",
+              "len": 22
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Sales Representative",
+              "ref": 30,
+              "type": "search",
+              "seq": 200,
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "IsDiscountPrinted",
+              "label": "Discount Printed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 210,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 18,
+              "type": "table",
+              "seq": 220,
+              "dl": "@HasCharges@='Y'",
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "ChargeAmt",
+              "label": "Charge amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 230,
+              "dl": "@HasCharges@='Y'",
+              "len": 22
+            },
+            {
+              "col": "PaymentRule",
+              "label": "Payment Rule",
+              "ref": 200012,
+              "type": "string",
+              "seq": 240,
+              "mandatory": true,
+              "def": "P",
+              "len": 1
+            },
+            {
+              "col": "C_PaymentTerm_ID",
+              "label": "Payment Term",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 250,
+              "mandatory": true,
+              "dl": "@PaymentRule@='P' | @PaymentRule@='D'",
+              "len": 22,
+              "fk": "C_PaymentTerm"
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 270,
+              "dl": "@$Element_PJ@='Y'",
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 280,
+              "dl": "@$Element_AY@='Y'",
+              "len": 22,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "dl": "@$Element_MC@='Y'",
+              "len": 22,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 300,
+              "dl": "@$Element_OT@=Y",
+              "len": 22,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 310,
+              "dl": "@$Element_U1@=Y",
+              "len": 22,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 320,
+              "dl": "@$Element_U2@=Y",
+              "len": 22,
+              "fk": "User2"
+            },
+            {
+              "col": "TotalLines",
+              "label": "Total Lines",
+              "ref": 12,
+              "type": "amount",
+              "seq": 330,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "GrandTotal",
+              "label": "Grand Total",
+              "ref": 12,
+              "type": "amount",
+              "seq": 340,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "DocStatus",
+              "label": "Document Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 350,
+              "mandatory": true,
+              "readonly": true,
+              "def": "DR",
+              "len": 2
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 360,
+              "mandatory": true,
+              "readonly": true,
+              "def": "0",
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "IsPayScheduleValid",
+              "label": "Pay Schedule valid",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 370,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "IsInDispute",
+              "label": "In Dispute",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 380,
+              "mandatory": true,
+              "dl": "@Processed@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsPaid",
+              "label": "Paid",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 420,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@Processed@=Y",
+              "len": 1
+            },
+            {
+              "col": "InvoiceCollectionType",
+              "label": "Collection Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 430,
+              "dl": "@Processed@=Y",
+              "len": 1
+            },
+            {
+              "col": "DunningGrace",
+              "label": "Dunning Grace Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 440,
+              "dl": "@Processed@=Y",
+              "len": 7
+            },
+            {
+              "col": "C_DunningLevel_ID",
+              "label": "Dunning Level",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 450,
+              "readonly": true,
+              "dl": "@Processed@=Y",
+              "len": 22,
+              "fk": "C_DunningLevel"
+            },
+            {
+              "col": "C_CashPlanLine_ID",
+              "label": "Cash Plan Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 460,
+              "len": 10,
+              "fk": "C_CashPlanLine"
+            },
+            {
+              "col": "IsFixedAssetInvoice",
+              "label": "Is Fixed Asset Invoice",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 470,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "RelatedInvoice_ID",
+              "label": "Related Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 480,
+              "readonly": true,
+              "dl": "@RelatedInvoice_ID@ > 0",
+              "len": 10,
+              "fk": "RelatedInvoice"
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 490,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 500,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            },
+            {
+              "col": "C_Employee_ID",
+              "label": "Employee",
+              "ref": 18,
+              "type": "table",
+              "seq": 510,
+              "dl": "@$Element_EP@=Y",
+              "len": 10,
+              "fk": "C_Employee"
+            }
+          ],
+          "singleRow": true,
+          "where": "C_Invoice.IsSOTrx='Y'"
+        },
+        {
+          "name": "Invoice Line",
+          "table": "C_InvoiceLine",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "Line",
+              "label": "Line No",
+              "ref": 11,
+              "type": "integer",
+              "seq": 40,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@SQL=SELECT NVL(MAX(Line),0)+10 AS DefaultValue FROM C_InvoiceLine WHERE C_Invoice_ID=@C_Invoice_ID@",
+              "len": 22
+            },
+            {
+              "col": "M_InOutLine_ID",
+              "label": "Shipment/Receipt Line",
+              "ref": 30,
+              "type": "search",
+              "seq": 50,
+              "readonly": true,
+              "len": 22,
+              "fk": "M_InOutLine"
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 60,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 70,
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 80,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "S_ResourceAssignment_ID",
+              "label": "Resource Assignment",
+              "ref": 33,
+              "type": "assignment",
+              "seq": 90,
+              "len": 22
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 100,
+              "len": 255
+            },
+            {
+              "col": "QtyEntered",
+              "label": "Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 120,
+              "def": "@#C_UOM_ID@",
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "QtyInvoiced",
+              "label": "Quantity Invoiced",
+              "ref": 29,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@UOMConversion@=Y | @Processed@=Y",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "PriceEntered",
+              "label": "Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 140,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "PriceActual",
+              "label": "Unit Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 150,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "PriceList",
+              "label": "List Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 160,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "C_Tax_ID",
+              "label": "Tax",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 170,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_Tax"
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 180,
+              "dl": "@$Element_PJ@='Y'",
+              "len": 10,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 190,
+              "dl": "@$Element_AY@='Y'",
+              "len": 10,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 200,
+              "dl": "@$Element_MC@='Y'",
+              "len": 10,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 210,
+              "dl": "@$Element_OT@=Y",
+              "len": 10,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 220,
+              "dl": "@$Element_U1@='Y'",
+              "len": 10,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 230,
+              "dl": "@$Element_U2@='Y'",
+              "len": 10,
+              "fk": "User2"
+            },
+            {
+              "col": "LineNetAmt",
+              "label": "Line Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 240,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "IsDescription",
+              "label": "Description Only",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 250,
+              "mandatory": true,
+              "readonly": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "A_Asset_ID",
+              "label": "Asset",
+              "ref": 30,
+              "type": "search",
+              "seq": 260,
+              "len": 22,
+              "fk": "A_Asset"
+            },
+            {
+              "col": "IsPrinted",
+              "label": "Printed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 270,
+              "mandatory": true,
+              "readonly": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 280,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            },
+            {
+              "col": "C_Employee_ID",
+              "label": "Employee",
+              "ref": 18,
+              "type": "table",
+              "seq": 300,
+              "dl": "@$Element_EP@=Y",
+              "len": 10,
+              "fk": "C_Employee"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Invoice_ID"
+        },
+        {
+          "name": "Invoice Tax",
+          "table": "C_InvoiceTax",
+          "level": 1,
+          "seq": 30,
+          "fields": [
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "C_Tax_ID",
+              "label": "Tax",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_Tax"
+            },
+            {
+              "col": "C_TaxProvider_ID",
+              "label": "Tax Provider",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "len": 22,
+              "fk": "C_TaxProvider"
+            },
+            {
+              "col": "TaxAmt",
+              "label": "Tax Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 60,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "TaxBaseAmt",
+              "label": "Tax base Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 70,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "IsTaxIncluded",
+              "label": "Price includes Tax",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 80,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "fk": "C_Invoice_ID"
+        },
+        {
+          "name": "Payment Schedule",
+          "table": "C_InvoicePaySchedule",
+          "level": 1,
+          "seq": 40,
+          "fields": [
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 50,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "C_PaySchedule_ID",
+              "label": "Payment Schedule",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 60,
+              "len": 22,
+              "fk": "C_PaySchedule"
+            },
+            {
+              "col": "DueDate",
+              "label": "Due Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 80,
+              "mandatory": true,
+              "len": 7
+            },
+            {
+              "col": "DueAmt",
+              "label": "Amount due",
+              "ref": 12,
+              "type": "amount",
+              "seq": 90,
+              "mandatory": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "DiscountDate",
+              "label": "Discount Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 100,
+              "mandatory": true,
+              "identifier": true,
+              "len": 7
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 110,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "IsValid",
+              "label": "Valid",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 130,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Invoice_ID"
+        },
+        {
+          "name": "Allocation",
+          "table": "C_AllocationLine",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "readonly": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "C_AllocationHdr_ID",
+              "label": "Allocation",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AllocationHdr"
+            },
+            {
+              "col": "DateTrx",
+              "label": "Transaction Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 50,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "C_Payment_ID",
+              "label": "Payment",
+              "ref": 30,
+              "type": "search",
+              "seq": 60,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Payment"
+            },
+            {
+              "col": "Amount",
+              "label": "Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 80,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 100,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "WriteOffAmt",
+              "label": "Write-off Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 110,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "OverUnderAmt",
+              "label": "Over/Under Payment",
+              "ref": 12,
+              "type": "amount",
+              "seq": 120,
+              "readonly": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "fk": "C_Invoice_ID"
+        }
+      ],
+      "node": "Invoices"
+    },
+    "169": {
+      "name": "Shipment (Customer)",
+      "table": "M_InOut",
+      "tabs": [
+        {
+          "name": "Shipment",
+          "table": "M_InOut",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "DateOrdered",
+              "label": "Date Ordered",
+              "ref": 15,
+              "type": "date",
+              "seq": 40,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "M_RMA_ID",
+              "label": "RMA",
+              "ref": 30,
+              "type": "search",
+              "seq": 50,
+              "dl": "@M_RMA_ID@!0",
+              "len": 22,
+              "fk": "M_RMA"
+            },
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 60,
+              "mandatory": true,
+              "identifier": true,
+              "len": 30
+            },
+            {
+              "col": "POReference",
+              "label": "Order Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 70,
+              "len": 20
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 80,
+              "len": 255
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 18,
+              "type": "table",
+              "seq": 90,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "MovementDate",
+              "label": "Movement Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 100,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "DateAcct",
+              "label": "Account Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 110,
+              "mandatory": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 120,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 130,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "AD_User_ID",
+              "label": "User/Contact",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 140,
+              "def": "-1",
+              "len": 22,
+              "fk": "AD_User"
+            },
+            {
+              "col": "M_Warehouse_ID",
+              "label": "Warehouse",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 150,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Warehouse"
+            },
+            {
+              "col": "PriorityRule",
+              "label": "Priority",
+              "ref": 17,
+              "type": "list",
+              "seq": 160,
+              "mandatory": true,
+              "def": "5",
+              "len": 1
+            },
+            {
+              "col": "DeliveryRule",
+              "label": "Delivery Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 170,
+              "mandatory": true,
+              "def": "A",
+              "len": 1
+            },
+            {
+              "col": "PickDate",
+              "label": "Pick Date",
+              "ref": 16,
+              "type": "datetime",
+              "seq": 180,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "SalesRep_ID",
+              "label": "Sales Representative",
+              "ref": 18,
+              "type": "table",
+              "seq": 190,
+              "len": 22,
+              "fk": "SalesRep"
+            },
+            {
+              "col": "DeliveryViaRule",
+              "label": "Delivery Via",
+              "ref": 17,
+              "type": "list",
+              "seq": 200,
+              "mandatory": true,
+              "def": "P",
+              "len": 1
+            },
+            {
+              "col": "M_Shipper_ID",
+              "label": "Shipper",
+              "ref": 18,
+              "type": "table",
+              "seq": 210,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 22,
+              "fk": "M_Shipper"
+            },
+            {
+              "col": "ShipDate",
+              "label": "Ship Date",
+              "ref": 16,
+              "type": "datetime",
+              "seq": 230,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 7
+            },
+            {
+              "col": "NoPackages",
+              "label": "No Packages",
+              "ref": 11,
+              "type": "integer",
+              "seq": 240,
+              "dl": "@DeliveryViaRule@=S",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "TrackingNo",
+              "label": "Tracking No",
+              "ref": 10,
+              "type": "string",
+              "seq": 250,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 60
+            },
+            {
+              "col": "FreightCostRule",
+              "label": "Freight Cost Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 260,
+              "mandatory": true,
+              "def": "I",
+              "len": 1
+            },
+            {
+              "col": "FreightAmt",
+              "label": "Freight Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 270,
+              "dl": "@FreightCostRule@='F'",
+              "len": 22
+            },
+            {
+              "col": "FreightCharges",
+              "label": "Freight Charges",
+              "ref": 17,
+              "type": "list",
+              "seq": 280,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 10
+            },
+            {
+              "col": "FOB",
+              "label": "Freight Terms",
+              "ref": 17,
+              "type": "list",
+              "seq": 290,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 10
+            },
+            {
+              "col": "Insurance",
+              "label": "Insurance",
+              "ref": 17,
+              "type": "list",
+              "seq": 300,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 1
+            },
+            {
+              "col": "ShipperAccount",
+              "label": "Shipper Account Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 310,
+              "dl": "@DeliveryViaRule@=S",
+              "len": 40
+            },
+            {
+              "col": "IsDropShip",
+              "label": "Drop Shipment",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 330,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DropShip_BPartner_ID",
+              "label": "Drop Ship Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 340,
+              "dl": "@IsDropShip@='Y'",
+              "len": 10,
+              "fk": "DropShip_BPartner"
+            },
+            {
+              "col": "DropShip_Location_ID",
+              "label": "Drop Shipment Location",
+              "ref": 18,
+              "type": "table",
+              "seq": 350,
+              "dl": "@IsDropShip@='Y'",
+              "len": 10,
+              "fk": "DropShip_Location"
+            },
+            {
+              "col": "DropShip_User_ID",
+              "label": "Drop Shipment Contact",
+              "ref": 18,
+              "type": "table",
+              "seq": 360,
+              "dl": "@IsDropShip@='Y'",
+              "len": 10,
+              "fk": "DropShip_User"
+            },
+            {
+              "col": "IsAlternateReturnAddress",
+              "label": "Alternate Return Address",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 370,
+              "mandatory": true,
+              "dl": "@DeliveryViaRule@=S",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "ReturnBPartner_ID",
+              "label": "Return Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 380,
+              "dl": "@DeliveryViaRule@=S & @IsAlternateReturnAddress@='Y'",
+              "len": 10,
+              "fk": "ReturnBPartner"
+            },
+            {
+              "col": "ReturnLocation_ID",
+              "label": "Return Location",
+              "ref": 18,
+              "type": "table",
+              "seq": 390,
+              "dl": "@DeliveryViaRule@=S & @IsAlternateReturnAddress@='Y'",
+              "len": 10,
+              "fk": "ReturnLocation"
+            },
+            {
+              "col": "ReturnUser_ID",
+              "label": "Return User/Contact",
+              "ref": 18,
+              "type": "table",
+              "seq": 400,
+              "dl": "@DeliveryViaRule@=S & @IsAlternateReturnAddress@='Y'",
+              "len": 10,
+              "fk": "ReturnUser"
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 18,
+              "type": "table",
+              "seq": 420,
+              "dl": "@HasCharges@='Y'",
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "ChargeAmt",
+              "label": "Charge amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 430,
+              "dl": "@HasCharges@='Y'",
+              "len": 22
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 440,
+              "dl": "@$Element_PJ@=Y",
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 450,
+              "dl": "@$Element_AY@=Y",
+              "len": 22,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 460,
+              "dl": "@$Element_MC@=Y",
+              "len": 22,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 470,
+              "dl": "@$Element_OT@=Y",
+              "len": 22,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 480,
+              "dl": "@$Element_U1@=Y",
+              "len": 22,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 490,
+              "dl": "@$Element_U2@=Y",
+              "len": 22,
+              "fk": "User2"
+            },
+            {
+              "col": "MovementType",
+              "label": "Movement Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 500,
+              "mandatory": true,
+              "readonly": true,
+              "len": 2
+            },
+            {
+              "col": "IsInTransit",
+              "label": "In Transit",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 520,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "DateReceived",
+              "label": "Date Received",
+              "ref": 15,
+              "type": "date",
+              "seq": 530,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "DocStatus",
+              "label": "Document Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 540,
+              "mandatory": true,
+              "readonly": true,
+              "def": "DR",
+              "len": 2
+            },
+            {
+              "col": "IsInDispute",
+              "label": "In Dispute",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 560,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 580,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 590,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            }
+          ],
+          "singleRow": true,
+          "where": "M_InOut.MovementType IN ('C-')"
+        },
+        {
+          "name": "Shipment Line",
+          "table": "M_InOutLine",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "M_InOut_ID",
+              "label": "Shipment/Receipt",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "M_InOut"
+            },
+            {
+              "col": "C_OrderLine_ID",
+              "label": "Sales Order Line",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "len": 22,
+              "fk": "C_OrderLine"
+            },
+            {
+              "col": "Line",
+              "label": "Line No",
+              "ref": 11,
+              "type": "integer",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@SQL=SELECT NVL(MAX(Line),0)+10 AS DefaultValue FROM M_InOutLine WHERE M_InOut_ID=@M_InOut_ID@",
+              "len": 22
+            },
+            {
+              "col": "M_Product_ID",
+              "label": "Product",
+              "ref": 30,
+              "type": "search",
+              "seq": 60,
+              "identifier": true,
+              "len": 22,
+              "fk": "M_Product"
+            },
+            {
+              "col": "M_AttributeSetInstance_ID",
+              "label": "Attribute Set Instance",
+              "ref": 35,
+              "type": "string",
+              "seq": 70,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "M_Locator_ID",
+              "label": "Locator",
+              "ref": 31,
+              "type": "locator",
+              "seq": 80,
+              "def": "@M_Locator_ID@",
+              "len": 22
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 90,
+              "dl": "@C_Charge_ID@!0",
+              "len": 10,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 14,
+              "type": "text",
+              "seq": 100,
+              "len": 255
+            },
+            {
+              "col": "QtyEntered",
+              "label": "Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 110,
+              "mandatory": true,
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "C_UOM_ID",
+              "label": "UOM",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 120,
+              "mandatory": true,
+              "def": "@#C_UOM_ID@",
+              "len": 22,
+              "fk": "C_UOM"
+            },
+            {
+              "col": "MovementQty",
+              "label": "Movement Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 130,
+              "mandatory": true,
+              "identifier": true,
+              "dl": "@UOMConversion@=Y | @Processed@=Y",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "PickedQty",
+              "label": "Picked Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 140,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "TargetQty",
+              "label": "Target Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 150,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "ConfirmedQty",
+              "label": "Confirmed Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 160,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "ScrappedQty",
+              "label": "Scrapped Quantity",
+              "ref": 29,
+              "type": "string",
+              "seq": 170,
+              "readonly": true,
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 180,
+              "dl": "@$Element_PJ@=Y",
+              "len": 10,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 190,
+              "dl": "@$Element_AY@='Y'",
+              "len": 10,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_ProjectPhase_ID",
+              "label": "Project Phase",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 200,
+              "dl": "@$Element_PJ@=Y",
+              "len": 10,
+              "fk": "C_ProjectPhase"
+            },
+            {
+              "col": "C_ProjectTask_ID",
+              "label": "Project Task",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 210,
+              "dl": "@$Element_PJ@=Y",
+              "len": 10,
+              "fk": "C_ProjectTask"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 220,
+              "dl": "@$Element_MC@='Y'",
+              "len": 10,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 230,
+              "dl": "@$Element_OT@=Y",
+              "len": 10,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 240,
+              "dl": "@$Element_U1@='Y'",
+              "len": 10,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 250,
+              "dl": "@$Element_U2@='Y'",
+              "len": 10,
+              "fk": "User2"
+            },
+            {
+              "col": "IsAutoProduce",
+              "label": "Auto Produce",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 260,
+              "readonly": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 270,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 280,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_InOut_ID"
+        },
+        {
+          "name": "Packages",
+          "table": "M_Package",
+          "level": 1,
+          "seq": 50,
+          "fields": [
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 30
+            },
+            {
+              "col": "M_InOut_ID",
+              "label": "Shipment/Receipt",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_InOut"
+            },
+            {
+              "col": "LatestPickupTime",
+              "label": "Latest Pickup Time",
+              "ref": 24,
+              "type": "string",
+              "seq": 60,
+              "len": 7
+            },
+            {
+              "col": "DateReceived",
+              "label": "Date Received",
+              "ref": 15,
+              "type": "date",
+              "seq": 70,
+              "len": 7
+            },
+            {
+              "col": "ReceivedInfo",
+              "label": "Info Received",
+              "ref": 10,
+              "type": "string",
+              "seq": 80,
+              "len": 255
+            },
+            {
+              "col": "EstimatedWeight",
+              "label": "Estimated Weight",
+              "ref": 29,
+              "type": "string",
+              "seq": 90,
+              "len": 14
+            },
+            {
+              "col": "Weight",
+              "label": "Weight",
+              "ref": 29,
+              "type": "string",
+              "seq": 100,
+              "len": 14
+            },
+            {
+              "col": "C_UOM_Weight_ID",
+              "label": "UOM for Weight",
+              "ref": 18,
+              "type": "table",
+              "seq": 110,
+              "len": 10,
+              "fk": "C_UOM_Weight"
+            },
+            {
+              "col": "Length",
+              "label": "Length",
+              "ref": 29,
+              "type": "string",
+              "seq": 120,
+              "len": 14
+            },
+            {
+              "col": "C_UOM_Length_ID",
+              "label": "UOM for Length",
+              "ref": 18,
+              "type": "table",
+              "seq": 130,
+              "len": 10,
+              "fk": "C_UOM_Length"
+            },
+            {
+              "col": "Width",
+              "label": "Width",
+              "ref": 29,
+              "type": "string",
+              "seq": 140,
+              "len": 14
+            },
+            {
+              "col": "Height",
+              "label": "Height",
+              "ref": 29,
+              "type": "string",
+              "seq": 150,
+              "len": 14
+            },
+            {
+              "col": "M_Shipper_ID",
+              "label": "Shipper",
+              "ref": 18,
+              "type": "table",
+              "seq": 160,
+              "mandatory": true,
+              "len": 22,
+              "fk": "M_Shipper"
+            },
+            {
+              "col": "M_ShippingProcessor_ID",
+              "label": "Shipping Processor",
+              "ref": 18,
+              "type": "table",
+              "seq": 170,
+              "len": 10,
+              "fk": "M_ShippingProcessor"
+            },
+            {
+              "col": "ShipDate",
+              "label": "Ship Date (For FedEx only)",
+              "ref": 15,
+              "type": "date",
+              "seq": 180,
+              "len": 7
+            },
+            {
+              "col": "BoxCount",
+              "label": "Box Count",
+              "ref": 11,
+              "type": "integer",
+              "seq": 190,
+              "def": "1",
+              "len": 14
+            },
+            {
+              "col": "M_ShipperPackaging_ID",
+              "label": "Shipper Packaging",
+              "ref": 18,
+              "type": "table",
+              "seq": 200,
+              "len": 10,
+              "fk": "M_ShipperPackaging"
+            },
+            {
+              "col": "M_ShipperLabels_ID",
+              "label": "Shipper Labels",
+              "ref": 18,
+              "type": "table",
+              "seq": 210,
+              "len": 10,
+              "fk": "M_ShipperLabels"
+            },
+            {
+              "col": "M_ShipperPickupTypes_ID",
+              "label": "Shipper Pickup Types",
+              "ref": 18,
+              "type": "table",
+              "seq": 220,
+              "len": 10,
+              "fk": "M_ShipperPickupTypes"
+            },
+            {
+              "col": "Insurance",
+              "label": "Insurance",
+              "ref": 17,
+              "type": "list",
+              "seq": 230,
+              "len": 1
+            },
+            {
+              "col": "InsuredAmount",
+              "label": "Insured Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 240,
+              "len": 14
+            },
+            {
+              "col": "FreightCharges",
+              "label": "Freight Charges",
+              "ref": 17,
+              "type": "list",
+              "seq": 250,
+              "len": 10
+            },
+            {
+              "col": "FOB",
+              "label": "Freight Terms",
+              "ref": 17,
+              "type": "list",
+              "seq": 260,
+              "len": 10
+            },
+            {
+              "col": "ShipperAccount",
+              "label": "Shipper Account Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 270,
+              "len": 40
+            },
+            {
+              "col": "DutiesShipperAccount",
+              "label": "Duties Shipper Account (For FedEx only)",
+              "ref": 10,
+              "type": "string",
+              "seq": 280,
+              "len": 40
+            },
+            {
+              "col": "C_BPartner_Location_ID",
+              "label": "Partner Location (For UPS only)",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 290,
+              "len": 10,
+              "fk": "C_BPartner_Location"
+            },
+            {
+              "col": "HandlingCharge",
+              "label": "Handling Charge",
+              "ref": 12,
+              "type": "amount",
+              "seq": 300,
+              "len": 14
+            },
+            {
+              "col": "IsAddedHandling",
+              "label": "Added Handling (For UPS only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 310,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "CashOnDelivery",
+              "label": "COD",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 320,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "PaymentRule",
+              "label": "Payment Rule",
+              "ref": 17,
+              "type": "list",
+              "seq": 330,
+              "dl": "@CashOnDelivery@=Y",
+              "len": 1
+            },
+            {
+              "col": "DeliveryConfirmation",
+              "label": "Delivery Confirmation",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 340,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DeliveryConfirmationType",
+              "label": "Delivery Confirmation Type (For FedEx only)",
+              "ref": 17,
+              "type": "list",
+              "seq": 350,
+              "dl": "@DeliveryConfirmation@=Y",
+              "len": 30
+            },
+            {
+              "col": "IsVerbalConfirmation",
+              "label": "Verbal Confirmation (For UPS only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 360,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsSaturdayDelivery",
+              "label": "Saturday Delivery",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 370,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsSaturdayPickup",
+              "label": "Saturday Pickup",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 380,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsFutureDayShipment",
+              "label": "Future Day Shipment (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 390,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsResidential",
+              "label": "Residential",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 400,
+              "mandatory": true,
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "HomeDeliveryPremiumType",
+              "label": "Home Delivery Premium Type (For FedEx only)",
+              "ref": 17,
+              "type": "list",
+              "seq": 410,
+              "dl": "@IsResidential@=Y",
+              "len": 30
+            },
+            {
+              "col": "HomeDeliveryPremiumPhone",
+              "label": "Phone Number (For FedEx only)",
+              "ref": 10,
+              "type": "string",
+              "seq": 420,
+              "dl": "@IsResidential@=Y",
+              "len": 30
+            },
+            {
+              "col": "HomeDeliveryPremiumDate",
+              "label": "Date (For FedEx only)",
+              "ref": 15,
+              "type": "date",
+              "seq": 430,
+              "dl": "@IsResidential@=Y",
+              "len": 7
+            },
+            {
+              "col": "IsHazMat",
+              "label": "Hazardous Materials (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 440,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DotHazardClassOrDivision",
+              "label": "Dot Hazard Class or Division (For FedEx only)",
+              "ref": 17,
+              "type": "list",
+              "seq": 450,
+              "dl": "@IsHazMat@=Y",
+              "len": 30
+            },
+            {
+              "col": "IsCargoAircraftOnly",
+              "label": "Cargo Aircraft Only (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 460,
+              "mandatory": true,
+              "dl": "@IsHazMat@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsAccessible",
+              "label": "Accessible (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 470,
+              "mandatory": true,
+              "dl": "@IsHazMat@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsDryIce",
+              "label": "Dry Ice (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 480,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "DryIceWeight",
+              "label": "Dry Ice Weight (For FedEx only)",
+              "ref": 12,
+              "type": "amount",
+              "seq": 490,
+              "dl": "@IsDryIce@=Y",
+              "len": 14
+            },
+            {
+              "col": "IsHoldAtLocation",
+              "label": "Hold At Location (For FedEx only)",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 500,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "HoldAddress_ID",
+              "label": "Hold Address (For FedEx only)",
+              "ref": 18,
+              "type": "table",
+              "seq": 510,
+              "dl": "@IsHoldAtLocation@=Y",
+              "len": 10,
+              "fk": "HoldAddress"
+            },
+            {
+              "col": "IsIgnoreZipStateNotMatch",
+              "label": "Ignore Zip State Not Match",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 520,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsIgnoreZipNotFound",
+              "label": "Ignore Zip Not Found",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 530,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "IsDutiable",
+              "label": "Dutiable",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 540,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "NotificationType",
+              "label": "Notification Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 550,
+              "len": 2
+            },
+            {
+              "col": "NotificationMessage",
+              "label": "Notification Message",
+              "ref": 10,
+              "type": "string",
+              "seq": 560,
+              "dl": "@NotificationType@!''",
+              "len": 255
+            },
+            {
+              "col": "Price",
+              "label": "Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 610,
+              "len": 14
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 620,
+              "len": 10,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "Surcharges",
+              "label": "Surcharges",
+              "ref": 37,
+              "type": "string",
+              "seq": 630,
+              "len": 14
+            },
+            {
+              "col": "TotalPrice",
+              "label": "Total Price",
+              "ref": 37,
+              "type": "string",
+              "seq": 640,
+              "len": 14
+            },
+            {
+              "col": "TrackingNo",
+              "label": "Tracking No",
+              "ref": 10,
+              "type": "string",
+              "seq": 650,
+              "len": 255
+            },
+            {
+              "col": "TrackingInfo",
+              "label": "Tracking Info",
+              "ref": 10,
+              "type": "string",
+              "seq": 660,
+              "len": 255
+            },
+            {
+              "col": "RateInquiryMessage",
+              "label": "Rate Inquiry Message",
+              "ref": 14,
+              "type": "text",
+              "seq": 670,
+              "len": 2000
+            },
+            {
+              "col": "ShippingRespMessage",
+              "label": "Response Message",
+              "ref": 14,
+              "type": "text",
+              "seq": 680,
+              "len": 2000
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 690,
+              "len": 255
+            },
+            {
+              "col": "Processed",
+              "label": "Processed",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 700,
+              "mandatory": true,
+              "def": "N",
+              "len": 1
+            }
+          ],
+          "singleRow": true,
+          "fk": "M_InOut_ID"
+        }
+      ],
+      "node": "Shipments"
+    },
+    "195": {
+      "name": "Payment and Receipt",
+      "table": "C_Payment",
+      "tabs": [
+        {
+          "name": "Payment",
+          "table": "C_Payment",
+          "level": 0,
+          "seq": 10,
+          "fields": [
+            {
+              "col": "DocumentNo",
+              "label": "Document No",
+              "ref": 10,
+              "type": "string",
+              "seq": 30,
+              "mandatory": true,
+              "identifier": true,
+              "len": 30
+            },
+            {
+              "col": "C_BankAccount_ID",
+              "label": "Bank Account",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 40,
+              "len": 22,
+              "fk": "C_BankAccount"
+            },
+            {
+              "col": "C_DocType_ID",
+              "label": "Document Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 50,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_DocType"
+            },
+            {
+              "col": "IsReceipt",
+              "label": "Receipt",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 60,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "DateTrx",
+              "label": "Transaction Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 70,
+              "mandatory": true,
+              "identifier": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "DateAcct",
+              "label": "Account Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 80,
+              "mandatory": true,
+              "def": "@#Date@",
+              "len": 7
+            },
+            {
+              "col": "Description",
+              "label": "Description",
+              "ref": 10,
+              "type": "string",
+              "seq": 90,
+              "len": 255
+            },
+            {
+              "col": "C_BPartner_ID",
+              "label": "Business Partner",
+              "ref": 30,
+              "type": "search",
+              "seq": 100,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_BPartner"
+            },
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 110,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 120,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "C_Project_ID",
+              "label": "Project",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 130,
+              "dl": "@$Element_PJ@=Y & (@C_Invoice_ID@=0 | @C_Invoice_ID@='')",
+              "len": 22,
+              "fk": "C_Project"
+            },
+            {
+              "col": "C_Charge_ID",
+              "label": "Charge",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 140,
+              "len": 22,
+              "fk": "C_Charge"
+            },
+            {
+              "col": "IsPrepayment",
+              "label": "Prepayment",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 150,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "C_Activity_ID",
+              "label": "Activity",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 160,
+              "dl": "@$Element_AY@=Y",
+              "len": 22,
+              "fk": "C_Activity"
+            },
+            {
+              "col": "C_Campaign_ID",
+              "label": "Campaign",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 170,
+              "dl": "@$Element_MC@=Y",
+              "len": 22,
+              "fk": "C_Campaign"
+            },
+            {
+              "col": "AD_OrgTrx_ID",
+              "label": "Trx Organization",
+              "ref": 18,
+              "type": "table",
+              "seq": 180,
+              "dl": "@$Element_OT@=Y",
+              "len": 22,
+              "fk": "AD_OrgTrx"
+            },
+            {
+              "col": "User1_ID",
+              "label": "User Element List 1",
+              "ref": 30,
+              "type": "search",
+              "seq": 190,
+              "dl": "@$Element_U1@=Y",
+              "len": 22,
+              "fk": "User1"
+            },
+            {
+              "col": "User2_ID",
+              "label": "User Element List 2",
+              "ref": 30,
+              "type": "search",
+              "seq": 200,
+              "dl": "@$Element_U2@=Y",
+              "len": 22,
+              "fk": "User2"
+            },
+            {
+              "col": "PayAmt",
+              "label": "Payment amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 210,
+              "mandatory": true,
+              "identifier": true,
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "C_Currency_ID",
+              "label": "Currency",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 220,
+              "mandatory": true,
+              "len": 22,
+              "fk": "C_Currency"
+            },
+            {
+              "col": "C_ConversionType_ID",
+              "label": "Currency Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 230,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@",
+              "len": 22,
+              "fk": "C_ConversionType"
+            },
+            {
+              "col": "IsOverrideCurrencyRate",
+              "label": "Override Currency Conversion Rate",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 240,
+              "mandatory": true,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "CurrencyRate",
+              "label": "Rate",
+              "ref": 22,
+              "type": "number",
+              "seq": 250,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@ & @IsOverrideCurrencyRate@=Y",
+              "len": 22
+            },
+            {
+              "col": "ConvertedAmt",
+              "label": "Converted Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 260,
+              "dl": "@C_Currency_ID@!@$C_Currency_ID@ & @IsOverrideCurrencyRate@=Y",
+              "len": 22
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 270,
+              "dl": "@C_Invoice_ID:0@^0",
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "WriteOffAmt",
+              "label": "Write-off Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 280,
+              "dl": "@C_Invoice_ID:0@^0",
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "IsOverUnderPayment",
+              "label": "Over/Under Payment",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 290,
+              "mandatory": true,
+              "dl": "@C_Invoice_ID:0@^0",
+              "def": "Y",
+              "len": 1
+            },
+            {
+              "col": "OverUnderAmt",
+              "label": "Over/Under Payment",
+              "ref": 12,
+              "type": "amount",
+              "seq": 300,
+              "dl": "@IsOverUnderPayment@=Y & @C_Invoice_ID:0@^0",
+              "def": "0",
+              "len": 22
+            },
+            {
+              "col": "TenderType",
+              "label": "Tender type",
+              "ref": 17,
+              "type": "list",
+              "seq": 310,
+              "mandatory": true,
+              "def": "K",
+              "len": 1
+            },
+            {
+              "col": "C_POSTenderType_ID",
+              "label": "POS Tender Type",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 320,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_POSTenderType"
+            },
+            {
+              "col": "IsOnline",
+              "label": "Online Access",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 330,
+              "mandatory": true,
+              "len": 1
+            },
+            {
+              "col": "RoutingNo",
+              "label": "Routing No",
+              "ref": 10,
+              "type": "string",
+              "seq": 340,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "AccountNo",
+              "label": "Account No",
+              "ref": 10,
+              "type": "string",
+              "seq": 350,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "IBAN",
+              "label": "IBAN",
+              "ref": 10,
+              "type": "string",
+              "seq": 360,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 40
+            },
+            {
+              "col": "SwiftCode",
+              "label": "Swift code",
+              "ref": 10,
+              "type": "string",
+              "seq": 370,
+              "dl": "@TenderType@=A | @TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "CheckNo",
+              "label": "Check No",
+              "ref": 10,
+              "type": "string",
+              "seq": 380,
+              "dl": "@TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "Micr",
+              "label": "Micr",
+              "ref": 10,
+              "type": "string",
+              "seq": 390,
+              "dl": "@TenderType@=K",
+              "len": 20
+            },
+            {
+              "col": "CreditCardType",
+              "label": "Credit Card",
+              "ref": 17,
+              "type": "list",
+              "seq": 400,
+              "dl": "@TenderType@=C",
+              "def": "M",
+              "len": 1
+            },
+            {
+              "col": "TrxType",
+              "label": "Transaction Type",
+              "ref": 17,
+              "type": "list",
+              "seq": 410,
+              "mandatory": true,
+              "dl": "@TenderType@=C",
+              "def": "S",
+              "len": 1
+            },
+            {
+              "col": "CreditCardNumber",
+              "label": "Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 420,
+              "dl": "@TenderType@=C",
+              "len": 20
+            },
+            {
+              "col": "CreditCardVV",
+              "label": "Verification Code",
+              "ref": 10,
+              "type": "string",
+              "seq": 430,
+              "dl": "@TenderType@=C",
+              "len": 4
+            },
+            {
+              "col": "CreditCardExpMM",
+              "label": "Exp. Month",
+              "ref": 11,
+              "type": "integer",
+              "seq": 440,
+              "dl": "@TenderType@=C",
+              "def": "1",
+              "len": 22
+            },
+            {
+              "col": "CreditCardExpYY",
+              "label": "Exp. Year",
+              "ref": 11,
+              "type": "integer",
+              "seq": 450,
+              "dl": "@TenderType@=C",
+              "def": "03",
+              "len": 22
+            },
+            {
+              "col": "A_Name",
+              "label": "Account Name",
+              "ref": 10,
+              "type": "string",
+              "seq": 460,
+              "identifier": true,
+              "dl": "@TenderType@=C | @TenderType@=K",
+              "len": 60
+            },
+            {
+              "col": "A_Street",
+              "label": "Account Street",
+              "ref": 10,
+              "type": "string",
+              "seq": 470,
+              "dl": "@TenderType@=C | @TenderType@=K & @IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "A_City",
+              "label": "Account City",
+              "ref": 10,
+              "type": "string",
+              "seq": 480,
+              "dl": "@TenderType@=C | @TenderType@=K & @IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "A_Zip",
+              "label": "Account Zip/Postal",
+              "ref": 10,
+              "type": "string",
+              "seq": 490,
+              "dl": "@TenderType@=C | @TenderType@=K & @IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "A_State",
+              "label": "Account State",
+              "ref": 10,
+              "type": "string",
+              "seq": 500,
+              "dl": "@TenderType@=C | @TenderType@=K & @IsOnline@=Y",
+              "len": 40
+            },
+            {
+              "col": "A_Country",
+              "label": "Account Country",
+              "ref": 10,
+              "type": "string",
+              "seq": 510,
+              "dl": "@TenderType@=C | @TenderType@=K & @IsOnline@=Y",
+              "len": 40
+            },
+            {
+              "col": "A_Ident_DL",
+              "label": "Driver License",
+              "ref": 10,
+              "type": "string",
+              "seq": 520,
+              "dl": "@TenderType@=K & @IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "A_Ident_SSN",
+              "label": "Social Security No",
+              "ref": 10,
+              "type": "string",
+              "seq": 530,
+              "dl": "@TenderType@=K & @IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "A_EMail",
+              "label": "Account EMail",
+              "ref": 10,
+              "type": "string",
+              "seq": 540,
+              "dl": "@TenderType@=K & @IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "TaxAmt",
+              "label": "Tax Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 550,
+              "dl": "@CreditCardType@=P & @IsOnline@=Y",
+              "len": 22
+            },
+            {
+              "col": "PONum",
+              "label": "PO Number",
+              "ref": 10,
+              "type": "string",
+              "seq": 560,
+              "dl": "@CreditCardType@=P & @IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "VoiceAuthCode",
+              "label": "Voice authorization code",
+              "ref": 10,
+              "type": "string",
+              "seq": 570,
+              "dl": "@IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "Orig_TrxID",
+              "label": "Original Transaction ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 580,
+              "dl": "@IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "IsApproved",
+              "label": "Approved",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 600,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "R_Result",
+              "label": "Result",
+              "ref": 10,
+              "type": "string",
+              "seq": 610,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "R_RespMsg",
+              "label": "Response Message",
+              "ref": 10,
+              "type": "string",
+              "seq": 620,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "IsVoided",
+              "label": "Voided",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 630,
+              "mandatory": true,
+              "dl": "@TenderType@=C & @IsOnline@=Y",
+              "def": "N",
+              "len": 1
+            },
+            {
+              "col": "R_VoidMsg",
+              "label": "Void Message",
+              "ref": 14,
+              "type": "text",
+              "seq": 640,
+              "readonly": true,
+              "dl": "@TenderType@=C & @IsOnline@=Y",
+              "len": 255
+            },
+            {
+              "col": "R_PnRef",
+              "label": "Reference",
+              "ref": 10,
+              "type": "string",
+              "seq": 650,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "R_AuthCode",
+              "label": "Authorization Code",
+              "ref": 10,
+              "type": "string",
+              "seq": 660,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 20
+            },
+            {
+              "col": "R_AvsZip",
+              "label": "Zip verified",
+              "ref": 17,
+              "type": "list",
+              "seq": 670,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 1
+            },
+            {
+              "col": "R_AvsAddr",
+              "label": "Address verified",
+              "ref": 17,
+              "type": "list",
+              "seq": 680,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 1
+            },
+            {
+              "col": "C_PaymentProcessor_ID",
+              "label": "Payment Processor",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 690,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_PaymentProcessor"
+            },
+            {
+              "col": "CustomerPaymentProfileID",
+              "label": "Customer Payment Profile ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 700,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "CustomerProfileID",
+              "label": "Customer Profile ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 710,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "CustomerAddressID",
+              "label": "Customer Address ID",
+              "ref": 10,
+              "type": "string",
+              "seq": 720,
+              "readonly": true,
+              "dl": "@IsOnline@=Y",
+              "len": 60
+            },
+            {
+              "col": "DocStatus",
+              "label": "Document Status",
+              "ref": 17,
+              "type": "list",
+              "seq": 730,
+              "mandatory": true,
+              "readonly": true,
+              "def": "DR",
+              "len": 2
+            },
+            {
+              "col": "IsSelfService",
+              "label": "Self-Service",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 750,
+              "mandatory": true,
+              "readonly": true,
+              "len": 1
+            },
+            {
+              "col": "IsAllocated",
+              "label": "Allocated",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 770,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@Processed@=Y",
+              "len": 1
+            },
+            {
+              "col": "IsReconciled",
+              "label": "Reconciled",
+              "ref": 20,
+              "type": "yesno",
+              "seq": 780,
+              "mandatory": true,
+              "readonly": true,
+              "dl": "@Processed@=Y",
+              "len": 1
+            },
+            {
+              "col": "C_Department_ID",
+              "label": "Department",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 790,
+              "dl": "@$Element_DP@=Y",
+              "len": 22,
+              "fk": "C_Department"
+            },
+            {
+              "col": "C_CostCenter_ID",
+              "label": "Cost Center",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 800,
+              "dl": "@$Element_CC@=Y",
+              "len": 22,
+              "fk": "C_CostCenter"
+            },
+            {
+              "col": "C_Employee_ID",
+              "label": "Employee",
+              "ref": 18,
+              "type": "table",
+              "seq": 810,
+              "dl": "@$Element_EP@=Y",
+              "len": 10,
+              "fk": "C_Employee"
+            }
+          ],
+          "singleRow": true,
+          "where": "C_Payment.C_BPartner_ID IS NOT NULL"
+        },
+        {
+          "name": "Allocate",
+          "table": "C_PaymentAllocate",
+          "level": 1,
+          "seq": 15,
+          "fields": [
+            {
+              "col": "C_Payment_ID",
+              "label": "Payment",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "mandatory": true,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_Payment"
+            },
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 50,
+              "mandatory": true,
+              "identifier": true,
+              "len": 10,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "InvoiceAmt",
+              "label": "Invoice Amt",
+              "ref": 12,
+              "type": "amount",
+              "seq": 60,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "Amount",
+              "label": "Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 70,
+              "mandatory": true,
+              "identifier": true,
+              "len": 22
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 80,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "WriteOffAmt",
+              "label": "Write-off Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 90,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "OverUnderAmt",
+              "label": "Over/Under Payment",
+              "ref": 12,
+              "type": "amount",
+              "seq": 100,
+              "mandatory": true,
+              "len": 22
+            },
+            {
+              "col": "RemainingAmt",
+              "label": "Remaining Amt",
+              "ref": 12,
+              "type": "amount",
+              "seq": 110,
+              "readonly": true,
+              "def": "@SQL=SELECT MAX(p.PayAmt)-COALESCE(SUM(a.Amount),0)\nFROM C_Payment p \nLEFT OUTER JOIN C_PaymentAllocate a ON (p.C_Payment_ID=a.C_Payment_ID)\nWHERE p.C_Payment_ID=@C_Payment_ID@",
+              "len": 22
+            },
+            {
+              "col": "C_AllocationLine_ID",
+              "label": "Allocation Line",
+              "ref": 19,
+              "type": "tableDirect",
+              "seq": 120,
+              "readonly": true,
+              "len": 10,
+              "fk": "C_AllocationLine"
+            }
+          ],
+          "singleRow": true,
+          "fk": "C_Payment_ID"
+        },
+        {
+          "name": "Allocations",
+          "table": "C_AllocationLine",
+          "level": 1,
+          "seq": 20,
+          "fields": [
+            {
+              "col": "C_Payment_ID",
+              "label": "Payment",
+              "ref": 30,
+              "type": "search",
+              "seq": 30,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Payment"
+            },
+            {
+              "col": "C_AllocationHdr_ID",
+              "label": "Allocation",
+              "ref": 30,
+              "type": "search",
+              "seq": 40,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_AllocationHdr"
+            },
+            {
+              "col": "DateTrx",
+              "label": "Transaction Date",
+              "ref": 15,
+              "type": "date",
+              "seq": 50,
+              "readonly": true,
+              "len": 7
+            },
+            {
+              "col": "C_Invoice_ID",
+              "label": "Invoice",
+              "ref": 30,
+              "type": "search",
+              "seq": 60,
+              "readonly": true,
+              "identifier": true,
+              "len": 22,
+              "fk": "C_Invoice"
+            },
+            {
+              "col": "C_Order_ID",
+              "label": "Order",
+              "ref": 30,
+              "type": "search",
+              "seq": 70,
+              "readonly": true,
+              "len": 22,
+              "fk": "C_Order"
+            },
+            {
+              "col": "Amount",
+              "label": "Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 80,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "DiscountAmt",
+              "label": "Discount Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 100,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "WriteOffAmt",
+              "label": "Write-off Amount",
+              "ref": 12,
+              "type": "amount",
+              "seq": 110,
+              "mandatory": true,
+              "readonly": true,
+              "len": 22
+            },
+            {
+              "col": "OverUnderAmt",
+              "label": "Over/Under Payment",
+              "ref": 12,
+              "type": "amount",
+              "seq": 120,
+              "readonly": true,
+              "len": 22
+            }
+          ],
+          "singleRow": true,
+          "readonly": true,
+          "fk": "C_Payment_ID"
+        }
+      ],
+      "node": "Payments"
+    }
+  },
+  "wfmc": {
+    "states": [
+      "DR",
+      "CO",
+      "AP",
+      "NA",
+      "VO",
+      "IN",
+      "RE",
+      "CL",
+      "IP",
+      "WP",
+      "WC"
+    ],
+    "statusNames": {
+      "DR": "Drafted",
+      "CO": "Completed",
+      "AP": "Approved",
+      "NA": "Not Approved",
+      "VO": "Voided",
+      "IN": "Invalid",
+      "RE": "Reversed",
+      "CL": "Closed",
+      "??": "Unknown",
+      "IP": "In Progress",
+      "WP": "Waiting Payment",
+      "WC": "Waiting Confirmation"
+    },
+    "actions": {
+      "CO": "Complete",
+      "AP": "Approve",
+      "RJ": "Reject",
+      "PO": "Post",
+      "VO": "Void",
+      "CL": "Close",
+      "RC": "Reverse - Correct",
+      "RA": "Reverse - Accrual",
+      "IN": "Invalidate",
+      "RE": "Re-activate",
+      "PR": "Prepare",
+      "XL": "Unlock",
+      "WC": "Wait Complete"
+    },
+    "transitions": [
+      [
+        "DR",
+        "PR",
+        "IP"
+      ],
+      [
+        "IN",
+        "PR",
+        "IP"
+      ],
+      [
+        "DR",
+        "CO",
+        "CO"
+      ],
+      [
+        "IP",
+        "CO",
+        "CO"
+      ],
+      [
+        "WC",
+        "CO",
+        "CO"
+      ],
+      [
+        "IP",
+        "WC",
+        "WC"
+      ],
+      [
+        "DR",
+        "VO",
+        "VO"
+      ],
+      [
+        "IP",
+        "VO",
+        "VO"
+      ],
+      [
+        "IN",
+        "VO",
+        "VO"
+      ],
+      [
+        "CO",
+        "VO",
+        "VO"
+      ],
+      [
+        "WC",
+        "VO",
+        "VO"
+      ],
+      [
+        "WP",
+        "VO",
+        "VO"
+      ],
+      [
+        "DR",
+        "IN",
+        "IN"
+      ],
+      [
+        "IP",
+        "IN",
+        "IN"
+      ],
+      [
+        "IN",
+        "XL",
+        "IP"
+      ],
+      [
+        "CO",
+        "CL",
+        "CL"
+      ],
+      [
+        "CO",
+        "RE",
+        "IP"
+      ],
+      [
+        "CO",
+        "RC",
+        "RE"
+      ],
+      [
+        "CO",
+        "RA",
+        "RE"
+      ],
+      [
+        "IP",
+        "AP",
+        "IP"
+      ],
+      [
+        "IP",
+        "RJ",
+        "IP"
+      ],
+      [
+        "CO",
+        "PO",
+        "CO"
+      ]
+    ]
+  },
+  "doctypes": [
+    {
+      "id": 115,
+      "name": "GL Journal",
+      "docBaseType": "GLJ",
+      "baseTable": "GL_Journal",
+      "isSOTrx": false
+    },
+    {
+      "id": 116,
+      "name": "AR Invoice",
+      "docBaseType": "ARI",
+      "baseTable": "C_Invoice",
+      "isSOTrx": true
+    },
+    {
+      "id": 117,
+      "name": "AR Invoice Indirect",
+      "docBaseType": "ARI",
+      "baseTable": "C_Invoice",
+      "isSOTrx": true
+    },
+    {
+      "id": 118,
+      "name": "AR Credit Memo",
+      "docBaseType": "ARC",
+      "baseTable": "C_Invoice",
+      "isSOTrx": true
+    },
+    {
+      "id": 119,
+      "name": "AR Receipt",
+      "docBaseType": "ARR",
+      "baseTable": "C_Payment",
+      "isSOTrx": true
+    },
+    {
+      "id": 120,
+      "name": "MM Shipment",
+      "docBaseType": "MMS",
+      "baseTable": "M_InOut",
+      "isSOTrx": true
+    },
+    {
+      "id": 121,
+      "name": "MM Shipment Indirect",
+      "docBaseType": "MMS",
+      "baseTable": "M_InOut",
+      "isSOTrx": true
+    },
+    {
+      "id": 122,
+      "name": "MM Receipt",
+      "docBaseType": "MMR",
+      "baseTable": "M_InOut",
+      "isSOTrx": false
+    },
+    {
+      "id": 123,
+      "name": "AP Invoice",
+      "docBaseType": "API",
+      "baseTable": "C_Invoice",
+      "isSOTrx": false
+    },
+    {
+      "id": 124,
+      "name": "AP CreditMemo",
+      "docBaseType": "APC",
+      "baseTable": "C_Invoice",
+      "isSOTrx": false
+    },
+    {
+      "id": 125,
+      "name": "AP Payment",
+      "docBaseType": "APP",
+      "baseTable": "C_Payment",
+      "isSOTrx": false
+    },
+    {
+      "id": 126,
+      "name": "Purchase Order",
+      "docBaseType": "POO",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 127,
+      "name": "Purchase Requisition",
+      "docBaseType": "POR",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 128,
+      "name": "Quotation",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 129,
+      "name": "Proposal",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 130,
+      "name": "Prepay Order",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 131,
+      "name": "Customer Return Material",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 132,
+      "name": "Standard Order",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 133,
+      "name": "On Credit Order",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 134,
+      "name": "Warehouse Order",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 135,
+      "name": "POS Order",
+      "docBaseType": "SOO",
+      "baseTable": "C_Order",
+      "isSOTrx": true
+    },
+    {
+      "id": 136,
+      "name": "Project Issue",
+      "docBaseType": "PJI",
+      "baseTable": "C_ProjectIssue",
+      "isSOTrx": false
+    },
+    {
+      "id": 137,
+      "name": "Payment Allocation",
+      "docBaseType": "CMA",
+      "baseTable": "C_Cash",
+      "isSOTrx": false
+    },
+    {
+      "id": 138,
+      "name": "Match Invoice",
+      "docBaseType": "MXI",
+      "baseTable": "M_MatchInv",
+      "isSOTrx": false
+    },
+    {
+      "id": 139,
+      "name": "Material Production",
+      "docBaseType": "MMP",
+      "baseTable": "M_Production",
+      "isSOTrx": false
+    },
+    {
+      "id": 140,
+      "name": "GL Document",
+      "docBaseType": "GLD",
+      "baseTable": "GL_JournalBatch",
+      "isSOTrx": false
+    },
+    {
+      "id": 141,
+      "name": "Cash Journal",
+      "docBaseType": "CMC",
+      "baseTable": "C_Cash",
+      "isSOTrx": false
+    },
+    {
+      "id": 142,
+      "name": "Match PO",
+      "docBaseType": "MXP",
+      "baseTable": "M_MatchPO",
+      "isSOTrx": false
+    },
+    {
+      "id": 143,
+      "name": "Material Movement",
+      "docBaseType": "MMM",
+      "baseTable": "M_Movement",
+      "isSOTrx": false
+    },
+    {
+      "id": 144,
+      "name": "Material Physical Inventory",
+      "docBaseType": "MMI",
+      "baseTable": "M_Inventory",
+      "isSOTrx": false
+    },
+    {
+      "id": 145,
+      "name": "AR Pro Forma Invoice",
+      "docBaseType": "ARF",
+      "baseTable": "C_Invoice",
+      "isSOTrx": true
+    },
+    {
+      "id": 146,
+      "name": "Bank Statement",
+      "docBaseType": "CMB",
+      "baseTable": "C_BankStatement",
+      "isSOTrx": false
+    },
+    {
+      "id": 147,
+      "name": "MM Receipt with Confirmation",
+      "docBaseType": "MMR",
+      "baseTable": "M_InOut",
+      "isSOTrx": false
+    },
+    {
+      "id": 148,
+      "name": "MM Shipment with Pick",
+      "docBaseType": "MMS",
+      "baseTable": "M_InOut",
+      "isSOTrx": true
+    },
+    {
+      "id": 149,
+      "name": "MM Customer Return",
+      "docBaseType": "MMR",
+      "baseTable": "M_InOut",
+      "isSOTrx": true
+    },
+    {
+      "id": 150,
+      "name": "Vendor Return Material",
+      "docBaseType": "POO",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 151,
+      "name": "MM Vendor Return",
+      "docBaseType": "MMS",
+      "baseTable": "M_InOut",
+      "isSOTrx": false
+    },
+    {
+      "id": 50000,
+      "name": "Payroll",
+      "docBaseType": "HRP",
+      "baseTable": "HR_Process",
+      "isSOTrx": false
+    },
+    {
+      "id": 50001,
+      "name": "GL Journal Batch",
+      "docBaseType": "GLJ",
+      "baseTable": "GL_Journal",
+      "isSOTrx": false
+    },
+    {
+      "id": 50002,
+      "name": "Manufacturing Order",
+      "docBaseType": "MOP",
+      "baseTable": "PP_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 50010,
+      "name": "Maintenance Order",
+      "docBaseType": "MOF",
+      "baseTable": "PP_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 50011,
+      "name": "Quality Order",
+      "docBaseType": "MQO",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 50012,
+      "name": "Distribution Order",
+      "docBaseType": "DOO",
+      "baseTable": "DD_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 50013,
+      "name": "Manufacturing Cost Collector",
+      "docBaseType": "MCC",
+      "baseTable": "PP_Cost_Collector",
+      "isSOTrx": false
+    },
+    {
+      "id": 200000,
+      "name": "Internal Use Inventory",
+      "docBaseType": "MMI",
+      "baseTable": "M_Inventory",
+      "isSOTrx": false
+    },
+    {
+      "id": 200001,
+      "name": "Asset Addition",
+      "docBaseType": "FAA",
+      "baseTable": "A_Asset_Addition",
+      "isSOTrx": false
+    },
+    {
+      "id": 200002,
+      "name": "Asset Depreciation",
+      "docBaseType": "FDP",
+      "baseTable": null,
+      "isSOTrx": false
+    },
+    {
+      "id": 200003,
+      "name": "Asset Disposal",
+      "docBaseType": "FAD",
+      "baseTable": "A_Asset_Disposed",
+      "isSOTrx": false
+    },
+    {
+      "id": 200004,
+      "name": "Cost Adjustment",
+      "docBaseType": "MMI",
+      "baseTable": "M_Inventory",
+      "isSOTrx": false
+    },
+    {
+      "id": 200026,
+      "name": "Warehouse Purchase Order",
+      "docBaseType": "POO",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    },
+    {
+      "id": 200027,
+      "name": "Point of Purchase Order",
+      "docBaseType": "POO",
+      "baseTable": "C_Order",
+      "isSOTrx": false
+    }
+  ],
+  "downstream": {
+    "C_DepositBatch": [
+      "C_Payment"
+    ],
+    "C_Payment": [
+      "C_Invoice",
+      "C_Order"
+    ],
+    "C_Invoice": [
+      "A_Asset_Addition",
+      "A_Asset_Disposed",
+      "DD_Order",
+      "M_InOut",
+      "M_InOutConfirm"
+    ],
+    "DD_Order": [
+      "M_Movement",
+      "PP_MRP"
+    ],
+    "M_Movement": [
+      "M_MovementConfirm"
+    ],
+    "M_InOut": [
+      "M_InOutConfirm"
+    ],
+    "C_Order": [
+      "C_Invoice",
+      "DD_Order",
+      "M_InOut",
+      "M_RMA",
+      "PP_MRP"
+    ],
+    "M_RMA": [
+      "C_Invoice",
+      "M_InOut"
+    ],
+    "GL_JournalBatch": [
+      "A_Asset_Addition"
+    ],
+    "MP_Maintain": [
+      "MP_OT"
+    ],
+    "MP_OT_Request": [
+      "MP_OT"
+    ],
+    "M_Inventory": [
+      "M_InOutConfirm",
+      "M_MovementConfirm"
+    ],
+    "M_Requisition": [
+      "PP_MRP"
+    ],
+    "PP_Order": [
+      "PP_Cost_Collector",
+      "PP_MRP",
+      "PP_Order_Node"
+    ],
+    "PP_Order_Node": [
+      "PP_Cost_Collector"
+    ]
+  },
+  "settlement": [
+    [
+      "C_Invoice",
+      "C_Payment"
+    ],
+    [
+      "C_Order",
+      "C_Payment"
+    ]
+  ],
+  "state_machine": {
+    "C_Order": [
+      "Drafted",
+      "InProgress",
+      "Completed",
+      "Voided",
+      "Closed"
+    ],
+    "C_Invoice": [
+      "Drafted",
+      "InProgress",
+      "Completed",
+      "Reversed",
+      "Voided"
+    ],
+    "C_Payment": [
+      "Drafted",
+      "InProgress",
+      "Completed",
+      "Voided"
+    ],
+    "M_InOut": [
+      "Drafted",
+      "InProgress",
+      "Completed",
+      "Voided",
+      "Closed"
+    ],
+    "C_Project": [
+      "Drafted",
+      "InProgress",
+      "Completed",
+      "Voided",
+      "Closed"
+    ]
+  },
+  "dropdowns": {
+    "DocStatus": [
+      {
+        "value": "DR",
+        "name": "Drafted"
+      },
+      {
+        "value": "IP",
+        "name": "In Progress"
+      },
+      {
+        "value": "CO",
+        "name": "Completed"
+      },
+      {
+        "value": "VO",
+        "name": "Voided"
+      },
+      {
+        "value": "CL",
+        "name": "Closed"
+      },
+      {
+        "value": "RE",
+        "name": "Reversed"
+      }
+    ]
+  }
+}

--- a/viewer/schema_5table.sql
+++ b/viewer/schema_5table.sql
@@ -1,0 +1,76 @@
+-- schema_5table.sql — PB canonical 5-table runtime storage (docs/ERP.md §0, §0.1)
+-- Witness: PB gate §BRIDGE (scripts/test_bridge.js).
+--
+-- The 5 tables are GENERIC. Every domain field (C_Order's ~60 columns, etc.) lives
+-- in `metadata` JSON keyed by AD ColumnName; the P0 manifest tells the UI which keys
+-- to render per doc_type. This is what lets 5 tables hold 1003 tables' worth of fields.
+-- Structural relationships get real columns (the gate-derived set, ERP.md §0):
+--   derivation lineage      -> documents.source_id
+--   sub-document            -> documents.parent_id
+--   line -> its document    -> document_lines.document_id
+--   line-level lineage      -> document_lines.source_line_id   (InvoiceLine->OrderLine)
+--   settlement / 3-way match-> document_lines.match_type + source_line_id + metadata ref
+--   master recursion        -> items.parent_id                  (Product->Category)
+--   spatial hierarchy       -> containers.parent_id
+--   ledger Batch->Journal   -> journal.batch_id / journal.journal_id
+-- Citations (a row naming another by id) are always representable as a metadata ref.
+--
+-- IDs are TEXT so the op-log can use GUIDs (acceptance discipline #5: no MAX+1).
+-- The bridge stores a legacy AD key as String(<Table>_ID); ad_data reconstructs it.
+--
+-- RECONCILIATION RESOLVED (2026-05-29, docs/ERP.md §0.2): THIS is the single canonical
+-- 5-table runtime. doc_engine.js (Spatial ERP POC) defined same-named tables with
+-- different columns but is UNREACHABLE dead code (its only consumer erp_panel.js is
+-- loaded by no HTML). It is retired as the P3b reference oracle, NOT a live engine —
+-- so there is no shared-DB hazard. kernel_ops.js stays the shared module.
+
+CREATE TABLE IF NOT EXISTS containers (
+  id        TEXT PRIMARY KEY,
+  parent_id TEXT REFERENCES containers(id),  -- Site->Building->Floor
+  type      TEXT NOT NULL,                   -- legacy AD TableName (the "category")
+  metadata  TEXT NOT NULL DEFAULT '{}'       -- domain fields keyed by ColumnName
+);
+
+CREATE TABLE IF NOT EXISTS items (
+  id        TEXT PRIMARY KEY,
+  parent_id TEXT REFERENCES items(id),       -- master is recursive: Product->Category
+  type      TEXT NOT NULL,                   -- legacy AD TableName
+  metadata  TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS documents (
+  id           TEXT PRIMARY KEY,
+  doc_type     TEXT NOT NULL,                -- 1:1 with legacy AD TableName (hub preserved)
+  doc_status   TEXT DEFAULT 'DR',            -- AD DocStatus value (DR/IP/CO/VO/CL/RE)
+  source_id    TEXT REFERENCES documents(id),-- derivation lineage (Invoice->Order)
+  parent_id    TEXT REFERENCES documents(id),-- sub-document (ProductionPlan->Production)
+  container_id TEXT REFERENCES containers(id),
+  metadata     TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS document_lines (
+  id             TEXT PRIMARY KEY,
+  document_id    TEXT REFERENCES documents(id),       -- the line's owning document
+  source_line_id TEXT REFERENCES document_lines(id),  -- line lineage (InvoiceLine->OrderLine)
+  line_no        INTEGER,                              -- AD "Line" sequence
+  match_type     TEXT,                                 -- settlement edge tag (MATCH_INV/MATCH_PO/CONFIRM/LANDED_COST); NULL for plain lines
+  metadata       TEXT NOT NULL DEFAULT '{}'            -- domain fields + counterpart line-refs
+);
+
+CREATE TABLE IF NOT EXISTS journal (
+  id         TEXT PRIMARY KEY,
+  batch_id   TEXT,                            -- GL_JournalBatch
+  journal_id TEXT,                            -- GL_Journal (Batch->Journal->Line)
+  source     TEXT REFERENCES documents(id),   -- the document this posting derives from
+  metadata   TEXT NOT NULL DEFAULT '{}'       -- account/debit/credit/etc. as Fact_Acct fields
+);
+
+-- kernel_ops already exists (kernel_ops.js ensureTable). The 5 tables above are a
+-- rebuildable projection of that log (event sourcing, ERP.md §0).
+
+CREATE INDEX IF NOT EXISTS idx_documents_type      ON documents(doc_type);
+CREATE INDEX IF NOT EXISTS idx_documents_source    ON documents(source_id);
+CREATE INDEX IF NOT EXISTS idx_doclines_document   ON document_lines(document_id);
+CREATE INDEX IF NOT EXISTS idx_doclines_sourceline ON document_lines(source_line_id);
+CREATE INDEX IF NOT EXISTS idx_items_parent        ON items(parent_id);
+CREATE INDEX IF NOT EXISTS idx_containers_parent   ON containers(parent_id);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v557';
+const CACHE_VERSION = 'v558';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## Phase A — edge primitives go live

Takes the **dormant, proven** ERP edge primitives (A1–A4) live by wiring them into `erp.html`, co-committed with the ready `#gbviews`/PB-bridge work that shares the file.

### Phase-A wiring (behaviour-preserving until invoked)
- `kernel_ops.js` v6 — W-CHAIN/W-SIGN tamper-evident op-log (prev_hash/op_hash/sig, sealChain/verifyChain/setSigner), **G-IDENTITY** op_uuid
- `erp_signer.js` (A2 W-SIGN) — edge ECDSA-P256 signer, idb non-extractable custody
- `erp_replay.js` (A3 W-OWNER·CAS) — owner-gate + CAS guarded replay (LOADED, not yet invoked — Phase B)
- `erp_persist.js` (A4 W-PERSIST) — durable local + signed-snapshot hook
- erp.html: MODULES += the 3 modules; `installSigner` + `requestPersist` on load; `window.__erpDb`; **A5 `⛓ Verify ledger` pill** → `verifyChain()` ("Ledger OK — N ops" / "Tamper at op N"); pill z-index 9999 so the click lands over the constellation canvas

### #gbviews / PB-bridge (co-committed)
- `ad_data.js` / `ad_parser.js` / `ad_ui.js` / `panels.js` / `tools.js`
- `ad_table_map.js` (AD table → 5-table slot), `schema_5table.sql`, `manifest.json` (P0 generated AD manifest)

### Witnesses (bim-compiler)
`test_kernel_{identity,sign,owner,persist,chain}.js` — all §-PASS. In-browser headless check (erp_check.log + screenshots): all 4 modules load, §-lines emit, real pill-click → `§VERIFY_LEDGER ok=true`.

### Deploy hygiene
- Cherry-picked onto current `main` (clean — 3 commits, only the intended 11 files; the 55-commit s284e branch history with already-squashed S285 work was NOT replayed)
- `package.json` = main's superset (sql.js + eslint/globals); local untracked copies dropped
- no-undef gate **green**; full local `fast-checks` suite **green** (11/11)
- SW bump: `CACHE_VERSION` v557→**v558**, `erp.html sw.js?v=`→**558** (match), module `var V=?v=22`

Phase B (invoking `replayGuarded` on real document flows) is deferred — see `prompts/ERP_PHASE_A_DEPLOY.md §Phase B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)