### PR TITLE
Unified outline-on-solid select (drop cyan) + re-tap deselect + pick-bbox leak fix

### DIFF
--- a/viewer/import_worker.js
+++ b/viewer/import_worker.js
@@ -85,8 +85,26 @@ function discFromFilename(fname) {
   return null;
 }
 
-function classifyDisc(ifcClass, filenameDisc) {
+// §FLOWTERM-REFINE: IfcFlowTerminal is the abstract supertype generic/IFC2x3 exporters emit for
+// sprinklers, lights, diffusers AND sanitary fixtures — the flat "IfcFlowTerminal → MEP" rule buries
+// them all in MEP (sprinklers never show under FP in Find). Disambiguate the catch-all by element-name
+// keyword. Filename discipline (e.g. LTU_AHouse_FP.ifc) still wins; deterministic; unmatched → MEP.
+var FLOWTERM_NAME_DISC = [
+  [['sprinkler','fire suppression','fire protection','firefight'], 'FP'],
+  [['light','luminaire','lamp','downlight','spotlight'], 'ELEC'],
+  [['receptacle','socket','outlet','switch','panelboard','panel board'], 'ELEC'],
+  [['diffuser','grille','register','air terminal','supply air','return air','exhaust'], 'ACMV'],
+  [['lavatory','water closet','urinal','sink','basin','shower','toilet','wc','sanitary','bidet','faucet','tap'], 'PLB'],
+];
+function classifyDisc(ifcClass, filenameDisc, name) {
   if (filenameDisc) return filenameDisc;
+  if (ifcClass === 'IfcFlowTerminal' && name) {
+    var low = String(name).toLowerCase();
+    for (var fi = 0; fi < FLOWTERM_NAME_DISC.length; fi++) {
+      var keys = FLOWTERM_NAME_DISC[fi][0];
+      for (var ki = 0; ki < keys.length; ki++) if (low.indexOf(keys[ki]) >= 0) return FLOWTERM_NAME_DISC[fi][1];
+    }
+  }
   return DISC_MAP[ifcClass] || 'ARC';
 }
 
@@ -404,7 +422,7 @@ self.onmessage = async function(e) {
             ifcClass: ifcClass,
             name: el.Name ? el.Name.value : ifcClass + '_' + id,
             storey: elementToStorey[id] || 'Unknown',
-            discipline: classifyDisc(ifcClass, discFromFilename(filename)),
+            discipline: classifyDisc(ifcClass, discFromFilename(filename), el.Name ? el.Name.value : ''),  // §FLOWTERM-REFINE
             material: '',
           });
         } catch(e) { /* skip unreadable */ }

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -788,6 +788,9 @@
     function _clearShapeOverlays() {
       _shapeOverlays.forEach(function(o) {
         if (o.mesh && o.mesh.parent) o.mesh.parent.remove(o.mesh);
+        // §UNIFIED-SELECT: drop the per-overlay instance→guid map registered in _buildShapeMeshes
+        // (so picking can never resolve a stale, removed overlay).
+        if (o.mesh && A._instanceMeta) delete A._instanceMeta[o.mesh.id];
         if (o.disposeMat && o.mesh && o.mesh.material) o.mesh.material.dispose();
       });
       _shapeOverlays = [];
@@ -967,8 +970,15 @@
         // ghost(0.2)=1 draws first (under), solid focus=2, cyan shine=3 on top
         inst.renderOrder = color != null ? 3 : ((solidOpacity != null && solidOpacity < 1) ? 1 : 2);
         inst.userData._shapeOverlay = true;
+        // §UNIFIED-SELECT: map each overlay instance back to its real element guid so a 3D tap on
+        // the overlay (picking.js instanced path) resolves the element — this is what lets a re-tap
+        // on a focused/selected element DESELECT it (the overlay sits over the x-ray-dimmed base, so
+        // without this the tap hits a guid-less mesh and the toggle never fires). Cleared in
+        // _clearShapeOverlays. inst.id is globally unique → never collides with real scene meshes.
+        A._instanceMeta = A._instanceMeta || {};
+        A._instanceMeta[inst.id] = g.els.map(function (e) { return { guid: e[0] }; });
         A.scene.add(inst);
-        _shapeOverlays.push({ mesh: inst, disposeMat: true }); // cyan + clones are ours to dispose
+        _shapeOverlays.push({ mesh: inst, disposeMat: true }); // clones are ours to dispose
         made += g.els.length;
       }
       if (missing) console.log('[RP-C] §SHAPE_MISS hashes_not_streamed=' + missing + ' (set=' + set.size + ')');
@@ -2358,6 +2368,18 @@
       // cruft — always tear them down on close so nothing lingers invisibly.
       _roomLensReset();
       _highlightLensReset();
+      // §PICK-BBOX-LEAK (user): the picking.js-owned bbox (window._pickHighlight, a LineSegments
+      // EdgesGeometry) is a SHARED global cleared only when a NEW pick happens — clearHighlight()
+      // above disposes it ONLY when it === the Find-local _highlight (and early-returns when that's
+      // null). So a bbox from a 3D tap / info-panel re-highlight survives Find discard (scene + GPU
+      // leak). Own it here unconditionally: remove from scene + dispose its geometry. (Material is
+      // the shared A._bboxMaterial singleton — never dispose that.)
+      if (window._pickHighlight) {
+        if (window._pickHighlight.parent) window._pickHighlight.parent.remove(window._pickHighlight);
+        if (window._pickHighlight.geometry) window._pickHighlight.geometry.dispose();
+        window._pickHighlight = null;
+        if (A.markDirty) A.markDirty();
+      }
       if (elIsoBar) elIsoBar.style.display = 'none';
       // §S280d: Reset tree visibility for next open
       _treeRevealed = false;
@@ -3050,18 +3072,36 @@
       var set = (guids instanceof Set) ? guids
               : new Set((Array.isArray(guids) ? guids : [guids]).filter(Boolean));
       if (!set.size) { console.log('[RP-TB] §FOCUS_ELEM skip=empty'); return 0; }
-      // Clear any prior lens/highlight, ghost the rest, light the focus as a cyan shine-through mesh.
+      // §UNIFIED-SELECT (user "drop cyan"): ONE select look for pick / Find zoom-to / history-restore.
+      // Ghost the rest (0.1), draw the focus in its OWN real material (SOLID), and mark it with the
+      // OutlinePass silhouette — the S277 Bonsai outline. NO cyan shine-through fill (the depth-model
+      // "bright-blue item" is retired; the outline reads the selection cleanly on its real material).
       _clearShapeOverlays();
       _clearHlOverlay();
       if (A.setOutline) A.setOutline([]);
       if (!A.xrayOn && A.toggleXray) { A.toggleXray(); _hlXrayWasOff = true; } // x-ray path: rest → transparent
       _dimXrayTo(0.1);                                                          // §DEPTH: rest = 0.1 ghost
-      // colorOpacity path → MeshBasicMaterial cyan, depthTest off → SHINES THROUGH occluders.
-      var lit = _buildShapeMeshes(set, 0x00e5ff, null, 0.9);
+      // color=null → opaque clone of each element's REAL material; solidOpacity=1 → fully solid.
+      var _ovBefore = _shapeOverlays.length;
+      var lit = _buildShapeMeshes(set, null, 1, null);
+      var _ovMeshes = [];
+      for (var _oi = _ovBefore; _oi < _shapeOverlays.length; _oi++) _ovMeshes.push(_shapeOverlays[_oi].mesh);
+      // §YELLOW-SILHOUETTE: IDENTICAL treatment to the Find drill (_drillSelect) so a 3D pick, a Find
+      // zoom-to and a history-restore all read the same — yellow silhouette that SHINES THROUGH the
+      // ghosted rest (hidden-edge same yellow). Mobile/no-OutlinePass → faint yellow fill fallback.
+      if (A._outlinePass && A.setOutline && _ovMeshes.length) {
+        A.setOutline(_ovMeshes, 0xffd400);
+        A._outlinePass.hiddenEdgeColor.set(0xffd400);
+        A._outlinePass.edgeThickness = 3;
+        A._outlinePass.edgeStrength = 6;
+        A._outlinePass.edgeGlow = 0.3;
+      } else if (!_ovMeshes.length || !A._outlinePass) {
+        _buildShapeMeshes(set, 0xffd400, null, 0.35); // fallback: faint yellow fill (no silhouette pass)
+      }
       var zoomed = false;
       if (opts.frame !== false) zoomed = (opts.item === false) ? _zoomToGroup(set) : _zoomToGuids(set, 1.1);
       if (A.markDirty) A.markDirty();
-      console.log('[RP-TB] §FOCUS_ELEM guids=' + set.size + ' lit=' + lit +
+      console.log('[RP-TB] §FOCUS_ELEM guids=' + set.size + ' lit=' + lit + ' outline=' + _ovMeshes.length +
         ' frame=' + (opts.frame !== false) + ' zoom=' + (zoomed ? 'fit' : 'none') + ' xray=' + (A.xrayOn ? 'on' : 'off'));
       return lit;
     };


### PR DESCRIPTION
Fixes a cluster of select/Find regressions reported by the user. All trace to the history-scrubber unification (PR #172) routing the live 3D pick through the Find lens's cyan depth-model primitive.

## What changed (viewer/navigate_find.js)
1. **Drop cyan — one select look everywhere.** `A.focusElement` (used by 3D pick, Find zoom-to, history-restore) now draws the focus in its **real material, solid, with the yellow OutlinePass silhouette** — the exact same treatment the Find drill (`_drillSelect`) already uses. The cyan `0x00e5ff` shine-through "bright-blue item" from the FIND_LENS_DEPTH_MODEL spec is removed (user: "cyan is not useful; Find already does its silhouette well").
2. **Re-tap deselect works again.** Each shape-overlay instance is now registered in `A._instanceMeta[mesh.id]` with its element guid. Previously a re-tap hit the opaque, guid-less overlay sitting over the x-ray-dimmed base → guid resolved null → picking.js early-returned before its toggle (`guid === A._lastPickGuid`), so the selection never cleared.
3. **Pick-bbox leak on Find discard.** `closeFindPanel` now unconditionally removes + disposes `window._pickHighlight` (the picking-owned `LineSegments`/`EdgesGeometry` bbox). It was a shared global cleared only on a *new* pick; `clearHighlight()` freed it only when it `===` the Find-local `_highlight` and early-returned when that was null — so a bbox from a tap survived discard (scene + GPU leak).

## viewer/import_worker.js
4. **§FLOWTERM-REFINE.** Dropped-IFC import disambiguates the abstract `IfcFlowTerminal` by element name (sprinkler→FP, light→ELEC, diffuser→ACMV, sanitary→PLB) instead of dumping everything into MEP.

## Verification
- `node --check` clean on both files.
- Pick toggle traced: tap → focus overlay tagged with guid → re-tap resolves guid via `_instanceMeta` → picking.js:407 deselect fires.
- Visual confirmation still needed in-browser (outline color/thickness parity with Find drill; leak gone after close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)