### PR TITLE
fix(find): 0.2 ghost shines through hidden base + drop-IFC import normalizes storey

### DIFF
--- a/viewer/import_worker.js
+++ b/viewer/import_worker.js
@@ -252,13 +252,23 @@ self.onmessage = async function(e) {
       } catch(e) { /* use filename */ }
     }
 
+    // §STOREY_NORMALIZE: Revit exports reference PLANES (Ceiling, Top-of-Steel…) as IfcBuildingStorey,
+    // so MEP/STR elements land on "Level 2 Ceiling"/"Level 2 TOS" — junk sibling storeys that pollute
+    // the Find Storey/Room trees. Fold into the base level. Mirrors tools/extract.py normalize_storey.
+    const REF_LEVEL_SUFFIXES = [' Ceiling', ' TOS', ' T.O.S.', ' Top of Steel', ' Soffit'];
+    const normalizeStorey = (nm) => {
+      if (!nm) return nm;
+      const s = String(nm).trim(), low = s.toLowerCase();
+      for (const suf of REF_LEVEL_SUFFIXES) { if (low.endsWith(suf.toLowerCase())) return s.slice(0, -suf.length).trim(); }
+      return s;
+    };
     // Get storeys
-    const storeyMap = {}; // expressID → storey name
+    const storeyMap = {}; // expressID → storey name (normalized)
     const storeyLines = ifcApi.GetLineIDsWithType(modelID, WebIFC.IFCBUILDINGSTOREY);
     for (let i = 0; i < storeyLines.size(); i++) {
       try {
         const s = ifcApi.GetLine(modelID, storeyLines.get(i));
-        storeyMap[storeyLines.get(i)] = s.Name ? s.Name.value : 'Level ' + i;
+        storeyMap[storeyLines.get(i)] = normalizeStorey(s.Name ? s.Name.value : 'Level ' + i);
       } catch(e) { /* skip */ }
     }
 

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=24',
+        'navigate_find.js?v=25',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -807,7 +807,11 @@
           var base = A._getMaterial ? A._getMaterial(g.rgba, g.ifc) : null;
           mat = base ? base.clone() : new THREE.MeshStandardMaterial({ color: 0xcccccc });
           if (solidOpacity != null && solidOpacity < 1) {
-            mat.transparent = true; mat.opacity = solidOpacity; mat.depthWrite = false; // context shows the lit item through it
+            // §DEPTH ghost (0.2 ancestor): SHINE THROUGH the hidden base. The dimmed base is opacity-0
+            // but still writes depth → it OCCLUDED this 0.2 overlay (deeper group "showed only solid,
+            // no 0.2"). depthTest off + low renderOrder draws it under the solid focus, through the
+            // invisible base. (Witnessed: ghost 0.20 dT0 dW0 ro1; Hospital intermediate anc=[0.2×N].)
+            mat.transparent = true; mat.opacity = solidOpacity; mat.depthWrite = false; mat.depthTest = false;
           } else {
             mat.transparent = false; mat.opacity = 1; mat.depthWrite = true;
           }
@@ -822,7 +826,8 @@
           inst.setMatrixAt(j, m4);
         }
         inst.instanceMatrix.needsUpdate = true;
-        inst.renderOrder = color != null ? 3 : 2;
+        // ghost(0.2)=1 draws first (under), solid focus=2, cyan shine=3 on top
+        inst.renderOrder = color != null ? 3 : ((solidOpacity != null && solidOpacity < 1) ? 1 : 2);
         inst.userData._shapeOverlay = true;
         A.scene.add(inst);
         _shapeOverlays.push({ mesh: inst, disposeMat: true }); // cyan + clones are ours to dispose

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v602';
+const CACHE_VERSION = 'v603';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Two fixes
**1. 0.2 ancestor ghost occlusion** (regression — dropped from main in a concurrent squash race during #153). A deeper-group select builds the parent at 0.2, but the dimmed base is opacity-0 yet still **writes depth**, occluding the depth-tested 0.2 overlay → "deeper group showed only solid, no 0.2". Ghost overlays now render `depthTest=false` + `renderOrder 1` (shine through the invisible base, under the solid focus). Witnessed on Hospital: `§TYPE_SELECT GROUP anc=[0.2×N]`, overlays `0.20 dT0 ro1`.

**2. Drop-IFC import normalizes storey.** `import_worker.js` injected the *same* corruption `tools/extract.py` did — it copied the `IfcBuildingStorey` name verbatim, so Revit reference planes (`Level 2 Ceiling`/`TOS`) became junk sibling storeys. Added the matching `normalizeStorey()` so imported models are clean too. Mirrors the Python `normalize_storey` (extract.py) + `scripts/normalize_storey.py`.

SW `v602→v603`, `navigate_find.js?v=24→25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)