### PR TITLE
docs(readme): land full rebalance on main (25 buildings, 2025–2026, roadmap) + expand Built-with

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,7 @@ Two engines in one browser tab, sharing one operation log. Drop an IFC file and 
 
 **Live:** [red1oon.github.io/bim-ootb](https://red1oon.github.io/bim-ootb/) — **Film (both engines):** [BIM and ERP, one engine](https://youtu.be/hnLYNcRihzs)
 
-## The two write-ups
-
-| Side | Technical paper |
-|------|-----------------|
-| **BIM** | [BIM OOTB — Technical Feature Paper](https://red1oon.github.io/BIMCompiler/FeatureComparison/) |
-| **ERP** | [Migrate & Compare (ERP) — legacy ERP vs the WASM event-sourced browser](https://red1oon.github.io/BIMCompiler/MigrateComparisonPaper/) |
+Two technical papers, one per engine: **BIM →** [Feature Paper](https://red1oon.github.io/BIMCompiler/FeatureComparison/) · **ERP →** [Migrate & Compare](https://red1oon.github.io/BIMCompiler/MigrateComparisonPaper/).
 
 ---
 
@@ -31,23 +26,49 @@ A browser-native IFC viewer — no server, no cloud subscription, no install. Op
 - **PWA** — works offline after first visit
 - **18 Languages** — auto-detected from browser locale
 
-→ Full feature paper: [FeatureComparison](https://red1oon.github.io/BIMCompiler/FeatureComparison/)
+**Bigger topics shipped recently:**
+
+- **Universal history timeline** — one merged op|view stream in a shared `common/history_bar.js`, retiring the legacy grid-undo bar; recording-depth toggle; persists and recalls across page-leave / tab-close / return
+- **Typed natural-language query** — type a question in the viewer bar → SQL → answer + 3D highlight; 92/92 across 7 buildings (EN/Malay/Swedish), zero drift
+- **Find / Revit+ Lens** — uniform depth model (ghost / group-solid / shine-through item), room·material·phase·storey lenses, x-ray (Alt+X), tight-FOV group-zoom drill
+- **Alt+X envelope ghost** — disc-coloured instanced bbox wireframes (free, no hang) — see the model's skeleton through its skin
+- **City Mode (S285)** — camera ray-blast streaming with ARC-first gate and wave eviction; whole-city facade resident, 786 buildings
+- **Precision camera** — Auto-Pivot live re-centre orbit (room-centroid / selected element), keyboard cluster
+- **Synthesized SFX** — zero-asset cinematic audio overlay (Time-Machine score, nav cues, surface-aware ray-blast)
+
+→ **Read the paper:** [BIM OOTB Feature Paper](https://red1oon.github.io/BIMCompiler/FeatureComparison/)
 
 ## ERP side — Op-Log Engine
 
-Beside the BIM model, the same browser runs an ERP kernel forked from the iDempiere lineage (Compiere → ADempiere → iDempiere). State is a *deterministic fold over a signed operation log* — a fact is computed by replaying the log, not stored as a guarded scalar — so it runs serverless, over SQLite WASM, and works offline. iDempiere's Application Dictionary (~925 tables) is re-expressed as five relations plus verbs; the same op-log that drives the model folds a building into a procurement order.
+**Open `erp/erp.html`.** The same browser that renders the building also runs an ERP kernel forked from the iDempiere lineage (Compiere → ADempiere → iDempiere). State is a *deterministic fold over a signed operation log* — a fact is computed by replaying the log, not stored as a guarded scalar — so it runs serverless, over SQLite WASM, and works offline. iDempiere's Application Dictionary (~925 tables) is re-expressed as five relations plus verbs, and the *same* op-log that drives the model folds a building into a procurement order.
 
-- **iDempiere client** — `erp/idempiere.html`: every window, tab and field folded live from the Application Dictionary in SQLite WASM, with identity & context sign-in
-- **ERP OOTB** — `erp/erp.html`: the Application Dictionary as an offline-first app — multi-tenant, shareable context, history scrubber, pill chrome
+The ERP side has its own sprint — ~90 PRs building, in order:
+
+- **AD renderer** — `erp/erp.html`: every window, tab and field rendered live from the Application Dictionary in SQLite WASM; multi-tenant, `?login=` demo auto-login, shareable context (Share pill captures *and* restores), mobile cards ≤760px
+- **iDempiere client** — `erp/idempiere.html`: the same AD framework rendered as an iDempiere-flavoured client, with a real Odoo Client 12 tenant folded in as a second renderer
+- **Lens family** — over the one op-log: durable, drag-to-`SET_STATUS` **Kanban** (Odoo-marvel cards), chat-as-inbox **feed-fold**, **Data Globe** graph, Accts-Posted ledger lens — one-tap Graph ⇆ Kanban
+- **⚖ Rule pill** — *lifecycle-as-data*: "when may this Order Complete" is itself a signed, reversible op that re-folds live; client-scoped to the logged-in tenant, honest-disabled
+- **One signed op-log (I-4)** — the live write path is genuinely signed; gated signed **Complete** governs the CO lifecycle; GL debits == credits self-verify on every hop
 - **Glassbowl** — `erp/glassbowl.html`: the engine rendered *from its own data* — the kernel inspecting itself
-- **Lenses** — Kanban, chat-as-inbox feed-fold, and the Data Globe graph, all reading the same fold
-- **Rule fold** — client-scoped, honest-disabled validation rules folded over the logged-in tenant
-- **Signed ledger** — hash-chained op-log with an in-browser signer; GL debits == credits self-verify on every hop
-- **Odoo Migrate Agent** — `erp/odoo_agent/`: a native, *delegate-to-install* agent — the browser never touches your Odoo; you run the agent locally, it folds your order→delivery→invoice chain to `odoo_chain.json`, you load that back in the browser
+- **Migrate / Install** — pick-your-ERP dialog + the **Odoo Migrate Agent** (`erp/odoo_agent/`, self-contained `.zip`): a native *delegate-to-install* agent — the browser never touches your Odoo; you run it locally, it folds your order→delivery→invoice chain to `odoo_chain.json`, and Install persists the merged tenant so it survives reload
 
 A proven kernel and architecture, not a finished ERP. The constituent techniques are established (event sourcing, hash-chained ledgers, single-writer-at-the-edge, local-first); the contribution is their composition under ERP semantics and the BIM↔ERP unification. Honest about gaps — SAP S/4HANA folding is not-run, B1 is a mock — see the paper.
 
-→ Evaluator paper (iDempiere/Odoo/SAP vs the browser): [MigrateComparisonPaper](https://red1oon.github.io/BIMCompiler/MigrateComparisonPaper/)
+→ **Read the paper:** [Migrate & Compare — legacy ERP vs the WASM event-sourced browser](https://red1oon.github.io/BIMCompiler/MigrateComparisonPaper/)
+
+---
+
+## Roadmap
+
+**ERP — two big objectives.** Once migration from **both iDempiere and Odoo** is stable on the signed op-log, fold the kernel forward into two new op-log-native apps:
+
+1. **uniCenta POS** — a new browser version, driven by **replenishment** (the POS lifecycle as folds over the same ledger).
+2. **Warehouse mobile walk** — a phone-first pick/put-away "walk the aisles" app over the same tenant.
+
+**BIM — two big objectives.**
+
+1. **2D Grid Editor modelling** — author and edit the model from the 2D grid, not just view it.
+2. **Parallel history timeline** — the universal op|view timeline running side-by-side across building and ERP context.
 
 ---
 
@@ -83,9 +104,9 @@ erp/                  — ERP engine
   docs/               — ERP feature specs
 ```
 
-## 30 Pre-loaded Buildings
+## 25 Pre-loaded Buildings
 
-The gallery includes 30 IFC buildings from public datasets — from a simple house (487 elements) to a hospital (40,086 elements). Building databases are served from OCI Object Storage; the viewer code is served from GitHub Pages.
+The gallery includes 25 IFC buildings from public datasets (8 landmark + 17 city) — from a simple house (487 elements) to a hospital (40,086 elements). Building databases are served from OCI Object Storage; the viewer code is served from GitHub Pages.
 
 ## Deploy
 
@@ -111,11 +132,18 @@ cd tests && npm install && npx playwright test
 
 | Library | Version | Purpose |
 |---------|---------|---------|
-| Three.js | r160 ESM | 3D rendering, BatchedMesh, DLOD |
-| sql.js | 1.10.3 | SQLite in WASM (BIM + ERP) |
-| web-ifc | 0.0.77 | IFC parsing (IFC2x3 + IFC4) |
-| SheetJS | 0.20.3 | Excel export |
-| Chart.js | 4.x | BOQ/cost charts |
+| Three.js | r160 ESM | 3D rendering — BatchedMesh, DLOD, post-FX (EffectComposer/SSAO/Outline), WebGPU build |
+| SQLite WASM (sql.js) | 1.10.3 + FTS5 | the database for **both** engines — BIM model + ERP Application Dictionary, in-browser |
+| sql.js-httpvfs | bundled | range-read streaming of remote `.db` files (load only the pages you touch) |
+| web-ifc | 0.0.77 | IFC parsing (IFC2x3 + IFC4), client-side |
+| Canvas 2D | native | 2D plans, dimension chains, door arcs, grid overlay, clash/snag, print sheets, Time Machine |
+| SheetJS / ExcelJS + FileSaver | 0.20.3 | Excel export |
+| Chart.js | 4.x | BOQ / cost charts |
+| qrcode.js | bundled | QR share codes |
+| bigdecimal.js | bundled | exact decimal GL math (no float money in the ERP ledger) |
+| SimplexNoise | bundled | procedural ground / sky textures |
+| Service Worker + Web App Manifest | — | PWA / offline-first |
+| IndexedDB · Web Workers · BroadcastChannel | native | IFC import store · off-main-thread SQLite/import · cross-tab history sync |
 
 ## History
 
@@ -139,4 +167,4 @@ The browser sprint (S200–S271, April 20 — May 23) produced 552 commits and 9
 
 ## License
 
-MIT. Copyright (c) 2006–2026 Redhuan D. Oon.
+MIT. Copyright (c) 2025–2026 Redhuan D. Oon.


### PR DESCRIPTION
## Why

PR #209 was merged **after only its first commit**, so these never reached `main` — the live README still showed **30 buildings** and **2006** copyright:

- buildings **30 → 25** (the landing manifest renders exactly 25 archetypes: 8 landmark + 17 city)
- copyright **2006 → 2025–2026**
- the `## Roadmap` section (ERP: uniCenta POS + Warehouse walk after iDempiere/Odoo migration · BIM: 2D Grid Editor + parallel history timeline)
- the "Bigger topics shipped recently" BIM highlights
- the erp.html-first ERP arc

This re-lands all of it on current `main`.

## Plus — expanded "Built with"

Added the libraries actually in the tree (non-invent, verified in `viewer/lib`, `erp/lib`):
**SQLite WASM (sql.js + FTS5)** called out as the DB for *both* engines · **sql.js-httpvfs** range streaming · **Canvas 2D** (2D plans, dim chains, door arcs, grid overlay, clash, print) · ExcelJS/FileSaver · qrcode.js · **bigdecimal.js** (exact GL math) · SimplexNoise · Service Worker + manifest · IndexedDB / Web Workers / BroadcastChannel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)