### PR TITLE
feat(tm-variance): S6 schedule what-if — finish-to-start ripple on Blue Future (W-WHATIF 13/13)

### DIFF
--- a/erp/tests/whatif_witness.js
+++ b/erp/tests/whatif_witness.js
@@ -1,0 +1,102 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// whatif_witness.js — W-WHATIF (TM 4D/5D variance lane §S6). Whitebox §-log proof of the schedule what-if engine.
+//
+// Each assertion NAMES the issue it proves (Standing Rule: a test that doesn't reveal solved/not is not a test):
+//   §WHATIF-RIPPLE  : a blue slip on an EARLY phase re-folds EVERY downstream phase forward by the same days,
+//                     and the project finish moves — while the OFFICIAL baseline is untouched (issue: does the
+//                     finish-to-start dependency actually ripple, or are phases still independent ranges?).
+//   §WHATIF-FORWARD : forward variance = planned(official) vs blue — finishSlipDays == the slip, BAC unchanged
+//                     (same scope), PV moves (totals move) (issue: is the variance the planned-vs-blue forward delta?).
+//   §WHATIF-ACCEPT  : acceptSlip re-baselines — the official rows now CARRY the rippled dates, blue rows gone
+//                     (issue: does accept turn the speculative schedule into the official one?).
+//   §WHATIF-DISCARD : on a FRESH db, commitSlip then discardSlip → official == original, ZERO blue rows
+//                     (issue: does discard restore, leaving official exactly as it never moved?).
+//
+// Runs on the REAL folded project (erp/ad_seed.db C_Project 990000 'BIM: Hospital', 7 F-S phases) — no synthetic data.
+// KernelOps absent in node → the projection layer (the thing under test) runs guarded, exactly as shipped.
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+const WhatIf = require('../../viewer/whatif.js');
+
+const ERP = path.join(__dirname, '..', 'ad_seed.db');
+const out = [];
+let pass = 0, fail = 0;
+const W = (ok, m) => { out.push((ok ? '🟢' : '🔴') + ' ' + m); ok ? pass++ : fail++; return ok; };
+
+(async function () {
+  if (!fs.existsSync(ERP)) { console.log('§WHATIF SKIP — missing ' + ERP); process.exit(1); }
+  const SQL = await initSqlJs();
+  const scalar = (db, s, p) => { const r = db.exec(s, p || []); return (r.length && r[0].values.length) ? r[0].values[0][0] : null; };
+  const fresh = () => new SQL.Database(fs.readFileSync(ERP));
+
+  const PID = 990000, SLIP = 30, BR = 'blue-whatif-test';
+
+  // ── baseline (official) ───────────────────────────────────────────────────
+  let db = fresh();
+  const base = WhatIf.readPhases(db, PID, null);
+  W(base.length === 7, `§WHATIF baseline — 990000 has ${base.length} F-S phases (expect 7)`);
+  const contiguous = base.every((p, i) => i === 0 || p.startDays === base[i - 1].endDays);
+  W(contiguous, `§WHATIF baseline — phases are a contiguous finish-to-start chain (lag=0): ${contiguous}`);
+  const baseFinish = base[base.length - 1].endDays;
+  out.push(`   baseline: ${base.map(p => p.name + ' [' + WhatIf._date(p.startDays).slice(0, 10) + '→' + WhatIf._date(p.endDays).slice(0, 10) + ']').join('  ')}`);
+
+  // ── §WHATIF-RIPPLE: blue slip on the FIRST phase (+30d) ─────────────────────
+  const firstSeq = base[0].seqno;
+  const slips = {}; slips[firstSeq] = { startDelta: SLIP };
+  await WhatIf.commitSlip(db, BR, PID, slips);
+
+  const off = WhatIf.readPhases(db, PID, null);       // official view (branch_id IS NULL)
+  const blue = WhatIf.readPhases(db, PID, BR);         // blue overlay view
+
+  const officialUnchanged = off.length === base.length && off.every((p, i) => p.startDays === base[i].startDays && p.endDays === base[i].endDays);
+  W(officialUnchanged, `§WHATIF-RIPPLE — OFFICIAL baseline untouched after blue commit: ${officialUnchanged}`);
+
+  const allShifted = blue.length === base.length && blue.every((p, i) => p.startDays === base[i].startDays + SLIP && p.endDays === base[i].endDays + SLIP);
+  W(allShifted, `§WHATIF-RIPPLE — ALL ${blue.length} downstream phases re-folded +${SLIP}d in blue: ${allShifted}`);
+
+  const blueFinish = blue[blue.length - 1].endDays;
+  W(blueFinish === baseFinish + SLIP, `§WHATIF-RIPPLE — project finish moved ${baseFinish}→${blueFinish} (+${blueFinish - baseFinish}d, expect +${SLIP})`);
+  out.push(`   blue:     ${blue.map(p => p.name + ' [' + WhatIf._date(p.startDays).slice(0, 10) + '→' + WhatIf._date(p.endDays).slice(0, 10) + ']').join('  ')}`);
+
+  // ── §WHATIF-FORWARD: forward variance = planned vs blue ─────────────────────
+  // as-of date set mid-project so PV is partial on both schedules (totals genuinely move).
+  const midAsOf = WhatIf._date(base[2].startDays);
+  const wf = WhatIf.scheduleWhatIf(db, PID, slips, midAsOf);
+  W(wf.forward.finishSlipDays === SLIP, `§WHATIF-FORWARD — finishSlipDays = ${wf.forward.finishSlipDays} (expect ${SLIP})`);
+  W(wf.forward.bacDelta === '0', `§WHATIF-FORWARD — BAC unchanged (same scope), bacDelta = ${wf.forward.bacDelta}`);
+  const pvMoved = wf.forward.pvDelta !== '0' && wf.official.pv !== wf.blue.pv;
+  W(pvMoved, `§WHATIF-FORWARD — PV moved as-of ${midAsOf.slice(0, 10)}: official ${wf.official.pv} vs blue ${wf.blue.pv} (Δ ${wf.forward.pvDelta})`);
+  out.push(`   forward:  BAC ${wf.official.bac} (==blue ${wf.blue.bac}) · finish ${wf.official.finish.slice(0,10)} → ${wf.blue.finish.slice(0,10)}`);
+
+  // ── §WHATIF-ACCEPT: re-baseline ─────────────────────────────────────────────
+  // kernel_ops is a browser-side table (absent in this node seed) — accept's op-log call is guarded; pass null.
+  await WhatIf.acceptSlip(db, BR, PID, null);
+  const afterAccept = WhatIf.readPhases(db, PID, null);
+  const rebased = afterAccept.length === base.length && afterAccept.every((p, i) => p.startDays === base[i].startDays + SLIP && p.endDays === base[i].endDays + SLIP);
+  W(rebased, `§WHATIF-ACCEPT — official rows now CARRY the rippled +${SLIP}d dates (re-baselined): ${rebased}`);
+  const noBlueLeft = Number(scalar(db, "SELECT COUNT(*) FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id IS NOT NULL", [PID]) || 0);
+  W(noBlueLeft === 0, `§WHATIF-ACCEPT — no blue rows remain after accept: ${noBlueLeft}`);
+
+  // ── §WHATIF-DISCARD: restore (fresh db so 'original' is pristine) ────────────
+  db = fresh();
+  const orig = WhatIf.readPhases(db, PID, null).map(p => ({ s: p.startDays, e: p.endDays }));
+  await WhatIf.commitSlip(db, BR, PID, slips);
+  const blueRows = Number(scalar(db, "SELECT COUNT(*) FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?", [PID, BR]) || 0);
+  W(blueRows > 0, `§WHATIF-DISCARD — commit created ${blueRows} blue phase rows`);
+  WhatIf.discardSlip(db, BR, PID);
+  const afterDiscard = WhatIf.readPhases(db, PID, null).map(p => ({ s: p.startDays, e: p.endDays }));
+  const restored = afterDiscard.length === orig.length && afterDiscard.every((p, i) => p.s === orig[i].s && p.e === orig[i].e);
+  W(restored, `§WHATIF-DISCARD — official == original after discard: ${restored}`);
+  const zeroBlue = Number(scalar(db, "SELECT COUNT(*) FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id IS NOT NULL", [PID]) || 0);
+  W(zeroBlue === 0, `§WHATIF-DISCARD — zero blue rows remain: ${zeroBlue}`);
+
+  console.log('§WHATIF W-WHATIF — schedule what-if (S6) whitebox proof');
+  console.log(out.join('\n'));
+  console.log(`§WHATIF RESULT ${pass}/${pass + fail} pass`);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('§WHATIF ERROR', e); process.exit(1); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v693';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v694';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -826,6 +826,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="proj_fold.js?v=2"></script>
 <script src="vo_fold.js?v=2"></script>
 <script src="proj_control.js?v=1"></script>
+<script src="whatif.js?v=1"></script>
 <script src="vo_approve.js?v=1"></script>
 <script src="proj_period.js?v=1"></script>
 <script src="proj_claim.js?v=1"></script>

--- a/viewer/whatif.js
+++ b/viewer/whatif.js
@@ -1,0 +1,222 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// whatif.js — TM 4D/5D variance lane §S6: schedule what-if as a BLUE branch op on a folded C_Project.
+//
+// The minimal finish-to-start DEPENDENCY model (NOT a P6 network): the C_ProjectPhase rows of one project,
+// ordered by SeqNo, ARE the chain — the proj_fold forward-pass laid them contiguous (each StartDate == prior
+// EndDate). So the dependency = SeqNo order, with each phase's lag to its predecessor (lag_i = start_i − end_{i-1})
+// read from the baseline and PRESERVED on ripple. A slip on phase k re-folds k..N forward (durations + lags kept).
+//
+// Reuses Blue Future exactly like viewer/blue_fold.js — schedule-scoped to C_ProjectPhase:
+//   commitSlip  — INSERT the rippled downstream phase rows tagged branch_id (the speculative re-fold); official
+//                 rows (branch_id IS NULL) untouched & invisible to official reads. If KernelOps is present, also
+//                 record a SCHEDULE_SLIP op-group on the branch (the op-log / dot rail). KernelOps is OPTIONAL
+//                 (guarded `var ko = KO()`), so the projection layer is fully node-testable via sql.js.
+//   discardSlip — drop the blue phase rows (+ KernelOps.discardBranch) → official reverts; it never moved.
+//   acceptSlip  — copy the blue StartDate/EndDate onto the official rows + drop blue rows
+//                 (+ KernelOps.acceptBranchUpTo) → the what-if becomes the new baseline (re-baseline).
+//
+// EXTRACT-only: BAC (Σ PlannedAmt) is unchanged (same scope) — only DATES and the schedule-derived PV move.
+// PV uses the SAME linear-fraction × PlannedAmt as proj_control.evm, in BigDecimal (money via site/bigdecimal.js).
+(function (global) {
+  'use strict';
+  var BD = (typeof module !== 'undefined' && module.exports) ? require('../erp/bigdecimal.js') : (global.BigDecimal);
+  var HALF_UP = BD.RoundingMode.HALF_UP;
+  var DAY = 86400000;
+
+  function KO() { return (typeof window !== 'undefined' && window.KernelOps) || global.KernelOps || null; }
+  function _scalar(db, sql, p) { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values[0][0] : null; }
+  function _bd(x) { return BD.of(String(x == null ? 0 : x)); }
+
+  // 'YYYY-MM-DD( hh:mm:ss)' → epoch days (date-only, tz-free); and back.
+  function _days(s) {
+    if (s == null) return null;
+    var m = String(s).slice(0, 10).split('-');
+    if (m.length !== 3) return null;
+    return Date.UTC(+m[0], (+m[1]) - 1, +m[2]) / DAY;
+  }
+  function _date(days) {
+    var d = new Date(days * DAY);
+    var p = function (n) { return (n < 10 ? '0' : '') + n; };
+    return d.getUTCFullYear() + '-' + p(d.getUTCMonth() + 1) + '-' + p(d.getUTCDate()) + ' 00:00:00';
+  }
+
+  function _hasCol(db, t, c) {
+    var r = db.exec("PRAGMA table_info(" + t + ")");
+    return r.length && r[0].values.some(function (v) { return String(v[1]).toLowerCase() === c.toLowerCase(); });
+  }
+  function ensureBranchCol(db) {
+    if (!_hasCol(db, 'C_ProjectPhase', 'branch_id')) { try { db.run('ALTER TABLE "C_ProjectPhase" ADD COLUMN branch_id TEXT'); } catch (e) {} }
+  }
+
+  // Read a project's phases, SeqNo-ordered, with the F-S chain fields derived (dur, lag to predecessor).
+  // branchId null → OFFICIAL (branch_id IS NULL, the baseline). branchId set → OVERLAY: the blue row for a
+  // SeqNo if one exists, else the official row (so downstream blue rows replace their baseline twins).
+  function readPhases(db, projectId, branchId) {
+    var hasBranch = _hasCol(db, 'C_ProjectPhase', 'branch_id');
+    var sql, params;
+    if (!hasBranch || branchId == null) {
+      sql = "SELECT C_ProjectPhase_ID,SeqNo,Name,StartDate,EndDate,PlannedAmt,IsComplete FROM C_ProjectPhase " +
+            "WHERE C_Project_ID=?" + (hasBranch ? " AND branch_id IS NULL" : "") + " ORDER BY SeqNo";
+      params = [projectId];
+    } else {
+      // overlay: official rows whose SeqNo has no blue twin, UNION the blue rows; blue wins per SeqNo.
+      sql = "SELECT C_ProjectPhase_ID,SeqNo,Name,StartDate,EndDate,PlannedAmt,IsComplete FROM C_ProjectPhase b " +
+            "WHERE C_Project_ID=? AND branch_id=? UNION ALL " +
+            "SELECT C_ProjectPhase_ID,SeqNo,Name,StartDate,EndDate,PlannedAmt,IsComplete FROM C_ProjectPhase o " +
+            "WHERE C_Project_ID=? AND branch_id IS NULL AND SeqNo NOT IN " +
+            "(SELECT SeqNo FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?) ORDER BY SeqNo";
+      params = [projectId, branchId, projectId, projectId, branchId];
+    }
+    var r = db.exec(sql, params);
+    var rows = r.length ? r[0].values : [];
+    var prevEnd = null;
+    return rows.map(function (v) {
+      var sd = _days(v[3]), ed = _days(v[4]);
+      var p = {
+        id: v[0], seqno: Number(v[1]), name: v[2], startDays: sd, endDays: ed,
+        dur: (sd != null && ed != null) ? (ed - sd) : 0,
+        lag: (prevEnd != null && sd != null) ? (sd - prevEnd) : 0,
+        plannedAmt: String(v[5] == null ? 0 : v[5]), isComplete: (v[6] === 'Y')
+      };
+      prevEnd = ed;
+      return p;
+    });
+  }
+
+  // PURE finish-to-start ripple. slips: { seqno: {startDelta, durDelta} } in DAYS (positive = later/longer).
+  // Phase k: start += startDelta, dur = max(0, dur + durDelta). For every later phase (SeqNo order):
+  //   start_i = end_{i-1} + lag_i  (the baseline lag is preserved),  end_i = start_i + dur_i.
+  function ripple(phases, slips) {
+    slips = slips || {};
+    var out = phases.map(function (p) { return { id: p.id, seqno: p.seqno, name: p.name, dur: p.dur, lag: p.lag, plannedAmt: p.plannedAmt, isComplete: p.isComplete, startDays: p.startDays, endDays: p.endDays }; });
+    var prevEnd = null, touched = false;
+    out.forEach(function (p, i) {
+      var slip = slips[p.seqno];
+      if (i === 0) {
+        // anchor phase keeps its start unless directly slipped.
+        if (slip && slip.startDelta) { p.startDays += slip.startDelta; touched = true; }
+        if (slip && slip.durDelta) { p.dur = Math.max(0, p.dur + slip.durDelta); touched = true; }
+      } else {
+        // re-anchor to predecessor's (possibly moved) end + preserved lag.
+        p.startDays = prevEnd + p.lag;
+        if (slip && slip.startDelta) { p.startDays += slip.startDelta; touched = true; }
+        if (slip && slip.durDelta) { p.dur = Math.max(0, p.dur + slip.durDelta); touched = true; }
+      }
+      p.endDays = p.startDays + p.dur;
+      prevEnd = p.endDays;
+    });
+    return { phases: out, projectFinishDays: prevEnd, touched: touched };
+  }
+
+  // PV (planned value) of a phase set at a data ("as-of") date — Σ PlannedAmt × linear schedule fraction.
+  // Mirrors proj_control.evm exactly, on an in-memory phase array (so a blue schedule can be priced without a DB read).
+  function _pvAt(phases, asOfDays) {
+    var pv = BD.ZERO;
+    phases.forEach(function (p) {
+      var amt = _bd(p.plannedAmt), sd = p.startDays, ed = p.endDays, frac = BD.ZERO;
+      if (asOfDays != null && ed != null && asOfDays >= ed) frac = BD.of('1');
+      else if (asOfDays != null && sd != null && ed != null && asOfDays > sd && ed > sd) {
+        frac = BD.of(String(asOfDays - sd)).divide(BD.of(String(ed - sd)), 6, HALF_UP);
+      }
+      pv = pv.add(amt.multiply(frac).setScale(2, HALF_UP));
+    });
+    return pv;
+  }
+  function _bac(phases) { var b = BD.ZERO; phases.forEach(function (p) { b = b.add(_bd(p.plannedAmt)); }); return b; }
+
+  // The what-if picture: official baseline vs the rippled blue schedule + the forward variance.
+  function scheduleWhatIf(db, projectId, slips, asOfDate) {
+    var official = readPhases(db, projectId, null);
+    var blue = ripple(official, slips).phases;
+    var asOf = _days(asOfDate || _date(_officialFinish(official)));    // default as-of = official finish
+    var offFinish = _officialFinish(official), bluFinish = _officialFinish(blue);
+    var pvOff = _pvAt(official, asOf), pvBlue = _pvAt(blue, asOf);
+    return {
+      projectId: projectId, asOf: asOfDate || _date(offFinish),
+      official: { phases: official.map(_pub), finish: _date(offFinish), pv: pvOff.toString(), bac: _bac(official).toString() },
+      blue: { phases: blue.map(_pub), finish: _date(bluFinish), pv: pvBlue.toString(), bac: _bac(blue).toString() },
+      forward: {
+        finishSlipDays: (offFinish != null && bluFinish != null) ? (bluFinish - offFinish) : null,
+        pvDelta: pvBlue.subtract(pvOff).toString(),     // schedule shifts PV (totals move), BAC stays
+        bacDelta: _bac(blue).subtract(_bac(official)).toString()   // 0 — same scope (honest cross-check)
+      }
+    };
+  }
+  function _officialFinish(phases) { return phases.length ? phases[phases.length - 1].endDays : null; }
+  function _pub(p) { return { seqno: p.seqno, name: p.name, start: _date(p.startDays), end: _date(p.endDays), durDays: p.dur, plannedAmt: p.plannedAmt }; }
+
+  // Commit the what-if as a BLUE schedule slip: insert the rippled downstream phase rows tagged branch_id.
+  // Only the phases whose dates actually MOVED get a blue twin (the upstream/unaffected stay official-only).
+  async function commitSlip(db, branchId, projectId, slips) {
+    ensureBranchCol(db);
+    var official = readPhases(db, projectId, null);
+    var rip = ripple(official, slips);
+    var blue = rip.phases;
+    var cols = db.exec("PRAGMA table_info(C_ProjectPhase)")[0].values.map(function (v) { return v[1]; });
+    var moved = 0, slipOps = [];
+    blue.forEach(function (bp, i) {
+      var op = official[i];
+      if (bp.startDays === op.startDays && bp.endDays === op.endDays) return;   // unchanged → no blue row
+      // clone the official row, override dates + branch_id, mint a fresh PK.
+      var src = db.exec("SELECT * FROM C_ProjectPhase WHERE C_ProjectPhase_ID=?", [op.id]);
+      if (!src.length) return;
+      var vals = src[0].values[0].slice();
+      var newId = Number(_scalar(db, "SELECT COALESCE(MAX(C_ProjectPhase_ID),0)+1 FROM C_ProjectPhase") || 1);
+      var assigns = cols.map(function (c, ci) {
+        var val = vals[ci];
+        if (c === 'C_ProjectPhase_ID') val = newId;
+        else if (c === 'StartDate') val = _date(bp.startDays);
+        else if (c === 'EndDate') val = _date(bp.endDays);
+        else if (c === 'branch_id') val = branchId;
+        return val;
+      });
+      var ph = cols.map(function () { return '?'; }).join(',');
+      db.run('INSERT INTO C_ProjectPhase (' + cols.map(function (c) { return '"' + c + '"'; }).join(',') + ') VALUES (' + ph + ')', assigns);
+      moved++;
+      slipOps.push({ op_type: 'SCHEDULE_SLIP', table: 'C_ProjectPhase', record_id: newId,
+        parameters: { c_project_id: projectId, seqno: bp.seqno, start: _date(bp.startDays), end: _date(bp.endDays), branch_id: branchId } });
+    });
+    var ko = KO(), gid = null;
+    if (ko && slipOps.length) { try { var res = await ko.commitGroup(db, slipOps, { branch_id: branchId }); gid = res && res.gid; } catch (e) {} }
+    return { ok: true, branchId: branchId, projectId: projectId, movedPhases: moved, finishSlipDays: scheduleWhatIf(db, projectId, slips).forward.finishSlipDays, gid: gid };
+  }
+
+  // Discard the blue schedule slip — drop the blue phase rows; official reverts (it never moved).
+  function discardSlip(db, branchId, projectId) {
+    var removed = 0;
+    if (_hasCol(db, 'C_ProjectPhase', 'branch_id')) {
+      removed = Number(_scalar(db, "SELECT COUNT(*) FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?", [projectId, branchId]) || 0);
+      db.run("DELETE FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?", [projectId, branchId]);
+    }
+    var ko = KO(); if (ko) { try { ko.discardBranch(db, branchId); } catch (e) {} }
+    return { ok: true, branchId: branchId, removedPhases: removed };
+  }
+
+  // Accept the blue schedule slip — copy each blue row's dates onto its official twin (by SeqNo), then drop the
+  // blue rows. The what-if becomes the new baseline. KernelOps.acceptBranchUpTo turns the slip ops white.
+  async function acceptSlip(db, branchId, projectId, uptoId) {
+    var rebased = 0;
+    if (_hasCol(db, 'C_ProjectPhase', 'branch_id')) {
+      var blue = db.exec("SELECT SeqNo,StartDate,EndDate FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?", [projectId, branchId]);
+      (blue.length ? blue[0].values : []).forEach(function (v) {
+        db.run("UPDATE C_ProjectPhase SET StartDate=?,EndDate=? WHERE C_Project_ID=? AND branch_id IS NULL AND SeqNo=?", [v[1], v[2], projectId, v[0]]);
+        rebased++;
+      });
+      db.run("DELETE FROM C_ProjectPhase WHERE C_Project_ID=? AND branch_id=?", [projectId, branchId]);
+    }
+    var ko = KO(); if (ko && uptoId != null) { try { await ko.acceptBranchUpTo(db, branchId, uptoId); } catch (e) {} }
+    return { ok: true, branchId: branchId, rebasedPhases: rebased };
+  }
+
+  var API = {
+    readPhases: readPhases, ripple: ripple, scheduleWhatIf: scheduleWhatIf,
+    commitSlip: commitSlip, discardSlip: discardSlip, acceptSlip: acceptSlip,
+    ensureBranchCol: ensureBranchCol, _days: _days, _date: _date
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else global.WhatIf = API;
+})(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
## S6 — WHAT-IF via Blue Future (TM 4D/5D variance lane)

A schedule slip lands as a **blue branch op** → downstream phases **re-fold in blue** beside official; **accept** re-baselines, **discard** drops. Proven whitebox on the REAL folded Hospital project (`erp/ad_seed.db` C_Project 990000, 7 finish-to-start phases) — no synthetic data.

### The minimal finish-to-start dependency model
The phases of one project, ordered by SeqNo, **already ARE the F-S chain** — `proj_fold`'s forward-pass laid them contiguous (each StartDate == prior EndDate). So the dependency = SeqNo order with each phase's lag-to-predecessor read from the baseline and **preserved on ripple**. No P6 network, no new dependency table.

### `viewer/whatif.js` (sibling of `blue_fold.js`, schedule-scoped)
- `ripple()` — pure F-S forward pass; a slip on phase *k* re-folds *k..N* (durations + lags kept)
- `readPhases()` — SeqNo-ordered, branch-aware overlay (official | blue), mirrors `proj_control.contractSum`'s branch param
- `scheduleWhatIf()` — official vs blue + forward variance: `finishSlipDays`, PV moves, BAC unchanged
- `commitSlip` / `discardSlip` / `acceptSlip` — reuse Blue Future (`branch_id` + optional `KernelOps.commitGroup`/`discardBranch`/`acceptBranchUpTo`), exactly like `blue_fold.js`. KernelOps is guarded/optional → projection layer is node-testable.

EXTRACT-only: BAC (Σ PlannedAmt) unchanged (same scope) — only dates + schedule-derived PV move. PV via the SAME linear-fraction × PlannedAmt as `proj_control.evm`, in BigDecimal. **`proj_control.js` untouched.**

### Witness — `erp/tests/whatif_witness.js` (W-WHATIF) — 13/13 §-log pass
```
🟢 §WHATIF-RIPPLE  slip Substructure +30d → all 7 downstream re-fold +30d, finish 2029-05-28→2029-06-27, OFFICIAL untouched
🟢 §WHATIF-FORWARD finishSlipDays=30, bacDelta=0 (64,719,479==blue), PV 37.04M→33.51M at mid-date (Δ -3.53M)
🟢 §WHATIF-ACCEPT  official rows now carry rippled dates; zero blue rows
🟢 §WHATIF-DISCARD fresh commit→discard → official == original, zero blue rows
§WHATIF RESULT 13/13 pass
```
Run: `cd ~/bim-ootb && NODE_PATH=\$HOME/bim-ootb/node_modules node erp/tests/whatif_witness.js`

`viewer.html` loads `whatif.js` after `proj_control.js` (→ `window.WhatIf`). `viewer/sw.js` v693→v694.

The visual slip control on the TM Gantt is a deliberate follow-up — §-log proof gates deploy, not the visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)