### PR TITLE
test(doc-dots): fix stale funnel-site count 5→4 (§Z-1 witness)

### DIFF
--- a/erp/tests/poc_doc_dots.js
+++ b/erp/tests/poc_doc_dots.js
@@ -49,7 +49,7 @@ ok(Object.keys(one.changes).length === 1 && CORE.docLabel(one) === 'Save c_order
 // 3. funnel wiring (structural, against the shipped source)
 var src = fs.readFileSync(path.join(__dirname, '../crud_overlay.js'), 'utf8');
 var calls = (src.match(/docDot\(CORE\.docLabel\(/g) || []).length;
-ok(calls === 5, 'docDot(CORE.docLabel(…)) wired at exactly the 5 funnel sites (3 CRUD + committed + dry): ' + calls);
+ok(calls === 4, 'docDot(CORE.docLabel(…)) wired at exactly the 4 funnel sites (dry+committed DOC_ACTION, dry+committed CRUD — 3 types share commitCrud/dryCrud since c84211d): ' + calls);
 ok(/docDot\(CORE\.docLabel\(op, fname\(op\.key\)\) \+ ' \(dry\)', op\)/.test(src), 'dry fallback marks the dot " (dry)" and passes op (§A-GRAIL)');
 ok(!/addEventListener\(['"](input|keydown|keyup)['"][\s\S]{0,200}docDot/.test(src), 'no input/key handler reaches docDot (commit boundary only)');
 ok(/function docDot\(label, op\) \{ try \{ if \(typeof global\.recordDocMoment === 'function'\)/.test(src), 'docDot(label,op) delegates to the page recordDocMoment (typeof-guarded)');


### PR DESCRIPTION
## Summary
- `poc_doc_dots.js` was asserting exactly 5 `docDot(CORE.docLabel(…))` call sites, but `c84211d` (CRUD_EDIT_PERSIST, signed sidecar) consolidated the 3 per-CRUD-type sites into shared `commitCrud`/`dryCrud` → 4 sites now cover the same commit boundaries.
- No recording gap: all 4 paths (dry+committed DOC_ACTION, dry+committed CRUD) still fire one dot per committed gesture.

## §Z-1 witness results
- **W-Z-EVENTS** (headless): ALL PASS (14/14)
- **W-HIST-SESSION** (browser, Duplex): ALL PASS — BUILDING_OPEN dot recorded, section toggle records `kind=event` dot, scrub mints no new dot, re-home logs `reHome=true`
- **§IDMP-HIST** (browser, idempiere): PASS — pushes=4 dots=4, bloom=true, restore readOnly=Y, zero mutations, zero page errors
- **W-DOC-DOTS** (headless): ALL PASS after count update

🤖 Generated with [Claude Code](https://claude.com/claude-code)