### PR TITLE
feat(modeller): replay an instance's STR edits on reopen — prior edits re-appear (sw v733)

### DIFF
--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -189,8 +189,8 @@
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
 <script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
-<script src="str_walker_bridge.js?v=3" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
+<script src="str_walker_outliner.js?v=5" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/

--- a/viewer/str_walker_bridge.js
+++ b/viewer/str_walker_bridge.js
@@ -96,6 +96,29 @@
     return { committed: committed, exceptions: rw.exceptions, ops: rw.ops };
   }
 
+  // Replay recorded grid-move edits onto a FRESH walk (after swbInit) so reopening a building re-applies
+  // its prior edits WITHOUT re-committing — the ops are ALREADY in the signed log; this just re-folds the
+  // walker state to match. Deterministic: the SAME snap + swReWalk as the live edit path (swbOnGridMove),
+  // so the replayed state is bit-for-bit the edited state. Drives the mo_<key> instance's visual restore.
+  //   edits = [{ axis:'x'|'y', datum, delta }, …]  (in commit order, e.g. from STR_WALK_EDIT op rows)
+  function swbReplay(edits, opts) {
+    opts = opts || {};
+    if (!_state) { console.warn('§STRWALK-REPLAY no state — call swbInit first'); return null; }
+    if (!edits || !edits.length) return { applied: 0, exceptions: [] };
+    var applied = 0, allEx = [];
+    edits.forEach(function (e) {
+      var edit = { axis: e.axis, datum: e.datum, delta: e.delta, material: opts.material || 'STEEL' };
+      var lines = edit.axis === 'x' ? _state.base.grid.xLines : _state.base.grid.yLines;
+      if (lines && lines.length) edit.datum = SW.swNearest(edit.datum, lines).line;   // same snap as live
+      var rw = SW.swReWalk(_state.base, edit, opts);
+      _state.base = rw.after;                              // FOLD (no commit — already signed in the log)
+      allEx = allEx.concat(rw.exceptions);
+      applied++;
+    });
+    console.log('§STRWALK-REPLAY applied ' + applied + ' recorded edit(s) → ' + allEx.length + ' exception(s) (no re-commit)');
+    return { applied: applied, exceptions: allEx };
+  }
+
   // Threshold below which a walked element is HIGHLIGHTED low-confidence in the Outliner Disc-tab.
   // 0.8 sits above the shipped map's low block (P≈0.67) and below its high block (P≈0.93) → it flags
   // exactly the elements the RosettaStone says are least trustworthy.
@@ -123,7 +146,7 @@
              elements: elements, lowConfidence: lowConf, lowConfThreshold: STRWALK_LOW_CONF };
   }
 
-  var api = { swbInit: swbInit, swbOnGridMove: swbOnGridMove, swbTabData: swbTabData };
+  var api = { swbInit: swbInit, swbOnGridMove: swbOnGridMove, swbReplay: swbReplay, swbTabData: swbTabData };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   if (typeof window !== 'undefined') Object.keys(api).forEach(function (k) { window[k] = api[k]; });
 })();

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -147,12 +147,30 @@
     });
   }
 
+  // Re-apply this instance's recorded STR_WALK_EDIT ops onto the FRESH walk so prior edits re-appear
+  // VISUALLY on reopen. The reference re-derived clean (swbInit from pristine meta.db); swbReplay folds
+  // the recorded edits WITHOUT re-committing (they are already in the signed mo_ log).
+  function _replayEdits() {
+    var O = window.Bonsai && window.Bonsai.oplog;
+    if (!O || !O.db || !window.swbReplay) return;
+    try {
+      var res = O.db.exec("SELECT parameters FROM kernel_ops WHERE op_type='STR_WALK_EDIT' AND undone=0 ORDER BY id");
+      if (!res.length) return;
+      var edits = res[0].values.map(function (row) { var p = JSON.parse(row[0]); return { axis: p.axis, datum: p.datum, delta: p.delta }; });
+      var rr = window.swbReplay(edits, {});
+      if (rr) { lastEx = rr.exceptions || []; if (window.Bonsai.outliner) window.Bonsai.outliner.refresh(); }
+      console.log(TAG + ' §STRWALK-REPLAY restored ' + (rr ? rr.applied : 0) + ' edit(s) from mo_ instance');
+    } catch (e) { console.warn(TAG + ' replay failed', e && e.message); }
+  }
+
   // Fork the per-building EDITABLE INSTANCE (op-log key 'mo_<building>') so this resident's signed edits
   // fold into its own instance while the loaded meta.db REFERENCE (the IDB cache entry) stays pristine.
+  // Once the instance's op-log is loaded, replay its recorded edits back into the fresh walk.
   function _forkEditable(res) {
     var O = window.Bonsai && window.Bonsai.oplog;
     if (O && O.setModelKey) O.setModelKey('mo_' + res.key).then(function (n) {
       console.log(TAG + ' §STRWALK-MO editable instance mo_' + res.key + ' active ops=' + n + ' (reference meta.db stays pristine)');
+      _replayEdits();
     });
   }
 
@@ -222,7 +240,12 @@
               return window.Bonsai.oplog.commit({ op_type: t, parameters: Object.assign({}, p, i ? { inputGuids: i } : {}) }, {});
             };
             var r = window.swbOnGridMove({ axis: m.axis, datum: pos, delta: delta }, commit, {});
-            if (r) { lastEx = r.exceptions || []; if (window.Bonsai.outliner) window.Bonsai.outliner.refresh(); }
+            if (r) {
+              // persist the edit as a compact REPLAY record so reopening the mo_ instance re-applies it
+              // to the fresh walk (the visual restore). The walker snaps internally → store the raw datum.
+              commit('STR_WALK_EDIT', { axis: m.axis, datum: pos, delta: delta }, null, null);
+              lastEx = r.exceptions || []; if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+            }
           }
         }
       } catch (e) { console.warn(TAG + ' rewalk failed', e && e.message); }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v732';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v733';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
Completes the `mo_<key>` editable instance. Reopening a resident re-derives the walk **clean** from the pristine `meta.db`, then **re-applies the instance's recorded edits** so the prior structural state re-appears **visually** — without re-committing (the ops are already in the signed `mo_` log).

## How
- `str_walker_bridge.js`: `+ swbReplay(edits)` (ported from witnessed `deploy/dev`) — applies recorded `{axis,datum,delta}` grid moves via the **same** snap + `swReWalk` as the live path, but with **no commit**. `swbInit`/`swbOnGridMove` unchanged.
- `str_walker_outliner.js`: a grid move now also persists a compact **`STR_WALK_EDIT`** op (the replay record); `_forkEditable` → after `setModelKey` loads the `mo_` log, `_replayEdits` reads its `STR_WALK_EDIT` rows → `swbReplay` → refresh. The reference (`meta.db`, IndexedDB) is still never mutated.
- `str_walker_bridge.js?v=3→4`, `str_walker_outliner.js?v=4→5`, `CACHE_VERSION v732→v733`.

## Witness
- **W-STR-REPLAY 5/5** (real `Schependomlaan_meta`): discovers a cascading edit (10 cascade ops, 2 exceptions); a fresh `swbInit` resets to the pristine walk; `swbReplay` reproduces the **live-edited** `swbTabData` **bit-for-bit** with no commit fn — faithful, commit-free reconstruction.
- `W-RESIDENT-OPEN` 13/13, `W-MO-INSTANCE` 8/8, `W-STR-BRIDGE`/`-ARCONLY`/`-GENERAL-SC` unchanged.

This closes the task-3 arc: **cloud→local residents → per-building editable instance → edits survive reopen**, reference pristine throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)