### PR TITLE
feat(modeller): auto-emit MEP on building-drop [W-ROUTEWALK-AUTODROP]

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -188,7 +188,7 @@
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
-<script src="routewalker.js?v=1" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
+<script src="routewalker.js?v=2" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
 
 <!-- Scene bootstrap: reuse the viewer's THREE stack (r184 webgpu build), expose global THREE + window.A. -->
 <script type="module">
@@ -1261,6 +1261,65 @@ function rotateInsert() {                                          // R key / Ro
 }
 // Drop a whole BOM assembly: expand its subtree to N leaf placements and commit one signed GEOM_INSERT per
 // leaf (the recursion + parent-relative transforms live in bonsai_library.expandAssembly). W-BOM-ASSEMBLY.
+// ── AUTO-EMIT MEP ON BUILDING DROP (W-ROUTEWALK-AUTODROP) ────────────────────────────────────────────
+// When a BUILDING / FLOOR assembly is dropped, its STRUCTURAL BOM carries no MEP (verified: BUILDING_DX_STD
+// = 1099 leaves, MEP=0). So RouteWalker routes the building's MEP from the real mep_rw.db anchors keyed to
+// that building (fuzzy-matched on the assembly name), then rwAlignSegments REGISTERS the anchor-space runs to
+// the just-placed building's WORLD bbox (1:1 m + the drop yaw). Each run commits as ONE signed GEOM_SWEEP —
+// the SAME bridge proven by W-ROUTEWALKER-MEP 8/8 + W-ROUTEWALK-MODELLER. Runs async (does NOT block the drop);
+// longest-runs-first, capped (occt pipe is costly) and §-logged honestly. No clash gate yet (follow-on).
+let _rwInitP = null;
+function _rwReadyOnce() {                                  // lazy one-shot rwInit(mep_rw.db) on the first building drop
+  if (!_rwInitP) _rwInitP = (async () => {
+    if (typeof rwInit !== 'function') return false;
+    const SQL = await window.initSqlJs({ locateFile: f => new URL('lib/' + f, location.href).href });
+    return rwInit(SQL, '');
+  })().catch(e => { console.warn('§MODELLER rwInit fail ' + e); return false; });
+  return _rwInitP;
+}
+// Resolve the dropped assembly → a mep_rw.db anchor building key. The catalog encodes the source building in
+// names/ids (per-building BOM doctrine: DX=Duplex, SH=SampleHouse, TE/LKTN=Terminal) — map those to the anchor
+// keys (rwFindAnchorKey then fuzzy-matches). Returns '' when no building is recognised (→ no MEP routed).
+function _rwBuildingHint(asm) {
+  const s = (((asm && asm.name) || '') + ' ' + ((asm && asm.id) || '')).toUpperCase();
+  if (/DUPLEX|\bDX\b|DX_|_DX_/.test(s)) return 'Duplex';
+  if (/SAMPLE\s*HOUSE|\bSH\b|SH_|_SH_/.test(s)) return 'SampleHouse';
+  if (/TERMINAL|\bTE\b|TE_|TBLKTN|LKTN/.test(s)) return 'Terminal';
+  return (asm && asm.name) || '';
+}
+async function autoRouteMEP(asm, leaves) {
+  const ready = await _rwReadyOnce();
+  if (!ready) return { found: 0, routed: 0 };
+  const name = _rwBuildingHint(asm);
+  const segs = name ? rwRouteSegments(null, name, { arcEnvelope: [] }) : [];   // anchor-space runs (no building DB)
+  if (!segs.length) { console.log('§MODELLER autoroute no-MEP building="' + name + '"'); return { found: 0, routed: 0 }; }
+  // world bbox of the just-placed structural leaves = the registration target
+  const bmin = [Infinity, Infinity, Infinity], bmax = [-Infinity, -Infinity, -Infinity];
+  leaves.forEach(l => { const p = [l.x, l.y, l.z]; for (let i = 0; i < 3; i++) { if (p[i] < bmin[i]) bmin[i] = p[i]; if (p[i] > bmax[i]) bmax[i] = p[i]; } });
+  const placedBBox = { min: bmin, max: bmax };
+  const aligned = rwAlignSegments(segs, placedBBox, { rotDeg: insRot || 0 });
+  // aligned bbox (over ALL runs, before the cap) — alignedMin == placedMin by construction (registration proof)
+  const amin = [Infinity, Infinity, Infinity], amax = [-Infinity, -Infinity, -Infinity];
+  aligned.forEach(s => [s.from, s.to].forEach(p => { for (let i = 0; i < 3; i++) { if (p[i] < amin[i]) amin[i] = p[i]; if (p[i] > amax[i]) amax[i] = p[i]; } }));
+  aligned.sort((a, b) => b.len - a.len);                          // longest mains first (most meaningful runs)
+  const MAX = (typeof window.__rwMaxRuns === 'number') ? window.__rwMaxRuns : 40;
+  const ops = rwSweepOps(aligned, { profileM: 0.05, limit: MAX });
+  console.log('§MODELLER autoroute building="' + name + '" found=' + segs.length + ' emitting=' + ops.length +
+    (ops.length < segs.length ? ' (capped of ' + segs.length + ', longest-first)' : ''));
+  let routed = 0;
+  for (const op of ops) {
+    try { const res = await window.Bonsai.oplog.commit(op, { color: 0x4fb0ff }); if (res && res.verify) routed++; }
+    catch (e) { console.warn('§MODELLER autoroute commit fail ' + (e && e.message || e)); }
+    setStat('routing MEP… ' + routed + '/' + ops.length);
+  }
+  await window.Bonsai.oplog.scrubTo(window.Bonsai.oplog.length);  // fold the new runs into the scene
+  if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+  syncHistory(); audioCue('commit');
+  setStat('routed ' + routed + ' MEP runs for ' + name + (ops.length < segs.length ? ' (' + segs.length + ' total)' : ''));
+  console.log('§MODELLER autoroute-done building="' + name + '" routed=' + routed + ' of ' + ops.length);
+  return { found: segs.length, routed: routed, emitted: ops.length,
+           placedMin: bmin.map(v => +v.toFixed(3)), alignedMin: amin.map(v => +v.toFixed(3)), alignedMax: amax.map(v => +v.toFixed(3)) };
+}
 async function placeAssembly(x, y) {
   const L = window.Bonsai.library, asm = L.assembly(insertHash);
   // CENTER-anchor the drop. expandAssembly seats children CORNER-anchored ([0..W]), but the ghost box (showGhost
@@ -1298,6 +1357,11 @@ async function placeAssembly(x, y) {
       else console.log('§MODELLER assembly-drop meshes-upgraded leaves=' + (needs.length - boxed) + '/' + needs.length);
     }).catch(() => { if (tries > 0) setTimeout(() => upgrade(tries - 1), 300); });
     upgrade(2);
+  }
+  // AUTO-EMIT MEP: a dropped BUILDING / FLOOR routes its MEP from real mep_rw.db anchors → signed GEOM_SWEEP runs,
+  // registered to this placed footprint. Async — does NOT block the drop. No-op for buildings with no MEP recipe.
+  if (asm && (asm.level === 'BUILDING' || asm.level === 'FLOOR')) {
+    window.__lastAutoRoute = autoRouteMEP(asm, leaves).catch(e => { console.warn('§MODELLER autoroute fail ' + e); return { found: 0, routed: 0 }; });
   }
   disarmPick();                                                  // detach the ghost from the pointer after the drop
   return { id: lastInsertId, count: placed.length };
@@ -1908,6 +1972,54 @@ if (qs.get('routewalk') === 'demo') {
     window.__routewalkResult = out;
     window.__routewalkDone = true;
     console.log('§MODELLER routewalk-done');
+  })();
+}
+// ?routewalk=drop proves AUTO-EMIT on building-drop (W-ROUTEWALK-AUTODROP): drop a real Duplex FLOOR (structural,
+// MEP=0) via the REAL placeAssembly path — the auto-route fires, routes the building's MEP from mep_rw.db anchors,
+// registers them to the placed footprint (rwAlignSegments), and commits each as a signed GEOM_SWEEP. Asserts: the
+// floor's structural leaves placed; auto-route found MEP + emitted a bounded set; every run signed + verifies;
+// every run lands INSIDE the placed building's world bbox (alignment); runs folded + under the Routes category.
+if (qs.get('routewalk') === 'drop') {
+  (async () => {
+    const out = {}; const L = window.Bonsai.library, O = window.Bonsai.oplog;
+    try {
+      await L.ready();
+      window.__rwMaxRuns = 8;                                     // bound the witness (occt pipe is costly)
+      const FLOOR = 'DX_FDN_STR';                                 // a real Duplex floor (structural, MEP=0), few leaves
+      insRot = 0; insElev = 0; inserting = true; insertHash = FLOOR; O.clear();
+      out.structuralLeaves = L.expandAssembly(FLOOR, { x: 6, y: 4, z: 0, rot: 0 }).length;
+      await placeAssembly(6, 4);                                  // REAL drop → triggers autoRouteMEP
+      out.structuralCommitted = O._geomOps().filter(o => o.op_type === 'GEOM_INSERT').length;
+      const ar = await (window.__lastAutoRoute || Promise.resolve({}));
+      out.found = ar.found; out.emitted = ar.emitted; out.routed = ar.routed;
+      const sweeps = O._geomOps().filter(o => o.op_type === 'GEOM_SWEEP');
+      out.sweepRows = sweeps.length;
+      // REGISTRATION: rwAlignSegments maps the anchor bbox-min → the placed footprint corner, so alignedMin must
+      // equal placedMin (the transform targeted THIS drop), and EVERY emitted run lies inside [alignedMin,Max].
+      // MEP fills the whole envelope, so it legitimately extends above a single floor — bbox-registration, not
+      // floor-containment, is the right invariant.
+      out.placedMin = ar.placedMin; out.alignedMin = ar.alignedMin; out.alignedMax = ar.alignedMax;
+      out.cornerRegistered = ar.placedMin && ar.alignedMin &&
+        Math.abs(ar.placedMin[0] - ar.alignedMin[0]) < 1e-3 && Math.abs(ar.placedMin[1] - ar.alignedMin[1]) < 1e-3 &&
+        Math.abs(ar.placedMin[2] - ar.alignedMin[2]) < 1e-3;
+      const T = 1e-3; let inside = 0, runLenSum = 0;
+      sweeps.forEach(o => { const pa = o.parameters.path;
+        const ok = pa.every(p => p[0] >= ar.alignedMin[0] - T && p[0] <= ar.alignedMax[0] + T &&
+          p[1] >= ar.alignedMin[1] - T && p[1] <= ar.alignedMax[1] + T &&
+          p[2] >= ar.alignedMin[2] - T && p[2] <= ar.alignedMax[2] + T);
+        if (ok) inside++;
+        runLenSum += Math.hypot(pa[1][0] - pa[0][0], pa[1][1] - pa[0][1], pa[1][2] - pa[0][2]); });
+      out.runsInBBox = inside; out.runLenSum = +runLenSum.toFixed(2);
+      out.signed = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verify = (await O.verify()).ok;
+      out.totalOps = O.length;
+      const g = window.Bonsai.group();
+      out.tris = g.children.filter(o => o.isMesh).reduce((n, m) => n + (m.geometry.index ? m.geometry.index.count / 3 : 0), 0);
+      out.routesCategory = Array.from(document.querySelectorAll('#bonsai-outliner [data-grp]')).some(d => d.getAttribute('data-grp') === 'routes');
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER routewalk drop fail ' + e); }
+    window.__routewalkDropResult = out;
+    window.__routewalkDropDone = true;
+    console.log('§MODELLER routewalk-drop-done');
   })();
 }
 // ?insert=demo proves library-component insert @ LOD (W-BONSAI-INSERT): enter Insert mode via the button, pick a

--- a/viewer/routewalker.js
+++ b/viewer/routewalker.js
@@ -252,6 +252,30 @@ function rwSweepOps(segments, opts) {
   });
 }
 
+// Align anchor-space route segments to a WORLD-placed building (the auto-emit-on-drop transform).
+// The dropped building's STRUCTURAL leaves are in modeller world space; its MEP anchors are in extraction
+// space. Both are the SAME building at 1:1 metres, so map the anchor bbox-min → the placed-leaf bbox-min,
+// + an optional yaw about +Z (the drop rotation). Returns segments with world-space from/to.
+//   placedBBox: { min:[x,y,z], max:[x,y,z] } world bbox of the just-placed structural leaves.
+//   opts: { rotDeg } (the drop rotation; 0 = the common case).
+function rwAlignSegments(segments, placedBBox, opts) {
+  if (!segments.length) return [];
+  opts = opts || {};
+  var rad = (opts.rotDeg || 0) * Math.PI / 180, cs = Math.cos(rad), sn = Math.sin(rad);
+  var amin = [Infinity, Infinity, Infinity];
+  segments.forEach(function (s) {
+    [s.from, s.to].forEach(function (p) { for (var i = 0; i < 3; i++) if (p[i] < amin[i]) amin[i] = p[i]; });
+  });
+  var wmin = placedBBox.min;
+  function map(p) {
+    var lx = p[0] - amin[0], ly = p[1] - amin[1], lz = p[2] - amin[2];
+    return [wmin[0] + (cs * lx - sn * ly), wmin[1] + (sn * lx + cs * ly), wmin[2] + lz];
+  }
+  return segments.map(function (s) {
+    return { disc: s.disc, storey: s.storey, axis: s.axis, from: map(s.from), to: map(s.to), len: s.len };
+  });
+}
+
 // Centroid of all segment endpoints — the natural drop-transform pivot
 // (negate to centre a routed building at the modeller origin / drop point).
 function rwSegmentCentroid(segments) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v676';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v677';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/bonsai_routewalk_autodrop_live.js
+++ b/viewer/tests/bonsai_routewalk_autodrop_live.js
@@ -1,0 +1,67 @@
+// W-ROUTEWALK-AUTODROP — auto-emit MEP on building-drop, IN the real modeller.
+// CLAIM: dropping a real Duplex FLOOR (structural BOM, MEP=0) through the REAL placeAssembly path auto-fires
+// RouteWalker: it routes the building's MEP from the real mep_rw.db anchors (the structural drop has none),
+// REGISTERS the anchor-space runs to the just-placed floor's WORLD bbox (rwAlignSegments), and commits each as
+// a signed GEOM_SWEEP. Asserts: structural leaves placed; auto-route found MEP + emitted a bounded set; every
+// run signed + the chain verifies; every run lands INSIDE the placed footprint (alignment); folded + Routes cat.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-routewalk2', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json',
+  '.db': 'application/octet-stream' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(RW|MODELLER (autoroute|assembly|routewalk))/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?routewalk=drop`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__routewalkDropDone === true', { timeout: 180000 })
+    .catch(() => console.log('  ✗ timeout waiting for __routewalkDropDone'));
+
+  const probe = await pg.evaluate(() => {
+    const res = window.__routewalkDropResult || {};
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera);
+    const gl = r.getContext(); const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
+    const px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let lit = 0; for (let i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+    return { res, litPct: +(100 * lit / (w * h)).toFixed(1) };
+  }).catch(e => ({ err: String(e) }));
+
+  const x = probe.res || {};
+  console.log('  §AUTODROP structuralLeaves=' + x.structuralLeaves + ' structuralCommitted=' + x.structuralCommitted +
+    ' found=' + x.found + ' emitted=' + x.emitted + ' routed=' + x.routed + ' sweepRows=' + x.sweepRows +
+    ' cornerRegistered=' + x.cornerRegistered + ' runsInBBox=' + x.runsInBBox + ' runLenSum=' + x.runLenSum +
+    ' placedMin=[' + x.placedMin + '] alignedMin=[' + x.alignedMin + '] signed=' + x.signed + ' verify=' + x.verify +
+    ' totalOps=' + x.totalOps + ' tris=' + x.tris + ' routesCategory=' + x.routesCategory +
+    ' litPixels=' + probe.litPct + '%' + (x.error ? ' ERROR=' + x.error : ''));
+
+  await br.close(); server.close();
+
+  const dropped = x.structuralLeaves === 7 && x.structuralCommitted === 7;     // real Duplex floor placed (structural)
+  const foundMEP = x.found > 100;                                              // routed the building's MEP from real anchors
+  const emittedBounded = x.emitted === 8 && x.routed === 8 && x.sweepRows === 8; // bounded auto-emit (cap=8) all committed
+  const allSigned = x.signed === (7 + 8);                                      // 7 GEOM_INSERT + 8 GEOM_SWEEP all signed
+  const registered = x.cornerRegistered === true && x.runsInBBox === 8;        // routes targeted + contained in the footprint
+  const realRuns = x.runLenSum > 1.0;                                          // runs span real distance (not collapsed)
+  const chainOK = x.verify === true;
+  const inOutliner = x.routesCategory === true;
+  const drew = probe.litPct > 0.5;
+  const pass = dropped && foundMEP && emittedBounded && allSigned && registered && realRuns && chainOK && inOutliner && drew;
+  console.log('  §AUTODROP VERDICT ' + (pass ? 'PASS' : 'FAIL') +
+    ' — floorDropped=' + dropped + ' foundMEP=' + foundMEP + ' emittedBounded=' + emittedBounded +
+    ' allSigned=' + allSigned + ' routesRegistered=' + registered + ' realRuns=' + realRuns +
+    ' chainVerifies=' + chainOK + ' inOutlinerRoutes=' + inOutliner + ' drew=' + drew);
+  console.log('── W-ROUTEWALK-AUTODROP ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## Auto-route MEP when a building is dropped

Builds on #450 (RouteWalker → GEOM_SWEEP emit). Now the emit is **automatic on drop**: drop a Duplex building/floor and its MEP routes itself into the op-log as signed runs, registered to the placed footprint.

### Why anchors, not placed leaves
The catalog's per-building BOMs are **structural-only** (verified: `BUILDING_DX_STD` = 1099 leaves, **MEP=0**). So the MEP comes from the real `mep_rw.db` anchors keyed to the building, and `rwAlignSegments` registers those anchor-space runs onto the just-placed building's **world bbox** (1:1 m, anchor-min → placed-min, + drop yaw).

### What
- **`routewalker.js`**: `rwAlignSegments(segments, placedBBox, {rotDeg})` — the registration transform (W-ROUTEWALKER-MEP **8/8**, bim-compiler).
- **`modeller.html`**: `autoRouteMEP(asm, leaves)` triggered from `placeAssembly` for BUILDING/FLOOR drops. `_rwBuildingHint` maps the catalog's per-building naming (DX→Duplex, SH→SampleHouse, TE/LKTN→Terminal) to the anchor key. Lazy one-shot `rwInit(mep_rw.db)`. **Async** (never blocks the drop); longest-runs-first, capped, §-logged.
- `sw.js` v676→**v677**; `routewalker.js?v=1→2`.

### Witness — W-ROUTEWALK-AUTODROP PASS
`viewer/tests/bonsai_routewalk_autodrop_live.js` (`?routewalk=drop`):
```
structuralLeaves=7 found=2783 emitted=8 routed=8 sweepRows=8 cornerRegistered=true
runsInBBox=8 runLenSum=91.65 placedMin=[1.808,-4.691,0.561] alignedMin=[1.808,-4.691,0.561]
signed=15 verify=true routesCategory=true litPixels=18.6%
VERDICT PASS — floorDropped · foundMEP · emittedBounded · allSigned · routesRegistered ·
realRuns · chainVerifies · inOutlinerRoutes · drew
```
Drop a real Duplex floor (structural) → its MEP auto-routes from real data, folds as signed runs registered to the footprint, verifies, groups under Routes.

### Honest v1 bounds (§-logged)
No clash gate yet (`arcEnvelope=[]`) → longest runs can cross the envelope as diagonals; cap (`__rwMaxRuns`, default 40) because occt pipe is costly. **Follow-on**: feed the placed building's ARC envelope to the clash gate + per-storey run consolidation → fewer, wall-hugging mains with full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)