### PR TITLE
ci(release): daily zero-touch auto-publish of the release PR

### DIFF
--- a/.github/workflows/auto-publish-release.yml
+++ b/.github/workflows/auto-publish-release.yml
@@ -1,0 +1,36 @@
+# Fully-automatic publishing — no human merge, ever.
+# prompts/RESUME_SYSMON_RELEASE_LINK.md §FIX B (user 2026-06-25: "I like it to be auto … my decision not needed").
+#
+# release-please keeps an open "Release PR" (labelled `autorelease: pending`) that batches merged changes. The
+# only manual step left was merging it. This job does that for you on a DAILY cadence: once a day it auto-merges
+# whatever release PR is open → release-please then cuts the vX.Y.Z release + changelog. A day with no merges →
+# no release PR → this is a no-op. Nothing to tune; nothing to decide.
+name: auto-publish-release
+
+on:
+  schedule:
+    - cron: '0 1 * * *'      # 01:00 UTC daily — publishes the previous day's batch
+  workflow_dispatch: {}        # manual escape hatch / publish-now button
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-publish-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge the pending release PR (if any)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number -q '.[0].number // empty')
+          if [ -z "$PR" ]; then echo "no pending release PR — nothing to publish today (no-op)"; exit 0; fi
+          echo "§AUTO-PUBLISH merging release PR #$PR → release-please will cut the release"
+          gh pr merge "$PR" --repo "$REPO" --squash --auto


### PR DESCRIPTION
Closes the last manual step in the release flow: a daily scheduled job (+ `workflow_dispatch`) auto-merges release-please's open `autorelease: pending` PR, so a day's batch publishes itself — no human merge, no decision. No-op on days with nothing to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)