### PR TITLE
feat(erp-kanban): durable drag — persist + restore op-log on reload (gap #2)

### DIFF
--- a/erp/kanban_lens.html
+++ b/erp/kanban_lens.html
@@ -58,23 +58,39 @@
   // status-grouped fold over the resident DataSource. PER-ROW (real doc ids) so each card is a REAL
   // document a drag can SET_STATUS — not a count placeholder. Pure read; no write here. (§KANBAN-FOLD)
   var TMAP = { c_invoice: 'C_Invoice', c_order: 'C_Order', c_payment: 'C_Payment' };
-  function foldDocStatus(db) {
-    var folds = [], CAP = 30;   // cap cards/(table,status) so the board stays legible (logged, not silent)
+  // read-the-tip: latest persisted status per doc from the projection's `documents` table (id='DOC:table#id').
+  // gap #2 — a reloaded board shows the op-log result, not the stale bundle status; absent ⇒ bundle (honest).
+  function tipStatus(projDb) {
+    var tip = {};
+    try {
+      var r = projDb && projDb.exec("SELECT id, doc_status FROM documents");
+      if (r && r.length) r[0].values.forEach(function (row) { tip[row[0]] = row[1]; });
+    } catch (e) { /* no documents yet */ }
+    return tip;
+  }
+  function foldDocStatus(db, projDb) {
+    var folds = [], CAP = 30, tip = tipStatus(projDb), overlaid = 0;
     Object.keys(TMAP).forEach(function (tb) {
       try {
-        var pk = tb + '_id';
+        var T = TMAP[tb], pk = tb + '_id';
         var r = db.exec("SELECT " + pk + " AS id, docstatus FROM " + tb + " WHERE docstatus IS NOT NULL");
         if (!r.length) return;
         var byS = {};
-        r[0].values.forEach(function (row) { var s = row[1]; (byS[s] = byS[s] || []).push(row[0]); });
+        r[0].values.forEach(function (row) {
+          var id = row[0], s = row[1];
+          var t = tip['DOC:' + T + '#' + id];               // op-log tip wins over the bundle status
+          if (t && t !== s) { s = t; overlaid++; }
+          (byS[s] = byS[s] || []).push(id);
+        });
         Object.keys(byS).forEach(function (s) {
           var ids = byS[s], capped = ids.slice(0, CAP);
-          if (ids.length > CAP) log('fold cap ' + TMAP[tb] + '/' + s + ' ' + ids.length + '->' + CAP);
-          folds.push({ table: TMAP[tb], doc_status: s, count: ids.length, ids: capped });
+          if (ids.length > CAP) log('fold cap ' + T + '/' + s + ' ' + ids.length + '->' + CAP);
+          folds.push({ table: T, doc_status: s, count: ids.length, ids: capped });
         });
       } catch (e) { log('fold skip ' + tb + ': ' + e.message); }
     });
-    log('foldDocStatus folds=' + folds.length + ' cards=' + folds.reduce(function (a, f) { return a + f.ids.length; }, 0));
+    log('foldDocStatus folds=' + folds.length + ' cards=' + folds.reduce(function (a, f) { return a + f.ids.length; }, 0) +
+      ' tipOverlaid=' + overlaid);
     return folds;
   }
 
@@ -102,7 +118,7 @@
     // ── STEP-0: publish window.ERP (the seam) — drag→dispatch becomes a REAL signed SET_STATUS. ──
     await publishERP(SQL, db, wfmc);
 
-    var folds = foldDocStatus(db);
+    var folds = foldDocStatus(db, window.__kanbanProj);   // overlay the op-log tip (gap #2 persistence)
     // showEmptyStates: render ALL wfmc stages as columns (Odoo-style pipeline) so a drag to ANY legal
     // target stage has a column to land in — else _moveCardDom can't place the card (col absent).
     var board = KanbanLens.buildBoard(folds, wfmc, { showEmptyStates: true });
@@ -121,6 +137,13 @@
           var v = window.ERP.verify();
           console.log('§KANBAN-WRITE ok action=' + res.action + ' ' + res.table + '#' + res.id +
             ' to=' + dr.to + ' op=' + (dr.op_uuid || '-') + ' chainOk=' + v.chainOk + ' len=' + v.len);
+          // gap #2 — persist the op-LOG blob so the edit survives reload (boot restores + reads-the-tip).
+          try {
+            var buf = window.__kanbanProj.export().buffer;
+            idbPutBlob('bim_ootb_cache', 'dbs', 'kanban_proj', buf).then(function () {
+              console.log('§KANBAN-PERSIST saved bytes=' + buf.byteLength);
+            }).catch(function (e) { console.log('§KANBAN-PERSIST err ' + e.message); });
+          } catch (e) { console.log('§KANBAN-PERSIST export err ' + e.message); }
         } else if (dr && dr.rejected) {
           console.log('§KANBAN-WRITE rejected why=' + dr.why);
         }
@@ -129,6 +152,40 @@
   }
 
   function _rows(res) { if (!res.length) return []; return res[0].values.map(function (v) { var o = {}; res[0].columns.forEach(function (c, i) { o[c] = v[i]; }); return o; }); }
+
+  function idbGetBlob(dbName, store, key) {
+    return new Promise(function (resolve) {
+      try {
+        var rq = indexedDB.open(dbName, 1);
+        rq.onupgradeneeded = function () { try { rq.result.createObjectStore(store); } catch (e) {} };
+        rq.onsuccess = function () {
+          var db = rq.result;
+          if (!db.objectStoreNames.contains(store)) { db.close(); return resolve(null); }
+          var tx = db.transaction(store, 'readonly'); var g = tx.objectStore(store).get(key);
+          g.onsuccess = function () { db.close(); resolve(g.result || null); };
+          g.onerror = function () { db.close(); resolve(null); };
+        };
+        rq.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  }
+
+  function idbPutBlob(dbName, store, key, buf) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var rq = indexedDB.open(dbName, 1);
+        rq.onupgradeneeded = function () { try { rq.result.createObjectStore(store); } catch (e) {} };
+        rq.onsuccess = function () {
+          var db = rq.result;
+          if (!db.objectStoreNames.contains(store)) { db.close(); return reject(new Error('no store')); }
+          var tx = db.transaction(store, 'readwrite'); tx.objectStore(store).put(buf, key);
+          tx.oncomplete = function () { db.close(); resolve(true); };
+          tx.onerror = function () { db.close(); reject(tx.error || new Error('put failed')); };
+        };
+        rq.onerror = function () { reject(rq.error || new Error('open failed')); };
+      } catch (e) { reject(e); }
+    });
+  }
 
   // publishERP — mirror spike_writepath.html: projection + real signer + makeSeam + role-gated ctx → window.ERP.
   // The lens NEVER forks a verb; it consumes this seam. Role grants exactly the (table:action) edges in wfmc.
@@ -142,7 +199,18 @@
       var adQ = adDb ? function (s, p) { return _rows(adDb.exec(s, p || [])); } : function () { return []; };
       var gbQ = function (s, p) { return _rows(gbDb.exec(s, p || [])); };
 
-      var projDb = new SQL.Database(); K.initProjection(projDb);
+      // gap #2 — DURABILITY: persist the signed op-LOG and replay on boot (write-path spine: persist the
+      // log, never the edited projection). Restore the prior projection blob from IDB; set APP.DB_URL so
+      // kernel_ops._persistToIdb writes (it no-ops on unset DB_URL). The board then reads-the-tip (documents).
+      var PROJ_KEY = 'kanban_proj';
+      var prior = await idbGetBlob('bim_ootb_cache', 'dbs', PROJ_KEY);
+      var projDb;
+      if (prior && prior.byteLength > 100) {
+        try { projDb = new SQL.Database(new Uint8Array(prior)); log('§KANBAN-RESTORE ops from IDB bytes=' + prior.byteLength); }
+        catch (e) { projDb = new SQL.Database(); K.initProjection(projDb); log('§KANBAN-RESTORE failed, fresh: ' + e.message); }
+      } else { projDb = new SQL.Database(); K.initProjection(projDb); }
+      window.APP = window.APP || {}; window.APP.DB_URL = PROJ_KEY;   // unlock _persistToIdb (gap #2)
+      window.__kanbanProj = projDb;                                  // exposed for the fold overlay + witness
       try { await window.ErpSigner.installSigner(window.KernelOps, { dbName: 'bim_erp_signer' }); }
       catch (e) { log('§SIGN skip ' + e.message); }
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v569';
+const CACHE_VERSION = 'v570';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_kanban_persist.js
+++ b/erp/tests/poc_kanban_persist.js
@@ -1,0 +1,75 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that a kanban drag SURVIVES RELOAD (gap #2 — durability).
+//   THE CLAIM (write-path spine: persist the op-LOG, replay on boot, read-the-tip): a drag commits a signed
+//   op AND persists the projection to IDB; a fresh page load restores it and the board shows the edit — not the
+//   stale bundle status. Proves writes are durable, not in-memory-only.
+//     1. §KANBAN-WRITE — drag commits (as poc_kanban_write proves) + §KANBAN-PERSIST saves the blob to IDB.
+//     2. §KANBAN-RESTORE — RELOAD (same origin/context → IDB persists) restores the op-log; foldDocStatus
+//        overlays the tip (tipOverlaid>=1) and the dragged card appears in its NEW column with NO re-drag.
+//   NON-INVENT: same real doc, real wfmc edge; the post-reload status comes from the persisted op-log, nowhere else.
+//   §-log first — READ poc_kanban_persist.log before any conclusion.
+// Run:  node tests/poc_kanban_persist.js 2>&1 | tee tests/poc_kanban_persist.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.wasm':'application/wasm', '.css':'text/css' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/kanban_lens.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+const ready = (page) => page.waitForFunction(() => window.__kanban && window.ERP && window.ERP.dispatch, { timeout: 20000 });
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const url = `http://localhost:${port}/kanban_lens.html`;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const context = await browser.newContext();   // ONE context → IDB persists across the reload
+  const page = await context.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // ── session 1: drag a real card to a legal stage, persist ──
+  await page.goto(url, { waitUntil: 'networkidle' }); await ready(page).catch(() => {});
+  const pick = await page.evaluate(() => {
+    const b = window.__kanban.board;
+    for (const c of b.cards) { const z = b.dropZones[c.status] || []; if (z.length) return { key: c.key, table: c.table, id: c.id, from: c.status, to: z[0].toStatus }; }
+    return null;
+  });
+  console.log('§KANBAN-PICK ' + JSON.stringify(pick));
+  if (pick) await page.evaluate((pk) => window.__kanban._onDrop(pk.key, pk.to), pick);
+  // wait for the persist to land in IDB
+  await page.waitForFunction(() => window.__persistDone === true || true, { timeout: 1000 }).catch(() => {});
+  await page.waitForTimeout(800);
+  const persistLog = logs.find(l => l.includes('§KANBAN-PERSIST saved')) || '(no persist)';
+  console.log('§KANBAN-PERSIST ' + persistLog);
+
+  // ── session 2: RELOAD (same context → IDB survives) — the edit must come back with NO drag ──
+  logs.length = 0;
+  await page.reload({ waitUntil: 'networkidle' }); await ready(page).catch(() => {});
+  await page.waitForTimeout(500);
+  const restoreLog = logs.find(l => l.includes('§KANBAN-RESTORE')) || '(no restore)';
+  const foldLog = logs.find(l => l.includes('foldDocStatus')) || '(no fold)';
+  const afterReload = await page.evaluate((pk) => {
+    const card = window.__kanban.board.cards.find(c => c.key === pk.key);
+    const col = document.querySelector('.kanban-col[data-status="' + pk.to + '"]');
+    const inTargetCol = !!(col && Array.from(col.querySelectorAll('.kanban-card')).some(el => el.dataset.key === pk.key));
+    return { status: card ? card.status : null, inTargetCol: inTargetCol };
+  }, pick);
+  console.log('§KANBAN-RESTORE ' + restoreLog);
+  console.log('  ' + foldLog);
+  console.log('§KANBAN-PERSIST-CHECK card=' + pick.key + ' expected=' + pick.to + ' afterReloadStatus=' + afterReload.status + ' inTargetCol=' + afterReload.inTargetCol);
+
+  await page.screenshot({ path: path.join(__dirname, 'kanban_persist.png') });
+
+  const pass = !!pick && /saved bytes=/.test(persistLog) && /§KANBAN-RESTORE ops from IDB/.test(restoreLog) &&
+    /tipOverlaid=[1-9]/.test(foldLog) && afterReload.status === pick.to && afterReload.inTargetCol === true && errs.length === 0;
+  console.log('§KANBAN-PERSIST-RESULT ' + (pass ? 'PASS' : 'FAIL') + ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
Kanban drag committed only in-memory → reload lost it. Now `kanban_lens.html` persists the projection op-log to IDB after each ok dispatch and restores it on boot, with `foldDocStatus` overlaying the `documents` tip (read-the-tip). A drag now survives a full reload. Witness `tests/poc_kanban_persist.js` → **§KANBAN-PERSIST-RESULT PASS** (C_Invoice#109 CO→VO persists 53KB, reload restores it to VO, tipOverlaid=1, no re-drag). sw v570. Scope: erp/ only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)