### PR TITLE
fix(modeller): M1 grid-undo — gridline coords are a fold of the op-log — W-GRIDMOVE-UNDO 4/4

### DIFF
--- a/viewer/bonsai_grid.js
+++ b/viewer/bonsai_grid.js
@@ -30,9 +30,33 @@
       this.xlabels = spec.xlabels || this.xs.map((_, i) => String.fromCharCode(65 + i));   // A,B,C…
       this.ylabels = spec.ylabels || this.ys.map((_, i) => String(i + 1));                  // 1,2,3…
       if (this.snapTol == null && spec.snapTol) this.snapTol = spec.snapTol;
+      this._baseXs = this.xs.slice(); this._baseYs = this.ys.slice();   // immutable base — grid coords FOLD from this + active GEOM_GRID_MOVE deltas (M1)
       console.log(TAG + ' define xs=[' + this.xs + '] ys=[' + this.ys + '] labels=' + this.xlabels.join('') + '/' + this.ylabels.join(''));
       if (this._group) this.render();
       return this;
+    },
+
+    // M1 fix: the authoring gridline positions are a FOLD of the op-log — the defined base + the delta of every
+    // ACTIVE GEOM_GRID_MOVE (non-undone AND within the scrub cursor, the SAME set the geometry fold renders).
+    // Re-derived on every op-log change so undo/redo/scrub revert the grid deterministically. Previously
+    // bonsai_gridmove.commit mutated grid.xs imperatively and undo never reverted it → next snap used a stale line.
+    foldFromOplog() {
+      const O = window.Bonsai && window.Bonsai.oplog;
+      if (!this._baseXs || !this._baseYs || !O || !O.db) return;
+      const xs = this._baseXs.slice(), ys = this._baseYs.slice();
+      const ops = O._geomOps ? O._geomOps() : [];
+      const upto = (typeof O.cursor === 'number') ? Math.min(O.cursor, ops.length) : ops.length;
+      for (let i = 0; i < upto; i++) {
+        const op = ops[i]; if (!op || op.op_type !== 'GEOM_GRID_MOVE') continue;
+        const p = op.parameters || {}; const mm = /^g([xy])(\d+)$/.exec(p.gridId || '');
+        if (!mm || !p.delta) continue;
+        const arr = mm[1] === 'x' ? xs : ys, idx = +mm[2];
+        if (idx >= 0 && idx < arr.length) arr[idx] += p.delta;
+      }
+      const changed = xs.length !== this.xs.length || ys.length !== this.ys.length ||
+        xs.some((v, i) => v !== this.xs[i]) || ys.some((v, i) => v !== this.ys[i]);
+      this.xs = xs; this.ys = ys;
+      if (changed && this._group && this.active) this.render();   // only rebuild lines when a grid coord actually moved
     },
 
     render() {
@@ -88,5 +112,8 @@
 
   window.Bonsai = window.Bonsai || {};
   window.Bonsai.grid = Grid;
+  // Re-derive grid coords from the op-log on every change (commit/undo/redo/delete/clear/reload all _emit this).
+  // Scrub does NOT _emit → scrubToShared calls foldFromOplog directly at its call site.
+  window.addEventListener('bonsai:oplog', () => { try { Grid.foldFromOplog(); } catch (e) {} });
   console.log(TAG + ' module loaded');
 })();

--- a/viewer/bonsai_gridmove.js
+++ b/viewer/bonsai_gridmove.js
@@ -48,8 +48,8 @@
       const commands = this.computeCommands(gridId, delta);
       const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_GRID_MOVE',
         parameters: { gridId, delta, commands } }, {});
-      const m = this._map[gridId];   // advance the authoring gridline so later snaps/drags use the new position
-      if (m) { const arr = m.axis === 'x' ? window.Bonsai.grid.xs : window.Bonsai.grid.ys; arr[m.index] += delta; window.Bonsai.grid.render(); }
+      // The authoring gridline advances via Grid.foldFromOplog — a FOLD of the op-log fired on this commit's
+      // bonsai:oplog event — NOT mutated here, so undo/redo/scrub revert it deterministically (M1 fix).
       console.log(TAG + ' commit grid=' + gridId + ' delta=' + delta + ' cmds=' + commands.length +
         ' verify=' + res.verify + ' tris=' + res.triangleCount);
       return { ...res, commands };

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -778,6 +778,7 @@ let _applyingRemoteScrub = false;
 async function scrubToShared(cursor, publish) {
   histStamp(cursor); paintRecords(cursor);
   await window.Bonsai.oplog.scrubTo(cursor);
+  if (window.Bonsai.grid && window.Bonsai.grid.foldFromOplog) window.Bonsai.grid.foldFromOplog();   // grid follows the scrub (scrubTo doesn't _emit) — M1
   if (publish && window.Connect && window.Connect.on && !_applyingRemoteScrub)
     window.Connect.publish('timeline', { cursor: cursor, length: window.Bonsai.oplog.length, surface: 'modeller' });
 }
@@ -2187,6 +2188,53 @@ if (qs.get('multiselect') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER multiselect demo fail ' + e); }
     window.__multiResult = out; window.__multiDone = true;
     console.log('§MODELLER multiselect-done');
+  })();
+}
+// ?gridundo=demo proves the GRID-UNDO CORRECTNESS FIX (W-GRIDMOVE-UNDO / M1): a committed GEOM_GRID_MOVE advances
+// the authoring gridline, but the line is now a FOLD of the op-log (base + active deltas) — so UNDO reverts it,
+// REDO re-applies it, and SCRUB to before the move shows the base line. Previously the coord was mutated
+// imperatively and never reverted → the next snap used a stale gridline. Drives the real gridmove/undo/scrub paths.
+if (qs.get('gridundo') === 'demo') {
+  (async () => {
+    const out = {}; const O = window.Bonsai.oplog; const G = window.Bonsai.grid;
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    const snapX = (x) => +G.snap(x, 1.5).x.toFixed(2);
+    try {
+      G.define({ xs: [0, 2, 4], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] }); G.show(true);
+      O.clear(); await sleep(50);
+      out.baseX1 = G.xs[1];                                          // 2 (gridline B)
+      // a thin wall straddling gridline B so the move recomposes geometry too (full GEOM_GRID_MOVE path)
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[1.9, 0], [2.1, 0], [2.1, 3], [1.9, 3]] }, depth: 3 } });
+      await sleep(50);
+      const res = await window.Bonsai.gridmove.commit('gx1', 1.0);   // drag gridline B +1.0 → x=3
+      await sleep(80);
+      out.afterMoveX1 = G.xs[1];                                     // 3
+      out.gridMoveOps = O._geomOps().filter(o => o.op_type === 'GEOM_GRID_MOVE').length;   // 1
+      out.snapMovedAfterMove = snapX(3.05);                          // 3.00 — a point near the MOVED line snaps to it
+      out.verifyAfterMove = (await O.verify()).ok;
+
+      // SCRUB back to before the grid move (cursor=1, the wall only) → grid reverts to base, then forward again
+      await scrubToShared(1, false); await sleep(40);
+      out.scrubBackX1 = G.xs[1];                                     // 2 (base restored under scrub)
+      out.snapBaseAfterScrub = snapX(2.05);                         // 2.00 — base line snaps again
+      await scrubToShared(O.length, false); await sleep(40);
+      out.scrubFwdX1 = G.xs[1];                                      // 3 (re-applied at the tip)
+
+      // UNDO the grid move → gridline reverts to base (THE BUG: previously stayed at 3)
+      const u = await O.undo(); out.undoId = u.undone; await sleep(80);
+      out.afterUndoX1 = G.xs[1];                                     // 2
+      out.gridMoveOpsAfterUndo = O._geomOps().filter(o => o.op_type === 'GEOM_GRID_MOVE').length;   // 0
+      out.snapBaseAfterUndo = snapX(2.05);                          // 2.00 — base line is the snap target again
+      out.snapMovedAfterUndo = snapX(3.05);                        // 3.05 (NOT 3.0 — the moved line is gone)
+      out.verifyAfterUndo = (await O.verify()).ok;
+
+      // REDO → gridline advances again
+      const rd = await O.redo(); out.redoId = rd.redone; await sleep(80);
+      out.afterRedoX1 = G.xs[1];                                     // 3
+      out.snapMovedAfterRedo = snapX(3.05);                          // 3.00
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER gridundo demo fail ' + e); }
+    window.__gridundoResult = out; window.__gridundoDone = true;
+    console.log('§MODELLER gridundo-done');
   })();
 }
 // ?gmpreview=demo proves the Move-Grid PREVIEW (W-BONSAI-GMPREVIEW, the user's "move grid" feedback gap): while

--- a/viewer/tests/bonsai_gridundo_live.js
+++ b/viewer/tests/bonsai_gridundo_live.js
@@ -1,0 +1,53 @@
+// W-GRIDMOVE-UNDO — grid-undo correctness witness (M1; MODELLER_DIRECT_MANIPULATION.md §0-RESULTS TIER 2).
+// CLAIM: the authoring gridline position is now a FOLD of the op-log (defined base + the delta of every ACTIVE
+// GEOM_GRID_MOVE) — so committing a grid drag advances the line, UNDO reverts it, REDO re-applies it, and SCRUB to
+// before the move shows the base line, with snap() always targeting the correct (current) gridline. Previously
+// bonsai_gridmove.commit mutated grid.xs imperatively and undo never reverted it → the next snap used a stale line.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-gridundo', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|GRIDMOVE|GRID|BONSAI)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?gridundo=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__gridundoDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __gridundoDone'));
+
+  const x = await pg.evaluate(() => window.__gridundoResult || {}).catch(e => ({ error: String(e) }));
+  await br.close(); server.close();
+
+  console.log('  §GRIDUNDO base.x1=' + x.baseX1 + ' afterMove.x1=' + x.afterMoveX1 + ' gridMoveOps=' + x.gridMoveOps +
+    ' snapMovedAfterMove=' + x.snapMovedAfterMove + ' verifyAfterMove=' + x.verifyAfterMove);
+  console.log('  §GRIDUNDO scrubBack.x1=' + x.scrubBackX1 + ' snapBaseAfterScrub=' + x.snapBaseAfterScrub +
+    ' scrubFwd.x1=' + x.scrubFwdX1);
+  console.log('  §GRIDUNDO undoId=' + x.undoId + ' afterUndo.x1=' + x.afterUndoX1 + ' gridMoveOpsAfterUndo=' +
+    x.gridMoveOpsAfterUndo + ' snapBaseAfterUndo=' + x.snapBaseAfterUndo + ' snapMovedAfterUndo=' + x.snapMovedAfterUndo +
+    ' verifyAfterUndo=' + x.verifyAfterUndo);
+  console.log('  §GRIDUNDO redoId=' + x.redoId + ' afterRedo.x1=' + x.afterRedoX1 + ' snapMovedAfterRedo=' +
+    x.snapMovedAfterRedo + (x.error ? '  ERROR=' + x.error : ''));
+
+  const moved = x.baseX1 === 2 && x.afterMoveX1 === 3 && x.gridMoveOps === 1 && x.snapMovedAfterMove === 3 && x.verifyAfterMove === true;
+  const scrubReverts = x.scrubBackX1 === 2 && x.snapBaseAfterScrub === 2 && x.scrubFwdX1 === 3;        // grid follows the scrub both ways
+  const undoReverts = x.undoId != null && x.afterUndoX1 === 2 && x.gridMoveOpsAfterUndo === 0 &&
+    x.snapBaseAfterUndo === 2 && x.snapMovedAfterUndo !== 3 && x.verifyAfterUndo === true;             // THE FIX: line + snap revert
+  const redoReapplies = x.redoId != null && x.afterRedoX1 === 3 && x.snapMovedAfterRedo === 3;
+
+  const pass = moved && scrubReverts && undoReverts && redoReapplies;
+  console.log('  §GRIDUNDO VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — moved=' + moved + ' scrubReverts=' + scrubReverts + ' undoReverts=' + undoReverts + ' redoReapplies=' + redoReapplies);
+  console.log('── W-GRIDMOVE-UNDO ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## M1 — grid-undo correctness bug

`MODELLER_DIRECT_MANIPULATION.md` §0-RESULTS TIER 2. `GEOM_GRID_MOVE.commit` mutated `grid.xs[index] += delta` imperatively, but undo/redo/scrub never reverted it → after an undo the **next snap used a stale gridline**.

## Fix — gridline coords become a fold of the op-log
`Grid.foldFromOplog()` resets to the **defined base** and re-applies the delta of every **active** (non-undone, within the scrub cursor) `GEOM_GRID_MOVE` — the same op set the geometry fold renders. Re-derived on every `bonsai:oplog` event (commit/undo/redo/delete/clear/reload) and at the `scrubToShared` call site (`scrubTo` doesn't `_emit`). `gridmove.commit` no longer touches `grid.xs`. This matches the **"geometry = fold of the signed op-log"** doctrine — grid coords are no longer host state that can drift.

Render is skipped when no coord actually changed (avoids rebuilding gridlines on every unrelated insert/cut).

## Witness — `W-GRIDMOVE-UNDO` 4/4 (headless, `tests/bonsai_gridundo_live.js`)
Drives the real gridmove/undo/redo/scrub paths: commit advances gridline B 2→3 (snap targets 3) → **scrub** back shows base 2 (snap targets 2) then forward shows 3 → **undo** reverts to 2 (snap no longer hits 3, base 2 snaps again, chain verifies) → **redo** re-applies 3.

Regression: `W-BONSAI-GRID`, `-GRIDMOVE`, `-MOVE`, `-MULTISELECT` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)