### PR TITLE
feat(erp): Rpt M_InOut KIND-1 report fold (AD_Process 117) — sw v714 (W-PROC-MINOUT)

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -98,6 +98,12 @@
     }
     registerHandler('report:c_order',   receiptHandler('c_order'),   { kind: 'report', reportKey: 'c_order' });
     registerHandler('report:c_invoice', receiptHandler('c_invoice'), { kind: 'report', reportKey: 'c_invoice' });
+    // report:m_inout — "Rpt M_InOut" (AD_Process 117, "Delivery Note / Shipment Print"). KIND-1, the print
+    // sibling of InOutGenerate (§P2-leg1 makes the M_InOut; this prints it). Folds via the SAME foldReceipt over
+    // the ALREADY-PRESENT REPORT_MAP.m_inout — ZERO new fold code. A shipment is a NON-FINANCIAL document
+    // (amount:null → subtotal/tax/total stay null, qty=MovementQty carried) — honest, never a fabricated total.
+    // AD_PROCESS_FOLD_LANE §P2-tail-leg1 — Witness: W-PROC-MINOUT.
+    registerHandler('report:m_inout',   receiptHandler('m_inout'),   { kind: 'report', reportKey: 'm_inout' });
     // report:c_project — "Rpt C_Project" (AD_Process 217, Project Print). KIND-1, folds via the SAME foldReceipt
     // (REPORT_MAP.c_project), no new fold code. AD_PROCESS_FOLD_LANE §P2-leg3 — Witness: W-PROC-PROJPRINT.
     registerHandler('report:c_project', receiptHandler('c_project'), { kind: 'report', reportKey: 'c_project' });
@@ -438,6 +444,10 @@
       // map known report procs to the report_overlay header tables (extracted, not invented)
       if (/c_order\b|order print|rpt c_order/.test(hay) && !/invoice/.test(hay)) return 'report:c_order';
       if (/c_invoice|invoice print|rpt c_invoice/.test(hay)) return 'report:c_invoice';
+      // "Rpt M_InOut" (117) — M_InOut-SPECIFIC: m_inout\b (word-boundary) so "Rpt M_InOutConfirm" (292,
+      // "m_inoutconfirm" — no boundary) and the RV_InOutDetails report-VIEWs (293/294) stay absent-handler.
+      // "delivery note"/"shipment print" are the print-format name; "shipment confirmation"/"...details" do NOT match.
+      if (/m_inout\b|delivery note|shipment print/.test(hay)) return 'report:m_inout';
       // "Rpt C_Project" (217) — SPECIFIC match (c_project / project print), NOT the broad "project" so the other
       // RV_Project* report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay absent-handler (no foldReceipt
       // for a report view — those are a later report-view fold, not this leg).

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -439,7 +439,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=5"></script>
+<script src="ad_process.js?v=6"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v713';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v714';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## AD_PROCESS_FOLD_LANE §P2-tail-leg1 — Rpt M_InOut (Delivery Note / Shipment Print)

The first P2-tail leg and the **print sibling of InOutGenerate** (§P2-leg1 makes the M_InOut; this prints it).

Blank-classname report proc **117** ("Rpt M_InOut", isReport=Y) resolves to `report:m_inout` and folds an M_InOut via the **EXISTING** `report_overlay.foldReceipt` over the **ALREADY-PRESENT** `REPORT_MAP.m_inout` row:
- **ZERO new fold code** (even less than leg3, which added a map row).
- **ZERO host change** — `_procCtx` is generic over any `REPORT_MAP` key; `renderProcResult` already renders a non-financial fold.
- A shipment is a **NON-FINANCIAL** document (`amount:null` → subtotal/tax/total stay null, `qty=MovementQty` carried) — folded honestly, **never a fabricated total**.
- `resolveClassname` match is `m_inout\b` (word-boundary) so **292 "Rpt M_InOutConfirm"** + **293/294 RV_InOutDetails** stay the honest absent-handler card (a substring `rpt m_inout` would wrongly catch "m_inoutconfirm").

`ad_process.js?v=6`, `CACHE_VERSION v714`.

## Witnesses (bim-compiler)
- `poc_proc_minout.js` (**W-PROC-MINOUT 6/6**) — resolve; non-financial fold of real M_InOut 100 (DocumentNo 600000, qty 1); per-line `qty=MovementQty` + price/amount null oracle; falsifier (bend MovementQty +7 → folded qty shifts exactly); word-boundary guard (292/293/294 stay absent-handler). EXIT 0.
- `poc_minout_live.js` (**W-PROC-MINOUT-LIVE PASS**) — `?process=117` deep link folds M_InOut 100 to a non-financial receipt card in-browser off the served CamelCase `ad_seed.db` (M_InOut_ID/DocumentNo/MovementQty), 0 pageerrors. EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)