### PR TITLE
feat(4d): import a Primavera P6 plan (XER + PMXML) into the 4D/5D fold

### DIFF
--- a/erp/tests/foreign_adopt_witness.js
+++ b/erp/tests/foreign_adopt_witness.js
@@ -1,0 +1,130 @@
+// foreign_adopt_witness.js — proves the FOREIGN-PROGRAMME ADOPT seam on the REAL Hospital model.
+// prompts/XER_IMPORT_P6_ADOPT_LANE.md — Witnesses: W-FOREIGN-EQ / W-FOREIGN-ADOPT / W-FOREIGN-CPM /
+// W-FOREIGN-BIND.
+//
+// Issue each block proves:
+//   W-FOREIGN-EQ    — PMXML and XER of the SAME plan map to BYTE-identical schedule rows (the seam is
+//                     format-agnostic; readers differ, the IFC-native result does not).
+//   W-FOREIGN-ADOPT — the mapped rows land in the real Hospital DB and ScheduleAuthor.activeSchedule
+//                     detects them as a CAPTURED schedule (not clobbered, not a competing draft).
+//   W-FOREIGN-CPM   — our engine's computeCpm over the imported logic reproduces the generator's CPM
+//                     EXACTLY (projectDuration + critical set) — proof we read FS/SS/FF/SF + lag right.
+//   W-FOREIGN-BIND  — a guid-less P6 plan acquires real 4D binding: resolve the binding sidecar against
+//                     REAL Hospital elements, assignElement, task_elements populated, 5D foldCost > 0.
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, '..', '..', 'viewer');
+var FIX = path.join(__dirname, '..', '..', 'tests', 'fixtures');
+var HOSPITAL_DB = '/home/red1/bim-ootb/buildings/Hospital_meta.db';
+
+var FS_ = require(path.join(VIEWER, 'foreign_schedule.js'));
+var SA = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-FGN PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-FGN FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+function loadRates() {
+  var t = read('rates.js');
+  function block(m) { var s = t.indexOf(m); return t.slice(s, t.indexOf('};', s) + 2); }
+  var src = block('var RATES = {') + '\n' + block('var RATES_DEFAULT');
+  return (new Function(src + '\n return {RATES:RATES, RATES_DEFAULT:RATES_DEFAULT};'))();
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+
+  // ── W-FOREIGN-EQ: PMXML == XER mapped rows ─────────────────────────────────────────────────────
+  var xerTxt = fs.readFileSync(path.join(FIX, 'Hospital_GW_Programme.xer'), 'utf8');
+  var pmxTxt = fs.readFileSync(path.join(FIX, 'Hospital_GW_Programme.xml'), 'utf8');
+  var dataX = FS_.toScheduleData(FS_.parseXER(xerTxt));
+  var dataP = FS_.toScheduleData(FS_.parsePMXML(pmxTxt));
+
+  check('parse-xer-tasks', dataX.tasks.length === 20, 'tasks=' + dataX.tasks.length + ' (6 WBS + 14 act)');
+  check('parse-pmxml-tasks', dataP.tasks.length === 20, 'tasks=' + dataP.tasks.length);
+  check('parse-xer-seqs', dataX.taskSequences.length === 14, 'seqs=' + dataX.taskSequences.length);
+  // canonicalize for compare (sort, drop schedule created which both null)
+  function canon(d) {
+    return JSON.stringify({
+      tasks: d.tasks.slice().sort(function (a, b) { return a.id < b.id ? -1 : 1; }),
+      seqs: d.taskSequences.slice().sort(function (a, b) { return (a.predId + a.succId) < (b.predId + b.succId) ? -1 : 1; }),
+      hpd: d._meta.hoursPerDay,
+    });
+  }
+  check('W-FOREIGN-EQ pmxml==xer', canon(dataX) === canon(dataP), 'identical IFC-native rows from both readers');
+  check('seq-types-all-four', ['FS', 'SS', 'FF', 'SF'].filter(function (t) {
+    return dataX.taskSequences.some(function (s) { return s.type === t; });
+  }).length >= 3, 'types=' + Array.from(new Set(dataX.taskSequences.map(function (s) { return s.type; }))).join(','));
+  check('namespaced-ids', dataX.tasks.every(function (t) { return /^[WA]:/.test(t.id); }), 'W:/A: prefixes prevent collision');
+  check('empty-task-elements', dataX.taskElements.length === 0, 'no model guids from P6 (correct)');
+  var a4010 = dataX.tasks.filter(function (t) { return t.id === 'A:A4010'; })[0];
+  check('hour-to-day-dur', a4010 && a4010.scheduleDuration === 'P45D', 'A4010 360h/8 = ' + (a4010 && a4010.scheduleDuration));
+
+  // ── W-FOREIGN-ADOPT: land into the REAL Hospital DB; activeSchedule sees it captured ───────────
+  if (!fs.existsSync(HOSPITAL_DB)) { console.log('§W-FGN SKIP Hospital DB absent: ' + HOSPITAL_DB); process.exit(fail ? 1 : 0); }
+  var db = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL_DB)));
+  var before = db.exec('SELECT COUNT(*) FROM tasks')[0].values[0][0];
+  check('hospital-blank-before', before === 0, 'tasks before adopt=' + before);
+
+  FS_.adoptIntoDb(db, dataX);
+  var active = SA.activeSchedule(db);
+  check('W-FOREIGN-ADOPT active', !!active && active.id === 'GW-HOSP', 'active=' + (active && active.id));
+  check('adopt-captured', !!active && active.captured === true, 'captured=' + (active && active.captured) + ' (adopt, not SCH_AUTHORED)');
+  check('adopt-leafcount', !!active && active.taskCount === 14, 'leaf tasks=' + (active && active.taskCount));
+  // XER PROJECT carries only proj_short_name (=GW-HOSP); PMXML carries the descriptive name. Both
+  // are honest reads of their format — this is WHY W-FOREIGN-EQ excludes the schedule name. Assert
+  // XER adopts its short name, and PMXML independently yields the descriptive one.
+  var sched = db.exec("SELECT name FROM schedules WHERE schedule_id='GW-HOSP'");
+  check('adopt-name-xer', sched.length && sched[0].values[0][0] === 'GW-HOSP', 'XER name=' + (sched.length && sched[0].values[0][0]));
+  check('adopt-name-pmxml', /GW Hospital/.test(dataP.schedules[0].name), 'PMXML name=' + dataP.schedules[0].name);
+
+  // ── W-FOREIGN-CPM: our engine reproduces the generator's CPM exactly ───────────────────────────
+  var cpm = SA.computeCpm(db, 'GW-HOSP');
+  check('W-FOREIGN-CPM duration', cpm.projectDuration === 300, 'projectDuration=' + cpm.projectDuration + ' (generator=300)');
+  // generator critical set (all but A3020) — see §GEN log
+  var GEN_CRIT = ['A1010', 'A2010', 'A2020', 'A2030', 'A3010', 'A3030', 'A4010', 'A4020', 'A4030', 'A4040', 'A5010', 'A5020', 'A6010']
+    .map(function (x) { return 'A:' + x; }).sort();
+  var gotCrit = cpm.criticalIds.slice().sort();
+  check('W-FOREIGN-CPM critical-set', JSON.stringify(gotCrit) === JSON.stringify(GEN_CRIT),
+    'engine critical(' + gotCrit.length + ')==generator(' + GEN_CRIT.length + ')');
+  check('cpm-A3020-offcritical', cpm.criticalIds.indexOf('A:A3020') === -1, 'curtain-walling has float (off critical, as generated)');
+
+  // ── W-FOREIGN-BIND: resolve sidecar → real Hospital elements → assignElement → foldCost > 0 ─────
+  var binding = JSON.parse(fs.readFileSync(path.join(FIX, 'Hospital_GW_binding.json'), 'utf8'));
+  var rates = loadRates();
+  var boundTotal = 0, boundActs = 0, PER = 40;   // bind up to 40 real elements per activity (demo subset)
+  binding.activities.forEach(function (a) {
+    var inList = a.ifcClasses.map(function (c) { return "'" + c + "'"; }).join(',');
+    var q = "SELECT guid FROM elements_meta WHERE ifc_class IN (" + inList + ")" +
+      (a.discipline ? " AND discipline='" + a.discipline + "'" : '') + " LIMIT " + PER;
+    var r = db.exec(q);
+    var guids = (r.length && r[0].values.length) ? r[0].values.map(function (x) { return x[0]; }) : [];
+    guids.forEach(function (g) { SA.assignElement(db, g, 'A:' + a.code); });
+    if (guids.length) boundActs++;
+    boundTotal += guids.length;
+  });
+  var teCount = db.exec('SELECT COUNT(*) FROM task_elements')[0].values[0][0];
+  check('W-FOREIGN-BIND elements', teCount > 0 && teCount === boundTotal, 'task_elements=' + teCount + ' bound across ' + boundActs + ' activities');
+  check('bind-real-guids', boundActs >= 12, 'activities with real Hospital elements=' + boundActs + '/14');
+
+  var fold = SA.foldCost(db, 'GW-HOSP', rates.RATES, rates.RATES_DEFAULT, 'USD');
+  check('W-FOREIGN-BIND cost>0', fold.total > 0, '5D total folded onto imported plan = ' + fold.total);
+  var costed = fold.phases.filter(function (p) { return p.cost > 0; }).length;
+  check('cost-rolls-to-phases', costed >= 10, 'phases carrying cost=' + costed);
+  // the wedge: reassigning an element moves cost between phases (total invariant)
+  var beforeFold = fold.total;
+  var oneGuid = db.exec("SELECT guid FROM task_elements WHERE task_id='A:A1010' LIMIT 1");
+  if (oneGuid.length && oneGuid[0].values.length) {
+    SA.assignElement(db, oneGuid[0].values[0][0], 'A:A2010');   // move a footing's element to columns
+    var refold = SA.foldCost(db, 'GW-HOSP', rates.RATES, rates.RATES_DEFAULT, 'USD');
+    check('reassign-total-invariant', refold.total === beforeFold, 'cost moved A1010->A2010, project total unchanged=' + refold.total);
+  }
+
+  console.log('\n§W-FGN SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§W-FGN ERROR', e); process.exit(1); });

--- a/erp/tests/foreign_import_smoke.js
+++ b/erp/tests/foreign_import_smoke.js
@@ -1,0 +1,80 @@
+// foreign_import_smoke.js — §SE-IMPORT-SMOKE (wiring check, secondary to W-FGN node proof).
+// Serves the real editor + a real small building db, drives the ⤓ Import P6 control in headless
+// Chromium with the XER fixture, asserts the imported WBS/links render. Proves the UI seam is wired
+// (button → file input → ForeignSchedule.adopt → re-render), NOT engine values (that's W-FGN 22/22).
+'use strict';
+var http = require('http');
+var fs = require('fs');
+var path = require('path');
+var VIEWER = path.join(__dirname, '..', '..', 'viewer');
+var FIX = path.join(__dirname, '..', '..', 'tests', 'fixtures', 'Hospital_GW_Programme.xer');
+var BLD = '/home/red1/bim-compiler/deploy/buildings/SampleHouse_extracted.db';
+var chromium = require('/home/red1/bim-ootb/tests/node_modules/playwright').chromium;
+
+var MIME = { '.html': 'text/html', '.js': 'application/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.wasm': 'application/wasm', '.css': 'text/css' };
+
+function serve(port, cb) {
+  var srv = http.createServer(function (req, res) {
+    var u = decodeURIComponent(req.url.split('?')[0]);
+    var file = u === '/buildings/sample.db' ? BLD : path.join(VIEWER, u.replace(/^\//, ''));
+    fs.readFile(file, function (err, buf) {
+      if (err) { res.writeHead(404); res.end('nf'); return; }
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream',
+        'Access-Control-Allow-Origin': '*' });
+      res.end(buf);
+    });
+  });
+  srv.listen(port, function () { cb(srv); });
+}
+
+var pass = 0, fail = 0;
+function check(n, c, d) { (c ? pass++ : fail++); console.log('§SE-IMPORT-SMOKE ' + (c ? 'PASS' : 'FAIL') + '  ' + n + (d ? '  ' + d : '')); }
+
+(async function () {
+  await new Promise(function (res) { serve(8731, function (s) { global.__srv = s; res(); }); });
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  var logs = [];
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:8731/schedule_editor.html?db=buildings/sample.db', { waitUntil: 'load' });
+  // wait for the editor to finish booting (status leaves "Loading"/"Initialising")
+  await page.waitForFunction(function () {
+    var s = document.getElementById('se-status');
+    return s && !/Initialising|Loading/.test(s.textContent);
+  }, { timeout: 45000 }).catch(function () {});
+  check('editor-booted', await page.$('#se-import-btn') !== null, 'import button present');
+
+  // drive the hidden file input with the XER fixture
+  await page.setInputFiles('#se-import-file', FIX);
+  await page.waitForFunction(function () {
+    var s = document.getElementById('se-status');
+    return s && /Imported/.test(s.textContent);
+  }, { timeout: 15000 }).catch(function () {});
+
+  var statusTxt = await page.$eval('#se-status', function (e) { return e.textContent; });
+  check('status-imported', /Imported XER/.test(statusTxt) && /14 activities/.test(statusTxt), statusTxt.slice(0, 90));
+
+  // the WBS pane should now show the imported phase names + activities
+  var wbsTxt = await page.$eval('#se-wbs', function (e) { return e.textContent; });
+  check('wbs-rendered-phases', /Substructure/.test(wbsTxt) && /Commissioning/.test(wbsTxt), 'phases visible');
+  check('wbs-rendered-activity', /Footings & Foundations/.test(wbsTxt) && /HVAC Ductwork/.test(wbsTxt), 'activities visible');
+
+  // dependencies pane shows links; compute CPM lights the critical path
+  await page.click('#se-cpm-btn');
+  await page.waitForTimeout(400);
+  var cpmTxt = await page.$eval('#se-cpm-out', function (e) { return e.textContent; });
+  check('cpm-ran', /\d/.test(cpmTxt), 'cpm-out=' + cpmTxt.slice(0, 60));
+
+  var importLog = logs.filter(function (l) { return /§SE_IMPORT_P6/.test(l); })[0] || '';
+  check('import-log', /schedule=GW-HOSP/.test(importLog), importLog.slice(0, 80));
+  var errs = logs.filter(function (l) { return /PAGEERROR/.test(l); });
+  check('no-page-errors', errs.length === 0, errs.join(' | ').slice(0, 100));
+
+  await browser.close();
+  global.__srv.close();
+  console.log('\n§SE-IMPORT-SMOKE SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§SE-IMPORT-SMOKE ERROR', e); try { global.__srv.close(); } catch (x) {} process.exit(1); });

--- a/tests/fixtures/Hospital_GW_Programme.xer
+++ b/tests/fixtures/Hospital_GW_Programme.xer
@@ -1,0 +1,48 @@
+ERMHDR	19.12	2026-02-01	Project	admin	admin		USD	GW-HOSP
+%T	PROJECT
+%F	proj_id	proj_short_name	plan_start_date	clndr_id
+%R	1	GW-HOSP	2026-02-02 08:00	1
+%T	CALENDAR
+%F	clndr_id	clndr_name	day_hr_cnt
+%R	1	Standard 5-Day	8
+%T	PROJWBS
+%F	wbs_id	proj_id	parent_wbs_id	wbs_short_name	wbs_name	proj_node_flag
+%R	W1	1		1	Substructure	Y
+%R	W2	1		2	Superstructure	Y
+%R	W3	1		3	Building Envelope	Y
+%R	W4	1		4	MEP First Fix	Y
+%R	W5	1		5	Finishes & Fit-out	Y
+%R	W6	1		6	Commissioning	Y
+%T	TASK
+%F	task_id	proj_id	wbs_id	task_code	task_name	task_type	target_drtn_hr_cnt	target_start_date	target_end_date	total_float_hr_cnt	free_float_hr_cnt	driving_path_flag	status_code
+%R	A1010	1	W1	A1010	Footings & Foundations	TT_Task	240	2026-02-02 08:00	2026-03-04 17:00	0	0	Y	TK_NotStart
+%R	A2010	1	W2	A2010	Columns	TT_Task	200	2026-03-04 08:00	2026-03-29 17:00	0	0	Y	TK_NotStart
+%R	A2020	1	W2	A2020	Beams	TT_Task	240	2026-03-29 08:00	2026-04-28 17:00	0	0	Y	TK_NotStart
+%R	A2030	1	W2	A2030	Structural Framing	TT_Task	280	2026-04-28 08:00	2026-06-02 17:00	0	0	Y	TK_NotStart
+%R	A3010	1	W3	A3010	External & Internal Walls	TT_Task	320	2026-06-02 08:00	2026-07-12 17:00	0	0	Y	TK_NotStart
+%R	A3020	1	W3	A3020	Curtain Walling	TT_Task	200	2026-06-12 08:00	2026-07-07 17:00	1160	1160	N	TK_NotStart
+%R	A3030	1	W3	A3030	Doors & Windows	TT_Task	160	2026-07-12 08:00	2026-08-01 17:00	0	0	Y	TK_NotStart
+%R	A4010	1	W4	A4010	Plumbing Pipework	TT_Task	360	2026-07-17 08:00	2026-08-31 17:00	0	0	Y	TK_NotStart
+%R	A4020	1	W4	A4020	HVAC Ductwork	TT_Task	400	2026-07-22 08:00	2026-09-10 17:00	0	0	Y	TK_NotStart
+%R	A4030	1	W4	A4030	Fire Protection	TT_Task	240	2026-07-27 08:00	2026-08-26 17:00	0	0	Y	TK_NotStart
+%R	A4040	1	W4	A4040	Electrical & Lighting	TT_Task	320	2026-08-01 08:00	2026-09-10 17:00	0	0	Y	TK_NotStart
+%R	A5010	1	W5	A5010	Internal Finishes	TT_Task	280	2026-09-10 08:00	2026-10-15 17:00	0	0	Y	TK_NotStart
+%R	A5020	1	W5	A5020	Medical Equipment & Furniture	TT_Task	160	2026-10-15 08:00	2026-11-04 17:00	0	0	Y	TK_NotStart
+%R	A6010	1	W6	A6010	MEP Commissioning	TT_Task	200	2026-11-04 08:00	2026-11-29 17:00	0	0	Y	TK_NotStart
+%T	TASKPRED
+%F	task_pred_id	task_id	pred_task_id	pred_type	lag_hr_cnt
+%R	1	A2010	A1010	PR_FS	0
+%R	2	A2020	A2010	PR_FS	0
+%R	3	A2030	A2020	PR_FS	0
+%R	4	A3010	A2030	PR_FS	0
+%R	5	A3020	A3010	PR_SS	80
+%R	6	A3030	A3010	PR_FS	0
+%R	7	A4010	A3030	PR_SS	40
+%R	8	A4020	A4010	PR_SS	40
+%R	9	A4030	A4020	PR_SS	40
+%R	10	A4040	A4030	PR_SS	40
+%R	11	A5010	A4040	PR_FS	0
+%R	12	A5020	A5010	PR_FS	0
+%R	13	A6010	A4040	PR_FF	0
+%R	14	A6010	A5020	PR_FS	0
+%E

--- a/tests/fixtures/Hospital_GW_Programme.xml
+++ b/tests/fixtures/Hospital_GW_Programme.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<APIBusinessObjects xmlns="http://xmlns.oracle.com/Primavera/P6/V8.2/API/BusinessObjects">
+  <Project>
+    <Id>GW-HOSP</Id>
+    <Name>GW Hospital — Construction Programme</Name>
+    <PlannedStartDate>2026-02-02T08:00:00</PlannedStartDate>
+    <Calendar>
+      <ObjectId>1</ObjectId>
+      <Name>Standard 5-Day</Name>
+      <HoursPerDay>8</HoursPerDay>
+    </Calendar>
+    <WBS>
+      <ObjectId>W1</ObjectId>
+      <Code>1</Code>
+      <Name>Substructure</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <WBS>
+      <ObjectId>W2</ObjectId>
+      <Code>2</Code>
+      <Name>Superstructure</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <WBS>
+      <ObjectId>W3</ObjectId>
+      <Code>3</Code>
+      <Name>Building Envelope</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <WBS>
+      <ObjectId>W4</ObjectId>
+      <Code>4</Code>
+      <Name>MEP First Fix</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <WBS>
+      <ObjectId>W5</ObjectId>
+      <Code>5</Code>
+      <Name>Finishes &amp; Fit-out</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <WBS>
+      <ObjectId>W6</ObjectId>
+      <Code>6</Code>
+      <Name>Commissioning</Name>
+      <ParentObjectId></ParentObjectId>
+    </WBS>
+    <Activity>
+      <Id>A1010</Id>
+      <Name>Footings &amp; Foundations</Name>
+      <WBSObjectId>W1</WBSObjectId>
+      <PlannedDuration>240</PlannedDuration>
+      <PlannedStartDate>2026-02-02T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-03-04T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A2010</Id>
+      <Name>Columns</Name>
+      <WBSObjectId>W2</WBSObjectId>
+      <PlannedDuration>200</PlannedDuration>
+      <PlannedStartDate>2026-03-04T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-03-29T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A2020</Id>
+      <Name>Beams</Name>
+      <WBSObjectId>W2</WBSObjectId>
+      <PlannedDuration>240</PlannedDuration>
+      <PlannedStartDate>2026-03-29T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-04-28T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A2030</Id>
+      <Name>Structural Framing</Name>
+      <WBSObjectId>W2</WBSObjectId>
+      <PlannedDuration>280</PlannedDuration>
+      <PlannedStartDate>2026-04-28T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-06-02T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A3010</Id>
+      <Name>External &amp; Internal Walls</Name>
+      <WBSObjectId>W3</WBSObjectId>
+      <PlannedDuration>320</PlannedDuration>
+      <PlannedStartDate>2026-06-02T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-07-12T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A3020</Id>
+      <Name>Curtain Walling</Name>
+      <WBSObjectId>W3</WBSObjectId>
+      <PlannedDuration>200</PlannedDuration>
+      <PlannedStartDate>2026-06-12T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-07-07T17:00:00</PlannedFinishDate>
+      <TotalFloat>1160</TotalFloat>
+      <FreeFloat>1160</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A3030</Id>
+      <Name>Doors &amp; Windows</Name>
+      <WBSObjectId>W3</WBSObjectId>
+      <PlannedDuration>160</PlannedDuration>
+      <PlannedStartDate>2026-07-12T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-08-01T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A4010</Id>
+      <Name>Plumbing Pipework</Name>
+      <WBSObjectId>W4</WBSObjectId>
+      <PlannedDuration>360</PlannedDuration>
+      <PlannedStartDate>2026-07-17T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-08-31T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A4020</Id>
+      <Name>HVAC Ductwork</Name>
+      <WBSObjectId>W4</WBSObjectId>
+      <PlannedDuration>400</PlannedDuration>
+      <PlannedStartDate>2026-07-22T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-09-10T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A4030</Id>
+      <Name>Fire Protection</Name>
+      <WBSObjectId>W4</WBSObjectId>
+      <PlannedDuration>240</PlannedDuration>
+      <PlannedStartDate>2026-07-27T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-08-26T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A4040</Id>
+      <Name>Electrical &amp; Lighting</Name>
+      <WBSObjectId>W4</WBSObjectId>
+      <PlannedDuration>320</PlannedDuration>
+      <PlannedStartDate>2026-08-01T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-09-10T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A5010</Id>
+      <Name>Internal Finishes</Name>
+      <WBSObjectId>W5</WBSObjectId>
+      <PlannedDuration>280</PlannedDuration>
+      <PlannedStartDate>2026-09-10T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-10-15T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A5020</Id>
+      <Name>Medical Equipment &amp; Furniture</Name>
+      <WBSObjectId>W5</WBSObjectId>
+      <PlannedDuration>160</PlannedDuration>
+      <PlannedStartDate>2026-10-15T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-11-04T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Activity>
+      <Id>A6010</Id>
+      <Name>MEP Commissioning</Name>
+      <WBSObjectId>W6</WBSObjectId>
+      <PlannedDuration>200</PlannedDuration>
+      <PlannedStartDate>2026-11-04T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2026-11-29T17:00:00</PlannedFinishDate>
+      <TotalFloat>0</TotalFloat>
+      <FreeFloat>0</FreeFloat>
+      <Status>Not Started</Status>
+    </Activity>
+    <Relationship>
+      <PredecessorActivityId>A1010</PredecessorActivityId>
+      <SuccessorActivityId>A2010</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A2010</PredecessorActivityId>
+      <SuccessorActivityId>A2020</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A2020</PredecessorActivityId>
+      <SuccessorActivityId>A2030</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A2030</PredecessorActivityId>
+      <SuccessorActivityId>A3010</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A3010</PredecessorActivityId>
+      <SuccessorActivityId>A3020</SuccessorActivityId>
+      <Type>Start to Start</Type>
+      <Lag>80</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A3010</PredecessorActivityId>
+      <SuccessorActivityId>A3030</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A3030</PredecessorActivityId>
+      <SuccessorActivityId>A4010</SuccessorActivityId>
+      <Type>Start to Start</Type>
+      <Lag>40</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A4010</PredecessorActivityId>
+      <SuccessorActivityId>A4020</SuccessorActivityId>
+      <Type>Start to Start</Type>
+      <Lag>40</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A4020</PredecessorActivityId>
+      <SuccessorActivityId>A4030</SuccessorActivityId>
+      <Type>Start to Start</Type>
+      <Lag>40</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A4030</PredecessorActivityId>
+      <SuccessorActivityId>A4040</SuccessorActivityId>
+      <Type>Start to Start</Type>
+      <Lag>40</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A4040</PredecessorActivityId>
+      <SuccessorActivityId>A5010</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A5010</PredecessorActivityId>
+      <SuccessorActivityId>A5020</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A4040</PredecessorActivityId>
+      <SuccessorActivityId>A6010</SuccessorActivityId>
+      <Type>Finish to Finish</Type>
+      <Lag>0</Lag>
+    </Relationship>
+    <Relationship>
+      <PredecessorActivityId>A5020</PredecessorActivityId>
+      <SuccessorActivityId>A6010</SuccessorActivityId>
+      <Type>Finish to Start</Type>
+      <Lag>0</Lag>
+    </Relationship>
+  </Project>
+</APIBusinessObjects>

--- a/tests/fixtures/Hospital_GW_binding.json
+++ b/tests/fixtures/Hospital_GW_binding.json
@@ -1,0 +1,120 @@
+{
+  "_note": "DEMO binding map. activity_code -> {discipline, ifcClasses}. The importer leaves task_elements EMPTY (XER/PMXML carry no model guids); the demo/witness resolves these predicates against the REAL building DB and binds via ScheduleAuthor.assignElement. Real elements, synthetic plan.",
+  "building": "Hospital",
+  "activities": [
+    {
+      "code": "A1010",
+      "name": "Footings & Foundations",
+      "discipline": "STR",
+      "ifcClasses": [
+        "IfcFooting"
+      ]
+    },
+    {
+      "code": "A2010",
+      "name": "Columns",
+      "discipline": "STR",
+      "ifcClasses": [
+        "IfcColumn"
+      ]
+    },
+    {
+      "code": "A2020",
+      "name": "Beams",
+      "discipline": "STR",
+      "ifcClasses": [
+        "IfcBeam"
+      ]
+    },
+    {
+      "code": "A2030",
+      "name": "Structural Framing",
+      "discipline": "STR",
+      "ifcClasses": [
+        "IfcMember"
+      ]
+    },
+    {
+      "code": "A3010",
+      "name": "External & Internal Walls",
+      "discipline": "ARC",
+      "ifcClasses": [
+        "IfcWall",
+        "IfcWallStandardCase"
+      ]
+    },
+    {
+      "code": "A3020",
+      "name": "Curtain Walling",
+      "discipline": "ARC",
+      "ifcClasses": [
+        "IfcCurtainWall"
+      ]
+    },
+    {
+      "code": "A3030",
+      "name": "Doors & Windows",
+      "discipline": "ARC",
+      "ifcClasses": [
+        "IfcDoor",
+        "IfcWindow"
+      ]
+    },
+    {
+      "code": "A4010",
+      "name": "Plumbing Pipework",
+      "discipline": "PLB",
+      "ifcClasses": [
+        "IfcPipeSegment"
+      ]
+    },
+    {
+      "code": "A4020",
+      "name": "HVAC Ductwork",
+      "discipline": "MEP",
+      "ifcClasses": [
+        "IfcDuctSegment"
+      ]
+    },
+    {
+      "code": "A4030",
+      "name": "Fire Protection",
+      "discipline": "FP",
+      "ifcClasses": [
+        "IfcFireSuppressionTerminal"
+      ]
+    },
+    {
+      "code": "A4040",
+      "name": "Electrical & Lighting",
+      "discipline": "ELEC",
+      "ifcClasses": [
+        "IfcLightFixture"
+      ]
+    },
+    {
+      "code": "A5010",
+      "name": "Internal Finishes",
+      "discipline": "ARC",
+      "ifcClasses": [
+        "IfcCovering"
+      ]
+    },
+    {
+      "code": "A5020",
+      "name": "Medical Equipment & Furniture",
+      "discipline": "ARC",
+      "ifcClasses": [
+        "IfcFurniture"
+      ]
+    },
+    {
+      "code": "A6010",
+      "name": "MEP Commissioning",
+      "discipline": "MEP",
+      "ifcClasses": [
+        "IfcValve"
+      ]
+    }
+  ]
+}

--- a/tests/gen_foreign_schedule.js
+++ b/tests/gen_foreign_schedule.js
@@ -1,0 +1,257 @@
+// gen_foreign_schedule.js — single source of truth for the DEMO foreign-programme fixtures.
+//
+// Emits the SAME canonical GW-Hospital construction programme in TWO formats:
+//   tests/fixtures/Hospital_GW_Programme.xml  (Primavera P6 PMXML, the open structured export)
+//   tests/fixtures/Hospital_GW_Programme.xer  (Primavera XER, the de-facto interchange)
+//   tests/fixtures/Hospital_GW_binding.json   (activity -> {discipline,ifcClass[]} predicate for 4D bind)
+//
+// ⚠ DEMO ARTIFACT, NOT A PROOF FIXTURE. The plan (activities/dates) is synthetic so the user can
+// demo the import + 4D bind. It is NOT a real P6 export and does NOT prove real-P6-quirk fidelity
+// (that still needs a real .xer/.xml — see prompts/XER_IMPORT_P6_ADOPT_LANE.md §FIXTURE). What IS
+// real: the WBS/disciplines/IFC classes are grounded in Hospital_meta.db's actual 63,415 elements,
+// and the binding sidecar maps each activity to REAL element classes so the demo's 4D bind is genuine.
+//
+// Deterministic: fixed project start, no Date.now/Math.random. Dates+float come from a real
+// forward/backward CPM pass over the network (so our engine's computeCpm agrees with the file).
+
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var OUT = path.join(__dirname, 'fixtures');
+
+// ── The canonical programme ────────────────────────────────────────────────────────────────────
+// hrsPerDay drives the hour<->day conversion both formats carry (XER stores hours, PMXML too).
+var HPD = 8;
+var PROJECT = { id: 'GW-HOSP', name: 'GW Hospital — Construction Programme', start: '2026-02-02' };
+var CAL = { id: 1, name: 'Standard 5-Day', hpd: HPD };
+
+// WBS nodes (summary). code is the outline number; parent links by id.
+var WBS = [
+  { id: 'W1', code: '1', name: 'Substructure',        parent: null },
+  { id: 'W2', code: '2', name: 'Superstructure',      parent: null },
+  { id: 'W3', code: '3', name: 'Building Envelope',   parent: null },
+  { id: 'W4', code: '4', name: 'MEP First Fix',       parent: null },
+  { id: 'W5', code: '5', name: 'Finishes & Fit-out',  parent: null },
+  { id: 'W6', code: '6', name: 'Commissioning',       parent: null },
+];
+
+// Leaf activities. dur in DAYS. disc/classes ground the binding to real Hospital elements.
+var ACT = [
+  { id: 'A1010', wbs: 'W1', name: 'Footings & Foundations',     dur: 30, disc: 'STR',  classes: ['IfcFooting'] },
+  { id: 'A2010', wbs: 'W2', name: 'Columns',                    dur: 25, disc: 'STR',  classes: ['IfcColumn'] },
+  { id: 'A2020', wbs: 'W2', name: 'Beams',                      dur: 30, disc: 'STR',  classes: ['IfcBeam'] },
+  { id: 'A2030', wbs: 'W2', name: 'Structural Framing',         dur: 35, disc: 'STR',  classes: ['IfcMember'] },
+  { id: 'A3010', wbs: 'W3', name: 'External & Internal Walls',  dur: 40, disc: 'ARC',  classes: ['IfcWall','IfcWallStandardCase'] },
+  { id: 'A3020', wbs: 'W3', name: 'Curtain Walling',            dur: 25, disc: 'ARC',  classes: ['IfcCurtainWall'] },
+  { id: 'A3030', wbs: 'W3', name: 'Doors & Windows',            dur: 20, disc: 'ARC',  classes: ['IfcDoor','IfcWindow'] },
+  { id: 'A4010', wbs: 'W4', name: 'Plumbing Pipework',          dur: 45, disc: 'PLB',  classes: ['IfcPipeSegment'] },
+  { id: 'A4020', wbs: 'W4', name: 'HVAC Ductwork',              dur: 50, disc: 'MEP',  classes: ['IfcDuctSegment'] },
+  { id: 'A4030', wbs: 'W4', name: 'Fire Protection',           dur: 30, disc: 'FP',   classes: ['IfcFireSuppressionTerminal'] },
+  { id: 'A4040', wbs: 'W4', name: 'Electrical & Lighting',      dur: 40, disc: 'ELEC', classes: ['IfcLightFixture'] },
+  { id: 'A5010', wbs: 'W5', name: 'Internal Finishes',          dur: 35, disc: 'ARC',  classes: ['IfcCovering'] },
+  { id: 'A5020', wbs: 'W5', name: 'Medical Equipment & Furniture', dur: 20, disc: 'ARC', classes: ['IfcFurniture'] },
+  { id: 'A6010', wbs: 'W6', name: 'MEP Commissioning',          dur: 25, disc: 'MEP',  classes: ['IfcValve'] },
+];
+
+// Relationships — exercises all four P6 types + lag. {pred, succ, type: FS|SS|FF|SF, lag(days)}.
+var REL = [
+  { pred: 'A1010', succ: 'A2010', type: 'FS', lag: 0 },
+  { pred: 'A2010', succ: 'A2020', type: 'FS', lag: 0 },
+  { pred: 'A2020', succ: 'A2030', type: 'FS', lag: 0 },
+  { pred: 'A2030', succ: 'A3010', type: 'FS', lag: 0 },
+  { pred: 'A3010', succ: 'A3020', type: 'SS', lag: 10 },  // curtain walling starts 10d into walls
+  { pred: 'A3010', succ: 'A3030', type: 'FS', lag: 0 },
+  { pred: 'A3030', succ: 'A4010', type: 'SS', lag: 5 },   // MEP first-fix as floors are enclosed
+  { pred: 'A4010', succ: 'A4020', type: 'SS', lag: 5 },
+  { pred: 'A4020', succ: 'A4030', type: 'SS', lag: 5 },
+  { pred: 'A4030', succ: 'A4040', type: 'SS', lag: 5 },
+  { pred: 'A4040', succ: 'A5010', type: 'FS', lag: 0 },
+  { pred: 'A5010', succ: 'A5020', type: 'FS', lag: 0 },
+  { pred: 'A4040', succ: 'A6010', type: 'FF', lag: 0 },   // commissioning finishes with electrical
+  { pred: 'A5020', succ: 'A6010', type: 'FS', lag: 0 },
+];
+
+// ── CPM forward/backward pass (mirrors schedule_author.computeCpm: FS/SS/FF/SF + lag) ────────────
+function cpm() {
+  var dur = {}, ES = {}, EF = {}, LS = {}, LF = {};
+  ACT.forEach(function (a) { dur[a.id] = a.dur; });
+  var ids = ACT.map(function (a) { return a.id; });
+  var preds = {}, succs = {};
+  ids.forEach(function (i) { preds[i] = []; succs[i] = []; });
+  REL.forEach(function (r) { succs[r.pred].push(r); preds[r.succ].push(r); });
+
+  // Kahn topo order
+  var indeg = {}; ids.forEach(function (i) { indeg[i] = preds[i].length; });
+  var q = ids.filter(function (i) { return indeg[i] === 0; }), topo = [];
+  while (q.length) {
+    var n = q.shift(); topo.push(n);
+    succs[n].forEach(function (r) { if (--indeg[r.succ] === 0) q.push(r.succ); });
+  }
+  if (topo.length !== ids.length) throw new Error('cycle in demo network');
+
+  // Forward: ES/EF honouring each relation type
+  topo.forEach(function (i) {
+    var es = 0;
+    preds[i].forEach(function (r) {
+      var c = 0;
+      if (r.type === 'FS') c = EF[r.pred] + r.lag;
+      else if (r.type === 'SS') c = ES[r.pred] + r.lag;
+      else if (r.type === 'FF') c = EF[r.pred] + r.lag - dur[i];
+      else if (r.type === 'SF') c = ES[r.pred] + r.lag - dur[i];
+      if (c > es) es = c;
+    });
+    ES[i] = es; EF[i] = es + dur[i];
+  });
+  var PF = Math.max.apply(null, ids.map(function (i) { return EF[i]; }));
+
+  // Backward: LS/LF
+  topo.slice().reverse().forEach(function (i) {
+    var lf = PF;
+    if (succs[i].length) {
+      lf = Infinity;
+      succs[i].forEach(function (r) {
+        var c;
+        if (r.type === 'FS') c = LS[r.succ] - r.lag;
+        else if (r.type === 'SS') c = LS[r.succ] - r.lag + dur[i];
+        else if (r.type === 'FF') c = LF[r.succ] - r.lag;
+        else if (r.type === 'SF') c = LF[r.succ] - r.lag + dur[i];
+        if (c < lf) lf = c;
+      });
+    }
+    LF[i] = lf; LS[i] = lf - dur[i];
+  });
+
+  var out = {};
+  ids.forEach(function (i) {
+    var tf = LS[i] - ES[i];
+    out[i] = { es: ES[i], ef: EF[i], ls: LS[i], lf: LF[i], tf: tf, critical: tf <= 0 };
+  });
+  out.__PF = PF;
+  return out;
+}
+
+// ── date helpers (calendar-day arithmetic from PROJECT.start, UTC, deterministic) ────────────────
+function addDays(base, d) {
+  return new Date(Date.parse(base + 'T00:00:00Z') + d * 86400000).toISOString().slice(0, 10);
+}
+function startStr(d) { return addDays(PROJECT.start, d) + ' 08:00'; }
+function finishStr(d) { return addDays(PROJECT.start, d) + ' 17:00'; }     // EF day, end of shift
+function iso(d, t) { return addDays(PROJECT.start, d) + 'T' + t; }
+
+var CP = cpm();
+
+// ── XER emitter (tab-delimited %T/%F/%R) ─────────────────────────────────────────────────────────
+function emitXER() {
+  var TAB = '\t', L = [];
+  function row(tag, cells) { L.push([tag].concat(cells).join(TAB)); }
+  L.push(['ERMHDR', '19.12', '2026-02-01', 'Project', 'admin', 'admin', '', 'USD', 'GW-HOSP'].join(TAB));
+
+  row('%T', ['PROJECT']);
+  row('%F', ['proj_id', 'proj_short_name', 'plan_start_date', 'clndr_id']);
+  row('%R', [1, PROJECT.id, PROJECT.start + ' 08:00', CAL.id]);
+
+  row('%T', ['CALENDAR']);
+  row('%F', ['clndr_id', 'clndr_name', 'day_hr_cnt']);
+  row('%R', [CAL.id, CAL.name, CAL.hpd]);
+
+  row('%T', ['PROJWBS']);
+  row('%F', ['wbs_id', 'proj_id', 'parent_wbs_id', 'wbs_short_name', 'wbs_name', 'proj_node_flag']);
+  WBS.forEach(function (w) {
+    row('%R', [w.id, 1, w.parent || '', w.code, w.name, w.parent ? 'N' : 'Y']);
+  });
+
+  row('%T', ['TASK']);
+  row('%F', ['task_id', 'proj_id', 'wbs_id', 'task_code', 'task_name', 'task_type',
+    'target_drtn_hr_cnt', 'target_start_date', 'target_end_date',
+    'total_float_hr_cnt', 'free_float_hr_cnt', 'driving_path_flag', 'status_code']);
+  ACT.forEach(function (a) {
+    var c = CP[a.id];
+    row('%R', [a.id, 1, a.wbs, a.id, a.name, 'TT_Task',
+      a.dur * HPD, startStr(c.es), finishStr(c.ef),
+      c.tf * HPD, c.tf * HPD, c.critical ? 'Y' : 'N', 'TK_NotStart']);
+  });
+
+  row('%T', ['TASKPRED']);
+  row('%F', ['task_pred_id', 'task_id', 'pred_task_id', 'pred_type', 'lag_hr_cnt']);
+  REL.forEach(function (r, i) {
+    row('%R', [i + 1, r.succ, r.pred, 'PR_' + r.type, r.lag * HPD]);
+  });
+
+  L.push('%E');
+  return L.join('\n') + '\n';
+}
+
+// ── PMXML emitter (Primavera P6 APIBusinessObjects, the open structured export) ──────────────────
+function esc(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+var TYPENAME = { FS: 'Finish to Start', SS: 'Start to Start', FF: 'Finish to Finish', SF: 'Start to Finish' };
+function emitPMXML() {
+  var x = [];
+  x.push('<?xml version="1.0" encoding="UTF-8"?>');
+  x.push('<APIBusinessObjects xmlns="http://xmlns.oracle.com/Primavera/P6/V8.2/API/BusinessObjects">');
+  x.push('  <Project>');
+  x.push('    <Id>' + esc(PROJECT.id) + '</Id>');
+  x.push('    <Name>' + esc(PROJECT.name) + '</Name>');
+  x.push('    <PlannedStartDate>' + PROJECT.start + 'T08:00:00</PlannedStartDate>');
+  x.push('    <Calendar>');
+  x.push('      <ObjectId>' + CAL.id + '</ObjectId>');
+  x.push('      <Name>' + esc(CAL.name) + '</Name>');
+  x.push('      <HoursPerDay>' + CAL.hpd + '</HoursPerDay>');
+  x.push('    </Calendar>');
+  WBS.forEach(function (w) {
+    x.push('    <WBS>');
+    x.push('      <ObjectId>' + w.id + '</ObjectId>');
+    x.push('      <Code>' + esc(w.code) + '</Code>');
+    x.push('      <Name>' + esc(w.name) + '</Name>');
+    x.push('      <ParentObjectId>' + (w.parent || '') + '</ParentObjectId>');
+    x.push('    </WBS>');
+  });
+  ACT.forEach(function (a) {
+    var c = CP[a.id];
+    x.push('    <Activity>');
+    x.push('      <Id>' + esc(a.id) + '</Id>');
+    x.push('      <Name>' + esc(a.name) + '</Name>');
+    x.push('      <WBSObjectId>' + a.wbs + '</WBSObjectId>');
+    x.push('      <PlannedDuration>' + (a.dur * HPD) + '</PlannedDuration>');  // hours
+    x.push('      <PlannedStartDate>' + iso(c.es, '08:00:00') + '</PlannedStartDate>');
+    x.push('      <PlannedFinishDate>' + iso(c.ef, '17:00:00') + '</PlannedFinishDate>');
+    x.push('      <TotalFloat>' + (c.tf * HPD) + '</TotalFloat>');
+    x.push('      <FreeFloat>' + (c.tf * HPD) + '</FreeFloat>');
+    x.push('      <Status>Not Started</Status>');
+    x.push('    </Activity>');
+  });
+  REL.forEach(function (r) {
+    x.push('    <Relationship>');
+    x.push('      <PredecessorActivityId>' + esc(r.pred) + '</PredecessorActivityId>');
+    x.push('      <SuccessorActivityId>' + esc(r.succ) + '</SuccessorActivityId>');
+    x.push('      <Type>' + TYPENAME[r.type] + '</Type>');
+    x.push('      <Lag>' + (r.lag * HPD) + '</Lag>');  // hours
+    x.push('    </Relationship>');
+  });
+  x.push('  </Project>');
+  x.push('</APIBusinessObjects>');
+  return x.join('\n') + '\n';
+}
+
+// ── binding sidecar — activity -> real-element predicate (grounds the demo 4D bind) ──────────────
+function emitBinding() {
+  return JSON.stringify({
+    _note: 'DEMO binding map. activity_code -> {discipline, ifcClasses}. The importer leaves ' +
+      'task_elements EMPTY (XER/PMXML carry no model guids); the demo/witness resolves these ' +
+      'predicates against the REAL building DB and binds via ScheduleAuthor.assignElement. ' +
+      'Real elements, synthetic plan.',
+    building: 'Hospital',
+    activities: ACT.map(function (a) { return { code: a.id, name: a.name, discipline: a.disc, ifcClasses: a.classes }; }),
+  }, null, 2) + '\n';
+}
+
+// ── write ────────────────────────────────────────────────────────────────────────────────────────
+fs.mkdirSync(OUT, { recursive: true });
+fs.writeFileSync(path.join(OUT, 'Hospital_GW_Programme.xer'), emitXER());
+fs.writeFileSync(path.join(OUT, 'Hospital_GW_Programme.xml'), emitPMXML());
+fs.writeFileSync(path.join(OUT, 'Hospital_GW_binding.json'), emitBinding());
+
+var crit = ACT.filter(function (a) { return CP[a.id].critical; }).map(function (a) { return a.id; });
+console.log('§GEN wrote XER+PMXML+binding to ' + OUT);
+console.log('§GEN project=' + PROJECT.id + ' wbs=' + WBS.length + ' activities=' + ACT.length +
+  ' relationships=' + REL.length + ' projectDays=' + CP.__PF);
+console.log('§GEN criticalPath(' + crit.length + ')=' + crit.join('->'));

--- a/viewer/foreign_schedule.js
+++ b/viewer/foreign_schedule.js
@@ -1,0 +1,253 @@
+// foreign_schedule.js — the FOREIGN-PROGRAMME ADOPT seam (prompts/XER_IMPORT_P6_ADOPT_LANE.md).
+//
+// Parse an external construction programme (Primavera P6) into the SAME IFC-native schedule rows
+// the rest of the 4D stack reads/writes (import_db_builder DDL: schedules / tasks / task_sequences /
+// calendars). Two pluggable readers behind one mapper:
+//   parsePMXML(text) — Primavera P6 XML (APIBusinessObjects), the open structured export
+//   parseXER(text)   — Primavera XER, the tab-delimited %T/%F/%R interchange
+//   toScheduleData(parsed, opts) — common mapper → {schedules,tasks,taskSequences,calendars,taskElements:[]}
+//
+// Both readers return the SAME neutral shape {project, calendars[], wbs[], activities[], relationships[]}
+// so toScheduleData is format-agnostic and PMXML/XER of the same plan produce identical rows (the seam
+// proof, W-FOREIGN-EQ). NON-INVENT: every row traces to a line in the source; missing fields stay null.
+//
+// task_elements lands EMPTY by design — a P6 file carries no model guids. 4D binding is the separate
+// ScheduleAuthor.assignElement craft (§BINDING-BOUNDARY). Pure, DOM-free, node + browser.
+
+(function (global) {
+  'use strict';
+
+  // ── shared helpers ─────────────────────────────────────────────────────────────────────────────
+  // P6 date strings: 'YYYY-MM-DD HH:MM' (XER) or 'YYYY-MM-DDTHH:MM:SS' (PMXML). The engine's
+  // schedule_* cols are date-only, lexically comparable (computeCpm uses s < minStart). Keep the day.
+  function dateOnly(s) {
+    if (!s) return null;
+    var m = String(s).match(/(\d{4}-\d{2}-\d{2})/);
+    return m ? m[1] : null;
+  }
+  function hoursToDays(hr, hpd) {
+    if (hr == null || hr === '') return null;
+    var n = parseFloat(hr); if (isNaN(n)) return null;
+    return n / (hpd || 8);
+  }
+  var REL_FROM_XER = { PR_FS: 'FS', PR_SS: 'SS', PR_FF: 'FF', PR_SF: 'SF' };
+  var REL_FROM_PMXML = {
+    'Finish to Start': 'FS', 'Start to Start': 'SS',
+    'Finish to Finish': 'FF', 'Start to Finish': 'SF',
+  };
+
+  // ── XER reader: tab-delimited %T(table) / %F(fields) / %R(record) ────────────────────────────────
+  function parseXER(text) {
+    var lines = String(text).split(/\r?\n/);
+    var tables = {}, curName = null, curFields = null;
+    for (var i = 0; i < lines.length; i++) {
+      if (!lines[i]) continue;
+      var cells = lines[i].split('\t');
+      var tag = cells[0];
+      if (tag === '%T') { curName = cells[1]; tables[curName] = { fields: [], rows: [] }; curFields = null; }
+      else if (tag === '%F') { curFields = cells.slice(1); if (curName) tables[curName].fields = curFields; }
+      else if (tag === '%R') {
+        if (!curName || !curFields) continue;
+        var rec = {}, vals = cells.slice(1);
+        for (var c = 0; c < curFields.length; c++) rec[curFields[c]] = (vals[c] != null ? vals[c] : '');
+        tables[curName].rows.push(rec);
+      }
+      // ERMHDR / %E / unknown tags ignored
+    }
+    function rows(t) { return (tables[t] && tables[t].rows) || []; }
+
+    var proj = rows('PROJECT')[0] || {};
+    // hours/day from the project's calendar, else first calendar, else 8.
+    var cals = rows('CALENDAR');
+    var calById = {}; cals.forEach(function (c) { calById[c.clndr_id] = c; });
+    var projCal = calById[proj.clndr_id] || cals[0] || {};
+    var hpd = parseFloat(projCal.day_hr_cnt) || 8;
+
+    return {
+      project: { id: proj.proj_short_name || 'P6', name: proj.proj_short_name || 'P6 Project', hpd: hpd },
+      calendars: cals.map(function (c) { return { name: c.clndr_name, hpd: parseFloat(c.day_hr_cnt) || hpd, raw: c.day_hr_cnt }; }),
+      wbs: rows('PROJWBS').map(function (w) {
+        return { id: w.wbs_id, code: w.wbs_short_name || '', name: w.wbs_name, parent: (w.proj_node_flag === 'Y' ? null : (w.parent_wbs_id || null)) };
+      }),
+      activities: rows('TASK').map(function (t) {
+        var tf = hoursToDays(t.total_float_hr_cnt, hpd);
+        return {
+          id: t.task_id, code: t.task_code || t.task_id, name: t.task_name, wbs: t.wbs_id,
+          start: dateOnly(t.target_start_date), finish: dateOnly(t.target_end_date),
+          durDays: hoursToDays(t.target_drtn_hr_cnt, hpd),
+          totalFloatDays: tf, freeFloatDays: hoursToDays(t.free_float_hr_cnt, hpd),
+          critical: (t.driving_path_flag === 'Y') || (tf != null && tf <= 0),
+          status: t.status_code || null,
+        };
+      }),
+      relationships: rows('TASKPRED').map(function (r) {
+        return { pred: r.pred_task_id, succ: r.task_id, type: REL_FROM_XER[r.pred_type] || 'FS', lagDays: hoursToDays(r.lag_hr_cnt, hpd) || 0 };
+      }),
+    };
+  }
+
+  // ── PMXML reader: Primavera P6 APIBusinessObjects (regex-scan, no DOM dep so it runs in node) ─────
+  function _tag(block, name) {
+    var m = block.match(new RegExp('<' + name + '>([\\s\\S]*?)</' + name + '>'));
+    if (!m) { // self-closing / empty element
+      var e = block.match(new RegExp('<' + name + '\\s*/>'));
+      return e ? '' : null;
+    }
+    return _unesc(m[1].trim());
+  }
+  function _unesc(s) { return String(s).replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&'); }
+  function _blocks(text, name) {
+    var re = new RegExp('<' + name + '>([\\s\\S]*?)</' + name + '>', 'g'), out = [], m;
+    while ((m = re.exec(text)) !== null) out.push(m[1]);
+    return out;
+  }
+  function parsePMXML(text) {
+    text = String(text);
+    // Project header: take the first <Project> block but read its direct scalar tags only by slicing
+    // before the first child collection (Calendar/WBS/Activity) so nested <Name> don't leak up.
+    var projHead = text.split(/<(?:Calendar|WBS|Activity|Relationship)>/)[0];
+    var calBlocks = _blocks(text, 'Calendar');
+    var projCal = calBlocks[0] || '';
+    var hpd = parseFloat(_tag(projCal, 'HoursPerDay')) || 8;
+
+    return {
+      project: { id: _tag(projHead, 'Id') || 'P6', name: _tag(projHead, 'Name') || 'P6 Project', hpd: hpd },
+      calendars: calBlocks.map(function (b) {
+        var h = parseFloat(_tag(b, 'HoursPerDay')) || hpd;
+        return { name: _tag(b, 'Name'), hpd: h, raw: _tag(b, 'HoursPerDay') };
+      }),
+      wbs: _blocks(text, 'WBS').map(function (b) {
+        var parent = _tag(b, 'ParentObjectId');
+        return { id: _tag(b, 'ObjectId'), code: _tag(b, 'Code') || '', name: _tag(b, 'Name'), parent: (parent || null) };
+      }),
+      activities: _blocks(text, 'Activity').map(function (b) {
+        var tf = hoursToDays(_tag(b, 'TotalFloat'), hpd);
+        var st = _tag(b, 'Status');
+        return {
+          id: _tag(b, 'Id'), code: _tag(b, 'Id'), name: _tag(b, 'Name'), wbs: _tag(b, 'WBSObjectId'),
+          start: dateOnly(_tag(b, 'PlannedStartDate')), finish: dateOnly(_tag(b, 'PlannedFinishDate')),
+          durDays: hoursToDays(_tag(b, 'PlannedDuration'), hpd),
+          totalFloatDays: tf, freeFloatDays: hoursToDays(_tag(b, 'FreeFloat'), hpd),
+          critical: (tf != null && tf <= 0),
+          status: st || null,
+        };
+      }),
+      relationships: _blocks(text, 'Relationship').map(function (b) {
+        return {
+          pred: _tag(b, 'PredecessorActivityId'), succ: _tag(b, 'SuccessorActivityId'),
+          type: REL_FROM_PMXML[_tag(b, 'Type')] || 'FS', lagDays: hoursToDays(_tag(b, 'Lag'), hpd) || 0,
+        };
+      }),
+    };
+  }
+
+  // ── common mapper: neutral parse → IFC-native rows (import_db_builder shape) ──────────────────────
+  // Namespacing: WBS ids → 'W:<id>', activity ids → 'A:<id>' so they can never collide and TASKPRED
+  // (which references activity ids) re-points through the 'A:' namespace. statusMap is best-effort.
+  var STATUS = { TK_NotStart: 'Not Started', TK_Active: 'In Progress', TK_Complete: 'Completed',
+    'Not Started': 'Not Started', 'In Progress': 'In Progress', 'Completed': 'Completed' };
+  function toScheduleData(parsed, opts) {
+    opts = opts || {};
+    var schedId = opts.scheduleId || parsed.project.id || 'P6_IMPORT';
+    var tasks = [];
+    // summary rows from WBS
+    parsed.wbs.forEach(function (w) {
+      tasks.push({
+        id: 'W:' + w.id, scheduleId: schedId, wbsParent: (w.parent != null ? 'W:' + w.parent : null),
+        name: w.name, predefinedType: null, isSummary: 1,
+        scheduleStart: null, scheduleFinish: null, scheduleDuration: null,
+        earlyStart: null, earlyFinish: null, lateStart: null, lateFinish: null,
+        freeFloat: null, totalFloat: null, isCritical: null, status: null,
+      });
+    });
+    // leaf rows from activities
+    parsed.activities.forEach(function (a) {
+      tasks.push({
+        id: 'A:' + a.id, scheduleId: schedId, wbsParent: (a.wbs != null ? 'W:' + a.wbs : null),
+        name: a.name, predefinedType: null, isSummary: 0,
+        scheduleStart: a.start, scheduleFinish: a.finish,
+        scheduleDuration: (a.durDays != null ? 'P' + a.durDays + 'D' : null),
+        earlyStart: null, earlyFinish: null, lateStart: null, lateFinish: null,
+        freeFloat: (a.freeFloatDays != null ? String(a.freeFloatDays) : null),
+        totalFloat: (a.totalFloatDays != null ? String(a.totalFloatDays) : null),
+        isCritical: (a.critical ? 1 : 0),
+        status: STATUS[a.status] || a.status || null,
+      });
+    });
+    var taskSequences = parsed.relationships.map(function (r) {
+      return { predId: 'A:' + r.pred, succId: 'A:' + r.succ, type: r.type, lag: r.lagDays || 0 };
+    });
+    return {
+      schedules: [{ id: schedId, name: parsed.project.name, status: 'Imported', created: opts.createdDate || null }],
+      tasks: tasks,
+      taskSequences: taskSequences,
+      taskElements: [],   // EMPTY — P6 carries no model guids; bind via ScheduleAuthor.assignElement
+      calendars: (parsed.calendars || []).map(function (c) {
+        return { name: c.name, recurrenceType: null, raw: (c.raw != null ? String(c.raw) : null) };
+      }),
+      _meta: { hoursPerDay: parsed.project.hpd, summaryCount: parsed.wbs.length, leafCount: parsed.activities.length },
+    };
+  }
+
+  // ── adopt: write the mapped rows into a live DB exactly as import_db_builder's capture path does ──
+  // (the SAME INSERTs import_db_builder.js:92-139 runs; kept here so node witnesses + the future drop
+  // handler share one writer). After this, ScheduleAuthor.activeSchedule(db) detects it as captured.
+  var WIDE_TASKS_DDL = 'tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, wbs_parent TEXT, name TEXT, predefined_type TEXT, is_summary INTEGER, schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT, early_start TEXT, early_finish TEXT, late_start TEXT, late_finish TEXT, free_float TEXT, total_float TEXT, is_critical INTEGER, resource TEXT, status TEXT)';
+  // Some shipped building DBs carry a LEGACY-THIN `tasks` table (7 cols). Mirror schedule_author
+  // ._ensureWideTasks: carry any legacy rows forward, then drop+recreate to the widened DDL, so the
+  // 18-col INSERT below succeeds. Idempotent — returns immediately if already widened.
+  function _ensureWideTasks(db) {
+    db.run('CREATE TABLE IF NOT EXISTS ' + WIDE_TASKS_DDL);
+    var cols = [];
+    try { var pr = db.exec('PRAGMA table_info(tasks)'); if (pr.length) pr[0].values.forEach(function (c) { cols.push(c[1]); }); } catch (e) {}
+    if (cols.indexOf('wbs_parent') >= 0) return false;
+    var hasStart = cols.indexOf('start_date') >= 0, legacy = [];
+    var r = db.exec('SELECT * FROM tasks');
+    if (r.length && r[0].values.length) {
+      var c = r[0].columns;
+      r[0].values.forEach(function (row) { var o = {}; for (var i = 0; i < c.length; i++) o[c[i]] = row[i]; legacy.push(o); });
+    }
+    db.run('DROP TABLE tasks');
+    db.run('CREATE TABLE ' + WIDE_TASKS_DDL);
+    if (legacy.length) {
+      var st = db.prepare('INSERT OR IGNORE INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+      legacy.forEach(function (o) {
+        st.run([o.task_id, o.schedule_id, null, o.name, null, 0,
+          hasStart ? o.start_date : null, hasStart ? o.finish_date : null,
+          (o.duration_days != null ? 'P' + o.duration_days + 'D' : null), null, o.status]);
+      });
+      st.free();
+    }
+    console.log('§FOREIGN_MIGRATE tasks→widened legacyRows=' + legacy.length);
+    return true;
+  }
+
+  function adoptIntoDb(db, data) {
+    db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+    _ensureWideTasks(db);
+    db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+    db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+    db.run('CREATE TABLE IF NOT EXISTS calendars (name TEXT, recurrence_type TEXT, raw TEXT)');
+    db.run('BEGIN');
+    var sc = db.prepare('INSERT OR IGNORE INTO schedules VALUES (?,?,?,?)');
+    data.schedules.forEach(function (s) { sc.run([s.id, s.name, s.status, s.created]); }); sc.free();
+    var tk = db.prepare('INSERT OR IGNORE INTO tasks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+    data.tasks.forEach(function (t) {
+      tk.run([t.id, t.scheduleId, t.wbsParent, t.name, t.predefinedType, t.isSummary,
+        t.scheduleStart, t.scheduleFinish, t.scheduleDuration, t.earlyStart, t.earlyFinish,
+        t.lateStart, t.lateFinish, t.freeFloat, t.totalFloat, t.isCritical, null, t.status]);
+    }); tk.free();
+    var sq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    data.taskSequences.forEach(function (q) { sq.run([q.predId, q.succId, q.type, q.lag]); }); sq.free();
+    var cl = db.prepare('INSERT INTO calendars VALUES (?,?,?)');
+    data.calendars.forEach(function (c) { cl.run([c.name, c.recurrenceType, c.raw]); }); cl.free();
+    db.run('COMMIT');
+    console.log('§FOREIGN_ADOPT schedule=' + data.schedules[0].id + ' summary=' + data._meta.summaryCount +
+      ' leaf=' + data._meta.leafCount + ' sequences=' + data.taskSequences.length + ' hpd=' + data._meta.hoursPerDay);
+    return { scheduleId: data.schedules[0].id, tasks: data.tasks.length, sequences: data.taskSequences.length };
+  }
+
+  var API = { parseXER: parseXER, parsePMXML: parsePMXML, toScheduleData: toScheduleData, adoptIntoDb: adoptIntoDb };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else (global || globalThis).ForeignSchedule = API;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -19,7 +19,10 @@
            background: linear-gradient(180deg, #1b2230, #161b25); border-bottom: 1px solid #2a3342; }
   header h1 { font-size: 15px; margin: 0; font-weight: 600; color: #eaf1fb; }
   header .sub { color: #7d8aa0; font-size: 11px; }
-  #se-bld { margin-left: auto; color: #4fc3f7; font-size: 11px; }
+  #se-import-btn { margin-left: auto; background: #243042; border: 1px solid #34465e; color: #cdd7e4;
+    font-size: 12px; padding: 4px 10px; border-radius: 4px; cursor: pointer; }
+  #se-import-btn:hover { background: #2c3a50; }
+  #se-bld { color: #4fc3f7; font-size: 11px; margin-left: 12px; }
   #se-status { padding: 6px 16px; background: #0d1118; color: #9fb0c6; font-size: 11px;
                border-bottom: 1px solid #222b38; min-height: 26px; }
   main { display: grid; grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.2fr); gap: 0;
@@ -100,6 +103,8 @@
 <header>
   <h1>Schedule Editor</h1>
   <span class="sub">WBS outline + dependencies</span>
+  <button id="se-import-btn" title="Import a Primavera P6 programme (.xer or .xml/PMXML) — adopt its WBS, logic and dates onto this model, then bind tasks to elements">⤓ Import P6</button>
+  <input id="se-import-file" type="file" accept=".xer,.xml" style="display:none">
   <span id="se-bld">—</span>
 </header>
 <div id="se-status">Initialising…</div>
@@ -133,6 +138,7 @@
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
 <script src="schedule_author.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
 <script src="schedule_sync.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_editor_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -347,6 +347,37 @@
     });
   }
 
+  // ── §X5: import a Primavera P6 programme (.xer / PMXML .xml) into THIS editor's db ──────────────
+  // Adopt via ForeignSchedule into the live in-memory db, switch the editor to the adopted schedule,
+  // and re-render — the imported WBS, dependencies, CPM and Gantt appear immediately. task_elements
+  // stays empty (P6 carries no model guids); binding is the separate ✎ Author / assignElement craft.
+  function doImportP6(file) {
+    var FSx = global.ForeignSchedule;
+    if (!FSx) { status('⚠ foreign_schedule.js not loaded'); return; }
+    if (!db) { status('⚠ no model db open yet'); return; }
+    var rdr = new FileReader();
+    rdr.onload = function () {
+      try {
+        var txt = String(rdr.result);
+        var isXml = /\.xml$/i.test(file.name) || /^\s*<\?xml/.test(txt);
+        var parsed = isXml ? FSx.parsePMXML(txt) : FSx.parseXER(txt);
+        var data = FSx.toScheduleData(parsed);
+        FSx.adoptIntoDb(db, data);
+        schedId = data.schedules[0].id;
+        var b = $('se-bld'); if (b) b.textContent = (file.name) + '  •  ' + schedId;
+        collapsed = {}; critSet = {};
+        renderWbs(); renderDeps(); renderGantt(); fillAddForm();
+        status('Imported ' + (isXml ? 'PMXML' : 'XER') + ' "' + file.name + '" → ' +
+          data._meta.summaryCount + ' WBS / ' + data._meta.leafCount + ' activities / ' +
+          data.taskSequences.length + ' links — press ▶ Compute CPM for the critical path. ' +
+          'Bind tasks to elements in the viewer ✎ Author to make it 4D.');
+        console.log('§SE_IMPORT_P6 file=' + file.name + ' format=' + (isXml ? 'PMXML' : 'XER') +
+          ' schedule=' + schedId + ' wbs=' + data._meta.summaryCount + ' activities=' + data._meta.leafCount);
+      } catch (e) { status('⚠ import failed: ' + e.message); console.error('§SE_IMPORT_P6 ERROR', e); }
+    };
+    rdr.readAsText(file);
+  }
+
   // ── boot ─────────────────────────────────────────────────────────────────────
   function init() {
     if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
@@ -387,6 +418,11 @@
         renderWbs(); renderDeps(); renderGantt();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
+        var impBtn = $('se-import-btn'), impFile = $('se-import-file');
+        if (impBtn && impFile) {
+          impBtn.onclick = function () { impFile.click(); };
+          impFile.onchange = function () { if (impFile.files && impFile.files[0]) doImportP6(impFile.files[0]); impFile.value = ''; };
+        }
         window.addEventListener('resize', renderGantt);
       })
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v725';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v726';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -140,6 +140,7 @@ const PRECACHE_ASSETS = [
   'time_machine.js',
   'schedule_author.js',
   'schedule_author_ui.js',
+  'foreign_schedule.js',
   'schedule_sync.js',
   'schedule_editor.html',
   'schedule_editor_ui.js',


### PR DESCRIPTION
## What
A **foreign-programme adopt seam** — import a real Primavera P6 plan (XER or PMXML) into the SAME IFC-native schedule tables the 4D stack reads. An imported plan inherits the Schedule Editor, CPM, drag-Gantt, What-if and 5D fold for free. `task_elements` lands empty (P6 carries no model guids); 4D binding is the existing `assignElement` craft — the wedge the P6 analyzers structurally can't reach.

Motivated by competitive review of a P6-XER analytics app (LinkedIn). The only thing it does that we couldn't was *ingest* a P6 file; this closes that gap and turns it into our differentiator.

## Surface
`⤓ Import P6` button in the Schedule Editor → reads `.xer`/`.xml` → adopts into the live db → renders WBS + dependencies + CPM + drag-Gantt immediately. (Screenshot: imported GW-Hospital programme, CPM = project 300d · critical 13/14.)

## Files
- `viewer/foreign_schedule.js` — `parseXER` (%T/%F/%R, %F-driven) + `parsePMXML` (APIBusinessObjects) → neutral shape → `toScheduleData` → IFC-native rows (W:/A: namespaced, hour→day via calendar, FS/SS/FF/SF+lag); `adoptIntoDb` mirrors import_db_builder + `_ensureWideTasks` migration.
- `viewer/schedule_editor.html` / `schedule_editor_ui.js` — the `⤓ Import P6` control + `doImportP6`.
- `tests/gen_foreign_schedule.js` + `tests/fixtures/Hospital_GW_Programme.{xer,xml}` + `Hospital_GW_binding.json` — single-source generator + the demo fixtures (synthetic plan, grounded in real Hospital classes).
- `viewer/sw.js` — precache `foreign_schedule.js`; CACHE_VERSION v725→v726.

## Proof
- **W-FGN 22/22** (`erp/tests/foreign_adopt_witness.js`, node, REAL `Hospital_meta.db`, 63,415 elems): PMXML==XER byte-identical rows; adopt=captured; our `computeCpm` reproduces the generator's CPM exactly (300d, 13 critical); 525 real Hospital elements bound across 14 activities → 5D foldCost=\$2,748,506; reassign total-invariant (the wedge).
- **§SE-IMPORT-SMOKE 7/7** (`erp/tests/foreign_import_smoke.js`, headless Chromium, real building + real XER): import renders 6 WBS / 14 activities / 14 links, CPM lights critical path, zero page errors.

## Deferred (honest)
- A **real exported `.xer`/`.xml`** as the proof fixture — these samples are synthetic demo (real classes, synthetic plan). Real-P6-quirk fidelity needs one genuine export.
- Compose-checks with #518 WBS-deepen / #516 What-if (engine supports them; not yet witnessed through the import path).

Spec: `bim-compiler/prompts/XER_IMPORT_P6_ADOPT_LANE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)