### PR TITLE
feat(erp): creator credit (red1 / MIT License 2005/6) on login info panel

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -283,6 +283,9 @@
   .idmp-login-info b { color:#33404f; font-weight:600; }
   .idmp-login-info .idmp-info-mon a { color:var(--idmp-blue); text-decoration:none; font-weight:600; }
   .idmp-login-info .idmp-info-mon a:hover { text-decoration:underline; }
+  .idmp-login-info .idmp-info-creator { margin-top:7px; padding-top:7px; border-top:1px solid #f3f5f8; color:#9aa4b1; }
+  .idmp-login-info .idmp-info-creator a { color:#5a6675; text-decoration:none; font-weight:600; }
+  .idmp-login-info .idmp-info-creator a:hover { text-decoration:underline; }
   .idmp-login-label { font-size:11px; text-transform:uppercase; letter-spacing:.4px; color:var(--idmp-muted); margin:13px 0 5px; }
   .idmp-login-list { display:flex; flex-direction:column; gap:6px; max-height:48vh; overflow:auto; }
   .idmp-login-user { display:flex; align-items:center; gap:10px; padding:9px 12px; border:1px solid var(--idmp-border);
@@ -408,6 +411,7 @@
       <div class="idmp-info-row"><span id="idmp-info-ver">Code &mdash;</span> &middot; Dictionary: iDempiere &middot; SQLite&#8209;wasm &middot; serverless</div>
       <div class="idmp-info-creds"><b>System:</b> SuperUser / System &nbsp;&middot;&nbsp; <b>GardenWorld:</b> GardenAdmin / GardenAdmin</div>
       <div class="idmp-info-mon"><a href="#" id="idmp-sysmon-link">System Monitor</a> &middot; <a href="#" id="idmp-release-link">Plugins &amp; Releases</a></div>
+      <div class="idmp-info-creator">Created by Redhuan D. Oon (<a href="mailto:red1org@gmail.com" id="idmp-creator-email">red1</a>) &middot; <a href="https://github.com/red1oon/bim-ootb" id="idmp-creator-license" target="_blank" rel="noopener">MIT License 2005/6</a></div>
     </div>
   </div>
 </div>

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v722';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v723';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_system_monitor_live.js
+++ b/erp/tests/poc_system_monitor_live.js
@@ -33,7 +33,9 @@ var server = http.createServer(function (req, res) {
   // ── login info panel ──────────────────────────────────────────────────────────────────────────────────────────
   var panel = await page.evaluate(function () {
     var info = document.getElementById('idmp-login-info');
-    return { present: !!info, text: info ? info.textContent.replace(/\s+/g, ' ').trim() : '', link: !!document.getElementById('idmp-sysmon-link') };
+    var em = document.getElementById('idmp-creator-email'), lic = document.getElementById('idmp-creator-license');
+    return { present: !!info, text: info ? info.textContent.replace(/\s+/g, ' ').trim() : '', link: !!document.getElementById('idmp-sysmon-link'),
+      emailHref: em ? em.getAttribute('href') : null, licHref: lic ? lic.getAttribute('href') : null };
   });
 
   // ── open the monitor + read what it rendered ──────────────────────────────────────────────────────────────────
@@ -70,6 +72,8 @@ var server = http.createServer(function (req, res) {
   ck(panel.present && panel.link, 'login info panel renders with a System Monitor link');
   ck(/SuperUser \/ System/.test(panel.text) && /GardenAdmin \/ GardenAdmin/.test(panel.text), 'panel shows the default credential hints (System: SuperUser/System · GardenWorld: GardenAdmin/GardenAdmin)');
   ck(/serverless/.test(panel.text), 'panel states the serverless / SQLite-wasm posture + version line');
+  ck(/Redhuan D\. Oon \(red1\)/.test(panel.text) && panel.emailHref === 'mailto:red1org@gmail.com', 'creator credit: Redhuan D. Oon (red1 → mailto:red1org@gmail.com)');
+  ck(/MIT License 2005\/6/.test(panel.text) && /github\.com\/red1oon/.test(panel.licHref || ''), 'MIT License 2005/6 → GitHub (' + panel.licHref + ')');
   ck(/§SYSTEM-MONITOR open/.test(L) && /§SYSTEM-MONITOR gather/.test(L), 'clicking the link opens the monitor (gather ran)');
   var want = ['System', 'Memory', 'Cache', 'Logs & Trace', 'Servers & Cluster', 'Database'];
   ck(want.every(function (g) { return mon.groups.indexOf(g) >= 0; }), 'monitor mirrors iDempiere sections: ' + want.join(', '));


### PR DESCRIPTION
Adds the creator credit to the login info panel (iDempiere's copyright spot): **Created by Redhuan D. Oon (red1) · MIT License 2005/6** — `red1` → mailto:red1org@gmail.com, `MIT License 2005/6` → github.com/red1oon/bim-ootb.

W-SYSTEM-MONITOR-LIVE **13/13** (adds creator + license hyperlink assertions). sw v723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)