### PR TITLE
feat(erp): iDempiere-UI I1 — pill bar + renderer #1 (idempiere.html)

### DIFF
--- a/viewer/erp.html
+++ b/viewer/erp.html
@@ -368,7 +368,7 @@ var _shellReady = false;
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=558')
+  navigator.serviceWorker.register('sw.js?v=559')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }

--- a/viewer/idempiere.html
+++ b/viewer/idempiere.html
@@ -511,5 +511,13 @@
   });
 })();
 </script>
+<script>
+// Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data + ad_seed.db are precached (sw v559).
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js?v=559')
+    .then(function (r) { console.log('§SW_REG scope=' + r.scope); })
+    .catch(function (e) { console.warn('§SW_REG_FAIL', e); });
+}
+</script>
 </body>
 </html>

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v558';
+const CACHE_VERSION = 'v559';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency
@@ -44,6 +44,7 @@ const PRECACHE_ASSETS = [
   'boq_charts.html',
   'mep_report.html',
   'erp.html',
+  'idempiere.html',
   '2d.html',
   'offline.html',
   'manifest.webmanifest',
@@ -127,10 +128,14 @@ const PRECACHE_ASSETS = [
   'ghostglass.js',
   'qrcode.min.js',
   'pill_builder.js',
+  // idempiereUI.md I1 — ERP pill bar + renderer #1 (idempiere.html)
+  'icons.js',
+  'erp_pills.js',
   'list_builder.js',
   'settings_editor.js',
   'panel_nav.js',
   'redpill.png',
+  'aplus.png',
   // Lazy-loaded modules
   'navigate.js',
   'wizard.js',
@@ -146,6 +151,7 @@ const PRECACHE_ASSETS = [
   // Vendor libs not in LOCAL_LIBS (loaded by index.html)
   'lib/httpvfs.js',
   // Config files
+  'pills.json',
   'clash_rules.json',
   'grid_rules.json',
   'rates/cidb2024_my.json',


### PR DESCRIPTION
## iDempiere Renderer #1 — "pick your ERP" I1 (prompts/idempiereUI.md, docs/IDEMPIERE_RENDERER_SPEC.md)

A faithful **iDempiere-classic desktop UI** (`idempiere.html`) folded entirely from the Application Dictionary in `ad_seed.db` via **SQLite WASM** — no server, no iDempiere runtime — launched from `erp.html`'s new registry-driven **pill bar**.

### What's here
- `idempiere.html` — renderer #1: header (neutral **A+** mark, not the trademarked logo) · left AD_Menu tree (14 standard groups) · MDI window tabs · toolbar (refresh / record-nav / Grid·Form; CRUD disabled until CRUD-P) · AD tab-strip · grid + form · status bar. Reuses `ad_parser`/`ad_data`; desktop EXACT, mobile adapts (≤760px drawer).
- `erp_pills.js` + `icons.js` + `pills.json` — pill bar mounted from the manifest; `pill_builder.js` used as-is; icons VERBATIM from panels.js. `idempiere` pill → `idempiere.html` (`aplus.png`).
- `erp.html` — loads the 3 scripts; bottom-nav kept (no regression).
- `sw.js` — v559, precaches the new assets (offline-capable).

### Witnesses (headless §-log, ALL PASS)
- `§PILL-MANIFEST page=erp pills=13 handAuthoredButtons=0 inlineSvg=0` · `§ICONS-PARITY verbatim=12 drift=0` · `§PILL_ICON img=aplus.png logo_present=N`
- `§IDEMPIERE-FOLD menu groups=53 leaves=534 source=ad_menu · window=Menu(105) tabs=2 fields=20 gridRows=587 source=sqlite handAuthored=0` → **SQLite WASM is up to it.**
- Playwright smoke: live page renders 587 menu nodes + window/tabs/grid, boot 183ms.

### Ethics / safety
Neutral **A+** mark (`aplus.png`); trademarked `idempiere_logo.png` removed; text "iDempiere-like" only (docs/IDEMPIERE_2.md §Guardrails). 153/153 AD-UI baseline untouched (`ad_ui.js` not edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)