### PR TITLE
feat(modeller): per-discipline COLOUR for SH MEP fixtures (W-ROUTEWALK-FIXTURES-COLOUR)

### DIFF
--- a/viewer/bonsai_kernel.js
+++ b/viewer/bonsai_kernel.js
@@ -162,7 +162,9 @@
       }
       if (g) { while (g.children.length) g.remove(g.children[0]); }   // replay = clear then re-fold
       let totalTris = 0;
-      meshes.forEach(md => { const m = this._buildMesh(md, { color: opts.color }); totalTris += md.triangleCount; if (g) g.add(m); });
+      // PER-MESH colour wins over the fold-level colour: a folded insert (RouteWalker fixture) carries md.color
+      // (its discipline hex from parameters.color); B-rep solids have none → fall back to the fold-level opts.color.
+      meshes.forEach(md => { const m = this._buildMesh(md, { color: md.color != null ? md.color : opts.color }); totalTris += md.triangleCount; if (g) g.add(m); });
       this._lastRegenStats = d.stats || null;   // {rebuilt, hits, tess, tessHits} — incremental-regen cache witness hook
       const ms = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : 0) - t0;
       const st = d.stats ? ' regen[rebuilt=' + d.stats.rebuilt + ' hits=' + d.stats.hits + ' tess=' + d.stats.tess + ' tessHits=' + d.stats.tessHits + ']' : '';

--- a/viewer/bonsai_library.js
+++ b/viewer/bonsai_library.js
@@ -188,7 +188,9 @@
         pl = { x: ox, y: oy, z: oz, rot };
       }
       const positions = place(base.positions, pl, base.bbox || c.bbox);   // real mesh seats on its own bbox
-      return { featureId: op.id, triangleCount: base.indices.length / 3, positions, normals: null, indices: base.indices };
+      // PER-MESH colour: a signed GEOM_INSERT may carry parameters.color (hex int) — RouteWalker fixtures persist
+      // their discipline colour there so each box keeps it through scrub/replay (the fold is otherwise one colour).
+      return { featureId: op.id, triangleCount: base.indices.length / 3, positions, normals: null, indices: base.indices, color: (P.color != null ? P.color : undefined) };
     },
 
     // GHOST preview (uncommitted): a LOD-200 box of the component at a candidate placement, so the host can

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -163,7 +163,7 @@
 <div id="stat">booting…</div>
 
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->
-<script src="bonsai_kernel.js?v=2" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
+<script src="bonsai_kernel.js?v=3" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
 <!-- Bonsai 2D sketch front: planegcs constraint solver -> solved profile -> GEOM_EXTRUDE_POLY. -->
 <script src="bonsai_sketch.js?v=1" onerror="console.warn('§SKETCH LOAD_FAIL bonsai_sketch.js')"></script>
 <!-- Signed op-log engine (shipped kernel_ops: hash chain + edge signature) + sql.js it commits into. -->
@@ -182,7 +182,7 @@
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=9" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=10" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
@@ -1335,12 +1335,18 @@ async function autoRouteMEP(asm, leaves) {
     const byClass = (L.catalog() || []).find(c => c.ifc_class === f.ifcClass);   // fallback: any box of the right ifc class
     return byClass ? byClass.hash : 'ROLE__DIFFUSER';                            // final generic ACMV box
   };
+  // Discipline COLOUR (step C): f.rgba is the REAL material_rgba from RW_IFC_MAP ('r,g,b,a'). Persist it as a hex
+  // int in the signed op PARAMETERS (not the per-commit {color} opt — GEOM_INSERT is non-LEAF, so every re-fold/
+  // scrub rebuilds via foldChainToScene with one fold-level colour and would LOSE a per-commit colour). Persisted
+  // in params → survives the DB round-trip → foldInsert reads parameters.color → each fixture mesh keeps its colour
+  // through scrub/history replay (step F). Lights warm-yellow, fans cyan, sprinkler red, outlet amber, sanitary blue.
+  const rgbaHex = s => { const p = String(s || '').split(',').map(Number); const ch = i => Number.isFinite(p[i]) ? Math.max(0, Math.min(255, p[i] | 0)) : 180; return (ch(0) << 16) | (ch(1) << 8) | ch(2); };   // NOT `p[i]||180` — a legit 0 channel (amber B=0) must stay 0
   let placedFx = 0;
   for (const f of fixtures) {
     const hash = hashFor(f); const c = L.get(hash); const ch = c ? c.h : 0.4;
     const w = toWorld([f.x, f.y, f.z]);
     const op = { op_type:'GEOM_INSERT',
-      parameters: { hash: hash, placement: { x:+w[0].toFixed(4), y:+w[1].toFixed(4), z:+(w[2]-ch/2).toFixed(4), rot: insRot||0 }, lod:'200' },
+      parameters: { hash: hash, placement: { x:+w[0].toFixed(4), y:+w[1].toFixed(4), z:+(w[2]-ch/2).toFixed(4), rot: insRot||0 }, lod:'200', color: rgbaHex(f.rgba) },
       _rw: { fixture: true, disc: f.disc, product: f.product, ifc: f.ifcClass, room: f.room } };
     try { const res = await window.Bonsai.oplog.commit(op); if (res) placedFx++; }
     catch (e) { console.warn('§MODELLER fixture commit fail ' + (e && e.message || e)); }
@@ -2064,14 +2070,32 @@ if (qs.get('routewalk') === 'sh') {
       await placeAssembly(6, 4);                                   // REAL drop → triggers autoRouteMEP (fixtures path)
       const ar = await (window.__lastAutoRoute || Promise.resolve({}));
       out.building = 'SampleHouse'; out.fixtures = ar.fixtures || 0; out.fxDisc = ar.fxDisc || {};
-      const fxOps = O._geomOps().filter(o => o._rw && o._rw.fixture);
+      // Fixtures are the only GEOM_INSERT rows carrying a persisted discipline `color` (structural leaves have none).
+      // _rw is an in-memory tag that does NOT survive _geomOps() (reads DB cols only) — parameters.color is the
+      // reload-safe signal, so identify fixtures by it.
+      const fxOps = O._geomOps().filter(o => o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters.color != null);
       out.fixtureOps = fxOps.length;
-      out.products = {}; fxOps.forEach(o => { const p = o._rw.product; out.products[p] = (out.products[p]||0)+1; });
       out.hasELEC = (out.fxDisc.ELEC || 0) > 0; out.hasACMV = (out.fxDisc.ACMV || 0) > 0;
       out.noWetRoom = !out.fxDisc.FP && !out.fxDisc.PLB;           // SH honestly has no sprinkler/plumbing
       out.signed = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
       out.verify = (await O.verify()).ok;
-      out.pass = out.fixtures === 23 && out.fixtureOps === 23 && out.hasELEC && out.hasACMV && out.noWetRoom && out.verify;
+      // STEP C: assert each fixture MESH carries its discipline colour (not the grey default) AFTER the authoritative
+      // fold — i.e. it survived the DB round-trip + scrubTo re-fold (history replay keeps colour, step F).
+      const GREY = 0x9fb4c8;
+      const grp = window.Bonsai.group();
+      const meshByFid = {};
+      if (grp) grp.children.forEach(m => { if (m.userData && m.userData.featureId != null) meshByFid[m.userData.featureId] = m; });
+      let coloured = 0, miscoloured = 0; const hexSet = {};
+      fxOps.forEach(o => {
+        const want = o.parameters.color, m = meshByFid[o.id];
+        const got = (m && m.material && m.material.color) ? m.material.color.getHex() : null;
+        if (got === want && want !== GREY) { coloured++; hexSet[want] = (hexSet[want] || 0) + 1; } else miscoloured++;
+      });
+      out.colouredFixtures = coloured; out.miscolouredFixtures = miscoloured; out.distinctColours = Object.keys(hexSet).length;
+      console.log('§MODELLER routewalk-sh-colour coloured=' + coloured + '/' + fxOps.length + ' miscoloured=' + miscoloured +
+        ' distinct=' + out.distinctColours + ' hex=' + Object.keys(hexSet).map(h => (+h).toString(16)).join(','));
+      out.pass = out.fixtures === 23 && out.fixtureOps === 23 && out.hasELEC && out.hasACMV && out.noWetRoom && out.verify &&
+        out.colouredFixtures === 23 && out.miscolouredFixtures === 0 && out.distinctColours >= 3;
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER routewalk sh fail ' + e); }
     window.__routewalkShResult = out;
     window.__routewalkShDone = true;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v685';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v686';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/bonsai_routewalk_colour_live.js
+++ b/viewer/tests/bonsai_routewalk_colour_live.js
@@ -1,0 +1,66 @@
+// W-ROUTEWALK-FIXTURES-COLOUR-LIVE — the 23 SH MEP fixtures render in DISCIPLINE colour, IN the real modeller.
+// CLAIM: driving ?routewalk=sh, autoRouteMEP places the 23 fixtures as signed GEOM_INSERT box proxies, each with a
+// persisted parameters.color = rgbaHex(f.rgba). After the authoritative scrubTo re-fold, every fixture MESH in the
+// BonsaiAuthored group carries its discipline colour (NOT the grey default) — proving the colour survives the DB
+// round-trip + history-replay fold. Reads window.__routewalkShResult (page self-test) + a GL pixel-lit sanity.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join('/tmp/wt-mep-colour', 'viewer');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json',
+  '.db': 'application/octet-stream' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(RW|MODELLER|OPLOG)/.test(t)) console.log('  ' + t); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?routewalk=sh`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__routewalkShDone === true', { timeout: 180000 })
+    .catch(() => console.log('  ✗ timeout waiting for __routewalkShDone'));
+
+  const probe = await pg.evaluate(() => {
+    const res = window.__routewalkShResult || {};
+    // pull the actual material colours of the fixture meshes for the §-log (independent of the page self-test)
+    const O = window.Bonsai.oplog, grp = window.Bonsai.group();
+    const meshByFid = {}; if (grp) grp.children.forEach(m => { if (m.userData && m.userData.featureId != null) meshByFid[m.userData.featureId] = m; });
+    const fxOps = O._geomOps().filter(o => o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters.color != null);
+    const hexes = {}; let grey = 0;
+    fxOps.forEach(o => { const m = meshByFid[o.id]; const h = (m && m.material && m.material.color) ? m.material.color.getHex() : -1; hexes[h] = (hexes[h] || 0) + 1; if (h === 0x9fb4c8) grey++; });
+    let litPct = 0;
+    try { const r = window.A.renderer; r.render(window.A.scene, window.A.camera); const gl = r.getContext();
+      const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight; const px = new Uint8Array(w * h * 4);
+      gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px); let lit = 0;
+      for (let i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+      litPct = +(100 * lit / (w * h)).toFixed(1); } catch (e) {}
+    return { res, meshHexes: Object.keys(hexes).map(k => (k < 0 ? 'none' : (+k).toString(16)) + ':' + hexes[k]).join(' '), greyFixtures: grey, litPct };
+  }).catch(e => ({ err: String(e) }));
+
+  const x = probe.res || {};
+  console.log('  §SH fixtures=' + x.fixtures + ' fixtureOps=' + x.fixtureOps + ' hasELEC=' + x.hasELEC + ' hasACMV=' + x.hasACMV +
+    ' noWetRoom=' + x.noWetRoom + ' verify=' + x.verify + ' coloured=' + x.colouredFixtures + ' miscoloured=' + x.miscolouredFixtures +
+    ' distinctColours=' + x.distinctColours + (x.error ? ' ERROR=' + x.error : ''));
+  console.log('  §SH-MESH meshHexes=[' + probe.meshHexes + '] greyFixtures=' + probe.greyFixtures + ' litPixels=' + probe.litPct + '%');
+
+  await br.close(); server.close();
+
+  const placed = x.fixtures === 23 && x.fixtureOps === 23;
+  const coloured = x.colouredFixtures === 23 && x.miscolouredFixtures === 0;   // every fixture mesh carries its colour
+  const readable = x.distinctColours >= 3 && probe.greyFixtures === 0;          // ≥3 disciplines distinct, none left grey
+  const chainOK = x.verify === true;
+  const drew = probe.litPct > 0.5;
+  const pass = placed && coloured && readable && chainOK && drew && x.pass === true;
+  console.log('  §SH VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — placed=' + placed + ' allColoured=' + coloured +
+    ' readableDistinct=' + readable + ' chainVerifies=' + chainOK + ' drew=' + drew + ' pageSelfTest=' + x.pass);
+  console.log('── W-ROUTEWALK-FIXTURES-COLOUR-LIVE ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
Step C of the SampleHouse "all systems go" MEP benchmark. The 23 auto-placed fixtures now render in their **real discipline colour** (from `RW_IFC_MAP.material_rgba`) instead of grey box proxies:

- lights → warm-yellow `#ffdc64`
- fans / diffusers / aircon → cyan `#64c8ff`/`#78d2ff`/`#96dcff`
- outlets / switches → amber `#ffc800`
- (sanitary blue / sprinkler red fire when a building has a wet room — SH has none)

### How
The colour is threaded through the **signed fold** so it survives the DB round-trip + `scrubTo` re-fold (history replay, step F). The per-commit `{color}` opt does **not** survive a `GEOM_INSERT` (non-LEAF → every re-fold rebuilds via `foldChainToScene` with one fold-level colour). So:

- `modeller.html` `autoRouteMEP`: persist `parameters.color = rgbaHex(f.rgba)` on each fixture `GEOM_INSERT` (`rgbaHex` keeps a legit `0` channel — amber B=0 — not `||180`).
- `bonsai_library.js` `foldInsert`: echo `parameters.color` onto the mesh descriptor.
- `bonsai_kernel.js` `foldChainToScene`: per-mesh `md.color` wins over the fold-level colour (B-rep solids have none → unchanged grey default; no regression).
- `?routewalk=sh` self-test now asserts each fixture **mesh** carries its colour after the authoritative fold; also fixed its fixture filter (`_rw` does not survive `_geomOps` — use the persisted `parameters.color`).

### Witnesses
- **W-ROUTEWALK-FIXTURES-COLOUR 5/5** headless (`bim-compiler scripts/witness_routewalker_fixtures_colour.js`) — data + plumbing contract; caught the `||180` zero-channel bug (OUTLET/SWITCH amber was rendering pink).
- **W-ROUTEWALK-FIXTURES-COLOUR-LIVE PASS** (`viewer/tests/bonsai_routewalk_colour_live.js`, puppeteer): 23/23 coloured, 0 grey, 5 distinct disciplines, chain verifies, drew 83.7%.
- W-ROUTEWALK-FIXTURES-DB 5/5 + GEO 7/7 still PASS (no regression).

`bonsai_kernel.js?v=3`, `bonsai_library.js?v=10`, sw `v686`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)