### PR TITLE
feat(modeller): §GEO_SUMMARY runtime self-proof on BOM drop (LAST_MILE §7 JS twin)

### DIFF
--- a/viewer/bonsai_library.js
+++ b/viewer/bonsai_library.js
@@ -151,6 +151,55 @@
       });
       return out;
     },
+
+    // ── §GEO_SUMMARY — the drop's OWN runtime drift verdict (the JS twin of the Java compiler's `[GEO] SUMMARY`,
+    // LAST_MILE_PROBLEM.md §7 "Next step for coder"). After a BOM is dropped, the modeller recomputes the proven
+    // IntraBOM invariant over the EXPANDED placement and emits ONE self-contained §-log line — so expandAssembly
+    // POLICES ITSELF at runtime, instead of correctness living only in the external witness (W-MODELLER-DROP).
+    // Faithful to IntraBOMRelativeTest (= scripts/witness_modeller_drop.js checkInvariant), scoped by bom_TYPE:
+    //   • R1 |dx|,|dy| < 10m  and  R2 |dz| < 4.5m  for every SET/ROOM bom leaf offset
+    //   • R3 absolute-leak gate: a SET/ROOM expanded at origin keeps its all-pairs leaf-CENTRE span within its own
+    //     footprint env = max(declared bbox, 10m room-scale) + 3m. A leaf flung to building-absolute coords (the
+    //     PR#478 scatter — DX ±22.8m when MIRROR was mis-handled or the sub-BOM origin / ½-extent dropped) blows
+    //     the span past env → DRIFT. FLOOR/BUILDING boms are EXEMPT from R1/R2/R3 (legit building-scale offsets
+    //     the Java resolves additively against the tack origin) — only their SET/ROOM descendants are gated.
+    // worst = the worst single excess (R1/R2 overage or R3 pair-span excess) in mm; DRIFT = total violations.
+    // LOG-ONLY: reads the catalog + expandAssembly output, never mutates geometry or the op-log → cannot regress
+    // geometry. On the proven catalog every droppable root is `worst=0mm, DRIFT=0`; DRIFT>0 = a port regression.
+    geoSummary(rootId) {
+      const root = ASM_BY_ID[rootId]; if (!root) return null;
+      const R1 = 10, R2 = 4.5, ENV_FLOOR = 10, ENV_TOL = 3;
+      let viol = 0, worst = 0; const detail = [], seen = {};
+      const span = (vals) => { let mn = Infinity, mx = -Infinity; for (let i = 0; i < vals.length; i++) { const v = vals[i]; if (v < mn) mn = v; if (v > mx) mx = v; } return mx - mn; };
+      const walk = (id) => {
+        const a = ASM_BY_ID[id]; if (!a || seen[id]) return; seen[id] = true;
+        const scoped = !(a.level === 'FLOOR' || a.level === 'BUILDING');   // IntraBOM scoping: SET/ROOM only
+        (a.children || []).forEach(ch => {
+          if (ch.isBom) { walk(ch.ref); return; }
+          if (!scoped) return;
+          const e1 = Math.max(Math.abs(ch.dx) - R1, Math.abs(ch.dy) - R1);
+          if (e1 > 0) { viol++; worst = Math.max(worst, e1); detail.push('R1 ' + id + '/' + ch.role + ' dx=' + ch.dx + ' dy=' + ch.dy); }
+          const e2 = Math.abs(ch.dz || 0) - R2;
+          if (e2 > 0) { viol++; worst = Math.max(worst, e2); detail.push('R2 ' + id + '/' + ch.role + ' dz=' + ch.dz); }
+        });
+        if (scoped) {                                                      // R3 all-pairs span vs own envelope
+          const ex = this.expandAssembly(id, { x: 0, y: 0, z: 0, rot: 0 });
+          if (ex.length > 1) {
+            const sX = span(ex.map(l => l.x)), sY = span(ex.map(l => l.y));
+            const envX = Math.max(a.w || 0, ENV_FLOOR) + ENV_TOL, envY = Math.max(a.d || 0, ENV_FLOOR) + ENV_TOL;
+            const e3 = Math.max(sX - envX, sY - envY);
+            if (e3 > 0) { viol++; worst = Math.max(worst, e3); detail.push('R3 ' + id + ' span=' + sX.toFixed(1) + 'x' + sY.toFixed(1) + ' env=' + envX.toFixed(1) + 'x' + envY.toFixed(1)); }
+          }
+        }
+      };
+      walk(rootId);
+      const all = this.expandAssembly(rootId, { x: 0, y: 0, z: 0, rot: 0 });
+      const n = all.length, pairs = n * (n - 1) / 2, worstMm = Math.round(worst * 1000);
+      console.log('§GEO_SUMMARY ' + rootId + ' [' + root.level + '] ' + n + ' leaves, ' + pairs + ' pairs, worst=' + worstMm + 'mm, DRIFT=' + viol);
+      if (viol) console.warn(TAG + ' §GEO_SUMMARY DRIFT ' + viol + ' — port regression (expected 0): ' + detail.slice(0, 6).join(' | '));
+      return { rootId, level: root.level, leaves: n, pairs, worstMm, drift: viol, detail };
+    },
+
     setLod(featureId, lod) { this._lod[featureId] = String(lod); return this; },
     lodFor(featureId, fallback) { return this._lod[featureId] || fallback || '200'; },
 

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -183,7 +183,7 @@
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=10" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=11" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
@@ -1490,6 +1490,7 @@ async function placeAssembly(x, y) {
   lastInsertId = placed[placed.length - 1].id; bLod.style.display = ''; bLod.disabled = false; paintLod();
   setStat('assembled ' + (asm ? asm.name : insertHash) + ' → ' + placed.length + ' parts placed (signed)'); audioCue('commit'); syncHistory();
   console.log('§MODELLER assembly-drop ' + insertHash + ' parts=' + placed.length);
+  try { L.geoSummary(insertHash); } catch (e) { console.warn('§GEO_SUMMARY failed ' + e); }  // runtime self-proof (LAST_MILE §7)
   // refine ALL leaves to real meshes in ONE pass: load the geom store once, set LOD-300 per leaf, single re-fold.
   // SELF-HEALING (W-BONSAI-LOD-RESILIENT): if the geometries fetch hiccups, the leaves land as LOD-200 boxes; with
   // the resilient ensureMesh, RETRY the load up to twice (300ms apart) so a transient drop doesn't leave the user

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v697';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v698';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
The modeller BOM drop now emits its own runtime drift verdict — the JS twin of the Java compiler's `[GEO] SUMMARY` (docs/LAST_MILE_PROBLEM.md §7 "Next step for coder"). `expandAssembly` polices itself at runtime instead of correctness living only in the external witness.

On every drop:
```
§GEO_SUMMARY BUILDING_SH_STD [BUILDING] 55 leaves, 1485 pairs, worst=0mm, DRIFT=0
```

## How
- `bonsai_library.js` **`geoSummary(rootId)`** — recomputes the proven IntraBOM invariant (faithful to `IntraBOMRelativeTest` / `witness_modeller_drop.js checkInvariant`), scoped by bom_type:
  - R1 `|dx|,|dy|<10m` + R2 `|dz|<4.5m` for SET/ROOM leaf offsets
  - R3 absolute-leak gate: all-pairs leaf-centre span vs `env = max(declared bbox, 10m)+3m` — catches a leaf flung to building-absolute coords (the **PR#478 scatter class**, DX ±22.8m)
  - FLOOR/BUILDING exempt (legit building-scale offsets); only SET/ROOM descendants gated
  - **LOG-ONLY** — reads catalog + `expandAssembly`, never mutates geometry or the op-log → cannot regress geometry
- `modeller.html placeAssembly` calls `L.geoSummary(insertHash)` after the drop
- `bonsai_library.js?v=10→11`, `sw v697→v698`

## Proof — W-GEO-SUMMARY (`scripts/witness_modeller_geo_summary.js`, bim-compiler)
- **G2** all **57** droppable roots (SET:33 ROOM:5 FLOOR:16 BUILDING:3, maxLeaves=1099) report `DRIFT=0 / worst=0mm`
- **G3** line format matches the Java `[GEO] SUMMARY` twin
- **G4 falsifiability** — the gate FIRES (`worst=4844mm, DRIFT=1`) on a simulated PR#478 scatter (MIRROR ignored + origin/½-extent dropped). A self-proof that can only say PASS is not a proof.
- `W-MODELLER-DROP` unchanged (host == Java oracle 0.000mm) — additive method, single call-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)