### PR TITLE
feat(erp): iDempiere renderer #1 — master-detail drill (sw v560)

### DIFF
--- a/viewer/erp.html
+++ b/viewer/erp.html
@@ -368,7 +368,7 @@ var _shellReady = false;
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=559')
+  navigator.serviceWorker.register('sw.js?v=560')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }

--- a/viewer/idempiere.html
+++ b/viewer/idempiere.html
@@ -212,6 +212,7 @@
   var _records = [];
   var _recIdx = 0;
   var _viewMode = 'grid';    // 'grid' | 'form'
+  var _selByLevel = {};      // tabLevel -> selected record's key value (drives master-detail filtering)
 
   function $(id) { return document.getElementById(id); }
   function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; }
@@ -324,7 +325,7 @@
       _openWins[windowId] = { win: win, name: name || win.name };
       console.log('§IDEMPIERE window=' + win.name + '(' + windowId + ') tabs=' + (win.tabs ? win.tabs.length : 0) + ' source=sqlite');
     }
-    _activeWin = windowId; _activeTabIdx = 0; _viewMode = 'grid';
+    _activeWin = windowId; _activeTabIdx = 0; _viewMode = 'grid'; _selByLevel = {};
     renderWinTabs(); renderToolbar(); renderTabStrip(); renderActiveTab();
   }
   function closeWindow(windowId) {
@@ -382,7 +383,10 @@
   function renderTabStrip() {
     var w = _curWin(); var strip = $('idmp-tabstrip'); strip.style.display = 'flex'; strip.innerHTML = '';
     (w.tabs || []).forEach(function (tab, i) {
-      var t = el('div', 'idmp-adtab' + (i === _activeTabIdx ? ' active' : ''), tab.name + (tab.tabLevel ? '' : ''));
+      var lvl = tab.tabLevel || 0;
+      var t = el('div', 'idmp-adtab' + (i === _activeTabIdx ? ' active' : ''), (lvl ? '└ ' : '') + tab.name);
+      if (lvl) t.style.paddingLeft = (14 + lvl * 12) + 'px';
+      t.title = 'TabLevel ' + lvl + (tab.tableName ? ' · ' + tab.tableName : '');
       t.addEventListener('click', function () { _activeTabIdx = i; _viewMode = 'grid'; renderActiveTab(); renderTabStrip(); renderToolbar(); });
       strip.appendChild(t);
     });
@@ -392,6 +396,27 @@
   function _tableExists(t) {
     try { var r = db.exec("SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND lower(name)=lower('" + t.replace(/'/g, "") + "') LIMIT 1"); return r.length > 0; }
     catch (e) { return true; }
+  }
+  // The tab table's primary key column (the FK a child references) — AD key field, else iDempiere TableName+'_ID'.
+  function _keyCol(tab) {
+    var k = (tab.fields || []).filter(function (f) { return f.isKey; })[0];
+    return k ? k.columnName : (tab.tableName ? tab.tableName + '_ID' : null);
+  }
+  function _colExists(table, col) {
+    try {
+      var r = db.exec('PRAGMA table_info(' + table + ')'); if (!r.length) return false;
+      var ci = r[0].columns.indexOf('name');
+      return r[0].values.some(function (v) { return String(v[ci]).toLowerCase() === String(col).toLowerCase(); });
+    } catch (e) { return false; }
+  }
+  // SQL literal for a parent key value (numeric pk unquoted, else quoted+escaped).
+  function _lit(v) { return (typeof v === 'number' || /^[0-9]+$/.test(String(v))) ? String(v) : "'" + String(v).replace(/'/g, "''") + "'"; }
+  // Record the currently-selected record's key at this tab's level; clear stale deeper selections.
+  function _setSel(tab) {
+    var lvl = tab.tabLevel || 0;
+    var rec = _records[_recIdx];
+    _selByLevel[lvl] = rec ? recVal(rec, _keyCol(tab)) : null;
+    Object.keys(_selByLevel).forEach(function (L) { if (Number(L) > lvl) delete _selByLevel[L]; });
   }
   function renderActiveTab() {
     var tab = _curTab(); if (!tab) return;
@@ -409,12 +434,28 @@
       status(_curWin().name + ' › ' + tab.name + '  ·  table ' + tab.tableName + ' not in curated seed');
       return;
     }
-    var where = tab.whereClause && tab.whereClause.indexOf('@') < 0 ? tab.whereClause : null; // skip context-var clauses in I1
+    var clauses = [];
+    if (tab.whereClause && tab.whereClause.indexOf('@') < 0) clauses.push('(' + tab.whereClause + ')'); // skip context-var clauses in I1
+    // ── Master-detail: a child tab (tabLevel>0) filters by its parent record's key (the iDempiere drill) ──
+    var level = tab.tabLevel || 0, mdNote = '';
+    if (level > 0) {
+      var w = _curWin(), pIdx = -1;
+      for (var pi = _activeTabIdx - 1; pi >= 0; pi--) { if ((w.tabs[pi].tabLevel || 0) === level - 1) { pIdx = pi; break; } }
+      if (pIdx >= 0) {
+        var pTab = w.tabs[pIdx], pKey = _keyCol(pTab), pPk = _selByLevel[level - 1];
+        if (pPk != null && pKey && _colExists(tab.tableName, pKey)) {
+          clauses.push(pKey + '=' + _lit(pPk));
+          mdNote = pTab.tableName + '.' + pKey + '=' + pPk;
+          console.log('§IDEMPIERE-MD tab=' + tab.name + ' level=' + level + ' parent=' + pTab.tableName + ' filter=' + pKey + '=' + pPk);
+        }
+      }
+    }
+    var where = clauses.length ? clauses.join(' AND ') : null;
     var orderBy = tab.orderByClause && tab.orderByClause.indexOf('@') < 0 ? tab.orderByClause : null;
     _records = ADD.readRecords(db, tab.tableName, where, orderBy) || [];
     if (_records.length > 200) _records = _records.slice(0, 200); // cap display in I1
-    _recIdx = 0;
-    console.log('§IDEMPIERE tab=' + tab.name + ' table=' + tab.tableName + ' rows=' + _records.length + ' fields=' + (tab.fields ? tab.fields.length : 0));
+    _recIdx = 0; _setSel(tab);
+    console.log('§IDEMPIERE tab=' + tab.name + ' table=' + tab.tableName + ' rows=' + _records.length + ' fields=' + (tab.fields ? tab.fields.length : 0) + (mdNote ? ' parentFilter=' + mdNote : ''));
     renderBody();
   }
   function _displayFields(tab) {
@@ -456,7 +497,7 @@
     _records.forEach(function (rec, i) {
       var tr = el('tr'); tr.dataset.i = i;
       cols.forEach(function (f) { tr.appendChild(el('td', null, fmt(f, recVal(rec, f.columnName)))); });
-      tr.addEventListener('click', function () { _recIdx = i; _viewMode = 'form'; renderBody(); renderToolbar(); });
+      tr.addEventListener('click', function () { _recIdx = i; _setSel(tab); _viewMode = 'form'; renderBody(); renderToolbar(); });
       tb.appendChild(tr);
     });
     table.appendChild(tb);
@@ -479,7 +520,7 @@
     var nav = $('idmp-recnav');
     if (nav) nav.textContent = _records.length ? ('Record ' + (_recIdx + 1) + ' of ' + _records.length) : '0 records';
     if (_viewMode === 'form') { var tab = _curTab(); if (tab) { $('idmp-content').innerHTML = ''; $('idmp-content').appendChild(buildForm(tab)); } }
-    var t = _curTab(); if (t) updateStatus(t);
+    var t = _curTab(); if (t) { _setSel(t); updateStatus(t); }
   }
   function updateStatus(tab) {
     var w = _curWin();
@@ -514,7 +555,7 @@
 <script>
 // Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data + ad_seed.db are precached (sw v559).
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js?v=559')
+  navigator.serviceWorker.register('sw.js?v=560')
     .then(function (r) { console.log('§SW_REG scope=' + r.scope); })
     .catch(function (e) { console.warn('§SW_REG_FAIL', e); });
 }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v559';
+const CACHE_VERSION = 'v560';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency

--- a/viewer/tests/test_idempiere_master_detail.js
+++ b/viewer/tests/test_idempiere_master_detail.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: headless §-witness for idempiere.html MASTER-DETAIL drill (the core iDempiere ZK behaviour).
+//   ISSUE it proves: selecting a header record and opening a child tab filters the child rows by the
+//   parent FK — i.e. the drill returns the parent's children ONLY, not the whole child table. Uses the
+//   AD self-management window (Window → Tab → Field) since those dictionary tables hold data in ad_seed.db.
+//   §-log first — READ the log before any conclusion.
+// Run:  node tests/test_idempiere_master_detail.js 2>&1 | tee tests/test_idempiere_master_detail.log
+'use strict';
+var fs = require('fs'), path = require('path');
+var initSqlJs = require('sql.js');
+var VIEWER = path.join(__dirname, '..');
+global.window = global.window || {};
+var ADParser = require(path.join(VIEWER, 'ad_parser.js'));
+var ADData = require(path.join(VIEWER, 'ad_data.js'));
+
+var fails = 0;
+function ok(c, m) { if (!c) { fails++; console.log('  ✗ FAIL: ' + m); } else { console.log('  ✓ ' + m); } }
+function count(db, t, where) { try { var r = db.exec('SELECT COUNT(*) FROM ' + t + (where ? ' WHERE ' + where : '')); return Number(r[0].values[0][0]); } catch (e) { return -1; } }
+function keyCol(tab) { var k = (tab.fields || []).filter(function (f) { return f.isKey; })[0]; return k ? k.columnName : tab.tableName + '_ID'; }
+
+(async function () {
+  console.log('=== §IDEMPIERE-MD witness — master-detail drill filters child by parent FK ===');
+  var SQL = await initSqlJs();
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(path.join(VIEWER, 'ad_seed.db'))));
+  ADParser.init(db);
+
+  // Find the AD "Window" self-management window (header tab table = AD_Window).
+  var r = db.exec("SELECT t.AD_Window_ID FROM AD_Tab t JOIN AD_Table tb ON t.AD_Table_ID=tb.AD_Table_ID WHERE tb.TableName='AD_Window' AND t.TabLevel=0 LIMIT 1");
+  ok(r.length > 0, 'found the AD_Window self-management window');
+  var winId = Number(r[0].values[0][0]);
+  var win = ADParser.getWindow(db, winId);
+  console.log('  window=' + win.name + '(' + winId + ') tabs=' + win.tabs.length);
+
+  // Header (level 0) = AD_Window; pick the first record's key (what selecting a row does in the UI).
+  var hdr = win.tabs.filter(function (t) { return (t.tabLevel || 0) === 0; })[0];
+  var hdrRows = ADData.readRecords(db, hdr.tableName, null, null);
+  ok(hdrRows.length > 0, 'header tab ' + hdr.tableName + ' has records (' + hdrRows.length + ')');
+  var hdrKey = keyCol(hdr);
+  var selPk = hdrRows[0][hdrKey];
+  console.log('  selected header ' + hdr.tableName + '.' + hdrKey + '=' + selPk + ' (' + (hdrRows[0].Name || '') + ')');
+
+  // Child (level 1) = AD_Tab; the drill filters AD_Tab WHERE AD_Window_ID = selected window.
+  var child = win.tabs.filter(function (t) { return (t.tabLevel || 0) === 1 && t.tableName; })[0];
+  ok(!!child, 'window has a level-1 child tab (' + (child && child.tableName) + ')');
+  var childTotal = count(db, child.tableName);
+  var childFiltered = count(db, child.tableName, hdrKey + '=' + selPk);
+  console.log('§IDEMPIERE-MD parent=' + hdr.tableName + '.' + hdrKey + '=' + selPk +
+    ' child=' + child.tableName + ' filtered=' + childFiltered + ' total=' + childTotal);
+  ok(childFiltered > 0, child.tableName + ' filtered to the parent returns rows (' + childFiltered + ')');
+  ok(childFiltered < childTotal, 'DRILL NARROWS: ' + child.tableName + ' filtered (' + childFiltered + ') << total (' + childTotal + ')');
+
+  // Grandchild (level 2) = AD_Field; drill again by the selected child (AD_Tab) key.
+  var childRows = ADData.readRecords(db, child.tableName, hdrKey + '=' + selPk, null);
+  var childKey = keyCol(child);
+  var selChildPk = childRows.length ? childRows[0][childKey] : null;
+  var grand = win.tabs.filter(function (t) { return (t.tabLevel || 0) === 2 && t.tableName; })[0];
+  if (grand && selChildPk != null) {
+    var gTotal = count(db, grand.tableName);
+    var gFiltered = count(db, grand.tableName, childKey + '=' + selChildPk);
+    console.log('§IDEMPIERE-MD parent=' + child.tableName + '.' + childKey + '=' + selChildPk +
+      ' child=' + grand.tableName + ' filtered=' + gFiltered + ' total=' + gTotal);
+    ok(gFiltered > 0 && gFiltered < gTotal, 'DRILL NARROWS L2: ' + grand.tableName + ' filtered (' + gFiltered + ') << total (' + gTotal + ')');
+  } else {
+    console.log('  (no level-2 tab or no child row to drill — skipping L2)');
+  }
+
+  console.log('\n=== RESULT: ' + (fails === 0 ? 'ALL PASS — master-detail drill filters by parent FK' : fails + ' FAIL') + ' ===');
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.error('FATAL: ' + e.message); process.exit(1); });


### PR DESCRIPTION
## Master-detail drill — the core iDempiere ZK behaviour

Select a header record → open a child tab (tabLevel>0) → child rows **filter by the parent FK**, folded from SQLite WASM. Nested AD tab-strip (└ child indent), record-nav + selection sync, honest curated-seed handling preserved.

### Witnessed on the AD self-management window (Window → Tab → Field)
- `§IDEMPIERE-MD tab=Tab level=1 parent=AD_Window filter=AD_Window_ID=100` → **AD_Tab 13 rows (of 1130)**
- `§IDEMPIERE-MD ... child=AD_Field filtered=31 total=20911` → **AD_Field 31 rows (of 20911)**
- Live Playwright: open W102, select AD_Window #100, click └ Tab → grid shows the 13 child tabs; status `Window, Tab and Field › Tab · Record 1 of 13 · AD_Tab`.

### Tests (headless §-log)
- NEW `tests/test_idempiere_master_detail.js` — proves the drill NARROWS (filtered << total) at L1 and L2. ALL PASS.
- `test_pills_manifest.js` + `test_idempiere_fold.js` still green (no regression).

### Deploy
- `sw.js` v560 (idempiere.html is precached → bump refreshes returning users). idempiere.html + erp.html register `sw.js?v=560`.
- `ad_ui.js` untouched (153/153 AD-UI baseline intact). Trademark-safe (A+ mark only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)