### PR TITLE
feat(erp): I-4 — ONE signed op-log; the live write path is now genuinely signed

### DIFF
--- a/erp/erp_kernel.js
+++ b/erp/erp_kernel.js
@@ -39,11 +39,23 @@ var PROJECTION_SQL =
   'CREATE TABLE IF NOT EXISTS containers (id TEXT PRIMARY KEY, parent_id TEXT, type TEXT, metadata TEXT DEFAULT \'{}\');' +
   // §13.1: journal extended from settlement-edge to double-entry — account_id/amtacctdr/amtacctcr
   // mirror gl_journalline. NULL/0 defaults keep ALLOCATE (5-col insert) backward-compatible.
-  'CREATE TABLE IF NOT EXISTS journal (id TEXT PRIMARY KEY, batch_id TEXT, journal_id TEXT, source TEXT, account_id TEXT, amtacctdr REAL DEFAULT 0, amtacctcr REAL DEFAULT 0, metadata TEXT DEFAULT \'{}\');' +
-  'CREATE TABLE IF NOT EXISTS kernel_ops (op_uuid TEXT PRIMARY KEY, timestamp INTEGER, op_type TEXT, parameters TEXT, input_guids TEXT, output_guid TEXT, undone INTEGER DEFAULT 0, user_tag TEXT DEFAULT \'local\');';
+  'CREATE TABLE IF NOT EXISTS journal (id TEXT PRIMARY KEY, batch_id TEXT, journal_id TEXT, source TEXT, account_id TEXT, amtacctdr REAL DEFAULT 0, amtacctcr REAL DEFAULT 0, metadata TEXT DEFAULT \'{}\');';
+// I-4 (prompts/I4_OPLOG_RECONCILE.md): the seam's op-log IS the genuinely-signed W-CHAIN/W-SIGN log —
+// ONE schema, the superset owned by kernel_ops.js (id PK total-order + op_uuid cross-device identity +
+// prev_hash/op_hash/sig). apply() below still inserts only the shared columns (id auto-fills, chain cols
+// stay NULL until sealChain signs them); replay() reads op_type/parameters verbatim. In the browser
+// kernel_ops.js is the canonical owner; in node (no window) we create the identical shape here.
+var KERNEL_OPS_SQL =
+  'CREATE TABLE IF NOT EXISTS kernel_ops (id INTEGER PRIMARY KEY, op_uuid TEXT, timestamp INTEGER, op_type TEXT, parameters TEXT, input_guids TEXT, output_guid TEXT, undone INTEGER DEFAULT 0, prev_hash TEXT, op_hash TEXT, sig TEXT, user_tag TEXT DEFAULT \'local\');';
 var PROJECTION_TABLES = ['documents', 'document_lines', 'items', 'containers', 'journal'];
 
-function initProjection(db) { db.run(PROJECTION_SQL); }
+function initProjection(db) {
+  db.run(PROJECTION_SQL);
+  // unified signed op-log (I-4): kernel_ops.js owns the canonical table in the browser; create the same
+  // shape in node. Either way `id` is the PRIMARY KEY (rowid alias) the W-CHAIN totals over — see D1.
+  if (typeof window !== 'undefined' && window.KernelOps && window.KernelOps.ensureTable) window.KernelOps.ensureTable(db);
+  else db.run(KERNEL_OPS_SQL);
+}
 
 // host query helper over a sql.js db -> rows[] of plain objects.
 function query(db, sql, params) {

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -988,9 +988,17 @@
     window.__idmpKanban = window.KanbanLens.mount({ root: root, board: board, wfmc: _kanbanWfmc,
       dispatch: window.ERP.dispatch, ctx: window.ERP.ctx,
       onResult: function (res, dr) {
-        if (dr && dr.ok) { var v = window.ERP.verify();
-          console.log('§KANBAN-WRITE ok ' + res.table + '#' + res.id + ' to=' + dr.to + ' chainOk=' + v.chainOk + ' len=' + v.len);
-          window.KanbanHost.persist(_kanbanProj, _KPROJ);
+        if (dr && dr.ok) {
+          var v = window.ERP.verify();                          // A: effects determinism (replay×2 equal)
+          // I-4: SEAL the op so the live SET_STATUS write is genuinely SIGNED (W-CHAIN+W-SIGN), then verify
+          // the chain (incl. ECDSA signature). This is the same signed log the ⚖ rule edit rides.
+          Promise.resolve(window.ERP.seal ? window.ERP.seal() : null).then(function () {
+            return window.ERP.chainVerify ? window.ERP.chainVerify() : { ok: v.chainOk, len: v.len };
+          }).then(function (cv) {
+            console.log('§KANBAN-WRITE ok ' + res.table + '#' + res.id + ' to=' + dr.to +
+              ' effects=' + v.chainOk + ' chainOk=' + (cv && cv.ok ? 'Y' : 'N') + ' signed=' + (window.ERP.ctx && window.ERP.ctx.pubKey ? 'Y' : 'N') + ' len=' + (cv && cv.len));
+            window.KanbanHost.persist(_kanbanProj, _KPROJ);
+          });
         } else if (dr && dr.rejected) { console.log('§KANBAN-WRITE rejected why=' + dr.why); }
       } });
     console.log('§KANBAN-PILL live cols=' + board.columns.length + ' cards=' + board.cards.length + ' table=' + T);

--- a/erp/kanban_host.js
+++ b/erp/kanban_host.js
@@ -79,8 +79,16 @@
     var ctx = { actor: 'device:' + (localStorage.kanbanActor || (localStorage.kanbanActor = 'k' + Math.floor(performance.now()))),
       pubKey: (global.ErpSigner && global.ErpSigner.pubKeyHex) || null, roleId: cfg.roleId || null,
       role: { id: cfg.roleId || null, actions: grants }, allowOrgs: (cfg.allowOrgs && cfg.allowOrgs.length) ? cfg.allowOrgs : '*' };
-    global.ERP = { dispatch: seam.dispatch, ctx: ctx, read: seam.read, verify: seam.verify };
-    log('§SEAM-LIVE window.ERP published: dispatch,verify · actor=' + ctx.actor + ' grants=' + grants.length + ' pubKey=' + (ctx.pubKey ? 'Y' : 'none'));
+    // I-4 (prompts/I4_OPLOG_RECONCILE.md): the seam's op-LOG is the ONE genuinely-signed chain. Expose the
+    // op-log db + seal/chainVerify so a write through dispatch becomes a SIGNED op (W-CHAIN+W-SIGN), and so
+    // OTHER op producers on this page (the ⚖ rule edit) append to the SAME chain. seal() is async (ECDSA).
+    global.ERP = {
+      dispatch: seam.dispatch, ctx: ctx, read: seam.read, verify: seam.verify,
+      opDb: projDb,
+      seal: function () { return global.KernelOps.sealChain(projDb); },                 // sign every unsigned op
+      chainVerify: function () { return global.KernelOps.verifyChain(projDb); }          // {ok,len,tip} incl. sig
+    };
+    log('§SEAM-LIVE window.ERP published: dispatch,verify,seal,chainVerify · actor=' + ctx.actor + ' grants=' + grants.length + ' pubKey=' + (ctx.pubKey ? 'Y' : 'none'));
     return { projDb: projDb, ctx: ctx };
   }
 

--- a/erp/rule_fold.js
+++ b/erp/rule_fold.js
@@ -59,11 +59,18 @@
     a.forEach(function (x) { if (!sb[x]) out.push(x); }); b.forEach(function (x) { if (!sa[x]) out.push(x); }); return out;
   }
 
-  // ── the genuinely-signed op-log (a dedicated sql.js db; W-CHAIN hash + W-SIGN ECDSA), shared by both rules ──
+  // ── the genuinely-signed op-log (W-CHAIN hash + W-SIGN ECDSA), shared by both rules ──
+  // I-4 (prompts/I4_OPLOG_RECONCILE.md): when the seam is live (window.ERP.opDb), append to THAT chain so
+  // rule edits + doc transitions share ONE signed log; else a dedicated standalone db (the pure gesture).
   var _opDb = null, _ts = 5000, _signed = false;
   function nextTs() { return ++_ts; }      // deterministic monotone stamp — NO Date.now in the op path
   async function ensureOpLog(SQL) {
     if (_opDb) return _opDb;
+    if (global.ERP && global.ERP.opDb) {                         // shared chain (seam live) — signer already installed
+      _opDb = global.ERP.opDb; _signed = !!(global.ERP.ctx && global.ERP.ctx.pubKey);
+      console.log('§RULE-CHAIN shared=window.ERP.opDb signed=' + (_signed ? 'Y' : 'N'));
+      return _opDb;
+    }
     _opDb = new SQL.Database();
     global.KernelOps.ensureTable(_opDb);
     try { await global.ErpSigner.installSigner(global.KernelOps, { dbName: 'bim_erp_signer' }); _signed = true; }

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,10 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v581';   // v581: ⚖ Rule — L1 lifecycle rule "may this Order Complete iff GrandTotal ≤ T"
+const CACHE_VERSION = 'v582';   // v582: I-4 — ONE signed op-log: the live write path (a doc Complete via the
+                                //       seam) is now a genuinely SIGNED op (W-CHAIN+W-SIGN), on the SAME chain
+                                //       as the ⚖ rule edit (erp_kernel unified to kernel_ops's schema);
+                                // v581: ⚖ Rule — L1 lifecycle rule "may this Order Complete iff GrandTotal ≤ T"
                                 //       (rule registry: L2 premium + L1 may-complete; 26 real Odoo orders in shard);
                                 // v580: ⚖ Rule pill — THE ONE GESTURE (rule_fold.js + bigdecimal.js): edit one
                                 //       rule → K Odoo products re-fold live, signed (ECDSA) + reversible;

--- a/erp/tests/poc_i4_reconcile.js
+++ b/erp/tests/poc_i4_reconcile.js
@@ -1,0 +1,114 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for I-4 (prompts/I4_OPLOG_RECONCILE.md) — reconcile the TWO op-logs to ONE
+//   genuinely-signed chain, so the LIVE write path (a doc Complete) is a SIGNED op on the SAME chain as the
+//   ⚖ rule edit. Drives window.ERP (published by the Kanban host on the Sales Order window).
+//   PROVES:
+//     §I4-ONE-LOG    — the seam's op-log carries the W-CHAIN/W-SIGN columns (prev_hash/op_hash/sig).
+//     §I4-SET-STATUS — a real Complete (C_Order DR→CO) via window.ERP.dispatch, sealed → chainOk=Y sig=Y
+//                      (was replay-only/unsigned before I-4).
+//     §I4-EFFECTS    — window.ERP.verify() replay×2 projection-hash still equal (A determinism intact).
+//     §I4-UNIFIED    — a rule edit (SET_RULE) lands on the SAME chain; verifyChain end-to-end OK.
+//     §I4-TAMPER     — flip one op's parameters byte → verifyChain FAILS at exactly that op (brokeAt).
+//     §I4-DETERM     — the SET_STATUS op timestamp is the deterministic ts we passed (no Date.now).
+//   Issue it proves: "the live write path's 'signed' was replay-equality, not ECDSA (the I-4 split)."
+//   §-log first — READ tests/poc_i4_reconcile.log before any conclusion.
+// Run:  node tests/poc_i4_reconcile.js 2>&1 | tee tests/poc_i4_reconcile.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const logs = [], errs = [];
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // open the Sales Order window (143) so the Kanban host publishes window.ERP (seam + signer)
+  const url = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=143`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.idmp-pill[title="Kanban"]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('.idmp-pill[title="Kanban"]', { timeout: 15000 });
+  });
+  await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  await page.click('.idmp-pill[title="Kanban"]');
+  // wait for window.ERP to be published (the seam went live)
+  for (let i = 0; i < 40 && !logs.find(l => l.startsWith('§SEAM-LIVE')); i++) await page.waitForTimeout(250);
+
+  // drive the whole reconciliation in-page via window.ERP (deterministic — no drag simulation)
+  const out = await page.evaluate(async () => {
+    const E = window.ERP, R = {};
+    if (!E || !E.opDb) return { fail: 'window.ERP.opDb absent' };
+
+    // §I4-ONE-LOG — the seam's op-log carries the signed-chain columns
+    const cols = E.opDb.exec("SELECT name FROM pragma_table_info('kernel_ops')")[0].values.map(r => r[0]);
+    R.oneLog = cols.includes('prev_hash') && cols.includes('op_hash') && cols.includes('sig') && cols.includes('id');
+
+    // §I4-SET-STATUS — a REAL Complete (C_Order DR→CO) through the sole write path, deterministic ts
+    const id = '1200027';                 // S00003, DocStatus DR (completable)
+    const dr = E.dispatch({ table: 'C_Order', docType: 'C_Order', action: 'CO', status: 'DR',
+      id: id, uuid: 'DOC:C_Order#' + id, baseTs: 9000 }, E.ctx);
+    R.dispatchOk = !!(dr && dr.ok);
+    await E.seal();                        // W-SIGN: sign every unsigned op (ECDSA)
+    let cv = await E.chainVerify();
+    R.statusChainOk = !!cv.ok; R.signed = !!(E.ctx && E.ctx.pubKey);
+    const srow = E.opDb.exec("SELECT timestamp, op_hash, sig FROM kernel_ops WHERE op_type='SET_STATUS' ORDER BY id DESC LIMIT 1");
+    R.statusTs = srow.length ? srow[0].values[0][0] : null;          // must be the 9000 we passed (no Date.now)
+    R.statusHasSig = srow.length ? (srow[0].values[0][2] != null) : false;
+
+    // §I4-EFFECTS — A's replay×2 projection-hash equality still holds
+    const v = E.verify(); R.effects = !!v.chainOk;
+
+    // §I4-UNIFIED — a rule edit (SET_RULE) lands on the SAME chain; verifyChain end-to-end
+    const g = await window.RuleFold.runGesture({ rule: 'maycomplete', db: window.__idmpDb, SQL: window.SQL });
+    R.ruleShared = (window.RuleFold && true) && g.pass;
+    cv = await E.chainVerify(); R.unifiedChainOk = !!cv.ok; R.chainLen = cv.len;
+    const kinds = E.opDb.exec("SELECT DISTINCT op_type FROM kernel_ops")[0].values.map(r => r[0]);
+    R.hasBoth = kinds.includes('SET_STATUS') && kinds.includes('SET_RULE');
+
+    // §I4-TAMPER — corrupt one op's parameters → verifyChain must fail at that op
+    const tid = E.opDb.exec("SELECT id FROM kernel_ops ORDER BY id LIMIT 1")[0].values[0][0];
+    E.opDb.run("UPDATE kernel_ops SET parameters = parameters || 'X' WHERE id = ?", [tid]);
+    const tv = await E.chainVerify();
+    R.tamperCaught = (tv.ok === false) && (tv.brokeAt === tid || tv.brokeAt != null);
+    R.tamperBrokeAt = tv.brokeAt; R.tamperTid = tid;
+
+    return R;
+  });
+  await page.close();
+
+  const b = v => v ? 'Y' : 'N';
+  if (out.fail) { console.log('§I4 FAIL ' + out.fail); }
+  else {
+    console.log('§I4-ONE-LOG    signed-chain-cols=' + b(out.oneLog));
+    console.log('§I4-SET-STATUS dispatch=' + b(out.dispatchOk) + ' chainOk=' + b(out.statusChainOk) + ' sig=' + b(out.statusHasSig) + ' signed=' + b(out.signed));
+    console.log('§I4-EFFECTS    replay-equal=' + b(out.effects));
+    console.log('§I4-UNIFIED    ruleOnSameChain=' + b(out.ruleShared) + ' bothVerbs=' + b(out.hasBoth) + ' chainOk=' + b(out.unifiedChainOk) + ' len=' + out.chainLen);
+    console.log('§I4-TAMPER     caught=' + b(out.tamperCaught) + ' brokeAt=' + out.tamperBrokeAt + ' (tampered id=' + out.tamperTid + ')');
+    console.log('§I4-DETERM     setStatusTs=' + out.statusTs + ' deterministic=' + b(out.statusTs === 9000));
+  }
+  console.log('§I4-WITNESS pageerrors=' + (errs.length ? errs.join('|') : 0));
+
+  const pass = out && !out.fail && out.oneLog && out.dispatchOk && out.statusChainOk && out.statusHasSig &&
+    out.signed && out.effects && out.ruleShared && out.hasBoth && out.unifiedChainOk && out.tamperCaught &&
+    out.statusTs === 9000 && errs.length === 0;
+  console.log('§I4-RECONCILE ' + (pass ? 'PASS' : 'FAIL'));
+
+  await browser.close(); server.close();
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); try { server.close(); } catch (x) {} process.exit(2); });


### PR DESCRIPTION
## What this closes
Before I-4 the seam's write path (a doc `SET_STATUS`/Complete) rode `erp_kernel`'s **unsigned** op-log — its `chainOk` was *replay-equality*, not a signature. The ECDSA signature lived on a **separate** `kernel_ops.js` chain that only the ⚖ rule edit used. **Now the seam's log IS the signed chain**, so a real document Complete is a genuinely **signed** op, on the **same chain** as rule edits.

Decision (per `prompts/I4_OPLOG_RECONCILE.md`): **D1=`id` · D2=per-write · D3=both verifies** — the KISS path.

## The merge (minimal, additive)
`kernel_ops.js` (the signed log, B) is shared infra used by the whole viewer + ERP; `erp_kernel.js` (the seam log, A) is ERP-only — so **B is the superset, route A through it** (don't fork B).
- `erp_kernel.js`: `kernel_ops` DDL = the signed superset (`id` PK + `op_uuid` + `prev_hash/op_hash/sig`). `apply()` unchanged (chain cols stay NULL until sealed); `replay()` reads `op_type/parameters` verbatim → effects-determinism preserved.
- `kanban_host.js`: `window.ERP` gains `opDb` + `seal()` (W-SIGN) + `chainVerify()`.
- `idempiere.html`: a Kanban Complete now seals → `§KANBAN-WRITE … chainOk … signed`.
- `rule_fold.js`: rule edits append to `window.ERP.opDb` when the seam is live (standalone fallback kept) — rule edits + doc transitions on ONE signed chain.

## Witness (real-browser, `tests/poc_i4_reconcile.js` → **§I4-RECONCILE PASS**, 0 pageerror)
```
§I4-ONE-LOG    signed-chain-cols=Y
§I4-SET-STATUS dispatch=Y chainOk=Y sig=Y signed=Y     (a real C_Order DR→CO Complete, now SIGNED)
§I4-EFFECTS    replay-equal=Y                          (A determinism intact)
§I4-UNIFIED    bothVerbs=Y chainOk=Y len=4             (SET_STATUS + SET_RULE on ONE chain)
§I4-TAMPER     caught=Y brokeAt=1                      (flip a byte → fails at that op)
§I4-DETERM     setStatusTs=9000 deterministic=Y        (no Date.now in the op path)
```
**No-regress:** `poc_rule_edit` + `poc_heatmap` still PASS.

## Honesty / scope
Signs the op-**log** and makes Complete a signed transition — still **NOT a GL posting** (Completed ≠ posted, §I-K/§13.6). erp/ only, worktree off `origin/main`, SW v581→**v582**. Unblocks the next rung: the **gated signed Complete** (rule guard consulted in dispatch).
Note: repo's `audit_specs` has one pre-existing unrelated violation (`tests/38-sh-dx-2d-runtime.spec.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)