### PR TITLE
Modeller UX: ⇄ adjacency lens — render cross-edges on the backbone (W-UX-6)

### DIFF
--- a/tests/witness_modeller_xedge_lens.js
+++ b/tests/witness_modeller_xedge_lens.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * W-UX-XEDGE — headless witness for the adjacency lens (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-6, JS-derive fork):
+ *   • abuts cross-edges are DERIVED on Open (window.swXEdges.abuts, pristine substrate — not baked)
+ *   • the ⇄ lens toggle (#bo-adj) lights up on click and reports the edge count
+ *   • selecting an element highlights EXACTLY its abuts neighbours on the containment backbone (data-adj=1),
+ *     and the selected row shows its degree — the highlight set == the derived map (parity, NON-INVENT)
+ *   • toggling the lens OFF clears the highlights
+ *
+ * Wiring/parity gate; the abuts edge VALUES are the node witness W-CROSS-EDGES-ABUTS (JS==Python). Serves
+ * viewer/ + the repo modeller/ residents.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var VIEWER = path.join(__dirname, '..', 'viewer');
+var MODELLER = path.join(__dirname, '..', 'modeller');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = p.indexOf('/modeller/') === 0 ? path.join(MODELLER, p.slice('/modeller/'.length))
+             : path.join(VIEWER, p === '/' ? 'modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-UX-XEDGE — adjacency lens (headless) ═══');
+
+  // Open SampleHouse → abuts derived
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () { return !!(window.swXEdges && Array.isArray(window.swXEdges.abuts)) &&
+    !!(window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree()); }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(300);
+
+  var nAbuts = await page.evaluate(function () { return (window.swXEdges && window.swXEdges.abuts) ? window.swXEdges.abuts.length : -1; });
+  chk('E1 abuts derived on Open (window.swXEdges.abuts)', nAbuts > 0, 'edges=' + nAbuts);
+
+  // Toggle the ⇄ lens ON
+  await page.click('#bo-adj');
+  await page.waitForTimeout(150);
+  var lensOn = await page.evaluate(function () { return window.Bonsai.outliner._adjLens === true; });
+  chk('E2 ⇄ lens toggles ON', lensOn);
+  var lensLogged = logs.some(function (l) { return /§XEDGE-LENS adjacency=true edges=/.test(l); });
+  chk('E3 §XEDGE-LENS toggle logged with edge count', lensLogged, logs.filter(function (l) { return /XEDGE-LENS adjacency/.test(l); })[0] || '');
+
+  // Select the max-degree element → highlight EXACTLY its neighbours
+  var sel = await page.evaluate(function () {
+    var X = (window.swXEdges && window.swXEdges.abuts) || [];
+    var nbrs = {};
+    X.forEach(function (e) { (nbrs[e.a] || (nbrs[e.a] = new Set())).add(e.b); (nbrs[e.b] || (nbrs[e.b] = new Set())).add(e.a); });
+    var best = null, bd = -1; Object.keys(nbrs).forEach(function (g) { if (nbrs[g].size > bd) { bd = nbrs[g].size; best = g; } });
+    if (best == null) return { ok: false };
+    var present = new Set(); document.querySelectorAll('#bo-tree [data-bnode]').forEach(function (d) { present.add(d.getAttribute('data-bnode')); });
+    var expected = Array.from(nbrs[best]).filter(function (g) { return present.has(g); }).length;
+    var row = null; document.querySelectorAll('#bo-tree [data-bnode]').forEach(function (d) { if (d.getAttribute('data-bnode') === best) row = d; });
+    if (!row) return { ok: false, best: best, degree: bd };
+    row.click();   // fires the wired onclick → setActive + (lens) repaint
+    var adjRows = document.querySelectorAll('#bo-tree [data-adj="1"]').length;
+    var selRow = null; document.querySelectorAll('#bo-tree [data-bnode]').forEach(function (d) { if (d.getAttribute('data-bnode') === best) selRow = d; });
+    var deg = selRow ? selRow.querySelector('.bn-deg') : null;
+    return { ok: true, best: best.slice(0, 10), degree: bd, expected: expected, adjRows: adjRows, badge: deg ? deg.textContent : null };
+  });
+  chk('E4 selected element has abuts neighbours', sel.ok && sel.degree > 0, 'degree=' + sel.degree);
+  chk('E5 highlighted rows == derived neighbour set (parity, NON-INVENT)', sel.ok && sel.adjRows === sel.expected && sel.expected > 0, 'adjRows=' + sel.adjRows + ' expected=' + sel.expected);
+  chk('E6 selected row shows its ⇄degree badge', sel.ok && sel.badge === ('⇄' + sel.degree), 'badge=' + sel.badge + ' degree=' + sel.degree);
+  var selLogged = logs.some(function (l) { return /§XEDGE-LENS select=.*neighbours=/.test(l); });
+  chk('E7 §XEDGE-LENS select logged', selLogged);
+
+  // Toggle the lens OFF → highlights cleared
+  await page.click('#bo-adj');
+  await page.waitForTimeout(150);
+  var cleared = await page.evaluate(function () { return window.Bonsai.outliner._adjLens === false && document.querySelectorAll('#bo-tree [data-adj="1"]').length === 0; });
+  chk('E8 lens OFF clears highlights', cleared);
+
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('E9 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('W-UX-XEDGE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/bonsai_outliner.js
+++ b/viewer/bonsai_outliner.js
@@ -26,6 +26,10 @@
 
   const Outliner = {
     _el: null, _find: '', _collapsed: {}, _categories: [],
+    // W-UX-6: the "⇄ adjacency" lens — when ON, selecting an element highlights its typed cross-edge
+    // neighbours (Find-style) on the containment backbone. Edges are READ from window.swXEdges (derived
+    // on-the-fly from the pristine substrate, NON-INVENT — abuts ships today; later edge types slot in).
+    _adjLens: false, _adjMap: null,
 
     // Default categories — extensible. A category = { key, label, match(op)->bool, node(op)->{id,label,sub} }.
     _defaults() {
@@ -39,6 +43,23 @@
     },
     addCategory(cat) { this._categories.push(cat); this.refresh(); return this; },   // seam for Room/Phase/ERP
 
+    // ── W-UX-6 adjacency lens helpers ────────────────────────────────────────────────────────────────
+    // Build guid → Set(neighbour guids) from ALL window.swXEdges arrays (each edge = {a,b,...}, a/b guids).
+    // Undirected. abuts ships today; later derived edge types (anchored/spans/fills/aggregates) union in free.
+    _buildAdjMap() {
+      const map = {}, X = (typeof window !== 'undefined' && window.swXEdges) || {};
+      Object.keys(X).forEach(kind => {
+        const edges = X[kind]; if (!Array.isArray(edges)) return;
+        edges.forEach(e => {
+          if (e == null || e.a == null || e.b == null) return;
+          (map[e.a] || (map[e.a] = new Set())).add(e.b);
+          (map[e.b] || (map[e.b] = new Set())).add(e.a);
+        });
+      });
+      return map;
+    },
+    _adjCount() { const X = (typeof window !== 'undefined' && window.swXEdges) || {}; return Object.keys(X).reduce((s, k) => s + (Array.isArray(X[k]) ? X[k].length : 0), 0); },
+
     mount(parentSel) {
       if (this._el) return this._el;
       if (!this._categories.length) this._categories = this._defaults();
@@ -50,14 +71,27 @@
         'z-index:20;display:flex;flex-direction:column;user-select:none';
       el.innerHTML =
         '<div style="padding:9px 11px;font-size:11px;letter-spacing:.12em;color:#5b6473;border-bottom:1px solid #2c303a">OUTLINER</div>' +
-        '<div style="padding:7px 9px;border-bottom:1px solid #2c303a">' +
-        '<input id="bo-find" placeholder="🔍 find…" style="width:100%;box-sizing:border-box;background:#13151a;' +
-        'border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:5px 8px;font-size:12px;outline:none"></div>' +
+        '<div style="padding:7px 9px;border-bottom:1px solid #2c303a;display:flex;gap:6px;align-items:center">' +
+        '<input id="bo-find" placeholder="🔍 find…" style="flex:1;min-width:0;box-sizing:border-box;background:#13151a;' +
+        'border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:5px 8px;font-size:12px;outline:none">' +
+        '<button id="bo-adj" title="Adjacency lens — highlight a selected element’s abutting neighbours" ' +
+        'style="flex:0 0 auto;background:#13151a;border:1px solid #2c303a;border-radius:5px;color:#7f8aa0;' +
+        'padding:4px 8px;font-size:13px;cursor:pointer;line-height:1">⇄</button></div>' +
         '<div id="bo-tree" style="flex:1;overflow:auto;padding:5px 4px"></div>' +
         '<div id="bo-foot" style="padding:6px 11px;border-top:1px solid #2c303a;font-size:10px;color:#4a5260"></div>';
       host.appendChild(el);
       this._el = el;
       el.querySelector('#bo-find').addEventListener('input', e => { this._find = e.target.value.toLowerCase(); this._paint(); });
+      el.querySelector('#bo-adj').addEventListener('click', () => {
+        this._adjLens = !this._adjLens;
+        const b = this._el.querySelector('#bo-adj');
+        b.style.background = this._adjLens ? '#23364a' : '#13151a';
+        b.style.borderColor = this._adjLens ? '#3a6ea5' : '#2c303a';
+        b.style.color = this._adjLens ? '#cfe3f6' : '#7f8aa0';
+        const n = this._adjLens ? this._adjCount() : 0;
+        console.log(TAG + ' §XEDGE-LENS adjacency=' + this._adjLens + ' edges=' + n);
+        this._paint();
+      });
       window.addEventListener('bonsai:oplog', () => this.refresh());
       this.refresh();
       console.log(TAG + ' mounted categories=' + this._categories.map(c => c.key).join(','));
@@ -83,6 +117,8 @@
 
     _paint() {
       const tree = this._el.querySelector('#bo-tree'); if (!tree) return;
+      // W-UX-6: refresh the adjacency map for this paint when the lens is ON (cheap; reads window.swXEdges).
+      this._adjMap = this._adjLens ? this._buildAdjMap() : null;
       const ops = (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps() : [];
       // FLAT categories (op-log feature groups — Walls/Openings/etc., unchanged). TREE categories (deep, seeded,
       // editable — the BOM Tree composition facet, SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE) take a separate path.
@@ -123,7 +159,8 @@
       this._wireTrees(treeCats);
       const foot = this._el.querySelector('#bo-foot');
       const tip = (window.Bonsai.oplog && window.Bonsai.oplog._lastTip) || '';
-      foot.textContent = (f ? shown + '/' + total + ' shown' : total + ' features') + (tip ? '  🔒 ' + tip.slice(0, 8) : '');
+      const lens = this._adjLens ? ('  ⇄ ' + this._adjCount() + ' edges') : '';
+      foot.textContent = (f ? shown + '/' + total + ' shown' : total + ' features') + lens + (tip ? '  🔒 ' + tip.slice(0, 8) : '');
       console.log(TAG + ' paint total=' + total + ' shown=' + shown + ' find="' + f + '" trees=' + treeCats.length);
     },
 
@@ -154,11 +191,18 @@
         const pad = 16 + depth * 14;
         // W-UX-4: a DISCIPLINE node (n.disc) is a WALKER entry point — render a ▶ walk affordance + carry data-disc.
         const walkGlyph = n.disc ? ' <span class="bn-walk" title="Walk this discipline" style="color:#4fc3f7">▶</span>' : '';
+        // W-UX-6: adjacency lens — a NEIGHBOUR of the selected element gets a ⇄ badge + amber tint; the selected
+        // element shows its neighbour COUNT. Both read the derived map (window.swXEdges), never a baked table.
+        const nbrSet = (this._adjLens && isLeaf && this._adjMap) ? this._adjMap[window.Bonsai._selId] : null;
+        const isNbr = !!(nbrSet && nbrSet.has(n.id) && n.id !== window.Bonsai._selId);
+        const selDeg = (this._adjLens && active && isLeaf && this._adjMap && this._adjMap[n.id]) ? this._adjMap[n.id].size : 0;
+        const adjBadge = isNbr ? ' <span class="bn-adj" title="abuts the selected element" style="color:#e0a23a">⇄</span>'
+          : (selDeg ? ' <span class="bn-deg" style="color:#e0a23a;font-family:ui-monospace,monospace">⇄' + selDeg + '</span>' : '');
+        const rowBg = active ? 'background:#26456b;color:#dce6f4' : (isNbr ? 'background:#2c2616;color:#e6dcc2' : 'color:#c7cdd8');
         html += '<div data-bnode="' + n.id + '" data-tcat="' + ckey + '" data-leaf="' + (isLeaf ? 1 : 0) + '"' +
-          (n.disc ? ' data-disc="' + n.disc + '"' : '') + ' draggable="true" ' +
-          'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' +
-          (active ? 'background:#26456b;color:#dce6f4' : 'color:#c7cdd8') + '">' +
-          (kids.length ? CHEV(!ncol) : LEAF) + n.label + walkGlyph +
+          (n.disc ? ' data-disc="' + n.disc + '"' : '') + (isNbr ? ' data-adj="1"' : '') + ' draggable="true" ' +
+          'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' + rowBg + '">' +
+          (kids.length ? CHEV(!ncol) : LEAF) + n.label + walkGlyph + adjBadge +
           (n.sub ? '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span>' : '') + '</div>';
         if (kids.length && !ncol) { const r = this._renderNodes(kids, depth + 1, ckey, match); html += r.html; shown += r.shown; }
       });
@@ -175,7 +219,12 @@
         const id = d.getAttribute('data-bnode'), isLeaf = d.getAttribute('data-leaf') === '1';
         const disc = d.getAttribute('data-disc');
         d.onclick = () => {
-          if (isLeaf) { const num = +id; if (window.Bonsai.select && !isNaN(num)) window.Bonsai.select(num); else this.setActive(id); }
+          if (isLeaf) {
+            const num = +id; if (window.Bonsai.select && !isNaN(num)) window.Bonsai.select(num); else this.setActive(id);
+            // W-UX-6: with the adjacency lens ON, a fresh selection re-folds neighbour highlights (full repaint —
+            // setActive only restyles flat data-fid rows; the bom-graph bnode highlights are computed in _paint).
+            if (this._adjLens) { const deg = (this._adjMap && this._adjMap[id]) ? this._adjMap[id].size : 0; console.log(TAG + ' §XEDGE-LENS select=' + String(id).slice(0, 10) + ' neighbours=' + deg); this._paint(); }
+          }
           else {
             // W-UX-4: a discipline node WALKS on click (and still toggles its subtree). The walker dispatch
             // (STR walk / RouteWalker / honest refusal) is the category's onWalk; pure pointer, no geometry.

--- a/viewer/modeller.html
+++ b/viewer/modeller.html
@@ -183,7 +183,7 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=4" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=5" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
 <script src="bom_tree.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
 <script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>


### PR DESCRIPTION
The GRAPH half of the Outliner (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-6). Engine fork resolved by the user (2026-06-26): **JS-derive on-the-fly** (pristine substrate, like the shipped `abuts`), not the baked tables.

## What
- A **⇄ lens** toggle in the Outliner header. When ON, selecting an element highlights its typed cross-edge **neighbours** (Find-style) on the containment backbone — a ⇄ badge + amber tint on each neighbour row, and the selected row shows its **degree** (⇄N). The footer reports the live edge count.
- Edges are **read from `window.swXEdges`** (derived on Open from the pristine bbox substrate — never baked into the resident DB). `abuts` ships today; the lens unions later JS-derived edge types (`anchored`/`spans`/`fills_host`/`aggregates`) for free as they land.
- **NON-INVENT**: the highlighted set IS the derived adjacency map — witnessed to exact parity.

## Witness
`witness_modeller_xedge_lens.js` — **W-UX-XEDGE 9/9** (headless, real SampleHouse: 169 abuts derived on Open; lens toggles + logs; the max-degree element highlights EXACTLY its 19 derived neighbours = map parity; degree badge ⇄19; lens OFF clears all highlights). Full prior suite re-run green (W-UX-PILL 12, W-UX-DISC 8, W-UX-VERBS 9, smoke 9).

## Scope / next
- Modeller stays isolated (§101 Drift Law): modeller-only `bonsai_outliner.js`; viewer untouched.
- This is W-UX-6 **Phase 1** (render the shipped `abuts`). **Phase 2** (own slice): JS-derive the other 4 edge types, each oracle'd vs the witnessed Python builders, so the lens spans the full SDG.
- Unchanged pre-existing audit note: `tests/audit_specs.js` exits 1 on the unrelated `38-sh-dx-2d-runtime.spec.js` debt (identical on `origin/main`); zero new violations here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)