### PR TITLE
fix(erp-rule): client-scope the ⚖ Rule pill (honest tenant, honest-disable) — RULE_EDIT_SPEC §11

### DIFF
--- a/erp/docs/RULE_EDIT_SPEC.md
+++ b/erp/docs/RULE_EDIT_SPEC.md
@@ -109,3 +109,37 @@ a document's lifecycle transition**, the most valuable rule a user edits.
 
 Both rules share ONE generalized engine (`RULES` registry in `rule_fold.js`) and ONE signed op-log
 (rule-tagged `SET_RULE` ops); the ⚖ Rule overlay switches between them.
+
+## 11. Client-scoping (the honest tenant) — bug fix 2026-06-06
+**Issue it proves/disproves:** "the Rule pill is hard-bound to Odoo." `rule_fold.js` hardcoded
+`AD_Client_ID = 12` in BOTH rule populations and stamped `tenant=Odoo(12)` on every §RULE-EDIT line.
+On any non-Odoo login (e.g. GardenWorld, Client 11) the pill therefore queried Odoo's rows — returning
+**0** under a GardenWorld-only seed — and lied `tenant=Odoo(12) FAIL no-population`, even though
+GardenWorld has 114 priced products that the rule *should* fold. The engine is supposed to be
+client-agnostic (the AD is the model; the tenant is data), so the rule must fold over the **logged-in
+client**.
+
+- **Source of the client (NON-INVENT):** the live login session. `idempiere.html` `applySession()`
+  exposes `window.__idmpClient = _session.client` (`{id, name}`); `rule_fold.js` reads it (with an
+  `opts.client` override for tests). No client ⇒ honest no-client, never a hardcoded default.
+- **Scope:** each rule's `load(adDb, clientId)` substitutes the live `clientId` (coerced to a number)
+  for the literal `12`. Odoo logins still resolve `clientId=12` → identical results (regression below).
+- **Honest-disable:** when the logged-in client has **no population** for a rule (e.g. GardenWorld has
+  0 DR/IP orders → `maycomplete`), the overlay disables ▶ Run for that rule and states the real client;
+  it never pretends Odoo. Emits `§RULE-DISABLE rule=<id> client=<Name>(<id>) reason=no-population`.
+
+Witness contract (`tests/poc_rule_client_scope.js` — whitebox §-log first):
+```
+# (A) regression — login Odoo(12) with the 12-odoo shard: UNCHANGED
+§RULE-EDIT layer=L2 rule=premium tenant=Odoo(12) … edit=T:100→500 population=35 …   (still 12 of 35)
+§RULE-GESTURE layer=L2 rule=premium PASS N=35 …
+
+# (B) the fix — login GardenWorld(11), no Odoo shard: scoped to the real client
+§RULE-OPEN  rules=[premium(L2),maycomplete(L1)] tenant=GardenWorld(11)        (the honest tenant, NOT Odoo(12))
+§RULE-SCOPE rule=premium client=GardenWorld(11) population=114                (client 11's 114, NOT 0, NOT 35)
+§RULE-SCOPE rule=maycomplete client=GardenWorld(11) population=0
+§RULE-DISABLE rule=maycomplete client=GardenWorld(11) reason=no-population    (0 DR/IP orders → honest-disable ▶ Run)
+§RULE-CLIENT-SCOPE PASS premium.tenant=GardenWorld(11) premium.pop=114 maycomplete=disabled odooRegress=PASS
+```
+- Pass = (A) Odoo gesture still PASS (no regression) AND (B) `population` & `tenant` reflect the live
+  client (114 / GardenWorld(11), not 0 / Odoo(12)) AND `maycomplete` honest-disabled AND 0 pageerrors.

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -318,7 +318,7 @@
 <script src="kanban_host.js?v=1"></script>
 <!-- The ONE gesture — edit one rule → K records re-fold live, signed + reversible (docs/RULE_EDIT_SPEC.md). -->
 <script src="bigdecimal.js?v=1"></script>
-<script src="rule_fold.js?v=1"></script>
+<script src="rule_fold.js?v=2"></script>
 <script>
 (function () {
   'use strict';
@@ -502,6 +502,8 @@
     applySession();
   }
   function applySession() {
+    // expose the live login client (the honest tenant) for client-scoped lenses (RuleFold §11) — NON-INVENT
+    window.__idmpClient = _session.client;   // { id, name }
     // header context bar — live Client · Role · Org (replaces the old static string)
     var orgLabel = _session.org ? _session.org.name.replace(/\s*\(.*\)/, '') : '—';
     $('idmp-ctx').textContent = _session.client.name + ' · ' + _session.role.name + ' · ' + orgLabel;

--- a/erp/rule_fold.js
+++ b/erp/rule_fold.js
@@ -1,7 +1,9 @@
 // BIM OOTB — ERP. Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
 //
 // rule_fold.js — THE ONE GESTURE (window.RuleFold): edit ONE rule → K records re-fold live, signed +
-//   reversible, on the migrated Odoo Client-12 tenant. Implements docs/RULE_EDIT_SPEC.md (and
+//   reversible, on the LOGGED-IN client (the honest tenant — read from window.__idmpClient, never
+//   hardcoded; e.g. the migrated Odoo Client-12 tenant, or GardenWorld-11). §11 client-scoping.
+//   Implements docs/RULE_EDIT_SPEC.md (and
 //   bim-compiler prompts/RULE_EDIT_ONE_GESTURE.md). Engine-as-data: the rule is DATA (a SET_RULE op on
 //   the genuinely-signed W-CHAIN/W-SIGN op-log), the "K reflow" is the re-FOLD of a derived classification
 //   — NOT a per-record rewrite. NON-INVENT (real Odoo data), §-log first.
@@ -19,6 +21,13 @@
   'use strict';
 
   function bd(v) { return global.BigDecimal.of(String(v)); }
+  // the live login client (the honest tenant) — NON-INVENT: from the session, never a hardcoded default.
+  // idempiere.html applySession() sets window.__idmpClient = _session.client ({id,name}); opts.client overrides (tests).
+  function curClient(opts) {
+    var c = (opts && opts.client) || global.__idmpClient || null;
+    return (c && c.id != null) ? { id: Number(c.id), name: c.name || ('Client ' + c.id) } : null;
+  }
+  function clientLabel(c) { return c ? (c.name + '(' + c.id + ')') : 'no-client'; }
   function rows(adDb, sql) {
     var r; try { r = adDb.exec(sql); } catch (e) { return []; }
     if (!r.length) return [];
@@ -31,18 +40,18 @@
       id: 'premium', layer: 'L2', title: 'L2 · PREMIUM (products)', gate: 'PREMIUM-tag', cmp: 'gte',
       T0: 100, T1: 500, attr: 'PriceStd',
       desc: 'a product is PREMIUM iff PriceStd ≥ T  (a classification guard)',
-      load: function (adDb) { return rows(adDb,
+      load: function (adDb, cid) { return rows(adDb,
         'SELECT p.M_Product_ID id, p.Name name, pp.PriceStd v FROM M_ProductPrice pp ' +
-        'JOIN M_Product p ON p.M_Product_ID = pp.M_Product_ID WHERE p.AD_Client_ID = 12 ORDER BY pp.PriceStd DESC'); },
+        'JOIN M_Product p ON p.M_Product_ID = pp.M_Product_ID WHERE p.AD_Client_ID = ' + (cid | 0) + ' ORDER BY pp.PriceStd DESC'); },
       badge: function (k, n, T) { return '⚖ PREMIUM: ' + k + ' of ' + n + '   (T = ' + T + ')'; }
     },
     maycomplete: {
       id: 'maycomplete', layer: 'L1', title: 'L1 · May Complete (orders)', gate: 'Complete(CO)', cmp: 'lte',
       T0: 1500, T1: 3000, attr: 'GrandTotal',
       desc: 'an order (DR/IP) may Complete (CO) without approval iff GrandTotal ≤ T  — a LIFECYCLE guard on the wfmc transition',
-      load: function (adDb) { return rows(adDb,
+      load: function (adDb, cid) { return rows(adDb,
         "SELECT C_Order_ID id, DocumentNo name, GrandTotal v FROM C_Order " +
-        "WHERE AD_Client_ID = 12 AND DocStatus IN ('DR','IP') ORDER BY GrandTotal DESC"); },
+        "WHERE AD_Client_ID = " + (cid | 0) + " AND DocStatus IN ('DR','IP') ORDER BY GrandTotal DESC"); },
       badge: function (k, n, T) { return '⚖ MAY COMPLETE: ' + k + ' of ' + n + '   (approval limit T = ' + T + ')'; }
     }
   };
@@ -114,8 +123,10 @@
     opts = opts || {};
     var R = RULES[opts.rule || 'premium'];
     var adDb = opts.db || global.__idmpDb, SQL = opts.SQL || global.SQL;
-    var pop = R.load(adDb), N = pop.length;
-    if (N === 0) { console.log('§RULE-GESTURE layer=' + R.layer + ' rule=' + R.id + ' FAIL no-population'); return { pass: false, reason: 'no-population' }; }
+    var client = curClient(opts);                       // the live tenant — never hardcoded
+    if (!client) { console.log('§RULE-GESTURE layer=' + R.layer + ' rule=' + R.id + ' FAIL no-client'); return { pass: false, reason: 'no-client' }; }
+    var pop = R.load(adDb, client.id), N = pop.length;
+    if (N === 0) { console.log('§RULE-GESTURE layer=' + R.layer + ' rule=' + R.id + ' FAIL no-population client=' + clientLabel(client)); return { pass: false, reason: 'no-population' }; }
 
     var opDb = await ensureOpLog(SQL);
     await commitEdit(opDb, R, null, R.T0, []);          // seed the rule as DATA at the default threshold
@@ -144,7 +155,7 @@
     if (opts.render) opts.render(pop, set2, R.T0); if (opts.animate) await _sleep(400);
 
     // ── emit the witness contract (reversibility PROVEN by step 4 before these lines print) ──
-    var tag = 'layer=' + R.layer + ' rule=' + R.id + ' tenant=Odoo(12) gate=' + R.gate;
+    var tag = 'layer=' + R.layer + ' rule=' + R.id + ' tenant=' + clientLabel(client) + ' gate=' + R.gate;
     console.log('§RULE-EDIT ' + tag + ' edit=T:' + R.T0 + '→' + R.T1 + ' population=' + N + ' affected=' + crossFwd.length +
       ' refold=ok signedOp=' + fwd.uuid.slice(0, 8) + ' chainOk=' + (fwd.chainOk ? 'Y' : 'N') + ' reversible=' + (reversible ? 'Y' : 'N'));
     console.log('§RULE-EDIT-ORACLE layer=' + R.layer + ' rule=' + R.id + ' rebuilt==' + (oracleOk ? 'live' : 'DIFF') + ' K=' + rebuilt1.length + ' chainOk=' + (ov.ok ? 'Y' : 'N'));
@@ -165,6 +176,7 @@
     opts = opts || {};
     var adDb = opts.db || global.__idmpDb, SQL = opts.SQL || global.SQL, status = opts.status || function () {};
     if (!global.BigDecimal || !global.KernelOps || !global.ErpSigner) { status('Rule gesture: engine/signer/bigdecimal not loaded'); return; }
+    var client = curClient(opts);             // the honest tenant for this overlay — scopes every load
 
     var cur = 'premium';
     var wrap = _el('div', 'font-family:system-ui,sans-serif');
@@ -197,8 +209,15 @@
           (on ? 'background:#b8860b;color:#fff;border-color:#b8860b' : 'background:#fff;color:#475467');
       });
       sub.textContent = R.desc + '  ·  Editing T is one signed op; the K reflow is a re-fold of the rule.';
-      var pop = R.load(adDb);
-      if (!pop.length) { badge.textContent = '(no ' + R.id + ' population — need the Odoo tenant)'; list.innerHTML = ''; return; }
+      var pop = R.load(adDb, client && client.id);
+      console.log('§RULE-SCOPE rule=' + R.id + ' client=' + clientLabel(client) + ' population=' + pop.length);
+      if (!pop.length) {                       // honest-disable: this client has no population for this rule
+        badge.textContent = '(no ' + R.id + ' population in ' + clientLabel(client) + ')';
+        list.innerHTML = ''; run.disabled = true;
+        console.log('§RULE-DISABLE rule=' + R.id + ' client=' + clientLabel(client) + ' reason=no-population');
+        return;
+      }
+      run.disabled = false;
       render(pop, fold(pop, R.T0, R.cmp), R.T0);
     }
     ['premium', 'maycomplete'].forEach(function (id) {
@@ -208,7 +227,7 @@
 
     run.addEventListener('click', function () {
       run.disabled = true; status('Running signed rule-edit gesture (' + RULES[cur].layer + ')…');
-      runGesture({ rule: cur, db: adDb, SQL: SQL, render: render, animate: true }).then(function (res) {
+      runGesture({ rule: cur, db: adDb, SQL: SQL, client: client, render: render, animate: true }).then(function (res) {
         run.disabled = false;
         status(res.pass ? ('§RULE-GESTURE ' + res.layer + ' PASS — ' + res.affected + ' of ' + res.N + ' reflowed, signed + reversible') : 'Rule gesture: see console §-log');
       });
@@ -217,8 +236,8 @@
     wrap.appendChild(tabs); wrap.appendChild(badge); wrap.appendChild(sub); wrap.appendChild(list);
     bar.appendChild(run); wrap.appendChild(bar);
     select('premium');
-    if (opts.mount) opts.mount('Rule edit — Odoo (signed, reversible re-fold)', wrap);
-    console.log('§RULE-OPEN rules=[premium(L2),maycomplete(L1)] tenant=Odoo(12)');
+    if (opts.mount) opts.mount('Rule edit — ' + clientLabel(client) + ' (signed, reversible re-fold)', wrap);
+    console.log('§RULE-OPEN rules=[premium(L2),maycomplete(L1)] tenant=' + clientLabel(client));
   }
 
   global.RuleFold = { open: open, runGesture: runGesture, setT: setT, fold: fold, _RULES: RULES };

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,8 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v587';   // v587: §MOBILE-LANDING — phone post-login lands on the menu drawer (was empty canvas) + tap-to-close backdrop;
+const CACHE_VERSION = 'v588';   // v588: ⚖ Rule pill client-scoping (RULE_EDIT_SPEC §11) — fold over the LOGGED-IN client (window.__idmpClient), honest tenant label + honest-disable on no-population (was hardcoded Odoo Client-12);
+                                // v587: §MOBILE-LANDING — phone post-login lands on the menu drawer (was empty canvas) + tap-to-close backdrop;
                                 // v586: §MOBILE-VIEW — record LIST renders as .acc cards @≤760px (table = desktop only) + bottom pill rail;
                                 // v585: Migrate INSTALL persists the merged tenant (shard-in → idbPut) so a
                                 //       migrated client (e.g. Odoo 12) survives a plain reload — actual, not transient;

--- a/erp/tests/poc_rule_client_scope.js
+++ b/erp/tests/poc_rule_client_scope.js
@@ -1,0 +1,114 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for RULE_EDIT_SPEC §11 (client-scoping bug fix, 2026-06-06).
+//   ISSUE IT PROVES: "the ⚖ Rule pill was hard-bound to Odoo (AD_Client_ID=12)" — on any non-Odoo
+//   login it queried Odoo's rows and lied `tenant=Odoo(12) FAIL no-population`. The fix: fold over the
+//   LOGGED-IN client (window.__idmpClient, set by idempiere.html applySession), honest tenant label +
+//   honest-disable when the client has no population.
+//   PROVES:
+//     (A) REGRESSION — login Odoo(12) w/ the 12-odoo shard: premium gesture STILL §RULE-GESTURE PASS,
+//         tenant=Odoo(12), population=35 (the fix didn't break the original path).
+//     (B) THE FIX — login GardenWorld(11), NO Odoo shard: §RULE-OPEN tenant=GardenWorld(11) (NOT Odoo);
+//         §RULE-SCOPE premium population=114 (client 11's real products, NOT 0, NOT 35) corroborated by
+//         the rendered badge DOM; maycomplete (0 DR/IP orders) → §RULE-DISABLE + ▶ Run disabled (honest).
+//   §-log first — READ tests/poc_rule_client_scope.log before any conclusion.
+// Run:  node tests/poc_rule_client_scope.js 2>&1 | tee tests/poc_rule_client_scope.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+// open the ⚖ Rule pill after a login auto-completes (fallback: confirm the role step if it stalls there)
+async function openRulePill(page) {
+  await page.waitForSelector('.idmp-pill[title="Rule"]', { timeout: 20000 }).catch(async () => {
+    const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click();
+    await page.waitForSelector('.idmp-pill[title="Rule"]', { timeout: 15000 });
+  });
+  await page.click('.idmp-pill[title="Rule"]');
+  await page.waitForSelector('#rule-run', { timeout: 8000 });
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const result = { A: {}, B: {} };
+
+  // ── (A) REGRESSION: Odoo(12) login with the 12-odoo shard — premium gesture must still PASS ──
+  {
+    const logsA = [], errsA = [];
+    const page = await browser.newPage();
+    page.on('console', m => logsA.push(m.text()));
+    page.on('pageerror', e => errsA.push(e.message));
+    await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=140`,
+      { waitUntil: 'networkidle' });
+    await openRulePill(page);
+    await page.click('[data-rule="premium"]');
+    await page.waitForTimeout(300);
+    await page.click('#rule-run');
+    for (let i = 0; i < 80 && !logsA.find(l => l.startsWith('§RULE-GESTURE layer=L2 rule=premium')); i++) await page.waitForTimeout(250);
+    await page.close();
+
+    const find = re => logsA.find(l => re.test(l)) || '';
+    const gest = find(/^§RULE-GESTURE layer=L2 rule=premium /);
+    const edit = find(/^§RULE-EDIT layer=L2 rule=premium /);
+    [gest, edit].forEach(l => console.log(l || '(missing A §-line)'));
+    result.A.gestPass = /\bPASS\b/.test(gest) && /signed=Y/.test(gest);
+    result.A.pop35    = /N=35\b/.test(gest);
+    result.A.tenant   = /tenant=Odoo\(12\)/.test(edit);
+    result.A.errs     = errsA.length;
+    console.log(`§RULE-A-REGRESS gestPass=${result.A.gestPass} pop35=${result.A.pop35} tenant=Odoo(12)?${result.A.tenant} pageerr=${result.A.errs}`);
+  }
+
+  // ── (B) THE FIX: GardenWorld(11) login, NO shard — scoped to client 11, maycomplete honest-disabled ──
+  {
+    const logsB = [], errsB = [];
+    const page = await browser.newPage();
+    page.on('console', m => logsB.push(m.text()));
+    page.on('pageerror', e => errsB.push(e.message));
+    await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin`,
+      { waitUntil: 'networkidle' });
+    await openRulePill(page);          // open() defaults to premium → §RULE-OPEN + §RULE-SCOPE premium
+    await page.waitForTimeout(400);
+    // corroborate population via the rendered badge DOM (not just the §-log)
+    const badge = await page.evaluate(() => (document.body.textContent || '').match(/PREMIUM:\s*(\d+)\s+of\s+(\d+)/));
+    result.B.badgeN = badge ? Number(badge[2]) : NaN;
+    // switch to maycomplete → must honest-disable (0 DR/IP orders in GardenWorld)
+    await page.click('[data-rule="maycomplete"]');
+    await page.waitForTimeout(400);
+    result.B.runDisabled = await page.$eval('#rule-run', b => b.disabled).catch(() => false);
+    await page.close();
+
+    const find = re => logsB.find(l => re.test(l)) || '';
+    const open  = find(/^§RULE-OPEN /);
+    const scP   = find(/^§RULE-SCOPE rule=premium /);
+    const scM   = find(/^§RULE-SCOPE rule=maycomplete /);
+    const disab = find(/^§RULE-DISABLE rule=maycomplete /);
+    [open, scP, scM, disab].forEach(l => console.log(l || '(missing B §-line)'));
+    result.B.tenantGW   = /tenant=GardenWorld\(11\)/.test(open);
+    result.B.notOdoo    = !/Odoo\(12\)/.test(open) && !/Odoo\(12\)/.test(scP);
+    result.B.pop114     = /population=114\b/.test(scP);
+    result.B.mayZero    = /population=0\b/.test(scM);
+    result.B.disabled   = /reason=no-population/.test(disab) && result.B.runDisabled;
+    result.B.errs       = errsB.length;
+    console.log(`§RULE-B-FIX tenantGW=${result.B.tenantGW} notOdoo=${result.B.notOdoo} pop114=${result.B.pop114} badgeN=${result.B.badgeN} mayZero=${result.B.mayZero} disabled=${result.B.disabled} pageerr=${result.B.errs}`);
+  }
+
+  await browser.close(); server.close();
+
+  const aOk = result.A.gestPass && result.A.pop35 && result.A.tenant && result.A.errs === 0;
+  const bOk = result.B.tenantGW && result.B.notOdoo && result.B.pop114 && result.B.badgeN === 114 &&
+              result.B.mayZero && result.B.disabled && result.B.errs === 0;
+  const pass = aOk && bOk;
+  console.log(`§RULE-CLIENT-SCOPE ${pass ? 'PASS' : 'FAIL'} premium.tenant=GardenWorld(11) premium.pop=114 maycomplete=${result.B.disabled ? 'disabled' : 'NOT-disabled'} odooRegress=${aOk ? 'PASS' : 'FAIL'}`);
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); try { server.close(); } catch (x) {} process.exit(2); });


### PR DESCRIPTION
## Issue it proves/disproves
"The ⚖ Rule pill was hard-bound to Odoo." `erp/rule_fold.js` hardcoded `AD_Client_ID = 12` in **both** rule populations and stamped `tenant=Odoo(12)` on every `§RULE-EDIT` line. On any non-Odoo login (e.g. **GardenWorld, Client 11**) the pill queried Odoo's rows — returning **0** under a GardenWorld-only seed — and lied `tenant=Odoo(12) FAIL no-population`, even though GardenWorld has **114** priced products the rule should fold. The engine is client-agnostic; the tenant is data.

## Fix (NON-INVENT, §-log first)
- Read the live login client from `window.__idmpClient` (set in `idempiere.html` `applySession` from `_session.client`), with an `opts.client` override for tests. **No hardcoded default** — no client ⇒ honest `no-client`, never Odoo.
- `RULES.*.load(adDb, clientId)` substitutes the live `clientId` (coerced `|0`) for the literal `12`. Odoo logins still resolve `clientId=12` → identical results.
- Honest tenant label on `§RULE-OPEN` / `§RULE-EDIT` + the overlay title; `§RULE-SCOPE` logs the scoped population per rule select.
- **Honest-disable:** empty population for the logged-in client disables ▶ Run and emits `§RULE-DISABLE`.

## Witness — whitebox `§`-log (`tests/poc_rule_client_scope.js`)
`§RULE-CLIENT-SCOPE PASS`:
- **(A) regression** Odoo(12)+shard: premium `§RULE-GESTURE PASS N=35`, `tenant=Odoo(12)`, 0 pageerr.
- **(B) the fix** GardenWorld(11), no shard: `§RULE-OPEN tenant=GardenWorld(11)`, `§RULE-SCOPE premium population=114` (badge DOM = 114), `maycomplete population=0` → `§RULE-DISABLE` + ▶ Run disabled, 0 pageerr.
- Existing `tests/poc_rule_edit.js` still `§RULE-EDIT-POC PASS` (premium 12/35, maycomplete 21/26) — no regression.

Audits: `audit_sw_precache` ✅, `audit_script_tags` ✅, `audit_spec_paths` ✅. (`audit_specs` RULE-2 fail on `38-sh-dx-2d-runtime.spec.js` is **pre-existing on origin/main**, unrelated to this erp-only diff.)

`erp/sw.js` v587→**v588**; `rule_fold.js?v=1→2`. Branched off fresh `origin/main`; touches `erp/*` only (does not touch held PR #170's files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)