### PR TITLE
feat(modeller): Operability v4 — camera zoom-to-fit + view presets

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -29,6 +29,8 @@
 <canvas id="c"></canvas>
 <div id="bar">
   <button id="b-home" title="Back to the Matrix" onclick="location.href='../index2.html?home=1'"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg><span>Home</span></button>
+  <button id="b-fit" title="Zoom to fit (F) — frames the selection, or all"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg><span>Fit</span></button>
+  <button id="b-view" title="Cycle view: Iso / Top"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3 8 9 5 9-5"/><path d="M12 13v8"/></svg><span>Iso</span></button>
   <button id="b-wall" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Wall</span></button>
   <button id="b-open" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg><span>Opening</span></button>
   <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
@@ -134,6 +136,40 @@ window.addEventListener('resize', () => {
   controls.update();
   renderer.render(scene, camera);
 })();
+
+// ── CAMERA: zoom-to-fit + view presets (operability v4) — geometry is Z-up but camera.up stays Y so the
+// sketch plan view (looking straight down −Z) isn't degenerate; presets are limited to Iso/Top accordingly.
+const bFit = document.getElementById('b-fit'), bView = document.getElementById('b-view');
+const VIEWS = [{ name: 'Iso', dir: new THREE.Vector3(1, 0.85, 1) }, { name: 'Top', dir: new THREE.Vector3(0, 0.001, 1) }];
+let _viewIdx = 0;
+function _authoredBox() {
+  const g = window.Bonsai.group && window.Bonsai.group();
+  if (!g || !g.children.length) return null;
+  const box = new THREE.Box3().setFromObject(g);
+  return box.isEmpty() ? null : box;
+}
+function frameBox(box, dir) {
+  if (!box) return false;
+  const c = box.getCenter(new THREE.Vector3()), s = box.getSize(new THREE.Vector3());
+  const radius = Math.max(s.x, s.y, s.z, 0.5) * 0.5;
+  const dist = radius / Math.sin((camera.fov * Math.PI / 180) / 2) * 1.3 + radius;   // fit the bounding sphere + margin
+  const d = (dir || VIEWS[_viewIdx].dir).clone().normalize();
+  controls.target.copy(c); camera.position.copy(c).addScaledVector(d, dist); controls.update();
+  if (window.A && A.requestRender) A.requestRender();
+  return true;
+}
+function fitView() {
+  const box = (typeof selectedMesh !== 'undefined' && selectedMesh) ? new THREE.Box3().setFromObject(selectedMesh) : _authoredBox();
+  if (frameBox(box, VIEWS[_viewIdx].dir)) setStat((typeof selectedMesh !== 'undefined' && selectedMesh) ? 'framed selection' : 'framed all'); else setStat('nothing to frame');
+}
+bFit.onclick = () => fitView();
+bView.onclick = () => {
+  _viewIdx = (_viewIdx + 1) % VIEWS.length; const v = VIEWS[_viewIdx]; bView.querySelector('span').textContent = v.name;
+  frameBox(_authoredBox() || new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(4, 3, 3)), v.dir); setStat('view: ' + v.name);
+};
+window.addEventListener('keydown', (e) => {
+  if ((e.key === 'f' || e.key === 'F') && !/^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '')) { e.preventDefault(); fitView(); }
+});
 
 // ── Sample op-rows (kernel_ops-shaped) — same params proven by W-KERNEL-FOLD / W-KERNEL-SIGNED.
 const WALL = { id: 1, op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 4, h: 0.2 }, dir: [0, 0, 3] } };
@@ -717,7 +753,7 @@ console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai
 const qs = new URLSearchParams(location.search);
 // PERSISTENCE: restore the saved signed model on boot so work survives a reload — unless a demo hook runs
 // (demos clear() and drive their own state). Folds the restored op-log to the scene + refreshes panels.
-if (![...qs.keys()].some(k => /^(author|recipe|preload|outliner|grid|ifc|signed|fastauthor|sweep|route|fillet|constrain|gridmove|gmpreview|sketch|insert|place|edit|ux|numdim)$/.test(k))) {
+if (![...qs.keys()].some(k => /^(author|recipe|preload|outliner|grid|ifc|signed|fastauthor|sweep|route|fillet|constrain|gridmove|gmpreview|sketch|insert|place|edit|ux|numdim|camera)$/.test(k))) {
   (async () => { try { const n = await window.Bonsai.oplog.restore(); if (n) { syncHistory(); setStat('restored ' + n + ' feature' + (n === 1 ? '' : 's') + ' from your last session'); } } catch (e) { console.warn('§MODELLER restore fail ' + e); } window.__restoreDone = true; })();
 }
 const q = qs.get('author');
@@ -1297,6 +1333,29 @@ if (qs.get('numdim') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER numdim demo fail ' + e); }
     window.__numdimResult = out; window.__numdimDone = true;
     console.log('§MODELLER numdim-done');
+  })();
+}
+// ?camera=demo proves CAMERA fit + view presets (W-BONSAI-CAMERA): a wall authored far from the default view is
+// brought into frame by Fit (target jumps to its centre), and the View button cycles to a Top (plan) view.
+if (qs.get('camera') === 'demo') {
+  (async () => {
+    const out = {}; const O = window.Bonsai.oplog;
+    try {
+      O.clear();
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[20, 0], [24, 0], [24, 0.2], [20, 0.2]] }, depth: 3 } });   // far from default view (~x22)
+      const b = new THREE.Box3().setFromObject(window.Bonsai.group()); const c = b.getCenter(new THREE.Vector3());
+      out.centerX = +c.x.toFixed(1);
+      out.targetBeforeX = +controls.target.x.toFixed(1);                       // default ~2 (geometry off-frame)
+      bFit.onclick();                                                          // Fit → frame all
+      out.targetAfterX = +controls.target.x.toFixed(1);                        // ≈ centerX
+      out.camDist = +camera.position.distanceTo(controls.target).toFixed(1);
+      bView.onclick();                                                         // cycle to Top
+      out.viewLabel = bView.querySelector('span').textContent;
+      const dx = Math.abs(camera.position.x - controls.target.x), dy = Math.abs(camera.position.y - controls.target.y), dz = camera.position.z - controls.target.z;
+      out.topIsAbove = dz > Math.max(dx, dy);                                  // Top = camera mostly above (+Z)
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER camera demo fail ' + e); }
+    window.__cameraResult = out; window.__cameraDone = true;
+    console.log('§MODELLER camera-done');
   })();
 }
 // ?sketch=demo drives a deliberately NOISY hand-drawn quad through the solver -> extrude (W-BONSAI-SKETCH).

--- a/viewer/tests/bonsai_camera_live.js
+++ b/viewer/tests/bonsai_camera_live.js
@@ -1,0 +1,40 @@
+// W-BONSAI-CAMERA — camera fit + view presets witness (operability v4). prompts/BONSAI_KERNEL_RESEARCH.md.
+// CLAIM: you can navigate — Zoom-to-fit frames geometry that's off-screen (orbit target jumps to its centre at a
+// sensible distance), and the View button cycles to a Top (plan) view. Fixes "no zoom-to-fit / no view presets".
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|KRN)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html?camera=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__cameraDone === true', { timeout: 120000 }).catch(() => console.log('  ✗ timeout'));
+
+  const x = await pg.evaluate(() => window.__cameraResult || {}).catch(e => ({ err: String(e) }));
+  console.log('  §BONSAI-CAMERA centerX=' + x.centerX + ' targetBeforeX=' + x.targetBeforeX + ' targetAfterX=' + x.targetAfterX +
+    ' camDist=' + x.camDist + ' viewLabel=' + x.viewLabel + ' topIsAbove=' + x.topIsAbove + (x.error ? ' ERROR=' + x.error : ''));
+  await br.close(); server.close();
+
+  const wasOffFrame = Math.abs((x.targetBeforeX || 0) - (x.centerX || 0)) > 10;        // geometry started far from the view
+  const fitFramed = Math.abs((x.targetAfterX || 0) - (x.centerX || 0)) < 0.6;          // Fit moved the orbit target onto it
+  const saneDist = x.camDist > 1 && x.camDist < 30;                                     // framed at a reasonable distance
+  const topPreset = x.viewLabel === 'Top' && x.topIsAbove === true;                     // View cycled to a plan view
+  const pass = wasOffFrame && fitFramed && saneDist && topPreset;
+  console.log('  §BONSAI-CAMERA VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — startedOffFrame=' + wasOffFrame + ' fitFramedGeometry=' + fitFramed + ' saneDistance=' + saneDist + ' topViewPreset=' + topPreset);
+  console.log('── W-BONSAI-CAMERA ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
Fourth operability slice. **Fit** button (key **F**) frames the selection or all geometry; **View** button cycles **Iso ↔ Top** (plan). camera.up stays Y so the sketch plan view isn't degenerate (Front omitted by design).

Witness `W-BONSAI-CAMERA`: a wall far off-frame (x~22) is brought into view by Fit (orbit target 2→22, sane distance), View cycles to a Top preset. No regression: PLACE/EDIT/SKETCH/GRIDMOVE/INSERT PASS.

Remaining (v5): vertex/edge snapping to existing geometry, real 23k-part catalog (httpvfs), branch history tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>