### PR TITLE
feat(time-machine): ↗ Editor button — open the full Schedule Editor from the TM

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v715';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v716';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1840,6 +1840,7 @@
         '<button id="tm-gantt" style="font-size:12px;padding:2px 6px" title="Gantt chart">&#x1F4CA;</button>' +
         '<button id="tm-author" style="font-size:12px;padding:2px 6px" title="Author 4D schedule — build phases up, assign elements, tune dates">&#9998;</button>' +
         '<button id="tm-whatif" style="font-size:12px;padding:2px 6px" title="What-if: slip a phase, watch the chain re-fold in blue">&#9094;</button>' +
+        '<button id="tm-editor" style="font-size:11px;padding:2px 6px" title="Open the full Schedule Editor in a new tab — expandable WBS, dependencies, critical path (CPM) and interactive drag-Gantt">&#8599; Editor</button>' +
         '<button id="tm-dash" style="font-size:12px;padding:2px 6px" title="Dashboard">&#x1F4CB;</button>' +
         '<button id="tm-var" style="font-size:13px;padding:2px 6px;display:none" title="Budget vs Actual variance">&#x2696;</button>' +
         '<span id="tm-big-counter" style="flex:1;font-size:18px;font-weight:bold;color:#4fc3f7;text-align:center;letter-spacing:1px">DAY 0 | HR 0</span>' +
@@ -1942,6 +1943,20 @@
       e.stopPropagation();
       if (window.WhatIfPanel) window.WhatIfPanel.open();
       else { var s = document.getElementById('tm-status'); if (s) s.textContent = 'What-if engine not loaded'; }
+    });
+    // §SE-C: open the full Schedule Editor (WBS · dependencies · CPM · drag-Gantt) in its own tab,
+    // carrying the current building's DB so it edits the SAME model. The TM is the schedule hub; the
+    // power tool lives on a separate surface (front visual stays light).
+    var _editor = document.getElementById('tm-editor');
+    if (_editor) _editor.addEventListener('pointerup', function(e) {
+      e.stopPropagation();
+      var a = A();
+      var dburl = (a && a.DB_URL) ? a.DB_URL : (new URL(location.href)).searchParams.get('db');
+      var u = new URL('schedule_editor.html', location.href);
+      if (dburl) u.searchParams.set('db', dburl);
+      window.open(u.toString(), '_blank');
+      var s = document.getElementById('tm-status'); if (s) s.textContent = 'Schedule Editor opened in a new tab';
+      console.log('§TIME_MACHINE open schedule_editor db=' + (dburl || '(default)'));
     });
 
     // Transport buttons

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -884,7 +884,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=57" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=58" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>


### PR DESCRIPTION
## The missing entry point

The Schedule Editor (`viewer/schedule_editor.html`, §SE arc #503–506) was live but **reachable only by URL** — no button anywhere in the app opened it. The Time Machine is the schedule hub (it already owns **✎ Author** and **⑂ What-if**), so the full editor's launch belongs there.

- New **`↗ Editor`** button next to ✎/⑂ → opens `schedule_editor.html` in a new tab, carrying the current building's DB (`A.DB_URL`, or the page's `?db=`) so it edits the **same** model. URL resolved with `new URL(…, location.href)` so it works under `/viewer/` and on OCI/GH-Pages.
- Mirrors the proven ✎/⑂ `pointerup` wiring exactly; the front visual stays light, the power tool is a separate surface (§SE-C).

### Witness
**§BTN-SMOKE 4/4** (headless viewer boot, real SampleHouse): Time Machine opens → `#tm-editor` exists, labeled "↗ Editor" → click opens `schedule_editor.html` with the `?db=` param (`§TIME_MACHINE` log confirms).

`time_machine.js` v57→v58; `sw.js` v715→v716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)