### PR TITLE
feat(history): 3-state recording-depth toggle (HISTORY_SCRUB_FIX §6)

### DIFF
--- a/tests/probe_history_depth.js
+++ b/tests/probe_history_depth.js
@@ -1,0 +1,89 @@
+// probe_history_depth.js — witness HISTORY_SCRUB_FIX §6: the 3-state recording-depth toggle.
+//   BLUE 'all'  → ELEMENT_PICK + Find-nav + milestones all RECORDED.
+//   GREEN 'doc' → ELEMENT_PICK + axis/group/item DROPPED (profile=doc); GRID_MOVE/BUILDING_OPEN KEPT.
+//   GREY 'off'  → everything dropped (profile=off); bar shows only the depth toggle.
+//   Choice PERSISTS across reload. Icon glyph/colour reflects depth. Leak-safe.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8147;
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Duplex_extracted.db&bld=Duplex`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({ serviceWorkers: 'block' });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.db && A.activeBuilding && A.meshCache && Object.keys(A.meshCache).length > 0; }, { timeout: 180000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+    await sleep(2000);
+    await page.evaluate(() => { try { localStorage.removeItem('bim.universalHist.depth'); } catch(e){} });
+    await page.evaluate(() => { if (window.UniversalHistory) { UniversalHistory.setDepth('all'); UniversalHistory.open(); } });
+    await sleep(300);
+
+    function pick(label) {
+      return page.evaluate((label) => {
+        const A = window.A || window.APP;
+        KernelOps.commitOp(A.db, 'ELEMENT_PICK', { cls: 'IfcDoor', name: label, disc: 'ARC', storey: '01' }, ['g-' + label]);
+      }, label);
+    }
+    function grid(label) {
+      return page.evaluate((label) => {
+        const A = window.A || window.APP;
+        KernelOps.commitOp(A.db, 'GRID_MOVE', { axis: 'X', label: label, from: 0, to: 100, cascade: [] });
+      }, label);
+    }
+    const depth = () => page.evaluate(() => UniversalHistory.getDepth());
+    const offGlyph = () => page.evaluate(() => { var b = document.getElementById('hist-off'); return b ? { g: b.textContent, c: b.style.color } : null; });
+    const pushCount = () => logs.filter(l => l.includes('§HIST_PUSH')).length;
+
+    // ── BLUE 'all' — a pick is RECORDED ──────────────────────────────────
+    console.log('depth default (want all): ' + (await depth()));
+    var n0 = pushCount();
+    await pick('blue1'); await sleep(150);
+    console.log('BLUE pick recorded (want +1): delta=' + (pushCount() - n0) + ' glyph=' + JSON.stringify(await offGlyph()));
+
+    // ── GREEN 'doc' — pick DROPPED, GRID_MOVE KEPT ───────────────────────
+    await page.evaluate(() => UniversalHistory.setDepth('doc')); await sleep(150);
+    console.log('depth now (want doc): ' + (await depth()) + ' glyph=' + JSON.stringify(await offGlyph()));
+    var n1 = pushCount();
+    await pick('green_pick'); await sleep(150);
+    var afterPick = pushCount();
+    await grid('green_grid'); await sleep(150);
+    var afterGrid = pushCount();
+    console.log('DOC: pick delta (want 0): ' + (afterPick - n1) + ' | grid delta (want +1): ' + (afterGrid - afterPick));
+    console.log('§HIST_DROP profile=doc present: ' + logs.some(l => l.includes('§HIST_DROP') && l.includes('profile=doc') && l.includes('ELEMENT_PICK')));
+
+    // ── GREY 'off' — everything DROPPED, bar still shows the toggle ───────
+    await page.evaluate(() => UniversalHistory.setDepth('off')); await sleep(150);
+    console.log('depth now (want off): ' + (await depth()) + ' glyph=' + JSON.stringify(await offGlyph()));
+    var n2 = pushCount();
+    await grid('off_grid'); await sleep(150);
+    console.log('OFF: grid delta (want 0): ' + (pushCount() - n2));
+    const barOff = await page.evaluate(() => {
+      const bar = document.getElementById('universal-hist-btns'), off = document.getElementById('hist-off'), marks = document.getElementById('hist-marks');
+      return { barVisible: bar && getComputedStyle(bar).display !== 'none', offVisible: off && getComputedStyle(off).display !== 'none', marksHidden: marks && getComputedStyle(marks).display === 'none' };
+    });
+    console.log('OFF bar state (want barVisible+offVisible true, marksHidden true): ' + JSON.stringify(barOff));
+
+    // ── persistence across reload ────────────────────────────────────────
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.db && A.meshCache && Object.keys(A.meshCache).length > 0; }, { timeout: 180000 }).catch(e => console.log('RELOAD_WAIT_FAIL ' + e.message));
+    await sleep(1500);
+    console.log('depth after reload (want off — persisted): ' + (await page.evaluate(() => window.UniversalHistory && UniversalHistory.getDepth())));
+
+    // ── cycle all→doc→off→all ────────────────────────────────────────────
+    await page.evaluate(() => UniversalHistory.setDepth('all'));
+    const cyc = [];
+    for (var i = 0; i < 3; i++) { await page.evaluate(() => UniversalHistory.cycleDepth()); cyc.push(await page.evaluate(() => UniversalHistory.getDepth())); }
+    console.log('cycle from all (want doc,off,all): ' + JSON.stringify(cyc));
+
+    console.log('--- PAGEERRORS ---');
+    console.log(logs.filter(l => l.startsWith('PAGEERROR')).join('\n') || '(none)');
+    await ctx.close();
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/run_history_depth.sh
+++ b/tests/run_history_depth.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -u
+cd /tmp/wt-hd
+PORT="${PORT:-8147}"
+LOG=tests/history_depth_probe.log
+python3 -m http.server "$PORT" >/tmp/hd_http.log 2>&1 &
+SRV=$!
+for i in $(seq 1 30); do curl -s -o /dev/null "http://localhost:$PORT/viewer/viewer.html" && break; sleep 0.3; done
+PORT="$PORT" timeout --signal=KILL 170 node tests/probe_history_depth.js >"$LOG" 2>&1
+RC=$?
+kill -9 "$SRV" 2>/dev/null
+pkill -9 -f chrome-headless-shell 2>/dev/null
+pkill -9 -f "http.server $PORT" 2>/dev/null
+echo "EXIT=$RC"
+echo "---- chrome alive (want none) ----"
+ps -eo comm | grep -i chrome | grep -v grep || echo "(clean)"

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v615';
+const CACHE_VERSION = 'v616';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -39,32 +39,52 @@
   //   camera micro-nudges never reach us (navigate_find only calls pushView for these three),
   //   but the gate still names them so curation lives in one place.
   var UNDOABLE_OPS = { 'GRID_MOVE': true, 'ELEMENT_PLACE': true }; // back-compat export
-  var SIGNIFICANCE = {
-    // ELEMENT_PICK QUALIFIES (HISTORY_SCRUB_FIX §1): a direct 3D tap is a SELECTION moment —
-    // semantically identical to a Find-lens item-select, which is already recorded. It is read-
-    // only (mutates nothing) → recorded as a 'pick' entry that restores via A.focusElement, NOT
-    // via undo/redo flag-flip (it is NOT in UNDOABLE_OPS). Audit ops stay dropped (below).
-    // BUILDING_OPEN (§7): a read-only milestone so a fresh session's timeline is non-empty.
-    op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'ELEMENT_PICK': true, 'BUILDING_OPEN': true }, // qualifying model ops
-    view: { 'axis': true, 'group': true, 'item': true }           // qualifying view moments
+
+  // §6 RECORDING-DEPTH PROFILES — the gate consults ONE active profile (tune by feel HERE; a depth
+  // toggle just SWAPS which profile, not a refactor). The history icon cycles the depth:
+  //   BLUE 'all' — record EVERYTHING (ELEMENT_PICK + axis/group/item + milestones): replay exactly.
+  //   GREEN 'doc' — record DOC-level events only (the clean trail); DROP taps + Find-nav.
+  //   GREY 'off'  — record nothing.
+  // §6b canonical buckets: ALL = picks + Find-nav + milestones; DOC = the "real items" only.
+  var PROFILES = {
+    all: {
+      // ELEMENT_PICK (§1) + BUILDING_OPEN (§7) + Find-nav (axis/group/item) all qualify.
+      op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'ELEMENT_PICK': true, 'BUILDING_OPEN': true },
+      view: { 'axis': true, 'group': true, 'item': true }
+    },
+    doc: {
+      // DOC whitelist (the viewer's "real items"): milestones + data mutations + design lifecycle.
+      // DROP ELEMENT_PICK + axis/group/item (Find-nav) — the advanced "clean trail".
+      op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'BUILDING_OPEN': true,
+              'DESIGN_SAVE': true, 'DESIGN_OPEN': true, 'CAPTURE_4D': true, 'CLASH_SNAG': true },
+      view: {} // Find-nav dropped in DOC mode
+    }
   };
+  var SIGNIFICANCE = PROFILES.all; // back-compat export — re-pointed at the active profile by setDepth
   var COALESCE_MS = 700; // rapid same-signature repeats inside this window fold into one entry
 
-  // significant(event) → true if this event belongs on the timeline. The ONE decision point.
-  // event = { source:'op'|'view', type:<opType|viewKind>, label } . Logs every DROP.
+  var DEPTH_KEY = 'bim.universalHist.depth';
+  var _depth = (function () {
+    try { var d = localStorage.getItem(DEPTH_KEY); return (d === 'all' || d === 'doc' || d === 'off') ? d : 'all'; }
+    catch (e) { return 'all'; } // default BLUE/all
+  })();
+  function _on() { return _depth !== 'off'; } // recording is on unless OFF
+
+  // significant(event) → true if this event belongs on the timeline, per the ACTIVE depth profile.
+  // event = { source:'op'|'view', type:<opType|viewKind>, label } . Logs every DROP (with profile).
   function significant(ev) {
-    var ok = !!(SIGNIFICANCE[ev.source] && SIGNIFICANCE[ev.source][ev.type]);
+    if (_depth === 'off') {
+      console.log('§HIST_DROP source=' + ev.source + ' type=' + ev.type + ' reason=off profile=off label="' + (ev.label || '') + '"');
+      return false;
+    }
+    var prof = PROFILES[_depth] || PROFILES.all;
+    var ok = !!(prof[ev.source] && prof[ev.source][ev.type]);
     if (!ok) {
       console.log('§HIST_DROP source=' + ev.source + ' type=' + ev.type +
-        ' reason=not-significant label="' + (ev.label || '') + '"');
+        ' reason=not-significant profile=' + _depth + ' label="' + (ev.label || '') + '"');
     }
     return ok;
   }
-
-  var ENABLED_KEY = 'bim.universalHist.on';
-  var _enabled = (function () {
-    try { return localStorage.getItem(ENABLED_KEY) !== 'off'; } catch (e) { return true; } // default ON
-  })();
 
   function _now() { return (typeof Date !== 'undefined') ? Date.now() : 0; }
 
@@ -82,7 +102,7 @@
   // COALESCE: if the entry repeats the tip's signature within COALESCE_MS, fold into it
   // (update payload, keep one step) — §-logged, so the curation is never silent.
   function _push(entry) {
-    if (!_enabled || _suppress) return;
+    if (!_on() || _suppress) return;
     if (entry.ts == null) entry.ts = _now();
     // Coalesce rapid same-signature repeats only when we're at the tip (no redo tail to break).
     if (_cursor >= 0 && _cursor === _stream.length - 1) {
@@ -152,7 +172,7 @@
   // VIEW-nav push — navigate_find calls this with its semantic view entry. We tag it kind:'view'
   // and remember the entry verbatim so restore can replay it through the registered callback.
   function pushView(v) {
-    if (!_enabled) return;
+    if (!_on()) return;
     var label = v.label || v.axis || 'view';
     // Same ONE gate as the model side — axis/group/item qualify; anything else is dropped (§-logged).
     if (!significant({ source: 'view', type: v.kind, label: label })) return;
@@ -283,14 +303,19 @@
     });
   }
 
-  // ── Off-toggle ────────────────────────────────────────────────────────
-  function setEnabled(on) {
-    _enabled = !!on;
-    try { localStorage.setItem(ENABLED_KEY, on ? 'on' : 'off'); } catch (e) {}
+  // ── Recording-depth (§6): all → doc → off, cycled on the history icon ──────────────────
+  function setDepth(d) {
+    if (d !== 'all' && d !== 'doc' && d !== 'off') return;
+    _depth = d;
+    SIGNIFICANCE = PROFILES[d] || PROFILES.all; // keep the back-compat export on the active profile
+    try { localStorage.setItem(DEPTH_KEY, d); } catch (e) {}
     _render();
-    console.log('§HIST_TOGGLE enabled=' + _enabled);
+    console.log('§HIST_DEPTH depth=' + _depth);
   }
-  function isEnabled() { return _enabled; }
+  function cycleDepth() { setDepth(_depth === 'all' ? 'doc' : (_depth === 'doc' ? 'off' : 'all')); }
+  // Back-compat: the old on/off API maps onto the depth model (on = all, off = off).
+  function setEnabled(on) { setDepth(on ? 'all' : 'off'); }
+  function isEnabled() { return _on(); }
 
   // Clear the whole timeline (e.g. on building switch). Kernel_ops itself is untouched.
   function clear() { _stream = []; _cursor = -1; _render(); }
@@ -359,7 +384,7 @@
     _marks.style.cssText = 'display:flex;gap:3px;align-items:center;padding:0 4px;overflow-x:auto;max-width:60vw';
     _off = document.createElement('button');
     _off.id = 'hist-off'; _off.style.cssText = BTN + ';font-size:13px';
-    _off.addEventListener('pointerup', function (e) { e.stopPropagation(); setEnabled(!_enabled); });
+    _off.addEventListener('pointerup', function (e) { e.stopPropagation(); cycleDepth(); }); // §6: all→doc→off
     _bar.appendChild(_back); _bar.appendChild(_fwd);
     _bar.appendChild(_marks); _bar.appendChild(_off);
     // §2 BLOOM: double-tap the BAR itself (empty area — dots/buttons stopPropagation) toggles chips.
@@ -405,22 +430,29 @@
     return chip;
   }
 
+  // §6 depth glyph/colour on the history icon: BLUE all · GREEN doc · GREY off.
+  var _DEPTH_UI = {
+    all: { g: '◉', c: '#4fc3f7', t: 'Recording: ALL — taps + nav + milestones (tap → DOC only)' },
+    doc: { g: '◑', c: '#66bb6a', t: 'Recording: DOC only — the clean trail (tap → OFF)' },
+    off: { g: '◯', c: '#888',    t: 'Recording: OFF (tap → ALL)' }
+  };
   function _render() {
     if (!_bar) return;
-    _off.textContent = _enabled ? '◉' : '◯';   // ◉ on / ◯ off
-    _off.title = _enabled ? 'History ON — tap to turn off' : 'History OFF — tap to turn on';
-    _off.style.color = _enabled ? '#4fc3f7' : '#888';
-    // Visible when the user opened it AND recording is on. Off → hidden + not recording.
-    var show = _opened && _enabled;
+    var du = _DEPTH_UI[_depth] || _DEPTH_UI.all;
+    _off.textContent = du.g; _off.style.color = du.c; _off.title = du.t;
+    // Bar visible whenever opened (so the depth toggle stays reachable even when OFF).
+    var show = _opened;
     _bar.style.display = show ? 'flex' : 'none';
     if (!show) return;
-    var hasSteps = _stream.length > 0;
+    var recording = _on();
+    var hasSteps = recording && _stream.length > 0; // OFF → just the depth toggle, no arrows/dots
     _back.style.display = hasSteps ? '' : 'none';
     _fwd.style.display = hasSteps ? '' : 'none';
     _marks.style.display = hasSteps ? 'flex' : 'none';
+    _marks.innerHTML = '';
+    if (!hasSteps) return; // OFF or empty → bar shows only the depth toggle
     _back.style.opacity = (_cursor >= 0) ? '1' : '0.35';
     _fwd.style.opacity = (_cursor < _stream.length - 1) ? '1' : '0.35';
-    _marks.innerHTML = '';
     var current = null;
     for (var i = 0; i < _stream.length; i++) {
       var e = _stream[i], applied = (i <= _cursor), isCurrent = (i === _cursor);
@@ -457,7 +489,7 @@
 
   // ── Keyboard: Ctrl+Z / Ctrl+Shift+Z route here universally ───────────────
   document.addEventListener('keydown', function (e) {
-    if (!_enabled) return;
+    if (!_on()) return;
     var key = (e.key || '').toLowerCase();
     if (e.ctrlKey && key === 'z' && !e.shiftKey) { e.preventDefault(); open(); undo(); }
     else if ((e.ctrlKey && key === 'z' && e.shiftKey) || (e.ctrlKey && key === 'y')) { e.preventDefault(); open(); redo(); }
@@ -471,6 +503,10 @@
     jumpTo:              jumpTo,
     setEnabled:          setEnabled,
     isEnabled:           isEnabled,
+    setDepth:            setDepth,    // §6: 'all' | 'doc' | 'off'
+    cycleDepth:          cycleDepth,
+    getDepth:            function () { return _depth; },
+    PROFILES:            PROFILES,    // data-driven depth profiles — edit to tune "what matters"
     clear:               clear,
     open:                open,
     toggleOpen:          toggleOpen,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -813,7 +813,7 @@
 <script src="grid_contours.js?v=5" onerror="console.warn('[GridContours] grid_contours.js skipped')"></script>
 <script src="grid_dim_chains.js?v=4" onerror="console.warn('[DimChains] grid_dim_chains.js skipped')"></script>
 <script src="kernel_ops.js?v=3" onerror="console.warn('[KernelOps] kernel_ops.js skipped')"></script>
-<script src="universal_history.js?v=4" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
+<script src="universal_history.js?v=5" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
 <script src="bom_extract.js?v=1" onerror="console.warn('[BOMExtract] bom_extract.js skipped')"></script>
 <script src="verb_expand.js?v=1" onerror="console.warn('[VerbExpand] verb_expand.js skipped')"></script>
 <script src="bom_walker.js?v=1" onerror="console.warn('[BOMWalker] bom_walker.js skipped')"></script>


### PR DESCRIPTION
## HISTORY_SCRUB_FIX — PR-2: recording-depth toggle (§6)

Builds on #172/#174. The history icon now cycles a 3-state recording depth — the gate consults ONE active profile (not a refactor; the gate was already the single data-driven decision point).

- **BLUE `all` (◉)** — record EVERYTHING: `ELEMENT_PICK` + `axis/group/item` Find-nav + milestones. "Replay exactly what I did."
- **GREEN `doc` (◑)** — DOC-level only: `GRID_MOVE`/`ELEMENT_PLACE`/`BUILDING_OPEN` + design SAVE/OPEN/4D/clash-snag; **DROP** taps + Find-nav. The advanced "clean trail."
- **GREY `off` (◯)** — record nothing; the bar still shows the depth toggle so it's reachable to cycle back.

Two `PROFILES.all/.doc` + an active `_depth` pointer that `significant()` reads. Persists in `localStorage` (`bim.universalHist.depth`). Back-compat: `setEnabled`→`setDepth(all|off)`, `isEnabled`→`depth!==off`. New API: `setDepth/cycleDepth/getDepth/PROFILES`. §6b canonical buckets honoured (ALL = picks + Find-nav + milestones; DOC = "real items").

### Whitebox §-witness (Duplex, headless, leak-safe — chrome clean)
`tests/run_history_depth.sh`:
- default `all`; BLUE pick recorded (`+1`, ◉ `rgb(79,195,247)`).
- DOC (◑ green): pick **dropped** (`§HIST_DROP profile=doc`), `GRID_MOVE` **kept** (`+1`).
- OFF (◯ grey): grid dropped, bar+toggle visible, marks hidden.
- depth persists `off` across reload; cycle `all→doc→off→all`; no `PAGEERROR`.

Cache: `universal_history.js?v=5`, `sw.js v616`. Deferred to PR-3: §9 cache-info · §8 landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)