### PR TITLE
feat(erp): period-close in-app + evaluator comparison paper (→ main)

### DIFF
--- a/erp/BIMERPPaper.md
+++ b/erp/BIMERPPaper.md
@@ -1,0 +1,265 @@
+# The Construction Economy Is About To Get Hit By an ERP Expert
+
+<div class="bim-banner" markdown>
+<b>Academic paper — applying 30 years of ERP to construction.</b> What Autodesk and Primavera should have done together, from the architect of ADempiere and iDempiere.
+</div>
+
+*What Autodesk and Primavera should have done together, but i can't wait.*
+
+**Redhuan D. Oon**
+ADempiere (2006) | iDempiere (2010) | Author, *Open Source ERP* (2010) | BIM5D (2025)
+
+red1org@gmail.com | [LinkedIn](https://www.linkedin.com/in/red1oon/)
+
+**Open Source Repositories:**
+
+| Repository | What's There |
+|-----------|-------------|
+| [BIMCompiler](https://github.com/red1oon/BIMCompiler) | The compiler, BIM COBOL verbs, BIM Designer, Back Office — this paper's subject |
+| [Federation](https://github.com/red1oon/IfcOpenShell/tree/feature/IFC4_DB/src/bonsai/bonsai/bim/module/federation) | FederatedModel powering IFC as a spatial model inside Bonsai/Blender |
+| [Terrain Topology](https://github.com/red1oon/IfcOpenShell/tree/feature/IFC4_DB/src/bonsai/bonsai/bim/module/federation/pdf_terrain) | Terrain mesh mapper for survey data, contour generation, cut-and-fill |
+| [River IoT](https://github.com/red1oon/IfcOpenShell/tree/feature/IFC4_DB/src/bonsai/bonsai/bim/module/federation/river) | IoT sensor framework for environmental and infrastructure monitoring |
+
+March 2026
+
+---
+
+## 1. The Problem Nobody Has Solved
+
+Construction is the world's largest industry that still cannot answer a simple question deterministically: *given this building design, what exactly do I need to buy, where does each piece go, and can I prove it?*
+
+Design tools (Revit, ArchiCAD, Bonsai) produce geometry. ERP systems (SAP, Oracle, iDempiere) manage procurement. Between them sits a manual, error-prone gap where quantity surveyors extract Bills of Materials from drawings by hand. This gap is estimated to cost the industry billions annually in rework, over-ordering, and undetected non-compliance.
+
+The gap persists because design software treats buildings as geometry problems, while ERP treats products as data problems. No widely-adopted open-source tool has built the bridge — a deterministic compiler that reads one and writes the other.
+
+This paper describes a working system that does exactly that.
+
+## 2. The Insight: A Building Is a Manufactured Product
+
+In 2006, we built ADempiere's manufacturing BOM module. In 2010, we rebuilt it for iDempiere. After two decades of watching M_Product, M_BOM, and C_Order handle everything from circuit boards to furniture assemblies, the realisation was unavoidable:
+
+**A building is just a very large manufactured product with spatial coordinates.**
+
+Every wall panel is an M_Product. Every floor plan is an M_BOM (assembly recipe). Every construction project is a C_Order. The only thing manufacturing MRP lacks is the *where* — the (x, y, z) coordinates that turn a flat bill of materials into a three-dimensional building.
+
+We call this **Spatial MRP**: Material Requirements Planning extended with tack offsets — parent-relative coordinates (dx, dy, dz) on each BOM line that tell the compiler exactly where each child element sits relative to its parent.
+
+This is not a metaphor. The data model is structurally identical to iDempiere's manufacturing module, extended with three integer columns per BOM line (see `docs/DATA_MODEL.md`).
+
+## 3. What the Compiler Does
+
+The BIM Intent Compiler reads an IFC building model (the international standard for building data) and produces a factorised Bill of Materials mapped to ERP procurement tables — deterministically, reproducibly, and with mathematical proof at every step.
+
+**Input:** An IFC file. The largest tested model contains 48,428 elements across 8 engineering disciplines — architecture, structural, fire protection, HVAC, electrical, curtain wall, sprinklers, and LPG (see `docs/TerminalAnalysis.md`).
+
+**Output:** A 700-line BOM that expands back to those 48,428 placements. A 73:1 compression ratio. Each line is a recipe (product x quantity x position formula), not a placed instance. The compiler *expands* recipes into placements at compile time — the same operation an ERP system performs when it explodes a manufacturing BOM into work orders.
+
+**Pipeline:** Nine stages — validate metadata, parse DSL, compile geometry, apply templates, write output, execute domain verbs, compute digest, verify geometry, prove placement (see `docs/SourceCodeGuide.md` §Pipeline).
+
+**The Prime Rule:** *Extract or compile only.* Every coordinate in the output traces to either an extracted IFC position (via IfcOpenShell) or a computed tack offset from BOM formulas. Nothing is invented. This is the compiler's most important property, and it is enforced by six verification gates (see §4).
+
+## 4. How We Know It Works
+
+Claims without proof are marketing. This system is built on proof.
+
+**Six verification gates** run on every compilation:
+
+| Gate | What It Checks |
+|------|----------------|
+| G1-COUNT | Element count in output matches BOM expansion |
+| G2-VOLUME | Aggregate volume within tolerance |
+| G3-DIGEST | SHA256 spatial fingerprint is reproducible |
+| G4-TAMPER | No hardcoded coordinates, no weakened tests |
+| G5-PROVENANCE | Every output element traces to a source |
+| G6-ISOLATION | No cross-contamination between buildings |
+
+**196 witness assertions** — machine-checkable claims, each running as a JUnit test. Example: *"W-ROUTE-SP-1: sprinkler spacing >= 3000mm in TE storey 2."* A failing witness blocks the compilation gate. These are not unit tests in the conventional sense — they are executable specifications that prove construction compliance (see `docs/TestArchitecture.md`).
+
+**A tamper seal** — SHA256 fingerprints of 68 critical files. If a developer weakens a test to make it pass, the seal breaks, requiring a re-seal ceremony with full git diff review. This prevents the most insidious form of regression: tests that evolve to match broken code.
+
+**Rosetta Stone buildings** — real IFC models compiled as reproducible benchmarks:
+
+| Building | Checks Passing | Domain |
+|----------|---------------|--------|
+| Sample House (SH) | 9/10 | Residential |
+| Duplex (DX) | 7/10 | Multi-unit residential |
+| Terminal (TE) | 8/10 | Commercial (airport) |
+| Bridge (BR) | 10/10 | Infrastructure |
+| Road (RD) | 4/4 | Infrastructure |
+| Rail (RL) | 4/4 | Infrastructure |
+
+Element counts: see [PROGRESS.md](https://github.com/red1oon/BIMCompiler/blob/master/PROGRESS.md).
+
+*Checks = 6 gates (G1-G6) plus gate-specific sub-checks (e.g. G5-PROVENANCE has 7 internal checks). A building with 6/6 gates passing may still have sub-check debt. See `docs/TestArchitecture.md` for per-gate breakdown.*
+
+These numbers are not cherry-picked. DX scores 7/10 because the MIRROR verb (for mirrored duplex halves) is incomplete. TE's G2-VOLUME tolerance is 13.7%, not zero, because CLUSTER verb offset tables use +/-10% tolerance for semi-regular grids. We publish the failures alongside the successes (see `docs/PROGRESS.md`).
+
+## 5. BIM COBOL: A Domain Language for Construction
+
+Every building mutation passes through a named, auditable verb. We call this **BIM COBOL** — not because it resembles COBOL syntax, but because it serves the same purpose: a domain-expert-readable language where a fire engineer can read `ROUTE SPRINKLERS SPACING 3000mm` and verify compliance without reading Java.
+
+77 verbs are implemented. The five that matter most:
+
+| Verb | What It Does | Coverage |
+|------|-------------|----------|
+| TILE | Lays a 2D grid (floor tiles, ceiling panels, roof sheets) | 74.4% of Terminal's 48K elements |
+| ROUTE | Runs MEP piping/ducting along a path | Sprinklers, drainage, HVAC |
+| CLUSTER | Groups semi-regular elements (tolerance-based) | Dominant in infrastructure |
+| FRAME | Places structural members with LBD alignment | Columns, beams, bracing |
+| ARRAY | Lays a 1D linear sequence | Fence posts, bollards, sleepers |
+
+Each verb produces a typed `VerbResult` — success/failure, witness proof, and payload. No anonymous SQL. No silent geometry mutations. Full audit trail via W_Verb_Node, iDempiere's production order pattern (see `docs/BIM_COBOL.md`).
+
+## 6. The BIM Designer: Compilation as User Interface
+
+Most BIM tools let users draw geometry directly. This system does the opposite: the user chooses parameters, and the compiler builds.
+
+**Architecture:** A TCP server (Java, port 9876) serves a Blender addon (Python) via ndjson protocol. The Blender side is deliberately thin — it renders what the compiler produces. All logic lives in Java. All data lives in SQLite. This is the "Java-smart, Python-dumb" principle (see `docs/BlenderBridge.md`).
+
+**What works today (408/414 tests passing, 42 test classes):**
+
+- **Snap-to-room placement** — user selects a product from the catalog, compiler validates it fits (dimensions, clearance, discipline rules) and places it at the correct tack offset
+- **Assembly builder** — layer-by-layer wall/roof/floor composition with thermal U-value calculation per BS EN ISO 6946. Swap a layer, and the parent AABB and U-value recalculate automatically (see `docs/ASSEMBLY_BUILDER_SRS.md`)
+- **Variant save/recall** — every design state is a C_Order snapshot in output.db (compile DB). Compare variants side-by-side. Undo via changelog replay. Save persists to .blend file
+- **Infrastructure terrain snap** — four modes (ON_SURFACE, ABOVE, BELOW, PIER) on real survey data (689 points, 294m x 229m, 20m elevation band). Cut-and-fill volumetrics with grading strategy. Alignment model for road/rail curvature (see `docs/INFRA_DESIGNER_SRS.md`)
+- **Product catalog** with deterministic similarity ranking — no AI, no embeddings, just feature vectors over known attributes
+- **Jurisdiction-scoped validation** — rules per building code (currently MY/UBBL, 30 rules), enforced at placement time via AD_Val_Rule, iDempiere's validation rule pattern
+
+**What's still batch-mode:** The Blender integration currently requires a full recompile after each edit. Real-time incremental update (G-8 on the roadmap) is architecturally prepared — file watchers and scope detectors exist — but the pipeline does not yet support partial-stage entry. This is a significant gap between the current prototype and a production-grade interactive editor.
+
+## 7. Multi-User Back Office and ERP Reporting
+
+Construction projects have many stakeholders reading the same data differently. A project manager wants a Gantt chart. A cost consultant wants a 5D breakdown. A sustainability officer wants embodied carbon. A facilities manager wants a maintenance schedule. An auditor wants a change log.
+
+The Back Office module (BIMBackOffice, ~3,000 LOC Java, separate HTTP server on port 9877) serves all of them from the same compiled data:
+
+**Session management:** Token-based (UUID), 30-minute timeout, per-database write locks (ReentrantLock), SQLite WAL mode for concurrent reads. `whoIsEditing()` detects when two users target the same building — conflict detection, not resolution. This is single-JVM, single-server. No distributed locking. No clustering. Honest about the scale it handles today.
+
+**Report engine (4D-7D), each a DAO reading the same BOM data:**
+
+| Dimension | What It Reports | Source Pattern |
+|-----------|----------------|----------------|
+| 4D Schedule | Construction sequence, Gantt tasks, labour-days by trade | ScheduleDAO — phase-sequence grouping (not CPM/PERT) |
+| 5D Cost | 3-component breakdown: material + labour + equipment | CostDAO — CIDB Malaysia 2024 rates |
+| 6D Sustainability | Embodied carbon (kgCO2e/m2), material passport | SustainabilityDAO — carbon map from component library |
+| 7D Facility Mgmt | Maintenance schedule, lifecycle cost, asset register | FacilityMgmtDAO — COBie-compatible structure |
+
+**Portfolio and governance:**
+
+- **Cross-project portfolio** — scans all `*_BOM.db` files, aggregates cost, carbon, schedule, maintenance across buildings and infrastructure
+- **Kanban board** — workflow cards grouped by DocStatus (DR/IP/CO/AP), following iDempiere's document lifecycle (see `docs/DocAction_SRS.md`)
+- **Balanced scorecard** — 4 perspectives (Financial, Client, Process, Learning) x 3+ KPIs
+- **Audit trail** — ChangelogDAO logs every PLACE/DELETE/MOVE/RESIZE with old/new values, supports undo. Mirrors iDempiere's AD_ChangeLog
+
+**ERP pattern fidelity:** This is not a BIM tool pretending to be ERP. The data model *is* ERP. C_DocType routes building types. DocStatus governs lifecycle. AD_Val_Rule scopes validation by jurisdiction. W_Verb_Node records verb execution. AD_PrintFormat configures output selection. Every table name, every column convention, every lifecycle state comes from iDempiere's dictionary (see `docs/DATA_MODEL.md` §1).
+
+**What's not here yet:** Role-based access control (AD_Role). PDF/CSV export. Report execution queue (AD_Process). Multi-currency cost rates. COBie MVD schema validation. These are roadmap items — the ERP patterns they follow are well-understood from two decades of iDempiere, but the construction-specific implementation is not yet written.
+
+## 8. Standards, Compliance, and Inter-Discipline Coordination
+
+Construction compliance is not optional. Buildings must meet fire codes, structural standards, accessibility requirements, and energy regulations — and these differ by jurisdiction.
+
+**How this system handles it:**
+
+- **Disciplines are metadata, not code branches.** The same BOM walker processes all 8 disciplines (ARC, STR, FP, ACMV, ELEC, SP, CW, LPG). What differs is the AD_Val_Rule set activated per discipline and jurisdiction. Adding a discipline means inserting rows, not writing code (see `docs/BOMBasedCompilation.md` §Disciplines).
+
+- **Validation is three-tiered:**
+  1. **BomValidator** — structural integrity (9 pre-commit checks: orphan lines, AABB envelope, tack non-negative, extraction reconciliation)
+  2. **PlacementValidator** — compliance thresholds (room minimum size, ceiling height, door width — scoped by jurisdiction)
+  3. **InferenceEngine** — rule chaining with dependency cascades (if a parent rule fails, child rules are skipped, not falsely passed)
+
+- **Jurisdiction scoping via AD_Val_Rule:** Currently Malaysian UBBL (30 rules). The target is 200+ rules across 6 jurisdictions (SG, UK, AU, US, EU, HK). Each jurisdiction is a set of AD_Val_Rule rows with threshold parameters — not a code branch. The architecture is proven; the rule population is the work ahead.
+
+- **IFC version bridging:** A 4-tier alias cascade in ERP.db resolves IFC2x3's generic classes (IfcFlowTerminal) to IFC4's specific classes (IfcOutlet) — 84 alias rows covering 85% of MEP element names. New IFC types are added via INSERT into `ad_ifc_class_map` (46 rows), not code changes (see `docs/DISC_VALIDATION_DB_SRS.md`).
+
+- **Calibration against real buildings:** CalibrationDAO compares rule predictions (what the validator *thinks* should be placed) against actual engineer decisions extracted from the Terminal model (what *was* placed). This grounds the rules in professional practice, not just regulatory text (see `docs/CALIBRATION_SRS.md`).
+
+## 9. One Year of Development: Honest Accounting
+
+This system was built over approximately 40 working sessions spanning 12 months (2025-2026), producing roughly 20,000 lines of Java across 4 Maven modules, backed by 196 passing witness assertions and 280+ JUnit tests.
+
+**What made this pace possible:**
+
+The architecture — the recognition that IFC elements map structurally to ERP product lines — comes from 20 years of building and maintaining iDempiere's manufacturing BOM module. This is not a fresh insight arrived at by studying BIM; it is a pattern recognised by someone who has written M_BOM code for two decades and then looked at a building.
+
+Claude Code (Anthropic's AI coding assistant) served as pair-programming partner throughout, handling implementation mechanics — DAO boilerplate, test scaffolding, SQL migration scripts, documentation — while the author directed architecture, domain mapping, and verification strategy. The AI accelerated implementation roughly 3-5x but did not originate the domain architecture. An AI coding assistant without the ERP domain background would produce a geometry tool, not a Spatial MRP compiler.
+
+**What exists today:**
+
+| Component | LOC | Tests | Status |
+|-----------|-----|-------|--------|
+| DAGCompiler (11-stage pipeline) | ~5,000 | 58 tests (G1-G6 gates) | Production-grade for tested buildings |
+| BIM COBOL (verb engine) | ~3,000 | 27 tests | 77 verbs, 202 witnesses |
+| IFCtoBOM (extraction pipeline) | ~3,000 | 10 tests | SH, DX migrated; TE transitioning |
+| BonsaiBIMDesigner (GUI server) | ~8,500 | 408 tests (42 classes) | Design mode functional |
+| BIMBackOffice (ERP reporting) | ~3,000 | 14 tests | Portfolio, 4D-7D, sessions |
+
+**What does not exist yet:**
+
+- No building above 50K elements has been tested (target: 500K)
+- No production ERP write-back (iDempiere REST integration is Phase H)
+- No role-based access control or multi-tenant deployment
+- No real-time interactive editing (batch recompile only)
+- No round-trip proof (compile → re-extract → compare)
+- No certified COBie or regulatory submission output
+- No multi-currency or internationalised cost model
+- Incremental compilation is stubbed, not wired
+- DX mirror verb is incomplete (7/10 gates)
+
+## 10. Roadmap: From Proof to Platform
+
+**Near-term (in progress):**
+- CP-1: TE per-element traceability (closes the 48K-element verification gap)
+- CP-2: DX MIRROR verb completion
+- G-8: BlenderBridge real-time snap (batch → interactive transition)
+
+**Medium-term (ERP maturity):**
+- Phase BO-3..5: Report queue, PDF/CSV export, role-based access
+- Phase J: 6 jurisdiction codes, 200+ compliance rules, regulatory templates
+- Phase H: iDempiere REST integration — live ERP write-back of C_Order + C_OrderLine
+
+**Longer-term (platform):**
+- Phase R: 500K-element stress testing, batch extraction of 50+ IFC models
+- Phase RE: Multi-format report engine (JSON/CSV/XLSX/IFC/iDempiere)
+- Phase D: Synthetic Rosetta Stone — round-trip compilation proof
+- Multi-user WebSocket, distributed sessions, clustered deployment
+
+**The competitive moat is data-driven extensibility.** New IFC types, new validation rules, new jurisdictions, new disciplines, new verb patterns — all added via INSERT, not code. The authority tables (ad_ifc_class_map, AD_Val_Rule, verb formulas) replace hard-coded enumerations with database records. This is the iDempiere philosophy applied to construction: the application dictionary *is* the application.
+
+---
+
+## Appendix: Reference Documentation
+
+| Document | Contents |
+|----------|----------|
+| `docs/BOMBasedCompilation.md` | Master specification: tack convention, BOM hierarchy, discipline routing |
+| `docs/TestArchitecture.md` | G1-G6 gates, tamper seal, traceability matrix, anti-drift policy |
+| `docs/BIM_COBOL.md` | Verb grammar, VerbResult contract, compilation targets |
+| `docs/DATA_MODEL.md` | Per-building schema, tack columns, world reconstruction formula |
+| `docs/SourceCodeGuide.md` | Code navigation, entry points, module structure |
+| `docs/BIM_Designer.md` | GUI architecture, compile-driven editing, generative path |
+| `docs/ASSEMBLY_BUILDER_SRS.md` | Layer-by-layer TACK, U-value calculation, 17 witnesses |
+| `docs/INFRA_DESIGNER_SRS.md` | Terrain snap, alignment model, cut-and-fill, 38 witnesses |
+| `docs/MANIFESTO.md` | iDempiere mapping, C_Order model, ERP pattern fidelity |
+| `docs/DocAction_SRS.md` | Document lifecycle (DR->IP->CO->AP), discipline routing |
+| `docs/DISC_VALIDATION_DB_SRS.md` | Three-database split, alias cascade, IFC version bridging |
+| `docs/CALIBRATION_SRS.md` | Rule prediction vs actual placement, ground truth metrics |
+| `docs/TerminalAnalysis.md` | 48K-element analysis, verb factorisation, discipline coverage |
+| `docs/InfrastructureAnalysis.md` | Bridge/road/rail compilation, domain-agnostic proof |
+| `docs/archive/CORE_SRS.md` | (Archived) Scale targets, report engine — superseded by ACTION_ROADMAP + StrategicIndustryPositioning |
+| `docs/StrategicIndustryPositioning.md` | IFC scorecard (31/36), competitive analysis, 4 moats |
+| `docs/ACTION_ROADMAP.md` | Phase gates G-1 through G-13, critical path items |
+| `docs/TIER1_SRS.md` | 4D-7D reporting, audit trail, 3D native |
+| `PROGRESS.md` | Current session state, witness counts, pass rates |
+
+---
+
+*This paper describes working software, not a proposal. The source code, test results, and compilation databases are available for inspection. Claims are bounded by the evidence presented — where something is planned but not built, it is labelled as such.*
+
+*Development assisted by Claude Code (Anthropic). Domain architecture by the author.*
+
+---
+
+Copyright 2025-2026 Redhuan D. Oon. All rights reserved. This paper may be freely distributed for academic, research, and conference purposes with attribution. The software described herein is open source under GPL v2.
+
+*Copyright (c) 2025-2026 Redhuan D. Oon. MIT Licensed.*

--- a/erp/DistributedERP.md
+++ b/erp/DistributedERP.md
@@ -1,0 +1,577 @@
+# Distributed ERP — Contention Map & Guards
+
+**Thesis.** The "hard distributed-systems problem" in ERP is **mostly a modelling artifact.** Model the
+domain as it physically is — goods have a *location*, work has an *owner*, money moves at the *cadence of
+atoms* — and contention dissolves for ~90% of usage, collapses to a daily pipeline for ~10%, and reduces to
+**one genuinely real-time op-class** (customer-global entitlements). None of it needs a fat always-on server.
+
+Companion to [ERP.md §0.20](ERP.md#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet)
+(secured/durable phase) and [LocalFirstPriorArt.md](LocalFirstPriorArt.md) (comparison of related systems).
+This doc is the architecture under test — each scenario below was worked through against the residuals in §8,
+which the ledger reconciles. Beneath the mechanics sit the truths in §0,
+from which the whole design falls out. SPEC, 2026-05-31 (consolidated rev).
+
+---
+
+## 0. The two truths — and the root beneath them
+
+This doc is the *mechanics*. They are not assumed; they were derived. Each section below is one truth at work.
+
+**The root truth.** *The fact is a fold over a signed sequence — never a stored, guarded scalar.*
+`QtyOnHand` is not a cell you mutate; it is `Σ` of movements (`M_Transaction`), exactly as a trial balance
+is `Σ` of journal entries. The authoritative number is **derived**, never held. The instant you model a
+derived quantity as a shared mutable cell (`UPDATE qty = qty - 1`) you *invent* the contention you then have
+to solve. Delete the scalar; keep the fold; the contention was never real.
+
+From that root, four working truths (candidate mantras — wording for `CLAUDE.md` pending ratification, §11):
+
+1. **Deterministic. Non-invent. Extract.** *(computation)* — state is a pure function of the ordered,
+   recorded inputs; nothing computed that isn't replayable. **This makes the holder irrelevant:** any
+   replica replays to the same number. (The existing prime directive — here it is *infrastructure*, §7.)
+2. **Not real-time — business-time.** *(cadence)* — the fold reconciles at the cadence the business actually
+   runs (close-of-day, overnight, next-day), not in microseconds. *The business sets the clock, not the
+   system;* real-time is the **degenerate case** (the one indivisible op-class, §5) where the business demands
+   instant.
+3. **Secure the fact, not the container.** *(trust)* — a fact signed at its point of origin is authentic
+   *anywhere*, so it needs no trusted store. Durability attaches to what the user already keeps (their
+   email/social, §5.2b); the guarantee-regress (back up the backup of the backup…) **terminates**, because
+   every durable thing is either the user's own pre-existing channel or reconstructible from self-securing
+   facts.
+4. **The system can't prevent — only witness.** *(the floor)* — fraud/overspend is **not solvable** (CAP in a
+   partition; the offline witness; the bearer token; the lying insider — impossibility, not bugs). Every
+   system that claims to "solve" it is secretly doing record-and-consequence and charging for the costume. So
+   we don't pay to prevent the unpreventable — we **witness** it cheaply (signed chain), **record** it
+   permanently (the ledger), and **consequence** it (blacklist/receivable). *We reduced the cost of a
+   non-solution.*
+
+**Two keystones bind them:**
+- *Determinism earns business-time* — because each site is deterministically exact **locally**, deferring the
+  **global** fold to close-of-day loses nothing; the sum is identical whenever computed. (1 makes 2 safe.)
+- *Self-securing facts terminate the regress* — determinism makes a fact's *value* portable and signing makes
+  its *authenticity* portable, so the fact can live anywhere durable; no server of record is needed. (1+3.)
+
+### From server to serverless — what moved where (explain it to yourself)
+
+"Serverless" is **not** "no machine ever talks to another." It is **no *server of record*** — no machine
+that *owns the truth*. Every job a classic ERP server did still happens; each moved off the server onto
+either the **signed log**, the **deterministic kernel on each client**, the **user's own channel**, or a
+**dumb facilitator** that owns nothing. The mapping — each line proven (proof in the right column):
+
+| What a server used to do | Now done — without a server of record | Proof |
+|---|---|---|
+| Hold the authoritative state | the **signed op-log**; state = its deterministic *fold*, recomputable by anyone | §0 root · `poc_distributed.js` |
+| Mint record IDs (DocNo) | **edge-minted UUID** recorded as an op input — unique without coordination (G-IDENTITY) | `poc_distributed.js` (no clash) |
+| Run business logic / validate | the **deterministic kernel on every client** — same verbs both sides, no server re-run | `erp_kernel.js` (replay-hash) |
+| Merge concurrent edits | **union signed logs → total-order → replay** → identical state everywhere | `poc_distributed.js` |
+| Prevent conflicts / double-write | **owner-gate** (G-SINGLE-WRITER) + **CAS** for the one op-class — enforced on replay | `poc_distributed.js` |
+| Detect tampering | the log **hash-chains itself**; `verifyChain()` finds the altered op | `poc_chain.js` · live `kernel_ops.js` |
+| Authenticate / authorise | **edge signature** (W-SIGN) — wrong key fails anywhere; holder can present, not forge | `poc_sign.js` |
+| Durably store / back up | the **user's own email/social** + export; the local copy is disposable | `poc_persist.js` |
+| Sequence multi-party order | a **dumb facilitator** (accept + order + persist + relay), daily — itself rebuildable from signed logs | §6 |
+| Reconcile discrepancies | the **ledger** (double-entry, 1494) — the fact is a fold here too | §8 |
+| Be always-on | **nothing** — work offline; sync at business-time | Truth 2 |
+
+**The analogy that grounds it: git.** No central machine owns your code history — every clone holds it all,
+can verify it, can rebuild from it; GitHub is a *convenience*, not the truth (lose it → push to a new host
+from any clone, nothing lost). Commits are **hash-chained** (= W-CHAIN) and can be **signed** (= W-SIGN).
+Git is a serverless-*of-record* distributed system millions use daily. **This project does to ERP
+transactions what git did to source code:** the log is the truth, the host is disposable, history is chained
+and signable. The one thing git lacks that we add — *invariant enforcement* (no double-spend) — is the
+owner-gate + the single CAS op-class. Everything else, git already proves is possible.
+
+**Measured witness:** [DepreciationPerf.md](DepreciationPerf.md) puts numbers on this mapping with a real
+iDempiere batch (40-year asset depreciation): where the server's ~20 min actually goes (per-row `saveEx` =
+~1M round-trips, not the maths), a four-tier comparison, and the honest counter-hype — *most* of the speed is
+a server-side SQL rewrite; SQLite-WASM's real edge is **no server + local reads**, not raw throughput.
+
+The rest is these truths meeting concrete scenarios — the normal multi-POS day (§3), the adversarial edges
+(§9), and how it compares to related systems (§10).
+
+---
+
+## 1. The 90/10 reframe
+
+- **~90% of ERP is single-writer/owned** — a sales order belongs to a rep, a PO to a buyer, a pick to a
+  worker. No concurrency challenge at all. The real businesses *dispatch* work to exactly one person.
+- **~10% is the "100 branches → central" case** — and it is **not** multi-master concurrency. It is a
+  **one-way trip circle**: branches → central (sales/orders up) → `QtyOnHand` + replenishment → branches
+  (stock/POS down). Overnight, directed. An op-log handles this natively as **deterministic fan-in →
+  deterministic fan-out** (push branch logs up, total-order + replay → exact state, derive replenishment
+  ops, push down). No conflict resolution.
+- **The only genuine all-round-sync need** is a single indivisible thing claimed in real time across sites
+  — e.g. a loyalty prize claimed at two branches the same day. That is **one op-class** (§5), not a
+  property of the whole system.
+
+---
+
+## 2. Physics partitions the data — the granularity ladder
+
+Contention over goods is solved not by an algorithm but by **atoms having a location.** Single-writer is
+enforced by the physical world at every granularity:
+
+| Granularity | Owner | Why no contention |
+|---|---|---|
+| **Branch** | the shop | a shop's stock is physically *in that shop* (`M_StorageOnHand` per `M_Locator`/`Org`) — another branch cannot ship it |
+| **Van** (DSD / van-sales) | the salesperson | each van loaded at depot in the morning (fan-out); its stock is physically the salesperson's |
+| **Box-in-hand** | whoever holds it | **you cannot scan a box that isn't physically there** — the scan *is* proof-of-possession and the commitment op; two people can't scan the same physical unit |
+
+**Cadence matches physics.** Goods move next-day at fastest, so the data only needs **daily** consistency.
+Real-time global inventory sync solves a problem physics doesn't pose — you can't get a unit from another
+branch faster than a transfer anyway. Overnight batch is therefore the *correct* cadence, not a tolerated
+limitation: the book catches up with the atoms at the rate the atoms travel.
+
+**The scan is the op.** `SCAN(unit_SSCC → customer, qty, ts)` — the barcode/SSCC is the unit's natural
+**UUID** (global identity handed over by GS1; FKs reference it). Scan data is captured as an *input* in the
+op, never recomputed → replay stays deterministic.
+
+---
+
+## 3. Normal operation — a multi-POS day, end to end
+
+Edge cases (§9) are the minority. The **common** case is handled natively by single-writer-by-physics (§2) +
+deterministic backflush + the one-way circle — *no special machinery.* Walk a real day:
+
+**One till, one shop (the 90%).** A sale is one op — `SELL(item, qty, ts)` — committed locally; the
+projection updates at 0ms. Component consumption is **backflushed**: the BOM recipe is exploded
+*deterministically* (`SELL burger → −1 bun, −1 patty, …`), never recorded line-by-line. `QtyOnHand` is the
+fold over `M_Transaction`. Entirely offline-capable; the device is the whole system.
+*(Backflush **is** deterministic replay of the recipe — the same BOM verb that compiles a building, run at
+point of sale. Truth 1.)*
+
+**Two tills, one shop.** Each till owns its own sales; two sales are appends to disjoint positions — the logs
+**union trivially**, `OnHand` is the fold of both, no contention (*the fact is a fold, not a scalar*). The
+*only* contended case — two tills, the genuine last unit — is a **local LAN single-writer** decision
+(sub-millisecond, §9-D), not a distributed problem.
+
+**Multi-branch (the 10% — the one-way circle).** Branches sell all day against their own physical stock
+(provisional, local, instant). **Close-of-day:** each branch pushes its signed log up to the dumb post office
+(§6), which assigns total order + persists. **Overnight:** deterministic replay → exact consolidated state →
+derive replenishment ops (reorder where below min) → fan out down. **Next day:** receipts restock the branch
+locator; selling resumes. Directed, daily, no multi-master, no conflict resolution.
+*(Truth 2 — the replenishment fact is **produced after** the day's sales reconcile; it cannot exist sooner.)*
+
+**Van / DSD.** Loaded at depot in the morning (fan-out); its stock is physically the salesperson's
+(single-writer by possession); each `SCAN(SSCC → customer)` is the commitment op (you can't scan a box you
+don't hold); settlement at end-of-day reconciles the van.
+
+In every normal flow the pattern is identical: **append a signed op where you physically stand; the fold
+computes the number; reconcile at business cadence.** Nobody writes a shared scalar; nothing blocks on the
+network; the post office only sequences and relays. The edges in §9 are exactly the residue this leaves —
+bounded, named, and ledger-backed.
+
+> **Worked examples — [the Lens Family](LensFamily.md).** This doctrine made concrete, extracted from my iDempiere
+> Unicenta POS + plugins and ported to browser lenses over the one model: [POS](POSLens.md) (in-person sale) ·
+> [WMS / Logistics / Robots](WMSLens.md) (movement) · [Social Platform](SocialPlatformLens.md) (on-the-move) ·
+> [Credit Ledger](CreditLedgerLens.md) (receivables) · [Workforce](WorkforceLens.md) (attendance/tasks) ·
+> [Guaranteed Channels](GuaranteedChannels.md) (transport/payment pipes). Hub: **[LensFamily](LensFamily.md)**.
+> One source act, the rest a fold, no central control — a business run from a phone. The smallest complete proofs of
+> the doctrine above.
+
+---
+
+## 4. The fundamental guard set
+
+Invariants the system enforces so contention is structurally impossible for the common case:
+
+| Guard | Invariant | Kills |
+|---|---|---|
+| **G-IDENTITY** | every entity = global UUID PK (edge-minted, recorded as an op input); FKs → UUID; human handle = `user/date/doc/#` per-*device* (gapless in its own namespace, unique without coordination) | PackIn/merge clashes; centralised DocNo allocation |
+| **G-EXCLUSIVE-DISPATCH** | a work item is delivered to **exactly one** writer (queue, not broadcast) | two clients ever receiving the same order |
+| **G-SINGLE-WRITER** | at any instant **≤1 owner** (device/session, not human) may emit mutating ops on an entity; others read-only; non-owner ops rejected on replay | concurrent writes to one doc |
+| **G-RESERVATION** | consuming a shared pool requires a lease granted **at dispatch** (online); offline work stays inside the envelope | pooled-resource contention (where stock isn't physically partitioned) |
+| **G-ORDERED-HANDOFF** | ownership transfers only via an explicit **ordered** handoff op — never a two-owner window | hand-off races |
+| **G-LEASE-EXPIRY** | unexercised ownership/reservation expires after N and returns to pool; expiry is itself an ordered op | a device offline for a week locking resources forever |
+| **G-READ-ANYWHERE-WRITE-OWNER** | reads replicate freely (stale snapshots ok); writes are owner-gated | read/write coupling |
+
+**Architecture:** *avoid by ownership (primary)* — G-EXCLUSIVE-DISPATCH + G-SINGLE-WRITER + physical
+location cover ~all normal flow → no contention, no rollback. *Resolve by total-order (fallback)* — the
+dumb async broker (§6) only for the rare uncontainable edge. Belt **and** suspenders.
+
+---
+
+## 5. The one real-time op-class — customer-global entitlements
+
+The *customer* is the only entity that can be "in two branches at once," so loyalty prizes / gift balances /
+coupons / **credit** are the single op-class needing more than ownership + daily cadence. Full lifecycle,
+pure OOTB (no fat server):
+
+1. **Issue = a URL.** Mint a merchant-**signed** token (customer/limit/validity), encode as URL/QR, deliver
+   (SMS/WhatsApp/QR), customer's browser persists it as a wallet entry (their op-log). Reuses existing
+   `share.js` / QR (`BarcodeDetector`) / PWA machinery — *proven already: our `?tm=play` share-URL replays an
+   instance on any device (server effect, no server). Add a signature and it carries credit, not just a view.*
+   Two flavors:
+   - **Self-contained URL** → *zero-server issuance* (merchant signs locally).
+   - **Activation link** → one narrow `DateLastUsed`-style touch so a link can't mint infinite cards.
+2. **Carry = signed op-log on the customer's phone.** The customer is their own single-writer. The token is
+   **merchant-signed + hash-chained** (= `§0.20` W-SIGN/W-CHAIN) so the holder can *present* but not
+   *forge* it — they don't hold the signing key.
+2b. **Persist & recover = the user's own email / social account** (zero-infra durability — resolves the
+   §0.20 W-PERSIST eviction worry). Each use emits a **signed email** (a full signed snapshot of the latest
+   count, or a hash-chained delta) to the customer's own inbox. **The inbox is a durable, user-owned,
+   append-only, tamper-evident log** — already universal, already backed up, accessible from any device.
+   **Recovery:** lost phone/PWA → the new PWA reads the customer's **latest email** and restores the count.
+   No server owns the data — *the user's own channel does* (Truth 3). The email is an **untrusted pipe**: a
+   forged email body simply fails signature verification, so the pipe needs zero trust. (Caveats: pick the
+   chain tip by signed `seq`/`prev_hash`, not arrival order; send a **full signed snapshot per email** for
+   single-email recovery robustness; encrypt-to-user for privacy. "Email receipt" is old — "**inbox as the
+   recoverable signed state-log**" is the fresh framing.)
+3. **Claim/spend:**
+   - **Online (normal POS):** sub-second authority **compare-and-set** (set-if-unset) → first-wins. Same
+     weight as a card-payment auth — not a burden. (A plain `DateLastUsed` *read* is best-effort only — two
+     branches can read "unused" before either writes; CAS is the hard guarantee.)
+   - **Offline (CAP edge):** choose by value × frequency — **high-value → block** ("confirming…", like an
+     offline card decline); **low-value → allow + reconcile.** For *credit*, an offline overspend simply
+     becomes a larger **receivable** — accounting-native, not an error state.
+4. **Reconcile = the ledger** (§8).
+
+**Bearer vs bound (honest caveat):** a URL is a bearer token. **Promo → bearer** (forwarding = viral
+coupon, desirable). **Personal credit → bind on first open** (sign to the customer's device/public key, or
+one activation touch) or forwarding = giving away the credit line.
+
+**Scan unification:** QR = URL made physical → scanning a customer's QR at POS reads their entitlement, the
+*same gesture* as scanning a box. One scan model: goods (SSCC → which unit) and customers (token → who/what
+credit).
+
+---
+
+## 6. How much central persistence? — a dumb async post office
+
+Because clients **deterministically replay** the ordered log to identical state, the central thing runs
+**no business logic.** It is a **facilitator, not an actor.** It does three things (the ActiveMQ job):
+**accept** ops (append-only), **assign a total order** (the one thing that must be centralised), **persist
+durably + fan out**. A Kafka/ActiveMQ-class **log broker**, not a server-side ERP. It doesn't know what an
+invoice *is*. It never re-runs business logic, never validates semantics, never signs — *signing is at the
+edge (the merchant's key), enforcement is the deterministic kernel on every client (non-owner ops rejected on
+replay).*
+
+| Mode | Central post office needed? |
+|---|---|
+| Single user / one device | **No** — device + export/backup is the whole system; cloud = optional backup |
+| Multi-device / durability / 100-branch circle | **Yes — only the dumb broker** (order + persist + relay), run **daily** |
+| Contended invariants (rare; only where stock isn't physically partitioned) | the broker's total order **is** the serialization point — no separate locks; loser of true contention gets a *deterministic, explainable* correction (e.g. backorder), not an arbitrary overwrite |
+
+The post office wears a second hat for the entitlement op-class: a **sub-second matchmaker** for the online
+CAS (a compare-and-set register over an opaque token — still facilitation, not business logic). That is the
+*only* always-fast online need; everything else is daily. **Even the post office is disposable:** because
+every op is signed + hash-chained, the total order is reconstructible from the collected signed logs
+(`prev_hash` encodes order) — lose the broker and the union of clients'/emails' logs rebuilds it.
+
+### 6.1 The centralized-ID problem, in one place
+
+Classic ERP centralises identity allocation: a single sequence service (`AD_Sequence`) hands out primary
+keys and gapless document numbers, which forces an always-available coordinator. That requirement is split
+into three parts here, only one of which needs any centralisation:
+
+1. **Primary-key identity is fully decentralised.** Each entity's PK is an **edge-minted UUID**, recorded as
+   an op input (G-IDENTITY, §4; implemented per
+   [ERP.md §0.21](ERP.md#021-g-identity-wired-into-the-kernel--identity-is-an-input-never-computed-2026-06-01-spec--identity)).
+   Two devices mint without coordination and their logs union with no clash
+   ([poc_distributed.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_distributed.js)).
+2. **Total order is the one part that is centralised — minimally.** Ordering across parties is assigned by
+   the dumb facilitator (above), which runs no business logic and is itself reconstructible from the signed
+   logs. It sequences; it is not an authority.
+3. **The gapless human document number is a per-device namespace.** The sequential identifier users expect
+   (e.g. `INV-2026-0001`) is issued as `user/date/doc/#` within each device's own namespace — gapless in that
+   namespace, unique across devices without coordination — and is distinct from the global UUID PK. No shared
+   counter is required.
+
+So the only centralised function is sequencing, and even that is rebuildable offline. Identity allocation,
+the part that classically forces a coordinator, requires none.
+
+---
+
+## 7. Determinism is load-bearing (not just nice)
+
+The dumb-broker model only works if **clients converge from the ordered log** — so *any* nondeterministic
+verb (a live FX/rate lookup, an uncaptured clock read, a re-rolled random) breaks it. The prime directive
+(deterministic, non-invent, extract-or-compile-only) therefore stops being a virtue and becomes
+**infrastructure**: determinism is *what lets the server be dumb and the clients agree.* Practical rule
+(already enforced in our runtime): nondeterministic values (UUIDs, timestamps, scanned codes, external
+rates) are **generated at the edge and recorded as inputs in the op** — the kernel only ever *reads* them,
+never computes them. Use **UUIDv7** for identity (timestamp-sortable + collision-safe via the random tail;
+a millisecond alone is *not* a uniqueness guarantee). *Witness: `replay-hash == live-hash` — proven in
+`scripts/erp_kernel.js` / `poc_kernel.js` / `poc_longtail.js` on the sql.js (browser) binding.*
+
+---
+
+## 8. Capstone — accounting *is* the reconciliation engine
+
+We don't need perfect real-time distributed consistency, because **accounting was invented to reconcile
+imperfection.** Double-entry bookkeeping (Pacioli, 1494) is the original eventually-consistent log — five
+centuries of provisions for shrinkage, bad debt, overages, disputed claims, double-payouts. So a local-first
+ERP's job is **not** to prevent every discrepancy in real time (CAP says you can't) — it is to **feed clean,
+ordered, signed ops into the system already designed to reconcile discrepancy.** The op-log and the ledger
+are the same instinct, 500 years apart — both are *folds over an append-only log*: `OnHand = Σ M_Transaction`
+is the same shape as `Balance = Σ journal`. **Accounting reconciles because it never stored a balance either.**
+
+Every residual in this doc resolves there: a double-claim → flagged at month-end, promo-expensed; a credit
+overspend → a receivable; a phantom scan → a van shortage the salesperson is liable for. **Common in the
+real world; provisioned; not a showstopper.** And our ordered, hash-chained log makes every such case *more*
+auditable than a centralised system (full lineage, deterministic first-wins, no quiet overwrite).
+
+---
+
+## 9. Edge scenarios — the adversarial suite
+
+The normal day (§3) leaves a bounded residue. Each row names the issue it proves/disproves, the truth/guard
+that carries it, the acceptance witness, and the **honest residual**. (This consolidates the former
+"residuals" list — every item below is on the list, none is a blocker.)
+
+### A. Durability & loss
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| Browser eviction (Safari ~7-day) | T3 / W-PERSIST | self-securing log + email durability; `navigator.storage.persist()` requested on first load | `persisted=true`; export→wipe→import → `replay-hash == pre-export hash` | shared browser limitation — mitigated, not eliminated |
+| Lost phone / local copy | T3 | recover from latest **signed email snapshot** → replay to identical state | new PWA reads latest email → count restored | email-account loss is a risk the user **already** carries; we inherit it, never manufacture a new one |
+| Lost sequencer / post office | T1 + T3 | total order reconstructible from collected signed ops (`prev_hash` encodes order) | rebuild order from union of signed logs → same hash | the logs must be gathered; a *convenience* is lost, not the truth |
+
+### B. Forgery & authenticity
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| **False email / URL / data** | T3 / W-SIGN | container untrusted **by design**; only signed content verifies | forged body fails signature under issuer key → rejected | none beyond key custody (below) |
+| Signing-key theft / custody | T3 | the **one irreducible anchor**; secure-enclave + rotation | — | irreducible — true for *every* system (steal a server's key too) |
+| Bearer token forwarded | §5 / T3 | bind-on-first-open for personal credit; bearer is fine for promo/view | forwarded credit fails device-bind check | promo forwarding is *desirable* (viral coupon) |
+| Tampered local log | W-CHAIN | hash-chain; `verifyChain()` detects tamper at op N | alter op N → chain breaks **at exactly N**; clean → `chain OK len=N` | detection, **not** prevention — by design (the floor) |
+
+### C. Freshness / double-spend (the one real-time op-class, §5)
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| Replay a genuine token (claim twice) | §5 / T2 | online **CAS** set-if-unset, first-wins | 2nd claim sees spent → rejected, no double payout | needs the sub-second touch — the *one* online need |
+| Two branches read "unused" before either writes | §5 | **CAS**, not a plain `DateLastUsed` read | first CAS wins | — |
+| Offline overspend window | §5.3 / T4 | value-tiered: high-value **block**, low-value **allow + reconcile** | overspend → **receivable**, not an error | bounded residual → the ledger (the floor) |
+
+### D. Ownership / contention
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| Doc edit across a handoff (two-owner window) | G-ORDERED-HANDOFF / G-SINGLE-WRITER / W-OWNER | ownership transfers only via an **ordered handoff op**; designated-owner node at the seam | two peers allocate the same invoice → owner rejects the 2nd, no money lost | concentrated at **few seams**, not per-collection |
+| Device offline a week holding a lock | G-LEASE-EXPIRY | lease expires after N, returns to pool; expiry is itself an ordered op | unexercised lease → reclaimed | generous leases + provably-unexercised expiry |
+| Two tills, the genuine last unit | (local) | **local LAN single-writer**, sub-ms | — | not distributed — a local problem |
+| In-transit ownership (truck A→B) | (movement) | iDempiere in-transit locator / `M_Movement` confirm-both-ends | shipped-not-received accounted in the daily reconcile | the daily reconcile must carry it |
+| Pooled resource (stock not physically partitioned) | G-RESERVATION | lease granted at dispatch (online); offline stays inside the envelope | — | lease-expiry oversell — rare in retail |
+
+### E. Determinism integrity
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| Nondeterministic verb creeps in (live FX / clock / random) | T1 / §7 | values generated at edge, **recorded as op inputs**; kernel only reads; UUIDv7 | `replay-hash == live-hash` holds | failure mode = divergence breaks merge → the prime directive is *infrastructure*, not style |
+| Identity collision on merge | T1 / G-IDENTITY | **edge-minted UUID PK** (not numeric seq); identity is an op input | two devices' logs union with **no PK clash** | Implemented in the kernel ([ERP.md §0.21](ERP.md#021-g-identity-wired-into-the-kernel--identity-is-an-input-never-computed-2026-06-01-spec--identity), witness `§IDENTITY` / [poc_identity.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_identity.js)): natural-key `docKey`/`lineKey` retired; replay re-reads recorded ids (`edgeMintCalls=0`) |
+| Schema migration to N offline clients | (shared hard) | compiled-AD **manifest** + forward-only / frozen-effects replay | old ops replay to original effect (frozen) | an open problem across the category; partial mitigation only |
+
+### F. The irreducible (the floor — Truth 4)
+| Scenario | Truth / § | Mechanism | Acceptance witness | Honest residual |
+|---|---|---|---|---|
+| Insider fraud (the **key-holder** lies) | T4 / §8 | double-entry + physical reconciliation; the hash-chain makes it *more* auditable | the lie must be told consistently across **all** books → caught at count | not crypto's job — accounting's |
+| Cloned / printed barcode (scan without the box) | T4 | caught at van settlement + accounting | — | shrinkage/fraud, *not* a distributed problem |
+| The unsolvable residual (CAP partition; offline witness) | T4 | **record + consequence + price-in** | — | **not solvable** — we reduced the *cost of the non-solution* |
+
+---
+
+## 10. Comparison with related systems
+
+Detailed in [LocalFirstPriorArt.md](LocalFirstPriorArt.md); summarised here. A recurring constraint in
+local-first systems is that server and client run different code, which leads implementations to hand-code
+conflict logic, overwrite optimistic state, or implement business logic twice. The approach here —
+deterministic semantic verbs, with one kernel on both sides — avoids that constraint. The table states each
+system's approach, its documented limitation, and the corresponding difference here; sources are cited in
+[LocalFirstPriorArt.md](LocalFirstPriorArt.md).
+
+| System | Approach | Documented limitation | Difference here |
+|---|---|---|---|
+| [Replicache](https://doc.replicache.dev/) | server re-runs mutations as the authority | the server may not compute the same result, so optimistic state can be overwritten; conflict logic is per-mutator; no zero-server mode (a backend of authority is required) | determinism removes the divergence case; offline-only operation is supported |
+| [ElectricSQL](https://electric-sql.com/) | read-path sync; writes go through the application's own API | bidirectional sync documented as "fundamentally difficult"; reads sync from Postgres, writes go through a separate API — two disjoint paths, no unified write model | the op-log is symmetric — push-ops are the read-ops; one model, no Postgres coupling |
+| [PowerSync](https://powersync.com/) | Postgres→SQLite; writes routed through the backend | the backend is the write authority (default last-write-wins); write-side business logic and conflict policy live server-side, not symmetric or offline-authoritative | the deterministic kernel is the write path, authored once and run on both sides |
+| [LiveStore](https://livestore.dev/) | event-sourced, SQLite-materialised (the nearest neighbour) | beta; requires a sync provider; no built-in auth; documented scale and P2P limits | identical at the data layer (no technique novelty); the difference is at the application level (combined BIM and ERP, AD→5-table reduction) |
+| CRDTs ([Automerge](https://automerge.org/)/[Yjs](https://yjs.dev/)) | guaranteed convergence with no referee | per the literature, cannot enforce invariants that depend on the latest version; no access control | only a degenerate CRDT is needed (grow-only op-set + total order + replay); invariants are enforced by the deterministic kernel, not the CRDT |
+
+**Reconciliation cost.** Because a fact is a fold over an append-only log, a merge is
+`union → verify signatures → order → replay`. For single-writer cases (≈90%) it is trivial (disjoint
+entities); for derived quantities it is addition (a PN-counter); for the one contended op-class it uses
+total order plus owner-gating — the same server-authoritative sequencing the CRDT literature prescribes for
+invariant-bearing state. The cost: determinism must hold exactly (the prime directive), semantic seams still
+require an owner node (few, not per-type), and schema migration remains an open problem (shared across the
+category).
+
+**Limits on novelty claims.** SQLite-in-WASM (sql.js, 2012; official WASM/OPFS, 2022; wa-sqlite) is
+established. Local-first as a category (LiveStore, ElectricSQL, Replicache, RxDB) is established
+([ERP.md §0.20](ERP.md#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet):
+no novelty on the mechanism). "Replace any database app" would be incorrect: full-dataset download, browser
+eviction, unbounded scale, and built-in auth are documented limits, and this is not intended for multi-TB
+analytics or high-concurrency OLTP at scale. SQLite-WASM, local-first, op-logs, CRDTs, and hash-chains are
+all prior work, not contributions of this project.
+
+**What is specific to this project — to the authors' knowledge, a combination rather than a technique**
+(consistent with [ERP.md §0.20](ERP.md#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet);
+the absence of prior art cannot be proven):
+1. **BIM geometry + ERP transactions under one op-log / one kernel** (BIM undo == ERP audit) — no prior art found.
+2. **The domain reduction** — iDempiere AD (925 tables, `M*` classes) → **5 tables + deterministic verbs**.
+3. **The doctrine** (§0) — fact-is-a-fold, secure-the-fact, business-time, the non-solution floor — a coherent
+   serverless-ERP *stance*, not a tech first.
+
+---
+
+## 11. What infrastructure is actually required
+
+**No fat always-on server.** The complete tested architecture needs only:
+1. **Per-shop / per-van / per-box single-writer** — free from physical ownership + `M_Locator`.
+2. **A thin async post office** (order + persist + relay), run **daily** — the one-way trip circle. *(And even
+   it is disposable — reconstructible from signed logs, §6.)*
+3. **A sub-second touch** for the *one* customer-global op-class (online CAS), high-value only.
+4. **Signed, hash-chained logs** (W-CHAIN/W-SIGN) — justified concretely by credit-on-phone.
+5. **The user's own email / social account** as zero-infra durable persistence + recovery (§5.2b).
+6. **The ledger** — doing the reconciliation job it has done since 1494.
+
+> **Second mantra (proposed — wording to be ratified before it enters `CLAUDE.md`).** The prime directive
+> governs *computation* — *"Deterministic. Non-invent. Extract."* This architecture adds three more governing
+> *cadence, trust, and the floor* (§0): **(2) Not real-time — business-time. (3) Secure the fact, not the
+> container. (4) The system can't prevent — only witness; we reduced the cost of a non-solution.** Candidate
+> short forms for the persistence/ownership axis: *"Data is truth; the signed log is trust; the user holds
+> both."* / *"User-owned. Server-less. Ledger-reconciled."* / *"No server of record — the user's own log is."*
+> Keystones: *determinism earns business-time*; *self-securing facts terminate the regress*.
+
+**Sources / cross-refs:** [ERP.md §0.20](ERP.md#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet)
+(phase + witnesses W-CHAIN/SIGN/PERSIST/OWNER) ·
+[LocalFirstPriorArt.md](LocalFirstPriorArt.md) (Replicache/ElectricSQL/PowerSync/LiveStore/CRDTs, per-system
+analysis) · [scripts/erp_kernel.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/erp_kernel.js)
++ [poc_kernel.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_kernel.js)
++ [poc_longtail.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_longtail.js)
+(`replay-hash == live-hash`, browser binding) · [SpatialERP_OOTB.md §11.5](SpatialERP_OOTB.md) ·
+iDempiere `M_Transaction` / `M_StorageOnHand` / `M_StorageReservation` / `M_Movement`.
+
+### 11.1 The Disposable-Host paradigm — what it actually costs to run
+
+A standard corporate ERP install is **three always-on tiers, per tenant, 24/7**: an application
+server (ZK/OSGi/JVM), a database server (Postgres), and the surrounding cache/load-balancer/standby. That
+fleet is the dominant hosting line item, and it runs whether anyone is clicking or not.
+
+This architecture deletes that tier rather than renting it more cheaply. The compute moves *into the
+client* — the deterministic kernel over SQLite-WASM (§7, §0) — so the server side reduces to two things,
+both of which the doc has already shown are *disposable* (reconstructible from the signed logs, §6/§11):
+
+1. **Static object storage** for the signed log snapshot — a CDN/bucket object. Near-zero marginal cost,
+   scales for free, no process to keep alive. *(Witnessed live: the same signed snapshot served
+   interchangeably from GitHub raw, an OCI bucket, and localhost — `build/erp/replica_poc.html`,
+   `scripts/test_kernel_replica.js`; any reachable host replays to an identical, controller-signed chain
+   tip, so the host is genuinely interchangeable.)*
+2. **A thin "dumb post office" relay** (§6) — order + persist + relay only, no business logic — run
+   *intermittently*, not 24/7, and itself reconstructible from the logs. *(Witnessed:
+   `build/erp/erp_relay_server.js`, `scripts/test_kernel_relay.js` — idempotent ingest, convergence over
+   HTTP, durable restart.)*
+
+**Where the saving comes from — stated so a reader can check it, not asserted.** The reduction is bounded
+by *how much of a given bill is the always-on app+DB compute tier* — usually the majority. Eliminating it
+leaves static storage plus an intermittent relay, so an **order-of-magnitude (up to ~90%) cut is an
+architectural claim about removing that tier**, not a measured invoice — quote it as such. It is largest
+for the **~90% single-writer workload** (§1), which needs **no server at all** (one device, offline-first);
+it shrinks for the **~10%** that needs the relay and the *one* customer-global CAS touch (§5). What remains
+to pay: cheap static hosting, the intermittent relay, and that sub-second CAS for high-value global ops.
+
+**The interactive-speed half is a separate axis — don't conflate them.** Near-instant UI comes from two
+real removals: no per-interaction network round-trip (the kernel answers locally) and no server-rendered
+widget tree (HTML-native UI replaces the ZK round-trip "click tax", [ERP.md §4b](ERP.md#4b-html-native-ui-replacing-zk-patterns)).
+**Honest caveat (carried from §19.6 / the measured A-B):** our ~100× local throughput figure is *almost
+entirely the asynchronous-durability trade* (instant local append vs synchronous fsync/commit), **not**
+server-removal — server-removal only wins over a *network*. So: the **cost** win is the disposed compute
+tier; the **latency** win is local compute + no click tax; the **throughput** number is the durability
+trade. Three distinct claims, kept distinct.
+
+**Trade priced in, not hidden:** durability is *asynchronous* (Truth 2) — a write is durable when the log
+reaches a replica, not at keystroke. That is the one honest cost of having no always-on server of record,
+and the signed log + multi-replica publish (§5.2b, and the 3-host replica above) is how it is made safe.
+
+---
+
+## 12. Relationship to blockchain and to general-purpose sync
+
+**Blockchain: shared data structure, different problem.** This design uses blockchain's data structure — a
+hash-chained, signed, append-only log (W-CHAIN/W-SIGN) — but not its consensus machinery (proof-of-work or
+-stake, global replication, tokens). That machinery buys trustless agreement among mutually distrusting
+parties over a single global state. ERP does not pose that problem: physics partitions the writers (§2), the
+business sets the cadence (Truth 2), and accounting reconciles the remainder (§8). The signed append-only log
+is retained; the consensus layer is not required. The model is **trust-anchored local-first** (a signing key
+plus a sequencer), not trustless consensus — and **P2P-capable rather than P2P-dependent**: single-user is
+one device, multi-party exchange of signed logs is possible, and the facilitator (§6) is an optional relay. A
+closer analogy than blockchain is version control (git): a content-addressed, append-only history any
+participant can hold and reconcile.
+
+**Why general-purpose frameworks centralise more.** Replicache, ElectricSQL, PowerSync, and LiveStore build
+*general* sync infrastructure, where a server is genuinely necessary because a general tool cannot assume the
+domain partitions the data. This project is an *application* that uses domain-specific structure — location,
+ownership, cadence — to remove the parts a general tool must keep. The components involved (event-sourced
+SQLite, hash chains, CRDTs) are all established; the difference is the synthesis, not a new primitive (§10).
+
+**Scope of any novelty claim.** The technique is not novel (§10). What is specific to this project, to the
+authors' knowledge, is the combination: BIM geometry and ERP transactions under one op-log (BIM undo and ERP
+audit are the same mechanism), the design principles in §0, and a running substrate — a deterministic kernel,
+a real iDempiere AD extraction, and a BIM op-log. This is a claim about combination and placement, not about
+any underlying technique, and is stated subject to the limit that the absence of prior art cannot be proven.
+In summary: the ledger is an append-only log, and git and SQLite-WASM are long-established; the work here is
+the synthesis — applying that log structure to ERP transactions and BIM geometry under one kernel.
+
+---
+
+## 13. Sharding the engine by gravity — what arrives, and when (2026-06-01, SPEC)
+
+§2 partitions the **transaction data** by where atoms physically are. This section partitions the **engine
+itself** — the dictionary (925 AD tables → cells → verbs → FK spines, [ERP.md](ERP.md) §12) — for the client that must
+hold it. The two are **orthogonal axes of the same root** (§7, *identity/inputs recorded, never recomputed*):
+§2 is *where the goods are*, §13 is *which of the engine you've pulled down yet*.
+
+**The problem, stated honestly.** The full AD is too big to ship whole to a browser, and the naïve fix
+(stream every table) makes the first paint wait on the long tail. But you never need it whole *at once* —
+and the engine already tells you what matters: **op-log gravity** ([ERP.md](ERP.md) §0.6/§0.13/§0.17) self-ranks the
+cells by real mass (`C_Invoice` #1 = the settlement spine). So don't shard by schema; **shard by gravity**,
+and stream shards *on approach* — the same doctrine as BIM geometry DLOD, with one substitution.
+
+> **One streaming doctrine, two distance metrics.** Geometry streams by **camera distance** (DLOD / split-DB
+> / click-to-stream, S285 city). The engine streams by **op-log mass**. *Distance to the work* replaces
+> *distance to the eye.* That a single pattern serves both spatial-BIM and transactional-ERP is the §0.20
+> unification made operational — not a coincidence, the same op-log seen two ways.
+
+**The shard unit — a *single table, ranked by gravity* (smart per-table; the resolved fork).** Three
+granularities were on the table; the spectrum, and why per-table wins *once gravity is computed from real
+traversal*:
+
+| Granularity | What it is | Verdict |
+|---|---|---|
+| per-module | iDempiere's own packaging | Rejected — modules cut *across* gravity (one module mixes hot and cold cells), so pulling one hot cell over-fetches its cold module-mates |
+| per-gravity-band | a contiguous gravity slice plus its explicit 1-hop FK closure | Workable but coarser than needed: it bundles by hand a closure that gravity already encodes, shipping cold band-mates that may never be touched |
+| per-table, gravity-ranked | one AD table per shard, the manifest ordered by op-log gravity | **Chosen.** Finest grain, no over-fetch, and no dangling trace: gravity is itself a fold over op-log traversal, which crosses FKs, so a hot table's frequently-walked neighbours co-rank and arrive alongside it. The closure is implied by the ranking rather than added separately |
+
+**The key realization: gravity already *is* the closure.** Because the op-log records real journeys down the
+FK spines (§0.6/§0.13 — derivation green, settlement amber), a table and the neighbours actually traversed
+*from* it accrue mass **together**. So a per-table manifest sorted by gravity pulls the hot closure in
+naturally — the band machinery was solving a problem the gravity score had already solved. The rare,
+genuinely-cold FK is the *stub* case below, not a reason to coarsen the unit. This is the engine analogue of a
+DLOD level — "the N nearest tables," where *near* = op-log mass, not metres. **Tier 0 = the top-gravity
+tables** (`C_Invoice` #1, the O2C/P2P spine) — the prefetched `<300ms` `initbubble.json` ([ERP.md](ERP.md)
+instant-globe). The 155 dormant cold cells ([ERP.md](ERP.md) §0.11 *housed-vs-active*) sit at the bottom of the
+ranking — present in the manifest, **fetched only on touch**.
+
+**The manifest is a fold over the log (no new infrastructure, §6).** Gravity is an aggregation over
+`kernel_ops` (count / `grandtotal`, [ERP.md](ERP.md) §0.6 analytical substrate) — computed **offline, deterministically**
+(no `Date.now`/`Math.random`, §7). The shard manifest is just that fold — every table with its gravity rank.
+The **dumb post office** that already orders + persists + fans out the op-log (§6) serves the tables too:
+*pull = "give me table T."* No authority, no business logic server-side — and because the log is deterministic
+(§7), a client **verifies a shard's content hash against the ordered log** rather than trusting it. A shard is
+*checked, not believed* — the same stance W-CHAIN takes on ops (§9-B).
+
+**The fetch trigger — lazy, gravity-cached, with a feedback loop ([ERP.md](ERP.md) §0.10).** A table is pulled when the
+user *moves toward* a not-yet-resident cell: clicks a cold bubble, follows an FK spine into an unfetched table,
+or scans a code (§2 *the scan is the op*) that references a cold doc-type. Once fetched, a table stays resident
+and **its access bumps its own gravity** (the §0.6 op-log feedback loop) — so next session's tier 0 reflects
+*this* operator's real usage, not a static default. The cache warms toward the work.
+
+**The honest edge — a stub, never an invention.** An FK followed *before* its target table is resident draws a
+**stub bubble** (`cold — fetching`), not a guessed or stale value — extract-only, never-invent ([ERP.md](ERP.md) §0.17).
+The fetch resolves it in place. This is exactly S285's invisible-bbox frontier (place the marker, stream the
+content) carried onto the engine graph. **No silent truncation:** the stub is visible and logged, so "I
+haven't pulled that yet" can never masquerade as "that's all there is."
+
+**What this is and isn't.** It **is** a deterministic, gravity-ordered lazy-loader for an engine-as-data, on
+the infrastructure §6 already requires. It is **not** a new sync primitive (the §10/§12 honesty holds — DLOD,
+lazy-fetch, content-addressing are all mature); the distinctive move is the *substitution* — **op-log mass as
+the LOD metric for a business engine**, unifying the spatial and transactional loaders under one rule.
+**Witness (when built, mirroring the suite's discipline):** a `gravity_seed`-ranked per-table manifest whose
+tier-0 content-hash matches the prefetched globe; a cold-cell touch pulls exactly that table (its hot
+neighbours already co-resident **by rank**, not by an explicit closure — proving gravity self-bundles), with
+over-fetch counted = 0; an unresolved FK renders a stub (not a value); the resident set's replay-hash equals
+the full-engine replay-hash for every path actually walked. SPEC only — no code yet; T3-adjacent (it serves
+the read-only trace first, edit later).

--- a/erp/ERP.md
+++ b/erp/ERP.md
@@ -1,0 +1,2720 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+# ERP OOTB — iDempiere Application Dictionary in a Browser
+
+## Overview
+
+iDempiere's Application Dictionary (AD) is a metadata-driven UI framework:
+windows, tabs, fields, menus, validation rules, and display logic are stored
+as database rows rather than code. Editing a row in `AD_Field` changes the
+rendered UI with no recompilation.
+
+This document describes running the AD client-side. The AD metadata is
+exported from a live iDempiere PostgreSQL instance, loaded into SQLite via
+[sql.js](https://sql.js.org) (SQLite compiled to WebAssembly), and rendered
+by a JavaScript AD interpreter — with no JVM, PostgreSQL, OSGi, or server
+process. The construction-project bridge (`C_Project`, see
+[SpatialERP_OOTB.md](SpatialERP_OOTB.md)) is one menu node within the full
+AD tree. Scope and limits are stated in [§10](#10-scope-and-status) and the
+prior-art comparison in [DistributedERP.md §10](DistributedERP.md#10-comparison-with-related-systems).
+
+---
+
+## Companion documents (the ERP map)
+
+The secured/distributed thinking and its proofs live in dedicated sub-docs — read in this order:
+
+| Doc | What it holds |
+|---|---|
+| **[DistributedERP.md](DistributedERP.md)** | The contention map — the **two truths** + *server→serverless* mapping (§0), normal multi-POS day (§3), the guard set (§4), the one real-time op-class (§5), the **dumb facilitator** (§6), determinism (§7), accounting-as-reconciler (§8), the **edge-scenario adversarial suite** (§9), **how we differ on this turf** (§10), and **[sharding the engine by gravity](DistributedERP.md#13-sharding-the-engine-by-gravity-what-arrives-and-when-2026-06-01-spec)** (§13 — op-log mass as the LOD metric; what arrives, and when). |
+| **[LocalFirstPriorArt.md](LocalFirstPriorArt.md)** | How Replicache / ElectricSQL / PowerSync / LiveStore / CRDTs do it — their documented weaknesses, our deterministic-verbs-both-sides lever, the honest shared pain. |
+| **[EnablingTechTimeline.md](EnablingTechTimeline.md)** | The cited technology timeline — what made this possible when; the two compasses. |
+| **[SpatialERP_OOTB.md](SpatialERP_OOTB.md)** | Spatial ERP — the browser-only ERP replacing iDempiereOOTB; §11.5 inventory/movement model. |
+| **[BOM_ENGINE_SPEC.md](BOM_ENGINE_SPEC.md)** · **[DATA_MODEL.md](DATA_MODEL.md)** | The BOM recipe engine (the verb that compiles a building *and* backflushes a POS sale) + the 5-table bridge. |
+| **[IDEMPIERE_2.md](IDEMPIERE_2.md)** · **[PLUGIN_ARCHITECTURE.md](PLUGIN_ARCHITECTURE.md)** · **[ENGINE_CONTRACT.md](ENGINE_CONTRACT.md)** | iDempiere 2.0 — the engine-as-data **model**, the **metadata-first plugin/manifest** (charge-model DR/CR→Acct + masters; no new skill to author), and the **engine↔UI seam** (`read`/`dispatch`/`manifest`/`verbs`/`verify` + role context — where owner/role-of-client is enforced). |
+
+**Proofs (spec-first, witness-led; each witness asserts `replay-hash == live-hash` against a browser sql.js binding):**
+- **Witnesses.** Six in-process witnesses pass: W-CHAIN, Merge/G-IDENTITY, W-OWNER/CAS, W-SIGN, W-PERSIST/email-recovery, lease-expiry/value-tiering. Each corresponds to one of the scripts listed below; the secured/durable phase frame is in [§0.20](#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet).
+- **[scripts/erp_kernel.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/erp_kernel.js)** — the deterministic kernel; exercised by [poc_kernel.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_kernel.js) and [poc_longtail.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_longtail.js).
+- The §9 witnesses, each doubling as the spec for its production change: [poc_chain.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_chain.js), [poc_distributed.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_distributed.js), [poc_sign.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_sign.js), [poc_persist.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_persist.js), [poc_policy.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_policy.js), [poc_identity.js](https://github.com/red1oon/BIMCompiler/blob/full/scripts/poc_identity.js). W-CHAIN is implemented in `bim-ootb/viewer/kernel_ops.js` (`sealChain`/`verifyChain`/`setSigner`, v5).
+
+See [§0.20](#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet) for the phase frame (witnesses W-CHAIN/W-SIGN/W-PERSIST/W-OWNER) and [§0.21](#021-g-identity-wired-into-the-kernel--identity-is-an-input-never-computed-2026-06-01-spec--identity) for the landed G-IDENTITY change.
+
+---
+
+## This document — section map
+
+This is a long working document. It is layered from *why* → *what* → *how* → *limits*.
+Read top-to-bottom for the argument, or jump by the band you need:
+
+| Band | Sections | What it answers | Read this if you want… |
+|---|---|---|---|
+| **Orientation** | Overview · Companion documents · [Underlying structure](#underlying-structure-for-readers-familiar-with-idempiere) · [Views](#views-seeing-the-underlying-model) | What this is and why it's more than a port | the one-sentence thesis and the proven-vs-parked line |
+| **The model** | [§0](#0-storage-model-decision-2026-05-29-chosen-path-c-the-bridge) and its subsections §0.1–§0.21 | The storage decision (the 5-table bridge), the rules engine, the op-log, the two spines, the diff-verified verticals, the long-tail seam, identity | the heart of the design — how a thousand tables become five and an engine becomes data |
+| **The build** | §1–§9 | Concrete pipeline: AD→SQLite mapping, PostgreSQL export, the parser, the card-first renderer, HTML-native UI, the construction bridge, analytics, the channel, the landing page, the phases | to reproduce or extend the toolchain |
+| **Scope & architecture** | §10–§17 | Honest scope/status, the three-layer split, the 5-table foundation, the compiled manifest, kernel gravity, the known monsters, schema coverage, the architecture summary | the boundaries and the risk register |
+| **The unified model** | §18 | BOM + WfMC on one log; document-as-event; the oracle that validates handlers | the theoretical spine that ties it together |
+| **Performance** | §19 | Transaction cost vs iDempiere — analytical, apples-to-apples; the side-by-side win/trade/extra table | where it wins, where it trades, and the extra it pays |
+| **Status** | [§20 Addendum](#20-addendum-prototype-status-and-the-role-of-the-ui-views-2026-06-01) | Prototype status; the three UI views as fast POCs; the roadmap | a plain statement of how finished this is |
+
+> **§0 has 21 subsections** because it is where the design was actually derived,
+> dated and witnessed in sequence. It reads as a worklog: each `§0.N` records one
+> decision and the witness that closed it. Skim the headers first; descend only into
+> the ones you need.
+
+---
+
+## Underlying structure (for readers familiar with iDempiere)
+
+> For readers from an iDempiere background, the premise is already familiar. The AD
+> demonstrates it: a window, tab, field, validation rule, and menu are not code — they
+> are rows. "The application is data" is iDempiere's design, not a claim of this
+> project. What follows is an account of what this project does differently, the
+> reasoning, and what is proven versus parked.
+
+### The one-sentence thesis
+iDempiere made the **UI** data and left the **engine** as code (the `M*` model
+classes, doc processors, callouts, the workflow/accounting/costing engines, OSGi).
+This project pushes the *same bet one layer deeper*: **the engine becomes data too**
+— the document lifecycle, the matchers, the accounting postings, even *where the
+work concentrates* — extracted into a structure small enough to render, run, replay,
+and explain **itself** in a browser, with **zero hand-authored glue** (the
+extract-only rule, §0.1). Glassbowl is that structure made visible.
+
+### What actually collapses (and why an AD veteran should care)
+
+| In iDempiere you know… | …here it becomes | The merit |
+|---|---|---|
+| **~a thousand tables**, each an `M*` class | a **5-table runtime** (`containers`, `items`, `documents`, `document_lines`, `journal`) + a `doc_type` discriminator (§0) | one storage shape the whole catalogue maps onto — **98.4 % of business edges mappable, hub `C_Order` still #1** (witness §5TBL). The schema stops growing with the feature list. |
+| **`completeIt()` across dozens of models** | a handful of **pure verbs** `(doc,ctx)→ops[]` — `completeOrder`, `createShipment`, `createInvoice`, `allocate`, `match` | the O2C / P2P verticals reproduce the **GardenWorld oracle exactly** (§VERTICAL, §ORACLE-SUITE); GL is structurally mapped but not yet data-verified (§0.17) — and the long-tail document ships **matcher-free**, the matcher *composing in* only at the buyer-reconciliation gate (§0.19). Less engine, not more. |
+| **Modules you install & activate** | **hot vs. cold cells** of a `(doc_type × doc_status)` grid; 155 stay dormant | "the whole platform is already here, dormant — it turns on the moment you use it." Nothing to install; **op-log gravity self-ranks** where the work really is (`C_Invoice` #1 = the settlement spine, §0.13/§14). |
+| **thousands of foreign keys** | **4 structural roles** — containment / derivation / settlement / reference (the "two spines") | the map reads at a glance: green **derivation** = the easy everyday O2C flow; red **settlement** = matching & reconciliation, where money — and mistakes — concentrate. Classification is **derived, 0 hand-authored** (witness §GLASSBOWL). |
+| **AD_ChangeLog + an audit trail bolted on** | **`kernel_ops`** — every state change a rich op (payload + actor + **before/after** + lineage), replayable | the audit log **is** the source of truth: replay rebuilds the projection from the op-log alone (hash-match). History, undo-preview, and the future write-loop all read the *same* log. |
+| **Two logins** — System Admin (the dictionary) vs. a client like GardenWorld (the rows) | **one canvas** — the §0.18b duality fused | click the `C_Invoice` *type-cell* (admin view) and its real invoices (`#200001 = $100.70`) surface right there (operator view). The **trace** is where the two layers meet: a type-level FK spine lit by one instance's journey. No tab-switching, no second login. |
+
+### Why this is more than a port
+A port would re-skin those ~thousand tables in a browser. This **re-bases** them. The merit
+is not "iDempiere without a JVM" (though it is also that — SQLite WASM, sql.js, no
+PostgreSQL/OSGi/server); it is that the engine is now **inspectable as data**, so it
+can do the things a code-engine structurally resists: surface *everything about one
+entity in one place*; ship *dormant and self-activating*; **draw its own map** of
+where value and risk pool; and — the parked endgame — let you **edit a rule and watch
+the affected records flip on that map** (the diff-oracle in the browser, §2d-3).[^grail] That
+last step turns the map of the engine into the *console you run the engine from*.
+
+[^grail]: **The elusive Holy Grail this project is after.** See [HolyGrail.md](HolyGrail.md) — the author's account (as ADempiere's founding leader) of why editable-rules-live was structurally out of reach inside a code-engine ERP, and why this paradigm reaches it.
+
+### Verification discipline (extract-only)
+The same principle the AD embodies — declare rather than hand-write — is applied here
+as **extract or compile only**: every node, edge, rule, row, op, and rendering
+parameter is read from `ad_full.db` / `erp_rules.db` / `kernel_ops`, not invented. A
+value with no source is recorded as a finding rather than guessed (for example, with
+GL `fact_acct=0` the Accounting view reports "not posted in this dataset" instead of
+synthesising a posting). Consequently the running views render from the source data
+directly rather than from a separate mock dataset.
+
+### Proven vs. parked (no overclaim)
+- **Proven, witnessed:** AD→manifest compile; the 5-table bridge (§5TBL); the
+  diff-verified O2C/P2P/GL verticals + matcher-free long-tail (§0.17–§0.19); the
+  runtime kernel + replay (§0.16); Glassbowl rendering the engine from data alone,
+  with the lifecycle trace, dossier, real rows, and op-log History (§GLASSBOWL).
+- **Parked behind T3 (write-loop, `push=live`, explicit go):** editing rules/records
+  in place, the live rule-impact preview, the on-screen keyboard / view-back input.
+  Today's surface is **read-only**; the greyed CRUD and the History undo-preview are
+  the honest *seam* to that next step, not the step itself.
+
+*Read on for the storage decision (§0), the cell model, the kernel, and the
+diff-oracle that holds it all to the GardenWorld truth.*
+
+---
+
+## Views — seeing the underlying model
+
+The model below (the 5-table cells, the FK spines, the kernel op-log, the rule
+tables) is not just storage — it is **the thing the views render**. Each view is a
+different *projection of the same extracted structure*; none carries its own data.
+Two are built today, both **read-only, extract-only, 0 hand-authored**, both in
+`bim-compiler` and served from the BIMCompiler Pages site (they touch nothing in
+`bim-ootb`/live). They are how an iDempiere mind *looks at* the §0.18b duality.
+
+### View 1 — Glassbowl (`docs/glassbowl.html`) — the engine, mapped
+**What it is:** the engine rendered *from itself* — bubbles are the **cells**
+(§12 5-table foundation, §0.7 self-graphing), the lines between them are the **FK
+spines** (§0.13 the two spines — derivation green, settlement amber, reference
+behind). Spec: `docs/GLASSBOWL_DOSSIER.md`; prior art `docs/GLASSBOWL.md`.
+
+**How it uses the model — every surface traces to a model section:**
+- **The map** = the FK graph of `ad_full` collapsed onto the cell layer (§0.7). A
+  bubble *is* a `C_*` type-cell; an edge *is* a real foreign key, classified by spine.
+- **The trace** = a lineage walk down the derivation spine (§0.6 op-log lineage,
+  §0.19 long-tail): pick `C_Order` and its real journey
+  `Order → Shipment → Invoice → Payment → Allocation` lights as **one instance's
+  path over the type-level spine** — the §0.18b two-logins-fused moment made literal.
+- **The dossier** (Data / Rules / Columns / History) = the 5–7 iDempiere windows
+  fused: **Data** = real rows from `glassbowl_data.db`; **Rules** = `erp_rules`
+  validation SQL (§0.5, §0.8); **Columns** = `ad_column`; **History** = the
+  `kernel_ops` op-log with before/after (§0.6, §0.16) as a read-only undo-preview.
+- **The eye candy** (orbit depth-planes, swipe picker, WebAudio, QR scan, mobile
+  handle) maps to data, never decoration: planes come from spine role, audio pitch
+  rises per real lineage hop. *Spectacle on the surface, substance underneath.*
+- **Witness:** `§GLASSBOWL-WIRING 85/85`, gen `§GLASSBOWL/§LIFECYCLE/§ORBIT PASS`,
+  `hand=0`. Live + proven (deployed commit `e2d6702d`).
+
+### View 2 — Glassbowl Gravity (`build/erp/glassbowl_gravity.html`) — the engine, *weighed*
+**What it is:** a focused companion view that distils ONE claim — *legacy ERP makes
+you build a report; this engine presents itself.* Three knobs, every number a **live
+`GROUP BY` over the 8 real GardenWorld orders** (extracted from `glassbowl_data.db`,
+0 invented). Built as a separate file precisely so the loved Glassbowl stays untouched.
+
+**How it uses the model — the three knobs ARE three model facets:**
+- **Pivot (lens)** = the analytical substrate (§0.6 op-log as analytical store, §0.7
+  graph/pivot view). Flick `Partner · Month · Status · Type` and the population
+  re-blooms — a literal `GROUP BY` re-run client-side over real rows, the friendly
+  name kept, the facet value riding under as a subtitle. Customer-vs-vendor colour
+  comes straight from `issotrx`, not assigned.
+- **Gravity (measure)** = **kernel gravity** (§14 the op-log as constellation driver,
+  §0.17 *gravity self-ranks `C_Invoice` #1*). Mass = count or `grandtotal`; the
+  heaviest group is biggest and pulled to centre, deterministic (golden-angle, eased,
+  no `Math.random` — replay-safe per the §0.16 discipline). *Position becomes earned.*
+- **Depth dial (AD ↔ GW)** = the **§0.18b duality made a continuous control**: drag
+  down to the **type/dictionary** layer (the 5-cell FK spine — what the engine *is*),
+  up through the **instance/record** population, up again into one record's **real
+  line items**. One gesture spans dictionary → records → lines.
+- **The honest stop:** the trace lights *exactly as far as the FKs link it* — order
+  `80001` runs full to allocation (`$98.50`); the others halt at invoice with a note
+  saying **why** (no payment FK in this dataset). The extract-only rule (§0.17
+  contained-set, §Non-goals "never fake one") shown as a feature, not hidden.
+- **Witness:** `§GRAVITY orders=8 chains=4 hand=0`, plus `§PIVOT`/`§TRACE` on each
+  interaction. Inlined totals reconcile to the DB to the cent (`$9,914.07`).
+
+### How the views compare to BI tools
+A BI/OLAP tool (PowerBI and similar) performs the same operations — slice, pivot,
+drill — but over a decoupled copy that must be modelled first, and the drill path
+terminates at detail rows. The Glassbowl views operate directly on the live engine
+tables: the drill terminates at the operational document together with its rules,
+workflow, and lineage (editing is parked, T3), and every displayed value is read
+from the system's own structure rather than a separate analytical model. The
+distinction is the data source (live engine vs. modelled copy), not the set of
+operations.
+
+**Parked (T3):** both views are read-only. Editing rules/records in place, the live
+rule-impact preview (§0.4, §2d-3 in the Glassbowl spec), and writing through the depth
+dial open with the write-loop (`push=live`, explicit go) — the greyed CRUD and the
+History undo-preview are the honest seam, not the step.
+
+---
+
+## §0. Storage Model Decision (2026-05-29) — chosen path: (c) The Bridge
+
+**Chosen:** 5-table runtime (`containers`, `items`, `documents`, `document_lines`,
+`journal`) + `kernel_ops`. **AD is the compiler input** (→ `manifest.json`); the
+runtime never touches `C_Order` etc. directly. `ad_data.js` is the **explicit swap
+layer**, mapping every AD window to its 5-table slot via an `ad_table_map`
+(e.g. `C_Order → {storage:'documents', docType:'PURCHASE_ORDER', fk_map:{…}}`).
+
+**Why:** `Doc = Event` (§18.8) wants a `documents` table whose rows ARE the
+event-bearing entities; the AD-faithful compiler (proven by §BOM_TEST) becomes
+the front-end that feeds it. The bridge keeps the pivot auditable and reversible.
+
+**Costs (recorded, not hidden):** storage schema rebuilt; `ad_data` CRUD rewritten
+(<200 lines); the already-shipped real-table `erp.html` needs a one-time data
+migration (not a UI rewrite); P0's manifest compiler **survives**, P0's wire-in is
+partially redone.
+
+**Validation GATE (discipline — do before any 5-table build):**
+`scripts/test_5table_bom.js` must show the `ad_table_map` is **expressive enough**
+to represent every edge §BOM_TEST classified (mapping-completeness, ~0 unmappable)
+AND that the derivation hub ranking survives the table→`doc_type` collapse
+(`C_Order` group still #1). Acyclicity is now a *runtime instance* invariant
+(no document is its own ancestor via `source_id`), enforced by the kernel, not a
+schema property. The §-log makes the call.
+
+**Status:** P0 (AD-faithful manifest + wire-in) stays as the compiler front-end and
+the interim shipped product until the bridge validation passes.
+
+**Gate RESULT (witness: §5TBL, `scripts/test_5table_bom.js`, 2026-05-29):**
+**98.4% of business edges mappable** (2,156 / 2,192); **hub `C_Order` #1, preserved.**
+The residual 1.6% (36 edges) are slotting refinements for the real `ad_table_map`
+(line-level junction/confirm/allocation records mis-slotted as `items` — e.g.
+`M_MatchInv`, `M_MatchPO`, `M_*LineMA`, `C_LandedCost*` are all `document_lines`),
+**not** expressiveness gaps. The gate **derived the minimal runtime schema**:
+
+| Slot | + columns derived by the gate |
+|------|-------------------------------|
+| `containers` | `parent_id` (Site→Building→Floor) |
+| `items` | **`parent_id`** — master data is recursive (Product→Category, Product→Price/Substitute) |
+| `documents` | `source_id` (derivation lineage), `container_id`, `doc_type` |
+| `document_lines` | `document_id`, **`source_line_id`** — lineage recurses to the line (InvoiceLine→OrderLine) |
+| `journal` | Batch→Journal→Line; **entries only** (`Fact_Acct`, `GL_Journal*`). `GL_Category`/`GL_Budget` are accounting MASTER → `items` |
+| + `kernel_ops` | the log |
+
+Plus two rules the gate forced: **`AD_*` / `_Trl` / `RV_*` are compiler input, never
+runtime** (§3); **citations are reference-ids in metadata-JSON, always representable.**
+GATE = OPEN (residue is `ad_table_map` slotting, tracked into PB).
+
+### §0.1 PB explicit slotting (resolves the 36 residual edges → unmapped=0)
+
+The PV gate's heuristic dumped 32 tables into the `items` fallback (or the
+`/Year|Project/` `containers` regex) when they are really lines / sub-documents /
+junctions. The explicit `ad_table_map.js` (PB artifact 2) overrides them. Each
+override is **extract-derived** — it resolves a specific unmappable edge logged by
+`test_5table_bom.js` (witness: `/tmp/pb/unmappable_all.txt`, 2026-05-29) and is
+confirmed against `DocStatus` membership (isDoc query, same date):
+
+| Override slot | Tables | Why (the edge it fixes) |
+|---|---|---|
+| `documents` (sub-doc, `parent_id`) | `M_ProductionPlan` | groups lines under `M_Production`; no `DocStatus` so heuristic mis-slotted it `items`. `M_ProductionLine→M_ProductionPlan` then = line→doc. |
+| `document_lines` (line / MA / confirm) | `C_InvoicePaySchedule` `C_OrderPaySchedule` `C_OrderLandedCost` `C_PaymentAllocate` `C_POSPayment` `M_Package` `M_InOutLineConfirm` `M_InOutLineMA` `M_InventoryLineMA` `M_MovementLineConfirm` `M_MovementLineMA` `M_ProductionLineMA` `PP_Cost_CollectorMA` `PP_Order_BOM` `PP_Order_Cost` `PP_Order_Workflow` `PP_Order_Node_Asset` `PP_Order_NodeNext` `PP_Order_Node_Product` `MP_Maintain_Task` `MP_OT_Task` `A_Depreciation_Exp` | child of a document (→`document_id`) or of another line (→`source_line_id`); parents confirmed `documents` by isDoc (`M_InOutConfirm`, `MP_Maintain`, `PP_Order_Node`, …). |
+| `document_lines` (settlement, `match_type`) | `M_MatchInv` `M_MatchPO` `C_LandedCost` `C_LandedCostAllocation` | §18.2 three-way-match: a row LINKS ≥2 lines across documents — `source_line_id` to one line, counterpart line-ref in `metadata`, tagged `match_type`. An edge, not content. |
+| `items` (master / link) | `R_IssueProject` `HR_Year` | not spatial containers — the `/Project|Year/` regex over-grabbed; both reduce to `items→items`. |
+
+Two `representable()` refinements the explicit slots expose (the true 5-table
+relationship set, not heuristic gaps): **(a)** a line citing master data
+(`document_lines → items`, e.g. `S_TimeExpenseLine → C_BPartner`) is a metadata
+reference — representable, same as the already-allowed `documents → items`;
+**(b)** a document posting to the ledger (`documents → journal`, e.g.
+`A_Asset_Addition → GL_JournalBatch`) is a posting reference carried in
+`metadata`/`journal.source` — not a lifecycle derivation.
+
+**2nd-order cascade (found by running the explicit gate, `test_bridge.js`):** moving
+a table to `document_lines`/`documents` re-slots its *children*. 8 more tables
+slotted: child lines `M_PackageLine` `M_PackageMPS` `PP_Order_BOMLine`
+`MP_Maintain_Resource` `MP_OT_Resource` `C_OrderLandedCostAllocation` →
+`document_lines` (→`source_line_id`); `PP_Order_Workflow` → `documents` (sub-doc
+header that `PP_Order_Node` nests under); `HR_Period` → `items` (sibling of
+`HR_Year`). **GATE RESULT (witness `§BRIDGE`, `scripts/test_bridge.js`, 2026-05-29):
+`map windows=7 docTypes=49 unmapped=0`; round-trip/lineage/match all PASS; PB gate
+GREEN.**
+
+### §0.2 One engine — `doc_engine.js` reconciliation (resolved 2026-05-29)
+
+There were two implementations of "the 5-table model": `schema_5table.sql` (PB,
+AD-bridge) and `doc_engine.js` (the earlier **Spatial ERP POC** — `containers/items/
+documents/document_lines/journal` + `StateMachine` + `JournalEngine` + construction
+handlers, 79 tests). **Evidence (grep, 2026-05-29):** the POC's only consumer
+`erp_panel.js` is loaded by **zero** HTML entries; the live `erp.html` references it 0
+times. The POC (≈1,149 lines incl. tests) is **unreachable dead code** — its tests
+pass but exercise a module nothing loads.
+
+**Decision — canonical = `schema_5table.sql` (PB).** Not preference:
+- It is the only schema validated against real data (§BRIDGE, 2,192 edges) and it
+  **has the columns the full ERP provably needs** that `doc_engine` lacks
+  (`source_id`, `source_line_id`, `match_type`, `parent_id`). Making `doc_engine`
+  canonical would mean re-adding all of those — strictly more work for a worse start.
+- `doc_engine`'s 5-state `StateMachine` is **superseded** by P2's `manifest.wfmc`
+  (52 DocTypes, AD-faithful codes).
+
+The POC is **retired as the P3b reference oracle**, not migrated column-by-column:
+`construction.js` demonstrates the handler→effects pattern (structural template only —
+its *content* is the construction domain, out of product scope §0.3), `JournalEngine`
+shows journal-on-complete. The real P3b content oracle is the iDempiere Java
+(`MOrder`/`MInvoice`/`MInOut`/`MPayment`, §18.10). `kernel_ops.js` stays the shared
+module (BIM undo == ERP audit). The two-engine fork is closed; no live breakage
+(nothing loads the POC).
+
+### §0.3 Product scope — narrow O2C / P2P / GL / Inventory (2026-05-29)
+
+The PB/PV gates proved the 5-table model is **expressive enough for all of iDempiere**
+(a universality result — that's why the 37 overrides reach into the HR/manufacturing/
+asset long tail). The **product**, however, is deliberately narrow: emulate iDempiere
+for **Sales→Ship (O2C)**, **Procure→Receipt (P2P)**, **GL**, and **inventory storage** —
+nothing more. So:
+- **In-scope lifecycle tables / DocTypes:** `C_Order` (SOO/POO), `C_Invoice`
+  (ARI/API), `C_Payment` (ARR/APP), `M_InOut` (MMS/MMR), `M_Inventory`/`M_Movement`
+  (MMI/MMM) + `StorageOnHand` (§18.9), `GL_Journal`/`Fact_Acct` (GLJ). `M_MatchInv`/
+  `M_MatchPO` for three-way match.
+- **Out of product scope** (mapped for model-completeness only, NOT handler targets):
+  manufacturing (`PP_*`), maintenance (`MP_*`), HR (`HR_*`), assets (`A_*`), projects.
+- **P3b hot cells follow this spine:** `(C_Order,CO)`→derive `M_InOut`,
+  `(C_Order POO,CO)`→receipt+`M_MatchPO`, `(C_Invoice,CO)`+`M_MatchInv`,
+  `(C_Payment,CO)`+allocation, journal-on-complete, `M_InOut,CO`→`StorageOnHand`.
+  This is exactly the hub-first ordering, now bounded.
+
+**Adopted for free from the BIM viewer (shared, not rebuilt):** the **main pill** of
+icons, and the **Settings JSON editor** (another session builds it — JSONs edited in
+the standard accordion-table format). ERP's config (`manifest`, `clash`-style rules,
+and the P6 signed-policy / handler-policy JSON) is editable through that shared editor,
+so **P6 Rule Console reuses Settings**, and the AD accordion renderer and the Settings
+editor **share the same table/accordion methods**.
+
+### §0.4 Editable business rules — the SystemAdmin role (the differentiator)
+
+**The pain in normal ERP:** business logic is hardcoded in compiled server code
+(iDempiere's ~15k lines). Changing a rule needs a developer + redeploy; the change is
+unaudited, irreversible, and can't be tried safely. We push as much as possible from
+*code* into *editable metadata* a **SystemAdmin role** edits via the shared Settings
+JSON accordion editor (§0.3). The split (this is §18.6/§18.7 made concrete):
+
+| Layer | Where it lives | Editable by SystemAdmin? |
+|---|---|---|
+| **Cell legality** — which actions are valid from which status, per DocType | `manifest.wfmc` + `doctypes` (P2) | Yes (JSON) |
+| **Field validation** — mandatory / readonly / displayLogic / defaults | `manifest` field contract (P0) | Yes (JSON) |
+| **Posting rules** — account mappings per doc_type, debit/credit | a **policy JSON** (replaces `doc_engine`'s hardcoded `JOURNAL_RULES`) | Yes (JSON) |
+| **Conditional flags** — `autoCreateShipment`, `creditCheck`, match `tolerance`, downstream-protection | a **policy JSON** (`scope:"global"` marked, §18.5) | Yes (JSON) |
+| **Effect *shape*** — "Complete order ⇒ emit shipment + lines" | a P3b **handler** (`(doc,ctx)→ops[]`) | No — code, parameterized by the policy above |
+
+**The honest boundary:** parameters, mappings, conditions, and which-action-when become
+metadata; the *shape* of a novel procedural effect stays a handler. Trying to
+metadata-ize arbitrary procedural logic rebuilds the complexity as a DSL (the classic
+"configurable rules engine that's harder than code" anti-pattern). So handlers stay
+small code; **everything around them is editable knobs.** Rule: a P3b handler must read
+its knobs from the policy JSON, never hardcode them — so editability is built-in, not
+retrofitted.
+
+**Why ours is safe where normal ERP isn't:** because the op-log is the truth (event
+sourcing), a SystemAdmin rule change is *itself a `kernel_ops` op* — auditable,
+reversible, and **dry-runnable** (P6 Rule Console: edit policy → replay affected
+documents → diff effects, before committing). Editable rules that can't silently break
+production. (This depends on the op-log actually being replayable — see the foundation
+note: ops must carry enough payload to rebuild the projection.)
+
+**Positioning — this was once the domain of Drools/BRMS.** Externalizing business
+rules into editable, declarative, safe-to-change artifacts is the exact ambition of
+heavyweight rules engines (Drools/JBoss BRMS, the KIE workbench, DRL/decision tables).
+Those needed a JVM, a server, Rete expertise, and rule-ordering/conflict-resolution
+(salience) — and the generality became its own complexity monster, often harder to
+reason about than the code it replaced. It is **more achievable today, and simpler,**
+for four reasons, and only if we hold one line:
+1. **We don't build a general inference engine.** Rete matches arbitrary rules in
+   arbitrary order — that generality is the cost. We metadata-ize only *knobs and
+   dispatch*; effect shapes stay handlers (§0.4 boundary). Small, tractable surface.
+2. **Cell decomposition replaces conflict resolution.** Drools' hard problem is "which
+   rules fire, in what order." Our state-machine-per-DocType makes dispatch
+   deterministic: the cell `(DocType,status,action)` selects exactly one handler + its
+   policy. No Rete, no salience.
+3. **iDempiere already did the declarative modeling.** The AD is a 60k-row metadata
+   dictionary; we *compile* it (P0/P2), we don't reinvent it. Half the "rules engine"
+   already exists as data.
+4. **The op-log gives safety Drools never had** — change-as-op, replay, dry-run, undo.
+   In-browser, local-first, ~150-line kernel — no JVM, no workbench.
+
+**The one line to hold:** the temptation is to drift *into* Drools — make handlers
+themselves data, build a DSL. That rebuilds the monster. The §0.4 boundary (handlers =
+code, everything around them = editable metadata) is the discipline that keeps this
+grand-but-shippable. Achievable **for the narrow spine today** (§0.3); the long tail is
+incremental, not a prerequisite.
+
+> **Thesis (§0.4–0.7).** ERP was always the *hard rules monster* — logic hardcoded,
+> changes dangerous, analytics bolted on. Here it becomes a **smart rule assistant:
+> deterministic, without AI intrusion, in a closed controlled environment.** "Smart"
+> comes from the op-log (statistics over real actions — frequencies, recurrence,
+> outcomes), NOT from an LLM. So the assistant *suggests and explains*, the human
+> *decides*, dry-run *proves* — every step reproducible, auditable, and offline. No
+> hallucination, no nondeterminism, no data leaving the tab. The PRIME DIRECTIVE
+> (Deterministic · Non-invent · Extract) holds all the way up to the rules layer.
+
+### §0.5 The rules engine — per-cell decision tables
+
+The concrete shape of §0.4's editable policy. NOT Rete/DSL/inference — a **decision
+table per `(DocType, status, action)` cell**. The cell decomposition already removed
+the hard part (ordering/conflict/salience): within a cell there is no rule graph, just
+rows. Each cell has:
+- a **fixed menu of named effects** — *code* handlers (`createShipment`, `postJournal`,
+  `allocatePayment`, `creditHold`, `matchThreeWay`; ~6–10 for the whole §0.3 spine).
+  Users pick from it, never write it.
+- an **editable decision table** (policy JSON): rows of
+  `when: [[field, op, value], …]` (AND within a row, first-match across rows) →
+  `then: [{effect, params}]`. `value` may be a literal or a `@policy-ref`
+  (`@CreditLimit`, `@AR`) so mappings are defined once.
+
+The engine is **one ~50-line evaluator**: for the cell, walk rows, eval `when` against
+the document, dispatch matched `then` effects → `ops[]` → kernel applies. Democratised
+because (1) it's a *table* rendered in the shared accordion-table UI (§0.3), (2)
+conditions use the document's own field names, (3) effects are a dropdown, (4) it can be
+authored/round-tripped in **Excel** (`excel.js`/SheetJS already ships). Safe because the
+predicate language is tiny and non-Turing-complete (`= ≠ > ≥ < ≤ in empty`; field /
+literal / `@ref`; no functions, loops, or arithmetic) → statically checkable; and every
+table edit is a `kernel_ops` op → **dry-runnable** (§0.6) and undoable. **Boundary:** the
+table *selects and parameterizes* effects; novel computation (an allocation algorithm)
+stays a named handler the table calls.
+
+### §0.6 The op-log as analytical + rule-feedback substrate (the keystone)
+
+`kernel_ops` is already audit + undo + sync substrate + gravity (§14). It is *also* the
+**analytical store** — no bolt-on warehouse/ETL (the normal-ERP analytics pain). Every
+action is a timestamped, typed, parameterized event with actor + input/output GUIDs
+(`commitOp` already carries `timestamp, op_type, parameters, input_guids, output_guid`).
+So in-browser over `kernel_ops`:
+- **Optics** — frequency per `(DocType, action)`, where users hesitate or **undo** (undo
+  is an op), who does what.
+- **Flow / cycle-time** — order→ship latency, receipt lateness, approval lag = timestamp
+  deltas along a lineage.
+- **Budget / forecast** — journal ops are the *actuals*; budget is policy metadata;
+  variance is one query. Forecasting reuses the **dry-run replay** machinery (P6): a
+  forecast is replaying *hypothetical future ops* forward — same engine that dry-runs a
+  rule change.
+
+**The closed loop (preemptive, not after-the-fact):** the log *mines candidate decision
+rows* — "credit holds from BPartner Y are approved 100% → suggest auto-approve"; "users
+undo this auto-shipment 40% → flag the rule as wrong"; "these monthly manual journal
+corrections recur → suggest an auto-posting rule." Flow: **log → suggestion → dry-run →
+human commit.** P4 gravity reaches its full form: not just "what's hot" but "what rule
+should exist." Disciplines: **suggest, never auto-apply** (human-in-loop = safety AND
+democratisation); **explainable simple stats, not an ML platform** (frequencies,
+recurrence, conditional-outcome rates, cycle-times — readable by a user).
+
+**Keystone:** editable-safe-rules, analytics, forecasting, AND sync all share ONE
+dependency — **the op-log must be rich** (payload + actor + before/after + lineage
+GUIDs). Thin `{table,id,action}` ops (PB's current usage) support none of it; the
+`commitOp` schema already *allows* rich ops — we just must *use* them. This elevates
+"make the op-log real" from a P4 detail to the **foundation** the rest stands on.
+
+### §0.7 Every model is self-graphing (Odoo-like — and more)
+
+Like Odoo, every model can switch from its accordion-table view to a **graph/pivot
+view** with no per-model code. We already have the asset: `ad_charts.js`
+(`renderOverlay(db, tableName)`, `drawBar/Pie/Treemap/Completeness`, canvas, DPR-aware)
+and the 📊 Charts entry in `ad_ui.js`. The generalisation: **derive the measures and
+dimensions from the compiled manifest field types** (P0) — `amount`/`number`/`qty` →
+measures; `list`/`yesno`/`tableDirect`/`date` → group-by dimensions — so any model
+graphs itself automatically, no `getPrebuilt` curation needed.
+
+**The "more" Odoo can't do natively** (because ours is event-sourced, not a state
+snapshot): **temporal** views (how this model evolved over time, from the log),
+**flow/funnel** views (the document lineage `order→invoice→payment` straight from P2's
+derivation graph), **cycle-time** and **undo-rate** charts (the rule-grading of §0.6
+rendered as graphs), and **forecast** overlays (dry-run forward-replay). Same renderer,
+the log supplies a time axis Odoo's aggregations don't have.
+
+### §0.8 Surfacing the hooks + the right to touch rules
+
+iDempiere already separated **hook-point from behavior**: `AD_Column.Callout` names a
+Java method that fires on field change; `ModelValidator` / DocEvent registers a Java
+class that fires on a document action. The *binding* is declarative metadata in AD; the
+*behavior* is opaque compiled Java — visible only to, and editable only by, a coder.
+This is precisely the cell→handler dispatch we generalise: Callout = a field-change
+cell, DocEvent = a `(DocType, status, action)` cell. **We make both halves visible:**
+the parameterisable part becomes an editable decision table (§0.5), the computational
+part a named handler (§0.4), and the binding is *already in AD* so we compile it as the
+cell→handler wiring.
+
+**Concrete extraction gap (TODO for P3b):** our current `ad_seed.db` **stripped
+`Callout`** (the §1 column-subset) and never exported `AD_ModelValidator`. Re-export
+both from the source PostgreSQL (docker, §1). Compiled, the Callout/Validator strings
+are simultaneously **(a)** the cell→handler wiring, **(b)** the P3b backlog (*where
+logic exists* — cross-referenced with op-log gravity §0.6 for *where it matters*), and
+**(c)** the §18.10 oracle pointers (*which Java to port*). What survived the strip and
+helps now: `AD_Val_Rule_ID` + `ValueMin/Max` (declarative validation), the `ad_wf_*`
+workflow graph (a second declarative process source beside P2's WfMC), and the full
+role/access layer (below).
+
+**Capability-first — the fundamental right is structural, security is a later layer.**
+Because a rule is just editable metadata behind the accordion editor, **the right to
+touch rules is granted by default** — not gated behind a permission system we must build
+first. iDempiere's default is "locked unless you're a coder"; ours flips to "open unless
+an implementor restricts it." Security is an **additive** layer implementors add later —
+and its metadata is **already present** (`ad_role`, `ad_document_action_access`,
+`ad_table_access`, `ad_window_access`): compile those into "who may edit which rules /
+fire which actions" when needed, without touching the foundation. Same graceful shape as
+everywhere else: capable/open by default, narrowed by additive policy. The fundamental
+right comes first; the lock is optional and comes second.
+
+### §0.9 The rule mechanism — metadata, preset, always editable (JSR-223, PWA-native)
+
+**Governing principle: model everything as metadata.** Business logic is not hardcoded;
+it is a **rule record** in the dictionary — iDempiere's own `AD_Rule` pattern, confirmed
+in source (`MRule.java`: `RULETYPE_JSR223ScriptingAPIs`, `SCRIPT_PREFIX="@script:"`,
+engine-by-name, `setContext()` injecting the record/context as script bindings). A rule
+is `{ eventType, form, body, binding }`:
+- **eventType / binding** — the cell hook, straight from iDempiere: a **Callout**
+  (field `onChange`, bound to a column) or a **DocEvent** (a `ModelValidator` TIMING —
+  `BEFORE/AFTER_PREPARE/COMPLETE/VOID…`, bound to a `(DocType, action)` cell).
+- **form** (how the body is expressed) — a tier, all metadata-housed:
+  - **SQL** — runs *natively* in sql.js (the common ones you wrote in SQL translate
+    1:1, no port — a real win); for set-based validation/lookup/derivation + `AD_Val_Rule`.
+  - **expression (JS)** — sandboxed; per-record value-derivation + predicates. Your
+    Groovy/BeanShell scripts port here; JSR-223's engine abstraction is *unnecessary* —
+    the browser host language IS JavaScript, so the rule language = the runtime language.
+  - **decision table** (§0.5) — declarative which-effect-when sugar.
+  - **named handler** — the side-effecting / heavy-procedural 20% (e.g. `completeIt`'s
+    `createShipment`/`createInvoice` fan-out). Side-effect rules become handlers that
+    **return ops**, never mutate directly.
+- The three rule kinds you confirmed map onto the tiers: **derivation** → SQL/expression
+  (Callout), **validation** → SQL/expression predicate+message (DocEvent BEFORE_*),
+  **side-effects** → named handler returning ops (DocEvent), parameterized by policy.
+
+**Authored by power-users/consultants (your answer)** — so the SQL/expression tier *is*
+the democratisation layer (not core-dev work); tables serve the simplest cases, handlers
+the implementor/dev cases. Capability-first (§0.8) means every rule ships editable.
+
+**Preset the common rules, always editable.** The system is *batteries-included*: it
+ships the proven common rules **extracted from iDempiere's model logic** — and that
+logic is *already metadata-driven*, which is why presetting works. `MOrder.completeIt()`
+(source, confirmed) fans out conditionally on `C_DocType` flags
+(`isAutoGenerateInout`, `isAutoGenerateInvoice`, `DeliveryRule`, `DocSubTypeSO`,
+`evalAutoGenerateInOutRule`) and fires `fireDocValidate(BEFORE/AFTER_COMPLETE)`. So a
+preset = {those DocType flags as editable policy} + {validation/derivation as
+SQL/expression rules} + {the fan-out as named handlers}. Out-of-box working
+O2C/P2P/GL/inventory; **nothing blank, everything editable.**
+
+**Determinism sandbox (the one cost iDempiere didn't bear):** expression/handler rules
+run with no `Date.now`/`Math.random`/network/DOM, timeout-bounded, pure over
+record+context — so replay, dry-run, and the no-AI-nondeterminism thesis hold. SQL rules
+are deterministic by nature.
+
+**Oracle is local & confirmed:** `~/idempiere-dev-setup/idempiere/org.adempiere.base/
+src/org/compiere/model/` (`MOrder`/`MInvoice`/`MInOut`/`MPayment`/`MMatchInv`,
+`MRule`). P3b extracts presets from here (§18.10). **Extraction TODO grows:** re-export
+`AD_Rule` + `AD_Val_Rule` + `Callout` (+ the `C_DocType` policy flags) from the source
+PostgreSQL — currently stripped from `ad_seed.db` (only dangling FK ids survived).
+
+### §0.10 Building it — raw migration first, then the Rule Compiler
+
+**Step 0 — raw PG→SQLite migration (mechanical, faithful, do this first).** We already
+*have* it all: the iDempiere PostgreSQL DB (full AD + config + `AD_Rule`/`AD_Val_Rule`
+scripts + `Callout` + `C_DocType` flags + `AD_PrintFormat` + `RV_*` views) and the Java
+source. Don't build a clever extractor against PG/Java — first **migrate the whole PG
+DB straight into "SQLite speak" as a separate cluster** of SQLite files. SQLite's loose
+typing makes the bulk (tables + data + the rule *scripts*, which are just text columns)
+near-mechanical; the flagged subset that needs care: **sequences** (drop — §5 forbids
+MAX+1 anyway), **stored functions/triggers** (skip — logic lives in Java/rules, not
+data), and **`RV_*` views** (translate the PG-specific SQL, or snapshot, or defer). The
+**Java is NOT migrated** — it can't be; it stays the §18.10 oracle for hand-porting
+handlers. Output: a raw, complete `ad_full` / `erp_rules` SQLite cluster the PWA's sql.js
+reads directly. This also *supersedes* the "selectively re-export the stripped columns"
+TODO (§0.8/0.9) — migrate everything raw, decide what to use later.
+
+*Working principle (aligned with the onset).* `ad_seed.db` was already a PG→SQLite
+export (§1), just stripped; Step 0 is **the same proven pipeline run complete** (raw, no
+strip). And it's incremental by design: get the faithful raw corpus in, then
+**refactor/compile as we go** — expect **several iterations before the better model and
+the right separation emerge.** Don't perfect the compiler or the cluster boundaries
+before the data exists; let the clean separation reveal itself through use (gravity,
+§0.6) rather than be designed up front.
+
+**Step 1 — the Rule Compiler** (analyser, the rules analogue of `compile_manifest.js`)
+now reads **local SQLite** (not PG, not Java — much easier, like P0 already does) and
+*places* the logic as §0.9 rule records. Two sources, two honesty tiers:
+- **AD metadata (auto-extractable, deterministic):** `AD_Rule` scripts, `Callout`
+  bindings, `AD_Val_Rule` SQL, `C_DocType` policy flags, the `ad_wf_*` graph → emitted
+  directly as rule records (SQL/expression/table forms + policy). This is pure
+  extraction — safe to automate.
+- **iDempiere Model Java (NOT auto-translatable):** procedural bodies like
+  `completeIt()`'s fan-out **cannot be safely machine-translated** to JS — that's the
+  §18.10 hand-port, verified by the diff-oracle. So the compiler instead **emits the
+  handler backlog**: which cells have logic (from the Callout/Validator/DocType
+  bindings) + the oracle pointer (class/method) + the gravity rank (§0.6), and scaffolds
+  handler **stubs**. Humans fill the bodies, hottest cell first. *Auto-extract the
+  declarative/script/flag layer; hand-port the procedural layer — never pretend the
+  latter is automatic.*
+
+**Separate, streamable store.** Output is a distinct **rule DB** (name it `erp_rules.db`
+to avoid colliding with the BIM pipeline's product-catalog `ERP.db`), kept OUT of the
+slim instant-load manifest. Reusing the proven split-DB pattern (lazy-fetch +
+IndexedDB cache, as `panels.js`/buildings already do): **fetch a cell's rules on first
+use, cache only the used ones** — gravity (§0.6) ranks what to preset/cache. The long
+tail stays remote until touched (the Objective's "reference, lazy-loaded" principle).
+
+**The "abstract engine" = the runtime rule evaluator.** One uniform interface that
+dispatches by `form`: SQL → run in sql.js; expression → deterministic JS sandbox;
+table → the §0.5 matcher; handler → the named fn (returns ops). The kernel calls it at
+each cell; it never cares which form a rule took. The compiler SEEDS `erp_rules.db` with
+the presets; the Settings editor edits them; every edit is a `kernel_ops` op (§0.6).
+
+### §0.10a Master-data first-mile — the migrate ShowMe (master/metadata only)
+
+*Spec for `prompts/MIGRATE_SHOWME_OVERLAY.md` — the THINNEST adoption step: take an
+iDempiere operator from "my data is locked in a Docker Postgres" to "my master data is
+in my browser." A LATER ShowMe handles plugin **logic**, transactions, posting, and the
+cent-perfect oracle-gate (§0.17). This section is master/metadata only.*
+
+**Honest 2-part flow (never a browser→Postgres pipe).** A browser cannot open TCP to
+Postgres:5432. So there are two touches:
+- **The agent (local):** `scripts/migrate_pg_to_sqlite.js` (NOT forked) run by the
+  operator with their own creds. It reads their PG and writes a master/metadata-only
+  SQLite + a progress file.
+- **The overlay (browser, `bim-ootb/viewer/`):** reuses the existing ShowMe/help layer
+  (`docs/ReadMeShowMe.md`, `docs/HelpO2C.md`). It *guides* the user to the agent and
+  *reflects* the agent's progress file. "Watch it stream in" = the overlay mirrors the
+  agent's per-table log, not a live socket.
+
+**Scope — DECIDED 2026-06-02 (widens the prompt's literal "allowlist / no plugins").**
+The operator confirmed the line is **logic, not data**: take ALL AD metadata + masters,
+*including custom/plugin-added metadata tables* (they are AD-defined, transaction-free);
+defer only plugin **Java logic** (which was never in PG — §0.10 "Java is NOT migrated").
+Concretely:
+- **TAKE** (all clients, whole tables, no row filter): the headline master allowlist
+  PLUS the full AD metadata corpus, custom dictionary tables included.
+- **EXCLUDE**: operational data only — the **`docstatus` document tables** (82 in
+  GardenWorld), their transaction **line/fact children**, accounting postings
+  (`fact_acct*`), and runtime **logs/temp** (`ad_changelog`, `ad_session`, `ad_pinstance*`,
+  `ad_wf_process/activity/eventaudit`, `t_*`). The agent computes this denylist by RULE
+  (docstatus query + name patterns) and **logs the resolved exclusion set** for review
+  (Log Mandate) — non-invent: the docstatus set is queried, the patterns are named
+  iDempiere schema objects, no values are synthesized.
+
+**Two-tier streaming (clean demo + completeness).**
+- **Headline masters** (streamed visibly, one `§` line each — the overlay's "watch them
+  land"): `C_BPartner`, `C_BP_Group`, `M_Product`, `M_Product_Category`, `C_UOM`,
+  `C_ElementValue` (chart of accounts), `C_Charge`, `C_Tax`, `C_Currency`. Verified live
+  in GardenWorld: 18 / 3 / 55 / 14 / 15 / 379 / 3 / 6 / 175 rows.
+- **The rest of the metadata corpus**: taken into the resident DB, summarized in the log
+  as `+N metadata tables` (not streamed line-by-line).
+
+**Client discovery + auto-seek + confirm (the connect step).** The agent enumerates
+`AD_Client` (id, name, and whether the client holds master rows) and emits it as JSON the
+overlay renders as a picklist. iDempiere seeds **0 = System** (shared dictionary masters:
+currencies/UOM/countries live here) and **11 = GardenWorld** (the demo tenant). Behaviour:
+- If a **3rd (real tenant) client** exists, the agent **auto-selects** it — but the
+  overlay **requires the user to confirm** before the run.
+- If only 0/11 exist (the demo box), auto-select 11.
+- Migration takes the master/metadata tables **whole** (all clients' rows) regardless of
+  the selection — discovery is *informational* (which tenant am I looking at), not a row
+  filter; masters across all clients are all AD metadata and safe.
+
+**Instance identity (re-import must not clobber).** Each run is a local **instance** keyed
+off the source `ad_client_id`. A local registry (`build/erp/instances.json`) records every
+import `{instance_id, source_host, source_db, source_client_id, client_name, rows}`. On a
+run whose `(source, client_id)` was already imported, the agent assigns the **next free
+integer** as a LOCAL instance marker (re-importing GardenWorld `11` → `12` → `13` …) and
+namespaces the output DB by it (`ad_masters_<instance>.db`) so repeated imports coexist
+rather than overwrite. The marker is a **local counter only** — the migrated rows keep
+their source `ad_client_id` untouched (no FK rewrite); the marker lives in the registry and
+in `_migration_meta`. First import of client `11` → instance `11`; the next → `12`.
+
+**Post-migration ReadMe (share/serve OUT — step 5, guidance over existing infra).** Reuse
+the existing ReadMe layer + `share.js`/QR + the S284 self-contained-HTML (embed-db) path +
+the off-grid `sw.js`. Two user stories, no new infra: **(a) send the file → identical DB
+for anyone** — verifiable, not hoped: deterministic replay → same projection hash, signed
+chain → tamper-evident (`verify`); **(b) put it online → it's served** from any static host
+(GitHub Pages / OCI bucket), no backend.
+
+**Witnesses (§-log first).**
+- `§MIGRATE-CLIENTS found=[0:System,11:GardenWorld] real=[11] auto=11 confirm-required=Y`
+  — discovery enumerates the PG clients and auto-seeks the real tenant.
+- `§MIGRATE-AGENT source=<host/db> instance=<n> masters=[…] tables=N rows=R metadata=+M
+  docs-skipped=Y plugins-logic-skipped=Y` — agent pulled ONLY master/metadata (documents,
+  transactions, postings, logs excluded; plugin LOGIC deferred).
+- `§MIGRATE stream table=C_BPartner rows=18 … table=C_ElementValue rows=379` — headline
+  masters land per table (counts match the live PG).
+- `§MIGRATE-INSTANCE source-client=11 reimport=Y instance=12` — re-import gets a fresh
+  instance marker, prior import preserved.
+
+### §0.11 Housed vs active — the full extent, hidden but callable
+
+This resolves the apparent tension with §0.3 (narrow scope). **Two distinct things:**
+- **PRODUCT scope (active, §0.3)** — what is *built, preset, handler-backed, and shown
+  by default*: O2C / P2P / GL / inventory. A clean, modern, narrow ERP.
+- **PLATFORM housing (this)** — the **full extent of iDempiere** is *housed*: all
+  models, all rules, and the **set reports**, as streamable metadata in `erp_rules.db`
+  — dormant but **callable**. The long tail isn't *excluded*, it's *not loaded yet*.
+
+**This vindicates PB.** Mapping the *entire* dictionary — every table and edge, incl. the `PP_/MP_/HR_/A_`
+long tail) was not scope-creep — it is the **housing**: PB *proved* the 5-table model
+holds the full iDempiere corpus. Those long-tail rows sit dormant in the runtime /
+`erp_rules.db` and stream in when touched (§0.10 lazy-fetch + gravity cache). **How they stream
+— smart per-table, ranked by gravity:** each table is a shard; the manifest is sorted by op-log
+gravity (tier 0 = the prefetched settlement spine; cold cells at the tail, fetched on touch).
+Because gravity is a fold over op-log *traversal*, a hot table's walked FK neighbours **co-rank
+and arrive with it** — the closure self-bundles, no banding needed; an unresolved FK draws a
+*stub*, never an invention. Full spec: **[DistributedERP.md §13 — Sharding the engine by gravity](DistributedERP.md#13-sharding-the-engine-by-gravity-what-arrives-and-when-2026-06-01-spec)**.
+
+**Reporting too — the "set ones."** iDempiere's preset reports are housed: `AD_PrintFormat`
+/ `ad_printformatitem` (present in `ad_seed.db`) + the `RV_*` reporting views (correctly
+*excluded from the runtime lifecycle graph* in P2 — they aren't documents — but kept as
+**report artifacts**). The §0.7 self-graphing + these presets = the reporting layer;
+modern artifacts (accordion, graphs, decision tables, op-log analytics) manage what
+iDempiere managed with its legacy Java/ZK surface.
+
+**The UX is progressive disclosure: "when an iDempiere user walks in."** A new user sees
+the clean narrow ERP. A seasoned iDempiere user reaches for manufacturing, a specific
+validator, or a standard report — and **it's there**, streamed and activated on demand,
+familiar. The bulk is *hidden* (not in the instant payload, not cluttering the UI) yet
+*callable* (lazy-stream + gravity-cache). **Narrow product, full platform** — the same
+graceful-degradation shape as everywhere: minimal/clean by default, full depth on
+demand.
+
+### §0.12 Empirical validation — the Sales→Ship POC (2026-05-29, §POC PASS)
+
+Steps 0 + 1 ran complete and we POC'd the **hard parts first** against the GardenWorld
+oracle. Witnesses: `build/erp/{migrate,verify,compile_rules,verify_rules,probe,poc,poc_match}.log`.
+
+**The diff-oracle needs NO live iDempiere.** GardenWorld already executed its
+transactions, so the `M_InOut` / `C_Invoice` / `M_MatchPO` / `M_MatchInv` rows already in
+`ad_full.db` **are** the oracle's output. We replay our logic on the *inputs* and compare to
+those rows. (Live iDempiere is only needed to oracle *ambiguous* cases we don't have data for.)
+
+What is now **proven**, not asserted:
+- **Derivation** (`completeOrder` fan-out) reproduces the oracle's shipment/invoice lines
+  *exactly* — built as **state + decision-table(C_DocType policy flags) + a tiny verb
+  registry** (`createShipment`/`createInvoice`), NOT a ported `MOrder.completeIt`.
+- **Settlement** (three-way match) reproduces the oracle **18/18** for both `M_MatchInv`
+  and `M_MatchPO`, 0 missed / 0 extra — as a **constraint (partitioned JOIN + balance)**,
+  NOT a ported `MMatchPO`/`MMatchInv` algorithm.
+- **Frozen effects** (§18.8): editing a decision-table flag is forward-only — a new order
+  changes, but **replaying the old order's stored ops reproduces the original shipment.**
+- **The two probe gaps close cheaply**: a `@ctx@` resolver (176/331 validation rules need
+  it) + a PG→SQLite dialect shim (`least`→`min`). With them, `sql=335 + policy=52` of the
+  739 records are engine-serveable for free.
+
+**Model-handling verdict (answers "do we hand-port 294 handlers?" — no).** The handler hell
+collapses to **~8 effect-verbs + decision tables (derivation) + ONE generic matcher
+(settlement)**. The 51 DocTypes share ~5 base-table model methods that differ only by
+flag-driven fan-out — that difference is *data* (already extracted in Step 1), not code.
+
+### §0.13 The two spines — where the ERP hell actually lives
+
+The BOM insight (every FK is a containment or derivation edge, §18.1) is confirmed — but
+the POC surfaced its crucial exception, **the third edge**, and *that* is the hell:
+
+- **The BOM tree** — containment (header→line) + derivation (order→ship→invoice). One tree
+  per document, parent/source pointers, deterministic replay. **Trivial; falls out for free.**
+- **The settlement lattice** — `M_Match*`, allocation, costing, bank-rec, landed-cost. These
+  are **"must-agree" edges that LINK ≥2 independently-grown trees**. A match node has **N
+  parents** (the graph is a DAG, not a forest) — which is exactly why P2 had to exclude
+  settlement back-edges to keep the lifecycle graph acyclic.
+
+The decisive evidence: matched **vendor invoices carry `c_order_id = NULL`** — settlement does
+not follow the order chain. A naive "same-order + product + qty" match scored **0/18**;
+re-partitioned by the **trading-partner account (`C_BPartner_ID`) + document polarity
+(vendor `V+`/`issotrx=N`)** it scored **18/18**. So:
+
+> **BIM = pure BOM (containment + derivation). ERP = BOM + settlement.** The two spines have
+> different organizing keys — the BOM tree is keyed by the document; the settlement lattice is
+> keyed by the *partner account*. **The entire ERP hell is concentrated on the settlement
+> spine** (the multi-parent DAG joins). Tame that and ERP is tamed.
+
+This refines the tiering: the **usage tier** (active narrow / housed long-tail, §0.11) governs
+*what to load*; the **spine tier** (derivation-cheap / settlement-costly) governs *where to
+spend logic* — orthogonal axes, two concerns.
+
+### §0.14 Everything is a predicate on an edge — GUARD vs GENERATE, one engine
+
+Composing the BOM insight (relationships are typed edges) with the rule insight (Step 1: every
+rule is `{binding, form, body}`) yields the whole runtime in one sentence: **a graph of typed
+edges, each carrying predicates, all evaluated by one engine, dispatched by `form`.** Four
+iDempiere mechanisms are the *same* primitive — a predicate bound to an edge:
+
+| mechanism | predicate on which edge | polarity |
+|---|---|---|
+| `AD_Val_Rule` (331) | "this FK may point to rows WHERE …" (data guard) | **GUARD** → bool |
+| role / `document_action_access` (2156) | "this **actor** may fire this action" (state-edge guard) | **GUARD** → bool |
+| WfMC transition (22) | "this status→status is legal" | **GUARD** → bool |
+| three-way **match** | "these two lines pair WHERE …" (settlement-edge *generator*) | **GENERATE** → ops[] |
+| derivation verbs | "derive child document from parent" | **GENERATE** → ops[] |
+
+Two refinements that keep it safe/deterministic: **(a) abstract body, typed binding** — the
+body can be anything (`form` = sql/expression/table/handler), but the *binding* is typed on
+three axes (which edge · what subject: data-row/line-pair/actor/state · when: the cell hook);
+**(b) GUARD vs GENERATE** — a predicate either gates an edge (→bool) or produces edges (→ops).
+
+**Access composes INTO the engine, not beside it (§0.8 made literal).** `ad_role_orgaccess`
+*narrows the matcher's partition* (you may only match within orgs your role sees);
+`document_action_access` *gates whether you may run the cell at all*. Access is just more
+predicates on the same edges — capability-first by default, narrowed by additive policy.
+
+**The generic Detail⋈Detail matcher** (the prize). One parameterized function serves the whole
+hard class — three-way match, payment allocation, inventory costing, bank reconciliation,
+landed-cost — because they are all *line-set ⋈ line-set under a non-unique key*:
+
+```
+match = partition(BPartner ∩ role-visible-orgs)   // the settlement spine, access-scoped
+      + key (product) + qty within tolerance       // the constraint
+      + ordering policy (FIFO/LIFO/by-amount/…)     // disambiguation, EDITABLE knob (data)
+      + greedy first-fit                            // deterministic
+```
+
+Proven: on real data it reproduces the oracle 18/18; on a synthetic *ambiguous* fixture the
+ordering policy is a real deterministic knob (FIFO→earliest, LIFO→latest) and role-scope
+narrows the partition and *overrides* the policy. One engine: match + ordering + access + guard,
+all via data, never bespoke code. (Ambiguity oracle = FIFO/LIFO *spec*; real-data = iDempiere.)
+
+### §0.15 The abstract engine, extracted — `scripts/erp_engine.js`
+
+The §0.10 "abstract engine" is now a real, separated module — **pure, no DB binding imported;
+the host injects `query(sql)→rows`**, so the *same core* runs under `sql.js` (browser) and
+`better-sqlite3` (node tests). Exports: `resolveCtx`, `dialectShim`, `evalGuard` (GUARD),
+`match`/`VERBS`/`completeOrder` (GENERATE). No `Date.now`/`Math.random`/DOM/network →
+replay/dry-run safe (§0.9 determinism). This paid the separation debt (the engine had been
+smeared/inlined across two probes); the regression — both POCs still green on the extracted
+module — proves it is the same logic.
+
+**Remaining debt (the next session's work):** (1) the matcher's partition/policy/access are
+still passed as JS opts in the harness — **not yet LOADED from `erp_rules` policy JSON +
+`ad_role`/`ad_role_orgaccess`** (the compile→engine wire); (2) **no kernel** applies + commits
+the returned ops to `kernel_ops` (handlers return ops; they're diff-compared, not yet
+committed/replayed through the log); (3) the engine lives in `bim-compiler/scripts` and must
+**move to `bim-ootb` as the shared module** both BIM and ERP import, when wired. See
+`prompts/ERP_RUNTIME_ENGINE.md`.
+
+### §0.16 The wire + the kernel — data-driven evaluator and op-log kernel (2026-05-29, §WIRE/§KERNEL PASS)
+
+The three debts of §0.15 are now closed for the O2C spine (witnesses: `build/erp/{poc_wire,poc_kernel}.log`; gate `verify_rules.log`):
+
+**(1) The compile→engine WIRE (`scripts/erp_runtime.js` · §WIRE PASS).** A `loadCell(ruleQuery,
+baseTable, action)` host layer sources EVERY engine opt from a rule record — no JS literals:
+ordering ← `MATCHPOLICY:<cell>` (new editable seed, default FIFO logged), fan-out flags ←
+`DOCPOLICY:<docTypeId>`, access scope (allowOrgs partition + may-run gate) ← `ACCESS:<roleId>`
+(new Step-1 extension compiling `ad_role` + `ad_role_orgaccess` + `ad_document_action_access`),
+guards ← `Validation` records bound to the table. Re-running Sales→Ship with zero JS opts kept
+settlement **18/18** for both `M_MatchInv`/`M_MatchPO` and derivation exact. The editable-rule
+loop is real: flipping the `MATCHPOLICY` body FIFO→LIFO **deterministically moved the pairing**
+(`pairsChanged=1`); a role scoped to org {0} **emptied the matcher partition** (`match=0/18` —
+access composes INTO the engine, §0.8); a role with no doc-action grant gave `mayRun=N`. The
+rule compiler now emits **746 records** (matchpolicy=2, access=5 added); the gate `verify_rules.js`
+extends `EVENT_TYPES` with `MatchPolicy`/`Access` and asserts the wiring inputs — PASS.
+
+**(2) The op-log KERNEL (`scripts/erp_kernel.js` · §KERNEL PASS).** Handlers are PURE
+`(doc,ctx)→ops[]` (read-only ctx, never a writable db); `Kernel.apply` applies each op to the
+5-table projection AND commits a **RICH op** (payload + actor + before/after + lineage GUIDs —
+the §0.6 keystone, witnessed: `§KERNEL rich-op actor=… payload.op=… lineage.out=…`).
+`Kernel.dispatch` runs the §18.6 ladder — state-machine legal (P2 `manifest.wfmc`) → `evalGuard`
+→ `Handlers.run` → `Kernel.apply`. The **violation guard** rolls back and rejects an out-of-log
+write (`§KERNEL violation out-of-log-write=BLOCKED`, sneaky row gone). **Replay** rebuilds the
+projection from `kernel_ops` ALONE with an identical hash (`§KERNEL replay projection==committed
+HASH=…`), and **frozen effects** hold: editing the rule is forward-only — a new order under the
+flipped policy doesn't ship, yet replaying the old order's stored ops still produces its original
+shipment (`old-ship=3 new-ship=0 replay-old-ship=3`). Worked fixture `T_ORDER_SHIPMENT_ALLOCATION`
+green end-to-end (shipment lines ARE the inventory fact — no inventory-mutation op; StorageOnHand
+deduction exact; shipment-Complete no double-count; payment-Allocate → ALLOCATE edge + journal).
+Deterministic (natural-key ids, ctx timestamps — no `Date.now`/`Math.random`), so replay is exact.
+The prototype's `commitOp` shape is exactly what `bim-ootb/viewer/kernel_ops.js` already ALLOWS.
+
+**(3) Relocation to `bim-ootb` — PARKED, awaiting go.** `erp_engine.js` + `erp_runtime.js` +
+`erp_kernel.js` still live in `bim-compiler/scripts/`. Moving them into `bim-ootb/viewer/` as the
+shared module erp.html imports (with `kernel_ops.js` NOT forking) is **T3 — push=live, no deploy
+without explicit go.**
+
+### §0.17 P3b BREADTH — the contained-set thesis, diff-verified across O2C/P2P/GL (2026-05-29, §ORACLE-SUITE 5/6 + §GRAVITY PASS)
+
+The §0.12 thesis — *"the handler hell collapses to ~8 effect-verbs + decision tables + ONE
+generic matcher"* — was on trial here against the **whole hot-cell scope**, each cell diffed
+against the iDempiere oracle, not asserted on the one proven path. **It held.** Witnesses:
+`build/erp/{diff_oracle,gravity_seed}.log`.
+
+**The diff-oracle harness (`scripts/diff_oracle.js` + `diff_oracle_cells.js`).** Per hot cell:
+register the PURE handler → dispatch the document-event through `Kernel.dispatch` (the §18.6
+ladder) → normalise the emitted op-group + the GardenWorld oracle rows to a canonical effect set
+→ diff. **The oracle is STATIC, not live (§0.12):** GardenWorld already executed every O2C/P2P/GL
+transaction, so the `M_InOut`/`C_Invoice`/`M_Match*`/`C_Allocation` rows in `ad_full.db` ARE the
+oracle's output — deterministic (no `Date.now`/sequence/id drift the live Docker path introduces).
+**Live Docker iDempiere is the documented FALLBACK** for a cell the static data can't ground —
+logged `oracle=NO-DATA(docker-fallback)`, never silently skipped.
+
+**Six hot cells, each EXTRACTED from its Java oracle method (not ported):**
+
+| cell | oracle | verbs | matcher | diff |
+|---|---|---|---|---|
+| `C_Order` SOO:CO | `MOrder.completeIt()` | `createShipment` | – | shipment **6/6** |
+| `C_Order` POO:CO | `MOrder.completeIt()` (purch) | `completeOrder` | – | no-fanout **MATCH** |
+| `M_InOut` MMR:CO | `MInOut.completeIt()` | setStatus | **Y** | M_MatchPO **19/19** + no-mutation |
+| `C_Invoice` API:CO | `MInvoice.completeIt():2077` | setStatus | **Y** | M_MatchInv **18/18** + M_MatchPO **18/18** |
+| `C_Payment` APP:CO | `MPayment`/`MAllocation*` | `allocate` | – | allocation **1/1** |
+| `GL_Journal` GLJ:CO | `MJournal.completeIt()` | – | – | **dataless** (fact_acct=0 → docker) |
+
+**Verdict — the contained set is sufficient:**
+- **Settlement (the §0.13 "hell") = ONE matcher, ZERO new verbs.** M_MatchInv + M_MatchPO across
+  *both* MMR:CO and API:CO are the same `E.match` (partition=BPartner, key=product, qty±tol) with
+  opts loaded from data (`MATCHPOLICY`/`ACCESS`). No bespoke per-cell algorithm.
+- **Derivation = `completeOrder` + a decision table.** SOO ships (DocType 133/135 `Y/Y`); POO does
+  NOT (DocType 126 `isautogenerateinout=N`) — the *same* verb, behaviour flipped by a data flag.
+
+**Two findings logged loud (the real output of a breadth test, §18.6):**
+1. **The matcher RE-DERIVES what iDempiere reads off a FK** (documented divergence, §18.10).
+   `MInvoice.completeIt()` follows the invoice line's own `M_InOutLine_ID`/`C_OrderLine_ID`; our
+   generic matcher reconstructs the identical pairs from partner+product+qty — and additionally
+   works when the FK is absent (invoice-before-receipt). It needs an **input-scoping** refinement
+   (MMR match restricted to order-linked receipts, else 2 false positives from no-PO receipts that
+   coincidentally share partner+product+qty) — that is caller *structure*, not a matcher change.
+2. **Allocation is NOT the matcher class** (this REFINES §0.14, which had listed it there).
+   Payment 100 (`PayAmt` 98.5) settles invoice 101 (`GrandTotal` 100.7) — a **partial, user-directed**
+   settlement. The qty-equality constraint does not apply; it is reproduced by **following
+   `C_Payment.C_Invoice_ID` + the existing ALLOCATE verb** (derivation-by-FK) — *cheaper* than
+   3-way match, not part of the settlement-lattice hell.
+
+**Kernel gravity seed (`scripts/gravity_seed.js`, P4 preview).** Ops stamped with their emitting
+cell; one §14-weighted query self-ranks the backlog: **`(C_Invoice,CO)` is #1** (weight 56.0, 36
+`MATCH` ops) — empirical confirmation of §0.13 (the settlement spine is where the logic concentrates).
+155 cold cells stay unwritten and cost nothing (§18.6). The product compiles its own backlog from use.
+
+**Kernel change:** added a `MATCH` op (the §0.1 `document_lines.match_type` settlement edge — the
+GENERATE output of the §0.14 matcher) and extended `ALLOCATE` to carry `invoice_id`. The four
+baselines (`§POC`/`§POCMATCH`/`§WIRE`/`§KERNEL`) all still PASS — no regression; the `MATCH` op
+also round-trips through **replay** (live-hash == replay-hash, 39 match rows reproduced). GL posting
+(`Fact_Acct`) is the one genuinely unwritten effect; it is dataless in this snapshot (async posting
+not run) and routes to the Docker fallback — the honest edge of the static-oracle method.
+
+### §0.18 Stepping back — what P3b means for the PRODUCT (not just the verification)
+
+A post-P3b reflection (the in-frame review verified the harness; this asks whether the frame fits
+the product). Three reframings that keep the next session sharp:
+
+**(a) The kernel is NOT iDempiere server heritage — it is the spine BIM already chose.** The
+temptation is to read kernel + matcher + dispatch as a faithful port of iDempiere's *server*
+architecture and ask whether that is overkill for a single-user, no-concurrency PWA. It is not a
+port: the kernel is ~150 lines replacing ~15,000, and it earns its keep on **three single-user axes
+today** — (1) undo/redo + time-machine (the BIM viewer *already* ships `kernel_ops` for exactly
+this), (2) deterministic replay / frozen effects (editable rules without corrupting history), (3)
+it is the *same* op-log BIM committed to. Concurrency is the *fourth* thing the same log buys later
+for free, not the reason it exists.
+
+**(b) P3b surfaced the PRODUCT-TIERING line — this is the real finding, beyond "thesis holds."**
+The data says the **entire long-tail flow is the cheap path**: `order→ship` and `pay→allocate` are
+FK-following + decision tables (derivation-by-FK, §0.13 BOM spine). The expensive **settlement
+lattice** (3-way match, costing, bank-rec, landed-cost) is the **buyer/pro tier** — the user who
+reconciles PO↔receipt↔invoice. A lone operator's *"bought it, here's the bill, mark paid"* is
+literally the allocation path P3b proved is **cheaper than the matcher** (§0.17 finding 2). This
+maps onto the existing **usage tier (§0.11): active-narrow vs housed-long-tail** — so the seam to
+**ship the cheap path to everyone and gate the matcher behind a pro mode** is already in the model.
+
+**(c) The op-log IS an operation-based CRDT (CmRDT) — the correct sync substrate, vs state CRDT.**
+For multi-user/server-side sync later (the question was raised explicitly), the SQLite-world options
+split two ways: **state CRDT** (e.g. `cr-sqlite` — column-level LWW relations, WASM build, automatic
+row merge) vs **op CRDT** (our `kernel_ops` — causal lineage GUIDs + parent pointers + deterministic
+frozen replay, Git-style DAG merge per §18.5/§18.7). State CRDT auto-merges but **LWW silently
+violates invariants** (two peers each "fully allocate" the same invoice → money lost). The op-log
+carries semantic intent and concentrates the hard merges at the few **document-handoff seams**
+(single-invoice-per-order, budget) where §18.7's *designated-owner node* / detect-and-reconcile is
+the right answer. Verdict: **do not adopt a state CRDT as the foundation — that downgrades the
+op-log**; reserve `cr-sqlite`-style LWW only for cold, invariant-free reference tables. The
+document-event op-GROUP (§18.8) is already the atomic causal unit that ships and replays together.
+
+**Open questions for the next session (not P3b blockers):** the editable-rules loop is proven for
+*flag edits* (FIFO→LIFO, fan-out on/off) but NOT for a user **inventing a new DocType behaviour
+needing a new verb** (that is the gravity-backlog path, §18.6 — write it when hot); the GL leg
+(`GLJ:CO → Fact_Acct`) is asserted, not tested (the static oracle has no posted facts); and the
+settlement cells dispatch the *universe* in one synthetic event rather than per-document (the count
+is faithful only because partitioning is clean — a per-document dispatch would test isolation).
+
+**(d) Enabling-tech timing — what gave us the edge, and when (so "are we too early?" is answered).**
+The *market-timing* statement is canonical in `SpatialERP_OOTB.md §11.5` ("three technologies matured
+2022–2024: SQLite WASM + Three.js r150+ + Web Payment Request API"). This note adds the one axis §11.5
+does **not** cover — the **concurrency-layer** distinction, which is what the "too early?" question is
+actually about. The recurring outside question is whether a browser-native ERP is *early* against the
+immature SQLite-WASM **multi-tab concurrency** layer. It is not — because that layer is **not our path**. Our
+window opened from three *mature* capabilities, and we deliberately route around the one still settling:
+
+| Capability | Matured | Role here | Concurrency exposure |
+|---|---|---|---|
+| **sql.js** (Emscripten→WASM SQLite, **in-memory**) | ~2014, rock-solid | the DB we actually ride: load file → query in RAM → export whole file | **none** — single in-memory context, no OPFS access-handle contention |
+| Official **SQLite WASM** build | beta late-2022 | reference / option; we do *not* depend on its persistent VFS | (would expose us if adopted — see below) |
+| **web-ifc** WASM (browser IFC parse) | 2023+ | drop-IFC onboarding, IFC2x3+IFC4, 122K elements | n/a |
+| **Three.js** r160 (Dec 2023) → r184 (Apr 2025); `BatchedMesh.addInstance` since r166 | 2024 | the *recent* enabler — 122K-element buildings / 1M-element cities smooth in a tab | n/a |
+
+The layer that is genuinely *still settling 2023→2027* is **persistent OPFS multi-tab concurrency**:
+`opfs-sahpool` (SQLite 3.43.0, 2023) is fast but has **zero** multi-tab concurrency; `OPFSCoopSyncVFS`
+allows concurrent connections but single transaction; wa-sqlite's `OPFSWriteAheadVFS` (Apr 2026, Chrome
+121+ only) is the first to allow reads parallel to a writer. **We touch none of it.** Persistence/sync is
+the **op-log (`kernel_ops`, a CmRDT — see (c))**, not concurrent OPFS writes; IndexedDB caches the file
+blob (our real ceiling is the ~1GB IDB record cap, already hit + fixed, not access handles). So the
+"too early" framing rests on a false premise: we are **not** perched on the immature concurrency feature
+waiting for Memory64/SharedWorkers — we ride 2014-era in-memory SQLite + a 2024-era 3D pipeline and treat
+concurrency as the *fourth* thing the op-log buys later for free (per (a)). **Read the right way, that
+immaturity is a first-mover *bonus*, not a risk:** the layer the field is still waiting on is the layer
+we routed around — so its unsettled state is direct evidence we arrived ahead of the pack, not early
+against an unproven bet (see `SpatialERP_OOTB.md §11.5`). The only move that *would*
+expose us to the OPFS timeline is migrating off sql.js to a persistent VFS — a choice to make only when a
+concrete need forces it, at which point the table above is the caveat list. (Verified May 2026 against
+sqlite.org/wasm + powersync.com state-of-persistence; external version/date claims from the DeepSeek
+analysis were largely fabricated and should not be cited.)
+
+### §0.19 P3c — the long-tail vertical ships matcher-free; the matcher composes in at one seam (2026-05-30, §VERTICAL + §GATE + §LONGTAIL PASS)
+
+P3c turned the §0.18b product-tiering finding into running code and closed the §0.18 per-document
+faithfulness gap. Witnesses: `build/erp/{diff_oracle,poc_longtail}.log`. Three results:
+
+**(1) Per-document dispatch — the §0.18 faithfulness gap, closed (Task 1).** The P3b settlement cells
+dispatched the whole vendor universe in ONE synthetic `invoiceDocId:'ALL'` event; `diff_oracle_cells.js`
+MMR:CO / API:CO now dispatch **per receipt / per invoice**, each reconciling ONLY its own lines within
+its partition, with consumed counterpart lines withheld from later documents (no double-claim, §18.8).
+The matcher opts still load from data; the candidate set is now one document's lines. **Isolation guard:**
+`Σ(per-document matches) == the P3b universe count` (M_MatchPO **19/19**, M_MatchInv **18/18**, M_MatchPO
+**18/18**), 0 missed / 0 extra — proving no cross-document leak the universe run was hiding. The clean
+data (no partner+product+qty ambiguity within any partition) makes per-document == universe exact.
+`§VERTICAL perdoc cell=(C_Invoice,CO) docs=4 … isolation=OK`. §ORACLE-SUITE stayed 5/6 PASS — no regression.
+
+**(2) The lone-operator vertical runs end-to-end, matcher NOT invoked (Task 2).** `scripts/poc_longtail.js`
+drives the one full GardenWorld chain — sales order 101 (DocType 135, BPartner 112) — through the kernel
+as **five per-document-event op-groups**: `raise SO → ship → invoice → receive payment → allocate`, using
+ONLY derivation verbs (`completeOrder` PLANS the fan-out from the decision table; `createShipment`/
+`createInvoice` emit the planned ship/invoice op-groups), FK-directed `ALLOCATE` (partial: PayAmt 98.5 of
+GrandTotal 100.7), and the C_DocType decision table. **`E.match` is monkey-patched with a call counter
+and asserted NOT-INVOKED across the whole path** (calls=0). The effects reproduce the oracle exactly
+(shipment line, invoice line, allocation edge — each 1/1) and **replay rebuilds the projection EXACTLY**
+(live-hash == replay-hash, 7 ops). `§VERTICAL flow=lone-operator events=5 matcher=NOT-INVOKED ops=7
+replay=EXACT diff=MATCH`. This is the empirical proof of §0.18b: the entire long-tail flow is the cheap
+path (derivation-by-FK), not the settlement lattice.
+
+**(3) The pro-gate seam — capability-first, additive not a fork (Task 3).** The exact cell where the
+matcher becomes necessary is **buyer reconciliation (`C_Invoice:CO` 3-way, PO↔receipt↔invoice)**. The tier
+split is expressed as **DATA** — a `CAPABILITY.pro_reconciliation.enabledFor` flag the SystemAdmin toggles
+per (DocType,action), §0.11 made operational. With the flag OFF (lone operator), the invoice completes
+with the cheap `setStatus` handler and the matcher is not invoked (settlement edges=0). With the flag ON,
+the matcher **composes IN**: the *same* cheap status op is emitted, with the settlement-edge ops APPENDED
+(`pro.ops == cheap.ops + matcher.edges`) — additive policy, the cheap-path handler never rewritten.
+`§GATE cheap-path-cells=[(C_Order,CO),(M_InOut,CO),(C_Invoice,CO cheap),(C_Payment,CO),(C_AllocationHdr,CO)]
+pro-gate-cell=(C_Invoice,CO 3-way) composes=Y data-gated=Y`. **Open edge:** the capability flag lives in
+memory in the POC; persisting it as a `CAPABILITY` rule in `erp_rules.db` (alongside `ACCESS`/`DOCPOLICY`)
+is the one-line next step. No `bim-ootb`, no Docker — T3 relocation still parked.
+
+### §0.20 NEXT PHASE — the secured/durable axis (UI POC frozen) (2026-05-31, SPEC — first witnesses have since landed; see §0.21)
+
+**Pivot.** The UI POC is proven: §0.19 drives the full O2C/P2P/GL chain through the kernel,
+matcher-gated, `replay-hash == live-hash`. **No further UI work** — the next phase tackles the
+*weak axes* §0.18(d) named (security, tamper-evidence, durability, multi-user) instead.
+
+**State of the art — has anyone solved these? Yes, and they all solved it the *same way*** (researched
+2026-05-31; sources below; **per-system mechanism / weakness / our-workaround deep-dive in
+`docs/LocalFirstPriorArt.md`**). The honest, load-bearing finding:
+
+> **Every production local-first system anchors trust in a server.** ElectricSQL and PowerSync (JWT
+> auth + Postgres Row-Level-Security mirrored into sync rules) and Replicache (server *re-runs* every
+> mutation — the server is the authority, the client an optimistic cache) all answer security + auth +
+> durability + multi-user the same way: **the server is the source of truth; the client is an offline
+> cache.** Conflict-convergence is a *mature, solved* category — CRDTs (Automerge's recent memory/performance
+> rewrite; Yjs powering Figma/Linear/Notion). Tamper-evidence is *mature crypto* —
+> hash-chained + Merkle append-only logs (Trillian, Rekor / Certificate Transparency).
+
+**What that means for us (and where "first" does and does NOT apply):**
+
+| Weak axis | Field's solved answer | Our move | First? |
+|---|---|---|---|
+| **Multi-user convergence** | CRDTs (Automerge/Yjs) — but they solve *convergence, not business invariants* | **Keep our semantic op-CRDT** (§0.18c): generic CRDT/LWW would silently violate invariants (double-allocate). We are *at frontier* here, not behind | No, but **we're ahead** on invariant-preserving merge |
+| **Tamper-evidence** | hash-chain + Merkle transparency logs (server/CA infra) | **Hash-chain + optionally sign each `kernel_ops` op** — extend today's replay-hash into a per-op chained hash; verifiable *offline* | **Narrowly yes** — the *placement* (transparency-log technique inside a browser-resident *business* log) is the one genuinely distinctive win |
+| **Durability** | `persist()` + treat local as cache + sync-to-server-of-truth | Finish §16.3: `navigator.storage.persist()` + op-log export/backup. Proven pattern | No — adopt it |
+| **Security / auth (multi-user)** | trusted backend: JWT + RLS / server-re-run | When multi-user is needed, adopt a **thin trust anchor** — §18.7 *designated-owner node* IS this. Proven, not novel | No — adopt it |
+
+**The architecture — two domains, one async op-log seam (this resolves the tension).** Separate the
+concerns cleanly into **two asynchronous domains that never block each other**, with `kernel_ops` as the
+boundary between them:
+
+- **UI domain (instant, optimistic, offline)** — the proven POC. Every action commits an op locally and the
+  projection updates at **0ms**; the user never waits on the network. Unchanged from today.
+- **Server domain (a dumb facilitator, async)** — *not* a re-running authority. It **accepts** pushed ops
+  (append-only), **assigns a total order** (the one thing that must be centralised), and **persists + fans
+  out**. It runs **no business logic** — determinism (§0.16) makes server re-execution redundant: clients
+  replay the ordered log to identical state, so there is no "server disagrees → overwrite" case (the
+  Replicache tax). *Signing is at the edge* (the user/merchant key, W-SIGN); *enforcement is the deterministic
+  kernel on every client* (non-owner ops rejected on replay, G-SINGLE-WRITER); *the facilitator only
+  sequences.* See `docs/DistributedERP.md §6` (facilitator-not-actor) + §10 (why this differs from
+  Replicache/PowerSync/ElectricSQL, which DO re-run/route writes through a backend).
+
+Because the seam is **asynchronous**, security does not cost interactive latency: the UI domain commits
+locally and is never gated on the facilitator. This refines §0.18(d): the zero-server property holds only for
+single-user/offline operation with no server at all; secured multi-user adds a thin async **facilitator**
+(order + persist + relay) that is not a trusted compute authority. The local commit path is unchanged in
+either case. The op-log is already the right
+payload (push = new ops, pull = the ordered/total-ordered log); the designated-owner node (§18.7) is a
+*client* role (the owner-gating that runs on replay), not a server that recomputes. *(The fact is a fold over
+the ordered log; the facilitator orders, the clients fold — `DistributedERP.md §0`.)*
+
+**Residual honesty.** Server-grade security/tamper-resistance still **cannot** be done purely client-side —
+the *secured* universe is the server domain doing the validating/signing; user-held keys give offline
+tamper-*evidence* (W-CHAIN/W-SIGN) but the *authority* is the trusted node. So we are **not "first to make a
+serverless ERP secure"** (the secured path has a server domain — that's the point). What stays distinctive,
+narrowly: a **cryptographically tamper-evident, offline-verifiable business op-log** + invariant-preserving
+merge + a **clean async two-domain split that preserves 0ms UX** — known techniques in an unusual
+arrangement, consistent with every other claim in this doc.
+
+**"First for BIM *and* ERP?" — defensible as combination, NOT as technique (researched 2026-05-31).** The
+*pattern* (op-log + optimistic UI + async trusted sync) is a **mature category** with off-the-shelf
+frameworks — nearest neighbor **LiveStore** ("git-inspired syncing via event-sourcing on reactive SQLite",
+conceptually almost identical to `kernel_ops` at the data layer); also ElectricSQL, Replicache, RxDB. **No
+"first" on the mechanism.** But by *domain*: offline BIM tools (OpenSpace, xeokit, BIMvision) are
+cache-for-*viewing*, not op-log local-first *editing* — none found; and no prominent local-first ERP
+*product* surfaced (SAP/Odoo/iDempiere stay server-authoritative). The **unification — BIM geometry *and*
+ERP transactions under ONE op-log (BIM undo == ERP audit, same kernel)** — turned up **no prior art**.
+Defensible claim, with the epistemic limit stated: ***first to our knowledge* to unify spatial-BIM and
+transactional-ERP under a single local-first op-log with an instant-UI / async-secured-server split** —
+*placement/combination* first, not *technique* first. (Cannot prove a negative; absence of search evidence
+≠ proof. LiveStore named so the claim is made knowing the neighbour exists.)
+
+**Phase tasks (spec-first — witness claim precedes code):**
+- **W-CHAIN** — each `kernel_ops` op stores `prev_hash`; `verifyChain()` walks the log and proves
+  `tamper detected at op N` on any altered payload. *Witness:* mutate one op's payload → chain breaks at
+  exactly that op; clean log → `chain OK len=N`.
+- **W-SIGN** *(optional, gated)* — ops signed with a user/device key; `verifyChain()` also checks signature.
+  *Witness:* op signed by key A fails verification under key B.
+- **W-PERSIST** — `navigator.storage.persist()` requested on first load; log export/restore round-trips.
+  *Witness:* `persisted=true` logged; export→wipe→import → `replay-hash == pre-export hash`.
+- **W-OWNER** *(multi-user, later)* — designated-owner-node reconcile at document-handoff seams (§18.7).
+  *Witness:* two peers each allocate the same invoice → owner rejects the second, no money lost.
+
+UI is frozen at the proven POC; this phase touches only `kernel_ops` integrity + persistence + (later) the
+trust anchor. **The full distributed-contention design — physics-partitions-data (branch→van→box), the
+guard set, the 90/10 + one-way-circle, the single customer-entitlement op-class with its URL-issued →
+phone-carried → touch/reconcile → ledger lifecycle, and the accounting-as-reconciler capstone — is specced
+in `docs/DistributedERP.md`** (stress-tested end-to-end: gapless DocNo, two-client ship, StorageOnHand,
+100-branch overnight, bonus-card double-claim, credit-on-phone, van-sales scan). **Sources:** [PowerSync](https://powersync.com/) · [ElectricSQL — local-first with your API](https://electric-sql.com/blog/2024/11/21/local-first-with-your-existing-api) · [Replicache push/auth](https://doc.replicache.dev/reference/server-push) · [Automerge](https://automerge.org/) · [Trillian / transparency.dev](https://transparency.dev/) · [LiveStore](https://livestore.dev/) (nearest-neighbour event-sourced local-first data layer).
+
+### §0.21 G-IDENTITY wired into the kernel — identity is an input, never computed (2026-06-01, SPEC + §IDENTITY)
+
+The Merge/G-IDENTITY POC (`scripts/poc_distributed.js`, §0.20 ledger #2) proved the property in a
+throwaway harness; this section ports it into the real prototype kernel `scripts/erp_kernel.js`. It is
+Phase-A item #2 of `prompts/ERP_DEPLOY_AND_TOUR.md`. **Witness:** `build/erp/poc_identity.log`
+(`§IDENTITY PASS`), driving the *actual* `Kernel.apply`/`Kernel.replay` — not a model of them.
+
+**The defect being fixed (two conflated identities, both computed).**
+- *Op id* — `kernel_ops` PK was `INTEGER PRIMARY KEY AUTOINCREMENT` (`erp_kernel.js`). Two devices each
+  mint `1,2,3…`; their logs **cannot union** without PK collision — the exact failure the POC's
+  "numeric-seq PKs collide" contrast names (`poc_distributed.js`).
+- *Entity id* (`output_guid`) — computed by `docKey`/`lineKey` (format `DOC:table@from<srcId>`) **on every
+  replay** from the payload. Computing identity at replay time violates DistributedERP §7 ("identity is an
+  input, never computed"): a recomputation can diverge from what the edge originally minted.
+
+**The decisions (D1–D4).**
+
+- **D1 — Op id becomes an edge-minted UUID, recorded.** `kernel_ops` PK → `op_uuid TEXT`, plus a `seq INTEGER`
+  for stable intra-device ordering. Minted via `ctx.mintOp(op,i)` (injectable) — prod passes
+  `crypto.randomUUID()`; the test default is the deterministic `actor + ':' + (baseTs+i)` so two devices
+  (`A:1000…`, `B:1000…`) union **clash-free without randomness** (replay-safe, §0.16 — no `Math.random`).
+- **D2 — Entity identity is supplied to the kernel and recorded in the op payload; replay READS it.** `apply`
+  stamps `op.uuid` once at first application and the rich payload carries it; `replay` finds `op.uuid`
+  present and uses it verbatim — `edgeMint` is **never invoked on the replay path**. This is the §7 fix:
+  the kernel no longer *computes* identity during replay, it *reads the recorded input*.
+- **D3 — `docKey`/`lineKey` are retired as the kernel's identity source.** Their deterministic-seed logic is
+  relocated into a single `edgeMint(op,state)` (folding the `DOC:`/`LINE:`/`ALLOC:`/`MATCH:` constructors)
+  that runs **at most once, at first apply, only when an op arrives without a `uuid`** — i.e. it models the
+  *edge* minting identity before the op enters the kernel. For source-derived docs `edgeMint` reproduces the
+  prior `DOC:…@from…` string **so the §ORACLE-SUITE / §LONGTAIL witnesses stay byte-stable** (`poc_longtail.js`
+  queries `document_id='DOC:M_InOut@from<id>'` — unchanged). The behaviour preserved; the *placement* of the
+  computation moved from "kernel, every replay" to "edge, once, recorded."
+- **D4 — This is the New-doc seam (forward, T3 stays parked).** A genuinely new document (no `source_id`)
+  takes an edge-minted `crypto.randomUUID()` at creation — exactly the moment a future **"New doc"** button
+  needs an identity *before any server exists*. The famed iDempiere **`ProcessIt()`/Complete** doc-action is
+  already `Kernel.dispatch` through the §18.6 ladder (`erp_kernel.js`); editing/CRUD surfacing from the
+  read-only stub (the "ring of fire" `+ (eye) (pencil) -` around a bubble is one rendering of it) is the
+  parked **T3** phase. #2 does not build T3 — it satisfies the identity contract T3 will require, so New-doc
+  + ProcessIt can be added later without re-touching the kernel.
+
+**Scope discipline.** All edits land in **`scripts/erp_kernel.js` only** — op generators (`erp_engine.js`
+verbs, inline handlers) emit *logical* ops with no guid, so `apply` is the single stamping chokepoint; no
+verb/handler/UI change, no `bim-ootb`, no deploy. T3 relocation (§0.16(3)) still parked.
+
+**Witnesses (W-IDENTITY-LIVE — must hold AND no regression):**
+- `§IDENTITY merge devices=2 ops=N` — two kernels apply disjoint op groups; union of their `kernel_ops`
+  has **distinct `op_uuid` count == N** (no PK clash).
+- `§IDENTITY replay hashA=… hashB=…` — replaying the merged, totally-ordered (`timestamp,op_uuid`) log into
+  two fresh kernels yields the **same projection hash** (holder-irrelevant).
+- `§IDENTITY no-recompute` — replay reproduces every `output_guid` from the recorded payload with
+  `edgeMint` call-count **0** on the replay path.
+- **No regression:** `poc_kernel.log §KERNEL PASS`, `poc_longtail.log §VERTICAL … replay=EXACT`,
+  `diff_oracle.log §ORACLE-SUITE 5/6`, `poc_distributed.log §DIST PASS` all still green.
+
+---
+
+## §1. iDempiere AD → SQLite Table Mapping
+
+### Source: live PostgreSQL (docker)
+
+```
+docker start postgres
+docker exec postgres psql -U adempiere -d idempiere
+```
+
+### AD metadata tables to export
+
+| PostgreSQL Table | Rows | Purpose | SQLite mapping |
+|---|---|---|---|
+| AD_Menu | 826 | Menu tree nodes | Direct copy |
+| AD_TreeNodeMM | 828 | Parent-child hierarchy for menu | Direct copy |
+| AD_Window | 458 | Window definitions | Direct copy |
+| AD_Tab | 1,167 | Tabs within windows | Direct copy |
+| AD_Field | 21,432 | Fields within tabs | Direct copy |
+| AD_Column | 26,519 | Column metadata (type, length, mandatory) | Direct copy |
+| AD_Table | 1,076 | Table definitions | Direct copy |
+| AD_Reference | 606 | Reference types (dropdown, search, etc.) | Direct copy |
+| AD_Ref_List | 1,545 | Dropdown option values | Direct copy |
+| AD_Element | 6,026 | UI labels and descriptions | Direct copy |
+
+**Total: ~60,000 rows of metadata. Estimated SQLite size: ~8-12 MB.**
+
+All tables use `CREATE TABLE IF NOT EXISTS` — safe to add to any existing DB.
+
+### Column subset (strip unused)
+
+Each AD table has ~30-60 columns. Many are unused by the UI renderer
+(CreatedBy, UpdatedBy, AD_Client_ID, AD_Org_ID for multi-tenant). We export
+a focused subset:
+
+**AD_Menu:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Menu (
+    AD_Menu_ID    INTEGER PRIMARY KEY,
+    Name          TEXT NOT NULL,
+    Description   TEXT,
+    IsSummary     TEXT DEFAULT 'N',      -- Y = folder, N = leaf
+    Action        TEXT,                   -- W=Window, R=Report, P=Process, X=Form
+    AD_Window_ID  INTEGER,
+    AD_Process_ID INTEGER,
+    AD_Form_ID    INTEGER,
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+**AD_TreeNodeMM** (menu hierarchy):
+```sql
+CREATE TABLE IF NOT EXISTS AD_TreeNodeMM (
+    AD_Tree_ID  INTEGER NOT NULL,        -- 10 = main menu tree
+    Node_ID     INTEGER NOT NULL,        -- = AD_Menu_ID
+    Parent_ID   INTEGER NOT NULL,        -- 0 = root
+    SeqNo       INTEGER DEFAULT 0,
+    IsActive    TEXT DEFAULT 'Y',
+    PRIMARY KEY (AD_Tree_ID, Node_ID)
+);
+```
+
+**AD_Window:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Window (
+    AD_Window_ID  INTEGER PRIMARY KEY,
+    Name          TEXT NOT NULL,
+    Description   TEXT,
+    Help          TEXT,
+    WindowType    TEXT DEFAULT 'M',      -- M=Maintain, T=Transaction, Q=Query
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Tab:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Tab (
+    AD_Tab_ID     INTEGER PRIMARY KEY,
+    AD_Window_ID  INTEGER NOT NULL,
+    Name          TEXT NOT NULL,
+    Description   TEXT,
+    Help          TEXT,
+    AD_Table_ID   INTEGER NOT NULL,
+    TabLevel      INTEGER DEFAULT 0,     -- 0=header, 1=detail, 2=sub-detail
+    SeqNo         INTEGER DEFAULT 10,
+    IsSingleRow   TEXT DEFAULT 'N',
+    IsReadOnly    TEXT DEFAULT 'N',
+    WhereClause   TEXT,
+    OrderByClause TEXT,
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Field:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Field (
+    AD_Field_ID   INTEGER PRIMARY KEY,
+    AD_Tab_ID     INTEGER NOT NULL,
+    AD_Column_ID  INTEGER NOT NULL,
+    Name          TEXT NOT NULL,
+    Description   TEXT,
+    Help          TEXT,
+    SeqNo         INTEGER DEFAULT 10,
+    IsDisplayed   TEXT DEFAULT 'Y',
+    DisplayLogic  TEXT,                  -- iDempiere logic expression
+    IsMandatory   TEXT,                  -- Y/N or logic expression
+    IsReadOnly    TEXT DEFAULT 'N',
+    DefaultValue  TEXT,
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Column:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Column (
+    AD_Column_ID    INTEGER PRIMARY KEY,
+    AD_Table_ID     INTEGER NOT NULL,
+    ColumnName      TEXT NOT NULL,
+    Name            TEXT,
+    Description     TEXT,
+    AD_Reference_ID INTEGER,             -- field type: 10=String, 11=Integer, 19=TableDirect, etc.
+    AD_Val_Rule_ID  INTEGER,
+    FieldLength     INTEGER DEFAULT 0,
+    IsMandatory     TEXT DEFAULT 'N',
+    IsKey           TEXT DEFAULT 'N',
+    IsIdentifier    TEXT DEFAULT 'N',
+    DefaultValue    TEXT,
+    ValueMin        TEXT,
+    ValueMax        TEXT,
+    IsActive        TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Table:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Table (
+    AD_Table_ID   INTEGER PRIMARY KEY,
+    TableName     TEXT NOT NULL,
+    Name          TEXT,
+    Description   TEXT,
+    AD_Window_ID  INTEGER,
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Reference & AD_Ref_List:**
+```sql
+CREATE TABLE IF NOT EXISTS AD_Reference (
+    AD_Reference_ID INTEGER PRIMARY KEY,
+    Name            TEXT NOT NULL,
+    Description     TEXT,
+    ValidationType  TEXT,                -- L=List, T=Table, D=DataType
+    IsActive        TEXT DEFAULT 'Y'
+);
+
+CREATE TABLE IF NOT EXISTS AD_Ref_List (
+    AD_Ref_List_ID  INTEGER PRIMARY KEY,
+    AD_Reference_ID INTEGER NOT NULL,
+    Value           TEXT NOT NULL,
+    Name            TEXT NOT NULL,
+    Description     TEXT,
+    IsActive        TEXT DEFAULT 'Y'
+);
+```
+
+**AD_Element** (labels):
+```sql
+CREATE TABLE IF NOT EXISTS AD_Element (
+    AD_Element_ID INTEGER PRIMARY KEY,
+    ColumnName    TEXT,
+    Name          TEXT NOT NULL,
+    PrintName     TEXT,
+    Description   TEXT,
+    IsActive      TEXT DEFAULT 'Y'
+);
+```
+
+---
+
+## §2. PostgreSQL Export Strategy
+
+### Script: `scripts/export_ad.sh`
+
+```bash
+#!/bin/bash
+# Export iDempiere AD metadata from PostgreSQL to SQLite
+# Requires: docker postgres container running with idempiere DB
+
+CONTAINER=postgres
+DB=idempiere
+USER=adempiere
+OUTPUT=deploy/dev/ad_seed.sql
+
+TABLES=(
+  "AD_Menu:AD_Menu_ID,Name,Description,IsSummary,Action,AD_Window_ID,AD_Process_ID,AD_Form_ID,IsActive"
+  "AD_TreeNodeMM:AD_Tree_ID,Node_ID,Parent_ID,SeqNo,IsActive"
+  "AD_Window:AD_Window_ID,Name,Description,Help,WindowType,IsActive"
+  "AD_Tab:AD_Tab_ID,AD_Window_ID,Name,Description,Help,AD_Table_ID,TabLevel,SeqNo,IsSingleRow,IsReadOnly,WhereClause,OrderByClause,IsActive"
+  "AD_Field:AD_Field_ID,AD_Tab_ID,AD_Column_ID,Name,Description,Help,SeqNo,IsDisplayed,DisplayLogic,IsMandatory,IsReadOnly,DefaultValue,IsActive"
+  "AD_Column:AD_Column_ID,AD_Table_ID,ColumnName,Name,Description,AD_Reference_ID,AD_Val_Rule_ID,FieldLength,IsMandatory,IsKey,IsIdentifier,DefaultValue,ValueMin,ValueMax,IsActive"
+  "AD_Table:AD_Table_ID,TableName,Name,Description,AD_Window_ID,IsActive"
+  "AD_Reference:AD_Reference_ID,Name,Description,ValidationType,IsActive"
+  "AD_Ref_List:AD_Ref_List_ID,AD_Reference_ID,Value,Name,Description,IsActive"
+  "AD_Element:AD_Element_ID,ColumnName,Name,PrintName,Description,IsActive"
+)
+```
+
+For each table: `COPY (SELECT columns FROM table WHERE IsActive='Y') TO STDOUT CSV`
+→ parse CSV → generate `INSERT OR IGNORE INTO` statements → write to ad_seed.sql.
+
+### Data sanitization
+- Strip `IsActive='N'` rows (reduces noise)
+- NULL → empty string for TEXT, 0 for INTEGER
+- Escape single quotes in text values
+- Filter AD_TreeNodeMM to `AD_Tree_ID = 10` (main menu tree only)
+- No BLOBs in AD tables — all text/integer
+
+### Expected output size
+- ~60,000 INSERT statements
+- ~4-8 MB SQL file
+- Loads in < 2 seconds via sql.js
+
+---
+
+## §3. AD Parser Design — `ad_parser.js`
+
+Pure data reader. No UI. No side effects except §-log.
+
+### API
+
+```javascript
+ADParser.init(db)
+  // §AD_PARSER init
+  // Reads AD table counts, logs: menu=826 windows=458 tabs=1167 fields=21432
+
+ADParser.getMenuTree(db)
+  // §AD_PARSER menuTree nodes=826 roots=15
+  // Returns: { id, name, children: [...], action, windowId, isSummary }
+  // Builds tree from AD_Menu + AD_TreeNodeMM (Parent_ID → children)
+
+ADParser.getWindow(db, windowId)
+  // §AD_PARSER getWindow id=130 name=Project tabs=8
+  // Returns: { id, name, description, windowType, tabs: [...] }
+
+ADParser.getTabs(db, windowId)
+  // §AD_PARSER getTabs windowId=130 count=8
+  // Returns: [{ id, name, tabLevel, seqNo, tableName, fields: [...] }]
+  // Sorted by SeqNo. Each tab includes its fields.
+
+ADParser.getFields(db, tabId)
+  // §AD_PARSER getFields tabId=157 count=45
+  // Returns: [{ id, name, columnName, referenceId, seqNo, isDisplayed,
+  //             displayLogic, isMandatory, isReadOnly, defaultValue }]
+  // Joins AD_Field → AD_Column for column metadata
+
+ADParser.resolveReference(db, referenceId)
+  // §AD_PARSER resolveRef id=319 type=List options=5
+  // Returns: [{ value, name, description }] for List references
+  // Returns: { tableName, keyColumn, displayColumn } for Table references
+
+ADParser.getTableName(db, tableId)
+  // Returns TableName from AD_Table
+```
+
+### iDempiere Reference Types (AD_Reference_ID values)
+
+| ID | Name | Renderer |
+|---|---|---|
+| 10 | String | `<input type="text">` |
+| 11 | Integer | `<input type="number">` |
+| 12 | Amount | `<input type="number" step="0.01">` |
+| 13 | ID | hidden (primary key) |
+| 14 | Text | `<textarea>` |
+| 15 | Date | `<input type="date">` |
+| 16 | DateTime | `<input type="datetime-local">` |
+| 17 | List | `<select>` from AD_Ref_List |
+| 18 | Table | `<select>` with AD_Val_Rule filter |
+| 19 | TableDir | `<select>` from referenced table |
+| 20 | YesNo | `<input type="checkbox">` |
+| 22 | Number | `<input type="number" step="any">` |
+| 28 | Button | `<button>` (triggers DocAction) |
+| 29 | Quantity | `<input type="number">` |
+| 30 | Search | `<input>` with typeahead lookup |
+| 38 | FilePath | `<input type="file">` |
+
+---
+
+## §4. Card-First AD Renderer — `ad_ui.js`
+
+Mobile-first. Dark theme. Same visual language as BIM OOTB.
+
+### Menu — hamburger sidebar
+
+```
+┌──────────────────────────────────┐
+│ ☰ ERP OOTB           [🔍] [👤]  │  App bar
+├──────────────────────────────────┤
+│                                  │
+│  ┌────────────────────────────┐  │
+│  │  C_Project: ABC Tower      │  │  Current window
+│  │  Phase: Foundation          │  │  as card
+│  │  Status: ⬤ IN_PROGRESS      │  │
+│  │  ...                        │  │
+│  └────────────────────────────┘  │
+│                                  │
+│  ← swipe → (next record)        │
+│  ↑ swipe ↑ (next tab)           │
+│                                  │
+└──────────────────────────────────┘
+```
+
+Tap ☰ → sidebar slides in:
+
+```
+┌────────────────────┬─────────────┐
+│ ☰ Menu             │             │
+│                    │  (dimmed)   │
+│ ▼ Partner Relations│             │
+│   ● Business Partn │             │
+│   ○ Contact        │             │
+│ ▼ Materials Mgmt   │             │
+│   ● Product        │             │
+│   ○ Price List     │             │
+│ ▼ Project Mgmt     │             │
+│   ● Project ←ACTIVE│             │
+│ ▼ Financial        │             │
+│   ○ GL Journal     │             │
+│ ▼ Manufacturing    │             │
+│   ○ BOM            │             │
+│ ...                │             │
+└────────────────────┴─────────────┘
+```
+
+### Window → tab cards
+
+Each AD_Window renders as a card stack. Tabs are horizontal swipe pages.
+Reuses `swipe.js` from P3 UI.
+
+Tab header bar:
+```
+┌──────────────────────────────────┐
+│ [Project] [Phase] [Task] [Line] │  Tab bar (scroll horizontal)
+│  ════════                       │  Underline = active tab
+├──────────────────────────────────┤
+│                                  │
+│  Name: ABC Tower Construction    │  Fields rendered from AD_Field
+│  Status: [▼ In Progress]        │  Reference types determine widget
+│  Start Date: [2026-05-13]       │
+│  End Date: [2026-12-31]         │
+│  ...                            │
+│                                  │
+│  [Save] [Delete] [New]          │  Actions
+│                                  │
+└──────────────────────────────────┘
+```
+
+### Field rendering rules
+
+```javascript
+// For each AD_Field in the tab:
+// 1. Get AD_Column via AD_Column_ID
+// 2. Get Reference type via AD_Reference_ID
+// 3. Render appropriate input widget
+// 4. Apply DisplayLogic (show/hide)
+// 5. Apply IsMandatory (red border if empty)
+// 6. Apply IsReadOnly (disabled)
+// 7. Apply DefaultValue on new record
+```
+
+### DisplayLogic parser
+
+iDempiere display logic format: `@ColumnName@='value'&@Other@!''`
+
+```javascript
+function evaluateDisplayLogic(logic, record) {
+  // Replace @ColumnName@ with record[ColumnName]
+  // Evaluate: = (equals), ! (not equals), > < >= <=
+  // Combine: & (AND), | (OR)
+  // Returns: true (show) or false (hide)
+}
+```
+
+---
+
+## §4b. HTML-Native UI — Replacing ZK Patterns
+
+> **Principle:** iDempiere uses ZK Framework (server-side Java → HTML widget rendering, ~2006 architecture). Every click is a server round-trip. HTML Living Standard (2024+) provides native equivalents that are faster, offline-capable, and GPU-accelerated — no framework needed.
+
+### Accordion Data Panels — `<details>` + CSS
+
+ZK uses `Groupbox` with server-managed open/close state. HTML `<details>` is native, zero-JS, accessible:
+
+```html
+<!-- Native accordion — no JS, no framework, keyboard accessible -->
+<details open>
+  <summary>Partner Relations</summary>
+  <div class="accordion-body">
+    <a href="#" data-window="C_BPartner">Business Partner</a>
+    <a href="#" data-window="AD_User">Contact</a>
+  </div>
+</details>
+<details>
+  <summary>Materials Management</summary>
+  <div class="accordion-body">
+    <a href="#" data-window="M_Product">Product</a>
+    <a href="#" data-window="M_PriceList">Price List</a>
+  </div>
+</details>
+```
+
+**Enhancements over ZK:**
+
+| ZK Pattern | HTML-Native Replacement | Advantage |
+|---|---|---|
+| `Groupbox` open/close | `<details>/<summary>` | Zero JS, keyboard accessible, animated via CSS `transition` |
+| `Tabbox` tab switching | CSS `scroll-snap` + swipe | Native momentum, touch-friendly, no server round-trip |
+| `Listbox` row selection | `<dialog>` + popover list | Native modal, backdrop, Escape key, focus trap |
+| `Textbox` validation | `<input>` + `pattern` + `:invalid` CSS | Browser-native, no server validation round-trip |
+| `Datebox` calendar | `<input type="date">` | Native picker on all platforms, locale-aware |
+| `Combobox` dropdown | `<datalist>` + `<input list>` | Native search-as-you-type, no custom JS |
+| `Tree` hierarchy | Nested `<details>` | Collapsible tree with zero JS, infinite nesting |
+| `Grid` data table | CSS Grid + `subgrid` | Responsive, sticky headers, no fixed columns |
+| `Messagebox` alert | `<dialog>` element | Native modal, animatable, no Z-index wars |
+
+### Animated Accordion (CSS only)
+
+```css
+details .accordion-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+  overflow: hidden;
+}
+details[open] .accordion-body {
+  grid-template-rows: 1fr;
+}
+details summary {
+  cursor: pointer;
+  padding: 12px 16px;
+  background: rgba(255,255,255,0.05);
+  border-radius: 8px;
+  list-style: none;  /* remove default triangle */
+}
+details summary::before {
+  content: '▸';
+  display: inline-block;
+  transition: transform 0.2s;
+  margin-right: 8px;
+}
+details[open] summary::before {
+  transform: rotate(90deg);
+}
+```
+
+### View Transitions (panel morphing)
+
+When user navigates between ERP windows (e.g. Project → Phase → Task), the DOM morphs with cross-fade:
+
+```javascript
+// One line wraps any DOM change into a smooth transition
+document.startViewTransition(() => {
+  renderWindow(nextWindowId);  // swaps DOM content
+});
+```
+
+Browser automatically:
+1. Snapshots old state
+2. Renders new state
+3. Cross-fades between them (GPU-accelerated, ~16ms)
+4. Falls back to instant swap if unsupported
+
+**No animation library needed.** This replaces ZK's `Clients.evalJavascript()` animation hacks.
+
+### Scroll-Snap for Tab Navigation
+
+Instead of ZK `Tabbox` (click tab header → server fetches panel → re-renders):
+
+```css
+.tab-container {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.tab-panel {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+}
+```
+
+User swipes left/right between tab panels. Native momentum, no JS event handling, works on mobile. Tab header highlights sync via `IntersectionObserver`:
+
+```javascript
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(e => {
+    if (e.isIntersecting) highlightTab(e.target.dataset.tabId);
+  });
+}, { root: tabContainer, threshold: 0.5 });
+tabPanels.forEach(p => observer.observe(p));
+```
+
+### Popover for Field Help + FK Lookup
+
+```html
+<!-- Field with popover help -->
+<label>
+  Business Partner
+  <button popovertarget="bp-help">?</button>
+</label>
+<input type="text" list="bp-list" />
+<datalist id="bp-list">
+  <!-- populated from AD_Ref_List or FK query -->
+</datalist>
+<div id="bp-help" popover>
+  Select the business partner for this transaction.
+  Links to C_BPartner table.
+</div>
+```
+
+`popover` attribute: native positioning, auto-dismiss on outside click, no Z-index management. Replaces ZK's `Popup` component entirely.
+
+### Container Queries for Responsive Panels
+
+Each ERP panel resizes based on its own width, not the viewport:
+
+```css
+.erp-panel {
+  container-type: inline-size;
+}
+@container (max-width: 400px) {
+  .field-row { flex-direction: column; }  /* stack labels above inputs */
+}
+@container (min-width: 600px) {
+  .field-row { display: grid; grid-template-columns: 150px 1fr; }  /* label left, input right */
+}
+```
+
+This means the same panel works in:
+- Full-screen desktop (wide layout)
+- Side-by-side with 3D viewer (narrow layout)
+- Mobile (stacked layout)
+
+No media queries, no breakpoint math — each panel is self-contained.
+
+### Performance Comparison
+
+| Operation | ZK (iDempiere) | HTML-Native (ERP OOTB) |
+|---|---|---|
+| Open accordion | ~200ms (server round-trip + re-render) | ~16ms (CSS transition, no JS) |
+| Switch tab | ~300-500ms (AJAX + DOM replace) | ~0ms (scroll-snap, already loaded) |
+| Show tooltip | ~150ms (server → Popup component) | ~1ms (popover, native) |
+| Validate field | ~200ms (server → Callout) | ~0ms (browser `:invalid`, pattern match) |
+| Load dropdown | ~300ms (AJAX → Listbox) | ~5ms (`<datalist>` from IndexedDB) |
+| Render 100 rows | ~1-2s (server → Grid → DOM) | ~10ms (CSS Grid, virtual scroll) |
+
+**Total tab-to-data: ZK ~2-5s per interaction vs HTML-native ~20ms.**
+
+### Implementation in `ad_ui.js`
+
+The existing card renderer (`ad_ui.js`) already uses dark-theme cards with swipe. The accordion pattern replaces the sidebar menu:
+
+1. **Menu**: nested `<details>` tree (replaces current sidebar list)
+2. **Window tabs**: `scroll-snap` container (replaces current tab bar click handlers)
+3. **Field rendering**: `<datalist>` for FK lookups, `<input type="date/number">` for typed fields, `<dialog>` for confirmations
+4. **Transitions**: `document.startViewTransition()` wrapping `renderWindow()`
+5. **Responsive**: `container-type: inline-size` on `.erp-panel`
+
+All native. No framework. No build step. Same pattern as the BIM viewer: single HTML, browser does the work.
+
+---
+
+## §5. C_Project = Construction POC Bridge
+
+The existing construction POC handlers map directly to C_Project AD window:
+
+| POC Concept | AD Concept | Table |
+|---|---|---|
+| Lead/Document | C_Project record | C_Project |
+| Phase container | C_ProjectPhase tab | C_ProjectPhase |
+| Task | C_ProjectTask tab | C_ProjectTask |
+| BOQ line | C_ProjectLine tab | C_ProjectLine |
+| Status lifecycle | DocAction (DR→IP→CO→VO) | C_Project.DocStatus |
+
+### BIM integration
+
+C_Project window gets a special "BIM" action button:
+- If the project has a `geometry_id` or IFC link → show "Open in 3D"
+- BroadcastChannel posts to viewer for cross-tab highlighting
+- Reuses existing `bim_4d` channel pattern from boq_charts.html
+
+---
+
+## §6. Cross-table analytics
+
+Because all data is in one SQLite database in the browser, an SQL query across
+any tables can be rendered as a chart client-side, with no server round-trip.
+
+### Built-in chart views
+
+Each AD_Window gets a [📊] button that opens an analytics overlay:
+
+```sql
+-- Projects by status (C_Project)
+SELECT DocStatus, COUNT(*), SUM(PlannedAmt)
+FROM C_Project GROUP BY DocStatus
+
+-- Products by category with total value
+SELECT pc.Name, COUNT(*), SUM(pp.PriceStd * pp.PriceLimit)
+FROM M_Product p
+JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID
+LEFT JOIN M_ProductPrice pp ON p.M_Product_ID = pp.M_Product_ID
+GROUP BY pc.Name
+
+-- Partner aging (open invoices)
+SELECT bp.Name, SUM(inv.GrandTotal), MIN(inv.DateInvoiced)
+FROM C_Invoice inv
+JOIN C_BPartner bp ON inv.C_BPartner_ID = bp.C_BPartner_ID
+WHERE inv.IsPaid = 'N'
+GROUP BY bp.Name ORDER BY MIN(inv.DateInvoiced)
+```
+
+Rendered using Canvas bar/pie charts — same pattern as `boq_charts.html`.
+
+**Comparison with a server-side approach (e.g. Odoo):**
+- A server-side stack performs cross-table queries via server + ORM + (in Odoo's case) Python.
+- The client-side approach here uses one SQL statement plus Canvas, executing locally and offline.
+- Any SQL can be entered in a query box and rendered as a chart.
+- The query is the report definition; no separate report-designer or reporting engine (e.g. Jasper) is required.
+
+---
+
+## §7. BroadcastChannel Integration
+
+### Channel: `bim_erp`
+
+Following the existing `bim_4d` pattern in `main.js` line 154.
+
+| Direction | Message | Payload | Action |
+|---|---|---|---|
+| ERP → Viewer | `ERP_FOCUS_STOREY` | `{ storey: 'Ground Floor' }` | Viewer filters to storey |
+| ERP → Viewer | `ERP_HIGHLIGHT` | `{ guids: [...], color }` | Viewer highlights elements |
+| ERP → Viewer | `ERP_PING` | `{}` | Check if viewer is open |
+| Viewer → ERP | `ERP_ELEMENT_PICKED` | `{ guid, ifc_class, storey }` | ERP shows related records |
+| Viewer → ERP | `ERP_PONG` | `{}` | Viewer is alive |
+
+---
+
+## §8. Landing Page Integration
+
+### SYSNOVA/index.html changes
+
+1. Each building card gets an amber "ERP" button alongside "3D Viewer"
+2. `openERP(archName)` opens `sandbox/erp.html?db=buildings/{name}_extracted.db`
+3. Footer "ERP — GOD MODE" becomes "ERP OOTB" linking to `sandbox/erp.html`
+4. Tab tracker shows ERP tabs alongside 3D tabs
+
+### Standalone mode
+
+`erp.html` with no `?db=` parameter → loads `ad_seed.sql` with full AD metadata
++ sample data for C_Project, C_BPartner, M_Product. This is the demo mode.
+
+`erp.html?db=Hospital.db` → loads building DB, adds AD tables on top,
+bootstraps containers from BIM elements_meta storeys.
+
+---
+
+## §9. Implementation Phases
+
+### Phase 1 — This session (spec + export + parser)
+
+| Step | Deliverable | Verify |
+|---|---|---|
+| 1 | `docs/ERP.md` (this file) | Spec complete |
+| 2 | `scripts/export_ad.sh` | Exports 10 AD tables from PostgreSQL |
+| 3 | `deploy/dev/ad_seed.sql` | ~60K rows of real iDempiere AD metadata |
+| 4 | `deploy/dev/ad_parser.js` | getMenuTree, getWindow, getTabs, getFields |
+| 5 | `tests/test_ad_parser.js` | §-log verified: menu=826, windows=458, tabs=1167 |
+
+### Phase 2 — Next session (renderer + CRUD)
+
+| Step | Deliverable | Verify |
+|---|---|---|
+| 6 | `deploy/dev/ad_ui.js` | Menu sidebar, window cards, tab swipe, field inputs |
+| 7 | `deploy/dev/ad_data.js` | Generic CRUD for any AD_Table |
+| 8 | `deploy/dev/erp.html` rewrite | Full AD-driven UI |
+| 9 | `deploy/dev/ad_charts.js` | Cross-table analytics charts |
+| 10 | Landing page integration | ERP buttons on building cards |
+
+### Phase 3 — Showcase session
+
+| Step | Deliverable | Verify |
+|---|---|---|
+| 11 | Sample data for 3 windows | C_Project, C_BPartner, M_Product with real records |
+| 12 | BroadcastChannel wiring | ERP ↔ BIM viewer cross-tab |
+| 13 | Deploy to OCI dev bucket | Live at sandbox/erp.html |
+| 14 | Video demo | Full AD menu → C_Project → BIM link → chart |
+
+---
+
+## §10. Scope and status
+
+The Application Dictionary in this build comprises 826 menu nodes, 458 windows,
+1167 tabs, and 21,432 fields, served from a ~12MB SQLite file loaded via
+WebAssembly, with no server process and offline operation. The AD metadata is
+not modified — it is extracted from a live iDempiere instance and reinterpreted
+client-side.
+
+Status, stated without overclaim: the construction-project window (`C_Project`)
+is the worked example, three windows are wired end-to-end, and the remaining
+menu tree is present as metadata but not every cell is handler-backed (the
+housed-vs-active distinction, [§0.11](#011-housed-vs-active--the-full-extent-hidden-but-callable)).
+For proven-vs-parked, see [§0.17](#017-p3b-breadth--the-contained-set-thesis-diff-verified-across-o2cp2pgl-2026-05-29-oracle-suite-56--gravity-pass),
+[§0.20](#020-next-phase--the-secureddurable-axis-ui-poc-frozen-2026-05-31-spec--no-code-yet), and the
+witness scripts ([scripts/](https://github.com/red1oon/BIMCompiler/tree/full/scripts) — `poc_*.js`, each
+asserting `replay-hash == live-hash`). This is not the first SQLite-WASM or local-first system; the prior-art
+floor is in [DistributedERP.md §10](DistributedERP.md#10-comparison-with-related-systems).
+
+---
+
+## §11. The three-layer architecture
+
+§1–§10 establish that the AD can run in a browser. Running it unchanged,
+however — roughly a thousand tables and tens of thousands of field definitions — carries
+the full server-side footprint into a client-side runtime that does not need
+it. The architecture separates the ERP into three layers:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  PRESENTATION — what the user sees and touches          │
+│  Globe constellation, accordion drill, pills, settings  │
+│  Reads data via SQL. Triggers logic via user actions.    │
+│  Files: ad_ui.js, ad_graph.js, erp.html                │
+├─────────────────────────────────────────────────────────┤
+│  LOGIC — business rules, pure functions                 │
+│  "When payment completes, allocate against invoices"     │
+│  Takes db + document. Produces kernel_ops. Testable.     │
+│  Files: rules/*.js (allocation, pricing, tax, bom, etc) │
+├─────────────────────────────────────────────────────────┤
+│  DATA — 5 tables + kernel_ops + journal                 │
+│  Dumb storage. No triggers. No procedures. Portable.     │
+│  The op log IS the audit trail. Journal IS the books.    │
+│  Files: SQLite WASM (ad_seed.db or business.db)         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Boundaries (enforced, not suggested):**
+- Presentation → Logic: calls rule functions on user action
+- Logic → Data: `commitOp()` is the ONLY write path
+- Data → Presentation: SQL queries are the ONLY read path
+- No layer reaches into another's internals
+
+### §11.1 Why separation matters
+
+In iDempiere, logic is scattered across 6 extension points:
+ModelValidator, Callout, DocAction, Process, DB triggers, AD_Val_Rule.
+A developer changing "what happens when an invoice completes" must check
+all six. This is the real ERP monster — not the data model, not the UI,
+but the logic spaghetti.
+
+In ERP OOTB, logic lives in ONE place: rule functions. Each is a pure
+function that takes a database handle and a document ID, reads what it
+needs, and produces kernel_ops. No framework. No base class. No interface
+to implement. Just: data in, ops out.
+
+```javascript
+// rules/allocation.js — pure function, testable, readable
+function allocatePayment(db, paymentId) {
+  var payment = getDoc(db, paymentId);
+  var invoices = getOpenInvoices(db, payment.metadata.partner_id);
+  var remaining = payment.metadata.amount;
+  for (var i = 0; i < invoices.length && remaining > 0; i++) {
+    var allocated = Math.min(remaining, invoices[i].metadata.amount);
+    commitOp(db, 'ALLOCATE', {
+      payment: paymentId, invoice: invoices[i].id, amount: allocated
+    });
+    remaining -= allocated;
+  }
+}
+```
+
+This function is:
+- **Testable** — pass it a mock db, verify the ops it produces
+- **Readable** — a business person can follow the logic
+- **Reversible** — undo the commitOps, the allocation unwinds
+- **Auditable** — kernel_ops records which rule fired and why
+
+---
+
+## §12. The 5-Table Foundation
+
+iDempiere has on the order of a thousand tables because it grew organically over 20 years —
+each module adding its own tables. The 5-table design (from SpatialERP
+POC §3.1) says: **a document is a document.**
+
+| Table | What | Replaces in iDempiere |
+|---|---|---|
+| `containers` | Spatial hierarchy: Site→Building→Floor | C_Project, C_ProjectPhase, M_Warehouse |
+| `items` | Things in containers: products, partners, materials | M_Product, C_BPartner, M_BOM |
+| `documents` | ALL doc types in ONE table | C_Order, C_Invoice, C_Payment, M_InOut |
+| `document_lines` | Lines for any document | C_OrderLine, C_InvoiceLine, M_InOutLine |
+| `journal` | Auto-posted double-entry accounting | GL_Journal, Fact_Acct |
+| + `kernel_ops` | Event log, undo/redo, audit trail | AD_ChangeLog (no undo equivalent) |
+
+A Purchase Order, an Invoice, a Lead, a Credit Memo — they're all rows
+in `documents` with different `doc_type`. The structure is identical.
+Only the business rules differ, and those live in the logic layer, not
+the schema.
+
+### §12.1 The journal as proof of correctness
+
+Every document completion produces journal entries:
+```
+Complete PO #1001 → debit INVENTORY, credit ACCOUNTS_PAYABLE
+Complete Invoice #5001 → debit ACCOUNTS_PAYABLE, credit CASH
+```
+
+Undo a completion → `journalReverse()` posts counter-entries → net = 0.
+This is double-entry bookkeeping — Luca Pacioli's 1494 invention — in
+30 lines of JavaScript. The journal is the source of truth for finance.
+If the journal balances, the books are correct. Everything else is UI.
+
+### §12.2 The metadata JSON column
+
+Each table has a `metadata TEXT DEFAULT '{}'` column. This is where
+domain-specific fields live: `land_size` for a property lead,
+`payment_terms` for a PO, `tax_rate` for an invoice line.
+
+This is a deliberate trade-off: schemaless flexibility over rigid columns.
+The compiled manifest (§13) tells the UI which metadata fields to render
+for each doc_type. The kernel enforces mandatory metadata fields at
+commitOp time. But the table schema never changes.
+
+---
+
+## §13. The Compiled Manifest — AD as Compiler Input
+
+The full AD (roughly a thousand tables, tens of thousands of fields) is **compile-time input**,
+not a runtime dependency. A build script reads ad_seed.db and outputs a
+slim manifest:
+
+```
+ad_seed.db (13MB)  →  compile_manifest.js  →  manifest.json (~2KB)
+   source code              compiler               compiled artifact
+```
+
+The manifest contains only what the browser needs:
+
+```json
+{
+  "windows": {
+    "123": {
+      "name": "Business Partner",
+      "table": "items",
+      "doc_type": null,
+      "tabs": [
+        { "name": "Partner", "level": 0,
+          "fields": [
+            {"col": "Name", "type": "string", "mandatory": true},
+            {"col": "IsCustomer", "type": "yesno"}
+          ]},
+        { "name": "Contact", "level": 1, "fk": "partner_id",
+          "fields": [
+            {"col": "Name", "type": "string", "mandatory": true},
+            {"col": "EMail", "type": "string"}
+          ]}
+      ]
+    }
+  },
+  "state_machine": {
+    "PURCHASE_ORDER": ["Drafted","Completed","Voided","Closed"],
+    "INVOICE": ["Drafted","Completed","Reversed","Voided"]
+  },
+  "downstream": {
+    "PURCHASE_ORDER": ["INVOICE","SHIPMENT"],
+    "INVOICE": ["PAYMENT"]
+  }
+}
+```
+
+**Runtime payload:** initbubble.json (2KB) + manifest.json (2KB) = 4KB.
+Everything the globe, accordion, and kernel enforcement need. WASM + the
+business data SQLite only loads when the user drills into actual records.
+
+The AD stays on the shelf as the reference — the source code. The manifest
+is the compiled binary. The browser runs the binary. You edit the source
+when you need to change the UI structure, then recompile.
+
+---
+
+## §14. Kernel Gravity — The Op Log as Constellation Driver
+
+Traditional ERP dashboards query data volume: `SELECT COUNT(*) FROM C_Order`.
+This tells you how much data exists, not what matters right now.
+
+kernel_ops provides **activity gravity**: what's being worked on, by whom,
+how recently. One query replaces N per-table counts:
+
+```sql
+SELECT json_extract(parameters, '$.table') AS tbl,
+       COUNT(DISTINCT json_extract(parameters, '$.id')) AS records,
+       MAX(timestamp) AS last_touch
+FROM kernel_ops
+WHERE undone = 0 AND timestamp > ?
+GROUP BY tbl
+```
+
+The constellation's bubble aura (glow radius) is driven by this gravity.
+Bright = active. Dim = dormant. Pulsing = just changed. The globe becomes
+a **live operations monitor** — the user's activity shapes the view.
+
+Op type weighting prevents noise (20 typo edits ≠ 20 meaningful actions):
+
+| Op type | Gravity weight |
+|---|---|
+| AD_SAVE (new record) | 1.0 |
+| AD_SAVE (update) | 0.2 |
+| DOC_COMPLETE | 2.0 |
+| DOC_VOID | 1.5 |
+| ALLOCATE | 1.0 |
+| AD_DELETE | 0.5 |
+| SESSION_START | 0.0 |
+
+---
+
+## §15. The Known Monsters — Local-First Risk Assessment
+
+Replacing a server-mediated ERP with browser-only storage creates three
+known failure modes. Each is bounded and solvable.
+
+**Full analysis:** `prompts/ERP_KERNEL_MONSTERS.md`
+
+| Monster | Risk | Core mitigation |
+|---|---|---|
+| Two tabs overwrite same record | LOW (single user) | BroadcastChannel awareness toast |
+| Orphaned documents (undo parent with children) | MEDIUM | Downstream FK check in kernel (50 lines) |
+| Gravity noise (edits ≠ significance) | LOW (UX only) | Distinct record count + op type weighting |
+
+### §15.1 The 10 Invariants
+
+Business rules ERP OOTB must enforce. If the kernel handles all 10,
+AD field settings become optional structural metadata.
+
+| # | Invariant | Kernel enforcement |
+|---|---|---|
+| 1 | Mandatory fields | commitOp rejects null on mandatory |
+| 2 | FK integrity | commitOp checks referenced record exists |
+| 3 | Doc state transitions | State map: `{Drafted:[Complete,Void]}` |
+| 4 | Downstream protection | DOWNSTREAM map check before undo |
+| 5 | Sequence numbering | MAX+1 (single-user = no collision) |
+| 6 | Period closing | Check C_Period.IsActive on DOC_COMPLETE |
+| 7 | Duplicate prevention | SELECT COUNT WHERE Value = ? before INSERT |
+| 8 | Audit trail | kernel_ops logs everything (already done) |
+| 9 | Undo boundary | compact() prunes past 2 sessions (already done) |
+| 10 | Currency consistency | Store CurrencyISO in metadata |
+
+~150 lines total for all 10. iDempiere uses ~15,000 lines for the same
+invariants plus 200 others that single-user browser ERP doesn't need.
+
+### §15.2 What we deliberately don't solve (yet)
+
+- Multi-device sync → only if users need phone + laptop simultaneously
+- Multi-currency conversion → only if users operate across currencies
+- Full AD runtime loading → compiled manifest replaces it
+- Server-side locking → single-user browser makes it unnecessary
+
+---
+
+## §16. Database Coverage and Storage Economics
+
+### §16.1 Current coverage of iDempiere schema
+
+ad_seed.db contains roughly a third of iDempiere's table definitions.
+
+| Category | Missing | Examples |
+|---|---|---|
+| AD_ (system/admin) | 160 | Alert, Auth, Processor, Archive, ChangeLog |
+| Views + translations (_V, _Trl) | 41 | Report views, multi-language overlays |
+| I_ (import) | 18 | Data migration staging tables |
+| GL_ (accounting) | 4 | GL_Distribution, GL_Fund, GL_FundRestriction |
+| C_ (commercial) | 120 | Commission, Dunning, RfQ, Subscription, POS |
+| M_ (material) | 65 | Production, QualityTest, CostQueue, LotCtl |
+| Other (workflow, HR, asset, mfg) | 239 | A_Asset, PP_*, HR_*, W_* |
+
+The missing tables fall into two groups:
+- **Server-only plumbing** (~400): processors, schedulers, auth, import,
+  views, translations. These have no function in a browser runtime.
+- **Advanced business modules** (~250): manufacturing, commissions, dunning,
+  subscriptions, RfQ, quality control. These serve enterprises with
+  dedicated ERP administrators.
+
+The 356 present tables include all AD metadata (10 tables, 59K rows) and
+all GardenWorld business data (C_BPartner, M_Product, C_Order, C_Invoice,
+C_Payment, M_InOut, etc.).
+
+### §16.2 Storage comparison: PostgreSQL vs SQLite
+
+Measured from GardenWorld seed data:
+
+| Metric | PostgreSQL | SQLite (ad_seed.db) |
+|---|---|---|
+| Full GardenWorld install | ~350MB | 12.1MB |
+| Compression ratio | — | **29x smaller** |
+| Total rows | ~84K | 84,134 |
+| Bytes per row | ~500-800 | 151 |
+| AD metadata (70% of rows) | ~250MB | ~8.4MB |
+| Business data only (30%) | ~100MB | ~3.6MB |
+
+PostgreSQL overhead comes from: WAL (write-ahead log), TOAST (large
+object storage), MVCC (multi-version concurrency control — stores
+multiple row versions for concurrent transactions), per-row transaction
+IDs, system catalogs, and index structures. All required for a multi-user
+server. None needed in a single-user browser.
+
+SQLite stores page-aligned data with no concurrency overhead. One file,
+no fragmentation, no transaction versioning.
+
+### §16.3 Browser storage limits
+
+IndexedDB quotas (where the SQLite file is cached):
+
+| Browser | Default | With `navigator.storage.persist()` |
+|---|---|---|
+| Chrome | 60% of device disk | Same, marked non-evictable |
+| Firefox | 50% of device disk | Same, marked non-evictable |
+| Safari/iOS | 1GB per origin | Up to 20% of disk on request |
+
+A medium business with 100K documents would produce ~50MB in SQLite.
+A 256GB phone allows ~150GB in IndexedDB. Storage is not the constraint.
+
+Transfer time is the constraint: 12MB on 3G = ~30 seconds. This is why
+the architecture uses lazy fetch — load only the tables the user drills
+into. The manifest (2KB) + initbubble.json (2KB) + a single table
+fetch (~3KB for 18 partners) = under 10KB for first interaction.
+
+### §16.4 Metadata JSON queryability
+
+The `metadata TEXT` column on core tables stores domain-specific fields
+as JSON. SQLite's `json_extract()` is slower than real column access.
+
+Measured bounds:
+- `json_extract` over 5,000 rows: <10ms desktop, <30ms mobile
+- Over 84K rows (full ad_seed.db): <50ms
+- Acceptable for interactive drill; insufficient for batch reporting
+
+Mitigation: fields that become frequent query targets are promoted to
+real columns via `ALTER TABLE ADD COLUMN` (SQLite supports this without
+table rebuild). The JSON column is a staging area for schemaless fields,
+not the permanent home for high-frequency analytics.
+
+### §16.5 Manifest override mechanism
+
+The compiled manifest (§13) is the base configuration. Two override
+paths exist for runtime customisation without recompilation:
+
+1. **Direct JSON edit** — manifest.json is human-readable. Change a
+   field's mandatory flag, reorder tabs, add a field. Reload the page.
+   No compiler, no server, no PostgreSQL.
+
+2. **Settings JSON (localStorage)** — the S282 settings template stores
+   user preferences that patch the manifest at load time: hidden fields,
+   reordered tabs, custom labels, bubble order. The manifest is the
+   default; localStorage overrides are the personalisation layer.
+
+The compiler (`scripts/compile_manifest.js`) is for cold-start generation
+from the AD source. It is not required for day-to-day configuration.
+
+### §16.6 Relationship between legacy tables and 5-table model
+
+The 5 core tables (§12) and the legacy iDempiere tables coexist in the
+same SQLite database. They serve different roles:
+
+| Concern | Legacy tables (C_*, M_*) | 5-table model |
+|---|---|---|
+| Role | Imported reference data | Runtime working data |
+| Schema | Fixed columns per table | Generic + metadata JSON |
+| Source | PostgreSQL export (ad_seed.db) | Created by doc_engine.js |
+| Growth | Static (GardenWorld demo) | Grows with user activity |
+| Example | C_BPartner has 30+ columns | items has 8 columns + metadata JSON |
+
+The compiled manifest maps each window to its backing table — whether
+that table is `C_BPartner` (legacy) or `items` (5-table). The accordion
+and kernel_ops work identically with both.
+
+When a feature requires a table not in the 5-table model (e.g.,
+C_Commission for sales commissions), the lazy fetch retrieves that
+table's schema from the manifest and its data from the server or
+ad_seed.db. The 5-table runtime does not grow unless needed.
+
+Tables that exist in both models (e.g., partners exist in C_BPartner
+AND could be stored in items) are not migrated. Legacy data stays in
+legacy tables. New data created by the user goes to the 5-table model.
+The manifest tells the UI which table to query for each window.
+
+---
+
+## §17. Architecture summary (extends §10)
+
+[§10](#10-scope-and-status) covers running the AD client-side. This section
+summarises the runtime architecture built on top of it: an ERP runtime over
+five tables, business logic as pure functions, undo/redo via event sourcing
+([§0.16](#016-the-wire--the-kernel--data-driven-evaluator-and-op-log-kernel-2026-05-29-wirekernel-pass)),
+and a constellation UI in place of the menu-tree navigator. No JVM,
+PostgreSQL, OSGi, or server process is required at runtime.
+
+The ~13MB Application Dictionary is compiled to a compact manifest
+([§13](#13-the-compiled-manifest--ad-as-compiler-input)) that drives rendering;
+the full AD is retained as the source for reference and recompilation, but is
+not loaded wholesale at runtime (it streams by gravity rank,
+[DistributedERP.md §13](DistributedERP.md#13-sharding-the-engine-by-gravity-what-arrives-and-when-2026-06-01-spec)).
+The enforcement surface is small: ~150 lines of kernel, five tables, one write
+path (`commitOp`), one audit trail (`kernel_ops`), one accounting projection
+(`journal`).
+
+---
+
+## §18. The Unified Model — BOM + WfMC on One Log (empirically validated)
+
+This section is not theory. Every claim below was tested against the WHOLE
+iDempiere dictionary (roughly a thousand tables and thousands of FK columns) by
+`scripts/test_bom_theory.js` (in the bim-compiler repo). The §BOM_TEST log is
+the witness. Re-run it to reproduce.
+
+### §18.1 Every relationship is one of two edges
+
+Strip the labels off iDempiere's schema and only two relationship kinds remain:
+
+1. **Structure edge** — recursive parent→children (the BOM). Two flavours:
+   - **Containment** ("has-a"): `Building→Floors`, `Order→OrderLines`,
+     `Window→Tabs→Fields`. The parent *holds* the child.
+   - **Derivation** ("made-from, by a verb"): `Order→Invoice→Shipment→Payment`.
+     The child is *computed from* the source document by a DocAction (see §18.3).
+2. **Component citation** — a leaf names independently-existing master/reference
+   data by quantity (`OrderLine→Product`, `Invoice→Partner`). Cited, not composed.
+
+This is the BOM principle (`docs/BOMBasedCompilation.md`) applied to business
+documents. **There is one compiler.** A building is a BOM; a purchase order is a
+BOM; the AD window hierarchy is a BOM. BIM and ERP are the same recursion over
+different leaves. The op-log (`kernel_ops`) is the BOM's composition history.
+
+### §18.2 What the data said (witness: §BOM_TEST, 2026-05-29)
+
+| Test | Result | Verdict |
+|---|---|---|
+| T1 resolution | 3,465 / 5,231 domain FKs resolve (66%) via `_ID` convention | conclusions robust on the resolved sample |
+| T2 acyclicity | TWO cycles found | naive "structure = DAG" **falsified — and refined** |
+| T5 hubs | `C_Order` in-degree **23** (#1), then Invoice 20, Payment 17, RMA 12, PP_Order 10 | source-replication **CONFIRMED** |
+
+The two T2 cycles are not refutations — they forced two true distinctions:
+
+- **Derivation cycle `Order→Payment→Invoice→Order`** = the **three-way match**.
+  Resolved by *direction*: forward **lineage** (Invoice derived-from Order) is a
+  DAG; the closing edge is a **settlement back-reference** — a third relation, the
+  reconciliation citation. This is how a source document stays bound to its replicas.
+- **Containment cycle `OrderLine↔RequisitionLine`** = **component reuse**. A part
+  appears in two BOMs (Order, Requisition). **Per-context, containment is always a
+  DAG** (tab levels strictly increase). Reuse across assemblies is the BOM
+  superpower, not a cycle. Containment must be compiled *per-window*, never as a
+  global tree.
+
+**The refined rule:** containment is per-context; derivation is causal-forward;
+settlement back-references close reconciliation loops. Nothing fell outside the model.
+
+### §18.3 A document is a *lifecycle*, not a table
+
+Witness §BOM_TEST: 51 tables carry **both** `DocStatus` and `DocAction`; 52
+`C_DocType` configurations exist. The definitive split is **lifecycle vs none**:
+
+> **Document** = `DocType` (configures) + `DocAction` (drives — the verbs) +
+> `DocStatus` (records) + `kernel_ops` (audits). **Master data** has none — it is
+> a lifeless citation.
+
+- **DocAction *is* the verb.** The 14 actions — `PR` Prepare, `CO` Complete,
+  `AP` Approve, `RJ` Reject, `WC` Wait-Complete, `VO` Void, `CL` Close,
+  `RE` Re-activate, `RC` Reverse-Correct, `RA` Reverse-Accrual, `PO` Post,
+  `IN` Invalidate, `XL` Unlock — are the operators that advance state **and fire
+  derivations**. `Complete` on `C_Order` is what produces the 23 replicas T5 measured.
+- **`C_DocType` is the parameterization** — "one source, many purposes." Same
+  `C_Order` table; DocType selects which sequence, which downstream docs, which
+  GL treatment.
+
+So the *behavioural* surface of the whole dictionary is tiny: a few dozen document
+types driven by a handful of verbs. The bloat is parts on a shelf; the behaviour is small and
+WfMC-shaped.
+
+### §18.4 WfMC from the ground up — and it collapses into one log
+
+| WfMC reference element | Compiled artifact |
+|---|---|
+| Process definition | `C_DocType` (+ optional `AD_Workflow`) |
+| States / activities | `DocStatus` values |
+| Transitions | the 14 `DocAction` verbs |
+| Worklist | the **gravity globe** — what needs action, glowing |
+| Audit trail | **`kernel_ops`** |
+
+`kernel_ops` is therefore *simultaneously*: WfMC execution history, sync/replication
+substrate (§ multi-node), undo/time-machine, and gravity source (§14 already weights
+`DOC_COMPLETE`=2.0, `DOC_VOID`=1.5). **One append-only log, replayed, is the whole
+engine.** The workflow engine and the replication engine were never separate.
+
+**Correction this forces:** the manifest's `state_machine` must be compiled
+**per `C_DocType`** (from the DocAction set + transition rules), NOT hardcoded per
+table — because one `C_Order` table behaves differently by DocType. The current
+`compile_manifest.js` §4 hardcoding is a placeholder, replaced in the build plan.
+
+### §18.5 Local-first mesh — no one node holds the whole
+
+Each user is a local-first node owning their ~10% working set; the org ERP is the
+**union of nodes**, synced user-to-user by merging op-logs (Git-style DAG: parent
+pointers, fetch-fills-gaps, deterministic replay). "Heavy mode" is the mesh, not a
+monolith. Integrity goes eventually-consistent and conflicts cluster at **document
+handoffs** (the derivation seams) — the same few places where global invariants
+(single-invoice-per-order, cross-user budget) live. Those few get *detect-and-reconcile*
+or a *designated owner node*; everything else is enforced locally. Causality follows
+the **lineage spine** (compile-time taggable: FK to a lifecycle table = lineage;
+else citation), not the full FK tangle.
+
+**Build order is therefore hub-first** — `C_Order → C_Invoice → C_Payment → M_RMA
+→ PP_Order` — because the derivation hubs are where usage, money, WfMC richness, and
+gravity all concentrate. See `prompts/ERP_KERNEL_BUILD.md` for the phased plan.
+
+### §18.6 Scaffold vs business logic — the handler registry
+
+The state machine is **not** where the complexity lives. The bloat-and-hell is the
+**business logic**: pre-conditions, side effects, post-conditions, and conditional
+fan-out (`Order→Invoice only if IsInvoice`). Every hellish rule attaches to exactly
+one **cell**: `(DocType, currentStatus, action)`.
+
+**The scaffold contains the hell; it does not remove it.**
+`DocType + DocAction + DocStatus + kernel_ops` is scaffold — it guarantees you only
+call `completeInvoice()` on a valid Invoice, never on a voided Order. The mechanism
+is **dispatch by cell**:
+
+- **State machine** — which cells are *reachable* (legal transitions). Compiled data.
+- **Handler registry** — the *behavior at a cell*: `handler[(DocType, action)] =
+  fn(doc, ctx) → ops[]`. Contains all the bespoke logic. A handler may invoke other
+  handlers → composed workflows. **Each handler touches only its own DocType**, so
+  the bloat scattered across the whole dictionary is partitioned into isolated, nameable units.
+- **kernel_ops** — every effect a handler produces is an op. **A side effect that
+  bypasses the log is a violation, and it is detectable.** Handlers *return* ops; the
+  kernel *applies* them (this is the path to B1: kernel owns the write). That makes
+  every handler a pure, testable function and the log the single source of truth.
+
+**Why this tames the 15,000 lines:**
+- The hell becomes **visible** (one cell, one handler), **testable** (given doc+ctx,
+  assert emitted ops), **replayable/undoable/auditable** (it's all ops).
+- Handlers are written **hot-first**, ranked by gravity (§14). Most cells are never
+  exercised — so most handlers are never written. The product compiles its own
+  business-logic backlog from observed usage. The 90% nobody uses costs nothing.
+
+**Summary for code:**
+- State machine = *allowed transitions* (compiled — build P2).
+- Handler registry = *business logic* (per-cell handlers — build phase, gravity-ranked).
+- Log = *single source of truth* (already `kernel_ops`).
+
+### §18.7 The mailbox and the rulebook — out-of-band, content-addressed, never a server brain
+
+**The engine lives where the user lives.** Every peer runs the same deterministic
+kernel on its local SQLite; there is no server-side engine. The server, if any, is a
+**pure relay** — "an S3 bucket with auth" — storing op-logs and snapshots for peers
+to push/pull (Git-remote style). It never applies, merges, or arbitrates. Removing
+the central brain does not delete the hard problems; it **relocates** them — into the
+op-log protocol and into *peer roles*, never back into the server:
+
+- **Visibility/auth** — the relay still needs *addressed* inboxes (per-org/per-user)
+  and keys. It reads the envelope address; it never opens the letter.
+- **Global invariants** (single-invoice-per-order, cross-user budget) — moved to a
+  **designated peer role** (the AP node owns invoice issuance; others request) or
+  detect-and-reconcile at merge. Coordination is a *user with a hat*, never a server.
+- **Hints** ("hot ops you may want") — computed from op *metadata* (table, type, ts,
+  user_tag) only, never by applying the op; or dropped entirely in favour of peer
+  gossip. Encrypt op bodies → the relay sees only routing headers.
+- **Version skew is THE hard problem** — each PWA self-updates, so ops from mixed
+  kernel/handler versions coexist with no central migration. Defence: every op carries
+  `kernel_version`; handlers stay deterministic AND backward-compatible.
+
+**Rules are two layers, not one:**
+- **Handler *code*** (imperative `completeOrder()` logic) ships *with* the PWA
+  (service worker), versioned with the kernel. **Never** hot-swapped as remote code.
+- **Policy *data*** (declarative flags: `(Order,Complete):{creditCheck:false}`) is a
+  **signed, content-addressed manifest** (`policy_vN.json`, Git/IPFS) the admin
+  publishes; handlers *read* it at write time. Hot-swappable, governable, auditable.
+
+**Two append-only logs, one link.** The event log (`kernel_ops`) and the policy/config
+log (content-addressed, signed) are stitched by a `policy_hash` stamped on every op —
+not needed for replay (effects are frozen, §18.8) but required for AUDIT: *"why did
+this complete with no credit check?"* → the op cites `policy_v2`. Local rule overrides
+must be **marked** so un-synced policy can't silently pollute shared history; admin-key
+trust (who publishes, rotation/compromise) is an org-root-key / designated-peer concern.
+
+### §18.8 Doc is the Event — the document-event as the atomic unit
+
+A document is **not** a row that events happen *to*. Its lifecycle **is** the event
+stream: PO #5 *is* `created → completed → invoiced → paid`. The row (current
+`DocStatus`) is the fold; the `DocAction`s are the events.
+
+"The transaction" is the giveaway: the **document-event is the atomicity boundary.**
+When `Complete` fires, the handler returns a *group* of effect-ops (status change +
+invoice + lines + journal). That group is the single unit of four things at once:
+
+- **Atomic** — commits or rolls back together (the transaction).
+- **Undoable** — undo a document-event undoes the whole group, never a stray op.
+- **Syncable** — the causal unit that ships and replays together.
+- **Auditable** — stamped with `policy_hash` + `kernel_version`.
+
+This is the unit that makes the op-log coherent rather than a flat stream — and it is
+exactly P3b's handler contract (`handler → ops[]`). In the 5-table model, each
+`documents` row **is** the event-carrying aggregate root.
+
+### §18.9 Aggregates are checkpointed projections (precise rule)
+
+Not "no mutable aggregates." The authoritative state is the log; aggregates
+(`StorageOnHand`, `OrderLine.Price`) are **rebuildable projections**, never sources of
+truth. But a naive JOIN-over-all-history is O(history) and won't scale — so they MAY
+be **materialised as checkpoints**: `StorageOnHand = checkpoint_at_cursor_N +
+Σ(mutations since N)`. The kernel treats them as a cache the log can always
+regenerate. This is the same snapshot+delta needed for mesh compaction/bootstrap.
+
+### §18.10 The oracle: iDempiere's model classes validate handlers (extract, don't port)
+
+We have the golden reference — iDempiere's 20-year Java source. Use it to **validate**
+that each JS handler implements the same business rules, **never to port blindly**.
+This is EXTRACT-don't-invent applied to behaviour (the §18.6 "hell").
+
+- **Per `(DocType, action)`, the Java method is the spec.** Before writing
+  `completeOrder()`, open `org.compiere.model.MOrder.completeIt()`; copy its
+  pre-conditions, side effects and post-conditions as the handler's pre-flight
+  citation (`// Oracle: MOrder.completeIt() — checks: isProcessed, credit, …`).
+  Each check → one test fixture (a test names the rule it proves).
+- **Diff-oracle (Docker) — the strongest test.** Run the same transaction in a real
+  iDempiere (`docker start postgres`), dump the affected rows, run the JS handler on
+  the same input, compare. **The schemas differ** (real tables vs 5-table) — so
+  compare at the **semantic/op level, normalised through `ad_table_map`** (a created
+  `C_Invoice` ⇄ `documents[INVOICE]` + lines), or compare the effect-ops both sides
+  emit. Mismatch = bug OR a *documented* intentional divergence.
+- **Gravity-ordered.** Extract oracle rules HOT-CELL-FIRST — `MOrder.completeIt()`
+  before the long tail — the same backlog as the handler registry (§18.6, §14).
+- **The oracle grounds the policy schema (§18.7).** The flags (`creditCheck`,
+  `autoCreateShipment`) are *read off* what `completeIt()` conditionally does; the
+  `Order→Invoice iff IsInvoice` fan-out (§BOM_TEST T3) is literally a branch in the Java.
+- **Scope the diff to the document-event (§18.8)** — compare the documents/lines/journal
+  the transaction produced (the atomic op-group), not transient state. iDempiere posts
+  accounting asynchronously; our `journal` is synchronous — normalise that.
+- **Don't copy:** concurrency locking, server round-trips, OSGi/plugins, the framework.
+  The ~150-line kernel + per-cell handlers replace ~15,000 lines.
+
+---
+
+*Copyright (c) 2025-2026 Redhuan D. Oon. MIT Licensed.*
+
+---
+
+## §19. Performance Model — Transaction Cost vs iDempiere (analytical, multi-user apples-to-apples)
+
+This section is an **analytical cost model, not a benchmark.** Where a mechanism is
+proven it cites the witness; the GL case is an explicit projection. The comparison is
+held **apples-to-apples**: iDempiere is multi-user by construction, so it is compared
+against *this architecture in its secured/multi-user configuration* (§0.20 — local kernel
++ asynchronous facilitator + W-CHAIN/W-SIGN), **not** the bare single-user mode. The
+single-user/offline mode is the lower bound, noted for contrast.
+
+### §19.1 Two latencies, decoupled
+
+Traditional three-tier ERP collapses two costs into one synchronous commit; this
+architecture separates them:
+
+- **Interactive latency `T_i`** — what the operator waits for: `T_compute + T_apply + T_commit`.
+- **Convergence latency `T_c`** — until other users / the supervisor log reflect it:
+  `T_order + T_push + T_ingest + T_fanout`.
+
+In iDempiere `T_i ≈ T_c` — the WAL-synced commit *is* the point of multi-user visibility.
+Here `T_i` is local (in-RAM, ~0 ms perceived) and `T_c` is asynchronous (the facilitator
+orders + persists + fans out). The multi-user tax is paid in both systems: iDempiere pays
+it **synchronously, inside `T_i`**; this architecture pays it **asynchronously, inside `T_c`**.
+
+| Cost term | iDempiere (multi-user server) | Here (secured multi-user) |
+|---|---|---|
+| client ⇄ server network | per action, inside `T_i` | **0** in `T_i`; the push is in `T_c` |
+| DB statement round-trip | JDBC ⇄ PostgreSQL, inside `T_i` | **0** — sql.js runs in-process |
+| isolation | MVCC + row locks, synchronous | deterministic replay; cross-writer invariants at one CAS seam (`DistributedERP.md §5`) |
+| durable commit | WAL fsync, synchronous | op-log append; durability achieved on relay to the facilitator (`T_c`) |
+| total ordering | implicit in the single authoritative DB | the facilitator assigns it, asynchronously |
+
+The guarantees are **not identical**: iDempiere gives synchronous serializability for every
+op; this gives asynchronous convergence + deterministic replay, with synchronous
+enforcement reserved for the single online CAS op-class (oversell / double-claim). That
+trade is the substance of the comparison, not a footnote.
+
+### §19.2 Extra operations this kernel performs
+
+The audit / replay / sync substrate is not free. Per state change the kernel does work
+iDempiere does not:
+
+| Extra op | iDempiere default | Here | Cost / when it bites |
+|---|---|---|---|
+| Rich op: before/after + lineage GUIDs | `AD_ChangeLog` optional, changed-columns only | **always**, full snapshot (§0.6) | memory + CPU per op; scales with batch rows × row width — the main batch tax |
+| Hash-chain per op (W-CHAIN) | none | SHA over each op | ~µs each (native); O(n) over a batch — negligible per op |
+| Signature (W-SIGN) | DB session auth | optional asymmetric sign | ms-scale → **sealed at chain-segment boundaries, not per op**; per-op signing would dominate a batch |
+| Identity mint + record (G-IDENTITY §0.21) | server DB sequence (a round-trip) | UUID minted + recorded locally | trades a sequence round-trip for a few bytes — net win |
+| Settlement re-derivation | follows the stored FK (`M_InOutLine_ID`/`C_OrderLine_ID`) | matcher reconstructs pairs from partner + product + qty (partitioned join + greedy first-fit, §0.17) | **genuinely more CPU than an FK-follow** — the one place this does *more* work than iDempiere; buys FK-absent robustness |
+| Replay + hash verify | trusts DB state | rebuilds the projection from the log, hash-compares | O(log), on demand, off the hot path |
+
+### §19.3 Overhead iDempiere carries that this avoids
+
+The reciprocal: iDempiere's hot path includes MVCC version rows, WAL fsync, per-statement
+parse/plan over JDBC, OSGi event dispatch, `ModelValidator` reflection, ZK component-tree
+round-trips, and sequence round-trips. The net trade is **infrastructural overhead removed
+from the hot path** (network, MVCC, WAL, JVM/OSGi) **for semantic overhead added**
+(snapshot, hash, optional sign, occasional re-derivation) — mostly small per-op and partly
+deferrable.
+
+### §19.4 The two cases (order-of-magnitude, illustrative)
+
+**POS Order Complete** (proven path: 7 ops, `replay-hash == live-hash`, §0.19).
+
+- *iDempiere (multi-user):* one network round-trip + dozens of JDBC statements (shipment,
+  invoice, allocation, `Fact_Acct`, status, sequence) + MVCC/WAL commit → interactive
+  latency on the order of 10²–10³ ms; multi-user visibility at the same synchronous commit.
+- *Here (secured multi-user):* `T_i` on the order of 10⁰–10¹ ms (local 7-op apply + 7
+  rich/hashed ops; signature sealed per segment, not per op); `T_c` = async push (~KB) +
+  facilitator append/order + fan-out, typically sub-second in the background.
+- *Apples-to-apples:* both reach multi-user visibility in well under a second, but the
+  operator's wait stays ~1–3 orders lower here because the multi-user tax sits in `T_c`,
+  not `T_i`.
+
+**10,000-line GL batch** (projection — the `Fact_Acct` posting cell is **not yet
+implemented or verified**, §0.17).
+
+- *iDempiere:* iterative posting, on the order of 10⁴–10⁵ INSERTs including double-entry
+  facts + index/MVCC → tens of seconds to minutes; visible on commit.
+- *Here (projected):* ~10⁴ ops applied in one in-RAM transaction (sub-second to seconds) +
+  ~10⁴ before/after snapshots (the real memory tax) + ~10⁴ hashes (tens of ms native) + one
+  segment-sealed signature (not 10⁴ signs); relay payload on the order of a few MB pushed
+  asynchronously; facilitator ingest is O(n) **append**, not re-posting.
+- *Apples-to-apples:* structurally ~1–2 orders faster to local completion, and the
+  supervisor ingests by appending rather than re-executing — conditioned on (a) GL posting
+  being built, (b) the snapshot + log-persistence tail, (c) running off the main thread
+  (Web Worker).
+
+### §19.5 Envelope — what this model does and does not claim
+
+- **Analytical, not benchmarked.** The sync/integrity mechanics are POC-witnessed
+  (`poc_chain` / `poc_sign` / `poc_distributed` / `poc_persist`; W-CHAIN in
+  `kernel_ops.js` v5), **not** a deployed N-terminal multi-site benchmark.
+- **GL is a projection** — the posting cell is dataless / untested (§0.17).
+- **Async oversight is not a real-time gate.** Cross-writer enforcement that must block in
+  real time is the single online CAS op-class (`DistributedERP.md §5`); everything else
+  converges eventually.
+- **The advantage is architectural, not algorithmic:** identical document logic, executed
+  in-process against in-memory SQLite + an append-only signed op-log, with the multi-user
+  tax deferred to an asynchronous facilitator instead of paid synchronously per transaction.
+
+### §19.6 Side-by-side summary — where this wins, and the extra it requires
+
+Order-of-magnitude, analytical (see §19.5 envelope). "Better" is stated honestly —
+some rows favour iDempiere, some are a deliberate trade. The last column is the **extra
+work this architecture must do** to reach the stated position (the cost of the win).
+
+| Dimension | iDempiere (multi-user server) | This architecture | Better? | Extra needed here |
+|---|---|---|---|---|
+| **Operator-perceived latency** (POS complete) | network + dozens of JDBC stmts + WAL commit (~10²–10³ ms) | local in-RAM apply of the 7-op group (~10⁰–10¹ ms) | **This** (~1–3 orders) | none — it is the default path |
+| **Bulk throughput** (10k GL batch) | iterative posting, ~10⁴–10⁵ INSERTs (tens of s – min) | one in-RAM transaction (sub-s – s) | **This** (~1–2 orders), *projected* | build the GL `Fact_Acct` cell (§0.17); run off-thread (Web Worker); absorb snapshot/log tail |
+| **Multi-user visibility** | synchronous at commit | asynchronous convergence | **Trade** — synchronous vs eventual | async facilitator (order + persist + fan-out) |
+| **Durability** | WAL fsync, synchronous, on-box | op-log relayed to facilitator / cloud / mailbox replica | **Trade** — synchronous vs eventual | W-PERSIST + relay; until relayed, the local copy is volatile |
+| **Cross-writer enforcement** (oversell / double-claim) | locks / MVCC on every op, synchronous | one online set-if-unset CAS op-class | **Trade** — broad vs narrow-but-sufficient | the single synchronous CAS op (`DistributedERP.md §5`) |
+| **Audit trail** | `AD_ChangeLog`, optional, changed-columns only | `kernel_ops` rich op (before/after + lineage), always on | **This** | rich-op memory/write per change |
+| **Tamper-evidence** | none by default | hash-chain (W-CHAIN) + optional signature (W-SIGN) | **This** | hash per op; signature sealed per chain-segment |
+| **Replay / undo / time-machine** | none — the DB is only current state | deterministic replay; frozen effects | **This** (structural) | determinism sandbox (no `Date.now`/`Math.random`); identity-as-input (§0.21) |
+| **Analytics** | bolt-on warehouse / ETL | the op-log *is* the analytical store (§0.6) | **This** | a rich op-log + the gravity fold (§14) |
+| **Settlement matching** | follows the stored FK | re-derives pairs from partner + product + qty (§0.17) | **iDempiere** cheaper; **This** more robust (works FK-absent) | extra matcher compute (partitioned join + greedy) |
+| **Identity / sequence** | server DB sequence (a round-trip) | edge-minted UUID, recorded (§0.21) | **This** (no round-trip) | record `op_uuid` + `seq` per op |
+| **Infrastructure footprint** | JVM + OSGi + PostgreSQL + app server | single HTML + sql.js, no server | **This** | for multi-user, one thin **async** facilitator (not a compute authority) |
+
+**Reading it in one line:** this architecture wins decisively on **interactive latency, footprint,
+audit, tamper-evidence, replay, and analytics**; it deliberately **trades** synchronous
+multi-user durability/visibility/enforcement for asynchronous convergence (re-added by the
+§0.20 facilitator), and pays a small **extra** per-op cost (rich snapshot + hash, occasionally
+re-derivation) to get the audit/replay/sync substrate "for free" downstream. The only row where
+it does genuinely *more compute* than iDempiere is settlement matching — and that buys
+FK-absent robustness.
+
+---
+
+## §20. Addendum — prototype status and the role of the UI views (2026-06-01)
+
+**What this is: a working prototype, not a finished product.** The witnessed parts — the
+5-table collapse (§5TBL), the O2C/P2P verticals reproducing the GardenWorld oracle
+(§0.17–§0.19), the kernel + deterministic replay (§0.16), the read-only Glassbowl views
+(§Views), and W-CHAIN live in `kernel_ops.js` — demonstrate the architecture end-to-end on a
+*contained* data set. They are not a deployment covering an organisation's full document set,
+and the write-loop (T3) is still parked.
+
+**The premise it rests on — absorbing iDempiere's inherent model.** iDempiere's Application
+Dictionary already encodes the inherent model of an ERP: the windows, tabs, fields, references,
+validation rules, document types, and the lifecycle each document follows. Most of what any
+given user needs is therefore already *described* there — it is the engine *around* the AD that
+this project re-bases as data (the §thesis). The claim is not that this prototype reimplements
+every business concern; it is that **once it absorbs more of the AD's inherent model** — more
+doc types, more reference/validation rules, the GL posting cell (§0.17), and localisation /
+compliance rows — the same extract-only mechanism that reproduced O2C/P2P extends to those
+concerns **without new hand-written engine code**. The breadth comes from absorbing the
+dictionary, not from writing features. That is what makes "addresses most of the users'
+concerns" a structural goal rather than a backlog.
+
+**The three UI views are fast POCs, not the product surface.** Glassbowl (the engine *mapped*,
+View 1), Glassbowl Gravity (the engine *weighed*, View 2), and the ReadMe/ShowMe help-tour (the
+engine *guided* — `docs/ReadMeShowMe.md`, added today) are each a quick, read-only response to
+**one scenario a tail user might bring**: *"show me the structure" · "show me where value and
+risk pool" · "show me where the control is, and do it for me."* They are deliberately cheap to
+stand up — the same `createElementNS` SVG, the same keyed-overlay governance
+(`UI_OVERLAY_GOVERNANCE.md`), 0 hand-authored, generated from the extracted data — precisely so
+that **whatever scenario a given tail entails, a matching view can be built the same way**: a
+thin projection of the already-extracted model, not a new application.
+
+**Roadmap (addendum).** Stated as intent; each item ships spec-first, witness-led, on the
+existing extract-only discipline. Mirrored in the UI doc's addendum (`docs/ReadMeShowMe.md`).
+- **Absorb more AD model** — doc types beyond O2C/P2P, reference/validation rules, the GL
+  posting cell (§0.17), and localisation / compliance rows (the long tail's real first need).
+- **Land the write-loop (T3)** — the greyed CRUD ring and the History undo-preview become the
+  signed kernel write (`crud_overlay.js`: E2 dry-run → E3 signed kernel, `commitOp`/`sealChain`).
+- **A thin POC view per tail scenario** — each new need (a particular trade, a compliance
+  regime, an operator's daily flow) gets its own read-only view over the extracted model first,
+  editable once T3 lands. The roadmap is *extend the model + project a view*, not *build N apps*.

--- a/erp/HolyGrail.md
+++ b/erp/HolyGrail.md
@@ -1,0 +1,447 @@
+/**
+ * BIM OOTB / ERP OOTB — The Holy Grail: editable business rules, live.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+# The Holy Grail — Editable Business Rules, Live
+
+> *A first-person note from the author. The technical claims below are grounded in the
+> dated, witnessed sections of [ERP.md](ERP.md); this page is the reasoning that ties
+> them to a quest I have carried for a long time.*
+
+## Who is writing this, and why it is personal
+
+I am Redhuan D. Oon. I was the founding leader of **ADempiere**, and in that role I
+materially ushered in the birth of **iDempiere** — the community, the people, and the
+direction that made it possible. I then left that path to pursue this one.
+
+I did not leave because the open-source ERP idea was wrong. I left because the thing I
+most wanted from it — **rules you can edit while the system runs, safely, without a
+build** — was structurally out of reach inside the architecture we had built. For two
+years I tried to reach it from the inside: I attempted, with Spring and plain Java, to
+extract even the *core* of the model — `PO.java`, `Info.java` — into something light
+enough to re-host and re-open. It did not converge. This document is the account of why
+it could not, and why a browser-and-PWA paradigm shift reached it from the outside —
+something that genuinely surprised me, the person who had spent the most time failing at
+it the other way.
+
+## What the Holy Grail actually is
+
+Not "an ERP in a browser." That is a means. The grail is one specific capability:
+
+> **Edit a business rule, and watch the affected records change on the map — live,
+> reversibly, with no recompilation and no server.**
+
+In this project that is named directly: the *parked endgame* in
+[ERP.md "Why this is more than a port"](ERP.md) — *"let you **edit a rule and watch the
+affected records flip on that map** (the diff-oracle in the browser, §2d-3)"* — and in
+[GLASSBOWL_DOSSIER.md](GLASSBOWL_DOSSIER.md) as *the final big picture*: Glassbowl stops
+being a map of the engine and becomes **the console you run the engine from**.
+
+It is earmarked precisely, not vaguely:
+
+| Earmark | What it fixes |
+|---|---|
+| **[ERP.md §0.4](ERP.md)** — *Editable business rules, the SystemAdmin role* | names this as **the differentiator**, not a feature |
+| **[ERP.md §0.5](ERP.md)** — *the rules engine = a per-cell decision table* | the shape: a table per `(DocType, status, action)` cell — **not** Rete / DSL / inference |
+| **[ERP.md §0.9](ERP.md)** — *the rule mechanism, JSR-223-native* | the host language **is** JavaScript, so the rule language = the runtime language; the scripting-engine abstraction is *unnecessary* |
+| **[ERP.md §0.10](ERP.md)** — *the Rule Compiler* | the rules are already extracted to data: `erp_rules.db`, **746 records**, diff-verified |
+| **ERP.md §2d-3 / GLASSBOWL_DOSSIER.md** | the live edit-and-reflow loop — the grail itself |
+
+## Why two years of extracting `PO.java` was the wrong target
+
+This is the part I most want a future reader — especially one still inside a code-engine
+ERP — to understand, because it cost me the most to learn.
+
+`PO.java` is **not extractable**, and it never was. Not because it is hard, but because
+it is the **wrong thing to extract**. It is an *imperative* engine. Pull on it and the
+entire transitive graph follows: the model registry, the OSGi service wiring, the
+transaction manager, the callout chain, the `MTable`/`MColumn` reflection. You are
+trying to lift the engine *with its whole gravity well attached*. Two years is simply
+what that costs — and it does not converge, however much effort you add.
+
+The paradigm shift is not "do the extraction better in a PWA." It is to **stop
+extracting the engine, and extract what the engine operates on**:
+
+- The Application Dictionary rows and the rule records were **already data** —
+  `AD_Rule`, `AD_Val_Rule`. That is iDempiere's own design ([ERP.md §0.9](ERP.md)); half
+  the "rules engine" already exists as data. We *compile* it, we do not reinvent it.
+- The *remainder* — the deterministic part that actually runs a document — is small.
+  Re-hosted as a **~150-line kernel** in the browser's native JavaScript, `PO.java`'s job
+  (persist + lifecycle) becomes `apply(op)` plus the op-log fold; `Info.java`'s job (the
+  windowed UI) becomes the keyed-overlay Application Dictionary (the UI-overlay
+  governance model — every UI concern a keyed layer over a tagged element).
+
+The bloat was not ported. It was **deleted by being re-based.** That is why the shift
+worked from the outside when extraction failed from the inside.
+
+### So — are we free of `PO.java`?
+
+Two senses, and they differ. **From *running* it: yes, completely.** Nothing in the browser
+instantiates or extends `PO.java`; each of its jobs is re-based onto data or the log — generic
+save → `apply(op)` + the 5-table fold (no `UPDATE`-in-place exists at all); change-tracking →
+`kernel_ops` before/after + lineage; `beforeSave`/mandatory validation → rules-as-data
+(`AD_Val_Rule`); `get_ID` → edge-minted UUID recorded as input (§0.21); model-validator firing →
+the named-handler registry; `trx` → the op-group, the document-event as the atomic unit (§18.8).
+Witnessed: replay reproduces the O2C/P2P oracle to the cent with **zero iDempiere code executing.**
+
+The freedom came **by never extracting it.** Carrying `PO.java` somewhere lighter never converges
+— you drag its whole gravity well. But `PO.java`'s defining property, *generic and
+metadata-driven*, is precisely what makes it deletable: anything fully driven by metadata is
+replaceable by *reading the metadata and folding the log*. iDempiere could not take that step
+because that core was welded to the JVM / OSGi / `trx` / side-effects; remove the weld and
+`PO.java` has nothing left to do.
+
+**From what its subclasses *knew*: deliberately not — and that is correct.** The `M*.*It()`
+methods remain the **oracle** we verify against, per cell, so "extract" never slides into "guess."
+The day that consultation ends is the day every cell is extracted and verified — the §0.17 breadth
+campaign, in flight (O2C/P2P done; GL still dataless; the DocAction corpus being abstracted now).
+Free of *running* it; finishing the extraction of what it taught the models is the campaign, not a
+new idea.
+
+## Why it is a grail others cannot reach
+
+Three conditions have to hold **at the same time**. Almost no system has all three —
+which is exactly why this remained a quest rather than a checkbox:
+
+1. **The engine is data.** A rule is a *row you read*, not Java you recompile.
+2. **The host language is the rule language.** Browser JavaScript *is* the runtime, so
+   editing a rule is editing the running system — no JSR-223, no Drools workbench, no
+   scripting bridge ([ERP.md §0.9](ERP.md)).
+3. **The op-log makes editing safe.** Change-as-op, replay, dry-run, undo — *the safety
+   Drools never had* ([ERP.md §0.4](ERP.md)). You can edit a rule and **not corrupt
+   history**, because effects are frozen and replayable ([ERP.md §0.18](ERP.md)).
+
+iDempiere has condition (1) only half-done and lacks (2) and (3): its rules are
+half-data, half-welded into `M*` Java side effects, so they can never be made *fully*
+editable-at-runtime without the JVM / OSGi / workbench that constitute the bloat. Drools
+has a rule engine but no op-log safety and no engine-as-data. For them this is a *stuck*
+problem; here it is a **structural property**. The bloat that prevents them is precisely
+the bloat this project removed.
+
+> **How *every* ERP's logic enters** (the generalize / decision-data / caged-plugin question, and why a
+> Drools-*like* affordance is kept but the Drools *engine* is not) → the six-layer **logic-admission model** in
+> [IDEMPIERE_2.md](IDEMPIERE_2.md#the-logic-admission-model--how-all-of-odooerpnextsap-logic-enters). The grail is
+> that model's L1/L2/L5 made *live*.
+
+## The honest status — half-claimed, one mile left
+
+I will not overclaim my own grail. It is **half-reached, and witnessed that far:**
+
+- **Reached:** the rules are extracted to data — `erp_rules.db`, **746 records**,
+  **diff-verified** against the GardenWorld oracle ([ERP.md §0.10, §0.17](ERP.md)).
+  The engine renders *itself* from that data (Glassbowl), read-only.
+- **Remaining:** the **live edit loop** — *edit the rule → records reflow on the map* —
+  is the write-loop, gated behind T3 (`push=live`, explicit go). The read-only History
+  undo-preview and the greyed CRUD ring are the honest *seam* to it, not the step.
+
+And the seam is now being built. The CRUD / Validation overlay (the "ring-of-fire" edit
+layer, governed by the UI-overlay model) carries the
+`AD_Val_Rule` model as a keyed, editable layer. Make that validation layer *editable and
+re-folding* instead of static, and the grail is demonstrable in one gesture. The single
+witness that closes it:
+
+```
+§RULE-EDIT key=c_invoice rule=non_negative_amt edit=min:0→min:100
+           affected=K records re-fold verify=ok reversible=Y
+```
+
+Change one validation row; watch *K* records change which side of the rule they fall on,
+live; op-logged, signed, reversible. That witness is the whole paradigm shift made
+visible in a single gesture — and the architecture it needs (engine-as-data + a
+JavaScript host + the signed op-log) is **already standing under it.**
+
+## Roadmap check — the write-seam, as of 2026-06-01
+
+The grail is the *last rung of the write-loop*, not a separate project. Here is the
+ladder from today's read-only surface to the live rule-edit, and where each rung stands —
+this section is meant to be updated as a checkpoint each time a rung is climbed.
+
+| Rung | What it is | State |
+|---|---|---|
+| **R0** | Rules extracted to data, diff-verified (`erp_rules.db`, 746 records) | **done — witnessed** |
+| **R1** | The engine renders itself from that data, read-only (Glassbowl) | **done — live** |
+| **E2** | The write *seam* — CRUD ring + the document state machine (**Process / DocAction**) modelled as keyed data, **dry-run** | **done — witnessed (this checkpoint)** |
+| **E3** | The seam goes live — `apply` → `commitOp`/`sealChain`, `verifyChain` after each; projection re-folds; acceptance oracle (rebuilt #80001 == traced #80001) | next |
+| **E4** | Owner-gate + CAS invoked on the write path (the Phase-A guards surfaced) | pending |
+| **§RULE-EDIT** | **The grail** — edit a *rule* row; watch *K* records re-fold live, signed + reversible | the last rung |
+
+**What just landed, and why it matters to the grail.** The CRUD + **Process (DocAction)**
+overlay (E2) is now mounted in tandem with the Help guide as an independent peer layer —
+witnessed `§CRUD-PROC pass=27 fail=0`, plus the earlier CRUD validation/dry-run witnesses,
+all still dry-run. The **Process** piece is the part that matters here: it models the
+document's *state machine* — `completeIt()`, the legality of `DR→CO`, the IP-on-unmet
+outcome — as **data** (`docAction` descriptors naming the real `M*.completeIt()` oracles),
+not code. That widens the grail's surface from *field-validation rules* to *lifecycle
+rules*: the most valuable rule a user edits is usually "**when may this complete, and what
+does completion do**" — and that is now keyed data the same edit loop can reach. The grail
+is no longer only "edit a minimum amount"; it is "edit when an invoice may post."
+
+**The honest gap is unchanged.** E2 is still **dry-run** — it logs the op it *would* run.
+The load-bearing step is **E3**: the signed write plus the acceptance oracle that proves a
+re-built document matches the traced one. Until E3 is green, the seam is a faithful *model*
+of the engine, not the live engine; and the grail rung (`§RULE-EDIT`) sits one step past
+E3/E4. So the checkpoint verdict, stated plainly: **the seam to the grail is now built and
+witnessed as data; the current is not yet flowing through it.** A rung climbed, honestly
+logged — which is the difference between building and day-dreaming.
+
+## Abstracting the DocAction corpus — and why it is the migration solvent
+
+The grail edits *rules*; the most valuable rules govern a document's *lifecycle* — *when may
+this complete, and what does completion do.* So the engine must express the whole iDempiere
+**DocAction** corpus (≈13 actions — `DR/PR/CO/AP/RJ/CL/RC/RA/VO/RE/IN/XL/PO` — over ≈13
+statuses) as **data**, not code, without re-bloating into per-model logic. It does, because
+`DocumentEngine` is *already shared code in iDempiere, not per-model* — the tell that a state
+machine is hiding inside a switch. It abstracts into three layers, and **only one is
+per-model:**
+
+| Layer | What it is | Cost |
+|---|---|---|
+| **The transition table** | `(DocStatus × DocAction) → {legal?, nextStatus, guard, handler}` — one generic, sparse decision table (§0.5) | extracted **once**, model-agnostic |
+| **The handler families** | the side effects — and the corpus *collapses* (below) | a small closed set |
+| **The oracle** | each `docAction` names its `M*.<action>It()`; the diff-oracle proves the generic handler reproduces it, cell by cell | verify, never port |
+
+**The corpus collapses — but by *de-interleaving*, not by being secretly empty.**
+`MOrder.completeIt()` and `MInvoice.completeIt()` genuinely run for pages. They are long
+because each **interleaves four concerns** in one imperative method — and the same blob is
+re-written in `MOrder`, `MInvoice`, `MInOut`, `MPayment`. Separate the four and the pages shrink,
+because three of them are written **once for the whole corpus:**
+
+| Concern tangled inside the method | What it is | Where it goes | Written |
+|---|---|---|---|
+| `setDocStatus`/`Processed`/`DocAction`, validate hooks | status bookkeeping (boilerplate in every method) | the transition table | **once** |
+| mandatory fields, credit limit, legal status | guards — predicates (§0.14 GUARD) | rules (data) | **once, shared** |
+| `createShipment`, `createInvoice`, `reserveStock`, `allocate`, `match`, post | generation verbs (§0.14 GENERATE), **shared across models** | named handlers | **once each** |
+| which verbs fire, in what order, under which condition | the per-doc-type **recipe** | data — the `docAction` fan-out descriptor | a short list |
+
+What remains genuinely model-specific and intricate — BOM / phantom explode (MOrder), material
+transaction + costing + ASI (MInOut), the posting recipes — is a **small set of named handlers,
+verified per cell against the `M*.*It()` oracle** (§0.17), far smaller than the raw page count
+once boilerplate, guards, and the *duplicated* generation verbs are factored out.
+`MInvoice.completeIt()` is mostly calls to verbs O2C already proved — `match`, `allocate`, post —
+plus balance updates; its irreducible recipe is a handful of lines. `prepareIt` reduces the same
+way: its guards → rules, its `reserveStock` / explode → the same generation verbs as `completeIt`.
+
+The genuinely trivial actions carry **no handler at all** — straight into the table (~3 lines
+each in iDempiere): `approveIt` (`setIsApproved`), `rejectIt`, `unlockIt` (`setProcessing(false)`),
+`invalidateIt` (`setDocStatus(INVALID)`).
+
+And the **reversal family collapses to ONE generic handler:** `voidIt` / `reverseCorrectIt` /
+`reverseAccrualIt` / `reActivateIt` = *"emit the inverse of the document's op-group."* The op-log
+holds the original ops, so reversal is appending the negation — **the per-model, notoriously buggy
+reverse code in iDempiere becomes a single op-log operation.** This is the structural gift.
+(`closeIt` = set status + clamp the residual; near-generic.)
+
+So the reduction is real, but the mechanism is **factor the four concerns apart and de-duplicate
+the shared verbs** — not "the code was empty." The bulk (status, guards, shared verbs, posting) is
+written once for the whole corpus; the per-model remainder is a short recipe plus a few verified
+handlers, `completeIt` / `prepareIt` included.
+
+**Why this is the migration solvent.** Row migration is the easy part everyone already does.
+What makes ERP migration hell — and what *locks* customers into SAP/Odoo — is the **behaviour**:
+the lifecycle, the posting rules, the approvals. Nobody migrates behaviour because it is *code
+in the source system*. The moment behaviour is **data** (a transition table + named handlers
+verified against an oracle), migrating behaviour becomes migrating data. Every ERP's document
+lifecycle is the same shape — a state machine over documents descended from double-entry
+(1494). Onboarding a foreign instance becomes an **adapter** mapping *their* `(status, action,
+transition)` onto *this* generic table, and their schema onto the 5-table bridge; the engine
+never changes, only adapter rows. And because the target is an op-log, the migration is itself
+**replayable, auditable, reversible** — the same reversal-family handler that voids a document
+can unwind a bad import. You do not migrate *into* a new schema; you **fold the old system's
+facts into the universal one.**
+
+**The honest boundary.** "Eat *any* instance" is earned **one diff-oracle at a time.**
+iDempiere is tractable because its DocAction is known and GardenWorld is the oracle. Odoo is
+open and its state machine is extractable (oracle buildable). SAP is the asymptote — closed
+ABAP plus decades of customer Z-code where the real behaviour hides; the honest claim there is
+"the standard flows + extractable config, with Z-customisations per engagement." The method is
+proven by the *first* clean abstraction — iDempiere's DocAction, the one being built now — and
+the rest is campaign, in sequence (iDempiere → Odoo → SAP standard → SAP custom), each gated by
+its own oracle. Migration removes the barrier to leaving; the grail (editable rules, live)
+supplies the reason to land. Both halves, or the solvent has nothing to pour into.
+
+**Odoo — second abstraction, WITNESSED (2026-06-03, `§ODOO-FOLD PASS`).** Odoo 17 demo was stood up,
+one full sell-side O2C chain (SO `S00023` → delivery → invoice → GL post → payment → reconcile) was
+driven to completion via RPC and frozen as a static oracle (`build/erp/odoo_oracle.{json,db}`, §0.12).
+A *pure* adapter (`scripts/odoo_adapter.js` — the Odoo↔iDempiere data dictionary, no business logic)
+folded that chain through the **existing** kernel verbs: `newVerbs=[]`, all 5 hops mapped, effects
+reproduce Odoo to the cent, replay exact (`scripts/poc_odoo_fold.js`, log `build/erp/odoo_fold.log`).
+The solvent dissolved a *second* ERP with nothing invented — the strongest evidence yet that the
+verb set is general, not iDempiere-local. **Honest bound (named, not hidden):** this is ONE sell-side
+chain. Account *determination* (which GL account) came from Odoo as host data — the POST verb owns only
+ΣDR==ΣCR (§13.1), it does not re-derive Odoo's account logic. Full payment used FK-directed `ALLOCATE`.
+
+**Buy-side + partials, WITNESSED (2026-06-03).** The campaign then folded three more Odoo chains, all
+`newVerbs=[]`: the full 3-way `MATCH` (PO `P00011` → receipt → bill → post → reconcile, `§ODOO-FOLD-3WAY
+PASS` — the 6th verb now exercised, all six fold Odoo); the f7 partial-receipt (PO `P00012` ordered 20 /
+received 12 / billed 12, `§ODOO-FOLD-PARTIAL PASS` — decomposes into an exact-match settlement leg + an
+FK-directed open remainder, §0.17); and **f8 bill≠receipt** (PO `P00013` received 12, billed 8) — the one
+case that found a real engine gap. The SHIPPED exact-qty matcher pairs only when `|qtyL−qtyR|≤tol`, so it
+could not reconcile bill≠receipt. **That gap is now closed (`§ODOO-FOLD-F8 PASS`):** `erp_engine.match`
+gained opt-in **partial-QUANTITY matching** (`opts.partial=true` — pair `min(qty)`, carry the remainder),
+reconciling to the unit (matched 8 + open-to-bill 4 == received 12) still via the SAME `MATCH` verb. The
+honest classification held through the fix: it was new matcher **behaviour** (code), NOT a new verb
+(`newVerbs=[]`) and NOT adapter-shaped (data) — and the exact-qty fast path stayed untouched, no regression.
+
+**Partial PAYMENT, WITNESSED (2026-06-03, `§ODOO-FOLD-PAYPART PASS`).** The last Odoo bound the sell-side
+fold named was full-vs-partial *reconciliation*. A fresh chain was driven to a partial-payment state (SO
+`S00027` → invoice 5002.50 → register a payment of **3000**), leaving Odoo's computed residual **2002.50**,
+`payment_state='partial'`, frozen as a static oracle. The fold reproduces it with the **same `ALLOCATE`
+verb at the smaller amount** — residual = total − allocated, to the cent — `newVerbs=[]` **and no engine
+change**. Partial payment is the cleanest result of the campaign: it was *free*. (Contrast f8, which cost
+~15 lines of matcher behaviour: the difference is that a partial *payment* is one allocation at a smaller
+amount, whereas a partial *quantity match* is a genuinely different pairing.)
+
+**Account determination, DERIVED (2026-06-03, `§ODOO-FOLD-ACCTDERIV PASS`).** The one bound named at every
+step above was that the folds took Odoo's *resolved* GL accounts as host data — "reproduces given accounts."
+That bound is now closed. Odoo's determination CONFIG was extracted (product income = template account →
+category fallback; tax = the tax's repartition account; receivable = the partner property) and a resolver
+DERIVES the accounts from that config alone — reproducing Odoo's actual posting to the account (400000
+Sales / 251000 Tax / 121000 AR), the derived double-entry balancing to the cent. It stays **host glue, not
+engine** (POST still owns only ΣDR==ΣCR), and the determination logic was learned clean-room from the config
+*structure*, never Odoo's source. The claim is raised from "reproduces *given* accounts" to "**derives** the
+accounts" — `newVerbs=[]`.
+
+**Odoo, in sum:** six folds with nothing invented — sell-side O2C, buy-side 3-way, partial receipt,
+bill≠receipt, partial payment, and account derivation — across all six verbs, `newVerbs=[]` throughout, with
+exactly one engine change in the whole campaign (the f8 partial-quantity matcher). The remaining items
+(multi-currency, anglo-saxon COGS) are optional claim-raisers, not blockers.
+**Next abstraction: SAP — the asymptote.** The *allowed half* is prepared (2026-06-03): a clean-room,
+blind schema/state-map HYPOTHESIS (`scripts/sap_adapter.js`) mapping the standard SD+FI chain (VBAK/VBAP →
+LIKP/LIPS → VBRK/VBRP → BKPF/BSEG|**ACDOCA** → BSEG clearing, with **VBFA** as the explicit derivation
+spine) onto the same six verbs, plus a runner (`scripts/poc_sap_fold.js`) gated to `§SAP-ORACLE unavailable`
+until a real export exists. The hypothesis is sharp precisely because S/4HANA's own redesign converged on
+our shape — one append-style journal (ACDOCA) + an explicit document-flow graph (VBFA). What is *not* done,
+and cannot be without violating non-invent, is the fold itself: that needs a real IDES/S/4HANA oracle, in
+its own session, **never against an invented oracle.** The honest claim stays "standard flows + extractable
+config; Z-customisations per engagement" — and the value of the SAP run is finding *which* Z-behaviour does
+not fold, not a foregone PASS.
+
+## The hard parts, worked through — why the showstoppers aren't
+
+Three forward challenges look like showstoppers until you model them as the ledger already does.
+None requires the OLTP server, the lock manager, or the always-on coordinator a classic ERP carries.
+
+### 1. Compacting the signed log — *balance brought forward*
+
+The op-log is hash-chained for tamper-evidence — each entry carries the fingerprint of the one
+before it, so any later alteration is caught. After years it is millions of entries: too large for a
+tab, too slow to replay from the start. You cannot simply delete the old ones — the chain would snap
+and the old history could no longer be proven intact.
+
+The resolution is the **period close.** At close, write one **signed checkpoint** carrying (a) the
+closing balances and (b) the fingerprint of the chain head, signed by the controller. That checkpoint
+becomes a new genesis: the next period chains off it; the closed period's entries are **archived
+(cold), not deleted**; the live tab carries only the open period + the last checkpoint. Tamper-evidence
+survives — re-add the archived entries and they must fold to the signed balance, to the cent, or fraud
+is proven. This is **balance brought forward**: total the books, carry the opening balance, box the
+journals in the archive. iDempiere already does the accounting half; we add only the signature and the
+fingerprint. The hash-chain checkpoint and the accountant's year-end close are the *same ritual* — the
+domain solved this 500 years ago. *(Optional reinforcements: a Merkle root keeps per-transaction
+provability of a closed period in 32 bytes; emailing the checkpoint fingerprint to yourself binds even
+the signer.)*
+
+### 2. Atomicity — the document *is* the atomic unit
+
+Atomicity — all of a document's effects, or none — needs no transaction manager here, because there is
+no multi-row `UPDATE` to half-complete. A document-event is **one op-group** (§18.8), appended to the
+log as a unit; state is the *fold* over it. The group folds in completely or not at all, and a torn
+write fails its own hash. Atomicity is **structural** — the same dissolve-don't-coordinate move that
+removed contention: delete the multi-write transaction, keep the single atomic append.
+
+### 3. OLTP — physics is the lock, the ledger is the witness
+
+Classic OLTP spends its effort on **isolation**: row locks / MVCC so concurrent writers do not clobber
+shared state. The DistributedERP doctrine ([DistributedERP.md](DistributedERP.md) §1–§6) shows that
+shared state is mostly a modelling artifact:
+
+- **Atomicity** — solved above (the op-group).
+- **Consistency** — the deterministic kernel + guards (period control included) enforce invariants on
+  apply and on replay.
+- **Isolation** — *physics partitions the writers.* A till owns its sales, a van owns its load, a
+  box-in-hand owns itself — two writers cannot touch the same aggregate because the **atoms have a
+  location** (§2). The one genuinely shared thing — the last unit, a global entitlement — is the single
+  **CAS op-class** (§5): one set-if-unset, not a lock manager.
+- **Durability** — asynchronous: the local append is instant; durability lands when the log is relayed
+  (W-PERSIST). The one honest trade (§19.6) — synchronous durability for async convergence.
+
+Per terminal this *wins*: in-RAM apply of the op-group, no network per transaction (~1–3 orders faster
+than networked JDBC, §19). What remains is mechanical, not theoretical — maintain the read-projection
+incrementally at high append rates, bounded by the period checkpoint so the working set stays small.
+
+**And the deepest case — stock — is where the ledger earns its keep.** You do *not* lock the world to
+prevent an oversell; in a partition you cannot, and every system that claims to is secretly
+record-and-consequence ([DistributedERP.md](DistributedERP.md) §0, truth 4). Instead: **the physical
+count is the truth; the ledger is the running expectation; reconciliation surfaces the difference.** The
+scan *is* the op — you cannot scan a unit that is not physically there — so a physical unit cannot be
+double-committed. The ledger's job is not to *prevent* the discrepancy but to **tell you the stock is
+off** so you reconcile: POS → BOM backflush → replenishment → physical reconciliation. *Physics is the
+truth; the ledger is the witness that the books drifted.*
+
+### What it leaves you — keep just the ledger
+
+Strip the machinery a classic ERP needs for these — the transaction manager, the lock/MVCC layer, the
+always-on OLTP server, the sync coordinator — and **what remains is the ledger**: a signed, append-only
+op-log; its fold (the balances); and reconciliation against the physical world. Compaction is *balance
+b/f*; atomicity is *one op-group*; concurrency is *physics + one CAS*; multi-site is a *dumb async
+facilitator* that only orders and relays ([DistributedERP.md](DistributedERP.md) §6), never an
+authority. The hard parts are not unsolved — they are **re-expressed as accounting**, the one part of an
+ERP that was always going to stay. It has been thought through; the ledger is enough.
+
+**Witnesses — these are runs, not arguments (dated, headless, replay-deterministic).** The three hard parts
+above are exercised on the actual editing-layer op shape in `scripts/poc_showstopper.js` (`§SHOW PASS`): the
+document-event op-group folds all-or-none (a torn op is rejected whole), the period-close checkpoint re-folds
+the cold archive to the signed balances *to the cent* with the tamper caught at the exact op, and the single
+CAS holds across the checkpoint boundary. The "mechanical, bounded by the checkpoint" claim is then *measured*
+in `scripts/poc_volume.js` (`§VOL PASS`): bootstrap from the last checkpoint stays flat as total history grows
+100× while a full replay grows with it — the working set is bounded by the period, not the log; the binding
+constraint is the per-op hash (append and verify), which sets the close cadence, not a wall. And the durability
+path — the inbox as the recoverable signed log — is stress-tested in `scripts/poc_email_dr.js` (`§EMAIL-DR
+PASS`): the data recovers unconditionally from any reachable valid snapshot, but the key does not live in the
+inbox — without an anchor the encrypted snapshots are undecryptable, and the three anchors that close that gap
+(own k-of-n channels, corporate escrow, platform passkey) each add a named, non-zero trust. The regress
+terminates for the *fact* unconditionally; for the *key*, only at a chosen anchor — and naming it is the floor.
+
+**Performance, measured (not asserted).** `scripts/poc_volume_ceiling.js` pushes the log/fold layer to 20M
+ops with no wall and a linear curve (~437 bytes/op); `scripts/poc_volume_sqljs.js` re-measures on the actual
+browser stack (sql.js + `crypto.subtle`), where a per-op append is ≈15 µs, bound by the async hash, not by
+SQLite, and the fold (a SQL `GROUP BY` over a bounded chart of accounts) stays sub-frame. Against a legacy
+central database the gap is set by *where the work happens*: `scripts/poc_legacy_ab.js` shows that **on one
+box** Postgres ≈ local SQLite (both ~1 ms, fsync-bound) — so the ~100× there is honestly the async-durability
+trade (§19.6), not server-removal. `scripts/poc_remote_pos.js` shows the **remote** case, where it matters: a
+POS sale's cashier-perceived latency is RTT-bound for a central DB (tens to hundreds of ms, and the till
+*cannot sell when the link is down*) versus a local apply plus an asynchronous relay to HQ — RTT-independent
+and offline-capable; a 10k-document batch-plus-charts runs locally with no network and no per-chart round-trip
+(~12× over a fair server-side batch at cross-region latency). Every legacy figure is raw SQL, excluding the
+ORM/OSGi/JDBC layers that only make it slower — a floor, not a ceiling. The one honest cost throughout is the
+same async-durability trade; the gains are server-removal and locality, named, not rounded up.
+
+**Where this sits among the fast-SQLite systems — and the claim I will *not* make.** Embedded SQLite at scale
+is not new: Expensify's Bedrock, Cloudflare's D1, Turso/libSQL all run it in production. On a single box, with
+durability matched, an in-process engine is roughly 3× a networked one on writes — and that advantage *inverts*
+under heavy concurrency, a benchmark a fair critic will (and should) cite. So I do not claim a faster engine.
+The real difference is the **write path**: every one of those peers keeps strong consistency by escalating each
+write to a central primary over the network. This design does not — a write applies locally and the signed
+op-group is relayed asynchronously, with a single compare-and-set for the one genuinely shared resource. That
+is a different *consistency model*, not a faster engine; its cost is eventual convergence, and its dividends are
+the two things a round-trip-to-a-primary architecture cannot give a till: it keeps selling when the network is
+down, and there is no write-contention to lose under concurrency, because each terminal is the single writer of
+its own partition. The speed argument is modest and conditional; the architecture argument — offline,
+single-writer, signed — is the one that holds.
+
+## A closing note, to the version of me from two years ago
+
+The two years spent proving the *imperative* extraction does not converge were not
+wasted — they are the evidence that the *declarative-extract* path is the one that does.
+The grail was never going to be reached by carrying the old engine somewhere lighter. It
+is reached by realizing the engine should have been data all along, and that the one
+thing a code-engine structurally cannot give you — a rule you edit while it runs, safely
+— falls out for free the moment it is.
+
+---
+
+*Grounding: [ERP.md](ERP.md) §0.4 · §0.5 · §0.9 · §0.10 · §0.17 · §0.18 · §2d-3 ·
+[GLASSBOWL_DOSSIER.md](GLASSBOWL_DOSSIER.md) · the §20 prototype addendum. Every claim of
+extraction here is witnessed in a dated log; nothing on this page is asserted that the
+source data does not support.*

--- a/erp/OpLogERP.md
+++ b/erp/OpLogERP.md
@@ -1,0 +1,53 @@
+# An ERP Engine as a Deterministic Fold over a Signed Operation Log
+
+<div class="bim-banner" markdown>
+<b>Technical abstract.</b> An accounting kernel whose state is a deterministic fold over an append-only, signed operation log — serverless, in the browser, over SQLite. A companion to the [BIM-ERP](ERP.md) work.
+</div>
+
+**Redhuan D. Oon**
+ADempiere (2006) | iDempiere (2010) | Author, *Open Source ERP* (2010) | BIM5D (2025)
+
+red1org@gmail.com | [LinkedIn](https://www.linkedin.com/in/red1oon/)
+
+Forked from the iDempiere lineage (Compiere → ADempiere → iDempiere), MIT.
+
+June 2026
+
+---
+
+## Abstract
+
+Conventional ERP systems represent state as mutable rows protected by a database server, a lock manager, and a transaction monitor. This work represents state instead as a *deterministic fold over an append-only, cryptographically signed sequence of operations*: a fact is computed by replaying the log, never stored as a guarded scalar. An accounting kernel built this way executes without a server — in a browser, over SQLite — and accepts writes while partitioned from all peers.
+
+The constituent techniques are established: append-only-log-as-system-of-record with deterministic materialisation (Datomic, event sourcing); hash-chained verifiable ledgers (Amazon QLDB, immudb); single-writer state at the edge (Cloudflare Durable Objects); offline convergence (local-first / CRDT). The contribution is their composition under ERP semantics, with two structural results:
+
+1. **Reduction.** iDempiere's Application Dictionary (≈925 tables) reduces to a five-relation bridge — *documents, lines, journal, containers, items* — plus a small verb set, sufficient to fold an ERP within a single browser context.
+2. **Unification.** BIM and ERP share one operation log, so a building model materialises into a procurement order through the same kernel.
+
+The method is *extraction* rather than greenfield specification: iDempiere's model classes act as the oracle and its executed records (the GardenWorld dataset) as static ground truth, each verb validated by multiset-diffing the kernel's projection against those records. We report a kernel and architecture witnessed by deterministic replay, period-close checkpointing (compaction as balance-carried-forward), and a single compare-and-set operation class for the one genuinely shared resource.
+
+## Scope
+
+Offline availability and per-operation verifiability are structural consequences of the log model, not optimisations. Reported latency is local in-memory apply measured against an equivalent client–server SQL baseline that trades synchronous durability for asynchronous convergence; **no head-to-head measurement against iDempiere is claimed.** Live rule editing with online re-fold, foreign-schema migration (Odoo, SAP), and the complete document-action suite are specified and partially witnessed, not shipped.
+
+## Assembly (technical summary)
+
+1. **Treat the Application Dictionary as data** — extract it; ≈925 tables reduce to five relations plus verbs.
+2. **De-interleave DocAction** — the document lifecycle becomes a status table, shared verbs, and per-type recipes rather than per-class `completeIt()` methods.
+3. **Make state a fold** — replace in-place mutation (`UPDATE qty = qty − 1`) with replay over ordered operations; with no shared mutable cell there is no write contention to serialise.
+4. **Compact via the accounting period** — period close is a signed checkpoint carrying balances forward; the live log stays bounded by the open period, not the system lifetime.
+5. **Partition by physics, reconcile by CAS** — disjoint aggregates union without coordination; the single shared quantity (the last unit) is one compare-and-set operation class, no lock manager.
+6. **Co-locate execution and substrate** — the kernel runs on SQLite in the browser; the same operation log drives the BIM model, so a building folds into a Project Order.
+
+## Witnesses
+
+Each claim is reproducible from the repository, validated by `§`-tagged logs rather than assertion:
+
+| Claim | Witness |
+|-------|---------|
+| AD → five-relation reduction; verbs reproduce executed output | `scripts/diff_oracle.js`, `diff_oracle_cells.js` (multiset diff vs the GardenWorld oracle) |
+| Op-group atomicity (all-or-none); period-close checkpoint reconciles the cold archive to the signed balances to the cent; single CAS across the checkpoint | `scripts/poc_showstopper.js` → `§SHOW PASS` |
+| Working set bounded by the period, not the log (flat bootstrap across 100× history) | `scripts/poc_volume.js` → `§VOL PASS` |
+| Signed hash-chain, ordered replay, owner-gate / CAS, key-recovery floor | `scripts/poc_chain.js`, `poc_distributed.js`, `poc_sign.js`, `poc_email_dr.js` |
+
+Companion documents: [AD-in-Browser (iDempiere)](ERP.md) · [The Holy Grail (editable rules, live)](HolyGrail.md) · [Distributed ERP (Contention Map)](DistributedERP.md) · [Local-First Prior Art](LocalFirstPriorArt.md).

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -645,7 +645,7 @@
   }
   global.__crud = { enable: enable, disable: disable, openRing: openRing, core: CORE, store: function () { return STORE; },
                     setStatus: setDocStatus, statusBar: function () { return statusBar; }, pulseProc: pulseProc,
-                    kernelDb: function () { return SIDE; }, withSidecar: withSidecar,
+                    kernelDb: function () { return SIDE; }, withSidecar: withSidecar, persist: _sidePersist,
                     readTip: function (table, id) { return SIDE ? CORE.readTip(SIDE, table, id) : null; }, history: history };
   console.log('§CRUD layer mounted (Edit-mode ready)');
 })(typeof window !== 'undefined' ? window : this);

--- a/erp/erp.html
+++ b/erp/erp.html
@@ -61,6 +61,9 @@
 </head>
 <body>
 
+<!-- Evaluator on-ramp → the basic comparison paper (docs/MigrateComparisonPaper.md). -->
+<a href="migrate_compare.html" id="cmp-link" style="position:fixed;top:10px;left:12px;z-index:9500;display:inline-flex;align-items:center;gap:6px;min-height:34px;padding:0 12px;border-radius:18px;border:1px solid rgba(108,159,255,.4);background:rgba(12,15,20,.82);color:#6c9fff;text-decoration:none;font:13px -apple-system,system-ui,sans-serif">▤ How this compares</a>
+
 <div id="loading">
   <div class="spinner"></div>
   <div>Loading ERP OOTB&hellip;</div>

--- a/erp/erp_period_close.js
+++ b/erp/erp_period_close.js
@@ -1,0 +1,168 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// erp_period_close.js — ERP.md §0.20 contract-freeze / HolyGrail §"hard parts" (compaction = period-close).
+// Witness: W-PCLOSE (scripts/test_kernel_period_close.js). Spec: prompts/PERIOD_CLOSE_FOLD_POC.md §Spec.
+//
+// Lifts the ALREADY-GREEN abstract proof scripts/poc_showstopper.js §SHOW-CKPT onto the REAL kernel_ops log:
+// a closed accounting period collapses to ONE signed checkpoint op carrying the closing balances (integer
+// cents) + the prior chain-head fingerprint; pre-checkpoint ops are dropped from the LIVE log; the next
+// period folds FROM the checkpoint balances (balance brought forward). Re-folding [checkpoint + post-ckpt]
+// is byte/cent-identical to folding the full genesis history — so compaction loses nothing — and the
+// checkpoint is tamper-evident (hash chain + controller signature over the new tip).
+//
+// This module COMPOSES on the kernel (commitOp / sealChain / verifyChain / replayOps) — it does NOT bloat
+// kernel_ops.js. The signature reuses erp_snapshot_sign (ECDSA P-256, pinned controller key). Determinism:
+// the fold reads account/cents ONLY (never timestamp/id/uuid); closePeriod re-stamps the checkpoint op to a
+// RECORDED ts (an INPUT) — NO Date.now()/Math.random() on any fold/replay path.
+(function () {
+  'use strict';
+
+  var CKPT_TYPE   = 'PERIOD_CLOSE';
+  var REOPEN_TYPE = 'PERIOD_REOPEN';
+
+  // ── the accounting fold (deterministic, integer cents) ──────────────────────────────────────────
+  // TWO posting shapes fold here, both deterministic in integer cents; document ops (orders/ships/
+  // invoices) carry neither → skipped; CKPT/REOPEN are control ops, never postings. `opening` is the
+  // balance brought forward (default empty). The closing balance of an account = net cents.
+  //   (1) SYNTHETIC (poc_showstopper / test_kernel_period_close): `{account:string, cents:int}`.
+  //   (2) REAL — the LIVE app's §13.1 POST verb (~/bim-ootb/erp/erp_kernel.js applyOne): double-entry
+  //       `{lines:[{account_id, amtacctdr, amtacctcr}]}`, ΣDR==ΣCR. Per-account b/f = Σ(DR)−Σ(CR) cents.
+  //       Implementing prompts/ERP_SUBSTRATE_INTEGRATION.md §INTEG-POSTINGS-RECONCILE — Witness:
+  //       W-POSTINGS-RECONCILE. Additive: the synthetic path is byte-identical when no `lines` present.
+  function _isPosting(p) {
+    return p && typeof p.account === 'string' && typeof p.cents === 'number' && (p.cents | 0) === p.cents;
+  }
+  // cents() mirrors ~/bim-ootb/erp/erp_postings.js exactly (the app's own DR/CR→cents) for an identical
+  // fold; amounts are 2-dp Fact_Acct values so Math.round is deterministic (no Number drift at 2 places).
+  function _cents(n) { return Math.round(Number(n || 0) * 100); }
+  function foldBalances(ops, opening) {
+    var bal = {}, a;
+    if (opening) { for (a in opening) if (Object.prototype.hasOwnProperty.call(opening, a)) bal[a] = opening[a]; }
+    (ops || []).forEach(function (op) {
+      if (op.op_type === CKPT_TYPE || op.op_type === REOPEN_TYPE) return;   // control ops, not postings
+      var p = op.parameters;                                                // replayOps already JSON-parses
+      if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { return; } }
+      if (!p) return;
+      if (Array.isArray(p.lines)) {                                         // (2) real double-entry POST op
+        p.lines.forEach(function (l) {
+          var acct = String(l.account_id);
+          bal[acct] = (bal[acct] || 0) + _cents(l.amtacctdr) - _cents(l.amtacctcr);
+        });
+        return;
+      }
+      if (!_isPosting(p)) return;                                           // (1) synthetic posting
+      bal[p.account] = (bal[p.account] || 0) + p.cents;
+    });
+    return { bal: bal };
+  }
+
+  function balSum(bal) { var s = 0; for (var a in bal) s += bal[a]; return s; }   // double-entry: 0 when balanced
+  // balEqual — max absolute per-account difference in cents (0 ⇒ cent-identical). The falsifier metric.
+  function balEqual(x, y) {
+    var keys = {}, k, max = 0;
+    for (k in x) keys[k] = 1; for (k in y) keys[k] = 1;
+    for (k in keys) max = Math.max(max, Math.abs((x[k] || 0) - (y[k] || 0)));
+    return { equal: max === 0, maxDiffCents: max };
+  }
+
+  // ── closePeriod — fold the live log → closing balances → ONE signed checkpoint → compact ────────
+  // signer = { signTip: async(tipHex)->sigHex, signed_by?:string }. periodMeta = { period, ts }.
+  // ts is a RECORDED close timestamp (an INPUT), so the checkpoint op — hence the new tip — is deterministic.
+  async function closePeriod(db, kernel, signer, periodMeta) {
+    periodMeta = periodMeta || {};
+    var period = (periodMeta.period != null) ? periodMeta.period : 1;
+    var ts     = (periodMeta.ts != null) ? periodMeta.ts : 0;
+
+    // 1. seal + verify the period being closed; capture its chain-head fingerprint (prev_tip).
+    await kernel.sealChain(db);
+    var pre = await kernel.verifyChain(db);
+    if (!pre.ok) throw new Error('closePeriod: pre-close chain does not verify (brokeAt=' + pre.brokeAt + ' ' + pre.why + ')');
+    var prevTip = pre.tip, archived = pre.len;
+
+    // 2. fold the live ops → closing balances (integer cents).
+    var live = kernel.replayOps(db);
+    var closing = foldBalances(live, null).bal;
+
+    // 3. commit ONE checkpoint op carrying the deterministic payload; re-stamp to the recorded ts; re-seal.
+    var ckptId = kernel.commitOp(db, CKPT_TYPE, { period: period, closing_balances: closing, prev_tip: prevTip });
+    db.run('UPDATE kernel_ops SET timestamp=? WHERE id=?', [ts, ckptId]);
+
+    // 4. compact: drop every pre-checkpoint op from the LIVE log; the checkpoint becomes the new anchor.
+    //    (The full pre-close log is the cold archive — kept by the caller, never deleted here.)
+    db.run('DELETE FROM kernel_ops WHERE id < ?', [ckptId]);
+
+    // 5. re-seal the compacted live log; the new tip is the fingerprint of [PERIOD_CLOSE].
+    var sealRes = await kernel.sealChain(db);
+    var post = await kernel.verifyChain(db);
+    if (!post.ok) throw new Error('closePeriod: post-compaction chain does not verify');
+    var tip = post.tip;
+
+    // 6. the controller signs the NEW tip (the signed checkpoint = chain-head fingerprint signed).
+    var sig = null;
+    if (signer && typeof signer.signTip === 'function') sig = await signer.signTip(tip);
+
+    console.log('§PCLOSE-FOLD period=' + period + ' archived=' + archived + ' closing=' + JSON.stringify(closing) +
+                ' balSum=' + balSum(closing) + ' prevTip=' + (prevTip || '').slice(0, 12) + '…');
+    console.log('§PCLOSE-COMPACT liveLen=' + post.len + ' (≪ ' + archived + ') newTip=' + (tip || '').slice(0, 12) +
+                '… verifyLive=' + (post.ok ? 'ok' : 'FAIL') + ' sealed=' + sealRes.sealed);
+    console.log('§PCLOSE-SIGN tip=' + (tip || '').slice(0, 12) + '… signed=' + (sig ? 'Y' : 'N') +
+                ' by=' + (signer && signer.signed_by || 'controller'));
+
+    return { period: period, closing_balances: closing, prev_tip: prevTip, tip: tip, sig: sig,
+             signed_by: (signer && signer.signed_by) || 'controller', archived: archived, liveLen: post.len };
+  }
+
+  // ── bootstrapFromCheckpoint — opening = latest checkpoint's closing balances; fold post-ckpt forward ──
+  function _latestCheckpoint(db) {
+    var r = db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='" + CKPT_TYPE + "' ORDER BY id DESC LIMIT 1");
+    if (!r.length || !r[0].values.length) return null;
+    return { id: r[0].values[0][0], params: JSON.parse(r[0].values[0][1]) };
+  }
+  function bootstrapFromCheckpoint(db, kernel) {
+    var ck = _latestCheckpoint(db);
+    var opening = ck ? ck.params.closing_balances : {};
+    var period  = ck ? ck.params.period : 0;
+    // post-checkpoint ops only (id > ckptId); the checkpoint op itself is a control op, skipped by the fold.
+    var live = kernel.replayOps(db);
+    var post = ck ? live.filter(function (o) { return o.id > ck.id; }) : live;
+    var current = foldBalances(post, opening).bal;
+    console.log('§PCLOSE-BF fromCheckpoint=' + (ck ? 'Y(period=' + period + ')' : 'N') +
+                ' opening=' + JSON.stringify(opening) + ' postCount=' + post.length +
+                ' current=' + JSON.stringify(current));
+    return { period: period, opening: opening, current: current, postCount: post.length, fromCheckpoint: !!ck };
+  }
+
+  // ── reopenPeriod (optional §PCLOSE-REOPEN) — a SUPERSEDE op re-chained onto the head; the original
+  //    PERIOD_CLOSE stays in the chain (audit), never edited in place (the iDempiere reopen wrinkle). ──
+  async function reopenPeriod(db, kernel, signer, meta) {
+    meta = meta || {};
+    var ck = _latestCheckpoint(db);
+    if (!ck) throw new Error('reopenPeriod: no checkpoint to reopen');
+    var ts = (meta.ts != null) ? meta.ts : 0;
+    var id = kernel.commitOp(db, REOPEN_TYPE, { period: ck.params.period, supersedes_ckpt_id: ck.id, reason: meta.reason || 'reopen' });
+    db.run('UPDATE kernel_ops SET timestamp=? WHERE id=?', [ts, id]);
+    var sealRes = await kernel.sealChain(db);
+    var v = await kernel.verifyChain(db);
+    var sig = (signer && typeof signer.signTip === 'function') ? await signer.signTip(v.tip) : null;
+    // the original checkpoint must still be present + the chain must still verify through it.
+    var still = db.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='" + CKPT_TYPE + "'");
+    var ckptCount = Number(still[0].values[0][0]);
+    console.log('§PCLOSE-REOPEN supersedes=ckpt#' + ck.id + ' reopenOp=' + id + ' origCkptStillInChain=' +
+                (ckptCount >= 1 ? 'Y' : 'N') + ' verify=' + (v.ok ? 'ok' : 'FAIL') + ' tip=' + (v.tip || '').slice(0, 12) + '…');
+    return { period: ck.params.period, reopenId: id, tip: v.tip, sig: sig, verify: v.ok, ckptCount: ckptCount, sealed: sealRes.sealed };
+  }
+
+  var _api = {
+    foldBalances: foldBalances,
+    balSum: balSum,
+    balEqual: balEqual,
+    closePeriod: closePeriod,
+    bootstrapFromCheckpoint: bootstrapFromCheckpoint,
+    reopenPeriod: reopenPeriod,
+    CKPT_TYPE: CKPT_TYPE,
+    REOPEN_TYPE: REOPEN_TYPE
+  };
+  if (typeof module !== 'undefined' && module.exports) { module.exports = _api; }
+  if (typeof window !== 'undefined') { window.ErpPeriodClose = _api; }
+  if (typeof console !== 'undefined') { console.log('§PCLOSE_LOADED v1 (period-close fold = signed checkpoint = balance b/f)'); }
+})();

--- a/erp/glassbowl.html
+++ b/erp/glassbowl.html
@@ -854,8 +854,15 @@ if(!window.__restored&&isMobile())setPanelCollapsed(true);else syncPanelUI(docum
 <script src="bigdecimal.js"></script>
 <!-- production signed kernel (W-CHAIN/W-SIGN) — one source, copied from bim-ootb/viewer/kernel_ops.js. GP3: Process ▶ commits real signed SET_STATUS ops to a sidecar log. -->
 <script src="kernel_ops.js"></script>
+<!-- edge signer (W-SIGN) — turns the signed checkpoint un-FORGEABLE; loadOrMint custody, reused by period-close. -->
+<script src="erp_signer.js"></script>
 <!-- CRUD ring-of-fire + Process/DocAction overlay — peer behavior layer, keyed to bubbles. GP3: Process ▶ = REAL signed write (sidecar log, read-the-tip). -->
 <script src="crud_overlay.js"></script>
+<!-- Period-close in-app (§INTEG-WIRE) — fold the live sidecar op-log → ONE signed checkpoint = balance b/f; bootstrap from it on load. -->
+<script src="erp_period_close.js"></script>
+<script src="period_close_ui.js"></script>
 <!-- Report (read face of the op-log) — peer overlay; the ring's ▤ verb folds a Receipt from the bundle. PURE READ. (CRUD_P_R_REPORT.md R1) -->
 <script src="report_overlay.js"></script>
+<!-- §INTEG-WIRE — mount the period-close control into the info panel (the op-log's natural home: compact → checkpoint). -->
+<script>(function(){function m(){if(!(window.PeriodClose&&window.__crud&&window.ErpPeriodClose)){return setTimeout(m,300);}var p=document.getElementById('panel');if(p&&!p.querySelector('.pclose-ctl')){try{window.PeriodClose.renderInto(p,{});console.log('§INTEG-WIRE control mounted in #panel');}catch(e){console.warn('§INTEG-WIRE mount',e&&e.message);}}}if(document.readyState!=='loading')m();else document.addEventListener('DOMContentLoaded',m);})();</script>
 </body></html>

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -246,6 +246,7 @@
     <div class="idmp-login-mark">A+</div>
     <div class="idmp-login-title">iDempiere&#8209;like — Sign In</div>
     <div class="idmp-login-sub">Offline demo · identity &amp; context <b>selection</b> (no password) — folded from <b>ad_seed.db</b></div>
+    <div class="idmp-login-sub" style="margin-top:6px"><a href="migrate_compare.html" style="color:#6c9fff;text-decoration:none">▤ How this compares to iDempiere / Odoo / SAP&nbsp;›</a></div>
     <div id="idmp-login-step1">
       <div class="idmp-login-label">Select a user</div>
       <div id="idmp-login-users" class="idmp-login-list"></div>

--- a/erp/migrate_compare.html
+++ b/erp/migrate_compare.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Migrate &amp; Compare — Legacy ERP vs the WASM Event-Sourced Browser</title>
+<!--
+  migrate_compare.html — the basic, evaluator-facing comparison page (prompts/ERP_SUBSTRATE_INTEGRATION /
+  docs/MigrateComparisonPaper.md). Renders the SINGLE source migrate_compare.md (no duplication, no drift):
+  a thesis, a round-trip-vs-local diagram, and a source-cited vitals table comparing iDempiere/Odoo/SAP
+  with our WASM event-source concept. Self-contained — a tiny markdown renderer, no external library.
+  Linked from erp.html + idempiere.html. NON-INVENT: every number lives in the .md, each cell footnoted.
+-->
+<style>
+  :root{--bg:#0c0f14;--card:#141a22;--ink:#e7edf3;--dim:#9fb0c8;--line:#222c38;--accent:#6c9fff;--good:#5fd08a}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;-webkit-text-size-adjust:100%}
+  .wrap{max-width:980px;margin:0 auto;padding:24px 18px 80px}
+  .top{display:flex;align-items:center;gap:12px;margin-bottom:8px}
+  .back{display:inline-flex;align-items:center;gap:6px;min-height:38px;padding:0 14px;border-radius:20px;border:1px solid var(--line);background:rgba(255,255,255,.04);color:var(--accent);text-decoration:none;font-size:13px}
+  #doc h1{font-size:24px;line-height:1.25;margin:18px 0 6px}
+  #doc h2{font-size:19px;margin:28px 0 8px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  #doc h3{font-size:16px;margin:20px 0 6px;color:var(--accent)}
+  #doc p{margin:10px 0}
+  #doc a{color:var(--accent)}
+  #doc hr{border:none;border-top:1px solid var(--line);margin:22px 0}
+  #doc blockquote{margin:12px 0;padding:10px 14px;border-left:3px solid var(--accent);background:rgba(108,159,255,.07);border-radius:0 8px 8px 0;color:var(--dim);font-size:14px}
+  #doc pre{background:#0b0f16;border:1px solid var(--line);border-radius:10px;padding:14px;overflow:auto;font:12.5px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;color:#cfe0f5}
+  #doc code{background:rgba(255,255,255,.07);border-radius:5px;padding:1px 5px;font:12.5px ui-monospace,Menlo,monospace}
+  #doc pre code{background:none;padding:0}
+  #doc ul,#doc ol{margin:10px 0;padding-left:22px}#doc li{margin:5px 0}
+  .tablewrap{overflow-x:auto;margin:14px 0;-webkit-overflow-scrolling:touch}
+  #doc table{border-collapse:collapse;width:100%;min-width:680px;font-size:13px}
+  #doc th,#doc td{border:1px solid var(--line);padding:9px 11px;text-align:left;vertical-align:top}
+  #doc th{background:#1a2230;color:#fff;position:sticky;top:0}
+  #doc tbody tr:nth-child(even){background:rgba(255,255,255,.02)}
+  #doc td:last-child{background:rgba(95,208,138,.06)}
+  .err{color:#e88;padding:20px}
+  sup{color:var(--accent);font-size:11px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="top"><a class="back" id="back" href="erp.html">‹ Back</a></div>
+  <div id="doc"><p class="err" style="display:none" id="err"></p></div>
+</div>
+<script>
+// minimal, scoped markdown renderer — handles exactly the constructs in migrate_compare.md:
+// fenced code, h1-h3, hr, blockquote, GFM pipe tables, ordered/unordered lists, paragraphs;
+// inline: **bold**, `code`, [text](url), [^ref] footnote markers. No external dependency.
+(function () {
+  function esc(s) { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+  function inline(s) {
+    s = esc(s);
+    s = s.replace(/`([^`]+)`/g, function (_, c) { return '<code>' + c + '</code>'; });
+    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    s = s.replace(/\[\^([^\]]+)\]/g, '<sup>[$1]</sup>');                          // footnote ref
+    s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (_, t, u) {                // links: local .md → this viewer ?f=
+      var m = u.match(/^([A-Za-z0-9_]+\.md)(#.*)?$/);
+      var href = m ? ('migrate_compare.html?f=' + m[1] + (m[2] || '')) : u; return '<a href="' + href + '">' + t + '</a>'; });
+    return s;
+  }
+  function table(rows) {
+    var head = rows[0].slice(1, -1).split('|').map(function (c) { return c.trim(); });
+    var body = rows.slice(2).map(function (r) { return r.slice(1, -1).split('|').map(function (c) { return c.trim(); }); });
+    var h = '<div class="tablewrap"><table><thead><tr>' + head.map(function (c) { return '<th>' + inline(c) + '</th>'; }).join('') + '</tr></thead><tbody>';
+    h += body.map(function (r) { return '<tr>' + r.map(function (c) { return '<td>' + inline(c) + '</td>'; }).join('') + '</tr>'; }).join('');
+    return h + '</tbody></table></div>';
+  }
+  function render(md) {
+    var lines = md.replace(/\r/g, '').split('\n'), out = [], i = 0;
+    while (i < lines.length) {
+      var ln = lines[i];
+      if (/^```/.test(ln)) { var buf = []; i++; while (i < lines.length && !/^```/.test(lines[i])) buf.push(lines[i++]); i++; out.push('<pre><code>' + esc(buf.join('\n')) + '</code></pre>'); continue; }
+      if (/^#{1,6}\s/.test(ln)) { var lvl = ln.match(/^#+/)[0].length, txt = ln.replace(/^#+\s/, '');
+        var id = txt.toLowerCase().replace(/[^\w]+/g, '-').replace(/^-+|-+$/g, '');
+        out.push('<h' + lvl + ' id="' + id + '">' + inline(txt) + '</h' + lvl + '>'); i++; continue; }
+      if (/^---+\s*$/.test(ln)) { out.push('<hr>'); i++; continue; }
+      if (/^\s*\|.*\|\s*$/.test(ln) && i + 1 < lines.length && /^\s*\|[\s:|-]+\|\s*$/.test(lines[i + 1])) {
+        var tb = []; while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) tb.push(lines[i++].trim()); out.push(table(tb)); continue; }
+      if (/^>\s?/.test(ln)) { var q = []; while (i < lines.length && /^>\s?/.test(lines[i])) q.push(lines[i++].replace(/^>\s?/, '')); out.push('<blockquote>' + inline(q.join(' ')) + '</blockquote>'); continue; }
+      if (/^\s*[-*]\s+/.test(ln)) { var ul = []; while (i < lines.length && /^\s*[-*]\s+/.test(lines[i])) ul.push('<li>' + inline(lines[i++].replace(/^\s*[-*]\s+/, '')) + '</li>'); out.push('<ul>' + ul.join('') + '</ul>'); continue; }
+      if (/^\s*\d+\.\s+/.test(ln)) { var ol = []; while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) ol.push('<li>' + inline(lines[i++].replace(/^\s*\d+\.\s+/, '')) + '</li>'); out.push('<ol>' + ol.join('') + '</ol>'); continue; }
+      if (/^\s*$/.test(ln)) { i++; continue; }
+      var p = []; while (i < lines.length && !/^\s*$/.test(lines[i]) && !/^(#{1,6}\s|```|>|\s*[-*]\s|\s*\d+\.\s|---+\s*$)/.test(lines[i]) && !/^\s*\|.*\|\s*$/.test(lines[i])) p.push(lines[i++]);
+      out.push('<p>' + inline(p.join(' ')) + '</p>');
+    }
+    return out.join('\n');
+  }
+  // whitelist of renderable docs (no arbitrary fetch). Default = the comparison paper.
+  var DOCS = { 'migrate_compare.md': 'Migrate & Compare', 'ERP.md': 'ERP — AD-in-a-browser blueprint',
+    'HolyGrail.md': 'Holy Grail — end-state & hard parts', 'OpLogERP.md': 'OpLog ERP — the log is the truth',
+    'DistributedERP.md': 'Distributed ERP — serverless doctrine', 'BIMERPPaper.md': 'BIM·ERP — why & provenance' };
+  function param(n) { try { return new URLSearchParams(location.search).get(n); } catch (e) { return null; } }
+  var hash = (location.search.match(/#.*$/) || [''])[0];
+  var f = param('f'); if (!f || !DOCS.hasOwnProperty(f)) f = 'migrate_compare.md';
+  if (f !== 'migrate_compare.md') document.title = DOCS[f] + ' — ERP OOTB';
+  fetch(f, { cache: 'no-cache' })
+    .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); })
+    .then(function (md) {
+      document.getElementById('doc').innerHTML = render(md);
+      console.log('§MIGRATE-COMPARE rendered f=' + f + ' chars=' + md.length);
+      if (location.hash) { var t = document.getElementById(location.hash.slice(1)); if (t) t.scrollIntoView(); }
+    })
+    .catch(function (e) { var el = document.getElementById('err'); el.style.display = 'block'; el.textContent = 'Could not load ' + f + ' — ' + e.message; });
+  // back: a deep paper returns to the comparison page; the comparison page returns to its referrer surface.
+  var back = document.getElementById('back');
+  if (f !== 'migrate_compare.md') { back.href = 'migrate_compare.html'; back.textContent = '‹ Back to comparison'; }
+  else { try { if (/idempiere\.html/.test(document.referrer || '')) back.href = 'idempiere.html'; } catch (e) {} }
+})();
+</script>
+</body>
+</html>

--- a/erp/migrate_compare.md
+++ b/erp/migrate_compare.md
@@ -1,0 +1,165 @@
+# Migrate & Compare — Legacy ERP vs the WASM Event-Sourced Browser
+
+> **Status:** DRAFT (2026-06-08). The basic, evaluator-facing companion to the deep papers
+> ([ERP.md](ERP.md) · [DistributedERP.md](DistributedERP.md) · [BIMERPPaper.md](BIMERPPaper.md)).
+> Every number below traces to a real source file in this repo (path cited per cell).
+> Where no head-to-head number exists, the cell says so — nothing here is invented.
+
+---
+
+## Thesis (one paragraph)
+
+A classic ERP (iDempiere, Odoo, SAP) is a **server of record**: every read, write, posting and
+period-close is a round-trip to a machine that *owns the truth*. We keep the same accounting and the
+same document flow but **delete the server of record**: the authoritative state is a *signed,
+hash-chained op-log*, and the current numbers are a deterministic **fold** of that log replayed by a
+SQLite-WASM kernel **inside the browser**. The host becomes disposable (like a Git remote); the user
+owns the log; a period-close is a *signed checkpoint* the books are carried forward from, not a
+server batch job with downtime. This is a claim about the **substrate and delivery**, not feature
+breadth — the legacy stacks have vastly more features. What we show is that the *architecture* folds
+the same transactions with **zero network on the read/fold path**, proven against a live Odoo and the
+real in-browser kernel.
+
+---
+
+## The comparison diagram
+
+```
+LEGACY ERP  (iDempiere / Odoo / SAP — "server of record")
+────────────────────────────────────────────────────────
+  user gesture ──HTTP──▶ app server ──SQL──▶ database ──▶ posting/validation
+       ▲                                                        │
+       └───────────────── rendered page / row ◀────────────────┘
+  • every read & write = a network round-trip
+  • the DB OWNS the truth; client is a thin view
+  • period close = server batch job (per-row saveEx ≈ 1M round-trips), down-window
+
+
+OUR WASM EVENT-SOURCE  ("the browser is the server")
+────────────────────────────────────────────────────────
+  user gesture ──▶ op ──▶ local WASM kernel (commit + hash-chain + sign)
+                            │
+                            ├─▶ replay/fold (SQLite-WASM, in-memory) ──▶ paint
+                            │        0 network on the read/fold path
+                            └─▶ (later, async) push signed op to a DUMB facilitator
+                                 / user's own channel — host is disposable, log is truth
+  • state = Σ(fold of the signed op-log); recomputable by anyone
+  • period close = SIGNED CHECKPOINT = balance b/f (no down-window)
+```
+
+Source for the "what moved off the server" mapping: **`docs/DistributedERP.md` §0 lines 53–85**
+(server→serverless table, each row carries its own proof script). The "no per-interaction network
+round-trip (the kernel answers locally)" claim: **`docs/DistributedERP.md` §10 lines 467–468**.
+
+---
+
+## Vitals table
+
+Columns are **architecture**, not a feature scorecard. Numbers are measured on *this* box / *this*
+browser POC unless marked. "n/a — architectural" = the legacy stack has no comparable single number
+because the property is structural (e.g. it always needs a network).
+
+| Vital | iDempiere | Odoo | SAP | Our WASM event-source |
+|---|---|---|---|---|
+| **Period close** | Server batch job + down-window (per-row `saveEx` ≈ ~1M round-trips on a 40-yr depreciation run) [^dep] | Server batch job [^arch] | Server batch job [^arch] | **Signed checkpoint = balance b/f**, no down-window; 40k-op close-fold ≈ **2.68 s** in-browser, archived=40000→live=1, reconcile **maxDiff=0c** [^pclose][^drive] |
+| **Server round-trip (read/fold path)** | network round-trip per interaction [^arch] | network round-trip per interaction [^arch] | network round-trip per interaction [^arch] | **0 — the kernel answers locally** (no server of record on read/fold) [^noround] |
+| **Bootstrap (open the books)** | re-query the server [^arch] | re-query the server [^arch] | re-query the server [^arch] | **~53× faster from checkpoint than genesis replay** — fromCkpt **0.90 ms** vs fromGenesis **47.70 ms**, browser-measured at 40k ops, same result [^drive] |
+| **Storage primitive (1000 ops, one atomic commit)** | Postgres durable WAL+fsync **5.24 ms** (0.0052 ms/op) [^bench] | (Postgres, same engine) [^arch] | n/a — architectural [^arch] | sql.js in-browser incl. sha256 chain **208.45 ms** (0.2084 ms/op) — slower per-op, buys **no server**; Postgres buys durability+concurrency+network we DEFER to the install [^bench] |
+| **Commit throughput (batch vs naive, 5000 ops)** | n/a — architectural [^arch] | n/a — architectural [^arch] | n/a — architectural [^arch] | batch `commitGroup` **~22,492 ops/s = 2.4× naive** per-op+sealChain [^sync] |
+| **Fold/append ceiling (in-process)** | n/a — architectural [^arch] | n/a — architectural [^arch] | n/a — architectural [^arch] | append+fold **stay linear to 20,000,000 ops** (largest fit; ~437 B/op retained); fold ~40M ops/s hot [^ceiling] |
+| **Deployment / bloat (DB seed)** | `Adempiere_pg.dmp` **45.2 MB** [^bloat] | n/a — different schema [^arch] | n/a — different schema [^arch] | `erp/ad_seed.db` **12.7 MB** (≈**3.5×** smaller); the 12.7 MB IS the self-describing AD [^bloat] |
+| **Deployment / bloat (runtime LOC)** | **1,427,147 Java LOC** / 4,465 files + JVM+Postgres+3.7 GB build [^bloat] | n/a — different codebase [^arch] | n/a — different codebase [^arch] | **16,068 JS LOC** / 39 files / 884 KB, static + SQLite-WASM, offline (≈**89×** fewer LOC, zero server/JVM/DB) [^bloat] |
+| **Live-DB → SQLite footprint** | Postgres **143 MB** on-disk (GardenWorld) [^bloat2] | n/a — architectural [^arch] | n/a — architectural [^arch] | **43 MB SQLite** (925 tables, 187,133 rows) ≈ **3.3×** smaller; gzip 11.7 MB (3.7×) [^bloat2] |
+| **Data ownership / durability** | server DB owns the record [^arch] | server DB owns the record [^arch] | server DB owns the record [^arch] | **user-owned signed op-log**; host disposable (Git analogy); durably stored via the user's own channel + export; tamper caught by `verifyChain()`, forgery caught by ECDSA-P256 signature [^own][^pclose] |
+| **Migration fold (does the legacy flow fold into our verbs?)** | folds via the 6 verbs (the AD is the source) [^bloat] | **PROVEN against LIVE Odoo 17** — SO S00023 → 5/5 hops, newVerbs=[], GL ΣDr==ΣCr 5002.50 [^odoo] | **B1 (Business One) PROVEN vs a MOCK export** (5/5, journal balances 770.00); **S/4HANA NOT-RUN — gated on a real oracle** [^b1][^sap] | the migration-solvent thesis: every hop maps to `CREATE_DOCUMENT/CREATE_LINE/SET_STATUS/POST/ALLOCATE` [^odoo][^b1] |
+
+---
+
+## Method & honesty
+
+**What is measured (real, on this box / browser):**
+- Period-close fold, balance-b/f, reconcile-to-0c, tamper/forgery rejection, determinism — on the
+  **real kernel** (`scripts/test_kernel_period_close.js`) and against **real double-entry POST ops**
+  (`scripts/test_integ_postings_reconcile.js`).
+- Browser-measured 40k-op close-fold timing, bootstrap 53× speedup, reconcile maxDiff=0
+  (`build/erp/period_close_drive.log`, an in-browser drive).
+- Storage primitive sql.js-vs-Postgres (`build/erp/bench_oplog_pg.log`), batch throughput
+  (`build/erp/sync_poc_smoke.log`), volume ceiling to 20M ops (`build/erp/poc_volume_ceiling.log`).
+- Bloat figures `du`/`wc`/sqlite-measured 2026-06-06 (`internal/BLOAT_MEASUREMENT.md`, summarised in
+  the bloat memory).
+- The Odoo fold is against a **running Odoo 17** instance (`build/erp/odoo_fold_live.log`,
+  `§ODOO-FOLD-LIVE PASS`).
+
+**What is architectural (a property, not a head-to-head number):**
+- "0 round-trip" — a *structural* fact (no server of record on the read/fold path), not a benchmark.
+  The honest counter is that server-removal only wins over a network; on-box the durable Postgres
+  primitive is *faster* per-op (it buys durability + concurrency we defer).
+- Most "ERP cells" marked *n/a — architectural* because the legacy stack exposes no single comparable
+  number (e.g. throughput ceiling, batch-vs-naive) — its design is server-bound by definition.
+
+**NOT feature parity — say it plainly.** iDempiere, Odoo and SAP have *vastly* more features,
+processes, localisations and integrations than this engine. The 16K LOC RENDERS the dictionary and
+FOLDS the paths built so far (order-to-cash, journal/posting, signed rule-edit, period close). It does
+**not** re-implement the full transactional server. The reduction is a **delivery/definition**
+reduction (the generic AD-interpretation engine is leaner because the AD is self-describing; the whole
+server/build stack is removed). Each transactional verb/process is irreducible and must still be folded
+deterministically. See `feedback_erp_perf_claims` and the honest-caveat block in the bloat memory.
+
+---
+
+## GAPS (vitals lacking a measured source — do not claim a number)
+
+1. **SAP S/4HANA fold** — BLOCKED. `build/erp/sap_fold.log` says `§SAP-FOLD NOT-RUN (skeleton ready;
+   gated on oracle access)`. No real SAP O2C+FI export has been folded; only **SAP Business One (B1)
+   against a hand-authored MOCK** has (`build/erp/b1_fold.log`). The "SAP" column is therefore
+   *partly mock, partly not-run* — never present S/4HANA as proven.
+2. **Odoo / SAP server-side period-close timing & down-window** — no measured number; marked
+   *architectural*. We have our own 2.68 s/40k-op figure but no head-to-head legacy batch-close time.
+3. **Odoo / SAP server round-trip latency (ms)** — not measured here. The closest real datum is the
+   iDempiere depreciation run (`DepreciationPerf.md`: per-row `saveEx` ≈ ~1M round-trips), and the
+   `feedback_erp_perf_claims` matrix (REMOTE per-txn 2–5 orders, RTT-bound) — both iDempiere-flavoured,
+   not Odoo/SAP. Cite as illustrative, not as an Odoo/SAP measurement.
+4. **Postgres per-op floor vs our per-op** is a *primitive-only* comparison (no callouts/posting/JVM on
+   either side) — `bench_oplog_pg.log` states this explicitly; do not extrapolate to whole-document cost.
+5. **Live-DB → SQLite (143 MB → 43 MB)** was measured on a static dump + repo (Docker Postgres was NOT
+   running at measure time) — see the bloat memory caveat.
+
+---
+
+## Further reading — go deeper
+
+This page is the on-ramp. To see *how* each claim is built, follow these into the deep papers:
+
+- **[ERP.md](ERP.md)** — the **"AD-in-a-browser" blueprint**: how the iDempiere Application Dictionary is
+  folded from SQLite and rendered as a live client, the six verbs (`CREATE_DOCUMENT / CREATE_LINE /
+  SET_STATUS / POST / ALLOCATE / MATCH`) every document flow reduces to, and the full engine reference.
+  *Start here if you want the whole architecture.*
+- **[HolyGrail.md](HolyGrail.md)** — the **end-state vision and its "hard parts"**: multi-site sync, durability
+  on disposable hosts, and compaction = the period-close *signed checkpoint = balance b/f* you just saw.
+  *Read this for where the whole effort is converging and why these were the hard problems.*
+- **[OpLogERP.md](OpLogERP.md)** — the **event-sourcing model in one page**: why the authoritative state is a
+  *signed, hash-chained op-log* and the current numbers are a deterministic **fold** of it — not a row in a
+  server DB. *The shortest explanation of "the log is the truth."*
+- **[DistributedERP.md](DistributedERP.md)** — the **serverless / secured doctrine + adversarial contention map**:
+  the server→serverless table behind the "0 round-trip" claim, the Git-remote "host is disposable" analogy,
+  and the honest counter-arguments. *Read this for the distributed-systems reasoning and the proof scripts.*
+- **[BIMERPPaper.md](BIMERPPaper.md)** — the **"why / provenance" piece** (Redhuan Oon, 30 years of ERP):
+  the motivation, the lineage from iDempiere/Adempiere/Compiere, and what problem this is really solving.
+
+---
+
+## Footnote sources
+
+[^pclose]: `build/erp/test_kernel_period_close.log` — `§PCLOSE-FOLD` archived=15→live=1, `§PCLOSE-RECONCILE … maxDiff=0c`, tamper/forgery/determinism all PASS on the real kernel.
+[^drive]: `build/erp/period_close_drive.log` — in-browser drive: `close N=20000 closeFold=2681.8ms archived=40000 live=1`; `bootstrap fromCkpt=0.90ms fromGenesis=47.70ms speedup=53.0x same=true`; `reconcile maxDiff=0c`.
+[^noround]: `docs/DistributedERP.md` §0 (server→serverless table, lines 53–85) + §10 lines 467–468 ("no per-interaction network round-trip (the kernel answers locally)").
+[^bench]: `build/erp/bench_oplog_pg.log` — N=1000 ops, one atomic commit: sql.js 208.45 ms (0.2084 ms/op, incl. sha256 chain); Postgres durable WAL+fsync 5.24 ms (0.0052 ms/op). Explicitly "NOT a head-to-head".
+[^sync]: `build/erp/sync_poc_smoke.log` — 5,000 events: naive 9,390 ops/s; batch commitGroup 22,492 ops/s = 2.4× (corroborated `sync_poc_prod_smoke.log`).
+[^ceiling]: `build/erp/poc_volume_ceiling.log` — append/fold stay LINEAR; largestFit=20,000,000 ops, ~437 B/op retained; fold ~40.8M ops/s hot at 5M.
+[^bloat]: bloat memory (`reference_bloat_reduction.md`, measured 2026-06-06 from `~/idempiere-dev-setup/idempiere`) — seed 45.2 MB → 12.7 MB (≈3.5×); 1,427,147 Java LOC → 16,068 JS LOC (≈89×). Full evidence `internal/BLOAT_MEASUREMENT.md`.
+[^bloat2]: same memory — LIVE GardenWorld DB Postgres 143 MB on-disk → 43 MB SQLite (925 tables, 187,133 rows, ≈3.3×); gzip 11.7 MB (3.7×).
+[^odoo]: `build/erp/odoo_fold_live.log` — `§ODOO-FOLD-LIVE PASS`: live odoodemo (Odoo 17, :8069) SO S00023, 5/5 hops mapped, newVerbs=[], total 5002.50 == oracle, GL ΣDr==ΣCr.
+[^b1]: `build/erp/b1_fold.log` — `§B1-FOLD PASS`: SAP Business One O2C + OJDT/JDT1, 5/5 hops, journal 770.00==770.00. Source = a hand-authored MOCK Service-Layer shape (user-authorized 2026-06-05), NOT a real export.
+[^sap]: `build/erp/sap_fold.log` — `§SAP-FOLD NOT-RUN` / `BLOCKED — awaiting a REAL SAP oracle. No fold claimed.` (S/4HANA).
+[^own]: `docs/DistributedERP.md` §0 lines 74–80 (the Git analogy — log is truth, host disposable) + the signed-checkpoint/tamper proofs in [^pclose].
+[^arch]: Architectural property of a server-of-record ERP — no comparable single measured number in this repo; stated as structure, not benchmarked. Honest-caveat doctrine: `feedback_erp_perf_claims`.

--- a/erp/period_close_ui.js
+++ b/erp/period_close_ui.js
@@ -1,0 +1,159 @@
+/* period_close_ui.js — §INTEG-WIRE (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2, slice A)
+ *
+ * Wires the FROZEN period-close substrate (erp_period_close.js → window.ErpPeriodClose) into the live
+ * ERP app, on the REAL signed op-log (crud_overlay's `glassbowl_kernel_ops` sidecar). An accountant
+ * closes a period → ONE signed checkpoint carrying the closing balances → the pre-checkpoint ops are
+ * compacted out → next load BOOTSTRAPS from the checkpoint (opening = balance brought forward).
+ *
+ * Composition only — no engine logic here, no invented posting. Reuses:
+ *   window.ErpPeriodClose  (closePeriod / bootstrapFromCheckpoint / foldBalances)
+ *   window.KernelOps       (the canonical signed kernel — commitOp/commitGroup/sealChain/verifyChain)
+ *   window.ErpSigner       (the APP edge signer — loadOrMint custody + makeSigner; NOT a demo key)
+ *   window.__crud          (withSidecar → the live sidecar db; persist → re-persist after compaction)
+ *
+ * Whitebox witness: erp/tests/poc_period_close_wire.js (§INTEG-WIRE). Read the log.
+ */
+(function (global) {
+  'use strict';
+  var TAG = '§INTEG-WIRE';
+
+  function _ready() { return !!(global.ErpPeriodClose && global.KernelOps && global.ErpSigner && global.__crud); }
+
+  // ensure sql.js is loaded — glassbowl loads it LAZILY (withBundle), so initSqlJs may be absent at init.
+  // crud_overlay.withSidecar needs window.initSqlJs to build the sidecar; load the same bundle on demand.
+  function _ensureSql(cb) {
+    if (typeof global.initSqlJs === 'function') { cb(true); return; }
+    try {
+      var sc = global.document.createElement('script');
+      sc.src = 'sqljs/sql-wasm.js';
+      sc.onload = function () { cb(typeof global.initSqlJs === 'function'); };
+      sc.onerror = function () { cb(false); };
+      (global.document.head || global.document.documentElement).appendChild(sc);
+    } catch (e) { cb(false); }
+  }
+
+  // resolve the live sidecar kernel db (lazily hydrated by crud_overlay, which needs sql.js present).
+  function _withDb(cb) {
+    _ensureSql(function () {
+      var c = global.__crud;
+      if (c && typeof c.withSidecar === 'function') { c.withSidecar(cb); return; }
+      cb(c && typeof c.kernelDb === 'function' ? c.kernelDb() : null);
+    });
+  }
+
+  // signer onto closePeriod's {signTip, signed_by} contract, via the APP signer (edge custody, IDB-persisted).
+  function _signer() {
+    return global.ErpSigner.loadOrMint('bim_erp_signer').then(function (kp) {
+      var s = global.ErpSigner.makeSigner(kp);
+      return { signTip: function (tipHex) { return s.sign(tipHex); }, signed_by: 'edge',
+               _verify: function (tipHex, sig) { return s.verify(tipHex, sig); } };
+    });
+  }
+
+  // boot — on load, open the current balances from the latest checkpoint (the b/f) without re-folding genesis.
+  function boot() {
+    if (!_ready()) { setTimeout(boot, 250); return; }
+    _withDb(function (db) {
+      if (!db) { console.log(TAG + ' boot: no sidecar db yet'); return; }
+      try {
+        var bf = global.ErpPeriodClose.bootstrapFromCheckpoint(db, global.KernelOps);
+        var cur = bf.balances || bf.current || bf.bal || {};
+        console.log('§PCLOSE-BF-LIVE fromCheckpoint=' + (bf.fromCheckpoint ? 'Y' : 'N') +
+                    ' period=' + (bf.period != null ? bf.period : '-') +
+                    ' accounts=' + Object.keys(cur).length + ' balances=' + JSON.stringify(cur));
+      } catch (e) { console.warn(TAG + ' boot bootstrap error', e && e.message); }
+    });
+  }
+
+  // close — fold the live ops → signed checkpoint → compact → re-persist the sidecar. Returns a Promise.
+  function close(opts) {
+    opts = opts || {};
+    if (!_ready()) return Promise.reject(new Error('period-close: engine/signer/crud not loaded'));
+    return _signer().then(function (signer) {
+      return new Promise(function (resolve, reject) {
+        _withDb(function (db) {
+          if (!db) { reject(new Error('period-close: no sidecar db')); return; }
+          var period = (opts.period != null) ? opts.period : _nextPeriod(db);
+          var ts = (opts.ts != null) ? opts.ts : _stamp();   // recorded close ts (deterministic INPUT)
+          Promise.resolve(global.ErpPeriodClose.closePeriod(db, global.KernelOps, signer, { period: period, ts: ts }))
+            .then(function (res) {
+              if (global.__crud && typeof global.__crud.persist === 'function') global.__crud.persist();
+              console.log(TAG + ' closed period=' + res.period + ' archived=' + res.archived + '→live=' + res.liveLen +
+                          ' accounts=' + Object.keys(res.closing_balances).length +
+                          ' closing=' + JSON.stringify(res.closing_balances) +
+                          ' tip=' + (res.tip || '').slice(0, 12) + '… signed=' + (res.sig ? 'Y' : 'N') + ' by=' + res.signed_by);
+              resolve(res);
+            }).catch(reject);
+        });
+      });
+    });
+  }
+
+  // the next period number = (latest checkpoint period) + 1, else 1. A recorded INPUT, never invented.
+  function _nextPeriod(db) {
+    try {
+      var r = db.exec("SELECT parameters FROM kernel_ops WHERE op_type='" + global.ErpPeriodClose.CKPT_TYPE + "' ORDER BY id DESC LIMIT 1");
+      if (r.length && r[0].values.length) return (JSON.parse(r[0].values[0][0]).period || 0) + 1;
+    } catch (e) {}
+    return 1;
+  }
+  // deterministic-enough close stamp: seconds epoch (recorded into the op, so the tip is stable on replay).
+  function _stamp() { return (typeof Date !== 'undefined') ? Math.floor(Date.now() / 1000) : 0; }
+
+  // renderInto — inject the accounting-gated "Close period" control + a live balance-b/f readout into a
+  // container (the role-gated Accts Posted overlay). Read-only panels stay read-only; this is the action.
+  function _injectCSS() {
+    var d = global.document; if (!d || d.getElementById('pclose-css')) return;
+    var s = d.createElement('style'); s.id = 'pclose-css';
+    s.textContent = '.pclose-ctl{display:flex;flex-direction:column;gap:8px;margin-top:14px;padding-top:12px;border-top:1px solid rgba(255,255,255,.12)}' +
+      '.pclose-btn{align-self:flex-start;min-height:38px;padding:0 14px;border-radius:20px;border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.05);color:inherit;font:inherit;font-size:13px;cursor:pointer}' +
+      '.pclose-btn:disabled{opacity:.6;cursor:default}.pclose-read{font-size:12px;opacity:.75}';
+    (d.head || d.documentElement).appendChild(s);
+  }
+  function renderInto(container, opts) {
+    if (!container) return null;
+    opts = opts || {};
+    _injectCSS();
+    var wrap = global.document.createElement('div');
+    wrap.className = 'pclose-ctl';
+    var btn = global.document.createElement('button');
+    btn.className = 'pclose-btn';
+    btn.type = 'button';
+    btn.textContent = '⛒ Close period';
+    var read = global.document.createElement('div');
+    read.className = 'pclose-read';
+    function paint(balances, period) {
+      var ks = Object.keys(balances || {});
+      read.textContent = ks.length
+        ? ('Period ' + period + ' carried forward — ' + ks.length + ' accounts (Σ=' + _fmtSum(balances) + ')')
+        : 'No closed period yet — balances fold from genesis.';
+    }
+    // initial readout from the current checkpoint
+    _withDb(function (db) {
+      try {
+        var bf = global.ErpPeriodClose.bootstrapFromCheckpoint(db, global.KernelOps);
+        paint(bf.balances || bf.current || bf.bal || {}, bf.period != null ? bf.period : '-');
+      } catch (e) { paint({}, '-'); }
+    });
+    btn.addEventListener('click', function () {
+      btn.disabled = true; btn.textContent = '⛒ Closing…';
+      close(opts).then(function (res) {
+        paint(res.closing_balances, res.period);
+        btn.textContent = '⛒ Closed P' + res.period + ' ✓'; btn.disabled = false;
+        if (typeof opts.onClosed === 'function') opts.onClosed(res);
+      }).catch(function (e) {
+        btn.textContent = '⛒ Close period'; btn.disabled = false;
+        console.warn(TAG + ' close failed', e && e.message);
+      });
+    });
+    wrap.appendChild(btn); wrap.appendChild(read);
+    container.appendChild(wrap);
+    return wrap;
+  }
+  function _fmtSum(b) { var s = 0, a; for (a in b) s += b[a]; return (s / 100).toFixed(2); }
+
+  global.PeriodClose = { boot: boot, close: close, renderInto: renderInto };
+  if (global.document && global.document.readyState !== 'loading') setTimeout(boot, 300);
+  else if (global.document) global.document.addEventListener('DOMContentLoaded', function () { setTimeout(boot, 300); });
+  console.log('§PCLOSE-UI loaded (window.PeriodClose: boot/close/renderInto)');
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -88,6 +88,8 @@ const PRECACHE_ASSETS = [
   'rule_fold.js',      // THE ONE GESTURE (window.RuleFold) — signed, reversible rule edit + re-fold (RULE_EDIT_SPEC)
   'erp_period_close.js', // §INTEG-WIRE — period-close fold = signed checkpoint = balance b/f (window.ErpPeriodClose)
   'period_close_ui.js',  // §INTEG-WIRE — in-app close/bootstrap on the live sidecar op-log (window.PeriodClose)
+  'migrate_compare.html', // evaluator-facing comparison paper (docs/MigrateComparisonPaper.md) — linked from erp.html+idempiere.html
+  'migrate_compare.md',   // its single source; deep papers (ERP/HolyGrail/OpLog/Distributed/BIMERP .md) fetch on-demand, not precached
   'qrcode.min.js',
   'manifest.json',
   'pills.json',

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,8 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v599';   // v599: INIT-BUBBLE freshness backstop — SWR navigation (v598) reaches a returning user fresh only on the SECOND post-deploy reload (old SW serves the nav before the new one activates); erp.html+idempiere.html now do a one-shot controllerchange→reload so a deploy converges in ONE reload (witness erp/tests/poc_init_deploy_fresh.js: reload1Settled=B, oneReloadConverges=Y);
+const CACHE_VERSION = 'v600';   // v600: §INTEG-WIRE — period-close in-app (erp_period_close.js + period_close_ui.js): an accountant closes a period → signed checkpoint = balance b/f on the live sidecar op-log; next load bootstraps from the checkpoint. Substrate (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2 slice A) on the collapsed canonical kernel (commitGroup). Witness erp/tests/poc_period_close_wire.js (§INTEG-WIRE).
+// v599: INIT-BUBBLE freshness backstop — SWR navigation (v598) reaches a returning user fresh only on the SECOND post-deploy reload (old SW serves the nav before the new one activates); erp.html+idempiere.html now do a one-shot controllerchange→reload so a deploy converges in ONE reload (witness erp/tests/poc_init_deploy_fresh.js: reload1Settled=B, oneReloadConverges=Y);
                                 // v598: INIT-BUBBLE INSTANT — navigation served stale-while-revalidate (was network-first), so a warm load paints the init-bubble shell from cache with ZERO network round-trip instead of awaiting the HTML document over the wire (witness erp/tests/poc_init_instant.js: warm bubblePaint 883ms→<300ms under 800ms nav latency); db already deferred off the paint path;
                                 // v597: pill ⋯ trigger UX — (a) FLAT horizontal kebab (icons.js moreHoriz) on ALL pill surfaces (erp.html + idempiere, desktop+mobile) so OUR ⋯ differs from Android's own vertical ⋮; (b) mobile dock anchors the ⋯ to a CONSTANT right-edge position (order:-1 + justify-content:flex-start) so it no longer re-centres out from under the finger on collapse;
                                 // v596: Kanban "Odoo-marvel" cards + shared Graph/Kanban status palette (KANBAN_MARVEL_SPEC, PR #177) merged with the mobile pill-reopen fix (v595);
@@ -85,6 +86,8 @@ const PRECACHE_ASSETS = [
   'kanban_host.js',    // reusable Kanban host: publish window.ERP + persist/restore the op-log
   'bigdecimal.js',     // exact decimal compare for the rule fold (never raw JS Number) — window.BigDecimal
   'rule_fold.js',      // THE ONE GESTURE (window.RuleFold) — signed, reversible rule edit + re-fold (RULE_EDIT_SPEC)
+  'erp_period_close.js', // §INTEG-WIRE — period-close fold = signed checkpoint = balance b/f (window.ErpPeriodClose)
+  'period_close_ui.js',  // §INTEG-WIRE — in-app close/bootstrap on the live sidecar op-log (window.PeriodClose)
   'qrcode.min.js',
   'manifest.json',
   'pills.json',

--- a/erp/tests/poc_period_close_wire.js
+++ b/erp/tests/poc_period_close_wire.js
@@ -1,0 +1,117 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness that PERIOD-CLOSE is wired into the live app on the REAL signed op-log
+//   (prompts/ERP_SUBSTRATE_INTEGRATION.md Phase 2 slice A — §INTEG-WIRE). THE CLAIM:
+//     1. §INTEG-WIRE close — with real double-entry POST ops in the live `glassbowl_kernel_ops` sidecar,
+//        window.PeriodClose.close() folds them → ONE signed checkpoint carrying the closing balances
+//        (net DR−CR cents), compacts the pre-checkpoint ops, and re-persists the sidecar. signed=Y.
+//     2. §PCLOSE-BF-LIVE bootstrap — RELOAD (same context → IDB persists); on boot the app opens from the
+//        checkpoint: opening balances == the closing balances brought forward, WITHOUT re-folding genesis.
+//   NON-INVENT: the POST ops are the app's real §13.1 shape ({lines:[{account_id,amtacctdr,amtacctcr}]});
+//   the post-reload balances come from the persisted signed checkpoint, nowhere else.
+//   §-log first — READ poc_period_close_wire.log before any conclusion.
+// Run:  node tests/poc_period_close_wire.js 2>&1 | tee tests/poc_period_close_wire.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.wasm':'application/wasm', '.css':'text/css' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/glassbowl.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+const ready = (page) => page.waitForFunction(
+  () => window.PeriodClose && window.ErpPeriodClose && window.KernelOps && window.ErpSigner && window.__crud,
+  { timeout: 25000 });
+
+// the app's REAL §13.1 POST shape — a sales invoice (AR/Revenue) + its payment (Cash/AR).
+const POSTS = [
+  { table: 'C_Invoice', id: 109, lines: [ { account_id: '101', amtacctdr: 434.13, amtacctcr: 0 }, { account_id: '400', amtacctdr: 0, amtacctcr: 434.13 } ] },
+  { table: 'C_Payment', id: 77,  lines: [ { account_id: '108', amtacctdr: 434.13, amtacctcr: 0 }, { account_id: '101', amtacctdr: 0, amtacctcr: 434.13 } ] },
+];
+const EXPECT = { '101': 0, '400': -43413, '108': 43413 };   // net DR−CR cents (AR settles to 0)
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const url = `http://localhost:${port}/glassbowl.html`;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const context = await browser.newContext();   // ONE context → IDB persists across the reload
+  const page = await context.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  // ── session 1: seed real POST ops into the live sidecar, then close the period ──
+  await page.goto(url, { waitUntil: 'networkidle' });
+  const wired = await ready(page).then(() => true).catch(() => false);
+  const hasRender = await page.evaluate(() => typeof window.PeriodClose.renderInto === 'function');
+  // PeriodClose.boot lazily loads sql.js + builds the sidecar; wait for it before seeding.
+  const sidecarUp = await page.waitForFunction(
+    () => typeof window.initSqlJs === 'function' && window.__crud && window.__crud.kernelDb && window.__crud.kernelDb() != null,
+    { timeout: 25000 }).then(() => true).catch(() => false);
+  console.log('§WIRE-SIDECAR initSqlJs+sidecar-built=' + sidecarUp);
+
+  const seeded = await page.evaluate((posts) => new Promise((res) => {
+    window.__crud.withSidecar((db) => {
+      try {
+        posts.forEach(p => window.KernelOps.commitOp(db, 'POST', p));
+        window.__crud.persist();
+        setTimeout(() => res({ ok: true, n: posts.length }), 300);
+      } catch (e) { res({ ok: false, err: String(e && e.message || e) }); }
+    });
+  }), POSTS);
+  console.log('§WIRE-SEED ops=' + (seeded && seeded.n) + ' ok=' + (seeded && seeded.ok) + (seeded && seeded.err ? ' err=' + seeded.err : ''));
+
+  const closeRes = await page.evaluate(() => window.PeriodClose.close({ period: 1, ts: 9000 })
+    .then(r => ({ ok: true, r })).catch(e => ({ ok: false, err: String(e && e.message || e) })));
+  const r = closeRes && closeRes.r;
+  console.log('§WIRE-CLOSE ok=' + (closeRes && closeRes.ok) + (closeRes && closeRes.err ? ' err=' + closeRes.err : '') +
+    (r ? ' period=' + r.period + ' archived=' + r.archived + ' liveLen=' + r.liveLen + ' signed=' + (r.sig ? 'Y' : 'N') +
+         ' closing=' + JSON.stringify(r.closing_balances) : ''));
+
+  // ── session 2: RELOAD (same context → IDB survives) — boot must open from the checkpoint (b/f) ──
+  logs.length = 0;
+  await page.reload({ waitUntil: 'networkidle' });
+  await ready(page).catch(() => {});
+  await page.waitForFunction(() => window.__pcloseBfSeen === true ||
+    (window.performance && true), { timeout: 1000 }).catch(() => {});
+  await page.waitForTimeout(1200);   // PeriodClose.boot runs ~300ms after DOMContentLoaded
+  const bfLog = logs.find(l => l.includes('§PCLOSE-BF-LIVE')) || '(no bootstrap log)';
+  console.log('§WIRE-RELOAD ' + bfLog);
+
+  // independent read of the persisted opening balances after reload
+  const afterBoot = await page.evaluate(() => new Promise((res) => {
+    window.__crud.withSidecar((db) => {
+      try {
+        const bf = window.ErpPeriodClose.bootstrapFromCheckpoint(db, window.KernelOps);
+        res({ fromCk: !!bf.fromCheckpoint, period: bf.period, bal: bf.balances || bf.current || bf.bal || {} });
+      } catch (e) { res({ err: String(e && e.message || e) }); }
+    });
+  }));
+  console.log('§WIRE-BF afterReload fromCheckpoint=' + (afterBoot && afterBoot.fromCk) +
+    ' period=' + (afterBoot && afterBoot.period) + ' balances=' + JSON.stringify(afterBoot && afterBoot.bal));
+
+  // ── verdict ──
+  function balEq(a, b) { const ks = {}; let max = 0; for (const k in a) ks[k] = 1; for (const k in b) ks[k] = 1;
+    for (const k in ks) max = Math.max(max, Math.abs((a[k] | 0) - (b[k] | 0))); return max; }
+  const closingOk = !!(r && balEq(r.closing_balances, EXPECT) === 0 && Object.keys(r.closing_balances).length === 3);
+  const signedOk  = !!(r && r.sig);
+  const compactOk = !!(r && r.archived >= POSTS.length && r.liveLen === 1);
+  const bfOk      = !!(afterBoot && afterBoot.fromCk && balEq(afterBoot.bal, EXPECT) === 0);
+  const bfLogOk   = /fromCheckpoint=Y/.test(bfLog);
+
+  console.log('   ' + (wired ? '🟢' : '🔴') + ' W1 substrate wired into app (PeriodClose/ErpPeriodClose/KernelOps/ErpSigner/__crud) renderInto=' + hasRender);
+  console.log('   ' + (closingOk ? '🟢' : '🔴') + ' W2 close folds real POST ops → closing balances == expected net DR−CR (AR settles to 0)');
+  console.log('   ' + (signedOk ? '🟢' : '🔴') + ' W3 checkpoint signed by the app edge signer (signed=Y)');
+  console.log('   ' + (compactOk ? '🟢' : '🔴') + ' W4 compaction: pre-checkpoint ops archived, live log = 1 (checkpoint anchor)');
+  console.log('   ' + (bfOk ? '🟢' : '🔴') + ' W5 RELOAD bootstraps from checkpoint — opening balances == balance b/f (no genesis re-fold)');
+  console.log('   ' + (bfLogOk ? '🟢' : '🔴') + ' W6 boot emitted §PCLOSE-BF-LIVE fromCheckpoint=Y');
+
+  const pass = wired && hasRender && closingOk && signedOk && compactOk && bfOk && bfLogOk && errs.length === 0;
+  console.log('§INTEG-WIRE-RESULT ' + (pass ? 'PASS' : 'FAIL') + ' pageErrors=' + (errs.length ? errs.join('|') : 0));
+
+  await browser.close(); server.close(); process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('PROBE-ERR', e); server.close(); process.exit(2); });


### PR DESCRIPTION
Lands **Phase 2 slice A** (period-close in-app) + the **evaluator comparison paper**, both cleanly rebased onto `main` (the kernel collapse from #195 is already there; this cherry-picks only the period-close commit to avoid a squash-history collision).

### Period-close in-app (§INTEG-WIRE)
Wired into glassbowl.html on the live signed op-log: close a period → ONE signed checkpoint = balance b/f → reload bootstraps from it. Witness `erp/tests/poc_period_close_wire.js` PASS (6/6, pageErrors=0); §INTEG-FRESHNESS precache audit 100/0-missing; `sw` v599→**v600** (this bump is the true deploy switch — it serves the collapsed v8 kernel + period-close to returning users in one reload).

### Evaluator comparison paper
`erp/migrate_compare.html` renders `migrate_compare.md` (single source, no drift) — diagram + source-cited vitals table vs iDempiere/Odoo/SAP. **Further reading** links into the deep papers (ERP / HolyGrail / OpLog / DistributedERP / BIMERP), each explaining what's there, rendered in-app via `?f=`. Linked from `erp.html` (on-ramp pill) + `idempiere.html` (sign-in card). Honest: GAPS section + per-cell footnotes; SAP S/4HANA marked NOT-RUN.

Per the agreed model (1c): merge-to-main is fine; the sw version bump gates the actual deploy. Smoke-witnessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)