### PR TITLE
fix(modeller): center BOM-assembly drop on the cursor [W-BOM-DROP-CENTER]

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -1247,7 +1247,16 @@ function rotateInsert() {                                          // R key / Ro
 // leaf (the recursion + parent-relative transforms live in bonsai_library.expandAssembly). W-BOM-ASSEMBLY.
 async function placeAssembly(x, y) {
   const L = window.Bonsai.library, asm = L.assembly(insertHash);
-  const leaves = L.expandAssembly(insertHash, { x, y, z: insElev, rot: insRot });
+  // CENTER-anchor the drop. expandAssembly seats children CORNER-anchored ([0..W]), but the ghost box (showGhost
+  // above) is CENTER-anchored ([-W/2..+W/2]) — so a raw expand lands the whole set in the +X/+Y quadrant, offset
+  // from the ghost by ≈(+W/2,+D/2) (BOM_DROP_SPATIAL_INVESTIGATION §RESULT: anchor mismatch, NOT bad data — the
+  // BOM cascade is proven parent-relative & untouched here). Shift the expand origin back by the ROTATED half-
+  // extent so the footprint CENTER lands on the drop point. Level-agnostic: identical for a furniture SET … a
+  // whole BUILDING (just a cascade of BOMs). W-BOM-DROP-CENTER.
+  const _r = (insRot || 0) * Math.PI / 180, _cs = Math.cos(_r), _sn = Math.sin(_r);
+  const _ox = ((asm && asm.w) || 0) / 2, _oy = ((asm && asm.d) || 0) / 2;
+  const cx = x - (_cs * _ox - _sn * _oy), cy = y - (_sn * _ox + _cs * _oy);
+  const leaves = L.expandAssembly(insertHash, { x: cx, y: cy, z: insElev, rot: insRot });
   if (!leaves.length) { setStat('assembly ' + insertHash + ' has no placeable leaves'); return null; }
   const placed = [];
   for (const lf of leaves) {                                     // each leaf = one signed op-row (the chain)
@@ -1983,6 +1992,45 @@ if (qs.get('place') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER place demo fail ' + e); }
     window.__placeResult = out; window.__placeDone = true;
     console.log('§MODELLER place-done');
+  })();
+}
+// ?dropcenter=demo proves W-BOM-DROP-CENTER: a dropped assembly's footprint CENTERS on the drop point, not the
+// +X/+Y quadrant (BOM_DROP_SPATIAL_INVESTIGATION §RESULT — anchor mismatch fix). Calls the REAL placeAssembly
+// directly (NO canvas pointer dispatch → bypasses OrbitControls.setPointerCapture, which throws on synthetic
+// pointers in headless). The proof is EXACT + deterministic: every committed leaf == the raw CORNER expansion at
+// the same drop, shifted by exactly −(W/2, D/2). Level-agnostic; uses a small curated SET so the drop is fast.
+if (qs.get('dropcenter') === 'demo') {
+  (async () => {
+    const out = {}; const L = window.Bonsai.library, O = window.Bonsai.oplog;
+    const near = (a, b, t) => Math.abs(a - b) <= (t || 1e-3);
+    try {
+      await L.ready();
+      // a coherent SET/ROOM with a real footprint (>0.5m each side) and a fast leaf count — the cluster users drop
+      const pick = L.assemblies()
+        .map(a => ({ a, n: L.expandAssembly(a.id, { x: 0, y: 0, z: 0, rot: 0 }).length }))
+        .filter(x => x.n >= 2 && x.n <= 24 && (x.a.w || 0) > 0.5 && (x.a.d || 0) > 0.5)
+        .sort((x, y) => (y.a.w * y.a.d) - (x.a.w * x.a.d)).map(x => x.a)[0];
+      if (!pick) { out.error = 'no suitable SET assembly'; }
+      else {
+        out.pick = pick.id; out.level = pick.level; out.w = +pick.w.toFixed(2); out.d = +pick.d.toFixed(2);
+        insRot = 0; insElev = 0; inserting = true; insertHash = pick.id; O.clear();
+        const raw = L.expandAssembly(pick.id, { x: 4, y: 3, z: 0, rot: 0 });   // OLD (corner-anchored) placements
+        await placeAssembly(4, 3);                                             // REAL drop through the fixed path
+        out.committed = O.length; out.N = raw.length;
+        const com = O._geomOps().map(o => o.parameters.placement);
+        // EXACT: each committed leaf is the raw corner placement shifted back by the rotated half-extent (rot=0)
+        out.shifted = com.length === raw.length &&
+          com.every((p, i) => near(p.x, raw[i].x - pick.w / 2, 0.01) && near(p.y, raw[i].y - pick.d / 2, 0.01));
+        const cxs = com.map(p => p.x), cys = com.map(p => p.y);
+        out.center = [+(((Math.min(...cxs) + Math.max(...cxs)) / 2)).toFixed(2), +(((Math.min(...cys) + Math.max(...cys)) / 2)).toFixed(2)];
+        // soft sanity: footprint center lands on the drop (4,3), no longer at (4+W/2, 3+D/2)
+        out.centeredOnDrop = near(out.center[0], 4, Math.max(0.51, pick.w * 0.15)) && near(out.center[1], 3, Math.max(0.51, pick.d * 0.15));
+        out.oldQuadrantOffset = +Math.hypot(pick.w / 2, pick.d / 2).toFixed(2);   // the scatter the fix removes
+        out.verify = (await O.verify()).ok;
+      }
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER dropcenter fail ' + e); }
+    window.__dropCenterResult = out; window.__dropCenterDone = true;
+    console.log('§MODELLER dropcenter-done ' + JSON.stringify(out));
   })();
 }
 // ?edit=demo proves EDITABILITY (W-BONSAI-EDIT): delete a single feature, cascade-delete a parent (its cut child

--- a/viewer/tests/bom_assembly_live.js
+++ b/viewer/tests/bom_assembly_live.js
@@ -99,9 +99,23 @@ const server = http.createServer((q, r) => {
     // picker DETACHES after the drop (no ghost stuck to the pointer) — user-reported fix
     const ghostDetached = !window.A.scene.children.find(o => o.name === 'InsertGhost');
 
+    // W-BOM-DROP-CENTER: placeAssembly CENTER-anchors the corner-anchored expansion under the center-anchored
+    // ghost. The host dropped at world (4,3) with rot=0 → every committed placement must equal the RAW corner
+    // expansion at (4,3) shifted by exactly −(W/2, D/2). Equivalently the committed footprint CENTER lands on the
+    // drop point (4,3), not at (4+W/2, 3+D/2) as before the fix. Deterministic, no GPU. (BOM_DROP §RESULT fix a.)
+    const raw = L.expandAssembly(pick.id, { x: 4, y: 3, z: 0, rot: 0 });
+    const com = O._geomOps().map(o => o.parameters.placement);
+    const hw = (pick.w || 0) / 2, hd = (pick.d || 0) / 2;
+    const dropCentered = com.length === raw.length &&
+      com.every((p, i) => near(p.x, raw[i].x - hw, 0.01) && near(p.y, raw[i].y - hd, 0.01));
+    const cxs = com.map(p => p.x), cys = com.map(p => p.y);
+    const fcx = +(((Math.min(...cxs) + Math.max(...cxs)) / 2)).toFixed(2);
+    const fcy = +(((Math.min(...cys) + Math.max(...cys)) / 2)).toFixed(2);
+
     return { pickId: pick.id, level: pick.level, parts: pick.children.length, directLeafLines, N,
       recursionExpanded, relativeOk, rotationOk, det, layoutSpread, linId, ghostDetached,
-      committed, verify: !!(ver && ver.ok), signedCount, allInsert, distinctPts, meshCount };
+      committed, verify: !!(ver && ver.ok), signedCount, allInsert, distinctPts, meshCount,
+      dropCentered, footprintCenter: [fcx, fcy], asmW: +(pick.w || 0).toFixed(2), asmD: +(pick.d || 0).toFixed(2) };
   });
 
   await br.close(); server.close();
@@ -119,6 +133,7 @@ const server = http.createServer((q, r) => {
     chainVerifies:   r.verify === true,                      // signed kernel_ops chain verifies
     everyRowSigned:  r.signedCount === r.committed && r.committed > 0,
     partsSpread:     r.distinctPts > 1,                      // distinct placements (not stacked)
+    dropCentered:    r.dropCentered === true,                // W-BOM-DROP-CENTER: footprint center sits on the drop point
     renders:         r.meshCount >= r.N                      // N leaf meshes folded into the scene
   };
   const pass = Object.values(checks).every(Boolean);

--- a/viewer/tests/bom_dropcenter_live.js
+++ b/viewer/tests/bom_dropcenter_live.js
@@ -1,0 +1,45 @@
+// W-BOM-DROP-CENTER — DAGeVu modeller: dropping a BOM assembly CENTERS its footprint on the drop point.
+// Before the fix, expandAssembly seats children CORNER-anchored ([0..W]) while the ghost box is CENTER-anchored
+// ([-W/2..+W/2]), so the whole set landed in the +X/+Y quadrant, offset from the ghost by ≈(+W/2,+D/2) — the
+// "scatter" in ModelBOMDrop.png. The fix (placeAssembly) shifts the expand origin back by the ROTATED half-extent.
+// PROVES the issue: every committed leaf == the raw corner expansion shifted by exactly −(W/2,D/2) ⇒ footprint
+// center on the drop. Level-agnostic (furniture SET … whole BUILDING — a cascade of BOMs). Drives the REAL
+// placeAssembly via the in-page ?dropcenter=demo self-test (NO canvas pointer → bypasses the headless
+// OrbitControls.setPointerCapture flake). prompts/BOM_DROP_SPATIAL_INVESTIGATION.md §RESULT fix (a).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 160)));
+  pg.on('console', m => { const t = m.text(); if (/dropcenter|recursion stop/.test(t)) console.log('  ' + t); });
+  await pg.goto(`http://localhost:${port}/modeller.html?dropcenter=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__dropCenterDone === true', { timeout: 45000 }).catch(() => {});
+  const r = await pg.evaluate(() => window.__dropCenterResult || { error: 'no result' });
+  await br.close(); server.close();
+  console.log('  §DROPCENTER ' + JSON.stringify(r));
+  const checks = {
+    setPicked:       !!r.pick && r.committed > 1,                   // a real, multi-part SET was dropped
+    committedAllN:   r.committed === r.N && r.N > 1,                // every expanded leaf committed
+    shiftedHalf:     r.shifted === true,                           // EXACT: leaf == raw − (W/2,D/2)  ← the fix
+    centeredOnDrop:  r.centeredOnDrop === true,                     // footprint center sits on the drop point (4,3)
+    movedOffQuadrant: r.oldQuadrantOffset > 0.3,                   // the pre-fix scatter was non-trivial (real bug)
+    chainVerifies:   r.verify === true                             // signed op-log still verifies
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §DROPCENTER VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' '));
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What
Dropping a BOM assembly in the DAGeVu modeller scattered its parts into the +X/+Y quadrant instead of landing under the cursor (see `ModelBOMDrop.png`).

## Root cause (proven, not data)
`BOM_DROP_SPATIAL_INVESTIGATION.md §RESULT`: the extraction is **correct** — `m_bom_line` dx/dy/dz are genuinely parent-LBD-relative (no regression). The scatter is a **render anchor-convention mismatch**: `expandAssembly` seats children **corner-anchored** (`[0..W]`) while the insert ghost box is **center-anchored** (`[-W/2..+W/2]`), so the set landed offset from the ghost by ≈`(+W/2, +D/2)`.

## Fix
`placeAssembly` shifts the expand origin back by the **rotated half-extent** so the footprint **center** lands on the drop point. The BOM cascade itself is untouched (`expandAssembly` unchanged). **Level-agnostic** — a furniture SET and a whole BUILDING (a cascade of BOMs) center identically; BUILDING stays droppable as the top of the cascade per design.

## Witness — `W-BOM-DROP-CENTER` (`viewer/tests/bom_dropcenter_live.js`)
Drives the **real** `placeAssembly` via an in-page `?dropcenter=demo` self-test (no canvas pointer dispatch → dodges the headless OrbitControls `setPointerCapture` flake that hangs the UI-pointer witnesses locally).

```
§DROPCENTER {"pick":"DX_FDN_STR","level":"FLOOR","w":8.8,"d":17.8,"committed":7,"N":7,"shifted":true,"center":[4,3],"centeredOnDrop":true,"oldQuadrantOffset":9.93,"verify":true}
§DROPCENTER VERDICT PASS — setPicked=true committedAllN=true shiftedHalf=true centeredOnDrop=true movedOffQuadrant=true chainVerifies=true
```

- `shifted=true` — every committed leaf == raw corner placement − (W/2, D/2), exact & deterministic
- `center=[4,3]` — footprint center lands precisely on the drop point
- `oldQuadrantOffset=9.93` — pre-fix the FLOOR landed 9.93 m off the cursor
- signed op-log still verifies

Also extends `W-BOM-ASSEMBLY` (`bom_assembly_live.js`) with a `dropCentered` check through the host-drop UI path (runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)