### PR TITLE
feat(erp): S2B — AD-folded CRUD generality (every table editable per its own dictionary)

### DIFF
--- a/erp/ad_parser.js
+++ b/erp/ad_parser.js
@@ -280,7 +280,7 @@
       'SELECT f.AD_Field_ID, f.Name, f.Description, f.SeqNo, ' +
       '       f.IsDisplayed, f.DisplayLogic, f.IsMandatory, f.IsReadOnly, f.DefaultValue, ' +
       '       c.AD_Column_ID, c.ColumnName, c.AD_Reference_ID, c.FieldLength, ' +
-      '       c.IsMandatory as ColMandatory, c.IsKey, c.IsIdentifier, ' +
+      '       c.IsMandatory as ColMandatory, c.IsKey, c.IsIdentifier, c.IsUpdateable, ' +
       '       c.DefaultValue as ColDefault ' +
       'FROM AD_Field f ' +
       'JOIN AD_Column c ON f.AD_Column_ID = c.AD_Column_ID ' +
@@ -314,7 +314,8 @@
         referenceType: REF_TYPES[refId] || 'string',
         fieldLength: o.FieldLength,
         isKey: o.IsKey === 'Y',
-        isIdentifier: o.IsIdentifier === 'Y'
+        isIdentifier: o.IsIdentifier === 'Y',
+        isUpdateable: o.IsUpdateable !== 'N'                 // S2B: AD_Column.IsUpdateable (null/Y → updateable; 'N' → display-only on Edit)
       };
     }).filter(Boolean);
 

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -602,8 +602,82 @@
     return null;
   }
 
+  // ── S2B (AD-FOLDED CRUD GENERALITY) — derive a crud_ops-shaped entry FROM THE DICTIONARY so EVERY window is
+  // editable per its OWN AD, not a curated 5-table allow-list (Janke/Compiere vision). PURE + headless-testable.
+  // Input `adFields` = the renderer's already-folded field shape (ADParser.getFields): {columnName, name,
+  // isMandatory, isReadOnly, isUpdateable, isKey, isDisplayed, referenceType, defaultValue, displayLogic}. We do
+  // NOT re-derive types/refs — we MAP what the renderer already folded. opts: {key, title, isView, isReadOnly,
+  // forVerb}. The signed write path (commitCrud→listTip overlay→reload-survival) is UNCHANGED; only the SPEC
+  // SOURCE moves from the hand-list to the AD.
+  // mapRefDisplayType — the AUTHORITATIVE map: iDempiere DisplayType id → the overlay form type vocab. Folded from
+  //   the raw AD_Reference_ID (ADParser exposes `referenceId`) so it is correct even where the renderer's coarse
+  //   REF_TYPES string is imperfect (e.g. 20=Yes-No, 18=Table). Returns null for an unknown id (→ string fallback).
+  //   number: 11 Integer · 12 Amount · 22 Number · 29 Quantity. date: 15 Date · 16 DateTime · 24 Time. fk: 18 Table ·
+  //   19 TableDir · 30 Search. id: 13 ID (hidden PK) · 28 Button (dropped by the caller). else (10 String · 14 Text ·
+  //   17 List · 20 Yes-No · …) → string (LEG-1: list/yesno render as an editable text of the raw value; AD_Ref_List
+  //   option-fold is a named follow-on).
+  function mapRefDisplayType(rid) {
+    switch (Number(rid)) {
+      case 11: case 12: case 22: case 29: return 'number';
+      case 15: case 16: case 24: return 'date';
+      case 18: case 19: case 30: return 'fk';
+      case 13: return 'id'; case 28: return 'button';
+      // string-rendered ids — MUST be enumerated so a known id never falls through to the coarse referenceType
+      // fallback (where 20=Yes-No is mislabelled 'table'→fk): 10 String · 14 Text · 17 List · 20 Yes-No · 21 Location
+      // · 23 Binary · 25 Account · 31 Locator · 32 Image · 33 Assignment · 34 Memo · 35 PAttribute · 38 PrinterName.
+      case 10: case 14: case 17: case 20: case 21: case 23: case 25: case 31: case 32: case 33: case 34: case 35: case 38: return 'string';
+      default: return null;   // truly unknown id → caller falls back to the referenceType string
+    }
+  }
+  // mapRefType — fallback by the renderer's coarse referenceType STRING (older callers / when no referenceId).
+  function mapRefType(rt) {
+    switch (rt) {
+      case 'integer': case 'amount': case 'number': case 'quantity': return 'number';
+      case 'date': case 'datetime': return 'date';
+      case 'tableDirect': case 'table': case 'search': return 'fk';
+      case 'id': return 'id'; case 'button': return 'button';
+      default: return 'string';   // string · text · char · list · yesno · unknown
+    }
+  }
+  function foldCrudSpec(adFields, opts) {
+    opts = opts || {};
+    var roTable = !!opts.isView || !!opts.isReadOnly;     // AD_Table.IsView or AD_Tab.IsReadOnly → the whole row is read-only
+    var forVerb = opts.forVerb || 'update';
+    var fields = (adFields || []).map(function (f) {
+      // type from the AUTHORITATIVE AD_Reference_ID; fall back to the coarse referenceType string.
+      var type = (f && f.referenceId != null ? mapRefDisplayType(f.referenceId) : null) || mapRefType(f && f.referenceType);
+      return f && f.isDisplayed && !f.isKey && type !== 'button' && type !== 'id' ? { f: f, type: type } : null;
+    }).filter(Boolean).map(function (ft) {
+      var f = ft.f, type = ft.type;
+      // IsUpdateable='N' is SETTABLE on New (iDempiere fills it once) but display-only on Edit; isReadOnly + a
+      // read-only table/tab are always read-only.
+      var readonly = !!f.isReadOnly || roTable || (forVerb === 'update' && f.isUpdateable === false);
+      var spec = { col: String(f.columnName).toLowerCase(), label: f.name || f.columnName, type: type,
+                   required: !!f.isMandatory, readonly: readonly };
+      // DEFAULTS: resolve the well-known AD context variables iDempiere's Env fills on New (@#AD_Client_ID@,
+      // @#AD_Org_ID@, @#Date@) from opts.ctx — so a mandatory system column (AD_Client_ID/AD_Org_ID) doesn't block a
+      // folded create; keep PLAIN literals (0/N/Y/DR…); drop any OTHER unevaluated expression (@SQL=…, functions) —
+      // we don't run the full AD default-expression language here (named follow-on), and never seed an un-evaluated
+      // token (it would fail the field validator). Edit pre-fills the real row regardless.
+      var d = f.defaultValue, ctx = opts.ctx || {};
+      if (d != null && String(d) !== '') {
+        var ds = String(d);
+        if (ds === '@#AD_Client_ID@' && ctx.clientId != null) spec.default = ctx.clientId;
+        else if (ds === '@#AD_Org_ID@' && ctx.orgId != null) spec.default = ctx.orgId;
+        else if (ds === '@#Date@' && ctx.today) spec.default = ctx.today;
+        else if (!/[@()]/.test(ds)) spec.default = d;
+      }
+      if (type === 'fk') spec.ref = String(f.columnName).toLowerCase().replace(/_id$/, '');
+      if (f.displayLogic != null && String(f.displayLogic).trim() !== '') spec.displaylogic = f.displayLogic;
+      return spec;
+    });
+    return { key: opts.key, title: opts.title || opts.key, folded: true, isView: !!opts.isView,
+             verbs: roTable ? [] : ['create', 'update', 'delete'], fields: fields };
+  }
+
   var CORE = {
     entriesOf: entriesOf, verbEnabled: verbEnabled, defaultsFor: defaultsFor,
+    foldCrudSpec: foldCrudSpec, mapRefType: mapRefType,                          // S2B: AD-folded CRUD spec (general, not curated)
     validateField: validateField, validate: validate, effectiveFlags: effectiveFlags, cleanVals: cleanVals, buildOp: buildOp,
     docActionOutcome: docActionOutcome, legalDocActions: legalDocActions, kernelParamsFor: kernelParamsFor, readTip: readTip, tipValues: tipValues,
     normDateValue: normDateValue, buildDocActionGroup: buildDocActionGroup, docLabel: docLabel,
@@ -675,7 +749,18 @@
   if (typeof window !== 'undefined') window.addEventListener('beforeunload', function () { try { _bufferDraft(); } catch (e) {} });
 
   function today() { try { return new Date().toISOString().slice(0, 10); } catch (e) { return ''; } }
-  function entryFor(key) { return STORE && !isMeta(key) && STORE[key] ? (function () { var e = STORE[key]; e.key = key; return e; })() : null; }
+  // S2B — FOLDED holds host-registered AD-folded specs (one per non-curated table). entryFor prefers the CURATED
+  //   crud_ops entry (it carries docPolicy fan-out / ownerGate / docAction); else falls back to the folded spec so
+  //   ANY window is editable per its own dictionary. Lower-cased key, mirrors crud_ops keys.
+  var FOLDED = {};
+  function registerFolded(key, entry) { if (key && entry) FOLDED[String(key).toLowerCase()] = entry; }
+  function entryFor(key) {
+    if (STORE && !isMeta(key) && STORE[key]) { var e = STORE[key]; e.key = key; return e; }
+    var f = FOLDED[String(key).toLowerCase()];
+    if (f) { f.key = String(key).toLowerCase(); return f; }
+    return null;
+  }
+  function hasEntry(key) { return !!(STORE && !isMeta(key) && STORE[key]) || !!FOLDED[String(key).toLowerCase()]; }
 
   // _ensureStore — load the keyed crud_ops.json store once (idempotent). Shared by Edit-mode enable AND the
   // host DocAction lane (hostProcess), which fires WITHOUT enabling Edit mode and still needs the store's
@@ -954,7 +1039,7 @@
     if (!e || !(e.fields || []).some(function (f) { return String(f.col).toLowerCase() === 'documentno'; })) return;
     var cur = vals.documentno;
     if (cur != null && String(cur) !== '' && String(cur) !== 'auto') return;   // a real default already present → keep
-    var pv = _previewDocNo(e.key);
+    var pv = _previewDocNo(e.key, vals);                       // GAP (c): honour the doctype's controlled sequence when vals carry a C_DocType
     vals.documentno = pv != null ? pv : '';
     if (pv != null) console.log('§DOCNO-PREVIEW table=' + e.key + ' documentno=' + pv + ' (sequence preview, finalised on Save)');
   }
@@ -1144,9 +1229,23 @@
     });
   }
   // ── §AD-MODELVAL-LIVE plumbing — lazy per-table installer over the page bundle (sql.js → b3 shim) ──
-  var MV_INSTALLER = { c_order: 'installMOrderSaveHooks', m_inout: 'installMInOutSaveHooks',
-    c_invoice: 'installMInvoiceSaveHooks', c_payment: 'installMPaymentSaveHooks' };
-  var _mvInstalled = {};
+  // AUDIT GAP (d) — general not custom: DISCOVER the model-validator installers from the AdModelVal registry instead
+  //   of a hardcoded 4-table map. Every `install<Model>SaveHooks` export is invoked once (idempotent); each registers
+  //   its own BEFORE_SAVE hooks under its table (registerValidator). fireHooks then resolves coverage from REGISTRY —
+  //   so ALL ~13 ported model validators apply (the old map wired only 4), and a table with no ported hook is a clean
+  //   no-op. Install is pure registration (db is captured in hook closures, touched only when a hook fires) → safe.
+  var _mvAllInstalled = false;
+  function _installAllModelVal(b) {
+    var MV = global.AdModelVal; if (!MV) return [];
+    var installed = [];
+    Object.keys(MV).forEach(function (m) {
+      if (/^install[A-Z].*SaveHooks$/.test(m) && typeof MV[m] === 'function') {
+        try { MV[m](b); installed.push(m); } catch (e) { console.log('§AD-MODELVAL-LIVE installer ' + m + ' skipped (' + (e && e.message) + ')'); }
+      }
+    });
+    if (typeof MV.installDefaultHooks === 'function') { try { MV.installDefaultHooks(); installed.push('installDefaultHooks'); } catch (e) {} }
+    return installed;
+  }
   function _mvB3(dbh) {   // better-sqlite3-shaped shim over sql.js; lowercase keys (engines proven on ad_full.db);
     function lc(o) { if (!o) return o; var r = {}; for (var k in o) r[k.toLowerCase()] = o[k]; return r; }
     function run(sql, args, all) {                              // absent table/column in this bundle slice → no-row
@@ -1173,13 +1272,17 @@
       all: function () { return run(sql, Array.prototype.slice.call(arguments), true); }
     }; } };
   }
-  // _docCtx — the session document context the beforeSave hooks consult (iDempiere Env). The default Warehouse
-  //   for the session org (else the client's first active warehouse) — read from m_warehouse, never invented.
+  // _docCtx — the session document context the beforeSave hooks consult (iDempiere Env). The default Warehouse.
+  //   AUDIT GAP (b) — general not custom: iDempiere reads the org's DEFAULT warehouse from AD_OrgInfo.M_Warehouse_ID
+  //   (MOrgInfo.getM_Warehouse_ID), NOT "the lowest active warehouse id". Read that FIRST; only if AD_OrgInfo carries
+  //   none fall back to the org's first active warehouse, then the client's. Always a real m_warehouse, never invented.
   function _docCtx(b) {
     var ctx = {};
     try {
       var app = global.APP || {}, org = Number(app.orgId) || 0, cli = Number(app.clientId) || 0, wh = null;
-      if (org) wh = b.prepare("SELECT m_warehouse_id FROM m_warehouse WHERE ad_org_id=? AND isactive='Y' ORDER BY m_warehouse_id LIMIT 1").get(org);
+      if (org) { try { var oi = b.prepare("SELECT m_warehouse_id FROM ad_orginfo WHERE ad_org_id=? LIMIT 1").get(org);
+        if (oi && oi.m_warehouse_id != null) wh = { m_warehouse_id: oi.m_warehouse_id }; } catch (e0) {} }
+      if ((!wh || wh.m_warehouse_id == null) && org) wh = b.prepare("SELECT m_warehouse_id FROM m_warehouse WHERE ad_org_id=? AND isactive='Y' ORDER BY m_warehouse_id LIMIT 1").get(org);
       if ((!wh || wh.m_warehouse_id == null) && cli) wh = b.prepare("SELECT m_warehouse_id FROM m_warehouse WHERE ad_client_id=? AND isactive='Y' ORDER BY m_warehouse_id LIMIT 1").get(cli);
       if (wh && wh.m_warehouse_id != null) ctx.m_warehouse_id = Number(wh.m_warehouse_id);
     } catch (e) {}
@@ -1187,12 +1290,13 @@
   }
   function fireBeforeSaveHooks(e, vals, orig, cb) {
     var MV = global.AdModelVal;
-    if (!MV || !MV_INSTALLER[e.key] || typeof withBundle !== 'function') { cb(null); return; }
+    if (!MV || typeof withBundle !== 'function') { cb(null); return; }
     withBundle(function (db) {
       var out = null;
       try {
         var b = _mvB3(db);
-        if (!_mvInstalled[e.key]) { _mvInstalled[e.key] = true; var n = MV[MV_INSTALLER[e.key]](b); console.log('§AD-MODELVAL-LIVE installed ' + MV_INSTALLER[e.key] + ' hooks=' + n); }
+        if (!_mvAllInstalled) { _mvAllInstalled = true; var ins = _installAllModelVal(b); console.log('§AD-MODELVAL-LIVE installed-all registry=' + ins.length + ' [' + ins.join(',') + ']'); }
+        // GAP (d): no ported hook for this table → fireHooks returns fired=0, ok=true (a clean no-op, not a gate).
         var rec = {}, k;
         if (orig) for (k in orig) rec[k.toLowerCase()] = orig[k];
         for (k in vals) rec[k.toLowerCase()] = vals[k];
@@ -1701,11 +1805,30 @@
   // _previewDocNo — the sequence's NEXT DocumentNo WITHOUT consuming it (iDempiere shows this preview on a New
   //   form; the field is filled so the numeric val rule passes + the user isn't asked to type a doc number).
   //   The real number is allocated (and the sequence consumed) at commit by _allocDocNo. Returns null if no seq.
-  function _previewDocNo(table) {
+  // AUDIT GAP (c) — honour the doctype's controlled sequence (general not custom): when the record carries a
+  //   C_DocType(/Target) whose C_DocType.IsDocNoControlled='Y', iDempiere allocates DocumentNo from that doctype's
+  //   DocNoSequence_ID, NOT the table-level DocumentNo_<table> sequence. Returns the AD_Sequence_ID to use, else
+  //   null (→ fall back to the named table sequence). c_doctype is lower-cased in the bundle (data table).
+  function _docTypeSeqId(mdb, fields) {
+    try {
+      if (!fields) return null;
+      var dt = fields.c_doctype_id != null ? fields.c_doctype_id : (fields.C_DocType_ID != null ? fields.C_DocType_ID
+             : (fields.c_doctypetarget_id != null ? fields.c_doctypetarget_id : fields.C_DocTypeTarget_ID));
+      if (dt == null || String(dt) === '' || !isFinite(Number(dt))) return null;
+      var r = mdb.exec("SELECT isdocnocontrolled, docnosequence_id FROM c_doctype WHERE c_doctype_id=" + Number(dt) + " LIMIT 1");
+      if (!r.length || !r[0].values.length) return null;
+      var controlled = String(r[0].values[0][0]).toUpperCase() === 'Y', seqId = r[0].values[0][1];
+      return (controlled && seqId != null) ? Number(seqId) : null;
+    } catch (e) { return null; }
+  }
+  function _previewDocNo(table, fields) {
     var mdb = (typeof globalThis !== 'undefined' && globalThis.__idmpDb) || null; if (!mdb) return null;
     var cols = _getTableCols(table); if (!cols['documentno']) return null;
     try {
-      var r = mdb.exec("SELECT CurrentNext, Prefix, Suffix FROM AD_Sequence WHERE UPPER(Name)=UPPER(?) AND IsActive='Y' LIMIT 1", ['DocumentNo_' + table]);
+      var dtSeq = _docTypeSeqId(mdb, fields);
+      var r = dtSeq != null
+        ? mdb.exec("SELECT CurrentNext, Prefix, Suffix FROM AD_Sequence WHERE AD_Sequence_ID=" + dtSeq + " AND IsActive='Y' LIMIT 1")
+        : mdb.exec("SELECT CurrentNext, Prefix, Suffix FROM AD_Sequence WHERE UPPER(Name)=UPPER(?) AND IsActive='Y' LIMIT 1", ['DocumentNo_' + table]);
       if (!r.length || !r[0].values.length) return null;
       var v = r[0].values[0]; return (v[1] || '') + v[0] + (v[2] || '');
     } catch (e) { return null; }
@@ -1716,9 +1839,11 @@
     var cols = _getTableCols(table);
     if (!cols['documentno']) return null;
     try {
-      var seqName = 'DocumentNo_' + table;
-      var r = mdb.exec("SELECT AD_Sequence_ID, CurrentNext, IncrementNo, Prefix, Suffix FROM AD_Sequence WHERE UPPER(Name)=UPPER(?) AND IsActive='Y' LIMIT 1", [seqName]);
-      if (!r.length || !r[0].values.length) { console.log('§DOCNO no-sequence table=' + table + ' (named, not faked)'); return null; }
+      var dtSeq = _docTypeSeqId(mdb, fields), seqName = 'DocumentNo_' + table;
+      var r = dtSeq != null
+        ? mdb.exec("SELECT AD_Sequence_ID, CurrentNext, IncrementNo, Prefix, Suffix FROM AD_Sequence WHERE AD_Sequence_ID=" + dtSeq + " AND IsActive='Y' LIMIT 1")
+        : mdb.exec("SELECT AD_Sequence_ID, CurrentNext, IncrementNo, Prefix, Suffix FROM AD_Sequence WHERE UPPER(Name)=UPPER(?) AND IsActive='Y' LIMIT 1", [seqName]);
+      if (!r.length || !r[0].values.length) { console.log('§DOCNO no-sequence table=' + table + (dtSeq != null ? ' doctypeSeq=' + dtSeq : ' seq=' + seqName) + ' (named, not faked)'); return null; }
       var v = r[0].values[0], seqId = v[0], next = v[1], incr = v[2] || 1, prefix = v[3] || '', suffix = v[4] || '';
       var docNo = (prefix || '') + next + (suffix || '');
       // honor a MANUAL override (a value the user changed AWAY from the preview); otherwise allocate (consume)
@@ -1726,7 +1851,7 @@
       var provided = fields ? (fields['DocumentNo'] != null ? fields['DocumentNo'] : fields['documentno']) : null;
       if (provided != null && String(provided) !== '' && String(provided) !== String(docNo)) return null;
       mdb.run('UPDATE AD_Sequence SET CurrentNext=' + (next + incr) + ' WHERE AD_Sequence_ID=' + seqId);
-      console.log('§DOCNO table=' + table + ' seq=' + seqName + ' next=' + next + ' docno=' + docNo + ' replay-stable=Y');
+      console.log('§DOCNO table=' + table + ' seq=' + (dtSeq != null ? ('doctype#' + dtSeq) : seqName) + ' next=' + next + ' docno=' + docNo + ' docNoControlled=' + (dtSeq != null) + ' replay-stable=Y');
       return docNo;
     } catch (e) { return null; }
   }
@@ -2057,6 +2182,7 @@
                     process: hostProcess,   // S1/J5: host-callable signed DocAction (iDempiere pill/bar/grid-batch → shared lane)
                     create: hostCreate,     // S2/J4: host-callable New — opens the create form directly (ring not fanned) → signed CRUD_CREATE
                     update: hostUpdate, remove: hostDelete,   // S2/J4 full-CRUD: host-callable Edit/Delete on a specific id (ring not fanned) → signed CRUD_UPDATE/DELETE
+                    registerFolded: registerFolded, ensureStore: _ensureStore, hasEntry: hasEntry,   // S2B: AD-folded CRUD — host registers a dictionary-derived spec so ANY table is editable (entryFor fallback)
                     fireCreateCallout: fireCreateCallout,   // S2/J4: host glue — AD callout dispatch on a create-form field change (price/defaults)
                     foldBack: foldBackDocOp, foldForward: foldForwardDocOp,  // §A-GRAIL: fold via scrub
                     setStatus: setDocStatus, statusBar: function () { return statusBar; }, pulseProc: pulseProc,

--- a/erp/glassbowl.html
+++ b/erp/glassbowl.html
@@ -875,7 +875,7 @@ try{if(window.WholeHistory){WholeHistory.mount({page:"glassbowl",rootPrefix:"../
 <!-- T1 (SO_FULL_CRUD_GAP.md, W-SO-COMPLETE-UI): the PROVEN engine (UMD of bim-compiler scripts/erp_engine.js — window.ERPEngine, same file idempiere.html loads). crud_overlay.completeFanout extracts the completeIt consequence set (ship+invoice creates) from it. MUST load before crud_overlay. -->
 <script src="erp_engine.js?v=1"></script>
 <!-- CRUD ring-of-fire + Process/DocAction overlay — peer behavior layer, keyed to bubbles. GP3: Process ▶ = REAL signed write (sidecar log, read-the-tip). T1: Complete a c_order = the WHOLE document process committed as ONE group. T2: renderDataTab unions CRUD_CREATE rows + hides DELETE tombstones (CORE.listTip). -->
-<script src="crud_overlay.js?v=4"></script>
+<script src="crud_overlay.js?v=5"></script>
 <!-- Period-close in-app (§INTEG-WIRE) — fold the live sidecar op-log → ONE signed checkpoint = balance b/f; bootstrap from it on load. -->
 <script src="erp_period_close.js"></script>
 <script src="period_close_ui.js"></script>

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -412,7 +412,7 @@
 </div>
 
 <script src="vfs_detect.js?v=1"></script>
-<script src="ad_parser.js?v=23"></script>
+<script src="ad_parser.js?v=24"></script>
 <!-- UI_UNPARK_RESUME.md — proven AD engines (source of truth: bim-compiler build/erp/): logic evaluator
      (W-LOGIC-EVAL 3044/3044) · DocAction FSM (W-*-FSM, 22 tables) · beforeSave hooks (W-*-SAVE, 12 installers). -->
 <script src="ad_evaluator.js?v=24"></script>
@@ -516,7 +516,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
      overlay fetches crud_ops.json at enable. The host adapter (in the inline script below) provides
      withBundle/curChain/__crudHostAnchor so the ring binds to the FOCUSED record; T1 fan-out + T2 list-tip +
      T4 owner-gate ride along unchanged. -->
-<script src="crud_overlay.js?v=14"></script>
+<script src="crud_overlay.js?v=15"></script>
 <!-- BLUE FUTURE (FRONTEND_LANE_MASTER §OUTSTANDING item 0 browser legs) — the UNOFFICIAL speculative-branch skin
      over kernel v9 (branchOps/discardBranch/acceptBranchUpTo). crud_overlay.js consumes its readBranch()/groupMeta()
      seams (loaded above, so BlueFuture must come AFTER it for the rail to mount, but the seams read lazily so order
@@ -1248,10 +1248,12 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   //    REAL existing handler — never forks a verb: New/Save = the CRUD ring + its #cfSave; Process = the FSM seam.
   function _openCrudRing() {   // = the ✎ CRUD toolbar button (New/Save/Delete bundled in the ring), reused
     var tab = _curTab(); var tn = tab && tab.tableName ? String(tab.tableName).toLowerCase() : null;
-    if (!window.__crud || !tn || !_crudHas(tn)) { status('CRUD ring — this table is not editable (not in crud_ops)'); return; }
+    if (!window.__crud || !tn || !_crudHas(tn)) { status('CRUD ring — this table is not editable (read-only)'); return; }
     try { var ck = document.getElementById('crudModeCk'); if (ck && !ck.checked) { ck.checked = true; ck.dispatchEvent(new Event('change')); } } catch (e) {}
     window.__crud.enable();
-    var tries = 0; (function tryOpen() { if (window.__crud.openRing && window.__crud.store && window.__crud.store()) { window.__crud.openRing(tn); console.log('§FORM-PILL crud-ring table=' + tn + ' record=' + _curRecPk()); } else if (tries++ < 30) { setTimeout(tryOpen, 60); } })();
+    _withFoldedEntry(tn, 'update', function () {     // S2B — fold a non-curated table so the ring's verbs resolve (entryFor fallback); ensureStore ran first
+      if (window.__crud.openRing) { window.__crud.openRing(tn); console.log('§FORM-PILL crud-ring table=' + tn + ' record=' + _curRecPk()); }
+    });
   }
   // _openCreate (S2/J4) — iDempiere's OWN New: open the create FORM directly via the host seam (__crud.create),
   //   NOT the visual ring fan (doctrine §0: the ring is Glass/Gravity-only). The create-twin of J5's Process seam:
@@ -1262,8 +1264,11 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     if (typeof window.__crud.create !== 'function') { _openCrudRing(); return; }   // pre-J4 fallback (older overlay)
     // hostCreate runs _ensureStore (the crud_ops fetch is lazy) then checks entryFor/verbEnabled — so a New on the
     //   very first click (before the store loads) resolves correctly; a non-creatable table logs §CRUD-HOSTCREATE skip.
-    window.__crud.create(tn);                                  // the form + CSS are mounted at overlay init — no enable()/ring needed (mirrors hostProcess)
-    console.log('§FORM-PILL new=create-form table=' + tn + ' (ring not fanned)');
+    // S2B — register the AD-folded create-spec for a non-curated table FIRST so entryFor resolves (general, not curated).
+    _withFoldedEntry(tn, 'create', function () {
+      window.__crud.create(tn);                                // the form + CSS are mounted at overlay init — no enable()/ring needed (mirrors hostProcess)
+      console.log('§FORM-PILL new=create-form table=' + tn + ' (ring not fanned)');
+    });
   }
   // _openEdit / _openDelete (S2/J4 full-CRUD) — iDempiere's OWN Edit/Delete: open the edit form / delete-confirm
   //   DIRECTLY on the SELECTED record via the host seam (__crud.update/remove), NOT the ring fan (doctrine §0).
@@ -1281,14 +1286,18 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   function _openEdit() {
     var t = _selectedPkFor('edit'); if (!t) return;
     if (typeof window.__crud.update !== 'function') { _openCrudRing(); return; }   // pre-full-CRUD fallback (older overlay)
-    window.__crud.update(t.tn, t.id);
-    console.log('§FORM-PILL edit=edit-form table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+    _withFoldedEntry(t.tn, 'update', function () {                                 // S2B — fold a non-curated table (IsUpdateable=N → display-only on edit)
+      window.__crud.update(t.tn, t.id);
+      console.log('§FORM-PILL edit=edit-form table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+    });
   }
   function _openDelete() {
     var t = _selectedPkFor('delete'); if (!t) return;
     if (typeof window.__crud.remove !== 'function') { _openCrudRing(); return; }
-    window.__crud.remove(t.tn, t.id);
-    console.log('§FORM-PILL delete=delete-confirm table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+    _withFoldedEntry(t.tn, 'update', function () {                                 // S2B — fold a non-curated table so entryFor resolves
+      window.__crud.remove(t.tn, t.id);
+      console.log('§FORM-PILL delete=delete-confirm table=' + t.tn + ' id=' + t.id + ' (ring not fanned)');
+    });
   }
   function _formSave() {        // = iDempiere Save: persist the edits in the open CRUD overlay form (its #cfSave)
     var sv = document.getElementById('cfSave');
@@ -2154,12 +2163,66 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     try { var tab = _curTab(); if (!tab) return null; var rec = _records[_recIdx]; if (!rec) return null;
       var v = recVal(rec, _keyCol(tab)); return (v === '' || v == null) ? null : v; } catch (e) { return null; }
   }
-  // _crudHas — does the overlay's crud_ops store carry an entry for this (lower-cased) table? Drives the
-  // ✎ CRUD button's enabled state. Tolerant: store may not be fetched yet → treat as "maybe" (let the ring decide).
-  function _crudHas(tn) {
+  // _curatedHas — does the CURATED crud_ops store carry an entry for this (lower-cased) table? (The 5 document
+  //   tables: docPolicy fan-out + ownerGate.) Tolerant: store may not be fetched yet → "maybe".
+  function _curatedHas(tn) {
     try { var st = window.__crud && window.__crud.store && window.__crud.store();
       if (!st) return true;                 // store not fetched yet — don't pre-disable; openRing re-checks
       return Object.prototype.hasOwnProperty.call(st, tn); } catch (e) { return true; }
+  }
+  // S2B — _tableIsView: AD_Table.IsView='Y' → the table is a database VIEW = read-only (no New/Edit/Delete).
+  //   Cached per table; reads the seed AD_Table like the IsChangeLog probe.
+  var _isViewCache = {};
+  function _tableIsView(tn) {
+    if (tn == null) return false; var key = String(tn).toLowerCase();
+    if (key in _isViewCache) return _isViewCache[key];
+    var v = false;
+    try { var r = db.exec("SELECT IsView FROM AD_Table WHERE UPPER(TableName)=UPPER(?) LIMIT 1", [tn]);
+      v = r.length && r[0].values.length && String(r[0].values[0][0]).toUpperCase() === 'Y'; } catch (e) {}
+    _isViewCache[key] = v; return v;
+  }
+  // S2B — _foldableTab: a NON-curated table the AD says is editable (not a view, not a read-only tab, has fields).
+  //   The general path: every window editable per its OWN dictionary, retiring the curated allow-list as the GATE.
+  function _foldableTab(tab) {
+    if (!tab || !tab.tableName) return false;
+    var tn = String(tab.tableName).toLowerCase();
+    if (_curatedHas(tn)) return false;                       // curated wins (its docPolicy fan-out)
+    if (_tableIsView(tn) || tab.isReadOnly) return false;    // AD_Table.IsView / AD_Tab.IsReadOnly → read-only
+    return (tab.fields || []).some(function (f) { return f.isDisplayed && !f.isKey; });
+  }
+  // S2B — _foldCrudSpecForTab: derive + register the crud_ops-shaped entry FROM the current tab's AD-folded
+  //   fields (the renderer's getFields shape — reused, not re-derived) so hostCreate/Update/Delete's entryFor
+  //   resolves for a non-curated table. forVerb shapes the readonly set (IsUpdateable='N' settable on New,
+  //   display-only on Edit). Returns the registered spec (or null when the engine seam is absent).
+  function _foldCrudSpecForTab(tab, forVerb) {
+    if (!tab || !tab.tableName || !window.__crud || !window.__crud.core ||
+        typeof window.__crud.core.foldCrudSpec !== 'function' || typeof window.__crud.registerFolded !== 'function') return null;
+    var tn = String(tab.tableName).toLowerCase();
+    // ctx = the session Env defaults the AD context-variable defaults resolve from (@#AD_Client_ID@/@#AD_Org_ID@/
+    //   @#Date@) — so a mandatory system column doesn't block a folded New. iDempiere fills these from Env, never asks.
+    var ctx = { clientId: (_session && _session.client) ? _session.client.id : null,
+                orgId: (_session && _session.org) ? _session.org.id : null,
+                today: (new Date()).toISOString().slice(0, 10) };
+    var spec = window.__crud.core.foldCrudSpec(tab.fields, {
+      key: tn, title: tab.name || tn, isView: _tableIsView(tn), isReadOnly: !!tab.isReadOnly, forVerb: forVerb || 'update', ctx: ctx });
+    window.__crud.registerFolded(tn, spec);
+    console.log('§S2B-FOLD table=' + tn + ' verb=' + (forVerb || 'update') + ' verbs=[' + (spec.verbs || []).join(',') + '] fields=' + (spec.fields || []).length + ' isView=' + spec.isView + ' tabRO=' + !!tab.isReadOnly);
+    return spec;
+  }
+  // _crudHas — is this table editable AT ALL? curated crud_ops OR AD-foldable (S2B general). Drives the ✎ CRUD
+  //   button's enabled state. Tolerant: store may not be fetched yet → "maybe".
+  function _crudHas(tn) {
+    if (_curatedHas(tn)) return true;
+    return _foldableTab(_curTab());
+  }
+  // S2B — _withFoldedEntry: register a dictionary-folded spec for a NON-curated table BEFORE invoking a host CRUD
+  //   seam, so entryFor resolves. ensureStore first (so _curatedHas sees the loaded crud_ops; a curated doc table
+  //   is NEVER folded — its docPolicy entry wins). forVerb shapes the readonly set. Degrades to a bare run() if the
+  //   overlay predates the seam (older cache) — the host seam then logs its own honest skip.
+  function _withFoldedEntry(tn, forVerb, run) {
+    var es = window.__crud && window.__crud.ensureStore;
+    var go = function () { if (!_curatedHas(tn)) _foldCrudSpecForTab(_curTab(), forVerb); run(); };
+    if (typeof es === 'function') es(go); else go();
   }
   // withBundle — the overlay's read source on iDempiere = THIS window's seed db (immutable baseline).
   window.withBundle = function (cb) { try { if (db) cb(db); else cb(null); } catch (e) { try { cb(null); } catch (e2) {} } };

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v700';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v701';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_ad_folded_crud.js
+++ b/erp/tests/poc_ad_folded_crud.js
@@ -1,0 +1,78 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: HEADLESS engine witness for S2B AD-FOLDED CRUD GENERALITY (W-AD-FOLDED-CRUD). Proves CORE.foldCrudSpec
+//   derives a crud_ops-shaped entry FROM THE DICTIONARY (the renderer's getFields field shape) — general, not a
+//   curated allow-list. ISSUE it proves: "are all tables editable per their own AD?" — today only the curated 5
+//   were; this shows the fold produces create/update/delete verbs + typed fields for any editable table, [] for a
+//   VIEW, and applies the IsUpdateable='N' = display-only-on-Edit / settable-on-New rule + context-default resolve.
+// §-log first — READ tests/poc_ad_folded_crud.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_ad_folded_crud.js   (cwd = bim-ootb/erp)
+'use strict';
+const CORE = require('../crud_overlay.js');
+let pass = 0, fail = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+
+// A faithful slice of ADParser.getFields() over C_BPartner's header tab (window 123 / tab 220) — the real shape:
+// AD_Client_ID/AD_Org_ID are mandatory + IsUpdateable='N' with @#…@ context defaults; Value/Name are string;
+// C_BP_Group_ID is tableDirect (fk); SO_CreditLimit is amount (number); the PK + a Button are dropped.
+// referenceId = the AUTHORITATIVE iDempiere DisplayType id (13 ID, 19 TableDir, 10 String, 20 Yes-No, 12 Amount,
+//   28 Button, 14 Text) — the fold maps from this, not the renderer's coarse string. IsCustomer is reference 20
+//   (Yes-No), which must fold to a string text input, NOT an FK (the bug a coarse map would introduce).
+const BP_FIELDS = [
+  { columnName: 'C_BPartner_ID', name: 'BP', isKey: true, isDisplayed: true, referenceId: 13 },
+  { columnName: 'AD_Client_ID', name: 'Client', isDisplayed: true, isMandatory: true, isUpdateable: false, referenceId: 19, defaultValue: '@#AD_Client_ID@' },
+  { columnName: 'AD_Org_ID', name: 'Org', isDisplayed: true, isMandatory: true, isUpdateable: false, referenceId: 19, defaultValue: '@#AD_Org_ID@' },
+  { columnName: 'Value', name: 'Search Key', isDisplayed: true, isMandatory: true, isUpdateable: true, referenceId: 10 },
+  { columnName: 'Name', name: 'Name', isDisplayed: true, isMandatory: true, isUpdateable: true, referenceId: 10 },
+  { columnName: 'C_BP_Group_ID', name: 'BP Group', isDisplayed: true, isMandatory: true, isUpdateable: true, referenceId: 19 },
+  { columnName: 'IsCustomer', name: 'Customer', isDisplayed: true, isMandatory: true, isUpdateable: true, referenceId: 20, defaultValue: 'N' },
+  { columnName: 'SO_CreditLimit', name: 'Credit', isDisplayed: true, isUpdateable: true, referenceId: 12, defaultValue: '0' },
+  { columnName: 'AD_PrintFormat_ID', name: 'Btn', isDisplayed: true, referenceId: 28 },
+  { columnName: 'Help', name: 'Comment', isDisplayed: false, referenceId: 14 }   // not displayed → dropped
+];
+const CTX = { clientId: 11, orgId: 12, today: '2026-06-17' };
+
+console.log('§W-AD-FOLDED-CRUD start');
+
+// 1 — an editable (non-view) table folds to a full CRUD spec
+const upd = CORE.foldCrudSpec(BP_FIELDS, { key: 'c_bpartner', title: 'Business Partner', isView: false, isReadOnly: false, forVerb: 'update', ctx: CTX });
+ok('editable table → verbs create/update/delete', JSON.stringify(upd.verbs) === JSON.stringify(['create', 'update', 'delete']), JSON.stringify(upd.verbs));
+const cols = upd.fields.map(f => f.col);
+ok('PK + Button + non-displayed dropped; data cols kept', !cols.includes('c_bpartner_id') && !cols.includes('ad_printformat_id') && !cols.includes('help') && cols.includes('value') && cols.includes('name'), JSON.stringify(cols));
+
+// 2 — type mapping: amount→number, tableDirect→fk(ref=col minus _id), string→string
+const credit = upd.fields.find(f => f.col === 'so_creditlimit');
+const grp = upd.fields.find(f => f.col === 'c_bp_group_id');
+ok('amount → number', credit && credit.type === 'number', credit && credit.type);
+ok('tableDirect → fk with ref = column minus _id', grp && grp.type === 'fk' && grp.ref === 'c_bp_group', grp && (grp.type + '/' + grp.ref));
+ok('string → string + required carried from IsMandatory', upd.fields.find(f => f.col === 'value').type === 'string' && upd.fields.find(f => f.col === 'value').required === true);
+ok('Yes-No (AD_Reference_ID=20) folds to STRING, NOT fk (authoritative id, not the coarse map)', upd.fields.find(f => f.col === 'iscustomer').type === 'string', upd.fields.find(f => f.col === 'iscustomer').type);
+
+// 3 — IsUpdateable='N' = display-only on EDIT, settable on NEW
+const cre = CORE.foldCrudSpec(BP_FIELDS, { key: 'c_bpartner', forVerb: 'create', ctx: CTX });
+const orgUpd = upd.fields.find(f => f.col === 'ad_org_id'), orgCre = cre.fields.find(f => f.col === 'ad_org_id');
+ok('IsUpdateable=N → readonly on EDIT', orgUpd && orgUpd.readonly === true);
+ok('IsUpdateable=N → settable (not readonly) on NEW', orgCre && orgCre.readonly === false);
+
+// 4 — context defaults resolved from session Env (so a mandatory system col doesn't block New); @SQL/unknown dropped
+ok('@#AD_Client_ID@ resolved from ctx on New', cre.fields.find(f => f.col === 'ad_client_id').default === 11, String(cre.fields.find(f => f.col === 'ad_client_id').default));
+ok('@#AD_Org_ID@ resolved from ctx on New', cre.fields.find(f => f.col === 'ad_org_id').default === 12);
+ok('plain literal default kept (SO_CreditLimit=0)', cre.fields.find(f => f.col === 'so_creditlimit').default === '0');
+
+// 5 — a VIEW (or read-only tab) folds to a read-only spec: no verbs
+const view = CORE.foldCrudSpec(BP_FIELDS, { key: 'rv_unposted', isView: true });
+const roTab = CORE.foldCrudSpec(BP_FIELDS, { key: 'c_bpartner', isReadOnly: true });
+ok('AD_Table.IsView=Y → read-only (no verbs)', view.verbs.length === 0 && view.isView === true, JSON.stringify(view.verbs));
+ok('AD_Tab.IsReadOnly=Y → read-only (no verbs)', roTab.verbs.length === 0, JSON.stringify(roTab.verbs));
+
+// 6 — mapRefType coverage (the AD_Reference vocab → form type)
+const m = CORE.mapRefType;
+ok('mapRefType: integer/quantity→number, date/datetime→date, table/search→fk, list/yesno→string',
+  m('integer') === 'number' && m('quantity') === 'number' && m('date') === 'date' && m('datetime') === 'date' &&
+  m('table') === 'fk' && m('search') === 'fk' && m('list') === 'string' && m('yesno') === 'string');
+
+const verdict = fail === 0;
+console.log('\n§W-AD-FOLDED-CRUD ' + (verdict ? '✅' : '🔴') + ' — foldCrudSpec derives editability FROM THE AD: every'
+  + ' non-view table yields create/update/delete + typed fields, a view yields none, IsUpdateable=N is display-only'
+  + ' on Edit but settable on New, and Env context defaults resolve so mandatory system columns never block New.');
+console.log((verdict ? '✅' : '❌') + ' W-AD-FOLDED-CRUD: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+process.exit(fail > 0 ? 1 : 0);

--- a/erp/tests/poc_ad_folded_crud_live.js
+++ b/erp/tests/poc_ad_folded_crud_live.js
@@ -1,0 +1,212 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for S2B AD-FOLDED CRUD GENERALITY (W-AD-FOLDED-CRUD-LIVE). The ISSUE: today only
+//   the curated 5 document tables (crud_ops.json) are editable; the user's principle is "rules general not custom"
+//   (Janke/Compiere AD vision) — EVERY window editable per its OWN dictionary. This proves a NON-curated table,
+//   Business Partner (C_BPartner, window 123), is now New/Edit/Delete-capable purely from the AD fold, with the
+//   SIGNED write path unchanged. crud_ops becomes an OPTIONAL override, not the gate.
+//   PROVES (and HONESTLY records any gap):
+//     SETUP — open Business Partner (c_bpartner: not in crud_ops, not a view) → §S2B-FOLD verbs=[create,update,delete].
+//     ACT 1 — CREATE: New pill → folded create form (ring NOT fanned) → fill mandatory fields → Save → ONE signed
+//        CRUD_CREATE (verifyChain=ok); the row APPEARS (synthetic pk) and SURVIVES reload.
+//     ACT 2 — EDIT: open the created BP → Edit pill (ring NOT fanned) → an IsUpdateable='N' field (AD_Org_ID) is
+//        DISPLAY-ONLY (disabled); change Name → Save → ONE signed CRUD_UPDATE; the new Name SURVIVES reload.
+//     ACT 3 — DELETE: Delete pill → confirm → ONE signed CRUD_DELETE; the row DISAPPEARS and the hide SURVIVES reload.
+//     ACT 4 — VIEW read-only: the SAME engine folds a view (AD_Table.IsView='Y') to NO verbs (read-only).
+//     0 pageerrors.
+//   §-log first — READ tests/poc_ad_folded_crud_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_ad_folded_crud_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+async function tapPill(page, pid) {
+  return page.evaluate((p) => { const b = document.getElementById('pill-' + p); if (!b) return false;
+    b.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); return true; }, pid);
+}
+async function gotoTenant(page, url) {
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const ok = await page.$('#idmp-login-ok'); if (ok) await ok.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(1200);
+}
+const gridPks = (page) => page.evaluate(() =>
+  Array.from(document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]')).map(tr => Number(tr.getAttribute('data-ad-record'))));
+const ringOpen = (page) => page.evaluate(() => { const r = document.getElementById('crudRing'); return !!(r && r.classList.contains('open')); });
+async function openRow(page, pk) {
+  await page.evaluate((p) => { const tr = Array.from(document.querySelectorAll('.idmp-grid tbody tr[data-ad-record]')).find(t => Number(t.getAttribute('data-ad-record')) === p); if (tr) tr.click(); }, pk);
+  await page.waitForSelector('#pill-formedit', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(300);
+}
+async function backToGrid(page) {
+  await page.evaluate(() => { const t = document.querySelector('#idmp-tabstrip .idmp-adtab.active') || document.querySelector('#idmp-tabstrip .idmp-adtab'); if (t) t.click(); });
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(600);
+}
+// fill every mandatory editable field on the open folded create form (iDempiere asks for these on a New BP)
+async function fillBpForm(page, marker) {
+  await page.evaluate((m) => {
+    const form = document.getElementById('crudForm'); if (!form) return;
+    const set = (col, val) => { const el = form.querySelector('[data-col="' + col + '"]'); if (!el || el.disabled) return;
+      if (el.tagName === 'SELECT' && !Array.from(el.options).some(o => String(o.value) === String(val))) { const o = document.createElement('option'); o.value = val; o.textContent = val; el.appendChild(o); }
+      el.value = val; el.dispatchEvent(new Event('change', { bubbles: true })); el.dispatchEvent(new Event('input', { bubbles: true })); };
+    set('value', m); set('name', m); set('c_bp_group_id', '103');
+    ['iscustomer', 'isvendor', 'isemployee', 'issalesrep', 'issummary', 'isprospect', 'ispotaxexempt', 'is1099vendor'].forEach(c => set(c, c === 'iscustomer' ? 'Y' : 'N'));
+    set('so_creditlimit', '0');
+    // generic sweep — any still-empty, enabled, REQUIRED field (the * marker is shown) gets a sane value by type
+    form.querySelectorAll('.cfrow').forEach(row => {
+      const req = row.querySelector('.req'); const el = row.querySelector('[data-col]');
+      if (!el || el.disabled) return;
+      const required = req && req.style.display !== 'none';
+      if (required && (el.value == null || el.value === '')) {
+        if (el.tagName === 'SELECT') { const opt = Array.from(el.options).find(o => o.value); if (opt) el.value = opt.value; }
+        else { el.value = el.type === 'number' ? '0' : 'N'; }
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    });
+  }, marker);
+  await page.waitForTimeout(300);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [], errs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+
+  let pass = 0, fail = 0;
+  const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+  const lastLog = (re) => [...logs].reverse().find(l => re.test(l)) || '';
+  const anyLog = (re) => logs.some(l => re.test(l));
+
+  const bpUrl = `http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin&window=123`;
+  await gotoTenant(page, bpUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  const basePks = (await gridPks(page)).filter(p => p > 0);
+  console.log('§FOLD-CRUD setup window=123 table=c_bpartner baseRealPks=' + JSON.stringify(basePks));
+  ok('Business Partner window opens with existing C_BPartner rows (a NON-curated table)', basePks.length >= 1, 'pks=' + JSON.stringify(basePks));
+  // c_bpartner is NOT in the curated crud_ops store
+  const curated = await page.evaluate(() => { try { const st = window.__crud.store && window.__crud.store(); return !!(st && Object.prototype.hasOwnProperty.call(st, 'c_bpartner')); } catch (e) { return null; } });
+  ok('c_bpartner is NOT in the curated crud_ops allow-list (proves generality, not a hand-list)', curated === false, 'curatedHas=' + curated);
+
+  // ════════════ ACT 1 — FOLD + CREATE ════════════
+  await openRow(page, basePks[0]);
+  await tapPill(page, 'formnew');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(700);
+  const foldLog = lastLog(/§S2B-FOLD table=c_bpartner/);
+  console.log('§FOLD-CRUD ACT1 fold="' + foldLog + '"');
+  ok('§S2B-FOLD derived create/update/delete verbs for c_bpartner FROM the AD', /verbs=\[create,update,delete\]/.test(foldLog) && /isView=false/.test(foldLog), foldLog);
+  ok('New opened a create form (NOT the "not in crud_ops" skip)', anyLog(/§CRUD-HOSTCREATE table=c_bpartner open=create-form/) && !anyLog(/§CRUD-HOSTCREATE table=c_bpartner skipped/), '');
+  const marker = 'S2B-BP-' + Math.floor(port);
+  await fillBpForm(page, marker);
+  const newRingFanned = await ringOpen(page);
+  await page.evaluate(() => { const s = document.getElementById('cfSave'); if (s) s.click(); });
+  await page.waitForTimeout(1500);
+  const rejected = lastLog(/§CRUD validate key=c_bpartner verb=create REJECT/);
+  await backToGrid(page);
+  const afterCreate = await gridPks(page);
+  const createdPk = afterCreate.filter(p => p < 0)[0];
+  const persistC = lastLog(/§CRUD-PERSIST .*op=CRUD_CREATE/);
+  console.log('§FOLD-CRUD ACT1 createdPk=' + createdPk + ' ringFanned=' + newRingFanned + ' reject="' + rejected + '" persist="' + persistC + '"');
+  ok('CREATE: ONE signed CRUD_CREATE (verifyChain=ok), row appears, ring not fanned, no validate-reject',
+    /op=CRUD_CREATE.*verifyChain=ok/.test(persistC) && createdPk < 0 && !newRingFanned && !rejected, 'createdPk=' + createdPk);
+
+  // RELOAD → the created BP survives
+  await gotoTenant(page, bpUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const reloadPks1 = await gridPks(page);
+  ok('CREATE SURVIVES reload (the new BP re-folds after a fresh load)', reloadPks1.indexOf(createdPk) >= 0, 'pks=' + JSON.stringify(reloadPks1));
+  const draftPk = createdPk;
+
+  // ════════════ ACT 2 — EDIT (IsUpdateable=N display-only) ════════════
+  await openRow(page, draftPk);
+  await tapPill(page, 'formedit');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(600);
+  const editState = await page.evaluate(() => {
+    const f = document.getElementById('crudForm'), r = document.getElementById('crudRing');
+    const org = f && f.querySelector('[data-col="ad_org_id"]'), nm = f && f.querySelector('[data-col="name"]');
+    return { open: !!(f && f.classList.contains('open')), ring: !!(r && r.classList.contains('open')),
+             title: f ? (f.querySelector('.cfh') || {}).textContent : null,
+             orgDisabled: !!(org && org.disabled), nameDisabled: !!(nm && nm.disabled) };
+  });
+  console.log('§FOLD-CRUD ACT2 editState=' + JSON.stringify(editState));
+  ok('Edit opens the edit form DIRECTLY (ring not fanned)', editState.open && !editState.ring && /Edit/.test(String(editState.title || '')), JSON.stringify(editState));
+  ok('IsUpdateable=N field (AD_Org_ID) is DISPLAY-ONLY on edit; an updateable field (Name) is editable', editState.orgDisabled === true && editState.nameDisabled === false, 'orgDisabled=' + editState.orgDisabled + ' nameDisabled=' + editState.nameDisabled);
+  const marker2 = marker + '-EDIT';
+  await page.evaluate((m) => { const d = document.querySelector('#crudForm [data-col="name"]'); if (d) { d.value = m; d.dispatchEvent(new Event('input', { bubbles: true })); d.dispatchEvent(new Event('change', { bubbles: true })); } }, marker2);
+  await page.evaluate(() => { const s = document.getElementById('cfSave'); if (s) s.click(); });
+  await page.waitForTimeout(1500);
+  await backToGrid(page);
+  const persistU = lastLog(/§CRUD-PERSIST .*op=CRUD_UPDATE/);
+  console.log('§FOLD-CRUD ACT2 persist="' + persistU + '"');
+  ok('UPDATE: ONE signed CRUD_UPDATE (verifyChain=ok)', /op=CRUD_UPDATE.*verifyChain=ok/.test(persistU), persistU);
+  // RELOAD → the edited Name survives
+  await gotoTenant(page, bpUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  await openRow(page, draftPk);
+  await tapPill(page, 'formedit');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(600);
+  const reloadName = await page.evaluate(() => { const d = document.querySelector('#crudForm [data-col="name"]'); return d ? d.value : null; });
+  console.log('§FOLD-CRUD ACT2 RELOAD name="' + reloadName + '" (want "' + marker2 + '")');
+  ok('UPDATE SURVIVES reload (the edited Name re-folds)', String(reloadName) === marker2, 'got="' + reloadName + '"');
+  await page.evaluate(() => { const c = document.getElementById('cfCancel'); if (c) c.click(); });
+  await page.waitForTimeout(300); await backToGrid(page);
+
+  // ════════════ ACT 3 — DELETE ════════════
+  await openRow(page, draftPk);
+  await tapPill(page, 'formdel');
+  await page.waitForSelector('#crudForm.open', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(400);
+  const delRing = await ringOpen(page);
+  await page.evaluate(() => { const d = document.getElementById('cfDel'); if (d) d.click(); });
+  await page.waitForTimeout(1400);
+  await backToGrid(page);
+  const afterDel = await gridPks(page);
+  const persistD = lastLog(/§CRUD-PERSIST .*op=CRUD_DELETE/);
+  console.log('§FOLD-CRUD ACT3 gone=' + (afterDel.indexOf(draftPk) < 0) + ' ringFanned=' + delRing + ' persist="' + persistD + '"');
+  ok('DELETE: ONE signed CRUD_DELETE (verifyChain=ok), ring not fanned, row disappears', /op=CRUD_DELETE.*verifyChain=ok/.test(persistD) && !delRing && afterDel.indexOf(draftPk) < 0, persistD);
+  await gotoTenant(page, bpUrl);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const reloadPks2 = await gridPks(page);
+  ok('DELETE SURVIVES reload (the deleted BP stays gone)', reloadPks2.indexOf(draftPk) < 0, 'pks=' + JSON.stringify(reloadPks2));
+
+  // ════════════ ACT 4 — VIEW read-only (the SAME engine the host folds with) ════════════
+  const viewVerbs = await page.evaluate(() => {
+    try { return window.__crud.core.foldCrudSpec([{ columnName: 'X', name: 'X', isDisplayed: true, referenceType: 'string' }], { key: 'rv_unposted', isView: true }).verbs; } catch (e) { return null; }
+  });
+  ok('a VIEW (AD_Table.IsView=Y) folds to NO verbs — correctly read-only', Array.isArray(viewVerbs) && viewVerbs.length === 0, JSON.stringify(viewVerbs));
+
+  ok('0 pageerrors across all folded-CRUD acts', errs.length === 0, errs.length ? errs.slice(0, 3).join(' | ') : '');
+
+  const verdict = fail === 0;
+  console.log('\n§CRITIC-VERDICT(AD-FOLDED-CRUD) ' + (verdict ? '✅' : '🔴') + ' — CRUD is now GENERAL, not curated: a '
+    + 'window whose table is NOT in crud_ops (Business Partner) is New/Edit/Delete-capable purely from its OWN AD '
+    + '(foldCrudSpec), each op ONE signed write that survives reload; an IsUpdateable=N field is display-only on '
+    + 'Edit; a VIEW table is read-only. The signed write path is unchanged — only the spec SOURCE moved to the dict.');
+  console.log((verdict ? '✅' : '❌') + ' W-AD-FOLDED-CRUD-LIVE: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+  if (process.env.DUMP) { console.log('\n── PAGE §-LOGS ──'); logs.filter(l => /§(S2B|CRUD|LIST-TIP|FORM-PILL|AD-MODELVAL|DOCNO)/.test(l)).forEach(l => console.log('  ' + l)); }
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
## What
Retires `crud_ops.json` as the **gate**. A window whose table is NOT in the curated 5-table allow-list (e.g. **C_BPartner**) is now New/Edit/Delete-capable purely from its **own AD dictionary**, with the signed write path unchanged — the user's "rules general not custom" / Janke-Compiere AD vision.

Root cause: the only blocker was `crud_overlay.js entryFor()` returning null for a non-curated table. The form pills already surface; the write lane (`saveForm→commitCrud→listTip→reload-survival`) is already table-generic. So the fix gives `entryFor` an AD-folded fallback.

## How
- **`CORE.foldCrudSpec(adFields,opts)`** (engine, pure/testable): maps the renderer's AD-folded field shape → a crud_ops-shaped entry. Type from the **authoritative `AD_Reference_ID`** (`mapRefDisplayType` — fixes Yes-No=20 that the coarse renderer map mislabels as fk). Read-only from `AD_Table.IsView` + `AD_Tab.IsReadOnly` + per-field `IsReadOnly` + (`IsUpdateable='N'` → display-only on Edit, settable on New). `@#AD_Client_ID@/@#AD_Org_ID@/@#Date@` context defaults resolved from session Env so a mandatory system column never blocks New. `FOLDED` fallback + `entryFor` (curated wins); seams `registerFolded`/`ensureStore`/`hasEntry`.
- **`ad_parser.js`**: expose `AD_Column.IsUpdateable` on folded fields.
- **`idempiere.html`**: `_tableIsView`/`_foldCrudSpecForTab`/`_foldableTab`/`_curatedHas`; `_crudHas`=curated OR foldable; the four openers register the verb-shaped folded spec before the existing host seam. `crud_ops` stays an **optional override** (the 5 doc tables keep docPolicy fan-out + ownerGate).

### Audit gaps closed (same fold-from-AD principle)
- **(b)** `_docCtx` default warehouse from `AD_OrgInfo.M_Warehouse_ID` (not "lowest org wh id").
- **(c)** `_allocDocNo`/`_previewDocNo` honour `C_DocType.DocNoSequence_ID` when `IsDocNoControlled='Y'`.
- **(d)** `MV_INSTALLER` hardcoded 4-table map → **discover** all `install*SaveHooks` from the AdModelVal registry (~13 ported validators now apply, was 4).

## Witnesses
- **W-AD-FOLDED-CRUD 14/14** (headless engine) + **W-AD-FOLDED-CRUD-LIVE 14/14** (C_BPartner New/Edit/Delete each ONE signed op + survive reload; `IsUpdateable=N` display-only on Edit; a VIEW table read-only; 0 pageerrors).
- Regressions GREEN: crud-full 10/10, create 12/12, process 18/18, form-pill 6/6, grid-batch 7/7, gridstatus 7/7, recinfo 7/7, draft 10/10, blue 15/15.

sw **v701**; `crud_overlay.js?v=15`; `ad_parser.js?v=24`; glassbowl `crud_overlay.js?v=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)