### PR TITLE
fix(erp): ship Glassbowl help_ops.json + crud_ops.json to erp/ folder-home

### DIFF
--- a/erp/crud_ops.json
+++ b/erp/crud_ops.json
@@ -1,0 +1,92 @@
+{
+  "__meta": {
+    "version": 1,
+    "spec": "prompts/CRUD_OVERLAY.md",
+    "governance": "prompts/UI_OVERLAY_GOVERNANCE.md",
+    "ops": { "o2c": { "title": "Order to Cash" } },
+    "note": "Keyed CRUD store — sibling to help_ops.json. key = on-screen element id (a glassbowl bubble's table id; later an erp.html AD field = its column id). The CRUD overlay reads this by key; devs edit ONLY this file. Each entry IS the iDempiere AD model for that element: verbs[] = AD_Table/AD_Window actions (drives which ring icon is enabled vs greyed); fields[] = AD_Column (col=ColumnName, type=AD_Reference, readonly=!IsUpdateable, required=IsMandatory, default=DefaultValue, ref=AD_Reference_Value FK table) + validation = AD_Val_Rule. The overlay renders/enforces type/readonly/required/default + validation BEFORE kernel.apply(). Field VALUES are NOT here — Edit pre-fills from the live bundle DB (truth-bound); only New uses default. default expr vocab: 'today' -> ISO date, 'auto' -> server/seq docno placeholder, else literal.",
+    "verbVocab": ["create", "update", "delete", "process"],
+    "docStatus": { "DR": "Drafted", "IP": "In Progress", "CO": "Completed", "CL": "Closed" }
+  },
+
+  "c_order": {
+    "op": "o2c", "ordinal": 1, "kind": "bubble", "tab": "Data",
+    "title": "Order",
+    "verbs": ["create", "update", "delete", "process"],
+    "docAction": { "action": "CO", "from": "DR", "to": "CO", "requires": ["c_bpartner_id", "grandtotal"], "oracle": "org.compiere.model.MOrder.completeIt()" },
+    "ownerGated": true,
+    "cas": "claimed_by",
+    "fields": [
+      { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
+        "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
+      { "col": "c_bpartner_id", "label": "Business Partner", "type": "fk", "ref": "c_bpartner", "required": true },
+      { "col": "dateordered", "label": "Date Ordered", "type": "date", "required": true, "default": "today" },
+      { "col": "grandtotal", "label": "Grand Total", "type": "number", "required": true, "default": 0,
+        "validation": { "min": 0, "valRule": "non_negative_amt" } },
+      { "col": "description", "label": "Description", "type": "string", "required": false, "default": "" },
+      { "col": "docstatus", "label": "Status", "type": "list", "ref": "docStatus", "required": true, "default": "DR" }
+    ]
+  },
+
+  "m_inout": {
+    "op": "o2c", "ordinal": 2, "kind": "bubble", "tab": "Data",
+    "title": "Shipment",
+    "verbs": ["create", "update", "delete", "process"],
+    "docAction": { "action": "CO", "from": "DR", "to": "CO", "requires": ["movementdate"], "oracle": "org.compiere.model.MInOut.completeIt()" },
+    "ownerGated": true,
+    "fields": [
+      { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
+        "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
+      { "col": "movementdate", "label": "Movement Date", "type": "date", "required": true, "default": "today" },
+      { "col": "description", "label": "Description", "type": "string", "required": false, "default": "" },
+      { "col": "docstatus", "label": "Status", "type": "list", "ref": "docStatus", "required": true, "default": "DR" }
+    ]
+  },
+
+  "c_invoice": {
+    "op": "o2c", "ordinal": 3, "kind": "bubble", "tab": "Data",
+    "title": "Invoice",
+    "verbs": ["update", "delete", "process"],
+    "docAction": { "action": "CO", "from": "DR", "to": "CO", "requires": ["dateinvoiced"], "oracle": "org.compiere.model.MInvoice.completeIt()" },
+    "ownerGated": true,
+    "fields": [
+      { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
+        "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
+      { "col": "dateinvoiced", "label": "Date Invoiced", "type": "date", "required": true, "default": "today" },
+      { "col": "grandtotal", "label": "Grand Total", "type": "number", "readonly": true,
+        "note": "derived by replaying the log against the order/shipment — not entered (help_ops c_invoice: 'derived by replaying the log, not stored twice')" },
+      { "col": "description", "label": "Description", "type": "string", "required": false, "default": "" },
+      { "col": "docstatus", "label": "Status", "type": "list", "ref": "docStatus", "required": true, "default": "DR" }
+    ]
+  },
+
+  "c_payment": {
+    "op": "o2c", "ordinal": 4, "kind": "bubble", "tab": "Data",
+    "title": "Payment",
+    "verbs": ["create", "update", "delete", "process"],
+    "docAction": { "action": "CO", "from": "DR", "to": "CO", "requires": ["payamt", "datetrx"], "oracle": "org.compiere.model.MPayment.completeIt()" },
+    "ownerGated": true,
+    "fields": [
+      { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
+        "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
+      { "col": "payamt", "label": "Pay Amount", "type": "number", "required": true, "default": 0,
+        "validation": { "min": 0, "valRule": "non_negative_amt" } },
+      { "col": "datetrx", "label": "Transaction Date", "type": "date", "required": true, "default": "today" },
+      { "col": "docstatus", "label": "Status", "type": "list", "ref": "docStatus", "required": true, "default": "DR" }
+    ]
+  },
+
+  "c_allocationline": {
+    "op": "o2c", "ordinal": 5, "kind": "bubble", "tab": "Data",
+    "title": "Reconciled (Allocation)",
+    "verbs": ["create", "delete"],
+    "ownerGated": true,
+    "fields": [
+      { "col": "amount", "label": "Amount", "type": "number", "required": true, "default": 0,
+        "validation": { "min": 0, "valRule": "non_negative_amt" } },
+      { "col": "c_invoice_id", "label": "Invoice", "type": "fk", "ref": "c_invoice", "required": true },
+      { "col": "c_payment_id", "label": "Payment", "type": "fk", "ref": "c_payment", "required": true },
+      { "col": "datetrx", "label": "Transaction Date", "type": "date", "required": true, "default": "today" }
+    ]
+  }
+}

--- a/erp/help_ops.json
+++ b/erp/help_ops.json
@@ -1,0 +1,79 @@
+{
+ "__meta": {
+  "version": 2,
+  "spec": "prompts/READSHOWME_DYNAMIC_SPEC.md",
+  "ops": {
+   "o2c": {
+    "title": "Order to Cash",
+    "seed": 101,
+    "lineage": true
+   }
+  },
+  "note": "Keyed _TRL-style help store. key = on-screen element id. The ON-SCREEN card shows only {title, tip} (minimal, screen is crowded) + ShowMe/Read more. The DETAIL + figure live in the ReadMe doc (readmeAnchor → HelpO2C page, same corresponding step). paraHTML/figure here are the SOURCE that generates that doc, not shown on screen."
+ },
+ "o2c": {
+  "op": "o2c",
+  "ordinal": 0,
+  "target": null,
+  "kind": "overview",
+  "title": "Order to Cash",
+  "tip": "The everyday flow: order → ship → invoice → pay → reconcile.",
+  "paraHTML": "<p>The most common journey in any business: a customer <b>orders</b>, you <b>ship</b>, you <b>invoice</b>, they <b>pay</b>, and the payment is <b>reconciled</b> to the invoice. Below, one real order &mdash; Sales Order <b>#80001</b> ($100.70) &mdash; is traced end to end from the actual data.</p>[[FIG 1.0: the whole lit O2C chain on the map]]",
+  "readmeAnchor": "HelpO2C.md#o2c"
+ },
+ "c_order": {
+  "op": "o2c",
+  "ordinal": 1,
+  "target": "c_order",
+  "kind": "process",
+  "tab": "Data",
+  "title": "Order",
+  "tip": "What the customer committed to buy — SO #80001, $100.70.",
+  "paraHTML": "<p>The <b>Order</b> records what the customer committed to buy. Here it is Sales Order <b>#80001</b>, total <b>$100.70</b>. Everything downstream &mdash; shipment, invoice, payment &mdash; references this one document. It needs no server: the order is a single signed entry appended at the edge.</p>[[FIG 1.1: the Order bubble focused, Data tab showing #80001]]",
+  "readmeAnchor": "HelpO2C.md#c_order"
+ },
+ "m_inout": {
+  "op": "o2c",
+  "ordinal": 2,
+  "target": "m_inout",
+  "kind": "process",
+  "tab": "Data",
+  "title": "Shipment",
+  "tip": "The goods shipped against the order.",
+  "paraHTML": "<p>The <b>Shipment</b> (Material In/Out) is the goods leaving the warehouse against the order. It points back at the order it fulfils, so the link lives in the data &mdash; not in a session.</p>[[FIG 1.2: the Shipment bubble focused, Data tab]]",
+  "readmeAnchor": "HelpO2C.md#m_inout"
+ },
+ "c_invoice": {
+  "op": "o2c",
+  "ordinal": 3,
+  "target": "c_invoice",
+  "kind": "process",
+  "tab": "Data",
+  "title": "Invoice",
+  "tip": "The bill — $100.70, matching the order.",
+  "paraHTML": "<p>The <b>Invoice</b> bills the customer &mdash; <b>$100.70</b>, the same figure as the order: what was ordered, shipped and billed all agree. The amount is <i>derived</i> by replaying the log, not stored twice.</p>[[FIG 1.3: the Invoice bubble focused, Data tab showing $100.70]]",
+  "readmeAnchor": "HelpO2C.md#c_invoice"
+ },
+ "c_payment": {
+  "op": "o2c",
+  "ordinal": 4,
+  "target": "c_payment",
+  "kind": "process",
+  "tab": "Data",
+  "title": "Payment",
+  "tip": "The customer's payment, ready to be matched.",
+  "paraHTML": "<p>The <b>Payment</b> is the customer settling up. It is recorded as its own document, ready to be matched against the invoice.</p>[[FIG 1.4: the Payment bubble focused, Data tab]]",
+  "readmeAnchor": "HelpO2C.md#c_payment"
+ },
+ "c_allocationline": {
+  "op": "o2c",
+  "ordinal": 5,
+  "target": "c_allocationline",
+  "kind": "bubble",
+  "tab": "Data",
+  "title": "Reconciled (Allocation)",
+  "tip": "Payment reconciled to the invoice — $98.50.",
+  "paraHTML": "<p>The <b>Allocation</b> reconciles the payment to the invoice &mdash; here <b>$98.50</b>. This is the careful step a bookkeeper double-checks, and it is the <i>one matcher</i> that folds receivable against receipt for every kind of match.</p>[[FIG 1.5: the Allocation bubble focused, Data tab showing $98.50]]",
+  "readmeAnchor": "HelpO2C.md#c_allocationline"
+ }
+}


### PR DESCRIPTION
## What
Adds the two runtime-fetch keyed-store sidecars that Glassbowl's overlays load but that never got copied into the `erp/` folder-home:
- `erp/help_ops.json` (Need Help store)
- `erp/crud_ops.json` (Edit / ring-of-fire store)

## Why they were missing
Glassbowl moved into `erp/` in 41d8c36, but both files are loaded via `fetch()` (`help_overlay.js:363`, `crud_overlay.js:250`), **not** `<script src>` — so an asset-by-reference copy was structurally blind to them. On `erp/` they 404'd → `JSON.parse: unexpected character at line 1 column 1` → **Need Help + Edit both dead** (matches the live `§HELP load-error` / `§CRUD load-error` logs). Source of truth: `build/erp/` (also correct in `docs/`).

## Risk
Additive only — these paths never existed in `erp/`, so nothing to overwrite. No code touched.

## Left to the live mobile-erp session (per CLAUDE.md)
`erp/sw.js` PRECACHE_ASSETS + `CACHE_VERSION` bump for offline parity — `sw.js` is the conflict magnet and is mid-edit there. Keep both sessions' precache additions, take the higher version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)