### PR TITLE
feat(nlp): mobile guard — count-only for huge sets, leaf-zoom single element

### DIFF
--- a/viewer/NLP_QUERIES.md
+++ b/viewer/NLP_QUERIES.md
@@ -25,6 +25,13 @@ the answer is a set of elements.
 Phrasing is forgiving — filler words, order, case, and punctuation don't matter
 (`SHOW me ALL the doors!!!` works the same as `doors`).
 
+### Mobile-safe 3D behaviour
+- **Large result (>2000 elements)** → shows the **count only**, no 3D highlight. Lighting up
+  tens of thousands of meshes is the one heavy op; skipping it keeps cheap phones smooth.
+- **Normal result (≤2000)** → highlights the matched elements in 3D.
+- **Single element (a "leaf")** → highlights **and zooms the camera in** to frame it
+  (reuses `A.zoomToGuid`).
+
 ### Storey names work in any language
 `level 3` resolves against the building's **actual** storey labels, so it finds
 `Level 3`, Malay `Aras 03`, Swedish `VÅNING 3`, or worded `Third Floor` — automatically.

--- a/viewer/nlp.js
+++ b/viewer/nlp.js
@@ -293,9 +293,17 @@ function setupNlp(A) {
                 cur2 = typeof _TRL!=='undefined'&&_TRL.cur2||'USD',
                 rate = typeof _TRL!=='undefined'&&_TRL.cur_rate||3.91;
           const f = BimDecoder.formatResult(d, (s, p) => A.db.exec(s, p || []), { cur, cur2, rate });
-          showToast(f.summary, { cols: f.table.cols, vals: f.table.vals, parsed: { desc: d.desc } }, 'ok');
-          if (f.guids && f.guids.length) highlightGuids(f.guids); else clearHighlights();
-          console.log('[NLP2026] §NLP_DEC kind=' + d.kind + ' guids=' + (f.guids ? f.guids.length : 0) + ' "' + f.summary.substring(0, 80) + '"');
+          // Mobile guard: huge result sets show the COUNT only — lighting up tens of
+          // thousands of meshes is the one heavy op. Leaf (single element) zooms in.
+          const n = f.guids ? f.guids.length : 0, HL_CAP = 2000;
+          const note = n > HL_CAP ? '  (too many to show in 3D — count only)' : '';
+          showToast(f.summary + note, { cols: f.table.cols, vals: f.table.vals, parsed: { desc: d.desc } }, 'ok');
+          if (!n || n > HL_CAP) { clearHighlights(); }
+          else {
+            highlightGuids(f.guids);
+            if (n === 1 && typeof A.zoomToGuid === 'function') A.zoomToGuid(f.guids[0]); // final leaf → frame it
+          }
+          console.log('[NLP2026] §NLP_DEC kind=' + d.kind + ' n=' + n + (n > HL_CAP ? ' COUNT_ONLY' : '') + (n === 1 ? ' LEAFZOOM' : '') + ' "' + f.summary.substring(0, 60) + '"');
           return;
         }
       } catch (e) { console.log('[NLP2026] §NLP_DEC_ERR ' + e.message + ' — legacy fallback'); }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v617';
+const CACHE_VERSION = 'v618';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
Caps the one heavy op (3D highlight) in the NLP query bar so it stays smooth on cheap phones:
- **> 2000 elements** → show the **count only**, skip highlight (toast notes it)
- **≤ 2000** → highlight as before
- **single element (leaf)** → highlight **and zoom the camera in** (`A.zoomToGuid`)

## Scope / safety
- Touches **`nlp.js` only** (+ `sw.js` v617→v618, `NLP_QUERIES.md`). `decoder.js` unchanged.
- **Does NOT touch `navigate_find.js`** — no collision with the Find refactor.

## Witnessed (Hospital, real guid counts)
`pipes(28073)=COUNT_ONLY` · `doors(440)=HIGHLIGHT` · `doors-on-level-2(56)=HIGHLIGHT` · `cost/disciplines=aggregate(no 3D)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)