### PR TITLE
feat(erp): BIM-in-window embed — Open Model docks the viewer in the Project window (sw v707, W-BIM-EMBED)

### DIFF
--- a/erp/bim_embed.js
+++ b/erp/bim_embed.js
@@ -1,0 +1,123 @@
+/**
+ * BIM OOTB — bim_embed.js — the DETECT (read) face of the BIM-in-window embed seam.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * A "BIM set" is declared as a STANDARD AD_Attachment row (AD_Table.AD_Table_ID=254) whose
+ * `title` is sentinel-tagged 'BIM Set: <name>' and whose `textmsg` holds the viewer-DB URL
+ * (DisplayType URL=40 semantics). The renderer's "AD flag" is therefore: does (AD_Table_ID,
+ * Record_ID) own a BIM-set attachment? — ONE keyed query, NEVER `if window==130`. Any table
+ * supporting attachments lights up for free (the generality proof).
+ *
+ * NON-INVENT: this rides the standard iDempiere AD_Attachment construct (verified in ad_seed.db,
+ * AD_Table_ID 254). The URL value is our app's declaration. See
+ * prompts/BIM_EMBED_WINDOW_SESSION.md §B0/§B1. Witness: scripts/poc_bim_embed.js (W-BIM-EMBED-DECLARE).
+ */
+(function (global) {
+  'use strict';
+
+  var BIM_SET_PREFIX = 'BIM Set:';
+  var ATTACH_TABLE_ID = 254;  // AD_Table.AD_Table_ID for AD_Attachment (verified ad_seed.db)
+
+  // sql.js helper — run a SELECT, return an array of plain row-objects.
+  function _rows(db, sql, params) {
+    var st = db.prepare(sql);
+    if (params) st.bind(params);
+    var out = [];
+    while (st.step()) out.push(st.getAsObject());
+    st.free();
+    return out;
+  }
+
+  /**
+   * bimSetFor — the renderer's AD flag. Returns {id,title,url} for the first ACTIVE BIM-set
+   * attachment on (adTableId, recordId), or null when the record owns none (→ panel absent,
+   * honest, not an empty frame). A BIM-set tag with an empty URL resolves null too.
+   */
+  function bimSetFor(db, adTableId, recordId) {
+    var rows = _rows(db,
+      "SELECT ad_attachment_id AS id, title, textmsg AS url FROM ad_attachment " +
+      "WHERE ad_table_id=? AND record_id=? AND title LIKE ? " +
+      "AND (isactive IS NULL OR isactive='Y') ORDER BY ad_attachment_id LIMIT 1",
+      [adTableId, recordId, BIM_SET_PREFIX + '%']);
+    if (!rows.length) return null;
+    var r = rows[0];
+    if (!r.url) return null;
+    return { id: r.id, title: r.title, url: r.url };
+  }
+
+  /**
+   * insertBimSet — idempotent DECLARE. Drops any prior BIM-set row for (adTableId,recordId),
+   * then inserts ONE standard AD_Attachment with the sentinel title + url. Returns the new id.
+   * ONE code path shared by scripts/seed_bim_attachment.js AND the witness (non-invent).
+   * o = {adTableId, recordId, name, url, clientId, orgId, now?, uu?}
+   */
+  function insertBimSet(db, o) {
+    db.run("DELETE FROM ad_attachment WHERE ad_table_id=? AND record_id=? AND title LIKE ?",
+      [o.adTableId, o.recordId, BIM_SET_PREFIX + '%']);
+    var mx = _rows(db, "SELECT COALESCE(MAX(ad_attachment_id),1000000) AS mx FROM ad_attachment")[0].mx;
+    var id = mx + 1;
+    var title = BIM_SET_PREFIX + ' ' + (o.name || ('Record ' + o.recordId));
+    var now = o.now || '2026-06-17 00:00:00';
+    var uu = o.uu || ('bimset-' + o.adTableId + '-' + o.recordId);
+    db.run(
+      "INSERT INTO ad_attachment " +
+      "(ad_attachment_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, " +
+      " ad_table_id, record_id, title, textmsg, ad_attachment_uu) " +
+      "VALUES (?,?,?,'Y',?,100,?,100,?,?,?,?,?)",
+      [id, o.clientId, o.orgId, now, now, o.adTableId, o.recordId, title, o.url, uu]);
+    return id;
+  }
+
+  // resolve AD_Table.AD_Table_ID from a table name (case-insensitive; ad_seed.db is mixed-case).
+  function tableId(db, tableName) {
+    var rows = _rows(db, "SELECT ad_table_id AS id FROM ad_table WHERE lower(tablename)=lower(?) LIMIT 1",
+      [tableName]);
+    return rows.length ? rows[0].id : null;
+  }
+
+  // bimSetForTable — the renderer's convenience flag: resolve by table NAME (what the active tab carries),
+  // not the numeric AD_Table_ID. Returns {id,title,url} | null. No if-window==130 anywhere.
+  function bimSetForTable(db, tableName, recordId) {
+    var tid = tableId(db, tableName);
+    if (tid == null) return null;
+    return bimSetFor(db, tid, recordId);
+  }
+
+  // ── Declared BIM-set seed (the in-app declaration) ──────────────────────────────────────────────
+  // Applied to the LOADED db at boot (ensureSeedBimSets) rather than baked into ad_seed.db — so there is
+  // NO 26MB binary churn and it auto-survives a seed re-export (no re-apply needed). Each entry is a
+  // standard AD_Attachment row. NON-INVENT: the URL points at a REAL served viewer building.
+  var SEED_BIM_SETS = [
+    { adTableId: 203, recordId: 101, name: 'Landscape Complex (Hospital model)',
+      url: '../viewer/viewer.html?db=buildings/Hospital_extracted.db&bld=Hospital', clientId: 11, orgId: 11 }
+  ];
+
+  // ensureSeedBimSets — idempotently declare the SEED_BIM_SETS onto the loaded db (boot hook). Only inserts
+  // a row that is absent, so a runtime/user-added BIM set is never clobbered. Returns the count present.
+  function ensureSeedBimSets(db) {
+    if (!db) return 0;
+    var n = 0;
+    SEED_BIM_SETS.forEach(function (o) {
+      try { if (!bimSetFor(db, o.adTableId, o.recordId)) insertBimSet(db, o); n++; } catch (e) {}
+    });
+    return n;
+  }
+
+  // count of active BIM-set rows on a record (idempotency check helper).
+  function bimSetCount(db, adTableId, recordId) {
+    return _rows(db,
+      "SELECT COUNT(*) AS n FROM ad_attachment WHERE ad_table_id=? AND record_id=? AND title LIKE ? " +
+      "AND (isactive IS NULL OR isactive='Y')",
+      [adTableId, recordId, BIM_SET_PREFIX + '%'])[0].n;
+  }
+
+  var API = {
+    bimSetFor: bimSetFor, bimSetForTable: bimSetForTable, tableId: tableId,
+    insertBimSet: insertBimSet, bimSetCount: bimSetCount,
+    ensureSeedBimSets: ensureSeedBimSets, SEED_BIM_SETS: SEED_BIM_SETS,
+    BIM_SET_PREFIX: BIM_SET_PREFIX, ATTACH_TABLE_ID: ATTACH_TABLE_ID
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  if (typeof window !== 'undefined') window.BimEmbed = API; else if (global) global.BimEmbed = API;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/erp/bim_panel.js
+++ b/erp/bim_panel.js
@@ -1,0 +1,121 @@
+/**
+ * BIM OOTB — bim_panel.js — the in-app BIM embed PANEL (dock / float / maximize / pop-out).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * BimPanel.open(url, {title}) mounts a single draggable floating iframe that loads the BIM viewer
+ * chromelessly (appends &embedded=true — the EXISTING viewer param, config.js A.EMBEDDED). We own the
+ * dock/float/max state (the OS popup↔tab drag is a browser dead-end), so the host record stays visible
+ * underneath in float. Pop-out opens the RAW url (with chrome) in a new tab. Listens for the viewer's
+ * {type:'bim:ready'} postMessage (§-log). Drag idiom ported verbatim from pos_lens.js _makePanelDraggable
+ * (itself from the viewer measure.js idiom). See prompts/BIM_EMBED_WINDOW_SESSION.md §B2 (W-BIM-EMBED).
+ */
+(function () {
+  'use strict';
+  var PANEL_ID = 'bim-embed-panel';
+  var STYLE_ID = 'bim-embed-panel-style';
+
+  function _icon(name, sz) {
+    var I = window.ICONS && window.ICONS[name];
+    return I ? ('<svg width="' + (sz || 18) + '" height="' + (sz || 18) + '" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + I.svg + '</svg>') : '';
+  }
+
+  function _ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    var s = document.createElement('style'); s.id = STYLE_ID;
+    s.textContent =
+      '#' + PANEL_ID + '{position:fixed;z-index:9000;background:#1e1e1e;border:1px solid #444;' +
+      'border-radius:8px;box-shadow:0 10px 40px rgba(0,0,0,.55);display:flex;flex-direction:column;overflow:hidden;}' +
+      '#' + PANEL_ID + '.state-float{left:12px;top:64px;width:46vw;height:60vh;}' +
+      '#' + PANEL_ID + '.state-dock{left:auto;right:0;top:0;width:42vw;height:100vh;border-radius:0;}' +
+      '#' + PANEL_ID + '.state-max{left:0;top:0;width:100vw;height:100vh;border-radius:0;}' +
+      '#' + PANEL_ID + ' .bim-panel-hdr{display:flex;align-items:center;gap:8px;padding:6px 10px;' +
+      'background:#262626;color:#eee;font:600 13px system-ui,sans-serif;cursor:grab;user-select:none;}' +
+      '#' + PANEL_ID + ' .bim-panel-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '#' + PANEL_ID + ' .bim-panel-grip{opacity:.5;}' +
+      '#' + PANEL_ID + ' .bim-panel-ctrls{display:flex;gap:2px;}' +
+      '#' + PANEL_ID + ' .bim-panel-btn{background:none;border:0;color:#bbb;padding:4px;border-radius:5px;' +
+      'cursor:pointer;display:flex;align-items:center;}' +
+      '#' + PANEL_ID + ' .bim-panel-btn:hover{background:#3a3a3a;color:#fff;}' +
+      '#' + PANEL_ID + ' .bim-panel-frame{flex:1;width:100%;border:0;background:#0b0b0b;}' +
+      '@media (max-width:760px){#' + PANEL_ID + '.state-float{left:0;top:0;width:100vw;height:100vh;border-radius:0;}}';
+    document.head.appendChild(s);
+  }
+
+  // ported verbatim from pos_lens.js §R2-4 _makePanelDraggable (the established pointer-drag idiom).
+  function _makeDraggable(panel, handle) {
+    var sx, sy, ox, oy, dragging = false, pid = null;
+    handle.addEventListener('pointerdown', function (e) {
+      if (e.target.closest('.bim-panel-btn')) return;       // buttons aren't drag handles
+      var r = panel.getBoundingClientRect();
+      ox = r.left; oy = r.top; sx = e.clientX; sy = e.clientY; dragging = true; pid = e.pointerId;
+      panel.style.right = 'auto'; panel.style.bottom = 'auto';
+      panel.style.left = ox + 'px'; panel.style.top = oy + 'px';
+      try { handle.setPointerCapture(pid); } catch (er) {}
+      handle.style.cursor = 'grabbing'; e.preventDefault();
+    });
+    handle.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var nx = ox + (e.clientX - sx), ny = oy + (e.clientY - sy);
+      nx = Math.max(0, Math.min(nx, window.innerWidth - 40));
+      ny = Math.max(0, Math.min(ny, window.innerHeight - 40));
+      panel.style.left = nx + 'px'; panel.style.top = ny + 'px';
+    });
+    function _end() { if (!dragging) return; dragging = false; handle.style.cursor = 'grab'; try { handle.releasePointerCapture(pid); } catch (er) {} console.log('§BIM-PANEL-DRAG moved=Y'); }
+    handle.addEventListener('pointerup', _end);
+    handle.addEventListener('pointercancel', _end);
+  }
+
+  function close() {
+    var p = document.getElementById(PANEL_ID);
+    if (p) { p.remove(); console.log('§BIM-PANEL close'); }
+  }
+
+  function open(url, opts) {
+    opts = opts || {};
+    if (!url) { console.warn('§BIM-PANEL open called with no url'); return null; }
+    _ensureStyle();
+    close();   // single panel at a time
+
+    var embUrl = url + (url.indexOf('?') >= 0 ? '&' : '?') + 'embedded=true';
+    var panel = document.createElement('div'); panel.id = PANEL_ID; panel.className = 'state-float';
+
+    var hdr = document.createElement('div'); hdr.className = 'bim-panel-hdr';
+    hdr.innerHTML = '<span class="bim-panel-grip">⠿</span><span class="bim-panel-title"></span>';
+    hdr.querySelector('.bim-panel-title').textContent = opts.title || 'BIM Model';
+
+    function setState(s) { panel.className = 'state-' + s; console.log('§BIM-PANEL state=' + s); }
+    function ctl(name, title, fn) {
+      var b = document.createElement('button'); b.className = 'bim-panel-btn'; b.title = title;
+      b.innerHTML = _icon(name, 16);
+      b.addEventListener('click', function (e) { e.stopPropagation(); fn(); });
+      return b;
+    }
+    var ctrls = document.createElement('div'); ctrls.className = 'bim-panel-ctrls';
+    ctrls.appendChild(ctl('panelRight', 'Dock', function () { setState('dock'); }));
+    ctrls.appendChild(ctl('pictureInPicture2', 'Float', function () { setState('float'); }));
+    ctrls.appendChild(ctl('maximize', 'Maximize', function () { setState('max'); }));
+    ctrls.appendChild(ctl('externalLink', 'Open in new tab', function () { window.open(url, '_blank'); console.log('§BIM-PANEL popout'); }));
+    ctrls.appendChild(ctl('xmark', 'Close', close));
+    hdr.appendChild(ctrls);
+
+    var frame = document.createElement('iframe'); frame.className = 'bim-panel-frame'; frame.id = 'bim-panel-frame';
+    frame.setAttribute('title', opts.title || 'BIM Model'); frame.src = embUrl;
+
+    panel.appendChild(hdr); panel.appendChild(frame);
+    document.body.appendChild(panel);
+    _makeDraggable(panel, hdr);
+    console.log('§BIM-EMBED-PANEL open url=' + embUrl + ' title=' + (opts.title || 'BIM Model'));
+    return panel;
+  }
+
+  // viewer → host: the embedded viewer posts {type:'bim:ready'} once chromeless mode is up.
+  window.addEventListener('message', function (e) {
+    var d = e.data;
+    if (d && typeof d === 'object' && d.type === 'bim:ready')
+      console.log('§BIM-EMBED-READY viewer ready bld=' + (d.bld || '?'));
+  });
+
+  window.BimPanel = { open: open, close: close };
+})();

--- a/erp/icons.js
+++ b/erp/icons.js
@@ -77,7 +77,18 @@
     // SPATIAL_PICKING_SPEC §S-3 — Lucide route (warehouse pill idempiere.html + WH walk strip mode indicator).
     route:    { svg: '<circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/>' },
     // POS FOLLOW-UP ROUND 2 §R2-6 — Lucide plus (the "register NEW product" import dock glyph).
-    plus:     { svg: '<path d="M5 12h14"/><path d="M12 5v14"/>' }
+    plus:     { svg: '<path d="M5 12h14"/><path d="M12 5v14"/>' },
+    // BIM_EMBED_WINDOW_SESSION §B2 — verbatim Lucide line glyphs for the BIM-in-window embed panel +
+    // status/Time-Machine/PO-drawer controls. ERP-only surface, not in panels.js (precedent: overlay-kit set).
+    pictureInPicture2: { svg: '<path d="M21 9V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h4"/><rect width="10" height="7" x="12" y="13" rx="2"/>' },
+    externalLink:      { svg: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>' },
+    paperclip:         { svg: '<path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/>' },
+    filter:            { svg: '<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>' },
+    play:              { svg: '<polygon points="6 3 20 12 6 21 6 3"/>' },
+    pause:             { svg: '<rect x="14" y="4" width="4" height="16" rx="1"/><rect x="6" y="4" width="4" height="16" rx="1"/>' },
+    radio:             { svg: '<path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/><circle cx="12" cy="12" r="2"/><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/><path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"/>' },
+    truck:             { svg: '<path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/>' },
+    calendar:          { svg: '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>' }
   };
   if (typeof window !== "undefined") window.ICONS = ICONS;
   if (typeof module !== "undefined" && module.exports) module.exports = ICONS;

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -477,6 +477,9 @@
 <!-- The ONE gesture — edit one rule → K records re-fold live, signed + reversible (docs/RULE_EDIT_SPEC.md). -->
 <script src="bigdecimal.js?v=1"></script>
 <script src="bim_orders_overlay.js?v=1"></script>
+<!-- BIM_EMBED_WINDOW_SESSION §B2 — DETECT a BIM-set attachment (bim_embed.js) + the dock/float/max embed panel (bim_panel.js). -->
+<script src="bim_embed.js?v=1"></script>
+<script src="bim_panel.js?v=1"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
 <script src="report_overlay.js?v=3"></script>
 <script src="rule_fold.js?v=2"></script>
@@ -704,6 +707,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // ad_seed.db, so they appear in the STANDARD C_Project / C_Order windows. Additive delta (PK >= BIM_BASE),
     // idempotent; the idb seed cache was written from raw bytes above so it stays unpolluted. Witness W-BIM-OVERLAY.
     if (window.BimOrdersOverlay) { try { await window.BimOrdersOverlay.apply(SQL, db); } catch (e) { console.log('§BIM_OVERLAY_ERR ' + e.message); } }
+    // BIM_EMBED_WINDOW_SESSION §B2 — declare the BIM-set attachment(s) onto the loaded db (boot overlay, no
+    // ad_seed.db binary churn, idempotent). Lights the "Open Model" affordance on a BIM-bearing record. W-BIM-EMBED.
+    if (window.BimEmbed && window.BimEmbed.ensureSeedBimSets) { try { var _bn = window.BimEmbed.ensureSeedBimSets(db); console.log('§BIM-EMBED seed-bimsets applied=' + _bn); } catch (e) { console.log('§BIM-EMBED-SEED-ERR ' + e.message); } }
     // ?shard=<file>.db — SHARD-IN (the URL install path). Same installShard() the Install dialog drives in-page.
     var shardParam = new URLSearchParams(location.search).get('shard');
     if (shardParam) await installShard(shardParam);
@@ -1462,11 +1468,40 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         ' desktopTable=' + (!mq ? (!tblHidden ? 'Y' : 'N') : 'n/a') +
         ' pillRail=bottom@≤760');
     }
-    else host.appendChild(buildForm(tab));
+    else host.appendChild(buildForm(tab));   // refreshForm() (below) rebuilds the form + mounts the BIM affordance
     updateStatus(tab);
     refreshForm();
     // item 5 — re-evaluate showWhen:"form-view" pills now the view (grid/form) is settled.
     if (window.IdmpPills && window.IdmpPills.setDocContext) window.IdmpPills.setDocContext();
+  }
+  // BIM_EMBED_WINDOW_SESSION §B2 — when the active record OWNS a BIM-set attachment (declared in the AD,
+  // detected via bim_embed.js — NO if-window==130), show an "Open Model" affordance that mounts the viewer
+  // in the dock/float/max embed panel (bim_panel.js). No BIM set → no affordance (honest, panel absent).
+  function _mountBimAffordance(tab) {
+    if (!window.BimEmbed || !window.BimPanel || !db || !tab || !tab.tableName) return;
+    var rec = _records[_recIdx]; if (!rec) return;
+    var pk = recVal(rec, _keyCol(tab)); if (pk == null || String(pk) === '') return;
+    var bs; try { bs = window.BimEmbed.bimSetForTable(db, tab.tableName, pk); } catch (e) { bs = null; }
+    if (!bs) { console.log('§BIM-EMBED affordance table=' + tab.tableName + ' record=' + pk + ' bimSet=absent'); return; }
+    var formEl = $('idmp-form') || $('idmp-content'); if (!formEl) return;
+    var I = window.ICONS && window.ICONS.package;
+    var bar = el('div', 'idmp-bim-affordance');
+    bar.style.cssText = 'margin:8px 0;padding:8px 12px;display:flex;align-items:center;gap:10px;' +
+      'background:rgba(79,195,247,.08);border:1px solid rgba(79,195,247,.35);border-radius:8px;';
+    var btn = el('button', 'idmp-bim-open');
+    btn.style.cssText = 'display:inline-flex;align-items:center;gap:7px;padding:6px 12px;cursor:pointer;' +
+      'background:#1f6feb;color:#fff;border:0;border-radius:7px;font:600 13px system-ui,sans-serif;';
+    btn.innerHTML = (I ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + I.svg + '</svg>' : '') + '<span>Open Model</span>';
+    btn.title = bs.title || 'Open the BIM model for this record';
+    btn.addEventListener('click', function () {
+      window.BimPanel.open(bs.url, { title: bs.title || (tab.name + ' · model') });
+      console.log('§BIM-EMBED open table=' + tab.tableName + ' record=' + pk + ' url=' + bs.url);
+    });
+    var lbl = el('span', null, bs.title || 'BIM model'); lbl.style.cssText = 'color:#9bd; font:13px system-ui,sans-serif;';
+    bar.appendChild(btn); bar.appendChild(lbl);
+    formEl.insertBefore(bar, formEl.firstChild);
+    console.log('§BIM-EMBED affordance table=' + tab.tableName + ' record=' + pk + ' bimSet=present url=' + bs.url);
   }
   // GRID_BATCH_FORM_PILL_SPEC item 4 — multi-select keyed by record PK (survives a grid re-render) + a batch
   //   "gear" toolbar that fans _fsmCtx(tab,rec).dispatch over the LEGAL-ACTION INTERSECTION of the selection.
@@ -2213,7 +2248,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   function refreshForm() {
     var nav = $('idmp-recnav');
     if (nav) nav.textContent = _records.length ? ('Record ' + (_recIdx + 1) + ' of ' + _records.length) : '0 records';
-    if (_viewMode === 'form') { var tab = _curTab(); if (tab) { $('idmp-content').innerHTML = ''; $('idmp-content').appendChild(buildForm(tab)); } }
+    if (_viewMode === 'form') { var tab = _curTab(); if (tab) { $('idmp-content').innerHTML = ''; $('idmp-content').appendChild(buildForm(tab)); _mountBimAffordance(tab); } }
     var t = _curTab(); if (t) { _setSel(t); updateStatus(t); }
   }
   function updateStatus(tab) {

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v707';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v706';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v707';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -28,6 +28,8 @@ const CDN_ASSETS = [
 const PRECACHE_ASSETS = [
   'erp.html',
   'idempiere.html',
+  'bim_embed.js',     // BIM_EMBED §B2 — BIM-set DETECT (bimSetForTable), W-BIM-EMBED
+  'bim_panel.js',     // BIM_EMBED §B2 — dock/float/max embed panel
   'ad_charts.js',
   'ad_data.js',
   'ad_docfsm.js',

--- a/erp/tests/poc_bim_embed_live.js
+++ b/erp/tests/poc_bim_embed_live.js
@@ -1,0 +1,100 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for BIM_EMBED_WINDOW_SESSION.md §B2 — W-BIM-EMBED (host side).
+//   PROVES on iDempiere's own Project window (130), GardenWorld (client 11), via
+//   ?client=garden&window=130&record=<pk>:
+//     (A) PRESENT: project 101 (owns a BIM-set AD_Attachment) → the "Open Model" affordance mounts in the
+//         form view (§BIM-EMBED affordance ... bimSet=present), keyed off the AD — no if-window==130.
+//     (B) ABSENT (honest): project 100 (Standard, no BIM set) → NO affordance (bimSet=absent).
+//     (C) MOUNT: clicking Open Model mounts the dock/float/max embed panel — #bim-embed-panel + an iframe
+//         whose src carries the viewer URL + &embedded=true (chromeless). Controls present; state toggles.
+//     (D) READY (best-effort): the embedded viewer posts {bim:ready} → §BIM-EMBED-READY. Headless WebGL may
+//         not fully boot the 3D viewer — if ready doesn't arrive it is logged 🟡 (NOT a fail; host wiring is
+//         what B2 proves; ready round-trip re-checked on a real browser).
+//     0 pageerrors.
+//   §-log first — READ tests/poc_bim_embed_live.log before any conclusion (exit code is NOT evidence).
+// Run:  cd /tmp/wt-bimembed/erp && node tests/poc_bim_embed_live.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');   // worktree root — serves BOTH /erp and /viewer
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/erp/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [], errs = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+function soft(ok, label, detail) { S('   ' + (ok ? '🟢' : '🟡') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function openAt(page, port, pk) {
+  await page.goto('http://127.0.0.1:' + port + '/erp/idempiere.html?login=GardenAdmin&window=130&record=' + pk,
+    { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);   // let auto-login → openWindow(130) → land-on-record → renderBody settle
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on('console', m => log.push('  [console] ' + m.text()));
+  page.on('pageerror', e => { errs.push(String(e)); log.push('  [pageerror] ' + e); });
+
+  S('§W-BIM-EMBED (host side) — Open-Model affordance + embed panel on iDempiere Project window 130');
+
+  // ── (A) PRESENT on project 101 ───────────────────────────────────────────
+  await openAt(page, port, 101);
+  const aff101 = log.some(l => /§BIM-EMBED affordance .*record=101 .*bimSet=present/.test(l));
+  const btn101 = await page.evaluate(() => !!document.querySelector('.idmp-bim-open'));
+  if (btn101) { try { await page.screenshot({ path: require('os').homedir() + '/Pictures/Screenshots/bim_embed_b2_form.png' }); } catch (e) {} }
+  verdict(aff101, 'project 101 → §BIM-EMBED affordance bimSet=present');
+  verdict(btn101, 'project 101 → "Open Model" button rendered in the form');
+
+  // ── (C) MOUNT: click Open Model → embed panel + iframe(embedded=true) ─────
+  let mounted = { panel:false, src:'', ctrls:0 };
+  if (btn101) {
+    await page.evaluate(() => document.querySelector('.idmp-bim-open').click());
+    await page.waitForTimeout(1500);
+    mounted = await page.evaluate(() => {
+      const p = document.getElementById('bim-embed-panel');
+      const f = document.getElementById('bim-panel-frame');
+      return { panel: !!p, src: f ? f.getAttribute('src') : '', ctrls: p ? p.querySelectorAll('.bim-panel-btn').length : 0 };
+    });
+  }
+  verdict(mounted.panel, 'Open Model → embed panel mounted (#bim-embed-panel)');
+  verdict(/embedded=true/.test(mounted.src) && /Hospital/.test(mounted.src),
+    'iframe src = viewer URL + &embedded=true (chromeless)', mounted.src);
+  verdict(mounted.ctrls >= 5, 'panel controls present (dock/float/max/popout/close)', 'count=' + mounted.ctrls);
+
+  // ── (D) READY (best-effort) ───────────────────────────────────────────────
+  await page.waitForTimeout(3500);
+  try { await page.screenshot({ path: require('os').homedir() + '/Pictures/Screenshots/bim_embed_b2_panel.png' }); } catch (e) {}
+  const ready = log.some(l => /§BIM-EMBED-READY/.test(l));
+  soft(ready, 'embedded viewer posted {bim:ready} (headless WebGL may skip — host wiring proven regardless)');
+
+  // ── (B) ABSENT on project 100 ─────────────────────────────────────────────
+  await openAt(page, port, 100);
+  const aff100present = log.some(l => /§BIM-EMBED affordance .*record=100 .*bimSet=present/.test(l));
+  const aff100absent = log.some(l => /§BIM-EMBED affordance .*record=100 .*bimSet=absent/.test(l));
+  const btn100 = await page.evaluate(() => !!document.querySelector('.idmp-bim-open'));
+  verdict(!aff100present && !btn100, 'project 100 (Standard) → NO affordance (honest absent)',
+    aff100absent ? 'logged bimSet=absent' : 'no affordance log');
+
+  // ── pageerrors ────────────────────────────────────────────────────────────
+  verdict(errs.length === 0, '0 pageerrors', errs.length ? errs.slice(0, 3).join(' | ') : 'clean');
+
+  const pass = fails === 0;
+  S('\n§W-BIM-EMBED ' + (pass ? 'PASS' : 'FAIL') + ' (fails=' + fails + ') — host-side affordance+panel proven on iDempiere; ' +
+    'highlight/focusRecord round-trip = B3');
+  fs.writeFileSync(path.join(__dirname, 'poc_bim_embed_live.log'), log.join('\n'));
+  await browser.close(); server.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -15,6 +15,16 @@ async function initViewer() {
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
     setupPicking, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
+  // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
+  // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).
+  if (APP.EMBEDDED) {
+    try { document.documentElement.classList.add('bim-embedded'); } catch (e) {}
+    try {
+      if (window.parent && window.parent !== window)
+        window.parent.postMessage({ type: 'bim:ready', bld: (new URLSearchParams(location.search)).get('bld') || null }, '*');
+    } catch (e) {}
+    console.log('§BIM-EMBEDDED chromeless mode on; ready posted to host');
+  }
   if (typeof setupDLOD === 'function') setupDLOD(APP);
   if (typeof setupNlp === 'function') setupNlp(APP);
   if (typeof setupGhostGlass === 'function') setupGhostGlass(APP);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -419,6 +419,17 @@
     .swipe-hidden, #hud.swipe-hidden, #search-box.swipe-hidden, #info-panel.swipe-hidden { display: none !important; }
   }
 </style>
+<style>
+/* BIM_EMBED_WINDOW_SESSION §B2 — chromeless when docked inside the iDempiere window (html.bim-embedded,
+   set by main.js when ?embedded=true). Hides the viewer's own app chrome so it reads as a native sub-panel;
+   the 3D canvas + model stay. Additive/guarded — ids that aren't present are simply no-ops. */
+html.bim-embedded #hud, html.bim-embedded #icon-pill, html.bim-embedded #overflow-scrim,
+html.bim-embedded #search-box, html.bim-embedded #info-panel, html.bim-embedded #site-cam-btn,
+html.bim-embedded #walk-mode-btn, html.bim-embedded #nlp-btn, html.bim-embedded #panel-toggle-btn,
+html.bim-embedded #minmax-btn, html.bim-embedded #mobile-bar, html.bim-embedded #mobile-pill,
+html.bim-embedded #status-bar-wrap, html.bim-embedded #doc-timeline { display: none !important; }
+html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
+</style>
 </head>
 <body>
 <div id="hud" style="display:none!important">


### PR DESCRIPTION
§B2 of BIM_EMBED_WINDOW_SESSION. A C_Project record owning a BIM-set AD_Attachment shows an 'Open Model' affordance that docks the BIM viewer in a float/dock/max/pop-out panel (chromeless via the existing embedded=true param), record visible underneath. Detect keyed off the AD (bimSetForTable) — never if-window==130, so any table lights up free. Boot overlay = no ad_seed.db churn. Localhost W-BIM-EMBED 8/8 (?login=GardenAdmin&window=130&record=101), 0 pageerrors; W-BIM-EMBED-DECLARE 9/9 headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)