### PR TITLE
feat(erp-hud): remove top-right ⛶ maximize + 🔍 search icons (pill rail dup)

### DIFF
--- a/erp/ad_ui.js
+++ b/erp/ad_ui.js
@@ -1610,21 +1610,11 @@
       }
     });
 
-    container.appendChild(fsBtn);
-
-    // Search button — mobile access (no Alt+S on touch devices)
-    var searchBtn = document.createElement('button');
-    searchBtn.textContent = '\uD83D\uDD0D'; // 🔍
-    searchBtn.title = 'Search (Alt+S)';
-    searchBtn.style.cssText = 'position:absolute;top:6px;right:40px;background:rgba(0,0,0,0.5);' +
-      'border:1px solid rgba(255,255,255,0.15);color:#aaa;font-size:14px;' +
-      'cursor:pointer;width:28px;height:28px;border-radius:6px;z-index:5;' +
-      'display:flex;align-items:center;justify-content:center;line-height:1;';
-    searchBtn.addEventListener('pointerup', function (e) {
-      e.stopPropagation();
-      _toggleSearchOverlay();
-    });
-    container.appendChild(searchBtn);
+    // §HUD-DEDUP — top-right ⛶ maximize + 🔍 search icons REMOVED from the graph HUD.
+    // Both live in the pill rail now (erp_pills.js: id=find → search, id=maximize → fullscreen),
+    // so the in-container duplicates are gone. fsBtn stays DEFINED (not appended) because
+    // _resizeGraph mutates its label/style during the globe auto-maximize; it's just no longer shown.
+    console.log('§AD_UI hud-dedup removed=[maximize,search] keptInPill=[find,maximize]');
 
     // Companion links (🫧 Glassbowl · ✦ Gravity · 📖 Read) REMOVED from the graph HUD — they were
     // buttons OUTSIDE the pill rail. All in the pill now: glassbowl/gravity already in pills.json;

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,8 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v578';   // v578: glassbowl/gravity pills → LOCAL nav (was remote BIMCompiler GH Pages);
+const CACHE_VERSION = 'v579';   // v579: removed top-right ⛶ maximize + 🔍 search HUD icons (dup of pill rail);
+                                // v578: glassbowl/gravity pills → LOCAL nav (was remote BIMCompiler GH Pages);
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Removes the two redundant HUD icons at the top-right of the ERP globe/graph surface. Both controls already live in the pill rail (`erp_pills.js`: `id=find` → search, `id=maximize` → fullscreen), so the in-container duplicates were just clutter.

## Changes
- `erp/ad_ui.js` — `searchBtn` (🔍) deleted entirely; `fsBtn` (⛶) no longer appended to the DOM. `var fsBtn` stays **defined** because `_resizeGraph` mutates its label/style during the globe's auto-maximize — it's simply never shown now.
- Witness line replaces them: `§AD_UI hud-dedup removed=[maximize,search] keptInPill=[find,maximize]`
- `erp/sw.js` — `CACHE_VERSION` v578→v579 so clients re-fetch the updated `ad_ui.js`.

`node --check` passes on both files; zero remaining `searchBtn` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)