### PR TITLE
feat(erp): in-place CRUD undo reconcile (P5) — fix phantom-draft-pip; Ignore↔timeline distinction — erp sw v709 (W-INPLACE-UNDO-LIVE)

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -1097,8 +1097,14 @@
     if (!_formCtx || _formCtx.verb !== 'update') return null;
     var st = _draftStore(); if (!st) return null;
     var vals = gatherVals(_formCtx.e);
+    // P5 (phantom-draft-pip fix): diff against the POST-RENDER baseline on an inline form — `_formCtx.baseline` is the
+    //   RAW record, but populateRefs/fieldInput normalize on render (date→yyyy-MM-dd, an fk select landing on another
+    //   option, number coercion), so an UNTOUCHED open would read those as "changed" → a spurious AMBER pip + a
+    //   §DRAFT-PUT the user never typed. `_inlineBaseline` is the same as-rendered baseline _inlineDirty/validate use,
+    //   so an untouched inline open now buffers NOTHING. The modal path keeps the raw baseline (unchanged).
+    var baseDraft = (_formCtx.inline && _inlineBaseline) ? _inlineBaseline : _formCtx.baseline;
     var rec = draftPut(st, _formCtx.e.key, _formCtx.id, vals,
-      { baseline: _formCtx.baseline, tipSnapshot: _formCtx.baseline, ts: ++_draftSeq });
+      { baseline: baseDraft, tipSnapshot: baseDraft, ts: ++_draftSeq });
     if (rec) _setDraftPip(_formCtx.e.key, _formCtx.id, rec.cols);
     else _clearDraftPip(_formCtx.e.key, _formCtx.id);   // clean leave → strand no stale pip
     return rec;

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -526,7 +526,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
      overlay fetches crud_ops.json at enable. The host adapter (in the inline script below) provides
      withBundle/curChain/__crudHostAnchor so the ring binds to the FOCUSED record; T1 fan-out + T2 list-tip +
      T4 owner-gate ride along unchanged. -->
-<script src="crud_overlay.js?v=18"></script>
+<script src="crud_overlay.js?v=19"></script>
 <!-- BLUE FUTURE (FRONTEND_LANE_MASTER §OUTSTANDING item 0 browser legs) — the UNOFFICIAL speculative-branch skin
      over kernel v9 (branchOps/discardBranch/acceptBranchUpTo). crud_overlay.js consumes its readBranch()/groupMeta()
      seams (loaded above, so BlueFuture must come AFTER it for the rail to mount, but the seams read lazily so order

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_inplace_undo_live.js
+++ b/erp/tests/poc_inplace_undo_live.js
@@ -1,0 +1,138 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for P5 of the iDempiere-FAITHFUL IN-PLACE CRUD lane
+//   (prompts/CRUD_INPLACE_EDIT_SESSION.md §P5 / T3; RESUME_INPLACE_P4.md §P5). W-INPLACE-UNDO-LIVE.
+//   THE ISSUE this test proves/disproves:
+//   (1) PHANTOM-DRAFT-PIP — does opening a record inline and leaving it UNTOUCHED buffer a spurious draft + raise an
+//       AMBER unsaved-edit pip? It MUST NOT: an untouched open buffers NOTHING (the buffer diffs against the POST-
+//       render baseline `_inlineBaseline`, not the raw record, so render-normalization — date/fk/number — is not a
+//       phantom "change"). A GENUINE edit still buffers + raises the pip.
+//   (2) IGNORE vs TIMELINE — Ignore (verb bar) discards the UNCOMMITTED delta and is shown by the AMBER hollow
+//       `.scrubdraft` pip (distinct from the solid committed `.scrubdot`); the op-log timeline only ever carries
+//       COMMITTED ops. Save is the BOUNDARY: only a Save puts a committed mark on the timeline. The two are never
+//       confused. Source of truth = iDempiere dataIgnore() (discard unsaved) vs the persisted op-log.
+//   §-log first — READ tests/poc_inplace_undo_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_inplace_undo_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+let pass = 0, fail = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+
+async function openFormView(page) {
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const okb = await page.$('#idmp-login-ok'); if (okb) await okb.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(700);
+  await page.evaluate(() => { const tr = document.querySelector('.idmp-grid tbody tr[data-ad-record]'); if (tr) tr.click(); });
+  await page.waitForSelector('#idmp-inline-mount .cfrow', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(400);
+}
+
+const firstTextCol = (page) => page.evaluate(() => {
+  const mount = document.getElementById('idmp-inline-mount');
+  const pref = ['name', 'value', 'description', 'taxid', 'duns'];
+  let inp = null;
+  if (mount) { for (const c of pref) { const e = mount.querySelector('input.cfi[type="text"][data-col="' + c + '"]:not([disabled])'); if (e) { inp = e; break; } }
+    if (!inp) inp = mount.querySelector('input.cfi[type="text"]:not([disabled])'); }
+  return inp ? { col: inp.getAttribute('data-col'), val: inp.value } : null;
+});
+const typeField = (page, col, v) => page.evaluate(({ col, v }) => {
+  const el = document.querySelector('#idmp-inline-mount input.cfi[data-col="' + col + '"]');
+  if (!el) return false; el.value = v; el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); return true;
+}, { col, v });
+const clickVerb = (page, v) => page.evaluate((v) => { const b = document.querySelector('#idmp-inline-mount .ic-vb[data-v="' + v + '"]'); if (b && !b.disabled) { b.click(); return true; } return false; }, v);
+// simulate the nav/beforeunload buffer flush (inline forms buffer via the exposed seam, not closeForm)
+const bufferDraft = (page) => page.evaluate(() => { try { return !!(window.__crud && window.__crud.bufferDraft && window.__crud.bufferDraft()); } catch (e) { return false; } });
+const pipState = (page) => page.evaluate(() => ({
+  amber: !!document.querySelector('#idmp-scrub .scrubdraft'),        // AMBER hollow unsaved-edit pip
+  committed: document.querySelectorAll('#idmp-scrub .scrubdot').length   // committed/nav marks on the timeline
+}));
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  console.log('\n§INPLACE-UNDO ===== Ignore (uncommitted) vs the committed op-log timeline — distinct + no phantom pip =====');
+
+  const logs = [], errs = [];
+  const page = await browser.newPage({ viewport: { width: 1280, height: 860 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+  const anyLog = re => logs.some(l => re.test(l));
+  const countLog = re => logs.filter(l => re.test(l)).length;
+
+  const boot = 'seed=ad_seed.db&login=GardenAdmin&window=123';
+  await page.goto(`http://localhost:${port}/idempiere.html?${boot}`, { waitUntil: 'networkidle' });
+  await openFormView(page);
+
+  const f = await firstTextCol(page);
+  ok('found an editable text field to drive', !!(f && f.col), f ? ('col=' + f.col) : 'none');
+  if (!f || !f.col) { console.log('\n❌ W-INPLACE-UNDO-LIVE: cannot proceed — no editable field'); await browser.close(); server.close(); process.exit(1); }
+  const col = f.col, orig = f.val == null ? '' : f.val;
+
+  // ── (1) PHANTOM-DRAFT-PIP: an UNTOUCHED open must buffer NOTHING ──
+  const draftsBefore = countLog(/§DRAFT-PUT/);
+  const buffered = await bufferDraft(page); await page.waitForTimeout(200);
+  const p0 = await pipState(page);
+  const draftsAfterUntouched = countLog(/§DRAFT-PUT/);
+  console.log('§INPLACE-UNDO[untouched] bufferDraft=' + buffered + ' §DRAFT-PUT(before=' + draftsBefore + ',after=' + draftsAfterUntouched + ') amberPip=' + p0.amber);
+  ok('an UNTOUCHED inline open buffers NOTHING (no §DRAFT-PUT, phantom-pip fix)', !buffered && draftsAfterUntouched === draftsBefore, 'put before=' + draftsBefore + ' after=' + draftsAfterUntouched);
+  ok('no AMBER unsaved-edit pip on an untouched open', !p0.amber);
+
+  // ── (2a) a GENUINE edit DOES buffer + raise the amber pip (the pip still works) ──
+  await typeField(page, col, (orig + ' [u]').slice(0, 38)); await page.waitForTimeout(200);
+  const realBuffer = await bufferDraft(page); await page.waitForTimeout(250);
+  const p1 = await pipState(page);
+  ok('a GENUINE edit buffers a draft (§DRAFT-PUT cols includes ' + col + ')', realBuffer && anyLog(new RegExp('§DRAFT-PUT key=\\S*c_bpartner.*cols=.*' + col)), 'buffered=' + realBuffer);
+  ok('the AMBER hollow unsaved-edit pip (.scrubdraft) shows — distinct from committed dots', p1.amber);
+
+  // ── (2b) IGNORE discards the uncommitted delta — pip clears, NO committed op added to the timeline ──
+  const committedBeforeIgnore = (await pipState(page)).committed;
+  // re-open the form to the buffered state, then Ignore (the form view re-mounts on the tip; type to make it dirty again)
+  await typeField(page, col, (orig + ' [u2]').slice(0, 38)); await page.waitForTimeout(150);
+  const persistBeforeIgnore = countLog(/§CRUD-PERSIST/);
+  await clickVerb(page, 'ignore'); await page.waitForTimeout(300);
+  const r = await firstTextCol(page);
+  const persistAfterIgnore = countLog(/§CRUD-PERSIST/);
+  ok('Ignore reverts the field to the tip (uncommitted discard, §INPLACE-IGNORE)', r && r.val === orig && anyLog(/§INPLACE-IGNORE table=c_bpartner/), 'val="' + (r && r.val) + '" expect="' + orig + '"');
+  ok('Ignore commits NOTHING to the op-log timeline (no new §CRUD-PERSIST)', persistAfterIgnore === persistBeforeIgnore, 'persist before=' + persistBeforeIgnore + ' after=' + persistAfterIgnore);
+
+  // ── (2c) SAVE is the BOUNDARY: only a Save puts a COMMITTED mark on the timeline ──
+  const persistBeforeSave = countLog(/§CRUD-PERSIST/);
+  await typeField(page, col, (orig + ' [saved]').slice(0, 38)); await page.waitForTimeout(200);
+  await clickVerb(page, 'save'); await page.waitForTimeout(1400);
+  const persistAfterSave = countLog(/§CRUD-PERSIST/);
+  ok('Save commits ONE signed op to the timeline (§CRUD-PERSIST) — the boundary', persistAfterSave > persistBeforeSave, 'persist before=' + persistBeforeSave + ' after=' + persistAfterSave);
+  const afterSave = await firstTextCol(page);
+  ok('after Save the inline form re-mounts clean (no stranded unsaved state)', !!afterSave && /\[saved\]/.test(afterSave.val || ''), 'val="' + (afterSave && afterSave.val) + '"');
+
+  ok('0 pageerrors across the run', errs.length === 0, errs.slice(0, 3).join(' | '));
+  await page.close();
+
+  console.log('\n----- relevant page-console § lines -----');
+  logs.filter(l => /§DRAFT-PUT|§IDMP-HIST (setDraftPip|clearDraftPip)|§INPLACE-IGNORE|§CRUD-PERSIST|§DRAFT-OFFER/.test(l)).slice(0, 30).forEach(l => console.log('   ' + l));
+  console.log('-----------------------------------------');
+
+  const verdict = (fail === 0)
+    ? 'CRITIC ✔ Ignore and the op-log timeline are distinct: an UNTOUCHED inline open raises NO phantom unsaved-pip (the buffer diffs the post-render baseline); a genuine edit raises the AMBER hollow pip; Ignore discards the uncommitted delta (revert to tip, nothing on the timeline); and Save is the boundary that puts the one committed op on the timeline. iDempiere dataIgnore-faithful (P5).'
+    : 'CRITIC ✘ Ignore/timeline reconcile not faithful yet — see the 🔴 above.';
+  console.log('\n§INPLACE-UNDO-VERDICT ' + verdict);
+  console.log((fail === 0 ? '✅' : '❌') + ' W-INPLACE-UNDO-LIVE: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL)');
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
**P5** of the iDempiere-faithful in-place CRUD lane (T3 reconcile) — **completes the lane (P1–P5)**.

## What
- **FIX — phantom-draft-pip** (the one the user noticed): `_bufferDraft` diffed `gatherVals()` (POST-render) against `_formCtx.baseline` (the **raw** record). On an inline form, `populateRefs`/`fieldInput` normalize on render (date→`yyyy-MM-dd`, an fk select landing on another option, number coercion), so an **untouched** open read those as "changed" → a spurious AMBER pip + a `§DRAFT-PUT` the user never typed. Inline forms now diff against `_inlineBaseline` (the same post-render baseline `_inlineDirty`/validate already use) → an untouched open buffers **nothing**; a genuine edit still buffers + raises the pip. The modal path keeps the raw baseline (unchanged).
- **Ignore↔timeline distinction** (already built — the witness asserts it): AMBER hollow `.scrubdraft` pulse pip = unsaved/opt-in-restore vs the solid committed `.scrubdot`; verb-bar `● unsaved` / `Ignore — discard unsaved edits`; **Save is the boundary** (Process blocked while dirty, from P2/T3). Ignore discards the uncommitted delta (nothing on the timeline); Save commits the one signed op.

## Witness
**W-INPLACE-UNDO-LIVE 10/10** (`tests/poc_inplace_undo_live.js`): untouched inline open buffers nothing (no `§DRAFT-PUT`, no amber pip); a genuine edit raises the amber pip; Ignore reverts to tip with no new `§CRUD-PERSIST`; Save commits one signed op.

Regressions GREEN: inplace-grid 11, inplace-edit 12, inplace-newdel 14, draft-restore 10, crud-full 10, ad-folded-crud-live 14, form-pill 6, ring-leak 10, grid-batch 7, recinfo 7, process-signed 18, selfedit 30, critic-create 12 (+ #360 bim-embed on the merged tree).

erp **sw v709**, `crud_overlay?v=19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)