### PR TITLE
fix(viewer): counter clamp + reliable clear-cache + cached-building indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
   #hub .hub-card:hover { border-color:rgba(79,195,247,.5); transform:translateY(-1px); }
   #hub .hub-card:active { transform:scale(.98); }
   #hub .hub-card .nm { color:#e6e6ea; font-size:13px; font-weight:600; line-height:1.2; word-break:break-word; }
+  #hub .hub-card.cached .nm { color:#4fc97a; }  /* §CACHE-INDICATOR — green name = building DB already in IndexedDB cache */
   #hub .hub-card .mt { color:#7a8294; font-size:10.5px; margin-top:4px; }
   #hub .hub-card .db { display:flex; gap:2px; margin-top:8px; height:5px; }
   #hub .hub-card .db i { display:block; height:100%; border-radius:2px; }
@@ -495,10 +496,37 @@ function _card(a){
     var pct=(a.disciplines[d]/a.count)*100;
     return '<i style="background:'+(DISC_COLORS[d]||'#888')+';width:'+Math.max(pct*1.2,4)+'px" title="'+d+'"></i>';
   }).join('');
-  return '<div class="hub-card" onclick="openBuilding(\''+a.name+'\')">'+
+  return '<div class="hub-card" data-bld="'+a.name+'" onclick="openBuilding(\''+a.name+'\')">'+
     '<div class="nm">'+a.name+'</div>'+
     '<div class="mt"><b>'+a.count.toLocaleString()+'</b> elements &middot; '+Object.keys(a.disciplines||{}).join(' ')+'</div>'+
     '<div class="db">'+bars+'</div></div>';
+}
+// §CACHE-INDICATOR — green a building's name if its DB is already in the IndexedDB building cache
+// (bim_ootb_cache/dbs, keyed by fetched URL). After Clear cache → no keys → names stay white. Best-effort.
+async function _markCachedBuildings(){
+  try{
+    var keys = await new Promise(function(res){
+      var o; try { o = indexedDB.open('bim_ootb_cache'); } catch(e){ return res([]); }
+      o.onerror = function(){ res([]); };
+      o.onsuccess = function(){
+        var db = o.result;
+        if(!db.objectStoreNames.contains('dbs')){ db.close(); return res([]); }
+        try {
+          var rq = db.transaction('dbs','readonly').objectStore('dbs').getAllKeys();
+          rq.onsuccess = function(){ db.close(); res(rq.result || []); };
+          rq.onerror = function(){ db.close(); res([]); };
+        } catch(e){ db.close(); res([]); }
+      };
+    });
+    var keyStr = '\n' + keys.join('\n') + '\n';
+    document.querySelectorAll('#hub .hub-card[data-bld]').forEach(function(card){
+      var bld = BUILDINGS[card.getAttribute('data-bld')];
+      if(!bld || !bld.db) return;
+      var stem = bld.db.replace(/_extracted\.db$/,'').replace(/\.db$/,'');
+      // split builds cache *_meta/_geo/_positions, single caches *_extracted.db — match on the stem boundary
+      if(keyStr.indexOf('/'+stem+'_') >= 0 || keyStr.indexOf('/'+bld.db) >= 0) card.classList.add('cached');
+    });
+  }catch(e){ /* indicator is best-effort, never blocks the hub */ }
 }
 var _hubBuilt=false;
 async function buildHubBody(){
@@ -523,6 +551,7 @@ async function buildHubBody(){
     if(landmark.length) html+='<div class="hub-sect"><div class="hub-sh">Landmark buildings</div><div class="hub-grid">'+landmark.map(_card).join('')+'</div></div>';
     document.getElementById('hub-status').remove();
     b.insertAdjacentHTML('beforeend', html);
+    _markCachedBuildings();
     L('§HUB_CARDS rendered city='+city.length+' landmark='+landmark.length);
   } catch(e){
     var s=document.getElementById('hub-status'); if(s){ s.innerHTML='&#9888; '+e.message+' &mdash; <a href="javascript:location.reload()" style="color:#4fc3f7">reload</a>'; }
@@ -533,16 +562,36 @@ function openAbout(){ if(window.AboutDIY && AboutDIY.open){ AboutDIY.open(); L('
 function openFlags(){ if(window._TRL_LOADER && _TRL_LOADER.openFlagPicker){ _TRL_LOADER.openFlagPicker(); L('§FLAGS picker opened (real _TRL_LOADER)'); } else { L('§FLAGS _TRL_LOADER missing'); } }
 // 8th launcher — Clear cache: drops the entered flag + imports + caches, so the NEXT load shows the
 // red/blue gate again. (Mirrors index.html clearAllCache; this is the only thing that re-arms the gate.)
+// Reliably empty an IndexedDB even if another tab holds it open: clear every object store.
+// (deleteDatabase silently BLOCKS on open connections and the old code treated onblocked as success,
+//  so the building cache survived — the reported bug.) Then best-effort delete the now-empty DB.
+function _emptyIdb(name){
+  return new Promise(function(res){
+    var open; try { open = indexedDB.open(name); } catch(e){ return res(); }
+    open.onerror = function(){ res(); };
+    open.onsuccess = function(){
+      var db = open.result;
+      try {
+        var names = Array.prototype.slice.call(db.objectStoreNames);
+        if(!names.length){ db.close(); try{ indexedDB.deleteDatabase(name); }catch(e){} return res(); }
+        var tx = db.transaction(names, 'readwrite');
+        names.forEach(function(s){ try{ tx.objectStore(s).clear(); }catch(e){} });
+        tx.oncomplete = function(){ db.close(); try{ indexedDB.deleteDatabase(name); }catch(e){} res(); };
+        tx.onerror = function(){ db.close(); res(); };
+        tx.onabort = function(){ db.close(); res(); };
+      } catch(e){ try{ db.close(); }catch(_){} res(); }
+    };
+  });
+}
 async function clearCache(){
   sfxPress();
   // HONEST confirm — list exactly what goes. ONLY the in-browser building IndexedDB + the entered flag;
   // the installed app / offline shells stay, and any IFC saved as a .db file is the user's own copy.
   if(!confirm('Reset to the start screen?\n\nClears the in-browser building data:\n  • cached buildings\n  • any IFC scene you dropped in (not saved to a .db file)\nand returns you to the red / blue choice.\n\nKeeps: the installed app + offline data, and any .db you saved yourself.')) return;
   try { localStorage.removeItem('mx_entered'); localStorage.removeItem('bim_ootb_viewed'); } catch(e){}
-  await new Promise(function(res){ var n=0, done=function(){ if(++n>=2) res(); };
-    try { var r1=indexedDB.deleteDatabase('bim_ootb_imports'); r1.onsuccess=r1.onerror=r1.onblocked=done; } catch(e){ done(); }
-    try { var r2=indexedDB.deleteDatabase('bim_ootb_cache');   r2.onsuccess=r2.onerror=r2.onblocked=done; } catch(e){ done(); } });
-  L('§CLEAR building IndexedDB + entered wiped (app/offline caches KEPT) → reload to red/blue gate');
+  await _emptyIdb('bim_ootb_imports');
+  await _emptyIdb('bim_ootb_cache');
+  L('§CLEAR building IndexedDB stores cleared (app/offline caches KEPT) → reload to red/blue gate');
   location.href='index.html';
 }
 

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -603,9 +603,11 @@ async function setupScene(A) {
         const { done, value } = await reader.read();
         if (done) break;
         chunks.push(value); received += value.length;
-        const pct = Math.round((received / contentLength) * 100);
+        // §S-PROGRESS-META — clamp ≤100%: gzip/transfer-encoding makes Content-Length (compressed)
+        // smaller than received (decompressed) bytes, so the raw ratio can exceed 1.0.
+        const pct = Math.min(100, Math.round((received / contentLength) * 100));
         if (A.status) A.status.textContent = `Downloading ${fileName}... ${pct}% (${(received/1024/1024).toFixed(0)}/${(contentLength/1024/1024).toFixed(0)}MB)`;
-        // §S-PROGRESS-META — drive the visible bar during cachedFetch (meta.db phase), not just the status text
+        // drive the visible bar during cachedFetch (meta.db phase), not just the status text
         var _sp = document.getElementById('s-progress');
         if (_sp) _sp.style.width = pct + '%';
       }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v679';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v680';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Three fixes (all tested headless on the front door — 25 cards, 0 errors):
- **counter >100%** clamped (gzip Content-Length < decompressed bytes)
- **Clear cache** now reliably empties the building IndexedDB (old code let deleteDatabase silently block)
- **cached indicator**: hub building name green when cached, white after clear

sw CACHE_VERSION v679→v680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)