### PR TITLE
§GATE-1: RED/ORANGE conformity gate on modeller edits (the planner's gate)

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -202,6 +202,7 @@
 <script src="cross_edges.js?v=2" onerror="console.warn('§XEDGE LOAD_FAIL cross_edges.js')"></script>
 <script src="arc_editable.js?v=1" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
 <script src="sdg_cascade.js?v=1" onerror="console.warn('§SDG LOAD_FAIL sdg_cascade.js')"></script>
+<script src="sdg_gate.js?v=1" onerror="console.warn('§GATE LOAD_FAIL sdg_gate.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
@@ -1416,9 +1417,37 @@ async function commitMoveDrag() {
   await commitMove(+dx.toFixed(4), +dy.toFixed(4), +dz.toFixed(4));
 }
 canvas.addEventListener('pointerup', () => { if (moving && _moveDrag) commitMoveDrag(); });
+// §GATE-1 helpers (RESUME_MODELLER_CONFORMITY_GATE.md). Snapshot every editable mesh's world AABB → {fid: box}.
+function _gateBoxes() {
+  const g = window.Bonsai && window.Bonsai.group && window.Bonsai.group(); const out = {};
+  if (g) g.children.forEach(m => { if (m.isMesh && m.userData && m.userData.featureId != null) { m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox; out[m.userData.featureId] = [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z]; } });
+  return out;
+}
+// rel for the gate: hosted-by (door-in-wall) + abuts (face-touch) are EXPECTED contact (never a clash); hostOf
+// drives the door-out-of-host check. Resolved guid→fid through the §ARC-1 bridge over the recovered edges.
+function _gateRel() {
+  const X = window.swXEdges || {}, fbg = window.__arcFidByGuid || {}, relSet = {}, hostOf = {};
+  (X.fills || []).forEach(e => { const h = fbg[e.host_guid], f = fbg[e.filling_guid]; if (h != null && f != null) { relSet[Math.min(h, f) + '|' + Math.max(h, f)] = 1; hostOf[f] = h; } });
+  (X.abuts || []).forEach(e => { const a = fbg[e.a], b = fbg[e.b]; if (a != null && b != null) relSet[Math.min(a, b) + '|' + Math.max(a, b)] = 1; });
+  return { related: (a, b) => !!relSet[Math.min(a, b) + '|' + Math.max(a, b)], hostOf: hostOf };
+}
+// evaluate conformity on the just-committed edit; toast + emissive-highlight the offending pairs; return a status tag.
+function _runGate(before, moved) {
+  if (!(window.SdgGate && window.__arcFidByGuid)) return '';
+  const res = window.SdgGate.evaluate(before, _gateBoxes(), moved, _gateRel(), {});
+  if (!res.red.length && !res.orange.length) return '';
+  console.log('§GATE red=' + res.red.length + ' orange=' + res.orange.length + ' ' + JSON.stringify(res.red.slice(0, 3)) + ' ' + JSON.stringify(res.orange.slice(0, 3)));
+  const hot = new Set(); res.red.forEach(r => { hot.add(r.a); hot.add(r.b); }); res.orange.forEach(o => { hot.add(o.a); hot.add(o.b); });
+  const hex = res.red.length ? 0x661010 : 0x5a3a10;          // RED vs ORANGE emissive flash on the offending meshes
+  const g = window.Bonsai.group(); if (g) g.children.forEach(m => { if (m.isMesh && m.userData && hot.has(m.userData.featureId)) _emis(m, hex); });
+  if (res.red.length) toast('⛔ ' + res.red.length + ' conformity violation' + (res.red.length > 1 ? 's' : '') + ': ' + res.red.map(r => r.kind).join(', '), 'error');
+  else toast('⚠ ' + res.orange.length + ' tight clearance — accept or ignore', 'info');
+  return res.red.length ? ('⛔ ' + res.red.length + ' RED') : ('⚠ ' + res.orange.length + ' ORANGE');
+}
 async function commitMove(dx, dy, dz) {
   const ids = selectedIds.size ? Array.from(selectedIds) : (selectedId != null ? [selectedId] : []);
   if (!ids.length) return;                                     // guard: never move an absent/undone feature
+  const _gateBefore = _gateBoxes();                            // §GATE-1: snapshot AABBs BEFORE the edit (delta-honest)
   setStat(ids.length > 1 ? ('moving ' + ids.length + ' objects…') : 'moving…');
   try {
     let lastVerify = true;
@@ -1438,7 +1467,12 @@ async function commitMove(dx, dy, dz) {
       console.log('§SDG-CASCADE hosted-by rider=' + rfid + ' rides host-move dx=' + dx.toFixed(3) + ' dy=' + dy.toFixed(3) + ' dz=' + dz.toFixed(3) + ' verify=' + rr.verify);
     }
     if (riders.length) console.log('§SDG-CASCADE hosted-by hosts=' + ids.length + ' riders=' + riders.length);
-    setStat((ids.length > 1 ? ('moved ' + ids.length + ' objects') : ('moved #' + ids[0])) + (riders.length ? (' +' + riders.length + ' hosted') : '') + ' Δ(' + dx.toFixed(2) + ',' + dy.toFixed(2) + ',' + dz.toFixed(2) + ')  verify=' + lastVerify);
+    // §GATE-1 (W-SDG-GATE): the planner's gate — after the ride, CHECK what the edit BROKE. RED = hard violation
+    // (wall clash / door out of its host), ORANGE = soft accept/ignore (tight clearance). REPORTS (does not revert);
+    // the signed op stands, the user decides (spine: no auto-converge, user-gated).
+    const gateMsg = _runGate(_gateBefore, ids.concat(riders));
+    window.__lastGate = gateMsg;                          // test hook (W-SDG-GATE smoke): last gate status
+    setStat((ids.length > 1 ? ('moved ' + ids.length + ' objects') : ('moved #' + ids[0])) + (riders.length ? (' +' + riders.length + ' hosted') : '') + ' Δ(' + dx.toFixed(2) + ',' + dy.toFixed(2) + ',' + dz.toFixed(2) + ')  verify=' + lastVerify + (gateMsg ? '  ' + gateMsg : ''));
     audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     window.Bonsai.selectMany(ids); clearMoveGhost();      // re-fold replaced the meshes → always re-grab fresh refs (no stale)
     if (moving) buildMoveGizmo();                         // reposition the gizmo on the moved selection (move mode only)
@@ -1447,6 +1481,7 @@ async function commitMove(dx, dy, dz) {
     setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER move fail ' + err);
   }
 }
+window.__commitMove = commitMove;   // test hook (W-SDG-GATE smoke): drive a deterministic move through the real path
 // H3 yaw commit — rotate the selection about the SET centroid (W-BONSAI-ROTATE-GROUP). Each child gets a signed
 // GEOM_ROTATE (spins it in place about its OWN centre) plus, when it is off the centroid, a GEOM_MOVE that orbits
 // its centre about the set centroid by the same angle: Tᵢ = G + Rθ(Cᵢ−G). A single selection ⇒ Cᵢ==G ⇒ no move

--- a/modeller/sdg_gate.js
+++ b/modeller/sdg_gate.js
@@ -1,0 +1,86 @@
+// sdg_gate.js — §GATE-1: the RED/ORANGE conformity gate on a committed edit (the spine's "planner's gate" / MRP
+// exception message). After a move/ride, CHECK the result: RED = a hard constraint the edit BROKE, ORANGE = soft
+// accept/ignore. DELTA-based: flags only what the EDIT changed (a pre-existing as-extracted overlap is NOT a
+// violation — the building shipped that way). Pure geometry over MEASURED AABBs + RECOVERED edges; invents no rule.
+// Reuses the cross_edges overlap convention. See RESUME_MODELLER_CONFORMITY_GATE.md §GATE-1. Dual-export (window+node).
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.SdgGate = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+  var CLASH_TOL = 0.02;       // m — interpenetration deeper than this (and deeper than before) = a clash
+  var CLEARANCE = 0.5;        // m — default soft clearance (measured residential standard ~0.5m; a PARAMETER)
+
+  // AABB layout = [minx,maxx,miny,maxy,minz,maxz]. signed per-axis overlap: >0 interpenetrate, =0 touch, <0 gap.
+  function overlaps(a, b) {
+    var ov = [];
+    for (var k = 0; k < 3; k++) ov.push(Math.min(a[2 * k + 1], b[2 * k + 1]) - Math.max(a[2 * k], b[2 * k]));
+    return ov;
+  }
+  // >0 ⇒ volumetric interpenetration depth (min separating translation); 0 ⇒ not overlapping.
+  function penetration(a, b) {
+    var ov = overlaps(a, b);
+    return (ov[0] > 0 && ov[1] > 0 && ov[2] > 0) ? Math.min(ov[0], ov[1], ov[2]) : 0;
+  }
+  // face-gap when separated on EXACTLY one axis (a clean face-to-face near-miss); null for corner/overlap.
+  function faceGap(a, b) {
+    var ov = overlaps(a, b), sep = [];
+    for (var k = 0; k < 3; k++) if (ov[k] < 0) sep.push(k);
+    return sep.length === 1 ? -ov[sep[0]] : null;
+  }
+  function centre(a) { return [(a[0] + a[1]) / 2, (a[2] + a[3]) / 2, (a[4] + a[5]) / 2]; }
+  function withinXY(box, pt, tol) {       // is pt inside box's XY footprint (the wall opening sits in plan)
+    tol = tol || 0;
+    return pt[0] >= box[0] - tol && pt[0] <= box[1] + tol && pt[1] >= box[2] - tol && pt[1] <= box[3] + tol;
+  }
+
+  // evaluate(before, after, moved, rel, opts) → {red:[{kind,a,b,depth?}], orange:[{kind,a,b,gap}]}. PURE.
+  //   before/after = {fid: aabb}      moved = [fid,…] (host + cascade riders)
+  //   rel = { related(a,b)->bool  (hosted-by/abuts/anchored = EXPECTED contact, never a clash),
+  //           hostOf: {fillingFid: hostFid} }      opts = {clashTol, clearance}
+  function evaluate(before, after, moved, rel, opts) {
+    opts = opts || {}; rel = rel || {};
+    var clashTol = opts.clashTol != null ? opts.clashTol : CLASH_TOL;
+    var clearance = opts.clearance != null ? opts.clearance : CLEARANCE;
+    var related = rel.related || function () { return false; };
+    var hostOf = rel.hostOf || {};
+    var movedSet = {}; moved.forEach(function (m) { movedSet[m] = 1; });
+    var allFids = Object.keys(after);
+    var red = [], orange = [], seen = {};
+
+    // (1) CLASH + (3) CLEARANCE — each moved element vs every other (deduped by unordered pair)
+    moved.forEach(function (m) {
+      if (!after[m]) return;
+      allFids.forEach(function (o) {
+        if (+o === +m) return;
+        var key = Math.min(+m, +o) + '|' + Math.max(+m, +o);
+        if (seen[key]) return; seen[key] = 1;
+        if (related(+m, +o)) return;                          // expected contact (door-in-wall, abuts) → never a clash
+        var penA = penetration(after[m], after[o]);
+        var penB = (before[m] && before[o]) ? penetration(before[m], before[o]) : 0;
+        if (penA > clashTol && penA > penB + clashTol) {       // NEW or WORSENED interpenetration
+          red.push({ kind: 'clash', a: +m, b: +o, depth: +penA.toFixed(4) }); return;
+        }
+        var gapA = faceGap(after[m], after[o]);
+        var gapB = (before[m] && before[o]) ? faceGap(before[m], before[o]) : null;
+        if (gapA != null && gapA >= 0 && gapA < clearance && (gapB == null || gapA < gapB - 1e-9)) {
+          orange.push({ kind: 'clearance', a: +m, b: +o, gap: +gapA.toFixed(4) });
+        }
+      });
+    });
+
+    // (2) DOOR OUT OF HOST — a moved filling whose centre left its host footprint (catches sliding a door off its wall)
+    Object.keys(hostOf).forEach(function (fStr) {
+      var f = +fStr, h = hostOf[f];
+      if (!movedSet[f] && !movedSet[h]) return;
+      if (!after[f] || !after[h] || !before[f] || !before[h]) return;
+      if (withinXY(before[h], centre(before[f]), 0.05) && !withinXY(after[h], centre(after[f]), 0.05)) {
+        red.push({ kind: 'door-out', a: f, b: h });
+      }
+    });
+
+    return { red: red, orange: orange };
+  }
+
+  return { evaluate: evaluate, penetration: penetration, faceGap: faceGap, overlaps: overlaps, CLASH_TOL: CLASH_TOL, CLEARANCE: CLEARANCE };
+});

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v17';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v18';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -53,6 +53,7 @@ const PRECACHE_ASSETS = [
   'cross_edges.js',
   'arc_editable.js',
   'sdg_cascade.js',
+  'sdg_gate.js',
   'disc_walker.js',
   'str_walker.js',
   'str_walker_bridge.js',

--- a/modeller/tests/witness_sdg_gate.js
+++ b/modeller/tests/witness_sdg_gate.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * W-SDG-GATE — §GATE-1 value witness (PURE NODE, REAL SampleHouse). The RED/ORANGE conformity gate: after a
+ * move/ride, flag the hard violations the edit BROKE (RED) and soft accept/ignore (ORANGE), delta-honestly (a
+ * pre-existing as-extracted overlap is NOT flagged). Pure geometry over MEASURED seeded AABBs + RECOVERED edges.
+ *
+ *   A1 clean      — lift a wall into open space ⇒ red=0 orange=0
+ *   A2 RED clash  — drive wall A onto wall B ⇒ red has clash{A,B,depth>tol}
+ *   A3 delta-honest — a pre-existing B–C overlap, move a DIFFERENT wall ⇒ no clash mentions {B,C}
+ *   A4 door-out   — slide a DOOR off its wall ⇒ red door-out{door,host}; move the HOST (door rides) ⇒ none
+ *   A5 ORANGE     — bring a wall within < CLEARANCE of a neighbour (gap shrinks) ⇒ orange clearance{…}; far ⇒ none
+ *   A6 non-invent — gate reads only the passed AABBs + edges; CLEARANCE is an explicit param
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgGate = require(path.join(ROOT, 'sdg_gate.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function aabb(p) { var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9]; for (var i = 0; i < p.length; i += 3) for (var k = 0; k < 3; k++) { if (p[i + k] < mn[k]) mn[k] = p[i + k]; if (p[i + k] > mx[k]) mx[k] = p[i + k]; } return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]]; }
+function tr(b, d) { return [b[0] + d[0], b[1] + d[0], b[2] + d[1], b[3] + d[1], b[4] + d[2], b[5] + d[2]]; }
+function ctr(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+function hasKind(arr, kind, x, y) { return arr.some(function (r) { return r.kind === kind && ((r.a === x && r.b === y) || (r.a === y && r.b === x)); }); }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-SDG-GATE — §GATE-1 RED/ORANGE conformity (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, { commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); }, building: 'SampleHouse' });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+
+  // base (seeded) boxes for every fid
+  var base = {}; Object.keys(opByFid).forEach(function (fid) { base[fid] = aabb(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }).positions); });
+
+  // rel: hosted-by pairs are EXPECTED contact (never a clash); hostOf for door-out
+  var fillsPairs = {}, hostOf = {};
+  fills.forEach(function (e) { var hf = fbg[e.host_guid], ff = fbg[e.filling_guid]; if (hf != null && ff != null) { fillsPairs[Math.min(hf, ff) + '|' + Math.max(hf, ff)] = 1; hostOf[ff] = hf; } });
+  var rel = { related: function (a, b) { return !!fillsPairs[Math.min(a, b) + '|' + Math.max(a, b)]; }, hostOf: hostOf };
+
+  // the seeded walls
+  var walls = Object.keys(opByFid).filter(function (fid) { var c = opByFid[fid].params.ifc_class; return c === 'IfcWall' || c === 'IfcWallStandardCase'; }).map(Number);
+  var A = walls[0], B = walls[1], C = walls[2];
+
+  // A1 — clean: lift wall A +10m into open space
+  var b1 = {}; Object.keys(base).forEach(function (f) { b1[f] = base[f]; });
+  var a1 = {}; Object.keys(base).forEach(function (f) { a1[f] = (+f === A) ? tr(base[f], [0, 0, 10]) : base[f]; });
+  var g1 = SdgGate.evaluate(b1, a1, [A], rel, {});
+  chk('A1 clean move (lift into open space) → no flags', g1.red.length === 0 && g1.orange.length === 0, 'red=' + g1.red.length + ' orange=' + g1.orange.length);
+
+  // A2 — RED clash: drive wall A onto wall B (delta = B.centre − A.centre)
+  var dAB = [ctr(base[B])[0] - ctr(base[A])[0], ctr(base[B])[1] - ctr(base[A])[1], ctr(base[B])[2] - ctr(base[A])[2]];
+  var a2 = {}; Object.keys(base).forEach(function (f) { a2[f] = (+f === A) ? tr(base[f], dAB) : base[f]; });
+  var g2 = SdgGate.evaluate(base, a2, [A], rel, {});
+  chk('A2 RED clash: wall driven onto another wall → clash{A,B} flagged', hasKind(g2.red, 'clash', A, B), 'red=' + JSON.stringify(g2.red.slice(0, 2)));
+
+  // A3 — delta-honest: pre-existing B–C overlap (in BOTH before+after), move a DIFFERENT wall A cleanly
+  var dCB = [ctr(base[B])[0] - ctr(base[C])[0], ctr(base[B])[1] - ctr(base[C])[1], ctr(base[B])[2] - ctr(base[C])[2]];
+  var b3 = {}, a3 = {};
+  Object.keys(base).forEach(function (f) { b3[f] = (+f === C) ? tr(base[f], dCB) : base[f]; });   // C already on B (as-extracted-like)
+  Object.keys(base).forEach(function (f) { a3[f] = (+f === C) ? tr(base[f], dCB) : ((+f === A) ? tr(base[f], [0, 0, 10]) : base[f]); });
+  var g3 = SdgGate.evaluate(b3, a3, [A], rel, {});
+  chk('A3 delta-honest: pre-existing B–C overlap NOT flagged when a different wall moves', !hasKind(g3.red, 'clash', B, C) && g3.red.length === 0, 'red=' + g3.red.length);
+
+  // A4 — door-out: pick a fills edge whose filling centre IS within the host footprint (so "leaving" is detectable),
+  // then slide the door off its wall (alone) vs ride-the-host (move host + ALL its fillings, as the real cascade does).
+  var inHost = function (h, f) { var hb = base[h], c = ctr(base[f]); return c[0] >= hb[0] - 0.05 && c[0] <= hb[1] + 0.05 && c[1] >= hb[2] - 0.05 && c[1] <= hb[3] + 0.05; };
+  var fe = fills.find(function (e) { var h = fbg[e.host_guid], f = fbg[e.filling_guid]; return h != null && f != null && inHost(h, f); });
+  var door = fbg[fe.filling_guid], host = fbg[fe.host_guid];
+  var hostFillings = fills.filter(function (e) { return fbg[e.host_guid] === host && fbg[e.filling_guid] != null; }).map(function (e) { return fbg[e.filling_guid]; });
+  var far = [8, 8, 0];
+  var a4a = {}; Object.keys(base).forEach(function (f) { a4a[f] = (+f === door) ? tr(base[f], far) : base[f]; });   // door alone
+  var g4a = SdgGate.evaluate(base, a4a, [door], rel, {});
+  var ride = [host].concat(hostFillings);                                                                            // host + ALL its fillings ride (cascade)
+  var a4b = {}; Object.keys(base).forEach(function (f) { a4b[f] = (ride.indexOf(+f) >= 0) ? tr(base[f], far) : base[f]; });
+  var g4b = SdgGate.evaluate(base, a4b, ride, rel, {});
+  chk('A4 door-out: sliding a DOOR off its wall → red door-out{door,host}; moving the host (all fillings ride) → none',
+    hasKind(g4a.red, 'door-out', door, host) && !g4b.red.some(function (r) { return r.kind === 'door-out'; }), 'alone=' + g4a.red.length + ' ride=' + g4b.red.length);
+
+  // A5 — ORANGE clearance band (real wall A + a constructed neighbour overlapping in Y,Z, separated in X)
+  var wa = base[A], wid = wa[1] - wa[0];
+  var nb = [wa[1] + 2.0, wa[1] + 2.0 + wid, wa[2], wa[3], wa[4], wa[5]];   // neighbour 2.0m away on +X (gap 2.0 > clearance)
+  var bb = {}; bb[A] = wa; bb['9001'] = nb;
+  // move A to within 0.3m of the neighbour (gap 0.3 < 0.5 clearance, no overlap)
+  var aTight = {}; aTight[A] = tr(wa, [2.0 - 0.3, 0, 0]); aTight['9001'] = nb;
+  var g5 = SdgGate.evaluate(bb, aTight, [A], { related: function () { return false; } }, {});
+  // control: move A only 1.0m closer (gap 1.0 > clearance) → no orange
+  var aFar = {}; aFar[A] = tr(wa, [1.0, 0, 0]); aFar['9001'] = nb;
+  var g5c = SdgGate.evaluate(bb, aFar, [A], { related: function () { return false; } }, {});
+  chk('A5 ORANGE clearance: gap shrinks below CLEARANCE → orange; stays above → none',
+    g5.orange.some(function (o) { return o.kind === 'clearance' && o.gap < 0.5; }) && g5c.orange.length === 0,
+    'tight=' + JSON.stringify(g5.orange[0] || null) + ' far=' + g5c.orange.length);
+
+  // A6 — non-invent: explicit CLEARANCE param changes the band, nothing hardcoded/fabricated
+  var g6 = SdgGate.evaluate(bb, aTight, [A], { related: function () { return false; } }, { clearance: 0.2 });   // 0.3 gap > 0.2 → no orange
+  chk('A6 non-invent: CLEARANCE is an explicit param (0.2 ⇒ 0.3m gap no longer ORANGE)', g6.orange.length === 0, 'orange@0.2=' + g6.orange.length);
+
+  console.log('W-SDG-GATE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_sdg_gate_smoke.js
+++ b/modeller/tests/witness_sdg_gate_smoke.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * §GATE-SMOKE — §GATE-1 wiring smoke (headless, self-served). Drives the REAL commitMove: a clean move raises NO
+ * flag; driving one element onto another raises a RED conformity violation (§GATE log + RED toast + status tag).
+ * SECONDARY to the node value witness W-SDG-GATE.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+function serve() { return new Promise(function (r) { var s = http.createServer(function (rq, rs) { var p = decodeURIComponent(rq.url.split('?')[0]); var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p); fs.readFile(fp, function (e, b) { if (e) { rs.statusCode = 404; return rs.end('nf'); } rs.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream'); rs.setHeader('Accept-Ranges', 'bytes'); rs.end(b); }); }); s.listen(0, function () { r(s); }); }); }
+
+(async function () {
+  var srv = await serve(); var port = srv.address().port; var logs = [];
+  var browser = await chromium.launch(); var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+  console.log('═══ §GATE-SMOKE — conformity gate wiring (headless) ═══');
+
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () { return !!(window.__arcFidByGuid && Object.keys(window.__arcFidByGuid).length > 0) && !!(window.SdgGate); }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  // pick the two MOST-SEPARATED editable elements (guaranteed unrelated) → moving A onto B is a clean clash
+  var plan = await page.evaluate(function () {
+    var g = window.Bonsai.group(); var boxes = [];
+    g.children.forEach(function (m) { if (m.isMesh && m.userData && m.userData.featureId != null && window.__arcGuidByFid[m.userData.featureId] != null) { m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox; boxes.push({ fid: m.userData.featureId, c: [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2] }); } });
+    var bestA = null, bestB = null, bd = -1;
+    for (var i = 0; i < boxes.length; i++) for (var j = i + 1; j < boxes.length; j++) { var d = Math.hypot(boxes[i].c[0] - boxes[j].c[0], boxes[i].c[1] - boxes[j].c[1], boxes[i].c[2] - boxes[j].c[2]); if (d > bd) { bd = d; bestA = boxes[i]; bestB = boxes[j]; } }
+    return { aFid: bestA.fid, bFid: bestB.fid, delta: [bestB.c[0] - bestA.c[0], bestB.c[1] - bestA.c[1], bestB.c[2] - bestA.c[2]], n: boxes.length };
+  });
+  chk('G1 substrate ready (editable elements + SdgGate loaded)', plan.n > 0 && plan.aFid != null, 'elements=' + plan.n);
+
+  // clean move: lift element A +10m into open space → NO gate flag
+  await page.evaluate(async function (p) { window.Bonsai.select(p.aFid); await window.__commitMove(0, 0, 10); }, plan);
+  await page.waitForTimeout(250);
+  var cleanGate = await page.evaluate(function () { return window.__lastGate; });
+  chk('G2 clean move (lift into open space) raises NO flag', !cleanGate, 'lastGate="' + cleanGate + '"');
+  var redLogsBefore = logs.filter(function (l) { return /§GATE red=[1-9]/.test(l); }).length;
+
+  // clash move: drive A onto B (delta = B.centre − A.centre) → RED conformity violation
+  await page.evaluate(async function (p) { window.Bonsai.select(p.aFid); await window.__commitMove(p.delta[0], p.delta[1], p.delta[2] - 10); }, plan);
+  await page.waitForTimeout(350);
+  var clashGate = await page.evaluate(function () { return window.__lastGate; });
+  var redLogged = logs.some(function (l) { return /§GATE red=[1-9]/.test(l); });
+  var redToast = logs.some(function (l) { return /§TOAST kind=error.*conformity violation/.test(l); });
+  chk('G3 driving one element onto another → RED conformity violation flagged', /RED/.test(clashGate || ''), 'lastGate="' + clashGate + '"');
+  chk('G4 §GATE red=N logged', redLogged, logs.filter(function (l) { return /§GATE red=/.test(l); }).slice(-1)[0] || '');
+  chk('G5 RED toast raised (the MRP exception message)', redToast, logs.filter(function (l) { return /§TOAST.*conformity/.test(l); }).slice(-1)[0] || '');
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('G6 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('§GATE-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## What
Adds the SDG spine's **planner's gate** to modeller edits — the piece that turns the modeller from a *mover* into a *planner*. After a move/ride, it **checks what the edit broke**: **RED** = hard violation (wall clash / door out of its host), **ORANGE** = soft accept/ignore (tight clearance).

Grep had confirmed **zero conformity check** existed in the edit path — you could drag a wall through another or slide a door out of its opening and nothing flagged it.

## How
- **`sdg_gate.js`** (pure, dual-export): `evaluate(before, after, moved, rel, opts) → {red, orange}`. **Delta-based** — flags only what the edit *changed*, never a pre-existing as-extracted overlap (the building shipped that way). Reuses the `cross_edges` overlap convention. Hosted-by/abuts pairs are **expected contact** (never a clash); `hostOf` drives door-out.
- **`commitMove`**: snapshots AABBs before, runs the gate after the cascade → `§GATE` log + RED/ORANGE **toast** (the MRP exception message) + emissive highlight of the offending pair + status tag. The signed op **stands** — the gate reports, the user decides (spine: no auto-converge, user-gated).

**NON-INVENT**: pure geometry over measured post-move AABBs + recovered edges; `CLEARANCE` is an explicit parameter, never a fabricated rule.

## Witnessed
- **W-SDG-GATE 6/6** (node, real SampleHouse): clean move → none; RED clash (wall onto wall); **delta-honest** (pre-existing B–C overlap ignored when a different wall moves); door-out vs ride-the-host (ties to the cascade — moving a host rides *all* its fillings); ORANGE clearance band; non-invent param.
- **§GATE-SMOKE 6/6** (headless): clean move no flag; drive element onto another → 3 RED clashes + RED toast.
- **Cascade smoke regression 6/6** — door-rides path unaffected, no false flag.
- `sw` v17→v18.

## Roadmap context
This is slice (3) of the Modeller-vision roadmap (after §ARC-1 editable substrate #571 + §SDG-CASCADE hosted-by ride #573). Next candidates: one-click revert of a RED edit · gate the STRETCH engine the same way · ORANGE backprop (suggest the fix) · enterprise fold (edit → 4D/5D/ERP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)