### PR TITLE
fix(4d): authored schedule flows to What-if + stop re-prompting Generate (W-WHATIF-AUTHORED-SYNC, sw v723)

### DIFF
--- a/viewer/proj_fold.js
+++ b/viewer/proj_fold.js
@@ -291,7 +291,57 @@
     };
   }
 
-  var API = { foldProjectOrder: foldProjectOrder, BIM_BASE: BIM_BASE };
+  // foldAuthoredPhases(db, building, phases, opts) — sync the AUTHORED 4D schedule (the wizard's phases,
+  // straight from the IFC `tasks` table) into the ERP C_ProjectPhase rows the What-if panel reads. Unlike
+  // foldProjectOrder (which RE-DERIVES phases from element IFC-class via sequence_rules + needs priced rows),
+  // this writes the user's OWN phase set 1:1 — name/seqno/dates/plannedAmt — so What-if matches the wizard.
+  // find-or-create C_Project by Value; find-or-create C_ProjectPhase by (Project, Name) → UPDATE seqno/dates/
+  // plannedAmt; INSERT if absent. IDEMPOTENT (a 2nd identical sync = +0 phases). Writes ONLY C_ProjectPhase
+  // (all What-if needs); the C_ProjectTask/Line tree is foldProjectOrder's job. Blue branch rows are untouched.
+  //   phases: [{ name, seqno, start, end, plannedAmt }]  (start/end 'YYYY-MM-DD' or full ts; plannedAmt num|str)
+  function foldAuthoredPhases(db, building, phases, opts) {
+    opts = opts || {};
+    var CL = opts.clientId != null ? opts.clientId : 11;
+    var OG = opts.orgId != null ? opts.orgId : 11;
+    var U = opts.user != null ? opts.user : 100;
+    var now = opts.now || (function () { try { return new Date().toISOString().replace('T', ' ').slice(0, 19); } catch (e) { return '2026-01-01 00:00:00'; } })();
+    var id = _allocator(db);
+    var created = { projects: 0, phases: 0, updated: 0 };
+    function _ts(d) { if (!d) return null; d = String(d); return d.length <= 10 ? d + ' 00:00:00' : d.slice(0, 19); }
+
+    var projId = _scalar(db, "SELECT C_Project_ID FROM C_Project WHERE Value=?", [building]);
+    if (projId == null) {
+      projId = id('C_Project', 'C_Project_ID');
+      var curId = opts.currencyId != null ? opts.currencyId : 100;
+      db.run("INSERT INTO C_Project (C_Project_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy," +
+        "Value,Name,IsSummary,C_Currency_ID,PlannedAmt,PlannedQty,IsCommitment,ProjInvoiceRule,ProjectLineLevel,Processed,C_Project_UU) " +
+        "VALUES (?,?,?,'Y',?,?,?,?,?,?,'N',?,0,0,'N','-','P','N',?)",
+        [projId, CL, OG, now, U, now, U, building, 'BIM: ' + building, curId, _uu()]);
+      created.projects = 1;
+    }
+
+    (phases || []).forEach(function (p, i) {
+      var nm = String(p.name || ('Phase ' + (i + 1)));
+      var seq = (p.seqno != null) ? p.seqno : (i + 1);
+      var s = _ts(p.start), e = _ts(p.end);
+      var amt = (p.plannedAmt != null) ? String(p.plannedAmt) : '0';
+      var phId = _scalar(db, "SELECT C_ProjectPhase_ID FROM C_ProjectPhase WHERE C_Project_ID=? AND Name=?", [projId, nm]);
+      if (phId == null) {
+        phId = id('C_ProjectPhase', 'C_ProjectPhase_ID');
+        db.run("INSERT INTO C_ProjectPhase (C_ProjectPhase_ID,C_Project_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy," +
+          "Name,SeqNo,StartDate,EndDate,IsComplete,PlannedAmt,Qty,C_ProjectPhase_UU) VALUES (?,?,?,?,'Y',?,?,?,?,?,?,?,?,'N',?,0,?)",
+          [phId, projId, CL, OG, now, U, now, U, nm, seq, s, e, amt, _uu()]);
+        created.phases++;
+      } else {
+        db.run("UPDATE C_ProjectPhase SET SeqNo=?,StartDate=?,EndDate=?,PlannedAmt=? WHERE C_ProjectPhase_ID=?", [seq, s, e, amt, phId]);
+        created.updated++;
+      }
+    });
+    console.log('§PROJ_FOLD_AUTHORED project="' + building + '" phases=+' + created.phases + ' updated=' + created.updated + ' projId=' + projId);
+    return { projectId: projId, created: created };
+  }
+
+  var API = { foldProjectOrder: foldProjectOrder, foldAuthoredPhases: foldAuthoredPhases, BIM_BASE: BIM_BASE };
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ProjFold = API;
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -33,6 +33,71 @@
     } catch (e) { console.log('§AUTHOR_UI_COST_ERR ' + (e && e.message)); return null; }
   }
 
+  // ── Sync the authored schedule → What-if (the ⑂ panel reads C_ProjectPhase, NOT the IFC tasks table) ──
+  // Without this, pressing Generate/Apply writes only `tasks`; What-if keeps showing a stale, thin
+  // C_ProjectPhase from a one-time `> to ERP` push (user-reported: SampleCastle What-if had one phase while
+  // the wizard showed four). We fold the authored phases 1:1 into the SAME OPFS store What-if reads, then
+  // refresh it. Open OPFS-first (else the bundled seed), exactly like whatif_panel._loadDb.
+  function _openErpDb(SQL) {
+    var fromOpfs = Promise.resolve(null);
+    try {
+      if (navigator.storage && navigator.storage.getDirectory) {
+        fromOpfs = navigator.storage.getDirectory()
+          .then(function (root) { return root.getDirectoryHandle('bim_analysis'); })
+          .then(function (dir) { return dir.getFileHandle('bim_project_orders.db'); })
+          .then(function (fh) { return fh.getFile(); })
+          .then(function (f) { return f.arrayBuffer(); })
+          .then(function (buf) { return new SQL.Database(new Uint8Array(buf)); })
+          .catch(function () { return null; });
+      }
+    } catch (e) {}
+    return fromOpfs.then(function (d) {
+      if (d) return d;
+      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); })
+        .then(function (buf) { return new SQL.Database(new Uint8Array(buf)); })
+        .catch(function () { return null; });
+    });
+  }
+  function _persistErpDb(d) {
+    try {
+      if (!navigator.storage || !navigator.storage.getDirectory) return Promise.resolve(false);
+      var bytes = d.export();
+      return navigator.storage.getDirectory()
+        .then(function (root) { return root.getDirectoryHandle('bim_analysis', { create: true }); })
+        .then(function (dir) { return dir.getFileHandle('bim_project_orders.db', { create: true }); })
+        .then(function (fh) { return fh.createWritable(); })
+        .then(function (w) { return w.write(bytes).then(function () { return w.close(); }); })
+        .then(function () { return true; }).catch(function () { return false; });
+    } catch (e) { return Promise.resolve(false); }
+  }
+  function _syncWhatIf() {
+    var d = db(), a = A();
+    if (!d || !a || !_state) return;
+    if (!global.ProjFold || !global.ProjFold.foldAuthoredPhases) { console.log('§AUTHOR_UI_WHATIF skip=ProjFold-absent'); return; }
+    var SQL = a._SQL || global.SQL; if (!SQL) { console.log('§AUTHOR_UI_WHATIF skip=sqljs-absent'); return; }
+    var building = a.activeBuilding; if (!building) { console.log('§AUTHOR_UI_WHATIF skip=no-building'); return; }
+    var cost = costFold(), costByTask = {};
+    if (cost && cost.phases) cost.phases.forEach(function (p) { costByTask[p.taskId] = p.cost; });
+    var r = d.exec("SELECT task_id, name, schedule_start, schedule_finish FROM tasks WHERE schedule_id='" +
+      _state.schedId + "' AND is_summary=0 ORDER BY COALESCE(schedule_start,'9999-99-99'), rowid");
+    var rows = (r.length && r[0].values) ? r[0].values : [];
+    var phases = rows.map(function (row, i) {
+      return { name: row[1] || row[0], seqno: i + 1, start: row[2], end: row[3], plannedAmt: costByTask[row[0]] || 0 };
+    });
+    if (!phases.some(function (p) { return p.start && p.end; })) { console.log('§AUTHOR_UI_WHATIF skip=undated (originate dates first)'); return; }
+    _openErpDb(SQL).then(function (edb) {
+      if (!edb) { console.log('§AUTHOR_UI_WHATIF skip=erp-db-unavailable'); return; }
+      try {
+        var res = global.ProjFold.foldAuthoredPhases(edb, building, phases, {});
+        _persistErpDb(edb).then(function (saved) {
+          console.log('§AUTHOR_UI_WHATIF folded project=' + res.projectId + ' phases=' + phases.length +
+            ' (+' + res.created.phases + '/upd' + res.created.updated + ') persisted=' + saved);
+          if (global.WhatIfPanel && global.WhatIfPanel.refresh) global.WhatIfPanel.refresh();
+        });
+      } catch (e) { console.log('§AUTHOR_UI_WHATIF_ERR ' + (e && e.message)); }
+    });
+  }
+
   function _injectStyle() {
     if (document.getElementById('sa-style')) return;
     var s = document.createElement('style');
@@ -169,6 +234,7 @@
     SA().scheduleContiguous(d, _state.schedId, { start: _state.start || '2026-01-01', phaseDays: 30 });
     refreshState(); render();
     status('Scheduled — phases now carry dates and appear in the timeline.');
+    _syncWhatIf();   // dates just originated → mirror into C_ProjectPhase for the What-if panel
   }
 
   // ── Apply to 4D: re-fold the Time Machine so the gantt shows the authored schedule ──
@@ -176,15 +242,19 @@
     applyDates();
     status('Applied. ' + (A() && A()._tmOn ? 're-folding Time Machine…' : 'open Time Machine to view'));
     console.log('§AUTHOR_UI_APPLY tmOn=' + !!(A() && A()._tmOn));
-    if (A() && A()._tmOn && typeof global.toggleTimeMachine === 'function') {
-      // toggle off→on re-runs injectGantt → _cap overlays the authored windows (W-AUTHOR-4D-BLANK)
+    if (A() && A()._tmOn && typeof global.tmRefoldSchedule === 'function') {
+      // re-fold off the LIVE edited tasks (invalidates the stale gantt cache) — W-TM-REFOLD
+      global.tmRefoldSchedule();
+    } else if (A() && A()._tmOn && typeof global.toggleTimeMachine === 'function') {
       global.toggleTimeMachine();
-      setTimeout(function () { global.toggleTimeMachine(); }, 60);
+      setTimeout(function () { global.toggleTimeMachine(); }, 60);   // fallback (older viewer)
     }
+    _syncWhatIf();   // mirror the authored phases into C_ProjectPhase so the What-if (⑂) panel matches
   }
 
   function render() {
     var body = document.getElementById('sa-body'); if (!body) return;
+    syncControls();   // keep the Generate/Regenerate button label in step with the current schedule state
     if (!_state || !_state.order.length) {
       body.innerHTML = '<div style="font-size:11px;color:#9bb;line-height:1.5">' +
         'No <b>editable</b> schedule here yet. The Time Machine may already play a rule-generated ' +
@@ -373,8 +443,24 @@
   function syncControls() {
     var draft = document.getElementById('sa-draft'), blank = document.getElementById('sa-blank');
     var cap = !!(_state && _state.captured);
-    if (draft) draft.style.display = cap ? 'none' : '';
+    var hasPhases = !!(_state && _state.order && _state.order.length);
+    if (draft) {
+      draft.style.display = cap ? 'none' : '';
+      if (!cap) {
+        // Once a schedule already exists (authored / applied), pressing this REGENERATES from rules and
+        // CLOBBERS manual phase/date/assignment edits — so demote it from the primary "first draft" CTA.
+        // Otherwise the prominent "Generate first draft" button reads as "you must generate again" even
+        // right after Apply to 4D (user-reported). hasPhases → secondary "Regenerate".
+        draft.textContent = hasPhases ? 'Regenerate' : 'Generate first draft';
+        draft.classList.toggle('sa-primary', !hasPhases);
+        draft.title = hasPhases
+          ? 'Rebuild the draft from rules — discards manual phase/date/assignment edits'
+          : 'Fold the model into organized, editable phases';
+      }
+    }
     if (blank && blank.parentElement) blank.parentElement.style.display = cap ? 'none' : '';
+    console.log('§AUTHOR_UI_CONTROLS cap=' + cap + ' hasPhases=' + hasPhases +
+      ' draftLabel=' + (draft ? draft.textContent : '-') + ' primary=' + (draft ? draft.classList.contains('sa-primary') : '-'));
   }
   function close() { if (_panel) _panel.style.display = 'none'; console.log('§AUTHOR_UI_CLOSE'); }
   function toggle() { if (_panel && _panel.style.display === 'flex') close(); else open(); }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v722';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v723';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_whatif_authored_sync.js
+++ b/viewer/tests/witness_whatif_authored_sync.js
@@ -1,0 +1,69 @@
+// # ⚠ DO NOT REMOVE — W-WHATIF-AUTHORED-SYNC
+// ISSUE PROVED: the What-if (⑂) panel reads C_ProjectPhase, while the Author wizard writes the IFC `tasks`
+//   table — so after "Generate/Apply" the What-if kept showing a stale, thin one-phase fold (user saw
+//   SampleCastle What-if with ONE Architecture line while the wizard showed four). ProjFold.foldAuthoredPhases
+//   mirrors the authored phases 1:1 into C_ProjectPhase so What-if matches. This drives:
+//     (a) the REAL ProjFold.foldAuthoredPhases (require'd verbatim from proj_fold.js), and
+//     (b) the EXACT What-if reader SQL sliced from whatif.js readPhases,
+//   on a real sql.js db seeded to the bug (a project with only 'Architecture'), proving: the 4 authored
+//   phases appear, the pre-existing Architecture row is UPDATED not duplicated, and a 2nd sync is +0 (idempotent).
+// Whitebox §-log; no browser. Run: node viewer/tests/witness_whatif_authored_sync.js  → exit 0 = GREEN.
+const fs = require('fs'), path = require('path');
+const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+// proj_fold.js requires ../erp/bigdecimal.js in node — present in the repo
+const ProjFold = require(path.join(__dirname, '..', 'proj_fold.js'));
+
+// the EXACT phase-reader SQL What-if uses (no branch column path), sliced-equivalent from whatif.js:62
+const WHATIF_SQL = "SELECT C_ProjectPhase_ID,SeqNo,Name,StartDate,EndDate,PlannedAmt,IsComplete FROM C_ProjectPhase " +
+  "WHERE C_Project_ID=? ORDER BY SeqNo";
+
+let pass = 0, fail = 0;
+function ok(c, m) { c ? pass++ : fail++; console.log(`§WIAUTH ${c ? 'PASS' : 'FAIL'} ${m}`); }
+
+(async () => {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  // minimal ERP shape + the BUG seed: a SampleCastle project with ONLY an Architecture phase (the stale push)
+  db.run(`CREATE TABLE C_Project (C_Project_ID INTEGER PRIMARY KEY, AD_Client_ID INT, AD_Org_ID INT, IsActive TEXT,
+            Created TEXT, CreatedBy INT, Updated TEXT, UpdatedBy INT, Value TEXT, Name TEXT, IsSummary TEXT,
+            C_Currency_ID INT, PlannedAmt REAL, PlannedQty REAL, IsCommitment TEXT, ProjInvoiceRule TEXT,
+            ProjectLineLevel TEXT, Processed TEXT, C_Project_UU TEXT);
+          CREATE TABLE C_ProjectPhase (C_ProjectPhase_ID INTEGER PRIMARY KEY, C_Project_ID INT, AD_Client_ID INT,
+            AD_Org_ID INT, IsActive TEXT, Created TEXT, CreatedBy INT, Updated TEXT, UpdatedBy INT, Name TEXT,
+            SeqNo INT, StartDate TEXT, EndDate TEXT, IsComplete TEXT, PlannedAmt REAL, Qty REAL, C_ProjectPhase_UU TEXT);`);
+  db.run(`INSERT INTO C_Project (C_Project_ID,Value,Name) VALUES (990500,'SampleCastle','BIM: SampleCastle');`);
+  db.run(`INSERT INTO C_ProjectPhase (C_ProjectPhase_ID,C_Project_ID,Name,SeqNo,StartDate,EndDate,PlannedAmt)
+            VALUES (990501,990500,'Architecture',1,'2026-01-01 00:00:00','2026-01-30 00:00:00',100);`);
+
+  const before = db.exec(WHATIF_SQL, [990500])[0].values;
+  ok(before.length === 1 && before[0][2] === 'Architecture', `BEFORE: What-if sees 1 phase (Architecture) — the stale fold`);
+
+  // the authored schedule from the wizard (4 phases, the left panel), dates + 5D cost
+  const phases = [
+    { name: 'Superstructure', seqno: 1, start: '2026-01-01', end: '2026-02-01', plannedAmt: 500000 },
+    { name: 'MEP Rough-in',   seqno: 2, start: '2026-02-01', end: '2026-03-01', plannedAmt: 300000 },
+    { name: 'Architecture',   seqno: 3, start: '2026-03-01', end: '2026-04-01', plannedAmt: 400000 },
+    { name: 'Finishes',       seqno: 4, start: '2026-04-01', end: '2026-04-30', plannedAmt: 200000 },
+  ];
+  const r1 = ProjFold.foldAuthoredPhases(db, 'SampleCastle', phases, {});
+  ok(r1.projectId === 990500, `re-uses existing C_Project 990500 (find-or-create, no dup)`);
+  ok(r1.created.phases === 3 && r1.created.updated === 1, `+3 new phases, Architecture UPDATED in place (not duplicated)`);
+
+  const after = db.exec(WHATIF_SQL, [990500])[0].values;
+  ok(after.length === 4, `AFTER: What-if sees all 4 authored phases (was 1)`);
+  ok(after.map(v => v[2]).join('|') === 'Superstructure|MEP Rough-in|Architecture|Finishes', `phases SeqNo-ordered match the wizard`);
+  const arch = after.find(v => v[2] === 'Architecture');
+  ok(arch && Number(arch[5]) === 400000 && arch[3] === '2026-03-01 00:00:00', `Architecture row UPDATED to authored cost+dates (not the stale 100/Jan)`);
+  ok(db.exec("SELECT COUNT(*) FROM C_ProjectPhase WHERE Name='Architecture' AND C_Project_ID=990500")[0].values[0][0] === 1, `exactly ONE Architecture row (no duplicate)`);
+
+  // idempotent: a 2nd identical sync adds 0 phases
+  const r2 = ProjFold.foldAuthoredPhases(db, 'SampleCastle', phases, {});
+  ok(r2.created.phases === 0 && r2.created.updated === 4, `idempotent: 2nd sync +0 new, 4 updated-in-place`);
+
+  // a brand-new building creates the C_Project + all phases
+  const r3 = ProjFold.foldAuthoredPhases(db, 'NewTower', phases, {});
+  ok(r3.created.projects === 1 && r3.created.phases === 4, `new building → C_Project + 4 phases created`);
+
+  console.log(`§WIAUTH-SUMMARY ${pass}/${pass + fail} pass`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e.stack); process.exit(1); });

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,11 +824,11 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../erp/ad_docfsm.js"></script>
 <script src="../erp/kernel_ops.js"></script>
 <script src="blue_fold.js?v=1"></script>
-<script src="proj_fold.js?v=2"></script>
+<script src="proj_fold.js?v=3"></script>
 <script src="vo_fold.js?v=2"></script>
 <script src="proj_control.js?v=1"></script>
 <script src="whatif.js?v=2"></script>
-<script src="whatif_panel.js?v=3"></script>
+<script src="whatif_panel.js?v=4"></script>
 <script src="vo_approve.js?v=1"></script>
 <script src="proj_period.js?v=1"></script>
 <script src="proj_claim.js?v=1"></script>
@@ -888,7 +888,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="time_machine.js?v=59" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_author_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context

--- a/viewer/whatif_panel.js
+++ b/viewer/whatif_panel.js
@@ -292,5 +292,13 @@
     });
   }
 
-  global.WhatIfPanel = { open: open };
+  // refresh() — re-read the OPFS store (which the Author wizard's Apply just re-folded) and, if the panel
+  // is open, re-pick the project + re-render in place. Nulls the cached _db so _loadDb re-reads from disk.
+  function refresh() {
+    _db = null;
+    if (document.getElementById('whatif-panel')) { console.log('§WHATIF-UI refresh — panel open, reloading'); open(); }
+    else console.log('§WHATIF-UI refresh — panel closed, will reload on next open');
+  }
+
+  global.WhatIfPanel = { open: open, refresh: refresh };
 })(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
Two TM-review follow-ups (`prompts/TM_REVIEW_FINDINGS.md`) the user hit on SampleCastle.

## 1. What-if showed one stale phase while the wizard showed four
What-if (⑂) reads ERP **`C_ProjectPhase`** — written only by a one-time `> to ERP` `proj_fold` push — while the Author wizard writes the IFC **`tasks`** table. Two decoupled models, so "Generate/Apply" never reached What-if (SampleCastle: one Architecture line vs four authored phases).

**Fix:** new `ProjFold.foldAuthoredPhases` mirrors the authored phases 1:1 into `C_ProjectPhase` (find-or-create by name → update seqno/dates/plannedAmt, idempotent — blue branch rows untouched). The wizard's **Apply / Schedule-now** folds into the **same OPFS store** What-if reads, persists, and calls the new `WhatIfPanel.refresh()`, so What-if updates right away.

## 2. Wizard kept prompting "Generate first draft" after Apply
`syncControls` only hid Generate for *imported* schedules. Now, once a schedule has phases, it demotes to a secondary **"Regenerate"** (regenerating clobbers edits — no longer the primary CTA). Apply also re-folds via the #515 `tmRefoldSchedule` instead of the toggle+60ms.

## Witness — W-WHATIF-AUTHORED-SYNC 9/9 (node, sql.js)
Real `ProjFold.foldAuthoredPhases` + the exact What-if reader SQL, seeded to the bug (project with only `Architecture`):
```
§WIAUTH PASS BEFORE: What-if sees 1 phase (Architecture) — the stale fold
§WIAUTH PASS +3 new phases, Architecture UPDATED in place (not duplicated)
§WIAUTH PASS AFTER: What-if sees all 4 authored phases (was 1)
§WIAUTH PASS idempotent: 2nd sync +0 new, 4 updated-in-place
§WIAUTH-SUMMARY 9/9 pass
```
sw `v722→v723`; `proj_fold.js?v=3`, `whatif_panel.js?v=4`, `schedule_author_ui.js?v=6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)