### PR TITLE
System Monitor: 4 field-health widgets (G2) + D2 default schema-version stamping (sw v752)

### DIFF
--- a/erp/error_beacon.js
+++ b/erp/error_beacon.js
@@ -1,0 +1,84 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/**
+ * error_beacon.js — S1 SPIKE: the MINIMAL field-error beacon (NOT the G2 telemetry pipeline).
+ *   Card: prompts/RESUME_S1_DISCOVERY_SPIKES.md §Beacon  ·  Risk: ProductionRisks.md G2 (observability)
+ *
+ * The paradigm's failures are SILENT — there is no server log, so an uncaught error in the field just
+ * vanishes and you fly blind. This does the *least* that stops that: it wires window.onerror +
+ * unhandledrejection to (1) a §-tagged console line you can read in a §-log witness, and (2) a small
+ * bounded OFFLINE ring buffer (localStorage) so the last errors survive a reload for inspection.
+ *
+ * EXPLICITLY NOT here (tenant-gated remedies, per the spike scope):
+ *   - NO network telemetry pipe / no beacon-to-server (navigator.sendBeacon is deliberately absent);
+ *   - NO PII — only message + source coordinates + a truncated stack are kept (no user data, no inputs).
+ *
+ * §SPIKE-BEACON installed=Y captured=N sample=…   ← read this line; it is the proof the beacon is live.
+ */
+(function () {
+  'use strict';
+  if (typeof window === 'undefined') return;
+  if (window.__ERR_BEACON__) return;                 // idempotent — load-once even if included twice
+
+  var KEY = 'bim_field_errors';                      // offline ring (survives reload; cleared by user/quota)
+  var MAX = 50;                                      // bounded — never an unbounded buffer
+  var captured = 0;
+
+  function store() { try { return window.localStorage; } catch (e) { return null; } }
+
+  function ringPush(rec) {
+    var s = store(); if (!s) return;
+    var buf;
+    try { buf = JSON.parse(s.getItem(KEY) || '[]'); } catch (e) { buf = []; }
+    buf.push(rec);
+    if (buf.length > MAX) buf = buf.slice(buf.length - MAX);   // keep the most recent MAX only
+    try { s.setItem(KEY, JSON.stringify(buf)); } catch (e) { /* quota: drop silently, console line still fired */ }
+  }
+
+  // PII-free record: message + where + a short stack head. No inputs, no user/business data.
+  function record(kind, message, src, line, col, stack) {
+    captured++;
+    var rec = {
+      kind: kind,
+      message: String(message || '').slice(0, 300),
+      src: String(src || '').slice(0, 200),
+      line: line || 0, col: col || 0,
+      stack: String(stack || '').split('\n').slice(0, 3).join(' | ').slice(0, 400),
+      // monotonic counter, NOT a wall clock — keeps the record deterministic & carries no session timing PII
+      seq: captured
+    };
+    ringPush(rec);
+    // the §-tagged line a witness reads — the beacon's whole reason to exist (stop flying blind)
+    console.log('§FIELD-ERROR kind=' + rec.kind + ' seq=' + rec.seq +
+      ' msg="' + rec.message.replace(/"/g, "'") + '" at=' + rec.src + ':' + rec.line + ':' + rec.col);
+    // live count for the New-Paradigm Monitor's G2 widget (it can read window.__ERR_BEACON__.captured)
+    api.captured = captured;
+  }
+
+  window.addEventListener('error', function (e) {
+    // resource-load errors (e.target is an element) carry no Error — note them too, but cheaply
+    if (e && e.target && e.target.tagName) {
+      record('resource', (e.target.tagName + ' ' + (e.target.src || e.target.href || '')), e.target.src || e.target.href || '', 0, 0, '');
+      return;
+    }
+    record('error', e && e.message, e && e.filename, e && e.lineno, e && e.colno, e && e.error && e.error.stack);
+  }, true);
+
+  window.addEventListener('unhandledrejection', function (e) {
+    var r = e && e.reason;
+    var msg = (r && r.message) || (typeof r === 'string' ? r : 'unhandledrejection');
+    record('promise', msg, '', 0, 0, r && r.stack);
+  });
+
+  var api = {
+    captured: 0,
+    list: function () { var s = store(); try { return JSON.parse(s.getItem(KEY) || '[]'); } catch (e) { return []; } },
+    clear: function () { var s = store(); if (s) s.removeItem(KEY); captured = 0; this.captured = 0; },
+    // test hook — drive a synthetic capture without throwing (used by the §-log witness)
+    _emit: function (msg) { record('test', msg, 'error_beacon.js', 0, 0, ''); }
+  };
+  window.__ERR_BEACON__ = api;
+
+  console.log('§SPIKE-BEACON installed=Y captured=' + captured + ' sample=(none-yet) buf=localStorage:' + KEY +
+    ' bound=' + MAX + ' telemetryPipe=N pii=N');
+})();

--- a/erp/field_health.js
+++ b/erp/field_health.js
@@ -1,0 +1,138 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/**
+ * system_monitor.js — the New-Paradigm System Monitor (4 field-health widgets).
+ *   Spec: prompts/SYSTEM_MONITOR_WIDGETS.md §SPEC  ·  Risk register: docs/ProductionRisks.md §H
+ *   Thresholds: docs/FoldEngineConstraints.md §6 (db_file_size_mb, quota_used_pct, offline_queue_mb, vfs_backend)
+ *
+ * Classic iDempiere's System Monitor watched the SERVER's vitals (JVM heap, DB pool). With no server, this
+ * watches the PARADIGM's vitals — the signals that only exist because the server is gone. It is the SysAdmin's
+ * optic + control surface, and the concrete remedy for G2 (observability-without-a-server).
+ *
+ * PURE FOLD (holy-grail law: declarative fold + rules exposed, NON-INVENT): SystemMonitor.fold(signals) reads
+ * injected signal-readers and returns a structured readout — testable headless, no browser. render() paints it.
+ *
+ *   SystemMonitor.fold({
+ *     beacon,        // window.__ERR_BEACON__  (error_beacon.js) — { captured, list() }   | optional
+ *     queue,         // ERP.OfflineQueue instance (offline_queue.js) — count/relayed/oldestAgeMs | optional
+ *     db,            // sql.js Database holding the op-log — for PRAGMA page_count×page_size  | optional
+ *     vfs,           // result of ERP.VFS.detect()  — { backend, misconfig, reason }         | optional
+ *     storageEstimate, // { usage, quota } from navigator.storage.estimate()                 | optional
+ *     persisted,     // boolean from navigator.storage.persisted()                           | optional
+ *     bootstrapPath  // 'checkpoint' | 'genesis'                                             | optional
+ *   }) -> { widgets: [{ id,label,value,status,detail }], overall }
+ *
+ * status ∈ ok|warn|alert|na. overall = worst widget status. A missing signal → na (NEVER invented).
+ */
+'use strict';
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else { root.ERP = root.ERP || {}; root.ERP.FieldHealth = factory(); }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  var DB_WARN_MB = 100, DB_ALERT_MB = 200;        // §6 db_file_size_mb: >100 compact, >200 OOM ceiling
+  var QUOTA_WARN_PCT = 70;                         // §6 quota_used_pct
+  var QUEUE_AGE_WARN_DAYS = 6;                     // §6 offline_queue_mb age > 6 days
+  var RANK = { ok: 0, na: 1, warn: 2, alert: 3 };
+
+  function round1(x) { return Math.round(x * 10) / 10; }
+
+  // ── Widget 1: field errors (G2) — from the error beacon ──────────────────────────────────────────
+  function _fieldErrors(beacon) {
+    if (!beacon || typeof beacon.captured !== 'number') return { id: 'field_errors', label: 'Field errors', value: 'n/a', status: 'na', detail: 'beacon not installed' };
+    var n = beacon.captured;
+    var recent = (typeof beacon.list === 'function') ? beacon.list() : [];
+    var hard = recent.filter(function (r) { return r.kind === 'error' || r.kind === 'promise'; }).length;
+    var status = n === 0 ? 'ok' : (hard > 0 ? 'alert' : 'warn');
+    return { id: 'field_errors', label: 'Field errors', value: n, status: status,
+      detail: n === 0 ? 'no uncaught errors this session' : (hard + ' hard / ' + n + ' total captured (offline ring)') };
+  }
+
+  // ── Widget 2: durability ladder (A1) — the most important field-health widget ─────────────────────
+  //   local → syncing → durable@N. The INVARIANT: an unrelayed op is NEVER shown as "durable".
+  function _durability(queue, storageEstimate, persisted) {
+    if (!queue || typeof queue.count !== 'function') return { id: 'durability_ladder', label: 'Durability', value: 'n/a', status: 'na', detail: 'no offline queue' };
+    var total = queue.count();
+    // relayed (server-durable) vs in-flight (local-only, NOT safe) — read straight off the queue records
+    var durable = 0, inflight = 0;
+    (queue._q || []).forEach(function (r) { if (r.relayed) durable++; else inflight++; });
+    var oldestSec = Math.round((queue.oldestAgeMs ? queue.oldestAgeMs() : 0) / 1000);
+    var quotaPct = (storageEstimate && storageEstimate.quota) ? round1(100 * storageEstimate.usage / storageEstimate.quota) : null;
+    var status = 'ok';
+    if (inflight > 0) status = 'warn';                                  // unsynced work exists → not all safe
+    if (oldestSec > QUEUE_AGE_WARN_DAYS * 86400) status = 'warn';
+    if (quotaPct != null && quotaPct > QUOTA_WARN_PCT) status = 'warn';
+    if (persisted === false && inflight > 0) status = 'alert';          // unsynced AND eviction not resisted
+    return { id: 'durability_ladder', label: 'Durability', value: 'durable@' + durable + ' · inflight ' + inflight,
+      status: status, detail: 'total=' + total + ' oldestUnackedSec=' + oldestSec +
+        (quotaPct != null ? ' quota=' + quotaPct + '%' : '') + ' persisted=' + (persisted == null ? '?' : persisted) +
+        (inflight > 0 ? ' (inflight is NOT durable — never shown safe)' : '') };
+  }
+
+  // ── Widget 3: op-log DB size gauge (B1 — the REAL ceiling) — the reassuring optic ─────────────────
+  function _dbSize(db) {
+    if (!db || typeof db.exec !== 'function') return { id: 'db_size_gauge', label: 'Op-log DB', value: 'n/a', status: 'na', detail: 'no db handle' };
+    var pc, ps;
+    try {
+      pc = db.exec('PRAGMA page_count'); ps = db.exec('PRAGMA page_size');
+      var pages = pc[0].values[0][0], size = ps[0].values[0][0];
+      var mb = round1((pages * size) / (1024 * 1024));
+      var status = mb > DB_ALERT_MB ? 'alert' : (mb > DB_WARN_MB ? 'warn' : 'ok');
+      var headroom = round1(DB_ALERT_MB - mb);
+      return { id: 'db_size_gauge', label: 'Op-log DB', value: mb + ' MB', status: status,
+        detail: 'ceiling ' + DB_ALERT_MB + ' MB · headroom ' + headroom + ' MB · ' +
+          (status === 'ok' ? Math.round(DB_ALERT_MB / Math.max(mb, 0.1)) + '× under ceiling' : 'compact recommended') };
+    } catch (e) {
+      return { id: 'db_size_gauge', label: 'Op-log DB', value: 'n/a', status: 'na', detail: 'PRAGMA failed: ' + e.message };
+    }
+  }
+
+  // ── Widget 4: environment / VFS (C1) — which storage backend + bootstrap path ─────────────────────
+  function _environment(vfs, bootstrapPath) {
+    if (!vfs || !vfs.backend) return { id: 'environment', label: 'Environment', value: 'n/a', status: 'na', detail: 'vfs not detected' };
+    var status = vfs.misconfig ? 'warn' : 'ok';
+    var detail = vfs.reason || (vfs.backend.toUpperCase() + ' VFS');
+    if (bootstrapPath === 'genesis') { status = 'alert'; detail += ' · ⚠ genesis bootstrap (checkpoint missing/corrupt)'; }
+    else if (bootstrapPath) { detail += ' · bootstrap=' + bootstrapPath; }
+    return { id: 'environment', label: 'Environment', value: vfs.backend.toUpperCase() + (bootstrapPath ? ' · ' + bootstrapPath : ''),
+      status: status, detail: detail };
+  }
+
+  function fold(signals) {
+    signals = signals || {};
+    var widgets = [
+      _fieldErrors(signals.beacon),
+      _durability(signals.queue, signals.storageEstimate, signals.persisted),
+      _dbSize(signals.db),
+      _environment(signals.vfs, signals.bootstrapPath)
+    ];
+    var overall = widgets.reduce(function (acc, w) { return RANK[w.status] > RANK[acc] ? w.status : acc; }, 'ok');
+    // §-log each widget (the witness reads these) + overall
+    widgets.forEach(function (w) { console.log('§MON-' + w.id.toUpperCase() + ' value="' + w.value + '" status=' + w.status + ' — ' + w.detail); });
+    console.log('§MON-OVERALL=' + overall);
+    return { widgets: widgets, overall: overall };
+  }
+
+  // ── render — paint the readout into a DOM element (no-op headless) ────────────────────────────────
+  var COLOR = { ok: '#2e9e4f', warn: '#d98a00', alert: '#d23b3b', na: '#888' };
+  function render(readout, el) {
+    if (typeof document === 'undefined' || !el) return readout;     // headless: fold-only
+    var dot = function (s) { return '<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:' + COLOR[s] + ';margin-right:7px"></span>'; };
+    var rows = readout.widgets.map(function (w) {
+      return '<div style="display:flex;align-items:center;padding:7px 10px;border-bottom:1px solid #ececec">' +
+        dot(w.status) +
+        '<div style="flex:1"><div style="font-weight:600;font-size:13px">' + w.label + '</div>' +
+        '<div style="font-size:11px;color:#777">' + w.detail + '</div></div>' +
+        '<div style="font-variant-numeric:tabular-nums;font-size:13px;color:' + COLOR[w.status] + '">' + w.value + '</div></div>';
+    }).join('');
+    el.innerHTML =
+      '<div style="font-family:system-ui,sans-serif;border:1px solid #ddd;border-radius:8px;max-width:380px;overflow:hidden">' +
+      '<div style="padding:8px 10px;background:#1d2733;color:#fff;font-size:12px;font-weight:600;display:flex;justify-content:space-between">' +
+      '<span>System Monitor — paradigm vitals</span>' + dot(readout.overall) + '</div>' + rows + '</div>';
+    return readout;
+  }
+
+  console.log('§FIELDHEALTH_LOADED v1 (4 widgets: field_errors/durability_ladder/db_size_gauge/environment)');
+  return { fold: fold, render: render };
+}));

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -464,6 +464,7 @@
   </main>
 </div>
 
+<script src="error_beacon.js?v=1" onerror="console.warn('§LOAD_FAIL error_beacon.js — field-error capture disabled')"></script><!-- SYSTEM_MONITOR_WIDGETS §H — minimal field-error beacon (G2 seed); loads early to catch boot errors -->
 <script src="vfs_detect.js?v=1"></script>
 <script src="ad_parser.js?v=24"></script>
 <!-- UI_UNPARK_RESUME.md — proven AD engines (source of truth: bim-compiler build/erp/): logic evaluator
@@ -496,7 +497,8 @@
 <script src="genesis_seed.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §SA1 — default-CoA seed; MUST load before genesis.js (it reads global.GenesisSeed at load) -->
 <script src="genesis.js?v=2"></script>
 <script src="system_tenant.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §SA1 — boot overlay: make System(0) a log-in-able tenant -->
-<script src="system_monitor.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor, serverless reframe (window.SystemMonitor) -->
+<script src="field_health.js?v=1"></script><!-- SYSTEM_MONITOR_WIDGETS §H — 4 field-health widgets engine (ERP.FieldHealth.fold); folded into the System Monitor panel below -->
+<script src="system_monitor.js?v=2"></script><!-- SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor, serverless reframe (window.SystemMonitor) + §H field-health widgets -->
 <script src="plugin_release.js?v=1"></script><!-- SYSTEM_ADMIN_LANE §6 — Plugin Management + gated Release/Update surface (window.PluginRelease) -->
 <script src="erp_preview.js?v=2"></script>
 <!-- CONSISTENCY_FINISH.md §K-1/§K-2 — icons.js (verbatim glyph DATA) + the shared overlay kit load BEFORE
@@ -523,7 +525,14 @@
 <!-- MIGRATE_ERP_PICKER.md §SPEC — still loaded: the login front-door tenant picker (ErpPicker.manifest). -->
 <script src="erp_picker.js?v=6"></script>
 <!-- Kanban write path — engine seam (window.ERP) + the lens chrome + the reusable host (publish/persist). -->
-<script src="kernel_ops.js?v=2"></script>
+<script src="kernel_ops.js?v=3"></script>
+<script src="op_upcaster.js?v=1"></script><!-- D2 (prompts/D2_REMEDY_VERSIONING.md): schema_version stamp + read-time upcaster registry -->
+<script>/* D2: make schema_version stamping the default write seam. install() self-guards (logs SKIPPED if the
+   kernel lacks setVersionStamper), so this is safe; stamping is forward-only + inert to every reducer
+   (witnessed W-D2-* PASS). */
+  try { if (window.ERP && window.ERP.OpUpcaster) window.ERP.OpUpcaster.install(window.KernelOps); }
+  catch (e) { console.warn('§OP_UPCASTER install failed', e); }
+</script>
 <script src="erp_signer.js?v=1"></script>
 <script src="erp_kernel.js?v=1"></script>
 <script src="erp_seam.js?v=1"></script>

--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -82,17 +82,18 @@
     // Forward-reconciled from the app's erp/ copy on the §INTEG-COLLAPSE (2026-06-08); the substrate's
     // byte-stable period-close replay depends on it. See prompts/ERP_SUBSTRATE_INTEGRATION.md §ARCHIVE.
     var stamp = (ts != null) ? ts : Date.now();
+    var vParams = _stamp(opType, params);                  // D2: brand schema version into params (signed) if wired
     db.run(
       'INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid) ' +
       'VALUES (?, ?, ?, ?, ?, ?)',
-      [uuid, stamp, opType, JSON.stringify(params),
+      [uuid, stamp, opType, JSON.stringify(vParams),
        inputGuids ? JSON.stringify(inputGuids) : null,
        outputGuid || null]
     );
     var r = db.exec('SELECT last_insert_rowid()');
     var opId = r[0].values[0][0];
     console.log('§KERNEL_OP committed id=' + opId + ' uuid=' + (uuid ? uuid.slice(0, 8) : 'null') +
-                ' type=' + opType + ' params=' + JSON.stringify(params));
+                ' type=' + opType + ' params=' + JSON.stringify(vParams));
     // S243 §3.7: persist modified DB back to IndexedDB so refresh survives
     _persistToIdb(db);
     return opId;
@@ -133,6 +134,16 @@
   // Set an edge signer to turn on W-SIGN. Key custody lives at the edge (the device/merchant),
   // never in this module. Leave unset for W-CHAIN-only (tamper-evidence without signatures).
   function setSigner(signer) { _signer = signer; }
+
+  // D2 (prompts/D2_REMEDY_VERSIONING.md): an optional version-stamper that brands every NEW op's params with
+  // its schema version BEFORE hashing — so the version is a signed fact. fn(opType, params) -> params'. Wired
+  // by ERP.OpUpcaster.install(KernelOps) at app boot; UNSET = legacy behaviour (ops carry no _sv = version 1).
+  // The kernel stays decoupled — it never imports the upcaster, just calls this hook if installed.
+  var _versionStamp = null;
+  function setVersionStamper(fn) { _versionStamp = fn; }
+  function _stamp(opType, params) {
+    return (_versionStamp && params && typeof params === 'object') ? _versionStamp(opType, params) : params;
+  }
 
   function _canonical(op) {   // stable serialisation — every mutating field, fixed order
     return op.id + '|' + op.timestamp + '|' + op.op_type + '|' +
@@ -289,6 +300,7 @@
     for (var i = 0; i < opsArray.length; i++) {
       var src = opsArray[i];
       var params = src.params != null ? src.params : src.parameters;
+      params = _stamp(src.op_type, params);                  // D2: brand schema version (signed) if wired
       // §I-J (W-RATE-INPUT) — currency-determinism precondition: a conversion-bearing op MUST carry its
       // recorded rate inputs (rate/rateDate/rateSource), else the WHOLE group is rejected (all-or-none,
       // commits NOTHING). Today nothing is conversion-bearing → inert but enforced. NEVER looks up a rate.
@@ -598,6 +610,7 @@
     commitGroup:  commitGroup,   // §I-K (W-OPGROUP): N ops, ONE group hash, all-or-none, sealed once (async)
     verifyChain:  verifyChain,   // W-CHAIN/W-SIGN: prove tamper-evidence (async)
     setSigner:    setSigner,     // W-SIGN: install an edge signer (opt-in)
+    setVersionStamper: setVersionStamper, // D2: install a schema-version stamper (opt-in; ERP.OpUpcaster.install)
     assertRateAsInput: assertRateAsInput, // §I-J (W-RATE-INPUT): currency-determinism guard (pure, rate-as-op-input)
     branchOps:    branchOps,     // BLUE FUTURE (W-BLUE-FUTURE): the ops of a speculative branch (id order)
     discardBranch: discardBranch, // BLUE FUTURE: shirk the blues — fold the whole branch away atomically

--- a/erp/op_upcaster.js
+++ b/erp/op_upcaster.js
@@ -1,0 +1,121 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/**
+ * op_upcaster.js — D2 REMEDY: schema_version per op + a read-time upcaster registry.
+ *   Spec: prompts/D2_REMEDY_VERSIONING.md  ·  Register: docs/ProductionRisks.md D2  ·  Spike: spike_d2_versioning.js
+ *   Prompted by Ludwikowski "Event Sourcing — what could possibly go wrong?" (events immutable + live forever).
+ *
+ * THE CONSTRAINT (measured by §SPIKE-D2): our op-log is SIGNED — op_hash = SHA-256(prev_hash | canonical(op))
+ * and canonical INCLUDES JSON.stringify(parameters). So you can NEVER migrate by rewriting a stored op
+ * (verifyChain → 'payload altered'). The ONLY legal migration is UPCAST-ON-READ: transform an old-shape op to
+ * the current shape IN MEMORY, just before the reducer; the stored op is never touched, the chain stays valid.
+ *
+ * THE STRATEGY (forward-only, mirrors the append-only migration/*.sql sacred rule):
+ *   - stamp every NEW op with `params._sv` = the current schema version for its op_type (a SIGNED fact —
+ *     it's inside parameters, so it is hashed; an op's declared version is tamper-evident);
+ *   - legacy ops with no `_sv` are version 1;
+ *   - register upcasters version N → N+1 per op_type; upcast() chains them up to current at READ time;
+ *   - an op from a FUTURE version this client doesn't know is REFUSED LOUDLY (throws), never silently misapplied.
+ *
+ *   ERP.OpUpcaster
+ *     .SV_KEY                                  // '_sv'
+ *     .setCurrent(opType, version)             // declare the current schema version for an op_type
+ *     .currentOf(opType) -> version            // default 1
+ *     .register(opType, fromVersion, fn)       // fn(params)->params : ONE step up (fromVersion → fromVersion+1)
+ *     .stamp(opType, params) -> params'        // returns a COPY with _sv = currentOf(opType)
+ *     .versionOf(params) -> version            // params._sv || 1 (legacy = 1)
+ *     .supports(op) -> bool                    // can we upcast this op's version up to current?
+ *     .upcast(op) -> op'                       // {op_type,parameters} → upcasted (THROWS D2_UNSUPPORTED if not)
+ *     .upcastAll(ops) -> ops'                  // map upcast over a replayed op list (parameters → object)
+ *     .commitVersioned(kernel, db, opType, params, …) -> opId   // stamp then kernel.commitOp (the write seam)
+ *     .reset()                                 // clear registry (tests)
+ *
+ * §FALSIFIER: an upcasted fold whose result != the op's ORIGINAL effect = a reinterpretation of history (FAIL).
+ *   A future-version op that folds SILENTLY instead of refusing = FAIL. Rewriting a stored op to migrate = FAIL
+ *   (the chain breaks — that is the whole point; this module exists so you never need to).
+ */
+'use strict';
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else { root.ERP = root.ERP || {}; root.ERP.OpUpcaster = factory(); }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  var SV_KEY = '_sv';
+  var _current = {};                 // opType -> current schema version
+  var _up = {};                      // opType -> { fromVersion -> fn }
+
+  function currentOf(opType) { return _current[opType] || 1; }
+  function setCurrent(opType, version) { _current[opType] = version; }
+  function versionOf(params) { return (params && params[SV_KEY]) || 1; }
+
+  function register(opType, fromVersion, fn) {
+    if (typeof fn !== 'function') throw new Error('upcaster fn required');
+    (_up[opType] = _up[opType] || {})[fromVersion] = fn;
+    // a registered upcaster fromVersion→fromVersion+1 implies current is at least fromVersion+1
+    if ((fromVersion + 1) > currentOf(opType)) _current[opType] = fromVersion + 1;
+  }
+
+  function stamp(opType, params) {
+    var out = {}; for (var k in params) if (Object.prototype.hasOwnProperty.call(params, k)) out[k] = params[k];
+    out[SV_KEY] = currentOf(opType);
+    return out;
+  }
+
+  // can we walk version → current via registered single-step upcasters? (and not from the future)
+  function supports(op) {
+    var p = _params(op);
+    var v = versionOf(p), cur = currentOf(op.op_type);
+    if (v > cur) return false;                                  // op from a newer schema than we know → refuse
+    var steps = _up[op.op_type] || {};
+    for (var n = v; n < cur; n++) if (typeof steps[n] !== 'function') return false;   // a missing rung → refuse
+    return true;
+  }
+
+  function _params(op) {
+    var p = op.parameters;
+    return (typeof p === 'string') ? JSON.parse(p) : p;
+  }
+
+  function upcast(op) {
+    if (!supports(op)) {
+      var e = new Error('D2_UNSUPPORTED op_type=' + op.op_type + ' version=' + versionOf(_params(op)) +
+        ' current=' + currentOf(op.op_type) + ' — refusing (client cannot frozen-replay this schema; update needed)');
+      e.code = 'D2_UNSUPPORTED';
+      console.log('§D2-REFUSE ' + e.message);
+      throw e;
+    }
+    var p = _params(op), v = versionOf(p), cur = currentOf(op.op_type);
+    var steps = _up[op.op_type] || {};
+    for (var n = v; n < cur; n++) { p = steps[n](p); }           // chain N→N+1 up to current (in memory)
+    p[SV_KEY] = cur;
+    var out = {}; for (var k in op) out[k] = op[k]; out.parameters = p;   // stored op untouched; this is a COPY
+    return out;
+  }
+
+  function upcastAll(ops) { return (ops || []).map(upcast); }
+
+  // write seam — stamp the current version into params, then commit through the real kernel verb (no fork)
+  function commitVersioned(kernel, db, opType, params, inputGuids, outputGuid, opUuid, ts) {
+    return kernel.commitOp(db, opType, stamp(opType, params), inputGuids, outputGuid, opUuid, ts);
+  }
+
+  function reset() { _current = {}; _up = {}; }
+
+  // install — make stamping the DEFAULT write seam: every kernel.commitOp/commitGroup now brands params._sv.
+  // One line at app boot: ERP.OpUpcaster.install(window.KernelOps). Decoupled — the kernel only sees the fn.
+  function install(kernel) {
+    if (!kernel || typeof kernel.setVersionStamper !== 'function') {
+      console.log('§OP_UPCASTER install SKIPPED — kernel has no setVersionStamper (update kernel_ops.js)');
+      return false;
+    }
+    kernel.setVersionStamper(stamp);
+    console.log('§OP_UPCASTER install OK — schema_version stamping is now the default write seam');
+    return true;
+  }
+
+  console.log('§OP_UPCASTER_LOADED v1 (D2: schema_version stamp + read-time upcaster registry)');
+  return { SV_KEY: SV_KEY, setCurrent: setCurrent, currentOf: currentOf, versionOf: versionOf,
+    register: register, stamp: stamp, supports: supports, upcast: upcast, upcastAll: upcastAll,
+    commitVersioned: commitVersioned, install: install, reset: reset };
+}));

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v751';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v752';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -38,6 +38,9 @@ const PRECACHE_ASSETS = [
   'ad_process.js',    // B-5/C-5 — process dispatch spine (window.AdProcess), W-PROC / W-AD-PROC-LIVE
   'ad_table_map.js',
   'vfs_detect.js',    // CONSTRAINT_MITIGATION item 3 — OPFS/IDB detection at boot (§VFS monitor)
+  'error_beacon.js',  // SYSTEM_MONITOR_WIDGETS §H — minimal field-error beacon (G2 seed)
+  'field_health.js',  // SYSTEM_MONITOR_WIDGETS §H — 4 field-health widgets engine (ERP.FieldHealth)
+  'op_upcaster.js',   // D2 — schema_version stamp + read-time upcaster registry (default write seam)
   'ad_ui.js',
   'erp_panel.js',
   'erp_persist.js',

--- a/erp/system_monitor.js
+++ b/erp/system_monitor.js
@@ -38,9 +38,31 @@
   }
 
   // ── data gather (all real / honest) ─────────────────────────────────────────────────────────────────────────
+  // SYSTEM_MONITOR_WIDGETS §H — fold the 4 paradigm field-health widgets from REAL live signals (NON-INVENT).
+  //   field_errors ← window.__ERR_BEACON__ (error_beacon.js)  ·  durability ← offline queue (na if absent)
+  //   db_size_gauge ← window.ERP.opDb (the live signed op-log)  ·  environment ← window.ERP.VFS.detect()
+  function persistedP() {
+    try { if (navigator.storage && navigator.storage.persisted) return navigator.storage.persisted(); } catch (e) {}
+    return Promise.resolve(null);
+  }
+  function foldFieldHealth(est, persisted) {
+    var FH = global.ERP && global.ERP.FieldHealth;
+    if (!FH || typeof FH.fold !== 'function') return null;
+    var vfs = null; try { vfs = global.ERP.VFS && global.ERP.VFS.detect(); } catch (e) {}
+    var r = FH.fold({
+      beacon: global.__ERR_BEACON__,
+      queue: global.ERP && global.ERP.offlineQueue,            // present only if the app instantiated one
+      db: global.ERP && global.ERP.opDb,                       // the live signed op-log db
+      vfs: vfs,
+      storageEstimate: est ? { usage: est.usage, quota: est.quota } : null,
+      persisted: persisted
+    });
+    return r;
+  }
+
   function gather() {
-    return Promise.all([swVersion(), storageEstimate()]).then(function (r) {
-      var ver = r[0], est = r[1], h = heap(), tenants = residentTenants();
+    return Promise.all([swVersion(), storageEstimate(), persistedP()]).then(function (r) {
+      var ver = r[0], est = r[1], persisted = r[2], h = heap(), tenants = residentTenants();
       var d = {
         release: ver || '(uncontrolled)',
         os: (navigator.platform || '—') + ' · ' + (navigator.hardwareConcurrency || '?') + ' cores',
@@ -48,9 +70,10 @@
         heap: h ? (mb(h.used) + ' used / ' + mb(h.total) + ' heap · limit ' + mb(h.limit)) : 'n/a (this browser does not expose JS heap)',
         storage: est ? (mb(est.usage) + ' used of ' + mb(est.quota) + ' available') : 'n/a',
         tenants: tenants ? tenants.length : null,
-        tenantNames: tenants ? tenants.map(function (c) { return c.name; }).join(', ') : null
+        tenantNames: tenants ? tenants.map(function (c) { return c.name; }).join(', ') : null,
+        fieldHealth: foldFieldHealth(est, persisted)
       };
-      console.log('§SYSTEM-MONITOR gather release=' + d.release + ' heap=' + (h ? 'real' : 'n/a') + ' storage=' + (est ? 'real' : 'n/a') + ' tenants=' + d.tenants);
+      console.log('§SYSTEM-MONITOR gather release=' + d.release + ' heap=' + (h ? 'real' : 'n/a') + ' storage=' + (est ? 'real' : 'n/a') + ' tenants=' + d.tenants + ' fieldHealth=' + (d.fieldHealth ? d.fieldHealth.overall : 'n/a'));
       return d;
     });
   }
@@ -60,6 +83,17 @@
   function row(label, value, reframe) {
     return '<tr><th>' + esc(label) + '</th><td>' + (reframe ? '<span class="sm-badge">No longer needed</span> ' : '') + value
       + (reframe ? ' <a class="sm-rf" href="' + COMPARE + '">Read further&nbsp;&rsaquo;</a>' : '') + '</td></tr>';
+  }
+
+  // field-health rows — one per widget, with a status dot (paradigm vitals; the G2 observability remedy)
+  var FH_DOT = { ok: '#2e9e4f', warn: '#d98a00', alert: '#d23b3b', na: '#9aa4b1' };
+  function fhRows(fh) {
+    if (!fh || !fh.widgets) return '';
+    var rows = fh.widgets.map(function (w) {
+      var dot = '<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:' + FH_DOT[w.status] + ';margin-right:7px;vertical-align:middle"></span>';
+      return '<tr><th>' + dot + esc(w.label) + '</th><td><b style="color:' + FH_DOT[w.status] + '">' + esc(String(w.value)) + '</b> <span class="sm-dim">' + esc(w.detail) + '</span></td></tr>';
+    }).join('');
+    return '<tr class="sm-grp"><td colspan="2">Field health · paradigm vitals</td></tr>' + rows;
   }
 
   function panelHTML(d) {
@@ -73,6 +107,7 @@
         row('Release', '<b>' + esc(d.release) + '</b> &middot; dictionary folded from the iDempiere oracle') +
         row('Environment', esc(d.os)) +
         row('Client', esc(d.ua)) +
+        fhRows(d.fieldHealth) +
         '<tr class="sm-grp"><td colspan="2">Memory</td></tr>' +
         row('Heap usage', esc(d.heap)) +
         '<tr class="sm-grp"><td colspan="2">Cache</td></tr>' +


### PR DESCRIPTION
Lands two threads from the S1 discovery / G2 observability work into the live ERP app.

## ① System Monitor — paradigm field-health widgets (G2)
The existing serverless-reframe **System Monitor** (`window.SystemMonitor`) now folds **4 field-health widgets** from REAL live signals (NON-INVENT — a missing signal renders `n/a`, never a guess):

| Widget | Folds | Risk |
|---|---|---|
| **Field errors** | `error_beacon.js` (`window.__ERR_BEACON__`) | G2 — silent failures surfaced |
| **Durability** | offline queue (na until one exists) | A1 — never labels an unsynced op "durable" |
| **Op-log DB** | `window.ERP.opDb` PRAGMA size vs 200 MB ceiling | B1 (real) — headroom optic |
| **Environment** | `window.ERP.VFS.detect()` + bootstrap path | C1 — OPFS/IDB |

- New `erp/field_health.js` = `ERP.FieldHealth.fold` (identical to the bim-compiler `build/erp` engine; witnessed `poc_system_monitor.js` **14/14**).
- New `erp/error_beacon.js` = minimal field-error beacon (G2 seed), loads early to catch boot errors. No telemetry pipe, no PII.
- `panelHTML` adds a **"Field health · paradigm vitals"** group, styled iDempiere-faithfully.

## ② D2 — schema_version stamping is now the default write seam
- `kernel_ops.js` gains a decoupled `setVersionStamper` hook (byte-identical to the bim-compiler source); `erp/op_upcaster.js` + a boot line install it → `§OP_UPCASTER install OK`.
- Forward-only, inert to every reducer, `verifyChain` holds (witnessed **W-D2-FREEZE/CONVERGE/REFUSE/SIGNED/TAMPER + DEFAULT-SEAM**, all PASS in bim-compiler). `install()` self-guards (SKIPPED if the kernel lacks the hook).

## Verification
Headless Chromium on the live `idempiere.html`: **§SYSMON-LIVE-SMOKE OVERALL=PASS (14/14)** — scripts load, upcaster installs OK, monitor opens, all 4 widgets render, `§MON-*` folds emit.

`sw.js` v751→v752; precache adds the 3 new files; `kernel_ops?v=3`, `system_monitor?v=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)