### PR TITLE
feat(erp): gated signed Complete — the editable rule governs the CO lifecycle transition

### DIFF
--- a/erp/erp_seam.js
+++ b/erp/erp_seam.js
@@ -27,6 +27,9 @@
 var fs = (typeof require !== 'undefined') ? require('fs') : null;
 var K = (typeof require !== 'undefined') ? require('./erp_kernel')
         : (typeof window !== 'undefined' ? window.ERPKernel : null);
+// BigDecimal for EXACT money/qty compare in the admission guard (never raw JS Number). Browser: window.BigDecimal.
+var BD = (typeof window !== 'undefined' && window.BigDecimal) ? window.BigDecimal
+       : ((typeof require !== 'undefined') ? (function () { try { return require('./bigdecimal'); } catch (e) { return null; } })() : null);
 
 function projQ(db, sql, params) { return K.query(db, sql, params || []); }
 
@@ -63,6 +66,14 @@ function makeSeam(cfg) {
 
   // ── dispatch(intent, ctx) — the SOLE write path; gated engine-side, deterministic+signed (I4) ────
   // Returns {ok, op_uuid, before, after} or {rejected, why}. ctx{actor,pubKey,roleId,allowOrgs,role}.
+  // current threshold of an admission rule = the last SET_RULE for that rule on the SAME signed op-log.
+  function currentRuleT(ruleId) {
+    var rows = projQ(projDb, "SELECT parameters FROM kernel_ops WHERE op_type='SET_RULE' AND undone=0 ORDER BY rowid");
+    var T = null;
+    rows.forEach(function (r) { try { var p = JSON.parse(r.parameters); var pl = p.payload || p; if (pl && pl.rule === ruleId && pl.T != null) T = pl.T; } catch (e) {} });
+    return T;
+  }
+
   function dispatch(intent, ctx) {
     ctx = ctx || {};
     var table = intent.table, action = intent.action;
@@ -70,6 +81,24 @@ function makeSeam(cfg) {
     if (ctx.role && ctx.role.actions) {
       var key = table + ':' + action;
       if (ctx.role.actions.indexOf(key) < 0) return { rejected: true, why: 'role-no-grant', detail: key };
+    }
+    // (a2) ADMISSION RULE (gated lifecycle): an editable, SIGNED rule may gate this transition. Read the
+    // rule's current threshold from the SAME signed op-log (last SET_RULE) and compare the doc's attribute
+    // EXACTLY (BigDecimal). Engine-side → the UI cannot bypass it. No rule set → ungated (default-allow).
+    var ar = cfg.admissionRules && cfg.admissionRules[table + ':' + action];
+    if (ar) {
+      var T = currentRuleT(ar.ruleId);
+      if (T != null) {
+        var vr = adQ('SELECT ' + ar.col + ' AS v FROM ' + ar.table + ' WHERE ' + ar.key + ' = ?', [intent.id]);
+        var val = vr.length ? vr[0].v : null;
+        if (val != null) {
+          var pass = BD ? (ar.cmp === 'lte' ? BD.of(String(val)).compareTo(BD.of(String(T))) <= 0
+                                            : BD.of(String(val)).compareTo(BD.of(String(T))) >= 0)
+                        : (ar.cmp === 'lte' ? Number(val) <= Number(T) : Number(val) >= Number(T));
+          if (!pass) return { rejected: true, why: 'rule-guard',
+            detail: ar.ruleId + ' ' + ar.col + '=' + val + (ar.cmp === 'lte' ? ' > T=' : ' < T=') + T };
+        }
+      }
     }
     // (b) owner-gate (G-SINGLE-WRITER): a mutation on an already-owned doc by a different actor is refused.
     if (intent.uuid) {

--- a/erp/kanban_host.js
+++ b/erp/kanban_host.js
@@ -75,7 +75,10 @@
       });
     });
 
-    var seam = Seam.makeSeam({ projDb: projDb, adQ: adQ, factQ: gbQ, wfmc: cfg.wfmc, newDb: function () { return new cfg.SQL.Database(); } });
+    // admissionRules (gated lifecycle): the editable, signed L1 rule "an order may Complete iff GrandTotal ≤ T"
+    // gates the C_Order CO transition engine-side. No rule set → ungated (existing completes unaffected).
+    var admissionRules = { 'C_Order:CO': { ruleId: 'maycomplete', table: 'C_Order', key: 'C_Order_ID', col: 'GrandTotal', cmp: 'lte' } };
+    var seam = Seam.makeSeam({ projDb: projDb, adQ: adQ, factQ: gbQ, wfmc: cfg.wfmc, admissionRules: admissionRules, newDb: function () { return new cfg.SQL.Database(); } });
     var ctx = { actor: 'device:' + (localStorage.kanbanActor || (localStorage.kanbanActor = 'k' + Math.floor(performance.now()))),
       pubKey: (global.ErpSigner && global.ErpSigner.pubKeyHex) || null, roleId: cfg.roleId || null,
       role: { id: cfg.roleId || null, actions: grants }, allowOrgs: (cfg.allowOrgs && cfg.allowOrgs.length) ? cfg.allowOrgs : '*' };

--- a/erp/rule_fold.js
+++ b/erp/rule_fold.js
@@ -94,6 +94,18 @@
     return ops[ops.length - 1].parameters.T;
   }
 
+  // setT — commit ONE signed SET_RULE edit (no full gesture). Used to drive the gated-Complete demo: change
+  // the admission threshold the seam's dispatch guard reads. Returns {ok,uuid,chainOk,from,to}.
+  async function setT(ruleId, toT, opts) {
+    opts = opts || {};
+    var R = RULES[ruleId]; if (!R) return { ok: false, why: 'unknown-rule' };
+    var opDb = await ensureOpLog(opts.SQL || global.SQL);
+    var fromT = rebuildT(opDb, ruleId);
+    var res = await commitEdit(opDb, R, fromT, toT, []);
+    console.log('§RULE-SET rule=' + ruleId + ' T:' + fromT + '→' + toT + ' signedOp=' + res.uuid.slice(0, 8) + ' chainOk=' + (res.chainOk ? 'Y' : 'N'));
+    return { ok: true, uuid: res.uuid, chainOk: res.chainOk, from: fromT, to: toT };
+  }
+
   function _sleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
 
   // ── runGesture — the full witnessed gesture for one rule; emits the §-line contract (RULE_EDIT_SPEC §8) ──
@@ -209,6 +221,6 @@
     console.log('§RULE-OPEN rules=[premium(L2),maycomplete(L1)] tenant=Odoo(12)');
   }
 
-  global.RuleFold = { open: open, runGesture: runGesture, fold: fold, _RULES: RULES };
+  global.RuleFold = { open: open, runGesture: runGesture, setT: setT, fold: fold, _RULES: RULES };
   console.log('§RULE_FOLD_LOADED rule_fold.js (the ONE gesture — L2 premium + L1 may-complete, signed, reversible)');
 })(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,10 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v582';   // v582: I-4 — ONE signed op-log: the live write path (a doc Complete via the
+const CACHE_VERSION = 'v583';   // v583: GATED COMPLETE — the editable, signed L1 rule "order may Complete iff
+                                //       GrandTotal ≤ T" now GATES the real CO transition engine-side (dispatch
+                                //       admission guard); edit the rule → a blocked order completes, signed;
+                                // v582: I-4 — ONE signed op-log: the live write path (a doc Complete via the
                                 //       seam) is now a genuinely SIGNED op (W-CHAIN+W-SIGN), on the SAME chain
                                 //       as the ⚖ rule edit (erp_kernel unified to kernel_ops's schema);
                                 // v581: ⚖ Rule — L1 lifecycle rule "may this Order Complete iff GrandTotal ≤ T"

--- a/erp/tests/poc_gated_complete.js
+++ b/erp/tests/poc_gated_complete.js
@@ -1,0 +1,93 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for the GATED SIGNED COMPLETE (prompts/I4_OPLOG_RECONCILE.md §payoff) —
+//   the editable, signed L1 rule "an order may Complete iff GrandTotal ≤ T" GATES the real wfmc CO
+//   transition, engine-side, on the unified signed chain. Closes the loop: edit the rule → a blocked
+//   order now completes.
+//   PROVES (drives window.ERP.dispatch + RuleFold.setT on the Sales Order window):
+//     §GATED-COMPLETE high order (5002.5) at T=1500 → admit=N why=rule-guard  (the rule BLOCKS it)
+//     §GATED-COMPLETE low  order (434.13) at T=1500 → admit=Y signed          (the gate discriminates)
+//     §RULE-SET maycomplete T:1500→6000 (one signed op)
+//     §GATED-COMPLETE high order (5002.5) at T=6000 → admit=Y signed chainOk=Y (edit the rule → it completes)
+//   Issue it proves: "the editable rule is cosmetic — it doesn't actually govern the lifecycle." It does:
+//     the guard is in dispatch (the sole write path), so the UI cannot bypass it.
+//   §-log first — READ tests/poc_gated_complete.log before any conclusion.
+// Run:  node tests/poc_gated_complete.js 2>&1 | tee tests/poc_gated_complete.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const logs = [], errs = [];
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  const url = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=143`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.idmp-pill[title="Kanban"]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('.idmp-pill[title="Kanban"]', { timeout: 15000 });
+  });
+  await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  await page.click('.idmp-pill[title="Kanban"]');
+  for (let i = 0; i < 40 && !logs.find(l => l.startsWith('§SEAM-LIVE')); i++) await page.waitForTimeout(250);
+
+  const out = await page.evaluate(async () => {
+    const E = window.ERP, ad = window.__idmpDb;
+    if (!E || !E.opDb) return { fail: 'window.ERP.opDb absent' };
+    const statusOf = id => { const r = ad.exec("SELECT DocStatus FROM C_Order WHERE C_Order_ID=" + id); return r.length ? r[0].values[0][0] : 'DR'; };
+    let ts = 9000;
+    async function complete(id) {           // attempt a real CO transition through the sole write path
+      const dr = E.dispatch({ table: 'C_Order', docType: 'C_Order', action: 'CO',
+        status: statusOf(id), id: String(id), uuid: 'DOC:C_Order#' + id, baseTs: (ts += 100) }, E.ctx);
+      let chainOk = null, signed = null;
+      if (dr && dr.ok) { await E.seal(); const cv = await E.chainVerify(); chainOk = !!cv.ok; signed = (E.ctx && E.ctx.pubKey) ? true : false; }
+      return { admit: !!(dr && dr.ok), why: dr && dr.rejected ? dr.why : null, op: dr && dr.op_uuid, chainOk, signed };
+    }
+    const R = {};
+    await window.RuleFold.setT('maycomplete', 1500, { SQL: window.SQL });   // signed rule edit → ceiling 1500
+    R.highBlocked = await complete(1200002);                                // S00025 = 5002.5 > 1500 → blocked
+    R.lowAdmit   = await complete(1200027);                                 // S00003 = 434.13 ≤ 1500 → admitted
+    R.raise      = await window.RuleFold.setT('maycomplete', 6000, { SQL: window.SQL }); // raise ceiling (signed)
+    R.highAfter  = await complete(1200002);                                 // now 5002.5 ≤ 6000 → admitted
+    const cv = await E.chainVerify(); R.chainOk = !!cv.ok; R.chainLen = cv.len;
+    return R;
+  });
+  await page.close();
+
+  const b = v => v ? 'Y' : 'N';
+  if (out.fail) console.log('§GATED-COMPLETE FAIL ' + out.fail);
+  else {
+    console.log('§GATED-COMPLETE order=S00025(5002.5) T=1500 admit=' + b(out.highBlocked.admit) + ' why=' + (out.highBlocked.why || '-'));
+    console.log('§GATED-COMPLETE order=S00003(434.13) T=1500 admit=' + b(out.lowAdmit.admit) + ' signedOp=' + (out.lowAdmit.op || '-') + ' chainOk=' + b(out.lowAdmit.chainOk));
+    console.log('§RULE-SET maycomplete T:' + out.raise.from + '→' + out.raise.to + ' signedOp=' + (out.raise.uuid ? out.raise.uuid.slice(0, 8) : '-') + ' chainOk=' + b(out.raise.chainOk));
+    console.log('§GATED-COMPLETE order=S00025(5002.5) T=6000 admit=' + b(out.highAfter.admit) + ' signedOp=' + (out.highAfter.op || '-') + ' chainOk=' + b(out.highAfter.chainOk));
+    console.log('§GATED-WITNESS chainOk=' + b(out.chainOk) + ' len=' + out.chainLen + ' pageerrors=' + (errs.length ? errs.join('|') : 0));
+  }
+
+  const pass = out && !out.fail &&
+    out.highBlocked.admit === false && out.highBlocked.why === 'rule-guard' &&
+    out.lowAdmit.admit === true && out.lowAdmit.chainOk === true &&
+    out.raise.chainOk === true &&
+    out.highAfter.admit === true && out.highAfter.chainOk === true &&
+    out.chainOk === true && errs.length === 0;
+  console.log('§GATED-COMPLETE-POC ' + (pass ? 'PASS' : 'FAIL'));
+
+  await browser.close(); server.close();
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); try { server.close(); } catch (x) {} process.exit(2); });


### PR DESCRIPTION
## Closes the loop
The editable, **signed** L1 rule *"an order may Complete iff `GrandTotal ≤ T`"* now **gates the real wfmc `CO` transition**, engine-side. Edit the rule → a previously-blocked order completes — live, signed. Builds on I-4 (#144, the unified signed op-log).

The guard lives in `erp_seam.dispatch` (the **sole** write path), so the UI cannot bypass it. It reads the rule's current threshold from the **same signed op-log** (last `SET_RULE`) and compares the doc's `GrandTotal` **exactly** (BigDecimal). No rule set → ungated (existing completes unaffected).

## Witness (real-browser, `tests/poc_gated_complete.js` → **§GATED-COMPLETE-POC PASS**, 0 pageerror)
```
§GATED-COMPLETE order=S00025(5002.5) T=1500 admit=N why=rule-guard       ← the rule BLOCKS the Complete
§GATED-COMPLETE order=S00003(434.13) T=1500 admit=Y signed               ← the gate discriminates
§RULE-SET       maycomplete T:1500→6000 (one signed op)
§GATED-COMPLETE order=S00025(5002.5) T=6000 admit=Y signed chainOk=Y     ← edit the rule → it completes
```
The same order S00025 goes from **blocked → completable** purely by editing the (signed) rule. **No-regress:** `poc_i4_reconcile` + `poc_rule_edit` + `poc_heatmap` still PASS.

## Files / scope
- `erp_seam.js`: admission guard in `dispatch` + `currentRuleT` reader + BigDecimal compare → `{rejected, why:'rule-guard'}`.
- `kanban_host.js`: wires `admissionRules { 'C_Order:CO' → maycomplete }`.
- `rule_fold.js`: `RuleFold.setT(rule, T)` — one signed edit.
- erp/ only, worktree off `origin/main`, SW v582→**v583**.

## Honesty
Gates + signs the `CO` transition (status), governed by the editable rule — still **NOT a GL posting** (Completed ≠ posted, §I-K/§13.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)