### PR TITLE
feat(landing): restore Live Stats link — bottom-left of Matrix portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,13 @@
     color:rgba(180,200,190,.0); transition:color 1.2s ease; pointer-events:none; letter-spacing:.5px; }
   #portal.ready .por-hint { color:rgba(150,200,180,.7); }
 
+  /* site traffic link — bottom-left corner of the Matrix portal (carried over from the old landing footer) */
+  .por-stats { position:fixed; left:14px; bottom:14px; z-index:30; font-family:'IM Fell English',Georgia,serif;
+    font-size:13px; letter-spacing:.4px; text-decoration:none; color:rgba(150,200,180,0);
+    transition:color 1.2s ease; pointer-events:none; }
+  #portal.ready .por-stats { color:rgba(150,200,180,.55); pointer-events:auto; }
+  #portal.ready .por-stats:hover { color:var(--glow); }
+
   /* ---- desktop background (rail + hub live over this) ---- */
   #desktop { background:#07090f; }
 
@@ -148,6 +155,7 @@
   <div id="portal-vortex"></div>
   <div id="portal-stage"></div>
   <div class="por-hint intertitle">choose your door</div>
+  <a class="por-stats" href="https://red1oon.goatcounter.com" target="_blank" rel="noopener" title="Site traffic stats (GoatCounter)">📊 Live Stats</a>
 </div>
 
 <!-- desktop background (rail + hub open over this) -->


### PR DESCRIPTION
## What
Re-adds the **📊 Live Stats** link (→ https://red1oon.goatcounter.com) to the Matrix landing portal, at the **bottom-left corner**.

## Why
The old gallery landing had this link in its footer. The Matrix portal that replaced it dropped it, making the traffic dashboard hard to reach (user request).

## How
- Fixed-position `.por-stats` anchor inside `#portal`, bottom-left (`left:14px; bottom:14px`).
- Fades in with the `#portal.ready` cue and brightens on hover — same idiom as `.por-hint`.
- No i18n on this page, so the label is plain text.

## Verified
Headless render: link present, `left=14px bottom=14px`, opacity 1, correct href. Screenshot confirms bottom-left placement, clear of the centered "choose your door" hint and the bottom-right `⋯` rail.

> Note: the Matrix landing also lacks the GoatCounter **count.js** tracking tag (separate from this link) — landing visits aren't being counted, though other pages still feed the dashboard. Out of scope here; flag for a follow-up if you want the landing tracked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)