### PR TITLE
fix(modeller): scene GridHelper lies flat + Outliner shows product name

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -128,7 +128,9 @@ controls.target.set(4, 2, 0.4);
 
 scene.add(new THREE.HemisphereLight(0xbfd4ff, 0x202028, 1.1));
 const key = new THREE.DirectionalLight(0xffffff, 1.4); key.position.set(5, 10, 7); scene.add(key);
-const grid = new THREE.GridHelper(40, 40, 0x2a3040, 0x21262f); scene.add(grid);
+const grid = new THREE.GridHelper(40, 40, 0x2a3040, 0x21262f);
+grid.rotation.x = Math.PI / 2;   // GridHelper defaults to the XZ plane (Y-up); rotate onto XY so it lies FLAT in our Z-up world (was standing up as a wall)
+scene.add(grid);
 scene.add(new THREE.AxesHelper(1.5));
 
 // window.A — the alternative viewer's app object, matching the viewer's A.scene convention so
@@ -922,7 +924,7 @@ window.Bonsai.outliner.addCategory({ key: 'components', label: 'Components', mat
   node: op => { const p = op.parameters.placement, c = window.Bonsai.library && window.Bonsai.library.get(op.parameters.hash);
     const a = (p && window.Bonsai.grid.refAt) ? window.Bonsai.grid.refAt(p.x, p.y) : null;
     const lod = window.Bonsai.library ? window.Bonsai.library.lodFor(op.id, op.parameters.lod) : op.parameters.lod;
-    return { id: op.id, label: (c ? c.ifc_class.replace('Ifc', '') : 'Component'),
+    return { id: op.id, label: (c ? (c.name || c.ifc_class.replace('Ifc', '')) : 'Component'),
       sub: ((a && (a.x || a.y)) ? ((a.x || '·') + '-' + (a.y || '·')) : '#' + op.id) + ' ·LOD' + lod }; } });
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;

--- a/viewer/tests/scene_grid_outliner_live.js
+++ b/viewer/tests/scene_grid_outliner_live.js
@@ -1,0 +1,36 @@
+// W-SCENE-GRID-OUTLINER — the scene GridHelper lies FLAT on XY (Z-up world, was a vertical wall) + the
+// Outliner shows the PRODUCT NAME (e.g. 'Bed King'), not the bare ifc_class. Math/DOM asserts, no visuals.
+const http=require('http'),fs=require('fs'),path=require('path');const VIEWER=require('path').join(__dirname,'..');
+const pup=require(path.join(process.env.HOME,'bim-compiler','node_modules','puppeteer'));
+const MIME={'.html':'text/html','.js':'text/javascript','.wasm':'application/wasm','.json':'application/json','.css':'text/css','.map':'application/json'};
+const s=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/modeller.html';fs.readFile(path.join(VIEWER,p),(e,b)=>{if(e){r.writeHead(404);r.end();return}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});r.end(b)})});
+(async()=>{await new Promise(r=>s.listen(0,r));const port=s.address().port;
+const br=await pup.launch({headless:'new',args:['--no-sandbox','--use-gl=angle','--use-angle=swiftshader','--enable-unsafe-swiftshader','--ignore-gpu-blocklist']});
+const pg=await br.newPage();pg.on('pageerror',e=>console.log('ERR',String(e).slice(0,120)));
+await pg.goto(`http://localhost:${port}/modeller.html`,{waitUntil:'load',timeout:60000});
+await pg.waitForFunction('window.Bonsai&&window.Bonsai.library&&window.Bonsai.library.ready&&window.A',{timeout:30000}).catch(()=>{});
+await pg.evaluate(()=>window.Bonsai.library.ready());
+const r=await pg.evaluate(async()=>{
+ const THREE=window.THREE;
+ // 1) scene GridHelper flat on XY?
+ const gh=window.A.scene.children.find(o=>o.type==='GridHelper');
+ const bb=new THREE.Box3().setFromObject(gh);
+ const gridZext=+(bb.max.z-bb.min.z).toFixed(3), gridYext=+(bb.max.y-bb.min.y).toFixed(2);
+ // 2) Outliner product name?
+ window.Bonsai.grid.define({xs:[0,4],ys:[0,3]});window.Bonsai.oplog.clear();
+ document.getElementById('b-insert').click();await window.Bonsai.library.ready();
+ const bed=[...document.querySelectorAll('#ins-body .ins-c')].find(b=>/bed king/i.test(b.textContent+b.title));bed.click();
+ const c=document.getElementById('c'),rect=c.getBoundingClientRect();const v=new THREE.Vector3(2,1.5,0).project(window.A.camera);
+ c.dispatchEvent(new PointerEvent('pointerdown',{button:0,clientX:rect.left+(v.x+1)/2*rect.width,clientY:rect.top+(1-v.y)/2*rect.height,bubbles:true}));
+ for(let i=0;i<60&&window.Bonsai.oplog.length<1;i++)await new Promise(r=>setTimeout(r,50));
+ if(window.Bonsai.outliner)window.Bonsai.outliner.refresh();
+ const rows=[...document.querySelectorAll('#bonsai-outliner [data-fid]')].map(d=>d.textContent.replace(/\s+/g,' ').trim());
+ return {gridZext,gridYext,gridRotX:+gh.rotation.x.toFixed(2),outlinerRows:rows};
+});
+await br.close();s.close();
+console.log(JSON.stringify(r));
+const gridFlat=r.gridZext<0.01 && r.gridYext>10;   // grid spans XY (Y wide), ~0 in Z = lying flat
+const nameOk=r.outlinerRows.some(t=>/Bed King/i.test(t));
+console.log('SCENE-GRID flat='+gridFlat+' (Zext='+r.gridZext+' rotX='+r.gridRotX+')  OUTLINER name='+nameOk+' rows='+JSON.stringify(r.outlinerRows));
+console.log('VERDICT '+(gridFlat&&nameOk?'PASS':'FAIL'));
+process.exit(gridFlat&&nameOk?0:1)})();


### PR DESCRIPTION
Two tiny details (user-pinpointed):

1. **Scene reference grid on its side** — `THREE.GridHelper` defaults to the **XZ plane (Y-up)**, so in our **Z-up** world it stood up as a wall. (Distinct from the *feature* grid, which was already correct — that was our miscommunication.) Fix: `grid.rotation.x = π/2` → lies flat on XY.
2. **Outliner product names** — inserted components were labelled by bare ifc_class ("Furniture"); now use the **product name** ("Bed King"), falling back to ifc_class.

**W-SCENE-GRID-OUTLINER PASS**: GridHelper Z-extent=0 (flat, rotX=1.57) + Outliner row = 'Bed King #1'.

Still queued for a fresh session (§NOTED): per-mesh furniture orientation (some library meshes authored non-Z-up) + dims-match occasionally picking another item's geometry (user: OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)