### PR TITLE
feat(find): surface existing Project Order link (no re-create) — additive, for review

### DIFF
--- a/erp/tests/find_openlink_witness.js
+++ b/erp/tests/find_openlink_witness.js
@@ -1,0 +1,64 @@
+// find_openlink_witness.js — W-FIND-OPENLINK (prompts/FIND_OPENLINK_EXISTING_ORDERLINE.md)
+//
+// ISSUE PROVED: the Find panel's existing-order detection (_surfaceExistingOrder) finds a folded
+// C_Project for a building via the SAME query the shipped code runs, and builds the SAME deep-link URL
+// _pushToErp uses — so a building that already IS a Project Order surfaces the "open ↗" link (no
+// re-create), while a non-folded building does not. Non-invent: the SQL + URL template are EXTRACTED
+// VERBATIM from viewer/navigate_find.js and run against the REAL erp/ad_seed.db. Whitebox §-log only.
+// Additive-safety is the design (guarded async, never touches cost/push/navigate) — this proves the
+// detection logic the link depends on.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var ROOT = path.resolve(__dirname, '..', '..');            // worktree root
+var NF = path.join(ROOT, 'viewer', 'navigate_find.js');
+var SEED = path.join(ROOT, 'erp', 'ad_seed.db');
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-FIND-OPENLINK PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-FIND-OPENLINK FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+// Extract the EXACT detection SQL + URL template the shipped _surfaceExistingOrder uses (non-invent).
+var src = fs.readFileSync(NF, 'utf8');
+var sqlM = src.match(/db\.exec\("(SELECT C_Project_ID FROM C_Project WHERE Value=\?)"/);
+var urlM = src.match(/'(\.\.\/erp\/idempiere\.html\?client=garden&window=130&record=)'/);
+check('extract-detection-sql', !!sqlM, sqlM ? sqlM[1] : 'NOT FOUND in navigate_find.js');
+check('extract-url-template', !!urlM, urlM ? urlM[1] : 'NOT FOUND in navigate_find.js');
+var DETECT_SQL = sqlM ? sqlM[1] : null;
+var URL_TPL = urlM ? urlM[1] : null;
+// the surfacing function must be wired into the selection hook and guarded
+check('wired-into-selection-hook', /_surfaceExistingOrder\(set\)/.test(src), 'called from _updateSelCost');
+check('guarded-additive', /never impact Find|additive — never impact Find/.test(src), 'try/catch + catch guards present');
+check('reuses-ensureErpDb', /_surfaceExistingOrder[\s\S]{0,400}_ensureErpDb\(\)/.test(src), 'reuses the proven lazy loader');
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(SEED)));
+
+  function detect(building) {
+    var r = db.exec(DETECT_SQL, [building]);
+    return (r.length && r[0].values.length) ? r[0].values[0][0] : null;
+  }
+
+  // Hospital IS a folded Project Order in the seed (C_Project Value='Hospital', id 990000).
+  var pidH = detect('Hospital');
+  check('folded-building-detected', pidH === 990000, 'Hospital -> C_Project_ID=' + pidH);
+  // The link the Find panel would surface, built from the SAME template + pid.
+  var url = URL_TPL + encodeURIComponent(pidH);
+  check('builds-correct-deeplink', url === '../erp/idempiere.html?client=garden&window=130&record=990000', 'url=' + url);
+
+  // A building with no folded project → null → no link surfaced (create-push stays, untouched).
+  var pidNone = detect('NoSuchBuilding_XYZ');
+  check('unfolded-building-no-link', pidNone === null, 'NoSuchBuilding -> ' + pidNone);
+
+  // The link target window is 130 (C_Project) — same as the post-push deep-link, so "open existing" and
+  // "open just-created" land on the identical record surface (consistency).
+  check('same-window-as-push-link', /window=130/.test(URL_TPL), 'url template = ' + URL_TPL);
+
+  console.log('§W-FIND-OPENLINK RESULT ' + pass + '/' + (pass + fail));
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(function (e) { console.error('§W-FIND-OPENLINK ERROR', e); process.exit(2); });

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -135,7 +135,7 @@ async function initViewer() {
       }
       // Load sub-modules in dependency order, then the bootstrap
       var modules = [
-        'navigate_find.js?v=42',
+        'navigate_find.js?v=43',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -989,7 +989,12 @@
       _lastSelSet = (set && set.size) ? set : null;            // remember selection for the > to ERP push
       _lastSelLabel = scopeLabel || '';
       // selection changed → any prior push's deep-link is now stale; hide it until this set is pushed
-      if (elErpOpen) { elErpOpen.style.display = 'none'; elErpOpen.removeAttribute('href'); }
+      if (elErpOpen) { elErpOpen.style.display = 'none'; elErpOpen.removeAttribute('href'); elErpOpen.title = 'Open the created Project Order in iDempiere (GardenWorld)'; }
+      var _eb0 = document.getElementById('find-erp-btn'); if (_eb0) _eb0.title = 'Push selection to ERP as a Project Order';
+      // BIM→Project (find-erp-deeplink): purely-additive — if this building is ALREADY a folded Project
+      // Order, surface the "open ↗" link to it on selection so the user opens the existing order instead
+      // of re-creating it. Guarded + async; cannot affect cost/push/navigate (user: don't impact Find).
+      try { _surfaceExistingOrder(set); } catch (e) {}
       var el = document.getElementById('find-selected-cost');
       if (!el) return;
       try {
@@ -1054,6 +1059,32 @@
         }
         return { building: building, projectId: pid, ifcClass: ifcClass, project: proj, line: line, phase: phase };
       }).catch(function (e) { console.log('§ZOOM-COST err=' + e.message); return null; });
+    }
+    // BIM→Project (find-erp-deeplink): when the active building ALREADY has a folded C_Project, surface
+    // the existing "open ↗" deep-link on selection — so the user opens that Project Order rather than
+    // re-creating it. PURELY ADDITIVE: reuses the proven _ensureErpDb + the same record URL _pushToErp
+    // builds; only sets the elErpOpen link + tooltips; wrapped so it can NEVER affect cost/push/navigate.
+    // (Slice-1 grain = project-level: the link opens the building's C_Project, window 130. Per-line/guid
+    //  precision + the OPFS cross-session store are noted follow-ups in FIND_OPENLINK_EXISTING_ORDERLINE.md.)
+    function _surfaceExistingOrder(set) {
+      if (!elErpOpen || !set || !set.size) return;
+      var mySet = set;                                   // race guard — selection may change before resolve
+      _ensureErpDb().then(function (db) {
+        if (!db || mySet !== _lastSelSet) return;        // db not available, or selection moved on
+        var pid = null;
+        try {
+          var r = db.exec("SELECT C_Project_ID FROM C_Project WHERE Value=?", [A.activeBuilding]);
+          pid = (r.length && r[0].values.length) ? r[0].values[0][0] : null;
+        } catch (e) { return; }
+        if (pid == null) return;                          // building not folded yet → keep create-push as-is
+        var url = '../erp/idempiere.html?client=garden&window=130&record=' + encodeURIComponent(pid);
+        elErpOpen.setAttribute('href', url);
+        elErpOpen.style.display = 'inline-block';
+        elErpOpen.title = 'Already in a Project Order — open it (no need to push again)';
+        var btn = document.getElementById('find-erp-btn');
+        if (btn) btn.title = 'Already a Project Order — use the “open ↗” link, or push to add more';
+        console.log('[RP-C] §PROJ_LINK_EXISTING building="' + A.activeBuilding + '" project=' + pid + ' url=' + url);
+      }).catch(function () { /* additive — never impact Find */ });
     }
     function _pct(planned, committed) { return planned > 0 ? Math.round((committed - planned) * 100 / planned) : 0; }
     function _showClassCost(ifcClass, matchCount, guid) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v719';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v720';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Find panel: "open ↗" to the existing Project Order instead of re-creating it

**Request:** when an element's counterpart already exists as a Project Order Line, the Find panel should show an **open-link** to that order — so you don't create what was created before, you just go to it.

**Why it was easy:** the rails already existed — the `#find-erp-open` "open ↗" element (it surfaces after a push), the `_ensureErpDb`/project lookup, and the record deep-link URL. This slice just **surfaces that link on selection** when the building is already a folded `C_Project`.

### Purely additive — does NOT touch cost / push / navigate
*(explicitly per "be careful not to impact the Find Panel")*
- New `_surfaceExistingOrder(set)` called from the **existing** selection hook `_updateSelCost`. Reuses the proven `_ensureErpDb`; runs the **same** project lookup and builds the **same** `…window=130&record=<C_Project_ID>` URL that `_pushToErp` uses — so "open existing" and "open just-created" land on the identical record.
- **Guarded:** `try/catch` at the call site + `.catch` in the async body; a race guard (`mySet === _lastSelSet`) drops stale resolves; any error is a silent no-op. The hook also **resets** the link + tooltips each selection change so nothing goes stale.
- The `› ERP` create path is **unchanged**. Building not folded → behaviour identical to before.

### Witness
**W-FIND-OPENLINK 9/9** (node, **real** `erp/ad_seed.db`; SQL + URL extracted **verbatim** from `navigate_find.js`): `Hospital` → `C_Project_ID 990000` → builds `record=990000` deep-link; an unfolded building → `null` → no link (create-push untouched); plus wired-into-hook + guarded + reuses-loader assertions.

### Scope (slice-1)
Grain = **project-level** (the link opens the building's `C_Project`, window 130). Follow-ups noted in `prompts/FIND_OPENLINK_EXISTING_ORDERLINE.md`: per-line/guid precision, and reading the OPFS `bim_project_orders.db` so **prior-session** pushes are detected after reload (today: pre-baked projects + same-session pushes are detected, since `_ensureErpDb` caches the mutated db).

`main.js` navigate_find `?v=42→43`; `sw.js` v719→v720.

**Not auto-merged / not deployed** — opened for your review of the Find-panel change. Suggested eyeball: open the **Hospital** model → Find → select a type → the **open ↗** link appears (→ record 990000) without pushing; confirm cost / › ERP / ▶ still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)