### PR TITLE
fix(erp): idempiere.html fits a 390px phone (grid + header overflow)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -74,7 +74,9 @@
   .idmp-children { display:none; }
   .idmp-node.open > .idmp-children { display:block; }
   /* ── Main content ── */
-  #idmp-main { flex:1; display:flex; flex-direction:column; min-height:0; background:var(--idmp-bg); }
+  /* min-width:0 lets the flex item shrink below the grid's intrinsic width so the grid scrolls INSIDE
+     #idmp-content (overflow:auto) instead of ballooning #idmp-main past the viewport (mobile overflow fix). */
+  #idmp-main { flex:1; min-width:0; display:flex; flex-direction:column; min-height:0; background:var(--idmp-bg); }
   /* window MDI tabs */
   #idmp-wintabs {
     flex:0 0 auto; display:flex; align-items:flex-end; gap:2px; padding:6px 8px 0; background:var(--idmp-bg);
@@ -197,6 +199,9 @@
     body.menu-open #idmp-menu { transform:translateX(0); }
     .idmp-form { grid-template-columns:1fr; }
     .idmp-fld label { flex-basis:110px; }
+    /* the header breadcrumb (#idmp-ctx) is nowrap and shoved the role/home/help buttons off the right edge at
+       390px; it duplicates the bottom status bar, so drop it on mobile and keep the buttons reachable. */
+    #idmp-header .ctx { display:none; }
   }
 </style>
 </head>

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,7 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v574';
+const CACHE_VERSION = 'v575';
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_mobile_gridfit.js
+++ b/erp/tests/poc_mobile_gridfit.js
@@ -1,0 +1,32 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that idempiere.html FITS a 390px phone — the gap the narrow §MOB-TOPBAR
+//   witness missed. PROVES (issue: "mobile not done — #idmp-main 2145px, header buttons off-screen right"):
+//     1. no horizontal PAGE scroll (document.scrollWidth == clientWidth) — the AD grid no longer balloons the
+//        page; #idmp-main constrained to the viewport (the min-width:0 flex fix).
+//     2. the grid is still REACHABLE — it scrolls horizontally INSIDE #idmp-content (overflow:auto), not by
+//        pushing the page (which body{overflow:hidden} would clip → unreachable on touch).
+//     3. the header role/home/help buttons (#idmp-switch/home/help-btn) are ON-SCREEN (breadcrumb hidden on
+//        mobile, it duplicates the bottom status bar).
+//   §-log first — READ tests/poc_mobile_gridfit.log before any conclusion.
+// Run:  node tests/poc_mobile_gridfit.js 2>&1 | tee tests/poc_mobile_gridfit.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http=require('http'),fs=require('fs'),path=require('path');const ROOT=path.join(__dirname,'..');
+const MIME={'.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png'};
+const server=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/idempiere.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){r.writeHead(404);r.end('404');return;}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});r.end(b);});});
+(async()=>{await new Promise(r=>server.listen(0,r));const port=server.address().port;
+const br=await chromium.launch();const pg=await br.newPage();await pg.setViewportSize({width:390,height:844});
+const errs=[];pg.on('pageerror',e=>errs.push(e.message));
+await pg.goto(`http://localhost:${port}/idempiere.html?window=140`,{waitUntil:'networkidle'});
+await pg.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)',{timeout:15000});
+await pg.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+await pg.waitForSelector('#idmp-login-ok');await pg.click('#idmp-login-ok');await pg.waitForTimeout(1500);
+const m=await pg.evaluate(()=>{var de=document.documentElement,vw=de.clientWidth;var c=document.getElementById('idmp-content');
+  function on(id){var e=document.getElementById(id);if(!e)return false;var b=e.getBoundingClientRect();return b.right<=vw+1&&b.left>=-1;}
+  return {pageOverflow:de.scrollWidth>vw+1, docSW:de.scrollWidth, vw:vw, mainW:Math.round(document.getElementById('idmp-main').getBoundingClientRect().width),
+    contentScrolls:c?c.scrollWidth>c.clientWidth+1:false, help:on('idmp-help-btn'), home:on('idmp-home-btn'), sw:on('idmp-switch-btn')};});
+await pg.screenshot({path:path.join(__dirname,'mob_topbar_fixed.png')});
+console.log('§MOBILE-GRIDFIT pageOverflow='+m.pageOverflow+' docSW='+m.docSW+' mainW='+m.mainW+'/vw='+m.vw+' gridScrollsInContent='+m.contentScrolls+' btnsOnscreen=help:'+m.help+'/home:'+m.home+'/switch:'+m.sw+' pageErrors='+(errs.length?errs.join('|'):0));
+const pass=!m.pageOverflow&&m.mainW<=m.vw+1&&m.contentScrolls&&m.help&&m.home&&m.sw&&errs.length===0;
+console.log('§MOBILE-GRIDFIT '+(pass?'PASS':'FAIL'));
+await br.close();server.close();process.exit(pass?0:1);})().catch(e=>{console.error('PROBE-ERR',e);server.close();process.exit(2);});


### PR DESCRIPTION
## What
At 390px the iDempiere renderer didn't fit: `#idmp-main` was **2145px** wide (the AD grid never constrained to the viewport), so `body{overflow:hidden}` clipped the right-hand grid columns **and** the header role/home/help buttons — unreachable on touch. The earlier `§MOB-TOPBAR` witness passed narrowly (breadcrumb + pill rail only) and never measured the content.

- `#idmp-main { min-width:0 }` — lets the flex item shrink below the grid's intrinsic width; the grid now scrolls **inside** `#idmp-content` (`overflow:auto`) instead of pushing the page.
- `@media(max-width:760px)`: hide the header breadcrumb `#idmp-ctx` (it duplicates the bottom status bar and shoved the buttons off-screen).

## Witness (§-log first)
`tests/poc_mobile_gridfit.js` → **§MOBILE-GRIDFIT PASS**: `docSW 2145→390`, no page overflow, grid scrolls in-container, switch/home/help on-screen, 0 pageerror. Picker + heat-map witnesses still green (no desktop regression).

SW `erp/sw.js` v574→v575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)