### PR TITLE
§STRETCH-1: make the seeded ARC building grid-STRETCHABLE + gated

### DIFF
--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -156,10 +156,18 @@
         else { a.fx *= P.fx != null ? P.fx : 1; a.fy *= P.fy != null ? P.fy : 1; a.fz *= P.fz != null ? P.fz : 1; }   // GEOM_SCALE: net multiplicative scale (W-BONSAI-SCALE PATH B)
         moveBy.set(P.parent, a);
       }
+      // §STRETCH-1: GEOM_GRID_MOVE makes inserts grid-STRETCHABLE host-side. Collect each op's per-feature commands
+      // IN OP ORDER (the worker folds B-rep solids; inserts are skipped there → host-side here, NO double-apply).
+      const gridBy = new Map();                                          // featureId -> [command,…] (ordered)
+      for (const op of ops) {
+        if (op.op_type !== 'GEOM_GRID_MOVE') continue;
+        const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
+        for (const cmd of (P.commands || [])) { if (cmd.featureId == null) continue; const list = gridBy.get(cmd.featureId) || []; list.push(cmd); gridBy.set(cmd.featureId, list); }
+      }
       const d = kernelOps.length ? await this._foldChain(kernelOps) : { meshes: [] };
       const meshes = (d.meshes || []).slice();
       if (window.Bonsai.library) {
-        for (const op of insertOps) { try { meshes.push(window.Bonsai.library.foldInsert(op, moveBy.get(op.id))); } catch (e) { console.warn(TAG + ' insert fold fail ' + e); } }
+        for (const op of insertOps) { try { meshes.push(window.Bonsai.library.foldInsert(op, moveBy.get(op.id), gridBy.get(op.id))); } catch (e) { console.warn(TAG + ' insert fold fail ' + e); } }
       }
       if (g) { while (g.children.length) g.remove(g.children[0]); }   // replay = clear then re-fold
       let totalTris = 0;

--- a/modeller/bonsai_library.js
+++ b/modeller/bonsai_library.js
@@ -334,7 +334,7 @@
     // host and applied here BEFORE place() so the existing yaw + ground-seat math (place() subtracts bbox[4]) runs
     // unchanged and the delta lands in the position BUFFER → geo.computeBoundingBox sees world coords for free
     // (gridmove.elementData + bCut bbox stay correct with zero consumer edits).
-    foldInsert(op, mv) {
+    foldInsert(op, mv, gridCmds) {
       const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
       // §ARC-1: a RAW-BBOX insert (no catalog hash, P.bbox = a MEASURED box from element_transforms) is the
       // editable-ARC substrate path — a real building wall/door seeded as a signed GEOM_INSERT carrying its own
@@ -379,6 +379,24 @@
         pl = { x: ox, y: oy, z: oz, rot };
       }
       const positions = place(base.positions, pl, base.bbox || (c ? c.bbox : rawBox));   // real mesh seats on its own bbox
+      // §STRETCH-1: GEOM_GRID_MOVE makes an insert grid-STRETCHABLE host-side (the worker folds only B-rep solids).
+      // Each command applies to the WORLD positions, IN OP ORDER — a faithful mirror of the worker's TRANSLATE/SCALE
+      // (bonsai_kernel_worker.js): TRANSLATE shifts the axis by delta; SCALE is non-uniform, anchored at the
+      // stationary world MIN edge: coord = f·coord + (min·(1−f) + translateDelta). min is recomputed from the CURRENT
+      // positions before each scale (self-consistent under stacked grid moves). NON-INVENT: pure geometry, no rule.
+      if (gridCmds && gridCmds.length) {
+        for (let g = 0; g < gridCmds.length; g++) {
+          const cmd = gridCmds[g], k = cmd.axis === 'x' ? 0 : cmd.axis === 'y' ? 1 : 2;
+          if (cmd.action === 'TRANSLATE') {
+            const d = cmd.delta || 0; for (let i = k; i < positions.length; i += 3) positions[i] += d;
+          } else {                                                       // SCALE about the world min edge
+            const f = cmd.newScale != null ? cmd.newScale : 1;
+            let mn = Infinity; for (let i = k; i < positions.length; i += 3) if (positions[i] < mn) mn = positions[i];
+            const tx = mn * (1 - f) + (cmd.translateDelta || 0);
+            for (let i = k; i < positions.length; i += 3) positions[i] = f * positions[i] + tx;
+          }
+        }
+      }
       // PER-MESH colour: a signed GEOM_INSERT may carry parameters.color (hex int) — RouteWalker fixtures persist
       // their discipline colour there so each box keeps it through scrub/replay (the fold is otherwise one colour).
       return { featureId: op.id, triangleCount: base.indices.length / 3, positions, normals: null, indices: base.indices, color: (P.color != null ? P.color : undefined) };

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1097,12 +1097,18 @@ async function commitGridMove() {
   if (!_dragGrid || Math.abs(_dragGrid.delta || 0) < 0.05) { exitGridMove(); return; }
   const { id, delta } = _dragGrid;
   setStat('recomposing…');
+  const _gateBefore = _gateBoxes();                            // §STRETCH-1: snapshot AABBs BEFORE the stretch (delta-honest gate)
   try {
     const res = await window.Bonsai.gridmove.commit(id, delta);
-    setStat('grid ' + id + ' moved ' + delta.toFixed(2) + '  recomposed=' + res.commands.length + '  verify=' + res.verify);
+    // §STRETCH-1 (W-SDG-GATE): gate the STRETCH like a move — RED (a stretched wall now clashing, or a door fallen
+    // out of its host) / ORANGE (clearance). The changed set = the engine's recompose commands' featureIds.
+    const gateMsg = _runGate(_gateBefore, (res.commands || []).map(c => c.featureId).filter(f => f != null));
+    window.__lastGate = gateMsg;
+    setStat('grid ' + id + ' moved ' + delta.toFixed(2) + '  recomposed=' + res.commands.length + '  verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
     audioCue('commit'); exitGridMove(); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER gridmove fail ' + err); }
 }
+window.__gridStretch = async (id, delta) => { _dragGrid = { id, delta }; await commitGridMove(); };   // test hook (§STRETCH-GATE smoke)
 canvas.addEventListener('pointerup', () => { if (gridMoving && _dragGrid) commitGridMove(); });
 
 // ── MOVE (direct-manipulation of a PLACED object) ─────────────────────────────────────────────────

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v18';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v19';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_grid_insert.js
+++ b/modeller/tests/witness_grid_insert.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * W-GRID-INSERT — §STRETCH-1 value witness (PURE NODE). foldInsert now makes a box-proxy insert grid-STRETCHABLE
+ * host-side: a GEOM_GRID_MOVE command applies to the WORLD positions, a faithful mirror of the worker's
+ * TRANSLATE/SCALE (bonsai_kernel_worker.js). Proves the box math + back-compat (no command ⇒ byte-identical).
+ *
+ *   T1 TRANSLATE   — world box shifts by delta on the axis; extent + other axes unchanged
+ *   T2 SCALE far   — min edge FIXED, width = f·w (worker formula: coord = f·coord + min·(1−f))
+ *   T3 SCALE near  — translateDelta shifts the min edge by exactly td (left-edge stretch)
+ *   T4 compose     — GEOM_MOVE then grid SCALE: min taken from the MOVED positions (op order respected)
+ *   T5 back-compat — gridCmds undefined/[] ⇒ positions byte-identical to the 2-arg call (non-invent, no perturbation)
+ */
+'use strict';
+var path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+var ROOT = path.join(__dirname, '..');
+require(path.join(ROOT, 'bonsai_library.js'));
+var Library = global.window.Bonsai.library;
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function approx(a, b) { return Math.abs(a - b) <= 1e-9; }
+function ax(p) { var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9]; for (var i = 0; i < p.length; i += 3) for (var k = 0; k < 3; k++) { if (p[i + k] < mn[k]) mn[k] = p[i + k]; if (p[i + k] > mx[k]) mx[k] = p[i + k]; } return { xmin: mn[0], xmax: mx[0], ymin: mn[1], ymax: mx[1], zmin: mn[2], zmax: mx[2] }; }
+// a raw-bbox insert: local box [-1,1,-0.5,0.5,-1.5,1.5] placed centred at (5,0,3) (ground-seat z=1.5 → centre z=3)
+function op() { return { id: 1, op_type: 'GEOM_INSERT', parameters: { bbox: [-1, 1, -0.5, 0.5, -1.5, 1.5], placement: { x: 5, y: 0, z: 1.5, rot: 0 } } }; }
+
+console.log('═══ W-GRID-INSERT — §STRETCH-1 grid-stretchable insert (node) ═══');
+
+var base = ax(Library.foldInsert(op()).positions);                                  // world [4,6,-0.5,0.5,1.5,4.5]
+chk('T0 base world box', approx(base.xmin, 4) && approx(base.xmax, 6) && approx(base.zmin, 1.5) && approx(base.zmax, 4.5), JSON.stringify(base));
+
+// T1 — TRANSLATE x +2
+var t1 = ax(Library.foldInsert(op(), null, [{ action: 'TRANSLATE', axis: 'x', delta: 2 }]).positions);
+chk('T1 TRANSLATE x+2: box shifts +2, extent + y/z unchanged', approx(t1.xmin, 6) && approx(t1.xmax, 8) && approx(t1.ymin, -0.5) && approx(t1.zmin, 1.5), JSON.stringify(t1));
+
+// T2 — SCALE x f=2 far edge (translateDelta 0): min fixed at 4, max 6→8, width 2→4
+var t2 = ax(Library.foldInsert(op(), null, [{ action: 'SCALE', axis: 'x', newScale: 2, translateDelta: 0 }]).positions);
+chk('T2 SCALE x f=2 far: min FIXED at 4, width = f·w (→[4,8])', approx(t2.xmin, 4) && approx(t2.xmax, 8), JSON.stringify({ xmin: t2.xmin, xmax: t2.xmax }));
+
+// T3 — SCALE x f=2 near edge (translateDelta 0.5): min shifts by exactly td (matches worker min→min+td)
+var t3 = ax(Library.foldInsert(op(), null, [{ action: 'SCALE', axis: 'x', newScale: 2, translateDelta: 0.5 }]).positions);
+chk('T3 SCALE x f=2 near (td=0.5): min shifts by td → [4.5,8.5]', approx(t3.xmin, 4.5) && approx(t3.xmax, 8.5), JSON.stringify({ xmin: t3.xmin, xmax: t3.xmax }));
+
+// T4 — compose: GEOM_MOVE dx=+2 then grid SCALE x f=2 → min taken from MOVED positions (6) → [6,10]
+var t4 = ax(Library.foldInsert(op(), { dx: 2, dy: 0, dz: 0 }, [{ action: 'SCALE', axis: 'x', newScale: 2, translateDelta: 0 }]).positions);
+chk('T4 compose move+scale: min from MOVED box → [6,10] (op order respected)', approx(t4.xmin, 6) && approx(t4.xmax, 10), JSON.stringify({ xmin: t4.xmin, xmax: t4.xmax }));
+
+// T5 — back-compat: no gridCmds ⇒ byte-identical to a [] command list AND to the 2-arg call
+var p2 = Library.foldInsert(op(), null).positions;
+var pEmpty = Library.foldInsert(op(), null, []).positions;
+var same = p2.length === pEmpty.length && Array.prototype.every.call(p2, function (v, i) { return v === pEmpty[i]; });
+chk('T5 back-compat: gridCmds=[] ⇒ positions byte-identical to the 2-arg call', same);
+
+console.log('W-GRID-INSERT: ' + pass + ' PASS / ' + fail + ' FAIL');
+process.exit(fail ? 1 : 0);

--- a/modeller/tests/witness_stretch_gate_smoke.js
+++ b/modeller/tests/witness_stretch_gate_smoke.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * §STRETCH-GATE-SMOKE — §STRETCH-1 wiring smoke (headless). Proves the seeded ARC building is now actually
+ * grid-STRETCHABLE (a gridline drag changes a real wall's geometry) AND that the conformity gate runs on a stretch.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+function serve() { return new Promise(function (r) { var s = http.createServer(function (rq, rs) { var p = decodeURIComponent(rq.url.split('?')[0]); var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p); fs.readFile(fp, function (e, b) { if (e) { rs.statusCode = 404; return rs.end('nf'); } rs.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream'); rs.setHeader('Accept-Ranges', 'bytes'); rs.end(b); }); }); s.listen(0, function () { r(s); }); }); }
+
+(async function () {
+  var srv = await serve(); var port = srv.address().port; var logs = [];
+  var browser = await chromium.launch(); var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+  console.log('═══ §STRETCH-GATE-SMOKE — ARC grid-stretchable + gated (headless) ═══');
+
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () { return !!(window.__arcFidByGuid && Object.keys(window.__arcFidByGuid).length > 0) && !!(window.Bonsai.gridmove); }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(400);
+
+  // find a gridline whose drag produces a recompose command for a SEEDED wall (so the stretch is on the real building)
+  var plan = await page.evaluate(function () {
+    var GM = window.Bonsai.gridmove, gbf = window.__arcGuidByFid;   // fid → guid (a command targets a SEEDED element)
+    var lines = GM.gridLines();
+    for (var d = 0; d < 2; d++) {
+      var delta = d === 0 ? 0.6 : -0.6;
+      for (var i = 0; i < lines.length; i++) {
+        var cmds = GM.computeCommands(lines[i].id, delta);
+        var hit = cmds.find(function (c) { return gbf[c.featureId] != null; });   // prefer a SCALE (a true stretch) if present
+        var scaleHit = cmds.find(function (c) { return gbf[c.featureId] != null && c.action === 'SCALE'; });
+        if (scaleHit || hit) { var pick = scaleHit || hit; return { id: lines[i].id, delta: delta, fid: pick.featureId, action: pick.action, n: cmds.length }; }
+      }
+    }
+    return { id: null };
+  });
+  chk('S1 a gridline drag recomposes a SEEDED wall (the real building is grid-attached)', plan.id != null, 'grid=' + plan.id + ' fid=' + plan.fid + ' action=' + plan.action);
+
+  function meshBox(fid) { return page.evaluate(function (f) { var g = window.Bonsai.group(); var m = g.children.find(function (o) { return o.isMesh && o.userData.featureId === f; }); if (!m) return null; m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox; return [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z]; }, fid); }
+
+  var before = await meshBox(plan.fid);
+  await page.evaluate(async function (p) { await window.__gridStretch(p.id, p.delta); }, plan);
+  await page.waitForTimeout(500);
+  var after = await meshBox(plan.fid);
+  var changed = before && after && before.some(function (v, i) { return Math.abs(v - after[i]) > 1e-4; });
+  chk('S2 the seeded wall GEOMETRY changed (insert is now grid-stretchable, was a no-op before)', changed,
+    'before=[' + (before || []).map(function (x) { return x.toFixed(2); }) + '] after=[' + (after || []).map(function (x) { return x.toFixed(2); }) + ']');
+
+  // gate ran on the stretch: §GATE evaluated (look for the gate to have executed — log line OR a clean pass with no error)
+  var gateRan = await page.evaluate(function () { return window.__lastGate !== undefined; });
+  chk('S3 the conformity gate RAN on the stretch (commitGridMove → _runGate wired)', gateRan, 'lastGate="' + (await page.evaluate(function () { return window.__lastGate; })) + '"');
+
+  // force a clash: drag the same gridline by a LARGE delta so the recomposed wall drives into the building → RED
+  var redBefore = logs.filter(function (l) { return /§GATE red=[1-9]/.test(l); }).length;
+  await page.evaluate(async function (p) { await window.__gridStretch(p.id, p.delta > 0 ? 8 : -8); }, plan);
+  await page.waitForTimeout(500);
+  var redLogged = logs.filter(function (l) { return /§GATE red=[1-9]/.test(l); }).length > redBefore;
+  var gateMsg = await page.evaluate(function () { return window.__lastGate; });
+  chk('S4 a large stretch that drives a wall into the building → RED conformity flagged', redLogged || /RED/.test(gateMsg || ''),
+    'red=' + redLogged + ' lastGate="' + gateMsg + '" ' + (logs.filter(function (l) { return /§GATE red=/.test(l); }).slice(-1)[0] || ''));
+
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('S5 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('§STRETCH-GATE-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## What
Makes the **seeded ARC building actually grid-stretchable** — dragging a gridline now stretches/translates the real walls — and **gates** the stretch. Closes the finding that the grid-stretch engine never reached the building.

**The gap:** `GEOM_GRID_MOVE` folds **worker-side** (B-rep solids only); the seeded ARC walls are `GEOM_INSERT` **box proxies** folded host-side, and `foldInsert` ignored grid moves. The engine *classified* the inserts and emitted commands — the fold just dropped them.

## How
- **`foldInsert(op, mv, gridCmds)`** — a 3rd arg applies `GEOM_GRID_MOVE` commands to the **world** positions after `place()`, a faithful mirror of the worker's **TRANSLATE** (shift) / **SCALE** (non-uniform, anchored at the world min edge: `coord = f·coord + min·(1−f) + translateDelta`), min recomputed per scale. The local `GEOM_SCALE` (gizmo) path is untouched.
- **`foldChainToScene`** — collects each `GEOM_GRID_MOVE` op's per-feature commands in op order (`gridBy`), passes to `foldInsert`. The worker still folds B-rep solids only (skips inserts) → **no double-apply**.
- **`commitGridMove`** — snapshots AABBs before, runs the §GATE-1 conformity gate after: a stretched wall that clashes or whose door falls out of its host flags **RED**.

**NON-INVENT**: pure geometry, mirrors the worker.

## Witnessed
- **W-GRID-INSERT 6/6** (node): TRANSLATE; SCALE far (min fixed, width = f·w); SCALE near (min + translateDelta); compose move+scale (op order); back-compat (`gridCmds=[]` byte-identical).
- **§STRETCH-GATE-SMOKE 5/5** (headless): a gridline drag recomposes a **seeded** wall → its geometry **changes** (was a no-op) → gate runs → a large stretch drives a wall into the building → `§GATE red` clash logged.
- **Regression all green** (core-fold change): W-ARC-EDITABLE 8/8, W-SDG-CASCADE 7/7, W-SDG-GATE 6/6, foldinsert-regression 5/5 (node) + cascade/gate/arc-seed smokes 6/6/8 (headless).
- `sw` v18→v19.

## Roadmap
Slice 4 of the Modeller-vision roadmap (§ARC-1 substrate → §SDG-CASCADE ride → §GATE-1 gate → **§STRETCH-1 stretchable+gated**). The vision's primary handle (3D grid, stretch≠scale) now works on the real building, conformity-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)