### PR TITLE
fix(modeller): basic BOM drop lands on the cursor — centre on the true footprint

### DIFF
--- a/viewer/bonsai_library.js
+++ b/viewer/bonsai_library.js
@@ -145,6 +145,10 @@
             cx = wx + sign * hw; cy = wy + sign * hd;     // x/y get +half = box CENTRE (place() centres in x/y).
             // cz stays wz: bboxFromDims bases the proxy box at z=0, so place() seats the BASE at z = LBD bottom
             // (= the BOM dz); the Java AABB minZ is exactly dz, so NO half is added in z (would float the box).
+            // ⚠ NOTE: the +half is added along WORLD axes, NOT rotated by the drop yaw — correct at yaw=0 (the
+            // basic drop) but one of several reasons ROTATED drops are not yet a faithful port (KNOWN ⛔; needs
+            // the Java PlacementCollectorVisitor cumulative reflect∘rotate transform ported as a unit, not
+            // piecemeal). The reported "basic BOM drop" issue was CENTRING (dropOrigin), not this.
           }
           out.push({ hash: ch.ref, x: +cx.toFixed(4), y: +cy.toFixed(4), z: +cz.toFixed(4), rot: wrot, role: ch.role });
         }
@@ -198,6 +202,37 @@
       console.log('§GEO_SUMMARY ' + rootId + ' [' + root.level + '] ' + n + ' leaves, ' + pairs + ' pairs, worst=' + worstMm + 'mm, DRIFT=' + viol);
       if (viol) console.warn(TAG + ' §GEO_SUMMARY DRIFT ' + viol + ' — port regression (expected 0): ' + detail.slice(0, 6).join(' | '));
       return { rootId, level: root.level, leaves: n, pairs, worstMm, drift: viol, detail };
+    },
+
+    // ── TRUE leaf-footprint AABB of a dropped assembly (W-BOM-DROP-CENTER). Expand the BOM to its N leaf boxes
+    // and union their world AABBs — the ACTUAL footprint the parts occupy. This is NOT the catalog's declared
+    // aabb (asm.w/d): that is the parent-PRODUCT box, not the laid-out children (e.g. BED_SET declares 1.2×0.6m
+    // but its 5 children span 3.5×2.0m). Used to (a) centre the drop on the cursor and (b) size the ghost box so
+    // both match where the parts really land. Returns null for a leafless assembly.
+    footprintAABB(id, placement) {
+      const lv = this.expandAssembly(id, placement || { x: 0, y: 0, z: 0, rot: 0 });
+      if (!lv.length) return null;
+      let xn = Infinity, xx = -Infinity, yn = Infinity, yx = -Infinity, zn = Infinity, zx = -Infinity;
+      for (let i = 0; i < lv.length; i++) {
+        const lf = lv[i], c = this.get(lf.hash), bb = c && c.bbox;
+        const hw = bb ? (bb[1] - bb[0]) / 2 : 0, hd = bb ? (bb[3] - bb[2]) / 2 : 0, hh = bb ? (bb[5] - bb[4]) : 0;
+        if (lf.x - hw < xn) xn = lf.x - hw; if (lf.x + hw > xx) xx = lf.x + hw;
+        if (lf.y - hd < yn) yn = lf.y - hd; if (lf.y + hd > yx) yx = lf.y + hd;
+        if (lf.z < zn) zn = lf.z; if (lf.z + hh > zx) zx = lf.z + hh;   // box base = lf.z, top = base + height
+      }
+      return { minX: xn, maxX: xx, minY: yn, maxY: yx, minZ: zn, maxZ: zx,
+               cx: (xn + xx) / 2, cy: (yn + yx) / 2, cz: (zn + zx) / 2, w: xx - xn, d: yx - yn, h: zx - zn };
+    },
+
+    // ── The expand ORIGIN that lands an assembly's true leaf-footprint CENTRE on a cursor point (cursorX,cursorY)
+    // at yaw `rot` (W-BOM-DROP-CENTER). Centring on the declared aabb half (asm.w/2) mis-seats the drop by up to
+    // metres because asm.w/d is the parent-product box, not the laid-out footprint (§DROP-CENTER). Back off by the
+    // REAL footprint centre, rotated by the drop yaw, so the cluster centre = the cursor for ANY assembly/rotation.
+    dropOrigin(id, cursorX, cursorY, rot) {
+      const fp = this.footprintAABB(id, { x: 0, y: 0, z: 0, rot: 0 });
+      if (!fp) return { x: cursorX, y: cursorY };
+      const r = (rot || 0) * Math.PI / 180, cs = Math.cos(r), sn = Math.sin(r);
+      return { x: cursorX - (cs * fp.cx - sn * fp.cy), y: cursorY - (sn * fp.cx + cs * fp.cy) };
     },
 
     setLod(featureId, lod) { this._lod[featureId] = String(lod); return this; },

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -183,7 +183,7 @@
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=11" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=12" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
@@ -1346,9 +1346,19 @@ function disarmPick() { insertHash = null; clearGhost(); if (insertPanel) insert
 function showGhost(x, y) {                                        // translucent preview of where/how the insert lands
   if (!insertHash) return;
   const L = window.Bonsai.library, asm = L.isAssembly(insertHash) ? L.assembly(insertHash) : null;
-  const pa = asm                                                 // assembly ghost = its aabb footprint box
-    ? L.previewBox([-(asm.w || 0.2) / 2, (asm.w || 0.2) / 2, -(asm.d || 0.2) / 2, (asm.d || 0.2) / 2, 0, asm.h || 0.1], { x, y, z: insElev, rot: insRot })
-    : L.previewArrays(insertHash, { x, y, z: insElev, rot: insRot });
+  let pa;
+  if (asm) {
+    // assembly ghost = the TRUE leaf footprint placed at the SAME drop origin the commit uses (dropOrigin), so the
+    // preview box exactly encloses where the parts land. (The old ghost used the declared aabb asm.w/d = the
+    // parent-PRODUCT box, not the laid-out children → preview and landing disagreed. W-BOM-DROP-CENTER.)
+    const o = L.dropOrigin(insertHash, x, y, insRot);
+    const fp = L.footprintAABB(insertHash, { x: 0, y: 0, z: 0, rot: 0 });
+    pa = fp
+      ? L.previewBox([fp.minX, fp.maxX, fp.minY, fp.maxY, fp.minZ, fp.maxZ], { x: o.x, y: o.y, z: insElev, rot: insRot })
+      : L.previewBox([-(asm.w || 0.2) / 2, (asm.w || 0.2) / 2, -(asm.d || 0.2) / 2, (asm.d || 0.2) / 2, 0, asm.h || 0.1], { x, y, z: insElev, rot: insRot });
+  } else {
+    pa = L.previewArrays(insertHash, { x, y, z: insElev, rot: insRot });
+  }
   if (!pa) return;
   if (!ghostMesh) {
     ghostMesh = new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial({ color: 0x4fc3f7, transparent: true, opacity: 0.32, depthWrite: false }));
@@ -1471,16 +1481,14 @@ async function autoRouteMEP(asm, leaves) {
 }
 async function placeAssembly(x, y) {
   const L = window.Bonsai.library, asm = L.assembly(insertHash);
-  // CENTER-anchor the drop. expandAssembly seats children CORNER-anchored ([0..W]), but the ghost box (showGhost
-  // above) is CENTER-anchored ([-W/2..+W/2]) — so a raw expand lands the whole set in the +X/+Y quadrant, offset
-  // from the ghost by ≈(+W/2,+D/2) (BOM_DROP_SPATIAL_INVESTIGATION §RESULT: anchor mismatch, NOT bad data — the
-  // BOM cascade is proven parent-relative & untouched here). Shift the expand origin back by the ROTATED half-
-  // extent so the footprint CENTER lands on the drop point. Level-agnostic: identical for a furniture SET … a
-  // whole BUILDING (just a cascade of BOMs). W-BOM-DROP-CENTER.
-  const _r = (insRot || 0) * Math.PI / 180, _cs = Math.cos(_r), _sn = Math.sin(_r);
-  const _ox = ((asm && asm.w) || 0) / 2, _oy = ((asm && asm.d) || 0) / 2;
-  const cx = x - (_cs * _ox - _sn * _oy), cy = y - (_sn * _ox + _cs * _oy);
-  const leaves = L.expandAssembly(insertHash, { x: cx, y: cy, z: insElev, rot: insRot });
+  // CENTER-anchor the drop on the TRUE leaf footprint. The whitebox §-log proved the cause of "the basic BOM drop
+  // lands wrong": placeAssembly used to back the expand origin off by HALF THE DECLARED aabb (asm.w/2) — but
+  // asm.w/d is the parent-PRODUCT box, NOT the laid-out children (BED_SET declares 1.2×0.6m, its leaves span
+  // 3.5×2.0m), so the cluster landed up to 22m OFF the cursor. A pure translation → the §GEO_SUMMARY / IntraBOM
+  // DRIFT check never saw it. dropOrigin backs off by the REAL footprint centre instead → cluster centre on the
+  // drop point for ANY assembly, yaw=0 exact (W-BOM-DROP-CENTER G3a, 57/57 <1mm). Rotated drops = tracked ⛔.
+  const o = L.dropOrigin(insertHash, x, y, insRot);
+  const leaves = L.expandAssembly(insertHash, { x: o.x, y: o.y, z: insElev, rot: insRot });
   if (!leaves.length) { setStat('assembly ' + insertHash + ' has no placeable leaves'); return null; }
   const placed = [];
   for (const lf of leaves) {                                     // each leaf = one signed op-row (the chain)

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v698';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v699';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Whitebox §-log found the maths: placeAssembly centred on half the **declared aabb** (asm.w/2 = parent-product box, not the laid-out leaf footprint), so the cluster landed **up to 22.18m off the cursor** (DX building), 7.02m (SampleHouse), 0.80m (bed set). A pure translation → §GEO_SUMMARY/IntraBOM DRIFT never saw it.

**Fix:** `footprintAABB` + `dropOrigin` centre on the REAL leaf footprint (shared by ghost + commit). `expandAssembly` (proven yaw=0 path) untouched — W-MODELLER-DROP host==oracle 0.000mm + W-GEO-SUMMARY stay green. W-BOM-DROP-CENTER: old 22.18m off → all 57 assemblies land <1mm (worst 0.07mm).

**KNOWN ⛔ (the log shows it FAILING by 45m, surfaced not hidden):** ROTATED drops are not yet a faithful port — LBD half-extent added on world axes + yaw dropped under MIRROR; needs the Java PlacementCollectorVisitor reflect∘rotate transform ported as a unit.

`bonsai_library.js?v=12`, `sw v699`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)