### PR TITLE
§SDG-CASCADE: hosted-by ride (drag wall → door rides) in the modeller

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -201,6 +201,7 @@
 <!-- Cross-edges: the typed SDG lateral edges (abuts/...) derived on-the-fly from the bbox substrate. -->
 <script src="cross_edges.js?v=2" onerror="console.warn('§XEDGE LOAD_FAIL cross_edges.js')"></script>
 <script src="arc_editable.js?v=1" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
+<script src="sdg_cascade.js?v=1" onerror="console.warn('§SDG LOAD_FAIL sdg_cascade.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
@@ -1426,7 +1427,18 @@ async function commitMove(dx, dy, dz) {
       lastVerify = res.verify;
       console.log('§MOVE commit dx=' + dx.toFixed(3) + ' dy=' + dy.toFixed(3) + ' dz=' + dz.toFixed(3) + ' parent=' + tid + ' verify=' + res.verify);
     }
-    setStat((ids.length > 1 ? ('moved ' + ids.length + ' objects') : ('moved #' + ids[0])) + ' Δ(' + dx.toFixed(2) + ',' + dy.toFixed(2) + ',' + dz.toFixed(2) + ')  verify=' + lastVerify);
+    // §SDG-CASCADE (W-SDG-CASCADE-MODELLER): a moved HOST drags its hosted FILLINGS (door/window rides the wall),
+    // resolved through the §ARC-1 featureId↔guid bridge over REAL rel_fills_host edges. Same delta = rigid ride
+    // (rosetta-invertible). Directional + one-hop; deduped against the moved set so a co-selected door never double-moves.
+    const riders = (window.SdgCascade && window.swXEdges && window.__arcGuidByFid && window.__arcFidByGuid)
+      ? window.SdgCascade.ridersFor(ids, window.__arcGuidByFid, window.__arcFidByGuid, window.swXEdges.fills, new Set(ids))
+      : [];
+    for (const rfid of riders) {
+      const rr = await window.Bonsai.oplog.commit({ op_type: 'GEOM_MOVE', parameters: { parent: rfid, dx, dy, dz, induced: 'hosted-by' } }, {});
+      console.log('§SDG-CASCADE hosted-by rider=' + rfid + ' rides host-move dx=' + dx.toFixed(3) + ' dy=' + dy.toFixed(3) + ' dz=' + dz.toFixed(3) + ' verify=' + rr.verify);
+    }
+    if (riders.length) console.log('§SDG-CASCADE hosted-by hosts=' + ids.length + ' riders=' + riders.length);
+    setStat((ids.length > 1 ? ('moved ' + ids.length + ' objects') : ('moved #' + ids[0])) + (riders.length ? (' +' + riders.length + ' hosted') : '') + ' Δ(' + dx.toFixed(2) + ',' + dy.toFixed(2) + ',' + dz.toFixed(2) + ')  verify=' + lastVerify);
     audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     window.Bonsai.selectMany(ids); clearMoveGhost();      // re-fold replaced the meshes → always re-grab fresh refs (no stale)
     if (moving) buildMoveGizmo();                         // reposition the gizmo on the moved selection (move mode only)

--- a/modeller/sdg_cascade.js
+++ b/modeller/sdg_cascade.js
@@ -1,0 +1,41 @@
+// sdg_cascade.js — §SDG-CASCADE (W-SDG-CASCADE-MODELLER): the HOSTED-BY ride, the SDG forward-fold cascade in the
+// modeller. When a HOST (wall) moves, its hosted FILLINGS (door/window) ride by the SAME delta — resolved through
+// the §ARC-1 featureId↔guid bridge over the REAL rel_fills_host edges (window.swXEdges.fills). See
+// RESUME_ARC_EDITABLE_SUBSTRATE.md "slice (2)" + SPATIAL_DEPENDENCY_GRAPH.md §FORWARD.
+//
+// DIRECTIONAL: a host drags its fillings; a filling does NOT drag its host (you can slide a door without dragging
+// the wall). ONE HOP (wall→door; doors are never hosts). PURE RIGID TRANSLATION by the host's delta → the door's
+// offset to the wall is invariant → rosetta-invertible (apply −delta recovers the original; 0.000mm round-trip).
+// NON-INVENT: rides only on edges the extractor recovered (provenance ifc:recovered); fabricates no relationship.
+//
+// Dual-export (window + node) like arc_editable.js / cross_edges.js, so the value witness runs pure-node.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.SdgCascade = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+
+  // ridersFor(movedFids, guidByFid, fidByGuid, fills, movedSet?) → [riderFid]
+  //   the hosted FILLINGS of the moved HOSTS, deduped, excluding anything already in the moved set. Pure.
+  //   guidByFid: featureId → guid (window.__arcGuidByFid)   fidByGuid: guid → featureId (window.__arcFidByGuid)
+  //   fills: window.swXEdges.fills rows {host_guid, filling_guid, …}
+  function ridersFor(movedFids, guidByFid, fidByGuid, fills, movedSet) {
+    var out = [], seen = {};
+    if (!Array.isArray(movedFids) || !guidByFid || !fidByGuid || !Array.isArray(fills)) return out;
+    movedSet = movedSet || new Set(movedFids);
+    for (var i = 0; i < movedFids.length; i++) {
+      var g = guidByFid[movedFids[i]];
+      if (g == null) continue;                                  // a moved synthetic primitive (no guid) → no ride
+      for (var j = 0; j < fills.length; j++) {
+        var e = fills[j];
+        if (e.host_guid === g && e.filling_guid != null) {      // the moved element IS the host → its filling rides
+          var rfid = fidByGuid[e.filling_guid];
+          if (rfid != null && !movedSet.has(rfid) && !seen[rfid]) { seen[rfid] = 1; out.push(rfid); }
+        }
+      }
+    }
+    return out;
+  }
+
+  return { ridersFor: ridersFor };
+});

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v16';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v17';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -52,6 +52,7 @@ const PRECACHE_ASSETS = [
   'bom_tree_outliner.js',
   'cross_edges.js',
   'arc_editable.js',
+  'sdg_cascade.js',
   'disc_walker.js',
   'str_walker.js',
   'str_walker_bridge.js',

--- a/modeller/tests/witness_sdg_cascade.js
+++ b/modeller/tests/witness_sdg_cascade.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * W-SDG-CASCADE-MODELLER — §SDG-CASCADE value witness (PURE NODE, REAL SampleHouse). The hosted-by ride: a moved
+ * HOST (wall) drags its hosted FILLINGS (door/window) by the SAME delta, over the REAL rel_fills_host edges
+ * resolved through the §ARC-1 featureId↔guid bridge. Exercises the REAL foldInsert (the ride math) + CrossEdges
+ * (the real edges) + ArcEditable (the bridge).
+ *
+ * Issue under test: before slice (2), dragging a wall left its doors behind (cascade was a no-op). Proves the
+ * door now RIDES, rigidly, only on recovered edges, invertibly (rosetta 0.000mm).
+ *
+ *   C1 directional  — ridersFor(host) includes its filling; ridersFor(filling) is EMPTY (a door never drags its wall)
+ *   C2 all fillings — a wall with k fillings ⇒ all k ride; deduped; a moved filling never double-rides
+ *   C3 rigid ride   — under delta d, foldInsert centre of host AND rider each shift by EXACTLY d (no drift)
+ *   C4 offset-inv   — (rider − host) centre offset is INVARIANT under the move (rigid body: the door stays in its hole)
+ *   C5 rosetta      — applying −d to the +d fold recovers the original centre within 1e-6 (invertible, 0.000mm)
+ *   C6 non-invent   — every ride edge has provenance 'ifc:recovered'; no rider lacks a real fills edge
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function approx(a, b) { return Math.abs(a - b) <= 1e-6; }
+function centre(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [(mn[0] + mx[0]) / 2, (mn[1] + mx[1]) / 2, (mn[2] + mx[2]) / 2];
+}
+function foldCentre(op, fid, mv) { return centre(Library.foldInsert({ id: fid, op_type: 'GEOM_INSERT', parameters: op.params }, mv || null).positions); }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-SDG-CASCADE-MODELLER — hosted-by ride (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+
+  // seed → ops + bridge (the §ARC-1 substrate); real fills edges from CrossEdges
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var X = CrossEdges.deriveAll(bdb);
+  var fills = X.fills;
+  chk('C0 substrate ready: seed + bridge + real fills edges', seed.committed > 0 && fills.length > 0, 'seeded=' + seed.committed + ' fills=' + fills.length);
+
+  // a fills edge whose BOTH endpoints are seeded (ARC↔ARC) — host=wall, filling=door
+  var edge = fills.find(function (e) { return fbg[e.host_guid] != null && fbg[e.filling_guid] != null; });
+  var hostFid = fbg[edge.host_guid], doorFid = fbg[edge.filling_guid];
+
+  // C1 — directional
+  var ridersOfHost = SdgCascade.ridersFor([hostFid], gbf, fbg, fills, new Set([hostFid]));
+  var ridersOfDoor = SdgCascade.ridersFor([doorFid], gbf, fbg, fills, new Set([doorFid]));
+  chk('C1 host drags its filling; filling does NOT drag its host (directional)',
+    ridersOfHost.indexOf(doorFid) >= 0 && ridersOfDoor.length === 0, 'host→' + ridersOfHost.length + ' door→' + ridersOfDoor.length);
+
+  // C2 — all fillings of a multi-fill host ride; dedupe; moved filling never double-rides
+  var byHost = {}; fills.forEach(function (e) { if (fbg[e.host_guid] != null && fbg[e.filling_guid] != null) (byHost[e.host_guid] = byHost[e.host_guid] || []).push(e.filling_guid); });
+  var bestHost = Object.keys(byHost).sort(function (a, b) { return byHost[b].length - byHost[a].length; })[0];
+  var bestHostFid = fbg[bestHost], expectFillFids = byHost[bestHost].map(function (g) { return fbg[g]; });
+  var ridersBest = SdgCascade.ridersFor([bestHostFid], gbf, fbg, fills, new Set([bestHostFid]));
+  var allRide = expectFillFids.every(function (f) { return ridersBest.indexOf(f) >= 0; }) && ridersBest.length === new Set(ridersBest).size;
+  // co-select the host AND one filling → that filling must NOT appear as an induced rider (already moved)
+  var ridersCo = SdgCascade.ridersFor([bestHostFid, expectFillFids[0]], gbf, fbg, fills, new Set([bestHostFid, expectFillFids[0]]));
+  chk('C2 all k fillings ride; deduped; a co-moved filling never double-rides',
+    allRide && ridersCo.indexOf(expectFillFids[0]) < 0, 'k=' + expectFillFids.length + ' riders=' + ridersBest.length + ' co=' + ridersCo.length);
+
+  // C3/C4/C5 — fold geometry under a delta
+  var d = [1.5, -0.7, 0.3], mv = { dx: d[0], dy: d[1], dz: d[2] };
+  var h0 = foldCentre(opByFid[hostFid], hostFid), r0 = foldCentre(opByFid[doorFid], doorFid);
+  var h1 = foldCentre(opByFid[hostFid], hostFid, mv), r1 = foldCentre(opByFid[doorFid], doorFid, mv);
+  var hostShift = approx(h1[0], h0[0] + d[0]) && approx(h1[1], h0[1] + d[1]) && approx(h1[2], h0[2] + d[2]);
+  var riderShift = approx(r1[0], r0[0] + d[0]) && approx(r1[1], r0[1] + d[1]) && approx(r1[2], r0[2] + d[2]);
+  chk('C3 rigid ride: host AND rider centres each shift by EXACTLY the delta', hostShift && riderShift,
+    'host[' + h0.map(function (x) { return x.toFixed(2); }) + ']→[' + h1.map(function (x) { return x.toFixed(2); }) + ']');
+  var off0 = [r0[0] - h0[0], r0[1] - h0[1], r0[2] - h0[2]], off1 = [r1[0] - h1[0], r1[1] - h1[1], r1[2] - h1[2]];
+  chk('C4 door↔wall offset INVARIANT under the move (door stays in its hole)',
+    approx(off0[0], off1[0]) && approx(off0[1], off1[1]) && approx(off0[2], off1[2]), 'off=[' + off0.map(function (x) { return x.toFixed(3); }) + ']');
+
+  // C5 — rosetta: apply −d to the +d fold → original centre (invertible, 0.000mm)
+  var hBack = [h1[0] - d[0], h1[1] - d[1], h1[2] - d[2]], rBack = [r1[0] - d[0], r1[1] - d[1], r1[2] - d[2]];
+  var maxErr = Math.max(Math.abs(hBack[0] - h0[0]), Math.abs(hBack[1] - h0[1]), Math.abs(hBack[2] - h0[2]),
+    Math.abs(rBack[0] - r0[0]), Math.abs(rBack[1] - r0[1]), Math.abs(rBack[2] - r0[2]));
+  chk('C5 rosetta round-trip: −delta recovers the original (invertible, 0.000mm)', maxErr <= 1e-6, 'maxErr=' + maxErr.toExponential(2) + 'mm');
+
+  // C6 — non-invent: every ride rests on a recovered edge
+  var allRecovered = fills.every(function (e) { return e.provenance === 'ifc:recovered'; });
+  var ridersAllHaveEdge = ridersBest.every(function (rf) {
+    var g = gbf[rf]; return fills.some(function (e) { return e.filling_guid === g && e.host_guid === bestHost; });
+  });
+  chk('C6 non-invent: every fills edge is ifc:recovered + every rider has a real edge', allRecovered && ridersAllHaveEdge);
+
+  console.log('W-SDG-CASCADE-MODELLER: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_sdg_cascade_smoke.js
+++ b/modeller/tests/witness_sdg_cascade_smoke.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * §SDG-CASCADE-SMOKE — wiring smoke (headless, self-served). End-to-end: open SampleHouse → select a HOST wall →
+ * enter Move → ArrowRight nudge → commitMove fires the hosted-by cascade → the hosted DOOR mesh RIDES by the same
+ * delta. SECONDARY to the node value witness W-SDG-CASCADE-MODELLER; proves the commitMove integration + §-log.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+function serve() { return new Promise(function (r) { var s = http.createServer(function (rq, rs) { var p = decodeURIComponent(rq.url.split('?')[0]); var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p); fs.readFile(fp, function (e, b) { if (e) { rs.statusCode = 404; return rs.end('nf'); } rs.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream'); rs.setHeader('Accept-Ranges', 'bytes'); rs.end(b); }); }); s.listen(0, function () { r(s); }); }); }
+
+(async function () {
+  var srv = await serve(); var port = srv.address().port; var logs = [];
+  var browser = await chromium.launch(); var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+  console.log('═══ §SDG-CASCADE-SMOKE — hosted-by ride wiring (headless) ═══');
+
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () { return !!(window.__arcFidByGuid && Object.keys(window.__arcFidByGuid).length > 0) && !!(window.swXEdges && Array.isArray(window.swXEdges.fills)); }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  // pick a host wall that has a seeded filling; record both mesh centres BEFORE
+  var pick = await page.evaluate(function () {
+    var fbg = window.__arcFidByGuid, fills = window.swXEdges.fills;
+    var e = fills.find(function (e) { return fbg[e.host_guid] != null && fbg[e.filling_guid] != null; });
+    if (!e) return { ok: false };
+    function meshC(fid) { var g = window.Bonsai.group(); var m = g && g.children.find(function (o) { return o.isMesh && o.userData.featureId === fid; }); if (!m) return null; m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox; return [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2]; }
+    var hostFid = fbg[e.host_guid], doorFid = fbg[e.filling_guid];
+    window.Bonsai.select(hostFid);
+    return { ok: true, hostFid: hostFid, doorFid: doorFid, hostBefore: meshC(hostFid), doorBefore: meshC(doorFid), step: (function () { var i = document.getElementById('dim-move'); return i ? parseFloat(i.value) : 1; })() };
+  });
+  chk('G1 a host wall with a seeded filling is selectable', pick.ok && pick.hostBefore && pick.doorBefore, 'host=' + (pick.hostFid) + ' door=' + (pick.doorFid));
+
+  // enter Move mode, nudge +X via ArrowRight → commitMove fires the cascade
+  await page.click('#b-move'); await page.waitForTimeout(150);
+  await page.keyboard.press('ArrowRight');
+  await page.waitForFunction(function () { return window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.length >= 41; }, { timeout: 8000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  var after = await page.evaluate(function (p) {
+    function meshC(fid) { var g = window.Bonsai.group(); var m = g && g.children.find(function (o) { return o.isMesh && o.userData.featureId === fid; }); if (!m) return null; m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox; return [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2]; }
+    return { hostAfter: meshC(p.hostFid), doorAfter: meshC(p.doorFid), ops: window.Bonsai.oplog.length };
+  }, pick);
+
+  function approx(a, b) { return Math.abs(a - b) <= 1e-4; }
+  var step = pick.step;
+  var hostDx = after.hostAfter[0] - pick.hostBefore[0];
+  var doorDx = after.doorAfter[0] - pick.doorBefore[0];
+  chk('G2 host wall moved +' + step + 'm in X', approx(hostDx, step), 'hostDx=' + hostDx.toFixed(3));
+  chk('G3 hosted DOOR RIDES the wall (same +' + step + 'm in X, not left behind)', approx(doorDx, step), 'doorDx=' + doorDx.toFixed(3));
+  chk('G4 rigid: door & wall moved by the SAME delta', approx(hostDx, doorDx), 'host=' + hostDx.toFixed(3) + ' door=' + doorDx.toFixed(3));
+  chk('G5 §SDG-CASCADE hosted-by logged with a rider', logs.some(function (l) { return /§SDG-CASCADE hosted-by rider=/.test(l); }), logs.filter(function (l) { return /SDG-CASCADE/.test(l); })[0] || '');
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('G6 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('§SDG-CASCADE-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## What
Slice (2) of the SDG forward-fold cascade, on the §ARC-1 editable substrate (#571). **When a HOST (wall) moves, its hosted FILLINGS (door/window) ride by the same delta** — the door stays in its hole instead of being left behind.

## How
- **`sdg_cascade.js`** (new, pure, dual-export): `ridersFor(movedFids, guidByFid, fidByGuid, fills)` → the hosted fillings of the moved hosts, resolved through the §ARC-1 `featureId↔guid` bridge over the **real `rel_fills_host` edges** (`window.swXEdges.fills`). **Directional** (a door never drags its wall), **one-hop**, deduped vs the moved set.
- **`commitMove`**: after the dragged `GEOM_MOVE`s, emit an induced `GEOM_MOVE` for each rider (same delta, `provenance: induced:'hosted-by'`).

Pure rigid translation → **rosetta-invertible** (apply −delta recovers the original; 0.000mm). **NON-INVENT**: rides only on `ifc:recovered` edges, fabricates no relationship.

## Witnessed
- **W-SDG-CASCADE-MODELLER 7/7** (node, real SampleHouse): directional; all k fillings ride (deduped); rigid ride by exact delta; door↔wall offset invariant; rosetta −delta recovers original (`maxErr 7e-8mm`); every ride on a recovered edge.
- **§SDG-CASCADE-SMOKE 6/6** (headless): select wall → Move → ArrowRight → door mesh rides +1m, same delta, signed+verified, `§SDG-CASCADE` logged.
- `sw` v16→v17.

## Scope note
`contains`/`rel_aggregates` has **no ARC element↔element data** in the simple set (SampleHouse/Duplex/SampleCastle all 0 — it's spatial/STR-assembly decomposition). So **hosted-by is the real, universal cascade**; the contains half was dropped by design (recorded in spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)