### PR TITLE
fix(modeller): Operability v1 — correct placement + edit/delete/undo

### DIFF
--- a/viewer/bonsai_library.js
+++ b/viewer/bonsai_library.js
@@ -27,20 +27,25 @@
     for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
     return u8.buffer;
   }
-  // rotate (about +Z by rad) then translate — placement frame for an assembled component.
-  function place(positions, pl) {
+  // rotate (yaw, about +Z) about the component's local origin → translate to placement.
+  // GROUND-SEAT: the component's local bbox BOTTOM (zmin) lands at placement.z (default 0) so a
+  // component sits ON the ground, not half-buried (a door spanning local z ∈ [−1.05,+1.05] at z=0
+  // would otherwise sink 1.05 below grade). Yaw is about Z so it does not change z → seat is yaw-invariant.
+  function place(positions, pl, bbox) {
     const rad = ((pl && pl.rot) || 0) * Math.PI / 180, cs = Math.cos(rad), sn = Math.sin(rad);
-    const ox = (pl && pl.x) || 0, oy = (pl && pl.y) || 0, oz = (pl && pl.z) || 0;
+    const ox = (pl && pl.x) || 0, oy = (pl && pl.y) || 0;
+    const seatZ = ((pl && pl.z) || 0) - (bbox ? bbox[4] : 0);   // bbox[4] = local zmin → placement.z (elevation)
     const out = new Float32Array(positions.length);
     for (let i = 0; i < positions.length; i += 3) {
       const x = positions[i], y = positions[i + 1], z = positions[i + 2];
-      out[i] = cs * x - sn * y + ox; out[i + 1] = sn * x + cs * y + oy; out[i + 2] = z + oz;
+      out[i] = cs * x - sn * y + ox; out[i + 1] = sn * x + cs * y + oy; out[i + 2] = z + seatZ;
     }
     return out;
   }
   // 12-tri box from a local bbox = the LOD-200 proxy (corner-indexed, two tris per face).
+  // bbox layout is [minx,maxx,miny,maxy,minz,maxz] (NOT [x0,y0,z0,x1,y1,z1]) — map axes explicitly.
   function boxArrays(bb) {
-    const [x0, y0, z0, x1, y1, z1] = bb;
+    const x0 = bb[0], x1 = bb[1], y0 = bb[2], y1 = bb[3], z0 = bb[4], z1 = bb[5];
     const p = [x0,y0,z0, x1,y0,z0, x1,y1,z0, x0,y1,z0, x0,y0,z1, x1,y0,z1, x1,y1,z1, x0,y1,z1];
     const positions = new Float32Array(p);
     const idx = [0,1,2, 0,2,3,  4,6,5, 4,7,6,  0,4,5, 0,5,1,  1,5,6, 1,6,2,  2,6,7, 2,7,3,  3,7,4, 3,4,0];
@@ -65,8 +70,16 @@
       const c = this.get(P.hash); if (!c) throw new Error('GEOM_INSERT unknown component ' + P.hash);
       const lod = this.lodFor(op.id, P.lod);
       const base = (lod === '300') ? this.meshArrays(P.hash) : boxArrays(c.bbox);
-      const positions = place(base.positions, P.placement);
+      const positions = place(base.positions, P.placement, c.bbox);
       return { featureId: op.id, triangleCount: base.indices.length / 3, positions, normals: null, indices: base.indices };
+    },
+
+    // GHOST preview (uncommitted): a LOD-200 box of the component at a candidate placement, so the host can
+    // show where/how an insert will land (with current yaw + elevation) BEFORE the user clicks to commit.
+    previewArrays(hash, placement) {
+      const c = this.get(hash); if (!c) return null;
+      const base = boxArrays(c.bbox);
+      return { positions: place(base.positions, placement, c.bbox), indices: base.indices, bbox: c.bbox };
     }
   };
 

--- a/viewer/bonsai_oplog.js
+++ b/viewer/bonsai_oplog.js
@@ -96,6 +96,52 @@
 
     async verify() { return window.KernelOps.verifyChain(this.db); },
 
+    // ---- EDIT (operability): soft-delete / undo / redo by toggling the kernel_ops `undone` flag. `undone`
+    // is NOT part of the signed payload (verifyChain never reads it), so the append-only chain stays valid and
+    // every "edit" is reversible — features are hidden/shown, never rewritten. Invariant kept: never leave an
+    // ACTIVE child (GEOM_CUT/FILLET/…) whose referenced parent is undone (that would break the fold).
+    _allGeom() {
+      const r = this.db.exec("SELECT id, op_type, parameters, undone FROM kernel_ops WHERE " + GEOM + " ORDER BY id");
+      if (!r.length) return [];
+      return r[0].values.map(v => { const p = JSON.parse(v[2]); return { id: v[0], op_type: v[1], parent: p.parent, undone: v[3] }; });
+    },
+    _setUndone(ids, val) { if (ids.length) this.db.run("UPDATE kernel_ops SET undone=" + (val ? 1 : 0) + " WHERE id IN (" + ids.join(',') + ")"); },
+
+    // Delete ONE feature (+ its children that reference it as parent) — soft, reversible via redo.
+    async deleteFeature(featureId) {
+      if (!this.db) return { deleted: [] };
+      const kids = this._allGeom().filter(o => o.parent === featureId && !o.undone).map(o => o.id);
+      const ids = [featureId, ...kids];
+      this._setUndone(ids, 1);
+      await this._foldUpto(); this._emit();
+      console.log(TAG + ' delete feature=' + featureId + (kids.length ? ' +kids[' + kids + ']' : '') + ' active=' + this.length);
+      return { deleted: ids };
+    },
+    // Undo = soft-delete the most-recent ACTIVE feature (LIFO; newest has no active dependents).
+    async undo() {
+      if (!this.db) return { undone: null };
+      const active = this._allGeom().filter(o => !o.undone);
+      if (!active.length) return { undone: null };
+      const top = active[active.length - 1].id;
+      this._setUndone([top], 1);
+      await this._foldUpto(); this._emit();
+      console.log(TAG + ' undo id=' + top + ' active=' + this.length);
+      return { undone: top };
+    },
+    // Redo = reactivate the most-recent undone feature, walking UP any undone ancestor chain (keep the invariant).
+    async redo() {
+      if (!this.db) return { redone: null };
+      const all = this._allGeom(); const undoneRows = all.filter(o => o.undone);
+      if (!undoneRows.length) return { redone: null };
+      const byId = new Map(all.map(o => [o.id, o]));
+      const on = []; let cur = undoneRows[undoneRows.length - 1]; const top = cur.id;
+      while (cur && cur.undone) { on.push(cur.id); cur = cur.parent != null ? byId.get(cur.parent) : null; }
+      this._setUndone(on, 0);
+      await this._foldUpto(); this._emit();
+      console.log(TAG + ' redo id=' + top + (on.length > 1 ? ' +ancestors' : '') + ' active=' + this.length);
+      return { redone: top };
+    },
+
     // Tamper test (W-SIGN in-viewer): mutate a committed parameter behind the chain's back → verify must fail.
     async tamperFirstGeom() {
       const r = this.db.exec("SELECT id FROM kernel_ops WHERE " + GEOM + " ORDER BY id LIMIT 1");

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -519,6 +519,7 @@ bIfc.onclick = async () => {
 const bInsert = document.getElementById('b-insert');
 const bLod = document.getElementById('b-lod');
 let inserting = false, insertHash = null, lastInsertId = null, insertPanel = null;
+let insRot = 0, insElev = 0, ghostMesh = null, ghostXY = null;   // pending placement: yaw(deg) + elevation(z), live ghost
 function isInsert(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && o.op_type === 'GEOM_INSERT'; }
 function lodTargetId() { return (selectedId != null && isInsert(selectedId)) ? selectedId : lastInsertId; }
 function paintLod() {
@@ -526,11 +527,28 @@ function paintLod() {
   const lod = id != null ? window.Bonsai.library.lodFor(id, '200') : '200';
   bLod.querySelector('span').textContent = 'LOD ' + lod; bLod.classList.toggle('on', lod === '300');
 }
+function clearGhost() { if (ghostMesh) { scene.remove(ghostMesh); ghostMesh.geometry.dispose(); ghostMesh.material.dispose(); ghostMesh = null; } ghostXY = null; }
+function showGhost(x, y) {                                        // translucent preview of where/how the insert lands
+  if (!insertHash) return;
+  const pa = window.Bonsai.library.previewArrays(insertHash, { x, y, z: insElev, rot: insRot }); if (!pa) return;
+  if (!ghostMesh) {
+    ghostMesh = new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial({ color: 0x4fc3f7, transparent: true, opacity: 0.32, depthWrite: false }));
+    ghostMesh.name = 'InsertGhost'; ghostMesh.renderOrder = 999; scene.add(ghostMesh);
+  }
+  const g = ghostMesh.geometry;
+  g.setAttribute('position', new THREE.BufferAttribute(pa.positions, 3)); g.setIndex(new THREE.BufferAttribute(pa.indices, 1)); g.computeBoundingSphere();
+  ghostXY = { x, y }; if (window.A && A.requestRender) A.requestRender();
+}
+function rotateInsert() {                                          // R key / Rotate button — yaw the pending insert 90°
+  insRot = (insRot + 90) % 360;
+  const rl = insertPanel && insertPanel.querySelector('#ins-rot'); if (rl) rl.textContent = insRot + '°';
+  if (ghostXY) showGhost(ghostXY.x, ghostXY.y); setStat('insert rotation ' + insRot + '°');
+}
 async function placeComponent(x, y) {
   if (!insertHash) { setStat('pick a component first'); return null; }
-  const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_INSERT', parameters: { hash: insertHash, placement: { x, y, z: 0, rot: 0 }, lod: '200' } });
+  const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_INSERT', parameters: { hash: insertHash, placement: { x, y, z: insElev, rot: insRot }, lod: '200' } });
   lastInsertId = res.id; bLod.style.display = ''; bLod.disabled = false; paintLod();
-  setStat('inserted ' + window.Bonsai.library.get(insertHash).ifc_class + ' #' + res.id + '  tris=' + res.triangleCount); audioCue('commit'); syncHistory();
+  setStat('inserted ' + window.Bonsai.library.get(insertHash).ifc_class + ' #' + res.id + ' @' + insRot + '°' + (insElev ? ' elev ' + insElev : '') + '  tris=' + res.triangleCount); audioCue('commit'); syncHistory();
   return res;
 }
 function buildInsertPanel() {
@@ -539,18 +557,27 @@ function buildInsertPanel() {
   p.style.cssText = 'position:fixed;left:252px;top:60px;width:212px;background:#1b1d23;border:1px solid #2c303a;border-radius:7px;padding:8px;z-index:30;font:12px system-ui,sans-serif;color:#c7cdd8;display:none';
   let h = '<div style="font-size:10px;letter-spacing:.1em;color:#5b6473;margin-bottom:6px">COMPONENT LIBRARY</div>';
   window.Bonsai.library.catalog().forEach(c => {
-    h += '<button data-hash="' + c.hash + '" class="ins-c" style="display:block;width:100%;box-sizing:border-box;text-align:left;margin:3px 0;background:#13151a;border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:6px 8px;cursor:pointer">' + c.ifc_class.replace('Ifc', '') + ' <span style="color:#7f8aa0;font-size:10px">' + c.fc + ' tris</span></button>';
+    const d = c.bbox, dim = (d[1] - d[0]).toFixed(1) + '×' + (d[5] - d[4]).toFixed(1) + 'm';   // W×H from bbox so users can tell parts apart
+    h += '<button data-hash="' + c.hash + '" class="ins-c" style="display:block;width:100%;box-sizing:border-box;text-align:left;margin:3px 0;background:#13151a;border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:6px 8px;cursor:pointer">' + c.ifc_class.replace('Ifc', '') + ' <span style="color:#7f8aa0;font-size:10px">' + dim + '</span></button>';
   });
+  // pending-placement controls: Rotate (yaw 90°) + Elevation. Lucide rotate-cw line icon (no unicode glyph).
+  h += '<div style="display:flex;align-items:center;gap:7px;margin-top:9px;border-top:1px solid #2c303a;padding-top:9px">' +
+    '<button id="ins-rotbtn" style="display:flex;align-items:center;gap:5px;background:#13151a;border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:5px 9px;cursor:pointer">' +
+    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>Rotate <span id="ins-rot" style="color:#4fc3f7">0°</span></button>' +
+    '<span style="font-size:10px;color:#5b6473">(R)</span></div>';
+  h += '<div style="display:flex;align-items:center;gap:6px;margin-top:7px;font-size:11px;color:#7f8aa0">Elevation <input id="ins-elev" type="number" step="0.1" value="0" style="width:62px;box-sizing:border-box;background:#13151a;border:1px solid #2c303a;border-radius:4px;color:#c7cdd8;padding:3px 6px;outline:none"> m</div>';
   p.innerHTML = h; document.body.appendChild(p); insertPanel = p;
   p.querySelectorAll('.ins-c').forEach(b => b.onclick = () => {
     insertHash = b.getAttribute('data-hash');
     p.querySelectorAll('.ins-c').forEach(x => x.style.borderColor = '#2c303a'); b.style.borderColor = '#4fc3f7';
-    setStat('click the grid to place ' + window.Bonsai.library.get(insertHash).ifc_class);
+    setStat('move over the grid to aim, R to rotate, click to place ' + window.Bonsai.library.get(insertHash).ifc_class);
   });
+  p.querySelector('#ins-rotbtn').onclick = () => rotateInsert();
+  p.querySelector('#ins-elev').oninput = (e) => { insElev = parseFloat(e.target.value) || 0; if (ghostXY) showGhost(ghostXY.x, ghostXY.y); setStat('insert elevation ' + insElev + 'm'); };
   return p;
 }
-function enterInsert() { inserting = true; buildInsertPanel().style.display = ''; bInsert.classList.add('on'); bLod.style.display = ''; bLod.disabled = (lastInsertId == null); paintLod(); setStat('insert: pick a component, then click the grid'); }
-function exitInsert() { inserting = false; if (insertPanel) insertPanel.style.display = 'none'; bInsert.classList.remove('on'); setStat('ready'); }
+function enterInsert() { inserting = true; buildInsertPanel().style.display = ''; bInsert.classList.add('on'); bLod.style.display = ''; bLod.disabled = (lastInsertId == null); paintLod(); setStat('insert: pick a component, aim on the grid (R rotates), click to place'); }
+function exitInsert() { inserting = false; clearGhost(); if (insertPanel) insertPanel.style.display = 'none'; bInsert.classList.remove('on'); setStat('ready'); }
 bInsert.onclick = () => inserting ? exitInsert() : enterInsert();
 bLod.onclick = async () => {
   const id = lodTargetId(); if (id == null) return;
@@ -565,6 +592,16 @@ canvas.addEventListener('pointerdown', async (e) => {
   const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
   raycaster.setFromCamera(ndc, camera); const hit = new THREE.Vector3();
   if (raycaster.ray.intersectPlane(GROUND, hit)) { const s = window.Bonsai.grid.snap(hit.x, hit.y); await placeComponent(s.x, s.y); }
+});
+canvas.addEventListener('pointermove', (e) => {                  // live ghost follows the cursor while inserting
+  if (!inserting || !insertHash) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera); const hit = new THREE.Vector3();
+  if (raycaster.ray.intersectPlane(GROUND, hit)) { const s = window.Bonsai.grid.snap(hit.x, hit.y); showGhost(s.x, s.y); }
+});
+window.addEventListener('keydown', (e) => {                       // R rotates the pending insert (skip when typing in a field)
+  if (inserting && (e.key === 'r' || e.key === 'R') && !/^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '')) { e.preventDefault(); rotateInsert(); }
 });
 
 bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = false;
@@ -881,6 +918,37 @@ if (qs.get('insert') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER insert demo fail ' + e); }
     window.__insertResult = out; window.__insertDone = true;
     console.log('§MODELLER insert-done');
+  })();
+}
+// ?place=demo proves PLACEMENT CORRECTNESS (W-BONSAI-PLACE): a component lands SEATED on the ground (not
+// half-buried — the door bug), can be ROTATED before placing (R / Rotate button), and ELEVATED — each a signed
+// GEOM_INSERT; a live ghost previews the landing. Drives the REAL UI handlers.
+if (qs.get('place') === 'demo') {
+  (async () => {
+    const out = {};
+    const meshOf = (fid) => { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid); if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox; return { zmin: +b.min.z.toFixed(2), zmax: +b.max.z.toFixed(2), xext: +(b.max.x - b.min.x).toFixed(2), yext: +(b.max.y - b.min.y).toFixed(2) }; };
+    const rect = canvas.getBoundingClientRect();
+    const toClient = (gx, gy) => { const v = new THREE.Vector3(gx, gy, 0).project(camera); return { clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height }; };
+    const clickGround = async (gx, gy) => { const c = toClient(gx, gy); const before = window.Bonsai.oplog.length; canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, ...c, bubbles: true })); for (let i = 0; i < 40 && window.Bonsai.oplog.length === before; i++) await new Promise(r => setTimeout(r, 50)); };
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      window.Bonsai.oplog.clear();
+      const door = window.Bonsai.library.catalog().find(c => c.ifc_class === 'IfcDoor');
+      bInsert.onclick();
+      document.querySelector('#ins-panel .ins-c[data-hash="' + door.hash + '"]').onclick();
+      canvas.dispatchEvent(new PointerEvent('pointermove', { ...toClient(4, 3), bubbles: true }));   // ghost appears on aim
+      out.ghost = !!scene.getObjectByName('InsertGhost');
+      await clickGround(4, 3); out.seated = meshOf(lastInsertId);                                    // 1) ground: zmin≈0 zmax≈2.1, wide in X
+      insertPanel.querySelector('#ins-rotbtn').onclick(); out.rotDeg = insRot;                       // 2) rotate 90° (button)
+      await clickGround(0, 0); out.rotated = meshOf(lastInsertId);                                   //    footprint swaps to wide in Y
+      const elev = insertPanel.querySelector('#ins-elev'); elev.value = '3'; elev.oninput({ target: elev });  // 3) elevate 3m
+      await clickGround(8, 3); out.elevated = meshOf(lastInsertId);                                  //    zmin≈3 zmax≈5.1
+      out.inserts = window.Bonsai.oplog._geomOps().filter(o => o.op_type === 'GEOM_INSERT').length;
+      out.signed = window.Bonsai.oplog.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verify = (await window.Bonsai.oplog.verify()).ok;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER place demo fail ' + e); }
+    window.__placeResult = out; window.__placeDone = true;
+    console.log('§MODELLER place-done');
   })();
 }
 // ?fillet=demo proves the occt fillet/chamfer shoulders + EDGE-PICK UI (W-BONSAI-FILLET): commit a wall, select

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -44,6 +44,9 @@
   <button id="b-insert" disabled title="Insert a library component (assemble, don't draw)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16.5 9.4 7.55 4.24"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.29 7 12 12 20.71 7"/><line x1="12" x2="12" y1="22" y2="12"/></svg><span>Insert</span></button>
   <button id="b-lod" disabled style="display:none" title="Refine the selected component's level of detail (same signed row)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/></svg><span>LOD 200</span></button>
   <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
+  <button id="b-undo" disabled title="Undo last (Ctrl+Z)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg><span>Undo</span></button>
+  <button id="b-redo" disabled title="Redo (Ctrl+Shift+Z)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg><span>Redo</span></button>
+  <button id="b-del" disabled title="Delete selected (Del)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Z"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/></svg><span>Delete</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
   <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
 </div>
@@ -256,6 +259,7 @@ function highlight(mesh) {
   selectedMesh = mesh; selectedId = mesh ? mesh.userData.featureId : null;
   if (mesh && mesh.material && mesh.material.emissive) mesh.material.emissive.setHex(0x2b5a8c);
   bCut.disabled = selectedId == null;
+  const bd = document.getElementById('b-del'); if (bd) bd.disabled = selectedId == null;   // Delete acts on the selection
   window.Bonsai._selId = selectedId;                       // mirror to Outliner so 3D pick highlights its row
   if (window.Bonsai.outliner) window.Bonsai.outliner.setActive(selectedId);   // restyle the active row only — no DB query / tree rebuild per pick
   console.log('§MODELLER select featureId=' + selectedId);
@@ -604,6 +608,31 @@ window.addEventListener('keydown', (e) => {                       // R rotates t
   if (inserting && (e.key === 'r' || e.key === 'R') && !/^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '')) { e.preventDefault(); rotateInsert(); }
 });
 
+// ── EDIT: Delete (selected) / Undo / Redo (operability leg 2) — soft-delete via the signed op-log ──────
+const bUndo = document.getElementById('b-undo'), bRedo = document.getElementById('b-redo'), bDel = document.getElementById('b-del');
+function refreshEditButtons() {                                   // enable Undo/Redo by what's available
+  const O = window.Bonsai.oplog; if (!O || !O.db) { bUndo.disabled = bRedo.disabled = true; return; }
+  const all = O._allGeom();
+  bUndo.disabled = !all.some(o => !o.undone);
+  bRedo.disabled = !all.some(o => o.undone);
+}
+window.addEventListener('bonsai:oplog', refreshEditButtons);
+async function deleteSelected() {
+  if (selectedId == null) return;
+  const id = selectedId; await window.Bonsai.oplog.deleteFeature(id); highlight(null); audioCue('cut');
+  setStat('deleted feature #' + id); syncHistory();
+}
+bDel.onclick = () => deleteSelected();
+bUndo.onclick = async () => { const r = await window.Bonsai.oplog.undo(); if (r.undone != null) { if (selectedId === r.undone) highlight(null); audioCue('clear'); setStat('undo #' + r.undone); syncHistory(); } };
+bRedo.onclick = async () => { const r = await window.Bonsai.oplog.redo(); if (r.redone != null) { audioCue('tick'); setStat('redo #' + r.redone); syncHistory(); } };
+window.addEventListener('keydown', (e) => {
+  const typing = /^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '');
+  if (typing) return;
+  if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z')) { e.preventDefault(); (e.shiftKey ? bRedo : bUndo).onclick(); }
+  else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || e.key === 'Y')) { e.preventDefault(); bRedo.onclick(); }
+  else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedId != null && !sketching && !routing) { e.preventDefault(); deleteSelected(); }
+});
+
 bWall.disabled = bOpen.disabled = bClear.disabled = bSketch.disabled = bIfc.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = false;
 window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
 // Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
@@ -949,6 +978,41 @@ if (qs.get('place') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER place demo fail ' + e); }
     window.__placeResult = out; window.__placeDone = true;
     console.log('§MODELLER place-done');
+  })();
+}
+// ?edit=demo proves EDITABILITY (W-BONSAI-EDIT): delete a single feature, cascade-delete a parent (its cut child
+// goes too — no fold break), and undo/redo (LIFO) — all via soft-delete over the SIGNED op-log (chain stays valid).
+if (qs.get('edit') === 'demo') {
+  (async () => {
+    const out = {}; const O = window.Bonsai.oplog;
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      const lib = window.Bonsai.library.catalog();
+      // DELETE: wall + cut(child of wall) + door insert → 3 active
+      O.clear();
+      const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
+      await O.commit({ op_type: 'GEOM_CUT', parameters: { parent: wall.id, void: { c1: [1, -1, 1], c2: [2, 1, 2] } } });
+      const ins = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: lib.find(c => c.ifc_class === 'IfcDoor').hash, placement: { x: 6, y: 1, z: 0, rot: 0 }, lod: '200' } });
+      out.start = O.length;                              // 3
+      window.Bonsai.select(ins.id); await deleteSelected();
+      out.afterDeleteDoor = O.length;                    // 2
+      out.verifyA = (await O.verify()).ok;
+      await O.deleteFeature(wall.id);                    // delete wall → cascades the cut child
+      out.afterDeleteWall = O.length;                    // 0 (no "GEOM_CUT parent not found" fold error)
+      out.verifyB = (await O.verify()).ok;
+      // UNDO/REDO (LIFO): wall + column
+      O.clear();
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
+      await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: lib.find(c => c.ifc_class === 'IfcColumn').hash, placement: { x: 6, y: 1, z: 0, rot: 0 }, lod: '200' } });
+      out.u0 = O.length;                                 // 2
+      await O.undo(); out.u1 = O.length;                 // 1
+      await O.undo(); out.u2 = O.length;                 // 0
+      await O.redo(); out.r1 = O.length;                 // 1
+      await O.redo(); out.r2 = O.length;                 // 2
+      out.verifyC = (await O.verify()).ok;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER edit demo fail ' + e); }
+    window.__editResult = out; window.__editDone = true;
+    console.log('§MODELLER edit-done');
   })();
 }
 // ?fillet=demo proves the occt fillet/chamfer shoulders + EDGE-PICK UI (W-BONSAI-FILLET): commit a wall, select

--- a/viewer/tests/bonsai_edit_live.js
+++ b/viewer/tests/bonsai_edit_live.js
@@ -1,0 +1,42 @@
+// W-BONSAI-EDIT — editability witness (operability leg 2). prompts/BONSAI_KERNEL_RESEARCH.md.
+// CLAIM: you can now EDIT a model — DELETE a single feature, CASCADE-delete a parent (its cut child goes too,
+// with no fold break), and UNDO/REDO (LIFO) — all via soft-delete (the kernel_ops `undone` flag, which is NOT
+// in the signed payload) so the append-only chain stays VALID throughout. Fixes the "can't change/delete = fails
+// basic AD usage" gap. Drives the engine edit API the toolbar buttons + Ctrl+Z/Del call.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|LIBRARY|KRN|BONSAI)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html?edit=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__editDone === true', { timeout: 120000 }).catch(() => console.log('  ✗ timeout'));
+
+  const x = await pg.evaluate(() => window.__editResult || {}).catch(e => ({ err: String(e) }));
+  console.log('  §BONSAI-EDIT start=' + x.start + ' afterDeleteDoor=' + x.afterDeleteDoor + ' verifyA=' + x.verifyA +
+    ' afterDeleteWall=' + x.afterDeleteWall + ' verifyB=' + x.verifyB +
+    ' undo[' + x.u0 + '→' + x.u1 + '→' + x.u2 + '] redo[→' + x.r1 + '→' + x.r2 + '] verifyC=' + x.verifyC + (x.error ? ' ERROR=' + x.error : ''));
+  await br.close(); server.close();
+
+  const deleteOne = x.start === 3 && x.afterDeleteDoor === 2 && x.verifyA === true;        // single leaf delete, chain valid
+  const cascade = x.afterDeleteWall === 0 && x.verifyB === true;                            // parent delete takes its cut child, no fold break
+  const undoRedo = x.u0 === 2 && x.u1 === 1 && x.u2 === 0 && x.r1 === 1 && x.r2 === 2 && x.verifyC === true;  // LIFO, chain valid
+  const pass = deleteOne && cascade && undoRedo;
+  console.log('  §BONSAI-EDIT VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — deleteOneFeature=' + deleteOne + ' cascadeDeleteParent=' + cascade + ' undoRedoLIFO=' + undoRedo);
+  console.log('── W-BONSAI-EDIT ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_place_live.js
+++ b/viewer/tests/bonsai_place_live.js
@@ -1,0 +1,47 @@
+// W-BONSAI-PLACE — placement correctness witness (operability leg 1). prompts/BONSAI_KERNEL_RESEARCH.md.
+// CLAIM: an inserted library component now lands CORRECTLY — SEATED on the ground (its bbox bottom at the
+// placement elevation, not half-buried), ROTATABLE before placing (R / Rotate button yaws it 90°, footprint
+// turns), and ELEVATABLE (placed at a chosen Z) — each a signed GEOM_INSERT, with a live ghost preview while
+// aiming. Fixes the "door won't stand right / can't aim it" operability gap. Drives the REAL UI handlers.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|LIBRARY|KRN|BONSAI)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html?place=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__placeDone === true', { timeout: 120000 }).catch(() => console.log('  ✗ timeout'));
+
+  const x = await pg.evaluate(() => window.__placeResult || {}).catch(e => ({ err: String(e) }));
+  const J = o => JSON.stringify(o);
+  console.log('  §BONSAI-PLACE ghost=' + x.ghost + ' seated=' + J(x.seated) + ' rotDeg=' + x.rotDeg + ' rotated=' + J(x.rotated) +
+    ' elevated=' + J(x.elevated) + ' inserts=' + x.inserts + ' signed=' + x.signed + ' verify=' + x.verify + (x.error ? ' ERROR=' + x.error : ''));
+  await br.close(); server.close();
+
+  const S = x.seated || {}, R = x.rotated || {}, E = x.elevated || {};
+  const seated = S.zmin != null && Math.abs(S.zmin) <= 0.02 && S.zmax > 2.0 && S.zmax < 2.2;   // sits ON ground, full height (NOT -1.05..1.05)
+  const footprintWideX = S.xext > S.yext + 0.5;                                                // door faces +X by default (W=1.78 >> T=0.15)
+  const rotated = x.rotDeg === 90 && R.yext > R.xext + 0.5;                                     // after 90° yaw the footprint turns (now wide in Y)
+  const elevated = E.zmin != null && Math.abs(E.zmin - 3) <= 0.02 && E.zmax > 5.0 && E.zmax < 5.2;  // seated at elevation 3m
+  const allSigned = x.inserts === 3 && x.signed === 3 && x.verify === true;
+  const ghost = x.ghost === true;
+  const pass = seated && footprintWideX && rotated && elevated && allSigned && ghost;
+  console.log('  §BONSAI-PLACE VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — groundSeated=' + seated + ' correctFootprint=' + footprintWideX + ' rotateBeforePlace=' + rotated +
+    ' elevation=' + elevated + ' threeSignedInserts=' + allSigned + ' ghostPreview=' + ghost);
+  console.log('── W-BONSAI-PLACE ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
First slice of the modeller operability fixes (from the code-grounded audit). Addresses the door pain + the editability blocker, witness-first.

**Leg 1 — placement correctness (`W-BONSAI-PLACE`)** — fixes "the door won't stand right / can't aim it":
- **Ground-seat**: a component's local bbox bottom now lands at `placement.z` (default 0). The Door (local z −1.05→1.05) now sits **0→2.1**, not half-buried.
- Also fixes a real pre-existing bug: `boxArrays` mis-mapped the bbox axes (`[minx,maxx,miny,maxy,minz,maxz]` read as `[x0,y0,z0,...]`) so the LOD-200 proxy was malformed since #377.
- **Rotate** before placing (R key / Rotate button, 90° steps) + **Elevation** (numeric, m) + a live translucent **ghost** preview following the cursor; library buttons show W×H.

**Leg 2 — edit core (`W-BONSAI-EDIT`)** — fixes "can't change/delete = fails basic AD usage":
- **Delete-one** (+ cascade: deleting a wall takes its cut child, no fold break), **Undo/Redo** (LIFO) — soft-delete via the `undone` flag, which is NOT in the signed payload, so `verifyChain` stays valid and edits are reversible.
- Undo/Redo/Delete toolbar buttons + Ctrl+Z / Ctrl+Shift+Z / Del shortcuts.

Witnesses (this run): PLACE — seated 0..2.1, 90° rotate turns footprint, elev 3m→3..5.1, ghost, 3 signed, verify ok. EDIT — delete leaf 3→2, cascade →0, undo/redo 2→1→0→1→2, verify ok throughout. No regression: INSERT/RECIPE/ROUTE/GRIDMOVE/SIGNED PASS.

Together with leg 1's rotate/elevate, **delete + re-place is now a complete edit loop.** Follow-ups (v2): grid-move feedback, timeline labels, persistence, numeric dimension input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>