### PR TITLE
feat(modeller): W-BONSAI-ASM-PREVIEW (#6) — rich assembly-drop preview (sw v15)

### DIFF
--- a/modeller/bonsai_library.js
+++ b/modeller/bonsai_library.js
@@ -388,6 +388,33 @@
     previewBox(bbox, placement) {
       const base = boxArrays(bbox);
       return { positions: place(base.positions, placement, bbox), indices: base.indices, bbox };
+    },
+    // RICH ASSEMBLY GHOST (M7 / RESUME_MODELLER_POLISH.md #6): the N CHILD boxes at their REAL landing positions
+    // — the SAME dropLeaves transform the commit uses (footprint centred on the cursor + drop yaw + host-rotation),
+    // merged into one geometry — so the preview shows the actual child set, not just the enclosing aabb. Capped at
+    // MAX leaves: a whole-building drop returns {tooMany:n} and the caller falls back to the footprint box (logged),
+    // protecting the per-pointermove path. Returns {positions,indices,count} | {tooMany:n} | null.
+    previewLeafBoxes(id, placement) {
+      const pl = placement || { x: 0, y: 0, z: 0, rot: 0 };
+      const leaves = this.dropLeaves(id, pl.x || 0, pl.y || 0, pl.rot || 0, pl.z || 0);
+      if (!leaves || !leaves.length) return null;
+      const MAX = 2000;
+      if (leaves.length > MAX) return { tooMany: leaves.length };
+      let nv = 0, ni = 0; const parts = [];
+      for (let i = 0; i < leaves.length; i++) {
+        const lf = leaves[i], c = this.get(lf.hash), bb = (c && c.bbox) || [-0.05, 0.05, -0.05, 0.05, 0, 0.1];
+        const ba = boxArrays(bb);
+        const pos = place(ba.positions, { x: lf.x, y: lf.y, z: lf.z, rot: lf.rot }, bb);
+        parts.push({ pos: pos, idx: ba.indices }); nv += pos.length / 3; ni += ba.indices.length;
+      }
+      const positions = new Float32Array(nv * 3), indices = new Uint32Array(ni);
+      let vo = 0, io = 0;
+      for (let j = 0; j < parts.length; j++) {
+        const p = parts[j]; positions.set(p.pos, vo * 3);
+        for (let k = 0; k < p.idx.length; k++) indices[io + k] = p.idx[k] + vo;
+        vo += p.pos.length / 3; io += p.idx.length;
+      }
+      return { positions: positions, indices: indices, count: leaves.length };
     }
   };
 

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -207,7 +207,7 @@
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
 <script src="str_walker_outliner.js?v=9" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
-<script src="bonsai_library.js?v=15" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
+<script src="bonsai_library.js?v=16" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="../viewer/connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
@@ -1539,6 +1539,7 @@ const bInsert = document.getElementById('b-insert');
 const bLod = document.getElementById('b-lod');
 let inserting = false, insertHash = null, lastInsertId = null, insertPanel = null;
 let insRot = 0, insElev = 0, ghostMesh = null, ghostXY = null;   // pending placement: yaw(deg) + elevation(z), live ghost
+let _asmGhost = null;   // M7: cached rich assembly-ghost child cluster (rebuilt only on hash/yaw/elev change)
 function isInsert(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && o.op_type === 'GEOM_INSERT'; }
 // standalone B-rep solids the worker can spin in place (GEOM_ROTATE): extrude/poly walls, swept runs, filleted solids.
 const SOLID_OPS = new Set(['GEOM_EXTRUDE', 'GEOM_EXTRUDE_POLY', 'GEOM_SWEEP', 'GEOM_FILLET']);
@@ -1549,7 +1550,7 @@ function paintLod() {
   const lod = id != null ? window.Bonsai.library.lodFor(id, '200') : '200';
   bLod.querySelector('span').textContent = 'LOD ' + lod; bLod.classList.toggle('on', lod === '300');
 }
-function clearGhost() { if (ghostMesh) { scene.remove(ghostMesh); ghostMesh.geometry.dispose(); ghostMesh.material.dispose(); ghostMesh = null; } ghostXY = null; }
+function clearGhost() { if (ghostMesh) { scene.remove(ghostMesh); ghostMesh.geometry.dispose(); ghostMesh.material.dispose(); ghostMesh = null; } ghostXY = null; _asmGhost = null; }
 // After a drop, DISARM the pending pick so the ghost stops sticking to the pointer (user: "shake off once Insert
 // done"). Panel stays open; re-click a part/set to arm the next placement.
 function disarmPick() { insertHash = null; clearGhost(); if (insertPanel) insertPanel.querySelectorAll('.ins-c,.ins-a').forEach(x => x.style.borderColor = ''); }
@@ -1558,13 +1559,27 @@ function showGhost(x, y) {                                        // translucent
   const L = window.Bonsai.library, asm = L.isAssembly(insertHash) ? L.assembly(insertHash) : null;
   let pa;
   if (asm) {
-    // assembly ghost = the TRUE leaf footprint, centred on the cursor + rotated by the drop yaw — the SAME rigid
-    // transform dropLeaves applies to the parts, so the preview box exactly encloses where they land. (The old ghost
-    // used the declared aabb asm.w/d = the parent-PRODUCT box → preview and landing disagreed. W-BOM-DROP-CENTER.)
-    const fp = L.footprintAABB(insertHash, { x: 0, y: 0, z: 0, rot: 0 });
-    pa = fp
-      ? L.previewBox([fp.minX - fp.cx, fp.maxX - fp.cx, fp.minY - fp.cy, fp.maxY - fp.cy, fp.minZ, fp.maxZ], { x, y, z: insElev, rot: insRot })
-      : L.previewBox([-(asm.w || 0.2) / 2, (asm.w || 0.2) / 2, -(asm.d || 0.2) / 2, (asm.d || 0.2) / 2, 0, asm.h || 0.1], { x, y, z: insElev, rot: insRot });
+    // M7 (#6): the RICH ghost = the N CHILD boxes at their real landing positions (the SAME dropLeaves transform
+    // the commit uses), so the preview shows the actual child set, not just the enclosing aabb. Built ONCE per
+    // (hash, yaw, elev) at the origin and cached, then rigidly TRANSLATED to the cursor each pointermove (the
+    // per-leaf expand + host-rotation runs only on arm/rotate/elevate, never per move). A whole-building drop
+    // (> cap) falls back to the TRUE footprint box (W-BOM-DROP-CENTER), logged. yaw=0 ⇒ footprint centred on cursor.
+    if (!_asmGhost || _asmGhost.hash !== insertHash || _asmGhost.rot !== insRot || _asmGhost.elev !== insElev) {
+      const lb = L.previewLeafBoxes(insertHash, { x: 0, y: 0, z: insElev, rot: insRot });
+      if (lb && lb.tooMany) console.log('§MODELLER asm-ghost leaves=' + lb.tooMany + ' > cap → footprint box');
+      _asmGhost = { hash: insertHash, rot: insRot, elev: insElev,
+        positions: (lb && lb.positions) || null, indices: (lb && lb.indices) || null, count: (lb && lb.count) || 0 };
+    }
+    if (_asmGhost.positions) {                                     // translate the cached child cluster to the cursor
+      const src = _asmGhost.positions, p2 = new Float32Array(src.length);
+      for (let i = 0; i < src.length; i += 3) { p2[i] = src[i] + x; p2[i + 1] = src[i + 1] + y; p2[i + 2] = src[i + 2]; }
+      pa = { positions: p2, indices: _asmGhost.indices };
+    } else {                                                       // cap fallback → the TRUE leaf-footprint aabb box
+      const fp = L.footprintAABB(insertHash, { x: 0, y: 0, z: 0, rot: 0 });
+      pa = fp
+        ? L.previewBox([fp.minX - fp.cx, fp.maxX - fp.cx, fp.minY - fp.cy, fp.maxY - fp.cy, fp.minZ, fp.maxZ], { x, y, z: insElev, rot: insRot })
+        : L.previewBox([-(asm.w || 0.2) / 2, (asm.w || 0.2) / 2, -(asm.d || 0.2) / 2, (asm.d || 0.2) / 2, 0, asm.h || 0.1], { x, y, z: insElev, rot: insRot });
+    }
   } else {
     pa = L.previewArrays(insertHash, { x, y, z: insElev, rot: insRot });
   }
@@ -3217,6 +3232,63 @@ if (qs.get('dropcenter') === 'demo') {
     } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER dropcenter fail ' + e); }
     window.__dropCenterResult = out; window.__dropCenterDone = true;
     console.log('§MODELLER dropcenter-done ' + JSON.stringify(out));
+  })();
+}
+// ?asmpreview=demo proves M7 RICH assembly ghost (W-BONSAI-ASM-PREVIEW, RESUME_MODELLER_POLISH.md #6): the drop
+// preview shows the N CHILD boxes at their real landing positions, not just one enclosing aabb box.
+if (qs.get('asmpreview') === 'demo') {
+  (async () => {
+    const out = {}; const L = window.Bonsai.library;
+    const near = (a, b, t) => Math.abs(a - b) <= (t || 1e-2);
+    try {
+      await L.ready();
+      const pick = L.assemblies().map(a => ({ a, n: L.expandAssembly(a.id, { x: 0, y: 0, z: 0, rot: 0 }).length }))
+        .filter(x => x.n >= 2 && x.n <= 24 && (x.a.w || 0) > 0.5 && (x.a.d || 0) > 0.5)
+        .sort((x, y) => (y.a.w * y.a.d) - (x.a.w * x.a.d)).map(x => x.a)[0];
+      if (!pick) { out.error = 'no suitable SET assembly'; }
+      else {
+        const X = 4, Y = 3;
+        const leaves = L.dropLeaves(pick.id, X, Y, 0, 0);            // the REAL landing positions
+        const lb = L.previewLeafBoxes(pick.id, { x: X, y: Y, z: 0, rot: 0 });
+        out.pick = pick.id; out.N = leaves.length;
+        out.boxCount = lb && lb.count;
+        out.indexCount = lb && lb.indices.length;                    // N boxes × 36 (NOT 36 = a single aabb box)
+        out.boxesPerLeaf = out.indexCount / 36 === out.N;
+        // each ghost child box centroid (8 verts) sits on its leaf's landing (XY) — the preview == the real drop.
+        let matched = 0;
+        for (let i = 0; i < leaves.length; i++) {
+          let sx = 0, sy = 0; for (let v = 0; v < 8; v++) { sx += lb.positions[(i * 8 + v) * 3]; sy += lb.positions[(i * 8 + v) * 3 + 1]; }
+          sx /= 8; sy /= 8;
+          if (near(sx, leaves[i].x, 0.02) && near(sy, leaves[i].y, 0.02)) matched++;
+        }
+        out.matched = matched; out.boxesAtLanding = matched === leaves.length;
+        // rigid translation: re-preview shifted by (+10,+5) ⇒ every vertex moves exactly (10,5,0).
+        const lb2 = L.previewLeafBoxes(pick.id, { x: X + 10, y: Y + 5, z: 0, rot: 0 });
+        let md = 0; for (let k = 0; k < lb.positions.length; k += 3) {
+          md = Math.max(md, Math.abs(lb2.positions[k] - (lb.positions[k] + 10)),
+            Math.abs(lb2.positions[k + 1] - (lb.positions[k + 1] + 5)), Math.abs(lb2.positions[k + 2] - lb.positions[k + 2]));
+        }
+        out.translateExact = md < 1e-4; out.maxTransDrift = +md.toFixed(6);
+        // WIRING: arm + showGhost → the scene ghost carries N boxes; a pointer move shifts every vertex rigidly.
+        insRot = 0; insElev = 0; inserting = true; insertHash = pick.id; _asmGhost = null;
+        showGhost(X, Y);
+        out.ghostIdx = ghostMesh ? ghostMesh.geometry.getIndex().count : 0;   // expect N×36
+        out.ghostRich = out.ghostIdx === out.N * 36;
+        const p0 = ghostMesh.geometry.getAttribute('position').array.slice();
+        showGhost(X + 7, Y);
+        const p1 = ghostMesh.geometry.getAttribute('position').array;
+        let dmax = -Infinity, dmin = Infinity;
+        for (let k = 0; k < p0.length; k += 3) { const dx = p1[k] - p0[k]; if (dx > dmax) dmax = dx; if (dx < dmin) dmin = dx; }
+        out.ghostMoved = near(dmax, 7, 1e-3) && near(dmin, 7, 1e-3);          // every vertex +7 in x (cached translate)
+        // robustness: the biggest assembly never throws — returns child boxes OR an honest {tooMany} cap.
+        const big = L.assemblies().map(a => ({ a, n: L.expandAssembly(a.id, { x: 0, y: 0, z: 0, rot: 0 }).length })).sort((x, y) => y.n - x.n)[0];
+        const bl = big ? L.previewLeafBoxes(big.a.id, { x: 0, y: 0, z: 0, rot: 0 }) : null;
+        out.bigN = big && big.n; out.bigOk = !!(bl && (bl.tooMany || bl.positions));
+        clearGhost(); inserting = false; insertHash = null;
+      }
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§MODELLER asmpreview fail ' + e); }
+    window.__asmPreviewResult = out; window.__asmPreviewDone = true;
+    console.log('§MODELLER asmpreview-done ' + JSON.stringify(out));
   })();
 }
 // ?edit=demo proves EDITABILITY (W-BONSAI-EDIT): delete a single feature, cascade-delete a parent (its cut child

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v14';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v15';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_asmpreview_live.js
+++ b/modeller/tests/bonsai_asmpreview_live.js
@@ -1,0 +1,53 @@
+// W-BONSAI-ASM-PREVIEW — M7 rich assembly-drop preview (RESUME_MODELLER_POLISH.md #6).
+// CLAIM (the issue this proves): the assembly drop preview showed only ONE enclosing aabb footprint box, not
+// the N child placements — the user couldn't see what the set actually looks like before dropping. The fix
+// renders the N CHILD boxes at their real landing positions (the SAME dropLeaves transform the commit uses),
+// merged into one ghost, cached per (hash,yaw,elev) and translated to the cursor each move. Witnessed: the ghost
+// carries N×36 indices (N boxes, not 1), every child box centroid sits on its leaf's landing, a cursor move
+// shifts every vertex rigidly, and a building-sized drop returns an honest {tooMany} cap (never throws).
+const http = require('http'), fs = require('fs'), path = require('path');
+const MODELLER = path.join('/tmp/wt-asm', 'modeller');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const VIEWER = path.join('/tmp/wt-asm', 'viewer');   // dagevu_catalog.json lives here (shared data, fetched by the modeller)
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(MODELLER, p), (e, b) => {
+    if (!e) { r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b); return; }
+    fs.readFile(path.join(VIEWER, p), (e2, b2) => {      // fall back to the shared viewer data dir (catalog/geometries)
+      if (e2) { r.writeHead(404); r.end('404 ' + p); return; }
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b2);
+    });
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader',
+           '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('console', m => { const t = m.text(); if (/^§MODELLER asm/.test(t)) console.log('  ' + t.slice(0, 240)); });
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  await pg.goto(`http://localhost:${port}/modeller.html?asmpreview=demo`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__asmPreviewDone === true', { timeout: 120000 })
+    .catch(() => console.log('  ✗ timeout waiting for __asmPreviewDone'));
+  const x = await pg.evaluate(() => window.__asmPreviewResult || {}).catch(e => ({ err: String(e) }));
+  await br.close(); server.close();
+
+  console.log('  §ASMPREVIEW ' + JSON.stringify(x));
+  // A1 the ghost is N child boxes, not one aabb box (N×36 indices, N≥2).
+  const A1 = x.N >= 2 && x.boxCount === x.N && x.boxesPerLeaf === true;
+  // A2 every child box centroid sits on its leaf's real landing position.
+  const A2 = x.boxesAtLanding === true && x.matched === x.N;
+  // A3 a cursor move translates the cached cluster rigidly (function + wired showGhost path).
+  const A3 = x.translateExact === true && x.ghostRich === true && x.ghostMoved === true;
+  // A4 the biggest assembly is handled without throwing (child boxes or an honest cap).
+  const A4 = x.bigOk === true && x.bigN >= 2;
+  const checks = { A1, A2, A3, A4 };
+  Object.keys(checks).forEach(k => console.log('  ' + k + ' ' + (checks[k] ? 'PASS' : 'FAIL')));
+  const pass = !x.error && Object.values(checks).every(Boolean);
+  console.log('  §BONSAI-ASM-PREVIEW VERDICT ' + (pass ? 'PASS' : 'FAIL') + (x.error ? ' ERROR=' + x.error : ''));
+  console.log('── W-BONSAI-ASM-PREVIEW ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## What
M7 / RESUME_MODELLER_POLISH.md #6. The assembly drop preview showed only **one** enclosing aabb footprint box — the user couldn't see the actual child set before dropping. Now the ghost renders the **N child boxes at their real landing positions** (the SAME `dropLeaves` transform the commit uses: footprint centred on cursor + drop yaw + host-rotation inheritance). Gated on the BOM-drop anchor fix, which has shipped (W-BOM-DROP-CENTER).

## How
`bonsai_library.previewLeafBoxes(id, placement)` builds the N box-proxies at the leaf landings, merged into one geometry (capped at 2000 → a whole-building drop returns `{tooMany}` and falls back to the TRUE footprint box, logged). `showGhost` builds the cluster **once** per (hash, yaw, elev) and caches it, then rigidly **translates** to the cursor each pointermove (per-leaf expand + host-rotation runs only on arm/rotate/elevate). `clearGhost` resets the cache. **Drop/commit path untouched** — preview-only.

## Witness — W-BONSAI-ASM-PREVIEW 4/4
`modeller/tests/bonsai_asmpreview_live.js` (`?asmpreview=demo`, real DX::DX_TF_STR 14-leaf set): A1 ghost = N child boxes (N×36 indices, not 36) · A2 every child box centroid on its leaf's real landing · A3 cursor move translates the cluster rigidly (504-idx ghost, every vertex +7) · A4 biggest assembly (N=265) handled without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)