### PR TITLE
feat(history): clash dot restores the pair + Clash panel (field('clash'))

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v665';   // shared About/DIY modal wired to the viewer Help pill (common/about_diy.js) atop v664 history-tap. git history is the record.
+const CACHE_VERSION = 'v666';   // v666: clash dot restores the pair + Clash panel (field('clash'), universal_history.js?v=24)
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/poc_clash_restore.js
+++ b/viewer/tests/poc_clash_restore.js
@@ -1,0 +1,80 @@
+// ⚠ DO NOT REMOVE — browser §-witness for the CLASH restore field (HISTORY_KNOB_SIGNAL_TAP §LOCKED-FIELD).
+// ISSUE (user, live): "Clash shows the zoom-to but WITHOUT the clash pair and Clash panel." The clash dot
+//   restored only camera+ambient (keys=…cam,section,palette) — no pair highlight, no list panel.
+// FIX: field('clash', read, write) in universal_history.js — read() stamps the inspected pair into every
+//   moment's view; write(pair) re-opens the list panel (from persisted _currentClashes, no re-detection) and
+//   _flyToClash → pair highlight + fly. recordEvent self-suppresses because applyView holds isApplying()=true.
+// PROVES (against the REAL field registered by _wireTap on the harness, with A clash-API stubbed):
+//   1. clash field registered (currentView carries clash:{a,b} when a pair is inspected).
+//   2. applyView({clash}) → _flyToClash called with the GUID-matched idx (pair restored) + isApplying()=true
+//      during it (so the inner recordEvent would NOT mint a new dot — no scrub pollution).
+//   3. panel re-shown: when the list was dismissed (_clashRevealActive=false), write re-calls _revealClashes
+//      BEFORE _flyToClash (Clash panel comes back).
+//   4. write(null) on a non-clash moment dismisses the viz (keepMatrix=true).
+//   §-log first — READ tests/poc_clash_restore.log before any conclusion (exit code is NOT evidence).
+// Run:  node viewer/tests/poc_clash_restore.js 2>&1 | tee viewer/tests/poc_clash_restore.log   (cwd = bim-ootb)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json', '.wasm': 'application/wasm', '.css': 'text/css' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  fs.readFile(path.join(ROOT, p), (e, buf) => { if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); });
+});
+const PASS = [], FAIL = [];
+function check(n, c, d) { (c ? PASS : FAIL).push(n); console.log((c ? '✅ ' : '❌ ') + n + (d ? ' — ' + d : '')); }
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('pageerror', e => errs.push(e.message));
+  await page.goto(`http://localhost:${port}/viewer/tests/histbar_viewer_harness.html`, { waitUntil: 'networkidle' });
+  await page.evaluate(() => window.__ready);
+  await page.waitForTimeout(200);
+
+  // Stub the clash API on the REAL window.A the harness exposes; record calls.
+  const r = await page.evaluate(() => {
+    var A = window.A;
+    var calls = { fly: [], reveal: 0, dismiss: 0, applyingDuringFly: null };
+    A._currentClashRules = { display: {} };
+    A._currentClashes = [ ['GUID_A', 'GUID_B', 0,0,0,0,0,0, 0.058], ['GUID_C', 'GUID_D', 0,0,0,0,0,0, 0.064] ];
+    A._clashRevealActive = true;
+    A._currentClashViewIdx = 1;                              // user inspected the 2nd clash (GUID_C/GUID_D)
+    A._flyToClash = function (idx) { calls.fly.push(idx); calls.applyingDuringFly = !!(window.HistoryTap.isApplying && window.HistoryTap.isApplying()); };
+    A._revealClashes = function () { calls.reveal++; };
+    A._dismissClashes = function () { calls.dismiss++; };
+
+    // (1) the inspected pair is stamped into the live view
+    var view = window.HistoryTap.currentView();
+
+    // (2) restore that pair → _flyToClash(idx=1), isApplying must be true during it
+    window.HistoryTap.applyView({ clash: { a: 'GUID_C', b: 'GUID_D' } }, 'Clash 0.064m');
+
+    // (3) panel dismissed → restore must re-show it (reveal) BEFORE fly
+    A._clashRevealActive = false;
+    window.HistoryTap.applyView({ clash: { a: 'GUID_A', b: 'GUID_B' } }, 'Clash 0.058m');
+    var revealedBeforeFly = calls.reveal === 1 && calls.fly.length === 2 && calls.fly[1] === 0;
+
+    // (4) a non-clash moment clears the viz
+    A._clashRevealActive = true;
+    window.HistoryTap.applyView({ clash: null }, 'plain');
+
+    return { stampedPair: view.clash, calls: calls, revealedBeforeFly: revealedBeforeFly };
+  });
+
+  check('clash field registered (pair stamped into view)', r.stampedPair && r.stampedPair.a === 'GUID_C' && r.stampedPair.b === 'GUID_D', JSON.stringify(r.stampedPair));
+  check('restore → _flyToClash GUID-matched idx (pair restored)', r.calls.fly[0] === 1, 'flyIdx=' + r.calls.fly[0]);
+  check('recordEvent suppressed (isApplying true during fly)', r.calls.applyingDuringFly === true);
+  check('dismissed panel re-shown before fly (Clash panel back)', r.revealedBeforeFly, 'reveal=' + r.calls.reveal + ' fly=[' + r.calls.fly + ']');
+  check('non-clash moment dismisses viz', r.calls.dismiss === 1, 'dismiss=' + r.calls.dismiss);
+  check('no page errors', errs.length === 0, errs.join(' | '));
+
+  console.log('§W-CLASH SUMMARY pass=' + PASS.length + ' fail=' + FAIL.length);
+  await browser.close(); server.close();
+  process.exit(FAIL.length ? 1 : 0);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/viewer/universal_history.js
+++ b/viewer/universal_history.js
@@ -263,9 +263,42 @@
     T.field('palette',
       function () { var A = _A(); return A ? (A._ambienceTick || 0) : 0; },
       function (tick) { var A = _A(); if (A && A.updateAmbience) A.updateAmbience(tick); });
+    // §CLASH — the inspected clash PAIR (which two elements + the panel). The clash dot used to restore only
+    // camera+ambient (zoom-to) — NOT the highlighted pair or the Clash list panel (user: "Clash shows the zoom
+    // to but without the clash pair and Clash panel"). read() = the pair currently inspected (by GUID, gated on
+    // the panel being active so a stale idx never re-fires); write(pair) re-inspects it: re-open the list panel
+    // from the PERSISTED _currentClashes (read-only re-render, NO re-detection) if it was dismissed, then
+    // _flyToClash → red/blue overlap meshes + outline + fly. _flyToClash's own recordEvent self-suppresses here
+    // because applyView holds isApplying()=true. write(null) = a non-clash moment → clear the viz (keep matrix).
+    T.field('clash',
+      function () {
+        var A = _A();
+        if (!A || !A._clashRevealActive || A._currentClashViewIdx == null || !A._currentClashes) return null;
+        var c = A._currentClashes[A._currentClashViewIdx];
+        return (c && c[0] && c[1]) ? { a: c[0], b: c[1] } : null;
+      },
+      function (pair) {
+        var A = _A();
+        if (!A) return;
+        if (!pair || !pair.a) {                                   // moment had no clash → clear any current viz
+          if (A._clashRevealActive && A._dismissClashes) A._dismissClashes(true);   // keepMatrix
+          return;
+        }
+        if (!A._currentClashes || !A._flyToClash) return;         // no clash list this session → can't reconstruct (cold)
+        var idx = -1, cc = A._currentClashes;
+        for (var i = 0; i < cc.length; i++) {
+          var c = cc[i];
+          if (c && ((c[0] === pair.a && c[1] === pair.b) || (c[0] === pair.b && c[1] === pair.a))) { idx = i; break; }
+        }
+        if (idx < 0) return;                                      // pair not in the current list (rules changed) → skip
+        if (!A._clashRevealActive && A._revealClashes && A._currentClashRules) {
+          A._revealClashes(A._currentClashes, A._currentClashRules);   // re-show the panel (no re-detection)
+        }
+        A._flyToClash(idx);                                       // pair highlight + fly + row (recordEvent suppressed)
+      });
     if (T.sniff) T.sniff(true);   // recording goes TOTAL: read every §act from the stream, deny-filtered
     if (T.onFeed) T.onFeed(_drainTap);   // ── THE SUBSCRIPTION: the bar now LISTENS to the §-stream ──
-    console.log('§HIST_TAP_WIRED fields(ghost,xray,cam,section,palette) + sniffer ON + bar SUBSCRIBES tap — one symmetric line each');
+    console.log('§HIST_TAP_WIRED fields(ghost,xray,cam,section,palette,clash) + sniffer ON + bar SUBSCRIBES tap — one symmetric line each');
   }
 
   // ── BAR SUBSCRIBES TO THE TAP (HISTORY_KNOB_SIGNAL_TAP §GAP-BAR-NEVER-CONSUMED-THE-TAP, §THE WORK 1&5) ──

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -829,7 +829,7 @@
 <!-- ABOUT_BOX_CONSOLIDATE.md — the ONE shared About/DIY modal (Help pill → AboutDIY.open). Self-contained
      (embeds its own Lucide glyphs) — does NOT load erp/icons.js, which would clobber the viewer's own window.ICONS. -->
 <script src="../common/about_diy.js?v=1" onerror="console.warn('[AboutDIY] about_diy.js skipped')"></script>
-<script src="universal_history.js?v=23" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
+<script src="universal_history.js?v=24" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>
 <script src="bom_extract.js?v=1" onerror="console.warn('[BOMExtract] bom_extract.js skipped')"></script>
 <script src="verb_expand.js?v=1" onerror="console.warn('[VerbExpand] verb_expand.js skipped')"></script>
 <script src="bom_walker.js?v=1" onerror="console.warn('[BOMWalker] bom_walker.js skipped')"></script>


### PR DESCRIPTION
## Issue (user, live)
"Working history shows back the X (section) panel at its cut, but **Clash only shows the zoom-to — without the clash pair and Clash panel**." The clash dot (a `CLASH_INSPECT` event) restored only camera+ambient (`keys=…,cam,section,palette`) because no field carried the inspected pair.

## Fix — the §LOCKED-FIELD primitive
`field('clash', read, write)` in `universal_history.js _wireTap`:
- **read()** stamps the inspected pair `{a,b}` (by GUID, gated on `_clashRevealActive` so a stale idx never re-fires) into every moment's view vector → the clash dot now carries its pair.
- **write(pair)** re-inspects: if the list was dismissed, re-open it from the **persisted** `_currentClashes` via `_revealClashes` (read-only re-render, **no re-detection**), then `_flyToClash(idx)` → red/blue overlap meshes + outline + fly. GUID-matched so it survives an idx shift. `write(null)` clears the viz on a non-clash moment.
- `_flyToClash`'s own `recordEvent` **self-suppresses** because `applyView` holds `isApplying()=true` → scrubbing never mints a new dot. No change to the restore dispatch — the existing `_tapApply(entry.viewState)` already applies every registered field.

## Witness
`viewer/tests/poc_clash_restore.js` (browser, against the REAL field on the harness): pair stamped · restore → `_flyToClash` GUID-matched idx · `isApplying` true during fly · dismissed panel re-shown before fly · non-clash moment dismisses — **6/6**. Regressions: #340 node **9/9** + browser **6/6**.

viewer sw v666 · `universal_history.js?v=24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)