### PR TITLE
feat(tm): S1 — variance drawer reads the stored twin (W-PC-TWIN-SOURCE 13/13)

### DIFF
--- a/tests/shot_tm_variance.js
+++ b/tests/shot_tm_variance.js
@@ -1,0 +1,51 @@
+// transient — screenshot the TM variance drawer on a real building. The drawer is 2D canvas (renders from ops,
+// not WebGL), so it shoots reliably. Captures §TM_VARIANCE + a PNG. Run: node tests/shot_tm_variance.js [bld]
+'use strict';
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const os = require('os');
+const ROOT = path.join(__dirname, '..');
+const BLD = process.argv[2] || 'Hospital';
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream', '.bin':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm', '.mjs':'text/javascript' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => { if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); });
+});
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  const page = await browser.newPage({ viewport: { width: 900, height: 900 } });
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+  page.on('pageerror', e => cons.push('PAGEERR ' + e));
+  const URL = `http://localhost:${port}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db&bld=${BLD}`;
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  // wait until the building db + TM toggle are ready
+  for (let i = 0; i < 80; i++) {
+    const ready = await page.evaluate(() => !!(window.toggleTimeMachine && window.APP && window.APP.db)).catch(() => false);
+    if (ready) break; await sleep(1000);
+  }
+  await page.evaluate(() => window.toggleTimeMachine());
+  // wait for the timeline to generate (panel visible + ops)
+  let ok = false;
+  for (let i = 0; i < 90; i++) {
+    ok = await page.evaluate(() => { const p = document.getElementById('time-machine-panel'); return !!(p && p.style.display !== 'none' && window.tmGetState && window.tmGetState().cursor); }).catch(() => false);
+    if (ok || cons.some(t => /§GANTT_(MINI|CACHE|SAVE)/.test(t))) { ok = true; break; } await sleep(1000);
+  }
+  // open the variance drawer
+  await page.evaluate(() => { const b = document.getElementById('tm-var'); if (b) b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(1200);
+  const varLog = cons.filter(t => /§TM_VARIANCE/.test(t));
+  const SHOT = path.join(os.homedir(), 'Pictures', 'Screenshots', 'tm_variance_' + BLD + '.png');
+  try { fs.mkdirSync(path.dirname(SHOT), { recursive: true }); } catch (e) {}
+  const panel = await page.$('#time-machine-panel');
+  if (panel) await panel.screenshot({ path: SHOT }); else await page.screenshot({ path: SHOT });
+  console.log('bld=' + BLD + ' panelReady=' + ok);
+  console.log(varLog.join('\n') || '(no §TM_VARIANCE log captured)');
+  console.log('§GANTT lines: ' + cons.filter(t => /§GANTT/.test(t)).slice(0, 3).join(' | '));
+  console.log('SHOT=' + SHOT);
+  await browser.close(); server.close();
+  process.exit(varLog.length ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });

--- a/tests/test_tm_broadcast.js
+++ b/tests/test_tm_broadcast.js
@@ -1,0 +1,102 @@
+/**
+ * test_tm_broadcast.js — W-TM-PINPOINT + W-TM-BROADCAST (TM_4D5D_VARIANCE_LANE §S3).
+ *
+ * ISSUE PROVEN: scrubbing the Time Machine must (1) PINPOINT the exact element(s) the data is addressing at the
+ *   cursor — the frontier (ops whose window straddles the cursor), with a parked-cursor fallback to the last
+ *   finished op — and (2) BROADCAST that scrub over the shared Connect bus in realtime (cursor + frontier +
+ *   lead selection), echo-guarded + throttled, and APPLY a sibling surface's inbound scrub. The 4D itself is NOT
+ *   regenerated. Whitebox: slices the PURE _frontierAt + the broadcast fns out of time_machine.js, stubs Connect.
+ *
+ * Run: node tests/test_tm_broadcast.js
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  🟢 ' + msg); } else { fail++; console.log('  🔴 FAIL: ' + msg); } }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+const a = src.indexOf('var _applyingRemoteScrub = false;');
+const b = src.indexOf('// ── §S260c: Outline effect');
+if (a < 0 || b < 0 || b < a) { console.log('§TEST FAIL: could not locate §S3 broadcast span'); process.exit(1); }
+const logic = src.slice(a, b);
+
+const DAY = 86400000, base = Date.parse('2026-06-13T00:00:00Z');
+// 3 sequential phases, distinct guids — a clean frontier to pinpoint
+function mkOps() {
+  const PH = [['Substructure', 0, 30], ['Superstructure', 30, 120], ['Finishes', 120, 150]];
+  const ops = [];
+  PH.forEach(p => { for (let i = 0; i < 5; i++) {
+    const s = base + (p[1] + (p[2] - p[1]) * (i / 5)) * DAY;
+    ops.push({ start_ts: s, end_ts: s + ((p[2] - p[1]) / 5) * DAY, output_guid: p[0].slice(0, 3) + i, parameters: { phase: p[0] } });
+  } });
+  return ops;
+}
+const ops = mkOps(), projStart = base, projEnd = base + 150 * DAY;
+
+// fake DOM element for the pinpoint callout
+function fakeEl() { return { style: {}, innerHTML: '', id: '' }; }
+
+function mkSandbox(over) {
+  const published = [];
+  const s = Object.assign({
+    _ops: ops, _cursor: base, _projectStart: projStart, _projectEnd: projEnd, _active: true,
+    A: function () { return { activeBuilding: 'Hospital' }; },
+    window: { Connect: { on: true, publish: function (ch, p) { published.push({ ch, p }); } } },
+    document: { _el: fakeEl(), getElementById: function () { return this._el; }, createElement: function () { return fakeEl(); }, body: { appendChild: function () {} } },
+    console: { log: function () {} },
+    Date: { now: function () { return s.__clock; } },
+    renderAtTime: function (c) { s.__rendered = c; }, anchorFromCursor: function () {}, configSlider: function () {},
+    __clock: 100000, __rendered: null, __published: published,
+  }, over || {});
+  vm.runInNewContext(logic + '\n; globalThis.__front=_frontierAt; globalThis.__bcast=_broadcastTimeline; globalThis.__remote=_applyRemoteTimeline;', s);
+  return s;
+}
+
+// ── W-TM-PINPOINT — _frontierAt returns the ops the cursor is addressing ──
+const sb = mkSandbox();
+const midSuper = base + 75 * DAY;   // mid-Superstructure
+const fr = sb.__front(midSuper);
+console.log('\n§TM_PINPOINT cursor=midSuper frontier=' + fr.map(f => f.guid).join(',') + '\n');
+assert(fr.length > 0 && fr.every(f => f.phase === 'Superstructure'), 'W-TM-PINPOINT: mid-Superstructure pinpoints only Superstructure ops (' + fr.length + ')');
+assert(fr.every(f => { const op = ops.find(o => o.output_guid === f.guid); return op && op.start_ts <= midSuper && op.end_ts > midSuper; }), 'every pinpointed guid is an op whose window STRADDLES the cursor (addressed now)');
+assert(sb.__front(base - DAY).length === 0, 'before any op → nothing addressed (empty frontier)');
+const after = sb.__front(projEnd + 10 * DAY);
+assert(after.length === 1 && after[0].phase === 'Finishes', 'parked past the end → falls back to the last finished op (1 item, ' + after[0].phase + ')');
+
+// ── W-TM-BROADCAST — scrub publishes timeline + lead selection; echo-guarded; throttled ──
+const sb2 = mkSandbox();
+sb2.__clock = 100000; sb2.eval = null;
+// set cursor + broadcast
+vm.runInNewContext('_cursor = ' + midSuper + '; __bcast();', Object.assign(sb2, { __bcast: sb2.__bcast }));
+const pub = sb2.__published;
+const tl = pub.find(p => p.ch === 'timeline'), selp = pub.find(p => p.ch === 'selection');
+console.log('§TM_BROADCAST published channels=' + pub.map(p => p.ch).join(',') + '\n');
+assert(tl && tl.p.surface === 'viewer' && tl.p.building === 'Hospital', 'W-TM-BROADCAST: publishes "timeline" tagged surface=viewer + building');
+assert(tl && typeof tl.p.cursor === 'number' && typeof tl.p.frac === 'number' && Array.isArray(tl.p.frontier) && tl.p.frontier.length > 0, 'timeline payload carries cursor + frac + frontier guids');
+assert(selp && selp.p.guid === tl.p.lead && selp.p.surface === 'viewer', 'publishes a "selection" pinpointing the LEAD addressed element (ERP/sibling lights its record)');
+
+// throttle — a second broadcast at the same wall-clock is suppressed
+const before = sb2.__published.length;
+vm.runInNewContext('__bcast();', sb2);
+assert(sb2.__published.length === before, 'throttled: a second scrub within the window does not re-fan-out');
+
+// echo guard — applying a remote scrub must NOT re-publish
+const sb3 = mkSandbox();
+vm.runInNewContext('_applyingRemoteScrub = true; _cursor = ' + midSuper + '; __bcast();', sb3);
+assert(sb3.__published.length === 0, 'echo guard: no publish while applying a remote scrub');
+
+// ── inbound: a sibling viewer scrub moves our cursor; foreign surface/building ignored ──
+const sb4 = mkSandbox();
+vm.runInNewContext('__remote({ surface:"viewer", building:"Hospital", cursor:' + midSuper + ' });', sb4);
+assert(sb4.__rendered === midSuper, 'inbound viewer scrub (same building) applies the cursor via renderAtTime');
+const sb5 = mkSandbox();
+vm.runInNewContext('__remote({ surface:"modeller", cursor:' + midSuper + ' }); __remote({ surface:"viewer", building:"OtherBld", cursor:' + midSuper + ' });', sb5);
+assert(sb5.__rendered === null, 'inbound from a foreign surface OR different building is ignored (no cross-model scrub)');
+
+console.log('\nW-TM-PINPOINT + W-TM-BROADCAST ' + pass + '/' + (pass + fail));
+fs.writeFileSync(path.join(__dirname, 'test_tm_broadcast.log'),
+  '§TM_PINPOINT frontier=' + fr.length + ' §TM_BROADCAST channels=' + pub.map(p => p.ch).join(',') + '\n' +
+  'W-TM-PINPOINT + W-TM-BROADCAST ' + pass + '/' + (pass + fail) + '\n');
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/test_tm_variance.js
+++ b/tests/test_tm_variance.js
@@ -1,0 +1,81 @@
+/**
+ * test_tm_variance.js — W-TM-VARIANCE: the budget-vs-actual variance logic in time_machine.js.
+ * Whitebox (§-log first): extracts the PURE variance functions (no DOM/3D) from time_machine.js and runs them
+ * on synthetic planned ops, proving: over-budget + late drama, Superstructure marquee blow-out, deterministic
+ * (identical across runs), and _buildActualOps shifts every op later. Spec: GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL.
+ * Run: node tests/test_tm_variance.js
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  🟢 ' + msg); } else { fail++; console.log('  🔴 FAIL: ' + msg); } }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+// slice the pure-logic span: from `var _DAY_MS` up to (but not including) `function _recomputeBounds`
+const a = src.indexOf('var _DAY_MS = 86400000;');
+const b = src.indexOf('function _recomputeBounds()');
+if (a < 0 || b < 0 || b < a) { console.log('§TEST FAIL: could not locate variance logic span'); process.exit(1); }
+const logic = src.slice(a, b);
+
+// LABOR_RATES from rates.js (real cost basis) — same as the running app
+const ratesSandbox = {};
+vm.runInNewContext(fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8'), ratesSandbox);
+
+const DAY = 86400000;
+const base = new Date('2026-06-13T00:00:00Z').getTime();
+// synthetic PLANNED ops — Hospital-like 6 phases, Superstructure the largest (many steel ops)
+const PH = [
+  ['Substructure', 'CONCRETE_GANG', 0, 90, 60],
+  ['Superstructure', 'STEEL_ERECTOR', 90, 1100, 800],   // the big one
+  ['MEP Rough-in', 'MEP_CREW', 1100, 1900, 300],
+  ['Architecture', 'FINISHING_CREW', 1900, 2300, 250],
+  ['MEP Final', 'MEP_CREW', 2300, 2420, 80],
+  ['Finishes', 'FINISHING_CREW', 2420, 2480, 120],
+];
+const ops = [];
+PH.forEach(function (p) {
+  var name = p[0], res = p[1], d0 = p[2], d1 = p[3], cnt = p[4];
+  for (var i = 0; i < cnt; i++) {
+    var s = base + (d0 + (d1 - d0) * (i / cnt)) * DAY;
+    ops.push({ start_ts: s, end_ts: s + 10 * DAY, op_type: 'ELEMENT_PLACE', parameters: { phase: name, resource: res, storey: 'L' + (i % 4) } });
+  }
+});
+
+const sandbox = {
+  window: { LABOR_RATES: ratesSandbox.LABOR_RATES || {} },
+  _ops: ops, _opsPlanned: null, _projectStart: base, _projectEnd: base + 2480 * DAY,
+  console: console,
+};
+vm.runInNewContext(logic + '\n; globalThis.__V = _computeVariance(); globalThis.__buildActual = _buildActualOps;', sandbox);
+const V = sandbox.__V;
+const actual = sandbox.__buildActual();
+
+console.log('\n§TM_VARIANCE plannedCost=' + V.tP + ' actualCost=' + V.tA + ' over=' + V.pctOver + '% lateDays=' + V.lateDays + ' phases=' + V.phases.length + '\n');
+
+assert(V.phases.length === 6, 'all 6 phases aggregated (' + V.phases.length + ')');
+assert(V.tA > V.tP && V.pctOver > 0, 'OVER budget — drama (' + V.pctOver + '% over, +' + (V.tA - V.tP) + ')');
+assert(V.lateDays > 0, 'finish runs LATE (' + V.lateDays + ' days)');
+var sup = V.phases.find(function (p) { return p.phase === 'Superstructure'; });
+assert(sup && sup.marquee === true, 'Superstructure flagged marquee');
+var biggest = V.phases.slice().sort(function (x, y) { return y.dCost - x.dCost; })[0];
+assert(biggest.phase === 'Superstructure', 'Superstructure is the biggest cost blow-out (+' + biggest.dCost + ')');
+assert(V.phases.every(function (p) { return p.aStart >= p.pStart && p.aEnd >= p.pEnd; }), 'every phase actual ≥ planned (late, never early)');
+
+// determinism — recompute and compare
+const s2 = { window: sandbox.window, _ops: ops, _opsPlanned: null, _projectStart: base, _projectEnd: base + 2480 * DAY, console: { log: function () {} } };
+vm.runInNewContext(logic + '\n; globalThis.__V2 = _computeVariance();', s2);
+assert(s2.__V2.tA === V.tA && s2.__V2.tP === V.tP && s2.__V2.lateDays === V.lateDays, 'DETERMINISTIC — identical across runs');
+
+// _buildActualOps shifts every op later, preserves count
+assert(actual.length === ops.length, '_buildActualOps preserves op count (' + actual.length + ')');
+assert(actual.every(function (o, i) { return o.start_ts > ops[i].start_ts && o.end_ts > ops[i].end_ts; }), '_buildActualOps shifts every op later');
+
+console.log('\nphase breakdown:');
+V.phases.forEach(function (p) { console.log('  ' + (p.marquee ? '⚠ ' : '  ') + p.phase.padEnd(15) + ' Δ' + p.dDays + 'd  Δcost=' + p.dCost); });
+
+console.log('\nW-TM-VARIANCE ' + pass + '/' + (pass + fail));
+fs.writeFileSync(path.join(__dirname, 'test_tm_variance.log'),
+  '§TM_VARIANCE plannedCost=' + V.tP + ' actualCost=' + V.tA + ' over=' + V.pctOver + '% lateDays=' + V.lateDays + '\nW-TM-VARIANCE ' + pass + '/' + (pass + fail) + '\n');
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/test_tm_variance.js
+++ b/tests/test_tm_variance.js
@@ -1,81 +1,111 @@
 /**
- * test_tm_variance.js — W-TM-VARIANCE: the budget-vs-actual variance logic in time_machine.js.
- * Whitebox (§-log first): extracts the PURE variance functions (no DOM/3D) from time_machine.js and runs them
- * on synthetic planned ops, proving: over-budget + late drama, Superstructure marquee blow-out, deterministic
- * (identical across runs), and _buildActualOps shifts every op later. Spec: GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL.
- * Run: node tests/test_tm_variance.js
+ * test_tm_variance.js — W-PC-TWIN-SOURCE + W-PC-DRAWER (TM_4D5D_VARIANCE_LANE §S1).
+ *
+ * ISSUE PROVEN: the ⚖ variance drawer must show the STORED twin (iDempiere C_Project/C_ProjectPhase
+ *   PlannedAmt→CommittedAmt from erp/ad_seed.db), NOT a runtime recompute. The old WIP recomputed planned
+ *   (LABOR_RATES×days) and actual (a hash variant) → it only CORRELATED with the records. This test reads the
+ *   real stored numbers via sqlite3 (dependency-free), feeds them into the pure _computeVariance() sliced out
+ *   of viewer/time_machine.js, and FALSIFIES drift: drawer total must equal the stored CommittedAmt EXACTLY.
+ *
+ * Whitebox (§-log first); no DOM/3D. Run: node tests/test_tm_variance.js
  */
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { execSync } = require('child_process');
 
 let pass = 0, fail = 0;
 function assert(cond, msg) { if (cond) { pass++; console.log('  🟢 ' + msg); } else { fail++; console.log('  🔴 FAIL: ' + msg); } }
 
+const ERP = path.join(__dirname, '..', 'erp', 'ad_seed.db');
+function q(sql) { return execSync('sqlite3 -separator "|" "' + ERP + '" ' + JSON.stringify(sql), { encoding: 'utf8' }).trim(); }
+
+// ── 1. Read the STORED twin straight from the seed (the source of truth the drawer must echo) ──
+const projRow = q("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value='Hospital'").split('|');
+const projId = Number(projRow[0]), storedPlanned = Number(projRow[1]), storedCommitted = Number(projRow[2]);
+const phaseRows = q("SELECT Name,SeqNo,StartDate,EndDate,PlannedAmt,CommittedAmt FROM C_ProjectPhase WHERE C_Project_ID=" + projId + " AND Name<>'Unsequenced' ORDER BY SeqNo")
+  .split('\n').filter(Boolean).map(function (l) {
+    const c = l.split('|');
+    return { name: c[0], seqno: Number(c[1]), start: Date.parse(c[2]), end: Date.parse(c[3]), planned: Number(c[4]), committed: Number(c[5]) };
+  });
+console.log('\n§TWIN_READ project=' + projId + ' planned=' + storedPlanned + ' committed=' + storedCommitted + ' phases=' + phaseRows.length);
+
+// ── 2. Synthetic _ops covering the same phases (supplies the cursor-axis windows _computeVariance joins to) ──
+const DAY = 86400000, base = Date.parse('2026-06-13T00:00:00Z');
+const PHWIN = [
+  ['Substructure', 0, 90], ['Superstructure', 90, 1100], ['MEP Rough-in', 1100, 1900],
+  ['Architecture', 1900, 2300], ['MEP Final', 2300, 2420], ['Finishes', 2420, 2480],
+];
+// Sequential, non-overlapping windows — the typical injectGantt shape (phases run one after another). Each
+// op stays inside its phase band so winEnd < next phase winStart (where windows DO overlap, the earlier
+// seqno wins the phase-under-cursor lookup, by design — deterministic).
+const ops = [];
+PHWIN.forEach(function (p) {
+  const span = p[2] - p[1], step = span / 20;
+  for (let i = 0; i < 20; i++) {
+    const s = base + (p[1] + step * i) * DAY;
+    ops.push({ start_ts: s, end_ts: s + step * 0.8 * DAY, op_type: 'ELEMENT_PLACE', parameters: { phase: p[0] } });
+  }
+});
+
+// ── 3. Slice the pure variance logic and run _computeVariance with the twin injected ──
 const src = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
-// slice the pure-logic span: from `var _DAY_MS` up to (but not including) `function _recomputeBounds`
 const a = src.indexOf('var _DAY_MS = 86400000;');
 const b = src.indexOf('function _recomputeBounds()');
 if (a < 0 || b < 0 || b < a) { console.log('§TEST FAIL: could not locate variance logic span'); process.exit(1); }
 const logic = src.slice(a, b);
 
-// LABOR_RATES from rates.js (real cost basis) — same as the running app
-const ratesSandbox = {};
-vm.runInNewContext(fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8'), ratesSandbox);
+function run() {
+  const sandbox = {
+    window: {}, A: function () { return null; }, fetch: undefined, Promise: Promise,
+    _ops: ops, _opsPlanned: null, _projectStart: base, _projectEnd: base + 2480 * DAY,
+    _cursor: base, console: { log: function () {} },
+  };
+  vm.runInNewContext(logic +
+    '\n; _twin = { building:"Hospital", projectId:' + projId + ', planned:' + storedPlanned + ', committed:' + storedCommitted +
+    ', phases:' + JSON.stringify(phaseRows) + ' };' +
+    '\n; globalThis.__V = _computeVariance();', sandbox);
+  return sandbox.__V;
+}
+const V = run();
+console.log('§TM_VARIANCE source=twin plannedCost=' + V.tP + ' committedCost=' + V.tA + ' over=' + V.pctOver + '% phases=' + V.phases.length + '\n');
 
-const DAY = 86400000;
-const base = new Date('2026-06-13T00:00:00Z').getTime();
-// synthetic PLANNED ops — Hospital-like 6 phases, Superstructure the largest (many steel ops)
-const PH = [
-  ['Substructure', 'CONCRETE_GANG', 0, 90, 60],
-  ['Superstructure', 'STEEL_ERECTOR', 90, 1100, 800],   // the big one
-  ['MEP Rough-in', 'MEP_CREW', 1100, 1900, 300],
-  ['Architecture', 'FINISHING_CREW', 1900, 2300, 250],
-  ['MEP Final', 'MEP_CREW', 2300, 2420, 80],
-  ['Finishes', 'FINISHING_CREW', 2420, 2480, 120],
-];
-const ops = [];
-PH.forEach(function (p) {
-  var name = p[0], res = p[1], d0 = p[2], d1 = p[3], cnt = p[4];
-  for (var i = 0; i < cnt; i++) {
-    var s = base + (d0 + (d1 - d0) * (i / cnt)) * DAY;
-    ops.push({ start_ts: s, end_ts: s + 10 * DAY, op_type: 'ELEMENT_PLACE', parameters: { phase: name, resource: res, storey: 'L' + (i % 4) } });
-  }
-});
+// ── W-PC-TWIN-SOURCE — the FALSIFIER: drawer numbers == stored records EXACTLY (not correlated) ──
+assert(V.tA === storedCommitted, 'W-PC-TWIN-SOURCE: total == C_Project.CommittedAmt EXACTLY (' + V.tA + ' == ' + storedCommitted + ')');
+assert(V.tP === storedPlanned, 'total planned == C_Project.PlannedAmt EXACTLY (' + V.tP + ' == ' + storedPlanned + ')');
+const sumA = phaseRows.reduce(function (s, p) { return s + p.committed; }, 0);
+assert(sumA === storedCommitted, 'Σ phase CommittedAmt rolls up to project total (' + sumA + ')');
+assert(V.phases.every(function (p) {
+  const tp = phaseRows.find(function (x) { return x.name === p.phase; });
+  return tp && p.aCost === tp.committed && p.pCost === tp.planned;
+}), 'every phase shows its STORED committed/planned (no recompute)');
 
-const sandbox = {
-  window: { LABOR_RATES: ratesSandbox.LABOR_RATES || {} },
-  _ops: ops, _opsPlanned: null, _projectStart: base, _projectEnd: base + 2480 * DAY,
-  console: console,
-};
-vm.runInNewContext(logic + '\n; globalThis.__V = _computeVariance(); globalThis.__buildActual = _buildActualOps;', sandbox);
-const V = sandbox.__V;
-const actual = sandbox.__buildActual();
+// honest, realistic mixed signs — this is records, not a fabricated always-over drama
+const sup = V.phases.find(function (p) { return p.phase === 'Superstructure'; });
+assert(sup && sup.marquee === true && sup.dCost > 0, 'Superstructure is the marquee blow-out (+' + sup.pct + '%, +' + sup.dCost + ')');
+const mep = V.phases.find(function (p) { return p.phase === 'MEP Rough-in'; });
+const fin = V.phases.find(function (p) { return p.phase === 'Finishes'; });
+assert(mep && mep.dCost < 0, 'MEP Rough-in is UNDER budget — honest mixed sign (' + mep.pct + '%)');
+assert(fin && fin.dCost < 0, 'Finishes is UNDER budget — honest mixed sign (' + fin.pct + '%)');
+assert(!V.phases.every(function (p) { return p.dCost > 0; }), 'NOT every phase over — proves these are records, not a hash variant');
 
-console.log('\n§TM_VARIANCE plannedCost=' + V.tP + ' actualCost=' + V.tA + ' over=' + V.pctOver + '% lateDays=' + V.lateDays + ' phases=' + V.phases.length + '\n');
+// determinism — same input → identical output
+const V2 = run();
+assert(V2.tA === V.tA && V2.tP === V.tP && V2.phases.length === V.phases.length, 'DETERMINISTIC — identical across runs');
 
-assert(V.phases.length === 6, 'all 6 phases aggregated (' + V.phases.length + ')');
-assert(V.tA > V.tP && V.pctOver > 0, 'OVER budget — drama (' + V.pctOver + '% over, +' + (V.tA - V.tP) + ')');
-assert(V.lateDays > 0, 'finish runs LATE (' + V.lateDays + ' days)');
-var sup = V.phases.find(function (p) { return p.phase === 'Superstructure'; });
-assert(sup && sup.marquee === true, 'Superstructure flagged marquee');
-var biggest = V.phases.slice().sort(function (x, y) { return y.dCost - x.dCost; })[0];
-assert(biggest.phase === 'Superstructure', 'Superstructure is the biggest cost blow-out (+' + biggest.dCost + ')');
-assert(V.phases.every(function (p) { return p.aStart >= p.pStart && p.aEnd >= p.pEnd; }), 'every phase actual ≥ planned (late, never early)');
+// ── W-PC-DRAWER — the cursor-tracking data: every phase has a usable window; cursor maps to its phase ──
+assert(V.phases.every(function (p) { return isFinite(p.winStart) && isFinite(p.winEnd) && p.winStart <= p.winEnd; }), 'W-PC-DRAWER: every phase carries a finite gantt window (winStart ≤ winEnd)');
+function phaseAt(cursor) { for (let i = 0; i < V.phases.length; i++) { const p = V.phases[i]; if (cursor >= p.winStart && cursor <= p.winEnd) return p.phase; } return null; }
+const midSup = (sup.winStart + sup.winEnd) / 2;
+assert(phaseAt(midSup) === 'Superstructure', 'cursor inside Superstructure window resolves to Superstructure (phase-under-cursor)');
+assert(phaseAt(fin.winStart) === 'Finishes', 'tap-to-jump target (winStart) lands inside its own phase');
+assert(V.phases.every(function (p) { return phaseAt(p.winStart) === p.phase; }), 'every phase winStart maps back to that phase (reciprocal tap)');
 
-// determinism — recompute and compare
-const s2 = { window: sandbox.window, _ops: ops, _opsPlanned: null, _projectStart: base, _projectEnd: base + 2480 * DAY, console: { log: function () {} } };
-vm.runInNewContext(logic + '\n; globalThis.__V2 = _computeVariance();', s2);
-assert(s2.__V2.tA === V.tA && s2.__V2.tP === V.tP && s2.__V2.lateDays === V.lateDays, 'DETERMINISTIC — identical across runs');
+console.log('\nphase breakdown (from records):');
+V.phases.forEach(function (p) { console.log('  ' + (p.marquee ? '⚠ ' : '  ') + p.phase.padEnd(15) + ' planned=' + p.pCost + ' committed=' + p.aCost + '  Δ=' + (p.dCost >= 0 ? '+' : '') + p.dCost + ' (' + (p.pct >= 0 ? '+' : '') + p.pct + '%)'); });
 
-// _buildActualOps shifts every op later, preserves count
-assert(actual.length === ops.length, '_buildActualOps preserves op count (' + actual.length + ')');
-assert(actual.every(function (o, i) { return o.start_ts > ops[i].start_ts && o.end_ts > ops[i].end_ts; }), '_buildActualOps shifts every op later');
-
-console.log('\nphase breakdown:');
-V.phases.forEach(function (p) { console.log('  ' + (p.marquee ? '⚠ ' : '  ') + p.phase.padEnd(15) + ' Δ' + p.dDays + 'd  Δcost=' + p.dCost); });
-
-console.log('\nW-TM-VARIANCE ' + pass + '/' + (pass + fail));
+console.log('\nW-PC-TWIN-SOURCE + W-PC-DRAWER ' + pass + '/' + (pass + fail));
 fs.writeFileSync(path.join(__dirname, 'test_tm_variance.log'),
-  '§TM_VARIANCE plannedCost=' + V.tP + ' actualCost=' + V.tA + ' over=' + V.pctOver + '% lateDays=' + V.lateDays + '\nW-TM-VARIANCE ' + pass + '/' + (pass + fail) + '\n');
+  '§TM_VARIANCE source=twin plannedCost=' + V.tP + ' committedCost=' + V.tA + ' over=' + V.pctOver + '%\n' +
+  'W-PC-TWIN-SOURCE + W-PC-DRAWER ' + pass + '/' + (pass + fail) + '\n');
 process.exit(fail === 0 ? 0 : 1);

--- a/tests/test_zoom_cost_panel.js
+++ b/tests/test_zoom_cost_panel.js
@@ -1,0 +1,84 @@
+/**
+ * test_zoom_cost_panel.js — W-PC-PANEL + W-PC-JUNCTURE + W-PC-HONEST (TM_4D5D_VARIANCE_LANE §S2).
+ *
+ * ISSUE PROVEN: the viewer's Zoom-Across IFC cost panel (#info-cost) must FOLD the twin's stored pair for a
+ *   selected IFC class — line PlannedAmt (line grain) + COMMITTED from its phase (c_projectphase_id →
+ *   C_ProjectPhase.CommittedAmt; line CommittedAmt is null on disk BY DESIGN) + the whole-project pair — and
+ *   never recompute. And it must be honest: cost is "from records", and the juncture jump targets a REAL phase
+ *   TM can land on. Reads the real seed via sqlite3 (dependency-free) + greps the source for the read path.
+ *
+ * Whitebox (§-log first). Run: node tests/test_zoom_cost_panel.js
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { execSync } = require('child_process');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  🟢 ' + msg); } else { fail++; console.log('  🔴 FAIL: ' + msg); } }
+
+const ERP = path.join(__dirname, '..', 'erp', 'ad_seed.db');
+function q(sql) { return execSync('sqlite3 -separator "|" "' + ERP + '" ' + JSON.stringify(sql), { encoding: 'utf8' }).trim(); }
+
+// the fold the panel does, replicated against the real seed (same SQL as navigate_find._foldClassTwin)
+function foldClassTwin(ifcClass) {
+  const proj = q("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value='Hospital'").split('|');
+  const pid = Number(proj[0]);
+  const ln = q("SELECT pl.PlannedAmt, pl.c_projectphase_id FROM C_ProjectLine pl JOIN M_Product p ON pl.M_Product_ID=p.M_Product_ID WHERE pl.C_Project_ID=" + pid + " AND p.Value='" + ifcClass + "'");
+  if (!ln) return { project: { planned: Number(proj[1]), committed: Number(proj[2]) }, line: null, phase: null };
+  const lc = ln.split('|');
+  const ph = q("SELECT Name,PlannedAmt,CommittedAmt,StartDate FROM C_ProjectPhase WHERE C_ProjectPhase_ID=" + Number(lc[1])).split('|');
+  return {
+    project: { planned: Number(proj[1]), committed: Number(proj[2]) },
+    line: { planned: Number(lc[0]), phaseId: Number(lc[1]) },
+    phase: { name: ph[0], planned: Number(ph[1]), committed: Number(ph[2]), start: ph[3] },
+  };
+}
+const pct = (p, c) => p > 0 ? Math.round((c - p) * 100 / p) : 0;
+
+// canonical TM phase tokens (the cursor axis) — the juncture target must be one of these
+const rs = {}; vm.runInNewContext(fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8'), rs);
+const PHASES = {}; Object.keys(rs.SEQUENCE_RULES || {}).forEach(k => { PHASES[rs.SEQUENCE_RULES[k].phase] = 1; });
+
+console.log('\n§ZOOM-COST-TEST canonical phases: ' + Object.keys(PHASES).join(', '));
+
+// ── W-PC-PANEL — the fold == stored records, marquee +60% ──
+const beam = foldClassTwin('IfcBeam');     // Superstructure — the marquee
+console.log('§ZOOM-COST IfcBeam linePlanned=' + beam.line.planned + ' phase="' + beam.phase.name + '" phasePair=' + beam.phase.planned + '→' + beam.phase.committed + ' (' + pct(beam.phase.planned, beam.phase.committed) + '%)');
+const beamLineStored = Number(q("SELECT pl.PlannedAmt FROM C_ProjectLine pl JOIN M_Product p ON pl.M_Product_ID=p.M_Product_ID WHERE pl.C_Project_ID=990000 AND p.Value='IfcBeam'"));
+assert(beam.line.planned === beamLineStored, 'W-PC-PANEL: IfcBeam line PlannedAmt == stored C_ProjectLine (' + beam.line.planned + ')');
+assert(beam.phase.name === 'Superstructure', 'IfcBeam folds to its real phase (Superstructure)');
+const supStored = q("SELECT PlannedAmt,CommittedAmt FROM C_ProjectPhase WHERE C_Project_ID=990000 AND Name='Superstructure'").split('|');
+assert(beam.phase.planned === Number(supStored[0]) && beam.phase.committed === Number(supStored[1]), 'phase pair == stored C_ProjectPhase (' + beam.phase.planned + '→' + beam.phase.committed + ')');
+assert(pct(beam.phase.planned, beam.phase.committed) === 60, 'marquee blow-out is +60% (' + pct(beam.phase.planned, beam.phase.committed) + '%)');
+assert(beam.project.planned === 64719479 && beam.project.committed === 87372995, 'project header pair == stored C_Project (64.7M→87.4M, +' + pct(beam.project.planned, beam.project.committed) + '%)');
+
+// honest mixed sign — an under-budget class folds to a NEGATIVE phase variance
+const cov = foldClassTwin('IfcCovering');  // Finishes — under budget
+assert(cov.phase.name === 'Finishes' && pct(cov.phase.planned, cov.phase.committed) < 0, 'IfcCovering folds to Finishes UNDER budget (' + pct(cov.phase.planned, cov.phase.committed) + '%) — honest mixed sign');
+
+// ── W-PC-JUNCTURE — class→phase resolves to a phase TM can actually land on (a real cursor-axis token) ──
+['IfcBeam', 'IfcCovering', 'IfcDoor', 'IfcSlab', 'IfcColumn'].forEach(cls => {
+  const t = foldClassTwin(cls);
+  assert(t.phase && PHASES[t.phase.name], 'W-PC-JUNCTURE: ' + cls + ' → phase "' + (t.phase && t.phase.name) + '" is a real TM cursor-axis phase (jump lands)');
+});
+assert(/^\d{4}-\d\d-\d\d/.test(beam.phase.start), 'phase carries a REAL StartDate from records (' + beam.phase.start + ') — not fabricated');
+
+// ── W-PC-HONEST — the panel reads records + labels honestly; no invented line committed, no fabricated date ──
+const navSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'navigate_find.js'), 'utf8');
+const cut = navSrc.slice(navSrc.indexOf('function _foldClassTwin'), navSrc.indexOf('A._showClassCost'));
+assert(/from records/.test(cut), 'W-PC-HONEST: cost block is labelled "from records"');
+assert(/C_ProjectPhase\.CommittedAmt|c_projectphase_id/.test(cut), 'committed is folded from the phase grain (control-account), as documented');
+assert(!/line[^\n]*committed\s*=\s*[^=]/i.test(cut) && !/CommittedAmt\s*\*\s*/.test(cut), 'no invented/recomputed LINE committed (line CommittedAmt earns at S5)');
+assert(!/Date\.now|new Date\([^)]*slip|\+\s*slip|actualEnd|lateDays/.test(cut), 'no fabricated ACTUAL date in the panel (date stays planned baseline / projected)');
+
+// the line CommittedAmt really is null on disk (the design fact the panel relies on)
+const lineCommittedNulls = Number(q("SELECT COUNT(*) FROM C_ProjectLine WHERE C_Project_ID=990000 AND PlannedAmt>0 AND CommittedAmt IS NULL"));
+assert(lineCommittedNulls > 0, 'line CommittedAmt is NULL on disk by design (nulls=' + lineCommittedNulls + ') — panel folds from phase, not a baked line figure');
+
+console.log('\nW-PC-PANEL + W-PC-JUNCTURE + W-PC-HONEST ' + pass + '/' + (pass + fail));
+fs.writeFileSync(path.join(__dirname, 'test_zoom_cost_panel.log'),
+  '§ZOOM-COST IfcBeam phase=' + beam.phase.name + ' pair=' + beam.phase.planned + '→' + beam.phase.committed +
+  ' proj=' + beam.project.planned + '→' + beam.project.committed + '\n' +
+  'W-PC-PANEL + W-PC-JUNCTURE + W-PC-HONEST ' + pass + '/' + (pass + fail) + '\n');
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1030,6 +1030,67 @@
           .then(function () { return true; }).catch(function () { return false; });
       } catch (e) { return Promise.resolve(false); }
     }
+    // ── §S2 (TM_4D5D_VARIANCE_LANE) — Zoom-Across cost fold ─────────────────────────────────────────────────
+    // When the ERP "Zoom Across" pill lands the viewer on an IFC class, fold that class's STORED twin cost into
+    // the #info-panel: the line's PlannedAmt (line grain) + the COMMITTED from its phase (c_projectphase_id →
+    // C_ProjectPhase.CommittedAmt — line CommittedAmt is null on disk BY DESIGN, it earns at S5) + the whole
+    // project pair (header scope). READ-only off the same ../erp/ad_seed.db the push path loaded. NO recompute.
+    function _money(n) { n = Math.round(Number(n) || 0); var a = Math.abs(n), s = n < 0 ? '-' : '';
+      if (a >= 1e6) return s + 'RM' + (a / 1e6).toFixed(1) + 'M'; if (a >= 1e3) return s + 'RM' + Math.round(a / 1e3) + 'K'; return s + 'RM' + a; }
+    function _foldClassTwin(ifcClass) {
+      return _ensureErpDb().then(function (db) {
+        if (!db) return null;
+        var building = A.activeBuilding;
+        function ex(sql, p) { try { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values : null; } catch (e) { return null; } }
+        var pr = ex("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value=?", [building]);
+        if (!pr) return null;   // this building isn't a folded project → no cost fold
+        var pid = pr[0][0], proj = { planned: Number(pr[0][1] || 0), committed: Number(pr[0][2] || 0) };
+        var line = null, phase = null;
+        var ln = ex("SELECT pl.PlannedAmt, pl.c_projectphase_id FROM C_ProjectLine pl JOIN M_Product p ON pl.M_Product_ID=p.M_Product_ID WHERE pl.C_Project_ID=? AND p.Value=?", [pid, ifcClass]);
+        if (ln) {
+          line = { planned: Number(ln[0][0] || 0), phaseId: ln[0][1] };
+          var ph = ex("SELECT Name,PlannedAmt,CommittedAmt,StartDate FROM C_ProjectPhase WHERE C_ProjectPhase_ID=?", [ln[0][1]]);
+          if (ph) phase = { name: ph[0][0], planned: Number(ph[0][1] || 0), committed: Number(ph[0][2] || 0), start: ph[0][3] };
+        }
+        return { building: building, projectId: pid, ifcClass: ifcClass, project: proj, line: line, phase: phase };
+      }).catch(function (e) { console.log('§ZOOM-COST err=' + e.message); return null; });
+    }
+    function _pct(planned, committed) { return planned > 0 ? Math.round((committed - planned) * 100 / planned) : 0; }
+    function _showClassCost(ifcClass, matchCount) {
+      var box = document.getElementById('info-cost'); if (!box) return;
+      box.style.display = 'none';
+      _foldClassTwin(ifcClass).then(function (t) {
+        if (!t) { console.log('§ZOOM-COST skip — no twin for class="' + ifcClass + '"'); return; }
+        var pj = t.project, pjPct = _pct(pj.planned, pj.committed);
+        var html = '<div style="color:#4fc3f7;font-weight:bold;margin-bottom:3px">Cost variance <span style="font-size:9px;color:#888;font-weight:normal">· from records</span></div>';
+        if (t.phase) {   // the committed actual lives at phase/control-account grain
+          var phPct = _pct(t.phase.planned, t.phase.committed), over = t.phase.committed >= t.phase.planned;
+          html += '<div><span class="label">' + ifcClass + '</span>: <span class="value">' + _money(t.line ? t.line.planned : 0) + ' planned</span></div>';
+          html += '<div><span class="label">Phase ' + t.phase.name + '</span>: <span class="value">' + _money(t.phase.planned) + ' → ' + _money(t.phase.committed) +
+            ' <b style="color:' + (over ? '#ff6b6b' : '#26a69a') + '">(' + (phPct >= 0 ? '+' : '') + phPct + '%)</b></span></div>';
+        }
+        html += '<div><span class="label">Project ' + t.building + '</span>: <span class="value">' + _money(pj.planned) + ' → ' + _money(pj.committed) +
+          ' <b style="color:' + (pj.committed >= pj.planned ? '#ff6b6b' : '#26a69a') + '">(' + (pjPct >= 0 ? '+' : '') + pjPct + '%)</b></span></div>';
+        // "View at this moment" — jump TM to this class's phase window (scene partially-built there).
+        if (t.phase && typeof window.tmJumpToPhase === 'function') {
+          html += '<div style="margin-top:6px"><button id="info-cost-tm" style="background:#1565c0;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:11px;cursor:pointer">⏱ View at this moment</button></div>';
+        }
+        box.innerHTML = html;
+        box.style.display = 'block';
+        var ipnl = document.getElementById('info-panel'); if (ipnl) ipnl.style.display = 'block';
+        var jb = document.getElementById('info-cost-tm');
+        if (jb && t.phase) jb.addEventListener('click', function (e) {
+          e.stopPropagation();
+          console.log('§ZOOM-COST_JUMP class="' + ifcClass + '" phase="' + t.phase.name + '"');
+          window.tmJumpToPhase(t.phase.name);
+        });
+        console.log('§ZOOM-COST class="' + ifcClass + '" matches=' + (matchCount || 0) + ' linePlanned=' + (t.line ? t.line.planned : 'n/a') +
+          ' phase="' + (t.phase ? t.phase.name : '-') + '" phasePlanned=' + (t.phase ? t.phase.planned : '-') + ' phaseCommitted=' + (t.phase ? t.phase.committed : '-') +
+          ' projPlanned=' + pj.planned + ' projCommitted=' + pj.committed + ' projPct=' + pjPct + '%');
+      });
+    }
+    A._showClassCost = _showClassCost;   // exposed for applyFindScope + witnesses
+
     // BIM→Project: every › ERP push outcome gets audio + a clear status (user: "good practice — a status
     // message, with audio feedback; happy audio when it succeeds"). Reuses the SFX engine (window.__sfx,
     // rows in sfx.json — NOT hardcoded synth, the wh_walk/PRE-PINNED-FACT idiom). Silent if audio is off.
@@ -3362,6 +3423,8 @@
       var set = new Set((nav.results || []).map(function (r) { return r.guid; }).filter(Boolean));
       if (set.size) A.focusElement(set, { item: false });
       console.log('§ZOOM-SCOPE kind=class scope="' + scope + '" matches=' + set.size);
+      // §S2 — fold this class's twin cost into the #info-panel (Planned→Committed pair, from records).
+      try { _showClassCost(scope, set.size); } catch (e) { console.log('§ZOOM-COST wire_err=' + e.message); }
       return set.size;
     };
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v675';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v676';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v674';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v675';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v673';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v674';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1763,7 +1763,7 @@
         '<button id="tm-eye" style="padding:2px 6px;min-width:36px;min-height:36px;background:#888" title="Drone Pilot — cinematic camera"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2"/><circle cx="12" cy="12" r="3"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M12 2v4"/><path d="M12 18v4"/></svg></button>' +
         '<button id="tm-gantt" style="font-size:12px;padding:2px 6px" title="Gantt chart">&#x1F4CA;</button>' +
         '<button id="tm-dash" style="font-size:12px;padding:2px 6px" title="Dashboard">&#x1F4CB;</button>' +
-        '<button id="tm-var" style="font-size:13px;padding:2px 6px" title="Budget vs Actual variance">&#x2696;</button>' +
+        '<button id="tm-var" style="font-size:13px;padding:2px 6px;display:none" title="Budget vs Actual variance">&#x2696;</button>' +
         '<span id="tm-big-counter" style="flex:1;font-size:18px;font-weight:bold;color:#4fc3f7;text-align:center;letter-spacing:1px">DAY 0 | HR 0</span>' +
         '<button id="tm-close" style="width:22px;height:22px;font-size:12px;padding:0;line-height:1" title="Close">&#x2715;</button>' +
       '</div>' +
@@ -2636,10 +2636,11 @@
   // Load the folded ERP twin once: fetch the seed db → sql.js → read the C_Project cost pair + its phases.
   // Same lazy-fetch idiom as navigate_find._ensureErpDb; read-only (db.close after extracting the figures).
   function _loadTwin() {
-    if (_twin || _twinLoading) return Promise.resolve(_twin);
     var app = A();
-    var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
     var building = (app && app.activeBuilding) || 'Hospital';
+    if (_twin && _twin.building === building) return Promise.resolve(_twin);   // cached for THIS building
+    if (_twinLoading) return Promise.resolve(null);                            // a load is in flight; caller retries
+    var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
     if (!SQL) { console.log('§TM_TWIN_DEFER no sql.js factory'); return Promise.resolve(null); }
     _twinLoading = true;
     return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
@@ -3408,6 +3409,13 @@
     updateStatus();
     if (_ganttVisible) drawGanttMini();
     if (_dashVisible) drawDashboard();
+    // §S2 — the ⚖ variance drawer only offers itself when this building HAS a folded twin (a C_Project with the
+    // PlannedAmt↔CommittedAmt pair). No twin → no button, no drawer (user: "don't trigger it when no such info").
+    _loadTwin().then(function (t) {
+      var vb = document.getElementById('tm-var');
+      if (vb) vb.style.display = t ? '' : 'none';
+      console.log('§TM_VAR_GATE building="' + ((app && app.activeBuilding) || '?') + '" twin=' + (t ? 'yes' : 'no') + ' ⚖=' + (t ? 'shown' : 'hidden'));
+    });
     console.log('§TIME_MACHINE ON — ' + _ops.length + ' ops, ' + _days.length + ' days, ' +
       'project: ' + new Date(_projectStart).toLocaleDateString() + ' → ' + new Date(_projectEnd).toLocaleDateString());
   }
@@ -3505,6 +3513,42 @@
   }
 
   window.toggleTimeMachine = toggle;
+
+  // §S2 (TM_4D5D_VARIANCE_LANE) — juncture jump: land the cursor at the START of a named phase's window so the
+  // scene is rendered PARTIALLY-BUILT at that moment (the IFC cost panel's "View at this moment"). The phase
+  // window comes from TM's own _ops (same axis the cursor scrubs). Opens the ⚖ drawer so the cost story shows.
+  // Activates TM first if needed (async). Returns a Promise<bool> (true = landed in the phase window).
+  window.tmJumpToPhase = function (phaseName) {
+    phaseName = String(phaseName || '');
+    function doJump() {
+      if (!_ops.length) { console.log('§TM_JUNCTURE skip=no-ops phase="' + phaseName + '"'); return false; }
+      var s = Infinity, e = -Infinity;
+      for (var i = 0; i < _ops.length; i++) {
+        var ph = (_ops[i].parameters || {}).phase || 'Architecture';
+        if (ph === phaseName) { if (_ops[i].start_ts < s) s = _ops[i].start_ts; if (_ops[i].end_ts > e) e = _ops[i].end_ts; }
+      }
+      if (!isFinite(s)) { console.log('§TM_JUNCTURE miss phase="' + phaseName + '" (no ops in that phase)'); return false; }
+      _cursor = s;
+      renderAtTime(_cursor);
+      try { anchorFromCursor(); } catch (x) {}
+      try { configSlider(); } catch (x) {}
+      // surface the cost story: open the ⚖ variance drawer (reads the twin) if it isn't already open — ONLY when
+      // this building actually has a twin (no twin → no drawer; the ⚖ button is hidden anyway).
+      if (_twin && !_varVisible) {
+        _varVisible = true;
+        var vbtn = document.getElementById('tm-var'); if (vbtn) vbtn.classList.add('tm-active');
+        var vbox = document.getElementById('tm-var-box'); if (vbox) vbox.classList.add('open');
+        drawVariance();
+      }
+      var pct = Math.round((_cursor - _projectStart) / Math.max(1, _projectEnd - _projectStart) * 100);
+      console.log('§TM_JUNCTURE phase="' + phaseName + '" cursor=' + Math.round(_cursor) +
+        ' winStart=' + new Date(s).toISOString().slice(0, 10) + ' built~' + pct + '% (partially built)');
+      return true;
+    }
+    if (_active) return Promise.resolve(doJump());
+    var p = activate();
+    return (p && p.then) ? p.then(function () { return doJump(); }) : Promise.resolve(doJump());
+  };
 
   // S265 Phase 3: Expose TM state for share URL
   window.tmGetState = function() {

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1212,6 +1212,81 @@
     // Force immediate render — mobile browsers defer rAF until touch
     if (app.renderer && app.scene && app.camera) app.renderer.render(app.scene, app.camera);
     updateStatus();
+    _broadcastTimeline();   // §S3 — realtime cross-tab scrub + pinpoint the item the data is addressing
+  }
+
+  // ── §S3 (TM_4D5D_VARIANCE_LANE) — realtime cross-tab timeline broadcast + scene pinpoint ──
+  // The 4D ALREADY EXISTS (injectGantt). This stage does NOT regenerate it — it BROADCASTS the scrub over the
+  // shared Connect bus (same channel the modeller speaks) so sibling tabs/surfaces follow in lockstep, and it
+  // PINPOINTS the element(s) the cursor is addressing at this instant (the frontier) — publishing them as a
+  // selection (so an ERP tab lights the matching record) + a HUD callout that singles them out.
+  var _applyingRemoteScrub = false;   // echo guard: don't re-publish a scrub we're applying from another surface
+  var _lastTLms = 0;                   // throttle wall-clock (runtime only; never used by witnesses)
+  // PURE: the guids "addressed by the data" at cursorMs = ops whose window straddles the cursor (being built now).
+  // Falls back to the most-recently-finished op when nothing is mid-flight, so a parked cursor still pinpoints.
+  function _frontierAt(cursorMs) {
+    var live = [], lastDone = null;
+    for (var i = 0; i < _ops.length; i++) {
+      var op = _ops[i];
+      if (op.start_ts > cursorMs) continue;
+      var guid = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+      if (!guid) continue;
+      if (op.end_ts > cursorMs) live.push({ guid: guid, phase: (op.parameters || {}).phase || 'Architecture' });
+      else if (!lastDone || op.end_ts > lastDone.end) lastDone = { guid: guid, phase: (op.parameters || {}).phase || 'Architecture', end: op.end_ts };
+    }
+    if (!live.length && lastDone) live.push({ guid: lastDone.guid, phase: lastDone.phase });
+    return live;
+  }
+  function _broadcastTimeline() {
+    var C = window.Connect;
+    if (!_ops.length) return;
+    var frontier = _frontierAt(_cursor);
+    var guids = frontier.map(function (f) { return f.guid; });
+    var lead = frontier.length ? frontier[0] : null;
+    // HUD callout — single out the item(s) the data is addressing at this moment (always, even off-bus)
+    _updatePinpoint(frontier);
+    if (!C || !C.on || _applyingRemoteScrub) return;     // off-bus or echoing a remote scrub → no publish
+    var now = (function () { try { return Date.now(); } catch (e) { return _lastTLms + 100; } })();
+    if (now - _lastTLms < 80) return;                    // throttle the fan-out during playback/drag
+    _lastTLms = now;
+    var app = A(), span = _projectEnd - _projectStart;
+    C.publish('timeline', { cursor: _cursor, frac: span > 0 ? (_cursor - _projectStart) / span : 0,
+      frontier: guids.slice(0, 40), lead: lead ? lead.guid : null, phase: lead ? lead.phase : null,
+      building: (app && app.activeBuilding) || null, surface: 'viewer' });
+    // pinpoint cross-surface: publish the lead addressed element as a selection (ERP/sibling lights its record)
+    if (lead) C.publish('selection', { guid: lead.guid, ifcClass: null, surface: 'viewer' });
+    console.log('§TM_BROADCAST cursor=' + Math.round(_cursor) + ' frontier=' + guids.length + ' lead=' + String(lead && lead.guid).slice(0, 10) + ' phase=' + (lead ? lead.phase : '-'));
+  }
+  // inbound scrub from a sibling viewer tab (same building) → move our cursor to match, echo-guarded.
+  function _applyRemoteTimeline(t) {
+    if (!t || t.surface !== 'viewer' || !_active || !_ops.length) return;
+    var app = A();
+    if (t.building && app && app.activeBuilding && t.building !== app.activeBuilding) return;  // different model
+    var span = _projectEnd - _projectStart;
+    var c = (typeof t.cursor === 'number') ? t.cursor : (typeof t.frac === 'number' ? _projectStart + t.frac * span : null);
+    if (c == null) return;
+    _applyingRemoteScrub = true;
+    try { _cursor = Math.max(_projectStart, Math.min(_projectEnd, c)); renderAtTime(_cursor); try { anchorFromCursor(); configSlider(); } catch (e) {} }
+    finally { _applyingRemoteScrub = false; }
+    console.log('§TM_TL_IN cursor=' + Math.round(_cursor) + ' from=' + (t.surface || '?'));
+  }
+  // HUD callout that names the addressed item(s) — created lazily, sits above the TM panel.
+  function _updatePinpoint(frontier) {
+    var el = document.getElementById('tm-pinpoint');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'tm-pinpoint';
+      el.style.cssText = 'position:fixed;left:50%;transform:translateX(-50%);bottom:128px;z-index:16;background:rgba(8,16,40,0.78);' +
+        'border:1px solid #4fc3f7;border-radius:14px;padding:4px 12px;font-size:12px;color:#e8f4ff;pointer-events:none;' +
+        'backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);white-space:nowrap;display:none';
+      document.body.appendChild(el);
+    }
+    if (!_active || !frontier || !frontier.length) { el.style.display = 'none'; return; }
+    var byPhase = {}; frontier.forEach(function (f) { byPhase[f.phase] = (byPhase[f.phase] || 0) + 1; });
+    var ph = Object.keys(byPhase).sort(function (a, b) { return byPhase[b] - byPhase[a]; })[0];
+    el.innerHTML = '<span style="color:#4fc3f7">⊕ Now building</span> · ' + frontier.length + ' item' +
+      (frontier.length > 1 ? 's' : '') + ' · <b>' + ph + '</b>';
+    el.style.display = 'block';
   }
 
   // ── §S260c: Outline effect — wireframe edge overlay on mesh ──
@@ -3449,6 +3524,7 @@
     if (ganttBox) ganttBox.classList.remove('open');
     // §TM-VARIANCE: reset the drawer state on deactivate (the twin cache is kept — it's read-only).
     _varVisible = false; _opsPlanned = null;
+    var pin = document.getElementById('tm-pinpoint'); if (pin) pin.style.display = 'none';   // §S3 — clear the pinpoint callout
     var varBtn = document.getElementById('tm-var'); if (varBtn) varBtn.classList.remove('tm-active');
     var varBox = document.getElementById('tm-var-box'); if (varBox) varBox.classList.remove('open');
     toggleDashDOM(false);
@@ -3480,6 +3556,8 @@
   // ── Init ──
   function init() {
     buildPanel();
+    // §S3 — listen for a sibling surface's scrub on the shared Connect bus (the modeller already speaks it).
+    try { if (window.Connect && window.Connect.subscribe) window.Connect.subscribe('timeline', _applyRemoteTimeline); } catch (e) {}
 
     // S265: TM button is now in icon pill — no longer injected into overflow
     // var toolbar = document.querySelector('#search-body > div');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -36,9 +36,7 @@
   // §TM-VARIANCE (GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL): planned = TM's own generated timeline; actual = a
   // deterministic over-run VARIANT computed live on it. No shipped schedule data — a variant ON what's there.
   var _varVisible = false;
-  var _opsPlanned = null;   // snapshot of the planned _ops (taken when variance first opens)
-  var _opsActual = null;    // the variant ops (built on demand for "Watch Actual")
-  var _watchActual = false; // when true, the SCENE animates the actual variant (the user's "animate the actual")
+  var _opsPlanned = null;   // snapshot of the planned _ops phase windows (taken when variance first opens)
   var _ganttTasks = [];  // computed task groups for click detection
   // T3 (4D_CAPTURE_AND_FALLBACK §3.1): native-4D coverage of the active schedule.
   var _capActive = false;   // true when the timeline used a captured IFC schedule
@@ -1208,6 +1206,7 @@
     applySunCycle(cursorMs);
     if (_ganttVisible) drawGanttMini();
     if (_dashVisible) drawDashboard();
+    if (_varVisible) drawVariance();   // §S1 — variance drawer tracks the scrub (hairline + phase-under-cursor)
 
     if (app.markDirty) app.markDirty();
     // Force immediate render — mobile browsers defer rAF until touch
@@ -2038,6 +2037,23 @@
       if (vbox) vbox.classList.toggle('open', _varVisible);
       if (_varVisible) drawVariance();
     });
+    // §S1 — tap a phase row in the variance drawer to jump the cursor to that phase's window (reciprocal of
+    // the hairline: the scrub moves the highlight, a tap moves the cursor). Maps click-Y → phase row.
+    document.getElementById('tm-var-canvas').addEventListener('pointerup', function (e) {
+      if (!_active || !_ops.length || !_twin) return;
+      var V = _computeVariance();
+      if (!V || !V.phases.length) return;
+      var rect = e.target.getBoundingClientRect();
+      var barH = 9, gap = 5, rowH = barH + gap;
+      var ti = Math.floor((e.clientY - rect.top - 4) / rowH);
+      if (ti < 0 || ti >= V.phases.length) return;
+      var p = V.phases[ti];
+      _cursor = p.winStart;
+      renderAtTime(_cursor);
+      anchorFromCursor();
+      configSlider();
+      console.log('§TM_VARIANCE_JUMP phase="' + p.phase + '" cursor=' + Math.round(_cursor) + ' committed=' + p.aCost);
+    });
     document.getElementById('tm-gantt-canvas').addEventListener('pointerup', function(e) {
       if (!_active || !_ops.length) return;
       var rect = e.target.getBoundingClientRect();
@@ -2607,122 +2623,124 @@
     'Finishes': '#26a69a'
   };
 
-  // ── §TM-VARIANCE — budget-vs-actual on TM's OWN timeline (GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL) ──
-  // Planned = the generated construction timeline TM already computes (_ops). Actual = a DETERMINISTIC
-  // over-run VARIANT (no random / no Date.now): per phase h=hash(name), start slips late + duration stretches
-  // + cost scales >1; Superstructure is the marquee blow-out. Same input → identical output, every run.
+  // ── §TM-VARIANCE — budget-vs-actual from the STORED twin (TM_4D5D_VARIANCE_LANE §S1) ──
+  // COST is READ, never recomputed: PlannedAmt → CommittedAmt straight off the iDempiere C_Project /
+  // C_ProjectPhase records baked into erp/ad_seed.db (erp/tests/bake_gw_hospital_variance.js). The drawer
+  // shows the SAME figure the ledger holds — §DOCTRINE 2/3 "variance = the PlannedAmt↔CommittedAmt pair,
+  // read the twin, don't recompute". Phase TIME windows come from TM's own injected gantt (_ops) so the
+  // cursor scrubs the same axis as the 3D scene. No LABOR_RATES×days, no hash variant — that only correlated.
   var _DAY_MS = 86400000;
   var _VAR_ORDER = ['Substructure', 'Superstructure', 'MEP Rough-in', 'Architecture', 'MEP Final', 'Finishes'];
-  function _strHash(s) { var h = 2166136261; s = String(s); for (var i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); } return h >>> 0; }
-  function _phaseVariant(name) {
-    var h = _strHash(name), marquee = /Superstructure/i.test(name);
-    return { slip: (h % 18) + (marquee ? 40 : 4),                 // start days late
-             stretch: (h % 26) + (marquee ? 130 : 10),            // extra duration days (finish even later)
-             factor: marquee ? 1.60 : (1.04 + ((h >> 8) % 36) / 100),  // cost ×; always over (1.04..1.40, marquee 1.60)
-             marquee: marquee };
-  }
-  function _opCost(op) {                                          // == drawDashboard cost basis (rate_per_day×crew×days)
-    var LR = window.LABOR_RATES || {};
-    var res = (op.parameters || {}).resource || '';
-    var lr = LR[res]; var daily = lr ? lr.rate_per_day * (lr.crew_size || 1) : 95;
-    var dur = Math.max(1, (op.end_ts || _projectEnd) - (op.start_ts || _projectStart)) / _DAY_MS;
-    return daily * dur;
+  var _twin = null;          // { building, projectId, planned, committed, phases:[{name,seqno,start,end,planned,committed}] }
+  var _twinLoading = false;
+  // Load the folded ERP twin once: fetch the seed db → sql.js → read the C_Project cost pair + its phases.
+  // Same lazy-fetch idiom as navigate_find._ensureErpDb; read-only (db.close after extracting the figures).
+  function _loadTwin() {
+    if (_twin || _twinLoading) return Promise.resolve(_twin);
+    var app = A();
+    var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
+    var building = (app && app.activeBuilding) || 'Hospital';
+    if (!SQL) { console.log('§TM_TWIN_DEFER no sql.js factory'); return Promise.resolve(null); }
+    _twinLoading = true;
+    return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+      var db = new SQL.Database(new Uint8Array(buf));
+      var pr = db.exec("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value=?", [building]);
+      if (!pr.length || !pr[0].values.length) { db.close(); _twinLoading = false; console.log('§TM_TWIN_MISS building="' + building + '" — not a folded project'); return null; }
+      var pid = pr[0].values[0][0], planned = Number(pr[0].values[0][1] || 0), committed = Number(pr[0].values[0][2] || 0);
+      var ph = db.exec("SELECT Name,SeqNo,StartDate,EndDate,PlannedAmt,CommittedAmt FROM C_ProjectPhase WHERE C_Project_ID=" + Number(pid) + " AND Name<>'Unsequenced' ORDER BY SeqNo");
+      var phases = (ph.length ? ph[0].values : []).map(function (row) {
+        return { name: row[0], seqno: Number(row[1] || 0), start: Date.parse(row[2]), end: Date.parse(row[3]),
+                 planned: Number(row[4] || 0), committed: Number(row[5] || 0) };
+      });
+      db.close();
+      _twin = { building: building, projectId: pid, planned: planned, committed: committed, phases: phases };
+      _twinLoading = false;
+      console.log('§TM_TWIN_LOADED building="' + building + '" planned=' + planned + ' committed=' + committed + ' phases=' + phases.length);
+      return _twin;
+    }).catch(function (e) { _twinLoading = false; console.log('§TM_TWIN_ERR ' + e.message); return null; });
   }
   function _money(n) { n = Math.round(n); var a = Math.abs(n), s = n < 0 ? '-' : '';
     if (a >= 1e6) return s + 'RM' + (a / 1e6).toFixed(1) + 'M'; if (a >= 1e3) return s + 'RM' + Math.round(a / 1e3) + 'K'; return s + 'RM' + a; }
-  // aggregate the planned ops into phases, then derive the actual variant per phase.
+  // Join the STORED twin cost (READ) to TM's gantt phase windows (the scrub axis). The cost numbers are the
+  // records verbatim — Σ phase PlannedAmt == C_Project.PlannedAmt and Σ CommittedAmt == C_Project.CommittedAmt
+  // (verified: 64,719,479 → 87,372,995). The _ops aggregation only supplies each phase's TIME window so the
+  // cursor + hairline land on the same axis as the 3D scene. Marquee = any phase ≥+50% over (Superstructure).
   function _computeVariance() {
-    var src = _opsPlanned || _ops, agg = {};
+    if (!_twin) return null;
+    var src = _opsPlanned || _ops, win = {};
     for (var i = 0; i < src.length; i++) {
       var op = src[i], ph = (op.parameters || {}).phase || 'Architecture';
-      if (!agg[ph]) agg[ph] = { phase: ph, pStart: op.start_ts, pEnd: op.end_ts, pCost: 0, count: 0 };
-      var a = agg[ph];
-      if (op.start_ts < a.pStart) a.pStart = op.start_ts;
-      if (op.end_ts > a.pEnd) a.pEnd = op.end_ts;
-      a.pCost += _opCost(op); a.count++;
+      if (!win[ph]) win[ph] = { start: op.start_ts, end: op.end_ts };
+      else { if (op.start_ts < win[ph].start) win[ph].start = op.start_ts; if (op.end_ts > win[ph].end) win[ph].end = op.end_ts; }
     }
-    var phases = Object.keys(agg).map(function (k) { return agg[k]; }).filter(function (p) { return p.count > 0; })
-      .sort(function (x, y) { var ix = _VAR_ORDER.indexOf(x.phase), iy = _VAR_ORDER.indexOf(y.phase); return (ix < 0 ? 99 : ix) - (iy < 0 ? 99 : iy); });
-    var tP = 0, tA = 0, t0 = Infinity, maxEnd = -Infinity;
-    phases.forEach(function (p) {
-      var v = _phaseVariant(p.phase);
-      p.aStart = p.pStart + v.slip * _DAY_MS;
-      p.aEnd = p.pEnd + (v.slip + v.stretch) * _DAY_MS;
-      p.aCost = Math.round(p.pCost * v.factor);
-      p.pCost = Math.round(p.pCost);
-      p.marquee = v.marquee;
-      p.dDays = Math.round((p.aEnd - p.pEnd) / _DAY_MS);
-      p.dCost = p.aCost - p.pCost;
-      tP += p.pCost; tA += p.aCost;
-      if (p.pStart < t0) t0 = p.pStart;
-      if (p.aEnd > maxEnd) maxEnd = p.aEnd;
-    });
-    return { phases: phases, tP: tP, tA: tA, dCost: tA - tP, pctOver: tP > 0 ? Math.round((tA - tP) / tP * 100) : 0,
-             t0: t0, plannedEnd: _projectEnd, actualEnd: maxEnd, lateDays: Math.round((maxEnd - _projectEnd) / _DAY_MS) };
-  }
-  // build the actual-variant ops (each planned op shifted by its phase's slip + stretch) for SCENE playback.
-  function _buildActualOps() {
-    var src = _opsPlanned || _ops;
-    return src.map(function (op) {
-      var v = _phaseVariant((op.parameters || {}).phase || 'Architecture');
-      var clone = {}; for (var k in op) clone[k] = op[k];
-      clone.start_ts = op.start_ts + v.slip * _DAY_MS;
-      clone.end_ts = op.end_ts + (v.slip + v.stretch) * _DAY_MS;
-      return clone;
-    });
+    var t0 = Infinity, t1 = -Infinity, pStart = Infinity, pEnd = -Infinity;
+    var phases = _twin.phases.map(function (tp) {
+      var w = win[tp.name], dCost = tp.committed - tp.planned;
+      var ws = w ? w.start : tp.start, we = w ? w.end : tp.end;
+      if (isFinite(ws) && ws < t0) t0 = ws;
+      if (isFinite(we) && we > t1) t1 = we;
+      if (isFinite(tp.start) && tp.start < pStart) pStart = tp.start;
+      if (isFinite(tp.end) && tp.end > pEnd) pEnd = tp.end;
+      return { phase: tp.name, pCost: tp.planned, aCost: tp.committed, dCost: dCost,
+               pct: tp.planned > 0 ? Math.round(dCost / tp.planned * 100) : 0,
+               winStart: ws, winEnd: we, startDate: tp.start, endDate: tp.end,
+               marquee: tp.planned > 0 && dCost / tp.planned >= 0.5 };
+    }).sort(function (x, y) { var ix = _VAR_ORDER.indexOf(x.phase), iy = _VAR_ORDER.indexOf(y.phase); return (ix < 0 ? 99 : ix) - (iy < 0 ? 99 : iy); });
+    if (!isFinite(t0)) { t0 = _projectStart; t1 = _projectEnd; }
+    return { phases: phases, tP: _twin.planned, tA: _twin.committed, dCost: _twin.committed - _twin.planned,
+             pctOver: _twin.planned > 0 ? Math.round((_twin.committed - _twin.planned) / _twin.planned * 100) : 0,
+             t0: t0, t1: t1, plannedStart: pStart, plannedEnd: pEnd };
   }
   function _recomputeBounds() {
     var s = Infinity, e = -Infinity;
     for (var i = 0; i < _ops.length; i++) { if (_ops[i].start_ts < s) s = _ops[i].start_ts; if (_ops[i].end_ts > e) e = _ops[i].end_ts; }
     if (isFinite(s)) { _projectStart = s; _projectEnd = e; }
   }
-  // toggle whether the 3D SCENE animates the actual variant (the user's "scene animating only the actual").
-  function _toggleWatchActual() {
-    _watchActual = !_watchActual;
-    if (_watchActual) { if (!_opsPlanned) _opsPlanned = _ops.slice(); _opsActual = _buildActualOps(); _ops = _opsActual; }
-    else if (_opsPlanned) { _ops = _opsPlanned; }
-    _recomputeBounds();
-    _cursor = _projectStart;
-    renderAtTime(_cursor); configSlider(); updateStatus();
-    if (_ganttVisible) drawGanttMini();
-    if (_dashVisible) drawDashboard();
-    drawVariance();
-    console.log('§TM_VARIANCE_WATCH actual=' + _watchActual + ' ops=' + _ops.length + ' end=' + new Date(_projectEnd).toISOString().slice(0, 10));
+  // map the scrub cursor to the phase whose gantt window contains it (for the hairline + row highlight).
+  function _varPhaseUnderCursor(V) {
+    if (!V) return -1;
+    for (var i = 0; i < V.phases.length; i++) { var p = V.phases[i]; if (_cursor >= p.winStart && _cursor <= p.winEnd) return i; }
+    return -1;
   }
   function drawVariance() {
     if (!_ops.length) return;
-    if (!_opsPlanned) _opsPlanned = _ops.slice();          // first open: snapshot the planned timeline
-    var V = _computeVariance();
-    var fmtD = function (ms) { return new Date(ms).toISOString().slice(0, 10); };
-
-    // header — the headline totals + a Watch-Actual toggle
+    if (!_opsPlanned) _opsPlanned = _ops.slice();          // first open: snapshot the planned timeline (phase windows)
     var head = document.getElementById('tm-var-head');
+    if (!_twin) {                                          // records not fetched yet → load, then redraw
+      if (head) head.innerHTML = '<b style="color:#4fc3f7">Budget vs Actual</b><div style="margin-top:2px;color:#888">Reading records…</div>';
+      _loadTwin().then(function (t) { if (t && _varVisible) drawVariance(); });
+      return;
+    }
+    var V = _computeVariance();
+    if (!V) { if (head) head.innerHTML = '<b style="color:#4fc3f7">Budget vs Actual</b><div style="margin-top:2px;color:#888">No project records for this model</div>'; return; }
+    var fmtD = function (ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '—'; };
+    var curIdx = _varPhaseUnderCursor(V);
+
+    // header — the headline COST pair (READ from the twin) + the planned schedule span. Honest labels:
+    // cost Δ is "from records"; the date span is the planned baseline (no actual-date column yet → §S3).
     if (head) {
       head.innerHTML =
         '<div style="display:flex;justify-content:space-between;align-items:center;gap:6px">' +
           '<b style="color:#4fc3f7">Budget vs Actual</b>' +
-          '<button id="tm-var-watch" class="' + (_watchActual ? 'tm-active' : '') + '" style="font-size:9px;padding:2px 6px">' +
-            (_watchActual ? '▶ Watching Actual' : '▶ Watch Actual') + '</button>' +
+          '<span style="font-size:9px;color:#888">from records · ' + _twin.building + '</span>' +
         '</div>' +
-        '<div style="margin-top:2px">Cost <b style="color:#9fd6ff">' + _money(V.tP) + '</b> → ' +
-          '<b style="color:#ff6b6b">' + _money(V.tA) + '</b> ' +
+        '<div style="margin-top:2px">Cost <b style="color:#9fd6ff" title="C_Project.PlannedAmt">' + _money(V.tP) + '</b> → ' +
+          '<b style="color:#ff6b6b" title="C_Project.CommittedAmt">' + _money(V.tA) + '</b> ' +
           '<span style="color:' + (V.dCost >= 0 ? '#ff6b6b' : '#26a69a') + '">(' + (V.dCost >= 0 ? '+' : '') + V.pctOver + '%, ' +
           (V.dCost >= 0 ? '+' : '') + _money(V.dCost) + ')</span></div>' +
-        '<div>Finish <span style="color:#9fd6ff">' + fmtD(V.plannedEnd) + '</span> → ' +
-          '<span style="color:#ff6b6b">' + fmtD(V.actualEnd) + '</span> ' +
-          '<b style="color:' + (V.lateDays >= 0 ? '#ff6b6b' : '#26a69a') + '">(' + (V.lateDays >= 0 ? '+' : '') + V.lateDays + 'd)</b></div>';
-      var wb = document.getElementById('tm-var-watch');
-      if (wb) wb.addEventListener('pointerup', function (e) { e.stopPropagation(); _toggleWatchActual(); });
+        '<div style="color:#9fd6ff">Schedule ' + fmtD(V.plannedStart) + ' → ' + fmtD(V.plannedEnd) +
+          ' <span style="color:#888">(planned baseline)</span></div>';
     }
 
-    // canvas — paired bars per phase on ONE timeline: planned (muted) over actual (vivid + red over-run tail)
+    // canvas — one bar per phase on the SAME axis the cursor scrubs; bar color = phase, edge cap red/green by
+    // COST over/under (from records). Phase under the cursor is outlined; a vertical hairline marks the cursor.
     var canvas = document.getElementById('tm-var-canvas');
     var box = document.getElementById('tm-var-box');
     if (canvas && box) {
       var phases = V.phases, n = phases.length;
-      var pairH = 7, gap = 2, rowH = pairH * 2 + gap + 6, marginL = 64;
-      var cW = box.clientWidth, cH = n * rowH + 6, barW = cW - marginL - 6;
-      var range = Math.max(1, V.actualEnd - V.t0);
+      var barH = 9, gap = 5, rowH = barH + gap, marginL = 64;
+      var cW = box.clientWidth, cH = n * rowH + 8, barW = cW - marginL - 6;
+      var range = Math.max(1, V.t1 - V.t0);
       canvas.width = cW * (window.devicePixelRatio || 1);
       canvas.height = cH * (window.devicePixelRatio || 1);
       canvas.style.height = cH + 'px';
@@ -2732,37 +2750,43 @@
       ctx.textBaseline = 'middle'; ctx.font = '9px sans-serif';
       for (var ti = 0; ti < n; ti++) {
         var p = phases[ti], color = PHASE_COLORS[p.phase] || '#888', y = ti * rowH + 4;
+        var over = p.dCost > 0;
         // label
-        ctx.fillStyle = p.marquee ? '#ff8c00' : '#bbb'; ctx.textAlign = 'right';
-        ctx.fillText((p.marquee ? '⚠ ' : '') + p.phase.substring(0, 11), marginL - 4, y + pairH);
-        // planned bar (muted)
-        var px = marginL + (p.pStart - V.t0) / range * barW, pw = Math.max(2, (p.pEnd - p.pStart) / range * barW);
-        ctx.globalAlpha = 0.30; ctx.fillStyle = color; ctx.fillRect(px, y, pw, pairH);
-        // actual bar (vivid) + red over-run tail beyond planned finish
-        var ax = marginL + (p.aStart - V.t0) / range * barW, aw = Math.max(2, (p.aEnd - p.aStart) / range * barW);
-        var ay = y + pairH + gap;
-        ctx.globalAlpha = 0.9; ctx.fillStyle = color; ctx.fillRect(ax, ay, aw, pairH);
-        var plannedEndX = marginL + (p.pEnd - V.t0) / range * barW;
-        if (p.aEnd > p.pEnd) { ctx.fillStyle = '#e53935'; var tx = Math.max(ax, plannedEndX); ctx.fillRect(tx, ay, (ax + aw) - tx, pairH); }
-        ctx.globalAlpha = 1;
+        ctx.fillStyle = (ti === curIdx) ? '#fff' : (p.marquee ? '#ff8c00' : '#bbb'); ctx.textAlign = 'right';
+        ctx.fillText((p.marquee ? '⚠ ' : '') + p.phase.substring(0, 11), marginL - 4, y + barH / 2);
+        // phase bar on the cursor axis
+        var px = marginL + (p.winStart - V.t0) / range * barW, pw = Math.max(3, (p.winEnd - p.winStart) / range * barW);
+        ctx.globalAlpha = (ti === curIdx) ? 1 : 0.78; ctx.fillStyle = color; ctx.fillRect(px, y, pw, barH);
+        // cost over/under cap on the trailing edge (red over, green under) — the variance signal
+        ctx.globalAlpha = 1; ctx.fillStyle = over ? '#e53935' : '#26a69a';
+        ctx.fillRect(px + pw - 3, y, 3, barH);
+        // row highlight outline for the phase under the cursor
+        if (ti === curIdx) { ctx.strokeStyle = '#fff'; ctx.lineWidth = 1; ctx.strokeRect(px - 0.5, y - 0.5, pw + 1, barH + 1); }
+      }
+      // cursor hairline
+      var hx = marginL + (_cursor - V.t0) / range * barW;
+      if (hx >= marginL && hx <= marginL + barW) {
+        ctx.strokeStyle = '#4fc3f7'; ctx.lineWidth = 1;
+        ctx.beginPath(); ctx.moveTo(hx, 0); ctx.lineTo(hx, cH); ctx.stroke();
       }
     }
 
-    // compact per-phase variance list
+    // compact per-phase variance list — committed vs planned, ΔCost from records.
     var list = document.getElementById('tm-var-list');
     if (list) {
       var html = '';
-      V.phases.forEach(function (p) {
-        var dc = (p.dCost >= 0 ? '+' : '') + _money(p.dCost), dd = (p.dDays >= 0 ? '+' : '') + p.dDays + 'd';
-        var col = (p.dCost > 0 || p.dDays > 0) ? '#ff6b6b' : '#26a69a';
-        html += '<div style="display:flex;justify-content:space-between;gap:6px">' +
+      V.phases.forEach(function (p, i) {
+        var dc = (p.dCost >= 0 ? '+' : '') + _money(p.dCost);
+        var col = p.dCost > 0 ? '#ff6b6b' : '#26a69a';
+        html += '<div style="display:flex;justify-content:space-between;gap:6px' + (i === curIdx ? ';color:#fff;font-weight:bold' : '') + '">' +
           '<span>' + (p.marquee ? '⚠ ' : '') + p.phase + '</span>' +
-          '<span style="color:' + col + '">' + dd + ' · ' + dc + '</span></div>';
+          '<span style="color:' + col + '">' + dc + ' (' + (p.pct >= 0 ? '+' : '') + p.pct + '%)</span></div>';
       });
       list.innerHTML = html;
     }
-    console.log('§TM_VARIANCE phases=' + V.phases.length + ' plannedCost=' + V.tP + ' actualCost=' + V.tA +
-      ' over=' + V.pctOver + '% lateDays=' + V.lateDays + ' watch=' + _watchActual);
+    console.log('§TM_VARIANCE source=twin building="' + _twin.building + '" phases=' + V.phases.length +
+      ' plannedCost=' + V.tP + ' committedCost=' + V.tA + ' over=' + V.pctOver + '% curPhase=' +
+      (curIdx >= 0 ? V.phases[curIdx].phase : '-'));
   }
 
   function drawGanttMini() {
@@ -3415,9 +3439,8 @@
     if (ganttBtn) ganttBtn.classList.remove('tm-active');
     var ganttBox = document.getElementById('tm-gantt-box');
     if (ganttBox) ganttBox.classList.remove('open');
-    // §TM-VARIANCE: restore the planned ops (undo any "Watch Actual" swap) + reset the drawer state.
-    if (_watchActual && _opsPlanned) { _ops = _opsPlanned; _recomputeBounds(); }
-    _watchActual = false; _varVisible = false; _opsPlanned = null; _opsActual = null;
+    // §TM-VARIANCE: reset the drawer state on deactivate (the twin cache is kept — it's read-only).
+    _varVisible = false; _opsPlanned = null;
     var varBtn = document.getElementById('tm-var'); if (varBtn) varBtn.classList.remove('tm-active');
     var varBox = document.getElementById('tm-var-box'); if (varBox) varBox.classList.remove('open');
     toggleDashDOM(false);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -33,6 +33,12 @@
   var _highlightMeshes = [];
   var _ganttVisible = false;
   var _dashVisible = false;
+  // §TM-VARIANCE (GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL): planned = TM's own generated timeline; actual = a
+  // deterministic over-run VARIANT computed live on it. No shipped schedule data — a variant ON what's there.
+  var _varVisible = false;
+  var _opsPlanned = null;   // snapshot of the planned _ops (taken when variance first opens)
+  var _opsActual = null;    // the variant ops (built on demand for "Watch Actual")
+  var _watchActual = false; // when true, the SCENE animates the actual variant (the user's "animate the actual")
   var _ganttTasks = [];  // computed task groups for click detection
   // T3 (4D_CAPTURE_AND_FALLBACK §3.1): native-4D coverage of the active schedule.
   var _capActive = false;   // true when the timeline used a captured IFC schedule
@@ -1758,6 +1764,7 @@
         '<button id="tm-eye" style="padding:2px 6px;min-width:36px;min-height:36px;background:#888" title="Drone Pilot — cinematic camera"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2"/><circle cx="12" cy="12" r="3"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M12 2v4"/><path d="M12 18v4"/></svg></button>' +
         '<button id="tm-gantt" style="font-size:12px;padding:2px 6px" title="Gantt chart">&#x1F4CA;</button>' +
         '<button id="tm-dash" style="font-size:12px;padding:2px 6px" title="Dashboard">&#x1F4CB;</button>' +
+        '<button id="tm-var" style="font-size:13px;padding:2px 6px" title="Budget vs Actual variance">&#x2696;</button>' +
         '<span id="tm-big-counter" style="flex:1;font-size:18px;font-weight:bold;color:#4fc3f7;text-align:center;letter-spacing:1px">DAY 0 | HR 0</span>' +
         '<button id="tm-close" style="width:22px;height:22px;font-size:12px;padding:0;line-height:1" title="Close">&#x2715;</button>' +
       '</div>' +
@@ -1791,6 +1798,11 @@
           '<div id="tm-gantt-hair" style="position:absolute;top:0;width:2px;height:100%;background:#ff8c00;pointer-events:none;z-index:1;display:none"></div>' +
           '<div id="tm-gantt-tip" style="position:absolute;top:4px;left:0;background:rgba(20,20,40,0.92);color:#ff8c00;font-size:10px;padding:3px 8px;border-radius:3px;border:1px solid rgba(255,140,0,0.3);pointer-events:none;z-index:2;display:none;white-space:nowrap;max-width:280px;overflow:hidden;text-overflow:ellipsis"></div>' +
         '</div>' +
+      '</div>' +
+      '<div id="tm-var-box" class="tm-drawer-bottom">' +
+        '<div id="tm-var-head" style="padding:4px 6px 2px;font-size:11px;color:#e0e0e0;line-height:1.5"></div>' +
+        '<canvas id="tm-var-canvas" style="width:100%;cursor:default"></canvas>' +
+        '<div id="tm-var-list" style="padding:2px 6px 4px;font-size:10px;color:#ccc"></div>' +
       '</div>' +
       '<div id="tm-dash-col" class="tm-drawer-right">' +
         '<div style="display:flex;gap:8px;justify-content:center;margin-bottom:8px">' +
@@ -2010,6 +2022,21 @@
       }
       toggleDashDOM(_dashVisible);
       if (_dashVisible) drawDashboard();
+    });
+    document.getElementById('tm-var').addEventListener('pointerup', function(e) {
+      e.stopPropagation();
+      _varVisible = !_varVisible;
+      // Mobile: only one bottom drawer at a time (mirror the gantt/dash rule)
+      if (_varVisible && window.innerWidth < 600 && _ganttVisible) {
+        _ganttVisible = false;
+        var gb2 = document.getElementById('tm-gantt-box'); if (gb2) gb2.classList.remove('open');
+        var gbt2 = document.getElementById('tm-gantt'); if (gbt2) gbt2.classList.remove('tm-active');
+      }
+      var vbtn = document.getElementById('tm-var');
+      if (vbtn) vbtn.classList.toggle('tm-active', _varVisible);
+      var vbox = document.getElementById('tm-var-box');
+      if (vbox) vbox.classList.toggle('open', _varVisible);
+      if (_varVisible) drawVariance();
     });
     document.getElementById('tm-gantt-canvas').addEventListener('pointerup', function(e) {
       if (!_active || !_ops.length) return;
@@ -2579,6 +2606,164 @@
     'MEP Final': '#ab47bc',
     'Finishes': '#26a69a'
   };
+
+  // ── §TM-VARIANCE — budget-vs-actual on TM's OWN timeline (GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL) ──
+  // Planned = the generated construction timeline TM already computes (_ops). Actual = a DETERMINISTIC
+  // over-run VARIANT (no random / no Date.now): per phase h=hash(name), start slips late + duration stretches
+  // + cost scales >1; Superstructure is the marquee blow-out. Same input → identical output, every run.
+  var _DAY_MS = 86400000;
+  var _VAR_ORDER = ['Substructure', 'Superstructure', 'MEP Rough-in', 'Architecture', 'MEP Final', 'Finishes'];
+  function _strHash(s) { var h = 2166136261; s = String(s); for (var i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); } return h >>> 0; }
+  function _phaseVariant(name) {
+    var h = _strHash(name), marquee = /Superstructure/i.test(name);
+    return { slip: (h % 18) + (marquee ? 40 : 4),                 // start days late
+             stretch: (h % 26) + (marquee ? 130 : 10),            // extra duration days (finish even later)
+             factor: marquee ? 1.60 : (1.04 + ((h >> 8) % 36) / 100),  // cost ×; always over (1.04..1.40, marquee 1.60)
+             marquee: marquee };
+  }
+  function _opCost(op) {                                          // == drawDashboard cost basis (rate_per_day×crew×days)
+    var LR = window.LABOR_RATES || {};
+    var res = (op.parameters || {}).resource || '';
+    var lr = LR[res]; var daily = lr ? lr.rate_per_day * (lr.crew_size || 1) : 95;
+    var dur = Math.max(1, (op.end_ts || _projectEnd) - (op.start_ts || _projectStart)) / _DAY_MS;
+    return daily * dur;
+  }
+  function _money(n) { n = Math.round(n); var a = Math.abs(n), s = n < 0 ? '-' : '';
+    if (a >= 1e6) return s + 'RM' + (a / 1e6).toFixed(1) + 'M'; if (a >= 1e3) return s + 'RM' + Math.round(a / 1e3) + 'K'; return s + 'RM' + a; }
+  // aggregate the planned ops into phases, then derive the actual variant per phase.
+  function _computeVariance() {
+    var src = _opsPlanned || _ops, agg = {};
+    for (var i = 0; i < src.length; i++) {
+      var op = src[i], ph = (op.parameters || {}).phase || 'Architecture';
+      if (!agg[ph]) agg[ph] = { phase: ph, pStart: op.start_ts, pEnd: op.end_ts, pCost: 0, count: 0 };
+      var a = agg[ph];
+      if (op.start_ts < a.pStart) a.pStart = op.start_ts;
+      if (op.end_ts > a.pEnd) a.pEnd = op.end_ts;
+      a.pCost += _opCost(op); a.count++;
+    }
+    var phases = Object.keys(agg).map(function (k) { return agg[k]; }).filter(function (p) { return p.count > 0; })
+      .sort(function (x, y) { var ix = _VAR_ORDER.indexOf(x.phase), iy = _VAR_ORDER.indexOf(y.phase); return (ix < 0 ? 99 : ix) - (iy < 0 ? 99 : iy); });
+    var tP = 0, tA = 0, t0 = Infinity, maxEnd = -Infinity;
+    phases.forEach(function (p) {
+      var v = _phaseVariant(p.phase);
+      p.aStart = p.pStart + v.slip * _DAY_MS;
+      p.aEnd = p.pEnd + (v.slip + v.stretch) * _DAY_MS;
+      p.aCost = Math.round(p.pCost * v.factor);
+      p.pCost = Math.round(p.pCost);
+      p.marquee = v.marquee;
+      p.dDays = Math.round((p.aEnd - p.pEnd) / _DAY_MS);
+      p.dCost = p.aCost - p.pCost;
+      tP += p.pCost; tA += p.aCost;
+      if (p.pStart < t0) t0 = p.pStart;
+      if (p.aEnd > maxEnd) maxEnd = p.aEnd;
+    });
+    return { phases: phases, tP: tP, tA: tA, dCost: tA - tP, pctOver: tP > 0 ? Math.round((tA - tP) / tP * 100) : 0,
+             t0: t0, plannedEnd: _projectEnd, actualEnd: maxEnd, lateDays: Math.round((maxEnd - _projectEnd) / _DAY_MS) };
+  }
+  // build the actual-variant ops (each planned op shifted by its phase's slip + stretch) for SCENE playback.
+  function _buildActualOps() {
+    var src = _opsPlanned || _ops;
+    return src.map(function (op) {
+      var v = _phaseVariant((op.parameters || {}).phase || 'Architecture');
+      var clone = {}; for (var k in op) clone[k] = op[k];
+      clone.start_ts = op.start_ts + v.slip * _DAY_MS;
+      clone.end_ts = op.end_ts + (v.slip + v.stretch) * _DAY_MS;
+      return clone;
+    });
+  }
+  function _recomputeBounds() {
+    var s = Infinity, e = -Infinity;
+    for (var i = 0; i < _ops.length; i++) { if (_ops[i].start_ts < s) s = _ops[i].start_ts; if (_ops[i].end_ts > e) e = _ops[i].end_ts; }
+    if (isFinite(s)) { _projectStart = s; _projectEnd = e; }
+  }
+  // toggle whether the 3D SCENE animates the actual variant (the user's "scene animating only the actual").
+  function _toggleWatchActual() {
+    _watchActual = !_watchActual;
+    if (_watchActual) { if (!_opsPlanned) _opsPlanned = _ops.slice(); _opsActual = _buildActualOps(); _ops = _opsActual; }
+    else if (_opsPlanned) { _ops = _opsPlanned; }
+    _recomputeBounds();
+    _cursor = _projectStart;
+    renderAtTime(_cursor); configSlider(); updateStatus();
+    if (_ganttVisible) drawGanttMini();
+    if (_dashVisible) drawDashboard();
+    drawVariance();
+    console.log('§TM_VARIANCE_WATCH actual=' + _watchActual + ' ops=' + _ops.length + ' end=' + new Date(_projectEnd).toISOString().slice(0, 10));
+  }
+  function drawVariance() {
+    if (!_ops.length) return;
+    if (!_opsPlanned) _opsPlanned = _ops.slice();          // first open: snapshot the planned timeline
+    var V = _computeVariance();
+    var fmtD = function (ms) { return new Date(ms).toISOString().slice(0, 10); };
+
+    // header — the headline totals + a Watch-Actual toggle
+    var head = document.getElementById('tm-var-head');
+    if (head) {
+      head.innerHTML =
+        '<div style="display:flex;justify-content:space-between;align-items:center;gap:6px">' +
+          '<b style="color:#4fc3f7">Budget vs Actual</b>' +
+          '<button id="tm-var-watch" class="' + (_watchActual ? 'tm-active' : '') + '" style="font-size:9px;padding:2px 6px">' +
+            (_watchActual ? '▶ Watching Actual' : '▶ Watch Actual') + '</button>' +
+        '</div>' +
+        '<div style="margin-top:2px">Cost <b style="color:#9fd6ff">' + _money(V.tP) + '</b> → ' +
+          '<b style="color:#ff6b6b">' + _money(V.tA) + '</b> ' +
+          '<span style="color:' + (V.dCost >= 0 ? '#ff6b6b' : '#26a69a') + '">(' + (V.dCost >= 0 ? '+' : '') + V.pctOver + '%, ' +
+          (V.dCost >= 0 ? '+' : '') + _money(V.dCost) + ')</span></div>' +
+        '<div>Finish <span style="color:#9fd6ff">' + fmtD(V.plannedEnd) + '</span> → ' +
+          '<span style="color:#ff6b6b">' + fmtD(V.actualEnd) + '</span> ' +
+          '<b style="color:' + (V.lateDays >= 0 ? '#ff6b6b' : '#26a69a') + '">(' + (V.lateDays >= 0 ? '+' : '') + V.lateDays + 'd)</b></div>';
+      var wb = document.getElementById('tm-var-watch');
+      if (wb) wb.addEventListener('pointerup', function (e) { e.stopPropagation(); _toggleWatchActual(); });
+    }
+
+    // canvas — paired bars per phase on ONE timeline: planned (muted) over actual (vivid + red over-run tail)
+    var canvas = document.getElementById('tm-var-canvas');
+    var box = document.getElementById('tm-var-box');
+    if (canvas && box) {
+      var phases = V.phases, n = phases.length;
+      var pairH = 7, gap = 2, rowH = pairH * 2 + gap + 6, marginL = 64;
+      var cW = box.clientWidth, cH = n * rowH + 6, barW = cW - marginL - 6;
+      var range = Math.max(1, V.actualEnd - V.t0);
+      canvas.width = cW * (window.devicePixelRatio || 1);
+      canvas.height = cH * (window.devicePixelRatio || 1);
+      canvas.style.height = cH + 'px';
+      var ctx = canvas.getContext('2d');
+      ctx.setTransform(window.devicePixelRatio || 1, 0, 0, window.devicePixelRatio || 1, 0, 0);
+      ctx.clearRect(0, 0, cW, cH);
+      ctx.textBaseline = 'middle'; ctx.font = '9px sans-serif';
+      for (var ti = 0; ti < n; ti++) {
+        var p = phases[ti], color = PHASE_COLORS[p.phase] || '#888', y = ti * rowH + 4;
+        // label
+        ctx.fillStyle = p.marquee ? '#ff8c00' : '#bbb'; ctx.textAlign = 'right';
+        ctx.fillText((p.marquee ? '⚠ ' : '') + p.phase.substring(0, 11), marginL - 4, y + pairH);
+        // planned bar (muted)
+        var px = marginL + (p.pStart - V.t0) / range * barW, pw = Math.max(2, (p.pEnd - p.pStart) / range * barW);
+        ctx.globalAlpha = 0.30; ctx.fillStyle = color; ctx.fillRect(px, y, pw, pairH);
+        // actual bar (vivid) + red over-run tail beyond planned finish
+        var ax = marginL + (p.aStart - V.t0) / range * barW, aw = Math.max(2, (p.aEnd - p.aStart) / range * barW);
+        var ay = y + pairH + gap;
+        ctx.globalAlpha = 0.9; ctx.fillStyle = color; ctx.fillRect(ax, ay, aw, pairH);
+        var plannedEndX = marginL + (p.pEnd - V.t0) / range * barW;
+        if (p.aEnd > p.pEnd) { ctx.fillStyle = '#e53935'; var tx = Math.max(ax, plannedEndX); ctx.fillRect(tx, ay, (ax + aw) - tx, pairH); }
+        ctx.globalAlpha = 1;
+      }
+    }
+
+    // compact per-phase variance list
+    var list = document.getElementById('tm-var-list');
+    if (list) {
+      var html = '';
+      V.phases.forEach(function (p) {
+        var dc = (p.dCost >= 0 ? '+' : '') + _money(p.dCost), dd = (p.dDays >= 0 ? '+' : '') + p.dDays + 'd';
+        var col = (p.dCost > 0 || p.dDays > 0) ? '#ff6b6b' : '#26a69a';
+        html += '<div style="display:flex;justify-content:space-between;gap:6px">' +
+          '<span>' + (p.marquee ? '⚠ ' : '') + p.phase + '</span>' +
+          '<span style="color:' + col + '">' + dd + ' · ' + dc + '</span></div>';
+      });
+      list.innerHTML = html;
+    }
+    console.log('§TM_VARIANCE phases=' + V.phases.length + ' plannedCost=' + V.tP + ' actualCost=' + V.tA +
+      ' over=' + V.pctOver + '% lateDays=' + V.lateDays + ' watch=' + _watchActual);
+  }
 
   function drawGanttMini() {
     if (!_ops.length) return;
@@ -3230,6 +3415,11 @@
     if (ganttBtn) ganttBtn.classList.remove('tm-active');
     var ganttBox = document.getElementById('tm-gantt-box');
     if (ganttBox) ganttBox.classList.remove('open');
+    // §TM-VARIANCE: restore the planned ops (undo any "Watch Actual" swap) + reset the drawer state.
+    if (_watchActual && _opsPlanned) { _ops = _opsPlanned; _recomputeBounds(); }
+    _watchActual = false; _varVisible = false; _opsPlanned = null; _opsActual = null;
+    var varBtn = document.getElementById('tm-var'); if (varBtn) varBtn.classList.remove('tm-active');
+    var varBox = document.getElementById('tm-var-box'); if (varBox) varBox.classList.remove('open');
     toggleDashDOM(false);
     _active = false;
     _panel.style.display = 'none';

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -477,6 +477,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
   <div><span class="label" data-trl="h_storey">Storey</span>: <span class="value" id="info-storey">—</span></div>
   <div><span class="label" data-trl="h_discipline">Discipline</span>: <span class="value" id="info-disc">—</span></div>
   <div><span class="label" data-trl="h_material">Material</span>: <span class="value" id="info-material">—</span></div>
+  <!-- §S2 (TM_4D5D_VARIANCE_LANE) — Zoom-Across cost fold: the twin's Planned→Committed pair for this IFC class
+       (line grain) + its phase + the whole project, READ from C_Project/C_ProjectLine/C_ProjectPhase. -->
+  <div id="info-cost" style="display:none;margin-top:8px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.12)"></div>
   <div id="snag-btn-row" style="margin-top:6px;display:none"><button onclick="openSiteCamera()" style="background:#f44336;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:12px;cursor:pointer">📸 <span data-trl="ui_snag">Snag</span></button></div>
 </div>
 <!-- S265 Phase 4: storey-panel and disc-panel moved inside #hud as accordion sections -->


### PR DESCRIPTION
**TM_4D5D_VARIANCE_LANE §S1 — make variance true.**

The WIP variance drawer (cherry-picked here onto fresh `main`) recomputed both sides at runtime — planned via `LABOR_RATES×days`, actual via a hash variant — so it only *correlated* with the iDempiere records. This makes it read the twin.

### What changed (`viewer/time_machine.js`)
- **`_loadTwin()`** — lazily fetches `../erp/ad_seed.db` → sql.js → `C_Project` / `C_ProjectPhase` `PlannedAmt`/`CommittedAmt` (same idiom as `navigate_find._ensureErpDb`; read-only, `db.close()` after).
- **`_computeVariance`** now joins the **stored cost (records verbatim)** to TM's gantt phase windows (the scrub axis). Deleted `_opCost` / `_phaseVariant` / `_buildActualOps` / `_toggleWatchActual` / `_watchActual`.
- **`renderAtTime`** redraws the drawer on every scrub: cursor **hairline** + **phase-under-cursor highlight**; **tap a phase row** → cursor jumps to that phase's window (reciprocal).
- **Honest labels** (iDempiere doctrine): cost is "from records"; schedule is the "planned baseline" (no actual-date column until §S3).

### Proof — `W-PC-TWIN-SOURCE` + `W-PC-DRAWER` 13/13 (`tests/test_tm_variance.js`)
Reads the **real seed** via `sqlite3` (dependency-free) and falsifies any drift:
- drawer total == `SELECT CommittedAmt FROM C_Project WHERE Value='Hospital'` **exactly** (87,372,995, to the rupiah)
- every phase shows its **stored** committed/planned (no recompute)
- honest mixed signs — Superstructure **+60%** marquee, MEP Rough-in **−3%**, Finishes **−11%** (NOT a fabricated always-over)
- phase-under-cursor + tap-to-jump map correctly

Note: populated-drawer Playwright shot deferred — Hospital geometry lives in browser OPFS (unreachable from disk) and the warehouse model is too heavy for headless swiftshader; whitebox §-log is the primary proof per project testing rule. Viewer sw `v673 → v674`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)