### PR TITLE
fix(erp-pill): flat ⋯ kebab (all surfaces) + anchor mobile dock trigger (no re-center)

### DIFF
--- a/erp/erp.html
+++ b/erp/erp.html
@@ -80,9 +80,9 @@
 
 <!-- idempiereUI.md I1 — BIM pill bar, registry-driven from pills.json (the idempiere pill launches
      idempiere.html, renderer #1). icons.js = verbatim icon set; pill_builder.js used as-is. -->
-<script src="icons.js?v=24"></script>
+<script src="icons.js?v=25"></script>
 <script src="pill_builder.js?v=25"></script>
-<script src="erp_pills.js?v=24"></script>
+<script src="erp_pills.js?v=25"></script>
 <script>
 // Phase 1: Instant constellation — fetch initbubble.json, then init
 var _shellReady = false;

--- a/erp/erp_pills.js
+++ b/erp/erp_pills.js
@@ -130,9 +130,9 @@
       var trigger = document.createElement('button');
       trigger.id = 'erp-pill-trigger';
       trigger.title = 'Pills';
-      // canonical vertical kebab (moreVert) from the verbatim icon set — same glyph as the BIM viewer trigger
-      var _mv = (window.ICONS && window.ICONS.moreVert) ? window.ICONS.moreVert.svg
-        : '<circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>';
+      // FLAT (horizontal) kebab from the verbatim icon set — differs from Android's own vertical ⋮ menu (user-requested, all surfaces).
+      var _mv = (window.ICONS && window.ICONS.moreHoriz) ? window.ICONS.moreHoriz.svg
+        : '<circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/>';
       trigger.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + _mv + '</svg>';
       wrap.appendChild(pill);
       wrap.appendChild(trigger);

--- a/erp/icons.js
+++ b/erp/icons.js
@@ -31,6 +31,7 @@
     disciplines: { svg: '<circle cx="12" cy="12" r="3" fill="currentColor"/><circle cx="12" cy="4" r="2"/><circle cx="12" cy="20" r="2"/><circle cx="4" cy="12" r="2"/><circle cx="20" cy="12" r="2"/><circle cx="6.34" cy="6.34" r="2"/><circle cx="17.66" cy="6.34" r="2"/><circle cx="6.34" cy="17.66" r="2"/><circle cx="17.66" cy="17.66" r="2"/><line x1="12" y1="7" x2="12" y2="9"/><line x1="12" y1="15" x2="12" y2="17"/><line x1="7" y1="12" x2="9" y2="12"/><line x1="15" y1="12" x2="17" y2="12"/>' },
     maximize: { svg: '<path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/>' },
     moreVert: { svg: '<circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>' },
+    moreHoriz: { svg: '<circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/>' },  // FLAT kebab — pill ⋯ trigger (differs from Android's own vertical ⋮)
     // verbatim from viewer/panels.js — the iDempiere pill rail glyphs (Graph/Kanban/Install/Migrate)
     barChart: { svg: '<path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>' },
     layout: { svg: '<rect width="18" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/>' },

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -326,9 +326,9 @@
 <!-- §A ERP_BOTTOM_BAR_AND_LIFECYCLE — the bottom/side bar from the SAME registry as erp.html/BIM (retire the
      hand-rolled #idmp-pillrail). icons.js (verbatim glyph DATA) + pill_builder.js (the renderer) + idmp_pills.js
      (binds fn BY ID to window.IdmpPillActions) + sibling pills_idmp.json (the manifest). §PILL-REGISTRY. -->
-<script src="icons.js?v=1"></script>
+<script src="icons.js?v=2"></script>
 <script src="pill_builder.js?v=3"></script>
-<script src="idmp_pills.js?v=3"></script>
+<script src="idmp_pills.js?v=4"></script>
 <!-- §B ERP_BOTTOM_BAR — cross-tab history scrubber (Glassbowl #scrub pattern): records semantic nav moments
      across the window tabs; double-tap blooms chips; dot click = read-only restore (never mutates the op-log). -->
 <script src="idmp_history.js?v=2"></script>

--- a/erp/idmp_pills.js
+++ b/erp/idmp_pills.js
@@ -94,8 +94,9 @@
       var trigger = document.createElement('button');
       trigger.id = 'idmp-pill-trigger';
       trigger.title = 'Pills';
-      var _mv = (window.ICONS && window.ICONS.moreVert) ? window.ICONS.moreVert.svg
-        : '<circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>';
+      // FLAT (horizontal) kebab so OUR ⋯ differs from Android's own vertical ⋮ system menu (user-requested).
+      var _mv = (window.ICONS && window.ICONS.moreHoriz) ? window.ICONS.moreHoriz.svg
+        : '<circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/>';
       trigger.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + _mv + '</svg>';
       wrap.appendChild(pill);
       wrap.appendChild(trigger);
@@ -151,9 +152,14 @@
       // NOTE: PillBuilder toggles the pill via inline display:block, which defeats flex-direction:row — so the
       // row is laid out with inline-flex buttons + nowrap (horizontal, scrollable) instead of a flex row.
       '@media (max-width:760px){' +
+        // Pin the dock content to the RIGHT edge (row-reverse main-start) and force the ⋯ trigger to be the
+        // right-most item (order:-1) so it holds ONE constant position whether the pills row is shown or
+        // collapsed — a tapped control must never jump out from under the finger. Was justify-content:center,
+        // which re-centred the lone trigger on collapse (x≈15→179). Mobile-scoped; desktop column dock untouched.
         '#idmp-pillbar{right:0;left:0;bottom:0;top:auto;transform:none;flex-direction:row-reverse;' +
-          'align-items:center;justify-content:center;gap:6px;padding:6px 8px;background:rgba(20,22,32,0.92);' +
+          'align-items:center;justify-content:flex-start;gap:6px;padding:6px 8px;background:rgba(20,22,32,0.92);' +
           'border-top:1px solid rgba(255,255,255,0.08);}' +
+        '#idmp-pill-trigger{order:-1;}' +
         '#idmp-pill{max-height:none;background:transparent;border:none;backdrop-filter:none;' +
           '-webkit-backdrop-filter:none;padding:0;white-space:nowrap;overflow-x:auto;overflow-y:hidden;}' +
         '#idmp-pill button{display:inline-flex;margin:0 3px;}' +

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -7,7 +7,8 @@
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
 // Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v596';   // v596: Kanban "Odoo-marvel" cards + shared Graph/Kanban status palette (KANBAN_MARVEL_SPEC, PR #177) merged with the mobile pill-reopen fix (v595);
+const CACHE_VERSION = 'v597';   // v597: pill ⋯ trigger UX — (a) FLAT horizontal kebab (icons.js moreHoriz) on ALL pill surfaces (erp.html + idempiere, desktop+mobile) so OUR ⋯ differs from Android's own vertical ⋮; (b) mobile dock anchors the ⋯ to a CONSTANT right-edge position (order:-1 + justify-content:flex-start) so it no longer re-centres out from under the finger on collapse;
+                                // v596: Kanban "Odoo-marvel" cards + shared Graph/Kanban status palette (KANBAN_MARVEL_SPEC, PR #177) merged with the mobile pill-reopen fix (v595);
                                 // v595: PILL_REOPEN_FIX — ⋯-collapsed mobile pill re-opens on re-tap; outside-tap close used `e.target!==trigger`, mis-read the trigger's inner <svg> tap as outside → folded-then-reopened in one tap so it never stayed collapsed; now `!trigger.contains(e.target)` (PR fix/pill-reopen);
                                 // v594: Kanban "Odoo-marvel" cards (KANBAN_MARVEL_SPEC) — dictionary-driven avatar+title+amount+date (zero per-model code) + shared semantic status colour palette across Kanban cards AND Graph bars (consistent L&F, status-at-a-glance for the long tail);
                                 // v593: ⚖ Rule pill client-scoping (RULE_EDIT_SPEC §11, PR #171) merged with chrome §A–§D — fold over the LOGGED-IN client (window.__idmpClient), honest tenant label + honest-disable on no-population (was hardcoded Odoo Client-12);

--- a/erp/tests/poc_pill_trigger.js
+++ b/erp/tests/poc_pill_trigger.js
@@ -1,0 +1,72 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for the pill ⋯ trigger UX (v597), two user-requested changes:
+//   (a) FLAT (horizontal) kebab on ALL pill surfaces (erp.html + idempiere.html) so OUR ⋯ differs from
+//       Android's own vertical ⋮ system menu — the trigger's 3 dots must share ONE cy (horizontal row).
+//   (b) On the iDempiere MOBILE bottom dock, the ⋯ holds a CONSTANT position when the pills collapse
+//       (was justify-content:center → the lone trigger re-centred, x≈15→179, out from under the finger).
+//       Fix: order:-1 + justify-content:flex-start pins it to the right edge. Assert |Δx| is tiny.
+//   §-log first — READ tests/poc_pill_trigger.log before any conclusion.
+// Run:  node tests/poc_pill_trigger.js 2>&1 | tee tests/poc_pill_trigger.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+let DEFAULT = '/idempiere.html';
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = DEFAULT;
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+// flat = the 3 kebab dots share one cy (horizontal). vertical kebab would have cy 5/12/19.
+async function isFlat(page, trigSel) {
+  const cys = await page.$$eval(trigSel + ' svg circle', cs => cs.map(c => c.getAttribute('cy'))).catch(() => []);
+  return { cys, flat: cys.length === 3 && cys.every(v => v === cys[0]) };
+}
+const xOf = (page, sel) => page.$eval(sel, el => Math.round(el.getBoundingClientRect().x)).catch(() => null);
+const dispOf = (page, sel) => page.$eval(sel, el => getComputedStyle(el).display).catch(() => 'absent');
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // (a) FLAT glyph — erp.html
+  DEFAULT = '/erp.html';
+  await page.goto(`http://localhost:${port}/erp.html`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);
+  const erpFlat = await isFlat(page, '#erp-pill-trigger');
+  console.log('§PILL-TRIGGER surface=erp.html flat=' + (erpFlat.flat ? 'Y' : 'N') + ' cy=' + JSON.stringify(erpFlat.cys));
+
+  // (a) FLAT glyph + (b) position stability — idempiere.html mobile dock
+  DEFAULT = '/idempiere.html';
+  await page.goto(`http://localhost:${port}/idempiere.html`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);
+  const idmpFlat = await isFlat(page, '#idmp-pill-trigger');
+  const xExpanded = await xOf(page, '#idmp-pill-trigger');
+  // collapse the dock (tap ⋯), capped at 3 taps
+  let disp = await dispOf(page, '#idmp-pill'), taps = 0;
+  while (disp !== 'none' && taps < 3) { await page.tap('#idmp-pill-trigger'); await page.waitForTimeout(250); disp = await dispOf(page, '#idmp-pill'); taps++; }
+  const xCollapsed = await xOf(page, '#idmp-pill-trigger');
+  const dx = (xExpanded != null && xCollapsed != null) ? Math.abs(xExpanded - xCollapsed) : 999;
+  const stable = dx <= 4;
+  console.log('§PILL-TRIGGER surface=idempiere.html flat=' + (idmpFlat.flat ? 'Y' : 'N') + ' cy=' + JSON.stringify(idmpFlat.cys) +
+    ' xExpanded=' + xExpanded + ' xCollapsed=' + xCollapsed + ' dx=' + dx + ' anchored=' + (stable ? 'Y' : 'N') + ' (collapsedDisplay=' + disp + ')');
+
+  await page.screenshot({ path: path.join(__dirname, 'pill_trigger_390.png') });
+
+  const pass = erpFlat.flat && idmpFlat.flat && stable && disp === 'none' && errs.length === 0;
+  console.log('§PILL-TRIGGER-RESULT ' + (pass ? 'PASS' : 'FAIL') +
+    ' flatAll=' + (erpFlat.flat && idmpFlat.flat) + ' anchored=' + stable + ' dx=' + dx +
+    ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); try { server.close(); } catch (x) {} process.exit(2); });


### PR DESCRIPTION
Two user-requested ⋯ trigger fixes (desktop + mobile, erp.html + idempiere):

**(a) Flat horizontal kebab** — the ⋯ used a *vertical* three-dots (`moreVert`), clashing with Android's own vertical ⋮ system menu. Added `icons.js` `moreHoriz` and switched **both** pill triggers (`idmp_pills.js`, `erp_pills.js`) to it, so OUR ⋯ is unmistakably ours — on every pill surface, desktop and mobile.

**(b) Mobile dock anchor** — on the iDempiere bottom dock the ⋯ was `justify-content:center` on a `row-reverse` bar, so collapsing the pills row re-centered the lone trigger (x≈15→179), moving it out from under the finger. A tapped control must never jump. Fix (mobile-scoped, no DOM reorder → desktop column dock untouched): `#idmp-pill-trigger{order:-1}` + `justify-content:flex-start` pins the ⋯ to a constant right-edge spot. (erp.html's dock is a right-edge vertical column with no mobile bottom-row → no recenter bug.)

## Witness — `tests/poc_pill_trigger.js` → `§PILL-TRIGGER-RESULT PASS`
- `§PILL-TRIGGER surface=erp.html flat=Y cy=["12","12","12"]`
- `§PILL-TRIGGER surface=idempiere.html flat=Y cy=["12","12","12"] xExpanded=350 xCollapsed=350 dx=0 anchored=Y`
- Regressions still PASS: `poc_pill_reopen` (re-open both surfaces), `poc_idmp_pills` (registry §A). Audits: sw_precache + script_tags 0 missing.

erp sw v596→**v597**; `icons.js?v` 24→25 / 1→2, `idmp_pills.js?v` 3→4, `erp_pills.js?v` 24→25. Branched off fresh origin/main, erp-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)