### PR TITLE
feat(landing): #buildings deep-link → Buildings/IFC hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,6 +548,12 @@ async function clearCache(){
 
 // ============ BOOT ============
 (async function boot(){
+  // Deep-link: /#buildings (or ?hub=1) opens the Buildings/IFC hub straight away — the docs "Open" link
+  // lands here. Takes precedence over the cold gate; showPortalFresh mounts the round selector BEHIND the
+  // overlay (+ marks entered), so closing the hub reveals the matrix, never a blank. (§BUILDINGS-DEEPLINK)
+  if(location.hash==='#buildings' || new URLSearchParams(location.search).has('hub')){
+    L('§BOOT deep-link → Buildings/IFC hub'); showPortalFresh(); openHub(); return;
+  }
   var navType=(performance.getEntriesByType('navigation')[0]||{}).type||'navigate';
   var entered=false; try { entered=localStorage.getItem('mx_entered')==='1'; } catch(e){}
   var state=await probeColdWarm();


### PR DESCRIPTION
## What
The docs User Guide **Open** link for the BIM Viewer pointed at the portal root, landing users on the Morpheus 8-icon matrix — the **Buildings / IFC hub** was one extra click. `openHub()` is an in-page overlay with no URL trigger.

## Change
Boot deep-link: `/#buildings` (or `?hub=1`) → `showPortalFresh()` + `openHub()` **before** the cold gate. The round selector mounts behind the overlay (closing the hub reveals the matrix, never a blank). Reuses existing functions — no new HTML, no catalog duplication. `§BUILDINGS-DEEPLINK`

## Verify
- `https://red1oon.github.io/bim-ootb/#buildings` → Buildings/IFC hub opens directly (catalog + drop zone)
- close hub → round selector; **Home** → matrix
- normal `/` load unchanged (cold gate / reload / return all as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)