### PR TITLE
Modeller W-BONSAI-POINTS-RECOVERY (#4): sketch/route points survive Escape — sw v12

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -607,16 +607,29 @@ const bConstrain = document.getElementById('b-constrain');
 const CON_LABEL = { axis: 'Axis', rect: 'Rect', square: 'Square' };
 function paintConstrain() { const m = window.Bonsai.sketch.mode; bConstrain.querySelector('span').textContent = CON_LABEL[m] || m; bConstrain.classList.toggle('on', m !== 'axis'); }
 bConstrain.onclick = () => { const m = window.Bonsai.sketch.cycleMode(); paintConstrain(); audioCue('tick'); setStat('sketch constraint: ' + (CON_LABEL[m] || m)); };
+// #4 POINT RECOVERY (RESUME_MODELLER_POLISH.md): in-progress sketch/route points are transient (not op-log) — a
+// stray Escape used to lose them all. Now a cancel-exit BUFFERS them for the session; re-opening the tool RESTORES
+// them. A commit clears the draft; cancelling with no points discards it (the Backspace-to-empty = "start fresh").
+let _sketchDraft = null, _routeDraft = null;
 function enterSketch() {
   sketching = true; window.Bonsai.sketch.reset(); applyModeCursor();
+  if (_sketchDraft && _sketchDraft.length) {                     // restore a buffered in-progress sketch
+    _sketchDraft.forEach(pt => window.Bonsai.sketch.addPoint(pt.x, pt.y));
+    if (window.toast) toast('restored ' + _sketchDraft.length + ' in-progress sketch points (Backspace to trim)', 'ok');
+  }
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone(), up: camera.up.clone() };
   camera.up.set(0, 1, 0);   // top-down plan needs Y-up (looking down −Z with Z-up is degenerate)
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
   bExtrude.style.display = ''; bExtrude.disabled = false; dimDepth.style.display = ''; bSketch.innerHTML = SK_CANCEL;
   bConstrain.style.display = ''; bConstrain.disabled = false; paintConstrain();
-  sketchMarkers(); setStat('sketch: click ≥3 points on the grid, then Extrude');
+  const np = window.Bonsai.sketch.points.length;
+  sketchMarkers(); setStat(np ? ('sketch: ' + np + ' points restored — continue or Extrude') : 'sketch: click ≥3 points on the grid, then Extrude');
 }
-function exitSketch() {
+function exitSketch(committed) {
+  const p = window.Bonsai.sketch.points;                         // buffer in-progress points on a CANCEL (not a commit)
+  if (committed) _sketchDraft = null;
+  else if (p && p.length) { _sketchDraft = p.map(pt => ({ x: pt.x, y: pt.y })); if (window.toast) toast(p.length + ' sketch points saved — re-open Sketch to continue', 'info'); }
+  else _sketchDraft = null;                                      // cancelled with no points → discard any old draft
   sketching = false; bExtrude.style.display = 'none'; dimDepth.style.display = 'none'; bConstrain.style.display = 'none'; bSketch.innerHTML = SK_SKETCH; applyModeCursor();
   if (sketchGroup) { while (sketchGroup.children.length) sketchGroup.remove(sketchGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); if (savedCam.up) camera.up.copy(savedCam.up); controls.update(); }
@@ -642,7 +655,7 @@ bExtrude.onclick = async () => {
     // leg 3: a sketched wall is committed as a FEATURE in the op-log (not a one-shot author).
     const res = await window.Bonsai.sketch.commitExtrude(parseFloat(dimDepth.value) || 3, { color: 0x9fd6b4 });
     setStat('committed wall #' + res.id + '  solveStatus=' + res.solveStatus + '  tris=' + res.triangleCount);
-    audioCue('commit'); exitSketch(); syncHistory();
+    audioCue('commit'); exitSketch(true); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§SKETCH extrude fail ' + err); }
 };
 
@@ -831,13 +844,20 @@ function routeMarkers() {
 }
 function enterRoute() {
   routing = true; routePts = []; applyModeCursor();
+  if (_routeDraft && _routeDraft.length) {                       // restore a buffered in-progress route
+    routePts = _routeDraft.map(p => p.slice());
+    if (window.toast) toast('restored ' + routePts.length + ' in-progress route points (Backspace to trim)', 'ok');
+  }
   savedCam = { pos: camera.position.clone(), tgt: controls.target.clone(), up: camera.up.clone() };
   camera.up.set(0, 1, 0);   // top-down route plan: Y-up (Z-up degenerate looking down −Z)
   camera.position.set(2, 1.5, 12); controls.target.set(2, 1.5, 0); controls.update();
-  bRun.style.display = ''; bRun.disabled = true; dimProf.style.display = ''; bRoute.innerHTML = RT_CANCEL;
-  routeMarkers(); setStat('route: click ≥2 points on the grid to lay a run, then Sweep Run');
+  bRun.style.display = ''; bRun.disabled = routePts.length < 2; dimProf.style.display = ''; bRoute.innerHTML = RT_CANCEL;
+  routeMarkers(); setStat(routePts.length ? ('route: ' + routePts.length + ' points restored — continue or Sweep Run') : 'route: click ≥2 points on the grid to lay a run, then Sweep Run');
 }
-function exitRoute() {
+function exitRoute(committed) {
+  if (committed) _routeDraft = null;                             // buffer in-progress points on a CANCEL (not a commit)
+  else if (routePts && routePts.length) { _routeDraft = routePts.map(p => p.slice()); if (window.toast) toast(routePts.length + ' route points saved — re-open Route to continue', 'info'); }
+  else _routeDraft = null;                                       // cancelled with no points → discard any old draft
   routing = false; bRun.style.display = 'none'; dimProf.style.display = 'none'; bRoute.innerHTML = RT_ROUTE; applyModeCursor();
   if (routeGroup) { while (routeGroup.children.length) routeGroup.remove(routeGroup.children[0]); }
   if (savedCam) { camera.position.copy(savedCam.pos); controls.target.copy(savedCam.tgt); if (savedCam.up) camera.up.copy(savedCam.up); controls.update(); }
@@ -862,7 +882,7 @@ bRun.onclick = async () => {
   try {
     const pw = parseFloat(dimProf.value) || 0.3;
     const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_SWEEP', parameters: { profile: { w: pw, h: pw }, path: routePts.slice() } }, { color: 0xffb74f });
-    setStat('swept run #' + res.id + '  verify=' + res.verify + '  tris=' + res.triangleCount); audioCue('commit'); exitRoute(); syncHistory();
+    setStat('swept run #' + res.id + '  verify=' + res.verify + '  tris=' + res.triangleCount); audioCue('commit'); exitRoute(true); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER route fail ' + err); }
 };
 

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v11';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v12';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_points_recovery_live.js
+++ b/modeller/tests/bonsai_points_recovery_live.js
@@ -1,0 +1,76 @@
+// W-BONSAI-POINTS-RECOVERY — DAGeVu modeller: in-progress sketch/route points survive a stray Escape
+// (RESUME_MODELLER_POLISH.md #4). Points were transient (not op-log) → Escape lost them all. Now a cancel-exit
+// BUFFERS them for the session and re-opening the tool RESTORES them; a commit clears the draft; emptying the points
+// then cancelling discards it. Driven via real toolbar clicks + window.Bonsai.sketch.addPoint (reliable, no pointer
+// flake). Proves: (R1) buffer+restore across Escape; (R2) commit clears the draft; (R3) empty-then-cancel discards;
+// (R4) route mirrors the same _routeDraft buffer/restore (served source — routePts is module-local).
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 200)));
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.sketch && window.Bonsai.library && window.Bonsai.library.ready", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const enterSketchBtn = () => pg.evaluate(() => document.getElementById('b-sketch').click());
+  const escape = () => pg.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+  const nPts = () => pg.evaluate(() => window.Bonsai.sketch.points.length);
+  const addPts = pts => pg.evaluate(p => p.forEach(([x, y]) => window.Bonsai.sketch.addPoint(x, y)), pts);
+  let PASS = 0, FAIL = 0;
+  const ok = (c, m) => { (c ? PASS++ : FAIL++); console.log('  ' + (c ? '✅' : '❌') + ' ' + m); };
+  try {
+    // R1 — BUFFER + RESTORE across a stray Escape
+    await enterSketchBtn(); await sleep(80);
+    await addPts([[0, 0], [3, 0], [3, 2]]); await sleep(40);
+    const drew = await nPts();
+    await escape(); await sleep(80);                              // stray Escape — used to lose everything
+    const afterEsc = await nPts();
+    await enterSketchBtn(); await sleep(120);                     // re-open Sketch
+    const restored = await nPts();
+    ok(drew === 3 && restored === 3, 'R1 BUFFER+RESTORE: drew=' + drew + ' → Escape (pts now ' + afterEsc + ') → re-open restored=' + restored);
+
+    // R2 — COMMIT clears the draft (3 restored points are extruded; re-open is empty)
+    await pg.evaluate(() => document.getElementById('b-extrude').click());
+    await sleep(900);                                             // async commitExtrude
+    await enterSketchBtn(); await sleep(120);
+    const afterCommit = await nPts();
+    ok(afterCommit === 0, 'R2 COMMIT-CLEARS: after extrude+commit, re-open has ' + afterCommit + ' points (draft discarded)');
+
+    // R3 — empty-then-cancel DISCARDS (Backspace to 0, Escape → no resurrection)
+    await addPts([[0, 0], [2, 0]]); await sleep(40);             // (currently in sketch from R2 re-open)
+    await escape(); await sleep(60);                              // buffer 2
+    await enterSketchBtn(); await sleep(100);                     // restore 2
+    const r2pts = await nPts();
+    await pg.evaluate(() => { while (window.Bonsai.sketch.points.length) window.Bonsai.sketch.points.pop(); });   // empty them
+    await escape(); await sleep(60);                              // cancel with 0 → discard draft
+    await enterSketchBtn(); await sleep(100);
+    const afterDiscard = await nPts();
+    ok(r2pts === 2 && afterDiscard === 0, 'R3 DISCARD-EMPTY: restored=' + r2pts + ' → emptied → cancel → re-open=' + afterDiscard);
+    await escape();   // leave sketch clean
+
+    // R4 — route mirrors the same buffer/restore (served source; routePts is module-local so not directly readable)
+    const src = await (await fetch(`http://localhost:${port}/modeller.html`)).text();
+    const routeMirror = /_routeDraft = routePts\.map\(p => p\.slice\(\)\)/.test(src) &&     // exitRoute buffers
+      /routePts = _routeDraft\.map\(p => p\.slice\(\)\)/.test(src) &&                        // enterRoute restores
+      /exitRoute\(true\)/.test(src);                                                         // commit clears
+    ok(routeMirror, 'R4 ROUTE-MIRROR: enter/exitRoute buffer+restore _routeDraft, commit clears (served source)');
+  } catch (e) { console.log('  ERR ' + (e && e.stack || e)); FAIL++; }
+
+  await br.close(); server.close();
+  console.log('  §POINTS-RECOVERY VERDICT ' + (FAIL ? 'FAIL' : 'PASS') + ' — ' + PASS + ' PASS / ' + FAIL + ' FAIL');
+  process.exit(FAIL ? 1 : 0);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## What

Sketch + route points were transient (not in the op-log), so a **stray Escape lost them all**. Now a cancel-exit **buffers** the in-progress points for the session and re-opening the tool **restores** them.

- Cancel (Escape / toggle) → buffer + toast "N points saved — re-open to continue".
- Re-open → restore + toast "restored N points (Backspace to trim)".
- **Commit clears** the draft (the points became geometry).
- **Empty then cancel discards** it (Backspace to 0 + Escape = "start fresh").
- `enter/exitSketch` + `enter/exitRoute` carry a session draft; `exit(committed)` distinguishes commit from cancel. `sw.js` v11 → **v12**.

## Witness — `modeller/tests/bonsai_points_recovery_live.js` **W-BONSAI-POINTS-RECOVERY 4/4**

Toolbar clicks + `sketch.addPoint` (no pointer flake): R1 buffer+restore across Escape (3 → Esc → re-open 3) · R2 commit clears the draft (re-open = 0) · R3 empty-then-cancel discards (restored 2 → emptied → cancel → re-open 0) · R4 route mirrors the same `_routeDraft` buffer/restore + commit-clears (served source — `routePts` is module-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)