### PR TITLE
Connect Scene P2: timeline channel — one log, two folds, co-vanish

### DIFF
--- a/viewer/connect_scene.js
+++ b/viewer/connect_scene.js
@@ -36,11 +36,13 @@
     _bc: null,                                   // BroadcastChannel — same-origin N-surface fan-out
     _seen: [],                                   // recent envelope keys (dedup across dual transports)
 
+    _token: null,                                // unique per-INSTANCE id (two tabs of the same surface differ)
     // Register this surface and wire the inbound listener. Idempotent.
     register(surface) {
       this._surface = surface || _uid('surface');
+      if (!this._token) this._token = _uid('inst');   // self-guard keys on the instance, NOT the surface type
       this._wire();
-      console.log(TAG + ' register surface=' + this._surface);
+      console.log(TAG + ' register surface=' + this._surface + ' inst=' + this._token);
       return this;
     },
 
@@ -62,7 +64,7 @@
     // Publish to all OTHER surfaces over `channel`. No-op (logged) when the broker is off.
     publish(channel, payload) {
       if (!this._on) { console.log(TAG + ' publish DROP (off) ch=' + channel); return false; }
-      const env = { __connect: ENVELOPE, channel: channel, payload: payload, from: this._surface, mid: _uid('m') };
+      const env = { __connect: ENVELOPE, channel: channel, payload: payload, from: this._surface, inst: this._token, mid: _uid('m') };
       this._fanout(env);
       console.log(TAG + ' publish ch=' + channel + ' from=' + this._surface + ' mid=' + env.mid);
       return true;
@@ -74,7 +76,7 @@
         if (!this._on) { console.log(TAG + ' ping DROP (off)'); resolve([]); return; }
         const mid = _uid('p'); const acks = [];
         this._acks[mid] = (from) => { acks.push(from); };
-        this._fanout({ __connect: ENVELOPE, channel: '__ping', payload: null, from: this._surface, mid: mid });
+        this._fanout({ __connect: ENVELOPE, channel: '__ping', payload: null, from: this._surface, inst: this._token, mid: mid });
         console.log(TAG + ' ping mid=' + mid + ' from=' + this._surface);
         setTimeout(() => {
           delete this._acks[mid];
@@ -112,10 +114,10 @@
     },
 
     _deliver(env) {
-      if (env.from === this._surface) return;    // never deliver our own message back to ourselves
+      if (env.inst && env.inst === this._token) return;  // never deliver our own message back to ourselves (by INSTANCE)
       if (this._dupe(env)) return;               // already handled via the other transport
       if (env.channel === '__ping') {            // auto-ACK a ping back to the sender
-        const ack = { __connect: ENVELOPE, channel: '__ack', payload: null, from: this._surface, mid: env.mid };
+        const ack = { __connect: ENVELOPE, channel: '__ack', payload: null, from: this._surface, inst: this._token, mid: env.mid };
         this._peerWindows().forEach((w) => { try { w.postMessage(ack, '*'); } catch (e) {} });
         try { window.dispatchEvent(new CustomEvent('connect:local', { detail: ack })); } catch (e) {}
         console.log(TAG + ' ping<- from=' + env.from + ' ACK mid=' + env.mid);

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -259,6 +259,15 @@ if (window.Connect && bConnect) {
     if (_soundOn) audioCue('tick');
     console.log('§CONNECT-MODELLER toggle on=' + on);
   };
+  // CONNECT_SCENE_SPEC.md P2 — inbound timeline cursor: fold BOTH projections (geometry + records) to it,
+  // echo-guarded. Scrub in one surface → every connected surface folds the one signed log to the same op_hash.
+  window.Connect.subscribe('timeline', async (t) => {
+    if (!t || typeof t.cursor !== 'number' || !window.Bonsai.oplog) return;
+    const c = Math.max(0, Math.min(t.cursor, window.Bonsai.oplog.length));
+    console.log('§CONNECT-TL-IN modeller cursor=' + c + '/' + window.Bonsai.oplog.length + ' from=' + (t.surface || '?'));
+    _applyingRemoteScrub = true;
+    try { slider.value = c; await scrubToShared(c, false); } finally { _applyingRemoteScrub = false; }
+  });
   // Inbound selection from another surface → select the feature whose component ifc_class matches (same signed
   // class). Echo-guarded so applying it doesn't re-publish. The match folds from the op-log, not a hand map.
   window.Connect.subscribe('selection', (sel) => {
@@ -532,11 +541,35 @@ function syncHistory() {
   const n = window.Bonsai.oplog.length;
   slider.max = n; slider.value = window.Bonsai.oplog.cursor; slider.disabled = n === 0;
   histStamp(+slider.value);
+  if (typeof paintRecords === 'function') paintRecords(+slider.value);   // keep the record fold in step with commits
 }
-slider.addEventListener('input', async () => {
-  histStamp(+slider.value);
-  await window.Bonsai.oplog.scrubTo(+slider.value);
-});
+// CONNECT_SCENE_SPEC.md P2 — the signed op-log IS the timeline. A "records" fold projects the SAME authored
+// ops into rows (one log, two folds: geometry ⟂ records). foldRecords(cursor) reads ops up to the cursor —
+// a deterministic FOLD, never invented. The hidden #rec-count lets the witness assert the record co-vanish.
+function foldRecords(cursor) {
+  if (!window.Bonsai.oplog || !window.Bonsai.oplog.db) return [];
+  const ops = window.Bonsai.oplog._geomOps();
+  const n = cursor == null ? window.Bonsai.oplog.cursor : Math.max(0, Math.min(cursor, ops.length));
+  return ops.slice(0, n).map(o => ({ id: o.id, label: featLabel(o), op_hash: o.op_hash }));
+}
+function paintRecords(cursor) {
+  const recs = foldRecords(cursor);
+  let el = document.getElementById('rec-count');
+  if (!el) { el = document.createElement('span'); el.id = 'rec-count'; el.style.display = 'none'; document.body.appendChild(el); }
+  el.textContent = String(recs.length);
+  window.Bonsai._records = recs;   // expose the record fold (the second projection of the one signed log)
+  return recs.length;
+}
+// Apply a scrub cursor to BOTH folds (geometry + records). _applyingRemoteScrub guards the echo loop so a
+// cursor received over the timeline channel doesn't re-broadcast.
+let _applyingRemoteScrub = false;
+async function scrubToShared(cursor, publish) {
+  histStamp(cursor); paintRecords(cursor);
+  await window.Bonsai.oplog.scrubTo(cursor);
+  if (publish && window.Connect && window.Connect.on && !_applyingRemoteScrub)
+    window.Connect.publish('timeline', { cursor: cursor, length: window.Bonsai.oplog.length, surface: 'modeller' });
+}
+slider.addEventListener('input', async () => { await scrubToShared(+slider.value, true); });
 
 // ── ARCHITECTURAL GRID (2D correlation) ─────────────────────────────────────────────────────────
 const bGrid = document.getElementById('b-grid');
@@ -1118,6 +1151,37 @@ if (qs.get('connectsel') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER connectsel fail ' + e); }
     window.__connectSelResult = out; window.__connectSelReady = true;
     console.log('§MODELLER connectsel-ready id=' + out.insertedId + ' class=' + out.ifcClass);
+  })();
+}
+// ?connecttl=demo sets up the Connect Scene P2 timeline witness (W-CONNECT-TIMELINE): author a deterministic
+// recipe (two GEOM_INSERT features) into the signed op-log, enable Connect. The witness then scrubs the shared
+// cursor and asserts BOTH folds (geometry meshes + record rows) co-vanish/restore across two connected surfaces.
+if (qs.get('connecttl') === 'demo') {
+  (async () => {
+    const out = {};
+    const place = async (hash, gx, gy) => {
+      if (!inserting) bInsert.onclick();                  // enter insert mode ONCE (it persists for multi-place)
+      const pBtn = document.querySelector('#ins-panel .ins-c[data-hash="' + hash + '"]'); if (pBtn) pBtn.onclick();
+      const rect = canvas.getBoundingClientRect();
+      const v = new THREE.Vector3(gx, gy, 0).project(camera);
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height, bubbles: true }));
+    };
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      window.Bonsai.oplog.clear();
+      const cat = window.Bonsai.library.catalog();
+      const a = cat.find(c => c.ifc_class === 'IfcDoor') || cat[0];
+      const b = cat.find(c => c.ifc_class === 'IfcColumn') || cat[1] || cat[0];
+      await place(a.hash, 4, 3); for (let i = 0; i < 60 && window.Bonsai.oplog.length < 1; i++) await new Promise(r => setTimeout(r, 50));
+      await place(b.hash, 8, 3); for (let i = 0; i < 60 && window.Bonsai.oplog.length < 2; i++) await new Promise(r => setTimeout(r, 50));
+      syncHistory();
+      out.length = window.Bonsai.oplog.length;          // expect 2
+      out.records = paintRecords(window.Bonsai.oplog.length);
+      window.__scrubShared = scrubToShared;             // witness seam: drive a shared scrub + await the fold
+      window.Connect.enable();
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER connecttl fail ' + e); }
+    window.__connectTlResult = out; window.__connectTlReady = true;
+    console.log('§MODELLER connecttl-ready length=' + out.length + ' records=' + out.records);
   })();
 }
 // ?place=demo proves PLACEMENT CORRECTNESS (W-BONSAI-PLACE): a component lands SEATED on the ground (not

--- a/viewer/tests/connect_timeline_live.js
+++ b/viewer/tests/connect_timeline_live.js
@@ -1,0 +1,69 @@
+// W-CONNECT-TIMELINE — Connect Scene P2 witness (prompts/CONNECT_SCENE_SPEC.md P2).
+// CLAIM: the signed op-log IS the timeline. Two SEPARATE same-origin Modeller surfaces joined by the Connect
+// broker author the SAME signed chain (identical deterministic op_hashes); a scrub on surface A broadcasts the
+// op-cursor over the 'timeline' channel and surface B folds the one signed log to the SAME cursor. And the log
+// folds TWO ways at once — geometry (meshes) AND records (rows) — so scrubbing BACK before a feature makes its
+// geometry AND its record BOTH vanish, and forward restores both: one log, two folds, co-vanishing, in lockstep
+// across surfaces. (3D draw GPU-gated; the MESH COUNT + RECORD COUNT + cross-surface §-log are the assertions.)
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+const meshCount = () => { const g = window.Bonsai.group && window.Bonsai.group(); return g ? g.children.filter(o => o.isMesh).length : -1; };
+const recCount = () => { const el = document.getElementById('rec-count'); return el ? +el.textContent : -1; };
+const state = "(" + (function () { const g = window.Bonsai.group && window.Bonsai.group(); const m = g ? g.children.filter(o => o.isMesh).length : -1; const el = document.getElementById('rec-count'); const r = el ? +el.textContent : -1; return { mesh: m, rec: r, cursor: window.Bonsai.oplog.cursor }; }).toString() + ")()";
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const open = async (tag) => {
+    const pg = await br.newPage();
+    pg.on('console', m => { const t = m.text(); if (/^§(CONNECT-TL|MODELLER connecttl)/.test(t)) console.log('  [' + tag + '] ' + t); });
+    pg.on('pageerror', e => console.log('  [' + tag + '] ERR ' + String(e).slice(0, 160)));
+    await pg.goto(`http://localhost:${port}/modeller.html?connecttl=demo&connect=1`, { waitUntil: 'load', timeout: 90000 });
+    await pg.waitForFunction('window.__connectTlReady === true && window.__connectTlResult.length === 2', { timeout: 120000 })
+      .catch(() => console.log('  ✗ [' + tag + '] connecttl not ready'));
+    return pg;
+  };
+  const A = await open('A');                     // open A first so it is listening
+  const B = await open('B');
+
+  // Scrub A to cursor 1 → B should fold to 1 (geometry 1 mesh, records 1). Drive A's shared-scrub seam and await it.
+  await A.evaluate(() => window.__scrubShared(1, true));
+  await new Promise(r => setTimeout(r, 600));
+  const a1 = await A.evaluate(state), b1 = await B.evaluate(state);
+  // Scrub A back to 0 → both empty (geometry gone, records gone).
+  await A.evaluate(() => window.__scrubShared(0, true));
+  await new Promise(r => setTimeout(r, 600));
+  const a0 = await A.evaluate(state), b0 = await B.evaluate(state);
+  // Scrub A forward to 2 → both restore.
+  await A.evaluate(() => window.__scrubShared(2, true));
+  await new Promise(r => setTimeout(r, 600));
+  const a2 = await A.evaluate(state), b2 = await B.evaluate(state);
+
+  await br.close(); server.close();
+
+  const J = o => JSON.stringify(o);
+  console.log('  §CONNECT-TIMELINE A@1=' + J(a1) + ' B@1=' + J(b1));
+  console.log('  §CONNECT-TIMELINE A@0=' + J(a0) + ' B@0=' + J(b0));
+  console.log('  §CONNECT-TIMELINE A@2=' + J(a2) + ' B@2=' + J(b2));
+  const co = (s, mesh, rec) => s.mesh === mesh && s.rec === rec && s.cursor === (mesh);   // both folds + cursor agree
+  const checks = {
+    crossSurface_1: co(b1, 1, 1),                  // A's scrub crossed to B → B folded both projections to 1
+    coVanish_0:     co(a0, 0, 0) && co(b0, 0, 0),  // scrub back before feature 1 → geometry AND records gone, both surfaces
+    restore_2:      co(a2, 2, 2) && co(b2, 2, 2),  // forward → both folds restore, both surfaces
+    twoFoldsTrack:  a1.mesh === a1.rec && b1.mesh === b1.rec   // the two folds move together (one log, two folds)
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §CONNECT-TIMELINE VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' ') + '  (3D draw GPU-gated 🟡)');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## P2 — Timeline channel (W-CONNECT-TIMELINE ✅)

Follows #383 (P0 broker + P1 selection). The **signed op-log IS the timeline**: a scrub broadcasts the op-cursor over the `timeline` channel; every connected surface folds the one signed log to the same `op_hash`. The log folds **two ways at once** — geometry (meshes) + records (rows) — so scrubbing back before a feature makes its geometry **and** its record both vanish, and forward restores both, in lockstep across surfaces.

- `connect_scene.js` — self-guard now keys on a unique per-**instance** token, not the surface **type**, so two tabs of the same surface (e.g. two Modellers) actually talk (real correctness fix).
- `modeller.html` — scrub publishes `timeline {cursor}`; subscribe folds both projections (geometry + `foldRecords`) echo-guarded; `?connecttl=demo` autopilot.
- **W-CONNECT-TIMELINE PASS** across two connected surfaces: cross-surface cursor sync + geometry/record **co-vanish(0)/restore(2)** + two-folds-track. Regression: W-CONNECT-BUS + W-CONNECT-SELECT still PASS. 3D draw GPU-gated 🟡.

### Honest scope
The witness folds the SAME signed chain on two surfaces (identical authored recipe). The deeper integration — one surface folding **another's** live-authored chain into an ERP-record projection (the full ERP-record co-vanish) — is the next leg, gated on the authored→ERP bridge / a real BIM-pushed project (same blocker B3/B5 flagged; no fabricated data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)