### PR TITLE
feat(idempiere): login + Role/Client/Org session (renderer #1)

### DIFF
--- a/viewer/idempiere.html
+++ b/viewer/idempiere.html
@@ -149,6 +149,37 @@
   }
   #idmp-loading .sp { width:34px; height:34px; border:3px solid #cfd8e3; border-top-color:var(--idmp-blue); border-radius:50%; animation:sp .8s linear infinite; }
   @keyframes sp { to { transform:rotate(360deg); } }
+  /* ── Login / Role·Client·Org selection (docs §3b) — identity SELECTION, not auth ── */
+  #idmp-login {
+    position:fixed; inset:0; z-index:120; display:flex; align-items:center; justify-content:center;
+    background:linear-gradient(135deg,var(--idmp-header),#0f2f57);
+  }
+  .idmp-login-card {
+    background:#fff; border-radius:10px; width:384px; max-width:92vw; padding:26px 28px;
+    box-shadow:0 14px 44px rgba(0,0,0,0.4); max-height:92vh; overflow:auto;
+  }
+  .idmp-login-mark { width:42px; height:42px; border-radius:8px; background:var(--idmp-blue); color:#fff;
+    font-weight:800; font-size:17px; letter-spacing:-.5px; display:flex; align-items:center; justify-content:center; margin:0 auto 10px; }
+  .idmp-login-title { text-align:center; font-size:18px; font-weight:700; }
+  .idmp-login-sub { text-align:center; font-size:11.5px; color:var(--idmp-muted); margin:5px 0 16px; }
+  .idmp-login-label { font-size:11px; text-transform:uppercase; letter-spacing:.4px; color:var(--idmp-muted); margin:13px 0 5px; }
+  .idmp-login-list { display:flex; flex-direction:column; gap:6px; max-height:48vh; overflow:auto; }
+  .idmp-login-user { display:flex; align-items:center; gap:10px; padding:9px 12px; border:1px solid var(--idmp-border);
+    border-radius:6px; cursor:pointer; background:#fbfcfe; font-size:14px; }
+  .idmp-login-user:hover { background:var(--idmp-hover); border-color:var(--idmp-blue); }
+  .idmp-login-user .av { width:26px; height:26px; border-radius:50%; background:var(--idmp-blue); color:#fff;
+    display:flex; align-items:center; justify-content:center; font-weight:700; font-size:12px; flex:0 0 auto; }
+  .idmp-login-user.disabled { opacity:.5; cursor:not-allowed; }
+  .idmp-login-user.disabled:hover { background:#fbfcfe; border-color:var(--idmp-border); }
+  .idmp-login-user .tag { margin-left:auto; font-size:11px; color:var(--idmp-muted); }
+  #idmp-login select, #idmp-login input { width:100%; height:34px; border:1px solid var(--idmp-border);
+    border-radius:5px; padding:0 9px; font-size:13px; background:#fff; color:var(--idmp-text); }
+  #idmp-login input[readonly] { background:#eef1f5; color:var(--idmp-muted); }
+  .idmp-login-actions { display:flex; gap:8px; margin-top:18px; }
+  .idmp-login-actions button { flex:1; height:36px; border-radius:6px; border:1px solid var(--idmp-border);
+    cursor:pointer; font-size:13px; font-weight:600; }
+  .idmp-login-actions .primary { background:var(--idmp-blue); color:#fff; border-color:var(--idmp-blue); }
+  .idmp-login-note { font-size:11px; color:var(--idmp-muted); margin-top:12px; text-align:center; }
   /* ── Mobile adaptation (desktop is exact; mobile may adapt) ── */
   @media (max-width:760px) {
     #idmp-burger { display:flex; }
@@ -167,14 +198,41 @@
 
 <div id="idmp-loading"><div class="sp"></div><div id="idmp-load-msg">Loading iDempiere — folding the Application Dictionary from SQLite&hellip;</div></div>
 
+<!-- Login / Role·Client·Org selection (docs §3b) — folded from AD_User/AD_Role/AD_Org; SELECTION, not auth -->
+<div id="idmp-login" style="display:none">
+  <div class="idmp-login-card">
+    <div class="idmp-login-mark">A+</div>
+    <div class="idmp-login-title">iDempiere&#8209;like — Sign In</div>
+    <div class="idmp-login-sub">Offline demo · identity &amp; context <b>selection</b> (no password) — folded from <b>ad_seed.db</b></div>
+    <div id="idmp-login-step1">
+      <div class="idmp-login-label">Select a user</div>
+      <div id="idmp-login-users" class="idmp-login-list"></div>
+    </div>
+    <div id="idmp-login-step2" style="display:none">
+      <div class="idmp-login-label">Role</div>
+      <select id="idmp-login-role"></select>
+      <div class="idmp-login-label">Client</div>
+      <input id="idmp-login-client" readonly>
+      <div class="idmp-login-label">Organisation</div>
+      <select id="idmp-login-org"></select>
+      <div class="idmp-login-actions">
+        <button id="idmp-login-back" class="ghost">&lsaquo; Back</button>
+        <button id="idmp-login-ok" class="primary">Log In &rsaquo;</button>
+      </div>
+      <div id="idmp-login-note" class="idmp-login-note"></div>
+    </div>
+  </div>
+</div>
+
 <div id="idmp-header">
   <button id="idmp-burger" class="hbtns"><button title="Menu">&#9776;</button></button>
   <span id="idmp-logo">A+</span>
   <span id="idmp-title">iDempiere&#8209;like</span>
   <input id="idmp-search" type="search" placeholder="Search menu&hellip;" autocomplete="off">
   <span class="spacer"></span>
-  <span class="ctx" id="idmp-ctx">GardenWorld · System Administrator</span>
+  <span class="ctx" id="idmp-ctx">&mdash;</span>
   <span class="hbtns">
+    <button id="idmp-switch-btn" title="Switch role / Log out">&#8644;</button>
     <button id="idmp-home-btn" title="Home / Engine view (erp.html)">&#8962;</button>
     <button title="Help" id="idmp-help-btn">?</button>
   </span>
@@ -198,12 +256,19 @@
 
 <script src="ad_parser.js?v=22"></script>
 <script src="ad_data.js?v=22"></script>
+<script src="idmp_session.js?v=22"></script>
 <script>
 (function () {
   'use strict';
   var _t0 = performance.now();
   var db = null;
-  var ADP = window.ADParser, ADD = window.ADData;
+  var ADP = window.ADParser, ADD = window.ADData, SES = window.IdmpSession;
+
+  // ── Session (docs §3b): identity + Role·Client·Org context SELECTION (no server, no auth) ──
+  var _session = null;       // { user, role, client, org, roles, orgs, winSet } — null until login
+  var _loginUser = null;     // the user picked at login step 1 (drives step 2)
+  var _lastMenu = { visible: 0, total: 0 };  // last scopeMenu counts (for the §witness)
+  var _pendingWid = null;    // ?window=<id> deep link, opened AFTER login
 
   // open-window state (a faithful single-window desktop; MDI tabs track opened windows)
   var _openWins = {};        // windowId -> { win, name }
@@ -269,22 +334,82 @@
     if (ADP && ADP.init) ADP.init(db);
     console.log('§IDEMPIERE boot db=' + src + ' ms=' + Math.round(performance.now() - _t0));
 
-    buildMenu();
+    // Menu builds only AFTER login — it is role-scoped (docs §3b). Defer the deep link too.
+    _pendingWid = new URLSearchParams(location.search).get('window');
     $('idmp-loading').style.display = 'none';
+    showLogin('user');
+  }
 
-    // deep link ?window=<id>
-    var wid = new URLSearchParams(location.search).get('window');
-    if (wid) openWindow(Number(wid));
+  // ── Login flow (docs §3b/§3b.1): pick user → Role/Client/Org → role-scoped session ──
+  function showLogin(step) {
+    $('idmp-login').style.display = 'flex';
+    if (step === 'role' && _loginUser) loginStep2(_loginUser); else loginStep1();
+  }
+  function loginStep1() {
+    $('idmp-login-step2').style.display = 'none';
+    $('idmp-login-step1').style.display = '';
+    var host = $('idmp-login-users'); host.innerHTML = '';
+    SES.listUsers(db).forEach(function (u) {
+      var row = el('div', 'idmp-login-user' + (u.hasRoles ? '' : ' disabled'));
+      row.appendChild(el('span', 'av', (u.name || '?').charAt(0).toUpperCase()));
+      row.appendChild(el('span', 'nm', u.name));
+      if (!u.hasRoles) row.appendChild(el('span', 'tag', '(no roles)'));   // seed reality — named, not dropped
+      else row.addEventListener('click', function () { _loginUser = u; loginStep2(u); });
+      host.appendChild(row);
+    });
+  }
+  function loginStep2(u) {
+    $('idmp-login-step1').style.display = 'none';
+    $('idmp-login-step2').style.display = '';
+    var roleSel = $('idmp-login-role'); roleSel.innerHTML = '';
+    var roles = SES.rolesForUser(db, u.id);
+    roles.forEach(function (r) { var o = el('option', null, r.name); o.value = r.id; roleSel.appendChild(o); });
+    function syncRole() {
+      var rid = Number(roleSel.value);
+      var client = SES.clientFor(db, rid);
+      $('idmp-login-client').value = client ? (client.name + ' (' + client.id + ')') : '';
+      var orgSel = $('idmp-login-org'); orgSel.innerHTML = '';
+      SES.orgsForRole(db, rid).forEach(function (o) { var op = el('option', null, o.name); op.value = o.id; orgSel.appendChild(op); });
+    }
+    roleSel.onchange = syncRole; syncRole();
+    $('idmp-login-note').textContent = u.name + ' · ' + roles.length + ' role(s) — context selection, not authentication';
+  }
+  function doLogin() {
+    var rid = Number($('idmp-login-role').value);
+    var oid = Number($('idmp-login-org').value);
+    _session = SES.buildContext(db, _loginUser.id, { roleId: rid, orgId: oid });
+    if (!_session) { $('idmp-login-note').textContent = 'That user has no roles — cannot log in.'; return; }
+    $('idmp-login').style.display = 'none';
+    applySession();
+  }
+  function applySession() {
+    // header context bar — live Client · Role · Org (replaces the old static string)
+    var orgLabel = _session.org ? _session.org.name.replace(/\s*\(.*\)/, '') : '—';
+    $('idmp-ctx').textContent = _session.client.name + ' · ' + _session.role.name + ' · ' + orgLabel;
+    // a role change can revoke window access — close any open windows, reset to placeholder
+    _openWins = {}; _activeWin = null; renderWinTabs();
+    $('idmp-toolbar').style.display = 'none'; $('idmp-tabstrip').style.display = 'none';
+    $('idmp-content').innerHTML = '<div id="idmp-placeholder"><div class="big">&#128193;</div>Select a menu item to open a window.<br>Menu + data scoped to <b>' + _session.role.name + '</b>.</div>';
+    buildMenu();   // role-scoped
+    console.log('§IDEMPIERE-LOGIN user=' + _session.user.name + ' roles=' + (_session.roles ? _session.roles.length : '?') +
+      ' client=' + _session.client.name + '(' + _session.client.id + ')' +
+      ' org=' + (_session.org ? _session.org.name.replace(/\s.*/, '') : '-') +
+      ' menu-visible=' + _lastMenu.visible + '/' + _lastMenu.total +
+      ' source=ad_user/ad_role/ad_window_access handAuthored=0');
+    if (_pendingWid) { var w = Number(_pendingWid); _pendingWid = null; if (_session.winSet[w]) openWindow(w); }
   }
 
   // ── Left menu tree (folded from AD_Menu) ──
   function buildMenu() {
     var roots = (ADP && ADP.getMenuTree) ? ADP.getMenuTree(db) : [];
+    // Role-scope: prune W leaves the role can't open + empty folders (docs §3b.1). winSet from AD_Window_Access.
+    var scoped = (_session && SES && SES.scopeMenu) ? SES.scopeMenu(roots, _session.winSet) : { tree: roots, visible: 0, total: 0 };
+    _lastMenu = scoped;
     var tree = $('idmp-tree'); tree.innerHTML = '';
     var groups = 0, leaves = 0;
-    roots.forEach(function (n) { var r = renderNode(n); tree.appendChild(r.dom); groups += r.groups; leaves += r.leaves; });
-    console.log('§IDEMPIERE menu groups=' + groups + ' leaves=' + leaves + ' source=ad_menu handAuthored=0');
-    status('Menu: ' + groups + ' groups · ' + leaves + ' items — folded from AD_Menu');
+    scoped.tree.forEach(function (n) { var r = renderNode(n); tree.appendChild(r.dom); groups += r.groups; leaves += r.leaves; });
+    console.log('§IDEMPIERE menu groups=' + groups + ' leaves=' + leaves + ' visibleWindows=' + scoped.visible + '/' + scoped.total + ' source=ad_menu handAuthored=0');
+    status('Menu: ' + groups + ' groups · ' + leaves + ' items' + (_session ? ' · scoped to ' + _session.role.name : '') + ' — folded from AD_Menu');
   }
   function renderNode(node) {
     var groups = 0, leaves = 0;
@@ -436,6 +561,12 @@
     }
     var clauses = [];
     if (tab.whereClause && tab.whereClause.indexOf('@') < 0) clauses.push('(' + tab.whereClause + ')'); // skip context-var clauses in I1
+    // ── Session data scope (docs §3b.1): client always; specific org narrows; org 0=* means no org narrowing.
+    // Applied ONLY when the column exists on this table — same clause layer as master-detail's parent FK.
+    if (_session) {
+      if (_session.client && _colExists(tab.tableName, 'AD_Client_ID')) clauses.push('AD_Client_ID IN (0,' + _session.client.id + ')');
+      if (_session.org && _session.org.id !== 0 && _colExists(tab.tableName, 'AD_Org_ID')) clauses.push('AD_Org_ID IN (0,' + _session.org.id + ')');
+    }
     // ── Master-detail: a child tab (tabLevel>0) filters by its parent record's key (the iDempiere drill) ──
     var level = tab.tabLevel || 0, mdNote = '';
     if (level > 0) {
@@ -548,14 +679,20 @@
     $('idmp-burger').addEventListener('click', function () { document.body.classList.toggle('menu-open'); });
     $('idmp-home-btn').addEventListener('click', function () { location.href = 'erp.html'; });
     $('idmp-help-btn').addEventListener('click', function () { status('Help / ShowMe overlay — arrives once the UI is confirmed'); });
+    // Login overlay wiring (docs §3b): Back→pick another user (logout), Log In→commit session,
+    // switch-role→reopen at the Role step, backdrop click→dismiss only if already logged in.
+    $('idmp-login-back').addEventListener('click', loginStep1);
+    $('idmp-login-ok').addEventListener('click', doLogin);
+    $('idmp-switch-btn').addEventListener('click', function () { showLogin('role'); });
+    $('idmp-login').addEventListener('click', function (e) { if (e.target === $('idmp-login') && _session) $('idmp-login').style.display = 'none'; });
     boot().catch(function (e) { console.error('§IDEMPIERE boot error: ' + e.message); $('idmp-load-msg').textContent = 'Boot error: ' + e.message; });
   });
 })();
 </script>
 <script>
-// Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data + ad_seed.db are precached (sw v559).
+// Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data/idmp_session + ad_seed.db are precached (sw v561).
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js?v=560')
+  navigator.serviceWorker.register('sw.js?v=561')
     .then(function (r) { console.log('§SW_REG scope=' + r.scope); })
     .catch(function (e) { console.warn('§SW_REG_FAIL', e); });
 }

--- a/viewer/idmp_session.js
+++ b/viewer/idmp_session.js
@@ -1,0 +1,148 @@
+// idmp_session.js — iDempiere login / Role·Client·Org session fold (renderer #1).
+// Implementing docs/IDEMPIERE_RENDERER_SPEC.md §3b + §3b.1 — Witness: §IDEMPIERE-LOGIN.
+// Pure folds over ad_seed.db (AD_User, AD_User_Roles, AD_Role, AD_Client, AD_Role_OrgAccess,
+// AD_Org, AD_Window_Access). No DOM, no writes — the SAME calls the headless witness makes.
+// HONEST: no server → identity/context SELECTION, not password auth (docs §3b honest framing).
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+(function () {
+  'use strict';
+
+  // db.exec → array of {column,value} row objects (mirrors ad_data.readRecords shape).
+  function rows(db, sql, params) {
+    var r = db.exec(sql, params || []);
+    if (!r.length) return [];
+    var cols = r[0].columns;
+    return r[0].values.map(function (v) {
+      var o = {}; for (var i = 0; i < cols.length; i++) o[cols[i]] = v[i]; return o;
+    });
+  }
+  function num(v) { return v == null ? null : Number(v); }
+
+  // ── Step 1: the login user list (all 8 AD_User rows; hasRoles flags seed reality) ──
+  // Only users with an AD_User_Roles row can proceed (faithful to iDempiere). Role-less
+  // users are returned too so the UI can NAME them disabled, not silently drop them.
+  function listUsers(db) {
+    var us = rows(db,
+      'SELECT u.AD_User_ID AS id, u.Name AS name, u.AD_Client_ID AS clientId, ' +
+      '  (SELECT COUNT(*) FROM AD_User_Roles ur WHERE ur.AD_User_ID = u.AD_User_ID) AS nRoles ' +
+      'FROM AD_User u WHERE u.IsActive = \'Y\' ORDER BY u.AD_User_ID');
+    var out = us.map(function (u) {
+      return { id: num(u.id), name: (u.name || '').trim(), clientId: num(u.clientId), hasRoles: num(u.nRoles) > 0 };
+    });
+    var withRoles = out.filter(function (u) { return u.hasRoles; }).length;
+    console.log('§IDMP-SESSION listUsers users=' + out.length + ' withRoles=' + withRoles + ' source=ad_user/ad_user_roles');
+    return out;
+  }
+
+  // ── Step 2: roles for a user (the Role dropdown) ──
+  function rolesForUser(db, userId) {
+    var rs = rows(db,
+      'SELECT r.AD_Role_ID AS id, r.Name AS name, r.AD_Client_ID AS clientId ' +
+      'FROM AD_User_Roles ur JOIN AD_Role r ON ur.AD_Role_ID = r.AD_Role_ID ' +
+      'WHERE ur.AD_User_ID = ? AND r.IsActive = \'Y\' ORDER BY r.Name', [userId]);
+    var out = rs.map(function (r) { return { id: num(r.id), name: (r.name || '').trim(), clientId: num(r.clientId) }; });
+    console.log('§IDMP-SESSION rolesForUser user=' + userId + ' roles=' + out.length + ' source=ad_user_roles/ad_role');
+    return out;
+  }
+
+  // ── Step 3: the client a role fixes (AD_Role.AD_Client_ID → AD_Client) ──
+  function clientFor(db, roleId) {
+    var c = rows(db,
+      'SELECT cl.AD_Client_ID AS id, cl.Name AS name FROM AD_Role r ' +
+      'JOIN AD_Client cl ON r.AD_Client_ID = cl.AD_Client_ID WHERE r.AD_Role_ID = ?', [roleId]);
+    var out = c.length ? { id: num(c[0].id), name: (c[0].name || '').trim() } : null;
+    console.log('§IDMP-SESSION clientFor role=' + roleId + ' client=' + (out ? out.name + '(' + out.id + ')' : 'none') + ' source=ad_role/ad_client');
+    return out;
+  }
+
+  // ── Step 4: orgs a role may access (AD_Role_OrgAccess LEFT JOIN AD_Org). ──
+  // Org 0 = "*" (All accessible) is a real grant row in AD_Role_OrgAccess but has NO AD_Org row
+  // (the iDempiere "*" convention, like client 0 = System) — so it is LEFT-joined and kept, named
+  // "*" from convention, not invented. AD_Role_OrgAccess is the driver so org 0 is never dropped.
+  function orgsForRole(db, roleId) {
+    var os = rows(db,
+      'SELECT oa.AD_Org_ID AS id, o.Name AS name FROM AD_Role_OrgAccess oa ' +
+      'LEFT JOIN AD_Org o ON oa.AD_Org_ID = o.AD_Org_ID ' +
+      'WHERE oa.AD_Role_ID = ? AND oa.IsActive = \'Y\' ORDER BY oa.AD_Org_ID', [roleId]);
+    var out = os.map(function (o) {
+      var id = num(o.id);
+      return { id: id, name: id === 0 ? '* (All accessible)' : (o.name || '').trim() };
+    });
+    console.log('§IDMP-SESSION orgsForRole role=' + roleId + ' orgs=' + out.length + ' source=ad_role_orgaccess/ad_org');
+    return out;
+  }
+
+  // ── role-scope: the set of AD_Window_IDs the role may open (AD_Window_Access) ──
+  function accessibleWindows(db, roleId) {
+    var ws = rows(db,
+      'SELECT DISTINCT AD_Window_ID AS id FROM AD_Window_Access ' +
+      'WHERE AD_Role_ID = ? AND IsActive = \'Y\'', [roleId]);
+    var set = {};
+    ws.forEach(function (w) { if (w.id != null) set[Number(w.id)] = 1; });
+    console.log('§IDMP-SESSION accessibleWindows role=' + roleId + ' windows=' + Object.keys(set).length + ' source=ad_window_access');
+    return set;
+  }
+
+  // ── prune the AD_Menu tree to the role's accessible windows ──
+  // Hide action='W' leaves whose windowId ∉ winSet; then drop summary folders left empty.
+  // Non-W leaves (P/R/F/X/I/T) are NOT access-scoped here (§3b.1 bounded scope). Returns a
+  // new pruned tree (input is not mutated) plus visible/total W-window counts.
+  function scopeMenu(roots, winSet) {
+    var total = {}, visible = {};
+    function prune(node) {
+      var isFolder = node.isSummary || (node.children && node.children.length);
+      if (isFolder) {
+        var kids = (node.children || []).map(prune).filter(Boolean);
+        if (!kids.length) return null;                       // empty folder → drop
+        var copy = {}; for (var k in node) copy[k] = node[k];
+        copy.children = kids; return copy;
+      }
+      if (node.action === 'W' && node.windowId != null) {
+        var wid = Number(node.windowId); total[wid] = 1;
+        if (!winSet[wid]) return null;                       // window the role can't open → drop
+        visible[wid] = 1;
+      }
+      return node;
+    }
+    var tree = (roots || []).map(prune).filter(Boolean);
+    var out = { tree: tree, visible: Object.keys(visible).length, total: Object.keys(total).length };
+    console.log('§IDMP-SESSION scopeMenu visibleWindows=' + out.visible + '/' + out.total + ' roots=' + tree.length);
+    return out;
+  }
+
+  // ── compose the full login context (used by the page + the witness) ──
+  // Picks the user's first role unless roleId given; client is fixed by the role; org defaults
+  // to the first accessible (often 0=All). Returns the session object + the scoped menu counts.
+  function buildContext(db, userId, opts) {
+    opts = opts || {};
+    var roles = rolesForUser(db, userId);
+    if (!roles.length) { console.log('§IDMP-SESSION buildContext user=' + userId + ' NO-ROLES (cannot log in)'); return null; }
+    var role = roles.filter(function (r) { return r.id === opts.roleId; })[0] || roles[0];
+    var client = clientFor(db, role.id);
+    var orgs = orgsForRole(db, role.id);
+    var org = orgs.filter(function (o) { return o.id === opts.orgId; })[0] || orgs[0] || null;
+    var users = listUsers(db);
+    var user = users.filter(function (u) { return u.id === Number(userId); })[0] || { id: Number(userId), name: '#' + userId };
+    var winSet = accessibleWindows(db, role.id);
+    return {
+      user: user, role: role, client: client, org: org,
+      roles: roles, orgs: orgs, winSet: winSet
+    };
+  }
+
+  var IdmpSession = {
+    listUsers: listUsers,
+    rolesForUser: rolesForUser,
+    clientFor: clientFor,
+    orgsForRole: orgsForRole,
+    accessibleWindows: accessibleWindows,
+    scopeMenu: scopeMenu,
+    buildContext: buildContext
+  };
+
+  if (typeof window !== 'undefined') window.IdmpSession = IdmpSession;
+  if (typeof module !== 'undefined' && module.exports) module.exports = IdmpSession;
+
+  console.log('§IDMP-SESSION_LOADED v1');
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -113,6 +113,7 @@ const PRECACHE_ASSETS = [
   'kernel_ops.js',
   'ad_parser.js',
   'ad_data.js',
+  'idmp_session.js',
   'ad_graph.js',
   'ad_ui.js',
   'ad_charts.js',

--- a/viewer/tests/test_idempiere_login.js
+++ b/viewer/tests/test_idempiere_login.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: headless §-witness for idempiere.html LOGIN / Role·Client·Org session (renderer #1).
+//   THE CLAIM (docs/IDEMPIERE_RENDERER_SPEC.md §3b/§3b.1): the recognizable iDempiere on-ramp —
+//   pick user → Role/Client/Org → role-scoped menu + client/org-scoped data — folds ENTIRELY from
+//   real rows in ad_seed.db (AD_User/AD_User_Roles/AD_Role/AD_Client/AD_Role_OrgAccess/AD_Org/
+//   AD_Window_Access). No hand-authored identity. This test runs the SAME idmp_session.js folds the
+//   page uses, over the SAME ad_seed.db, and asserts each step + that role scope HIDES windows.
+//   §-log first — READ the log before any conclusion.
+// Run:  node tests/test_idempiere_login.js 2>&1 | tee tests/test_idempiere_login.log   (cwd = bim-ootb/viewer)
+'use strict';
+var fs = require('fs'), path = require('path');
+var initSqlJs = require('sql.js');
+var VIEWER = path.join(__dirname, '..');
+
+global.window = global.window || {};                 // ad_parser + idmp_session are browser IIFEs
+var ADParser = require(path.join(VIEWER, 'ad_parser.js'));
+var Session = require(path.join(VIEWER, 'idmp_session.js'));
+
+var fails = 0;
+function ok(cond, msg) { if (!cond) { fails++; console.log('  ✗ FAIL: ' + msg); } else { console.log('  ✓ ' + msg); } }
+
+(async function () {
+  console.log('=== §IDEMPIERE-LOGIN witness — login + Role·Client·Org session folds from the AD ===');
+  var SQL = await initSqlJs();
+  var buf = fs.readFileSync(path.join(VIEWER, 'ad_seed.db'));
+  var db = new SQL.Database(new Uint8Array(buf));
+
+  // ── ISSUE 1: the login user list folds from AD_User; role-less users are NAMED, not dropped ──
+  console.log('\n[ISSUE 1] login user list (AD_User) + hasRoles flags seed reality');
+  var users = Session.listUsers(db);
+  ok(users.length === 8, 'AD_User returns 8 users (got ' + users.length + ')');
+  var withRoles = users.filter(function (u) { return u.hasRoles; });
+  var without = users.filter(function (u) { return !u.hasRoles; });
+  ok(withRoles.length === 4, 'exactly 4 users have roles — can log in (got ' + withRoles.length + ': ' + withRoles.map(function (u) { return u.name; }).join(',') + ')');
+  ok(without.length === 4, '4 users have NO roles — disabled, named not dropped (' + without.map(function (u) { return u.name; }).join(',') + ')');
+
+  // ── ISSUE 2: GardenAdmin → roles → client (a role fixes its client) ──
+  console.log('\n[ISSUE 2] roles for a user, and the client a role fixes');
+  var admin = users.filter(function (u) { return u.name === 'GardenAdmin'; })[0];
+  ok(!!admin, 'GardenAdmin present in AD_User');
+  var roles = Session.rolesForUser(db, admin.id);
+  ok(roles.length === 3, 'GardenAdmin has 3 roles (got ' + roles.length + ': ' + roles.map(function (r) { return r.name; }).join(',') + ')');
+  var adminRole = roles.filter(function (r) { return r.name === 'GardenWorld Admin'; })[0];
+  ok(!!adminRole, 'role "GardenWorld Admin" available to GardenAdmin');
+  var client = Session.clientFor(db, adminRole.id);
+  ok(client && client.id === 11 && /GardenWorld/.test(client.name), 'role fixes client = GardenWorld(11) (got ' + (client ? client.name + '(' + client.id + ')' : 'none') + ')');
+
+  // ── ISSUE 3: orgs the role may access; org 0 = "*" (All) offered ──
+  console.log('\n[ISSUE 3] org access (AD_Role_OrgAccess), incl. org 0 = "*" (All)');
+  var orgs = Session.orgsForRole(db, adminRole.id);
+  ok(orgs.length === 10, 'GardenWorld Admin has 10 org-access rows (got ' + orgs.length + ')');
+  ok(orgs.some(function (o) { return o.id === 0; }), 'org 0 = "*" (All) is offered for the Admin role');
+  ok(orgs.some(function (o) { return o.id === 11 && /HQ/.test(o.name); }), 'org HQ(11) present');
+
+  // ── ISSUE 4: role-scoped menu — AD_Window_Access HIDES windows the role can't open ──
+  console.log('\n[ISSUE 4] role-scoped menu (AD_Window_Access prunes the AD_Menu tree)');
+  var roots = ADParser.getMenuTree(db);
+  var winSetAdmin = Session.accessibleWindows(db, adminRole.id);    // role 102
+  var scopedAdmin = Session.scopeMenu(roots, winSetAdmin);
+  ok(scopedAdmin.total > 0, 'menu has W-windows to scope (total=' + scopedAdmin.total + ')');
+  ok(scopedAdmin.visible < scopedAdmin.total, 'Admin scope HIDES some windows — proves it is a real filter (' + scopedAdmin.visible + '/' + scopedAdmin.total + ')');
+
+  // a LOWER-privilege role must see strictly fewer windows than Admin (proves scope varies by role)
+  var userRole = users.filter(function (u) { return u.name === 'GardenUser'; })[0];
+  var gUserRoles = Session.rolesForUser(db, userRole.id);
+  var plainRole = gUserRoles.filter(function (r) { return r.name === 'GardenWorld User'; })[0];
+  ok(!!plainRole, 'role "GardenWorld User" available to GardenUser');
+  var scopedUser = Session.scopeMenu(roots, Session.accessibleWindows(db, plainRole.id)); // role 103
+  ok(scopedUser.visible < scopedAdmin.visible, 'GardenWorld User sees FEWER windows than Admin (' + scopedUser.visible + ' < ' + scopedAdmin.visible + ') — role scope varies');
+
+  // ── ISSUE 5: buildContext composes the whole session in one fold ──
+  console.log('\n[ISSUE 5] buildContext composes user→role→client→org→winSet');
+  var ctx = Session.buildContext(db, admin.id, { roleId: adminRole.id, orgId: 11 });
+  ok(ctx && ctx.user.name === 'GardenAdmin', 'ctx.user = GardenAdmin');
+  ok(ctx.role.name === 'GardenWorld Admin', 'ctx.role = GardenWorld Admin');
+  ok(ctx.client.id === 11, 'ctx.client = GardenWorld(11)');
+  ok(ctx.org && ctx.org.id === 11, 'ctx.org = HQ(11)');
+  ok(Object.keys(ctx.winSet).length > 0, 'ctx.winSet populated (' + Object.keys(ctx.winSet).length + ' windows)');
+
+  // role-less user yields no context (faithful — cannot log in)
+  var sys = users.filter(function (u) { return u.name === 'System'; })[0];
+  ok(Session.buildContext(db, sys.id) === null, 'role-less user (System) → null context (cannot log in)');
+
+  console.log('\n§IDEMPIERE-LOGIN user=' + ctx.user.name + ' roles=' + roles.length +
+    ' client=' + ctx.client.name + '(' + ctx.client.id + ') org=' + ctx.org.name.replace(/\s.*/, '') +
+    ' menu-visible=' + scopedAdmin.visible + '/' + scopedAdmin.total +
+    ' source=ad_user/ad_role/ad_window_access handAuthored=0');
+
+  console.log('\n=== RESULT: ' + (fails === 0 ? 'ALL PASS — the iDempiere login folds from the AD' : fails + ' FAIL') + ' ===');
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.error('FATAL: ' + e.message + '\n' + e.stack); process.exit(1); });


### PR DESCRIPTION
The recognizable iDempiere on-ramp — pick user → Role/Client/Org → role-scoped menu + client/org-scoped data — folded entirely from real rows in `ad_seed.db` (AD_User / AD_User_Roles / AD_Role / AD_Client / AD_Role_OrgAccess / AD_Org / AD_Window_Access). No server: identity/context **selection**, not authentication (docs §3b honest framing).

## Changes
- **`idmp_session.js`** (new) — shared fold module (`listUsers`/`rolesForUser`/`clientFor`/`orgsForRole`/`accessibleWindows`/`scopeMenu`/`buildContext`); pure SELECTs, §-logged, used by both the page and the headless witness.
- **`idempiere.html`** — login overlay, live `Client · Role · Org` context bar, role-scoped menu (`AD_Window_Access` prunes W leaves + empty folders), client/org data-scope WHERE layer (same as master-detail's parent FK), switch-role/logout cycle.
- **`sw.js`** — precache `idmp_session.js` (offline parity).
- **`tests/test_idempiere_login.js`** (new) — `§IDEMPIERE-LOGIN` witness, headless, ALL PASS.

## Witness
```
§IDEMPIERE-LOGIN user=GardenAdmin roles=3 client=GardenWorld(11) org=HQ
                 menu-visible=294/332 source=ad_user/ad_role/ad_window_access handAuthored=0
```
Role scope is real: Admin 294/332 windows vs User 163/332.

## Seed reality (named, not papered over)
4/8 users have roles (others disabled `(no roles)`); org 0 = `*` surfaced from the grant (no AD_Org row); single client GardenWorld(11) → role→client switching is wired but not demonstrable until a 2nd tenant is imported.

Implements `docs/IDEMPIERE_RENDERER_SPEC.md` §3b/§3b.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)