### PR TITLE
feat(erp): BIM-embed generality — 2nd table (M_Warehouse) lights from an AD flag alone — sw v709 (W-BIM-EMBED §B4)

### DIFF
--- a/erp/bim_embed.js
+++ b/erp/bim_embed.js
@@ -89,8 +89,13 @@
   // NO 26MB binary churn and it auto-survives a seed re-export (no re-apply needed). Each entry is a
   // standard AD_Attachment row. NON-INVENT: the URL points at a REAL served viewer building.
   var SEED_BIM_SETS = [
+    // Project Order (C_Project 203) — the driving case.
     { adTableId: 203, recordId: 101, name: 'Landscape Complex (Hospital model)',
-      url: '../viewer/viewer.html?db=buildings/Hospital_extracted.db&bld=Hospital', clientId: 11, orgId: 11 }
+      url: '../viewer/viewer.html?db=buildings/Hospital_extracted.db&bld=Hospital', clientId: 11, orgId: 11 },
+    // GENERALITY (§B4): a SECOND, non-Project table — M_Warehouse (190) record 103 "HQ Warehouse" — lights the
+    // SAME "Open Model" affordance with ZERO new render code, purely from this AD flag. This is the framework proof.
+    { adTableId: 190, recordId: 103, name: 'HQ Warehouse (Terminal model)',
+      url: '../viewer/viewer.html?db=buildings/Terminal_extracted.db&bld=Terminal', clientId: 11, orgId: 11 }
   ];
 
   // ensureSeedBimSets — idempotently declare the SEED_BIM_SETS onto the loaded db (boot hook). Only inserts

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_bim_embed_live.js
+++ b/erp/tests/poc_bim_embed_live.js
@@ -34,10 +34,11 @@ function S(m) { log.push(m); console.log(m); }
 function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
 function soft(ok, label, detail) { S('   ' + (ok ? '🟢' : '🟡') + ' ' + label + (detail ? ' — ' + detail : '')); }
 
-async function openAt(page, port, pk) {
-  await page.goto('http://127.0.0.1:' + port + '/erp/idempiere.html?login=GardenAdmin&window=130&record=' + pk,
+async function openAt(page, port, pk, win) {
+  win = win || 130;
+  await page.goto('http://127.0.0.1:' + port + '/erp/idempiere.html?login=GardenAdmin&window=' + win + '&record=' + pk,
     { waitUntil: 'networkidle' });
-  await page.waitForTimeout(2500);   // let auto-login → openWindow(130) → land-on-record → renderBody settle
+  await page.waitForTimeout(2500);   // let auto-login → openWindow(win) → land-on-record → renderBody settle
 }
 
 (async () => {
@@ -87,6 +88,14 @@ async function openAt(page, port, pk) {
   const btn100 = await page.evaluate(() => !!document.querySelector('.idmp-bim-open'));
   verdict(!aff100present && !btn100, 'project 100 (Standard) → NO affordance (honest absent)',
     aff100absent ? 'logged bimSet=absent' : 'no affordance log');
+
+  // ── (B4) GENERALITY: a SECOND, non-Project table lights up from an AD flag alone (ZERO new render code) ──
+  await openAt(page, port, 103, 139);   // M_Warehouse "HQ Warehouse", window 139 (Warehouse and Locators)
+  const affWh = log.some(l => /§BIM-EMBED affordance .*record=103 .*bimSet=present/.test(l));
+  const btnWh = await page.evaluate(() => !!document.querySelector('.idmp-bim-open'));
+  const whUrl = await page.evaluate(() => { var b = document.querySelector('.idmp-bim-open'); return b ? b.title : ''; });
+  verdict(affWh && btnWh, 'M_Warehouse 103 (window 139) → "Open Model" lights from the AD flag alone (B4 generality)',
+    whUrl || '');
 
   // ── pageerrors ────────────────────────────────────────────────────────────
   verdict(errs.length === 0, '0 pageerrors', errs.length ? errs.slice(0, 3).join(' | ') : 'clean');


### PR DESCRIPTION
§B4 — the framework proof. An M_Warehouse BIM-set declaration makes the SAME 'Open Model' affordance appear on the Warehouse window (139) with ZERO new render code; detect is keyed off the AD attachment (bimSetForTable), never the window id. W-BIM-EMBED 9/9 live, 0 pageerrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)