### PR TITLE
feat(4d-author): draggable Author + What-if panels; honest empty-state copy

### DIFF
--- a/erp/tests/panel_drag_wiring.js
+++ b/erp/tests/panel_drag_wiring.js
@@ -1,0 +1,25 @@
+// panel_drag_wiring.js — W-PANEL-DRAG (FUSED_4D5D_WEDGE_LANE — user ask 2026-06-23)
+// Both TM-owned panels (Author 4D, What-if) are repositionable by dragging their header. Live
+// drag proven by Playwright (exact-px move, screenshots); this guards the wiring stays in place.
+var fs = require('fs'), path = require('path');
+var V = path.resolve(__dirname, '..', '..', 'viewer');
+var pass = 0, fail = 0;
+function ck(n, c, d) { if (c) { pass++; console.log('§W-DRAG PASS  ' + n + (d ? '  ' + d : '')); } else { fail++; console.log('§W-DRAG FAIL  ' + n + (d ? '  ' + d : '')); } }
+var sa = fs.readFileSync(path.join(V, 'schedule_author_ui.js'), 'utf8');
+var wi = fs.readFileSync(path.join(V, 'whatif_panel.js'), 'utf8');
+
+// Author panel: header handle id + drag wired + repositions via left/top.
+ck('author-head-handle', /id="sa-head"[^>]*cursor:grab/.test(sa), 'sa-head grab handle');
+ck('author-drag-wired', /dragByHandle\(_panel, document\.getElementById\('sa-head'\)\)/.test(sa), 'dragByHandle(panel, sa-head)');
+ck('author-drag-impl', /function dragByHandle[\s\S]{0,900}panel\.style\.left/.test(sa), 'sets panel left/top');
+ck('author-drag-ignores-controls', /closest\([^)]*button,input,select,a/.test(sa), 'ignores buttons/inputs');
+// honest empty-state copy (the Hospital "no schedule" confusion fix).
+ck('author-copy-editable', /No <b>editable<\/b> schedule here yet/.test(sa), 'wording clarifies generative≠editable');
+
+// What-if panel: drag by its <h3> title bar, separate from the .wi-track slip drag.
+ck('whatif-drag-wired', /_dragByHandle\(panel, panel\.querySelector\('h3'\)\)/.test(wi), '_dragByHandle(panel, h3)');
+ck('whatif-drag-impl', /function _dragByHandle[\s\S]{0,900}panel\.style\.left/.test(wi), 'sets panel left/top');
+ck('whatif-drag-skips-tracks', /closest\([^)]*\.wi-track/.test(wi), 'header drag ignores phase tracks');
+
+console.log('§W-PANEL-DRAG RESULT ' + pass + '/' + (pass + fail));
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -176,9 +176,11 @@
   function render() {
     var body = document.getElementById('sa-body'); if (!body) return;
     if (!_state || !_state.order.length) {
-      body.innerHTML = '<div style="font-size:11px;color:#9bb;line-height:1.5">No schedule yet. ' +
-        'Click <b>Generate first draft</b> to fold the model into organized phases — then rename, ' +
-        'reassign elements, and tune dates. Each edit is written to the project.</div>';
+      body.innerHTML = '<div style="font-size:11px;color:#9bb;line-height:1.5">' +
+        'No <b>editable</b> schedule here yet. The Time Machine may already play a rule-generated ' +
+        'timeline for this model, but that is computed on the fly — not an editable, authored schedule. ' +
+        'Click <b>Generate first draft</b> to fold the model into organized, editable phases — then ' +
+        'rename, reassign elements, and tune dates. Each edit is written to the project.</div>';
       return;
     }
     var d = db();
@@ -287,7 +289,7 @@
     _panel = document.createElement('div');
     _panel.id = 'schedule-author-panel';
     _panel.innerHTML =
-      '<div style="display:flex;align-items:center;gap:6px">' +
+      '<div id="sa-head" style="display:flex;align-items:center;gap:6px;cursor:grab" title="Drag to move">' +
         '<b style="flex:1;color:#4fc3f7;font-size:13px">&#9998; Author 4D Schedule</b>' +
         '<button id="sa-close" style="width:22px;height:22px;padding:0">&#x2715;</button>' +
       '</div>' +
@@ -304,8 +306,33 @@
     document.getElementById('sa-close').onclick = close;
     document.getElementById('sa-draft').onclick = generateDraft;
     document.getElementById('sa-apply').onclick = applyTo4D;
+    dragByHandle(_panel, document.getElementById('sa-head'));   // panel is repositionable (drag the header)
     _built = true;
     render();
+  }
+
+  // Reposition the whole panel by dragging its header (pointer events; ignores buttons/inputs).
+  function dragByHandle(panel, handle) {
+    if (!panel || !handle) return;
+    handle.style.cursor = 'grab';
+    var ox, oy, sx, sy, dragging = false;
+    handle.addEventListener('pointerdown', function (e) {
+      if (e.target.closest && e.target.closest('button,input,select,a')) return;
+      var r = panel.getBoundingClientRect();
+      dragging = true; ox = e.clientX; oy = e.clientY; sx = r.left; sy = r.top;
+      handle.style.cursor = 'grabbing';
+      try { handle.setPointerCapture(e.pointerId); } catch (x) {}
+      e.preventDefault();
+    });
+    handle.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      panel.style.left = (sx + e.clientX - ox) + 'px';
+      panel.style.top = (sy + e.clientY - oy) + 'px';
+      panel.style.right = 'auto'; panel.style.bottom = 'auto'; panel.style.transform = 'none';
+    });
+    function end() { dragging = false; handle.style.cursor = 'grab'; }
+    handle.addEventListener('pointerup', end);
+    handle.addEventListener('pointercancel', end);
   }
 
   function open() {
@@ -327,5 +354,5 @@
   global.openScheduleAuthorWizard = open;
   global.ScheduleAuthorUI = { open: open, close: close, toggle: toggle };
 
-  console.log('§SCHEDULE_AUTHOR_UI_LOADED v2');
+  console.log('§SCHEDULE_AUTHOR_UI_LOADED v3');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v708';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -827,7 +827,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="vo_fold.js?v=2"></script>
 <script src="proj_control.js?v=1"></script>
 <script src="whatif.js?v=2"></script>
-<script src="whatif_panel.js?v=2"></script>
+<script src="whatif_panel.js?v=3"></script>
 <script src="vo_approve.js?v=1"></script>
 <script src="proj_period.js?v=1"></script>
 <script src="proj_claim.js?v=1"></script>
@@ -886,7 +886,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="schedule_author.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_author_ui.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author_ui.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context

--- a/viewer/whatif_panel.js
+++ b/viewer/whatif_panel.js
@@ -197,6 +197,30 @@
     _render();
   }
 
+  // Reposition the whole panel by dragging its title bar (separate from the phase-track drag-to-slip).
+  function _dragByHandle(panel, handle) {
+    if (!panel || !handle) return;
+    handle.style.cursor = 'grab';
+    var ox, oy, sx, sy, dragging = false;
+    handle.addEventListener('pointerdown', function (e) {
+      if (e.target.closest && e.target.closest('button,input,select,a,.wi-track')) return;
+      var r = panel.getBoundingClientRect();
+      dragging = true; ox = e.clientX; oy = e.clientY; sx = r.left; sy = r.top;
+      handle.style.cursor = 'grabbing';
+      try { handle.setPointerCapture(e.pointerId); } catch (x) {}
+      e.preventDefault(); e.stopPropagation();
+    });
+    handle.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      panel.style.left = (sx + e.clientX - ox) + 'px';
+      panel.style.top = (sy + e.clientY - oy) + 'px';
+      panel.style.right = 'auto'; panel.style.bottom = 'auto'; panel.style.transform = 'none';
+    });
+    function end() { dragging = false; handle.style.cursor = 'grab'; }
+    handle.addEventListener('pointerup', end);
+    handle.addEventListener('pointercancel', end);
+  }
+
   // P1.b — DIRECT-MANIPULATION drag-to-slip (front-visual dominant). Dragging a phase track maps the
   // horizontal Δpx → whole days via WhatIf.pxToDays, writing the SAME _slips[seqno].startDelta the
   // steppers use, so the blue ripple re-folds live. Listeners live on `document` so they survive the
@@ -262,6 +286,7 @@
       panel.querySelector('#wi-accept').addEventListener('click', _accept);
       panel.querySelector('#wi-discard').addEventListener('click', _discard);
       panel.addEventListener('pointerdown', _onTrackDown);   // P1.b drag-to-slip (delegated, stable)
+      _dragByHandle(panel, panel.querySelector('h3'));       // reposition the whole panel by its title bar
       console.log('§WHATIF-UI open project=' + _pid + ' "' + _name + '" phases=' + _phases.length);
       _render();
     });


### PR DESCRIPTION
Addresses two pieces of user feedback (2026-06-23) on the 4D/5D panels.

## Draggable panels
The Author 4D Schedule and What-if panels are now **repositionable** by dragging their header
(pointer-events; ignores buttons/inputs). The What-if panel drags by its `<h3>` title bar — kept
separate from the existing `.wi-track` drag-to-slip. (The Time Machine panel was already draggable.)

**Live-proven by Playwright** on real SampleHouse: the Author panel moved exactly **(−260, +120)**,
What-if **(−200, −150)**, zero page errors. `W-PANEL-DRAG 8/8` guards the wiring.

## "No schedule yet" → honest copy
On a building that already shows a playing timeline (e.g. **Hospital**), the wizard previously said
"No schedule yet", which reads wrong. **Why it happens:** the Time Machine's timeline is *generative*
— `injectGantt` computes it on the fly from trade rules (and the what-if reads the baked ERP project
phases). Neither is an *editable, authored* schedule in the IFC `tasks` table (`SCH_AUTHORED`), which
is the only thing this wizard edits. Reworded the empty state to say exactly that: the model may
already play a rule-generated timeline, but it isn't editable — **Generate first draft** folds it into
editable phases.

`viewer.html schedule_author_ui.js?v=4` + `whatif_panel.js?v=3`; `sw v708→v709`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)