### PR TITLE
feat(erp): Rpt M_Inventory KIND-1 report fold (AD_Process 291) — sw v718 (W-PROC-MINVENTORY)

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -108,6 +108,10 @@
     // of report:m_inout (AD_PROCESS_FOLD_LANE §P2-tail-leg2): folds an M_Movement → a NON-FINANCIAL receipt via the
     // SAME report_overlay.foldReceipt over REPORT_MAP.m_movement — ZERO new fold code, zero host change.
     registerHandler('report:m_movement',receiptHandler('m_movement'),{ kind: 'report', reportKey: 'm_movement' });
+    // report:m_inventory — "Rpt M_Inventory" (AD_Process 291, "Physical Inventory Print"). KIND-1, the third
+    // inventory-document print (AD_PROCESS_FOLD_LANE §P2-tail-leg3): folds an M_Inventory → a NON-FINANCIAL receipt
+    // (qty=QtyCount) via the SAME report_overlay.foldReceipt over REPORT_MAP.m_inventory — ZERO new fold code.
+    registerHandler('report:m_inventory',receiptHandler('m_inventory'),{ kind: 'report', reportKey: 'm_inventory' });
     // report:c_project — "Rpt C_Project" (AD_Process 217, Project Print). KIND-1, folds via the SAME foldReceipt
     // (REPORT_MAP.c_project), no new fold code. AD_PROCESS_FOLD_LANE §P2-leg3 — Witness: W-PROC-PROJPRINT.
     registerHandler('report:c_project', receiptHandler('c_project'), { kind: 'report', reportKey: 'c_project' });
@@ -456,6 +460,10 @@
       // procs ("M_Movement_Process"/"M_MovementConfirm_Process", 122/286 — isReport=N, never reach here anyway) and
       // any future RV_Movement* report-VIEW stay absent-handler. "inventory move print" is the unique print name.
       if (/m_movement\b|inventory move print/.test(hay)) return 'report:m_movement';
+      // "Rpt M_Inventory" (291) — M_Inventory-SPECIFIC: m_inventory\b (word-boundary) | "physical inventory print"
+      // so the imperative M_Inventory procs (105/106 carry non-blank classnames; 107 "M_Inventory Process" is
+      // isReport=N → never reaches here) stay absent-handler. "inventory" alone is NOT matched (too broad).
+      if (/m_inventory\b|physical inventory print/.test(hay)) return 'report:m_inventory';
       // "Rpt C_Project" (217) — SPECIFIC match (c_project / project print), NOT the broad "project" so the other
       // RV_Project* report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay absent-handler (no foldReceipt
       // for a report view — those are a later report-view fold, not this leg).

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -439,7 +439,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=7"></script>
+<script src="ad_process.js?v=8"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -497,7 +497,7 @@
 <script src="bim_embed.js?v=1"></script>
 <script src="bim_panel.js?v=2"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
-<script src="report_overlay.js?v=5"></script>
+<script src="report_overlay.js?v=6"></script>
 <script src="rule_fold.js?v=2"></script>
 <!-- POS_ADDON_SPEC §P-1..§P-4 — the POS addon: engine verbs (UMD of bim-compiler scripts/erp_engine.js),
      the fold glue (pos_core.js, == bim-compiler build/erp source of truth), the dumb-terminal lens.

--- a/erp/report_overlay.js
+++ b/erp/report_overlay.js
@@ -36,6 +36,14 @@
     m_movement:{ key: 'm_movement',pk: 'm_movement_id',lineTable: 'm_movementline',fk: 'm_movement_id',
                  fkProduct: 'm_product_id', amount: null,        qty: 'movementqty', price: null,
                  date: 'movementdate', total: null },
+    // Rpt M_Inventory (AD_Process 291, "Physical Inventory Print") — the third inventory-document print
+    // (AD_PROCESS_FOLD_LANE §P2-tail-leg3, after m_inout + m_movement). NON-FINANCIAL: a physical count carries
+    // qty=QtyCount (the counted quantity), not money — amount/price/total null. Header M_Inventory + lines
+    // M_InventoryLine; no c_bpartner_id column → partner folds honestly null. SAME foldReceipt, NO new fold code.
+    // The browser lc() helper aliases the bundle's CamelCase (DocumentNo/QtyCount/MovementDate) to these keys.
+    m_inventory:{key: 'm_inventory',pk:'m_inventory_id',lineTable:'m_inventoryline',fk:'m_inventory_id',
+                 fkProduct: 'm_product_id', amount: null,        qty: 'qtycount',    price: null,
+                 date: 'movementdate', total: null },
     // Rpt C_Project (AD_Process 217, "Project Print") — a KIND-1 report folded by the SAME foldReceipt as the
     // order/invoice prints (no new fold code, AD_PROCESS_FOLD_LANE §P2-leg3). A project IS a document: header
     // C_Project + lines C_ProjectLine; the planned amounts are its money (subtotal = Σ PlannedAmt, total = the

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v717';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v718';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## AD_PROCESS_FOLD_LANE §P2-tail-leg3 — Rpt M_Inventory (Physical Inventory Print)

The third inventory-document print, completing the trio: **Rpt M_InOut** (#367) → **Rpt M_Movement** (#398) → **Rpt M_Inventory**. KIND-1 report fold, **zero new fold code, zero host change**.

- **AD_Process 291** ("Rpt M_Inventory" / "Physical Inventory Print", blank classname, `isReport=Y`, no paras) resolves through the W-PROC spine to a synthesized `report:m_inventory` key.
- Folds an **M_Inventory → a NON-FINANCIAL receipt** via the EXISTING `report_overlay.foldReceipt` over one new `REPORT_MAP.m_inventory` row.
- A physical count carries **qty=QtyCount** (the counted quantity), not money: `amount/price/total` fold honestly to `null`; M_Inventory has no `c_bpartner_id` → `partner` null.
- Real served bundle row: **M_Inventory 100** (DocumentNo 10000000, 1 line, product 147, QtyCount 1).
- `resolveClassname` match is M_Inventory-SPECIFIC (`m_inventory\b` | "physical inventory print"); the imperative `M_Inventory Create`/`Update` (105/106, non-blank classnames) + `M_Inventory Process` (107, `isReport=N`) stay the honest absent-handler card. "inventory" alone is NOT matched.

### Witnesses (both EXIT 0)
- `poc_proc_minventory.js` — **W-PROC-MINVENTORY 6/6**: resolve, non-financial cent-honest fold, per-line qty=QtyCount, falsifier (+7), guard (105/106/107).
- `poc_minventory_live.js` — **W-PROC-MINVENTORY-LIVE PASS**, 0 pageerrors: `?process=291` deep-link (GardenAdmin/role 102) → result card, M_Inventory 100 folds to qty 1 in-browser off the real CamelCase bundle.
- Regression: W-PROC-MINOUT / W-PROC-MOVEMENT / W-PROC-PROJPRINT (headless) + W-PROC-MOVEMENT-LIVE all still PASS.

`sw v717→v718`, `ad_process.js?v=7→8`, `report_overlay.js?v=5→6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)