### PR TITLE
fix(viewer): restore Help shortcuts palette; About/DIY → corner download triangle

### DIFF
--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1121,7 +1121,7 @@ function setupPanels(A) {
       { id: 'redpill',    name: 'Doc Mode',       key: ',', platform: 'desktop', img: 'redpill.png', icon: '', fn: function() { if (typeof window.toggleDocPill === 'function') window.toggleDocPill(); }, isActive: function() { return !!window._docMode; } },
       { id: 'find',       name: 'Find / Navigate', key: 'f', icon: I.search.svg, fn: function() { if (A.openFindPanel) A.openFindPanel(''); },
         children: [ { name: 'Search by name/class' }, { name: 'Filter by storey/type' }, { name: 'Voice search (mic)' }, { name: 'Navigate to element' } ] },
-      { id: 'help',       name: 'Help',            key: 'F1', icon: I.lifeBuoy.svg, fn: function() { if (window.AboutDIY) window.AboutDIY.open(); else if (typeof showCommandPalette === 'function') showCommandPalette(); } },
+      { id: 'help',       name: 'Help',            key: 'F1', icon: I.lifeBuoy.svg, fn: function() { if (typeof showCommandPalette === 'function') showCommandPalette(); } },
       // HISTORY_KNOB_DIAL.md rework: ONE "W" World-history pill replaces the old History pill.
       //   TAP        = open the cross-page overlay (which building/doc/page).
       //   LONG-PRESS = a small drawer: Z (this page's dot-timeline bar) + bomb (clear history, warns first).

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1018,8 +1018,11 @@ async function setupScene(A) {
           console.log('§PWA_BADGE click=update (green)');
           _checkUpdate();
         } else {
-          console.log('§PWA_BADGE click=download (blue)');
-          _startOfflineDownload();
+          // ABOUT_BOX_CONSOLIDATE.md — the corner download triangle opens the shared
+          // About/DIY modal (its DIY tab is the self-host installer). Help pill keeps the
+          // shortcuts palette. Fallback to the raw offline download if AboutDIY is absent.
+          console.log('§PWA_BADGE click=about-diy (blue)');
+          if (window.AboutDIY) window.AboutDIY.open(); else _startOfflineDownload();
         }
       });
       console.log('§PWA_BADGE rendered color=' + _badgeColor);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v666';   // v666: clash dot restores the pair + Clash panel (field('clash'), universal_history.js?v=24)
+const CACHE_VERSION = 'v667';   // v667: Help pill restored to the shortcuts palette; the corner download triangle opens About/DIY (was wrongly on Help). git history is the record.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/poc_about_help_restore.js
+++ b/viewer/tests/poc_about_help_restore.js
@@ -1,0 +1,88 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-module §-witness for the ABOUT_BOX_CONSOLIDATE rewire fix. PROVES the About/DIY
+//   modal was wrongly bound to the WHOLE Help pill and is now bound only to the command-palette
+//   corner download triangle, with Help restored to the shortcuts palette:
+//     1. The Help pill's fn opens the shortcuts palette (#cmd-palette), NOT the About modal.
+//     2. showCommandPalette() renders the corner download triangle (#cmd-install-badge).
+//     3. Clicking the (blue, not-installed) triangle opens the shared About/DIY modal (.adq-card)
+//        and logs §PWA_BADGE click=about-diy — it no longer fires the raw offline download.
+//   §-log first — READ tests/poc_about_help_restore.log before any conclusion (exit code ≠ evidence).
+// Run:  node viewer/tests/poc_about_help_restore.js 2>&1 | tee viewer/tests/poc_about_help_restore.log   (cwd = bim-ootb worktree)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json', '.wasm': 'application/wasm', '.css': 'text/css', '.png': 'image/png' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+
+const PASS = [], FAIL = [];
+function check(n, c) { (c ? PASS : FAIL).push(n); console.log((c ? '✅ ' : '❌ ') + n); }
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const logs = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', m => logs.push(m.text()));
+
+  await page.goto(`http://localhost:${port}/viewer/viewer.html`, { waitUntil: 'networkidle' });
+  // scene.js registers window.showCommandPalette during boot; about_diy.js registers window.AboutDIY.
+  await page.waitForFunction(() => typeof window.showCommandPalette === 'function', { timeout: 20000 });
+
+  const wired = await page.evaluate(() => ({
+    hasPalette: typeof window.showCommandPalette === 'function',
+    hasAbout: !!(window.AboutDIY && typeof window.AboutDIY.open === 'function'),
+  }));
+  check('showCommandPalette registered (shortcuts palette exists)', wired.hasPalette);
+  check('AboutDIY modal module loaded', wired.hasAbout);
+
+  // 1. The Help pill fn opens the shortcuts palette, NOT the About modal.
+  await page.evaluate(() => {
+    // close anything open first
+    var p = document.getElementById('cmd-palette'); if (p) p.remove();
+    var a = document.querySelector('.adq-card'); if (a && a.closest) { var ov = a.closest('[id]'); }
+    window.showCommandPalette();   // simulate the Help pill / F1 route
+  });
+  await page.waitForTimeout(120);
+  const afterHelp = await page.evaluate(() => ({
+    palette: !!document.getElementById('cmd-palette'),
+    badge: !!document.getElementById('cmd-install-badge'),
+    aboutOpen: !!document.querySelector('.adq-card'),
+  }));
+  check('Help route → shortcuts palette open (#cmd-palette)', afterHelp.palette);
+  check('Help route → About modal NOT opened', !afterHelp.aboutOpen);
+  check('Palette renders the corner download triangle (#cmd-install-badge)', afterHelp.badge);
+
+  // 2. Click the corner triangle → About/DIY modal opens (blue/not-installed branch).
+  const badgeColor = await page.evaluate(() => {
+    var b = document.getElementById('cmd-install-badge');
+    return b ? b.style.borderColor : null;
+  });
+  await page.evaluate(() => {
+    var b = document.getElementById('cmd-install-badge');
+    b.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await page.waitForTimeout(200);
+  const afterBadge = await page.evaluate(() => ({
+    aboutOpen: !!document.querySelector('.adq-card'),
+    paletteGone: !document.getElementById('cmd-palette'),
+  }));
+  check('Triangle is the not-installed (blue) variant', /4fc3f7|79, ?195, ?247/i.test(badgeColor || ''));
+  check('Triangle click → About/DIY modal opens (.adq-card)', afterBadge.aboutOpen);
+  check('Triangle click → §PWA_BADGE click=about-diy logged (not raw download)', logs.some(l => /§PWA_BADGE click=about-diy/.test(l)));
+  check('Triangle click → NO §PWA_BADGE click=download (blue)', !logs.some(l => /§PWA_BADGE click=download/.test(l)));
+
+  await browser.close();
+  server.close();
+  console.log('\n§W-ABOUT-HELP-RESTORE ' + PASS.length + '/' + (PASS.length + FAIL.length) + (FAIL.length ? ' — FAIL: ' + FAIL.join('; ') : ' ALL PASS'));
+  process.exit(FAIL.length ? 1 : 0);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -844,7 +844,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="kernel_ops.js?v=4" onerror="console.warn('[KernelOps] kernel_ops.js skipped')"></script>
 <script src="../common/whole_history.js?v=4" onerror="console.warn('[WholeHistory] common/whole_history.js skipped')"></script>
 <script src="../common/history_bar.js?v=6" onerror="console.warn('[HistoryBar] common/history_bar.js skipped')"></script>
-<!-- ABOUT_BOX_CONSOLIDATE.md — the ONE shared About/DIY modal (Help pill → AboutDIY.open). Self-contained
+<!-- ABOUT_BOX_CONSOLIDATE.md — the ONE shared About/DIY modal (the command-palette corner download triangle → AboutDIY.open; the Help pill keeps the shortcuts palette). Self-contained
      (embeds its own Lucide glyphs) — does NOT load erp/icons.js, which would clobber the viewer's own window.ICONS. -->
 <script src="../common/about_diy.js?v=1" onerror="console.warn('[AboutDIY] about_diy.js skipped')"></script>
 <script src="universal_history.js?v=24" onerror="console.warn('[UniversalHistory] universal_history.js skipped')"></script>


### PR DESCRIPTION
The About/DIY consolidation (#339) bound the modal to the **whole Help pill**, which
wiped out the keyboard-shortcuts command palette. Per the report, the modal should only
have replaced the command palette's **corner "download" triangle**.

## Fix
- **panels.js** — Help pill → `showCommandPalette()` again (the shortcuts palette restored).
- **scene.js** — the command-palette corner triangle (`#cmd-install-badge`), blue/not-installed
  branch, now opens `AboutDIY.open()` (its DIY tab is the self-host installer) instead of the
  raw `_startOfflineDownload()`; green/installed branch unchanged (`_checkUpdate()`).
- **viewer.html** — comment corrected; **sw** v666→v667.

## Proof
`viewer/tests/poc_about_help_restore.js` — **W-ABOUT-HELP-RESTORE 9/9** (real Chromium):
Help route → palette open & About NOT opened; triangle renders; triangle click → `.adq-card`
About modal + `§PWA_BADGE click=about-diy`, with no raw-download fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)