### PR TITLE
feat(modeller): Lucide line icons + authoring audio feedback

### DIFF
--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -10,6 +10,14 @@
   'use strict';
   const TAG = '§OUTLINER';
 
+  // Lucide line disclosure glyphs (verbatim chevron-down / chevron-right) — no unicode triangles.
+  const CHEV = (open) => '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px">' +
+    (open ? '<path d="m6 9 6 6 6-6"/>' : '<path d="m9 18 6-6-6-6"/>') + '</svg>';
+  // Leaf marker — a small dot (a leaf row is not expandable, so a chevron would mislead).
+  const LEAF = '<svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor" stroke="none" ' +
+    'style="vertical-align:-1px;margin-right:5px;opacity:.55"><circle cx="12" cy="12" r="3"/></svg>';
+
   function gridRef(pt) {
     if (!pt || !window.Bonsai.grid || !window.Bonsai.grid.xs.length) return null;
     const r = window.Bonsai.grid.refAt(pt[0], pt[1]);
@@ -65,13 +73,13 @@
       const f = this._find;
       const match = n => !f || (n.label + ' ' + n.sub).toLowerCase().includes(f);
       let total = 0, shown = 0;
-      let html = '<div style="padding:2px 6px;color:#8b94a3">▼ Bonsai Model</div>';
+      let html = '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'Bonsai Model</div>';
       groups.forEach(g => {
         const vis = g.nodes.filter(match); total += g.nodes.length; shown += vis.length;
         if (f && !vis.length) return;
         const col = this._collapsed[g.cat.key];
         html += '<div data-grp="' + g.cat.key + '" style="padding:2px 6px 2px 16px;color:#6f7a8b;cursor:pointer">' +
-          (col ? '▸ ' : '▼ ') + g.cat.label + ' <span style="color:#454e5d">(' + g.nodes.length + ')</span></div>';
+          CHEV(!col) + g.cat.label + ' <span style="color:#454e5d">(' + g.nodes.length + ')</span></div>';
         if (col) return;
         vis.forEach(n => {
           const active = window.Bonsai._selId === n.id;
@@ -79,7 +87,7 @@
             (active ? 'background:#26456b;color:#dce6f4' : 'color:#c7cdd8') + '" ' +
             'onmouseover="this.style.background=\'' + (active ? '#26456b' : '#23262e') + '\'" ' +
             'onmouseout="this.style.background=\'' + (active ? '#26456b' : 'transparent') + '\'">' +
-            '▸ ' + n.label + '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span></div>';
+            LEAF + n.label + '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span></div>';
         });
       });
       tree.innerHTML = html;

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -12,9 +12,11 @@
   #c { display: block; width: 100vw; height: 100vh; }
   #bar { position: fixed; top: 10px; left: 252px; display: flex; gap: 8px; z-index: 10; flex-wrap: wrap; max-width: calc(100vw - 270px); }
   #bar button { background: #232733; color: #cdd6e4; border: 1px solid #39404f; border-radius: 7px;
-    padding: 8px 12px; font-size: 13px; cursor: pointer; }
+    padding: 8px 12px; font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
   #bar button:hover { background: #2c3140; }
   #bar button:disabled { opacity: .5; cursor: default; }
+  #bar button.on { background: #1f3147; border-color: #4fc3f7; color: #9fd4f7; }
+  #bar button .ic { width: 15px; height: 15px; flex: 0 0 auto; }
   #stat { position: fixed; bottom: 10px; left: 252px; color: #6b7488; font-size: 11px; z-index: 10;
     font-family: ui-monospace, monospace; white-space: pre; }
   #title { position: fixed; top: 12px; right: 14px; color: #4a5163; font-size: 11px; z-index: 10; letter-spacing: .08em; }
@@ -26,14 +28,14 @@
 <body>
 <canvas id="c"></canvas>
 <div id="bar">
-  <button id="b-wall" disabled>+ Wall</button>
-  <button id="b-open" disabled>+ Opening</button>
-  <button id="b-grid" disabled>▦ Grid</button>
-  <button id="b-sketch" disabled>✎ Sketch</button>
-  <button id="b-extrude" disabled style="display:none">⬆ Extrude</button>
-  <button id="b-cut" disabled>✂ Cut</button>
-  <button id="b-ifc" disabled>⤓ IFC</button>
-  <button id="b-clear" disabled>Clear</button>
+  <button id="b-wall" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Wall</span></button>
+  <button id="b-open" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Opening</span></button>
+  <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
+  <button id="b-sketch" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg><span>Sketch</span></button>
+  <button id="b-extrude" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg><span>Extrude</span></button>
+  <button id="b-cut" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg><span>Cut</span></button>
+  <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
+  <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
 </div>
 <div id="hist" style="position:fixed;bottom:36px;left:252px;right:10px;display:flex;align-items:center;gap:10px;z-index:10;color:#6b7488;font-size:11px;font-family:ui-monospace,monospace">
   <span>history</span>
@@ -136,6 +138,10 @@ bClear.onclick = () => { const g = window.Bonsai.group && window.Bonsai.group();
 // (auto H/V), then Extrude folds the solved profile into a solid via GEOM_EXTRUDE_POLY.
 const bSketch = document.getElementById('b-sketch');
 const bExtrude = document.getElementById('b-extrude');
+// Lucide line icons (verbatim) for the Sketch button's two states — no unicode glyphs on the surface.
+const _ico = (p) => '<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + p + '</svg>';
+const SK_SKETCH = _ico('<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/>') + '<span>Sketch</span>';
+const SK_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
 const GROUND = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);   // z=0 sketch plane
 const raycaster = new THREE.Raycaster();
 let sketching = false, sketchGroup = null, savedCam = null;
@@ -157,11 +163,11 @@ function enterSketch() {
   sketching = true; window.Bonsai.sketch.reset();
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone() };
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
-  bExtrude.style.display = ''; bExtrude.disabled = false; bSketch.textContent = '✕ Cancel';
+  bExtrude.style.display = ''; bExtrude.disabled = false; bSketch.innerHTML = SK_CANCEL;
   sketchMarkers(); setStat('sketch: click ≥3 points on the grid, then Extrude');
 }
 function exitSketch() {
-  sketching = false; bExtrude.style.display = 'none'; bSketch.textContent = '✎ Sketch';
+  sketching = false; bExtrude.style.display = 'none'; bSketch.innerHTML = SK_SKETCH;
   if (sketchGroup) { while (sketchGroup.children.length) sketchGroup.remove(sketchGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); controls.update(); }
 }
@@ -255,7 +261,7 @@ const bGrid = document.getElementById('b-grid');
 window.Bonsai.grid.define();   // default column grid A–D × 1–3
 bGrid.onclick = () => {
   const on = window.Bonsai.grid.show(!window.Bonsai.grid.active);
-  bGrid.textContent = on ? '▦ Grid ✓' : '▦ Grid';
+  bGrid.classList.toggle('on', on);
   setStat(on ? 'grid ON — sketch clicks snap to gridlines (A-1, B-2…)' : 'grid off');
 };
 

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -36,6 +36,7 @@
   <button id="b-cut" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg><span>Cut</span></button>
   <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
+  <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
 </div>
 <div id="hist" style="position:fixed;bottom:36px;left:252px;right:10px;display:flex;align-items:center;gap:10px;z-index:10;color:#6b7488;font-size:11px;font-family:ui-monospace,monospace">
   <span>history</span>
@@ -127,6 +128,7 @@ async function author(op, color) {
   try {
     const r = await window.Bonsai.author(op, { color });
     setStat(op.op_type + '  tris=' + r.triangleCount + '  bbox=[' + r.bbox + ']');
+    audioCue('author');
   } catch (e) { setStat('FAIL ' + (e && e.message || e)); console.warn('§BONSAI author fail ' + e); }
 }
 bWall.onclick = () => author(WALL, 0x9fb4c8);
@@ -142,6 +144,35 @@ const bExtrude = document.getElementById('b-extrude');
 const _ico = (p) => '<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + p + '</svg>';
 const SK_SKETCH = _ico('<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/>') + '<span>Sketch</span>';
 const SK_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
+
+// ── AUTHORING AUDIO FEEDBACK ──────────────────────────────────────────────────────────────────
+// Carries the Morpheus red-pill audio into the modeller: a short Web Audio cue on each authoring
+// action. Sound toggle (default ON, persisted) lives on the toolbar; moves into the shared pill
+// rail when that lands. Verbatim Lucide volume-2 / volume-x icons (no unicode).
+let _soundOn = (localStorage.getItem('bonsai_sound') !== 'off');
+let _ac = null;
+function _actx() { try { _ac = _ac || new (window.AudioContext || window.webkitAudioContext)(); if (_ac.state === 'suspended' && _ac.resume) _ac.resume(); return _ac; } catch (e) { return null; } }
+function audioCue(kind) {
+  if (!_soundOn) return;
+  console.log('§AUDIO cue=' + kind + ' on=' + _soundOn);
+  const ac = _actx(); if (!ac) return;
+  try {
+    const t = ac.currentTime;
+    const TONES = { author: [330, 523], commit: [392, 587], cut: [294, 220], tick: [660], export: [523, 784], clear: [220, 165] };
+    (TONES[kind] || [440]).forEach((f, i) => {
+      const o = ac.createOscillator(), g = ac.createGain(), ts = t + i * 0.06;
+      o.type = 'sine'; o.frequency.setValueAtTime(f, ts);
+      g.gain.setValueAtTime(0.0001, ts); g.gain.exponentialRampToValueAtTime(0.13, ts + 0.012); g.gain.exponentialRampToValueAtTime(0.0001, ts + 0.18);
+      o.connect(g).connect(ac.destination); o.start(ts); o.stop(ts + 0.2);
+    });
+  } catch (e) {}
+}
+const bSound = document.getElementById('b-sound');
+const VOL_ON = _ico('<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>') + '<span>Sound</span>';
+const VOL_OFF = _ico('<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="22" x2="16" y1="9" y2="15"/><line x1="16" x2="22" y1="9" y2="15"/>') + '<span>Muted</span>';
+function paintSound() { bSound.innerHTML = _soundOn ? VOL_ON : VOL_OFF; bSound.classList.toggle('on', _soundOn); }
+bSound.onclick = () => { _soundOn = !_soundOn; localStorage.setItem('bonsai_sound', _soundOn ? 'on' : 'off'); paintSound(); if (_soundOn) audioCue('tick'); };
+paintSound();
 const GROUND = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);   // z=0 sketch plane
 const raycaster = new THREE.Raycaster();
 let sketching = false, sketchGroup = null, savedCam = null;
@@ -192,7 +223,7 @@ bExtrude.onclick = async () => {
     // leg 3: a sketched wall is committed as a FEATURE in the op-log (not a one-shot author).
     const res = await window.Bonsai.sketch.commitExtrude(3, { color: 0x9fd6b4 });
     setStat('committed wall #' + res.id + '  solveStatus=' + res.solveStatus + '  tris=' + res.triangleCount);
-    exitSketch(); syncHistory();
+    audioCue('commit'); exitSketch(); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§SKETCH extrude fail ' + err); }
 };
 
@@ -240,7 +271,7 @@ bCut.onclick = async () => {
   setStat('cutting…');
   try {
     const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_CUT', parameters: { parent: selectedId, void: { c1, c2 } } }, { color: 0x9fd6b4 });
-    setStat('cut opening in #' + selectedId + '  tris=' + res.triangleCount); highlight(null); syncHistory();
+    setStat('cut opening in #' + selectedId + '  tris=' + res.triangleCount); audioCue('cut'); highlight(null); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER cut fail ' + err); }
 };
 
@@ -262,6 +293,7 @@ window.Bonsai.grid.define();   // default column grid A–D × 1–3
 bGrid.onclick = () => {
   const on = window.Bonsai.grid.show(!window.Bonsai.grid.active);
   bGrid.classList.toggle('on', on);
+  audioCue('tick');
   setStat(on ? 'grid ON — sketch clicks snap to gridlines (A-1, B-2…)' : 'grid off');
 };
 
@@ -272,7 +304,7 @@ bIfc.onclick = async () => {
   setStat('exporting IFC…');
   try {
     const r = await window.Bonsai.ifc.exportModel({ name: 'bonsai_model.ifc' });
-    setStat('IFC exported  walls=' + r.walls + '  openings=' + r.openings + '  ' + r.bytes.length + ' bytes (downloaded)');
+    setStat('IFC exported  walls=' + r.walls + '  openings=' + r.openings + '  ' + r.bytes.length + ' bytes (downloaded)'); audioCue('export');
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§IFC export fail ' + err); }
 };
 

--- a/viewer/tests/bonsai_modicons_live.js
+++ b/viewer/tests/bonsai_modicons_live.js
@@ -1,0 +1,73 @@
+// W-BONSAI-MODICONS — modeller icon-redo witness (BONSAI_MORPHEUS_WIRING.md Task 4b).
+// CLAIM: the modeller's placeholder unicode glyphs (▦ ✎ ⬆ ✂ ⤓ + ▼/▸) are replaced by verbatim
+// Lucide LINE icons with ZERO functional regression — the toolbar still authors a wall+opening,
+// the Sketch button toggles its icon/label, the Grid button toggles its active state, and the
+// Outliner renders chevron disclosure. No unicode symbol glyph survives on the toolbar/outliner.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-modicons', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.mjs':'text/javascript', '.wasm':'application/wasm',
+  '.json':'application/json', '.css':'text/css', '.png':'image/png', '.map':'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+const UNICODE_GLYPH = /[←-⯿\u{1F000}-\u{1FAFF}]/u;
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist', '--window-size=1200,760'] });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 760 });
+  const errs = []; const logs = [];
+  pg.on('console', m => { const t = m.text(); if (/§BONSAI author/.test(t)) { logs.push(t); console.log('  ' + t); } });
+  pg.on('pageerror', e => { errs.push(String(e)); console.log('  ERR ' + String(e).slice(0, 200)); });
+
+  await pg.goto(`http://localhost:${port}/modeller.html?author=both`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__authorDone === true', { timeout: 120000 }).catch(() => console.log('  ✗ timeout __authorDone'));
+
+  // toolbar: every button has an svg.ic, and none carries a unicode symbol glyph
+  const bar = await pg.evaluate(() => {
+    const btns = Array.from(document.querySelectorAll('#bar button'));
+    return btns.map(b => ({ id: b.id, hasSvg: !!b.querySelector('svg.ic'), text: (b.textContent || '').trim() }));
+  });
+  const allHaveIcons = bar.every(b => b.hasSvg);
+  const noGlyph = bar.every(b => !UNICODE_GLYPH.test(b.text));
+
+  // Grid toggle → .on class; Sketch toggle → icon+label swaps to Cancel then back
+  const gridOn = await pg.evaluate(() => { document.getElementById('b-grid').click(); return document.getElementById('b-grid').classList.contains('on'); });
+  const sketchToggle = await pg.evaluate(() => {
+    const b = document.getElementById('b-sketch'); b.click();
+    const inSketch = { label: (b.textContent || '').trim(), hasSvg: !!b.querySelector('svg.ic') };
+    b.click(); const back = (b.textContent || '').trim();
+    return { inSketch, back };
+  });
+
+  // Outliner: chevron svgs present, no ▼/▸ text glyphs
+  const outliner = await pg.evaluate(() => {
+    const el = document.getElementById('bonsai-outliner') || document.querySelector('[id*="outliner"]');
+    const tree = document.getElementById('bo-tree') || (el && el.querySelector('[id*="tree"]'));
+    const host = tree || el || document.body;
+    const svgN = host.querySelectorAll('svg').length;
+    const txt = host.textContent || '';
+    return { found: !!(el || tree), svgCount: svgN, hasTriangle: /[▼▸]/.test(txt) };
+  });
+
+  const shot = path.join(VIEWER, 'modeller_icons_shot.png');
+  await pg.screenshot({ path: shot }).catch(() => {});
+  await br.close(); server.close();
+
+  const wall = logs.find(t => /op=GEOM_EXTRUDE/.test(t));
+  const open = logs.find(t => /op=GEOM_OPENING/.test(t));
+  const authored = wall && /inScene=true/.test(wall) && open && /inScene=true/.test(open);
+  const sketchOK = sketchToggle.inSketch.hasSvg && /Cancel/.test(sketchToggle.inSketch.label) && /Sketch/.test(sketchToggle.back);
+  const pass = errs.length === 0 && authored && allHaveIcons && noGlyph && gridOn && sketchOK && !outliner.hasTriangle && outliner.svgCount >= 1;
+  console.log('  §BONSAI-MODICONS buttons=' + bar.length + ' allIcons=' + allHaveIcons + ' noGlyph=' + noGlyph +
+    ' gridOn=' + gridOn + ' sketchToggle=' + sketchOK + ' outlinerChevrons=' + outliner.svgCount + ' outlinerTriangleText=' + outliner.hasTriangle +
+    ' authored=' + authored + ' pageerrors=' + errs.length);
+  console.log('  shot: ' + shot);
+  console.log('── W-BONSAI-MODICONS ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_modicons_live.js
+++ b/viewer/tests/bonsai_modicons_live.js
@@ -21,8 +21,10 @@ const UNICODE_GLYPH = /[←-⯿\u{1F000}-\u{1FAFF}]/u;
   const br = await puppeteer.launch({ headless: 'new',
     args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist', '--window-size=1200,760'] });
   const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 760 });
-  const errs = []; const logs = [];
-  pg.on('console', m => { const t = m.text(); if (/§BONSAI author/.test(t)) { logs.push(t); console.log('  ' + t); } });
+  const errs = []; const logs = []; const audio = [];
+  pg.on('console', m => { const t = m.text();
+    if (/§BONSAI author/.test(t)) { logs.push(t); console.log('  ' + t); }
+    if (/§AUDIO/.test(t)) { audio.push(t); console.log('  ' + t); } });
   pg.on('pageerror', e => { errs.push(String(e)); console.log('  ERR ' + String(e).slice(0, 200)); });
 
   await pg.goto(`http://localhost:${port}/modeller.html?author=both`, { waitUntil: 'load', timeout: 60000 });
@@ -55,6 +57,19 @@ const UNICODE_GLYPH = /[←-⯿\u{1F000}-\u{1FAFF}]/u;
     return { found: !!(el || tree), svgCount: svgN, hasTriangle: /[▼▸]/.test(txt) };
   });
 
+  // sound toggle: default ON (.on + Sound label), click → Muted; authoring fired a §AUDIO cue
+  const sound = await pg.evaluate(() => {
+    const b = document.getElementById('b-sound');
+    if (!b) return { exists: false };
+    const onAtStart = b.classList.contains('on');
+    const labelOn = (b.textContent || '').trim();
+    b.click();
+    const mutedAfter = !b.classList.contains('on') && /Muted/.test(b.textContent || '');
+    b.click(); // back on
+    return { exists: true, hasSvg: !!b.querySelector('svg.ic'), onAtStart, labelOn, mutedAfter };
+  });
+  const audioFired = audio.some(t => /§AUDIO cue=author/.test(t));
+
   const shot = path.join(VIEWER, 'modeller_icons_shot.png');
   await pg.screenshot({ path: shot }).catch(() => {});
   await br.close(); server.close();
@@ -63,10 +78,11 @@ const UNICODE_GLYPH = /[←-⯿\u{1F000}-\u{1FAFF}]/u;
   const open = logs.find(t => /op=GEOM_OPENING/.test(t));
   const authored = wall && /inScene=true/.test(wall) && open && /inScene=true/.test(open);
   const sketchOK = sketchToggle.inSketch.hasSvg && /Cancel/.test(sketchToggle.inSketch.label) && /Sketch/.test(sketchToggle.back);
-  const pass = errs.length === 0 && authored && allHaveIcons && noGlyph && gridOn && sketchOK && !outliner.hasTriangle && outliner.svgCount >= 1;
+  const soundOK = sound.exists && sound.hasSvg && sound.onAtStart && sound.mutedAfter;
+  const pass = errs.length === 0 && authored && allHaveIcons && noGlyph && gridOn && sketchOK && !outliner.hasTriangle && outliner.svgCount >= 1 && soundOK && audioFired;
   console.log('  §BONSAI-MODICONS buttons=' + bar.length + ' allIcons=' + allHaveIcons + ' noGlyph=' + noGlyph +
     ' gridOn=' + gridOn + ' sketchToggle=' + sketchOK + ' outlinerChevrons=' + outliner.svgCount + ' outlinerTriangleText=' + outliner.hasTriangle +
-    ' authored=' + authored + ' pageerrors=' + errs.length);
+    ' sound=' + soundOK + ' audioCue=' + audioFired + ' authored=' + authored + ' pageerrors=' + errs.length);
   console.log('  shot: ' + shot);
   console.log('── W-BONSAI-MODICONS ' + (pass ? 'PASS' : 'FAIL') + ' ──');
   process.exit(pass ? 0 : 1);


### PR DESCRIPTION
BONSAI_MORPHEUS_WIRING.md Task 4b + audio (user direction).

- Toolbar placeholder unicode glyphs → verbatim Lucide line icons (▦→grid ✎→pencil ⬆→move-up
  ✂→scissors ⤓→download +→plus Clear→trash); outliner ▼/▸ → chevron-down/right + leaf dots.
- Authoring audio feedback: a short Web Audio cue per action (author/commit/cut/grid/export),
  gated by a Sound toggle (default ON, persisted). Carries the Morpheus red-pill audio in.

Witnesses: W-BONSAI-MODICONS (9 buttons icon+label no-glyph, Grid .on toggle, Sketch↔Cancel
swap, outliner chevrons, §AUDIO cue=author fires, sound toggle mutes/unmutes, 0 page errors)
+ W-BONSAI-OUTLINER re-run PASS (collapse/find/select intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)