### PR TITLE
fix(viewer): single-owner render loop — kill S287 double-loop (CPU)

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -5,7 +5,7 @@
  */
 // main.js — initViewer() orchestrator: creates APP, calls each module's setup, starts render loop
 // DEV version — adds setupNlp (S211 voice command / NLP query)
-console.log('§MAIN_JS v37 loaded — S287 render-loop resume on focus/pageshow');
+console.log('§MAIN_JS v38 loaded — S287b single-owner render loop');
 async function initViewer() {
   const APP = window.APP = {};
 
@@ -521,23 +521,28 @@ async function initViewer() {
 
   // §S271: Pause rAF when tab backgrounded — saves battery, avoids WebGL context kill
   var _tabVisible = true;
-  // §S287: never leave the loop dead. Restart only if not already running (no double-loop).
-  function _ensureLoop() {
-    _tabVisible = true;
-    if (!_rafId) { _needsRender = true; _rafId = requestAnimationFrame(animate); console.log('§RENDER_LOOP resumed'); }
+  var _rafId, _loopStarts = 0;
+  // §S287b: SINGLE-OWNER render loop. Every (re)start routes through here; the _rafId guard
+  // guarantees exactly ONE rAF chain — fixes the S287 focus/pageshow + async-init double-loop
+  // (which ran render twice per frame). Witness: §RENDER_LOOP start total= must stay 1.
+  function _startLoop() {
+    if (_rafId) return;                       // already running — never double
+    _loopStarts++;
+    _needsRender = true;
+    _rafId = requestAnimationFrame(animate);
+    console.log('§RENDER_LOOP start total=' + _loopStarts);
   }
+  function _ensureLoop() { _tabVisible = true; _startLoop(); }
   document.addEventListener('visibilitychange', function() {
     _tabVisible = !document.hidden;
-    if (_tabVisible) { _needsRender = true; if (!_rafId) _rafId = requestAnimationFrame(animate); }
+    if (_tabVisible) _startLoop();
     else if (_rafId) { cancelAnimationFrame(_rafId); _rafId = null; }
     console.log('§TAB_VISIBILITY visible=' + _tabVisible);
   });
-  // §S287: background-load / bfcache safety net — refocusing or re-showing the tab
-  // must revive a loop that was cancelled while hidden (the "stuck after reload" case).
+  // §S287: revive a loop cancelled while hidden — refocus, or bfcache restore (persisted).
+  // Both go through _startLoop's guard, so they can never start a second chain.
   window.addEventListener('focus', _ensureLoop);
-  window.addEventListener('pageshow', _ensureLoop);
-
-  var _rafId;
+  window.addEventListener('pageshow', function(e) { if (e.persisted) _ensureLoop(); });
   // §S276: WebGPURenderer compiles shader pipelines per material. On 122K scenes with 100+
   // materials, synchronous compilation during render() times out the main thread.
   // Fix: after streaming adds all materials, call compileAsync() to pre-warm pipelines
@@ -616,8 +621,8 @@ async function initViewer() {
     }
   }
 
-  // Go
-  animate();
+  // Go — §S287b: single guarded kickoff (no double loop if focus/pageshow fired during init)
+  _startLoop();
   APP.init().then(async function() {
     // S223: Load diff DB if ?diffdb= param present (variation comparison)
     const diffDbUrl = new URLSearchParams(location.search).get('diffdb');

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v572';
+const CACHE_VERSION = 'v573';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -835,7 +835,7 @@
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=52" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
-<script src="main.js?v=37"></script>
+<script src="main.js?v=38"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>
 <script>


### PR DESCRIPTION
S287 focus/pageshow + async-init could start two concurrent rAF chains → 2x render/CPU. Now one guarded `_startLoop()`; pageshow gated to bfcache. Witness: `§RENDER_LOOP start total=` stays 1. `§MAIN_JS v38`, SW `v573`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)