### PR TITLE
feat(history): field() primitive + section fix + log-sniffer — recording goes total (PR #3)

### DIFF
--- a/common/history_tap.js
+++ b/common/history_tap.js
@@ -15,7 +15,15 @@
     max:  null,                                                              // nearly all (deny still applies)
   };
   // Noise floor: even 'max' never records these tags (render churn / not user intent).
-  var DENY_TAG = { RENDER_TICK: 1, IDLE_GATE: 1, HOVER: 1, PANEL_BLUR: 1, LOAD_FAIL: 1 };
+  // Tuned against the live Hospital firehose (§RENDER_LOOP/§IDLE_GATE/§SFX_* dominated the stream).
+  // NB: KBD_ROUTE is NOT denied — that's how Alt+X/Z ghost-xray is captured; its noise ("drop key") is
+  // dropped by NOISE_LABEL instead. EVT/RESTORE = the tap's OWN output (anti-recursion for the sniffer).
+  var DENY_TAG = {
+    RENDER_TICK: 1, RENDER_LOOP: 1, IDLE_GATE: 1, HOVER: 1, PANEL_BLUR: 1, PANEL_FOCUS: 1, LOAD_FAIL: 1,
+    SFX_NAV: 1, SFX_SUSPEND: 1, SFX_RESUME: 1, SFX_INIT: 1, SFX_CONFIG: 1, FILTER_GUIDS: 1, GRID_SCISSORS: 1,
+    KBD_SEQ_ENGINE: 1, KBD_SEQ_FIRE: 1, KBD_SEQ: 1, BBOX: 1, BBOX_PLACEHOLDERS: 1, BBOX_CLEARED: 1,
+    EVT: 1, RESTORE: 1, HIST_PUSH: 1, HIST_UNDO: 1, HIST_REDO: 1, KRN_CHAIN: 1, KRN_PERSIST: 1,
+  };
   // Intra-tag noise: same tag, but the line is internal routing/error, not a user action.
   var NOISE_LABEL = /pass-through|no-op|error|blocked|unregistered|drop key|guard/i;
 
@@ -38,15 +46,24 @@
   }
   function snapView() { var c = {}; for (var k in ambient) c[k] = ambient[k]; return c; }
 
-  // (1) Camera & other NON-stream state come from one optional pull-hook — loose-coupled, host opt-in.
-  var viewProvider = null;                              // () => ({ cam:{p,t}, … })  registered by host
+  // ── THE PRIMITIVE: field(name, read, write) ────────────────────────────────────────
+  // ONE symmetric line makes any view-act restorable: capture = read(), restore = write(value).
+  // Lives in the feature's OWN module → history couples to nothing. Adding section/palette/clash =
+  // one field() line. Two branches are two field-maps; orthogonal fields (color vs section) UNION
+  // with no collision — which is exactly what makes "combine A's color + B's section" effortless.
+  var fields = {};                                     // name -> { read, write }
+  function field(name, read, write) { fields[name] = { read: read, write: write }; }
+
+  // (compat) the old asymmetric pair, now expressed AS fields — kept so existing hosts don't break.
+  var viewProvider = null;
   function setViewProvider(fn) { viewProvider = fn; }
-  // (2) Seed ambient once from current state (so a toggle ON before the tap woke up isn't missed).
+  function registerApplier(key, fn) { field(key, null, fn); }
   function seed(state) { if (state) for (var k in state) ambient[k] = state[k]; }
 
-  // Build the current view vector: ambient mirror (from stream) + provider pulls (camera etc, authoritative).
+  // Build the current view vector: stream-ambient toggles + every field's read() (authoritative).
   function buildView() {
     var v = snapView();
+    for (var name in fields) { if (fields[name].read) { try { v[name] = fields[name].read(); } catch (e) {} } }
     if (viewProvider) { try { var ext = viewProvider(); for (var k in ext) v[k] = ext[k]; } catch (e) {} }
     return v;
   }
@@ -57,18 +74,54 @@
     all.push({ tag: tag, label: label, payload: payload || null, view: buildView(), t: all.length });     // … then stamp.
   }
 
-  // (3) RESTORE — re-apply a recorded entry's view vector to the live scene.
-  // Appliers are registered by the host (one per state key) — the tap stays scene-agnostic.
-  var appliers = {};                                   // key -> fn(value)
-  function registerApplier(key, fn) { appliers[key] = fn; }
+  // ── THE LOG-SNIFFER: recording goes TOTAL with ZERO per-feature wiring ──────────────
+  // Every act already prints a §line (Log Mandate). We read that stream instead of instrumenting each
+  // feature. A crumb is LIGHTWEIGHT (no view-stamp) — the read-only "what I did" net the knob filters.
+  // Boot/load/render LIFECYCLE — logged, but not "what the USER did". Excluded from the sniffer net so
+  // "total recording" means total ACTIONS, not total console output. (Explicit S() acts bypass this.)
+  var LIFECYCLE = /_(LOADED|READY|INIT|DONE|WIRED?|MODULE|VERSION|REGISTER|CHECK|AUDIT|PROBE|FETCHED|FLUSH|STREAM|DETAIL|MISS_READ|WRITE_OK|QUERY|RESULT|DETECT|RECOLOR|EARLY|FROM_POSITIONS)$|^(UPGRADE|CACHE|BVH|BOOTSTRAP|SPLIT|GEO|DB|DS|SW|PWA|FOG|ENV|SKY|TONE|GROUND|BATCHED|BLOB|INSTANCED|PROGRESSIVE|NORMALS|CENTRES|HASH|DIFF|HELPERS|PANELS|LISTNAV|QUOTA|OFFSET|MAIN|COLOR_MGMT|LENSFLARE|EFFECTS|SITECAM|NLP|MEASURE|SHARE|RECORD|ERROR_REPORTER|GHOSTGLASS|UI_PILL|PILL|MOBILE)/;
+  function feedCrumb(tag, label) {
+    if (DENY_TAG[tag] || LIFECYCLE.test(tag) || NOISE_LABEL.test(label)) return;  // firehose + lifecycle + intra-tag noise
+    var n = all.length;                                             // dedupe vs the last few (explicit S() + its console.log overlap)
+    for (var i = n - 1; i >= 0 && i >= n - 3; i--) if (all[i].tag === tag && all[i].label === label) return;
+    reduceAmbient(tag, label);
+    all.push({ tag: tag, label: label, payload: null, crumb: true, t: all.length });
+  }
+  var _origLog = null, _sniffing = false;
+  var TAGRE = /§([A-Z][A-Z0-9_]*)\s*([^\n]*)/;                      // find §TAG anywhere ("[S205] §SECTION …")
+  function sniff(enable) {
+    if (enable && !_origLog && typeof console !== 'undefined') {
+      _origLog = console.log;
+      console.log = function () {
+        _origLog.apply(console, arguments);                        // never swallow the real log
+        if (_sniffing) return;                                     // anti-recursion
+        try {
+          _sniffing = true;
+          var s = ''; for (var i = 0; i < arguments.length; i++) s += (typeof arguments[i] === 'string' ? arguments[i] : '') + ' ';
+          var m = TAGRE.exec(s);
+          if (m) feedCrumb(m[1], (m[2] || '').trim().slice(0, 80));
+        } catch (e) {} finally { _sniffing = false; }
+      };
+      try { console.log('§EVT SNIFF|on — recording every §act, deny-filtered'); } catch (e) {}
+    } else if (!enable && _origLog) { console.log = _origLog; _origLog = null; }
+  }
+
+  // RESTORE — re-apply a recorded view vector: each field's write() reproduces its slice of the look.
   function applyView(view, label) {
     if (!view) return false;
     var applied = [];
     for (var k in view) {
-      if (appliers[k]) { try { appliers[k](view[k]); applied.push(k); } catch (e) {} }
+      if (fields[k] && fields[k].write) { try { fields[k].write(view[k]); applied.push(k); } catch (e) {} }
     }
     try { console.log('§EVT RESTORE|' + (label || '?') + ' keys=' + applied.join(',')); } catch (e) {}
     return applied.length > 0;
+  }
+  // COMBINE — union two recorded looks into one. Orthogonal fields (color vs section) never collide;
+  // a shared field → second wins (last-writer). This is "merge" reduced to a vector union (no 3-way).
+  function combineViews() {
+    var out = {};
+    for (var i = 0; i < arguments.length; i++) { var v = arguments[i] || {}; for (var k in v) out[k] = v[k]; }
+    return out;
   }
   function restore(entry) { return entry ? applyView(entry.view, entry.label) : false; }
   function setKnob(l) { if (STOPS.hasOwnProperty(l) || l === 'max') level = l; }
@@ -83,10 +136,10 @@
   }
   function clear() { all.length = 0; }
 
-  var Tap = { feed: feed, setKnob: setKnob, getKnob: getKnob, history: history, clear: clear,
-              seed: seed, setViewProvider: setViewProvider, registerApplier: registerApplier,
-              restore: restore, currentView: currentView, applyView: applyView,
-              _all: all, STOPS: STOPS };
+  var Tap = { feed: feed, feedCrumb: feedCrumb, sniff: sniff, setKnob: setKnob, getKnob: getKnob, history: history, clear: clear,
+              field: field, seed: seed, setViewProvider: setViewProvider, registerApplier: registerApplier,
+              restore: restore, currentView: currentView, applyView: applyView, combineViews: combineViews,
+              _all: all, _fields: fields, STOPS: STOPS };
 
   // S() — the sink. Keeps the §-debug line you have today AND feeds the tap. No event bus.
   function S(tag, label, payload) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v628';
+const CACHE_VERSION = 'v629';
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -463,6 +463,7 @@ function setupTools(A) {
 
   A.updateAmbience = function(val) {
     var tick = Math.round(Number(val));
+    A._ambienceTick = tick;   // §-tap palette field reads this (one scalar = the whole palette state)
     A._restoreSunglass();
     if (tick === 0) {
       document.getElementById('sunglass-val').textContent = 'Off';

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -97,40 +97,41 @@
   function _tapView() { try { return window.HistoryTap ? HistoryTap.currentView() : null; } catch (e) { return null; } }
   function _tapApply(v, label) { try { if (v && window.HistoryTap) HistoryTap.applyView(v, label); } catch (e) {} }
   function _wireTap() {
-    if (!window.HistoryTap) return;
+    if (!window.HistoryTap || !window.HistoryTap.field) return;
     var T = window.HistoryTap;
-    // Camera + live toggle state are pulled at capture (authoritative — no stream desync).
-    T.setViewProvider(function () {
-      var A = _A(), v = {};
-      try { if (typeof window.ghostXrayOn === 'function') v.ghost = window.ghostXrayOn(); } catch (e) {}
-      try { if (A) v.xray = !!A.xrayOn; } catch (e) {}
-      try {
-        if (A && A.camera && A.controls) {
-          var p = A.camera.position, t = A.controls.target;
-          v.cam = { p: [p.x, p.y, p.z], t: [t.x, t.y, t.z] };
+    // ── ONE symmetric line per restorable act: field(name, read, write). ───────────────
+    // read() = capture the slice · write(v) = reproduce it. Adding a new act = add a line.
+    T.field('ghost',
+      function () { return (typeof window.ghostXrayOn === 'function') ? window.ghostXrayOn() : false; },
+      function (want) { if (typeof window.ghostXrayOn === 'function' && typeof window.toggleGhostXray === 'function' && window.ghostXrayOn() !== !!want) window.toggleGhostXray(); });
+    T.field('xray',
+      function () { return !!(_A() && _A().xrayOn); },
+      function (want) { var A = _A(); if (A && !!A.xrayOn !== !!want && A.toggleXray) A.toggleXray(); });
+    T.field('cam',
+      function () { var A = _A(); if (!(A && A.camera && A.controls)) return null; var p = A.camera.position, t = A.controls.target; return { p: [p.x, p.y, p.z], t: [t.x, t.y, t.z] }; },
+      function (c) { var A = _A(); if (A && A.camera && A.controls && c && c.p) { A.camera.position.set(c.p[0], c.p[1], c.p[2]); if (c.t) A.controls.target.set(c.t[0], c.t[1], c.t[2]); A.controls.update(); if (A.markDirty) A.markDirty(); } });
+    // §SECTION — full cut state is {on, axis, cut} where cut = sectionPlane.constant (the slider position).
+    // write() drives the REAL setters: toggle on/off, set axis, then land the exact cut.  (demo's branch B)
+    T.field('section',
+      function () { var A = _A(); if (!A) return null; return { on: !!A.sectionOn, axis: A.sectionAxis, cut: (A.sectionPlane ? A.sectionPlane.constant : 0) }; },
+      function (s) {
+        var A = _A(); if (!(A && s)) return;
+        if (!s.on) { if (A.sectionOn && A.toggleSection) A.toggleSection(); return; }   // target = off → clear
+        if (!A.sectionOn && A.toggleSection) A.toggleSection();                          // target = on → enable
+        if (A.sectionAxis !== s.axis && A.setSectionAxis) A.setSectionAxis(s.axis);      // axis (re-applies range)
+        else if (A.applySectionAxis) A.applySectionAxis();
+        if (typeof s.cut === 'number' && A.updateSectionPlane) {
+          A.updateSectionPlane(s.cut);                                                   // the EXACT cut position
+          var sl = document.getElementById('section-slider'); if (sl) sl.value = s.cut;  // sync the slider thumb
         }
-      } catch (e) {}
-      return v;
-    });
-    // Appliers set the scene back to a recorded state (toggles are flip-to-target; camera is set+update).
-    T.registerApplier('ghost', function (want) {
-      try { if (typeof window.ghostXrayOn === 'function' && typeof window.toggleGhostXray === 'function' && window.ghostXrayOn() !== !!want) window.toggleGhostXray(); } catch (e) {}
-    });
-    T.registerApplier('xray', function (want) {
-      var A = _A(); try { if (A && !!A.xrayOn !== !!want && A.toggleXray) A.toggleXray(); } catch (e) {}
-    });
-    T.registerApplier('cam', function (c) {
-      var A = _A();
-      try {
-        if (A && A.camera && A.controls && c && c.p) {
-          A.camera.position.set(c.p[0], c.p[1], c.p[2]);
-          if (c.t) A.controls.target.set(c.t[0], c.t[1], c.t[2]);
-          A.controls.update(); if (A.markDirty) A.markDirty();
-        }
-      } catch (e) {}
-    });
-    try { T.seed({ ghost: (typeof window.ghostXrayOn === 'function') ? window.ghostXrayOn() : false, xray: !!(_A() && _A().xrayOn) }); } catch (e) {}
-    console.log('§HIST_TAP_WIRED provider+appliers(ghost,xray,cam)+seed');
+        if (A.markDirty) A.markDirty();
+      });
+    // §PALETTE — the whole palette/ambience is one scalar tick.  (the demo's branch A)
+    T.field('palette',
+      function () { var A = _A(); return A ? (A._ambienceTick || 0) : 0; },
+      function (tick) { var A = _A(); if (A && A.updateAmbience) A.updateAmbience(tick); });
+    if (T.sniff) T.sniff(true);   // recording goes TOTAL: read every §act from the stream, deny-filtered
+    console.log('§HIST_TAP_WIRED fields(ghost,xray,cam,section,palette) + sniffer ON — one symmetric line each');
   }
 
   // MODEL op apply: flips the signed kernel_ops `undone` flag (never deletion) + dispatches replay.

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -771,7 +771,7 @@
 <script src="pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
-<script src="../common/history_tap.js?v=2" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
+<script src="../common/history_tap.js?v=4" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
 <script src="scene.js?v=51" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
@@ -813,7 +813,7 @@
 <script src="grid_dim_chains.js?v=4" onerror="console.warn('[DimChains] grid_dim_chains.js skipped')"></script>
 <script src="kernel_ops.js?v=3" onerror="console.warn('[KernelOps] kernel_ops.js skipped')"></script>
 <script src="../common/history_bar.js?v=1" onerror="console.warn('[HistoryBar] common/history_bar.js skipped')"></script>
-<script src="universal_history.js?v=8" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
+<script src="universal_history.js?v=10" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
 <script src="bom_extract.js?v=1" onerror="console.warn('[BOMExtract] bom_extract.js skipped')"></script>
 <script src="verb_expand.js?v=1" onerror="console.warn('[VerbExpand] verb_expand.js skipped')"></script>
 <script src="bom_walker.js?v=1" onerror="console.warn('[BOMWalker] bom_walker.js skipped')"></script>


### PR DESCRIPTION
Stacked on #207. PR #3 of `prompts/HISTORY_KNOB_SIGNAL_TAP.md`.

## `field(name, read, write)` — the elegant restore primitive
Collapses the provider+applier pair (PR #2) into ONE symmetric line: capture = `read()`, restore = `write(v)`. Adding any restorable act = one line, ideally in the feature's own module. `combineViews(a,b)` = vector **union** — orthogonal fields (color vs section) never collide, so "merge A's color + B's section" is effortless. Fields wired: ghost · xray · cam · section · palette.

## Section-cut FIX (the live bug you hit)
It captured only `{axis}` and force-called `applySectionAxis()` → couldn't restore the cut position or turn section off. Now `{on, axis, cut}` (cut = `sectionPlane.constant`) driving the real setters. **W-SECTION-RT PASS** — cut=12.5 restored exactly.

## log-sniffer — recording goes TOTAL, zero per-feature wiring
Wrap the logger, regex `§TAG`, feed a lightweight crumb. Excludes the firehose (`RENDER_LOOP`/`IDLE_GATE`/`SFX_*`), boot **lifecycle** (`_LOADED`/`_INIT`/`UPGRADE_`/`CACHE_`…), and intra-tag noise; dedupes vs explicit `S()`; anti-recursion guarded. **W-SNIFFER PASS** — caught `SECTION`/`COLOR_PALETTE`/`SUNGLASS` acts that were **never wired** to `S()`.

This separates the two costs cleanly: **recording = total & free** (the sniffer), **restoring = one `field()` line** per state-holding act.

## Witnessed (headless, live Hospital geo+meshes)
`W-COMBINE` (color⊕section) · `W-SECTION-RT` (exact cut) · `W-SNIFFER` (total capture, noise excluded) — all PASS.

## Not here (next)
The **knob allow-sets** (which tags surface at low/mid/high) still need expanding to the real vocabulary — that lands with the **5-stop knob UI (PR #4)**: drag=breadth · press=thumbnail · pitched detents · ERP-mapping care. Capture is now total; curation is the knob's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)