### PR TITLE
Dashboard: highlight charted Explore chips + memoize fold/count helpers (perf)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3115,7 +3115,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     ov.appendChild(hd); ov.appendChild(node); document.body.appendChild(ov);
   }
   // distinct-value count of a column across the open window's records (heat-map cardinality scoring).
-  function _distinctCount(col) { var s = {}; _records.forEach(function (r) { s[String(recVal(r, col))] = 1; }); return Object.keys(s).length; }
+  // ── dashboard compute cache — _distinctCount/_groupRecsBy/_groupRecs are recomputed many times per open
+  //   (each a full _records scan, the folds also re-run fmt per row). Memoize per CURRENT _records array;
+  //   auto-invalidates when _records is reassigned (window/record load) or its length changes — no call-site
+  //   bookkeeping, and a stale fold can never outlive the data it folded. Pure reads, behaviour-identical. ──
+  var _dcCache = {}, _grpCache = {}, _grCache = null, _cacheArr = null, _cacheLen = -1;
+  var _dcCalls = 0, _dcComputes = 0, _grpCalls = 0, _grpComputes = 0;   // whitebox: calls ≫ computes ⇒ dedup working
+  function _dashCacheGate() { if (_cacheArr !== _records || _cacheLen !== _records.length) { _cacheArr = _records; _cacheLen = _records.length; _dcCache = {}; _grpCache = {}; _grCache = null; } }
+  function _distinctCount(col) { _dashCacheGate(); _dcCalls++; if (col in _dcCache) return _dcCache[col]; _dcComputes++; var s = {}; _records.forEach(function (r) { s[String(recVal(r, col))] = 1; }); return (_dcCache[col] = Object.keys(s).length); }
   // Pick the best CATEGORICAL/lookup column for a heat map when there is no docstatus lifecycle: prefer
   // declared FK/list references (tableDirect/table/search/list/yesno) or *_ID columns, with cardinality in a
   // useful band (≥2, < rows — never constant, never unique-per-row). Falls back to any usable column.
@@ -3133,13 +3140,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     return best;
   }
   function _groupRecs() {
+    _dashCacheGate(); if (_grCache) return _grCache;
     var tab = _curTab(); if (!tab || !_records.length) return null;
     var flds = _displayFields(tab) || [], pick = null, hasStatus = false;
     for (var i = 0; i < flds.length; i++) { var cn = (flds[i].columnName || '').toLowerCase(); if (cn.indexOf('docstatus') >= 0 || cn.indexOf('status') >= 0) { pick = flds[i]; hasStatus = true; break; } }
     if (!pick) pick = _bestPivot(tab) || flds[0];   // no lifecycle → a sensible lookup, NOT a blind flds[0]
     if (!pick) return null;
     var g = {}; _records.forEach(function (r) { var v = String(fmt(pick, recVal(r, pick.columnName)) || '(blank)'); (g[v] = g[v] || []).push(r); });
-    return { col: pick, label: pick.name, groups: g, tab: tab, hasStatus: hasStatus };
+    return (_grCache = { col: pick, label: pick.name, groups: g, tab: tab, hasStatus: hasStatus });
   }
   // Heat map = the no-pivot fallback for the Kanban (a board with no wfmc states has no drop-zones, so an
   // empty board is useless): tiles per distinct lookup value, intensity ∝ count. Counts are REAL row folds.
@@ -3283,7 +3291,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     return (_displayFields(tab) || []).filter(function (f) { var c = _distinctCount(f.columnName); return c >= 2 && c < Math.max(_records.length, 2); });
   }
   function _groupRecsBy(field) {
-    var g = {}; _records.forEach(function (r) { var v = String(fmt(field, recVal(r, field.columnName)) || '(blank)'); (g[v] = g[v] || []).push(r); }); return g;
+    _dashCacheGate(); _grpCalls++; var k = field.columnName; if (k in _grpCache) return _grpCache[k];
+    _grpComputes++; var g = {}; _records.forEach(function (r) { var v = String(fmt(field, recVal(r, field.columnName)) || '(blank)'); (g[v] = g[v] || []).push(r); });
+    return (_grpCache[k] = g);
   }
   // List lens — the records as a compact table (the iDempiere grid, distilled).
   function openListInto(mount) {
@@ -3364,7 +3374,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var gr = _groupRecs();
     // collapsible header — a chevron toggles the body (default collapsed on phones to keep first sight clean)
     var hd = el('button', 'ask-head'); var chev = el('span', 'ask-chev', '▾');
-    hd.appendChild(el('span', null, 'Explore — tap a cut')); hd.appendChild(chev);
+    hd.appendChild(el('span', null, 'Explore — tap a cut to chart it')); hd.appendChild(chev);
     var bodyA = el('div', 'ask-body');
     abox.appendChild(hd); abox.appendChild(bodyA);
     var line = el('div', 'ask-summary'); bodyA.appendChild(line);
@@ -3382,15 +3392,21 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var cols = _records.length ? Object.keys(_records[0]) : [], titleCol = _titleColOf(cols);
     var dims = _dimFields(tab);
     // a "By X" chip TOGGLES a donut for X into the LEFT grid (fills the empty spot); 2nd tap removes it.
+    //   Chips whose chart is ALREADY on the grid (the auto-picked overview donuts) start HIGHLIGHTED (.on) +
+    //   tooltip — so the user sees that these chips drive those donuts (tap to remove, tap any other to add).
+    var _titleOn = 'Shown on the left — tap to remove', _titleOff = 'Tap to chart this on the left';
     dims.forEach(function (f) {
-      var chip = el('button', 'ask-chip', 'By ' + f.name);
+      var shown = !!grid.querySelector('[data-dim="' + f.columnName + '"]');
+      var chip = el('button', 'ask-chip' + (shown ? ' on' : ''), 'By ' + f.name);
+      chip.title = shown ? _titleOn : _titleOff;
       chip.addEventListener('click', function () {
         var added = _addDonutCard(grid, f.columnName, 'By ' + f.name, _groupRecsBy(f), /status/i.test(f.columnName) ? f.columnName : null, amtCol);
-        chip.classList.toggle('on', added);
+        chip.classList.toggle('on', added); chip.title = added ? _titleOn : _titleOff;
         console.log('§ASK chip=by-' + f.columnName + ' added=' + added);
       });
       chips.appendChild(chip);
     });
+    console.log('§ASK-CHIPS-SYNC shownOnLoad=' + chips.querySelectorAll('.on').length + ' totalChips=' + dims.length);
     if (amtCol) {
       var topChip = el('button', 'ask-chip', 'Top 3 by ' + amtCol);
       topChip.addEventListener('click', function () {
@@ -3415,6 +3431,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       }
     }
     console.log('§ASK-PANEL summaryLen=' + s.length + ' chips=' + chips.children.length + ' dims=' + dims.length + ' collapsed=' + collapsed);
+    // whitebox perf: full Graph build done — distinctCount/groupBy were called far more than computed (memoized).
+    console.log('§DASH-CACHE distinctCount calls=' + _dcCalls + ' computes=' + _dcComputes + ' · groupBy calls=' + _grpCalls + ' computes=' + _grpComputes + ' (saved ' + ((_dcCalls - _dcComputes) + (_grpCalls - _grpComputes)) + ' full scans)');
   }
   // month-bucket a date column → { 'YYYY-MM': rows[] }, chronological (the trend chart).
   function _groupByMonth(field) {
@@ -3565,6 +3583,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   //   paints instantly then streams the Ask panel in (never blocks first sight). FUNDAMENTAL LAW: a ⋯-rail lens.
   function openDashboard() {
     if (!_session) { status('Log in first'); return; }
+    _cacheArr = null;   // force a fresh compute-cache for this open (covers in-place record edits since last open)
+    _dcCalls = _dcComputes = _grpCalls = _grpComputes = 0;
     var tab = _curTab(); var gr = _groupRecs();
     if (!gr) { status('Open a window with records first'); return; }
     var amtCol = _amountColOf(_records.length ? Object.keys(_records[0]) : []);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v743';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v744';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_dashboard_export.js
+++ b/erp/tests/poc_dashboard_export.js
@@ -31,6 +31,20 @@ const readDl = async (dl)=>{const p=await dl.path();return fs.readFileSync(p,'ut
   await clickPill(page,'dashboard');
   await page.waitForFunction(()=>document.querySelector('.dash-card .donut-svg'),{timeout:10000});
 
+  // CHIP SYNC — Explore chips for already-shown donuts start highlighted (.on); §ASK-CHIPS-SYNC shownOnLoad>0.
+  await page.waitForFunction(()=>document.querySelector('.dash-side .ask-chip'),{timeout:5000}).catch(()=>{});
+  await page.waitForTimeout(150);
+  const onChips=await page.evaluate(()=>document.querySelectorAll('.dash-side .ask-chip.on').length);
+  const syncLog=logs.filter(l=>/§ASK-CHIPS-SYNC/.test(l)).pop()||'';
+  const syncShown=Number((syncLog.match(/shownOnLoad=(\d+)/)||[])[1]);
+  ok.chipSync = onChips>0 && syncShown>0 && onChips===syncShown;
+  console.log('§W-CHIP-SYNC domOn='+onChips+' :: '+syncLog+' :: '+(ok.chipSync?'OK':'FAIL'));
+  // PERF — distinctCount/groupBy memoized: §DASH-CACHE calls ≫ computes (saved scans>0).
+  const cacheLog=logs.filter(l=>/§DASH-CACHE/.test(l)).pop()||'';
+  const saved=Number((cacheLog.match(/saved (\d+)/)||[])[1]);
+  ok.cache = /§DASH-CACHE/.test(cacheLog) && saved>0;
+  console.log('§W-CACHE :: '+cacheLog+' :: '+(ok.cache?'OK':'FAIL'));
+
   // per-card CSV: open the export menu on the first donut card → CSV → capture the download, parse it back.
   await page.click('.dash-card .dash-export');
   await page.waitForSelector('.dash-exmenu .dash-exmi',{timeout:4000});


### PR DESCRIPTION
Follow-up to #479, two user asks.

## 1. Explore chips show what's charted
Chips whose donut is **already** on the grid (the auto-picked overview charts) now start **highlighted** (`.on`) with a tooltip, so the chip↔donut link is obvious — tap a lit chip to remove its chart, tap any other to add one. Header → *"Explore — tap a cut to chart it"*.
Witness `§ASK-CHIPS-SYNC shownOnLoad=5` == 5 lit chips == 5 donuts.

## 2. Perf — fewer redundant record scans
`_distinctCount` / `_groupRecsBy` / `_groupRecs` were recomputed many times per dashboard open (each a full `_records` scan; the folds also re-run `fmt` per row). Now **memoized per the current `_records` array** — auto-invalidates when `_records` is reassigned (window/record load) or its length changes, and `openDashboard` forces a fresh cache so in-place edits can't go stale. Pure reads → behaviour-identical. (`resolveFK` was already cached, so this targets the *scans*.)
Witness `§DASH-CACHE`: distinctCount **135 calls → 60 computes (75 full scans saved)** on a 4-row window; scales with rows×fields.

## Witness
`erp/tests/poc_dashboard_export.js` — **W-DASH-EXPORT 8/8 PASS** (adds `chipSync` + `cache` checks), errs=0. Existing `poc_dashboard.js` still PASS. sw v743→v744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)