### PR TITLE
feat(erp-ui): Share pill captures AND restores full ERP context

### DIFF
--- a/erp/ad_ui.js
+++ b/erp/ad_ui.js
@@ -3358,6 +3358,41 @@
     }
   }
 
+  // §SHARE — capture the live context as the SAME deep-link params erp.html restores on load
+  // (client/window/record). Capture is the mirror of the existing restore — non-invent. (docs/ERP_SHARE_SPEC.md)
+  function _currentRecordPk() {
+    if (_currentScreen !== 'window' || !_currentWindow || !_currentRecords.length) return null;
+    var tab = _currentWindow.tabs[_currentTabIdx];
+    if (!tab) return null;
+    var rec = _currentRecords[_currentRecordIdx];
+    if (!rec) return null;
+    var pk = _caseGet(rec, tab.tableName + '_ID');
+    return (pk === undefined || pk === null) ? null : pk;
+  }
+
+  function _getContext() {
+    var ctx = { client: _currentClient, screen: _currentScreen };
+    if (_currentScreen === 'window' && _currentWindow) {
+      ctx.window = _currentWindow.id;
+      var pk = _currentRecordPk();
+      if (pk !== null) ctx.record = pk;
+    }
+    return ctx;
+  }
+
+  function _buildShareUrl() {
+    var ctx = _getContext();
+    var base = (typeof location !== 'undefined') ? (location.origin + location.pathname) : 'erp.html';
+    var qs = [];
+    if (ctx.client) qs.push('client=' + encodeURIComponent(ctx.client));
+    if (ctx.window !== undefined && ctx.window !== null) qs.push('window=' + encodeURIComponent(ctx.window));
+    if (ctx.record !== undefined && ctx.record !== null) qs.push('record=' + encodeURIComponent(ctx.record));
+    var url = base + (qs.length ? '?' + qs.join('&') : '');
+    console.log('§AD_UI buildShareUrl ' + url + ' (client=' + (ctx.client || '') +
+      ' window=' + (ctx.window != null ? ctx.window : '-') + ' record=' + (ctx.record != null ? ctx.record : '-') + ')');
+    return url;
+  }
+
   var ADUI = {
     init:       init,
     hydrate:    _hydrate,
@@ -3366,6 +3401,9 @@
     // §19 Deep-link helpers
     setClient:  _setClient,
     navToRecord: _navToRecordByPk,
+    // §SHARE — capture/restore full context (docs/ERP_SHARE_SPEC.md)
+    getContext: _getContext,
+    buildShareUrl: _buildShareUrl,
     // Exposed for testing — CRUD toolbar / arrow keys
     navRecord:  _navRecord,
     getRecordIdx: function () { return _currentRecordIdx; },

--- a/erp/docs/ERP_SHARE_SPEC.md
+++ b/erp/docs/ERP_SHARE_SPEC.md
@@ -1,0 +1,36 @@
+# ERP Share Pill — Capture & Restore Full Context (spec)
+
+**Issue:** the `share` pill on `erp.html` copies a bare `location.href` — it does NOT capture the
+current ERP context, so a recipient lands on the home globe, not where the sender was.
+
+**Goal (user):** ONE Share control in the pill that **captures AND restores full context**.
+
+## Non-invent principle
+The RESTORE side already exists in `erp.html`: on load it reads `?client=` / `?window=` / `?record=`
+and calls `ADUI.setClient` / `ADUI.openWindow` / `ADUI.navToRecord`. So Share must emit a URL using the
+**same param names** — capture is the mirror of the existing restore, nothing new invented.
+
+## Context model (what is shareable)
+`{ client, screen, window, record }`, all read from live ADUI state:
+- `client` = `_currentClient` (system | gardenworld)
+- `screen` = `_currentScreen` (home | window | charts | more)
+- `window` = `_currentWindow.id` (only when screen=window)
+- `record` = pk of `_currentRecords[_currentRecordIdx]` via `_caseGet(rec, tab.tableName+'_ID')`
+
+## Changes
+1. **ad_ui.js** — add `getContext()` (returns the model) + `buildShareUrl()` (emits
+   `<origin><path>?client=&window=&record=` using the existing restore params). Expose both on `ADUI`.
+   §-log: `§AD_UI buildShareUrl <url>`.
+2. **erp_pills.js** — `share` fn → `ADUI.buildShareUrl()` → `navigator.share({url})` (mobile) /
+   `clipboard.writeText` + toast (desktop). §-log: `§SHARE url=<url>`.
+3. **erp.html** — fix a latent restore TIMING bug: the `?window/?record` deep-link ran *before*
+   `_waitAndHydrate` finished hydrating (openWindow would hit the not-ready guard). Move the
+   window/record restore INSIDE `_waitAndHydrate`, right after `ADUI.hydrate(db)` — so a shared link
+   restores reliably on a cold load.
+
+## Witness — `tests/poc_share_roundtrip.js` (real Chromium)
+- `§SHARE-CAPTURE` — open a window + land on its first record; `ADUI.getContext()` has
+  `window`+`record`; `buildShareUrl()` emits `?client=&window=&record=`.
+- `§SHARE-RESTORE` — open that URL in a FRESH page; after hydrate, `ADUI.getContext().window` ==
+  captured window and `.record` == captured record, `screen=window`. Round-trip is symmetric.
+- `§SHARE-ROUNDTRIP PASS` iff capture==restore. Proves the pill captures AND restores full context.

--- a/erp/erp.html
+++ b/erp/erp.html
@@ -75,14 +75,14 @@
 <div id="bottom-nav"></div>
 
 <!-- §INSTANT Phase 1: globe renders from initbubble.json in <300ms -->
-<script src="ad_graph.js?v=23"></script>
-<script src="ad_ui.js?v=23"></script>
+<script src="ad_graph.js?v=24"></script>
+<script src="ad_ui.js?v=24"></script>
 
 <!-- idempiereUI.md I1 — BIM pill bar, registry-driven from pills.json (the idempiere pill launches
      idempiere.html, renderer #1). icons.js = verbatim icon set; pill_builder.js used as-is. -->
-<script src="icons.js?v=23"></script>
-<script src="pill_builder.js?v=23"></script>
-<script src="erp_pills.js?v=23"></script>
+<script src="icons.js?v=24"></script>
+<script src="pill_builder.js?v=24"></script>
+<script src="erp_pills.js?v=24"></script>
 <script>
 // Phase 1: Instant constellation — fetch initbubble.json, then init
 var _shellReady = false;
@@ -91,12 +91,12 @@ var _shellReady = false;
   var _tBoot = performance.now();
 
   // Compiled manifest — structure for the 7 curated windows (parallel, non-blocking).
-  fetch('manifest.json?v=23').then(function(r) { return r.json(); }).then(function(mf) {
+  fetch('manifest.json?v=24').then(function(r) { return r.json(); }).then(function(mf) {
     window.AD_MANIFEST = mf;
     console.log('§BENCH manifest loaded windows=' + Object.keys(mf.windows || {}).length);
   }).catch(function(e) { console.log('§BENCH manifest fetch failed: ' + e.message); });
 
-  fetch('initbubble.json?v=23').then(function(r) { return r.json(); }).then(function(data) {
+  fetch('initbubble.json?v=24').then(function(r) { return r.json(); }).then(function(data) {
     window.INIT_BUBBLES = data;
 
     var params = new URLSearchParams(window.location.search);
@@ -156,7 +156,7 @@ var _shellReady = false;
     });
   }
 
-  var V = '?v=23';
+  var V = '?v=24';
   // Modules NOT loaded in Phase 1 (ad_graph.js + ad_ui.js already loaded)
   var MODULES = [
     'kernel_ops.js' + V,
@@ -319,27 +319,30 @@ var _shellReady = false;
     window.__erpDb = db;
 
     // ── Wait for Phase 1 shell, then hydrate silently ────────────────
+    // §SHARE restore — deep-link (?window/?record) MUST run AFTER hydrate (db ready), else openWindow
+    // hits the not-ready guard and the shared context silently fails to restore. (docs/ERP_SHARE_SPEC.md)
+    function _restoreDeepLink() {
+      var windowParam = params.get('window');
+      if (windowParam && typeof ADUI !== 'undefined') {
+        console.log('§ERP_HTML auto-open window=' + windowParam);
+        ADUI.openWindow(Number(windowParam));
+        var recordParam = params.get('record');
+        if (recordParam) {
+          console.log('§ERP_HTML auto-record=' + recordParam);
+          ADUI.navToRecord(recordParam);
+        }
+      }
+    }
     function _waitAndHydrate() {
       if (typeof _shellReady !== 'undefined' && _shellReady) {
         ADUI.hydrate(db);
+        _restoreDeepLink();   // db is ready now — restore the shared context
       } else {
         setTimeout(_waitAndHydrate, 50);
       }
     }
     if (typeof ADUI !== 'undefined') {
       _waitAndHydrate();
-    }
-
-    // §19 Deep links (now that DB is ready)
-    var windowParam = params.get('window');
-    if (windowParam && typeof ADUI !== 'undefined') {
-      console.log('§ERP_HTML auto-open window=' + windowParam);
-      ADUI.openWindow(Number(windowParam));
-      var recordParam = params.get('record');
-      if (recordParam) {
-        console.log('§ERP_HTML auto-record=' + recordParam);
-        ADUI.navToRecord(recordParam);
-      }
     }
 
     _bench.total_hydrate = Math.round(performance.now() - _tHydrate);

--- a/erp/erp_pills.js
+++ b/erp/erp_pills.js
@@ -51,10 +51,17 @@
       } catch (e) { _toast('Fullscreen not available'); }
     },
     share:     function () {
+      // §SHARE — capture full context (client/window/record) and share it; recipient restores via
+      // the same params erp.html reads on load. (docs/ERP_SHARE_SPEC.md)
+      var url = (window.ADUI && ADUI.buildShareUrl) ? ADUI.buildShareUrl() : location.href;
+      console.log('§SHARE url=' + url);
       try {
-        if (navigator.clipboard) { navigator.clipboard.writeText(location.href); _toast('Link copied'); }
-        else _toast('Share: ' + location.href);
-      } catch (e) { _toast('Share: ' + location.href); }
+        if (navigator.share) {
+          navigator.share({ title: 'ERP OOTB', text: 'ERP context', url: url }).catch(function () {});
+        } else if (navigator.clipboard) {
+          navigator.clipboard.writeText(url); _toast('Context link copied');
+        } else { _toast(url); }
+      } catch (e) { _toast(url); }
     },
     settings:  function () { _toast('Settings — JSON editor wires in a later task'); },
     verify:    function () {                                  // chain-integrity check — was a floating button, now a pill
@@ -82,7 +89,7 @@
   function mount() {
     if (!window.PillBuilder) { console.warn('§PILL-MANIFEST PillBuilder missing — not mounted'); return; }
 
-    fetch('pills.json?v=23').then(function (r) { return r.json(); }).then(function (mf) {
+    fetch('pills.json?v=24').then(function (r) { return r.json(); }).then(function (mf) {
       var pills = (mf.pills || []).slice().sort(function (a, b) { return (a.order || 0) - (b.order || 0); });
 
       var reusedBim = [], newErp = [];

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v567';
+const CACHE_VERSION = 'v568';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_share_roundtrip.js
+++ b/erp/tests/poc_share_roundtrip.js
@@ -1,0 +1,99 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that the Share pill CAPTURES and RESTORES full ERP context (erp.html).
+//   THE CLAIM (docs/ERP_SHARE_SPEC.md): the pill emits a URL with the SAME params erp.html restores on
+//   load (client/window/record), and a fresh load of that URL lands on the same window+record.
+//     1. §SHARE-CAPTURE — open a window holding records; ADUI.getContext() carries window+record;
+//        ADUI.buildShareUrl() emits ?client=&window=&record=.
+//     2. §SHARE-RESTORE — open that URL in a FRESH page; after hydrate, ADUI.getContext() restores the
+//        SAME window+record (screen=window). Symmetric round-trip → the recipient lands where the sender was.
+//   Issue it disproves: "the share pill copies a bare URL and the recipient lands on the home globe."
+//   §-log first — READ tests/poc_share_roundtrip.log before any conclusion.
+// Run:  node tests/poc_share_roundtrip.js 2>&1 | tee tests/poc_share_roundtrip.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/erp.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404'); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+function hydrateWaiter(page) {            // resolves when ADUI actually hydrates the DB (windows openable)
+  let done = false;
+  page.on('console', m => { if (m.text().includes('§AD_UI hydrate done')) done = true; });
+  return async () => {
+    for (let i = 0; i < 200 && !done; i++) await page.waitForTimeout(100);  // up to 20s
+    if (!done) throw new Error('hydrate-timeout');
+    await page.waitForFunction(() =>
+      window.AD_MANIFEST && window.AD_MANIFEST.windows &&
+      Object.keys(window.AD_MANIFEST.windows).length > 0, { timeout: 5000 });
+    await page.waitForTimeout(800);
+  };
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const base = `http://localhost:${port}/erp.html`;
+  const browser = await chromium.launch();
+
+  // ── Sender: open a window with records, capture the share URL ──
+  const sender = await browser.newPage();
+  const sErr = []; sender.on('pageerror', e => sErr.push(e.message));
+  const sHydrated = hydrateWaiter(sender);
+  await sender.goto(base, { waitUntil: 'networkidle' });
+  await sHydrated();
+
+  const capture = await sender.evaluate(() => {
+    const ids = Object.keys(window.AD_MANIFEST.windows);
+    // Prefer a window that has records (witnesses record-level too); else first window (window-level).
+    let firstId = null;
+    for (const id of ids) {
+      window.ADUI.openWindow(Number(id));
+      if (firstId === null) firstId = Number(id);
+      if (window.ADUI.getRecordCount() > 0) {
+        return { ok: true, level: 'record', id: Number(id), ctx: window.ADUI.getContext(),
+                 url: window.ADUI.buildShareUrl(), recCount: window.ADUI.getRecordCount() };
+      }
+    }
+    window.ADUI.openWindow(firstId);              // no business rows in this seed → window-level capture
+    return { ok: true, level: 'window', id: firstId, ctx: window.ADUI.getContext(),
+             url: window.ADUI.buildShareUrl(), recCount: 0 };
+  });
+  console.log('§SHARE-CAPTURE ' + JSON.stringify(capture));
+
+  // ── Recipient: open the captured URL fresh, assert context restores ──
+  let restore = { ok: false };
+  if (capture.ok) {
+    const url = capture.url.replace(/^https?:\/\/[^/]+\/[^?]*/, base);  // re-point origin to local server
+    const rcv = await browser.newPage();
+    const rErr = []; rcv.on('pageerror', e => rErr.push(e.message));
+    const rHydrated = hydrateWaiter(rcv);
+    await rcv.goto(url, { waitUntil: 'networkidle' });
+    await rHydrated();
+    await rcv.waitForTimeout(1500);               // let _restoreDeepLink run post-hydrate
+    restore = await rcv.evaluate(() => window.ADUI.getContext());
+    restore.pageErr = rErr.length;
+    console.log('§SHARE-RESTORE url=' + url + ' ctx=' + JSON.stringify(restore));
+    await rcv.screenshot({ path: path.join(__dirname, 'share_restore.png') });
+  }
+
+  const winOk = capture.ok && capture.ctx.window != null &&
+    String(restore.window) === String(capture.ctx.window) && restore.screen === 'window';
+  // record asserted ONLY if the seed carried a record to capture (non-invent — this seed is metadata-only)
+  const recOk = capture.ctx && capture.ctx.record == null
+    ? true
+    : String(restore.record) === String(capture.ctx.record);
+  const clientOk = String(restore.client) === String(capture.ctx.client);
+  const pass = winOk && recOk && clientOk && (restore.pageErr || 0) === 0 && sErr.length === 0;
+  console.log('§SHARE-ROUNDTRIP ' + (pass ? 'PASS' : 'FAIL') + ' level=' + capture.level +
+    ' captured(client=' + capture.ctx.client + ',win=' + capture.ctx.window + ',rec=' + (capture.ctx.record != null ? capture.ctx.record : 'none-in-seed') + ')' +
+    ' restored(client=' + restore.client + ',win=' + restore.window + ',rec=' + (restore.record != null ? restore.record : '-') + ')');
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
## §OUTSTANDING — "Share icon in the pill: capture AND restore full context"

The share pill copied a bare `location.href` → recipient landed on the home globe. Now it captures the live context as the **same deep-link params erp.html already restores on load** (`client`/`window`/`record`) — capture mirrors restore, non-invent.

- `ad_ui.js`: `+getContext()` `+buildShareUrl()` (emits `?client=&window=&record=`), exposed on `ADUI`.
- `erp_pills.js`: `share` fn → `ADUI.buildShareUrl()` → `navigator.share` (mobile) / clipboard+toast (desktop).
- `erp.html`: fixed a latent restore **timing bug** — `?window/?record` deep-link ran before hydrate (openWindow hit the not-ready guard); moved restore inside `_waitAndHydrate` after `ADUI.hydrate(db)`.
- SW `v567→v568`, `?v=23→24`. Spec `docs/ERP_SHARE_SPEC.md`.

## Witness (real Chromium)
`tests/poc_share_roundtrip.js` → **§SHARE-ROUNDTRIP PASS** — sender opens window 123 (Business Partner), `buildShareUrl` emits `?client=gardenworld&window=123`; a fresh load of that URL restores the same window (`screen=window`), 0 pageerror (+ `share_restore.png`). Record-level path wired via `navToRecord`; seed is metadata-only so no business row to witness (honest).

Scope: `erp/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)