### PR TITLE
Modeller W-BONSAI-CURSOR (#5): canvas cursor per mode/tool — sw v10

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -568,7 +568,7 @@ const CON_LABEL = { axis: 'Axis', rect: 'Rect', square: 'Square' };
 function paintConstrain() { const m = window.Bonsai.sketch.mode; bConstrain.querySelector('span').textContent = CON_LABEL[m] || m; bConstrain.classList.toggle('on', m !== 'axis'); }
 bConstrain.onclick = () => { const m = window.Bonsai.sketch.cycleMode(); paintConstrain(); audioCue('tick'); setStat('sketch constraint: ' + (CON_LABEL[m] || m)); };
 function enterSketch() {
-  sketching = true; window.Bonsai.sketch.reset();
+  sketching = true; window.Bonsai.sketch.reset(); applyModeCursor();
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone(), up: camera.up.clone() };
   camera.up.set(0, 1, 0);   // top-down plan needs Y-up (looking down −Z with Z-up is degenerate)
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
@@ -577,7 +577,7 @@ function enterSketch() {
   sketchMarkers(); setStat('sketch: click ≥3 points on the grid, then Extrude');
 }
 function exitSketch() {
-  sketching = false; bExtrude.style.display = 'none'; dimDepth.style.display = 'none'; bConstrain.style.display = 'none'; bSketch.innerHTML = SK_SKETCH;
+  sketching = false; bExtrude.style.display = 'none'; dimDepth.style.display = 'none'; bConstrain.style.display = 'none'; bSketch.innerHTML = SK_SKETCH; applyModeCursor();
   if (sketchGroup) { while (sketchGroup.children.length) sketchGroup.remove(sketchGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); if (savedCam.up) camera.up.copy(savedCam.up); controls.update(); }
 }
@@ -717,6 +717,19 @@ canvas.addEventListener('pointerdown', (e) => {           // bare (no-shift) pic
 // Raycast under the cursor BEFORE any click and give the feature a faint glow (dimmer than selection) + a
 // pointer cursor — the affordance every competitor has and DAGeVu's silent pick lacked. Skips selected meshes
 // (keeps their selection emissive), and is suppressed while a button is held (orbit) or any non-select mode/drag.
+// W-BONSAI-CURSOR (#5): the canvas cursor reflects the ACTIVE mode/tool so the pointer signals what a click does —
+// crosshair = place a point/edge, copy = drop a component, grab = drag a gridline, move = drag the transform gizmo.
+// Composes with the M3 hover-pointer: a mode that owns the cursor WINS; in plain browsing (no mode), hovering an
+// object still shows 'pointer'. One mode is active at a time, but the order is defensive. Pure CSS cursor, no deps.
+function modeCursor() {
+  if (inserting) return 'copy';                 // dropping a new component onto the grid
+  if (sketching || routing) return 'crosshair'; // drawing sketch points / a route
+  if (edgePicking) return 'crosshair';          // picking edges to fillet
+  if (gridMoving) return 'grab';                // grabbing a gridline to drag
+  if (moving) return 'move';                    // dragging the transform gizmo
+  return null;                                  // default browsing → hover decides
+}
+function applyModeCursor() { canvas.style.cursor = modeCursor() || ''; }
 let _hoverMesh = null, _hoverId = null;
 function setHover(mesh) {
   const hid = mesh ? mesh.userData.featureId : null;
@@ -724,7 +737,7 @@ function setHover(mesh) {
   if (_hoverMesh && !selectedIds.has(_hoverMesh.userData.featureId)) _emis(_hoverMesh, 0x000000);   // restore prev (unless it's selected)
   _hoverMesh = mesh; _hoverId = hid;
   if (mesh && !selectedIds.has(hid)) _emis(mesh, 0x14324a);   // faint hover tint (< selection 0x2b5a8c)
-  canvas.style.cursor = mesh ? 'pointer' : '';
+  canvas.style.cursor = modeCursor() || (mesh ? 'pointer' : '');   // a mode owns the cursor; else hover shows pointer
   if (window.A && A.requestRender) A.requestRender();
 }
 canvas.addEventListener('pointermove', (e) => {
@@ -777,7 +790,7 @@ function routeMarkers() {
   }
 }
 function enterRoute() {
-  routing = true; routePts = [];
+  routing = true; routePts = []; applyModeCursor();
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone(), up: camera.up.clone() };
   camera.up.set(0, 1, 0);   // top-down route plan: Y-up (Z-up degenerate looking down −Z)
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
@@ -785,7 +798,7 @@ function enterRoute() {
   routeMarkers(); setStat('route: click ≥2 points on the grid to lay a run, then Sweep Run');
 }
 function exitRoute() {
-  routing = false; bRun.style.display = 'none'; dimProf.style.display = 'none'; bRoute.innerHTML = RT_ROUTE;
+  routing = false; bRun.style.display = 'none'; dimProf.style.display = 'none'; bRoute.innerHTML = RT_ROUTE; applyModeCursor();
   if (routeGroup) { while (routeGroup.children.length) routeGroup.remove(routeGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); if (savedCam.up) camera.up.copy(savedCam.up); controls.update(); }
 }
@@ -840,14 +853,14 @@ async function enterFillet() {
   try {
     const r = await window.Bonsai.queryEdges(selectedId);
     window._edgeList = r.edges || [];
-    edgePicking = true; pickedEdges = new Set();
+    edgePicking = true; pickedEdges = new Set(); applyModeCursor();
     bApplyFillet.style.display = ''; bApplyFillet.disabled = true; dimRad.style.display = ''; bFillet.innerHTML = FIL_CANCEL;
     edgeMarkers(window._edgeList);
     setStat('fillet: click edges (' + window._edgeList.length + ' available), then Apply');
   } catch (e) { setStat('FAIL ' + (e && e.message || e)); console.warn('§MODELLER fillet edges fail ' + e); }
 }
 function exitFillet() {
-  edgePicking = false; bApplyFillet.style.display = 'none'; dimRad.style.display = 'none'; bFillet.innerHTML = FIL_FILLET;
+  edgePicking = false; bApplyFillet.style.display = 'none'; dimRad.style.display = 'none'; bFillet.innerHTML = FIL_FILLET; applyModeCursor();
   if (edgeGroup) { while (edgeGroup.children.length) edgeGroup.remove(edgeGroup.children[0]); }
 }
 bFillet.onclick = () => edgePicking ? exitFillet() : enterFillet();
@@ -981,11 +994,11 @@ function gmTint(commands) {
 }
 function enterGridMove() {
   if (!window.Bonsai.grid.active) { window.Bonsai.grid.show(true); bGrid.classList.add('on'); }
-  gridMoving = true; _dragGrid = null; bGridMove.innerHTML = GM_CANCEL; controls.enabled = false;   // grab gridlines, not the camera
+  gridMoving = true; _dragGrid = null; bGridMove.innerHTML = GM_CANCEL; controls.enabled = false; applyModeCursor();   // grab gridlines, not the camera
   setStat('move grid: hover a gridline, drag it — affected walls preview (blue=move, orange=stretch)');
 }
 function exitGridMove() {
-  gridMoving = false; _dragGrid = null; bGridMove.innerHTML = GM_MOVE; controls.enabled = true;
+  gridMoving = false; _dragGrid = null; bGridMove.innerHTML = GM_MOVE; controls.enabled = true; applyModeCursor();
   if (gmPreview) { scene.remove(gmPreview); gmPreview = null; } gmClearTints();
 }
 bGridMove.onclick = () => gridMoving ? exitGridMove() : enterGridMove();
@@ -1206,13 +1219,13 @@ function clearSnapMarker() { if (snapMarker) { scene.remove(snapMarker); snapMar
 function enterMove() {
   if (selectedId == null) { setStat('select an object first, then Move'); return; }
   if (!window.Bonsai.grid.active) { window.Bonsai.grid.show(true); bGrid.classList.add('on'); }
-  moving = true; _moveDrag = null; bMove.innerHTML = MV_CANCEL; bMove.classList.add('on'); controls.enabled = false;
+  moving = true; _moveDrag = null; bMove.innerHTML = MV_CANCEL; bMove.classList.add('on'); controls.enabled = false; applyModeCursor();
   if (dimMove) dimMove.style.display = '';
   buildMoveGizmo();
   setStat('move: drag an axis handle (X/Y/Z) or the hub (XY plane); snaps to grid + nearby geometry (G toggles), arrow-nudge ' + moveStep().toFixed(2) + 'm — Esc to exit');
 }
 function exitMove() {
-  moving = false; _moveDrag = null; bMove.innerHTML = MV_MOVE; bMove.classList.remove('on'); controls.enabled = true;
+  moving = false; _moveDrag = null; bMove.innerHTML = MV_MOVE; bMove.classList.remove('on'); controls.enabled = true; applyModeCursor();
   if (dimMove) dimMove.style.display = 'none';
   clearMoveGizmo(); clearMoveGhost(); clearSnapMarker();
 }
@@ -1772,8 +1785,8 @@ function buildInsertPanel() {
   window.Bonsai.library.ready().then(renderCatalog);   // populate once the BOM catalog JSON has loaded
   return p;
 }
-function enterInsert() { inserting = true; buildInsertPanel().style.display = 'block'; renderCatalog(); bInsert.classList.add('on'); bLod.style.display = ''; bLod.disabled = (lastInsertId == null); paintLod(); setStat('insert: pick from the BOM catalog, aim on the grid (R rotates), click to place'); }
-function exitInsert() { inserting = false; clearGhost(); if (insertPanel) insertPanel.style.display = 'none'; bInsert.classList.remove('on'); setStat('ready'); }
+function enterInsert() { inserting = true; buildInsertPanel().style.display = 'block'; renderCatalog(); applyModeCursor(); bInsert.classList.add('on'); bLod.style.display = ''; bLod.disabled = (lastInsertId == null); paintLod(); setStat('insert: pick from the BOM catalog, aim on the grid (R rotates), click to place'); }
+function exitInsert() { inserting = false; clearGhost(); applyModeCursor(); if (insertPanel) insertPanel.style.display = 'none'; bInsert.classList.remove('on'); setStat('ready'); }
 bInsert.onclick = () => inserting ? exitInsert() : enterInsert();
 bLod.onclick = async () => {
   const id = lodTargetId(); if (id == null) return;

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v9';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v10';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_cursor_live.js
+++ b/modeller/tests/bonsai_cursor_live.js
@@ -1,0 +1,75 @@
+// W-BONSAI-CURSOR — DAGeVu modeller: the canvas cursor reflects the ACTIVE mode/tool (RESUME_MODELLER_POLISH.md #5).
+// Crosshair = place a sketch/route point, copy = drop a component, grab = drag a gridline, move = drag the gizmo.
+// Driven by real toolbar-button clicks (reliable — no gizmo pointer-capture flake). Proves each mode sets its cursor,
+// exiting restores the default, and a mode cursor WINS over the M3 hover-pointer (setHover defers to modeCursor()).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.library && window.Bonsai.library.ready && window.Bonsai.oplog", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+
+  const cur = () => pg.$eval('#viewport, canvas', () => document.querySelector('canvas').style.cursor).catch(() => null);
+  const click = id => pg.evaluate(i => document.getElementById(i).click(), id);
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+  let PASS = 0, FAIL = 0;
+  const ok = (c, m) => { (c ? PASS++ : FAIL++); console.log('  ' + (c ? '✅' : '❌') + ' ' + m); };
+
+  // each: [button id, mode label, expected cursor]. Toggle ON → assert; toggle OFF → assert default ''.
+  const MODES = [
+    ['b-sketch', 'sketch', 'crosshair'],
+    ['b-route', 'route', 'crosshair'],
+    ['b-gridmove', 'gridMove', 'grab'],
+    ['b-insert', 'insert', 'copy'],
+  ];
+  try {
+    const base = await cur();
+    ok(base === '' || base === 'default' || base == null, 'default (no mode) cursor is neutral (got "' + base + '")');
+    for (const [id, label, want] of MODES) {
+      await click(id); await sleep(150);
+      const on = await cur();
+      ok(on === want, label + ' ON → cursor="' + on + '" (want "' + want + '")');
+      await click(id); await sleep(150);
+      const off = await cur();
+      ok(off === '' || off === 'default', label + ' OFF → cursor restored to default (got "' + off + '")');
+    }
+    // MOVE needs a selection: op-log insert a component, select it, then toggle Move → 'move'
+    const moved = await pg.evaluate(async () => {
+      const O = window.Bonsai.oplog, L = window.Bonsai.library;
+      const cat = L.catalog() || []; const hash = cat[0] && cat[0].hash;
+      const I = await O.commit({ op_type: 'GEOM_INSERT', parameters: { hash, placement: { x: 0, y: 0, z: 0, rot: 0 }, lod: '200' } });
+      await O.scrubTo(O.length); await new Promise(r => setTimeout(r, 200));
+      window.Bonsai.selectMany([I.id]); return I.id;
+    });
+    await click('b-move'); await sleep(150);
+    const mv = await cur();
+    ok(mv === 'move', 'move ON (with selection #' + moved + ') → cursor="' + mv + '" (want "move")');
+    await click('b-move'); await sleep(150);
+    const mvOff = await cur();
+    ok(mvOff === '' || mvOff === 'default', 'move OFF → cursor restored (got "' + mvOff + '")');
+    // composition: served source defers hover to the mode cursor (modeCursor() wins in setHover)
+    const src = await (await fetch(`http://localhost:${port}/modeller.html`)).text();
+    ok(/canvas\.style\.cursor = modeCursor\(\) \|\| \(mesh \? 'pointer' : ''\)/.test(src),
+      'setHover defers to modeCursor() (mode cursor wins over the hover-pointer)');
+  } catch (e) { console.log('  ERR ' + (e && e.stack || e)); FAIL++; }
+
+  await br.close(); server.close();
+  console.log('  §CURSOR VERDICT ' + (FAIL ? 'FAIL' : 'PASS') + ' — ' + PASS + ' PASS / ' + FAIL + ' FAIL');
+  process.exit(FAIL ? 1 : 0);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What

The canvas cursor never changed, so the pointer gave no hint of what a click would do. Now it reflects the **active mode/tool**:

| Mode | Cursor |
|------|--------|
| sketch / route | `crosshair` (place a point) |
| fillet edge-pick | `crosshair` (pick an edge) |
| grid-move | `grab` (drag a gridline) |
| move (gizmo) | `move` |
| insert | `copy` (drop a component) |
| plain browsing | hover an object → `pointer`, else default |

- `modeCursor()` (priority over the mode flags) + `applyModeCursor()`, called on every mode enter/exit. `setHover` defers to `modeCursor()` so a mode cursor **wins** over the M3 hover-pointer; in plain browsing, hovering an object still shows `pointer`. Pure CSS cursor, no deps. `sw.js` v9 → **v10**.

## Witness — `modeller/tests/bonsai_cursor_live.js` **W-BONSAI-CURSOR 12/12**

Real toolbar-button clicks (reliable — no gizmo pointer-capture flake): each mode sets its cursor, exit restores the neutral default, `move` needs a selection → `move`, and the served source defers hover to `modeCursor()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)