### PR TITLE
feat(erp-kanban): real draggable+durable Kanban in idempiere.html (gap c)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -274,6 +274,13 @@
 <script src="accts_posted.js?v=23"></script>
 <!-- §0.10a — first-mile Migrate ShowMe (launched from the login card). -->
 <script src="migrate_showme.js?v=22"></script>
+<!-- Kanban write path — engine seam (window.ERP) + the lens chrome + the reusable host (publish/persist). -->
+<script src="kernel_ops.js?v=1"></script>
+<script src="erp_signer.js?v=1"></script>
+<script src="erp_kernel.js?v=1"></script>
+<script src="erp_seam.js?v=1"></script>
+<script src="kanban_lens.js?v=2"></script>
+<script src="kanban_host.js?v=1"></script>
 <script>
 (function () {
   'use strict';
@@ -337,6 +344,7 @@
     var SQL;
     try { SQL = await initSqlJs({ locateFile: function () { return 'lib/sql-wasm-fts5.wasm'; } }); }
     catch (e) { SQL = await initSqlJs({ locateFile: function () { return 'https://cdn.jsdelivr.net/npm/sql.js-fts5@1.4.0/dist/sql-wasm.wasm'; } }); }
+    window.SQL = SQL;   // exposed for the Kanban host (KanbanHost.publish needs a SQL.Database factory)
 
     // ?seed=<file>.db loads a generated AD-gen seed (scripts/gen_ad.js) — bypasses the idb cache so it
     // never clobbers the real ad_seed.db cache and always loads fresh (§AD-RENDER). Default = ad_seed.db.
@@ -835,15 +843,53 @@
       b.style.width = Math.round(n / max * 100) + '%'; bw.appendChild(b); row.appendChild(bw); wrap.appendChild(row); });
     _overlay('Graph', wrap); console.log('§GRAPH-PILL by=' + gr.col.columnName + ' groups=' + keys.length + ' table=' + gr.tab.tableName);
   }
-  function openKanbanFor() {
+  // Kanban write-path host state (gap c) — lazy: publish window.ERP once, then mount the REAL draggable board.
+  var _kanbanWfmc = null, _kanbanProj = null, _KPROJ = 'idmp_kanban_proj';
+  var KDOC_TABLES = ['C_Order', 'C_Invoice', 'C_Payment', 'M_InOut'];   // doc tables with a docstatus lifecycle
+  async function _ensureKanbanERP() {
+    if (window.ERP && _kanbanProj) return true;
+    if (!window.KanbanHost || !window.SQL) { return false; }
+    if (!_kanbanWfmc) {
+      try { _kanbanWfmc = (await (await fetch('manifest.json?v=22')).json()).wfmc || {}; }
+      catch (e) { status('Kanban: wfmc load failed'); return false; }
+    }
+    var allowOrgs = (_session.orgs && _session.orgs.length) ? _session.orgs.map(function (o) { return o.id; }) : '*';
+    var pub = await window.KanbanHost.publish({ SQL: window.SQL, adDb: db, gbDb: db, wfmc: _kanbanWfmc,
+      tables: KDOC_TABLES, roleId: _session.role && _session.role.id, allowOrgs: allowOrgs, projKey: _KPROJ });
+    if (!pub) return false;
+    _kanbanProj = pub.projDb; return true;
+  }
+  async function openKanbanFor() {
     if (!_session) { status('Log in first'); return; }
     var gr = _groupRecs(); if (!gr) { status('Open a window with records first'); return; }
-    var board = el('div', 'kb-board');
-    Object.keys(gr.groups).forEach(function (k) { var col = el('div', 'kb-col');
-      col.appendChild(el('div', 'kb-colhd', k + ' · ' + gr.groups[k].length));
-      gr.groups[k].slice(0, 25).forEach(function (r) { col.appendChild(el('div', 'kb-card', String(recVal(r, _keyCol(gr.tab))))); });
-      board.appendChild(col); });
-    _overlay('Kanban — ' + gr.tab.name, board); console.log('§KANBAN-PILL cols=' + Object.keys(gr.groups).length + ' table=' + gr.tab.tableName);
+    var ok = await _ensureKanbanERP();
+    var tab = gr.tab, T = tab.tableName, kc = _keyCol(tab), statusCol = gr.col.columnName;
+    if (!ok || !window.KanbanLens) {   // engine/lens absent → honest fall back to the read-only board
+      var rb = el('div', 'kb-board');
+      Object.keys(gr.groups).forEach(function (k) { var c = el('div', 'kb-col'); c.appendChild(el('div', 'kb-colhd', k + ' · ' + gr.groups[k].length));
+        gr.groups[k].slice(0, 25).forEach(function (r) { c.appendChild(el('div', 'kb-card', String(recVal(r, kc)))); }); rb.appendChild(c); });
+      _overlay('Kanban — ' + tab.name + ' (read-only)', rb); console.log('§KANBAN-PILL readonly cols=' + Object.keys(gr.groups).length + ' table=' + T); return;
+    }
+    // fold the OPEN window's records PER-ROW by RAW docstatus (codes, not labels), overlaying the op-log tip.
+    var tip = window.KanbanHost.tip(_kanbanProj), byS = {};
+    _records.forEach(function (r) {
+      var id = recVal(r, kc), s = String(recVal(r, statusCol) || '');
+      var t = tip['DOC:' + T + '#' + id]; if (t) s = t;
+      (byS[s] = byS[s] || []).push(id);
+    });
+    var folds = Object.keys(byS).map(function (s) { return { table: T, doc_status: s, count: byS[s].length, ids: byS[s].slice(0, 30) }; });
+    var board = window.KanbanLens.buildBoard(folds, _kanbanWfmc, { showEmptyStates: true });
+    var root = el('div'); root.style.cssText = 'overflow:auto;max-height:78vh';
+    _overlay('Kanban — ' + tab.name, root);
+    window.__idmpKanban = window.KanbanLens.mount({ root: root, board: board, wfmc: _kanbanWfmc,
+      dispatch: window.ERP.dispatch, ctx: window.ERP.ctx,
+      onResult: function (res, dr) {
+        if (dr && dr.ok) { var v = window.ERP.verify();
+          console.log('§KANBAN-WRITE ok ' + res.table + '#' + res.id + ' to=' + dr.to + ' chainOk=' + v.chainOk + ' len=' + v.len);
+          window.KanbanHost.persist(_kanbanProj, _KPROJ);
+        } else if (dr && dr.rejected) { console.log('§KANBAN-WRITE rejected why=' + dr.why); }
+      } });
+    console.log('§KANBAN-PILL live cols=' + board.columns.length + ' cards=' + board.cards.length + ' table=' + T);
   }
   function openInstallFor() { status('Install: pull the full DB to this device, or pair via QR to your machine — POC'); console.log('§INSTALL-PILL action=install-stub'); }
   function openMigrateFor() { status('Migrate: run the local extractor on your machine, mirror here (QR pairing) — POC'); console.log('§MIGRATE-PILL action=migrate-stub'); }

--- a/erp/kanban_host.js
+++ b/erp/kanban_host.js
@@ -1,0 +1,102 @@
+/**
+ * BIM OOTB — ERP. Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
+ *
+ * kanban_host.js — the reusable HOST boot for the Kanban lens: publishes window.ERP (the ENGINE_CONTRACT §1
+ * seam) so a drag commits a REAL signed SET_STATUS, and gives durability (persist the op-LOG to IDB, restore
+ * + read-the-tip on boot). Same proven path as spike_writepath.html — consume the seam, NEVER fork a verb.
+ * Pages supply their own per-page fold (bundle tables vs the open window's records); the host owns the
+ * engine + persistence so kanban_lens.html and idempiere.html share ONE write path. (window.KanbanHost)
+ */
+(function (global) {
+  'use strict';
+  function log(m) { console.log('§KANBAN_HOST ' + m); }
+
+  function _rows(res) { if (!res.length) return []; return res[0].values.map(function (v) { var o = {}; res[0].columns.forEach(function (c, i) { o[c] = v[i]; }); return o; }); }
+
+  function idbGetBlob(dbName, store, key) {
+    return new Promise(function (resolve) {
+      try {
+        var rq = indexedDB.open(dbName, 1);
+        rq.onupgradeneeded = function () { try { rq.result.createObjectStore(store); } catch (e) {} };
+        rq.onsuccess = function () {
+          var db = rq.result;
+          if (!db.objectStoreNames.contains(store)) { db.close(); return resolve(null); }
+          var g = db.transaction(store, 'readonly').objectStore(store).get(key);
+          g.onsuccess = function () { db.close(); resolve(g.result || null); };
+          g.onerror = function () { db.close(); resolve(null); };
+        };
+        rq.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  }
+  function idbPutBlob(dbName, store, key, buf) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var rq = indexedDB.open(dbName, 1);
+        rq.onupgradeneeded = function () { try { rq.result.createObjectStore(store); } catch (e) {} };
+        rq.onsuccess = function () {
+          var db = rq.result;
+          if (!db.objectStoreNames.contains(store)) { db.close(); return reject(new Error('no store')); }
+          var tx = db.transaction(store, 'readwrite'); tx.objectStore(store).put(buf, key);
+          tx.oncomplete = function () { db.close(); resolve(true); };
+          tx.onerror = function () { db.close(); reject(tx.error || new Error('put failed')); };
+        };
+        rq.onerror = function () { reject(rq.error || new Error('open failed')); };
+      } catch (e) { reject(e); }
+    });
+  }
+  var IDB = 'bim_ootb_cache', STORE = 'dbs';
+
+  // publish(cfg) → { projDb, ctx } and sets window.ERP={dispatch,read,verify}.
+  // cfg: { SQL, adDb?, gbDb?, wfmc, tables:[AD names], roleId, allowOrgs, projKey }
+  async function publish(cfg) {
+    var K = global.ERPKernel, Seam = global.ERPSeam;
+    if (!K || !Seam) { log('§SEAM-LIVE skip — engine modules absent'); return null; }
+    var adQ = cfg.adDb ? function (s, p) { return _rows(cfg.adDb.exec(s, p || [])); } : function () { return []; };
+    var gbQ = cfg.gbDb ? function (s, p) { return _rows(cfg.gbDb.exec(s, p || [])); } : function () { return []; };
+
+    // gap #2 — restore the prior op-LOG blob (persist the log, replay on boot; never the edited projection).
+    var prior = await idbGetBlob(IDB, STORE, cfg.projKey);
+    var projDb;
+    if (prior && prior.byteLength > 100) {
+      try { projDb = new cfg.SQL.Database(new Uint8Array(prior)); log('§KANBAN-RESTORE ops from IDB bytes=' + prior.byteLength + ' key=' + cfg.projKey); }
+      catch (e) { projDb = new cfg.SQL.Database(); K.initProjection(projDb); log('§KANBAN-RESTORE failed, fresh: ' + e.message); }
+    } else { projDb = new cfg.SQL.Database(); K.initProjection(projDb); }
+
+    try { await global.ErpSigner.installSigner(global.KernelOps, { dbName: 'bim_erp_signer' }); }
+    catch (e) { log('§SIGN skip ' + e.message); }
+
+    var actions = {}; (cfg.wfmc.transitions || []).forEach(function (t) { actions[t[1]] = 1; });
+    var grants = [];
+    (cfg.tables || []).forEach(function (T) {
+      Object.keys(actions).forEach(function (a) {
+        K.register(T, a, function (doc, c) { return [{ op_type: 'SET_STATUS', table: doc.table, id: doc.id, doc_status: c.to, uuid: doc.uuid }]; });
+        grants.push(T + ':' + a);
+      });
+    });
+
+    var seam = Seam.makeSeam({ projDb: projDb, adQ: adQ, factQ: gbQ, wfmc: cfg.wfmc, newDb: function () { return new cfg.SQL.Database(); } });
+    var ctx = { actor: 'device:' + (localStorage.kanbanActor || (localStorage.kanbanActor = 'k' + Math.floor(performance.now()))),
+      pubKey: (global.ErpSigner && global.ErpSigner.pubKeyHex) || null, roleId: cfg.roleId || null,
+      role: { id: cfg.roleId || null, actions: grants }, allowOrgs: (cfg.allowOrgs && cfg.allowOrgs.length) ? cfg.allowOrgs : '*' };
+    global.ERP = { dispatch: seam.dispatch, ctx: ctx, read: seam.read, verify: seam.verify };
+    log('§SEAM-LIVE window.ERP published: dispatch,verify · actor=' + ctx.actor + ' grants=' + grants.length + ' pubKey=' + (ctx.pubKey ? 'Y' : 'none'));
+    return { projDb: projDb, ctx: ctx };
+  }
+
+  // tip(projDb) → { 'DOC:Table#id': status } — the read-the-tip overlay from the projection's documents table.
+  function tip(projDb) {
+    var t = {};
+    try { var r = projDb && projDb.exec("SELECT id, doc_status FROM documents"); if (r && r.length) r[0].values.forEach(function (row) { t[row[0]] = row[1]; }); }
+    catch (e) {}
+    return t;
+  }
+  // persist(projDb, projKey) — store the op-LOG blob so the edit survives reload (the seam's erp_kernel path
+  // writes directly, bypassing KernelOps._persistToIdb, so the host persists explicitly after each ok dispatch).
+  function persist(projDb, projKey) {
+    try { var buf = projDb.export().buffer; return idbPutBlob(IDB, STORE, projKey, buf).then(function () { log('§KANBAN-PERSIST saved bytes=' + buf.byteLength + ' key=' + projKey); return true; }); }
+    catch (e) { log('§KANBAN-PERSIST err ' + e.message); return Promise.resolve(false); }
+  }
+
+  global.KanbanHost = { publish: publish, tip: tip, persist: persist, _rows: _rows };
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v570';
+const CACHE_VERSION = 'v571';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -49,6 +49,8 @@ const PRECACHE_ASSETS = [
   'kernel_ops.js',     // shared infra — dedupe to common/ later (ERP_FOLDER_HOME.md)
   'erp_kernel.js',     // engine (window.ERPKernel) — kanban_lens.html publishes window.ERP via the seam
   'erp_seam.js',       // engine seam (window.ERPSeam.makeSeam) — ENGINE_CONTRACT §1 write path
+  'kanban_lens.js',    // Kanban board chrome (buildBoard/resolveDrag/mount) — lens + idempiere
+  'kanban_host.js',    // reusable Kanban host: publish window.ERP + persist/restore the op-log
   'qrcode.min.js',
   'manifest.json',
   'pills.json',

--- a/erp/tests/poc_idmp_kanban.js
+++ b/erp/tests/poc_idmp_kanban.js
@@ -1,0 +1,86 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that idempiere.html's Kanban pill mounts the REAL draggable board and a
+//   drag commits a signed SET_STATUS (gap c — the main renderer, not the standalone lens).
+//   THE CLAIM: openKanbanFor now publishes window.ERP (KanbanHost, ctx from the login _session) and mounts
+//   KanbanLens over the OPEN window's records (per-row docstatus fold), instead of the old display-only board.
+//     1. §SEAM-LIVE — window.ERP published after the Kanban pill opens (engine boot via _session).
+//     2. §KANBAN-PILL live — KanbanLens board mounts with real cards from the open Invoice window (8 CO docs).
+//     3. §KANBAN-WRITE — a legal drag commits a signed op (chainOk=Y); card moves.
+//   NON-INVENT: real ad_seed.db invoices (8×CO), real wfmc edge, the same seam the lens witnesses prove.
+//   §-log first — READ poc_idmp_kanban.log before any conclusion.
+// Run:  node tests/poc_idmp_kanban.js 2>&1 | tee tests/poc_idmp_kanban.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.wasm':'application/wasm', '.css':'text/css', '.png':'image/png' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // Invoice window (8 CO docs in ad_seed.db); ?window opens AFTER login.
+  await page.goto(`http://localhost:${port}/idempiere.html?window=167`, { waitUntil: 'networkidle' });
+
+  // ── login: pick the first enabled user → submit (defaults) ──
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)', { timeout: 15000 });
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok', { timeout: 5000 });
+  await page.click('#idmp-login-ok');
+
+  // ── wait for the deep-linked window to open + records to render ──
+  await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(1200);
+
+  // ── click the Kanban pill ──
+  await page.waitForSelector('.idmp-pill[title="Kanban"]', { timeout: 8000 });
+  await page.click('.idmp-pill[title="Kanban"]');
+  await page.waitForFunction(() => window.__idmpKanban && window.ERP && window.ERP.dispatch, { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(600);
+
+  const seam = logs.find(l => l.includes('§SEAM-LIVE')) || '(no §SEAM-LIVE)';
+  const pillLog = logs.find(l => l.includes('§KANBAN-PILL')) || '(no pill log)';
+  const mounted = await page.evaluate(() => {
+    const b = window.__idmpKanban && window.__idmpKanban.board;
+    return b ? { cols: b.columns.length, cards: b.cards.length } : null;
+  });
+  console.log('§SEAM-LIVE ' + seam);
+  console.log('§KANBAN-PILL ' + pillLog + ' :: board=' + JSON.stringify(mounted));
+
+  // ── drive a legal drag (real doc + real wfmc edge) ──
+  let drag = { moved: false };
+  if (mounted && mounted.cards) {
+    drag = await page.evaluate(() => {
+      const b = window.__idmpKanban.board;
+      for (const c of b.cards) { const z = b.dropZones[c.status] || []; if (z.length) {
+        const before = window.ERP.verify().len;
+        window.__idmpKanban._onDrop(c.key, z[0].toStatus);
+        return { key: c.key, to: z[0].toStatus, status: (b.cards.find(x => x.key === c.key) || {}).status,
+                 before: before, after: window.ERP.verify().len, chainOk: window.ERP.verify().chainOk }; } }
+      return { moved: false, note: 'no legal edge among cards' };
+    });
+  }
+  const writeLog = logs.find(l => l.includes('§KANBAN-WRITE ok')) || '(none)';
+  console.log('§KANBAN-WRITE ' + JSON.stringify(drag));
+  console.log('  ' + writeLog);
+
+  await page.screenshot({ path: path.join(__dirname, 'idmp_kanban.png') });
+
+  const pass = !!mounted && mounted.cards > 0 && /window.ERP published/.test(seam) &&
+    drag && drag.status === drag.to && drag.chainOk === true && drag.after === drag.before + 1 && errs.length === 0;
+  console.log('§IDMP-KANBAN-RESULT ' + (pass ? 'PASS' : 'FAIL') + ' pageErrors=' + (errs.length ? errs.slice(0,2).join('|') : 0));
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
idempiere.html's Kanban pill was display-only. Now it mounts the real `KanbanLens` board over the open window's records and a drag commits a **signed SET_STATUS** via `window.ERP` (built from the login `_session`), factored into a shared **kanban_host.js**. Read-only fallback if the engine is absent. Witness `tests/poc_idmp_kanban.js` → **§IDMP-KANBAN-RESULT PASS** (login → Invoice window → Kanban → §SEAM-LIVE, board 11 cols/4 real cards → drag C_Invoice#100 CO→VO, chainOk=Y). sw v571. Scope: erp/ only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)