### PR TITLE
feat(night+material): mixed light cull + camera fade + realistic surface sheen

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -338,10 +338,14 @@ function setupStreaming(A) {
     const opts = { color: new THREE.Color(r, g, b), flatShading: false };
     if (a < 1.0) { opts.transparent = true; opts.opacity = a; opts.side = THREE.DoubleSide; }
     // §S265: PBR roughness + metalness from standard material (or defaults)
-    opts.roughness = stdMat ? stdMat.rough : 0.7;
-    opts.metalness = stdMat ? stdMat.metal : 0.05;
+    // §refl: ease matte surfaces toward a soft sheen so walls/floors/concrete CATCH the lights
+    // (realistic emphasis) instead of reading as flat pale fills. Scale all roughness down ~25%;
+    // metals/glass stay glossy by ratio. Floor at 0.08 so nothing becomes a mirror artefact.
+    var _rough = stdMat ? stdMat.rough : 0.55;
+    opts.roughness = Math.max(0.08, _rough * 0.75);
+    opts.metalness = stdMat ? stdMat.metal : 0.08; // §refl: slight metal lift gives surfaces real specular response
     opts.side = THREE.DoubleSide; // §S260d: IFC geometry has inconsistent normals — DoubleSide ensures pick works
-    if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = 0.3; }
+    if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = 0.6; } // §refl: 0.3->0.6 — more realistic reflection emphasis
     const mat = new THREE.MeshStandardMaterial(opts);
     // §S277: Procedural normal perturbation — gives surface texture to flat IFC geometry.
     // Metallic surfaces (pipes, ducts, beams): fine brushed-metal grain.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v564';
+const CACHE_VERSION = 'v565';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -944,13 +944,19 @@ function setupTools(A) {
       // Small building — place ALL fixtures, no culling
       needed = allPos.map(function(p) { return { pos: p }; });
     } else {
-      // §S277d: nearest fixtures to CAMERA — lights the façade/overhangs/doorways you're
-      // looking at from outside (and the room around you when inside). Orbit-target scoring
-      // clustered all lights at building centre, starving the perimeter. Debounced by the
-      // controls 'change' listener (>5m move) so small orbits don't thrash the set.
-      var _eye = camPos;
+      // §S277d: MIXED selection — score by a point BETWEEN the eye and the look-at, so the
+      // active lights sit near you AND extend down the hall you're flying toward (they
+      // transfer ahead as you move). Pure camera-nearest clustered them all at the eye; pure
+      // orbit-target clustered them at building centre. Debounced by the controls 'change'
+      // listener (>5m move) so small orbits don't thrash the set.
+      var _tgt = A.controls ? A.controls.target : camPos;
+      var _aim = {
+        x: camPos.x + (_tgt.x - camPos.x) * 0.5,
+        y: camPos.y + (_tgt.y - camPos.y) * 0.5,
+        z: camPos.z + (_tgt.z - camPos.z) * 0.5
+      };
       var sorted = allPos.map(function(p) {
-        var dx = p.x - _eye.x, dy = p.y - _eye.y, dz = p.z - _eye.z;
+        var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
         return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
       }).sort(function(a, b) { return a.dist2 - b.dist2; });
       needed = sorted.slice(0, NIGHT_MAX_LIGHTS);
@@ -962,9 +968,14 @@ function setupTools(A) {
       l.dispose();
     });
     A._nightLights = [];
-    // §S277d: Fixed intensity at fixture positions — no camera-distance fade
+    // §S277d: camera-distance fade — lights near the eye (you're inside, next to them) dim to
+    // 30%; lights far away (you're outside looking in) stay full strength for façade throw.
+    // Fixes "inside too bright" without losing the exterior overhang/doorway spillover.
     needed.forEach(function(f) {
-      var light = new THREE.PointLight(0xffe4b5, NIGHT_LIGHT_INTENSITY, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
+      var dist = camPos.distanceTo(f.pos);
+      var fade = Math.min(1.0, dist / 15);              // 0 at the light, full at 15m+
+      var intensity = NIGHT_LIGHT_INTENSITY * (0.3 + 0.7 * fade);  // never below 30%
+      var light = new THREE.PointLight(0xffe4b5, intensity, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
       light.position.copy(f.pos);
       A.scene.add(light);
       A._nightLights.push(light);


### PR DESCRIPTION
## Night lighting
- **Mixed light selection** — the 12 active POL are scored by the midpoint between eye and look-at, so they extend down the hall you fly toward and transfer ahead (pure-camera clustered them on you; pure orbit-target clustered them at building centre).
- **Camera-distance fade** restored — lights within ~15m dim to 30%, far lights stay full for façade throw. Fixes 'inside too bright' without losing the exterior overhang/doorway spillover.

## Material realism (less pale)
- Roughness scaled ×0.75 so matte concrete/plaster/slab (0.85–0.95) catch a soft specular sheen instead of flat pale fills; metals/glass stay glossy by ratio, clamped at 0.08.
- envMapIntensity 0.3→0.6, default metalness 0.05→0.08.

sw v564→v565. Verified on localhost.