### PR TITLE
feat(erp): pick-your-ERP Install/Migrate dialog + real Odoo browser fold

### DIFF
--- a/erp/erp_picker.js
+++ b/erp/erp_picker.js
@@ -1,0 +1,258 @@
+/**
+ * BIM OOTB — ERP. Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
+ *
+ * erp_picker.js — the "pick-your-ERP" Install/Migrate dialog (prompts/MIGRATE_ERP_PICKER.md §SPEC).
+ *   ONE dialog family: Install + Migrate both call open({mode}). It (S1) lists ALL five ERPs always,
+ *   (S2) best-effort DETECTS what is present and highlights it / greys the rest, (S3) defaults to the
+ *   detected source and asks "migrate your <X> data?", (S4) routes on confirm:
+ *     iDempiere → MigrateShowMe (real PG agent) · Odoo → the real delegate-to-install fold (download the
+ *     install-side agent → load odoo_chain.json → RE-FOLD through window.ERPKernel) · others → honest "coming".
+ *   NON-INVENT: detection is a liveness probe only (no-cors, opaque) — the browser never reads ERP data
+ *   cross-origin; extraction is delegate-to-install. Absent adapter ⇒ honest "coming", never a faked migrate.
+ *
+ *   §-witnesses (console, §-log first):
+ *     §ERP-PICKER open mode=<m> erps=5
+ *     §ERP-PICKER detect odoo=<Y|N> idempiere=agent
+ *     §ERP-PICKER highlight=<key> greyed=[sap,oracle,dynamics]
+ *     §ERP-PICKER default=<key>
+ *     §ERP-PICKER confirm erp=<key> route=<route>   |   §ERP-PICKER coming erp=<key>
+ *     §ODOO-MIGRATE-BROWSER loaded events=5 mapped=5/5 verbs=[…] newVerbs=[] glDr==glCr verify chainOk=Y
+ */
+(function (global) {
+  'use strict';
+
+  // S1 — the full list, always rendered. real:true ⇒ a working route; real:false ⇒ honest "coming".
+  var ERPS = [
+    { key: 'idempiere', name: 'iDempiere',   icon: '🟧', real: true,  route: 'showme' },
+    { key: 'odoo',      name: 'Odoo',        icon: '🟣', real: true,  route: 'odoo', probe: probeOdoo },
+    { key: 'sap',       name: 'SAP',         icon: '🔵', real: false },
+    { key: 'oracle',    name: 'Oracle',      icon: '🔴', real: false },
+    { key: 'dynamics',  name: 'MS Dynamics', icon: '🟦', real: false }
+  ];
+
+  var _overlay = null, _mode = 'migrate', _status = null;
+  var _detected = {};   // key → true (port reachable). idempiere is 'agent' (real, not auto-probeable).
+  var _sel = null, _SQL = null;
+
+  function _el(tag, attrs, html) {
+    var e = document.createElement(tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) { e.setAttribute(k, attrs[k]); });
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+  function _$(id) { return document.getElementById(id); }
+  function _erp(k) { return ERPS.filter(function (e) { return e.key === k; })[0]; }
+  function _say(m) { if (typeof _status === 'function') _status(m); }
+
+  // ── S2 — best-effort liveness probe (no-cors = opaque; reachable ⇒ resolve). Never reads ERP data. ──
+  function probe(url, ms) {
+    return new Promise(function (resolve) {
+      var done = false;
+      var t = setTimeout(function () { if (!done) { done = true; resolve(false); } }, ms);
+      try {
+        fetch(url, { mode: 'no-cors', cache: 'no-store' })
+          .then(function () { if (!done) { done = true; clearTimeout(t); resolve(true); } })
+          .catch(function () { if (!done) { done = true; clearTimeout(t); resolve(false); } });
+      } catch (e) { if (!done) { done = true; clearTimeout(t); resolve(false); } }
+    });
+  }
+  function probeOdoo() { return probe('http://localhost:8069/web/health', 1200); }
+
+  function open(opts) {
+    opts = opts || {};
+    _mode = opts.mode === 'install' ? 'install' : 'migrate';
+    _status = opts.status || null;
+    _detected = {}; _sel = null;
+    _injectStyle();
+    if (_overlay) close();
+    _overlay = _el('div', { id: 'ep-overlay', class: 'ep-overlay' });
+    _overlay.innerHTML =
+      '<div class="ep-card" role="dialog" aria-label="Pick your ERP">'
+      + '<div class="ep-head"><span>' + (_mode === 'install' ? '⬇ Install onto this device' : '🔌 Migrate from your ERP')
+      + '</span><button id="ep-x" class="ep-x" aria-label="Close">&times;</button></div>'
+      + '<div id="ep-body" class="ep-body"></div></div>';
+    document.body.appendChild(_overlay);
+    _$('ep-x').onclick = close;
+    _overlay.addEventListener('click', function (e) { if (e.target === _overlay) close(); });
+    console.log('§ERP-PICKER open mode=' + _mode + ' erps=' + ERPS.length);
+    _renderPicker();
+    _runDetection();
+  }
+  function close() { if (_overlay) { _overlay.remove(); _overlay = null; } }
+
+  // ── render the card grid + footer question ──
+  function _renderPicker() {
+    var body = _$('ep-body'); if (!body) return;
+    body.innerHTML =
+      '<p class="ep-dim">Pick the system to ' + _mode + ' from. We detect what is running on this machine and '
+      + 'pre-select it — the others are listed for when their adapter lands.</p>'
+      + '<div id="ep-grid" class="ep-grid"></div>'
+      + '<div id="ep-foot" class="ep-foot"></div>';
+    var grid = _$('ep-grid');
+    ERPS.forEach(function (e) {
+      var card = _el('div', { id: 'ep-c-' + e.key, class: 'ep-cardlet' });
+      card.innerHTML = '<div class="ep-ic">' + e.icon + '</div><div class="ep-nm">' + e.name + '</div>'
+        + '<div id="ep-b-' + e.key + '" class="ep-badge">' + _badge(e) + '</div>';
+      card.onclick = function () { _select(e.key); };
+      grid.appendChild(card);
+    });
+    _renderFoot();
+  }
+  function _badge(e) {
+    if (!e.real) return '<span class="ep-coming">coming soon</span>';
+    if (e.probe) return '<span class="ep-probing">detecting…</span>';
+    return '<span class="ep-agent">via agent</span>';
+  }
+
+  function _runDetection() {
+    var probes = ERPS.filter(function (e) { return e.real && e.probe; });
+    Promise.all(probes.map(function (e) {
+      return e.probe().then(function (live) { _detected[e.key] = !!live; _paintCard(e.key); return [e.key, live]; });
+    })).then(function () {
+      console.log('§ERP-PICKER detect odoo=' + (_detected.odoo ? 'Y' : 'N') + ' idempiere=agent');
+      // S3 default: a detected ERP wins; else the first real one.
+      var hit = ERPS.filter(function (e) { return _detected[e.key]; })[0];
+      var def = hit || ERPS.filter(function (e) { return e.real; })[0];
+      var greyed = ERPS.filter(function (e) { return !e.real; }).map(function (e) { return e.key; });
+      console.log('§ERP-PICKER highlight=' + (hit ? hit.key : 'none') + ' greyed=[' + greyed.join(',') + ']');
+      console.log('§ERP-PICKER default=' + def.key);
+      _select(def.key);
+    });
+  }
+
+  function _paintCard(key) {
+    var e = _erp(key), b = _$('ep-b-' + key), c = _$('ep-c-' + key);
+    if (b) b.innerHTML = _detected[key] ? '<span class="ep-detect">● detected</span>' : (e.real ? '<span class="ep-agent">via agent</span>' : '<span class="ep-coming">coming soon</span>');
+    if (c) c.classList.toggle('ep-live', !!_detected[key]);
+  }
+
+  function _select(key) {
+    _sel = key;
+    ERPS.forEach(function (e) { var c = _$('ep-c-' + e.key); if (c) c.classList.toggle('ep-sel', e.key === key); });
+    _renderFoot();
+  }
+
+  function _renderFoot() {
+    var foot = _$('ep-foot'); if (!foot || !_sel) return;
+    var e = _erp(_sel);
+    var verb = _mode === 'install' ? 'install' : 'migrate';
+    var q = _mode === 'install' ? ('Install <b>' + e.name + '</b> data onto this device?')
+                                : ('Do you want to ' + verb + ' your <b>' + e.name + '</b> data?');
+    var btn = e.real
+      ? '<button id="ep-go" class="ep-btn ep-primary">' + (_mode === 'install' ? 'Install ' : 'Migrate ') + e.name + '</button>'
+      : '<button id="ep-go" class="ep-btn" disabled>' + e.name + ' — coming</button>';
+    foot.innerHTML = '<div class="ep-q">' + q + '</div>' + btn
+      + (e.real ? '' : '<div class="ep-dim ep-comingnote">No adapter yet — ' + e.name + ' migration is on the way. '
+         + 'Nothing is faked; pick iDempiere or Odoo for a real fold.</div>');
+    var go = _$('ep-go'); if (go && e.real) go.onclick = function () { _confirm(_sel); };
+  }
+
+  // ── S4 — route on confirm ──
+  function _confirm(key) {
+    var e = _erp(key);
+    if (!e.real) { console.log('§ERP-PICKER coming erp=' + key); _say(e.name + ' migration is coming.'); return; }
+    console.log('§ERP-PICKER confirm erp=' + key + ' route=' + e.route);
+    if (e.route === 'showme') {
+      close();
+      if (global.MigrateShowMe && global.MigrateShowMe.open) global.MigrateShowMe.open();
+      else _say('Migrate ShowMe overlay not loaded.');
+      return;
+    }
+    if (e.route === 'odoo') { _renderOdoo(); return; }
+  }
+
+  // ── Odoo sub-flow (delegate-to-install): run the agent → load chain → re-fold via ERPKernel ──
+  function _renderOdoo() {
+    var body = _$('ep-body'); if (!body) return;
+    body.innerHTML =
+      '<p class="ep-dim">The browser never connects to Odoo directly (delegate-to-install). Run the '
+      + 'extractor on the machine that has Odoo — it pulls the chain and writes <code>odoo_chain.json</code>, '
+      + 'which you load here. Every value below is a recorded Odoo row.</p>'
+      + '<p><b>1.</b> Get the install-side agent and run it (needs Node + sql.js + the adapter):</p>'
+      + '<a class="ep-btn ep-primary" href="odoo_agent.js" download="odoo_agent.js">⬇ Download odoo_agent.js</a>'
+      + '<pre class="ep-cmd">node odoo_agent.js   # → build/erp/odoo_chain.json</pre>'
+      + '<p><b>2.</b> Load the <code>odoo_chain.json</code> it produced:</p>'
+      + '<input type="file" id="ep-chain" accept=".json,application/json" class="ep-file">'
+      + '<div id="ep-result" class="ep-result"></div>'
+      + '<div class="ep-foot"><button id="ep-back" class="ep-btn">&larr; Back</button></div>';
+    _$('ep-back').onclick = function () { _renderPicker(); _select(_sel); };
+    _$('ep-chain').onchange = function () {
+      var f = this.files && this.files[0]; if (!f) return;
+      f.text().then(function (txt) { _foldChain(JSON.parse(txt)); })
+        .catch(function (err) { _$('ep-result').innerHTML = '<div class="ep-err">Load failed: ' + err.message + '</div>'; });
+    };
+  }
+
+  function _ensureSql() {
+    if (_SQL) return Promise.resolve(_SQL);
+    if (typeof initSqlJs !== 'function') return Promise.reject(new Error('sql.js not loaded'));
+    return initSqlJs({ locateFile: function () { return 'lib/sql-wasm-fts5.wasm'; } }).then(function (S) { _SQL = S; return S; });
+  }
+
+  // RE-FOLD the loaded chain through window.ERPKernel + the carried wfmc (the Odoo dictionary). The engine
+  // is shared; the dictionary travels in the file. Proves the same 6 verbs migrate Odoo, in the browser.
+  function _foldChain(chain) {
+    var out = _$('ep-result'); out.innerHTML = '<div class="ep-dim">Folding ' + (chain.events || []).length + ' hops through the engine…</div>';
+    var K = global.ERPKernel;
+    if (!K) { out.innerHTML = '<div class="ep-err">Engine (window.ERPKernel) not loaded — open the Kanban pill once to boot it, then retry.</div>'; return; }
+    _ensureSql().then(function (S) {
+      var db = new S.Database(); K.initProjection(db);
+      var qfn = function (s, p) { return K.query(db, s, p); };
+      var known = chain.KNOWN_VERBS || ['CREATE_DOCUMENT', 'CREATE_LINE', 'SET_STATUS', 'ALLOCATE', 'MATCH', 'POST'];
+      var rows = [], used = {}, mapped = 0;
+      chain.events.forEach(function (ev) { K.register(ev.d.docType, ev.d.action, (function (ops) { return function () { return ops; }; })(ev.ops)); });
+      chain.events.forEach(function (ev, i) {
+        ev.ops.forEach(function (o) { used[o.op_type] = 1; });
+        var r = K.dispatch(db, { wfmc: chain.wfmc, guards: [], query: qfn, actor: 'odoo:migrate', baseTs: 1000 + i * 100 }, ev.d);
+        if (r.ok) mapped++;
+        rows.push({ name: ev.name, doc: ev.d.docType + ':' + ev.d.action, ops: ev.ops.length, ok: !!r.ok, to: r.to || (r.stage + ':' + r.reason) });
+      });
+      var usedVerbs = Object.keys(used).sort();
+      var newVerbs = usedVerbs.filter(function (v) { return known.indexOf(v) < 0; });
+      var dr = (chain.gl && chain.gl.dr) || 0, cr = (chain.gl && chain.gl.cr) || 0, balanced = Number(dr).toFixed(2) === Number(cr).toFixed(2);
+      // verify: replay the op-log twice; identical rebuild = trust (the §1 replay-hash check).
+      var chainOk = false, tip = '', len = 0;
+      try { var a = K.replay(db, new S.Database()), b = K.replay(db, new S.Database()); chainOk = a.hash === b.hash; tip = a.hash; len = a.ops; } catch (e) {}
+      out.innerHTML =
+        '<table class="ep-tbl"><thead><tr><th>hop</th><th>doc</th><th>ops</th><th>→</th></tr></thead><tbody>'
+        + rows.map(function (r) { return '<tr class="' + (r.ok ? '' : 'ep-bad') + '"><td>' + r.name + '</td><td>' + r.doc + '</td><td>' + r.ops + '</td><td>' + (r.ok ? '✓ ' + r.to : '✗ ' + r.to) + '</td></tr>'; }).join('')
+        + '</tbody></table>'
+        + '<div class="ep-sum">'
+        + '<div>SO <b>' + (chain.meta && chain.meta.so) + '</b> → invoice <b>' + (chain.meta && chain.meta.invoice) + '</b>, total <b>' + Number((chain.totals && chain.totals.total) || 0).toFixed(2) + '</b></div>'
+        + '<div>mapped <b>' + mapped + '/' + chain.events.length + '</b> · verbs [' + usedVerbs.join(', ') + '] · newVerbs [<b>' + newVerbs.join(',') + '</b>]</div>'
+        + '<div>invoice GL ΣDr ' + Number(dr).toFixed(2) + ' ' + (balanced ? '== ' : '≠ ') + 'ΣCr ' + Number(cr).toFixed(2) + ' ' + (balanced ? '✓' : '✗') + '</div>'
+        + '<div>verify chain ' + (chainOk ? '✓ trusted' : '✗') + ' · ops ' + len + ' · tip <code>' + String(tip).slice(0, 16) + '…</code></div>'
+        + '</div>';
+      console.log('§ODOO-MIGRATE-BROWSER loaded events=' + chain.events.length + ' mapped=' + mapped + '/' + chain.events.length
+        + ' verbs=[' + usedVerbs.join(',') + '] newVerbs=[' + newVerbs.join(',') + '] glDr' + (balanced ? '==' : '!=') + 'glCr verify chainOk=' + (chainOk ? 'Y' : 'N') + ' tip=' + tip);
+      if (db.close) db.close();
+    }).catch(function (e) { out.innerHTML = '<div class="ep-err">Fold failed: ' + e.message + '</div>'; });
+  }
+
+  function _injectStyle() {
+    if (_$('ep-style')) return;
+    var s = _el('style', { id: 'ep-style' });
+    s.textContent =
+      '.ep-overlay{position:fixed;inset:0;background:rgba(8,10,16,.66);z-index:99998;display:flex;align-items:center;justify-content:center;font-family:system-ui,sans-serif}'
+      + '.ep-card{background:#fff;color:#1a1d22;width:min(560px,94vw);max-height:90vh;overflow:auto;border-radius:14px;box-shadow:0 22px 64px rgba(0,0,0,.45)}'
+      + '.ep-head{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;border-bottom:1px solid #eee;font-weight:700;font-size:17px;color:#0b6}'
+      + '.ep-x{border:0;background:none;font-size:24px;cursor:pointer;color:#999;line-height:1}'
+      + '.ep-body{padding:18px 20px;font-size:14px;line-height:1.5}.ep-dim{color:#777;font-size:12px;margin:0 0 14px}'
+      + '.ep-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(96px,1fr));gap:10px;margin:6px 0 16px}'
+      + '.ep-cardlet{border:2px solid #e6e6ea;border-radius:12px;padding:12px 6px;text-align:center;cursor:pointer;opacity:.55;transition:.12s}'
+      + '.ep-cardlet:hover{border-color:#bcd}.ep-cardlet.ep-live{opacity:1}.ep-cardlet.ep-sel{border-color:#0b6;box-shadow:0 0 0 3px rgba(11,170,102,.18)}'
+      + '.ep-ic{font-size:24px}.ep-nm{font-size:12px;font-weight:600;margin:4px 0 6px}'
+      + '.ep-badge{font-size:10px;min-height:14px}.ep-detect{color:#0b6;font-weight:700}.ep-agent{color:#36c}.ep-coming{color:#a98}.ep-probing{color:#aaa}'
+      + '.ep-q{font-size:15px;margin:6px 0 12px}.ep-foot{margin-top:8px;display:flex;gap:10px;align-items:center;flex-wrap:wrap}'
+      + '.ep-btn{padding:9px 16px;border:1px solid #ccc;background:#f5f5f5;border-radius:8px;cursor:pointer;font-size:13px}.ep-btn[disabled]{opacity:.5;cursor:not-allowed}'
+      + '.ep-primary{background:#0b6;color:#fff;border-color:#0b6}.ep-comingnote{margin-top:4px;flex-basis:100%}'
+      + '.ep-cmd{background:#0d1117;color:#9be29b;padding:10px;border-radius:8px;font-size:12px;white-space:pre-wrap;word-break:break-all;margin:8px 0}'
+      + '.ep-file{margin:8px 0}.ep-result{margin-top:12px}'
+      + '.ep-tbl{width:100%;border-collapse:collapse;font-size:12px;margin-bottom:10px}.ep-tbl th,.ep-tbl td{text-align:left;padding:5px 8px;border-bottom:1px solid #f0f0f0}.ep-tbl th{color:#888;font-weight:600}.ep-bad{color:#c33}'
+      + '.ep-sum{font-size:13px;line-height:1.7;background:#f6faf7;border:1px solid #d8efe2;border-radius:8px;padding:10px 12px}'
+      + '.ep-err{color:#c33;font-size:13px}';
+    document.head.appendChild(s);
+  }
+
+  global.ErpPicker = { open: open, close: close, _erps: ERPS };
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -274,6 +274,8 @@
 <script src="accts_posted.js?v=23"></script>
 <!-- §0.10a — first-mile Migrate ShowMe (launched from the login card). -->
 <script src="migrate_showme.js?v=22"></script>
+<!-- MIGRATE_ERP_PICKER.md §SPEC — pick-your-ERP Install/Migrate dialog (detect→highlight→default→route). -->
+<script src="erp_picker.js?v=1"></script>
 <!-- Kanban write path — engine seam (window.ERP) + the lens chrome + the reusable host (publish/persist). -->
 <script src="kernel_ops.js?v=1"></script>
 <script src="erp_signer.js?v=1"></script>
@@ -905,8 +907,8 @@
       } });
     console.log('§KANBAN-PILL live cols=' + board.columns.length + ' cards=' + board.cards.length + ' table=' + T);
   }
-  function openInstallFor() { status('Install: pull the full DB to this device, or pair via QR to your machine — POC'); console.log('§INSTALL-PILL action=install-stub'); }
-  function openMigrateFor() { status('Migrate: run the local extractor on your machine, mirror here (QR pairing) — POC'); console.log('§MIGRATE-PILL action=migrate-stub'); }
+  function openInstallFor() { console.log('§INSTALL-PILL action=picker'); if (window.ErpPicker) ErpPicker.open({ mode: 'install', status: status }); else status('ERP picker not loaded.'); }
+  function openMigrateFor() { console.log('§MIGRATE-PILL action=picker'); if (window.ErpPicker) ErpPicker.open({ mode: 'migrate', status: status }); else status('ERP picker not loaded.'); }
   function buildPillRail() {
     _injectPillCSS();
     var rail = el('div'); rail.id = 'idmp-pillrail';

--- a/erp/odoo_agent.js
+++ b/erp/odoo_agent.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
+//
+// odoo_agent.js — the INSTALL-SIDE Odoo migration extractor (delegate-to-install). It runs on the machine
+//   that has Odoo (Node, like poc_odoo_fold_live), re-pulls SO S00023's O2C chain LIVE from the running
+//   odoodemo (Odoo 17, :8069) via JSON-RPC, folds it through the SAME pure adapter (odoo_adapter.js) + the
+//   6 kernel verbs, SELF-VERIFIES (every hop commits, newVerbs=[], invoice GL ΣDr==ΣCr), then EMITS
+//   build/erp/odoo_chain.json = { meta, wfmc, KNOWN_VERBS, events:[{name,d,ops}], totals, gl }. The BROWSER
+//   (erp_picker.js Odoo sub-flow) loads that file and re-folds through window.ERPKernel — the browser never
+//   CORSes into Odoo; this agent is the recorded bridge (ERP.md delegate-to-install doctrine). NON-INVENT:
+//   every value is a recorded Odoo row.  §-log first.
+//   Run:  node scripts/odoo_agent.js 2>&1 | tee build/erp/odoo_agent.log
+'use strict';
+var path = require('path'), fs = require('fs'), http = require('http');
+var initSqlJs = require('sql.js');
+var K = require('./erp_kernel');
+var A = require('./odoo_adapter');
+
+var HOST = process.env.ODOO_HOST || 'localhost', PORT = Number(process.env.ODOO_PORT || 8069);
+var DB = process.env.ODOO_DB || 'odoodemo', LOGIN = process.env.ODOO_LOGIN || 'admin', PASSWORD = process.env.ODOO_PASSWORD || 'admin';
+var SO = process.env.ODOO_SO || 'S00023';
+var OUT = path.join(__dirname, '..', 'build', 'erp', 'odoo_chain.json');
+
+function rpc(service, method, args) {
+  return new Promise(function (resolve, reject) {
+    var body = JSON.stringify({ jsonrpc: '2.0', method: 'call', params: { service: service, method: method, args: args } });
+    var req = http.request({ host: HOST, port: PORT, path: '/jsonrpc', method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) } }, function (res) {
+      var d = ''; res.on('data', function (c) { d += c; }); res.on('end', function () {
+        try { var j = JSON.parse(d); if (j.error) return reject(new Error(JSON.stringify(j.error.data && j.error.data.message || j.error))); resolve(j.result); }
+        catch (e) { reject(e); } });
+    });
+    req.on('error', reject); req.write(body); req.end();
+  });
+}
+function n2(x) { return Number(x).toFixed(2); }
+
+(async function () {
+  var fails = 0; function ok(c, m, d) { if (!c) fails++; console.log('   ' + (c ? '🟢' : '🔴') + ' ' + m + (d ? ' — ' + d : '')); }
+  console.log('\n══ ODOO-AGENT — extract+fold SO ' + SO + ' from the RUNNING odoo (' + DB + ' @ ' + HOST + ':' + PORT + ') ══\n');
+
+  // ── connect ──
+  var uid = await rpc('common', 'login', [DB, LOGIN, PASSWORD]);
+  ok(!!uid, 'authenticated to live odoo', 'uid=' + uid);
+  if (!uid) { console.log('\n§ODOO-AGENT FAIL auth\n'); process.exit(1); }
+  var ex = function (model, method, args, kw) { return rpc('object', 'execute_kw', [DB, uid, PASSWORD, model, method, args, kw || {}]); };
+
+  // ── extract the O2C chain LIVE (same shape as odoo_oracle.json; nothing fabricated) ──
+  var so = (await ex('sale.order', 'search_read', [[['name', '=', SO]]], { fields: ['id', 'name', 'state', 'amount_untaxed', 'amount_tax', 'amount_total'] }))[0];
+  ok(!!so, 'live SO found', so && (so.name + ' id=' + so.id + ' state=' + so.state));
+  if (!so) { console.log('\n§ODOO-AGENT FAIL no-so\n'); process.exit(1); }
+  var solines = await ex('sale.order.line', 'search_read', [[['order_id', '=', so.id], ['display_type', '=', false]]],
+    { fields: ['product_id', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'price_unit', 'price_subtotal', 'price_total'] });
+  var inv = (await ex('account.move', 'search_read', [[['invoice_origin', '=', so.name], ['move_type', '=', 'out_invoice']]],
+    { fields: ['id', 'name', 'state', 'move_type', 'amount_untaxed', 'amount_tax', 'amount_total', 'amount_residual', 'payment_state', 'invoice_origin'] }))[0];
+  ok(!!inv, 'live invoice found', inv && (inv.name + ' ' + inv.payment_state));
+  var gl = await ex('account.move.line', 'search_read', [[['move_id', '=', inv.id]]],
+    { fields: ['name', 'account_id', 'debit', 'credit', 'balance', 'product_id', 'quantity', 'tax_line_id', 'display_type'] });
+  var moves = await ex('stock.move', 'search_read', [[['sale_line_id', 'in', solines.map(function (l) { return l.id; })], ['state', '=', 'done']]],
+    { fields: ['product_id', 'quantity', 'state'] });
+
+  function pname(pid) { return pid ? pid[1] : ''; }
+  var live = {
+    meta: { so: so.name, so_id: so.id, invoice: inv.name, invoice_id: inv.id, payment: [], reconcile_amount: inv.amount_total, payment_state: inv.payment_state },
+    sale_order: { name: so.name, state: so.state, amount_untaxed: so.amount_untaxed, amount_tax: so.amount_tax, amount_total: so.amount_total },
+    sale_order_lines: solines.map(function (l) { return { product: pname(l.product_id), pid: l.product_id[0], qty: l.product_uom_qty, qty_delivered: l.qty_delivered, qty_invoiced: l.qty_invoiced, price_unit: l.price_unit, subtotal: l.price_subtotal, total: l.price_total }; }),
+    delivery_moves: moves.map(function (m) { return { product: pname(m.product_id), pid: m.product_id[0], qty: m.quantity, state: m.state }; }),
+    invoice: { name: inv.name, state: inv.state, move_type: inv.move_type, amount_untaxed: inv.amount_untaxed, amount_tax: inv.amount_tax, amount_total: inv.amount_total, amount_residual: inv.amount_residual, payment_state: inv.payment_state, invoice_origin: inv.invoice_origin },
+    invoice_gl_lines: gl.filter(function (g) { return g.display_type !== 'line_section' && g.display_type !== 'line_note'; }).map(function (g) {
+      return { name: g.name, account: g.account_id ? g.account_id[1] : '', debit: g.debit, credit: g.credit, balance: g.balance, product: pname(g.product_id), qty: g.quantity, is_tax: !!g.tax_line_id, display_type: g.display_type || 'product' }; }),
+    payment: []
+  };
+  console.log('\n── live extract: SO ' + live.meta.so + ' lines=' + live.sale_order_lines.length + ' moves=' + live.delivery_moves.length +
+    ' invoice=' + live.meta.invoice + ' gl=' + live.invoice_gl_lines.length + ' total=' + n2(live.meta.reconcile_amount) + ' (' + live.meta.payment_state + ')\n');
+
+  // ── FOLD through the adapter + kernel verbs (self-verify the chain BEFORE writing it) ──
+  var built = A.buildEvents(live);
+  built.events.forEach(function (ev) { K.register(ev.d.docType, ev.d.action, function () { return ev.ops; }); });
+  var SQL = await initSqlJs();
+  var db = new SQL.Database(); K.initProjection(db);
+  var qfn = function (s, p) { return K.query(db, s, p); };
+  var usedVerbs = {}, mapped = 0;
+  built.events.forEach(function (ev, i) {
+    ev.ops.forEach(function (o) { usedVerbs[o.op_type] = 1; });
+    var d = K.dispatch(db, { wfmc: built.wfmc, guards: [], query: qfn, actor: 'odoo:agent', baseTs: 1000 + i * 100 }, ev.d);
+    if (d.ok) mapped++;
+    ok(d.ok, 'event ' + (i + 1) + ' ' + ev.name + ' committed (' + ev.d.status + '→' + (d.to || '?') + ')', d.ok ? 'ops=' + d.applied : d.stage + ':' + d.reason);
+  });
+  var used = Object.keys(usedVerbs).sort();
+  var newVerbs = used.filter(function (v) { return A.KNOWN_VERBS.indexOf(v) < 0; });
+  var dr = live.invoice_gl_lines.reduce(function (a, g) { return a + Number(g.debit || 0); }, 0);
+  var cr = live.invoice_gl_lines.reduce(function (a, g) { return a + Number(g.credit || 0); }, 0);
+  ok(mapped === built.events.length, 'every hop migrated', mapped + '/' + built.events.length);
+  ok(newVerbs.length === 0, 'newVerbs empty — Odoo folds with the existing 6 verbs', 'used=[' + used.join(',') + ']');
+  ok(n2(dr) === n2(cr), 'invoice GL balances (ΣDr==ΣCr)', n2(dr) + '==' + n2(cr));
+
+  // ── EMIT the chain file the browser loads (events carry their ops; wfmc is the odoo dictionary) ──
+  var chain = {
+    meta: { source: 'odoodemo (Odoo 17) live via odoo_agent.js', so: live.meta.so, so_id: live.meta.so_id,
+      invoice: live.meta.invoice, invoice_id: live.meta.invoice_id, payment_state: live.meta.payment_state, host: HOST + ':' + PORT, db: DB },
+    wfmc: built.wfmc,
+    KNOWN_VERBS: A.KNOWN_VERBS,
+    events: built.events.map(function (ev) { return { name: ev.name, d: ev.d, ops: ev.ops }; }),
+    totals: { untaxed: live.sale_order.amount_untaxed, tax: live.sale_order.amount_tax, total: live.sale_order.amount_total, reconcile: live.meta.reconcile_amount },
+    gl: { lines: live.invoice_gl_lines.map(function (g) { return { name: g.name, account: g.account, debit: g.debit, credit: g.credit, is_tax: g.is_tax }; }), dr: Number(n2(dr)), cr: Number(n2(cr)) }
+  };
+  fs.writeFileSync(OUT, JSON.stringify(chain, null, 2));
+  console.log('\n§ODOO-AGENT events=' + chain.events.length + ' mapped=' + mapped + '/' + built.events.length +
+    ' verbs=[' + used.join(',') + '] newVerbs=[' + newVerbs.join(',') + '] gl Dr==Cr=' + (n2(dr) === n2(cr)) +
+    ' total=' + n2(chain.totals.total) + ' wrote ' + path.relative(path.join(__dirname, '..'), OUT) + ' bytes=' + fs.statSync(OUT).size);
+
+  var pass = fails === 0;
+  console.log('\n§ODOO-AGENT ' + (pass ? 'PASS' : 'FAIL') + ' (' + fails + ' fails)\n');
+  process.exit(pass ? 0 : 1);
+})().catch(function (e) { console.error('§ODOO-AGENT ERROR', e.message); process.exit(2); });

--- a/erp/odoo_chain.json
+++ b/erp/odoo_chain.json
@@ -1,0 +1,234 @@
+{
+  "meta": {
+    "source": "odoodemo (Odoo 17) live via odoo_agent.js",
+    "so": "S00023",
+    "so_id": 23,
+    "invoice": "INV/2026/00005",
+    "invoice_id": 25,
+    "payment_state": "paid",
+    "host": "localhost:8069",
+    "db": "odoodemo"
+  },
+  "wfmc": {
+    "transitions": [
+      [
+        "DR",
+        "CO",
+        "CO"
+      ],
+      [
+        "CO",
+        "POST",
+        "CO"
+      ]
+    ]
+  },
+  "KNOWN_VERBS": [
+    "CREATE_DOCUMENT",
+    "CREATE_LINE",
+    "SET_STATUS",
+    "ALLOCATE",
+    "MATCH",
+    "POST"
+  ],
+  "events": [
+    {
+      "name": "confirm SO",
+      "d": {
+        "docType": "C_Order",
+        "action": "CO",
+        "status": "DR"
+      },
+      "ops": [
+        {
+          "op_type": "SET_STATUS",
+          "table": "C_Order",
+          "id": 23,
+          "doc_status": "CO",
+          "uuid": "DOC:C_Order#23",
+          "op_uuid": "odoo:agent:1000"
+        }
+      ]
+    },
+    {
+      "name": "deliver",
+      "d": {
+        "docType": "M_InOut",
+        "action": "CO",
+        "status": "DR"
+      },
+      "ops": [
+        {
+          "op_type": "CREATE_DOCUMENT",
+          "table": "M_InOut",
+          "source_id": 23,
+          "doc_status": "CO",
+          "uuid": "DOC:M_InOut@from23",
+          "op_uuid": "odoo:agent:1101"
+        },
+        {
+          "op_type": "CREATE_LINE",
+          "table": "M_InOutLine",
+          "source_line_id": "21",
+          "line_no": 1,
+          "m_product_id": 21,
+          "movementqty": 10,
+          "uuid": "LINE:M_InOutLine@from21",
+          "op_uuid": "odoo:agent:1102"
+        },
+        {
+          "op_type": "CREATE_LINE",
+          "table": "M_InOutLine",
+          "source_line_id": "31",
+          "line_no": 2,
+          "m_product_id": 31,
+          "movementqty": 10,
+          "uuid": "LINE:M_InOutLine@from31",
+          "op_uuid": "odoo:agent:1103"
+        }
+      ]
+    },
+    {
+      "name": "invoice",
+      "d": {
+        "docType": "C_Invoice",
+        "action": "CO",
+        "status": "DR"
+      },
+      "ops": [
+        {
+          "op_type": "CREATE_DOCUMENT",
+          "table": "C_Invoice",
+          "source_id": 23,
+          "doc_status": "CO",
+          "uuid": "DOC:C_Invoice@from23",
+          "op_uuid": "odoo:agent:1204"
+        },
+        {
+          "op_type": "CREATE_LINE",
+          "table": "C_InvoiceLine",
+          "source_line_id": "31",
+          "line_no": 1,
+          "m_product_id": 31,
+          "qtyinvoiced": 10,
+          "linenetamt": 2950,
+          "uuid": "LINE:C_InvoiceLine@from31",
+          "op_uuid": "odoo:agent:1205"
+        },
+        {
+          "op_type": "CREATE_LINE",
+          "table": "C_InvoiceLine",
+          "source_line_id": "21",
+          "line_no": 2,
+          "m_product_id": 21,
+          "qtyinvoiced": 10,
+          "linenetamt": 1400,
+          "uuid": "LINE:C_InvoiceLine@from21",
+          "op_uuid": "odoo:agent:1206"
+        }
+      ]
+    },
+    {
+      "name": "post GL",
+      "d": {
+        "docType": "C_Invoice",
+        "action": "POST",
+        "status": "CO"
+      },
+      "ops": [
+        {
+          "op_type": "POST",
+          "table": "C_Invoice",
+          "id": 25,
+          "lines": [
+            {
+              "account_id": "400000 Product Sales",
+              "amtacctdr": 0,
+              "amtacctcr": 2950,
+              "role": "REV"
+            },
+            {
+              "account_id": "400000 Product Sales",
+              "amtacctdr": 0,
+              "amtacctcr": 1400,
+              "role": "REV"
+            },
+            {
+              "account_id": "251000 Tax Received",
+              "amtacctdr": 0,
+              "amtacctcr": 652.5,
+              "role": "TAX"
+            },
+            {
+              "account_id": "121000 Account Receivable",
+              "amtacctdr": 5002.5,
+              "amtacctcr": 0,
+              "role": "AR"
+            }
+          ],
+          "acctschema": 1,
+          "uuid": "POST:C_Invoice#25",
+          "op_uuid": "odoo:agent:1307"
+        }
+      ]
+    },
+    {
+      "name": "reconcile",
+      "d": {
+        "docType": "C_AllocationHdr",
+        "action": "CO",
+        "status": "DR"
+      },
+      "ops": [
+        {
+          "op_type": "ALLOCATE",
+          "payment_id": "pay25",
+          "invoice_id": 25,
+          "amount": 5002.5,
+          "uuid": "ALLOC:pay25:inv25",
+          "op_uuid": "odoo:agent:1408"
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "untaxed": 4350,
+    "tax": 652.5,
+    "total": 5002.5,
+    "reconcile": 5002.5
+  },
+  "gl": {
+    "lines": [
+      {
+        "name": "[FURN_6666] Acoustic Bloc Screens",
+        "account": "400000 Product Sales",
+        "debit": 0,
+        "credit": 2950,
+        "is_tax": false
+      },
+      {
+        "name": "[E-COM11] Cabinet with Doors",
+        "account": "400000 Product Sales",
+        "debit": 0,
+        "credit": 1400,
+        "is_tax": false
+      },
+      {
+        "name": "15%",
+        "account": "251000 Tax Received",
+        "debit": 0,
+        "credit": 652.5,
+        "is_tax": true
+      },
+      {
+        "name": "INV/2026/00005",
+        "account": "121000 Account Receivable",
+        "debit": 5002.5,
+        "credit": 0,
+        "is_tax": false
+      }
+    ],
+    "dr": 5002.5,
+    "cr": 5002.5
+  }
+}

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v572';
+const CACHE_VERSION = 'v573';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -39,6 +39,7 @@ const PRECACHE_ASSETS = [
   'erp_signer.js',
   'migrate_showme.js',
   'migrate_agent.js',
+  'erp_picker.js',     // MIGRATE_ERP_PICKER.md §SPEC — pick-your-ERP Install/Migrate dialog (window.ErpPicker)
   'idmp_session.js',
   'erp_postings.js',   // FRONTEND_LANE_MASTER §2 Item C — frozen read-fold (UMD copy, window.ERPPostings)
   'accts_posted.js',   // Accts-Posted lens (buildCtx/buildPostedVM/mount/mountAccordion, window.AcctsPosted)

--- a/erp/tests/poc_erp_picker.js
+++ b/erp/tests/poc_erp_picker.js
@@ -1,0 +1,86 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for MIGRATE_ERP_PICKER.md §SPEC — the pick-your-ERP Install/Migrate dialog.
+//   PROVES:
+//     1. §ERP-PICKER open/detect/highlight/default — all 5 ERPs listed; Odoo (running :8069) DETECTED;
+//        coming ones greyed; a default is pre-selected.
+//     2. §ERP-PICKER confirm erp=odoo route=odoo — confirming Odoo opens the delegate-to-install sub-flow.
+//     3. §ODOO-MIGRATE-BROWSER — loading the LIVE-produced odoo_chain.json re-folds through window.ERPKernel:
+//        mapped=5/5, newVerbs=[], invoice GL ΣDr==ΣCr, replay verify chainOk=Y.
+//   Issue it disproves: "Install/Migrate are still honest stubs / Odoo migrate is not real in the browser."
+//   §-log first — READ tests/poc_erp_picker.log before any conclusion.
+// Run:  node tests/poc_erp_picker.js 2>&1 | tee tests/poc_erp_picker.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');                       // bim-ootb/erp
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/') p = '/idempiere.html';
+  const f = path.join(ROOT, p);
+  fs.readFile(f, (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(f)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  await page.goto(`http://localhost:${port}/idempiere.html`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);                              // let boot + sql.js + pills settle
+
+  // 1) open Migrate → picker
+  await page.click('button[title="Migrate"]');
+  await page.waitForTimeout(2200);                              // let the no-cors Odoo probe resolve/timeout
+
+  const cards = await page.$$eval('.ep-cardlet .ep-nm', ns => ns.map(n => n.textContent));
+  const detectLog  = logs.find(l => l.startsWith('§ERP-PICKER detect')) || '(no detect)';
+  const hiLog      = logs.find(l => l.startsWith('§ERP-PICKER highlight')) || '(no highlight)';
+  const defLog     = logs.find(l => l.startsWith('§ERP-PICKER default')) || '(no default)';
+  console.log('§PICKER-CARDS listed=[' + cards.join(',') + '] count=' + cards.length);
+  console.log('§PICKER-DETECT ' + detectLog);
+  console.log('§PICKER-HILITE ' + hiLog + ' | ' + defLog);
+
+  // 2) select Odoo + confirm → sub-flow
+  await page.click('#ep-c-odoo');
+  await page.waitForTimeout(150);
+  await page.click('#ep-go');
+  await page.waitForTimeout(400);
+  const confirmLog = logs.find(l => l.startsWith('§ERP-PICKER confirm erp=odoo')) || '(no confirm)';
+  const subFlow = await page.$('#ep-chain');
+  console.log('§PICKER-CONFIRM ' + confirmLog + ' subFlowShown=' + (subFlow ? 'Y' : 'N'));
+
+  // 3) load the LIVE chain → re-fold through the engine
+  await page.setInputFiles('#ep-chain', path.join(ROOT, 'odoo_chain.json'));
+  await page.waitForTimeout(1500);
+  const foldLog = logs.find(l => l.startsWith('§ODOO-MIGRATE-BROWSER')) || '(no fold)';
+  console.log('§PICKER-FOLD ' + foldLog);
+
+  await page.screenshot({ path: path.join(__dirname, 'erp_picker.png') });
+
+  const detectedOdoo = /odoo=Y/.test(detectLog);
+  const allFive = cards.length === 5;
+  const confirmed = /route=odoo/.test(confirmLog) && !!subFlow;
+  const folded = /mapped=5\/5/.test(foldLog) && /newVerbs=\[\]/.test(foldLog)
+              && /glDr==glCr/.test(foldLog) && /chainOk=Y/.test(foldLog);
+
+  console.log('§ERP-PICKER-WITNESS allFive=' + allFive + ' detectedOdoo=' + detectedOdoo
+    + ' confirmed=' + confirmed + ' folded=' + folded + ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+  const pass = allFive && confirmed && folded && errs.length === 0;   // detectedOdoo soft (env-dependent)
+  console.log('§ERP-PICKER ' + (pass ? 'PASS' : 'FAIL'));
+
+  await browser.close();
+  server.close();
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
## What
Turns the Install/Migrate pills from stubs into the real **pick-your-ERP** dialog (`window.ErpPicker`), backed by the LIVE-proven Odoo fold. Per `prompts/MIGRATE_ERP_PICKER.md §SPEC`.

- **S1** lists all 5 ERPs always: iDempiere · Odoo · SAP · Oracle · MS Dynamics
- **S2** live-detects Odoo (`:8069` no-cors **liveness only** — the browser never reads ERP data cross-origin; extraction is delegate-to-install), highlights detected, greys coming
- **S3** defaults to the detected source and asks *"migrate your `<X>` data?"*
- **S4** routes: iDempiere→`MigrateShowMe` · Odoo→delegate-to-install sub-flow · SAP/Oracle/Dynamics→honest "coming" (non-invent)
- **Odoo sub-flow**: download `odoo_agent.js` (install-side extractor → `odoo_chain.json`, live-pulled from odoodemo) → file-load the chain → **re-fold each hop through `window.ERPKernel`** + the wfmc carried in the file (one engine, N dictionaries)

## Witness (§-log first)
`tests/poc_erp_picker.js` → **§ERP-PICKER PASS**: allFive=true, Odoo detected, confirm route=odoo, `§ODOO-MIGRATE-BROWSER mapped=5/5 newVerbs=[] glDr==glCr chainOk=Y`, 0 pageerrors. `audit_specs.js` exit 0.

SW `erp/sw.js` v572→v573 + `erp_picker.js` precached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)