### PR TITLE
feat(4d-author): respect IFC schedules crafted in Bonsai/Revit (adopt, don't clobber)

### DIFF
--- a/erp/tests/author_captured_witness.js
+++ b/erp/tests/author_captured_witness.js
@@ -1,0 +1,71 @@
+// author_captured_witness.js — W-AUTHOR-CAPTURED (FUSED_4D5D_WEDGE_LANE — user 2026-06-23)
+//
+// ISSUE PROVED: a model dropped from Bonsai/Revit can arrive WITH a native IFC schedule
+// (import_worker captures IfcWorkSchedule/IfcTask into schedules/tasks/task_elements, keyed by IFC
+// GlobalId — NOT 'SCH_AUTHORED'). The wizard must (a) DETECT and edit that imported schedule, and
+// (b) NOT rule-generate a competing one — because _cap reads ALL schedule_ids, so two schedules =
+// a doubled timeline. This witness builds a SYNTHETIC captured schedule (test scaffolding that
+// mirrors import_worker's output — NOT claimed as real building data) on a real SampleHouse and
+// proves activeSchedule + the double-read hazard, through the VERBATIM _cap.
+
+var fs = require('fs'), path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..'), VIEWER = path.join(ROOT, 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var SA = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function ck(n, c, d) { if (c) { pass++; console.log('§W-CAPT PASS  ' + n + (d ? '  ' + d : '')); } else { fail++; console.log('§W-CAPT FAIL  ' + n + (d ? '  ' + d : '')); } }
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+function loadRules() { var t = read('rates.js'), s = t.indexOf('var SEQUENCE_RULES = {'), d = t.indexOf('var SEQUENCE_DEFAULT'); return (new Function(t.slice(s, t.indexOf('};', d) + 2) + '\n return SEQUENCE_RULES;'))(); }
+function loadCap() { var t = read('time_machine.js'), s = t.indexOf('var _cap = (function() {'), e = t.indexOf('})();', s) + 5; return new Function('db', t.slice(s, e) + '\n return _cap;'); }
+
+var WIDE = 'CREATE TABLE tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)';
+
+(async function () {
+  var RULES = loadRules(), makeCap = loadCap();
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+
+  // ── Simulate import_worker landing a Bonsai/Revit IfcWorkSchedule (GlobalId-keyed) ──
+  db.run('DROP TABLE IF EXISTS tasks'); db.run(WIDE);
+  db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+  db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+  var CAP = '0BonsaiWorkSched0GUID00';   // an IFC-GlobalId-shaped schedule_id (NOT SCH_AUTHORED)
+  db.run("INSERT INTO schedules VALUES (?,?,?,?)", [CAP, 'Bonsai Programme', 'PLANNED', '2027-01-01']);
+  db.run("INSERT INTO tasks (task_id,schedule_id,name,is_summary,schedule_start,schedule_finish) VALUES ('T_FRAME',?, 'Framing',0,'2027-01-04','2027-02-01')", [CAP]);
+  db.run("INSERT INTO tasks (task_id,schedule_id,name,is_summary,schedule_start,schedule_finish) VALUES ('T_FIT',?,  'Fit-out',0,'2027-02-01','2027-03-15')", [CAP]);
+  var g = db.exec('SELECT guid FROM elements_meta LIMIT 2')[0].values;
+  db.run("INSERT INTO task_elements VALUES ('T_FRAME',?)", [g[0][0]]);
+  db.run("INSERT INTO task_elements VALUES ('T_FIT',?)", [g[1][0]]);
+
+  // ── 1. activeSchedule detects the IMPORTED schedule (captured, not authored) ──
+  var act = SA.activeSchedule(db);
+  ck('detects-captured', !!act && act.id === CAP, 'active=' + (act && act.id));
+  ck('flagged-captured', !!act && act.captured === true && act.authored === false, 'captured=' + (act && act.captured));
+  ck('captured-name', !!act && act.name === 'Bonsai Programme', 'name=' + (act && act.name));
+  ck('captured-taskcount', !!act && act.taskCount === 2, 'tasks=' + (act && act.taskCount));
+
+  // ── 2. the shipped _cap plays the imported schedule (so the TM shows the real Bonsai dates) ──
+  var cap = makeCap(db);
+  ck('cap-plays-imported', !!cap && cap.taskCount === 2, 'cap.taskCount=' + (cap && cap.taskCount));
+  ck('cap-binds-imported', !!cap && cap.guidTask[g[0][0]] === 'T_FRAME', 'guid→' + (cap && cap.guidTask[g[0][0]]));
+
+  // ── 3. WHY the guard matters: if we ALSO rule-generate SCH_AUTHORED, _cap double-reads ──
+  SA.materializeDefault(db, RULES, { start: '2026-01-01', phaseDays: 30 });   // the naive (wrong) move
+  var capBoth = makeCap(db);
+  ck('double-read-hazard', !!capBoth && capBoth.taskCount === 2 + 3, 'cap.taskCount=' + (capBoth && capBoth.taskCount) + ' (2 imported + 3 generated = doubled)');
+  // and activeSchedule now PREFERS the user's authored draft (so re-open edits SCH_AUTHORED)
+  var act2 = SA.activeSchedule(db);
+  ck('authored-wins-when-present', !!act2 && act2.id === 'SCH_AUTHORED' && act2.authored, 'active=' + (act2 && act2.id));
+
+  // ── 4. wiring: the UI adopts/guards (the safeguard that prevents step 3 in the app) ──
+  var ui = read('schedule_author_ui.js');
+  ck('ui-open-adopts', /function open\(\)[\s\S]{0,900}activeSchedule\(db\(\)\)/.test(ui), 'open() → activeSchedule');
+  ck('ui-generate-guards', /if \(act && act\.captured\)[\s\S]{0,400}return;/.test(ui), 'generateDraft bails on captured');
+  ck('ui-hides-generate', /function syncControls\(\)[\s\S]{0,300}draft\.style\.display = cap/.test(ui), 'hides Generate when captured');
+
+  console.log('§W-AUTHOR-CAPTURED RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-CAPT ERROR', e); process.exit(2); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -177,6 +177,39 @@
     return { ok: true, guid: guid, taskId: taskId };
   }
 
+  // activeSchedule(db) — detect the schedule the wizard should EDIT. A model dropped from Bonsai/Revit
+  // arrives WITH a native IFC schedule (import_worker captures IfcWorkSchedule/IfcTask into these same
+  // tables, keyed by IFC GlobalId — NOT 'SCH_AUTHORED'). So the wizard must recognize an imported
+  // (captured) schedule and edit IT, never rule-generate a competing one (_cap reads ALL schedule_ids
+  // → two schedules = a doubled timeline). Priority: the user's own SCH_AUTHORED draft, else the
+  // imported schedule. Returns {id, name, taskCount, authored, captured} or null when no dated schedule.
+  function activeSchedule(db) {
+    var r;
+    try {
+      r = db.exec("SELECT schedule_id, COUNT(*) AS n FROM tasks " +
+        "WHERE schedule_start IS NOT NULL AND (is_summary IS NULL OR is_summary=0) AND schedule_id IS NOT NULL " +
+        "GROUP BY schedule_id");
+    } catch (e) { return null; }
+    if (!r.length || !r[0].values.length) return null;
+    var list = r[0].values.map(function (row) {
+      return { id: row[0], taskCount: row[1], authored: row[0] === 'SCH_AUTHORED' };
+    });
+    try {
+      var nr = db.exec("SELECT schedule_id, name FROM schedules");
+      if (nr.length && nr[0].values.length) {
+        var nm = {}; nr[0].values.forEach(function (x) { nm[x[0]] = x[1]; });
+        list.forEach(function (s) { s.name = nm[s.id] || s.id; });
+      }
+    } catch (e) {}
+    list.forEach(function (s) { if (!s.name) s.name = s.id; });
+    var authored = list.filter(function (s) { return s.authored; })[0];
+    var pick = authored || list[0];
+    pick.captured = !pick.authored;
+    console.log('§AUTHOR_DETECT schedules=' + list.length + ' active=' + pick.id +
+      ' captured=' + pick.captured + ' tasks=' + pick.taskCount);
+    return pick;
+  }
+
   // scheduleContiguous(db, scheduleId, opts) — §MI-FLOW: the user's deliberate "originate the dates"
   // act (the optional "suggest a start"). Lays the leaf phases out contiguously from opts.start so
   // a blank-materialized (undated) schedule becomes datable on demand. Orders by rowid = insert
@@ -263,6 +296,7 @@
     matchRule: matchRule,
     materializeDefault: materializeDefault,
     scheduleContiguous: scheduleContiguous,
+    activeSchedule: activeSchedule,
     assignElement: assignElement,
     foldCost: foldCost
   };
@@ -270,5 +304,5 @@
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v3');
+  console.log('§SCHEDULE_AUTHOR_LOADED v4');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -141,6 +141,16 @@
   function generateDraft() {
     var d = db(); if (!d) { status('No model loaded'); return; }
     if (!SA()) { status('Author engine not loaded'); return; }
+    // Never rule-generate a competing schedule when the model already carries an IMPORTED one
+    // (Bonsai/Revit). Adopt it for editing instead — _cap reads all schedule_ids, so two would double.
+    var act = SA().activeSchedule ? SA().activeSchedule(d) : null;
+    if (act && act.captured) {
+      _state = { schedId: act.id, start: '2026-01-01', order: [], name: {}, dur: {}, count: {}, captured: true };
+      refreshState(); syncControls(); render();
+      status('This model already has an imported schedule (' + act.name + ') — editing it in place, not regenerating.');
+      console.log('§AUTHOR_UI_ADOPT-CAPTURED id=' + act.id + ' tasks=' + act.taskCount);
+      return;
+    }
     var blankEl = document.getElementById('sa-blank');
     var blank = !!(blankEl && blankEl.checked);
     var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', phaseDays: 30, blank: blank });
@@ -338,15 +348,33 @@
   function open() {
     if (!_built) build();
     _panel.style.display = 'flex';
-    // If a schedule was already authored this session, re-read it.
-    if (!_state && db()) {
-      var r = db().exec("SELECT schedule_id FROM schedules WHERE schedule_id='SCH_AUTHORED'");
-      if (r.length && r[0].values.length) {
-        _state = { schedId: 'SCH_AUTHORED', start: '2026-01-01', order: [], name: {}, dur: {}, count: {} };
-        refreshState(); render();
+    // Adopt whatever schedule the model already has — the user's own SCH_AUTHORED draft, OR a
+    // schedule IMPORTED with the model (Bonsai/Revit IfcWorkSchedule, captured by import_worker into
+    // the same tables). We edit it in place; we never rule-generate a competing one.
+    if (!_state && db() && SA() && SA().activeSchedule) {
+      var act = SA().activeSchedule(db());
+      if (act) {
+        _state = { schedId: act.id, start: '2026-01-01', order: [], name: {}, dur: {}, count: {}, captured: act.captured };
+        refreshState();
+        status(act.captured
+          ? 'Editing the schedule imported with this model (' + act.name + ') — ' + act.taskCount +
+            ' tasks. Rename, reassign, re-date; edits stay in this schedule.'
+          : 'Editing your authored schedule — ' + act.taskCount + ' tasks.');
+        render();
       }
     }
-    console.log('§AUTHOR_UI_OPEN built=' + _built + ' hasSchedule=' + (!!_state));
+    syncControls();
+    console.log('§AUTHOR_UI_OPEN built=' + _built + ' hasSchedule=' + (!!_state) +
+      ' captured=' + !!(_state && _state.captured));
+  }
+
+  // When editing an IMPORTED (captured) schedule, hide the rule-generate controls — you craft the
+  // real schedule in place, you do not regenerate over it (that would clobber the crafted dates/WBS).
+  function syncControls() {
+    var draft = document.getElementById('sa-draft'), blank = document.getElementById('sa-blank');
+    var cap = !!(_state && _state.captured);
+    if (draft) draft.style.display = cap ? 'none' : '';
+    if (blank && blank.parentElement) blank.parentElement.style.display = cap ? 'none' : '';
   }
   function close() { if (_panel) _panel.style.display = 'none'; console.log('§AUTHOR_UI_CLOSE'); }
   function toggle() { if (_panel && _panel.style.display === 'flex') close(); else open(); }
@@ -354,5 +382,5 @@
   global.openScheduleAuthorWizard = open;
   global.ScheduleAuthorUI = { open: open, close: close, toggle: toggle };
 
-  console.log('§SCHEDULE_AUTHOR_UI_LOADED v3');
+  console.log('§SCHEDULE_AUTHOR_UI_LOADED v4');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v709';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v710';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -885,8 +885,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="schedule_author.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_author_ui.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context


### PR DESCRIPTION
**User point (2026-06-23):** some dropped IFC carry a 4D schedule authored in **Bonsai or Revit**.

The drop/import pipeline already captures it — `import_worker` extracts `IfcWorkSchedule` / `IfcTask`
(WBS via `IfcRelNests`, `ScheduleStart/Finish` **verbatim**) / `IfcRelSequence` / `IfcRelAssignsToProcess`
into the same `schedules`/`tasks`/`task_elements` tables, keyed by the IFC `GlobalId` (logs `§4D_FOUND`).

But the wizard only knew `SCH_AUTHORED`, so it:
1. reported **"no schedule"** on a model that *has* a real imported one, and
2. on **Generate** would create a **competing** `SCH_AUTHORED` next to it — and since `_cap` reads
   **all** `schedule_id`s, that **doubles the timeline**.

## Fix — captured-aware (no read-path change)
- **`ScheduleAuthor.activeSchedule(db)`** detects the schedule to edit: the user's `SCH_AUTHORED`
  draft if present, else the **imported (captured)** schedule. Returns `{id,name,taskCount,captured}`.
- The wizard **adopts** the active schedule on open and edits it **in place** — a dropped Bonsai/Revit
  schedule now shows up editable, not "no schedule".
- **`generateDraft` bails** when a captured schedule exists (adopts it instead of rule-generating a
  competing one); the Generate / Start-blank controls are hidden while editing an imported schedule.

## Proof
**W-AUTHOR-CAPTURED 11/11** — synthetic captured `IfcWorkSchedule` on real SampleHouse: `activeSchedule`
flags it captured; the **verbatim `_cap`** plays the imported dates; demonstrates the double-read hazard
(2 imported + 3 generated = 5) the guard prevents; authored wins when both exist; UI wiring.
**Live-confirmed** (headless Chromium): wizard adopts *"Bonsai Programme"*, Generate hidden, 0 errors.
Regressions green (16/16 · 10/10 · 11/11 · 14/14). `schedule_author.js?v=4` + `schedule_author_ui.js?v=5`; `sw v709→v710`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)