### PR TITLE
STR Walker live in the modeller (?strwalk) + fix #530 qs-TDZ modeller breakage

### DIFF
--- a/tests/smoke_strwalk_modeller.js
+++ b/tests/smoke_strwalk_modeller.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * §STRWALK-SMOKE — headless WIRING check for ?strwalk in the live modeller (deploy gate, secondary
+ * to the node witnesses W-STR-* 29/29). Per TestArchitecture §Browser Testing: Playwright verifies
+ * WIRING only (scripts load, category registers, button mounts, grid-move wrap installs) — value
+ * verification is the §-log/witness, not this. Serves the worktree viewer/, loads modeller.html?strwalk.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', 'viewer');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller.html?strwalk', { waitUntil: 'load', timeout: 30000 });
+  // wait for the register hook to fire (or scene ready)
+  await page.waitForFunction(function () {
+    return window.__sceneReady === true || (window.STRWalkerOutliner && document.getElementById('strwalk-open'));
+  }, { timeout: 20000 }).catch(function () {});
+  await page.waitForTimeout(800);
+
+  var r = await page.evaluate(function () {
+    return {
+      engineLoaded: typeof window.swWalkSkeleton === 'function' && typeof window.swReWalk === 'function',
+      bridgeLoaded: typeof window.swbInit === 'function' && typeof window.swbOnGridMove === 'function',
+      olLoaded: !!window.STRWalkerOutliner,
+      categoryAdded: !!(window.Bonsai && window.Bonsai.outliner && window.Bonsai.outliner._categories &&
+        window.Bonsai.outliner._categories.some(function (c) { return c.key === 'strwalk'; })),
+      buttonMounted: !!document.getElementById('strwalk-open'),
+      gridWrapped: !!(window.Bonsai && window.Bonsai.gridmove && window.Bonsai.gridmove._strWrapped)
+    };
+  });
+
+  var pass = 0, fail = 0;
+  function chk(name, cond) { if (cond) { pass++; console.log('  ✅ ' + name); } else { fail++; console.log('  ❌ ' + name); } }
+  console.log('═══ §STRWALK-SMOKE — ?strwalk wiring (headless) ═══');
+  chk('C1 engine loaded (str_walker.js)', r.engineLoaded);
+  chk('C2 bridge loaded (str_walker_bridge.js)', r.bridgeLoaded);
+  chk('C3 outliner-wiring loaded (STRWalkerOutliner)', r.olLoaded);
+  chk('C4 STR category registered in Outliner', r.categoryAdded);
+  chk('C5 🏗 STR button mounted', r.buttonMounted);
+  chk('C6 Bonsai.gridmove.commit wrapped (re-walk hook)', r.gridWrapped);
+  var registered = logs.some(function (l) { return /§MODELLER STR Walker ON/.test(l); });
+  chk('C7 §MODELLER STR Walker ON logged', registered);
+  var loadFail = logs.filter(function (l) { return /STRWALK LOAD_FAIL/.test(l); });
+  chk('C8 no STRWALK script LOAD_FAIL', loadFail.length === 0);
+
+  console.log('§STRWALK-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -185,6 +185,11 @@
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
 <script src="bom_tree.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
 <script src="bom_tree_outliner.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
+<!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
+     (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
+<script src="str_walker.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
+<script src="str_walker_bridge.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
+<script src="str_walker_outliner.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
@@ -1744,9 +1749,15 @@ window.Bonsai.outliner.addCategory({ key: 'components', label: 'Components', mat
     const lod = window.Bonsai.library ? window.Bonsai.library.lodFor(op.id, op.parameters.lod) : op.parameters.lod;
     return { id: op.id, label: (c ? (c.name || c.ifc_class.replace('Ifc', '')) : 'Component'),
       sub: ((a && (a.x || a.y)) ? ((a.x || '·') + '-' + (a.y || '·')) : '#' + op.id) + ' ·LOD' + lod + ((mv.dx || mv.dy || mv.dz) ? ' ·moved' : '') }; } });
+// Query string — declared here (BEFORE the register hooks). FIX 2026-06-26: was a top-level `const qs` declared
+// ~90 lines below, so the ?bomtree hook (and now ?strwalk) referenced it in its TDZ → "Cannot access 'qs' before
+// initialization" threw on EVERY load, killing __sceneReady. Hoisted up; the later duplicate declaration removed.
+const qs = new URLSearchParams(location.search);
 // BOM Tree composition facet (the ARC BOM editor) — flag-gated ?bomtree for now; Open any extracted.db → editable BOM
 // tree in the Outliner, re-parent = signed BOM_REPARENT (geometry untouched). SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE.
 if (qs.get('bomtree') !== null && window.BOMTreeOutliner) { window.BOMTreeOutliner.register(); console.log('§MODELLER BOM Tree editor ON (?bomtree)'); }
+// STR Walker (?strwalk) — STR as a WALKED discipline: 🏗 open an STR building → walk; grid drag re-walks + flags.
+if (qs.get('strwalk') !== null && window.STRWalkerOutliner) { window.STRWalkerOutliner.register(); console.log('§MODELLER STR Walker ON (?strwalk)'); }
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
@@ -1834,10 +1845,10 @@ console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai
 })();
 
 // Headless witness hooks. ?author=wall|opening|both auto-authors the sample ops.
-const qs = new URLSearchParams(location.search);
+// (`const qs` hoisted up to before the register hooks — see the FIX note above.)
 // PERSISTENCE: restore the saved signed model on boot so work survives a reload — unless a demo hook runs
 // (demos clear() and drive their own state). Folds the restored op-log to the scene + refreshes panels.
-if (![...qs.keys()].some(k => /^(author|recipe|preload|outliner|grid|ifc|signed|fastauthor|sweep|route|routewalk|fillet|constrain|gridmove|gmpreview|sketch|insert|place|edit|ux|numdim|camera|regen)$/.test(k))) {
+if (![...qs.keys()].some(k => /^(author|recipe|preload|outliner|grid|ifc|signed|fastauthor|sweep|route|routewalk|fillet|constrain|gridmove|gmpreview|sketch|insert|place|edit|ux|numdim|camera|regen|bomtree|strwalk)$/.test(k))) {
   (async () => { try { const n = await window.Bonsai.oplog.restore(); if (n) { syncHistory(); setStat('restored ' + n + ' feature' + (n === 1 ? '' : 's') + ' from your last session'); } } catch (e) { console.warn('§MODELLER restore fail ' + e); } window.__restoreDone = true; })();
 }
 const q = qs.get('author');

--- a/viewer/str_walker.js
+++ b/viewer/str_walker.js
@@ -1,0 +1,352 @@
+/**
+ * BIM OOTB — STR Walker JS (the structural RouteWalker)
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Implements prompts/STR_ROUTEWALKING_SPEC.md — the STRUCTURAL walker, mirror of RouteWalker.
+ * SLICE 1 = the SKELETON walk (deterministic, RS-clean): derive the emergent structural grid
+ * from a building's columns (the SDG datum_plane substrate), then WALK each column onto its
+ * grid intersection. Position = f(grid). NON-INVENT: every gridline value is the MEAN of the
+ * real column coordinates it owns (traceable), zero hardcoded spacing, zero invented positions.
+ *
+ * This file is NEW. It edits no existing file. GUID prefix: SW2D- (never collides with
+ * IFC-extracted, Java RW-, or JS RW2D- elements).
+ *
+ * Witness: scripts/witness_str_walk_skeleton.js (W-STR-WALK-SKELETON).
+ * Oracle: pristine *_extracted.db / raw extraction — NEVER cooked output.db.
+ */
+'use strict';
+
+// ─── Constants ───────────────────────────────────────────────
+var SW_PREFIX = 'SW2D-';
+// Cluster gap tolerance (metres): a gap > this between consecutive sorted column coordinates
+// starts a new gridline. Within-line jitter is centimetres; adjacent lines are ≥~0.5m apart.
+// MEASURED on Terminal (158 cols): the grid RESOLVES at gapTol ≤ 0.5m → 18×10 lines, max column
+// residual 0.329m, mean 5.2cm (a stable plateau; coarser tol MERGES real X-lines → false 0.855m
+// residual). Tuned to the data via the sweep in witness_str_walk_skeleton.js, reported by §-log.
+var SW_GRID_GAP_TOL = 0.5;
+// A cluster whose total span exceeds this is rejected as NOT a single gridline (anti-drift guard
+// against greedy chaining across a whole wing). Span is reported; never silently merged.
+var SW_GRID_SPAN_MAX = 2.0;
+
+// ─── 1D clustering → gridlines (the emergent datum) ──────────
+// Greedy by consecutive gap; gridline value = MEAN of the cluster it owns (non-invent).
+// Returns [{ value, members:[v...], span }]. Members trace each line to real coordinates.
+function swClusterAxis(values, gapTol, spanMax) {
+  if (!values.length) return [];
+  var sorted = values.slice().sort(function (a, b) { return a - b; });
+  var lines = [];
+  var cur = [sorted[0]];
+  for (var i = 1; i < sorted.length; i++) {
+    if (sorted[i] - sorted[i - 1] <= gapTol) {
+      cur.push(sorted[i]);
+    } else {
+      lines.push(cur); cur = [sorted[i]];
+    }
+  }
+  lines.push(cur);
+  return lines.map(function (members) {
+    var sum = members.reduce(function (s, v) { return s + v; }, 0);
+    var span = members[members.length - 1] - members[0];
+    return { value: sum / members.length, members: members, span: span, spanOk: span <= spanMax };
+  });
+}
+
+// ─── Derive the emergent structural grid from columns ────────
+// columns: [{ guid, x, y, z }]. Returns { xLines:[..], yLines:[..], xMeta, yMeta, gapTol }.
+function swDeriveGrid(columns, opts) {
+  opts = opts || {};
+  var gapTol = opts.gapTol != null ? opts.gapTol : SW_GRID_GAP_TOL;
+  var spanMax = opts.spanMax != null ? opts.spanMax : SW_GRID_SPAN_MAX;
+  var xMeta = swClusterAxis(columns.map(function (c) { return c.x; }), gapTol, spanMax);
+  var yMeta = swClusterAxis(columns.map(function (c) { return c.y; }), gapTol, spanMax);
+  return {
+    xLines: xMeta.map(function (m) { return m.value; }),
+    yLines: yMeta.map(function (m) { return m.value; }),
+    xMeta: xMeta, yMeta: yMeta, gapTol: gapTol, spanMax: spanMax
+  };
+}
+
+// ─── Nearest gridline ────────────────────────────────────────
+function swNearest(value, lines) {
+  var best = lines[0], bestD = Math.abs(value - lines[0]);
+  for (var i = 1; i < lines.length; i++) {
+    var d = Math.abs(value - lines[i]);
+    if (d < bestD) { bestD = d; best = lines[i]; }
+  }
+  return { line: best, dist: bestD };
+}
+
+// ─── SKELETON WALK: snap each column onto its grid intersection ──
+// Position = f(grid): walked (x,y) is EXACTLY a gridline pair (deterministic, RS-clean).
+// residual = planar distance from the real column to its snapped intersection (reported, the
+// grid-quantization error). z is kept verbatim (Z lattice handled by a later slice).
+function swWalkColumns(columns, grid, opts) {
+  opts = opts || {};
+  var out = [];
+  for (var i = 0; i < columns.length; i++) {
+    var c = columns[i];
+    var nx = swNearest(c.x, grid.xLines);
+    var ny = swNearest(c.y, grid.yLines);
+    var residual = Math.hypot(nx.dist, ny.dist);
+    out.push({
+      guid: SW_PREFIX + (c.guid || ('col' + i)),
+      srcGuid: c.guid,                 // the extracted column this walks (oracle link)
+      x: nx.line, y: ny.line, z: c.z,  // ON the grid — f(grid)
+      residual: residual,
+      provenance: 'derived:grid'       // never ifc_extract; the position is computed from the datum
+    });
+  }
+  return out;
+}
+
+// ─── SPANS WALK: girders between adjacent grid columns ───────
+// The `spans` edge (prompts/SPATIAL_DEPENDENCY_GRAPH.md §SPANS): along each gridline, columns
+// snapped to that line are sorted and ADJACENT pairs get a girder. The girder runs ON one datum
+// (its gridline) and SPANS between two distinct perpendicular datums (the two gridlines its
+// endpoints sit on); span == |toDatum − fromDatum| = one structural bay. Cross-section is NOT
+// derived here (held; sized by the regulatory handler later). NON-INVENT: endpoints are real
+// snapped columns, span is a measured grid gap, zero invented length.
+function swWalkGirders(columns, grid, opts) {
+  var snap = columns.map(function (c) {
+    return { x: swNearest(c.x, grid.xLines).line, y: swNearest(c.y, grid.yLines).line, srcGuid: c.guid };
+  });
+  var girders = [];
+  function emit(axis, onDatum, fromD, toD, from, to, i) {
+    girders.push({
+      guid: SW_PREFIX + 'GIRDER-' + axis + onDatum.toFixed(2) + '-' + i,
+      axis: axis, onDatum: onDatum,            // the gridline the girder runs along
+      fromDatum: fromD, toDatum: toD,          // the two distinct datums it spans between
+      from: from, to: to, span: Math.abs(toD - fromD),
+      provenance: 'derived:str-walk'
+    });
+  }
+  // Girders along each X-line span between adjacent Y-datums (sort the line's columns by y).
+  grid.xLines.forEach(function (xl) {
+    var on = snap.filter(function (s) { return s.x === xl; }).sort(function (a, b) { return a.y - b.y; });
+    for (var i = 1; i < on.length; i++) {
+      if (on[i].y === on[i - 1].y) continue;   // duplicate column at one intersection
+      emit('Xline@', xl, on[i - 1].y, on[i].y, [xl, on[i - 1].y], [xl, on[i].y], i);
+    }
+  });
+  // Girders along each Y-line span between adjacent X-datums.
+  grid.yLines.forEach(function (yl) {
+    var on = snap.filter(function (s) { return s.y === yl; }).sort(function (a, b) { return a.x - b.x; });
+    for (var i = 1; i < on.length; i++) {
+      if (on[i].x === on[i - 1].x) continue;
+      emit('Yline@', yl, on[i - 1].x, on[i].x, [on[i - 1].x, yl], [on[i].x, yl], i);
+    }
+  });
+  return girders;
+}
+
+// ═══ REGULATORY HANDLER — span/depth + deflection → RED/ORANGE (STR_ROUTEWALKING_SPEC §2B) ═══
+// EVERY threshold lives in this CITED table — no magic numbers in the logic below (the door
+// doctrine: measure/cite, never invent). These are PRELIMINARY (LOD 200-300) sizing rules of
+// thumb with their code basis; a full check is the engineer's, not the walker's. UBBL (Malaysia)
+// governs structural design by ADOPTING the MS EN Eurocodes, so Eurocode is the citation of record.
+var SW_SPAN_RULES = {
+  STEEL: {
+    depthRatio: 20,        // preliminary girder depth ≈ span/20
+    deflectionDenom: 360,  // serviceability δ ≤ span/360 (variable load)
+    maxBeamSpan: 18,       // practical rolled-section span; beyond → plate girder / truss
+    source: 'EN 1993-1-1 (Eurocode 3) §7.2 serviceability δ≤L/360; preliminary depth ≈ L/20 ' +
+            '(SCI Steel Designers\' Manual). Cross-ref AISC 360-16; IBC/ASCE 7 Table 1604.3.'
+  },
+  RC: {
+    depthRatio: 12,        // preliminary RC beam overall depth ≈ span/12
+    deflectionDenom: 250,  // total deflection ≈ span/250 basic
+    maxBeamSpan: 12,       // beyond → post-tension / deep beam
+    source: 'EN 1992-1-1 (Eurocode 2) §7.4.2 span/effective-depth basic ratios; preliminary depth ' +
+            '≈ L/12. Cross-ref ACI 318-19 Table 9.3.1.1 (L/16 simply-supported).'
+  }
+};
+
+// Check one walked girder's span against the cited rule → a RED/ORANGE/GREEN signal.
+// span (m); opts.material 'STEEL'|'RC'; opts.proposedDepth (m, optional) = the depth being offered.
+function swCheckGirder(span, opts) {
+  opts = opts || {};
+  var mat = opts.material || 'STEEL';
+  var rule = SW_SPAN_RULES[mat];
+  var requiredDepth = span / rule.depthRatio;
+  var maxDeflection = span / rule.deflectionDenom;
+  var signal, message;
+  if (span > rule.maxBeamSpan) {
+    signal = 'RED';
+    message = 'span ' + span.toFixed(1) + 'm > ' + rule.maxBeamSpan + 'm max for a ' + mat +
+      ' beam → no valid solid-beam load path: add an intermediate column or use a truss';
+  } else if (opts.proposedDepth != null && opts.proposedDepth < requiredDepth - 1e-9) {
+    signal = 'ORANGE';
+    message = 'proposed depth ' + opts.proposedDepth.toFixed(2) + 'm < required ' +
+      requiredDepth.toFixed(2) + 'm (L/' + rule.depthRatio + ') → upsize';
+  } else {
+    signal = 'GREEN';
+    message = 'ok: provide depth ≥ ' + requiredDepth.toFixed(2) + 'm (L/' + rule.depthRatio +
+      '), keep δ ≤ ' + maxDeflection.toFixed(3) + 'm (L/' + rule.deflectionDenom + ')';
+  }
+  return {
+    signal: signal, material: mat, span: span, requiredDepth: requiredDepth,
+    maxDeflection: maxDeflection, rule: 'span/depth+deflection', source: rule.source,
+    message: message, provenance: 'derived:regulatory'
+  };
+}
+
+// Validate a REAL member's as-built depth against the rule (depth adequate ⟺ span/depth ≤ ratio).
+function swConforms(span, depth, opts) {
+  var mat = (opts && opts.material) || 'STEEL';
+  var rule = SW_SPAN_RULES[mat];
+  var ratio = depth > 0 ? span / depth : Infinity;
+  return { conforms: ratio <= rule.depthRatio, ratio: ratio, limit: rule.depthRatio, source: rule.source };
+}
+
+// ═══ TESSELLATION WALKER — the GENERATIVE half (STR_ROUTEWALKING_SPEC §2A.3 / §5) ═══
+// A space-frame / cladding system = ONE measured unit repeated n times over a measured surface
+// domain = `instanced-by n` (extent = f(n); collapse n→1 ⇒ the system vanishes). This walk is
+// GENERATIVE: it reconstructs the COUNT + COVERAGE within tol, NEVER bit-exact positions, and is
+// graded against extracted plates as ORACLE. NON-INVENT: unit, domain, surface profile and band
+// density are all MEASURED; provenance derived:str-walk; the non-modal tail is reported, not dropped.
+
+// Measure the tessellation parameters from a real plate cloud (no invention).
+// plates: [{ x,y,z, bx,by,bz }]. opts.edgeTrim = fraction of extreme x-bands dropped as taper.
+function swDeriveTessellation(plates, opts) {
+  opts = opts || {};
+  var edgeTrim = opts.edgeTrim != null ? opts.edgeTrim : 0.1;
+  // modal unit = most common rounded bbox (the repeated cell)
+  var hist = {};
+  plates.forEach(function (p) {
+    var k = p.bx.toFixed(1) + 'x' + p.by.toFixed(1) + 'x' + p.bz.toFixed(2);
+    hist[k] = (hist[k] || 0) + 1;
+  });
+  var modeKey = Object.keys(hist).sort(function (a, b) { return hist[b] - hist[a]; })[0];
+  var modalCount = hist[modeKey];
+  var mb = modeKey.split('x').map(Number);
+  // domain = bbox of centres
+  var xs = plates.map(function (p) { return p.x; }), ys = plates.map(function (p) { return p.y; }),
+      zs = plates.map(function (p) { return p.z; });
+  var domain = {
+    minX: Math.min.apply(null, xs), maxX: Math.max.apply(null, xs),
+    minY: Math.min.apply(null, ys), maxY: Math.max.apply(null, ys),
+    minZ: Math.min.apply(null, zs), maxZ: Math.max.apply(null, zs)
+  };
+  // surface profile z ≈ f(x): mean z per 1m x-band. NOTE this is a 1D MID-SURFACE simplification of
+  // the true z=f(x,y) shell (the canopy curves in BOTH x and y; measured locally thin = 0.07m/cell,
+  // globally 8.7m). Sufficient for count/extent reconstruction; a full 2D surface fit is a later slice.
+  var bandSum = {}, bandN = {};
+  plates.forEach(function (p) { var b = Math.floor(p.x); bandSum[b] = (bandSum[b] || 0) + p.z; bandN[b] = (bandN[b] || 0) + 1; });
+  var bands = Object.keys(bandN).map(Number).sort(function (a, b) { return a - b; });
+  var zProfile = bands.map(function (b) { return { x: b, z: bandSum[b] / bandN[b], n: bandN[b] }; });
+  // interior band density (edge-trimmed) → independent count predictor
+  var counts = bands.map(function (b) { return bandN[b]; }).sort(function (a, b) { return a - b; });
+  var lo = Math.floor(counts.length * edgeTrim);
+  var interior = counts.slice(lo, counts.length - lo);
+  var bandDensity = interior.reduce(function (s, v) { return s + v; }, 0) / interior.length;
+  return {
+    unit: { bx: mb[0], by: mb[1], bz: mb[2] }, modalShare: modalCount / plates.length,
+    tail: plates.length - modalCount, domain: domain, zProfile: zProfile,
+    nBands: bands.length, bandDensity: bandDensity, predictedN: Math.round(bandDensity * bands.length),
+    extractedN: plates.length
+  };
+}
+
+function _swZAt(zProfile, x) {
+  var best = zProfile[0];
+  for (var i = 1; i < zProfile.length; i++) if (Math.abs(zProfile[i].x - x) < Math.abs(best.x - x)) best = zProfile[i];
+  return best.z;
+}
+
+// Generate n unit placements tiling the surface domain (extent = f(n)). The domain filled is
+// PROPORTIONAL to n: collapse n→1 ⇒ a single cell. Positions are a regular reconstruction of the
+// distribution (band by band at the measured density), NOT a claim to match extracted positions.
+function swWalkTessellation(tess, n, opts) {
+  var d = tess.domain, out = [];
+  var perBand = Math.max(1, Math.round(tess.bandDensity));
+  var bandsNeeded = Math.ceil(n / perBand);
+  for (var bi = 0; bi < bandsNeeded && out.length < n; bi++) {
+    var x = d.minX + bi;                  // 1m x-strips, as measured
+    if (x > d.maxX) break;
+    var z = _swZAt(tess.zProfile, x);     // surface height at this strip (z = f(x))
+    var inStrip = Math.min(perBand, n - out.length);
+    for (var j = 0; j < inStrip; j++) {
+      var y = d.minY + (d.maxY - d.minY) * (inStrip > 1 ? j / (inStrip - 1) : 0);
+      out.push({ guid: SW_PREFIX + 'PLATE-' + bi + '-' + j, x: x, y: y, z: z,
+        bx: tess.unit.bx, by: tess.unit.by, bz: tess.unit.bz, provenance: 'derived:str-walk' });
+    }
+  }
+  return out;
+}
+
+// ═══ RE-WALK LOOP — ARC edit → STR re-walks (STR_ROUTEWALKING_SPEC §3/§4) = THE WEDGE ═══
+// An ARC grid edit (a datum moves by Δ) cascades through the walker as ONE signed op chain:
+// columns on the moved datum re-anchor; girders touching it re-span (cross-section HELD); the
+// regulatory handler re-checks the changed spans and any signal that FLIPS becomes an EXCEPTION
+// (the "you may need to upsize / add a column" message). NON-INVENT: the ONLY new number is the
+// user's Δ; every new position/span is Δ folded onto a measured value; every exception is cited.
+//   base  = { grid, walked, girders } from swWalkSkeleton
+//   edit  = { axis:'x'|'y', datum:<gridline value to move>, delta:<metres>, material }
+function swReWalk(base, edit, opts) {
+  opts = opts || {};
+  var mat = edit.material || 'STEEL';
+  var ops = [{ opType: 'GEOM_GRID_MOVE', params: { axis: edit.axis, datum: edit.datum, delta: edit.delta }, provenance: 'user-edit' }];
+
+  // 1. re-anchor columns sitting on the moved datum (others untouched) — position = f(new grid)
+  var movedColumns = [];
+  var newWalked = base.walked.map(function (c) {
+    var on = edit.axis === 'y' ? c.y === edit.datum : c.x === edit.datum;
+    if (!on) return c;
+    var nc = Object.assign({}, c);
+    if (edit.axis === 'y') nc.y = c.y + edit.delta; else nc.x = c.x + edit.delta;
+    movedColumns.push(nc);
+    ops.push({ opType: 'STR_REANCHOR', params: { srcGuid: c.srcGuid, from: [c.x, c.y], to: [nc.x, nc.y] }, provenance: 'derived:grid' });
+    return nc;
+  });
+
+  // 2. re-span girders touching the moved datum + regulatory re-check
+  var changedGirders = [], exceptions = [];
+  var newGirders = base.girders.map(function (g) {
+    var spansIt = (g.fromDatum === edit.datum || g.toDatum === edit.datum);
+    var runsAlong = (edit.axis === 'y' && g.axis === 'Yline@' && g.onDatum === edit.datum) ||
+                    (edit.axis === 'x' && g.axis === 'Xline@' && g.onDatum === edit.datum);
+    if (!spansIt && !runsAlong) return g;
+    var ng = Object.assign({}, g);
+    if (runsAlong) {                          // girder ALONG the moved line: translate, span held
+      ng.onDatum = g.onDatum + edit.delta;
+      if (Array.isArray(g.from)) { ng.from = g.from.slice(); ng.to = g.to.slice(); }
+      return ng;
+    }
+    if (g.fromDatum === edit.datum) ng.fromDatum = g.fromDatum + edit.delta;
+    if (g.toDatum === edit.datum) ng.toDatum = g.toDatum + edit.delta;
+    ng.span = Math.abs(ng.toDatum - ng.fromDatum);   // cross-section held; only the span changes
+    ops.push({ opType: 'STR_RESPAN', params: { guid: g.guid, oldSpan: g.span, newSpan: ng.span }, provenance: 'derived:str-walk' });
+    changedGirders.push(ng);
+    var before = swCheckGirder(g.span, { material: mat });
+    var after = swCheckGirder(ng.span, { material: mat });
+    if (before.signal !== after.signal) {            // the WEDGE: an edit surfaces a consequence
+      exceptions.push({ guid: g.guid, oldSignal: before.signal, newSignal: after.signal, span: ng.span, message: after.message, source: after.source });
+      ops.push({ opType: 'STR_SIGNAL', params: { guid: g.guid, from: before.signal, to: after.signal, message: after.message }, source: after.source, provenance: 'derived:regulatory' });
+    }
+    return ng;
+  });
+
+  return { ops: ops, movedColumns: movedColumns, changedGirders: changedGirders,
+           exceptions: exceptions, after: { grid: base.grid, walked: newWalked, girders: newGirders } };
+}
+
+// ─── Convenience: derive + walk in one call ──────────────────
+function swWalkSkeleton(columns, opts) {
+  var grid = swDeriveGrid(columns, opts);
+  var walked = swWalkColumns(columns, grid, opts);
+  var girders = swWalkGirders(columns, grid, opts);
+  return { grid: grid, walked: walked, girders: girders };
+}
+
+// ─── Exports (node) + globals (browser eval) ─────────────────
+var _swApi = {
+  SW_PREFIX: SW_PREFIX, SW_GRID_GAP_TOL: SW_GRID_GAP_TOL, SW_GRID_SPAN_MAX: SW_GRID_SPAN_MAX,
+  swClusterAxis: swClusterAxis, swDeriveGrid: swDeriveGrid, swNearest: swNearest,
+  swWalkColumns: swWalkColumns, swWalkGirders: swWalkGirders, swWalkSkeleton: swWalkSkeleton,
+  SW_SPAN_RULES: SW_SPAN_RULES, swCheckGirder: swCheckGirder, swConforms: swConforms,
+  swDeriveTessellation: swDeriveTessellation, swWalkTessellation: swWalkTessellation,
+  swReWalk: swReWalk
+};
+if (typeof module !== 'undefined' && module.exports) module.exports = _swApi;
+if (typeof window !== 'undefined') Object.keys(_swApi).forEach(function (k) { window[k] = _swApi[k]; });

--- a/viewer/str_walker_bridge.js
+++ b/viewer/str_walker_bridge.js
@@ -1,0 +1,85 @@
+/**
+ * BIM OOTB — STR Walker Bridge (engine → live modeller)
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Connects the proven STR walker (str_walker.js) to the modeller's signed op-log + Outliner:
+ *   building DB → walker base state → on GEOM_GRID_MOVE → swReWalk → kernel_ops commits → STR tab.
+ * STR_ROUTEWALKING_SPEC.md §6 item (7). Flag-gated (?strwalk) in modeller.html; edits no existing file.
+ *
+ * Commit is DEPENDENCY-INJECTED: the browser passes KernelOps.commitOp bound to APP.db; the witness
+ * passes the REAL kernel_ops.js commit against a sql.js DB (proves row compatibility). provenance is
+ * folded INTO the stored params so traceability survives the persisted row. NON-INVENT throughout.
+ */
+'use strict';
+(function () {
+  var SW = (typeof require !== 'undefined') ? require('./str_walker.js') : (typeof window !== 'undefined' ? window : this);
+
+  var _state = null;  // { base: {grid,walked,girders}, columnCount }
+
+  function _readColumns(db) {
+    var res = db.exec("SELECT m.guid,t.center_x,t.center_y,t.center_z FROM elements_meta m " +
+      "JOIN element_transforms t ON t.guid=m.guid WHERE m.discipline='STR' AND m.ifc_class='IfcColumn'");
+    if (!res.length) return [];
+    return res[0].values.map(function (r) { return { guid: r[0], x: r[1], y: r[2], z: r[3] }; });
+  }
+
+  // Init the walker state from the opened building (the ARC twin's STR columns = the walk anchors).
+  function swbInit(db, opts) {
+    var cols = _readColumns(db);
+    if (!cols.length) { console.warn('§STRWALK-INIT no STR columns in this building'); _state = null; return null; }
+    var base = SW.swWalkSkeleton(cols, opts || {});
+    _state = { base: base, columnCount: cols.length };
+    console.log('§STRWALK-INIT columns=' + cols.length + ' grid=' + base.grid.xLines.length + '×' +
+      base.grid.yLines.length + ' girders=' + base.girders.length);
+    return _state;
+  }
+
+  // React to a committed GEOM_GRID_MOVE: re-walk STR + commit the cascade as signed ops.
+  //   gridMoveParams = { axis:'x'|'y', datum, delta } (bonsai_gridmove.js GEOM_GRID_MOVE)
+  //   commit = function(opType, params, inputGuids, outputGuid)  (e.g. KernelOps.commitOp bound to db)
+  function swbOnGridMove(gridMoveParams, commit, opts) {
+    opts = opts || {};
+    if (!_state) { console.warn('§STRWALK-REWALK no state — call swbInit first'); return null; }
+    var edit = { axis: gridMoveParams.axis, datum: gridMoveParams.datum, delta: gridMoveParams.delta,
+                 material: opts.material || 'STEEL' };
+    // The live authoring-grid line position is not bit-identical to the walker's emergent datum →
+    // snap it to the nearest walker gridline so the re-walk targets the right structural bay.
+    var lines = edit.axis === 'x' ? _state.base.grid.xLines : _state.base.grid.yLines;
+    if (lines && lines.length) {
+      var snapped = SW.swNearest(edit.datum, lines).line;
+      if (snapped !== edit.datum) console.log('§STRWALK-SNAP datum ' + edit.datum + ' → walker ' + snapped);
+      edit.datum = snapped;
+    }
+    var rw = SW.swReWalk(_state.base, edit, opts);
+    var committed = 0;
+    rw.ops.forEach(function (op) {
+      if (op.opType === 'GEOM_GRID_MOVE') return;          // the grid edit already committed by the modeller
+      var inputGuids = op.params.srcGuid ? [op.params.srcGuid] : (op.params.guid ? [op.params.guid] : null);
+      var params = Object.assign({}, op.params,            // fold provenance/source INTO params so the row keeps it
+        { provenance: op.provenance }, op.source ? { source: op.source } : {});
+      commit(op.opType, params, inputGuids, null);
+      committed++;
+    });
+    _state.base = rw.after;                                 // FOLD: the re-walked state becomes current
+    console.log('§STRWALK-REWALK Δ=' + edit.delta + 'm ' + edit.axis + '@' + edit.datum +
+      ' → ' + committed + ' STR ops, ' + rw.exceptions.length + ' exception(s)');
+    rw.exceptions.forEach(function (e) {
+      console.log('§STRWALK-EXCEPTION ' + e.oldSignal + '→' + e.newSignal + ' @' + e.span.toFixed(1) + 'm: ' + e.message);
+    });
+    return { committed: committed, exceptions: rw.exceptions, ops: rw.ops };
+  }
+
+  // Data for the Outliner STR walker tab (the §VISION-LOCK Disc-tab follower view).
+  function swbTabData() {
+    if (!_state) return null;
+    var g = _state.base, sig = { RED: 0, ORANGE: 0, GREEN: 0 };
+    g.girders.forEach(function (gd) { sig[SW.swCheckGirder(gd.span, {}).signal]++; });
+    return { columns: g.walked.length, girders: g.girders.length,
+             grid: g.grid.xLines.length + '×' + g.grid.yLines.length, signals: sig };
+  }
+
+  var api = { swbInit: swbInit, swbOnGridMove: swbOnGridMove, swbTabData: swbTabData };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (typeof window !== 'undefined') Object.keys(api).forEach(function (k) { window[k] = api[k]; });
+})();

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -1,0 +1,108 @@
+/**
+ * BIM OOTB — STR Walker ⇄ Outliner wiring (the structural walker in the Modeller).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Wires the proven STR walker (str_walker.js + str_walker_bridge.js) into the modeller Outliner +
+ * the signed op-log. STR_ROUTEWALKING_SPEC.md §6 item (7b). Flag-gated ?strwalk; edits no existing file.
+ *   • registers an STR Outliner category (the §VISION-LOCK Disc-tab follower view: grid/columns/
+ *     girders + live RED/ORANGE/GREEN signal counts from swbTabData)
+ *   • 🏗 STR button opens an extracted.db → swbInit (reads STR columns + transforms = the walk anchors)
+ *   • wraps Bonsai.gridmove.commit → on a real GEOM_GRID_MOVE, re-walks STR + commits the signed
+ *     cascade via Bonsai.oplog.commit (THE WEDGE: the drag surfaces a structural exception)
+ * Engine is node-witnessed (W-STR-* 29/29 incl. W-STR-BRIDGE 5/5 vs real kernel_ops). NON-INVENT.
+ */
+(function () {
+  'use strict';
+  var TAG = '§STRWALK-OL';
+  if (typeof window === 'undefined') return;
+  var ready = false, lastEx = [];
+
+  function tabRows() {
+    var d = window.swbTabData && window.swbTabData();
+    if (!d) return [{ id: 'sw-empty', label: 'Open an STR building (🏗) to walk', sub: '' }];
+    var rows = [
+      { id: 'sw-grid', label: 'Grid ' + d.grid, sub: d.columns + ' columns' },
+      { id: 'sw-gird', label: d.girders + ' girders', sub: 'RED ' + d.signals.RED + ' · ORANGE ' + d.signals.ORANGE + ' · GREEN ' + d.signals.GREEN }
+    ];
+    lastEx.forEach(function (e, i) {
+      rows.push({ id: 'sw-ex' + i, label: '⛔ ' + e.oldSignal + '→' + e.newSignal + ' @' + e.span.toFixed(1) + 'm', sub: e.message });
+    });
+    return rows;
+  }
+
+  function category() {
+    return {
+      key: 'strwalk', label: 'STR Walker',
+      tree: function () { return tabRows(); }
+    };
+  }
+
+  // Open an extracted.db and init the walker from its STR columns (the walk anchors).
+  function openStrDb(file) {
+    if (!window.SQL) { console.warn(TAG + ' sql.js not ready'); return; }
+    var fr = new FileReader();
+    fr.onload = function () {
+      try {
+        var db = new window.SQL.Database(new Uint8Array(fr.result));
+        var st = window.swbInit(db);   // §STRWALK-INIT logged by the bridge
+        db.close();
+        ready = !!st; lastEx = [];
+        if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+        console.log(TAG + ' init from "' + (file.name || 'db') + '" ready=' + ready);
+      } catch (e) { console.warn(TAG + ' open failed', e && e.message); }
+    };
+    fr.readAsArrayBuffer(file);
+  }
+
+  function mountButton() {
+    if (document.getElementById('strwalk-open')) return;
+    var inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.db,.sqlite';
+    inp.style.display = 'none'; inp.id = 'strwalk-file';
+    inp.onchange = function () { if (inp.files && inp.files[0]) openStrDb(inp.files[0]); };
+    document.body.appendChild(inp);
+    var btn = document.createElement('button'); btn.id = 'strwalk-open'; btn.title = 'Open an STR building → walk the structure';
+    btn.textContent = '🏗 STR';
+    btn.style.cssText = 'position:fixed;top:8px;left:336px;z-index:30;background:#1b1d23;color:#c7cdd8;' +
+      'border:1px solid #2c303a;border-radius:6px;padding:5px 10px;font:12px system-ui;cursor:pointer';
+    btn.onclick = function () { inp.click(); };
+    document.body.appendChild(btn);
+  }
+
+  // Wrap the grid-move controller so a real drag re-walks STR + commits the signed cascade.
+  function wrapGridMove() {
+    var GM = window.Bonsai && window.Bonsai.gridmove;
+    if (!GM || GM._strWrapped) return;
+    var orig = GM.commit.bind(GM);
+    GM.commit = async function (gridId, delta) {
+      var res = await orig(gridId, delta);                 // the modeller commits GEOM_GRID_MOVE first
+      try {
+        if (ready && window.swbOnGridMove) {
+          var m = GM._map && GM._map[gridId];               // gridId → {axis,index}
+          var G = window.Bonsai.grid;
+          if (m && G) {
+            var pos = m.axis === 'x' ? G.xs[m.index] : G.ys[m.index];
+            var commit = function (t, p, i, o) {
+              return window.Bonsai.oplog.commit({ op_type: t, parameters: Object.assign({}, p, i ? { inputGuids: i } : {}) }, {});
+            };
+            var r = window.swbOnGridMove({ axis: m.axis, datum: pos, delta: delta }, commit, {});
+            if (r) { lastEx = r.exceptions || []; if (window.Bonsai.outliner) window.Bonsai.outliner.refresh(); }
+          }
+        }
+      } catch (e) { console.warn(TAG + ' rewalk failed', e && e.message); }
+      return res;
+    };
+    GM._strWrapped = true;
+    console.log(TAG + ' wrapped Bonsai.gridmove.commit → STR re-walk on grid drag');
+  }
+
+  window.STRWalkerOutliner = {
+    register: function () {
+      if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.addCategory(category());
+      mountButton();
+      wrapGridMove();
+      console.log(TAG + ' registered — STR Walker category + 🏗 open + grid-drag re-walk (the wedge)');
+    },
+    _openStrDb: openStrDb, _category: category
+  };
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v727';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v728';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -94,6 +94,9 @@ const PRECACHE_ASSETS = [
   'import.js',
   'mep_coordination.js',
   'routewalker.js',
+  'str_walker.js',
+  'str_walker_bridge.js',
+  'str_walker_outliner.js',
   // SPATIAL_PICKING_SPEC §S-2..§S-5: warehouse pick-walk addon (data-gated pill)
   'wh_route.js',
   'wh_walk.js',


### PR DESCRIPTION
## What

Lands the **STR Walker** (STR as a *walked* discipline — see `STR_ROUTEWALKING_SPEC.md`) into the live modeller, flag-gated `?strwalk` (additive, like `?bomtree`). And fixes a **P0 modeller regression** found while wiring it.

## ⚠ P0 fix (pre-existing, from #530)
The `?bomtree` register hook references the top-level `const qs` **before** its declaration (a temporal-dead-zone error). On `origin/main` this throws `Cannot access 'qs' before initialization` on **every** modeller load, aborting the inline script before `__sceneReady`. 

Verified headless against `origin/main` (0bf40aa): no-flag / `?bomtree` / `?strwalk` all threw, `__sceneReady=undefined`. (A local stale checkout masked it.)

**Fix:** hoist `const qs` above the register hooks; remove the late duplicate. After: all three paths recover `sceneReady=true`, 0 pageerrors.

## STR Walker wiring (`?strwalk`)
- `str_walker.js` + `str_walker_bridge.js` + `str_walker_outliner.js` — engine + bridge are node-witnessed in bim-compiler (**W-STR-* 29/29**, incl. **W-STR-BRIDGE 5/5** against the real `kernel_ops.js`).
- STR Walker Outliner category + 🏗 *open an STR building* button.
- Wraps `Bonsai.gridmove.commit` → a real grid drag **re-walks STR** and commits the signed cascade (`STR_REANCHOR`/`STR_RESPAN`/`STR_SIGNAL`), surfacing a **cited structural exception** (the wedge: "this girder now over-spans → add a column").
- `sw.js` v727→v728 + precache the 3 scripts.

## Witness
- `tests/smoke_strwalk_modeller.js` **8/8** headless: scripts load, STR category registered, 🏗 button mounted, gridmove wrap installed, `§MODELLER STR Walker ON`, no `LOAD_FAIL`.
- `audit_script_tags.js` 0 missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)