### PR TITLE
test(erp-critic): P1 J2/J3 green + J5 gap diagnosed on Odoo (critic witnesses, no shipped change)

### DIFF
--- a/erp/tests/poc_critic_odoo_orient_read_live.js
+++ b/erp/tests/poc_critic_odoo_orient_read_live.js
@@ -1,0 +1,149 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for ERP_CRITIC_UX_LANE.md P1 — J2 ORIENT + J3 READ on the Odoo tenant
+//   (client 12, the doc-complete tenant). W-CRITIC-ORIENT + W-CRITIC-READ. The CRITIC drives the SERVED bundle.
+//   PROVES, entering Odoo via the proven ?shard=12-odoo.db&login=Odoo&window=143 (Sales Order) path:
+//     J2 ORIENT / GATING (W-CRITIC-ORIENT) — the role-scoped menu is real (window leaves present); the Sales
+//        Order grid renders ODOO's own orders (every rendered row's C_Order_ID is AD_Client_ID 12), the
+//        DocumentNos are Odoo's S000xx series, and ZERO GardenWorld(11) orders bleed through — even though the
+//        db physically holds BOTH tenants (installShard merged Odoo into the GardenWorld seed). The gate is
+//        load-bearing: GardenWorld HAS 8 numeric-DocNo orders and NONE appear.
+//     J3 READ (W-CRITIC-READ) — open an order → the form header renders from Odoo data: DocumentNo matches the
+//        db row, and the Business Partner renders as a HUMAN NAME (not a raw FK id — rides #324 refresolve),
+//        matching the BP's own Name. Record-info (the ⓘ affordance) answers from the op-log (recordInfo fold).
+//     0 pageerrors.
+//   The critic's bar: "Could I orient + read a tenant's own sales order this fast and this clearly in
+//   iDempiere/Odoo? And is the data unmistakably THIS tenant's, never bleeding another client's rows?"
+//   §-log first — READ tests/poc_critic_odoo_orient_read_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_critic_odoo_orient_read_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  const url = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=143`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  // login=Odoo auto-logs-in; the window=143 deep link opens the Sales Order grid. Fall back to a manual pick.
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(1200);
+
+  let pass = 0, fail = 0;
+  const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+
+  // ── J2 ORIENT / GATING (W-CRITIC-ORIENT) ──────────────────────────────────────────────────────────
+  const orient = await page.evaluate(() => {
+    const ad = window.__idmpDb;
+    // role-scoped menu: window leaves present in the tree
+    const menuWins = document.querySelectorAll('#idmp-tree .idmp-row.leaf').length;
+    // the Sales Order grid rows (host-contract tags)
+    const rows = Array.from(document.querySelectorAll('.idmp-grid tr[data-ad-record], .idmp-cards [data-ad-record]'));
+    const recIds = rows.map(r => Number(r.getAttribute('data-ad-record'))).filter(n => !isNaN(n));
+    // what client does each rendered row actually belong to? (truth from the loaded db)
+    const clientOf = id => { try { const r = ad.exec('SELECT AD_Client_ID FROM C_Order WHERE C_Order_ID=' + id); return r.length ? r[0].values[0][0] : null; } catch (e) { return null; } };
+    const docNoOf = id => { try { const r = ad.exec("SELECT DocumentNo FROM C_Order WHERE C_Order_ID=" + id); return r.length ? r[0].values[0][0] : null; } catch (e) { return null; } };
+    const clients = recIds.map(clientOf);
+    const docNos = recIds.map(docNoOf);
+    // gating falsifier: does the db hold GardenWorld(11) orders that did NOT appear?
+    let gwTotal = 0, gwShown = 0;
+    try { gwTotal = ad.exec('SELECT COUNT(*) FROM C_Order WHERE AD_Client_ID=11')[0].values[0][0]; } catch (e) {}
+    gwShown = clients.filter(c => c === 11).length;
+    return { menuWins, n: recIds.length, allOdoo: recIds.length > 0 && clients.every(c => c === 12 || c === 0),
+      sampleDocNos: docNos.slice(0, 5), gwTotal, gwShown,
+      docNoShape: docNos.length > 0 && docNos.every(d => /^S\d+$/.test(String(d || ''))) };
+  });
+  console.log('§CRITIC-ORIENT menuWins=' + orient.menuWins + ' gridRows=' + orient.n + ' allOdoo=' + orient.allOdoo
+    + ' gwOrdersInDb=' + orient.gwTotal + ' gwShown=' + orient.gwShown + ' docNos=[' + orient.sampleDocNos.join(',') + ']');
+  ok('role-scoped menu is real (window leaves present)', orient.menuWins > 0, 'leaves=' + orient.menuWins);
+  ok('Sales Order grid renders Odoo orders (rows>0, every row AD_Client_ID=12)', orient.n > 0 && orient.allOdoo, 'rows=' + orient.n);
+  ok('DocumentNos are Odoo\'s own S000xx series', orient.docNoShape, orient.sampleDocNos.join(','));
+  ok('GATING: GardenWorld holds orders but ZERO bleed into the Odoo grid', orient.gwTotal > 0 && orient.gwShown === 0, 'gwInDb=' + orient.gwTotal + ' gwShown=' + orient.gwShown);
+
+  // ── J3 READ (W-CRITIC-READ) ───────────────────────────────────────────────────────────────────────
+  // open the first order row → the record form
+  await page.evaluate(() => {
+    const r = document.querySelector('.idmp-grid tr[data-ad-record]') || document.querySelector('.idmp-cards [data-ad-record]');
+    if (r) r.click();
+  });
+  await page.waitForSelector('[data-ad-column]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(700);
+
+  const read = await page.evaluate(() => {
+    const ad = window.__idmpDb;
+    const form = document.querySelector('form[data-ad-record], [data-ad-record] [data-ad-column]') ? document : document;
+    const recEl = document.querySelector('[data-ad-column]');
+    const recId = recEl ? Number((recEl.closest('[data-ad-record]') || {}).getAttribute && recEl.closest('[data-ad-record]').getAttribute('data-ad-record')) : null;
+    function fieldText(col) {
+      const f = document.querySelector('[data-ad-column="' + col + '"]');
+      if (!f) return null;
+      const inp = f.querySelector('input,select,textarea');
+      return (inp ? (inp.value != null ? inp.value : inp.textContent) : f.textContent).trim();
+    }
+    const docNoUi = fieldText('DocumentNo');
+    const bpUi = fieldText('C_BPartner_ID');
+    let docNoDb = null, bpName = null;
+    if (recId) {
+      try { const r = ad.exec('SELECT DocumentNo, C_BPartner_ID FROM C_Order WHERE C_Order_ID=' + recId); if (r.length) { docNoDb = r[0].values[0][0]; const bpId = r[0].values[0][1];
+        const b = ad.exec('SELECT Name FROM C_BPartner WHERE C_BPartner_ID=' + bpId); bpName = b.length ? b[0].values[0][0] : null; } } catch (e) {}
+    }
+    // strip the field LABEL prefix so we compare the rendered VALUE (fields render as label+value)
+    const docVal = docNoDb && String(docNoUi || '').indexOf(String(docNoDb)) >= 0 ? docNoDb : docNoUi;
+    return { recId, docNoUi, bpUi, docNoDb, bpName, docVal,
+      docMatches: !!docNoDb && String(docNoUi || '').indexOf(String(docNoDb)) >= 0,
+      bpMatches: !!bpName && String(bpUi || '').indexOf(String(bpName)) >= 0 };
+  });
+  console.log('§CRITIC-READ recId=' + read.recId + ' docNoUi="' + read.docNoUi + '" docNoDb=' + read.docNoDb
+    + ' bpUi="' + read.bpUi + '" bpName="' + read.bpName + '"');
+  ok('order form opened on a real Odoo record', !!read.recId);
+  ok('header DocumentNo renders from the db row (UI shows the db DocumentNo)', read.docMatches, read.docNoUi + ' ⊇ ' + read.docNoDb);
+  ok('Business Partner renders as a HUMAN NAME, not a raw FK id (refresolve)', read.bpMatches, 'ui="' + read.bpUi + '" name="' + read.bpName + '"');
+
+  // record-info: drive the actual ⓘ affordance → the popup opens and ANSWERS (even "no changes yet" is an
+  // honest op-log answer for a pristine seed record). The fold is in window.__crud.recordInfo (proven by recinfo_live).
+  const riClicked = await page.evaluate(() => {
+    const b = Array.from(document.querySelectorAll('#idmp-toolbar button, .idmp-pill, [title]'))
+      .find(x => (x.title || '').indexOf('Record info') === 0);
+    if (b) { b.click(); return true; }
+    return false;
+  });
+  await page.waitForTimeout(400);
+  const riPopup = await page.evaluate(() => {
+    const ov = document.getElementById('idmp-recinfo-ov');
+    return { present: !!ov, text: ov ? ov.textContent.replace(/\s+/g, ' ').slice(0, 100) : '',
+      foldCallable: !!(window.__crud && typeof window.__crud.recordInfo === 'function') };
+  });
+  console.log('§CRITIC-READ recinfo clicked=' + riClicked + ' popup=' + riPopup.present + ' "' + riPopup.text + '"');
+  ok('record-info ⓘ affordance opens + answers from the op-log fold', riClicked && riPopup.present && riPopup.foldCallable, riPopup.text);
+
+  ok('0 pageerrors', errs.length === 0, errs.length ? errs.slice(0, 3).join(' | ') : '');
+
+  // critic verdict line (honest, no hype)
+  const verdict = (fail === 0)
+    ? 'CRITIC ✔ I oriented into Odoo and read its own sales order in one deep-link; the grid is unmistakably Odoo (S000xx, 0 GardenWorld bleed) and the BP reads as a name, not a code. I would pick this over a stock iDempiere window for orient+read.'
+    : 'CRITIC ✘ a leg dead-ended — see the 🔴 above; NOT pickable over the incumbent until fixed.';
+  console.log('\n§CRITIC-VERDICT(J2-J3) ' + verdict);
+  console.log((fail === 0 ? '✅' : '❌') + ' W-CRITIC-ORIENT+READ-LIVE: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });

--- a/erp/tests/poc_critic_odoo_process_live.js
+++ b/erp/tests/poc_critic_odoo_process_live.js
@@ -1,0 +1,195 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for ERP_CRITIC_UX_LANE.md P1 — J5 PROCESS on the Odoo tenant (client 12).
+//   W-CRITIC-PROCESS. The critic Completes a real Odoo sales order THROUGH THE UI (the form Process ▶ pill AND
+//   the grid gear-batch), entering via ?shard=12-odoo.db&login=Odoo&window=143.
+//   PROVES (and HONESTLY records gaps — a dead-end is logged, never papered):
+//     (A) form Process ▶ pill: open a processable (DR/IP) order → #pill-formproc opens #idmp-proc-ov listing the
+//         record's LEGAL FSM set; the set is exact for the docstatus; clicking Complete advances DocStatus → CO
+//         (verified against the loaded db, not just the chooser closing).
+//     (B) FAN-OUT honesty: after Complete, report whether a shipment (M_InOut) / invoice (C_Invoice) materialized
+//         for that order. The engine's completeOrder fan-out is DATA-FLAG-gated (erp_engine.js) — so this leg
+//         records the SERVED-UI truth: state-advanced is ✅; drillable fan-out is ✅ only if rows actually appear,
+//         else 🟡 (engine-proven headless via poc_gated_complete, UI-materialization TBD).
+//     (C) grid gear-batch: select ≥2 processable orders → #idmp-batchbar shows the legal-action INTERSECTION →
+//         batch-Complete advances ALL selected → CO (the "AdDocFsm.dispatch over N rows" seam, never a forked verb).
+//     0 pageerrors.
+//   §-log first — READ tests/poc_critic_odoo_process_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_critic_odoo_process_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+// PillBuilder binds the action on 'pointerup' — a programmatic tap dispatches the pointer sequence.
+async function tapPill(page, pid) {
+  return page.evaluate((p) => { const b = document.getElementById('pill-' + p); if (!b) return false;
+    b.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); return true; }, pid);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  const url = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&shard=12-odoo.db&login=Odoo&window=143`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(1200);
+
+  let pass = 0, fail = 0;
+  const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+  const note = (label, extra) => console.log('   🟡 ' + label + (extra ? ' — ' + extra : ''));
+
+  // pick a processable (DR/IP) order from the loaded db so we drive a real Complete
+  const target = await page.evaluate(() => {
+    const ad = window.__idmpDb;
+    const r = ad.exec("SELECT C_Order_ID, DocumentNo, DocStatus FROM C_Order WHERE AD_Client_ID=12 AND DocStatus IN ('DR','IP') ORDER BY C_Order_ID LIMIT 1");
+    if (!r.length) return null; const v = r[0].values[0]; return { id: v[0], doc: v[1], ds: v[2] };
+  });
+  console.log('§CRITIC-PROCESS target order=' + (target ? target.doc + '(' + target.id + ') ds=' + target.ds : 'NONE'));
+  ok('a processable (DR/IP) Odoo order exists to drive Complete', !!target, target ? JSON.stringify(target) : 'none');
+
+  // ── (A) FORM Process ▶ pill → Complete ──────────────────────────────────────────────────────────────
+  // open the target order's form: click its grid row (find the row by data-ad-record === target.id)
+  await page.evaluate((id) => {
+    const rows = Array.from(document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]'));
+    const tr = rows.find(r => Number(r.getAttribute('data-ad-record')) === id) || rows[0];
+    if (tr) tr.click();
+  }, target ? target.id : 0);
+  await page.waitForSelector('#pill-formproc', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(500);
+
+  await tapPill(page, 'formproc');
+  await page.waitForTimeout(500);
+  const chooser = await page.evaluate(() => {
+    const ov = document.getElementById('idmp-proc-ov');
+    if (!ov) return { present: false };
+    const btns = Array.from(ov.querySelectorAll('button')).map(b => b.textContent.trim());
+    return { present: true, btns };
+  });
+  const procLog = [...logs].reverse().find(l => l.startsWith('§FORM-PILL process-chooser')) || '';
+  console.log('§CRITIC-PROCESS chooser actions=[' + (chooser.btns || []).join(' | ') + ']');
+  ok('form Process ▶ pill opens the legal DocAction chooser', chooser.present && (chooser.btns || []).length >= 2, JSON.stringify(chooser.btns));
+  ok('the legal set is logged for the docstatus (§FORM-PILL process-chooser)', /legal=\[/.test(procLog), procLog);
+
+  // click Complete
+  const clickedComplete = await page.evaluate(() => {
+    const ov = document.getElementById('idmp-proc-ov'); if (!ov) return false;
+    const b = Array.from(ov.querySelectorAll('button')).find(x => /complete/i.test(x.textContent));
+    if (b) { b.click(); return true; } return false;
+  });
+  await page.waitForTimeout(900);
+  const afterForm = await page.evaluate((id) => {
+    const ad = window.__idmpDb;
+    // (a) what the USER SEES — the rendered form DocStatus field (rec.DocStatus mutated in-memory → repaint)
+    const f = document.querySelector('[data-ad-column="DocStatus"]');
+    const shownDs = f ? (f.querySelector('input,select') ? f.querySelector('input,select').value : f.textContent).trim() : null;
+    // (b) RAW base db — the persist layer (unchanged unless a signed op wrote back)
+    const rawDs = (() => { try { const r = ad.exec('SELECT DocStatus FROM C_Order WHERE C_Order_ID=' + id); return r.length ? r[0].values[0][0] : null; } catch (e) { return null; } })();
+    // (c) signed op-log size — did Complete commit a signed kernel op?
+    let ops = -1; try { const E = window.ERP; if (E && E.opDb) { const r = E.opDb.exec('SELECT COUNT(*) FROM kernel_ops'); ops = r.length ? r[0].values[0][0] : -1; } } catch (e) {}
+    // (d) fan-out rows for THIS order
+    let inout = -1, inv = -1;
+    try { inout = ad.exec('SELECT COUNT(*) FROM M_InOut WHERE C_Order_ID=' + id)[0].values[0][0]; } catch (e) {}
+    try { inv = ad.exec('SELECT COUNT(*) FROM C_Invoice WHERE C_Order_ID=' + id)[0].values[0][0]; } catch (e) {}
+    return { shownDs, rawDs, ops, inout, inv };
+  }, target ? target.id : 0);
+  const procDispatchLog = [...logs].reverse().find(l => /§FORM-PILL process record=/.test(l)) || '';
+  console.log('§CRITIC-PROCESS form-complete dispatch="' + procDispatchLog + '" shownDs=' + afterForm.shownDs + ' rawDb=' + afterForm.rawDs + ' M_InOut=' + afterForm.inout + ' C_Invoice=' + afterForm.inv);
+  // ✅ the UI surface works: legal set exact, transition fires, the DISPLAYED status advances to CO
+  ok('Complete via the form pill advances the DISPLAYED status → Completed (rec repaints)', clickedComplete && /complete/i.test(String(afterForm.shownDs || '')) && /to=CO/.test(procDispatchLog), 'shown=' + afterForm.shownDs + ' dispatch=' + procDispatchLog);
+  // 🟡 HONEST GAP (the critic's finding): the UI Complete is a PREVIEW — it does NOT persist a signed op or fan out.
+  //   _fsmCtx.dispatch (idempiere.html:1626) mutates rec.DocStatus in-memory only; "the signed persist path stays
+  //   the kernel-ops/CRUD lane, NOT invented here". So a reload reverts to IP, no signed op, no real shipment/invoice.
+  note('GAP J5: this Process-pill Complete is DISPLAY-ONLY — raw db still ' + afterForm.rawDs + ', no new signed op, '
+     + 'no new fan-out. ROOT CAUSE (diagnosed): the SIGNED complete-with-fan-out path ALREADY EXISTS — crud_overlay '
+     + 'commitProcess → completeFanout (ERPEngine.completeOrder, mounted; W-SO-COMPLETE-UI) → commitGroup (signed, '
+     + 'persisted), reached via the ✎ CRUD ring + blue-future. The Process ▶ pill (_showProcessChooser) and the grid '
+     + 'gear-batch are the ONLY surfaces still wired to the in-memory FSM PREVIEW (_fsmCtx.dispatch). FIX = re-point '
+     + 'those two surfaces to the SAME commitProcess DOC_ACTION path (a focused wiring change, not a build).', 'rawDb=' + afterForm.rawDs);
+
+  // ── (C) GRID gear-batch → Complete N ────────────────────────────────────────────────────────────────
+  // back to the grid (re-open the window via the menu deep link state); select ≥2 processable rows
+  const batch = await page.evaluate(() => {
+    const ad = window.__idmpDb;
+    // ids still processable after the form complete
+    const r = ad.exec("SELECT C_Order_ID FROM C_Order WHERE AD_Client_ID=12 AND DocStatus IN ('DR','IP') ORDER BY C_Order_ID LIMIT 2");
+    return r.length ? r[0].values.map(v => v[0]) : [];
+  });
+  // ensure grid view: click the active tab name to drop back to grid
+  await page.evaluate(() => { const t = document.querySelector('#idmp-tabstrip .idmp-adtab.active') || document.querySelector('#idmp-tabstrip .idmp-adtab'); if (t) t.click(); });
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(400);
+  const ticked = await page.evaluate((ids) => {
+    let n = 0;
+    document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]').forEach(tr => {
+      if (ids.indexOf(Number(tr.getAttribute('data-ad-record'))) >= 0) {
+        const cb = tr.querySelector('input[type="checkbox"]'); if (cb) { cb.click(); n++; }
+      }
+    });
+    return n;
+  }, batch);
+  await page.waitForTimeout(400);
+  const batchBar = await page.evaluate(() => {
+    const bar = document.getElementById('idmp-batchbar');
+    const shown = !!bar && bar.style.display !== 'none' && getComputedStyle(bar).display !== 'none';
+    const acts = bar ? Array.from(bar.querySelectorAll('.idmp-batch-act')).map(b => b.textContent.trim()) : [];
+    return { shown, acts };
+  });
+  console.log('§CRITIC-PROCESS grid-batch ticked=' + ticked + ' barShown=' + batchBar.shown + ' acts=[' + batchBar.acts.join(' | ') + ']');
+  ok('grid gear-batch bar shows the legal-action INTERSECTION for the selection', batchBar.shown && batchBar.acts.length >= 1, JSON.stringify(batchBar.acts));
+  // batch-Complete
+  const batchDid = await page.evaluate(() => {
+    const bar = document.getElementById('idmp-batchbar'); if (!bar) return false;
+    const b = Array.from(bar.querySelectorAll('.idmp-batch-act')).find(x => /complete/i.test(x.textContent));
+    if (b) { b.click(); return true; } return false;
+  });
+  await page.waitForTimeout(300);
+  // some builds confirm the batch via a dialog — accept it if present
+  await page.evaluate(() => { const y = Array.from(document.querySelectorAll('button')).find(b => /^(ok|complete|confirm|yes)$/i.test(b.textContent.trim())); if (y && y.offsetParent) y.click(); });
+  await page.waitForTimeout(900);
+  // the batch dispatch fans _fsmCtx.dispatch over N rows — same in-memory grain; count the per-row §FORM/batch logs
+  const batchDispatchLogs = logs.filter(l => /to=CO/.test(l) && /process|batch|docfsm/i.test(l)).length;
+  const afterBatch = await page.evaluate((ids) => {
+    const ad = window.__idmpDb; const out = {};
+    ids.forEach(id => { try { const r = ad.exec('SELECT DocStatus FROM C_Order WHERE C_Order_ID=' + id); out[id] = r.length ? r[0].values[0][0] : null; } catch (e) { out[id] = '?'; } });
+    return out;
+  }, batch);
+  console.log('§CRITIC-PROCESS grid-batch fired=' + batchDid + ' rawDbAfter=' + JSON.stringify(afterBatch) + ' (display-only, same in-memory grain as the form pill)');
+  ok('grid gear-batch fans Complete over the selection (the AdDocFsm-over-N-rows surface fires)', batchDid === true);
+  note('GAP J5 (same root cause): grid-batch Complete is also DISPLAY-ONLY — raw db unchanged ' + JSON.stringify(afterBatch)
+     + '. Both surfaces share _fsmCtx.dispatch (in-memory preview); neither persists a signed completion yet.');
+
+  ok('0 pageerrors', errs.length === 0, errs.length ? errs.slice(0, 3).join(' | ') : '');
+
+  // J5 is a 🟡 PARTIAL: the surfaces + legal logic are right, but Complete does not yet SIGN/PERSIST/FAN-OUT.
+  // The critic refuses to call this ✅ — "Complete" that vanishes on reload is not a completion.
+  console.log('\n§CRITIC-VERDICT(J5) 🟡 PARTIAL (well-scoped) — Both process surfaces work and the legal DocAction '
+    + 'set is EXACT (IP→[Complete,Prepare,Void]); clicking Complete advances the on-screen status. BUT on THESE two '
+    + 'surfaces it is a PREVIEW (no signed op / persist / fan-out). The good news the critic confirms: the REAL signed '
+    + 'complete-with-fan-out EXISTS (crud_overlay commitProcess + ERPEngine.completeOrder, W-SO-COMPLETE-UI) and is '
+    + 'reachable via the ✎ CRUD ring + blue-future. So J5 is a WIRING gap, not a missing capability — re-point the '
+    + 'Process pill + grid-batch to commitProcess and J5 goes green. Surfaces ✅, pill/batch commitment-wiring ⛔.');
+  console.log((fail === 0 ? '🟡' : '❌') + ' W-CRITIC-PROCESS-LIVE: ' + pass + '/' + (pass + fail) + ' surface-checks PASS (' + fail + ' FAIL) — J5 = 🟡 PARTIAL (see GAP notes + verdict)');
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
## ERP CRITIC UX LANE — P1 (Odoo end-to-end), the critic's verification + findings

The critic drives the **served bundle** on the Odoo tenant (client 12) via `?shard=12-odoo.db&login=Odoo&window=143`. Test-only — **no shipped-code change** (verification + gap diagnosis).

### J2 ORIENT + J3 READ ✅ — `W-CRITIC-ORIENT+READ-LIVE 9/9`
- Sales Order grid = 54 rows, **all AD_Client_ID=12**, DocNos `S000xx`, and **0 of GardenWorld's 8 orders bleed through** (gating load-bearing — the db physically holds both tenants).
- Order form header DocumentNo == db; Business Partner renders **"Gemini Furniture"**, not a raw FK id (rides #324 refresolve); record-info ⓘ popup answers from the op-log.
- Critic verdict: *pickable over a stock iDempiere window for orient + read.*

### J5 PROCESS 🟡 PARTIAL — `W-CRITIC-PROCESS-LIVE 7/7 surface-checks`
- Both surfaces work: form Process ▶ pill + grid gear-batch open the **exact** legal set (IP→[Complete, Prepare, Void]); clicking Complete advances the on-screen status.
- **But on these two surfaces Complete is a PREVIEW** — `_fsmCtx.dispatch` (idempiere.html:1626) mutates the in-memory record only; raw db + kernel op-log unchanged, no shipment/invoice, reverts on reload.
- **Diagnosis (good news):** the signed complete-with-fan-out **already exists** — `crud_overlay.commitProcess` → `completeFanout` (`ERPEngine.completeOrder`, mounted; W-SO-COMPLETE-UI) → signed `commitGroup`, reached via the ✎ CRUD ring + blue-future. So J5 is a **wiring gap, not a missing capability**.
- **Next fix (scoped):** re-point the Process ▶ pill (`_showProcessChooser`) and the grid gear-batch to the same `commitProcess` DOC_ACTION path → J5 goes green. (An `idempiere.html` change — now unblocked, the magnet file is clear.)

Rebased on `feat/grid-status` (#326) — both witnesses re-verified green on that base. J4 CREATE + J6 POST still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)