### PR TITLE
fix(modeller): front-elevated Z-up framing — grid reads flat, not lopsided

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -116,12 +116,15 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x14161c);
 
 const camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.05, 5000);
-camera.position.set(6, 5, 8);
 camera.up.set(0, 0, 1);   // world is Z-up → screen-up = Z so placed components STAND (top-down sketch view flips to Y-up)
+// FRONT-elevated Z-up framing: look mostly along +Y from in front, slightly to the side. With up=Z this keeps a
+// GRID AXIS roughly horizontal (the XY grid reads as a flat FLOOR receding, not a tilted diamond) AND objects
+// stand. A 45°-azimuth iso would render the axis-aligned grid as a lopsided diamond — avoid it.
+camera.position.set(8, -7, 6);
 
 const controls = new THREE.OrbitControls(camera, canvas);
 controls.enableDamping = true;
-controls.target.set(2, 1, 1.5);
+controls.target.set(4, 2, 0.4);
 
 scene.add(new THREE.HemisphereLight(0xbfd4ff, 0x202028, 1.1));
 const key = new THREE.DirectionalLight(0xffffff, 1.4); key.position.set(5, 10, 7); scene.add(key);
@@ -147,7 +150,9 @@ window.addEventListener('resize', () => {
 // sketch plan view (looking straight down −Z) isn't degenerate; presets are limited to Iso/Top accordingly.
 const bFit = document.getElementById('b-fit'), bView = document.getElementById('b-view');
 // up per view: Iso/3D = Z-up (objects stand); Top = Y-up (plan of the XY ground, non-degenerate looking down −Z).
-const VIEWS = [{ name: 'Iso', dir: new THREE.Vector3(1, 0.85, 1), up: new THREE.Vector3(0, 0, 1) },
+// Iso = front-elevated (mostly +Y, slight +X), up=Z → grid reads as a flat floor (not a lopsided diamond) +
+// objects stand. Top = plan looking down −Z, up=Y (non-degenerate).
+const VIEWS = [{ name: 'Iso', dir: new THREE.Vector3(0.45, -1, 0.7), up: new THREE.Vector3(0, 0, 1) },
                { name: 'Top', dir: new THREE.Vector3(0, 0.001, 1), up: new THREE.Vector3(0, 1, 0) }];
 let _viewIdx = 0;
 function _authoredBox() {

--- a/viewer/tests/bom_orientation_live.js
+++ b/viewer/tests/bom_orientation_live.js
@@ -31,6 +31,13 @@ const server = http.createServer((q, r) => {
     const up0 = cam.up.toArray().map(n => +n.toFixed(2));
     // default iso view: a higher world-Z point must project HIGHER on screen than a lower one (Z = screen-up)
     const zUpDefault = ndcY(2, 1, 3) > ndcY(2, 1, 1);
+    // GRID NOT LOPSIDED: the world +X grid axis must read ~HORIZONTAL on screen (a flat floor), not a 45° diamond.
+    // angle of world-X in screen space (account for aspect); <28° = aligned floor, ~45° = lopsided diamond.
+    const aspect = cam.aspect || (window.innerWidth / window.innerHeight);
+    const o = new THREE.Vector3(4, 2, 0).project(cam), xx = new THREE.Vector3(5, 2, 0).project(cam);
+    const sx = (xx.x - o.x) * aspect, sy = (xx.y - o.y);
+    const gridAxisDeg = +(Math.atan2(Math.abs(sy), Math.abs(sx)) * 180 / Math.PI).toFixed(1);
+    const gridFlat = gridAxisDeg < 28;
 
     // insert a real door, frame it (iso), then its TOP (max world-Z) must land above its BASE on screen
     window.Bonsai.grid.define({ xs: [0, 4], ys: [0, 3] }); window.Bonsai.oplog.clear();
@@ -55,7 +62,7 @@ const server = http.createServer((q, r) => {
     document.getElementById('b-view').click(); await new Promise(r => setTimeout(r, 100));   // back to Iso
     const upIso = cam.up.toArray().map(n => +n.toFixed(2));
 
-    return { up0, zUpDefault, topZ: +topZ.toFixed(2), botZ: +botZ.toFixed(2), doorUpright, upTop, upIso };
+    return { up0, zUpDefault, topZ: +topZ.toFixed(2), botZ: +botZ.toFixed(2), doorUpright, upTop, upIso, gridAxisDeg, gridFlat };
   });
 
   await br.close(); server.close();
@@ -65,6 +72,7 @@ const server = http.createServer((q, r) => {
     initZup:     eq(r.up0, [0, 0, 1]),                 // camera up is Z at load
     zIsScreenUp: r.zUpDefault === true,                // world +Z projects up on screen (iso)
     doorStands:  r.doorUpright === true,               // door top above base on screen (tall in Z)
+    gridFlat:    r.gridFlat === true,                  // grid axis ~horizontal (flat floor, NOT a lopsided diamond)
     topIsYup:    eq(r.upTop, [0, 1, 0]),               // Top/plan view flips to Y-up
     isoBackZup:  eq(r.upIso, [0, 0, 1])                // returning to Iso restores Z-up
   };


### PR DESCRIPTION
## Issue (user)
After #389 (camera.up=Z) objects stand, but the **grid renders as a tilted diamond** (lopsided), and re-leveling the grid would lay objects back on their side.

## Root cause
With `up=Z`, screen-right = `dir × Z`. The old default camera sat at a **45° azimuth**, so the axis-aligned XY grid projects to a 45° diamond. (The old `up=Y` view kept world-X horizontal — grid looked flat — but laid objects on their side.)

## Fix
**Front-elevated framing** (camera `(8,-7,6)` → target `(4,2,0.4)`; Iso dir `(0.45,-1,0.7)`) so a **grid axis stays ~horizontal** → the grid reads as a flat **floor** receding *and* objects stand.

**W-BOM-ORIENT** gains a `gridFlat` guard (world-X axis angle <28° off horizontal): measured **45° → 13°**. All orientation checks PASS.

## Note
Separate, still-queued: some library *furniture* meshes are authored non-Z-up in their own data (e.g. Dining_Chair) → those individual meshes stay tilted until the next-session extraction-normalization. This PR fixes the scene/grid, not the per-mesh data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)