### PR TITLE
feat(4d-author): §AUTHOR-1 — author the 4D schedule UP from a blank model (TM-owned wizard)

### DIFF
--- a/erp/tests/author_4d_witness.js
+++ b/erp/tests/author_4d_witness.js
@@ -1,0 +1,125 @@
+// author_4d_witness.js — W-AUTHOR-4D-BLANK (FUSED_4D5D_WEDGE_LANE §AUTHOR-1)
+//
+// ISSUE PROVED: a user can start from a real model with ZERO 4D metadata, materialize an
+// ORGANIZED default schedule (phases = WBS leaves, every element assigned), and CRAFT it by
+// reassigning an element to a different phase — and the SHIPPED read-path (injectGantt's `_cap`
+// overlay) picks up the authored tasks + honours the reassignment, bound by guid (the P2 link).
+//
+// Non-invent: real SampleHouse_extracted.db (60 elements, tasks=0 = genuinely blank 4D); the
+// `_cap` consumer is EXTRACTED VERBATIM from viewer/time_machine.js (not re-typed); the phase
+// rules are EXTRACTED VERBATIM from viewer/rates.js. Whitebox §-log proof only.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..');           // worktree root
+var VIEWER = path.join(ROOT, 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-AUTHOR PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-AUTHOR FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+// Extract `var SEQUENCE_RULES = {...}; ... var SEQUENCE_DEFAULT = {...};` verbatim from rates.js.
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var SEQUENCE_RULES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+
+// Extract the REAL `_cap` IIFE verbatim from time_machine.js → a callable function of `db`.
+function loadCapConsumer() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'time_machine.js'), 'utf8');
+  var start = txt.indexOf('var _cap = (function() {');
+  if (start < 0) throw new Error('could not find _cap in time_machine.js');
+  var end = txt.indexOf('})();', start) + '})();'.length;
+  var slice = txt.slice(start, end);
+  console.log('§W-AUTHOR CAP-SLICE bytes=' + slice.length + ' (verbatim from time_machine.js)');
+  // eslint-disable-next-line no-new-func
+  return new Function('db', slice + '\n return _cap;');
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var rulesPack = loadRules();
+  var RULES = rulesPack.SEQUENCE_RULES, DEFAULT = rulesPack.SEQUENCE_DEFAULT;
+  console.log('§W-AUTHOR RULES-LOADED keys=' + Object.keys(RULES).length + ' default=' + DEFAULT.phase);
+  var makeCap = loadCapConsumer();
+
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+
+  // ── 1. Blank-4D precondition (real model, no schedule) ───────────────────────
+  var nElems = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+  var nTasks0 = db.exec("SELECT COUNT(*) FROM tasks")[0].values[0][0];
+  var nTE0 = db.exec("SELECT COUNT(*) FROM task_elements")[0].values[0][0];
+  check('blank-tasks', nTasks0 === 0, 'tasks=' + nTasks0);
+  check('blank-task_elements', nTE0 === 0, 'task_elements=' + nTE0);
+  check('model-has-elements', nElems > 0, 'elements=' + nElems);
+
+  // ── 2. Materialize the organized default schedule ────────────────────────────
+  var res = ScheduleAuthor.materializeDefault(db, RULES, { start: '2026-01-01', phaseDays: 30 });
+  check('phases-created', res.phases.length >= 2, 'phases=' + res.phases.length +
+    ' [' + res.phases.map(function (p) { return p.name + ':' + p.count; }).join(', ') + ']');
+  check('every-element-assigned', res.assignmentCount === nElems,
+    'assignments=' + res.assignmentCount + ' elements=' + nElems);
+
+  // WBS shape: one summary ROOT (is_summary=1) + N dated leaves (is_summary=0).
+  var roots = db.exec("SELECT COUNT(*) FROM tasks WHERE is_summary=1")[0].values[0][0];
+  var leaves = db.exec("SELECT COUNT(*) FROM tasks WHERE (is_summary IS NULL OR is_summary=0) AND schedule_start IS NOT NULL")[0].values[0][0];
+  check('one-summary-root', roots === 1, 'summaryRoots=' + roots);
+  check('dated-leaves-eq-phases', leaves === res.phases.length, 'datedLeaves=' + leaves + ' phases=' + res.phases.length);
+  // Every leaf nests under the root (organized WBS tree).
+  var orphan = db.exec("SELECT COUNT(*) FROM tasks WHERE is_summary=0 AND wbs_parent <> '" + res.rootId + "'")[0].values[0][0];
+  check('leaves-nest-under-root', orphan === 0, 'orphanLeaves=' + orphan);
+
+  // ── 3. Shipped read-path (`_cap`) sees the authored schedule ─────────────────
+  var cap = makeCap(db);
+  check('cap-active', cap !== null, 'cap=' + (cap ? 'captured' : 'null'));
+  check('cap-leafcount', cap && cap.taskCount === res.phases.length, 'cap.taskCount=' + (cap && cap.taskCount));
+  var guidMapped = cap ? Object.keys(cap.guidTask).length : 0;
+  check('cap-maps-every-guid', guidMapped === nElems, 'guidTask=' + guidMapped + ' elements=' + nElems);
+
+  // Spot-check: an IfcFurniture element must land in the Finishes phase task (rule-correct binding).
+  var furn = db.exec("SELECT guid FROM elements_meta WHERE ifc_class='IfcFurniture' LIMIT 1");
+  var finishesTask = 'TASK_Finishes';
+  if (furn.length && furn[0].values.length) {
+    var fg = furn[0].values[0][0];
+    check('cap-furniture-in-finishes', cap && cap.guidTask[fg] === finishesTask,
+      'IfcFurniture guid->' + (cap && cap.guidTask[fg]));
+  } else { check('cap-furniture-in-finishes', false, 'no IfcFurniture element found'); }
+
+  // ── 4. CRAFT: reassign one element to a DIFFERENT phase → re-fold honours it ──
+  // Pick a Superstructure (IfcMember) element and a control element we will NOT touch.
+  var member = db.exec("SELECT guid FROM elements_meta WHERE ifc_class='IfcMember' LIMIT 2");
+  var movedGuid = member[0].values[0][0];
+  var controlGuid = member[0].values[1][0];
+  var srcTaskBefore = cap.guidTask[movedGuid];
+  var ctrlTaskBefore = cap.guidTask[controlGuid];
+  // Target a phase that is NOT the source (Architecture).
+  var targetTask = 'TASK_Architecture';
+  var asg = ScheduleAuthor.assignElement(db, movedGuid, targetTask);
+  check('craft-assign-ok', asg.ok === true, 'moved ' + srcTaskBefore + ' -> ' + targetTask);
+
+  var cap2 = makeCap(db);
+  check('craft-reassign-honored', cap2 && cap2.guidTask[movedGuid] === targetTask,
+    'after re-fold guid->' + (cap2 && cap2.guidTask[movedGuid]));
+  check('craft-control-unchanged', cap2 && cap2.guidTask[controlGuid] === ctrlTaskBefore,
+    'control still->' + (cap2 && cap2.guidTask[controlGuid]) + ' (was ' + ctrlTaskBefore + ')');
+  // The moved element now carries the TARGET task's real window (the overlay payload).
+  var targetWin = cap2.win[targetTask];
+  check('craft-carries-target-window', !!targetWin && cap2.guidTask[movedGuid] === targetTask,
+    'target window name="' + (targetWin && targetWin.name) + '"');
+
+  console.log('§W-AUTHOR-4D-BLANK RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-AUTHOR ERROR', e); process.exit(2); });

--- a/erp/tests/author_wizard_wiring.js
+++ b/erp/tests/author_wizard_wiring.js
@@ -1,0 +1,86 @@
+// author_wizard_wiring.js — W-AUTHOR-WIZARD-WIRE (FUSED_4D5D_WEDGE_LANE §AUTHOR-1 slice-2)
+//
+// ISSUE PROVED: the authoring wizard is correctly MOUNTED on the Time-Machine surface and its
+// button handlers invoke the proven engine. Specifically:
+//   (a) schedule_author_ui.js loads and exposes the launch API the TM `tm-author` button calls;
+//   (b) the TM panel hosts `tm-author` + `tm-whatif` buttons wired to ScheduleAuthorUI / WhatIfPanel;
+//   (c) what-if is RE-HOMED off the Find box (no `find-whatif-btn` left) → TM (§ARCH-OWNERSHIP);
+//   (d) both scripts are registered in viewer.html;
+//   (e) the engine calls the wizard handlers make (materializeDefault → assignElement) still fold a
+//       valid authored schedule on the REAL model (the value-correctness itself is W-AUTHOR-4D-BLANK).
+//
+// Live browser smoke (click → panel renders → draft) is deferred to deploy: the sandbox has no
+// browser/jsdom. Whitebox §-log + module-load + real-engine proof here, per docs/TestArchitecture
+// §Browser Testing (§-log first, Playwright second).
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..');
+var VIEWER = path.join(ROOT, 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-WIRE PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-WIRE FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+
+(async function () {
+  // ── (a) UI module loads and exposes the launch API (no DOM needed at load) ────
+  // Provide a minimal global so the IIFE's top-level (globals + console.log) runs cleanly.
+  var stub = { console: console };
+  global.self = stub;                                  // module binds to `self`
+  require(path.join(VIEWER, 'schedule_author_ui.js'));
+  check('ui-exposes-open', typeof stub.openScheduleAuthorWizard === 'function', 'openScheduleAuthorWizard');
+  check('ui-exposes-toggle', !!(stub.ScheduleAuthorUI && typeof stub.ScheduleAuthorUI.toggle === 'function'), 'ScheduleAuthorUI.toggle');
+
+  // ── (b) TM panel hosts the two buttons + wires them to the TM-owned engines ───
+  var tm = read('time_machine.js');
+  check('tm-author-button', tm.indexOf("id=\"tm-author\"") >= 0, 'tm-author in panel');
+  check('tm-whatif-button', tm.indexOf("id=\"tm-whatif\"") >= 0, 'tm-whatif in panel');
+  check('tm-author-wired', /tm-author[\s\S]{0,400}ScheduleAuthorUI/.test(tm), 'handler→ScheduleAuthorUI');
+  check('tm-whatif-wired', /tm-whatif[\s\S]{0,400}WhatIfPanel\.open/.test(tm), 'handler→WhatIfPanel.open');
+
+  // ── (c) what-if RE-HOMED off Find (satellite no longer owns the launch) ───────
+  var nf = read('navigate_find.js');
+  check('find-whatif-button-removed', nf.indexOf('find-whatif-btn') < 0, 'no find-whatif-btn');
+  check('find-whatif-handler-removed', nf.indexOf('WhatIfPanel.open') < 0, 'no WhatIfPanel.open in Find');
+  check('find-rehome-note', nf.indexOf('RE-HOMED') >= 0, 'rehome rationale documented');
+
+  // ── (d) scripts registered in viewer.html ────────────────────────────────────
+  var html = read('viewer.html');
+  check('html-loads-engine', /schedule_author\.js\?v=/.test(html), 'schedule_author.js included');
+  check('html-loads-ui', /schedule_author_ui\.js\?v=/.test(html), 'schedule_author_ui.js included');
+  // pill discoverability
+  var pj = read('panels.js');
+  check('pill-children-author', pj.indexOf('Author 4D schedule') >= 0, 'tm pill child added');
+
+  // ── (e) the engine calls the wizard handlers make work on the REAL model ──────
+  // generateDraft() → ScheduleAuthor.materializeDefault ; reassign() → ScheduleAuthor.assignElement.
+  var SA = require(path.join(VIEWER, 'schedule_author.js'));
+  var rulesTxt = read('rates.js');
+  var rs = rulesTxt.indexOf('var SEQUENCE_RULES = {');
+  var di = rulesTxt.indexOf('var SEQUENCE_DEFAULT');
+  var slice = rulesTxt.slice(rs, rulesTxt.indexOf('};', di) + 2);
+  // eslint-disable-next-line no-new-func
+  var RULES = (new Function(slice + '\n return SEQUENCE_RULES;'))();
+
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+  var res = SA.materializeDefault(db, RULES, { start: '2026-01-01', phaseDays: 30 });
+  check('handler-draft-folds', res.phases.length >= 2 && res.assignmentCount > 0,
+    'phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
+  // reassign verb the dropdown invokes
+  var anyEl = db.exec("SELECT guid FROM elements_meta LIMIT 1")[0].values[0][0];
+  var target = res.phases[res.phases.length - 1].taskId;
+  var asg = SA.assignElement(db, anyEl, target);
+  var bound = db.exec("SELECT task_id FROM task_elements WHERE guid='" + anyEl + "'");
+  check('handler-reassign-binds', asg.ok && bound[0].values[0][0] === target,
+    'guid→' + (bound.length && bound[0].values[0][0]));
+
+  console.log('§W-AUTHOR-WIZARD-WIRE RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-WIRE ERROR', e); process.exit(2); });

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -179,7 +179,7 @@
       '</div>',
       // S275: Selected item summary + inline navigate button
       // BIM\u2192Project TASK A: indicative 5D cost of the selection (docs/BIMtoProject.md \u00A7A)
-      '<div id="find-selected"><span id="find-selected-text"></span><span id="find-selected-cost" title="Indicative 5D cost (active rate pack)"></span><button class="find-nav-inline" id="find-erp-btn" title="Push selection to ERP as a Project Order">\u203A ERP</button><a id="find-erp-open" target="_blank" rel="noopener" title="Open the created Project Order in iDempiere (GardenWorld)">open \u2197</a><button class="find-nav-inline" id="find-whatif-btn" title="What-if schedule: slip a phase, watch the finish-to-start chain re-fold in blue">What-if</button><button class="find-nav-inline" id="find-navigate-btn" title="Navigate">\u25B6</button></div>',
+      '<div id="find-selected"><span id="find-selected-text"></span><span id="find-selected-cost" title="Indicative 5D cost (active rate pack)"></span><button class="find-nav-inline" id="find-erp-btn" title="Push selection to ERP as a Project Order">\u203A ERP</button><a id="find-erp-open" target="_blank" rel="noopener" title="Open the created Project Order in iDempiere (GardenWorld)">open \u2197</a><button class="find-nav-inline" id="find-navigate-btn" title="Navigate">\u25B6</button></div>',
       '<div id="find-results"></div>',
     ].join('');
     document.body.appendChild(panel);
@@ -3351,12 +3351,8 @@
     // ── BIM→Project TASK C: wire the > to ERP button (folds the selection via window.ProjFold) ──
     if (elErpBtn) { elErpBtn.tabIndex = 0; elErpBtn.onclick = function () { _pushToErp(); }; }
 
-    // ── §S6 what-if: open the schedule what-if panel on the folded project (window.WhatIfPanel) ──
-    var elWhatIf = document.getElementById('find-whatif-btn');
-    if (elWhatIf) { elWhatIf.tabIndex = 0; elWhatIf.onclick = function () {
-      if (window.WhatIfPanel) window.WhatIfPanel.open();
-      else if (A.status) A.status.textContent = 'What-if engine not loaded';
-    }; }
+    // ── §S6 what-if RE-HOMED → Time Machine (§ARCH-OWNERSHIP: TM owns 4D/5D, Find is a satellite).
+    //    The launch now lives on the TM clock-pill surface (time_machine.js tm-whatif button). ──
 
     // ── Expose for navigate.js Section D and external callers ──
     A.clearHighlight = clearHighlight;

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1159,7 +1159,7 @@ function setupPanels(A) {
       // Alt+X bounding-box envelope ghost — hold-chip off X-Ray (sibling x-ray mode); pill:false → Help/Settings only, no standalone pill.
       { id: 'bbox',       name: 'Bounding Boxes',  key: 'Alt+X', pill: false, icon: I.box.svg, fn: function() { if (typeof window.toggleGhostXray === 'function') window.toggleGhostXray(); }, isActive: function() { return typeof window.ghostXrayOn === 'function' && window.ghostXrayOn(); } },
       { id: 'tm',         name: 'Time Machine',    key: 't', icon: I.clock.svg, fn: function() { if (typeof toggleTimeMachine === 'function') toggleTimeMachine(); }, isActive: function() { return !!A._tmOn; },
-        children: [ { name: 'Gantt timeline' }, { name: 'Play / Pause sequence' }, { name: 'Phase slider' }, { name: 'Share ?tm=play link' } ] },
+        children: [ { name: 'Gantt timeline' }, { name: 'Author 4D schedule (✎)' }, { name: 'What-if (slip a phase)' }, { name: 'Play / Pause sequence' }, { name: 'Phase slider' }, { name: 'Share ?tm=play link' } ] },
       { id: 'section',    name: 'Section Cut',     key: 'x', icon: I.scissors.svg, fn: function() { if (A.toggleSection) A.toggleSection(); }, isActive: function() { return !!A.sectionOn; },
         children: [ { name: 'Y axis (vertical)' }, { name: 'X axis (lateral)' }, { name: 'Z axis (depth)' }, { name: 'Slider 0\u2013100%' }, { name: 'Bookmarks' } ] },
       { id: 'background', name: 'Background',      key: 'b', keepOpen: true, icon: I.contrast.svg,

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1,0 +1,183 @@
+// schedule_author.js — §AUTHOR-1 (FUSED_4D5D_WEDGE_LANE) — the FIRST authoring slice.
+// Build the 4D schedule UP from a blank model: rule-group elements into ORGANIZED phases
+// (WBS) written into the IFC-native 4D tables, then craft (reassign) elements between phases.
+//
+// Implementing FUSED_4D5D_WEDGE_LANE.md §AUTHOR-1 — Witness: W-AUTHOR-4D-BLANK
+// SOURCE OF TRUTH = the IFC-native tables `schedules`/`tasks`/`task_elements` ONLY
+// (per §AUTHOR-1 "NOT a new kernel_ops op; corrected 2026-06-23"). kernel_ops mirroring deferred.
+//
+// Pure, DOM-free, node-testable. `materializeDefault` writes EXACTLY the substrate that
+// injectGantt's `_cap` overlay (time_machine.js ~2405) reads: dated, non-summary leaf tasks +
+// task_elements assignments. The task->guid row IS the P2 identity-link (survives rename).
+(function (global) {
+  'use strict';
+
+  // matchRule — REPLICATES time_machine.js matchRule EXACTLY (longest-substring containment),
+  // so authored phases are identical to what injectGantt would group elements into.
+  function matchRule(cls, rules, dflt) {
+    rules = rules || {};
+    dflt = dflt || { phase: 'Architecture', sequence: 6, resource: null };
+    if (!cls) return dflt;
+    var bestKey = null, bestLen = 0;
+    for (var key in rules) {
+      if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
+    }
+    return bestKey ? rules[bestKey] : dflt;
+  }
+
+  function _slug(name) {
+    return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  }
+
+  // YYYY-MM-DD a given number of whole days after a base date string. Pure UTC arithmetic so
+  // it is deterministic regardless of host timezone (no Date.now / locale dependence).
+  function _addDays(baseStr, days) {
+    var b = Date.parse(baseStr + 'T00:00:00Z');
+    var d = new Date(b + days * 86400000);
+    return d.toISOString().slice(0, 10);
+  }
+
+  function _cols(db, table) {
+    var out = [];
+    try {
+      var r = db.exec('PRAGMA table_info(' + table + ')');
+      if (r.length && r[0].values.length) r[0].values.forEach(function (c) { out.push(c[1]); });
+    } catch (e) {}
+    return out;
+  }
+
+  // Some shipped building DBs carry a LEGACY-thin `tasks` table
+  // (task_id, schedule_id, name, start_date, finish_date, duration_days, status) that the read-path
+  // `_cap` cannot consume (its query selects schedule_start/is_summary → errors → generative
+  // fallback). Migrate it to the widened import_db_builder DDL so authored rows are readable.
+  // Safe: maps the thin columns forward (no data loss), then drops + recreates.
+  function _ensureWideTasks(db) {
+    db.run('CREATE TABLE IF NOT EXISTS tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)');
+    var cols = _cols(db, 'tasks');
+    if (cols.indexOf('wbs_parent') >= 0) return false;        // already widened
+    // Carry forward any legacy rows (start_date/finish_date/duration_days → schedule_*).
+    var legacy = [];
+    var hasStart = cols.indexOf('start_date') >= 0;
+    var r = db.exec('SELECT * FROM tasks');
+    if (r.length && r[0].values.length) {
+      var c = r[0].columns;
+      r[0].values.forEach(function (row) {
+        var o = {}; for (var i = 0; i < c.length; i++) o[c[i]] = row[i];
+        legacy.push(o);
+      });
+    }
+    db.run('DROP TABLE tasks');
+    db.run('CREATE TABLE tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)');
+    if (legacy.length) {
+      var st = db.prepare('INSERT OR IGNORE INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+      legacy.forEach(function (o) {
+        st.run([o.task_id, o.schedule_id, null, o.name, null, 0,
+          hasStart ? o.start_date : null, hasStart ? o.finish_date : null,
+          (o.duration_days != null ? 'P' + o.duration_days + 'D' : null), null, o.status]);
+      });
+      st.free();
+    }
+    console.log('§AUTHOR_MIGRATE tasks→widened legacyRows=' + legacy.length);
+    return true;
+  }
+
+  // materializeDefault(db, rules, opts) — originate the smart-default schedule on a blank model.
+  // db: a sql.js Database with `elements_meta`. rules: SEQUENCE_RULES map. opts: {start, phaseDays,
+  // scheduleId, defaultRule}. Idempotent — rebuilds the SCH_AUTHORED schedule from scratch.
+  function materializeDefault(db, rules, opts) {
+    opts = opts || {};
+    var start = opts.start || '2026-01-01';
+    var phaseDays = opts.phaseDays || 30;
+    var schedId = opts.scheduleId || 'SCH_AUTHORED';
+    var dflt = opts.defaultRule || (global.SEQUENCE_DEFAULT) || { phase: 'Architecture', sequence: 6, resource: null };
+    rules = rules || (global.SEQUENCE_RULES) || {};
+
+    // Ensure the IFC-native 4D tables exist (mirror import_db_builder.js DDL exactly).
+    db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+    _ensureWideTasks(db);   // migrate any legacy-thin tasks table → the widened DDL `_cap` reads
+    db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+
+    // Idempotent rebuild: drop any prior authored rows for this schedule.
+    var oldIds = [];
+    var pr = db.exec("SELECT task_id FROM tasks WHERE schedule_id='" + schedId + "'");
+    if (pr.length && pr[0].values.length) pr[0].values.forEach(function (r) { oldIds.push(r[0]); });
+    oldIds.forEach(function (tid) { db.run('DELETE FROM task_elements WHERE task_id=?', [tid]); });
+    db.run("DELETE FROM tasks WHERE schedule_id='" + schedId + "'");
+    db.run("DELETE FROM schedules WHERE schedule_id='" + schedId + "'");
+
+    // Read the raw material: every element + its class.
+    var elems = [];
+    var er = db.exec('SELECT guid, ifc_class FROM elements_meta');
+    if (er.length && er[0].values.length) {
+      er[0].values.forEach(function (r) { elems.push({ guid: r[0], cls: r[1] }); });
+    }
+
+    // Group into phases via the SAME rule the read-path uses.
+    var phases = {};   // phaseName -> { name, seq, guids:[] }
+    elems.forEach(function (e) {
+      var rule = matchRule(e.cls, rules, dflt);
+      var p = phases[rule.phase];
+      if (!p) { p = phases[rule.phase] = { name: rule.phase, seq: rule.sequence, guids: [] }; }
+      if (rule.sequence < p.seq) p.seq = rule.sequence;   // phase ordered by its earliest rule
+      p.guids.push(e.guid);
+    });
+
+    // Order phases by sequence (then name, stable) → contiguous WBS leaves.
+    var ordered = Object.keys(phases).map(function (k) { return phases[k]; });
+    ordered.sort(function (a, b) { return (a.seq - b.seq) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0); });
+
+    db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start]);
+
+    // ROOT summary task (is_summary=1 → excluded from _cap leaf window; spans the whole project).
+    var rootId = 'TASK_ROOT';
+    var totalDays = Math.max(phaseDays, ordered.length * phaseDays);
+    var projFinish = _addDays(start, ordered.length * phaseDays);
+    db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, start, projFinish, 'P' + totalDays + 'D', null, 'PLANNED']);
+
+    var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+    var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
+    var outPhases = [], cursor = 0, assignN = 0;
+    ordered.forEach(function (p) {
+      var tid = 'TASK_' + _slug(p.name);
+      var s = _addDays(start, cursor * phaseDays);
+      var f = _addDays(start, (cursor + 1) * phaseDays);
+      cursor++;
+      // Leaf, dated, is_summary=0 → exactly what _cap.win picks up.
+      stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, 'P' + phaseDays + 'D', null, 'PLANNED']);
+      p.guids.forEach(function (g) { stmtTe.run([tid, g]); assignN++; });
+      outPhases.push({ taskId: tid, name: p.name, sequence: p.seq, start: s, finish: f, count: p.guids.length });
+    });
+    stmtTk.free();
+    stmtTe.free();
+
+    console.log('§AUTHOR_MATERIALIZE schedule=' + schedId + ' phases=' + outPhases.length +
+      ' leafTasks=' + outPhases.length + ' assignments=' + assignN + ' elements=' + elems.length);
+    return { scheduleId: schedId, rootId: rootId, phases: outPhases, taskCount: outPhases.length, assignmentCount: assignN };
+  }
+
+  // assignElement(db, guid, taskId) — the CRAFT verb. Re-home one element to a different phase task.
+  // The reassignment IS the user override; the task->guid row is the P2 identity-link.
+  function assignElement(db, guid, taskId) {
+    var tk = db.exec('SELECT task_id FROM tasks WHERE task_id=?', [taskId]);
+    if (!tk.length || !tk[0].values.length) {
+      console.log('§AUTHOR_ASSIGN_FAIL guid=' + guid + ' taskId=' + taskId + ' reason=no_such_task');
+      return { ok: false, guid: guid, taskId: taskId, reason: 'no_such_task' };
+    }
+    db.run('DELETE FROM task_elements WHERE guid=?', [guid]);
+    db.run('INSERT OR IGNORE INTO task_elements VALUES (?,?)', [taskId, guid]);
+    console.log('§AUTHOR_ASSIGN guid=' + guid + ' -> task=' + taskId);
+    return { ok: true, guid: guid, taskId: taskId };
+  }
+
+  var API = {
+    matchRule: matchRule,
+    materializeDefault: materializeDefault,
+    assignElement: assignElement
+  };
+  if (typeof window !== 'undefined') window.ScheduleAuthor = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else global.ScheduleAuthor = API;
+
+  console.log('§SCHEDULE_AUTHOR_LOADED v1');
+})(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -1,0 +1,275 @@
+// schedule_author_ui.js — §AUTHOR-1 slice-2 — the 4D-schedule authoring WIZARD (front-visual).
+// TM-OWNED: launched from the Time Machine surface (the clock pill). Wraps the pure engine in
+// viewer/schedule_author.js (window.ScheduleAuthor) with a glass panel matching the TM idiom.
+//
+// Implementing FUSED_4D5D_WEDGE_LANE.md §AUTHOR-1 (Front-visual wizard) — the user builds the 4D
+// schedule UP, organized as phases (WBS), assigns elements, and tunes dates — every write lands in
+// the IFC-native schedules/tasks/task_elements tables (the same substrate injectGantt's _cap reads).
+// Steps: ① Generate first draft → ② Assign elements (3D highlight + reassign) → ③ Dates.
+(function (global) {
+  'use strict';
+
+  function A() { return global.APP || global.A; }
+  function db() { var a = A(); return a && a.db; }
+  function rules() { return global.SEQUENCE_RULES || {}; }
+  var SA = function () { return global.ScheduleAuthor; };
+
+  var _panel = null, _built = false;
+  var _state = null;   // { schedId, start, order:[taskId], name:{}, dur:{}, count:{} }
+
+  // ── date helper (UTC, deterministic) ──────────────────────────────────────────
+  function addDays(baseStr, n) {
+    var b = Date.parse(baseStr + 'T00:00:00Z');
+    return new Date(b + n * 86400000).toISOString().slice(0, 10);
+  }
+
+  function _injectStyle() {
+    if (document.getElementById('sa-style')) return;
+    var s = document.createElement('style');
+    s.id = 'sa-style';
+    s.textContent =
+      '#schedule-author-panel{position:fixed;bottom:80px;right:16px;z-index:260;width:320px;max-height:72vh;' +
+      'display:none;flex-direction:column;gap:6px;padding:12px;color:#e0e0e0;font-family:sans-serif;' +
+      'background:rgba(20,20,40,0.9);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);' +
+      'border:1px solid rgba(79,195,247,0.35);border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,0.5);' +
+      'overflow-y:auto;user-select:none}' +
+      '#schedule-author-panel button{background:rgba(255,255,255,0.1);color:#e0e0e0;border:1px solid rgba(79,195,247,0.3);' +
+      'border-radius:5px;padding:5px 8px;cursor:pointer;font-size:11px}' +
+      '#schedule-author-panel button:hover{background:rgba(79,195,247,0.2)}' +
+      '#schedule-author-panel button.sa-primary{background:#1a6b8a;color:#fff;font-weight:bold}' +
+      '#schedule-author-panel input,#schedule-author-panel select{background:rgba(255,255,255,0.08);color:#e0e0e0;' +
+      'border:1px solid rgba(79,195,247,0.25);border-radius:4px;padding:3px 5px;font-size:11px}' +
+      '.sa-phase{border:1px solid rgba(79,195,247,0.18);border-radius:7px;padding:6px;margin-bottom:6px}' +
+      '.sa-phase-hd{display:flex;align-items:center;gap:5px}' +
+      '.sa-dot{width:10px;height:10px;border-radius:50%;flex:0 0 auto}' +
+      '.sa-name{flex:1;min-width:0}' +
+      '.sa-meta{font-size:10px;color:#9bb;margin:4px 0 2px}' +
+      '.sa-elist{max-height:120px;overflow-y:auto;margin-top:4px}' +
+      '.sa-el{display:flex;align-items:center;gap:4px;padding:2px 0;font-size:10px;border-top:1px solid rgba(255,255,255,0.05)}' +
+      '.sa-el .sa-elname{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:pointer;color:#cfe}' +
+      '.sa-el select{font-size:9px;padding:1px 2px}';
+    document.head.appendChild(s);
+  }
+
+  // Deterministic phase colour (stable hue per phase name) — visual organiser only.
+  function phaseColor(name) {
+    var h = 0; for (var i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360;
+    return 'hsl(' + h + ',70%,55%)';
+  }
+
+  function status(msg) {
+    var el = document.getElementById('sa-status'); if (el) el.textContent = msg;
+    console.log('§AUTHOR_UI_STATUS ' + msg);
+  }
+
+  // Read the authored schedule back from the DB into _state (single source of truth = the tables).
+  function refreshState() {
+    var d = db(); if (!d || !_state) return;
+    var r = d.exec("SELECT task_id, name, schedule_start, schedule_finish FROM tasks " +
+      "WHERE schedule_id='" + _state.schedId + "' AND is_summary=0 ORDER BY schedule_start, task_id");
+    _state.order = []; _state.name = {}; _state.start = null;
+    if (r.length && r[0].values.length) {
+      r[0].values.forEach(function (row) {
+        _state.order.push(row[0]); _state.name[row[0]] = row[1];
+        if (!_state.dur[row[0]]) _state.dur[row[0]] = Math.max(1,
+          Math.round((Date.parse(row[3]) - Date.parse(row[2])) / 86400000));
+        if (!_state.start) _state.start = String(row[2]).slice(0, 10);
+      });
+    }
+    // element counts per task
+    _state.count = {};
+    var cr = d.exec("SELECT te.task_id, COUNT(*) FROM task_elements te JOIN tasks t ON t.task_id=te.task_id " +
+      "WHERE t.schedule_id='" + _state.schedId + "' GROUP BY te.task_id");
+    if (cr.length) cr[0].values.forEach(function (row) { _state.count[row[0]] = row[1]; });
+  }
+
+  // ── Authoring writes (each = an in-place edit of the IFC-native tables) ────────
+  function applyDates() {
+    var d = db(); if (!d || !_state) return;
+    var cursor = 0, start = _state.start || '2026-01-01';
+    _state.order.forEach(function (tid) {
+      var dur = _state.dur[tid] || 30;
+      var s = addDays(start, cursor), f = addDays(start, cursor + dur);
+      d.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
+        [s, f, 'P' + dur + 'D', tid]);
+      cursor += dur;
+    });
+    // root span
+    d.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
+      [start, addDays(start, cursor), _state.schedId]);
+    console.log('§AUTHOR_UI_DATES start=' + start + ' span=' + cursor + 'd phases=' + _state.order.length);
+  }
+
+  function renamePhase(tid, name) {
+    var d = db(); if (!d) return;
+    d.run("UPDATE tasks SET name=? WHERE task_id=?", [name, tid]);
+    _state.name[tid] = name;
+    console.log('§AUTHOR_UI_RENAME ' + tid + ' -> "' + name + '"');
+  }
+
+  function reassign(guid, taskId) {
+    var d = db(); if (!d || !SA()) return;
+    SA().assignElement(d, guid, taskId);   // the CRAFT verb (engine-proven, W-AUTHOR-4D-BLANK)
+    refreshState(); render();
+  }
+
+  function highlight(guid) {
+    var a = A(); if (a && a.focusElement) { a.focusElement([guid], { item: true, frame: false }); }
+    console.log('§AUTHOR_UI_FOCUS ' + guid);
+  }
+
+  // ── First draft: materialize the smart default from rules (the prebaked start) ──
+  function generateDraft() {
+    var d = db(); if (!d) { status('No model loaded'); return; }
+    if (!SA()) { status('Author engine not loaded'); return; }
+    var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', phaseDays: 30 });
+    _state = { schedId: res.scheduleId, start: '2026-01-01', order: [], name: {}, dur: {}, count: {} };
+    refreshState();
+    console.log('§AUTHOR_UI_DRAFT phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
+    status('Draft: ' + res.phases.length + ' phases, ' + res.assignmentCount + ' elements assigned');
+    render();
+  }
+
+  // ── Apply to 4D: re-fold the Time Machine so the gantt shows the authored schedule ──
+  function applyTo4D() {
+    applyDates();
+    status('Applied. ' + (A() && A()._tmOn ? 're-folding Time Machine…' : 'open Time Machine to view'));
+    console.log('§AUTHOR_UI_APPLY tmOn=' + !!(A() && A()._tmOn));
+    if (A() && A()._tmOn && typeof global.toggleTimeMachine === 'function') {
+      // toggle off→on re-runs injectGantt → _cap overlays the authored windows (W-AUTHOR-4D-BLANK)
+      global.toggleTimeMachine();
+      setTimeout(function () { global.toggleTimeMachine(); }, 60);
+    }
+  }
+
+  function render() {
+    var body = document.getElementById('sa-body'); if (!body) return;
+    if (!_state || !_state.order.length) {
+      body.innerHTML = '<div style="font-size:11px;color:#9bb;line-height:1.5">No schedule yet. ' +
+        'Click <b>Generate first draft</b> to fold the model into organized phases — then rename, ' +
+        'reassign elements, and tune dates. Each edit is written to the project.</div>';
+      return;
+    }
+    var d = db();
+    // phase-task option list (for reassign dropdowns)
+    var opts = _state.order.map(function (tid) {
+      return '<option value="' + tid + '">' + (_state.name[tid] || tid) + '</option>';
+    }).join('');
+
+    var html = '<div style="display:flex;gap:5px;align-items:center;margin-bottom:6px">' +
+      '<label style="font-size:10px;color:#9bb">Start</label>' +
+      '<input id="sa-start" type="date" value="' + (_state.start || '2026-01-01') + '" style="flex:1">' +
+      '</div>';
+
+    _state.order.forEach(function (tid) {
+      var nm = _state.name[tid] || tid, dur = _state.dur[tid] || 30, cnt = _state.count[tid] || 0;
+      html += '<div class="sa-phase" data-tid="' + tid + '">' +
+        '<div class="sa-phase-hd">' +
+          '<span class="sa-dot" style="background:' + phaseColor(nm) + '"></span>' +
+          '<input class="sa-name" value="' + nm.replace(/"/g, '&quot;') + '" data-tid="' + tid + '">' +
+          '<span style="font-size:10px;color:#9bb">' + cnt + ' el</span>' +
+        '</div>' +
+        '<div class="sa-meta">' +
+          '<button class="sa-dur" data-tid="' + tid + '" data-d="-5">&#8211;5d</button> ' +
+          '<b>' + dur + 'd</b> ' +
+          '<button class="sa-dur" data-tid="' + tid + '" data-d="5">+5d</button> ' +
+          '<button class="sa-toggle" data-tid="' + tid + '" style="float:right;font-size:9px">elements &#9662;</button>' +
+        '</div>' +
+        '<div class="sa-elist" data-tid="' + tid + '" style="display:none"></div>' +
+      '</div>';
+    });
+    body.innerHTML = html;
+
+    // wire start date
+    var st = document.getElementById('sa-start');
+    if (st) st.onchange = function () { _state.start = st.value; applyDates(); render(); };
+
+    // wire rename
+    body.querySelectorAll('input.sa-name').forEach(function (inp) {
+      inp.onchange = function () { renamePhase(inp.dataset.tid, inp.value.trim() || inp.dataset.tid); };
+    });
+    // wire duration steppers
+    body.querySelectorAll('button.sa-dur').forEach(function (b) {
+      b.onclick = function () {
+        var tid = b.dataset.tid, delta = parseInt(b.dataset.d, 10);
+        _state.dur[tid] = Math.max(1, (_state.dur[tid] || 30) + delta);
+        applyDates(); render();
+      };
+    });
+    // wire element-list expanders
+    body.querySelectorAll('button.sa-toggle').forEach(function (b) {
+      b.onclick = function () {
+        var tid = b.dataset.tid;
+        var box = body.querySelector('.sa-elist[data-tid="' + tid + '"]');
+        if (!box) return;
+        if (box.style.display === 'none') { _fillElements(box, tid, opts); box.style.display = 'block'; }
+        else box.style.display = 'none';
+      };
+    });
+  }
+
+  function _fillElements(box, tid, opts) {
+    var d = db(); if (!d) return;
+    var r = d.exec("SELECT te.guid, m.ifc_class, COALESCE(m.element_name,'') FROM task_elements te " +
+      "JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id='" + tid + "' ORDER BY m.ifc_class LIMIT 200");
+    var rows = (r.length && r[0].values) ? r[0].values : [];
+    box.innerHTML = rows.map(function (row) {
+      var g = row[0], cls = row[1], nm = row[2] || cls;
+      return '<div class="sa-el">' +
+        '<span class="sa-elname" data-g="' + g + '" title="' + g + '">' + (nm || cls) + '</span>' +
+        '<select class="sa-move" data-g="' + g + '">' +
+          '<option value="">move&#8230;</option>' + opts +
+        '</select></div>';
+    }).join('') || '<div style="font-size:10px;color:#9bb">no elements</div>';
+    box.querySelectorAll('.sa-elname').forEach(function (el) {
+      el.onclick = function () { highlight(el.dataset.g); };
+    });
+    box.querySelectorAll('select.sa-move').forEach(function (sel) {
+      sel.onchange = function () { if (sel.value) reassign(sel.dataset.g, sel.value); };
+    });
+  }
+
+  function build() {
+    _injectStyle();
+    _panel = document.createElement('div');
+    _panel.id = 'schedule-author-panel';
+    _panel.innerHTML =
+      '<div style="display:flex;align-items:center;gap:6px">' +
+        '<b style="flex:1;color:#4fc3f7;font-size:13px">&#9998; Author 4D Schedule</b>' +
+        '<button id="sa-close" style="width:22px;height:22px;padding:0">&#x2715;</button>' +
+      '</div>' +
+      '<div id="sa-status" style="font-size:10px;color:#9bb;min-height:13px">Build the schedule up from the model.</div>' +
+      '<div style="display:flex;gap:5px">' +
+        '<button id="sa-draft" class="sa-primary" style="flex:1">Generate first draft</button>' +
+        '<button id="sa-apply" style="flex:1">Apply to 4D &#9654;</button>' +
+      '</div>' +
+      '<div id="sa-body" style="margin-top:4px"></div>';
+    document.body.appendChild(_panel);
+    document.getElementById('sa-close').onclick = close;
+    document.getElementById('sa-draft').onclick = generateDraft;
+    document.getElementById('sa-apply').onclick = applyTo4D;
+    _built = true;
+    render();
+  }
+
+  function open() {
+    if (!_built) build();
+    _panel.style.display = 'flex';
+    // If a schedule was already authored this session, re-read it.
+    if (!_state && db()) {
+      var r = db().exec("SELECT schedule_id FROM schedules WHERE schedule_id='SCH_AUTHORED'");
+      if (r.length && r[0].values.length) {
+        _state = { schedId: 'SCH_AUTHORED', start: '2026-01-01', order: [], name: {}, dur: {}, count: {} };
+        refreshState(); render();
+      }
+    }
+    console.log('§AUTHOR_UI_OPEN built=' + _built + ' hasSchedule=' + (!!_state));
+  }
+  function close() { if (_panel) _panel.style.display = 'none'; console.log('§AUTHOR_UI_CLOSE'); }
+  function toggle() { if (_panel && _panel.style.display === 'flex') close(); else open(); }
+
+  global.openScheduleAuthorWizard = open;
+  global.ScheduleAuthorUI = { open: open, close: close, toggle: toggle };
+
+  console.log('§SCHEDULE_AUTHOR_UI_LOADED v1');
+})(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v703';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v704';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -137,6 +137,8 @@ const PRECACHE_ASSETS = [
   'precision_cam.js',
   'schedule_gate.js',
   'time_machine.js',
+  'schedule_author.js',
+  'schedule_author_ui.js',
   'error_reporter.js',
   'print_sheet.js',
   'ghostglass.js',

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1830,7 +1830,7 @@
       'background:rgba(20,20,40,0.85);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);' +
       'border:1px solid rgba(79,195,247,0.3);border-radius:12px;' +
       'box-shadow:0 4px 24px rgba(0,0,0,0.5);color:#e0e0e0;font-family:sans-serif;' +
-      'width:340px;user-select:none;touch-action:none;';
+      'width:376px;user-select:none;touch-action:none;';
 
     _panel.innerHTML =
       '<div style="display:flex;align-items:center;width:100%;cursor:grab" class="tm-drag">' +
@@ -1838,6 +1838,8 @@
         '<button id="tm-sun" style="font-size:14px;padding:4px 8px;min-width:32px;min-height:32px" title="Day/night cycle"><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:linear-gradient(90deg,#fff 50%,#222 50%);vertical-align:middle"></span></button>' +
         '<button id="tm-eye" style="padding:2px 6px;min-width:36px;min-height:36px;background:#888" title="Drone Pilot — cinematic camera"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2"/><circle cx="12" cy="12" r="3"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M12 2v4"/><path d="M12 18v4"/></svg></button>' +
         '<button id="tm-gantt" style="font-size:12px;padding:2px 6px" title="Gantt chart">&#x1F4CA;</button>' +
+        '<button id="tm-author" style="font-size:12px;padding:2px 6px" title="Author 4D schedule — build phases up, assign elements, tune dates">&#9998;</button>' +
+        '<button id="tm-whatif" style="font-size:12px;padding:2px 6px" title="What-if: slip a phase, watch the chain re-fold in blue">&#9094;</button>' +
         '<button id="tm-dash" style="font-size:12px;padding:2px 6px" title="Dashboard">&#x1F4CB;</button>' +
         '<button id="tm-var" style="font-size:13px;padding:2px 6px;display:none" title="Budget vs Actual variance">&#x2696;</button>' +
         '<span id="tm-big-counter" style="flex:1;font-size:18px;font-weight:bold;color:#4fc3f7;text-align:center;letter-spacing:1px">DAY 0 | HR 0</span>' +
@@ -1926,6 +1928,21 @@
     });
 
     document.getElementById('tm-slider').addEventListener('input', onSlide);
+
+    // §AUTHOR-1: the 4D-schedule authoring wizard + what-if are TM-owned (launched from this surface).
+    var _author = document.getElementById('tm-author');
+    if (_author) _author.addEventListener('pointerup', function(e) {
+      e.stopPropagation();
+      if (window.ScheduleAuthorUI) window.ScheduleAuthorUI.toggle();
+      else if (typeof window.openScheduleAuthorWizard === 'function') window.openScheduleAuthorWizard();
+      else { var s = document.getElementById('tm-status'); if (s) s.textContent = 'Author engine not loaded'; }
+    });
+    var _whatif = document.getElementById('tm-whatif');
+    if (_whatif) _whatif.addEventListener('pointerup', function(e) {
+      e.stopPropagation();
+      if (window.WhatIfPanel) window.WhatIfPanel.open();
+      else { var s = document.getElementById('tm-status'); if (s) s.textContent = 'What-if engine not loaded'; }
+    });
 
     // Transport buttons
     document.getElementById('tm-start-btn').addEventListener('pointerup', function(e) {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -884,7 +884,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=56" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="schedule_author.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author_ui.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
## §AUTHOR-1 — build the 4D schedule UP, organized, from a real-but-bare model

The FUSED 4D/5D wedge's keystone: originate a schedule on a real model that has ZERO 4D metadata
(the "blank Hospital" main intent), organized as phases (WBS) with elements assigned — every write
landing in the IFC-native `schedules`/`tasks`/`task_elements` tables (the same substrate
injectGantt's `_cap` overlay reads). TM is the owner/hub; what-if moves off Find onto the TM.

### Slice-1 — the authoring engine (`05fcad9`)
`viewer/schedule_author.js` (pure, DOM-free, node-testable):
- `materializeDefault(db, rules)` — rule-groups elements (matchRule, replicating time_machine.js)
  into ORGANIZED phases: one summary ROOT + a dated leaf task per phase + one assignment per
  element. `task→guid` = the P2 identity-link (survives rename).
- `assignElement(db, guid, taskId)` — the CRAFT verb (reassign an element to a different phase).
- `_ensureWideTasks` — migrates legacy-thin building DBs to the widened DDL the read-path consumes
  (this is *why* shipped DBs read as blank-4D: `_cap`'s query errors on the thin schema).

**W-AUTHOR-4D-BLANK 16/16** (`erp/tests/author_4d_witness.js`) on real `SampleHouse_extracted.db`
(60 elements, `tasks=0`). The `_cap` consumer is extracted VERBATIM from `time_machine.js`; rules
verbatim from `rates.js`. Blank → materialize 3 phases (all 60 assigned, WBS root+leaves) → shipped
`_cap` maps every guid → reassign one element honored on re-fold, control unchanged, bound by guid.

### Slice-2 — the TM-owned front-visual wizard (`df89a21`, `d9d55d3`)
`viewer/schedule_author_ui.js` — launched from the **Time Machine clock-pill surface**: ① Generate
first draft ② rename phases + expand/assign elements (click = 3D highlight, dropdown = reassign)
③ tune dates (per-phase duration steppers + project start) ④ Apply to 4D (re-folds the TM gantt).
- TM panel gains `tm-author` (✎) + `tm-whatif` (⑂) buttons.
- **What-if RE-HOMED** off the Find box → Time Machine (§ARCH-OWNERSHIP: TM owns 4D/5D; Find is a
  satellite). `find-whatif-btn` + handler removed from `navigate_find.js`.
- `viewer.html` loads both scripts (`time_machine.js?v=57`); `sw.js` precache + `v703→v704`.

**W-AUTHOR-WIZARD-WIRE 14/14** (`erp/tests/author_wizard_wiring.js`): UI module exposes the launch
API the TM button calls; buttons wired; Find what-if removed; scripts registered; the engine calls
the handlers make fold a valid schedule + bind a reassign on the real model. Live browser smoke
deferred to deploy (no browser/jsdom in sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)