### PR TITLE
feat(tm): E3 schedule-vs-actual — projected-from-cost date variance (W-SHOP-DATES 9/9)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v690';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v691';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/test_shop_dates.js
+++ b/viewer/tests/test_shop_dates.js
@@ -1,0 +1,83 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness for TM_4D5D §S4 E3 — "PP schedule-vs-actual = real op date variance" (W-SHOP-DATES).
+//   DOCTRINE (TM_4D5D §S3/§4): there is NO actual-date column to read (PP_Order.DateStart/DateFinish are NULL by
+//   design) → the schedule slip is a PROJECTION FROM COST, never an invented actual date: slip = planned-duration
+//   × (r−1), r = CommittedAmt/PlannedAmt (the real twin). Planned durations are REAL columns. Proves, against the
+//   real erp/ad_seed.db:
+//     A — per-PHASE planned duration reads from C_ProjectPhase.StartDate/EndDate (real, >0).
+//     B — per-PHASE r = CommittedAmt/PlannedAmt (real twin); slip = round(durDays×(r−1)) deterministic.
+//     C — honest MIXED signs: Superstructure slips LATE (+, cost +60% marquee); MEP Rough-in & Finishes slip
+//         EARLY (−, cost under) — never all-one-way.
+//     D — per-ORDER (real op) variance: each PP_Order's planned dur from its OWN DateStartSchedule/Finish; a
+//         Superstructure order's slip uses its phase r and is LATE.
+//     E — NO actual-date invented: PP_Order.DateStart/DateFinish remain NULL (the projection writes nothing).
+//     F — project rollup: rProj = project Committed/Planned; projSlip = round(projDur×(rProj−1)), finite, LATE
+//         (the +35% project overrun).
+//   Each assertion NAMES the issue. §-log first — READ test_shop_dates.log before concluding.
+// Run:  node viewer/tests/test_shop_dates.js          (exit 0 = PASS)
+'use strict';
+const { execFileSync } = require('child_process');
+const fs = require('fs'), path = require('path');
+const DB = path.join(__dirname, '..', '..', 'erp', 'ad_seed.db');
+const q = (sql) => execFileSync('sqlite3', [DB, sql], { encoding: 'utf8' }).trim();
+const rows = (sql) => q(sql).split('\n').filter(Boolean).map(l => l.split('|'));
+const DAY = 86400000;
+
+const log = []; let pass = 0, fail = 0;
+const S = (m) => { log.push(m); console.log(m); };
+const ok = (cond, label, detail) => { if (cond) pass++; else fail++; S('  ' + (cond ? 'PASS' : 'FAIL') + ' ' + label + (detail ? ' — ' + detail : '')); };
+
+// projection replicated VERBATIM from time_machine.js _computeScheduleProjection (the whitebox contract)
+const slip = (startMs, endMs, planned, committed) => {
+  const durDays = (isFinite(startMs) && isFinite(endMs) && endMs > startMs) ? Math.round((endMs - startMs) / DAY) : 0;
+  const r = planned > 0 ? committed / planned : 1;
+  return { durDays, r, slipDays: Math.round(durDays * (r - 1)) };
+};
+
+S('§W-SHOP-DATES — PP schedule-vs-actual = real op date variance (whitebox, projected-from-cost, real ad_seed.db)');
+
+// real twin phases (skip the empty 'Unsequenced')
+const ph = rows(`SELECT Name, StartDate, EndDate, PlannedAmt, CommittedAmt FROM C_ProjectPhase WHERE C_Project_ID=990000 AND PlannedAmt>0 ORDER BY SeqNo`)
+  .map(r => ({ name: r[0], start: Date.parse(r[1]), end: Date.parse(r[2]), planned: +r[3], committed: +r[4] }));
+ok(ph.length >= 5, 'twin has the real phases', 'phases=' + ph.length);
+
+// A — per-phase planned duration from real date columns
+const durOk = ph.every(p => slip(p.start, p.end, p.planned, p.committed).durDays > 0);
+ok(durOk, 'A — per-phase planned duration reads from C_ProjectPhase.StartDate/EndDate (real, >0)',
+   ph.map(p => p.name + ':' + slip(p.start, p.end, p.planned, p.committed).durDays + 'd').join(', '));
+
+// B — slip deterministic from r (run twice → identical)
+const run1 = ph.map(p => slip(p.start, p.end, p.planned, p.committed).slipDays).join(',');
+const run2 = ph.map(p => slip(p.start, p.end, p.planned, p.committed).slipDays).join(',');
+ok(run1 === run2, 'B — slip = round(durDays×(r−1)) is deterministic (byte-identical across runs)', run1);
+
+// C — honest mixed signs
+const get = (n) => ph.find(p => p.name === n);
+const sSup = slip(get('Superstructure').start, get('Superstructure').end, get('Superstructure').planned, get('Superstructure').committed);
+const sMep = get('MEP Rough-in') ? slip(get('MEP Rough-in').start, get('MEP Rough-in').end, get('MEP Rough-in').planned, get('MEP Rough-in').committed) : null;
+const sFin = get('Finishes') ? slip(get('Finishes').start, get('Finishes').end, get('Finishes').planned, get('Finishes').committed) : null;
+ok(sSup.slipDays > 0, 'C1 — Superstructure slips LATE (cost +60% marquee)', '+' + sSup.slipDays + 'd (r=' + sSup.r.toFixed(3) + ')');
+ok(sMep && sMep.slipDays < 0, 'C2 — MEP Rough-in slips EARLY (cost under)', sMep ? sMep.slipDays + 'd (r=' + sMep.r.toFixed(3) + ')' : 'absent');
+ok(sFin && sFin.slipDays < 0, 'C3 — Finishes slips EARLY (cost under) — mixed signs, not all-one-way', sFin ? sFin.slipDays + 'd (r=' + sFin.r.toFixed(3) + ')' : 'absent');
+
+// D — per-ORDER (real op) variance: a Superstructure PP_Order, planned dur from ITS OWN schedule columns
+const o = rows(`SELECT PP_Order_ID, DateStartSchedule, DateFinishSchedule FROM PP_Order WHERE C_Project_ID=990000 AND Description LIKE 'Superstructure%' ORDER BY PP_Order_ID LIMIT 1`)[0];
+const oSlip = slip(Date.parse(o[1]), Date.parse(o[2]), get('Superstructure').planned, get('Superstructure').committed);
+ok(oSlip.durDays > 0 && oSlip.slipDays > 0,
+   'D — per-ORDER planned dur from PP_Order.DateStartSchedule/Finish; slip LATE via its phase r',
+   `order=${o[0]} dur=${oSlip.durDays}d slip=+${oSlip.slipDays}d`);
+
+// E — no invented actual date: actuals stay NULL
+const nulls = q(`SELECT COUNT(*) FROM PP_Order WHERE C_Project_ID=990000 AND (DateStart IS NOT NULL OR DateFinish IS NOT NULL)`);
+ok(Number(nulls) === 0, 'E — NO actual-date invented: PP_Order.DateStart/DateFinish stay NULL (projected from cost)', 'non-null actuals=' + nulls);
+
+// F — project rollup
+const proj = rows(`SELECT MIN(StartDate), MAX(EndDate), SUM(PlannedAmt), SUM(CommittedAmt) FROM C_ProjectPhase WHERE C_Project_ID=990000 AND PlannedAmt>0`)[0];
+const pSlip = slip(Date.parse(proj[0]), Date.parse(proj[1]), +proj[2], +proj[3]);
+ok(pSlip.slipDays > 0 && isFinite(pSlip.slipDays), 'F — project rollup slips LATE (the +35% overrun), finite',
+   `rProj=${pSlip.r.toFixed(3)} projDur=${pSlip.durDays}d projSlip=+${pSlip.slipDays}d`);
+
+const verdict = `§RESULT W-SHOP-DATES  ${pass}/${pass + fail}  ${fail ? 'FAIL' : 'PASS'}`;
+S(''); S(verdict);
+fs.writeFileSync(path.join(__dirname, 'test_shop_dates.log'), log.join('\n') + '\n');
+process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2819,6 +2819,29 @@
     for (var i = 0; i < V.phases.length; i++) { var p = V.phases[i]; if (_cursor >= p.winStart && _cursor <= p.winEnd) return i; }
     return -1;
   }
+  // E3 / W-SHOP-DATES — the 4D counterpart to the 5D cost Δ. DOCTRINE (TM_4D5D §S3/§4): there is NO actual-date
+  // column to read (PP_Order.DateStart/DateFinish are NULL by design), so the schedule slip is a PROJECTION FROM
+  // COST — never an invented actual date: slip = planned-duration × (r−1), r = CommittedAmt/PlannedAmt (the real
+  // twin). Planned durations are REAL (C_ProjectPhase.StartDate/EndDate, per-order PP_Order.DateStartSchedule/
+  // Finish). Honestly labelled "projected from cost". Ripple/dependency is S6 — phases project INDEPENDENTLY here.
+  var _DAY = 86400000;
+  function _computeScheduleProjection(V) {
+    if (!V) return null;
+    var phases = V.phases.map(function (p) {
+      var durDays = (isFinite(p.startDate) && isFinite(p.endDate) && p.endDate > p.startDate)
+        ? Math.round((p.endDate - p.startDate) / _DAY) : 0;
+      var r = p.pCost > 0 ? p.aCost / p.pCost : 1;
+      var slipDays = Math.round(durDays * (r - 1));            // +late / −early, mirrors the cost over/under sign
+      return { phase: p.phase, durDays: durDays, r: r, slipDays: slipDays,
+               projEnd: isFinite(p.endDate) ? p.endDate + slipDays * _DAY : NaN, marquee: p.marquee };
+    });
+    var projDurDays = (isFinite(V.plannedStart) && isFinite(V.plannedEnd) && V.plannedEnd > V.plannedStart)
+      ? Math.round((V.plannedEnd - V.plannedStart) / _DAY) : 0;
+    var rProj = V.tP > 0 ? V.tA / V.tP : 1;                    // project-level ratio (no phase compounding = no ripple)
+    var projSlipDays = Math.round(projDurDays * (rProj - 1));
+    return { phases: phases, projDurDays: projDurDays, rProj: rProj, projSlipDays: projSlipDays,
+             projEnd: isFinite(V.plannedEnd) ? V.plannedEnd + projSlipDays * _DAY : NaN };
+  }
   function drawVariance() {
     if (!_ops.length) return;
     if (!_opsPlanned) _opsPlanned = _ops.slice();          // first open: snapshot the planned timeline (phase windows)
@@ -2832,6 +2855,9 @@
     if (!V) { if (head) head.innerHTML = '<b style="color:#4fc3f7">Budget vs Actual</b><div style="margin-top:2px;color:#888">No project records for this model</div>'; return; }
     var fmtD = function (ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '—'; };
     var curIdx = _varPhaseUnderCursor(V);
+    var SP = _computeScheduleProjection(V);                     // E3 — the projected-from-cost schedule slip (4D Δ)
+    var slipColor = function (d) { return d >= 0 ? '#ff6b6b' : '#26a69a'; };
+    var slipTxt = function (d) { return (d >= 0 ? '+' : '') + d + ' d'; };
 
     // header — the headline COST pair (READ from the twin) + the planned schedule span. Honest labels:
     // cost Δ is "from records"; the date span is the planned baseline (no actual-date column yet → §S3).
@@ -2846,7 +2872,10 @@
           '<span style="color:' + (V.dCost >= 0 ? '#ff6b6b' : '#26a69a') + '">(' + (V.dCost >= 0 ? '+' : '') + V.pctOver + '%, ' +
           (V.dCost >= 0 ? '+' : '') + _money(V.dCost) + ')</span></div>' +
         '<div style="color:#9fd6ff">Schedule ' + fmtD(V.plannedStart) + ' → ' + fmtD(V.plannedEnd) +
-          ' <span style="color:#888">(planned baseline)</span></div>';
+          ' <span style="color:#888">(planned baseline)</span></div>' +
+        (SP ? '<div style="color:#ffb74d">Projected finish ' + fmtD(SP.projEnd) +
+          ' <span style="color:' + slipColor(SP.projSlipDays) + '">(' + slipTxt(SP.projSlipDays) + ')</span>' +
+          ' <span style="color:#888">projected from cost</span></div>' : '');
     }
 
     // canvas — one bar per phase on the SAME axis the cursor scrubs; bar color = phase, edge cap red/green by
@@ -2895,15 +2924,20 @@
       V.phases.forEach(function (p, i) {
         var dc = (p.dCost >= 0 ? '+' : '') + _money(p.dCost);
         var col = p.dCost > 0 ? '#ff6b6b' : '#26a69a';
+        var sp = SP ? SP.phases[i] : null;                      // E3 — the per-phase projected schedule slip
+        var spTxt = sp ? ' <span style="color:' + slipColor(sp.slipDays) + '" title="projected from cost">' + slipTxt(sp.slipDays) + '</span>' : '';
         html += '<div style="display:flex;justify-content:space-between;gap:6px' + (i === curIdx ? ';color:#fff;font-weight:bold' : '') + '">' +
           '<span>' + (p.marquee ? '⚠ ' : '') + p.phase + '</span>' +
-          '<span style="color:' + col + '">' + dc + ' (' + (p.pct >= 0 ? '+' : '') + p.pct + '%)</span></div>';
+          '<span style="color:' + col + '">' + dc + ' (' + (p.pct >= 0 ? '+' : '') + p.pct + '%)' + spTxt + '</span></div>';
       });
       list.innerHTML = html;
     }
     console.log('§TM_VARIANCE source=twin building="' + _twin.building + '" phases=' + V.phases.length +
       ' plannedCost=' + V.tP + ' committedCost=' + V.tA + ' over=' + V.pctOver + '% curPhase=' +
       (curIdx >= 0 ? V.phases[curIdx].phase : '-'));
+    if (SP) console.log('§SCHED_PROJECT source=projected-from-cost building="' + _twin.building +
+      '" projEnd=' + fmtD(SP.projEnd) + ' projSlipDays=' + SP.projSlipDays + ' rProj=' + SP.rProj.toFixed(3) +
+      ' phases=' + SP.phases.map(function (x) { return x.phase + ':' + (x.slipDays >= 0 ? '+' : '') + x.slipDays + 'd'; }).join(','));
   }
 
   function drawGanttMini() {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -881,7 +881,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=54" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=55" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
## What
The **4D counterpart** to the 5D cost Δ in the ⚖ variance drawer — the last leg of §S4 (`TM_4D5D_VARIANCE_LANE`).

Per **doctrine** (TM_4D5D §S3/§4) there is **no actual-date column to read** — `PP_Order.DateStart/DateFinish` are NULL by design — so the schedule slip is a **projection from cost**, never an invented actual date:

```
slip = planned-duration × (r − 1),   r = CommittedAmt / PlannedAmt   (the real twin)
```

Planned durations are **real** columns (`C_ProjectPhase.StartDate/EndDate`; per-order `PP_Order.DateStartSchedule/Finish`). Honestly labelled **"projected from cost"**. Phases project **independently** — dependency ripple is S6.

## How (`viewer/time_machine.js`)
- `_computeScheduleProjection(V)`: per-phase `{durDays, r, slipDays, projEnd}` + a project rollup (`rProj`, `projSlipDays`, `projEnd`) from the **project** ratio (no phase compounding = no ripple).
- `drawVariance`: header gains `Projected finish <date> (+N d) projected from cost`; each per-phase row gains its slip chip (red late / green early). Logs `§SCHED_PROJECT`.

## Proof (whitebox §-log — Hospital geom in OPFS, live visual deferred)
`viewer/tests/test_shop_dates.js` → **W-SHOP-DATES 9/9 PASS**. Honest **mixed** signs:
- Superstructure **+188 d** (marquee, cost +60%)
- MEP Rough-in **−16 d** & Finishes **−2 d** (early)
- project rollup **+373 d** (+35% overrun)
- `E` — no actual date invented (`PP_Order.DateStart/DateFinish` stay NULL).

## sw
viewer `v690→v691` + `time_machine.js?v=55`. No ERP file / seed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)