### PR TITLE
feat(routewalker): snap wall-host MEP fixtures onto real walls (W-ROUTEWALK-WALL-SNAP)

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -189,7 +189,7 @@
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
-<script src="routewalker.js?v=4" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
+<script src="routewalker.js?v=5" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
 
 <!-- Scene bootstrap: reuse the viewer's THREE stack (r184 webgpu build), expose global THREE + window.A. -->
 <script type="module">
@@ -1402,7 +1402,8 @@ async function autoRouteMEP(asm, leaves) {
   // building_room, baked from its OWN extracted BOM) × the real recipe. Structural-only buildings carry no MEP
   // leaves and SH has no pipe anchors, so this is the only MEP a dropped SH gets — proven W-ROUTEWALK-FIXTURES-DB.
   const rooms = (typeof rwLoadRooms === 'function' && name) ? rwLoadRooms(name) : [];
-  const fixtures = (rooms.length && typeof rwPlaceFixtures === 'function') ? rwPlaceFixtures(rooms) : [];
+  // buildingName lets rwPlaceFixtures snap WALL-host fixtures onto the building's REAL wall solids (arc_envelope).
+  const fixtures = (rooms.length && typeof rwPlaceFixtures === 'function') ? rwPlaceFixtures(rooms, { buildingName: name }) : [];
   if (!segs.length && !fixtures.length) { console.log('§MODELLER autoroute no-MEP building="' + name + '"'); return { found: 0, routed: 0 }; }
   // World bbox min of placed structural leaves = origin of BOM coordinate frame in world space
   const bmin = [Infinity, Infinity, Infinity];

--- a/viewer/routewalker.js
+++ b/viewer/routewalker.js
@@ -23,6 +23,7 @@ var RW_PIPE_NOMINAL_MM = 50;
 var RW_PIPE_CROSS = RW_PIPE_NOMINAL_MM * 1.5;  // bbox cross-section
 var RW_MAX_PAIR_DIST = 50.0;  // metres — skip pairs > 50m apart
 var RW_ARC_CLASH_TOL = -0.01; // metres — pipes may touch walls but not penetrate
+var RW_WALL_SNAP_MAX = 1.5;   // metres — a wall-host fixture snaps onto a real wall within this; else keeps nominal
 
 // ─── MEP product → IFC class mapping ────────────────────────
 var RW_IFC_MAP = {
@@ -341,7 +342,16 @@ function rwPlaceFixtures(rooms, opts) {
     offRows[0].values.forEach(function (v) { var o = {}; cols.forEach(function (c, i) { o[c] = v[i]; }); offsets[v[0]] = o; });
   }
 
-  var out = [];
+  // WALL-MOUNT FIDELITY: a WALL-host fixture (switch/outlet/wall-aircon) nominally lands at the room SET's aabb
+  // EDGE — the furniture-extent, not a real wall. Snap it onto the nearest REAL wall solid (the building's
+  // arc_envelope thin-and-tall boxes, same source the clash gate uses) so switches/outlets actually mount on a
+  // wall surface. Honest fallback: where SH's PARTIAL wall model has no wall within RW_WALL_SNAP_MAX, the fixture
+  // keeps its nominal edge position (never teleported across the building). opts.wallBoxes injects them directly
+  // (witness); else they self-load from opts.buildingName.
+  var wallBoxes = opts.wallBoxes ||
+    (opts.buildingName ? _rwLoadArcEnvelopeFromDb(opts.buildingName).filter(function (a) { return Math.min(a.w, a.d) < 0.5 && a.h > 1.5; }) : []);
+
+  var out = [], snappedN = 0;
   rooms.forEach(function (room) {
     var spaceType = _rwRoleToSpace(room.type || room.role);
     var bomRows = _rwDb.exec(
@@ -361,9 +371,15 @@ function rwPlaceFixtures(rooms, opts) {
       var info = RW_IFC_MAP[product] || RW_IFC_MAP._DEFAULT;
       for (var q = 0; q < qty; q++) {
         var pos = _rwComputePosition(room, offset, host, q, qty);
+        var wsnap = false;
+        if (host === 'WALL' && wallBoxes.length) {
+          var sn = _rwSnapToWall(pos.x, pos.y, pos.z, wallBoxes, RW_WALL_SNAP_MAX);
+          if (sn.snapped) { pos.x = sn.x; pos.y = sn.y; wsnap = true; snappedN++; }
+        }
         out.push({
           product: product, ifcClass: info.cls, disc: info.disc, rgba: info.rgba,
-          x: pos.x, y: pos.y, z: pos.z, room: (room.name || spaceType), hostSurface: host, placementRule: rule
+          x: pos.x, y: pos.y, z: pos.z, room: (room.name || spaceType), hostSurface: host, placementRule: rule,
+          wallSnapped: wsnap
         });
       }
     });
@@ -371,9 +387,34 @@ function rwPlaceFixtures(rooms, opts) {
 
   var byDisc = {};
   out.forEach(function (f) { byDisc[f.disc] = (byDisc[f.disc] || 0) + 1; });
-  console.log('§RW_FIX rooms=' + rooms.length + ' fixtures=' + out.length +
+  console.log('§RW_FIX rooms=' + rooms.length + ' fixtures=' + out.length + ' wallSnapped=' + snappedN +
     ' disc=' + Object.keys(byDisc).map(function (k) { return k + ':' + byDisc[k]; }).join(' '));
   return out;
+}
+
+// Snap a wall-host fixture onto the nearest REAL wall solid (arc_envelope thin-and-tall box). Walls are thin in
+// ONE horizontal axis; mount the fixture on the box face nearest the point (the room-facing side) + a small
+// offset, clamped to the wall's span. Only snaps if a wall is within maxDist (else honest fallback to nominal).
+function _rwSnapToWall(x, y, z, wallBoxes, maxDist) {
+  var best = null, bestD = Infinity;
+  for (var i = 0; i < wallBoxes.length; i++) {
+    var a = wallBoxes[i];
+    if (z < a.cz - a.h / 2 - 0.10 || z > a.cz + a.h / 2 + 0.10) continue;   // fixture height must fall within the wall
+    var dx = Math.max(Math.abs(x - a.cx) - a.w / 2, 0);
+    var dy = Math.max(Math.abs(y - a.cy) - a.d / 2, 0);
+    var d = Math.sqrt(dx * dx + dy * dy);
+    if (d < bestD) { bestD = d; best = a; }
+  }
+  if (!best || bestD > (maxDist || 1.5)) return { x: x, y: y, z: z, snapped: false };
+  var nx = x, ny = y;
+  if (best.w <= best.d) {                                                    // thin in X → wall runs along Y
+    nx = best.cx + (x >= best.cx ? 1 : -1) * (best.w / 2 + 0.02);
+    ny = Math.max(best.cy - best.d / 2, Math.min(best.cy + best.d / 2, y));
+  } else {                                                                   // thin in Y → wall runs along X
+    ny = best.cy + (y >= best.cy ? 1 : -1) * (best.d / 2 + 0.02);
+    nx = Math.max(best.cx - best.w / 2, Math.min(best.cx + best.w / 2, x));
+  }
+  return { x: nx, y: ny, z: z, snapped: true, dist: bestD };
 }
 
 // Mirror of _rwApplyPattern's pairing, but collects endpoint pairs into `out`.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v688';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v689';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Closes the SampleHouse benchmark's honest residual (step A finding #2): WALL-host fixtures (switch / outlet / wall-aircon) landed at the room SET's **furniture-extent aabb edge**, not on a real wall — only **1 of 13** touched a real wall solid.

### Fix
`rwPlaceFixtures` now **snaps each wall-host fixture onto the nearest real wall solid** (`mep_rw.db` `arc_envelope` thin-and-tall boxes — the same source the clash gate uses): mounted on the box face nearest the point, clamped to the wall's span.
- **Honest fallback**: where SH's *partial* wall model has no wall within `RW_WALL_SNAP_MAX` (1.5m), the fixture keeps its nominal edge position — never teleported across the building.
- Open-space fixtures (ceiling/floor lights/fans/diffusers) are **untouched** — snapping is wall-host only.
- New `_rwSnapToWall` + `RW_WALL_SNAP_MAX`. `opts.wallBoxes` injects them (witness); the modeller passes `opts.buildingName` so the live path self-loads them.

### Result on SH
Wall-mounted fixtures **1 → 6** of 13 (the other 7 honestly keep nominal — no wall near them in SH's partial model).

### Witness
- **W-ROUTEWALK-WALL-SNAP 5/5** (`scripts/witness_routewalker_wall_snap.js`, bim-compiler): more-on-wall, snapped-are-actually-on-wall, never-pushed-outside-building, open-untouched, honest-fallback + deterministic.
- GEO 7/7 + DB 5/5 unchanged (no opts → no snap). Colour / x-ray / walk live tests still PASS (live `§RW_FIX wallSnapped=6`).

`routewalker.js?v=5`, sw `v689`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)