### PR TITLE
feat(find-lens): parent-relative depth (building 0 / parent 0.1 / selected) + Room floor = group

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=18',
+        'navigate_find.js?v=22',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -946,8 +946,30 @@
         A.dbQuery("SELECT element_guid FROM rel_contained_in_space WHERE space_guid = ?", [guid])
           .forEach(function(r) { set.add(r[0]); });
       } catch (e) { console.warn('[RP-TA] §ROOM_SELECT_ERR', e.message); }
-      // §DEPTH item: room CONTENTS = cyan item; enclosing storey = the 0.5 group; zoom frames the room VOLUME.
+      // §DEPTH item: room CONTENTS = cyan item; enclosing storey = the 0.1 parent ghost; zoom frames the room VOLUME.
       _drillSelect(set, name, 'ROOM_SELECT', storeySet, null, zoomBox);
+    }
+
+    // §DEPTH consistency: a Room-tree floor/type HEADER tap is a GROUP select — route it through the
+    // SAME B|G|I entry every other lens uses (was expand-only). Storey grouping → the floor's elements;
+    // Type grouping → the union of that type's rooms' contents. Group depth = 1.0 solid + fit-zoom,
+    // building(parent) = 0.1. (groupRooms = [{key,label}] for this header, captured at build time.)
+    function _roomGroupSelect(gk, groupRooms) {
+      var set = new Set();
+      try {
+        if (_roomGroupBy === 'type') {
+          var keys = (groupRooms || []).map(function(r) { return r.key; });
+          if (keys.length) {
+            var ph = keys.map(function() { return '?'; }).join(',');
+            A.dbQuery("SELECT element_guid FROM rel_contained_in_space WHERE space_guid IN (" + ph + ")", keys)
+              .forEach(function(r) { set.add(r[0]); });
+          }
+        } else {
+          A.dbQuery("SELECT guid FROM elements_meta WHERE storey = ?", [gk])
+            .forEach(function(r) { set.add(r[0]); });
+        }
+      } catch (e) { console.warn('[RP-TA] §ROOM_GROUP_ERR', e.message); }
+      _drillSelect(null, gk, 'ROOM_GROUP', set); // group mode: floor/type solid 1.0 + fit-zoom, building 0.1
     }
 
     // §RP sub-toggle row [A | B] — a small two-pill regroup control inside a lens tree.
@@ -1002,10 +1024,15 @@
           byGroup[gk].push({ key: r[0], label: r[1] || '(unnamed)' });
         });
         order.forEach(function(gk) {
-          var kids = byGroup[gk].map(function(rm) {
+          var groupRooms = byGroup[gk];
+          var kids = groupRooms.map(function(rm) {
             return _treeNode(rm.label, '', 1, { onTap: function() { _roomSelect(rm.key); } });
           });
-          elTree.appendChild(_treeNode(gk, byGroup[gk].length, 0, { children: kids }));
+          // §DEPTH consistency: a floor/type header tap is a GROUP select (like Storey/Phase/Material) —
+          // render it solid via the same B|G|I entry. (Was expand-only → "doesn't treat it as Group".)
+          // Arrow still expands the children.
+          elTree.appendChild(_treeNode(gk, groupRooms.length, 0,
+            { children: kids, onTap: function() { _roomGroupSelect(gk, groupRooms); } }));
         });
         console.log('[RP-T3] §LENS_GROUPS lens=room mode=volume groupBy=' + _roomGroupBy +
           ' groups=' + order.length + ' rooms=' + rooms.length +
@@ -1262,7 +1289,11 @@
       _clearShapeOverlays();
       _clearHlOverlay();
       if (!A.xrayOn && A.toggleXray) { A.toggleXray(); _hlXrayWasOff = true; } // rest → transparent
-      _dimXrayTo(0.1);  // §DEPTH: rest of building = 0.1 ghost, ALWAYS (group or item)
+      // §DEPTH (parent-relative): the selection's IMMEDIATE PARENT = 0.1 ghost, everything BEYOND = 0.
+      //  • GROUP select → parent IS the building → keep the building at 0.1 (e.g. Material, whose only
+      //    parent is the building, stays 0.1). • ITEM select → parent is the group (kept at 0.1 via the
+      //    group overlay below) → the building is BEYOND the parent → send it to 0 (gone).
+      _dimXrayTo(litN ? 0 : 0.1);
       if (elIsoBar) {
         elIsoBar.style.display = 'flex';
         if (elIsoBtn) elIsoBtn.style.display = 'none';
@@ -1271,7 +1302,9 @@
       if (A.markDirty) A.markDirty(); // immediate: the rest dims THIS frame → the tap is acknowledged at once
 
       var isGroup = !litN;                                  // no lit item → GROUP depth
-      var grpOp = isGroup ? 1.0 : (ctxOpacity != null ? ctxOpacity : 0.5);
+      // ITEM mode: the group is the selection's PARENT → faint 0.1 ghost (was 0.5; user: 0.5 "doesn't
+      // help" against a still-visible building — now building is 0 so 0.1 reads as the local context).
+      var grpOp = isGroup ? 1.0 : (ctxOpacity != null ? ctxOpacity : 0.1);
 
       // §PERF: build the heavy shape overlays OFF the pointer thread (next frames) so the tap
       // returns instantly. Group: frame1 = group solid 1.0 + fit-zoom. Item: frame1 = cyan item

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v599';
+const CACHE_VERSION = 'v600';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What (user feedback on the §DEPTH model)
Refines the depth model into ONE **parent-relative** rule, uniform across every lens:
> **selected** = bright (item) / solid (group) · its **immediate parent** = `0.1` ghost · everything **beyond** = `0`.

- **ITEM select:** building → **0** (gone), parent group → **0.1** (was 0.5 — "doesn't help" against a still-visible building; now the building is 0 so 0.1 reads as the local context), item = cyan.
- **GROUP select:** the group's parent is the building → building stays **0.1**, group = **1.0 solid** + fit-zoom. (Material has no intermediate level → its parent *is* the building → building correctly stays 0.1, exactly as reported.)
- **Scales to any depth** (Discipline › FP › Type › Element): only ever **two active layers** — parent `0.1` + selected — no special-casing per level.
- **Consistency fix:** the Room-tree floor/type **header** tap now fires a GROUP select through the **same `_drillSelect` B|G|I entry** every other lens uses (was expand-only → "doesn't treat it as Group effect"). The arrow still expands children.
- Also fixes the `navigate_find.js?v` **downgrade (18→22)** that rode in on #149.

## Witness (`tests/probe_depth.js`, Duplex, SW-blocked, leak-safe)
```
GROUP (storey):      §XRAY_DIM 0.1 · §STOREY_SELECT GROUP grpOp=1.0 solid=50 · §GROUP_ZOOM dist=21.6
ITEM  (type):        §XRAY_DIM 0   · §TYPE_SELECT ITEM lit=21 grpSolid=29 grpOp=0.1
ROOM floor header:   §XRAY_DIM 0.1 · §ROOM_GROUP GROUP grpOp=1.0 solid=50 · §GROUP_ZOOM   ← was expand-only
ROOM item:           §XRAY_DIM 0   · §ROOM_SELECT_ZOOM dist=7.5 (room volume)
```
No page errors; chrome clean.

SW `v599→v600`, `navigate_find.js?v=18→22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)