### PR TITLE
fix(erp): close the Glass-ring leak on iDempiere's surface — ✎ re-points to the form host-seam (W-RING-LEAK 10/10)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -1086,13 +1086,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       var tab = _curTab();
       var tn = tab && tab.tableName ? String(tab.tableName).toLowerCase() : null;
       var canCrud = !!(window.__crud && tn && _crudHas(tn));
-      btn('✎ CRUD', canCrud ? 'Edit / New / Delete / Complete this record (CRUD ring)' : 'CRUD ring — this table is not in crud_ops (read-only)', canCrud, function () {
+      // RING LEAK FIX (GRAND_LANE §0: iDempiere NEVER opens the Glass/Gravity ring — Execute is iDempiere's own UI
+      //   surface). The ✎ button re-points to the SAME form host-seam the form pills use (_openEdit → __crud.update
+      //   → edit form, ring NOT fanned); New/Delete/Complete stay on the form pills + DocAction bar. enable()/
+      //   openRing()/the Edit-mode toggle are never called from this surface, so §CRUD ring … view=on and
+      //   §CRUD-IDMP-OPEN can no longer fire on iDempiere. The ring remains Glass/Gravity-only.
+      btn('✎ Edit', canCrud ? 'Edit this record (opens the form — ring not fanned)' : 'Edit — this table is read-only per its dictionary', canCrud, function () {
         if (!window.__crud || !tn) return;
-        // ensure Edit-mode is on (the overlay gates writes behind it), then open the ring on the focused table.
-        try { var ck = document.getElementById('crudModeCk'); if (ck && !ck.checked) { ck.checked = true; ck.dispatchEvent(new Event('change')); } } catch (e) {}
-        window.__crud.enable();
-        // openRing reads crud_ops.json (fetched on enable); defer one frame so the store is present.
-        var tries = 0; (function tryOpen() { if (window.__crud.openRing && window.__crud.store && window.__crud.store()) { window.__crud.openRing(tn); console.log('§CRUD-IDMP-OPEN table=' + tn + ' record=' + _curRecPk()); } else if (tries++ < 30) { setTimeout(tryOpen, 60); } })();
+        _openEdit();
       });
     })();
     sep();

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v702';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v703';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_critic_ring_leak_live.js
+++ b/erp/tests/poc_critic_ring_leak_live.js
@@ -1,0 +1,99 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for the RING-LEAK fix on the iDempiere surface (FRONTEND_LANE_MASTER.md
+//   §OUTSTANDING "RING LEAK ON iDempiere"; doctrine GRAND_LANE_STRATEGY §0). W-RING-LEAK.
+//   THE BUG: the ✎ CRUD toolbar button fanned the Glass/Gravity visual ring on iDempiere's own surface
+//     (window.__crud.enable() + openRing → §CRUD ring … view=on + §CRUD-IDMP-OPEN). S2B widened it (the
+//     foldable-aware _crudHas fires for EVERY folded table, not just the curated 5), so the leak was now
+//     reachable on any window. This VIOLATES the doctrine: "iDempiere NEVER opens the ring; Execute is
+//     iDempiere's own UI surface, never the ring." The ring is Glass/Gravity-only.
+//   THE FIX: re-point ✎ (now "✎ Edit") to the SAME form host-seam the form pills use (_openEdit →
+//     __crud.update → the edit FORM, ring NOT fanned). New/Delete/Complete already live on the form pills +
+//     DocAction bar. enable()/openRing()/the Edit-mode toggle are never called from this surface.
+//
+//   ACT — drive the ✎ Edit toolbar button on an open record (c_bpartner on the editable GardenWorld tenant,
+//     and c_order on the doc-complete Odoo tenant). Assert: the EDIT FORM opens (#crudForm.open) via the
+//     host seam (§FORM-PILL edit=edit-form … ring not fanned), and the ring-fan logs §CRUD ring … view=on
+//     and §CRUD-IDMP-OPEN NEVER appear in the console on iDempiere. 0 pageerrors. The Glass ring stays
+//     Glass-only; the iDempiere surface stays native.
+//   §-log first — READ tests/poc_critic_ring_leak_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_critic_ring_leak_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+let pass = 0, fail = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+
+// click the ✎ Edit toolbar button (re-pointed off the ring) and return whether it was found/clicked.
+const clickEditBtn = (page) => page.evaluate(() => {
+  const b = Array.from(document.querySelectorAll('#idmp-toolbar button'))
+    .find(x => (x.title || '').indexOf('Edit this record') === 0 || (x.textContent || '').trim() === '✎ Edit');
+  if (b && !b.disabled) { b.click(); return { clicked: true, label: (b.textContent || '').trim() }; }
+  return { clicked: false, label: b ? (b.textContent || '').trim() : '(no edit button)' , disabled: b ? b.disabled : null };
+});
+
+async function driveTenant(browser, port, cfg) {
+  const logs = [], errs = [];
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+  const anyLog = re => logs.some(l => re.test(l));
+
+  await page.goto(`http://localhost:${port}/idempiere.html?${cfg.boot}`, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const okb = await page.$('#idmp-login-ok'); if (okb) await okb.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(1000);
+  // enter form view on a real record (the toolbar Edit targets the focused record)
+  await page.evaluate(() => { const tr = document.querySelector('.idmp-grid tbody tr[data-ad-record]'); if (tr) tr.click(); });
+  await page.waitForTimeout(700);
+
+  const clk = await clickEditBtn(page);
+  await page.waitForSelector('#crudForm.open', { timeout: 6000 }).catch(() => {});
+  await page.waitForTimeout(600);
+  const formOpen = await page.evaluate(() => !!document.querySelector('#crudForm.open'));
+  const ringFan = anyLog(/§CRUD ring .*view=on/);
+  const idmpOpen = anyLog(/§CRUD-IDMP-OPEN/);
+  const editForm = anyLog(/§FORM-PILL edit=edit-form/);
+
+  console.log('§RING-LEAK[' + cfg.key + '] btn="' + clk.label + '" clicked=' + clk.clicked + ' formOpen=' + formOpen
+    + ' editFormLog=' + editForm + ' ringFan=' + ringFan + ' idmpOpen=' + idmpOpen);
+  ok('[' + cfg.key + '] the ✎ Edit toolbar button is present + enabled on ' + cfg.table + ' (re-pointed off the ring)', clk.clicked, 'label="' + clk.label + '"');
+  ok('[' + cfg.key + '] it opens iDempiere\'s OWN edit FORM (host seam, ring not fanned)', formOpen && editForm, 'formOpen=' + formOpen + ' §FORM-PILL=' + editForm);
+  ok('[' + cfg.key + '] the Glass/Gravity ring NEVER fans on iDempiere (no §CRUD ring … view=on)', !ringFan);
+  ok('[' + cfg.key + '] no §CRUD-IDMP-OPEN — the leak is closed', !idmpOpen);
+  ok('[' + cfg.key + '] 0 pageerrors', errs.length === 0, errs.slice(0, 2).join(' | '));
+  await page.close();
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  console.log('\n§RING-LEAK ===== ✎ Edit re-points to the form host-seam — the ring stays Glass/Gravity-only =====');
+  // GardenWorld c_bpartner (the editable tenant — the user\'s named case) + Odoo c_order (a doc window)
+  await driveTenant(browser, port, { key: 'garden-bpartner', table: 'c_bpartner', boot: 'seed=ad_seed.db&login=GardenAdmin&window=123' });
+  await driveTenant(browser, port, { key: 'odoo-order',      table: 'c_order',    boot: 'seed=ad_seed.db&shard=12-odoo.db&login=12000&window=143' });
+
+  const verdict = (fail === 0)
+    ? 'CRITIC ✔ The ring leak is closed — ✎ Edit on iDempiere opens iDempiere\'s OWN edit form via the same signed host-seam the pills use; the Glass/Gravity visual ring NEVER fans on this surface (no §CRUD ring view=on, no §CRUD-IDMP-OPEN). Doctrine §0 holds: iDempiere keeps its own UI, the ring is Glass-only, and the underlying signed-commit engine is shared.'
+    : 'CRITIC ✘ the ring still leaks on iDempiere — see the 🔴 above.';
+  console.log('\n§RING-LEAK-VERDICT ' + verdict);
+  console.log((fail === 0 ? '✅' : '❌') + ' W-RING-LEAK: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
**GRAND_LANE_STRATEGY §0:** iDempiere NEVER opens the Glass/Gravity visual ring — Execute is iDempiere's OWN UI surface, never the ring.

## The bug
The `✎ CRUD` toolbar button (`idempiere.html:1088`) fanned the ring on iDempiere's surface: `window.__crud.enable()` + `openRing(tn)` → `§CRUD ring … view=on` + `§CRUD-IDMP-OPEN`. Legacy button predating the J4/J5 form re-point; **S2B widened it** (the foldable-aware `_crudHas` fires for *every* folded table, not just the curated 5), so the leak was reachable on any window.

## The fix (one bounded `idempiere.html` leg)
Re-point `✎` (now **"✎ Edit"**) to the SAME form host-seam the form pills use — `_openEdit → __crud.update →` the edit FORM, **ring NOT fanned** (doctrine §0). New/Delete/Complete already live on the form pills + DocAction bar. `enable()`/`openRing()`/the Edit-mode toggle are never called from this surface, so `§CRUD ring … view=on` and `§CRUD-IDMP-OPEN` can no longer fire on iDempiere. The ring stays **Glass/Gravity-only**; the iDempiere surface stays native and still SHARES the underlying signed-commit engine (the `migrate_status_panel` "CRUD general on iDempiere's own screens" claim is unchanged — this is UI-surface hygiene, not a capability gap).

## Witness — W-RING-LEAK 10/10 (0 pageerrors)
`erp/tests/poc_critic_ring_leak_live.js`: the ✎ Edit button on `c_bpartner` (GardenWorld) AND `c_order` (Odoo) opens iDempiere's own edit form via the host seam (`§FORM-PILL edit=edit-form … ring not fanned`); `§CRUD ring … view=on` and `§CRUD-IDMP-OPEN` NEVER appear.

## Regressions GREEN
form-pill 6/6 · critic-crud-full 10/10 · critic-create 12/12 · ad-folded-crud-live 14/14.

erp sw `v702`→`v703`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)