### PR TITLE
feat(modeller): bom-graph tab under DISC/ARC — ARC drops as a containment tree (sw v734)

### DIFF
--- a/viewer/bom_tree.js
+++ b/viewer/bom_tree.js
@@ -36,12 +36,36 @@ function seedTree(elements, opts) {
     var dc = e.disc == null ? 'ARC' : e.disc;
     var cl = e.cls == null ? 'Unknown' : e.cls;
     var sId = ensure('S|' + st, st, ROOT, 'storey');
-    var dId = ensure(sId + '|D|' + dc, dc, sId, 'disc');
+    // ROOM level (the spatial `contains` edge) — inserted between storey and discipline ONLY when the
+    // element has a real IfcSpace container (e.room, derived from rel_contained_in_space). Buildings with
+    // no IfcSpace (rooms = weak handle) simply skip this level — NON-INVENT, never a fabricated room.
+    var underStorey = sId;
+    if (e.room != null && e.room !== '') underStorey = ensure(sId + '|R|' + e.room, e.room, sId, 'room');
+    var dId = ensure(underStorey + '|D|' + dc, dc, underStorey, 'disc');
     var cId = ensure(dId + '|C|' + cl, cl, dId, 'class');
     // element leaf — guid is the id (globally unique, GUID-bound = rename/regroup-proof)
     nodes[e.guid] = { id: e.guid, label: e.guid, parent: cId, kind: 'element', prov: 'derived-seed', guid: e.guid };
   }
   return { nodes: nodes, roots: [ROOT] };
+}
+
+// SEED FROM a building DB (meta.db or extracted.db) — reads elements_meta + the spatial `contains` edge.
+// Room = the name of the spatial container an element sits in, MEASURED class-agnostically: a container
+// is a "room" when it carries a VOLUME (size_x present) — storeys/building have none, only spaces do
+// (measure-don't-whitelist; no IFC class literal). Absent spatial tables → no room level (graceful).
+// PURE over the DB (node-witnessable with sql.js). NON-INVENT: every group comes from a real row.
+function seedFromDb(db, opts) {
+  opts = opts || {};
+  var r = db.exec("SELECT guid, ifc_class, storey, discipline FROM elements_meta");
+  var els = (r.length ? r[0].values : []).map(function (v) { return { guid: v[0], cls: v[1], storey: v[2], disc: v[3] }; });
+  var room = {};
+  try {
+    var rr = db.exec("SELECT r.element_guid, s.name FROM rel_contained_in_space r " +
+      "JOIN spatial_structure s ON s.guid = r.space_guid WHERE s.size_x IS NOT NULL AND s.name IS NOT NULL");
+    if (rr.length) rr[0].values.forEach(function (v) { room[v[0]] = v[1]; });
+  } catch (e) { /* no spatial tables → storey-only tree (graceful) */ }
+  for (var i = 0; i < els.length; i++) els[i].room = room[els[i].guid] || null;
+  return seedTree(els, opts);
 }
 
 // ── REPARENT — the one composition edit. Pure pointer move; refuses cycle / self / missing (data integrity). ──
@@ -104,7 +128,7 @@ function leaves(tree) {
   return Object.keys(tree.nodes).filter(function (k) { return tree.nodes[k].kind === 'element'; });
 }
 
-var API = { seedTree: seedTree, reparent: reparent, applyOp: applyOp, foldOps: foldOps, bloc: bloc,
+var API = { seedTree: seedTree, seedFromDb: seedFromDb, reparent: reparent, applyOp: applyOp, foldOps: foldOps, bloc: bloc,
             leaves: leaves, wouldCycle: wouldCycle };
 window.BOMTree = API;
 if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/viewer/bom_tree_outliner.js
+++ b/viewer/bom_tree_outliner.js
@@ -86,19 +86,27 @@ if (typeof window !== 'undefined' && window.document) {
     };
   }
 
+  // Seed the BOM Tree from an OPEN building DB (the contains backbone: building→storey→ROOM→disc→class→
+  // element). Shared by the standalone 📂 Open and the guided resident Open (DISC/ARC). seedFromDb adds the
+  // ROOM level from the spatial `contains` edge when the building has IfcSpace (else storey-only, graceful).
+  function loadFromDb(db, building) {
+    State.building = (building || 'Building').replace(/\.db$/i, '').replace(/_(meta|extracted)$/i, '');
+    State.seed = T.seedFromDb(db, { building: State.building });
+    var nRoom = Object.keys(State.seed.nodes).filter(function (k) { return State.seed.nodes[k].kind === 'room'; }).length;
+    var nElem = T.leaves(State.seed).length;
+    console.log('§BOMTREE seeded "' + State.building + '" elements=' + nElem + ' rooms=' + nRoom + ' → BOM-graph tab');
+    if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    return { elements: nElem, rooms: nRoom };
+  }
+
   function openExtractedDb(file) {
     if (!window.SQL) { console.warn('§BOMTREE sql.js not ready'); return; }
     var fr = new FileReader();
     fr.onload = function () {
       try {
         var db = new window.SQL.Database(new Uint8Array(fr.result));
-        var r = db.exec("SELECT guid, ifc_class, storey, discipline FROM elements_meta");
-        var els = (r.length ? r[0].values : []).map(function (v) { return { guid: v[0], cls: v[1], storey: v[2], disc: v[3] }; });
-        State.building = (file.name || 'Building').replace(/\.db$/i, '').replace(/_extracted$/i, '');
-        State.seed = seedFromElements(els, State.building);
-        console.log('§BOMTREE opened "' + State.building + '" elements=' + els.length + ' → BOM Tree seeded');
+        loadFromDb(db, file.name);
         db.close();
-        if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
       } catch (e) { console.warn('§BOMTREE open failed', e && e.message); }
     };
     fr.readAsArrayBuffer(file);
@@ -124,7 +132,7 @@ if (typeof window !== 'undefined' && window.document) {
       mountOpenIcon();
       console.log('§BOMTREE registered — Open icon + BOM Tree category (ARC BOM editor, signed re-parent, geometry untouched)');
     },
-    openExtractedDb: openExtractedDb, _category: category, _currentTree: currentTree
+    openExtractedDb: openExtractedDb, loadFromDb: loadFromDb, _category: category, _currentTree: currentTree
   };
 }
 

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -183,14 +183,14 @@
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=3" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
-<script src="bom_tree.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
-<script src="bom_tree_outliner.js?v=1" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
+<script src="bom_tree.js?v=2" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
+<script src="bom_tree_outliner.js?v=2" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
 <script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=5" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_outliner.js?v=6" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
@@ -1758,7 +1758,13 @@ const qs = new URLSearchParams(location.search);
 // tree in the Outliner, re-parent = signed BOM_REPARENT (geometry untouched). SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE.
 if (qs.get('bomtree') !== null && window.BOMTreeOutliner) { window.BOMTreeOutliner.register(); console.log('§MODELLER BOM Tree editor ON (?bomtree)'); }
 // STR Walker (?strwalk) — STR as a WALKED discipline: 🏗 open an STR building → walk; grid drag re-walks + flags.
-if (qs.get('strwalk') !== null && window.STRWalkerOutliner) { window.STRWalkerOutliner.register(); console.log('§MODELLER STR Walker ON (?strwalk)'); }
+// The guided tool registers BOTH the STR Walker tab AND the bom-graph tab (DISC/ARC) so a resident Open
+// populates the containment tree (building→storey→room→disc→class→element) alongside the structural walk.
+if (qs.get('strwalk') !== null && window.STRWalkerOutliner) {
+  window.STRWalkerOutliner.register();
+  if (window.BOMTreeOutliner) window.BOMTreeOutliner.register();
+  console.log('§MODELLER STR Walker + bom-graph tab ON (?strwalk)');
+}
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -82,6 +82,10 @@
     try {
       var db = new window.SQL.Database(new Uint8Array(buf));
       var st = window.swbInit(db);   // §STRWALK-INIT logged by the bridge
+      // Same meta.db ALSO seeds the bom-graph tab (DISC/ARC): building→storey→room→disc→class→element.
+      if (window.BOMTreeOutliner && window.BOMTreeOutliner.loadFromDb) {
+        try { window.BOMTreeOutliner.loadFromDb(db, name); } catch (e) { console.warn(TAG + ' bom-graph seed failed', e && e.message); }
+      }
       db.close();
       ready = !!st; lastEx = [];
       if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v733';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v734';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What
Opening a resident now **also seeds the bom-graph tab**: the ARC building drops into the Outliner as a branching containment tree

**Building → Storey → Room → Discipline → Class → element**

derived from the same `meta.db` (the `contains` backbone). The 3D canvas is the spatial mirror; the Outliner is the primary drop surface. Reuses the witnessed `bom_tree.js` engine **and its signed re-parent** (drag = `BOM_REPARENT`, geometry untouched).

| Resident | Storeys | Rooms | Elements |
|---|---|---|---|
| SampleHouse | 3 | 0 (no IfcSpace) | 60 |
| Duplex | 5 | 11 | 1122 |
| Schependomlaan | 7 | 0 | 3284 |
| Terminal | 23 | 42 | 48428 |

## How
- `bom_tree.js`: `+ seedFromDb(db)` reads `elements_meta` + the spatial `contains` edge (`rel_contained_in_space ⋈ spatial_structure`) and inserts a **Room** level. Room is **measured class-agnostically** — a spatial container is a room when it carries a volume (`size_x` present); storeys/building have none (measure-don't-whitelist, **no IFC class literal** → grep-clean holds). Buildings with no rooms skip the level (graceful).
- `bom_tree_outliner.js`: `+ loadFromDb(db, building)` shared by the standalone 📂 Open and the guided resident Open.
- `str_walker_outliner.js`: the resident `_openBuffer` also calls `BOMTreeOutliner.loadFromDb` (same `meta.db`).
- `modeller.html`: `?strwalk` registers the bom-graph tab alongside the STR Walker.
- Cache: `bom_tree.js?v=1→2`, `bom_tree_outliner.js?v=1→2`, `str_walker_outliner.js?v=5→6`, `CACHE_VERSION v733→v734`.

## Witness
- **W-BOM-GRAPH 16/16** (4 real residents): lossless (leaf count == `elements_meta`), single Building root, storeys/classes all real, **rooms real + complete** on Duplex (11 rooms, 61 elements mapped) and Terminal (42 rooms, 1861 mapped), graceful 0-room on SampleHouse/SC, nothing invented.
- `W-BOM-TREE-EDIT` 15/15 (grep-clean + signed re-parent unchanged), `W-RESIDENT-OPEN` 13/13.

> Follow-on (next slice): the **typed cross-edges** (the 6 SDG edges — hosted-by / abuts / anchored-to / spans / instanced-by-n) over `meta.db`, rendered Find-style on top of this containment backbone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)