### PR TITLE
feat(morpheus): real drop-own-IFC in the Matrix hub

### DIFF
--- a/import_own.js
+++ b/import_own.js
@@ -1,0 +1,401 @@
+// import_own.js — drop-own-IFC for the Matrix hub (index2 ONLY).
+// VERBATIM EXTRACT from index.html (the live landing) — non-invent. S224 merge prompt removed
+// per MORPHEUS_PLATE_REBUILD.md (always new project → auto-open viewer). Loaded after import_db_builder.js.
+var _base = '';            // GH Pages = same-origin root (index.html _ociMatch → '')
+function trackTab(){}      // landing tab-tracker not present on the plate — no-op
+
+// ── discipline-from-filename ──
+var _VALID_DISCS = ['ARC','STR','MEP','PLB','ACMV','ELEC','FP','VENT','HEAT','SAN','COOL','VOID'];
+var _DISC_ALIAS = {
+  // Short forms from real-world IFC filenames
+  ELE:'ELEC', ELECTRICAL:'ELEC',
+  FIRE:'FP', SPR:'FP', SPRINKLER:'FP',
+  AIR:'ACMV', DUCT:'ACMV', HVAC:'ACMV', MECH:'ACMV', MECHANICAL:'ACMV',
+  ARCHITECTURAL:'ARC', STRUCTURAL:'STR', PLUMBING:'PLB',
+};
+function _discFromFilename(fname) {
+  var stem = fname.replace(/\.(ifc|obj|stl|dae|glb|gltf|3ds|fbx)$/i, '');
+  var parts = stem.split(/[_\-]/);
+  for (var i = parts.length - 1; i >= 0; i--) {
+    var p = parts[i].toUpperCase();
+    if (_VALID_DISCS.indexOf(p) >= 0) return p;
+    if (_DISC_ALIAS[p]) return _DISC_ALIAS[p];
+  }
+  return null;
+}
+
+// ── versioned import IDB + cache IDB ──
+const IMPORT_DB_NAME = 'bim_ootb_imports';
+const IMPORT_STORE = 'buildings';
+const IMPORT_DB_VERSION = 2;  // v2: versioned storage model
+function openImportDB() {
+  return new Promise(resolve => {
+    const req = indexedDB.open(IMPORT_DB_NAME, IMPORT_DB_VERSION);
+    req.onupgradeneeded = function(e) {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(IMPORT_STORE)) {
+        db.createObjectStore(IMPORT_STORE);
+      }
+      // Migrate v1 → v2: wrap old per-file records into versioned format
+      if (e.oldVersion < 2) {
+        const tx = req.transaction;
+        const store = tx.objectStore(IMPORT_STORE);
+        const getAll = store.getAllKeys();
+        getAll.onsuccess = function() {
+          const keys = getAll.result;
+          for (const key of keys) {
+            const gr = store.get(key);
+            gr.onsuccess = function() {
+              const old = gr.result;
+              if (old && !old.versions) {
+                // Old format: { meta, extractedDb, libraryDb } → new: { meta, versions[], latestVersion }
+                const migrated = {
+                  meta: old.meta,
+                  versions: [{ key: key, importDate: new Date().toISOString(), db: old.extractedDb }],
+                  latestVersion: 0
+                };
+                store.put(migrated, key);
+                console.log('[S224] §MIGRATE_V1 key=' + key);
+              }
+            };
+          }
+        };
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+const CACHE_DB_NAME = 'bim_ootb_cache';
+const CACHE_STORE = 'dbs';
+function openCacheDB() {
+  return new Promise(resolve => {
+    const req = indexedDB.open(CACHE_DB_NAME, 2);
+    req.onupgradeneeded = function() {
+      var db = req.result;
+      if (!db.objectStoreNames.contains(CACHE_STORE)) db.createObjectStore(CACHE_STORE);
+      if (!db.objectStoreNames.contains('timestamps')) db.createObjectStore('timestamps');
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+// Get a single project record
+async function getProject(key) {
+  const db = await openImportDB();
+  if (!db) return null;
+  return new Promise(resolve => {
+    const tx = db.transaction(IMPORT_STORE, 'readonly');
+    const req = tx.objectStore(IMPORT_STORE).get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+// Save a project record
+async function saveProject(key, record) {
+  const db = await openImportDB();
+  if (!db) return;
+  return new Promise(resolve => {
+    const tx = db.transaction(IMPORT_STORE, 'readwrite');
+    tx.objectStore(IMPORT_STORE).put(record, key);
+    tx.oncomplete = resolve;
+  });
+}
+// Open latest version of a project in viewer
+// opts: { wizard: true } to launch classification wizard in viewer
+async function openProject(key, btnEl, opts) {
+  if (btnEl) { btnEl.textContent = 'Opening...'; btnEl.disabled = true; }
+
+  // §S274: Check cache store FIRST (lightweight key check, no 760MB record read).
+  // If split-DB was pre-populated during import, skip reading the heavy project record entirely.
+  const cacheDb = await openCacheDB();
+  var dbUrl, libUrl;
+  var _splitUrl = 'import://' + key + '/' + key.replace(/\.ifc$/i, '_extracted.db');
+  var _geoUrl = 'import://' + key + '/' + key.replace(/\.ifc$/i, '_geo.db');
+
+  // IDB getKey() doesn't exist everywhere — use count() to check presence without loading data
+  var _hasCachedGeo = false;
+  if (cacheDb) {
+    _hasCachedGeo = await new Promise(function(resolve) {
+      var tx = cacheDb.transaction(CACHE_STORE, 'readonly');
+      var req = tx.objectStore(CACHE_STORE).count(IDBKeyRange.only(_geoUrl));
+      req.onsuccess = function() { resolve(req.result > 0); };
+      req.onerror = function() { resolve(false); };
+    });
+  }
+
+  if (_hasCachedGeo) {
+    // Fast path — cache already populated during import. Just open.
+    dbUrl = _splitUrl;
+    libUrl = _splitUrl;
+    console.log('[S274] §OPEN_PROJECT_INSTANT key=' + key + ' (cache pre-populated)');
+  } else {
+    // Slow path — read full record for legacy imports or monolith fallback
+    var record = await getProject(key);
+    if (!record || !record.versions.length) {
+      alert('Building not found');
+      if (btnEl) { btnEl.textContent = 'Open'; btnEl.disabled = false; }
+      return;
+    }
+    var base = record.versions[0];
+    if (!cacheDb) { if (btnEl) { btnEl.textContent = 'Open'; btnEl.disabled = false; } return; }
+
+    if (record.metaDb && record.geoDb) {
+      // Split-DB but cache not populated — legacy import, populate now
+      dbUrl = _splitUrl;
+      libUrl = _splitUrl;
+      var _metaUrl = 'import://' + key + '/' + key.replace(/\.ifc$/i, '_meta.db');
+      await new Promise(function(resolve) {
+        var tx = cacheDb.transaction(CACHE_STORE, 'readwrite');
+        var store = tx.objectStore(CACHE_STORE);
+        store.put(record.metaDb, _metaUrl);
+        store.put(record.metaDb, dbUrl);
+        store.put(record.geoDb, _geoUrl);
+        tx.oncomplete = resolve;
+      });
+      console.log('[S274] §OPEN_PROJECT_CACHE_FILL key=' + key + ' (legacy, populating cache)');
+    } else {
+      // Monolith — no split DBs available
+      dbUrl = 'import://' + key + '/v0';
+      libUrl = dbUrl;
+      await new Promise(resolve => {
+        var tx = cacheDb.transaction(CACHE_STORE, 'readwrite');
+        tx.objectStore(CACHE_STORE).put(base.db, dbUrl);
+        tx.objectStore(CACHE_STORE).put(base.db, libUrl);
+        tx.oncomplete = resolve;
+      });
+      console.log('[S274] §OPEN_PROJECT_MONOLITH key=' + key + ' size=' + (base.db.byteLength/1024/1024).toFixed(1) + 'MB');
+    }
+  }
+
+  // Variance/wizard — only needed on slow path (record already loaded).
+  // Fast path skips: IFC imports have no variance or wizard.
+  var diffParam = '';
+  var wizardParam = '';
+  if (typeof record !== 'undefined' && record) {
+    if (record.versions && record.versions.length > 1) {
+      for (var vi = 1; vi < record.versions.length; vi++) {
+        if (/revised/i.test(record.versions[vi].key || '')) {
+          var revUrl = 'import://' + key + '/v' + vi;
+          await new Promise(resolve => {
+            var tx2 = cacheDb.transaction(CACHE_STORE, 'readwrite');
+            tx2.objectStore(CACHE_STORE).put(record.versions[vi].db, revUrl);
+            tx2.oncomplete = resolve;
+          });
+          diffParam = '&diffdb=' + encodeURIComponent(revUrl);
+          console.log('[S225] §OPEN_DIFF key=' + key + ' base=v0(combined) diff=v' + vi + '(revised)');
+          break;
+        }
+      }
+    }
+    var isMesh = record.meta && record.meta.sourceFormat && record.meta.sourceFormat !== '.ifc';
+    var wizardDone = record.meta && record.meta.wizard_complete;
+    if (((opts && opts.wizard) || isMesh) && !wizardDone) {
+      wizardParam = '&wizard=1&wizardKey=' + encodeURIComponent(key);
+    }
+  }
+
+  var viewerUrl = (_base || '') + 'viewer/viewer.html?db=' +
+    encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(libUrl) + diffParam + wizardParam + '&ghost=1';
+  var win = window.open(viewerUrl, '_blank');
+  trackTab((record && record.meta && record.meta.name) || key, '3D', win);
+  if (btnEl) { btnEl.textContent = 'Open'; btnEl.disabled = false; }
+}
+
+// ── format detect + sql.js + web-ifc wasm + worker ──
+var LANDING_FORMAT_ROUTES = { ifc:'ifc', dae:'mesh', obj:'mesh', glb:'mesh', gltf:'mesh', '3ds':'mesh', fbx:'mesh', stl:'mesh' };
+function detectLandingFormat(filename) {
+  var ext = filename.split('.').pop().toLowerCase();
+  return { ext: ext, route: LANDING_FORMAT_ROUTES[ext] || null };
+}
+
+// §S284c: Get a same-origin resource — network first, then the SW Cache Storage.
+// The landing page is root-scoped and NOT controlled by the viewer/ service worker, so an
+// offline fetch() rejects; but caches.match() reads the precache directly, working offline.
+async function _fetchLocalOrCache(url) {
+  try { var r = await fetch(url); if (r && r.ok) return r; } catch (e) {}
+  var c = await caches.match(url);
+  if (c) { console.log('§SQL_FROM_CACHE ' + url); return c; }
+  throw new Error('unavailable offline: ' + url);
+}
+// §S284c: Load sql.js from LOCAL precached files (no CDN) so DB-build works offline.
+// Standalone uses embedded base64 sources; PWA/online uses viewer/lib/ + Cache Storage.
+async function _loadSqlJs() {
+  if (typeof initSqlJs === 'undefined') {
+    if (window._STANDALONE && window._SQL_WASM_JS) {
+      // Inject embedded sql-wasm.js
+      var fn = new Function(window._SQL_WASM_JS + '\n; window.initSqlJs = initSqlJs;');
+      fn();
+      console.log('§STANDALONE_SQL inline initSqlJs loaded');
+    } else {
+      // Load local sql-wasm.js text (network or SW cache), then eval to define initSqlJs
+      var jsResp = await _fetchLocalOrCache('viewer/lib/sql-wasm.js');
+      var jsText = await jsResp.text();
+      (new Function(jsText + '\n; if (typeof initSqlJs !== "undefined") window.initSqlJs = initSqlJs;'))();
+      console.log('§SQL_LOCAL initSqlJs loaded from viewer/lib');
+    }
+  }
+  if (window._STANDALONE && window._SQL_WASM_B64) {
+    // Decode base64 WASM → ArrayBuffer
+    var raw = atob(window._SQL_WASM_B64);
+    var buf = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+    return await initSqlJs({ wasmBinary: buf.buffer });
+  }
+  // PWA / online: feed the local WASM binary directly (works offline via Cache Storage)
+  var wasmResp = await _fetchLocalOrCache('viewer/lib/sql-wasm.wasm');
+  var wasmBuf = await wasmResp.arrayBuffer();
+  return await initSqlJs({ wasmBinary: wasmBuf });
+}
+var _IFC_ENGINE_CACHE = 'bim-ifc-engine';
+var _IFC_WASM_URL = 'viewer/lib/web-ifc.wasm';
+async function _getWebIfcWasm() {
+  // 1. Standalone HTML — bytes embedded as base64.
+  if (window._WEBIFC_WASM_B64) {
+    var raw = atob(window._WEBIFC_WASM_B64);
+    var buf = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+    console.log('§IFC_WASM_FROM_B64 size=' + buf.length);
+    return buf.buffer;
+  }
+  // 2. Page-owned cache (survives SW purge / version skew) — offline-safe.
+  try {
+    var pc = await caches.open(_IFC_ENGINE_CACHE);
+    var hit = await pc.match(_IFC_WASM_URL);
+    if (hit) { console.log('§IFC_WASM_FROM_CACHE page-cache'); return await hit.arrayBuffer(); }
+  } catch (e) {}
+  // 3. SW Cache Storage (precache) — offline-safe; caches.match reads across all caches.
+  try {
+    var swHit = await caches.match(_IFC_WASM_URL);
+    if (swHit) {
+      console.log('§IFC_WASM_FROM_CACHE sw-precache');
+      var swBuf = await swHit.arrayBuffer();
+      try { (await caches.open(_IFC_ENGINE_CACHE)).put(_IFC_WASM_URL, new Response(swBuf.slice(0), { headers: { 'Content-Type': 'application/wasm' } })); } catch (e) {}
+      return swBuf;
+    }
+  } catch (e) {}
+  // 4. Network (online only) — then warm the page cache for next time.
+  try {
+    var r = await fetch(_IFC_WASM_URL);
+    if (r && r.ok) {
+      var netBuf = await r.arrayBuffer();
+      console.log('§IFC_WASM_FROM_NET size=' + netBuf.byteLength);
+      try { (await caches.open(_IFC_ENGINE_CACHE)).put(_IFC_WASM_URL, new Response(netBuf.slice(0), { headers: { 'Content-Type': 'application/wasm' } })); } catch (e) {}
+      return netBuf;
+    }
+  } catch (e) {}
+  // 5. Genuinely unavailable — clear, honest error (NOT the cryptic emscripten abort).
+  console.warn('§IFC_ENGINE_UNAVAILABLE web-ifc.wasm not cached and offline');
+  throw new Error('IFC engine not available offline — connect to the internet once to enable offline IFC import.');
+}
+// §S284: Create Worker from Blob URL in standalone mode (file:// blocks script URLs)
+function _createWorker(scriptUrl) {
+  if (window._STANDALONE && window._WORKER_SOURCES) {
+    var key = scriptUrl.replace(/\?.*$/, '').replace(/^.*\//, '');
+    var src = window._WORKER_SOURCES[key];
+    if (src) {
+      // §S284b: Read web-ifc from <script type="text/plain" id="webifc-src"> DOM element
+      var webIfcEl = document.getElementById('webifc-src');
+      if (webIfcEl && (key === 'import_worker.js' || key === 'ifc_export_worker.js')) {
+        var webIfcSrc = webIfcEl.textContent;
+        // Replace the importScripts line with the actual source
+        src = src.replace(/importScripts\([^)]*web-ifc[^)]*\);?/, '// §S284b: web-ifc inlined by packager');
+        src = webIfcSrc + '\n' + src;
+        console.log('§STANDALONE_WEBIFC size=' + webIfcSrc.length);
+      }
+      // §S284c: Pass the base64 WASM STRING into the worker — the worker decodes it and
+      // mints the Blob URL in its OWN context. A blob URL minted on the main thread is NOT
+      // fetchable from a null-origin (file://) blob worker, which silently aborted IFC parse.
+      if (window._WEBIFC_WASM_B64 && key === 'import_worker.js') {
+        src = 'self._WEBIFC_WASM_B64 = "' + window._WEBIFC_WASM_B64 + '";\n' + src;
+        console.log('§STANDALONE_WASM_B64 injected len=' + window._WEBIFC_WASM_B64.length);
+      }
+      console.log('§STANDALONE_WORKER blob key=' + key + ' size=' + src.length);
+      return new Worker(URL.createObjectURL(new Blob([src], {type: 'application/javascript'})));
+    }
+  }
+  return new Worker(scriptUrl);
+}
+
+// ── trimmed import handler: single file, NEW project only (no S224 merge modal), auto-open viewer ──
+// Mirrors index.html handleImportFile new-project path verbatim, minus merge/renderImportCards.
+async function handleImportFile(file) {
+  if (!file) return;
+  var fmt = detectLandingFormat(file.name);
+  if (!fmt.route) { document.getElementById('import-status').textContent = 'Unsupported: .' + fmt.ext + ' — Accepted: IFC, OBJ, DAE, GLB, STL, FBX, 3DS'; return; }
+  const status = document.getElementById('import-status');
+  const progressBar = document.getElementById('import-progress-bar');
+  const sizeMB = (file.size / 1024 / 1024).toFixed(1);
+  status.textContent = 'Reading ' + file.name + ' (' + sizeMB + 'MB)...';
+  progressBar.parentElement.style.display = 'block'; progressBar.style.width = '0%'; progressBar.style.background = '#0277bd';
+  if (file.size > 200 * 1024 * 1024) status.textContent = 'Very large (' + sizeMB + 'MB) — may take a few minutes';
+  const arrayBuffer = await file.arrayBuffer();
+  var workerFile = (fmt.route === 'ifc') ? 'viewer/import_worker.js?v=9' : 'viewer/mesh_import_worker.js?v=2';
+  var workerMsg = (fmt.route === 'ifc') ? { arrayBuffer, filename: file.name } : { arrayBuffer, filename: file.name, ext: fmt.ext };
+  if (fmt.route === 'ifc') {
+    try { workerMsg.wasmBytes = await _getWebIfcWasm(); }
+    catch (engineErr) { status.textContent = engineErr.message; progressBar.style.background = '#cc4444'; return; }
+  }
+  const worker = _createWorker(workerFile);
+  worker.onmessage = async function (e) {
+    const msg = e.data;
+    if (msg.type === 'progress') { status.textContent = msg.phase; progressBar.style.width = msg.pct + '%'; return; }
+    if (msg.type === 'error') { status.textContent = 'Failed: ' + msg.message; progressBar.style.background = '#cc4444'; worker.terminate(); return; }
+    if (msg.type === 'done') {
+      status.textContent = 'Building databases...';
+      try {
+        const SQL = await _loadSqlJs();
+        var _fnDisc = _discFromFilename(file.name);
+        if (_fnDisc && msg.elements) {
+          msg.meta.disciplines = {};
+          for (var ei = 0; ei < msg.elements.length; ei++) msg.elements[ei].discipline = _fnDisc;
+          msg.meta.disciplines[_fnDisc] = msg.elements.length;
+          console.log('§DISC_OVERRIDE file=' + file.name + ' disc=' + _fnDisc + ' elements=' + msg.elements.length);
+        }
+        const dbs = buildImportDBs(SQL, msg);
+        const dbBuf = dbs.extractedDb;
+        var projectKey = file.name;
+        var _recSplit = dbs.metaDb && dbs.geoDb;
+        var newRecord = { meta: msg.meta, versions: [{ key: file.name, importDate: new Date().toISOString(), db: _recSplit ? null : dbBuf }], latestVersion: 0 };
+        if (_recSplit) { newRecord.metaDb = dbs.metaDb; newRecord.geoDb = dbs.geoDb; }
+        await saveProject(projectKey, newRecord);
+        console.log('§IMPORT_SAVED key=' + projectKey + ' elements=' + msg.meta.elementCount + ' split=' + !!_recSplit);
+        var _cacheDb = await openCacheDB();
+        if (_cacheDb && dbs.metaDb && dbs.geoDb) {
+          var _ck = projectKey;
+          var _cDbUrl = 'import://' + _ck + '/' + _ck.replace(/\.ifc$/i, '_extracted.db');
+          var _cMetaUrl = 'import://' + _ck + '/' + _ck.replace(/\.ifc$/i, '_meta.db');
+          var _cGeoUrl = 'import://' + _ck + '/' + _ck.replace(/\.ifc$/i, '_geo.db');
+          await new Promise(function (resolve) {
+            var tx = _cacheDb.transaction(CACHE_STORE, 'readwrite'); var store = tx.objectStore(CACHE_STORE);
+            store.put(dbs.metaDb, _cMetaUrl); store.put(dbs.metaDb, _cDbUrl); store.put(dbs.geoDb, _cGeoUrl);
+            tx.oncomplete = resolve;
+          });
+          console.log('§IMPORT_CACHE_PRELOAD meta+geo populated');
+        }
+        status.textContent = 'Imported ' + msg.meta.elementCount + ' elements — opening viewer...';
+        progressBar.style.width = '100%'; progressBar.style.background = '#44cc44';
+        openProject(projectKey);
+        console.log('§IMPORT_AUTO_OPEN key=' + projectKey);
+        setTimeout(function () { status.textContent = ''; progressBar.style.width = '0%'; progressBar.style.background = '#0277bd'; progressBar.parentElement.style.display = 'none'; }, 3000);
+      } catch (dbErr) { status.textContent = 'DB error: ' + dbErr.message; progressBar.style.background = '#cc4444'; console.log('§IMPORT_DB_ERROR ' + dbErr.message); }
+      worker.terminate();
+    }
+  };
+  worker.onerror = function (err) { status.textContent = 'Worker error: ' + err.message; progressBar.style.background = '#cc4444'; worker.terminate(); };
+  worker.postMessage(workerMsg, [arrayBuffer]);
+}
+
+// wire the hub drop zone + file input (called when the hub opens)
+function wireImportZone() {
+  var zone = document.getElementById('m-import-zone'); var input = document.getElementById('m-import-file');
+  if (!zone || !input || zone._wired) return; zone._wired = 1;
+  zone.addEventListener('dragover', function (e) { e.preventDefault(); zone.classList.add('drag'); });
+  zone.addEventListener('dragleave', function () { zone.classList.remove('drag'); });
+  zone.addEventListener('drop', function (e) { e.preventDefault(); zone.classList.remove('drag'); var f = e.dataTransfer.files; if (f && f.length) handleImportFile(f[0]); });
+  zone.addEventListener('click', function () { input.click(); });
+  input.addEventListener('change', function () { if (input.files.length) handleImportFile(input.files[0]); });
+  console.log('§IMPORT_ZONE wired (drop-own-IFC)');
+}

--- a/index2.html
+++ b/index2.html
@@ -120,7 +120,9 @@
   #hub .hub-card .db i { display:block; height:100%; border-radius:2px; }
   #hub .hub-import { max-width:920px; margin:0 auto 22px; }
   #hub .hub-drop { display:block; text-align:center; text-decoration:none; border:2px dashed rgba(79,195,247,.4);
-    border-radius:12px; padding:20px; color:#4fc3f7; font-weight:600; font-size:14px; }
+    border-radius:12px; padding:20px; color:#4fc3f7; font-weight:600; font-size:14px; cursor:pointer; transition:border-color .15s,background .15s; }
+  #hub .hub-drop:hover { border-color:rgba(79,195,247,.7); }
+  #hub .hub-drop.drag { border-color:#0277bd; background:rgba(2,119,189,.12); }
   @media (max-width:560px){ #hub .hub-grid { grid-template-columns:repeat(auto-fill,minmax(110px,1fr)); gap:8px; } }
 </style>
 </head>
@@ -167,6 +169,9 @@
 <script src="viewer/locale_loader.js"></script>
 <!-- Bonsai BIM modeller host: window.Bonsai (preload streams occt-wasm bytes — does NOT spin the worker). -->
 <script src="viewer/bonsai_kernel.js"></script>
+<!-- Drop-own-IFC: real landing import pipeline (buildImportDBs) + the verbatim-extracted handler/helpers. -->
+<script src="viewer/import_db_builder.js?v=4"></script>
+<script src="import_own.js?v=1"></script>
 
 <script>
 'use strict';
@@ -480,8 +485,15 @@ var _hubBuilt=false;
 async function buildHubBody(){
   if(_hubBuilt) return; _hubBuilt=true;
   var b=document.getElementById('hub-body');
-  b.innerHTML='<div class="hub-import"><a class="hub-drop" href="viewer/viewer.html?import=1">&#8595; Drop / open your own IFC in the viewer</a></div>'+
+  b.innerHTML='<div class="hub-import">'+
+      '<div id="m-import-zone" class="hub-drop">&#8595; Drop an IFC / 3D file here &mdash; or tap to browse</div>'+
+      '<input type="file" id="m-import-file" accept=".ifc,.dae,.obj,.glb,.gltf,.3ds,.fbx,.stl" style="display:none">'+
+      '<div id="import-status" style="text-align:center;color:#cfe3ef;font-size:12px;margin-top:8px;min-height:16px"></div>'+
+      '<div style="display:none;margin:8px auto 0;max-width:400px;height:4px;background:#222;border-radius:2px;overflow:hidden">'+
+        '<div id="import-progress-bar" style="height:100%;width:0%;background:#0277bd;border-radius:2px;transition:width .3s"></div></div>'+
+    '</div>'+
     '<div id="hub-status" style="text-align:center;color:#667;font-size:12px;padding:20px">loading building manifest&hellip;</div>';
+  if(typeof wireImportZone==='function') wireImportZone(); else L('§HUB import_own.js not loaded');
   try {
     var data=await fetch('manifest.json').then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); });
     if(!data||!Array.isArray(data.archetypes)) throw new Error('manifest missing archetypes');

--- a/viewer/tests/morpheus_import_live.js
+++ b/viewer/tests/morpheus_import_live.js
@@ -1,0 +1,44 @@
+// W-MPLATE-IMPORT — drop-own-IFC in the Matrix hub actually imports + opens the viewer.
+// Feeds a REAL IFC through the verbatim-extracted landing pipeline (import_own.js → import_worker →
+// buildImportDBs → IDB cache → openProject). Whitebox §-log + window.open capture.
+const http=require('http'),fs=require('fs'),path=require('path');
+const ROOT='/tmp/wt-mplate';
+const IFC=path.join(process.env.HOME,'bim-compiler/reference/residential/Ifc4_WallElementedCase.ifc');
+const pup=require(path.join(process.env.HOME,'bim-compiler','node_modules','puppeteer'));
+const MIME={'.html':'text/html','.js':'text/javascript','.mjs':'text/javascript','.wasm':'application/wasm','.json':'application/json','.css':'text/css','.jpg':'image/jpeg','.png':'image/png','.db':'application/octet-stream','.ifc':'text/plain'};
+const srv=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/index2.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){r.writeHead(404);return r.end('404 '+p);}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream','Access-Control-Allow-Origin':'*'});r.end(b);});});
+let pass=0,fail=0; const ck=(n,o)=>{console.log((o?'  PASS ':'  FAIL ')+n);o?pass++:fail++;};
+(async()=>{
+ await new Promise(r=>srv.listen(0,r));const port=srv.address().port;
+ const br=await pup.launch({headless:'new',args:['--no-sandbox','--enable-unsafe-swiftshader']});
+ const pg=await br.newPage();
+ const logs=[]; pg.on('console',m=>{const t=m.text();if(/§|Failed|error/i.test(t))logs.push(t);});
+ pg.on('pageerror',e=>console.log('  ERR '+String(e).slice(0,200)));
+ await pg.evaluateOnNewDocument(()=>{window.__opened=[];window.open=(u)=>{window.__opened.push(u);return{focus(){}}};});
+ await pg.goto(`http://localhost:${port}/index2.html?home=1`,{waitUntil:'load',timeout:60000});
+ await pg.waitForSelector('#portal.active',{timeout:8000}).catch(()=>{});
+ // open the hub directly
+ await pg.evaluate(()=>window.openHub());
+ await pg.waitForSelector('#m-import-zone',{timeout:8000}).catch(()=>{});
+ ck('hub import zone present + wired', await pg.evaluate(()=>!!document.getElementById('m-import-zone') && typeof window.handleImportFile==='function'));
+ ck('buildImportDBs (real landing builder) loaded', await pg.evaluate(()=>typeof window.buildImportDBs==='function'));
+ // feed the real IFC
+ const b64=fs.readFileSync(IFC).toString('base64');
+ await pg.evaluate(async(b64,name)=>{
+   const bin=atob(b64);const u=new Uint8Array(bin.length);for(let i=0;i<bin.length;i++)u[i]=bin.charCodeAt(i);
+   const file=new File([u],name,{type:'application/octet-stream'});
+   await window.handleImportFile(file);
+ }, b64, 'Ifc4_WallElementedCase.ifc');
+ // wait for save + auto-open (worker parse can take a few s)
+ await pg.waitForFunction(()=>window.__opened.some(u=>/import:\/\//.test(u)),{timeout:45000}).catch(()=>{});
+ const opened=await pg.evaluate(()=>window.__opened);
+ ck('§IMPORT_SAVED logged', logs.some(l=>/§IMPORT_SAVED/.test(l)));
+ ck('§IMPORT_AUTO_OPEN logged', logs.some(l=>/§IMPORT_AUTO_OPEN/.test(l)));
+ ck('opened viewer with import:// db + ghost', opened.some(u=>/viewer\/viewer\.html\?db=import%3A%2F%2F.*ghost=1/.test(u)));
+ // confirm it actually landed in the import IDB
+ const stored=await pg.evaluate(()=>new Promise(res=>{const rq=indexedDB.open('bim_ootb_imports');rq.onsuccess=()=>{const db=rq.result;if(!db.objectStoreNames.contains('buildings'))return res(0);const c=db.transaction('buildings','readonly').objectStore('buildings').count();c.onsuccess=()=>res(c.result);c.onerror=()=>res(-1);};rq.onerror=()=>res(-1);}));
+ ck('imported project persisted in bim_ootb_imports IDB', stored>=1);
+ console.log('\n  §W-MPLATE-IMPORT '+pass+'/'+(pass+fail)+(fail?' (FAIL)':' PASS'));
+ console.log('  import logs:'); logs.filter(l=>/§(IMPORT|DISC|IFC|SQL)|Failed/i.test(l)).slice(0,12).forEach(l=>console.log('    '+l));
+ await br.close();srv.close();process.exit(fail?1:0);
+})().catch(e=>{console.error(e);process.exit(1);});


### PR DESCRIPTION
The hub's drop-own-IFC was a stub. This ports the **live landing's working import pipeline** into the plate, verbatim (non-invent), dropping the S224 merge modal per MORPHEUS_PLATE_REBUILD.md.

- new **`import_own.js`** (index2-only, repo root) = verbatim helpers extracted from `index.html` + a trimmed `handleImportFile` (single file, new project → auto-open viewer)
- hub gets a real drop zone wired via `wireImportZone()`; loads `viewer/import_db_builder.js`
- file → `import_worker`(web-ifc)/`mesh_import_worker` → `buildImportDBs` → IDB cache → `viewer.html?db=import://…&ghost=1`

Witness: `viewer/tests/morpheus_import_live.js` — **W-MPLATE-IMPORT 6/6 PASS** (real `Ifc4_WallElementedCase.ifc` → 10 elements → built → saved → opened). No regression: **W-MPLATE 17/17**. Sandbox-safe: index2 + one new root file only; `index.html`/`viewer.html`/`erp.html` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)