### PR TITLE
Connect Scene P0+P1: shared cross-surface context (Modeller ⇄ Viewer) + DAGeVu rebrand

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -424,7 +424,7 @@ function openTab(url){ sfxPress(); L('§OPEN tab '+url); window.open(url,'_blank
 window.addEventListener('keydown', function(e){ if(e.key==='Escape'){ closeHub(); } });
 function launchModeller(){
   // Bonsai authoring is desktop-only (heavy occt-wasm kernel). On mobile → polite note, no launch.
-  if(isMobile()){ sfxPress(); L('§BONSAI-LAUNCH blocked mobile → desktop-only note'); toast('BIM authoring (Bonsai) is a desktop experience &mdash; open it on a larger screen.'); return; }
+  if(isMobile()){ sfxPress(); L('§BONSAI-LAUNCH blocked mobile → desktop-only note'); toast('BIM authoring (DAGeVu) is a desktop experience &mdash; open it on a larger screen.'); return; }
   // lazy-mount: occt bytes are warm; the worker spins inside modeller.html on demand.
   sfxPress(); L('§BONSAI-LAUNCH → viewer/modeller.html (occt bytes warm, worker spins there)');
   location.href='viewer/modeller.html';

--- a/viewer/connect_scene.js
+++ b/viewer/connect_scene.js
@@ -33,6 +33,8 @@
     _acks: Object.create(null),                  // ping mid -> collector(from)
     _wired: false,
     _onState: null,                              // optional indicator hook: fn(true|false)
+    _bc: null,                                   // BroadcastChannel — same-origin N-surface fan-out
+    _seen: [],                                   // recent envelope keys (dedup across dual transports)
 
     // Register this surface and wire the inbound listener. Idempotent.
     register(surface) {
@@ -92,14 +94,26 @@
       return ws;
     },
     _fanout(env) {
-      const ws = this._peerWindows();
-      ws.forEach((w) => { try { w.postMessage(env, '*'); } catch (e) {} });
-      // same-document peers (other surfaces sharing this window) hear it via a local event too.
+      // (a) same-origin N-surface fan-out (independent tabs/iframes) — the primary cross-surface transport.
+      if (this._bc) { try { this._bc.postMessage(env); } catch (e) {} }
+      // (b) window-tree peers (host parent + embedded child frames) — covers the ERP↔embedded-viewer case
+      //     and any cross-origin embed BroadcastChannel can't reach. Dedup by mid stops double-delivery.
+      this._peerWindows().forEach((w) => { try { w.postMessage(env, '*'); } catch (e) {} });
+      // (c) same-document peers (other modules sharing this window) hear it via a local event too.
       try { window.dispatchEvent(new CustomEvent('connect:local', { detail: env })); } catch (e) {}
+    },
+
+    // True the FIRST time an envelope is seen (per transport-independent key) — drops dual-transport echoes.
+    _dupe(env) {
+      const k = env.from + '|' + env.channel + '|' + env.mid;
+      if (this._seen.indexOf(k) !== -1) return true;
+      this._seen.push(k); if (this._seen.length > 256) this._seen.shift();
+      return false;
     },
 
     _deliver(env) {
       if (env.from === this._surface) return;    // never deliver our own message back to ourselves
+      if (this._dupe(env)) return;               // already handled via the other transport
       if (env.channel === '__ping') {            // auto-ACK a ping back to the sender
         const ack = { __connect: ENVELOPE, channel: '__ack', payload: null, from: this._surface, mid: env.mid };
         this._peerWindows().forEach((w) => { try { w.postMessage(ack, '*'); } catch (e) {} });
@@ -125,6 +139,7 @@
       };
       window.addEventListener('message', (e) => inbound(e.data));
       window.addEventListener('connect:local', (e) => inbound(e.detail));
+      try { if (typeof BroadcastChannel !== 'undefined') { this._bc = new BroadcastChannel('connect:v1'); this._bc.onmessage = (e) => inbound(e.data); } } catch (e) {}
     }
   };
 

--- a/viewer/connect_scene.js
+++ b/viewer/connect_scene.js
@@ -1,0 +1,133 @@
+// connect_scene.js — the CONNECT SCENE broker (prompts/CONNECT_SCENE_SPEC.md P0, W-CONNECT-BUS).
+//
+// A "Connect Scene" is NOT a merge of the three surfaces (Bonsai Modeller, BIM Viewer, iDempiere ERP).
+// It is a SHARED CONTEXT that makes them TALK while staying permanently separate (modeller↔viewer decree):
+// they keep their own chrome/DOM; they share SELECTION / TIMELINE / IDENTITY over the ONE signed op-log.
+//
+// This file is the BROKER only — `window.Connect`. No surface owns it. A surface `register()`s, then
+// `publish(channel,payload)` / `subscribe(channel,fn)` over it. Transport is auto-detected:
+//   - cross-document (iframe / host window)  → postMessage  (generalises the shipped bim:* bus, PR #369)
+//   - same-document (two modules, one page)  → in-process delivery
+// The broker is OPT-IN: `enable()`/`disable()`/`toggle()` gate ALL cross-surface traffic. Off = surfaces
+// independent (the decree's default). On = a small "connected surfaces" mode + live sync.
+//
+// P0 ships the bus + the toggle + a `ping()` round-trip+ACK primitive (the W-CONNECT-BUS witness).
+// Channels selection/timeline/identity are reserved here; they are WIRED in P1/P2/P3.
+(function () {
+  'use strict';
+  const TAG = '§CONNECT';
+  const ENVELOPE = 'connect:v1';                 // every broker message carries __connect === ENVELOPE
+  const CHANNELS = ['selection', 'timeline', 'identity'];   // the three real channels (reserved for P1–P3)
+
+  function _uid(p) {
+    // correlation id only — NOT part of the signed chain, so ad-hoc randomness is fine here.
+    try { return p + '-' + Math.random().toString(36).slice(2, 9); }
+    catch (e) { return p + '-' + (Connect._seq = (Connect._seq || 0) + 1); }
+  }
+
+  const Connect = {
+    CHANNELS,
+    _on: false,                                  // toggle gate — off ⇒ no cross-surface traffic
+    _surface: null,                              // this surface's id (e.g. 'modeller' | 'viewer' | 'erp')
+    _subs: Object.create(null),                  // channel -> Set(fn)
+    _acks: Object.create(null),                  // ping mid -> collector(from)
+    _wired: false,
+    _onState: null,                              // optional indicator hook: fn(true|false)
+
+    // Register this surface and wire the inbound listener. Idempotent.
+    register(surface) {
+      this._surface = surface || _uid('surface');
+      this._wire();
+      console.log(TAG + ' register surface=' + this._surface);
+      return this;
+    },
+
+    // ---- toggle (the opt-in gate) ----
+    enable()  { this._on = true;  this._wire(); this._indicate(true);  console.log(TAG + ' enabled surface=' + this._surface);  return true; },
+    disable() { this._on = false;             this._indicate(false); console.log(TAG + ' disabled surface=' + this._surface); return false; },
+    toggle()  { return this._on ? this.disable() : this.enable(); },
+    get on()  { return this._on; },
+    onState(fn) { this._onState = fn; },        // surface registers an indicator callback (button styling etc.)
+    _indicate(v) { if (typeof this._onState === 'function') { try { this._onState(v); } catch (e) {} } },
+
+    // ---- pub/sub ----
+    subscribe(channel, fn) {
+      const set = this._subs[channel] || (this._subs[channel] = new Set());
+      set.add(fn);
+      return () => set.delete(fn);              // unsubscribe handle
+    },
+
+    // Publish to all OTHER surfaces over `channel`. No-op (logged) when the broker is off.
+    publish(channel, payload) {
+      if (!this._on) { console.log(TAG + ' publish DROP (off) ch=' + channel); return false; }
+      const env = { __connect: ENVELOPE, channel: channel, payload: payload, from: this._surface, mid: _uid('m') };
+      this._fanout(env);
+      console.log(TAG + ' publish ch=' + channel + ' from=' + this._surface + ' mid=' + env.mid);
+      return true;
+    },
+
+    // Witness/health primitive: ping peers, resolve with the list of surfaces that ACK within `timeoutMs`.
+    ping(timeoutMs) {
+      return new Promise((resolve) => {
+        if (!this._on) { console.log(TAG + ' ping DROP (off)'); resolve([]); return; }
+        const mid = _uid('p'); const acks = [];
+        this._acks[mid] = (from) => { acks.push(from); };
+        this._fanout({ __connect: ENVELOPE, channel: '__ping', payload: null, from: this._surface, mid: mid });
+        console.log(TAG + ' ping mid=' + mid + ' from=' + this._surface);
+        setTimeout(() => {
+          delete this._acks[mid];
+          console.log(TAG + ' ping done mid=' + mid + ' acks=' + acks.length + ' [' + acks.join(',') + ']');
+          resolve(acks);
+        }, timeoutMs || 300);
+      });
+    },
+
+    // ---- transport (auto-detected) ----
+    // Peer windows = the host (parent) + any embedded child frames. A surface that is same-doc has no
+    // peer windows and delivers purely in-process (see _deliverLocal).
+    _peerWindows() {
+      const ws = [];
+      try { if (window.parent && window.parent !== window) ws.push(window.parent); } catch (e) {}
+      try { for (let i = 0; i < window.frames.length; i++) { if (window.frames[i] !== window) ws.push(window.frames[i]); } } catch (e) {}
+      return ws;
+    },
+    _fanout(env) {
+      const ws = this._peerWindows();
+      ws.forEach((w) => { try { w.postMessage(env, '*'); } catch (e) {} });
+      // same-document peers (other surfaces sharing this window) hear it via a local event too.
+      try { window.dispatchEvent(new CustomEvent('connect:local', { detail: env })); } catch (e) {}
+    },
+
+    _deliver(env) {
+      if (env.from === this._surface) return;    // never deliver our own message back to ourselves
+      if (env.channel === '__ping') {            // auto-ACK a ping back to the sender
+        const ack = { __connect: ENVELOPE, channel: '__ack', payload: null, from: this._surface, mid: env.mid };
+        this._peerWindows().forEach((w) => { try { w.postMessage(ack, '*'); } catch (e) {} });
+        try { window.dispatchEvent(new CustomEvent('connect:local', { detail: ack })); } catch (e) {}
+        console.log(TAG + ' ping<- from=' + env.from + ' ACK mid=' + env.mid);
+        return;
+      }
+      if (env.channel === '__ack') {
+        const cb = this._acks[env.mid]; if (cb) cb(env.from);
+        return;
+      }
+      const subs = this._subs[env.channel]; if (!subs) return;
+      subs.forEach((fn) => { try { fn(env.payload, env); } catch (e) { console.warn(TAG + ' sub err ' + e); } });
+    },
+
+    _wire() {
+      if (this._wired) return; this._wired = true;
+      const inbound = (env) => {
+        if (!env || env.__connect !== ENVELOPE) return;
+        // Off ⇒ surfaces independent. Still drain pending ACKs so a ping issued just before disable resolves.
+        if (!this._on && env.channel !== '__ack') { console.log(TAG + ' inbound DROP (off) ch=' + env.channel); return; }
+        this._deliver(env);
+      };
+      window.addEventListener('message', (e) => inbound(e.data));
+      window.addEventListener('connect:local', (e) => inbound(e.detail));
+    }
+  };
+
+  window.Connect = Connect;
+  console.log(TAG + ' broker loaded v1 (channels: ' + CHANNELS.join('/') + ' + toggle)');
+})();

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -37,6 +37,12 @@ async function initViewer() {
   APP._bimPostFocus = function (guid, ifcClass) {
     if (!guid) return;
     _bimPostParent({ type: 'bim:focusRecord', guid: guid, ifcClass: ifcClass || null });
+    // CONNECT_SCENE_SPEC.md P1 — generalise the bim:* pick-emit onto the shared 'selection' channel so the
+    // Modeller (and any connected surface) lands on the SAME signed entity, not just the ERP host. Anchored on
+    // signed identity: guid + ifcClass (ERP product Value == ifc_class; component ifc_class). NON-INVENT: both
+    // read from elements_meta — no fabricated map. _connectApplying guards the remote→local→remote echo loop.
+    if (window.Connect && window.Connect.on && !APP._connectApplying)
+      window.Connect.publish('selection', { guid: guid, ifcClass: ifcClass || null, surface: 'viewer' });
     console.log('§BIM-FOCUSREC guid=' + String(guid).slice(0, 12) + ' class=' + (ifcClass || '?'));
   };
   APP._bimGuidsForClass = function (ifcClass) {
@@ -70,6 +76,20 @@ async function initViewer() {
     if (d.type === 'bim:highlight') APP._bimHighlight(d);
     else if (d.type === 'bim:clearHighlight') { if (APP.clearFocusElement) APP.clearFocusElement(); console.log('§BIM-HL clear'); }
   });
+  // CONNECT_SCENE_SPEC.md P1 — the viewer joins the shared scene as surface 'viewer'. An incoming 'selection'
+  // (from the Modeller or ERP) highlights the SAME signed entity here via the existing focusElement path; the
+  // _connectApplying flag stops that highlight from re-publishing (echo guard). Opt-in: auto-enable on ?connect=1.
+  if (window.Connect) {
+    window.Connect.register('viewer');
+    window.Connect.subscribe('selection', function (sel) {
+      if (!sel) return;
+      console.log('§CONNECT-SEL-IN viewer guid=' + String(sel.guid || '').slice(0, 12) + ' class=' + (sel.ifcClass || '?') + ' from=' + (sel.surface || '?'));
+      APP._connectApplying = true;
+      try { APP._bimHighlight({ guid: sel.guid || null, ifcClass: sel.ifcClass || null }); }
+      finally { APP._connectApplying = false; }
+    });
+    try { if ((new URLSearchParams(location.search)).get('connect') === '1') window.Connect.enable(); } catch (e) {}
+  }
   if (typeof setupDLOD === 'function') setupDLOD(APP);
   if (typeof setupNlp === 'function') setupNlp(APP);
   if (typeof setupGhostGlass === 'function') setupGhostGlass(APP);

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -238,6 +238,17 @@ paintSound();
 // Connect Scene toggle (CONNECT_SCENE_SPEC.md P0): register this surface as 'modeller' on the broker, then
 // the button gates the opt-in shared-context mode. On = a lit "connected surfaces" chip; off = independent.
 const bConnect = document.getElementById('b-connect');
+let _applyingRemoteSel = false;   // echo guard: a selection applied FROM the scene must not re-broadcast.
+// Derive the signed-identity selection payload for a feature: op_hash (anchor) + the component's ifc_class
+// (the cross-surface bridge). FOLDS from the signed op-log + library — never hand-coded (NON-INVENT boundary).
+function _connectSelPayload(id) {
+  if (id == null || !window.Bonsai.oplog) return null;
+  const op = window.Bonsai.oplog._geomOps().find(o => o.id === id);
+  if (!op) return null;
+  let ifcClass = null;
+  if (op.op_type === 'GEOM_INSERT') { const c = window.Bonsai.library && window.Bonsai.library.get(op.parameters.hash); ifcClass = c ? c.ifc_class : null; }
+  return { op_hash: op.op_hash, featureId: id, ifcClass: ifcClass, surface: 'modeller' };
+}
 if (window.Connect && bConnect) {
   window.Connect.register('modeller');
   window.Connect.onState((on) => { bConnect.classList.toggle('on', on); bConnect.querySelector('span').textContent = on ? 'Connected' : 'Connect'; });
@@ -247,6 +258,18 @@ if (window.Connect && bConnect) {
     if (_soundOn) audioCue('tick');
     console.log('§CONNECT-MODELLER toggle on=' + on);
   };
+  // Inbound selection from another surface → select the feature whose component ifc_class matches (same signed
+  // class). Echo-guarded so applying it doesn't re-publish. The match folds from the op-log, not a hand map.
+  window.Connect.subscribe('selection', (sel) => {
+    if (!sel || !sel.ifcClass || !window.Bonsai.oplog) return;
+    let match = null;
+    for (const o of window.Bonsai.oplog._geomOps()) {
+      if (o.op_type === 'GEOM_INSERT') { const c = window.Bonsai.library && window.Bonsai.library.get(o.parameters.hash); if (c && c.ifc_class === sel.ifcClass) { match = o.id; break; } }
+    }
+    console.log('§CONNECT-SEL-IN modeller class=' + sel.ifcClass + ' from=' + (sel.surface || '?') + ' match=' + (match == null ? 'none' : match));
+    if (match != null) { _applyingRemoteSel = true; try { window.Bonsai.select(match); } finally { _applyingRemoteSel = false; } }
+  });
+  try { if ((new URLSearchParams(location.search)).get('connect') === '1') window.Connect.enable(); } catch (e) {}
 } else if (bConnect) { bConnect.disabled = true; }
 const GROUND = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);   // z=0 sketch plane
 const raycaster = new THREE.Raycaster();
@@ -321,6 +344,13 @@ function highlight(mesh) {
   window.Bonsai._selId = selectedId;                       // mirror to Outliner so 3D pick highlights its row
   if (window.Bonsai.outliner) window.Bonsai.outliner.setActive(selectedId);   // restyle the active row only — no DB query / tree rebuild per pick
   console.log('§MODELLER select featureId=' + selectedId);
+  // CONNECT_SCENE_SPEC.md P1 — broadcast the pick over the shared 'selection' channel so the Viewer/ERP land
+  // on the SAME signed entity. Payload is anchored on signed identity (op_hash) + the component's ifc_class
+  // (the only cross-surface bridge: viewer elements_meta + ERP product Value). Echo-guarded by _applyingRemoteSel.
+  if (window.Connect && window.Connect.on && !_applyingRemoteSel && selectedId != null) {
+    const p = _connectSelPayload(selectedId);
+    if (p && p.ifcClass) window.Connect.publish('selection', p);
+  }
 }
 window.Bonsai.select = (fid) => {                 // witness/programmatic hook
   const g = window.Bonsai.group && window.Bonsai.group();
@@ -1060,6 +1090,33 @@ if (qs.get('insert') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER insert demo fail ' + e); }
     window.__insertResult = out; window.__insertDone = true;
     console.log('§MODELLER insert-done');
+  })();
+}
+// ?connectsel=demo sets up the Connect Scene P1 selection witness (W-CONNECT-SELECT): insert a REAL Door
+// component (ifc_class IfcDoor) as a signed GEOM_INSERT, enable the Connect broker, and expose the feature id.
+// The witness then drives select (forward: Modeller→Viewer highlight) and an inbound selection (reverse).
+if (qs.get('connectsel') === 'demo') {
+  (async () => {
+    const out = {};
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      window.Bonsai.oplog.clear();
+      const cat = window.Bonsai.library.catalog();
+      const door = cat.find(c => c.ifc_class === 'IfcDoor') || cat[0];
+      out.ifcClass = door.ifc_class;
+      bInsert.onclick();
+      const pBtn = document.querySelector('#ins-panel .ins-c[data-hash="' + door.hash + '"]'); if (pBtn) pBtn.onclick();
+      const rect = canvas.getBoundingClientRect();
+      const v = new THREE.Vector3(4, 3, 0).project(camera);
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height, bubbles: true }));
+      for (let i = 0; i < 60 && window.Bonsai.oplog.length === 0; i++) await new Promise(r => setTimeout(r, 50));
+      const ins = window.Bonsai.oplog._geomOps().find(o => o.op_type === 'GEOM_INSERT');
+      out.insertedId = ins ? ins.id : null;
+      window.Connect.enable();                                    // join the scene (witness drives the surfaces)
+      window.__connectSelInsertedId = out.insertedId;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER connectsel fail ' + e); }
+    window.__connectSelResult = out; window.__connectSelReady = true;
+    console.log('§MODELLER connectsel-ready id=' + out.insertedId + ' class=' + out.ifcClass);
   })();
 }
 // ?place=demo proves PLACEMENT CORRECTNESS (W-BONSAI-PLACE): a component lands SEATED on the ground (not

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -3,8 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Bonsai Modeller — alternative authoring viewer</title>
-<!-- ALTERNATIVE viewer surface for the Bonsai authoring kernel. Does NOT load viewer.html /
+<title>DAGeVu Modeller — alternative authoring viewer</title>
+<!-- DAGeVu — the alternative authoring viewer surface (renamed from "Bonsai" to avoid brand clash; the
+     internal window.Bonsai API + bonsai_*.js filenames are unchanged for now). Does NOT load viewer.html /
      does NOT touch the production viewer. prompts/BONSAI_KERNEL_RESEARCH.md Item 2 leg 1:
      occt-wasm kernel in a Web Worker -> kernel_ops op-row folds into a mesh in this scene. -->
 <style>
@@ -61,7 +62,7 @@
   <input id="hist-slider" type="range" min="0" max="0" value="0" step="1" style="flex:1;accent-color:#4fc3f7" disabled>
   <span id="hist-label">0/0</span>
 </div>
-<div id="title">BONSAI · MODELLER</div>
+<div id="title">DAGeVu · MODELLER</div>
 <div id="stat">booting…</div>
 
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -54,6 +54,7 @@
   <button id="b-del" disabled title="Delete selected (Del)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Z"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/></svg><span>Delete</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
   <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
+  <button id="b-connect" title="Connect Scene — share selection/timeline with the Viewer &amp; ERP (opt-in; surfaces stay separate)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" x2="16" y1="12" y2="12"/></svg><span>Connect</span></button>
 </div>
 <div id="hist" style="position:fixed;bottom:36px;left:252px;right:10px;display:flex;align-items:center;gap:10px;z-index:10;color:#6b7488;font-size:11px;font-family:ui-monospace,monospace">
   <span>history</span>
@@ -84,6 +85,9 @@
 <script src="bonsai_outliner.js?v=1" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=1" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
+     identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
+<script src="connect_scene.js?v=1" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 
 <!-- Scene bootstrap: reuse the viewer's THREE stack (r184 webgpu build), expose global THREE + window.A. -->
 <script type="module">
@@ -231,6 +235,19 @@ const VOL_OFF = _ico('<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line
 function paintSound() { bSound.innerHTML = _soundOn ? VOL_ON : VOL_OFF; bSound.classList.toggle('on', _soundOn); }
 bSound.onclick = () => { _soundOn = !_soundOn; localStorage.setItem('bonsai_sound', _soundOn ? 'on' : 'off'); paintSound(); if (_soundOn) audioCue('tick'); };
 paintSound();
+// Connect Scene toggle (CONNECT_SCENE_SPEC.md P0): register this surface as 'modeller' on the broker, then
+// the button gates the opt-in shared-context mode. On = a lit "connected surfaces" chip; off = independent.
+const bConnect = document.getElementById('b-connect');
+if (window.Connect && bConnect) {
+  window.Connect.register('modeller');
+  window.Connect.onState((on) => { bConnect.classList.toggle('on', on); bConnect.querySelector('span').textContent = on ? 'Connected' : 'Connect'; });
+  bConnect.onclick = () => {
+    const on = window.Connect.toggle();
+    setStat(on ? 'Connect Scene ON — selection/timeline now shared with Viewer & ERP' : 'Connect Scene off — surfaces independent');
+    if (_soundOn) audioCue('tick');
+    console.log('§CONNECT-MODELLER toggle on=' + on);
+  };
+} else if (bConnect) { bConnect.disabled = true; }
 const GROUND = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);   // z=0 sketch plane
 const raycaster = new THREE.Raycaster();
 let sketching = false, sketchGroup = null, savedCam = null;

--- a/viewer/tests/connect_bus_live.js
+++ b/viewer/tests/connect_bus_live.js
@@ -1,0 +1,57 @@
+// W-CONNECT-BUS — Connect Scene P0 witness (prompts/CONNECT_SCENE_SPEC.md P0).
+// CLAIM: the broker `window.Connect` lets two SEPARATE surfaces (a 'modeller' host + an embedded 'viewer'
+// peer, distinct documents) exchange a ping ROUND-TRIP with ACK over auto-detected postMessage transport,
+// and the opt-in TOGGLE gates ALL cross-surface traffic — off on either end ⇒ zero ACKs. Surfaces stay
+// permanently separate (no shared DOM); only CONTEXT crosses. This is the bus P1–P3 channels ride on.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/tests/connect_harness.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§CONNECT/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/tests/connect_harness.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__connectReady === true', { timeout: 30000 })
+    .catch(() => console.log('  ✗ timeout waiting for __connectReady'));
+
+  const peerFrame = pg.frames().find(f => /connect_peer\.html/.test(f.url()));
+
+  // 1) both ON → ping round-trip should ACK from 'viewer'
+  const bothOn = await pg.evaluate(async () => { window.Connect.enable(); return await window.Connect.ping(400); });
+  // 2) host OFF → publish/ping gated at the sender → 0 acks
+  const hostOff = await pg.evaluate(async () => { window.Connect.disable(); return await window.Connect.ping(400); });
+  // 3) host ON again, but PEER OFF → inbound ping dropped at receiver → 0 acks (gating works on either end)
+  await peerFrame.evaluate(() => window.Connect.disable());
+  const peerOff = await pg.evaluate(async () => { window.Connect.enable(); return await window.Connect.ping(400); });
+  // 4) peer ON again → round-trip restored
+  await peerFrame.evaluate(() => window.Connect.enable());
+  const restored = await pg.evaluate(async () => await window.Connect.ping(400));
+
+  await br.close(); server.close();
+
+  const a = (arr) => Array.isArray(arr) ? arr : [];
+  console.log('  §CONNECT-BUS bothOn=[' + a(bothOn).join(',') + '] hostOff=[' + a(hostOff).join(',') +
+    '] peerOff=[' + a(peerOff).join(',') + '] restored=[' + a(restored).join(',') + ']');
+
+  const checks = {
+    roundTrip:   a(bothOn).length === 1 && a(bothOn)[0] === 'viewer',   // ACK came back from the OTHER surface
+    gateSender:  a(hostOff).length === 0,                               // toggle off at sender ⇒ no traffic
+    gateReceiver:a(peerOff).length === 0,                               // toggle off at receiver ⇒ no ACK
+    restores:    a(restored).length === 1 && a(restored)[0] === 'viewer'// re-enabling both restores the bus
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §CONNECT-BUS VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' '));
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/connect_harness.html
+++ b/viewer/tests/connect_harness.html
@@ -1,0 +1,15 @@
+<!doctype html><html><head><meta charset="utf-8"><title>connect harness (modeller)</title>
+<script src="../connect_scene.js"></script></head>
+<body>
+<!-- W-CONNECT-BUS host: surface 'modeller' hosting an embedded 'viewer' peer (iframe). The witness drives
+     register/enable/ping/disable on window.Connect here and asserts the round-trip + ACK + toggle gating. -->
+<iframe id="peer" src="connect_peer.html" style="width:160px;height:90px;border:0"></iframe>
+<script>
+  window.Connect.register('modeller');
+  window.__connectReady = false;
+  // wait for the peer iframe to load + register before the witness runs.
+  document.getElementById('peer').addEventListener('load', function () {
+    setTimeout(function () { window.__connectReady = true; console.log('§CONNECT-HOST modeller ready peerLoaded=1'); }, 50);
+  });
+</script>
+</body></html>

--- a/viewer/tests/connect_modeller_live.js
+++ b/viewer/tests/connect_modeller_live.js
@@ -1,0 +1,43 @@
+// W-CONNECT-BUS-MODELLER — P0 DOM leg: the Connect toggle is wired into the REAL modeller surface.
+// CLAIM: modeller.html loads connect_scene.js, registers surface 'modeller', and the toolbar #b-connect
+// button toggles the broker on/off (indicator + §-log) — proving the toggle lives on the actual surface,
+// not just the harness. (occt/WASM may not finish on Node18 V8; the broker + button wiring do not need it.)
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§CONNECT/.test(t)) console.log('  ' + t); });
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Connect && document.getElementById('b-connect')", { timeout: 30000 })
+    .catch(() => console.log('  ✗ timeout waiting for Connect+button'));
+
+  const r = await pg.evaluate(() => {
+    const btn = document.getElementById('b-connect');
+    const registered = window.Connect && window.Connect._surface === 'modeller';
+    const startOff = !window.Connect.on;
+    btn.click(); const afterClick = { on: window.Connect.on, label: btn.querySelector('span').textContent, lit: btn.classList.contains('on') };
+    btn.click(); const afterClick2 = { on: window.Connect.on, label: btn.querySelector('span').textContent };
+    return { registered, startOff, afterClick, afterClick2, hasBtn: !!btn };
+  }).catch(e => ({ err: String(e) }));
+
+  await br.close(); server.close();
+  console.log('  §CONNECT-MODELLER ' + JSON.stringify(r));
+  const pass = r.registered && r.startOff && r.afterClick && r.afterClick.on === true &&
+    r.afterClick.label === 'Connected' && r.afterClick.lit === true && r.afterClick2.on === false &&
+    r.afterClick2.label === 'Connect';
+  console.log('  §CONNECT-MODELLER VERDICT ' + (pass ? 'PASS' : 'FAIL'));
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/connect_peer.html
+++ b/viewer/tests/connect_peer.html
@@ -1,0 +1,11 @@
+<!doctype html><html><head><meta charset="utf-8"><title>connect peer (viewer)</title>
+<script src="../connect_scene.js"></script></head>
+<body>
+<!-- W-CONNECT-BUS peer: a second surface ('viewer') in its own document. Auto-registers + enables so it
+     ACKs pings from the host. The toggle is driven from the witness to prove gating. -->
+<script>
+  window.Connect.register('viewer');
+  window.Connect.enable();
+  console.log('§CONNECT-PEER viewer ready on=' + window.Connect.on);
+</script>
+</body></html>

--- a/viewer/tests/connect_select_live.js
+++ b/viewer/tests/connect_select_live.js
@@ -1,0 +1,82 @@
+// W-CONNECT-SELECT — Connect Scene P1 witness (prompts/CONNECT_SCENE_SPEC.md P1).
+// CLAIM: with the Modeller and the REAL Viewer (Clinic_extracted.db) running as TWO SEPARATE same-origin
+// surfaces joined by the Connect broker (BroadcastChannel), a pick in one lands on the SAME signed entity in
+// the other — resolved by the cross-surface bridge (component ifc_class == elements_meta ifc_class), NOT a
+// hand-coded map:
+//   FORWARD  Modeller selects an inserted IfcDoor → Viewer highlights IfcDoor against its real elements_meta.
+//   REVERSE  Viewer picks a real IfcDoor element → Modeller selects the owning Door feature.
+// Surfaces stay separate (no shared DOM); only the 'selection' CONTEXT crosses. 3D DRAW is GPU-gated → the
+// MATCH COUNT + the cross-surface §-log round-trip are the GPU-independent assertions.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+const GREP = /^§(CONNECT|BIM-HL|BIM-FOCUSREC|MODELLER connectsel)/;
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+
+  // ── Surface VIEWER (real model) — open first so it is listening before the modeller publishes ──
+  const vlogs = [];
+  const V = await br.newPage();
+  V.on('console', m => { const t = m.text(); if (GREP.test(t)) { vlogs.push(t); console.log('  [V] ' + t); } });
+  V.on('pageerror', e => console.log('  [V] ERR ' + String(e).slice(0, 200)));
+  await V.goto(`http://localhost:${port}/viewer.html?db=buildings/Clinic_extracted.db&bld=Clinic&connect=1`, { waitUntil: 'load', timeout: 90000 });
+  await V.waitForFunction('window.APP && window.APP.db && window.APP.dbQuery && window.Connect && window.Connect.on', { timeout: 120000 })
+    .catch(() => console.log('  ✗ viewer db/Connect not ready'));
+  const doorGuid = await V.evaluate(() => {
+    const r = window.APP.dbQuery("SELECT guid FROM elements_meta WHERE ifc_class='IfcDoor' LIMIT 1");
+    const n = window.APP.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class='IfcDoor'");
+    return { guid: r && r.length ? r[0][0] : null, count: n && n.length ? n[0][0] : 0 };
+  }).catch(() => ({ guid: null, count: 0 }));
+  console.log('  viewer Clinic IfcDoor count=' + doorGuid.count);
+
+  // ── Surface MODELLER — insert a Door, enable Connect ──
+  const mlogs = [];
+  const M = await br.newPage();
+  M.on('console', m => { const t = m.text(); if (GREP.test(t)) { mlogs.push(t); console.log('  [M] ' + t); } });
+  M.on('pageerror', e => console.log('  [M] ERR ' + String(e).slice(0, 200)));
+  await M.goto(`http://localhost:${port}/modeller.html?connectsel=demo`, { waitUntil: 'load', timeout: 90000 });
+  await M.waitForFunction('window.__connectSelReady === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ modeller connectsel not ready'));
+  const insertedId = await M.evaluate(() => window.__connectSelInsertedId).catch(() => null);
+  console.log('  modeller inserted Door featureId=' + insertedId);
+
+  // ── FORWARD: Modeller selects the Door → Viewer should highlight IfcDoor ──
+  await M.evaluate((id) => window.Bonsai.select(id), insertedId);
+  await new Promise(r => setTimeout(r, 800));
+  const fwdViewerGotSel = vlogs.some(l => /§CONNECT-SEL-IN viewer .*class=IfcDoor/.test(l));
+  const fwdHlLine = vlogs.find(l => /§BIM-HL class=IfcDoor match=(\d+)/.test(l));
+  const fwdMatch = fwdHlLine ? +fwdHlLine.match(/match=(\d+)/)[1] : 0;
+
+  // ── REVERSE: Viewer picks a real IfcDoor element → Modeller should select the Door feature ──
+  if (doorGuid.guid) await V.evaluate((g) => window.APP._bimPostFocus(g, 'IfcDoor'), doorGuid.guid);
+  await new Promise(r => setTimeout(r, 800));
+  const revModGotSel = mlogs.some(l => /§CONNECT-SEL-IN modeller class=IfcDoor .*match=(\d+)/.test(l) && !/match=none/.test(l));
+  const revSelId = await M.evaluate(() => window.Bonsai._selId).catch(() => null);
+
+  await br.close(); server.close();
+
+  console.log('  §CONNECT-SELECT forward{viewerGotSel=' + fwdViewerGotSel + ' match=' + fwdMatch + '} ' +
+    'reverse{modGotSel=' + revModGotSel + ' modSelId=' + revSelId + ' insertedId=' + insertedId + '}');
+  const checks = {
+    insertOk:    insertedId != null && doorGuid.count > 0,
+    fwdRouted:   fwdViewerGotSel,                          // modeller publish reached the viewer surface
+    fwdMatched:  fwdMatch > 0,                             // viewer matched IfcDoor against REAL elements_meta
+    revRouted:   revModGotSel,                             // viewer pick reached the modeller surface
+    revSelected: revSelId != null && revSelId === insertedId  // modeller landed on the SAME feature
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §CONNECT-SELECT VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' ') + '  (3D draw GPU-gated 🟡)');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -879,6 +879,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="time_machine.js?v=53" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
+<!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context
+     as surface 'viewer' — selection/timeline/identity over the one signed op-log. Opt-in (toggle / ?connect=1). -->
+<script src="connect_scene.js?v=1" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 <script src="main.js?v=43"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>


### PR DESCRIPTION
## Connect Scene — shared cross-surface context (not a merge)

Implements `prompts/CONNECT_SCENE_SPEC.md` P0–P1. A *Connect Scene* makes the three already-separate surfaces (Modeller, Viewer, ERP) **talk** while staying permanently separate — they share **selection / timeline / identity** over the one signed op-log, never DOM/chrome.

### P0 — Broker + toggle (W-CONNECT-BUS ✅)
- `viewer/connect_scene.js` — `window.Connect` broker: `register/publish/subscribe` + opt-in `enable/disable/toggle`. Transport auto-detected: **BroadcastChannel** (same-origin N-surface fan-out) + postMessage (window tree) + CustomEvent (same-doc), with mid-dedup. `ping()` round-trip+ACK primitive.
- `modeller.html` — Connect toolbar toggle (lit chip + §-log).
- **W-CONNECT-BUS 4/4** (round-trip + ACK + toggle gates both ends) + **W-CONNECT-BUS-MODELLER PASS**.

### P1 — Selection channel (W-CONNECT-SELECT ✅)
- Pick in one surface → the others land on the **same signed entity**, resolved by the cross-surface bridge (component `ifc_class` == `elements_meta.ifc_class` == ERP product `Value`) — folded from the op-log + library, **never hand-mapped** (NON-INVENT boundary).
- `main.js` (viewer): subscribe selection → `focusElement` highlight (echo-guarded); pick publishes selection; `?connect=1` auto-enable.
- `modeller.html`: `highlight()` publishes; subscribe selects the matching feature.
- **W-CONNECT-SELECT PASS** across two REAL surfaces over BroadcastChannel: forward Modeller→Viewer (match=254 real Clinic doors) + reverse Viewer→Modeller (lands on the same feature). 3D draw GPU-gated 🟡.

### Rebrand
- Modeller **'Bonsai' → 'DAGeVu'** (visible strings only: tab title, on-screen banner, launch toast) to avoid clashing with BlenderBIM's Bonsai. Internal `window.Bonsai` API / filenames / `W-BONSAI-*` witness ids unchanged.

### Not yet (follow-on)
- ERP as the third selection participant (bim_panel wiring), then **P2 timeline** + **P3 commit** channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)