### PR TITLE
feat(history): status row is JUST status — retire the third (scene) undo path (§5b)

### DIFF
--- a/tests/probe_status_just.js
+++ b/tests/probe_status_just.js
@@ -1,0 +1,58 @@
+// probe_status_just.js — witness HISTORY_SCRUB_FIX §5b: the status row is JUST status; the old
+// undo/redo arrows are gone; Backspace/\ route to the ONE universal timeline. Leak-safe.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8149;
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Duplex_extracted.db&bld=Duplex`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({ serviceWorkers: 'block' });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.db && A.activeBuilding && A.meshCache && Object.keys(A.meshCache).length > 0; }, { timeout: 180000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+    await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.streaming === false; }, { timeout: 60000 }).catch(() => {});
+    await sleep(1500);
+    await page.evaluate(() => { try { localStorage.removeItem('bim.universalHist.depth'); } catch(e){} if (window.UniversalHistory) UniversalHistory.setDepth('all'); });
+
+    // ── status row is JUST status (no ur-btn arrows) ─────────────────────
+    const status = await page.evaluate(() => {
+      var row = document.getElementById('status-row');
+      return {
+        undoBtn: !!document.getElementById('undo-btn'),
+        redoBtn: !!document.getElementById('redo-btn'),
+        urBtns: document.querySelectorAll('#status-row .ur-btn').length,
+        rowChildren: row ? row.children.length : -1,
+        onlyStatus: row ? (row.children.length === 1 && row.children[0].id === 'status') : false
+      };
+    });
+    console.log('--- §5b status row ---');
+    console.log(JSON.stringify(status) + ' (want undoBtn/redoBtn=false, urBtns=0, onlyStatus=true)');
+
+    // record a pick so there is something to undo
+    await page.evaluate(() => { const A = window.A || window.APP; KernelOps.commitOp(A.db, 'ELEMENT_PICK', { cls:'IfcDoor', name:'merk H', disc:'ARC', storey:'01' }, ['g1']); if (window.UniversalHistory) UniversalHistory.open(); });
+    await sleep(300);
+    const before = logs.filter(l => l.includes('§HIST_UNDO')).length;
+
+    // ── Backspace routes to the universal timeline (not raw scene-undo) ──
+    await page.evaluate(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true })); });
+    await sleep(400);
+    const after = logs.filter(l => l.includes('§HIST_UNDO')).length;
+    console.log('Backspace → §HIST_UNDO fired (want true): ' + (after > before));
+    console.log('raw §UNDO type= (old path) fired (want false): ' + logs.some(l => /§UNDO type=/.test(l)));
+
+    // scrub row still has its own undo/redo arrows
+    const scrub = await page.evaluate(() => ({ back: !!document.getElementById('hist-back'), fwd: !!document.getElementById('hist-fwd') }));
+    console.log('scrub row arrows present (want both true): ' + JSON.stringify(scrub));
+
+    console.log('--- PAGEERRORS ---');
+    console.log(logs.filter(l => l.startsWith('PAGEERROR')).join('\n') || '(none)');
+    await ctx.close();
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/run_status_just.sh
+++ b/tests/run_status_just.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -u
+cd /tmp/wt-hm
+PORT="${PORT:-8149}"
+python3 -m http.server "$PORT" >/tmp/sj_http.log 2>&1 &
+SRV=$!
+for i in $(seq 1 30); do curl -s -o /dev/null "http://localhost:$PORT/viewer/viewer.html" && break; sleep 0.3; done
+PORT="$PORT" timeout --signal=KILL 150 node tests/probe_status_just.js >tests/status_just_probe.log 2>&1
+echo "EXIT=$?"
+kill -9 "$SRV" 2>/dev/null
+pkill -9 -f chrome-headless-shell 2>/dev/null; pkill -9 -f "http.server $PORT" 2>/dev/null
+ps -eo comm | grep -i chrome | grep -v grep || echo "(clean)"

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1647,15 +1647,18 @@ async function setupScene(A) {
     var noMod = !e.ctrlKey && !e.altKey && !e.metaKey;
     var notInput = e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA';
 
-    // §S280: Backspace = undo, \ = redo (kernel_ops)
+    // §S280 / §HSF-5b: Backspace = undo, \ = redo — now route through the ONE universal timeline
+    // (skip-audit + replay + read-only picks), not the retired raw scene-undo.
     if (noMod && notInput && e.key === 'Backspace') {
       e.preventDefault();
-      if (window._doSceneUndo) window._doSceneUndo();
+      if (window.UniversalHistory) { UniversalHistory.open(); UniversalHistory.undo(); }
+      else if (window._doSceneUndo) window._doSceneUndo();
       return;
     }
     if (noMod && notInput && e.key === '\\') {
       e.preventDefault();
-      if (window._doSceneRedo) window._doSceneRedo();
+      if (window.UniversalHistory) { UniversalHistory.open(); UniversalHistory.redo(); }
+      else if (window._doSceneRedo) window._doSceneRedo();
       return;
     }
 
@@ -1804,7 +1807,9 @@ async function setupScene(A) {
     if (_redoBtn) { _redoBtn.classList.toggle('active-redo', hasRedo); }
   }
 
+  // §HSF-5b: delegate to the universal timeline (ONE undo path). Back-compat shim for any caller.
   window._doSceneUndo = function() {
+    if (window.UniversalHistory) { UniversalHistory.open(); UniversalHistory.undo(); return; }
     if (!window.KernelOps || !A.db) { A.status.textContent = 'No ops to undo'; return; }
     var op = KernelOps.undoOp(A.db);
     if (op) {
@@ -1816,6 +1821,7 @@ async function setupScene(A) {
     _updateUrButtons();
   };
   window._doSceneRedo = function() {
+    if (window.UniversalHistory) { UniversalHistory.open(); UniversalHistory.redo(); return; }
     if (!window.KernelOps || !A.db) { A.status.textContent = 'No ops to redo'; return; }
     var op = KernelOps.redoOp(A.db);
     if (op) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v617';
+const CACHE_VERSION = 'v618';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -522,14 +522,11 @@
 </div>
 <!-- §S280: Undo/Redo arrows flanking status bar -->
 <div id="status-bar-wrap">
+  <!-- §HSF-5b: the status row is now JUST the status text. The old undo/redo arrows (a separate
+       raw KernelOps.undoOp path) are RETIRED — undo/redo lives in the universal timeline scrub row
+       below (↶ ↷ + dot-line) / Ctrl+Z / Backspace, which routes through it. ONE undo path. -->
   <div id="status-row">
-    <button id="undo-btn" class="ur-btn" onclick="if(window._doSceneUndo)window._doSceneUndo()" title="Undo (Backspace)">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
-    </button>
     <div id="status">v3 — <span data-trl="ui_initializing">Initializing...</span></div>
-    <button id="redo-btn" class="ur-btn" onclick="if(window._doSceneRedo)window._doSceneRedo()" title="Redo (\)">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19 7-7-7-7"/><path d="M5 12h14"/></svg>
-    </button>
   </div>
   <!-- §HSF-3: universal-hist-btns (scrub row) is appended here at runtime by universal_history.js -->
 </div>
@@ -773,7 +770,7 @@
 <script src="pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
-<script src="scene.js?v=50" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=51" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=53" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>


### PR DESCRIPTION
## Status row = just status (one undo path)

The status bar still flanked `#status` with the old undo/redo arrows (`#undo-btn`/`#redo-btn` → `_doSceneUndo`/`_doSceneRedo`, a **raw** `KernelOps.undoOp` with no skip-audit/replay) — a **third** undo system, redundant with the universal timeline scrub row directly below it.

- `viewer.html`: removed both `.ur-btn` arrows; `#status-row` is now just the status text.
- `scene.js`: `Backspace`/`\` now route through the universal timeline (`UniversalHistory.undo/redo`); `_doSceneUndo/_doSceneRedo` delegate to it (back-compat shim).
- **Does not touch `navigate_find.js`** — the refactor lane is unaffected.

### Whitebox §-witness (Duplex, headless, leak-safe — chrome clean)
`status-row onlyStatus=true` (undo-btn/redo-btn absent, urBtns=0); `Backspace → §HIST_UNDO` fired (timeline); raw `§UNDO type=` old path **not** fired; scrub row ↶ ↷ intact; no `PAGEERROR`.

Cache: `scene.js?v=51`, `sw.js v618`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)