### PR TITLE
fix(pwa): home icon works offline — fall back to cached index.html

### DIFF
--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1193,8 +1193,8 @@ function setupPanels(A) {
         fn: function() { if (typeof window.toggleCamPivot === 'function') window.toggleCamPivot(); },
         isActive: function() { return !!window._autoPivot; } },
       { id: 'home',       name: 'Home',            icon: I.home.svg, fn: function() {
-          // §S283: In standalone PWA, open online hub in system browser (backdoor)
-          if (window.matchMedia('(display-mode: standalone)').matches || navigator.standalone) {
+          // §S283: Standalone PWA — open live hub only when online; fall back to cached index offline
+          if ((window.matchMedia('(display-mode: standalone)').matches || navigator.standalone) && navigator.onLine) {
             window.open('https://red1oon.github.io/bim-ootb/', '_blank');
             console.log('§PWA_HOME opened');
           } else {


### PR DESCRIPTION
## Summary
- Home icon in standalone PWA mode was always opening the live GitHub Pages URL (`https://red1oon.github.io/bim-ootb/`), which fails with no connection
- Now guards with `navigator.onLine`: online → opens live hub in new tab (existing behaviour); offline → navigates to SW-cached `../index.html`
- No other icons affected — `A.HOME_URL` (§WH-HOME) is a host-supplied URL for the iDempiere warehouse flow, not our concern here

## Test plan
- [ ] Online + installed PWA: home icon still opens live hub in new tab
- [ ] Offline + installed PWA: home icon navigates to the cached landing (opening page) without a network request
- [ ] Non-standalone (normal browser): unchanged — goes to `../index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)