### PR TITLE
docs(history): cross-app history spec + scrub-fix + cross-tab POC

### DIFF
--- a/poc/xtab_history_poc.html
+++ b/poc/xtab_history_poc.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<!-- POC: app-wide cross-tab history over a signed kernel log. Serverless, no deps.
+     RUN:  cd /home/red1/bim-ootb/poc && python3 -m http.server 8137
+     OPEN: http://localhost:8137/xtab_history_poc.html  in TWO tabs side by side.
+     Act in one tab → the history line updates in BOTH instantly (BroadcastChannel),
+     and survives reload (localStorage). Demonstrates: (1) cross-tab app-wide history,
+     (2) depth toggle All/Doc/Off, (3) clear-history vs the kernel log (source of truth),
+     (4) cache-size readout + clear button. -->
+<html lang="en"><head><meta charset="utf-8"><title>Cross-tab History POC</title>
+<style>
+  body{font-family:Segoe UI,system-ui,sans-serif;background:#0e141b;color:#cdd9e5;margin:0;padding:18px 22px}
+  h1{font-size:17px;color:#4fc3f7;margin:0 0 2px} .sub{color:#7a8a99;font-size:12px;margin-bottom:16px}
+  .row{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
+  button{background:rgba(30,50,80,.7);color:#9ad;border:1px solid rgba(255,255,255,.15);border-radius:7px;
+    padding:8px 12px;font-size:13px;cursor:pointer} button:hover{border-color:#4fc3f7;color:#cfe8ff}
+  .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px;margin:12px 0}
+  .card h2{font-size:13px;color:#4fc3f7;margin:0 0 8px} code{color:#ffd479}
+  table{width:100%;border-collapse:collapse;font-size:13px} td{padding:4px 6px;border-bottom:1px solid rgba(255,255,255,.05)}
+  td.r{text-align:right;color:#fff} .danger{color:#ff8a65;border-color:#ff8a6555}
+  /* the history scrub line (mirrors the viewer dot-line) */
+  #scrub{position:fixed;bottom:14px;left:50%;transform:translateX(-50%);display:flex;gap:6px;align-items:center;
+    background:rgba(16,22,30,.94);border:1px solid #2b3744;border-radius:20px;padding:6px 12px;max-width:80vw;z-index:9}
+  #scrub.bloom{border-radius:11px}
+  .dot{width:10px;height:10px;min-width:10px;border-radius:50%;background:#3a4a5a;cursor:pointer}
+  .dot.op{border-radius:2px} .dot.on{background:#ffd479;box-shadow:0 0 8px #ffd479}
+  #scrub.bloom .dot{width:auto;height:auto;border-radius:7px;padding:3px 9px;font-size:11px;color:#9ab;
+    background:#19222c;border:1px solid #2b3744;white-space:nowrap} #scrub.bloom .dot.on{color:#ffd479;border-color:#ffd479}
+  .depth{font-weight:700;letter-spacing:.5px} .b-all{color:#4fc3f7} .b-doc{color:#5fd38a} .b-off{color:#888}
+  .line{font-size:12px;color:#7a8a99;margin-top:6px}
+</style></head>
+<body>
+<h1>App-wide cross-tab history — POC</h1>
+<div class="sub">Open this page in TWO tabs. Act in one → both update live. Reload → it persists.
+  This is the lighter tech tier (BroadcastChannel + localStorage) that runs anywhere incl. GitHub Pages.</div>
+
+<div class="card"><h2>Do something (each = a kernel op or a view moment)</h2>
+  <div class="row">
+    <button onclick="openBuilding()">🏠 Open Building</button>
+    <button onclick="pickElement()">🔹 Pick Element (kernel op)</button>
+    <button onclick="lensNav()">🔍 Lens nav (view-only)</button>
+    <button onclick="menuTouch()">• Menu touch (trivial)</button>
+  </div>
+  <div class="line">Recording depth:
+    <button id="depthBtn" class="depth" onclick="cycleDepth()">●</button>
+    <span id="depthLbl"></span> — cycles ALL → DOC-only → OFF. (Green = doc events only.)</div>
+</div>
+
+<div class="card"><h2>Settings ▸ Cache Info</h2>
+  <table>
+    <tr><td>Kernel log (signed, source of truth)</td><td class="r" id="szKernel">–</td><td class="r" id="cntKernel">–</td></tr>
+    <tr><td>History view cache (derived, what the line shows)</td><td class="r" id="szView">–</td><td class="r" id="cntView">–</td></tr>
+  </table>
+  <div class="row" style="margin-top:12px">
+    <button onclick="clearHistory()">🧹 Clear History view</button>
+    <button onclick="rebuildFromKernel()">↺ Rebuild history from kernel</button>
+    <button class="danger" onclick="clearKernel()">⚠ Clear kernel (destructive)</button>
+  </div>
+  <div class="line" id="note"></div>
+</div>
+
+<div id="scrub"></div>
+
+<script>
+// ── Two stores, deliberately separate ───────────────────────────────────────
+//   K_KEY  = the SIGNED kernel log. Source of truth. Cleared ONLY by the destructive button.
+//   V_KEY  = the history VIEW cache. Derived/ephemeral. What the scrub line renders. Safe to clear.
+var K_KEY='poc.kernel', V_KEY='poc.histview', D_KEY='poc.depth';
+var ch = ('BroadcastChannel' in window) ? new BroadcastChannel('poc_hist') : null;
+var depth = localStorage.getItem(D_KEY) || 'all';      // all | doc | off
+var cursor = -1;                                        // scrub position
+var bloom = false;
+
+// Significance profiles — the ONE gate (mirrors universal_history.js SIGNIFICANCE).
+var DOC = {BUILDING_OPEN:1, GRID_MOVE:1, ELEMENT_PLACE:1};            // "real items"
+var ALL = {BUILDING_OPEN:1, ELEMENT_PICK:1, VIEW_NAV:1, GRID_MOVE:1, ELEMENT_PLACE:1}; // + picks + nav
+function significant(type){ if(depth==='off') return false; return !!((depth==='doc'?DOC:ALL)[type]); }
+
+function load(k){ try{return JSON.parse(localStorage.getItem(k)||'[]')}catch(e){return[]} }
+function save(k,v){ localStorage.setItem(k, JSON.stringify(v)); }
+function ping(){ if(ch) ch.postMessage('sync'); }     // tell other tabs to re-read + re-render
+
+// tiny fake hash chain, just to echo the "signed kernel" idea (NOT real crypto)
+function h(s){ var x=2166136261; for(var i=0;i<s.length;i++){x^=s.charCodeAt(i);x=Math.imul(x,16777619)} return (x>>>0).toString(16); }
+
+// ── Commit an event ─────────────────────────────────────────────────────────
+// Kernel ops ALWAYS go to the kernel log (the audit truth). The history VIEW only
+// gets the event if the current depth says it's significant. View-only moments
+// (VIEW_NAV) never touch the kernel log — they live only in the view cache.
+function commit(type, label, isView){
+  if(!isView){
+    var kl=load(K_KEY); var prev=kl.length?kl[kl.length-1].hash:'0';
+    var op={id:kl.length+1, type:type, label:label, prev:prev};
+    op.hash=h(op.id+type+label+prev); kl.push(op); save(K_KEY, kl);
+  }
+  if(significant(type)){
+    var v=load(V_KEY); v.push({type:type, label:label, op:!isView}); save(V_KEY, v);
+  } else {
+    note('dropped "'+label+'" — not significant at depth='+depth.toUpperCase());
+  }
+  cursor = load(V_KEY).length-1;
+  render(); ping();
+}
+function openBuilding(){ commit('BUILDING_OPEN','Opened Tower-A', false); }
+function pickElement(){  commit('ELEMENT_PICK','merk H · door', false); }
+function lensNav(){      commit('VIEW_NAV','Storey 2', true); }
+function menuTouch(){    commit('MENU_TOUCH','tapped a menu', false); } // never significant → shows the gate
+
+// ── Clearing — the crux of the user's question ──────────────────────────────
+function clearHistory(){ save(V_KEY, []); cursor=-1; render(); ping();
+  note('History VIEW cleared. Kernel log UNTOUCHED ('+load(K_KEY).length+' ops still signed). Try Rebuild.'); }
+function rebuildFromKernel(){
+  // Regenerate the timeline FROM the kernel log → proves the kernel is the source of truth.
+  // NOTE the honest limit: VIEW_NAV (lens-only) moments were never in the kernel, so they
+  // cannot be recovered — they are ephemeral by design. Picks/opens come back fully.
+  var kl=load(K_KEY), v=[];
+  kl.forEach(function(op){ if(significant(op.type)) v.push({type:op.type,label:op.label,op:true}); });
+  save(V_KEY, v); cursor=v.length-1; render(); ping();
+  note('Rebuilt '+v.length+' steps from the kernel log. (Lens-only nav not recoverable — ephemeral.)'); }
+function clearKernel(){ if(!confirm('Destroy the signed kernel log? (POC only)')) return;
+  save(K_KEY,[]); save(V_KEY,[]); cursor=-1; render(); ping(); note('Kernel + view both wiped.'); }
+
+// ── Depth toggle ────────────────────────────────────────────────────────────
+function cycleDepth(){ depth = depth==='all'?'doc':depth==='doc'?'off':'all';
+  localStorage.setItem(D_KEY, depth); render(); ping(); }
+
+// ── Render ──────────────────────────────────────────────────────────────────
+function bytes(k){ var s=localStorage.getItem(k)||''; return (new Blob([s]).size); }
+function fmt(n){ return n<1024?n+' B':(n/1024).toFixed(1)+' KB'; }
+function note(t){ document.getElementById('note').textContent=t; }
+function render(){
+  var v=load(V_KEY), kl=load(K_KEY);
+  // scrub line
+  var sc=document.getElementById('scrub'); sc.className=bloom?'bloom':''; sc.innerHTML='';
+  v.forEach(function(e,i){ var d=document.createElement('div');
+    d.className='dot '+(e.op?'op':'')+(i===cursor?' on':''); d.title=e.label;
+    if(bloom) d.textContent=e.label;
+    d.onclick=function(ev){ ev.stopPropagation(); cursor=i; render(); ping(); };
+    sc.appendChild(d); });
+  sc.onclick=function(){ bloom=!bloom; render(); };               // tap bar = bloom
+  if(!v.length) sc.innerHTML='<span style="color:#566;font-size:11px">no history — do something</span>';
+  // depth pill
+  var db=document.getElementById('depthBtn'), dl=document.getElementById('depthLbl');
+  db.className='depth '+(depth==='all'?'b-all':depth==='doc'?'b-doc':'b-off');
+  db.textContent = depth==='all'?'●':depth==='doc'?'◉':'○';
+  dl.textContent = depth==='all'?'ALL (every action)':depth==='doc'?'DOC events only':'OFF';
+  // cache info
+  document.getElementById('szKernel').textContent=fmt(bytes(K_KEY));
+  document.getElementById('szView').textContent=fmt(bytes(V_KEY));
+  document.getElementById('cntKernel').textContent=kl.length+' ops';
+  document.getElementById('cntView').textContent=v.length+' steps';
+}
+
+// ── Cross-tab wiring ─────────────────────────────────────────────────────────
+if(ch) ch.onmessage=function(){ depth=localStorage.getItem(D_KEY)||depth; render(); };  // live, same-origin
+window.addEventListener('storage', function(){ depth=localStorage.getItem(D_KEY)||depth; render(); }); // backup + cross-tab
+render();
+</script>
+</body></html>

--- a/prompts/FIND_VIEW_HISTORY.md
+++ b/prompts/FIND_VIEW_HISTORY.md
@@ -1,0 +1,70 @@
+# ⚠ DO NOT REMOVE — Find-lens VIEW-HISTORY timeline (standard undo/redo + off-toggle): RESUME
+# Scope: a STANDARD undo/redo timeline for Find-lens VIEW navigation (not model ops), with a
+#        visible icon to TURN IT OFF. Read-only: it moves the view, never mutates kernel_ops.
+# Edit shipping code in bim-ootb/viewer/ (canonical, GH Pages). Whitebox §-log FIRST; SAVE every
+# run to a log and READ it before any conclusion. Witness headless (leak-safe, below). Until ✅ DONE.
+
+## ☠ HARD RULES (cost real incidents — same as FIND_LENS_DEPTH_MODEL.md)
+- **Headless WebGL probes LEAK CPU.** Wrap EVERY probe: `timeout --signal=KILL 150 node probe.js`
+  in a run_*.sh, then `pkill -9 -f chrome-headless-shell`; probe must `try{…}finally{await browser.close()}`;
+  ≤1 browser at a time; verify `ps -eo comm | grep -i chrome` clean after. Inline `&`+curl in one Bash
+  tool call trips the sandbox → put the http.server + curl-retry in the run_*.sh, not inline.
+- **Probes must BLOCK the Service Worker** (`browser.newContext({serviceWorkers:'block'})`) or a stale SW
+  serves an old build and you debug a ghost.
+- **Shared bim-ootb tree is DIRTY + DIVERGED.** Deploy ONLY via an isolated worktree off origin/main →
+  PR → CI (e2e is FLAKY: `gh run rerun <id> --failed`) → squash-merge (`--admin` if base races) → SW bump.
+  NEVER checkout/stash/reset/rebase/pull the shared tree. cp ONLY your changed viewer files into the worktree.
+- Cut ceremony; decide and let the user judge by what appears. STOP only when about to INVENT (no source).
+
+## ✅ DEPENDS ON (already LIVE on main as of this writing)
+The uniform §DEPTH model (PR #143). The view is a pure function of selection depth and funnels through
+ONE entry: `viewer/navigate_find.js` `_drillSelect(litSet, label, tag, groupSet, ctxOpacity)`:
+- GROUP select → `_drillSelect(null, label, tag, groupSet)` (group 1.0 solid + fit-zoom).
+- ITEM select  → `_drillSelect(itemSet, label, tag, groupSet[, ctxOpacity])` (cyan item + group 0.5).
+- AXIS change  → `_setTreeMode(mode)`.
+This is the ENTIRE semantic surface to record — there is no other lens-nav state.
+
+## ▶ WHAT TO BUILD — a STANDARD view-history undo/redo (user re-scoped from the Glassbowl bloom)
+The user said: "the timeline scrub should be a **standard one** and **has an icon to turn it off**."
+So: a plain, familiar undo/redo timeline for VIEWS — NOT the fancy double-tap-bloom. Mirror the look of
+the EXISTING grid undo/redo bar (`viewer/grid_overlay.js` ~L1557-1595, `#undo-redo-btns`, the `↶ ↷`
+buttons) so it reads as the same control the app already has.
+
+Requirements:
+1. **Records only SEMANTIC view moments** — axis change, group select, item select. NEVER expands,
+   hovers, or camera micro-nudges (else "back" is 20 taps deep). The funnel above is exactly these.
+2. **A view = the params needed to replay** `{tag, label, mode:'group'|'item', litGuids:[], groupGuids:[],
+   ctxOpacity, axis, cam:{pos,target}}`. Snapshot `cam` AFTER the zoom settles (or store and lerp to it).
+3. **Standard undo/redo UX:** back (↶) / forward (↷) buttons step through `viewHist`. A thin row of
+   step markers is fine, but keep it standard — no double-tap bloom required. Current step highlighted.
+   Clicking a marker / pressing back restores that view.
+4. **Restore = replay, deterministic:** re-call `_drillSelect(litSet, label, tag, groupSet, ctxOpacity)`
+   from the stored guids (rebuilds opacity/zoom/highlight), then lerp the camera to the stored pose
+   (reuse `_lerpCam`). Restoring must NOT itself push a new history entry (guard with a `_restoring` flag).
+5. **OFF TOGGLE (the icon):** a visible button that turns the view-history OFF — when off, stop recording
+   AND hide the bar. Persist the on/off choice (localStorage) so it stays off across reloads. Default ON.
+6. **Read-only / separate layer:** NEVER touches `kernel_ops` or the grid undo. This is a sibling
+   view-log, its own array + DOM. Clears/rebuilds on building switch and on Find-panel close.
+
+## WIRING NOTES
+- Push a view from inside `_drillSelect` (covers group+item; it is only called on real selects) and from
+  `_setTreeMode` (axis). Skip the push when `_restoring` is true and when the off-toggle is off.
+- `_drillSelect`'s build is deferred (rAF); snapshot the camera pose on a short timeout after the zoom,
+  or store the target box and lerp on restore. Either is fine — witness whichever you choose.
+- Only show the bar while the Find panel is open and at least 1 view is recorded.
+
+## WITNESS TARGETS (whitebox §-log first; Playwright = wiring only; adapt tests/probe_depth.js)
+- Drive: open Find → tap a storey (GROUP) → expand → tap a type leaf (ITEM) → change axis. Then:
+  - `§VIEWLOG_PUSH` fires exactly 3× (group, item, axis) — NOT on expand/hover. Log n + label each.
+  - Press back: `§VIEWLOG_RESTORE idx=… label=…`; assert the scene overlays + opacities match the
+    earlier view (re-probe `userData._shapeOverlay` opacity: group→1.0, item→0.5/cyan) and the camera
+    moved back toward the stored pose. Restoring pushes NO new entry (n unchanged).
+  - Toggle OFF → bar hidden, a further select does NOT push (n unchanged); reload → still off (localStorage).
+- Save the probe output to a log; READ the log before any conclusion. Verify chrome procs clean after.
+
+## DEPLOY (clean-worktree, same flow as #143)
+Bump `viewer/sw.js` (current → next v) + any `?v=` you touch in `viewer/main.js`.
+`git worktree add -b feat/find-view-history /tmp/wt-vh origin/main`; cp ONLY changed viewer files in;
+`node --check` each; commit those paths; push; `gh pr create --base main`; wait `gh pr checks` green
+(rerun flaky e2e); `gh pr merge --squash --admin --delete-branch`; verify pages-build-deployment +
+curl live sw.js = new v; `git worktree remove /tmp/wt-vh --force`.

--- a/prompts/HISTORY_SCRUB_FIX.md
+++ b/prompts/HISTORY_SCRUB_FIX.md
@@ -1,0 +1,357 @@
+# ⚠ DO NOT REMOVE — History SCRUB fix: picks belong on the timeline + Glassbowl bloom + bottom placement
+# Scope: the universal history bar (universal_history.js) records grid-moves/places but DROPS the
+#        thing the user actually does in a viewing session — ELEMENT_PICK selections — so the bar shows
+#        nothing you did. Fix curation (pick = first-class selection), restore picks read-only, add the
+#        Glassbowl #scrub double-tap-to-chips bloom, re-seat the bar as ONE row directly UNDER the status
+#        bar, and FULLY retire the legacy grid undo. Edit shipping code ONLY in /home/red1/bim-ootb/viewer/.
+#        Whitebox §-log is the PRIMARY witness; SAVE every run to a log and READ it before any conclusion.
+#        Witness headless (leak-safe, below). Honour until ✅ DONE.
+
+## ☠ HARD RULES (cost real incidents)
+- Edit shipping code ONLY in `/home/red1/bim-ootb/viewer/`. Whitebox `§`-tagged console.log is PRIMARY;
+  Playwright is wiring-only. SAVE every probe run to a log and READ it before concluding.
+- Shared `/home/red1/bim-ootb` tree is DIRTY + other sessions are live in it. Do NOT git switch/stash/
+  reset/rebase/pull it. Deploy ONLY via an ISOLATED worktree off origin/main → PR → CI → squash-merge.
+- Headless WebGL probes LEAK CPU: put server+curl-retry+probe in a `run_*.sh`; wrap `timeout
+  --signal=KILL 150 node probe.js` then `pkill -9 -f chrome-headless-shell`; probe `try{…}finally{await
+  b.close()}`, ≤1 browser, `newContext({serviceWorkers:'block'})`; verify `ps -eo comm|grep -i chrome` clean.
+- `kernel_ops.js` carries a SIGNED hash chain (W-CHAIN). This timeline is READ-ONLY over it — NEVER mutate
+  kernel_ops rows, never break the chain. An ELEMENT_PICK is read-only by nature: it mutates NOTHING.
+- Cut ceremony; decide and let the user judge by what appears. STOP yourself only when about to INVENT
+  (no source) OR when a genuine architecture fork needs a user decision you cannot extract.
+
+## ☠ LINE-REF FRESHNESS (navigate_find.js was rewritten by the v41 depth-model PRs #163/165/166)
+Line numbers for `navigate_find.js` below are PRE-v41 and HAVE DRIFTED. **Anchor by FUNCTION NAME, not line.**
+Current origin/main (2026-06-06, post-merge): `_replayViewObj` ~313 · axis `_pushView` ~546 ·
+`_buildShapeMeshes(set,color,solidOpacity,colorOpacity,clipPlanes)` ~940 · `_drillSelect` ~1684 ·
+item/group `_pushView` ~1696. `picking.js` (~458 `§BBOX_DEBUG`) + `universal_history.js` (~42 `SIGNIFICANCE`,
+~54 drop-log) are UNCHANGED. Always `git grep -n 'function _name' origin/main -- <file>` to re-find before editing.
+
+## ▶ THE BUG (witnessed in user's log this session)
+User tapped a door in 3D. The log:
+```
+§KERNEL_OP committed id=1 type=ELEMENT_PICK params={"cls":"IfcDoor","name":"merk H","disc":"ARC","storey":"02 tweede verdieping"}
+§HIST_DROP source=op type=ELEMENT_PICK reason=not-significant label="ELEMENT_PICK"
+```
+A deliberate selection was DROPPED, and no `§HIST_PUSH` fired the whole session → the bar records nothing
+the user did. Root cause: the significance gate (`universal_history.js:42-45`, `:34`) buckets
+`ELEMENT_PICK` with audit/bookkeeping (`SESSION_START`/`GRID_DETECT`/`VIEW_FILTER`). Only `GRID_MOVE` and
+`ELEMENT_PLACE` qualify.
+
+### Why that's wrong (the categorisation error)
+The timeline's whole purpose (UNIVERSAL_HISTORY.md / FIND_LENS_DEPTH_MODEL.md): *"no way to see what was
+chosen some steps before"* → retrace the **selection/viewing** path.
+- A direct 3D pick **IS a selection moment** — semantically identical to a Find-lens *item-select*
+  (`navigate_find.js` item `_pushView`, `kind:'item'`, ~L1696), which IS recorded. So selecting a door via the Find tree gets
+  a step, but selecting the SAME door by tapping it in 3D gets dropped. That asymmetry is the defect.
+- A pick **mutates nothing** → it is VIEW-class, not a model op. It must NOT go through `undoOp`/`redoOp`
+  flag-flipping (`_applyOp`, `:195`); restore = re-select/re-highlight + frame, read-only.
+- Its label is also broken: `_opLabel` (`:116`) has no ELEMENT_PICK case → falls through to `return
+  opType` → bar reads "ELEMENT_PICK" instead of "merk H · door".
+
+## ▶ STUDY FIRST — how the OLD undo was *supposed* to work (and why it didn't)
+1. **Legacy grid bar** `viewer/grid_overlay.js:1554-1641` (`#undo-redo-btns`, `doUndo`/`doRedo`). Design
+   intent: walk the kernel_ops log, **skip audit ops** (loop ≤10, `§UNDO skip audit`), undo the first
+   `UNDOABLE_OPS` hit (`GRID_MOVE` only, `:1602`) by replaying `GridDrag.applyReplayedMove`. Why it under-
+   delivered: (a) GRID-ONLY — one op type; (b) no view/nav awareness — a pure viewing session produced an
+   empty/blind bar; (c) no step list, no labels — just ↶↷ with nothing to *see*. `showUndoRedo` is already
+   no-op'd when UniversalHistory exists (`:1558-1561`) — this fix RETIRES the code path for good.
+2. **The merged bar** `viewer/universal_history.js` (full read). The §GATE (`:28-57`) is the ONE curation
+   point — tune there, not at call sites. Restore split: ops via `_applyOp` (flag-flip), views via
+   `_viewRestore` → `navigate_find` `_replayViewObj` (`:311`). Dots render at `:296-326` (round=view,
+   square=op, label only in `title` tooltip — invisible on touch).
+3. **Pick commit site** `viewer/picking.js:599` — `KernelOps.commitOp(A.db,'ELEMENT_PICK',{cls,name,disc,
+   storey},[g])`. The `g` (guid) is the element to re-select on restore.
+4. **Glassbowl #scrub seed** `bim-compiler/build/erp/glassbowl.html:128-138` (CSS) + `:782-790`
+   (`renderScrub`, double-tap→`vlBloom` toggle). Bottom-center dot-line; `overflow-x:auto`; double-tap the
+   BAR (not a dot) blooms every dot into a labelled chip; gold = current. Mirror this; don't reinvent.
+
+## ▶ WHAT TO BUILD
+### 1. Curation — a pick is a first-class selection (the core fix)
+- Move `ELEMENT_PICK` OUT of the drop bucket. It QUALIFIES. Keep real bookkeeping dropped
+  (`SESSION_START`/`GRID_DETECT`/`VIEW_FILTER`) and keep coalescing distinct→separate, same→folded.
+- Record a pick as a **view-class** entry (or an op entry carrying a view-style restore — your call, but it
+  must restore read-only, never flag-flip). Store the guid + cls/name/disc/storey from params.
+- **Label by element**, not op type: `"merk H · door"` (name + humanised class), tooltip/chip can carry
+  disc/storey. Add the ELEMENT_PICK case wherever labels are built (`_opLabel` or a view-label path).
+- **Restore = re-focus the element as a SHAPE MESH, NOT a bbox.** ☠ HARD CONSTRAINT (user): a restored pick
+  must render the element's actual **shape mesh** (lit, cyan shine-through), NEVER the legacy yellow **bbox
+  box** picking.js draws today (`picking.js:431-481`, `§BBOX_DEBUG`, dims from `element_transforms`). Cubes/
+  boxes = non-renderable proxy (memory `feedback_no_cubes_render_gate`).
+- ☠ ARCHITECTURE (user-corrected — do NOT couple touch to Find): a **tap** and a **Find drill** are two
+  independent ROUTES to the same outcome ("element X is focused"). Find does not own touch. So do NOT
+  "replay the pick through Find." Instead extract the shape-mesh focus into a NEUTRAL shared primitive —
+  e.g. `A.focusElement(guids, {item:true})` — that lights elements as shape meshes (item cyan shine-through,
+  rest 0.1 ghost; the depth model) and frames them. BOTH the tap handler (`picking.js`) AND Find's
+  `_drillSelect` call it; history-restore calls it directly. The good renderer currently lives inside
+  navigate_find (`_buildShapeMeshes`) — lift it (or expose it) as this shared primitive; don't make callers
+  pretend to be Find.
+- Bonus this earns: the LIVE tap highlight also upgrades from the bbox box to the shape mesh (same source) —
+  not just on restore. (Keep `§PICK`/info-panel behaviour; replace only the visual highlight.)
+- **The §PERF work in navigate_find is now COMMITTED + LIVE** (origin/main, `navigate_find ?v=28`, v41 —
+  PR#165/166, 2026-06-06): deferred-rAF `_drillSelect` build, `_getInstanceRows` cache `§INSTROWS_CACHED`,
+  `_buildShapeMeshes(set,color,solidOpacity)`. ALSO live now: ghost MAX-blend shell @0.12, whole-row focus
+  band (`.row-focus`), Find drag fix (`measure.js`), x-ray-restore-on-room-lens-exit. So start this work
+  from FRESH `origin/main` (it carries all of the above) — reuse `_buildShapeMeshes` inside the shared
+  primitive; keep it; re-witness. (No longer "uncommitted/at-risk" — it's shipped.)
+- On the TIMELINE, a tapped element and a Find-drilled element are the SAME step kind ("selected element X")
+  — distinguish steps by WHAT was selected (single element vs group/scope), never by HOW (tap vs Find).
+
+### 2. Glassbowl bloom (currently missing — labels are hover-only → invisible on touch)
+- Add double-tap-the-BAR → bloom: dots expand into labelled chips (mirror glassbowl `:783-790` +
+  `.bloom` CSS `:136-138`). Double-tap again collapses. Tapping a CHIP/dot = `jumpTo` (read-only restore).
+- Current dot/chip = gold (`#ffd479`, glow). `overflow-x:auto` + auto-scroll so the gold one stays in view.
+- **Chip icons (polish, user wants it) — by WHAT, not HOW:**
+  - SINGLE element step → the element's **discipline icon** from the existing set in `viewer/panels.js`
+    (`discARC` house, `discACMV` wavy, `discMEP`/`pipe` elbow, `discELEC` bolt, `discSTR`, `discPLMB`).
+    Map by the element's `disc` (already in pick params + meta). Fallback = a generic box outline.
+  - GROUP / scope step (Storey N, all of a discipline, a room/material set) → ONE **scope icon** — the
+    `search` magnifier (`panels.js:12`) fits (Find narrows scope). The magnifier NEVER appears on a single-
+    element chip.
+  - Reuse `A.icon(name)` (`panels.js:~60`) to render the SVGs at chip size; don't hand-roll new SVGs.
+
+### 3. Placement — ONE row directly UNDER the status bar (bottom, horizontal)
+- DECISION (user-agreed): **bottom, horizontal**, NOT a left rail. It is a timeline (reads left→right), it
+  fuses with the centered status bar into one unit, and it is the most thumb-native spot on mobile.
+- Re-seat `#universal-hist-btns` from `bottom:32px;left:16px` (`universal_history.js:269`) to sit centered
+  **immediately below `#status-bar-wrap`** (`viewer.html:37-38`, currently `bottom:16px;left:50%`). Treat
+  status + scrub as a two-row stack: status text on top, the ↶ ↷ + dot-line scrub row beneath it. Reuse the
+  status-bar footprint per UNIVERSAL_HISTORY.md §DESIGN ("present AS the status bar — and JUST that"); do
+  not add a third chrome element. (Documented FALLBACK only if bottom ever collides with `⋯`/pill: a left
+  vertical rail — but ship bottom.)
+- Mobile (`viewer.html:360,409` status @ `bottom:calc(64px+safe-area)` / `bottom:2px`): keep the scrub in
+  the bottom thumb zone, clear of `#mobile-bar` (⋯, bottom-right) and `#mobile-pill`. Chips bloom UPWARD.
+  `max-width` ~74vw + horizontal scroll (glassbowl values).
+
+### 4. Maximise / fullscreen — the scrub line (and status) must SURVIVE it
+- ☠ HARD CONSTRAINT (user): when the screen is **maximised**, the history scrub line must STAY visible so
+  you can keep thumb-scrubbing. AND the status bar going away on maximise is itself a bug — **status should
+  also remain** ("which shuldnt" go away). The scrub is the persistent thumb control; don't let chrome-hide
+  swallow it.
+- Two maximise paths to handle (study both, witness both):
+  - **Native fullscreen** — `A.toggleFullscreen` (`tools.js:362`) / [] single-tap (`panels.js:1017-1021`,
+    `§MINMAX single-tap`). The scrub + status live in normal DOM so they SHOULD persist — verify they do
+    (no `:fullscreen{}` rule hides them) and fix if the OS/CSS drops them.
+  - **Focus-latest double-tap** — `focusOnlyLatest` (`panels.js:950+`) hides panels+HUD via `.swipe-hidden`.
+    EXEMPT the status-bar + scrub row from this hide (do NOT add them to `_focusOnlyHidden`). Confirm whether
+    `#status` is currently caught here — if so, that is the "status goes away" the user means; un-hide it.
+
+### 5. Retire the legacy grid undo for good
+- Remove the dead `#undo-redo-btns` build/`doUndo`/`doRedo`/`UNDOABLE_OPS` path in `grid_overlay.js`
+  (`:1554-1641`) — or reduce to a hard no-op with a `§`-note — so there is ONE undo path. Verify nothing
+  else calls `showUndoRedo`/`doUndo`/`doRedo`. Universal Ctrl+Z/Shift+Z already route through
+  universal_history (`:351-356`).
+
+### 6. Recording-DEPTH toggle on the history icon (user-designed) — built on the EXISTING gate
+The significance gate (`universal_history.js:42-57`, `SIGNIFICANCE` table) is already the ONE data-driven
+decision point — so a depth toggle is just SWAPPING which profile that gate consults. NOT a refactor.
+Make the history icon a **3-state recording-depth** cycle (tap to cycle):
+- **Blue (normal / ALL)** — record everything: ELEMENT_PICK, axis/group/item, menu touches. "Replay exactly
+  what I did." (= the current default profile + picks, from §1.)
+- **Green (DOC events only)** — stricter profile: record only doc-level events, DROP taps + Find-nav. The
+  advanced "clean trail." (user: "advanced users wanna skip trivial → only real items.")
+- **Grey/dim (OFF)** — record nothing (the existing OFF-toggle `:238`, fold into the cycle).
+Implement as TWO `SIGNIFICANCE` profiles (`PROFILE.all` / `PROFILE.doc`) + an active-profile pointer the
+icon switches; `significant()` reads the active one. Persist the choice (localStorage, like `ENABLED_KEY`).
+- **DOC profile whitelist (the viewer's "real items"):** `BUILDING_OPEN` (new, §7) · `GRID_MOVE` (grid line
+  moved) · `ELEMENT_PLACE` · design SAVE/OPEN · 4D capture · clash-snag created. DROP: ELEMENT_PICK, axis/
+  group/item, menu touches. (Tune the table by feel — that's the whole point of the centralised gate.)
+
+### 6b. EVENT CLASSIFICATION — the CANONICAL list (BOTH sessions classify HERE — do not invent your own)
+☠ READ THIS BEFORE adding any `History.push`. There are exactly TWO buckets. Do NOT add a third, do NOT
+re-decide per feature, do NOT push anything not on these lists without adding it here first. This is the
+single source of truth the depth toggle (§6) and the cross-tab bridge (§CONTRACT) both read.
+
+**THE ONE DECISION RULE (use this for anything not explicitly listed):**
+> Does it change the CONTEXT (what you're looking at / which page) OR change DATA? → **MAIN.**
+> Is it navigation WITHIN the current context that changes nothing? → **ALL.**
+> Is it a hover / scroll / expand / camera nudge / idle redraw? → **IGNORE (record nothing).**
+
+**MAIN / DOC events (coarse; GREEN mode; these CROSS TABS):** context switches + data mutations + milestones.
+- ANY app: **tab / page / mode change** (switching tab, panel takeover, 2D↔3D, opening another app/page). ← user: a tab change IS a main event.
+- VIEWER: `BUILDING_OPEN`, IFC import, **axis / lens / view-mode switch** (the viewer's "tab change" analog),
+  `GRID_MOVE` (grid line moved), `ELEMENT_PLACE`, design SAVE/OPEN, 4D capture, clash-snag created.
+- ERP: tab/window change, doc/line moved, order/SO/PO completed, **signed rule edit**, posting committed,
+  document status change, payment/allocation. (The user's "only happens in Red Pill/ERP" events.)
+
+**ALL events (fine-grained; BLUE mode only; STAY LOCAL to the tab — never cross tabs):** breadcrumbs of what
+you did *inside* one context, for replay.
+- VIEWER: `ELEMENT_PICK` (tap an element), group select (a specific storey/disc/room/material), item drill,
+  Find search/filter applied.
+- ERP: a specific record opened, list row navigation, search/filter applied within a tab.
+
+**IGNORE (record NOTHING — neither bucket):** hover, scroll, row expand/collapse, camera micro-nudges,
+idle/awake re-renders, focus changes, transient toasts.
+
+**☠ CROSS-TAB RULE (this is the "how does it manage across tabs" answer):**
+- **MAIN events** → written to the SHARED log `bim.history.v1` + a `BroadcastChannel('bim_history')` ping →
+  appear on EVERY tab's line (the app-wide trail). MAIN is the ONLY thing that crosses tabs.
+- **ALL events** → stay in the tab's OWN local history; NOT broadcast (else tab B re-renders on tab A's every
+  tap = flood). So the depth toggle doubles as the cross-tab filter: GREEN = the shared MAIN trail (identical
+  on every tab); BLUE = this tab's local ALL detail merged with the shared MAIN trail.
+- Net per tab = [this tab's fine detail] + [the app-wide MAIN trail from all tabs]. Restore stays owner-local
+  (§CONTRACT §3): clicking a MAIN step from another app deep-links to that app's tab, never restores in place.
+- **If unsure where something goes: apply THE ONE DECISION RULE above. Do NOT guess, do NOT add a new bucket,
+  do NOT silently push un-listed events — add the event to this section first, then push it.**
+
+### 7. Record "building opened" (the one NEW event to add now)
+Building launch today = `A.streamBuilding(name)` (`city.js:622`); SESSION_START exists but no open event.
+Add a `BUILDING_OPEN` significant event (commit a kernel op OR push a view-style entry) when a building
+finishes loading — label = building name, scope icon. This is the minimum so a fresh session's timeline
+shows "opened <Building>" even before any tap. Qualifies in BOTH profiles (all + doc).
+
+### 8. Landing-page history line (sibling timeline — SEPARATE tab/context)
+**WHY THIS MATTERS (positioning, honest):** the cross-tab tech itself is commodity (Figma/Docs sync tab
+state). What is novel — *to our knowledge, scoped to BIM/ERP* (not a universal negative) — is an **app-wide,
+serverless, SIGNED history/undo timeline shared LIVE across tabs**. BIM tools are single-session; ERP
+"history" is a server-side audit log, not a client-side scrubber. The first is the COMBINATION: signed
+kernel chain + no backend + one history spanning landing↔viewer↔ERP. Frame the demo around that, not the pipe.
+
+☠ ARCHITECTURE FACT: the landing (`index.html`) opens each building/viewer in a NEW TAB via `window.open`
+(`index.html:424,502,850,921`) — landing and viewer are different windows, CANNOT share one live
+`UniversalHistory` object. Landing already tracks opens (`openTabs`/`renderTabs`, `index.html:~346+`).
+- Give the LANDING its own doc-mode history line (same dot/bloom UX), recording: IFC imported · building
+  opened · city launched. Inherently "doc mode" (no element taps exist on landing).
+- To merge with the viewer's opens: both write doc-events to ONE shared `localStorage` log key (e.g.
+  `bim.docHistory`); landing renders the union. This is the only cross-tab bridge — keep it append-only,
+  read-only on the landing. Moderate addition; NOT a viewer rewrite. (Can ship after the viewer bar.)
+- **Cross-tab tech — what runs WHERE (host constraint):**
+  - SHIP (works on GitHub Pages, no special headers): `BroadcastChannel` (already in repo — `main.js:171`
+    `bim_4d`, `ad_ui.js` `bim_erp`) for live "refresh" pings + the shared `localStorage` doc-log for
+    persistence. This is the baseline landing↔viewer bridge.
+  - PROWESS DEMO (LOCAL-ONLY): the "one signed WASM kernel shared live across all tabs" via the
+    cross-origin-isolated / `SharedArrayBuffer` tier needs COOP+COEP response headers that **GitHub Pages
+    cannot send** → it must run on **localhost** (or a host where headers are controllable). Same wall that
+    blocked geo-range streaming (memory `project_mobile_meta_split`). Do NOT attempt the SAB tier on the GH
+    Pages deploy; build it as a local demo. (`SharedWorker`/OPFS sit between — usable but out of scope here.)
+
+### 9. Storage tiers + bloat control (the "Cache Info / clear history" answer)
+THREE tiers, deliberately separate — this is what makes clearing safe and bloat bounded:
+- **Kernel log** (`kernel_ops`) — PERSISTED, SIGNED, tiny. Records WHAT happened only: `op_type`,
+  `parameters` (small JSON), guids, hash chain (`kernel_ops.js:10-21`; hash over
+  `op_type|parameters|input|output`, `:123`). NO image/BLOB column. Already self-prunes to the last 2
+  SESSION_START boundaries (`:278`). ☠ NEVER put thumbnails/images in `parameters` — it bloats the DB AND
+  the signed hash of every op. The kernel stores *what you did*, never *what it looked like*.
+- **History view cache** — PERSISTED, tiny text (dot-line steps: label, guids, kind). DERIVED from the
+  kernel. Safe to clear; rebuildable from the kernel (except view-only lens-nav, which is ephemeral).
+- **Thumbnails** (if built, §FUTURE) — NOT persisted. Memory-only, capped LRU (~20), regenerated on demand
+  by replaying the view + snapshot. Self-maintaining → bloat is structurally bounded (the heavy tier is the
+  one we never keep). "Fresh session only" is the floor; lazy + capped is tighter.
+- **Settings ▸ Cache Info panel** (user-requested): list each browser store with its SIZE + a CLEAR button —
+  e.g. kernel log · history view cache · thumbnails · imported-building DBs (IndexedDB) · SW caches. Precedent
+  exists: `index.html` already has `clearAllCache()` (`:304`). Clearing the history view cache MUST NOT touch
+  kernel_ops (prove `verifyChain` still passes after) — offer a separate guarded "clear kernel" if at all.
+- POC proving all of the above (two separate stores, cross-tab sync, depth toggle, clear-vs-rebuild,
+  size readout): `bim-ootb/poc/xtab_history_poc.html` (serverless, BroadcastChannel+localStorage tier).
+
+## ▶ CROSS-APP CONTRACT — the COMMON place (iDempiere/ERP session: build to THIS section)
+Goal: ONE history line, same look + same log, across viewer AND every ERP page. Viewer (`viewer/*`) and
+ERP (`erp/*`) are SAME-ORIGIN (both under bim-ootb, opened as tabs from `index.html`) → `localStorage` +
+`BroadcastChannel` are shared across them with zero server. Each app already has its own signed `kernel_ops`
++ `commitOp` (`viewer/kernel_ops.js`, `erp/kernel_ops.js`) — they stay separate; only the HISTORY VIEW is shared.
+
+**1. Common collection point (the "common place"):** one append-only `localStorage` key — `bim.history.v1` —
+an array of event objects (capped/pruned, like kernel's 2-session prune). EVERY app appends here through the
+ONE significance gate. This is what makes the log come from a common place.
+
+**2. Common live-sync:** `BroadcastChannel('bim_history')`, message `'sync'` → every tab re-reads
+`bim.history.v1` and re-renders. (ERP keeps `bim_erp` for its own messaging; `bim_history` is the shared bar's
+channel.) Plus the `storage` event as a cross-tab backup. (POC proves this exact pattern.)
+
+**3. Event contract (the shape both apps write):**
+`{ seq, ts, source:'viewer'|'erp'|'landing', kind:'op'|'view', type, label, icon, restore }`
+- `type` passes the shared significance gate (DOC profile = the "real items"). ERP's significant types are the
+  doc-level ones the user means: doc/line moved, order completed, **signed rule edit**, posting (NOT every menu
+  touch). Viewer's: BUILDING_OPEN, ELEMENT_PICK, GRID_MOVE, … (this prompt's §1/§6).
+- `restore` is an OWNER-LOCAL payload: each app interprets its own events. Clicking a same-app step restores
+  in place (read-only); clicking a FOREIGN-source step deep-links / focuses that app's tab (you can't restore
+  an ERP doc inside the viewer). Keep foreign steps read-only labels for now.
+
+**4. Common UI component:** ONE shared bar module both pages include (generalise `viewer/universal_history.js`
+or factor a `common/history_bar.js`) so it looks identical everywhere — bottom-center dot-line + double-tap
+bloom + the 3-state depth toggle (§6) + OFF. It renders from `bim.history.v1`; it does NOT know about any
+specific kernel. Each app feeds it by wrapping its own `commitOp` to also call `History.push({source,…})`
+through the gate (the viewer wrapper at `universal_history.js:330-348` is the template; ERP mirrors it).
+
+**4b. The shared API (code to THIS — the module owns ~95%; apps inject only 2 things):**
+```js
+History.push({ source:'erp', kind:'op', type:'RULE_EDIT', label:'Signed rule: credit limit',
+               icon:'doc', restore:{ docId:4711 } });   // log one event (runs through the shared gate)
+History.registerRestore('erp', function(ev){ openDoc(ev.restore.docId); }); // how to restore THIS app's events
+History.setDepth('all'|'doc'|'off');  History.open();  History.undo();  History.redo();  History.jumpTo(i);
+```
+The module OWNS (identical everywhere, no per-app code): dot-line UI + bloom, depth toggle + OFF, persistence
+to `bim.history.v1`, `BroadcastChannel('bim_history')` sync, significance gate, coalesce, prune/cap, undo/redo/
+jump. Each app SUPPLIES only: (a) `push()` calls wired onto its own `commitOp`, (b) one `registerRestore(source,
+fn)` (restore can't be abstract — only each app rebuilds its own state), (c) its significant `type`s in the DOC
+profile table. `registerViewRestore` in `universal_history.js:134` is the existing seed for (b) — generalise it
+to `registerRestore(source, fn)`. This is the "just call the class, share all behaviour" model the user asked for.
+
+**5. Layout contract for ERP pages (what to tell the iDempiere session now):** leave the **bottom ~40px
+center strip CLEAR** on every ERP page (no fixed footer/toolbar overlapping bottom-center) so the shared line
+docks there, same slot as the viewer's status bar. Don't build a second/own history widget — include the
+common module and write to `bim.history.v1`.
+
+**6. Host constraint:** the shared-log + BroadcastChannel tier runs anywhere incl. GitHub Pages. The
+"one live signed WASM kernel shared across tabs" (SharedArrayBuffer) tier is LOCAL-ONLY (§8).
+
+## ▶ FUTURE / EXPLORE (note only — do NOT build this pass)
+- **Movie-thumbnail chips (EXPLORE, user-requested).** Feasible with existing primitives: snapshot via
+  `A.canvas.toDataURL()` (`tools.js:351`; WebGL needs the frame to have just rendered — the idle gate
+  already renders on each nav/pick, so capture in that wake), then "cut where the event is" by projecting
+  the element's bbox corners to screen (`point.project(A.camera)`, proven `city.js:1015`/`measure.js:1580`),
+  cropping that 2D rect to a small (~96×64) thumbnail. Store small (few KB) per RECORDED step (not per
+  frame). DESKTOP: show the thumbnail in the bloomed chip (big screen = real visual cue). MOBILE: stay
+  dots+labels (no room). Cost = one snapshot+crop per significant event — cheap at that cadence. Explore +
+  report cost/quality before committing.
+  - ☠ EPHEMERAL by design (user): thumbnails are NOT persisted and NEVER enter the kernel. Memory-only,
+    capped LRU (~20, evict oldest), regenerated on demand by replaying the view + snapshot. "Fresh session
+    only" is the floor. This keeps the heavy tier off disk → bloat stays bounded (see §9).
+- **ERP / Red Pill doc-line moves** are the canonical "real items" (doc moved, line edited, signed rule
+  edit). The Viewer's nearest equivalents are the DOC-profile whitelist in §6. Revisit when the ERP + viewer
+  histories are unified.
+
+## WITNESS TARGETS (whitebox §-log first; Playwright = wiring only)
+- Tap an element in 3D → `§HIST_PUSH ... kind=view/op label="<name> · <class>"` (NOT §HIST_DROP). Pick a
+  second distinct element → second step. Re-tap same element fast → coalesced (one step).
+- `§HIST_DROP` STILL fires for SESSION_START/GRID_DETECT/VIEW_FILTER (prove bookkeeping stays out).
+- `jumpTo` a pick step → the element re-highlights + frames (probe scene highlight + camera bbox). Read-only:
+  `verifyChain` PASSES after (`§HIST_CHAIN_OK`).
+- Mixed drive: grid move + Find group/item + 3D pick → merged stream lists ALL in order (`§HIST_LIST`).
+- Double-tap the bar → blooms to labelled chips; tap chip restores. Bar sits centered directly under the
+  status bar (probe getBoundingClientRect: scrub.top ≈ status.bottom, both horizontally centered).
+- Legacy `#undo-redo-btns` GONE (querySelector null). Save probe output to a log; READ it; chrome clean after.
+- **Restore renders SHAPE MESH, not bbox** — after `jumpTo` a pick step, probe `scene.traverse` for
+  `userData._shapeOverlay` material on the picked guid (cyan, shine-through). Assert NO `§BBOX_DEBUG`-style
+  box highlight is the restore mechanism. (FIND_LENS_DEPTH_MODEL.md opacity targets: rest 0.1 · group 0.5 ·
+  item cyan.)
+- **Maximise persistence** — drive native fullscreen AND `focusOnlyLatest`; probe `getBoundingClientRect` +
+  computed `display`: scrub row AND `#status` both still visible/on-screen in BOTH maximise modes.
+- **Depth toggle** — cycle the icon Blue→Green→Off. In GREEN, a tap is dropped (`§HIST_DROP ... profile=doc`)
+  while a `BUILDING_OPEN`/`GRID_MOVE` is kept; in BLUE the same tap is kept. Choice persists across reload.
+- **Building open** — load a building → `§HIST_PUSH ... BUILDING_OPEN label="<Building>"` appears with NO
+  prior taps (fresh-session timeline is non-empty).
+
+## ▶ WHITEBOX MUST PROVE TWO THINGS (user, explicit): IT WORKS + IT DOESN'T IMPACT OTHERS
+The §-log debug must demonstrate BOTH, in one readable log — not just the happy path.
+- **WORKS:** the §HIST_PUSH/§HIST_LIST/§HIST_CHAIN_OK + shape-mesh-restore + maximise-persistence lines above.
+- **NO REGRESSION (prove each still fires unchanged):**
+  - Picking still works end-to-end — `§PICK`, `§PICK_BBOX`, info-panel populates; tap-to-deselect still
+    clears. (The bbox highlight on a LIVE pick is untouched; only the timeline RESTORE uses shape mesh.)
+  - Find lens unaffected — `§GROUP_EXPAND_VIA_LABEL`, `§ROOM_SELECT`, `§XRAY_DIM`, `§INSTROWS_CACHED`
+    (count stays 1) all still fire; the uncommitted §PERF deferred-build path is intact.
+  - Kernel chain intact — `§KRN_CHAIN sealed`, `verifyChain ok=true` before AND after a timeline jump.
+  - Grid drag still commits + replays (`§KERNEL_OP type=GRID_MOVE`) even with the legacy bar removed.
+  - Idle/render gate untouched — `§IDLE_GATE`/`§RENDER_LOOP` still park-on-idle (no new always-on rAF from
+    the bar). The scrub re-render must be event-driven, not per-frame.
+  - `node deploy/dev/tests/audit_specs.js` (or the bim-ootb equivalent) exits 0 after any Playwright change.
+
+## DEPLOY — implement + witness + open PR, then PAUSE for review (do NOT auto-merge)
+Touches `universal_history.js` + `grid_overlay.js` + `picking.js` + `viewer.html` (+ maybe navigate_find).
+Bump `viewer/sw.js` CACHE_VERSION (read CURRENT off fresh origin/main first — it moves; take HIGHER on
+conflict, sw.js is the merge magnet) + any `?v=` you touch in `viewer/main.js`. `git fetch origin && git
+worktree add -b feat/history-scrub-fix /tmp/wt-hsf origin/main`; cp ONLY changed viewer paths in; `node
+--check` each; commit; push; `gh pr create --base main`; wait `gh pr checks` green (e2e FLAKY — `gh run
+rerun <id> --failed` for the golden-path streaming flake). **Then STOP and report the PR for human review —
+do NOT `gh pr merge`.** Report: study findings (why old undo under-delivered), the PR number, §-witness lines.
+```

--- a/prompts/UNIVERSAL_HISTORY.md
+++ b/prompts/UNIVERSAL_HISTORY.md
@@ -1,0 +1,90 @@
+# ⚠ DO NOT REMOVE — UNIVERSAL HISTORY timeline: study the old undo, REPLACE it, make it universal
+# Scope: turn the new Find-lens view-history scrubber into ONE universal history/undo-redo timeline
+#        that works across the WHOLE kernel log AND every panel — and RETIRE the old grid-only undo
+#        bar (the user: "it is no longer useful"). Add a pill ICON to open it + a HELP entry. Keep the
+#        OFF-toggle. Read shipping code in bim-ootb/viewer/. Whitebox §-log FIRST; SAVE every run to a
+#        log and READ it before any conclusion. Witness headless (leak-safe, below). Until ✅ DONE.
+
+## ☠ HARD RULES (cost real incidents)
+- Edit shipping code ONLY in `/home/red1/bim-ootb/viewer/`. Whitebox `§`-tagged console.log is the
+  PRIMARY witness; Playwright is wiring-only. SAVE every probe run to a log and READ it before concluding.
+- Shared `/home/red1/bim-ootb` tree is DIRTY + other sessions are live in it. Do NOT git switch/stash/
+  reset/rebase/pull it. Deploy ONLY via an ISOLATED worktree: `git fetch origin && git worktree add -b
+  feat/universal-history /tmp/wt-uh origin/main`. cp ONLY your changed viewer files into it; `node --check` each.
+- Headless WebGL probes LEAK CPU: put server+curl-retry+probe in a run_*.sh; wrap `timeout --signal=KILL
+  150 node probe.js` then `pkill -9 -f chrome-headless-shell`; probe `try{…}finally{await browser.close()}`,
+  ≤1 browser, `browser.newContext({serviceWorkers:'block'})`; verify `ps -eo comm|grep -i chrome` clean after.
+- `kernel_ops.js` carries a SIGNED hash chain (sealChain/verifyChain, W-CHAIN). This timeline is READ-ONLY
+  over it — NEVER mutate kernel_ops rows, never break the chain. Undo/redo of MODEL ops uses the EXISTING
+  undoOp/redoOp (the `undone` flag), not row deletion.
+- Cut ceremony; decide and let the user judge by what appears. STOP yourself only when about to INVENT
+  (no source) OR when a genuine architecture fork needs a user decision you cannot extract.
+
+## ▶ STUDY FIRST (the user said "by right it was to look at the old one")
+1. **Old grid undo/redo bar** — `viewer/grid_overlay.js` ~L1557-1595 (`#undo-redo-btns`, `↶ ↷`,
+   shown only in grid mode, `hideUndoRedo()` on exit) + `doUndo`/`doRedo` ~L1601-1637 (skip audit ops,
+   dispatch to `GridDrag.applyReplayedMove`). This is GRID-ONLY and tied to GridDrag — that narrowness
+   is WHY the user calls it "no longer useful". You will RETIRE this bar and fold its capability in.
+2. **The kernel log** — `viewer/kernel_ops.js`: `kernel_ops` table (op_uuid, op_type, parameters,
+   input/output guids, `undone`, prev_hash/op_hash/sig), `commitOp`, `undoOp(db)`, `redoOp(db)`,
+   `replayOps(db,type)`, `sealChain`/`verifyChain`. Op types seen: GRID_MOVE, SESSION_START, ELEMENT_PLACE,
+   ELEMENT_PICK. THIS is the model-side history.
+3. **The new Find view-history** — `viewer/navigate_find.js` `§VIEWLOG` block (~L219+): `_viewHist`,
+   `_viewIdx`, `_pushView`, `_restoreView`, `_restoring` guard, the `#…` bar + off-toggle (localStorage
+   `bim.findViewHist.on`). This is the VIEW-side history (lens nav: axis/group/item). It funnels through
+   `_drillSelect`/`_setTreeMode`. Read it fully — it is the UX seed for the universal timeline.
+
+## ▶ DESIGN DIRECTION (user, explicit) — ONE single timeline + an "events that matter" gate
+- It is **ONE single merged timeline**, NOT two parallel tracks. Model ops and view-nav moments live on
+  the same line, time-ordered. (User: "thot its easier to be a single timeline.")
+- **Present AS the status bar — and JUST that.** The present undo/redo bar already doubles as a status
+  bar; the universal timeline should TAKE OVER that status-bar slot (one lean bottom bar = the timeline +
+  its ↶ ↷ + the off-toggle/icon), NOT add a second chrome element. Keep it minimal — a status bar, nothing
+  heavier. (User: "it seems to be a status bar also the present undo/redo.. so yes we can have status bar
+  but just that.") Reuse the existing bar's footprint/placement rather than introducing new UI furniture.
+- The hard part is **CURATION: a mechanism for picking the events that MATTER.** Not every kernel op and
+  not every view tweak belongs on the timeline — a flood makes "back" useless. Build ONE centralized
+  significance gate that BOTH sources pass through before an entry is recorded:
+    - Make it data-driven and simple (KISS): e.g. a `significant(event)` predicate / a registry of
+      qualifying op-types + a per-push `significant` flag — ONE place that answers "does this matter?".
+    - View side: axis change · group select · item select QUALIFY; expands/hovers/camera micro-nudges do NOT.
+    - Model side: meaningful committed ops (e.g. ELEMENT_PLACE, a settled GRID_MOVE) QUALIFY; pure audit/
+      bookkeeping rows (SESSION_START, GRID_DETECT, and the like) do NOT. Coalesce rapid repeats of the
+      same op (e.g. a drag emitting many GRID_MOVE) into ONE entry, not twenty.
+    - `§-log every drop` (what was filtered and why) — silent curation reads as "nothing happened".
+  Keep the gate easy to tune (one table/threshold), because "what matters" will be adjusted by feel.
+
+## ▶ WHAT TO BUILD — ONE universal history timeline
+- **Replace** the old grid `#undo-redo-btns` with a single universal timeline control that is available
+  across ALL panels (not grid-only, not find-only) — a standard undo/redo `↶ ↷` plus a step row.
+- **Universal over BOTH logs:** it shows, in time order, BOTH model ops (the kernel_ops log — grid moves,
+  element places/picks, etc.) AND view-nav moments (the view-history). Undo/redo steps backward/forward
+  through this merged stream:
+    - a VIEW step → restore that view (replay `_drillSelect`/`_setTreeMode` + lerp camera), read-only.
+    - a MODEL-OP step → the existing `undoOp`/`redoOp` on kernel_ops (the `undone` flag + GridDrag replay),
+      NEVER row deletion, never break the W-CHAIN.
+  Decide a clean merge/ordering (timestamps or a unified sequence counter) — STUDY both before choosing;
+  if the two streams can't be cleanly merged without a user call, STOP and report that one fork.
+- **Pill ICON to open it** + a **HELP entry** (mirror however other panels expose help — study the
+  existing help/`?` affordance in the viewer and match it; don't invent a new pattern).
+- **OFF-toggle stays** (persisted, default ON): off → stop recording + hide the bar.
+- Keep it READ-ONLY-safe: never corrupt kernel_ops; the view layer stays a sibling.
+
+## WITNESS TARGETS (whitebox §-log first; Playwright = wiring only; adapt tests/probe_depth.js + the
+##  agent's tests/probe_viewhist.js)
+- Old grid `#undo-redo-btns` is GONE (querySelector null) and the universal bar is present instead.
+- Drive a mix: a grid move (model op) + Find group/item selects (view ops) → the timeline lists BOTH in
+  order (`§HIST_PUSH`/`§HIST_LIST` with kind=op|view). Undo steps back through the merged stream:
+  a view step restores the view (overlays/opacity/camera match), a model-op step flips `undone` and
+  replays — `verifyChain` still PASSES after (prove it, `§HIST_CHAIN_OK`).
+- Pill icon opens the bar; Help entry present. Off-toggle: hides + stops recording + persists across reload.
+- Save probe output to a log; READ it before concluding; chrome procs clean after.
+
+## DEPLOY — implement + witness + open PR, then PAUSE for review (do NOT auto-merge)
+This REPLACES a core control and touches `kernel_ops.js` + `grid_overlay.js`, so unlike the additive
+prior PRs: bump `viewer/sw.js` CACHE_VERSION (read the CURRENT value off fresh origin/main first — it
+moves; take higher on conflict, sw.js is the merge magnet) + any `?v=` you touch in `viewer/main.js`;
+commit ONLY changed viewer paths; `node --check` each; push `feat/universal-history`; `gh pr create
+--base main`; wait `gh pr checks` green (e2e is FLAKY — `gh run rerun <id> --failed` for the golden-path
+streaming flake). **Then STOP and report the PR for human review — do NOT `gh pr merge`.** Report: the
+study findings (how old undo worked, the merge design you chose), the PR number, and the §-witness lines.


### PR DESCRIPTION
Preserves the History/cross-tab session's local-only work onto origin ahead of the shared-tree reset (SHARED_TREE_RECONCILE.md). Docs + sandbox POC only — no shipping code touched. See prompts/HISTORY_SCRUB_FIX.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)