### PR TITLE
feat(erp): Project Print (AD_Process 217) — KIND-1 fold C_Project→receipt — erp sw v709

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -98,6 +98,9 @@
     }
     registerHandler('report:c_order',   receiptHandler('c_order'),   { kind: 'report', reportKey: 'c_order' });
     registerHandler('report:c_invoice', receiptHandler('c_invoice'), { kind: 'report', reportKey: 'c_invoice' });
+    // report:c_project — "Rpt C_Project" (AD_Process 217, Project Print). KIND-1, folds via the SAME foldReceipt
+    // (REPORT_MAP.c_project), no new fold code. AD_PROCESS_FOLD_LANE §P2-leg3 — Witness: W-PROC-PROJPRINT.
+    registerHandler('report:c_project', receiptHandler('c_project'), { kind: 'report', reportKey: 'c_project' });
 
     // org.compiere.report.TrialBalance -> report_overlay.foldTrialBalance over the posted journal.
     registerHandler('org.compiere.report.TrialBalance', function (ctx, info) {
@@ -435,6 +438,10 @@
       // map known report procs to the report_overlay header tables (extracted, not invented)
       if (/c_order\b|order print|rpt c_order/.test(hay) && !/invoice/.test(hay)) return 'report:c_order';
       if (/c_invoice|invoice print|rpt c_invoice/.test(hay)) return 'report:c_invoice';
+      // "Rpt C_Project" (217) — SPECIFIC match (c_project / project print), NOT the broad "project" so the other
+      // RV_Project* report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay absent-handler (no foldReceipt
+      // for a report view — those are a later report-view fold, not this leg).
+      if (/c_project|project print|rpt c_project/.test(hay)) return 'report:c_project';
     }
     return proc.classname || '';     // blank -> no handler -> absent-handler result downstream
   }

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -430,7 +430,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=4"></script>
+<script src="ad_process.js?v=5"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -488,7 +488,7 @@
 <script src="bim_embed.js?v=1"></script>
 <script src="bim_panel.js?v=1"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
-<script src="report_overlay.js?v=3"></script>
+<script src="report_overlay.js?v=4"></script>
 <script src="rule_fold.js?v=2"></script>
 <!-- POS_ADDON_SPEC §P-1..§P-4 — the POS addon: engine verbs (UMD of bim-compiler scripts/erp_engine.js),
      the fold glue (pos_core.js, == bim-compiler build/erp source of truth), the dumb-terminal lens.

--- a/erp/report_overlay.js
+++ b/erp/report_overlay.js
@@ -27,7 +27,15 @@
                  date: 'dateinvoiced', total: 'grandtotal' },
     m_inout:   { key: 'm_inout',   pk: 'm_inout_id',   lineTable: 'm_inoutline',   fk: 'm_inout_id',
                  fkProduct: 'm_product_id', amount: null,        qty: 'movementqty', price: null,
-                 date: 'movementdate', total: null }
+                 date: 'movementdate', total: null },
+    // Rpt C_Project (AD_Process 217, "Project Print") — a KIND-1 report folded by the SAME foldReceipt as the
+    // order/invoice prints (no new fold code, AD_PROCESS_FOLD_LANE §P2-leg3). A project IS a document: header
+    // C_Project + lines C_ProjectLine; the planned amounts are its money (subtotal = Σ PlannedAmt, total = the
+    // header PlannedAmt). C_Project has no DocumentNo → docnoCol names its identifier column (Value). The browser
+    // lc() helper aliases the bundle's CamelCase (PlannedAmt/Value) to these lowercase keys.
+    c_project: { key: 'c_project', pk: 'c_project_id', lineTable: 'c_projectline', fk: 'c_project_id',
+                 fkProduct: 'm_product_id', amount: 'plannedamt', qty: 'plannedqty', price: 'plannedprice',
+                 date: 'datecontract', total: 'plannedamt', docnoCol: 'value' }
   };
 
   function num(v) { return (v == null || v === '') ? null : Number(v); }
@@ -73,7 +81,7 @@
     var taxB = (subtotalB != null && totalB != null) ? totalB.subtract(subtotalB) : null;
     var subtotal = money2(subtotalB), total = (totalB != null ? money2(totalB) : null), tax = money2(taxB);
     return {
-      key: map.key, id: header[map.pk], docno: header.documentno,
+      key: map.key, id: header[map.pk], docno: header[map.docnoCol || 'documentno'],
       date: (map.date && header[map.date] != null) ? String(header[map.date]).slice(0, 10) : null,
       partner: (names.partner != null ? names.partner
                  : (header.c_bpartner_id != null ? '#' + header.c_bpartner_id : null)),

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v710';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
**P2-leg3 of `AD_PROCESS_FOLD_LANE.md`** — the first **KIND-1** (report) leg of this lane: a report proc folded through `report_overlay` with **zero new fold code**.

"Rpt C_Project" (AD_Process 217, blank classname, isReport=Y) resolves via the W-PROC spine to `report:c_project` and folds a **C_Project** through the EXISTING `report_overlay.foldReceipt` — a project *is* a document (header C_Project + lines C_ProjectLine; subtotal = Σ PlannedAmt, total = header PlannedAmt).

### `report_overlay.js?v=4`
- One `REPORT_MAP` row (`c_project`) + a generic `docnoCol` (C_Project has no DocumentNo → reads `Value`). The existing `foldReceipt` / `lc()` / `_procCtx` are all generic — **no per-process fold code**.

### `ad_process.js?v=5`
- Register `report:c_project` (the shared `receiptHandler`) + a **C_Project-specific** `resolveClassname` match — the `RV_Project*` report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay the honest **absent-handler** card, never mis-routed to `foldReceipt`.
- **No `idempiere.html` dispatch change**: `openProcess` + `renderProcResult` already render any `{lines, subtotal, total}` fold.

### Witnesses
- **W-PROC-PROJPRINT** (`scripts/poc_proc_projprint.js`) — 6/6: resolve, cent-exact subtotal/total/tax vs a BigDecimal re-derivation (project 101 = 600.00), falsifier, broad-match guard.
- **W-PROC-PROJPRINT-LIVE** (`scripts/poc_projprint_live.js`) — PASS, 0 pageerrors; the card renders honestly, and project 101 folds to **600.00 in-browser** reading the real CamelCase bundle exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)