### PR TITLE
feat(sched-editor): §SE-1 step 1+2 — WBS outline + view/edit dependencies (new-tab Gantt)

### DIFF
--- a/erp/tests/schedule_editor_witness.js
+++ b/erp/tests/schedule_editor_witness.js
@@ -1,0 +1,122 @@
+// schedule_editor_witness.js — W-SCHED-EDIT (FUSED_4D5D_WEDGE_LANE §SE-1)
+//
+// ISSUE PROVED: step 1+2 of the MSP-grade Gantt arc works on the engine — a user can SEE the schedule
+// as a WBS outline (wbsTree) and AUTHOR its dependencies (add / list / retype / lag / remove on the
+// IFC-native task_sequences table), with an invalid CYCLE refused deterministically (data integrity,
+// NOT optimisation — §SE-B boundary). Source of truth = task_sequences, written directly exactly as
+// assignElement writes task_elements (kernel_ops signing deferred).
+//
+// Non-invent: real SampleHouse_extracted.db (genuinely blank 4D) materialised to an organized default;
+// the phase rules are EXTRACTED VERBATIM from viewer/rates.js. Whitebox §-log proof only (CLAUDE.md:
+// prove the engine, don't boot a browser).
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..');           // worktree root
+var VIEWER = path.join(ROOT, 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-SCHED-EDIT PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-SCHED-EDIT FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+// Extract SEQUENCE_RULES + SEQUENCE_DEFAULT verbatim from rates.js (same loader as author_4d_witness).
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var SEQUENCE_RULES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+
+// Flatten the wbsTree into a list with depth, to assert outline shape.
+function flatten(roots, depth, out) {
+  out = out || []; depth = depth || 0;
+  roots.forEach(function (n) { out.push({ node: n, depth: depth }); flatten(n.children, depth + 1, out); });
+  return out;
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var rulesPack = loadRules();
+  var RULES = rulesPack.SEQUENCE_RULES, DEFAULT = rulesPack.SEQUENCE_DEFAULT;
+  console.log('§W-SCHED-EDIT RULES-LOADED keys=' + Object.keys(RULES).length + ' default=' + DEFAULT.phase);
+
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+  var SCHED = 'SCH_AUTHORED';
+
+  // ── precondition: blank 4D, then materialise the organized default ───────────
+  var nTasks0 = db.exec('SELECT COUNT(*) FROM tasks')[0].values[0][0];
+  check('blank-precondition', nTasks0 === 0, 'tasks=' + nTasks0);
+  var res = ScheduleAuthor.materializeDefault(db, RULES, { start: '2026-01-01', phaseDays: 30 });
+  check('phases-materialised', res.phases.length >= 3, 'phases=' + res.phases.length);
+
+  // ── STEP 1: WBS outline (wbsTree) ────────────────────────────────────────────
+  var roots = ScheduleAuthor.wbsTree(db, SCHED);
+  check('wbs-one-root', roots.length === 1, 'roots=' + roots.length);
+  var rootNode = roots[0];
+  check('wbs-root-is-summary', !!(rootNode && rootNode.isSummary), 'rootSummary=' + (rootNode && rootNode.isSummary));
+  var flat = flatten(roots);
+  var leaves = flat.filter(function (f) { return !f.node.isSummary; });
+  check('wbs-leaves-eq-phases', leaves.length === res.phases.length,
+    'leaves=' + leaves.length + ' phases=' + res.phases.length);
+  check('wbs-leaves-nest-depth1', leaves.every(function (f) { return f.depth === 1; }),
+    'leaf depths=[' + leaves.map(function (f) { return f.depth; }).join(',') + ']');
+  var withCounts = leaves.filter(function (f) { return f.node.guidCount > 0; }).length;
+  check('wbs-leaves-carry-element-counts', withCounts === leaves.length,
+    'leavesWithElems=' + withCounts + '/' + leaves.length);
+
+  // The ordered leaf task ids — author an FS chain across them (the user's dependency authoring).
+  var leafIds = leaves.map(function (f) { return f.node.id; });
+
+  // ── STEP 2a: add an FS chain phase1→phase2→...→phaseN ────────────────────────
+  var added = 0;
+  for (var i = 0; i < leafIds.length - 1; i++) {
+    var r = ScheduleAuthor.addDependency(db, leafIds[i], leafIds[i + 1], 'FS', 0);
+    if (r.ok) added++;
+  }
+  check('dep-chain-added', added === leafIds.length - 1, 'added=' + added + ' expected=' + (leafIds.length - 1));
+
+  var deps = ScheduleAuthor.listDependencies(db, SCHED);
+  check('dep-list-count', deps.length === added, 'listed=' + deps.length);
+  check('dep-list-has-names', deps.every(function (d) { return d.predName && d.succName && d.predName !== d.predId; }),
+    'sample="' + (deps[0] && (deps[0].predName + ' -> ' + deps[0].succName)) + '"');
+  check('dep-list-default-FS', deps.every(function (d) { return d.type === 'FS'; }), 'types ok');
+
+  // ── STEP 2b: CYCLE GUARD — a back-edge last→first must be REFUSED ─────────────
+  var back = ScheduleAuthor.addDependency(db, leafIds[leafIds.length - 1], leafIds[0], 'FS', 0);
+  check('cycle-refused', back.ok === false && back.reason === 'cycle',
+    'back-edge ok=' + back.ok + ' reason=' + back.reason);
+  var depsAfterCycle = ScheduleAuthor.listDependencies(db, SCHED).length;
+  check('cycle-not-persisted', depsAfterCycle === added, 'count still=' + depsAfterCycle);
+  // self-loop + duplicate also refused
+  check('self-loop-refused', ScheduleAuthor.addDependency(db, leafIds[0], leafIds[0]).reason === 'self_loop');
+  check('duplicate-refused', ScheduleAuthor.addDependency(db, leafIds[0], leafIds[1]).reason === 'duplicate');
+
+  // ── STEP 2c: retype FS→SS + set lag on the first edge ────────────────────────
+  var upd = ScheduleAuthor.updateDependency(db, leafIds[0], leafIds[1], { type: 'SS', lag: 5 });
+  check('dep-retype-lag', upd.ok && upd.type === 'SS' && upd.lag === 5, 'type=' + upd.type + ' lag=' + upd.lag);
+  var edge0 = ScheduleAuthor.listDependencies(db, SCHED).filter(function (d) {
+    return d.predId === leafIds[0] && d.succId === leafIds[1];
+  })[0];
+  check('dep-retype-persisted', edge0 && edge0.type === 'SS' && edge0.lag === 5,
+    'persisted type=' + (edge0 && edge0.type) + ' lag=' + (edge0 && edge0.lag));
+
+  // ── STEP 2d: remove one edge → count falls ───────────────────────────────────
+  var rem = ScheduleAuthor.removeDependency(db, leafIds[0], leafIds[1]);
+  check('dep-removed', rem.ok && rem.removed === 1, 'removed=' + rem.removed);
+  check('dep-count-fell', ScheduleAuthor.listDependencies(db, SCHED).length === added - 1,
+    'count=' + ScheduleAuthor.listDependencies(db, SCHED).length);
+
+  console.log('§W-SCHED-EDIT RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-SCHED-EDIT ERROR', e); process.exit(2); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -292,17 +292,158 @@
     return { currency: currency || '', total: total, phases: phases, unmappedClasses: unmappedClasses };
   }
 
+  // ── §SE-1 — WBS outline + dependency CRUD (the MSP-grade Gantt arc, step 1+2) ──────────────
+  // Pure, DOM-free reads/writes over the IFC-native tables. The schedule editor's NEW-TAB surface
+  // (schedule_editor_ui.js) renders these; the engine stays node-testable (W-SCHED-EDIT). Writes go
+  // STRAIGHT to task_sequences — the IFC-native dependency truth — exactly as assignElement writes
+  // task_elements (kernel_ops signing still deferred; §SE-D signed broadcast is a later slice).
+
+  var SEQ_TYPES = ['FS', 'SS', 'FF', 'SF'];   // IfcSequenceEnum: FINISH_START/START_START/FINISH_FINISH/START_FINISH
+
+  // wbsTree(db, scheduleId) — fold tasks.wbs_parent/is_summary into a nested tree. Roots = rows whose
+  // wbs_parent is null OR points outside this schedule's id set. Returns [{id,name,isSummary,start,
+  // finish,guidCount,children[]}] depth-first. Pure read; the collapsible outline renders this.
+  function wbsTree(db, scheduleId) {
+    var r;
+    try {
+      r = db.exec('SELECT task_id, wbs_parent, name, is_summary, schedule_start, schedule_finish ' +
+        'FROM tasks WHERE schedule_id=? ', [scheduleId]);
+    } catch (e) { return []; }
+    if (!r.length || !r[0].values.length) return [];
+    var nodes = {}, ids = {};
+    r[0].values.forEach(function (row) {
+      ids[row[0]] = true;
+      nodes[row[0]] = { id: row[0], parent: row[1], name: row[2] || row[0],
+        isSummary: !!row[3], start: row[4] || null, finish: row[5] || null,
+        guidCount: 0, children: [] };
+    });
+    // Element counts per task (the "N elements" badge on a leaf).
+    try {
+      var cr = db.exec('SELECT te.task_id, COUNT(*) FROM task_elements te ' +
+        'JOIN tasks t ON t.task_id=te.task_id WHERE t.schedule_id=? GROUP BY te.task_id', [scheduleId]);
+      if (cr.length && cr[0].values.length) cr[0].values.forEach(function (row) {
+        if (nodes[row[0]]) nodes[row[0]].guidCount = row[1];
+      });
+    } catch (e) {}
+    var roots = [];
+    Object.keys(nodes).forEach(function (id) {
+      var n = nodes[id];
+      if (n.parent && ids[n.parent] && n.parent !== id) nodes[n.parent].children.push(n);
+      else roots.push(n);
+    });
+    console.log('§SE_WBS schedule=' + scheduleId + ' nodes=' + Object.keys(nodes).length +
+      ' roots=' + roots.length);
+    return roots;
+  }
+
+  // listDependencies(db, scheduleId) — read task_sequences (pred→succ, type, lag), joined to task
+  // names, scoped to the schedule via the predecessor's schedule_id. Returns
+  // [{predId,predName,succId,succName,type,lag}].
+  function listDependencies(db, scheduleId) {
+    var r;
+    try {
+      r = db.exec('SELECT s.predecessor_id, p.name, s.successor_id, c.name, s.sequence_type, s.lag_days ' +
+        'FROM task_sequences s ' +
+        'JOIN tasks p ON p.task_id=s.predecessor_id ' +
+        'JOIN tasks c ON c.task_id=s.successor_id ' +
+        'WHERE p.schedule_id=? ORDER BY p.name, c.name', [scheduleId]);
+    } catch (e) { return []; }
+    if (!r.length || !r[0].values.length) return [];
+    return r[0].values.map(function (row) {
+      return { predId: row[0], predName: row[1] || row[0], succId: row[2], succName: row[3] || row[2],
+        type: row[4] || 'FS', lag: (row[5] != null ? row[5] : 0) };
+    });
+  }
+
+  // wouldCycle(db, predId, succId) — would adding pred→succ create a directed cycle? DFS forward from
+  // succ over existing edges; if we reach pred, the new edge closes a loop. Deterministic graph-integrity
+  // guard (a cyclic schedule is INVALID) — NOT resource optimisation (§SE-B: forbid the cycle, DO IT).
+  function wouldCycle(db, predId, succId) {
+    if (predId === succId) return true;
+    var adj = {};
+    try {
+      var r = db.exec('SELECT predecessor_id, successor_id FROM task_sequences');
+      if (r.length && r[0].values.length) r[0].values.forEach(function (row) {
+        (adj[row[0]] = adj[row[0]] || []).push(row[1]);
+      });
+    } catch (e) {}
+    var stack = [succId], seen = {};
+    while (stack.length) {
+      var cur = stack.pop();
+      if (cur === predId) return true;
+      if (seen[cur]) continue;
+      seen[cur] = true;
+      (adj[cur] || []).forEach(function (n) { if (!seen[n]) stack.push(n); });
+    }
+    return false;
+  }
+
+  // addDependency(db, predId, succId, type, lag) — author one IfcRelSequence edge. Refuses self-loop,
+  // unknown task, duplicate, and any cycle. Returns {ok, reason}.
+  function addDependency(db, predId, succId, type, lag) {
+    type = (type || 'FS').toUpperCase();
+    if (SEQ_TYPES.indexOf(type) < 0) type = 'FS';
+    lag = (lag == null || isNaN(parseFloat(lag))) ? 0 : parseFloat(lag);
+    function fail(reason) {
+      console.log('§SE_DEP_FAIL ' + predId + '->' + succId + ' reason=' + reason);
+      return { ok: false, predId: predId, succId: succId, reason: reason };
+    }
+    if (!predId || !succId) return fail('missing_id');
+    if (predId === succId) return fail('self_loop');
+    function exists(id) { var t = db.exec('SELECT 1 FROM tasks WHERE task_id=?', [id]); return t.length && t[0].values.length; }
+    if (!exists(predId) || !exists(succId)) return fail('no_such_task');
+    var dup = db.exec('SELECT 1 FROM task_sequences WHERE predecessor_id=? AND successor_id=?', [predId, succId]);
+    if (dup.length && dup[0].values.length) return fail('duplicate');
+    if (wouldCycle(db, predId, succId)) return fail('cycle');
+    db.run('INSERT INTO task_sequences VALUES (?,?,?,?)', [predId, succId, type, lag]);
+    console.log('§SE_DEP_ADD ' + predId + '->' + succId + ' type=' + type + ' lag=' + lag);
+    return { ok: true, predId: predId, succId: succId, type: type, lag: lag };
+  }
+
+  // removeDependency(db, predId, succId) — drop one edge. Returns {ok, removed}.
+  function removeDependency(db, predId, succId) {
+    var before = db.exec('SELECT COUNT(*) FROM task_sequences')[0].values[0][0];
+    db.run('DELETE FROM task_sequences WHERE predecessor_id=? AND successor_id=?', [predId, succId]);
+    var after = db.exec('SELECT COUNT(*) FROM task_sequences')[0].values[0][0];
+    console.log('§SE_DEP_DEL ' + predId + '->' + succId + ' removed=' + (before - after));
+    return { ok: before - after > 0, removed: before - after };
+  }
+
+  // updateDependency(db, predId, succId, patch) — retype (FS/SS/FF/SF) and/or set lag on an edge.
+  function updateDependency(db, predId, succId, patch) {
+    patch = patch || {};
+    var row = db.exec('SELECT sequence_type, lag_days FROM task_sequences WHERE predecessor_id=? AND successor_id=?', [predId, succId]);
+    if (!row.length || !row[0].values.length) {
+      console.log('§SE_DEP_UPD_FAIL ' + predId + '->' + succId + ' reason=no_such_edge');
+      return { ok: false, reason: 'no_such_edge' };
+    }
+    var type = row[0].values[0][0], lag = row[0].values[0][1];
+    if (patch.type != null) { var t = String(patch.type).toUpperCase(); if (SEQ_TYPES.indexOf(t) >= 0) type = t; }
+    if (patch.lag != null && !isNaN(parseFloat(patch.lag))) lag = parseFloat(patch.lag);
+    db.run('UPDATE task_sequences SET sequence_type=?, lag_days=? WHERE predecessor_id=? AND successor_id=?',
+      [type, lag, predId, succId]);
+    console.log('§SE_DEP_UPD ' + predId + '->' + succId + ' type=' + type + ' lag=' + lag);
+    return { ok: true, type: type, lag: lag };
+  }
+
   var API = {
     matchRule: matchRule,
     materializeDefault: materializeDefault,
     scheduleContiguous: scheduleContiguous,
     activeSchedule: activeSchedule,
     assignElement: assignElement,
-    foldCost: foldCost
+    foldCost: foldCost,
+    SEQ_TYPES: SEQ_TYPES,
+    wbsTree: wbsTree,
+    listDependencies: listDependencies,
+    wouldCycle: wouldCycle,
+    addDependency: addDependency,
+    removeDependency: removeDependency,
+    updateDependency: updateDependency
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v4');
+  console.log('§SCHEDULE_AUTHOR_LOADED v5');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>BIM OOTB — Schedule Editor (WBS + Dependencies)</title>
+<!--
+  §SE-1 — the MSP-grade Gantt editor, NEW-TAB surface (§SE-C). Step 1+2: collapsible WBS outline +
+  dependency view/edit. Open with ?db=<building.db>&… (config.js parity: defaults to Duplex on GH
+  Pages, the OCI bucket DB when hosted there). All graph logic lives in schedule_author.js (engine,
+  node-tested W-SCHED-EDIT); this page is the surface.
+-->
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 13px/1.45 -apple-system, Segoe UI, Roboto, sans-serif;
+         background: #11151c; color: #d8e0ea; }
+  header { display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+           background: linear-gradient(180deg, #1b2230, #161b25); border-bottom: 1px solid #2a3342; }
+  header h1 { font-size: 15px; margin: 0; font-weight: 600; color: #eaf1fb; }
+  header .sub { color: #7d8aa0; font-size: 11px; }
+  #se-bld { margin-left: auto; color: #4fc3f7; font-size: 11px; }
+  #se-status { padding: 6px 16px; background: #0d1118; color: #9fb0c6; font-size: 11px;
+               border-bottom: 1px solid #222b38; min-height: 26px; }
+  main { display: grid; grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.2fr); gap: 0;
+         height: calc(100vh - 96px); }
+  .pane { overflow: auto; padding: 10px 12px; }
+  .pane.left { border-right: 1px solid #232c3a; }
+  .pane h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #6f7d93;
+             margin: 0 0 8px; }
+  /* WBS outline */
+  .se-wbs-row { display: flex; align-items: center; gap: 6px; padding: 3px 4px; border-radius: 4px;
+                white-space: nowrap; }
+  .se-wbs-row:hover { background: #1a2230; }
+  .se-twisty { width: 12px; color: #5e6b80; cursor: default; user-select: none; }
+  .se-wbs-row .se-twisty:hover { color: #9fb0c6; }
+  .se-wbs-name { color: #cdd7e4; }
+  .se-wbs-name.se-summary { font-weight: 600; color: #eaf1fb; }
+  .se-badge { font-size: 10px; color: #76d1a0; background: #16271f; padding: 1px 6px;
+              border-radius: 8px; }
+  .se-dates { font-size: 10px; color: #6f7d93; margin-left: 6px; }
+  /* dependency rows */
+  .se-dep-row { display: flex; align-items: center; gap: 8px; padding: 5px 4px;
+                border-bottom: 1px solid #1c2531; }
+  .se-dep-pred { color: #eaf1fb; min-width: 90px; }
+  .se-dep-succ { color: #eaf1fb; flex: 1; }
+  .se-dep-arrow { color: #5e6b80; }
+  select, input, button { background: #1c2430; color: #d8e0ea; border: 1px solid #313c4d;
+                          border-radius: 5px; padding: 3px 6px; font: inherit; }
+  .se-dep-type { width: 56px; }
+  .se-dep-lag { width: 56px; }
+  .se-dep-del { color: #e08989; border-color: #3a2730; cursor: pointer; padding: 2px 8px; }
+  .se-dep-del:hover { background: #2a1a20; }
+  .se-empty { color: #6f7d93; font-style: italic; padding: 8px 4px; }
+  /* add-dependency form */
+  .se-add { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 14px;
+            padding: 10px; background: #141a24; border: 1px solid #232c3a; border-radius: 8px; }
+  .se-add label { font-size: 10px; color: #6f7d93; }
+  #se-add-btn { background: #1f6feb; border-color: #1f6feb; color: #fff; cursor: pointer;
+                font-weight: 600; padding: 4px 12px; }
+  #se-add-btn:hover { background: #2a7bf7; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Schedule Editor</h1>
+  <span class="sub">WBS outline + dependencies</span>
+  <span id="se-bld">—</span>
+</header>
+<div id="se-status">Initialising…</div>
+<main>
+  <section class="pane left">
+    <h2>Work Breakdown (WBS)</h2>
+    <div id="se-wbs"></div>
+  </section>
+  <section class="pane right">
+    <h2>Dependencies</h2>
+    <div id="se-deps"></div>
+    <div class="se-add">
+      <label>Add link:</label>
+      <select id="se-add-pred" title="predecessor"></select>
+      <span class="se-dep-arrow">→</span>
+      <select id="se-add-succ" title="successor"></select>
+      <label>type</label><select id="se-add-type" title="FS/SS/FF/SF"></select>
+      <label>lag</label><input id="se-add-lag" type="number" value="0" style="width:54px">
+      <button id="se-add-btn">+ Add</button>
+    </div>
+  </section>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
+<script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
+<script src="schedule_author.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_editor_ui.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+</body>
+</html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -1,0 +1,174 @@
+// schedule_editor_ui.js — §SE-1 step 1+2: the MSP-grade Gantt editor's NEW-TAB surface (§SE-C).
+//
+// A SEPARATE surface from the TM what-if showpiece: WBS outline (collapsible) on the left, dependency
+// view/EDIT on the right. Pure DOM glue over viewer/schedule_author.js (window.ScheduleAuthor) — all
+// graph logic + the cycle guard live in that node-tested engine (W-SCHED-EDIT). This file only loads a
+// building DB, renders the engine's reads, and routes user edits back through the engine's verbs.
+//
+// DB resolution mirrors config.js: ?db= param → OCI bucket base → buildings/Duplex_extracted.db.
+// Each successful edit broadcasts on the already-live BroadcastChannel('bim_4d') (main.js S240 listens)
+// — the §SE-D edit→watch rail; an open viewer reacts, a later slice teaches it to re-fold.
+(function (global) {
+  'use strict';
+
+  var SA = function () { return global.ScheduleAuthor; };
+  var db = null, schedId = null, bc = null;
+  var collapsed = {};   // task_id -> true when its subtree is collapsed
+
+  function $(id) { return document.getElementById(id); }
+  function status(msg) { var s = $('se-status'); if (s) s.textContent = msg; console.log('§SE_UI ' + msg); }
+  function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; }
+
+  // ── DB resolution (config.js parity) ─────────────────────────────────────────
+  function resolveDbUrl() {
+    var params = new URLSearchParams(location.search);
+    var ociMatch = location.href.match(/(https:\/\/objectstorage\.[^/]+\/n\/[^/]+\/b\/[^/]+\/o\/)/);
+    var base = ociMatch ? ociMatch[1] : '';
+    var last = null; try { last = localStorage.getItem('pwa_last_db'); } catch (e) {}
+    return params.get('db') || last || (base ? base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db');
+  }
+
+  function broadcast(detail) {
+    try {
+      if (!bc && typeof BroadcastChannel !== 'undefined') bc = new BroadcastChannel('bim_4d');
+      if (bc) { bc.postMessage(Object.assign({ type: '4D_SCHED_EDIT', from: 'schedule_editor', schedule: schedId }, detail)); }
+    } catch (e) {}
+  }
+
+  // ── STEP 1: collapsible WBS outline ──────────────────────────────────────────
+  function renderWbs() {
+    var host = $('se-wbs'); if (!host) return;
+    host.innerHTML = '';
+    var roots = SA().wbsTree(db, schedId);
+    if (!roots.length) { host.appendChild(el('div', 'se-empty', 'No schedule tasks.')); return; }
+    function walk(node, depth) {
+      var row = el('div', 'se-wbs-row');
+      row.style.paddingLeft = (depth * 18 + 6) + 'px';
+      row.dataset.task = node.id;
+      var hasKids = node.children && node.children.length;
+      var tw = el('span', 'se-twisty', hasKids ? (collapsed[node.id] ? '▸' : '▾') : ' ');
+      if (hasKids) tw.onclick = function () { collapsed[node.id] = !collapsed[node.id]; renderWbs(); };
+      row.appendChild(tw);
+      var nm = el('span', 'se-wbs-name' + (node.isSummary ? ' se-summary' : ''), node.name);
+      row.appendChild(nm);
+      if (!node.isSummary && node.guidCount) row.appendChild(el('span', 'se-badge', node.guidCount + ' el'));
+      if (node.start) row.appendChild(el('span', 'se-dates', node.start + (node.finish ? ' → ' + node.finish : '')));
+      host.appendChild(row);
+      if (hasKids && !collapsed[node.id]) node.children.forEach(function (c) { walk(c, depth + 1); });
+    }
+    roots.forEach(function (r) { walk(r, 0); });
+  }
+
+  // ── STEP 2: dependency view + edit ───────────────────────────────────────────
+  function taskOptions() {
+    // Leaf tasks (real work) are the linkable nodes; summaries roll up.
+    var roots = SA().wbsTree(db, schedId), leaves = [];
+    (function flat(ns) { ns.forEach(function (n) { if (!n.isSummary) leaves.push(n); flat(n.children || []); }); })(roots);
+    return leaves;
+  }
+
+  function renderDeps() {
+    var host = $('se-deps'); if (!host) return;
+    host.innerHTML = '';
+    var deps = SA().listDependencies(db, schedId);
+    if (!deps.length) { host.appendChild(el('div', 'se-empty', 'No dependencies yet — add one below.')); }
+    deps.forEach(function (d) {
+      var row = el('div', 'se-dep-row');
+      row.appendChild(el('span', 'se-dep-pred', d.predName));
+      // type selector
+      var sel = el('select', 'se-dep-type');
+      SA().SEQ_TYPES.forEach(function (t) { var o = el('option', null, t); o.value = t; if (t === d.type) o.selected = true; sel.appendChild(o); });
+      sel.onchange = function () {
+        var r = SA().updateDependency(db, d.predId, d.succId, { type: sel.value });
+        if (r.ok) { broadcast({ op: 'retype', predId: d.predId, succId: d.succId, value: sel.value }); status('Retyped ' + d.predName + ' → ' + d.succName + ' = ' + sel.value); refreshFold(); }
+      };
+      row.appendChild(sel);
+      // lag input
+      var lag = el('input', 'se-dep-lag'); lag.type = 'number'; lag.value = d.lag; lag.title = 'lag (days)';
+      lag.onchange = function () {
+        var r = SA().updateDependency(db, d.predId, d.succId, { lag: lag.value });
+        if (r.ok) { broadcast({ op: 'lag', predId: d.predId, succId: d.succId, value: r.lag }); status('Lag ' + d.predName + ' → ' + d.succName + ' = ' + r.lag + 'd'); }
+      };
+      row.appendChild(lag);
+      row.appendChild(el('span', 'se-dep-arrow', '→'));
+      row.appendChild(el('span', 'se-dep-succ', d.succName));
+      var del = el('button', 'se-dep-del', '✕'); del.title = 'remove link';
+      del.onclick = function () {
+        SA().removeDependency(db, d.predId, d.succId);
+        broadcast({ op: 'remove', predId: d.predId, succId: d.succId });
+        status('Removed ' + d.predName + ' → ' + d.succName); renderDeps(); refreshFold();
+      };
+      row.appendChild(del);
+      host.appendChild(row);
+    });
+    // refresh the add-form selects
+    fillAddForm();
+  }
+
+  function fillAddForm() {
+    var leaves = taskOptions();
+    ['se-add-pred', 'se-add-succ'].forEach(function (id) {
+      var s = $(id); if (!s) return; var keep = s.value; s.innerHTML = '';
+      leaves.forEach(function (n) { var o = el('option', null, n.name); o.value = n.id; s.appendChild(o); });
+      if (keep) s.value = keep;
+    });
+    var ts = $('se-add-type');
+    if (ts && !ts.options.length) SA().SEQ_TYPES.forEach(function (t) { var o = el('option', null, t); o.value = t; ts.appendChild(o); });
+  }
+
+  function onAdd() {
+    var pred = $('se-add-pred').value, succ = $('se-add-succ').value;
+    var type = $('se-add-type').value, lag = $('se-add-lag').value;
+    var r = SA().addDependency(db, pred, succ, type, lag);
+    if (!r.ok) {
+      var why = { self_loop: 'a task cannot depend on itself', cycle: 'that link would create a CYCLE (refused)',
+        duplicate: 'that link already exists', no_such_task: 'unknown task', missing_id: 'pick both tasks' }[r.reason] || r.reason;
+      status('⚠ Not added — ' + why);
+      return;
+    }
+    broadcast({ op: 'add', predId: pred, succId: succ, value: r.type });
+    status('Added ' + r.predId + ' → ' + r.succId + ' (' + r.type + ')');
+    renderDeps(); refreshFold();
+  }
+
+  // Re-run cost fold if available (dependency edits don't change cost, but keep the readout live).
+  function refreshFold() { /* CPM/date ripple = §SE step 3+; this slice only edits the graph. */ }
+
+  // ── boot ─────────────────────────────────────────────────────────────────────
+  function init() {
+    if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
+    var url = resolveDbUrl();
+    status('Loading ' + url.split('/').pop() + ' …');
+    var initSqlJs = global.initSqlJs;
+    initSqlJs({ locateFile: function (f) { return 'https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/' + f; } })
+      .then(function (SQL) {
+        return fetch(url).then(function (r) {
+          if (!r.ok) throw new Error('fetch ' + r.status);
+          return r.arrayBuffer();
+        }).then(function (buf) {
+          db = new SQL.Database(new Uint8Array(buf));
+          console.log('§SE_DB_OPEN size=' + (buf.byteLength / 1024).toFixed(0) + 'KB url=' + url.split('/').pop());
+        });
+      })
+      .then(function () {
+        var act = SA().activeSchedule(db);
+        if (!act) {
+          // Blank model → seed the smart default so there's a schedule to edit (rates.js globals).
+          var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+          schedId = 'SCH_AUTHORED';
+          status('Seeded default schedule (' + resM.phases.length + ' phases) — ' + url.split('/').pop());
+        } else {
+          schedId = act.id;
+          status('Editing ' + (act.name || act.id) + ' (' + act.taskCount + ' tasks)' + (act.captured ? ' — imported' : ''));
+        }
+        var b = $('se-bld'); if (b) b.textContent = url.split('/').pop() + '  •  ' + (schedId);
+        renderWbs(); renderDeps();
+        var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
+      })
+      .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
+  }
+
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps };
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})(typeof window !== 'undefined' ? window : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v710';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v711';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -139,6 +139,8 @@ const PRECACHE_ASSETS = [
   'time_machine.js',
   'schedule_author.js',
   'schedule_author_ui.js',
+  'schedule_editor.html',
+  'schedule_editor_ui.js',
   'error_reporter.js',
   'print_sheet.js',
   'ghostglass.js',


### PR DESCRIPTION
## §SE-1 — the MSP-grade Gantt arc, first slice (FUSED_4D5D_WEDGE_LANE)

A **separate surface** (§SE-C new tab) from the TM what-if showpiece: a collapsible **WBS outline** + **view/edit dependencies**, built on data we already extract (`tasks`/`task_sequences`/`task_elements`).

### Engine — `viewer/schedule_author.js` (pure, DOM-free, node-tested)
- `wbsTree` — folds `tasks.wbs_parent`/`is_summary` into a collapsible tree (+ per-leaf element counts).
- `listDependencies` / `addDependency` / `removeDependency` / `updateDependency` over the IFC-native `task_sequences` table — the dependency truth, written **directly** exactly as `assignElement` writes `task_elements` (kernel_ops signing still deferred).
- `wouldCycle` DFS guard: a back-edge closing a directed cycle is **REFUSED** — data integrity, **not** resource optimisation (the §SE-B rabbit-hole boundary). Self-loop / duplicate / unknown-task also refused.

### Surface — `viewer/schedule_editor.html` + `schedule_editor_ui.js`
Standalone tab; resolves a building DB like `config.js` (`?db=` → OCI base → Duplex), picks `activeSchedule()` or seeds the smart default, renders LEFT collapsible WBS outline + RIGHT dependency list with **add / retype (FS·SS·FF·SF) / lag / delete**. Cycle refusal surfaces **inline** (no silent drop). Each edit broadcasts on the already-live `BroadcastChannel('bim_4d')` `{type:'4D_SCHED_EDIT'}` — the §SE-D edit→watch rail (viewer already listens; live re-fold is a later slice).

### Witnesses
- **W-SCHED-EDIT 19/19** (`erp/tests/schedule_editor_witness.js`) — node, **real** `SampleHouse_extracted.db`: materialise default → WBS shape (1 summary root, 3 nested leaves) → FS chain → list with names → cycle/self/dup refused → retype SS + lag → remove. §-log proof only.
- **§SE-SMOKE 10/10** — headless Chromium: scripts load, DB opens, WBS renders (root + 3 leaves + element badges), add-dep through the real UI, cycle refused in the status line.

`sw.js` v710→v711; precache `schedule_editor.html` + `schedule_editor_ui.js`.

### Scope guard (honoured)
Step 1+2 only — **no CPM / float / interactive-drag Gantt** (§SE step 3–5) and **no resource leveling/optimisation** (the explicit refuse line). The cycle guard is the one deterministic "forbid" and is pure graph integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)