### PR TITLE
fix(kernel+2d): kernel edits survive reload (IDB version fix) + saved-card delete stays durable

### DIFF
--- a/tests/probe_2d_delete.js
+++ b/tests/probe_2d_delete.js
@@ -1,0 +1,90 @@
+// WITNESS: 2D saved-card delete must survive reload. project_2d_regression #3.
+// Repro of the real bug: kernel_ops flushes the WHOLE in-memory building DB (incl saved_sections)
+// to IndexedDB on any op; card delete mutates the DB directly (NOT via a kernel op) so it never
+// flushes; loadSavedSections is DB-first → on reload it reads the stale cached rows and ignores
+// the fresh localStorage → the deleted card REAPPEARS.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8161;
+const BLD = process.env.BLD || 'Duplex';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db&bld=${BLD}`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function enter2D(page) {
+  await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.db && A.activeBuilding; }, { timeout: 120000 });
+  await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.streaming === false; }, { timeout: 90000 }).catch(() => {});
+  await sleep(1200);
+  await page.evaluate(() => { if (window.toggleGridOverlay) window.toggleGridOverlay(); });
+  await sleep(2500);
+}
+function readCards() {
+  const body = document.getElementById('grid-panel-body');
+  const cards = body ? Array.from(body.querySelectorAll('.saved-section-btn')) : [];
+  return cards.map(c => ({ id: c.getAttribute('data-id'), name: (c.textContent || '').trim().slice(0, 12) }));
+}
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    // PERSIST service workers off but keep a persistent context dir so IndexedDB survives reload
+    const ctx = await browser.newContext({ serviceWorkers: 'block', viewport: { width: 1200, height: 800 } });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERR: ' + e.message));
+
+    page.on('framenavigated', () => logs.push('NAV'));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+    await enter2D(page);
+    let cards = await page.evaluate(readCards);
+    console.log('§W1 after-autocreate cards=' + JSON.stringify(cards));
+    const gf = cards.find(c => c.name === 'GF');
+    if (!gf) { console.log('ABORT: no GF card'); await ctx.close(); return; }
+
+    // force a kernel-op so the building DB (with GF+L1) is flushed to IndexedDB (debounced 2s)
+    await page.evaluate(() => { const A = window.A || window.APP; if (window.KernelOps) KernelOps.commitOp(A.db, 'ELEMENT_PICK', { cls: 'IfcWall', name: 'probe' }, ['g1']); });
+    await sleep(3200);
+    const persisted = logs.some(l => l.includes('§KRN_PERSIST'));
+    console.log('§W2 kernel flush to IDB fired=' + persisted);
+
+    // delete GF via its ✕ button (no kernel op follows → IDB NOT updated)
+    await page.evaluate((id) => {
+      const body = document.getElementById('grid-panel-body');
+      const del = body.querySelector('.saved-section-del[data-id="' + id + '"]');
+      if (del) del.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    }, gf.id);
+    await sleep(800);
+    cards = await page.evaluate(readCards);
+    console.log('§W3 in-session after-delete cards=' + JSON.stringify(cards) + '  (GF gone? ' + !cards.some(c => c.name === 'GF') + ')');
+
+    // in-session CLOSE + REOPEN panel (the other reading of "reopened")
+    await page.evaluate(() => { if (window.toggleGridOverlay) window.toggleGridOverlay(); }); // off
+    await sleep(400);
+    await page.evaluate(() => { if (window.toggleGridOverlay) window.toggleGridOverlay(); }); // on
+    await sleep(1500);
+    cards = await page.evaluate(readCards);
+    console.log('§W3b in-session REOPEN cards=' + JSON.stringify(cards) + '  (GF back? ' + cards.some(c => c.name === 'GF') + ')');
+
+    // delete the REMAINING card(s) → all-deleted (autoCreate-suppression path, the strongest reappear case)
+    await page.evaluate(() => {
+      const body = document.getElementById('grid-panel-body');
+      body.querySelectorAll('.saved-section-del').forEach(d => d.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })));
+    });
+    await sleep(800);
+    cards = await page.evaluate(readCards);
+    console.log('§W3c after-delete-ALL cards=' + JSON.stringify(cards) + '  (empty? ' + (cards.length === 0) + ')');
+
+    // RELOAD — the real test (do all cards come BACK via autoCreate?)
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await enter2D(page);
+    cards = await page.evaluate(readCards);
+    const gfBack = cards.some(c => c.name === 'GF');
+    console.log('§W4 AFTER-RELOAD cards=' + JSON.stringify(cards));
+    console.log('§W4 RESULT any-card-reappeared=' + (cards.length > 0) + '  GF-reappeared=' + gfBack + '  (want 0 cards)  ' + (cards.length ? 'BUG' : 'OK'));
+    console.log('--- §SAVE_SECTION / KRN lines ---');
+    console.log(logs.filter(l => /SAVE_SECTION loaded|reconcile|KRN_PERSIST|KRN_SEAL|KERNEL_OP committed/.test(l)).slice(-10).join('\n'));
+    console.log('--- pageerrors ---');
+    console.log(logs.filter(l => l.startsWith('PAGEERR')).slice(0, 5).join('\n') || '(none)');
+    await ctx.close();
+  } catch (e) { console.log('FATAL: ' + e.message + '\n' + (e.stack || '').split('\n').slice(0,4).join('\n')); }
+  finally { await browser.close(); }
+})();

--- a/tests/probe_krn_persist.js
+++ b/tests/probe_krn_persist.js
@@ -1,0 +1,59 @@
+// WITNESS: kernel-op edits must survive a page reload (S243 §3.7 "refresh survives").
+// Bug: kernel_ops._persistToIdb opens bim_ootb_cache at v1, but scene.js created it at v2 →
+// open fires onerror (VersionError), onsuccess never runs → §KRN_PERSIST never fires →
+// modified building DB never written back → reload loses the edit.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8161;
+const BLD = process.env.BLD || 'Duplex';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db&bld=${BLD}`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const MARKER = 'KRNTEST_' + (process.env.TAG || 'x');
+
+async function ready(page) {
+  await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.db && A.activeBuilding; }, { timeout: 120000 });
+  await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.streaming === false; }, { timeout: 90000 }).catch(() => {});
+  await sleep(1000);
+}
+function countMarker(m) {
+  const A = window.A || window.APP;
+  try {
+    const r = A.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE parameters LIKE '%" + m + "%'");
+    return (r.length && r[0].values.length) ? r[0].values[0][0] : 0;
+  } catch (e) { return 'ERR:' + e.message; }
+}
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({ serviceWorkers: 'block', viewport: { width: 1200, height: 800 } });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERR: ' + e.message));
+
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+    await ready(page);
+    // commit a distinctive kernel op
+    await page.evaluate((m) => { const A = window.A || window.APP; KernelOps.commitOp(A.db, 'ELEMENT_PICK', { marker: m }, ['g1']); }, MARKER);
+    await sleep(500);
+    const before = await page.evaluate(countMarker, MARKER);
+    console.log('§K1 marker committed in-session count=' + before);
+    // wait out the 2s debounce + seal
+    await sleep(3500);
+    const persistFired = logs.some(l => l.includes('§KRN_PERSIST') && !l.includes('ERR'));
+    const persistErr = logs.filter(l => /KRN_PERSIST_ERR|KRN_SEAL_ERR/.test(l));
+    console.log('§K2 §KRN_PERSIST fired=' + persistFired + (persistErr.length ? ' errs=' + JSON.stringify(persistErr) : ''));
+
+    // RELOAD — does the edit survive?
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await ready(page);
+    const after = await page.evaluate(countMarker, MARKER);
+    console.log('§K3 AFTER-RELOAD marker count=' + after + '  → survived=' + (after && after !== 0 && !String(after).startsWith('ERR')) + (Number(after) > 0 ? '  OK' : '  (lost = persistence broken)'));
+    console.log('--- KRN logs ---');
+    console.log(logs.filter(l => /KRN_PERSIST|KRN_SEAL|KERNEL_OP committed|KERNEL_OPS_LOADED/.test(l)).slice(-8).join('\n'));
+    console.log('--- pageerrors ---');
+    console.log(logs.filter(l => l.startsWith('PAGEERR')).slice(0, 5).join('\n') || '(none)');
+    await ctx.close();
+  } catch (e) { console.log('FATAL: ' + e.message); }
+  finally { await browser.close(); }
+})();

--- a/viewer/grid_overlay.js
+++ b/viewer/grid_overlay.js
@@ -771,11 +771,45 @@ function setupGridOverlay(APP) {
     return state;
   }
 
-  /** Load saved sections from DB into savedSections[]. Falls back to localStorage. */
+  /** Load saved sections. localStorage (per-building) is AUTHORITATIVE; the DB is a cache. */
   function loadSavedSections() {
     savedSections = [];
     if (!A.db) return;
     ensureSavedSectionsTable(A.db);
+
+    // §BLANK_IDLE-sibling fix (CARD-DELETE-DURABLE): localStorage is written synchronously on
+    // every save/delete, so it is the authoritative card set. The building DB is only a cache —
+    // and with kernel-op IDB persistence (now working, see kernel_ops §KRN_PERSIST_FIX), a card
+    // DELETED but not followed by a kernel-op flush still LINGERS in the persisted DB and would
+    // resurrect on reload if we trusted the DB first. So: prefer localStorage when present and
+    // reconcile the in-memory DB to it (a later kernel flush then persists the correct set).
+    // Fall back to the DB only when no localStorage record exists yet (legacy / first run).
+    var lsRows = null;
+    try {
+      var lsData = localStorage.getItem(lsKey());
+      if (lsData != null) lsRows = JSON.parse(lsData);   // NOTE: "[]" is a valid AUTHORITATIVE empty
+    } catch (e) { log('§SAVE_SECTION ls parse error: ' + e.message); lsRows = null; }
+
+    if (lsRows) {
+      savedSections = lsRows;
+      try {
+        A.db.run('DELETE FROM saved_sections');
+        for (var k = 0; k < lsRows.length; k++) {
+          var s = lsRows[k];
+          A.db.run(
+            'INSERT OR REPLACE INTO saved_sections (id,name,cut_value,plane_normal,detected_grids,timestamp,view_state) VALUES(?,?,?,?,?,?,?)',
+            [s.id, s.name, s.cut_value, s.plane_normal,
+             (s.dwells && s.dwells.length) ? JSON.stringify(s.dwells) : null,
+             s.timestamp || '',
+             s.view_state ? JSON.stringify(s.view_state) : null]
+          );
+        }
+      } catch (e) { log('§SAVE_SECTION reconcile error: ' + e.message); }
+      log('§SAVE_SECTION loaded=' + savedSections.length + ' src=localStorage');
+      return;
+    }
+
+    // No localStorage record yet → read from the DB (legacy DBs / first entry before any save)
     try {
       var r = A.db.exec('SELECT id, name, cut_value, plane_normal, detected_grids, view_state FROM saved_sections ORDER BY id');
       if (r.length && r[0].values.length) {
@@ -789,28 +823,7 @@ function setupGridOverlay(APP) {
         }
       }
     } catch (e) { log('§SAVE_SECTION load db error: ' + e.message); }
-
-    // Fall back to localStorage if DB has no rows (persists across reloads)
-    if (!savedSections.length) {
-      try {
-        var lsData = localStorage.getItem(lsKey());
-        if (lsData) {
-          var lsRows = JSON.parse(lsData);
-          for (var j = 0; j < lsRows.length; j++) {
-            var ss = lsRows[j];
-            try {
-              A.db.run(
-                'INSERT OR IGNORE INTO saved_sections (id,name,cut_value,plane_normal,detected_grids,timestamp,view_state) VALUES(?,?,?,?,?,?,?)',
-                [ss.id, ss.name, ss.cut_value, ss.plane_normal, null, ss.timestamp || '', ss.view_state ? JSON.stringify(ss.view_state) : null]
-              );
-            } catch (e2) { /* skip duplicate */ }
-          }
-          savedSections = lsRows;
-          log('§SAVE_SECTION restored ' + lsRows.length + ' from localStorage');
-        }
-      } catch (e) { log('§SAVE_SECTION localStorage read error: ' + e.message); }
-    }
-    log('§SAVE_SECTION loaded=' + savedSections.length);
+    log('§SAVE_SECTION loaded=' + savedSections.length + ' src=db');
   }
 
   /** Save current scissors cut to DB and localStorage.
@@ -839,6 +852,10 @@ function setupGridOverlay(APP) {
         var lastId = A.db.exec('SELECT last_insert_rowid()');
         if (lastId.length && lastId[0].values.length) latestSavedId = lastId[0].values[0][0];
       } catch (e2) { /* ignore */ }
+      // CARD-DELETE-DURABLE: clear localStorage BEFORE the (now ls-authoritative) reload so
+      // loadSavedSections reads the fresh DB (incl. this new row) rather than the stale ls set;
+      // we re-write ls from the fresh savedSections immediately after.
+      try { localStorage.removeItem(lsKey()); } catch (e) { /* no-op */ }
       loadSavedSections();
       try { localStorage.setItem(lsKey(), JSON.stringify(savedSections)); } catch (e) { /* no-op */ }
       // User saved a card manually — re-enable auto-create for future

--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -104,14 +104,28 @@
         try {
           var dbUrl = window.APP && APP.DB_URL;
           if (!dbUrl) return;
+          if (window.APP && APP._cacheDisabled) return;   // incognito / low quota → no IDB
           var buf = db.export().buffer;
-          var req = indexedDB.open('bim_ootb_cache', 1);
-          req.onupgradeneeded = function() { req.result.createObjectStore('dbs'); };
-          req.onsuccess = function() {
-            var tx = req.result.transaction('dbs', 'readwrite');
+          // §KRN_PERSIST_FIX: open the cache DB through the app's SINGLE opener (scene.js
+          // openCacheDB → version 2, ensures the 'dbs' store). The old hardcoded
+          // indexedDB.open('bim_ootb_cache', 1) drifted BELOW scene.js's v2 → the open fired
+          // onerror (VersionError), onsuccess never ran, and the edit was silently never
+          // persisted (kernel "survive refresh" was dead). Witness: probe_krn_persist.js.
+          var openP = (window.APP && APP.openCacheDB)
+            ? APP.openCacheDB()
+            : new Promise(function(res, rej) {
+                var rq = indexedDB.open('bim_ootb_cache');  // no version → current
+                rq.onsuccess = function() { res(rq.result); };
+                rq.onerror = function() { rej(rq.error); };
+              });
+          openP.then(function(idb) {
+            if (!idb) { console.warn('§KRN_PERSIST_ERR no cacheDB'); return; }
+            if (!idb.objectStoreNames.contains('dbs')) { console.warn('§KRN_PERSIST_ERR no dbs store'); return; }
+            var tx = idb.transaction('dbs', 'readwrite');
             tx.objectStore('dbs').put(buf, dbUrl);
-            console.log('§KRN_PERSIST url=' + dbUrl + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB');
-          };
+            tx.oncomplete = function() { console.log('§KRN_PERSIST url=' + dbUrl + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB'); };
+            tx.onerror = function() { console.warn('§KRN_PERSIST_ERR tx ' + (tx.error && tx.error.message)); };
+          }).catch(function(e) { console.warn('§KRN_PERSIST_ERR open ' + (e && e.message)); });
         } catch(e) { console.warn('§KRN_PERSIST_ERR', e); }
       }).catch(function(e) { console.warn('§KRN_SEAL_ERR', e); });
     }, 2000);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v625';
+const CACHE_VERSION = 'v626';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What & why
**Item (a) from §OUTSTANDING triage.** `kernel_ops._persistToIdb` opened `bim_ootb_cache` at **version 1**, but `scene.js` created that IndexedDB at **version 2** (the `timestamps` LRU store). Opening below the current version fires `onerror` (VersionError) — `onsuccess` never runs — so the modified building DB was **never written back**. Kernel-op edits (grid moves, element picks, saved sections) silently did **not survive a page refresh**, despite S243 §3.7 intending exactly that.

## Fix (two coupled parts)
1. **`kernel_ops.js`** — persist through the app's single cache-DB opener (`APP.openCacheDB` → v2, ensures the `dbs` store), with a no-version fallback, write logged on `tx.oncomplete`, and an `APP._cacheDisabled` (incognito/low-quota) guard.
2. **`grid_overlay.js` (COUPLED)** — re-enabling persistence resurfaces the 2D saved-card delete bug: a card deleted but not followed by a kernel-op flush lingers in the now-persisted DB and reappears on reload. `localStorage` is the synchronous authoritative record of card add/delete, so `loadSavedSections` now **prefers localStorage when present** (reconciling the in-memory DB to it), falling back to the DB only on first run; `saveSectionToDb` clears localStorage before the now-ls-authoritative reload so a new card isn't dropped.

SW `CACHE_VERSION` v625→v626.

## ⚠️ Blast radius (please weigh before deploy)
This **re-enables dormant app-wide persistence** — after this, kernel-tracked edits genuinely survive refresh (the intended feature, off for a while due to the version drift). Main user-visible effect: grid moves / picks / saved cards persist across reload. The one known interaction (saved-card delete) is handled and witnessed below. Not auto-merging — your call to deploy.

## Witnesses (whitebox §-log, headless swiftshader, Duplex — `tests/probe_*.js`)
**Kernel persistence:**
| | §KRN_PERSIST | reload marker |
|---|---|---|
| unfixed | `false` | count=0 (**LOST**) |
| fixed | `true` (14.6MB write) | count=1 (**SURVIVED**) |

**2D card delete under now-working persistence (`§W2 flush=true`):** delete sticks in-session (`§W3`), on panel reopen (`§W3b`), after reload (`§W4`), and delete-ALL → 0 cards reappear. No resurrection.

ESLint clean on both files. (`tests/audit_specs.js` has a pre-existing unrelated SKIP failure in `38-sh-dx-2d-runtime.spec.js` — no specs touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)