### PR TITLE
test(e2e): §F4 — capture real guide frames from Move + Walk witnesses

### DIFF
--- a/modeller/tests/witness_e2e_move.js
+++ b/modeller/tests/witness_e2e_move.js
@@ -28,6 +28,7 @@ const http = require('http'), fs = require('fs'), path = require('path');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const ROOT = path.join(__dirname, '..', '..');
+const SHOTS = path.join(__dirname, 'e2e_shots'); try { fs.mkdirSync(SHOTS, { recursive: true }); } catch (e) {}
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
 const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
   fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404 ' + p); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
@@ -35,9 +36,11 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
 (async () => {
   await new Promise(r => server.listen(0, r)); const port = server.address().port;
   const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
-  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850 });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850, deviceScaleFactor: 2 });
   const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
   const slog = []; pg.on('console', m => { const t = m.text(); if (/^§(MOVE|SDG|GATE)/.test(t)) slog.push(t); });
+  // F4: capture real guide frames at the asserted moments (2× DPR; non-invent — these ARE the app frames)
+  const shot = (label) => pg.screenshot({ path: path.join(SHOTS, 'W-E2E-MOVE-' + label + '.png') }).catch(() => {});
 
   console.log('═══ W-E2E-MOVE — real user: open → pick → move gizmo drag → commit → undo (maths-asserted, atomic) ═══');
   await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
@@ -102,6 +105,7 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
     return { on: document.getElementById('b-move').classList.contains('on'), hasGizmo: !!giz,
       handleWorld: wp ? [wp.x, wp.y, wp.z] : null };
   });
+  await shot('gizmo');   // guide frame: the XYZ transform gizmo raised on the selected element (A3 asserted)
 
   // A4/A5/A6 — real drag of the X handle: down on the shaft, move +1.0m along world-X, release
   let dragErr = '';
@@ -125,6 +129,7 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
       centre: window.__e2e.centre(f) };
   }, fid);
   const pix1 = await pg.evaluate(() => window.__e2e.pixsum());
+  await shot('moved');   // guide frame: the element after the committed X-axis GEOM_MOVE (A5/A7 asserted)
 
   // A8 — UNDO via the real history slider (range input → scrubToShared → oplog.scrubTo)
   await pg.evaluate(() => { const s = document.getElementById('hist-slider'); s.value = Math.max(0, (window.Bonsai.oplog.cursor - 1)); s.dispatchEvent(new Event('input', { bubbles: true })); });

--- a/modeller/tests/witness_e2e_walk.js
+++ b/modeller/tests/witness_e2e_walk.js
@@ -29,6 +29,7 @@ const http = require('http'), fs = require('fs'), path = require('path');
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const ROOT = path.join(__dirname, '..', '..');
+const SHOTS = path.join(__dirname, 'e2e_shots'); try { fs.mkdirSync(SHOTS, { recursive: true }); } catch (e) {}
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
 const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
   fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
@@ -36,8 +37,10 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
 (async () => {
   await new Promise(r => server.listen(0, r)); const port = server.address().port;
   const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
-  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850 });
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850, deviceScaleFactor: 2 });
   const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+  // F4: capture the real Walk guide frame at the asserted moment (2× DPR; non-invent — the actual app frame)
+  const shot = (label) => pg.screenshot({ path: path.join(SHOTS, 'W-E2E-WALK-' + label + '.png') }).catch(() => {});
 
   console.log('═══ W-E2E-WALK — real user: open → Walk ELEC (production discWalk) → render+commit → undo (maths) ═══');
   await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
@@ -79,6 +82,12 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
   // W5 — verifyChain on the live kernel_ops db
   const chain = await pg.evaluate(async () => { try { const db = await window.Bonsai.oplog._ensureDb(); const v = await window.KernelOps.verifyChain(db); return !!v.ok; } catch (e) { return 'ERR:' + e.message; } });
 
+  // capture the REAL status-bar line the Walk emits (before Fit overwrites it) — for truthful guide copy
+  const statusLine = await pg.evaluate(() => (document.getElementById('stat') || {}).textContent || '');
+  // guide frame: the walked ELEC fixtures rendered across the Duplex (W2/W7 asserted). Fit first to frame them.
+  const fitB = await pg.$('#b-fit'); if (fitB) { await fitB.click(); await sleep(600); }
+  await shot('fixtures');
+
   // W6 — UNDO via the real history slider back to pre-walk cursor
   await pg.evaluate(c => { const s = document.getElementById('hist-slider'); s.value = c; s.dispatchEvent(new Event('input', { bubbles: true })); }, before.cur);
   await sleep(800);
@@ -91,6 +100,7 @@ const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.sp
   console.log('  §BEFORE ' + JSON.stringify(before));
   console.log('  §WALK completed=' + completed + ' walkMs=' + walkMs + ' ' + JSON.stringify(after));
   console.log('  §CHAIN verifyChain=' + chain);
+  console.log('  §STATUS ' + JSON.stringify(statusLine));
   console.log('  §UNDO ' + JSON.stringify(undo));
 
   let pass = 0, fail = 0;


### PR DESCRIPTION
## Summary
- Folds the remaining real content from `lane/modeller-e2e-suite-2` (PR #585 already merged the rest) into `main`
- Instruments `witness_e2e_move.js` and `witness_e2e_walk.js` with `shot()` capture at their asserted moments (deviceScaleFactor:2), producing witness-traceable frames for `docs/img/modeller/` (bim-compiler PR #10)
- No assertion logic changed

## Test plan
- [x] `node modeller/tests/witness_e2e_move.js` → 9/9 PASS
- [x] `node modeller/tests/witness_e2e_walk.js` → 8/8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)