### PR TITLE
fix(modeller): background grid reads as a floor (classic-iso framing + corrected witness)

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -115,16 +115,21 @@ renderer.outputColorSpace = THREE.SRGBColorSpace;
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x14161c);
 
+// ONE consistent Z-up convention for the whole 3D scene: OrbitControls then orbits LEVEL about +Z (no per-view
+// roll band-aids). Set before any camera/controls are created so they inherit it. Plan views (top/sketch/route)
+// are the only documented exception — looking down the up-axis is degenerate, so those flip up→Y locally.
+THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
+
 const camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.05, 5000);
-camera.up.set(0, 0, 1);   // world is Z-up → screen-up = Z so placed components STAND (top-down sketch view flips to Y-up)
-// FRONT-elevated Z-up framing: look mostly along +Y from in front, slightly to the side. With up=Z this keeps a
-// GRID AXIS roughly horizontal (the XY grid reads as a flat FLOOR receding, not a tilted diamond) AND objects
-// stand. A 45°-azimuth iso would render the axis-aligned grid as a lopsided diamond — avoid it.
-camera.position.set(8, -7, 6);
+camera.up.set(0, 0, 1);
+// CLASSIC iso framing (numerically witnessed, W-SCENE-GRID): the view hits the z=0 grid plane at ~43° INCIDENCE
+// (≥40° → reads as a FLOOR you look down onto, not a grazing backdrop) and ~45° AZIMUTH off the Y-axis (so BOTH
+// grid families are oblique → a readable diamond floor, not one family seen edge-on). dir = (1,-1,1.3).
+camera.position.set(10.33, -6.83, 10.83);
 
 const controls = new THREE.OrbitControls(camera, canvas);
 controls.enableDamping = true;
-controls.target.set(4, 2, 0.4);
+controls.target.set(2, 1.5, 0);   // orbit/target on the FLOOR (z=0) so the grid is the ground under the model
 
 scene.add(new THREE.HemisphereLight(0xbfd4ff, 0x202028, 1.1));
 const key = new THREE.DirectionalLight(0xffffff, 1.4); key.position.set(5, 10, 7); scene.add(key);
@@ -154,7 +159,7 @@ const bFit = document.getElementById('b-fit'), bView = document.getElementById('
 // up per view: Iso/3D = Z-up (objects stand); Top = Y-up (plan of the XY ground, non-degenerate looking down −Z).
 // Iso = front-elevated (mostly +Y, slight +X), up=Z → grid reads as a flat floor (not a lopsided diamond) +
 // objects stand. Top = plan looking down −Z, up=Y (non-degenerate).
-const VIEWS = [{ name: 'Iso', dir: new THREE.Vector3(0.45, -1, 0.7), up: new THREE.Vector3(0, 0, 1) },
+const VIEWS = [{ name: 'Iso', dir: new THREE.Vector3(1, -1, 1.3), up: new THREE.Vector3(0, 0, 1) },
                { name: 'Top', dir: new THREE.Vector3(0, 0.001, 1), up: new THREE.Vector3(0, 1, 0) }];
 let _viewIdx = 0;
 function _authoredBox() {

--- a/viewer/tests/bom_orientation_live.js
+++ b/viewer/tests/bom_orientation_live.js
@@ -1,8 +1,10 @@
-// W-BOM-ORIENT — DAGeVu modeller: placed components STAND upright (Z-up world rendered Z-up). CLAIM: the
-// geometry was always correct Z-up; the bug was camera.up=Y laying the 3D view back. Fix = view-dependent up
-// (Iso/3D = Z-up so objects stand; Top/sketch = Y-up plan). Verified by MATH (screen projection), no visuals:
-// world +Z projects to screen-UP in the iso view, a door's top vertex lands ABOVE its base on screen, and the
-// top/sketch views flip to Y-up. (3D draw GPU-gated → projection math is the assertion.)
+// W-BOM-ORIENT — DAGeVu modeller: objects STAND upright AND the background grid READS AS A FLOOR. The earlier
+// rounds (#389/#390/#391) fixed up-vector + GridHelper yet the user still saw it wrong, because the witness
+// asserted the WRONG invariant (`gridAxisDeg<28` rewarded an axis-aligned camera — exactly what grazes the floor
+// edge-on into a backdrop). Holistic fix: ONE Z-up convention (THREE DEFAULT_UP=Z, level orbit) + a classic-iso
+// camera (~43° incidence onto z=0, ~45° azimuth) so BOTH grid families are oblique = a readable diamond floor.
+// Verified by MATH (screen projection), calibrated once vs a real render: world +Z projects screen-UP, a door's
+// top vertex lands above its base, FLOOR INCIDENCE ∈ [38,60]°, BOTH grid families project oblique (not edge-on).
 const http = require('http'), fs = require('fs'), path = require('path');
 const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
@@ -31,13 +33,23 @@ const server = http.createServer((q, r) => {
     const up0 = cam.up.toArray().map(n => +n.toFixed(2));
     // default iso view: a higher world-Z point must project HIGHER on screen than a lower one (Z = screen-up)
     const zUpDefault = ndcY(2, 1, 3) > ndcY(2, 1, 1);
-    // GRID NOT LOPSIDED: the world +X grid axis must read ~HORIZONTAL on screen (a flat floor), not a 45° diamond.
-    // angle of world-X in screen space (account for aspect); <28° = aligned floor, ~45° = lopsided diamond.
+    // GRID READS AS A FLOOR — the two invariants the old `gridAxisDeg<28` check MISSED (and inverted: that check
+    // rewarded an axis-aligned camera, which is exactly what grazes the floor edge-on). Both calibrated against a
+    // real render (shot_empty.png) so this is now verified by MATH, no eyeballs:
     const aspect = cam.aspect || (window.innerWidth / window.innerHeight);
-    const o = new THREE.Vector3(4, 2, 0).project(cam), xx = new THREE.Vector3(5, 2, 0).project(cam);
-    const sx = (xx.x - o.x) * aspect, sy = (xx.y - o.y);
-    const gridAxisDeg = +(Math.atan2(Math.abs(sy), Math.abs(sx)) * 180 / Math.PI).toFixed(1);
-    const gridFlat = gridAxisDeg < 28;
+    // (1) FLOOR INCIDENCE — angle the view ray makes with the z=0 grid plane. ~30° = grazing (grid reads as a
+    //     backdrop wall); 38-60° = you look DOWN onto a floor. classic iso ≈ 43°.
+    const vd = new THREE.Vector3().subVectors(window.A.controls.target, cam.position);
+    const floorIncidenceDeg = +(Math.asin(Math.abs(vd.z) / vd.length()) * 180 / Math.PI).toFixed(1);
+    // (2) BOTH GRID FAMILIES OBLIQUE — project a unit X-edge and a unit Y-edge of the floor; for a readable
+    //     diamond floor both have substantial on-screen length and are well-separated in angle. A grazing
+    //     axis-aligned view collapses one family to ~0 on screen (edge-on) → tiny length or near-parallel.
+    const prj = (x, y) => { const p = new THREE.Vector3(x, y, 0).project(cam); return [p.x * aspect, p.y]; };
+    const o2 = prj(2, 1.5), xs = prj(3, 1.5), ys = prj(2, 2.5);
+    const vx = [xs[0] - o2[0], xs[1] - o2[1]], vy = [ys[0] - o2[0], ys[1] - o2[1]];
+    const lx = Math.hypot(...vx), ly = Math.hypot(...vy);
+    const famAngleDeg = +(Math.acos(Math.max(-1, Math.min(1, (vx[0] * vy[0] + vx[1] * vy[1]) / (lx * ly)))) * 180 / Math.PI).toFixed(1);
+    const bothFamiliesVisible = Math.min(lx, ly) > 0.02;   // neither family edge-on (NDC units)
 
     // insert a real door, frame it (iso), then its TOP (max world-Z) must land above its BASE on screen
     window.Bonsai.grid.define({ xs: [0, 4], ys: [0, 3] }); window.Bonsai.oplog.clear();
@@ -62,7 +74,8 @@ const server = http.createServer((q, r) => {
     document.getElementById('b-view').click(); await new Promise(r => setTimeout(r, 100));   // back to Iso
     const upIso = cam.up.toArray().map(n => +n.toFixed(2));
 
-    return { up0, zUpDefault, topZ: +topZ.toFixed(2), botZ: +botZ.toFixed(2), doorUpright, upTop, upIso, gridAxisDeg, gridFlat };
+    return { up0, zUpDefault, topZ: +topZ.toFixed(2), botZ: +botZ.toFixed(2), doorUpright, upTop, upIso,
+             floorIncidenceDeg, famAngleDeg, bothFamiliesVisible, lx: +lx.toFixed(3), ly: +ly.toFixed(3) };
   });
 
   await br.close(); server.close();
@@ -72,7 +85,8 @@ const server = http.createServer((q, r) => {
     initZup:     eq(r.up0, [0, 0, 1]),                 // camera up is Z at load
     zIsScreenUp: r.zUpDefault === true,                // world +Z projects up on screen (iso)
     doorStands:  r.doorUpright === true,               // door top above base on screen (tall in Z)
-    gridFlat:    r.gridFlat === true,                  // grid axis ~horizontal (flat floor, NOT a lopsided diamond)
+    floorReads:  r.floorIncidenceDeg >= 38 && r.floorIncidenceDeg <= 60,  // look DOWN onto a floor, not graze it
+    diamond:     r.bothFamiliesVisible && r.famAngleDeg >= 35,            // both grid families oblique = readable floor
     topIsYup:    eq(r.upTop, [0, 1, 0]),               // Top/plan view flips to Y-up
     isoBackZup:  eq(r.upIso, [0, 0, 1])                // returning to Iso restores Z-up
   };

--- a/viewer/tests/grid_shot.js
+++ b/viewer/tests/grid_shot.js
@@ -1,0 +1,49 @@
+// One-off VISUAL capture of the modeller — renders real pixels (not projection math) so we can SEE the
+// background grid orientation. Spec MODELLER_BOM_CATALOG_SPEC §ORIENTATION: "reproduce visually, don't iterate
+// on headless math again." Saves: shot_empty (default view), shot_door (after inserting a door + Fit).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1100, height: 800 });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 160)));
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.library && window.Bonsai.library.ready && window.A && window.A.camera", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+  await new Promise(r => setTimeout(r, 400));
+  await pg.screenshot({ path: path.join(__dirname, 'shot_empty.png') });
+  console.log('§SHOT empty written');
+
+  // insert a door + fit (iso)
+  await pg.evaluate(async () => {
+    window.Bonsai.grid.define({ xs: [0, 4], ys: [0, 3] }); window.Bonsai.oplog.clear();
+    document.getElementById('b-insert').click(); await window.Bonsai.library.ready();
+    const door = [...document.querySelectorAll('#ins-body .ins-c')].find(b => /door/i.test(b.textContent + b.title));
+    door.click();
+    const THREE = window.THREE, cam = window.A.camera;
+    const c = document.getElementById('c'), rect = c.getBoundingClientRect();
+    const v = new THREE.Vector3(2, 1.5, 0).project(cam);
+    c.dispatchEvent(new PointerEvent('pointerdown', { button: 0, clientX: rect.left + (v.x + 1) / 2 * rect.width, clientY: rect.top + (1 - v.y) / 2 * rect.height, bubbles: true }));
+    for (let i = 0; i < 80 && window.Bonsai.oplog.length < 1; i++) await new Promise(r => setTimeout(r, 50));
+  });
+  await new Promise(r => setTimeout(r, 1200));
+  await pg.evaluate(() => document.getElementById('b-fit').click());
+  await new Promise(r => setTimeout(r, 500));
+  await pg.screenshot({ path: path.join(__dirname, 'shot_door.png') });
+  console.log('§SHOT door written');
+
+  await br.close(); server.close();
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What
The modeller's background grid kept reading as a tilted backdrop/wall instead of a floor, despite #389/#390/#391.

## Root cause — a backwards witness, not a GPU/visual gap
`W-BOM-ORIENT` asserted `gridAxisDeg < 28°`, which **rewards an axis-aligned camera** — exactly the framing that sights down one grid family and grazes the z=0 floor edge-on. The witness green-lit the bug, so every prior fix passed while still looking wrong.

## Fix (deterministic, math-verified)
- **One Z-up convention:** `THREE.Object3D.DEFAULT_UP = Z` → OrbitControls orbits level; no per-view roll band-aids fighting each other.
- **Classic-iso camera:** ~42.6° incidence onto the z=0 grid plane (≥38° = look *down* onto a floor) + ~45° azimuth (both grid families oblique = a readable diamond floor). `dir=(1,-1,1.3)`, target on the floor (z=0).
- **Witness corrected:** replaced the inverted `gridAxisDeg<28` with the two invariants it missed — `floorIncidence ∈ [38,60]°` and `bothFamiliesOblique (famAngle ≥ 35°)`. Calibrated once against a real render (`tests/grid_shot.js`), then verified by projection math only.

## Witnesses
- W-BOM-ORIENT **PASS** — floorIncidence=42.6°, famAngle=68.2°, doorStands=true, topIsYup=true
- bonsai camera / grid / insert witnesses unaffected (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)