### PR TITLE
feat(modeller): live-port ARC-only STR walker auto-pick (sw v730)

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -187,9 +187,9 @@
 <script src="bom_tree_outliner.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
-<script src="str_walker.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
+<script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
 <script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
-<script src="str_walker_bridge.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
+<script src="str_walker_bridge.js?v=3" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
 <script src="str_walker_outliner.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>

--- a/viewer/str_walker.js
+++ b/viewer/str_walker.js
@@ -67,6 +67,29 @@ function swDeriveGrid(columns, opts) {
   };
 }
 
+// ─── SEMI-GRID: derive the structural grid from ARC (the spec's "missing 4th handle") ──
+// Per convention (§VISION-LOCK): DROP ARC only, then WALK. The datums emerge from the ARC itself —
+// wall centerlines + any column centroids — so a WALL-BEARING building (no column frame, e.g.
+// residential SC) still yields a grid. A wall running in X sits at a constant Y → a Y-line; a
+// Y-running wall → an X-line; a column contributes both. NON-INVENT: lines = means of real ARC
+// coordinates; never seeded from STR (keeps "STR walks FROM ARC" non-circular).
+//   arcElements: [{ cx, cy, lx, ly, isColumn? }]   (lx/ly = bbox extents; long axis = run direction)
+function swDeriveSemiGrid(arcElements, opts) {
+  opts = opts || {};
+  var gap = opts.gapTol != null ? opts.gapTol : SW_GRID_GAP_TOL;
+  var xPts = [], yPts = [];
+  arcElements.forEach(function (e) {
+    if (e.isColumn) { xPts.push(e.cx); yPts.push(e.cy); }
+    else if (e.lx >= e.ly) { yPts.push(e.cy); }   // X-running wall → contributes a Y datum
+    else { xPts.push(e.cx); }                      // Y-running wall → contributes an X datum
+  });
+  return {
+    xLines: swClusterAxis(xPts, gap, 1e9).map(function (m) { return m.value; }),
+    yLines: swClusterAxis(yPts, gap, 1e9).map(function (m) { return m.value; }),
+    source: 'derived:arc-semigrid'
+  };
+}
+
 // ─── Nearest gridline ────────────────────────────────────────
 function swNearest(value, lines) {
   var best = lines[0], bestD = Math.abs(value - lines[0]);
@@ -210,6 +233,9 @@ function swConforms(span, depth, opts) {
 // plates: [{ x,y,z, bx,by,bz }]. opts.edgeTrim = fraction of extreme x-bands dropped as taper.
 function swDeriveTessellation(plates, opts) {
   opts = opts || {};
+  // NON-INVENT generality: a building with no space-frame (e.g. residential — walls, not a canopy)
+  // has NO tessellated system. Return null → the walker fabricates nothing. (W-STR-GENERAL-SC C2.)
+  if (!plates || !plates.length) return null;
   var edgeTrim = opts.edgeTrim != null ? opts.edgeTrim : 0.1;
   // modal unit = most common rounded bbox (the repeated cell)
   var hist = {};
@@ -342,7 +368,7 @@ function swWalkSkeleton(columns, opts) {
 // ─── Exports (node) + globals (browser eval) ─────────────────
 var _swApi = {
   SW_PREFIX: SW_PREFIX, SW_GRID_GAP_TOL: SW_GRID_GAP_TOL, SW_GRID_SPAN_MAX: SW_GRID_SPAN_MAX,
-  swClusterAxis: swClusterAxis, swDeriveGrid: swDeriveGrid, swNearest: swNearest,
+  swClusterAxis: swClusterAxis, swDeriveGrid: swDeriveGrid, swDeriveSemiGrid: swDeriveSemiGrid, swNearest: swNearest,
   swWalkColumns: swWalkColumns, swWalkGirders: swWalkGirders, swWalkSkeleton: swWalkSkeleton,
   SW_SPAN_RULES: SW_SPAN_RULES, swCheckGirder: swCheckGirder, swConforms: swConforms,
   swDeriveTessellation: swDeriveTessellation, swWalkTessellation: swWalkTessellation,

--- a/viewer/str_walker_bridge.js
+++ b/viewer/str_walker_bridge.js
@@ -25,14 +25,39 @@
     return res[0].values.map(function (r) { return { guid: r[0], x: r[1], y: r[2], z: r[3] }; });
   }
 
-  // Init the walker state from the opened building (the ARC twin's STR columns = the walk anchors).
+  // ARC walls = the dropped substrate for a wall-bearing (ARC-only) building. cx/cy + bbox extents
+  // (lx/ly) feed swDeriveSemiGrid; the long axis is the wall's run direction (non-invent, measured).
+  function _readArcWalls(db) {
+    var res = db.exec("SELECT t.center_x,t.center_y,t.bbox_x,t.bbox_y FROM elements_meta m " +
+      "JOIN element_transforms t ON t.guid=m.guid WHERE m.discipline='ARC' AND " +
+      "m.ifc_class IN ('IfcWall','IfcWallStandardCase')");
+    if (!res.length) return [];
+    return res[0].values.map(function (r) { return { cx: r[0], cy: r[1], lx: r[2], ly: r[3] }; });
+  }
+
+  // Init the walker state from the opened building. AUTO-PICK the grid source (the noted follow-up):
+  //   • STR columns present  → column-framed: swWalkSkeleton (grid from columns, walk girders).
+  //   • no STR columns       → wall-bearing (ARC-only drop): swDeriveSemiGrid from ARC walls = the
+  //                            editing datum/handle; impose NO column frame (W-STR-GENERAL-SC: the walk
+  //                            fabricates nothing). This is the user case — drop an ARC-only job, walk it.
   function swbInit(db, opts) {
+    opts = opts || {};
     var cols = _readColumns(db);
-    if (!cols.length) { console.warn('§STRWALK-INIT no STR columns in this building'); _state = null; return null; }
-    var base = SW.swWalkSkeleton(cols, opts || {});
-    _state = { base: base, columnCount: cols.length };
-    console.log('§STRWALK-INIT columns=' + cols.length + ' grid=' + base.grid.xLines.length + '×' +
-      base.grid.yLines.length + ' girders=' + base.girders.length);
+    if (cols.length) {
+      var base = SW.swWalkSkeleton(cols, opts);
+      _state = { base: base, columnCount: cols.length, system: 'column-framed' };
+      console.log('§STRWALK-INIT column-framed: columns=' + cols.length + ' grid=' + base.grid.xLines.length +
+        '×' + base.grid.yLines.length + ' girders=' + base.girders.length);
+      return _state;
+    }
+    // ARC-only / wall-bearing: derive the SEMI-GRID from ARC walls, fabricate no column skeleton.
+    var walls = _readArcWalls(db);
+    if (!walls.length) { console.warn('§STRWALK-INIT no STR columns AND no ARC walls — nothing to walk'); _state = null; return null; }
+    var grid = SW.swDeriveSemiGrid(walls, opts);
+    _state = { base: { grid: { xLines: grid.xLines, yLines: grid.yLines }, walked: [], girders: [] },
+               columnCount: 0, wallCount: walls.length, system: 'wall-bearing', gridSource: grid.source };
+    console.log('§STRWALK-INIT wall-bearing: 0 STR columns, ' + walls.length + ' ARC walls → semi-grid ' +
+      grid.xLines.length + '×' + grid.yLines.length + ' (' + grid.source + '; no column frame imposed)');
     return _state;
   }
 
@@ -93,7 +118,7 @@
                confidence: conf, lowConfidence: conf < STRWALK_LOW_CONF };
     });
     var lowConf = elements.filter(function (e) { return e.lowConfidence; }).length;
-    return { columns: g.walked.length, girders: g.girders.length,
+    return { columns: g.walked.length, girders: g.girders.length, system: _state.system || 'column-framed',
              grid: g.grid.xLines.length + '×' + g.grid.yLines.length, signals: sig,
              elements: elements, lowConfidence: lowConf, lowConfThreshold: STRWALK_LOW_CONF };
   }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v729';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v730';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
The live STR Walker (`str_walker.js` / `str_walker_bridge.js`, shipped in #533) **predated** `swDeriveSemiGrid` and the `swbInit` column-framed/wall-bearing **auto-pick**. Opening a **wall-bearing ARC-only** building live would **throw** (`swDeriveSemiGrid` undefined). This refreshes both files from the witnessed `bim-compiler` `deploy/dev` source (byte-identical) so `swbInit` auto-picks:

- **STR columns present** → column-framed (`swWalkSkeleton`)
- **no STR columns** → wall-bearing → `swDeriveSemiGrid` from ARC walls, **no column frame fabricated** (W-STR-GENERAL-SC)

`str_walker_outliner.js` (the #533 UI) and `walker_confidence.js` are unchanged.

## Cache
`str_walker.js?v=1→2`, `str_walker_bridge.js?v=2→3`, `CACHE_VERSION v729→v730`.

## Witness (in bim-compiler, identical source)
- W-STR-BRIDGE-ARCONLY 5/5
- W-STR-GENERAL-SC 6/6
- W-STR-BRIDGE 6/6
- Live-wiring smoke: window-loaded `swbInit` on a no-STR-columns stub auto-picks wall-bearing, derives a 2×2 semi-grid from 4 ARC walls, `swbTabData` does not throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)