### PR TITLE
feat(erp): Kanban heat-map fallback for windows with no docstatus lifecycle

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -827,13 +827,46 @@
     x.addEventListener('click', close); hd.appendChild(x);
     ov.appendChild(hd); ov.appendChild(node); document.body.appendChild(ov);
   }
+  // distinct-value count of a column across the open window's records (heat-map cardinality scoring).
+  function _distinctCount(col) { var s = {}; _records.forEach(function (r) { s[String(recVal(r, col))] = 1; }); return Object.keys(s).length; }
+  // Pick the best CATEGORICAL/lookup column for a heat map when there is no docstatus lifecycle: prefer
+  // declared FK/list references (tableDirect/table/search/list/yesno) or *_ID columns, with cardinality in a
+  // useful band (≥2, < rows — never constant, never unique-per-row). Falls back to any usable column.
+  function _bestPivot(tab) {
+    var flds = _displayFields(tab) || [], rows = _records.length, best = null, bestScore = -1;
+    var LOOKUP = { tableDirect: 1, table: 1, search: 1, list: 1, yesno: 1 };
+    var ideal = Math.min(24, Math.max(3, Math.ceil(rows / 4)));
+    function consider(f, declared) {
+      var c = _distinctCount(f.columnName); if (c < 2 || c >= rows) return;
+      var score = 1000 - Math.abs(c - ideal) - (declared ? 0 : 6);
+      if (score > bestScore) { bestScore = score; best = f; }
+    }
+    flds.forEach(function (f) { var cn = f.columnName || ''; if (LOOKUP[f.referenceType] || /_id$/i.test(cn)) consider(f, true); });
+    if (!best) flds.forEach(function (f) { consider(f, false); });          // last resort: any usable column
+    return best;
+  }
   function _groupRecs() {
     var tab = _curTab(); if (!tab || !_records.length) return null;
-    var flds = _displayFields(tab) || [], pick = null;
-    for (var i = 0; i < flds.length; i++) { var cn = (flds[i].columnName || '').toLowerCase(); if (cn.indexOf('docstatus') >= 0 || cn.indexOf('status') >= 0) { pick = flds[i]; break; } }
-    if (!pick) pick = flds[0]; if (!pick) return null;
+    var flds = _displayFields(tab) || [], pick = null, hasStatus = false;
+    for (var i = 0; i < flds.length; i++) { var cn = (flds[i].columnName || '').toLowerCase(); if (cn.indexOf('docstatus') >= 0 || cn.indexOf('status') >= 0) { pick = flds[i]; hasStatus = true; break; } }
+    if (!pick) pick = _bestPivot(tab) || flds[0];   // no lifecycle → a sensible lookup, NOT a blind flds[0]
+    if (!pick) return null;
     var g = {}; _records.forEach(function (r) { var v = String(fmt(pick, recVal(r, pick.columnName)) || '(blank)'); (g[v] = g[v] || []).push(r); });
-    return { col: pick, label: pick.name, groups: g, tab: tab };
+    return { col: pick, label: pick.name, groups: g, tab: tab, hasStatus: hasStatus };
+  }
+  // Heat map = the no-pivot fallback for the Kanban (a board with no wfmc states has no drop-zones, so an
+  // empty board is useless): tiles per distinct lookup value, intensity ∝ count. Counts are REAL row folds.
+  function _renderHeatMap(gr, container) {
+    var keys = Object.keys(gr.groups).map(function (k) { return { k: k, n: gr.groups[k].length }; }).sort(function (a, b) { return b.n - a.n; });
+    var max = 1; keys.forEach(function (e) { max = Math.max(max, e.n); });
+    container.appendChild(el('div', 'kb-note', 'No lifecycle (docstatus) in ' + gr.tab.name + ' — heat map by ' + gr.label + ' · ' + keys.length + ' values, ' + _records.length + ' rows.'));
+    var grid = el('div', 'hm-grid');
+    keys.forEach(function (e) { var t = e.n / max, cell = el('div', 'hm-cell');
+      cell.style.background = 'rgba(108,159,255,' + (0.14 + 0.78 * t).toFixed(3) + ')';
+      cell.appendChild(el('div', 'hm-k', e.k)); cell.appendChild(el('div', 'hm-n', String(e.n)));
+      cell.title = e.k + ' · ' + e.n + ' rows'; grid.appendChild(cell); });
+    container.appendChild(grid);
+    console.log('§HEATMAP by=' + gr.col.columnName + ' values=' + keys.length + ' max=' + max + ' rows=' + _records.length + ' table=' + gr.tab.tableName);
   }
   // one-tap switch between the two lenses of the SAME data (Graph bars ⇆ Kanban board) — proper UX:
   // the graph icon's view launches the interactive board, and the board switches back to the chart.
@@ -874,6 +907,14 @@
   async function openKanbanFor() {
     if (!_session) { status('Log in first'); return; }
     var gr = _groupRecs(); if (!gr) { status('Open a window with records first'); return; }
+    if (!gr.hasStatus) {                          // no wfmc lifecycle → heat map (a drop-zone board would be empty)
+      var hc = el('div'); hc.appendChild(_viewSwitch('📊 View as Graph', openGraphFor));
+      var hroot = el('div'); hroot.style.cssText = 'overflow:auto;max-height:72vh'; hc.appendChild(hroot);
+      _renderHeatMap(gr, hroot);
+      _overlay('Heat map — ' + gr.tab.name, hc);
+      console.log('§KANBAN-PILL heatmap by=' + gr.col.columnName + ' table=' + gr.tab.tableName);
+      return;
+    }
     var ok = await _ensureKanbanERP();
     var tab = gr.tab, T = tab.tableName, kc = _keyCol(tab), statusCol = gr.col.columnName;
     if (!ok || !window.KanbanLens) {   // engine/lens absent → honest fall back to the read-only board
@@ -926,7 +967,8 @@
     s.textContent = '#idmp-pillrail{position:fixed;right:10px;top:50%;transform:translateY(-50%);z-index:1200;display:flex;flex-direction:column;gap:8px;max-height:82vh;overflow:auto;padding:8px;border-radius:18px;background:rgba(20,22,32,.82);border:1px solid rgba(255,255,255,.1);backdrop-filter:blur(10px)}' +
       '.idmp-pill{display:flex;flex-direction:column;align-items:center;gap:2px;width:48px;min-height:48px;border:none;border-radius:14px;background:rgba(255,255,255,.06);color:#dfe6f2;cursor:pointer;padding:6px 2px}.idmp-pill:hover{background:rgba(108,159,255,.25)}.idmp-pill-ic{font-size:18px;line-height:1}.idmp-pill-lb{font-size:9px;opacity:.85}' +
       '.chart-wrap{max-width:640px}.chart-title{font-weight:700;margin-bottom:12px}.chart-row{display:flex;align-items:center;gap:10px;margin:6px 0}.chart-lbl{width:120px;font-size:12px;color:#9fb0c8;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.chart-barw{flex:1;background:rgba(255,255,255,.05);border-radius:6px}.chart-bar{background:linear-gradient(90deg,#1c5fa8,#6c9fff);color:#fff;font-size:11px;padding:3px 8px;border-radius:6px;min-width:24px;text-align:right;box-sizing:border-box}' +
-      '.kb-board{display:flex;gap:12px;overflow-x:auto;padding-bottom:8px}.kb-col{flex:0 0 200px;background:rgba(255,255,255,.04);border-radius:12px;padding:8px}.kb-colhd{font-size:12px;font-weight:700;color:#6c9fff;padding:4px 6px;margin-bottom:6px;border-bottom:1px solid rgba(255,255,255,.08)}.kb-card{background:#1a1f2e;border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:8px 10px;margin-bottom:6px;font-size:12px}';
+      '.kb-board{display:flex;gap:12px;overflow-x:auto;padding-bottom:8px}.kb-col{flex:0 0 200px;background:rgba(255,255,255,.04);border-radius:12px;padding:8px}.kb-colhd{font-size:12px;font-weight:700;color:#6c9fff;padding:4px 6px;margin-bottom:6px;border-bottom:1px solid rgba(255,255,255,.08)}.kb-card{background:#1a1f2e;border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:8px 10px;margin-bottom:6px;font-size:12px}' +
+      '.kb-note{font-size:12px;color:#9fb0c8;margin:2px 4px 12px;line-height:1.5}.hm-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px}.hm-cell{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:12px 10px;min-height:58px;display:flex;flex-direction:column;justify-content:space-between;color:#0a1020}.hm-k{font-size:12px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.hm-n{font-size:20px;font-weight:800;align-self:flex-end}';
     document.head.appendChild(s);
   }
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v573';
+const CACHE_VERSION = 'v574';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_heatmap.js
+++ b/erp/tests/poc_heatmap.js
@@ -1,0 +1,72 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for MIGRATE_ERP_PICKER.md §ALSO-REQUESTED — the no-pivot heat-map fallback.
+//   PROVES:
+//     1. §HEATMAP — a window with NO docstatus lifecycle (window=140, Product/M_Product) no longer renders an
+//        empty drop-zone board: the Kanban pill renders a HEAT MAP over a sensibly-detected lookup column
+//        (M_Product_Category_ID), with real per-value row counts (.hm-cell tiles > 1). _groupRecs picks a
+//        lookup, NOT a blind flds[0].
+//     2. board still wins when there IS a lifecycle — a docstatus window (window=167, C_Invoice) logs
+//        §KANBAN-PILL (board) and renders ZERO .hm-cell (no heat map hijack).
+//   Issue it disproves: "a window with no wfmc lifecycle shows an empty/degenerate Kanban board."
+//   §-log first — READ tests/poc_heatmap.log before any conclusion.
+// Run:  node tests/poc_heatmap.js 2>&1 | tee tests/poc_heatmap.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+async function openWindowKanban(browser, port, win) {
+  const logs = [], errs = [];
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+  await page.goto(`http://localhost:${port}/idempiere.html?window=${win}`, { waitUntil: 'networkidle' });
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)', { timeout: 15000 });
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok'); await page.click('#idmp-login-ok');
+  await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const k = await page.$('.idmp-pill[title="Kanban"]');
+  if (k) { await k.click(); await page.waitForTimeout(1800); }
+  const cells = await page.$$eval('.hm-cell', els => els.length).catch(() => 0);
+  await page.screenshot({ path: path.join(__dirname, 'heatmap_w' + win + '.png') });
+  await page.close();
+  return { logs, errs, cells };
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+
+  // 1) no-lifecycle window (AD_Table) → heat map
+  const hm = await openWindowKanban(browser, port, 140);
+  const heatLog = hm.logs.find(l => l.startsWith('§HEATMAP')) || '(no §HEATMAP)';
+  const heatKanban = hm.logs.find(l => l.startsWith('§KANBAN-PILL heatmap')) || '(no heatmap pill)';
+  console.log('§HM-NOPIVOT win=140 ' + heatLog + ' | ' + heatKanban + ' cells=' + hm.cells + ' errs=' + (hm.errs.length ? hm.errs.join('|') : 0));
+
+  // 2) lifecycle window (C_Invoice, has DocStatus) → board, NOT heat map
+  const bd = await openWindowKanban(browser, port, 167);
+  const boardLog = bd.logs.find(l => /^§KANBAN-PILL (live|readonly)/.test(l)) || '(no board)';
+  const noHeat = !bd.logs.find(l => l.startsWith('§HEATMAP'));
+  console.log('§HM-LIFECYCLE win=167 ' + boardLog + ' heatCells=' + bd.cells + ' noHeatMap=' + noHeat + ' errs=' + (bd.errs.length ? bd.errs.join('|') : 0));
+
+  const heatOk = /^§HEATMAP by=/.test(heatLog) && hm.cells > 1 && hm.errs.length === 0;
+  const boardOk = /^§KANBAN-PILL (live|readonly)/.test(boardLog) && bd.cells === 0 && noHeat && bd.errs.length === 0;
+  console.log('§HEATMAP-WITNESS heatOk=' + heatOk + ' boardOk=' + boardOk);
+  const pass = heatOk && boardOk;
+  console.log('§HEATMAP ' + (pass ? 'PASS' : 'FAIL'));
+
+  await browser.close(); server.close();
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
## What
ALSO-REQUESTED in `prompts/MIGRATE_ERP_PICKER.md`. A window whose table has no wfmc lifecycle rendered a degenerate Kanban (a board with no drop-zones) because `_groupRecs` fell back to a blind `flds[0]`.

- **`_bestPivot()`** picks a sensible categorical/lookup column (declared FK/list/yesno refs, or `*_ID`) with cardinality in a useful band (≥2, < rows — never constant, never unique-per-row).
- `_groupRecs` now flags `hasStatus`; the no-lifecycle case groups by the lookup, not `flds[0]`.
- The Kanban pill renders a **heat map** (tiles per distinct value, intensity ∝ real row counts) instead of an empty board.

## Witness (§-log first)
`tests/poc_heatmap.js` → **§HEATMAP PASS**:
- `win=140` Product (no docstatus) → `§HEATMAP by=M_Product_Category_ID … 13 cells`
- `win=167` C_Invoice (docstatus) → `§KANBAN-PILL` board, 0 heat cells (no hijack)

SW `erp/sw.js` v573→v574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)