### PR TITLE
fix(modeller): Walk tool — borrow hang + 112s commit freeze; user-emulating E2E gates (sw v25)

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -94,21 +94,32 @@
   // opens the rules with NO network — making the modeller sw.js "terminal_rules.db cached in
   // IndexedDB" claim true. Try IDB hit → on miss fetch + put → bare fetch fallback on any IDB
   // error. Browser-only: node witnesses use dwOpen and never reach this path (indexedDB guard).
+  // The IndexedDB cache is an OFFLINE OPTIMISATION, never the source of truth — so NO IDB operation may ever block
+  // a rules load. Under concurrent IDB use of the SHARED bim_ootb_cache 'dbs' store (scene.js caching the building
+  // DB + a fire-and-forget put + this get all contend), an open/get can hang WITHOUT firing success OR error — the
+  // classic silent-inactive-transaction failure. That stalled discWalk's pre-walk borrow → the whole Walk tool
+  // rendered nothing for the user (W-E2E-WALK proved this; nondeterministic race). Every IDB await is therefore
+  // timeout-guarded: a stall resolves to null and _loadDbBuf falls back to a bare network fetch (deterministic, no hang).
+  var IDB_TIMEOUT_MS = 1500;
+  function _withTimeout(p, ms, fallback) {
+    return Promise.race([p, new Promise(function (res) { setTimeout(function () { res(fallback); }, ms); })]);
+  }
   function _openCacheDB() {
     if (typeof indexedDB === 'undefined') return Promise.resolve(null);
-    if (ROOT.APP && ROOT.APP.openCacheDB) { try { return ROOT.APP.openCacheDB(); } catch (e) { /* fall through */ } }
-    return new Promise(function (res) {                       // no version → current (avoid VersionError drift below scene.js v2)
+    if (ROOT.APP && ROOT.APP.openCacheDB) { try { return _withTimeout(Promise.resolve(ROOT.APP.openCacheDB()), IDB_TIMEOUT_MS, null); } catch (e) { /* fall through */ } }
+    return _withTimeout(new Promise(function (res) {          // no version → current (avoid VersionError drift below scene.js v2)
       var rq = indexedDB.open('bim_ootb_cache');
       rq.onsuccess = function () { res(rq.result); };
       rq.onerror = function () { res(null); };
-    });
+      rq.onblocked = function () { res(null); };              // another connection blocks the open → don't wait, fall back to fetch
+    }), IDB_TIMEOUT_MS, null);
   }
   function _idbGet(idb, key) {
-    return new Promise(function (res) {
+    return _withTimeout(new Promise(function (res) {
       try { var rq = idb.transaction('dbs', 'readonly').objectStore('dbs').get(key);
         rq.onsuccess = function () { res(rq.result || null); }; rq.onerror = function () { res(null); };
       } catch (e) { res(null); }
-    });
+    }), IDB_TIMEOUT_MS, null);                                // a hung readonly tx (store-lock contention) → null → MISS → fetch
   }
   function _idbPut(idb, key, buf) {
     try { var tx = idb.transaction('dbs', 'readwrite'); tx.objectStore('dbs').put(buf, key);

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -220,7 +220,7 @@
 <!-- DiscWalker: the ONE shared discipline-walker engine (Placer/Router/Gate) reading the MEASURED
      terminal_rules.db (mined off Terminal). Supersedes the thin mep_rw.db recipes for the disc-node walk —
      every disc walks on ANY opened building from rules measured off a real coordinated building. -->
-<script src="disc_walker.js?v=5" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
+<script src="disc_walker.js?v=6" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
 <script src="seed_trunk.js?v=1" onerror="console.warn('§ST LOAD_FAIL seed_trunk.js')"></script>
 <!-- Modeller's OWN service worker (its own app folder now — trilogy viewer/·erp/·modeller/; mirrors erp/sw.js). -->
 <script>
@@ -2274,27 +2274,34 @@ async function _commitDiscWalk(disc, placements) {
   if (!O || !L) return 0;
   var cat = L.catalog() || [];
   var color = DW_COLOR[disc] || 0xc0c0c0;
-  var committed = 0;
+  // BATCH the placements into ONE signed group. Was a loop of N awaited O.commit() — each commit seals the chain +
+  // verifyChain + re-folds the WHOLE scene, ~0.4s each → a 267-fixture ELEC walk FROZE the UI for 112s (W-E2E-WALK
+  // measured it: walk+render done at 1.0s, commit ran to 113s). commitSeedGroup seals ONCE (one verifyChain, one
+  // fold) — same signed-chain result, ~1s. Safe: kernel_ops orders by rowid (ORDER BY id), never timestamp, so the
+  // shared group baseTs never affects ordering/hash. gid unique per walk (O.length) so a re-walk commits afresh.
+  var ops = [];
   for (var i = 0; i < placements.length; i++) {
     var p = placements[i];
     var found = cat.find(function (c) { return c.ifc_class === p.ifc_class; });
     var hash = found ? found.hash : (cat[0] ? cat[0].hash : null);
     if (!hash) continue;
-    var op = { op_type: 'GEOM_INSERT',
-      parameters: { hash: hash, placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +p.z.toFixed(4), rot: p.yaw || 0 },
-                    lod: '200', color: color,
-                    _dw: { disc: p.disc, storey: p.storey || '', prov: p.prov || '', ifc: p.ifc_class, host: p.host || null } } };
-    try { var res = await O.commit(op); if (res) committed++; }
-    catch (e) { console.warn('§DISC-WALK-COMMIT fail i=' + i + ' ' + (e && e.message)); }
+    ops.push({ op_type: 'GEOM_INSERT',
+      params: { hash: hash, placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +p.z.toFixed(4), rot: p.yaw || 0 },
+                lod: '200', color: color,
+                _dw: { disc: p.disc, storey: p.storey || '', prov: p.prov || '', ifc: p.ifc_class, host: p.host || null } } });
+  }
+  var committed = 0;
+  if (ops.length) {
+    try { var res = await O.commitSeedGroup(ops, 'dwwalk-' + disc + '-' + O.length); committed = (res.ids || []).length; }
+    catch (e) { console.warn('§DISC-WALK-COMMIT batch fail ' + (e && e.message)); }
   }
   if (committed) {
-    await O.scrubTo(O.length);
-    // foldChainToScene clears the editable group — restore ALL walked markers + chains on top of committed geometry
+    // commitSeedGroup already folded the chain (clears the editable group) — restore the walked markers + chains
     _redrawAllDiscWalks();
     if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     syncHistory(); audioCue('rollout');
   }
-  console.log('§DISC-WALK-COMMIT disc=' + disc + ' placements=' + placements.length + ' committed=' + committed);
+  console.log('§DISC-WALK-COMMIT disc=' + disc + ' placements=' + placements.length + ' committed=' + committed + ' (1 signed group)');
   window.__dwLastCommitDisc = disc;   // sentinel for witnesses
   return committed;
 }

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v24';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v25';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_e2e_move.js
+++ b/modeller/tests/witness_e2e_move.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-MOVE scope (read this block first)
+ * SCOPE: a USER-EMULATING, MATHS-ASSERTED, ATOMIC end-to-end test of the MOVE authoring tool — the standard the
+ *   user set: "a test suite must emulate a user series of actions that confirms each function works completely,
+ *   perfectly and atomically." This drives the REAL production path with REAL mouse input (puppeteer pg.mouse →
+ *   Chrome pointer events), NOT an engine seam: open a building from the chooser, PICK an element by clicking it,
+ *   enter Move, DRAG the X gizmo handle, RELEASE to commit, then UNDO via the real history slider. Every claim is a
+ *   number read back from the live op-log + scene graph + framebuffer — no eyeballing, no magic constants.
+ *
+ * THE WORKING SWIFTSHADER FLAGS: --use-gl=angle --use-angle=swiftshader (precedent witness_dw_pixelprobe.js).
+ *
+ * CLAIMS (Duplex, a real picked element):
+ *   A1 OPEN-REAL      — clicking Open → Duplex loads the building as editable meshes (group has ≥1 featureId mesh).
+ *   A2 PICK-REAL      — a real mouse click on an element SELECTS it (window.Bonsai._selSet gains exactly that fid).
+ *   A3 MOVE-ENTER     — clicking the Move pill enters move mode (b-move 'on') and builds the XYZ gizmo in the scene.
+ *   A4 DRAG-COMMITS   — a real X-handle drag+release commits EXACTLY ONE GEOM_MOVE op for the selected fid (op-log +1).
+ *   A5 ATOMIC         — the moved mesh's bbox-centre displacement == the committed op delta within 1e-3m
+ *                       (what is committed IS what is rendered — one coherent result, no drift).
+ *   A6 AXIS-PERFECT   — an X drag moves ONLY X: op dy==0 and dz==0, |dx|>0.01 (the axis constraint held).
+ *   A7 VISIBLE        — the framebuffer changed after the move (readPixels checksum differs → the user SEES it move).
+ *   A8 REVERSIBLE     — UNDO via the real history slider restores the bbox-centre to the original within 1e-3m and
+ *                       drops the op cursor by 1 (the action is atomic + perfectly reversible).
+ *   A9 NO-ERROR       — no pageerror across the whole sequence.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404 ' + p); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850 });
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+  const slog = []; pg.on('console', m => { const t = m.text(); if (/^§(MOVE|SDG|GATE)/.test(t)) slog.push(t); });
+
+  console.log('═══ W-E2E-MOVE — real user: open → pick → move gizmo drag → commit → undo (maths-asserted, atomic) ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.THREE && !!window.A && !!window.Bonsai', { timeout: 30000 }).catch(() => {});
+
+  // A1 — real Open → Duplex
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(2500);
+  const fit = await pg.$('#b-fit'); if (fit) { await fit.click(); await sleep(600); }
+
+  const editable = await pg.evaluate(() => {
+    const g = window.Bonsai.group(); return g.children.filter(o => o.isMesh && o.userData && o.userData.featureId != null).length;
+  });
+
+  // in-page helper: project a world point → client px (THREE is global, camera = window.A.camera)
+  await pg.evaluate(() => {
+    window.__e2e = {
+      proj(x, y, z) { const v = new window.THREE.Vector3(x, y, z).project(window.A.camera);
+        const cv = window.A.renderer.domElement, r = cv.getBoundingClientRect();
+        return [(v.x * 0.5 + 0.5) * r.width + r.left, (-v.y * 0.5 + 0.5) * r.height + r.top, v.z]; },
+      centre(fid) { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+        if (!m) return null; m.geometry.computeBoundingBox(); const b = new window.THREE.Box3().setFromObject(m);
+        const c = new window.THREE.Vector3(); b.getCenter(c); return [c.x, c.y, c.z]; },
+      pixsum() { const r = window.A.renderer; r.render(window.A.scene, window.A.camera); const gl = r.getContext();
+        const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight, px = new Uint8Array(w * h * 4);
+        gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px); let s = 0; for (let i = 0; i < px.length; i += 257) s = (s + px[i]) >>> 0; return s; },
+      // candidate elements with the largest projected screen footprint → most reliable to click
+      candidates() { const g = window.Bonsai.group(); const out = [];
+        for (const m of g.children) { if (!m.isMesh || m.userData.featureId == null) continue;
+          const b = new window.THREE.Box3().setFromObject(m); if (!isFinite(b.min.x)) continue;
+          const c = new window.THREE.Vector3(); b.getCenter(c); const p = this.proj(c.x, c.y, c.z);
+          const cv = window.A.renderer.domElement, r = cv.getBoundingClientRect();
+          if (p[0] < r.left + 20 || p[0] > r.right - 20 || p[1] < r.top + 20 || p[1] > r.bottom - 20 || p[2] > 1) continue;
+          const sz = new window.THREE.Vector3(); b.getSize(sz);
+          out.push({ fid: m.userData.featureId, sx: p[0], sy: p[1], vol: sz.x * sz.y * sz.z }); }
+        out.sort((a, b) => b.vol - a.vol); return out.slice(0, 12); }
+    };
+    return true;
+  });
+
+  // A2 — real pick: click candidates until one selects
+  const cands = await pg.evaluate(() => window.__e2e.candidates());
+  let fid = null;
+  for (const c of cands) {
+    await pg.mouse.move(c.sx, c.sy); await sleep(40); await pg.mouse.click(c.sx, c.sy); await sleep(120);
+    const sel = await pg.evaluate(() => Array.from(window.Bonsai._selSet || []));
+    if (sel.length === 1) { fid = sel[0]; break; }
+  }
+  const c0 = fid != null ? await pg.evaluate(f => window.__e2e.centre(f), fid) : null;
+  const oplog0 = await pg.evaluate(() => ({ len: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor }));
+  const pix0 = await pg.evaluate(() => window.__e2e.pixsum());
+
+  // A3 — enter Move
+  await pg.click('#b-move'); await sleep(300);
+  const moveState = await pg.evaluate(() => {
+    const giz = window.A.scene.children.find(o => o.name === 'MoveGizmo');
+    let handle = null;
+    if (giz) { giz.updateMatrixWorld(true); giz.traverse(o => { if (o.isMesh && o.userData.moveAxis === 'x' && !handle) handle = o; }); }
+    const wp = handle ? handle.getWorldPosition(new window.THREE.Vector3()) : null;
+    return { on: document.getElementById('b-move').classList.contains('on'), hasGizmo: !!giz,
+      handleWorld: wp ? [wp.x, wp.y, wp.z] : null };
+  });
+
+  // A4/A5/A6 — real drag of the X handle: down on the shaft, move +1.0m along world-X, release
+  let dragErr = '';
+  if (moveState.handleWorld) {
+    const Wh = moveState.handleWorld, DELTA = 1.0;
+    const down = await pg.evaluate(w => window.__e2e.proj(w[0], w[1], w[2]), Wh);
+    const up = await pg.evaluate((w, d) => window.__e2e.proj(w[0] + d, w[1], w[2]), Wh, DELTA);
+    await pg.mouse.move(down[0], down[1]); await sleep(40);
+    await pg.mouse.down(); await sleep(40);
+    await pg.mouse.move((down[0] + up[0]) / 2, (down[1] + up[1]) / 2, { steps: 4 }); await sleep(40);
+    await pg.mouse.move(up[0], up[1], { steps: 6 }); await sleep(60);
+    await pg.mouse.up(); await sleep(500);
+  } else { dragErr = 'no X handle found on gizmo'; }
+
+  const after = await pg.evaluate(f => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const last = ops[ops.length - 1] || null;
+    return { len: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor,
+      lastType: last && last.op_type, lastParent: last && last.parameters && last.parameters.parent,
+      d: last && last.parameters ? [last.parameters.dx, last.parameters.dy, last.parameters.dz] : null,
+      centre: window.__e2e.centre(f) };
+  }, fid);
+  const pix1 = await pg.evaluate(() => window.__e2e.pixsum());
+
+  // A8 — UNDO via the real history slider (range input → scrubToShared → oplog.scrubTo)
+  await pg.evaluate(() => { const s = document.getElementById('hist-slider'); s.value = Math.max(0, (window.Bonsai.oplog.cursor - 1)); s.dispatchEvent(new Event('input', { bubbles: true })); });
+  await sleep(600);
+  const undo = await pg.evaluate(f => ({ cur: window.Bonsai.oplog.cursor, centre: window.__e2e.centre(f) }), fid);
+
+  await br.close(); server.close();
+
+  const disp = (a, b) => a && b ? [b[0] - a[0], b[1] - a[1], b[2] - a[2]] : null;
+  const d_move = disp(c0, after.centre);            // bbox-centre displacement vs committed op delta
+  const d_undo = disp(c0, undo.centre);             // residual after undo
+  const norm = v => v ? Math.hypot(v[0], v[1], v[2]) : Infinity;
+  const opd = after.d || [0, 0, 0];
+  const atomicErr = (d_move && after.d) ? Math.hypot(d_move[0] - opd[0], d_move[1] - opd[1], d_move[2] - opd[2]) : Infinity;
+
+  console.log('  §OPEN editableMeshes=' + editable + ' picked fid=' + fid + ' c0=' + JSON.stringify(c0));
+  console.log('  §MOVE-STATE ' + JSON.stringify(moveState) + (dragErr ? ' ERR=' + dragErr : ''));
+  console.log('  §AFTER op=' + after.lastType + ' parent=' + after.lastParent + ' delta=' + JSON.stringify(after.d) +
+    ' centreDisp=' + JSON.stringify(d_move ? d_move.map(x => +x.toFixed(4)) : null) + ' atomicErr=' + atomicErr.toExponential(2) + 'm');
+  console.log('  §PIX before=' + pix0 + ' afterMove=' + pix1 + ' (changed=' + (pix0 !== pix1) + ')');
+  console.log('  §UNDO cursor ' + after.cur + '→' + undo.cur + ' residual=' + norm(d_undo).toExponential(2) + 'm');
+  slog.forEach(l => console.log('  ' + l));
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  chk('A1 OPEN-REAL (editable meshes)', editable > 0, 'meshes=' + editable);
+  chk('A2 PICK-REAL (one element selected)', fid != null, 'fid=' + fid);
+  chk('A3 MOVE-ENTER (mode on + gizmo)', moveState.on === true && moveState.hasGizmo === true, JSON.stringify({ on: moveState.on, gizmo: moveState.hasGizmo }));
+  chk('A4 DRAG-COMMITS exactly one GEOM_MOVE', after.lastType === 'GEOM_MOVE' && after.lastParent === fid && after.len === oplog0.len + 1, 'type=' + after.lastType + ' parent=' + after.lastParent + ' len ' + oplog0.len + '→' + after.len);
+  chk('A5 ATOMIC (render delta == committed delta)', atomicErr < 1e-3, 'atomicErr=' + atomicErr.toExponential(2) + 'm');
+  chk('A6 AXIS-PERFECT (X-only)', after.d != null && Math.abs(opd[0]) > 0.01 && Math.abs(opd[1]) < 1e-6 && Math.abs(opd[2]) < 1e-6, 'delta=' + JSON.stringify(after.d));
+  chk('A7 VISIBLE (framebuffer changed)', pix0 !== pix1, 'pixsum ' + pix0 + '→' + pix1);
+  chk('A8 REVERSIBLE (undo restores ≤1e-3m, cursor−1)', norm(d_undo) < 1e-3 && undo.cur === after.cur - 1, 'residual=' + norm(d_undo).toExponential(2) + 'm cursor ' + after.cur + '→' + undo.cur);
+  chk('A9 NO-ERROR', errs.length === 0 && !dragErr, (dragErr || '') + ' ' + errs.slice(0, 2).join(' | '));
+
+  console.log('W-E2E-MOVE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();

--- a/modeller/tests/witness_e2e_walk.js
+++ b/modeller/tests/witness_e2e_walk.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-WALK scope (read this block first)
+ * SCOPE: a USER-EMULATING, MATHS-ASSERTED E2E of the generative WALK tool through the REAL production path
+ *   (window.discWalk — the exact handler the Outliner "Walk · <disc>" row's onWalk calls), NOT the engine seam
+ *   (dwOpen/dwWalk) the older witnesses used. The seam HID two real defects this gate exists to lock out:
+ *     (1) discWalk awaited _dwEnsureBorrow before rendering, and the rules-DB IDB cache HUNG under transaction
+ *         contention → the Walk tool rendered NOTHING for the user (nondeterministic). FIX: timeout-guarded IDB
+ *         cache in disc_walker.js (a stalled IDB op falls back to a bare fetch).
+ *     (2) _commitDiscWalk committed N placements as N separate sealed op-log commits (~0.4s each) → a 267-fixture
+ *         ELEC walk FROZE the UI for 112s. FIX: one batched commitSeedGroup (~1s).
+ *   This gate drives the real path and asserts — by NUMBERS off the op-log + scene graph + framebuffer — that the
+ *   Walk completes promptly, renders every fixture, lands in the signed log, verifies, paints, and reverses.
+ *
+ * THE WORKING SWIFTSHADER FLAGS: --use-gl=angle --use-angle=swiftshader (precedent witness_dw_pixelprobe.js).
+ *
+ * CLAIMS (Duplex ELEC, residential rules):
+ *   W1 COMPLETES-FAST  — the real discWalk user action finishes (commit done) in < 15s (was STALL-forever, then 112s).
+ *   W2 RENDERED        — dwRoot carries ELEC InstancedMesh(es) whose instances == the walked fixture count (all painted).
+ *   W3 NON-EMPTY       — the walk placed > 0 fixtures (honest non-refuse on a real residential building).
+ *   W4 COMMITTED       — the op-log grew by the placement count as GEOM_INSERT (the walk is in the signed log).
+ *   W5 CHAIN-OK        — verifyChain passes after the batched commit (the signed hash-chain is intact).
+ *   W6 REVERSIBLE      — scrubbing the history slider back to pre-walk clears the ELEC fixtures (cursor restored).
+ *   W7 VISIBLE         — the framebuffer changed after the walk (readPixels checksum differs → the user SEES it).
+ *   W8 NO-ERROR        — no pageerror across the sequence.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850 });
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+
+  console.log('═══ W-E2E-WALK — real user: open → Walk ELEC (production discWalk) → render+commit → undo (maths) ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai && typeof window.discWalk==="function"', { timeout: 30000 }).catch(() => {});
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(2000);
+
+  const before = await pg.evaluate(() => {
+    const census = () => { const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+      const kids = root ? root.children : []; const e = kids.filter(o => o.userData && o.userData.dwDisc === 'ELEC');
+      return { elecObjs: e.length, instances: e.reduce((s, o) => s + (o.isInstancedMesh ? (o.count || 0) : 0), 0) }; };
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera); const gl = r.getContext();
+    const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight, px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let s = 0; for (let i = 0; i < px.length; i += 257) s = (s + px[i]) >>> 0;
+    return { oplogLen: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor, pix: s, ...census() };
+  });
+
+  // W1 — fire the REAL production Walk handler (what the Outliner "Walk · ELEC" row's onWalk calls) + time to commit-done
+  const t0 = Date.now();
+  await pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  const completed = await pg.waitForFunction(() => window.__dwLastCommitDisc === 'ELEC', { timeout: 25000, polling: 250 }).then(() => true).catch(() => false);
+  const walkMs = Date.now() - t0;
+  await sleep(300);
+
+  const after = await pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    const kids = root ? root.children : []; const e = kids.filter(o => o.userData && o.userData.dwDisc === 'ELEC');
+    let chainOk = false; try { chainOk = !!(window.__lastGate || true); } catch (x) {}
+    const inserts = window.Bonsai.oplog._geomOps().filter(o => o.op_type === 'GEOM_INSERT').length;
+    const r = window.A.renderer; r.render(window.A.scene, window.A.camera); const gl = r.getContext();
+    const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight, px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let s = 0; for (let i = 0; i < px.length; i += 257) s = (s + px[i]) >>> 0;
+    return { n: (window.__dwWalks && window.__dwWalks.ELEC || []).length, elecObjs: e.length,
+      instances: e.reduce((a, o) => a + (o.isInstancedMesh ? (o.count || 0) : 0), 0),
+      oplogLen: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor, inserts, pix: s };
+  });
+  // W5 — verifyChain on the live kernel_ops db
+  const chain = await pg.evaluate(async () => { try { const db = await window.Bonsai.oplog._ensureDb(); const v = await window.KernelOps.verifyChain(db); return !!v.ok; } catch (e) { return 'ERR:' + e.message; } });
+
+  // W6 — UNDO via the real history slider back to pre-walk cursor
+  await pg.evaluate(c => { const s = document.getElementById('hist-slider'); s.value = c; s.dispatchEvent(new Event('input', { bubbles: true })); }, before.cur);
+  await sleep(800);
+  const undo = await pg.evaluate(() => { const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    const kids = root ? root.children : []; const e = kids.filter(o => o.userData && o.userData.dwDisc === 'ELEC');
+    return { cur: window.Bonsai.oplog.cursor, elecObjs: e.length, elecInstances: e.reduce((a, o) => a + (o.isInstancedMesh ? (o.count || 0) : 0), 0) }; });
+
+  await br.close(); server.close();
+
+  console.log('  §BEFORE ' + JSON.stringify(before));
+  console.log('  §WALK completed=' + completed + ' walkMs=' + walkMs + ' ' + JSON.stringify(after));
+  console.log('  §CHAIN verifyChain=' + chain);
+  console.log('  §UNDO ' + JSON.stringify(undo));
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  chk('W1 COMPLETES-FAST (<15s, no hang/freeze)', completed && walkMs < 15000, 'completed=' + completed + ' walkMs=' + walkMs);
+  chk('W2 RENDERED (instances == walked count)', after.elecObjs > 0 && after.instances === after.n && after.n > 0, 'objs=' + after.elecObjs + ' instances=' + after.instances + ' n=' + after.n);
+  chk('W3 NON-EMPTY (real placement, not refuse)', after.n > 0, 'n=' + after.n);
+  chk('W4 COMMITTED (op-log grew by n GEOM_INSERT)', after.oplogLen === before.oplogLen + after.n && after.inserts >= after.n, 'oplog ' + before.oplogLen + '→' + after.oplogLen + ' (+' + after.n + ') inserts=' + after.inserts);
+  chk('W5 CHAIN-OK (verifyChain after batch)', chain === true, 'verifyChain=' + chain);
+  chk('W6 REVERSIBLE (undo clears ELEC, cursor back)', undo.elecInstances === 0 && undo.cur === before.cur, 'elecInstances=' + undo.elecInstances + ' cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ')');
+  chk('W7 VISIBLE (framebuffer changed)', before.pix !== after.pix, 'pix ' + before.pix + '→' + after.pix);
+  chk('W8 NO-ERROR', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  console.log('W-E2E-WALK: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Why
Reviewing the modeller, the user's standard was: a test must **emulate a real user series of actions** and confirm each function works **completely, perfectly, atomically — by maths, not by eye**. Checking the *real* path (not the engine seams the shipped witnesses use) exposed that the **Walk tool was broken for users** in two ways the seams hid.

## Two real defects (found by user-emulating probes, root-caused)
**1. Borrow HANG → Walk rendered nothing.** `discWalk` awaits `_dwEnsureBorrow` before rendering; `dwBorrowFile` loads `terminal_rules.db` through the shared `bim_ootb_cache` IndexedDB store, which under transaction contention **hangs without firing success OR error** (nondeterministic: `borrow-first` STALL, `dwInit-then-borrow` OK). The whole tool stalled.
→ **Fix:** `disc_walker.js` `_loadDbBuf` is timeout-guarded — `_openCacheDB`/`_idbGet` race a 1.5s timeout → `null` → bare network fetch. IDB is only a cache; a stalled IDB op can never block a load. Deterministic across 3 runs.

**2. 112-second UI FREEZE on commit.** `_commitDiscWalk` committed N placements as N separate sealed `O.commit()` calls (~0.4s each → 267 ELEC fixtures = **112s frozen**; timeline: walk+render done at 1.0s, commit ran to 113s).
→ **Fix:** one batched `commitSeedGroup` (one seal, one verifyChain, one fold) → ~1s. Safe: `kernel_ops` orders by rowid, never timestamp.

## Result (maths-asserted, real `discWalk` path)
Duplex ELEC: **2.5s** (was 112s / ∞), **267 fixtures rendered**, op-log +267 `GEOM_INSERT`, `verifyChain` ok, undo via the history slider fully reverses.

## New standing gates (real user actions, production path, asserted by op-log + scene-graph + readPixels — never by eye)
- **W-E2E-MOVE 9/9** — open → pick element → drag the X move-gizmo handle → commit → undo. **Atomic**: moved-mesh bbox-centre displacement == committed `GEOM_MOVE` delta to **2.4e-8m**; X-only; pixels changed; undo → 0.00m residual. (Also proved the conformity GATE fires in the real move path.)
- **W-E2E-WALK 8/8** — the gate above; W1 (`<15s`) guards the freeze regression, W2 guards the hang.

Regressions green: W-DW-PIXELPROBE 6/6, W-SEED-TRUNK-RENDER 8/8. sw v24→v25, disc_walker.js?v=5→v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)