### PR TITLE
feat(dashboard): spider web — collapse chosen pies into one concentration radar (W-DASH-WEB 4/4)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3555,7 +3555,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   //   is the documented NEXT step: it needs a COMMITTED baseline, which a generic window has no source for, so
   //   it is deliberately NOT faked here. One toggle (`_dashForecast`) drives the time-axis lenses; default OFF
   //   ⇒ the resting panel is byte-for-byte today's.
-  var _dashForecast = false, _curDashTab = 'graph';
+  var _dashForecast = false, _curDashTab = 'graph', _dashWeb = false;
   // run-rate forecast: project n future periods by the MEAN of the last k period-over-period deltas. Pure +
   //   unit-testable; emits §RUNRATE so the witness reads the arithmetic without a browser.
   function _runRateForecast(vals, n, k) {
@@ -3799,6 +3799,20 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     }
     charts.forEach(function (c) { _addDonutCard(grid, c.key, (c.label.indexOf('(') < 0 ? 'By ' : '') + c.label, c.groups, c.statusCol || null, amtCol); });
     var hint = el('div', 'dash-hint', 'Long-press a slice to open its records'); grid.appendChild(hint);   // gesture tip in the blank grid slot
+    // WEB toggle — collapse the pies on the board into ONE spider of their concentrations (and back). Built from
+    //   the LIVE cards, so it reflects exactly the pies the user chose to show. ≥3 pies needed for a web shape.
+    var webBox = el('div', 'dash-web'); webBox.style.display = 'none'; gbox.appendChild(webBox);
+    var webBtn = el('button', 'dash-webtoggle');
+    function _setWebBtn() { webBtn.innerHTML = '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" style="vertical-align:-2px"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4.5"/><path d="M12 3v18M3 12h18M5.6 5.6l12.8 12.8M18.4 5.6 5.6 18.4"/></svg> ' + (_dashWeb ? 'Pies' : 'Web'); }
+    function _paintWeb() {
+      webBox.innerHTML = ''; var specs = _webSpecsFromGrid(grid);
+      if (specs.length < 3) { webBox.appendChild(el('div', 'dash-hint', 'Add at least 3 pies (tap Explore chips) to see the web.')); console.log('§DASH-WEB skip spokes=' + specs.length); return; }
+      webBox.appendChild(el('div', 'dash-chart-h', 'Concentration web — ' + specs.length + ' cuts (spiky = lopsided, round = even)'));
+      _renderSpiderWeb(webBox, specs);
+    }
+    function _applyWeb() { _setWebBtn(); if (_dashWeb) { _paintWeb(); grid.style.display = 'none'; webBox.style.display = ''; } else { grid.style.display = ''; webBox.style.display = 'none'; } }
+    webBtn.addEventListener('click', function () { _dashWeb = !_dashWeb; _applyWeb(); console.log('§DASH-WEB-TOGGLE on=' + _dashWeb); });
+    gbox.insertBefore(webBtn, grid); _applyWeb();
     console.log('§DASH-OVERVIEW donuts=' + charts.length + ' status=' + (statusF ? statusF.columnName : 'none') + ' cats=' + picked.map(function (f) { return f.columnName; }).join(',') + ' date=' + (dateF ? dateF.columnName : 'none'));
     return grid;
   }
@@ -3817,8 +3831,45 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     });
     h.appendChild(ex); card.appendChild(h);
     _renderDonut(card, { groups: groups, statusCol: statusCol, amtCol: amtCol });
+    // stamp the pie's CONCENTRATION (biggest slice's share) on the card — the spider web reads these straight off
+    //   the live cards, so the web is built from exactly the pies the user has on the board. Same fold the donut
+    //   draws (amount-share if money, else count-share). NON-INVENT.
+    var _gk = Object.keys(groups), _tot = 0, _topN = -1, _topName = '';
+    _gk.forEach(function (k) { var vv = amtCol ? _amtSum(groups[k], amtCol) : groups[k].length; _tot += vv; if (vv > _topN) { _topN = vv; _topName = k; } });
+    card.setAttribute('data-conc', _tot ? Math.round(_topN / _tot * 100) : 0);
+    card.setAttribute('data-top', _topName);
+    card.setAttribute('data-label', String(title).replace(/^By\s+/, ''));
     var hint = grid.querySelector('.dash-hint'); if (hint) grid.insertBefore(card, hint); else grid.appendChild(card);
     return true;
+  }
+  // SPIDER WEB (W-DASH-WEB) — collapse the donut grid into ONE radar. §SPEC: each pie the user has on the board
+  //   becomes a SPOKE; the spoke's reach = that pie's CONCENTRATION (its biggest slice's % — read off data-conc).
+  //   So a spiky web = a cut dominated by one value (a risk or a gap); a round web = evenly spread. It's a
+  //   SCREENING glance — "which cut deserves a look" — then tap back to the pies to drill. The totals are the
+  //   SAME on every pie (same records), so concentration — not count — is what makes the spokes differ. NON-INVENT.
+  function _renderSpiderWeb(container, specs) {
+    var NS = 'http://www.w3.org/2000/svg', n = specs.length, W = 300, H = 240, cx = W / 2, cy = H / 2 + 6, maxR = 86;
+    function pt(i, rad) { var a = (-90 + i * 360 / n) * Math.PI / 180; return [cx + rad * Math.cos(a), cy + rad * Math.sin(a)]; }
+    var svg = document.createElementNS(NS, 'svg'); svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); svg.setAttribute('class', 'web-svg');
+    function poly(pts, fill, stroke, sw) { var p = document.createElementNS(NS, 'polygon'); p.setAttribute('points', pts.map(function (q) { return q[0].toFixed(1) + ',' + q[1].toFixed(1); }).join(' ')); p.setAttribute('fill', fill); p.setAttribute('stroke', stroke); if (sw) p.setAttribute('stroke-width', sw); svg.appendChild(p); return p; }
+    [25, 50, 75, 100].forEach(function (lvl) { poly(specs.map(function (_, i) { return pt(i, maxR * lvl / 100); }), 'none', 'rgba(255,255,255,.10)', 1); });   // grid rings
+    specs.forEach(function (_, i) { var e = pt(i, maxR), l = document.createElementNS(NS, 'line'); l.setAttribute('x1', cx); l.setAttribute('y1', cy); l.setAttribute('x2', e[0]); l.setAttribute('y2', e[1]); l.setAttribute('stroke', 'rgba(255,255,255,.10)'); svg.appendChild(l); });   // spokes
+    poly(specs.map(function (s, i) { return pt(i, maxR * Math.max(0, Math.min(100, s.conc)) / 100); }), 'rgba(108,159,255,.22)', '#6c9fff', 2);   // the shape
+    specs.forEach(function (s, i) {   // vertex dots + labels
+      var v = pt(i, maxR * Math.max(0, Math.min(100, s.conc)) / 100), d = document.createElementNS(NS, 'circle'); d.setAttribute('cx', v[0]); d.setAttribute('cy', v[1]); d.setAttribute('r', 3); d.setAttribute('fill', '#6c9fff');
+      var ti = document.createElementNS(NS, 'title'); ti.textContent = s.label + ' — biggest: ' + s.top + ' (' + s.conc + '%)'; d.appendChild(ti); svg.appendChild(d);
+      var lp = pt(i, maxR + 16), tx = document.createElementNS(NS, 'text'); tx.setAttribute('x', lp[0]); tx.setAttribute('y', lp[1]); tx.setAttribute('text-anchor', lp[0] < cx - 4 ? 'end' : lp[0] > cx + 4 ? 'start' : 'middle'); tx.setAttribute('dominant-baseline', 'middle'); tx.setAttribute('class', 'web-lbl');
+      tx.textContent = (s.label.length > 12 ? s.label.slice(0, 11) + '…' : s.label) + ' ' + s.conc + '%'; svg.appendChild(tx);
+    });
+    container.appendChild(svg);
+    console.log('§DASH-WEB spokes=' + n + ' conc=[' + specs.map(function (s) { return s.conc; }).join(',') + ']');
+    return svg;
+  }
+  // read the spider spokes off the live donut cards (excluding the S-curve/variance card) — the user's chosen pies.
+  function _webSpecsFromGrid(grid) {
+    return [].slice.call(grid.querySelectorAll('.dash-card[data-conc]')).map(function (c) {
+      return { label: c.getAttribute('data-label') || c.getAttribute('data-dim'), conc: Number(c.getAttribute('data-conc')) || 0, top: c.getAttribute('data-top') || '' };
+    });
   }
   // DASHBOARD — ONE surface, N lenses (Odoo multi-view). Tabs flip the SAME open-window records; the Graph tab
   //   paints instantly then streams the Ask panel in (never blocks first sight). FUNDAMENTAL LAW: a ⋯-rail lens.
@@ -4527,6 +4578,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       '.tl-col.future .tl-card{border:1px dashed rgba(108,159,255,.7);background:rgba(108,159,255,.07);color:#bcd2ff}.tl-col.future .tl-av{background:#3a5fa8;color:#cfe0ff}.tl-col.future .tl-t{color:#bcd2ff}.tl-col.future .tl-a{color:#9bbcff}.tl-col.future .tl-day{color:#9bbcff;font-weight:600}' +
       '.dash-scurve{grid-column:span 2}.dash-scurve .scurve-svg{width:100%;height:150px}.scurve-now{fill:#7f93b8;font-size:9px}.scurve-flab{fill:#9bbcff;font-size:9px;font-weight:600}.scurve-delta{font-size:10px;font-weight:700}' +
       '.dash-forecast.active{color:#9bbcff;border-bottom-color:#9bbcff}@media(max-width:640px){.dash-scurve{grid-column:span 1}}' +
+      // WEB — the spider toggle + one-radar view (pies collapse into spokes by concentration).
+      '.dash-webtoggle{align-self:flex-start;margin-bottom:10px;background:rgba(108,159,255,.10);border:1px solid rgba(108,159,255,.3);color:#9bbcff;font-size:12px;font-weight:600;padding:5px 11px;border-radius:8px;cursor:pointer}.dash-webtoggle:hover{background:rgba(108,159,255,.18)}' +
+      '.dash-web{display:flex;flex-direction:column;align-items:center;gap:8px;padding:6px 0}.dash-web .web-svg{width:100%;max-width:460px;height:auto}.web-lbl{fill:#aeb9cc;font-size:10px;font-weight:600}' +
       // mobile — snug: scrollable tabs, full-width charts, tighter chips/cards
       '@media(max-width:640px){.dash-tabs{overflow-x:auto;white-space:nowrap}.dash-tab{padding:8px 11px;font-size:12px}.dash-body{max-height:78vh}' +
       '.dash-split{flex-direction:column;gap:0}.dash-side{flex:1 1 auto;max-width:none;border-left:none;border-top:1px dashed rgba(255,255,255,.12);padding-left:0;padding-top:12px;margin-top:12px;position:static}' +

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v749';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v750';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/poc_dashboard_web.js
+++ b/erp/tests/poc_dashboard_web.js
@@ -1,0 +1,81 @@
+// Whitebox §-witness — DASHBOARD SPIDER WEB (W-DASH-WEB, this lane). §SPEC: idempiere.html.
+//   The Graph tab's "Web" toggle collapses the pies the user has on the board into ONE radar: each pie = a spoke,
+//   the spoke's reach = that pie's CONCENTRATION (biggest slice's % — read off the live card's data-conc). The
+//   totals are equal on every pie (same records), so CONCENTRATION is what makes the spokes differ — the whole
+//   point. NON-INVENT: each spoke is the same fold the donut already drew.
+//   Proves:
+//     W-WEB-SPOKES  : Web on → one .web-svg with one spoke per live pie (≥3); §DASH-WEB spokes==pie count.
+//     W-WEB-DIFFER  : the spokes are NOT all equal (the "same value" trap is solved — real spread of concentration).
+//     W-WEB-CHOSEN  : adding a pie via an Explore chip then re-opening the web adds a spoke (built from chosen pies).
+//     W-WEB-TOGGLE  : toggle off → pies grid back, web hidden.
+'use strict';
+const path = require('path'), http = require('http'), fs = require('fs');
+function pw(){for(const c of [path.join(__dirname,'../../tests/node_modules/playwright'),'/home/red1/bim-ootb/tests/node_modules/playwright']){try{return require(c)}catch(e){}}throw new Error('no pw')}
+const ROOT = path.join(__dirname, '..');
+const MIME = {'.html':'text/html','.js':'text/javascript','.json':'application/json','.db':'application/octet-stream','.wasm':'application/wasm','.css':'text/css','.png':'image/png','.svg':'image/svg+xml','.ico':'image/x-icon','.mjs':'text/javascript'};
+const server = http.createServer((req,res)=>{let p=decodeURIComponent(req.url.split('?')[0]);if(p==='/')p='/idempiere.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){res.writeHead(404);res.end('404');return}res.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});res.end(b)})});
+async function clickPill(page,id){await page.waitForSelector('#pill-'+id,{state:'attached',timeout:15000});await page.evaluate(()=>{var d=document.getElementById('idmp-pill'),t=document.getElementById('idmp-pill-trigger');if(d&&t&&getComputedStyle(d).display==='none')t.dispatchEvent(new PointerEvent('pointerup',{bubbles:true}))});await page.waitForTimeout(150);await page.evaluate(i=>document.getElementById('pill-'+i).dispatchEvent(new PointerEvent('pointerup',{bubbles:true})),id)}
+async function login(page,port,win){
+  await page.goto(`http://localhost:${port}/idempiere.html?client=garden&window=${win}`,{waitUntil:'networkidle'});
+  await page.waitForSelector('#idmp-login-users .idmp-login-user:not(.disabled)',{timeout:15000});
+  await page.click('#idmp-login-users .idmp-login-user:not(.disabled)');
+  await page.waitForSelector('#idmp-login-ok',{timeout:5000});await page.click('#idmp-login-ok');
+  await page.waitForSelector('[data-ad-table]',{timeout:15000}).catch(()=>{});await page.waitForTimeout(1700);
+}
+const last = (logs,re)=>logs.filter(l=>re.test(l)).pop()||'';
+const clickWeb = (page)=>page.evaluate(()=>document.querySelector('.dash-webtoggle').click());
+
+(async()=>{
+  const {chromium}=pw();await new Promise(r=>server.listen(0,r));const port=server.address().port;
+  const b=await chromium.launch();const page=await (await b.newContext()).newPage();
+  await page.setViewportSize({width:1280,height:860});
+  const logs=[],errs=[];page.on('console',m=>logs.push(m.text()));page.on('pageerror',e=>errs.push(e.message));
+  let ok={};
+
+  // Business Partner window (123) — multiple categorical cuts → several pies with DIFFERENT concentrations.
+  await login(page,port,'123');
+  await clickPill(page,'dashboard');
+  await page.waitForFunction(()=>document.querySelector('.dash-card .donut-svg'),{timeout:10000});
+  const pieCount = await page.evaluate(()=>document.querySelectorAll('.dash-grid .dash-card[data-conc]').length);
+
+  // ── W-WEB-SPOKES: flip to Web → one radar, spokes == live pies (≥3). ──
+  await clickWeb(page); await page.waitForTimeout(300);
+  await page.waitForSelector('.dash-web .web-svg',{timeout:5000});
+  const webLog = last(logs,/§DASH-WEB spokes=/);
+  const spokes = Number((webLog.match(/spokes=(\d+)/)||[])[1]);
+  const dots = await page.evaluate(()=>document.querySelectorAll('.dash-web .web-svg circle[r="3"]').length);
+  ok.spokes = spokes>=3 && spokes===pieCount && dots===spokes;
+  console.log('§W-WEB-SPOKES pies='+pieCount+' :: '+webLog+' dots='+dots+' :: '+(ok.spokes?'OK':'FAIL'));
+
+  // ── W-WEB-DIFFER: the concentrations are NOT all equal (the "same value" trap is solved). ──
+  const conc = ((webLog.match(/conc=\[([\d,]+)\]/)||[])[1]||'').split(',').map(Number);
+  const distinct = new Set(conc).size;
+  ok.differ = conc.length>=3 && distinct>=2 && conc.every(c=>c>=0&&c<=100);
+  console.log('§W-WEB-DIFFER conc=['+conc.join(',')+'] distinct='+distinct+' :: '+(ok.differ?'OK':'FAIL'));
+
+  // ── W-WEB-CHOSEN: flip back to pies, add a pie via an Explore chip, re-open web → a spoke is added. ──
+  await clickWeb(page); await page.waitForTimeout(200);   // back to pies
+  const added = await page.evaluate(()=>{
+    var chip=[].slice.call(document.querySelectorAll('.dash-side .ask-chip')).find(c=>!c.classList.contains('on'));
+    if(chip){chip.click();return true;} return false;
+  });
+  await page.waitForTimeout(300);
+  const pieCount2 = await page.evaluate(()=>document.querySelectorAll('.dash-grid .dash-card[data-conc]').length);
+  await clickWeb(page); await page.waitForTimeout(300);   // web again
+  const webLog2 = last(logs,/§DASH-WEB spokes=/);
+  const spokes2 = Number((webLog2.match(/spokes=(\d+)/)||[])[1]);
+  ok.chosen = !added || (pieCount2===pieCount+1 && spokes2===pieCount2);   // honest pass if no spare chip to add
+  console.log('§W-WEB-CHOSEN added='+added+' pies '+pieCount+'→'+pieCount2+' spokes2='+spokes2+' :: '+(ok.chosen?'OK':'FAIL'));
+
+  // ── W-WEB-TOGGLE: off → pies grid visible, web hidden. ──
+  await clickWeb(page); await page.waitForTimeout(200);
+  const state = await page.evaluate(()=>({grid:getComputedStyle(document.querySelector('.dash-grid')).display, web:getComputedStyle(document.querySelector('.dash-web')).display}));
+  ok.toggle = state.grid!=='none' && state.web==='none';
+  console.log('§W-WEB-TOGGLE grid='+state.grid+' web='+state.web+' :: '+(ok.toggle?'OK':'FAIL'));
+
+  const pass=Object.values(ok).filter(Boolean).length, total=Object.keys(ok).length;
+  console.log('\n§W-DASH-WEB '+pass+'/'+total+' '+JSON.stringify(ok));
+  if(errs.length) console.log('§PAGEERR '+errs.length+' :: '+errs.slice(0,3).join(' | '));
+  await b.close(); server.close();
+  process.exit(pass===total && !errs.length ? 0 : 1);
+})().catch(e=>{console.error('§FATAL '+e.message);process.exit(1)});


### PR DESCRIPTION
## What
The Graph tab gets a **Web** toggle. Click it and the pies on the board fly into **one radar**: each pie becomes a **spoke**, the spoke's reach = that pie's **concentration** (its biggest slice's %).

- **Spiky web** = a cut dominated by one value (a risk, or a data gap). **Round web** = evenly spread. A fast *"which cut deserves a look"* glance — then tap back to the pies to drill.
- Built from the **live donut cards**, so the web reflects exactly the pies the user chose to show (including ones added via Explore chips). Concentration is stamped on each card (`data-conc`) as the *same* fold the donut drew — amount-share for money pies, else count.

The totals are equal on every pie (same records), so **concentration — not count — is what makes the spokes differ**; that's the whole point. **NON-INVENT**, no LLM.

## Witness
`erp/tests/poc_dashboard_web.js` — **W-DASH-WEB 4/4**: SPOKES (one per live pie, ≥3), **DIFFER** (spokes are not all equal — the "same value" trap solved: `conc=[56,72,50,78,39]`), CHOSEN (chip-adding a pie grows the web 5→6), TOGGLE (off → pies back). Existing `poc_dashboard_export` 14/14 + forecast 5/5 + variance 3/3 green. `sw.js` v749→v750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)