### PR TITLE
fix(find): bigger drag grab-zone for the Find panel

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=23',
+        'navigate_find.js?v=24',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -12,7 +12,10 @@ function setupMeasure(A) {
   // ── Draggable panels ──
   A._makeDraggable = function(el) {
     var ox, oy, sx, sy, dragging = false, pending = false, moved = false, pid = null;
-    var dragStrip = window._isMobile ? 50 : 30;
+    // Top grab-zone height. Per-panel override via el._dragStrip (the Find panel sets a bigger one —
+    // "give me more margin to hold onto"). Backward-compatible: panels that don't set it are unchanged.
+    // A stationary tap inside the zone still reaches child controls (only a real move starts a drag).
+    var dragStrip = el._dragStrip || (window._isMobile ? 50 : 30);
     el.style.cursor = 'grab';
     // On mobile, intercept touch BEFORE the browser claims it for scroll/pan.
     // Only preventDefault in the drag zone; elsewhere let browser handle normally.

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -166,7 +166,9 @@
       '<div id="find-results"></div>',
     ].join('');
     document.body.appendChild(panel);
-    // S265 Phase 5: make Find panel draggable
+    // S265 Phase 5: make Find panel draggable — with a GENEROUS top grab-zone (user: the thin
+    // default strip was "hard to drag, give me more margin to hold onto"). Taps inside still work.
+    panel._dragStrip = window._isMobile ? 96 : 64;  // ~2× the default 50/30
     if (A._makeDraggable) A._makeDraggable(panel);
     // Pointer isolation
     panel.addEventListener('pointerdown', function(e) { e.stopPropagation(); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v601';
+const CACHE_VERSION = 'v602';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
The Find panel was draggable but the grab-strip (the shared `_makeDraggable` in `measure.js`) was a thin **30px desktop / 50 mobile** — "hard to drag, give me more margin to hold onto."

- Add a per-panel override **`el._dragStrip`** in `measure.js` (backward-compatible — every other panel is unchanged; `el._dragStrip || (mobile?50:30)`).
- Find panel sets `panel._dragStrip = 64 desktop / 96 mobile` (~2×).
- Taps inside the zone still reach child controls (only a real move starts a drag — existing behaviour).

`node --check` clean on both files. SW `v601→v602`, `navigate_find.js?v=23→24` (measure.js refreshed by the CACHE_VERSION bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)