### PR TITLE
ci(release): auto-publish cuts the release in-run (fixes token-merge no-trigger)

### DIFF
--- a/.github/workflows/auto-publish-release.yml
+++ b/.github/workflows/auto-publish-release.yml
@@ -1,15 +1,14 @@
 # Fully-automatic publishing — no human merge, ever.
 # prompts/RESUME_SYSMON_RELEASE_LINK.md §FIX B (user 2026-06-25: "I like it to be auto … my decision not needed").
 #
-# release-please keeps an open "Release PR" (labelled `autorelease: pending`) that batches merged changes. The
-# only manual step left was merging it. This job does that for you on a DAILY cadence: once a day it publishes
-# whatever release PR is open → release-please then cuts the vX.Y.Z release + changelog. A day with no merges →
-# no release PR → no-op. Nothing to tune; nothing to decide.
-#
-# Why it marks the checks itself: the release PR is bot-created, so GitHub does NOT run CI on it (workflows
-# don't fire on GITHUB_TOKEN-authored PRs). The PR is pure bookkeeping (CHANGELOG + version bump, no app code),
-# so this job marks the required contexts (fast-checks, e2e-tests) satisfied on its head — these statuses come
-# from THIS workflow's token (the GitHub Actions app, app_id 15368), which is exactly what branch protection requires.
+# Daily (and on-demand) this job PUBLISHES whatever release-please has batched. Two GitHub quirks make this
+# trickier than it looks, both handled here in ONE run (so nothing depends on a token-driven event that GitHub
+# would suppress):
+#   1. The release PR is bot-created → CI never runs on it → branch protection would block it. Step 1 marks the
+#      required contexts satisfied on its head (the PR is bookkeeping-only: CHANGELOG + version bump, no code).
+#   2. A merge done by GITHUB_TOKEN does NOT trigger other workflows → release-please wouldn't fire to cut the
+#      tag. So Step 2 runs release-please HERE, in the same run, which cuts the vX.Y.Z release for the just-merged
+#      PR. A day with no batch → no release PR → step 1 is a no-op and step 2 simply finds nothing to release.
 name: auto-publish-release
 
 on:
@@ -30,21 +29,30 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Publish the pending release PR (if any)
+      - name: Merge the pending release PR (if any)
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           PR=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number -q '.[0].number // empty')
-          if [ -z "$PR" ]; then echo "no pending release PR — nothing to publish today (no-op)"; exit 0; fi
+          if [ -z "$PR" ]; then echo "no open release PR to merge (already merged or nothing to release)"; exit 0; fi
           SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
-          echo "§AUTO-PUBLISH release PR #$PR @ $SHA — marking required contexts (bookkeeping-only PR) + merging"
+          echo "§AUTO-PUBLISH release PR #$PR @ $SHA — marking required contexts (bookkeeping-only) + merging"
           for ctx in fast-checks e2e-tests; do
             gh api -X POST "/repos/$REPO/statuses/$SHA" \
               -f state=success -f context="$ctx" \
               -f description="release PR — bookkeeping only (CHANGELOG + version), no app code to test" >/dev/null
             echo "  marked $ctx=success"
           done
-          gh pr merge "$PR" --repo "$REPO" --squash --auto
-          echo "§AUTO-PUBLISH merged #$PR → release-please will cut the release + changelog"
+          sleep 5
+          gh pr merge "$PR" --repo "$REPO" --squash
+          echo "§AUTO-PUBLISH merged #$PR"
+
+      # Cut the GitHub Release HERE (the token-driven merge above won't trigger release-please's own workflow).
+      # release-please is idempotent: it tags + releases any merged release PR that has no release yet, then is a
+      # no-op. This is what actually produces vX.Y.Z + the changelog notes.
+      - name: Cut the release for the merged release PR
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
A `GITHUB_TOKEN` merge doesn't trigger other workflows, so release-please never fired to tag. The auto-publish job now runs release-please itself right after merging — one run, no suppressed cross-trigger — so the release + changelog actually get cut. Idempotent (heals the already-merged v1.1.0 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)