### PR TITLE
feat(modeller): W-BONSAI-OUTLINER-INCR (#7) — incremental Outliner rebuild (sw v13)

### DIFF
--- a/modeller/bonsai_outliner.js
+++ b/modeller/bonsai_outliner.js
@@ -114,7 +114,9 @@
 
     // Pick-select is FREQUENT (every click) and changes ONLY which row is active — so restyle the existing
     // rows in place instead of re-querying the DB + rebuilding the whole tree (the old refresh() on each pick
-    // was the select-side jank). Full _paint() still runs on actual op-log changes (commit/clear/find).
+    // was the select-side jank). M8 (incremental): the active-blue is NEVER baked into the section HTML — it is
+    // painted here over the cached DOM for BOTH the flat op-log rows ([data-fid]) AND the seeded BOM-tree leaf
+    // rows ([data-bnode][data-leaf="1"]). A neighbour row (adjacency lens, data-adj=1) falls back to amber.
     setActive(id) {
       window.Bonsai._selId = id;
       if (!this._el) return;
@@ -125,56 +127,92 @@
         d.onmouseover = () => { d.style.background = on ? '#26456b' : '#23262e'; };
         d.onmouseout = () => { d.style.background = on ? '#26456b' : 'transparent'; };
       });
+      this._el.querySelectorAll('[data-bnode][data-leaf="1"]').forEach(d => {
+        const on = String(d.getAttribute('data-bnode')) === String(id);
+        const nbr = d.getAttribute('data-adj') === '1';     // adjacency-lens neighbour → amber base
+        d.style.background = on ? '#26456b' : (nbr ? '#2c2616' : 'transparent');
+        d.style.color = on ? '#dce6f4' : (nbr ? '#e6dcc2' : '#c7cdd8');
+      });
     },
 
+    // M8 INCREMENTAL (RESUME_MODELLER_POLISH.md #7): the Outliner has TWO sections — the seeded BOM-tree
+    // categories (the loaded building: storey→room→disc→class→element, thousands of nodes, RE-FOLDED only on a
+    // reparent/seed/walk) and the FLAT op-log groups (what the user authored, grows on every geometry commit).
+    // The old _paint rebuilt BOTH on EVERY `bonsai:oplog` change → re-folding + re-parsing + re-wiring the whole
+    // building tree on each move/cut = the "jank at 100+ features". Now each section is rendered to its OWN
+    // persistent container and the freshly-built HTML is STRING-DIFFED against the last render: an identical
+    // section is left UNTOUCHED (no innerHTML reparse, no querySelectorAll re-wire — the costly DOM work). A
+    // geometry commit changes only the flat HTML → the seeded tree DOM is reused as-is (identity preserved).
+    // Selection is applied by setActive() over whichever DOM survived, so a pure pick never rebuilds either side.
+    _ensureSections(tree) {
+      if (tree.querySelector('#bo-trees')) return;
+      tree.innerHTML =
+        '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'DAGeVu Model</div>' +
+        '<div id="bo-trees"></div><div id="bo-flats"></div>';
+      this._treesCache = this._flatsCache = null;   // fresh skeleton → force both sections to refill (no stale-cache desync)
+    },
     _paint() {
       const tree = this._el.querySelector('#bo-tree'); if (!tree) return;
+      this._ensureSections(tree);
       // W-UX-6: refresh the adjacency map for this paint when the lens is ON (cheap; reads window.swXEdges).
       this._adjMap = this._adjLens ? this._buildAdjMap() : null;
       const ops = (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps() : [];
-      // FLAT categories (op-log feature groups — Walls/Openings/etc., unchanged). TREE categories (deep, seeded,
-      // editable — the BOM Tree composition facet, SPATIAL_DEPENDENCY_GRAPH §OUTLINER-COHERENCE) take a separate path.
       const flatCats = this._categories.filter(c => !c.tree);
       const treeCats = this._categories.filter(c => c.tree);
-      const groups = flatCats.map(cat => ({ cat, nodes: ops.filter(cat.match).map(cat.node) }));
       const f = this._find;
       const match = n => !f || (n.label + ' ' + n.sub).toLowerCase().includes(f);
       let total = 0, shown = 0;
-      let html = '<div style="padding:2px 6px;color:#8b94a3">' + CHEV(true) + 'DAGeVu Model</div>';
-      // ARC LEADS (W-UX-3): the seeded containment TREE categories (BOM-graph Storey→Room→disc→class→element,
-      // then STR Walker) render FIRST — they are the loaded building, the primary surface. The FLAT op-log
-      // groups (Walls/Openings/Routes/… = what the user has authored, empty until they edit) follow below.
-      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); html += r.html; total += r.total; shown += r.shown; });
+
+      // ── SEEDED TREE section (ARC LEADS, W-UX-3) — re-rendered only when its HTML actually changes ──────────
+      let treesHtml = '';
+      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); treesHtml += r.html; total += r.total; shown += r.shown; });
+      let treeBuilt = false;
+      if (treesHtml !== this._treesCache) {
+        const c = tree.querySelector('#bo-trees'); c.innerHTML = treesHtml; this._wireTrees(c, treeCats);
+        this._treesCache = treesHtml; treeBuilt = true;
+      }
+
+      // ── FLAT op-log groups — grows with authored features; the only section a geometry commit changes ──────
+      const groups = flatCats.map(cat => ({ cat, nodes: ops.filter(cat.match).map(cat.node) }));
+      let flatsHtml = '';
       groups.forEach(g => {
         const vis = g.nodes.filter(match); total += g.nodes.length; shown += vis.length;
         if (f && !vis.length) return;
         const col = this._collapsed[g.cat.key];
-        html += '<div data-grp="' + g.cat.key + '" style="padding:2px 6px 2px 16px;color:#6f7a8b;cursor:pointer">' +
+        flatsHtml += '<div data-grp="' + g.cat.key + '" style="padding:2px 6px 2px 16px;color:#6f7a8b;cursor:pointer">' +
           CHEV(!col) + g.cat.label + ' <span style="color:#454e5d">(' + g.nodes.length + ')</span></div>';
         if (col) return;
-        vis.forEach(n => {
-          const active = window.Bonsai._selId === n.id;
-          html += '<div data-fid="' + n.id + '" style="padding:3px 6px 3px 32px;cursor:pointer;border-radius:4px;' +
-            (active ? 'background:#26456b;color:#dce6f4' : 'color:#c7cdd8') + '" ' +
-            'onmouseover="this.style.background=\'' + (active ? '#26456b' : '#23262e') + '\'" ' +
-            'onmouseout="this.style.background=\'' + (active ? '#26456b' : 'transparent') + '\'">' +
+        vis.forEach(n => {                                   // active-blue NOT baked — setActive() paints it
+          flatsHtml += '<div data-fid="' + n.id + '" style="padding:3px 6px 3px 32px;cursor:pointer;border-radius:4px;color:#c7cdd8" ' +
+            'onmouseover="this.style.background=\'#23262e\'" onmouseout="this.style.background=\'transparent\'">' +
             LEAF + n.label + '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span></div>';
         });
       });
-      tree.innerHTML = html;
-      tree.querySelectorAll('[data-grp]').forEach(d => d.onclick = () => { const k = d.getAttribute('data-grp'); this._collapsed[k] = !this._collapsed[k]; this._paint(); });
-      tree.querySelectorAll('[data-fid]').forEach(d => d.onclick = () => {
-        const fid = +d.getAttribute('data-fid');
-        if (window.Bonsai.select) window.Bonsai.select(fid);   // → highlight() → setActive(): restyle only, no rebuild
-        else this.setActive(fid);
-      });
-      this._wireTrees(treeCats);
+      let flatBuilt = false;
+      if (flatsHtml !== this._flatsCache) {
+        const c = tree.querySelector('#bo-flats'); c.innerHTML = flatsHtml; this._wireFlat(c);
+        this._flatsCache = flatsHtml; flatBuilt = true;
+      }
+
+      // selection highlight (over whichever DOM survived) + footer
+      this.setActive(window.Bonsai._selId);
       const foot = this._el.querySelector('#bo-foot');
       const tip = (window.Bonsai.oplog && window.Bonsai.oplog._lastTip) || '';
       let lens = '';
       if (this._adjLens) { const s = this._adjStats(); lens = '  ⇄' + s.abuts + ' ⌂' + s.fills + ' ⧉' + s.aggregates + ' ⊥' + s.datums; }
       foot.textContent = (f ? shown + '/' + total + ' shown' : total + ' features') + lens + (tip ? '  🔒 ' + tip.slice(0, 8) : '');
-      console.log(TAG + ' paint total=' + total + ' shown=' + shown + ' find="' + f + '" trees=' + treeCats.length);
+      this._lastPaint = { tree: treeBuilt, flat: flatBuilt };   // whitebox witness reads this (W-BONSAI-OUTLINER-INCR)
+      console.log(TAG + ' paint total=' + total + ' shown=' + shown + ' find="' + f + '" trees=' + treeCats.length +
+        ' treeBuilt=' + treeBuilt + ' flatBuilt=' + flatBuilt);
+    },
+    // Flat op-log group/row wiring (scoped to the #bo-flats container so it re-wires only on a flat rebuild).
+    _wireFlat(root) {
+      root.querySelectorAll('[data-grp]').forEach(d => d.onclick = () => { const k = d.getAttribute('data-grp'); this._collapsed[k] = !this._collapsed[k]; this._paint(); });
+      root.querySelectorAll('[data-fid]').forEach(d => d.onclick = () => {
+        const fid = +d.getAttribute('data-fid');
+        if (window.Bonsai.select) window.Bonsai.select(fid);   // → highlight() → setActive(): restyle only, no rebuild
+        else this.setActive(fid);
+      });
     },
 
     // ── DEEP / EDITABLE tree category (the BOM Tree composition facet). cat.tree() → [rootNode];
@@ -223,7 +261,9 @@
           if (dr.anchored) parts.push('⊥' + dr.anchored); if (dr.spans) parts.push('↕' + dr.spans);
           if (parts.length) adjBadge = ' <span class="bn-deg" style="color:#e0a23a;font-family:ui-monospace,monospace">' + parts.join(' ') + '</span>';
         }
-        const rowBg = active ? 'background:#26456b;color:#dce6f4' : (isNbr ? 'background:#2c2616;color:#e6dcc2' : 'color:#c7cdd8');
+        // active-blue is NOT baked here (M8) — setActive() paints the selected row over the cached DOM so a pure
+        // pick never forces a tree rebuild. Neighbour-amber (adjacency lens) stays structural (depends on selId).
+        const rowBg = isNbr ? 'background:#2c2616;color:#e6dcc2' : 'color:#c7cdd8';
         html += '<div data-bnode="' + n.id + '" data-tcat="' + ckey + '" data-leaf="' + (isLeaf ? 1 : 0) + '"' +
           (n.disc ? ' data-disc="' + n.disc + '"' : '') + (isNbr ? ' data-adj="1"' : '') + ' draggable="true" ' +
           'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' + rowBg + '">' +
@@ -234,13 +274,13 @@
       return { html: html, shown: shown };
     },
     _subtreeMatches(n, match) { if (match({ label: n.label, sub: n.sub || '' })) return true; return (n.children || []).some(c => this._subtreeMatches(c, match)); },
-    _wireTrees(treeCats) {
-      if (!this._el || !treeCats.length) return;
+    _wireTrees(root, treeCats) {
+      if (!root || !treeCats.length) return;
       const byKey = {}; treeCats.forEach(c => byKey[c.key] = c);
-      this._el.querySelectorAll('[data-tcat]:not([data-bnode])').forEach(d => d.onclick = () => {
+      root.querySelectorAll('[data-tcat]:not([data-bnode])').forEach(d => d.onclick = () => {
         const k = 'tcat|' + d.getAttribute('data-tcat'); this._collapsed[k] = !this._collapsed[k]; this._paint();
       });
-      this._el.querySelectorAll('[data-bnode]').forEach(d => {
+      root.querySelectorAll('[data-bnode]').forEach(d => {
         const id = d.getAttribute('data-bnode'), isLeaf = d.getAttribute('data-leaf') === '1';
         const disc = d.getAttribute('data-disc');
         d.onclick = () => {

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -194,7 +194,7 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=6" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=7" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
 <script src="bom_tree.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
 <script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
@@ -2520,6 +2520,55 @@ if (qs.get('outliner') === 'demo') {
     window.__outlinerResult = out;
     window.__outlinerDone = true;
     console.log('§MODELLER outliner-done');
+  })();
+}
+// ?outliner=incr proves the M8 INCREMENTAL rebuild (W-BONSAI-OUTLINER-INCR, RESUME_MODELLER_POLISH.md #7):
+// a geometry op-log change re-renders ONLY the flat op-log section — the seeded BOM-tree DOM is reused as-is
+// (string-diff cache, node identity preserved), so jank at 100+ features is gone. A real tree change still
+// rebuilds; selection highlights by in-place restyle without rebuilding either side.
+if (qs.get('outliner') === 'incr') {
+  (async () => {
+    const out = {};
+    try {
+      const Out = window.Bonsai.outliner;
+      // A sizeable seeded TREE category (the loaded building) under our control via window.__incrTree.
+      const mkTree = (lbl) => [{ id: 'grp-A', kind: 'group', label: lbl, children:
+        Array.from({ length: 150 }, (_, i) => ({ id: 'el-' + i, kind: 'element', label: 'Elem ' + i, sub: '' })) }];
+      window.__incrTree = mkTree('Synthetic Storey');
+      Out.addCategory({ key: 'incrtree', label: 'Synthetic Tree', tree: () => window.__incrTree });   // → refresh() = full paint #1
+      const trees = () => document.querySelector('#bonsai-outliner #bo-trees');
+      const flats = () => document.querySelector('#bonsai-outliner #bo-flats');
+      out.firstFullPaint = !!(Out._lastPaint && Out._lastPaint.tree);           // tree built on first paint
+      out.treeRows0 = trees().querySelectorAll('[data-bnode][data-leaf="1"]').length;   // 150 seeded leaves
+      // STAMP a seeded tree DOM node — survival across op-log changes proves the tree was NOT rebuilt.
+      const stampEl = trees().querySelector('[data-bnode="el-7"]'); stampEl.__stamp = 'KEEP';
+      // author a wall (a geometry op-log commit) — must touch the FLAT section only.
+      window.Bonsai.grid.define({ xs: [0, 4], ys: [0, 3], xlabels: ['A', 'B'], ylabels: ['1', '2'] });
+      const O = window.Bonsai.oplog; O.clear();
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      out.afterCommit = { tree: Out._lastPaint.tree, flat: Out._lastPaint.flat };   // expect {tree:false, flat:true}
+      const keep1 = trees().querySelector('[data-bnode="el-7"]');
+      out.domIdentityKept = !!(keep1 && keep1.__stamp === 'KEEP');                   // SAME DOM node reused
+      out.wallRowAppeared = /Wall/.test(flats().textContent);
+      // a 2nd geometry commit — tree still cached, flat grows.
+      await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 1], [4, 1], [4, 1.2], [0, 1.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+      out.afterCommit2Tree = Out._lastPaint.tree;                                    // expect false (cached)
+      out.wallCount = (flats().textContent.match(/Walls \((\d+)\)/) || [])[1];       // expect "2"
+      out.domStillKept = !!(trees().querySelector('[data-bnode="el-7"]') || {}).__stamp;
+      // a REAL tree change (relabel a node) must rebuild the tree section + drop the stale stamp.
+      window.__incrTree = mkTree('Renamed Storey'); Out.refresh();
+      out.treeRebuiltOnChange = Out._lastPaint.tree;                                 // expect true
+      out.stampDropped = !((trees().querySelector('[data-bnode="el-7"]') || {}).__stamp);   // new DOM → no stamp
+      // SELECTION on a tree leaf restyles in place — no rebuild of either section.
+      const before = Out._lastPaint;
+      const leaf = trees().querySelector('[data-bnode="el-3"][data-leaf="1"]'); leaf.click();
+      out.selectNoRebuild = Out._lastPaint === before;                              // same paint object = no _paint ran
+      out.selBg = leaf.style.background;                                            // browser may normalise hex→rgb
+      out.selectHighlighted = /26456b|38,\s*69,\s*107/i.test(leaf.style.background);  // active-blue painted by setActive
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§OUTLINER incr fail ' + e); }
+    window.__incrResult = out;
+    window.__incrDone = true;
+    console.log('§MODELLER outliner-incr-done ' + JSON.stringify(out));
   })();
 }
 // ?grid=demo proves 2D correlation (W-BONSAI-GRID): define a column grid, snap NOISY clicks to it,

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v12';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v13';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_outliner_incr_live.js
+++ b/modeller/tests/bonsai_outliner_incr_live.js
@@ -1,0 +1,53 @@
+// W-BONSAI-OUTLINER-INCR — Outliner INCREMENTAL rebuild witness (RESUME_MODELLER_POLISH.md #7, M8).
+// CLAIM (the issue this proves): the old Outliner rebuilt BOTH sections — the seeded BOM-tree (the whole
+// loaded building, thousands of nodes) AND the flat op-log groups — on EVERY `bonsai:oplog` change, so a
+// geometry edit re-folded + re-parsed + re-wired the entire building tree → "jank at 100+ features". The fix
+// renders each section to its own persistent container and string-diffs the freshly-built HTML: an unchanged
+// section is left UNTOUCHED in the DOM. PROVEN HERE by DOM-NODE IDENTITY: a stamped seeded-tree node survives
+// op-log commits (tree NOT rebuilt) but is dropped when the tree content actually changes (tree IS rebuilt);
+// selection highlights by in-place restyle (no rebuild of either side). Robust to spurious extra paints — the
+// asserts read the DOM, not the transient paint flag.
+const http = require('http'), fs = require('fs'), path = require('path');
+const MODELLER = path.join('/tmp/wt-outliner-incr', 'modeller');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(MODELLER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§(OUTLINER|MODELLER outliner-incr)/.test(t)) console.log('  ' + t.slice(0, 200)); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?outliner=incr`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__incrDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __incrDone'));
+  const x = await pg.evaluate(() => window.__incrResult || {}).catch(e => ({ err: String(e) }));
+  await br.close(); server.close();
+
+  console.log('  §INCR ' + JSON.stringify(x));
+  // I1 first paint built the seeded tree, all 150 leaves present (correctness baseline).
+  const I1 = x.firstFullPaint === true && x.treeRows0 === 150;
+  // I2 a geometry commit reused the seeded tree DOM (stamped node survived) and added the Wall row to flats.
+  const I2 = x.domIdentityKept === true && x.wallRowAppeared === true;
+  // I3 a 2nd commit kept the tree cached and grew the flat group to 2 (still the same stamped DOM node).
+  const I3 = x.wallCount === '2' && x.domStillKept === true;
+  // I4 a REAL tree change rebuilt the tree section — the stale stamp is gone (and the flag agrees).
+  const I4 = x.stampDropped === true && x.treeRebuiltOnChange === true;
+  // I5 selecting a tree leaf restyled in place: no _paint ran and the row went active-blue.
+  const I5 = x.selectNoRebuild === true && x.selectHighlighted === true;
+  const checks = { I1, I2, I3, I4, I5 };
+  Object.keys(checks).forEach(k => console.log('  ' + k + ' ' + (checks[k] ? 'PASS' : 'FAIL')));
+  const pass = !x.error && Object.values(checks).every(Boolean);
+  console.log('  §BONSAI-OUTLINER-INCR VERDICT ' + (pass ? 'PASS' : 'FAIL') + (x.error ? ' ERROR=' + x.error : ''));
+  console.log('── W-BONSAI-OUTLINER-INCR ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## What
M8 / RESUME_MODELLER_POLISH.md #7. The Outliner rebuilt **both** the seeded BOM-tree (the whole loaded building — thousands of nodes, re-folded + re-parsed + re-wired) **and** the flat op-log groups on **every** `bonsai:oplog` change → "jank at 100+ features" on every move/cut.

## How
Each section renders to its own persistent container (`#bo-trees` / `#bo-flats`); the freshly-built HTML is **string-diffed** against the last render and an unchanged section is left untouched in the DOM (no innerHTML reparse, no `querySelectorAll` re-wire). A geometry commit changes only the flat HTML → the seeded tree DOM is reused as-is (node identity preserved). `active`-blue is no longer baked into either section; `setActive()` paints it over the surviving DOM for flat **and** tree-leaf rows, so a pure pick never rebuilds either side. A real tree change (reparent/seed/walk) still rebuilds.

## Witness — W-BONSAI-OUTLINER-INCR 5/5
`modeller/tests/bonsai_outliner_incr_live.js` (`?outliner=incr`, headless): I1 first paint builds 150 seeded leaves · I2 a commit reuses the **stamped tree DOM node** + adds the Wall row to flats · I3 2nd commit keeps tree cached (Walls→2, stamp survives) · I4 a relabel rebuilds the tree (stamp dropped) · I5 selecting a tree leaf restyles in place (no `_paint`, active-blue applied). Asserts read **DOM identity**, robust to spurious paints. **W-BONSAI-OUTLINER (original) still PASS** — backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)