### PR TITLE
feat(tm): S5(B) earned-value (cost EVM) from the existing twin (W-PC-EVM 14/14)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v692';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v693';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/test_pc_evm.js
+++ b/viewer/tests/test_pc_evm.js
@@ -1,0 +1,84 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: whitebox §-witness for TM_4D5D §S5(B) — Earned-Value Management from the EXISTING twin (W-PC-EVM).
+//   NO generated C_ProjectIssue layer (option A declined — circular + invention). COST EVM only; schedule has no
+//   independent actual on this twin so NO SPI is emitted (see PC_EVM_SPEC §HONESTY FINDING). Replicates
+//   _computeEVM (time_machine.js) against the real erp/ad_seed.db twin and proves:
+//     A — at project END (all phases complete): EV == Σ PlannedAmt (BAC) to the rupiah; AC == Σ CommittedAmt;
+//         CPI == BAC/ΣCommitted (≈0.741); **EAC == the real CommittedAmt to the rupiah** (the forecast
+//         RECONSTRUCTS the actual — proof the fold is honest, not invented); VAC == BAC−EAC (negative = overrun).
+//     B — at a MID cursor (end of Superstructure): CPI < 1 (over budget); EAC > BAC (forecasts the overrun);
+//         EV/AC fold only completed phases; all finite.
+//     C — identities: CPI = EV/AC · CV = EV−AC · EAC = round(BAC/CPI) · VAC = BAC−EAC.
+//     D — NO invention: C_ProjectIssue row count == 0 (nothing generated); the fold is read-only.
+//     E — deterministic (byte-identical across runs).
+//   Each assertion NAMES its issue. §-log first — READ test_pc_evm.log before concluding.
+// Run:  node viewer/tests/test_pc_evm.js          (exit 0 = PASS)
+'use strict';
+const { execFileSync } = require('child_process');
+const fs = require('fs'), path = require('path');
+const DB = path.join(__dirname, '..', '..', 'erp', 'ad_seed.db');
+const q = (sql) => execFileSync('sqlite3', [DB, sql], { encoding: 'utf8' }).trim();
+const rows = (sql) => q(sql).split('\n').filter(Boolean).map(l => l.split('|'));
+
+const log = []; let pass = 0, fail = 0;
+const S = (m) => { log.push(m); console.log(m); };
+const ok = (cond, label, detail) => { if (cond) pass++; else fail++; S('  ' + (cond ? 'PASS' : 'FAIL') + ' ' + label + (detail ? ' — ' + detail : '')); };
+
+// real twin (skip empty 'Unsequenced'), shaped like _computeVariance's V.phases
+const ph = rows(`SELECT Name, StartDate, EndDate, PlannedAmt, CommittedAmt FROM C_ProjectPhase WHERE C_Project_ID=990000 AND PlannedAmt>0 ORDER BY SeqNo`)
+  .map(r => ({ phase: r[0], startDate: Date.parse(r[1]), endDate: Date.parse(r[2]), pCost: +r[3], aCost: +r[4] }));
+const V = { phases: ph, tP: ph.reduce((s, p) => s + p.pCost, 0), tA: ph.reduce((s, p) => s + p.aCost, 0) };
+
+// _computeEVM replicated VERBATIM from time_machine.js (the whitebox contract)
+function computeEVM(V, cursor) {
+  let EV = 0, AC = 0;
+  V.phases.forEach(p => {
+    const s = p.startDate, e = p.endDate;
+    const frac = (isFinite(s) && isFinite(e) && e > s) ? Math.max(0, Math.min(1, (cursor - s) / (e - s)))
+               : (isFinite(cursor) && isFinite(e) && cursor >= e ? 1 : 0);
+    EV += p.pCost * frac; AC += p.aCost * frac;
+  });
+  const BAC = V.tP, CPI = AC > 0 ? EV / AC : 1;
+  const EAC = CPI > 0 ? Math.round(BAC / CPI) : V.tA;
+  return { EV: Math.round(EV), AC: Math.round(AC), CPI, CV: Math.round(EV - AC), BAC, EAC, VAC: BAC - EAC };
+}
+
+S('§W-PC-EVM — Earned Value (cost) from the existing twin (whitebox, real ad_seed.db; no generated data)');
+
+const projEnd = Math.max.apply(null, ph.map(p => p.endDate));
+const supEnd = ph.find(p => p.phase === 'Superstructure').endDate;
+
+// A — at completion: forecast reconstructs the actual
+const A = computeEVM(V, projEnd);
+ok(A.EV === V.tP, 'A1 — at end EV == Σ PlannedAmt (BAC) to the rupiah', 'EV=' + A.EV + ' BAC=' + V.tP);
+ok(A.AC === V.tA, 'A2 — at end AC == Σ CommittedAmt to the rupiah', 'AC=' + A.AC + ' ΣCommitted=' + V.tA);
+ok(Math.abs(A.CPI - V.tP / V.tA) < 1e-9, 'A3 — CPI == BAC/ΣCommitted (the inverse overrun)', 'CPI=' + A.CPI.toFixed(4));
+ok(A.EAC === V.tA, 'A4 — forecast EAC == the REAL CommittedAmt to the rupiah (reconstructs the actual)', 'EAC=' + A.EAC + ' committed=' + V.tA);
+ok(A.VAC === V.tP - V.tA && A.VAC < 0, 'A5 — VAC == BAC−EAC, negative (the overrun)', 'VAC=' + A.VAC);
+
+// B — mid cursor (end of Superstructure, the +60% marquee): trending over
+const B = computeEVM(V, supEnd);
+ok(B.CPI < 1, 'B1 — mid-project CPI < 1 (over budget)', 'CPI=' + B.CPI.toFixed(3));
+ok(B.EAC > V.tP, 'B2 — mid-project EAC > BAC (forecasts the overrun)', 'EAC=' + B.EAC + ' BAC=' + V.tP);
+ok(B.EV > 0 && B.AC > 0 && isFinite(B.EAC), 'B3 — EV/AC fold completed phases, all finite', 'EV=' + B.EV + ' AC=' + B.AC);
+
+// C — identities
+const C = computeEVM(V, supEnd);
+ok(Math.abs(C.CPI - C.EV / C.AC) < 1e-9, 'C1 — CPI = EV/AC');
+ok(C.CV === C.EV - C.AC, 'C2 — CV = EV − AC', 'CV=' + C.CV);
+ok(C.EAC === Math.round(C.BAC / C.CPI), 'C3 — EAC = round(BAC/CPI)');
+ok(C.VAC === C.BAC - C.EAC, 'C4 — VAC = BAC − EAC');
+
+// D — no invention: C_ProjectIssue is absent OR empty (the fold generated nothing)
+const hasTbl = q(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND lower(name)='c_projectissue'`) === '1';
+const issues = hasTbl ? Number(q(`SELECT COUNT(*) FROM C_ProjectIssue`)) : 0;
+ok(issues === 0, 'D — NO invention: C_ProjectIssue absent/empty (nothing generated; read-only fold)',
+   hasTbl ? ('table present, rows=' + issues) : 'table absent (as in seed)');
+
+// E — deterministic
+ok(JSON.stringify(computeEVM(V, supEnd)) === JSON.stringify(computeEVM(V, supEnd)), 'E — deterministic (byte-identical across runs)');
+
+const verdict = `§RESULT W-PC-EVM  ${pass}/${pass + fail}  ${fail ? 'FAIL' : 'PASS'}`;
+S(''); S(verdict);
+fs.writeFileSync(path.join(__dirname, 'test_pc_evm.log'), log.join('\n') + '\n');
+process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2842,6 +2842,27 @@
     return { phases: phases, projDurDays: projDurDays, rProj: rProj, projSlipDays: projSlipDays,
              projEnd: isFinite(V.plannedEnd) ? V.plannedEnd + projSlipDays * _DAY : NaN };
   }
+  // S5(B) / W-PC-EVM — Earned-Value Management folded from the EXISTING twin (no generated C_ProjectIssue layer;
+  // PC_EVM_SPEC). COST is real: at the cursor, each phase contributes its baseline progress fraction →
+  // EV (budgeted value of work done) + AC (committed cost of work done) → CPI = EV/AC, and the at-completion
+  // forecast EAC = BAC/CPI (at completion EV=BAC ⇒ EAC = AC = the real CommittedAmt, to the rupiah). SCHEDULE has
+  // no independent actual on this twin (see §HONESTY FINDING) so we emit NO SPI — the schedule story is the E3
+  // "projected finish". Label "cost · from records". Cursor-driven (drawVariance re-folds on scrub).
+  function _computeEVM(V, cursor) {
+    if (!V) return null;
+    var EV = 0, AC = 0;
+    V.phases.forEach(function (p) {
+      var s = p.startDate, e = p.endDate;
+      var frac = (isFinite(s) && isFinite(e) && e > s) ? Math.max(0, Math.min(1, (cursor - s) / (e - s)))
+               : (isFinite(cursor) && isFinite(e) && cursor >= e ? 1 : 0);
+      EV += p.pCost * frac;                                   // BCWP — budgeted value of completed work
+      AC += p.aCost * frac;                                   // ACWP — committed cost of completed work
+    });
+    var BAC = V.tP;                                           // budget at completion = Σ PlannedAmt
+    var CPI = AC > 0 ? EV / AC : 1;
+    var EAC = CPI > 0 ? Math.round(BAC / CPI) : V.tA;         // forecast at completion (= committed once complete)
+    return { EV: Math.round(EV), AC: Math.round(AC), CPI: CPI, CV: Math.round(EV - AC), BAC: BAC, EAC: EAC, VAC: BAC - EAC };
+  }
   function drawVariance() {
     if (!_ops.length) return;
     if (!_opsPlanned) _opsPlanned = _ops.slice();          // first open: snapshot the planned timeline (phase windows)
@@ -2856,6 +2877,7 @@
     var fmtD = function (ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '—'; };
     var curIdx = _varPhaseUnderCursor(V);
     var SP = _computeScheduleProjection(V);                     // E3 — the projected-from-cost schedule slip (4D Δ)
+    var EVM = _computeEVM(V, _cursor);                          // S5(B) — cursor-driven cost EVM (CPI + EAC forecast)
     var slipColor = function (d) { return d >= 0 ? '#ff6b6b' : '#26a69a'; };
     var slipTxt = function (d) { return (d >= 0 ? '+' : '') + d + ' d'; };
 
@@ -2875,7 +2897,14 @@
           ' <span style="color:#888">(planned baseline)</span></div>' +
         (SP ? '<div style="color:#ffb74d">Projected finish ' + fmtD(SP.projEnd) +
           ' <span style="color:' + slipColor(SP.projSlipDays) + '">(' + slipTxt(SP.projSlipDays) + ')</span>' +
-          ' <span style="color:#888">projected from cost</span></div>' : '');
+          ' <span style="color:#888">projected from cost</span></div>' : '') +
+        // S5(B) EVM — cursor-driven earned value: EV/AC + CPI + the at-completion forecast (EAC). Cost only,
+        // from records (no independent SPI on this twin — see §HONESTY FINDING; schedule = the line above).
+        (EVM ? '<div style="margin-top:2px;color:#cfe8ff">EV <b>' + _money(EVM.EV) + '</b> / AC <b>' + _money(EVM.AC) + '</b>' +
+          ' · CPI <b style="color:' + (EVM.CPI >= 1 ? '#26a69a' : '#ff6b6b') + '">' + EVM.CPI.toFixed(2) + '</b>' +
+          ' · forecast <b title="EAC = BAC/CPI">' + _money(EVM.EAC) + '</b>' +
+          ' <span style="color:' + (EVM.VAC >= 0 ? '#26a69a' : '#ff6b6b') + '">(' + (EVM.VAC >= 0 ? '+' : '') + _money(EVM.VAC) + ')</span>' +
+          ' <span style="font-size:9px;color:#888">cost · from records</span></div>' : '');
     }
 
     // canvas — one bar per phase on the SAME axis the cursor scrubs; bar color = phase, edge cap red/green by
@@ -2938,6 +2967,8 @@
     if (SP) console.log('§SCHED_PROJECT source=projected-from-cost building="' + _twin.building +
       '" projEnd=' + fmtD(SP.projEnd) + ' projSlipDays=' + SP.projSlipDays + ' rProj=' + SP.rProj.toFixed(3) +
       ' phases=' + SP.phases.map(function (x) { return x.phase + ':' + (x.slipDays >= 0 ? '+' : '') + x.slipDays + 'd'; }).join(','));
+    if (EVM) console.log('§EVM_FOLD source=twin(cost) cursor=' + Math.round(_cursor) + ' EV=' + EVM.EV +
+      ' AC=' + EVM.AC + ' CPI=' + EVM.CPI.toFixed(3) + ' CV=' + EVM.CV + ' BAC=' + EVM.BAC + ' EAC=' + EVM.EAC + ' VAC=' + EVM.VAC);
   }
 
   function drawGanttMini() {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -881,7 +881,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=55" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=56" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
## What
The **Earned-Value capstone** in the ⚖ drawer — folded from the **existing twin** (`PlannedAmt`/`CommittedAmt` + phase windows). **No generated `C_ProjectIssue` layer** (option A declined: fabricating transactions that sum back to the figure they decompose is circular and adjacent to the pro-rata line-committed vetoed 2026-06-20). Real earn-the-actual waits for the OPFS round-trip. Spec: `prompts/PC_EVM_SPEC.md`.

## Honesty finding (no faked SPI)
Schedule has **no independent actual** on this twin (planned dates only; `PP_Order` actuals NULL; the gantt follows baseline). Our only schedule signal is the E3 slip — itself projected *from cost* (ratio `r`), so any SPI from it = `1/r` = **CPI restated**. So this ships **cost EVM only**; the schedule story stays the E3 *"projected finish"*. Block labelled *"cost · from records"*.

## How (`viewer/time_machine.js`)
- `_computeEVM(V, cursor)`: per-phase baseline progress → **EV** (BCWP) + **AC** (ACWP) → **CPI**=EV/AC, **CV**=EV−AC, forecast **EAC**=BAC/CPI, **VAC**=BAC−EAC. Cursor-driven (re-folds on scrub).
- `drawVariance`: header EVM line `EV / AC · CPI · forecast EAC (VAC)` (red over / green under). Logs `§EVM_FOLD`.

## Proof (whitebox §-log — Hospital geom in OPFS, live visual deferred)
`viewer/tests/test_pc_evm.js` → **W-PC-EVM 14/14 PASS**. The killer assertion: at completion **EAC = 87,372,995 to the rupiah == the real `CommittedAmt`** — the forecast *reconstructs* the actual. CPI **0.741** at completion; mid-project (end of Superstructure) CPI **0.626**, EAC > BAC (trending over). `C_ProjectIssue` absent = no invention. Regressions W-SHOP-DATES / W-PPZOOM-TM green.

## sw
viewer `v692→v693` + `time_machine.js?v=56`. No ERP file / seed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)