### PR TITLE
feat(erp): InvoiceGenerate (AD_Process 119) — KIND-2 fold CO Sales Order→C_Invoice — erp sw v707

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -250,6 +250,101 @@
     }
   };
 
+  // ════════════════════════════════════════════════════════════════════════════════════════════════════════
+  // KIND-2 process handler — InvoiceGenerate (AD_Process 119 "Generate Invoices", classname
+  //   org.compiere.process.InvoiceGenerate, isReport=N). The order-to-cash CLOSER + sibling of InOutGenerate: a
+  //   Completed Sales Order → a C_Invoice (invoice) op-group via the EXISTING erp_engine.buildDoc archetype
+  //   (KIND 2, newVerbs=0 — the DOC_SPECS.createInvoice shape). InvoiceRule is the sibling of DeliveryRule.
+  // Java home (EXTRACT, do NOT invent) — org.compiere.process.InvoiceGenerate:
+  //   doIt/generate — selects DocStatus IN('CO','CL') AND IsSOTrx='Y' orders that have a line with
+  //     QtyOrdered<>QtyInvoiced (line 159/167/176). Then branches on the order's InvoiceRule (X_C_Order:1546-1552:
+  //       'I' Immediate, 'D' AfterDelivery, 'O' AfterOrderDelivered, 'S' CustomerScheduleAfterDelivery):
+  //       'I' Immediate → the DIRECT order-line fold (the "After Order Delivered, Immediate" else-branch,
+  //          line 293-337): per order line toInvoice = QtyOrdered − QtyInvoiced (line 299); SKIP if
+  //          toInvoice.signum()==0 AND M_Product_ID != 0 ("nothing to invoice", line 300-301); createLine
+  //          (order,oLine,toInvoice,...) (line 325). EXACTLY the DOC_SPECS.createInvoice shape — newVerbs=0.
+  //       'D'/'O'/'S' → invoice from SHIPMENT lines (order.getShipments(), line 271-291 / 340-360) or an
+  //          MInvoiceSchedule (line 248-268). Those ride the SHIPMENT/SCHEDULE corpus (itself the InOutGenerate
+  //          output) — NAMED-DEFERRED here (honest, flagged in the result), the same law as InOutGenerate's
+  //          O/L/M/5 DeliveryRules. NOT a silent skip, NEVER a fabricated invoice.
+  //   createLine (line 388-413) — m_invoice = new MInvoice(order,...): Bill BPartner/Location, PriceList,
+  //     PaymentTerm, Currency, the SOO target doctype copied from the order; MInvoiceLine.setOrderLine +
+  //     setQtyInvoiced(toInvoice). Header copied from the order EXACTLY like createShipment's M_InOut header.
+  // Implementing AD_PROCESS_FOLD_LANE.md §P2-leg2 — Witness: W-PROC-INV
+  // ════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+  // invoiceGenGate — InvoiceGenerate's selection predicate as a per-order verdict (DocStatus IN('CO','CL') AND
+  // IsSOTrx='Y'). The "has an un-invoiced line" requirement is enforced by the empty-result branch downstream.
+  function invoiceGenGate(o) {
+    if (!o || !o.c_order_id)                       return { ok: false, missing: 'C_Order_ID', message: 'Order not found' };
+    if (o.docstatus !== 'CO' && o.docstatus !== 'CL') return { ok: false, missing: 'DocStatus', message: 'Order is not Completed/Closed (Generate Invoices invoices CO/CL orders only)' };
+    if (o.issotrx !== 'Y')                         return { ok: false, missing: 'IsSOTrx',   message: 'Order is not a Sales Order (Generate Invoices is the SO path)' };
+    return { ok: true };
+  }
+
+  // genInvoiceLines — per C_OrderLine → the invoice-line shape: QtyInvoiced = toInvoice (Immediate rule only).
+  // toInvoice = QtyOrdered − QtyInvoiced (signum-0 with a product → "nothing to invoice" → skip, source line 300).
+  // Non-Immediate rules ('D'/'O'/'S') invoice from the shipment/schedule corpus → NAMED-DEFERRED (deferredRule
+  // carries the code), exactly InOutGenerate's non-F/A deferral. EXTRACT-not-invent (qty carried verbatim).
+  function genInvoiceLines(orderLines, invoiceRule) {
+    var out = [], deferredRule = null;
+    if (invoiceRule !== 'I') {                                                 // D/O/S — shipment/schedule corpus
+      return { lines: out, deferredRule: invoiceRule || null };               //   named-deferred (honest)
+    }
+    (orderLines || []).forEach(function (l) {
+      var toInvoice = Number(l.qtyordered || 0) - Number(l.qtyinvoiced || 0);
+      if (toInvoice === 0 && Number(l.m_product_id || 0) !== 0) return;        // "nothing to invoice" (source 300)
+      if (toInvoice <= 0) return;                                              // over-invoiced / zero charge → skip
+      out.push({ c_orderline_id: l.c_orderline_id, m_product_id: l.m_product_id, qtyinvoiced: toInvoice, line: l.line, toInvoice: toInvoice });
+    });
+    return { lines: out, deferredRule: deferredRule };
+  }
+
+  // INVOICE_SPEC — the buildDoc archetype spec for an order→invoice fold (the createInvoice shape). The header
+  // is copied from the order EXACTLY like SHIPMENT_SPEC (Bill_Location is the invoice's C_BPartner_Location).
+  var INVOICE_SPEC = {
+    docTable: 'C_Invoice', lineTable: 'C_InvoiceLine',
+    parentId: 'c_order_id', lineParentId: 'c_orderline_id',
+    qtyTo: 'qtyinvoiced', qtyFrom: 'qtyinvoiced',
+    header: function (o) {
+      return {
+        issotrx: o.issotrx,
+        ad_client_id: o.ad_client_id, ad_org_id: o.ad_org_id,
+        c_bpartner_id: o.c_bpartner_id,
+        c_bpartner_location_id: o.bill_location_id || o.c_bpartner_location_id,  // MInvoice uses Bill_Location
+        c_currency_id: o.c_currency_id, c_paymentterm_id: o.c_paymentterm_id,
+        m_pricelist_id: o.m_pricelist_id, c_order_id: o.c_order_id
+      };
+    }
+  };
+
+  // registerInvoiceGenerate(engine) — wire the KIND-2 handler. ctx: fetchOrder(info)->C_Order row,
+  //   fetchOrderLines(info)->C_OrderLine rows. info.Record_ID = the C_Order_ID.
+  function registerInvoiceGenerate(engine) {
+    registerHandler('org.compiere.process.InvoiceGenerate', function (ctx, info) {
+      var order = ctx.fetchOrder ? ctx.fetchOrder(info) : null;
+      var gate = invoiceGenGate(order);
+      if (!gate.ok) return { ok: false, reason: 'order-not-invoiceable', message: gate.message, rows: 0, result: { gate: gate } };
+      var built = genInvoiceLines(ctx.fetchOrderLines ? ctx.fetchOrderLines(info) : [], order.invoicerule);
+      if (!built.lines.length) {
+        // Honest empty — every ordered qty already invoiced (or the rule is named-deferred). NOT a fake invoice.
+        return {
+          ok: true, rows: 0,
+          message: '@Created@ = 0' + (built.deferredRule ? ' (InvoiceRule ' + built.deferredRule + ' invoices from shipments/schedule — named-deferred)' : ' (nothing to invoice — ordered qty already invoiced)'),
+          result: { ops: [], lineCount: 0, deferredRule: built.deferredRule }
+        };
+      }
+      var ops = engine.buildDoc(INVOICE_SPEC, order, built.lines);
+      var li = 0;
+      ops.forEach(function (op) { if (op.op_type === 'CREATE_LINE') { op.line = built.lines[li++].line; } });
+      return {
+        ok: true, rows: built.lines.length,
+        message: '@Created@ = 1 (' + built.lines.length + ' invoice line' + (built.lines.length === 1 ? '' : 's') + ')',
+        result: { ops: ops, lineCount: built.lines.length, header: ops[0], issotrx: ops[0].issotrx, deferredRule: built.deferredRule }
+      };
+    }, { kind: 'process', action: 'GenerateInvoice' });
+  }
+
   // registerInOutGenerate(engine) — wire the KIND-2 handler. ctx: fetchOrder(info)->C_Order row,
   //   fetchOrderLines(info)->C_OrderLine rows, onHandOf(productId)->on-hand qty in the order's warehouse.
   function registerInOutGenerate(engine) {
@@ -459,6 +554,8 @@
     genOrderLines: genOrderLines, GENORDER_SPEC: GENORDER_SPEC,
     registerInOutGenerate: registerInOutGenerate, inoutGenGate: inoutGenGate,
     genShipmentLines: genShipmentLines, SHIPMENT_SPEC: SHIPMENT_SPEC,
+    registerInvoiceGenerate: registerInvoiceGenerate, invoiceGenGate: invoiceGenGate,
+    genInvoiceLines: genInvoiceLines, INVOICE_SPEC: INVOICE_SPEC,
     readProcess: readProcess, resolveClassname: resolveClassname,
     validateParams: validateParams, dispatch: dispatch,
     pickUsedProcesses: pickUsedProcesses,

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -424,7 +424,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=3"></script>
+<script src="ad_process.js?v=4"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -1865,6 +1865,10 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // (shipment) via the createShipment archetype (newVerbs=0). AD_PROCESS_FOLD_LANE §P2 — W-PROC-SHIP-LIVE.
     if (window.ERPEngine && typeof window.AdProcess.registerInOutGenerate === 'function')
       window.AdProcess.registerInOutGenerate(window.ERPEngine);
+    // §GENINV-LIVE — the KIND-2 InvoiceGenerate handler (AD_Process 119): a CO Sales Order → C_Invoice via the
+    // createInvoice archetype (newVerbs=0). AD_PROCESS_FOLD_LANE §P2-leg2 — Witness: W-PROC-INV-LIVE.
+    if (window.ERPEngine && typeof window.AdProcess.registerInvoiceGenerate === 'function')
+      window.AdProcess.registerInvoiceGenerate(window.ERPEngine);
     _procHandlersInstalled = true;
     console.log('§AD-PROC-LIVE handlers=[' + window.AdProcess.registeredClassnames().join(',') + '] reportCore=' + (core ? 'Y' : 'N') + ' engine=' + (window.ERPEngine ? 'Y' : 'N'));
   }
@@ -1987,29 +1991,41 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // §GENSHIP-LIVE — InOutGenerate is record-scoped here (ship ONE order). The menu form is a warehouse-batch
     // selector; we offer the journey-coherent "ship this order" picker (CO Sales Orders), warehouse from the order.
     if (proc.classname === 'org.compiere.process.InOutGenerate') { renderOrderPicker(proc); return; }
+    // §GENINV-LIVE — InvoiceGenerate is record-scoped here (invoice ONE order). Same CO Sales Order picker as
+    // Generate Shipments; the order supplies the mandatory AD_Org_ID para (DocAction defaults to Complete).
+    if (proc.classname === 'org.compiere.process.InvoiceGenerate') { renderOrderPicker(proc); return; }
     if (proc.paras.length) renderProcParamForm(proc);
     else runProcess(proc, {});
   }
   function renderOrderPicker(proc) {
+    // Shared CO Sales Order picker for the two KIND-2 order-to-cash generators: Generate Shipments
+    // (InOutGenerate, M_Warehouse_ID para from the order) + Generate Invoices (InvoiceGenerate, AD_Org_ID para
+    // from the order; InvoiceGenerate also takes CL orders). The order supplies the mandatory para in both cases.
+    var isInv = proc.classname === 'org.compiere.process.InvoiceGenerate';
+    var verb = isInv ? 'Generate Invoice' : 'Generate Shipment';
+    var tag = isInv ? '§GENINV-LIVE' : '§GENSHIP-LIVE';
     var pane = el('div', 'idmp-procpane idmp-procform');
     pane.appendChild(el('h3', null, proc.name));
-    pane.appendChild(el('div', 'sub', 'Process · AD_Process ' + proc.AD_Process_ID + ' · pick a completed Sales Order to generate a shipment from'));
-    var rows = _sqlRows("SELECT c_order_id, documentno, deliveryrule, m_warehouse_id FROM c_order WHERE docstatus='CO' AND issotrx='Y' ORDER BY c_order_id");
+    pane.appendChild(el('div', 'sub', 'Process · AD_Process ' + proc.AD_Process_ID + ' · pick a completed Sales Order to ' + (isInv ? 'generate an invoice from' : 'generate a shipment from')));
+    var statusClause = isInv ? "docstatus IN ('CO','CL')" : "docstatus='CO'";
+    var rows = _sqlRows("SELECT c_order_id, documentno, deliveryrule, invoicerule, m_warehouse_id, ad_org_id FROM c_order WHERE " + statusClause + " AND issotrx='Y' ORDER BY c_order_id");
     var fld = el('div', 'fld'); fld.appendChild(el('label', null, 'Sales Order'));
-    var sel = document.createElement('select'); sel.setAttribute('data-genship-order', '1');
+    var sel = document.createElement('select'); sel.setAttribute(isInv ? 'data-geninv-order' : 'data-genship-order', '1');
     if (!rows.length) { var o0 = el('option', null, '— no completed Sales Orders in this tenant —'); o0.value = ''; sel.appendChild(o0); }
-    rows.forEach(function (r) { var o = el('option', null, (r.documentno || ('Order ' + r.c_order_id)) + '  (rule ' + r.deliveryrule + ')'); o.value = String(r.c_order_id); o.setAttribute('data-wh', String(r.m_warehouse_id)); sel.appendChild(o); });
+    rows.forEach(function (r) { var o = el('option', null, (r.documentno || ('Order ' + r.c_order_id)) + '  (rule ' + (isInv ? r.invoicerule : r.deliveryrule) + ')'); o.value = String(r.c_order_id); o.setAttribute('data-wh', String(r.m_warehouse_id)); o.setAttribute('data-org', String(r.ad_org_id)); sel.appendChild(o); });
     fld.appendChild(sel); pane.appendChild(fld);
     var actions = el('div', 'actions');
-    var run = el('button', 'run', 'Generate Shipment'); run.setAttribute('data-proc-run', '1');
+    var run = el('button', 'run', verb); run.setAttribute('data-proc-run', '1');
     var cancel = el('button', null, 'Cancel');
     run.addEventListener('click', function () {
       var opt = sel.options[sel.selectedIndex];
       var id = sel.value ? Number(sel.value) : null;
       if (id == null) { status('Pick a Sales Order first'); return; }
-      var wh = opt ? Number(opt.getAttribute('data-wh')) : null;   // M_Warehouse_ID is a mandatory para — from the order
-      console.log('§GENSHIP-LIVE run proc=' + proc.AD_Process_ID + ' Record_ID(C_Order_ID)=' + id + ' M_Warehouse_ID=' + wh);
-      runProcess(proc, wh != null ? { M_Warehouse_ID: wh } : {}, id);
+      var params, wh = opt ? Number(opt.getAttribute('data-wh')) : null, org = opt ? Number(opt.getAttribute('data-org')) : null;
+      if (isInv) params = { AD_Org_ID: org, DocAction: 'CO' };     // AD_Org_ID is the mandatory para — from the order; DocAction = Complete
+      else params = wh != null ? { M_Warehouse_ID: wh } : {};       // M_Warehouse_ID is the mandatory para — from the order
+      console.log(tag + ' run proc=' + proc.AD_Process_ID + ' Record_ID(C_Order_ID)=' + id + (isInv ? ' AD_Org_ID=' + org : ' M_Warehouse_ID=' + wh));
+      runProcess(proc, params, id);
     });
     cancel.addEventListener('click', function () {
       $('idmp-content').innerHTML = '<div id="idmp-placeholder"><div class="big">&#128193;</div>Select a menu item to open a window.</div>'; status('Ready');
@@ -2148,19 +2164,23 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // §GENPO-LIVE / §GENSHIP-LIVE — a KIND-2 op-group result (CREATE_DOCUMENT + N CREATE_LINE), rendered
     // doc-aware off the folded header table. EXTRACT: every value comes from the source record / its lines.
     if (!absent && r && r.ops && r.header) {
-      var h = r.header, isShip = h.table === 'M_InOut';
+      var h = r.header, isShip = h.table === 'M_InOut', isInv = h.table === 'C_Invoice';
       if (isShip)
         pane.appendChild(el('div', 'msg', 'M_InOut (' + (h.movementtype === 'C-' ? 'Customer Shipment' : 'Vendor Receipt') +
           ') from order ' + h.c_order_id + ' · Warehouse ' + h.m_warehouse_id + ' · BPartner ' + h.c_bpartner_id));
+      else if (isInv)
+        pane.appendChild(el('div', 'msg', 'C_Invoice (' + (h.issotrx === 'Y' ? 'Sales' : 'Purchase') + ') from order ' +
+          h.c_order_id + ' · BPartner ' + h.c_bpartner_id + ' · Bill-Location ' + h.c_bpartner_location_id + ' · PaymentTerm ' + h.c_paymentterm_id));
       else
         pane.appendChild(el('div', 'msg', 'C_Order (' + (h.issotrx === 'Y' ? 'Sales' : 'Purchase') + ', On-Credit) from project ' +
           h.c_project_id + ' · BPartner ' + h.c_bpartner_id + ' · Warehouse ' + h.m_warehouse_id + ' · PriceList ' + h.m_pricelist_id));
       var lns = r.ops.filter(function (o) { return o.op_type === 'CREATE_LINE'; });
       var t = document.createElement('table'), tr = el('tr');
-      (isShip ? ['#', 'Product', 'Ship Qty'] : ['#', 'Product', 'Qty', 'Price']).forEach(function (hd, i) { tr.appendChild(el('th', i >= 2 ? 'r' : null, hd)); }); t.appendChild(tr);
+      (isShip ? ['#', 'Product', 'Ship Qty'] : isInv ? ['#', 'Product', 'Invoice Qty'] : ['#', 'Product', 'Qty', 'Price']).forEach(function (hd, i) { tr.appendChild(el('th', i >= 2 ? 'r' : null, hd)); }); t.appendChild(tr);
       lns.forEach(function (op) {
         tr = el('tr');
         (isShip ? [op.line, op.m_product_id, op.movementqty]
+                : isInv ? [op.line, op.m_product_id, op.qtyinvoiced]
                 : [op.line, op.m_product_id, op.qtyordered, op.priceactual == null ? '(price list)' : op.priceactual])
           .forEach(function (cv, i) { tr.appendChild(el('td', i >= 2 ? 'r' : null, cv == null ? '' : String(cv))); });
         t.appendChild(tr);
@@ -2168,6 +2188,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       pane.appendChild(t);
       pane.appendChild(el('div', 'msg', isShip
         ? r.lineCount + ' shipment line' + (r.lineCount === 1 ? '' : 's') + ' folded (MovementQty = min(QtyOrdered − QtyDelivered, OnHand))'
+        : isInv
+        ? r.lineCount + ' invoice line' + (r.lineCount === 1 ? '' : 's') + ' folded (QtyInvoiced = QtyOrdered − QtyInvoiced)'
         : r.lineCount + ' order line' + (r.lineCount === 1 ? '' : 's') + ' folded (Qty = PlannedQty − InvoicedQty; Price = PlannedPrice)'));
     }
     var back = el('div', null); var bb = el('button', null, 'Close');

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v706';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v707';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
**P2-leg2 of `AD_PROCESS_FOLD_LANE.md`** — the order-to-cash **closer**, sibling of InOutGenerate (#355).

A Completed Sales Order → a **C_Invoice** op-group via the EXISTING `erp_engine.buildDoc` `createInvoice` archetype (KIND 2, **newVerbs=0**). Per the **Immediate** InvoiceRule: `QtyInvoiced = QtyOrdered − QtyInvoiced`; the `D`/`O`/`S` rules invoice from the shipment/schedule corpus → **named-deferred** (honest, flagged). Semantics EXTRACTED from `InvoiceGenerate.java` (non-invent).

### Engine — `erp/ad_process.js?v=4`
- `registerInvoiceGenerate` + `invoiceGenGate` (DocStatus∈{CO,CL} ∧ IsSOTrx) + `genInvoiceLines` (Immediate fold, skip toInvoice≤0) + `INVOICE_SPEC` (the createInvoice header copied from the order).

### Host — `erp/idempiere.html`
- `_ensureProcHandlers` registers InvoiceGenerate; `renderOrderPicker` generalised for shipment+invoice (mandatory `AD_Org_ID` from the order, `DocAction=Complete`); `renderProcResult` renders the C_Invoice op-group (Invoice Qty column).

### Witnesses
- **W-PROC-INV** (`scripts/poc_proc_inv.js`) — 8/8: dispatch, honest-empty, `toInvoice` oracle-equivalent to the cent, partial-prior-invoicing, falsifier, named-deferral, gate.
- **W-PROC-INV-LIVE** (`scripts/poc_geninv_live.js`) — PASS, 0 pageerrors. Served CO orders are fully invoiced / D-rule deferred → the **honest empty** result (no fabricated C_Invoice — HONESTY INVARIANT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)