### PR TITLE
feat(modeller): BOM Tree editor in the Outliner — Open extracted.db, signed re-parent

### DIFF
--- a/tests/witness_bom_tree_outliner.js
+++ b/tests/witness_bom_tree_outliner.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// W-BOMTREE-OUTLINER — pure-logic proof of the BOM Tree ⇄ Outliner integration:
+// Open extracted.db → seedFromElements → treeNodes (deep render) → foldReparents (signed reparent fold). Headless.
+'use strict';
+const cp = require('child_process'), fs = require('fs'), path = require('path');
+const V = path.join(__dirname, '..', 'viewer');
+const O = require(path.join(V, 'bom_tree_outliner.js'));
+const DB = process.argv[2] || '/home/red1/bim-compiler/deploy/dev/buildings/SampleHouse_extracted.db';
+let pass = 0, fail = 0; const ok = (c, m) => { (c ? pass++ : fail++); console.log(`  ${c ? '✓' : '✗ FAIL'} ${m}`); };
+function load(db) { const r = JSON.parse(cp.execFileSync('sqlite3', ['-json', db, "SELECT guid, ifc_class cls, storey, discipline disc FROM elements_meta"], { encoding: 'utf8', maxBuffer: 1 << 28 }) || '[]'); return r.map(x => ({ guid: x.guid, cls: x.cls, storey: x.storey, disc: x.disc })); }
+function leaves(ns) { let o = []; (ns || []).forEach(n => { if (n.kind === 'element') o.push(n.id); if (n.children) o = o.concat(leaves(n.children)); }); return o; }
+(function () {
+  console.log('═══ W-BOMTREE-OUTLINER — Open extracted.db → seed → render → signed reparent (pure logic) ═══');
+  const els = load(DB); console.log(`  ${path.basename(DB)} elements=${els.length}`);
+  const seed = O.seedFromElements(els, 'SampleHouse');
+  const nodes = O.treeNodes(seed);
+  ok(nodes.length === 1, `one root (building) [${nodes.length}]`);
+  const lv = leaves(nodes);
+  ok(lv.length === els.length, `every element rendered as a leaf [${lv.length}/${els.length}]`);
+  ok(nodes[0].children.length > 0 && nodes[0].children[0].kind === 'group', `deep nested groups under the building root`);
+  const e0 = lv[0];
+  const t0 = O.foldReparents(seed, []); const p0 = t0.nodes[e0].parent;
+  const otherClass = Object.keys(t0.nodes).find(k => t0.nodes[k].kind === 'class' && k !== p0);
+  const folded = O.foldReparents(seed, [{ childId: e0, toParent: otherClass }]);
+  ok(folded.nodes[e0].parent === otherClass, `reparent fold: element moved to new parent`);
+  ok(folded.nodes[e0].prov === 'user-authored', `reparent: provenance flips derived-seed → user-authored`);
+  ok(leaves(O.treeNodes(folded)).length === els.length, `reparent: still lossless (every element present) [${leaves(O.treeNodes(folded)).length}]`);
+  ok(JSON.stringify(O.treeNodes(seed)) === JSON.stringify(O.treeNodes(seed)), `treeNodes deterministic`);
+  const src = fs.readFileSync(path.join(V, 'bom_tree_outliner.js'), 'utf8');
+  const hits = (src.match(/['"`]Ifc[A-Z][A-Za-z]+['"`]/g) || []);
+  ok(hits.length === 0, `integration grep-clean of IFC class names [${hits.length}]`);
+  console.log(`\n═══ W-BOMTREE-OUTLINER: ${pass}/${pass + fail} ${fail ? '✗ RED' : '🟢 GREEN'} ═══`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/bom_tree.js
+++ b/viewer/bom_tree.js
@@ -1,0 +1,112 @@
+/**
+ * BIM OOTB — BOM Tree (the editable COMPOSITION facet of the Outliner).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// bom_tree.js — Implementing SPATIAL_DEPENDENCY_GRAPH.md §OUTLINER-COHERENCE (composition facet = editable `contains`)
+//   + §BUILD-DECOMPOSITION part 1 (Outliner BOM editor). Witness: W-BOM-TREE-EDIT.
+//
+// THE COMPOSITION FACET: unlike the read-only classification facets (storey/room/disc — group-bys), THIS facet's
+// STRUCTURE is authored by drag — re-parent an element, grab an upper node for the whole branch. It is the BOM
+// PRINCIPLE made live (recursive parent→children, user-composed) and the home of "pick a branch/bunch, edit/replace".
+//
+// OP-LOG-DRIVEN, NOT extracted.db-traversal: SEED once from elements (the immutable substrate, derived grouping), then
+// the tree is `foldOps(seed, reparentOps)` — the log carries all change. RE-PARENT is a PURE RE-POINT (L0b metadata):
+// it moves a child's parent pointer and TOUCHES NO GEOMETRY (this module never holds x/y/z) — "land the thread, then
+// re-point it out". Op shape is kernel_ops-compatible ({opType,params}) so it ports straight onto the real signed log.
+// GREP-CLEAN: ifc_class is only ever an opaque grouping key — no class-name literal drives a branch.
+
+(function (window) {
+'use strict';
+
+// ── SEED — a derived grouping building → storey → discipline → class → element (provenance: derived-seed) ──
+// elements: [{ guid, storey, disc, cls }]. Returns { nodes:{id:node}, roots:[id] }; node = {id,label,parent,kind,prov,guid?}.
+function seedTree(elements, opts) {
+  opts = opts || {};
+  var building = opts.building || 'BUILDING';
+  var nodes = {}, ROOT = 'B';
+  nodes[ROOT] = { id: ROOT, label: building, parent: null, kind: 'building', prov: 'derived-seed' };
+  function ensure(id, label, parent, kind) {
+    if (!nodes[id]) nodes[id] = { id: id, label: label, parent: parent, kind: kind, prov: 'derived-seed' };
+    return id;
+  }
+  for (var i = 0; i < elements.length; i++) {
+    var e = elements[i];
+    var st = e.storey == null ? 'Unknown' : e.storey;
+    var dc = e.disc == null ? 'ARC' : e.disc;
+    var cl = e.cls == null ? 'Unknown' : e.cls;
+    var sId = ensure('S|' + st, st, ROOT, 'storey');
+    var dId = ensure(sId + '|D|' + dc, dc, sId, 'disc');
+    var cId = ensure(dId + '|C|' + cl, cl, dId, 'class');
+    // element leaf — guid is the id (globally unique, GUID-bound = rename/regroup-proof)
+    nodes[e.guid] = { id: e.guid, label: e.guid, parent: cId, kind: 'element', prov: 'derived-seed', guid: e.guid };
+  }
+  return { nodes: nodes, roots: [ROOT] };
+}
+
+// ── REPARENT — the one composition edit. Pure pointer move; refuses cycle / self / missing (data integrity). ──
+function wouldCycle(tree, childId, newParentId) {
+  var p = newParentId;
+  while (p != null) { if (p === childId) return true; p = tree.nodes[p] ? tree.nodes[p].parent : null; }
+  return false;
+}
+// returns true if applied; false if refused (and leaves the tree untouched).
+function reparent(tree, childId, newParentId) {
+  var c = tree.nodes[childId], np = tree.nodes[newParentId];
+  if (!c || !np) return false;                 // missing node
+  if (childId === newParentId) return false;    // self
+  if (c.parent === newParentId) return false;   // no-op
+  if (wouldCycle(tree, childId, newParentId)) return false; // cycle (parent under its own descendant)
+  c.parent = newParentId;
+  c.prov = 'user-authored';                     // provenance flips: this edge is now authored, not derived
+  return true;
+}
+
+// op shape (kernel_ops-compatible): { opType:'BOM_REPARENT', params:{ childId, toParent } }.
+function applyOp(tree, op) {
+  if (op && op.opType === 'BOM_REPARENT') return reparent(tree, op.params.childId, op.params.toParent);
+  return false;
+}
+// ── FOLD — the tree IS foldOps(seed, ops). Deterministic replay (last-writer-wins per child). ──
+function foldOps(seed, ops) {
+  var tree = clone(seed);
+  for (var i = 0; i < (ops || []).length; i++) applyOp(tree, ops[i]);
+  return tree;
+}
+function clone(tree) {
+  var nodes = {};
+  Object.keys(tree.nodes).forEach(function (k) {
+    var n = tree.nodes[k];
+    nodes[k] = { id: n.id, label: n.label, parent: n.parent, kind: n.kind, prov: n.prov, guid: n.guid };
+  });
+  return { nodes: nodes, roots: tree.roots.slice() };
+}
+
+// ── EN-BLOC — the bunch under a node (all element-leaf guids in its subtree). The selection a handler edits. ──
+function bloc(tree, nodeId) {
+  // children index
+  var kids = {};
+  Object.keys(tree.nodes).forEach(function (k) {
+    var p = tree.nodes[k].parent; if (p != null) (kids[p] || (kids[p] = [])).push(k);
+  });
+  var out = [], stack = [nodeId];
+  while (stack.length) {
+    var id = stack.pop(), n = tree.nodes[id];
+    if (!n) continue;
+    if (n.kind === 'element') out.push(n.guid);
+    (kids[id] || []).forEach(function (c) { stack.push(c); });
+  }
+  return out;
+}
+
+// all element-leaf guids in the tree (for the lossless-partition check)
+function leaves(tree) {
+  return Object.keys(tree.nodes).filter(function (k) { return tree.nodes[k].kind === 'element'; });
+}
+
+var API = { seedTree: seedTree, reparent: reparent, applyOp: applyOp, foldOps: foldOps, bloc: bloc,
+            leaves: leaves, wouldCycle: wouldCycle };
+window.BOMTree = API;
+if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/viewer/bom_tree_outliner.js
+++ b/viewer/bom_tree_outliner.js
@@ -1,0 +1,131 @@
+/**
+ * BIM OOTB — BOM Tree ⇄ Outliner wiring (the ARC BOM editor in the Modeller).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// bom_tree_outliner.js — wires the composition facet (bom_tree.js) into the modeller Outliner (bonsai_outliner.js).
+// Implementing SPATIAL_DEPENDENCY_GRAPH.md §OUTLINER-COHERENCE + §BUILD-DECOMPOSITION part 1. Witness: W-BOMTREE-OUTLINER.
+//
+// A normal OPEN icon loads ANY extracted.db (no special BOM-drop panel — user direction 2026-06-25); its elements_meta
+// SEED the BOM Tree (building→storey→disc→class→element). Re-parent by drag = a SIGNED BOM_REPARENT op in kernel_ops
+// (the one log); geometry is NEVER touched (pure pointer re-point — "land the thread, then re-point it out"). The tree
+// is foldOps(seed, reparentOps) — op-log-driven, deterministic replay. GREP-CLEAN: no IFC class literal drives a branch.
+
+(function (window) {
+'use strict';
+var T = (typeof window !== 'undefined' && window.BOMTree) ? window.BOMTree
+        : (typeof require !== 'undefined' ? require('./bom_tree.js') : null);
+
+// ── PURE (node-witnessable) ────────────────────────────────────────────────────────────────────────
+function seedFromElements(elements, building) { return T.seedTree(elements, { building: building || 'Building' }); }
+function foldReparents(seed, reparentOps) {
+  return T.foldOps(seed, (reparentOps || []).map(function (o) { return { opType: 'BOM_REPARENT', params: o }; }));
+}
+// convert BOMTree {nodes,roots} → nested render nodes [{id,label,sub,kind,children}] for the Outliner (sorted = stable)
+function treeNodes(tree) {
+  if (!tree) return [];
+  var kids = {};
+  Object.keys(tree.nodes).forEach(function (k) { var p = tree.nodes[k].parent; if (p != null) (kids[p] || (kids[p] = [])).push(k); });
+  function leafCount(id) { var ch = kids[id] || []; if (!ch.length) return tree.nodes[id].kind === 'element' ? 1 : 0; var c = 0; ch.forEach(function (k) { c += leafCount(k); }); return c; }
+  function build(id) {
+    var n = tree.nodes[id], ch = (kids[id] || []).slice();
+    var isLeaf = n.kind === 'element';
+    var node = { id: id, kind: isLeaf ? 'element' : 'group',
+      label: isLeaf ? shortGuid(n.guid != null ? n.guid : n.label) : n.label,
+      sub: isLeaf ? (n.prov === 'user-authored' ? '✎ moved' : '') : ('(' + leafCount(id) + ')'),
+      children: isLeaf ? [] : ch.map(build).sort(byLabel) };
+    return node;
+  }
+  return tree.roots.map(build);
+}
+function byLabel(a, b) { return a.kind !== b.kind ? (a.kind === 'group' ? -1 : 1) : (a.label < b.label ? -1 : a.label > b.label ? 1 : 0); }
+function shortGuid(g) { g = String(g); return g.length > 12 ? g.slice(0, 10) + '…' : g; }
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { seedFromElements: seedFromElements, foldReparents: foldReparents, treeNodes: treeNodes };
+}
+
+// ── BROWSER glue (Open icon · signed commit · category registration) ─────────────────────────────────
+if (typeof window !== 'undefined' && window.document) {
+  var State = { seed: null, building: null, seq: 0 };
+
+  function reparentOpsFromLog() {
+    var db = window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.db; if (!db) return [];
+    try {
+      var r = db.exec("SELECT parameters FROM kernel_ops WHERE op_type='BOM_REPARENT' AND undone=0 ORDER BY id");
+      return r.length ? r[0].values.map(function (v) { return JSON.parse(v[0]); }) : [];
+    } catch (e) { return []; }
+  }
+  function currentTree() { return State.seed ? foldReparents(State.seed, reparentOpsFromLog()) : null; }
+
+  function commitReparent(childId, toParent) {
+    var db = window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.db;
+    if (!db || !window.KernelOps) { console.warn('§BOMTREE no oplog db — cannot sign reparent'); return; }
+    var baseTs = 1800000000000 + (State.seq++) * 1000;   // dedicated band, deterministic, no Date.now
+    window.KernelOps.commitGroup(db, [{ op_type: 'BOM_REPARENT', params: { childId: childId, toParent: toParent } }],
+      { gid: 'bomtree-' + childId + '-' + toParent + '-' + State.seq, baseTs: baseTs })
+      .then(function (res) {
+        console.log('§BOMTREE reparent SIGNED child=' + childId + ' →' + toParent + ' ok=' + (res && res.committed));
+        if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+      })
+      .catch(function (e) { console.warn('§BOMTREE commit failed', e && e.message); });
+  }
+
+  function category() {
+    return {
+      key: 'bomtree', label: 'BOM Tree',
+      tree: function () { var t = currentTree(); return t ? treeNodes(t) : []; },
+      onReparent: function (childId, targetId) {
+        var t = currentTree(); if (!t || !t.nodes[targetId]) return;
+        var tgt = t.nodes[targetId];
+        var toParent = (tgt.kind === 'element') ? tgt.parent : targetId;   // drop on a group → into it; on a leaf → as a sibling
+        // validate on a throwaway fold (cycle/self/missing refused, geometry untouched) before signing
+        if (!T.reparent(currentTree(), childId, toParent)) { console.warn('§BOMTREE reparent refused', childId, '→', toParent); return; }
+        commitReparent(childId, toParent);
+      }
+    };
+  }
+
+  function openExtractedDb(file) {
+    if (!window.SQL) { console.warn('§BOMTREE sql.js not ready'); return; }
+    var fr = new FileReader();
+    fr.onload = function () {
+      try {
+        var db = new window.SQL.Database(new Uint8Array(fr.result));
+        var r = db.exec("SELECT guid, ifc_class, storey, discipline FROM elements_meta");
+        var els = (r.length ? r[0].values : []).map(function (v) { return { guid: v[0], cls: v[1], storey: v[2], disc: v[3] }; });
+        State.building = (file.name || 'Building').replace(/\.db$/i, '').replace(/_extracted$/i, '');
+        State.seed = seedFromElements(els, State.building);
+        console.log('§BOMTREE opened "' + State.building + '" elements=' + els.length + ' → BOM Tree seeded');
+        db.close();
+        if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+      } catch (e) { console.warn('§BOMTREE open failed', e && e.message); }
+    };
+    fr.readAsArrayBuffer(file);
+  }
+
+  function mountOpenIcon() {
+    if (document.getElementById('bomtree-open')) return;
+    var inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.db,.sqlite'; inp.style.display = 'none';
+    inp.id = 'bomtree-file';
+    inp.onchange = function () { if (inp.files && inp.files[0]) openExtractedDb(inp.files[0]); };
+    document.body.appendChild(inp);
+    var btn = document.createElement('button'); btn.id = 'bomtree-open'; btn.title = 'Open an extracted.db building';
+    btn.textContent = '📂 Open';
+    btn.style.cssText = 'position:fixed;top:8px;left:252px;z-index:30;background:#1b1d23;color:#c7cdd8;' +
+      'border:1px solid #2c303a;border-radius:6px;padding:5px 10px;font:12px system-ui;cursor:pointer';
+    btn.onclick = function () { inp.click(); };
+    document.body.appendChild(btn);
+  }
+
+  window.BOMTreeOutliner = {
+    register: function () {
+      if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.addCategory(category());
+      mountOpenIcon();
+      console.log('§BOMTREE registered — Open icon + BOM Tree category (ARC BOM editor, signed re-parent, geometry untouched)');
+    },
+    openExtractedDb: openExtractedDb, _category: category, _currentTree: currentTree
+  };
+}
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -84,7 +84,11 @@
     _paint() {
       const tree = this._el.querySelector('#bo-tree'); if (!tree) return;
       const ops = (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps() : [];
-      const groups = this._categories.map(cat => ({ cat, nodes: ops.filter(cat.match).map(cat.node) }));
+      // FLAT categories (op-log feature groups — Walls/Openings/etc., unchanged). TREE categories (deep, seeded,
+      // editable — the BOM Tree composition facet, SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE) take a separate path.
+      const flatCats = this._categories.filter(c => !c.tree);
+      const treeCats = this._categories.filter(c => c.tree);
+      const groups = flatCats.map(cat => ({ cat, nodes: ops.filter(cat.match).map(cat.node) }));
       const f = this._find;
       const match = n => !f || (n.label + ' ' + n.sub).toLowerCase().includes(f);
       let total = 0, shown = 0;
@@ -105,6 +109,7 @@
             LEAF + n.label + '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span></div>';
         });
       });
+      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); html += r.html; total += r.total; shown += r.shown; });
       tree.innerHTML = html;
       tree.querySelectorAll('[data-grp]').forEach(d => d.onclick = () => { const k = d.getAttribute('data-grp'); this._collapsed[k] = !this._collapsed[k]; this._paint(); });
       tree.querySelectorAll('[data-fid]').forEach(d => d.onclick = () => {
@@ -112,10 +117,70 @@
         if (window.Bonsai.select) window.Bonsai.select(fid);   // → highlight() → setActive(): restyle only, no rebuild
         else this.setActive(fid);
       });
+      this._wireTrees(treeCats);
       const foot = this._el.querySelector('#bo-foot');
       const tip = (window.Bonsai.oplog && window.Bonsai.oplog._lastTip) || '';
       foot.textContent = (f ? shown + '/' + total + ' shown' : total + ' features') + (tip ? '  🔒 ' + tip.slice(0, 8) : '');
-      console.log(TAG + ' paint total=' + total + ' shown=' + shown + ' find="' + f + '"');
+      console.log(TAG + ' paint total=' + total + ' shown=' + shown + ' find="' + f + '" trees=' + treeCats.length);
+    },
+
+    // ── DEEP / EDITABLE tree category (the BOM Tree composition facet). cat.tree() → [rootNode];
+    //    node = {id,label,sub,kind,children}. Drag a node onto another → cat.onReparent(childId,targetId) (signed op
+    //    upstream). GREP-CLEAN of geometry: this renders pointers only, never touches a placement.
+    _treeHtml(cat, match) {
+      const roots = (cat.tree ? cat.tree() : []) || [];
+      const ckey = 'tcat|' + cat.key, col = this._collapsed[ckey];
+      let leafTotal = 0; const countLeaves = ns => ns.forEach(n => { if (n.kind === 'element') leafTotal++; if (n.children) countLeaves(n.children); });
+      countLeaves(roots);
+      let html = '<div data-tcat="' + cat.key + '" style="padding:2px 6px 2px 16px;color:#6f7a8b;cursor:pointer">' +
+        CHEV(!col) + cat.label + ' <span style="color:#454e5d">(' + leafTotal + ')</span></div>';
+      let shown = 0;
+      if (!col) { const r = this._renderNodes(roots, 1, cat.key, match); html += r.html; shown = r.shown; }
+      return { html: html, total: leafTotal, shown: shown };
+    },
+    _renderNodes(nodes, depth, ckey, match) {
+      let html = '', shown = 0;
+      (nodes || []).forEach(n => {
+        const kids = n.children || [];
+        const isLeaf = n.kind === 'element';
+        const vis = !this._find || this._subtreeMatches(n, match);
+        if (!vis) return;
+        if (isLeaf) shown++;
+        const ncol = this._collapsed['bn|' + n.id];
+        const active = window.Bonsai._selId === n.id;
+        const pad = 16 + depth * 14;
+        html += '<div data-bnode="' + n.id + '" data-tcat="' + ckey + '" data-leaf="' + (isLeaf ? 1 : 0) + '" draggable="true" ' +
+          'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' +
+          (active ? 'background:#26456b;color:#dce6f4' : 'color:#c7cdd8') + '">' +
+          (kids.length ? CHEV(!ncol) : LEAF) + n.label +
+          (n.sub ? '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span>' : '') + '</div>';
+        if (kids.length && !ncol) { const r = this._renderNodes(kids, depth + 1, ckey, match); html += r.html; shown += r.shown; }
+      });
+      return { html: html, shown: shown };
+    },
+    _subtreeMatches(n, match) { if (match({ label: n.label, sub: n.sub || '' })) return true; return (n.children || []).some(c => this._subtreeMatches(c, match)); },
+    _wireTrees(treeCats) {
+      if (!this._el || !treeCats.length) return;
+      const byKey = {}; treeCats.forEach(c => byKey[c.key] = c);
+      this._el.querySelectorAll('[data-tcat]:not([data-bnode])').forEach(d => d.onclick = () => {
+        const k = 'tcat|' + d.getAttribute('data-tcat'); this._collapsed[k] = !this._collapsed[k]; this._paint();
+      });
+      this._el.querySelectorAll('[data-bnode]').forEach(d => {
+        const id = d.getAttribute('data-bnode'), isLeaf = d.getAttribute('data-leaf') === '1';
+        d.onclick = () => {
+          if (isLeaf) { const num = +id; if (window.Bonsai.select && !isNaN(num)) window.Bonsai.select(num); else this.setActive(id); }
+          else { this._collapsed['bn|' + id] = !this._collapsed['bn|' + id]; this._paint(); }
+        };
+        d.ondragstart = e => { e.dataTransfer.setData('text/bnode', id); this._dragSrc = id; };
+        d.ondragover = e => { e.preventDefault(); d.style.outline = '1px dashed #4a78b8'; };
+        d.ondragleave = () => { d.style.outline = 'none'; };
+        d.ondrop = e => {
+          e.preventDefault(); d.style.outline = 'none';
+          const src = (e.dataTransfer && e.dataTransfer.getData('text/bnode')) || this._dragSrc;
+          const cat = byKey[d.getAttribute('data-tcat')];
+          if (src && cat && cat.onReparent && src !== id) cat.onReparent(src, id);
+        };
+      });
     }
   };
 

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -181,7 +181,10 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=2" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=3" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
+<script src="bom_tree.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
+<script src="bom_tree_outliner.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
@@ -1741,6 +1744,9 @@ window.Bonsai.outliner.addCategory({ key: 'components', label: 'Components', mat
     const lod = window.Bonsai.library ? window.Bonsai.library.lodFor(op.id, op.parameters.lod) : op.parameters.lod;
     return { id: op.id, label: (c ? (c.name || c.ifc_class.replace('Ifc', '')) : 'Component'),
       sub: ((a && (a.x || a.y)) ? ((a.x || '·') + '-' + (a.y || '·')) : '#' + op.id) + ' ·LOD' + lod + ((mv.dx || mv.dy || mv.dz) ? ' ·moved' : '') }; } });
+// BOM Tree composition facet (the ARC BOM editor) — flag-gated ?bomtree for now; Open any extracted.db → editable BOM
+// tree in the Outliner, re-parent = signed BOM_REPARENT (geometry untouched). SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE.
+if (qs.get('bomtree') !== null && window.BOMTreeOutliner) { window.BOMTreeOutliner.register(); console.log('§MODELLER BOM Tree editor ON (?bomtree)'); }
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));


### PR DESCRIPTION
## What
The **ARC BOM editor** in the modeller's Outliner (`SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE / §BUILD-DECOMPOSITION part 1`).

- **📂 Open icon** loads ANY `extracted.db` (no special BOM-drop panel) → `elements_meta` seed a deep, editable **BOM Tree** (building→storey→disc→class→element) as a registered Outliner category.
- **Re-parent by drag = a SIGNED `BOM_REPARENT` op** in `kernel_ops` (the one log); **geometry is NEVER touched** (pure pointer re-point — "land the thread, then re-point it out"). Tree = `foldOps(seed, reparentOps)`, deterministic replay.
- **Outliner extended ADDITIVELY**: a category may now supply `tree()`/`onReparent` (deep nested render + HTML5 drag-drop). The existing flat Walls/Openings path is **byte-identical**.
- **Flag-gated `?bomtree`** — the default modeller is untouched (low regression risk).

## Witness
- **W-BOMTREE-OUTLINER 8/8** (`tests/witness_bom_tree_outliner.js`, node, real SampleHouse extracted.db): Open→seed→deep render→signed reparent fold, lossless, deterministic, grep-clean of IFC class names.
- Reuses **`bom_tree.js`** (W-BOM-TREE-EDIT 15/15 — re-parent geometry-untouched 0 mm).

## Files
`viewer/bom_tree.js` (model) · `viewer/bom_tree_outliner.js` (Open + seed + signed reparent) · `viewer/bonsai_outliner.js` (+tree category, additive) · `viewer/modeller.html` (wiring) · `tests/witness_bom_tree_outliner.js`.

## Not in this PR (follow-ons)
Headless browser smoke (load `modeller.html?bomtree`, open a db, assert the tree renders + a drag signs a `BOM_REPARENT`); landing the opened building's geometry into the modeller scene (selection-highlight needs it); the axis handler + align handler (parts 2–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)