### PR TITLE
feat(editor): deepen the WBS — add sub-tasks + break a phase down by storey/type (W-SE-WBS, sw v725)

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -561,6 +561,72 @@
     return { projectDuration: PF, projectStart: projStart, tasks: out, criticalIds: critical };
   }
 
+  // ── §SE-WBS: deepen the WBS — add a task, or break a phase down by an element attribute ──────────────
+  // addTask(db, scheduleId, opts) — the Editor's "＋ sub-task" / "＋ sibling". opts: { taskId?, name?,
+  // wbsParent? }. A new task is a LEAF (is_summary=0) and INHERITS its parent's date window so it shows in
+  // the TM at once. The parent is NOT forced to a summary — it keeps its own elements + _cap coverage (only
+  // breakdown, which empties the parent, marks it summary). Pass taskId for cross-tab replay determinism;
+  // else TASK_<slug(name)> with a numeric suffix on collision. Returns { ok, taskId, parent }.
+  function addTask(db, scheduleId, opts) {
+    opts = opts || {};
+    _ensureWideTasks(db);
+    var parent = opts.wbsParent || null;
+    var ps = null, pf = null, pdur = null;
+    if (parent) {
+      var pr = db.exec('SELECT schedule_start, schedule_finish, schedule_duration FROM tasks WHERE task_id=? AND schedule_id=?', [parent, scheduleId]);
+      if (!pr.length || !pr[0].values.length) { console.log('§SE_ADDTASK_FAIL parent=' + parent + ' reason=no_such_parent'); return { ok: false, reason: 'no_such_parent' }; }
+      ps = pr[0].values[0][0]; pf = pr[0].values[0][1]; pdur = pr[0].values[0][2];
+    }
+    var name = opts.name || 'New Task';
+    var tid = opts.taskId;
+    if (!tid) {
+      var base = 'TASK_' + (_slug(name) || 'X'); tid = base; var k = 1;
+      while (true) { var ex = db.exec('SELECT 1 FROM tasks WHERE task_id=?', [tid]); if (!ex.length || !ex[0].values.length) break; tid = base + '_' + (++k); }
+    }
+    db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,0,?,?,?,?,?)',
+      [tid, scheduleId, parent, name, 'CONSTRUCTION', ps, pf, pdur, null, 'PLANNED']);
+    console.log('§SE_ADDTASK id=' + tid + ' parent=' + (parent || '(root)') + ' name="' + name + '"');
+    return { ok: true, taskId: tid, parent: parent };
+  }
+
+  // breakdownByAttribute(db, scheduleId, taskId, attr) — auto-split a leaf phase's assigned elements into
+  // child sub-tasks grouped by an elements_meta attribute (storey | ifc_class/type | discipline). Each
+  // distinct value → child "<parent> · <value>" (DETERMINISTIC id parentId__<slug(value)> so a peer replay
+  // converges), the parent's elements move to the matching child, and the parent becomes a summary roll-up
+  // (is_summary=1 → dropped from _cap; children inherit its window so coverage is preserved). Returns
+  // { ok, parent, attr, groups:[{taskId,value,count}], created }.
+  var _BREAKDOWN_ATTRS = { storey: 'storey', ifc_class: 'ifc_class', class: 'ifc_class', type: 'ifc_class', discipline: 'discipline' };
+  function breakdownByAttribute(db, scheduleId, taskId, attr) {
+    _ensureWideTasks(db);
+    var col = _BREAKDOWN_ATTRS[String(attr || '').toLowerCase()];
+    if (!col) { console.log('§SE_BREAKDOWN_FAIL reason=bad_attr attr=' + attr); return { ok: false, reason: 'bad_attr' }; }
+    var pr = db.exec('SELECT name, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE task_id=? AND schedule_id=?', [taskId, scheduleId]);
+    if (!pr.length || !pr[0].values.length) { console.log('§SE_BREAKDOWN_FAIL reason=no_such_task task=' + taskId); return { ok: false, reason: 'no_such_task' }; }
+    var pName = pr[0].values[0][0] || taskId, ps = pr[0].values[0][1], pf = pr[0].values[0][2], pdur = pr[0].values[0][3];
+    var gr = db.exec("SELECT COALESCE(NULLIF(m." + col + ",''),'(none)') v, te.guid FROM task_elements te " +
+      "JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id=? ORDER BY v", [taskId]);
+    if (!gr.length || !gr[0].values.length) { console.log('§SE_BREAKDOWN_FAIL reason=no_elements task=' + taskId); return { ok: false, reason: 'no_elements' }; }
+    var groups = {};
+    gr[0].values.forEach(function (row) { (groups[row[0]] || (groups[row[0]] = [])).push(row[1]); });
+    var vals = Object.keys(groups).sort();
+    if (vals.length < 2) { console.log('§SE_BREAKDOWN_SKIP task=' + taskId + ' attr=' + col + ' reason=single_group'); return { ok: false, reason: 'single_group', groups: vals }; }
+    var out = [], created = 0;
+    vals.forEach(function (v) {
+      var cid = taskId + '__' + (_slug(v) || 'none');
+      var ex = db.exec('SELECT 1 FROM tasks WHERE task_id=?', [cid]);
+      if (!ex.length || !ex[0].values.length) {
+        db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,0,?,?,?,?,?)',
+          [cid, scheduleId, taskId, pName + ' · ' + v, 'CONSTRUCTION', ps, pf, pdur, null, 'PLANNED']);
+        created++;
+      }
+      groups[v].forEach(function (g) { db.run('DELETE FROM task_elements WHERE guid=?', [g]); db.run('INSERT OR IGNORE INTO task_elements VALUES (?,?)', [cid, g]); });
+      out.push({ taskId: cid, value: v, count: groups[v].length });
+    });
+    db.run('UPDATE tasks SET is_summary=1 WHERE task_id=? AND schedule_id=?', [taskId, scheduleId]);
+    console.log('§SE_BREAKDOWN parent=' + taskId + ' attr=' + col + ' groups=' + vals.length + ' created=' + created);
+    return { ok: true, parent: taskId, attr: col, groups: out, created: created };
+  }
+
   var API = {
     matchRule: matchRule,
     materializeDefault: materializeDefault,
@@ -576,7 +642,9 @@
     removeDependency: removeDependency,
     updateDependency: updateDependency,
     computeCpm: computeCpm,
-    moveTask: moveTask
+    moveTask: moveTask,
+    addTask: addTask,
+    breakdownByAttribute: breakdownByAttribute
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -132,8 +132,8 @@
 </section>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=5" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_author.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_sync.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
+<script src="schedule_editor_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -76,10 +76,52 @@
           tf <= 0 ? 'critical' : ('float ' + tf + 'd')));
       }
       if (node.start) row.appendChild(el('span', 'se-dates', node.start + (node.finish ? ' → ' + node.finish : '')));
+      // §SE-WBS deepen-the-tree actions: ＋ add a sub-task (any node) · break a populated leaf down by attribute
+      var act = el('span'); act.style.cssText = 'margin-left:auto;display:inline-flex;gap:4px;align-items:center';
+      var addBtn = el('button', null, '＋'); addBtn.title = 'Add a sub-task under ' + node.name;
+      addBtn.style.cssText = 'font-size:11px;line-height:1;padding:1px 5px;cursor:pointer';
+      addBtn.onclick = function (ev) { ev.stopPropagation(); doAddTask(node.id, node.name); };
+      act.appendChild(addBtn);
+      if (!node.isSummary && node.guidCount > 1) {
+        var sel = el('select'); sel.title = 'Break this phase into sub-tasks grouped by…';
+        sel.style.cssText = 'font-size:10px;padding:0 2px;cursor:pointer';
+        sel.appendChild(new Option('break by…', ''));
+        ['storey', 'type', 'discipline'].forEach(function (o) { sel.appendChild(new Option(o, o)); });
+        sel.onclick = function (ev) { ev.stopPropagation(); };
+        sel.onchange = function () { if (sel.value) doBreakdown(node.id, sel.value); };
+        act.appendChild(sel);
+      }
+      row.appendChild(act);
       host.appendChild(row);
       if (hasKids && !collapsed[node.id]) node.children.forEach(function (c) { walk(c, depth + 1); });
     }
     roots.forEach(function (r) { walk(r, 0); });
+  }
+
+  // §SE-WBS — deepen the WBS: add a sub-task, or auto-split a phase by an element attribute. Each edit runs
+  // the engine verb on our db, broadcasts a deterministic op so peer surfaces (2nd tab, the Viewer TM) converge,
+  // then refreshFold() invalidates any stale CPM and re-renders. New leaves inherit the parent's date window.
+  function doAddTask(parentId, parentName) {
+    var name = (window.prompt('New sub-task under "' + parentName + '":', 'New task') || '').trim();
+    if (!name) return;
+    var r = SA().addTask(db, schedId, { name: name, wbsParent: parentId });
+    if (!r || !r.ok) { status('add sub-task failed: ' + (r && r.reason)); return; }
+    broadcast({ op: 'addtask', schedId: schedId, taskId: r.taskId, name: name, wbsParent: parentId });
+    status('added "' + name + '" under ' + parentName);
+    collapsed[parentId] = false;   // reveal the new child
+    refreshFold();
+  }
+  function doBreakdown(taskId, attr) {
+    var r = SA().breakdownByAttribute(db, schedId, taskId, attr);   // 'type' maps to ifc_class in the engine
+    if (!r || !r.ok) {
+      status('break down: ' + (r && r.reason === 'single_group' ? ('only one ' + attr + ' here — nothing to split')
+        : (r && r.reason === 'no_elements' ? 'no elements on this task' : (r && r.reason))));
+      renderWbs(); return;
+    }
+    broadcast({ op: 'breakdown', schedId: schedId, taskId: taskId, attr: attr });
+    status('split into ' + r.groups.length + ' sub-tasks by ' + attr);
+    collapsed[taskId] = false;
+    refreshFold();
   }
 
   // ── STEP 2: dependency view + edit ───────────────────────────────────────────

--- a/viewer/schedule_sync.js
+++ b/viewer/schedule_sync.js
@@ -11,7 +11,7 @@
   var CHANNEL = 'bim_4d';        // the rail main.js already listens on (S240)
   var TYPE = '4D_SCHED_EDIT';
 
-  function SA() { return global.ScheduleAuthor; }
+  function SA() { return global.ScheduleAuthor || (typeof globalThis !== 'undefined' ? globalThis.ScheduleAuthor : null); }
 
   // applyOp(db, op) — replay one schedule op on a receiver db via the matching ScheduleAuthor verb.
   // PURE (no DOM, no channel). Returns the verb's result, or {ok:false, reason} for bad input.
@@ -24,6 +24,9 @@
       case 'retype': return SA().updateDependency(db, op.predId, op.succId, { type: op.value });
       case 'lag':    return SA().updateDependency(db, op.predId, op.succId, { lag: op.value });
       case 'cpm':    return SA().computeCpm(db, op.schedule, {});
+      // §SE-WBS structural edits — deterministic (explicit taskId / stable child ids) so peers converge.
+      case 'addtask':   return SA().addTask(db, op.schedId, { taskId: op.taskId, name: op.name, wbsParent: op.wbsParent });
+      case 'breakdown': return SA().breakdownByAttribute(db, op.schedId, op.taskId, op.attr);
       default:       return { ok: false, reason: 'unknown_op:' + (op.op || '?') };
     }
   }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v724';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v725';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_se_wbs_breakdown.js
+++ b/viewer/tests/witness_se_wbs_breakdown.js
@@ -1,0 +1,85 @@
+// # ⚠ DO NOT REMOVE — W-SE-WBS
+// ISSUE PROVED: the Schedule Editor could view/collapse the WBS but not DEEPEN it (user: "shouldn't the
+//   Editor allow adding or breakdown of further subitems?"). New engine verbs add that, and stay correct
+//   for the Time Machine's _cap (no orphaned elements) and for cross-tab replay (deterministic ids):
+//     addTask            — a new LEAF inherits the parent window; parent NOT forced summary (keeps coverage)
+//     breakdownByAttribute — split a phase's elements by storey/type; children inherit the window; parent
+//                            becomes a summary roll-up; EVERY element still sits on a non-summary leaf (_cap)
+//     schedule_sync.applyOp('addtask'|'breakdown') — replays IDENTICALLY on a peer db (surfaces converge)
+//   Drives the REAL verbs (require'd verbatim) on a real sql.js db. Whitebox §-log; no browser.
+//   Run: node viewer/tests/witness_se_wbs_breakdown.js   → exit 0 = GREEN.
+const path = require('path');
+const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const SA = require(path.join(__dirname, '..', 'schedule_author.js'));
+globalThis.ScheduleAuthor = SA;   // schedule_sync.applyOp resolves the engine via global.ScheduleAuthor
+const Sync = require(path.join(__dirname, '..', 'schedule_sync.js'));
+
+let pass = 0, fail = 0;
+function ok(c, m) { c ? pass++ : fail++; console.log(`§WBS ${c ? 'PASS' : 'FAIL'} ${m}`); }
+
+// seed: root + one dated leaf 'Architecture' holding 5 elements across 3 storeys / 2 classes
+function seed(SQL) {
+  const db = new SQL.Database();
+  db.run(`CREATE TABLE tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT,
+            predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT,
+            schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT,
+            free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT);
+          CREATE TABLE task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid));
+          CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT, element_name TEXT, storey TEXT, discipline TEXT);`);
+  db.run(`INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,is_summary,schedule_start,schedule_finish,schedule_duration) VALUES
+            ('TASK_ROOT','SCH_AUTHORED',NULL,'Project',1,'2026-01-01','2026-03-01','P59D'),
+            ('TASK_Architecture','SCH_AUTHORED','TASK_ROOT','Architecture',0,'2026-02-01','2026-03-01','P28D');`);
+  db.run(`INSERT INTO elements_meta VALUES
+            ('g1','IfcWall','','L1','ARC'),('g2','IfcWall','','L2','ARC'),('g3','IfcDoor','','L2','ARC'),
+            ('g4','IfcDoor','','L3','ARC'),('g5','IfcWall','','L3','ARC');`);
+  db.run(`INSERT INTO task_elements VALUES ('TASK_Architecture','g1'),('TASK_Architecture','g2'),
+            ('TASK_Architecture','g3'),('TASK_Architecture','g4'),('TASK_Architecture','g5');`);
+  return db;
+}
+const capLeafCount = db => db.exec("SELECT COUNT(*) FROM task_elements te JOIN tasks t ON t.task_id=te.task_id WHERE (t.is_summary IS NULL OR t.is_summary=0)")[0].values[0][0];
+const dump = db => JSON.stringify([db.exec('SELECT * FROM tasks ORDER BY task_id')[0].values,
+                                   db.exec('SELECT * FROM task_elements ORDER BY task_id,guid')[0].values]);
+
+(async () => {
+  const SQL = await initSqlJs();
+
+  // ── addTask: empty leaf under Architecture, inherits its window, parent stays a leaf (coverage intact) ──
+  let db = seed(SQL);
+  const a = SA.addTask(db, 'SCH_AUTHORED', { name: 'Fit-out', wbsParent: 'TASK_Architecture' });
+  ok(a.ok && a.taskId === 'TASK_Fit_out', `addTask → leaf id=${a.taskId} under Architecture`);
+  const ar = db.exec("SELECT wbs_parent,is_summary,schedule_start,schedule_finish FROM tasks WHERE task_id='TASK_Fit_out'")[0].values[0];
+  ok(ar[0] === 'TASK_Architecture' && ar[1] === 0 && ar[2] === '2026-02-01' && ar[3] === '2026-03-01', `child is_summary=0, inherits parent window 02-01..03-01`);
+  ok(db.exec("SELECT is_summary FROM tasks WHERE task_id='TASK_Architecture'")[0].values[0][0] === 0, `parent NOT forced to summary (keeps its elements + _cap coverage)`);
+  ok(capLeafCount(db) === 5, `all 5 elements still on non-summary leaves after addTask`);
+  const a2 = SA.addTask(db, 'SCH_AUTHORED', { name: 'Fit-out', wbsParent: 'TASK_Architecture' });
+  ok(a2.taskId === 'TASK_Fit_out_2', `name collision → suffixed id ${a2.taskId} (no clobber)`);
+
+  // ── breakdownByAttribute: split Architecture by storey → 3 children, parent becomes summary ──
+  db = seed(SQL);
+  const b = SA.breakdownByAttribute(db, 'SCH_AUTHORED', 'TASK_Architecture', 'storey');
+  ok(b.ok && b.groups.length === 3, `breakdown by storey → 3 groups (L1,L2,L3)`);
+  ok(b.groups.map(g => g.taskId).join(',') === 'TASK_Architecture__L1,TASK_Architecture__L2,TASK_Architecture__L3', `deterministic child ids parent__<storey>`);
+  ok(db.exec("SELECT is_summary FROM tasks WHERE task_id='TASK_Architecture'")[0].values[0][0] === 1, `parent → summary roll-up after its elements moved out`);
+  ok(db.exec("SELECT COUNT(*) FROM task_elements WHERE task_id='TASK_Architecture'")[0].values[0][0] === 0, `parent holds 0 direct elements (all moved to children)`);
+  ok(capLeafCount(db) === 5, `all 5 elements still on non-summary leaves (NO _cap coverage lost)`);
+  const l2 = db.exec("SELECT schedule_start,schedule_finish FROM tasks WHERE task_id='TASK_Architecture__L2'")[0].values[0];
+  ok(l2[0] === '2026-02-01' && l2[1] === '2026-03-01', `child inherits parent date window`);
+
+  // ── single-group guard: breakdown by discipline (all 'ARC') → refuse, nothing changed ──
+  const before = dump(db = seed(SQL));
+  const sg = SA.breakdownByAttribute(db, 'SCH_AUTHORED', 'TASK_Architecture', 'discipline');
+  ok(!sg.ok && sg.reason === 'single_group', `breakdown refused when only one group (all ARC)`);
+  ok(dump(db) === before, `single-group breakdown left the db UNCHANGED`);
+
+  // ── cross-tab convergence: applyOp('breakdown') on a peer db == direct call (byte-identical) ──
+  const dbA = seed(SQL), dbB = seed(SQL);
+  SA.breakdownByAttribute(dbA, 'SCH_AUTHORED', 'TASK_Architecture', 'storey');
+  Sync.applyOp(dbB, { op: 'breakdown', schedId: 'SCH_AUTHORED', taskId: 'TASK_Architecture', attr: 'storey' });
+  ok(dump(dbA) === dump(dbB), `applyOp('breakdown') converges peer db byte-identical to the direct verb`);
+  const dbC = seed(SQL);
+  Sync.applyOp(dbC, { op: 'addtask', schedId: 'SCH_AUTHORED', taskId: 'TASK_Fit_out', name: 'Fit-out', wbsParent: 'TASK_Architecture' });
+  ok(dbC.exec("SELECT 1 FROM tasks WHERE task_id='TASK_Fit_out'")[0].values.length === 1, `applyOp('addtask') replays with the explicit id`);
+
+  console.log(`§WBS-SUMMARY ${pass}/${pass + fail} pass`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e.stack); process.exit(1); });

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -886,8 +886,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=59" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="schedule_author.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_sync.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
+<script src="schedule_author.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_sync.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>


### PR DESCRIPTION
The Schedule Editor could view/collapse the WBS but not **deepen** it (user: *"shouldn't the Editor allow adding or breakdown or expanding of further subitems?"*). This adds both.

## Engine (`schedule_author.js`)
- **`addTask(db, schedId, {name, wbsParent})`** — a new **leaf** inherits the parent's date window; the parent is **not** forced to a summary, so its own elements + `_cap` coverage are preserved. Deterministic id (suffixes collisions).
- **`breakdownByAttribute(db, schedId, taskId, attr)`** — auto-split a populated phase's elements into child sub-tasks grouped by **storey | type | discipline**; children inherit the window; the emptied parent becomes a summary roll-up. **Every element still sits on a non-summary leaf → no `_cap`/4D coverage lost.** Deterministic child ids (`parent__<value>`).

## Editor UI (`schedule_editor_ui.js`)
A **＋** on each WBS row adds a sub-task; a **"break by…"** select on a populated leaf auto-splits it. Both broadcast a deterministic op; `schedule_sync.applyOp` gains `addtask`/`breakdown` so a 2nd tab and the Viewer TM converge.

## Witness — W-SE-WBS 15/15 (node, sql.js)
Real verbs: addTask inherits window + keeps coverage + suffixes id collisions; breakdown splits by storey, parent→summary, **all 5 elements stay on leaves**, single-group refused (db unchanged); `applyOp('breakdown'|'addtask')` converges a peer db **byte-identical**.
```
§WBS PASS all 5 elements still on non-summary leaves (NO _cap coverage lost)
§WBS PASS applyOp('breakdown') converges peer db byte-identical to the direct verb
§WBS-SUMMARY 15/15 pass
```
sw `v724→v725`; `schedule_author.js?v=8`, `schedule_sync.js?v=2`, `schedule_editor_ui.js?v=6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)