### PR TITLE
feat(modeller): tack-chain op-log emit for disc-walk

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1833,6 +1833,8 @@ window.discWalk = function (disc, ctx) {
       var gatedN = w.placements.filter(function (p) { return p.gated; }).length;
       setStat(disc + ' — ' + w.placed + ' placed across ' + w.storeys + ' storeys' + (gatedN ? ' · ' + gatedN + ' gated' : '') + (w.chains ? ' · ' + w.chains.length + ' routed' : ''));
       console.log('§DISC-WALK ' + disc + ' placed=' + w.placed + ' storeys=' + w.storeys + ' chains=' + (w.chains ? w.chains.length : 0) + ' gated=' + gatedN + ' (DiscWalker/terminal_rules)');
+      // Tack placements into the signed op-log as GEOM_INSERT — undoable + enterprise-foldable (W-DW-OPLOG)
+      await _commitDiscWalk(disc, w.placements);
     } catch (e) { console.warn('§DISC-WALK ' + disc + ' failed ' + (e && e.message)); }
   })();
 };
@@ -1883,6 +1885,39 @@ function _discGate() {
   Object.keys(window.__dwWalks).forEach(function (d) { all = all.concat(window.__dwWalks[d]); });
   if (all.length < 2) return { yields: 0 };
   return window.DiscWalker.gate(all);
+}
+// Tack-chain op-log emit (W-DW-OPLOG): commit each disc-walk placement as a signed GEOM_INSERT so the walk
+// is undoable and folds to the enterprise (same doctrine as dropLeaves/RouteWalker GEOM_SWEEP).
+// parameters._dw carries disc/storey/prov/ifc/host and persists in the DB via JSON.stringify(params).
+// Hash: exact ifc_class match in catalog, else first catalog entry (box proxy — identity lives in _dw.ifc).
+async function _commitDiscWalk(disc, placements) {
+  var O = window.Bonsai && window.Bonsai.oplog, L = window.Bonsai && window.Bonsai.library;
+  if (!O || !L) return 0;
+  var cat = L.catalog() || [];
+  var color = DW_COLOR[disc] || 0xc0c0c0;
+  var committed = 0;
+  for (var i = 0; i < placements.length; i++) {
+    var p = placements[i];
+    var found = cat.find(function (c) { return c.ifc_class === p.ifc_class; });
+    var hash = found ? found.hash : (cat[0] ? cat[0].hash : null);
+    if (!hash) continue;
+    var op = { op_type: 'GEOM_INSERT',
+      parameters: { hash: hash, placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +p.z.toFixed(4), rot: p.yaw || 0 },
+                    lod: '200', color: color,
+                    _dw: { disc: p.disc, storey: p.storey || '', prov: p.prov || '', ifc: p.ifc_class, host: p.host || null } } };
+    try { var res = await O.commit(op); if (res) committed++; }
+    catch (e) { console.warn('§DISC-WALK-COMMIT fail i=' + i + ' ' + (e && e.message)); }
+  }
+  if (committed) {
+    await O.scrubTo(O.length);
+    // foldChainToScene clears the editable group — restore the walk markers on top of committed geometry
+    _renderDiscWalk(disc, placements);
+    if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    syncHistory(); audioCue('rollout');
+  }
+  console.log('§DISC-WALK-COMMIT disc=' + disc + ' placements=' + placements.length + ' committed=' + committed);
+  window.__dwLastCommitDisc = disc;   // sentinel for witnesses
+  return committed;
 }
 
 // ── DISCIPLINE ROSTER (the convergence end-point) ───────────────────────────────────────────────────

--- a/modeller/tests/witness_modeller_dw_oplog.js
+++ b/modeller/tests/witness_modeller_dw_oplog.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * W-DW-OPLOG — headless witness for tack-chain op-log emit (RESUME_NEXT_SESSION §Tack-chain):
+ *   disc-walk placements are committed as signed GEOM_INSERT ops in the op-log so the walk is
+ *   undoable and enterprise-foldable. Each op carries parameters._dw (disc/storey/prov/ifc/host)
+ *   that persists in the DB via JSON.stringify and survives scrub/replay.
+ *
+ * Uses SampleHouse: 55 FP placements (50 array IfcFireSuppressionTerminal + 5 SHIM IfcAlarm).
+ *
+ * Checks (6):
+ *   O1 FP walk emits §DISC-WALK-COMMIT with committed>0
+ *   O2 oplog contains N GEOM_INSERT ops with parameters._dw.disc === 'FP'
+ *   O3 SHIM placement: ≥1 op has parameters._dw.host not null (IfcAlarm → host-wall tacked)
+ *   O4 undo (scrubTo length−1) reduces the FP GEOM_INSERT count by 1
+ *   O5 redo (scrubTo length) restores the count
+ *   O6 no script LOAD_FAIL / pageerror
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+async function openResident(page, key) {
+  await page.click('#b-open');
+  await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="' + key + '"]');
+  await page.waitForFunction(function () {
+    var t = window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree();
+    return !!t && Object.keys(t.nodes).some(function (id) { return t.nodes[id].kind === 'disc'; });
+  }, null, { timeout: 25000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.DiscWalker && window.DiscWalker._ready(); }, null, { timeout: 25000 }).catch(function () {});
+  // wait for catalog to load so hash lookups work
+  await page.waitForFunction(function () { return window.Bonsai && window.Bonsai.library && (window.Bonsai.library.catalog() || []).length > 0; }, null, { timeout: 10000 }).catch(function () {});
+  await page.waitForTimeout(300);
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-DW-OPLOG — tack-chain op-log emit (headless, SampleHouse) ═══');
+
+  await openResident(page, 'SampleHouse');
+
+  // ── walk FP onto SampleHouse ─────────────────────────────────────────────────────────────────────
+  logs.length = 0;
+  await page.click('#bo-tree [data-disc="FP"]');
+
+  // wait for markers to render (fast) then for commit loop to finish (sentinel set by _commitDiscWalk)
+  await page.waitForFunction(function () { return !!(window.__dwWalks && window.__dwWalks.FP && window.__dwWalks.FP.length > 0); }, null, { timeout: 15000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.__dwLastCommitDisc === 'FP'; }, null, { timeout: 15000 }).catch(function () {});
+  await page.waitForTimeout(300);
+
+  // O1: §DISC-WALK-COMMIT logged with committed>0
+  var commitLog = logs.find(function (l) { return /§DISC-WALK-COMMIT disc=FP/.test(l); }) || '';
+  var committedN = parseInt((commitLog.match(/committed=(\d+)/) || [0, 0])[1], 10);
+  chk('O1 FP walk emits §DISC-WALK-COMMIT committed>0', committedN > 0, commitLog || 'no log found');
+
+  // O2: oplog contains N GEOM_INSERT ops with parameters._dw.disc === 'FP'
+  var fpOps = await page.evaluate(function () {
+    if (!window.Bonsai.oplog || !window.Bonsai.oplog.db) return [];
+    return window.Bonsai.oplog._geomOps().filter(function (o) {
+      return o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters._dw && o.parameters._dw.disc === 'FP';
+    }).map(function (o) { return { id: o.id, ifc: o.parameters._dw.ifc, host: o.parameters._dw.host, prov: o.parameters._dw.prov }; });
+  });
+  chk('O2 oplog contains FP GEOM_INSERT ops with _dw.disc', fpOps.length > 0 && fpOps.length === committedN,
+    'oplog FP ops=' + fpOps.length + ' committed=' + committedN);
+
+  // O3: ≥1 SHIM op has _dw.host not null (IfcAlarm tacked onto host wall guid)
+  var shimOps = fpOps.filter(function (o) { return o.host; });
+  chk('O3 SHIM: ≥1 op has _dw.host guid (IfcAlarm→host-wall tacked)', shimOps.length > 0,
+    'shim ops=' + shimOps.length + (shimOps[0] ? ' eg host=' + String(shimOps[0].host).slice(0, 14) + '…' : ''));
+
+  // O4: undo() marks the last FP GEOM_INSERT as undone → active count drops by 1
+  await page.evaluate(function () { return window.Bonsai.oplog.undo(); });
+  await page.waitForTimeout(200);
+  var fpCountAfterUndo = await page.evaluate(function () {
+    if (!window.Bonsai.oplog || !window.Bonsai.oplog.db) return -1;
+    return window.Bonsai.oplog._geomOps().filter(function (o) {
+      return o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters._dw && o.parameters._dw.disc === 'FP';
+    }).length;
+  });
+  chk('O4 undo() marks last FP GEOM_INSERT undone (count −1)', fpCountAfterUndo === fpOps.length - 1,
+    'before=' + fpOps.length + ' after-undo=' + fpCountAfterUndo);
+
+  // O5: redo() restores the undone op → count back to N
+  await page.evaluate(function () { return window.Bonsai.oplog.redo(); });
+  await page.waitForTimeout(200);
+  var fpCountAfterRedo = await page.evaluate(function () {
+    if (!window.Bonsai.oplog || !window.Bonsai.oplog.db) return -1;
+    return window.Bonsai.oplog._geomOps().filter(function (o) {
+      return o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters._dw && o.parameters._dw.disc === 'FP';
+    }).length;
+  });
+  chk('O5 redo() restores FP op count', fpCountAfterRedo === fpOps.length,
+    'expected=' + fpOps.length + ' got=' + fpCountAfterRedo);
+
+  // O6: no script LOAD_FAIL / pageerror
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('O6 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  if (fail) {
+    console.log('--- DW-OPLOG logs ---');
+    logs.filter(function (l) { return /DISC-WALK|DW|LOAD_FAIL|PAGEERROR|FAIL/.test(l); }).slice(0, 16).forEach(function (l) { console.log('   ' + l); });
+  }
+  console.log('W-DW-OPLOG: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- `_commitDiscWalk(disc, placements)` commits each DiscWalker placement as a signed `GEOM_INSERT` in the op-log, making disc-walks undoable and enterprise-foldable
- `parameters._dw` persists `{disc, storey, prov, ifc, host}` in the signed DB row — survives scrub/history replay
- SHIM host-wall placements carry `_dw.host = wall guid` (IfcAlarm tacked onto real walls)
- After the commit fold, `_renderDiscWalk` re-runs to restore ephemeral 3D markers over the committed geometry
- `window.__dwLastCommitDisc` sentinel for witness sync

## Test plan
- [x] W-DW-OPLOG 6/6 (O1 committed>0, O2 _dw.disc round-trips, O3 SHIM host guid, O4 undo −1, O5 redo restored, O6 no errors)
- [x] W-TERM-WALK 9/9 regression-clean
- [x] W-UX-DISC 8/8 regression-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)