### PR TITLE
fix(viewer): resume render loop on focus/pageshow (stuck-after-bg-load)

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -5,7 +5,7 @@
  */
 // main.js — initViewer() orchestrator: creates APP, calls each module's setup, starts render loop
 // DEV version — adds setupNlp (S211 voice command / NLP query)
-console.log('§MAIN_JS v36 loaded — S286 desktop on-demand render gate (idle fan fix)');
+console.log('§MAIN_JS v37 loaded — S287 render-loop resume on focus/pageshow');
 async function initViewer() {
   const APP = window.APP = {};
 
@@ -521,12 +521,21 @@ async function initViewer() {
 
   // §S271: Pause rAF when tab backgrounded — saves battery, avoids WebGL context kill
   var _tabVisible = true;
+  // §S287: never leave the loop dead. Restart only if not already running (no double-loop).
+  function _ensureLoop() {
+    _tabVisible = true;
+    if (!_rafId) { _needsRender = true; _rafId = requestAnimationFrame(animate); console.log('§RENDER_LOOP resumed'); }
+  }
   document.addEventListener('visibilitychange', function() {
     _tabVisible = !document.hidden;
-    if (_tabVisible) { _needsRender = true; _rafId = requestAnimationFrame(animate); }
+    if (_tabVisible) { _needsRender = true; if (!_rafId) _rafId = requestAnimationFrame(animate); }
     else if (_rafId) { cancelAnimationFrame(_rafId); _rafId = null; }
     console.log('§TAB_VISIBILITY visible=' + _tabVisible);
   });
+  // §S287: background-load / bfcache safety net — refocusing or re-showing the tab
+  // must revive a loop that was cancelled while hidden (the "stuck after reload" case).
+  window.addEventListener('focus', _ensureLoop);
+  window.addEventListener('pageshow', _ensureLoop);
 
   var _rafId;
   // §S276: WebGPURenderer compiles shader pipelines per material. On 122K scenes with 100+

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v570';
+const CACHE_VERSION = 'v571';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -835,7 +835,7 @@
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=52" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
-<script src="main.js?v=36"></script>
+<script src="main.js?v=37"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>
 <script>


### PR DESCRIPTION
Tab loading backgrounded (`§TAB_VISIBILITY visible=false`) could leave §S271's rAF cancelled and never restart → frozen scene. Adds `focus`+`pageshow` revive (guarded, no double-loop). `§MAIN_JS v37`, SW `v571`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)