### PR TITLE
feat(erp): §INTEG-WIRE — period-close in-app (Phase 2 slice A, HELD)

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -645,7 +645,7 @@
   }
   global.__crud = { enable: enable, disable: disable, openRing: openRing, core: CORE, store: function () { return STORE; },
                     setStatus: setDocStatus, statusBar: function () { return statusBar; }, pulseProc: pulseProc,
-                    kernelDb: function () { return SIDE; }, withSidecar: withSidecar,
+                    kernelDb: function () { return SIDE; }, withSidecar: withSidecar, persist: _sidePersist,
                     readTip: function (table, id) { return SIDE ? CORE.readTip(SIDE, table, id) : null; }, history: history };
   console.log('§CRUD layer mounted (Edit-mode ready)');
 })(typeof window !== 'undefined' ? window : this);

--- a/erp/erp_period_close.js
+++ b/erp/erp_period_close.js
@@ -1,0 +1,168 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// erp_period_close.js — ERP.md §0.20 contract-freeze / HolyGrail §"hard parts" (compaction = period-close).
+// Witness: W-PCLOSE (scripts/test_kernel_period_close.js). Spec: prompts/PERIOD_CLOSE_FOLD_POC.md §Spec.
+//
+// Lifts the ALREADY-GREEN abstract proof scripts/poc_showstopper.js §SHOW-CKPT onto the REAL kernel_ops log:
+// a closed accounting period collapses to ONE signed checkpoint op carrying the closing balances (integer
+// cents) + the prior chain-head fingerprint; pre-checkpoint ops are dropped from the LIVE log; the next
+// period folds FROM the checkpoint balances (balance brought forward). Re-folding [checkpoint + post-ckpt]
+// is byte/cent-identical to folding the full genesis history — so compaction loses nothing — and the
+// checkpoint is tamper-evident (hash chain + controller signature over the new tip).
+//
+// This module COMPOSES on the kernel (commitOp / sealChain / verifyChain / replayOps) — it does NOT bloat
+// kernel_ops.js. The signature reuses erp_snapshot_sign (ECDSA P-256, pinned controller key). Determinism:
+// the fold reads account/cents ONLY (never timestamp/id/uuid); closePeriod re-stamps the checkpoint op to a
+// RECORDED ts (an INPUT) — NO Date.now()/Math.random() on any fold/replay path.
+(function () {
+  'use strict';
+
+  var CKPT_TYPE   = 'PERIOD_CLOSE';
+  var REOPEN_TYPE = 'PERIOD_REOPEN';
+
+  // ── the accounting fold (deterministic, integer cents) ──────────────────────────────────────────
+  // TWO posting shapes fold here, both deterministic in integer cents; document ops (orders/ships/
+  // invoices) carry neither → skipped; CKPT/REOPEN are control ops, never postings. `opening` is the
+  // balance brought forward (default empty). The closing balance of an account = net cents.
+  //   (1) SYNTHETIC (poc_showstopper / test_kernel_period_close): `{account:string, cents:int}`.
+  //   (2) REAL — the LIVE app's §13.1 POST verb (~/bim-ootb/erp/erp_kernel.js applyOne): double-entry
+  //       `{lines:[{account_id, amtacctdr, amtacctcr}]}`, ΣDR==ΣCR. Per-account b/f = Σ(DR)−Σ(CR) cents.
+  //       Implementing prompts/ERP_SUBSTRATE_INTEGRATION.md §INTEG-POSTINGS-RECONCILE — Witness:
+  //       W-POSTINGS-RECONCILE. Additive: the synthetic path is byte-identical when no `lines` present.
+  function _isPosting(p) {
+    return p && typeof p.account === 'string' && typeof p.cents === 'number' && (p.cents | 0) === p.cents;
+  }
+  // cents() mirrors ~/bim-ootb/erp/erp_postings.js exactly (the app's own DR/CR→cents) for an identical
+  // fold; amounts are 2-dp Fact_Acct values so Math.round is deterministic (no Number drift at 2 places).
+  function _cents(n) { return Math.round(Number(n || 0) * 100); }
+  function foldBalances(ops, opening) {
+    var bal = {}, a;
+    if (opening) { for (a in opening) if (Object.prototype.hasOwnProperty.call(opening, a)) bal[a] = opening[a]; }
+    (ops || []).forEach(function (op) {
+      if (op.op_type === CKPT_TYPE || op.op_type === REOPEN_TYPE) return;   // control ops, not postings
+      var p = op.parameters;                                                // replayOps already JSON-parses
+      if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { return; } }
+      if (!p) return;
+      if (Array.isArray(p.lines)) {                                         // (2) real double-entry POST op
+        p.lines.forEach(function (l) {
+          var acct = String(l.account_id);
+          bal[acct] = (bal[acct] || 0) + _cents(l.amtacctdr) - _cents(l.amtacctcr);
+        });
+        return;
+      }
+      if (!_isPosting(p)) return;                                           // (1) synthetic posting
+      bal[p.account] = (bal[p.account] || 0) + p.cents;
+    });
+    return { bal: bal };
+  }
+
+  function balSum(bal) { var s = 0; for (var a in bal) s += bal[a]; return s; }   // double-entry: 0 when balanced
+  // balEqual — max absolute per-account difference in cents (0 ⇒ cent-identical). The falsifier metric.
+  function balEqual(x, y) {
+    var keys = {}, k, max = 0;
+    for (k in x) keys[k] = 1; for (k in y) keys[k] = 1;
+    for (k in keys) max = Math.max(max, Math.abs((x[k] || 0) - (y[k] || 0)));
+    return { equal: max === 0, maxDiffCents: max };
+  }
+
+  // ── closePeriod — fold the live log → closing balances → ONE signed checkpoint → compact ────────
+  // signer = { signTip: async(tipHex)->sigHex, signed_by?:string }. periodMeta = { period, ts }.
+  // ts is a RECORDED close timestamp (an INPUT), so the checkpoint op — hence the new tip — is deterministic.
+  async function closePeriod(db, kernel, signer, periodMeta) {
+    periodMeta = periodMeta || {};
+    var period = (periodMeta.period != null) ? periodMeta.period : 1;
+    var ts     = (periodMeta.ts != null) ? periodMeta.ts : 0;
+
+    // 1. seal + verify the period being closed; capture its chain-head fingerprint (prev_tip).
+    await kernel.sealChain(db);
+    var pre = await kernel.verifyChain(db);
+    if (!pre.ok) throw new Error('closePeriod: pre-close chain does not verify (brokeAt=' + pre.brokeAt + ' ' + pre.why + ')');
+    var prevTip = pre.tip, archived = pre.len;
+
+    // 2. fold the live ops → closing balances (integer cents).
+    var live = kernel.replayOps(db);
+    var closing = foldBalances(live, null).bal;
+
+    // 3. commit ONE checkpoint op carrying the deterministic payload; re-stamp to the recorded ts; re-seal.
+    var ckptId = kernel.commitOp(db, CKPT_TYPE, { period: period, closing_balances: closing, prev_tip: prevTip });
+    db.run('UPDATE kernel_ops SET timestamp=? WHERE id=?', [ts, ckptId]);
+
+    // 4. compact: drop every pre-checkpoint op from the LIVE log; the checkpoint becomes the new anchor.
+    //    (The full pre-close log is the cold archive — kept by the caller, never deleted here.)
+    db.run('DELETE FROM kernel_ops WHERE id < ?', [ckptId]);
+
+    // 5. re-seal the compacted live log; the new tip is the fingerprint of [PERIOD_CLOSE].
+    var sealRes = await kernel.sealChain(db);
+    var post = await kernel.verifyChain(db);
+    if (!post.ok) throw new Error('closePeriod: post-compaction chain does not verify');
+    var tip = post.tip;
+
+    // 6. the controller signs the NEW tip (the signed checkpoint = chain-head fingerprint signed).
+    var sig = null;
+    if (signer && typeof signer.signTip === 'function') sig = await signer.signTip(tip);
+
+    console.log('§PCLOSE-FOLD period=' + period + ' archived=' + archived + ' closing=' + JSON.stringify(closing) +
+                ' balSum=' + balSum(closing) + ' prevTip=' + (prevTip || '').slice(0, 12) + '…');
+    console.log('§PCLOSE-COMPACT liveLen=' + post.len + ' (≪ ' + archived + ') newTip=' + (tip || '').slice(0, 12) +
+                '… verifyLive=' + (post.ok ? 'ok' : 'FAIL') + ' sealed=' + sealRes.sealed);
+    console.log('§PCLOSE-SIGN tip=' + (tip || '').slice(0, 12) + '… signed=' + (sig ? 'Y' : 'N') +
+                ' by=' + (signer && signer.signed_by || 'controller'));
+
+    return { period: period, closing_balances: closing, prev_tip: prevTip, tip: tip, sig: sig,
+             signed_by: (signer && signer.signed_by) || 'controller', archived: archived, liveLen: post.len };
+  }
+
+  // ── bootstrapFromCheckpoint — opening = latest checkpoint's closing balances; fold post-ckpt forward ──
+  function _latestCheckpoint(db) {
+    var r = db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='" + CKPT_TYPE + "' ORDER BY id DESC LIMIT 1");
+    if (!r.length || !r[0].values.length) return null;
+    return { id: r[0].values[0][0], params: JSON.parse(r[0].values[0][1]) };
+  }
+  function bootstrapFromCheckpoint(db, kernel) {
+    var ck = _latestCheckpoint(db);
+    var opening = ck ? ck.params.closing_balances : {};
+    var period  = ck ? ck.params.period : 0;
+    // post-checkpoint ops only (id > ckptId); the checkpoint op itself is a control op, skipped by the fold.
+    var live = kernel.replayOps(db);
+    var post = ck ? live.filter(function (o) { return o.id > ck.id; }) : live;
+    var current = foldBalances(post, opening).bal;
+    console.log('§PCLOSE-BF fromCheckpoint=' + (ck ? 'Y(period=' + period + ')' : 'N') +
+                ' opening=' + JSON.stringify(opening) + ' postCount=' + post.length +
+                ' current=' + JSON.stringify(current));
+    return { period: period, opening: opening, current: current, postCount: post.length, fromCheckpoint: !!ck };
+  }
+
+  // ── reopenPeriod (optional §PCLOSE-REOPEN) — a SUPERSEDE op re-chained onto the head; the original
+  //    PERIOD_CLOSE stays in the chain (audit), never edited in place (the iDempiere reopen wrinkle). ──
+  async function reopenPeriod(db, kernel, signer, meta) {
+    meta = meta || {};
+    var ck = _latestCheckpoint(db);
+    if (!ck) throw new Error('reopenPeriod: no checkpoint to reopen');
+    var ts = (meta.ts != null) ? meta.ts : 0;
+    var id = kernel.commitOp(db, REOPEN_TYPE, { period: ck.params.period, supersedes_ckpt_id: ck.id, reason: meta.reason || 'reopen' });
+    db.run('UPDATE kernel_ops SET timestamp=? WHERE id=?', [ts, id]);
+    var sealRes = await kernel.sealChain(db);
+    var v = await kernel.verifyChain(db);
+    var sig = (signer && typeof signer.signTip === 'function') ? await signer.signTip(v.tip) : null;
+    // the original checkpoint must still be present + the chain must still verify through it.
+    var still = db.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='" + CKPT_TYPE + "'");
+    var ckptCount = Number(still[0].values[0][0]);
+    console.log('§PCLOSE-REOPEN supersedes=ckpt#' + ck.id + ' reopenOp=' + id + ' origCkptStillInChain=' +
+                (ckptCount >= 1 ? 'Y' : 'N') + ' verify=' + (v.ok ? 'ok' : 'FAIL') + ' tip=' + (v.tip || '').slice(0, 12) + '…');
+    return { period: ck.params.period, reopenId: id, tip: v.tip, sig: sig, verify: v.ok, ckptCount: ckptCount, sealed: sealRes.sealed };
+  }
+
+  var _api = {
+    foldBalances: foldBalances,
+    balSum: balSum,
+    balEqual: balEqual,
+    closePeriod: closePeriod,
+    bootstrapFromCheckpoint: bootstrapFromCheckpoint,
+    reopenPeriod: reopenPeriod,
+    CKPT_TYPE: CKPT_TYPE,
+    REOPEN_TYPE: REOPEN_TYPE
+  };
+  if (typeof module !== 'undefined' && module.exports) { module.exports = _api; }
+  if (typeof window !== 'undefined') { window.ErpPeriodClose = _api; }
+  if (typeof console !== 'undefined') { console.log('§PCLOSE_LOADED v1 (period-close fold = signed checkpoint = balance b/f)'); }
+})();

--- a/erp/glassbowl.html
+++ b/erp/glassbowl.html
@@ -854,8 +854,15 @@ if(!window.__restored&&isMobile())setPanelCollapsed(true);else syncPanelUI(docum
 <script src="bigdecimal.js"></script>
 <!-- production signed kernel (W-CHAIN/W-SIGN) — one source, copied from bim-ootb/viewer/kernel_ops.js. GP3: Process ▶ commits real signed SET_STATUS ops to a sidecar log. -->
 <script src="kernel_ops.js"></script>
+<!-- edge signer (W-SIGN) — turns the signed checkpoint un-FORGEABLE; loadOrMint custody, reused by period-close. -->
+<script src="erp_signer.js"></script>
 <!-- CRUD ring-of-fire + Process/DocAction overlay — peer behavior layer, keyed to bubbles. GP3: Process ▶ = REAL signed write (sidecar log, read-the-tip). -->
 <script src="crud_overlay.js"></script>
+<!-- Period-close in-app (§INTEG-WIRE) — fold the live sidecar op-log → ONE signed checkpoint = balance b/f; bootstrap from it on load. -->
+<script src="erp_period_close.js"></script>
+<script src="period_close_ui.js"></script>
 <!-- Report (read face of the op-log) — peer overlay; the ring's ▤ verb folds a Receipt from the bundle. PURE READ. (CRUD_P_R_REPORT.md R1) -->
 <script src="report_overlay.js"></script>
+<!-- §INTEG-WIRE — mount the period-close control into the info panel (the op-log's natural home: compact → checkpoint). -->
+<script>(function(){function m(){if(!(window.PeriodClose&&window.__crud&&window.ErpPeriodClose)){return setTimeout(m,300);}var p=document.getElementById('panel');if(p&&!p.querySelector('.pclose-ctl')){try{window.PeriodClose.renderInto(p,{});console.log('§INTEG-WIRE control mounted in #panel');}catch(e){console.warn('§INTEG-WIRE mount',e&&e.message);}}}if(document.readyState!=='loading')m();else document.addEventListener('DOMContentLoaded',m);})();</script>
 </body></html>

--- a/erp/period_close_ui.js
+++ b/erp/period_close_ui.js
@@ -1,0 +1,159 @@
+/* period_close_ui.js — §INTEG-WIRE (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2, slice A)
+ *
+ * Wires the FROZEN period-close substrate (erp_period_close.js → window.ErpPeriodClose) into the live
+ * ERP app, on the REAL signed op-log (crud_overlay's `glassbowl_kernel_ops` sidecar). An accountant
+ * closes a period → ONE signed checkpoint carrying the closing balances → the pre-checkpoint ops are
+ * compacted out → next load BOOTSTRAPS from the checkpoint (opening = balance brought forward).
+ *
+ * Composition only — no engine logic here, no invented posting. Reuses:
+ *   window.ErpPeriodClose  (closePeriod / bootstrapFromCheckpoint / foldBalances)
+ *   window.KernelOps       (the canonical signed kernel — commitOp/commitGroup/sealChain/verifyChain)
+ *   window.ErpSigner       (the APP edge signer — loadOrMint custody + makeSigner; NOT a demo key)
+ *   window.__crud          (withSidecar → the live sidecar db; persist → re-persist after compaction)
+ *
+ * Whitebox witness: erp/tests/poc_period_close_wire.js (§INTEG-WIRE). Read the log.
+ */
+(function (global) {
+  'use strict';
+  var TAG = '§INTEG-WIRE';
+
+  function _ready() { return !!(global.ErpPeriodClose && global.KernelOps && global.ErpSigner && global.__crud); }
+
+  // ensure sql.js is loaded — glassbowl loads it LAZILY (withBundle), so initSqlJs may be absent at init.
+  // crud_overlay.withSidecar needs window.initSqlJs to build the sidecar; load the same bundle on demand.
+  function _ensureSql(cb) {
+    if (typeof global.initSqlJs === 'function') { cb(true); return; }
+    try {
+      var sc = global.document.createElement('script');
+      sc.src = 'sqljs/sql-wasm.js';
+      sc.onload = function () { cb(typeof global.initSqlJs === 'function'); };
+      sc.onerror = function () { cb(false); };
+      (global.document.head || global.document.documentElement).appendChild(sc);
+    } catch (e) { cb(false); }
+  }
+
+  // resolve the live sidecar kernel db (lazily hydrated by crud_overlay, which needs sql.js present).
+  function _withDb(cb) {
+    _ensureSql(function () {
+      var c = global.__crud;
+      if (c && typeof c.withSidecar === 'function') { c.withSidecar(cb); return; }
+      cb(c && typeof c.kernelDb === 'function' ? c.kernelDb() : null);
+    });
+  }
+
+  // signer onto closePeriod's {signTip, signed_by} contract, via the APP signer (edge custody, IDB-persisted).
+  function _signer() {
+    return global.ErpSigner.loadOrMint('bim_erp_signer').then(function (kp) {
+      var s = global.ErpSigner.makeSigner(kp);
+      return { signTip: function (tipHex) { return s.sign(tipHex); }, signed_by: 'edge',
+               _verify: function (tipHex, sig) { return s.verify(tipHex, sig); } };
+    });
+  }
+
+  // boot — on load, open the current balances from the latest checkpoint (the b/f) without re-folding genesis.
+  function boot() {
+    if (!_ready()) { setTimeout(boot, 250); return; }
+    _withDb(function (db) {
+      if (!db) { console.log(TAG + ' boot: no sidecar db yet'); return; }
+      try {
+        var bf = global.ErpPeriodClose.bootstrapFromCheckpoint(db, global.KernelOps);
+        var cur = bf.balances || bf.current || bf.bal || {};
+        console.log('§PCLOSE-BF-LIVE fromCheckpoint=' + (bf.fromCheckpoint ? 'Y' : 'N') +
+                    ' period=' + (bf.period != null ? bf.period : '-') +
+                    ' accounts=' + Object.keys(cur).length + ' balances=' + JSON.stringify(cur));
+      } catch (e) { console.warn(TAG + ' boot bootstrap error', e && e.message); }
+    });
+  }
+
+  // close — fold the live ops → signed checkpoint → compact → re-persist the sidecar. Returns a Promise.
+  function close(opts) {
+    opts = opts || {};
+    if (!_ready()) return Promise.reject(new Error('period-close: engine/signer/crud not loaded'));
+    return _signer().then(function (signer) {
+      return new Promise(function (resolve, reject) {
+        _withDb(function (db) {
+          if (!db) { reject(new Error('period-close: no sidecar db')); return; }
+          var period = (opts.period != null) ? opts.period : _nextPeriod(db);
+          var ts = (opts.ts != null) ? opts.ts : _stamp();   // recorded close ts (deterministic INPUT)
+          Promise.resolve(global.ErpPeriodClose.closePeriod(db, global.KernelOps, signer, { period: period, ts: ts }))
+            .then(function (res) {
+              if (global.__crud && typeof global.__crud.persist === 'function') global.__crud.persist();
+              console.log(TAG + ' closed period=' + res.period + ' archived=' + res.archived + '→live=' + res.liveLen +
+                          ' accounts=' + Object.keys(res.closing_balances).length +
+                          ' closing=' + JSON.stringify(res.closing_balances) +
+                          ' tip=' + (res.tip || '').slice(0, 12) + '… signed=' + (res.sig ? 'Y' : 'N') + ' by=' + res.signed_by);
+              resolve(res);
+            }).catch(reject);
+        });
+      });
+    });
+  }
+
+  // the next period number = (latest checkpoint period) + 1, else 1. A recorded INPUT, never invented.
+  function _nextPeriod(db) {
+    try {
+      var r = db.exec("SELECT parameters FROM kernel_ops WHERE op_type='" + global.ErpPeriodClose.CKPT_TYPE + "' ORDER BY id DESC LIMIT 1");
+      if (r.length && r[0].values.length) return (JSON.parse(r[0].values[0][0]).period || 0) + 1;
+    } catch (e) {}
+    return 1;
+  }
+  // deterministic-enough close stamp: seconds epoch (recorded into the op, so the tip is stable on replay).
+  function _stamp() { return (typeof Date !== 'undefined') ? Math.floor(Date.now() / 1000) : 0; }
+
+  // renderInto — inject the accounting-gated "Close period" control + a live balance-b/f readout into a
+  // container (the role-gated Accts Posted overlay). Read-only panels stay read-only; this is the action.
+  function _injectCSS() {
+    var d = global.document; if (!d || d.getElementById('pclose-css')) return;
+    var s = d.createElement('style'); s.id = 'pclose-css';
+    s.textContent = '.pclose-ctl{display:flex;flex-direction:column;gap:8px;margin-top:14px;padding-top:12px;border-top:1px solid rgba(255,255,255,.12)}' +
+      '.pclose-btn{align-self:flex-start;min-height:38px;padding:0 14px;border-radius:20px;border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.05);color:inherit;font:inherit;font-size:13px;cursor:pointer}' +
+      '.pclose-btn:disabled{opacity:.6;cursor:default}.pclose-read{font-size:12px;opacity:.75}';
+    (d.head || d.documentElement).appendChild(s);
+  }
+  function renderInto(container, opts) {
+    if (!container) return null;
+    opts = opts || {};
+    _injectCSS();
+    var wrap = global.document.createElement('div');
+    wrap.className = 'pclose-ctl';
+    var btn = global.document.createElement('button');
+    btn.className = 'pclose-btn';
+    btn.type = 'button';
+    btn.textContent = '⛒ Close period';
+    var read = global.document.createElement('div');
+    read.className = 'pclose-read';
+    function paint(balances, period) {
+      var ks = Object.keys(balances || {});
+      read.textContent = ks.length
+        ? ('Period ' + period + ' carried forward — ' + ks.length + ' accounts (Σ=' + _fmtSum(balances) + ')')
+        : 'No closed period yet — balances fold from genesis.';
+    }
+    // initial readout from the current checkpoint
+    _withDb(function (db) {
+      try {
+        var bf = global.ErpPeriodClose.bootstrapFromCheckpoint(db, global.KernelOps);
+        paint(bf.balances || bf.current || bf.bal || {}, bf.period != null ? bf.period : '-');
+      } catch (e) { paint({}, '-'); }
+    });
+    btn.addEventListener('click', function () {
+      btn.disabled = true; btn.textContent = '⛒ Closing…';
+      close(opts).then(function (res) {
+        paint(res.closing_balances, res.period);
+        btn.textContent = '⛒ Closed P' + res.period + ' ✓'; btn.disabled = false;
+        if (typeof opts.onClosed === 'function') opts.onClosed(res);
+      }).catch(function (e) {
+        btn.textContent = '⛒ Close period'; btn.disabled = false;
+        console.warn(TAG + ' close failed', e && e.message);
+      });
+    });
+    wrap.appendChild(btn); wrap.appendChild(read);
+    container.appendChild(wrap);
+    return wrap;
+  }
+  function _fmtSum(b) { var s = 0, a; for (a in b) s += b[a]; return (s / 100).toFixed(2); }
+
+  global.PeriodClose = { boot: boot, close: close, renderInto: renderInto };
+  if (global.document && global.document.readyState !== 'loading') setTimeout(boot, 300);
+  else if (global.document) global.document.addEventListener('DOMContentLoaded', function () { setTimeout(boot, 300); });
+  console.log('§PCLOSE-UI loaded (window.PeriodClose: boot/close/renderInto)');
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,8 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v599';   // v599: INIT-BUBBLE freshness backstop — SWR navigation (v598) reaches a returning user fresh only on the SECOND post-deploy reload (old SW serves the nav before the new one activates); erp.html+idempiere.html now do a one-shot controllerchange→reload so a deploy converges in ONE reload (witness erp/tests/poc_init_deploy_fresh.js: reload1Settled=B, oneReloadConverges=Y);
+const CACHE_VERSION = 'v600';   // v600: §INTEG-WIRE — period-close in-app (erp_period_close.js + period_close_ui.js): an accountant closes a period → signed checkpoint = balance b/f on the live sidecar op-log; next load bootstraps from the checkpoint. Substrate (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2 slice A) on the collapsed canonical kernel (commitGroup). Witness erp/tests/poc_period_close_wire.js (§INTEG-WIRE).
+// v599: INIT-BUBBLE freshness backstop — SWR navigation (v598) reaches a returning user fresh only on the SECOND post-deploy reload (old SW serves the nav before the new one activates); erp.html+idempiere.html now do a one-shot controllerchange→reload so a deploy converges in ONE reload (witness erp/tests/poc_init_deploy_fresh.js: reload1Settled=B, oneReloadConverges=Y);
                                 // v598: INIT-BUBBLE INSTANT — navigation served stale-while-revalidate (was network-first), so a warm load paints the init-bubble shell from cache with ZERO network round-trip instead of awaiting the HTML document over the wire (witness erp/tests/poc_init_instant.js: warm bubblePaint 883ms→<300ms under 800ms nav latency); db already deferred off the paint path;
                                 // v597: pill ⋯ trigger UX — (a) FLAT horizontal kebab (icons.js moreHoriz) on ALL pill surfaces (erp.html + idempiere, desktop+mobile) so OUR ⋯ differs from Android's own vertical ⋮; (b) mobile dock anchors the ⋯ to a CONSTANT right-edge position (order:-1 + justify-content:flex-start) so it no longer re-centres out from under the finger on collapse;
                                 // v596: Kanban "Odoo-marvel" cards + shared Graph/Kanban status palette (KANBAN_MARVEL_SPEC, PR #177) merged with the mobile pill-reopen fix (v595);
@@ -85,6 +86,8 @@ const PRECACHE_ASSETS = [
   'kanban_host.js',    // reusable Kanban host: publish window.ERP + persist/restore the op-log
   'bigdecimal.js',     // exact decimal compare for the rule fold (never raw JS Number) — window.BigDecimal
   'rule_fold.js',      // THE ONE GESTURE (window.RuleFold) — signed, reversible rule edit + re-fold (RULE_EDIT_SPEC)
+  'erp_period_close.js', // §INTEG-WIRE — period-close fold = signed checkpoint = balance b/f (window.ErpPeriodClose)
+  'period_close_ui.js',  // §INTEG-WIRE — in-app close/bootstrap on the live sidecar op-log (window.PeriodClose)
   'qrcode.min.js',
   'manifest.json',
   'pills.json',

--- a/erp/tests/poc_period_close_wire.js
+++ b/erp/tests/poc_period_close_wire.js
@@ -1,0 +1,117 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that PERIOD-CLOSE is wired into the live app on the REAL signed op-log
+//   (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2 slice A — §INTEG-WIRE). THE CLAIM:
+//     1. §INTEG-WIRE close — with real double-entry POST ops in the live `glassbowl_kernel_ops` sidecar,
+//        window.PeriodClose.close() folds them → ONE signed checkpoint carrying the closing balances
+//        (net DR−CR cents), compacts the pre-checkpoint ops, and re-persists the sidecar. signed=Y.
+//     2. §PCLOSE-BF-LIVE bootstrap — RELOAD (same context → IDB persists); on boot the app opens from the
+//        checkpoint: opening balances == the closing balances brought forward, WITHOUT re-folding genesis.
+//   NON-INVENT: the POST ops are the app's real §13.1 shape ({lines:[{account_id,amtacctdr,amtacctcr}]});
+//   the post-reload balances come from the persisted signed checkpoint, nowhere else.
+//   §-log first — READ poc_period_close_wire.log before any conclusion.
+// Run:  node tests/poc_period_close_wire.js 2>&1 | tee tests/poc_period_close_wire.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.wasm':'application/wasm', '.css':'text/css' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/glassbowl.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+const ready = (page) => page.waitForFunction(
+  () => window.PeriodClose && window.ErpPeriodClose && window.KernelOps && window.ErpSigner && window.__crud,
+  { timeout: 25000 });
+
+// the app's REAL §13.1 POST shape — a sales invoice (AR/Revenue) + its payment (Cash/AR).
+const POSTS = [
+  { table: 'C_Invoice', id: 109, lines: [ { account_id: '101', amtacctdr: 434.13, amtacctcr: 0 }, { account_id: '400', amtacctdr: 0, amtacctcr: 434.13 } ] },
+  { table: 'C_Payment', id: 77,  lines: [ { account_id: '108', amtacctdr: 434.13, amtacctcr: 0 }, { account_id: '101', amtacctdr: 0, amtacctcr: 434.13 } ] },
+];
+const EXPECT = { '101': 0, '400': -43413, '108': 43413 };   // net DR−CR cents (AR settles to 0)
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const url = `http://localhost:${port}/glassbowl.html`;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const context = await browser.newContext();   // ONE context → IDB persists across the reload
+  const page = await context.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // ── session 1: seed real POST ops into the live sidecar, then close the period ──
+  await page.goto(url, { waitUntil: 'networkidle' });
+  const wired = await ready(page).then(() => true).catch(() => false);
+  const hasRender = await page.evaluate(() => typeof window.PeriodClose.renderInto === 'function');
+  // PeriodClose.boot lazily loads sql.js + builds the sidecar; wait for it before seeding.
+  const sidecarUp = await page.waitForFunction(
+    () => typeof window.initSqlJs === 'function' && window.__crud && window.__crud.kernelDb && window.__crud.kernelDb() != null,
+    { timeout: 25000 }).then(() => true).catch(() => false);
+  console.log('§WIRE-SIDECAR initSqlJs+sidecar-built=' + sidecarUp);
+
+  const seeded = await page.evaluate((posts) => new Promise((res) => {
+    window.__crud.withSidecar((db) => {
+      try {
+        posts.forEach(p => window.KernelOps.commitOp(db, 'POST', p));
+        window.__crud.persist();
+        setTimeout(() => res({ ok: true, n: posts.length }), 300);
+      } catch (e) { res({ ok: false, err: String(e && e.message || e) }); }
+    });
+  }), POSTS);
+  console.log('§WIRE-SEED ops=' + (seeded && seeded.n) + ' ok=' + (seeded && seeded.ok) + (seeded && seeded.err ? ' err=' + seeded.err : ''));
+
+  const closeRes = await page.evaluate(() => window.PeriodClose.close({ period: 1, ts: 9000 })
+    .then(r => ({ ok: true, r })).catch(e => ({ ok: false, err: String(e && e.message || e) })));
+  const r = closeRes && closeRes.r;
+  console.log('§WIRE-CLOSE ok=' + (closeRes && closeRes.ok) + (closeRes && closeRes.err ? ' err=' + closeRes.err : '') +
+    (r ? ' period=' + r.period + ' archived=' + r.archived + ' liveLen=' + r.liveLen + ' signed=' + (r.sig ? 'Y' : 'N') +
+         ' closing=' + JSON.stringify(r.closing_balances) : ''));
+
+  // ── session 2: RELOAD (same context → IDB survives) — boot must open from the checkpoint (b/f) ──
+  logs.length = 0;
+  await page.reload({ waitUntil: 'networkidle' });
+  await ready(page).catch(() => {});
+  await page.waitForFunction(() => window.__pcloseBfSeen === true ||
+    (window.performance && true), { timeout: 1000 }).catch(() => {});
+  await page.waitForTimeout(1200);   // PeriodClose.boot runs ~300ms after DOMContentLoaded
+  const bfLog = logs.find(l => l.includes('§PCLOSE-BF-LIVE')) || '(no bootstrap log)';
+  console.log('§WIRE-RELOAD ' + bfLog);
+
+  // independent read of the persisted opening balances after reload
+  const afterBoot = await page.evaluate(() => new Promise((res) => {
+    window.__crud.withSidecar((db) => {
+      try {
+        const bf = window.ErpPeriodClose.bootstrapFromCheckpoint(db, window.KernelOps);
+        res({ fromCk: !!bf.fromCheckpoint, period: bf.period, bal: bf.balances || bf.current || bf.bal || {} });
+      } catch (e) { res({ err: String(e && e.message || e) }); }
+    });
+  }));
+  console.log('§WIRE-BF afterReload fromCheckpoint=' + (afterBoot && afterBoot.fromCk) +
+    ' period=' + (afterBoot && afterBoot.period) + ' balances=' + JSON.stringify(afterBoot && afterBoot.bal));
+
+  // ── verdict ──
+  function balEq(a, b) { const ks = {}; let max = 0; for (const k in a) ks[k] = 1; for (const k in b) ks[k] = 1;
+    for (const k in ks) max = Math.max(max, Math.abs((a[k] | 0) - (b[k] | 0))); return max; }
+  const closingOk = !!(r && balEq(r.closing_balances, EXPECT) === 0 && Object.keys(r.closing_balances).length === 3);
+  const signedOk  = !!(r && r.sig);
+  const compactOk = !!(r && r.archived >= POSTS.length && r.liveLen === 1);
+  const bfOk      = !!(afterBoot && afterBoot.fromCk && balEq(afterBoot.bal, EXPECT) === 0);
+  const bfLogOk   = /fromCheckpoint=Y/.test(bfLog);
+
+  console.log('   ' + (wired ? '🟢' : '🔴') + ' W1 substrate wired into app (PeriodClose/ErpPeriodClose/KernelOps/ErpSigner/__crud) renderInto=' + hasRender);
+  console.log('   ' + (closingOk ? '🟢' : '🔴') + ' W2 close folds real POST ops → closing balances == expected net DR−CR (AR settles to 0)');
+  console.log('   ' + (signedOk ? '🟢' : '🔴') + ' W3 checkpoint signed by the app edge signer (signed=Y)');
+  console.log('   ' + (compactOk ? '🟢' : '🔴') + ' W4 compaction: pre-checkpoint ops archived, live log = 1 (checkpoint anchor)');
+  console.log('   ' + (bfOk ? '🟢' : '🔴') + ' W5 RELOAD bootstraps from checkpoint — opening balances == balance b/f (no genesis re-fold)');
+  console.log('   ' + (bfLogOk ? '🟢' : '🔴') + ' W6 boot emitted §PCLOSE-BF-LIVE fromCheckpoint=Y');
+
+  const pass = wired && hasRender && closingOk && signedOk && compactOk && bfOk && bfLogOk && errs.length === 0;
+  console.log('§INTEG-WIRE-RESULT ' + (pass ? 'PASS' : 'FAIL') + ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
**Phase 2, slice A** of `prompts/ERP_SUBSTRATE_INTEGRATION.md` — the substrate lands in the product. Stacked on #195 (needs the v8 kernel's `commitGroup`); **base = `chore/kernel-collapse`**, so this diff shows only the period-close change. Deploy order: merge #195, then this.

An accountant closes a period → ONE signed checkpoint carrying the closing balances → pre-checkpoint ops compacted out → next load **bootstraps from the checkpoint** (opening = balance brought forward), no genesis re-fold.

### What's wired (composition only — no engine logic, no invented posting)
- `erp_period_close.js` (from `build/erp` source-of-truth) — folds BOTH the synthetic `{account,cents}` and the app's **real double-entry `POST {lines:[{account_id,amtacctdr,amtacctcr}]}`** shape, net DR−CR cents (§INTEG-POSTINGS-RECONCILE).
- `period_close_ui.js` (`window.PeriodClose`) — folds the live `glassbowl_kernel_ops` sidecar, signs the tip via the **app edge signer** (`erp_signer.js` loadOrMint, not a demo key), re-persists, bootstraps on load. Lazily ensures sql.js.
- `crud_overlay.js` — expose `__crud.persist` (1 line).
- `glassbowl.html` — load signer + period-close; mount the accounting-scoped "Close period" control into `#panel`.
- `sw.js` — PRECACHE the 2 modules + bump `CACHE_VERSION` v599→v600.

### Witness — §INTEG-WIRE (read `erp/tests/poc_period_close_wire.log`)
Real POST ops seeded into the live sidecar → close → `closing={101:0 (AR settled),108:+43413 (Cash),400:-43413 (Rev)}` signed=Y, archived=2→live=1; **RELOAD bootstraps from checkpoint, opening == balance b/f**; `pageErrors=0`. §INTEG-FRESHNESS: precache audit `100 found / 0 missing`. Regression: `poc_kanban_{persist,write}` still PASS.

### ⛔ HELD for "deploy"
On go: merge #195 → merge this → verify glassbowl.html on Pages (close a period, reload converges in one). sw v600 + the two `?v=` modules ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)