### PR TITLE
fix(erp): tenant delete trashcan consistently visible (was hover-only)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -276,10 +276,13 @@
   .idmp-login-demo.installing { opacity:.6; cursor:progress; }
   @keyframes idmp-demo-pulse { 0%,100%{opacity:.3} 50%{opacity:1} }
   /* tenant delete affordance (NEW_CLIENT_MGMT — reverse of install) + its red-rim warning */
+  /* Delete affordance is ALWAYS faintly visible on every deletable tenant (was opacity:0 = hover-only,
+     so on a glance only the hovered row showed it, and on touch — no hover — it was unreachable). Faint
+     by default → brightens on row hover → red on button hover. Consistent across all resident tenants. */
   .idmp-tenant-del { margin-left:8px; flex:0 0 auto; width:28px; height:28px; padding:0; border:1px solid transparent;
-    background:none; border-radius:6px; color:var(--idmp-muted); cursor:pointer; opacity:0; transition:.12s;
+    background:none; border-radius:6px; color:var(--idmp-muted); cursor:pointer; opacity:.4; transition:.12s;
     display:flex; align-items:center; justify-content:center; }
-  .idmp-login-user:hover .idmp-tenant-del { opacity:.65; }
+  .idmp-login-user:hover .idmp-tenant-del { opacity:.7; }
   .idmp-tenant-del:hover { opacity:1; color:#e5484d; background:#fdeced; border-color:#f3c0c2; }
   .idmp-del-overlay { position:fixed; inset:0; background:rgba(8,10,16,.55); z-index:100000;
     display:flex; align-items:center; justify-content:center; }

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v695';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v696';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Issue (from screenshots)
The login tenant-switcher delete affordance was `opacity:0`, revealed only on `.idmp-login-user:hover`. So:
- **At a glance, only the hovered row showed a trashcan** → looked like "only some tenants can be deleted" (the screenshot showed it on SAP Flights, the hovered row, but not Odoo).
- **On touch (no hover) the trashcan never appeared** → delete was unreachable on mobile.

The gating logic was already correct — every resident tenant **except** System(0)/GardenWorld(11) gets the button. Only the **default visibility** was wrong.

## Fix
CSS only: trashcan is **faintly visible by default** (`opacity:.4`) on every deletable tenant, brightening on row hover (`.7`) and red on button hover (`1`). Consistent across all resident/migrated tenants, desktop and mobile. Demo (not-yet-installed) rows still carry no trashcan by design — nothing to delete until entered/installed.

`erp/sw.js` v695→v696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)