### PR TITLE
feat(erp): Plugins & Releases — gated release/update surface iDempiere lacks (W-PLUGIN-RELEASE-LIVE)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -407,7 +407,7 @@
     <div id="idmp-login-info" class="idmp-login-info">
       <div class="idmp-info-row"><span id="idmp-info-ver">Code &mdash;</span> &middot; Dictionary: iDempiere &middot; SQLite&#8209;wasm &middot; serverless</div>
       <div class="idmp-info-creds"><b>System:</b> SuperUser / System &nbsp;&middot;&nbsp; <b>GardenWorld:</b> GardenAdmin / GardenAdmin</div>
-      <div class="idmp-info-mon"><a href="#" id="idmp-sysmon-link">System Monitor</a></div>
+      <div class="idmp-info-mon"><a href="#" id="idmp-sysmon-link">System Monitor</a> &middot; <a href="#" id="idmp-release-link">Plugins &amp; Releases</a></div>
     </div>
   </div>
 </div>
@@ -477,6 +477,7 @@
 <script src="genesis.js?v=2"></script>
 <script src="system_tenant.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §SA1 — boot overlay: make System(0) a log-in-able tenant -->
 <script src="system_monitor.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor, serverless reframe (window.SystemMonitor) -->
+<script src="plugin_release.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §6 — Plugin Management + gated Release/Update surface (window.PluginRelease) -->
 <script src="erp_preview.js?v=2"></script>
 <!-- CONSISTENCY_FINISH.md §K-1/§K-2 — icons.js (verbatim glyph DATA) + the shared overlay kit load BEFORE
      the import overlays (migrate_showme builds its STEPS at module load and renders Lucide icons). -->
@@ -3598,6 +3599,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     (function () {
       var lnk = $('idmp-sysmon-link');
       if (lnk) lnk.addEventListener('click', function (e) { e.preventDefault(); if (window.SystemMonitor) window.SystemMonitor.open(); });
+      var rlnk = $('idmp-release-link');
+      if (rlnk) rlnk.addEventListener('click', function (e) { e.preventDefault(); if (window.PluginRelease) window.PluginRelease.open(); });
       function fillVer() {
         try {
           if (!navigator.serviceWorker || !navigator.serviceWorker.controller) return;
@@ -3634,9 +3637,10 @@ window.__helpIdmpKeymap = {
 <script>
 // Offline/PWA parity with erp.html — idempiere.html + ad_parser/ad_data/idmp_session + ad_seed.db are precached (sw v561).
 if ('serviceWorker' in navigator) {
-  // §INIT-INSTANT freshness backstop — navigation is stale-while-revalidate (sw.js v598): instant cached
-  // first paint, and on a DEPLOY the new SW claims the page → controllerchange → ONE reload onto the fresh
-  // shell (so a deploy reaches a returning user in a single reload). Loop-guarded; skips the first install-claim.
+  // §INIT-INSTANT — navigation is stale-while-revalidate: instant cached first paint. SYSTEM_ADMIN_LANE §6:
+  // releases are now GATED (sw.js no longer auto-skipWaiting), so a new deploy INSTALLS but WAITS — it does NOT
+  // auto-claim. The System admin adopts it via the Release page (SKIP_WAITING → activate → claim → the
+  // controllerchange below fires → ONE reload onto the applied release). First install-claim is still silent.
   var _swHadCtrl = !!navigator.serviceWorker.controller, _swRefreshing = false;
   navigator.serviceWorker.addEventListener('controllerchange', function () {
     if (_swRefreshing) return;
@@ -3644,7 +3648,7 @@ if ('serviceWorker' in navigator) {
     _swRefreshing = true; console.log('§SW_UPDATE controllerchange → reload onto fresh shell'); location.reload();
   });
   navigator.serviceWorker.register('sw.js?v=683')
-    .then(function (r) { console.log('§SW_REG scope=' + r.scope); })
+    .then(function (r) { window.__swReg = r; console.log('§SW_REG scope=' + r.scope); })  // §6 — Release page reads r.waiting / r.update()
     .catch(function (e) { console.warn('§SW_REG_FAIL', e); });
 }
 </script>

--- a/erp/plugin_release.js
+++ b/erp/plugin_release.js
@@ -1,0 +1,154 @@
+// BIM OOTB — ERP. Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>. SPDX-License-Identifier: MIT
+// plugin_release.js — SYSTEM_ADMIN_LANE §6. iDempiere's Plugin Management (OSGi bundles), reframed for a
+//   serverless fold-engine — PLUS a Release/Update surface iDempiere has NO in-app equivalent of:
+//     · RELEASE — the running release (sw CACHE_VERSION). Check for updates; a new deploy WAITS (gated, not
+//       auto-latest) until Apply (→ SKIP_WAITING). "Further releases come through updates," not silent jumps.
+//     · PLUGINS — foreign code as plugins over OUR registry (window.PluginRegistry, W-PLUGIN): list / enable /
+//       disable / remove, each signed + reversible (Holy-Grail law: foreign imperative code is a plugin).
+//     · MODULES — our OWN code, folded as modules: core (always-on substrate) vs optional (features), each at
+//       the running release. (Live optional on/off via the pill-gate seam = the immediate follow-up.)
+//   NON-INVENT: real sw version, real registry rows; honest where a tier isn't loaded yet. W-PLUGIN-RELEASE.
+(function (global) {
+  'use strict';
+
+  // ask any SW worker (controller or the waiting one) for its CACHE_VERSION
+  function workerVersion(worker) {
+    return new Promise(function (res) {
+      if (!worker) return res(null);
+      try { var ch = new MessageChannel(); ch.port1.onmessage = function (e) { res(e.data && e.data.version || null); };
+        worker.postMessage({ type: 'GET_PRECACHE' }, [ch.port2]); setTimeout(function () { res(null); }, 800); }
+      catch (e) { res(null); }
+    });
+  }
+  function reg() { return global.__swReg || null; }
+  function pluginReg() { try { return (global.PluginEngine && global.PluginEngine._reg && global.PluginEngine._reg()) || null; } catch (e) { return null; } }
+
+  // our own code, folded as modules — core substrate vs optional features (NON-INVENT: these ship in PRECACHE)
+  var MODULES = [
+    { id: 'ad_parser', core: true, label: 'AD dictionary fold (windows/tabs/fields)' },
+    { id: 'idmp_session', core: true, label: 'Session · context (Ctx/Env) · client+org scope' },
+    { id: 'ad_data', core: true, label: 'Record read / write fold' },
+    { id: 'crud_overlay', core: true, label: 'CRUD + DocAction (signed commit)' },
+    { id: 'doc_poster', core: true, label: 'GL posting (== fact_acct)' },
+    { id: 'genesis', core: true, label: 'Initial Tenant Setup (op-logged birth)' },
+    { id: 'system_tenant', core: true, label: 'System(0) login surface' },
+    { id: 'pos_lens', core: false, label: 'POS terminal lens' },
+    { id: 'kanban_lens', core: false, label: 'Kanban board' },
+    { id: 'ninja_create', core: false, label: 'Ninja window builder' },
+    { id: 'plugin_overlay', core: false, label: 'Plugin Engine (foreign bundles)' },
+    { id: 'bim_embed', core: false, label: 'BIM-in-window embed' },
+    { id: 'blue_future', core: false, label: 'Blue Future (speculative branch)' },
+    { id: 'system_monitor', core: false, label: 'System Monitor' }
+  ];
+
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]; }); }
+
+  var CSS =
+    '#pr-root{position:fixed;inset:0;z-index:1400;display:flex;align-items:center;justify-content:center;font-family:system-ui,sans-serif}' +
+    '#pr-root .pr-backdrop{position:absolute;inset:0;background:rgba(8,12,20,.55)}' +
+    '#pr-root .pr-modal{position:relative;z-index:1;background:#fff;color:#1b2430;width:600px;max-width:94vw;max-height:88vh;overflow:auto;border-radius:10px;box-shadow:0 18px 50px rgba(0,0,0,.45)}' +
+    '#pr-root .pr-head{display:flex;align-items:center;gap:9px;padding:13px 16px;background:#0a4ea3;color:#fff;border-radius:10px 10px 0 0;position:sticky;top:0}' +
+    '#pr-root .pr-head b{font-size:15px}#pr-root .pr-sub{font-size:11px;opacity:.82;flex:1}' +
+    '#pr-root .pr-x{background:transparent;border:0;color:#fff;font-size:20px;cursor:pointer;padding:0 4px}' +
+    '#pr-root .pr-body{padding:8px 16px 16px}' +
+    '#pr-root .pr-grp{color:#0a4ea3;font-weight:700;font-size:11px;text-transform:uppercase;letter-spacing:.5px;border-bottom:2px solid #0a4ea3;padding:14px 0 5px;margin-bottom:6px}' +
+    '#pr-root .pr-rel{display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:13px;padding:4px 0}' +
+    '#pr-root .pr-tag{font-weight:700}' +
+    '#pr-root .pr-up{background:#fff7e6;border:1px solid #ffd591;color:#ad6800;border-radius:5px;padding:2px 8px;font-size:11.5px;font-weight:700}' +
+    '#pr-root .pr-ok{color:#237804;font-weight:600;font-size:12px}' +
+    '#pr-root button.pr-btn{background:#0a4ea3;color:#fff;border:0;border-radius:6px;padding:5px 11px;font-size:12px;cursor:pointer}' +
+    '#pr-root button.pr-btn.ghost{background:#eef1f5;color:#1b2430}' +
+    '#pr-root .pr-row{display:flex;align-items:center;gap:9px;font-size:12.5px;padding:6px 0;border-bottom:1px solid #eef1f5}' +
+    '#pr-root .pr-row .nm{font-weight:600}#pr-root .pr-row .meta{color:#8a95a3;font-size:11px}' +
+    '#pr-root .pr-row .sp{flex:1}' +
+    '#pr-root .pr-badge{display:inline-block;border-radius:4px;font-size:10px;font-weight:700;padding:1px 6px}' +
+    '#pr-root .pr-badge.core{background:#f0f5ff;color:#1d39c4;border:1px solid #adc6ff}' +
+    '#pr-root .pr-badge.opt{background:#f6ffed;color:#389e0d;border:1px solid #b7eb8f}' +
+    '#pr-root .pr-dim{color:#8a95a3;font-size:11.5px;padding:6px 0}';
+  function ensureCss() { if (document.getElementById('pr-css')) return; var s = document.createElement('style'); s.id = 'pr-css'; s.textContent = CSS; document.head.appendChild(s); }
+
+  function close() { var r = document.getElementById('pr-root'); if (r) r.remove(); }
+
+  function renderRelease(host, cur, waitingVer) {
+    var el = host.querySelector('#pr-release'); if (!el) return;
+    if (waitingVer) {
+      el.innerHTML = '<div class="pr-rel"><span>Running: <span class="pr-tag">' + esc(cur || '?') + '</span></span>'
+        + '<span class="pr-up">Update available &rarr; ' + esc(waitingVer) + '</span>'
+        + '<button class="pr-btn" data-pr-apply>Apply update</button></div>'
+        + '<div class="pr-dim">A new release is installed but held. Applying activates it and reloads — this is how further releases land (no silent auto-update).</div>';
+      el.querySelector('[data-pr-apply]').addEventListener('click', function () {
+        var r = reg(); if (r && r.waiting) { console.log('§PLUGIN-RELEASE apply waiting=' + waitingVer); r.waiting.postMessage({ type: 'SKIP_WAITING' }); }
+      });
+    } else {
+      el.innerHTML = '<div class="pr-rel"><span>Running: <span class="pr-tag">' + esc(cur || '(uncontrolled)') + '</span></span>'
+        + '<span class="pr-ok">&#10003; up to date</span><button class="pr-btn ghost" data-pr-check>Check for updates</button></div>'
+        + '<div class="pr-dim">This app is pinned to its release until you update it — a release/update surface iDempiere has no in-app equivalent of.</div>';
+      el.querySelector('[data-pr-check]').addEventListener('click', function () {
+        var r = reg(); if (!r) return; console.log('§PLUGIN-RELEASE check');
+        r.update().then(function () { return refreshRelease(host); }).catch(function () {});
+      });
+    }
+  }
+  function refreshRelease(host) {
+    var r = reg();
+    return Promise.all([workerVersion(navigator.serviceWorker && navigator.serviceWorker.controller), workerVersion(r && r.waiting)])
+      .then(function (v) { console.log('§PLUGIN-RELEASE state running=' + v[0] + ' waiting=' + (v[1] || 'none')); renderRelease(host, v[0], v[1]); });
+  }
+
+  function renderPlugins(host) {
+    var el = host.querySelector('#pr-plugins'); if (!el) return;
+    var pr = pluginReg();
+    var rows = pr ? pr.list() : null;
+    if (!pr) { el.innerHTML = '<div class="pr-dim">Plugin Engine not active yet — open it from the &middot;&middot;&middot; rail to load a <b>.foldbundle</b>; loaded plugins appear here to enable / disable / remove.</div>'; return; }
+    if (!rows.length) { el.innerHTML = '<div class="pr-dim">No plugins installed. A plugin is foreign code as a signed, reversible bundle — never auto-imported.</div>'; return; }
+    el.innerHTML = '';
+    rows.forEach(function (p) {
+      var on = /ACTIVE|STARTED|RESOLVED|ENABLED/i.test(String(p.state));
+      var row = document.createElement('div'); row.className = 'pr-row';
+      row.innerHTML = '<span class="nm">' + esc(p.id) + '</span><span class="meta">v' + esc(p.version || '?') + ' &middot; ' + esc(p.state) + '</span>'
+        + '<span class="sp"></span><button class="pr-btn ghost" data-pr-toggle>' + (on ? 'Disable' : 'Enable') + '</button>'
+        + '<button class="pr-btn ghost" data-pr-remove>Remove</button>';
+      row.querySelector('[data-pr-toggle]').addEventListener('click', function () {
+        try { if (on) pr.stopBundle(p.id); else pr.startBundle(p.id); console.log('§PLUGIN-RELEASE toggle id=' + p.id + ' ->' + (on ? 'stop' : 'start')); } catch (e) {}
+        renderPlugins(host);
+      });
+      row.querySelector('[data-pr-remove]').addEventListener('click', function () {
+        try { pr.uninstallBundle(p.id); console.log('§PLUGIN-RELEASE remove id=' + p.id); } catch (e) {}
+        renderPlugins(host);
+      });
+      el.appendChild(row);
+    });
+  }
+
+  function renderModules(host, cur) {
+    var el = host.querySelector('#pr-modules'); if (!el) return;
+    el.innerHTML = MODULES.map(function (m) {
+      return '<div class="pr-row"><span class="nm">' + esc(m.id) + '</span>'
+        + '<span class="pr-badge ' + (m.core ? 'core">core &middot; always-on' : 'opt">optional') + '</span>'
+        + '<span class="meta">' + esc(m.label) + '</span><span class="sp"></span>'
+        + '<span class="meta">' + esc(cur || '') + '</span></div>';
+    }).join('') + '<div class="pr-dim">Our own code, folded as modules. Core modules are the substrate the fold runs through; optional features can be turned off (live on/off via the pill gate — next).</div>';
+  }
+
+  function open() {
+    ensureCss(); close();
+    var root = document.createElement('div'); root.id = 'pr-root';
+    root.innerHTML =
+      '<div class="pr-modal"><div class="pr-head"><b>Plugins &amp; Releases</b>'
+      + '<span class="pr-sub">iDempiere Plugin Management + the release/update surface it lacks</span>'
+      + '<button class="pr-x" data-pr-close title="Close">&times;</button></div>'
+      + '<div class="pr-body">'
+      + '<div class="pr-grp">Release</div><div id="pr-release"><div class="pr-dim">checking…</div></div>'
+      + '<div class="pr-grp">Plugins (foreign code)</div><div id="pr-plugins"></div>'
+      + '<div class="pr-grp">Modules (our code)</div><div id="pr-modules"></div>'
+      + '</div></div><div class="pr-backdrop" data-pr-close></div>';
+    document.body.appendChild(root);
+    root.querySelectorAll('[data-pr-close]').forEach(function (e) { e.addEventListener('click', close); });
+    console.log('§PLUGIN-RELEASE open');
+    workerVersion(navigator.serviceWorker && navigator.serviceWorker.controller).then(function (cur) {
+      renderModules(root, cur); renderPlugins(root); refreshRelease(root);
+    });
+  }
+
+  global.PluginRelease = { open: open, close: close };
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v720';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v721';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -56,6 +56,7 @@ const PRECACHE_ASSETS = [
   'genesis_seed.js',   // NON-INVENT default-genesis data (311 iDempiere default accounts + 73 default-acct maps)
   'system_tenant.js',  // SYSTEM_ADMIN_LANE §SA1 — boot overlay: System(0) login surface (W-GENESIS-SYSADMIN)
   'system_monitor.js', // SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor (serverless reframe, window.SystemMonitor)
+  'plugin_release.js', // SYSTEM_ADMIN_LANE §6 — Plugin Management + gated Release/Update (window.PluginRelease)
   'erp_snapshot_sign.js', // ECDSA P-256 signer (UMD, window.ErpSnapshotSign) — signs the genesis bundle head
   '14-sap-chain.json', // SAP /DMO/ Flight PoC oracle (fetch-fold-install demo data; user can replace via file-drop)
   'idmp_session.js',
@@ -133,7 +134,11 @@ self.addEventListener('install', (event) => {
       )
     )
   );
-  self.skipWaiting();
+  // SYSTEM_ADMIN_LANE §6 — GATED RELEASES (no auto-adopt-latest). We DON'T skipWaiting() here: a new deploy
+  // installs but STAYS in `waiting` until the System admin clicks Apply in the Release page (→ SKIP_WAITING
+  // message below). The running app therefore stays on its release until updated on purpose — a release/update
+  // surface iDempiere has no in-app equivalent of. First-ever install still activates immediately (no prior
+  // worker to supersede), so a cold visit is unaffected; only UPDATES wait. W-PLUGIN-RELEASE.
 });
 
 self.addEventListener('activate', (event) => {

--- a/erp/tests/poc_plugin_release_live.js
+++ b/erp/tests/poc_plugin_release_live.js
@@ -1,0 +1,77 @@
+// W-PLUGIN-RELEASE-LIVE — iDempiere Plugin Management + the gated Release/Update surface it lacks, in a real
+//   browser. SYSTEM_ADMIN_LANE §6. Proves: (1) the login info panel carries a "Plugins & Releases" link; (2) it
+//   opens a panel with three sections — RELEASE (running sw CACHE_VERSION + Check-for-updates; gated, not auto-
+//   latest), PLUGINS (foreign code over window.PluginRegistry — honest note when none loaded), MODULES (our own
+//   code, core-vs-optional, at the running release); (3) the SW registration is exposed for the gated apply; (4)
+//   0 pageerrors. Run: node tests/poc_plugin_release_live.js   §-log first.
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+var ROOT = path.join(__dirname, '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+var server = http.createServer(function (req, res) {
+  var f = path.join(ROOT, decodeURIComponent(req.url.split('?')[0]));
+  fs.readFile(f, function (e, buf) { if (e) { res.writeHead(404); return res.end('404'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(f)] || 'application/octet-stream' }); res.end(buf); });
+});
+
+(async function () {
+  await new Promise(function (r) { server.listen(0, r); });
+  var port = server.address().port, base = 'http://localhost:' + port;
+  var logs = [], pageErrors = [];
+  var browser = await chromium.launch({ args: ['--no-sandbox'] });
+  var page = await browser.newPage();
+  page.on('console', function (m) { var t = m.text(); if (t.indexOf('§') === 0) logs.push(t); });
+  page.on('pageerror', function (e) { pageErrors.push(String(e)); });
+
+  await page.goto(base + '/idempiere.html', { waitUntil: 'networkidle' });
+  await page.waitForFunction(function () { return !!window.__idmpDb; }, null, { timeout: 30000 });
+  await page.waitForFunction(function () { return document.querySelector('#idmp-login-clients') && document.querySelector('#idmp-login-clients').children.length > 0; }, null, { timeout: 20000 });
+  await page.waitForSelector('#idmp-release-link', { state: 'visible', timeout: 10000 });
+  await page.waitForFunction(function () { return !!window.__swReg; }, null, { timeout: 8000 }).catch(function () {});
+
+  var hasLink = await page.$eval('#idmp-release-link', function (e) { return e.textContent.trim(); }).catch(function () { return null; });
+
+  await page.click('#idmp-release-link');
+  await page.waitForSelector('#pr-root #pr-modules .pr-row', { timeout: 8000 });
+  await page.waitForFunction(function () { var r = document.querySelector('#pr-release'); return r && r.textContent.indexOf('checking') < 0; }, null, { timeout: 8000 }).catch(function () {});
+
+  var view = await page.evaluate(function () {
+    var root = document.getElementById('pr-root');
+    var grps = [].map.call(root.querySelectorAll('.pr-grp'), function (e) { return e.textContent.trim(); });
+    var rel = (root.querySelector('#pr-release') || {}).textContent || '';
+    var modRows = root.querySelectorAll('#pr-modules .pr-row').length;
+    var coreBadges = root.querySelectorAll('#pr-modules .pr-badge.core').length;
+    var optBadges = root.querySelectorAll('#pr-modules .pr-badge.opt').length;
+    var plugins = (root.querySelector('#pr-plugins') || {}).textContent || '';
+    var checkBtn = !!root.querySelector('[data-pr-check]');
+    return { grps: grps, rel: rel.replace(/\s+/g, ' ').trim(), modRows: modRows, coreBadges: coreBadges, optBadges: optBadges, plugins: plugins.replace(/\s+/g, ' ').trim().slice(0, 80), checkBtn: checkBtn };
+  });
+
+  // exercise Check-for-updates (gated path) — must not throw; no new deploy → stays up to date
+  if (view.checkBtn) { await page.click('[data-pr-check]'); await page.waitForTimeout(400); }
+
+  console.log('═══ W-PLUGIN-RELEASE-LIVE — Plugin Management + the gated Release/Update surface iDempiere lacks ═══\n');
+  logs.filter(function (l) { return /PLUGIN-RELEASE|SW_REG/.test(l); }).forEach(function (l) { console.log('  ' + l); });
+  console.log('\n  link="' + hasLink + '"  groups=[' + view.grps.join(' · ') + ']');
+  console.log('  release="' + view.rel + '"');
+  console.log('  modules rows=' + view.modRows + ' core=' + view.coreBadges + ' optional=' + view.optBadges);
+  console.log('  plugins="' + view.plugins + '"  checkBtn=' + view.checkBtn + '\n');
+
+  var L = logs.join('\n'), pass = 0, fail = 0;
+  function ck(ok, msg) { (ok ? pass++ : fail++); console.log((ok ? '  ✓ ' : '  ✗ FAIL ') + msg); }
+  ck(hasLink && /Plugins & Releases/.test(hasLink), 'login info panel carries a "Plugins & Releases" link');
+  ck(/§PLUGIN-RELEASE open/.test(L), 'the link opens the Plugins & Releases page');
+  ck(['Release', 'Plugins (foreign code)', 'Modules (our code)'].every(function (g) { return view.grps.indexOf(g) >= 0; }), 'page has the three sections: Release · Plugins · Modules');
+  ck(/Running:/.test(view.rel) && /v7\d\d/.test(view.rel), 'Release section shows the running release (sw CACHE_VERSION) — ' + view.rel.slice(0, 60));
+  ck(view.checkBtn || /Update available/.test(view.rel), 'Release offers Check-for-updates (or shows a held update) — gated, not auto-latest');
+  ck(/§PLUGIN-RELEASE state running=v7\d\d/.test(L), 'release state read from the live SW (running version logged)');
+  ck(view.modRows >= 10 && view.coreBadges >= 5 && view.optBadges >= 3, 'Modules lists our code split core (always-on) vs optional — rows=' + view.modRows + ' core=' + view.coreBadges + ' opt=' + view.optBadges);
+  ck(view.plugins.length > 0, 'Plugins section renders (registry rows or an honest "none loaded" note)');
+  ck(pageErrors.length === 0, 'zero page errors' + (pageErrors.length ? ' — ' + pageErrors[0] : ''));
+
+  console.log('\n═══ W-PLUGIN-RELEASE-LIVE: ' + pass + ' PASS / ' + fail + ' FAIL ═══');
+  console.log(fail === 0 ? '✅ Plugin Management mirrored + a gated Release/Update surface iDempiere has no in-app equivalent of.' : '❌ gaps above.');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('test error', e); server.close(); process.exit(1); });


### PR DESCRIPTION
## What

SYSTEM_ADMIN_LANE §6 — a second System surface (reached from the login info panel → **Plugins & Releases**), answering "can our code be plugins / can this be a release-update page iDempiere doesn't have?"

**RELEASE — the surpass.** The app is now **pinned to its release**. `sw.js` no longer auto-`skipWaiting` on install, so a new deploy installs but **waits**. The Release section shows the running `CACHE_VERSION` + **Check for updates**; a held update is adopted only on explicit **Apply** (→ `SKIP_WAITING` → activate → one reload). Further releases come **through updates**, not silent auto-latest. First-ever install still activates immediately (nothing to supersede). iDempiere has no in-app equivalent — release changes there are server-side OSGi redeploy + restart.

**PLUGINS — foreign code as plugins.** list / enable / disable / remove over `window.PluginRegistry` (W-PLUGIN), signed + reversible; honest note when none loaded.

**MODULES — our own code, folded as modules.** core (always-on substrate) vs optional (features), each at the running release. Live optional on/off via the pill-gate seam is the immediate follow-up.

`idempiere.html` exposes `window.__swReg` for the gated apply + wires the link. NON-INVENT: real sw version, real registry rows.

## Witness

**W-PLUGIN-RELEASE-LIVE 9/9** (`tests/poc_plugin_release_live.js`): link opens the page; 3 sections; Release shows running v721 + gated Check; release state read from the live SW; Modules lists 14 (7 core / 7 optional); Plugins renders; 0 pageerrors.

Regressions green: system-monitor **11/11**, genesis-sysadmin **16/16**, frontdoor **12/12**.

sw v721. Note: gated releases change update delivery for the erp app (no auto-latest) — intentional per §6; no production users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)