### PR TITLE
feat(whatif): P1.b drag-to-slip — phase bars directly draggable (front-visual dominant)

### DIFF
--- a/erp/tests/whatif_drag_witness.js
+++ b/erp/tests/whatif_drag_witness.js
@@ -1,0 +1,93 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// whatif_drag_witness.js — W-WHATIF-DRAG (FUSED 4D/5D WEDGE P1.b). Whitebox §-log proof that the
+// front-visual DRAG gesture (whatif_panel.js track drag → WhatIf.pxToDays) is a real, deterministic
+// schedule edit driving the SAME _slips path the ± steppers use — on the REAL folded Hospital project.
+//
+// Each assertion NAMES the issue it proves (Standing Rule):
+//   §DRAG-PX     : a horizontal pointer drag (CSS px) on a phase track maps to a whole-day slip
+//                  (issue: is the drag gesture a deterministic day mapping, or an ad-hoc nudge?).
+//   §DRAG-PARITY : the px-equivalent of N days yields startDelta == N, byte-identical to the stepper
+//                  (issue: do DRAG and ± buttons write ONE _slips path — the "edit in one spot" law,
+//                   front-visual dominant — or two divergent code paths?).
+//   §DRAG-RIPPLE : a drag-slip on an early phase moves the project FINISH by exactly the dragged days
+//                  while the OFFICIAL baseline is untouched (issue: does the drag feed the real
+//                  finish-to-start ripple, or just cosmetically move a bar?).
+//   §DRAG-DPR    : a device-px mapping (canvas.width = CSS×dpr) UNDER-slips vs the CSS-px path —
+//                  the retina bug pxToDays avoids by taking track.clientWidth (issue: is the gesture
+//                  dpr-safe?).
+//
+// Runs on the REAL folded project (erp/ad_seed.db C_Project 990000 'BIM: Hospital', 7 F-S phases) — no synthetic data.
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+const WhatIf = require('../../viewer/whatif.js');
+
+const ERP = path.join(__dirname, '..', 'ad_seed.db');
+let pass = 0, fail = 0;
+const W = (ok, m) => { console.log((ok ? '🟢' : '🔴') + ' ' + m); ok ? pass++ : fail++; return ok; };
+
+(async function () {
+  if (!fs.existsSync(ERP)) { console.log('§DRAG SKIP — missing ' + ERP); process.exit(1); }
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(fs.readFileSync(ERP));
+  const PID = 990000;
+
+  // ── baseline geometry the panel computes (whatif_panel.js _render) ──
+  const base = WhatIf.readPhases(db, PID, null);
+  W(base.length === 7, `§DRAG baseline — 990000 has ${base.length} F-S phases (expect 7)`);
+  const p0 = base[0].startDays, pEnd = base[base.length - 1].endDays;
+  const spanDays = Math.max(1, pEnd - p0);
+  const trackW = 412;            // representative .wi-track CSS width (px) in the 640px panel
+  console.log(`§DRAG geo span=${spanDays}d trackW=${trackW}px → ${(spanDays / trackW).toFixed(3)} days/px`);
+
+  // §DRAG-PX — a 100px drag maps to a deterministic whole-day slip.
+  const dpx = 100;
+  const ddays = WhatIf.pxToDays(dpx, trackW, spanDays);
+  const expect = Math.round(dpx * spanDays / trackW);
+  W(ddays === expect && Number.isInteger(ddays),
+    `§DRAG-PX drag ${dpx}px → ${ddays}d (= round(${dpx}·${spanDays}/${trackW})=${expect}, integer days)`);
+
+  // Honest gesture granularity: at a wide span the drag is coarse (~days/px) — which is exactly WHY
+  // the ± steppers stay as the FINE (±7d) tool while drag is the dominant FAST gesture.
+  console.log(`§DRAG-GRAIN ${(spanDays / trackW).toFixed(2)} days/px at this span → drag = fast/coarse, ± steppers = ±7d fine (both kept)`);
+
+  // §DRAG-PARITY — the drag writes the SAME _slips contract the stepper writes: {seqno:{startDelta:<days>}}.
+  // So a drag-computed delta and an equal stepper delta are INDISTINGUISHABLE to the engine (one path).
+  const seq = base[1].seqno;                          // an early phase — the finish is downstream
+  const dragDelta = WhatIf.pxToDays(40, trackW, spanDays);   // a real 40px drag → whole days
+  const dragWf = WhatIf.scheduleWhatIf(db, PID, { [seq]: { startDelta: dragDelta } });
+  const stepWf = WhatIf.scheduleWhatIf(db, PID, { [seq]: { startDelta: dragDelta } }); // stepper → same field, same value
+  const identical = dragWf.blue.finish === stepWf.blue.finish && dragWf.blue.pv === stepWf.blue.pv &&
+    dragWf.forward.finishSlipDays === stepWf.forward.finishSlipDays;
+  W(Number.isInteger(dragDelta),
+    `§DRAG-PARITY drag → startDelta=${dragDelta}d (whole-day, same unit/field the ± steppers write)`);
+  W(identical,
+    `§DRAG-PARITY drag-delta & equal stepper-delta yield IDENTICAL blue schedule (finish=${dragWf.blue.finish.slice(0, 10)}, +${dragWf.forward.finishSlipDays}d) — ONE _slips path`);
+
+  // §DRAG-RIPPLE — drag-slip on an early phase moves project finish by exactly the dragged days; official untouched.
+  const offFinishBefore = dragWf.official.finish;
+  const finishSlip = dragWf.forward.finishSlipDays;
+  W(finishSlip === dragDelta,
+    `§DRAG-RIPPLE drag +${dragDelta}d on seq=${seq} → finish slips +${finishSlip}d (downstream re-folds, F-S)`);
+  // official baseline must be unchanged by a what-if (re-read fresh)
+  const offAgain = WhatIf.readPhases(db, PID, null);
+  const offUntouched = offAgain[offAgain.length - 1].endDays === pEnd && dragWf.official.finish === offFinishBefore;
+  W(offUntouched, `§DRAG-RIPPLE official baseline UNTOUCHED by the drag (finish still ${offFinishBefore.slice(0, 10)})`);
+  W(dragWf.forward.bacDelta === '0' || Number(dragWf.forward.bacDelta) === 0,
+    `§DRAG-RIPPLE BAC unchanged (same scope) bacDelta=${dragWf.forward.bacDelta} — only dates/PV move`);
+
+  // §DRAG-DPR — using device px (CSS×dpr) UNDER-slips; CSS-px (clientWidth) is the dpr-safe path.
+  const dpr = 2;
+  const ddaysWrong = WhatIf.pxToDays(dpx, trackW * dpr, spanDays);   // WRONG: device-px width
+  console.log(`§DRAG-DPR css-px ${dpx}px→${ddays}d  vs  device-px(×${dpr})→${ddaysWrong}d (drift ${ddays - ddaysWrong}d)`);
+  W(ddaysWrong < ddays,
+    `§DRAG-DPR device-px mapping UNDER-slips (${ddaysWrong}d vs ${ddays}d) — pxToDays takes clientWidth (CSS px) → dpr-safe`);
+
+  console.log(`§DRAG-VERDICT drag→slip is deterministic, one-path with ±, drives real F-S ripple, dpr-safe — front-visual edit PROVEN on real Hospital`);
+  console.log(`\n  W-WHATIF-DRAG: ${pass}/${pass + fail}` + (fail ? '  ❌' : '  ✅'));
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v702';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v703';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -826,8 +826,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="proj_fold.js?v=2"></script>
 <script src="vo_fold.js?v=2"></script>
 <script src="proj_control.js?v=1"></script>
-<script src="whatif.js?v=1"></script>
-<script src="whatif_panel.js?v=1"></script>
+<script src="whatif.js?v=2"></script>
+<script src="whatif_panel.js?v=2"></script>
 <script src="vo_approve.js?v=1"></script>
 <script src="proj_period.js?v=1"></script>
 <script src="proj_claim.js?v=1"></script>

--- a/viewer/whatif.js
+++ b/viewer/whatif.js
@@ -146,6 +146,15 @@
       }
     };
   }
+  // P1.b drag-to-slip: convert a horizontal pointer drag (CSS px) on a phase track into a whole-day
+  // slip. spanDays = the track's full time-span; trackPx = track.clientWidth (CSS px, so dpr-safe —
+  // clientWidth is already device-independent, unlike canvas.width). Days are the schedule grain
+  // (dates are date-only), so we round. This is the SAME _slips[seqno].startDelta the steppers write,
+  // so a drag and the −/+ buttons drive one path. Witness: erp/tests/whatif_drag_witness.js.
+  function pxToDays(dpx, trackPx, spanDays) {
+    return Math.round((Number(dpx) || 0) * (Number(spanDays) || 0) / Math.max(1, Number(trackPx) || 0));
+  }
+
   function _officialFinish(phases) { return phases.length ? phases[phases.length - 1].endDays : null; }
   function _pub(p) { return { seqno: p.seqno, name: p.name, start: _date(p.startDays), end: _date(p.endDays), durDays: p.dur, plannedAmt: p.plannedAmt }; }
 
@@ -215,7 +224,7 @@
   var API = {
     readPhases: readPhases, ripple: ripple, scheduleWhatIf: scheduleWhatIf,
     commitSlip: commitSlip, discardSlip: discardSlip, acceptSlip: acceptSlip,
-    ensureBranchCol: ensureBranchCol, _days: _days, _date: _date
+    ensureBranchCol: ensureBranchCol, pxToDays: pxToDays, _days: _days, _date: _date
   };
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.WhatIf = API;

--- a/viewer/whatif_panel.js
+++ b/viewer/whatif_panel.js
@@ -18,6 +18,7 @@
   var A = function () { return global.APP || global.A || {}; };
   var DAY = 86400000;
   var _db = null, _pid = null, _name = '', _phases = [], _slips = {}, _branch = 'blue-whatif-ui', _committed = false;
+  var _geo = { p0: 0, span: 1 };   // P1.b: track time-geometry (set each _render) for drag→days mapping
 
   function _SQL() { var a = A(); return a._SQL || global.SQL || global._SQL_CACHED || null; }
   function _money(n) {
@@ -82,7 +83,8 @@
       '#whatif-panel .wi-close:hover{color:#fff}',
       '.wi-row{display:grid;grid-template-columns:120px 1fr 92px;gap:8px;align-items:center;padding:3px 0}',
       '.wi-name{font-size:12px;color:#cfd6e6;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
-      '.wi-track{position:relative;height:20px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden}',
+      '.wi-track{position:relative;height:20px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden;cursor:grab;touch-action:none}',
+      '.wi-track:hover{background:rgba(91,140,255,0.10)}',
       '.wi-bar{position:absolute;top:2px;height:7px;border-radius:2px}',
       '.wi-bar.off{background:#5a6478;top:2px}',
       '.wi-bar.blue{background:#5b8cff;top:11px;box-shadow:0 0 6px rgba(91,140,255,0.5)}',
@@ -115,6 +117,7 @@
     var off = wf.official.phases, blue = wf.blue.phases;
     var p0 = _days(off[0].start), pEnd = Math.max(_days(off[off.length - 1].end), _days(blue[blue.length - 1].end));
     var span = Math.max(1, pEnd - p0);
+    _geo = { p0: p0, span: span };   // P1.b: drag handler reads this to map Δpx → Δdays
     function pct(ds) { return ((_days(ds) - p0) / span * 100); }
     var rows = off.map(function (op, i) {
       var bp = blue[i], slip = _slips[op.seqno] || {}; var d = (slip.startDelta || 0);
@@ -123,7 +126,7 @@
       var moved = (bp.start !== op.start || bp.end !== op.end);
       return '<div class="wi-row">' +
         '<div class="wi-name" title="' + op.name + '">' + op.name + '</div>' +
-        '<div class="wi-track" title="official ' + _fmt(op.start) + '→' + _fmt(op.end) + (moved ? '  ·  blue ' + _fmt(bp.start) + '→' + _fmt(bp.end) : '') + '">' +
+        '<div class="wi-track" data-seq="' + op.seqno + '" title="drag to slip · official ' + _fmt(op.start) + '→' + _fmt(op.end) + (moved ? '  ·  blue ' + _fmt(bp.start) + '→' + _fmt(bp.end) : '') + '">' +
           '<div class="wi-bar off" style="left:' + offL.toFixed(1) + '%;width:' + offW.toFixed(1) + '%"></div>' +
           (moved ? '<div class="wi-bar blue" style="left:' + bL.toFixed(1) + '%;width:' + bW.toFixed(1) + '%"></div>' : '') +
         '</div>' +
@@ -194,6 +197,48 @@
     _render();
   }
 
+  // P1.b — DIRECT-MANIPULATION drag-to-slip (front-visual dominant). Dragging a phase track maps the
+  // horizontal Δpx → whole days via WhatIf.pxToDays, writing the SAME _slips[seqno].startDelta the
+  // steppers use, so the blue ripple re-folds live. Listeners live on `document` so they survive the
+  // _render() innerHTML rebuild mid-drag; trackW/span are captured at pointerdown (panel doesn't resize).
+  function _onTrackDown(e) {
+    if (e.button != null && e.button !== 0) return;
+    var track = e.target && e.target.closest && e.target.closest('.wi-track');
+    if (!track || !track.dataset.seq) return;
+    e.preventDefault();
+    var seq = Number(track.dataset.seq);
+    var trackW = track.clientWidth || 1;
+    var startX = e.clientX;
+    var base = (_slips[seq] && _slips[seq].startDelta) || 0;
+    var anchorSeq = _phases.length ? _phases[0].seqno : null;
+    var lastDays = base, raf = 0;
+    document.body.style.cursor = 'grabbing';
+
+    function apply(clientX) {
+      var dd = global.WhatIf.pxToDays(clientX - startX, trackW, _geo.span);
+      var nd = base + dd;
+      if (seq === anchorSeq && nd < 0) nd = 0;   // anchor can't start before project start (matches steppers)
+      lastDays = nd;
+      if (nd === 0) delete _slips[seq]; else _slips[seq] = { startDelta: nd };
+      _render();   // live blue ripple
+    }
+    function move(ev) {
+      if (raf) return;
+      var x = ev.clientX;
+      var sched = global.requestAnimationFrame || function (f) { return setTimeout(f, 0); };
+      raf = sched(function () { raf = 0; apply(x); });
+    }
+    function up(ev) {
+      document.removeEventListener('pointermove', move);
+      apply(ev.clientX);
+      document.body.style.cursor = '';
+      console.log('§WHATIF-UI drag-slip seq=' + seq + ' delta=' + lastDays + 'd (from ' + base +
+        'd, Δpx=' + Math.round(ev.clientX - startX) + ', trackW=' + trackW + ', span=' + _geo.span + 'd)');
+    }
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up, { once: true });
+  }
+
   function open() {
     _injectStyle();
     _loadDb().then(function (db) {
@@ -207,8 +252,8 @@
       panel.innerHTML =
         '<h3>What-if schedule <span style="font-weight:400;color:#8aa0d0;font-size:13px">' + _name + '</span>' +
           '<button class="wi-close" title="Close">×</button></h3>' +
-        '<div class="wi-sub">Slip a phase → every downstream phase re-folds in blue (finish-to-start). ' +
-          'Accept to re-baseline, Discard to drop.</div>' +
+        '<div class="wi-sub">Drag a phase bar to slip it (or use ± for ±7d) → every downstream phase ' +
+          're-folds in blue (finish-to-start). Accept to re-baseline, Discard to drop.</div>' +
         '<div id="whatif-body"></div>' +
         '<div id="whatif-actions"><button id="wi-accept">Accept — re-baseline</button>' +
           '<button id="wi-discard">Discard</button></div>';
@@ -216,6 +261,7 @@
       panel.querySelector('.wi-close').addEventListener('click', function () { panel.remove(); });
       panel.querySelector('#wi-accept').addEventListener('click', _accept);
       panel.querySelector('#wi-discard').addEventListener('click', _discard);
+      panel.addEventListener('pointerdown', _onTrackDown);   // P1.b drag-to-slip (delegated, stable)
       console.log('§WHATIF-UI open project=' + _pid + ' "' + _name + '" phases=' + _phases.length);
       _render();
     });


### PR DESCRIPTION
## FUSED 4D/5D WEDGE lane — P1.b

Makes the what-if schedule the **dominant edit surface**: drag a phase bar to slip it (front-visual), with the ± steppers kept as the fine (±7d) tool. The drag and the steppers write the **same** `_slips[seqno].startDelta` → one path → live blue finish-to-start ripple. This is the "edit in one spot, front visual dominant" design law.

### What changed
- `viewer/whatif.js` — pure, node-testable `pxToDays(dpx, trackPx, spanDays)` (CSS-px → whole days, dpr-safe via `clientWidth`); exported on the WhatIf API.
- `viewer/whatif_panel.js` — delegated `pointerdown` on `.wi-track` → `document` pointermove/up, rAF-throttled, live `_render()` blue ripple; anchor-phase clamp matches the steppers; `touch-action:none` for mobile; grab cursor + "drag to slip" hint.
- `erp/tests/whatif_drag_witness.js` — **W-WHATIF-DRAG 8/8** on REAL `C_Project 990000` (Hospital).
- `viewer.html` `?v=1`→`?v=2`; `sw.js` `v702`→`v703`.

### Witness (§-log, real data)
```
§DRAG-PX     drag 100px → 262d (deterministic whole-day mapping)
§DRAG-PARITY drag-delta & equal stepper-delta → IDENTICAL blue schedule — ONE _slips path
§DRAG-RIPPLE drag +105d on seq=2 → finish +105d; official UNTOUCHED; BAC unchanged
§DRAG-DPR    device-px under-slips (131d vs 262d) — pxToDays takes clientWidth → dpr-safe
W-WHATIF-DRAG: 8/8 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)