### PR TITLE
feat(modeller): Router half live — nn-chains rendered + folded to op-log

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -13,7 +13,8 @@
 // The rules carry RELATIVE dz + spacing (these transfer to a new building); absolute Terminal
 // z-bands do NOT transfer and are not used for placement. Honest-REFUSE when no rule covers a
 // disc, or the building lacks the substrate (no storeys / no network elements to route).
-// SOURCE COPY lives in bim-compiler/build/; the deployed copy is bim-ootb/viewer/disc_walker.js.
+// SOURCE COPY lives in bim-compiler/build/; the deployed copy is bim-ootb/modeller/disc_walker.js
+// (the Modeller is its own top-level app now — trilogy viewer/·erp/·modeller/).
 (function () {
   'use strict';
   var TAG = '§DW';
@@ -156,6 +157,97 @@
     return chains;
   }
 
+  // ── ROUTER nn-CHAINS (live geometry) ────────────────────────────────────────────────
+  // route() above only COUNTS endpoint classes (does the building have both?). routeChains
+  // PRODUCES the real network: for each measured 'nn' rule, pair every from-element to its
+  // NEAREST to-element in 3D, bounded by the measured max gap. A spatial hash (cell=bound)
+  // keeps it O(n) — NOT brute-force n×m (4243×3821 pipe pairs would be 16M). NON-INVENT: every
+  // segment joins TWO REAL elements at their REAL element_transforms positions; the only derived
+  // thing is the nearest-neighbour pairing, capped at the measured gap so no implausibly long run
+  // is fabricated. A from-element with no neighbour within the bound is HONESTLY skipped + counted.
+  function _gapParams(pj) {
+    var p = {}; try { p = JSON.parse(pj || '{}'); } catch (e) { p = {}; }
+    return {                                                  // PLB uses *_m keys; ACMV uses nn_dist_*_m — accept both
+      avg: (p.avg_gap_m != null) ? p.avg_gap_m : p.nn_dist_avg_m,
+      max: (p.max_m != null) ? p.max_m : p.nn_dist_max_m,
+      min: (p.min_m != null) ? p.min_m : p.nn_dist_min_m
+    };
+  }
+  function _loadXYZ(bdb, cls) {
+    return _rows(bdb,
+      "SELECT m.guid g, t.center_x x, t.center_y y, t.center_z z " +
+      "FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class='" + _esc(cls) + "'");
+  }
+  var _DERIVED_MAX_K = 4;                                     // when a rule has no measured max, bound = K×avg (logged)
+  // ONE nn pass: for each ANCHOR element find the nearest CAND within `bound` (spatial-hash, O(n)).
+  // Returns the paired list {ai, ci, gap} + the no-neighbour count + the mean gap of paired.
+  function _nnPass(anchor, cand, bound) {
+    var CELL = bound > 0 ? bound : 1, grid = {};
+    var ck = function (a, b, c) { return a + ',' + b + ',' + c; };
+    cand.forEach(function (p, i) {
+      var k = ck(Math.floor(p.x / CELL), Math.floor(p.y / CELL), Math.floor(p.z / CELL));
+      (grid[k] = grid[k] || []).push(i);
+    });
+    var pairs = [], noNbr = 0, sum = 0;
+    anchor.forEach(function (f, fi) {
+      var ix = Math.floor(f.x / CELL), iy = Math.floor(f.y / CELL), iz = Math.floor(f.z / CELL);
+      var best = Infinity, bj = -1;
+      for (var dx = -1; dx <= 1; dx++) for (var dy = -1; dy <= 1; dy++) for (var dz = -1; dz <= 1; dz++) {
+        var arr = grid[ck(ix + dx, iy + dy, iz + dz)]; if (!arr) continue;
+        for (var a = 0; a < arr.length; a++) {
+          var p = cand[arr[a]];
+          if (p.g === f.g) continue;                         // self-pair guard (same-class nn, e.g. IfcMember→IfcMember)
+          var d = Math.sqrt((f.x - p.x) * (f.x - p.x) + (f.y - p.y) * (f.y - p.y) + (f.z - p.z) * (f.z - p.z));
+          if (d < best) { best = d; bj = arr[a]; }
+        }
+      }
+      if (bj >= 0 && best <= bound) { pairs.push({ ai: fi, ci: bj, gap: best }); sum += best; }
+      else { noNbr++; }
+    });
+    return { pairs: pairs, noNbr: noNbr, mean: pairs.length ? sum / pairs.length : Infinity };
+  }
+  function routeChains(disc, bdb) {
+    var rr = _rows(_db, "SELECT * FROM rule_routing WHERE disc='" + _esc(disc) + "' AND pattern='nn'");
+    var segs = [], byRule = [];
+    rr.forEach(function (r) {
+      var gp = _gapParams(r.params_json);
+      if (gp.avg == null && gp.max == null) {                // no measured gap → cannot bound → honest skip
+        byRule.push({ from: r.from_kind, to: r.to_kind, segs: 0, noNbr: 0, skipped: 'no-measured-gap' });
+        return;
+      }
+      var bound = (gp.max != null) ? gp.max : _DERIVED_MAX_K * gp.avg;
+      var gapSource = (gp.max != null) ? 'measured-max' : 'derived-from-avg';
+      var from = _loadXYZ(bdb, r.from_kind), to = _loadXYZ(bdb, r.to_kind);
+      if (!from.length || !to.length) {                      // building lacks one endpoint class → honest 0
+        byRule.push({ from: r.from_kind, to: r.to_kind, segs: 0, noNbr: 0, skipped: 'no-endpoints' });
+        return;
+      }
+      // The rule declares from→to, but its measured avg gap was mined from whichever endpoint set is the
+      // LEAF (one connection per device). Routing the wrong way pairs sparse devices across the room (inflated
+      // mean, fabricated long links). So run nn BOTH orientations and KEEP THE TIGHTER (smaller mean gap) — the
+      // direction where every iterated element has a genuine nearby partner = the real connectivity. NON-INVENT:
+      // both passes use only real positions; we choose the orientation that fabricates the least gap. Segments
+      // always record from_guid/to_guid by the RULE's from_kind/to_kind, regardless of which set we iterated.
+      var fwd = _nnPass(from, to, bound);                    // anchor=from, cand=to
+      var rev = _nnPass(to, from, bound);                    // anchor=to,   cand=from
+      var useRev = rev.mean < fwd.mean;
+      var chosen = useRev ? rev : fwd;
+      var iterDir = useRev ? 'to→from' : 'from→to';
+      chosen.pairs.forEach(function (pr) {
+        // map the paired indices back to from-class / to-class endpoints (rule semantics, not iteration order)
+        var fEl = useRev ? from[pr.ci] : from[pr.ai];
+        var tEl = useRev ? to[pr.ai] : to[pr.ci];
+        segs.push({ disc: disc, rule: 'nn', from_kind: r.from_kind, to_kind: r.to_kind,
+          from_guid: fEl.g, to_guid: tEl.g, from: [fEl.x, fEl.y, fEl.z], to: [tEl.x, tEl.y, tEl.z],
+          gap: +pr.gap.toFixed(4), bound: +(+bound).toFixed(4), gapSource: gapSource });
+      });
+      byRule.push({ from: r.from_kind, to: r.to_kind, segs: chosen.pairs.length, noNbr: chosen.noNbr,
+        bound: +(+bound).toFixed(4), gapSource: gapSource, avg_measured: gp.avg, iterDir: iterDir,
+        meanGap: +chosen.mean.toFixed(4) });
+    });
+    return { segs: segs, byRule: byRule };
+  }
+
   // ── GATE (place-order + avoidance) ─────────────────────────────────────────────────
   // Global per-disc order = the median order_index across the measured place_order rows.
   function order() {
@@ -218,9 +310,12 @@
     }
     var placements = place(disc, sub, bdb);
     var chains = route(disc, bdb);
+    var rc = routeChains(disc, bdb);                         // LIVE nn-chain geometry (real on MEP-rich bldgs, 0 on residents)
     console.log(TAG + ' §WALK disc=' + disc + ' bldg=' + buildingName + ' placed=' + placements.length +
-      ' chains=' + chains.length + ' storeys=' + sub.length);
-    return { disc: disc, refused: false, placed: placements.length, placements: placements, chains: chains, storeys: sub.length };
+      ' chains=' + chains.length + ' chainSegs=' + rc.segs.length + ' storeys=' + sub.length +
+      (rc.byRule.length ? ' [' + rc.byRule.map(function (b) { return b.from.replace('Ifc', '') + '→' + b.to.replace('Ifc', '') + ':' + (b.skipped || (b.segs + '/' + (b.segs + b.noNbr))); }).join(' ') + ']' : ''));
+    return { disc: disc, refused: false, placed: placements.length, placements: placements,
+      chains: chains, chainSegs: rc.segs, chainByRule: rc.byRule, storeys: sub.length };
   }
 
   // The walkable disciplines the measured rules cover — drives the Outliner "Walk" roster so a
@@ -234,7 +329,7 @@
   }
 
   var API = { dwInit: dwInit, dwOpen: dwOpen, dwWalk: dwWalk, substrate: substrate, place: place,
-    route: route, gate: gate, repRules: repRules, order: order, clearance: clearance,
+    route: route, routeChains: routeChains, gate: gate, repRules: repRules, order: order, clearance: clearance,
     hostWalls: hostWalls, countPer: countPer,
     disciplines: disciplines, _ready: function () { return _ready; } };
   ROOT.DiscWalker = API;

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -206,7 +206,7 @@
 <!-- DiscWalker: the ONE shared discipline-walker engine (Placer/Router/Gate) reading the MEASURED
      terminal_rules.db (mined off Terminal). Supersedes the thin mep_rw.db recipes for the disc-node walk —
      every disc walks on ANY opened building from rules measured off a real coordinated building. -->
-<script src="disc_walker.js?v=2" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
+<script src="disc_walker.js?v=3" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
 <!-- Modeller's OWN service worker (its own app folder now — trilogy viewer/·erp/·modeller/; mirrors erp/sw.js). -->
 <script>
 if ('serviceWorker' in navigator) {
@@ -1831,10 +1831,13 @@ window.discWalk = function (disc, ctx) {
       var gateRes = _discGate();
       _renderDiscWalk(disc, w.placements);
       var gatedN = w.placements.filter(function (p) { return p.gated; }).length;
-      setStat(disc + ' — ' + w.placed + ' placed across ' + w.storeys + ' storeys' + (gatedN ? ' · ' + gatedN + ' gated' : '') + (w.chains ? ' · ' + w.chains.length + ' routed' : ''));
-      console.log('§DISC-WALK ' + disc + ' placed=' + w.placed + ' storeys=' + w.storeys + ' chains=' + (w.chains ? w.chains.length : 0) + ' gated=' + gatedN + ' (DiscWalker/terminal_rules)');
+      var nSeg = (w.chainSegs && w.chainSegs.length) || 0;
+      setStat(disc + ' — ' + w.placed + ' placed across ' + w.storeys + ' storeys' + (gatedN ? ' · ' + gatedN + ' gated' : '') + (nSeg ? ' · ' + nSeg + ' nn-chains' : (w.chains ? ' · ' + w.chains.length + ' routed' : '')));
+      console.log('§DISC-WALK ' + disc + ' placed=' + w.placed + ' storeys=' + w.storeys + ' chains=' + (w.chains ? w.chains.length : 0) + ' chainSegs=' + nSeg + ' gated=' + gatedN + ' (DiscWalker/terminal_rules)');
       // Tack placements into the signed op-log as GEOM_INSERT — undoable + enterprise-foldable (W-DW-OPLOG)
       await _commitDiscWalk(disc, w.placements);
+      // ROUTER LIVE (§ROUTER-NNCHAIN): real nn-chain network → render ALL as 3D lines, fold a bounded sample to op-log
+      if (nSeg) { _renderDiscChains(disc, w.chainSegs); await _commitDiscChains(disc, w.chainSegs); }
     } catch (e) { console.warn('§DISC-WALK ' + disc + ' failed ' + (e && e.message)); }
   })();
 };
@@ -1910,14 +1913,73 @@ async function _commitDiscWalk(disc, placements) {
   }
   if (committed) {
     await O.scrubTo(O.length);
-    // foldChainToScene clears the editable group — restore the walk markers on top of committed geometry
-    _renderDiscWalk(disc, placements);
+    // foldChainToScene clears the editable group — restore ALL walked markers + chains on top of committed geometry
+    _redrawAllDiscWalks();
     if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     syncHistory(); audioCue('rollout');
   }
   console.log('§DISC-WALK-COMMIT disc=' + disc + ' placements=' + placements.length + ' committed=' + committed);
   window.__dwLastCommitDisc = disc;   // sentinel for witnesses
   return committed;
+}
+
+// ── ROUTER nn-CHAIN render + op-log fold (§ROUTER-NNCHAIN) ──────────────────────────────────────────
+// The Router produces real nearest-neighbour-3d segments between actual MEP elements (pipe fittings↔
+// segments, ducts↔terminals), measured on the OPEN building's own element positions. Render the WHOLE
+// network as cheap 3D lines (instant, all visible = "the Router half live"); fold a BOUNDED + LOGGED sample
+// to the signed op-log as GEOM_SWEEP (occt is per-sweep — RouteWalker shipped ~200; the full network is the
+// line view, the op-log proves the signed/foldable mechanism). parameters._dw carries the two real guids+gap.
+window.__dwChains = window.__dwChains || {};   // disc -> chain segments (for the redraw-after-scrub)
+window.DW_CHAIN_COMMIT_CAP = 60;               // op-log GEOM_SWEEP cap (occt is per-sweep, so this is a signed sample); the full network always renders as lines (window-scoped so a witness can shrink it)
+function _renderDiscChains(disc, segs) {
+  var root = _dwRoot(); if (!root) return;
+  root.children.slice().forEach(function (o) { if (o.userData && o.userData.dwChain === disc) root.remove(o); });   // clear prior
+  window.__dwChains[disc] = segs;
+  var base = DW_COLOR[disc] || 0xc0c0c0;
+  var pts = new Float32Array(segs.length * 6);
+  for (var i = 0; i < segs.length; i++) {
+    var s = segs[i];
+    pts[i * 6] = s.from[0]; pts[i * 6 + 1] = s.from[1]; pts[i * 6 + 2] = s.from[2];
+    pts[i * 6 + 3] = s.to[0]; pts[i * 6 + 4] = s.to[1]; pts[i * 6 + 5] = s.to[2];
+  }
+  var g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(pts, 3));
+  var lines = new THREE.LineSegments(g, new THREE.LineBasicMaterial({ color: base }));
+  lines.userData.dwChain = disc;
+  root.add(lines);
+  if (window.A && A.requestRender) A.requestRender();
+}
+async function _commitDiscChains(disc, segs) {
+  var O = window.Bonsai && window.Bonsai.oplog; if (!O) return 0;
+  var color = DW_COLOR[disc] || 0xc0c0c0;
+  var capMax = window.DW_CHAIN_COMMIT_CAP || 120;
+  var cap = Math.min(segs.length, capMax);
+  var committed = 0;
+  for (var i = 0; i < cap; i++) {                     // commit optimistically (LEAF append, no per-commit re-fold)
+    var s = segs[i];
+    var op = { op_type: 'GEOM_SWEEP',
+      parameters: { profile: { w: 0.05, h: 0.05 }, path: [s.from.slice(), s.to.slice()],
+                    _dw: { disc: s.disc, rule: s.rule, from_kind: s.from_kind, to_kind: s.to_kind,
+                           from_guid: s.from_guid, to_guid: s.to_guid, gap: s.gap } } };
+    try { var res = await O.commit(op, { color: color }); if (res) committed++; }
+    catch (e) { console.warn('§ROUTER-CHAIN-COMMIT fail i=' + i + ' ' + (e && e.message)); }
+  }
+  if (committed) {
+    await O.scrubTo(O.length);                        // ONE authoritative re-fold (mirrors RouteWalker autoRouteMEP)
+    _redrawAllDiscWalks();
+    if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    syncHistory(); audioCue('rollout');
+  }
+  console.log('§ROUTER-CHAIN-COMMIT disc=' + disc + ' folded=' + committed + '/' + segs.length +
+    (segs.length > cap ? ' (cap=' + capMax + ', occt-bounded; full ' + segs.length + ' rendered live)' : ''));
+  window.__dwLastChainDisc = disc;                    // sentinel for witnesses
+  return committed;
+}
+// foldChainToScene clears the editable group on every scrub — re-render every walked disc's placement markers
+// AND chain lines so a co-resident walk (FP+ELEC, or PLB placements+chains) survives a later commit's re-fold.
+function _redrawAllDiscWalks() {
+  Object.keys(window.__dwWalks).forEach(function (d) { if (window.__dwWalks[d]) _renderDiscWalk(d, window.__dwWalks[d]); });
+  Object.keys(window.__dwChains).forEach(function (d) { if (window.__dwChains[d]) _renderDiscChains(d, window.__dwChains[d]); });
 }
 
 // ── DISCIPLINE ROSTER (the convergence end-point) ───────────────────────────────────────────────────

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v1';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v2';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_modeller_router_nnchain.js
+++ b/modeller/tests/witness_modeller_router_nnchain.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * W-ROUTER-NNCHAIN — headless witness: the Router half LIVE on a real-MEP building (§ROUTER-NNCHAIN).
+ * Residents (SH/DX/SC) carry no MEP network → the Router honestly returns 0. The Terminal (a resident,
+ * Terminal_meta.db) IS MEP-rich, so walking PLB there produces real nearest-neighbour-3d chains. This witness
+ * proves the modeller wiring: chains render as 3D lines AND fold to the signed op-log as GEOM_SWEEP.
+ *
+ * Wiring gate (TestArchitecture §Browser Testing); the chain VALUES (real endpoints, measured cadence, gap
+ * bound, honest-skip) are proven by the node witness build/witness_disc_route_nnchain.js (6/6).
+ *
+ * Checks (7):
+ *   N1 walk PLB on Terminal → w.chainSegs > 0 (§DISC-WALK ... chainSegs=N)
+ *   N2 chains rendered as 3D lines in the DiscWalker root (THREE.LineSegments)
+ *   N3 §ROUTER-CHAIN-COMMIT folded>0 logged
+ *   N4 op-log contains GEOM_SWEEP ops carrying parameters._dw.from_guid + _dw.to_guid (real chain identity)
+ *   N5 folded count == min(segs, cap) and honestly logged when capped
+ *   N6 undo() removes the last sweep; redo() restores it
+ *   N7 no script LOAD_FAIL / pageerror
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+async function openResident(page, key) {
+  await page.click('#b-open');
+  await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="' + key + '"]');
+  // Terminal_meta.db is ~19MB — give the open + DiscWalker init generous time
+  await page.waitForFunction(function () { return window.DiscWalker && window.DiscWalker._ready(); }, null, { timeout: 60000 }).catch(function () {});
+  await page.waitForFunction(function () { return !!window.__dwBuf; }, null, { timeout: 60000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.Bonsai && window.Bonsai.library && (window.Bonsai.library.catalog() || []).length > 0; }, null, { timeout: 15000 }).catch(function () {});
+  await page.waitForTimeout(400);
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-ROUTER-NNCHAIN — Router half live on Terminal (headless) ═══');
+
+  await openResident(page, 'Terminal');
+  var opened = await page.evaluate(function () { return { buf: !!window.__dwBuf, name: window.__dwName || '', ready: !!(window.DiscWalker && window.DiscWalker._ready()) }; });
+  chk('N0 Terminal opened + DiscWalker ready', opened.buf && opened.ready, 'name=' + opened.name);
+
+  // WIRING gate (occt is slow headless) — shrink the op-log GEOM_SWEEP cap so the commit finishes fast.
+  // The chain VALUES at full scale are proven by the node witness; here we prove render+commit+undo wiring.
+  await page.evaluate(function () { window.DW_CHAIN_COMMIT_CAP = 12; });
+
+  // ── walk PLB → real nn-chains ────────────────────────────────────────────────────────────────────
+  logs.length = 0;
+  await page.click('#bo-tree [data-disc="PLB"]');
+  // wait for placement commit (sentinel) then chain commit (sentinel)
+  await page.waitForFunction(function () { return window.__dwLastCommitDisc === 'PLB'; }, null, { timeout: 90000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.__dwLastChainDisc === 'PLB'; }, null, { timeout: 120000 }).catch(function () {});
+  await page.waitForTimeout(500);
+
+  var walkLog = logs.find(function (l) { return /§DISC-WALK PLB .*chainSegs=\d+/.test(l); }) || '';
+  var nSeg = parseInt((walkLog.match(/chainSegs=(\d+)/) || [0, 0])[1], 10);
+  chk('N1 walk PLB → chainSegs>0 (Router routes real nn-chains)', nSeg > 0, walkLog || 'no walk log');
+
+  // N2 chains rendered as 3D lines
+  var lineSegs = await page.evaluate(function () {
+    var g = window.Bonsai.group && window.Bonsai.group(); if (!g) return -1;
+    var root = g.children.find(function (o) { return o.userData && o.userData.dwRoot; }); if (!root) return 0;
+    return root.children.filter(function (o) { return o.isLineSegments && o.userData.dwChain; }).reduce(function (n, o) { return n + (o.geometry.getAttribute('position').count / 2); }, 0);
+  });
+  chk('N2 chains rendered as 3D lines in DiscWalker root', lineSegs > 0, 'lineSegments=' + lineSegs);
+
+  // N3 + N5 chain commit logged + cap honored
+  var commitLog = logs.find(function (l) { return /§ROUTER-CHAIN-COMMIT disc=PLB/.test(l); }) || '';
+  var folded = parseInt((commitLog.match(/folded=(\d+)/) || [0, 0])[1], 10);
+  chk('N3 §ROUTER-CHAIN-COMMIT folded>0 logged', folded > 0, commitLog);
+
+  var cap = await page.evaluate(function () { return window.DW_CHAIN_COMMIT_CAP || 300; });
+  var expectFolded = Math.min(nSeg, cap);
+  chk('N5 folded == min(segs, cap), capping honestly logged', folded === expectFolded &&
+    (nSeg <= cap || /cap=\d+, occt-bounded; full \d+ rendered live/.test(commitLog)),
+    'folded=' + folded + ' expect=' + expectFolded + ' cap=' + cap);
+
+  // N4 op-log GEOM_SWEEP ops with _dw.from_guid/to_guid
+  var sweeps = await page.evaluate(function () {
+    if (!window.Bonsai.oplog || !window.Bonsai.oplog.db) return { total: 0, withDw: 0, sample: null };
+    var ops = window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP'; });
+    var withDw = ops.filter(function (o) { return o.parameters && o.parameters._dw && o.parameters._dw.from_guid && o.parameters._dw.to_guid; });
+    return { total: ops.length, withDw: withDw.length, sample: withDw[0] ? { f: withDw[0].parameters._dw.from_guid, t: withDw[0].parameters._dw.to_guid, gap: withDw[0].parameters._dw.gap } : null };
+  });
+  chk('N4 op-log GEOM_SWEEP ops carry _dw.from_guid + _dw.to_guid', sweeps.withDw === folded && sweeps.withDw > 0,
+    'sweeps=' + sweeps.total + ' withDw=' + sweeps.withDw + (sweeps.sample ? ' eg ' + sweeps.sample.f.slice(0, 8) + '→' + sweeps.sample.t.slice(0, 8) + ' gap=' + sweeps.sample.gap : ''));
+
+  // N6 undo/redo a sweep
+  var sweepBefore = sweeps.withDw;
+  await page.evaluate(function () { return window.Bonsai.oplog.undo(); });
+  await page.waitForTimeout(300);
+  var sweepAfterUndo = await page.evaluate(function () {
+    return window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP' && o.parameters && o.parameters._dw && o.parameters._dw.from_guid; }).length;
+  });
+  await page.evaluate(function () { return window.Bonsai.oplog.redo(); });
+  await page.waitForTimeout(300);
+  var sweepAfterRedo = await page.evaluate(function () {
+    return window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP' && o.parameters && o.parameters._dw && o.parameters._dw.from_guid; }).length;
+  });
+  chk('N6 undo() removes a chain sweep; redo() restores it', sweepAfterUndo === sweepBefore - 1 && sweepAfterRedo === sweepBefore,
+    'before=' + sweepBefore + ' undo=' + sweepAfterUndo + ' redo=' + sweepAfterRedo);
+
+  // N7 no script load failure / pageerror
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('N7 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  if (fail) {
+    console.log('--- ROUTER-NNCHAIN logs ---');
+    logs.filter(function (l) { return /DISC-WALK|ROUTER-CHAIN|DW |LOAD_FAIL|PAGEERROR|FAIL/.test(l); }).slice(0, 18).forEach(function (l) { console.log('   ' + l); });
+  }
+  console.log('W-ROUTER-NNCHAIN: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
Makes the **Router half** of the disc-walk engine *live*. Residents (SH/DX/SC) carry no MEP network so the Router honestly returns 0; the **Terminal** (a resident, `Terminal_meta.db`) is MEP-rich (3821 IfcPipeSegment, 568 IfcDuctSegment, …). Walking PLB/ACMV there now produces real **nearest-neighbour-3d chains** and the modeller:
- renders the **whole network** (e.g. 4314 PLB chains) as instant 3D lines = the live Router view;
- folds a **bounded, signed sample** to the op-log as `GEOM_SWEEP` (`parameters._dw.from_guid/to_guid/gap`) — undoable + enterprise-foldable, like the placement tacks (W-DW-OPLOG).

Engine change (`disc_walker.js`, synced from `bim-compiler/build/`): new `routeChains()` pairs every from-element to its nearest to-element in 3D via a spatial hash (O(n), not 16M brute-force pairs), bounded by the measured max gap. NON-INVENT — every segment joins two **real** elements at their **real** positions; from-elements with no neighbour are honestly skipped. Routes the **tighter** of the two nn orientations (the genuine connectivity direction), reproducing the Terminal-measured cadence.

`_commitDiscChains` commits up to `DW_CHAIN_COMMIT_CAP` (60) sweeps optimistically then one scrub (occt is per-sweep; the full network is the line view). Capping is logged honestly, never silent. `disc_walker.js?v=3`, sw `CACHE_VERSION v2`.

## Test plan
- [x] W-ROUTER-NNCHAIN 8/8 (headless, Terminal PLB, cap=12 wiring): lines rendered, sweeps carry real guids, cap honored+logged, undo/redo
- [x] Chain VALUES at full scale: `bim-compiler/build/witness_disc_route_nnchain.js` 6/6 (R1 live, R2 real-endpoints 0 mismatch, R3 gap-bounded, R4 cadence ±25%, R5 honest-skip, R6 resident-zero)
- [x] Regression-clean: W-DW-OPLOG 6/6, W-TERM-WALK 9/9, W-UX-DISC 8/8; generalize 49/49, shim 6/6, erp-equivalence 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)