### PR TITLE
test(whole-history): fix stale poc_whole_bar_dom selector (.whole-row → .whole-chip)

### DIFF
--- a/tests/poc_whole_bar_dom.js
+++ b/tests/poc_whole_bar_dom.js
@@ -30,9 +30,9 @@ const { spawn } = require('child_process');
       const launch = !!document.getElementById('whole-hist-launch');
       WH.setMode('whole'); WH.open();
       const panelShown = document.getElementById('whole-hist-panel').classList.contains('show');
-      const rowsWhole = document.querySelectorAll('#whole-hist-body .whole-row').length;
+      const rowsWhole = document.querySelectorAll('#whole-hist-body .whole-chip').length;
       // a foreign row (glassbowl) — find it by its badge text
-      const rows = Array.prototype.slice.call(document.querySelectorAll('#whole-hist-body .whole-row'));
+      const rows = Array.prototype.slice.call(document.querySelectorAll('#whole-hist-body .whole-chip'));
       const gRow = rows.find(r => /Glassbowl/.test(r.textContent));
       // stub navigation so the click doesn't actually leave the page
       try { Object.defineProperty(window, 'location', { value: { href: '' }, writable: true }); } catch (e) {}
@@ -40,7 +40,7 @@ const { spawn } = require('child_process');
       const handoff = JSON.parse(localStorage.getItem('bim.wholeRestore') || 'null');
       // THIS-page filter
       WH.setMode('this');
-      const rowsThis = document.querySelectorAll('#whole-hist-body .whole-row').length;
+      const rowsThis = document.querySelectorAll('#whole-hist-body .whole-chip').length;
       return { launch, panelShown, rowsWhole, rowsThis, handoff };
     });
     console.log('DOM result: ' + JSON.stringify(r));


### PR DESCRIPTION
## What
The DOM wiring witness `tests/poc_whole_bar_dom.js` was failing (`rowsWhole=0 → FAIL`) but the product works — verified live on mobile (clock launcher → WHOLE|THIS preview → pick).

**Root cause: test drift.** The W3 day-scroller (`HISTORY_WHOLE_TIMELINE.md`) changed the aggregate render from flat `.whole-row`s to a day-axis of `.whole-chip` entries. The test still queried the old `.whole-row` class → 0 matches → false failure. No product regression.

## Fix
Selector-only (`.whole-row` → `.whole-chip`, 3 sites). Now:
`§WHOLE-BAR-DOM launcher=true panel=true rowsWhole=4 rowsThis=1 foreignHandoff=ok => PASS`

No product code touched. Surfaced while verifying the KNOB-DIAL work (#230) — it was a pre-existing false failure, not caused by that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)