### PR TITLE
chore(kernel): §INTEG-COLLAPSE — one canonical kernel_ops (HELD for deploy)

### DIFF
--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -18,17 +18,19 @@
     '  undone INTEGER DEFAULT 0,' +
     '  prev_hash TEXT,' +   // W-CHAIN: tip this op chains onto (NULL until sealed)
     '  op_hash TEXT,' +     // W-CHAIN: SHA-256(prev_hash | canonical(op))
-    '  sig TEXT' +          // W-SIGN: edge signature over op_hash (NULL unless a signer is set)
+    '  sig TEXT,' +         // W-SIGN: edge signature over op_hash (NULL unless a signer is set)
+    '  gid TEXT' +          // §I-K (W-OPGROUP): group id — every op of an op-group shares one gid (NULL for single ops)
     ')';
   var IDX_TYPE_SQL =
     'CREATE INDEX IF NOT EXISTS idx_kernel_ops_type ON kernel_ops(op_type)';
   var IDX_UNDONE_SQL =
     'CREATE INDEX IF NOT EXISTS idx_kernel_ops_undone ON kernel_ops(undone, id)';
 
-  var _tableCreated = false;  // simple flag — one DB per session
-
+  // §I-K (W-OPGROUP): memoize per-db, not module-global. The browser uses ONE db (unchanged: created
+  // once), but commitGroup's witness + any multi-db caller must each get their own table — a module-wide
+  // flag would skip table creation on a second db. Additive robustness; single-db behaviour identical.
   function ensureTable(db) {
-    if (_tableCreated) return;
+    if (db.__kernelOpsTableCreated) return;
     try {
       db.run(TABLE_SQL);
       db.run(IDX_TYPE_SQL);
@@ -42,7 +44,9 @@
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN prev_hash TEXT"); } catch (ignore) {}
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN op_hash TEXT"); }  catch (ignore) {}
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN sig TEXT"); }      catch (ignore) {}
-      _tableCreated = true;
+      // §I-K (W-OPGROUP): group-id column on pre-existing DBs (idempotent, additive)
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN gid TEXT"); }      catch (ignore) {}
+      db.__kernelOpsTableCreated = true;
     } catch (e) {
       console.log('§KERNEL_OP ensureTable ERROR: ' + e.message);
     }
@@ -69,6 +73,8 @@
     // DETERMINISM (ERP.md §0.16): timestamp IS part of _canonical, so an op path that must replay
     // byte-stable supplies its own deterministic `ts` (no Date.now). Default keeps existing callers
     // (the BIM grid log) unchanged. Passed-in ts → reproducible op_hash across a rebuild.
+    // Forward-reconciled from the app's erp/ copy on the §INTEG-COLLAPSE (2026-06-08); the substrate's
+    // byte-stable period-close replay depends on it. See prompts/ERP_SUBSTRATE_INTEGRATION.md §ARCHIVE.
     var stamp = (ts != null) ? ts : Date.now();
     db.run(
       'INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid) ' +
@@ -156,24 +162,229 @@
     return { sealed: sealed, tip: prev };
   }
 
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+  // sealFrom — incremental seal: seal ONLY the rows from the last sealed tip forward, never the whole
+  // log. Already-sealed rows (carrying op_hash) are immutable by the chain's own guarantee (§I-K SPEC
+  // "Sealed ONCE per group"), so they are not re-read or re-hashed. This is the I-D flattening win:
+  // per-group seal cost becomes O(N-in-group) instead of O(log-length). sealChain (full re-seal) stays
+  // for post-compaction correctness (compact() may delete/collapse rows).
+  // _lastSealedTip(db) → { id, hash } of the highest already-sealed row, or { id:0, hash:GENESIS }.
+  function _lastSealedTip(db) {
+    var r = db.exec('SELECT id, op_hash FROM kernel_ops WHERE op_hash IS NOT NULL ORDER BY id DESC LIMIT 1');
+    if (!r.length || !r[0].values.length) return { id: 0, hash: GENESIS };
+    return { id: r[0].values[0][0], hash: r[0].values[0][1] };
+  }
+  async function sealFrom(db, fromTip) {
+    ensureTable(db);
+    var tip = fromTip || _lastSealedTip(db);
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig FROM kernel_ops WHERE id > ' + tip.id + ' ORDER BY id');
+    if (!r.length) { return { sealed: 0, tip: tip.hash, fromId: tip.id }; }
+    var rows = r[0].values, prev = tip.hash, sealed = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+      var sig = rows[i][6];
+      var h = await _sha256(prev + '|' + _canonical(op));
+      if (_signer && !sig) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      db.run('UPDATE kernel_ops SET prev_hash=?, op_hash=?, sig=? WHERE id=?', [prev, h, sig || null, op.id]);
+      prev = h; sealed++;
+    }
+    console.log('§KRN_SEAL_FROM fromId=' + tip.id + ' sealed=' + sealed + ' tip=' + prev.slice(0, 12) + '…' + (_signer ? ' signed' : ''));
+    return { sealed: sealed, tip: prev, fromId: tip.id };
+  }
+
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-J — Witness: W-RATE-INPUT
+  // assertRateAsInput — the currency-determinism guard (DistributedERP.md §7 / §9-E).
+  //
+  // SPEC (§I-J): a conversion rate read at REPLAY time is THE canonical nondeterminism breaker — two
+  // replays diverge → replay-hash != live-hash → merge breaks. RULE (non-invent + §7): the rate in force
+  // at the edge MUST be captured as an op INPUT (frozen into the op), never looked up later — same
+  // discipline as UUID/timestamp/scan. Until that is wired, multi-currency writes stay DISABLED.
+  //
+  // CONVENTION — an op is "conversion-bearing" iff its params declare a converted amount via EITHER:
+  //   (a) params.convertedAmt is present (not null/undefined), OR
+  //   (b) params.fx is an object (an explicit FX block).
+  // A conversion-bearing op MUST carry the recorded conversion INPUTS that make it replayable:
+  //   rate, rateDate, rateSource — sourced from params.fx.{rate,rateDate,rateSource} when params.fx is an
+  //   object, else params.{rate,rateDate,rateSource}. Missing any → REJECT (the multi-currency-disabled
+  //   rule, enforced). Single-currency ops (no conversion-bearing field) PASS untouched — zero behaviour
+  //   change today (the POC is single-currency; nothing is conversion-bearing).
+  //
+  // NON-INVENT: this guard NEVER fabricates a rate and NEVER looks one up. It only enforces that a
+  // conversion the caller already declared carries its own inputs. Returns { ok, conversionBearing, reason? }.
+  // PURE: no Date.now / Math.random / db / network — deterministic, safe in the hashed write path.
+  function assertRateAsInput(params) {
+    var p = params;
+    if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { p = null; } }
+    if (!p || typeof p !== 'object') return { ok: true, conversionBearing: false };
+    var hasFxBlock = p.fx != null && typeof p.fx === 'object';
+    var hasConvertedAmt = p.convertedAmt != null;
+    var conversionBearing = hasFxBlock || hasConvertedAmt;
+    if (!conversionBearing) return { ok: true, conversionBearing: false };
+    // read the recorded inputs from the fx block if present, else top-level params.
+    var src = hasFxBlock ? p.fx : p;
+    var missing = [];
+    if (src.rate == null)       missing.push('rate');
+    if (src.rateDate == null)   missing.push('rateDate');
+    if (src.rateSource == null) missing.push('rateSource');
+    if (missing.length) {
+      return { ok: false, conversionBearing: true,
+               reason: 'conversion-bearing op missing recorded rate input(s): ' + missing.join(',') +
+                       ' — multi-currency stays DISABLED until rate-as-input is provided (§I-J)' };
+    }
+    return { ok: true, conversionBearing: true, rate: src.rate, rateDate: src.rateDate, rateSource: src.rateSource };
+  }
+
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+  // commitGroup — the op-group atomic unit (ERP.md §18.8). N ops fold WHOLE or NONE:
+  //   1. STAGE off the last sealed tip — compute each op's prev_hash/op_hash, derive ONE group hash
+  //      groupHash = sha256(tip | op_hash[0] | … | op_hash[N-1]) binding the whole group to the tip.
+  //   2. ALL-OR-NONE GATE — if groupMeta.expectedHash is supplied and groupHash != expectedHash, commit
+  //      NOTHING (return committed:false). This is the torn-group rejection (poc_showstopper groupHash=FAIL).
+  //   3. ATOMIC COMMIT — wrap the N INSERTs in ONE SQL transaction (BEGIN…COMMIT / ROLLBACK on any
+  //      error) → zero rows on failure = no half-group (the storage-tier mirror of S2's fold-tier rule).
+  //   4. SEAL ONCE — seal only the N new rows via sealFrom (the I-D win; not N whole-log re-seals).
+  //   Every committed op carries the shared `gid` so the fold can re-segment groups (poc_showstopper groupsOf).
+  // Idempotent: re-invoking with a gid already present is a no-op (returns the existing group).
+  // NON-INVENT: a caller-supplied gid is honoured verbatim (G-IDENTITY input); minted only when absent.
+  // Signature: commitGroup(db, opsArray, groupMeta) -> { gid, ids, op_hashes, tip, sealed, committed, reason? }
+  async function commitGroup(db, opsArray, groupMeta) {
+    ensureTable(db);
+    groupMeta = groupMeta || {};
+    if (!Array.isArray(opsArray) || opsArray.length === 0) {
+      return { committed: false, reason: 'empty op-group', ids: [], op_hashes: [] };
+    }
+    // gid is an edge-minted INPUT (same discipline as op_uuid) — honour caller's, else mint at commit.
+    var gid = groupMeta.gid ||
+              ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : 'g-' + Date.now());
+
+    // ── Idempotency: a gid already present is a no-op (replay-safe, retry-safe). ──
+    var existing = db.exec('SELECT id, op_hash FROM kernel_ops WHERE gid = ' + JSON.stringify(gid) + ' ORDER BY id');
+    if (existing.length && existing[0].values.length) {
+      var exIds = existing[0].values.map(function (v) { return v[0]; });
+      var exHashes = existing[0].values.map(function (v) { return v[1]; });
+      console.log('§KRN_GROUP idempotent gid=' + gid + ' alreadyCommitted=' + exIds.length + ' ops');
+      return { gid: gid, ids: exIds, op_hashes: exHashes, tip: exHashes[exHashes.length - 1],
+               sealed: 0, committed: true, idempotent: true };
+    }
+
+    // ── 1. STAGE off the last sealed tip — derive per-op hashes WITHOUT writing. ──
+    // The staged ops will receive ids = max(id)+1..+N on insert; _canonical hashes `id`, so we must
+    // predict those ids to stage the exact hashes the seal will reproduce. They are contiguous because
+    // INTEGER PRIMARY KEY auto-increments monotonically and this group is a single transaction.
+    var tipRow = _lastSealedTip(db);
+    var maxR = db.exec('SELECT COALESCE(MAX(id),0) FROM kernel_ops');
+    var nextId = (maxR.length ? Number(maxR[0].values[0][0]) : 0) + 1;
+    var baseTs = (typeof groupMeta.baseTs === 'number') ? groupMeta.baseTs : Date.now();
+    var staged = [], prev = tipRow.hash, opHashes = [];
+    for (var i = 0; i < opsArray.length; i++) {
+      var src = opsArray[i];
+      var params = src.params != null ? src.params : src.parameters;
+      // §I-J (W-RATE-INPUT) — currency-determinism precondition: a conversion-bearing op MUST carry its
+      // recorded rate inputs (rate/rateDate/rateSource), else the WHOLE group is rejected (all-or-none,
+      // commits NOTHING). Today nothing is conversion-bearing → inert but enforced. NEVER looks up a rate.
+      var rateCheck = assertRateAsInput(params);
+      if (!rateCheck.ok) {
+        console.log('§RATE REJECT gid=' + gid + ' op[' + i + ']=' + (src.op_type || '?') +
+                    ' reason=' + rateCheck.reason + ' committedRows=0 (multi-currency disabled until rate-as-input)');
+        return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+                 committed: false, reason: rateCheck.reason };
+      }
+      var paramStr = (typeof params === 'string') ? params : JSON.stringify(params || null);
+      var inG = src.inputGuids != null ? src.inputGuids : (src.input_guids != null ? src.input_guids : null);
+      var inStr = inG ? (typeof inG === 'string' ? inG : JSON.stringify(inG)) : null;
+      var outG = src.outputGuid != null ? src.outputGuid : (src.output_guid != null ? src.output_guid : null);
+      var uuid = src.op_uuid || src.opUuid ||
+                 ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : null);
+      var row = { id: nextId + i, timestamp: baseTs, op_type: src.op_type, parameters: paramStr,
+                  input_guids: inStr, output_guid: outG || null, op_uuid: uuid };
+      var h = await _sha256(prev + '|' + _canonical(row));
+      row.op_hash = h; row.prev_hash = prev;
+      var sig = null;
+      if (_signer) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      row.sig = sig;
+      staged.push(row); opHashes.push(h); prev = h;
+    }
+    // derive ONE group hash binding the whole group to the tip (§I-K SPEC step 1).
+    var groupHash = await _sha256([tipRow.hash].concat(opHashes).join('|'));
+
+    // ── 2. ALL-OR-NONE GATE — expectedHash mismatch ⇒ reject the WHOLE group, commit nothing. ──
+    if (groupMeta.expectedHash && groupMeta.expectedHash !== groupHash) {
+      console.log('§KRN_GROUP REJECT gid=' + gid + ' groupHash=FAIL expected=' + String(groupMeta.expectedHash).slice(0, 12) +
+                  '… got=' + groupHash.slice(0, 12) + '… committedRows=0 (torn group → all-or-NONE)');
+      return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+               committed: false, reason: 'group hash mismatch' };
+    }
+
+    // ── 3. ATOMIC COMMIT — N INSERTs in ONE transaction; ROLLBACK on any error = zero rows. ──
+    var ids = [];
+    try {
+      db.run('BEGIN');
+      for (var j = 0; j < staged.length; j++) {
+        var s = staged[j];
+        db.run(
+          'INSERT INTO kernel_ops (id, op_uuid, timestamp, op_type, parameters, input_guids, output_guid, prev_hash, op_hash, sig, gid) ' +
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          [s.id, s.op_uuid, s.timestamp, s.op_type, s.parameters, s.input_guids, s.output_guid,
+           s.prev_hash, s.op_hash, s.sig, gid]
+        );
+        ids.push(s.id);
+      }
+      db.run('COMMIT');
+    } catch (e) {
+      try { db.run('ROLLBACK'); } catch (ignore) {}
+      console.log('§KRN_GROUP ROLLBACK gid=' + gid + ' err=' + e.message + ' committedRows=0 (all-or-NONE)');
+      return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+               committed: false, reason: 'transaction failed: ' + e.message };
+    }
+
+    // ── 4. SEAL ONCE from the tip forward (the I-D win — not N whole-log re-seals). ──
+    // Rows were inserted ALREADY-sealed (prev_hash/op_hash/sig staged); sealFrom is idempotent over them
+    // and confirms the tip. This keeps per-group seal cost O(N-in-group).
+    var sealRes = await sealFrom(db, tipRow);
+    console.log('§KRN_GROUP committed gid=' + gid + ' ops=' + ids.length + ' groupHash=' + groupHash.slice(0, 12) +
+                '… tip=' + sealRes.tip.slice(0, 12) + '… sealed=' + sealRes.sealed + ' (WHOLE — all-or-none)');
+    _persistToIdb(db);
+    return { gid: gid, ids: ids, op_hashes: opHashes, tip: sealRes.tip,
+             sealed: sealRes.sealed, committed: true, group_hash: groupHash };
+  }
+
   // verifyChain — walk the ordered log, recompute each op_hash, check the prev_hash link, and (if a
   // signer is set) the signature. Returns {ok, len, tip} or {ok:false, brokeAt, why} — proving
   // "tamper at op N" exactly as scripts/poc_chain.js does.
   async function verifyChain(db) {
     ensureTable(db);
-    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig FROM kernel_ops ORDER BY id');
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid FROM kernel_ops ORDER BY id');
     if (!r.length) return { ok: true, len: 0, tip: GENESIS };
     var rows = r[0].values, prev = GENESIS;
     for (var i = 0; i < rows.length; i++) {
       var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
                  parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
-      var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8];
-      if (storedHash == null) { console.log('§KRN_CHAIN verify unsealed at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'unsealed' }; }
-      if (storedPrev !== prev) return { ok: false, brokeAt: op.id, why: 'prev_hash link' };
-      var h = await _sha256(prev + '|' + _canonical(op));
-      if (h !== storedHash) { console.log('§KRN_CHAIN tamper at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'payload altered' }; }
-      if (_signer && !(await _signer.verify(storedHash, sig))) return { ok: false, brokeAt: op.id, why: 'signature' };
-      prev = h;
+      var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8], gid = rows[i][9];
+      var fail = null;
+      if (storedHash == null) { fail = 'unsealed'; }
+      else if (storedPrev !== prev) { fail = 'prev_hash link'; }
+      else {
+        var h = await _sha256(prev + '|' + _canonical(op));
+        if (h !== storedHash) { fail = 'payload altered'; }
+        else if (_signer && !(await _signer.verify(storedHash, sig))) { fail = 'signature'; }
+      }
+      if (fail) {
+        // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+        // Group-torn rule (mirrors poc_showstopper groupIntact): if a failing op belongs to a gid, the
+        // WHOLE group is broken — report brokeAt = the FIRST op of that gid, why='group torn'. A
+        // group-aware fold MUST skip every op of a torn gid (never apply a surviving sibling — that is
+        // the half-state naiveFold UNBALANCES). For an op with no gid, keep the per-op verdict.
+        if (gid != null) {
+          var gFirst = db.exec('SELECT MIN(id) FROM kernel_ops WHERE gid = ' + JSON.stringify(gid));
+          var brokeAt = (gFirst.length && gFirst[0].values.length) ? gFirst[0].values[0][0] : op.id;
+          console.log('§KRN_CHAIN group-torn gid=' + gid + ' failAt id=' + op.id + ' why=' + fail + ' brokeAt(group)=' + brokeAt);
+          return { ok: false, brokeAt: brokeAt, why: 'group torn', gid: gid, opFail: fail, failAt: op.id };
+        }
+        console.log('§KRN_CHAIN verify ' + fail + ' at id=' + op.id);
+        return { ok: false, brokeAt: op.id, why: fail };
+      }
+      prev = storedHash;
     }
     console.log('§KRN_CHAIN verify OK len=' + rows.length + ' tip=' + prev.slice(0, 12) + '…');
     return { ok: true, len: rows.length, tip: prev };
@@ -318,10 +529,13 @@
     replayOps:    replayOps,
     compact:      compact,
     sessionStart: sessionStart,
-    sealChain:    sealChain,     // W-CHAIN: (re)seal the log's hash chain (async)
+    sealChain:    sealChain,     // W-CHAIN: (re)seal the WHOLE log's hash chain (async, post-compaction)
+    sealFrom:     sealFrom,      // §I-K (W-OPGROUP): incremental seal-from-tip (the I-D flattening)
+    commitGroup:  commitGroup,   // §I-K (W-OPGROUP): N ops, ONE group hash, all-or-none, sealed once (async)
     verifyChain:  verifyChain,   // W-CHAIN/W-SIGN: prove tamper-evidence (async)
-    setSigner:    setSigner      // W-SIGN: install an edge signer (opt-in)
+    setSigner:    setSigner,     // W-SIGN: install an edge signer (opt-in)
+    assertRateAsInput: assertRateAsInput  // §I-J (W-RATE-INPUT): currency-determinism guard (pure, rate-as-op-input)
   };
 
-  console.log('§KERNEL_OPS_LOADED v6 (W-CHAIN/W-SIGN/G-IDENTITY)');
+  console.log('§KERNEL_OPS_LOADED v8 (W-CHAIN/W-SIGN/G-IDENTITY/W-OPGROUP/W-RATE-INPUT)');
 })();

--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -18,17 +18,19 @@
     '  undone INTEGER DEFAULT 0,' +
     '  prev_hash TEXT,' +   // W-CHAIN: tip this op chains onto (NULL until sealed)
     '  op_hash TEXT,' +     // W-CHAIN: SHA-256(prev_hash | canonical(op))
-    '  sig TEXT' +          // W-SIGN: edge signature over op_hash (NULL unless a signer is set)
+    '  sig TEXT,' +         // W-SIGN: edge signature over op_hash (NULL unless a signer is set)
+    '  gid TEXT' +          // §I-K (W-OPGROUP): group id — every op of an op-group shares one gid (NULL for single ops)
     ')';
   var IDX_TYPE_SQL =
     'CREATE INDEX IF NOT EXISTS idx_kernel_ops_type ON kernel_ops(op_type)';
   var IDX_UNDONE_SQL =
     'CREATE INDEX IF NOT EXISTS idx_kernel_ops_undone ON kernel_ops(undone, id)';
 
-  var _tableCreated = false;  // simple flag — one DB per session
-
+  // §I-K (W-OPGROUP): memoize per-db, not module-global. The browser uses ONE db (unchanged: created
+  // once), but commitGroup's witness + any multi-db caller must each get their own table — a module-wide
+  // flag would skip table creation on a second db. Additive robustness; single-db behaviour identical.
   function ensureTable(db) {
-    if (_tableCreated) return;
+    if (db.__kernelOpsTableCreated) return;
     try {
       db.run(TABLE_SQL);
       db.run(IDX_TYPE_SQL);
@@ -42,7 +44,9 @@
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN prev_hash TEXT"); } catch (ignore) {}
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN op_hash TEXT"); }  catch (ignore) {}
       try { db.run("ALTER TABLE kernel_ops ADD COLUMN sig TEXT"); }      catch (ignore) {}
-      _tableCreated = true;
+      // §I-K (W-OPGROUP): group-id column on pre-existing DBs (idempotent, additive)
+      try { db.run("ALTER TABLE kernel_ops ADD COLUMN gid TEXT"); }      catch (ignore) {}
+      db.__kernelOpsTableCreated = true;
     } catch (e) {
       console.log('§KERNEL_OP ensureTable ERROR: ' + e.message);
     }
@@ -57,7 +61,7 @@
    * @param {string} [outputGuid] created/modified entity ID
    * @returns {number} op id
    */
-  function commitOp(db, opType, params, inputGuids, outputGuid, opUuid) {
+  function commitOp(db, opType, params, inputGuids, outputGuid, opUuid, ts) {
     ensureTable(db);
     // G-IDENTITY (§0.21 D1/D4): identity is an edge-minted INPUT, recorded — never recomputed on
     // replay (replayOps re-reads it). Honour a caller-supplied op_uuid verbatim (the New-doc seam);
@@ -66,10 +70,16 @@
     // hash stays byte-identical (the chain still totals over `id`).
     var uuid = opUuid ||
                ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : null);
+    // DETERMINISM (ERP.md §0.16): timestamp IS part of _canonical, so an op path that must replay
+    // byte-stable supplies its own deterministic `ts` (no Date.now). Default keeps existing callers
+    // (the BIM grid log) unchanged. Passed-in ts → reproducible op_hash across a rebuild.
+    // Forward-reconciled from the app's erp/ copy on the §INTEG-COLLAPSE (2026-06-08); the substrate's
+    // byte-stable period-close replay depends on it. See prompts/ERP_SUBSTRATE_INTEGRATION.md §ARCHIVE.
+    var stamp = (ts != null) ? ts : Date.now();
     db.run(
       'INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid) ' +
       'VALUES (?, ?, ?, ?, ?, ?)',
-      [uuid, Date.now(), opType, JSON.stringify(params),
+      [uuid, stamp, opType, JSON.stringify(params),
        inputGuids ? JSON.stringify(inputGuids) : null,
        outputGuid || null]
     );
@@ -152,24 +162,229 @@
     return { sealed: sealed, tip: prev };
   }
 
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+  // sealFrom — incremental seal: seal ONLY the rows from the last sealed tip forward, never the whole
+  // log. Already-sealed rows (carrying op_hash) are immutable by the chain's own guarantee (§I-K SPEC
+  // "Sealed ONCE per group"), so they are not re-read or re-hashed. This is the I-D flattening win:
+  // per-group seal cost becomes O(N-in-group) instead of O(log-length). sealChain (full re-seal) stays
+  // for post-compaction correctness (compact() may delete/collapse rows).
+  // _lastSealedTip(db) → { id, hash } of the highest already-sealed row, or { id:0, hash:GENESIS }.
+  function _lastSealedTip(db) {
+    var r = db.exec('SELECT id, op_hash FROM kernel_ops WHERE op_hash IS NOT NULL ORDER BY id DESC LIMIT 1');
+    if (!r.length || !r[0].values.length) return { id: 0, hash: GENESIS };
+    return { id: r[0].values[0][0], hash: r[0].values[0][1] };
+  }
+  async function sealFrom(db, fromTip) {
+    ensureTable(db);
+    var tip = fromTip || _lastSealedTip(db);
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig FROM kernel_ops WHERE id > ' + tip.id + ' ORDER BY id');
+    if (!r.length) { return { sealed: 0, tip: tip.hash, fromId: tip.id }; }
+    var rows = r[0].values, prev = tip.hash, sealed = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+      var sig = rows[i][6];
+      var h = await _sha256(prev + '|' + _canonical(op));
+      if (_signer && !sig) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      db.run('UPDATE kernel_ops SET prev_hash=?, op_hash=?, sig=? WHERE id=?', [prev, h, sig || null, op.id]);
+      prev = h; sealed++;
+    }
+    console.log('§KRN_SEAL_FROM fromId=' + tip.id + ' sealed=' + sealed + ' tip=' + prev.slice(0, 12) + '…' + (_signer ? ' signed' : ''));
+    return { sealed: sealed, tip: prev, fromId: tip.id };
+  }
+
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-J — Witness: W-RATE-INPUT
+  // assertRateAsInput — the currency-determinism guard (DistributedERP.md §7 / §9-E).
+  //
+  // SPEC (§I-J): a conversion rate read at REPLAY time is THE canonical nondeterminism breaker — two
+  // replays diverge → replay-hash != live-hash → merge breaks. RULE (non-invent + §7): the rate in force
+  // at the edge MUST be captured as an op INPUT (frozen into the op), never looked up later — same
+  // discipline as UUID/timestamp/scan. Until that is wired, multi-currency writes stay DISABLED.
+  //
+  // CONVENTION — an op is "conversion-bearing" iff its params declare a converted amount via EITHER:
+  //   (a) params.convertedAmt is present (not null/undefined), OR
+  //   (b) params.fx is an object (an explicit FX block).
+  // A conversion-bearing op MUST carry the recorded conversion INPUTS that make it replayable:
+  //   rate, rateDate, rateSource — sourced from params.fx.{rate,rateDate,rateSource} when params.fx is an
+  //   object, else params.{rate,rateDate,rateSource}. Missing any → REJECT (the multi-currency-disabled
+  //   rule, enforced). Single-currency ops (no conversion-bearing field) PASS untouched — zero behaviour
+  //   change today (the POC is single-currency; nothing is conversion-bearing).
+  //
+  // NON-INVENT: this guard NEVER fabricates a rate and NEVER looks one up. It only enforces that a
+  // conversion the caller already declared carries its own inputs. Returns { ok, conversionBearing, reason? }.
+  // PURE: no Date.now / Math.random / db / network — deterministic, safe in the hashed write path.
+  function assertRateAsInput(params) {
+    var p = params;
+    if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { p = null; } }
+    if (!p || typeof p !== 'object') return { ok: true, conversionBearing: false };
+    var hasFxBlock = p.fx != null && typeof p.fx === 'object';
+    var hasConvertedAmt = p.convertedAmt != null;
+    var conversionBearing = hasFxBlock || hasConvertedAmt;
+    if (!conversionBearing) return { ok: true, conversionBearing: false };
+    // read the recorded inputs from the fx block if present, else top-level params.
+    var src = hasFxBlock ? p.fx : p;
+    var missing = [];
+    if (src.rate == null)       missing.push('rate');
+    if (src.rateDate == null)   missing.push('rateDate');
+    if (src.rateSource == null) missing.push('rateSource');
+    if (missing.length) {
+      return { ok: false, conversionBearing: true,
+               reason: 'conversion-bearing op missing recorded rate input(s): ' + missing.join(',') +
+                       ' — multi-currency stays DISABLED until rate-as-input is provided (§I-J)' };
+    }
+    return { ok: true, conversionBearing: true, rate: src.rate, rateDate: src.rateDate, rateSource: src.rateSource };
+  }
+
+  // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+  // commitGroup — the op-group atomic unit (ERP.md §18.8). N ops fold WHOLE or NONE:
+  //   1. STAGE off the last sealed tip — compute each op's prev_hash/op_hash, derive ONE group hash
+  //      groupHash = sha256(tip | op_hash[0] | … | op_hash[N-1]) binding the whole group to the tip.
+  //   2. ALL-OR-NONE GATE — if groupMeta.expectedHash is supplied and groupHash != expectedHash, commit
+  //      NOTHING (return committed:false). This is the torn-group rejection (poc_showstopper groupHash=FAIL).
+  //   3. ATOMIC COMMIT — wrap the N INSERTs in ONE SQL transaction (BEGIN…COMMIT / ROLLBACK on any
+  //      error) → zero rows on failure = no half-group (the storage-tier mirror of S2's fold-tier rule).
+  //   4. SEAL ONCE — seal only the N new rows via sealFrom (the I-D win; not N whole-log re-seals).
+  //   Every committed op carries the shared `gid` so the fold can re-segment groups (poc_showstopper groupsOf).
+  // Idempotent: re-invoking with a gid already present is a no-op (returns the existing group).
+  // NON-INVENT: a caller-supplied gid is honoured verbatim (G-IDENTITY input); minted only when absent.
+  // Signature: commitGroup(db, opsArray, groupMeta) -> { gid, ids, op_hashes, tip, sealed, committed, reason? }
+  async function commitGroup(db, opsArray, groupMeta) {
+    ensureTable(db);
+    groupMeta = groupMeta || {};
+    if (!Array.isArray(opsArray) || opsArray.length === 0) {
+      return { committed: false, reason: 'empty op-group', ids: [], op_hashes: [] };
+    }
+    // gid is an edge-minted INPUT (same discipline as op_uuid) — honour caller's, else mint at commit.
+    var gid = groupMeta.gid ||
+              ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : 'g-' + Date.now());
+
+    // ── Idempotency: a gid already present is a no-op (replay-safe, retry-safe). ──
+    var existing = db.exec('SELECT id, op_hash FROM kernel_ops WHERE gid = ' + JSON.stringify(gid) + ' ORDER BY id');
+    if (existing.length && existing[0].values.length) {
+      var exIds = existing[0].values.map(function (v) { return v[0]; });
+      var exHashes = existing[0].values.map(function (v) { return v[1]; });
+      console.log('§KRN_GROUP idempotent gid=' + gid + ' alreadyCommitted=' + exIds.length + ' ops');
+      return { gid: gid, ids: exIds, op_hashes: exHashes, tip: exHashes[exHashes.length - 1],
+               sealed: 0, committed: true, idempotent: true };
+    }
+
+    // ── 1. STAGE off the last sealed tip — derive per-op hashes WITHOUT writing. ──
+    // The staged ops will receive ids = max(id)+1..+N on insert; _canonical hashes `id`, so we must
+    // predict those ids to stage the exact hashes the seal will reproduce. They are contiguous because
+    // INTEGER PRIMARY KEY auto-increments monotonically and this group is a single transaction.
+    var tipRow = _lastSealedTip(db);
+    var maxR = db.exec('SELECT COALESCE(MAX(id),0) FROM kernel_ops');
+    var nextId = (maxR.length ? Number(maxR[0].values[0][0]) : 0) + 1;
+    var baseTs = (typeof groupMeta.baseTs === 'number') ? groupMeta.baseTs : Date.now();
+    var staged = [], prev = tipRow.hash, opHashes = [];
+    for (var i = 0; i < opsArray.length; i++) {
+      var src = opsArray[i];
+      var params = src.params != null ? src.params : src.parameters;
+      // §I-J (W-RATE-INPUT) — currency-determinism precondition: a conversion-bearing op MUST carry its
+      // recorded rate inputs (rate/rateDate/rateSource), else the WHOLE group is rejected (all-or-none,
+      // commits NOTHING). Today nothing is conversion-bearing → inert but enforced. NEVER looks up a rate.
+      var rateCheck = assertRateAsInput(params);
+      if (!rateCheck.ok) {
+        console.log('§RATE REJECT gid=' + gid + ' op[' + i + ']=' + (src.op_type || '?') +
+                    ' reason=' + rateCheck.reason + ' committedRows=0 (multi-currency disabled until rate-as-input)');
+        return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+                 committed: false, reason: rateCheck.reason };
+      }
+      var paramStr = (typeof params === 'string') ? params : JSON.stringify(params || null);
+      var inG = src.inputGuids != null ? src.inputGuids : (src.input_guids != null ? src.input_guids : null);
+      var inStr = inG ? (typeof inG === 'string' ? inG : JSON.stringify(inG)) : null;
+      var outG = src.outputGuid != null ? src.outputGuid : (src.output_guid != null ? src.output_guid : null);
+      var uuid = src.op_uuid || src.opUuid ||
+                 ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : null);
+      var row = { id: nextId + i, timestamp: baseTs, op_type: src.op_type, parameters: paramStr,
+                  input_guids: inStr, output_guid: outG || null, op_uuid: uuid };
+      var h = await _sha256(prev + '|' + _canonical(row));
+      row.op_hash = h; row.prev_hash = prev;
+      var sig = null;
+      if (_signer) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      row.sig = sig;
+      staged.push(row); opHashes.push(h); prev = h;
+    }
+    // derive ONE group hash binding the whole group to the tip (§I-K SPEC step 1).
+    var groupHash = await _sha256([tipRow.hash].concat(opHashes).join('|'));
+
+    // ── 2. ALL-OR-NONE GATE — expectedHash mismatch ⇒ reject the WHOLE group, commit nothing. ──
+    if (groupMeta.expectedHash && groupMeta.expectedHash !== groupHash) {
+      console.log('§KRN_GROUP REJECT gid=' + gid + ' groupHash=FAIL expected=' + String(groupMeta.expectedHash).slice(0, 12) +
+                  '… got=' + groupHash.slice(0, 12) + '… committedRows=0 (torn group → all-or-NONE)');
+      return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+               committed: false, reason: 'group hash mismatch' };
+    }
+
+    // ── 3. ATOMIC COMMIT — N INSERTs in ONE transaction; ROLLBACK on any error = zero rows. ──
+    var ids = [];
+    try {
+      db.run('BEGIN');
+      for (var j = 0; j < staged.length; j++) {
+        var s = staged[j];
+        db.run(
+          'INSERT INTO kernel_ops (id, op_uuid, timestamp, op_type, parameters, input_guids, output_guid, prev_hash, op_hash, sig, gid) ' +
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          [s.id, s.op_uuid, s.timestamp, s.op_type, s.parameters, s.input_guids, s.output_guid,
+           s.prev_hash, s.op_hash, s.sig, gid]
+        );
+        ids.push(s.id);
+      }
+      db.run('COMMIT');
+    } catch (e) {
+      try { db.run('ROLLBACK'); } catch (ignore) {}
+      console.log('§KRN_GROUP ROLLBACK gid=' + gid + ' err=' + e.message + ' committedRows=0 (all-or-NONE)');
+      return { gid: gid, ids: [], op_hashes: [], tip: tipRow.hash, sealed: 0,
+               committed: false, reason: 'transaction failed: ' + e.message };
+    }
+
+    // ── 4. SEAL ONCE from the tip forward (the I-D win — not N whole-log re-seals). ──
+    // Rows were inserted ALREADY-sealed (prev_hash/op_hash/sig staged); sealFrom is idempotent over them
+    // and confirms the tip. This keeps per-group seal cost O(N-in-group).
+    var sealRes = await sealFrom(db, tipRow);
+    console.log('§KRN_GROUP committed gid=' + gid + ' ops=' + ids.length + ' groupHash=' + groupHash.slice(0, 12) +
+                '… tip=' + sealRes.tip.slice(0, 12) + '… sealed=' + sealRes.sealed + ' (WHOLE — all-or-none)');
+    _persistToIdb(db);
+    return { gid: gid, ids: ids, op_hashes: opHashes, tip: sealRes.tip,
+             sealed: sealRes.sealed, committed: true, group_hash: groupHash };
+  }
+
   // verifyChain — walk the ordered log, recompute each op_hash, check the prev_hash link, and (if a
   // signer is set) the signature. Returns {ok, len, tip} or {ok:false, brokeAt, why} — proving
   // "tamper at op N" exactly as scripts/poc_chain.js does.
   async function verifyChain(db) {
     ensureTable(db);
-    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig FROM kernel_ops ORDER BY id');
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid FROM kernel_ops ORDER BY id');
     if (!r.length) return { ok: true, len: 0, tip: GENESIS };
     var rows = r[0].values, prev = GENESIS;
     for (var i = 0; i < rows.length; i++) {
       var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
                  parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
-      var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8];
-      if (storedHash == null) { console.log('§KRN_CHAIN verify unsealed at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'unsealed' }; }
-      if (storedPrev !== prev) return { ok: false, brokeAt: op.id, why: 'prev_hash link' };
-      var h = await _sha256(prev + '|' + _canonical(op));
-      if (h !== storedHash) { console.log('§KRN_CHAIN tamper at id=' + op.id); return { ok: false, brokeAt: op.id, why: 'payload altered' }; }
-      if (_signer && !(await _signer.verify(storedHash, sig))) return { ok: false, brokeAt: op.id, why: 'signature' };
-      prev = h;
+      var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8], gid = rows[i][9];
+      var fail = null;
+      if (storedHash == null) { fail = 'unsealed'; }
+      else if (storedPrev !== prev) { fail = 'prev_hash link'; }
+      else {
+        var h = await _sha256(prev + '|' + _canonical(op));
+        if (h !== storedHash) { fail = 'payload altered'; }
+        else if (_signer && !(await _signer.verify(storedHash, sig))) { fail = 'signature'; }
+      }
+      if (fail) {
+        // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
+        // Group-torn rule (mirrors poc_showstopper groupIntact): if a failing op belongs to a gid, the
+        // WHOLE group is broken — report brokeAt = the FIRST op of that gid, why='group torn'. A
+        // group-aware fold MUST skip every op of a torn gid (never apply a surviving sibling — that is
+        // the half-state naiveFold UNBALANCES). For an op with no gid, keep the per-op verdict.
+        if (gid != null) {
+          var gFirst = db.exec('SELECT MIN(id) FROM kernel_ops WHERE gid = ' + JSON.stringify(gid));
+          var brokeAt = (gFirst.length && gFirst[0].values.length) ? gFirst[0].values[0][0] : op.id;
+          console.log('§KRN_CHAIN group-torn gid=' + gid + ' failAt id=' + op.id + ' why=' + fail + ' brokeAt(group)=' + brokeAt);
+          return { ok: false, brokeAt: brokeAt, why: 'group torn', gid: gid, opFail: fail, failAt: op.id };
+        }
+        console.log('§KRN_CHAIN verify ' + fail + ' at id=' + op.id);
+        return { ok: false, brokeAt: op.id, why: fail };
+      }
+      prev = storedHash;
     }
     console.log('§KRN_CHAIN verify OK len=' + rows.length + ' tip=' + prev.slice(0, 12) + '…');
     return { ok: true, len: rows.length, tip: prev };
@@ -314,10 +529,13 @@
     replayOps:    replayOps,
     compact:      compact,
     sessionStart: sessionStart,
-    sealChain:    sealChain,     // W-CHAIN: (re)seal the log's hash chain (async)
+    sealChain:    sealChain,     // W-CHAIN: (re)seal the WHOLE log's hash chain (async, post-compaction)
+    sealFrom:     sealFrom,      // §I-K (W-OPGROUP): incremental seal-from-tip (the I-D flattening)
+    commitGroup:  commitGroup,   // §I-K (W-OPGROUP): N ops, ONE group hash, all-or-none, sealed once (async)
     verifyChain:  verifyChain,   // W-CHAIN/W-SIGN: prove tamper-evidence (async)
-    setSigner:    setSigner      // W-SIGN: install an edge signer (opt-in)
+    setSigner:    setSigner,     // W-SIGN: install an edge signer (opt-in)
+    assertRateAsInput: assertRateAsInput  // §I-J (W-RATE-INPUT): currency-determinism guard (pure, rate-as-op-input)
   };
 
-  console.log('§KERNEL_OPS_LOADED v6 (W-CHAIN/W-SIGN/G-IDENTITY)');
+  console.log('§KERNEL_OPS_LOADED v8 (W-CHAIN/W-SIGN/G-IDENTITY/W-OPGROUP/W-RATE-INPUT)');
 })();


### PR DESCRIPTION
**Phase 0** of the substrate→UI integration arc (`prompts/ERP_SUBSTRATE_INTEGRATION.md`).
Collapses the three drifted `kernel_ops.js` copies (app `erp/` v6 · `viewer/` v6 · canonical `build/erp` v8) into ONE reconciled canonical.

### Why
The three had **bidirectional** drift. Canonical v8 was richer (`commitGroup`/`sealFrom`/`assertRateAsInput`, `gid`, group-torn `verifyChain`); the app `erp/` copy was ahead on one thing — a deterministic `ts` param in `commitOp`. Folded the `ts` param forward so the collapse loses nothing. **Side effect:** the deployed v6 kernel lacked `commitGroup`, so `crud_overlay.js:517` was silently running the CRUD write path in **DRY fallback** — this activates the real signed write path.

### Witness (§INTEG-KERNEL-GREEN) — read the logs, not the exit code
- **10/10** live-app erp witnesses green on the reconciled kernel, `pageErrors=0` (rule_edit, rule_client_scope, mobile_cards, init_instant, gated_complete, i4_reconcile, accts_posted, kanban_write, kanban_persist, idempiere_fold).
- **5/5** substrate witnesses green (`test_kernel_{period_close,sync,rebase,relay,replica}`).
- Viewer surface (`undo`/`redo`/`replayOps`/`compact`) proven **byte-identical** to v6 by per-function diff; `commitOp` default path byte-identical. (Viewer browser probes aren't self-contained in a bare worktree — a null-db crashes v6 and v8 identically; environmental, not a regression.)

### Archive
Pre-collapse copies saved verbatim at `bim-compiler/build/erp/_archive/kernel_collapse_2026-06-08/` + drift-map README.

### ⛔ HELD — deploy gate checklist (do on "deploy")
- [ ] bump `erp/sw.js` `CACHE_VERSION` + viewer SW cache
- [ ] `?v=` bump on `kernel_ops.js` refs so the SW serves the new kernel
- [ ] verify live on Pages — kernel reaches a returning user within one reload (§INTEG-FRESHNESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)