### PR TITLE
Calibrated-confidence highlight in the STR Walker Outliner (?strwalk)

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -188,8 +188,9 @@
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
-<script src="str_walker_bridge.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
+<script src="str_walker_bridge.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
+<script src="str_walker_outliner.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/

--- a/viewer/str_walker_bridge.js
+++ b/viewer/str_walker_bridge.js
@@ -14,6 +14,7 @@
 'use strict';
 (function () {
   var SW = (typeof require !== 'undefined') ? require('./str_walker.js') : (typeof window !== 'undefined' ? window : this);
+  var WC = (typeof require !== 'undefined') ? require('./walker_confidence.js') : (typeof window !== 'undefined' ? window : this);
 
   var _state = null;  // { base: {grid,walked,girders}, columnCount }
 
@@ -70,13 +71,31 @@
     return { committed: committed, exceptions: rw.exceptions, ops: rw.ops };
   }
 
-  // Data for the Outliner STR walker tab (the §VISION-LOCK Disc-tab follower view).
+  // Threshold below which a walked element is HIGHLIGHTED low-confidence in the Outliner Disc-tab.
+  // 0.8 sits above the shipped map's low block (P≈0.67) and below its high block (P≈0.93) → it flags
+  // exactly the elements the RosettaStone says are least trustworthy.
+  var STRWALK_LOW_CONF = 0.8;
+
+  // Data for the Outliner STR walker tab (the §VISION-LOCK Disc-tab follower view). Each girder carries
+  // a CALIBRATED confidence (raw guard/rule margin → the SHIPPED Terminal isotonic map) — the EARNED,
+  // RosettaStone-calibrated number, never the raw one (spec §4). Low-confidence girders are surfaced.
   function swbTabData() {
     if (!_state) return null;
     var g = _state.base, sig = { RED: 0, ORANGE: 0, GREEN: 0 };
-    g.girders.forEach(function (gd) { sig[SW.swCheckGirder(gd.span, {}).signal]++; });
+    var maxSpan = SW.SW_SPAN_RULES.STEEL.maxBeamSpan;
+    var elements = g.girders.map(function (gd) {
+      var chk = SW.swCheckGirder(gd.span, {});
+      sig[chk.signal]++;
+      var ruleMargin = (maxSpan - gd.span) / maxSpan;     // code comfort (the spread)
+      var raw = WC.wcRaw(1, ruleMargin);                  // guard margin ~1 (placed); rule margin varies
+      var conf = WC.wcCalibrated(raw);                    // EARNED: shipped Terminal isotonic map
+      return { guid: gd.guid, span: gd.span, signal: chk.signal,
+               confidence: conf, lowConfidence: conf < STRWALK_LOW_CONF };
+    });
+    var lowConf = elements.filter(function (e) { return e.lowConfidence; }).length;
     return { columns: g.walked.length, girders: g.girders.length,
-             grid: g.grid.xLines.length + '×' + g.grid.yLines.length, signals: sig };
+             grid: g.grid.xLines.length + '×' + g.grid.yLines.length, signals: sig,
+             elements: elements, lowConfidence: lowConf, lowConfThreshold: STRWALK_LOW_CONF };
   }
 
   var api = { swbInit: swbInit, swbOnGridMove: swbOnGridMove, swbTabData: swbTabData };

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -25,6 +25,24 @@
       { id: 'sw-grid', label: 'Grid ' + d.grid, sub: d.columns + ' columns' },
       { id: 'sw-gird', label: d.girders + ' girders', sub: 'RED ' + d.signals.RED + ' · ORANGE ' + d.signals.ORANGE + ' · GREEN ' + d.signals.GREEN }
     ];
+    // CALIBRATED confidence (the EARNED gauge — fitted on the Terminal RosettaStone, never the raw
+    // number; spec §4). Surface a mean + the least-trustworthy girders, highlighted.
+    if (typeof d.lowConfidence === 'number') {
+      var els = d.elements || [];
+      var mean = els.length ? els.reduce(function (s, e) { return s + e.confidence; }, 0) / els.length : 0;
+      var thr = Math.round((d.lowConfThreshold || 0.8) * 100);
+      rows.push({ id: 'sw-conf', label: 'Confidence ' + Math.round(mean * 100) + '% mean',
+        sub: d.lowConfidence ? ('⚠ ' + d.lowConfidence + ' low-confidence (<' + thr + '%) — calibrated on Terminal')
+                             : ('✓ all girders ≥' + thr + '% (oracle-calibrated)') });
+      els.filter(function (e) { return e.lowConfidence; })
+         .sort(function (a, b) { return a.confidence - b.confidence; })
+         .slice(0, 6)
+         .forEach(function (e, i) {
+           rows.push({ id: 'sw-lc' + i, conf: e.confidence, low: true,
+             label: '⚠ ' + Math.round(e.confidence * 100) + '%  girder @' + e.span.toFixed(1) + 'm',
+             sub: 'signal ' + e.signal + ' — least-trustworthy walk (oracle-calibrated)' });
+         });
+    }
     lastEx.forEach(function (e, i) {
       rows.push({ id: 'sw-ex' + i, label: '⛔ ' + e.oldSignal + '→' + e.newSignal + ' @' + e.span.toFixed(1) + 'm', sub: e.message });
     });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v728';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v729';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -95,6 +95,7 @@ const PRECACHE_ASSETS = [
   'mep_coordination.js',
   'routewalker.js',
   'str_walker.js',
+  'walker_confidence.js',
   'str_walker_bridge.js',
   'str_walker_outliner.js',
   // SPATIAL_PICKING_SPEC §S-2..§S-5: warehouse pick-walk addon (data-gated pill)

--- a/viewer/walker_confidence.js
+++ b/viewer/walker_confidence.js
@@ -1,0 +1,105 @@
+/**
+ * BIM OOTB — Walker Confidence (the calibrated, earned confidence marker)
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Implements prompts/WALKER_GUARDS_ROSETTASTONE_SPEC.md §4 — every walked element carries a
+ * confidence ∈ [0,1]. The RAW number is f(guard margins + regulatory margin); but a raw number is
+ * MEANINGLESS until it PREDICTS correctness. So this module CALIBRATES it against the RosettaStone:
+ * bin walked elements by raw confidence, measure the ACTUAL walk-back match-rate per bin (the
+ * reliability curve), compute Expected Calibration Error, and — because raw guard margins measure
+ * GEOMETRIC safety, not oracle-match probability — fit a MONOTONIC (isotonic / PAV) recalibration
+ * map so "0.8" means ~80% right. NEVER display the raw number un-calibrated (the fake-gauge trap).
+ *
+ * Witness: scripts/witness_walker_confidence.js (W-CONFIDENCE-CALIBRATED). The negative control —
+ * a deliberately mis-set confidence — must FAIL the ECE bar (proves the test bites).
+ * Oracle = pristine extracted.db, NEVER output.db. This file is NEW; it edits no existing file.
+ */
+'use strict';
+
+function _clamp01(x) { return x < 0 ? 0 : (x > 1 ? 1 : x); }
+
+// ── SHIPPED calibration map (calibrate ONCE on the RosettaStone, apply LIVE where there is no oracle).
+// These isotonic/PAV blocks are the FIT on REAL Terminal STR walked elements (columns+girders) — a
+// DERIVED artifact, NOT an invented constant: scripts/witness_walker_confidence.js regenerates them
+// from Terminal_extracted.db and ASSERTS this constant reproduces (the reproducibility gate). Each
+// block = { xhi, p } : a raw confidence ≤ xhi maps to P(correct)=p (non-decreasing). The spec mandate:
+// "confidence is CALIBRATED on the RosettaStone BEFORE it is ever shown." ── provenance: derived:terminal-fit
+var WC_CALIBRATION = [
+  { xhi: 0.117052, p: 0.666667 },
+  { xhi: 0.911109, p: 0.929293 },
+  { xhi: 1.000000, p: 1.000000 }
+];
+
+// Apply a calibration map (blocks of {xhi,p}) to a raw confidence → calibrated P(correct) ∈ [0,1].
+// Defaults to the shipped Terminal map. This is what the live Outliner shows — never the raw number.
+function wcCalibrated(rawConf, map) {
+  var blocks = map || WC_CALIBRATION;
+  var x = _clamp01(rawConf);
+  for (var i = 0; i < blocks.length; i++) if (x <= blocks[i].xhi) return blocks[i].p;
+  return blocks.length ? blocks[blocks.length - 1].p : x;
+}
+
+// ── RAW confidence: weakest-link of the geometric guard margin and the regulatory margin. ──
+// guardMargin ∈ [0,1] (min guard margin from walker_guards.wgEvaluate); ruleMargin ∈ [0,1] (how far
+// the member sits under its code limit — e.g. (maxSpan−span)/maxSpan). Product = a candidate that is
+// both geometrically safe AND code-comfortable scores high. This is the number that is NOT yet
+// trustworthy — calibration below makes it so.
+function wcRaw(guardMargin, ruleMargin) {
+  return _clamp01(guardMargin) * _clamp01(ruleMargin == null ? 1 : ruleMargin);
+}
+
+// ── Reliability curve + ECE. samples: [{ conf, correct(0|1) }]. Equal-width bins over [0,1]. ──
+// ECE = Σ (n_bin/N) · |mean(conf in bin) − match-rate in bin| — the gap the marker is honest iff small.
+function wcReliability(samples, nBins) {
+  nBins = nBins || 10;
+  var bins = [];
+  for (var b = 0; b < nBins; b++) bins.push({ lo: b / nBins, hi: (b + 1) / nBins, n: 0, sumConf: 0, sumCorrect: 0 });
+  samples.forEach(function (s) {
+    var idx = Math.min(nBins - 1, Math.floor(s.conf * nBins));
+    bins[idx].n++; bins[idx].sumConf += s.conf; bins[idx].sumCorrect += s.correct;
+  });
+  var N = samples.length || 1, ece = 0;
+  bins.forEach(function (bin) {
+    if (!bin.n) { bin.predicted = null; bin.actual = null; return; }
+    bin.predicted = bin.sumConf / bin.n;     // mean confidence said in this bin
+    bin.actual = bin.sumCorrect / bin.n;     // actual match-rate measured against the oracle
+    ece += (bin.n / N) * Math.abs(bin.predicted - bin.actual);
+  });
+  return { bins: bins, ece: ece, n: samples.length };
+}
+
+// ── Isotonic recalibration via Pool-Adjacent-Violators. Fits a non-decreasing map rawConf→P(correct)
+//    on the oracle-labelled samples. Returns a step function (and its blocks) you apply to any raw conf. ──
+function wcFitIsotonic(samples) {
+  var s = samples.slice().sort(function (a, b) { return a.conf - b.conf; });
+  var blocks = [];   // each: { sum, n, xhi } ; mean = sum/n is non-decreasing across blocks
+  s.forEach(function (p) {
+    blocks.push({ sum: p.correct, n: 1, xhi: p.conf });
+    while (blocks.length > 1) {
+      var last = blocks[blocks.length - 1], prev = blocks[blocks.length - 2];
+      if (prev.sum / prev.n >= last.sum / last.n) {   // violation of non-decreasing → pool
+        blocks.pop(); blocks.pop();
+        blocks.push({ sum: prev.sum + last.sum, n: prev.n + last.n, xhi: last.xhi });
+      } else break;
+    }
+  });
+  var map = function (x) {
+    for (var i = 0; i < blocks.length; i++) if (x <= blocks[i].xhi) return blocks[i].sum / blocks[i].n;
+    return blocks.length ? blocks[blocks.length - 1].sum / blocks[blocks.length - 1].n : x;
+  };
+  return { map: map, blocks: blocks };
+}
+
+// ── ECE of a sample set under an arbitrary confidence function (used for raw, calibrated, control). ──
+function wcEce(samples, confFn, nBins) {
+  var mapped = samples.map(function (s) { return { conf: _clamp01(confFn(s)), correct: s.correct }; });
+  return wcReliability(mapped, nBins).ece;
+}
+
+var _wcApi = {
+  WC_CALIBRATION: WC_CALIBRATION, wcCalibrated: wcCalibrated,
+  wcRaw: wcRaw, wcReliability: wcReliability, wcFitIsotonic: wcFitIsotonic, wcEce: wcEce
+};
+if (typeof module !== 'undefined' && module.exports) module.exports = _wcApi;
+if (typeof window !== 'undefined') Object.keys(_wcApi).forEach(function (k) { window[k] = _wcApi[k]; });


### PR DESCRIPTION
## What
Renders the **calibrated** (RosettaStone-earned) confidence per walked girder in the STR Walker Outliner Disc-tab, with the least-trustworthy girders highlighted (⚠ + %).

## Why
The STR walk has no ground truth on a live/blank building. Per the Walker-Guards spec §4, confidence must be **calibrated** before it is ever shown (the System-Monitor honest-gauge lesson). This calibrates ONCE on the Terminal RosettaStone and applies the fitted map LIVE.

## Changes
- **NEW `viewer/walker_confidence.js`** — `WC_CALIBRATION` (isotonic/PAV map fitted on REAL Terminal STR) + `wcCalibrated()`. A *derived* artifact, not invented.
- `str_walker_bridge.js` `swbTabData` — per-girder calibrated confidence + `lowConfidence` flag/count (threshold 0.8).
- `str_walker_outliner.js` — confidence mean row + highlighted low-confidence girder rows.
- `modeller.html` — load `walker_confidence.js` before the bridge; bump str_walker_bridge/outliner `?v`.
- `sw.js` — v728→v729 + precache `walker_confidence.js`.

## Verification
- bim-compiler witnesses: **W-CONFIDENCE-CALIBRATED 6/6** (incl shipped-map reproduction from Terminal), **W-STR-BRIDGE 6/6** (per-element feed).
- Node integration smoke on these exact files: `swbTabData` → 108 girders, 8 low-confidence RED long-spans @0.667, all from the shipped map.

## Deploy note
The live/dev OCI `sandbox/` buckets currently serve the **viewer** (sw v387/v505) and do **not** carry `modeller.html` or the str-walker files — the modeller appears to be repo-only / not OCI-deployed. The OCI live push is intentionally NOT done here pending confirmation of the modeller's deploy target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)