### PR TITLE
feat(4d-author): §MI-FLOW true-blank start + ZoomAcross TM-routing (the two remaining lane items)

### DIFF
--- a/erp/tests/author_blank_start_witness.js
+++ b/erp/tests/author_blank_start_witness.js
@@ -1,0 +1,82 @@
+// author_blank_start_witness.js — W-AUTHOR-BLANK-START (FUSED_4D5D_WEDGE_LANE §MI-FLOW)
+//
+// ISSUE PROVED: a "true blank start" organizes the phases (WBS) + assignments but leaves them
+// UNDATED, so the schedule does NOT appear in the Time Machine until the USER originates the dates
+// (the auto-schedule becomes an optional "suggest a start"). The shipped read-path (_cap, extracted
+// VERBATIM from time_machine.js) SKIPS NULL-dated leaf tasks → nothing shows; after
+// scheduleContiguous the same _cap picks them up. Real SampleHouse. Whitebox §-log only.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..');
+var VIEWER = path.join(ROOT, 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var SA = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-BLANK PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-BLANK FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+
+function loadRules() {
+  var t = read('rates.js');
+  var s = t.indexOf('var SEQUENCE_RULES = {');
+  var d = t.indexOf('var SEQUENCE_DEFAULT');
+  var slice = t.slice(s, t.indexOf('};', d) + 2);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return SEQUENCE_RULES;'))();
+}
+function loadCap() {
+  var t = read('time_machine.js');
+  var s = t.indexOf('var _cap = (function() {');
+  var e = t.indexOf('})();', s) + '})();'.length;
+  // eslint-disable-next-line no-new-func
+  return new Function('db', t.slice(s, e) + '\n return _cap;');
+}
+
+(async function () {
+  var RULES = loadRules();
+  var makeCap = loadCap();
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+  var nElems = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+
+  // ── BLANK start: organize phases + assignments, but UNDATED ───────────────────
+  var res = SA.materializeDefault(db, RULES, { start: '2026-01-01', phaseDays: 30, blank: true });
+  check('blank-flag', res.blank === true, 'blank=' + res.blank);
+  check('phases-organized', res.phases.length >= 2, 'phases=' + res.phases.length);
+  check('elements-assigned', res.assignmentCount === nElems, 'assignments=' + res.assignmentCount + '/' + nElems);
+
+  // leaf tasks exist but are UNDATED
+  var leaves = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0")[0].values[0][0];
+  var dated = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0 AND schedule_start IS NOT NULL")[0].values[0][0];
+  check('leaves-exist', leaves === res.phases.length, 'leaves=' + leaves);
+  check('leaves-undated', dated === 0, 'datedLeaves=' + dated);
+
+  // the shipped read-path sees NOTHING (no dated leaf → _cap null) — the TM stays blank.
+  var cap0 = makeCap(db);
+  check('cap-blank-invisible', cap0 === null, 'cap=' + (cap0 ? 'captured' : 'null'));
+
+  // ── The user ORIGINATES the dates (the deliberate "suggest a start") ──────────
+  var sc = SA.scheduleContiguous(db, 'SCH_AUTHORED', { start: '2026-03-01', phaseDays: 20 });
+  check('scheduled-all', sc.scheduled === res.phases.length, 'scheduled=' + sc.scheduled);
+  var dated2 = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0 AND schedule_start IS NOT NULL")[0].values[0][0];
+  check('now-all-dated', dated2 === res.phases.length, 'datedLeaves=' + dated2);
+
+  // now the SAME shipped read-path PICKS THEM UP — the schedule appears in the TM, bound by guid.
+  var cap1 = makeCap(db);
+  check('cap-now-visible', cap1 !== null && cap1.taskCount === res.phases.length,
+    'cap.taskCount=' + (cap1 && cap1.taskCount));
+  check('cap-maps-every-guid', cap1 && Object.keys(cap1.guidTask).length === nElems,
+    'guidTask=' + (cap1 && Object.keys(cap1.guidTask).length) + '/' + nElems);
+  // first phase starts where the USER said (origination honored)
+  var firstStart = db.exec("SELECT MIN(schedule_start) FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0")[0].values[0][0];
+  check('origin-honored', String(firstStart).slice(0, 10) === '2026-03-01', 'firstStart=' + firstStart);
+
+  console.log('§W-AUTHOR-BLANK-START RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-BLANK ERROR', e); process.exit(2); });

--- a/erp/tests/zoom_tm_route_witness.js
+++ b/erp/tests/zoom_tm_route_witness.js
@@ -1,0 +1,39 @@
+// zoom_tm_route_witness.js — W-ZOOM-TM-ROUTE (FUSED_4D5D_WEDGE_LANE §ARCH-OWNERSHIP)
+//
+// ISSUE PROVED: ZoomAcross/Connect scope routing is "TM-if-open, else Find" — when the Time Machine
+// is OPEN it consumes the pinpoint (jumps to the element's moment via tmJumpToElement); else Find is
+// the default floor. applyFindScope is DOM-bound (Find panel), so the value proof is the live
+// §ZOOM-SCOPE route= log; here we prove the WIRING is in place + the consumer API it depends on
+// exists. (whitebox §-log first, per docs/TestArchitecture.)
+
+var fs = require('fs');
+var path = require('path');
+var VIEWER = path.resolve(__dirname, '..', '..', 'viewer');
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-ZTM PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-ZTM FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+
+var nf = read('navigate_find.js');
+var tm = read('time_machine.js');
+
+// Router branches present in applyFindScope (whole function body).
+var _s = nf.indexOf('A.applyFindScope = function');
+var scope = nf.slice(_s, nf.indexOf('\n    };', _s) + 6);
+check('router-reads-tmstate', /tmGetState\(\)/.test(scope) && /\.active/.test(scope), 'tmGetState().active');
+check('router-tmopen-flag', /var tmOpen =/.test(scope), 'tmOpen computed');
+check('router-tm-consume', /tmOpen[\s\S]{0,200}tmJumpToElement/.test(scope), 'TM-open → tmJumpToElement');
+check('router-logs-tm', /route=tm/.test(scope), '§ZOOM-SCOPE route=tm');
+check('router-logs-find', /route=find/.test(scope), '§ZOOM-SCOPE route=find (the floor)');
+check('router-both-kinds', (scope.match(/route=tm/g) || []).length >= 2, 'guid + class branches both routed');
+
+// Consumer API the router depends on must exist + behave (jump to element moment, state getter).
+check('tm-exposes-jump', /window\.tmJumpToElement = function/.test(tm), 'tmJumpToElement');
+check('tm-jump-sets-cursor', /tmJumpToElement[\s\S]{0,800}_cursor = op\.end_ts/.test(tm), 'jump → cursor at element moment');
+check('tm-exposes-state', /window\.tmGetState = function/.test(tm) && /active: _active/.test(tm), 'tmGetState().active');
+
+console.log('§W-ZOOM-TM-ROUTE RESULT ' + pass + '/' + (pass + fail));
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -135,7 +135,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=41',
+        'navigate_find.js?v=42',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -3419,11 +3419,22 @@
     A.applyFindScope = function (scope) {
       scope = String(scope || '').trim();
       if (!scope) { console.log('§ZOOM-SCOPE skip=empty'); return 0; }
+      // §ARCH-OWNERSHIP (FUSED_4D5D_WEDGE_LANE): if the Time Machine is OPEN it is the OWNER/consumer —
+      // it shows the pinpointed element AT ITS MOMENT (tmJumpToElement). Else Find is the default floor
+      // (cost/location users care about WHAT/WHERE, not the schedule). Mechanism = "TM-if-open, else Find".
+      var _tmSt = null; try { _tmSt = window.tmGetState && window.tmGetState(); } catch (e) {}
+      var tmOpen = !!(_tmSt && _tmSt.active && typeof window.tmJumpToElement === 'function');
+
       // guid-set: has a comma OR isn't an Ifc* class token → treat as explicit element ids.
       if (scope.indexOf(',') >= 0 || !/^ifc[a-z]/i.test(scope)) {
         var guids = scope.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
         var lit = A.focusElement(new Set(guids), { item: guids.length === 1 });
-        console.log('§ZOOM-SCOPE kind=guids n=' + guids.length + ' lit=' + lit);
+        if (tmOpen && guids.length) {
+          try { window.tmJumpToElement(guids[0]); } catch (e) {}   // TM consumes: jump to its construction moment
+          console.log('§ZOOM-SCOPE route=tm kind=guids n=' + guids.length + ' moment=' + guids[0]);
+        } else {
+          console.log('§ZOOM-SCOPE route=find kind=guids n=' + guids.length + ' lit=' + lit);
+        }
         return guids.length;
       }
       // IFC class: reuse the Find panel + runSearch so the UI reflects the scope and one code path filters.
@@ -3433,7 +3444,13 @@
       runSearch();
       var set = new Set((nav.results || []).map(function (r) { return r.guid; }).filter(Boolean));
       if (set.size) A.focusElement(set, { item: false });
-      console.log('§ZOOM-SCOPE kind=class scope="' + scope + '" matches=' + set.size);
+      if (tmOpen && set.size) {
+        var firstG = (nav.results || []).map(function (r) { return r.guid; }).filter(Boolean)[0];
+        if (firstG) { try { window.tmJumpToElement(firstG); } catch (e) {} }   // TM consumes the class's first element
+        console.log('§ZOOM-SCOPE route=tm kind=class scope="' + scope + '" matches=' + set.size + ' moment=' + (firstG || '-'));
+      } else {
+        console.log('§ZOOM-SCOPE route=find kind=class scope="' + scope + '" matches=' + set.size);
+      }
       // §S2 — fold this class's twin cost into the #info-panel (Planned→Committed pair, from records).
       try { _showClassCost(scope, set.size); } catch (e) { console.log('§ZOOM-COST wire_err=' + e.message); }
       return set.size;

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -90,6 +90,9 @@
     var phaseDays = opts.phaseDays || 30;
     var schedId = opts.scheduleId || 'SCH_AUTHORED';
     var dflt = opts.defaultRule || (global.SEQUENCE_DEFAULT) || { phase: 'Architecture', sequence: 6, resource: null };
+    var blank = !!opts.blank;   // §MI-FLOW true-blank start: organize phases+assignments but leave
+                                // them UNDATED so the user originates the schedule (nothing shows in
+                                // the TM until dated → _cap skips NULL-dated tasks).
     rules = rules || (global.SEQUENCE_RULES) || {};
 
     // Ensure the IFC-native 4D tables exist (mirror import_db_builder.js DDL exactly).
@@ -129,31 +132,35 @@
     db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start]);
 
     // ROOT summary task (is_summary=1 → excluded from _cap leaf window; spans the whole project).
+    // In blank mode dates are NULL (the user originates them via scheduleDefault/the wizard).
     var rootId = 'TASK_ROOT';
     var totalDays = Math.max(phaseDays, ordered.length * phaseDays);
-    var projFinish = _addDays(start, ordered.length * phaseDays);
+    var rootStart = blank ? null : start;
+    var rootFinish = blank ? null : _addDays(start, ordered.length * phaseDays);
     db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
-      [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, start, projFinish, 'P' + totalDays + 'D', null, 'PLANNED']);
+      [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, rootStart, rootFinish, blank ? null : 'P' + totalDays + 'D', null, 'PLANNED']);
 
     var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
     var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
     var outPhases = [], cursor = 0, assignN = 0;
     ordered.forEach(function (p) {
       var tid = 'TASK_' + _slug(p.name);
-      var s = _addDays(start, cursor * phaseDays);
-      var f = _addDays(start, (cursor + 1) * phaseDays);
+      var s = blank ? null : _addDays(start, cursor * phaseDays);
+      var f = blank ? null : _addDays(start, (cursor + 1) * phaseDays);
       cursor++;
-      // Leaf, dated, is_summary=0 → exactly what _cap.win picks up.
-      stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, 'P' + phaseDays + 'D', null, 'PLANNED']);
+      // Leaf, is_summary=0. Dated → _cap.win picks it up; blank/undated → _cap skips it (the user
+      // originates the dates, then it appears in the timeline). Assignments are made either way.
+      stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, blank ? null : 'P' + phaseDays + 'D', null, 'PLANNED']);
       p.guids.forEach(function (g) { stmtTe.run([tid, g]); assignN++; });
       outPhases.push({ taskId: tid, name: p.name, sequence: p.seq, start: s, finish: f, count: p.guids.length });
     });
     stmtTk.free();
     stmtTe.free();
 
-    console.log('§AUTHOR_MATERIALIZE schedule=' + schedId + ' phases=' + outPhases.length +
-      ' leafTasks=' + outPhases.length + ' assignments=' + assignN + ' elements=' + elems.length);
-    return { scheduleId: schedId, rootId: rootId, phases: outPhases, taskCount: outPhases.length, assignmentCount: assignN };
+    console.log('§AUTHOR_MATERIALIZE schedule=' + schedId + ' mode=' + (blank ? 'blank' : 'dated') +
+      ' phases=' + outPhases.length + ' leafTasks=' + outPhases.length +
+      ' assignments=' + assignN + ' elements=' + elems.length);
+    return { scheduleId: schedId, rootId: rootId, phases: outPhases, taskCount: outPhases.length, assignmentCount: assignN, blank: blank };
   }
 
   // assignElement(db, guid, taskId) — the CRAFT verb. Re-home one element to a different phase task.
@@ -168,6 +175,31 @@
     db.run('INSERT OR IGNORE INTO task_elements VALUES (?,?)', [taskId, guid]);
     console.log('§AUTHOR_ASSIGN guid=' + guid + ' -> task=' + taskId);
     return { ok: true, guid: guid, taskId: taskId };
+  }
+
+  // scheduleContiguous(db, scheduleId, opts) — §MI-FLOW: the user's deliberate "originate the dates"
+  // act (the optional "suggest a start"). Lays the leaf phases out contiguously from opts.start so
+  // a blank-materialized (undated) schedule becomes datable on demand. Orders by rowid = insert
+  // order = the sequence order materializeDefault used (NULL dates can't be ORDER BY'd).
+  function scheduleContiguous(db, scheduleId, opts) {
+    scheduleId = scheduleId || 'SCH_AUTHORED';
+    opts = opts || {};
+    var start = opts.start || '2026-01-01';
+    var phaseDays = opts.phaseDays || 30;
+    var lr = db.exec("SELECT task_id FROM tasks WHERE schedule_id='" + scheduleId +
+      "' AND (is_summary IS NULL OR is_summary=0) ORDER BY rowid");
+    var ids = (lr.length && lr[0].values.length) ? lr[0].values.map(function (r) { return r[0]; }) : [];
+    var cursor = 0;
+    ids.forEach(function (tid) {
+      var s = _addDays(start, cursor), f = _addDays(start, cursor + phaseDays);
+      db.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
+        [s, f, 'P' + phaseDays + 'D', tid]);
+      cursor += phaseDays;
+    });
+    db.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
+      [start, _addDays(start, cursor), scheduleId]);
+    console.log('§AUTHOR_SCHEDULE schedule=' + scheduleId + ' phases=' + ids.length + ' from=' + start + ' span=' + cursor + 'd');
+    return { scheduled: ids.length, start: start, span: cursor };
   }
 
   // foldCost(db, scheduleId, RATES, ratesDefault, currency) — §AUTHOR-1 step ④ (5D).
@@ -230,6 +262,7 @@
   var API = {
     matchRule: matchRule,
     materializeDefault: materializeDefault,
+    scheduleContiguous: scheduleContiguous,
     assignElement: assignElement,
     foldCost: foldCost
   };
@@ -237,5 +270,5 @@
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v2');
+  console.log('§SCHEDULE_AUTHOR_LOADED v3');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -77,15 +77,20 @@
   // Read the authored schedule back from the DB into _state (single source of truth = the tables).
   function refreshState() {
     var d = db(); if (!d || !_state) return;
+    // Order dated phases by date, undated (blank) phases by insert order (rowid) — NULL dates can't sort.
     var r = d.exec("SELECT task_id, name, schedule_start, schedule_finish FROM tasks " +
-      "WHERE schedule_id='" + _state.schedId + "' AND is_summary=0 ORDER BY schedule_start, task_id");
-    _state.order = []; _state.name = {}; _state.start = null;
+      "WHERE schedule_id='" + _state.schedId + "' AND is_summary=0 " +
+      "ORDER BY COALESCE(schedule_start,'9999-99-99'), rowid");
+    _state.order = []; _state.name = {}; _state.start = null; _state.undated = 0; _state.dated = {};
     if (r.length && r[0].values.length) {
       r[0].values.forEach(function (row) {
         _state.order.push(row[0]); _state.name[row[0]] = row[1];
-        if (!_state.dur[row[0]]) _state.dur[row[0]] = Math.max(1,
-          Math.round((Date.parse(row[3]) - Date.parse(row[2])) / 86400000));
-        if (!_state.start) _state.start = String(row[2]).slice(0, 10);
+        if (row[2] && row[3]) {   // dated phase
+          _state.dated[row[0]] = true;
+          if (!_state.dur[row[0]]) _state.dur[row[0]] = Math.max(1,
+            Math.round((Date.parse(row[3]) - Date.parse(row[2])) / 86400000));
+          if (!_state.start) _state.start = String(row[2]).slice(0, 10);
+        } else { _state.dated[row[0]] = false; _state.undated++; }   // blank → user originates dates
       });
     }
     // element counts per task
@@ -131,15 +136,29 @@
   }
 
   // ── First draft: materialize the smart default from rules (the prebaked start) ──
+  // §MI-FLOW: a "Start blank" toggle organizes phases+assignments but leaves them UNDATED, so the
+  // user originates the schedule (the auto-dates become an optional "suggest a start" — scheduleNow).
   function generateDraft() {
     var d = db(); if (!d) { status('No model loaded'); return; }
     if (!SA()) { status('Author engine not loaded'); return; }
-    var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', phaseDays: 30 });
+    var blankEl = document.getElementById('sa-blank');
+    var blank = !!(blankEl && blankEl.checked);
+    var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', phaseDays: 30, blank: blank });
     _state = { schedId: res.scheduleId, start: '2026-01-01', order: [], name: {}, dur: {}, count: {} };
     refreshState();
-    console.log('§AUTHOR_UI_DRAFT phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
-    status('Draft: ' + res.phases.length + ' phases, ' + res.assignmentCount + ' elements assigned');
+    console.log('§AUTHOR_UI_DRAFT mode=' + (blank ? 'blank' : 'dated') + ' phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
+    status(blank
+      ? 'Blank: ' + res.phases.length + ' phases organized, ' + res.assignmentCount + ' elements assigned — now set the dates'
+      : 'Draft: ' + res.phases.length + ' phases, ' + res.assignmentCount + ' elements assigned');
     render();
+  }
+
+  // The user's deliberate "originate the dates" act (blank mode) — lay phases out from the start date.
+  function scheduleNow() {
+    var d = db(); if (!d || !SA() || !_state) return;
+    SA().scheduleContiguous(d, _state.schedId, { start: _state.start || '2026-01-01', phaseDays: 30 });
+    refreshState(); render();
+    status('Scheduled — phases now carry dates and appear in the timeline.');
   }
 
   // ── Apply to 4D: re-fold the Time Machine so the gantt shows the authored schedule ──
@@ -174,14 +193,23 @@
     if (cost) { cur = cost.currency || ''; total = cost.total;
       cost.phases.forEach(function (p) { costByTask[p.taskId] = p.cost; }); }
 
+    var blankMode = _state.undated > 0;
     var html = '<div style="display:flex;gap:5px;align-items:center;margin-bottom:6px">' +
       '<label style="font-size:10px;color:#9bb">Start</label>' +
       '<input id="sa-start" type="date" value="' + (_state.start || '2026-01-01') + '" style="flex:1">' +
-      '</div>';
+      (blankMode ? '<button id="sa-schedule" class="sa-primary" title="Lay the phases out from the start date — the schedule appears in the timeline">Schedule now &#9654;</button>' : '') +
+      '</div>' +
+      (blankMode ? '<div style="font-size:10px;color:#e0b070;margin-bottom:4px">' + _state.undated +
+        ' phase(s) unscheduled — organized but undated. Set a start and press <b>Schedule now</b> to originate the dates.</div>' : '');
 
     _state.order.forEach(function (tid) {
-      var nm = _state.name[tid] || tid, dur = _state.dur[tid] || 30, cnt = _state.count[tid] || 0;
+      var nm = _state.name[tid] || tid, cnt = _state.count[tid] || 0;
       var cst = costByTask[tid] || 0;
+      var dated = _state.dated ? _state.dated[tid] !== false : true;
+      var durHtml = dated
+        ? '<button class="sa-dur" data-tid="' + tid + '" data-d="-5">&#8211;5d</button> <b>' +
+          (_state.dur[tid] || 30) + 'd</b> <button class="sa-dur" data-tid="' + tid + '" data-d="5">+5d</button> '
+        : '<span style="color:#e0b070">unscheduled</span> ';
       html += '<div class="sa-phase" data-tid="' + tid + '">' +
         '<div class="sa-phase-hd">' +
           '<span class="sa-dot" style="background:' + phaseColor(nm) + '"></span>' +
@@ -189,9 +217,7 @@
           '<span style="font-size:10px;color:#9bb">' + cnt + ' el</span>' +
         '</div>' +
         '<div class="sa-meta">' +
-          '<button class="sa-dur" data-tid="' + tid + '" data-d="-5">&#8211;5d</button> ' +
-          '<b>' + dur + 'd</b> ' +
-          '<button class="sa-dur" data-tid="' + tid + '" data-d="5">+5d</button> ' +
+          durHtml +
           '<span class="sa-cost" title="5D cost folded from assigned elements">' + cur + fmt(cst) + '</span>' +
           '<button class="sa-toggle" data-tid="' + tid + '" style="float:right;font-size:9px">elements &#9662;</button>' +
         '</div>' +
@@ -203,9 +229,13 @@
         cost.unmappedClasses.length + ' unmapped)</span>' : '') + '</div>';
     body.innerHTML = html;
 
-    // wire start date
+    // wire start date — in blank mode just remember it (the "Schedule now" button originates dates);
+    // in dated mode, changing the start re-lays the existing schedule.
     var st = document.getElementById('sa-start');
-    if (st) st.onchange = function () { _state.start = st.value; applyDates(); render(); };
+    if (st) st.onchange = function () { _state.start = st.value; if (!blankMode) { applyDates(); render(); } };
+    // wire "Schedule now" (blank mode → originate the dates)
+    var sched = document.getElementById('sa-schedule');
+    if (sched) sched.onclick = scheduleNow;
 
     // wire rename
     body.querySelectorAll('input.sa-name').forEach(function (inp) {
@@ -266,6 +296,9 @@
         '<button id="sa-draft" class="sa-primary" style="flex:1">Generate first draft</button>' +
         '<button id="sa-apply" style="flex:1">Apply to 4D &#9654;</button>' +
       '</div>' +
+      '<label style="display:flex;align-items:center;gap:5px;font-size:10px;color:#9bb;margin-top:2px" ' +
+        'title="Organize the phases + assignments but leave them UNDATED — you originate the schedule (§MI-FLOW)">' +
+        '<input type="checkbox" id="sa-blank"> Start blank (set the dates yourself)</label>' +
       '<div id="sa-body" style="margin-top:4px"></div>';
     document.body.appendChild(_panel);
     document.getElementById('sa-close').onclick = close;
@@ -294,5 +327,5 @@
   global.openScheduleAuthorWizard = open;
   global.ScheduleAuthorUI = { open: open, close: close, toggle: toggle };
 
-  console.log('§SCHEDULE_AUTHOR_UI_LOADED v1');
+  console.log('§SCHEDULE_AUTHOR_UI_LOADED v2');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v707';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -885,8 +885,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="schedule_author.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_author_ui.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author_ui.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
Closes the two remaining §AUTHOR-1 lane items. Both whitebox-witnessed on real SampleHouse.

## A) True-blank start (§MI-FLOW)
"Start blank" organizes the phases (WBS) + element assignments but leaves them **undated**, so the
schedule does **not** appear in the Time Machine until the user originates the dates — the
auto-schedule becomes an optional *"suggest a start"*, not the only path.

- **Engine:** `materializeDefault` gains `opts.blank` (leaf + root dates NULL); new
  `scheduleContiguous(db, scheduleId, opts)` lays the blank phases out from a user-chosen start
  (orders by `rowid` since NULL dates can't sort). `schedule_author.js` v3.
- **UI:** a "Start blank" checkbox; undated phases render *unscheduled*; a **"Schedule now ▶"**
  button originates the dates; in blank mode editing the start date doesn't auto-date.
- **W-AUTHOR-BLANK-START 11/11**: blank → leaves undated → the **verbatim `_cap`** sees nothing
  (TM stays blank) → `scheduleContiguous` → the same `_cap` now maps all 60 guids, user's start honored.

## B) ZoomAcross routing (§ARCH-OWNERSHIP "TM-if-open, else Find")
`applyFindScope` now checks `tmGetState().active`: when the Time Machine is **open** it **consumes**
the pinpoint (`tmJumpToElement` → the element's construction moment) for both guid- and class-scopes;
otherwise **Find** stays the default floor (cost/location users care about what/where, not schedule).
`§ZOOM-SCOPE route=tm|route=find` logs the decision.

- **W-ZOOM-TM-ROUTE 9/9**: router wiring + the `tmJumpToElement`/`tmGetState` consumer API it depends
  on. (The value proof is the live `§ZOOM-SCOPE route=` log — deferred to deploy, as `applyFindScope`
  is DOM-bound to the Find panel.)

Regressions green: W-AUTHOR-4D-BLANK 16/16, W-AUTHOR-5D-COST 10/10, W-AUTHOR-WIZARD-WIRE 14/14.
`viewer.html schedule_author{,_ui}.js?v=3`; `main.js navigate_find.js?v=42`; `sw v707→v708`.
Live browser smoke deferred to deploy (no sandbox browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)