### PR TITLE
feat(erp-kanban): one-tap Graph ⇆ Kanban switch (launch board from the graph icon)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -833,11 +833,21 @@
     var g = {}; _records.forEach(function (r) { var v = String(fmt(pick, recVal(r, pick.columnName)) || '(blank)'); (g[v] = g[v] || []).push(r); });
     return { col: pick, label: pick.name, groups: g, tab: tab };
   }
+  // one-tap switch between the two lenses of the SAME data (Graph bars ⇆ Kanban board) — proper UX:
+  // the graph icon's view launches the interactive board, and the board switches back to the chart.
+  function _viewSwitch(label, fn) {
+    var bar = el('div'); bar.style.cssText = 'display:flex;gap:8px;margin:0 0 12px;';
+    var b = el('button', null, label);
+    b.style.cssText = 'background:#1f6feb;color:#fff;border:none;border-radius:7px;padding:7px 13px;font-size:13px;font-weight:600;cursor:pointer';
+    b.addEventListener('click', fn); bar.appendChild(b); return bar;
+  }
   function openGraphFor() {
     if (!_session) { status('Log in first'); return; }
     var gr = _groupRecs(); if (!gr) { status('Open a window with records first'); return; }
     var keys = Object.keys(gr.groups), max = 1; keys.forEach(function (k) { max = Math.max(max, gr.groups[k].length); });
-    var wrap = el('div', 'chart-wrap'); wrap.appendChild(el('div', 'chart-title', 'By ' + gr.label + ' — ' + gr.tab.name + ' (' + _records.length + ' rows)'));
+    var wrap = el('div', 'chart-wrap');
+    wrap.appendChild(_viewSwitch('🗂 View as Kanban', openKanbanFor));   // 🗂 launch the board from the graph
+    wrap.appendChild(el('div', 'chart-title', 'By ' + gr.label + ' — ' + gr.tab.name + ' (' + _records.length + ' rows)'));
     keys.forEach(function (k) { var n = gr.groups[k].length, row = el('div', 'chart-row');
       row.appendChild(el('span', 'chart-lbl', k)); var bw = el('div', 'chart-barw'), b = el('div', 'chart-bar', String(n));
       b.style.width = Math.round(n / max * 100) + '%'; bw.appendChild(b); row.appendChild(bw); wrap.appendChild(row); });
@@ -865,10 +875,11 @@
     var ok = await _ensureKanbanERP();
     var tab = gr.tab, T = tab.tableName, kc = _keyCol(tab), statusCol = gr.col.columnName;
     if (!ok || !window.KanbanLens) {   // engine/lens absent → honest fall back to the read-only board
-      var rb = el('div', 'kb-board');
+      var rbc = el('div'); rbc.appendChild(_viewSwitch('📊 View as Graph', openGraphFor));
+      var rb = el('div', 'kb-board'); rbc.appendChild(rb);
       Object.keys(gr.groups).forEach(function (k) { var c = el('div', 'kb-col'); c.appendChild(el('div', 'kb-colhd', k + ' · ' + gr.groups[k].length));
         gr.groups[k].slice(0, 25).forEach(function (r) { c.appendChild(el('div', 'kb-card', String(recVal(r, kc)))); }); rb.appendChild(c); });
-      _overlay('Kanban — ' + tab.name + ' (read-only)', rb); console.log('§KANBAN-PILL readonly cols=' + Object.keys(gr.groups).length + ' table=' + T); return;
+      _overlay('Kanban — ' + tab.name + ' (read-only)', rbc); console.log('§KANBAN-PILL readonly cols=' + Object.keys(gr.groups).length + ' table=' + T); return;
     }
     // fold the OPEN window's records PER-ROW by RAW docstatus (codes, not labels), overlaying the op-log tip.
     var tip = window.KanbanHost.tip(_kanbanProj), byS = {};
@@ -879,8 +890,11 @@
     });
     var folds = Object.keys(byS).map(function (s) { return { table: T, doc_status: s, count: byS[s].length, ids: byS[s].slice(0, 30) }; });
     var board = window.KanbanLens.buildBoard(folds, _kanbanWfmc, { showEmptyStates: true });
-    var root = el('div'); root.style.cssText = 'overflow:auto;max-height:78vh';
-    _overlay('Kanban — ' + tab.name, root);
+    var container = el('div');
+    container.appendChild(_viewSwitch('📊 View as Graph', openGraphFor));   // switch back to the chart lens
+    var root = el('div'); root.style.cssText = 'overflow:auto;max-height:72vh';
+    container.appendChild(root);
+    _overlay('Kanban — ' + tab.name, container);
     window.__idmpKanban = window.KanbanLens.mount({ root: root, board: board, wfmc: _kanbanWfmc,
       dispatch: window.ERP.dispatch, ctx: window.ERP.ctx,
       onResult: function (res, dr) {

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v571';
+const CACHE_VERSION = 'v572';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/see_idmp_flow.js
+++ b/erp/tests/see_idmp_flow.js
@@ -1,0 +1,46 @@
+// Visual investigation (not a pass/fail witness): SEE the post-login launch flow in idempiere.html —
+// the pill rail (Graph/Kanban icons), the Graph view, and the Kanban board — as a real user would.
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.wasm':'application/wasm', '.css':'text/css', '.png':'image/png' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => { if (e) { res.writeHead(404); res.end('404'); return; } res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); });
+});
+const shot = (page, name) => page.screenshot({ path: path.join(__dirname, name) });
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  await page.goto(`http://localhost:${port}/idempiere.html?window=167`, { waitUntil: 'networkidle' });
+
+  // login
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)', { timeout: 15000 });
+  await shot(page, 'see_1_login.png');
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok'); await page.click('#idmp-login-ok');
+  await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(1200);
+  await shot(page, 'see_2_after_login_window.png');   // landing: open window + pill rail (Graph/Kanban icons)
+
+  // the pill rail — what icons are present?
+  const pills = await page.$$eval('.idmp-pill', bs => bs.map(b => b.title));
+  console.log('§PILL-RAIL after login: [' + pills.join(', ') + ']');
+
+  // Graph icon
+  const g = await page.$('.idmp-pill[title="Graph"]');
+  if (g) { await g.click(); await page.waitForTimeout(700); await shot(page, 'see_3_graph.png'); console.log('Graph: clicked'); }
+  else console.log('Graph: pill NOT FOUND');
+  // close overlay then Kanban
+  var x = await page.$('#posted-overlay .posted-ov-x'); if (x) { await x.click(); await page.waitForTimeout(300); }
+  const k = await page.$('.idmp-pill[title="Kanban"]');
+  if (k) { await k.click(); await page.waitForTimeout(900); await shot(page, 'see_4_kanban.png'); console.log('Kanban: clicked'); }
+
+  await browser.close(); server.close();
+})().catch(e => { console.error('ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
Graph + Kanban are two lenses of the same doc-status data. The graph view now has a **🗂 View as Kanban** button (launch the interactive board in one tap from the graph icon) and the board has **📊 View as Graph** to switch back. sw v572. Scope: erp/ only. Verified visually (switch_2_kanban.png) + idmp kanban witness PASS.