### PR TITLE
Revive RED PILL as contextual 'Link to BIM Viewer' — W-REDPILL-BIMVIEWER 6/6

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3319,6 +3319,18 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       rule: openRuleFor, pos: openPosFor,
       share: _shareCurrent, home: function () { location.href = 'erp.html'; },
       erpdoc: openReadCompare,
+      // RED PILL (revived, contextual) — cross-tab cold-launch: open the BIM Viewer at THIS record's building
+      //   scene. Replaces the retired BIM-in-window embed. Building = the BIM-band project's Value; ../viewer
+      //   idiom mirrors the warehouse pill. Warm path (focus an open viewer tab) comes later via the message bus.
+      bimviewer: function () {
+        var tab = _curTab(); var rec = _records[_recIdx];
+        var bld = (tab && rec) ? recVal(rec, 'Value') : null;
+        if (!bld) { status('No BIM model linked to this record'); console.log('§BIMVIEWER-PILL no-building'); return; }
+        var homeUrl = encodeURIComponent(location.origin + location.pathname.replace(/[^/]*$/, '') + 'idempiere.html');
+        var url = '../viewer/viewer.html?db=../buildings/' + encodeURIComponent(bld) + '_extracted.db&bld=' + encodeURIComponent(bld) + '&home=' + homeUrl;
+        window.open(url, '_blank');
+        console.log('§BIMVIEWER-PILL opened bld=' + bld + ' url=' + url);
+      },
       // ABOUT_BOX_CONSOLIDATE.md — ShowMe/Help now opens the ONE shared About/DIY modal (was toggleShowMe).
       // Install/Migrate pills retired: the DIY tab carries "bring your data in" (download agent → run → load).
       showme: function () { if (window.AboutDIY) window.AboutDIY.open(); else toggleShowMe(); },
@@ -3395,6 +3407,18 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     // GRID_BATCH_FORM_PILL_SPEC item 5 — showWhen:"form-view": the relocated record toolbar pills surface ONLY
     //   with a record open in FORM view (so they don't clutter the grid / front door). renderBody re-evaluates.
     window.IdmpPillFormGate = function () { return !!(_session && _curTab() && _viewMode === 'form'); };
+    // §AD-GATE — showWhen:"bim-record": the RED "Link to BIM Viewer" pill surfaces ONLY on a BIM-bearing record —
+    //   a C_Project in the BIM band (PK>=990000), whose Value is the building name pushed/baked from the model.
+    //   Keeps the iDempiere surface pure on every other record (the red pill is contextual, not always-on).
+    window.IdmpPillBimGate = function () {
+      try {
+        var tab = _curTab(); if (!_session || !tab) return false;
+        if (String(tab.tableName || '').toLowerCase() !== 'c_project') return false;
+        var rec = _records[_recIdx]; if (!rec) return false;
+        var pk = recVal(rec, 'C_Project_ID');
+        return pk != null && Number(pk) >= 990000;
+      } catch (e) { return false; }
+    };
     // §AD-GATE — showWhen:"pos-station" (POS_ADDON_SPEC §P-1): true only when the tenant carries a c_pos row.
     window.IdmpPillPosGate = function () {
       try { var r = _b3(window.__idmpDb).prepare('SELECT c_pos_id FROM c_pos LIMIT 1').get(); return !!(r && r.c_pos_id); }

--- a/erp/idmp_pills.js
+++ b/erp/idmp_pills.js
@@ -132,6 +132,10 @@
     // Process) surface ONLY with a record open in FORM view. Host answers via window.IdmpPillFormGate().
     var _formOk = (typeof window.IdmpPillFormGate === 'function') ? !!window.IdmpPillFormGate() : false;
     _actions.forEach(function (a) { if (a._showWhen === 'form-view') a.pill = _formOk ? undefined : false; });
+    // §AD-GATE — showWhen:"bim-record": the RED "Link to BIM Viewer" pill surfaces ONLY on a BIM-bearing record
+    // (C_Project in the BIM band, whose Value is the building name). Host answers via window.IdmpPillBimGate().
+    var _bimOk = (typeof window.IdmpPillBimGate === 'function') ? !!window.IdmpPillBimGate() : false;
+    _actions.forEach(function (a) { if (a._showWhen === 'bim-record') a.pill = _bimOk ? undefined : false; });
     var cfg = _PB.getConfig();
     var hidden = (cfg.hidden || []).filter(function (id) { return lifecycleIds.indexOf(id) < 0; }); // drop managed ids
     if (stage !== 'pre-client') hidden = hidden.concat(lifecycleIds);                                // in-client → overflow
@@ -180,13 +184,14 @@
     if (!window.PillBuilder) { console.warn('§IDMP-PILLS PillBuilder missing — not mounted'); return; }
     if (document.getElementById('idmp-pillbar')) return;     // idempotent (one bar)
 
-    fetch('pills_idmp.json?v=33').then(function (r) { return r.json(); }).then(function (mf) {
+    fetch('pills_idmp.json?v=34').then(function (r) { return r.json(); }).then(function (mf) {
       var pills = (mf.pills || []).slice().sort(function (a, b) { return (a.order || 0) - (b.order || 0); });
       var ACT = window.IdmpPillActions || {};
 
       var actions = pills.map(function (p) {
         var act = { id: p.id, name: p.name, key: p.key || '' };
         if (p.img) act.img = p.img; else act.icon = _resolveIcon(p) || '';
+        if (p.title) act.title = p.title;                    // friendly hover label (e.g. "Link to BIM Viewer")
         if (p.stage) act._stage = p.stage;                   // §C lifecycle tag (carried from the manifest)
         if (p.showWhen) act._showWhen = p.showWhen;           // §AD-GATE condition (e.g. "posting-doc") carried from the manifest
         // fn binds BY ID to the host's real handler; honest toast if a handler is missing (NON-INVENT).
@@ -208,6 +213,8 @@
       // form-view at BUILD too (the New/Save/Process pills start OFF the bar until a record is open in form view)
       var _formOk0 = (typeof window.IdmpPillFormGate === 'function') ? !!window.IdmpPillFormGate() : false;
       actions.forEach(function (a) { if (a._showWhen === 'form-view') a.pill = _formOk0 ? undefined : false; });
+      var _bimOk0 = (typeof window.IdmpPillBimGate === 'function') ? !!window.IdmpPillBimGate() : false;
+      actions.forEach(function (a) { if (a._showWhen === 'bim-record') a.pill = _bimOk0 ? undefined : false; });
 
       _injectStyle();
       var wrap = document.createElement('div');

--- a/erp/pills_idmp.json
+++ b/erp/pills_idmp.json
@@ -38,6 +38,16 @@
       "note": "by-status bar chart of the open window (openGraphFor) — barChart glyph."
     },
     {
+      "id": "bimviewer",
+      "name": "Link to BIM Viewer",
+      "title": "Link to BIM Viewer",
+      "key": "",
+      "img": "redpill.png",
+      "showWhen": "bim-record",
+      "order": 2.6,
+      "note": "RED PILL revived (contextual, not the retired always-on clean-mode toggle) — opens the BIM Viewer at this record's building scene (cross-tab cold-launch, ../viewer/viewer.html?db=../buildings/<Value>_extracted.db&bld=<Value>, same idiom as the warehouse pill). §AD-GATE showWhen:bim-record — surfaces ONLY on a BIM-bearing record (C_Project in the BIM band PK>=990000, whose Value IS the building name). Host answers via window.IdmpPillBimGate. Replaces the retired BIM-in-window embed. img=redpill.png; hover 'Link to BIM Viewer'."
+    },
+    {
       "id": "kanban",
       "name": "Kanban",
       "key": "",

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v731';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v732';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -114,6 +114,7 @@ const PRECACHE_ASSETS = [
   'pills.json',
   'idmp_pills.js',     // §A — iDempiere bar registration layer (binds pills_idmp.json fn BY ID to IdmpPillActions)
   'pills_idmp.json',   // §A — sibling manifest for the iDempiere renderer surface (GATE-1: separate from pills.json)
+  'redpill.png',       // RED PILL img — the contextual "Link to BIM Viewer" pill (showWhen:bim-record)
   'idmp_history.js',   // §B — cross-tab history scrubber (Glassbowl #scrub pattern, read-only restore)
   'glassbowl_pills.js',   // §GB-PILLS — Glassbowl+Gravity ⋯ registry binding (binds pills_glassbowl/gravity.json BY ID)
   'pills_glassbowl.json', // §GB-PILLS — Glassbowl manifest (home/trace/untangle/reset/mute/panel/edit/qr/showme/about)

--- a/erp/tests/poc_redpill_bimviewer.js
+++ b/erp/tests/poc_redpill_bimviewer.js
@@ -1,0 +1,73 @@
+// poc_redpill_bimviewer.js — W-REDPILL-BIMVIEWER: the revived RED PILL "Link to BIM Viewer" on the iDempiere
+// surface. Deep-links to the Hospital Project Order (GardenAdmin, win 130, record 990000) and proves:
+//   §gate  — IdmpPillBimGate() true on the BIM-band Hospital project; the red pill (#pill-bimviewer) renders
+//            with hover 'Link to BIM Viewer' and img redpill.png.
+//   §click — clicking it opens ../viewer/viewer.html?db=../buildings/Hospital_extracted.db&bld=Hospital (§BIMVIEWER-PILL).
+//   §pure  — on a NON-BIM seed project the gate is false → no red pill (surface stays pure iDempiere).
+// §-log first (read the .log). Run: node tests/poc_redpill_bimviewer.js
+'use strict';
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path'), os = require('os');
+const ROOT = path.join(__dirname, '..', '..');   // serve the bim-ootb root (so ../viewer, ../buildings resolve)
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm', '.mjs':'text/javascript', '.bin':'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/erp/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { res.writeHead(404); res.end('404 ' + p); return; } res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(b); });
+});
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = []; const W = (ok, m) => log.push((ok ? '🟢' : '🔴') + ' ' + m);
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const browser = await chromium.launch(); const page = await browser.newPage({ viewport: { width: 1100, height: 800 } });
+  const cons = []; page.on('console', m => cons.push(m.text())); page.on('pageerror', e => cons.push('PAGEERR ' + e));
+  // intercept window.open so the click is observable without spawning a tab
+  await page.addInitScript(() => { window.__opened = []; window.open = (u) => { window.__opened.push(u); return null; }; });
+
+  await page.goto(`http://localhost:${port}/erp/idempiere.html?login=GardenAdmin&window=130&record=990000`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // wait until the Hospital project record is the focused form record
+  let landed = false;
+  for (let i = 0; i < 60; i++) {
+    landed = await page.evaluate(() => typeof window.IdmpPillBimGate === 'function' && window.IdmpPillBimGate()).catch(() => false);
+    if (landed) break; await sleep(1000);
+  }
+  W(landed, '§gate IdmpPillBimGate() true on Hospital (BIM band 990000)');
+
+  // open the ⋯ pill rail
+  await page.evaluate(() => { const t = document.getElementById('idmp-pill-trigger'); if (t) t.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(800);
+  const pill = await page.evaluate(() => {
+    const b = document.getElementById('pill-bimviewer'); if (!b) return null;
+    const img = b.querySelector('img');
+    return { present: true, title: b.title, img: img ? img.getAttribute('src') : null };
+  });
+  W(pill && pill.present, 'red pill #pill-bimviewer present in the rail');
+  W(pill && pill.title === 'Link to BIM Viewer', "hover = 'Link to BIM Viewer' (got " + (pill && JSON.stringify(pill.title)) + ')');
+  W(pill && /redpill\.png/.test(pill.img || ''), 'pill uses redpill.png (got ' + (pill && pill.img) + ')');
+
+  // click → opens the viewer at the Hospital scene
+  await page.evaluate(() => { const b = document.getElementById('pill-bimviewer'); if (b) b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(400);
+  const opened = await page.evaluate(() => window.__opened.slice());
+  const url = opened.find(u => /viewer\.html/.test(u)) || '';
+  W(/\.\.\/viewer\/viewer\.html\?db=\.\.\/buildings\/Hospital_extracted\.db&bld=Hospital/.test(url), 'click opened the Hospital viewer URL (' + url + ')');
+
+  // screenshot the pill rail
+  const SHOT = path.join(os.homedir(), 'Pictures', 'Screenshots', 'redpill_bimviewer.png');
+  try { fs.mkdirSync(path.dirname(SHOT), { recursive: true }); } catch (e) {}
+  const bar = await page.$('#idmp-pillbar'); if (bar) await bar.screenshot({ path: SHOT }); else await page.screenshot({ path: SHOT });
+
+  // negative: a non-BIM seed project → gate false (surface pure). Navigate to a low-PK project.
+  const lowProj = await page.evaluate(() => { const db = window.__idmpDb; const r = db.exec("SELECT C_Project_ID FROM C_Project WHERE C_Project_ID<990000 LIMIT 1"); return r.length ? r[0].values[0][0] : null; });
+  if (lowProj != null) {
+    await page.goto(`http://localhost:${port}/erp/idempiere.html?login=GardenAdmin&window=130&record=${lowProj}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    let pure = false;
+    for (let i = 0; i < 40; i++) { const g = await page.evaluate(() => typeof window.IdmpPillBimGate === 'function' ? window.IdmpPillBimGate() : null).catch(() => null); if (g === false) { pure = true; break; } if (g === true) break; await sleep(1000); }
+    W(pure, '§pure non-BIM project (id=' + lowProj + ') → gate false, no red pill');
+  } else W(true, '§pure (no non-BIM project to test — skipped)');
+
+  console.log(log.join('\n'));
+  const pass = log.filter(l => l.startsWith('🟢')).length;
+  console.log('\nW-REDPILL-BIMVIEWER ' + pass + '/' + log.length + '  shot=' + SHOT);
+  fs.writeFileSync(path.join(__dirname, 'poc_redpill_bimviewer.log'), log.join('\n') + '\n\n' + cons.filter(t => /§BIMVIEWER|§IDMP|PAGEERR/.test(t)).slice(0, 20).join('\n'));
+  await browser.close(); server.close(); process.exit(pass === log.length ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });


### PR DESCRIPTION
The loosely-coupled **replacement for the retired BIM-in-window embed**: a cross-tab cold-launch from an iDempiere record to the BIM Viewer's 3D scene.

Brings back the **red pill** (`redpill.png`) — but **contextual**, not the retired always-on clean-mode toggle: it surfaces **only on a BIM-bearing record**, so every other record stays pure iDempiere chrome (honours the FUNDAMENTAL LAW).

- `pills_idmp.json`: new `bimviewer` pill (`img: redpill.png`, hover **"Link to BIM Viewer"**, `showWhen: "bim-record"`).
- `idmp_pills.js`: `bim-record` gate (build + per-record re-eval via `setDocContext→_applyStage`) + `title` passthrough; manifest `?v=34`.
- `idempiere.html`: `IdmpPillActions.bimviewer` opens `../viewer/viewer.html?db=../buildings/<Value>_extracted.db&bld=<Value>&home=…` (warehouse-pill idiom); `IdmpPillBimGate` = C_Project in the BIM band (PK≥990000, `Value` == building name).
- `sw.js`: precache `redpill.png`; v731→v732.

**Witness W-REDPILL-BIMVIEWER 6/6**: gate true on Hospital, red pill present with correct hover + `redpill.png` img, click opens the Hospital viewer URL, and gate **false on a non-BIM project** → no pill. Screenshot `redpill_bimviewer.png`.

Warm path (focus an already-open viewer tab via the message bus, + zoom to a specific element) is the next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)