### PR TITLE
feat(modeller): per-building editable instance — mo_<key> op-log fork (sw v732)

### DIFF
--- a/viewer/bonsai_oplog.js
+++ b/viewer/bonsai_oplog.js
@@ -74,6 +74,27 @@
       return this.length;
     },
 
+    // §MO — point the op-log at a per-building EDITABLE INSTANCE (key 'mo_<building>'). The loaded
+    // building DB (the fetched meta.db) is the PRISTINE REFERENCE — it lives in IndexedDB and is never
+    // written here; this op-log is the editable fold and persists to localStorage under its OWN key. So
+    // each resident carries its own signed edit history, and switching buildings never mutates either
+    // the reference or another building's instance. Default key (the scratch model) is untouched until
+    // a building sets one. (RESUME_MODELLER_WALK_SUBSTRATE task 3 — the mo_ editable instance.)
+    async setModelKey(key) {
+      if (!key || key === this._KEY) return this.length;
+      this._save();                                       // flush the current instance under its OLD key
+      if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache();
+      if (this.db) { try { this.db.close(); } catch (e) { } }
+      this.db = null; this._n = 0; this._cursor = 0;
+      this._KEY = key;                                    // the editable instance is now mo_<building>
+      await this._ensureDb();                             // load THIS building's saved op-log (empty on first open)
+      this._cursor = this.length;
+      if (this.length) await this._foldUpto(this._cursor);
+      this._emit();
+      console.log(TAG + ' model key → ' + key + ' active=' + this.length + ' (reference stays pristine)');
+      return this.length;
+    },
+
     _emit() { try { window.dispatchEvent(new CustomEvent('bonsai:oplog')); } catch (e) { } this._save(); },
     clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; try { localStorage.removeItem(this._KEY); } catch (e) { } if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache(); this._emit(); },
 

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -171,7 +171,7 @@
 <script src="lib/sql-wasm.js" onerror="console.warn('§OPLOG LOAD_FAIL sql-wasm.js')"></script>
 <script src="kernel_ops.js?v=8" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
-<script src="bonsai_oplog.js?v=4" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<script src="bonsai_oplog.js?v=5" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
 <script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
@@ -190,7 +190,7 @@
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
 <script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
 <script src="str_walker_bridge.js?v=3" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=3" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_outliner.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -147,6 +147,15 @@
     });
   }
 
+  // Fork the per-building EDITABLE INSTANCE (op-log key 'mo_<building>') so this resident's signed edits
+  // fold into its own instance while the loaded meta.db REFERENCE (the IDB cache entry) stays pristine.
+  function _forkEditable(res) {
+    var O = window.Bonsai && window.Bonsai.oplog;
+    if (O && O.setModelKey) O.setModelKey('mo_' + res.key).then(function (n) {
+      console.log(TAG + ' §STRWALK-MO editable instance mo_' + res.key + ' active ops=' + n + ' (reference meta.db stays pristine)');
+    });
+  }
+
   // Open a permanent resident: cache-first (local), else fetch the pristine meta.db from the cloud and
   // cache it. Terminal_meta.db is served gzip (content-encoding) → fetch().arrayBuffer() auto-inflates.
   function openResident(res) {
@@ -154,16 +163,19 @@
     _idbGetDb(url).then(function (cached) {
       if (cached) {
         console.log(TAG + ' §STRWALK-OPEN ' + res.key + ' cache-HIT (local) ' + (cached.byteLength / 1024).toFixed(0) + 'KB');
-        _openBuffer(cached, res.key);
+        if (_openBuffer(cached, res.key)) _forkEditable(res);
         return;
       }
       console.log(TAG + ' §STRWALK-OPEN ' + res.key + ' cache-MISS → fetch ' + url);
       fetch(url).then(function (r) { if (!r.ok) throw new Error('fetch ' + r.status); return r.arrayBuffer(); })
         .then(function (buf) {
           var ok = _openBuffer(buf, res.key);
-          if (ok) _idbPutDb(url, buf).then(function (p) {
-            console.log(TAG + ' §STRWALK-CACHE ' + res.db + ' persisted=' + p + ' (next Open is local) ' + (buf.byteLength / 1024).toFixed(0) + 'KB');
-          });
+          if (ok) {
+            _forkEditable(res);
+            _idbPutDb(url, buf).then(function (p) {
+              console.log(TAG + ' §STRWALK-CACHE ' + res.db + ' persisted=' + p + ' (next Open is local) ' + (buf.byteLength / 1024).toFixed(0) + 'KB');
+            });
+          }
         })
         .catch(function (e) { console.warn(TAG + ' §STRWALK-OPEN resident fetch FAILED ' + res.db, e && e.message); });
     });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v731';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v732';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
Opening a resident now forks a **per-building editable instance**. The op-log persists to localStorage under **`mo_<building>`** instead of the single global key, so each resident carries its **own signed edit history** while the loaded `meta.db` **reference** (the IndexedDB cache entry) is **never mutated**.

This is RESUME_MODELLER_WALK_SUBSTRATE task 3 — *"a `mo_<key>` editable instance folding the op-log while the loaded reference stays pristine."*

## How
- `bonsai_oplog.js`: `setModelKey(key)` — flush the current instance under its old key, swap, reload **this** building's saved op-log (empty on first open), re-fold. The default scratch key is untouched until a building sets one.
- `str_walker_outliner.js`: `openResident` → `_forkEditable` → `setModelKey('mo_'+key)` after a successful walk (both cache-hit and fetch paths).
- Reference (meta.db) lives in IndexedDB `bim_ootb_cache`; the editable op-log lives in localStorage `mo_<key>` — **separate stores**, so the reference can't be mutated by an edit.
- `bonsai_oplog.js?v=4→5`, `str_walker_outliner.js?v=3→4`, `CACHE_VERSION v731→v732`.

## Witness
`bim-compiler` **W-MO-INSTANCE 8/8** — drives the **shipped** OpLog + kernel_ops in node (browser globals stubbed):
fork → signed STR edit folds in (chain verifies) → opening Duplex is isolated → re-opening SampleHouse restores its **own** history (not Duplex's) → separate byte stores → op-log writes only `mo_*`/default keys, never a `buildings/*` reference key. `W-RESIDENT-OPEN` still 13/13.

> Follow-on (next slice): replay an instance's STR ops back into the walker state on reopen so prior edits re-appear visually (the data substrate is in place here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)