### PR TITLE
Fix: pill icons GPU hog — drop per-button backdrop-filter

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v671';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v672';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -307,9 +307,10 @@
   #mobile-pill button {
     position: fixed; pointer-events: auto;
     width: 40px; height: 40px; border: 1px solid rgba(255,255,255,0.12); border-radius: 50%;
-    background: rgba(22,24,32,0.42); color: #fff; cursor: pointer;
+    background: rgba(22,24,32,0.86); color: #fff; cursor: pointer;
     display: flex; align-items: center; justify-content: center; padding: 0; margin: 0;
-    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
+    /* NO per-button backdrop-filter: ~19 simultaneous blur layers hogged the GPU/compositor and
+       janked toggles (Fly especially) right when _sync() repainted them. Solid opaque bg instead. */
     box-shadow: 0 2px 10px rgba(0,0,0,0.30);
     opacity: 0; transform: scale(.35) translate(26px, 26px);     /* rolled-IN; JS sets per-index delay */
     transition: opacity .24s ease, transform .30s cubic-bezier(.22,.9,.25,1.2), background .15s, border-color .15s;


### PR DESCRIPTION
**Bug:** after the L-PATH pill (#403), clicking a pill icon (notably **Fly**) did nothing while the keyboard shortcut still worked, and it only worked once **sound/night** were disengaged.

**Root cause:** #403 moved the glass blur from the single container onto **each of ~19 buttons** (`backdrop-filter: blur(16px)` per button). ~19 simultaneous backdrop-blur layers saturate the compositor; clicking an icon also runs `_sync()` which repaints all 19 blurs — so Fly (GPU-heavy) janked out on icon-click, while the shortcut (no `_sync`) flew. Less baseline GPU load (night/sound off) let it through. The modeller's rail has ~5 buttons so the same code was fine there.

**Fix:** remove the per-button `backdrop-filter`; use a solid opaque background (`rgba(22,24,32,0.86)`). Keeps the L-shape + roll-out, zero blur cost.

`sw.js` v671 → v672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)