### PR TITLE
§ARC-1: load REAL ARC building as gizmo-editable, guid-carrying meshes

### DIFF
--- a/modeller/arc_editable.js
+++ b/modeller/arc_editable.js
@@ -1,0 +1,103 @@
+// arc_editable.js — §ARC-1 (RESUME_ARC_EDITABLE_SUBSTRATE.md): seed the REAL ARC building as gizmo-EDITABLE,
+// guid-carrying signed GEOM_INSERT op-rows. This is the substrate the Phase-2 SDG forward-fold cascade rests on:
+// before this, the modeller's editable scene was synthetic-only (user inserts/sketches) — real walls/doors existed
+// only as walker DATA + overlay markers, so "drag wall → door rides" had no wall to grab.
+//
+// NON-INVENT: every element's box is its MEASURED bbox at its MEASURED centre (element_transforms); nothing is
+// fabricated. The box lands its WORLD CENTRE exactly on center_xyz (place() ground-seat math, rotation-invariant).
+// Each seed op carries output_guid = the real IFC guid → the featureId↔guid bridge (kernel_ops.output_guid,
+// persisted + replay-stable) that the cascade slice uses to look up swXEdges neighbours by guid.
+//
+// Dual-export (window + node) like cross_edges.js, so the value witness (W-ARC-EDITABLE) runs pure-node.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.ArcEditable = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+  var TAG = '§ARC';
+
+  // ARC palette by ifc_class — COSMETIC ONLY (colour never touches geometry/position; non-invent geometry holds).
+  var PALETTE = {
+    IfcWall: 0xb9c4cf, IfcWallStandardCase: 0xb9c4cf, IfcSlab: 0x9aa6b0, IfcRoof: 0x8a94a0,
+    IfcDoor: 0xc8a06a, IfcWindow: 0x7fb0c8, IfcCovering: 0xcdd6dd, IfcOpeningElement: 0xff8c42,
+    IfcFurniture: 0xa9b8a0, IfcStair: 0x9aa6b0, IfcRailing: 0x9aa6b0, IfcColumn: 0x8f9aa6, IfcBeam: 0x8f9aa6
+  };
+  function colorFor(cls) { return PALETTE[cls] != null ? PALETTE[cls] : 0xb9c4cf; }
+
+  // discipline='ARC' is the canonical filter (VISION-LOCK: ARC = sole edited substrate). When the discipline
+  // column is absent/empty, fall back to an ARC-ish class set (LOGGED at the call site — measure-don't-whitelist
+  // caveat: this is a discipline-recovery fallback, not a geometry whitelist).
+  var ARC_CLASSES = ['IfcWall', 'IfcWallStandardCase', 'IfcDoor', 'IfcWindow', 'IfcSlab', 'IfcRoof',
+    'IfcCovering', 'IfcColumn', 'IfcBeam', 'IfcStair', 'IfcRailing', 'IfcFurniture', 'IfcOpeningElement'];
+
+  function _hasDiscipline(db) {
+    try { var r = db.exec("SELECT COUNT(*) FROM elements_meta WHERE discipline='ARC'"); return !!(r.length && r[0].values[0][0] > 0); }
+    catch (e) { return false; }
+  }
+
+  // buildSeedOps(db) — PURE read of a sql.js *_extracted.db → {ops, skipped, discipline}. Each op is the exact
+  // GEOM_INSERT shape foldInsert consumes for a raw-bbox (hash-less) insert.
+  function buildSeedOps(db) {
+    var hasDisc = _hasDiscipline(db);
+    var where = hasDisc ? "m.discipline='ARC'"
+      : '(' + ARC_CLASSES.map(function (c) { return "m.ifc_class='" + c + "'"; }).join(' OR ') + ')';
+    var sql = "SELECT m.guid, m.ifc_class, t.center_x, t.center_y, t.center_z, " +
+      "t.bbox_x, t.bbox_y, t.bbox_z, t.rotation_z FROM elements_meta m " +
+      "JOIN element_transforms t ON t.guid = m.guid WHERE " + where + " ORDER BY m.id";
+    var r = db.exec(sql), ops = [], skipped = [];
+    if (r.length) r[0].values.forEach(function (v) {
+      var guid = v[0], cls = v[1], cx = v[2], cy = v[3], cz = v[4], bx = v[5], by = v[6], bz = v[7], rz = v[8] || 0;
+      // honest-refuse: never fabricate a box for a NULL/degenerate-bbox element (skipped + logged, excluded from count)
+      if (cx == null || cy == null || cz == null || !(bx > 0) || !(by > 0) || !(bz > 0)) {
+        skipped.push({ guid: guid, ifc_class: cls, reason: 'no-bbox' }); return;
+      }
+      var bbox = [-bx / 2, bx / 2, -by / 2, by / 2, -bz / 2, bz / 2];   // MEASURED local box, centred in x/y/z
+      // ground-seat: place() seats local zmin (=-bz/2) at placement.z → world centre z = z + bz/2; set z = cz - bz/2
+      // so the box world-centre lands EXACTLY on (cx,cy,cz). Yaw about Z is centre-invariant.
+      var placement = { x: cx, y: cy, z: cz - bz / 2, rot: rz };
+      ops.push({
+        op_type: 'GEOM_INSERT',
+        params: { bbox: bbox, placement: placement, color: colorFor(cls), provenance: 'recovered:extracted', ifc_class: cls },
+        outputGuid: guid
+      });
+    });
+    return { ops: ops, skipped: skipped, discipline: hasDisc ? 'ARC' : 'fallback' };
+  }
+
+  // buildBridge(ops, ids) — ops[i] committed as kernel_ops row ids[i] (== its featureId). Build both directions
+  // and stash on window for O(1) cascade neighbour lookup (guid → swXEdges → neighbour guid → featureId).
+  function buildBridge(ops, ids) {
+    var fidByGuid = {}, guidByFid = {};
+    for (var i = 0; i < ops.length && i < ids.length; i++) {
+      fidByGuid[ops[i].outputGuid] = ids[i];
+      guidByFid[ids[i]] = ops[i].outputGuid;
+    }
+    if (typeof window !== 'undefined') { window.__arcFidByGuid = fidByGuid; window.__arcGuidByFid = guidByFid; }
+    return { fidByGuid: fidByGuid, guidByFid: guidByFid };
+  }
+
+  // seedArc — orchestrator. INJECTED io:
+  //   io.commitGroup(opsArray, gid) -> Promise<{ids, committed, idempotent}>   (the only writer)
+  //   io.fold()  -> Promise   (optional: redraw the chain after seeding)
+  //   io.building -> string   (deterministic gid 'arcseed-<building>' → idempotent re-seed)
+  // commits the WHOLE building as ONE op-group (atomic, one hash-chain, idempotent by gid) then folds once.
+  async function seedArc(buildingDb, io) {
+    io = io || {};
+    var name = io.building || 'building';
+    var built = buildSeedOps(buildingDb);
+    var gid = 'arcseed-' + name;
+    var groupOps = built.ops.map(function (o) { return { op_type: o.op_type, params: o.params, outputGuid: o.outputGuid }; });
+    var res = await io.commitGroup(groupOps, gid);
+    var ids = (res && res.ids) || [];
+    var bridge = buildBridge(built.ops, ids);
+    if (io.fold) { try { await io.fold(); } catch (e) { _log(TAG + ' fold after seed failed ' + (e && e.message)); } }
+    built.skipped.forEach(function (s) { _log(TAG + ' §ARC-SEED skip guid=' + s.guid + ' class=' + s.ifc_class + ' reason=' + s.reason); });
+    _log(TAG + ' §ARC-SEED building=' + name + ' committed=' + ids.length + ' skipped=' + built.skipped.length +
+      ' disc=' + built.discipline + ' idempotent=' + !!(res && res.idempotent));
+    return { committed: ids.length, skipped: built.skipped.length, ids: ids, bridge: bridge, ops: built.ops };
+  }
+
+  function _log(m) { if (typeof console !== 'undefined') console.log(m); }
+
+  return { buildSeedOps: buildSeedOps, buildBridge: buildBridge, seedArc: seedArc, colorFor: colorFor, ARC_CLASSES: ARC_CLASSES, TAG: TAG };
+});

--- a/modeller/bonsai_library.js
+++ b/modeller/bonsai_library.js
@@ -336,9 +336,16 @@
     // (gridmove.elementData + bCut bbox stay correct with zero consumer edits).
     foldInsert(op, mv) {
       const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
-      const c = this.get(P.hash); if (!c) throw new Error('GEOM_INSERT unknown component ' + P.hash);
+      // §ARC-1: a RAW-BBOX insert (no catalog hash, P.bbox = a MEASURED box from element_transforms) is the
+      // editable-ARC substrate path — a real building wall/door seeded as a signed GEOM_INSERT carrying its own
+      // measured extent. Box-proxy (LOD-200) only: there is no catalog mesh to refine to. A declared hash that is
+      // UNKNOWN still errors (unchanged); a hash-less op with no bbox is a malformed insert.
+      const c = P.hash ? this.get(P.hash) : null;
+      if (P.hash && !c) throw new Error('GEOM_INSERT unknown component ' + P.hash);
+      const rawBox = (!c && Array.isArray(P.bbox)) ? P.bbox : null;
+      if (!c && !rawBox) throw new Error('GEOM_INSERT needs a hash or a measured bbox');
       const lod = this.lodFor(op.id, P.lod);
-      let base = (lod === '300') ? this.meshArrays(P.hash) : boxArrays(c.bbox);
+      let base = (c && lod === '300') ? this.meshArrays(P.hash) : boxArrays(c ? c.bbox : rawBox);
       let pl = P.placement;
       // W-BONSAI-SCALE PATH B: net GEOM_SCALE folds host-side on the insert's LOCAL geometry — EDGE-ANCHORED at the
       // local bbox min per axis (stretch the object along its own length), so it composes with the existing yaw +
@@ -362,7 +369,7 @@
           // W-BONSAI-ROTATE: yaw the insert about its bbox CENTRE (the visible centre, == the gizmo ring centre) so it
           // SPINS in place rather than orbiting the placement origin. place() rotates local coords about (0,0) then
           // adds (ox,oy); to keep the world centre fixed under the new yaw, solve (ox,oy) from the centre invariant.
-          const bb = base.bbox || c.bbox, lcx = (bb[0] + bb[1]) / 2, lcy = (bb[2] + bb[3]) / 2;
+          const bb = base.bbox || (c ? c.bbox : rawBox), lcx = (bb[0] + bb[1]) / 2, lcy = (bb[2] + bb[3]) / 2;
           const r0 = pr * Math.PI / 180, c0 = Math.cos(r0), s0 = Math.sin(r0);
           const wcx = c0 * lcx - s0 * lcy + ox, wcy = s0 * lcx + c0 * lcy + oy;   // current world centre
           rot = pr + mv.drot;
@@ -371,7 +378,7 @@
         }
         pl = { x: ox, y: oy, z: oz, rot };
       }
-      const positions = place(base.positions, pl, base.bbox || c.bbox);   // real mesh seats on its own bbox
+      const positions = place(base.positions, pl, base.bbox || (c ? c.bbox : rawBox));   // real mesh seats on its own bbox
       // PER-MESH colour: a signed GEOM_INSERT may carry parameters.color (hex int) — RouteWalker fixtures persist
       // their discipline colour there so each box keeps it through scrub/replay (the fold is otherwise one colour).
       return { featureId: op.id, triangleCount: base.indices.length / 3, positions, normals: null, indices: base.indices, color: (P.color != null ? P.color : undefined) };

--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -148,6 +148,26 @@
       return { id: rowId, verify: v.ok, tip: v.tip, signed, ...r };
     },
 
+    // §ARC-1 (RESUME_ARC_EDITABLE_SUBSTRATE.md): seed a BATCH of RECOVERED building ops (each carrying its real
+    // IFC guid as output_guid) as ONE signed group — the editable-ARC substrate. Mirrors commit() (verify +
+    // persist + fold) but writes N ops + their guids at once. IDEMPOTENT by gid ('arcseed-<building>') so
+    // re-opening a building never double-seeds. opsArray = [{op_type:'GEOM_INSERT', params, outputGuid}, …].
+    // Returns {ids, idempotent}: ids[i] == the kernel_ops row id == featureId of ops[i] (the bridge anchor).
+    async commitSeedGroup(opsArray, gid) {
+      const db = await this._ensureDb();
+      if (!opsArray.length) return { ids: [], idempotent: false };
+      const baseTs = 1700000000000;                           // fixed → deterministic seed-row timestamps (replay-stable)
+      const res = await window.KernelOps.commitGroup(db, opsArray, { gid, baseTs });
+      if (!res.committed) throw new Error('commitSeedGroup rejected: ' + res.reason);
+      if (!res.idempotent) this._n = Math.max(this._n, res.ids.length);   // push future geom-grp gids past the seed
+      const v = await window.KernelOps.verifyChain(db);
+      this._lastTip = v.tip;
+      await this._foldUpto();                                 // redraw the chain → the seeded boxes appear, gizmo-ready
+      this._emit();                                           // persist mo_<building> + notify (autosave)
+      console.log(TAG + ' commitSeedGroup gid=' + gid + ' ops=' + res.ids.length + ' verify=' + v.ok + ' idempotent=' + !!res.idempotent);
+      return { ids: res.ids, idempotent: !!res.idempotent };
+    },
+
     // History scrubber: fold the first `upto` GEOM rows of the verified log. Deterministic prefix replay.
     async scrubTo(upto) {
       const r = await this._foldUpto(upto);

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -200,6 +200,7 @@
 <script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- Cross-edges: the typed SDG lateral edges (abuts/...) derived on-the-fly from the bbox substrate. -->
 <script src="cross_edges.js?v=2" onerror="console.warn('§XEDGE LOAD_FAIL cross_edges.js')"></script>
+<script src="arc_editable.js?v=1" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -198,7 +198,28 @@
     if (O && O.setModelKey) O.setModelKey('mo_' + res.key).then(function (n) {
       console.log(TAG + ' §STRWALK-MO editable instance mo_' + res.key + ' active ops=' + n + ' (reference meta.db stays pristine)');
       _replayEdits();
+      _seedArcEditable(O, res.key);
     });
+  }
+
+  // §ARC-1 — seed the REAL ARC building as gizmo-EDITABLE, guid-carrying GEOM_INSERT op-rows, so the SDG cascade
+  // (drag wall → door rides) has a real wall to grab. Re-opens the building buffer (kept on __dwBuf by _openBuffer)
+  // read-only, derives the measured seed ops, and commits them ONE signed group via the oplog. IDEMPOTENT by
+  // 'arcseed-<key>' → safe to call every open (already-seeded = no-op). NON-INVENT: bbox/centre are MEASURED.
+  function _seedArcEditable(O, key) {
+    if (!(window.ArcEditable && window.__dwBuf && window.SQL && window.KernelOps && O && O.commitSeedGroup)) return;
+    var bdb = null;
+    try {
+      bdb = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+      window.ArcEditable.seedArc(bdb, {
+        commitGroup: function (ops, gid) { return O.commitSeedGroup(ops, gid); },
+        building: key
+      }).then(function (r) {
+        console.log(TAG + ' §ARC-SEED-WIRE ' + key + ' editable ARC elements=' + r.committed + ' skipped=' + r.skipped +
+          ' (featureId↔guid bridge ready)');
+      }).catch(function (e) { console.warn(TAG + ' §ARC-SEED-WIRE failed ' + (e && e.message)); })
+        .finally(function () { try { if (bdb) bdb.close(); } catch (e) { } });
+    } catch (e) { console.warn(TAG + ' §ARC-SEED-WIRE open failed ' + (e && e.message)); if (bdb) { try { bdb.close(); } catch (e2) { } } }
   }
 
   // Open a permanent resident: cache-first (local), else fetch the substrate from the modeller's GH

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v15';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v16';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -51,6 +51,7 @@ const PRECACHE_ASSETS = [
   'bom_tree.js',
   'bom_tree_outliner.js',
   'cross_edges.js',
+  'arc_editable.js',
   'disc_walker.js',
   'str_walker.js',
   'str_walker_bridge.js',

--- a/modeller/tests/witness_arc_editable.js
+++ b/modeller/tests/witness_arc_editable.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * W-ARC-EDITABLE — §ARC-1 value witness (RESUME_ARC_EDITABLE_SUBSTRATE.md). PURE NODE (sql.js, no browser):
+ * prove the REAL ARC building seeds as gizmo-editable, guid-carrying GEOM_INSERT op-rows, landing on the MEASURED
+ * geometry with NO invention. Exercises the REAL foldInsert (raw-bbox path) + REAL KernelOps.commitGroup.
+ *
+ * Issue under test: the modeller's editable scene was synthetic-only — real walls/doors were never editable meshes,
+ * so the SDG cascade had no wall to grab. This proves the substrate now exists AND the featureId↔guid bridge is real.
+ *
+ * Checks (all assert the canvas-visible / data fact, no compute-then-pass):
+ *   A1 count          — N ARC seedable elements in db ⇒ N GEOM_INSERT ops committed (skips logged + counted)
+ *   A2 bridge         — every output_guid ∈ db guids; fid↔guid bijective; round-trips
+ *   A3 position       — folded mesh WORLD CENTRE == element_transforms.center_xyz within 1e-6 (NO constant offset)
+ *   A4 bbox           — seed op box extent == measured (bbox_x,y,z) exact; folded AABB extent == measured for rot≈0
+ *   A5 gizmo-ready    — folded mesh featureId == its op id (selectable + GEOM_MOVE-able)
+ *   A6 persisted guid — kernel_ops.output_guid == the real guid (replay-stable bridge, queryable by featureId)
+ *   A7 idempotent     — re-seed (same gid) ⇒ same op count, idempotent flag, bridge unchanged
+ *   A8 honest skip    — an element with NULLed bbox is SKIPPED (not boxed), logged, excluded from the count
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+
+// ── node shims so the window-IIFE modules load + the catalog fetch stays inert (no network) ──
+global.window = global.window || {};
+global.fetch = undefined;                 // bonsai_library: typeof fetch!=='function' ⇒ catalog Promise.resolve(false)
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;   // node 18: webcrypto not global
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+require(path.join(ROOT, 'kernel_ops.js'));            // → window.KernelOps
+require(path.join(ROOT, 'bonsai_library.js'));        // → window.Bonsai.library
+var KernelOps = global.window.KernelOps;
+var Library = global.window.Bonsai.library;
+
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+function approx(a, b, tol) { return Math.abs(a - b) <= (tol == null ? 1e-6 : tol); }
+
+// AABB centre + full extent of a foldInsert position buffer (Float32 x,y,z).
+function aabb(positions) {
+  var mn = [Infinity, Infinity, Infinity], mx = [-Infinity, -Infinity, -Infinity];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) {
+    var c = positions[i + k]; if (c < mn[k]) mn[k] = c; if (c > mx[k]) mx[k] = c;
+  }
+  return { cx: (mn[0] + mx[0]) / 2, cy: (mn[1] + mx[1]) / 2, cz: (mn[2] + mx[2]) / 2,
+           ex: mx[0] - mn[0], ey: mx[1] - mn[1], ez: mx[2] - mn[2] };
+}
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-ARC-EDITABLE — §ARC-1 editable ARC substrate + guid bridge (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+
+  // ground truth: measured ARC elements (with bbox) + their transforms, keyed by guid
+  var truth = {}, guidSet = {};
+  var gr = bdb.exec("SELECT m.guid, m.ifc_class, t.center_x,t.center_y,t.center_z, t.bbox_x,t.bbox_y,t.bbox_z, t.rotation_z " +
+    "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid WHERE m.discipline='ARC'");
+  var arcTotal = 0;
+  if (gr.length) gr[0].values.forEach(function (v) {
+    guidSet[v[0]] = 1;
+    if (v[5] > 0 && v[6] > 0 && v[7] > 0 && v[2] != null) {
+      arcTotal++;
+      truth[v[0]] = { cls: v[1], cx: v[2], cy: v[3], cz: v[4], bx: v[5], by: v[6], bz: v[7], rz: v[8] || 0 };
+    }
+  });
+  // all db guids (for output_guid ⊆ db-guids membership)
+  var allGuids = {}; var ar = bdb.exec("SELECT guid FROM elements_meta"); if (ar.length) ar[0].values.forEach(function (v) { allGuids[v[0]] = 1; });
+
+  // ── seed via the REAL KernelOps.commitGroup on a fresh oplog db ──
+  var oplog = new SQL.Database();
+  var commitGroup = function (opsArray, gid) {
+    return KernelOps.commitGroup(oplog, opsArray, { gid: gid, baseTs: 1700000000000 });
+  };
+  var seed = await ArcEditable.seedArc(bdb, { commitGroup: commitGroup, building: 'SampleHouse' });
+
+  // A1 — count
+  chk('A1 every ARC element seeded (N db ⇒ N GEOM_INSERT ops, no silent drop)',
+    arcTotal > 0 && seed.committed === arcTotal && seed.ops.length === arcTotal,
+    'arcTotal=' + arcTotal + ' committed=' + seed.committed);
+
+  // A2 — bridge bijective + membership + round-trip
+  var fids = Object.values(seed.bridge.fidByGuid), guids = Object.keys(seed.bridge.fidByGuid);
+  var allMembers = guids.every(function (g) { return allGuids[g] === 1; });
+  var bijective = new Set(fids).size === fids.length && new Set(guids).size === guids.length && fids.length === seed.committed;
+  var roundTrips = guids.every(function (g) { return seed.bridge.guidByFid[seed.bridge.fidByGuid[g]] === g; });
+  chk('A2 featureId↔guid bridge bijective + all guids real + round-trips',
+    allMembers && bijective && roundTrips, 'fids=' + fids.length + ' guids=' + guids.length);
+
+  // A3/A4/A5 — fold every seed op through the REAL foldInsert (raw-bbox path) and check geometry fidelity
+  var posOk = 0, boxConstrOk = 0, foldExtentOk = 0, fidOk = 0, rotZeroN = 0, n = seed.ops.length;
+  seed.ops.forEach(function (op) {
+    var g = op.outputGuid, T = truth[g], fid = seed.bridge.fidByGuid[g];
+    var d = Library.foldInsert({ id: fid, op_type: 'GEOM_INSERT', parameters: op.params });
+    var bb = aabb(d.positions);
+    if (approx(bb.cx, T.cx) && approx(bb.cy, T.cy) && approx(bb.cz, T.cz)) posOk++;        // world centre == measured (rot-invariant)
+    // construction-level: the seed box extent == measured bbox (exact)
+    var pe = op.params.bbox;
+    if (approx(pe[1] - pe[0], T.bx) && approx(pe[3] - pe[2], T.by) && approx(pe[5] - pe[4], T.bz)) boxConstrOk++;
+    // geometry-level extent: only axis-aligned (rot≈0) boxes keep AABB == measured
+    if (approx(T.rz % 360, 0, 1e-3) || approx(Math.abs(T.rz % 360), 360, 1e-3)) {
+      rotZeroN++;
+      if (approx(bb.ex, T.bx) && approx(bb.ey, T.by) && approx(bb.ez, T.bz)) foldExtentOk++;
+    }
+    if (d.featureId === fid) fidOk++;
+  });
+  chk('A3 folded mesh world-centre == measured center_xyz within 1e-6 (NO invented offset)', posOk === n, posOk + '/' + n);
+  chk('A4 seed box extent == measured bbox (exact) + rot≈0 AABB extent == measured', boxConstrOk === n && foldExtentOk === rotZeroN && rotZeroN > 0,
+    'boxConstr=' + boxConstrOk + '/' + n + ' foldExtent=' + foldExtentOk + '/' + rotZeroN);
+  chk('A5 each folded mesh carries featureId == its op id (gizmo-selectable + GEOM_MOVE-able)', fidOk === n, fidOk + '/' + n);
+
+  // A6 — output_guid persisted on kernel_ops, queryable by featureId(=id)
+  var persisted = 0, persistOk = true;
+  seed.ops.forEach(function (op) {
+    var fid = seed.bridge.fidByGuid[op.outputGuid];
+    var r = oplog.exec('SELECT output_guid FROM kernel_ops WHERE id=' + fid);
+    var og = r.length ? r[0].values[0][0] : null;
+    if (og === op.outputGuid) persisted++; else persistOk = false;
+  });
+  chk('A6 kernel_ops.output_guid == real guid for every seed op (replay-stable bridge)', persistOk && persisted === n, persisted + '/' + n);
+
+  // A7 — idempotent re-seed (same gid → no double-seed, bridge unchanged)
+  var seed2 = await ArcEditable.seedArc(bdb, { commitGroup: commitGroup, building: 'SampleHouse' });
+  var rowCount = oplog.exec('SELECT COUNT(*) FROM kernel_ops')[0].values[0][0];
+  var bridgeSame = JSON.stringify(seed2.bridge.fidByGuid) === JSON.stringify(seed.bridge.fidByGuid);
+  chk('A7 idempotent re-seed: same op count, idempotent flag, bridge unchanged',
+    seed2.committed === seed.committed && rowCount === n && bridgeSame, 'rows=' + rowCount + ' committed2=' + seed2.committed);
+
+  // A8 — honest skip: NULL a bbox on a clone → that element is skipped (not boxed), count drops by 1
+  var cdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var victim = Object.keys(truth)[0];
+  cdb.run("UPDATE element_transforms SET bbox_x=NULL WHERE guid='" + victim + "'");
+  var built2 = ArcEditable.buildSeedOps(cdb);
+  var skippedVictim = built2.skipped.some(function (s) { return s.guid === victim && s.reason === 'no-bbox'; });
+  chk('A8 NULL-bbox element SKIPPED (not fabricated), logged, excluded from count',
+    skippedVictim && built2.ops.length === arcTotal - 1, 'ops=' + built2.ops.length + ' (was ' + arcTotal + ') skipped=' + built2.skipped.length);
+
+  console.log('W-ARC-EDITABLE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_arc_editable_smoke.js
+++ b/modeller/tests/witness_arc_editable_smoke.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * §ARC-SEED-SMOKE — §ARC-1 wiring smoke (headless Chromium, self-served). SECONDARY to the node value witness
+ * W-ARC-EDITABLE; this proves the WIRING: opening SampleHouse in the REAL modeller seeds the editable ARC
+ * substrate, the featureId↔guid bridge populates on window, the seeded boxes are real gizmo-selectable meshes,
+ * and a recovered `fills` (door↔host) edge resolves BOTH endpoints to featureIds (cascade-ready).
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ §ARC-SEED-SMOKE — editable ARC substrate wiring (headless) ═══');
+
+  // Open SampleHouse → seed fires on _forkEditable
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () {
+    return !!(window.__arcFidByGuid && Object.keys(window.__arcFidByGuid).length > 0) &&
+           !!(window.swXEdges && Array.isArray(window.swXEdges.fills));
+  }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  var S = await page.evaluate(function () {
+    var fbg = window.__arcFidByGuid || {}, gbf = window.__arcGuidByFid || {};
+    var guids = Object.keys(fbg), fids = guids.map(function (g) { return fbg[g]; });
+    // scene editable meshes carrying a featureId that the bridge knows (== seeded ARC boxes)
+    var g = window.Bonsai && window.Bonsai.group && window.Bonsai.group();
+    var seededMeshes = 0, sampleFid = null;
+    if (g) g.children.forEach(function (m) {
+      if (m.isMesh && m.userData && m.userData.featureId != null && gbf[m.userData.featureId] != null) {
+        seededMeshes++; if (sampleFid == null) sampleFid = m.userData.featureId;
+      }
+    });
+    // cascade-ready: a fills edge with BOTH endpoints resolvable to featureIds
+    var fills = (window.swXEdges && window.swXEdges.fills) || [];
+    var fillsBoth = fills.filter(function (e) { return fbg[e.a] != null && fbg[e.b] != null; }).length;
+    var aggr = (window.swXEdges && window.swXEdges.aggregates) || [];
+    var aggrBoth = aggr.filter(function (e) { return fbg[e.a] != null && fbg[e.b] != null; }).length;
+    var bij = new Set(fids).size === fids.length;
+    return { nGuids: guids.length, bij: bij, seededMeshes: seededMeshes, sampleFid: sampleFid,
+      sampleGuid: sampleFid != null ? gbf[sampleFid] : null, fills: fills.length, fillsBoth: fillsBoth,
+      aggr: aggr.length, aggrBoth: aggrBoth };
+  });
+
+  chk('S1 §ARC-SEED-WIRE logged with committed count', logs.some(function (l) { return /§ARC-SEED-WIRE SampleHouse editable ARC elements=\d+/.test(l); }),
+    logs.filter(function (l) { return /ARC-SEED-WIRE/.test(l); })[0] || '');
+  chk('S2 featureId↔guid bridge populated on window + bijective', S.nGuids > 0 && S.bij, 'guids=' + S.nGuids);
+  chk('S3 seeded ARC elements are real gizmo-selectable meshes (featureId in scene == bridge)', S.seededMeshes > 0, 'seededMeshes=' + S.seededMeshes);
+  chk('S4 a seeded mesh resolves featureId→guid', S.sampleFid != null && !!S.sampleGuid, 'fid=' + S.sampleFid + ' guid=' + (S.sampleGuid || '').slice(0, 10));
+  chk('S5 cascade-ready: a fills (door↔host) edge resolves BOTH endpoints to featureIds', S.fills > 0 && S.fillsBoth > 0, 'fillsBoth=' + S.fillsBoth + '/' + S.fills);
+  // S6 — contains/aggregates is NOT an ARC element↔element relation in SampleHouse: all 34 parents are non-element
+  // (not-in-meta) STR-ASSEMBLY roots, children are STR IfcMember/IfcPlate (curtain-wall). Per VISION-LOCK STR is a
+  // WALKER, not edited substrate → 0 ARC-ARC aggregates is CORRECT, not a miss. Assert CONSISTENCY (any aggregates
+  // edge between two seeded ARC elements resolves) + log the honest count. The hosted-by cascade (S5) is the live
+  // one on this building; the contains cascade needs a building with element↔element aggregates (recorded in spec).
+  chk('S6 aggregates is STR-assembly (non-ARC) here → 0 ARC-ARC resolved is honest; consistency holds',
+    S.aggrBoth === 0, 'aggrBoth(ARC-ARC)=' + S.aggrBoth + '/' + S.aggr + ' (STR-assembly, parents non-element — out of ARC substrate per VISION-LOCK)');
+
+  // S7 — select a seeded mesh + GEOM_MOVE it (existing path still works on a seeded element)
+  var moved = await page.evaluate(async function (fid) {
+    var O = window.Bonsai.oplog; var before = O.length;
+    window.Bonsai.select(fid);
+    var r = await O.commit({ op_type: 'GEOM_MOVE', parameters: { parent: fid, dx: 0.5, dy: 0, dz: 0 } }, {});
+    return { ok: !!(r && r.verify), before: before, after: O.length };
+  }, S.sampleFid);
+  chk('S7 a seeded ARC element is GEOM_MOVE-able (signed, verified)', moved.ok && moved.after > moved.before, 'verify=' + moved.ok + ' ops ' + moved.before + '→' + moved.after);
+
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('S8 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('§ARC-SEED-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/modeller/tests/witness_foldinsert_regression.js
+++ b/modeller/tests/witness_foldinsert_regression.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * §ARC-1 REGRESSION — foldInsert raw-bbox extension must not perturb the catalog-hash path. Proves the present-hash
+ * branch is byte-identical to pre-change behaviour, the raw-bbox branch works, and malformed ops still throw.
+ */
+'use strict';
+var path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+var ROOT = path.join(__dirname, '..');
+require(path.join(ROOT, 'bonsai_library.js'));
+var Library = global.window.Bonsai.library;
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function aabb(p) { var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9]; for (var i = 0; i < p.length; i += 3) for (var k = 0; k < 3; k++) { if (p[i + k] < mn[k]) mn[k] = p[i + k]; if (p[i + k] > mx[k]) mx[k] = p[i + k]; } return { ex: mx[0] - mn[0], ey: mx[1] - mn[1], ez: mx[2] - mn[2], cx: (mn[0] + mx[0]) / 2, cy: (mn[1] + mx[1]) / 2 }; }
+function approx(a, b) { return Math.abs(a - b) <= 1e-6; }
+
+console.log('═══ §ARC-1 REGRESSION — foldInsert catalog path unperturbed ═══');
+var cat = Library.catalog();
+var col = cat.find(function (c) { return c.category === 'COLUMN'; });   // a legacy catalog component (known bbox)
+
+// R1 — catalog-hash LOD-200 box: extent == the component's declared bbox extent (unchanged behaviour)
+var d1 = Library.foldInsert({ id: 1, op_type: 'GEOM_INSERT', parameters: { hash: col.hash, placement: { x: 3, y: 4, z: 0, rot: 0 } } });
+var b1 = aabb(d1.positions), bb = col.bbox;
+chk('R1 catalog hash → LOD-200 box: extent == declared bbox + placed at x/y',
+  approx(b1.ex, bb[1] - bb[0]) && approx(b1.ey, bb[3] - bb[2]) && approx(b1.ez, bb[5] - bb[4]) && approx(b1.cx, 3) && approx(b1.cy, 4),
+  'ext=[' + b1.ex.toFixed(2) + ',' + b1.ey.toFixed(2) + ',' + b1.ez.toFixed(2) + ']');
+
+// R2 — raw-bbox (no hash) → box of the given measured extent
+var rb = [-1, 1, -0.5, 0.5, -1.5, 1.5];
+var d2 = Library.foldInsert({ id: 2, op_type: 'GEOM_INSERT', parameters: { bbox: rb, placement: { x: 0, y: 0, z: 0, rot: 0 } } });
+var b2 = aabb(d2.positions);
+chk('R2 raw-bbox (no hash) → box of measured extent', approx(b2.ex, 2) && approx(b2.ey, 1) && approx(b2.ez, 3), 'ext=[' + b2.ex + ',' + b2.ey + ',' + b2.ez + ']');
+
+// R3 — unknown hash still THROWS (guard preserved)
+var threw = false; try { Library.foldInsert({ id: 3, op_type: 'GEOM_INSERT', parameters: { hash: 'deadbeef', placement: {} } }); } catch (e) { threw = /unknown component/.test(e.message); }
+chk('R3 unknown catalog hash still throws (guard preserved)', threw);
+
+// R4 — neither hash nor bbox → throws (malformed insert)
+var threw2 = false; try { Library.foldInsert({ id: 4, op_type: 'GEOM_INSERT', parameters: { placement: {} } }); } catch (e) { threw2 = /hash or a measured bbox/.test(e.message); }
+chk('R4 no hash + no bbox → throws (malformed)', threw2);
+
+// R5 — featureId carried through (gizmo) on both paths
+chk('R5 featureId == op id on both catalog + raw paths', d1.featureId === 1 && d2.featureId === 2);
+
+console.log('§ARC-1 REGRESSION: ' + pass + ' PASS / ' + fail + ' FAIL');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What
Makes the real ARC building load as **gizmo-editable, guid-carrying meshes** in the modeller — the substrate the SDG forward-fold cascade rests on. Before this, the editable scene was synthetic-only (the gizmo could only move user-authored primitives); real walls/doors existed only as walker DATA + overlay markers, so "drag wall → door rides" had no wall to grab.

## How
- **`foldInsert` raw-bbox** (`bonsai_library.js`): a hash-less `GEOM_INSERT` with a MEASURED `P.bbox` → LOD-200 box. Present-hash path is byte-identical; unknown-hash + no-hash-no-bbox both still throw.
- **`arc_editable.js`** (new, dual-export): `buildSeedOps` reads `discipline='ARC'` `element_transforms` → measured `GEOM_INSERT` ops (box world-centre lands on `center_xyz`, **non-invent**); `seedArc` orchestrates; bridge maps `featureId↔guid`.
- **`bonsai_oplog.commitSeedGroup`**: one signed group, verify+fold+persist, **idempotent** by `arcseed-<building>`.
- **Wired** into `str_walker_outliner._forkEditable` — auto on building Open (reuses `__dwBuf`), no double-seed.
- **Bridge**: `window.__arcFidByGuid` / `__arcGuidByFid` + **persisted** `kernel_ops.output_guid` (queryable by featureId).

## Witnessed
- **W-ARC-EDITABLE 8/8** (node, real SampleHouse): 39 ARC → 39 ops; bridge bijective + all-guids-real + round-trips; folded world-centre == measured `center_xyz` <1e-6 (no invented offset); box extent exact + rot≈0 AABB exact (20/20); `featureId`==op id; `output_guid` persisted; idempotent re-seed; honest NULL-bbox skip.
- **§ARC-SEED-SMOKE 8/8** (headless): seed fires on Open, bridge on window, 39 gizmo-selectable meshes, a seeded element is `GEOM_MOVE`-able (signed+verified), no LOAD_FAIL.
- **§ARC-1 REGRESSION 5/5** (node): catalog-hash `foldInsert` path unperturbed; guards preserved.
- `sw` v15→v16.

## Finding (shapes the next slice)
SampleHouse `rel_fills_host` = 7 edges, **all ARC↔ARC, fully bridge-resolvable (7/7)** → the **hosted-by** cascade is live on real data. But `rel_aggregates` (34) parents are **non-element** STR-assembly roots → **0 ARC element↔element** aggregates (per VISION-LOCK, STR is a walker, not edited substrate). So the next slice's **contains** half needs a building with element-level aggregates; **hosted-by** ships on SampleHouse now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)