### PR TITLE
fix(shadow): §S288b refresh shadow map per traverse-chunk — kills shadow-sampler warning

### DIFF
--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -696,8 +696,16 @@ function setupTools(A) {
       (function _shadowChunk() {
         var end = Math.min(_si + 5000, _shadowList.length);
         for (; _si < end; _si++) { var o = _shadowList[_si]; if (o.visible) { o.castShadow = true; o.receiveShadow = true; } }
+        // §S288b: refresh the static shadow map after EVERY chunk, not just the last.
+        // With autoUpdate=false the depth texture is only (re)rendered on needsUpdate;
+        // a frame that renders mid-traverse — casters already tagged castShadow, materials
+        // compiled with a shadow sampler — would otherwise sample an unrendered shadow map
+        // ("not a depth texture with TEXTURE_COMPARE_MODE" WebGL warning, one frame of bad
+        // shading). Setting needsUpdate per chunk guarantees the texture exists before sampling.
+        A.renderer.shadowMap.needsUpdate = true;
+        if (A.markDirty) A.markDirty();
         if (_si < _shadowList.length) setTimeout(_shadowChunk, 0);
-        else { A.renderer.shadowMap.needsUpdate = true; if (A.markDirty) A.markDirty(); console.log('§SHADOW_TRAVERSE done count=' + _shadowList.length); }
+        else { console.log('§SHADOW_TRAVERSE done count=' + _shadowList.length); }
       })();
     } else {
       var _unshadowList = [];


### PR DESCRIPTION
Follow-up to #132.

## Regression introduced by #132
`§S288` set `shadowMap.autoUpdate=false`, but `needsUpdate` was only set at the **end** of the chunked caster-traverse (8789 casters → multiple `setTimeout` passes). A frame rendering **mid-traverse** had casters already tagged `castShadow` + materials compiled with a shadow sampler, but the shadow map's depth texture hadn't rendered yet:

```
WebGL warning: drawElementsInstanced: TEXTURE_2D at unit 0 is not a depth texture
with TEXTURE_COMPARE_MODE, but the shader sampler is a shadow sampler.
```

(one frame of wrong shading). With the old `autoUpdate=true` the map rendered every frame, so the texture always existed — hence this is new in #132.

## Fix (`viewer/tools.js`)
Set `needsUpdate=true` (+`markDirty()`) after **every** chunk, not just the last → the depth texture is (re)rendered as casters appear, always valid before sampling. Steady-state energy win unchanged (`autoUpdate` still `false`; `§SHADOW_PERF` gate intact).

## Verification
Driver-specific (real-GPU Firefox; headless swiftshader doesn't emit it) — observed live on LTU_AHouse (122K, 8789 casters), re-confirm in-browser that the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)