### PR TITLE
feat(dashboard): EVM variance S-curve on a Project window — planned vs committed + Δ (W-DASH-VARIANCE 3/3)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3607,6 +3607,63 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     console.log('§DASH-SCURVE months=' + c.months.length + ' cumLast=' + Math.round(c.cum[c.cum.length - 1]) + ' forecast=' + fc.length + ' measure=' + (amtCol || 'count'));
     return svg;
   }
+  // ── EVM VARIANCE S-CURVE (W-DASH-VARIANCE) — the "future tense" with a REAL committed baseline. §SPEC: on a
+  //   Project window, a project's C_ProjectPhase rows carry a baked PlannedAmt (the contract) AND a CommittedAmt
+  //   (the projected outturn) — both REAL, extracted, never invented (e.g. BIM: Hospital 990000 = 64.7M planned →
+  //   87.4M committed, +35%). So the S-curve here is the variance cockpit: cumulative PLANNED (grey baseline,
+  //   always) vs cumulative COMMITTED/forecast outturn (blue, revealed by the Forecast toggle) + the Δ. This is
+  //   the same picture the 4D Time Machine folds (viewer/time_machine.js _computeEVM) — one truth, two surfaces.
+  //   The interactive schedule what-if (date slips on a blue branch) lives in viewer/whatif.js on the Gantt; it is
+  //   NOT folded here — a generic dashboard has no schedule-slip surface, and faking one would invent.
+  function _isProjectWindow() { var t = _curTab(); return !!t && String(t.tableName || '').toLowerCase() === 'c_project'; }
+  // pick the project in the open window that HAS phases (mirrors whatif_panel _pickProject); NON-INVENT.
+  function _pickPhasedProject() {
+    if (!db) return null;
+    // prefer a project actually in the open records, else any project with phases.
+    var ids = _records.map(function (r) { return recVal(r, 'C_Project_ID'); }).filter(function (v) { return v != null; });
+    try {
+      for (var i = 0; i < ids.length; i++) {
+        var r0 = db.exec('SELECT 1 FROM C_ProjectPhase WHERE C_Project_ID=' + Number(ids[i]) + ' LIMIT 1');
+        if (r0.length && r0[0].values.length) { var nm = db.exec('SELECT Name FROM C_Project WHERE C_Project_ID=' + Number(ids[i])); return { id: ids[i], name: nm.length && nm[0].values.length ? nm[0].values[0][0] : ('#' + ids[i]) }; }
+      }
+      var r = db.exec("SELECT p.C_Project_ID,p.Name FROM C_Project p WHERE EXISTS(SELECT 1 FROM C_ProjectPhase ph WHERE ph.C_Project_ID=p.C_Project_ID) ORDER BY p.C_Project_ID DESC LIMIT 1");
+      if (r.length && r[0].values.length) return { id: r[0].values[0][0], name: r[0].values[0][1] };
+    } catch (e) { console.log('§DASH-VARIANCE-PICK err=' + e.message); }
+    return null;
+  }
+  // fold a project's phases into cumulative planned + committed by phase EndDate. Real rows, ordered; NON-INVENT.
+  function _projectEVM(projectId) {
+    var r; try { r = db.exec("SELECT SeqNo,Name,PlannedAmt,CommittedAmt,EndDate FROM C_ProjectPhase WHERE C_Project_ID=" + Number(projectId) + " AND Name<>'Unsequenced' ORDER BY SeqNo"); }
+    catch (e) { return null; }
+    if (!r.length || !r[0].values.length) return null;
+    var rows = r[0].values, labels = [], planned = [], committed = [], cp = 0, cc = 0, phaseRows = [];
+    rows.forEach(function (v) { cp += Number(v[2] || 0); cc += Number(v[3] || 0); labels.push(String(v[4] || '').slice(0, 7)); planned.push(cp); committed.push(cc); phaseRows.push({ name: v[1], planned: Number(v[2] || 0), committed: Number(v[3] || 0) }); });
+    return { labels: labels, planned: planned, committed: committed, bac: cp, eac: cc, phases: phaseRows };
+  }
+  // draw the variance S-curve: planned baseline (grey, always) + committed outturn (blue, when _dashForecast) + Δ.
+  function _renderVarianceSCurve(container, evm) {
+    var KL = window.KanbanLens, NS = 'http://www.w3.org/2000/svg', M = function (v) { return KL ? KL.fmtMoney(v) : String(Math.round(v)); };
+    var W = 320, H = 150, pad = 24, n = evm.planned.length, maxV = Math.max(evm.bac, evm.eac) || 1;
+    function X(i) { return pad + (W - 2 * pad) * (n > 1 ? i / (n - 1) : 0); }
+    function Y(v) { return H - pad - (H - 2 * pad) * (v / maxV); }
+    var svg = document.createElementNS(NS, 'svg'); svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); svg.setAttribute('class', 'scurve-svg');
+    function line(x1, y1, x2, y2, st, da) { var l = document.createElementNS(NS, 'line'); l.setAttribute('x1', x1); l.setAttribute('y1', y1); l.setAttribute('x2', x2); l.setAttribute('y2', y2); l.setAttribute('stroke', st); if (da) l.setAttribute('stroke-dasharray', da); svg.appendChild(l); }
+    function poly(arr, color, da, w) { var p = document.createElementNS(NS, 'path'); p.setAttribute('d', arr.map(function (v, i) { return (i ? 'L' : 'M') + X(i).toFixed(1) + ' ' + Y(v).toFixed(1); }).join(' ')); p.setAttribute('fill', 'none'); p.setAttribute('stroke', color); p.setAttribute('stroke-width', w || 2); if (da) p.setAttribute('stroke-dasharray', da); svg.appendChild(p); return p; }
+    line(pad, H - pad, W - pad, H - pad, 'rgba(255,255,255,.12)'); line(pad, pad, pad, H - pad, 'rgba(255,255,255,.12)');
+    poly(evm.planned, '#9aa6b8', null, 2.2);   // PLANNED baseline (the contract) — always
+    var pl = document.createElementNS(NS, 'text'); pl.setAttribute('x', X(n - 1)); pl.setAttribute('y', Y(evm.bac) + 12); pl.setAttribute('text-anchor', 'end'); pl.setAttribute('class', 'scurve-now'); pl.textContent = 'planned ' + M(evm.bac); svg.appendChild(pl);
+    var delta = evm.eac - evm.bac, pctv = evm.bac ? Math.round(delta / evm.bac * 100) : 0;
+    if (_dashForecast) {   // COMMITTED / forecast outturn — the future tense
+      poly(evm.committed, '#6c9fff', '6 4', 2.4);
+      var cl = document.createElementNS(NS, 'text'); cl.setAttribute('x', X(n - 1)); cl.setAttribute('y', Y(evm.eac) - 6); cl.setAttribute('text-anchor', 'end'); cl.setAttribute('class', 'scurve-flab'); cl.textContent = 'forecast ' + M(evm.eac); svg.appendChild(cl);
+      var dv = document.createElementNS(NS, 'text'); dv.setAttribute('x', pad + 2); dv.setAttribute('y', pad + 4); dv.setAttribute('class', 'scurve-delta'); dv.setAttribute('fill', delta > 0 ? '#e08a6a' : '#5bbf8a'); dv.textContent = 'Δ ' + (delta > 0 ? '+' : '') + M(delta) + ' (' + (pctv > 0 ? '+' : '') + pctv + '%)'; svg.appendChild(dv);
+    } else {
+      var hint = document.createElementNS(NS, 'text'); hint.setAttribute('x', X(n - 1)); hint.setAttribute('y', Y(evm.bac) - 6); hint.setAttribute('text-anchor', 'end'); hint.setAttribute('class', 'scurve-now'); hint.textContent = 'Forecast →'; svg.appendChild(hint);
+    }
+    container.appendChild(svg);
+    console.log('§DASH-VARIANCE phases=' + n + ' planned=' + Math.round(evm.bac) + ' committed=' + Math.round(evm.eac) + ' delta=' + Math.round(delta) + ' pct=' + pctv + ' forecast=' + (_dashForecast ? 1 : 0));
+    return svg;
+  }
   // ── EXPORT (DASHBOARD_EXPORT — "the killer feature we miss") — pure EXTRACT of the real folds, NON-INVENT:
   //   CSV = the fold rows (key, count/amount, %); SVG = the donut node serialized; PNG = that SVG rastered to a
   //   canvas. Per-chart affordance + a window-level "Export" (all records). Every byte traces to a real record. ──
@@ -3727,9 +3784,15 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     if (dateF) { charts.push({ key: dateF.columnName, label: dateF.name + ' (by month)', groups: _groupByMonth(dateF) }); }
     // grid of DONUT cards — all donuts, consistent + snuggled. Each is a real fold; top-6 + "others".
     var grid = el('div', 'dash-grid'); gbox.appendChild(grid);
-    // S-curve trend card FIRST (the time axis) — real cumulative; dashed forecast tail only when toggled on.
-    //   Honest skip when the window has no date dimension. Spans 2 columns so the line reads.
-    if (dateF) {
+    // S-curve trend card FIRST (the time axis). On a PROJECT window with a baked Planned/Committed baseline, this
+    //   is the EVM VARIANCE curve (planned vs committed outturn + Δ); otherwise the generic cumulative trend.
+    //   Honest skip when neither applies. Spans 2 columns so the line reads.
+    var evmProj = _isProjectWindow() ? _pickPhasedProject() : null, evm = evmProj ? _projectEVM(evmProj.id) : null;
+    if (evm) {
+      var vc = el('div', 'dash-card dash-scurve'); vc.setAttribute('data-dim', '__variance');
+      vc.appendChild(el('div', 'dash-chart-h', 'Planned vs committed — ' + evmProj.name + (_dashForecast ? ' (variance)' : '')));
+      if (_renderVarianceSCurve(vc, evm)) grid.appendChild(vc);
+    } else if (dateF) {
       var sc = el('div', 'dash-card dash-scurve'); sc.setAttribute('data-dim', '__scurve');
       sc.appendChild(el('div', 'dash-chart-h', 'Cumulative ' + (amtCol ? amtCol : 'count') + ' — ' + dateF.name + (_dashForecast ? ' + forecast' : '')));
       if (_renderSCurve(sc, { field: dateF, amtCol: amtCol })) grid.appendChild(sc);
@@ -4462,7 +4525,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       // FORECAST — the future tense: a dashed 'now' divider, dashed-blue projected columns, the S-curve trend card.
       '.tl-today{flex:0 0 auto;align-self:stretch;width:0;margin:0 6px;border-left:2px dashed rgba(108,159,255,.5);position:relative}.tl-today span{position:absolute;top:2px;left:-20px;font-size:9px;letter-spacing:.5px;color:#7f93b8;background:#11151f;padding:0 4px;border-radius:3px}' +
       '.tl-col.future .tl-card{border:1px dashed rgba(108,159,255,.7);background:rgba(108,159,255,.07);color:#bcd2ff}.tl-col.future .tl-av{background:#3a5fa8;color:#cfe0ff}.tl-col.future .tl-t{color:#bcd2ff}.tl-col.future .tl-a{color:#9bbcff}.tl-col.future .tl-day{color:#9bbcff;font-weight:600}' +
-      '.dash-scurve{grid-column:span 2}.dash-scurve .scurve-svg{width:100%;height:150px}.scurve-now{fill:#7f93b8;font-size:9px}.scurve-flab{fill:#9bbcff;font-size:9px;font-weight:600}' +
+      '.dash-scurve{grid-column:span 2}.dash-scurve .scurve-svg{width:100%;height:150px}.scurve-now{fill:#7f93b8;font-size:9px}.scurve-flab{fill:#9bbcff;font-size:9px;font-weight:600}.scurve-delta{font-size:10px;font-weight:700}' +
       '.dash-forecast.active{color:#9bbcff;border-bottom-color:#9bbcff}@media(max-width:640px){.dash-scurve{grid-column:span 1}}' +
       // mobile — snug: scrollable tabs, full-width charts, tighter chips/cards
       '@media(max-width:640px){.dash-tabs{overflow-x:auto;white-space:nowrap}.dash-tab{padding:8px 11px;font-size:12px}.dash-body{max-height:78vh}' +

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v747';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v748';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_dashboard_variance.js
+++ b/erp/tests/poc_dashboard_variance.js
@@ -1,0 +1,76 @@
+// Whitebox §-witness — DASHBOARD EVM variance S-curve (W-DASH-VARIANCE, this lane). §SPEC: idempiere.html.
+//   On a PROJECT window a phased project's baked PlannedAmt (contract) vs CommittedAmt (outturn) folds into the
+//   variance S-curve: planned baseline always, committed/forecast outturn + Δ when the Forecast toggle is on.
+//   NON-INVENT — the §DASH-VARIANCE numbers must EQUAL the real C_ProjectPhase Σ in ad_seed.db (no fabrication).
+//   Proves:
+//     W-VAR-CARD     : the Project window's Graph tab carries a variance S-curve card (data-dim="__variance").
+//     W-VAR-NUMBERS  : §DASH-VARIANCE planned/committed == the DB Σ(PlannedAmt)/Σ(CommittedAmt) for that project.
+//     W-VAR-FORECAST : Forecast OFF ⇒ planned baseline only (forecast=0); ON ⇒ committed line + Δ (forecast=1).
+'use strict';
+const path = require('path'), http = require('http'), fs = require('fs');
+function pw(){for(const c of [path.join(__dirname,'../../tests/node_modules/playwright'),'/home/red1/bim-ootb/tests/node_modules/playwright']){try{return require(c)}catch(e){}}throw new Error('no pw')}
+const { execFileSync } = require('child_process');
+const ROOT = path.join(__dirname, '..');
+const MIME = {'.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png','.svg':'image/svg+xml','.ico':'image/x-icon','.mjs':'text/javascript','.xlsx':'application/octet-stream'};
+const server = http.createServer((req,res)=>{let p=decodeURIComponent(req.url.split('?')[0]);if(p==='/')p='/idempiere.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){res.writeHead(404);res.end('404');return}res.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});res.end(b)})});
+async function clickPill(page,id){await page.waitForSelector('#pill-'+id,{state:'attached',timeout:15000});await page.evaluate(()=>{var d=document.getElementById('idmp-pill'),t=document.getElementById('idmp-pill-trigger');if(d&&t&&getComputedStyle(d).display==='none')t.dispatchEvent(new PointerEvent('pointerup',{bubbles:true}))});await page.waitForTimeout(150);await page.evaluate(i=>document.getElementById('pill-'+i).dispatchEvent(new PointerEvent('pointerup',{bubbles:true})),id)}
+async function login(page,port,win){
+  await page.goto(`http://localhost:${port}/idempiere.html?client=garden&window=${win}`,{waitUntil:'networkidle'});
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)',{timeout:15000});
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok',{timeout:5000});await page.click('#idmp-login-ok');
+  await page.waitForSelector('[data-ad-table]',{timeout:15000}).catch(()=>{});await page.waitForTimeout(1700);
+}
+const last = (logs,re)=>logs.filter(l=>re.test(l)).pop()||'';
+const toggleForecast = (page)=>page.evaluate(()=>document.querySelector('.dash-forecast').click());
+
+// the DB truth, computed independently from ad_seed.db via the sqlite3 CLI (the oracle the §-log must match).
+function dbTruth(){
+  try {
+    const out = execFileSync('sqlite3', [path.join(ROOT,'ad_seed.db'),
+      "SELECT p.C_Project_ID||'|'||CAST(ROUND(SUM(ph.PlannedAmt)) AS INT)||'|'||CAST(ROUND(SUM(ph.CommittedAmt)) AS INT) FROM C_ProjectPhase ph JOIN C_Project p ON p.C_Project_ID=ph.C_Project_ID WHERE ph.Name<>'Unsequenced' GROUP BY p.C_Project_ID ORDER BY SUM(ph.CommittedAmt) DESC LIMIT 1"],
+      {encoding:'utf8'}).trim();
+    const v = out.split('|'); return {id:Number(v[0]), planned:Number(v[1]), committed:Number(v[2])};
+  } catch(e){ console.log('§DBTRUTH-ERR '+e.message); return null; }
+}
+
+(async()=>{
+  const truth = dbTruth();
+  const {chromium}=pw();await new Promise(r=>server.listen(0,r));const port=server.address().port;
+  const b=await chromium.launch();const ctx=await b.newContext();const page=await ctx.newPage();
+  await page.setViewportSize({width:1280,height:860});
+  const logs=[],errs=[];page.on('console',m=>logs.push(m.text()));page.on('pageerror',e=>errs.push(e.message));
+  let ok={};
+
+  // Project window (130) — C_Project, carries the baked Planned/Committed phase baseline.
+  await login(page,port,'130');
+  await clickPill(page,'dashboard');
+  await page.waitForFunction(()=>document.querySelector('.dash-scurve'),{timeout:10000});
+
+  // ── W-VAR-CARD: the variance S-curve card is present (data-dim __variance), resting forecast=0. ──
+  const cardDom = await page.evaluate(()=>!!document.querySelector('.dash-card[data-dim="__variance"] svg.scurve-svg'));
+  const vRest = last(logs,/§DASH-VARIANCE/);
+  ok.card = cardDom && /forecast=0/.test(vRest);
+  console.log('§W-VAR-CARD dom='+cardDom+' :: '+vRest+' :: '+(ok.card?'OK':'FAIL'));
+
+  // ── W-VAR-NUMBERS: the §-log planned/committed EQUAL the independent DB Σ (NON-INVENT). ──
+  const planned = Number((vRest.match(/planned=(\d+)/)||[])[1]);
+  const committed = Number((vRest.match(/committed=(\d+)/)||[])[1]);
+  ok.numbers = truth!=null && planned===truth.planned && committed===truth.committed && committed>planned;
+  console.log('§W-VAR-NUMBERS log{planned='+planned+',committed='+committed+'} db{'+(truth?truth.planned+','+truth.committed:'?')+'} :: '+(ok.numbers?'OK':'FAIL'));
+
+  // ── W-VAR-FORECAST: toggle ON → committed line + Δ (forecast=1, delta>0). ──
+  await toggleForecast(page); await page.waitForTimeout(400);
+  const vFut = last(logs,/§DASH-VARIANCE/);
+  const fOn = /forecast=1/.test(vFut);
+  const delta = Number((vFut.match(/delta=(-?\d+)/)||[])[1]);
+  const dashedDom = await page.evaluate(()=>document.querySelectorAll('.dash-card[data-dim="__variance"] svg path[stroke-dasharray]').length);
+  ok.forecast = fOn && delta===(committed-planned) && delta>0 && dashedDom>=1;
+  console.log('§W-VAR-FORECAST :: '+vFut+' dashed='+dashedDom+' :: '+(ok.forecast?'OK':'FAIL'));
+
+  const pass = Object.values(ok).filter(Boolean).length, total = Object.keys(ok).length;
+  console.log('\n§W-DASH-VARIANCE '+pass+'/'+total+' '+JSON.stringify(ok));
+  if(errs.length) console.log('§PAGEERR '+errs.length+' :: '+errs.slice(0,3).join(' | '));
+  await b.close(); server.close();
+  process.exit(pass===total && !errs.length ? 0 : 1);
+})().catch(e=>{console.error('§FATAL '+e.message);process.exit(1)});


### PR DESCRIPTION
## What

The Dashboard's *future tense* with a **real committed baseline**. On the **Project** window, a phased project's baked **PlannedAmt** (the contract) and **CommittedAmt** (the projected outturn) fold into the variance cockpit S-curve — gated by the same **Forecast** toggle shipped in #488:

- **Planned baseline** (grey) shows always. Flip Forecast on → the **committed/forecast outturn** (dashed blue) + the **Δ** (e.g. *BIM: Hospital* 64.7M planned → 87.4M committed = **+22.65M / +35%**). This is the same EVM picture the 4D Time Machine folds (`viewer/time_machine.js`) — **one truth, two surfaces**.
- `_isProjectWindow` / `_pickPhasedProject` / `_projectEVM` read `C_ProjectPhase` straight from the live `db`; the generic run-rate S-curve (#488) still serves every other window.

## Doctrine

**NON-INVENT** — the `§DASH-VARIANCE` planned/committed numbers **equal the independent `sqlite3` Σ** of `PlannedAmt`/`CommittedAmt`; the witness diffs them to the rupiah. The committed baseline is *extracted, not modelled*. The interactive schedule what-if (date slips on a blue branch) stays in `viewer/whatif.js` on the Gantt surface — a generic dashboard has no slip surface, so it is **not faked here**.

## Witness

`erp/tests/poc_dashboard_variance.js` — **W-DASH-VARIANCE 3/3**:
- **CARD** — variance S-curve present (`data-dim="__variance"`), resting `forecast=0`.
- **NUMBERS** — `§DASH-VARIANCE` planned/committed `==` DB Σ (oracle via sqlite3 CLI).
- **FORECAST** — toggle ON → committed line + `Δ>0` dashed path.

Regression: `poc_dashboard_forecast.js` **5/5** + `poc_dashboard_export.js` **14/14** green. `sw.js` v747→v748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)