### PR TITLE
fix(ghost): shell opacity 0.2 -> 0.12

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=27',
+        'navigate_find.js?v=28',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -859,10 +859,10 @@
       mg.setAttribute('color', new THREE.BufferAttribute(outC, 3));
       mg.setIndex(new THREE.BufferAttribute(outI, 1));
       // §GHOST-MAXBLEND: MAX blend so overlapping envelope layers DON'T accumulate — looking through N
-      // walls reads the same as 1 (no "drown" in the building interior). result = max(color×0.2, behind).
+      // walls reads the same as 1 (no "drown" in the building interior). result = max(color×0.12, behind).
       // Bold over the dark scene; fades only against a bright lit-sky (rare). depthWrite stays false so all
       // faces reach the blend. Thin/outside view is unchanged (one layer either way).
-      var mat = new THREE.MeshBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.2,
+      var mat = new THREE.MeshBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.12,
         depthWrite: false, side: THREE.DoubleSide,
         blending: THREE.CustomBlending, blendEquation: THREE.MaxEquation,
         blendSrc: THREE.SrcAlphaFactor, blendDst: THREE.OneFactor });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v612';
+const CACHE_VERSION = 'v613';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Turn the MAX-blend ghost shell down to 0.12 per user. Bumps navigate_find `?v=28`, sw `v613`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)