### PR TITLE
feat(sched-editor): §SE-2 step 3 — bounded CPM forward/backward pass + critical-path highlight

### DIFF
--- a/erp/tests/schedule_cpm_witness.js
+++ b/erp/tests/schedule_cpm_witness.js
@@ -1,0 +1,95 @@
+// schedule_cpm_witness.js — W-SCHED-CPM (FUSED_4D5D_WEDGE_LANE §SE-2)
+//
+// ISSUE PROVED: computeCpm runs an EXACT critical-path forward/backward pass over the authored
+// task_sequences DAG — honouring FS/SS/FF/SF + lag — and writes early/late dates, total + free float,
+// and is_critical onto the leaf tasks. Two graphs:
+//   (1) a HAND-COMPUTED diamond → assert EXACT ES/EF/LS/LF/float/critical vs by-hand numbers (proves
+//       the maths, not merely that it runs).
+//   (2) REAL SampleHouse default + an authored FS chain → linear ⇒ every task critical, zero float,
+//       projectDuration = Σ durations.
+// Whitebox §-log only. This is the §SE-B "DO IT" half (deterministic compute); NO resource leveling.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.resolve(__dirname, '..', '..', 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-SCHED-CPM PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-SCHED-CPM FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var s = txt.indexOf('var SEQUENCE_RULES = {'), di = txt.indexOf('var SEQUENCE_DEFAULT');
+  var slice = txt.slice(s, txt.indexOf('};', di) + 2);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+
+function mkDb(SQL) {
+  var db = new SQL.Database();
+  db.run('CREATE TABLE tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)');
+  db.run('CREATE TABLE task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+  db.run('CREATE TABLE task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+  return db;
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+
+  // ── GRAPH 1: hand-computed diamond ───────────────────────────────────────────
+  // A→B (FS,0), A→C (FS,+2), B→D (FS,0), C→D (SS,+1). dur A2 B4 C3 D2.
+  // By hand: ES/EF A0/2 B2/6 C4/7 D6/8 ; LS/LF A0/2 B2/6 C5/8 D6/8 ;
+  // totalFloat A0 B0 C1 D0 (critical A,B,D) ; freeFloat A0 B0 C1 D0.
+  var db = mkDb(SQL);
+  [['A', 'P2D'], ['B', 'P4D'], ['C', 'P3D'], ['D', 'P2D']].forEach(function (t) {
+    db.run('INSERT INTO tasks (task_id,schedule_id,name,is_summary,schedule_duration,status) VALUES (?,?,?,0,?,?)',
+      [t[0], 'DIAMOND', t[0], t[1], 'PLANNED']);
+  });
+  db.run("INSERT INTO task_sequences VALUES ('A','B','FS',0)");
+  db.run("INSERT INTO task_sequences VALUES ('A','C','FS',2)");
+  db.run("INSERT INTO task_sequences VALUES ('B','D','FS',0)");
+  db.run("INSERT INTO task_sequences VALUES ('C','D','SS',1)");
+
+  var r = ScheduleAuthor.computeCpm(db, 'DIAMOND', { start: '2026-01-01' });
+  var byId = {}; r.tasks.forEach(function (t) { byId[t.id] = t; });
+  var EXPECT = {
+    A: { es: 0, ef: 2, ls: 0, lf: 2, totalFloat: 0, freeFloat: 0, critical: true },
+    B: { es: 2, ef: 6, ls: 2, lf: 6, totalFloat: 0, freeFloat: 0, critical: true },
+    C: { es: 4, ef: 7, ls: 5, lf: 8, totalFloat: 1, freeFloat: 1, critical: false },
+    D: { es: 6, ef: 8, ls: 6, lf: 8, totalFloat: 0, freeFloat: 0, critical: true }
+  };
+  Object.keys(EXPECT).forEach(function (id) {
+    var got = byId[id], exp = EXPECT[id];
+    var ok = got && ['es', 'ef', 'ls', 'lf', 'totalFloat', 'freeFloat'].every(function (k) { return got[k] === exp[k]; }) && got.critical === exp.critical;
+    check('diamond-' + id, ok, got ? ('es' + got.es + ' ef' + got.ef + ' ls' + got.ls + ' lf' + got.lf +
+      ' tf' + got.totalFloat + ' ff' + got.freeFloat + ' crit' + got.critical) : 'MISSING');
+  });
+  check('diamond-projectDuration', r.projectDuration === 8, 'PF=' + r.projectDuration);
+  check('diamond-criticalIds', r.criticalIds.sort().join(',') === 'A,B,D', 'critical=' + r.criticalIds.join(','));
+  // write-back hit the DB columns (dates + is_critical + float string)
+  var wb = db.exec("SELECT early_start, late_finish, total_float, is_critical FROM tasks WHERE task_id='C'")[0].values[0];
+  check('diamond-writeback', wb[0] === '2026-01-05' && wb[1] === '2026-01-09' && wb[2] === '1' && wb[3] === 0,
+    'C es=' + wb[0] + ' lf=' + wb[1] + ' tf=' + wb[2] + ' crit=' + wb[3]);
+
+  // ── GRAPH 2: real SampleHouse, FS chain ⇒ all critical, PF = Σ durations ──────
+  var rules = loadRules();
+  var sh = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+  ScheduleAuthor.materializeDefault(sh, rules.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+  var leaves = [];
+  (function flat(ns) { ns.forEach(function (n) { if (!n.isSummary) leaves.push(n.id); flat(n.children || []); }); })(ScheduleAuthor.wbsTree(sh, 'SCH_AUTHORED'));
+  for (var i = 0; i < leaves.length - 1; i++) ScheduleAuthor.addDependency(sh, leaves[i], leaves[i + 1], 'FS', 0);
+  var rc = ScheduleAuthor.computeCpm(sh, 'SCH_AUTHORED', { start: '2026-01-01' });
+  check('sh-all-critical', rc.tasks.length > 0 && rc.tasks.every(function (t) { return t.critical; }),
+    'critical=' + rc.criticalIds.length + '/' + rc.tasks.length);
+  check('sh-zero-float', rc.tasks.every(function (t) { return t.totalFloat === 0; }), 'all total_float=0');
+  var sumDur = rc.tasks.reduce(function (a, t) { return a + t.dur; }, 0);
+  check('sh-projectDuration-eq-sum', rc.projectDuration === sumDur, 'PF=' + rc.projectDuration + ' Σdur=' + sumDur);
+
+  console.log('§W-SCHED-CPM RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-SCHED-CPM ERROR', e); process.exit(2); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -306,8 +306,8 @@
   function wbsTree(db, scheduleId) {
     var r;
     try {
-      r = db.exec('SELECT task_id, wbs_parent, name, is_summary, schedule_start, schedule_finish ' +
-        'FROM tasks WHERE schedule_id=? ', [scheduleId]);
+      r = db.exec('SELECT task_id, wbs_parent, name, is_summary, schedule_start, schedule_finish, ' +
+        'is_critical, total_float FROM tasks WHERE schedule_id=? ', [scheduleId]);
     } catch (e) { return []; }
     if (!r.length || !r[0].values.length) return [];
     var nodes = {}, ids = {};
@@ -315,6 +315,7 @@
       ids[row[0]] = true;
       nodes[row[0]] = { id: row[0], parent: row[1], name: row[2] || row[0],
         isSummary: !!row[3], start: row[4] || null, finish: row[5] || null,
+        critical: row[6] === 1, totalFloat: (row[7] != null ? row[7] : null),
         guidCount: 0, children: [] };
     });
     // Element counts per task (the "N elements" badge on a leaf).
@@ -426,6 +427,118 @@
     return { ok: true, type: type, lag: lag };
   }
 
+  // ── §SE-2 — bounded CPM forward/backward pass (step 3; the deterministic compute, NOT leveling) ──
+  // Exact critical-path method over the authored task_sequences DAG, honouring FS/SS/FF/SF + lag.
+  // This is the §SE-B "DO IT" half; it STOPS before resource leveling / auto-optimisation (the refuse).
+
+  // duration in whole days: parse ISO P{n}D / P{n}W, else (finish-start), else 1.
+  function _durDays(durStr, startStr, finishStr) {
+    if (durStr) {
+      var d = /P(?:(\d+)W)?(?:(\d+)D)?/.exec(durStr);
+      if (d && (d[1] || d[2])) return (parseInt(d[1] || 0, 10) * 7) + parseInt(d[2] || 0, 10);
+    }
+    if (startStr && finishStr) {
+      var ms = Date.parse(finishStr + 'T00:00:00Z') - Date.parse(startStr + 'T00:00:00Z');
+      if (!isNaN(ms)) return Math.max(0, Math.round(ms / 86400000));
+    }
+    return 1;
+  }
+
+  // candidate EARLY START a predecessor imposes on a successor (forward pass + free-float reuse).
+  function _fwdES(pred, lag, type, succDur) {
+    switch (type) {
+      case 'SS': return pred.es + lag;
+      case 'FF': return pred.ef + lag - succDur;
+      case 'SF': return pred.es + lag - succDur;
+      default:   return pred.ef + lag;                 // FS
+    }
+  }
+  // candidate LATE FINISH a successor imposes on a predecessor (backward pass).
+  function _bwdLF(succ, lag, type, predDur) {
+    var succLS = succ.lf - succ.dur;
+    switch (type) {
+      case 'SS': return succLS - lag + predDur;
+      case 'FF': return succ.lf - lag;
+      case 'SF': return succ.lf - lag + predDur;
+      default:   return succLS - lag;                  // FS
+    }
+  }
+
+  // computeCpm(db, scheduleId, opts) — write early/late dates, float, is_critical onto the leaf tasks.
+  function computeCpm(db, scheduleId, opts) {
+    opts = opts || {};
+    var tr;
+    try {
+      tr = db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks ' +
+        'WHERE schedule_id=? AND (is_summary IS NULL OR is_summary=0)', [scheduleId]);
+    } catch (e) { return { error: 'no_tasks' }; }
+    if (!tr.length || !tr[0].values.length) return { error: 'no_tasks', tasks: [], projectDuration: 0, criticalIds: [] };
+    var T = {}, ids = [], minStart = null;
+    tr[0].values.forEach(function (row) {
+      var id = row[0], s = row[1], f = row[2];
+      if (s && (!minStart || s < minStart)) minStart = s;
+      T[id] = { id: id, dur: _durDays(row[3], s, f), es: 0, ef: 0, ls: 0, lf: 0, preds: [], succs: [] };
+      ids.push(id);
+    });
+    // edges among these leaf tasks only
+    var er = db.exec('SELECT predecessor_id, successor_id, sequence_type, lag_days FROM task_sequences');
+    if (er.length && er[0].values.length) er[0].values.forEach(function (row) {
+      var p = row[0], s = row[1];
+      if (!T[p] || !T[s]) return;                      // skip edges touching summary/foreign tasks
+      var edge = { pred: p, succ: s, type: (row[2] || 'FS').toUpperCase(), lag: (row[3] != null ? row[3] : 0) };
+      T[s].preds.push(edge); T[p].succs.push(edge);
+    });
+    // Kahn topo sort (DAG guaranteed by the §SE-1 cycle guard; bail defensively if not).
+    var indeg = {}, queue = [], topo = [];
+    ids.forEach(function (id) { indeg[id] = T[id].preds.length; if (indeg[id] === 0) queue.push(id); });
+    while (queue.length) {
+      var id = queue.shift(); topo.push(id);
+      T[id].succs.forEach(function (e) { if (--indeg[e.succ] === 0) queue.push(e.succ); });
+    }
+    if (topo.length !== ids.length) {
+      console.log('§SE_CPM_BAIL cycle-or-orphan topo=' + topo.length + ' tasks=' + ids.length);
+      return { error: 'cycle', tasks: [], projectDuration: 0, criticalIds: [] };
+    }
+    // FORWARD: ES/EF in topo order.
+    topo.forEach(function (id) {
+      var t = T[id], es = 0;
+      t.preds.forEach(function (e) { es = Math.max(es, _fwdES(T[e.pred], e.lag, e.type, t.dur)); });
+      t.es = Math.max(0, es); t.ef = t.es + t.dur;
+    });
+    var PF = 0; ids.forEach(function (id) { PF = Math.max(PF, T[id].ef); });
+    // BACKWARD: LF/LS in reverse topo order.
+    for (var i = topo.length - 1; i >= 0; i--) {
+      var t = T[topo[i]];
+      if (!t.succs.length) t.lf = PF;
+      else { var lf = Infinity; t.succs.forEach(function (e) { lf = Math.min(lf, _bwdLF(T[e.succ], e.lag, e.type, t.dur)); }); t.lf = lf; }
+      t.ls = t.lf - t.dur;
+    }
+    // float + critical + free float + write-back
+    var projStart = opts.start || minStart || '2026-01-01';
+    var critical = [];
+    var stmt = db.prepare('UPDATE tasks SET early_start=?, early_finish=?, late_start=?, late_finish=?, ' +
+      'free_float=?, total_float=?, is_critical=? WHERE task_id=?');
+    var out = topo.map(function (id) {
+      var t = T[id];
+      var total = t.ls - t.es;
+      var free = Infinity;
+      t.succs.forEach(function (e) { free = Math.min(free, T[e.succ].es - _fwdES(t, e.lag, e.type, T[e.succ].dur)); });
+      if (!isFinite(free)) free = total;
+      free = Math.max(0, free);
+      var isCrit = total <= 0 ? 1 : 0;
+      if (isCrit) critical.push(id);
+      stmt.run([_addDays(projStart, t.es), _addDays(projStart, t.ef),
+        _addDays(projStart, t.ls), _addDays(projStart, t.lf),
+        String(free), String(total), isCrit, id]);
+      return { id: id, es: t.es, ef: t.ef, ls: t.ls, lf: t.lf, dur: t.dur,
+        totalFloat: total, freeFloat: free, critical: !!isCrit };
+    });
+    stmt.free();
+    console.log('§SE_CPM schedule=' + scheduleId + ' tasks=' + out.length + ' projectDuration=' + PF +
+      ' critical=' + critical.length + ' [' + critical.join(',') + ']');
+    return { projectDuration: PF, projectStart: projStart, tasks: out, criticalIds: critical };
+  }
+
   var API = {
     matchRule: matchRule,
     materializeDefault: materializeDefault,
@@ -439,11 +552,12 @@
     wouldCycle: wouldCycle,
     addDependency: addDependency,
     removeDependency: removeDependency,
-    updateDependency: updateDependency
+    updateDependency: updateDependency,
+    computeCpm: computeCpm
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v5');
+  console.log('§SCHEDULE_AUTHOR_LOADED v6');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -39,6 +39,16 @@
   .se-badge { font-size: 10px; color: #76d1a0; background: #16271f; padding: 1px 6px;
               border-radius: 8px; }
   .se-dates { font-size: 10px; color: #6f7d93; margin-left: 6px; }
+  /* CPM: critical rail + float */
+  .se-wbs-row.se-critical { box-shadow: inset 3px 0 0 #e0556b; }
+  .se-float { font-size: 10px; margin-left: 6px; }
+  .se-float.crit { color: #e0556b; }
+  .se-float.slack { color: #76d1a0; }
+  .se-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+  #se-cpm-btn { background: #243042; border-color: #34465e; color: #cdd7e4; cursor: pointer; }
+  #se-cpm-btn:hover { background: #2c3a50; }
+  #se-cpm-out { font-size: 11px; color: #9fb0c6; }
+  .se-dep-row.se-dep-crit .se-dep-pred, .se-dep-row.se-dep-crit .se-dep-succ { color: #f0a6b1; font-weight: 600; }
   /* dependency rows */
   .se-dep-row { display: flex; align-items: center; gap: 8px; padding: 5px 4px;
                 border-bottom: 1px solid #1c2531; }
@@ -75,6 +85,10 @@
   </section>
   <section class="pane right">
     <h2>Dependencies</h2>
+    <div class="se-toolbar">
+      <button id="se-cpm-btn" title="Critical-path forward/backward pass over the dependency graph">▶ Compute CPM</button>
+      <span id="se-cpm-out"></span>
+    </div>
     <div id="se-deps"></div>
     <div class="se-add">
       <label>Add link:</label>
@@ -89,7 +103,7 @@
 </main>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_editor_ui.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_author.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_editor_ui.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -14,6 +14,7 @@
   var SA = function () { return global.ScheduleAuthor; };
   var db = null, schedId = null, bc = null;
   var collapsed = {};   // task_id -> true when its subtree is collapsed
+  var critSet = {};     // task_id -> true after a CPM run (drives the red rail + bold links)
 
   function $(id) { return document.getElementById(id); }
   function status(msg) { var s = $('se-status'); if (s) s.textContent = msg; console.log('§SE_UI ' + msg); }
@@ -42,7 +43,7 @@
     var roots = SA().wbsTree(db, schedId);
     if (!roots.length) { host.appendChild(el('div', 'se-empty', 'No schedule tasks.')); return; }
     function walk(node, depth) {
-      var row = el('div', 'se-wbs-row');
+      var row = el('div', 'se-wbs-row' + (node.critical ? ' se-critical' : ''));
       row.style.paddingLeft = (depth * 18 + 6) + 'px';
       row.dataset.task = node.id;
       var hasKids = node.children && node.children.length;
@@ -52,6 +53,11 @@
       var nm = el('span', 'se-wbs-name' + (node.isSummary ? ' se-summary' : ''), node.name);
       row.appendChild(nm);
       if (!node.isSummary && node.guidCount) row.appendChild(el('span', 'se-badge', node.guidCount + ' el'));
+      if (!node.isSummary && node.totalFloat != null) {
+        var tf = parseFloat(node.totalFloat);
+        row.appendChild(el('span', 'se-float ' + (tf <= 0 ? 'crit' : 'slack'),
+          tf <= 0 ? 'critical' : ('float ' + tf + 'd')));
+      }
       if (node.start) row.appendChild(el('span', 'se-dates', node.start + (node.finish ? ' → ' + node.finish : '')));
       host.appendChild(row);
       if (hasKids && !collapsed[node.id]) node.children.forEach(function (c) { walk(c, depth + 1); });
@@ -73,7 +79,9 @@
     var deps = SA().listDependencies(db, schedId);
     if (!deps.length) { host.appendChild(el('div', 'se-empty', 'No dependencies yet — add one below.')); }
     deps.forEach(function (d) {
-      var row = el('div', 'se-dep-row');
+      // a "critical link" = both endpoints critical after a CPM run.
+      var crit = critSet[d.predId] && critSet[d.succId];
+      var row = el('div', 'se-dep-row' + (crit ? ' se-dep-crit' : ''));
       row.appendChild(el('span', 'se-dep-pred', d.predName));
       // type selector
       var sel = el('select', 'se-dep-type');
@@ -87,7 +95,7 @@
       var lag = el('input', 'se-dep-lag'); lag.type = 'number'; lag.value = d.lag; lag.title = 'lag (days)';
       lag.onchange = function () {
         var r = SA().updateDependency(db, d.predId, d.succId, { lag: lag.value });
-        if (r.ok) { broadcast({ op: 'lag', predId: d.predId, succId: d.succId, value: r.lag }); status('Lag ' + d.predName + ' → ' + d.succName + ' = ' + r.lag + 'd'); }
+        if (r.ok) { broadcast({ op: 'lag', predId: d.predId, succId: d.succId, value: r.lag }); status('Lag ' + d.predName + ' → ' + d.succName + ' = ' + r.lag + 'd'); refreshFold(); }
       };
       row.appendChild(lag);
       row.appendChild(el('span', 'se-dep-arrow', '→'));
@@ -96,7 +104,7 @@
       del.onclick = function () {
         SA().removeDependency(db, d.predId, d.succId);
         broadcast({ op: 'remove', predId: d.predId, succId: d.succId });
-        status('Removed ' + d.predName + ' → ' + d.succName); renderDeps(); refreshFold();
+        status('Removed ' + d.predName + ' → ' + d.succName); refreshFold();
       };
       row.appendChild(del);
       host.appendChild(row);
@@ -128,11 +136,36 @@
     }
     broadcast({ op: 'add', predId: pred, succId: succ, value: r.type });
     status('Added ' + r.predId + ' → ' + r.succId + ' (' + r.type + ')');
-    renderDeps(); refreshFold();
+    refreshFold();
   }
 
-  // Re-run cost fold if available (dependency edits don't change cost, but keep the readout live).
-  function refreshFold() { /* CPM/date ripple = §SE step 3+; this slice only edits the graph. */ }
+  // §SE step 3 — Compute CPM over the authored DAG, then re-render with critical rail + float.
+  function onComputeCpm() {
+    if (!SA().computeCpm) return;
+    var r = SA().computeCpm(db, schedId, { start: '2026-01-01' });
+    var out = $('se-cpm-out');
+    if (r.error) {
+      critSet = {};
+      if (out) out.textContent = r.error === 'cycle' ? '⚠ graph has a cycle' : '⚠ no tasks to compute';
+    } else {
+      critSet = {}; r.criticalIds.forEach(function (id) { critSet[id] = true; });
+      if (out) out.textContent = 'project ' + r.projectDuration + 'd · critical ' + r.criticalIds.length + '/' + r.tasks.length;
+      broadcast({ op: 'cpm', projectDuration: r.projectDuration, criticalIds: r.criticalIds });
+    }
+    renderWbs(); renderDeps();
+  }
+
+  // After a graph edit the prior CPM is INVALID — null the computed columns (everywhere) until the
+  // user recomputes, so a stale critical path can never linger on a changed graph.
+  function refreshFold() {
+    critSet = {};
+    try {
+      if (db && schedId) db.run('UPDATE tasks SET early_start=NULL, early_finish=NULL, late_start=NULL, ' +
+        'late_finish=NULL, free_float=NULL, total_float=NULL, is_critical=NULL WHERE schedule_id=?', [schedId]);
+    } catch (e) {}
+    var o = $('se-cpm-out'); if (o) o.textContent = '';
+    renderWbs(); renderDeps();
+  }
 
   // ── boot ─────────────────────────────────────────────────────────────────────
   function init() {
@@ -164,11 +197,12 @@
         var b = $('se-bld'); if (b) b.textContent = url.split('/').pop() + '  •  ' + (schedId);
         renderWbs(); renderDeps();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
+        var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
       })
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }
 
-  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps };
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, computeCpm: onComputeCpm };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })(typeof window !== 'undefined' ? window : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v711';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v712';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## §SE-2 — step 3 of the MSP-grade Gantt arc (builds on #503)

The authored dependency DAG now drives a real **critical-path forward/backward pass** instead of the linear-by-SeqNo assumption. This is the §SE-B *"DO IT"* half — a deterministic compute over a graph the **user** authored; it **stops before** resource leveling / auto-optimisation (the NP-hard refuse line).

### Engine — `viewer/schedule_author.js`
- `computeCpm(db, schedId, opts)` — Kahn topo-sort the leaf-task DAG → forward pass (ES/EF) → backward pass (LS/LF) → total + free float → `is_critical`. Honours **all four** sequence types (FS/SS/FF/SF) + lag. Writes `early_*`/`late_*` (ISO dates), `free_float`/`total_float`, `is_critical` onto the columns the schema already carries; the `schedule_*` baseline is untouched. Durations from `schedule_duration` (P{n}D/W) else `(finish − start)`.
- `wbsTree` now also surfaces `is_critical` + `total_float` for the outline.

### Surface — `schedule_editor.html` + `schedule_editor_ui.js`
**▶ Compute CPM** → red critical rail on the WBS leaves, per-leaf float label, **bold critical dependency links**, and a `project Nd · critical k/n` readout. Editing the graph (add/retype/lag/remove) **invalidates** the prior CPM — the computed columns are nulled until recomputed, so a stale critical path can never linger.

### Witnesses
- **W-SCHED-CPM 10/10** (`erp/tests/schedule_cpm_witness.js`, node) — a **hand-computed diamond** (`A→B` FS, `A→C` FS+2lag, `B→D` FS, `C→D` SS+1lag; dur 2/4/3/2) asserted **exactly**: ES/EF/LS/LF/float/critical per node, critical path **A,B,D**, C float = 1, write-back dates — plus real SampleHouse FS chain ⇒ all-critical, zero float, `PF = 90 = Σdur`.
- **§SE-CPM-SMOKE 6/6** (headless Chromium) — chain → Compute CPM → critical rail (3) + bold links (2) + float labels + readout; a graph edit clears the stale CPM.
- **W-SCHED-EDIT 19/19** still green (the `wbsTree` extension is additive).

`sw.js` v711→v712.

### Scope guard (honoured)
Step 3 (+ step 4 critical-path highlight, which falls out of it). **No** resource leveling/optimisation; **no** interactive drag-Gantt yet (step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)