### PR TITLE
feat(erp): idempiere.html host conformance — STEP-0 §SEAM-FROZEN (IdmpHost + AD-key tagging)

### DIFF
--- a/erp/help_idmp.js
+++ b/erp/help_idmp.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// help_idmp.js — idempiere HOST ADAPTER for the SHARED help_overlay.js (prompts/IDEMPIERE_TOUR_GUIDE.md).
+// It REUSES help_overlay.js unchanged — NO FORK: this file contains ZERO coach logic (no coachPlan, no
+// buildBadges, no step machine). It only calls window.__help.init({host, nav}) with idempiere's exposed
+// globals, mapping the agreed key vocabulary (help_idmp_keymap.json) onto the host contract. READ-ONLY.
+//
+// HOST CONTRACT (docs/TourGuideHostContract.md §2): the FRONTEND lane (IDEMPIERE_RECORD_PANEL.md) publishes
+//   window.IdmpHost = { trace(on), focus(key,map), openTab(key,tab), has(key)->bool, locate(key)->{x,y,r} }
+// and tags its DOM by AD key + provides the #idmp-content mount. This adapter consumes that; it does NOT
+// tag chrome or expose globals (that is the frontend's host-conformance job). Until IdmpHost lands, every
+// nav fn no-ops gracefully (the tour shows its card + Read-more; ShowMe simply has nothing to drive yet).
+(function () {
+  if (typeof window === 'undefined' || !window.__help || typeof window.__help.init !== 'function') return;
+
+  var KEYMAP = window.__helpIdmpKeymap || {};              // help_idmp_keymap.json, fetched/inlined by the page
+  function H() { return window.IdmpHost || {}; }            // the frontend-exposed globals (may be absent yet)
+
+  var nav = {
+    // drive ShowMe through the host's exposed globals only — never reach into chrome internals.
+    trace:   function (on)       { if (H().trace)   H().trace(on); },
+    focus:   function (key)      { if (H().focus)   H().focus(key, KEYMAP[key] || null); },
+    openTab: function (key, tab) { if (H().openTab) H().openTab(key, tab); },
+    // has(key): does this chrome KNOW this AD key (→ make a numbered badge)? locate(key): its current rect.
+    has:     function (key)      { return H().has ? !!H().has(key) : false; },
+    locate:  function (key)      { return H().locate ? H().locate(key) : null; },
+    jive:    function () {}                                 // idempiere has no audio layer (optional global)
+  };
+
+  var host = document.getElementById('idmp-content') || document.body;
+  window.__help.init({ host: host, nav: nav, hostName: 'idempiere' });
+
+  var keys = Object.keys(KEYMAP).filter(function (k) { return k !== '__meta'; });
+  console.log('§TOUR overlay=help_overlay host=idempiere forked=0 adapter=init-only keys=' + keys.length +
+    ' globals=' + (window.IdmpHost ? 'live' : 'pending'));
+})();

--- a/erp/help_overlay.js
+++ b/erp/help_overlay.js
@@ -1,0 +1,397 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// help_overlay.js — ReadMe/ShowMe HELP overlay (READSHOWME_DYNAMIC_SPEC.md — D3).
+// A separated behavior layer (unobtrusive JS / Stimulus-style data-hooks / AOP cross-cutting concern):
+// it attaches to glassbowl's bubbles BY KEY, reads the keyed _TRL-style store help_ops.json, and never
+// edits the renderer. Opt-in (NeedHelp?), dismissible, dynamic (badges + steps generated from the store).
+// Reuses page globals: setTrace/setFocus/openDossierTab + N/idx/project/px/py/k/radius + helpJive/navJive/showmeJive.
+(function () {
+  // ════════════════════════════════════════════════════════════════════════
+  // PURE COACH CORE — no DOM. The guide's WHOLE vocabulary as data, domain-free
+  // and key-addressed (READSHOWME_DYNAMIC_SPEC.md §guide-vocabulary). Exported for
+  // the headless §-witness (W-HELP-COACH). INVARIANT: asserts NOTHING (§Invariant).
+  // ════════════════════════════════════════════════════════════════════════
+
+  // coachPlan — PURE: the ordered key-addressed intents ShowMe drives for a step,
+  // and the assert count (ALWAYS 0 — the guide narrates, the data speaks).
+  //  reveal: every step brings its element into view.
+  //  kind:'process' steps ALSO pulse the Process affordance (reveal-only, never
+  //  auto-fired) and highlight the live status bar. No posting logic, no branching.
+  function coachPlan(step) {
+    step = step || {};
+    var drove = ['reveal'];
+    if (step.kind === 'process') { drove.push('pulse'); drove.push('highlight:statusbar'); }
+    return { drove: drove, asserts: 0, key: step.key || null, target: step.target || null };
+  }
+
+  // legalNext — the only keys "on path" from a step: itself + the next step in order.
+  function legalNext(curStep, steps) {
+    var keys = {};
+    if (!curStep) return keys;
+    keys[curStep.key] = 1;
+    var i = steps ? steps.indexOf(curStep) : -1;
+    if (i >= 0 && steps[i + 1]) keys[steps[i + 1].key] = 1;
+    return keys;
+  }
+
+  // isVeer — PURE (§veer): an action key is a veer iff it is neither the current step
+  // nor its legal Next. A veer SUSPENDS (no kill, no timeline tag) — see suspend().
+  function isVeer(curStep, steps, actionKey) {
+    if (!curStep || actionKey == null) return false;
+    return !legalNext(curStep, steps)[actionKey];
+  }
+
+  // nextGate — PURE (§Next-gated-on-success): after a Process gesture on a live draft, decide whether
+  // Next may proceed. Reads ONLY the live docstatus the page reported + the step's expected success
+  // status (default 'CO'). Three outcomes, all read the same dumb way — compares live vs expected, never
+  // asks WHY (that is the Process layer's logic):
+  //   CO (== expect) → advance (Next proceeds, timeline tag fires)
+  //   IP             → hold   (re-highlight, NO advance, NO tag) — legitimate business non-completion
+  //   exception      → errorReport (NO advance, NO tag) — hand to the single ErrorReport class
+  //   none / other   → hold   (not yet processed, or an unexpected status; never advance on a non-success)
+  // The read-mode (no-gesture) bypass is the CALLER's concern (§Edit-mode gate), not this pure decision.
+  function nextGate(liveStatus, expect) {
+    expect = expect || 'CO';
+    if (liveStatus === 'exception') return { advanced: false, gate: 'exception', action: 'errorReport' };
+    if (liveStatus === expect)      return { advanced: true,  gate: liveStatus, action: 'advance' };
+    if (liveStatus === 'IP')        return { advanced: false, gate: 'IP', action: 'hold' };
+    return { advanced: false, gate: liveStatus || 'none', action: 'hold' };
+  }
+
+  var COACH = { coachPlan: coachPlan, legalNext: legalNext, isVeer: isVeer, nextGate: nextGate };
+
+  // node (headless witness): export the pure core and stop — no DOM to attach.
+  if (typeof module !== 'undefined' && module.exports) { module.exports = COACH; return; }
+  if (typeof document === 'undefined') return;
+
+  // ════════════════════════════════════════════════════════════════════════
+  // HOST ADAPTER (the lift — UI_OVERLAY_GOVERNANCE §host contract / docs/TourGuideHostContract.md).
+  // The overlay needs 3 things from its host: a MOUNT container, a NAV interface (drive ShowMe), and a
+  // LOCATE projection (key → screen pos, to place numbered badges + the card). The DEFAULTS below REPRODUCE
+  // today's glassbowl behavior VERBATIM (document.body + window.setFocus/setTrace/openDossierTab + the SVG
+  // projection N/idx/project/px/py/k/radius), so an un-init'd page (glassbowl) is behaviorally diff=0.
+  // A host (idempiere) calls window.__help.init({host, nav}) to REBIND — same module, different chrome. NO FORK.
+  // ════════════════════════════════════════════════════════════════════════
+  var HOST = document.body;
+  // glassbowl projection: key → {x,y,r,rRaw} or null (off-screen/unknown). r = screen radius (card gap),
+  // rRaw = unclamped node radius (badge offset) — preserves the ORIGINAL screenPt + positionBadges maths.
+  function gbLocate(key) {
+    try {
+      if (key && typeof N !== 'undefined' && typeof idx !== 'undefined' && idx[key] != null && typeof project === 'function') {
+        var n = N[idx[key]]; project(n); var kk = (typeof k === 'number' ? k : 1);
+        var rr = (typeof radius === 'function' ? radius(n) : 14);
+        return { x: px + n.sx * kk, y: py + n.sy * kk, r: Math.max(12, rr * kk), rRaw: rr };
+      }
+    } catch (e) {}
+    return null;
+  }
+  var NAV = {
+    trace:   function (on)       { if (window.setTrace) window.setTrace(on); },
+    focus:   function (key)      { if (window.setFocus) window.setFocus(key); },
+    openTab: function (key, tab) { if (window.openDossierTab) window.openDossierTab(key, tab); },
+    has:     function (key)      { return typeof idx !== 'undefined' && idx[key] != null; },
+    locate:  gbLocate,
+    jive:    function (which, dir) {
+      try {
+        if (which === 'help'   && typeof helpJive   === 'function') helpJive();
+        if (which === 'nav'    && typeof navJive    === 'function') navJive(dir);
+        if (which === 'showme' && typeof showmeJive === 'function') showmeJive();
+      } catch (e) {}
+    }
+  };
+  // init — a host rebinds the adapter: re-parent the chrome into its container and merge its nav fns.
+  function init(opts) {
+    opts = opts || {};
+    if (opts.host && opts.host !== HOST) {
+      HOST = opts.host;
+      if (wrap.parentNode !== HOST) HOST.appendChild(wrap);
+      if (card.parentNode !== HOST) HOST.appendChild(card);
+    }
+    if (opts.nav) { for (var key in opts.nav) { if (opts.nav[key]) NAV[key] = opts.nav[key]; } }
+    console.log('§TOUR overlay=help_overlay host=' + (opts.hostName || 'custom') + ' forked=0 mounts=2 init=ok');
+    return window.__help;
+  }
+
+  // ── injected CSS (self-contained module) ──
+  var css = document.createElement('style');
+  css.textContent =
+   '#needHelpWrap{position:fixed;top:10px;right:14px;z-index:70;display:flex;align-items:center;gap:6px;background:#13202b;border:1px solid #2f4654;border-radius:16px;padding:5px 11px;font:13px system-ui;color:#cfe8ee;cursor:pointer;user-select:none}' +
+   '#needHelpWrap:hover{border-color:#56d6e0}#needHelpWrap input{accent-color:#56d6e0;cursor:pointer}' +
+   '.help-q{position:fixed;z-index:69;width:20px;height:20px;border-radius:50%;background:#1668a8;color:#fff;font:700 13px system-ui;display:none;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 1px 5px rgba(0,0,0,.5);border:1px solid #7fd6e0;transition:transform .1s}' +
+   '.help-q:hover{transform:scale(1.18);background:#1f86d0}' +
+   '#helpCard{position:fixed;z-index:71;width:min(280px,84vw);background:#0f1a22;border:1px solid #2f4654;border-radius:11px;padding:11px 13px;color:#dbe9ee;font:13px/1.45 system-ui;box-shadow:0 6px 22px rgba(0,0,0,.55);display:none}' +
+   '#helpCard.open{display:block}#helpCard .hcnum{font-size:10.5px;letter-spacing:.07em;text-transform:uppercase;color:#6f93a2}' +
+   '#helpCard .hctitle{font-weight:600;font-size:15px;margin:2px 0 4px;color:#eaf6fa}#helpCard .hctip{margin:0 0 8px;color:#bcd2da}' +
+   '#helpCard figure{margin:8px 0;border:1px solid #294150;border-radius:8px;overflow:hidden}#helpCard figure img{display:block;width:100%}' +
+   '#helpCard figure figcaption{font-size:11px;color:#8fb3c0;padding:5px 8px;background:#0b141b}' +
+   '#helpCard .figph{border:1px dashed #3a5a6a;border-radius:8px;padding:14px;color:#7f9aa8;font-style:italic;font-size:12.5px;text-align:center;background:#0d1820;margin:8px 0}' +
+   '#helpCard .hcnav{display:flex;align-items:center;gap:7px;margin-top:10px}' +
+   '#helpCard a.hcmore{color:#7fd6e0;text-decoration:none;font-size:12.5px}#helpCard a.hcmore:hover{text-decoration:underline}' +
+   '#helpCard button.hcb{background:#16252f;color:#cfe8ee;border:1px solid #2f4654;border-radius:8px;padding:6px 12px;font:13px system-ui;cursor:pointer}' +
+   '#helpCard button.hcb:hover:not(:disabled){border-color:#56d6e0}#helpCard button.hcb:disabled{opacity:.35;cursor:default}' +
+   '#helpCard button.hcshow{background:#16493a;border-color:#2f6d5a;color:#bff0dd}#helpCard button.hcshow:hover{border-color:#56d6e0}' +
+   '#helpCard .hcgrow{flex:1}#helpCard .hcx{position:absolute;right:10px;top:8px;color:#6f93a2;cursor:pointer}' +
+   '#helpCard{cursor:grab}#helpCard.dragging{cursor:grabbing;user-select:none}#helpCard button,#helpCard a,#helpCard .hcx{cursor:pointer}';
+  document.head.appendChild(css);
+
+  var HELP = null, STEPS = [], cur = -1, on = false, raf = 0, badges = [], dragged = false;
+  var suspended = false, resumeIdx = -1;
+  var README_BASE = 'https://red1oon.github.io/BIMCompiler/';
+
+  var wrap = document.createElement('label'); wrap.id = 'needHelpWrap';
+  wrap.innerHTML = '<input type="checkbox" id="needHelpCk"><span>NeedHelp?</span>';
+  HOST.appendChild(wrap);                                  // HOST defaults to document.body (glassbowl); init() re-parents
+  var card = document.createElement('div'); card.id = 'helpCard'; HOST.appendChild(card);
+  var ck = document.getElementById('needHelpCk');
+
+  function readmeUrl(ref) { if (!ref) return '#'; var p = String(ref).split('#'); return README_BASE + p[0].replace(/\.md$/, '') + '/' + (p[1] ? ('#' + p[1]) : ''); }
+
+  // render paraHTML, swapping [[FIG x.y: advice]] -> the auto-snapped figure, with a placeholder fallback.
+  function renderPara(step) {
+    var html = step.paraHTML || '';
+    return html.replace(/\[\[FIG\s*([0-9.]+)\s*:\s*([^\]]*)\]\]/g, function (m, fig, advice) {
+      var src = 'figs/o2c_' + step.ordinal + '_' + step.key + '.png';
+      var safe = advice.replace(/'/g, '’');
+      return '<figure><img src="' + src + '" alt="Figure ' + fig + '" ' +
+        'onerror="this.parentNode.outerHTML=&quot;<div class=figph>Figure ' + fig + ' &mdash; ' + safe + '</div>&quot;">' +
+        '<figcaption>Figure ' + fig + ' — ' + advice + '</figcaption></figure>';
+    });
+  }
+
+  // ── key-addressed intent bus (governance: neither overlay imports the other; UI_OVERLAY_GOVERNANCE.md).
+  // The guide EMITS intents; the CRUD overlay (which owns the Process ▶ ring) reacts to them by KEY.
+  function emit(verb, detail) {
+    detail = detail || {}; detail.verb = verb;
+    try { window.dispatchEvent(new CustomEvent('overlay:guide', { detail: detail })); } catch (e) {}
+  }
+
+  // highlightStatusBar — point at the live #docStatusBar and READ what it says; assert NOTHING
+  // (§Invariant: the guide quotes the bar verbatim, never claims "it worked"). Returns the live text.
+  function highlightStatusBar() {
+    var bar = document.getElementById('docStatusBar');
+    var live = bar ? (bar.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    if (bar) { bar.classList.add('pulse'); setTimeout(function () { bar.classList.remove('pulse'); }, 2200); }
+    if (card.classList.contains('open') && !card.querySelector('.hcstatus')) {
+      var note = document.createElement('div'); note.className = 'hctip hcstatus';
+      note.textContent = 'Note the status' + (live ? ' — it reads: “' + live + '”.' : '.');
+      var nav = card.querySelector('.hcnav');
+      if (nav) card.insertBefore(note, nav); else card.appendChild(note);
+    }
+    return live;
+  }
+
+  // ShowMe — type-aware drive. Bubbles here; field/list/tab dispatch is the erp.html extension point (req 11).
+  // A kind:'process' step ALSO drives the coach vocabulary (READSHOWME §guide-vocabulary): reveal+pulse the
+  // Process affordance (key-addressed, never auto-fired) and highlight the live status bar — asserts NOTHING.
+  function showMe(step) {
+    NAV.jive('showme');
+    NAV.trace(true);
+    if (step.kind === 'overview' || !step.target) { console.log('§SHOWME op=' + step.op + ' drove=[trace] kind=overview via=host-globals'); return; }
+    NAV.focus(step.target);
+    if (step.tab) NAV.openTab(step.target, step.tab);
+    positionCard();
+    if (step.kind === 'process') {
+      var plan = COACH.coachPlan(step);
+      emit('pulse', { kind: 'process', key: step.key });   // reveal-only; CRUD overlay fans out + pulses ▶
+      var live = highlightStatusBar();
+      console.log('§HELP coach key=' + step.key + ' drove=[' + plan.drove.join(',') + '] asserts=' + plan.asserts + ' barRead=' + JSON.stringify(live));
+    }
+    console.log('§SHOWME op=' + step.op + ' key=' + step.key + ' drove=[trace,focus:' + step.target + (step.tab ? ',tab:' + step.tab : '') + '] via=host-globals invented=0');
+  }
+
+  // screen point {x,y,r,rRaw} for a key — DELEGATES to the host adapter's locate (glassbowl projection by
+  // default, idempiere getBoundingClientRect after init). null if off-screen/unknown.
+  function screenPt(target) { return NAV.locate(target); }
+  // all chain bubbles the card must NOT obscure (every step's target on screen).
+  function chainPts() { var a = []; STEPS.forEach(function (s) { var p = screenPt(s.target); if (p) a.push(p); }); return a; }
+  // count how many chain bubbles a card rect (L,T,w,h) would cover (expanded by each bubble's radius).
+  function overlapScore(L, T, w, h, pts) {
+    var n = 0;
+    for (var i = 0; i < pts.length; i++) { var p = pts[i]; if (p.x >= L - p.r && p.x <= L + w + p.r && p.y >= T - p.r && p.y <= T + h + p.r) n++; }
+    return n;
+  }
+
+  // anchor the card near the step's bubble but STEER CLEAR of the lit chain (req: don't obscure the
+  // bubbles in the chain). Tries right/left/below/above the target, picks the placement covering the
+  // fewest chain bubbles. Once the user drags it (dragged=true) we leave it parked where they put it.
+  function positionCard() {
+    if (dragged) return;                                  // user moved it to a clearer spot — respect it
+    var s = STEPS[cur]; if (!s) return;
+    var cw = card.offsetWidth || 300, chh = card.offsetHeight || 200;
+    var tgt = screenPt(s.target);
+    if (!tgt) { card.style.left = '50%'; card.style.top = '14%'; card.style.transform = 'translateX(-50%)'; return; }
+    var pts = chainPts(), g = 24;
+    var cands = [
+      { L: tgt.x + tgt.r + g,           T: tgt.y - chh / 2 },           // right (preferred)
+      { L: tgt.x - tgt.r - g - cw,      T: tgt.y - chh / 2 },           // left
+      { L: tgt.x - cw / 2,              T: tgt.y + tgt.r + g },         // below
+      { L: tgt.x - cw / 2,              T: tgt.y - tgt.r - g - chh }    // above
+    ];
+    var best = null, bestScore = Infinity;
+    cands.forEach(function (c) {
+      var L = Math.max(8, Math.min(window.innerWidth - cw - 8, c.L));
+      var T = Math.max(8, Math.min(window.innerHeight - chh - 8, c.T));
+      var sc = overlapScore(L, T, cw, chh, pts);          // earlier candidates win ties (strict <)
+      if (sc < bestScore) { bestScore = sc; best = { L: L, T: T }; }
+    });
+    card.style.transform = 'none';
+    card.style.left = best.L + 'px';
+    card.style.top = best.T + 'px';
+  }
+
+  // draggable (req: user can move the card to a clearer spot). Capture-after-move so a click on the
+  // card body doesn't jitter; drags starting on a button/link/✕ are ignored (those keep their action).
+  function setupDrag() {
+    var sx = 0, sy = 0, ox = 0, oy = 0, down = false, moving = false;
+    card.addEventListener('pointerdown', function (ev) {
+      if (ev.target.closest && ev.target.closest('button, a, .hcx')) return;
+      down = true; moving = false; sx = ev.clientX; sy = ev.clientY;
+      var rc = card.getBoundingClientRect(); ox = rc.left; oy = rc.top;
+    });
+    window.addEventListener('pointermove', function (ev) {
+      if (!down) return;
+      var dx = ev.clientX - sx, dy = ev.clientY - sy;
+      if (!moving) { if (Math.abs(dx) + Math.abs(dy) < 4) return; moving = true; dragged = true; card.style.transform = 'none'; card.classList.add('dragging'); }
+      card.style.left = Math.max(8, Math.min(window.innerWidth - card.offsetWidth - 8, ox + dx)) + 'px';
+      card.style.top = Math.max(8, Math.min(window.innerHeight - card.offsetHeight - 8, oy + dy)) + 'px';
+    });
+    window.addEventListener('pointerup', function () {
+      if (down && moving) console.log('§HELP card dragged spot=(' + card.style.left + ',' + card.style.top + ')');
+      down = false; moving = false; card.classList.remove('dragging');
+    });
+  }
+
+  function renderCard() {
+    var s = STEPS[cur]; if (!s) return;
+    card.innerHTML = '<span class=hcx title=close>✕</span>' +
+      '<div class=hcnum>Help ' + (cur + 1) + ' / ' + STEPS.length + ' · ' + (s.op || '') + '</div>' +
+      '<div class=hctitle>' + s.title + '</div>' +
+      '<div class=hctip>' + (s.tip || '') + '</div>' +
+      '<div class=hcnav><a class=hcmore href="' + readmeUrl(s.readmeAnchor) + '" target=_blank rel=noopener>Read more →</a>' +
+      '<span class=hcgrow></span>' +
+      '<button class=hcb id=hcPrev ' + (cur === 0 ? 'disabled' : '') + '>◀</button>' +
+      '<button class="hcb hcshow" id=hcShow>▶ ShowMe</button>' +
+      '<button class=hcb id=hcNext ' + (cur === STEPS.length - 1 ? 'disabled' : '') + '>Next ▶</button></div>';
+    card.querySelector('.hcx').addEventListener('click', close);
+    card.querySelector('#hcShow').addEventListener('click', function () { showMe(s); });
+    var pv = card.querySelector('#hcPrev'), nx = card.querySelector('#hcNext');
+    if (pv) pv.addEventListener('click', function () { goTo(cur - 1, true); });
+    if (nx) nx.addEventListener('click', function () { tryNext(); });
+    positionCard();
+  }
+
+  // ── Next gated on SUCCESS (READSHOWME §Next-gated-on-success) ────────────────
+  // editModeOn — read the live Edit-mode toggle (#crudModeCk) BY ID — same statusbar-kind DOM addressing
+  // the guide already uses for #docStatusBar; no import of the CRUD overlay (governance preserved).
+  function editModeOn() { var c = document.getElementById('crudModeCk'); return !!(c && c.checked); }
+  // readBarStatus — the live docstatus the page reported, read off #docStatusBar's class (s-XX). '' if none.
+  function readBarStatus() {
+    var bar = document.getElementById('docStatusBar');
+    if (!bar || !/\bshow\b/.test(bar.className)) return '';
+    var m = bar.className.match(/\bs-([A-Za-z]+)/);
+    return m ? m[1] : '';
+  }
+  // errorReportStep — Process threw: halt with ONE canned step and call the SINGLE ErrorReport class if the
+  // page exposes it. The guide does NOT re-implement error handling (READSHOWME §error-path) — the callable
+  // ErrorReport factor-out (error_reporter.js → bim-ootb/viewer/erp/) is the flagged precondition for E3.
+  function errorReportStep() {
+    var note = card.querySelector('.hcstatus');
+    if (!note && card.classList.contains('open')) {
+      note = document.createElement('div'); note.className = 'hctip hcstatus';
+      var nav = card.querySelector('.hcnav'); if (nav) card.insertBefore(note, nav); else card.appendChild(note);
+    }
+    if (note) note.textContent = 'Process raised an error — ErrorReport ready. Submit.';
+    try { if (typeof window.reportBug === 'function') window.reportBug(); } catch (e) {}
+  }
+  // tryNext — the Next gesture (await/acknowledge). On a live process step it is GATED on the real status
+  // bar: advance only on CO; IP/none → re-highlight + HOLD (no advance, no tag); exception → ErrorReport.
+  // In read/trace mode (Edit-mode OFF) there is no gesture and no gate — Next is a free acknowledgment.
+  function tryNext() {
+    var s = STEPS[cur];
+    if (s && s.kind === 'process' && editModeOn()) {
+      var live = readBarStatus() || 'none';
+      var g = COACH.nextGate(live, s.expect || 'CO');
+      console.log('§HELP next gate docstatus=' + g.gate + ' advanced=' + (g.advanced ? 'Y' : 'N'));
+      if (!g.advanced) { if (g.action === 'errorReport') errorReportStep(); else highlightStatusBar(); return; }
+    }
+    goTo(cur + 1, true);
+  }
+
+  function goTo(i, nav) {
+    if (i < 0 || i >= STEPS.length) return;
+    var dir = i > cur ? 1 : -1; cur = i;
+    if (nav) NAV.jive('nav', dir);
+    card.classList.add('open'); renderCard();
+    console.log('§READSHOWME step=' + i + ' key=' + STEPS[i].key + ' target=' + (STEPS[i].target || '-') + ' para=' + STEPS[i].readmeAnchor);
+  }
+  function open(i) { NAV.jive('help'); goTo(i == null ? 0 : i, false); }
+  function close() { card.classList.remove('open'); dragged = false; }   // reopening re-anchors to the chain
+
+  function buildSteps() {
+    STEPS = Object.keys(HELP).filter(function (k) { return k !== '__meta'; })
+      .map(function (k) { var e = HELP[k]; e.key = k; return e; })
+      .sort(function (a, b) { return (a.ordinal || 0) - (b.ordinal || 0); });
+  }
+  function buildBadges() {
+    clearBadges();
+    STEPS.forEach(function (s, i) {
+      if (!s.target || !NAV.has(s.target)) return;          // host KNOWS this key → it gets a numbered badge
+      var q = document.createElement('div'); q.className = 'help-q'; q.textContent = String(s.ordinal);
+      q.title = 'Help ' + s.ordinal + ': ' + s.title; q.setAttribute('data-i', i);
+      q.addEventListener('click', function (ev) { ev.stopPropagation(); open(i); });
+      HOST.appendChild(q); badges.push({ el: q, step: s });
+    });
+  }
+  function clearBadges() { badges.forEach(function (b) { if (b.el.parentNode) b.el.parentNode.removeChild(b.el); }); badges = []; }
+  function positionBadges() {
+    if (!on) return;
+    badges.forEach(function (b) {
+      var p = NAV.locate(b.step.target);                    // null → currently off-screen → hide
+      if (!p) { b.el.style.display = 'none'; return; }
+      var rRaw = (p.rRaw != null ? p.rRaw : p.r);           // hosts may report a single radius
+      b.el.style.display = 'flex';
+      b.el.style.left = (p.x + rRaw * 0.7) + 'px';
+      b.el.style.top = (p.y - rRaw - 10) + 'px';
+    });
+  }
+  function loop() { if (!on) { raf = 0; return; } positionBadges(); if (card.classList.contains('open')) positionCard(); raf = requestAnimationFrame(loop); }
+
+  function enable() {
+    on = true; suspended = false; resumeIdx = -1;
+    function go() { buildSteps(); buildBadges(); if (!raf) raf = requestAnimationFrame(loop); open(0); console.log('§HELP mode=on steps=' + STEPS.length + ' badges=' + badges.length); }
+    if (HELP) { go(); return; }
+    fetch('help_ops.json').then(function (r) { return r.json(); }).then(function (j) { HELP = j; go(); })
+      .catch(function (e) { console.warn('§HELP load-error', e && e.message); });
+  }
+  function disable() { on = false; if (raf) { cancelAnimationFrame(raf); raf = 0; } clearBadges(); close(); console.log('§HELP mode=off'); }
+  ck.addEventListener('change', function () { if (ck.checked) enable(); else disable(); });
+
+  // ── veer (§veer): an off-path action on the shared bus SUSPENDS the guide — it does NOT kill Help.
+  // NeedHelp? stays ON (badges live); no §VIEWLOG / timeline tag (a veer is not a Next); the step number
+  // is preserved for Resume. If the veered-to element has its own ReadMe step, meet them where they landed.
+  function suspend(actionKey) {
+    if (suspended) return;
+    suspended = true; resumeIdx = cur;
+    console.log('§HELP veer→suspend needhelp=' + (on ? 'on' : 'off') + ' tag=unchanged actionKey=' + actionKey);
+    var j = -1; for (var i = 0; i < STEPS.length; i++) { if (STEPS[i].key === actionKey) { j = i; break; } }
+    if (j >= 0) goTo(j, false);   // surface the veered-to card; nav=false → no navJive → no timeline tag
+  }
+  function resume() {
+    if (!suspended) return;
+    suspended = false;
+    if (resumeIdx >= 0) goTo(resumeIdx, false);
+    console.log('§HELP resume idx=' + resumeIdx);
+  }
+  // listen for CRUD verb gestures on the bus; off-path → suspend. Same-step / legal-Next gestures pass.
+  window.addEventListener('overlay:action', function (ev) {
+    if (!on) return;
+    var key = ev && ev.detail && ev.detail.key; var s = STEPS[cur];
+    if (s && COACH.isVeer(s, STEPS, key)) suspend(key);
+  });
+
+  setupDrag();
+  window.__help = { init: init, enable: enable, disable: disable, goTo: goTo, suspend: suspend, resume: resume,
+                    showMe: showMe, suspended: function () { return suspended; }, steps: function () { return STEPS; },
+                    adapter: function () { return { host: HOST, nav: NAV }; } };
+  console.log('§HELP layer mounted (NeedHelp? ready)');
+})();

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -292,6 +292,7 @@
   var _recIdx = 0;
   var _viewMode = 'grid';    // 'grid' | 'form'
   var _selByLevel = {};      // tabLevel -> selected record's key value (drives master-detail filtering)
+  var _winByName = {};       // AD window name (lowercased) -> windowId — built as the menu renders; drives IdmpHost.focus
 
   function $(id) { return document.getElementById(id); }
   function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; }
@@ -444,6 +445,7 @@
       row.addEventListener('click', function () { wrap.classList.toggle('open'); tw.textContent = wrap.classList.contains('open') ? '▾' : '▸'; });
     } else {
       leaves++;
+      if (node.action === 'W' && node.windowId) _winByName[(node.name || '').toLowerCase()] = Number(node.windowId);  // name->id for IdmpHost.focus
       row.addEventListener('click', function () {
         document.querySelectorAll('.idmp-row.leaf.active').forEach(function (e) { e.classList.remove('active'); });
         row.classList.add('active');
@@ -641,6 +643,7 @@
     if (!_records.length) { var tr = el('tr'); var td = el('td', null, 'No records'); td.colSpan = cols.length || 1; td.style.color = '#888'; tr.appendChild(td); tb.appendChild(tr); }
     _records.forEach(function (rec, i) {
       var tr = el('tr'); tr.dataset.i = i;
+      tr.setAttribute('data-ad-table', tab.tableName); tr.setAttribute('data-ad-record', recVal(rec, _keyCol(tab)));  // AD-key tag (host contract)
       cols.forEach(function (f) { tr.appendChild(el('td', null, fmt(f, recVal(rec, f.columnName)))); });
       tr.addEventListener('click', function () { _recIdx = i; _setSel(tab); _viewMode = 'form'; renderBody(); renderToolbar(); });
       tb.appendChild(tr);
@@ -651,8 +654,10 @@
   function buildForm(tab) {
     var form = el('div', 'idmp-form'); form.id = 'idmp-form';
     var rec = _records[_recIdx];
+    if (rec) { form.setAttribute('data-ad-table', tab.tableName); form.setAttribute('data-ad-record', recVal(rec, _keyCol(tab))); }  // AD-key tag (host contract)
     _displayFields(tab).forEach(function (f) {
       var fld = el('div', 'idmp-fld' + (f.isMandatory ? ' mand' : ''));
+      fld.setAttribute('data-ad-table', tab.tableName); fld.setAttribute('data-ad-column', f.columnName);
       fld.appendChild(el('label', null, f.name));
       var v = el('div', 'val' + (f.referenceType === 'yesno' ? ' bool' : ''), fmt(f, recVal(rec, f.columnName)));
       v.title = f.columnName + ' · ' + f.referenceType;
@@ -686,13 +691,62 @@
     });
   }
 
+  // ── Host contract — the STEP-0 freeze (docs/TourGuideHostContract.md §2; IDEMPIERE_RECORD_PANEL.md).
+  // Publishes the agreed nav/locate globals over THIS chrome so the Tour overlay + lens lenses bind BY KEY,
+  // unforked. data-ad-* tags are added at render (buildGrid/buildForm). SEAM #2 (host contract). SEAM #1
+  // (write: real dispatch + ctx) awaits the engine C0 wrapper — marked TODO(STEP-0) below, not invented here.
+  function _adMatch(elTable, key) { return elTable != null && String(elTable).toLowerCase() === String(key).toLowerCase(); }
+  function _firstByTable(key) {
+    var els = document.querySelectorAll('[data-ad-table]');
+    for (var i = 0; i < els.length; i++) if (_adMatch(els[i].getAttribute('data-ad-table'), key)) return els[i];
+    return null;
+  }
+  function _selectTabByTable(table) {
+    var w = _curWin(); if (!w || !w.tabs) return false;
+    for (var i = 0; i < w.tabs.length; i++) {
+      if (_adMatch(w.tabs[i].tableName, table)) { _activeTabIdx = i; _viewMode = 'grid'; renderActiveTab(); renderTabStrip(); renderToolbar(); return true; }
+    }
+    return false;
+  }
+  window.IdmpHost = {
+    // trace(on): enter/leave the record's flow view (a soft view hint — idempiere has no separate flow pane).
+    trace: function (on) { document.body.classList.toggle('idmp-tracing', !!on); },
+    // focus(key, map): open the keymap window BY NAME, then select the tab whose tableName matches. Record-level
+    //   selection + cold data degrade honestly per map.coverage — non-invent: it never fabricates a row.
+    focus: function (key, map) {
+      if (!map || !map.window) return;
+      var wid = _winByName[String(map.window).toLowerCase()];
+      if (wid == null) { status('ShowMe: "' + map.window + '" not in this menu (coverage ' + (map.coverage || 'partial') + ')'); return; }
+      openWindow(wid, map.window);
+      if (map.table) _selectTabByTable(map.table);
+    },
+    // openTab(key, tab): switch the focused window to the tab named `tab`.
+    openTab: function (key, tab) {
+      var w = _curWin(); if (!w || !w.tabs || !tab) return;
+      for (var i = 0; i < w.tabs.length; i++) if ((w.tabs[i].name || '').toLowerCase() === String(tab).toLowerCase()) { _activeTabIdx = i; _viewMode = 'grid'; renderActiveTab(); renderTabStrip(); renderToolbar(); return; }
+    },
+    // has(key): does THIS chrome currently render the AD table `key` (a [data-ad-table] is in the DOM)?
+    has: function (key) { return !!key && !!_firstByTable(key); },
+    // locate(key): on-screen rect of the keyed element (centre + badge radius), or null if off-screen.
+    locate: function (key) {
+      var e = _firstByTable(key); if (!e) return null;
+      var r = e.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return null;
+      return { x: r.left + r.width / 2, y: r.top + r.height / 2, r: 14, rRaw: 14 };
+    }
+    // TODO(STEP-0 seam#1 — write path): inject the engine C0 dispatch(intent, ctx) + populated ctx
+    //   {actor,pubKey,roleId,allowOrgs} so the lens chromes can commit (kanban drag / chat send). The kernel
+    //   write path is PROVEN (W-CRUD-WRITELOOP 11/11); only the C0 wrapper + ctx wiring remain (ENGINE_CONTRACT §6).
+  };
+  console.log('§SEAM-FROZEN seam=host-contract globals=IdmpHost methods=trace,focus,openTab,has,locate mount=#idmp-content');
+
   // ── Wire chrome ──
   document.addEventListener('DOMContentLoaded', function () {
     $('idmp-menu-filter').addEventListener('input', function (e) { applyFilter(e.target.value); });
     $('idmp-search').addEventListener('input', function (e) { $('idmp-menu-filter').value = e.target.value; applyFilter(e.target.value); });
     $('idmp-burger').addEventListener('click', function () { document.body.classList.toggle('menu-open'); });
     $('idmp-home-btn').addEventListener('click', function () { location.href = 'erp.html'; });
-    $('idmp-help-btn').addEventListener('click', function () { status('Help / ShowMe overlay — arrives once the UI is confirmed'); });
+    $('idmp-help-btn').addEventListener('click', function () { if (window.__help && window.__help.enable) { window.__help.enable(); status('ShowMe ready — tap a numbered badge'); } else status('Help / ShowMe overlay loading…'); });
     // Login overlay wiring (docs §3b): Back→pick another user (logout), Log In→commit session,
     // switch-role→reopen at the Role step, backdrop click→dismiss only if already logged in.
     $('idmp-login-back').addEventListener('click', loginStep1);
@@ -703,6 +757,22 @@
   });
 })();
 </script>
+<!-- §SEAM-FROZEN seam#2 — Tour Guide host overlay (record-panel host-conformance, IDEMPIERE_RECORD_PANEL.md).
+     window.IdmpHost + data-ad-* tagging are published by the script above; here we load the SHARED, UNFORKED
+     help_overlay.js + its init-only idempiere adapter (help_idmp.js), with the agreed key vocabulary inlined
+     (mirrors build/erp/help_idmp_keymap.json verbatim — the Tour drift gate). -->
+<script>
+window.__helpIdmpKeymap = {
+  "o2c":             { "kind": "overview", "window": null,               "coverage": "n/a" },
+  "c_order":         { "window": "Sales Order",         "table": "c_order",          "record": "#80001", "coverage": "partial" },
+  "m_inout":         { "window": "Shipment (Customer)", "table": "m_inout",          "coverage": "partial" },
+  "c_invoice":       { "window": "Sales Invoice",       "table": "c_invoice",        "coverage": "partial" },
+  "c_payment":       { "window": "Payment",             "table": "c_payment",        "coverage": "partial" },
+  "c_allocationline":{ "window": "Allocation",          "table": "c_allocationline", "coverage": "partial" }
+};
+</script>
+<script src="help_overlay.js?v=22"></script>
+<script src="help_idmp.js?v=22"></script>
 <script>
 // Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data/idmp_session + ad_seed.db are precached (sw v561).
 if ('serviceWorker' in navigator) {

--- a/erp/tests/poc_idmp_host.js
+++ b/erp/tests/poc_idmp_host.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: §SEAM-FROZEN witness for idempiere.html host-conformance (IDEMPIERE_RECORD_PANEL.md +
+//   docs/TourGuideHostContract.md §2). PROVES the STEP-0 freeze (SEAM #2, the host contract):
+//   (1) window.IdmpHost exposes the agreed {trace,focus,openTab,has,locate} — and the REAL extracted
+//       has/locate/focus LOGIC runs correctly against a DOM-shim (case-insensitive AD-key match, honest
+//       no-op when a window is absent — non-invent);
+//   (2) the O2C DOM is tagged data-ad-table/record at render (buildGrid + buildForm);
+//   (3) the inline __helpIdmpKeymap matches build/erp/help_idmp_keymap.json VERBATIM (the Tour drift gate);
+//   (4) the help-layer detection grep is green (IdmpHost + data-ad-* + help scripts + mount present);
+//   (5) HONEST scope: SEAM #1 (the write path dispatch+ctx) is still TODO(STEP-0) pending engine C0 — this
+//       witness freezes the NAV host contract only and says so (never claims writes work).
+// §-log first — writes tests/poc_idmp_host.log; READ the log, not the exit code.
+// Run:  node tests/poc_idmp_host.js 2>&1 | tee tests/poc_idmp_host.log   (cwd = bim-ootb/erp)
+'use strict';
+var fs = require('fs');
+var vm = require('vm');
+var path = require('path');
+
+var lines = [], pass = 0, fail = 0;
+function L(s) { lines.push(s); }
+function ck(c, m) { if (c) { pass++; L('   🟢 ' + m); } else { fail++; L('   🔴 ' + m); } }
+
+var HTML = fs.readFileSync(path.join(__dirname, '..', 'idempiere.html'), 'utf8');
+var CANON = JSON.parse(fs.readFileSync('/home/red1/bim-compiler/build/erp/help_idmp_keymap.json', 'utf8'));
+
+L('═══ POC-IDMP-HOST — §SEAM-FROZEN: idempiere.html host conformance (the STEP-0 freeze, seam #2) ═══\n');
+
+// ── (1) SURFACE (static): the contract is published, tagging + scripts + mount present ──────────────
+L('── §SEAM-FROZEN-SURFACE ──');
+ck(/window\.IdmpHost\s*=\s*\{/.test(HTML), 'window.IdmpHost is published (the frozen exposed-global, not a rival name)');
+['trace', 'focus', 'openTab', 'has', 'locate'].forEach(function (fn) {
+  ck(new RegExp('\\b' + fn + ':\\s*function').test(HTML), 'IdmpHost.' + fn + ' present');
+});
+ck(/setAttribute\('data-ad-table'/.test(HTML) && /setAttribute\('data-ad-record'/.test(HTML), 'O2C rows tagged data-ad-table + data-ad-record at render (buildGrid)');
+ck((HTML.match(/setAttribute\('data-ad-table'/g) || []).length >= 2, 'data-ad-table tagging in BOTH grid + form (>=2 sites)');
+ck(/_winByName\[\(node\.name/.test(HTML), 'menu render populates _winByName (name->id) so focus() can resolve a window');
+ck(/help_overlay\.js/.test(HTML) && /help_idmp\.js/.test(HTML), 'the SHARED help_overlay.js + init-only help_idmp.js are loaded (unforked)');
+ck(/window\.__helpIdmpKeymap\s*=/.test(HTML), 'the agreed key vocabulary is inlined as window.__helpIdmpKeymap');
+ck(/id="idmp-content"/.test(HTML), '#idmp-content mount present');
+ck(/TODO\(STEP-0 seam#1/.test(HTML), 'HONEST: the write path (seam #1 dispatch+ctx) is left TODO(STEP-0) — not faked');
+L('§SEAM-FROZEN-SURFACE globals=IdmpHost methods=5 tagging=Y scripts=Y mount=#idmp-content writeSeam=TODO\n');
+
+// ── (2) LOGIC (executed): extract the REAL IdmpHost block + helpers, run against a DOM-shim ──────────
+L('── §SEAM-FROZEN-MATCH (executes the real extracted IdmpHost) ──');
+var block = HTML.match(/function _adMatch[\s\S]*?window\.IdmpHost\s*=\s*\{[\s\S]*?\n  \};/);
+ck(!!block, 'extracted the IdmpHost implementation block from idempiere.html');
+
+function shimEl(table) {
+  return {
+    _t: table,
+    getAttribute: function (k) { return k === 'data-ad-table' ? table : null; },
+    getBoundingClientRect: function () { return { left: 100, top: 200, width: 80, height: 20, right: 180, bottom: 220 }; }
+  };
+}
+function offEl(table) {
+  return { _t: table, getAttribute: function (k) { return k === 'data-ad-table' ? table : null; },
+    getBoundingClientRect: function () { return { left: 0, top: 0, width: 0, height: 0, right: 0, bottom: 0 }; } };
+}
+var calls = { openWindow: [], status: [], render: 0 };
+var TAGGED = [shimEl('C_Order')];                              // canonical CASE in the DOM (vs lowercase key)
+var sandbox = {
+  console: { log: function () {} },
+  String: String, Number: Number, Object: Object, Array: Array,
+  document: {
+    body: { classList: { _v: null, toggle: function (c, on) { this._v = on; } } },
+    querySelectorAll: function (sel) { return sel === '[data-ad-table]' ? TAGGED : []; }
+  },
+  // deps the extracted nav fns close over (shimmed):
+  _winByName: { 'sales order': 200 },
+  openWindow: function (id, name) { calls.openWindow.push({ id: id, name: name }); },
+  _curWin: function () { return { tabs: [{ name: 'Sales Order', tableName: 'c_order' }, { name: 'Lines', tableName: 'c_orderline' }] }; },
+  renderActiveTab: function () { calls.render++; }, renderTabStrip: function () {}, renderToolbar: function () {},
+  status: function (s) { calls.status.push(s); }
+};
+sandbox.window = sandbox; sandbox._activeTabIdx = 9; sandbox._viewMode = 'form';
+try {
+  vm.runInNewContext(block[0], sandbox, { filename: 'idmp-host-extract.js' });
+  var H = sandbox.window.IdmpHost;
+  ck(H && typeof H.has === 'function', 'extracted IdmpHost is a live object with methods');
+  ck(H.has('c_order') === true, 'has("c_order") === true vs a data-ad-table="C_Order" element (CASE-INSENSITIVE match)');
+  ck(H.has('m_inout') === false, 'has("m_inout") === false when that table is NOT in the DOM (honest, no fabrication)');
+  var rect = H.locate('c_order');
+  ck(rect && rect.x === 140 && rect.y === 210 && rect.r === 14, 'locate("c_order") centres the badge on the real rect (x=140,y=210,r=14)');
+  ck(TAGGED.length && H.locate('m_inout') === null, 'locate(absent) === null (off-DOM → no badge, not a guess)');
+  TAGGED[0] = offEl('C_Order'); ck(H.locate('c_order') === null, 'locate() returns null for an OFF-SCREEN element (0×0 rect)'); TAGGED[0] = shimEl('C_Order');
+  H.trace(true); ck(sandbox.document.body.classList._v === true, 'trace(true) toggles the flow-view hint (no chrome reach-in)');
+  H.focus('c_order', { window: 'Sales Order', table: 'c_order', coverage: 'partial' });
+  ck(calls.openWindow.length === 1 && calls.openWindow[0].id === 200, 'focus() resolves the window BY NAME ("Sales Order"→200) and opens it');
+  ck(sandbox._activeTabIdx === 0, 'focus() selects the tab whose tableName matches the key (c_order → tab 0)');
+  calls.openWindow = []; calls.status = [];
+  H.focus('c_invoice', { window: 'Nonexistent Window', table: 'c_invoice', coverage: 'partial' });
+  ck(calls.openWindow.length === 0 && calls.status.length === 1, 'focus() on an ABSENT window NO-OPS gracefully + reports honest coverage (never throws, never invents)');
+} catch (e) { ck(false, 'executing the extracted IdmpHost threw: ' + (e && e.message)); }
+L('§SEAM-FROZEN-MATCH has=case-insensitive locate=rect-or-null focus=by-name+degrade trace=hint fabricated=0\n');
+
+// ── (3) KEYMAP drift (the Tour drift gate) ──────────────────────────────────────────────────────────
+L('── §SEAM-FROZEN-KEYMAP ──');
+var im = HTML.match(/window\.__helpIdmpKeymap\s*=\s*(\{[\s\S]*?\});/);
+var inline = im ? vm.runInNewContext('(' + im[1] + ')', {}) : {};
+var ck2 = function (k) { return Object.keys(k).filter(function (x) { return x !== '__meta'; }).sort(); };
+var ik = ck2(inline), ckk = ck2(CANON);
+ck(JSON.stringify(ik) === JSON.stringify(ckk), 'inline keymap key-set == canonical (no orphan/stale): ' + ik.join(','));
+var drift = 0, lc = 0;
+ckk.forEach(function (k) {
+  ['window', 'table', 'coverage', 'record'].forEach(function (f) { if ((inline[k] || {})[f] !== (CANON[k] || {})[f] && !((inline[k] || {})[f] == null && (CANON[k] || {})[f] == null)) drift++; });
+  if ((inline[k] || {}).table && inline[k].table !== inline[k].table.toLowerCase()) lc++;
+});
+ck(drift === 0, 'every inline entry (window/table/coverage/record) matches canonical VERBATIM — drift=' + drift);
+ck(lc === 0, 'all table keys are lowercase (the agreed vocabulary the tags resolve to) — uppercase=' + lc);
+L('§SEAM-FROZEN-KEYMAP keys=' + ik.length + ' drift=0 lowercase=Y source=help_idmp_keymap.json\n');
+
+// ── (4) DETECTION grep (the help-layer falsifier goes green) ─────────────────────────────────────────
+L('── §SEAM-FROZEN-DETECT (help-layer grep) ──');
+ck(/window\.(Idmp|Erp|Host)[A-Za-z]*\s*=/.test(HTML), 'artifact 1/3 — exposed-globals object (window.IdmpHost)');
+ck(/data-ad-(table|record)/.test(HTML), 'artifact 2/3 — AD-key tagging on the O2C DOM (data-ad-table/record)');
+ck(/idmp-content/.test(HTML), 'artifact 3/3 — mount point (#idmp-content)');
+ck(/SEAM-FROZEN/.test(HTML), 'bonus — §SEAM-FROZEN token emitted in-page (governance gate auditable)');
+L('§SEAM-FROZEN-DETECT artifacts=3/3 token=Y grep=GREEN\n');
+
+// ── summary ──
+var ok = fail === 0;
+L('§SEAM-FROZEN SUMMARY pass=' + pass + ' fail=' + fail + ' seam=#2(host-contract) seam#1(write)=TODO(C0)');
+L(ok ? '\n═══ ✅ POC-IDMP-HOST ALL PASS — idempiere.html exposes IdmpHost + tags by AD key; the NAV host contract (seam #2) is FROZEN. Write seam (#1) awaits engine C0. ═══'
+     : '\n═══ 🔴 POC-IDMP-HOST FAIL ═══');
+fs.writeFileSync(path.join(__dirname, 'poc_idmp_host.log'), lines.join('\n') + '\n');
+console.log(lines.join('\n'));
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
The **record-panel host-contract freeze** on `idempiere.html` (renderer #1) — the STEP-0 deliverable that unblocks the **Tour O2C walk** and the **lens-lane navigation**. Spec: `prompts/IDEMPIERE_RECORD_PANEL.md` + `docs/TourGuideHostContract.md §2`. **Additive only** — existing render / login / master-detail untouched.

## What lands
- **`window.IdmpHost`** = `{trace, focus, openTab, has, locate}` over idempiere's nav. `focus` opens a window **by name** (`_winByName`, built as the menu renders) + selects the matching tab; `has`/`locate` match `[data-ad-table]` **case-insensitively** (lowercase keymap ↔ canonical `C_Order` tags); `trace` = soft flow hint.
- **O2C DOM tagged** `data-ad-table` / `data-ad-record` at render (`buildGrid` + `buildForm`) + `data-ad-column` on fields. `#idmp-content` mount (already present).
- **Unforked** `help_overlay.js` + init-only `help_idmp.js` loaded (copied into `erp/`) + inline `__helpIdmpKeymap` (zero drift vs `build/erp/help_idmp_keymap.json`). Help button wired to ShowMe.

## Witnessed (headless, §-log first)
- `erp/tests/poc_idmp_host.js` → **§SEAM-FROZEN 31/31** — *executes the real extracted IdmpHost* (case-insensitive `has`, `locate` rect/null, `focus` by-name with honest no-op + coverage when a window is absent — never fabricates).
- Tour `scripts/test_tour_idempiere.js` still **24/24** (drift gate intact). Help-layer detection grep **GREEN**.

## Honest gaps (not faked)
- **Seam #1 (write `dispatch`/`ctx`) left `// TODO(STEP-0)`** pending engine **C0** (`ENGINE_CONTRACT §6`) — lens kanban-drag/chat-send stay inert; only **nav** unblocks here.
- Live-browser ShowMe walk + real-data record nav = post-deploy Playwright (secondary). O2C window names resolve only if present in `ad_seed.db`'s menu → graceful degrade otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)