### PR TITLE
feat(modeller): Operability v2 — persistence + timeline labels + Escape/point-undo

### DIFF
--- a/viewer/bonsai_oplog.js
+++ b/viewer/bonsai_oplog.js
@@ -22,7 +22,10 @@
     async _ensureDb() {
       if (this.db) return this.db;
       const SQL = await window.initSqlJs({ locateFile: f => new URL('lib/' + f, _base).href });
-      this.db = new SQL.Database();
+      // PERSISTENCE: restore the saved signed op-log from localStorage so work survives a reload.
+      const saved = this._loadBytes();
+      if (saved) { try { this.db = new SQL.Database(saved); console.log(TAG + ' restored saved model bytes=' + saved.length); } catch (e) { console.warn(TAG + ' restore failed ' + e); this.db = new SQL.Database(); } }
+      else this.db = new SQL.Database();
       window.KernelOps.ensureTable(this.db);
       // W-SIGN: install an edge signer so every committed op carries a verifiable signature over its op_hash.
       window.KernelOps.setSigner({
@@ -30,12 +33,30 @@
         verify: async (h, s) => s === await sha256hex(SECRET + '|' + h)
       });
       this._signed = true;
-      console.log(TAG + ' signed DB ready (kernel_ops chain + edge signer)');
+      // restore the group counter so new commits mint fresh gids (max existing group ordinal).
+      try { const r = this.db.exec("SELECT gid FROM kernel_ops WHERE gid LIKE 'geom-grp-%'"); if (r.length) this._n = r[0].values.reduce((m, v) => Math.max(m, parseInt(String(v[0]).replace('geom-grp-', '')) || 0), 0); } catch (e) { }
+      console.log(TAG + ' signed DB ready (kernel_ops chain + edge signer) groups=' + this._n);
       return this.db;
     },
 
-    _emit() { try { window.dispatchEvent(new CustomEvent('bonsai:oplog')); } catch (e) { } },
-    clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; this._emit(); },
+    // ---- PERSISTENCE: autosave the whole signed op-log to localStorage on every change; restore on boot.
+    // A modelling session's kernel_ops db is small (KB–tens of KB) → well within the localStorage budget.
+    _KEY: 'bonsai_model_v1',
+    _b64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); },
+    _unb64(b64) { const bin = atob(b64); const u8 = new Uint8Array(bin.length); for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i); return u8; },
+    _loadBytes() { try { const s = localStorage.getItem(this._KEY); return s ? this._unb64(s) : null; } catch (e) { return null; } },
+    _save() { try { if (this.db) localStorage.setItem(this._KEY, this._b64(this.db.export())); } catch (e) { console.warn(TAG + ' save failed ' + e); } },
+
+    // Boot-time restore: ensure the db (loads saved bytes), then fold it to the scene if non-empty.
+    async restore() {
+      await this._ensureDb();
+      if (this.length) { await this._foldUpto(); this._emit(); }
+      console.log(TAG + ' restore active=' + this.length);
+      return this.length;
+    },
+
+    _emit() { try { window.dispatchEvent(new CustomEvent('bonsai:oplog')); } catch (e) { } this._save(); },
+    clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; try { localStorage.removeItem(this._KEY); } catch (e) { } this._emit(); },
 
     // Read the live GEOM ops out of the signed log, mapped to fold-op shape (parent rides in parameters).
     _geomOps() {

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -421,13 +421,30 @@ bApplyFillet.onclick = async () => {
 
 // ── HISTORY SCRUBBER ────────────────────────────────────────────────────────────────────────────
 const slider = document.getElementById('hist-slider'), histLabel = document.getElementById('hist-label');
+// Human label for a feature op so the timeline reads "3/5 · Door" instead of a bare number (operability).
+function featLabel(op) {
+  if (!op) return ''; const P = op.parameters || {};
+  switch (op.op_type) {
+    case 'GEOM_EXTRUDE_POLY': return 'Wall'; case 'GEOM_EXTRUDE': return 'Wall';
+    case 'GEOM_CUT': return 'Opening'; case 'GEOM_SWEEP': return 'Route';
+    case 'GEOM_FILLET': return P.kind === 'chamfer' ? 'Chamfer' : 'Round'; case 'GEOM_GRID_MOVE': return 'Grid move';
+    case 'GEOM_INSERT': { const c = window.Bonsai.library && window.Bonsai.library.get(P.hash); return c ? c.ifc_class.replace('Ifc', '') : 'Component'; }
+    default: return op.op_type.replace('GEOM_', '');
+  }
+}
+function histStamp(val) {
+  const O = window.Bonsai.oplog; const n = O.length; const ops = O.db ? O._geomOps() : [];
+  const at = val > 0 ? ops[val - 1] : null;
+  histLabel.textContent = val + '/' + n + (at ? ' · ' + featLabel(at) : '');
+  slider.title = ops.length ? ops.map((o, i) => (i + 1) + '. ' + featLabel(o)).join('\n') : '';   // hover = full step list
+}
 function syncHistory() {
   const n = window.Bonsai.oplog.length;
   slider.max = n; slider.value = window.Bonsai.oplog.cursor; slider.disabled = n === 0;
-  histLabel.textContent = slider.value + '/' + n;
+  histStamp(+slider.value);
 }
 slider.addEventListener('input', async () => {
-  histLabel.textContent = slider.value + '/' + window.Bonsai.oplog.length;
+  histStamp(+slider.value);
   await window.Bonsai.oplog.scrubTo(+slider.value);
 });
 
@@ -628,8 +645,15 @@ bRedo.onclick = async () => { const r = await window.Bonsai.oplog.redo(); if (r.
 window.addEventListener('keydown', (e) => {
   const typing = /^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '');
   if (typing) return;
+  if (e.key === 'Escape') {                                       // cancel whatever mode is active
+    if (sketching) exitSketch(); else if (routing) exitRoute(); else if (edgePicking) exitFillet();
+    else if (gridMoving) exitGridMove(); else if (inserting) exitInsert(); else { highlight(null); }
+    return;
+  }
   if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z')) { e.preventDefault(); (e.shiftKey ? bRedo : bUndo).onclick(); }
   else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || e.key === 'Y')) { e.preventDefault(); bRedo.onclick(); }
+  else if (e.key === 'Backspace' && sketching && window.Bonsai.sketch.points.length) { e.preventDefault(); window.Bonsai.sketch.points.pop(); sketchMarkers(); setStat('sketch: ' + window.Bonsai.sketch.points.length + ' points'); }
+  else if (e.key === 'Backspace' && routing && routePts.length) { e.preventDefault(); routePts.pop(); routeMarkers(); bRun.disabled = routePts.length < 2; setStat('route: ' + routePts.length + ' points'); }
   else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedId != null && !sketching && !routing) { e.preventDefault(); deleteSelected(); }
 });
 
@@ -660,6 +684,11 @@ console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai
 
 // Headless witness hooks. ?author=wall|opening|both auto-authors the sample ops.
 const qs = new URLSearchParams(location.search);
+// PERSISTENCE: restore the saved signed model on boot so work survives a reload — unless a demo hook runs
+// (demos clear() and drive their own state). Folds the restored op-log to the scene + refreshes panels.
+if (![...qs.keys()].some(k => /^(author|recipe|preload|outliner|grid|ifc|signed|fastauthor|sweep|route|fillet|constrain|gridmove|sketch|insert|place|edit|ux)$/.test(k))) {
+  (async () => { try { const n = await window.Bonsai.oplog.restore(); if (n) { syncHistory(); setStat('restored ' + n + ' feature' + (n === 1 ? '' : 's') + ' from your last session'); } } catch (e) { console.warn('§MODELLER restore fail ' + e); } window.__restoreDone = true; })();
+}
 const q = qs.get('author');
 if (q) {
   (async () => {
@@ -1013,6 +1042,31 @@ if (qs.get('edit') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER edit demo fail ' + e); }
     window.__editResult = out; window.__editDone = true;
     console.log('§MODELLER edit-done');
+  })();
+}
+// ?ux=demo proves feedback wins (W-BONSAI-UX): Backspace undoes the last sketch point, Escape cancels a mode,
+// and the history timeline now LABELS each step (e.g. "2/2 · Door") instead of a bare number.
+if (qs.get('ux') === 'demo') {
+  (async () => {
+    const out = {};
+    try {
+      window.Bonsai.oplog.clear();
+      bSketch.onclick(); out.enteredSketch = sketching;                                  // enter sketch mode
+      window.Bonsai.sketch.addPoint(0, 0); window.Bonsai.sketch.addPoint(4, 0); window.Bonsai.sketch.addPoint(4, 3); sketchMarkers();
+      out.ptsBefore = window.Bonsai.sketch.points.length;                                 // 3
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace' }));           // point-undo
+      out.ptsAfter = window.Bonsai.sketch.points.length;                                  // 2
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));              // cancel sketch mode
+      out.escExited = !sketching;
+      const O = window.Bonsai.oplog;
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
+      await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: window.Bonsai.library.catalog().find(c => c.ifc_class === 'IfcDoor').hash, placement: { x: 6, y: 1, z: 0, rot: 0 }, lod: '200' } });
+      syncHistory();
+      out.histLabel = document.getElementById('hist-label').textContent;                  // "2/2 · Door"
+      out.sliderTitle = document.getElementById('hist-slider').title;                     // "1. Wall\n2. Door"
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER ux demo fail ' + e); }
+    window.__uxResult = out; window.__uxDone = true;
+    console.log('§MODELLER ux-done');
   })();
 }
 // ?fillet=demo proves the occt fillet/chamfer shoulders + EDGE-PICK UI (W-BONSAI-FILLET): commit a wall, select

--- a/viewer/tests/bonsai_persist_live.js
+++ b/viewer/tests/bonsai_persist_live.js
@@ -1,0 +1,56 @@
+// W-BONSAI-PERSIST — persistence witness (operability leg 3). prompts/BONSAI_KERNEL_RESEARCH.md.
+// CLAIM: authored work SURVIVES A RELOAD. The signed op-log autosaves to localStorage on every change and is
+// restored + re-folded on boot. Fixes the "reload loses everything" blocker. Same browser context, two loads.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const url = `http://localhost:${port}/modeller.html`;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|LIBRARY|KRN)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+
+  // --- LOAD 1: author a wall + a door, which autosaves to localStorage ---
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true', { timeout: 60000 }).catch(() => {});
+  const a = await pg.evaluate(async () => {
+    const O = window.Bonsai.oplog; O.clear();
+    await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
+    const door = window.Bonsai.library.catalog().find(c => c.ifc_class === 'IfcDoor');
+    await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: door.hash, placement: { x: 6, y: 1, z: 0, rot: 0 }, lod: '200' } });
+    return { len: O.length, tip: ((await O.verify()).tip || '').slice(0, 12), saved: !!localStorage.getItem('bonsai_model_v1') };
+  }).catch(e => ({ err: String(e) }));
+  console.log('  §BONSAI-PERSIST authored len=' + a.len + ' tip=' + a.tip + ' savedToLocalStorage=' + a.saved);
+
+  // --- LOAD 2: reload (same context → localStorage persists). restore() should re-fold the saved model. ---
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__restoreDone === true', { timeout: 60000 }).catch(() => console.log('  ✗ no __restoreDone'));
+  const b = await pg.evaluate(async () => {
+    const O = window.Bonsai.oplog; for (let i = 0; i < 60 && !O.db; i++) await new Promise(r => setTimeout(r, 50));
+    const v = await O.verify(); const g = window.Bonsai.group && window.Bonsai.group();
+    return { len: O.length, tip: (v.tip || '').slice(0, 12), verify: v.ok, meshes: g ? g.children.filter(o => o.isMesh).length : 0 };
+  }).catch(e => ({ err: String(e) }));
+  console.log('  §BONSAI-PERSIST afterReload len=' + b.len + ' tip=' + b.tip + ' verify=' + b.verify + ' meshes=' + b.meshes + (b.err ? ' ERR=' + b.err : ''));
+  await br.close(); server.close();
+
+  const authored = a.len === 2 && a.saved === true;
+  const restored = b.len === 2 && b.meshes === 2 && b.verify === true;     // both features back in the scene
+  const identical = b.tip === a.tip && !!a.tip;                            // same signed chain tip = byte-faithful restore
+  const pass = authored && restored && identical;
+  console.log('  §BONSAI-PERSIST VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — authoredAndSaved=' + authored + ' restoredOnReload=' + restored + ' chainTipIdentical=' + identical);
+  console.log('── W-BONSAI-PERSIST ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/bonsai_ux_live.js
+++ b/viewer/tests/bonsai_ux_live.js
@@ -1,0 +1,39 @@
+// W-BONSAI-UX — interaction feedback witness (operability leg 4). prompts/BONSAI_KERNEL_RESEARCH.md.
+// CLAIM: basic feedback works — Backspace undoes the last sketch point, Escape cancels the active mode, and the
+// history timeline LABELS each step ("2/2 · Door", hover lists all steps) instead of a bare number.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|LIBRARY)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html?ux=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__uxDone === true', { timeout: 120000 }).catch(() => console.log('  ✗ timeout'));
+
+  const x = await pg.evaluate(() => window.__uxResult || {}).catch(e => ({ err: String(e) }));
+  console.log('  §BONSAI-UX enteredSketch=' + x.enteredSketch + ' ptsBefore=' + x.ptsBefore + ' ptsAfter=' + x.ptsAfter +
+    ' escExited=' + x.escExited + ' histLabel="' + x.histLabel + '" sliderTitle=' + JSON.stringify(x.sliderTitle) + (x.error ? ' ERROR=' + x.error : ''));
+  await br.close(); server.close();
+
+  const pointUndo = x.enteredSketch === true && x.ptsBefore === 3 && x.ptsAfter === 2;     // Backspace removed last point
+  const escape = x.escExited === true;                                                      // Escape cancelled the mode
+  const timelineLabelled = /· Door$/.test(x.histLabel || '') && /Wall/.test(x.sliderTitle || '') && /Door/.test(x.sliderTitle || '');
+  const pass = pointUndo && escape && timelineLabelled;
+  console.log('  §BONSAI-UX VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — backspacePointUndo=' + pointUndo + ' escapeCancels=' + escape + ' timelineLabelled=' + timelineLabelled);
+  console.log('── W-BONSAI-UX ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
Second operability slice, witness-first.

**Leg 3 — persistence (`W-BONSAI-PERSIST`)** — fixes the "reload loses everything" blocker: the signed op-log autosaves to localStorage on every change and is restored + re-folded on boot. Restore is byte-faithful (same signed chain tip after reload). `clear()` wipes the key; the group counter is recovered so new commits mint fresh gids.

**Leg 4 — feedback (`W-BONSAI-UX`)**:
- **Escape** cancels any active mode (sketch/route/fillet/grid-move/insert).
- **Backspace** undoes the last sketch/route point (falls through to delete-selected otherwise).
- **Timeline labels**: the history scrubber now reads "2/2 · Door" with a hover list of every step, instead of a bare number — your named timeline gap.

Witnesses: PERSIST — author 2 → reload → 2 meshes restored, chain tip identical. UX — Backspace 3→2 points, Escape exits, timeline labelled. No regression: PLACE/EDIT/INSERT/RECIPE/ROUTE/SKETCH/GRIDMOVE PASS.

Remaining from the audit (v3): grid-move preview (which walls translate/stretch), numeric dimension input (extrude depth / sweep profile), real catalog (httpvfs), branch history tree, vertex/edge snapping, camera zoom-to-fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>