### PR TITLE
fix(modeller): drop holds the Java's micron precision — toFixed(4)→toFixed(7)

### DIFF
--- a/viewer/bonsai_library.js
+++ b/viewer/bonsai_library.js
@@ -150,7 +150,9 @@
             // OUTSIDE, as a rigid rotation about the cursor, by dropLeaves (PlacementCollectorVisitor has no drop
             // yaw — cumRot/cumMirror are the building's intrinsic transforms). So no yaw reaches this half-extent.
           }
-          out.push({ hash: ch.ref, x: +cx.toFixed(4), y: +cy.toFixed(4), z: +cz.toFixed(4), rot: wrot, role: ch.role });
+          // toFixed(7) = 0.1µm quantum (trims float noise, keeps the op-log clean) — was toFixed(4) = 0.1mm, which
+          // floored the all-pairs spatial offset at 50× the Java's attested 0.002mm bar (W-DROP-VS-JAVA GAP-1).
+          out.push({ hash: ch.ref, x: +cx.toFixed(7), y: +cy.toFixed(7), z: +cz.toFixed(7), rot: wrot, role: ch.role });
         }
       });
       return out;
@@ -241,9 +243,9 @@
       for (let i = 0; i < canonical.length; i++) {
         const lf = canonical[i], lx = lf.x - fp.cx, ly = lf.y - fp.cy;          // leaf relative to footprint centre
         out.push({ hash: lf.hash, role: lf.role,
-          x: +(cursorX + (cs * lx - sn * ly)).toFixed(4),                       // rigid-rotate the canonical cluster
-          y: +(cursorY + (sn * lx + cs * ly)).toFixed(4),                       // about the cursor by the drop yaw
-          z: +(lf.z + ez).toFixed(4),
+          x: +(cursorX + (cs * lx - sn * ly)).toFixed(7),                       // rigid-rotate the canonical cluster
+          y: +(cursorY + (sn * lx + cs * ly)).toFixed(7),                       // about the cursor by the drop yaw
+          z: +(lf.z + ez).toFixed(7),                                          // toFixed(7) = 0.1µm (GAP-1 precision)
           rot: (((lf.rot || 0) + (yaw || 0)) % 360 + 360) % 360 });             // mesh orientation += drop yaw
       }
       return out;

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -183,7 +183,7 @@
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=13" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v700';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v701';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What

The modeller BOM drop quantized leaf positions to **0.1mm** via `.toFixed(4)` (metres) in `expandAssembly` + `dropLeaves`. Relative offsets were structurally exact (rigid-invariant) but 50× coarser than the Java compiler's attested bar (`geo_verify`: 0.002mm worst).

Raise to `.toFixed(7)` (0.1µm) → all-pairs relative offsets land at **0.0000mm** vs the Java-faithful oracle for SH + DX at yaw 0/90. Less rounding = more precise, not different.

## Strict whitebox proof — `scripts/witness_drop_vs_java.js` (W-DROP-VS-JAVA), was RED, now GREEN

- **S1 PRECISION** — all-pairs worst was 0.1500mm → now **0.0000mm** (< Java's 0.002mm).
- **S2 ELEMENT COUNT** — resolved by reconciling against the REAL extraction (`deploy/buildings/SampleHouse_extracted.db`), not by inventing elements:
  - 60 extraction elements − **2 IfcCurtainWall containers** (0 `element_transforms`, folded into their 20 members + 6 plates) − **3 IfcCovering ceilings** (covering-GENERATED downstream, never BOM-placed per CLAUDE.md doctrine) = **55 placed == the drop**, class-for-class.
  - The Java `geo_verify`'s 58 = these 55 placed + the 3 generated coverings.

Siblings stay green: W-MODELLER-DROP (host==oracle 0.000mm), W-GEO-SUMMARY, W-BOM-DROP-CENTER.

`sw v701`, `bonsai_library.js?v=14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)