### PR TITLE
Modeller W-BONSAI-SCALE: gizmo cube scale-handles (edge-anchored, inserts) — sw v9

### DIFF
--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -19,7 +19,7 @@
     init() {
       if (this._worker) return this._worker;
       if (!this.isSupported()) { console.warn(TAG + ' unsupported host (needs WASM tail-calls + Worker)'); return null; }
-      const url = new URL('bonsai_kernel_worker.js?v=4', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin (W-BONSAI-ROTATE-SOLID)
+      const url = new URL('bonsai_kernel_worker.js?v=5', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b)
       this._worker = new Worker(url.href, { type: 'module' });
       this._worker.onmessage = (e) => {
         const d = e.data || {};
@@ -148,11 +148,12 @@
       const kernelOps = ops.filter(o => o.op_type !== 'GEOM_INSERT');   // KEEPS GEOM_MOVE → PATH A translates moved walls
       const moveBy = new Map();                                          // targetFeatureId -> {dx,dy,dz,drot} (net, summed)
       for (const op of ops) {
-        if (op.op_type !== 'GEOM_MOVE' && op.op_type !== 'GEOM_ROTATE') continue;
+        if (op.op_type !== 'GEOM_MOVE' && op.op_type !== 'GEOM_ROTATE' && op.op_type !== 'GEOM_SCALE') continue;
         const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
-        const a = moveBy.get(P.parent) || { dx: 0, dy: 0, dz: 0, drot: 0 };
+        const a = moveBy.get(P.parent) || { dx: 0, dy: 0, dz: 0, drot: 0, fx: 1, fy: 1, fz: 1 };
         if (op.op_type === 'GEOM_MOVE') { a.dx += P.dx || 0; a.dy += P.dy || 0; a.dz += P.dz || 0; }
-        else { a.drot += P.drot || 0; }                                  // GEOM_ROTATE: net yaw (about Z), applied host-side to inserts (W-BONSAI-ROTATE PATH B)
+        else if (op.op_type === 'GEOM_ROTATE') { a.drot += P.drot || 0; }   // net yaw (about Z), host-side to inserts (W-BONSAI-ROTATE PATH B)
+        else { a.fx *= P.fx != null ? P.fx : 1; a.fy *= P.fy != null ? P.fy : 1; a.fz *= P.fz != null ? P.fz : 1; }   // GEOM_SCALE: net multiplicative scale (W-BONSAI-SCALE PATH B)
         moveBy.set(P.parent, a);
       }
       const d = kernelOps.length ? await this._foldChain(kernelOps) : { meshes: [] };

--- a/modeller/bonsai_kernel_worker.js
+++ b/modeller/bonsai_kernel_worker.js
@@ -204,6 +204,15 @@ function buildSolids(kernel, ops) {
           shapeCache.set(ckey, out); solids.set(op.parent, { shape: out, hash: ckey });   // parent cached → NOT released
         }
       }
+    } else if (op.op_type === 'GEOM_SCALE') {          // non-uniform EDGE-ANCHORED scale (W-BONSAI-SCALE) — INSERTS only.
+      // The gizmo only offers scale handles on INSERTS (catalog components), which fold host-side in pure JS
+      // (library.foldInsert PATH B: scale base geometry edge-anchored, net factor accumulated in bonsai_kernel) —
+      // deterministic + composes exactly, no occt. A B-rep SOLID scale is DEFERRED: occt-wasm generalTransform uses
+      // BRepBuilderAPI_GTransform with Copy=false, so the derived shape ALIASES the shared base TShape and an
+      // intervening scrub/release corrupts it → a 2nd scale (or scale-X-then-Y, both real gizmo flows) leaks the prior
+      // factor onto the untouched axes (witnessed: x×2 then x×1.5 → z×2). The fix is a kernel-level Copy=true
+      // GTransform / bake primitive in lib/kernel — a separate effort, not a polish leg. So GEOM_SCALE on a worker
+      // solid is a TOLERANT NO-OP here until that lands (the gizmo never emits it for solids). RESUME_MODELLER_POLISH.md #3b.
     } else {                                           // LEAF feature (extrude/poly/sweep/opening)
       if (shapeCache.has(key)) { _stats.hits++; solids.set(op.id, { shape: shapeCache.get(key), hash: key }); continue; }
       _stats.rebuilt++;

--- a/modeller/bonsai_library.js
+++ b/modeller/bonsai_library.js
@@ -338,8 +338,22 @@
       const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
       const c = this.get(P.hash); if (!c) throw new Error('GEOM_INSERT unknown component ' + P.hash);
       const lod = this.lodFor(op.id, P.lod);
-      const base = (lod === '300') ? this.meshArrays(P.hash) : boxArrays(c.bbox);
+      let base = (lod === '300') ? this.meshArrays(P.hash) : boxArrays(c.bbox);
       let pl = P.placement;
+      // W-BONSAI-SCALE PATH B: net GEOM_SCALE folds host-side on the insert's LOCAL geometry — EDGE-ANCHORED at the
+      // local bbox min per axis (stretch the object along its own length), so it composes with the existing yaw +
+      // ground-seat math (place() seats on the SCALED bbox). SIZE only — scales geometry, never the placement.
+      if (mv && ((mv.fx != null && mv.fx !== 1) || (mv.fy != null && mv.fy !== 1) || (mv.fz != null && mv.fz !== 1))) {
+        const fx = mv.fx != null ? mv.fx : 1, fy = mv.fy != null ? mv.fy : 1, fz = mv.fz != null ? mv.fz : 1;
+        const bb = base.bbox || c.bbox;                                  // [xmin,xmax,ymin,ymax,zmin,zmax]
+        const ax = bb[0], ay = bb[2], az = bb[4];
+        const sp = base.positions.slice();                              // don't mutate the cached catalog arrays
+        for (let i = 0; i < sp.length; i += 3) {
+          sp[i] = ax + fx * (sp[i] - ax); sp[i + 1] = ay + fy * (sp[i + 1] - ay); sp[i + 2] = az + fz * (sp[i + 2] - az);
+        }
+        const sbb = [ax, ax + fx * (bb[1] - ax), ay, ay + fy * (bb[3] - ay), az, az + fz * (bb[5] - az)];
+        base = { positions: sp, indices: base.indices, bbox: sbb };
+      }
       if (mv && (mv.dx || mv.dy || mv.dz || mv.drot)) {
         let ox = (P.placement.x || 0) + (mv.dx || 0), oy = (P.placement.y || 0) + (mv.dy || 0);
         const oz = (P.placement.z || 0) + (mv.dz || 0), pr = P.placement.rot || 0;

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -166,7 +166,7 @@
 <div id="stat">booting…</div>
 
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->
-<script src="bonsai_kernel.js?v=3" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
+<script src="bonsai_kernel.js?v=4" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
 <!-- Bonsai 2D sketch front: planegcs constraint solver -> solved profile -> GEOM_EXTRUDE_POLY. -->
 <script src="bonsai_sketch.js?v=1" onerror="console.warn('§SKETCH LOAD_FAIL bonsai_sketch.js')"></script>
 <!-- Signed op-log engine (shipped kernel_ops: hash chain + edge signature) + sql.js it commits into. -->
@@ -196,7 +196,7 @@
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
 <script src="str_walker_outliner.js?v=9" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=14" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=15" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="../viewer/connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
@@ -1063,6 +1063,16 @@ function axisHandle(axis, color, L) {                          // one pickable c
   const grp = new THREE.Group(); grp.userData.moveAxis = axis; shaft.userData.moveAxis = axis; tip.userData.moveAxis = axis;
   grp.add(shaft, tip); return grp;
 }
+// W-BONSAI-SCALE: a pickable CUBE handle at the +axis end → drag it out to non-uniformly stretch the selection
+// (edge-anchored: the opposite face stays put). Distinct cube (vs the move arrow) so the two never confuse.
+function scaleHandle(axis, color, L) {
+  const dir = axis === 'x' ? new THREE.Vector3(1, 0, 0) : axis === 'y' ? new THREE.Vector3(0, 1, 0) : new THREE.Vector3(0, 0, 1);
+  const mat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.95, depthTest: false });
+  const cube = new THREE.Mesh(new THREE.BoxGeometry(0.17, 0.17, 0.17), mat);
+  cube.position.copy(dir.clone().multiplyScalar(L + 0.5));
+  cube.userData.moveAxis = 'scale' + axis.toUpperCase();   // scaleX / scaleY / scaleZ
+  return cube;
+}
 function buildMoveGizmo() {
   clearMoveGizmo(); const c = selCentre(); if (!c) return;
   const gbox = new THREE.Box3(); selMeshes().forEach(m => { m.geometry.computeBoundingBox(); gbox.expandByObject(m); });
@@ -1077,6 +1087,10 @@ function buildMoveGizmo() {
   if (_rotIds.length >= 1 && _rotIds.every(id => isInsert(id) || isSolid(id))) {   // H3: yaw ring on a single INSERT/SOLID OR a multi-select GROUP (rotates about the set centroid, W-BONSAI-ROTATE-GROUP)
     const ring = new THREE.Mesh(new THREE.TorusGeometry(Math.max(0.7, L * 0.95), 0.045, 8, 56), new THREE.MeshBasicMaterial({ color: 0xf5c542, transparent: true, opacity: 0.9, depthTest: false }));
     ring.userData.moveAxis = 'rotZ'; moveGizmo.add(ring);       // TorusGeometry lies in XY → rotates about +Z by construction
+    // W-BONSAI-SCALE: cube scale-handles on a single INSERT (catalog component). Edge-anchored, pure-JS fold (robust,
+    // composes). NOT offered on B-rep SOLIDS yet — occt-wasm generalTransform Copy=false leaks on compose (#3b, a
+    // kernel fix); showing a handle that scales wrong would be dishonest, so we gate to where scale is reliable.
+    if (_rotIds.length === 1 && isInsert(_rotIds[0])) moveGizmo.add(scaleHandle('x', 0xe2553b, L), scaleHandle('y', 0x46b955, L), scaleHandle('z', 0x4f93e0, L));
   }
   moveGizmo.traverse(o => { o.renderOrder = 1000; });          // draw over the solids like the insert ghost
   moveGizmo.position.copy(c); scene.add(moveGizmo);
@@ -1093,6 +1107,24 @@ function moveGhostShow(dx, dy, dz) {                           // translucent cl
   }
   moveGhost.position.set(dx, dy, dz);
   const c = selCentre(); if (c && moveGizmo) moveGizmo.position.set(c.x + dx, c.y + dy, c.z + dz);
+  if (window.A && A.requestRender) A.requestRender();
+}
+function selBox() {                                            // combined world bbox of the selection (group-aware; world==local for authored meshes)
+  const ms = selMeshes(); if (!ms.length && selectedMesh) ms.push(selectedMesh); if (!ms.length) return null;
+  const box = new THREE.Box3(); ms.forEach(m => { m.geometry.computeBoundingBox(); box.expandByObject(m); });
+  return isFinite(box.min.x) ? box : null;
+}
+function scaleGhostShow(ax, f) {                               // W-BONSAI-SCALE: clones stretched ×f, EDGE-ANCHORED at the selection min along ax
+  const ms = selMeshes(); if (!ms.length && selectedMesh) ms.push(selectedMesh); if (!ms.length || !_moveDrag) return;
+  if (!moveGhost) {
+    moveGhost = new THREE.Group();
+    ms.forEach(m => { const gm = new THREE.Mesh(m.geometry.clone(), new THREE.MeshBasicMaterial({ color: 0x4fc3f7, transparent: true, opacity: 0.35, depthWrite: false })); gm.renderOrder = 998; moveGhost.add(gm); });
+    scene.add(moveGhost);
+  }
+  const amin = _moveDrag.amin;                                 // group scaled ×f about origin → x'=f·x; edge-anchor: x'=amin+f(x−amin)=f·x+amin(1−f)
+  const s = { x: 1, y: 1, z: 1 }; s[ax] = f;
+  const off = { x: 0, y: 0, z: 0 }; off[ax] = amin * (1 - f);
+  moveGhost.scale.set(s.x, s.y, s.z); moveGhost.position.set(off.x, off.y, off.z);
   if (window.A && A.requestRender) A.requestRender();
 }
 function rotGhostShow(theta) {                                 // H3: translucent clones spun θ about the selection centre (pivot = ring centre)
@@ -1209,6 +1241,17 @@ canvas.addEventListener('pointerdown', (e) => {
     setStat('rotate — drag the ring (Shift = free, else 15° snap), release to commit');
     return;
   }
+  if (axis.indexOf('scale') === 0) {                            // W-BONSAI-SCALE: cube-handle drag → edge-anchored non-uniform stretch
+    const ax = axis.slice(5).toLowerCase();                     // scaleX → 'x'
+    const sb = selBox(); if (!sb) return;
+    const ext = ax === 'x' ? sb.max.x - sb.min.x : ax === 'y' ? sb.max.y - sb.min.y : sb.max.z - sb.min.z;
+    const amin = ax === 'x' ? sb.min.x : ax === 'y' ? sb.min.y : sb.min.z;
+    if (!(ext > 1e-4)) { setStat('scale: zero extent on ' + ax.toUpperCase()); return; }
+    const down = moveDragPoint(ax, ndc, c0); if (!down) return;
+    _moveDrag = { axis, ax, c0, down, ext, amin, f: 1 };
+    setStat('scale ' + ax.toUpperCase() + ' — drag the cube out (edge-anchored), release to commit');
+    return;
+  }
   const down = moveDragPoint(axis, ndc, c0); if (!down) return;
   _moveDrag = { axis, c0, down, dx: 0, dy: 0, dz: 0 };
   setStat('move ' + axis.toUpperCase() + ' — drag, release to commit');
@@ -1223,6 +1266,18 @@ canvas.addEventListener('pointermove', (e) => {
     if (!e.shiftKey) deg = Math.round(deg / 15) * 15;          // 15° snap unless Shift = free angle
     _moveDrag.drot = deg; rotGhostShow(deg * Math.PI / 180);
     setStat('rotate ' + (deg >= 0 ? '+' : '') + deg.toFixed(e.shiftKey ? 1 : 0) + '°' + (e.shiftKey ? '' : '  (15° snap)'));
+    return;
+  }
+  if (_moveDrag.axis && _moveDrag.axis.indexOf('scale') === 0) {   // W-BONSAI-SCALE: factor = (extent + drag)/extent, edge-anchored
+    const ax = _moveDrag.ax;
+    const p = moveDragPoint(ax, ndc, _moveDrag.c0); if (!p) return;
+    const d = p.clone().sub(_moveDrag.down);
+    const delta = ax === 'x' ? d.x : ax === 'y' ? d.y : d.z;
+    let f = (_moveDrag.ext + delta) / _moveDrag.ext;
+    if (!e.shiftKey) f = Math.round(f / 0.25) * 0.25;          // 0.25 snap unless Shift = free
+    f = Math.max(0.1, f);                                       // never collapse past 0.1× (degenerate solid)
+    _moveDrag.f = f; scaleGhostShow(ax, f);
+    setStat('scale ' + ax.toUpperCase() + ' ×' + f.toFixed(2) + (e.shiftKey ? '' : '  (0.25 snap)'));
     return;
   }
   const p = moveDragPoint(_moveDrag.axis, ndc, _moveDrag.c0); if (!p) return;
@@ -1243,6 +1298,11 @@ async function commitMoveDrag() {
     clearSnapMarker(); const deg = +(md.drot || 0).toFixed(2);
     if (Math.abs(deg) < 0.5) { clearMoveGhost(); buildMoveGizmo(); setStat('rotate: no change'); return; }
     await commitRotate(deg); return;
+  }
+  if (md.axis && md.axis.indexOf('scale') === 0) {              // W-BONSAI-SCALE commit
+    clearSnapMarker(); const f = +(md.f || 1).toFixed(4);
+    if (Math.abs(f - 1) < 0.01) { clearMoveGhost(); buildMoveGizmo(); setStat('scale: no change'); return; }
+    await commitScale(md.ax, f); return;
   }
   const c = md.c0; const sn = snappedMoveDelta(md.axis, c, md.dx, md.dy, md.dz);   // SAME resolver as the live preview
   let dx = sn.dx, dy = sn.dy, dz = sn.dz; clearSnapMarker();
@@ -1307,6 +1367,31 @@ async function commitRotate(drot) {
   } catch (err) {
     clearMoveGhost(); if (moving && ids.length) { window.Bonsai.selectMany(ids); buildMoveGizmo(); }
     setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER rotate fail ' + err);
+  }
+}
+// W-BONSAI-SCALE commit — non-uniform EDGE-ANCHORED scale of the selection along ONE axis. Emits one signed
+// GEOM_SCALE per target (fx/fy/fz, the dragged axis ≠1). Solids: the worker stretches the B-rep about the min-edge
+// (gp_GTrsf); inserts: bonsai_library folds the local geometry edge-anchored (PATH B). Single-selection only for now
+// (group non-uniform scale = a future leg). Reversible (undo) + composes (net factor multiplies) like move/rotate.
+async function commitScale(ax, f) {
+  const ids = selectedIds.size ? Array.from(selectedIds) : (selectedId != null ? [selectedId] : []);
+  if (!ids.length) return;
+  setStat('scaling…');
+  try {
+    const P = { fx: 1, fy: 1, fz: 1 }; P['f' + ax] = f;
+    let v = true;
+    for (const tid of ids) {
+      const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_SCALE', parameters: { parent: tid, fx: P.fx, fy: P.fy, fz: P.fz } }, {});
+      v = res.verify;
+      console.log('§SCALE commit ' + ax + '=' + f.toFixed(3) + ' parent=' + tid + ' verify=' + v);
+    }
+    setStat('scaled #' + ids[0] + ' ' + ax.toUpperCase() + ' ×' + f.toFixed(2) + '  verify=' + v);
+    audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    window.Bonsai.selectMany(ids); clearMoveGhost();
+    if (moving) buildMoveGizmo();
+  } catch (err) {
+    clearMoveGhost(); if (moving && ids.length) { window.Bonsai.selectMany(ids); buildMoveGizmo(); }
+    setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER scale fail ' + err);
   }
 }
 // Arrow-key NUDGE (deterministic, pointer-free): each press commits ONE GEOM_MOVE of moveStep() in that direction.

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v8';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v9';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_scale_live.js
+++ b/modeller/tests/bonsai_scale_live.js
@@ -1,0 +1,103 @@
+// W-BONSAI-SCALE — DAGeVu modeller: a placed catalog INSERT can be NON-UNIFORMLY scaled via the gizmo's cube handles.
+// A net GEOM_SCALE folds host-side on the insert's LOCAL geometry, EDGE-ANCHORED at the local bbox min per axis (the
+// opposite face stays put, the grabbed side stretches — the user-chosen anchor). Pure JS (bonsai_library.foldInsert +
+// the bonsai_kernel net-factor accumulator) — NO occt → deterministic + composes exactly. Driven PURELY through the
+// signed op-log (no canvas pointer). Proves: (A) a component scaled ×2 in X has its X-extent DOUBLE with the −X (min)
+// edge FIXED, Y/Z unchanged; exactly one signed GEOM_SCALE; chain verifies; scrub replays deterministically. (B) a 2nd
+// ×1.5 COMPOSES to net ×3 with Y/Z STILL unchanged (no cross-axis leak); undo restores the ×2 state. (C) a Y scale
+// touches ONLY Y (axis independence). Solid B-rep scale is DEFERRED (#3b, occt-wasm Copy=false). RESUME_MODELLER_POLISH.md #3.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  pg.on('console', m => { const t = m.text(); if (/SCALE/.test(t)) console.log('  ' + t); });
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.library && window.Bonsai.library.ready && window.Bonsai.oplog", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+
+  const r = await pg.evaluate(async () => {
+    const O = window.Bonsai.oplog, L = window.Bonsai.library, out = {};
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    const meshOf = fid => { const g = window.Bonsai.group(); return g && g.children.find(o => o.isMesh && o.userData.featureId === fid); };
+    const dims = fid => { const m = meshOf(fid); if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+      return { ex: +(b.max.x - b.min.x).toFixed(3), ey: +(b.max.y - b.min.y).toFixed(3), ez: +(b.max.z - b.min.z).toFixed(3),
+        xmin: +b.min.x.toFixed(3), ymin: +b.min.y.toFixed(3) }; };
+    const near = (a, b, t) => Math.abs(a - b) <= (t || 0.03);
+    const settle = async (fid, pred) => { for (let i = 0; i < 100; i++) { const d = dims(fid); if (d && pred(d)) return d; await sleep(50); } return dims(fid); };
+    try {
+      window.Bonsai.grid.show(false); O.clear(); await sleep(50);
+      const cat = L.catalog() || []; out.catN = cat.length; const hash = cat[0] && cat[0].hash;
+      // ── PART A: a catalog component scaled ×2 in X about its −X (min) edge
+      const I = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash, placement: { x: 0, y: 0, z: 0, rot: 0 }, lod: '200' } });
+      await O.scrubTo(O.length); await settle(I.id, () => true);
+      out.before = dims(I.id);
+      await O.commit({ op_type: 'GEOM_SCALE', parameters: { parent: I.id, fx: 2, fy: 1, fz: 1 } });
+      await O.scrubTo(O.length);
+      out.afterX2 = await settle(I.id, d => near(d.ex, out.before.ex * 2));
+      out.xDoubled  = near(out.afterX2.ex, out.before.ex * 2);
+      out.yzFixed   = near(out.afterX2.ey, out.before.ey) && near(out.afterX2.ez, out.before.ez);
+      out.minEdgeFixed = near(out.afterX2.xmin, out.before.xmin);              // EDGE-ANCHOR: −X face stays put
+      out.scaleOps  = O._geomOps().filter(o => o.op_type === 'GEOM_SCALE').length;
+      out.signed    = O.db.exec("SELECT COUNT(*) FROM kernel_ops WHERE sig IS NOT NULL")[0].values[0][0];
+      out.verifyA   = (await O.verify()).ok;
+      // determinism: scrub back (restores) then forward (doubled returns)
+      const n = O.length;
+      await O.scrubTo(n - 1); out.replayBefore = dims(I.id);
+      await O.scrubTo(n);     out.replayAfter  = dims(I.id);
+      out.deterministic = near(out.replayBefore.ex, out.before.ex) && near(out.replayAfter.ex, out.afterX2.ex);
+      // ── PART B: compose ×1.5 → net ×3, Y/Z MUST stay unchanged (no cross-axis leak)
+      await O.commit({ op_type: 'GEOM_SCALE', parameters: { parent: I.id, fx: 1.5, fy: 1, fz: 1 } });
+      await O.scrubTo(O.length);
+      out.afterX3 = await settle(I.id, d => near(d.ex, out.before.ex * 3, 0.05));
+      out.composes = near(out.afterX3.ex, out.before.ex * 3, 0.05) && near(out.afterX3.xmin, out.before.xmin) &&
+        near(out.afterX3.ey, out.before.ey) && near(out.afterX3.ez, out.before.ez);   // y/z UNCHANGED = leak-free
+      // undo restores the ×2 state
+      const u = await O.undo(); await O.scrubTo(O.length);
+      out.afterUndo = await settle(I.id, d => near(d.ex, out.afterX2.ex));
+      out.undoRestores = u.undone != null && near(out.afterUndo.ex, out.afterX2.ex) && (await O.verify()).ok;
+      // ── PART C: a fresh insert scaled ×2 in Y touches ONLY Y (axis independence)
+      O.clear(); await sleep(50);
+      const J = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash, placement: { x: 0, y: 0, z: 0, rot: 0 }, lod: '200' } });
+      await O.scrubTo(O.length); const jb = await settle(J.id, () => true);
+      await O.commit({ op_type: 'GEOM_SCALE', parameters: { parent: J.id, fx: 1, fy: 2, fz: 1 } });
+      await O.scrubTo(O.length);
+      const ja = await settle(J.id, d => near(d.ey, jb.ey * 2));
+      out.yOnly = near(ja.ey, jb.ey * 2) && near(ja.ex, jb.ex) && near(ja.ez, jb.ez) && near(ja.ymin, jb.ymin);
+      out.verifyC = (await O.verify()).ok;
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER scale fail ' + e); }
+    return out;
+  });
+
+  await br.close(); server.close();
+  console.log('  §SCALE ' + JSON.stringify(r));
+  const checks = {
+    xDoubled:        r.xDoubled === true,
+    yzUnchanged:     r.yzFixed === true,
+    minEdgeAnchored: r.minEdgeFixed === true,        // the user-chosen edge-anchor: −X face fixed
+    oneSignedScale:  r.scaleOps === 1 && r.signed >= 2,
+    chainVerifies:   r.verifyA === true,
+    deterministic:   r.deterministic === true,
+    composesX3:      r.composes === true,            // net ×3, NO cross-axis leak (y/z unchanged)
+    undoRestores:    r.undoRestores === true,
+    yAxisIndependent: r.yOnly === true,              // a Y scale touches only Y
+    verifiesC:       r.verifyC === true
+  };
+  const pass = Object.values(checks).every(Boolean);
+  console.log('  §SCALE VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' '));
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What

The direct-manipulation gizmo had **move + rotate** handles but no **scale**. This adds cube **scale-handles** (X/Y/Z) on a single selected **insert** (catalog component) — drag a cube out to non-uniformly stretch, **edge-anchored** at the opposite (min) face (the user-chosen anchor: the −axis face stays put, the grabbed side grows). One signed `GEOM_SCALE` per drag; composes, undoable, rename-proof.

- **`modeller.html`** — `scaleHandle()` cubes + scale pointer-drag (`factor=(extent+drag)/extent`, 0.25 snap / Shift = free, floor 0.1×) + edge-anchored ghost preview + `commitScale`.
- **`bonsai_library.foldInsert`** — net `GEOM_SCALE` folds host-side on the insert's local geometry, edge-anchored at the local bbox min per axis (**pure JS** → composes exactly, deterministic, no occt).
- **`bonsai_kernel`** — net-transform accumulator now carries multiplicative `fx/fy/fz` (PATH B).
- **`sw.js`** v8 → **v9**; `bonsai_kernel.js?v=4`, `bonsai_kernel_worker.js?v=5`, `bonsai_library.js?v=15`.

## Deferred — solid B-rep scale (#3b)

`occt-wasm generalTransform` uses `BRepBuilderAPI_GTransform` with **`Copy=false`**, so the derived shape aliases the shared base `TShape` and an intervening scrub/release corrupts it → a 2nd scale (or scale-X-then-Y, both real gizmo flows) **leaks** the prior factor onto the untouched axes (witnessed: x×2 then x×1.5 → z×2). Single scale is correct, but compose is not — so `GEOM_SCALE` on a worker solid is a **tolerant no-op** and the gizmo only shows scale handles on **inserts** (pure-JS reliable). Showing a handle that scales wrong would be dishonest. The fix is a kernel-level `Copy=true` GTransform / bake primitive — a separate effort.

## Witness — `modeller/tests/bonsai_scale_live.js` **W-BONSAI-SCALE 10/10** (op-log driven)

x×2 doubles X with the −X edge fixed, Y/Z unchanged · exactly one signed `GEOM_SCALE` · chain verifies · deterministic scrub · ×1.5 **composes** to net ×3 with **no cross-axis leak** · undo restores ×2 · a Y scale touches only Y.

Regression: `bonsai_rotate_solid_live` 9/9 green. The pointer-driven `move`/`insert` witnesses fail identically on clean `origin/main` (pre-existing headless OrbitControls/pointer flake, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)