### PR TITLE
feat(landing): add GoatCounter tracking tag — count Matrix-landing visits

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,5 +558,11 @@ async function clearCache(){
   else { L('§BOOT return ('+navType+') → ⋯ rail'); showMinimized(); }
 })();
 </script>
+
+<!-- GoatCounter traffic analytics — count landing visits (the ?ignore-me flag opts a device out).
+     Same counter the bottom-left Live Stats link reports from; carried over from the old gallery footer. -->
+<script>if(new URLSearchParams(location.search).has('ignore-me'))localStorage.setItem('goatcounter-ignore','t')</script>
+<script data-goatcounter="https://red1oon.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What
Adds the GoatCounter **count.js** tracking tag to the Matrix landing (`index.html`), so landing-page visits are counted — the missing half of #443 (which restored the *link* to the dashboard).

## How
- Tag added before `</body>`, pointing at the same counter (`red1oon.goatcounter.com/count`) the bottom-left Live Stats link reports from.
- Includes the `?ignore-me` device opt-out — carried over verbatim from the old gallery footer convention.

## No impact to working pages (headless-verified)
- All door functions (`openHub`/`closeHub`/`launchModeller`/`takeRed`/`takeBlue`/`showPortalFresh`/`showMinimized`) defined; **hub open/close works**; boot flow + Live Stats link intact.
- **Zero** page errors / console errors from this change.
- The only 404s (`2hands.jpg`, `import_own.js`, `favicon.ico`) are **pre-existing** local-server artifacts — identical with and without this change — and resolve on the real deploy.
- `count.js` loads 200. GoatCounter skips localhost by design, so the beacon fires only on the live domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)