### PR TITLE
feat(erp): Rpt PP_Order KIND-1 report fold (AD_Process 53028) — sw v726 (W-PROC-PPORDER)

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -112,6 +112,10 @@
     // inventory-document print (AD_PROCESS_FOLD_LANE §P2-tail-leg3): folds an M_Inventory → a NON-FINANCIAL receipt
     // (qty=QtyCount) via the SAME report_overlay.foldReceipt over REPORT_MAP.m_inventory — ZERO new fold code.
     registerHandler('report:m_inventory',receiptHandler('m_inventory'),{ kind: 'report', reportKey: 'm_inventory' });
+    // report:pp_order — "Rpt PP_Order" (AD_Process 53028, "Manufacturing Order"). KIND-1, a 4th document family
+    // (manufacturing, AD_PROCESS_FOLD_LANE §P2-tail-leg4): folds a PP_Order → a NON-FINANCIAL receipt (qty=
+    // QtyRequiered over PP_Order_BOMLine) via the SAME report_overlay.foldReceipt — ZERO new fold code.
+    registerHandler('report:pp_order',  receiptHandler('pp_order'),  { kind: 'report', reportKey: 'pp_order' });
     // report:c_project — "Rpt C_Project" (AD_Process 217, Project Print). KIND-1, folds via the SAME foldReceipt
     // (REPORT_MAP.c_project), no new fold code. AD_PROCESS_FOLD_LANE §P2-leg3 — Witness: W-PROC-PROJPRINT.
     registerHandler('report:c_project', receiptHandler('c_project'), { kind: 'report', reportKey: 'c_project' });
@@ -464,6 +468,11 @@
       // so the imperative M_Inventory procs (105/106 carry non-blank classnames; 107 "M_Inventory Process" is
       // isReport=N → never reaches here) stay absent-handler. "inventory" alone is NOT matched (too broad).
       if (/m_inventory\b|physical inventory print/.test(hay)) return 'report:m_inventory';
+      // "Rpt PP_Order" (53028) — PP_Order-SPECIFIC with WORD-BOUNDARIES on both alternatives: `pp_order\b` does NOT
+      // match "rv_pp_order_transactions" (120 — `_` is a word char, no boundary after "pp_order"); `manufacturing
+      // order\b` does NOT match "manufacturing orders review" (53030 — the trailing "s" breaks the boundary). Both
+      // those report-view procs (+ the isReport=N "PP_Order" process 53026) thus stay the honest absent-handler.
+      if (/pp_order\b|manufacturing order\b/.test(hay)) return 'report:pp_order';
       // "Rpt C_Project" (217) — SPECIFIC match (c_project / project print), NOT the broad "project" so the other
       // RV_Project* report-VIEW procs (218 RV_ProjectCycle, 226/228/229/234) stay absent-handler (no foldReceipt
       // for a report view — those are a later report-view fold, not this leg).

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -461,7 +461,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=8"></script>
+<script src="ad_process.js?v=9"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -520,7 +520,7 @@
 <script src="bigdecimal.js?v=1"></script>
 <script src="bim_orders_overlay.js?v=1"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
-<script src="report_overlay.js?v=6"></script>
+<script src="report_overlay.js?v=7"></script>
 <script src="rule_fold.js?v=2"></script>
 <!-- POS_ADDON_SPEC §P-1..§P-4 — the POS addon: engine verbs (UMD of bim-compiler scripts/erp_engine.js),
      the fold glue (pos_core.js, == bim-compiler build/erp source of truth), the dumb-terminal lens.

--- a/erp/report_overlay.js
+++ b/erp/report_overlay.js
@@ -44,6 +44,15 @@
     m_inventory:{key: 'm_inventory',pk:'m_inventory_id',lineTable:'m_inventoryline',fk:'m_inventory_id',
                  fkProduct: 'm_product_id', amount: null,        qty: 'qtycount',    price: null,
                  date: 'movementdate', total: null },
+    // Rpt PP_Order (AD_Process 53028, "Manufacturing Order") — a 4th non-sales document family (manufacturing,
+    // AD_PROCESS_FOLD_LANE §P2-tail-leg4). NON-FINANCIAL: a manufacturing order's BOM lines carry qty=QtyRequiered
+    // (the required component quantity), not money — amount/price/total null. Header PP_Order + lines
+    // PP_Order_BOMLine (line + m_product_id present → no fold-shape change). A production order is internal → no
+    // c_bpartner_id → partner null. date=DatePromised (the populated scheduling date; DateStart is null in seed).
+    // SAME foldReceipt, NO new fold code. The browser lc() helper aliases the CamelCase (DocumentNo/QtyRequiered).
+    pp_order:  { key: 'pp_order',  pk: 'pp_order_id',  lineTable: 'pp_order_bomline',fk: 'pp_order_id',
+                 fkProduct: 'm_product_id', amount: null,        qty: 'qtyrequiered',price: null,
+                 date: 'datepromised', total: null },
     // Rpt C_Project (AD_Process 217, "Project Print") — a KIND-1 report folded by the SAME foldReceipt as the
     // order/invoice prints (no new fold code, AD_PROCESS_FOLD_LANE §P2-leg3). A project IS a document: header
     // C_Project + lines C_ProjectLine; the planned amounts are its money (subtotal = Σ PlannedAmt, total = the

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v725';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v726';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## AD_PROCESS_FOLD_LANE §P2-tail-leg4 — Rpt PP_Order (Manufacturing Order)

A **4th document family** beyond sales/inventory: **manufacturing**. KIND-1 report fold, **zero new fold code, zero host change** — proves the receipt verb generalises past the sales/inventory tables.

- **AD_Process 53028** ("Rpt PP_Order" / "Manufacturing Order", blank classname, `isReport=Y`, no paras) resolves through the W-PROC spine to a synthesized `report:pp_order` key.
- Folds a **PP_Order → a NON-FINANCIAL receipt** via the EXISTING `report_overlay.foldReceipt` over one new `REPORT_MAP.pp_order` row. `PP_Order_BOMLine` has `line` + `m_product_id` → no fold-shape change.
- BOM lines carry **qty=QtyRequiered** (the required component quantity), not money: `amount/price/total` null; internal order → no `c_bpartner_id` → `partner` null; `date=DatePromised` (DateStart null in seed).
- Real served rows: **PP_Order 50000** (DocumentNo 8000, 2 BOM lines, line0 product 50008 QtyRequiered **5050.50505051** — folded **EXACTLY, no rounding** of the non-integer).
- `resolveClassname` match uses **word-boundaries** on both alternatives (`pp_order\b` | `manufacturing order\b`): skips `RV_PP_Order_Transactions` (120 — `_` is a word char) and `Manufacturing Orders Review` (53030 — the "s" breaks the boundary). Those report-VIEW procs + the `isReport=N` `PP_Order` process (53026) stay the honest absent-handler card.

### Witnesses (both EXIT 0)
- `poc_proc_pporder.js` — **W-PROC-PPORDER 6/6**: resolve, non-financial 2-line cent/qty-exact fold (incl. 5050.50505051), falsifier (+7), word-boundary guard (120/53030/53026).
- `poc_pporder_live.js` — **W-PROC-PPORDER-LIVE PASS**, 0 pageerrors: `?process=53028` deep-link (GardenAdmin/role 102) → result card, PP_Order 50000 folds 2 lines qty0 5050.50505051 in-browser off the real CamelCase bundle.
- Regression: W-PROC-MINOUT / MOVEMENT / MINVENTORY / PROJPRINT (headless) + W-PROC-MINVENTORY-LIVE all still PASS.

`sw v725→v726`, `ad_process.js?v=8→9`, `report_overlay.js?v=6→7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)