### PR TITLE
feat(erp): System Monitor + login info panel — iDempiere's System surface, serverless-reframed (W-SYSTEM-MONITOR-LIVE)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -276,6 +276,13 @@
     font-weight:800; font-size:17px; letter-spacing:-.5px; display:flex; align-items:center; justify-content:center; margin:0 auto 10px; }
   .idmp-login-title { text-align:center; font-size:18px; font-weight:700; }
   .idmp-login-sub { text-align:center; font-size:11.5px; color:var(--idmp-muted); margin:5px 0 16px; }
+  /* SYSTEM_ADMIN_LANE §6 — login info panel (version + credential hints + System Monitor link) */
+  .idmp-login-info { margin-top:16px; padding-top:11px; border-top:1px solid #eef1f5; text-align:center;
+    font-size:10.5px; color:var(--idmp-muted); line-height:1.7; }
+  .idmp-login-info .idmp-info-creds { color:#5a6675; }
+  .idmp-login-info b { color:#33404f; font-weight:600; }
+  .idmp-login-info .idmp-info-mon a { color:var(--idmp-blue); text-decoration:none; font-weight:600; }
+  .idmp-login-info .idmp-info-mon a:hover { text-decoration:underline; }
   .idmp-login-label { font-size:11px; text-transform:uppercase; letter-spacing:.4px; color:var(--idmp-muted); margin:13px 0 5px; }
   .idmp-login-list { display:flex; flex-direction:column; gap:6px; max-height:48vh; overflow:auto; }
   .idmp-login-user { display:flex; align-items:center; gap:10px; padding:9px 12px; border:1px solid var(--idmp-border);
@@ -394,6 +401,14 @@
          (login/pre-client-gated, behind the ⋯), reached via the SAME window.openInstallFor/openMigrateFor the card
          buttons used (kept). This reverses #204's card-buttons decision (now superseded). The ShowMe pill
          (§P4-1/§P4-2) is the front-door guide here. -->
+    <!-- SYSTEM_ADMIN_LANE §6 — iDempiere-style login info panel: release/dictionary version + the default
+         credential hints (the real seed users, exactly as iDempiere's demo login shows them) + the System
+         Monitor link (serverless reframe). Identity is still passwordless SELECTION; the pass is the hint. -->
+    <div id="idmp-login-info" class="idmp-login-info">
+      <div class="idmp-info-row"><span id="idmp-info-ver">Code &mdash;</span> &middot; Dictionary: iDempiere &middot; SQLite&#8209;wasm &middot; serverless</div>
+      <div class="idmp-info-creds"><b>System:</b> SuperUser / System &nbsp;&middot;&nbsp; <b>GardenWorld:</b> GardenAdmin / GardenAdmin</div>
+      <div class="idmp-info-mon"><a href="#" id="idmp-sysmon-link">System Monitor</a></div>
+    </div>
   </div>
 </div>
 
@@ -461,6 +476,7 @@
 <script src="genesis_seed.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §SA1 — default-CoA seed; MUST load before genesis.js (it reads global.GenesisSeed at load) -->
 <script src="genesis.js?v=2"></script>
 <script src="system_tenant.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §SA1 — boot overlay: make System(0) a log-in-able tenant -->
+<script src="system_monitor.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor, serverless reframe (window.SystemMonitor) -->
 <script src="erp_preview.js?v=2"></script>
 <!-- CONSISTENCY_FINISH.md §K-1/§K-2 — icons.js (verbatim glyph DATA) + the shared overlay kit load BEFORE
      the import overlays (migrate_showme builds its STEPS at module load and renders Lucide icons). -->
@@ -3578,6 +3594,21 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // tenant from the rail, which is exactly the "change tenant from the rail" journey J8 asks for.
     $('idmp-login-tenants-back').addEventListener('click', function () { _loginClient = null; _loginUser = null; loginStep0(SES.listClients(db), _demoTenants()); });
     $('idmp-login-ok').addEventListener('click', doLogin);
+    // SYSTEM_ADMIN_LANE §6 — login info panel: fill the live release tag (sw CACHE_VERSION) + open System Monitor.
+    (function () {
+      var lnk = $('idmp-sysmon-link');
+      if (lnk) lnk.addEventListener('click', function (e) { e.preventDefault(); if (window.SystemMonitor) window.SystemMonitor.open(); });
+      function fillVer() {
+        try {
+          if (!navigator.serviceWorker || !navigator.serviceWorker.controller) return;
+          var ch = new MessageChannel();
+          ch.port1.onmessage = function (ev) { var v = ev.data && ev.data.version; var el = $('idmp-info-ver'); if (v && el) el.innerHTML = 'Code ' + v; };
+          navigator.serviceWorker.controller.postMessage({ type: 'GET_PRECACHE' }, [ch.port2]);
+        } catch (e) {}
+      }
+      fillVer();   // SW may not control yet on a first cold load → retry when it takes control / is ready
+      try { if (navigator.serviceWorker) { navigator.serviceWorker.addEventListener('controllerchange', fillVer); navigator.serviceWorker.ready.then(fillVer); } } catch (e) {}
+    })();
     $('idmp-switch-btn').addEventListener('click', function () { showLogin('role'); });
     $('idmp-login').addEventListener('click', function (e) { if (e.target === $('idmp-login') && _session) $('idmp-login').style.display = 'none'; });
     boot().catch(function (e) { console.error('§IDEMPIERE boot error: ' + e.message); $('idmp-load-msg').textContent = 'Boot error: ' + e.message; });

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v719';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v720';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -55,6 +55,7 @@ const PRECACHE_ASSETS = [
   'genesis.js',        // genesis engine (UMD, window.Genesis) — births a tenant as a signed op-log
   'genesis_seed.js',   // NON-INVENT default-genesis data (311 iDempiere default accounts + 73 default-acct maps)
   'system_tenant.js',  // SYSTEM_ADMIN_LANE §SA1 — boot overlay: System(0) login surface (W-GENESIS-SYSADMIN)
+  'system_monitor.js', // SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor (serverless reframe, window.SystemMonitor)
   'erp_snapshot_sign.js', // ECDSA P-256 signer (UMD, window.ErpSnapshotSign) — signs the genesis bundle head
   '14-sap-chain.json', // SAP /DMO/ Flight PoC oracle (fetch-fold-install demo data; user can replace via file-drop)
   'idmp_session.js',

--- a/erp/system_monitor.js
+++ b/erp/system_monitor.js
@@ -1,0 +1,139 @@
+// BIM OOTB — ERP. Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
+// system_monitor.js — SYSTEM_ADMIN_LANE §6 (serverless reframe). iDempiere's System Monitor (the
+//   /idempiere-monitor servlet, AdempiereMonitor.java) — same sections (Memory · Cache · Logs/Trace · Servers ·
+//   Cluster/Threads · Database) — but on a serverless browser kernel: every section shows OUR REAL LOCAL value
+//   where one exists (heap via performance.memory, idb/cache via Storage API + the SW release), and an HONEST
+//   "No longer needed" reframe where the server is gone (background processors, cluster, thread pool, Postgres
+//   host), each carrying "Read further →" into the Migrate/Compare paper. NON-INVENT: real device numbers, real
+//   sw CACHE_VERSION; nothing faked (heap shows "n/a" where the browser doesn't expose it). W-SYSTEM-MONITOR-LIVE.
+(function (global) {
+  'use strict';
+  var COMPARE = 'migrate_compare.html';   // the MigrateComparison paper (same erp/ folder, ships in PRECACHE)
+
+  function mb(n) { return (n == null) ? null : (n / 1048576).toFixed(1) + ' MB'; }
+
+  // sw CACHE_VERSION = our RELEASE tag — asked over the live SW (GET_PRECACHE → {version}); null if no controller.
+  function swVersion() {
+    return new Promise(function (res) {
+      try {
+        if (!navigator.serviceWorker || !navigator.serviceWorker.controller) return res(null);
+        var ch = new MessageChannel();
+        ch.port1.onmessage = function (e) { res(e.data && e.data.version || null); };
+        navigator.serviceWorker.controller.postMessage({ type: 'GET_PRECACHE' }, [ch.port2]);
+        setTimeout(function () { res(null); }, 800);
+      } catch (e) { res(null); }
+    });
+  }
+  function storageEstimate() {
+    try { if (navigator.storage && navigator.storage.estimate) return navigator.storage.estimate(); } catch (e) {}
+    return Promise.resolve(null);
+  }
+  function heap() {
+    try { var m = (global.performance && global.performance.memory); if (m) return { used: m.usedJSHeapSize, total: m.totalJSHeapSize, limit: m.jsHeapSizeLimit }; } catch (e) {}
+    return null;
+  }
+  function residentTenants() {
+    try { if (global.SES && global.SES.listClients && global.__idmpDb) return global.SES.listClients(global.__idmpDb); } catch (e) {}
+    return null;
+  }
+
+  // ── data gather (all real / honest) ─────────────────────────────────────────────────────────────────────────
+  function gather() {
+    return Promise.all([swVersion(), storageEstimate()]).then(function (r) {
+      var ver = r[0], est = r[1], h = heap(), tenants = residentTenants();
+      var d = {
+        release: ver || '(uncontrolled)',
+        os: (navigator.platform || '—') + ' · ' + (navigator.hardwareConcurrency || '?') + ' cores',
+        ua: (navigator.userAgent || '').replace(/^Mozilla\/\S+\s*/, '').slice(0, 60),
+        heap: h ? (mb(h.used) + ' used / ' + mb(h.total) + ' heap · limit ' + mb(h.limit)) : 'n/a (this browser does not expose JS heap)',
+        storage: est ? (mb(est.usage) + ' used of ' + mb(est.quota) + ' available') : 'n/a',
+        tenants: tenants ? tenants.length : null,
+        tenantNames: tenants ? tenants.map(function (c) { return c.name; }).join(', ') : null
+      };
+      console.log('§SYSTEM-MONITOR gather release=' + d.release + ' heap=' + (h ? 'real' : 'n/a') + ' storage=' + (est ? 'real' : 'n/a') + ' tenants=' + d.tenants);
+      return d;
+    });
+  }
+
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]; }); }
+  // a section row: label + value; reframe=true draws the "No longer needed" badge + Read-further link.
+  function row(label, value, reframe) {
+    return '<tr><th>' + esc(label) + '</th><td>' + (reframe ? '<span class="sm-badge">No longer needed</span> ' : '') + value
+      + (reframe ? ' <a class="sm-rf" href="' + COMPARE + '">Read further&nbsp;&rsaquo;</a>' : '') + '</td></tr>';
+  }
+
+  function panelHTML(d) {
+    var t =
+      '<div class="sm-modal" role="dialog" aria-label="System Monitor">' +
+      '<div class="sm-head"><b>System Monitor</b>' +
+        '<span class="sm-sub">iDempiere-faithful · serverless kernel — this device</span>' +
+        '<button class="sm-x" data-sm-close title="Close">&times;</button></div>' +
+      '<div class="sm-body"><table class="sm-tbl">' +
+        '<tr class="sm-grp"><td colspan="2">System</td></tr>' +
+        row('Release', '<b>' + esc(d.release) + '</b> &middot; dictionary folded from the iDempiere oracle') +
+        row('Environment', esc(d.os)) +
+        row('Client', esc(d.ua)) +
+        '<tr class="sm-grp"><td colspan="2">Memory</td></tr>' +
+        row('Heap usage', esc(d.heap)) +
+        '<tr class="sm-grp"><td colspan="2">Cache</td></tr>' +
+        row('Local storage', esc(d.storage) + (d.tenants != null ? ' &middot; ' + d.tenants + ' resident tenant(s)' + (d.tenantNames ? ' (' + esc(d.tenantNames) + ')' : '') : '')) +
+        row('Cache reset', '<button class="sm-reset" data-sm-reset>Reset to seed</button> <span class="sm-dim">drop the local cache &amp; re-fold from the shipped seed</span>') +
+        '<tr class="sm-grp"><td colspan="2">Logs &amp; Trace</td></tr>' +
+        row('Trace', 'the signed <b>op-log</b> is the trace &mdash; replayable, per-tenant (git-for-data). No server log file.') +
+        '<tr class="sm-grp"><td colspan="2">Servers &amp; Cluster</td></tr>' +
+        row('Background processors', 'Accounting / Alert / Scheduler / Workflow run <b>on-open or on-sync</b> &mdash; no always-on daemon to babysit.', true) +
+        row('Cluster &amp; threads', 'one browser kernel &mdash; no cluster nodes, no JVM thread pool to tune.', true) +
+        '<tr class="sm-grp"><td colspan="2">Database</td></tr>' +
+        row('Engine', '<b>SQLite-wasm</b>, in-page &mdash; no Postgres host, no DB connection pool.', true) +
+      '</table></div></div>' +
+      '<div class="sm-backdrop" data-sm-close></div>';
+    return t;
+  }
+
+  var CSS =
+    '#sm-root{position:fixed;inset:0;z-index:1400;display:flex;align-items:center;justify-content:center;font-family:system-ui,sans-serif}' +
+    '#sm-root .sm-backdrop{position:absolute;inset:0;background:rgba(8,12,20,.55)}' +
+    '#sm-root .sm-modal{position:relative;z-index:1;background:#fff;color:#1b2430;width:560px;max-width:94vw;max-height:88vh;overflow:auto;border-radius:10px;box-shadow:0 18px 50px rgba(0,0,0,.45)}' +
+    '#sm-root .sm-head{display:flex;align-items:center;gap:9px;padding:13px 16px;background:#0a4ea3;color:#fff;border-radius:10px 10px 0 0;position:sticky;top:0}' +
+    '#sm-root .sm-head b{font-size:15px}' +
+    '#sm-root .sm-sub{font-size:11px;opacity:.82;flex:1}' +
+    '#sm-root .sm-x{background:transparent;border:0;color:#fff;font-size:20px;line-height:1;cursor:pointer;padding:0 4px}' +
+    '#sm-root .sm-body{padding:6px 16px 16px}' +
+    '#sm-root .sm-tbl{width:100%;border-collapse:collapse;font-size:12.5px}' +
+    '#sm-root .sm-tbl th{text-align:left;width:150px;color:#5a6675;font-weight:600;vertical-align:top;padding:7px 10px 7px 0;border-bottom:1px solid #eef1f5}' +
+    '#sm-root .sm-tbl td{padding:7px 0;border-bottom:1px solid #eef1f5;vertical-align:top}' +
+    '#sm-root .sm-grp td{padding:12px 0 4px;color:#0a4ea3;font-weight:700;font-size:11px;text-transform:uppercase;letter-spacing:.5px;border-bottom:2px solid #0a4ea3}' +
+    '#sm-root .sm-badge{display:inline-block;background:#eef4ff;color:#0a4ea3;border:1px solid #cfe0ff;border-radius:4px;font-size:10px;font-weight:700;padding:1px 6px;vertical-align:middle}' +
+    '#sm-root .sm-rf{color:#0a4ea3;text-decoration:none;font-weight:600;white-space:nowrap}' +
+    '#sm-root .sm-rf:hover{text-decoration:underline}' +
+    '#sm-root .sm-reset{background:#0a4ea3;color:#fff;border:0;border-radius:6px;padding:5px 11px;font-size:12px;cursor:pointer}' +
+    '#sm-root .sm-dim{color:#8a95a3;font-size:11px}';
+
+  function ensureCss() { if (document.getElementById('sm-css')) return; var s = document.createElement('style'); s.id = 'sm-css'; s.textContent = CSS; document.head.appendChild(s); }
+
+  async function resetToSeed() {
+    if (!global.confirm || !global.confirm('Reset to seed? This drops the local cache (resident tenants + edits) and re-folds from the shipped dictionary.')) return;
+    console.log('§SYSTEM-MONITOR reset-to-seed start');
+    try { await new Promise(function (r) { var q = indexedDB.deleteDatabase('erp_cache'); q.onsuccess = q.onerror = q.onblocked = function () { r(); }; }); } catch (e) {}
+    try { if (global.caches) { var ks = await caches.keys(); await Promise.all(ks.filter(function (k) { return /erp-ootb-/.test(k); }).map(function (k) { return caches.delete(k); })); } } catch (e) {}
+    console.log('§SYSTEM-MONITOR reset-to-seed done — reloading');
+    location.reload();
+  }
+
+  function close() { var r = document.getElementById('sm-root'); if (r) r.remove(); }
+  function open() {
+    ensureCss();
+    close();
+    var root = document.createElement('div'); root.id = 'sm-root';
+    root.innerHTML = '<div class="sm-modal"><div class="sm-head"><b>System Monitor</b><span class="sm-sub">loading…</span></div></div><div class="sm-backdrop" data-sm-close></div>';
+    document.body.appendChild(root);
+    console.log('§SYSTEM-MONITOR open');
+    gather().then(function (d) {
+      root.innerHTML = panelHTML(d);
+      root.querySelectorAll('[data-sm-close]').forEach(function (el) { el.addEventListener('click', close); });
+      var rb = root.querySelector('[data-sm-reset]'); if (rb) rb.addEventListener('click', resetToSeed);
+    });
+  }
+
+  global.SystemMonitor = { open: open, close: close, _gather: gather };
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/tests/poc_system_monitor_live.js
+++ b/erp/tests/poc_system_monitor_live.js
@@ -1,0 +1,87 @@
+// W-SYSTEM-MONITOR-LIVE — the iDempiere System Monitor, reframed for a serverless kernel, in a real browser.
+//   SYSTEM_ADMIN_LANE §6. Proves: (1) the login info panel shows the release/dictionary version + the default
+//   credential hints (SuperUser/System · GardenAdmin/GardenAdmin) + a System Monitor link; (2) the link opens a
+//   panel that mirrors iDempiere's monitor sections (System · Memory · Cache · Logs · Servers · Database) filled
+//   with REAL local data (heap via performance.memory, storage via the Storage API) and HONEST "No longer needed"
+//   reframes for the server-only bits, each linking Read-further → migrate_compare.html; (3) 0 pageerrors.
+// Run: node tests/poc_system_monitor_live.js   (serves erp/ on a local port). §-log first — read the log.
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+var ROOT = path.join(__dirname, '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+var server = http.createServer(function (req, res) {
+  var f = path.join(ROOT, decodeURIComponent(req.url.split('?')[0]));
+  fs.readFile(f, function (e, buf) { if (e) { res.writeHead(404); return res.end('404'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(f)] || 'application/octet-stream' }); res.end(buf); });
+});
+
+(async function () {
+  await new Promise(function (r) { server.listen(0, r); });
+  var port = server.address().port, base = 'http://localhost:' + port;
+  var logs = [], pageErrors = [];
+  var browser = await chromium.launch({ args: ['--no-sandbox', '--enable-precise-memory-info'] });
+  var page = await browser.newPage();
+  page.on('console', function (m) { var t = m.text(); if (t.indexOf('§') === 0) logs.push(t); });
+  page.on('pageerror', function (e) { pageErrors.push(String(e)); });
+
+  await page.goto(base + '/idempiere.html', { waitUntil: 'networkidle' });
+  await page.waitForFunction(function () { return !!window.__idmpDb; }, null, { timeout: 30000 });
+  await page.waitForFunction(function () { return document.querySelector('#idmp-login-step0') && document.querySelector('#idmp-login-clients').children.length > 0; }, null, { timeout: 20000 });
+  await page.waitForSelector('#idmp-login-info', { state: 'visible', timeout: 10000 });
+
+  // ── login info panel ──────────────────────────────────────────────────────────────────────────────────────────
+  var panel = await page.evaluate(function () {
+    var info = document.getElementById('idmp-login-info');
+    return { present: !!info, text: info ? info.textContent.replace(/\s+/g, ' ').trim() : '', link: !!document.getElementById('idmp-sysmon-link') };
+  });
+
+  // ── open the monitor + read what it rendered ──────────────────────────────────────────────────────────────────
+  await page.click('#idmp-sysmon-link');
+  await page.waitForSelector('#sm-root .sm-tbl', { timeout: 8000 });
+  await page.waitForFunction(function () { var s = document.querySelector('#sm-root .sm-sub'); return s && s.textContent.indexOf('loading') < 0; }, null, { timeout: 8000 }).catch(function () {});
+  var mon = await page.evaluate(function () {
+    var root = document.getElementById('sm-root');
+    var groups = [].map.call(root.querySelectorAll('.sm-grp td'), function (e) { return e.textContent.trim(); });
+    var rowsByLabel = {};
+    [].forEach.call(root.querySelectorAll('.sm-tbl tr:not(.sm-grp)'), function (tr) {
+      var th = tr.querySelector('th'), td = tr.querySelector('td'); if (th && td) rowsByLabel[th.textContent.trim()] = td.textContent.replace(/\s+/g, ' ').trim();
+    });
+    return {
+      groups: groups,
+      heap: rowsByLabel['Heap usage'] || '',
+      storage: rowsByLabel['Local storage'] || '',
+      release: rowsByLabel['Release'] || '',
+      badges: root.querySelectorAll('.sm-badge').length,
+      readFurther: [].map.call(root.querySelectorAll('.sm-rf'), function (a) { return a.getAttribute('href'); }),
+      reset: !!root.querySelector('[data-sm-reset]')
+    };
+  });
+
+  console.log('═══ W-SYSTEM-MONITOR-LIVE — iDempiere System Monitor, serverless reframe, in a real browser ═══\n');
+  logs.filter(function (l) { return /SYSTEM-MONITOR/.test(l); }).forEach(function (l) { console.log('  ' + l); });
+  console.log('\n  login panel: ' + JSON.stringify(panel));
+  console.log('  monitor groups=[' + mon.groups.join(' · ') + ']');
+  console.log('  release="' + mon.release + '"  heap="' + mon.heap + '"  storage="' + mon.storage + '"');
+  console.log('  reframe badges=' + mon.badges + '  readFurther=' + JSON.stringify(mon.readFurther) + '  reset=' + mon.reset + '\n');
+
+  var L = logs.join('\n'), pass = 0, fail = 0;
+  function ck(ok, msg) { (ok ? pass++ : fail++); console.log((ok ? '  ✓ ' : '  ✗ FAIL ') + msg); }
+  ck(panel.present && panel.link, 'login info panel renders with a System Monitor link');
+  ck(/SuperUser \/ System/.test(panel.text) && /GardenAdmin \/ GardenAdmin/.test(panel.text), 'panel shows the default credential hints (System: SuperUser/System · GardenWorld: GardenAdmin/GardenAdmin)');
+  ck(/serverless/.test(panel.text), 'panel states the serverless / SQLite-wasm posture + version line');
+  ck(/§SYSTEM-MONITOR open/.test(L) && /§SYSTEM-MONITOR gather/.test(L), 'clicking the link opens the monitor (gather ran)');
+  var want = ['System', 'Memory', 'Cache', 'Logs & Trace', 'Servers & Cluster', 'Database'];
+  ck(want.every(function (g) { return mon.groups.indexOf(g) >= 0; }), 'monitor mirrors iDempiere sections: ' + want.join(', '));
+  ck(/MB/.test(mon.heap) || /n\/a/.test(mon.heap), 'Memory row shows REAL heap (MB) or an honest n/a — ' + mon.heap);
+  ck(/MB/.test(mon.storage) || /n\/a/.test(mon.storage), 'Cache row shows REAL local-storage usage or honest n/a — ' + mon.storage);
+  ck(mon.badges >= 3, 'server-only sections carry the "No longer needed" reframe badge (' + mon.badges + ')');
+  ck(mon.readFurther.length >= 3 && mon.readFurther.every(function (h) { return /migrate_compare\.html/.test(h); }), 'every reframe links Read-further → migrate_compare.html (the MigrateComparison)');
+  ck(mon.reset, 'Cache section offers a Reset-to-seed action');
+  ck(pageErrors.length === 0, 'zero page errors' + (pageErrors.length ? ' — ' + pageErrors[0] : ''));
+
+  console.log('\n═══ W-SYSTEM-MONITOR-LIVE: ' + pass + ' PASS / ' + fail + ' FAIL ═══');
+  console.log(fail === 0 ? '✅ iDempiere\'s System Monitor, faithfully mirrored + honestly reframed for the serverless kernel.' : '❌ gaps above.');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('test error', e); server.close(); process.exit(1); });


### PR DESCRIPTION
## What

SYSTEM_ADMIN_LANE §6 — the first of the iDempiere System surfaces, reframed for our serverless kernel.

**Login info panel** (where iDempiere shows version on its login page): code/dictionary version + the default credential hints **exactly as iDempiere's demo login displays them** — `System: SuperUser / System` · `GardenWorld: GardenAdmin / GardenAdmin` (the real seed users) — plus a **System Monitor** link. (Identity stays passwordless selection; the pass is the hint.)

**System Monitor** — opens a panel mirroring iDempiere's `/idempiere-monitor` servlet **section-for-section** (System · Memory · Cache · Logs/Trace · Servers/Cluster · Database), but on a browser kernel:
- **Real local data**: JS heap (`performance.memory`), local-storage usage (Storage API), the live SW release tag (`CACHE_VERSION`), resident tenants. Cache → working **Reset to seed**.
- **Honest reframes**: server-only rows (background processors, cluster/threads, Postgres host) carry a **"No longer needed"** badge + *Read further →* `migrate_compare.html` (the MigrateComparison).
- **NON-INVENT**: nothing faked — heap shows `n/a` where a browser doesn't expose it.

## Witness

**W-SYSTEM-MONITOR-LIVE 11/11** (`tests/poc_system_monitor_live.js`): panel + credential hints + link render; click opens the monitor; all 6 iDempiere sections present; real heap (54.9 MB) + storage shown; 3 reframe badges all link to migrate_compare.html; reset action present; 0 pageerrors.

Regressions green: genesis-sysadmin **16/16**, frontdoor **12/12**.

sw v720. All additive (new `system_monitor.js` + login-card markup) — no shared data-script touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)