### PR TITLE
feat(erp): surface the Pivot LENS on the ⋯ pill rail (W-PIVOT-PILL 13/13)

### DIFF
--- a/erp/icons.js
+++ b/erp/icons.js
@@ -26,6 +26,7 @@
     lightbulb: { svg: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>' },
     circleHelp: { svg: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>' },
     grid: { svg: '<path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/>' },
+    table: { svg: '<path d="M12 3v18"/><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/>' },
     // POS_ADDON_SPEC §P-1 — Lucide shopping-cart, verbatim (the POS lens pill).
     shoppingCart: { svg: '<circle cx="8" cy="21" r="1"/><circle cx="19" cy="21" r="1"/><path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"/>' },
     // POS_KILLER_DEMO §LAYOUT.1 — Lucide image, verbatim (album card photo-less placeholder glyph).

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -501,7 +501,7 @@
 <script src="erp_preview.js?v=2"></script>
 <!-- CONSISTENCY_FINISH.md §K-1/§K-2 — icons.js (verbatim glyph DATA) + the shared overlay kit load BEFORE
      the import overlays (migrate_showme builds its STEPS at module load and renders Lucide icons). -->
-<script src="icons.js?v=11"></script>
+<script src="icons.js?v=12"></script>
 <script src="overlay_kit.js?v=1"></script>
 <!-- PLUGIN_SYSTEM_LANE.md §Phase A/D — the Fold-Engine plugin host (W-PLUGIN) + its pill overlay. ad_callout.js
      gives callout-contributing bundles a live target (it joins ad_modelval/ad_process/post_resolver already loaded). -->
@@ -565,7 +565,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
 <script src="pill_builder.js?v=4"></script>
 <script src="../viewer/connect_scene.js?v=1"></script><!-- §CONNECT-ERP: shared Connect bus (BroadcastChannel+postMessage); ERP registers as 'erp' on first Zoom-Across launch -->
 <script src="zoom_across.js?v=1"></script>
-<script src="idmp_pills.js?v=14"></script>
+<script src="idmp_pills.js?v=15"></script>
 <!-- §B ERP_BOTTOM_BAR — cross-tab history scrubber (Glassbowl #scrub pattern): records semantic nav moments
      across the window tabs; double-tap blooms chips; dot click = read-only restore (never mutates the op-log). -->
 <script src="../common/history_tap.js?v=6" onerror="console.warn('§IDMP-HIST-TAP history_tap.js absent — bar runs without view-depth')"></script>
@@ -3199,6 +3199,19 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     if (!pub) return false;
     _kanbanProj = pub.projDb; return true;
   }
+  // RESUME_360_KANBAN_PIVOT item 3 — surface the cross-tab Pivot LENS from the ⋯ rail (sibling to kanban/graph).
+  //   pivot_lens.html is a self-contained lens (loads sql.js + ?db=); host it as an IN-PAGE overlay iframe so the
+  //   iDempiere surface stays put (FUNDAMENTAL LAW: lenses live on the ⋯ rail, never the native chrome). Points
+  //   at the live tenant seed (ad_seed.db, same dir as pivot_lens.html). General table×row×col×measure, read-only.
+  function openPivotFor() {
+    if (!_session) { status('Log in first'); return; }
+    var fr = el('iframe');
+    fr.src = 'pivot_lens.html?db=ad_seed.db';
+    fr.style.cssText = 'width:100%;height:82vh;border:0;border-radius:10px;background:#0f1420';
+    fr.setAttribute('title', 'Pivot lens');
+    _overlay('Pivot — table × row × column × measure', fr);
+    console.log('§PIVOT-PILL opened src=' + fr.src);
+  }
   async function openKanbanFor() {
     if (!_session) { status('Log in first'); return; }
     var gr = _groupRecs(); if (!gr) { status('Open a window with records first'); return; }
@@ -3429,7 +3442,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   window.IdmpPosting = { posted: openPostedFor, preview: openPreviewFor, affordance: _openPostedAffordance };
   function mountPillRegistry() {
     window.IdmpPillActions = {
-      graph: openGraphFor, kanban: openKanbanFor,
+      graph: openGraphFor, kanban: openKanbanFor, pivot: openPivotFor,
       rule: openRuleFor, pos: openPosFor,
       share: _shareCurrent, home: function () { location.href = '../index.html?home=1'; },   // "Exit" → the Matrix landing (app-shell front door), RESUME_IDMP_FIDELITY leg 2
       erpdoc: openReadCompare,

--- a/erp/idmp_pills.js
+++ b/erp/idmp_pills.js
@@ -184,7 +184,7 @@
     if (!window.PillBuilder) { console.warn('§IDMP-PILLS PillBuilder missing — not mounted'); return; }
     if (document.getElementById('idmp-pillbar')) return;     // idempotent (one bar)
 
-    fetch('pills_idmp.json?v=35').then(function (r) { return r.json(); }).then(function (mf) {
+    fetch('pills_idmp.json?v=36').then(function (r) { return r.json(); }).then(function (mf) {
       var pills = (mf.pills || []).slice().sort(function (a, b) { return (a.order || 0) - (b.order || 0); });
       var ACT = window.IdmpPillActions || {};
 

--- a/erp/pills_idmp.json
+++ b/erp/pills_idmp.json
@@ -39,6 +39,14 @@
       "note": "draggable wfmc board / heat-map fallback (openKanbanFor) — board-columns layout glyph."
     },
     {
+      "id": "pivot",
+      "name": "Pivot",
+      "key": "",
+      "icon": "table",
+      "order": 3.5,
+      "note": "RESUME_360_KANBAN_PIVOT item 3 — the cross-tab Pivot LENS (openPivotFor → in-page overlay iframe of erp/pivot_lens.html?db=ad_seed.db). General engine: any table × row × col × measure (count|GrandTotal|Qty), read-only; cell click = §PIVOT-DRILL + Zoom-Across entry (decision #3). A LENS on the ⋯ rail (FUNDAMENTAL LAW — never native chrome), sibling to kanban/graph. Lucide table glyph (verbatim from panels.js ICONS)."
+    },
+    {
       "id": "rule",
       "name": "Rule",
       "key": "",

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v738';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v739';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/test_pivot_pill.js
+++ b/erp/tests/test_pivot_pill.js
@@ -1,0 +1,67 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness for RESUME_360_KANBAN_PIVOT item 3 — "surface pivot_lens on the ⋯ pill rail"
+//   (W-PIVOT-PILL). The Pivot LENS becomes reachable from the ⋯ rail, sibling to kanban/graph, never on the
+//   native iDempiere chrome (FUNDAMENTAL LAW). Structural (no browser) — the §-log + these asserts are the proof;
+//   a live pill-presence shot is the secondary Playwright leg. Proves, against the shipped source:
+//     A — pills_idmp.json registers a 'pivot' pill (icon 'table', a numeric order, name) on the rail.
+//     B — the 'table' glyph is NON-INVENT: byte-verbatim in icons.js AND its panels.js source (no drift).
+//     C — idempiere.html wires IdmpPillActions.pivot → openPivotFor, which opens pivot_lens.html?db=ad_seed.db
+//         as an in-page overlay (the lens stays on-surface) and logs §PIVOT-PILL.
+//     D — the lens target pivot_lens.html EXISTS and consumes a ?db= param (a real page, not a dead link).
+//     E — the freshness bumps are in place (erp sw, icons.js?v, pills_idmp.json?v, panels.js?v, viewer sw).
+//   Each assertion NAMES the issue. §-log first — READ test_pivot_pill.log before concluding.
+// Run:  node erp/tests/test_pivot_pill.js          (exit 0 = PASS)
+'use strict';
+const fs = require('fs'), path = require('path');
+const ERP = path.join(__dirname, '..');
+const VIEWER = path.join(ERP, '..', 'viewer');
+const read = (p) => fs.readFileSync(p, 'utf8');
+
+const log = []; let pass = 0, fail = 0;
+const S = (m) => { log.push(m); console.log(m); };
+const ok = (cond, label, detail) => { if (cond) pass++; else fail++; S('  ' + (cond ? 'PASS' : 'FAIL') + ' ' + label + (detail ? ' — ' + detail : '')); };
+
+S('§W-PIVOT-PILL — surface the Pivot LENS on the ⋯ pill rail (whitebox structural)');
+
+// A — pills_idmp.json registers the pivot pill
+const manifest = JSON.parse(read(path.join(ERP, 'pills_idmp.json')));
+const pills = manifest.pills || manifest;                 // tolerate {pills:[...]} or [...]
+const pivot = (Array.isArray(pills) ? pills : []).find(p => p.id === 'pivot');
+ok(!!pivot, 'A1 — pills_idmp.json has a "pivot" pill', pivot ? 'order=' + pivot.order : 'absent');
+ok(pivot && pivot.icon === 'table' && typeof pivot.order === 'number' && !!pivot.name,
+   'A2 — pivot pill is icon "table", numeric order, named', pivot ? JSON.stringify({ icon: pivot.icon, order: pivot.order, name: pivot.name }) : '-');
+
+// B — the 'table' glyph is non-invent (icons.js verbatim from panels.js)
+const ICONS = require(path.join(ERP, 'icons.js'));
+const PANELS = read(path.join(VIEWER, 'panels.js'));
+function panelsNamedSvg(name) { const m = PANELS.match(new RegExp('\\b' + name + ':\\s*\\{\\s*svg:\\s*\'([^\']*)\'')); return m ? m[1] : null; }
+const wantSvg = panelsNamedSvg('table'), gotSvg = ICONS.table && ICONS.table.svg;
+ok(!!gotSvg && !!wantSvg && wantSvg === gotSvg,
+   'B — "table" glyph byte-verbatim in icons.js AND its panels.js source (no drift, non-invent)',
+   'icons.has=' + !!gotSvg + ' panels.has=' + !!wantSvg + ' identical=' + (wantSvg === gotSvg));
+
+// C — idempiere.html wiring
+const idmp = read(path.join(ERP, 'idempiere.html'));
+ok(/pivot:\s*openPivotFor/.test(idmp), 'C1 — IdmpPillActions binds pivot → openPivotFor');
+ok(/function openPivotFor\s*\(/.test(idmp), 'C2 — openPivotFor is defined');
+ok(/pivot_lens\.html\?db=ad_seed\.db/.test(idmp), 'C3 — openPivotFor opens pivot_lens.html?db=ad_seed.db (the live tenant seed)');
+ok(/_overlay\(\s*['"]Pivot/.test(idmp) && /§PIVOT-PILL/.test(idmp), 'C4 — in-page overlay (on-surface) + §PIVOT-PILL log');
+
+// D — the lens target exists and is real
+const lens = read(path.join(ERP, 'pivot_lens.html'));
+ok(/URLSearchParams\(location\.search\)/.test(lens) && /params\.get\(['"]db['"]\)/.test(lens),
+   'D — pivot_lens.html exists and consumes a ?db= param (real page, not a dead link)');
+
+// E — freshness bumps in place
+const erpSw = read(path.join(ERP, 'sw.js')), viewerSw = read(path.join(VIEWER, 'sw.js'));
+const idmpPills = read(path.join(ERP, 'idmp_pills.js')), viewerHtml = read(path.join(VIEWER, 'viewer.html'));
+ok(/CACHE_VERSION = 'v739'/.test(erpSw), 'E1 — erp/sw.js bumped to v739 (icons.js/pills/idempiere.html changed)');
+ok(/CACHE_VERSION = 'v692'/.test(viewerSw), 'E2 — viewer/sw.js bumped to v692 (panels.js changed)');
+ok(/icons\.js\?v=12/.test(idmp) && /idmp_pills\.js\?v=15/.test(idmp), 'E3 — idempiere.html busts icons.js?v=12 + idmp_pills.js?v=15');
+ok(/pills_idmp\.json\?v=36/.test(idmpPills), 'E4 — idmp_pills.js busts pills_idmp.json?v=36');
+ok(/panels\.js\?v=42/.test(viewerHtml), 'E5 — viewer.html busts panels.js?v=42');
+
+const verdict = `§RESULT W-PIVOT-PILL  ${pass}/${pass + fail}  ${fail ? 'FAIL' : 'PASS'}`;
+S(''); S(verdict);
+fs.writeFileSync(path.join(__dirname, 'test_pivot_pill.log'), log.join('\n') + '\n');
+process.exit(fail ? 1 : 0);

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -33,6 +33,7 @@ var ICONS = {
   // S266: Doc pill icons — New From Reference designer
   doc:       { svg: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/>', trl: 'ui_tt_doc', key: 'D', desc: 'Document' },
   grid:      { svg: '<path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/>', trl: 'ui_tt_grid', key: null, desc: 'Grid' },
+  table:     { svg: '<path d="M12 3v18"/><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/>', trl: 'ui_tt_table', key: null, desc: 'Table' },
   next:      { svg: '<path d="m9 18 6-6-6-6"/>', trl: 'ui_tt_next', key: null, desc: 'Next Phase' },
   save:      { svg: '<path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/><path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7"/><path d="M7 3v4a1 1 0 0 0 1 1h7"/>', trl: 'ui_tt_save', key: null, desc: 'Save Design' },
   folderOpen: { svg: '<path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/>', trl: 'ui_tt_open', key: null, desc: 'Open Design' },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v691';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v692';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -797,7 +797,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=53" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=7" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
-<script src="panels.js?v=41" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
+<script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=4" onerror="console.warn('§LOAD_FAIL tour.js')"></script>


### PR DESCRIPTION
## What
`RESUME_360_KANBAN_PIVOT` item 3. The cross-tab **Pivot lens** (`erp/pivot_lens.html`, shipped in #462) had no entry point. It's now a **LENS on the `⋯` pill rail**, sibling to kanban/graph — never on the native iDempiere chrome (FUNDAMENTAL LAW).

## How
- `pills_idmp.json`: new `pivot` pill (icon `table`, order 3.5).
- `erp/idempiere.html`: `IdmpPillActions.pivot → openPivotFor` opens `pivot_lens.html?db=ad_seed.db` as an **in-page overlay iframe** (the lens stays on-surface); logs `§PIVOT-PILL`. General table×row×col×measure, read-only; cell → Zoom-Across (decision #3).
- `icons.js` + `viewer/panels.js`: add the Lucide **`table`** glyph, **byte-verbatim** (`panels.js` = the single source of truth; non-invent, parity holds).

## Proof
`erp/tests/test_pivot_pill.js` → **W-PIVOT-PILL 13/13 PASS** (registry entry, glyph parity panels↔icons, action wiring, real lens target, all freshness bumps). CI audits (`audit_sw_precache`, `audit_script_tags`, `node --check viewer`) green locally.

## sw
erp `v738→v739` · viewer `v691→v692` · `icons.js?v=12` · `idmp_pills.js?v=15` · `pills_idmp.json?v=36` · `panels.js?v=42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)