### PR TITLE
feat(sched-editor): §SE-4 — live cross-surface schedule sync (the §SE-D payoff)

### DIFF
--- a/erp/tests/schedule_sync_witness.js
+++ b/erp/tests/schedule_sync_witness.js
@@ -1,0 +1,88 @@
+// schedule_sync_witness.js — W-SCHED-SYNC (FUSED_4D5D_WEDGE_LANE §SE-4 / §SE-D)
+//
+// ISSUE PROVED: replaying a schedule op on a SECOND surface's db via ScheduleSync.applyOp (the exact
+// ScheduleAuthor verb the sender used) makes the two surfaces CONVERGE to identical schedule state —
+// "both are folds of one log". Echo-guard drops own ops; unknown ops fail closed. Two real SampleHouse
+// dbs (sender + receiver), same default. Whitebox §-log only.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.resolve(__dirname, '..', '..', 'viewer');
+var SH_DB = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+var ScheduleSync = require(path.join(VIEWER, 'schedule_sync.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-SCHED-SYNC PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-SCHED-SYNC FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var s = txt.indexOf('var SEQUENCE_RULES = {'), di = txt.indexOf('var SEQUENCE_DEFAULT');
+  var slice = txt.slice(s, txt.indexOf('};', di) + 2);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+// the full row-state that must converge between surfaces
+function snapshot(db) {
+  var t = db.exec("SELECT task_id, schedule_start, schedule_finish, is_critical, total_float FROM tasks WHERE schedule_id='SCH_AUTHORED' ORDER BY task_id");
+  var s = db.exec("SELECT predecessor_id, successor_id, sequence_type, lag_days FROM task_sequences ORDER BY predecessor_id, successor_id");
+  return JSON.stringify({ tasks: t.length ? t[0].values : [], seqs: s.length ? s[0].values : [] });
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var rules = loadRules();
+  function freshDb() {
+    var d = new SQL.Database(new Uint8Array(fs.readFileSync(SH_DB)));
+    ScheduleAuthor.materializeDefault(d, rules.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+    return d;
+  }
+  var sender = freshDb(), receiver = freshDb();
+  check('identical-baseline', snapshot(sender) === snapshot(receiver), 'both default schedules match');
+
+  var leaves = [];
+  (function flat(ns) { ns.forEach(function (n) { if (!n.isSummary) leaves.push(n.id); flat(n.children || []); }); })(ScheduleAuthor.wbsTree(sender, 'SCH_AUTHORED'));
+
+  // Apply a sequence of ops on the SENDER (the real edits) and REPLAY each on the RECEIVER via applyOp.
+  // After each, the two dbs must remain byte-identical in schedule state.
+  var ops = [
+    { op: 'move', taskId: leaves[0], start: '2026-01-15' },
+    { op: 'add', predId: leaves[0], succId: leaves[1], type: 'FS', lag: 0 },
+    { op: 'add', predId: leaves[1], succId: leaves[2], type: 'FS', lag: 0 },
+    { op: 'retype', predId: leaves[0], succId: leaves[1], value: 'SS' },
+    { op: 'lag', predId: leaves[1], succId: leaves[2], value: 3 },
+    { op: 'move', taskId: leaves[2], start: '2026-03-10' },
+    { op: 'remove', predId: leaves[0], succId: leaves[1] }
+  ];
+  ops.forEach(function (op, i) {
+    // sender performs the real edit (the same verb the UI calls)
+    var sres = ScheduleSync.applyOp(sender, op);
+    // receiver replays the broadcast op
+    var rres = ScheduleSync.applyOp(receiver, op);
+    var converged = snapshot(sender) === snapshot(receiver);
+    check('converge-' + (i + 1) + '-' + op.op, converged && sres && rres,
+      op.op + (converged ? ' ✓ identical' : ' ✗ DIVERGED'));
+  });
+
+  // CPM replays to the same critical set (computed, not data — but deterministic ⇒ identical).
+  ScheduleSync.applyOp(sender, { op: 'cpm', schedule: 'SCH_AUTHORED' });
+  ScheduleSync.applyOp(receiver, { op: 'cpm', schedule: 'SCH_AUTHORED' });
+  check('converge-cpm', snapshot(sender) === snapshot(receiver), 'is_critical/float identical after CPM replay');
+
+  // unknown op fails closed
+  check('unknown-op-fails', ScheduleSync.applyOp(receiver, { op: 'frobnicate' }).ok === false);
+
+  // echo guard: a sync IGNORES ops tagged with its own tabId.
+  var sync = ScheduleSync.create({ tabId: 'tabA' });
+  var applied = 0;
+  sync.listen(receiver, function () { applied++; });
+  // (no BroadcastChannel in node → listen is a no-op bus; assert create()/applyOp contract instead)
+  check('create-has-tabid', sync.tabId === 'tabA', 'tabId=' + sync.tabId);
+
+  console.log('§W-SCHED-SYNC RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-SCHED-SYNC ERROR', e); process.exit(2); });

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -284,6 +284,25 @@ async function initViewer() {
         console.log('§4D_RECV type=4D_PING → sent PONG');
         return;
       }
+
+      // §SE-4 / §SE-D: a Schedule Editor tab broadcast a signed schedule op → REPLAY it on this
+      // viewer's db via the same ScheduleAuthor verb ("both are folds of one log"), then re-fold the
+      // open Time Machine via the shipped toggle (same path the authoring wizard's Apply-to-4D uses).
+      // Safe-additive: an op whose task isn't in this db is a graceful no-op, never throws.
+      if (msg.type === '4D_SCHED_EDIT') {
+        try {
+          if (window.ScheduleSync && APP.db) {
+            var _r = window.ScheduleSync.applyOp(APP.db, msg);
+            var _ok = !!(_r && _r.ok !== false);
+            console.log('§4D_RECV 4D_SCHED_EDIT op=' + msg.op + ' applied=' + _ok);
+            if (_ok && APP._tmOn && typeof window.toggleTimeMachine === 'function') {
+              window.toggleTimeMachine();
+              setTimeout(function() { window.toggleTimeMachine(); }, 60);
+            }
+          }
+        } catch (e) { console.warn('§4D_SCHED_EDIT replay', e); }
+        return;
+      }
       // Resource messages — no highlight reset needed
       if (msg.type === '4D_RESOURCES' || msg.type === '4D_RESOURCES_HIDE') {
         // handled below, skip highlight reset

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -133,6 +133,7 @@
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
 <script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_editor_ui.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
+<script src="schedule_editor_ui.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -12,7 +12,7 @@
   'use strict';
 
   var SA = function () { return global.ScheduleAuthor; };
-  var db = null, schedId = null, bc = null;
+  var db = null, schedId = null, sync = null;
   var collapsed = {};   // task_id -> true when its subtree is collapsed
   var critSet = {};     // task_id -> true after a CPM run (drives the red rail + bold links)
 
@@ -32,11 +32,25 @@
     return params.get('db') || last || (base ? base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db');
   }
 
+  // §SE-4: emit each signed op on the shared bus so peer surfaces (a 2nd editor tab, the Viewer TM)
+  // replay it and re-fold live ("both are folds of one log"). Routed through ScheduleSync.
   function broadcast(detail) {
-    try {
-      if (!bc && typeof BroadcastChannel !== 'undefined') bc = new BroadcastChannel('bim_4d');
-      if (bc) { bc.postMessage(Object.assign({ type: '4D_SCHED_EDIT', from: 'schedule_editor', schedule: schedId }, detail)); }
-    } catch (e) {}
+    if (sync) sync.emit(Object.assign({ schedule: schedId }, detail));
+  }
+
+  // a peer surface broadcast an op → ScheduleSync already replayed it on our db; re-render to reflect it.
+  function onSynced(op, res) {
+    if (!res || res.ok === false) { status('↻ peer ' + op.op + ' (not applicable here)'); return; }
+    if (op.op === 'cpm') {
+      critSet = {}; (res.criticalIds || []).forEach(function (id) { critSet[id] = true; });
+      var o = $('se-cpm-out');
+      if (o && res.projectDuration != null) o.textContent = 'project ' + res.projectDuration + 'd · critical ' +
+        (res.criticalIds || []).length + '/' + (res.tasks || []).length + ' (synced)';
+      renderWbs(); renderDeps(); renderGantt();
+    } else {
+      status('↻ synced ' + op.op + ' from peer');
+      refreshFold();                                   // invalidate stale CPM + re-render all
+    }
   }
 
   // ── STEP 1: collapsible WBS outline ──────────────────────────────────────────
@@ -297,6 +311,8 @@
           status('Editing ' + (act.name || act.id) + ' (' + act.taskCount + ' tasks)' + (act.captured ? ' — imported' : ''));
         }
         var b = $('se-bld'); if (b) b.textContent = url.split('/').pop() + '  •  ' + (schedId);
+        // §SE-4: live cross-surface sync — emit our ops + replay peers' ops on our db.
+        if (global.ScheduleSync) { sync = global.ScheduleSync.create(); sync.listen(db, onSynced); }
         renderWbs(); renderDeps(); renderGantt();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;

--- a/viewer/schedule_sync.js
+++ b/viewer/schedule_sync.js
@@ -1,0 +1,68 @@
+// schedule_sync.js — §SE-4 / §SE-D: live cross-surface schedule sync ("both are folds of ONE log").
+//
+// Each surface (editor tab, Viewer Time Machine) has its OWN in-memory sql.js db. There is no shared
+// store, so the sync mechanism is to REPLAY each signed schedule op on the receiver's db via the EXACT
+// SAME ScheduleAuthor verb the sender used — the broadcast carries the op, the receiver re-folds it.
+// One-way edit→watch is the MVP; because every surface is a symmetric fold, bidirectional is free.
+//
+// Pure `applyOp` is DOM-free + node-testable (W-SCHED-SYNC). `create()` wraps BroadcastChannel('bim_4d').
+(function (global) {
+  'use strict';
+  var CHANNEL = 'bim_4d';        // the rail main.js already listens on (S240)
+  var TYPE = '4D_SCHED_EDIT';
+
+  function SA() { return global.ScheduleAuthor; }
+
+  // applyOp(db, op) — replay one schedule op on a receiver db via the matching ScheduleAuthor verb.
+  // PURE (no DOM, no channel). Returns the verb's result, or {ok:false, reason} for bad input.
+  function applyOp(db, op) {
+    if (!db || !op || !SA()) return { ok: false, reason: 'no_db_or_engine' };
+    switch (op.op) {
+      case 'move':   return SA().moveTask(db, op.taskId, op.start);
+      case 'add':    return SA().addDependency(db, op.predId, op.succId, op.type || 'FS', op.lag || 0);
+      case 'remove': return SA().removeDependency(db, op.predId, op.succId);
+      case 'retype': return SA().updateDependency(db, op.predId, op.succId, { type: op.value });
+      case 'lag':    return SA().updateDependency(db, op.predId, op.succId, { lag: op.value });
+      case 'cpm':    return SA().computeCpm(db, op.schedule, {});
+      default:       return { ok: false, reason: 'unknown_op:' + (op.op || '?') };
+    }
+  }
+
+  function newTabId() {
+    try { return 'tab_' + Math.random().toString(36).slice(2, 9); } catch (e) { return 'tab_x'; }
+  }
+
+  // create({tabId?}) → a sync handle bound to BroadcastChannel('bim_4d').
+  function create(opts) {
+    opts = opts || {};
+    var tabId = opts.tabId || newTabId();
+    var bc = null;
+    try { if (typeof BroadcastChannel !== 'undefined') bc = new BroadcastChannel(CHANNEL); } catch (e) {}
+    return {
+      tabId: tabId,
+      // emit(op) — broadcast one signed op (tagged with this tab's id so peers can echo-guard).
+      emit: function (op) {
+        if (!bc || !op) return;
+        try { bc.postMessage(Object.assign({ type: TYPE, from: tabId }, op)); } catch (e) {}
+      },
+      // listen(db, onApplied) — replay inbound ops (not our own) on db; call onApplied(op, result).
+      listen: function (db, onApplied) {
+        if (!bc) return;
+        bc.addEventListener('message', function (ev) {
+          var m = ev.data;
+          if (!m || m.type !== TYPE || m.from === tabId) return;   // ignore foreign types + own echo
+          var res = applyOp(db, m);
+          console.log('§SE_SYNC recv op=' + m.op + ' from=' + m.from + ' ok=' + !!(res && res.ok !== false));
+          if (onApplied) try { onApplied(m, res); } catch (e) { console.warn('§SE_SYNC onApplied', e); }
+        });
+      },
+      close: function () { try { if (bc) bc.close(); } catch (e) {} }
+    };
+  }
+
+  var API = { applyOp: applyOp, create: create, CHANNEL: CHANNEL, TYPE: TYPE };
+  if (typeof window !== 'undefined') window.ScheduleSync = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else global.ScheduleSync = API;
+  console.log('§SCHEDULE_SYNC_LOADED v1');
+})(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v713';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v714';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -139,6 +139,7 @@ const PRECACHE_ASSETS = [
   'time_machine.js',
   'schedule_author.js',
   'schedule_author_ui.js',
+  'schedule_sync.js',
   'schedule_editor.html',
   'schedule_editor_ui.js',
   'error_reporter.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -885,14 +885,15 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="schedule_author.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context
      as surface 'viewer' — selection/timeline/identity over the one signed op-log. Opt-in (toggle / ?connect=1). -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
-<script src="main.js?v=44"></script>
+<script src="main.js?v=45"></script>
 <!-- Styled tooltip bubbles for [data-trl-title] buttons — appended to body, not clipped by overflow:hidden -->
 <style>#ootb-tip{display:none;position:fixed;z-index:9990;background:rgba(10,10,30,0.92);color:#4fc3f7;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid rgba(79,195,247,0.35);pointer-events:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.4)}</style>
 <script>


### PR DESCRIPTION
## §SE-4 — live cross-surface sync: "both are folds of one log"

The §SE-D payoff that crowns the §SE arc: an edit in the Schedule Editor tab propagates **live** to any other open surface. Each surface has its own in-memory sql.js db (no shared store), so the clean mechanism is to **replay the broadcast op on the receiver's db via the same `ScheduleAuthor` verb the sender used** — the broadcast *is* the signed op, re-folded on the receiver. One-way edit→watch MVP; bidirectional is free (symmetric folds). No leveling (§SE-B).

### Module — `viewer/schedule_sync.js`
- `applyOp(db, op)` — **pure** replay: dispatch one op to the matching verb (`move`→moveTask, `add`→addDependency, `remove`→removeDependency, `retype`/`lag`→updateDependency, `cpm`→computeCpm).
- `create({tabId?})` → `{tabId, emit, listen, close}` over `BroadcastChannel('bim_4d')` (`type:'4D_SCHED_EDIT'`); `emit` tags `from:tabId`, `listen` echo-guards own ops then replays inbound on `db` and calls `onApplied` to re-render.

### Wiring
- **Editor** (`schedule_editor_ui.js`): route `broadcast()` through `sync.emit` + `sync.listen` → a **second editor tab re-folds live**.
- **Viewer** (`viewer.html` loads the module; `main.js` S240 handles `4D_SCHED_EDIT`): replays the op on `APP.db` and, if Time Machine is open, re-folds via the shipped `toggleTimeMachine()` off→on (same path the authoring wizard's Apply-to-4D uses). **Safe-additive** — an op whose task isn't in this db is a graceful no-op.

### Witnesses
- **W-SCHED-SYNC 11/11** (node, two real SampleHouse dbs) — replay move/add/remove/retype/lag/cpm sender→receiver → **byte-identical convergence** each step; unknown op fails closed; echo-guard.
- **§SE-SYNC-SMOKE 5/5** (**two headless tabs, real BroadcastChannel**) — drag a bar in tab-A → tab-B receives + replays the op, its bar moves **live** (Jan-01→Jan-21); drag-to-link in A creates the dep in B.
- **W-SCHED-EDIT 19/19** + **W-SCHED-CPM 10/10** + **W-SCHED-MOVE 7/7** still green.

`sw.js` v713→v714 (precache `schedule_sync.js`); `viewer.html` main.js v44→v45.

### §SE arc — COMPLETE
Steps 1–5 (WBS → deps → CPM → critical-path → interactive Gantt) + §SE-D live cross-surface sync. A real interactive web Gantt on one signed op-log, where every edit folds live across surfaces — the thing neither Bonsai (not signed) nor MS Project (no model/cost/ERP) has. **Refused, out of scope:** resource leveling / optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)