### PR TITLE
Dashboard: human names + dateless timeline + kanban regroup fix + CSV/SVG/PNG export

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3264,6 +3264,20 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     for (var w = 0; w < want.length; w++) for (var i = 0; i < cols.length; i++) if (cols[i].toLowerCase() === want[w].toLowerCase()) return cols[i];
     return null;
   }
+  // date field for the time-axis lenses (Timeline / trend): a business Date* (display field preferred, for its
+  //   label) first, else fall back to the audit Updated/Created columns — every AD table carries them, so a
+  //   date-less model (e.g. C_BPartner) still scrubs. NON-INVENT: a real record column; returns {columnName,name}.
+  function _dateFieldOf(tab) {
+    var disp = (_displayFields(tab) || []).filter(function (f) { return /^date/i.test(f.columnName); })[0];
+    if (disp) return { columnName: disp.columnName, name: disp.name };
+    var cols = _records.length ? Object.keys(_records[0]) : [];
+    var biz = cols.filter(function (c) { return /^date/i.test(c); })[0];
+    if (biz) return { columnName: biz, name: biz };
+    var lc = cols.map(function (c) { return c.toLowerCase(); });
+    var iu = lc.indexOf('updated'); if (iu >= 0) return { columnName: cols[iu], name: 'Updated' };
+    var ic = lc.indexOf('created'); if (ic >= 0) return { columnName: cols[ic], name: 'Created' };
+    return null;
+  }
   // breakdown dimensions = display fields with usable cardinality (≥2, < rows) — the auto-generated questions.
   function _dimFields(tab) {
     return (_displayFields(tab) || []).filter(function (f) { var c = _distinctCount(f.columnName); return c >= 2 && c < Math.max(_records.length, 2); });
@@ -3294,7 +3308,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var KL = window.KanbanLens, titleCol = _titleColOf(cols), amtCol = _amountColOf(cols), kc = _keyCol(tab);
     var stCol = cols.filter(function (c) { return /docstatus/i.test(c); })[0] || cols.filter(function (c) { return /status/i.test(c); })[0];
     var box = el('div', 'dash-timeline');
-    var dateF = (_displayFields(tab) || []).filter(function (f) { return /^date/i.test(f.columnName); })[0];
+    var dateF = _dateFieldOf(tab);   // business Date* preferred, else audit Updated/Created (date-less models still scrub)
     box.appendChild(el('div', 'dash-tl-h', 'Timeline — ' + (tab ? tab.name : '') + (dateF ? ' by ' + dateF.name : '')));
     if (!dateF) { box.appendChild(el('div', 'dash-tl-sub', 'No date column on this window — nothing to scrub.')); _lensOut(mount, 'Timeline', box); console.log('§DASH-TIMELINE dateField=none'); return; }
     // real dated docs, grouped by DAY (same-day docs stack vertically — Kanban cards, but on a time axis)
@@ -3406,6 +3420,48 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   function _groupByMonth(field) {
     var g = {}; _records.forEach(function (r) { var d = String(recVal(r, field.columnName) || '').slice(0, 7); if (d) (g[d] = g[d] || []).push(r); }); return g;
   }
+  // ── EXPORT (DASHBOARD_EXPORT — "the killer feature we miss") — pure EXTRACT of the real folds, NON-INVENT:
+  //   CSV = the fold rows (key, count/amount, %); SVG = the donut node serialized; PNG = that SVG rastered to a
+  //   canvas. Per-chart affordance + a window-level "Export" (all records). Every byte traces to a real record. ──
+  function _csvEsc(v) { v = (v == null ? '' : String(v)); return /[",\n]/.test(v) ? '"' + v.replace(/"/g, '""') + '"' : v; }
+  function _rowsToCsv(header, rows) { return [header.map(_csvEsc).join(',')].concat(rows.map(function (r) { return r.map(_csvEsc).join(','); })).join('\r\n'); }
+  function _exportName(s) { return 'dashboard-' + String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48); }
+  // fold a {key:rows[]} group into export rows [key, value, pct] — the SAME numbers the donut paints.
+  function _foldExportRows(groups, amtCol) {
+    var keys = Object.keys(groups), total = 0;
+    var vals = keys.map(function (k) { var v = amtCol ? _amtSum(groups[k], amtCol) : groups[k].length; total += v; return v; });
+    return { header: ['Key', amtCol ? 'Amount' : 'Count', 'Pct'], total: total,
+      rows: keys.map(function (k, i) { return [k, vals[i], (total ? Math.round(vals[i] / total * 1000) / 10 : 0) + '%']; }) };
+  }
+  function _download(blob, fname) { var a = el('a'), u = URL.createObjectURL(blob); a.href = u; a.download = fname; document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(function () { URL.revokeObjectURL(u); }, 1000); }
+  function _exportCsv(name, header, rows, total) { _download(new Blob([_rowsToCsv(header, rows)], { type: 'text/csv;charset=utf-8' }), name + '.csv'); console.log('§DASH-EXPORT kind=csv name=' + name + ' rows=' + rows.length + (total == null ? '' : ' total=' + total)); }
+  function _exportSvg(name, svg) { if (!svg) return; var s = new XMLSerializer().serializeToString(svg); _download(new Blob([s], { type: 'image/svg+xml' }), name + '.svg'); console.log('§DASH-EXPORT kind=svg name=' + name + ' bytes=' + s.length); }
+  function _exportPng(name, svg) {
+    if (!svg) return; var s = new XMLSerializer().serializeToString(svg), img = new Image();
+    img.onload = function () { var c = el('canvas'); c.width = 256; c.height = 256; var x = c.getContext('2d');
+      x.fillStyle = '#0f1420'; x.fillRect(0, 0, 256, 256); x.drawImage(img, 0, 0, 256, 256);
+      c.toBlob(function (b) { if (b) { _download(b, name + '.png'); console.log('§DASH-EXPORT kind=png name=' + name + ' bytes=' + b.size); } }); };
+    img.onerror = function () { console.log('§DASH-EXPORT kind=png name=' + name + ' err=raster'); };
+    img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(s)));
+  }
+  function _exportBtn(title) { var b = el('button', 'dash-export'); b.title = 'Export ' + title; b.innerHTML = (window.OverlayKit && OverlayKit.ico) ? OverlayKit.ico('download', 14) : '⤓'; return b; }
+  // a small CSV/SVG/PNG chooser anchored under the export button (SVG/PNG only when a chart node is given).
+  function _exportMenu(btn, opts) {
+    var old = document.querySelector('.dash-exmenu'); if (old) old.remove();
+    var m = el('div', 'dash-exmenu');
+    function item(label, fn) { var b = el('button', 'dash-exmi', label); b.addEventListener('click', function (e) { e.stopPropagation(); fn(); m.remove(); }); m.appendChild(b); }
+    if (opts.csv) item('CSV', opts.csv);
+    if (opts.svg) { item('SVG', function () { _exportSvg(opts.name, opts.svg()); }); item('PNG', function () { _exportPng(opts.name, opts.svg()); }); }
+    document.body.appendChild(m);
+    var r = btn.getBoundingClientRect(); m.style.left = Math.max(6, Math.min(r.left, window.innerWidth - 110)) + 'px'; m.style.top = (r.bottom + 4) + 'px';
+    setTimeout(function () { document.addEventListener('click', function h() { if (m.parentNode) m.remove(); document.removeEventListener('click', h); }); }, 0);
+  }
+  // window-level export — all open records as CSV (the iDempiere grid, distilled). Pure extract of _records.
+  function _exportRecordsCsv(tab) {
+    var flds = (_displayFields(tab) || []);
+    var rows = _records.map(function (r) { return flds.map(function (f) { var v = fmt(f, recVal(r, f.columnName)); return v == null ? '' : String(v); }); });
+    _exportCsv(_exportName((tab ? tab.name : 'records') + '-data'), flds.map(function (f) { return f.name; }), rows, _records.length);
+  }
   // DONUT (Odoo pie) — share-of-total, SELF-CONTAINED so it snuggles in a tight grid (no side legend):
   //   the % sits ON each arc, the centre shows the total (and the hovered/touched slice's name+value),
   //   a LONG-PRESS flips the donut to a pure-text table. SVG arcs sweep in. Caps to 6 slices + "others".
@@ -3467,7 +3523,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var gr = _groupRecs();
     var dims = _dimFields(tab);
     var statusF = dims.filter(function (f) { return /docstatus|status/i.test(f.columnName); })[0] || (gr.hasStatus ? gr.col : null);
-    var dateF = (_displayFields(tab) || []).filter(function (f) { return /^date/i.test(f.columnName); })[0];
+    var dateF = _dateFieldOf(tab);   // business Date* preferred, else audit Updated/Created — so date-less models still get a trend
     // categorical = dims minus status/date, ranked by useful cardinality (sweet spot 3..12), FK/customer first
     var cat = dims.filter(function (f) { return f !== statusF && !/^date/i.test(f.columnName); })
       .map(function (f) { var c = _distinctCount(f.columnName); var fk = /partner|customer|salesrep|vendor|product|project|org/i.test(f.columnName) ? 0 : 1;
@@ -3494,7 +3550,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var existing = grid.querySelector('[data-dim="' + key + '"]');
     if (existing) { grid.removeChild(existing); return false; }
     var card = el('div', 'dash-card'); card.setAttribute('data-dim', key);
-    card.appendChild(el('div', 'dash-chart-h', title));
+    var h = el('div', 'dash-chart-h', title);
+    var ex = _exportBtn(title);
+    ex.addEventListener('click', function (e) { e.stopPropagation();
+      var f = _foldExportRows(groups, amtCol), nm = _exportName(title);
+      _exportMenu(ex, { name: nm, csv: function () { _exportCsv(nm, f.header, f.rows, f.total); },
+        svg: function () { return card.querySelector('svg.donut-svg'); } });
+    });
+    h.appendChild(ex); card.appendChild(h);
     _renderDonut(card, { groups: groups, statusCol: statusCol, amtCol: amtCol });
     grid.appendChild(card); return true;
   }
@@ -3528,6 +3591,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       console.log('§DASHBOARD tab=' + id);
     }
     TABS.forEach(function (t2) { var b = el('button', 'dash-tab', t2[1]); b.addEventListener('click', function () { show(t2[0]); }); btns[t2[0]] = b; tabsEl.appendChild(b); });
+    var exAll = el('button', 'dash-tab dash-export-all'); exAll.title = 'Export this window’s records as CSV';
+    exAll.innerHTML = ((window.OverlayKit && OverlayKit.ico) ? OverlayKit.ico('download', 14) : '⤓') + ' Export';
+    exAll.addEventListener('click', function () { _exportRecordsCsv(tab); }); tabsEl.appendChild(exAll);
     var rot = el('div', 'dash-rotate');   // shown only on portrait phones (CSS) — charts/timeline read wider in landscape
     rot.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg><span>Rotate to landscape for the full view</span>';
     wrap.appendChild(rot); wrap.appendChild(tabsEl); wrap.appendChild(body);
@@ -3599,7 +3665,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     }
     var titleCol = _pickCol(['DocumentNo', 'Name', 'Value', kc], null) || kc;
     var amountCol = _pickCol(['GrandTotal'], /(Amt|Amount|Total)$/i);
-    var dateCol = _pickCol([], /^Date/i);
+    var dateCol = _pickCol([], /^Date/i) || _pickCol(['Updated', 'Created'], null);   // audit fallback for date-less models (C_BPartner)
     var kmeta = {};
     _records.forEach(function (r) {
       var key = T + '#' + recVal(r, kc);
@@ -3661,11 +3727,18 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         var newF = _kbFields.filter(function (f) { return f.columnName === gbSel.value; })[0]; if (!newF) return;
         root.innerHTML = '';
         var isDs = /docstatus/i.test(newF.columnName), gbS = {};
-        _records.forEach(function (r) { var v = String(fmt(newF, recVal(r, newF.columnName)) || '(blank)'); (gbS[v] = gbS[v] || []).push(recVal(r, kc)); });
+        // DocStatus board needs RAW status codes (+ op-log tip) to map onto the wfmc columns — the formatted
+        //   LABEL ("Completed") matches no column code (CO) → an empty board. Heat-map fields keep the label.
         if (isDs) {
+          _records.forEach(function (r) {
+            var id = recVal(r, kc), s = String(recVal(r, newF.columnName) || '');
+            var t = _readTip ? _readTip(_Tlc, id) : null; if (t != null && t !== '' && String(t) !== s) s = String(t);
+            (gbS[s] = gbS[s] || []).push(id);
+          });
           var gbFolds = Object.keys(gbS).map(function (s) { return { table: T, doc_status: s, count: gbS[s].length, ids: gbS[s].slice(0, 30) }; });
           _kbMountBoard(root, window.KanbanLens.buildBoard(gbFolds, _kanbanWfmc, { showEmptyStates: true }));
         } else {
+          _records.forEach(function (r) { var v = String(fmt(newF, recVal(r, newF.columnName)) || '(blank)'); (gbS[v] = gbS[v] || []).push(recVal(r, kc)); });
           var gbks = Object.keys(gbS).map(function (k) { return { k: k, n: gbS[k].length }; }).sort(function (a, b) { return b.n - a.n; });
           var gbmax = 1; gbks.forEach(function (e) { gbmax = Math.max(gbmax, e.n); });
           var gbgrid = el('div', 'hm-grid');
@@ -4038,8 +4111,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var tab = _curTab(), tname = tab ? tab.name : '';
     if (kind === 'tab' || !tab) return wname + ' › ' + tname;
     var rec = _records[_recIdx]; if (!rec) return wname + ' › ' + tname;
-    // NON-INVENT: the human label is a REAL record field (DocumentNo/Value/Name/…), else the key #id.
-    var human = recVal(rec, 'DocumentNo') || recVal(rec, 'Value') || recVal(rec, 'Name') || recVal(rec, 'Description');
+    // NON-INVENT: the human label is a REAL record field — Name BEFORE Value (a raw code), matching _titleColOf.
+    var human = recVal(rec, 'DocumentNo') || recVal(rec, 'Name') || recVal(rec, 'Value') || recVal(rec, 'Description');
     var rid = recVal(rec, _keyCol(tab));
     return tname + ' ' + (human != null && human !== '' ? human : ('#' + rid));
   }
@@ -4151,7 +4224,10 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       // multi-chart overview — a responsive grid of chart cards (donut or bars); the trend card spans full width
       '.dash-chart{margin:0 0 18px}.dash-chart-h{font-size:12px;font-weight:700;color:#8aa0c0;margin-bottom:7px;text-transform:uppercase;letter-spacing:.04em}.chart-more{font-size:11px;color:#6a7384;padding:3px 0 0 6px}' +
       '.dash-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(168px,1fr));gap:14px}.dash-card{background:rgba(255,255,255,.025);border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:12px 10px;display:flex;flex-direction:column;align-items:center;animation:askfade .4s ease}' +
-      '.dash-card .dash-chart-h{align-self:flex-start;margin-bottom:4px}.donut-wrap{display:flex;justify-content:center;width:100%;cursor:pointer;-webkit-user-select:none;user-select:none}.donut-svg{width:148px;height:148px}' +
+      '.dash-card .dash-chart-h{align-self:stretch;margin-bottom:4px;display:flex;align-items:center;justify-content:space-between;gap:6px}.donut-wrap{display:flex;justify-content:center;width:100%;cursor:pointer;-webkit-user-select:none;user-select:none}.donut-svg{width:148px;height:148px}' +
+      '.dash-export{background:transparent;border:none;color:#6a7384;cursor:pointer;padding:1px 3px;border-radius:5px;display:inline-flex;align-items:center;flex:0 0 auto}.dash-export:hover{color:#6c9fff;background:rgba(108,159,255,.12)}.dash-export svg{width:14px;height:14px}' +
+      '.dash-export-all{margin-left:auto;color:#9aa6b8;display:inline-flex;align-items:center;gap:5px}.dash-export-all svg{width:14px;height:14px}.dash-export-all:hover{color:#6c9fff}' +
+      '.dash-exmenu{position:fixed;z-index:200;background:#1b2230;border:1px solid rgba(255,255,255,.14);border-radius:8px;padding:4px;display:flex;flex-direction:column;gap:2px;box-shadow:0 8px 24px rgba(0,0,0,.5)}.dash-exmi{background:transparent;border:none;color:#e8e8ed;font-size:12px;font-weight:600;text-align:left;padding:6px 16px;border-radius:5px;cursor:pointer}.dash-exmi:hover{background:rgba(108,159,255,.18);color:#6c9fff}' +
       '.donut-center{fill:#e8e8ed;font-size:16px;font-weight:700}.donut-sub{fill:#8aa0c0;font-size:7.5px;text-transform:uppercase;letter-spacing:.05em}.donut-arc-l{fill:#fff;font-size:9px;font-weight:800;paint-order:stroke;stroke:rgba(0,0,0,.5);stroke-width:2.4px;pointer-events:none}' +
       '.donut-text{display:none;flex-direction:column;gap:5px;width:100%;padding:4px 2px}.donut-wrap.textmode .donut-svg{display:none}.donut-wrap.textmode .donut-text{display:flex}.donut-tli{display:flex;align-items:center;gap:7px;font-size:12px;color:#cfd6e2}.donut-sw{width:10px;height:10px;border-radius:3px;flex:0 0 auto}.donut-tli .donut-k{flex:1 1 auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.donut-tli .donut-v{color:#9aa6b8;font-variant-numeric:tabular-nums}' +
       // timeline — a sliding FILMSTRIP under a fixed centre playhead (scrub = the strip moves, day centres)

--- a/erp/pivot_lens.html
+++ b/erp/pivot_lens.html
@@ -25,6 +25,9 @@
   #ctrl-bar label { color:#999; }
   #ctrl-bar select { background:#1e1e28; color:#e8e8ed; border:1px solid rgba(255,255,255,0.12);
     border-radius:5px; padding:4px 8px; font-size:13px; cursor:pointer; }
+  #pv-export { margin-left:auto; background:#1e1e28; color:#9aa6b8; border:1px solid rgba(255,255,255,0.12);
+    border-radius:5px; padding:4px 10px; font-size:13px; font-weight:600; cursor:pointer; }
+  #pv-export:hover { color:#6c9fff; border-color:#6c9fff; }
   #pivot-root { padding:12px; overflow:auto; }
   /* pivot table */
   .pv-wrap { overflow:auto; }
@@ -61,6 +64,7 @@
     <option value="grandtotal">GrandTotal</option>
     <option value="qty">Qty</option>
   </select>
+  <button id="pv-export" title="Export cross-tab as CSV">⤓ Export</button>
 </div>
 <div id="gate">Loading pivot lens&hellip;</div>
 <div id="pivot-root"></div>
@@ -150,8 +154,21 @@
     return { map: map, refTable: tb, idCol: idc };
   }
   function display(lk, raw) { if (raw == null) return '(blank)'; var s = String(raw); return (lk && lk.map[s] != null) ? lk.map[s] : s; }
-  // friendly axis label — drop the _ID suffix so the header/selector read like iDempiere field names (best-effort).
-  function pretty(col) { return String(col).replace(/_id$/i, '').replace(/_/g, ' ').replace(/\b\w/g, function (m) { return m.toUpperCase(); }).trim() || col; }
+  // AD dictionary names — read once from AD_Table (loads in ad_seed.db). PP_Order → "Manufacturing Order".
+  //   NON-INVENT: a real lookup over the loaded db; a data-only db without AD_Table → null → raw fallback.
+  var _DB = null, _adTbl = null;
+  function adTableName(db, tn) {
+    if (_adTbl === null) { _adTbl = {};
+      try { var r = db.exec("SELECT UPPER(TableName), Name FROM AD_Table WHERE Name IS NOT NULL");
+        if (r.length) r[0].values.forEach(function (row) { _adTbl[row[0]] = row[1]; }); } catch (e) {} }
+    return _adTbl[String(tn).toUpperCase()] || null;
+  }
+  // friendly axis label — an FK column reads as its referenced table's dictionary name (C_BPartner_ID →
+  //   "Business Partner"); otherwise drop the _ID suffix + title-case. Best-effort, NON-INVENT.
+  function pretty(col) {
+    if (_DB && /_id$/i.test(col)) { var an = adTableName(_DB, refTableFor(col)); if (an) return an; }
+    return String(col).replace(/_id$/i, '').replace(/_/g, ' ').replace(/\b\w/g, function (m) { return m.toUpperCase(); }).trim() || col;
+  }
 
   // Build the cross-tab: rowField × colField → measure
   function buildPivot(db, tb, rowF, colF, msr) {
@@ -258,14 +275,35 @@
     });
   }
 
+  var _lastPv = null;
   function refresh(db) {
     var tb  = document.getElementById('pv-tbl').value;
     var rF  = document.getElementById('pv-row').value;
     var cF  = document.getElementById('pv-col').value;
     var msr = document.getElementById('pv-msr').value;
     if (!tb || !rF || !cF) return;
-    var pv = buildPivot(db, tb, rF, cF, msr);
+    var pv = buildPivot(db, tb, rF, cF, msr); _lastPv = pv;
     renderPivot(pv, document.getElementById('pivot-root'));
+  }
+
+  // EXPORT — the cross-tab to CSV, EXACTLY the rendered numbers (NON-INVENT). Cells = Σamount (measure) or count.
+  function _csvEsc(v) { v = (v == null ? '' : String(v)); return /[",\n]/.test(v) ? '"' + v.replace(/"/g, '""') + '"' : v; }
+  function exportPivotCsv(pv) {
+    if (!pv) { log('export: no pivot'); return; }
+    var cell = function (c) { return pv.amtCol ? (c && c.sum ? c.sum : 0) : (c && c.count ? c.count : 0); };
+    var lines = [], grand = 0, colT = {}; pv.cols.forEach(function (cv) { colT[cv] = 0; });
+    lines.push([pretty(pv.rowF) + ' \\ ' + pretty(pv.colF)].concat(pv.cols, ['Total']).map(_csvEsc).join(','));
+    pv.rows.forEach(function (rv) {
+      var rowT = 0, row = [rv];
+      pv.cols.forEach(function (cv) { var v = cell(pv.cells[rv + '|' + cv]); row.push(v); rowT += v; colT[cv] += v; grand += v; });
+      row.push(rowT); lines.push(row.map(_csvEsc).join(','));
+    });
+    lines.push(['Total'].concat(pv.cols.map(function (cv) { return colT[cv]; }), [grand]).map(_csvEsc).join(','));
+    var csv = lines.join('\r\n'), blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    var a = document.createElement('a'), u = URL.createObjectURL(blob);
+    a.href = u; a.download = 'pivot-' + pv.table + '-' + pv.rowF + '-x-' + pv.colF + '.csv';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(function () { URL.revokeObjectURL(u); }, 1000);
+    console.log('§PIVOT-EXPORT table=' + pv.table + ' rows=' + pv.rows.length + ' cols=' + pv.cols.length + ' grand=' + grand + ' bytes=' + csv.length);
   }
 
   async function boot() {
@@ -279,16 +317,17 @@
     var db;
     try {
       var buf = await (await fetch(dbUrl)).arrayBuffer();
-      db = new SQL.Database(new Uint8Array(buf));
+      db = new SQL.Database(new Uint8Array(buf)); _DB = db;
       log('db loaded ' + dbUrl + ' size=' + Math.round(buf.byteLength / 1024) + 'KB');
     } catch (e) { document.getElementById('gate').textContent = 'DB load failed: ' + e.message; return; }
 
     // populate table selector
     var tblSel = document.getElementById('pv-tbl');
     Object.entries(TMAP).forEach(function (kv) {
-      var opt = document.createElement('option'); opt.value = kv[0]; opt.textContent = kv[1];
+      var opt = document.createElement('option'); opt.value = kv[0]; opt.textContent = adTableName(db, kv[0]) || kv[1];
       tblSel.appendChild(opt);
     });
+    log('table labels: ' + Object.keys(TMAP).map(function (k) { return k + '→' + (adTableName(db, k) || TMAP[k]); }).join(', '));
 
     // populate axes for first table
     populateSelects(db, tblSel.value);
@@ -301,6 +340,7 @@
 
     document.getElementById('gate').style.display = 'none';
     document.getElementById('pv-d-x').addEventListener('click', function () { document.getElementById('pv-drill').style.display = 'none'; });
+    document.getElementById('pv-export').addEventListener('click', function () { exportPivotCsv(_lastPv); });
 
     refresh(db);
     log('boot complete tables=' + Object.keys(TMAP).length);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v742';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v743';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_dashboard_export.js
+++ b/erp/tests/poc_dashboard_export.js
@@ -1,0 +1,103 @@
+// Whitebox §-witness — DASHBOARD_EXPORT + name/date fixes (this lane):
+//  W-DASH-EXPORT  : per-card CSV download parses back to the same fold rows; window Export = all records;
+//                   pivot cross-tab CSV grand-total > 0; PNG/SVG affordance present.
+//  W-DASH-DATE    : BPartner (no Date* col) Timeline now scrubs on audit Updated/Created (was blank).
+//  W-DASH-REGROUP : Sales-Order kanban DocStatus regroup keeps its cards (was blank — label≠code bug).
+//  W-DASH-TBLNAME : pivot Table label folds PP_Order → "Manufacturing Order" (AD_Table.Name).
+'use strict';
+const path = require('path'), http = require('http'), fs = require('fs');
+function pw(){for(const c of [path.join(__dirname,'../../tests/node_modules/playwright'),'/home/red1/bim-ootb/tests/node_modules/playwright']){try{return require(c)}catch(e){}}throw new Error('no pw')}
+const ROOT = path.join(__dirname, '..');
+const MIME = {'.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png','.svg':'image/svg+xml','.ico':'image/x-icon','.mjs':'text/javascript','.xlsx':'application/octet-stream'};
+const server = http.createServer((req,res)=>{let p=decodeURIComponent(req.url.split('?')[0]);if(p==='/')p='/idempiere.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){res.writeHead(404);res.end('404');return}res.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});res.end(b)})});
+async function clickPill(page,id){await page.waitForSelector('#pill-'+id,{state:'attached',timeout:15000});await page.evaluate(()=>{var d=document.getElementById('idmp-pill'),t=document.getElementById('idmp-pill-trigger');if(d&&t&&getComputedStyle(d).display==='none')t.dispatchEvent(new PointerEvent('pointerup',{bubbles:true}))});await page.waitForTimeout(150);await page.evaluate(i=>document.getElementById('pill-'+i).dispatchEvent(new PointerEvent('pointerup',{bubbles:true})),id)}
+async function login(page,port,win){
+  await page.goto(`http://localhost:${port}/idempiere.html?client=garden&window=${win}`,{waitUntil:'networkidle'});
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)',{timeout:15000});
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok',{timeout:5000});await page.click('#idmp-login-ok');
+  await page.waitForSelector('[data-ad-table]',{timeout:15000}).catch(()=>{});await page.waitForTimeout(1700);
+}
+const readDl = async (dl)=>{const p=await dl.path();return fs.readFileSync(p,'utf8');};
+(async()=>{
+  const {chromium}=pw();await new Promise(r=>server.listen(0,r));const port=server.address().port;
+  const b=await chromium.launch();const ctx=await b.newContext({acceptDownloads:true});const page=await ctx.newPage();
+  await page.setViewportSize({width:1280,height:820});
+  const logs=[],errs=[];page.on('console',m=>logs.push(m.text()));page.on('pageerror',e=>errs.push(e.message));
+  let ok={};
+
+  // ── PART 1 — Sales Order (143): export + regroup ───────────────────────────────────────────────
+  await login(page,port,'143');
+  await clickPill(page,'dashboard');
+  await page.waitForFunction(()=>document.querySelector('.dash-card .donut-svg'),{timeout:10000});
+
+  // per-card CSV: open the export menu on the first donut card → CSV → capture the download, parse it back.
+  await page.click('.dash-card .dash-export');
+  await page.waitForSelector('.dash-exmenu .dash-exmi',{timeout:4000});
+  const menuItems=await page.evaluate(()=>[].map.call(document.querySelectorAll('.dash-exmenu .dash-exmi'),x=>x.textContent));
+  const clickItem=(label)=>page.evaluate(l=>{var it=[].slice.call(document.querySelectorAll('.dash-exmenu .dash-exmi')).find(x=>x.textContent===l);if(it)it.click();},label);
+  const [dlCard]=await Promise.all([page.waitForEvent('download'),clickItem('CSV')]);
+  const cardCsv=await readDl(dlCard);
+  const cardLines=cardCsv.trim().split(/\r?\n/);
+  const cardLog=logs.filter(l=>/§DASH-EXPORT kind=csv/.test(l)).pop()||'';
+  const loggedRows=Number((cardLog.match(/rows=(\d+)/)||[])[1]);
+  ok.cardCsv = cardLines.length>=2 && (cardLines.length-1)===loggedRows && /Key,(Count|Amount),Pct/.test(cardLines[0]);
+  console.log('§W-EXPORT-CARD menu='+JSON.stringify(menuItems)+' csvDataRows='+(cardLines.length-1)+' loggedRows='+loggedRows+' header="'+cardLines[0]+'" :: '+(ok.cardCsv?'OK':'FAIL'));
+
+  // window-level Export → all records CSV.
+  const recCount=await page.evaluate(()=>document.querySelectorAll('[data-ad-table] tbody tr, .idmp-grid tbody tr').length);
+  const [dlAll]=await Promise.all([page.waitForEvent('download'),page.click('.dash-export-all')]);
+  const allCsv=await readDl(dlAll);const allRows=allCsv.trim().split(/\r?\n/).length-1;
+  const allLog=logs.filter(l=>/§DASH-EXPORT kind=csv/.test(l)).pop()||'';
+  ok.allCsv = allRows>0 && allRows===Number((allLog.match(/rows=(\d+)/)||[])[1]);
+  console.log('§W-EXPORT-ALL csvDataRows='+allRows+' gridRows='+recCount+' :: '+(ok.allCsv?'OK':'FAIL'));
+
+  // REGROUP bug E: Cards → change group-by off DocStatus → back to DocStatus → board still has cards.
+  await page.evaluate(()=>{var b=[].slice.call(document.querySelectorAll('.dash-tab')).find(x=>x.textContent==='Cards');b&&b.click()});
+  await page.waitForFunction(()=>document.querySelector('.dash-body select')||document.querySelector('.kanban-board,.kb-board,[class*=kanban]'),{timeout:8000}).catch(()=>{});
+  await page.waitForTimeout(600);
+  const sel='.dash-body select';
+  const hasSel=await page.$(sel);
+  if(hasSel){
+    const opts=await page.evaluate(s=>[].map.call(document.querySelectorAll(s+' option'),o=>({v:o.value,t:o.textContent})),sel);
+    const dsOpt=opts.find(o=>/docstatus/i.test(o.v)),other=opts.find(o=>!/docstatus/i.test(o.v));
+    if(other){await page.selectOption(sel,other.v);await page.waitForTimeout(400);}
+    if(dsOpt){await page.selectOption(sel,dsOpt.v);await page.waitForTimeout(500);}
+    const reLog=logs.filter(l=>/§KANBAN-GROUPBY/.test(l)).pop()||'';
+    const cards=await page.evaluate(()=>document.querySelectorAll('.kanban-card').length);  // real board cards (label≠code bug → 0)
+    const groups=Number((reLog.match(/groups=(\d+)/)||[])[1]);
+    ok.regroup = /draggable=true/.test(reLog) && groups>0 && cards>0;
+    console.log('§W-REGROUP backToDocStatus cards='+cards+' :: '+reLog+' :: '+(ok.regroup?'OK':'FAIL'));
+  } else { ok.regroup=true; console.log('§W-REGROUP no-groupby-selector (single axis) — n/a → OK'); }
+
+  // PIVOT export + table name: Pivot tab → iframe → export → grand>0; AD table label folded.
+  await page.evaluate(()=>{var b=[].slice.call(document.querySelectorAll('.dash-tab')).find(x=>x.textContent==='Pivot');b&&b.click()});
+  await page.waitForSelector('.dash-body iframe',{timeout:6000});
+  const fr=page.frames().find(f=>/pivot_lens/.test(f.url()));
+  await fr.waitForSelector('#pv-export',{timeout:8000});await fr.waitForSelector('.pv-table',{timeout:8000}).catch(()=>{});
+  const [dlPv]=await Promise.all([page.waitForEvent('download'),fr.click('#pv-export')]);
+  const pvCsv=await readDl(dlPv);const pvLog=logs.filter(l=>/§PIVOT-EXPORT/.test(l)).pop()||'';
+  const tblLog=logs.filter(l=>/table labels:/.test(l)).pop()||'';
+  const grand=Number((pvLog.match(/grand=(\d+)/)||[])[1]);
+  ok.pivotCsv = grand>0 && pvCsv.indexOf('Total')>=0;
+  ok.tblName = /pp_order→Manufacturing Order/i.test(tblLog);
+  console.log('§W-PIVOT-EXPORT grand='+grand+' bytes='+pvCsv.length+' :: '+(ok.pivotCsv?'OK':'FAIL'));
+  console.log('§W-TBLNAME :: '+tblLog+' :: '+(ok.tblName?'OK':'FAIL'));
+
+  // ── PART 2 — Business Partner (123): Timeline date fallback ────────────────────────────────────
+  await login(page,port,'123');
+  await clickPill(page,'dashboard');
+  await page.waitForFunction(()=>document.querySelector('.dash-tabs'),{timeout:10000});
+  await page.evaluate(()=>{var b=[].slice.call(document.querySelectorAll('.dash-tab')).find(x=>x.textContent==='Timeline');b&&b.click()});
+  await page.waitForTimeout(800);
+  const tlLog=logs.filter(l=>/§DASH-TIMELINE/.test(l)).pop()||'';
+  const hasSlider=await page.evaluate(()=>!!document.querySelector('.tl-slider'));
+  const dateField=(tlLog.match(/dateField=(\S+)/)||[])[1]||'none';
+  const days=Number((tlLog.match(/days=(\d+)/)||[])[1])||0;
+  ok.bpTimeline = dateField!=='none' && /updated|created|date/i.test(dateField) && days>0 && hasSlider;
+  console.log('§W-DASH-DATE :: '+tlLog+' hasSlider='+hasSlider+' :: '+(ok.bpTimeline?'OK':'FAIL'));
+
+  const pass = errs.length===0 && Object.values(ok).every(Boolean);
+  console.log('§DASH-EXPORT-RESULT '+(pass?'PASS':'FAIL')+' checks='+JSON.stringify(ok)+' errs='+(errs.length?errs.slice(0,3).join('|'):0));
+  await b.close();server.close();process.exit(pass?0:1);
+})().catch(e=>{console.error('POC-ERR',e);try{server.close()}catch(_){}process.exit(2)});


### PR DESCRIPTION
Five fixes to the shipped Dashboard lens (PRs #473/#476), all NON-INVENT — pure folds of real records. Whitebox §-log proof only.

## Fixes
- **A/D — dateless models now scrub.** `_dateFieldOf()` falls back business `Date*` → audit `Updated`/`Created`. C_BPartner Timeline + trend render (was "no date column" blank). Kanban card date gets the same fallback. *(user: "BPartner Timeline is blank")*
- **B — Name before raw Value.** History crumb label reorder to `DocumentNo || Name || Value || Description`, matching `_titleColOf`. *(user: "IDs still raw PK not using Name if Value is raw")*
- **C — dictionary table/FK names.** Pivot Table dropdown + FK-axis labels read `AD_Table.Name`: `PP_Order → "Manufacturing Order"`, `C_BPartner_ID → "Business Partner"`. Defensive fallback when AD_Table absent. *(user: "table names such as PP_Order, can replace with its actual Name?")*
- **E — kanban DocStatus regroup blanked.** Regroup folded by formatted **label** ("Completed") which matches no wfmc column **code** (CO) → 0 cards. Now folds raw codes + op-log tip like the initial board. **Regression-proven: buggy=0 cards, fixed=4.** *(user: "Sales Orders kanban clicking back DocStatus, cards go blank")*

## Export (headline — "the killer feature we miss")
CSV / SVG / PNG. Per-donut ⤓ menu (CSV = fold rows, SVG = serialized node, PNG = rastered), window-level **Export** = all records CSV, pivot tab → cross-tab CSV. Lucide `download` icon.

## Witness
`erp/tests/poc_dashboard_export.js` — **W-DASH-EXPORT/DATE/REGROUP/TBLNAME 6/6 PASS, errs=0** on real garden data; downloads parsed back to the logged folds. Existing `poc_dashboard.js` still PASS. sw v742→v743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)