### PR TITLE
feat(erp): glassbowl/gravity become icon pills — drop #gbviews top links

### DIFF
--- a/viewer/erp.html
+++ b/viewer/erp.html
@@ -55,15 +55,8 @@
   ::-webkit-scrollbar { width: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
-  /* Companion Glassbowl views (served from BIMCompiler GitHub Pages) */
-  #gbviews { position: fixed; top: 9px; right: 12px; z-index: 11; display: flex; gap: 6px; }
-  #gbviews a {
-    font-size: 12px; font-weight: 600; color: #cdd6e4; text-decoration: none;
-    background: rgba(40,44,58,0.82); border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 14px; padding: 6px 11px; min-height: 0; line-height: 1;
-    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-  }
-  #gbviews a:hover { border-color: #56d6e0; color: #56d6e0; }
+  /* Companion Glassbowl + Gravity views are now pill icons (pills.json glassbowl/gravity),
+     mounted by erp_pills.js — the old #gbviews top-right text links were removed. */
 </style>
 </head>
 <body>
@@ -74,13 +67,8 @@
   <div id="load-status" style="margin-top:8px;font-size:11px;color:#555;"></div>
 </div>
 
-<!-- Companion Glassbowl views — the same model, seen two ways (read-only) -->
-<div id="gbviews">
-  <a href="https://red1oon.github.io/BIMCompiler/glassbowl.html" target="_blank" rel="noopener"
-     title="Glassbowl — the engine mapped from its own data (FK spines, trace, dossier)">🫧 Glassbowl</a>
-  <a href="https://red1oon.github.io/BIMCompiler/glassbowl_gravity.html" target="_blank" rel="noopener"
-     title="Glassbowl Gravity — pivot &amp; weigh the model (live GROUP BY, AD↔GW depth dial)">✦ Gravity</a>
-</div>
+<!-- Companion Glassbowl + Gravity views are now icon pills in the right-edge pill bar
+     (pills.json: glassbowl=rosetta, gravity=disciplines; erp_pills.js opens their HTMLs). -->
 
 <div id="breadcrumb"></div>
 <div id="content"></div>
@@ -368,7 +356,7 @@ var _shellReady = false;
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=560')
+  navigator.serviceWorker.register('sw.js?v=561')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }
@@ -439,7 +427,7 @@ if('serviceWorker' in navigator){
     }).catch(function (e) { console.warn('§VERIFY_LEDGER error', e); _toast('Verify error', false); });
   }
   window.ErpVerifyLedger = verifyLedger;
-  // Unobtrusive control — bottom-left, clear of #gbviews (top-right) and the offline badge (top).
+  // Unobtrusive control — bottom-left, clear of the right-edge pill bar and the offline badge (top).
   var b = document.createElement('button');
   b.id = 'verify-ledger-pill';
   b.type = 'button';

--- a/viewer/erp_pills.js
+++ b/viewer/erp_pills.js
@@ -88,9 +88,18 @@
         var act = { id: p.id, name: p.name, key: p.key || '' };
         if (p.img) act.img = p.img; else act.icon = _resolveIcon(p) || '';
 
-        // fn: nav pills navigate; the rest bind by id (handler or honest toast)
+        // fn: nav pills navigate; the rest bind by id (handler or honest toast).
+        // Absolute (external) URLs open in a new tab — companion views (glassbowl/gravity) on
+        // BIMCompiler GitHub Pages, matching the old #gbviews target="_blank". Local nav replaces in place.
         if (p.nav) {
-          act.fn = (function (url, id) { return function () { console.log('§PILL-NAV ' + id + '->' + url); location.href = url; }; })(p.nav, p.id);
+          act.fn = (function (url, id) {
+            return function () {
+              var external = /^https?:\/\//i.test(url);
+              console.log('§PILL-NAV ' + id + '->' + url + (external ? ' (new tab)' : ''));
+              if (external) window.open(url, '_blank', 'noopener');
+              else location.href = url;
+            };
+          })(p.nav, p.id);
         } else {
           act.fn = BINDINGS[p.id] || function () { _toast(p.name); };
         }

--- a/viewer/pills.json
+++ b/viewer/pills.json
@@ -16,7 +16,7 @@
     { "id": "settings",  "name": "Settings",     "key": "=",   "icon": "@bim",        "order": 10, "reuse": "bim" },
     { "id": "help",      "name": "Need Help",    "key": "F1",  "icon": "@bim",        "order": 11, "reuse": "bim" },
     { "id": "idempiere", "name": "iDempiere-like UI", "key": "", "img": "aplus.png", "order": 12, "reuse": "new", "nav": "idempiere.html", "note": "ETHICS: the user's neutral A+ raster (aplus.png) — NEVER the trademarked iDempiere logo (IDEMPIERE_PILL_HANDOFF.md, IDEMPIERE_2.md §Guardrails 3). Renderer #1 = idempiere.html." },
-    { "id": "glassbowl", "name": "Glassbowl",    "key": "",    "icon": "rosetta",     "order": 13, "reuse": "new", "nav": "glassbowl.html", "note": "on-brand crystal/gem (existing 'rosetta' glyph repurposed) — the engine-as-data lens / glass bowl" },
-    { "id": "gravity",   "name": "Gravity",      "key": "",    "icon": "disciplines", "order": 14, "reuse": "new", "nav": "glassbowl_gravity.html", "note": "central mass + orbiting satellites (existing 'disciplines' glyph repurposed) = a gravity / orbit system" }
+    { "id": "glassbowl", "name": "Glassbowl",    "key": "",    "icon": "rosetta",     "order": 13, "reuse": "new", "nav": "https://red1oon.github.io/BIMCompiler/glassbowl.html", "note": "on-brand crystal/gem (existing 'rosetta' glyph repurposed) — the engine-as-data lens / glass bowl. Companion view on BIMCompiler GitHub Pages (replaces the old #gbviews text link)." },
+    { "id": "gravity",   "name": "Gravity",      "key": "",    "icon": "disciplines", "order": 14, "reuse": "new", "nav": "https://red1oon.github.io/BIMCompiler/glassbowl_gravity.html", "note": "central mass + orbiting satellites (existing 'disciplines' glyph repurposed) = a gravity / orbit system. Companion view on BIMCompiler GitHub Pages (replaces the old #gbviews text link)." }
   ]
 }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v560';
+const CACHE_VERSION = 'v561';
 const CACHE_NAME = 'bim-ootb-' + CACHE_VERSION;
 
 // Local copies of vendor libs — single-origin, no CDN dependency


### PR DESCRIPTION
## What

The two top-right **text links** on `erp.html` (`#gbviews`: 🫧 Glassbowl / ✦ Gravity) become the right-edge pill bar's existing **icon pills** (`pills.json` glassbowl=rosetta, gravity=disciplines), per `PILL_MANIFEST_SPEC.md` / `IDEMPIERE_PILL_HANDOFF.md`. Result: a single, consistent pill surface; no stray non-pill chrome on top.

## Changes (4 files, `viewer/`)

- **erp.html** — remove `#gbviews` CSS + markup (redundant with the pill bar); fix stale comment; bump SW register `?v=561`.
- **pills.json** — repoint `glassbowl`/`gravity` `nav` from the missing local `glassbowl.html` / `glassbowl_gravity.html` (would 404) to the working `red1oon.github.io/BIMCompiler/...` URLs, so the pills still link to their respective HTMLs.
- **erp_pills.js** — absolute (external) pill nav opens in a new tab (`window.open(_blank, noopener)`), matching the old `target="_blank"`; local nav stays in place.
- **sw.js** — `CACHE_VERSION` v560→v561 so the cache-first precached `erp.html`/`erp_pills.js`/`pills.json` refresh on deploy.

## Witness
`§PILL-NAV id=glassbowl->https://red1oon.github.io/BIMCompiler/glassbowl.html (new tab)`

## Verified
- `pills.json` valid JSON (14 pills); `erp_pills.js` `node --check` clean.
- `rosetta` + `disciplines` glyphs present in `icons.js` → both render as icons (no `§PILL_ICON_MISS`).
- No live `#gbviews` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)