### PR TITLE
feat(modeller): M3 pre-pick hover highlight — cursor glow before click — W-BONSAI-HOVER 5/5

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -587,6 +587,26 @@ canvas.addEventListener('pointerdown', (e) => {           // bare (no-shift) pic
   const hit = pickAt(e.clientX, e.clientY);
   if (hit) { highlight(hit.object); setStat('selected feature #' + selectedId); }
 });
+// ── M3 HOVER PRE-PICK (W-BONSAI-HOVER) ──────────────────────────────────────────────────────────
+// Raycast under the cursor BEFORE any click and give the feature a faint glow (dimmer than selection) + a
+// pointer cursor — the affordance every competitor has and DAGeVu's silent pick lacked. Skips selected meshes
+// (keeps their selection emissive), and is suppressed while a button is held (orbit) or any non-select mode/drag.
+let _hoverMesh = null, _hoverId = null;
+function setHover(mesh) {
+  const hid = mesh ? mesh.userData.featureId : null;
+  if (hid === _hoverId) return;
+  if (_hoverMesh && !selectedIds.has(_hoverMesh.userData.featureId)) _emis(_hoverMesh, 0x000000);   // restore prev (unless it's selected)
+  _hoverMesh = mesh; _hoverId = hid;
+  if (mesh && !selectedIds.has(hid)) _emis(mesh, 0x14324a);   // faint hover tint (< selection 0x2b5a8c)
+  canvas.style.cursor = mesh ? 'pointer' : '';
+  if (window.A && A.requestRender) A.requestRender();
+}
+canvas.addEventListener('pointermove', (e) => {
+  if (!inSelectCtx() || marquee || _moveDrag || e.buttons) { if (_hoverId != null) setHover(null); return; }   // not while orbiting/dragging/another mode
+  const hit = pickAt(e.clientX, e.clientY);
+  setHover(hit ? hit.object : null);
+});
+canvas.addEventListener('pointerleave', () => { if (_hoverId != null) setHover(null); });
 
 // Cut an opening into the SELECTED wall: derive a window void from the wall bbox (full through the
 // thinnest axis, centred 40% on the other two), commit as a GEOM_CUT child of the selected feature.
@@ -2486,6 +2506,44 @@ if (qs.get('rotate') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER rotate demo fail ' + e); }
     window.__rotateResult = out; window.__rotateDone = true;
     console.log('§MODELLER rotate-done');
+  })();
+}
+// ?hover=demo proves PRE-PICK HOVER (W-BONSAI-HOVER / M3): moving the cursor over a feature (no click) gives it a
+// faint glow (dimmer than selection) + a pointer cursor; empty space clears both; a SELECTED feature keeps its
+// selection glow while a different feature is hovered; and hover is suppressed while a button is held (orbit).
+if (qs.get('hover') === 'demo') {
+  (async () => {
+    const out = {}; const O = window.Bonsai.oplog;
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    const meshOf = (fid) => window.Bonsai.group().children.find(o => o.isMesh && o.userData.featureId === fid);
+    const emisOf = (fid) => { const m = meshOf(fid); return m && m.material && m.material.emissive ? m.material.emissive.getHex() : null; };
+    const centreClient = (fid) => { const m = meshOf(fid); m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox; const c = new THREE.Vector3((b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2); const r = canvas.getBoundingClientRect(); const v = c.project(camera); return { clientX: r.left + (v.x + 1) / 2 * r.width, clientY: r.top + (1 - v.y) / 2 * r.height }; };
+    const move = (pt, buttons) => canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: pt.clientX, clientY: pt.clientY, buttons: buttons || 0, bubbles: true }));
+    try {
+      window.Bonsai.grid.show(false); O.clear(); await sleep(50);
+      const door = window.Bonsai.library.catalog().find(c => c.ifc_class === 'IfcDoor');
+      const A = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: door.hash, placement: { x: 0, y: 0, z: 0, rot: 0 }, lod: '200' } });
+      for (let i = 0; i < 40 && !meshOf(A.id); i++) await sleep(50);
+      const B = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash: door.hash, placement: { x: 3, y: 0, z: 0, rot: 0 }, lod: '200' } });
+      for (let i = 0; i < 40 && !meshOf(B.id); i++) await sleep(50);
+      out.ids = [A.id, B.id]; highlight(null); await sleep(20);
+      out.HOVER_TINT = 0x14324a; out.SEL_TINT = 0x2b5a8c;
+      // 1) hover A → glow + pointer cursor
+      const pa = centreClient(A.id); move(pa); await sleep(20);
+      out.hoverAId = _hoverId; out.hoverAEmis = emisOf(A.id); out.cursorOnA = canvas.style.cursor;
+      // 2) move to empty space → cleared
+      move({ clientX: 5, clientY: 5 }); await sleep(20);
+      out.hoverEmptyId = _hoverId; out.emisAfterLeave = emisOf(A.id); out.cursorEmpty = canvas.style.cursor;
+      // 3) select A, then hover B → B glows, A keeps selection glow
+      window.Bonsai.select(A.id); await sleep(20);
+      const pb = centreClient(B.id); move(pb); await sleep(20);
+      out.hoverBId = _hoverId; out.hoverBEmis = emisOf(B.id); out.selAEmisWhileHoverB = emisOf(A.id);
+      // 4) hover B with a button held (orbit) → suppressed
+      move({ clientX: 5, clientY: 5 }); await sleep(10); move(pb, 1); await sleep(20);
+      out.hoverWhileButton = _hoverId; out.bEmisWhileButton = emisOf(B.id);
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER hover demo fail ' + e); }
+    window.__hoverResult = out; window.__hoverDone = true;
+    console.log('§MODELLER hover-done');
   })();
 }
 // ?gmpreview=demo proves the Move-Grid PREVIEW (W-BONSAI-GMPREVIEW, the user's "move grid" feedback gap): while

--- a/viewer/tests/bonsai_hover_live.js
+++ b/viewer/tests/bonsai_hover_live.js
@@ -1,0 +1,51 @@
+// W-BONSAI-HOVER — pre-pick hover witness (M3; MODELLER_DIRECT_MANIPULATION.md §0-RESULTS TIER 2).
+// CLAIM: moving the cursor over a feature (no click) now gives it a FAINT glow (0x14324a, dimmer than the
+// 0x2b5a8c selection glow) + a pointer cursor — the discoverability affordance the silent pick lacked. Empty
+// space clears the glow + cursor; a SELECTED feature keeps its selection glow while a DIFFERENT feature is
+// hovered; and hover is suppressed while a mouse button is held (so it never fights an orbit drag).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-hover', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OPLOG|MODELLER|LIBRARY|BONSAI)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?hover=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__hoverDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __hoverDone'));
+
+  const x = await pg.evaluate(() => window.__hoverResult || {}).catch(e => ({ error: String(e) }));
+  await br.close(); server.close();
+
+  const ids = x.ids || [];
+  console.log('  §HOVER ids=[' + ids.join(',') + '] HOVER_TINT=' + x.HOVER_TINT + ' SEL_TINT=' + x.SEL_TINT);
+  console.log('  §HOVER (1) hoverAId=' + x.hoverAId + ' hoverAEmis=' + x.hoverAEmis + ' cursorOnA=' + JSON.stringify(x.cursorOnA));
+  console.log('  §HOVER (2) hoverEmptyId=' + x.hoverEmptyId + ' emisAfterLeave=' + x.emisAfterLeave + ' cursorEmpty=' + JSON.stringify(x.cursorEmpty));
+  console.log('  §HOVER (3) hoverBId=' + x.hoverBId + ' hoverBEmis=' + x.hoverBEmis + ' selAEmisWhileHoverB=' + x.selAEmisWhileHoverB);
+  console.log('  §HOVER (4) hoverWhileButton=' + x.hoverWhileButton + ' bEmisWhileButton=' + x.bEmisWhileButton + (x.error ? '  ERROR=' + x.error : ''));
+
+  const hoverGlows = x.hoverAId === ids[0] && x.hoverAEmis === x.HOVER_TINT && x.cursorOnA === 'pointer';
+  const distinctFromSelection = x.HOVER_TINT !== x.SEL_TINT;
+  const emptyClears = x.hoverEmptyId == null && x.emisAfterLeave === 0 && x.cursorEmpty === '';
+  const keepsSelectionGlow = x.hoverBId === ids[1] && x.hoverBEmis === x.HOVER_TINT && x.selAEmisWhileHoverB === x.SEL_TINT;
+  const suppressedWhileButton = x.hoverWhileButton == null && x.bEmisWhileButton === 0;
+
+  const pass = hoverGlows && distinctFromSelection && emptyClears && keepsSelectionGlow && suppressedWhileButton;
+  console.log('  §HOVER VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — hoverGlows=' + hoverGlows + ' distinctFromSelection=' + distinctFromSelection + ' emptyClears=' + emptyClears +
+    ' keepsSelectionGlow=' + keepsSelectionGlow + ' suppressedWhileButton=' + suppressedWhileButton);
+  console.log('── W-BONSAI-HOVER ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## M3 — pre-pick hover highlight

`MODELLER_DIRECT_MANIPULATION.md` §0-RESULTS M3 — the discoverability affordance every competitor has and DAGeVu's silent pick lacked. Caps the direct-manipulation lane (all TIER-0 P1·P2·P3 + TIER-1 H1·H2·H3 + M1 already live).

### What changed (`viewer/modeller.html`)
Moving the cursor over a feature (no click) gives it a **faint glow** (`0x14324a`, dimmer than the `0x2b5a8c` selection glow) + a **pointer cursor**.
- `setHover(mesh)` tints the hovered non-selected mesh, restores the previous one, sets the cursor; **skips selected meshes** so their selection emissive is preserved.
- A canvas `pointermove` drives it, **suppressed while a button is held** (never fights an orbit drag) or any non-select mode / marquee / gizmo drag is active; `pointerleave` clears.

### Witness — `W-BONSAI-HOVER` 5/5 (headless, `tests/bonsai_hover_live.js`)
Hover a feature → faint glow + pointer cursor (distinct from selection) → empty space clears glow + cursor → a selected feature keeps its selection glow while a different feature is hovered → hover suppressed while a button is held.

Regression: `W-BONSAI-MOVE`, `-MULTISELECT`, `-SNAPGEOM`, `-ROTATE` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)