### PR TITLE
perf(editor): reuse viewer IndexedDB cache, skip re-download of building DB (sw v724)

### DIFF
--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -134,6 +134,6 @@
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
 <script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=4" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_editor_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -283,6 +283,28 @@
     renderWbs(); renderDeps(); renderGantt();
   }
 
+  // Reuse the viewer's IndexedDB cache (bim_ootb_cache / store 'dbs', keyed by URL — scene.js A.cachedFetch)
+  // so the Editor does NOT re-download a whole building the viewer already streamed. The ↗ Editor button
+  // passes ?db=<APP.DB_URL>, the exact key the viewer wrote, so this hits. Read-only; a miss falls through
+  // to network. Opened WITHOUT a version so we never clobber the viewer's schema. (W-SE-DB-CACHE)
+  function _idbGetDb(url) {
+    return new Promise(function (resolve) {
+      try {
+        var rq = indexedDB.open('bim_ootb_cache');
+        rq.onsuccess = function () {
+          var idb = rq.result;
+          if (!idb.objectStoreNames.contains('dbs')) { resolve(null); return; }
+          try {
+            var g = idb.transaction('dbs', 'readonly').objectStore('dbs').get(url);
+            g.onsuccess = function () { resolve(g.result || null); };
+            g.onerror = function () { resolve(null); };
+          } catch (e) { resolve(null); }
+        };
+        rq.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  }
+
   // ── boot ─────────────────────────────────────────────────────────────────────
   function init() {
     if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
@@ -291,9 +313,16 @@
     var initSqlJs = global.initSqlJs;
     initSqlJs({ locateFile: function (f) { return 'https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/' + f; } })
       .then(function (SQL) {
-        return fetch(url).then(function (r) {
-          if (!r.ok) throw new Error('fetch ' + r.status);
-          return r.arrayBuffer();
+        return _idbGetDb(url).then(function (cached) {
+          if (cached) {
+            console.log('§SE_DB_CACHE_HIT ' + url.split('/').pop() + ' size=' + (cached.byteLength / 1024).toFixed(0) + 'KB — skipped re-download');
+            return cached;
+          }
+          console.log('§SE_DB_CACHE_MISS ' + url.split('/').pop() + ' — fetching');
+          return fetch(url).then(function (r) {
+            if (!r.ok) throw new Error('fetch ' + r.status);
+            return r.arrayBuffer();
+          });
         }).then(function (buf) {
           db = new SQL.Database(new Uint8Array(buf));
           console.log('§SE_DB_OPEN size=' + (buf.byteLength / 1024).toFixed(0) + 'KB url=' + url.split('/').pop());

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v723';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v724';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Bug (user-reported during the TM review)
The Schedule Editor (↗ from the Time Machine) did a plain `fetch(url)` of the **whole building DB** on every open — re-downloading a building the viewer had already streamed into IndexedDB.

## Fix
The ↗ button passes `?db=<APP.DB_URL>` — the exact key the viewer's `A.cachedFetch` writes under (`bim_ootb_cache` / store `dbs`). The Editor now reads that cache first (read-only; opened **without** a version so it can't clobber the viewer's schema) and only falls through to network on a miss.

§-log proof: `§SE_DB_CACHE_HIT <file> size=…KB — skipped re-download` (or `§SE_DB_CACHE_MISS … — fetching`).

sw `v723→v724`; `schedule_editor_ui.js?v=5`.

> Note: a follow-up is queued for the WBS **add sub-task / break-down** capability the Editor is currently missing — that needs a new engine verb and is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)