### PR TITLE
feat(modeller): Bonsai depth-track shoulders — route-sweep / fillet-chamfer / richer constraints / gridline-recompose

### DIFF
--- a/viewer/bonsai_gridmove.js
+++ b/viewer/bonsai_gridmove.js
@@ -1,0 +1,61 @@
+// bonsai_gridmove.js — Bonsai modeller adapter for the shipped Grid Kinematics engine (§S270).
+// prompts/BONSAI_KERNEL_RESEARCH.md §NEXT depth-track leg 4. The viewer's GridKinematicEngine.dragGrid is a
+// PURE fn (positions, delta) -> recompose commands [{guid, action:TRANSLATE|SCALE, axis, ...}]; grid_recompose
+// is the VIEWER-coupled glue (mutates THREE instance matrices). The modeller is decoupled, so this adapter feeds
+// the AUTHORED solids as the engine's elementData, runs the pure engine, and commits ONE signed GEOM_GRID_MOVE
+// op carrying the engine's commands — the worker fold then translates/stretches the attached solids. Drag a
+// gridline → attached walls RECOMPOSE, deterministic + scrub + tamper-evident like any feature in the op-log.
+(function () {
+  'use strict';
+  const TAG = '§GRIDMOVE';
+  const GM = {
+    _map: {},
+
+    // The engine's elementData = each authored solid's centre + bbox extents (the geometry it must recompose).
+    elementData() {
+      const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return [];
+      return g.children.filter(o => o.isMesh && o.userData.featureId != null).map(m => {
+        m.geometry.computeBoundingBox(); const bb = m.geometry.boundingBox;
+        return { guid: m.userData.featureId,
+          x: (bb.min.x + bb.max.x) / 2, y: (bb.min.y + bb.max.y) / 2, z: (bb.min.z + bb.max.z) / 2,
+          bboxX: bb.max.x - bb.min.x, bboxY: bb.max.y - bb.min.y, bboxZ: bb.max.z - bb.min.z,
+          ifcClass: 'IfcWall' };
+      });
+    },
+
+    // The engine's gridLines = the authoring grid's x + y lines, with a back-map gridId -> {axis, index}.
+    gridLines() {
+      const G = window.Bonsai.grid; const lines = []; this._map = {};
+      G.xs.forEach((x, i) => { const id = 'gx' + i; lines.push({ id, axis: 'x', pos: x }); this._map[id] = { axis: 'x', index: i }; });
+      G.ys.forEach((y, j) => { const id = 'gy' + j; lines.push({ id, axis: 'y', pos: y }); this._map[id] = { axis: 'y', index: j }; });
+      return lines;
+    },
+
+    // PURE recompose: build the engine from the current state and ask it for the commands for this drag.
+    computeCommands(gridId, delta) {
+      const Eng = window.GridKinematics && window.GridKinematics.GridKinematicEngine;
+      if (!Eng) throw new Error('GridKinematics engine not loaded');
+      const eng = new Eng(this.elementData(), this.gridLines());
+      eng.attachGridToElements();
+      // engine guid === our featureId; carry it forward as featureId so the worker fold is unambiguous.
+      return eng.dragGrid(gridId, delta).map(c => ({
+        featureId: c.guid, action: c.action, axis: c.axis,
+        delta: c.delta, newScale: c.newScale, translateDelta: c.translateDelta, edge: c.edge }));
+    },
+
+    // Commit ONE signed GEOM_GRID_MOVE per drag-release; the worker folds the recompose deterministically.
+    async commit(gridId, delta) {
+      const commands = this.computeCommands(gridId, delta);
+      const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_GRID_MOVE',
+        parameters: { gridId, delta, commands } }, {});
+      const m = this._map[gridId];   // advance the authoring gridline so later snaps/drags use the new position
+      if (m) { const arr = m.axis === 'x' ? window.Bonsai.grid.xs : window.Bonsai.grid.ys; arr[m.index] += delta; window.Bonsai.grid.render(); }
+      console.log(TAG + ' commit grid=' + gridId + ' delta=' + delta + ' cmds=' + commands.length +
+        ' verify=' + res.verify + ' tris=' + res.triangleCount);
+      return { ...res, commands };
+    }
+  };
+  window.Bonsai = window.Bonsai || {};
+  window.Bonsai.gridmove = GM;
+  console.log(TAG + ' module loaded');
+})();

--- a/viewer/bonsai_kernel.js
+++ b/viewer/bonsai_kernel.js
@@ -92,6 +92,19 @@
       return this._preload;
     },
 
+    // EDGE-PICK support: ask the worker for the edge midpoints of a parent feature's solid (in canonical
+    // getSubShapes order). The host renders these as pickable markers; the picked indices ride a GEOM_FILLET op.
+    queryEdges(parentId) {
+      const w = this.init();
+      if (!w) return Promise.reject(new Error('bonsai unsupported'));
+      const ops = (window.Bonsai.oplog && window.Bonsai.oplog._geomOps) ? window.Bonsai.oplog._geomOps() : [];
+      const id = ++this._seq;
+      return new Promise((resolve, reject) => {
+        this._pending.set(id, { resolve, reject });
+        w.postMessage({ id, listEdges: { ops, parentId } });
+      });
+    },
+
     // Fold a whole op-log CHAIN -> array of mesh payloads (the feature tree, evaluated in one pass).
     _foldChain(ops) {
       const w = this.init();

--- a/viewer/bonsai_kernel_worker.js
+++ b/viewer/bonsai_kernel_worker.js
@@ -91,25 +91,52 @@ function meshOf(kernel, shape, featureId) {
   return { featureId, triangleCount: m.triangleCount, positions, normals, indices };
 }
 
-// THE FEATURE-TREE FOLD: an ordered op-log -> a set of live solids. GEOM_CUT modifies its parent
-// solid IN PLACE (the child references a prior feature by id), so the op-log IS the feature tree and
-// the rendered geometry is a pure fold of the chain — replaying ops[0..k] is deterministic history.
-function foldChain(kernel, ops) {
+// Edge midpoints of a solid in CANONICAL getSubShapes('edge') order — the SAME order the fold uses to
+// resolve GEOM_FILLET edge indices, so an edge picked by index is stable across deterministic re-folds.
+// Midpoint = bbox centre (exact for the straight edges of our box/extrude solids); len = bbox diagonal.
+function edgeMidpoints(kernel, solid) {
+  const edges = kernel.getSubShapes(solid, 'edge');
+  const out = edges.map((e, i) => {
+    const b = kernel.getBoundingBox(e, false);
+    return { i, mid: [(b.xmin + b.xmax) / 2, (b.ymin + b.ymax) / 2, (b.zmin + b.zmax) / 2],
+             len: +Math.hypot(b.xmax - b.xmin, b.ymax - b.ymin, b.zmax - b.zmin).toFixed(4) };
+  });
+  edges.forEach(e => kernel.release(e));
+  return out;
+}
+
+// THE FEATURE-TREE FOLD (solids map): an ordered op-log -> a set of live solids. GEOM_CUT and GEOM_FILLET
+// modify their referenced parent solid IN PLACE (the child references a prior feature by id), so the op-log
+// IS the feature tree and the rendered geometry is a pure fold of the chain — replaying ops[0..k] = history.
+function buildSolids(kernel, ops) {
   const solids = new Map();   // featureId -> shape
   for (const op of ops) {
+    const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
     if (op.op_type === 'GEOM_CUT') {                 // IfcRelVoidsElement: cut the referenced parent
       const parent = solids.get(op.parent);
       if (!parent) throw new Error('GEOM_CUT parent ' + op.parent + ' not found');
-      const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
       const v = (a) => ({ x: a[0], y: a[1], z: a[2] });
       const void_ = kernel.makeBoxFromCorners(v(P.void.c1), v(P.void.c2));
       const cut = kernel.cut(parent, void_);
       kernel.release(void_); kernel.release(parent);
       solids.set(op.parent, cut);                    // parent geometry replaced by the cut result
+    } else if (op.op_type === 'GEOM_FILLET') {        // BRepFilletAPI: round (or chamfer) the referenced parent's picked edges
+      const parent = solids.get(op.parent);
+      if (!parent) throw new Error('GEOM_FILLET parent ' + op.parent + ' not found');
+      const all = kernel.getSubShapes(parent, 'edge');           // canonical order — must match edgeMidpoints()
+      const sel = (P.edges || []).map(i => all[i]).filter(s => s != null);
+      const r = P.radius != null ? P.radius : 0.1;
+      const result = (P.kind === 'chamfer') ? kernel.chamfer(parent, sel, r) : kernel.fillet(parent, sel, r);
+      all.forEach(e => kernel.release(e)); kernel.release(parent);
+      solids.set(op.parent, result);                 // parent geometry replaced by the filleted/chamfered result
     } else {
       solids.set(op.id, applyFeature(kernel, op));
     }
   }
+  return solids;
+}
+function foldChain(kernel, ops) {
+  const solids = buildSolids(kernel, ops);
   const meshes = [];
   for (const [fid, shape] of solids) { meshes.push(meshOf(kernel, shape, fid)); kernel.release(shape); }
   return meshes;
@@ -125,6 +152,15 @@ self.onmessage = async (e) => {
       return;
     }
     const kernel = await getKernel();
+    if (e.data.listEdges) {                          // EDGE-PICK: fold to the parent solid, report its edge midpoints
+      const { ops: cops, parentId } = e.data.listEdges;
+      const solids = buildSolids(kernel, cops);
+      const parent = solids.get(parentId);
+      const edges = parent ? edgeMidpoints(kernel, parent) : [];
+      for (const [, s] of solids) kernel.release(s);
+      self.postMessage({ id, ok: true, edges });
+      return;
+    }
     if (ops) {                                       // CHAIN fold (feature tree) -> array of meshes
       const meshes = foldChain(kernel, ops);
       const transfer = [];

--- a/viewer/bonsai_kernel_worker.js
+++ b/viewer/bonsai_kernel_worker.js
@@ -129,6 +129,27 @@ function buildSolids(kernel, ops) {
       const result = (P.kind === 'chamfer') ? kernel.chamfer(parent, sel, r) : kernel.fillet(parent, sel, r);
       all.forEach(e => kernel.release(e)); kernel.release(parent);
       solids.set(op.parent, result);                 // parent geometry replaced by the filleted/chamfered result
+    } else if (op.op_type === 'GEOM_GRID_MOVE') {     // §S270 grid kinematics: recompose attached solids per the engine's commands
+      for (const c of (P.commands || [])) {
+        const s = solids.get(c.featureId); if (!s) continue;
+        if (c.action === 'TRANSLATE') {
+          const d = c.delta || 0;
+          const out = kernel.translate(s, c.axis === 'x' ? d : 0, c.axis === 'y' ? d : 0, c.axis === 'z' ? d : 0);
+          kernel.release(s); solids.set(c.featureId, out);
+        } else if (c.action === 'SCALE') {             // axis-stretch about the element's stationary (min) edge: new = a + f·(old−a)
+          const f = c.newScale != null ? c.newScale : 1;
+          const b = kernel.getBoundingBox(s, false);
+          const a = c.axis === 'x' ? b.xmin : c.axis === 'y' ? b.ymin : b.zmin;
+          const tx = a * (1 - f) + (c.translateDelta || 0);
+          const M = c.axis === 'x' ? [f, 0, 0, tx, 0, 1, 0, 0, 0, 0, 1, 0]
+                  : c.axis === 'y' ? [1, 0, 0, 0, 0, f, 0, tx, 0, 0, 1, 0]
+                  :                  [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, f, tx];
+          // generalTransform = gp_GTrsf (supports NON-UNIFORM scale); plain transform = gp_Trsf which would
+          // collapse an axis stretch to a uniform det^(1/3) scale. A grid stretch is non-uniform by definition.
+          const out = kernel.generalTransform(s, M);
+          kernel.release(s); solids.set(c.featureId, out);
+        }
+      }
     } else {
       solids.set(op.id, applyFeature(kernel, op));
     }

--- a/viewer/bonsai_kernel_worker.js
+++ b/viewer/bonsai_kernel_worker.js
@@ -37,17 +37,30 @@ function applyFeature(kernel, op) {
     return solid;
   }
   if (op.op_type === 'GEOM_SWEEP') {              // BRepOffsetAPI_MakePipe: rectangle profile swept along a polyline spine (MEP run / route)
-    const w = P.profile.w, h = P.profile.h;       // profile centred on the spine start, in the XY plane (normal +Z = spine's initial direction)
+    const w = P.profile.w, h = P.profile.h;
     const v = (x, y, z) => ({ x, y, z });
-    const pc = [[-w / 2, -h / 2], [w / 2, -h / 2], [w / 2, h / 2], [-w / 2, h / 2]];
+    const path = P.path;                          // [[x,y,z],...] ≥2 points
+    // Place the profile PERPENDICULAR to the spine's initial tangent, CENTRED on path[0], so the sweep is
+    // well-conditioned for ANY route direction (a horizontal ground route as well as the demo's +Z riser).
+    // Frame: T = start tangent; pick up=+Y unless T is ~parallel to +Y (then +Z); U,V span the profile plane.
+    // For T=+Z this yields U=+X,V=+Y → byte-identical to the original XY profile centred at the origin.
+    const S = path[0];
+    let tx = path[1][0] - S[0], ty = path[1][1] - S[1], tz = path[1][2] - S[2];
+    const tl = Math.hypot(tx, ty, tz) || 1; tx /= tl; ty /= tl; tz /= tl;
+    const up = Math.abs(ty) < 0.9 ? [0, 1, 0] : [0, 0, 1];
+    let ux = up[1] * tz - up[2] * ty, uy = up[2] * tx - up[0] * tz, uz = up[0] * ty - up[1] * tx;   // U = up × T
+    const ul = Math.hypot(ux, uy, uz) || 1; ux /= ul; uy /= ul; uz /= ul;
+    const vx = ty * uz - tz * uy, vy = tz * ux - tx * uz, vz = tx * uy - ty * ux;                   // V = T × U
+    const corner = (su, sv) => v(S[0] + su * (w / 2) * ux + sv * (h / 2) * vx,
+                                 S[1] + su * (w / 2) * uy + sv * (h / 2) * vy,
+                                 S[2] + su * (w / 2) * uz + sv * (h / 2) * vz);
+    const cpts = [corner(-1, -1), corner(1, -1), corner(1, 1), corner(-1, 1)];
     const pedges = [];
-    for (let i = 0; i < pc.length; i++) {
-      const a = pc[i], b = pc[(i + 1) % pc.length];
-      pedges.push(kernel.makeLineEdge(v(a[0], a[1], 0), v(b[0], b[1], 0)));
+    for (let i = 0; i < cpts.length; i++) {
+      pedges.push(kernel.makeLineEdge(cpts[i], cpts[(i + 1) % cpts.length]));
     }
     const pwire = kernel.makeWire(pedges);
     const face = kernel.makeFace(pwire);
-    const path = P.path;                          // [[x,y,z],...] ≥2 points; starts at the profile (origin) so the sweep is well-conditioned
     const sedges = [];
     for (let i = 0; i < path.length - 1; i++) {
       sedges.push(kernel.makeLineEdge(v(path[i][0], path[i][1], path[i][2]), v(path[i + 1][0], path[i + 1][1], path[i + 1][2])));

--- a/viewer/bonsai_oplog.js
+++ b/viewer/bonsai_oplog.js
@@ -70,9 +70,11 @@
       // deterministic so the optimistic mesh == the eventual chain-fold mesh (no flicker); any later scrub/cut
       // reconciles to the authoritative foldChainToScene. Full incremental regen = the op_hash-cache card.
       let r;
-      const isCut = op.op_type === 'GEOM_CUT' || (op.parameters && op.parameters.parent != null);
-      if (isCut) {
-        r = await this._foldUpto();                              // cut modifies a referenced parent → authoritative re-fold
+      // LEAF ops (extrude/sweep) build a fresh solid → O(1) optimistic append. Everything else (GEOM_CUT,
+      // GEOM_FILLET, GEOM_GRID_MOVE) MUTATES prior solids in the fold → must take the authoritative re-fold.
+      const LEAF = op.op_type === 'GEOM_EXTRUDE' || op.op_type === 'GEOM_EXTRUDE_POLY' || op.op_type === 'GEOM_SWEEP';
+      if (!LEAF) {
+        r = await this._foldUpto();                              // mutates a referenced solid → authoritative re-fold
       } else {
         const ad = await window.Bonsai.author({ id: rowId, op_type: op.op_type, parameters: op.parameters }, { color: opts && opts.color, featureId: rowId });
         this._cursor = this.length;                              // history cursor advances to the new tip

--- a/viewer/bonsai_sketch.js
+++ b/viewer/bonsai_sketch.js
@@ -12,6 +12,10 @@
     points: [],          // [{ id, x, y }] in sketch-plane (XY) coords, in click order
     _gcs: null,
     AXIS_TOL: 0.35,      // |dy| < AXIS_TOL*|dx| ⇒ treat edge as horizontal (and vice-versa)
+    mode: 'axis',        // constraint intent: 'axis' (per-edge H/V) | 'rect' (∥ + ⊥) | 'square' (rect + equal sides)
+    MODES: ['axis', 'rect', 'square'],
+    setMode(m) { if (this.MODES.includes(m)) this.mode = m; return this.mode; },
+    cycleMode() { this.mode = this.MODES[(this.MODES.indexOf(this.mode) + 1) % this.MODES.length]; return this.mode; },
 
     async _ensure() {
       if (!this._gcs) {
@@ -38,19 +42,40 @@
       return cons;
     },
 
+    // Richer constraints (the planegcs shoulders): treat each ring edge as a LINE primitive, then express
+    // GEOMETRIC INTENT over those lines — opposite edges PARALLEL, adjacent edges PERPENDICULAR (mode 'rect'),
+    // plus EQUAL_LENGTH of two adjacent edges (mode 'square'). Only the H/V mode used point-pair constraints;
+    // these use the line + parallel/perpendicular_ll/equal_length family (we previously wired just 2 of ~60).
+    // Returns { lines, constraints } so solve() can push both. Falls back to axis for non-quad rings.
+    _buildConstraints() {
+      const n = this.points.length;
+      if (this.mode === 'axis' || n !== 4) return { lines: [], constraints: this._autoConstraints() };
+      const lines = [];
+      for (let i = 0; i < n; i++) lines.push({ id: 'L' + i, type: 'line', p1_id: this.points[i].id, p2_id: this.points[(i + 1) % n].id });
+      const cons = [
+        { id: 'par02', type: 'parallel', l1_id: 'L0', l2_id: 'L2' },        // opposite edges parallel
+        { id: 'par13', type: 'parallel', l1_id: 'L1', l2_id: 'L3' },
+        { id: 'perp01', type: 'perpendicular_ll', l1_id: 'L0', l2_id: 'L1' } // one right angle ⇒ all four (with the ∥ pair)
+      ];
+      if (this.mode === 'square') cons.push({ id: 'eq01', type: 'equal_length', l1_id: 'L0', l2_id: 'L1' });
+      return { lines, constraints: cons };
+    },
+
     async solve() {
       if (this.points.length < 3) throw new Error('need >=3 points to solve a profile');
       const gcs = await this._ensure();
       gcs.clear_data();
       // p0 is the fixed anchor; the rest are free for the solver to clean up.
       this.points.forEach((p, i) => gcs.push_primitive({ id: p.id, type: 'point', x: p.x, y: p.y, fixed: i === 0 }));
-      const cons = this._autoConstraints();
-      cons.forEach(c => gcs.push_primitive(c));
+      const built = this._buildConstraints();
+      built.lines.forEach(l => gcs.push_primitive(l));         // line primitives must precede the constraints that reference them
+      built.constraints.forEach(c => gcs.push_primitive(c));
       const status = gcs.solve();
       gcs.apply_solution();
       const solved = this.points.map(p => { const s = gcs.sketch_index.get_sketch_point(p.id); return { x: s.x, y: s.y }; });
-      console.log(TAG + ' solve status=' + status + ' pts=' + solved.length + ' constraints=' + cons.length);
-      return { status, points: solved, constraints: cons.length };
+      console.log(TAG + ' solve mode=' + this.mode + ' status=' + status + ' pts=' + solved.length +
+        ' lines=' + built.lines.length + ' constraints=' + built.constraints.length);
+      return { status, points: solved, constraints: built.constraints.length, mode: this.mode };
     },
 
     // Solve the sketch, then author the solved profile as a real solid in A.scene via the worker kernel.

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -37,6 +37,8 @@
   <button id="b-cut" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg><span>Cut</span></button>
   <button id="b-route" disabled title="Sweep a profile along a route (MEP run)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg><span>Route</span></button>
   <button id="b-run" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg><span>Sweep Run</span></button>
+  <button id="b-fillet" disabled title="Round a selected solid's picked edges"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 21H7a4 4 0 0 1-4-4V3"/><path d="M21 3a14 14 0 0 0-14 14"/></svg><span>Fillet</span></button>
+  <button id="b-applyfillet" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span>Apply</span></button>
   <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
   <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
@@ -249,7 +251,7 @@ window.Bonsai.select = (fid) => {                 // witness/programmatic hook
   highlight(m || null); return selectedId;
 };
 canvas.addEventListener('pointerdown', (e) => {
-  if (sketching || routing || e.button !== 0 || e.shiftKey) return;
+  if (sketching || routing || edgePicking || e.button !== 0 || e.shiftKey) return;
   const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return;
   const r = canvas.getBoundingClientRect();
   const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
@@ -335,6 +337,69 @@ bRun.onclick = async () => {
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER route fail ' + err); }
 };
 
+// ── FILLET / CHAMFER (edge-pick) ─────────────────────────────────────────────────────────────────
+// occt fillet/chamfer shoulders. The NEW input device = picking an EDGE of a solid in 3D: the worker
+// reports the selected feature's edge midpoints (canonical getSubShapes order); we render pickable markers,
+// the user clicks edges, and Apply commits a signed GEOM_FILLET (parent + edge indices + radius). Edge
+// indices are stable across the deterministic re-fold, so the rounded result replays + verifies like any op.
+const bFillet = document.getElementById('b-fillet');
+const bApplyFillet = document.getElementById('b-applyfillet');
+const FIL_FILLET = _ico('<path d="M21 21H7a4 4 0 0 1-4-4V3"/><path d="M21 3a14 14 0 0 0-14 14"/>') + '<span>Fillet</span>';
+const FIL_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
+let edgePicking = false, edgeGroup = null, pickedEdges = new Set();
+function edgeMarkers(edges) {
+  if (!edgeGroup) { edgeGroup = new THREE.Group(); edgeGroup.name = 'EdgePick'; scene.add(edgeGroup); }
+  while (edgeGroup.children.length) edgeGroup.remove(edgeGroup.children[0]);
+  edges.forEach(ed => {
+    const on = pickedEdges.has(ed.i);
+    const m = new THREE.Mesh(new THREE.SphereGeometry(0.09, 12, 12),
+      new THREE.MeshBasicMaterial({ color: on ? 0xffd24f : 0x6fd6ff }));
+    m.position.set(ed.mid[0], ed.mid[1], ed.mid[2]); m.userData.edgeIndex = ed.i; edgeGroup.add(m);
+  });
+  edgeGroup.updateMatrixWorld(true);   // markers must have a fresh world matrix for raycast hit-testing on the same tick
+}
+async function enterFillet() {
+  if (selectedId == null) { setStat('select a solid first, then Fillet'); return; }
+  setStat('reading edges…');
+  try {
+    const r = await window.Bonsai.queryEdges(selectedId);
+    window._edgeList = r.edges || [];
+    edgePicking = true; pickedEdges = new Set();
+    bApplyFillet.style.display = ''; bApplyFillet.disabled = true; bFillet.innerHTML = FIL_CANCEL;
+    edgeMarkers(window._edgeList);
+    setStat('fillet: click edges (' + window._edgeList.length + ' available), then Apply');
+  } catch (e) { setStat('FAIL ' + (e && e.message || e)); console.warn('§MODELLER fillet edges fail ' + e); }
+}
+function exitFillet() {
+  edgePicking = false; bApplyFillet.style.display = 'none'; bFillet.innerHTML = FIL_FILLET;
+  if (edgeGroup) { while (edgeGroup.children.length) edgeGroup.remove(edgeGroup.children[0]); }
+}
+bFillet.onclick = () => edgePicking ? exitFillet() : enterFillet();
+canvas.addEventListener('pointerdown', (e) => {
+  if (!edgePicking || e.button !== 0 || e.shiftKey || !edgeGroup) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = raycaster.intersectObjects(edgeGroup.children, false)[0];
+  if (hit) {
+    const i = hit.object.userData.edgeIndex;
+    if (pickedEdges.has(i)) pickedEdges.delete(i); else pickedEdges.add(i);
+    edgeMarkers(window._edgeList);
+    bApplyFillet.disabled = pickedEdges.size === 0;
+    setStat('fillet: ' + pickedEdges.size + ' edge(s) selected');
+  }
+});
+bApplyFillet.onclick = async () => {
+  if (pickedEdges.size === 0) { setStat('pick at least one edge'); return; }
+  setStat('filleting…');
+  try {
+    const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_FILLET',
+      parameters: { parent: selectedId, edges: Array.from(pickedEdges), radius: 0.1, kind: 'fillet' } }, { color: 0x9fd6b4 });
+    setStat('filleted #' + selectedId + '  verify=' + res.verify + '  tris=' + res.triangleCount);
+    audioCue('commit'); exitFillet(); highlight(null); syncHistory();
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER fillet fail ' + err); }
+};
+
 // ── HISTORY SCRUBBER ────────────────────────────────────────────────────────────────────────────
 const slider = document.getElementById('hist-slider'), histLabel = document.getElementById('hist-label');
 function syncHistory() {
@@ -368,7 +433,7 @@ bIfc.onclick = async () => {
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§IFC export fail ' + err); }
 };
 
-bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = false;
+bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = false;
 window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
 // Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
 // NOTE: the modeller's Outliner is an AUTHORING tree only — it deliberately carries NO 4D/5D info; that is the
@@ -376,6 +441,9 @@ window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) ov
 window.Bonsai.outliner.addCategory({ key: 'routes', label: 'Routes', match: op => op.op_type === 'GEOM_SWEEP',
   node: op => { const p = op.parameters.path; const a = (p && window.Bonsai.grid.refAt) ? window.Bonsai.grid.refAt(p[0][0], p[0][1]) : null;
     return { id: op.id, label: 'Run', sub: (a && (a.x || a.y)) ? ((a.x || '·') + '-' + (a.y || '·')) + ' ·' + p.length + 'pt' : '#' + op.id + ' ·' + (p ? p.length : 0) + 'pt' }; } });
+window.Bonsai.outliner.addCategory({ key: 'fillets', label: 'Fillets', match: op => op.op_type === 'GEOM_FILLET',
+  node: op => ({ id: op.parameters.parent, label: (op.parameters.kind === 'chamfer' ? 'Chamfer' : 'Round'),
+    sub: '⮡ Wall ' + op.parameters.parent + ' ·' + (op.parameters.edges ? op.parameters.edges.length : 0) + 'e' }) });
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
@@ -628,6 +696,53 @@ if (qs.get('route') === 'demo') {
     window.__routeResult = out;
     window.__routeDone = true;
     console.log('§MODELLER route-done');
+  })();
+}
+// ?fillet=demo proves the occt fillet/chamfer shoulders + EDGE-PICK UI (W-BONSAI-FILLET): commit a wall, select
+// it, enter Fillet mode (worker reports the solid's edges), SIMULATE a click on the longest (vertical) edge's
+// marker via the real pointerdown handler, Apply → signed GEOM_FILLET rounds that edge (tris grow), the Outliner
+// shows a Fillets category, scrub replays deterministically; then a kind:'chamfer' op proves the chamfer shoulder.
+if (qs.get('fillet') === 'demo') {
+  (async () => {
+    const O = window.Bonsai.oplog; O.clear();
+    const out = {};
+    try {
+      const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.4], [0, 0.4]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      out.afterWall = wall.triangleCount;
+      window.Bonsai.select(wall.id);
+      await bFillet.onclick();                                   // enter Fillet mode → worker reports edges
+      out.edgeCount = (window._edgeList || []).length;          // a box-like solid has 12 edges
+      out.edgePicking = edgePicking;
+      // pick the LONGEST edge (a vertical corner, length 3) — a safe, clearly-roundable edge.
+      const longest = (window._edgeList || []).slice().sort((a, b) => b.len - a.len)[0];
+      out.longestLen = longest ? longest.len : null;
+      const rect = canvas.getBoundingClientRect();
+      const v = new THREE.Vector3(longest.mid[0], longest.mid[1], longest.mid[2]).project(camera);
+      const cx = rect.left + (v.x + 1) / 2 * rect.width, cy = rect.top + (1 - v.y) / 2 * rect.height;
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: cx, clientY: cy, bubbles: true }));
+      out.pickedCount = pickedEdges.size; out.applyEnabled = !bApplyFillet.disabled;
+      await bApplyFillet.onclick();                              // Apply → signed GEOM_FILLET
+      out.exited = !edgePicking;
+      const g = window.Bonsai.group();
+      out.afterFillet = g.children.filter(o => o.isMesh).reduce((n, m) => n + (m.geometry.index ? m.geometry.index.count / 3 : 0), 0);
+      out.signed = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verify = (await O.verify()).ok;
+      const rows = Array.from(document.querySelectorAll('#bonsai-outliner #bo-tree [data-fid]')).map(d => d.textContent.replace(/\s+/g, ' ').trim());
+      out.filletRow = rows.find(r => /Round/.test(r)) || null;
+      out.filletsCategory = Array.from(document.querySelectorAll('#bonsai-outliner [data-grp]')).some(d => d.getAttribute('data-grp') === 'fillets');
+      out.scrub1 = (await O.scrubTo(1)).triangleCount;          // plain wall (fillet gone)
+      out.scrub2 = (await O.scrubTo(2)).triangleCount;          // filleted (back)
+      // CHAMFER shoulder via the same op with kind:'chamfer' — on a FRESH second wall's edge (the first wall's
+      // longest edge was consumed by the fillet, so chamfering it would hit changed topology). Proves both edge-ops.
+      await O.scrubTo(O.length);                                 // restore the full fold before adding wall2
+      const wall2 = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[6, 0], [10, 0], [10, 0.4], [6, 0.4]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      const e2 = (await window.Bonsai.queryEdges(wall2.id)).edges.slice().sort((a, b) => b.len - a.len)[0];
+      const cham = await O.commit({ op_type: 'GEOM_FILLET', parameters: { parent: wall2.id, edges: [e2.i], radius: 0.1, kind: 'chamfer' } }, { color: 0x9fd6b4 });
+      out.chamferTris = cham.triangleCount; out.chamferVerify = cham.verify;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER fillet demo fail ' + e); }
+    window.__filletResult = out;
+    window.__filletDone = true;
+    console.log('§MODELLER fillet-done');
   })();
 }
 // ?sketch=demo drives a deliberately NOISY hand-drawn quad through the solver -> extrude (W-BONSAI-SKETCH).

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -34,6 +34,7 @@
   <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
   <button id="b-sketch" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg><span>Sketch</span></button>
   <button id="b-extrude" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg><span>Extrude</span></button>
+  <button id="b-constrain" disabled style="display:none" title="Constraint intent the solver enforces on the sketch"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span>Axis</span></button>
   <button id="b-cut" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg><span>Cut</span></button>
   <button id="b-route" disabled title="Sweep a profile along a route (MEP run)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg><span>Route</span></button>
   <button id="b-run" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg><span>Sweep Run</span></button>
@@ -195,15 +196,21 @@ function sketchMarkers() {
     sketchGroup.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(ring), new THREE.LineBasicMaterial({ color: 0x4fc3f7 })));
   }
 }
+// Constraint-intent cycle (the planegcs shoulders): Axis (per-edge H/V) → Rect (∥+⊥) → Square (+ equal sides).
+const bConstrain = document.getElementById('b-constrain');
+const CON_LABEL = { axis: 'Axis', rect: 'Rect', square: 'Square' };
+function paintConstrain() { const m = window.Bonsai.sketch.mode; bConstrain.querySelector('span').textContent = CON_LABEL[m] || m; bConstrain.classList.toggle('on', m !== 'axis'); }
+bConstrain.onclick = () => { const m = window.Bonsai.sketch.cycleMode(); paintConstrain(); audioCue('tick'); setStat('sketch constraint: ' + (CON_LABEL[m] || m)); };
 function enterSketch() {
   sketching = true; window.Bonsai.sketch.reset();
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone() };
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
   bExtrude.style.display = ''; bExtrude.disabled = false; bSketch.innerHTML = SK_CANCEL;
+  bConstrain.style.display = ''; bConstrain.disabled = false; paintConstrain();
   sketchMarkers(); setStat('sketch: click ≥3 points on the grid, then Extrude');
 }
 function exitSketch() {
-  sketching = false; bExtrude.style.display = 'none'; bSketch.innerHTML = SK_SKETCH;
+  sketching = false; bExtrude.style.display = 'none'; bConstrain.style.display = 'none'; bSketch.innerHTML = SK_SKETCH;
   if (sketchGroup) { while (sketchGroup.children.length) sketchGroup.remove(sketchGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); controls.update(); }
 }
@@ -743,6 +750,48 @@ if (qs.get('fillet') === 'demo') {
     window.__filletResult = out;
     window.__filletDone = true;
     console.log('§MODELLER fillet-done');
+  })();
+}
+// ?constrain=demo proves the richer planegcs shoulders (W-BONSAI-CONSTRAIN): a deliberately non-rectangular quad
+// is cleaned to a true rectangle by parallel+perpendicular_ll (mode 'rect'), to a square by + equal_length (mode
+// 'square'), two points are made mirror-symmetric by p2p_symmetric_ppp, and the Constrain toolbar button cycles
+// the intent. We previously wired only 2 of ~60 constraints (horizontal_pp/vertical_pp); these add 4 more.
+if (qs.get('constrain') === 'demo') {
+  (async () => {
+    const out = {}; const S = window.Bonsai.sketch;
+    const NOISY = [[0, 0], [4, 0.6], [3.0, 3.0], [0.4, 2.5]];   // opposite sides NOT parallel, corners NOT 90°
+    const quadMetrics = (pts) => {
+      const v = (a, b) => [b[0] - a[0], b[1] - a[1]];
+      const ang = (u, w) => { const d = u[0] * w[0] + u[1] * w[1]; const m = Math.hypot(u[0], u[1]) * Math.hypot(w[0], w[1]); return Math.acos(Math.max(-1, Math.min(1, d / (m || 1)))) * 180 / Math.PI; };
+      const e = [v(pts[0], pts[1]), v(pts[1], pts[2]), v(pts[2], pts[3]), v(pts[3], pts[0])];
+      let maxCorner = 0; for (let i = 0; i < 4; i++) maxCorner = Math.max(maxCorner, Math.abs(90 - ang(e[i], e[(i + 1) % 4])));
+      const len = e.map(x => Math.hypot(x[0], x[1]));
+      return { maxCorner: +maxCorner.toFixed(2), par: +Math.abs(180 - ang(e[0], e[2])).toFixed(2), sideRatio: +(Math.max(len[0], len[1]) / Math.min(len[0], len[1])).toFixed(3) };
+    };
+    const solveMode = async (m) => { S.reset(); S.setMode(m); NOISY.forEach(p => S.addPoint(p[0], p[1])); const r = await S.solve(); return { status: r.status, cons: r.constraints, m: quadMetrics(r.points.map(p => [p.x, p.y])) }; };
+    try {
+      out.input = quadMetrics(NOISY);
+      out.axis = await solveMode('axis');
+      out.rect = await solveMode('rect');
+      out.square = await solveMode('square');
+      // SYMMETRY shoulder (p2p_symmetric_ppp): a,b made mirror-symmetric about a fixed centre c ⇒ c = midpoint(a,b).
+      const g = await S._ensure(); g.clear_data();
+      g.push_primitive({ id: 'c', type: 'point', x: 1, y: 1, fixed: true });
+      g.push_primitive({ id: 'a', type: 'point', x: 0.1, y: 0.2, fixed: false });
+      g.push_primitive({ id: 'b', type: 'point', x: 2.3, y: 1.6, fixed: false });
+      g.push_primitive({ id: 'sym', type: 'p2p_symmetric_ppp', p1_id: 'a', p2_id: 'b', p_id: 'c' });
+      const st = g.solve(); g.apply_solution();
+      const A = g.sketch_index.get_sketch_point('a'), B = g.sketch_index.get_sketch_point('b'), C = g.sketch_index.get_sketch_point('c');
+      out.sym = { status: st, midErr: +Math.hypot((A.x + B.x) / 2 - C.x, (A.y + B.y) / 2 - C.y).toFixed(4) };
+      // UI cycle: the Constrain button cycles axis→rect→square→axis (label tracks the mode).
+      out.btnExists = !!document.getElementById('b-constrain');
+      S.setMode('axis'); const labels = [];
+      for (let k = 0; k < 3; k++) { bConstrain.onclick(); labels.push(bConstrain.querySelector('span').textContent); }
+      out.cycleLabels = labels;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER constrain demo fail ' + e); }
+    window.__constrainResult = out;
+    window.__constrainDone = true;
+    console.log('§MODELLER constrain-done');
   })();
 }
 // ?sketch=demo drives a deliberately NOISY hand-drawn quad through the solver -> extrude (W-BONSAI-SKETCH).

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -32,6 +32,7 @@
   <button id="b-wall" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Wall</span></button>
   <button id="b-open" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Opening</span></button>
   <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
+  <button id="b-gridmove" disabled title="Drag a gridline — attached walls recompose"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 5-3-3-3 3"/><path d="m15 19-3 3-3-3"/><path d="M2 12h20"/></svg><span>Move Grid</span></button>
   <button id="b-sketch" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg><span>Sketch</span></button>
   <button id="b-extrude" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg><span>Extrude</span></button>
   <button id="b-constrain" disabled style="display:none" title="Constraint intent the solver enforces on the sketch"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span>Axis</span></button>
@@ -66,6 +67,9 @@
 <script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
 <!-- Bonsai architectural authoring grid: column grid on the sketch plane + snap-to-grid (2D correlation). -->
 <script src="bonsai_grid.js?v=1" onerror="console.warn('§GRID LOAD_FAIL bonsai_grid.js')"></script>
+<!-- Grid Kinematics engine (§S270, pure recompose math) + the modeller adapter (gridline-drag → GEOM_GRID_MOVE). -->
+<script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
+<script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=1" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 
@@ -258,7 +262,7 @@ window.Bonsai.select = (fid) => {                 // witness/programmatic hook
   highlight(m || null); return selectedId;
 };
 canvas.addEventListener('pointerdown', (e) => {
-  if (sketching || routing || edgePicking || e.button !== 0 || e.shiftKey) return;
+  if (sketching || routing || edgePicking || gridMoving || e.button !== 0 || e.shiftKey) return;
   const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return;
   const r = canvas.getBoundingClientRect();
   const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
@@ -429,6 +433,70 @@ bGrid.onclick = () => {
   setStat(on ? 'grid ON — sketch clicks snap to gridlines (A-1, B-2…)' : 'grid off');
 };
 
+// ── GRID MOVE (gridline-drag recompose) ───────────────────────────────────────────────────────────
+// The §S270 parametric-grid payoff: drag a gridline and the attached walls RECOMPOSE (ATTACH→translate,
+// SPAN/EDGE→stretch) via the pure GridKinematicEngine, committed as ONE signed GEOM_GRID_MOVE op.
+const bGridMove = document.getElementById('b-gridmove');
+const GM_MOVE = _ico('<path d="M12 2v20"/><path d="m15 5-3-3-3 3"/><path d="m15 19-3 3-3-3"/><path d="M2 12h20"/>') + '<span>Move Grid</span>';
+const GM_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
+let gridMoving = false, _dragGrid = null, gmPreview = null;
+function nearestGridline(x, y) {
+  const G = window.Bonsai.grid; let best = null, bd = 0.6;
+  G.xs.forEach((gx, i) => { const d = Math.abs(x - gx); if (d < bd) { bd = d; best = { id: 'gx' + i, axis: 'x', coord: gx }; } });
+  G.ys.forEach((gy, j) => { const d = Math.abs(y - gy); if (d < bd) { bd = d; best = { id: 'gy' + j, axis: 'y', coord: gy }; } });
+  return best;
+}
+function gmPreviewLine(axis, coord) {
+  if (gmPreview) { scene.remove(gmPreview); gmPreview = null; }
+  const G = window.Bonsai.grid;
+  const a = axis === 'x' ? [new THREE.Vector3(coord, G.ys[0], 0.03), new THREE.Vector3(coord, G.ys[G.ys.length - 1], 0.03)]
+                         : [new THREE.Vector3(G.xs[0], coord, 0.03), new THREE.Vector3(G.xs[G.xs.length - 1], coord, 0.03)];
+  gmPreview = new THREE.Line(new THREE.BufferGeometry().setFromPoints(a), new THREE.LineBasicMaterial({ color: 0xffd24f }));
+  scene.add(gmPreview);
+}
+function enterGridMove() {
+  if (!window.Bonsai.grid.active) { window.Bonsai.grid.show(true); bGrid.classList.add('on'); }
+  gridMoving = true; _dragGrid = null; bGridMove.innerHTML = GM_CANCEL; controls.enabled = false;   // grab gridlines, not the camera
+  setStat('move grid: drag a gridline — attached walls recompose');
+}
+function exitGridMove() {
+  gridMoving = false; _dragGrid = null; bGridMove.innerHTML = GM_MOVE; controls.enabled = true;
+  if (gmPreview) { scene.remove(gmPreview); gmPreview = null; }
+}
+bGridMove.onclick = () => gridMoving ? exitGridMove() : enterGridMove();
+canvas.addEventListener('pointerdown', (e) => {
+  if (!gridMoving || e.button !== 0 || e.shiftKey) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(GROUND, hit)) return;
+  const gl = nearestGridline(hit.x, hit.y);
+  if (gl) { _dragGrid = { ...gl, downAt: gl.axis === 'x' ? hit.x : hit.y }; gmPreviewLine(gl.axis, gl.coord); setStat('drag grid ' + gl.id + ' (' + gl.axis + ')'); }
+});
+canvas.addEventListener('pointermove', (e) => {
+  if (!gridMoving || !_dragGrid) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(GROUND, hit)) return;
+  const cur = _dragGrid.axis === 'x' ? hit.x : hit.y;
+  _dragGrid.delta = cur - _dragGrid.downAt;
+  gmPreviewLine(_dragGrid.axis, _dragGrid.coord + _dragGrid.delta);
+});
+async function commitGridMove() {
+  if (!_dragGrid || Math.abs(_dragGrid.delta || 0) < 0.05) { exitGridMove(); return; }
+  const { id, delta } = _dragGrid;
+  setStat('recomposing…');
+  try {
+    const res = await window.Bonsai.gridmove.commit(id, delta);
+    setStat('grid ' + id + ' moved ' + delta.toFixed(2) + '  recomposed=' + res.commands.length + '  verify=' + res.verify);
+    audioCue('commit'); exitGridMove(); syncHistory();
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER gridmove fail ' + err); }
+}
+canvas.addEventListener('pointerup', () => { if (gridMoving && _dragGrid) commitGridMove(); });
+
 // ── IFC EXPORT ──────────────────────────────────────────────────────────────────────────────────
 const bIfc = document.getElementById('b-ifc');
 bIfc.onclick = async () => {
@@ -440,7 +508,7 @@ bIfc.onclick = async () => {
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§IFC export fail ' + err); }
 };
 
-bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = false;
+bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = false;
 window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
 // Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
 // NOTE: the modeller's Outliner is an AUTHORING tree only — it deliberately carries NO 4D/5D info; that is the
@@ -451,6 +519,9 @@ window.Bonsai.outliner.addCategory({ key: 'routes', label: 'Routes', match: op =
 window.Bonsai.outliner.addCategory({ key: 'fillets', label: 'Fillets', match: op => op.op_type === 'GEOM_FILLET',
   node: op => ({ id: op.parameters.parent, label: (op.parameters.kind === 'chamfer' ? 'Chamfer' : 'Round'),
     sub: '⮡ Wall ' + op.parameters.parent + ' ·' + (op.parameters.edges ? op.parameters.edges.length : 0) + 'e' }) });
+window.Bonsai.outliner.addCategory({ key: 'gridmoves', label: 'Grid Moves', match: op => op.op_type === 'GEOM_GRID_MOVE',
+  node: op => ({ id: op.id, label: 'Move ' + op.parameters.gridId,
+    sub: (op.parameters.delta > 0 ? '+' : '') + (+op.parameters.delta).toFixed(2) + ' ·' + (op.parameters.commands ? op.parameters.commands.length : 0) + ' recomp' }) });
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
@@ -792,6 +863,57 @@ if (qs.get('constrain') === 'demo') {
     window.__constrainResult = out;
     window.__constrainDone = true;
     console.log('§MODELLER constrain-done');
+  })();
+}
+// ?gridmove=demo proves the §S270 grid-kinematics shoulder (W-BONSAI-GRIDMOVE): a thin wall ATTACHED to grid B
+// and a wide wall whose right EDGE sits on grid B. Entering Move-Grid mode and DRAGGING grid B (real pointer
+// down→move→up) commits ONE signed GEOM_GRID_MOVE: the attached wall TRANSLATES and the edge wall STRETCHES via
+// the pure GridKinematicEngine — the scene's max-x grows, the chain verifies+signs, the Outliner shows a Grid
+// Moves row, and scrubbing back undoes the recompose deterministically. Drives the real drag handlers.
+if (qs.get('gridmove') === 'demo') {
+  (async () => {
+    const out = {};
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4], ys: [0, 3], xlabels: ['A', 'B'], ylabels: ['1', '2'] });
+      window.Bonsai.grid.show(true);
+      const O = window.Bonsai.oplog; O.clear();
+      // Wall1: centred ON grid B (x=4), half-extent 0.3 (between EDGE_TOL 0.1 and ATTACH_TOL 0.5) → ATTACH → translate.
+      // Wall2: wide x[0,4], right edge on grid B → EDGE_RIGHT → stretch.
+      const w1 = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[3.7, 0], [4.3, 0], [4.3, 3], [3.7, 3]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      const w2 = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      out.w1 = w1.id; out.w2 = w2.id;
+      const featBox = () => { const o = {}; window.Bonsai.group().children.filter(m => m.isMesh).forEach(m => { m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox; o[m.userData.featureId] = { x: [+b.min.x.toFixed(2), +b.max.x.toFixed(2)], z: [+b.min.z.toFixed(2), +b.max.z.toFixed(2)] }; }); return o; };
+      out.before = featBox();
+      const box0 = new THREE.Box3().setFromObject(window.Bonsai.group()); out.maxXBefore = +box0.max.x.toFixed(2);
+      // peek the engine's commands for the drag (TRANSLATE for the attached wall, SCALE for the edge wall).
+      out.commands = window.Bonsai.gridmove.computeCommands('gx1', 1.5).map(c => c.action);
+      // DRIVE THE REAL DRAG: enter mode, pointer down on grid B, move +1.5 in x, release.
+      bGridMove.onclick();                                       // enter Move-Grid mode
+      out.entered = gridMoving;
+      const rect = canvas.getBoundingClientRect();
+      const toClient = (x, y) => { const v = new THREE.Vector3(x, y, 0).project(camera); return { clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height }; };
+      const down = toClient(4, 1.5), move = toClient(5.5, 1.5);
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: down.clientX, clientY: down.clientY, bubbles: true }));
+      out.grabbed = _dragGrid && _dragGrid.id;
+      canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: move.clientX, clientY: move.clientY, bubbles: true }));
+      out.dragDelta = _dragGrid ? +(_dragGrid.delta || 0).toFixed(2) : null;
+      canvas.dispatchEvent(new PointerEvent('pointerup', { button: 0, clientX: move.clientX, clientY: move.clientY, bubbles: true }));
+      await new Promise(r => setTimeout(r, 400));                // let the async commitGridMove + fold settle
+      out.exited = !gridMoving;
+      out.after = featBox();   // per-feature x/z bbox after the recompose (verify Wall1 translated, Wall2 x-stretched, z intact)
+      const box1 = new THREE.Box3().setFromObject(window.Bonsai.group()); out.maxXAfter = +box1.max.x.toFixed(2);
+      out.signed = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verify = (await O.verify()).ok;
+      out.gridOps = O._geomOps().filter(o => o.op_type === 'GEOM_GRID_MOVE').length;
+      const rows = Array.from(document.querySelectorAll('#bonsai-outliner #bo-tree [data-fid]')).map(d => d.textContent.replace(/\s+/g, ' ').trim());
+      out.moveRow = rows.find(r => /Move gx1/.test(r)) || null;
+      out.gridMovesCategory = Array.from(document.querySelectorAll('#bonsai-outliner [data-grp]')).some(d => d.getAttribute('data-grp') === 'gridmoves');
+      await O.scrubTo(2); out.scrubBack = +(new THREE.Box3().setFromObject(window.Bonsai.group()).max.x).toFixed(2);   // before the move
+      await O.scrubTo(3); out.scrubFwd = +(new THREE.Box3().setFromObject(window.Bonsai.group()).max.x).toFixed(2);    // after the move
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER gridmove demo fail ' + e); }
+    window.__gridmoveResult = out;
+    window.__gridmoveDone = true;
+    console.log('§MODELLER gridmove-done');
   })();
 }
 // ?sketch=demo drives a deliberately NOISY hand-drawn quad through the solver -> extrude (W-BONSAI-SKETCH).

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -35,6 +35,8 @@
   <button id="b-sketch" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg><span>Sketch</span></button>
   <button id="b-extrude" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg><span>Extrude</span></button>
   <button id="b-cut" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg><span>Cut</span></button>
+  <button id="b-route" disabled title="Sweep a profile along a route (MEP run)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg><span>Route</span></button>
+  <button id="b-run" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg><span>Sweep Run</span></button>
   <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
   <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
@@ -247,7 +249,7 @@ window.Bonsai.select = (fid) => {                 // witness/programmatic hook
   highlight(m || null); return selectedId;
 };
 canvas.addEventListener('pointerdown', (e) => {
-  if (sketching || e.button !== 0 || e.shiftKey) return;
+  if (sketching || routing || e.button !== 0 || e.shiftKey) return;
   const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return;
   const r = canvas.getBoundingClientRect();
   const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
@@ -274,6 +276,63 @@ bCut.onclick = async () => {
     const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_CUT', parameters: { parent: selectedId, void: { c1, c2 } } }, { color: 0x9fd6b4 });
     setStat('cut opening in #' + selectedId + '  tris=' + res.triangleCount); audioCue('cut'); highlight(null); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER cut fail ' + err); }
+};
+
+// ── ROUTE MODE (sweep a profile along a path = MEP run) ──────────────────────────────────────────
+// §OOTB authoring mode 3 (RouteWalker → MEP sweep). Click points on the ground plane to lay a route;
+// Sweep Run folds the SIGNED op-log GEOM_SWEEP (occt kernel.pipe) into a duct/pipe solid along the path.
+// The worker orients the rectangle profile perpendicular to the route's start tangent (so a horizontal
+// ground route sweeps correctly), centred on the first point. One route = one signed op-row.
+const bRoute = document.getElementById('b-route');
+const bRun = document.getElementById('b-run');
+const RT_ROUTE = _ico('<circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/>') + '<span>Route</span>';
+const RT_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
+let routing = false, routePts = [], routeGroup = null;
+function routeMarkers() {
+  if (!routeGroup) { routeGroup = new THREE.Group(); routeGroup.name = 'RoutePreview'; scene.add(routeGroup); }
+  while (routeGroup.children.length) routeGroup.remove(routeGroup.children[0]);
+  routePts.forEach(p => {
+    const m = new THREE.Mesh(new THREE.SphereGeometry(0.07, 12, 12), new THREE.MeshBasicMaterial({ color: 0xffb74f }));
+    m.position.set(p[0], p[1], 0.01); routeGroup.add(m);
+  });
+  if (routePts.length >= 2) {
+    const line = routePts.map(p => new THREE.Vector3(p[0], p[1], 0.01));   // open polyline (a route, not a loop)
+    routeGroup.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(line), new THREE.LineBasicMaterial({ color: 0xffb74f })));
+  }
+}
+function enterRoute() {
+  routing = true; routePts = [];
+  savedCam = { pos: camera.position.clone(), tgt: controls.target.clone() };
+  camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
+  bRun.style.display = ''; bRun.disabled = true; bRoute.innerHTML = RT_CANCEL;
+  routeMarkers(); setStat('route: click ≥2 points on the grid to lay a run, then Sweep Run');
+}
+function exitRoute() {
+  routing = false; bRun.style.display = 'none'; bRoute.innerHTML = RT_ROUTE;
+  if (routeGroup) { while (routeGroup.children.length) routeGroup.remove(routeGroup.children[0]); }
+  if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); controls.update(); }
+}
+bRoute.onclick = () => routing ? exitRoute() : enterRoute();
+canvas.addEventListener('pointerdown', (e) => {
+  if (!routing || e.button !== 0 || e.shiftKey) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  if (raycaster.ray.intersectPlane(GROUND, hit)) {
+    const s = window.Bonsai.grid.snap(hit.x, hit.y);   // same 2D correlation as sketch — snap to gridlines
+    routePts.push([s.x, s.y, 0]); routeMarkers();
+    bRun.disabled = routePts.length < 2;
+    setStat('route: ' + routePts.length + ' points' + (s.ref && (s.snappedX || s.snappedY) ? '  @' + s.ref : ''));
+  }
+});
+bRun.onclick = async () => {
+  if (routePts.length < 2) { setStat('need ≥2 route points'); return; }
+  setStat('sweeping…');
+  try {
+    const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_SWEEP', parameters: { profile: { w: 0.3, h: 0.3 }, path: routePts.slice() } }, { color: 0xffb74f });
+    setStat('swept run #' + res.id + '  verify=' + res.verify + '  tris=' + res.triangleCount); audioCue('commit'); exitRoute(); syncHistory();
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER route fail ' + err); }
 };
 
 // ── HISTORY SCRUBBER ────────────────────────────────────────────────────────────────────────────
@@ -309,8 +368,14 @@ bIfc.onclick = async () => {
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§IFC export fail ' + err); }
 };
 
-bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = false;
-window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log
+bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = false;
+window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
+// Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
+// NOTE: the modeller's Outliner is an AUTHORING tree only — it deliberately carries NO 4D/5D info; that is the
+// Viewer's job after handoff (modeller stays permanently separate from the Viewer — separation of concern).
+window.Bonsai.outliner.addCategory({ key: 'routes', label: 'Routes', match: op => op.op_type === 'GEOM_SWEEP',
+  node: op => { const p = op.parameters.path; const a = (p && window.Bonsai.grid.refAt) ? window.Bonsai.grid.refAt(p[0][0], p[0][1]) : null;
+    return { id: op.id, label: 'Run', sub: (a && (a.x || a.y)) ? ((a.x || '·') + '-' + (a.y || '·')) + ' ·' + p.length + 'pt' : '#' + op.id + ' ·' + (p ? p.length : 0) + 'pt' }; } });
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
@@ -516,6 +581,53 @@ if (qs.get('sweep') === 'demo') {
     window.__sweepResult = out;
     window.__sweepDone = true;
     console.log('§MODELLER sweep-done');
+  })();
+}
+// ?route=demo proves the SWEEP toolbar wiring + interactive path-pick (W-BONSAI-ROUTE): enter route mode via the
+// Route button, lay an L-shaped run by SIMULATING ground clicks (the same pointerdown handler the user hits), Sweep
+// Run commits a signed GEOM_SWEEP, the solid spans both runs of the path, the Outliner shows it under Routes, and
+// scrubbing replays it deterministically. Drives the REAL UI handlers — not the engine API directly.
+if (qs.get('route') === 'demo') {
+  (async () => {
+    const out = {};
+    try {
+      window.Bonsai.grid.define({ xs: [0, 3, 6], ys: [0, 2], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      window.Bonsai.oplog.clear();
+      bRoute.onclick();                                         // enter route mode (button)
+      out.routing = routing; out.runDisabledAtEntry = bRun.disabled;
+      const rect = canvas.getBoundingClientRect();
+      // ground-plane points for an L route A-1 → B-1 → B-2; project to screen so the REAL pointerdown handler runs.
+      const groundToClient = (x, y) => {
+        const v = new THREE.Vector3(x, y, 0).project(camera);
+        return { clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height };
+      };
+      for (const [gx, gy] of [[0.1, 0.05], [2.95, 0.08], [3.05, 1.95]]) {
+        const c = groundToClient(gx, gy);
+        canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: c.clientX, clientY: c.clientY, bubbles: true }));
+      }
+      out.points = routePts.length; out.runEnabled = !bRun.disabled;
+      await bRun.onclick();                                     // Sweep Run (button) → signed GEOM_SWEEP
+      out.exitedRoute = !routing;
+      const ops = window.Bonsai.oplog._geomOps();
+      out.sweepOps = ops.filter(o => o.op_type === 'GEOM_SWEEP').length;
+      out.signed = window.Bonsai.oplog.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verify = (await window.Bonsai.oplog.verify()).ok;
+      // bounding box of the authored run must span both legs of the L (x≈0→3, y≈0→2).
+      const g = window.Bonsai.group();
+      const box = new THREE.Box3().setFromObject(g); const s = new THREE.Vector3(); box.getSize(s);
+      out.size = { x: +s.x.toFixed(2), y: +s.y.toFixed(2), z: +s.z.toFixed(2) };
+      out.tris = g.children.filter(o => o.isMesh).reduce((n, m) => n + (m.geometry.index ? m.geometry.index.count / 3 : 0), 0);
+      // Outliner reflects the run under a Routes category.
+      const rows = Array.from(document.querySelectorAll('#bonsai-outliner #bo-tree [data-fid]')).map(d => d.textContent.replace(/\s+/g, ' ').trim());
+      out.routeRow = rows.find(r => /Run/.test(r)) || null;
+      const hasRoutesGrp = Array.from(document.querySelectorAll('#bonsai-outliner [data-grp]')).some(d => d.getAttribute('data-grp') === 'routes');
+      out.routesCategory = hasRoutesGrp;
+      out.scrub0 = (await window.Bonsai.oplog.scrubTo(0)).triangleCount;
+      out.scrub1 = (await window.Bonsai.oplog.scrubTo(1)).triangleCount;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER route demo fail ' + e); }
+    window.__routeResult = out;
+    window.__routeDone = true;
+    console.log('§MODELLER route-done');
   })();
 }
 // ?sketch=demo drives a deliberately NOISY hand-drawn quad through the solver -> extrude (W-BONSAI-SKETCH).

--- a/viewer/tests/bonsai_constrain_live.js
+++ b/viewer/tests/bonsai_constrain_live.js
@@ -1,0 +1,52 @@
+// W-BONSAI-CONSTRAIN — Bonsai modeller DEPTH leg 3 witness (prompts/BONSAI_KERNEL_RESEARCH.md §NEXT depth track).
+// CLAIM: the modeller now wires the richer planegcs constraint shoulders (we previously used only 2 of ~60 —
+// horizontal_pp/vertical_pp). A deliberately non-rectangular quad (corners far from 90°, opposite sides not
+// parallel) is cleaned by the line + parallel + perpendicular_ll family into a TRUE rectangle (mode 'rect'),
+// and into a SQUARE once equal_length is added (mode 'square'), the solver succeeding (status 0); two points are
+// made mirror-symmetric by p2p_symmetric_ppp (the fixed centre lands on their midpoint); and a Constrain toolbar
+// button cycles the intent axis→rect→square. This is genuinely richer 2D parametrics earned with no new binding.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(SKETCH|MODELLER)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?constrain=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__constrainDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __constrainDone'));
+
+  const x = await pg.evaluate(() => window.__constrainResult || {}).catch(e => ({ err: String(e) }));
+  const j = (o) => o ? ('status=' + o.status + ' cons=' + o.cons + ' maxCorner=' + o.m.maxCorner + '° par=' + o.m.par + '° sideRatio=' + o.m.sideRatio) : 'null';
+  console.log('  §BONSAI-CONSTRAIN input.maxCorner=' + (x.input && x.input.maxCorner) + '°');
+  console.log('  §BONSAI-CONSTRAIN axis   ' + j(x.axis));
+  console.log('  §BONSAI-CONSTRAIN rect   ' + j(x.rect));
+  console.log('  §BONSAI-CONSTRAIN square ' + j(x.square));
+  console.log('  §BONSAI-CONSTRAIN sym    status=' + (x.sym && x.sym.status) + ' midErr=' + (x.sym && x.sym.midErr) +
+    ' | btnExists=' + x.btnExists + ' cycleLabels=' + JSON.stringify(x.cycleLabels) + (x.error ? ' ERROR=' + x.error : ''));
+
+  await br.close(); server.close();
+
+  const inputNoisy = x.input && x.input.maxCorner > 3;                                   // the input really wasn't a rectangle
+  const rectClean = x.rect && x.rect.status === 0 && x.rect.cons === 3 && x.rect.m.maxCorner < 0.5 && x.rect.m.par < 0.5;
+  const squareClean = x.square && x.square.status === 0 && x.square.cons === 4 && x.square.m.maxCorner < 0.5 && x.square.m.sideRatio < 1.02;
+  const symOK = x.sym && x.sym.status === 0 && x.sym.midErr < 1e-3;                      // centre is the midpoint ⇒ symmetric
+  const uiCycles = x.btnExists === true && JSON.stringify(x.cycleLabels) === JSON.stringify(['Rect', 'Square', 'Axis']);
+  const pass = inputNoisy && rectClean && squareClean && symOK && uiCycles;
+  console.log('  §BONSAI-CONSTRAIN VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — inputNoisy=' + inputNoisy + ' rectClean=' + rectClean + ' squareClean=' + squareClean + ' symmetry=' + symOK + ' uiCycles=' + uiCycles);
+  console.log('── W-BONSAI-CONSTRAIN ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_fillet_live.js
+++ b/viewer/tests/bonsai_fillet_live.js
@@ -1,0 +1,66 @@
+// W-BONSAI-FILLET — Bonsai modeller DEPTH leg 2 witness (prompts/BONSAI_KERNEL_RESEARCH.md §NEXT depth track).
+// CLAIM: the occt fillet/chamfer shoulders (index.js fillet/chamfer) are reachable through the SIGNED op-log,
+// with the NEW input device they needed — EDGE PICKING. Driving the REAL UI (select solid → Fillet button →
+// simulated click on the longest edge's marker → Apply), a signed GEOM_FILLET rounds the picked edge: the solid
+// gains triangles (a rounded edge is richer than a sharp box), the chain verifies + is signed, the Outliner shows
+// a Fillets category, scrub replays deterministically (prefix 1=plain wall tris, 2=filleted), and a kind:'chamfer'
+// op proves the chamfer shoulder on the same edge. Edge indices are stable across the deterministic re-fold.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|OUTLINER|KRN|KERNEL_OPS)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?fillet=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__filletDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __filletDone'));
+
+  const probe = await pg.evaluate(() => {
+    const res = window.__filletResult || {};
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera);
+    const gl = r.getContext(); const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
+    const px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let lit = 0; for (let i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+    return { res, litPct: +(100 * lit / (w * h)).toFixed(1) };
+  }).catch(e => ({ err: String(e) }));
+
+  const x = probe.res || {};
+  console.log('  §BONSAI-FILLET edgeCount=' + x.edgeCount + ' longestLen=' + x.longestLen + ' picked=' + x.pickedCount +
+    ' applyEnabled=' + x.applyEnabled + ' exited=' + x.exited + ' afterWall=' + x.afterWall + ' afterFillet=' + x.afterFillet +
+    ' signed=' + x.signed + ' verify=' + x.verify + ' filletRow="' + x.filletRow + '" filletsCategory=' + x.filletsCategory +
+    ' scrub1=' + x.scrub1 + ' scrub2=' + x.scrub2 + ' chamferTris=' + x.chamferTris + ' chamferVerify=' + x.chamferVerify +
+    ' litPixels=' + probe.litPct + '%' + (x.error ? ' ERROR=' + x.error : ''));
+
+  await br.close(); server.close();
+
+  const edgesReported = x.edgeCount === 12;                          // a box-like extrude solid has 12 edges
+  const pickedAnEdge = x.pickedCount === 1 && x.applyEnabled === true;
+  const rounded = x.afterFillet > x.afterWall;                       // a rounded edge adds triangles
+  const signedOK = x.signed === 2 && x.verify === true;              // wall + fillet, both signed, chain verifies
+  const inOutliner = x.filletsCategory === true && /Round/.test(x.filletRow || '');
+  const replayOK = x.scrub1 === x.afterWall && x.scrub2 === x.afterFillet;
+  const exited = x.exited === true;
+  const chamferOK = x.chamferTris > x.afterWall && x.chamferVerify === true;   // chamfer shoulder also folds + signs
+  const drew = probe.litPct > 0.5;
+  const pass = edgesReported && pickedAnEdge && rounded && signedOK && inOutliner && replayOK && exited && chamferOK && drew;
+  console.log('  §BONSAI-FILLET VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — edgesReported=' + edgesReported + ' pickedAnEdge=' + pickedAnEdge + ' rounded=' + rounded +
+    ' signed=' + signedOK + ' inOutlinerFillets=' + inOutliner + ' replayDeterministic=' + replayOK +
+    ' exited=' + exited + ' chamfer=' + chamferOK + ' drew=' + drew);
+  console.log('── W-BONSAI-FILLET ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_gridmove_live.js
+++ b/viewer/tests/bonsai_gridmove_live.js
@@ -1,0 +1,73 @@
+// W-BONSAI-GRIDMOVE — Bonsai modeller DEPTH leg 4 witness (prompts/BONSAI_KERNEL_RESEARCH.md §NEXT depth track).
+// CLAIM: the shipped §S270 Grid Kinematics engine (GridKinematicEngine.dragGrid — a PURE recompose fn) now drives
+// REAL authored geometry in the modeller. A thin wall ATTACHED to grid B and a wide wall whose right EDGE sits on
+// grid B: entering Move-Grid mode and DRAGGING grid B (real pointer down→move→up) commits ONE signed GEOM_GRID_MOVE
+// whose stored commands the worker folds — the attached wall TRANSLATES and the edge wall STRETCHES, so the scene's
+// max-x grows from ~4.1 to >5.5; the chain verifies + is signed, the Outliner shows a Grid Moves row, and scrubbing
+// back undoes the recompose deterministically (max-x returns to ~4.1). The parametric-grid payoff, no new binding.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|GRIDMOVE|OUTLINER|KRN)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?gridmove=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__gridmoveDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __gridmoveDone'));
+
+  const probe = await pg.evaluate(() => {
+    const res = window.__gridmoveResult || {};
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera);
+    const gl = r.getContext(); const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
+    const px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let lit = 0; for (let i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+    return { res, litPct: +(100 * lit / (w * h)).toFixed(1) };
+  }).catch(e => ({ err: String(e) }));
+
+  const x = probe.res || {};
+  const b = x.before || {}, a = x.after || {}, w1 = x.w1, w2 = x.w2;
+  console.log('  §BONSAI-GRIDMOVE entered=' + x.entered + ' grabbed=' + x.grabbed + ' dragDelta=' + x.dragDelta +
+    ' commands=' + JSON.stringify(x.commands) + ' maxXBefore=' + x.maxXBefore + ' maxXAfter=' + x.maxXAfter +
+    ' exited=' + x.exited + ' signed=' + x.signed + ' verify=' + x.verify + ' gridOps=' + x.gridOps +
+    ' moveRow="' + x.moveRow + '" gridMovesCategory=' + x.gridMovesCategory +
+    ' scrubBack=' + x.scrubBack + ' scrubFwd=' + x.scrubFwd + ' litPixels=' + probe.litPct + '%' + (x.error ? ' ERROR=' + x.error : ''));
+  console.log('  §BONSAI-GRIDMOVE wall1(ATTACH) x ' + JSON.stringify(b[w1] && b[w1].x) + '→' + JSON.stringify(a[w1] && a[w1].x) +
+    '  wall2(EDGE) x ' + JSON.stringify(b[w2] && b[w2].x) + '→' + JSON.stringify(a[w2] && a[w2].x) +
+    '  wall2 z ' + JSON.stringify(b[w2] && b[w2].z) + '→' + JSON.stringify(a[w2] && a[w2].z));
+
+  await br.close(); server.close();
+
+  const enteredMode = x.entered === true && x.grabbed === 'gx1';
+  const dragged = Math.abs((x.dragDelta || 0) - 1.5) < 0.2;                       // pointer move produced ~+1.5
+  const bothActions = Array.isArray(x.commands) && x.commands.includes('TRANSLATE') && x.commands.includes('SCALE');
+  const recomposed = x.maxXAfter > 5.4 && x.maxXBefore < 4.6;                     // attached wall moved + edge wall stretched
+  // ATTACH wall translated ~+1.5 in x (both endpoints shift), EDGE wall stretched in x (right edge ~5.5) with z intact.
+  const w1Translated = b[w1] && a[w1] && Math.abs((a[w1].x[0] - b[w1].x[0]) - 1.5) < 0.2 && Math.abs((a[w1].x[1] - b[w1].x[1]) - 1.5) < 0.2;
+  const w2Stretched = b[w2] && a[w2] && Math.abs(a[w2].x[0] - b[w2].x[0]) < 0.2 && a[w2].x[1] > 5.3 &&
+    Math.abs(a[w2].z[0] - b[w2].z[0]) < 0.05 && Math.abs(a[w2].z[1] - b[w2].z[1]) < 0.05;   // x-only stretch, z untouched
+  const oneSignedMove = x.gridOps === 1 && x.signed === 3 && x.verify === true;   // wall+wall+grid_move, all signed
+  const inOutliner = x.gridMovesCategory === true && /Move gx1/.test(x.moveRow || '');
+  const replayOK = Math.abs(x.scrubBack - x.maxXBefore) < 0.2 && Math.abs(x.scrubFwd - x.maxXAfter) < 0.2;
+  const exited = x.exited === true;
+  const drew = probe.litPct > 0.5;
+  const pass = enteredMode && dragged && bothActions && recomposed && w1Translated && w2Stretched && oneSignedMove && inOutliner && replayOK && exited && drew;
+  console.log('  §BONSAI-GRIDMOVE VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — enteredMode=' + enteredMode + ' dragged=' + dragged + ' translate+scale=' + bothActions + ' recomposed=' + recomposed +
+    ' wall1Translated=' + w1Translated + ' wall2StretchedXonly=' + w2Stretched +
+    ' oneSignedMove=' + oneSignedMove + ' inOutliner=' + inOutliner + ' replayDeterministic=' + replayOK + ' exited=' + exited + ' drew=' + drew);
+  console.log('── W-BONSAI-GRIDMOVE ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_route_live.js
+++ b/viewer/tests/bonsai_route_live.js
@@ -1,0 +1,66 @@
+// W-BONSAI-ROUTE — Bonsai modeller DEPTH leg 1 witness (prompts/BONSAI_KERNEL_RESEARCH.md §NEXT depth track).
+// CLAIM: the occt SWEEP shoulder (kernel.pipe) is now WIRED TO THE TOOLBAR with interactive path-pick — no
+// longer engine-only (?sweep=demo). Driving the REAL UI handlers (Route button → simulated ground pointerdowns
+// → Sweep Run button), an L-shaped ground route commits as ONE signed GEOM_SWEEP op, folds to a solid whose
+// bounding box spans BOTH legs of the L (x≈3, y≈2 — a real swept run, not a degenerate box), the chain verifies
+// and is signed, the Outliner shows the run under a Routes category, and scrub replays it deterministically.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  const logs = [];
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|OUTLINER|KRN|KERNEL_OPS)/.test(t)) { logs.push(t); console.log('  ' + t); } });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?route=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__routeDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __routeDone'));
+
+  const probe = await pg.evaluate(() => {
+    const res = window.__routeResult || {};
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera);
+    const gl = r.getContext(); const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
+    const px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let lit = 0; for (let i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+    return { res, litPct: +(100 * lit / (w * h)).toFixed(1) };
+  }).catch(e => ({ err: String(e) }));
+
+  const x = probe.res || {};
+  const sz = x.size || {};
+  console.log('  §BONSAI-ROUTE routing=' + x.routing + ' pts=' + x.points + ' runEnabled=' + x.runEnabled +
+    ' exitedRoute=' + x.exitedRoute + ' sweepOps=' + x.sweepOps + ' signed=' + x.signed + ' verify=' + x.verify +
+    ' bbox=[' + sz.x + ',' + sz.y + ',' + sz.z + '] tris=' + x.tris +
+    ' routeRow="' + x.routeRow + '" routesCategory=' + x.routesCategory +
+    ' scrub0=' + x.scrub0 + ' scrub1=' + x.scrub1 + ' litPixels=' + probe.litPct + '%');
+
+  await br.close(); server.close();
+
+  const pickedPath = x.points === 3 && x.runEnabled === true;        // 3 ground clicks landed → Sweep Run armed
+  const oneSignedSweep = x.sweepOps === 1 && x.signed === 1 && x.verify === true;
+  const spansL = sz.x > 2.5 && sz.y > 1.5;                            // bbox covers the 3m + 2m legs of the L route
+  const swept = x.tris > 12;                                          // richer than a box
+  const inOutliner = x.routesCategory === true && /Run/.test(x.routeRow || '');
+  const replayOK = x.scrub0 === 0 && x.scrub1 === x.tris;            // deterministic prefix fold over the signed log
+  const exited = x.exitedRoute === true;
+  const drew = probe.litPct > 0.5;
+  const pass = x.routing === true && pickedPath && oneSignedSweep && spansL && swept && inOutliner && replayOK && exited && drew;
+  console.log('  §BONSAI-ROUTE VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — enteredRouteMode=' + (x.routing === true) + ' pickedPath=' + pickedPath + ' oneSignedSweep=' + oneSignedSweep +
+    ' spansLpath=' + spansL + ' swept=' + swept + ' inOutlinerRoutes=' + inOutliner +
+    ' replayDeterministic=' + replayOK + ' exitedRoute=' + exited + ' drew=' + drew);
+  console.log('── W-BONSAI-ROUTE ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
Exposes 4 advanced authoring "shoulders" the modeller already stood on but didn't use — each = ONE signed \`GEOM_*\` op (deterministic fold, scrub + tamper-evident, lands in Outliner). Built leg-by-leg, witness-first, on the mapped kernel inventory (NON-INVENT). 19 in-viewer witnesses GREEN (4 new + 15 prior, no regression).

- **W-BONSAI-ROUTE** — GEOM_SWEEP wired to a Route toolbar button + interactive ground-plane path-pick (was engine-only \`?sweep=demo\`); worker profile now oriented perpendicular to spine start tangent (T=+Z reproduces old XY byte-identical). Routes Outliner category.
- **W-BONSAI-FILLET** — occt fillet/chamfer via a new EDGE-PICK input device; worker \`foldChain→buildSolids\`, \`listEdges\` reports midpoints in canonical getSubShapes order; host queryEdges + edge-marker pick + Apply. Fillets category.
- **W-BONSAI-CONSTRAIN** — richer planegcs (was H/V only): ring edges → line primitives, Constrain cycle (Axis→Rect→Square) applies parallel + perpendicular_ll + equal_length; p2p_symmetric_ppp proven.
- **W-BONSAI-GRIDMOVE** — §S270 parametric-grid payoff: \`bonsai_gridmove.js\` adapts authored solids→engine elementData, runs the PURE \`GridKinematicEngine.dragGrid\`, commits ONE signed GEOM_GRID_MOVE. ATTACH walls TRANSLATE, EDGE/SPAN walls STRETCH (non-uniform via generalTransform/gp_GTrsf). Grid Moves category.

Witness verdicts (this run):
- ROUTE: oneSignedSweep=true spansLpath=true replayDeterministic=true drew=true
- FILLET: pickedAnEdge=true rounded=true chamfer=true signed=true replayDeterministic=true
- CONSTRAIN: rectClean=true squareClean=true symmetry=true (noisy quad→0° rect→unit square)
- GRIDMOVE: wall1Translated=true wall2StretchedXonly=true oneSignedMove=true replayDeterministic=true
- Regression: SIGNED / RECIPE / SKETCH / IFC all PASS.

CI (deploy-pages.yml) minifies into the Pages artifact on merge → live on GH Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>