### PR TITLE
feat(erp): Rpt M_Movement KIND-1 report fold (AD_Process 290) — sw v717 (W-PROC-MOVEMENT)

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -104,6 +104,10 @@
     // (amount:null → subtotal/tax/total stay null, qty=MovementQty carried) — honest, never a fabricated total.
     // AD_PROCESS_FOLD_LANE §P2-tail-leg1 — Witness: W-PROC-MINOUT.
     registerHandler('report:m_inout',   receiptHandler('m_inout'),   { kind: 'report', reportKey: 'm_inout' });
+    // report:m_movement — "Rpt M_Movement" (AD_Process 290, "Inventory Move Print"). KIND-1, the warehouse sibling
+    // of report:m_inout (AD_PROCESS_FOLD_LANE §P2-tail-leg2): folds an M_Movement → a NON-FINANCIAL receipt via the
+    // SAME report_overlay.foldReceipt over REPORT_MAP.m_movement — ZERO new fold code, zero host change.
+    registerHandler('report:m_movement',receiptHandler('m_movement'),{ kind: 'report', reportKey: 'm_movement' });
     // report:c_project — "Rpt C_Project" (AD_Process 217, Project Print). KIND-1, folds via the SAME foldReceipt
     // (REPORT_MAP.c_project), no new fold code. AD_PROCESS_FOLD_LANE §P2-leg3 — Witness: W-PROC-PROJPRINT.
     registerHandler('report:c_project', receiptHandler('c_project'), { kind: 'report', reportKey: 'c_project' });
@@ -448,6 +452,10 @@
       // "m_inoutconfirm" — no boundary) and the RV_InOutDetails report-VIEWs (293/294) stay absent-handler.
       // "delivery note"/"shipment print" are the print-format name; "shipment confirmation"/"...details" do NOT match.
       if (/m_inout\b|delivery note|shipment print/.test(hay)) return 'report:m_inout';
+      // "Rpt M_Movement" (290) — M_Movement-SPECIFIC: m_movement\b (word-boundary) so the imperative M_Movement
+      // procs ("M_Movement_Process"/"M_MovementConfirm_Process", 122/286 — isReport=N, never reach here anyway) and
+      // any future RV_Movement* report-VIEW stay absent-handler. "inventory move print" is the unique print name.
+      if (/m_movement\b|inventory move print/.test(hay)) return 'report:m_movement';
       // "Rpt C_Project" (217) — SPECIFIC match (c_project / project print), NOT the broad "project" so the other
       // RV_Project* report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay absent-handler (no foldReceipt
       // for a report view — those are a later report-view fold, not this leg).

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -439,7 +439,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=6"></script>
+<script src="ad_process.js?v=7"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -497,7 +497,7 @@
 <script src="bim_embed.js?v=1"></script>
 <script src="bim_panel.js?v=2"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
-<script src="report_overlay.js?v=4"></script>
+<script src="report_overlay.js?v=5"></script>
 <script src="rule_fold.js?v=2"></script>
 <!-- POS_ADDON_SPEC §P-1..§P-4 — the POS addon: engine verbs (UMD of bim-compiler scripts/erp_engine.js),
      the fold glue (pos_core.js, == bim-compiler build/erp source of truth), the dumb-terminal lens.

--- a/erp/report_overlay.js
+++ b/erp/report_overlay.js
@@ -28,6 +28,14 @@
     m_inout:   { key: 'm_inout',   pk: 'm_inout_id',   lineTable: 'm_inoutline',   fk: 'm_inout_id',
                  fkProduct: 'm_product_id', amount: null,        qty: 'movementqty', price: null,
                  date: 'movementdate', total: null },
+    // Rpt M_Movement (AD_Process 290, "Inventory Move Print") — the warehouse sibling of m_inout (AD_PROCESS_FOLD_LANE
+    // §P2-tail-leg2). A material movement is NON-FINANCIAL (amount/price/total null) — header M_Movement + lines
+    // M_MovementLine, the carried value is qty=MovementQty. SAME foldReceipt, NO new fold code. A movement has no
+    // c_bpartner_id (internal locator→locator) → partner folds honestly null. The browser lc() helper aliases the
+    // bundle's CamelCase (DocumentNo/MovementQty/MovementDate) to these lowercase keys.
+    m_movement:{ key: 'm_movement',pk: 'm_movement_id',lineTable: 'm_movementline',fk: 'm_movement_id',
+                 fkProduct: 'm_product_id', amount: null,        qty: 'movementqty', price: null,
+                 date: 'movementdate', total: null },
     // Rpt C_Project (AD_Process 217, "Project Print") — a KIND-1 report folded by the SAME foldReceipt as the
     // order/invoice prints (no new fold code, AD_PROCESS_FOLD_LANE §P2-leg3). A project IS a document: header
     // C_Project + lines C_ProjectLine; the planned amounts are its money (subtotal = Σ PlannedAmt, total = the

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v716';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v717';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## AD_PROCESS_FOLD_LANE §P2-tail-leg2 — Rpt M_Movement (Inventory Move Print)

The warehouse sibling of **Rpt M_InOut** (§P2-tail-leg1, #367). KIND-1 report fold, **zero new fold code, zero host change**.

- **AD_Process 290** ("Rpt M_Movement" / "Inventory Move Print", blank classname, `isReport=Y`, no paras) resolves through the W-PROC spine to a synthesized `report:m_movement` key.
- Folds an **M_Movement → a NON-FINANCIAL receipt** via the EXISTING `report_overlay.foldReceipt` over one new `REPORT_MAP.m_movement` row.
- A material movement carries **qty (MovementQty), not money**: `amount/price/total` fold honestly to `null` (never a fabricated total); a locator→locator move has no `c_bpartner_id` → `partner` null.
- Real served bundle row: **M_Movement 100** (DocumentNo 10000000, 1 line, product 123, qty 4).
- `resolveClassname` match is M_Movement-SPECIFIC (`m_movement\b` | "inventory move print"); the imperative `M_Movement_Process` / `M_MovementConfirm_Process` (122/286, `isReport=N`) stay the honest absent-handler card.

### Witnesses (both EXIT 0)
- `poc_proc_movement.js` — **W-PROC-MOVEMENT 6/6**: resolve, non-financial cent-honest fold, per-line qty=MovementQty, falsifier (+7), guard.
- `poc_movement_live.js` — **W-PROC-MOVEMENT-LIVE PASS**, 0 pageerrors: `?process=290` deep-link (GardenAdmin/role 102) → result card, M_Movement 100 folds to qty 4 in-browser off the real CamelCase bundle.
- Regression: W-PROC-MINOUT / W-PROC-PROJPRINT (headless) + W-PROC-MINOUT-LIVE all still PASS.

`sw v716→v717`, `ad_process.js?v=6→7`, `report_overlay.js?v=4→5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)