### PR TITLE
fix(night): cull POL by camera not orbit target — lights the façade you face

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v563';
+const CACHE_VERSION = 'v564';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -944,10 +944,13 @@ function setupTools(A) {
       // Small building — place ALL fixtures, no culling
       needed = allPos.map(function(p) { return { pos: p }; });
     } else {
-      // §S277d: Nearest 4 fixtures to orbit target (stable) — not camera (jumps on orbit)
-      var _tgt = A.controls ? A.controls.target : camPos;
+      // §S277d: nearest fixtures to CAMERA — lights the façade/overhangs/doorways you're
+      // looking at from outside (and the room around you when inside). Orbit-target scoring
+      // clustered all lights at building centre, starving the perimeter. Debounced by the
+      // controls 'change' listener (>5m move) so small orbits don't thrash the set.
+      var _eye = camPos;
       var sorted = allPos.map(function(p) {
-        var dx = p.x - _tgt.x, dy = p.y - _tgt.y, dz = p.z - _tgt.z;
+        var dx = p.x - _eye.x, dy = p.y - _eye.y, dz = p.z - _eye.z;
         return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
       }).sort(function(a, b) { return a.dist2 - b.dist2; });
       needed = sorted.slice(0, NIGHT_MAX_LIGHTS);


### PR DESCRIPTION
Orbit-target scoring clustered all 12 night lights at the building centre, starving the perimeter so overhangs/doorways/corridors stayed dark from outside. Now scores fixtures by distance to the camera. 12-light cap unchanged. sw v563->v564.