### PR TITLE
fix(viewer): catch fullscreen promise — no more uncaught F11 rejection

### DIFF
--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -360,11 +360,16 @@ function setupTools(A) {
 
   // Fullscreen
   A.toggleFullscreen = function() {
-    if (!document.fullscreenElement) {
-      document.documentElement.requestFullscreen();
-    } else {
-      document.exitFullscreen();
-    }
+    // §FULLSCREEN: requestFullscreen()/exitFullscreen() return promises. F11 is
+    // browser-reserved (Firefox does native fullscreen), so the programmatic request
+    // from that same handler is denied → unhandled rejection ("Uncaught (in promise)
+    // TypeError: Fullscreen request denied"). Swallow it — native F11 still works.
+    try {
+      var p = !document.fullscreenElement
+        ? document.documentElement.requestFullscreen()
+        : document.exitFullscreen();
+      if (p && p.catch) p.catch(function(e) { console.warn('§FULLSCREEN denied: ' + (e && e.message)); });
+    } catch (e) { console.warn('§FULLSCREEN error: ' + (e && e.message)); }
   };
 
   // Theme — reverse background (light/dark)


### PR DESCRIPTION
Surfaced during shadow-fix testing (unrelated to #132/#133).

`A.toggleFullscreen` called `requestFullscreen()`/`exitFullscreen()` without catching the returned promise. F11 is browser-reserved (Firefox does native fullscreen), so the page's programmatic request from that same keydown handler is denied → **`Uncaught (in promise) TypeError: Fullscreen request denied`** on every F11 press. Harmless (native F11 still works) but it's an unhandled rejection that can mask real errors.

Fix: catch the promise (+ try/catch the sync call), log `§FULLSCREEN` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)