### PR TITLE
feat(erp): Rpt M_InOutConfirm fold (AD_Process 292) — line-sort + product-join [AD_PROCESS_FOLD §P2-tail-leg6]

### DIFF
--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -104,6 +104,12 @@
     // (amount:null → subtotal/tax/total stay null, qty=MovementQty carried) — honest, never a fabricated total.
     // AD_PROCESS_FOLD_LANE §P2-tail-leg1 — Witness: W-PROC-MINOUT.
     registerHandler('report:m_inout',   receiptHandler('m_inout'),   { kind: 'report', reportKey: 'm_inout' });
+    // report:m_inoutconfirm — "Rpt M_InOutConfirm" (AD_Process 292, "Shipment Confirmation"). KIND-1, the LINE-SORT +
+    // PRODUCT-JOIN variant (AD_PROCESS_FOLD_LANE §P2-tail-leg6): the confirm-line m_inoutlineconfirm has no `line` col
+    // and no m_product_id → REPORT_MAP.m_inoutconfirm carries lineSort + lineProductVia, and the db-aware ctx
+    // (host _procCtx / witness) resolves the ORDER BY + the parent-line product join before folding. foldReceipt is
+    // UNCHANGED — NO new fold verb. A confirmation is NON-FINANCIAL (qty=ConfirmedQty; partner/total/amount/price null).
+    registerHandler('report:m_inoutconfirm', receiptHandler('m_inoutconfirm'), { kind: 'report', reportKey: 'm_inoutconfirm' });
     // report:m_movement — "Rpt M_Movement" (AD_Process 290, "Inventory Move Print"). KIND-1, the warehouse sibling
     // of report:m_inout (AD_PROCESS_FOLD_LANE §P2-tail-leg2): folds an M_Movement → a NON-FINANCIAL receipt via the
     // SAME report_overlay.foldReceipt over REPORT_MAP.m_movement — ZERO new fold code, zero host change.
@@ -470,9 +476,14 @@
       // map known report procs to the report_overlay header tables (extracted, not invented)
       if (/c_order\b|order print|rpt c_order/.test(hay) && !/invoice/.test(hay)) return 'report:c_order';
       if (/c_invoice|invoice print|rpt c_invoice/.test(hay)) return 'report:c_invoice';
-      // "Rpt M_InOut" (117) — M_InOut-SPECIFIC: m_inout\b (word-boundary) so "Rpt M_InOutConfirm" (292,
-      // "m_inoutconfirm" — no boundary) and the RV_InOutDetails report-VIEWs (293/294) stay absent-handler.
-      // "delivery note"/"shipment print" are the print-format name; "shipment confirmation"/"...details" do NOT match.
+      // "Rpt M_InOutConfirm" (292, "Shipment Confirmation") — CHECKED FIRST + CONFIRM-SPECIFIC: m_inoutconfirm\b |
+      // "shipment confirmation" (§P2-tail-leg6). It does NOT catch 117 "Rpt M_InOut" ("shipment print", no "confirm");
+      // the report-VIEWs 284 RV_InOutLineConfirm / 285 RV_InOutConfirm ("rv_inout*confirm", names "Open Confirmation(s)")
+      // carry no literal "m_inoutconfirm" + no "shipment confirmation" → stay absent-handler; 280 M_InOutConfirm_Process
+      // is isReport=N → never reaches here. Must precede the m_inout rule (though m_inout\b alone would not catch it).
+      if (/m_inoutconfirm\b|shipment confirmation/.test(hay)) return 'report:m_inoutconfirm';
+      // "Rpt M_InOut" (117) — M_InOut-SPECIFIC: m_inout\b (word-boundary) so the RV_InOutDetails report-VIEWs (293/294)
+      // stay absent-handler. "delivery note"/"shipment print" are the print-format name; "...details" do NOT match.
       if (/m_inout\b|delivery note|shipment print/.test(hay)) return 'report:m_inout';
       // "Rpt M_Movement" (290) — M_Movement-SPECIFIC: m_movement\b (word-boundary) so the imperative M_Movement
       // procs ("M_Movement_Process"/"M_MovementConfirm_Process", 122/286 — isReport=N, never reach here anyway) and

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -463,7 +463,7 @@
 <!-- B-5/C-5 process dispatch (MULTI_LANE_LAUNCH Lane A) — AD_Process spine (W-PROC). Its report handlers
      resolve to report_overlay's PURE CORE folds, loaded below AFTER bigdecimal.js (the folds are BigDecimal-exact
      and BD must exist at parse time — glassbowl.html load-order parity). -->
-<script src="ad_process.js?v=10"></script>
+<script src="ad_process.js?v=11"></script>
 <script src="ad_data.js?v=23"></script>
 <script src="idmp_session.js?v=24"></script>
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
@@ -522,7 +522,7 @@
 <script src="bigdecimal.js?v=1"></script>
 <script src="bim_orders_overlay.js?v=1"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
-<script src="report_overlay.js?v=8"></script>
+<script src="report_overlay.js?v=9"></script>
 <script src="rule_fold.js?v=2"></script>
 <!-- POS_ADDON_SPEC §P-1..§P-4 — the POS addon: engine verbs (UMD of bim-compiler scripts/erp_engine.js),
      the fold glue (pos_core.js, == bim-compiler build/erp source of truth), the dumb-terminal lens.
@@ -2183,7 +2183,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       fetchLines: function (key, info) {
         var map = RM[key]; if (!map) return [];
         var hdr = header(key, info); if (!hdr) return [];
-        return _sqlRows('SELECT * FROM ' + map.lineTable + ' WHERE ' + map.fk + '=' + Number(hdr[map.pk]) + ' ORDER BY line');
+        var rows = _sqlRows('SELECT * FROM ' + map.lineTable + ' WHERE ' + map.fk + '=' + Number(hdr[map.pk]) + ' ORDER BY ' + (map.lineSort || 'line'));
+        // lineProductVia (§P2-tail-leg6): the product lives on a PARENT line table, not this line row — resolve it
+        // per line through the join + set it on the row, so foldReceipt + names read r[fkProduct] unchanged.
+        if (map.lineProductVia) { var via = map.lineProductVia;
+          rows.forEach(function (r) { var lid = r[via.fk];
+            if (lid != null) { var pr = _sqlRows('SELECT ' + via.product + ' AS p FROM ' + via.table + ' WHERE ' + via.pk + '=' + Number(lid))[0]; r[map.fkProduct] = pr ? pr.p : null; } });
+        }
+        return rows;
       },
       names: function (key, hdr, lines) {
         var map = RM[key], prods = {};

--- a/erp/report_overlay.js
+++ b/erp/report_overlay.js
@@ -28,6 +28,16 @@
     m_inout:   { key: 'm_inout',   pk: 'm_inout_id',   lineTable: 'm_inoutline',   fk: 'm_inout_id',
                  fkProduct: 'm_product_id', amount: null,        qty: 'movementqty', price: null,
                  date: 'movementdate', total: null },
+    // Rpt M_InOutConfirm (AD_Process 292, "Shipment Confirmation") — the LINE-SORT + PRODUCT-JOIN variant
+    // (AD_PROCESS_FOLD_LANE §P2-tail-leg6). The confirm-line table m_inoutlineconfirm has (a) NO `line` column →
+    // `lineSort` names the ORDER BY column instead (m_inoutlineconfirm_id), and (b) NO m_product_id → `lineProductVia`
+    // tells the db-aware caller to resolve each line's product through the parent shipment line (m_inoutline_id →
+    // m_inoutline.m_product_id) and set it on the row before folding. foldReceipt itself is UNCHANGED. NON-FINANCIAL:
+    // qty=ConfirmedQty (amount/price/total null); no c_bpartner_id on the header → partner null; no business date → null.
+    m_inoutconfirm:{key:'m_inoutconfirm',pk:'m_inoutconfirm_id',lineTable:'m_inoutlineconfirm',fk:'m_inoutconfirm_id',
+                 fkProduct: 'm_product_id', amount: null,        qty: 'confirmedqty', price: null,
+                 date: null, total: null, lineSort: 'm_inoutlineconfirm_id',
+                 lineProductVia: { fk: 'm_inoutline_id', table: 'm_inoutline', pk: 'm_inoutline_id', product: 'm_product_id' } },
     // Rpt M_Movement (AD_Process 290, "Inventory Move Print") — the warehouse sibling of m_inout (AD_PROCESS_FOLD_LANE
     // §P2-tail-leg2). A material movement is NON-FINANCIAL (amount/price/total null) — header M_Movement + lines
     // M_MovementLine, the carried value is qty=MovementQty. SAME foldReceipt, NO new fold code. A movement has no
@@ -601,7 +611,11 @@
         var header = lc(rowsOf(db.exec('SELECT * FROM ' + map.key + ' WHERE ' + map.pk + '=' + id + ' LIMIT 1'))[0]) || null;
         if (!header) { renderUnsupported(db, key); return; }
         var lines = [];
-        try { lines = rowsOf(db.exec('SELECT * FROM ' + map.lineTable + ' WHERE ' + map.fk + '=' + id + ' ORDER BY line')).map(lc); } catch (e) {}
+        try { lines = rowsOf(db.exec('SELECT * FROM ' + map.lineTable + ' WHERE ' + map.fk + '=' + id + ' ORDER BY ' + (map.lineSort || 'line'))).map(lc); } catch (e) {}
+        // lineProductVia (§P2-tail-leg6): the carried product lives on a PARENT line table, not this line row —
+        // resolve it per line through the join and set it on the row, so foldReceipt reads r[fkProduct] unchanged.
+        if (map.lineProductVia) { var via = map.lineProductVia;
+          lines.forEach(function (r) { var lid = r[via.fk]; if (lid != null) r[map.fkProduct] = nameOf(db, via.table, via.pk, lid, via.product); }); }
         var names = { partner: nameOf(db, 'c_bpartner', 'c_bpartner_id', header.c_bpartner_id, 'name'), products: {} };
         lines.forEach(function (r) { var pid = r[map.fkProduct]; if (pid != null && names.products[pid] === undefined) names.products[pid] = nameOf(db, 'm_product', 'm_product_id', pid, 'name'); });
         var rec = CORE.foldReceipt(map, header, lines, names);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v730';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v731';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## AD_PROCESS_FOLD §P2-tail-leg6 — Rpt M_InOutConfirm (AD_Process 292, "Shipment Confirmation")

The 6th KIND-1 report leg: the **line-sort + product-join** variant. A blank-classname report proc resolves to `report:m_inoutconfirm` and folds an `M_InOutConfirm` → a NON-FINANCIAL receipt via the **existing** `report_overlay.foldReceipt` — **no new fold verb**.

The confirm-line `m_inoutlineconfirm` has no `line` column and no `m_product_id`, so the new `REPORT_MAP.m_inoutconfirm` row carries two generic, map-driven fields the db-aware callers honour:
- `lineSort` — the `ORDER BY` column (`m_inoutlineconfirm_id`)
- `lineProductVia` — resolve each line's product through the parent shipment line (`m_inoutline_id` → `m_inoutline.m_product_id`)

`foldReceipt` itself is untouched. `qty=ConfirmedQty`; partner/date/amount/price/total honestly null.

### Changes
- `erp/report_overlay.js` (`?v=9`): `REPORT_MAP.m_inoutconfirm` + `show()` honours `lineSort` + `lineProductVia`
- `erp/ad_process.js` (`?v=11`): register `report:m_inoutconfirm` + CONFIRM-SPECIFIC `resolveClassname` match; guards 280 (imperative) + 284/285 (RV_* report-views) stay absent-handler
- `erp/idempiere.html`: `_procCtx.fetchLines` honours `lineSort` + `lineProductVia`
- `erp/sw.js`: `CACHE_VERSION v731`

### Witnesses (bim-compiler)
- **W-PROC-MINOUTCONFIRM 6/6** headless — dispatch, fold, product-join (128 "Azalea Bush"), falsifier, guards
- **W-PROC-MINOUTCONFIRM-LIVE PASS** — proc 292 dispatches in-browser; M_InOutConfirm 100 folds to qty 10 / product "Azalea Bush" via the join; 0 pageerrors
- Regression: report-fold 7/7 headless + minout/pporder/payment live PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)