### PR TITLE
feat(erp): genesis → resident tenant — a born tenant becomes a login-able client (sw v707)

### DIFF
--- a/erp/genesis.html
+++ b/erp/genesis.html
@@ -56,13 +56,42 @@
 <script src="overlay_kit.js"></script>
 <script src="erp_snapshot_sign.js"></script>
 <script src="genesis_seed.js?v=1"></script>
-<script src="genesis.js?v=1"></script>
+<script src="genesis.js?v=2"></script>
 <script src="post_resolver.js?v=1"></script>
 <script src="doc_poster.js?v=1"></script>
 <script>
 (function () {
   'use strict';
   var $ = function (id) { return document.getElementById(id); };
+  var _installBundle = null;   // the last birth's install bundle (G1..G7), set on a successful birth
+
+  // ── idb handoff (shares 'erp_cache'/'blobs' with idempiere.html) — write the install bundle, then redirect ──
+  function idbPut(key, val) {
+    return new Promise(function (resolve) {
+      try {
+        var req = indexedDB.open('erp_cache', 1);
+        req.onupgradeneeded = function () { req.result.createObjectStore('blobs'); };
+        req.onsuccess = function () {
+          var tx = req.result.transaction('blobs', 'readwrite');
+          tx.objectStore('blobs').put(val, key);
+          tx.oncomplete = function () { resolve(true); };
+          tx.onerror = function () { resolve(false); };
+        };
+        req.onerror = function () { resolve(false); };
+      } catch (e) { resolve(false); }
+    });
+  }
+  // B3 — hand the born tenant to idempiere.html as a RESIDENT install: stash the bundle, redirect; the host's boot
+  // allocates the free client band, re-bands + merges it into the live ad_seed, then the login switcher lists it.
+  function installResident(btn) {
+    if (!_installBundle) return;
+    btn.disabled = true; btn.textContent = 'Installing…';
+    console.log('§W-GENESIS-RESIDENT-LIVE handoff client=' + _installBundle.input.clientName + ' groups=' + _installBundle.groups.length);
+    idbPut('genesis_pending', _installBundle).then(function () {
+      location.href = 'idempiere.html?installGenesis=1';
+    });
+  }
+  window._genesisInstallResident = installResident;   // the render() button calls this
 
   // ── better-sqlite3-shaped shim over a sql.js handle: get/all/run, named (@key) + positional (?). ──
   // (idempiere.html's _b3 is read-only; foldGenesis needs run() for INSERTs, so this is the full shim.)
@@ -122,6 +151,16 @@
       db.prepare('INSERT INTO c_invoiceline VALUES (@a,@b,@c)').run({ a: invId, b: born.refs.productId, c: 100.00 });
       db.prepare('INSERT INTO c_invoicetax VALUES (@a,@b,@c)').run({ a: invId, b: born.refs.taxId, c: 9.00 });
 
+      // INSTALL BUNDLE — G1..G6 + a G7 carrying THIS sample invoice (named columns so mergeGenesisInto can
+      // column-intersect into the resident schema). The same op-log, just one group longer; reband bands its
+      // *_id (invId > base) automatically. Stashed for the "Install as resident tenant" button (B3 handoff).
+      _installBundle = { input: born.input, tip: born.tip, refs: born.refs, groups: born.groups.concat([{
+        seq: born.groups.length + 1, label: 'G7 sample invoice', ops: [
+          { op: 'CREATE', table: 'c_invoice', row: { c_invoice_id: invId, c_bpartner_id: born.refs.bpartnerId, ad_client_id: born.refs.clientId, grandtotal: 109.00, issotrx: 'Y', ispaid: 'N', dateinvoiced: '2024-01-15', docstatus: 'CO' } },
+          { op: 'CREATE', table: 'c_invoiceline', row: { c_invoice_id: invId, m_product_id: born.refs.productId, ad_client_id: born.refs.clientId, linenetamt: 100.00 } },
+          { op: 'CREATE', table: 'c_invoicetax', row: { c_invoice_id: invId, c_tax_id: born.refs.taxId, ad_client_id: born.refs.clientId, taxamt: 9.00 } }
+        ] }]) };
+
       // POST via the shipped doc_poster + post_resolver (same verbs the live Posting-Preview uses)
       var gl = window.DocPoster.derivePostings(db, { table: 'C_Invoice', id: invId }, born.refs.acctSchemaId, window.PostResolver);
       var byVal = {}; gl.lines.forEach(function (l) { byVal[l.value] = l; });
@@ -162,7 +201,12 @@
         + ' · ΣDr ' + money(gl.sumDr / 100) + ' / ΣCr ' + money(gl.sumCr / 100) + '</div></div>'
       + '<div class="card dim">Signed genesis bundle: head <span class="mono">' + s.sig.tip.slice(0, 16) + '…</span> · ECDSA P-256 '
         + (s.verified ? '<span class="ok">✓ verified</span>' : '<span class="bad">✗ unverified</span>')
-        + '<br>This birth is replayable, branchable and reversible — the tenant\'s entire genesis is an auditable op-log.</div>';
+        + '<br>This birth is replayable, branchable and reversible — the tenant\'s entire genesis is an auditable op-log.</div>'
+      // B3 — make the born tenant REAL: install it as a resident client you can log in to and work.
+      + (ok ? '<div class="card"><div style="margin-bottom:6px"><b>Make it real</b> — install <b>' + born.input.clientName
+          + '</b> as a resident tenant: re-banded into a free client slot, merged into the live dictionary, then you '
+          + 'log in to it and work (its windows, its data, sharing the System AD).</div>'
+          + '<button id="install-resident" onclick="_genesisInstallResident(this)">⬇ Install as resident tenant</button></div>' : '');
   }
 })();
 </script>

--- a/erp/genesis.js
+++ b/erp/genesis.js
@@ -176,7 +176,8 @@
     return {
       input: { clientName: clientName, currencyId: ccyId, currencyPrecision: ccyPrec, adminUser: adminUser, dateAcct: dateAcct },
       groups: groups, tip: parent,
-      refs: { clientId: clientId, orgId: orgId, acctSchemaId: asId, bpartnerId: bpId, productId: prodId,
+      refs: { clientId: clientId, orgId: orgId, roleAdminId: roleAdminId, userId: userId,
+              acctSchemaId: asId, bpartnerId: bpId, productId: prodId,
               taxId: taxId, doctypeAriId: dtAriId, warehouseId: whId, periodId: periodId,
               ev: evByValue, vc: vcByColumn }
     };
@@ -204,6 +205,147 @@
     return n;
   }
 
+  // ── rebandGenesis — make a born tenant RESIDENT-safe (GENESIS_RESIDENT_TENANT_SESSION §SPEC). W-GENESIS-RESIDENT ─
+  //
+  //   A born tenant mints every id from a fixed base (1_000_000) — so two tenants, or a tenant + the resident
+  //   ad_seed, collide on PK/id values. Re-band offsets every genesis-minted *_id into a free per-client numeric
+  //   band, exactly the convention the demo shards use (clientNum*100000; Odoo[12] → 12_50001, 12_00001, …).
+  //
+  //   NON-INVENT rule (deterministic, no Date/random):
+  //     · idMap is built ONLY from the minted set — every distinct *_id value > genesisBase across all ops. Shared
+  //       System references (currencyId=100, etc.) are < genesisBase, so they are never in the map → never remapped.
+  //     · clientId          → newClientId (the small free AD_Client_ID; what listClients/scoping key on).
+  //     · every other minted → newClientId*stride + (id - genesisBase)   (the high data band).
+  //     · isactive:'Y' is injected into any row lacking it — SES.listClients (and most read-site queries) filter
+  //       IsActive='Y'; a born row carries none, so without this the resident tenant is invisible. 'Y' is the
+  //       canonical active flag every real iDempiere row carries (extract-the-default, not invent).
+  //     · the hash chain is recomputed over the re-banded ops so the op-log still verifies (git-for-a-tenant).
+  //   bundle = { groups, refs? } (born, optionally with an appended G7 sample-invoice group). Returns the same
+  //   shape re-banded, plus { clientId, idMap }.
+  function rebandGenesis(bundle, opts) {
+    opts = opts || {};
+    var newClientId = opts.clientId;
+    if (newClientId == null) throw new Error('rebandGenesis: opts.clientId required');
+    var base = opts.genesisBase != null ? opts.genesisBase : 1000000;
+    var stride = opts.stride != null ? opts.stride : 100000;
+    var bandBase = newClientId * stride;
+    var groups = bundle.groups || [];
+    var clientId = bundle.refs ? bundle.refs.clientId : null;
+
+    // collect the minted set, then build the value→value map
+    var minted = {};
+    groups.forEach(function (g) { (g.ops || []).forEach(function (o) {
+      Object.keys(o.row || {}).forEach(function (k) {
+        if (/_id$/i.test(k)) { var v = o.row[k]; if (typeof v === 'number' && v > base) minted[v] = true; }
+      });
+    }); });
+    var map = {};
+    Object.keys(minted).forEach(function (s) {
+      var v = Number(s);
+      map[v] = (v === clientId) ? newClientId : bandBase + (v - base);
+    });
+
+    // re-band the ops + inject isactive, rebuild the hash chain
+    var parent = '0'.repeat(64), out = [];
+    groups.forEach(function (g) {
+      var ops = (g.ops || []).map(function (o) {
+        var row = {};
+        Object.keys(o.row || {}).forEach(function (k) {
+          var v = o.row[k];
+          // apply by VALUE-membership, not column name: account columns are *_acct (c_receivable_acct,
+          // p_revenue_acct, t_due_acct) yet hold minted C_ValidCombination ids. The map holds ONLY genesis-minted
+          // ids (all > base), and no genesis amount/rate is > base, so value-membership has no false positive.
+          if (typeof v === 'number' && map[v] != null) v = map[v];
+          row[k] = v;
+        });
+        if (row.isactive == null) row.isactive = 'Y';
+        return { op: o.op, table: o.table, row: row };
+      });
+      var tip = sha256(parent + JSON.stringify(ops));
+      out.push({ seq: g.seq, label: g.label, ops: ops, parent: parent, tip: tip });
+      parent = tip;
+    });
+
+    // re-band refs (so callers — the invoice post, the deep link — address the new ids)
+    function rm(v) { return (typeof v === 'number' && map[v] != null) ? map[v] : v; }
+    var refs = null;
+    if (bundle.refs) {
+      refs = { clientId: newClientId };
+      Object.keys(bundle.refs).forEach(function (k) {
+        var v = bundle.refs[k];
+        if (k === 'clientId') return;
+        if (v && typeof v === 'object') { var m = {}; Object.keys(v).forEach(function (kk) { m[kk] = rm(v[kk]); }); refs[k] = m; }
+        else refs[k] = rm(v);
+      });
+    }
+    return { input: bundle.input, groups: out, tip: parent, refs: refs, clientId: newClientId, idMap: map };
+  }
+
+  // ── mergeGenesisInto — merge re-banded CREATE ops into an EXISTING (resident) DB, never CREATE a table ────────
+  //   The resident ad_seed already holds the System dictionary + other tenants; a born tenant SHARES it (client 0
+  //   AD, client N data). So we INTERSECT each row with the resident table's real columns (case-insensitive — born
+  //   rows are lowercase, resident tables CamelCase) and INSERT OR IGNORE (idempotent re-install). A table or column
+  //   the resident schema does not carry is skipped, never synthesized (NON-INVENT). Mirrors installShard's merge.
+  function mergeGenesisInto(groups, db) {
+    var schema = {}, n = 0;
+    function cols(t) {
+      if (schema[t] !== undefined) return schema[t];
+      var info; try { info = db.prepare('PRAGMA table_info("' + t + '")').all(); } catch (e) { info = []; }
+      var m = null;
+      if (info && info.length) { m = {}; info.forEach(function (c) { m[String(c.name).toLowerCase()] = c.name; }); }
+      schema[t] = m; return m;
+    }
+    groups.forEach(function (g) { (g.ops || []).forEach(function (o) {
+      if (o.op !== 'CREATE') return;
+      var c = cols(o.table); if (!c) return;                                  // resident has no such table → skip
+      var keys = Object.keys(o.row).filter(function (k) { return c[k.toLowerCase()]; });
+      if (!keys.length) return;
+      var canon = keys.map(function (k) { return '"' + c[k.toLowerCase()] + '"'; });
+      var sql = 'INSERT OR IGNORE INTO "' + o.table + '" (' + canon.join(',') + ') VALUES (' +
+        keys.map(function (k) { return '@' + k; }).join(',') + ')';
+      try { db.prepare(sql).run(o.row); n++; } catch (e) { /* honest skip; caller logs the count */ }
+    }); });
+    return n;
+  }
+
+  // ── nextClientId — first free AD_Client_ID for a born tenant, floored at 17 so the 5 demo tenants (12-16, each
+  //   data-banded to ≤1.6e6) never collide on either the client number OR the high data band (17→1_700_000). ──────
+  function nextClientId(db) {
+    var floor = 17, taken = {};
+    try {
+      var rows = db.prepare('SELECT AD_Client_ID AS id FROM AD_Client').all();
+      rows.forEach(function (r) { taken[Number(r.id)] = true; });
+    } catch (e) {}
+    var n = floor; while (taken[n]) n++;
+    return n;
+  }
+
+  // ── grantFullAccess — grant the born admin role access to the SHARED (System/client-0) dictionary ────────────
+  //   A born tenant SHARES client-0's AD_Window/Process/Form, but the menu is role-scoped via AD_*_Access — with
+  //   none, the tenant logs in to an EMPTY menu (can't work). iDempiere's InitialClientSetup grants the new client
+  //   admin role access to the dictionary; this replicates that at INSTALL time (where the resident db with the
+  //   System dictionary is available — genesis has no db at birth). NON-INVENT: we read the EXISTING System rows
+  //   and grant them (IsActive='Y'), exactly the setup default; INSERT OR IGNORE on the composite PK = idempotent.
+  function grantFullAccess(db, roleId, clientId, orgId) {
+    var n = 0;
+    function grant(srcTbl, accTbl, idCol, extra) {
+      var src; try { src = db.prepare('SELECT ' + idCol + ' AS id FROM ' + srcTbl + " WHERE IsActive='Y'").all(); } catch (e) { src = []; }
+      src.forEach(function (r) {
+        if (r.id == null) return;
+        var cols = ['AD_Client_ID', 'AD_Org_ID', 'AD_Role_ID', idCol, 'IsActive'].concat(Object.keys(extra || {}));
+        var vals = { c: clientId, o: orgId || 0, r: roleId, k: r.id };
+        var ph = ['@c', '@o', '@r', '@k', "'Y'"]; Object.keys(extra || {}).forEach(function (e) { ph.push("'" + extra[e] + "'"); });
+        try { db.prepare('INSERT OR IGNORE INTO ' + accTbl + ' (' + cols.join(',') + ') VALUES (' + ph.join(',') + ')').run(vals); n++; } catch (e) {}
+      });
+    }
+    grant('AD_Window', 'AD_Window_Access', 'AD_Window_ID', { IsReadWrite: 'Y' });
+    grant('AD_Process', 'AD_Process_Access', 'AD_Process_ID', {});
+    grant('AD_Form', 'AD_Form_Access', 'AD_Form_ID', {});
+    try { db.prepare("INSERT OR IGNORE INTO AD_Role_OrgAccess (AD_Client_ID,AD_Org_ID,AD_Role_ID,IsActive) VALUES (@c,@o,@r,'Y')")
+      .run({ c: clientId, o: orgId || 0, r: roleId }); } catch (e) {}
+    return n;
+  }
+
   // ── signHead — sign the genesis head tip (the signed bundle); isomorphic webcrypto (node + browser) ─────────
   async function signHead(groups) {
     if (typeof global.crypto === 'undefined' || !global.crypto.subtle) {
@@ -218,7 +360,9 @@
     return { tip: head, sig: await S.signTip(priv, head), pub: pub, verify: function (t, s) { return S.verifyTip(t, s, pub); } };
   }
 
-  var _api = { birthTenant: birthTenant, foldGenesis: foldGenesis, signHead: signHead, IdGen: IdGen, sha256: sha256 };
+  var _api = { birthTenant: birthTenant, foldGenesis: foldGenesis, signHead: signHead, IdGen: IdGen, sha256: sha256,
+    rebandGenesis: rebandGenesis, mergeGenesisInto: mergeGenesisInto, nextClientId: nextClientId,
+    grantFullAccess: grantFullAccess };
   if (typeof module !== 'undefined' && module.exports) module.exports = _api;
   else global.Genesis = _api;
 

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -443,6 +443,7 @@
      FOLD-frozen verbs (post_resolver/doc_poster, UMD) + the seam; renders via the SAME AcctsPosted renderer. -->
 <script src="post_resolver.js?v=1"></script>
 <script src="doc_poster.js?v=1"></script>
+<script src="genesis.js?v=2"></script>
 <script src="erp_preview.js?v=2"></script>
 <!-- CONSISTENCY_FINISH.md §K-1/§K-2 — icons.js (verbatim glyph DATA) + the shared overlay kit load BEFORE
      the import overlays (migrate_showme builds its STEPS at module load and renders Lucide icons). -->
@@ -589,6 +590,13 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       req.onsuccess = function () { req.result.transaction('blobs', 'readwrite').objectStore('blobs').put(val, key); };
     } catch (e) {}
   }
+  function idbDel(key) {
+    try {
+      var req = indexedDB.open('erp_cache', 1);
+      req.onupgradeneeded = function () { req.result.createObjectStore('blobs'); };
+      req.onsuccess = function () { req.result.transaction('blobs', 'readwrite').objectStore('blobs').delete(key); };
+    } catch (e) {}
+  }
   function loadScript(url, cdn) {
     return new Promise(function (resolve) {
       var s = document.createElement('script'); s.src = url; s.onload = resolve;
@@ -668,6 +676,65 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   }
   window.idmpInstallShard = installShard;   // the Install dialog success-path calls this in-page (erp_picker.js)
 
+  // ── installGenesis(bundle) — make a BORN tenant (genesis.html, an op-log of rows, not a .db file) RESIDENT ─────
+  // The sibling of installShard for the genesis path (GENESIS_RESIDENT_TENANT_SESSION §SPEC). genesis.html hands
+  // off the bundle via idb; here we allocate a free client band, RE-BAND every minted id into it (no collision),
+  // MERGE its rows into the live ad_seed sharing the System dictionary, and PERSIST — reusing the SAME persist seam
+  // installShard uses, so the born tenant survives a reload and the login switcher lists it. NON-INVENT: the engine
+  // (Genesis.rebandGenesis/mergeGenesisInto/nextClientId) is the headless-witnessed verb (W-GENESIS-RESIDENT); this
+  // is only the host glue (allocate + persist + idempotent guard). Returns {ok,clientId,rows,persisted}.
+  async function installGenesis(bundle) {
+    if (!bundle || !bundle.groups || !window.Genesis) return { ok: false };
+    // IDEMPOTENT GUARD — the born client carries no fixed id (it is allocated here), so guard on a same-name
+    // resident tenant: if one already exists, this is a re-entry (e.g. reload with a stale pending) → no-op.
+    var name = (bundle.input && bundle.input.clientName) || 'NewCo';
+    try { var exist = db.exec("SELECT AD_Client_ID FROM AD_Client WHERE Name=" + "'" + String(name).replace(/'/g, "''") + "'");
+      if (exist.length && exist[0].values.length) {
+        console.log('§GENESIS-RESIDENT-LIVE install-skip name=' + name + ' already-resident client=' + exist[0].values[0][0]);
+        return { ok: true, already: true, clientId: Number(exist[0].values[0][0]) }; } } catch (e) {}
+    var dbw = _b3w(db);                                        // full (writeable) better-sqlite3 shim over the live db
+    var newId = window.Genesis.nextClientId(dbw);
+    var rb = window.Genesis.rebandGenesis(bundle, { clientId: newId });
+    var rows = window.Genesis.mergeGenesisInto(rb.groups, dbw);
+    // GRANT the born admin role access to the shared System dictionary — else it logs in to an EMPTY menu. Same
+    // setup-default the headless witness proves (W-GENESIS-RESIDENT): read the System windows, grant them.
+    var grants = window.Genesis.grantFullAccess(dbw, rb.refs.roleAdminId, newId, rb.refs.orgId);
+    var clAfter = (SES && db) ? SES.listClients(db).length : -1;
+    console.log('§GENESIS-RESIDENT-LIVE install name=' + name + ' client=' + newId + ' rows=' + rows + ' grants=' + grants + ' clients→' + clAfter);
+    var persisted = false;
+    if (rows > 0) {
+      try { idbPut('ad_seed_v16', db.export().buffer); persisted = true;
+        console.log('§GENESIS-RESIDENT-LIVE persist key=ad_seed_v16 client=' + newId + ' resident=Y');
+        try { if (window.WholeHistory) window.WholeHistory.record({ page: 'idempiere', kind: 'op',
+          label: 'Installed tenant ' + name + ' (' + rows + ' rows, client ' + newId + ')' }); } catch (e2) {} }
+      catch (e) { console.warn('§GENESIS-RESIDENT-LIVE persist failed ' + e.message); }
+    }
+    return { ok: rows > 0, clientId: newId, rows: rows, persisted: persisted };
+  }
+  window.idmpInstallGenesis = installGenesis;
+
+  // full (writeable) better-sqlite3-shaped shim over the live sql.js db — _b3 is read-only; mergeGenesisInto needs
+  // prepare().run() (INSERT) + prepare().all() (PRAGMA). Same shape genesis.html uses; named (@key) + positional.
+  function _b3w(dbh) {
+    function lc(o) { if (!o) return o; var r = {}; for (var k in o) r[k.toLowerCase()] = o[k]; return r; }
+    function bindp(st, sql, args) {
+      if (!args.length) return; var p = args[0];
+      if (p != null && typeof p === 'object' && !Array.isArray(p)) {
+        var b = {}; Object.keys(p).forEach(function (k) { var m = sql.match(new RegExp('[@:$]' + k + '\\b')); b[(m ? m[0][0] : '@') + k] = p[k]; }); st.bind(b);
+      } else { st.bind(args.slice()); }
+    }
+    function exec(sql, args, all) {
+      var st = dbh.prepare(sql), out = all ? [] : undefined;
+      try { bindp(st, sql, args); if (all) { while (st.step()) out.push(lc(st.getAsObject())); } else if (st.step()) out = lc(st.getAsObject()); }
+      finally { st.free(); } return out;
+    }
+    return { prepare: function (sql) { return {
+      get: function () { return exec(sql, [].slice.call(arguments), false); },
+      all: function () { return exec(sql, [].slice.call(arguments), true); },
+      run: function () { var st = dbh.prepare(sql); try { bindp(st, sql, [].slice.call(arguments)); st.step(); } finally { st.free(); } return {}; }
+    }; } };
+  }
+
   async function boot() {
     await loadScript('lib/sql-wasm-fts5.js', 'https://cdn.jsdelivr.net/npm/sql.js-fts5@1.4.0/dist/sql-wasm.js');
     var SQL;
@@ -707,6 +774,13 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // ?shard=<file>.db — SHARD-IN (the URL install path). Same installShard() the Install dialog drives in-page.
     var shardParam = new URLSearchParams(location.search).get('shard');
     if (shardParam) await installShard(shardParam);
+    // GENESIS HANDOFF — genesis.html stashes a born tenant's bundle in idb then redirects here. Install it as a
+    // resident client (allocate band + re-band + merge + persist), clear the pending key so a later reload is a
+    // no-op, then fall through to login — the switcher now lists the new tenant. (GENESIS_RESIDENT_TENANT_SESSION B3.)
+    if (new URLSearchParams(location.search).get('installGenesis')) {
+      try { var pending = await idbGet('genesis_pending');
+        if (pending && pending.groups) { await installGenesis(pending); idbDel('genesis_pending'); }
+      } catch (e) { console.warn('§GENESIS-RESIDENT-LIVE handoff failed ' + e.message); } }
     if (ADP && ADP.init) ADP.init(db);
     console.log('§IDEMPIERE boot db=' + src + ' ms=' + Math.round(performance.now() - _t0));
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v706';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v707';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_genesis_resident_live.js
+++ b/erp/tests/poc_genesis_resident_live.js
@@ -1,0 +1,111 @@
+// W-GENESIS-RESIDENT-LIVE — drive the FULL genesis→resident flow in a real browser (sql.js + IndexedDB):
+//   genesis.html births a tenant + posts to the cent → "Install as resident tenant" → idb handoff → redirect to
+//   idempiere.html?installGenesis=1 → boot allocates a free band, re-bands + merges + grants + persists → the login
+//   switcher lists the born tenant → it enters → its invoice data + account chain resolve, 0 cross-leak, 0 errors.
+// Run: node tests/poc_genesis_resident_live.js   (serves erp/ on a local port). §-log first — read the log.
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+
+var ROOT = path.join(__dirname, '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+var server = http.createServer(function (req, res) {
+  var f = path.join(ROOT, decodeURIComponent(req.url.split('?')[0]));
+  fs.readFile(f, function (e, buf) {
+    if (e) { res.writeHead(404); return res.end('404'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(f)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+// whitebox queries over the live in-page db (window.__idmpDb) — runs in the browser
+function probe() {
+  function one(sql) { try { var r = window.__idmpDb.exec(sql); return r.length && r[0].values.length ? r[0].values[0][0] : null; } catch (e) { return 'ERR:' + e.message; } }
+  function rows(sql) { try { var r = window.__idmpDb.exec(sql); return r.length ? r[0].values.map(function (v) { return v[0]; }) : []; } catch (e) { return []; } }
+  var clients = rows("SELECT cl.Name FROM AD_Client cl JOIN AD_Role r ON r.AD_Client_ID=cl.AD_Client_ID AND r.IsActive='Y' " +
+    "JOIN AD_User_Roles ur ON ur.AD_Role_ID=r.AD_Role_ID JOIN AD_User u ON u.AD_User_ID=ur.AD_User_ID AND u.IsActive='Y' " +
+    "WHERE cl.IsActive='Y' GROUP BY cl.AD_Client_ID ORDER BY cl.AD_Client_ID");
+  var acmeId = one("SELECT AD_Client_ID FROM AD_Client WHERE Name='AcmeCo'");
+  var roleId = one("SELECT AD_Role_ID FROM AD_Role WHERE AD_Client_ID=" + acmeId + " AND Name LIKE '%Admin%'");
+  return {
+    clients: clients,
+    acmeId: acmeId,
+    windowAccess: one("SELECT COUNT(*) FROM AD_Window_Access WHERE AD_Role_ID=" + roleId),
+    invGrand: one("SELECT grandtotal FROM C_Invoice WHERE AD_Client_ID=" + acmeId),
+    invClientScoped: one("SELECT COUNT(*) FROM C_Invoice WHERE AD_Client_ID=" + acmeId),
+    receivableValue: one("SELECT ev.Value FROM C_Invoice i JOIN C_BP_Customer_Acct ba ON ba.C_BPartner_ID=i.C_BPartner_ID " +
+      "JOIN C_ValidCombination vc ON vc.C_ValidCombination_ID=ba.C_Receivable_Acct " +
+      "JOIN C_ElementValue ev ON ev.C_ElementValue_ID=vc.Account_ID WHERE i.AD_Client_ID=" + acmeId),
+    gwBp: one("SELECT COUNT(*) FROM C_BPartner WHERE AD_Client_ID=11"),
+    acmeChart: one("SELECT COUNT(*) FROM C_ElementValue WHERE AD_Client_ID=" + acmeId)
+  };
+}
+
+(async function () {
+  await new Promise(function (r) { server.listen(0, r); });
+  var port = server.address().port, base = 'http://localhost:' + port;
+  var logs = [], pageErrors = [];
+  var browser = await chromium.launch({ args: ['--no-sandbox'] });
+  var page = await browser.newPage();
+  page.on('console', function (m) { var t = m.text(); if (t.indexOf('§') === 0) logs.push(t); });
+  page.on('pageerror', function (e) { pageErrors.push(String(e)); });
+
+  // ── 1. genesis.html — birth + post, then install ─────────────────────────────────────────────────────────────
+  await page.goto(base + '/genesis.html', { waitUntil: 'networkidle' });
+  await page.evaluate(function () { return new Promise(function (r) { var q = indexedDB.deleteDatabase('erp_cache'); q.onsuccess = q.onerror = q.onblocked = function () { r(); }; }); });
+  await page.click('#go');
+  await page.waitForSelector('#install-resident', { timeout: 20000 });
+  await page.click('#install-resident');
+
+  // ── 2. redirect → idempiere.html?installGenesis=1 — boot installs the born tenant ───────────────────────────────
+  await page.waitForURL(/installGenesis=1/, { timeout: 20000 });
+  await page.waitForFunction(function () { return !!window.__idmpDb; }, null, { timeout: 30000 });
+  await page.waitForFunction(function () { return document.querySelector('#idmp-login-step0') && document.querySelector('#idmp-login-clients').children.length > 0; }, null, { timeout: 20000 });
+  await page.waitForTimeout(400);
+
+  var p = await page.evaluate(probe);
+  var step0Names = await page.$$eval('#idmp-login-clients .nm', function (els) { return els.map(function (e) { return e.textContent.trim(); }); });
+
+  // ── 3. enter — click the born tenant → its user list ──────────────────────────────────────────────────────────
+  var entered = false, enterUser = null;
+  try {
+    await page.click("#idmp-login-clients .idmp-login-user:has(.nm:text-is('AcmeCo'))", { timeout: 5000 });
+    await page.waitForSelector('#idmp-login-step1:visible', { timeout: 8000 });
+    enterUser = (await page.$$eval('#idmp-login-users .nm', function (els) { return els.map(function (e) { return e.textContent.trim(); }); })).join(',');
+    entered = true;
+  } catch (e) { pageErrors.push('enter-step: ' + e.message); }
+
+  // ── 4. persistence — reload WITHOUT the param: the born tenant must STILL be resident (it stuck) ────────────────
+  await page.goto(base + '/idempiere.html', { waitUntil: 'networkidle' });
+  await page.waitForFunction(function () { return !!window.__idmpDb; }, null, { timeout: 30000 });
+  await page.waitForTimeout(400);
+  var pReload = await page.evaluate(function () { try { var r = window.__idmpDb.exec("SELECT AD_Client_ID FROM AD_Client WHERE Name='AcmeCo'"); return r.length && r[0].values.length ? r[0].values[0][0] : null; } catch (e) { return null; } });
+
+  // ── verdict ───────────────────────────────────────────────────────────────────────────────────────────────────
+  console.log('═══ W-GENESIS-RESIDENT-LIVE — a born tenant becomes a RESIDENT, login-able client in a REAL browser ═══\n');
+  logs.filter(function (l) { return /GENESIS-RESIDENT-LIVE|CRITIC-FRONTDOOR|login-step0/.test(l); }).forEach(function (l) { console.log('  ' + l); });
+  console.log('  probe → clients=[' + p.clients.join(',') + '] acme=' + p.acmeId + ' winAccess=' + p.windowAccess
+    + ' inv$=' + p.invGrand + ' receivable=' + p.receivableValue + ' chart=' + p.acmeChart + ' gwBp=' + p.gwBp);
+  console.log('  step0 DOM names=[' + step0Names.join(',') + ']  enteredUser=' + enterUser + '  reloadAcme=' + pReload + '\n');
+
+  var L = logs.join('\n'), pass = 0, fail = 0;
+  function ck(ok, msg) { (ok ? pass++ : fail++); console.log((ok ? '  ✓ ' : '  ✗ FAIL ') + msg); }
+  ck(/§W-GENESIS-RESIDENT-LIVE handoff client=AcmeCo groups=7/.test(L), 'genesis.html births + hands off the bundle (G1..G7)');
+  ck(/§GENESIS-RESIDENT-LIVE install name=AcmeCo client=17 rows=\d+ grants=\d+/.test(L), 'boot installs the born tenant (reband+merge+grant) at client 17');
+  ck(/§GENESIS-RESIDENT-LIVE persist .* resident=Y/.test(L), 'merged tenant persisted to the resident cache');
+  ck(Number(p.acmeId) === 17, 'born tenant is resident as AD_Client 17');
+  ck(p.clients.indexOf('AcmeCo') >= 0 && p.clients.indexOf('GardenWorld') >= 0, 'login switcher lists BOTH AcmeCo and GardenWorld (0 leak)');
+  ck(step0Names.indexOf('AcmeCo') >= 0, 'the born tenant appears in the step-0 switcher DOM');
+  ck(Number(p.windowAccess) > 300, 'born admin role has a workable menu (full dictionary window access) — ' + p.windowAccess);
+  ck(Number(p.invClientScoped) >= 1 && Number(p.invGrand) === 109, 'the invoice window renders ITS data ($109 invoice scoped to client 17)');
+  ck(String(p.receivableValue) === '12110', 'the invoice account chain resolves to the oracle receivable (12110) — posts to the cent');
+  ck(Number(p.gwBp) === 18, 'GardenWorld data untouched (18 BPartners) — 0 cross-leak');
+  ck(entered, 'the born tenant ENTERS — its user list shows (' + enterUser + ')');
+  ck(Number(pReload) === 17, 'the born tenant STICKS — still resident after a plain reload (no param)');
+  ck(pageErrors.length === 0, 'zero page errors' + (pageErrors.length ? ' — ' + pageErrors[0] : ''));
+
+  console.log('\n═══ W-GENESIS-RESIDENT-LIVE: ' + pass + ' PASS / ' + fail + ' FAIL ═══');
+  console.log(fail === 0 ? '✅ A born tenant is now a RESIDENT client you log in to and work — Initial Client Setup is USABLE on our engine.' : '❌ gaps above.');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('test error', e); server.close(); process.exit(1); });


### PR DESCRIPTION
## What
Turns the witnessed genesis BIRTH into a tenant a real person logs into and works. The Initial Tenant Setup wizard (`genesis.html`, PR #356) proved a born tenant posts a sales invoice to the cent — but birthed into a throwaway in-memory db. This persists the born tenant into the resident `ad_seed` and surfaces it in the login switcher, sharing the System (client-0) dictionary.

## How (consume the seam, never fork)
**Engine — `genesis.js`, isomorphic, headless-witnessed W-GENESIS-RESIDENT 15/15:**
- `rebandGenesis` — the one hard part: offset every minted `*_id` into a free `clientNum*100000` band (the shard convention), remap by value-membership (so `*_acct` columns band too), inject `isactive='Y'`, recompute the hash chain. 0 collisions vs resident PKs.
- `mergeGenesisInto` — column-intersect `INSERT OR IGNORE` into the EXISTING resident schema (never CREATE; case-insensitive; idempotent).
- `nextClientId` — first free `AD_Client_ID`, floor 17 (skips the 12-16 demo band → data band ≥1.7e6, clear of every demo).
- `grantFullAccess` — grant the born admin role the shared System windows/processes/forms + org access (else login → empty menu). The iDempiere setup default.

**Browser:** `idempiere.html` `window.idmpInstallGenesis(bundle)` reuses the `installShard` persist seam (`idbPut('ad_seed_v16')` + WholeHistory); boot consumes an idb `genesis_pending` handoff. `genesis.html` gains an **Install as resident tenant** button → handoff → redirect.

## Witnesses
- **W-GENESIS-RESIDENT 15/15** (headless, `scripts/poc_genesis_resident.js` in bim-compiler): birth→reband(17)→merge into a copy of the REAL `ad_seed.db` → listClients lists AcmeCo(17) · GardenWorld 0-bleed · the resident invoice posts 12110/41000/21610 to the cent · all rows scoped · idempotent re-merge.
- **W-GENESIS-RESIDENT-LIVE 13/13** (`erp/tests/poc_genesis_resident_live.js`, real browser): birth→install→redirect→boot installs→switcher lists AcmeCo(17)+GardenWorld (0 leak)→enters (jdoe)→invoice renders its data, receivable resolves to oracle 12110→sticks after reload→**0 page errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)