### PR TITLE
feat(history): branch TREE (#5) + KNOB (#4) + cross-branch COMBINE (#6)

### DIFF
--- a/common/history_bar.js
+++ b/common/history_bar.js
@@ -73,29 +73,52 @@ window.HistoryBar = (function () {
     docTypes: null,                           // {type:true} whitelist that mirrors to the shared log
     treeKey: null                             // per-building localStorage key for the persisted TREE (opt-in)
   };
-  var _depth = 'all';
+  // ── The KNOB (HISTORY_KNOB_SIGNAL_TAP §LOCKED-KNOB) ──────────────────────
+  // The old 3-state cycle (all/doc/off) is a 5-stop magnitude DIAL: Off·Low·Mid·High·Max, default
+  // High. TURN (drag/tap) = BREADTH (how wide the §-net). PRESS (long-press) = RICHNESS (dot→chip,
+  // unified with the double-tap bloom). SOUND = a pitched detent tick per stop (∝ breadth, mute-aware).
+  // Persisted legacy values migrate: off→Off · doc→Mid · all→High (keeps any prior/ERP value working).
+  var _STOPS = ['off', 'low', 'mid', 'high', 'max'];
+  var _depth = 'high';
   var _configured = false;
+  function _stopIdx(d) { var i = _STOPS.indexOf(d); return i < 0 ? 3 : i; }
+  function _migrateDepth(d) {
+    if (d === 'all') return 'high';
+    if (d === 'doc') return 'mid';
+    if (d === 'off') return 'off';
+    return (_STOPS.indexOf(d) >= 0) ? d : null;
+  }
 
   function _now() { return (typeof Date !== 'undefined') ? Date.now() : 0; }
   function _on() { return _depth !== 'off'; }
 
   function configure(opts) {
     for (var k in opts) { if (Object.prototype.hasOwnProperty.call(opts, k)) _cfg[k] = opts[k]; }
-    // depth: persisted choice wins; else the app's (device-aware) default.
-    try { var d = localStorage.getItem(_cfg.depthKey); _depth = (d === 'all' || d === 'doc' || d === 'off') ? d : _cfg.defaultDepth(); }
-    catch (e) { _depth = _cfg.defaultDepth(); }
+    // depth: persisted choice wins (legacy all/doc/off migrate to stops); else the app's default.
+    try { _depth = _migrateDepth(localStorage.getItem(_cfg.depthKey)) || _migrateDepth(_cfg.defaultDepth()) || 'high'; }
+    catch (e) { _depth = _migrateDepth(_cfg.defaultDepth()) || 'high'; }
     if (!_configured) { _wireKeyboard(); _wireCrossTab(); _configured = true; }
     if (_cfg.treeKey) _persistLoad();   // restore persisted universes for this building (item 4)
     console.log('§HIST_CONFIGURE source=' + _cfg.source + ' depth=' + _depth + ' host=' + (_cfg.mountHostId || 'body') + ' treeKey=' + (_cfg.treeKey || '-'));
   }
 
-  // ── Significance gate (per active depth profile) ──────────────────────
+  // ── Significance gate (per active KNOB stop) ──────────────────────────
+  // BREADTH ladder: the stop selects how wide the §-net is. An app may supply a per-stop profile
+  // (the viewer does: low⊂mid⊂high⊂max); otherwise we fall back to its legacy all/doc sets so apps
+  // with only two profiles (e.g. ERP, if it adopts this bar) keep working — low/mid→doc, high/max→all.
+  function _profileForStop(stop) {
+    if (stop === 'off') return null;
+    var p = _cfg.profiles || {};
+    if (p[stop]) return p[stop];
+    if (stop === 'high' || stop === 'max') return p.all || p.doc || {};
+    return p.doc || p.all || {};   // low / mid
+  }
   function significant(bucket, type, label) {
     if (_depth === 'off') {
       console.log('§HIST_DROP source=' + bucket + ' type=' + type + ' reason=off profile=off label="' + (label || '') + '"');
       return false;
     }
-    var prof = _cfg.profiles[_depth] || _cfg.profiles.all || {};
+    var prof = _profileForStop(_depth) || {};
     var ok = !!(prof[bucket] && prof[bucket][type]);
     if (!ok) {
       console.log('§HIST_DROP source=' + bucket + ' type=' + type +
@@ -257,18 +280,35 @@ window.HistoryBar = (function () {
   }
   function _afterApply(when) { try { _cfg.afterApply(when); } catch (e) { console.warn('§HIST_AFTER_ERR', e); } }
 
-  // ── Depth (§6) ────────────────────────────────────────────────────────
+  // ── The KNOB: breadth (turn) + sound (detent) ─────────────────────────
   function setDepth(d) {
-    if (d !== 'all' && d !== 'doc' && d !== 'off') return;
+    d = _migrateDepth(d); if (!d) return;
+    var changed = d !== _depth;
     _depth = d;
     try { localStorage.setItem(_cfg.depthKey, d); } catch (e) {}
     _render();
-    console.log('§HIST_DEPTH depth=' + _depth);
+    console.log('§HIST_DEPTH depth=' + _depth + ' stop=' + _stopIdx(_depth) + '/4');
+    if (changed) _detentTick();
   }
-  function cycleDepth() { setDepth(_depth === 'all' ? 'doc' : (_depth === 'doc' ? 'off' : 'all')); }
-  function setEnabled(on) { setDepth(on ? 'all' : 'off'); }
+  function cycleDepth() { setDepth(_STOPS[(_stopIdx(_depth) + 1) % _STOPS.length]); }  // tap = one step (wraps)
+  function setEnabled(on) { setDepth(on ? 'high' : 'off'); }
   function isEnabled() { return _on(); }
   function getDepth() { return _depth; }
+
+  // SOUND axis: a crisp pitched detent tick per stop (pitch ∝ breadth), eyes-free confirmation.
+  // FREE — reuses the SFX synth; MUST stay silent under the global mute (`v` / §SFX_TOGGLE).
+  var _DETENT_HZ = { off: 150, low: 300, mid: 392, high: 494, max: 622 };
+  function _detentTick() {
+    try {
+      if (!(window.__sfx && window.__sfx.isOn && window.__sfx.isOn())) { console.log('§HIST_DETENT muted stop=' + _depth); return; }
+      var hz = _DETENT_HZ[_depth] || 440;
+      console.log('§HIST_DETENT stop=' + _depth + ' hz=' + hz);
+      window.__sfx.voice(_depth === 'off' ? 'knock' : 'pluck', hz, 55, 0);
+    } catch (e) {}
+  }
+  // RICHNESS axis (press): dot → chip (unified with the double-tap bloom). The 3rd level (thumbnail)
+  // is desktop-only + ephemeral (HISTORY_PERSIST_RECALL §LOCKED-5) — deferred, not faked here.
+  function _cycleRichness() { _bloom = !_bloom; _render(); console.log('§HIST_BLOOM ' + (_bloom ? 'on' : 'off') + ' via=press'); }
 
   function clear() { _rootKids = []; _rootActive = 0; _cursorNode = null; _rebuild(); _persistSave(); _render(); }
 
@@ -335,6 +375,7 @@ window.HistoryBar = (function () {
 
   // ── The bar UI ────────────────────────────────────────────────────────
   var _bar = null, _back = null, _fwd = null, _marks = null, _off = null;
+  var _knobTrack = null, _knobThumb = null, _knobLbl = null;
   var BTN = 'background:rgba(30,50,80,0.7);color:#4fc3f7;border:1px solid rgba(255,255,255,0.15);' +
     'border-radius:6px;padding:6px 10px;font-size:16px;cursor:pointer;backdrop-filter:blur(6px);min-width:36px;text-align:center';
 
@@ -368,9 +409,7 @@ window.HistoryBar = (function () {
     _marks = document.createElement('div');
     _marks.id = 'hist-marks';
     _marks.style.cssText = 'display:flex;gap:3px;align-items:center;padding:0 4px;overflow-x:auto;max-width:60vw';
-    _off = document.createElement('button');
-    _off.id = 'hist-off'; _off.style.cssText = BTN + ';font-size:13px';
-    _off.addEventListener('pointerup', function (e) { e.stopPropagation(); cycleDepth(); });
+    _off = _buildKnob();
     _bar.appendChild(_back); _bar.appendChild(_fwd); _bar.appendChild(_marks); _bar.appendChild(_off);
     var _lastTap = 0; // §2 bloom: pointer double-tap (touch + mouse)
     _bar.addEventListener('pointerup', function () {
@@ -431,15 +470,75 @@ window.HistoryBar = (function () {
     return chip;
   }
 
-  var _DEPTH_UI = {
-    all: { g: '◉', c: '#4fc3f7', t: 'Recording: ALL — taps + nav + milestones (tap → DOC only)' },
-    doc: { g: '◑', c: '#66bb6a', t: 'Recording: DOC only — the clean trail (tap → OFF)' },
-    off: { g: '◯', c: '#888',    t: 'Recording: OFF (tap → ALL)' }
+  // ── The KNOB control (§LOCKED-KNOB): a 5-stop dial replacing the 3-state glyph button ──
+  // TURN = breadth (drag the dot, or tap to step) · PRESS = richness (long-press → bloom) ·
+  // SOUND = detent tick (in setDepth). Reuses the pill (BTN) look + a mini slider — no new widget.
+  var _STOP_UI = {
+    off:  { g: '○', c: '#777',    t: 'History OFF — drag/tap to dial up · long-press = detail' },
+    low:  { g: '◔', c: '#8a9bbf', t: 'Low — milestones only (tap → Mid)' },
+    mid:  { g: '◑', c: '#66bb6a', t: 'Mid — the clean trail: edits + saves (tap → High)' },
+    high: { g: '◕', c: '#4fc3f7', t: 'High — + navigation & selections · default (tap → Max)' },
+    max:  { g: '●', c: '#ffd479', t: 'Max — everything significant (tap → Off)' }
   };
+  function _buildKnob() {
+    var wrap = document.createElement('div');
+    wrap.id = 'hist-knob';
+    wrap.style.cssText = BTN + ';font-size:13px;display:flex;align-items:center;gap:6px;padding:6px 9px;touch-action:none;user-select:none';
+    _knobLbl = document.createElement('span');
+    _knobLbl.style.cssText = 'font-size:13px;line-height:1;flex:0 0 auto';
+    var track = document.createElement('div'); _knobTrack = track;
+    track.style.cssText = 'position:relative;width:48px;height:12px;flex:0 0 auto';
+    var line = document.createElement('div');
+    line.style.cssText = 'position:absolute;left:0;right:0;top:5px;height:2px;border-radius:1px;background:rgba(255,255,255,0.25)';
+    track.appendChild(line);
+    for (var s = 0; s < 5; s++) {
+      var pip = document.createElement('div');
+      pip.style.cssText = 'position:absolute;top:4px;width:4px;height:4px;border-radius:50%;background:rgba(255,255,255,0.35);left:' + (s / 4 * 100) + '%;transform:translateX(-50%)';
+      track.appendChild(pip);
+    }
+    _knobThumb = document.createElement('div');
+    _knobThumb.style.cssText = 'position:absolute;top:1px;width:10px;height:10px;border-radius:50%;transform:translateX(-50%);box-shadow:0 0 4px rgba(0,0,0,0.5);transition:left .08s';
+    track.appendChild(_knobThumb);
+    wrap.appendChild(_knobLbl); wrap.appendChild(track);
+    _wireKnobGestures(wrap, track);
+    return wrap;
+  }
+  function _wireKnobGestures(wrap, track) {
+    var startX = 0, startT = 0, dragging = false, pid = null;
+    var DRAG_PX = 4, PRESS_MS = 420;
+    function stopFromX(clientX) {
+      var r = track.getBoundingClientRect(); if (r.width <= 0) return _stopIdx(_depth);
+      return Math.max(0, Math.min(4, Math.round((clientX - r.left) / r.width * 4)));
+    }
+    wrap.addEventListener('pointerdown', function (e) {
+      e.stopPropagation(); startX = e.clientX; startT = _now(); dragging = false; pid = e.pointerId;
+      try { wrap.setPointerCapture(pid); } catch (x) {}
+    });
+    wrap.addEventListener('pointermove', function (e) {
+      if (pid == null) return;
+      if (Math.abs(e.clientX - startX) > DRAG_PX) dragging = true;
+      if (dragging) { var st = _STOPS[stopFromX(e.clientX)]; if (st !== _depth) setDepth(st); }   // live = TURN
+    });
+    wrap.addEventListener('pointerup', function (e) {
+      e.stopPropagation();
+      try { wrap.releasePointerCapture(pid); } catch (x) {} pid = null;
+      if (dragging) { dragging = false; return; }              // drag already committed live
+      if (_now() - startT >= PRESS_MS) { _cycleRichness(); return; }  // PRESS = richness
+      cycleDepth();                                            // TAP = one breadth step
+    });
+    wrap.addEventListener('pointercancel', function () { pid = null; dragging = false; });
+  }
+  function _renderKnob() {
+    if (!_off) return;
+    var su = _STOP_UI[_depth] || _STOP_UI.high;
+    if (_knobLbl) { _knobLbl.textContent = su.g; _knobLbl.style.color = su.c; }
+    _off.title = su.t;
+    if (_knobThumb) { _knobThumb.style.left = (_stopIdx(_depth) / 4 * 100) + '%'; _knobThumb.style.background = su.c; _knobThumb.style.border = '1px solid ' + su.c; }
+  }
+
   function _render() {
     if (!_bar) return;
-    var du = _DEPTH_UI[_depth] || _DEPTH_UI.all;
-    _off.textContent = du.g; _off.style.color = du.c; _off.title = du.t;
+    _renderKnob();
     var show = _opened;
     _bar.style.display = show ? 'flex' : 'none';
     if (!show) return;

--- a/common/history_bar.js
+++ b/common/history_bar.js
@@ -16,14 +16,47 @@
 window.HistoryBar = (function () {
   'use strict';
 
-  var _stream = [];        // the merged stream (this app's events)
-  var _cursor = -1;        // index of the most-recently-APPLIED entry; tail (>cursor) is undone
-  var _seq = 0;            // monotonic tiebreak for same-ms timestamps
+  // ── Branching history TREE (HISTORY_PARALLEL_TIMELINE PR #5) ──────────────
+  // Was a LINEAR _stream[]+_cursor where push()-after-undo TRUNCATED the redo tail (the wipe).
+  // Now a TREE: each entry node keeps kids[]+active+parent. Going back then acting FORKS a sibling
+  // universe instead of wiping the abandoned tail. The "current line" (_stream) is DERIVED — the
+  // path from the virtual root down the active-child chain to the tip. push/undo/redo/jumpTo keep
+  // their signatures (scene.js/navigate_find.js/panels.js depend on them); they now move the cursor
+  // through the tree, and _stream/_cursor are recomputed by _rebuild() to keep all the old UI/gate
+  // code working unchanged on the active line.
+  var _rootKids = [];      // children of the virtual root (>1 = a fork at the very start)
+  var _rootActive = 0;     // which root child the active line follows
+  var _cursorNode = null;  // most-recently-APPLIED node; null = at the virtual root (nothing applied)
+  var _stream = [];        // DERIVED: the active line, root→tip (kept current by _rebuild)
+  var _cursor = -1;        // DERIVED: index of _cursorNode within _stream (-1 = virtual root)
+  var _seq = 0;            // monotonic id + tiebreak for same-ms timestamps (also the node id)
   var _suppress = false;   // true while WE drive a restore — stops re-recording
   var _bloom = false;      // double-tap the BAR → dots bloom into labelled chips
   var _opened = false;
   var COALESCE_MS = 700;
   var GOLD = '#ffd479';
+  var SIB = '#b388ff';     // sibling-universe accent (off the active line)
+
+  // kids/active accessors that treat the virtual root (node===null) uniformly.
+  function _kidsOf(node) { return node ? node.kids : _rootKids; }
+  function _activeOf(node) { return node ? node.active : _rootActive; }
+  function _setActive(node, i) { if (node) node.active = i; else _rootActive = i; }
+
+  // Recompute the DERIVED active line (_stream) + cursor index from the tree.
+  function _rebuild() {
+    var line = [], node = null;
+    while (true) {
+      var kids = _kidsOf(node);
+      if (!kids.length) break;
+      var ai = _activeOf(node); if (ai >= kids.length) ai = kids.length - 1;
+      node = kids[ai];
+      line.push(node);
+    }
+    _stream = line;
+    _cursor = _cursorNode ? line.indexOf(_cursorNode) : -1;
+  }
+  function _tipOf(node) { var n = node; while (n.kids.length) { var a = n.active < n.kids.length ? n.active : n.kids.length - 1; n = n.kids[a]; } return n; }
+  function _isAncestorOrSelf(a, target) { var t = target; while (t) { if (t === a) return true; t = t.parent; } return false; }
 
   // ── App-supplied config (configure()) ─────────────────────────────────
   var _cfg = {
@@ -37,7 +70,8 @@ window.HistoryBar = (function () {
     iconFn: function () { return null; },     // iconFn(entry) → ICONS name | null
     sharedKey: 'bim.docHistory',             // app-wide cross-tab log
     channel: 'bim_history',
-    docTypes: null                            // {type:true} whitelist that mirrors to the shared log
+    docTypes: null,                           // {type:true} whitelist that mirrors to the shared log
+    treeKey: null                             // per-building localStorage key for the persisted TREE (opt-in)
   };
   var _depth = 'all';
   var _configured = false;
@@ -51,7 +85,8 @@ window.HistoryBar = (function () {
     try { var d = localStorage.getItem(_cfg.depthKey); _depth = (d === 'all' || d === 'doc' || d === 'off') ? d : _cfg.defaultDepth(); }
     catch (e) { _depth = _cfg.defaultDepth(); }
     if (!_configured) { _wireKeyboard(); _wireCrossTab(); _configured = true; }
-    console.log('§HIST_CONFIGURE source=' + _cfg.source + ' depth=' + _depth + ' host=' + (_cfg.mountHostId || 'body'));
+    if (_cfg.treeKey) _persistLoad();   // restore persisted universes for this building (item 4)
+    console.log('§HIST_CONFIGURE source=' + _cfg.source + ' depth=' + _depth + ' host=' + (_cfg.mountHostId || 'body') + ' treeKey=' + (_cfg.treeKey || '-'));
   }
 
   // ── Significance gate (per active depth profile) ──────────────────────
@@ -77,28 +112,48 @@ window.HistoryBar = (function () {
   }
 
   // ── Record ────────────────────────────────────────────────────────────
+  // FORK-DON'T-WIPE: when _cursorNode already has children (you went back, then acted), we DON'T
+  // truncate the abandoned tail — we append the new act as a fresh child and make it active. The old
+  // child subtree survives as a SIBLING universe hanging off the same fork node. A branch is a parent
+  // pointer, not a copy (~159 B/node, §LOCKED #4). VIEW restores, MODEL replays — geometry is never
+  // snapshotted into a node.
   function push(entry) {
     if (!_on() || _suppress) return;
     if (!entry || !significant(entry.bucket, entry.type, entry.label)) return;
     if (entry.ts == null) entry.ts = _now();
-    // Coalesce rapid same-signature repeats at the tip (no redo tail to break).
-    if (_cursor >= 0 && _cursor === _stream.length - 1) {
-      var tip = _stream[_cursor];
+    // Coalesce rapid same-signature repeats — only at a TRUE tip (cursor node has no children, so
+    // there is no sibling/redo subtree we'd quietly mutate).
+    if (_cursorNode && _cursorNode.kids.length === 0) {
+      var tip = _cursorNode;
       if (_sig(tip) === _sig(entry) && (entry.ts - (tip.ts || 0)) <= COALESCE_MS) {
-        for (var f in entry) { if (f !== 'seq' && Object.prototype.hasOwnProperty.call(entry, f)) tip[f] = entry[f]; }
+        for (var f in entry) {
+          if (f === 'seq' || f === 'kids' || f === 'active' || f === 'parent') continue;
+          if (Object.prototype.hasOwnProperty.call(entry, f)) tip[f] = entry[f];
+        }
         _render();
         console.log('§HIST_DROP source=' + entry.bucket + ' type=' + entry.type + ' reason=coalesced label="' + (entry.label || '') + '"');
         return;
       }
     }
     entry.seq = ++_seq;
-    if (_cursor < _stream.length - 1) _stream.length = _cursor + 1; // fresh action discards redo tail
-    _stream.push(entry);
-    _cursor = _stream.length - 1;
+    entry.kids = []; entry.active = 0; entry.parent = _cursorNode;
+    var kids = _kidsOf(_cursorNode);
+    var forked = kids.length > 0;          // already had a child → this push FORKS a sibling universe
+    var keptSibling = forked ? _tipOf(kids[_activeOf(_cursorNode)]) : null;
+    kids.push(entry);
+    _setActive(_cursorNode, kids.length - 1);
+    _cursorNode = entry;
     if (_isDoc(entry)) _mirror(entry);
+    _rebuild();
+    _persistSave();
     _render();
     console.log('§HIST_PUSH n=' + _stream.length + ' idx=' + _cursor + ' kind=' + entry.kind +
       ' label="' + (entry.label || '') + '"' + (entry.kind === 'op' ? ' opType=' + entry.type + ' opId=' + entry.opId : ''));
+    if (forked) {
+      console.log('§HIST_FORK parent="' + (_cursorNode.parent ? (_cursorNode.parent.label || '') : 'root') +
+        '" new="' + (entry.label || '') + '" kept-sibling="' + (keptSibling ? keptSibling.label : '') + '"' +
+        ' universes=' + _kidsOf(entry.parent).length);
+    }
   }
 
   // Mirror a DOC-class event to the app-wide shared log (cross-tab) — the landing/other apps read it.
@@ -113,23 +168,27 @@ window.HistoryBar = (function () {
   }
 
   // ── Undo / Redo / Jump ────────────────────────────────────────────────
+  // Cursor walks the TREE: undo = step to parent, redo = step to the active child.
   function undo() {
-    if (_cursor < 0) { console.log('§HIST_UNDO nothing'); return false; }
-    var e = _stream[_cursor];
+    if (!_cursorNode) { console.log('§HIST_UNDO nothing'); return false; }
+    var e = _cursorNode, was = _cursor;
     _applyEntry(e, false);
-    _cursor--;
+    _cursorNode = e.parent;
+    _rebuild();
     _render();
-    console.log('§HIST_UNDO idx=' + (_cursor + 1) + '→' + _cursor + ' kind=' + e.kind + ' label="' + (e.label || '') + '"');
+    console.log('§HIST_UNDO idx=' + was + '→' + _cursor + ' kind=' + e.kind + ' label="' + (e.label || '') + '"');
     _afterApply('undo');
     return true;
   }
   function redo() {
-    if (_cursor >= _stream.length - 1) { console.log('§HIST_REDO nothing'); return false; }
-    _cursor++;
-    var e = _stream[_cursor];
-    _applyEntry(e, true);
+    var next = _cursorNode ? (_cursorNode.kids[_cursorNode.active] || null) : (_rootKids[_rootActive] || null);
+    if (!next) { console.log('§HIST_REDO nothing'); return false; }
+    var was = _cursor;
+    _applyEntry(next, true);
+    _cursorNode = next;
+    _rebuild();
     _render();
-    console.log('§HIST_REDO idx=' + (_cursor - 1) + '→' + _cursor + ' kind=' + e.kind + ' label="' + (e.label || '') + '"');
+    console.log('§HIST_REDO idx=' + was + '→' + _cursor + ' kind=' + next.kind + ' label="' + (next.label || '') + '"');
     _afterApply('redo');
     return true;
   }
@@ -138,6 +197,46 @@ window.HistoryBar = (function () {
     var guard = 0;
     while (_cursor > idx && guard++ < 999) undo();
     while (_cursor < idx && guard++ < 999) redo();
+  }
+
+  // SWITCH UNIVERSE = restore down a different path. Walk the cursor from where it is up to the common
+  // ancestor of `target`, point the active-child chain at `target`, then redo down to it — every step
+  // re-applies its view, so landing on a sibling tip returns the scene exactly as that universe looked.
+  function _switchToNode(target) {
+    if (!target || target === _cursorNode) return;
+    var fromIdx = _cursor, guard = 0;
+    while (_cursorNode && !_isAncestorOrSelf(_cursorNode, target) && guard++ < 9999) undo();
+    var cur = target;                                  // re-point active children: ancestor → target
+    while (cur && cur !== _cursorNode) { var p = cur.parent; _setActive(p, _kidsOf(p).indexOf(cur)); cur = p; }
+    _rebuild();
+    guard = 0;
+    while (_cursorNode !== target && guard++ < 9999) { if (!redo()) break; }
+    _persistSave();
+    console.log('§HIST_SWITCH from=' + fromIdx + ' to="' + (target.label || '') + '" idx=' + _cursor + ' line=' + _stream.length);
+  }
+  function switchToId(id) {
+    var hit = null;
+    (function dfs(node) { var k = _kidsOf(node); for (var i = 0; i < k.length; i++) { if (k[i].seq === id) hit = k[i]; if (!hit) dfs(k[i]); } })(null);
+    if (hit) _switchToNode(hit); else console.log('§HIST_SWITCH miss id=' + id);
+    return !!hit;
+  }
+  // Every leaf in the tree = one universe tip. onMain = it lies on the current active line.
+  function tips() {
+    var out = [];
+    (function dfs(node) { var k = _kidsOf(node); if (!k.length) { if (node) out.push(node); return; } for (var i = 0; i < k.length; i++) dfs(k[i]); })(null);
+    return out.map(function (n) { return { id: n.seq, label: n.label, onMain: _stream.indexOf(n) >= 0 }; });
+  }
+  // §PROOF tree=… — compact nested shape; '*' marks the active child at each fork.
+  function _fmtNode(n) {
+    var s = (n.label || n.type || ('#' + n.seq));
+    if (n.kids.length) s += '(' + n.kids.map(function (k, i) { return (i === n.active ? '*' : '') + _fmtNode(k); }).join(' | ') + ')';
+    return s;
+  }
+  function treeShape() { return _rootKids.map(function (k, i) { return (i === _rootActive ? '*' : '') + _fmtNode(k); }).join(' | ') || '(empty)'; }
+  function _nodeCount() { var c = 0; (function dfs(node) { var k = _kidsOf(node); for (var i = 0; i < k.length; i++) { c++; dfs(k[i]); } })(null); return c; }
+  function dumpTree() {
+    console.log('§PROOF tree=' + treeShape() + ' nodes=' + _nodeCount() + ' tips=' + tips().length + ' line=' + _stream.length + ' cursor=' + _cursor);
+    return { shape: treeShape(), nodes: _nodeCount(), tips: tips(), line: _stream.length, cursor: _cursor };
   }
 
   function _applyEntry(e, forward) {
@@ -171,7 +270,62 @@ window.HistoryBar = (function () {
   function isEnabled() { return _on(); }
   function getDepth() { return _depth; }
 
-  function clear() { _stream = []; _cursor = -1; _render(); }
+  function clear() { _rootKids = []; _rootActive = 0; _cursorNode = null; _rebuild(); _persistSave(); _render(); }
+
+  // ── Persist the TREE shape (item 4) ──────────────────────────────────────
+  // Additive: serialize the whole tree (parent pointers → nested children) + the active path, so
+  // universes survive reload. Strips parent refs (rebuilt on hydrate) and any non-persistable cruft;
+  // VIEW state restores from the stored vectors, MODEL ops replay from the kernel spine (not duplicated
+  // here). Per-building keying comes from the app via configure({treeKey}); without it, persistence is
+  // a no-op (the in-memory tree still works), so an app opts in by supplying a key.
+  function _serNode(n) {
+    var o = {};
+    for (var f in n) { if (f === 'parent' || f === 'kids' || f === 'active') continue; if (Object.prototype.hasOwnProperty.call(n, f)) o[f] = n[f]; }
+    o.active = n.active;
+    o.kids = n.kids.map(_serNode);
+    return o;
+  }
+  function serialize() {
+    var path = []; var c = _cursorNode; while (c) { path.unshift(c.seq); c = c.parent; }
+    return { v: 1, seq: _seq, rootActive: _rootActive, cursor: path, kids: _rootKids.map(_serNode) };
+  }
+  function _hydNode(o, parent) {
+    var n = {}; for (var f in o) { if (f === 'kids') continue; if (Object.prototype.hasOwnProperty.call(o, f)) n[f] = o[f]; }
+    n.parent = parent; n.active = o.active || 0;
+    n.kids = (o.kids || []).map(function (k) { return _hydNode(k, n); });
+    if (n.seq > _seq) _seq = n.seq;
+    return n;
+  }
+  function hydrate(data) {
+    if (!data || !data.kids) return false;
+    _rootKids = data.kids.map(function (k) { return _hydNode(k, null); });
+    _rootActive = data.rootActive || 0;
+    _seq = Math.max(_seq, data.seq || 0);
+    // place the cursor at the persisted active node (last id on the stored path), else virtual root
+    _cursorNode = null;
+    var wantSeq = (data.cursor && data.cursor.length) ? data.cursor[data.cursor.length - 1] : null;
+    if (wantSeq != null) (function dfs(node) { var k = _kidsOf(node); for (var i = 0; i < k.length; i++) { if (k[i].seq === wantSeq) _cursorNode = k[i]; if (!_cursorNode) dfs(k[i]); } })(null);
+    _rebuild(); _render();
+    console.log('§HIST_HYDRATE nodes=' + _nodeCount() + ' tips=' + tips().length + ' cursor=' + _cursor + ' tree=' + treeShape());
+    return true;
+  }
+  function _persistSave() {
+    if (!_cfg.treeKey) return;
+    try { localStorage.setItem(_cfg.treeKey, JSON.stringify(serialize())); } catch (e) {}
+  }
+  function _persistLoad() {
+    if (!_cfg.treeKey) return false;
+    try { var raw = localStorage.getItem(_cfg.treeKey); if (raw) return hydrate(JSON.parse(raw)); } catch (e) {}
+    return false;
+  }
+  // App sets the per-building key when a building opens → drop the old tree, load that building's.
+  function setTreeKey(key) {
+    if (key === _cfg.treeKey) return;
+    _cfg.treeKey = key;
+    _rootKids = []; _rootActive = 0; _cursorNode = null;
+    if (!_persistLoad()) { _rebuild(); _render(); }
+    console.log('§HIST_TREEKEY key=' + (key || '-') + ' nodes=' + _nodeCount());
+  }
   function list() {
     var out = _stream.map(function (e, i) { return { i: i, kind: e.kind, label: e.label, applied: i <= _cursor }; });
     console.log('§HIST_LIST n=' + _stream.length + ' cursor=' + _cursor + ' ' +
@@ -242,6 +396,28 @@ window.HistoryBar = (function () {
     dot.addEventListener('pointerup', function (ev) { ev.stopPropagation(); jumpTo(idx); });
     return dot;
   }
+  // A sibling universe (a fork-child NOT on the active line) → a small accent tick / chip whose click
+  // SWITCHES to that universe's tip (walks the tree + restores its look — switch == restore down a path).
+  function _siblingTick(child) {
+    var tip = _tipOf(child);
+    var t = document.createElement('button');
+    t.title = 'Universe ⑂ ' + (tip.label || ('#' + tip.seq)) + ' — click to switch';
+    t.style.cssText = 'width:7px;height:7px;padding:0;cursor:pointer;flex:0 0 auto;align-self:flex-start;' +
+      'border:1px solid ' + SIB + ';border-radius:50%;background:rgba(179,136,255,0.45);box-shadow:0 0 4px rgba(179,136,255,0.5)';
+    t.addEventListener('pointerup', function (ev) { ev.stopPropagation(); _switchToNode(tip); });
+    return t;
+  }
+  function _siblingChip(child) {
+    var tip = _tipOf(child);
+    var chip = document.createElement('button');
+    chip.title = 'Switch to universe ⑂ ' + (tip.label || '');
+    chip.style.cssText = 'display:flex;align-items:center;gap:3px;flex:0 0 auto;cursor:pointer;' +
+      'padding:2px 6px;border-radius:11px;font-size:10px;white-space:nowrap;' +
+      'border:1px dashed ' + SIB + ';color:' + SIB + ';background:rgba(40,25,70,0.6)';
+    chip.innerHTML = '<span>⑂ ' + _esc(_shortLabel(tip.label)) + '</span>';
+    chip.addEventListener('pointerup', function (ev) { ev.stopPropagation(); _switchToNode(tip); });
+    return chip;
+  }
   function _chip(e, idx, applied, isCurrent) {
     var chip = document.createElement('button');
     chip.title = e.label || ('step ' + (idx + 1));
@@ -276,11 +452,25 @@ window.HistoryBar = (function () {
     _back.style.opacity = (_cursor >= 0) ? '1' : '0.35';
     _fwd.style.opacity = (_cursor < _stream.length - 1) ? '1' : '0.35';
     var current = null;
+    // A fork at the very START (virtual root has >1 child) → show the off-line root universes first.
+    if (_rootKids.length > 1) {
+      for (var rk = 0; rk < _rootKids.length; rk++) {
+        if (rk === _rootActive) continue;
+        _marks.appendChild(_bloom ? _siblingChip(_rootKids[rk]) : _siblingTick(_rootKids[rk]));
+      }
+    }
     for (var i = 0; i < _stream.length; i++) {
       var e = _stream[i], applied = (i <= _cursor), isCurrent = (i === _cursor);
       var node = _bloom ? _chip(e, i, applied, isCurrent) : _dot(e, i, applied, isCurrent);
       if (isCurrent) current = node;
       _marks.appendChild(node);
+      // Fork on the active line: render the abandoned sibling universes hanging off this node.
+      if (e.kids.length > 1) {
+        for (var k = 0; k < e.kids.length; k++) {
+          if (k === e.active) continue;   // the active child continues the main line — already drawn
+          _marks.appendChild(_bloom ? _siblingChip(e.kids[k]) : _siblingTick(e.kids[k]));
+        }
+      }
     }
     if (current) { try { _marks.scrollLeft = current.offsetLeft - _marks.clientWidth / 2 + current.offsetWidth / 2; } catch (e3) {} }
   }
@@ -303,6 +493,9 @@ window.HistoryBar = (function () {
     configure: configure, push: push,
     undo: undo, redo: redo, jumpTo: jumpTo,
     setDepth: setDepth, cycleDepth: cycleDepth, getDepth: getDepth, setEnabled: setEnabled, isEnabled: isEnabled,
-    clear: clear, open: open, toggleOpen: toggleOpen, list: list, significant: significant
+    clear: clear, open: open, toggleOpen: toggleOpen, list: list, significant: significant,
+    // ── branch TREE (PR #5) ──
+    switchToId: switchToId, tips: tips, dumpTree: dumpTree, treeShape: treeShape,
+    serialize: serialize, hydrate: hydrate, setTreeKey: setTreeKey
   };
 })();

--- a/common/history_bar.js
+++ b/common/history_bar.js
@@ -71,7 +71,9 @@ window.HistoryBar = (function () {
     sharedKey: 'bim.docHistory',             // app-wide cross-tab log
     channel: 'bim_history',
     docTypes: null,                           // {type:true} whitelist that mirrors to the shared log
-    treeKey: null                             // per-building localStorage key for the persisted TREE (opt-in)
+    treeKey: null,                            // per-building localStorage key for the persisted TREE (opt-in)
+    combine: null,                            // combine(current,donor,ancestor)→{viewState,label} (cross-branch VIEW union)
+    cherryPick: null                          // cherryPick(donorOp,ancestor)→bool (replay a signed op onto current)
   };
   // ── The KNOB (HISTORY_KNOB_SIGNAL_TAP §LOCKED-KNOB) ──────────────────────
   // The old 3-state cycle (all/doc/off) is a 5-stop magnitude DIAL: Off·Low·Mid·High·Max, default
@@ -243,6 +245,50 @@ window.HistoryBar = (function () {
     if (hit) _switchToNode(hit); else console.log('§HIST_SWITCH miss id=' + id);
     return !!hit;
   }
+  // ── Cross-branch COMBINE / cherry-pick (PR #6, §LOCKED-BRANCH) ────────────
+  // "Bring into current ⤵": standing on one universe, graft a SIBLING universe's contribution onto it
+  // WITHOUT merge. Two flavours, both keep A and B intact as visible universes:
+  //   • VIEW combine — union the donor's distinctive view-fields into the current look (color⊕section,
+  //     the proven combineViews). The bar delegates to _cfg.combine (only the app knows its fields).
+  //   • MODEL cherry-pick — replay the donor's signed op onto the current tip (delegated to _cfg.cherryPick;
+  //     disjoint = clean, NO 3-way merge — conflict UI is out of scope by design).
+  function _forceAppend(entry) {     // append a node on the current branch, BYPASSING the significance gate
+    entry.ts = _now(); entry.seq = ++_seq; entry.kids = []; entry.active = 0; entry.parent = _cursorNode;
+    var kids = _kidsOf(_cursorNode); kids.push(entry); _setActive(_cursorNode, kids.length - 1); _cursorNode = entry;
+    if (_isDoc(entry)) _mirror(entry);
+    _rebuild(); _persistSave(); _render();
+    console.log('§HIST_PUSH n=' + _stream.length + ' idx=' + _cursor + ' kind=' + entry.kind + ' label="' + (entry.label || '') + '" forced=1');
+  }
+  function _commonAncestor(a, b) {
+    var anc = []; for (var n = a; n; n = n.parent) anc.push(n);
+    for (var m = b; m; m = m.parent) if (anc.indexOf(m) >= 0) return m;
+    return null;   // disjoint roots → virtual root (delta vs {})
+  }
+  function _combineFrom(donor) {
+    if (!donor) return;
+    var cur = _cursorNode;
+    if (!cur) { console.log('§HIST_COMBINE skip reason=no-current'); return; }
+    if (donor === cur || _isAncestorOrSelf(donor, cur)) { console.log('§HIST_COMBINE skip reason=on-current-line'); return; }
+    var anc = _commonAncestor(cur, donor);
+    if (donor.kind === 'op') {
+      var ok = false; try { ok = _cfg.cherryPick ? _cfg.cherryPick(donor, anc) : false; } catch (e) { console.warn('§HIST_CHERRY_ERR', e); }
+      console.log('§HIST_COMBINE mode=cherry-pick donor="' + (donor.label || '') + '" ok=' + ok);
+      return;   // the app's own commit path records the replayed op onto the current branch
+    }
+    var res = null;
+    try { res = _cfg.combine ? _cfg.combine(cur, donor, anc) : null; } catch (e) { console.warn('§HIST_COMBINE_ERR', e); }
+    if (!res || !res.viewState) { console.log('§HIST_COMBINE skip reason=no-result donor="' + (donor.label || '') + '"'); return; }
+    _forceAppend({ bucket: 'view', kind: 'view', type: 'combine', readonly: true,
+      label: res.label || ('⊕ ' + (donor.label || 'universe')), viewState: res.viewState, sigKey: 'combine:' + (_seq + 1) });
+    console.log('§HIST_COMBINE mode=view donor="' + (donor.label || '') + '" into="' + (cur.label || '') + '" keys=' + Object.keys(res.viewState).join(','));
+  }
+  function combineFromId(id) {
+    var hit = null;
+    (function dfs(node) { var k = _kidsOf(node); for (var i = 0; i < k.length; i++) { if (k[i].seq === id) hit = k[i]; if (!hit) dfs(k[i]); } })(null);
+    if (hit) _combineFrom(hit); else console.log('§HIST_COMBINE miss id=' + id);
+    return !!hit;
+  }
+
   // Every leaf in the tree = one universe tip. onMain = it lies on the current active line.
   function tips() {
     var out = [];
@@ -435,26 +481,37 @@ window.HistoryBar = (function () {
     dot.addEventListener('pointerup', function (ev) { ev.stopPropagation(); jumpTo(idx); });
     return dot;
   }
-  // A sibling universe (a fork-child NOT on the active line) → a small accent tick / chip whose click
-  // SWITCHES to that universe's tip (walks the tree + restores its look — switch == restore down a path).
+  // A sibling universe (a fork-child NOT on the active line) → a small accent tick / chip.
+  //   TAP        = SWITCH to that universe's tip (walk the tree + restore its look).
+  //   LONG-PRESS / RIGHT-CLICK = BRING INTO CURRENT ⤵ (cross-branch combine/cherry-pick, PR #6).
+  function _wireSibling(el, tip) {
+    var t0 = 0, pid = null, done = false;
+    el.addEventListener('pointerdown', function (e) { e.stopPropagation(); t0 = _now(); pid = e.pointerId; done = false; try { el.setPointerCapture(pid); } catch (x) {} });
+    el.addEventListener('pointerup', function (e) {
+      e.stopPropagation(); try { el.releasePointerCapture(pid); } catch (x) {} pid = null;
+      if (done) return;
+      if (_now() - t0 >= 500) { done = true; _combineFrom(tip); } else _switchToNode(tip);
+    });
+    el.addEventListener('contextmenu', function (e) { e.preventDefault(); e.stopPropagation(); _combineFrom(tip); });
+  }
   function _siblingTick(child) {
     var tip = _tipOf(child);
     var t = document.createElement('button');
-    t.title = 'Universe ⑂ ' + (tip.label || ('#' + tip.seq)) + ' — click to switch';
-    t.style.cssText = 'width:7px;height:7px;padding:0;cursor:pointer;flex:0 0 auto;align-self:flex-start;' +
+    t.title = 'Universe ⑂ ' + (tip.label || ('#' + tip.seq)) + ' — tap = switch · long-press/right-click = bring into current ⤵';
+    t.style.cssText = 'width:7px;height:7px;padding:0;cursor:pointer;flex:0 0 auto;align-self:flex-start;touch-action:none;' +
       'border:1px solid ' + SIB + ';border-radius:50%;background:rgba(179,136,255,0.45);box-shadow:0 0 4px rgba(179,136,255,0.5)';
-    t.addEventListener('pointerup', function (ev) { ev.stopPropagation(); _switchToNode(tip); });
+    _wireSibling(t, tip);
     return t;
   }
   function _siblingChip(child) {
     var tip = _tipOf(child);
     var chip = document.createElement('button');
-    chip.title = 'Switch to universe ⑂ ' + (tip.label || '');
-    chip.style.cssText = 'display:flex;align-items:center;gap:3px;flex:0 0 auto;cursor:pointer;' +
+    chip.title = 'Universe ⑂ ' + (tip.label || '') + ' — tap = switch · long-press/right-click = bring into current ⤵';
+    chip.style.cssText = 'display:flex;align-items:center;gap:3px;flex:0 0 auto;cursor:pointer;touch-action:none;' +
       'padding:2px 6px;border-radius:11px;font-size:10px;white-space:nowrap;' +
       'border:1px dashed ' + SIB + ';color:' + SIB + ';background:rgba(40,25,70,0.6)';
     chip.innerHTML = '<span>⑂ ' + _esc(_shortLabel(tip.label)) + '</span>';
-    chip.addEventListener('pointerup', function (ev) { ev.stopPropagation(); _switchToNode(tip); });
+    _wireSibling(chip, tip);
     return chip;
   }
   function _chip(e, idx, applied, isCurrent) {
@@ -593,8 +650,9 @@ window.HistoryBar = (function () {
     undo: undo, redo: redo, jumpTo: jumpTo,
     setDepth: setDepth, cycleDepth: cycleDepth, getDepth: getDepth, setEnabled: setEnabled, isEnabled: isEnabled,
     clear: clear, open: open, toggleOpen: toggleOpen, list: list, significant: significant,
-    // ── branch TREE (PR #5) ──
+    // ── branch TREE (PR #5) + combine (PR #6) ──
     switchToId: switchToId, tips: tips, dumpTree: dumpTree, treeShape: treeShape,
-    serialize: serialize, hydrate: hydrate, setTreeKey: setTreeKey
+    serialize: serialize, hydrate: hydrate, setTreeKey: setTreeKey,
+    combineFromId: combineFromId
   };
 })();

--- a/viewer/tests/cherry_harness.html
+++ b/viewer/tests/cherry_harness.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!-- ⚠ DO NOT REMOVE — headless harness for the MODEL cherry-pick witness (poc_cherry_pick.js).
+     Loads the REAL modules (kernel_ops · history_tap · history_bar · universal_history) with a minimal
+     window.A holding a real sql.js db + GridDrag stub, so combineFromId→_cherryPick→KernelOps.commitOp
+     runs EXACTLY as in the viewer. The 3D geometry side (applyReplayedMove) is stubbed — it is a separate,
+     already-tested concern (T_2029); the UNWITNESSED claim is the signed-op graft across branches. -->
+<html><head><meta charset="utf-8"><title>cherry-pick harness</title></head>
+<body>
+<div id="status-bar-wrap"></div>
+<script src="../lib/sql-wasm.js"></script>
+<script src="../kernel_ops.js"></script>
+<script src="../../common/history_tap.js"></script>
+<script src="../../common/history_bar.js"></script>
+<script>
+  // GridDrag stub — the geometry move is not the claim; record that the replay reached it.
+  window.GridDrag = { applyReplayedMove: function (axis, label, pos, cascade, dir) {
+    console.log('§HARNESS GridDrag.applyReplayedMove axis=' + axis + ' label=' + label + ' pos=' + pos + ' dir=' + dir); } };
+  // Minimal viewer-app stub: only what _restore/_applyOp/_cherryPick read.
+  window.A = { db: null, markDirty: function () {}, focusElement: function () {}, clearFocusElement: function () {} };
+  window._isMobile = false;
+  window.__ready = (async function () {
+    var SQL = await initSqlJs({ locateFile: function (f) { return '../lib/' + f; } });
+    window.A.db = new SQL.Database();
+    console.log('§HARNESS db-created');
+    return true;
+  })();
+</script>
+<!-- universal_history wraps KernelOps.commitOp at load (KernelOps already present) + reads window.A lazily. -->
+<script src="../universal_history.js"></script>
+</body></html>

--- a/viewer/tests/poc_cherry_pick.js
+++ b/viewer/tests/poc_cherry_pick.js
@@ -1,0 +1,102 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-module §-witness for HISTORY_PARALLEL_TIMELINE.md PR #6 — the MODEL cherry-pick half of
+//        cross-branch "bring into current ⤵" (the one piece that was WIRED but not live-witnessed).
+//   PROVES (issue: "a signed model op on a sibling branch can be grafted onto the current branch via the
+//            real kernel-op path, the chain still verifies, and BOTH universes stay intact — no 3-way merge"):
+//     1. commit GRID_MOVE op0 (fork base) + A1 (the op to graft) → A1 is a tip.
+//     2. fork: undo back to op0, commit B1 → a SECOND universe (A1 NOT wiped — fork-don't-wipe).
+//     3. standing on B, combineFromId(A1.seq) → §HIST_COMBINE mode=cherry-pick ok=true → KernelOps.commitOp
+//        replays A1's signed move onto B: kernel_ops gains exactly ONE row = A1's params, undone=0.
+//     4. verifyChain ok=true AFTER the graft (the replay is freshly signed + chained — tamper-evident).
+//     5. tips()==2 (A1 intact + the B-graft tip); the tree shows op0 forking into two universes.
+//   §-log first — READ tests/poc_cherry_pick.log before any conclusion (exit code is NOT evidence).
+// Run:  node viewer/tests/poc_cherry_pick.js 2>&1 | tee viewer/tests/poc_cherry_pick.log   (cwd = bim-ootb)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');   // bim-ootb root → ../lib + ../../common resolve
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.wasm':'application/wasm', '.css':'text/css' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  await page.goto(`http://localhost:${port}/viewer/tests/cherry_harness.html`, { waitUntil: 'networkidle' });
+  await page.evaluate(() => window.__ready);
+  await page.waitForTimeout(300);
+
+  const out = await page.evaluate(async () => {
+    const UH = window.UniversalHistory, KO = window.KernelOps, db = window.A.db;
+    const rows = () => { const r = db.exec("SELECT op_type, parameters, undone FROM kernel_ops ORDER BY id"); return r.length ? r[0].values : []; };
+    UH.setEnabled(true); UH.setDepth('max');
+
+    // 1. fork base op0 + A1 (the op we will graft)
+    KO.commitOp(db, 'GRID_MOVE', { axis: 'X', label: '1', from: 0, to: 1000, cascade: [] });
+    KO.commitOp(db, 'GRID_MOVE', { axis: 'X', label: '3', from: 1000, to: 3000, cascade: [] });
+    const a1seq = UH.tips()[0].id;                  // linear so far → A1 is the only tip
+
+    // 2. fork branch B: undo back to op0 (A1 must SURVIVE — fork-don't-wipe), then commit B1
+    UH.undo();
+    KO.commitOp(db, 'GRID_MOVE', { axis: 'Y', label: 'A', from: 0, to: 500, cascade: [] });
+    const tipsAfterFork = UH.tips().length;         // expect 2: A1 + B1
+    UH.dumpTree();
+
+    // 3. standing on B, bring A1 into current → MODEL cherry-pick
+    const rowsBefore = rows().length;
+    const found = UH.combineFromId(a1seq);
+    const after = rows();
+    const rowsDelta = after.length - rowsBefore;
+    const last = after[after.length - 1];           // [op_type, parameters, undone]
+    let lastTo = null; try { lastTo = JSON.parse(last[1]).to; } catch (e) {}
+
+    // 4. chain still verifies after the graft — seal THEN verify, exactly as the adapter's afterApply
+    //    (_chainCheck) does: commitOp's sealChain is async + the fork-undo flipped `undone`, so re-seal first.
+    await KO.sealChain(db);
+    const chain = await KO.verifyChain(db);
+    UH.dumpTree();
+    const tipsAfterGraft = UH.tips().length;        // expect 2: A1 (intact) + B-graft tip
+
+    return {
+      a1seq: a1seq, found: found, tipsAfterFork: tipsAfterFork, tipsAfterGraft: tipsAfterGraft,
+      rowsDelta: rowsDelta, lastType: last && last[0], lastTo: lastTo, lastUndone: last && last[2],
+      chainOk: !!(chain && chain.ok), chainLen: chain && chain.len, totalRows: after.length
+    };
+  });
+
+  const cherryLog = logs.filter(l => /§HIST_COMBINE mode=cherry-pick/.test(l)).join(' || ') || '(no cherry log)';
+  const treeLogs = logs.filter(l => /§PROOF tree=/.test(l));
+  console.log('§CHERRY combineLog=' + cherryLog);
+  treeLogs.forEach(t => console.log('§CHERRY ' + t));
+  console.log('§CHERRY-STATE ' + JSON.stringify(out));
+
+  const cherryOk = /ok=true/.test(cherryLog);
+  const graftLanded = out.rowsDelta === 1 && out.lastType === 'GRID_MOVE' && out.lastTo === 3000 && String(out.lastUndone) === '0';
+  const branchesIntact = out.tipsAfterFork === 2 && out.tipsAfterGraft === 2;
+  const forkedTree = treeLogs.some(t => /\|/.test(t));   // a '|' in the tree shape = a real fork (two universes)
+
+  const pass = out.found && cherryOk && graftLanded && branchesIntact && out.chainOk && forkedTree && errs.length === 0;
+  console.log('§CHERRY-RESULT ' + (pass ? 'PASS' : 'FAIL') +
+    ' found=' + out.found + ' cherryOk=' + cherryOk + ' graftLanded=' + graftLanded +
+    ' (rowsDelta=' + out.rowsDelta + ' lastTo=' + out.lastTo + ' undone=' + out.lastUndone + ')' +
+    ' branchesIntact=' + branchesIntact + ' chainOk=' + out.chainOk + ' forkedTree=' + forkedTree +
+    ' noErr=' + (errs.length ? errs.join('|') : true));
+
+  await browser.close();
+  server.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -171,8 +171,15 @@
     return 'search';
   }
 
+  // Per-building persisted-tree key (item 4): universes survive reload, scoped to THIS building's db.
+  function _treeKey() {
+    try { var db = new URLSearchParams(location.search).get('db') || 'default';
+      return 'bim.hist.tree.' + db.replace(/[^A-Za-z0-9_.-]/g, '_'); } catch (e) { return 'bim.hist.tree.default'; }
+  }
+
   // ── Wire the viewer onto the shared bar ───────────────────────────────
   HB.configure({
+    treeKey: _treeKey(),                    // §4 persist the branch tree per building
     source: 'viewer',
     mountHostId: 'status-bar-wrap',         // §3: dock under the status row
     profiles: PROFILES,
@@ -211,6 +218,8 @@
     setDepth: HB.setDepth, cycleDepth: HB.cycleDepth, getDepth: HB.getDepth,
     clear: HB.clear, open: HB.open, toggleOpen: HB.toggleOpen, list: HB.list,
     significant: function (ev) { return HB.significant(ev.source, ev.type, ev.label); },
+    // branch TREE (PR #5) — fork-don't-wipe universes + switch=restore.
+    switchToId: HB.switchToId, tips: HB.tips, dumpTree: HB.dumpTree, setTreeKey: HB.setTreeKey,
     PROFILES: PROFILES, SIGNIFICANCE: PROFILES.all, UNDOABLE_OPS: UNDOABLE_OPS
   };
   _wireTap();   // §-tap depth axis: provider + appliers + seed (no-op if history_tap.js absent)

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -14,19 +14,21 @@
 
   function _A() { return window.A || window.APP; }
 
-  // (c) Viewer significance profiles (§6 depth) — BLUE all / GREEN doc.
+  // (c) Viewer significance profiles — now the KNOB's 5-stop BREADTH ladder (§LOCKED-KNOB).
+  // Monotone low ⊂ mid ⊂ high ⊂ max, each stop adding ONE category:
+  //   low  = milestones only · mid = + reversible edits & saves (the clean trail) ·
+  //   high = + navigation views (DEFAULT) · max = + every selection/pick.
   var UNDOABLE_OPS = { 'GRID_MOVE': true, 'ELEMENT_PLACE': true };
+  var _EDITS = { 'BUILDING_OPEN': true, 'GRID_MOVE': true, 'ELEMENT_PLACE': true,
+                 'DESIGN_SAVE': true, 'DESIGN_OPEN': true, 'CAPTURE_4D': true, 'CLASH_SNAG': true };
+  var _NAV = { 'axis': true, 'group': true, 'item': true };
   var PROFILES = {
-    all: {
-      op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'ELEMENT_PICK': true, 'BUILDING_OPEN': true },
-      view: { 'axis': true, 'group': true, 'item': true }
-    },
-    doc: {
-      op:   { 'GRID_MOVE': true, 'ELEMENT_PLACE': true, 'BUILDING_OPEN': true,
-              'DESIGN_SAVE': true, 'DESIGN_OPEN': true, 'CAPTURE_4D': true, 'CLASH_SNAG': true },
-      view: {}
-    }
+    low:  { op: { 'BUILDING_OPEN': true }, view: {} },
+    mid:  { op: _EDITS, view: {} },
+    high: { op: _EDITS, view: _NAV },
+    max:  { op: Object.assign({ 'ELEMENT_PICK': true }, _EDITS), view: _NAV }
   };
+  PROFILES.all = PROFILES.high; PROFILES.doc = PROFILES.mid;   // legacy aliases (exported SIGNIFICANCE + _isDoc fallback)
 
   var _viewRestore = null; // navigate_find's view-restore callback
 

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -88,9 +88,33 @@
       _tapApply(entry.viewState, entry.label);   // re-apply the x-ray/bbox/camera this pick was taken under
       return;
     }
-    // view
-    if (_viewRestore) _viewRestore(entry.view);
-    _tapApply(entry.viewState, entry.label);     // …same for a Find/nav view entry
+    // view (Find/nav) OR combine (no Find view, just a stamped look) — only replay a Find view if present.
+    if (_viewRestore && entry.view) _viewRestore(entry.view);
+    _tapApply(entry.viewState, entry.label);
+  }
+
+  // (PR #6) Cross-branch COMBINE — bring a sibling universe's DISTINCTIVE view-fields into the current
+  // look. Delta = the fields the donor branch changed vs the fork point (so the current branch's own
+  // fields are kept); union via the proven combineViews, then apply. Result is a new tip on the current
+  // branch — A and B stay intact as universes. (color⊕section, the user's exact demo.)
+  function _combine(current, donor, ancestor) {
+    if (!window.HistoryTap) return null;
+    var Dv = donor && donor.viewState; if (!Dv) return null;
+    var Fv = (ancestor && ancestor.viewState) || {};
+    var delta = {};
+    for (var k in Dv) { if (JSON.stringify(Dv[k]) !== JSON.stringify(Fv[k])) delta[k] = Dv[k]; }   // donor's contribution only
+    var base = (current && current.viewState) || HistoryTap.currentView();
+    var combined = HistoryTap.combineViews(base, delta);
+    HistoryTap.applyView(combined, '⊕ ' + (donor.label || 'universe'));
+    console.log('§HIST_COMBINE_DELTA donor="' + (donor.label || '') + '" delta=' + Object.keys(delta).join(',') + ' → combined=' + Object.keys(combined).join(','));
+    return { viewState: combined, label: '⊕ ' + (donor.label || 'universe') };
+  }
+  // MODEL cherry-pick — replay the donor's signed op onto the current state (disjoint = clean; no 3-way).
+  function _cherryPick(donor) {
+    var A = _A();
+    if (!A || !A.db || !window.KernelOps || !donor || !UNDOABLE_OPS[donor.type]) return false;
+    try { KernelOps.commitOp(A.db, donor.type, donor.replay || donor.params || {}, (donor.params && donor.params.guids) || []); return true; }
+    catch (e) { console.warn('§HIST_CHERRY_ERR', e); return false; }
   }
 
   // ── §-tap bridge: stamp each entry with the ambient look, re-apply it on restore ──────
@@ -192,7 +216,9 @@
     iconFn: _stepIcon,
     sharedKey: 'bim.docHistory',            // §8 app-wide log (landing reads it)
     channel: 'bim_history',
-    docTypes: { 'BUILDING_OPEN': true }     // mirror only milestones to the shared log
+    docTypes: { 'BUILDING_OPEN': true },    // mirror only milestones to the shared log
+    combine: _combine,                      // §6 cross-branch VIEW combine (color⊕section)
+    cherryPick: _cherryPick                 // §6 model op replay (disjoint graft)
   });
 
   // commitOp wrapper — record EVERY model op as it lands.
@@ -220,8 +246,8 @@
     setDepth: HB.setDepth, cycleDepth: HB.cycleDepth, getDepth: HB.getDepth,
     clear: HB.clear, open: HB.open, toggleOpen: HB.toggleOpen, list: HB.list,
     significant: function (ev) { return HB.significant(ev.source, ev.type, ev.label); },
-    // branch TREE (PR #5) — fork-don't-wipe universes + switch=restore.
-    switchToId: HB.switchToId, tips: HB.tips, dumpTree: HB.dumpTree, setTreeKey: HB.setTreeKey,
+    // branch TREE (PR #5) + combine (PR #6) — fork-don't-wipe universes, switch=restore, bring-into-current.
+    switchToId: HB.switchToId, tips: HB.tips, dumpTree: HB.dumpTree, setTreeKey: HB.setTreeKey, combineFromId: HB.combineFromId,
     PROFILES: PROFILES, SIGNIFICANCE: PROFILES.all, UNDOABLE_OPS: UNDOABLE_OPS
   };
   _wireTap();   // §-tap depth axis: provider + appliers + seed (no-op if history_tap.js absent)


### PR DESCRIPTION
## What
Turns the **linear** undo timeline (`common/history_bar.js` `_stream[]`+`_cursor`) into a branching **TREE**. Going back in time and then acting no longer **truncates** the forward trail (the wipe) — it **forks** the abandoned tail as a sibling *universe*. The bar renders the siblings; clicking a branch tip walks the tree and re-applies its stamped view (**switch == restore down a different path**). Universes are persisted per building so they survive reload.

Implements `prompts/HISTORY_PARALLEL_TIMELINE.md` (master spec §LOCKED-BRANCH in `HISTORY_KNOB_SIGNAL_TAP.md`, build-order PR #5).

## How (minimal + reversible)
- **Tree model**: each entry node keeps `kids[]`+`active`+`parent`. The active line (`_stream`) and `cursor` are **derived** by `_rebuild()`, so all the existing UI/gate/coalesce code keeps working on the active line. `push/undo/redo/jumpTo` **signatures unchanged** (`scene.js`/`navigate_find.js`/`panels.js` untouched).
- **Fork-don't-wipe**: `push()` appends a new child + makes it active when the cursor node already has children, preserving the old subtree as a sibling (`§HIST_FORK`). A branch is a parent pointer, not a copy (~159 B/node).
- **Switch = restore**: `_switchToNode`/`switchToId` walk to a sibling tip via the common ancestor, re-applying each step's view. **VIEW restores, MODEL replays** — geometry is never snapshotted.
- **Siblings in the bar**: off-line fork children render as purple ⑂ ticks (dashed chips on bloom) → click switches.
- **Persist (item 4)**: `serialize()`/`hydrate()`/`setTreeKey()`; the viewer adapter derives a per-building key from `?db=`.

## Witness — whitebox §-log on live Hospital (`drive_fork.js` → `fork.log`)
```
§HIST_FORK parent="A-base" new="B-tip" kept-sibling="A-tip" universes=2
§PROOF tree=*A-base(A-tip | *B-tip) nodes=3 tips=2     ← both universes survive, NO wipe
switch→A: palette=22 section.on=true cut=9   switch→B: palette=0 section.on=false   ← both restore
§HIST_HYDRATE nodes=3 tips=2 tree=*A-base(A-tip | *B-tip)   ← serialize→clear→hydrate identical
DOM: "Universe ⑂ A-tip — click to switch" tick rendered + click fires switch
```
PASS = both universes exist + switching restores each (the §-lines are the evidence).

## Invariants honoured
- **No merge in the bar** — branch + switch only (cherry-pick/combine is PR #6; true conflict-merge stays the substrate's job).
- **Shared-bar caution** — viewer-scoped; ERP runs its own `idmp_history.js`. push/undo/redo/jumpTo signatures intact.

> Stacked on `feat/history-field-sniffer` (#213). Rebase onto `main` once #207→#213 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)