### PR TITLE
feat(pivot): heatmap — tint each cross-tab cell by its share (W-PIVOT-HEATMAP 3/3)

### DIFF
--- a/erp/pivot_lens.html
+++ b/erp/pivot_lens.html
@@ -38,6 +38,7 @@
     text-align:right; font-size:13px; color:#c8c8d8; white-space:nowrap; cursor:pointer; }
   .pv-table td:first-child { text-align:left; color:#e8e8ed; font-weight:500; }
   .pv-table td:hover { background:rgba(108,159,255,0.13); }
+  .pv-table td.pv-heat:hover { background:rgba(108,159,255,0.58) !important; }
   .pv-table tr.total-row td { border-top:2px solid rgba(255,255,255,0.14); color:#7bb3ff; font-weight:600; }
   .pv-table td.pv-zero { color:rgba(255,255,255,0.18); }
   /* drill pop */
@@ -226,6 +227,10 @@
     // data rows
     var colTotals = {}; pv.cols.forEach(function (cv) { colTotals[cv] = { count: 0, sum: 0 }; });
     var grandTotal = { count: 0, sum: 0 };
+    // HEATMAP — color each data cell by its share of the biggest cell (darker = higher). Real values only,
+    //   NON-INVENT: the same count/sum the cell already shows. Totals + labels stay plain so they don't dominate.
+    var heatMax = 0;
+    pv.rows.forEach(function (rv) { pv.cols.forEach(function (cv) { var c = pv.cells[rv + '|' + cv]; if (c) { var hv = pv.amtCol ? c.sum : c.count; if (hv > heatMax) heatMax = hv; } }); });
     pv.rows.forEach(function (rv) {
       var tr = document.createElement('tr');
       var tdR = document.createElement('td'); tdR.textContent = rv; tr.appendChild(tdR);
@@ -237,6 +242,7 @@
         var v = pv.amtCol ? cell.sum : cell.count;
         td.textContent = fmt(cell);
         if (!v) td.classList.add('pv-zero');
+        else if (heatMax > 0) { td.classList.add('pv-heat'); td.style.background = 'rgba(108,159,255,' + (0.07 + 0.45 * (v / heatMax)).toFixed(3) + ')'; }   // heat tint by share
         // cell drill — tap = §PIVOT-DRILL id panel; LONG-PRESS = ask the host to open these records in the window
         if (cell.count) td.style.cursor = 'pointer';
         (function (cRv, cCv, cCell) {
@@ -272,9 +278,9 @@
     t.appendChild(ttr);
     wrap.appendChild(t);
     var note = document.createElement('div'); note.className = 'pv-note';
-    note.textContent = pv.rows.length + ' row values · ' + pv.cols.length + ' column values · click a cell to see its record IDs';
+    note.textContent = pv.rows.length + ' row values · ' + pv.cols.length + ' column values · darker = higher · click a cell to see its record IDs';
     root.appendChild(wrap); root.appendChild(note);
-    log('renderPivot table=' + pv.table + ' rows=' + pv.rows.length + ' cols=' + pv.cols.length + ' measure=' + pv.msr + ' grandCount=' + grandTotal.count);
+    log('renderPivot table=' + pv.table + ' rows=' + pv.rows.length + ' cols=' + pv.cols.length + ' measure=' + pv.msr + ' grandCount=' + grandTotal.count + ' heatMax=' + heatMax);
   }
 
   function populateSelects(db, tb) {

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v748';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v749';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_pivot_heatmap.js
+++ b/erp/tests/poc_pivot_heatmap.js
@@ -1,0 +1,51 @@
+// Whitebox §-witness — PIVOT HEATMAP (W-PIVOT-HEATMAP, this lane). §SPEC: pivot_lens.html.
+//   Each data cell is tinted blue by its share of the biggest cell (darker = higher) — the SAME count/sum the
+//   cell already shows (NON-INVENT). Totals + row labels stay plain so they never dominate the heat.
+//   Proves:
+//     W-HEAT-CELLS    : data cells carry .pv-heat with an rgba background; §renderPivot heatMax>0.
+//     W-HEAT-GRADIENT : the tint scales with value — the bigger cell is darker (higher alpha) than a smaller one.
+//     W-HEAT-PLAIN    : the totals row keeps NO heat tint (stays plain).
+'use strict';
+const path = require('path'), http = require('http'), fs = require('fs');
+function pw(){for(const c of [path.join(__dirname,'../../tests/node_modules/playwright'),'/home/red1/bim-ootb/tests/node_modules/playwright']){try{return require(c)}catch(e){}}throw new Error('no pw')}
+const ROOT = path.join(__dirname, '..');
+const MIME = {'.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png','.svg':'image/svg+xml','.mjs':'text/javascript'};
+const server = http.createServer((req,res)=>{let p=decodeURIComponent(req.url.split('?')[0]);if(p==='/')p='/pivot_lens.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){res.writeHead(404);res.end('404');return}res.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});res.end(b)})});
+const alpha = (bg)=>{const m=/rgba?\([^)]*?,\s*([\d.]+)\s*\)/.exec(bg||'');return m?Number(m[1]):0;};
+
+(async()=>{
+  const {chromium}=pw();await new Promise(r=>server.listen(0,r));const port=server.address().port;
+  const b=await chromium.launch();const page=await (await b.newContext()).newPage();
+  const logs=[],errs=[];page.on('console',m=>logs.push(m.text()));page.on('pageerror',e=>errs.push(e.message));
+  let ok={};
+
+  // load the pivot standalone over the real tenant seed (Sales Orders, client 11) — auto-picks row/col fields.
+  await page.goto(`http://localhost:${port}/pivot_lens.html?db=ad_seed.db&table=c_order&client=11`,{waitUntil:'networkidle'});
+  await page.waitForSelector('.pv-table td.pv-heat',{timeout:15000});
+
+  // ── W-HEAT-CELLS: heat cells exist, each has an rgba background; §-log heatMax>0. ──
+  const heated = await page.evaluate(()=>[].map.call(document.querySelectorAll('.pv-table td.pv-heat'),td=>({t:td.textContent,bg:td.style.background})));
+  const renderLog = logs.filter(l=>/renderPivot/.test(l)).pop()||'';
+  const heatMax = Number((renderLog.match(/heatMax=(\d+)/)||[])[1]);
+  ok.cells = heated.length>0 && heated.every(h=>/rgba/.test(h.bg)) && heatMax>0;
+  console.log('§W-HEAT-CELLS heated='+heated.length+' :: '+renderLog+' :: '+(ok.cells?'OK':'FAIL'));
+
+  // ── W-HEAT-GRADIENT: bigger value → darker (higher alpha). ──
+  const withVal = heated.map(h=>({v:Number(String(h.t).replace(/[^\d.-]/g,''))||0, a:alpha(h.bg)})).filter(x=>x.v>0);
+  const maxCell = withVal.reduce((m,x)=>x.v>m.v?x:m, withVal[0]||{v:0,a:0});
+  const minCell = withVal.reduce((m,x)=>x.v<m.v?x:m, withVal[0]||{v:0,a:1});
+  // if every data cell shares one value there's no gradient to prove — accept the single-tone case honestly.
+  ok.gradient = withVal.length>0 && (maxCell.v===minCell.v ? maxCell.a>0 : maxCell.a>minCell.a);
+  console.log('§W-HEAT-GRADIENT max{v='+maxCell.v+',a='+maxCell.a+'} min{v='+minCell.v+',a='+minCell.a+'} :: '+(ok.gradient?'OK':'FAIL'));
+
+  // ── W-HEAT-PLAIN: the totals row carries NO heat tint. ──
+  const totalHeated = await page.evaluate(()=>document.querySelectorAll('.pv-table tr.total-row td.pv-heat').length);
+  ok.plain = totalHeated===0;
+  console.log('§W-HEAT-PLAIN totalRowHeatCells='+totalHeated+' :: '+(ok.plain?'OK':'FAIL'));
+
+  const pass=Object.values(ok).filter(Boolean).length, total=Object.keys(ok).length;
+  console.log('\n§W-PIVOT-HEATMAP '+pass+'/'+total+' '+JSON.stringify(ok));
+  if(errs.length) console.log('§PAGEERR '+errs.length+' :: '+errs.slice(0,3).join(' | '));
+  await b.close(); server.close();
+  process.exit(pass===total && !errs.length ? 0 : 1);
+})().catch(e=>{console.error('§FATAL '+e.message);process.exit(1)});


### PR DESCRIPTION
## What
The **Pivot** tab now reads as a **heatmap**: every data cell is tinted blue by its share of the biggest cell (**darker = higher**), so the hot spots jump out without reading every number.

**NON-INVENT** — the tint scales the *same* count/sum the cell already shows. Totals and row labels stay plain so they never dominate; hover darkens for legibility.

## Witness
`erp/tests/poc_pivot_heatmap.js` — **W-PIVOT-HEATMAP 3/3**: CELLS (`.pv-heat` + rgba bg, `§renderPivot heatMax>0`), GRADIENT (bigger value → higher alpha), PLAIN (totals row un-tinted). Existing `poc_dashboard_export.js` **14/14** (pivot drill/CSV) green. `sw.js` v748→v749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)