### PR TITLE
feat(modeller): seed-trunk render GATE + construction animation (sw v24)

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -2394,24 +2394,74 @@ function _redrawAllDiscWalks() {
 // fixtures are REFUSED, never forced. GENERATED/plausible (no ground truth for an absent discipline). Rendered
 // as disc-coloured LineSegments under dwRoot (cleared/redrawn with the disc walk).
 window.__dwTrunk = window.__dwTrunk || {};
-function _renderSeedTrunk(disc, net) {
+function _renderSeedTrunk(disc, net, opts) {
+  opts = opts || {};
   var root = _dwRoot(); if (!root) return;
   root.children.slice().forEach(function (o) { if (o.userData && o.userData.dwTrunk === disc) root.remove(o); });
   window.__dwTrunk[disc] = net;
-  if (!net || net.refused || !net.storeys) { if (window.A && A.requestRender) A.requestRender(); return; }
-  var pts = [];
-  net.storeys.forEach(function (s) { (s.edges || []).forEach(function (poly) {
-    for (var i = 0; i + 1 < poly.length; i++) { pts.push(poly[i][0], poly[i][1], poly[i][2], poly[i + 1][0], poly[i + 1][1], poly[i + 1][2]); }
-  }); });
-  net.risers.forEach(function (r) { pts.push(r.x, r.y, r.z0, r.x, r.y, r.z1); });   // vertical riser at the real stair XY
+  // NB: net.refused on a SUCCESS net is the integer COUNT of unreachable fixtures (≥0), NOT a refusal flag — only the
+  // planTrunk early-return uses refused===true. Guarding on the truthy count wrongly blanked the trunk whenever any
+  // fixture was unreachable (caught by W-SEED-TRUNK-RENDER). Bail only on a genuine boolean refusal / missing storeys.
+  if (!net || net.refused === true || !net.storeys) { if (window.A && A.requestRender) A.requestRender(); return; }
+  // ── SEGMENTS KEYED BY GRAPH-PATH DISTANCE FROM THE SEED (Task 2 construction animation; prompts/RESUME_SEED_TRUNK.md
+  // §TASK 2). Each backbone polyline walks a fixture (leaf) BACK to its source: poly[last] is the SEED end on the ground
+  // storey (net.storeys[0], which planTrunk always pushes first), or the feeding riser base on an upper storey. We key
+  // every segment by its cumulative path length from that seed end, banded ground-corridor → riser-climb → upper-corridor,
+  // so the reveal grows OUTWARD from the seed. The order is DERIVED from the engine's own coords — it invents no order
+  // beyond the seed-distance the backbone already encodes (RENDER-only; the data/geometry is unchanged, just revealed).
+  var segs = [];   // { k:sortKey, v:[ax,ay,az,bx,by,bz] }
+  function addPoly(poly, base) {
+    var cum = 0;
+    for (var i = poly.length - 1; i > 0; i--) {           // walk from the seed end (poly[last]) toward the leaf (poly[0])
+      var a = poly[i], b = poly[i - 1];                   // a = nearer the seed, b = nearer the leaf
+      segs.push({ k: base + cum, v: [a[0], a[1], a[2], b[0], b[1], b[2]] });
+      cum += Math.hypot(b[0] - a[0], b[1] - a[1], b[2] - a[2]);
+    }
+    return cum;
+  }
+  var groundMax = 0;
+  (net.storeys[0].edges || []).forEach(function (poly) { if (poly.length >= 2) groundMax = Math.max(groundMax, addPoly(poly, 0)); });
+  var RISER_BAND = groundMax + 1;
+  net.risers.forEach(function (r, i) { segs.push({ k: RISER_BAND + i * 1e-3, v: [r.x, r.y, r.z0, r.x, r.y, r.z1] }); });   // riser climbs after the ground corridor
+  var UPPER_BAND = RISER_BAND + 1;
+  for (var si = 1; si < net.storeys.length; si++) {
+    (net.storeys[si].edges || []).forEach(function (poly) { if (poly.length >= 2) addPoly(poly, UPPER_BAND); });
+  }
+  segs.sort(function (a, b) { return a.k - b.k; });
+  var pts = []; segs.forEach(function (s) { pts.push(s.v[0], s.v[1], s.v[2], s.v[3], s.v[4], s.v[5]); });
   if (!pts.length) { if (window.A && A.requestRender) A.requestRender(); return; }
   var g = new THREE.BufferGeometry(); g.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3));
   var col = DW_COLOR[disc] || 0xffa500;
   var line = new THREE.LineSegments(g, new THREE.LineBasicMaterial({ color: col, linewidth: 2 }));
-  line.userData.dwTrunk = disc; root.add(line);
+  line.userData.dwTrunk = disc; line.userData.dwTrunkSegs = segs.length; root.add(line);
+  var _segs = segs.length, _riserSegs = net.risers.length, _corridorSegs = _segs - _riserSegs;
   console.log('§SEED-TRUNK ' + disc + ' served=' + net.served + ' refused=' + net.refused + ' risers=' + net.risers.length +
-    ' totalLen=' + net.totalLen.toFixed(1) + 'm segs=' + (pts.length / 6) + ' (corridor-aware, real-stair risers, non-invent)');
-  if (window.A && A.requestRender) A.requestRender();
+    ' totalLen=' + net.totalLen.toFixed(1) + 'm segs=' + _segs + ' (rendered corridorSegs=' + _corridorSegs +
+    ' riserSegs=' + _riserSegs + '; seed-outward ordered; corridor-aware, real-stair risers, non-invent)');
+  // CONSTRUCTION ANIMATION — reveal seed-outward via the geometry draw-range. RENDER-only effect; ends EXACTLY on the
+  // full proven geometry (gate-asserted via §SEED-TRUNK-ANIM finalSegs==net). prefers-reduced-motion → instant fallback.
+  var TOTAL_V = pts.length / 3;                            // vertices (non-indexed: 2 per segment)
+  var reduced = false; try { reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) {}
+  if (opts.instant || reduced) {
+    g.setDrawRange(0, TOTAL_V);
+    console.log('§SEED-TRUNK-ANIM ' + disc + ' mode=' + (opts.instant ? 'instant' : 'reduced-motion') + ' frames=0 ms=0 finalSegs=' + _segs + ' (no animation; full geometry)');
+    if (window.A && A.requestRender) A.requestRender(); return;
+  }
+  g.setDrawRange(0, 0);
+  var DUR = 2000, t0 = null, frames = 0;
+  (function step(now) {
+    if (t0 === null) t0 = now; frames++;
+    var u = Math.min(1, (now - t0) / DUR), e = 1 - Math.pow(1 - u, 3);   // easeOutCubic
+    g.setDrawRange(0, Math.floor(e * _segs) * 2);
+    if (window.A && A.requestRender) A.requestRender();
+    if (u < 1) { requestAnimationFrame(step); }
+    else {
+      g.setDrawRange(0, TOTAL_V); var finalSegs = g.drawRange.count / 2;
+      console.log('§SEED-TRUNK-ANIM ' + disc + ' mode=animated frames=' + frames + ' ms=' + Math.round(now - t0) +
+        ' finalSegs=' + finalSegs + ' (' + (finalSegs === _segs ? 'EXACT==net' : 'MISMATCH net=' + _segs) + '; ends at full proven geometry)');
+      if (window.A && A.requestRender) A.requestRender();
+    }
+  })(typeof performance !== 'undefined' && performance.now ? performance.now() : 0);
 }
 // risers = real IfcStair columns (deduped by XY); storeys = the building's floors (z = lowest element per storey,
 // deduped ≥2m apart, named storeys only) — the structural levels the riser climbs, not the elevated fixture z.
@@ -2465,7 +2515,7 @@ window.seedTrunk = async function (disc) {
     if (!chosen) return;                                    // user cancelled
     var net = window.SeedTrunk.planTrunk(bdb, fixtures, { x: chosen.x, y: chosen.y, storey: chosen.storey },
       _seedRisers(bdb), { storeys: _seedStoreys(bdb, fixtures), groundStorey: chosen.storey });
-    if (net.refused) { alert('Could not route a trunk: ' + (net.reason || 'no storeys')); return; }
+    if (net.refused === true) { alert('Could not route a trunk: ' + (net.reason || 'no storeys')); return; }   // boolean refusal only (refused is else a fixture COUNT)
     _renderSeedTrunk(disc, net);
     if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.refresh();
   } finally { bdb.close(); }
@@ -2476,6 +2526,9 @@ window.seedTrunk = async function (disc) {
 // is unreliable under puppeteer+swiftshader (fine in real browsers). This seam is render-only (no new behaviour;
 // it calls the same functions the live walk calls), used by modeller/tests/witness_dw_pixelprobe.js.
 window.__dwRender = { walk: _renderDiscWalk, assembly: _renderDiscAssembly, redraw: _redrawAllDiscWalks };
+// render-only seam for the seed-trunk render gate (W-SEED-TRUNK-RENDER): drives the SAME _renderSeedTrunk the live
+// "Route trunk" calls (with opts, so the witness can exercise the animated path as well as the instant census path).
+window.__seedTrunkRender = _renderSeedTrunk;
 // §4 WHITEBOX PIXEL PROBE (roadmap #4): a headless readback proving the disc-walk render actually painted —
 // (1) a scene-graph census of the dwRoot group for a disc (fixture box InstancedMesh, §3c connector-edge
 // LineSegments, routed tubes, assembled parts) so a witness confirms the render WIRED the expected objects,
@@ -2503,6 +2556,61 @@ window.__dwPixelProbe = function (disc) {
   } catch (e) { out.err = (out.err ? out.err + '; ' : '') + 'readPixels ' + (e && e.message); }
   console.log('§DW-PIXELPROBE disc=' + disc + ' boxes=' + out.boxes + ' instances=' + out.instances +
     ' connectorEdges=' + out.edges + ' tubes=' + out.tubes + ' parts=' + out.parts + ' asmEdges=' + out.asmEdges +
+    ' litPixels=' + out.litPct + '%' + (out.err ? ' err=' + out.err : ''));
+  return out;
+};
+// T1 SEED-TRUNK RENDER GATE (prompts/RESUME_SEED_TRUNK.md §TASK 1; W-SEED-TRUNK-RENDER) — the seed-trunk analogue
+// of __dwPixelProbe. Renders the trunk via the SAME _renderSeedTrunk the live walk calls, then returns a SCENE-GRAPH
+// CENSUS of the dwTrunk LineSegments under dwRoot so a headless witness machine-verifies the render == planTrunk's net
+// (closing the "eyeball gap"). WHITEBOX (like §DW-TUBE endpointDrift): the rendered vertices are read back and the
+// witness asserts they match net's coords + counts — the gate asserts render==data, never a magic number. NON-INVENT:
+// pure readback of the rendered frame + scene graph; no synthetic data. Returns the census + litPct; logs §SEED-TRUNK-PROBE.
+window.__seedTrunkProbe = function (disc, net) {
+  _renderSeedTrunk(disc, net, { instant: true });          // SAME render the Outliner "Route trunk" calls; instant = final geometry for the gate
+  var out = { disc: disc, lineSegments: 0, vertices: 0, segments: 0, verticalSegs: 0, corridorSegs: 0, maxDrift: 0, samples: 0, litPct: 0 };
+  var rendered = [];                                        // [[x,y,z]..] every rendered vertex (for the no-drift check)
+  try {
+    var root = _dwRoot();
+    var lines = root ? root.children.filter(function (o) { return o.isLineSegments && o.userData && o.userData.dwTrunk === disc; }) : [];
+    out.lineSegments = lines.length;
+    lines.forEach(function (line) {
+      var pos = line.geometry.getAttribute('position'); if (!pos) return;
+      out.vertices += pos.count;
+      for (var i = 0; i + 1 < pos.count; i += 2) {           // each pair (i, i+1) = one rendered segment
+        var ax = pos.getX(i), ay = pos.getY(i), az = pos.getZ(i), bx = pos.getX(i + 1), by = pos.getY(i + 1), bz = pos.getZ(i + 1);
+        rendered.push([ax, ay, az], [bx, by, bz]);
+        out.segments++;
+        // a riser is a vertical segment (same XY, Δz≠0); a corridor segment lies in a storey plane (Δz≈0)
+        if (Math.abs(ax - bx) < 1e-4 && Math.abs(ay - by) < 1e-4 && Math.abs(az - bz) > 1e-4) out.verticalSegs++;
+        else out.corridorSegs++;
+      }
+    });
+    // NO-DRIFT (order-independent, whitebox like §DW-TUBE endpointDrift): sample net's own polyline+riser points and
+    // confirm each maps to a rendered vertex within tol → the render carries planTrunk's coords verbatim. Order-free so
+    // the seed-outward animation reorder (Task 2) cannot perturb it.
+    if (net && net.storeys && rendered.length) {
+      var samplePts = [];
+      net.storeys.forEach(function (s) { (s.edges || []).forEach(function (poly) { poly.forEach(function (p) { samplePts.push(p); }); }); });
+      (net.risers || []).forEach(function (r) { samplePts.push([r.x, r.y, r.z0], [r.x, r.y, r.z1]); });
+      var stride = Math.max(1, Math.floor(samplePts.length / 60));   // cap ≈60 samples
+      for (var si = 0; si < samplePts.length; si += stride) {
+        var p = samplePts[si], best = Infinity;
+        for (var ri = 0; ri < rendered.length; ri++) { var q = rendered[ri];
+          var d = Math.hypot(p[0] - q[0], p[1] - q[1], p[2] - q[2]); if (d < best) { best = d; if (best < 1e-6) break; } }
+        if (best > out.maxDrift) out.maxDrift = best; out.samples++;
+      }
+    }
+  } catch (e) { out.err = 'census ' + (e && e.message); }
+  try {
+    var r = window.A.renderer; r.render(window.A.scene, window.A.camera); var gl = r.getContext();
+    var w = gl.drawingBufferWidth, h = gl.drawingBufferHeight, px = new Uint8Array(w * h * 4);
+    gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px); var lit = 0;
+    for (var i = 0; i < px.length; i += 4) { if (px[i] > 40 || px[i + 1] > 44 || px[i + 2] > 52) lit++; }
+    out.litPct = +(100 * lit / (w * h)).toFixed(2);
+  } catch (e) { out.err = (out.err ? out.err + '; ' : '') + 'readPixels ' + (e && e.message); }
+  console.log('§SEED-TRUNK-PROBE disc=' + disc + ' lineSegments=' + out.lineSegments + ' vertices=' + out.vertices +
+    ' segments=' + out.segments + ' corridorSegs=' + out.corridorSegs + ' verticalSegs(risers)=' + out.verticalSegs +
+    ' maxDrift=' + out.maxDrift.toExponential(2) + 'm samples=' + out.samples +
     ' litPixels=' + out.litPct + '%' + (out.err ? ' err=' + out.err : ''));
   return out;
 };

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v23';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v24';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_seed_trunk_render.js
+++ b/modeller/tests/witness_seed_trunk_render.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-SEED-TRUNK-RENDER scope (read this block first)
+ * SCOPE: prompts/RESUME_SEED_TRUNK.md §TASK 1 — the STANDING render gate for the seed→3D corridor trunk. Closes the
+ *   "eyeball gap": the seed-trunk ENGINE is witnessed in bim-compiler (W-SEED-TRUNK / -CORRIDOR / -RISER / -ENGINE),
+ *   but the modeller RENDER of the trunk (disc-coloured LineSegments: per-storey corridor polylines + vertical risers)
+ *   shipped (#580) proven only by eyeball. This headless readback machine-verifies that _renderSeedTrunk paints the
+ *   trunk and that the rendered geometry == SeedTrunk.planTrunk's net (counts + a sampled coord), so every future
+ *   render change is GATED, not eyeballed.
+ *
+ *   ⚠ Drives the render via the IDB-FREE engine API (dwOpen/dwBorrow with PLAIN-FETCHED rules DBs) + the
+ *   window.__seedTrunkProbe seam — NOT the production discWalk()/seedTrunk() path, which caches rules in the
+ *   bim_ootb_cache IndexedDB layer (unreliable under puppeteer+swiftshader; fine in real browsers). The RENDER
+ *   function exercised here (_renderSeedTrunk) is byte-for-byte the one window.seedTrunk() invokes.
+ *
+ *   WIRING/deploy check (TestArchitecture §Browser Testing) — the trunk's geometry VALUES are proven by the
+ *   bim-compiler node witnesses (W-SEEDTRUNK-ENGINE 6/6 etc.). Read the §-log; exit ≠ evidence.
+ *
+ * THE WORKING SWIFTSHADER FLAGS (the eyeball-blocker was a wrong flag, not a wall — see the card): the precedent is
+ *   witness_dw_pixelprobe.js. `--use-gl=angle --use-angle=swiftshader` works; `--use-gl=swiftshader` FAILS
+ *   ("Error creating WebGL context"). Do NOT repeat the wrong flag.
+ *
+ * CLAIMS (ELEC trunk on Duplex — residential, walked via duplex_rules.db):
+ *   P1 RENDERED       — dwRoot carries exactly 1 LineSegments tagged userData.dwTrunk==='ELEC' (the trunk drew).
+ *   P2 VERTS==DATA    — rendered geometry.position.count == 2 × (Σ corridor polyline segs + risers) computed from net
+ *                       (the gate asserts render==planTrunk data, NOT a magic number).
+ *   P3 RISERS==DATA   — vertical rendered segments (Δz≠0) == net's climbing risers; corridor segs == Σ(poly.length-1).
+ *   P4 NO-DRIFT       — every sampled net polyline/riser point maps to a rendered vertex within 1e-3m (order-independent
+ *                       whitebox, like §DW-TUBE endpointDrift): the render carries planTrunk's coords verbatim.
+ *   P5 PAINTED        — litPixels > 0 after render (canvas non-blank; the trunk reached the framebuffer).
+ *   P6 NO-ERROR       — no pageerror / no walk error.
+ *   P7 ANIM-ENDS-FULL — the construction animation (Task 2) ends EXACTLY on the full proven geometry: driving the
+ *                       ANIMATED render path emits §SEED-TRUNK-ANIM with finalSegs == net segs over >1 frame.
+ *   P8 REDUCED-MOTION — with prefers-reduced-motion:reduce emulated, the render falls back to instant (full geometry,
+ *                       frames=0) — accessibility-safe, still ends on the proven geometry.
+ *   REGRESSION        — W-DW-PIXELPROBE must still be green (run separately; this gate does not perturb it).
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const ROOT = path.join(__dirname, '..', '..');   // repo root → ../modeller/<db> + rules DBs resolve
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' });
+    r.end(b);
+  });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1100, height: 800 });
+  const logs = [];
+  pg.on('console', m => { const t = m.text(); if (/^§(SEED-TRUNK|DISC-WALK|DW-)/.test(t)) logs.push(t); });
+  const errs = [];
+  pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+
+  console.log('═══ W-SEED-TRUNK-RENDER — seed→3D trunk render paints + render==planTrunk net (headless, Duplex ELEC) ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.SQL && !!window.DiscWalker && !!window.SeedTrunk && !!window.__seedTrunkProbe',
+    { timeout: 30000 }).catch(() => {});
+
+  // open Duplex (sets window.__dwBuf + establishes the scene/dwRoot host)
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(500);
+
+  // Drive the ELEC walk + seed + trunk plan via the IDB-FREE engine API, then render via __seedTrunkProbe (the seam
+  // that calls the SAME _renderSeedTrunk window.seedTrunk() calls). Return the net summary + the scene-graph census.
+  logs.length = 0;
+  const res = await pg.evaluate(async () => {
+    try {
+      const SQL = window.SQL, DW = window.DiscWalker, ST = window.SeedTrunk;
+      const dxBuf = await (await fetch('./duplex_rules.db')).arrayBuffer();
+      DW.dwOpen(new SQL.Database(new Uint8Array(dxBuf)));               // residential rules (duplex_rules.db)
+      const bdb = new SQL.Database(new Uint8Array(window.__dwBuf));
+      const w = DW.dwWalk('ELEC', bdb, 'Duplex');
+      const fixtures = w.placements;
+      const seed = DW.defaultSeed(bdb, { vertical: true });             // door/stair entry (deterministic default)
+      // storey levels (the modeller's caller path): each named storey at its median fixture z
+      const byS = {}; fixtures.forEach(p => { if (p.storey && !/^unknown$/i.test(p.storey)) (byS[p.storey] = byS[p.storey] || []).push(p.z); });
+      const storeys = Object.keys(byS).map(nm => { const zs = byS[nm].slice().sort((a, b) => a - b); return { name: nm, z: zs[zs.length >> 1] }; })
+        .sort((a, b) => a.z - b.z);
+      // risers = real IfcStair columns, deduped by XY
+      const rr = bdb.exec("SELECT m.guid g, t.center_x x, t.center_y y FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class LIKE '%Stair%'");
+      const risers = []; if (rr.length) rr[0].values.forEach(v => { const s = { guid: v[0], x: v[1], y: v[2] };
+        if (!risers.some(o => Math.hypot(o.x - s.x, o.y - s.y) < 0.5)) risers.push(s); });
+      const net = ST.planTrunk(bdb, fixtures, { x: seed.x, y: seed.y, storey: seed.storey }, risers,
+        { storeys: storeys, groundStorey: seed.storey });
+      const diag = { walk: fixtures.length, placed: w.placed, seedRefused: !!seed.refused, seedReason: seed.reason || '',
+        seedStorey: seed.storey, storeys: storeys.map(s => s.name + '@' + (s.z != null ? s.z.toFixed(2) : '?')), risers: risers.length };
+      bdb.close();
+      if (net.refused === true) return { err: 'planTrunk refused: ' + (net.reason || '(none)'), diag };   // boolean refusal (net.refused is else a fixture COUNT)
+      // EXPECTED counts derived from the SAME net the render consumes (render==data, not a magic number)
+      let expCorridor = 0;
+      net.storeys.forEach(s => (s.edges || []).forEach(poly => { expCorridor += Math.max(0, poly.length - 1); }));
+      const expRiserClimb = net.risers.filter(r => Math.abs(r.z1 - r.z0) > 1e-6).length;
+      const expSegs = expCorridor + net.risers.length;
+      window.__stNet = net;                                            // keep for the animated/reduced-motion runs (P7/P8)
+      const probe = window.__seedTrunkProbe('ELEC', net);              // ← RENDERS (instant) via _renderSeedTrunk + censuses dwRoot
+      return { fixtures: fixtures.length, served: net.served, refused: net.refused, risers: net.risers.length,
+        expCorridor, expRiserClimb, expSegs, probe };
+    } catch (e) { return { err: String(e && e.message) + ' | ' + ((e.stack || '').split('\n')[1] || '') }; }
+  });
+  await sleep(300);
+
+  if (res.err) { console.log('  §ERR ' + res.err); if (res.diag) console.log('  §DIAG ' + JSON.stringify(res.diag)); await br.close(); server.close(); console.log('W-SEED-TRUNK-RENDER: 0 PASS / 1 FAIL'); process.exit(1); }
+  const p = res.probe;
+  console.log('  §NET fixtures=' + res.fixtures + ' served=' + res.served + ' refused=' + res.refused + ' risers=' + res.risers +
+    ' expSegs=' + res.expSegs + ' (corridor=' + res.expCorridor + ' riserClimb=' + res.expRiserClimb + ')');
+  console.log('  §PROBE ' + JSON.stringify(p));
+  console.log('  ' + (logs.find(l => /§SEED-TRUNK-PROBE/.test(l)) || '(no §SEED-TRUNK-PROBE)'));
+
+  // P7 — drive the ANIMATED render path (no instant), let rAF run to completion, read the §SEED-TRUNK-ANIM log.
+  logs.length = 0;
+  await pg.emulateMediaFeatures([{ name: 'prefers-reduced-motion', value: 'no-preference' }]);
+  await pg.evaluate(() => window.__seedTrunkRender('ELEC', window.__stNet));   // animated (opts default)
+  await pg.waitForFunction(() => !!window.console, { timeout: 100 }).catch(() => {});
+  await sleep(2800);                                                  // DUR=2000ms + margin for rAF to settle
+  const animLog = logs.find(l => /§SEED-TRUNK-ANIM ELEC mode=animated/.test(l)) || '';
+  const animSegs = (animLog.match(/finalSegs=(\d+)/) || [])[1];
+  const animFrames = +((animLog.match(/frames=(\d+)/) || [])[1] || 0);
+  console.log('  ' + (animLog || '(no animated §SEED-TRUNK-ANIM)'));
+
+  // P8 — reduced-motion instant fallback.
+  logs.length = 0;
+  await pg.emulateMediaFeatures([{ name: 'prefers-reduced-motion', value: 'reduce' }]);
+  await pg.evaluate(() => window.__seedTrunkRender('ELEC', window.__stNet));
+  await sleep(300);
+  const rmLog = logs.find(l => /§SEED-TRUNK-ANIM ELEC mode=reduced-motion/.test(l)) || '';
+  const rmSegs = (rmLog.match(/finalSegs=(\d+)/) || [])[1];
+  console.log('  ' + (rmLog || '(no reduced-motion §SEED-TRUNK-ANIM)'));
+
+  await br.close(); server.close();
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  chk('P1 RENDERED (1 dwTrunk LineSegments)', p.lineSegments === 1, 'lineSegments=' + p.lineSegments);
+  chk('P2 VERTS == 2×data segs', p.vertices === 2 * res.expSegs && p.segments === res.expSegs, 'vertices=' + p.vertices + ' expVertices=' + (2 * res.expSegs) + ' segments=' + p.segments);
+  chk('P3 RISERS+CORRIDOR == data', p.verticalSegs === res.expRiserClimb && p.corridorSegs === (res.expSegs - res.expRiserClimb), 'verticalSegs=' + p.verticalSegs + ' expRiserClimb=' + res.expRiserClimb + ' corridorSegs=' + p.corridorSegs);
+  chk('P4 NO-DRIFT (all sampled net pts on rendered verts)', p.samples > 0 && p.maxDrift < 1e-3, 'maxDrift=' + (p.maxDrift != null ? p.maxDrift.toExponential(2) : '?') + 'm samples=' + p.samples);
+  chk('P5 PAINTED (canvas non-blank)', p.litPct > 0, 'litPixels=' + p.litPct + '%');
+  chk('P6 no pageerror', errs.length === 0 && !p.err, (p.err || '') + ' ' + errs.slice(0, 2).join(' | '));
+  chk('P7 ANIM ends on full proven geometry', animSegs === String(res.expSegs) && animFrames > 1, 'finalSegs=' + animSegs + ' expSegs=' + res.expSegs + ' frames=' + animFrames);
+  chk('P8 REDUCED-MOTION instant fallback', rmSegs === String(res.expSegs), 'finalSegs=' + rmSegs + ' expSegs=' + res.expSegs);
+
+  console.log('W-SEED-TRUNK-RENDER: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
Closes the seed→3D corridor trunk **eyeball gap** with a machine render gate and adds a **construction animation** (the trunk grows from the seed outward). `prompts/RESUME_SEED_TRUNK.md` T1 + T2.

### T1 — Render gate (W-SEED-TRUNK-RENDER, 8/8 GREEN)
- `window.__seedTrunkProbe(disc, net)`: renders via the SAME `_renderSeedTrunk` the live "Route trunk" calls, then a scene-graph census of the `dwTrunk` LineSegments (vertices == 2×data segs, vertical risers, corridor segs) + an order-independent no-drift check (every sampled `net` point maps to a rendered vertex <1e-3m) + one-frame readPixels litPct.
- `modeller/tests/witness_seed_trunk_render.js` — headless swiftshader, IDB-free engine API (the proven `--use-gl=angle --use-angle=swiftshader` flags). Duplex ELEC walk → `defaultSeed` → `planTrunk` → probe. **maxDrift 5e-7m, litPct 64%.** W-DW-PIXELPROBE regression green.

### 🐞 Real bug caught by the gate
`_renderSeedTrunk` / `window.seedTrunk` guarded on `net.refused` being truthy — but on a SUCCESS net `refused` is the integer **COUNT** of unreachable fixtures (only the `planTrunk` early-return uses `refused===true`). So any building with a refused fixture rendered an **empty trunk** / alerted "could not route". Duplex ELEC refuses 112/267 yet now renders all 5936 segments. Fixed to `=== true`.

### T2 — Construction animation
The trunk grows from the seed outward: segments keyed by **graph-path distance from the seed** (derived from the engine's own polyline coords — invents no order beyond the seed-distance the backbone already encodes), banded ground-corridor → riser-climb → upper-corridor, revealed via `geometry.setDrawRange` over ~2s easeOutCubic. RENDER-only (data unchanged); `prefers-reduced-motion` → instant fallback. `§SEED-TRUNK-ANIM` logs frames/ms/finalSegs; the gate asserts the animation ends **exactly** on `net` (P7 animated 32 frames/2033ms finalSegs==5936; P8 reduced-motion instant).

## Witness
```
W-SEED-TRUNK-RENDER: 8 PASS / 0 FAIL
W-DW-PIXELPROBE: 6 PASS / 0 FAIL (regression)
```
sw v23→v24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)