### PR TITLE
feat(sched-editor): §SE-3 step 5 — interactive drag-Gantt (reschedule + drag-to-link)

### DIFF
--- a/erp/tests/schedule_move_witness.js
+++ b/erp/tests/schedule_move_witness.js
@@ -1,0 +1,64 @@
+// schedule_move_witness.js — W-SCHED-MOVE (FUSED_4D5D_WEDGE_LANE §SE-3)
+//
+// ISSUE PROVED: moveTask (the drag-to-reschedule verb) shifts a LEAF task to a new start, PRESERVING
+// its duration, writing schedule_start/finish — and refuses summary/unknown tasks. On real SampleHouse.
+// Whitebox §-log only. The drag gesture itself is proven by §SE-GANTT-SMOKE (headless); this proves the
+// engine maths a drag invokes.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.resolve(__dirname, '..', '..', 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-SCHED-MOVE PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-SCHED-MOVE FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var s = txt.indexOf('var SEQUENCE_RULES = {'), di = txt.indexOf('var SEQUENCE_DEFAULT');
+  var slice = txt.slice(s, txt.indexOf('};', di) + 2);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+function daysBetween(a, b) { return Math.round((Date.parse(b + 'T00:00:00Z') - Date.parse(a + 'T00:00:00Z')) / 86400000); }
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var rules = loadRules();
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+  ScheduleAuthor.materializeDefault(db, rules.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+
+  // pick the first leaf
+  var leaves = [];
+  (function flat(ns) { ns.forEach(function (n) { if (!n.isSummary) leaves.push(n); flat(n.children || []); }); })(ScheduleAuthor.wbsTree(db, 'SCH_AUTHORED'));
+  check('have-leaves', leaves.length >= 1, 'leaves=' + leaves.length);
+  var t = leaves[0];
+  var before = db.exec("SELECT schedule_start, schedule_finish FROM tasks WHERE task_id='" + t.id + "'")[0].values[0];
+  var oldStart = before[0], oldFinish = before[1];
+  var oldDur = daysBetween(oldStart, oldFinish);
+
+  // ── move +7 days ─────────────────────────────────────────────────────────────
+  var newStart = '2026-01-08';   // oldStart is 2026-01-01 → +7
+  var res = ScheduleAuthor.moveTask(db, t.id, newStart);
+  check('move-ok', res.ok === true, 'start=' + res.start + ' finish=' + res.finish);
+  check('move-start-shifted', res.start === newStart && daysBetween(oldStart, res.start) === 7,
+    'oldStart=' + oldStart + ' newStart=' + res.start);
+  check('move-duration-preserved', daysBetween(res.start, res.finish) === oldDur,
+    'newDur=' + daysBetween(res.start, res.finish) + ' oldDur=' + oldDur);
+  // persisted?
+  var after = db.exec("SELECT schedule_start, schedule_finish FROM tasks WHERE task_id='" + t.id + "'")[0].values[0];
+  check('move-persisted', after[0] === newStart && after[1] === res.finish,
+    'db start=' + after[0] + ' finish=' + after[1]);
+
+  // ── refusals ─────────────────────────────────────────────────────────────────
+  check('refuse-summary', ScheduleAuthor.moveTask(db, 'TASK_ROOT', '2026-02-01').reason === 'is_summary');
+  check('refuse-unknown', ScheduleAuthor.moveTask(db, 'TASK_NOPE', '2026-02-01').reason === 'no_such_task');
+
+  console.log('§W-SCHED-MOVE RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-SCHED-MOVE ERROR', e); process.exit(2); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -464,6 +464,28 @@
     }
   }
 
+  // moveTask(db, taskId, newStart) — §SE-3 drag-to-reschedule verb. Move one LEAF task so it starts on
+  // newStart (YYYY-MM-DD), PRESERVING its duration (parsed from schedule_duration, else old finish−start,
+  // else 1). Writes schedule_start/finish only — the baseline; CPM invalidation is the caller's concern
+  // (mirrors the dependency-edit flow). Refuses unknown/summary tasks. Returns {ok, start, finish, days}.
+  function moveTask(db, taskId, newStart) {
+    var r = db.exec('SELECT is_summary, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE task_id=?', [taskId]);
+    if (!r.length || !r[0].values.length) {
+      console.log('§SE_MOVE_FAIL task=' + taskId + ' reason=no_such_task');
+      return { ok: false, reason: 'no_such_task' };
+    }
+    var row = r[0].values[0];
+    if (row[0] === 1) {
+      console.log('§SE_MOVE_FAIL task=' + taskId + ' reason=is_summary');
+      return { ok: false, reason: 'is_summary' };
+    }
+    var days = _durDays(row[3], row[1], row[2]);
+    var finish = _addDays(newStart, days);
+    db.run('UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE task_id=?', [newStart, finish, taskId]);
+    console.log('§SE_MOVE task=' + taskId + ' start=' + newStart + ' finish=' + finish + ' days=' + days);
+    return { ok: true, start: newStart, finish: finish, days: days };
+  }
+
   // computeCpm(db, scheduleId, opts) — write early/late dates, float, is_critical onto the leaf tasks.
   function computeCpm(db, scheduleId, opts) {
     opts = opts || {};
@@ -553,11 +575,12 @@
     addDependency: addDependency,
     removeDependency: removeDependency,
     updateDependency: updateDependency,
-    computeCpm: computeCpm
+    computeCpm: computeCpm,
+    moveTask: moveTask
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v6');
+  console.log('§SCHEDULE_AUTHOR_LOADED v7');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -23,7 +23,7 @@
   #se-status { padding: 6px 16px; background: #0d1118; color: #9fb0c6; font-size: 11px;
                border-bottom: 1px solid #222b38; min-height: 26px; }
   main { display: grid; grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.2fr); gap: 0;
-         height: calc(100vh - 96px); }
+         height: 42vh; border-bottom: 1px solid #232c3a; }
   .pane { overflow: auto; padding: 10px 12px; }
   .pane.left { border-right: 1px solid #232c3a; }
   .pane h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #6f7d93;
@@ -49,6 +49,31 @@
   #se-cpm-btn:hover { background: #2c3a50; }
   #se-cpm-out { font-size: 11px; color: #9fb0c6; }
   .se-dep-row.se-dep-crit .se-dep-pred, .se-dep-row.se-dep-crit .se-dep-succ { color: #f0a6b1; font-weight: 600; }
+  /* Gantt timeline */
+  .gantt-pane { height: calc(58vh - 96px); overflow: auto; padding: 10px 12px; }
+  .gantt-pane h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #6f7d93;
+                   margin: 0 0 8px; }
+  .gantt-pane h2 .hint { text-transform: none; letter-spacing: 0; color: #566177; font-weight: 400; }
+  #se-gantt { position: relative; }
+  .g-axis { position: relative; height: 16px; margin-left: 152px; border-bottom: 1px solid #2a3342;
+            margin-bottom: 4px; }
+  .g-tick { position: absolute; top: 0; font-size: 9px; color: #56627a; border-left: 1px solid #222b38;
+            height: 16px; padding-left: 3px; }
+  .g-row { display: flex; align-items: center; height: 26px; }
+  .g-label { width: 150px; min-width: 150px; padding-right: 6px; color: #cdd7e4; white-space: nowrap;
+             overflow: hidden; text-overflow: ellipsis; font-size: 12px; }
+  .g-track { position: relative; flex: 1; height: 26px; }
+  .g-bar { position: absolute; top: 4px; height: 18px; border-radius: 4px; background: #2f6fd1;
+           cursor: grab; box-shadow: 0 1px 2px rgba(0,0,0,.4); display: flex; align-items: center;
+           color: #eaf1fb; font-size: 10px; padding: 0 6px; white-space: nowrap; overflow: hidden;
+           user-select: none; }
+  .g-bar.crit { background: #d2475c; }
+  .g-bar.dragging { cursor: grabbing; opacity: .85; outline: 1px solid #9fb6d6; }
+  .g-handle { position: absolute; right: -5px; top: 6px; width: 12px; height: 14px; cursor: crosshair;
+              color: #9fb6d6; font-size: 11px; text-align: center; line-height: 14px; }
+  .g-handle:hover { color: #fff; }
+  .g-link-mode .g-bar { outline: 1px dashed #4a6fa5; }
+  .gantt-empty { color: #6f7d93; font-style: italic; padding: 14px 4px; }
   /* dependency rows */
   .se-dep-row { display: flex; align-items: center; gap: 8px; padding: 5px 4px;
                 border-bottom: 1px solid #1c2531; }
@@ -101,9 +126,13 @@
     </div>
   </section>
 </main>
+<section class="gantt-pane">
+  <h2>Timeline (Gantt) <span class="hint">— drag a bar to reschedule · drag the ▸ handle onto another bar to link</span></h2>
+  <div id="se-gantt"></div>
+</section>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_editor_ui.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_editor_ui.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -19,6 +19,9 @@
   function $(id) { return document.getElementById(id); }
   function status(msg) { var s = $('se-status'); if (s) s.textContent = msg; console.log('§SE_UI ' + msg); }
   function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; }
+  // UTC day arithmetic (timezone-independent, matches the engine's _addDays).
+  function addDays(base, n) { return new Date(Date.parse(base + 'T00:00:00Z') + n * 86400000).toISOString().slice(0, 10); }
+  function daysBetween(a, b) { return Math.round((Date.parse(b + 'T00:00:00Z') - Date.parse(a + 'T00:00:00Z')) / 86400000); }
 
   // ── DB resolution (config.js parity) ─────────────────────────────────────────
   function resolveDbUrl() {
@@ -124,6 +127,105 @@
     if (ts && !ts.options.length) SA().SEQ_TYPES.forEach(function (t) { var o = el('option', null, t); o.value = t; ts.appendChild(o); });
   }
 
+  // ── STEP 5: interactive Gantt — bars on a day-axis, drag-to-reschedule + drag-to-link ────────
+  function renderGantt() {
+    var host = $('se-gantt'); if (!host) return;
+    host.innerHTML = '';
+    var leaves = taskOptions().filter(function (n) { return n.start && n.finish; });
+    if (!leaves.length) {
+      host.appendChild(el('div', 'gantt-empty', 'No dated tasks — schedule the WBS first, then drag the bars here.'));
+      return;
+    }
+    // shared day-axis over all bars
+    var min = leaves[0].start, max = leaves[0].finish;
+    leaves.forEach(function (n) { if (n.start < min) min = n.start; if (n.finish > max) max = n.finish; });
+    var totalDays = Math.max(1, daysBetween(min, max));
+    var labelW = 152;
+    var chartW = Math.max(240, (host.clientWidth || 700) - labelW - 8);
+    var pxPerDay = chartW / totalDays;
+
+    // axis: a tick roughly every ~7 days (snap to weeks), labelled with the date.
+    var axis = el('div', 'g-axis');
+    var stepDays = Math.max(7, Math.ceil(totalDays / 8 / 7) * 7);
+    for (var d = 0; d <= totalDays; d += stepDays) {
+      var tick = el('div', 'g-tick', addDays(min, d));
+      tick.style.left = (d * pxPerDay) + 'px';
+      axis.appendChild(tick);
+    }
+    host.appendChild(axis);
+
+    leaves.forEach(function (n) {
+      var dur = daysBetween(n.start, n.finish);
+      var off = daysBetween(min, n.start);
+      var row = el('div', 'g-row');
+      row.appendChild(el('div', 'g-label', n.name));
+      var track = el('div', 'g-track');
+      var bar = el('div', 'g-bar' + (n.critical ? ' crit' : ''), dur + 'd');
+      bar.style.left = (off * pxPerDay) + 'px';
+      bar.style.width = Math.max(8, dur * pxPerDay) + 'px';
+      bar.dataset.task = n.id;
+      bar.title = n.name + '  ' + n.start + ' → ' + n.finish + (n.totalFloat != null ? '  (float ' + n.totalFloat + 'd)' : '');
+      _wireBarDrag(bar, n, off, pxPerDay);
+      var handle = el('div', 'g-handle', '▸');
+      handle.title = 'drag onto another bar to link (FS)';
+      _wireLinkDrag(handle, n);
+      bar.appendChild(handle);
+      track.appendChild(bar);
+      row.appendChild(track);
+      host.appendChild(row);
+    });
+    console.log('§SE_GANTT bars=' + leaves.length + ' span=' + min + '..' + max + ' days=' + totalDays);
+  }
+
+  // drag a bar horizontally → reschedule (snap to whole days, duration locked).
+  function _wireBarDrag(bar, node, offDays, pxPerDay) {
+    bar.addEventListener('mousedown', function (e) {
+      if (e.target.className === 'g-handle') return;       // handle owns link-drag
+      e.preventDefault();
+      var startX = e.clientX, origLeft = offDays * pxPerDay;
+      bar.classList.add('dragging');
+      function mv(ev) { bar.style.left = (origLeft + (ev.clientX - startX)) + 'px'; }
+      function up(ev) {
+        document.removeEventListener('mousemove', mv); document.removeEventListener('mouseup', up);
+        bar.classList.remove('dragging');
+        var deltaDays = Math.round((ev.clientX - startX) / pxPerDay);
+        if (deltaDays === 0) { bar.style.left = origLeft + 'px'; return; }
+        var newStart = addDays(node.start, deltaDays);
+        var r = SA().moveTask(db, node.id, newStart);
+        if (r.ok) {
+          broadcast({ op: 'move', taskId: node.id, start: r.start, finish: r.finish });
+          status('Moved ' + node.name + ' ' + (deltaDays > 0 ? '+' : '') + deltaDays + 'd → ' + r.start);
+          refreshFold();                                   // invalidate stale CPM + re-render all
+        }
+      }
+      document.addEventListener('mousemove', mv); document.addEventListener('mouseup', up);
+    });
+  }
+
+  // drag from a bar's handle onto another bar → addDependency(FS) (cycle-guarded inline).
+  function _wireLinkDrag(handle, node) {
+    handle.addEventListener('mousedown', function (e) {
+      e.preventDefault(); e.stopPropagation();
+      var host = $('se-gantt'); if (host) host.classList.add('g-link-mode');
+      function up(ev) {
+        document.removeEventListener('mouseup', up);
+        if (host) host.classList.remove('g-link-mode');
+        var tgt = document.elementFromPoint(ev.clientX, ev.clientY);
+        while (tgt && tgt !== document.body && !(tgt.classList && tgt.classList.contains('g-bar'))) tgt = tgt.parentNode;
+        if (!tgt || !tgt.dataset || !tgt.dataset.task || tgt.dataset.task === node.id) { status('Link cancelled'); return; }
+        var r = SA().addDependency(db, node.id, tgt.dataset.task, 'FS', 0);
+        if (!r.ok) {
+          var why = { cycle: 'would create a CYCLE', duplicate: 'link already exists', self_loop: 'same task' }[r.reason] || r.reason;
+          status('⚠ Link refused — ' + why); return;
+        }
+        broadcast({ op: 'add', predId: node.id, succId: tgt.dataset.task, value: 'FS' });
+        status('Linked ' + node.id + ' → ' + tgt.dataset.task + ' (FS)');
+        refreshFold();
+      }
+      document.addEventListener('mouseup', up);
+    });
+  }
+
   function onAdd() {
     var pred = $('se-add-pred').value, succ = $('se-add-succ').value;
     var type = $('se-add-type').value, lag = $('se-add-lag').value;
@@ -152,7 +254,7 @@
       if (out) out.textContent = 'project ' + r.projectDuration + 'd · critical ' + r.criticalIds.length + '/' + r.tasks.length;
       broadcast({ op: 'cpm', projectDuration: r.projectDuration, criticalIds: r.criticalIds });
     }
-    renderWbs(); renderDeps();
+    renderWbs(); renderDeps(); renderGantt();
   }
 
   // After a graph edit the prior CPM is INVALID — null the computed columns (everywhere) until the
@@ -164,7 +266,7 @@
         'late_finish=NULL, free_float=NULL, total_float=NULL, is_critical=NULL WHERE schedule_id=?', [schedId]);
     } catch (e) {}
     var o = $('se-cpm-out'); if (o) o.textContent = '';
-    renderWbs(); renderDeps();
+    renderWbs(); renderDeps(); renderGantt();
   }
 
   // ── boot ─────────────────────────────────────────────────────────────────────
@@ -195,14 +297,15 @@
           status('Editing ' + (act.name || act.id) + ' (' + act.taskCount + ' tasks)' + (act.captured ? ' — imported' : ''));
         }
         var b = $('se-bld'); if (b) b.textContent = url.split('/').pop() + '  •  ' + (schedId);
-        renderWbs(); renderDeps();
+        renderWbs(); renderDeps(); renderGantt();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
+        window.addEventListener('resize', renderGantt);
       })
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }
 
-  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, computeCpm: onComputeCpm };
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })(typeof window !== 'undefined' ? window : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v712';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v713';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## §SE-3 — step 5 of the MSP-grade Gantt arc (builds on #503/#504)

**The MS-Project feel — and the §SE-B wedge surface.** Bonsai/IfcOpenShell have steps 1–4, but their Gantt is a generated *visualisation* you edit via property panels — they **lack #5**. A real **drag-on-the-chart** web editor on our signed log + ERP fold is the genuinely new thing. Rabbit-hole guard intact: a drag is the user moving a bar **they** authored (deterministic) — no auto-reschedule / leveling.

### Engine — `viewer/schedule_author.js`
- `moveTask(db, taskId, newStart)` — reschedule one leaf to `newStart`, **preserving duration** (from `schedule_duration` else old finish−start); writes `schedule_start/finish`. Refuses summary/unknown. The only new verb; **drag-to-link reuses** the shipped `addDependency` (cycle guard intact).

### Surface — `schedule_editor.html` + `schedule_editor_ui.js`
- A full-width **Timeline (Gantt)** pane below WBS/Deps: one bar per dated leaf on a shared day-axis (`pxPerDay = width/Σspan`) with date ticks; **critical bars red** (post-CPM), else blue.
- **Drag-to-reschedule:** mousedown on a bar → release snaps `deltaDays = round(dx/pxPerDay)` → `moveTask` → re-render + invalidate stale CPM + broadcast `4D_SCHED_EDIT`. Day-snapped, duration-locked.
- **Drag-to-link:** drag a bar's ▸ handle onto another bar → `addDependency(FS)`, cycle refusal **inline** (no silent drop).

### Witnesses
- **W-SCHED-MOVE 7/7** (`erp/tests/schedule_move_witness.js`, node, real SampleHouse) — move a phase +7d → start+finish both shift +7, duration unchanged, persisted; summary/unknown refused.
- **§SE-GANTT-SMOKE 9/9** (headless Chromium, **real mouse events**) — 3 bars render; drag a bar → `§SE_MOVE` fires, start advances, chart re-renders; drag-to-link creates a dep; a reverse drag refused as a **CYCLE** inline.
- **W-SCHED-EDIT 19/19** + **W-SCHED-CPM 10/10** still green.

`sw.js` v712→v713.

### Arc status
Steps 1–5 of §SE now shipped (WBS → deps → CPM → critical-path → interactive Gantt). Remaining in the lane: TM-tab **consumes** the `4D_SCHED_EDIT` broadcast for live cross-tab re-fold. **Refused (out of scope):** resource leveling / schedule optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)