### PR TITLE
perf(erp): init-bubble INSTANT — navigation stale-while-revalidate

### DIFF
--- a/erp/sw.js
+++ b/erp/sw.js
@@ -6,8 +6,12 @@
 // erp/sw.js — Service Worker for the ERP app's own folder home (docs/ERP_FOLDER_HOME.md).
 // Scope = /erp/ (registered by erp.html / idempiere.html). Distinct cache PREFIX from the
 // BIM viewer SW so the two coexist on one origin — each purges ONLY its own prefix.
-// Network-first for .html/.js (fresh on deploy); cache-first for .wasm/images.
-const CACHE_VERSION = 'v597';   // v597: pill ⋯ trigger UX — (a) FLAT horizontal kebab (icons.js moreHoriz) on ALL pill surfaces (erp.html + idempiere, desktop+mobile) so OUR ⋯ differs from Android's own vertical ⋮; (b) mobile dock anchors the ⋯ to a CONSTANT right-edge position (order:-1 + justify-content:flex-start) so it no longer re-centres out from under the finger on collapse;
+// Navigation (.html) = STALE-WHILE-REVALIDATE (instant cached first paint + background refresh — the
+// init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
+// deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
+// bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
+const CACHE_VERSION = 'v598';   // v598: INIT-BUBBLE INSTANT — navigation served stale-while-revalidate (was network-first), so a warm load paints the init-bubble shell from cache with ZERO network round-trip instead of awaiting the HTML document over the wire (witness erp/tests/poc_init_instant.js: warm bubblePaint 883ms→<300ms under 800ms nav latency); db already deferred off the paint path;
+                                // v597: pill ⋯ trigger UX — (a) FLAT horizontal kebab (icons.js moreHoriz) on ALL pill surfaces (erp.html + idempiere, desktop+mobile) so OUR ⋯ differs from Android's own vertical ⋮; (b) mobile dock anchors the ⋯ to a CONSTANT right-edge position (order:-1 + justify-content:flex-start) so it no longer re-centres out from under the finger on collapse;
                                 // v596: Kanban "Odoo-marvel" cards + shared Graph/Kanban status palette (KANBAN_MARVEL_SPEC, PR #177) merged with the mobile pill-reopen fix (v595);
                                 // v595: PILL_REOPEN_FIX — ⋯-collapsed mobile pill re-opens on re-tap; outside-tap close used `e.target!==trigger`, mis-read the trigger's inner <svg> tap as outside → folded-then-reopened in one tap so it never stayed collapsed; now `!trigger.contains(e.target)` (PR fix/pill-reopen);
                                 // v594: Kanban "Odoo-marvel" cards (KANBAN_MARVEL_SPEC) — dictionary-driven avatar+title+amount+date (zero per-model code) + shared semantic status colour palette across Kanban cards AND Graph bars (consistent L&F, status-at-a-glance for the long tail);
@@ -131,7 +135,7 @@ self.addEventListener('fetch', (event) => {
   const url = event.request.url;
   if (event.request.method !== 'GET') return;
   if (url.split('?')[0].endsWith('.db')) return;   // ad_seed.db handled by the page directly
-  if (event.request.mode === 'navigate') { event.respondWith(networkFirst(event.request)); return; }
+  if (event.request.mode === 'navigate') { event.respondWith(staleWhileRevalidate(event.request)); return; }
   if (isNetworkFirst(url)) { event.respondWith(networkFirst(event.request)); return; }
   event.respondWith(cacheFirst(event.request));
 });
@@ -152,6 +156,28 @@ function networkFirst(request) {
       return new Response('<h1>Offline</h1><p>Open the ERP after a first online visit.</p>',
         { headers: { 'Content-Type': 'text/html' } });
     }));
+}
+
+// staleWhileRevalidate — serve the cached document INSTANTLY (no network wait) while refreshing the cache
+// in the background. Used for navigations so the init-bubble shell paints immediately on a warm load
+// instead of awaiting the HTML over the network (ERP_INIT_BUBBLE_INSTANT.md). First-ever visit (no cache)
+// awaits the network. Query is stripped for the cache key (the precached 'erp.html'/'idempiere.html' shell),
+// so deep-links (?window=…) still hit the cached shell and the page reads its own params at runtime.
+function staleWhileRevalidate(request) {
+  var cacheUrl = request.url.split('?')[0];
+  var revalidate = fetch(request).then(resp => {
+    if (resp && resp.status === 200) {
+      const clone = resp.clone();
+      caches.open(CACHE_NAME).then(c => c.put(cacheUrl, clone));
+    }
+    return resp;
+  }).catch(() => null);
+  return caches.match(cacheUrl).then(cached => {
+    if (cached) return cached;   // instant — background revalidate already in flight
+    return revalidate.then(r => r || caches.match(cacheUrl)).then(r => r ||
+      new Response('<h1>Offline</h1><p>Open the ERP after a first online visit.</p>',
+        { headers: { 'Content-Type': 'text/html' } }));
+  });
 }
 
 function cacheFirst(request) {

--- a/erp/tests/poc_init_instant.js
+++ b/erp/tests/poc_init_instant.js
@@ -1,0 +1,109 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for the ERP init-bubble FIRST PAINT (prompts/ERP_INIT_BUBBLE_INSTANT.md).
+//   The "init bubble" = the initbubble.json constellation/globe. It must paint INSTANTLY (≤300ms from
+//   navigationStart), and the 12.7MB ad_seed.db must NOT be on the first-paint path (it starts AFTER).
+//   MEASURES (the number is the proof, NOT a screenshot — §-log first, READ tests/poc_init_instant.log):
+//     bubblePaint = perf.now() at the moment #loading hides / globe canvas is up = navigationStart→paint.
+//     scriptWallEnd = max(responseEnd) of the body scripts the bubble currently waits on (ad_graph/ad_ui/…).
+//     dbStart = ad_seed.db resource startTime (-1 if not requested yet). dbStartsAfterBubble = dbStart>bubblePaint.
+//     firstPaintBlockedBy = scripts | sw | db | none (heuristic from the gaps above).
+//   cold = fresh context (no SW/IDB). warm = 2nd load in the same context (SW controls + IDB primed).
+//   ISSUE proved/disproved: "the init bubble lags ~1s; it should be instant; sharding was promised
+//   (first paint from the tiny shard, big DB deferred)." PASS = bubblePaint ≤300ms cold AND warm + dbStartsAfterBubble.
+// Run:  node tests/poc_init_instant.js 2>&1 | tee tests/poc_init_instant.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png' };
+const THRESHOLD = 300;   // ms — the "instant" target (navigationStart → bubble first paint)
+// REALISTIC NETWORK: localhost has ~0 latency, so a plain load can't tell network-first from cache-first
+// (both look instant). We inject a delay ONLY on the erp.html navigation document — the exact request the
+// SW serves networkFirst — so the witness DISCRIMINATES: a warm load that still paints ≤300ms PROVES the
+// navigation is served from cache (not awaiting the network). On GH Pages this delay is real CDN latency.
+const NAV_DELAY = parseInt(process.env.NAV_DELAY || '800', 10);   // ms added to the HTML document response only
+
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/erp.html';
+  const isNav = p.endsWith('.html');
+  fs.readFile(path.join(ROOT, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404'); return; }
+    const send = () => { r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b); };
+    if (isNav && NAV_DELAY > 0) setTimeout(send, NAV_DELAY); else send();
+  });
+});
+
+// Measure ONE load: wait for the bubble (loading overlay hidden OR a globe canvas present), then read the
+// Performance API in-page. performance.now() is relative to navigationStart (timeOrigin), so it IS the
+// navStart→event elapsed. Resource Timing gives per-asset startTime/responseEnd.
+async function measure(pg, port, label) {
+  await pg.goto(`http://localhost:${port}/erp.html`, { waitUntil: 'commit' });
+  // bubble first paint = #loading gone (display:none or removed) — that is exactly when erp.html reveals
+  // the globe (line ~117). Fall back to a visible globe canvas if the overlay id ever changes.
+  await pg.waitForFunction(() => {
+    const l = document.getElementById('loading');
+    const hidden = !l || getComputedStyle(l).display === 'none' || l.offsetParent === null;
+    const canvas = document.querySelector('#content canvas, canvas');
+    return hidden || !!canvas;
+  }, { timeout: 20000 });
+  const bubblePaint = await pg.evaluate(() => performance.now());
+  // let Phase-2 kick the db fetch so we can see it starts AFTER the bubble.
+  await pg.waitForTimeout(1500);
+  const m = await pg.evaluate(() => {
+    const res = performance.getEntriesByType('resource');
+    const find = (frag) => { const e = res.find(r => r.name.includes(frag)); return e ? Math.round(e.startTime) : -1; };
+    const end = (frag) => { const e = res.find(r => r.name.includes(frag)); return e ? Math.round(e.responseEnd) : -1; };
+    const scriptWallEnd = Math.max(end('ad_graph.js'), end('ad_ui.js'), end('icons.js'), end('pill_builder.js'), end('erp_pills.js'));
+    return {
+      scriptWallEnd: scriptWallEnd,
+      adUiEnd: end('ad_ui.js'), adGraphEnd: end('ad_graph.js'),
+      initbubbleEnd: end('initbubble.json'),
+      dbStart: find('ad_seed.db'),
+      swController: !!navigator.serviceWorker.controller
+    };
+  });
+  const bp = Math.round(bubblePaint);
+  const dbAfter = (m.dbStart < 0) || (m.dbStart >= bp);
+  // blocked-by heuristic: if the bubble paints within 80ms of the script wall finishing, the scripts gate it.
+  let blockedBy = 'none';
+  if (m.scriptWallEnd > 0 && bp - m.scriptWallEnd < 80 && bp > THRESHOLD) blockedBy = 'scripts';
+  else if (m.dbStart >= 0 && m.dbStart < bp) blockedBy = 'db';
+  else if (bp > THRESHOLD) blockedBy = 'sw';
+  console.log(`§INIT-INSTANT[${label}] bubblePaint=${bp}ms scriptWallEnd=${m.scriptWallEnd}ms (ad_ui=${m.adUiEnd} ad_graph=${m.adGraphEnd}) initbubbleEnd=${m.initbubbleEnd}ms dbStart=${m.dbStart}ms dbStartsAfterBubble=${dbAfter?'Y':'N'} swController=${m.swController} firstPaintBlockedBy=${blockedBy}`);
+  return { bubblePaint: bp, dbAfter, blockedBy, scriptWallEnd: m.scriptWallEnd };
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await chromium.launch();
+  const errs = [];
+
+  // ── COLD: fresh context (no SW, no IDB cache) ──
+  const ctxCold = await br.newContext();
+  const pgCold = await ctxCold.newPage();
+  pgCold.on('pageerror', e => errs.push('[cold] ' + e.message));
+  const cold = await measure(pgCold, port, 'cold');
+  await pgCold.close();
+  await ctxCold.close();
+
+  // ── WARM: same context across two loads so the SW installs+controls and IDB is primed ──
+  const ctxWarm = await br.newContext();
+  const pgWarm = await ctxWarm.newPage();
+  pgWarm.on('pageerror', e => errs.push('[warm] ' + e.message));
+  await measure(pgWarm, port, 'warm-1(prime)');   // first load: SW installs, IDB fills
+  await pgWarm.waitForTimeout(800);
+  const warm = await measure(pgWarm, port, 'warm');  // second load: SW controls, cache+IDB warm
+  await pgWarm.close();
+  await ctxWarm.close();
+
+  await br.close(); server.close();
+
+  // The discriminating gate is the WARM (repeat) load — the "still lag a sec" the user feels every visit.
+  // A first-ever COLD visit legitimately downloads the HTML over the network (NAV_DELAY), so it is reported
+  // for context but not gated. Warm paint ≤ THRESHOLD despite NAV_DELAY=${NAV_DELAY}ms PROVES the navigation
+  // is served from cache (stale-while-revalidate), not awaiting a network round-trip.
+  const pass = warm.bubblePaint <= THRESHOLD && warm.dbAfter && cold.dbAfter && errs.length === 0;
+  console.log(`§INIT-INSTANT cold=${cold.bubblePaint}ms warm=${warm.bubblePaint}ms threshold=${THRESHOLD}ms navDelay=${NAV_DELAY}ms dbStartsAfterBubble=${cold.dbAfter && warm.dbAfter ? 'Y' : 'N'} blockedBy(cold=${cold.blockedBy},warm=${warm.blockedBy}) pageErrors=${errs.length ? errs.join('|') : 0}`);
+  console.log('§INIT-INSTANT-RESULT ' + (pass ? 'PASS' : 'FAIL') + ' — warm bubble first paint ≤' + THRESHOLD + 'ms despite ' + NAV_DELAY + 'ms nav latency, db deferred');
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('FATAL ' + e.message); process.exit(2); });


### PR DESCRIPTION
## What
The ERP init-bubble (the `initbubble.json` constellation) lagged ~1s on warm loads. It should be instant — "sharding was promised."

## Measured first (don't guess the bottleneck)
New whitebox witness `erp/tests/poc_init_instant.js` (Playwright + Performance API). On localhost the bubble already paints in 120ms cold / 42ms warm and `dbStartsAfterBubble=Y` — so structurally the sharding promise was **already kept** (the 12.7MB `ad_seed.db` is off the first-paint path; Phase-1 scripts are precached/cache-first).

The residual lag was the SW serving the **navigation** (`erp.html` / `idempiere.html`) **network-first**: every load awaited a network round-trip for the HTML document even fully cached, and that delayed document cascaded into the script wall and the bubble paint. The witness injects 800ms nav latency so localhost can discriminate network-first from cache-first:

| | warm bubblePaint | result |
|---|---|---|
| before (network-first) | **883ms** | `§INIT-INSTANT-RESULT FAIL` |
| after (stale-while-revalidate) | **46ms** | `§INIT-INSTANT-RESULT PASS` |

Cold first-visit (~909ms) is unchanged — the HTML must be downloaded once. `dbStartsAfterBubble=Y` throughout; 0 pageErrors.

## Fix
Serve navigations **stale-while-revalidate**: return the cached shell instantly, refresh the cache in the background. Freshness on deploy is still carried by the SW version bump (`skipWaiting` + `clients.claim` precache the new shell), so SWR strands a user at most one load right at a deploy boundary.

- `erp/sw.js`: navigation branch `networkFirst` → `staleWhileRevalidate` (new fn); `CACHE_VERSION` v597 → **v598**.
- `erp/tests/poc_init_instant.js`: new witness.

## Regression
`poc_mobile_cards.js` still PASS through the changed SW (idempiere.html loads, cards=35, 0 pageErrors at 390px + 1280px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)