### PR TITLE
fix(erp): Process toolbar tooltip Alt+P → Alt+O (oracle parity)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -1290,7 +1290,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       var gear = (window.ICONS && window.ICONS.settings)
         ? ('<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + window.ICONS.settings.svg + '</svg> ')
         : '⚙ ';
-      btn(gear + 'Process', 'Process (Alt+P) — run the document/table process', hasProc, function () { _showProcessChooser(); });
+      // Accelerator = Alt+O (oracle: ADWindowToolbar altKeyMap.put(VK_O, btnProcess); Alt+P is btnPrint's, not Process's).
+      btn(gear + 'Process', 'Process (Alt+O) — run the document/table process', hasProc, function () { _showProcessChooser(); });
       // Zoom Across — iDempiere's btnZoomAcross (magnifier, verified vs theme ZoomAcross24.png). WHERE-USED:
       //   opens a popup of the windows whose records reference THIS record (with counts); pick one → that window
       //   opens FILTERED to the referencers. Enabled only on a real saved record (a PK to be referenced).

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v735';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v736';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
iDempiere `ADWindowToolbar` binds `altKeyMap.put(VK_O, btnProcess)` — **Process is Alt+O**, and Alt+P is `btnPrint`'s. Our gear tooltip mislabelled it "Alt+P".

Pure fidelity correctness against the verified oracle (`~/idempiere-dev-setup/idempiere/.../ADWindowToolbar.java:524-525`). RESUME_IDMP_FIDELITY Leg 5 tooltip sub-bug (the `reports`/Print split remainder of Leg 5 stays parked on a user decision). sw v735→v736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)