### PR TITLE
Modeller UX: pill Open + ARC-leads Outliner + disc=walker + UserGuide (W-UX-1..5)

### DIFF
--- a/tests/smoke_strwalk_modeller.js
+++ b/tests/smoke_strwalk_modeller.js
@@ -38,10 +38,11 @@ function serve() {
   page.on('console', function (m) { logs.push(m.text()); });
   page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
 
-  await page.goto('http://localhost:' + port + '/modeller.html?strwalk', { waitUntil: 'load', timeout: 30000 });
+  // DEFAULT load (no flag) — the modeller's outliner now registers ARC + STR Walker on EVERY load (W-UX-3).
+  await page.goto('http://localhost:' + port + '/modeller.html', { waitUntil: 'load', timeout: 30000 });
   // wait for the register hook to fire (or scene ready)
   await page.waitForFunction(function () {
-    return window.__sceneReady === true || (window.STRWalkerOutliner && document.getElementById('strwalk-open'));
+    return window.__sceneReady === true || (window.STRWalkerOutliner && document.getElementById('b-open'));
   }, { timeout: 20000 }).catch(function () {});
   await page.waitForTimeout(800);
 
@@ -52,22 +53,26 @@ function serve() {
       olLoaded: !!window.STRWalkerOutliner,
       categoryAdded: !!(window.Bonsai && window.Bonsai.outliner && window.Bonsai.outliner._categories &&
         window.Bonsai.outliner._categories.some(function (c) { return c.key === 'strwalk'; })),
-      buttonMounted: !!document.getElementById('strwalk-open'),
+      // W-UX-2: the OLD top-left drop controls are gone; W-UX-1: the pill Open replaces them.
+      oldButtonGone: !document.getElementById('strwalk-open') && !document.getElementById('bomtree-open') &&
+        !document.getElementById('strwalk-resident'),
+      openPill: !!document.getElementById('b-open'),
       gridWrapped: !!(window.Bonsai && window.Bonsai.gridmove && window.Bonsai.gridmove._strWrapped)
     };
   });
 
   var pass = 0, fail = 0;
   function chk(name, cond) { if (cond) { pass++; console.log('  ✅ ' + name); } else { fail++; console.log('  ❌ ' + name); } }
-  console.log('═══ §STRWALK-SMOKE — ?strwalk wiring (headless) ═══');
+  console.log('═══ §STRWALK-SMOKE — modeller default wiring (headless) ═══');
   chk('C1 engine loaded (str_walker.js)', r.engineLoaded);
   chk('C2 bridge loaded (str_walker_bridge.js)', r.bridgeLoaded);
   chk('C3 outliner-wiring loaded (STRWalkerOutliner)', r.olLoaded);
-  chk('C4 STR category registered in Outliner', r.categoryAdded);
-  chk('C5 🏗 STR button mounted', r.buttonMounted);
+  chk('C4 STR category registered in Outliner (default load, no flag)', r.categoryAdded);
+  chk('C5 old top-left drop panel GONE (strwalk/bomtree open buttons removed)', r.oldButtonGone);
+  chk('C5b Open pill (#b-open) present', r.openPill);
   chk('C6 Bonsai.gridmove.commit wrapped (re-walk hook)', r.gridWrapped);
-  var registered = logs.some(function (l) { return /§MODELLER STR Walker ON/.test(l); });
-  chk('C7 §MODELLER STR Walker ON logged', registered);
+  var registered = logs.some(function (l) { return /§MODELLER outliner ready/.test(l); });
+  chk('C7 §MODELLER outliner ready logged', registered);
   var loadFail = logs.filter(function (l) { return /STRWALK LOAD_FAIL/.test(l); });
   chk('C8 no STRWALK script LOAD_FAIL', loadFail.length === 0);
 

--- a/tests/witness_modeller_disc_walk.js
+++ b/tests/witness_modeller_disc_walk.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * W-UX-DISC — headless witness for "Disc = walker" (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-4):
+ *   • a discipline node in the bom-graph is a clickable WALKER entry point (carries data-disc + a ▶ glyph)
+ *   • click STR → SURFACES the real STR walk (swbInit done at Open) + expands the STR Walker tab
+ *   • click MEP on SampleCastle → RouteWalker has no anchors for it → HONEST refusal, NO fabricated run
+ *
+ * Wiring gate (TestArchitecture §Browser Testing); the STR walk VALUES are proven by the node W-STR-* suite.
+ * Serves viewer/ + the repo modeller/ residents (the live ../modeller/<db> playground).
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var VIEWER = path.join(__dirname, '..', 'viewer');
+var MODELLER = path.join(__dirname, '..', 'modeller');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = p.indexOf('/modeller/') === 0 ? path.join(MODELLER, p.slice('/modeller/'.length))
+             : path.join(VIEWER, p === '/' ? 'modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+async function openResidentAndSeed(page, key) {
+  await page.click('#b-open');
+  await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="' + key + '"]');
+  await page.waitForFunction(function (k) {
+    var t = window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree();
+    return !!t && Object.keys(t.nodes).some(function (id) { return t.nodes[id].kind === 'disc'; });
+  }, key, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(300);
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-UX-DISC — disc = walker (headless) ═══');
+
+  // ── STR disc → surfaces the real walk (SampleHouse) ─────────────────────────────────────────────
+  await openResidentAndSeed(page, 'SampleHouse');
+  var discDom = await page.evaluate(function () {
+    var nodes = [].slice.call(document.querySelectorAll('#bo-tree [data-disc]'));
+    return { count: nodes.length, hasSTR: nodes.some(function (d) { return d.getAttribute('data-disc') === 'STR'; }),
+      glyph: nodes.length ? !!nodes[0].querySelector('.bn-walk') : false };
+  });
+  chk('B1 discipline nodes are walker entry points (data-disc + ▶ glyph)', discDom.count >= 1 && discDom.glyph, 'discNodes=' + discDom.count);
+  chk('B2 SampleHouse exposes an STR disc node', discDom.hasSTR);
+
+  logs.length = 0;
+  await page.click('#bo-tree [data-disc="STR"]');
+  await page.waitForTimeout(250);
+  var strSurfaced = logs.some(function (l) { return /§DISC-WALK STR surfaced/.test(l); });
+  chk('B3 click STR → §DISC-WALK STR surfaced (real walk, not faked)', strSurfaced, logs.filter(function (l) { return /DISC-WALK/.test(l); })[0] || '');
+  var strTabOpen = await page.evaluate(function () { return window.Bonsai.outliner._collapsed['tcat|strwalk'] === false; });
+  chk('B4 STR Walker tab expanded on STR click', strTabOpen);
+
+  // ── MEP disc → honest refusal (SampleCastle has MEP but RouteWalker has no anchors for it) ───────
+  await openResidentAndSeed(page, 'SampleCastle');
+  var mepEl = await page.waitForSelector('#bo-tree [data-disc="MEP"]', { timeout: 30000 }).catch(function () { return null; });
+  chk('B5 SampleCastle exposes an MEP disc node', !!mepEl);
+
+  logs.length = 0;
+  var sweepsBefore = await page.evaluate(function () { return (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP'; }).length : 0; });
+  await page.click('#bo-tree [data-disc="MEP"]');
+  // discWalk MEP is async (rwInit + route); wait for its honest-refusal (or routed) log to land
+  await page.waitForTimeout(900);
+  var sweepsAfter = await page.evaluate(function () { return (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP'; }).length : 0; });
+  var mepRefused = logs.some(function (l) { return /§DISC-WALK MEP no-walk/.test(l); });
+  var mepRouted = logs.some(function (l) { return /§DISC-WALK MEP routed/.test(l); });
+  chk('B6 click MEP → honest §DISC-WALK MEP no-walk (no anchors)', mepRefused && !mepRouted, logs.filter(function (l) { return /DISC-WALK MEP/.test(l); })[0] || '');
+  chk('B7 NO fabricated run — GEOM_SWEEP count unchanged', sweepsAfter === sweepsBefore, 'before=' + sweepsBefore + ' after=' + sweepsAfter);
+
+  var loadFail = logs.concat([]).filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('B8 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  if (fail) { console.log('--- DISC-WALK logs ---'); logs.filter(function (l) { return /DISC-WALK|RW_INIT|rwInit|FAIL/.test(l); }).forEach(function (l) { console.log('   ' + l); }); }
+  console.log('W-UX-DISC: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/tests/witness_modeller_pill_verbs.js
+++ b/tests/witness_modeller_pill_verbs.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * W-UX-VERBS — headless witness for the pill-rail verbs (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-5).
+ *   • UserGuide  — NEW pill #b-guide opens a self-contained modeller guide overlay (the gap this slice fills)
+ *   • 3D Grid    — #b-grid pill is present + enabled; clicking toggles the grid datums (already shipped)
+ *   • Export/IFC — #b-ifc pill present + enabled (the export verb, already shipped)
+ *   • History    — the #hist-slider timeline surface is present (already shipped)
+ * Every #bar button auto-joins the rail + the ? help registry, so these are all discoverable pills.
+ * Pure-UI wiring gate; serves viewer/ only (no building DB needed).
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', 'viewer');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true; }, { timeout: 20000 }).catch(function () {});
+  await page.waitForTimeout(300);
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-UX-VERBS — pill rail verbs (headless) ═══');
+
+  var present = await page.evaluate(function () {
+    function btn(id) { var b = document.getElementById(id); return b ? { exists: true, disabled: b.disabled, inBar: b.closest('#bar') != null } : { exists: false }; }
+    return { guide: btn('b-guide'), grid: btn('b-grid'), ifc: btn('b-ifc'), open: btn('b-open'),
+      hist: !!document.getElementById('hist-slider') };
+  });
+  chk('D1 UserGuide pill #b-guide present in the rail', present.guide.exists && present.guide.inBar);
+  chk('D2 3D Grid pill #b-grid present + enabled', present.grid.exists && present.grid.inBar && !present.grid.disabled, 'disabled=' + present.grid.disabled);
+  chk('D3 Export/IFC pill #b-ifc present + enabled', present.ifc.exists && present.ifc.inBar && !present.ifc.disabled, 'disabled=' + present.ifc.disabled);
+  chk('D4 History timeline (#hist-slider) present', present.hist);
+
+  // UserGuide overlay opens with the real sections
+  await page.click('#b-guide');
+  await page.waitForTimeout(150);
+  var guide = await page.evaluate(function () {
+    var p = document.getElementById('m-guide-panel');
+    if (!p || p.style.display !== 'block') return { open: false };
+    var secs = [].slice.call(p.querySelectorAll('.mg-sec')).map(function (d) { return (d.firstChild && d.firstChild.textContent || '').trim(); });
+    return { open: true, count: secs.length, secs: secs };
+  });
+  chk('D5 Guide overlay opens with the modeller verb sections', guide.open && guide.count === 7, 'sections=' + guide.count);
+  chk('D6 Guide covers Open + Disc=walker + 3D Grid', guide.open && guide.secs.indexOf('Open') >= 0 &&
+    guide.secs.indexOf('Disc = walker') >= 0 && guide.secs.indexOf('3D Grid') >= 0, (guide.secs || []).join(' · '));
+
+  // 3D Grid pill toggles the datums
+  var beforeGrid = await page.evaluate(function () { return !!(window.Bonsai && window.Bonsai.grid && window.Bonsai.grid.active); });
+  await page.click('#b-grid');
+  await page.waitForTimeout(150);
+  var afterGrid = await page.evaluate(function () { return !!(window.Bonsai && window.Bonsai.grid && window.Bonsai.grid.active); });
+  chk('D7 3D Grid pill toggles grid.active', beforeGrid !== afterGrid, 'before=' + beforeGrid + ' after=' + afterGrid);
+
+  var guideLogged = logs.some(function (l) { return /§MODELLER-GUIDE open=true/.test(l); });
+  chk('D8 §MODELLER-GUIDE logged', guideLogged);
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('D9 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('W-UX-VERBS: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/tests/witness_modeller_ux_pill.js
+++ b/tests/witness_modeller_ux_pill.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * W-UX-PILL — headless witness for the Modeller UX redesign (RESUME_MODELLER_UX_OUTLINER_PILL):
+ *   • W-UX-1  the pill "Open" loads a resident → swbInit walk + bom-graph seed (clicked, not faked)
+ *   • W-UX-2  the OLD top-left drop panel (▾ resident / 🏗 / 📂 Open) is GONE
+ *   • W-UX-3  ARC LEADS: the bom-graph (containment) category registers by DEFAULT (no flag) and renders
+ *             FIRST in the Outliner; SampleHouse seeds the real qualified rooms (W-ROOM-STOREY-QUALIFY: 3).
+ *
+ * Per TestArchitecture §Browser Testing this is the secondary (wiring) gate; the VALUE proofs are the
+ * node witnesses (W-BOM-GRAPH / W-ROOM-STOREY-QUALIFY / W-STR-*). Serves viewer/ + the repo modeller/
+ * resident DBs (the GH-Pages playground the live loader fetches from ../modeller/<db>).
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var VIEWER = path.join(__dirname, '..', 'viewer');
+var MODELLER = path.join(__dirname, '..', 'modeller');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = p.indexOf('/modeller/') === 0 ? path.join(MODELLER, p.slice('/modeller/'.length))
+             : path.join(VIEWER, p === '/' ? 'modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true; }, { timeout: 20000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-UX-PILL — Modeller Open pill + ARC-leads outliner (headless) ═══');
+
+  // ── W-UX-2: old drop panel gone ────────────────────────────────────────────────────────────────
+  var state = await page.evaluate(function () {
+    var cats = (window.Bonsai && window.Bonsai.outliner && window.Bonsai.outliner._categories) || [];
+    var keys = cats.map(function (c) { return c.key; });
+    return {
+      oldGone: !document.getElementById('strwalk-open') && !document.getElementById('bomtree-open') && !document.getElementById('strwalk-resident'),
+      openPill: !!document.getElementById('b-open'),
+      keys: keys,
+      bomIdx: keys.indexOf('bomtree'),
+      strIdx: keys.indexOf('strwalk')
+    };
+  });
+  chk('A1 old top-left drop panel GONE (strwalk/bomtree/resident)', state.oldGone);
+  chk('A2 Open pill (#b-open) present', state.openPill);
+  chk('A3 ARC (bomtree) + STR (strwalk) registered by DEFAULT', state.bomIdx >= 0 && state.strIdx >= 0, 'keys=[' + state.keys.join(',') + ']');
+  chk('A4 ARC LEADS — bomtree registered before strwalk', state.bomIdx >= 0 && state.bomIdx < state.strIdx, 'bomIdx=' + state.bomIdx + ' strIdx=' + state.strIdx);
+
+  // ── W-UX-1: click Open → panel → pick SampleHouse ───────────────────────────────────────────────
+  // sql.js (WASM) initialises async; the live user opens well after boot, so wait for window.SQL here.
+  await page.waitForFunction(function () { return !!window.SQL; }, { timeout: 20000 }).catch(function () {});
+  await page.click('#b-open');
+  await page.waitForTimeout(150);
+  var panel = await page.evaluate(function () {
+    var p = document.getElementById('m-open-panel');
+    if (!p || p.style.display !== 'block') return { open: false };
+    var rows = [].slice.call(p.querySelectorAll('.mo-row'));
+    return { open: true, rows: rows.length, local: rows.some(function (d) { return d.getAttribute('data-key') === '__local'; }),
+      sh: rows.some(function (d) { return d.getAttribute('data-key') === 'SampleHouse'; }) };
+  });
+  chk('A5 Open chooser opens with the 4 residents + local door', panel.open && panel.rows === 5 && panel.local && panel.sh,
+    'rows=' + panel.rows + ' local=' + panel.local + ' SampleHouse=' + panel.sh);
+
+  // click the SampleHouse row → the SHIPPED openResident() walks + seeds the bom-graph
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  // wait for the walk + seed to settle (swbTabData truthy + a bom-graph seed log)
+  await page.waitForFunction(function () {
+    return typeof window.swbTabData === 'function' && !!window.swbTabData() &&
+      !!(window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree());
+  }, { timeout: 20000 }).catch(function () {});
+  await page.waitForTimeout(300);
+
+  var opened = await page.evaluate(function () {
+    var t = window.BOMTreeOutliner._currentTree();
+    var kinds = {};
+    if (t) Object.keys(t.nodes).forEach(function (k) { var kd = t.nodes[k].kind; kinds[kd] = (kinds[kd] || 0) + 1; });
+    var d = window.swbTabData && window.swbTabData();
+    // is the bom-graph tree rendered FIRST in the outliner DOM (before the flat Walls group)?
+    var treeEl = document.getElementById('bo-tree');
+    var html = treeEl ? treeEl.innerHTML : '';
+    var bomPos = html.indexOf('data-tcat="bomtree"');
+    var wallsPos = html.indexOf('data-grp="walls"');
+    return { kinds: kinds, walkReady: !!d, columns: d ? d.columns : null,
+      arcRendersFirst: bomPos >= 0 && (wallsPos < 0 || bomPos < wallsPos), bomPos: bomPos, wallsPos: wallsPos };
+  });
+  chk('A6 SampleHouse walk ready (swbTabData populated)', opened.walkReady, 'columns=' + opened.columns);
+  chk('A7 bom-graph seeded — storeys present', (opened.kinds.storey || 0) >= 1, 'kinds=' + JSON.stringify(opened.kinds));
+  chk('A8 SampleHouse qualified ROOMS = 3 (W-ROOM-STOREY-QUALIFY)', (opened.kinds.room || 0) === 3, 'rooms=' + (opened.kinds.room || 0));
+  chk('A9 ARC renders FIRST in the Outliner (before flat Walls group)', opened.arcRendersFirst, 'bomPos=' + opened.bomPos + ' wallsPos=' + opened.wallsPos);
+
+  var openLogged = logs.some(function (l) { return /§STRWALK-OPEN SampleHouse/.test(l); });
+  chk('A10 §STRWALK-OPEN SampleHouse logged (clicked, not faked)', openLogged);
+  var seedLogged = logs.some(function (l) { return /§BOMTREE seeded "SampleHouse"/.test(l); });
+  chk('A11 §BOMTREE seeded SampleHouse logged', seedLogged);
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('A12 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  if (fail) {
+    console.log('--- relevant logs ---');
+    logs.filter(function (l) { return /STRWALK|BOMTREE|XEDGE|fetch|FAIL|PAGEERROR|sql/.test(l); }).forEach(function (l) { console.log('   ' + l); });
+  }
+  console.log('W-UX-PILL: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/bom_tree_outliner.js
+++ b/viewer/bom_tree_outliner.js
@@ -112,25 +112,14 @@ if (typeof window !== 'undefined' && window.document) {
     fr.readAsArrayBuffer(file);
   }
 
-  function mountOpenIcon() {
-    if (document.getElementById('bomtree-open')) return;
-    var inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.db,.sqlite'; inp.style.display = 'none';
-    inp.id = 'bomtree-file';
-    inp.onchange = function () { if (inp.files && inp.files[0]) openExtractedDb(inp.files[0]); };
-    document.body.appendChild(inp);
-    var btn = document.createElement('button'); btn.id = 'bomtree-open'; btn.title = 'Open an extracted.db building';
-    btn.textContent = '📂 Open';
-    btn.style.cssText = 'position:fixed;top:8px;left:252px;z-index:30;background:#1b1d23;color:#c7cdd8;' +
-      'border:1px solid #2c303a;border-radius:6px;padding:5px 10px;font:12px system-ui;cursor:pointer';
-    btn.onclick = function () { inp.click(); };
-    document.body.appendChild(btn);
-  }
+  // (W-UX-2 2026-06-26) The old top-left `📂 Open` icon was REMOVED — Open is now a pill-rail verb (the chooser
+  // of the 4 residents + a local .db door). `openExtractedDb` (local-file → seed the BOM-graph tab) stays exported
+  // for that pill path. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-2.
 
   window.BOMTreeOutliner = {
     register: function () {
       if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.addCategory(category());
-      mountOpenIcon();
-      console.log('§BOMTREE registered — Open icon + BOM Tree category (ARC BOM editor, signed re-parent, geometry untouched)');
+      console.log('§BOMTREE registered — BOM-graph (ARC) category (signed re-parent, geometry untouched); Open re-homed to the pill rail');
     },
     openExtractedDb: openExtractedDb, loadFromDb: loadFromDb, _category: category, _currentTree: currentTree
   };

--- a/viewer/bom_tree_outliner.js
+++ b/viewer/bom_tree_outliner.js
@@ -34,6 +34,8 @@ function treeNodes(tree) {
       label: isLeaf ? shortGuid(n.guid != null ? n.guid : n.label) : n.label,
       sub: isLeaf ? (n.prov === 'user-authored' ? '✎ moved' : '') : ('(' + leafCount(id) + ')'),
       children: isLeaf ? [] : ch.map(build).sort(byLabel) };
+    // W-UX-4: tag a DISCIPLINE node so the Outliner can make it a WALKER entry point (click → walk that disc).
+    if (n.kind === 'disc') node.disc = n.label;
     return node;
   }
   return tree.roots.map(build);
@@ -82,7 +84,11 @@ if (typeof window !== 'undefined' && window.document) {
         // validate on a throwaway fold (cycle/self/missing refused, geometry untouched) before signing
         if (!T.reparent(currentTree(), childId, toParent)) { console.warn('§BOMTREE reparent refused', childId, '→', toParent); return; }
         commitReparent(childId, toParent);
-      }
+      },
+      // W-UX-4: a discipline node is a WALKER entry point — click it → walk that disc. The cross-engine
+      // dispatch (STR=swbInit walk, already done at Open; MEP/etc=RouteWalker or an honest refusal) lives in
+      // window.discWalk (modeller.html UX glue) so this category stays a pure BOM-graph view.
+      onWalk: function (disc) { if (window.discWalk) window.discWalk(disc, { building: State.building }); }
     };
   }
 

--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -152,10 +152,13 @@
         const ncol = this._collapsed['bn|' + n.id];
         const active = window.Bonsai._selId === n.id;
         const pad = 16 + depth * 14;
-        html += '<div data-bnode="' + n.id + '" data-tcat="' + ckey + '" data-leaf="' + (isLeaf ? 1 : 0) + '" draggable="true" ' +
+        // W-UX-4: a DISCIPLINE node (n.disc) is a WALKER entry point — render a ▶ walk affordance + carry data-disc.
+        const walkGlyph = n.disc ? ' <span class="bn-walk" title="Walk this discipline" style="color:#4fc3f7">▶</span>' : '';
+        html += '<div data-bnode="' + n.id + '" data-tcat="' + ckey + '" data-leaf="' + (isLeaf ? 1 : 0) + '"' +
+          (n.disc ? ' data-disc="' + n.disc + '"' : '') + ' draggable="true" ' +
           'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' +
           (active ? 'background:#26456b;color:#dce6f4' : 'color:#c7cdd8') + '">' +
-          (kids.length ? CHEV(!ncol) : LEAF) + n.label +
+          (kids.length ? CHEV(!ncol) : LEAF) + n.label + walkGlyph +
           (n.sub ? '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span>' : '') + '</div>';
         if (kids.length && !ncol) { const r = this._renderNodes(kids, depth + 1, ckey, match); html += r.html; shown += r.shown; }
       });
@@ -170,9 +173,15 @@
       });
       this._el.querySelectorAll('[data-bnode]').forEach(d => {
         const id = d.getAttribute('data-bnode'), isLeaf = d.getAttribute('data-leaf') === '1';
+        const disc = d.getAttribute('data-disc');
         d.onclick = () => {
           if (isLeaf) { const num = +id; if (window.Bonsai.select && !isNaN(num)) window.Bonsai.select(num); else this.setActive(id); }
-          else { this._collapsed['bn|' + id] = !this._collapsed['bn|' + id]; this._paint(); }
+          else {
+            // W-UX-4: a discipline node WALKS on click (and still toggles its subtree). The walker dispatch
+            // (STR walk / RouteWalker / honest refusal) is the category's onWalk; pure pointer, no geometry.
+            if (disc) { const cat = byKey[d.getAttribute('data-tcat')]; if (cat && cat.onWalk) cat.onWalk(disc); }
+            this._collapsed['bn|' + id] = !this._collapsed['bn|' + id]; this._paint();
+          }
         };
         d.ondragstart = e => { e.dataTransfer.setData('text/bnode', id); this._dragSrc = id; };
         d.ondragover = e => { e.preventDefault(); d.style.outline = '1px dashed #4a78b8'; };

--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -93,6 +93,10 @@
       const match = n => !f || (n.label + ' ' + n.sub).toLowerCase().includes(f);
       let total = 0, shown = 0;
       let html = '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'DAGeVu Model</div>';
+      // ARC LEADS (W-UX-3): the seeded containment TREE categories (BOM-graph Storey→Room→disc→class→element,
+      // then STR Walker) render FIRST — they are the loaded building, the primary surface. The FLAT op-log
+      // groups (Walls/Openings/Routes/… = what the user has authored, empty until they edit) follow below.
+      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); html += r.html; total += r.total; shown += r.shown; });
       groups.forEach(g => {
         const vis = g.nodes.filter(match); total += g.nodes.length; shown += vis.length;
         if (f && !vis.length) return;
@@ -109,7 +113,6 @@
             LEAF + n.label + '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span></div>';
         });
       });
-      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); html += r.html; total += r.total; shown += r.shown; });
       tree.innerHTML = html;
       tree.querySelectorAll('[data-grp]').forEach(d => d.onclick = () => { const k = d.getAttribute('data-grp'); this._collapsed[k] = !this._collapsed[k]; this._paint(); });
       tree.querySelectorAll('[data-fid]').forEach(d => d.onclick = () => {

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -150,6 +150,7 @@
   <button id="b-insert" disabled title="Insert a library component (assemble, don't draw)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16.5 9.4 7.55 4.24"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.29 7 12 12 20.71 7"/><line x1="12" x2="12" y1="22" y2="12"/></svg><span>Insert</span></button>
   <button id="b-lod" disabled style="display:none" title="Refine the selected component's level of detail (same signed row)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/></svg><span>LOD 200</span></button>
   <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
+  <button id="b-guide" title="Modeller User Guide — how to Open, walk, edit & export"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg><span>Guide</span></button>
   <button id="b-del" disabled title="Delete selected (Del)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Z"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/></svg><span>Delete</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
   <button id="b-sound" title="Authoring sound feedback" class="on"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg><span>Sound</span></button>
@@ -1877,6 +1878,49 @@ window.discWalk = function (disc, ctx) {
     if (panel && panel.style.display === 'block' && !panel.contains(e.target) && !bOpen.contains(e.target)) close();
   });
 })();
+
+// ── MODELLER USER GUIDE (W-UX-5): a self-contained overlay (no viewer/OCI dependency — §101 Drift Law)
+// describing the REAL modeller verbs the rest of this UX shipped. Prose only; no fabricated data. Toggled
+// from the #b-guide pill. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-5.
+(function initGuide() {
+  const bGuide = document.getElementById('b-guide');
+  if (!bGuide) return;
+  const SECTIONS = [
+    ['Open', 'Pill ▸ Open → pick one of the 4 residents (or a local .db). It walks the structure (STR) and seeds the ARC bom-graph — no separate drop panel.'],
+    ['Outliner — ARC leads', 'The one panel is the surface: Building ▸ Storey ▸ Room ▸ discipline ▸ class ▸ element (real door/AABB-qualified rooms; door-less storeys read "· layer"). The find box filters across it.'],
+    ['Disc = walker', 'Click a discipline node to walk it: STR surfaces the structural walk; an MEP-family disc routes when anchored, else it refuses honestly ("no walk") — never a fabricated run.'],
+    ['3D Grid', 'The grid is the primary handle. Grid shows/hides the datums; Move Grid drags a gridline so attached walls RECOMPOSE — stretch, not scale (openings stay host-constrained).'],
+    ['Author', 'Sketch a profile, Insert a catalog component (assemble, don\'t draw), Cut an opening, Route an MEP run, Fillet an edge. Every edit is one signed op in the log.'],
+    ['History', 'Scrub the bottom timeline to fold the model to any point; Ctrl+Z / Ctrl+⇧Z undo/redo. Geometry is a deterministic fold over the signed op-log.'],
+    ['Save / Export', 'Your edits auto-save to the signed op-log (restored on your next visit, per building). IFC exports a standards IFC4 file from the same log.']
+  ];
+  let panel = null;
+  function build() {
+    panel = document.createElement('div'); panel.id = 'm-guide-panel';
+    panel.style.cssText = 'position:fixed;bottom:74px;right:70px;z-index:42;width:320px;max-height:calc(100vh - 150px);' +
+      'overflow:auto;display:none;padding:14px 16px;background:rgba(20,22,30,0.95);border:1px solid #2c303a;' +
+      'border-radius:12px;color:#c7cdd8;font:12.5px/1.55 system-ui,sans-serif;' +
+      'backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);box-shadow:0 8px 30px rgba(0,0,0,0.55)';
+    let h = '<div style="font-size:10px;letter-spacing:.14em;color:#5b6473;margin-bottom:10px">MODELLER · USER GUIDE</div>';
+    SECTIONS.forEach(function (s) {
+      h += '<div class="mg-sec" style="margin-bottom:11px"><div style="color:#9fd4f7;font-weight:600;margin-bottom:2px">' + s[0] + '</div>' +
+        '<div style="color:#aab3c2">' + s[1] + '</div></div>';
+    });
+    panel.innerHTML = h;
+    document.body.appendChild(panel);
+  }
+  bGuide.onclick = function (e) {
+    e.stopPropagation();
+    if (!panel) build();
+    const open = panel.style.display !== 'block';
+    panel.style.display = open ? 'block' : 'none'; bGuide.classList.toggle('on', open);
+    console.log('§MODELLER-GUIDE open=' + open + ' sections=' + SECTIONS.length);
+  };
+  document.addEventListener('pointerdown', function (e) {
+    if (panel && panel.style.display === 'block' && !panel.contains(e.target) && !bGuide.contains(e.target)) { panel.style.display = 'none'; bGuide.classList.remove('on'); }
+  });
+})();
+
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -129,6 +129,7 @@
 <canvas id="c"></canvas>
 <div id="bar">
   <button id="b-home" title="Back to the Matrix" onclick="location.href='../index.html?home=1'"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg><span>Home</span></button>
+  <button id="b-open" title="Open a building — load a resident or a local .db → walk + bom-graph"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2"/></svg><span>Open</span></button>
   <button id="b-fit" title="Zoom to fit (F) — frames the selection, or all"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg><span>Fit</span></button>
   <button id="b-view" title="Cycle view: Iso / Top"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3 8 9 5 9-5"/><path d="M12 13v8"/></svg><span>Iso</span></button>
   <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
@@ -181,10 +182,10 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=3" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=4" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
 <script src="bom_tree.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
-<script src="bom_tree_outliner.js?v=2" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
+<script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- Cross-edges: the typed SDG lateral edges (abuts/...) derived on-the-fly from the bbox substrate. -->
 <script src="cross_edges.js?v=1" onerror="console.warn('§XEDGE LOAD_FAIL cross_edges.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
@@ -192,7 +193,7 @@
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
 <script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=7" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_outliner.js?v=8" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
@@ -1756,17 +1757,94 @@ window.Bonsai.outliner.addCategory({ key: 'components', label: 'Components', mat
 // ~90 lines below, so the ?bomtree hook (and now ?strwalk) referenced it in its TDZ → "Cannot access 'qs' before
 // initialization" threw on EVERY load, killing __sceneReady. Hoisted up; the later duplicate declaration removed.
 const qs = new URLSearchParams(location.search);
-// BOM Tree composition facet (the ARC BOM editor) — flag-gated ?bomtree for now; Open any extracted.db → editable BOM
-// tree in the Outliner, re-parent = signed BOM_REPARENT (geometry untouched). SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE.
-if (qs.get('bomtree') !== null && window.BOMTreeOutliner) { window.BOMTreeOutliner.register(); console.log('§MODELLER BOM Tree editor ON (?bomtree)'); }
-// STR Walker (?strwalk) — STR as a WALKED discipline: 🏗 open an STR building → walk; grid drag re-walks + flags.
-// The guided tool registers BOTH the STR Walker tab AND the bom-graph tab (DISC/ARC) so a resident Open
-// populates the containment tree (building→storey→room→disc→class→element) alongside the structural walk.
-if (qs.get('strwalk') !== null && window.STRWalkerOutliner) {
-  window.STRWalkerOutliner.register();
-  if (window.BOMTreeOutliner) window.BOMTreeOutliner.register();
-  console.log('§MODELLER STR Walker + bom-graph tab ON (?strwalk)');
+// (W-UX-1 2026-06-26) Expose the sql.js factory as window.SQL so the pill **Open** can build an SQL.Database
+// from a resident's / local .db bytes (str_walker_outliner._openBuffer + bom_tree_outliner.openExtractedDb both
+// read window.SQL synchronously). bonsai_oplog inits its own copy for the op-log; this is a tiny parallel init
+// for the OPEN path (initSqlJs returns the same emscripten module shape; idempotent enough). NON-INVENT: just bytes→db.
+if (!window.SQL && window.initSqlJs) {
+  window.initSqlJs({ locateFile: f => 'lib/' + f }).then(function (S) { window.SQL = S; console.log('§MODELLER sql.js ready (window.SQL set for Open)'); })
+    .catch(function (e) { console.warn('§MODELLER sql.js init fail ' + (e && e.message)); });
 }
+// (W-UX-3 2026-06-26) ARC LEADS, by DEFAULT. The Outliner IS the modeller's primary surface now, so the
+// containment categories register on EVERY load (no longer flag-gated behind ?bomtree/?strwalk — those flags
+// are still accepted, as no-ops, by the restore-skip list below). ORDER matters: register the BOM-graph (ARC)
+// category FIRST so it leads the tree, then the STR Walker result tab. A pill "Open" (below) seeds them from a
+// resident or a local .db. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-1/§W-UX-3.
+if (window.BOMTreeOutliner) window.BOMTreeOutliner.register();   // ARC = the lead containment tree
+if (window.STRWalkerOutliner) window.STRWalkerOutliner.register();   // STR Walker result tab + grid-drag re-walk
+console.log('§MODELLER outliner ready — ARC (bom-graph) leads + STR Walker tab (Open via the pill rail)');
+
+// ── OPEN (W-UX-1): the pill-rail verb that replaced the old top-left drop panels. Clicking #b-open opens a
+// small chooser of the 4 permanent residents (reusing RESIDENTS[] from str_walker_outliner.js) + a local-.db
+// door (the dev/arbitrary-DB path). A pick calls the SHIPPED openResident()/openStrDb() — which swbInit-walks
+// + seeds the bom-graph (ARC) tab + derives cross-edges in one go. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-1.
+(function initOpenChooser() {
+  const bOpen = document.getElementById('b-open');
+  const SW = window.STRWalkerOutliner;
+  if (!bOpen || !SW) { if (bOpen) bOpen.disabled = true; return; }
+  const residents = SW._residents || [];
+  let panel = null, fileInp = null;
+  function ensureOutlinerOpen() {
+    try { localStorage.setItem('dagevu_modeller_ol_open', '1'); } catch (e) {}
+    document.body.classList.remove('ol-collapsed');
+  }
+  function pick(res) {
+    console.log('§MODELLER-OPEN chooser pick resident=' + res.key);
+    SW._openResident(res); ensureOutlinerOpen(); close();
+  }
+  function pickLocal() {
+    if (!fileInp) {
+      fileInp = document.createElement('input'); fileInp.type = 'file'; fileInp.accept = '.db,.sqlite';
+      fileInp.style.display = 'none'; fileInp.id = 'm-open-file';
+      fileInp.onchange = function () {
+        if (fileInp.files && fileInp.files[0]) {
+          console.log('§MODELLER-OPEN chooser pick local=' + fileInp.files[0].name);
+          SW._openStrDb(fileInp.files[0]); ensureOutlinerOpen();
+        }
+        fileInp.value = '';
+      };
+      document.body.appendChild(fileInp);
+    }
+    fileInp.click(); close();
+  }
+  function build() {
+    panel = document.createElement('div'); panel.id = 'm-open-panel';
+    panel.style.cssText = 'position:fixed;bottom:74px;right:70px;z-index:41;width:248px;display:none;padding:10px;' +
+      'background:rgba(20,22,30,0.94);border:1px solid #2c303a;border-radius:12px;color:#c7cdd8;' +
+      'font:12px system-ui,sans-serif;backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);' +
+      'box-shadow:0 8px 30px rgba(0,0,0,0.5)';
+    let h = '<div style="font-size:10px;letter-spacing:.14em;color:#5b6473;margin:2px 4px 8px">OPEN A BUILDING</div>';
+    residents.forEach(function (r) {
+      h += '<div class="mo-row" data-key="' + r.key + '" style="display:flex;align-items:center;gap:9px;padding:7px 8px;' +
+        'border-radius:8px;cursor:pointer"><span style="width:20px;text-align:center">🏠</span><span>' + r.label + '</span></div>';
+    });
+    h += '<div style="border-top:1px solid #23262e;margin:7px 2px 6px"></div>';
+    h += '<div class="mo-row" data-key="__local" style="display:flex;align-items:center;gap:9px;padding:7px 8px;' +
+      'border-radius:8px;cursor:pointer"><span style="width:20px;text-align:center">📁</span><span>Open local .db…</span></div>';
+    panel.innerHTML = h;
+    document.body.appendChild(panel);
+    panel.querySelectorAll('.mo-row').forEach(function (d) {
+      d.onmouseover = function () { d.style.background = '#23262e'; };
+      d.onmouseout = function () { d.style.background = 'transparent'; };
+      d.onclick = function () {
+        const k = d.getAttribute('data-key');
+        if (k === '__local') return pickLocal();
+        const r = residents.filter(function (x) { return x.key === k; })[0]; if (r) pick(r);
+      };
+    });
+  }
+  function close() { if (panel) panel.style.display = 'none'; bOpen.classList.remove('on'); }
+  bOpen.onclick = function (e) {
+    e.stopPropagation();
+    if (!panel) build();
+    const open = panel.style.display !== 'block';
+    panel.style.display = open ? 'block' : 'none'; bOpen.classList.toggle('on', open);
+    console.log('§MODELLER-OPEN chooser open=' + open + ' residents=' + residents.length);
+  };
+  document.addEventListener('pointerdown', function (e) {
+    if (panel && panel.style.display === 'block' && !panel.contains(e.target) && !bOpen.contains(e.target)) close();
+  });
+})();
 setStat('ready — supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));
 window.__sceneReady = true;
 console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai.isSupported() : '?'));

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -1774,6 +1774,38 @@ if (window.BOMTreeOutliner) window.BOMTreeOutliner.register();   // ARC = the le
 if (window.STRWalkerOutliner) window.STRWalkerOutliner.register();   // STR Walker result tab + grid-drag re-walk
 console.log('§MODELLER outliner ready — ARC (bom-graph) leads + STR Walker tab (Open via the pill rail)');
 
+// ── DISC = WALKER (W-UX-4): a discipline node in the bom-graph is a WALKER entry point. Clicking it dispatches
+// to that discipline's walker over the substrate the Open already loaded. STR is already walked at Open (swbInit);
+// clicking STR SURFACES that walk (grid/columns/girders) and expands the STR Walker tab. MEP-family discs route
+// via RouteWalker (anchor-dependent) — and when the open building has no anchors/recipe we REFUSE honestly (no
+// fabricated run, non-invent). ARC is the base substrate the others fill, not a walked layer.
+// RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-4. (RouteWalker-in-modeller anchors for arbitrary buildings = the
+// SEPARATE engine task flagged in the substrate handoff §0 — not this UX slice.)
+window.discWalk = function (disc, ctx) {
+  disc = String(disc || '').toUpperCase();
+  var name = (ctx && ctx.building) || '';
+  if (disc === 'STR') {
+    var d = window.swbTabData && window.swbTabData();
+    if (d) {
+      if (window.Bonsai.outliner) { window.Bonsai.outliner._collapsed['tcat|strwalk'] = false; window.Bonsai.outliner.refresh(); }
+      setStat('STR walk — ' + d.columns + ' columns · ' + d.girders + ' girders');
+      console.log('§DISC-WALK STR surfaced grid=' + d.grid + ' columns=' + d.columns + ' girders=' + d.girders);
+    } else { console.log('§DISC-WALK STR no-walk (open a building first)'); }
+    return;
+  }
+  if (disc === 'ARC') { setStat('ARC is the base layer — the disciplines fill it'); console.log('§DISC-WALK ARC is the base substrate (not a walked discipline)'); return; }
+  // MEP family (MEP/PLB/ELEC/ACMV/FP/…) → RouteWalker, anchor-dependent → honest refusal when unanchored.
+  (async function () {
+    try {
+      var ready = (typeof _rwReadyOnce === 'function') ? await _rwReadyOnce() : false;
+      var segs = (ready && typeof rwRouteSegments === 'function' && name) ? (rwRouteSegments(null, name) || []) : [];
+      var mine = segs.filter(function (s) { return String(s.disc || '').toUpperCase() === disc; });
+      if (mine.length) { setStat(disc + ' — ' + mine.length + ' routed segments'); console.log('§DISC-WALK ' + disc + ' routed ' + mine.length + ' segment(s) (RouteWalker)'); }
+      else { setStat(disc + ' — no walk (no anchors for ' + name + ')'); console.log('§DISC-WALK ' + disc + ' no-walk — RouteWalker has no anchors/recipe for "' + name + '" (honest refusal, no fabricated run)'); }
+    } catch (e) { console.warn('§DISC-WALK ' + disc + ' failed ' + (e && e.message)); }
+  })();
+};
+
 // ── OPEN (W-UX-1): the pill-rail verb that replaced the old top-left drop panels. Clicking #b-open opens a
 // small chooser of the 4 permanent residents (reusing RESIDENTS[] from str_walker_outliner.js) + a local-.db
 // door (the dev/arbitrary-DB path). A pick calls the SHIPPED openResident()/openStrDb() — which swbInit-walks

--- a/viewer/str_walker_outliner.js
+++ b/viewer/str_walker_outliner.js
@@ -215,29 +215,10 @@
     });
   }
 
-  function mountButton() {
-    if (document.getElementById('strwalk-open')) return;
-    // ▾ resident picker — the guided drop surface (cloud → local cache → walk).
-    var sel = document.createElement('select'); sel.id = 'strwalk-resident';
-    sel.title = 'Open a resident building (fetched from the cloud, then cached on your device)';
-    sel.style.cssText = 'position:fixed;top:8px;left:336px;z-index:30;background:#1b1d23;color:#c7cdd8;' +
-      'border:1px solid #2c303a;border-radius:6px;padding:5px 8px;font:12px system-ui;cursor:pointer';
-    var ph = document.createElement('option'); ph.value = ''; ph.textContent = '▾ Open building…'; sel.appendChild(ph);
-    RESIDENTS.forEach(function (r) { var o = document.createElement('option'); o.value = r.key; o.textContent = r.label; sel.appendChild(o); });
-    sel.onchange = function () { var r = RESIDENTS.filter(function (x) { return x.key === sel.value; })[0]; if (r) openResident(r); sel.value = ''; };
-    document.body.appendChild(sel);
-    // 🏗 STR — open a LOCAL .db (kept alongside the curated residents).
-    var inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.db,.sqlite';
-    inp.style.display = 'none'; inp.id = 'strwalk-file';
-    inp.onchange = function () { if (inp.files && inp.files[0]) openStrDb(inp.files[0]); };
-    document.body.appendChild(inp);
-    var btn = document.createElement('button'); btn.id = 'strwalk-open'; btn.title = 'Open a local STR building file → walk the structure';
-    btn.textContent = '🏗';
-    btn.style.cssText = 'position:fixed;top:8px;left:486px;z-index:30;background:#1b1d23;color:#c7cdd8;' +
-      'border:1px solid #2c303a;border-radius:6px;padding:5px 10px;font:12px system-ui;cursor:pointer';
-    btn.onclick = function () { inp.click(); };
-    document.body.appendChild(btn);
-  }
+  // (W-UX-2 2026-06-26) The old top-left drop panel (▾ resident picker + 🏗 local-file button) was REMOVED —
+  // it is redundant now the bottom-right pill rail carries **Open** (the chooser of the 4 residents + a local
+  // .db door), wired to `openResident`/`openStrDb` below. The Open verbs stay here (the walker owns them);
+  // only the redundant DOM is gone. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-2.
 
   // Wrap the grid-move controller so a real drag re-walks STR + commits the signed cascade.
   function wrapGridMove() {
@@ -274,9 +255,8 @@
   window.STRWalkerOutliner = {
     register: function () {
       if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.addCategory(category());
-      mountButton();
       wrapGridMove();
-      console.log(TAG + ' registered — STR Walker category + 🏗 open + grid-drag re-walk (the wedge)');
+      console.log(TAG + ' registered — STR Walker category + grid-drag re-walk (the wedge); Open re-homed to the pill rail');
     },
     _openStrDb: openStrDb, _category: category,
     _openResident: openResident, _openBuffer: _openBuffer, _residents: RESIDENTS, _modellerBase: _modellerBase


### PR DESCRIPTION
Re-shapes the Modeller UX around ONE coherent surface (RESUME_MODELLER_UX_OUTLINER_PILL). UX/wiring over engines already built + witnessed — no engine rebuilds.

## W-UX-1 — Pill **Open** (load the 4)
A bottom-right glass pill **Open** opens a chooser of the 4 residents + a local-.db door, wired to the shipped `openResident()`/`openStrDb()` (walk + bom-graph seed + cross-edges in one). `window.SQL` now initialised at boot so the Open path can build an `SQL.Database` from bytes.

## W-UX-2 — Remove the old drop panels
The redundant top-left controls are gone: `str_walker` ▾ resident picker + 🏗, and `bom_tree` 📂 Open. The Open verbs stay in the engines; only the DOM was removed.

## W-UX-3 — ARC leads
BOM-graph (containment) + STR Walker register by **default** (no `?strwalk` flag) and the seeded TREE categories render FIRST, above the flat authored op-log groups. SampleHouse → Ground Floor + 3 qualified rooms (W-ROOM-STOREY-QUALIFY).

## W-UX-4 — Disc = walker
A discipline node is a clickable walker entry point (`data-disc` + ▶ glyph). Click STR → surfaces the real STR walk + expands the STR Walker tab. Click an MEP-family disc → RouteWalker when anchored, else an **honest refusal** (`§DISC-WALK <disc> no-walk`) — zero fabricated run. (Deep RouteWalker-in-modeller anchors for arbitrary buildings remain the separate engine task per substrate handoff §0.)

## W-UX-5 — Pill verbs
NEW **Guide** pill (`#b-guide`) → a self-contained Modeller User Guide overlay (no viewer/OCI dep). The other verbs already ship as rail pills/surfaces: **3D Grid** (`#b-grid`, toggles datums), **Export/IFC** (`#b-ifc`), **History** (`#hist` timeline + Ctrl+Z/⇧Z); **Save** is implicit (signed op-log auto-persists per building).

## Witnesses (headless, real residents)
- `witness_modeller_ux_pill.js` — W-UX-PILL 12/12
- `witness_modeller_disc_walk.js` — W-UX-DISC 8/8
- `witness_modeller_pill_verbs.js` — W-UX-VERBS 9/9
- `smoke_strwalk_modeller.js` — 9/9 (updated for the new wiring)

## Notes
- Modeller stays isolated (§101 Drift Law): modeller-only files + `../modeller/` hosting; viewer untouched.
- `tests/audit_specs.js` exits 1 on a **pre-existing, unrelated** viewer debt (`38-sh-dx-2d-runtime.spec.js`, 5 SKIP paths) — identical on clean `origin/main`; this PR adds zero new violations.
- Not in this PR (own slices): **W-UX-6** (render cross-edges on the backbone — reserved architecture fork) and **W-VIEWER-BOM-DEPRECATE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)