### PR TITLE
feat(tm): PP_Order Zoom-Across → BIM Viewer TimeMachine (W-PPZOOM-TM 7/7)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3565,6 +3565,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         if (pid != null) { var p = _sqlRows('SELECT value FROM m_product WHERE m_product_id=' + Number(pid))[0]; find = p && p.value ? String(p.value) : null; }
         return { bld: String(pr.value), find: find };
       }
+      if (tn === 'pp_order') {                                       // PP_ORDER_ZOOM_TM_SPEC §A — a manufacturing
+        var ppId = recVal(ctx.rec, 'PP_Order_ID');                  //   order → its project's building, in TM mode
+        var pProj = recVal(ctx.rec, 'C_Project_ID');                //   landed at this order's construction moment
+        if (pProj == null || Number(pProj) < 990000) return null;   // only BIM-band project orders carry a scene
+        var ppr = _sqlRows('SELECT value FROM c_project WHERE c_project_id=' + Number(pProj))[0];
+        if (!ppr || !ppr.value) return null;
+        return { bld: String(ppr.value), find: null, tm: { order: Number(ppId) } };   // .tm ⇒ TimeMachine target
+      }
       return null;
     }
     if (window.ZoomAcross) window.ZoomAcross.register({
@@ -3582,6 +3590,23 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         if (sc.find) url += '&find=' + encodeURIComponent(sc.find);  // carry the finer scope to the Find panel
         window.open(url, '_blank');
         console.log('§ZOOM-ACROSS launch id=viewer bld=' + sc.bld + ' find=' + (sc.find || '-') + ' url=' + url);
+      }
+    });
+    // PP_ORDER_ZOOM_TM_SPEC §A — the manufacturing/project order destination: BIM Viewer in TimeMachine mode,
+    //   deep-linked to THIS order (?tm=1&pporder=<id>) so the 4D scrubber + shopfloor S-curve land at its moment.
+    //   available ONLY when the focus resolves a `.tm` scope (a PP_Order) — never for plain C_Project lines.
+    if (window.ZoomAcross) window.ZoomAcross.register({
+      id: 'timemachine', label: 'BIM TimeMachine',
+      available: function (ctx) { var s = _zoomScope(ctx); return !!(s && s.tm && s.bld); },
+      launch: function (ctx) {
+        _connectEnable();                                            // OPT-IN: wire Connect on first Zoom-Across launch
+        var sc = _zoomScope(ctx);
+        if (!sc || !sc.tm || !sc.bld) { status('No BIM model linked to this order'); console.log('§ZOOM-ACROSS no-scope id=timemachine'); return; }
+        var homeUrl = encodeURIComponent(location.origin + location.pathname.replace(/[^/]*$/, '') + 'idempiere.html');
+        var url = '../viewer/viewer.html?db=../buildings/' + encodeURIComponent(sc.bld) + '_extracted.db&bld=' +
+          encodeURIComponent(sc.bld) + '&home=' + homeUrl + '&tm=1&pporder=' + encodeURIComponent(sc.tm.order);
+        window.open(url, '_blank');
+        console.log('§ZOOM-ACROSS launch id=timemachine bld=' + sc.bld + ' pporder=' + sc.tm.order + ' url=' + url);
       }
     });
     // §CONNECT-ERP-SCRUB-START — ERP-side Connect reaction: subscribe selection+timeline from the BIM viewer.

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v737';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v738';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v687';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v688';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/test_pp_zoom_tm.js
+++ b/viewer/tests/test_pp_zoom_tm.js
@@ -1,0 +1,115 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness for PP_ORDER_ZOOM_TM_SPEC — "PP_Order Zoom-Across → BIM Viewer TimeMachine".
+//   The Hospital scene's geometry lives in OPFS (unreachable from disk) → live VISUAL is DEFERRED; this §-log
+//   IS the proof (feedback_whitebox_deduce_not_browser). It replicates, against the REAL erp/ad_seed.db:
+//     A — the ERP _zoomScope(pp_order) fold: a Hospital PP_Order resolves {bld, tm:{order}} (identity, not a link).
+//     B — the launch URL the 'timemachine' destination builds carries ?tm=1&pporder=<id>&bld=<bld>.
+//     C — tmJumpToOrder's phase token is EXTRACTED from PP_Order.Description ("<Phase> — <CREW>"), not invented.
+//     D — cursor landing mode=phase: when the phase has ops on the scene axis → cursor == that phase's winStart.
+//     E — cursor landing mode=projected: when it doesn't → order finish date mapped onto [_projectStart,_projectEnd]
+//         by its position in the shopfloor span; finite, in-range, matches the proportional formula (honest label).
+//     F — the order's PP_Order_Cost Σ CumulatedAmt > 0 (the cost the S-curve folds for this order).
+//     G — guard: a non-BIM-band order (C_Project_ID null / <990000) resolves NO scene (null) — pure otherwise.
+//   Each assertion NAMES the issue it proves. §-log first — READ test_pp_zoom_tm.log before concluding.
+// Run:  node viewer/tests/test_pp_zoom_tm.js        (exit 0 = PASS)
+'use strict';
+const { execFileSync } = require('child_process');
+const fs = require('fs'), path = require('path');
+const DB = path.join(__dirname, '..', '..', 'erp', 'ad_seed.db');
+const q = (sql) => execFileSync('sqlite3', [DB, sql], { encoding: 'utf8' }).trim();
+const rows = (sql) => q(sql).split('\n').filter(Boolean).map(l => l.split('|'));
+
+const log = []; let pass = 0, fail = 0;
+const S = (m) => { log.push(m); console.log(m); };
+const ok = (cond, label, detail) => { if (cond) pass++; else fail++; S('  ' + (cond ? 'PASS' : 'FAIL') + ' ' + label + (detail ? ' — ' + detail : '')); };
+
+// ── the two folds under test, replicated VERBATIM from the shipped code (the whitebox contract) ──────────────
+// ERP erp/idempiere.html _zoomScope(pp_order) + the 'timemachine' launch URL.
+function zoomScopePPOrder(ppId) {
+  const r = rows(`SELECT PP_Order_ID, C_Project_ID FROM PP_Order WHERE PP_Order_ID=${ppId}`);
+  if (!r.length) return null;
+  const pProj = r[0][1];
+  if (pProj === '' || pProj == null || Number(pProj) < 990000) return null;     // BIM band only
+  const pr = rows(`SELECT value FROM c_project WHERE c_project_id=${Number(pProj)}`);
+  if (!pr.length || !pr[0][0]) return null;
+  return { bld: String(pr[0][0]), find: null, tm: { order: Number(ppId) } };
+}
+function launchUrl(sc) {
+  const home = encodeURIComponent('https://x/erp/idempiere.html');
+  return '../viewer/viewer.html?db=../buildings/' + encodeURIComponent(sc.bld) + '_extracted.db&bld=' +
+    encodeURIComponent(sc.bld) + '&home=' + home + '&tm=1&pporder=' + encodeURIComponent(sc.tm.order);
+}
+// TM viewer/time_machine.js tmJumpToOrder cursor resolver (the doJump math, pure slice).
+function resolveCursor(info, ops, projectStart, projectEnd) {
+  const phase = String(info.desc || '').split(' — ')[0].trim();
+  let s = Infinity, e = -Infinity;
+  for (const op of ops) {
+    const ph = (op.parameters || {}).phase || 'Architecture';
+    if (ph === phase) { if (op.start_ts < s) s = op.start_ts; if (op.end_ts > e) e = op.end_ts; }
+  }
+  if (isFinite(s)) return { phase, mode: 'phase', cursor: s };
+  let frac = 0.5;
+  if (isFinite(info.spanMin) && isFinite(info.spanMax) && info.spanMax > info.spanMin && isFinite(info.end))
+    frac = Math.max(0, Math.min(1, (info.end - info.spanMin) / (info.spanMax - info.spanMin)));
+  return { phase, mode: 'projected', cursor: projectStart + frac * (projectEnd - projectStart), frac };
+}
+function orderInfo(ppId) {
+  const r = rows(`SELECT Description, DateStartSchedule, DateFinishSchedule, C_Project_ID FROM PP_Order WHERE PP_Order_ID=${ppId}`);
+  if (!r.length) return null;
+  const pid = r[0][3];
+  const cost = Number(q(`SELECT COALESCE(SUM(CumulatedAmt),0) FROM PP_Order_Cost WHERE PP_Order_ID=${ppId}`) || 0);
+  const sp = rows(`SELECT MIN(o.DateFinishSchedule), MAX(o.DateFinishSchedule) FROM PP_Order o JOIN PP_Order_Cost oc ON o.PP_Order_ID=oc.PP_Order_ID WHERE o.C_Project_ID=${Number(pid)}`)[0];
+  return { desc: r[0][0], start: Date.parse(r[0][1]), end: Date.parse(r[0][2]), cost,
+           spanMin: Date.parse(sp[0]), spanMax: Date.parse(sp[1]) };
+}
+
+S('§W-PPZOOM-TM — PP_Order Zoom-Across → BIM Viewer TimeMachine (whitebox, real ad_seed.db; live visual deferred)');
+
+// pick a real Hospital order (Superstructure has a distinct phase token + nonzero cost)
+const ORD = Number(q(`SELECT PP_Order_ID FROM PP_Order WHERE C_Project_ID=990000 AND Description LIKE 'Superstructure%' ORDER BY PP_Order_ID LIMIT 1`));
+S('  · chosen Hospital order PP_Order_ID=' + ORD + ' (' + q(`SELECT Description FROM PP_Order WHERE PP_Order_ID=${ORD}`) + ')');
+
+// A — ERP scope fold
+const sc = zoomScopePPOrder(ORD);
+ok(!!sc && sc.bld === 'Hospital' && sc.tm && sc.tm.order === ORD,
+   'A — _zoomScope(pp_order) resolves the building + TM order by identity', sc ? `bld=${sc.bld} tm.order=${sc.tm.order}` : 'null');
+
+// B — launch URL
+const url = sc ? launchUrl(sc) : '';
+ok(/[?&]tm=1(&|$)/.test(url) && url.indexOf('pporder=' + ORD) !== -1 && url.indexOf('bld=Hospital') !== -1,
+   'B — timemachine launch URL carries tm=1 & pporder & bld', url);
+
+// C — phase token extracted from Description
+const info = orderInfo(ORD);
+const phaseTok = String(info.desc || '').split(' — ')[0].trim();
+ok(phaseTok === 'Superstructure', 'C — phase token EXTRACTED from Description (not invented)', `phase="${phaseTok}"`);
+
+// D — mode=phase: synthetic axis [0,5000] with a Superstructure op window [1000,2000]
+const opsHit = [
+  { start_ts: 100, end_ts: 900, parameters: { phase: 'Substructure' } },
+  { start_ts: 1000, end_ts: 2000, parameters: { phase: 'Superstructure' } },
+  { start_ts: 2100, end_ts: 4000, parameters: { phase: 'Finishes' } }
+];
+const rD = resolveCursor(info, opsHit, 0, 5000);
+ok(rD.mode === 'phase' && rD.cursor === 1000, 'D — mode=phase lands cursor at the phase winStart', `mode=${rD.mode} cursor=${rD.cursor}`);
+
+// E — mode=projected: axis [PS,PE] with NO Superstructure op (Hospital geom in OPFS reality)
+const PS = 1_000_000, PE = 9_000_000;
+const opsMiss = [{ start_ts: PS, end_ts: 2_000_000, parameters: { phase: 'Architecture' } }];
+const rE = resolveCursor(info, opsMiss, PS, PE);
+const fracExpect = Math.max(0, Math.min(1, (info.end - info.spanMin) / (info.spanMax - info.spanMin)));
+const curExpect = PS + fracExpect * (PE - PS);
+ok(rE.mode === 'projected' && isFinite(rE.cursor) && rE.cursor >= PS && rE.cursor <= PE && Math.abs(rE.cursor - curExpect) < 1,
+   'E — mode=projected maps order finish onto the construction axis, finite & in-range', `mode=${rE.mode} frac=${rE.frac.toFixed(3)} cursor=${Math.round(rE.cursor)}`);
+
+// F — cost Σ
+ok(info.cost > 0, 'F — order PP_Order_Cost Σ CumulatedAmt > 0 (the S-curve fold)', 'Σ=' + Math.round(info.cost));
+
+// G — non-BIM-band order resolves no scene
+const demo = Number(q(`SELECT PP_Order_ID FROM PP_Order WHERE COALESCE(C_Project_ID,0)<990000 ORDER BY PP_Order_ID LIMIT 1`));
+ok(zoomScopePPOrder(demo) === null, 'G — non-BIM-band order (demo) resolves NO scene (pure otherwise)', 'demo order=' + demo);
+
+const verdict = `§RESULT W-PPZOOM-TM  ${pass}/${pass + fail}  ${fail ? 'FAIL' : 'PASS'}`;
+S(''); S(verdict);
+fs.writeFileSync(path.join(__dirname, 'test_pp_zoom_tm.log'), log.join('\n') + '\n');
+process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3657,16 +3657,22 @@
 
     setTimeout(hookCommitOp, 2000);
 
-    // URL param: ?tm=1 (open time machine) or ?tm=play (open + auto-play forward)
-    var tmParam = new URLSearchParams(location.search).get('tm');
-    if (tmParam) {
+    // URL param: ?tm=1 (open time machine) · ?tm=play (open + auto-play forward) ·
+    //   ?pporder=<id> (PP_ORDER_ZOOM_TM_SPEC §B — deep-link to a manufacturing order's moment; implies tm=1).
+    var _sp = new URLSearchParams(location.search);
+    var tmParam = _sp.get('tm');
+    var ppParam = _sp.get('pporder');
+    if (tmParam || ppParam) {
       // Wait for DB to load before activating
       var _tmWait = setInterval(function() {
         var app = A();
         if (app && app.db && app.scene && app.buildingsRendered && app.buildingsRendered.size > 0 && !app.streaming) {
           clearInterval(_tmWait);
           activate();
-          if (tmParam === 'play') {
+          if (ppParam) {
+            try { window.tmJumpToOrder(ppParam); }                  // straight to the order's construction moment
+            catch (e) { console.log('§TM_ORDER_JUMP deeplink-err ' + e); }
+          } else if (tmParam === 'play') {
             // Jump to start then play forward
             _cursor = _projectStart;
             renderAtTime(_cursor);
@@ -3754,6 +3760,80 @@
     if (_active) return Promise.resolve(doJump());
     var p = activate();
     return (p && p.then) ? p.then(function () { return doJump(); }) : Promise.resolve(doJump());
+  };
+
+  // PP_ORDER_ZOOM_TM_SPEC §B — land the TM at a manufacturing/project order's construction moment. The order
+  // reaches us by IDENTITY (?pporder= / ERP Zoom-Across, never a bespoke link): PP_Order → its phase (the
+  // Description token "<Phase> — <CREW>", the shared key with the gantt phase windows) → the cursor. The shopfloor
+  // S-curve (dashboard) + the ⚖ variance drawer couple to the frozen frame. Honest mode: 'phase' when that phase
+  // has ops on the loaded scene's axis; else 'projected' — the order's finish date mapped onto
+  // [_projectStart,_projectEnd] by its position in the shopfloor span (labelled, never blurred). Returns
+  // Promise<bool>. Whitebox §-log = the proof (the Hospital scene's geom lives in OPFS → live VISUAL deferred).
+  window.tmJumpToOrder = function (ppOrderId) {
+    ppOrderId = Number(ppOrderId);
+    var app = A();
+    var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
+    function fetchOrder() {
+      if (!SQL) { console.log('§TM_ORDER_JUMP skip=no-SQL order=' + ppOrderId); return Promise.resolve(null); }
+      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+        var db = new SQL.Database(new Uint8Array(buf));
+        var r = db.exec('SELECT Description, DateStartSchedule, DateFinishSchedule, C_Project_ID FROM PP_Order WHERE PP_Order_ID=' + ppOrderId);
+        if (!r.length || !r[0].values.length) { db.close(); return null; }
+        var row = r[0].values[0], pid = row[3];
+        var c = db.exec('SELECT COALESCE(SUM(CumulatedAmt),0) FROM PP_Order_Cost WHERE PP_Order_ID=' + ppOrderId);
+        // shopfloor finish-date span (the same orders the S-curve folds) → the projected-mode axis
+        var sp = db.exec('SELECT MIN(o.DateFinishSchedule), MAX(o.DateFinishSchedule) FROM PP_Order o' +
+          ' JOIN PP_Order_Cost oc ON o.PP_Order_ID=oc.PP_Order_ID WHERE o.C_Project_ID=' + Number(pid));
+        db.close();
+        return { desc: row[0], start: Date.parse(row[1]), end: Date.parse(row[2]),
+                 cost: (c.length && c[0].values.length) ? Number(c[0].values[0][0]) : 0,
+                 spanMin: (sp.length && sp[0].values.length) ? Date.parse(sp[0].values[0][0]) : NaN,
+                 spanMax: (sp.length && sp[0].values.length) ? Date.parse(sp[0].values[0][1]) : NaN };
+      }).catch(function (e) { console.log('§TM_ORDER_JUMP fetch-err ' + e.message); return null; });
+    }
+    function doJump(info) {
+      if (!info) { console.log('§TM_ORDER_JUMP miss order=' + ppOrderId + ' (no PP_Order row)'); return false; }
+      if (!_ops.length) { console.log('§TM_ORDER_JUMP skip=no-ops order=' + ppOrderId); return false; }
+      var phase = String(info.desc || '').split(' — ')[0].trim();   // — = em-dash, the generator's token sep
+      var s = Infinity, e = -Infinity;                                    // mode=phase: this phase's window on the axis
+      for (var i = 0; i < _ops.length; i++) {
+        var ph = (_ops[i].parameters || {}).phase || 'Architecture';
+        if (ph === phase) { if (_ops[i].start_ts < s) s = _ops[i].start_ts; if (_ops[i].end_ts > e) e = _ops[i].end_ts; }
+      }
+      var mode;
+      if (isFinite(s)) { _cursor = s; mode = 'phase'; }
+      else {                                                             // mode=projected: order finish → axis position
+        var frac = 0.5;
+        if (isFinite(info.spanMin) && isFinite(info.spanMax) && info.spanMax > info.spanMin && isFinite(info.end))
+          frac = Math.max(0, Math.min(1, (info.end - info.spanMin) / (info.spanMax - info.spanMin)));
+        _cursor = _projectStart + frac * (_projectEnd - _projectStart);
+        mode = 'projected';
+      }
+      renderAtTime(_cursor);
+      try { anchorFromCursor(); } catch (x) {}
+      try { configSlider(); } catch (x) {}
+      if (_twin && !_varVisible) {                                       // couple the 5D cost story (⚖ drawer)
+        _varVisible = true;
+        var vb = document.getElementById('tm-var'); if (vb) vb.classList.add('tm-active');
+        var vx = document.getElementById('tm-var-box'); if (vx) vx.classList.add('open');
+        drawVariance();
+      }
+      if (!_dashVisible) { _dashVisible = true; try { toggleDashDOM(true); } catch (x) {} }
+      try { drawDashboard(); } catch (x) {}                             // drawDashboard lazy-loads the shopfloor S-curve
+      var pct = Math.round((_cursor - _projectStart) / Math.max(1, _projectEnd - _projectStart) * 100);
+      console.log('§TM_ORDER_JUMP order=' + ppOrderId + ' phase="' + phase + '" mode=' + mode +
+        ' cursor=' + Math.round(_cursor) + ' at=' + (isFinite(_cursor) ? new Date(_cursor).toISOString().slice(0, 10) : '—') +
+        ' cost=' + Math.round(info.cost) + ' built~' + pct + '%');
+      return true;
+    }
+    function whenReady() {                                              // activate() is async → wait for the op-log
+      return new Promise(function (resolve) {
+        if (_active && _ops.length) { resolve(); return; }
+        if (!_active) activate();
+        var n = 0, iv = setInterval(function () { if (_ops.length || ++n > 60) { clearInterval(iv); resolve(); } }, 500);
+      });
+    }
+    return whenReady().then(fetchOrder).then(doJump);
   };
 
   // S265 Phase 3: Expose TM state for share URL

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -881,7 +881,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=53" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=54" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
## What
Completes the **360 loop from the manufacturing/project-order side**. A `PP_Order`'s red-pill Zoom-Across now lands the **BIM Viewer TimeMachine** at that order's construction moment, with the shopfloor S-curve + ⚖ variance drawer coupled. One identity (`PP_Order_ID → C_Project_ID → phase`), four folds. Spec: `prompts/PP_ORDER_ZOOM_TM_SPEC.md`.

## How
**ERP (`erp/idempiere.html`)**
- `_zoomScope()` resolves a BIM-band `PP_Order` → `{bld, tm:{order}}` purely by identity (no bespoke link).
- New `ZoomAcross.register({id:'timemachine', label:'BIM TimeMachine', …})` — the **same red pill** (`#pill-zoomacross`); with 2+ targets the existing "Zoom across to…" chooser appears. Launch → `viewer.html?…&tm=1&pporder=<id>`.

**Viewer/TM (`viewer/time_machine.js`)**
- `window.tmJumpToOrder(id)`: phase token **extracted** from `PP_Order.Description` ("\<Phase\> — \<CREW\>", the shared gantt-phase key). Cursor lands `mode=phase` when that phase has ops on the loaded scene axis, else `mode=projected` (order finish mapped onto `[_projectStart,_projectEnd]` — honestly labelled, never blurred). Opens the ⚖ drawer + shopfloor S-curve. Logs `§TM_ORDER_JUMP`.
- `?pporder` deep-link wired into the existing `?tm` init path.

**Seed** — re-baked the S4 E1 shopfloor onto main's `ad_seed.db` (idempotent, deterministic): **18 PP_Order / 64 PP_Order_Cost**. main carried the `_loadShopfloor` code but only 2 demo orders — this lands the data it expects. W-SHOP-PERSIST 10/10.

## Proof (whitebox §-log — Hospital geom lives in OPFS, live visual deferred)
`viewer/tests/test_pp_zoom_tm.js` → **W-PPZOOM-TM 7/7 PASS**: scope fold, launch URL (`tm=1&pporder`), phase extraction, both cursor modes, cost Σ (=12,288,421 for the sampled order), non-BIM-band guard.

## sw
erp `v737→v738` (idempiere.html), viewer `v687→v688` + `time_machine.js?v=54`. `ad_seed.db` skips the SW (served fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)