### PR TITLE
fix(erp): round-trip — fresh BIM push wins over stale idb cache (W-BIM-OVERLAY-AUTHORITATIVE 7/7)

### DIFF
--- a/erp/bim_orders_overlay.js
+++ b/erp/bim_orders_overlay.js
@@ -13,8 +13,10 @@
 //
 // Why overlay-the-delta (not load-the-whole-file): the base stays the live ad_seed.db (never stale),
 // and only the BIM rows (PK >= 990000, the band proj_fold/vo_fold allocate in) are layered on top.
-// INSERT OR IGNORE on the PK → idempotent (re-boot / re-push adds nothing already present). The idb
-// seed cache is written from the RAW seed bytes BEFORE this overlay, so the cache is never polluted.
+// The OPFS push is AUTHORITATIVE: overlayTable CLEARS the dst BIM band, then INSERTs (was INSERT OR IGNORE).
+// The idb seed cache is written from RAW seed bytes BEFORE this overlay — but a LATER action (demo-tenant
+// install / seed reset / genesis / tenant delete) can persist the already-overlaid db back into the cache,
+// freezing a stale band; clearing-then-inserting makes a fresh push immune to that (round-trip regression fix).
 //
 // Dual export: node (require → tests/poc_bim_overlay.js) + browser (window.BimOrdersOverlay).
 (function (global) {
@@ -35,7 +37,12 @@
     return cols.length ? cols[0] : null;
   }
 
-  // copy BIM rows (PK >= BIM_BASE) of one table from srcDb into dstDb; INSERT OR IGNORE → idempotent.
+  // Copy BIM rows (PK >= BIM_BASE) of one table from srcDb (OPFS) into dstDb. The OPFS push is AUTHORITATIVE:
+  // when OPFS has band rows for this table we CLEAR the dst band first, then INSERT — so a fresh push is NEVER
+  // masked by a stale BIM band frozen into the idb seed cache. (ad_seed_v16 can be persisted POST-overlay by a
+  // demo-tenant install / seed reset / genesis / tenant delete → it captures the overlaid band; the old
+  // INSERT OR IGNORE then silently skipped the new push on the PK collision = the round-trip regression.)
+  // W-BIM-OVERLAY-AUTHORITATIVE. The push/OPFS-write path is untouched (revert-safe).
   function overlayTable(srcDb, dstDb, table) {
     var dcols = _cols(dstDb, table); if (!dcols.length) return 0;
     var pk = _pk(dcols, table); if (!pk) return 0;
@@ -44,8 +51,15 @@
     catch (e) { return 0; }
     if (!res.length || !res[0].values.length) return 0;
     var c = res[0].columns, vals = res[0].values, n = 0;
-    var sql = 'INSERT OR IGNORE INTO "' + table + '" ("' + c.join('","') + '") VALUES (' + c.map(function () { return '?'; }).join(',') + ')';
-    for (var i = 0; i < vals.length; i++) { try { dstDb.run(sql, vals[i]); n++; } catch (e) {} }
+    // PER-PK authoritative replace: drop ONLY the dst rows whose PK the OPFS push actually provides, then insert.
+    // NOT a band-wide wipe — the seed itself carries band rows (e.g. the Hospital twin C_Project 990000) that are
+    // NOT in OPFS and must survive. So OPFS overwrites its own pushed rows; seed-baked band rows are untouched.
+    var pkIdx = -1; for (var k = 0; k < c.length; k++) if (c[k].toLowerCase() === pk.toLowerCase()) { pkIdx = k; break; }
+    var del = 'DELETE FROM "' + table + '" WHERE "' + pk + '" = ?';
+    var sql = 'INSERT INTO "' + table + '" ("' + c.join('","') + '") VALUES (' + c.map(function () { return '?'; }).join(',') + ')';
+    for (var i = 0; i < vals.length; i++) {
+      try { if (pkIdx >= 0) dstDb.run(del, [vals[i][pkIdx]]); dstDb.run(sql, vals[i]); n++; } catch (e) {}
+    }
     return n;
   }
 

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -531,7 +531,7 @@
 <script src="kanban_host.js?v=1"></script>
 <!-- The ONE gesture — edit one rule → K records re-fold live, signed + reversible (docs/RULE_EDIT_SPEC.md). -->
 <script src="bigdecimal.js?v=1"></script>
-<script src="bim_orders_overlay.js?v=1"></script>
+<script src="bim_orders_overlay.js?v=2"></script>
 <!-- report folds for the AD_Process registered handlers (foldReceipt/foldTrialBalance) — needs BigDecimal above. -->
 <script src="report_overlay.js?v=9"></script>
 <script src="rule_fold.js?v=2"></script>

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v739';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v740';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/tests/poc_bim_overlay_authoritative.js
+++ b/tests/poc_bim_overlay_authoritative.js
@@ -1,0 +1,92 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// poc_bim_overlay_authoritative.js — round-trip REGRESSION fix witness (W-BIM-OVERLAY-AUTHORITATIVE).
+// The bug: the idb seed cache (ad_seed_v16) can be persisted AFTER the BIM overlay has run (a demo-tenant
+// install / seed reset / genesis / tenant delete does idbPut(db.export())), freezing a STALE BIM band into
+// the cache. The old overlay used INSERT OR IGNORE → a fresh push (same band PK) was SILENTLY SKIPPED, so the
+// Find › ERP deep-link opened the ERP but the project wasn't there. The fix: overlayTable does a PER-PK
+// authoritative replace (delete the dst rows whose PK the OPFS push provides, then insert) → the OPFS push wins,
+// WITHOUT wiping seed-baked band rows (the Hospital twin C_Project 990000 lives in the seed, not OPFS). Proves:
+//   A — STALE pushed row in dst (polluted cache) + FRESH push in src (OPFS, same PK) → after overlay, dst carries
+//       the FRESH values (the OLD INSERT-OR-IGNORE would have KEPT the stale row — the regression).
+//   CRIT — the seed-baked Hospital band project (990000, NOT in OPFS) SURVIVES (not a band-wide wipe).
+//   B — base rows (PK < BIM_BASE) untouched.
+//   C — idempotent: a 2nd overlay leaves the fresh values + no dup.
+//   D — empty src → dst pushed band row left as-is (no accidental wipe; revert-safe).
+// Run: NODE_PATH=$HOME/bim-ootb/tests/node_modules:$HOME/bim-ootb/node_modules node tests/poc_bim_overlay_authoritative.js
+'use strict';
+const fs = require('fs'), path = require('path');
+const initSqlJs = require('sql.js');
+const ProjFold = require('../viewer/proj_fold.js');
+const Overlay = require('../erp/bim_orders_overlay.js');
+
+const ERP = [path.join(__dirname, '..', 'erp', 'ad_seed.db'),
+  path.join(process.env.HOME, 'bim-ootb', 'erp', 'ad_seed.db')].find(fs.existsSync);
+const RATES_DIR = path.join(__dirname, '..', 'viewer', 'rates');
+const BIM_BASE = Overlay.BIM_BASE;
+
+const log = []; let pass = 0, fail = 0;
+const S = (m) => { log.push(m); console.log(m); };
+const ok = (c, label, d) => { if (c) pass++; else fail++; S('  ' + (c ? 'PASS' : 'FAIL') + ' ' + label + (d ? ' — ' + d : '')); };
+const scalar = (db, sql) => { const r = db.exec(sql); return r.length && r[0].values.length ? r[0].values[0][0] : null; };
+const proj = (db, value) => { const r = db.exec("SELECT C_Project_ID, PlannedAmt FROM C_Project WHERE Value='" + value + "'"); return r.length && r[0].values.length ? { pk: Number(r[0].values[0][0]), planned: Number(r[0].values[0][1]) } : null; };
+const bandCount = (db, value) => scalar(db, "SELECT COUNT(*) FROM C_Project WHERE Value='" + value + "'");
+
+(async function () {
+  if (!ERP) { S('§BIM_OVERLAY_AUTH SKIP — missing erp db'); process.exit(1); }
+  const SQL = await initSqlJs();
+  const sr = JSON.parse(fs.readFileSync(path.join(RATES_DIR, 'sequence_rules.json'), 'utf8'));
+  const seed = fs.readFileSync(ERP);
+  const opts = (now) => ({ seqRules: sr.SEQUENCE_RULES, laborRates: sr.LABOR_RATES, packCurrencyISO: 'USD', now, bpartnerId: 119 });
+  const HOSP = proj(new SQL.Database(new Uint8Array(seed)), 'Hospital');   // seed-baked band project
+  S('§W-BIM-OVERLAY-AUTHORITATIVE — fresh OPFS push wins over stale cache, seed band survives (round-trip fix)');
+  S('  · seed-baked Hospital band: PK=' + (HOSP && HOSP.pk) + ' PlannedAmt=' + (HOSP && HOSP.planned));
+
+  // FRESH push (OPFS) — building 'RoundTrip', a BIG project
+  const src = new SQL.Database(new Uint8Array(seed));
+  ProjFold.foldProjectOrder(src, 'RoundTrip', [{ disc: 'ARC', cls: 'IfcWall', storey: 'L1', count: 50, unit: 'EA', qty: 50, rate: 100, cost: 5000 }], opts('2026-06-21 00:00:00'));
+  const fresh = proj(src, 'RoundTrip');
+
+  // POLLUTED cache (dst) — same band PK baked with STALE/different values (a prior, smaller push)
+  const dst = new SQL.Database(new Uint8Array(seed));
+  ProjFold.foldProjectOrder(dst, 'RoundTrip', [{ disc: 'ARC', cls: 'IfcWall', storey: 'L1', count: 3, unit: 'EA', qty: 3, rate: 100, cost: 300 }], opts('2026-06-10 00:00:00'));
+  const stale = proj(dst, 'RoundTrip');
+  const baseBefore = scalar(dst, 'SELECT COUNT(*) FROM C_Project WHERE C_Project_ID < ' + BIM_BASE);
+  S('  · stale dst push PK=' + stale.pk + ' planned=' + stale.planned + '  |  fresh src push PK=' + fresh.pk + ' planned=' + fresh.planned);
+  ok(fresh.pk === stale.pk && fresh.planned !== stale.planned, 'arrange: same band PK, different PlannedAmt', 'PK=' + stale.pk);
+
+  // ACT
+  Overlay.overlayRows(src, dst, Overlay.TABLES);
+
+  const after = proj(dst, 'RoundTrip');
+  ok(after.planned === fresh.planned && after.planned !== stale.planned,
+     'A — stale pushed row REPLACED by the fresh push (old INSERT-OR-IGNORE kept stale)',
+     'after=' + after.planned + ' (fresh=' + fresh.planned + ', stale=' + stale.planned + ')');
+  ok(bandCount(dst, 'RoundTrip') === 1, 'A2 — exactly one RoundTrip row (no duplicate)', 'rows=' + bandCount(dst, 'RoundTrip'));
+
+  const hospAfter = proj(dst, 'Hospital');
+  ok(!!hospAfter && hospAfter.pk === HOSP.pk && hospAfter.planned === HOSP.planned,
+     'CRIT — seed-baked Hospital band (not in OPFS) SURVIVES (per-PK replace, not a band wipe)',
+     'Hospital after: ' + (hospAfter ? hospAfter.pk + '/' + hospAfter.planned : 'GONE'));
+
+  ok(scalar(dst, 'SELECT COUNT(*) FROM C_Project WHERE C_Project_ID < ' + BIM_BASE) === baseBefore, 'B — base rows untouched', 'base=' + baseBefore);
+
+  Overlay.overlayRows(src, dst, Overlay.TABLES);
+  ok(bandCount(dst, 'RoundTrip') === 1 && proj(dst, 'RoundTrip').planned === fresh.planned, 'C — 2nd overlay idempotent (still fresh, no dup)');
+
+  // D — empty src leaves dst push intact
+  const dstD = new SQL.Database(new Uint8Array(seed));
+  ProjFold.foldProjectOrder(dstD, 'KeepMe', [{ disc: 'ARC', cls: 'IfcWall', storey: 'L1', count: 2, unit: 'EA', qty: 2, rate: 100, cost: 200 }], opts('2026-06-09 00:00:00'));
+  const keepBefore = bandCount(dstD, 'KeepMe');
+  Overlay.overlayRows(new SQL.Database(new Uint8Array(seed)), dstD, Overlay.TABLES);   // empty src (no fold)
+  ok(bandCount(dstD, 'KeepMe') === keepBefore && keepBefore > 0, 'D — empty src leaves dst push intact (no wipe; revert-safe)', 'rows=' + bandCount(dstD, 'KeepMe'));
+
+  src.close(); dst.close(); dstD.close();
+  const verdict = `§RESULT W-BIM-OVERLAY-AUTHORITATIVE  ${pass}/${pass + fail}  ${fail ? 'FAIL' : 'PASS'}`;
+  S(''); S(verdict);
+  fs.writeFileSync(path.join(__dirname, 'poc_bim_overlay_authoritative.log'), log.join('\n') + '\n');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Symptom
Find › ERP **"open ↗"** deep-link opened iDempiere but the pushed Project Order wasn't there (worked ~4 days ago).

## Root cause — NOT a round-trip code regression
The whole chain is unchanged in the last 4 days: deep-link **builder** (`navigate_find.js`, +98 additive lines only), **consumer** (`idempiere.html` `clientParam`/`winSet[130]`/`_landOnRecord`), **overlay module**, **write modules**, and the **seed** (AD_Window 130 = "Project", access intact).

It's **idb cache pollution**: at boot `idempiere.html` overlays the OPFS BIM band into the in-memory db, then a later action — **demo-tenant install (made one-click at the front door by #413, 06-19)**, seed reset, genesis, or tenant delete — does `idbPut('ad_seed_v16', db.export())`, freezing the overlaid band into the cache. Next boot loads it, and the old overlay's `INSERT OR IGNORE` then **silently skips the fresh push** on the PK collision.

## Fix (`erp/bim_orders_overlay.js`, READ side only — push/OPFS-write untouched = revert-safe)
`overlayTable` now does a **per-PK authoritative replace**: delete the dst rows whose PK the OPFS push provides, then insert → a fresh push always wins. **Not** a band-wide wipe — the seed itself carries band rows (the **Hospital twin** `C_Project 990000`) that aren't in OPFS and must survive.

> My first attempt blanket-deleted `PK >= 990000` — and the witness caught that it **wiped Hospital**. Fixed to per-PK.

## Proof
`tests/poc_bim_overlay_authoritative.js` → **W-BIM-OVERLAY-AUTHORITATIVE 7/7 PASS**: stale→fresh replace, **Hospital survives**, base untouched, idempotent, empty-src no-wipe.

## sw
erp `v739→v740` + `bim_orders_overlay.js?v=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)