### PR TITLE
fix(charts): restore chart tooltips (Chart.defaults.animation regression)

### DIFF
--- a/viewer/boq_charts.html
+++ b/viewer/boq_charts.html
@@ -1323,7 +1323,10 @@ function renderCharts() {
   const _tCharts = performance.now();
   console.log('§RENDER_CHARTS: start');
   // Light chart animations — quick, no infinite loops
-  Chart.defaults.animation = { duration: 800 };
+  // Mutate duration on the existing v4 animation defaults — do NOT replace the whole
+  // object (that drops the interpolator config → "this._fn is not a function" in the
+  // animator tick, which also kills tooltip fade → invisible tooltips). Migration 818ae9f.
+  Chart.defaults.animation.duration = 800;
   function logChart(n, type, title, dataLen) {
     console.log(`§CHART_${n} [${type}] "${title}": ${dataLen} data points — ${dataLen > 0 ? 'OK' : 'EMPTY'} +${Math.round(performance.now() - _tCharts)}ms`);
   }
@@ -2025,7 +2028,7 @@ function toggleTheme() {
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=592')
+  navigator.serviceWorker.register('sw.js?v=593')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v592';
+const CACHE_VERSION = 'v593';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Migration `818ae9f` set `Chart.defaults.animation = { duration: 800 }`, replacing the whole Chart.js v4 animation object → animator throws `this._fn is not a function` → tooltip fade stuck at opacity ~0.025 (invisible hover). Fix: mutate `.duration` instead of replacing.

Witnessed (headless Chromium, real hover): before this._fn=true/opacity=0.025 → after this._fn=false/opacity=1.0. Full render witness still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)