### PR TITLE
fix(viewer): self-heal stale/relative building db url to OCI base (W-DB-404-OCI-RETRY, sw v721)

### DIFF
--- a/viewer/config.js
+++ b/viewer/config.js
@@ -11,6 +11,9 @@ function setupConfig(A) {
   // Auto-resolve: if hosted on OCI Object Storage, use same bucket base for DB URLs
   const _ociMatch = location.href.match(/(https:\/\/objectstorage\.[^/]+\/n\/[^/]+\/b\/[^/]+\/o\/)/);
   const _base = _ociMatch ? _ociMatch[1] : '';
+  // OCI prod base for building DBs (matches index.html _prodBase). cachedFetch retries a failing
+  // relative buildings/<file> against this base so a stale relative db url self-heals (W-DB-404-OCI-RETRY).
+  A.PROD_BASE = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/';
   // §S283: If no ?db= param, try last building from localStorage (PWA resume), then default
   var _lastDb = null;
   try { _lastDb = localStorage.getItem('pwa_last_db'); } catch(e) {}

--- a/viewer/db_resolve.js
+++ b/viewer/db_resolve.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+//
+// db_resolve.js — building-asset URL self-heal.
+//
+// # ⚠ DO NOT REMOVE — SPEC (W-DB-404-OCI-RETRY)
+// SCOPE: one pure decision — given a building-asset URL that FAILED to fetch, return the
+//        OCI prod-base URL to retry, or null when no safe retry exists.
+// WHY:   On GH-Pages the building DBs live on OCI (config.js _prodBase), NOT in the relative
+//        `buildings/` tree (only warehouse_gardenworld.db is served from the page). A stale or
+//        relative db url — e.g. a resumed `pwa_last_db` ('../buildings/Ifc2x3_SampleCastle_…')
+//        or an old share link — 404s and BRICKS the viewer boot (§INIT_ERROR, no fallback).
+//        Rewriting the failing relative `buildings/<file>` to the OCI base and retrying ONCE
+//        lets a dead relative link self-heal instead of dead-ending.
+// RULES (each is a test case in tests/witness_db_404_oci_retry.js):
+//   R1 no prodBase            → null              (nothing to retry against)
+//   R2 already on OCI         → null              (the url IS the prod base → no loop)
+//   R3 import:// url          → null              (IDB-only, never networked)
+//   R4 not a buildings/ asset → null              (don't rewrite unrelated urls)
+//   R5 relative buildings/X   → prodBase+buildings/X        (the heal: ../buildings, buildings, /buildings)
+//   R6 absolute non-OCI .../buildings/X → prodBase+buildings/X  (heal a stale absolute GH-Pages link too)
+// NON-INVENT: only the filename (url.split('/').pop()) is reused; no path is fabricated.
+// Read the §-log after every run (Universal Protocol Log Mandate).
+(function () {
+  'use strict';
+
+  // ociRetryUrl(url, prodBase) → string | null
+  function ociRetryUrl(url, prodBase) {
+    if (!url || !prodBase) return null;                              // R1
+    if (typeof url !== 'string') return null;
+    if (url.indexOf('import://') === 0) return null;                 // R3
+    // R2 — already pointed at the prod base (or any OCI object-storage url): no safe retry, avoid a loop.
+    if (url.indexOf(prodBase) === 0) return null;
+    if (/^https?:\/\/objectstorage\./i.test(url)) return null;
+    // R4 — only building assets are OCI-hosted; leave everything else alone.
+    if (!/(^|\/)buildings\//.test(url)) return null;
+    var file = url.split('/').pop();                                 // R5/R6 — reuse the filename verbatim
+    if (!file) return null;
+    return prodBase + 'buildings/' + file;
+  }
+
+  var DbResolve = { ociRetryUrl: ociRetryUrl };
+  if (typeof window !== 'undefined') window.DbResolve = DbResolve;
+  if (typeof module !== 'undefined' && module.exports) module.exports = DbResolve;
+})();

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -600,7 +600,20 @@ async function setupScene(A) {
       throw new Error('DB not found in cache: ' + url);
     }
 
-    const resp = await fetch(url);
+    let resp = await fetch(url);
+    // §DB_404_OCI_RETRY (W-DB-404-OCI-RETRY): on GH-Pages the building DBs live on OCI (A.PROD_BASE),
+    // not the relative buildings/ tree. A stale/relative db url (resumed pwa_last_db, old share link)
+    // 404s here — rewrite the failing buildings/<file> to the OCI base and retry ONCE before giving up,
+    // so a dead relative link self-heals instead of bricking the viewer boot. Pure decision in db_resolve.js.
+    if (!resp.ok && window.DbResolve) {
+      var _ociUrl = window.DbResolve.ociRetryUrl(url, A.PROD_BASE);
+      if (_ociUrl) {
+        console.warn(`[S203] §DB_404_OCI_RETRY status=${resp.status} orig=${url} → ${_ociUrl}`);
+        var _ociResp = await fetch(_ociUrl);
+        if (_ociResp.ok) { resp = _ociResp; console.log(`[S203] §DB_404_OCI_OK url=${_ociUrl.split('/').pop()}`); }
+        else console.warn(`[S203] §DB_404_OCI_FAIL url=${_ociUrl} status=${_ociResp.status}`);
+      }
+    }
     if (!resp.ok) throw new Error(`Failed to fetch ${url}: ${resp.status}`);
     const contentLength = parseInt(resp.headers.get('Content-Length') || '0', 10);
     let buf;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v720';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v721';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -63,6 +63,7 @@ const PRECACHE_ASSETS = [
   'manifest.webmanifest',
   // Core viewer modules (order matches index.html script tags)
   'config.js',
+  'db_resolve.js',
   'helpers.js',
   'loader.js',
   'effects.js',

--- a/viewer/tests/witness_db_404_oci_retry.js
+++ b/viewer/tests/witness_db_404_oci_retry.js
@@ -1,0 +1,44 @@
+// # ⚠ DO NOT REMOVE — W-DB-404-OCI-RETRY
+// ISSUE PROVED: a stale/relative building-db url (e.g. '../buildings/Ifc2x3_SampleCastle_extracted.db',
+//   the resumed pwa_last_db that 404'd and bricked the viewer boot) is rewritten to the OCI prod base
+//   and is therefore retryable — instead of dead-ending at §INIT_ERROR.
+// METHOD: drive the REAL pure decision db_resolve.ociRetryUrl (require'd verbatim, no copy) across the
+//   six spec rules R1–R6 + the exact failing url from the bug report. Whitebox §-log; no browser needed.
+// Run: node viewer/tests/witness_db_404_oci_retry.js   → exit 0 = GREEN. Read the §-log, not the exit code.
+const path = require('path');
+const { ociRetryUrl } = require(path.join(__dirname, '..', 'db_resolve.js'));
+
+const PROD = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/';
+const BLD = PROD + 'buildings/';
+
+const cases = [
+  // R5 — the actual bug: relative ../buildings db + its sibling positions.bin both heal.
+  { id: 'R5-bug-db',   url: '../buildings/Ifc2x3_SampleCastle_extracted.db', prod: PROD, want: BLD + 'Ifc2x3_SampleCastle_extracted.db' },
+  { id: 'R5-bug-pos',  url: '../buildings/Ifc2x3_SampleCastle_positions.bin', prod: PROD, want: BLD + 'Ifc2x3_SampleCastle_positions.bin' },
+  { id: 'R5-bare',     url: 'buildings/Duplex_extracted.db',                 prod: PROD, want: BLD + 'Duplex_extracted.db' },
+  { id: 'R5-rooted',   url: '/bim-ootb/buildings/Clinic_meta.db',            prod: PROD, want: BLD + 'Clinic_meta.db' },
+  // R6 — stale ABSOLUTE GH-Pages building link heals to OCI too.
+  { id: 'R6-ghpages',  url: 'https://red1oon.github.io/bim-ootb/buildings/SampleCastle_extracted.db', prod: PROD, want: BLD + 'SampleCastle_extracted.db' },
+  // R1 — no prod base → null (nothing to retry against).
+  { id: 'R1-noprod',   url: '../buildings/Duplex_extracted.db',              prod: '',   want: null },
+  // R2 — already on OCI / prod base → null (no loop).
+  { id: 'R2-onoci',    url: BLD + 'Duplex_extracted.db',                     prod: PROD, want: null },
+  { id: 'R2-objstor',  url: 'https://objectstorage.x.oraclecloud.com/n/a/b/c/o/buildings/X.db', prod: PROD, want: null },
+  // R3 — import:// is IDB-only, never networked → null.
+  { id: 'R3-import',   url: 'import://myhouse/myhouse_extracted.db',         prod: PROD, want: null },
+  // R4 — not a buildings/ asset → leave it alone.
+  { id: 'R4-lib',      url: 'mep_rw.db',                                     prod: PROD, want: null },
+  { id: 'R4-asset',    url: '../viewer/scene.js',                            prod: PROD, want: null },
+  { id: 'R4-citydir',  url: '../buildingsX/foo.db',                          prod: PROD, want: null }, // 'buildings' must be a path segment
+];
+
+let pass = 0, fail = 0;
+for (const c of cases) {
+  const got = ociRetryUrl(c.url, c.prod);
+  const ok = got === c.want;
+  ok ? pass++ : fail++;
+  console.log(`§DB404 ${ok ? 'PASS' : 'FAIL'} ${c.id}  in=${c.url}  → ${got === null ? 'null' : got}` +
+              (ok ? '' : `  EXPECTED ${c.want === null ? 'null' : c.want}`));
+}
+console.log(`§DB404-SUMMARY ${pass}/${pass + fail} pass`);
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -786,6 +786,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="lib/httpvfs.js?v=1" onerror="console.warn('§LOAD_FAIL httpvfs.js — range-request streaming disabled')"></script>
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
+<script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
 <script src="effects.js?v=1" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="pill_builder.js?v=2" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>


### PR DESCRIPTION
## Bug
At a Project Order, opening the BIM viewer 404'd at boot:
```
[S192] §INIT_ERROR Failed to fetch ../buildings/Ifc2x3_SampleCastle_extracted.db: 404
```

## Root cause (confirmed by curl)
Building DBs are served from **OCI** (`_prodBase`), not the GH-Pages `buildings/` tree — only `warehouse_gardenworld.db` is on GH-Pages; even the default `Duplex_extracted.db` is 404 there, 200 on OCI. The viewer was handed a **stale relative** url (`../buildings/Ifc2x3_SampleCastle_…`, an old-naming `pwa_last_db`/share link). On GH-Pages `config.js` sets `_base=''`, so the relative path resolves to the page tree → 404. The existing `pwa_last_db` recovery only fires when there is **no** `?db=` param, so an explicit dead db had no fallback and bricked the boot.

## Fix
`cachedFetch` now rewrites a failing relative `buildings/<file>` to the OCI base and retries **once** before throwing — a dead relative link self-heals instead of dead-ending. The decision is a pure function (`db_resolve.js → ociRetryUrl`) so it's whitebox-testable. `config.js` exposes `A.PROD_BASE`; the heal also covers stale **absolute** GH-Pages building links (R6).

Heals all sibling assets uniformly (`_extracted.db`, `_positions.bin`, `_meta.db`, `_geo.db`) since they all flow through `cachedFetch`. Safe-degrade: guarded by `window.DbResolve &&`.

## Witness — W-DB-404-OCI-RETRY 12/12 (node, §-log)
Drives the REAL `ociRetryUrl` over spec rules R1–R6 + the exact failing url and its `positions.bin` sibling:
```
§DB404 PASS R5-bug-db  ../buildings/Ifc2x3_SampleCastle_extracted.db → …/o/buildings/Ifc2x3_SampleCastle_extracted.db
§DB404 PASS R5-bug-pos ../buildings/Ifc2x3_SampleCastle_positions.bin → …/o/buildings/Ifc2x3_SampleCastle_positions.bin
… R1 no-prod→null · R2 already-OCI→null · R3 import://→null · R4 non-building→null …
§DB404-SUMMARY 12/12 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)