### PR TITLE
feat(modeller): rotate a placed B-rep solid — real occt GEOM_ROTATE + yaw ring for solids [W-BONSAI-ROTATE-SOLID]

### DIFF
--- a/viewer/bonsai_kernel.js
+++ b/viewer/bonsai_kernel.js
@@ -19,7 +19,7 @@
     init() {
       if (this._worker) return this._worker;
       if (!this.isSupported()) { console.warn(TAG + ' unsupported host (needs WASM tail-calls + Worker)'); return null; }
-      const url = new URL('bonsai_kernel_worker.js?v=3', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch (W-BONSAI-ROTATE)
+      const url = new URL('bonsai_kernel_worker.js?v=4', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin (W-BONSAI-ROTATE-SOLID)
       this._worker = new Worker(url.href, { type: 'module' });
       this._worker.onmessage = (e) => {
         const d = e.data || {};

--- a/viewer/bonsai_kernel_worker.js
+++ b/viewer/bonsai_kernel_worker.js
@@ -186,10 +186,24 @@ function buildSolids(kernel, ops) {
         }
         shapeCache.set(ckey, out); solids.set(c.featureId, { shape: out, hash: ckey });
       }
-    } else if (op.op_type === 'GEOM_ROTATE') {         // W-BONSAI-ROTATE: insert yaw folds HOST-side (PATH B via library.foldInsert).
-      // TOLERANT like GEOM_MOVE: an insert parent isn't in this worker's solids map → silent NO-OP. (Solid B-rep
-      // rotation about its centre = a follow-up leg; would generalTransform the shape here, mirroring GRID_MOVE SCALE.)
-      void solids.get(op.parent);
+    } else if (op.op_type === 'GEOM_ROTATE') {         // yaw a referenced solid about its bbox-centre Z (W-BONSAI-ROTATE-SOLID).
+      // Mirror of GEOM_MOVE: rotate the parent's B-rep IN PLACE so a later GEOM_CUT on the rotated wall reads the
+      // SPUN shape (move-then-rotate-then-cut is honest), successive rotations COMPOSE (each writes solids forward;
+      // op_hash = immutable prefix → distinct cache key), and it stays TOLERANT — an INSERT parent isn't in this
+      // worker's solids map (the host folds insert yaw via PATH B/library.foldInsert) → silent NO-OP.
+      const pe = solids.get(op.parent);
+      if (pe) {
+        const ckey = key + ':' + op.parent;
+        if (shapeCache.has(ckey)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(ckey), hash: ckey }); }
+        else {
+          _stats.rebuilt++;
+          const deg = (P.drot != null ? P.drot : (P.deg || 0));
+          const b = kernel.getBoundingBox(pe.shape, false);
+          const cx = (b.xmin + b.xmax) / 2, cy = (b.ymin + b.ymax) / 2;   // spin about the shape's centre, not the origin
+          const out = kernel.rotate(pe.shape, { point: { x: cx, y: cy, z: 0 }, direction: { x: 0, y: 0, z: 1 } }, deg * Math.PI / 180);
+          shapeCache.set(ckey, out); solids.set(op.parent, { shape: out, hash: ckey });   // parent cached → NOT released
+        }
+      }
     } else {                                           // LEAF feature (extrude/poly/sweep/opening)
       if (shapeCache.has(key)) { _stats.hits++; solids.set(op.id, { shape: shapeCache.get(key), hash: key }); continue; }
       _stats.rebuilt++;

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -941,7 +941,7 @@ function buildMoveGizmo() {
   moveGizmo.add(axisHandle('x', 0xe2553b, L), axisHandle('y', 0x46b955, L), axisHandle('z', 0x4f93e0, L));
   const hub = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.2), new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.5, depthTest: false }));
   hub.userData.moveAxis = 'xy'; moveGizmo.add(hub);
-  if (selectedIds.size <= 1 && selectedId != null && isInsert(selectedId)) {   // H3: yaw ring — INSERTS only (PATH B host re-place); solids fold in the worker (rotation = follow-up) so no ring → no silent no-op rotate
+  if (selectedIds.size <= 1 && selectedId != null && (isInsert(selectedId) || isSolid(selectedId))) {   // H3: yaw ring on a single INSERT (host re-place, PATH B) OR a SOLID (real occt spin in the worker, W-BONSAI-ROTATE-SOLID)
     const ring = new THREE.Mesh(new THREE.TorusGeometry(Math.max(0.7, L * 0.95), 0.045, 8, 56), new THREE.MeshBasicMaterial({ color: 0xf5c542, transparent: true, opacity: 0.9, depthTest: false }));
     ring.userData.moveAxis = 'rotZ'; moveGizmo.add(ring);       // TorusGeometry lies in XY → rotates about +Z by construction
   }
@@ -1207,6 +1207,9 @@ const bLod = document.getElementById('b-lod');
 let inserting = false, insertHash = null, lastInsertId = null, insertPanel = null;
 let insRot = 0, insElev = 0, ghostMesh = null, ghostXY = null;   // pending placement: yaw(deg) + elevation(z), live ghost
 function isInsert(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && o.op_type === 'GEOM_INSERT'; }
+// standalone B-rep solids the worker can spin in place (GEOM_ROTATE): extrude/poly walls, swept runs, filleted solids.
+const SOLID_OPS = new Set(['GEOM_EXTRUDE', 'GEOM_EXTRUDE_POLY', 'GEOM_SWEEP', 'GEOM_FILLET']);
+function isSolid(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && SOLID_OPS.has(o.op_type); }
 function lodTargetId() { return (selectedId != null && isInsert(selectedId)) ? selectedId : lastInsertId; }
 function paintLod() {
   const id = lodTargetId();
@@ -2538,11 +2541,12 @@ if (qs.get('rotate') === 'demo') {
       const u = await O.undo(); out.undoId = u.undone; await sleep(60);
       out.afterUndo = dims(ins.id); out.verifyAfterUndo = (await O.verify()).ok;
       exitMove();
-      // GATE: an authored SOLID (not an insert) must NOT get a yaw ring (rotation would silently no-op for solids).
+      // GATE (flipped by W-BONSAI-ROTATE-SOLID): an authored SOLID now DOES get a yaw ring — the worker spins its
+      // B-rep via real occt rotation, so the ring is no longer a no-op. (Was INSERT-only.)
       O.clear(); { const _g = window.Bonsai.group(); while (_g.children.length) _g.remove(_g.children[0]); } await sleep(50);
       const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [2, 0], [2, 0.2], [0, 0.2]] }, depth: 3 } });
       await sleep(60); window.Bonsai.select(wall.id); bMove.onclick();
-      out.solidRing = !!(moveGizmo && moveGizmo.children.find(o => o.userData.moveAxis === 'rotZ'));   // false — no ring on a solid
+      out.solidRing = !!(moveGizmo && moveGizmo.children.find(o => o.userData.moveAxis === 'rotZ'));   // true — solids now carry the ring
       exitMove();
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER rotate demo fail ' + e); }
     window.__rotateResult = out; window.__rotateDone = true;

--- a/viewer/tests/bonsai_rotate_live.js
+++ b/viewer/tests/bonsai_rotate_live.js
@@ -5,7 +5,7 @@
 // put, the chain verifies + is signed (insert+rotate), scrub replays deterministically, and undo restores the
 // prior yaw. (Solid/group rotation = follow-ups; the worker carries a tolerant GEOM_ROTATE no-op branch.)
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-rotate', 'viewer');
+const VIEWER = path.join(__dirname, '..');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
   '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
@@ -57,13 +57,13 @@ const server = http.createServer((q, r) => {
   const centreFixed = Math.abs((a.cx || 0) - (b.cx || 0)) < 0.03 && Math.abs((a.cy || 0) - (b.cy || 0)) < 0.03;       // spins in place
   const replayDeterministic = Math.abs(((x.replayBefore || {}).ex) - b.ex) < 0.03 && Math.abs(((x.replayAfter || {}).ex) - a.ex) < 0.03;
   const undoRestores = x.undoId != null && Math.abs((au.ex || 0) - (b.ex || 0)) < 0.03 && Math.abs((au.ey || 0) - (b.ey || 0)) < 0.03 && x.verifyAfterUndo === true;
-  const solidNoRing = x.solidRing === false;                                                // a solid gets NO yaw ring (would silently no-op)
+  const solidHasRing = x.solidRing === true;                                                 // a solid NOW carries a yaw ring (worker spins its B-rep) — W-BONSAI-ROTATE-SOLID
   const drew = probe.litPct > 0.5;
 
-  const pass = armed && dragged && oneSignedRotate && extentsSwapped && centreFixed && replayDeterministic && undoRestores && solidNoRing && drew;
+  const pass = armed && dragged && oneSignedRotate && extentsSwapped && centreFixed && replayDeterministic && undoRestores && solidHasRing && drew;
   console.log('  §ROTATE VERDICT ' + (pass ? 'PASS' : 'FAIL') +
     ' — armed=' + armed + ' dragged=' + dragged + ' oneSignedRotate=' + oneSignedRotate + ' extentsSwapped=' + extentsSwapped +
-    ' centreFixed=' + centreFixed + ' replayDeterministic=' + replayDeterministic + ' undoRestores=' + undoRestores + ' solidNoRing=' + solidNoRing + ' drew=' + drew);
+    ' centreFixed=' + centreFixed + ' replayDeterministic=' + replayDeterministic + ' undoRestores=' + undoRestores + ' solidHasRing=' + solidHasRing + ' drew=' + drew);
   console.log('── W-BONSAI-ROTATE ' + (pass ? 'PASS' : 'FAIL') + ' ──');
   process.exit(pass ? 0 : 1);
 })();

--- a/viewer/tests/bonsai_rotate_solid_live.js
+++ b/viewer/tests/bonsai_rotate_solid_live.js
@@ -1,0 +1,107 @@
+// W-BONSAI-ROTATE-SOLID — DAGeVu modeller: a placed B-rep SOLID (not just an insert) can be rotated. The worker's
+// GEOM_ROTATE branch now applies a REAL occt rotation about the shape's bbox-centre Z (was a tolerant no-op). Driven
+// PURELY through the signed op-log (no canvas pointer dispatch → dodges the headless OrbitControls.setPointerCapture
+// flake that hangs the gizmo-drag witnesses). Proves: (A) a non-square wall rotated 90° has its B-rep X/Y extents
+// SWAP with the centre fixed; one signed GEOM_ROTATE; chain verifies; scrub replays deterministically; a 2nd +90
+// COMPOSES back to the original extents; undo restores. (B) move→rotate→cut is honest — a void that only intersects
+// the MOVED+ROTATED shape removes material, proving the cut reads the transformed solid. RESUME_MODELLER_POLISH.md #1.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  pg.on('console', m => { const t = m.text(); if (/rotate-solid/.test(t)) console.log('  ' + t); });
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.library && window.Bonsai.library.ready && window.Bonsai.oplog", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+
+  const r = await pg.evaluate(async () => {
+    const O = window.Bonsai.oplog, out = {};
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    const meshOf = fid => { const g = window.Bonsai.group(); return g && g.children.find(o => o.isMesh && o.userData.featureId === fid); };
+    const dims = fid => { const m = meshOf(fid); if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+      return { ex: +(b.max.x - b.min.x).toFixed(3), ey: +(b.max.y - b.min.y).toFixed(3),
+        cx: +((b.min.x + b.max.x) / 2).toFixed(3), cy: +((b.min.y + b.max.y) / 2).toFixed(3),
+        nv: m.geometry.attributes.position ? m.geometry.attributes.position.count : 0 }; };
+    const near = (a, b, t) => Math.abs(a - b) <= (t || 0.06);
+    const settle = async (fid, pred) => { for (let i = 0; i < 100; i++) { const d = dims(fid); if (d && pred(d)) return d; await sleep(50); } return dims(fid); };
+    try {
+      window.Bonsai.grid.show(false); O.clear(); await sleep(50);
+      // ── PART A: a non-square wall (footprint 3.0 × 0.4) rotated 90° about its centre
+      const W = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [3, 0], [3, 0.4], [0, 0.4]] }, depth: 2.5 } });
+      await settle(W.id, () => true);
+      out.before = dims(W.id);
+      await O.commit({ op_type: 'GEOM_ROTATE', parameters: { parent: W.id, drot: 90 } });
+      await O.scrubTo(O.length);
+      out.after90 = await settle(W.id, d => near(d.ex, out.before.ey));
+      out.swapped = near(out.after90.ex, out.before.ey) && near(out.after90.ey, out.before.ex);   // X/Y extents swap
+      out.centreFixed = near(out.after90.cx, out.before.cx) && near(out.after90.cy, out.before.cy);
+      out.rotOps = O._geomOps().filter(o => o.op_type === 'GEOM_ROTATE').length;                  // exactly 1 signed rotate
+      out.signed = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verifyA = (await O.verify()).ok;
+      // determinism: scrub back (extents restore) then forward (swap returns)
+      const n = O.length;
+      await O.scrubTo(n - 1); out.replayBefore = dims(W.id);
+      await O.scrubTo(n); out.replayAfter = dims(W.id);
+      out.deterministic = near(out.replayBefore.ex, out.before.ex) && near(out.replayAfter.ex, out.after90.ex);
+      // compose: a 2nd +90 → 180 total → extents return to the original
+      await O.commit({ op_type: 'GEOM_ROTATE', parameters: { parent: W.id, drot: 90 } });
+      await O.scrubTo(O.length);
+      out.after180 = await settle(W.id, d => near(d.ex, out.before.ex));
+      out.composes = near(out.after180.ex, out.before.ex) && near(out.after180.ey, out.before.ey);
+      // undo restores the 90° state
+      const u = await O.undo(); await O.scrubTo(O.length);
+      out.afterUndo = await settle(W.id, d => near(d.ex, out.after90.ex));
+      out.undoRestores = u.undone != null && near(out.afterUndo.ex, out.after90.ex) && (await O.verify()).ok;
+
+      // ── PART B: move → rotate → cut honesty. Wall moved +4 in X then spun 90° spans y∈[-1.3,1.7]; a void at
+      // y∈[1.0,1.5] only intersects the MOVED+ROTATED shape (the un-rotated wall maxed at y=0.4) → if the cut lands
+      // (mesh vertex count changes) it proves GEOM_CUT read the transformed solid.
+      O.clear(); await sleep(50);
+      const W2 = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [3, 0], [3, 0.4], [0, 0.4]] }, depth: 2.5 } });
+      await settle(W2.id, () => true);
+      await O.commit({ op_type: 'GEOM_MOVE', parameters: { parent: W2.id, dx: 4, dy: 0, dz: 0 } });
+      await O.commit({ op_type: 'GEOM_ROTATE', parameters: { parent: W2.id, drot: 90 } });
+      await O.scrubTo(O.length);
+      const beforeCut = await settle(W2.id, () => true);
+      await O.commit({ op_type: 'GEOM_CUT', parameters: { parent: W2.id, void: { c1: [5.2, 1.0, 0.4], c2: [5.8, 1.5, 1.6] } } });
+      await O.scrubTo(O.length); await sleep(200);
+      const afterCut = dims(W2.id);
+      out.beforeCutNv = beforeCut ? beforeCut.nv : 0; out.afterCutNv = afterCut ? afterCut.nv : 0;
+      out.cutLanded = !!(afterCut && beforeCut && afterCut.nv !== beforeCut.nv);
+      out.verifyB = (await O.verify()).ok;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER rotate-solid fail ' + e); }
+    return out;
+  });
+
+  await br.close(); server.close();
+  console.log('  §ROTATE-SOLID ' + JSON.stringify(r));
+  const checks = {
+    extentsSwap:    r.swapped === true,
+    centreFixed:    r.centreFixed === true,
+    oneSignedRotate: r.rotOps === 1 && r.signed >= 2,
+    chainVerifies:  r.verifyA === true,
+    deterministic:  r.deterministic === true,
+    composes:       r.composes === true,
+    undoRestores:   r.undoRestores === true,
+    cutHonest:      r.cutLanded === true,         // move→rotate→cut: the void carved the transformed solid
+    cutVerifies:    r.verifyB === true
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §ROTATE-SOLID VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' '));
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What
`RESUME_MODELLER_POLISH.md` **item 1** (Rotate follow-up / H3). A placed **B-rep solid** (extrude/sweep/fillet) can now be rotated, not just inserts.

## Before
- The move-gizmo yaw **ring was INSERT-only** (`buildMoveGizmo` gated on `isInsert`).
- The worker's `GEOM_ROTATE` branch was a **tolerant no-op** for solids.

## Change
- **worker** (`bonsai_kernel_worker.js?v=4`): `GEOM_ROTATE` applies a **real occt rotation** about the shape's bbox-centre Z via `kernel.rotate` — a mirror of `GEOM_MOVE`: rotates the parent's B-rep **in place** (so a later `GEOM_CUT` reads the spun shape), successive rotations **compose** (op_hash cache key), and stays **tolerant** (an INSERT parent isn't in the worker's solids map → silent no-op; the host still folds insert yaw via PATH B).
- **host** (`modeller.html`): new `isSolid()` (`GEOM_EXTRUDE/EXTRUDE_POLY/SWEEP/FILLET`); the yaw ring now shows for a single **INSERT or SOLID**. Flipped the `?rotate=demo` gate sub-test (solids now carry a ring).

## Witness — `W-BONSAI-ROTATE-SOLID` (`tests/bonsai_rotate_solid_live.js`)
Op-log driven (no canvas pointer dispatch → dodges the headless OrbitControls `setPointerCapture` flake that hangs the gizmo-drag witnesses):
```
§ROTATE-SOLID VERDICT PASS — extentsSwap=true centreFixed=true oneSignedRotate=true chainVerifies=true
  deterministic=true composes=true undoRestores=true cutHonest=true cutVerifies=true
```
- non-square wall rotated 90°: B-rep extents **swap** `ex 3→0.4, ey 0.4→3`, centre fixed `(1.5,0.2)`
- exactly one signed `GEOM_ROTATE`; chain verifies; scrub replays deterministically
- a 2nd +90° **composes** back to `ex=3`; **undo restores** the 90° state
- **move→rotate→cut honest**: a void intersecting only the moved+rotated shape carved it (`nv 24→48`)

Also fixed a latent hardcoded `/tmp/wt-rotate` path in `bonsai_rotate_live.js` (→ `__dirname`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)