### PR TITLE
fix(erp-globe): kill the double bubble-burst on first erp.html load

### DIFF
--- a/erp/ad_graph.js
+++ b/erp/ad_graph.js
@@ -1742,6 +1742,34 @@
     }
   }
 
+  /**
+   * §INSTANT — in-place canvas resize. Rescales the existing globe to the new
+   * canvas size WITHOUT destroy()+re-init, so the entry animation (or current
+   * drill view) continues uninterrupted instead of bursting a second time.
+   * The canvas element is reused by the caller (only width/height change), so
+   * _ctx, listeners and the _animate loop stay valid — we only update geometry.
+   */
+  function resize(w, h) {
+    if (!_canvas) return;
+    var oldRadius = _radius || 1;
+    _W = w; _H = h;
+    _cx = _W / 2;
+    _cy = _H / 2;
+    _radius = Math.min(_W, _H) * 0.38;
+    var ratio = _radius / oldRadius;
+    // Rescale home/target/start/current positions by the radius ratio — keeps any
+    // in-flight animation proportional (nodes animating out from origin keep going).
+    for (var i = 0; i < _nodes.length; i++) {
+      var n = _nodes[i];
+      if (n.sx !== undefined) { n.sx *= ratio; n.sy *= ratio; n.sz *= ratio; }
+      if (n.homeSx !== undefined) { n.homeSx *= ratio; n.homeSy *= ratio; n.homeSz *= ratio; }
+      if (n._targetSx !== undefined) { n._targetSx *= ratio; n._targetSy *= ratio; n._targetSz *= ratio; }
+      if (n._startSx !== undefined) { n._startSx *= ratio; n._startSy *= ratio; n._startSz *= ratio; }
+    }
+    console.log('§AD_GRAPH resize w=' + _W + ' h=' + _H + ' radius=' + Math.round(_radius) +
+                ' nodes=' + _nodes.length + ' (in-place, no re-init)');
+  }
+
   function destroy() {
     if (_animId) { cancelAnimationFrame(_animId); _animId = null; }
     if (_canvas) {
@@ -1855,6 +1883,7 @@
     init: init,
     initFromBubbles: initFromBubbles,
     graphHydrate: graphHydrate,
+    resize: resize,
     destroy: destroy,
     showEntity: showEntity,
     focusNode: focusNode,

--- a/erp/ad_ui.js
+++ b/erp/ad_ui.js
@@ -1504,17 +1504,23 @@
         fsBtn.style.height = '28px';
         fsBtn.style.fontSize = '16px';
       }
-      ADGraph.destroy();
-      // §INSTANT — keep the curated skeleton authoritative even after _dbReady;
-      // graphHydrate(db) already enabled drill, so DON'T rebuild from _buildHomeNodes (no flash/reset).
-      if (typeof INIT_BUBBLES !== 'undefined' && ADGraph.initFromBubbles) {
-        ADGraph.initFromBubbles(canvas, INIT_BUBBLES, _currentClient,
-          _graphDrillCallback, _graphLongPressCallback, _toggleSearchOverlay);
-        // initFromBubbles resets the graph's _db to null; re-attach so tap-drill still queries records.
-        if (_dbReady && _db && ADGraph.graphHydrate) ADGraph.graphHydrate(_db);
+      // §INSTANT — resize the EXISTING globe in place (no destroy()+re-init). The
+      // canvas element is reused (only width/height changed above), so the animation
+      // loop, listeners and drill state survive — this kills the second "bubble burst"
+      // the 100ms auto-maximize used to cause by tearing the graph down and rebuilding.
+      if (ADGraph.resize) {
+        ADGraph.resize(canvas.width, canvas.height);
       } else {
-        ADGraph.init(canvas, _db, _currentClient,
-          _graphDrillCallback, _graphLongPressCallback, _toggleSearchOverlay);
+        // Legacy fallback: full rebuild (keeps the curated skeleton authoritative).
+        ADGraph.destroy();
+        if (typeof INIT_BUBBLES !== 'undefined' && ADGraph.initFromBubbles) {
+          ADGraph.initFromBubbles(canvas, INIT_BUBBLES, _currentClient,
+            _graphDrillCallback, _graphLongPressCallback, _toggleSearchOverlay);
+          if (_dbReady && _db && ADGraph.graphHydrate) ADGraph.graphHydrate(_db);
+        } else {
+          ADGraph.init(canvas, _db, _currentClient,
+            _graphDrillCallback, _graphLongPressCallback, _toggleSearchOverlay);
+        }
       }
       console.log('§AD_UI graphFullscreen=' + fullscreen +
         ' w=' + canvas.width + ' h=' + canvas.height);

--- a/erp/tests/poc_single_burst.js
+++ b/erp/tests/poc_single_burst.js
@@ -1,0 +1,63 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness proving the ERP init-bubble globe BURSTS ONCE on first erp.html load.
+//   ISSUE: on first load the constellation appeared, then ~100ms later the auto-maximize
+//   (_renderHomeGraph → setTimeout(_resizeGraph(true),100)) called ADGraph.destroy()+re-init,
+//   tearing the globe down and REBUILDING it at fullscreen size — a visible SECOND "bubble burst".
+//   FIX (ad_graph.js resize() + ad_ui.js _resizeGraph): the auto-maximize now resizes the existing
+//   globe IN PLACE (no destroy, no re-init), so the entry animation runs once.
+//   PROVES/DISPROVES: "the initial bubble burst happens twice when first calling erp.html."
+//   The number is the proof — READ tests/poc_single_burst.log, not a screenshot.
+//   Counts, over the WHOLE first load incl. the 100ms auto-maximize:
+//     builds   = §AD_GRAPH init + §AD_GRAPH initFromBubbles  (each = one full constellation build/burst)
+//     destroys = §AD_GRAPH destroy
+//     resizes  = §AD_GRAPH resize  (the in-place path the auto-maximize must now take)
+//     fullscreen = §AD_UI graphFullscreen=true  (the auto-maximize still happened)
+//   PASS = builds==1 AND destroys==0 AND resizes>=1 AND fullscreen seen AND no page errors.
+//   (Before the fix: builds==2, destroys==1 → FAIL, exactly the double burst.)
+// Run:  node tests/poc_single_burst.js 2>&1 | tee tests/poc_single_burst.log   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(__dirname + '/../../tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png' };
+
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/erp.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404'); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await chromium.launch();
+  const ctx = await br.newContext();
+  const pg = await ctx.newPage();
+
+  const errs = [];
+  let builds = 0, destroys = 0, resizes = 0, fullscreen = 0;
+  const trail = [];
+  pg.on('pageerror', e => errs.push(e.message));
+  pg.on('console', msg => {
+    const t = msg.text();
+    if (t.indexOf('§AD_GRAPH initFromBubbles') === 0 || t.indexOf('§AD_GRAPH init client=') === 0) { builds++; trail.push('build'); }
+    else if (t.indexOf('§AD_GRAPH destroy') === 0) { destroys++; trail.push('destroy'); }
+    else if (t.indexOf('§AD_GRAPH resize') === 0) { resizes++; trail.push('resize'); }
+    else if (t.indexOf('§AD_UI graphFullscreen=true') === 0) { fullscreen++; trail.push('fullscreen'); }
+  });
+
+  await pg.goto(`http://localhost:${port}/erp.html`, { waitUntil: 'commit' });
+  // Wait until DB-ready hydrate AND the 100ms auto-maximize have both fired (graphFullscreen=true),
+  // then a settle margin so any stray rebuild would be counted.
+  await pg.waitForFunction(() => window.__sawFullscreen === true || true, { timeout: 20000 }).catch(() => {});
+  await pg.waitForTimeout(3500);
+
+  await pg.close(); await ctx.close(); await br.close(); server.close();
+
+  console.log(`§SINGLE-BURST builds=${builds} destroys=${destroys} resizes=${resizes} fullscreen=${fullscreen} trail=[${trail.join(',')}] pageErrors=${errs.length ? errs.join('|') : 0}`);
+  const pass = builds === 1 && destroys === 0 && resizes >= 1 && fullscreen >= 1 && errs.length === 0;
+  console.log('§SINGLE-BURST-RESULT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — first erp.html load builds the globe ' + builds + 'x (want 1), destroys ' + destroys + 'x (want 0); auto-maximize resizes in place ' + resizes + 'x');
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('FATAL ' + e.message); process.exit(2); });


### PR DESCRIPTION
## Problem
On first `erp.html` load the init globe **bursts twice**: it builds once at panel size, then ~100ms later the auto-maximize (`_renderHomeGraph` → `setTimeout(_resizeGraph(true), 100)`) calls `ADGraph.destroy()` + re-init, tearing the constellation down and rebuilding it at fullscreen size.

User log tail showed: `§AD_GRAPH destroy` → `initFromBubbles` → `hydrated` → `graphFullscreen=true` — a full second build.

## Fix
- **ad_graph.js** — new `resize(w,h)`: rescales the existing globe's geometry (home/target/start/current node positions) by the radius ratio **in place**. The canvas element is reused (only width/height change), so `_ctx`, listeners and the `_animate` loop survive — no teardown, no re-burst.
- **ad_ui.js `_resizeGraph`** — take the `resize()` path instead of `destroy()`+re-init (legacy rebuild kept as fallback). Bonus: a mid-drill fullscreen toggle no longer resets to home view.

## Witness — `erp/tests/poc_single_burst.js` (W-SINGLE-BURST)
Counts globe builds vs teardowns across the whole first load:
- **unfixed:** `builds=2 destroys=1` → FAIL (the double burst)
- **fixed:** `builds=1 destroys=0 resizes=1` → PASS

`poc_init_instant.js` still PASS (warm first paint = 56ms, db deferred — no first-paint regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)