### PR TITLE
feat(modeller): seed→3D corridor trunk — Outliner popup + render (sw v23)

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -493,7 +493,14 @@
     var ext = [s.bx || 0, s.by_ || 0, s.bz || 0], ax = 0;
     if (ext[1] > ext[ax]) ax = 1; if (ext[2] > ext[ax]) ax = 2;
     var h = ext[ax] / 2, a = [s.x, s.y, s.z], b = [s.x, s.y, s.z];
-    a[ax] -= h; b[ax] += h; return { a: a, b: b };
+    a[ax] -= h; b[ax] += h; return { a: a, b: b, ax: ax };
+  }
+  // §FACE-SURFACE: MEASURED half-extent of an element's cross-section PERPENDICULAR to a run axis (mean of the two
+  // perp half-extents). centre-to-line over-states a bulky element's gap by ~this much; subtracting it (clamped ≥0)
+  // yields the surface-to-surface gap. NON-INVENT: bbox-derived, never a constant; 0 bbox → 0 (centre fallback).
+  function _perpHalf(bx, by, bz, ax) {
+    var e = [bx || 0, by || 0, bz || 0], perp = [0, 1, 2].filter(function (i) { return i !== ax; });
+    return (e[perp[0]] / 2 + e[perp[1]] / 2) / 2;
   }
   function _ptSeg(px, py, pz, a, b) {
     var abx = b[0] - a[0], aby = b[1] - a[1], abz = b[2] - a[2];
@@ -530,7 +537,12 @@
           if (d < best) { best = d; bj = si; }
         }
       }
-      if (bj >= 0 && best <= bound) { pairs.push({ ni: fi, ri: bj, gap: best }); sum += best; }
+      if (bj >= 0 && best <= bound) {
+        // §FACE-SURFACE: surface-to-surface gap = centre-line gap − both perp half-sections (measured), clamped ≥0.
+        var ax = lines[bj].ax, r = runs[bj];
+        var gSurf = Math.max(0, best - _perpHalf(r.bx, r.by_, r.bz, ax) - _perpHalf(f.bx, f.by_, f.bz, ax));
+        pairs.push({ ni: fi, ri: bj, gap: best, gapSurface: gSurf }); sum += best;
+      }
       else { noNbr++; }
     });
     return { pairs: pairs, noNbr: noNbr, mean: pairs.length ? sum / pairs.length : Infinity };
@@ -559,14 +571,15 @@
       if (opts.toFace) {
         var fromIsRun = /Segment/.test(r.from_kind);
         var runCls = fromIsRun ? r.from_kind : r.to_kind, nodeCls = fromIsRun ? r.to_kind : r.from_kind;
-        var runs = _loadXYZB(bdb, runCls), nodes = _loadXYZ(bdb, nodeCls);
+        var runs = _loadXYZB(bdb, runCls), nodes = _loadXYZB(bdb, nodeCls);  // nodes WITH bbox → §FACE-SURFACE gapSurface
         var fp = _nnPassFace(nodes, runs, bound);
         fp.pairs.forEach(function (pr) {
           var nEl = nodes[pr.ni], rEl = runs[pr.ri];
           var fEl = fromIsRun ? rEl : nEl, tEl = fromIsRun ? nEl : rEl;
           segs.push({ disc: disc, rule: 'nn', from_kind: r.from_kind, to_kind: r.to_kind,
             from_guid: fEl.g, to_guid: tEl.g, from: [fEl.x, fEl.y, fEl.z], to: [tEl.x, tEl.y, tEl.z],
-            gap: +pr.gap.toFixed(4), bound: +(+bound).toFixed(4), gapSource: gapSource, mode: 'face' });
+            gap: +pr.gap.toFixed(4), gapSurface: +pr.gapSurface.toFixed(4),  // §FACE-SURFACE: surface-to-surface gap
+            bound: +(+bound).toFixed(4), gapSource: gapSource, mode: 'face' });
         });
         byRule.push({ from: r.from_kind, to: r.to_kind, segs: fp.pairs.length, noNbr: fp.noNbr,
           bound: +(+bound).toFixed(4), gapSource: gapSource, avg_measured: gp.avg, iterDir: 'node→run-face',
@@ -962,6 +975,40 @@
       chains: chains, chainSegs: rc.segs, chainByRule: rc.byRule, storeys: sub.length };
   }
 
+  // ── SEED PICKER (human-in-the-loop service entry; W-SEED-TRUNK / W-SEED-DEFAULT) ──────────────────
+  // When the user walks a GENERATED discipline (Outliner.DISC.MEP) the modeller checks for an assigned SEED (the
+  // service entry the trunk radiates from). If none, it shows this DEFAULT in a popup → the user OKs or picks another.
+  // NON-INVENT: the default is a REAL element (IfcDoor, +IfcStair for vertical) picked DETERMINISTICALLY — the most
+  // EXTERNAL entry (nearest the footprint boundary) on the LOWEST storey = the service-entry proxy. It is a HEURISTIC
+  // the human confirms; we never claim it is correct, which is exactly why the popup exists. opts.seed (a guid) →
+  // the user's explicit choice WINS (returned verbatim). No entry element → honest REFUSE (no fabricated seed).
+  function defaultSeed(bdb, opts) {
+    opts = opts || {};
+    var classes = opts.classes || (opts.vertical ? ['IfcDoor', 'IfcStair'] : ['IfcDoor']);
+    var like = classes.map(function (c) { return "m.ifc_class LIKE '%" + _esc(c) + "%'"; }).join(' OR ');
+    var cand = _rows(bdb, "SELECT m.guid g, m.ifc_class c, m.storey st, t.center_x x, t.center_y y, t.center_z z " +
+      "FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE " + like);
+    if (opts.seed) {                                          // user's explicit choice wins — resolve to the real element
+      var s = cand.filter(function (e) { return e.g === opts.seed; })[0] ||
+        _rows(bdb, "SELECT m.guid g, m.ifc_class c, m.storey st, t.center_x x, t.center_y y, t.center_z z " +
+          "FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.guid='" + _esc(opts.seed) + "'")[0];
+      if (!s) return { refused: true, reason: 'assigned seed guid not found: ' + opts.seed };
+      return { guid: s.g, ifc_class: s.c, storey: s.st, x: s.x, y: s.y, z: s.z, source: 'user-assigned',
+        reason: 'user-assigned seed', candidates: cand.map(_seedLabel) };
+    }
+    if (!cand.length) return { refused: true, reason: 'no entry element (' + classes.join('/') + ') in model — ask the user to assign a seed' };
+    // footprint bbox from ALL elements → externality = min distance to a footprint edge (small = near the perimeter)
+    var bb = _rows(bdb, "SELECT MIN(center_x) x0, MAX(center_x) x1, MIN(center_y) y0, MAX(center_y) y1 FROM element_transforms")[0];
+    cand.forEach(function (e) { e.ext = Math.min(e.x - bb.x0, bb.x1 - e.x, e.y - bb.y0, bb.y1 - e.y); });
+    // deterministic: most external (smallest ext) → lowest storey (smallest z) → smallest guid
+    cand.sort(function (a, b) { return (a.ext - b.ext) || (a.z - b.z) || (a.g < b.g ? -1 : a.g > b.g ? 1 : 0); });
+    var d = cand[0];
+    return { guid: d.g, ifc_class: d.c, storey: d.st, x: d.x, y: d.y, z: d.z, externality: +d.ext.toFixed(4),
+      source: 'default-heuristic', reason: 'most external ' + d.c + ' on storey ' + d.st + ' (service-entry proxy; ' +
+      d.ext.toFixed(2) + 'm from footprint edge) — confirm or choose another', candidates: cand.map(_seedLabel) };
+  }
+  function _seedLabel(e) { return { guid: e.g, ifc_class: e.c, storey: e.st, x: e.x, y: e.y, z: e.z }; }
+
   // The walkable disciplines the measured rules cover — drives the Outliner "Walk" roster so a
   // discipline ABSENT from the open building (e.g. FP on a house) is still walkable. Derived, not whitelisted.
   function disciplines() {
@@ -977,7 +1024,7 @@
 
   var API = { dwInit: dwInit, dwOpen: dwOpen, dwBorrow: dwBorrow, dwBorrowFile: dwBorrowFile, dwWalk: dwWalk, assemble: assemble, connectorFor: connectorFor, connectorEnrich: connectorEnrich, substrate: substrate, place: place, hostBind: hostBind,
     route: route, routeChains: routeChains, gate: gate, repRules: repRules, order: order, clearance: clearance,
-    hostWalls: hostWalls, countPer: countPer, occupancy: occupancy,
+    hostWalls: hostWalls, countPer: countPer, occupancy: occupancy, defaultSeed: defaultSeed,
     _shimForDisc: _shimForDisc, _shimForFixture: _shimForFixture, _loadRuleShims: _loadRuleShims,
     disciplines: disciplines, loadedFile: loadedFile, _ready: function () { return _ready; } };
   ROOT.DiscWalker = API;

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -220,7 +220,8 @@
 <!-- DiscWalker: the ONE shared discipline-walker engine (Placer/Router/Gate) reading the MEASURED
      terminal_rules.db (mined off Terminal). Supersedes the thin mep_rw.db recipes for the disc-node walk —
      every disc walks on ANY opened building from rules measured off a real coordinated building. -->
-<script src="disc_walker.js?v=4" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
+<script src="disc_walker.js?v=5" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
+<script src="seed_trunk.js?v=1" onerror="console.warn('§ST LOAD_FAIL seed_trunk.js')"></script>
 <!-- Modeller's OWN service worker (its own app folder now — trilogy viewer/·erp/·modeller/; mirrors erp/sw.js). -->
 <script>
 if ('serviceWorker' in navigator) {
@@ -2383,7 +2384,92 @@ function _redrawAllDiscWalks() {
   Object.keys(window.__dwWalks).forEach(function (d) { if (window.__dwWalks[d]) _renderDiscWalk(d, window.__dwWalks[d]); });
   Object.keys(window.__dwChains).forEach(function (d) { if (window.__dwChains[d]) _renderDiscChains(d, window.__dwChains[d]); });
   if (window.__dwAssembly) Object.keys(window.__dwAssembly).forEach(function (d) { if (window.__dwAssembly[d]) _renderDiscAssembly(d, window.__dwAssembly[d]); });   // §3c
+  if (window.__dwTrunk) Object.keys(window.__dwTrunk).forEach(function (d) { if (window.__dwTrunk[d]) _renderSeedTrunk(d, window.__dwTrunk[d]); });   // seed→trunk
 }
+
+// ── SEED → 3D CORRIDOR TRUNK (seed_trunk.js; W-SEED-TRUNK / -CORRIDOR / -RISER / -ENGINE, bim-compiler) ──────
+// The engineer assigns the service ENTRY (a real door/stair); SeedTrunk.planTrunk routes a corridor-aware trunk
+// from it — around real walls, through real doors — joined across storeys by RISERS at real stairs. NON-INVENT:
+// every blocked nav cell is a real wall, every passage a real door, every riser a real IfcStair; unreachable
+// fixtures are REFUSED, never forced. GENERATED/plausible (no ground truth for an absent discipline). Rendered
+// as disc-coloured LineSegments under dwRoot (cleared/redrawn with the disc walk).
+window.__dwTrunk = window.__dwTrunk || {};
+function _renderSeedTrunk(disc, net) {
+  var root = _dwRoot(); if (!root) return;
+  root.children.slice().forEach(function (o) { if (o.userData && o.userData.dwTrunk === disc) root.remove(o); });
+  window.__dwTrunk[disc] = net;
+  if (!net || net.refused || !net.storeys) { if (window.A && A.requestRender) A.requestRender(); return; }
+  var pts = [];
+  net.storeys.forEach(function (s) { (s.edges || []).forEach(function (poly) {
+    for (var i = 0; i + 1 < poly.length; i++) { pts.push(poly[i][0], poly[i][1], poly[i][2], poly[i + 1][0], poly[i + 1][1], poly[i + 1][2]); }
+  }); });
+  net.risers.forEach(function (r) { pts.push(r.x, r.y, r.z0, r.x, r.y, r.z1); });   // vertical riser at the real stair XY
+  if (!pts.length) { if (window.A && A.requestRender) A.requestRender(); return; }
+  var g = new THREE.BufferGeometry(); g.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3));
+  var col = DW_COLOR[disc] || 0xffa500;
+  var line = new THREE.LineSegments(g, new THREE.LineBasicMaterial({ color: col, linewidth: 2 }));
+  line.userData.dwTrunk = disc; root.add(line);
+  console.log('§SEED-TRUNK ' + disc + ' served=' + net.served + ' refused=' + net.refused + ' risers=' + net.risers.length +
+    ' totalLen=' + net.totalLen.toFixed(1) + 'm segs=' + (pts.length / 6) + ' (corridor-aware, real-stair risers, non-invent)');
+  if (window.A && A.requestRender) A.requestRender();
+}
+// risers = real IfcStair columns (deduped by XY); storeys = the building's floors (z = lowest element per storey,
+// deduped ≥2m apart, named storeys only) — the structural levels the riser climbs, not the elevated fixture z.
+function _seedRisers(bdb) {
+  var r = bdb.exec("SELECT m.guid g, t.center_x x, t.center_y y FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class LIKE '%Stair%'");
+  var out = []; if (r.length) r[0].values.forEach(function (v) { var s = { guid: v[0], x: v[1], y: v[2] };
+    if (!out.some(function (o) { return Math.hypot(o.x - s.x, o.y - s.y) < 0.5; })) out.push(s); }); return out;
+}
+// storey levels = each fixture-storey at its MEDIAN fixture z (robust: MIN-z / foundation slabs create false
+// near-duplicate levels and could drop the real ground floor). Named storeys only; the riser climbs these and
+// the trunk roots at the SEED's storey (planTrunk groundStorey).
+function _seedStoreys(bdb, fixtures) {
+  var byS = {}; fixtures.forEach(function (p) { if (p.storey && !/^unknown$/i.test(p.storey)) (byS[p.storey] = byS[p.storey] || []).push(p.z); });
+  return Object.keys(byS).map(function (nm) { var zs = byS[nm].slice().sort(function (a, b) { return a - b; });
+    return { name: nm, z: zs[zs.length >> 1] }; }).sort(function (a, b) { return a.z - b.z; });
+}
+function _seedPopup(disc, seedInfo) {
+  return new Promise(function (resolve) {
+    var ov = document.createElement('div');
+    ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:99999;display:flex;align-items:center;justify-content:center;';
+    var box = document.createElement('div');
+    box.style.cssText = 'background:#1b1b1b;color:#eee;border:1px solid #555;border-radius:8px;padding:18px 20px;min-width:360px;font:13px system-ui,sans-serif;box-shadow:0 8px 40px rgba(0,0,0,.6);';
+    var cands = seedInfo.candidates || [];
+    var optHtml = cands.map(function (c) { var sel = c.guid === seedInfo.guid ? ' selected' : '';
+      return '<option value="' + c.guid + '"' + sel + '>' + (c.ifc_class || 'entry') + ' @ ' + (c.storey || '?') +
+        ' (' + c.x.toFixed(1) + ',' + c.y.toFixed(1) + ')</option>'; }).join('');
+    box.innerHTML = '<div style="font-weight:600;margin-bottom:6px;">Route ' + disc + ' trunk — service entry (seed)</div>' +
+      '<div style="opacity:.8;margin-bottom:10px;font-size:12px;line-height:1.4;">' + (seedInfo.reason || '') + '<br>Confirm the default entry or choose another:</div>' +
+      '<select id="_seedSel" style="width:100%;padding:6px;background:#111;color:#eee;border:1px solid #555;border-radius:4px;">' + optHtml + '</select>' +
+      '<div style="margin-top:14px;text-align:right;"><button id="_seedCancel" style="margin-right:8px;background:#333;color:#eee;border:1px solid #555;padding:6px 12px;border-radius:4px;cursor:pointer;">Cancel</button>' +
+      '<button id="_seedOk" style="background:#ffd24a;color:#111;border:none;padding:6px 16px;border-radius:4px;font-weight:600;cursor:pointer;">Route ▶</button></div>';
+    ov.appendChild(box); document.body.appendChild(ov);
+    function done(v) { if (ov.parentNode) document.body.removeChild(ov); resolve(v); }
+    box.querySelector('#_seedCancel').onclick = function () { done(null); };
+    box.querySelector('#_seedOk').onclick = function () { var g = box.querySelector('#_seedSel').value;
+      done(cands.filter(function (x) { return x.guid === g; })[0] || null); };
+    ov.onclick = function (e) { if (e.target === ov) done(null); };
+  });
+}
+// CHECK → DEFAULT → CONFIRM/OVERRIDE → ROUTE (the Outliner.DISC popup flow). Requires a prior disc walk (fixtures).
+window.seedTrunk = async function (disc) {
+  if (!window.SeedTrunk || !window.DiscWalker || !window.SQL) { console.warn('§SEED-TRUNK not ready'); return; }
+  var fixtures = (window.__dwWalks && window.__dwWalks[disc]) || [];
+  if (!fixtures.length) { alert('Walk ' + disc + ' first — there are no placed fixtures to route a trunk through.'); return; }
+  if (!window.__dwBuf) { alert('Open a building first.'); return; }
+  var bdb = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+  try {
+    var seedInfo = window.DiscWalker.defaultSeed(bdb);
+    if (seedInfo.refused) { alert('No entry element (door/stair) to seed the trunk from: ' + seedInfo.reason); return; }
+    var chosen = await _seedPopup(disc, seedInfo);
+    if (!chosen) return;                                    // user cancelled
+    var net = window.SeedTrunk.planTrunk(bdb, fixtures, { x: chosen.x, y: chosen.y, storey: chosen.storey },
+      _seedRisers(bdb), { storeys: _seedStoreys(bdb, fixtures), groundStorey: chosen.storey });
+    if (net.refused) { alert('Could not route a trunk: ' + (net.reason || 'no storeys')); return; }
+    _renderSeedTrunk(disc, net);
+    if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+  } finally { bdb.close(); }
+};
 // §4 WITNESS SEAM: re-expose the (module-scope) disc-walk render entry points so a headless witness can drive
 // the render directly via the IDB-free engine API (dwOpen/dwBorrow with plain-fetched rules DBs) — the
 // production walk path (discWalk → dwInit/dwBorrowFile) goes through the bim_ootb_cache IndexedDB layer, which
@@ -2442,6 +2528,19 @@ function _registerDiscRoster() {
       }) }];
     },
     onWalk: function (disc) { window.discWalk(disc, { building: window.__dwName }); }
+  });
+  // SEED-TRUNK roster: route a service trunk from a human-assigned entry through the WALKED fixtures (corridor-aware,
+  // real-stair risers). Lists only disciplines already walked (they have placed fixtures to route). onWalk → popup.
+  window.Bonsai.outliner.addCategory({
+    key: 'disctrunk', label: 'Route trunk · from entry (seed)',
+    tree: function () {
+      var walked = Object.keys(window.__dwWalks || {}).filter(function (d) { return window.__dwWalks[d] && window.__dwWalks[d].length; });
+      if (!walked.length) return [{ id: 'dt-load', label: 'walk a discipline first, then route its trunk', kind: 'group', children: [] }];
+      return [{ id: 'dt-root', label: 'Service trunk from a chosen entry', kind: 'group', children: walked.map(function (d) {
+        return { id: 'dt-' + d, label: d, kind: 'disc', disc: d, sub: (window.__dwTrunk && window.__dwTrunk[d]) ? 'routed ▶' : '▶ route' };
+      }) }];
+    },
+    onWalk: function (disc) { window.seedTrunk(disc); }
   });
   console.log('§DISC-WALK roster registered disciplines=' + ((window.DiscWalker && window.DiscWalker.disciplines && window.DiscWalker.disciplines().join(',')) || ''));
 }

--- a/modeller/seed_trunk.js
+++ b/modeller/seed_trunk.js
@@ -1,0 +1,146 @@
+/**
+ * seed_trunk.js — the human-in-the-loop SEED → 3D corridor trunk, promoted from the W-SEED-TRUNK / W-CORRIDOR-TRUNK /
+ * W-RISER-TRUNK witness spikes into ONE reusable engine module (bim-compiler + bim-ootb modeller).
+ *
+ * DOCTRINE (docs/internal/WalkerDoctrine.md + WalkerMaturity.md SEED-TRUNK): a GENERATED discipline (one the building
+ * LACKS) is filled by density + host-bind, but WHERE it starts is the engineer's call. The human assigns a SEED (a real
+ * entry element); planTrunk routes a service trunk from it — corridor-aware per storey (around walls, through real doors)
+ * and joined across storeys by RISERS at real stairs. NON-INVENT: every blocked nav cell is a real wall, every passage a
+ * real door, every riser a real IfcStair; an unreachable fixture is REFUSED, never forced. The route is GENERATED/
+ * plausible (no ground truth for an absent discipline) — the guarantees are falsifiable: it does not cross walls, it
+ * rises only at real stairs, and it refuses what it cannot reach.
+ *
+ * API:  planTrunk(bdb, fixtures, seedPt, risers, opts) -> {
+ *          storeys:[{name,z,served,refused,len,cross,edges:[[x,y,z]..polyline]}], risers:[{x,y,z0,z1,guid}],
+ *          served, refused, totalLen, seed, oneNetwork:bool }
+ *   bdb       = a building extracted.db handle (exec(sql) → sql.js result) for wall/door queries.
+ *   fixtures  = [{x,y,z,storey,host?}]  (e.g. DiscWalker.dwWalk(disc,bdb).placements)
+ *   seedPt    = {x,y,storey}            (e.g. DiscWalker.defaultSeed(bdb))  — the ground entry
+ *   risers    = [{x,y,guid}]            real IfcStair columns (deduped by XY)
+ *   opts.cell (0.25), opts.groundStorey (else lowest-z storey present in fixtures)
+ */
+(function (root) {
+  'use strict';
+  function _rows(bdb, sql) { var r = bdb.exec(sql); if (!r.length) return [];
+    return r[0].values.map(function (v) { var o = {}; r[0].columns.forEach(function (c, i) { o[c] = v[i]; }); return o; }); }
+  function _esc(s) { return String(s).replace(/'/g, "''"); }
+
+  function Heap() { this.a = []; }
+  Heap.prototype.push = function (n, d) { var a = this.a; a.push([d, n]); var i = a.length - 1;
+    while (i > 0) { var p = (i - 1) >> 1; if (a[p][0] <= a[i][0]) break; var t = a[p]; a[p] = a[i]; a[i] = t; i = p; } };
+  Heap.prototype.pop = function () { var a = this.a, top = a[0], last = a.pop();
+    if (a.length) { a[0] = last; var i = 0, n = a.length; for (;;) { var l = 2 * i + 1, r = l + 1, m = i;
+      if (l < n && a[l][0] < a[m][0]) m = l; if (r < n && a[r][0] < a[m][0]) m = r; if (m === i) break;
+      var t = a[m]; a[m] = a[i]; a[i] = t; i = m; } } return top; };
+  Heap.prototype.size = function () { return this.a.length; };
+
+  // nav grid from REAL walls (blocked) + REAL doors (carved passages)
+  function makeGrid(walls, doors, bb, CELL) {
+    var PAD = CELL / 2, DOOR_R = 0.6, x0 = bb.x0 - 1, y0 = bb.y0 - 1;
+    var nx = Math.ceil((bb.x1 - bb.x0 + 2) / CELL), ny = Math.ceil((bb.y1 - bb.y0 + 2) / CELL);
+    function cx(ix) { return x0 + (ix + 0.5) * CELL; } function cy(iy) { return y0 + (iy + 0.5) * CELL; }
+    function inWall(px, py, w, pad) { return px >= w.x - w.bx / 2 - pad && px <= w.x + w.bx / 2 + pad &&
+      py >= w.y - w.by_ / 2 - pad && py <= w.y + w.by_ / 2 + pad; }
+    function nearDoor(px, py) { for (var i = 0; i < doors.length; i++) if (Math.hypot(px - doors[i].x, py - doors[i].y) <= DOOR_R) return true; return false; }
+    var blocked = new Uint8Array(nx * ny);
+    for (var iy = 0; iy < ny; iy++) for (var ix = 0; ix < nx; ix++) { var px = cx(ix), py = cy(iy), hit = false;
+      for (var k = 0; k < walls.length; k++) if (inWall(px, py, walls[k], PAD)) { hit = true; break; }
+      if (hit && nearDoor(px, py)) hit = false; if (hit) blocked[iy * nx + ix] = 1; }
+    function snap(px, py) { var ix0 = Math.round((px - x0) / CELL - 0.5), iy0 = Math.round((py - y0) / CELL - 0.5);
+      for (var r = 0; r < Math.max(nx, ny); r++) for (var dy = -r; dy <= r; dy++) for (var dx = -r; dx <= r; dx++) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== r) continue; var ix = ix0 + dx, iy = iy0 + dy;
+        if (ix < 0 || iy < 0 || ix >= nx || iy >= ny) continue; if (!blocked[iy * nx + ix]) return iy * nx + ix; } return -1; }
+    function dijkstra(srcCells) { var n = nx * ny, dist = new Float64Array(n).fill(Infinity), pred = new Int32Array(n).fill(-1), h = new Heap();
+      srcCells.forEach(function (c) { if (c >= 0) { dist[c] = 0; h.push(c, 0); } });
+      var NB = [[1, 0, 1], [-1, 0, 1], [0, 1, 1], [0, -1, 1], [1, 1, 1.4142], [1, -1, 1.4142], [-1, 1, 1.4142], [-1, -1, 1.4142]];
+      while (h.size()) { var top = h.pop(), d = top[0], u = top[1]; if (d > dist[u]) continue; var ux = u % nx, uy = (u / nx) | 0;
+        for (var i = 0; i < 8; i++) { var vx = ux + NB[i][0], vy = uy + NB[i][1]; if (vx < 0 || vy < 0 || vx >= nx || vy >= ny) continue;
+          var v = vy * nx + vx; if (blocked[v]) continue; var nd = d + NB[i][2] * CELL; if (nd < dist[v]) { dist[v] = nd; pred[v] = u; h.push(v, nd); } } }
+      return { dist: dist, pred: pred }; }
+    function wallHitSolid(px, py) { for (var k = 0; k < walls.length; k++) if (inWall(px, py, walls[k], 0) && !nearDoor(px, py)) return true; return false; }
+    return { nx: nx, cx: cx, cy: cy, snap: snap, dijkstra: dijkstra, wallHitSolid: wallHitSolid };
+  }
+  // union of each reached node's shortest path back to its nearest source → backbone polylines + length + wall-crossings
+  function backbone(grid, srcCells, nodeCells, z) {
+    var dj = grid.dijkstra(srcCells), used = {}, reached = [], cross = 0, len = 0, polys = [];
+    nodeCells.forEach(function (c, idx) {
+      if (c < 0 || !isFinite(dj.dist[c])) return; reached.push(idx);
+      var cur = c, g = 0, poly = [];
+      while (cur !== -1 && g++ < 1e5) { poly.push([grid.cx(cur % grid.nx), grid.cy((cur / grid.nx) | 0), z]);
+        var p = dj.pred[cur]; if (p === -1) break;
+        var key = cur < p ? cur + '_' + p : p + '_' + cur;
+        if (!used[key]) { used[key] = 1;
+          var mx = (grid.cx(cur % grid.nx) + grid.cx(p % grid.nx)) / 2, my = (grid.cy((cur / grid.nx) | 0) + grid.cy((p / grid.nx) | 0)) / 2;
+          if (grid.wallHitSolid(mx, my)) cross++;
+          len += Math.hypot(grid.cx(cur % grid.nx) - grid.cx(p % grid.nx), grid.cy((cur / grid.nx) | 0) - grid.cy((p / grid.nx) | 0)); }
+        cur = p; }
+      polys.push(poly);
+    });
+    return { reached: reached, len: len, cross: cross, polys: polys };
+  }
+
+  function planTrunk(bdb, fixtures, seedPt, risers, opts) {
+    opts = opts || {}; var CELL = opts.cell || 0.25;
+    var bb = _rows(bdb, "SELECT MIN(center_x) x0, MAX(center_x) x1, MIN(center_y) y0, MAX(center_y) y1 FROM element_transforms")[0];
+    var byS = {}; fixtures.forEach(function (p) { (byS[p.storey] = byS[p.storey] || []).push(p); });
+    var storeys;
+    if (opts.storeys && opts.storeys.length) {
+      // CALLER-SUPPLIED storey levels (the modeller has the storey tree → structural floor z, not fixture-mount z).
+      // This is the intended path: a riser climbs structural levels, not the elevated fixture median.
+      storeys = opts.storeys.filter(function (s) { return byS[s.name]; })
+        .map(function (s) { return { name: s.name, z: s.z, fx: byS[s.name] }; }).sort(function (a, b) { return a.z - b.z; });
+    } else {
+      // FALLBACK (no storey tree): structural floor level ≈ the LOW fixture z per storey (fixtures mount above the floor),
+      // and serve only storeys with ≥1 fixture. Coarser than caller-supplied; the modeller should pass opts.storeys.
+      storeys = Object.keys(byS).map(function (name) { var zs = byS[name].map(function (p) { return p.z; }).sort(function (a, b) { return a - b; });
+        return { name: name, z: zs[Math.floor(zs.length * 0.1)], fx: byS[name] }; }).sort(function (a, b) { return a.z - b.z; });
+    }
+    if (!storeys.length) return { refused: true, reason: 'no fixtures to route' };
+    // ground = the storey the SEED sits on (the service enters there), else the caller's groundStorey, else lowest.
+    var gName = opts.groundStorey || (seedPt && seedPt.storey);
+    var ground = gName ? storeys.filter(function (s) { return s.name === gName; })[0] : storeys[0];
+    if (!ground) ground = storeys[0];
+    // NOTE: parenthesize z — a NEGATIVE storey z (e.g. a foundation at -1.4) would render `center_z--1.4`, and SQLite
+    // reads `--` as a line comment, truncating the query ("incomplete input"). `(z)` keeps it a subtraction.
+    function wallsNear(z) { return _rows(bdb, "SELECT t.center_x x, t.center_y y, t.bbox_x bx, t.bbox_y by_ FROM elements_meta m " +
+      "JOIN element_transforms t ON m.guid=t.guid WHERE (m.ifc_class LIKE '%Wall%' OR m.ifc_class LIKE '%Column%') AND ABS(t.center_z-(" + z + "))<1.8"); }
+    function doorsOn(name) { return _rows(bdb, "SELECT t.center_x x, t.center_y y FROM elements_meta m JOIN element_transforms t " +
+      "ON m.guid=t.guid WHERE m.ifc_class LIKE '%Door%' AND m.storey='" + _esc(name) + "'"); }
+
+    var out = { seed: seedPt, risers: [], storeys: [], served: 0, refused: 0, totalLen: 0, oneNetwork: true };
+    // GROUND: corridor backbone from the seed; must also reach every riser base
+    var gGrid = makeGrid(wallsNear(ground.z), doorsOn(ground.name), bb, CELL);
+    var seedCell = gGrid.snap(seedPt.x, seedPt.y);
+    var riserBaseCells = risers.map(function (r) { return gGrid.snap(r.x, r.y); });
+    var gFxCells = ground.fx.map(function (p) { return gGrid.snap(p.x, p.y); });
+    var gBB = backbone(gGrid, [seedCell], riserBaseCells.concat(gFxCells), ground.z);
+    var risersFed = risers.map(function (r, i) { return gBB.reached.indexOf(i) >= 0; });
+    var gReached = gBB.reached.filter(function (idx) { return idx >= risers.length; }).length;
+    out.storeys.push({ name: ground.name, z: ground.z, served: gReached, refused: ground.fx.length - gReached,
+      len: gBB.len, cross: gBB.cross, edges: gBB.polys });
+    out.served += gReached; out.refused += ground.fx.length - gReached; out.totalLen += gBB.len;
+    var fedRisers = risers.filter(function (r, i) { return risersFed[i]; });
+    fedRisers.forEach(function (r) { out.risers.push({ x: r.x, y: r.y, guid: r.guid, z0: ground.z, z1: null }); });
+
+    // UPPER storeys: each fixture fed by its NEAREST REACHABLE fed-riser (multi-source); refuse the rest
+    storeys.forEach(function (S) {
+      if (S === ground) return;
+      var grid = makeGrid(wallsNear(S.z), doorsOn(S.name), bb, CELL);
+      var srcCells = fedRisers.map(function (r) { return grid.snap(r.x, r.y); });
+      var fxCells = S.fx.map(function (p) { return grid.snap(p.x, p.y); });
+      var bbk = srcCells.length ? backbone(grid, srcCells, fxCells, S.z) : { reached: [], len: 0, cross: 0, polys: [] };
+      out.storeys.push({ name: S.name, z: S.z, served: bbk.reached.length, refused: S.fx.length - bbk.reached.length,
+        len: bbk.len, cross: bbk.cross, edges: bbk.polys });
+      out.served += bbk.reached.length; out.refused += S.fx.length - bbk.reached.length; out.totalLen += bbk.len;
+      // riser vertical edges to this storey (length)
+      fedRisers.forEach(function (r) { out.totalLen += (S.z - ground.z); });
+    });
+    out.risers.forEach(function (r) { r.z1 = storeys[storeys.length - 1].z; });
+    out.oneNetwork = risersFed.some(Boolean) || storeys.length === 1;
+    return out;
+  }
+
+  var API = { planTrunk: planTrunk, makeGrid: makeGrid, backbone: backbone };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  if (root) root.SeedTrunk = API;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v22';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v23';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -55,6 +55,7 @@ const PRECACHE_ASSETS = [
   'sdg_cascade.js',
   'sdg_gate.js',
   'disc_walker.js',
+  'seed_trunk.js',
   'str_walker.js',
   'str_walker_bridge.js',
   'str_walker_outliner.js',


### PR DESCRIPTION
## What
Brings the **seed→3D corridor trunk** (proven in bim-compiler: W-SEED-TRUNK / -CORRIDOR / -RISER / -ENGINE, 6–7/7 each) live in the modeller.

The engineer assigns a service **entry** (a real door/stair) via a popup; `SeedTrunk.planTrunk` routes a **corridor-aware** trunk from it — around real walls, through real doors — joined across storeys by **risers at real stairs**. Non-invent (every blocked nav cell a real wall, every passage a real door, every riser a real IfcStair); unreachable fixtures are honestly **refused**, never forced.

## Flow (your spec: check → default → confirm/override)
On **Outliner → 'Route trunk · from entry (seed)' → <disc>**: if no seed, `DiscWalker.defaultSeed` suggests the most-external entry door; the popup lets you **OK or choose another**; then the trunk routes + renders (disc-coloured lines).

## Changes
- `modeller/seed_trunk.js` (**new**) — planTrunk engine module
- `modeller/disc_walker.js` — ported current engine (adds `defaultSeed` + FACE-SURFACE `gapSurface`; additive, `?v=5`)
- `modeller.html` — `_renderSeedTrunk` + `window.seedTrunk` + popup + `_seedRisers`/`_seedStoreys` + roster; wired into `_redrawAllDiscWalks`
- `sw.js` — `CACHE_VERSION` v22→v23, precache `seed_trunk.js`

## Verification
- Headless smoke (IDB-free engine path): `defaultSeed`→IfcDoor+14 candidates; `planTrunk` served **121** fixtures across 4 storeys via a real-stair riser, honest refuse; **no SQL crash** (fixed a negative-z `--` comment bug found by the smoke).
- Module-side UI fns verified by **ESM syntax check** (headless chromium lacks WebGL → can't run the THREE module); **live-verify in a real browser** after deploy via the `§SEED-TRUNK` log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)