### PR TITLE
feat(history): ELEMENT_PICK first-class + A.focusElement shape-mesh focus (HISTORY_SCRUB_FIX §1)

### DIFF
--- a/tests/probe_history_picks.js
+++ b/tests/probe_history_picks.js
@@ -1,0 +1,198 @@
+// probe_history_picks.js — witness HISTORY_SCRUB_FIX §1 (Step 1): an ELEMENT_PICK is a
+// first-class, read-only SELECTION step that restores as a cyan SHAPE MESH via A.focusElement.
+// Drives the REAL viewer on Duplex (non-split, fast). Proves IT WORKS + IT DOESN'T IMPACT OTHERS.
+//
+// WORKS:
+//   1. A.focusElement exists (the neutral shared primitive).
+//   2. Real 3D tap → §PICK + §HIST_PUSH kind=pick label="<name> · <class>" (NOT §HIST_DROP) +
+//      §FOCUS_ELEM (live tap upgraded box→shape) + a userData._shapeOverlay (cyan) in the scene.
+//   3. A SECOND distinct tap → second §HIST_PUSH step. Stream kinds include 'pick'.
+//   4. jumpTo step 0 → element re-lights as a SHAPE MESH (scene has _shapeOverlay; §FOCUS_ELEM
+//      fired on restore, NOT a §BBOX_DEBUG box) + verifyChain ok=true after (§HIST_CHAIN_OK).
+// NO REGRESSION:
+//   5. §HIST_DROP still fires for an audit op (SESSION_START not-significant).
+//   6. info-panel populated on the live pick (info-name not '—').
+//   7. Find lens unaffected — §INSTROWS_CACHED still fires (count 1) on a group select.
+//   8. Idle gate intact — §IDLE_GATE / §RENDER_LOOP park lines still present.
+// SW BLOCKED. Leak-safe (caller kills chrome).
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8142;
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Duplex_extracted.db&bld=Duplex`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({ serviceWorkers: 'block' });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(() => {
+      const A = window.A || window.APP;
+      return A && A.db && A.activeBuilding && A.meshCache && Object.keys(A.meshCache).length > 0;
+    }, { timeout: 180000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+    await sleep(2500);
+    await page.evaluate(() => { try { localStorage.removeItem('bim.universalHist.on'); } catch(e){} });
+    // open the bar so it renders (not required for recording, but exercises _render with picks)
+    await page.evaluate(() => { if (window.UniversalHistory) UniversalHistory.open(); });
+    await sleep(200);
+
+    // ── 1. the neutral primitive is LAZY (lives in navigate module) ──────
+    const beforeLoad = await page.evaluate(() => {
+      const A = window.A || window.APP; return typeof (A && A.focusElement);
+    });
+    console.log('A.focusElement BEFORE navigate load (lazy → want undefined): ' + beforeLoad);
+
+    // Helper: project an element's center to a screen pixel and dispatch a real tap on the canvas.
+    async function tapElement(rank) {
+      return await page.evaluate((rank) => {
+        const A = window.A || window.APP;
+        const r = A.db.exec(
+          "SELECT m.guid, m.element_name, m.ifc_class, t.center_x, t.center_y, t.center_z " +
+          "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+          "WHERE t.center_x IS NOT NULL ORDER BY (t.bbox_x*t.bbox_y*t.bbox_z) DESC LIMIT 8");
+        if (!r.length || !r[0].values.length) return { ok: false, why: 'no-rows' };
+        const row = r[0].values[Math.min(rank, r[0].values.length - 1)];
+        const [guid, name, cls, cx, cy, cz] = row;
+        const c = A.ifc2three(cx, cy, cz);
+        const v = new THREE.Vector3(c.x, c.y, c.z).project(A.camera);
+        const px = (v.x * 0.5 + 0.5) * window.innerWidth;
+        const py = (-v.y * 0.5 + 0.5) * window.innerHeight;
+        const cv = A.canvas;
+        const opt = b => ({ bubbles: true, cancelable: true, clientX: px, clientY: py, button: 0, pointerId: 1, isPrimary: true });
+        cv.dispatchEvent(new PointerEvent('pointerdown', opt()));
+        cv.dispatchEvent(new PointerEvent('pointerup', opt()));
+        return { ok: true, guid: guid, name: name, cls: cls, px: Math.round(px), py: Math.round(py) };
+      }, rank);
+    }
+
+    function shapeOverlayCount() {
+      return page.evaluate(() => {
+        const A = window.A || window.APP; let n = 0, cyan = 0;
+        if (A && A.scene) A.scene.traverse(o => {
+          if (o.userData && o.userData._shapeOverlay) {
+            n++;
+            const m = o.material;
+            if (m && m.color && Math.round(m.color.b * 255) > 180 && Math.round(m.color.r * 255) < 80) cyan++;
+          }
+        });
+        return { overlays: n, cyan: cyan };
+      });
+    }
+
+    // ── 2. real 3D tap → auto-loads navigate, records pick, shape-mesh focus
+    // The tap itself triggers A.loadNavigate() (picking.js §FOCUS-ELEM guard), so no pre-load here
+    // — this witnesses the real first-tap path.
+    const t1 = await tapElement(0);
+    console.log('TAP1: ' + JSON.stringify(t1));
+    // wait for the lazy navigate module to load + the deferred focus to run
+    await page.waitForFunction(() => {
+      const A = window.A || window.APP; return A && typeof A.focusElement === 'function';
+    }, { timeout: 30000 }).catch(e => console.log('FOCUS_LOAD_WAIT_FAIL ' + e.message));
+    await sleep(1500);
+    const afterLoad = await page.evaluate(() => { const A = window.A || window.APP; return typeof A.focusElement; });
+    console.log('A.focusElement AFTER first tap (want function): ' + afterLoad);
+    const ov1 = await shapeOverlayCount();
+    console.log('after TAP1 shapeOverlays: ' + JSON.stringify(ov1) + ' (want overlays>0, cyan>0)');
+
+    // info-panel populated?
+    const info1 = await page.evaluate(() => {
+      const p = document.getElementById('info-panel');
+      return { display: p ? p.style.display : 'no-panel',
+               name: (document.getElementById('info-name') || {}).textContent,
+               cls:  (document.getElementById('info-class') || {}).textContent };
+    });
+    console.log('INFO-PANEL after TAP1: ' + JSON.stringify(info1) + ' (want display=block, name≠—)');
+
+    // ── 3. a SECOND distinct pick via the SAME API picking.js calls (deterministic;
+    // raycast-projected taps cluster on the front element). guid distinct from TAP1.
+    const t2 = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      const r = A.db.exec(
+        "SELECT m.guid, m.element_name, m.ifc_class, m.discipline, m.storey " +
+        "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+        "WHERE t.center_x IS NOT NULL AND m.ifc_class='IfcWindow' LIMIT 1");
+      if (!r.length || !r[0].values.length) return { ok: false };
+      const [guid, name, cls, disc, storey] = r[0].values[0];
+      KernelOps.commitOp(A.db, 'ELEMENT_PICK', { cls: cls, name: name, disc: disc, storey: storey }, [guid]);
+      return { ok: true, guid: guid, name: name, cls: cls };
+    });
+    console.log('PICK2 (direct commitOp, distinct): ' + JSON.stringify(t2));
+    await sleep(600);
+
+    console.log('--- §PICK ---');
+    console.log(logs.filter(l => /§PICK\b|§PICK /.test(l)).slice(-6).join('\n'));
+    console.log('--- §HIST_PUSH ---');
+    console.log(logs.filter(l => l.includes('§HIST_PUSH')).join('\n'));
+    console.log('--- §HIST_DROP ---');
+    console.log(logs.filter(l => l.includes('§HIST_DROP')).join('\n'));
+    console.log('--- §FOCUS_ELEM ---');
+    console.log(logs.filter(l => l.includes('§FOCUS_ELEM')).join('\n'));
+    console.log('--- §KERNEL_OP ELEMENT_PICK ---');
+    console.log(logs.filter(l => l.includes('§KERNEL_OP') && l.includes('ELEMENT_PICK')).join('\n'));
+
+    const listSnap = await page.evaluate(() => UniversalHistory.list());
+    console.log('STREAM kinds: ' + JSON.stringify(listSnap.map(e => e.kind)) +
+      ' labels: ' + JSON.stringify(listSnap.map(e => e.label)));
+
+    // ── 4. jumpTo step 0 → shape-mesh restore + chain ok ─────────────────
+    const focusBefore = logs.filter(l => l.includes('§FOCUS_ELEM ')).length;
+    await page.evaluate(() => UniversalHistory.jumpTo(0));
+    await sleep(1200);
+    const ovR = await shapeOverlayCount();
+    const focusAfter = logs.filter(l => l.includes('§FOCUS_ELEM ')).length;
+    console.log('after jumpTo(0) shapeOverlays: ' + JSON.stringify(ovR) +
+      ' §FOCUS_ELEM restore-fired: ' + (focusAfter > focusBefore) + ' (want overlays>0 AND restore-fired)');
+    await sleep(1400); // let async chainCheck resolve
+    console.log('--- §HIST_CHAIN_OK (after jumpTo) ---');
+    console.log(logs.filter(l => l.includes('§HIST_CHAIN_OK') || l.includes('§HIST_CHAIN_ERR')).join('\n'));
+    const chainNow = await page.evaluate(async () => {
+      const A = window.A || window.APP;
+      if (!window.KernelOps || !KernelOps.verifyChain) return 'no-verify';
+      const res = await KernelOps.verifyChain(A.db);
+      return res && res.ok;
+    });
+    console.log('verifyChain ok right now (want true): ' + chainNow);
+
+    // ── 5. audit op still DROPPED by the gate ────────────────────────────
+    await page.evaluate(() => { const A = window.A || window.APP; KernelOps.commitOp(A.db, 'SESSION_START', { note: 'audit' }); });
+    await sleep(200);
+    console.log('SESSION_START dropped: ' +
+      logs.some(l => l.includes('§HIST_DROP') && l.includes('SESSION_START')));
+
+    // ── 7. Find lens unaffected — a real Find drill still fires + records a VIEW step
+    // (interleaved with the picks → mixed stream). §INSTROWS_CACHED only logs for >1500-elem sets
+    // (Duplex storeys are small → small-set path), so we witness the DRILL tag + the view push.
+    const pushesBeforeFind = logs.filter(l => l.includes('§HIST_PUSH')).length;
+    await page.evaluate(async () => { const A = window.A || window.APP; if (A.loadNavigate) await A.loadNavigate(); A.openFindPanel(); });
+    await sleep(1200);
+    await page.evaluate(() => {
+      const rows = document.querySelectorAll('#find-tree [data-find-parent]');
+      if (rows.length) rows[0].children[1].dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    });
+    await sleep(1700);
+    const findDrillLines = logs.filter(l => / GROUP focus=| ITEM focus=|§GROUP_EXPAND_VIA_LABEL|_SELECT "/.test(l));
+    console.log('--- Find drill (want ≥1, proves Find lens intact) ---');
+    console.log(findDrillLines.slice(-4).join('\n') || '(NONE — investigate)');
+    console.log('--- §HIST_PUSH after Find (want a kind=view step) ---');
+    console.log(logs.filter(l => l.includes('§HIST_PUSH')).slice(pushesBeforeFind).join('\n') || '(none)');
+    console.log('§INSTROWS_CACHED count (Duplex small → may be 0; must NOT grow from picks): ' +
+      logs.filter(l => l.includes('§INSTROWS_CACHED')).length);
+    const listAfterFind = await page.evaluate(() => UniversalHistory.list());
+    console.log('STREAM kinds after Find (want pick,pick,…,view): ' + JSON.stringify(listAfterFind.map(e => e.kind)));
+
+    // ── 8. idle gate park lines present ──────────────────────────────────
+    console.log('--- idle gate sample ---');
+    console.log(logs.filter(l => l.includes('§IDLE_GATE') || l.includes('§RENDER_LOOP')).slice(-3).join('\n') || '(none seen)');
+
+    console.log('--- PAGEERRORS ---');
+    console.log(logs.filter(l => l.startsWith('PAGEERROR')).join('\n') || '(none)');
+
+    await ctx.close();
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/run_history_picks.sh
+++ b/tests/run_history_picks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Leak-safe witness runner for HISTORY_SCRUB_FIX §1 picks. Static server (bg) over the EDITED
+# worktree, probe under a hard KILL timeout, then reap any stray headless chrome. SW blocked.
+set -u
+cd /tmp/wt-hp
+PORT="${PORT:-8142}"
+LOG=tests/history_picks_probe.log
+
+python3 -m http.server "$PORT" >/tmp/hp_http.log 2>&1 &
+SRV=$!
+for i in $(seq 1 30); do curl -s -o /dev/null "http://localhost:$PORT/viewer/viewer.html" && break; sleep 0.3; done
+
+PORT="$PORT" timeout --signal=KILL 160 node tests/probe_history_picks.js >"$LOG" 2>&1
+RC=$?
+
+kill -9 "$SRV" 2>/dev/null
+pkill -9 -f chrome-headless-shell 2>/dev/null
+pkill -9 -f "http.server $PORT" 2>/dev/null
+echo "EXIT=$RC"
+echo "---- chrome procs still alive (want none) ----"
+ps -eo comm | grep -i chrome | grep -v grep || echo "(clean)"

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -33,7 +33,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=28',
+        'navigate_find.js?v=29',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -3097,6 +3097,39 @@
     A.findMainEntrance = findMainEntrance; // called by startNavigation in navigate.js
     A.friendlyName = friendlyName;         // called by startNavigation (nav.targetName)
 
+    // §FOCUS-ELEM (HISTORY_SCRUB_FIX §1): the NEUTRAL shared focus primitive. Lights a guid set as
+    // its real SHAPE MESH — cyan shine-through (depthTest off → visible through occluders) — with
+    // the rest ghosted to 0.1 (the depth model), and (optionally) frames it. DECOUPLED from Find:
+    // a 3D tap (picking.js), a Find drill, and a read-only history-restore all route HERE — none
+    // "pretends to be Find". NEVER the legacy yellow bbox box. Read-only: mutates nothing.
+    //   guids: a guid string, an array of guids, or a Set.
+    //   opts.item  (default true)  → single-element/item focus (1.1 tight zoom); false → group frame.
+    //   opts.frame (default true)  → also move the camera to frame it. picking.js passes false on a
+    //                                LIVE tap (don't hijack the camera); history-restore frames.
+    A.focusElement = function (guids, opts) {
+      opts = opts || {};
+      if (!A.scene || typeof THREE === 'undefined') { console.log('[RP-TB] §FOCUS_ELEM skip=no-scene'); return 0; }
+      var set = (guids instanceof Set) ? guids
+              : new Set((Array.isArray(guids) ? guids : [guids]).filter(Boolean));
+      if (!set.size) { console.log('[RP-TB] §FOCUS_ELEM skip=empty'); return 0; }
+      // Clear any prior lens/highlight, ghost the rest, light the focus as a cyan shine-through mesh.
+      _clearShapeOverlays();
+      _clearHlOverlay();
+      if (A.setOutline) A.setOutline([]);
+      if (!A.xrayOn && A.toggleXray) { A.toggleXray(); _hlXrayWasOff = true; } // x-ray path: rest → transparent
+      _dimXrayTo(0.1);                                                          // §DEPTH: rest = 0.1 ghost
+      // colorOpacity path → MeshBasicMaterial cyan, depthTest off → SHINES THROUGH occluders.
+      var lit = _buildShapeMeshes(set, 0x00e5ff, null, 0.9);
+      var zoomed = false;
+      if (opts.frame !== false) zoomed = (opts.item === false) ? _zoomToGroup(set) : _zoomToGuids(set, 1.1);
+      if (A.markDirty) A.markDirty();
+      console.log('[RP-TB] §FOCUS_ELEM guids=' + set.size + ' lit=' + lit +
+        ' frame=' + (opts.frame !== false) + ' zoom=' + (zoomed ? 'fit' : 'none') + ' xray=' + (A.xrayOn ? 'on' : 'off'));
+      return lit;
+    };
+    // Read-only teardown — drop the focus overlay + restore x-ray (same path as a lens reset).
+    A.clearFocusElement = function () { _highlightLensReset(); console.log('[RP-TB] §FOCUS_ELEM_CLEAR'); };
+
     // §S282b: _focusCycle removed — PanelNav handles zone cycling
     // §S282b: PanelNav replaces _findNav — universal zone-based keyboard nav
     // Fixes ArrowDown-from-input bug: input → storey header (not empty result list)

--- a/viewer/picking.js
+++ b/viewer/picking.js
@@ -244,6 +244,7 @@ function setupPicking(A) {
       if (A.setOutline) A.setOutline([], 0xff8c00);
       // §S277d: Restore isolation
       _restoreIsolation(A);
+      if (A.clearFocusElement) A.clearFocusElement(); // §FOCUS-ELEM: drop shape-mesh focus
       return;
     }
 
@@ -268,6 +269,7 @@ function setupPicking(A) {
       }
       if (A.setOutline) A.setOutline([], 0xff8c00);
       _restoreIsolation(A);
+      if (A.clearFocusElement) A.clearFocusElement(); // §FOCUS-ELEM: drop shape-mesh focus
       return;
     }
 
@@ -415,6 +417,7 @@ function setupPicking(A) {
       if (A.setOutline) A.setOutline([], 0xff8c00);
       // §S277d: Restore isolation
       _restoreIsolation(A);
+      if (A.clearFocusElement) A.clearFocusElement(); // §FOCUS-ELEM: drop shape-mesh focus
       A._lastPickGuid = null; A._lastPickCenter = null;
       console.log('§PICK_DESELECT guid=' + guid.substring(0, 12));
       return;
@@ -536,32 +539,45 @@ function setupPicking(A) {
     hlMesh.position.copy(hlPos);
     hlMesh.quaternion.copy(hlQuat);
     A.scene.add(hlMesh);
-    // §S277d: Isolation pick — dim everything, picked element semi-transparent (see internals)
-    _restoreIsolation(A);  // restore previous isolation first
-    var _pickMat = hit.object.material;
-    var _isolated = [];
-    A.scene.traverse(function(obj) {
-      if (!obj.isMesh && !obj.isInstancedMesh && !obj.isBatchedMesh) return;
-      if (!obj.material || obj === A.ground) return;
-      if (obj.material === _pickMat || obj === hit.object) return;  // skip picked element's material
-      if (obj.material.userData._pickDimmed) return;  // already dimmed
-      _isolated.push({ mat: obj.material, origOp: obj.material.opacity, origTr: obj.material.transparent });
-      obj.material.transparent = true;
-      obj.material.opacity = 0.15;
-      obj.material.userData._pickDimmed = true;
-      obj.material.needsUpdate = true;
-    });
-    A._pickIsolated = _isolated;
-    // Picked element: semi-transparent to show internals + outline
-    if (_pickMat && !_pickMat.userData._pickTarget) {
-      _pickMat.userData._pickTarget = true;
-      _pickMat.userData._pickOrigOp = _pickMat.opacity;
-      _pickMat.userData._pickOrigTr = _pickMat.transparent;
-      _pickMat.transparent = true;
-      _pickMat.opacity = 0.7;  // slightly see-through — reveals internal structure
-      _pickMat.needsUpdate = true;
+    // §FOCUS-ELEM (HISTORY_SCRUB_FIX §1, step 3): a LIVE tap lights the element's real SHAPE MESH
+    // (cyan shine-through, rest ghosted) via the NEUTRAL shared primitive — the SAME renderer the
+    // Find drill + history-restore use. frame:false → don't hijack the camera on a tap. Replaces
+    // the old isolation-dim + invisible-bbox visual. §PICK/info-panel/commitOp below are untouched.
+    // The primitive lives in the lazily-loaded navigate module, so the FIRST tap (before Find is
+    // ever opened) loads it once, then focuses; every later tap is instant. (NOT "opening Find" —
+    // just ensuring the file that HOSTS the shared renderer is present; the call stays neutral.)
+    if (guid && (A.focusElement || A.loadNavigate)) {
+      _restoreIsolation(A);                 // drop any prior isolation first (no double-dim)
+      if (A.focusElement) A.focusElement(guid, { item: true, frame: false });
+      else A.loadNavigate().then(function () { if (A.focusElement) A.focusElement(guid, { item: true, frame: false }); });
+    } else {
+      // Legacy fallback (primitive unavailable): isolation dim + picked-element see-through + outline.
+      _restoreIsolation(A);  // restore previous isolation first
+      var _pickMat = hit.object.material;
+      var _isolated = [];
+      A.scene.traverse(function(obj) {
+        if (!obj.isMesh && !obj.isInstancedMesh && !obj.isBatchedMesh) return;
+        if (!obj.material || obj === A.ground) return;
+        if (obj.material === _pickMat || obj === hit.object) return;  // skip picked element's material
+        if (obj.material.userData._pickDimmed) return;  // already dimmed
+        _isolated.push({ mat: obj.material, origOp: obj.material.opacity, origTr: obj.material.transparent });
+        obj.material.transparent = true;
+        obj.material.opacity = 0.15;
+        obj.material.userData._pickDimmed = true;
+        obj.material.needsUpdate = true;
+      });
+      A._pickIsolated = _isolated;
+      // Picked element: semi-transparent to show internals + outline
+      if (_pickMat && !_pickMat.userData._pickTarget) {
+        _pickMat.userData._pickTarget = true;
+        _pickMat.userData._pickOrigOp = _pickMat.opacity;
+        _pickMat.userData._pickOrigTr = _pickMat.transparent;
+        _pickMat.transparent = true;
+        _pickMat.opacity = 0.7;  // slightly see-through — reveals internal structure
+        _pickMat.needsUpdate = true;
+      }
+      if (A.setOutline && hit.object) A.setOutline([hit.object], 0xff8c00);
     }
-    if (A.setOutline && hit.object) A.setOutline([hit.object], 0xff8c00);
     hlMesh.visible = false;
     window._pickHighlight = hlMesh;
     if (A.markDirty) A.markDirty();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v613';
+const CACHE_VERSION = 'v614';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -40,7 +40,11 @@
   //   but the gate still names them so curation lives in one place.
   var UNDOABLE_OPS = { 'GRID_MOVE': true, 'ELEMENT_PLACE': true }; // back-compat export
   var SIGNIFICANCE = {
-    op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true },           // qualifying model ops
+    // ELEMENT_PICK QUALIFIES (HISTORY_SCRUB_FIX §1): a direct 3D tap is a SELECTION moment —
+    // semantically identical to a Find-lens item-select, which is already recorded. It is read-
+    // only (mutates nothing) → recorded as a 'pick' entry that restores via A.focusElement, NOT
+    // via undo/redo flag-flip (it is NOT in UNDOABLE_OPS). Audit ops stay dropped (below).
+    op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'ELEMENT_PICK': true }, // qualifying model ops
     view: { 'axis': true, 'group': true, 'item': true }           // qualifying view moments
   };
   var COALESCE_MS = 700; // rapid same-signature repeats inside this window fold into one entry
@@ -68,6 +72,8 @@
   function _sig(entry) {
     if (entry.kind === 'op') return 'op:' + entry.opType + ':' +
       (entry.replay && (entry.replay.axis + '/' + entry.replay.label) || '');
+    // pick signature = the guid set → re-tapping the SAME element fast coalesces into one step.
+    if (entry.kind === 'pick') return 'pick:' + ((entry.guids && entry.guids.join(',')) || entry.label || '');
     return 'view:' + (entry.view && (entry.view.kind + ':' + (entry.view.label || entry.view.axis)) || '');
   }
 
@@ -82,7 +88,9 @@
       var tip = _stream[_cursor];
       if (_sig(tip) === _sig(entry) && (entry.ts - (tip.ts || 0)) <= COALESCE_MS) {
         // Keep the single step; absorb the newer payload so undo lands on the latest pose/view.
-        if (entry.kind === 'op') tip.replay = entry.replay; else tip.view = entry.view;
+        if (entry.kind === 'op') tip.replay = entry.replay;
+        else if (entry.kind === 'pick') tip.guids = entry.guids;
+        else tip.view = entry.view;
         tip.ts = entry.ts; tip.label = entry.label;
         _render();
         console.log('§HIST_DROP source=' + entry.kind + ' type=' +
@@ -104,18 +112,38 @@
 
   // Record a MODEL op the moment it is committed (called from the commitOp wrapper, below).
   // Passes through the ONE significance gate; non-significant ops are dropped (§-logged).
-  function _recordOp(opId, opType, params) {
-    if (!significant({ source: 'op', type: opType, label: _opLabel(opType, params) })) return;
+  function _recordOp(opId, opType, params, guids) {
+    var label = _opLabel(opType, params);
+    if (!significant({ source: 'op', type: opType, label: label })) return;
+    // ELEMENT_PICK is a read-only SELECTION moment, not a model mutation. Record it as a view-
+    // class 'pick' entry carrying the guid(s); restore re-lights it via the neutral A.focusElement
+    // shape-mesh primitive (NOT a kernel flag-flip, NOT a Find replay). HISTORY_SCRUB_FIX §1.
+    if (opType === 'ELEMENT_PICK') {
+      var g = guids || (params && params.guids) || [];
+      if (!Array.isArray(g)) g = [g];
+      g = g.filter(Boolean);
+      _push({ kind: 'pick', opId: opId, opType: opType, undoable: false,
+        guids: g, label: label, params: params || {} });
+      return;
+    }
     _push({
       kind: 'op', opId: opId, opType: opType,
-      undoable: true, label: _opLabel(opType, params),
+      undoable: true, label: label,
       replay: params || {}
     });
+  }
+
+  // Humanise an IFC class for a label: "IfcDoor" → "door", "IfcFlowTerminal" → "flow terminal".
+  function _humanClass(cls) {
+    if (!cls) return 'element';
+    return String(cls).replace(/^Ifc/, '').replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
   }
 
   function _opLabel(opType, p) {
     if (opType === 'GRID_MOVE') return 'Grid ' + (p && p.label ? p.label : '') + ' move';
     if (opType === 'ELEMENT_PLACE') return 'Place ' + ((p && (p.cls || p.name)) || 'element');
+    // §1: label a pick by the ELEMENT, not the op — "merk H · door" (name + humanised class).
+    if (opType === 'ELEMENT_PICK') return ((p && p.name) || 'element') + ' · ' + _humanClass(p && p.cls);
     return opType;
   }
 
@@ -170,22 +198,41 @@
   function _applyEntry(e, forward) {
     if (e.kind === 'op') {
       _applyOp(e, forward);
-    } else { // view
-      if (forward) {
-        // Redo a view = restore THIS entry's view.
-        if (_viewRestore) _viewRestore(e.view);
-      } else {
-        // Undo a view = restore the PREVIOUS view entry (or clear if none).
-        var prevView = _findPrevView(_cursor - 1);
-        if (_viewRestore) _viewRestore(prevView); // null → callback clears overlays
-      }
+      return;
+    }
+    // Read-only entries (view-nav + element picks): forward shows THIS state, backward shows the
+    // previous read-only state (or clears). Never mutates the model / the signed kernel chain.
+    if (forward) {
+      _restoreReadOnly(e);
+    } else {
+      _restoreReadOnly(_findPrevReadOnly(_cursor - 1)); // null → clears overlays
     }
   }
 
-  // Walk back from idx to find the nearest VIEW entry at/below it (the view to fall back to on undo).
-  function _findPrevView(idx) {
+  // Restore a read-only entry's visual state. A 'pick' re-lights via the NEUTRAL A.focusElement
+  // shape-mesh primitive (NOT Find — a tap and a Find drill are independent routes to the same
+  // focus); a 'view' replays through navigate_find's registered callback. null → clear focus.
+  function _restoreReadOnly(e) {
+    var A = window.A || window.APP;
+    if (!e) {
+      if (A && A.clearFocusElement) A.clearFocusElement();
+      else if (_viewRestore) _viewRestore(null);
+      return;
+    }
+    if (e.kind === 'pick') {
+      // A.focusElement lives in the lazily-loaded navigate module — ensure it's present, then focus.
+      if (A && A.focusElement) A.focusElement(e.guids, { item: true });
+      else if (A && A.loadNavigate) A.loadNavigate().then(function () { if (A.focusElement) A.focusElement(e.guids, { item: true }); });
+      else console.warn('§HIST_RESTORE_NOFN A.focusElement missing');
+    } else { // view
+      if (_viewRestore) _viewRestore(e.view);
+    }
+  }
+
+  // Walk back from idx to find the nearest read-only (view|pick) entry at/below it.
+  function _findPrevReadOnly(idx) {
     for (var i = idx; i >= 0; i--) {
-      if (_stream[i].kind === 'view') return _stream[i].view;
+      if (_stream[i].kind === 'view' || _stream[i].kind === 'pick') return _stream[i];
     }
     return null;
   }
@@ -312,9 +359,9 @@
     for (var i = 0; i < _stream.length; i++) {
       var dot = document.createElement('button');
       var applied = (i <= _cursor);
-      var isView = _stream[i].kind === 'view';
+      var isView = _stream[i].kind === 'view' || _stream[i].kind === 'pick';
       dot.title = _stream[i].label || ('step ' + (i + 1));
-      // view = round dot, model-op = square dot — the two streams stay visually distinct.
+      // view/pick = round dot, model-op = square dot — the two streams stay visually distinct.
       dot.style.cssText = 'width:9px;height:9px;padding:0;cursor:pointer;' +
         'border:1px solid rgba(79,195,247,0.6);border-radius:' + (isView ? '50%' : '2px') + ';' +
         'background:' + (applied ? '#4fc3f7' : 'rgba(79,195,247,0.18)');
@@ -335,12 +382,13 @@
     }
     if (KernelOps.__uhistWrapped) return;
     var orig = KernelOps.commitOp;
-    KernelOps.commitOp = function (db, opType, params) {
+    KernelOps.commitOp = function (db, opType, params, guids) {
       var id = orig.apply(this, arguments);
       // params may be a JSON string (some callers stringify) or an object — normalise.
       var p = params;
       if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { p = {}; } }
-      try { _recordOp(id, opType, p); } catch (e) { console.warn('§HIST_REC_ERR', e); }
+      // guids (4th arg) carry the element(s) for an ELEMENT_PICK read-only restore.
+      try { _recordOp(id, opType, p, guids); } catch (e) { console.warn('§HIST_REC_ERR', e); }
       return id;
     };
     KernelOps.__uhistWrapped = true;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -775,7 +775,7 @@
 <script src="dlod.js?v=7" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=35" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=29" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
-<script src="picking.js?v=25" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
+<script src="picking.js?v=26" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=4" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
@@ -807,7 +807,7 @@
 <script src="grid_contours.js?v=5" onerror="console.warn('[GridContours] grid_contours.js skipped')"></script>
 <script src="grid_dim_chains.js?v=4" onerror="console.warn('[DimChains] grid_dim_chains.js skipped')"></script>
 <script src="kernel_ops.js?v=3" onerror="console.warn('[KernelOps] kernel_ops.js skipped')"></script>
-<script src="universal_history.js?v=2" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
+<script src="universal_history.js?v=3" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
 <script src="bom_extract.js?v=1" onerror="console.warn('[BOMExtract] bom_extract.js skipped')"></script>
 <script src="verb_expand.js?v=1" onerror="console.warn('[VerbExpand] verb_expand.js skipped')"></script>
 <script src="bom_walker.js?v=1" onerror="console.warn('[BOMWalker] bom_walker.js skipped')"></script>


### PR DESCRIPTION
## Step 1 of HISTORY_SCRUB_FIX — picks belong on the timeline, restored as a shape mesh

**The bug:** a deliberate 3D element pick was DROPPED by the history significance gate (`§HIST_DROP … ELEMENT_PICK not-significant`) — so a pure viewing session recorded *nothing the user did*. A door selected via the Find tree got a step; the **same door tapped in 3D** got dropped. That asymmetry is the defect.

### What this PR does (scoped to §1 only)
1. **`universal_history.js` — pick = first-class, read-only.** `ELEMENT_PICK` now qualifies through the ONE significance gate. It's recorded as a `kind:'pick'` entry (NOT a kernel flag-flip — it mutates nothing), **labelled by the element** (`"merk H · door"` via `_humanClass`), with the guid threaded from `commitOp`'s 4th arg. Restore routes to the neutral `A.focusElement` (never `undoOp`/`redoOp`), so the **signed kernel chain is untouched**. Re-tap-same-element coalesces (guid signature). Renders as a round (view-class) dot.
2. **`navigate_find.js` — the NEUTRAL shared primitive.** New `A.focusElement(guids,{item,frame})` + `A.clearFocusElement`, lifting the depth-model renderer (`_buildShapeMeshes`): lights elements as their real **SHAPE MESH** (cyan shine-through, `depthTest` off) with the rest ghosted to **0.1**. Decoupled from Find — a tap, a Find drill, and a history-restore all route here; none "pretends to be Find". NEVER the yellow bbox box.
3. **`picking.js` — live tap upgraded box→shape.** A live tap lights the shape mesh via `A.focusElement` (`frame:false` → no camera hijack) instead of the isolation-dim + invisible bbox. `§PICK`/`§PICK_BBOX`/info-panel/`commitOp` unchanged; deselect clears the focus. The primitive lives in the lazily-loaded navigate module, so the first tap loads it once then focuses (instant after).

### Whitebox §-witness (Duplex, headless, leak-safe — chrome clean after)
`tests/run_history_picks.sh` → `tests/history_picks_probe.log`. **Proves it works AND doesn't impact others:**

**WORKS**
- Lazy primitive: `A.focusElement` undefined before nav-load → `function` after first tap.
- Real 3D tap → `§PICK IfcSlab` + `§HIST_PUSH kind=pick label="…· slab"` (NOT `§HIST_DROP`) + `§FOCUS_ELEM lit=1` + `shapeOverlays {overlays:1, cyan:1}` + info-panel populated.
- 2 distinct picks → stream `["pick","pick"]`, each labelled by element.
- `jumpTo(0)` → `shapeOverlays {overlays:1,cyan:1}` + `§FOCUS_ELEM restore-fired:true` (SHAPE MESH, not bbox) + `§HIST_CHAIN_OK ok=true` + `verifyChain ok=true`.

**NO REGRESSION**
- `SESSION_START` still `§HIST_DROP` (gate bookkeeping intact).
- Find lens intact — `§STOREY_SELECT "Level 1" GROUP focus=50`; mixed stream `[pick,view]`; `§INSTROWS_CACHED` not perturbed by picks.
- Idle gate parks (`§IDLE_GATE park`/`wake`); no `PAGEERROR`.

Cache bumps: `picking.js?v=26`, `universal_history.js?v=3`, `navigate_find.js?v=29`, `sw.js v614`.

### Deferred (per spec) to later steps
bloom / placement-under-status-bar / maximise-persistence / depth-toggle / building-open (§2-7); shared module + ERP shared-MAIN hook (§CONTRACT); landing line + thumbnails (§8). This PR is **paused for human review** — not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)