### PR TITLE
Find follow-ups: bigger expand-+ tap target + Drop-IFC discipline note

### DIFF
--- a/viewer/import.js
+++ b/viewer/import.js
@@ -218,6 +218,17 @@ function setupImport(A) {
             }
 
             if (status) status.textContent = (typeof _TRL!=='undefined'&&_TRL.ui_imported||'Imported {n} elements').replace('{n}', msg.meta.elementCount);
+            // §FLOWTERM-NOTE (user "note on discipline"): discipline is INFERRED, not in the IFC. If the
+            // import had to disambiguate the abstract IfcFlowTerminal supertype by name, note how it split
+            // (and how many stayed MEP = no discipline keyword → review). Surfaced + §-logged.
+            try {
+              var _fts = msg.meta && msg.meta.flowTermSplit;
+              if (_fts && Object.keys(_fts).length) {
+                var _note = 'IfcFlowTerminal→ ' + Object.keys(_fts).sort().map(function(d){return d+'='+_fts[d];}).join(' ');
+                console.log('[FLOWTERM] §IMPORT_FLOWTERM_NOTE ' + _note + (_fts.MEP ? ' (MEP kept — no discipline keyword, review)' : ''));
+                if (status) status.textContent += '  ·  ' + _note;
+              }
+            } catch (e) { /* note only — never block import */ }
             if (progressBar) { progressBar.style.width = '100%'; progressBar.style.background = '#44cc44'; }
 
             // Refresh card list

--- a/viewer/import_worker.js
+++ b/viewer/import_worker.js
@@ -623,8 +623,25 @@ self.onmessage = async function(e) {
     // We send raw data back to main thread — it builds sql.js DBs there
     // (sql.js WASM can't run in all workers easily)
     const discCounts = {};
+    const flowTermSplit = {}; // §FLOWTERM-NOTE: how the abstract IfcFlowTerminal catch-all was split
     for (const el of renderableElements) {
       discCounts[el.discipline] = (discCounts[el.discipline] || 0) + 1;
+      if (el.ifcClass === 'IfcFlowTerminal') flowTermSplit[el.discipline] = (flowTermSplit[el.discipline] || 0) + 1;
+    }
+    // §IMPORT_DISC (user "harden Drop-IFC to note on discipline"): discipline is NOT carried in the
+    // IFC — we INFER it from the IFC class (+ element name for the abstract IfcFlowTerminal). Note the
+    // full tally so a dropped model's discipline split is auditable from the log.
+    var _discStr = Object.keys(discCounts).sort(function (a, b) { return discCounts[b] - discCounts[a]; })
+      .map(function (d) { return d + '=' + discCounts[d]; }).join(' ');
+    console.log('[FLOWTERM] §IMPORT_DISC ' + _discStr);
+    // §IMPORT_FLOWTERM_SPLIT: show how the ambiguous IfcFlowTerminal supertype was disambiguated by
+    // name. MEP-kept = the name had no FP/ELEC/ACMV/PLB keyword → the residual catch-all to review (this
+    // is the leak the refine narrows: sprinkler→FP, light→ELEC, diffuser→ACMV, sanitary→PLB).
+    var _ftKeys = Object.keys(flowTermSplit);
+    if (_ftKeys.length) {
+      console.log('[FLOWTERM] §IMPORT_FLOWTERM_SPLIT IfcFlowTerminal→ ' +
+        _ftKeys.sort().map(function (d) { return d + '=' + flowTermSplit[d]; }).join(' ') +
+        (flowTermSplit.MEP ? '  (MEP=' + flowTermSplit.MEP + ' kept — name had no discipline keyword, review)' : ' (all name-resolved)'));
     }
 
     const storeys = [...new Set(renderableElements.map(e => e.storey))].sort();
@@ -848,6 +865,7 @@ self.onmessage = async function(e) {
         elementCount: elements.length,
         geomCount: geometries.length,
         disciplines: discCounts,
+        flowTermSplit: flowTermSplit, // §FLOWTERM-NOTE: how the abstract IfcFlowTerminal was split by name
         storeys: storeys,
       },
       elements: renderableElements,

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2002,7 +2002,13 @@
           ';background:linear-gradient(180deg,rgba(255,255,255,0.06) 0%,rgba(255,255,255,0.02) 100%)' +
           ';border-left:3px solid rgba(79,195,247,0.3)' : '');
       var arrow = document.createElement('span');
-      arrow.style.cssText = 'font-size:' + (isParent ? '10px' : '8px') + ';opacity:0.5;width:12px;text-align:center;flex-shrink:0';
+      // §EXPAND-HITZONE (user): the expand "+" was a 12px glyph — the only expand affordance on
+      // storey/disc parent rows (label-tap there = select). Make the arrow a BIG tap target: a wider
+      // column + full row height (align-self:stretch + flex-center keeps the glyph put). Rows WITH
+      // children additionally reclaim the left gutter into the tap zone (below) so it extends to the
+      // LEFT of the "+". flex-center keeps the glyph visually where it was.
+      arrow.style.cssText = 'font-size:' + (isParent ? '10px' : '8px') + ';opacity:0.5;width:16px;' +
+        'text-align:center;flex-shrink:0;align-self:stretch;display:flex;align-items:center;justify-content:center';
       arrow.textContent = opts.children ? '\u25B8' : '';
       var text = document.createElement('span');
       text.style.cssText = 'flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis';
@@ -2047,6 +2053,13 @@
       // Close panel = restore full scene.
       if (childContainer) {
         arrow.style.cursor = 'pointer';
+        // §EXPAND-HITZONE: extend the tap area to the LEFT of the "+" by eating the row's left gutter
+        // (negative margin pulls the box left to the row edge; equal padding pushes the glyph back so
+        // it stays put visually). Now the whole left strip + the wider taller arrow toggles expand.
+        var _leftPad = isParent ? 10 : (22 + level * 12);
+        arrow.style.marginLeft = '-' + _leftPad + 'px';
+        arrow.style.paddingLeft = _leftPad + 'px';
+        arrow.title = 'Expand';
         arrow.addEventListener('pointerup', function(e) {
           e.stopPropagation();
           expanded = !expanded;


### PR DESCRIPTION
Follow-up to #186 (which squash-merged at the first commit). Re-lands the two commits that were orphaned by the squash. The Alt+X ghost auto-off attempt is intentionally NOT included — it broke shell-mode layering and was reverted.

## viewer/navigate_find.js — §EXPAND-HITZONE
The tree expand "+" was a 12px glyph (the only expand affordance on storey/disc parent rows, where label-tap = select). Now a big tap target: wider column + full row height (align-self:stretch + flex-center keeps the glyph in place) + reclaims the row's left gutter into the tap zone, so it extends to the left of the "+".

## viewer/import_worker.js + import.js — §IMPORT discipline note
Drop-IFC now NOTES its discipline derivation (discipline is inferred, not in the IFC):
- `§IMPORT_DISC` — full per-discipline tally.
- `§IMPORT_FLOWTERM_SPLIT` — how the abstract `IfcFlowTerminal` was disambiguated by name (sprinkler→FP, light→ELEC, diffuser→ACMV, sanitary→PLB) + how many stayed MEP (no keyword → review).
- The split is surfaced in the import status line.

## Verified
- `node --check` clean on all three.
- Cherry-picked off fresh `origin/main` (8ea5e5d) — no divergence, stray test symlink removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)