### PR TITLE
feat(viewer): §RENDERER_CAPS startup log (multi_draw + GPU)

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -44,6 +44,15 @@ async function setupScene(A) {
     preserveDrawingBuffer: true
   });
   console.log('§S277b_RENDERER WebGLRenderer r184 (WebGPU deferred)');
+  // §S281b: report multi_draw fast-path + GPU at startup. BatchedMesh collapses a bucket to ONE draw
+  // call only when WEBGL_multi_draw is present; without it = per-draw fallback = slower final render.
+  try {
+    var _capGl = renderer.getContext();
+    var _md = !!_capGl.getExtension('WEBGL_multi_draw');
+    var _dbg = _capGl.getExtension('WEBGL_debug_renderer_info');
+    var _gpu = _dbg ? _capGl.getParameter(_dbg.UNMASKED_RENDERER_WEBGL) : 'unknown';
+    console.log('§RENDERER_CAPS multi_draw=' + (_md ? 'on (fast batched path)' : 'off (slow — per-draw fallback)') + ' gpu=' + _gpu);
+  } catch(_e) { console.log('§RENDERER_CAPS probe failed: ' + (_e && _e.message)); }
   A._isWebGPU = _isWebGPU;
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setPixelRatio(_isMobileRenderer ? 1 : Math.min(window.devicePixelRatio, 2));  // §S271: mobile=1x, desktop=cap 2x

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v682';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v683';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Adds a one-line startup log reporting WEBGL_multi_draw availability (BatchedMesh fast vs per-draw fallback) + GPU string, to diagnose the 'slower final render' per browser/machine. Additive, try/catch. sw v682→v683. Tested headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)