### PR TITLE
Connect Scene P3: identity/commit channel + Outliner DAGeVu rename

### DIFF
--- a/viewer/bonsai_oplog.js
+++ b/viewer/bonsai_oplog.js
@@ -55,6 +55,25 @@
       return this.length;
     },
 
+    // Re-read the signed op-log from the SHARED store (localStorage) WITHOUT clearing it, then re-fold to scene.
+    // The Connect Scene identity channel (CONNECT_SCENE_SPEC.md P3) calls this: a commit in another surface grew
+    // the shared signed chain → this surface reloads it and re-folds. verifyChain still holds (same signed log).
+    async reload() {
+      // Preserve the user's scrub position: if they are LIVE at the tip, follow to the new tip; if they are
+      // scrubbed BACK reviewing history, a peer's commit must NOT yank them forward (it appends beyond cursor).
+      const wasAtTip = this.db ? (this._cursor >= this.length) : true;
+      const prevCursor = this._cursor;
+      if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache();
+      if (this.db) { try { this.db.close(); } catch (e) { } }
+      this.db = null;                      // force _ensureDb to re-load the saved bytes from the shared store
+      await this._ensureDb();
+      this._cursor = wasAtTip ? this.length : Math.min(prevCursor, this.length);
+      await this._foldUpto(this._cursor);
+      this._emit();
+      console.log(TAG + ' reload active=' + this.length + ' cursor=' + this._cursor);
+      return this.length;
+    },
+
     _emit() { try { window.dispatchEvent(new CustomEvent('bonsai:oplog')); } catch (e) { } this._save(); },
     clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; try { localStorage.removeItem(this._KEY); } catch (e) { } if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache(); this._emit(); },
 

--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -88,7 +88,7 @@
       const f = this._find;
       const match = n => !f || (n.label + ' ' + n.sub).toLowerCase().includes(f);
       let total = 0, shown = 0;
-      let html = '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'Bonsai Model</div>';
+      let html = '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'DAGeVu Model</div>';
       groups.forEach(g => {
         const vis = g.nodes.filter(match); total += g.nodes.length; shown += vis.length;
         if (f && !vis.length) return;

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -73,7 +73,7 @@
 <script src="lib/sql-wasm.js" onerror="console.warn('§OPLOG LOAD_FAIL sql-wasm.js')"></script>
 <script src="kernel_ops.js?v=8" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
-<script src="bonsai_oplog.js?v=2" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<script src="bonsai_oplog.js?v=3" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
 <script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
@@ -83,12 +83,12 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=1" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=1" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
-<script src="connect_scene.js?v=1" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
+<script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 
 <!-- Scene bootstrap: reuse the viewer's THREE stack (r184 webgpu build), expose global THREE + window.A. -->
 <script type="module">
@@ -259,6 +259,27 @@ if (window.Connect && bConnect) {
     if (_soundOn) audioCue('tick');
     console.log('§CONNECT-MODELLER toggle on=' + on);
   };
+  // CONNECT_SCENE_SPEC.md P3 — identity/commit channel. A commit grows the shared signed chain (a new tip);
+  // broadcast {tip,length} so connected surfaces RE-FOLD the shared store. Inbound → reload() (re-read the
+  // signed log + re-fold), echo-guarded. The op-log persists to localStorage = the shared signed substrate.
+  let _applyingRemoteId = false, _lastIdTip = null;
+  function _chainTip() { const O = window.Bonsai.oplog; const ops = (O && O.db) ? O._geomOps() : []; return ops.length ? ops[ops.length - 1].op_hash : null; }
+  window.addEventListener('bonsai:oplog', () => {
+    if (!window.Connect || !window.Connect.on || _applyingRemoteId) return;
+    const tip = _chainTip();
+    if (tip === _lastIdTip) return;
+    _lastIdTip = tip;
+    // _emit() dispatches THIS event BEFORE it writes the shared store (_save). Defer the broadcast one tick so a
+    // peer that reloads from the store reads the just-committed op, not the pre-commit bytes (the P3 race).
+    const len = window.Bonsai.oplog.length;
+    setTimeout(() => { if (window.Connect && window.Connect.on) window.Connect.publish('identity', { tip: tip, length: len, surface: 'modeller' }); }, 0);
+  });
+  window.Connect.subscribe('identity', async (id) => {
+    if (!id || !window.Bonsai.oplog) return;
+    console.log('§CONNECT-ID-IN modeller tip=' + String(id.tip || '').slice(0, 12) + ' length=' + id.length + ' from=' + (id.surface || '?'));
+    _applyingRemoteId = true;
+    try { await window.Bonsai.oplog.reload(); _lastIdTip = _chainTip(); syncHistory(); } finally { _applyingRemoteId = false; }
+  });
   // CONNECT_SCENE_SPEC.md P2 — inbound timeline cursor: fold BOTH projections (geometry + records) to it,
   // echo-guarded. Scrub in one surface → every connected surface folds the one signed log to the same op_hash.
   window.Connect.subscribe('timeline', async (t) => {
@@ -1182,6 +1203,35 @@ if (qs.get('connecttl') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER connecttl fail ' + e); }
     window.__connectTlResult = out; window.__connectTlReady = true;
     console.log('§MODELLER connecttl-ready length=' + out.length + ' records=' + out.records);
+  })();
+}
+// ?connectid=demo sets up the Connect Scene P3 identity witness (W-CONNECT-IDENTITY): author ONE feature into
+// the shared signed op-log, enable Connect, and expose __insertSecond so the witness can COMMIT a second feature
+// on one surface and assert a connected surface re-folds the shared chain to the new tip (verifyChain holds).
+if (qs.get('connectid') === 'demo') {
+  (async () => {
+    const out = {};
+    const placeOne = async (hash, gx, gy, target) => {
+      if (!inserting) bInsert.onclick();
+      const pBtn = document.querySelector('#ins-panel .ins-c[data-hash="' + hash + '"]'); if (pBtn) pBtn.onclick();
+      const rect = canvas.getBoundingClientRect();
+      const v = new THREE.Vector3(gx, gy, 0).project(camera);
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height, bubbles: true }));
+      for (let i = 0; i < 80 && window.Bonsai.oplog.length < target; i++) await new Promise(r => setTimeout(r, 50));
+    };
+    try {
+      window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+      window.Bonsai.oplog.clear();
+      const cat = window.Bonsai.library.catalog();
+      const a = cat.find(c => c.ifc_class === 'IfcDoor') || cat[0];
+      const b = cat.find(c => c.ifc_class === 'IfcColumn') || cat[1] || cat[0];
+      await placeOne(a.hash, 4, 3, 1); syncHistory();
+      out.length = window.Bonsai.oplog.length;          // expect 1
+      window.__insertSecond = async () => { await placeOne(b.hash, 8, 3, 2); syncHistory(); return window.Bonsai.oplog.length; };
+      window.Connect.enable();
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER connectid fail ' + e); }
+    window.__connectIdResult = out; window.__connectIdReady = true;
+    console.log('§MODELLER connectid-ready length=' + out.length);
   })();
 }
 // ?place=demo proves PLACEMENT CORRECTNESS (W-BONSAI-PLACE): a component lands SEATED on the ground (not

--- a/viewer/tests/connect_bus_live.js
+++ b/viewer/tests/connect_bus_live.js
@@ -4,7 +4,7 @@
 // and the opt-in TOGGLE gates ALL cross-surface traffic — off on either end ⇒ zero ACKs. Surfaces stay
 // permanently separate (no shared DOM); only CONTEXT crosses. This is the bus P1–P3 channels ride on.
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
   '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };

--- a/viewer/tests/connect_identity_live.js
+++ b/viewer/tests/connect_identity_live.js
@@ -1,0 +1,63 @@
+// W-CONNECT-IDENTITY — Connect Scene P3 witness (prompts/CONNECT_SCENE_SPEC.md P3).
+// CLAIM: a commit in one surface appends to the shared signed chain → it broadcasts {tip,length} over the
+// 'identity' channel → a connected surface RE-FOLDS the shared signed store and reflects the new feature live,
+// with verifyChain holding throughout (still one signed log). Two separate Modeller surfaces share the signed
+// op-log via its persisted store; surface A commits a 2nd feature → surface B grows to match, geometry reflects
+// it, chain verifies. (3D draw GPU-gated; length + mesh count + verifyChain + the cross-surface §-log assert it.)
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+const probe = "(async () => { const O = window.Bonsai.oplog; const g = window.Bonsai.group && window.Bonsai.group(); const mesh = g ? g.children.filter(o => o.isMesh).length : -1; let ok = null; try { ok = (await O.verify()).ok; } catch (e) { ok = 'ERR'; } return { length: O.length, mesh, verify: ok }; })()";
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const mkPage = (tag) => br.newPage().then(pg => {
+    pg.on('console', m => { const t = m.text(); if (/^§(CONNECT-ID|MODELLER connectid|OPLOG reload)/.test(t)) console.log('  [' + tag + '] ' + t); });
+    pg.on('pageerror', e => console.log('  [' + tag + '] ERR ' + String(e).slice(0, 160)));
+    return pg;
+  });
+  // A AUTHORS (clear + insert 1) into the shared signed store, then enables Connect.
+  const A = await mkPage('A');
+  await A.goto(`http://localhost:${port}/modeller.html?connectid=demo&connect=1`, { waitUntil: 'load', timeout: 90000 });
+  await A.waitForFunction('window.__connectIdReady === true && window.__connectIdResult.length === 1', { timeout: 120000 })
+    .catch(() => console.log('  ✗ [A] connectid not ready'));
+  // B is a PASSIVE connected surface (?connect=1, NO clear) — its boot restore reads A's shared store → length 1.
+  const B = await mkPage('B');
+  await B.goto(`http://localhost:${port}/modeller.html?connect=1`, { waitUntil: 'load', timeout: 90000 });
+  await B.waitForFunction('window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.length === 1 && window.Connect && window.Connect.on', { timeout: 120000 })
+    .catch(() => console.log('  ✗ [B] did not restore shared store to length 1'));
+
+  // Baseline: both at length 1 (shared store, identical recipe).
+  const a0 = await A.evaluate(probe), b0 = await B.evaluate(probe);
+  // A COMMITS a second feature → grows the shared signed chain → broadcasts identity {tip, length:2}.
+  await A.evaluate(() => window.__insertSecond());
+  await new Promise(r => setTimeout(r, 1200));
+  // B should have re-folded the shared store to length 2, geometry reflects it, chain still verifies.
+  const a1 = await A.evaluate(probe), b1 = await B.evaluate(probe);
+
+  await br.close(); server.close();
+
+  const J = o => JSON.stringify(o);
+  console.log('  §CONNECT-IDENTITY baseline A=' + J(a0) + ' B=' + J(b0));
+  console.log('  §CONNECT-IDENTITY afterCommit A=' + J(a1) + ' B=' + J(b1));
+  const checks = {
+    baseline:     a0.length === 1 && b0.length === 1,
+    committerGrew: a1.length === 2 && a1.mesh === 2 && a1.verify === true,
+    peerReFolded:  b1.length === 2 && b1.mesh === 2,             // B reflected A's commit live over the shared store
+    chainVerifies: b1.verify === true                            // still ONE signed log (verifyChain holds on B)
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §CONNECT-IDENTITY VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' ') + '  (3D draw GPU-gated 🟡)');
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/connect_modeller_live.js
+++ b/viewer/tests/connect_modeller_live.js
@@ -3,7 +3,7 @@
 // button toggles the broker on/off (indicator + §-log) — proving the toggle lives on the actual surface,
 // not just the harness. (occt/WASM may not finish on Node18 V8; the broker + button wiring do not need it.)
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
   '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };

--- a/viewer/tests/connect_select_live.js
+++ b/viewer/tests/connect_select_live.js
@@ -8,7 +8,7 @@
 // Surfaces stay separate (no shared DOM); only the 'selection' CONTEXT crosses. 3D DRAW is GPU-gated → the
 // MATCH COUNT + the cross-surface §-log round-trip are the GPU-independent assertions.
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
   '.json': 'application/json', '.css': 'text/css', '.map': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png' };

--- a/viewer/tests/connect_timeline_live.js
+++ b/viewer/tests/connect_timeline_live.js
@@ -6,7 +6,7 @@
 // geometry AND its record BOTH vanish, and forward restores both: one log, two folds, co-vanishing, in lockstep
 // across surfaces. (3D draw GPU-gated; the MESH COUNT + RECORD COUNT + cross-surface §-log are the assertions.)
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-connect', 'viewer');
+const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
   '.json': 'application/json', '.css': 'text/css', '.map': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png' };
@@ -24,17 +24,22 @@ const state = "(" + (function () { const g = window.Bonsai.group && window.Bonsa
   await new Promise(r => server.listen(0, r)); const port = server.address().port;
   const br = await puppeteer.launch({ headless: 'new',
     args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
-  const open = async (tag) => {
-    const pg = await br.newPage();
+  const mk = (tag) => br.newPage().then(pg => {
     pg.on('console', m => { const t = m.text(); if (/^§(CONNECT-TL|MODELLER connecttl)/.test(t)) console.log('  [' + tag + '] ' + t); });
     pg.on('pageerror', e => console.log('  [' + tag + '] ERR ' + String(e).slice(0, 160)));
-    await pg.goto(`http://localhost:${port}/modeller.html?connecttl=demo&connect=1`, { waitUntil: 'load', timeout: 90000 });
-    await pg.waitForFunction('window.__connectTlReady === true && window.__connectTlResult.length === 2', { timeout: 120000 })
-      .catch(() => console.log('  ✗ [' + tag + '] connecttl not ready'));
     return pg;
-  };
-  const A = await open('A');                     // open A first so it is listening
-  const B = await open('B');
+  });
+  // A AUTHORS the 2-feature recipe into the shared store (the only author → no competing identity traffic).
+  const A = await mk('A');
+  await A.goto(`http://localhost:${port}/modeller.html?connecttl=demo&connect=1`, { waitUntil: 'load', timeout: 90000 });
+  await A.waitForFunction('window.__connectTlReady === true && window.__connectTlResult.length === 2', { timeout: 120000 })
+    .catch(() => console.log('  ✗ [A] connecttl not ready'));
+  // B is a PASSIVE connected surface — restores A's shared store (length 2), then follows A's scrub over 'timeline'.
+  const B = await mk('B');
+  await B.goto(`http://localhost:${port}/modeller.html?connect=1`, { waitUntil: 'load', timeout: 90000 });
+  await B.waitForFunction('window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.length === 2 && window.Connect && window.Connect.on', { timeout: 120000 })
+    .catch(() => console.log('  ✗ [B] did not restore shared store to length 2'));
+  await new Promise(r => setTimeout(r, 400));
 
   // Scrub A to cursor 1 → B should fold to 1 (geometry 1 mesh, records 1). Drive A's shared-scrub seam and await it.
   await A.evaluate(() => window.__scrubShared(1, true));

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -881,7 +881,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context
      as surface 'viewer' — selection/timeline/identity over the one signed op-log. Opt-in (toggle / ?connect=1). -->
-<script src="connect_scene.js?v=1" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
+<script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 <script src="main.js?v=43"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>


### PR DESCRIPTION
## P3 — Identity/commit channel (W-CONNECT-IDENTITY ✅)

Completes the Connect Scene core trio (selection #383 · timeline #384 · **identity**). A commit in one surface appends to the shared signed chain → broadcasts `{tip}` over the `identity` channel → connected surfaces **re-fold the shared signed store** and reflect the new feature live, `verifyChain` holding throughout (still one signed log).

- `bonsai_oplog.js` — `reload()`: re-read the signed op-log from the shared store **without clearing it**, re-fold. **Cursor-preserving**: a peer's commit no longer yanks a surface that's scrubbed back reviewing history (only follows to tip if already live at tip) — a real product fix surfaced by the witness.
- `modeller.html` — commit publishes `identity` (deferred one tick so the peer reads post-`_save` bytes, not pre-commit); subscribe → `reload()`+`syncHistory`, echo-guarded; `?connectid=demo` autopilot.
- **W-CONNECT-IDENTITY PASS**; regression BUS/SELECT/TIMELINE all PASS (timeline now deterministic 3/3 via a passive-B witness). 3D draw GPU-gated 🟡.

### Rebrand follow-up
- `bonsai_outliner.js` — tree root label **'Bonsai Model' → 'DAGeVu Model'** (visible string missed in the first rebrand pass, user-reported). Version bumps (connect_scene v2, bonsai_oplog v3, outliner v2) to bust caches.

### Next (parked, not in this PR)
Organize the modeller's **INSERT component picker by BOM hierarchy** (BOM Category tree from the old project's `BOM.db` / `component_library.db`, ~23,888 parts, httpvfs range-load + browse/search). Independent of the Connect Scene lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)