### PR TITLE
fix(viewer): S286 desktop on-demand render gate — stop idle 60fps GPU burn

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -5,7 +5,7 @@
  */
 // main.js — initViewer() orchestrator: creates APP, calls each module's setup, starts render loop
 // DEV version — adds setupNlp (S211 voice command / NLP query)
-console.log('§MAIN_JS v35 loaded — S281 wire setupErrorReporter(APP)');
+console.log('§MAIN_JS v36 loaded — S286 desktop on-demand render gate (idle fan fix)');
 async function initViewer() {
   const APP = window.APP = {};
 
@@ -497,6 +497,7 @@ async function initViewer() {
 
   // Render loop — on-demand: only render when camera moves or streaming is active
   let _needsRender = true;
+  let _idleLogged = false; // §S286: whitebox — true once the desktop loop has parked idle
   APP.controls.addEventListener('change', () => { _needsRender = true; });
   APP.markDirty = () => { _needsRender = true; };
 
@@ -588,10 +589,21 @@ async function initViewer() {
         _needsRender = false;
       }
     } else {
-      // §S280c: Desktop renders unconditionally — same as smooth R184 era.
-      // Render gate removed: was S280b scope drift (perf change in UI session).
-      if (APP._composer && APP._composerEnabled) APP._composer.render();
-      else APP.renderer.render(APP.scene, APP.camera);
+      // §S286: Desktop on-demand render — restores the gate S280c reverted. Memory
+      // (project_s280c_perf.md) traced that era's sluggishness to an NVIDIA/Intel driver
+      // mismatch, NOT this gate. Idle static scene now parks at 0 GPU frames (was ~60 fps
+      // forever → fans). No TM exception: Time Machine self-renders via its own setTimeout
+      // timer → renderAtTime() (markDirty + direct render), so the loop is redundant even
+      // for TM. Every other camera path already calls markDirty.
+      if (_needsRender || APP.streaming || APP.walkModeActive || _orbiting) {
+        if (APP._composer && APP._composerEnabled) APP._composer.render();
+        else APP.renderer.render(APP.scene, APP.camera);
+        _needsRender = false;
+        if (_idleLogged) { console.log('§IDLE_GATE wake'); _idleLogged = false; }
+      } else if (!_idleLogged) {
+        console.log('§IDLE_GATE park — desktop loop idle, 0 GPU frames (static scene)');
+        _idleLogged = true;
+      }
     }
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v566';
+const CACHE_VERSION = 'v567';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -835,7 +835,7 @@
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=52" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
-<script src="main.js?v=35"></script>
+<script src="main.js?v=36"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>
 <script>
@@ -875,7 +875,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=526')
+  navigator.serviceWorker.register('sw.js?v=527')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }


### PR DESCRIPTION
## Problem
A loaded-but-idle scene on **desktop** repaints at ~60 fps forever → one CPU core + the Firefox GPU `CanvasRenderer` thread pegged, **fans spin up**. `/proc` sampling proved it's continuous GPU repaint (tab JS = 0% idle, CanvasRenderer ~54% sustained), **not a memory leak**.

## Root cause
`viewer/main.js` desktop `else` branch called `renderer.render()` **every frame unconditionally** — the mobile branch already gates on `_needsRender`. The gate existed (S280b) but was reverted in S280c, which blamed it for sluggishness that memory later traced to an **NVIDIA/Intel driver mismatch + unrebooted kernel** ("not a code regression"). Desktop never got the gate back.

## Fix
Gate the desktop branch like mobile: `if (_needsRender || APP.streaming || APP.walkModeActive || _orbiting)`. Idle static scene → **0 GPU frames**.

**Safe — verified, not invented:**
- No continuously-animating shaders (clouds dropped; no `clock`/`elapsedTime`/`uniforms.time`).
- Every camera path already calls `markDirty()` (fly, measure, scene, picking, grid — 19 files); OrbitControls `change` listener wakes the loop on orbit/damping.
- **No Time Machine exception** — TM self-renders via its own `setTimeout` timer → `renderAtTime()` (markDirty + direct render). The loop was redundant even for TM; gating calms TM too.

## Proof (whitebox)
`§IDLE_GATE park`/`wake` telemetry. Tested on localhost: boot → park → `markDirty` → wake → re-park, **0 pageerrors**.

Cache: `CACHE_VERSION` v566→v567, `main.js?v=35→36`, `sw.js?v=526→527`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)