### PR TITLE
feat(erp): ProjectGenOrder (AD_Process 164) — KIND-2 project→Sales Order fold

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -122,6 +122,102 @@
     }, { kind: 'docaction', action: 'Verify' });
   }
 
+  // ════════════════════════════════════════════════════════════════════════════════════════════════════════
+  // KIND-2 process handler — ProjectGenOrder (AD_Process 164 "Generate Order", classname
+  //   org.compiere.process.ProjectGenOrder, isReport=N, 0 params). The effect IS an engine verb: ASSEMBLE a
+  //   C_Order op-group via the EXISTING erp_engine.buildDoc archetype — newVerbs=0, NOT a Java port.
+  // Java home (EXTRACT, do NOT invent):
+  //   org.compiere.process.ProjectGenOrder.doIt (ProjectGenOrder.java:62-111) — generates a SALES order
+  //     (Env.setSOTrx(ctx,true); class doc "Generate Sales Order from Project"), ONE C_OrderLine per
+  //     C_ProjectLine: Qty = PlannedQty − InvoicedQty (line 96); Price = PlannedPrice when non-zero, else the
+  //     price-list price (ol.setPrice() = MProductPricing — NAMED-DEFERRED, like crud_overlay's FK membership).
+  //   org.compiere.model.MOrder(MProject,IsSOTrx,DocSubTypeSO) (MOrder.java:487-522) — the header: SO on the
+  //     On-Credit doctype (DocSubTypeSO_OnCredit="WI", MOrder.java:654); BP/BP-Loc/User/SalesRep/Campaign/
+  //     Warehouse/PriceList/PaymentTerm copied from the project; description=project name; dateordered=
+  //     datecontract, datepromised=datefinish.
+  //   ProjectGenOrder.getProject (line 120-132) — GATES on M_PriceList_Version + M_Warehouse + C_BPartner +
+  //     C_BPartner_Location, throwing IllegalArgumentException otherwise. We mirror that as an HONEST
+  //     'project-not-ready' rejection (NOT a fabricated order) — the HONESTY INVARIANT for thin/PoC seeds.
+  //   MProject.getM_PriceList_ID (MProject.java:168-178) — pricelist = the version's M_PriceList_ID (resolved
+  //     by the host fetcher, keeping this module DB-agnostic).
+  // Implementing AD_PROCESS_FOLD_LANE.md §P1 — Witness: W-PROC-GENPO
+  // ════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+  // projectGenGate — ProjectGenOrder.getProject's four IllegalArgumentException checks, as a returnable verdict.
+  function projectGenGate(p) {
+    if (!p || !p.c_project_id)                       return { ok: false, missing: 'C_Project_ID',          message: 'Project not found' };
+    if (!p.m_pricelist_version_id)                   return { ok: false, missing: 'M_PriceList_Version_ID', message: 'Project has no Price List' };
+    if (!p.m_warehouse_id)                           return { ok: false, missing: 'M_Warehouse_ID',         message: 'Project has no Warehouse' };
+    if (!p.c_bpartner_id || !p.c_bpartner_location_id) return { ok: false, missing: 'C_BPartner(_Location)_ID', message: 'Project has no Business Partner/Location' };
+    return { ok: true };
+  }
+
+  // genOrderLines — per C_ProjectLine → the order-line shape: Qty = PlannedQty − InvoicedQty; PriceActual =
+  // PlannedPrice when non-zero (the price-list branch is named-deferred → priceactual:null = "from price list").
+  // No money arithmetic here (qty/price are carried verbatim from the source row; the kernel does the cent math
+  // via bigdecimal.js downstream) — staging only, EXTRACT-not-invent.
+  function genOrderLines(lines) {
+    return (lines || []).map(function (l) {
+      var qty = Number(l.plannedqty || 0) - Number(l.invoicedqty || 0);
+      var fromPlanned = Number(l.plannedprice || 0) !== 0;
+      return {
+        c_projectline_id: l.c_projectline_id, m_product_id: l.m_product_id,
+        qtyordered: qty, line: l.line, description: l.description,
+        priceactual: fromPlanned ? l.plannedprice : null, _priceFromPlanned: fromPlanned
+      };
+    });
+  }
+
+  // GENORDER_SPEC — the buildDoc archetype spec for a project→SalesOrder fold (table-parameterised, no new verb).
+  var GENORDER_SPEC = {
+    docTable: 'C_Order', lineTable: 'C_OrderLine',
+    parentId: 'c_project_id', lineParentId: 'c_projectline_id',
+    qtyTo: 'qtyordered', qtyFrom: 'qtyordered',
+    header: function (p) {
+      return {
+        issotrx: 'Y', docsubtypeso: 'WI',                 // SO, On-Credit (MOrder.DocSubTypeSO_OnCredit)
+        c_doctypetarget_id: p._c_doctypetarget_id || null, // resolved on-credit SO doctype (host-supplied)
+        ad_client_id: p.ad_client_id, ad_org_id: p.ad_org_id,
+        c_bpartner_id: p.c_bpartner_id, c_bpartner_location_id: p.c_bpartner_location_id,
+        ad_user_id: p.ad_user_id, salesrep_id: p.salesrep_id, c_campaign_id: p.c_campaign_id,
+        m_warehouse_id: p.m_warehouse_id, m_pricelist_id: p.m_pricelist_id,
+        c_paymentterm_id: p.c_paymentterm_id,
+        description: p.name, dateordered: p.datecontract, datepromised: p.datefinish,
+        c_project_id: p.c_project_id
+      };
+    }
+  };
+
+  // registerProjectGenOrder(engine) — wire the KIND-2 handler; engine = erp_engine API (its buildDoc archetype).
+  // ctx the handler consumes: fetchProject(info)->project row (with m_pricelist_id + _c_doctypetarget_id
+  //   resolved), fetchProjectLines(info)->C_ProjectLine rows. info.Record_ID = the C_Project_ID (prepare()).
+  function registerProjectGenOrder(engine) {
+    registerHandler('org.compiere.process.ProjectGenOrder', function (ctx, info) {
+      var project = ctx.fetchProject ? ctx.fetchProject(info) : null;
+      var gate = projectGenGate(project);
+      if (!gate.ok) {
+        // getProject's IllegalArgumentException — honest rejection, NEVER a fabricated order.
+        return { ok: false, reason: 'project-not-ready', message: gate.message, rows: 0, result: { gate: gate } };
+      }
+      var norm = genOrderLines(ctx.fetchProjectLines ? ctx.fetchProjectLines(info) : []);
+      // KIND-2: the op-group rides the buildDoc archetype (CREATE_DOCUMENT + N CREATE_LINE), newVerbs=0.
+      var ops = engine.buildDoc(GENORDER_SPEC, project, norm);
+      // Decorate each CREATE_LINE with the source line's Line/Description/PriceActual (buildDoc carries only
+      // m_product_id + qtyordered). All EXTRACTED from the C_ProjectLine row — nothing invented.
+      var li = 0;
+      ops.forEach(function (op) {
+        if (op.op_type !== 'CREATE_LINE') return;
+        var n = norm[li++];
+        op.line = n.line; op.description = n.description; op.priceactual = n.priceactual;
+      });
+      return {
+        ok: true, rows: norm.length,
+        message: '@C_Order_ID@ generated from project (' + norm.length + ' line' + (norm.length === 1 ? '' : 's') + ')',
+        result: { ops: ops, lineCount: norm.length, header: ops[0], issotrx: 'Y', docsubtypeso: 'WI' }
+      };
+    }, { kind: 'process', action: 'GenerateOrder' });
+  }
+
   // ── Read the AD rows for a process: header + ordered params (the ProcessInfo source). ─────────────────
   function readProcess(db, ad_process_id) {
     var p = db.prepare('SELECT ad_process_id,value,name,classname,isreport,procedurename,jasperreport,ad_reportview_id FROM ad_process WHERE ad_process_id=?').get(ad_process_id);
@@ -213,16 +309,64 @@
     return {
       ad_process_id: proc.AD_Process_ID, name: proc.name, classname: classname,
       kind: entry.meta.kind || 'process', dispatched: true,
-      ok: out.ok !== false, reason: out.ok === false ? 'handler-failed' : 'ok',
+      ok: out.ok !== false, reason: out.ok === false ? (out.reason || 'handler-failed') : 'ok',
       validate: validate, rows: out.rows || 0, message: out.message, result: out.result
     };
+  }
+
+  // ── pickUsedProcesses — the P3 ON-DEMAND PICKER (GAP_CLOSURE_LANE §P3.5) ─────────────────────────────
+  // Returns the ACTUALLY-USED subset of AD_Process via TWO lenses, unioned:
+  //   byAccess  — AD_Process ⋈ AD_Process_Access (processes granted to at least one active role)
+  //   byWorkflow— AD_Process ⋈ AD_WF_Node        (processes that appear in a workflow node)
+  // This IS the mechanism; the 337-classname corpus is NOT pre-ported.
+  // opts.roles  — array of ad_role_id to narrow the access lens (default: all active roles)
+  // opts.includeWfNodes — false to skip the workflow lens (default: true)
+  // Implements GAP_CLOSURE_LANE.md §P3.5 — Witness: W-PROC-PICKER
+  function pickUsedProcesses(db, opts) {
+    opts = opts || {};
+    var roleClause = '';
+    if (opts.roles && opts.roles.length > 0) {
+      roleClause = ' AND pa.ad_role_id IN (' + opts.roles.map(Number).join(',') + ')';
+    }
+
+    // lens 1: access grants — AD_Process ⋈ AD_Process_Access
+    var byAccess = db.prepare(
+      "SELECT DISTINCT p.ad_process_id, p.value, p.classname, p.isreport " +
+      "FROM ad_process p " +
+      "JOIN ad_process_access pa ON pa.ad_process_id=p.ad_process_id AND pa.isactive='Y' " +
+      "WHERE p.isactive='Y'" + roleClause +
+      " ORDER BY p.ad_process_id"
+    ).all();
+
+    // lens 2: workflow nodes — AD_WF_Node ⋈ AD_Process (processes referenced as node actions)
+    var byWorkflow = [];
+    if (opts.includeWfNodes !== false) {
+      byWorkflow = db.prepare(
+        "SELECT DISTINCT p.ad_process_id, p.value, p.classname, p.isreport " +
+        "FROM ad_process p " +
+        "JOIN ad_wf_node n ON n.ad_process_id=p.ad_process_id AND n.isactive='Y' " +
+        "WHERE p.isactive='Y' ORDER BY p.ad_process_id"
+      ).all();
+    }
+
+    // union by ad_process_id (deterministic sort for oracle diff)
+    var seen = Object.create(null), union = [];
+    byAccess.concat(byWorkflow).forEach(function (r) {
+      if (!seen[r.ad_process_id]) { seen[r.ad_process_id] = true; union.push(r); }
+    });
+    union.sort(function (a, b) { return a.ad_process_id - b.ad_process_id; });
+
+    return { byAccess: byAccess, byWorkflow: byWorkflow, union: union };
   }
 
   var API = {
     REGISTRY: REGISTRY, registerHandler: registerHandler, hasHandler: hasHandler,
     registeredClassnames: registeredClassnames, installDefaultHandlers: installDefaultHandlers,
+    registerProjectGenOrder: registerProjectGenOrder, projectGenGate: projectGenGate,
+    genOrderLines: genOrderLines, GENORDER_SPEC: GENORDER_SPEC,
     readProcess: readProcess, resolveClassname: resolveClassname,
     validateParams: validateParams, dispatch: dispatch,
+    pickUsedProcesses: pickUsedProcesses,
     refType: refType, typeOk: typeOk, REF_TYPE: REF_TYPE
   };
 

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -421,7 +421,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=1"></script>
+<script src="ad_process.js?v=2"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -1854,8 +1854,12 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     if (_procHandlersInstalled || !window.AdProcess) return;
     var core = (window.__report && window.__report.core) ? window.__report.core : null;
     window.AdProcess.installDefaultHandlers(core);
+    // §GENPO-LIVE — the KIND-2 ProjectGenOrder handler (AD_Process 164) rides the EXISTING erp_engine.buildDoc
+    // archetype (newVerbs=0). Implementing AD_PROCESS_FOLD_LANE.md §P1 — Witness: W-PROC-GENPO-LIVE.
+    if (window.ERPEngine && typeof window.AdProcess.registerProjectGenOrder === 'function')
+      window.AdProcess.registerProjectGenOrder(window.ERPEngine);
     _procHandlersInstalled = true;
-    console.log('§AD-PROC-LIVE handlers=[' + window.AdProcess.registeredClassnames().join(',') + '] reportCore=' + (core ? 'Y' : 'N'));
+    console.log('§AD-PROC-LIVE handlers=[' + window.AdProcess.registeredClassnames().join(',') + '] reportCore=' + (core ? 'Y' : 'N') + ' engine=' + (window.ERPEngine ? 'Y' : 'N'));
   }
   // raw sql.js exec → array of lowercase-keyed row objects; an ABSENT table (seed slice) → [] + §-named, never a throw.
   function _sqlRows(sql) {
@@ -1907,7 +1911,28 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         return m;
       },
       countFacts: function () { var r = _sqlRows('SELECT count(*) n FROM fact_acct'); return r.length ? Number(r[0].n) : 0; },
-      countDocTypes: function () { var r = _sqlRows('SELECT count(*) n FROM c_doctype'); return r.length ? Number(r[0].n) : 0; }
+      countDocTypes: function () { var r = _sqlRows('SELECT count(*) n FROM c_doctype'); return r.length ? Number(r[0].n) : 0; },
+      // §GENPO-LIVE — ProjectGenOrder accessors. fetchProject resolves the version→pricelist (getM_PriceList_ID)
+      // + the On-Credit SO doctype (DocSubTypeSO_OnCredit='WI'), every value a REAL seed row. info.Record_ID =
+      // the chosen C_Project_ID (prepare()/getRecord_ID). A thin project (no warehouse/pricelist) → the handler's
+      // getProject gate honestly REJECTS — the seed's truth, never a fabricated order.
+      fetchProject: function (info) {
+        var id = info && info.Record_ID; if (id == null) return null;
+        var p = _sqlRows('SELECT * FROM c_project WHERE c_project_id=' + Number(id))[0]; if (!p) return null;
+        if (p.m_pricelist_version_id != null) {
+          var plv = _sqlRows('SELECT m_pricelist_id FROM m_pricelist_version WHERE m_pricelist_version_id=' + Number(p.m_pricelist_version_id))[0];
+          if (plv) p.m_pricelist_id = plv.m_pricelist_id;
+        }
+        var cl = (_session && _session.client) ? Number(_session.client.id) : null;
+        var dt = _sqlRows("SELECT c_doctype_id FROM c_doctype WHERE docsubtypeso='WI' AND docbasetype='SOO'" +
+          (cl != null ? ' AND ad_client_id=' + cl : '') + ' ORDER BY c_doctype_id LIMIT 1')[0];
+        p._c_doctypetarget_id = dt ? dt.c_doctype_id : null;
+        return p;
+      },
+      fetchProjectLines: function (info) {
+        var id = info && info.Record_ID; if (id == null) return [];
+        return _sqlRows('SELECT * FROM c_projectline WHERE c_project_id=' + Number(id) + ' ORDER BY line, c_projectline_id');
+      }
     };
   }
   // default resolution — ONLY the session-backed context vars resolve (real values, never invented);
@@ -1933,8 +1958,37 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     catch (e) { status('Process ' + processId + ' not found'); console.log('§AD-PROC-LIVE proc=' + processId + ' read-failed: ' + e.message); return; }
     console.log('§AD-PROC-LIVE open proc=' + proc.AD_Process_ID + ' name="' + proc.name + '" report=' + (proc.isReport ? 'Y' : 'N') + ' paras=' + proc.paras.length);
     status((name || proc.name) + ' — ' + (proc.isReport ? 'report' : 'process') + ' (AD_Process ' + proc.AD_Process_ID + ')');
+    // §GENPO-LIVE — ProjectGenOrder is RECORD-scoped (getRecord_ID = the C_Project). Its AD trigger button
+    // (C_Project.GenerateTo, ref 28) is dropped by the S2B foldCrudSpec, so the menu/process path supplies the
+    // project via a picker (decoupled path (a), AD_PROCESS_FOLD_LANE §CONFLICT). Every project row is real seed.
+    if (proc.classname === 'org.compiere.process.ProjectGenOrder') { renderProjectPicker(proc); return; }
     if (proc.paras.length) renderProcParamForm(proc);
     else runProcess(proc, {});
+  }
+  function renderProjectPicker(proc) {
+    var pane = el('div', 'idmp-procpane idmp-procform');
+    pane.appendChild(el('h3', null, proc.name));
+    pane.appendChild(el('div', 'sub', 'Process · AD_Process ' + proc.AD_Process_ID + ' · pick the project to generate a Sales Order from'));
+    var rows = _sqlRows('SELECT c_project_id, value, name FROM c_project ORDER BY c_project_id');
+    var fld = el('div', 'fld'); fld.appendChild(el('label', null, 'Project'));
+    var sel = document.createElement('select'); sel.setAttribute('data-genpo-project', '1');
+    if (!rows.length) { var o0 = el('option', null, '— no projects in this tenant —'); o0.value = ''; sel.appendChild(o0); }
+    rows.forEach(function (r) { var o = el('option', null, (r.value ? r.value + ' — ' : '') + (r.name || ('Project ' + r.c_project_id))); o.value = String(r.c_project_id); sel.appendChild(o); });
+    fld.appendChild(sel); pane.appendChild(fld);
+    var actions = el('div', 'actions');
+    var run = el('button', 'run', 'Generate Order'); run.setAttribute('data-proc-run', '1');
+    var cancel = el('button', null, 'Cancel');
+    run.addEventListener('click', function () {
+      var id = sel.value ? Number(sel.value) : null;
+      if (id == null) { status('Pick a project first'); return; }
+      console.log('§GENPO-LIVE run proc=' + proc.AD_Process_ID + ' Record_ID(C_Project_ID)=' + id);
+      runProcess(proc, {}, id);
+    });
+    cancel.addEventListener('click', function () {
+      $('idmp-content').innerHTML = '<div id="idmp-placeholder"><div class="big">&#128193;</div>Select a menu item to open a window.</div>'; status('Ready');
+    });
+    actions.appendChild(run); actions.appendChild(cancel); pane.appendChild(actions);
+    _showProcPane(pane);
   }
   function renderProcParamForm(proc) {
     var pane = el('div', 'idmp-procpane idmp-procform');
@@ -2002,12 +2056,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     pane.appendChild(actions); pane.appendChild(err);
     _showProcPane(pane);
   }
-  function runProcess(proc, params) {
+  function runProcess(proc, params, recordId) {
     var b = _b3(window.__idmpDb);
-    var res = window.AdProcess.dispatch(b, { AD_Process_ID: proc.AD_Process_ID, params: params }, _procCtx());
+    var info = { AD_Process_ID: proc.AD_Process_ID, params: params };
+    if (recordId != null) info.Record_ID = recordId;          // §GENPO-LIVE — record-scoped processes (getRecord_ID)
+    var res = window.AdProcess.dispatch(b, info, _procCtx());
     console.log('§AD-PROC-LIVE proc=' + res.ad_process_id + ' name="' + res.name + '" classname=' + (res.classname || '(blank)') +
       ' dispatched=' + (res.dispatched ? 'Y' : 'N') +
-      (res.dispatched ? ' ok=' + (res.ok ? 'Y' : 'N') + ' rows=' + res.rows : ' reason=' + res.reason));
+      (res.dispatched ? ' ok=' + (res.ok ? 'Y' : 'N') + ' rows=' + res.rows + (res.ok ? '' : ' reason=' + res.reason) : ' reason=' + res.reason));
     renderProcResult(proc, res);
   }
   function renderProcResult(proc, res) {
@@ -2036,6 +2092,24 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       else if (r.total != null) pane.appendChild(el('div', 'msg', 'Subtotal ' + r.subtotal + ' · Tax ' + r.tax + ' · Total ' + r.total));
       if (r.foldsFrom === 'fact_acct' && res.rows === 0)
         pane.appendChild(el('div', 'gap', 'fact_acct is not carried in ad_seed.db — the journal folds to an honest empty statement (seed scope, not engine scope).'));
+    }
+    // §GENPO-LIVE — a KIND-2 op-group result (ProjectGenOrder): render the would-be C_Order header + lines folded
+    // from the project (CREATE_DOCUMENT + N CREATE_LINE). EXTRACT: every value comes from the project / its lines.
+    if (!absent && r && r.ops && r.header) {
+      var h = r.header;
+      pane.appendChild(el('div', 'msg', 'C_Order (' + (h.issotrx === 'Y' ? 'Sales' : 'Purchase') + ', On-Credit) from project ' +
+        h.c_project_id + ' · BPartner ' + h.c_bpartner_id + ' · Warehouse ' + h.m_warehouse_id + ' · PriceList ' + h.m_pricelist_id));
+      var lns = r.ops.filter(function (o) { return o.op_type === 'CREATE_LINE'; });
+      var t = document.createElement('table'), tr = el('tr');
+      ['#', 'Product', 'Qty', 'Price'].forEach(function (hd, i) { tr.appendChild(el('th', i >= 2 ? 'r' : null, hd)); }); t.appendChild(tr);
+      lns.forEach(function (op) {
+        tr = el('tr');
+        [op.line, op.m_product_id, op.qtyordered, op.priceactual == null ? '(price list)' : op.priceactual]
+          .forEach(function (cv, i) { tr.appendChild(el('td', i >= 2 ? 'r' : null, cv == null ? '' : String(cv))); });
+        t.appendChild(tr);
+      });
+      pane.appendChild(t);
+      pane.appendChild(el('div', 'msg', r.lineCount + ' order line' + (r.lineCount === 1 ? '' : 's') + ' folded (Qty = PlannedQty − InvoicedQty; Price = PlannedPrice)'));
     }
     var back = el('div', null); var bb = el('button', null, 'Close');
     bb.style.cssText = 'margin-top:12px;font-size:12.5px;padding:5px 16px;border:1px solid var(--idmp-border);border-radius:6px;background:var(--idmp-panel);cursor:pointer';

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v703';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v704';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
AD_PROCESS_FOLD_LANE §P1. AD_Process 164 dispatches via the W-PROC spine to a KIND-2 handler that folds a C_Project → a C_Order op-group through the existing `erp_engine.buildDoc` archetype (newVerbs=0).

**Extracted from real iDempiere source (NON-INVENT):**
- `ProjectGenOrder.java` — generates a **Sales** order (Env.setSOTrx=true), one C_OrderLine per C_ProjectLine: Qty = PlannedQty − InvoicedQty, Price = PlannedPrice. (The lane card's "(PO)" guess is corrected against source.)
- `MOrder.java:487-522` — header from project, On-Credit SO doctype ("WI").
- getProject gate (PriceList-Version/Warehouse/BPartner/Location) → honest `project-not-ready` rejection, never a fabricated order (HONESTY INVARIANT).

**Witnesses:** W-PROC-GENPO (headless, fold == independent SQL re-derivation to the cent + PlannedQty falsifier) · W-PROC-GENPO-LIVE (live dispatch, real-project picker, thin project honestly rejected, 0 pageerrors).

sw v704 · ad_process.js?v=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)