### PR TITLE
fix(night): restore exterior light spillover — infinite range + intensity 8

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v562';
+const CACHE_VERSION = 'v563';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -737,10 +737,10 @@ function setupTools(A) {
   A._nightLights = [];       // active THREE.PointLight objects
   A._nightFixtures = [];     // [{x,y,z}] from DB — IFC coordinates
   A._nightSaved = null;      // saved day settings
-  var NIGHT_MAX_LIGHTS = 12; // §S277d: 12 POL — fills rooms properly
-  var NIGHT_LIGHT_RANGE = 30; // §S277d: 30m radius
-  var NIGHT_LIGHT_INTENSITY = 1.5; // §S277d: brighter — 4 lights need to cover more
-  var NIGHT_LIGHT_DECAY = 1.5; // §S277d: gentler decay — reaches further per light
+  var NIGHT_MAX_LIGHTS = 12; // §S277d: 12 proximity-culled lights — perf cap (each light = per-pixel cost/frame)
+  var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
+  var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
+  var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
 
   A.toggleNightMode = function() {
     A._nightMode = !A._nightMode;


### PR DESCRIPTION
## Problem
In night mode, interior PointLights stopped lighting **overhangs, doorways, and corridors when viewed from outside** — too dark. The "transfer" as you walk inside (nearest-N culling) still worked; the exterior throw was gone.

## Root cause
Regression from the S277d "night mode overhaul" (`d615dcfa` in bim-compiler). It retuned the night fixtures:
| Constant | Working (was) | Overhaul (broke) |
|---|---|---|
| `NIGHT_LIGHT_RANGE` | `0` (infinite) | `30` (hard cutoff) |
| `NIGHT_LIGHT_INTENSITY` | `8.0` | `1.5` |

The exterior spillover depended on **infinite range + intensity 8** — an interior lamp set back from the façade still threw light past the wall, with inverse-square handling falloff. The hard 30 m sphere + 5.3× dimmer intensity killed it. (The overhaul was tuned to "fill rooms", trading away the exterior reach.)

## Fix
- `NIGHT_LIGHT_RANGE` 30 → **0** (infinite)
- `NIGHT_LIGHT_INTENSITY` 1.5 → **8.0**
- `NIGHT_MAX_LIGHTS` kept at **12** — light *count* doesn't affect exterior reach (range+intensity do); it's only hall coverage, and each active light is a per-pixel cost/frame, so no perf regression vs current prod.
- decay unchanged (1.5). These lights don't cast shadows, so no shadow-map cost.
- `sw.js` CACHE_VERSION v562 → **v563**.

## Verify
Night mode → orbit outside the building: overhangs/doorways/corridors lit from interior fixtures; lighting transfers to interior fixtures as you move in.