### PR TITLE
fix(offline): route viewer ad_seed.db loads through IDB cache (sw v738)

### DIFF
--- a/viewer/diff.js
+++ b/viewer/diff.js
@@ -343,7 +343,7 @@ function setupDiff(A) {
     }
     return fromOpfs().then(function (db) {
       if (db) { _voErpDb = db; console.log('[RP-F] §VO_DB src=opfs'); return db; }
-      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); })
+      return APP.cachedFetch('../erp/ad_seed.db')
         .then(function (buf) { _voErpDb = new SQL.Database(new Uint8Array(buf)); console.log('[RP-F] §VO_DB src=seed'); return _voErpDb; })
         .catch(function (e) { console.log('[RP-F] §VO_DB_ERR ' + e.message); return null; });
     });

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1019,7 +1019,7 @@
       if (_bimErpDb) return Promise.resolve(_bimErpDb);
       var SQL = A._SQL || window.SQL || window._SQL_CACHED;   // viewer caches the sql.js factory as A._SQL (streaming.js:1343); window.SQL is only set on the ERP page
       if (!SQL || !window.ProjFold) return Promise.resolve(null);
-      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); })
+      return APP.cachedFetch('../erp/ad_seed.db')
         .then(function (buf) { _bimErpDb = new SQL.Database(new Uint8Array(buf)); return _bimErpDb; })
         .catch(function (e) { console.log('[RP-C] §PROJ_PUSH_DBERR ' + e.message); return null; });
     }

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -53,7 +53,7 @@
     } catch (e) {}
     return fromOpfs.then(function (d) {
       if (d) return d;
-      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); })
+      return APP.cachedFetch('../erp/ad_seed.db')
         .then(function (buf) { return new SQL.Database(new Uint8Array(buf)); })
         .catch(function () { return null; });
     });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v737';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v738';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2751,7 +2751,7 @@
     var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
     if (!SQL) { console.log('§TM_TWIN_DEFER no sql.js factory'); return Promise.resolve(null); }
     _twinLoading = true;
-    return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+    return APP.cachedFetch('../erp/ad_seed.db').then(function (buf) {
       var db = new SQL.Database(new Uint8Array(buf));
       var pr = db.exec("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value=?", [building]);
       if (!pr.length || !pr[0].values.length) { db.close(); _twinLoading = false; console.log('§TM_TWIN_MISS building="' + building + '" — not a folded project'); return null; }
@@ -2779,7 +2779,7 @@
     var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
     if (!SQL) return Promise.resolve(null);
     _shopfloorLoading = true;
-    return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+    return APP.cachedFetch('../erp/ad_seed.db').then(function (buf) {
       var db = new SQL.Database(new Uint8Array(buf));
       var pr = db.exec('SELECT C_Project_ID FROM C_Project WHERE Value=?', [building]);
       if (!pr.length || !pr[0].values.length) { db.close(); _shopfloorLoading = false; return null; }
@@ -3918,7 +3918,7 @@
     var SQL = (app && app._SQL) || window.SQL || window._SQL_CACHED;
     function fetchOrder() {
       if (!SQL) { console.log('§TM_ORDER_JUMP skip=no-SQL order=' + ppOrderId); return Promise.resolve(null); }
-      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+      return APP.cachedFetch('../erp/ad_seed.db').then(function (buf) {
         var db = new SQL.Database(new Uint8Array(buf));
         var r = db.exec('SELECT Description, DateStartSchedule, DateFinishSchedule, C_Project_ID FROM PP_Order WHERE PP_Order_ID=' + ppOrderId);
         if (!r.length || !r[0].values.length) { db.close(); return null; }

--- a/viewer/wh_walk.js
+++ b/viewer/wh_walk.js
@@ -105,9 +105,7 @@
     if (!window.POSCore) await loadScript('../erp/pos_core.js?v=3');
     if (!window.InOutConfirm) await loadScript('../erp/inout_confirm.js?v=1');
     if (!W.erpDb) {
-      var r = await fetch('../erp/ad_seed.db');
-      if (!r.ok) throw new Error('ad_seed.db fetch ' + r.status);
-      var buf = new Uint8Array(await r.arrayBuffer());
+      var buf = new Uint8Array(await APP.cachedFetch('../erp/ad_seed.db'));
       W.erpDb = new A._SQL.Database(buf);
       log('SEED loaded bytes=' + buf.length);
     }

--- a/viewer/whatif_panel.js
+++ b/viewer/whatif_panel.js
@@ -47,7 +47,7 @@
     } catch (e) { fromOpfs = Promise.resolve(null); }
     return fromOpfs.then(function (db) {
       if (db && _hasFoldedProject(db)) { _db = db; return _db; }
-      return fetch('../erp/ad_seed.db').then(function (r) { return r.arrayBuffer(); })
+      return APP.cachedFetch('../erp/ad_seed.db')
         .then(function (buf) { _db = new SQL.Database(new Uint8Array(buf)); return _db; })
         .catch(function (e) { console.log('§WHATIF-UI db-load-err ' + e.message); return null; });
     });


### PR DESCRIPTION
## Summary

- 8 bare `fetch('../erp/ad_seed.db')` calls in viewer files bypassed `APP.cachedFetch` and relied on browser HTTP cache only
- SW skips `.db` files entirely — so these had zero offline protection once browser cache expired or was cleared
- Files: `time_machine.js`×3, `whatif_panel.js`, `wh_walk.js`, `diff.js`, `schedule_author_ui.js`, `navigate_find.js`
- Fix: replace each with `APP.cachedFetch('../erp/ad_seed.db')` (already returns `ArrayBuffer`, so callers need no other change)
- First load writes to `bim_ootb_cache` IDB; every subsequent open is a `§CACHE_HIT` — no network

ERP side (`erp.html` / `idempiere.html`) already correct via `idbGet('ad_seed_v16')` — untouched.
Modeller left untouched (active session).

## Test plan
- [ ] Open viewer with a building → open Time Machine → check console for `§CACHE_HIT ../erp/ad_seed.db` on second open
- [ ] Go offline → open What-if / Find project-push — should still load from IDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)