### PR TITLE
feat(migrate): INSTALL persists the merged tenant — Odoo Client 12 survives reload (P2)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -391,6 +391,15 @@
         });
         sdb.close();
         console.log('§IDEMPIERE shard-in ' + shardParam + ' tables=' + mTbl + ' rows=' + mRow);
+        // INSTALL = make it STICK: persist the merged tenant into the resident cache so the migrated client
+        // survives a plain reload WITHOUT the ?shard= param (the migration is now actual, not a transient
+        // overlay). Guarded: only the real ad_seed.db is the resident base (never clobber a ?seed= gen db),
+        // and only when rows actually merged. INSERT OR IGNORE upstream keeps a re-install idempotent.
+        if (mRow > 0 && (!seedParam || seedFile === 'ad_seed.db')) {
+          try { idbPut('ad_seed_v13', db.export().buffer);
+            console.log('§IDEMPIERE shard-persist key=ad_seed_v13 rows=' + mRow + ' resident=Y'); }
+          catch (e) { console.warn('§IDEMPIERE shard-persist failed ' + e.message); }
+        }
       } catch (e) { console.warn('§IDEMPIERE shard-in failed ' + e.message); }
     }
     if (ADP && ADP.init) ADP.init(db);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,9 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v584';   // v584: Migrate▸Odoo staged box + self-sufficient odoo_agent.zip bundle (P0);
+const CACHE_VERSION = 'v585';   // v585: Migrate INSTALL persists the merged tenant (shard-in → idbPut) so a
+                                //       migrated client (e.g. Odoo 12) survives a plain reload — actual, not transient;
+                                // v584: Migrate▸Odoo staged box + self-sufficient odoo_agent.zip bundle (P0);
                                 // v583: GATED COMPLETE — the editable, signed L1 rule "order may Complete iff
                                 //       GrandTotal ≤ T" now GATES the real CO transition engine-side (dispatch
                                 //       admission guard); edit the rule → a blocked order completes, signed;

--- a/erp/tests/poc_client12_resident.js
+++ b/erp/tests/poc_client12_resident.js
@@ -1,0 +1,106 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness PROVING whether Odoo "Client 12" is an ACTUAL migrated/resident tenant or a
+//   TRANSIENT demo prop. Proves/disproves the report: "12-odoo.db loads via ?shard= but is NOT persisted —
+//   the merged db is never written to IDB, so a reload without the param loses Client 12."
+//   THREE checks, all on the REAL idempiere.html boot path (no mocks):
+//     A) §C12-INMEM   — with ?shard=12-odoo.db, the in-memory db HAS AD_Client 12 (+ its products). (loads ✓)
+//     B) §C12-IDB     — the PERSISTED IDB blob ('ad_seed_v13') does NOT contain Client 12.  (gap: not saved)
+//     C) §C12-RELOAD  — reloading WITHOUT ?shard= → Client 12 is GONE.                      (consequence)
+//   Verdict §C12-RESIDENT resident=<Y|N>: resident=Y only if the shard survives a no-param reload. Expected N
+//   today — that N is the "make it stick" (persist + switcher) gap, i.e. migration is not yet actual.
+//   §-log first — READ tests/poc_client12_resident.log before any conclusion.
+// Run:  node tests/poc_client12_resident.js 2>&1 | tee tests/poc_client12_resident.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+// run inside the page: count Client-12 rows in the live in-memory db
+const countInMem = () => {
+  const q = (s) => { try { const r = window.__idmpDb.exec(s); return r.length ? r[0].values[0][0] : 0; } catch (e) { return -1; } };
+  return { client: q("SELECT COUNT(*) FROM AD_Client WHERE AD_Client_ID=12"),
+           products: q("SELECT COUNT(*) FROM M_Product WHERE AD_Client_ID=12") };
+};
+// run inside the page: open the PERSISTED idb blob and count Client-12 there (proves whether it was saved)
+const countInIdb = () => new Promise((resolve) => {
+  try {
+    const req = indexedDB.open('erp_cache', 1);
+    req.onupgradeneeded = () => req.result.createObjectStore('blobs');
+    req.onsuccess = () => {
+      const g = req.result.transaction('blobs', 'readonly').objectStore('blobs').get('ad_seed_v13');
+      g.onsuccess = () => {
+        const buf = g.result;
+        if (!buf || !window.SQL) return resolve({ blob: !!buf, client: -2 });
+        try { const d = new window.SQL.Database(new Uint8Array(buf));
+          const r = d.exec("SELECT COUNT(*) FROM AD_Client WHERE AD_Client_ID=12");
+          const n = r.length ? r[0].values[0][0] : 0; d.close(); resolve({ blob: true, client: n }); }
+        catch (e) { resolve({ blob: true, client: -3, err: e.message }); }
+      };
+      g.onerror = () => resolve({ blob: false, client: -4 });
+    };
+    req.onerror = () => resolve({ blob: false, client: -5 });
+  } catch (e) { resolve({ blob: false, client: -6, err: e.message }); }
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext();          // fresh, empty IDB
+  const page = await ctx.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // ── A) DEFAULT seed path (exercises the real IDB cache) + the Odoo shard merged in ──
+  await page.goto(`http://localhost:${port}/idempiere.html?shard=12-odoo.db`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => !!window.__idmpDb, null, { timeout: 15000 });
+  await page.waitForTimeout(1200);
+  const shardLog = logs.find(l => l.startsWith('§IDEMPIERE shard-in')) || '(no shard-in log)';
+  const inmem = await page.evaluate(countInMem);
+  console.log('§C12-INMEM ' + shardLog + ' | client12-rows=' + inmem.client + ' products=' + inmem.products);
+
+  // ── B) what got PERSISTED? open the idb blob the app cached and look for Client 12 ──
+  const idb = await page.evaluate(countInIdb);
+  console.log('§C12-IDB persisted-blob=' + (idb.blob ? 'Y' : 'N') + ' client12-in-blob=' + idb.client
+    + (idb.err ? ' err=' + idb.err : '') + '  (>=1 ⇒ saved/resident · 0 ⇒ base-only, shard NOT persisted)');
+
+  // ── C) reload WITHOUT the shard param — does Client 12 survive? ──
+  await page.goto(`http://localhost:${port}/idempiere.html`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => !!window.__idmpDb, null, { timeout: 15000 });
+  await page.waitForTimeout(800);
+  const after = await page.evaluate(countInMem);
+  console.log('§C12-RELOAD no-shard-param client12-rows=' + after.client + ' products=' + after.products
+    + '  (0 ⇒ Client 12 GONE on reload ⇒ transient, not migrated)');
+
+  const loadsViaShard = inmem.client >= 1;
+  const persisted     = idb.client >= 1;
+  const survivesReload = after.client >= 1;
+  const resident = persisted && survivesReload;
+  console.log('§C12-RESIDENT loadsViaShard=' + (loadsViaShard ? 'Y' : 'N')
+    + ' persistedToIDB=' + (persisted ? 'Y' : 'N')
+    + ' survivesReload=' + (survivesReload ? 'Y' : 'N')
+    + ' → resident(actual-migration)=' + (resident ? 'Y' : 'N')
+    + ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+  console.log('§C12-VERDICT ' + (resident
+    ? 'Client 12 IS an actual resident migrated tenant.'
+    : 'Client 12 is a TRANSIENT demo prop — loads via ?shard= but is NOT persisted and is LOST on a plain reload. '
+      + 'The persist+switcher (make-it-stick) is the real migration gap, exactly as reported.'));
+
+  await browser.close();
+  server.close();
+  // PASS = the test ran cleanly and rendered a verdict (it is a falsifier; resident=N today is the expected finding).
+  process.exit(loadsViaShard && errs.length === 0 ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });

--- a/erp/tests/poc_odoo_records_show.js
+++ b/erp/tests/poc_odoo_records_show.js
@@ -1,0 +1,84 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness PROVING the migrated Odoo tenant's REAL records are resident AND showable in our
+//   SQLite/AD UI — "sample data can go in, and we show their records." Loads the demo URL (seed + 12-odoo.db
+//   shard + auto-login as Odoo + open the Product window), then (A) queries the live in-memory db for the
+//   ACTUAL Odoo business rows (products by name, the migrated sale order + its customer + grand total, the
+//   invoice) and (B) screenshots the rendered AD window. NON-INVENT: every value printed is read from the db
+//   the browser loaded — nothing fabricated.
+//   §-log first — READ tests/poc_odoo_records_show.log before any conclusion.
+// Run:  node tests/poc_odoo_records_show.js 2>&1 | tee tests/poc_odoo_records_show.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+// read REAL migrated Odoo rows from the live in-memory db (client 12)
+const readRecords = () => {
+  const all = (s) => { try { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; } catch (e) { return [['ERR:' + e.message]]; } };
+  const one = (s) => { const v = all(s); return v.length ? v[0][0] : null; };
+  return {
+    products:   one("SELECT COUNT(*) FROM M_Product WHERE AD_Client_ID=12"),
+    prodNames:  all("SELECT Name FROM M_Product WHERE AD_Client_ID=12 ORDER BY M_Product_ID LIMIT 6").map(r => r[0]),
+    orders:     one("SELECT COUNT(*) FROM C_Order WHERE AD_Client_ID=12"),
+    order:      all("SELECT DocumentNo, GrandTotal, DocStatus FROM C_Order WHERE AD_Client_ID=12 ORDER BY GrandTotal DESC LIMIT 1")[0] || null,
+    customer:   one("SELECT Name FROM C_BPartner WHERE AD_Client_ID=12 ORDER BY C_BPartner_ID LIMIT 1"),
+    invoice:    all("SELECT DocumentNo, GrandTotal FROM C_Invoice WHERE AD_Client_ID=12 LIMIT 1")[0] || null,
+    priced:     one("SELECT COUNT(*) FROM M_ProductPrice pp JOIN M_Product p ON p.M_Product_ID=pp.M_Product_ID WHERE p.AD_Client_ID=12")
+  };
+};
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 1200, height: 820 });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // the live demo URL: base seed + Odoo shard merged + auto-login as Odoo + open the Product window (140)
+  await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=140`,
+    { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => !!window.__idmpDb, null, { timeout: 15000 });
+  await page.waitForTimeout(2500);   // let auto-login + window render settle
+
+  const shardLog = logs.find(l => l.startsWith('§IDEMPIERE shard-in')) || '(no shard-in)';
+  const rec = await page.evaluate(readRecords);
+
+  console.log('§ODOO-RECORDS ' + shardLog);
+  console.log('§ODOO-RECORDS products=' + rec.products + ' priced=' + rec.priced + ' orders=' + rec.orders);
+  console.log('§ODOO-RECORDS sample-products=[' + rec.prodNames.join(' | ') + ']');
+  console.log('§ODOO-RECORDS top-order=' + (rec.order ? rec.order.join(' / ') : 'none')
+    + ' customer="' + rec.customer + '" invoice=' + (rec.invoice ? rec.invoice.join(' / ') : 'none'));
+
+  // did the AD UI actually render records on screen?
+  const header = await page.evaluate(() => (document.querySelector('#idmp-header, .idmp-header, header') || {}).innerText || '');
+  const rowsOnScreen = await page.evaluate(() =>
+    document.querySelectorAll('.rec-card, .ad-row, .grid-row, [data-record], tr').length);
+  console.log('§ODOO-RECORDS rendered header="' + String(header).replace(/\s+/g, ' ').trim().slice(0, 80)
+    + '" on-screen-rows=' + rowsOnScreen);
+
+  await page.screenshot({ path: path.join(__dirname, 'odoo_records_show.png'), fullPage: false });
+
+  const showable = rec.products >= 1 && Array.isArray(rec.prodNames) && rec.prodNames.length >= 1
+    && rec.order && errs.length === 0;
+  console.log('§ODOO-RECORDS-VERDICT showable=' + (showable ? 'Y' : 'N')
+    + ' (their REAL Odoo rows are resident + queryable + on screen) pageErrors=' + (errs.length ? errs.join('|') : 0));
+
+  await browser.close();
+  server.close();
+  process.exit(showable ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
**prompts/MIGRATE_INSTALL_TENANT.md P2** — make a migrated client *actual*, not a transient demo prop.

### The gap (proven)
`?shard=` merged tenant rows into the in-memory db but was **never persisted** — `idbPut` cached only the base seed, *before* the merge. So a plain reload lost Client 12.
`§C12-RESIDENT persistedToIDB=N survivesReload=N → resident=N`

### Fix
`idempiere.html`, right after shard-in: persist the merged db to the resident cache (`ad_seed_v13`) when rows merged and the seed is the real `ad_seed.db` (never clobber a `?seed=` gen db). Idempotent via the existing `INSERT OR IGNORE`. New `§IDEMPIERE shard-persist` witness.

### Witnesses (§-log first, whitebox real boot path)
- `erp/tests/poc_client12_resident.js`:
  - `§C12-IDB client12-in-blob=1`
  - `§C12-RELOAD no-shard-param client12-rows=1 products=35`  ← survives reload with **no URL param**
  - `§C12-RESIDENT persistedToIDB=Y survivesReload=Y → resident=Y` (0 pageErrors)
- `erp/tests/poc_odoo_records_show.js`: `§ODOO-RECORDS products=35 orders=27 top-order=S00023/5002.50 customer="Gemini Furniture" invoice=INV/2026/00005 showable=Y` — their real records render in the AD UI.

`sw.js` v584→v585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)