### PR TITLE
Modeller W-BONSAI-TOAST (#8): persistent error toast — sw v11

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -20,6 +20,17 @@
   #bar button .ic { width: 15px; height: 15px; flex: 0 0 auto; }
   #stat { position: fixed; bottom: 10px; left: 252px; color: #6b7488; font-size: 11px; z-index: 10;
     font-family: ui-monospace, monospace; white-space: pre; }
+  /* W-BONSAI-TOAST (#8): persistent error/info notice that the next status update can't overwrite. */
+  #toast-stack { position: fixed; bottom: 44px; left: 50%; transform: translateX(-50%); z-index: 60;
+    display: flex; flex-direction: column-reverse; gap: 8px; align-items: center; pointer-events: none; }
+  .toast { pointer-events: auto; max-width: 460px; padding: 10px 14px; border-radius: 10px; font-size: 13px;
+    background: rgba(20,22,30,0.96); border: 1px solid #2c303a; color: #c7cdd8; cursor: pointer;
+    box-shadow: 0 6px 24px rgba(0,0,0,0.45); opacity: 0; transform: translateY(8px);
+    transition: opacity .18s ease, transform .18s ease; display: flex; gap: 9px; align-items: flex-start; line-height: 1.35; }
+  .toast.show { opacity: 1; transform: translateY(0); }
+  .toast.error { border-color: #7a2e2e; background: rgba(40,20,22,0.96); color: #f3c9c9; }
+  .toast.ok { border-color: #2e6a3a; color: #c7e8cf; }
+  .toast .ti { font-weight: 700; flex: 0 0 auto; }
   #title { position: fixed; top: 12px; right: 14px; color: #4a5163; font-size: 11px; z-index: 10; letter-spacing: .08em; }
 
   /* ── Toolbar as a bottom-right WRAPPING pill rail (a new style): icon-only glass pills stack UP from the ⋯
@@ -229,7 +240,36 @@ THREE.OrbitControls = OrbitControls;
 THREE.ColorManagement.enabled = false;
 
 const stat = document.getElementById('stat');
-const setStat = (m) => { stat.textContent = m; };
+// W-BONSAI-TOAST (#8): error feedback used to live ONLY in the 11px status bar, which the very next action
+// overwrites — a failed op could vanish before it was read. toast() raises a persistent notice (errors linger
+// ~7s, click to dismiss, stack capped) that the status bar can't clobber. setStat auto-toasts any 'FAIL …' so all
+// 11 catch-block error paths surface without touching each one; the status bar still shows the terse line.
+let _toastStack = null;
+function toast(msg, kind) {
+  if (!_toastStack) { _toastStack = document.createElement('div'); _toastStack.id = 'toast-stack'; document.body.appendChild(_toastStack); }
+  const t = document.createElement('div'); t.className = 'toast' + (kind ? ' ' + kind : '');
+  const icon = kind === 'error' ? '⚠' : kind === 'ok' ? '✓' : 'ℹ';
+  const safe = String(msg).replace(/[<>&]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  t.innerHTML = '<span class="ti">' + icon + '</span><span>' + safe + '</span>';
+  _toastStack.appendChild(t);
+  requestAnimationFrame(() => t.classList.add('show'));
+  let done = false;
+  const dismiss = () => { if (done) return; done = true; t.classList.remove('show'); setTimeout(() => t.remove(), 220); };
+  t.addEventListener('click', dismiss);
+  setTimeout(dismiss, kind === 'error' ? 7000 : 4000);   // errors linger longer than info
+  while (_toastStack.children.length > 4) _toastStack.removeChild(_toastStack.firstChild);   // cap the stack
+  console.log('§TOAST kind=' + (kind || 'info') + ' ' + msg);
+  return t;
+}
+window.toast = toast;   // expose the UI util (other surfaces + witnesses can raise a notice)
+const setStat = (m) => { stat.textContent = m; if (/^FAIL\b/.test(String(m))) toast(String(m).replace(/^FAIL[:\s]*/, ''), 'error'); };
+// uncaught async op failures currently vanish silently → surface them too (deduped against a repeat burst)
+let _lastRej = '';
+window.addEventListener('unhandledrejection', (e) => {
+  const r = e && e.reason; const msg = (r && r.message) || String(r || 'unknown error');
+  if (msg === _lastRej) return; _lastRej = msg; setTimeout(() => { _lastRej = ''; }, 1500);
+  toast(msg, 'error');
+});
 
 const canvas = document.getElementById('c');
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v10';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v11';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_toast_live.js
+++ b/modeller/tests/bonsai_toast_live.js
@@ -1,0 +1,78 @@
+// W-BONSAI-TOAST — DAGeVu modeller: error feedback survives the next action (RESUME_MODELLER_POLISH.md #8).
+// Errors used to live only in the 11px status bar, overwritten by the next status update → a failed op could vanish
+// before it was read. toast() raises a persistent notice. Proves: (T1) a toast renders a .toast.error with its
+// message + ⚠; (T2) it PERSISTS after the status bar is overwritten (the whole point); (T3) click dismisses it;
+// (T4) the stack is capped (≤4); (T5) setStat routes any 'FAIL …' to a toast (served-source wiring — the path all 11
+// catch blocks ride); (T6) the unhandledrejection hook calls toast (manually dispatched — natural firing is flaky in
+// headless puppeteer, so we test the listener wiring deterministically).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.toast && window.Bonsai", { timeout: 30000 }).catch(() => {});
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  let PASS = 0, FAIL = 0;
+  const ok = (c, m) => { (c ? PASS++ : FAIL++); console.log('  ' + (c ? '✅' : '❌') + ' ' + m); };
+  try {
+    // T1 — a toast renders as .toast.error with the message + ⚠ icon
+    await pg.evaluate(() => window.toast('boom-1 the op failed', 'error'));
+    await sleep(150);
+    const t1 = await pg.evaluate(() => {
+      const el = document.querySelector('#toast-stack .toast.error');
+      return el ? { txt: el.textContent, icon: el.querySelector('.ti') && el.querySelector('.ti').textContent, shown: el.classList.contains('show') } : null;
+    });
+    ok(!!t1 && /boom-1/.test(t1.txt) && t1.icon === '⚠' && t1.shown, 'T1 toast renders .toast.error ⚠ "' + (t1 && t1.txt) + '"');
+
+    // T2 — overwrite the status bar; the toast must REMAIN (the fix: status can't clobber it)
+    await pg.evaluate(() => { document.getElementById('stat').textContent = 'some later status line'; });
+    await sleep(100);
+    const persist = await pg.evaluate(() => ({
+      toast: !!document.querySelector('#toast-stack .toast.error'), stat: document.getElementById('stat').textContent }));
+    ok(persist.toast === true && /later status/.test(persist.stat), 'T2 toast PERSISTS after the status bar is overwritten');
+
+    // T3 — click dismisses
+    await pg.evaluate(() => { const e = document.querySelector('#toast-stack .toast'); if (e) e.click(); });
+    await sleep(350);
+    ok(await pg.evaluate(() => !document.querySelector('#toast-stack .toast')), 'T3 click dismisses the toast');
+
+    // T4 — stack capped at ≤4 even when many fire
+    await pg.evaluate(() => { for (let i = 0; i < 6; i++) window.toast('burst-' + i, 'error'); });
+    await sleep(150);
+    const n = await pg.evaluate(() => document.querySelectorAll('#toast-stack .toast').length);
+    ok(n > 0 && n <= 4, 'T4 stack capped (' + n + ' ≤ 4) under a 6-toast burst');
+
+    // T5 — setStat routes FAIL → toast (served-source wiring, the path all 11 catch blocks ride)
+    const src = await (await fetch(`http://localhost:${port}/modeller.html`)).text();
+    ok(/if \(\/\^FAIL\\b\/\.test\(String\(m\)\)\) toast\(String\(m\)\.replace/.test(src),
+      'T5 setStat auto-toasts any FAIL message (all 11 catch-block errors surface)');
+
+    // T6 — the unhandledrejection hook is wired to toast (dispatched manually; natural firing is flaky headless)
+    const t6 = await pg.evaluate(async () => {
+      const before = document.querySelectorAll('#toast-stack .toast').length;
+      try { window.dispatchEvent(new PromiseRejectionEvent('unhandledrejection', { promise: Promise.resolve(), reason: new Error('rejection-surfaced') })); }
+      catch (e) { return { err: e.message }; }
+      await new Promise(r => setTimeout(r, 150));
+      const el = [...document.querySelectorAll('#toast-stack .toast')].find(t => /rejection-surfaced/.test(t.textContent));
+      return { found: !!el, before };
+    });
+    ok(t6 && t6.found === true, 'T6 unhandledrejection → toast("…")  (listener wired)');
+  } catch (e) { console.log('  ERR ' + (e && e.stack || e)); FAIL++; }
+
+  await br.close(); server.close();
+  console.log('  §TOAST VERDICT ' + (FAIL ? 'FAIL' : 'PASS') + ' — ' + PASS + ' PASS / ' + FAIL + ' FAIL');
+  process.exit(FAIL ? 1 : 0);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What

Error feedback lived **only** in the 11px status bar, overwritten by the very next status update — a failed op could vanish before it was read. Now a `toast(msg, kind)` raises a **persistent** notice the status bar can't clobber.

- Errors linger ~7s, click to dismiss, stack capped at 4, bottom-centre, themed (red for errors).
- **`setStat` auto-toasts any `FAIL …`** → all 11 catch-block error paths surface without editing each one (the status bar still shows the terse line).
- An `unhandledrejection` hook surfaces uncaught async op failures too (deduped).
- `window.toast` exposed as a reusable UI util. `sw.js` v10 → **v11**.

## Witness — `modeller/tests/bonsai_toast_live.js` **W-BONSAI-TOAST 6/6**

toast renders `.toast.error ⚠` · **PERSISTS** after the status bar is overwritten (the fix) · click dismisses · stack capped ≤4 under a burst · `setStat` routes `FAIL`→toast (served source) · `unhandledrejection`→toast (listener wired; dispatched manually since natural rejection firing is flaky in headless puppeteer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)