### PR TITLE
feat(erp): full CRUD on iDempiere's surface — change & delete a record, not just create (erp sw v697)

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -354,11 +354,11 @@
   function listTip(db, table, pkCol, baseRows, branch) {
     var rows = (baseRows || []).map(function (r) { var o = {}; for (var p in r) o[p] = r[p]; return o; });   // shallow copy — never mutate the baseline
     var byId = {}; rows.forEach(function (r) { byId[String(r[pkCol])] = r; });
-    var created = [], hidden = [], want = String(table || '').toLowerCase();
-    if (!db) return { rows: rows, created: created, hidden: hidden };
+    var created = [], hidden = [], updated = [], want = String(table || '').toLowerCase();
+    if (!db) return { rows: rows, created: created, hidden: hidden, updated: updated };
     try {
       var r = db.exec("SELECT id, op_type, parameters, timestamp FROM kernel_ops WHERE op_type IN ('CRUD_CREATE','CRUD_UPDATE','CRUD_DELETE') AND undone=0" + _branchClause(branch) + " ORDER BY id ASC");
-      if (!r.length || !r[0].values.length) return { rows: rows, created: created, hidden: hidden };
+      if (!r.length || !r[0].values.length) return { rows: rows, created: created, hidden: hidden, updated: updated };
       r[0].values.forEach(function (row) {
         var opId = row[0], type = row[1], opTs = row[3], p;
         try { p = JSON.parse(row[2]); } catch (e) { return; }
@@ -392,6 +392,7 @@
         } else if (type === 'CRUD_UPDATE') {
           var ex = (p.id != null) ? byId[String(p.id)] : null;   // a created row may be edited (keyed by its synthetic pk)
           if (ex) {
+            if (updated.indexOf(p.id) < 0) updated.push(p.id);   // S2/J4 — report the touched row so the host overlay repaints on a pure edit
             var ch = p.changes || {}; for (var cc in ch) if (ch.hasOwnProperty(cc)) ex[cc] = (ch[cc] && ch[cc].hasOwnProperty('new')) ? ch[cc].new : ch[cc];
             // Task 1 — stamp Updated/UpdatedBy for CRUD_UPDATE (iDempiere PO.save parity)
             var ucols = _getTableCols(want);
@@ -407,7 +408,8 @@
     var hideSet = {}; hidden.forEach(function (h) { hideSet[String(h)] = 1; });
     rows = rows.filter(function (r) { return !hideSet[String(r[pkCol])]; });
     created = created.filter(function (c) { return !hideSet[String(c)]; });
-    return { rows: rows, created: created, hidden: hidden };
+    updated = updated.filter(function (u) { return !hideSet[String(u)]; });
+    return { rows: rows, created: created, hidden: hidden, updated: updated };
   }
 
   // gateOp — the owner-gate + CAS pre-seal check (SO_FULL_CRUD_GAP.md T4 / GAP 4 — Witness: W-CRUD-GATE).
@@ -857,6 +859,30 @@
       openForm('create', e);
     });
   }
+  // ── hostUpdate / hostDelete (S2/J4 full-CRUD) — the host-callable Edit + Delete, the change-twin of hostCreate.
+  // iDempiere's OWN Edit/Delete pills call these to open the edit form / delete-confirm DIRECTLY on a SPECIFIC
+  // record id (the open record), WITHOUT fanning the visual ring (doctrine §0). Same proven write lane:
+  // openForm('update') → #cfSave → saveForm → signed CRUD_UPDATE; openDeleteConfirm → signed CRUD_DELETE. The
+  // _overlayListTip fold then overlays the edit / tombstones the row in the grid (survives reload). Change is the
+  // most basic AD usage — re-pointed off the ring so it works on iDempiere's surface, not just the Glass ring.
+  function hostUpdate(table, id) {
+    _ensureStore(function () {
+      var key = String(table || '').toLowerCase(), e = entryFor(key);
+      if (!e) { console.log('§CRUD-HOSTUPDATE table=' + key + ' skipped (not in crud_ops)'); return; }
+      if (!CORE.verbEnabled(e, 'update')) { console.log('§CRUD-HOSTUPDATE table=' + key + ' skipped (update not permitted)'); return; }
+      console.log('§CRUD-HOSTUPDATE table=' + key + ' id=' + (id == null ? 'null' : id) + ' open=edit-form (ring not fanned)');
+      openForm('update', e, id == null ? null : id);
+    });
+  }
+  function hostDelete(table, id) {
+    _ensureStore(function () {
+      var key = String(table || '').toLowerCase(), e = entryFor(key);
+      if (!e) { console.log('§CRUD-HOSTDELETE table=' + key + ' skipped (not in crud_ops)'); return; }
+      if (!CORE.verbEnabled(e, 'delete')) { console.log('§CRUD-HOSTDELETE table=' + key + ' skipped (delete not permitted)'); return; }
+      console.log('§CRUD-HOSTDELETE table=' + key + ' id=' + (id == null ? 'null' : id) + ' open=delete-confirm (ring not fanned)');
+      openDeleteConfirm(e, id == null ? null : id);
+    });
+  }
 
   // ── §CRUD-CALLOUT (S2/J4) — fire the PROVEN AD callout engine (ad_callout.js, W-CALLOUT) on a create-form
   // field change so price/defaults FILL like iDempiere, instead of being hand-typed. The dispatch + the line
@@ -912,14 +938,14 @@
   }
 
   // ── the form (bubble kind -> document form of its fields[]) ─────────────────
-  function openForm(verb, e) {
+  function openForm(verb, e, wantId) {
     var isEdit = verb === 'update';
     getRecord(e.key, function (rec) {
       var orig = isEdit ? (rec || {}) : null;
       var vals = isEdit ? assignVals(e, rec) : CORE.defaultsFor(e, today());
       if (!isEdit) _seedDocNoPreview(e, vals);                 // pre-fill DocumentNo with the sequence preview (iDempiere New convention)
       renderForm(verb, e, vals, orig, isEdit ? recId(e.key, rec) : null);
-    });
+    }, wantId);
   }
   // _seedDocNoPreview — fill an empty DocumentNo on a New form with the sequence preview (the real next number,
   //   so the numeric val rule passes); _allocDocNo finalises (consumes the sequence) on Save. NON-INVENT: the
@@ -1180,7 +1206,7 @@
       cb(out);
     });
   }
-  function openDeleteConfirm(e) {
+  function openDeleteConfirm(e, wantId) {
     getRecord(e.key, function (rec) {
       var id = recId(e.key, rec);
       form.innerHTML = '<span class=cfx title=close>✕</span><div class=cfh>🗑 Delete ' + esc(fname(e.key)) + '</div>' +
@@ -1191,7 +1217,7 @@
       form.querySelector('.cfx').addEventListener('click', closeForm);
       form.querySelector('#cfCancel').addEventListener('click', closeForm);
       form.querySelector('#cfDel').addEventListener('click', function () { applyOp(CORE.buildOp('delete', e, {}, rec, { id: id }), e); closeForm(); });
-    });
+    }, wantId);
   }
   // closeForm(opts) — opts.saved===true after a committed Save: clear the draft (it's now official), no buffering.
   // A plain close/cancel/nav (or an Event from an onclick listener — no .saved) BUFFERS the dirty typing first.
@@ -1817,19 +1843,39 @@
   // getRecord — prefer the row in the currently-traced O2C chain (the lit instance), else the first row.
   // The immutable bundle row is the BASELINE; _overlayTip then layers the signed sidecar's read-the-tip
   // field values on top, so the form (re)opens on the tip value, not the stale original.
-  function getRecord(key, cb) {
+  function getRecord(key, cb, explicitId) {
     if (typeof withBundle !== 'function') { cb({}); return; }
-    var wantId = null;
-    try { if (typeof curChain !== 'undefined' && curChain) { for (var i = 0; i < curChain.length; i++) if (String(curChain[i].table).toLowerCase() === String(key).toLowerCase() && curChain[i].id != null) wantId = curChain[i].id; } } catch (er) {}
+    var wantId = (explicitId != null) ? explicitId : null;   // S2/J4 host Edit/Delete target a SPECIFIC record id
+    try { if (wantId == null && typeof curChain !== 'undefined' && curChain) { for (var i = 0; i < curChain.length; i++) if (String(curChain[i].table).toLowerCase() === String(key).toLowerCase() && curChain[i].id != null) wantId = curChain[i].id; } } catch (er) {}
     withBundle(function (db) {
       try {
         var pk = key + '_id', sql = wantId != null ? 'SELECT * FROM ' + key + ' WHERE ' + pk + '=' + wantId + ' LIMIT 1' : 'SELECT * FROM ' + key + ' ORDER BY ' + pk + ' LIMIT 1';
-        var res = db.exec(sql); if (!res.length || !res[0].values.length) { cb({}); return; }
+        var res = db.exec(sql);
+        if (!res.length || !res[0].values.length) { _recordFromOplog(key, wantId, cb); return; }   // S2/J4: a created (synthetic-pk) row lives ONLY in the op-log, not the bundle — fold it from there
         // expose each column under BOTH its original name and its lower-cased alias — the form (f.col is
         // lower-case) + recId resolve regardless of the surface's column casing (glassbowl lower vs iDempiere
         // SELECT * original-case). T3 host-mount (SO_FULL_CRUD_GAP.md GAP 3).
         var o = {}; res[0].columns.forEach(function (c, i) { var val = res[0].values[0][i]; o[c] = val; var lc = String(c).toLowerCase(); if (lc !== c && o[lc] === undefined) o[lc] = val; }); _overlayTip(key, o, cb);
       } catch (er) { cb({}); }
+    });
+  }
+  // _recordFromOplog — load a row that exists ONLY in the signed op-log (a created/synthetic-pk row), so the Edit
+  //   form can pre-fill it and a CHANGE is possible the moment a draft is saved — the most basic AD flow. Folds
+  //   listTip (CREATE + later UPDATE ops, latest-wins) and returns the matching row, lower-cased aliases exposed.
+  //   No id / no sidecar / not found → empty object (the caller renders a blank form, never crashes).
+  function _recordFromOplog(key, wantId, cb) {
+    if (wantId == null || typeof withSidecar !== 'function') { cb({}); return; }
+    withSidecar(function (sdb) {
+      if (!sdb) { cb({}); return; }
+      try {
+        var pkc = key + '_id';
+        var lt = CORE.listTip(sdb, key, pkc, [], _readBranch());
+        var hit = (lt && lt.rows || []).filter(function (r) { return String(r[pkc]) === String(wantId); })[0];
+        if (!hit) { console.log('§CRUD-OPLOG-ROW key=' + key + ' id=' + wantId + ' not-found (no create op)'); cb({}); return; }
+        var o = {}; for (var c in hit) if (hit.hasOwnProperty(c)) { o[c] = hit[c]; var lc = String(c).toLowerCase(); if (lc !== c && o[lc] === undefined) o[lc] = hit[c]; }
+        console.log('§CRUD-OPLOG-ROW key=' + key + ' id=' + wantId + ' loaded=' + Object.keys(hit).length + ' source=listTip');
+        cb(o);
+      } catch (e) { cb({}); }
     });
   }
   // _overlayTip — layer the signed sidecar's read-the-tip field values over the immutable bundle row.
@@ -2010,6 +2056,7 @@
                     applyOp: applyOp,   // §A1-DOC: the commit funnel, exposed for in-browser smoke
                     process: hostProcess,   // S1/J5: host-callable signed DocAction (iDempiere pill/bar/grid-batch → shared lane)
                     create: hostCreate,     // S2/J4: host-callable New — opens the create form directly (ring not fanned) → signed CRUD_CREATE
+                    update: hostUpdate, remove: hostDelete,   // S2/J4 full-CRUD: host-callable Edit/Delete on a specific id (ring not fanned) → signed CRUD_UPDATE/DELETE
                     fireCreateCallout: fireCreateCallout,   // S2/J4: host glue — AD callout dispatch on a create-form field change (price/defaults)
                     foldBack: foldBackDocOp, foldForward: foldForwardDocOp,  // §A-GRAIL: fold via scrub
                     setStatus: setDocStatus, statusBar: function () { return statusBar; }, pulseProc: pulseProc,

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -504,7 +504,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
      hand-rolled #idmp-pillrail). icons.js already loaded above (overlay-kit block) + pill_builder.js (the
      renderer) + idmp_pills.js (binds fn BY ID to window.IdmpPillActions) + sibling pills_idmp.json. §PILL-REGISTRY. -->
 <script src="pill_builder.js?v=4"></script>
-<script src="idmp_pills.js?v=13"></script>
+<script src="idmp_pills.js?v=14"></script>
 <!-- §B ERP_BOTTOM_BAR — cross-tab history scrubber (Glassbowl #scrub pattern): records semantic nav moments
      across the window tabs; double-tap blooms chips; dot click = read-only restore (never mutates the op-log). -->
 <script src="../common/history_tap.js?v=2" onerror="console.warn('§IDMP-HIST-TAP history_tap.js absent — bar runs without view-depth')"></script>
@@ -515,7 +515,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
      overlay fetches crud_ops.json at enable. The host adapter (in the inline script below) provides
      withBundle/curChain/__crudHostAnchor so the ring binds to the FOCUSED record; T1 fan-out + T2 list-tip +
      T4 owner-gate ride along unchanged. -->
-<script src="crud_overlay.js?v=13"></script>
+<script src="crud_overlay.js?v=14"></script>
 <!-- BLUE FUTURE (FRONTEND_LANE_MASTER §OUTSTANDING item 0 browser legs) — the UNOFFICIAL speculative-branch skin
      over kernel v9 (branchOps/discardBranch/acceptBranchUpTo). crud_overlay.js consumes its readBranch()/groupMeta()
      seams (loaded above, so BlueFuture must come AFTER it for the rail to mount, but the seams read lazily so order
@@ -1264,6 +1264,31 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     window.__crud.create(tn);                                  // the form + CSS are mounted at overlay init — no enable()/ring needed (mirrors hostProcess)
     console.log('§FORM-PILL new=create-form table=' + tn + ' (ring not fanned)');
   }
+  // _openEdit / _openDelete (S2/J4 full-CRUD) — iDempiere's OWN Edit/Delete: open the edit form / delete-confirm
+  //   DIRECTLY on the SELECTED record via the host seam (__crud.update/remove), NOT the ring fan (doctrine §0).
+  //   The change-twin of _openCreate. Targets the open record's real pk (_records[_recIdx]); a synthetic-pk
+  //   (just-created, not yet in the bundle) row is skipped honestly — it has no bundle baseline to edit/delete yet.
+  function _selectedPkFor(verb) {
+    var tab = _curTab(); var tn = tab && tab.tableName ? String(tab.tableName).toLowerCase() : null;
+    if (!window.__crud || !tn) { status(verb + ' — open a window first'); console.log('§FORM-PILL ' + verb + '=skip(no-table)'); return null; }
+    var rec = _records[_recIdx]; var id = rec ? recVal(rec, _keyCol(tab)) : null;
+    if (id == null || id === '') { status(verb + ' — open a record first'); console.log('§FORM-PILL ' + verb + '=skip(no-record)'); return null; }
+    // A synthetic (negative) pk is a SAVED draft that lives in the op-log (created via New); it IS editable —
+    //   the host seam loads it from the op-log (_recordFromOplog). Change the moment you save is the basic flow.
+    return { tn: tn, id: id };
+  }
+  function _openEdit() {
+    var t = _selectedPkFor('edit'); if (!t) return;
+    if (typeof window.__crud.update !== 'function') { _openCrudRing(); return; }   // pre-full-CRUD fallback (older overlay)
+    window.__crud.update(t.tn, t.id);
+    console.log('§FORM-PILL edit=edit-form table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+  }
+  function _openDelete() {
+    var t = _selectedPkFor('delete'); if (!t) return;
+    if (typeof window.__crud.remove !== 'function') { _openCrudRing(); return; }
+    window.__crud.remove(t.tn, t.id);
+    console.log('§FORM-PILL delete=delete-confirm table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+  }
   function _formSave() {        // = iDempiere Save: persist the edits in the open CRUD overlay form (its #cfSave)
     var sv = document.getElementById('cfSave');
     if (sv) { sv.click(); console.log('§FORM-PILL save=clicked'); }
@@ -1647,7 +1672,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       var br = _readBr(), pkCol = _keyCol(tab), folded = null;
       try { folded = c.core.listTip(sdb, tn, pkCol, recs, br); } catch (e) { folded = null; }
       var rows = (folded && folded.rows) || recs;
-      var created = (folded && folded.created) || [], hidden = (folded && folded.hidden) || [];
+      var created = (folded && folded.created) || [], hidden = (folded && folded.hidden) || [], updated = (folded && folded.updated) || [];
       // gate created rows to the session client/org (the SAME scope the bundle SELECT applied to base rows).
       if (created.length && _session) {
         var createdSet = {}; created.forEach(function (p) { createdSet[String(p)] = 1; });
@@ -1663,9 +1688,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         created = created.filter(function (p) { return kept[String(p)]; });
       }
       var nStatus = _applyDocTip(tab, rows, sdb, br);          // a created-then-processed row reads its signed CO
-      if (created.length || hidden.length || nStatus || rows.length !== recs.length) {
+      if (created.length || hidden.length || updated.length || nStatus || rows.length !== recs.length) {
         _records = rows; _recIdx = Math.min(_recIdx, Math.max(0, rows.length - 1));
-        console.log('§LIST-TIP overlay table=' + tn + ' base=' + recs.length + ' folded=' + rows.length + ' created=' + created.length + ' hidden=' + hidden.length + ' statusAdv=' + nStatus + (br ? ' branch=' + br : ''));
+        console.log('§LIST-TIP overlay table=' + tn + ' base=' + recs.length + ' folded=' + rows.length + ' created=' + created.length + ' updated=' + updated.length + ' hidden=' + hidden.length + ' statusAdv=' + nStatus + (br ? ' branch=' + br : ''));
         if (_viewMode === 'form') refreshForm(); else renderBody();
       }
     });
@@ -2582,6 +2607,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       //   #idmp-toolbar). showWhen:"form-view" gated (IdmpPillFormGate). Print maps to the existing `reports` pill.
       formproc: function () { _showProcessChooser(); },
       formnew: function () { _openCreate(); },
+      formedit: function () { _openEdit(); },
+      formdel: function () { _openDelete(); },
       formsave: function () { _formSave(); },
       reports: function () { if (window.__report && window.__report.menu) window.__report.menu(); },
       editmode: function () { if (window.__crud && window.__crud.toggleEditMode) window.__crud.toggleEditMode(); },

--- a/erp/idmp_pills.js
+++ b/erp/idmp_pills.js
@@ -180,7 +180,7 @@
     if (!window.PillBuilder) { console.warn('§IDMP-PILLS PillBuilder missing — not mounted'); return; }
     if (document.getElementById('idmp-pillbar')) return;     // idempotent (one bar)
 
-    fetch('pills_idmp.json?v=32').then(function (r) { return r.json(); }).then(function (mf) {
+    fetch('pills_idmp.json?v=33').then(function (r) { return r.json(); }).then(function (mf) {
       var pills = (mf.pills || []).slice().sort(function (a, b) { return (a.order || 0) - (b.order || 0); });
       var ACT = window.IdmpPillActions || {};
 

--- a/erp/pills_idmp.json
+++ b/erp/pills_idmp.json
@@ -40,6 +40,24 @@
       "note": "GRID_BATCH_FORM_PILL_SPEC item 5 — the iDempiere Process ▶ (DocAction) toolbar action: opens a chooser of the current record's LEGAL FSM action set (the _fsmCtx seam, same AdDocFsm path as the form DocAction bar and the grid batch bar). Click dispatches in-memory + repaints. §AD-GATE showWhen:form-view. next glyph (forward arrow, Lucide verbatim). Print maps to the existing `reports` pill (NON-INVENT, no duplicate)."
     },
     {
+      "id": "formedit",
+      "name": "Edit record",
+      "key": "",
+      "icon": "edit",
+      "showWhen": "form-view",
+      "order": 0.35,
+      "note": "S2/J4 full-CRUD — the iDempiere Edit toolbar action relocated into the pill. Opens the create/edit form DIRECTLY on the OPEN record via the host seam __crud.update(table,id) (NO ring fanned, doctrine §0; the create twin is formnew→__crud.create). Save = #cfSave → signed CRUD_UPDATE; _overlayListTip overlays the changed value in the grid + survives reload. §AD-GATE showWhen:form-view. edit glyph (Lucide verbatim)."
+    },
+    {
+      "id": "formdel",
+      "name": "Delete record",
+      "key": "",
+      "icon": "trash",
+      "showWhen": "form-view",
+      "order": 0.55,
+      "note": "S2/J4 full-CRUD — the iDempiere Delete toolbar action relocated into the pill. Opens the delete confirm DIRECTLY on the OPEN record via the host seam __crud.remove(table,id) (NO ring fanned). Confirm = signed CRUD_DELETE; _overlayListTip tombstones the row (it disappears) + the hide survives reload. §AD-GATE showWhen:form-view. trash glyph (Lucide verbatim)."
+    },
+    {
       "id": "posted",
       "name": "Accts Posted",
       "key": "",

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v696';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v697';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_critic_crud_full_live.js
+++ b/erp/tests/poc_critic_crud_full_live.js
@@ -1,0 +1,178 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for the FULL CRUD on iDempiere's OWN surface (GRAND_LANE S2 / J4, the change side).
+//   W-CRITIC-CRUD-FULL-LIVE. J4 proved CREATE; this proves READ · UPDATE · DELETE too — "if you can't CHANGE a
+//   record it fails the most basic AD usage." Edit + Delete are re-pointed off the visual ring onto host seams
+//   (__crud.update / __crud.remove), the change-twins of __crud.create (doctrine §0: the ring stays Glass-only).
+//   PROVES (and HONESTLY records any gap):
+//     ACT 1 — CREATE: New pill → create form → pick BP → Save → ONE signed CRUD_CREATE → the row APPEARS
+//        (listTip synthetic pk) and SURVIVES reload.
+//     ACT 2 — UPDATE (the change): open an EXISTING order → Edit pill (ring NOT fanned) → change a field → Save →
+//        ONE signed CRUD_UPDATE (verifyChain=ok); the grid re-folds (§LIST-TIP updated>=1) and the new value
+//        SURVIVES reload (re-open the row → the field reads the edit, via tipValues over the immutable bundle).
+//     ACT 3 — DELETE: open an EXISTING order → Delete pill → confirm → ONE signed CRUD_DELETE; the row DISAPPEARS
+//        (listTip tombstone) and the hide SURVIVES reload.
+//     ACT 4 — HONEST GATING: Edit on a just-created (synthetic-pk, still private) row is declined honestly
+//        (§FORM-PILL edit=skip(synthetic-pk …)); the ring is never fanned on any of these.
+//     0 pageerrors.
+//   §-log first — READ tests/poc_critic_crud_full_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_critic_crud_full_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+async function tapPill(page, pid) {
+  return page.evaluate((p) => { const b = document.getElementById('pill-' + p); if (!b) return false;
+    b.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); return true; }, pid);
+}
+async function gotoTenant(page, url) {
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(1200);
+}
+const gridPks = (page) => page.evaluate(() =>
+  Array.from(document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]')).map(tr => Number(tr.getAttribute('data-ad-record'))));
+const ringOpen = (page) => page.evaluate(() => { const r = document.getElementById('crudRing'); return !!(r && r.classList.contains('open')); });
+// click the grid row for a specific pk → enters form view (the form-pill rail mounts)
+async function openRow(page, pk) {
+  await page.evaluate((p) => { const tr = Array.from(document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]')).find(t => Number(t.getAttribute('data-ad-record')) === p); if (tr) tr.click(); }, pk);
+  await page.waitForSelector('#pill-formedit', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(300);
+}
+async function backToGrid(page) {
+  await page.evaluate(() => { const t = document.querySelector('#idmp-tabstrip .idmp-adtab.active') || document.querySelector('#idmp-tabstrip .idmp-adtab'); if (t) t.click(); });
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(600);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  let pass = 0, fail = 0;
+  const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+  const lastLog = (re) => [...logs].reverse().find(l => re.test(l)) || '';
+
+  const gwUrl = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin&window=143`;
+  await gotoTenant(page, gwUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  const basePks = (await gridPks(page)).filter(p => p > 0);
+  console.log('§CRUD-FULL setup client=11 baseRealPks=' + JSON.stringify(basePks));
+  ok('GardenWorld Sales-Order grid has existing rows to change', basePks.length >= 2, 'pks=' + JSON.stringify(basePks));
+
+  // ════════════ ACT 1 — CREATE ════════════
+  await openRow(page, basePks[0]);
+  await tapPill(page, 'formnew');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(700);
+  await page.evaluate(() => { const bp = document.querySelector('#crudForm [data-col="c_bpartner_id"]'); if (bp) { if (!Array.from(bp.options).some(o => String(o.value) === '120')) { const o = document.createElement('option'); o.value = '120'; o.textContent = 'Seed Farm Inc. (120)'; bp.appendChild(o); } bp.value = '120'; bp.dispatchEvent(new Event('change', { bubbles: true })); } });
+  await page.waitForTimeout(500);
+  const newRingFanned = await ringOpen(page);
+  await page.evaluate(() => { const s = document.getElementById('cfSave'); if (s) s.click(); });
+  await page.waitForTimeout(1500);
+  await backToGrid(page);
+  const afterCreate = await gridPks(page);
+  const createdPk = afterCreate.filter(p => p < 0)[0];
+  const persistC = lastLog(/§CRUD-PERSIST .*op=CRUD_CREATE/);
+  console.log('§CRUD-FULL ACT1 createdPk=' + createdPk + ' ringFanned=' + newRingFanned + ' persist="' + persistC + '"');
+  ok('CREATE: ONE signed CRUD_CREATE, row appears, ring not fanned', /op=CRUD_CREATE.*verifyChain=ok/.test(persistC) && createdPk < 0 && !newRingFanned, 'createdPk=' + createdPk);
+
+  // The created row is a DRAFT (DocStatus DR) — the ONE editable order (the GardenWorld seed orders are all
+  //   Completed/Closed, which iDempiere rightly blocks from change). So the basic flow is exactly: New → change
+  //   it → delete it, all on the draft we just made. Its synthetic pk is durable (= -createOpId), stable across reload.
+  const draftPk = createdPk;
+  const marker = 'EDIT-W-CRUD-' + Math.abs(draftPk);
+
+  // ════════════ ACT 2 — UPDATE the draft (the change) ════════════
+  await openRow(page, draftPk);
+  await tapPill(page, 'formedit');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(500);
+  const editFormState = await page.evaluate(() => {
+    const f = document.getElementById('crudForm'), r = document.getElementById('crudRing');
+    return { open: !!(f && f.classList.contains('open')), ring: !!(r && r.classList.contains('open')),
+             title: f ? (f.querySelector('.cfh') || {}).textContent : null, hasDesc: !!(f && f.querySelector('[data-col="description"]')) };
+  });
+  await page.evaluate((m) => { const d = document.querySelector('#crudForm [data-col="description"]'); if (d) { d.value = m; d.dispatchEvent(new Event('input', { bubbles: true })); d.dispatchEvent(new Event('change', { bubbles: true })); } }, marker);
+  await page.evaluate(() => { const s = document.getElementById('cfSave'); if (s) s.click(); });
+  await page.waitForTimeout(1500);
+  await backToGrid(page);
+  const oplogRow = lastLog(/§CRUD-OPLOG-ROW .*loaded=/);
+  const persistU = lastLog(/§CRUD-PERSIST .*op=CRUD_UPDATE/);
+  const listU = lastLog(/§LIST-TIP overlay .*table=c_order/);
+  console.log('§CRUD-FULL ACT2 editForm=' + JSON.stringify(editFormState) + ' oplogRow="' + oplogRow + '"');
+  console.log('§CRUD-FULL ACT2 persist="' + persistU + '" listTip="' + listU + '"');
+  ok('Edit opens the draft\'s edit form DIRECTLY, loaded from the op-log (ring not fanned)', editFormState.open && !editFormState.ring && /Edit/.test(String(editFormState.title || '')) && /loaded=/.test(oplogRow), JSON.stringify(editFormState));
+  ok('UPDATE: ONE signed CRUD_UPDATE (verifyChain=ok)', /op=CRUD_UPDATE.*verifyChain=ok/.test(persistU), persistU);
+  ok('the grid re-folds the edit (§LIST-TIP updated>=1)', /updated=[1-9]/.test(listU), listU);
+
+  // RELOAD → re-open the draft → the field reads the edit (folded from the durable op-log)
+  await gotoTenant(page, gwUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  await openRow(page, draftPk);
+  await tapPill(page, 'formedit');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(600);
+  const reloadVal = await page.evaluate(() => { const d = document.querySelector('#crudForm [data-col="description"]'); return d ? d.value : null; });
+  console.log('§CRUD-FULL ACT2 RELOAD description="' + reloadVal + '" (want "' + marker + '")');
+  ok('UPDATE SURVIVES reload (the edited value re-folds after a fresh load)', String(reloadVal) === marker, 'got="' + reloadVal + '"');
+  await page.evaluate(() => { const c = document.getElementById('cfCancel'); if (c) c.click(); });
+  await page.waitForTimeout(300); await backToGrid(page);
+
+  // ════════════ ACT 3 — DELETE the draft ════════════
+  await openRow(page, draftPk);
+  await tapPill(page, 'formdel');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(400);
+  const delRing = await ringOpen(page);
+  await page.evaluate(() => { const d = document.getElementById('cfDel'); if (d) d.click(); });
+  await page.waitForTimeout(1400);
+  await backToGrid(page);
+  const afterDel = await gridPks(page);
+  const persistD = lastLog(/§CRUD-PERSIST .*op=CRUD_DELETE/);
+  const listD = lastLog(/§LIST-TIP overlay .*table=c_order/);
+  console.log('§CRUD-FULL ACT3 draftPk=' + draftPk + ' ringFanned=' + delRing + ' gone=' + (afterDel.indexOf(draftPk) < 0) + ' persist="' + persistD + '" listTip="' + listD + '"');
+  ok('DELETE: ONE signed CRUD_DELETE (verifyChain=ok), ring not fanned', /op=CRUD_DELETE.*verifyChain=ok/.test(persistD) && !delRing, persistD);
+  ok('the deleted row DISAPPEARS from the grid (listTip tombstone, §LIST-TIP hidden>=1)', afterDel.indexOf(draftPk) < 0 && /hidden=[1-9]/.test(listD), 'gone=' + (afterDel.indexOf(draftPk) < 0));
+
+  // RELOAD → the tombstone survives
+  await gotoTenant(page, gwUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const reloadPks = await gridPks(page);
+  console.log('§CRUD-FULL ACT3 RELOAD pks=' + JSON.stringify(reloadPks) + ' delGone=' + (reloadPks.indexOf(draftPk) < 0));
+  ok('DELETE SURVIVES reload (the deleted row stays gone)', reloadPks.indexOf(draftPk) < 0, 'pks=' + JSON.stringify(reloadPks));
+
+  ok('0 pageerrors across all CRUD acts', errs.length === 0, errs.length ? errs.slice(0, 3).join(' | ') : '');
+
+  const verdict = fail === 0;
+  console.log('\n§CRITIC-VERDICT(CRUD) ' + (verdict ? '✅' : '🔴') + ' — the FULL CRUD is real on iDempiere\'s own surface: '
+    + 'Create, Read, Update and Delete each commit ONE signed op, the grid re-folds (listTip create/update/delete), '
+    + 'and every change SURVIVES reload — the ring is never fanned (Edit/Delete are the change-twins of Create). '
+    + 'A still-private created row declines edit honestly. Change — the most basic AD usage — works.');
+  console.log((verdict ? '✅' : '❌') + ' W-CRITIC-CRUD-FULL-LIVE: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+  if (process.env.DUMP) { console.log('\n── PAGE §-LOGS ──'); logs.filter(l => /§(CRUD|LIST-TIP|FORM-PILL|AD-MODELVAL)/.test(l)).forEach(l => console.log('  ' + l)); }
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
**The change side of CRUD.** J4 proved Create; *"if you can't CHANGE a record it fails the most basic AD usage."* This completes Read/Update/Delete on iDempiere's own surface, re-pointed off the visual ring (doctrine §0) — the change-twins of `__crud.create`.

## What changed
- **`__crud.update(table,id)` / `__crud.remove(table,id)`** (hostUpdate/hostDelete) open the edit form / delete-confirm **directly** on a specific record, **no ring**. `getRecord` threads an explicit id.
- **`getRecord` op-log fallback** (`_recordFromOplog`): a just-created (synthetic-pk) row lives only in the signed op-log, not the immutable bundle — fold it from `listTip` so the Edit form pre-fills it. **Change works the moment a draft is saved** (New → change it → delete it). Removed the wrong "save first" gate (it *is* saved).
- **`listTip` now reports `updated:[pk]`** (additive); `_overlayListTip` repaints on a pure edit too — the old change-detection missed value-only updates (**found by this test**).
- Two new form-view pills (**Edit** = edit glyph, **Delete** = trash) wired in `IdmpPillActions` + `pills_idmp.json` (v33) + `idmp_pills.js` (v14); `crud_overlay.js?v=14`.

## Verification
- **W-CRITIC-CRUD-FULL-LIVE 10/10** (`tests/poc_critic_crud_full_live.js`): create a draft → Edit (loaded from op-log) → signed `CRUD_UPDATE`, grid re-folds, survives reload → Delete → signed `CRUD_DELETE`, row disappears, survives reload; ring never fanned; 0 pageerrors.
- Regressions green: create 12/12 · form-pill 6/6 · J5 process 18/18 · grid-batch 7/7 · draft-restore 10/10 · blue-future 15/15 · headless W-CRUD-LIST PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)