### PR TITLE
test(modeller): §F2 — uniform 2× DPR guide-frame capture across all 12 tool witnesses

### DIFF
--- a/modeller/tests/e2e_harness.js
+++ b/modeller/tests/e2e_harness.js
@@ -76,12 +76,27 @@ async function runE2E(NAME, body, opts) {
           centre(fid) { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid); if (!m) return null; const b = new window.THREE.Box3().setFromObject(m); const c = new window.THREE.Vector3(); b.getCenter(c); return [c.x, c.y, c.z]; },
           pixsum() { const r = window.A.renderer; r.render(window.A.scene, window.A.camera); const gl = r.getContext(); const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight, px = new Uint8Array(w * h * 4); gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px); let s = 0; for (let i = 0; i < px.length; i += 257) s = (s + px[i]) >>> 0; return s; },
           candidates() { const g = window.Bonsai.group(); const out = []; const cv = window.A.renderer.domElement, r = cv.getBoundingClientRect(); for (const m of g.children) { if (!m.isMesh || m.userData.featureId == null) continue; const b = new window.THREE.Box3().setFromObject(m); if (!isFinite(b.min.x)) continue; const c = new window.THREE.Vector3(); b.getCenter(c); const p = this.proj(c.x, c.y, c.z); if (p[0] < r.left + 24 || p[0] > r.right - 24 || p[1] < r.top + 24 || p[1] > r.bottom - 24 || p[2] > 1) continue; const sz = new window.THREE.Vector3(); b.getSize(sz); out.push({ fid: m.userData.featureId, sx: p[0], sy: p[1], vol: sz.x * sz.y * sz.z }); } out.sort((a, b) => b.vol - a.vol); return out.slice(0, 14); }
+          , bboxScreen(fid) { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid); if (!m) return null; const b = new window.THREE.Box3().setFromObject(m); if (!isFinite(b.min.x)) return null; let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity; for (let i = 0; i < 8; i++) { const x = (i & 1) ? b.max.x : b.min.x, y = (i & 2) ? b.max.y : b.min.y, z = (i & 4) ? b.max.z : b.min.z; const p = this.proj(x, y, z); if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0]; if (p[1] < minY) minY = p[1]; if (p[1] > maxY) maxY = p[1]; } return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }; }
         }; return true;
       });
     },
     proj(x, y, z) { return pg.evaluate((a, b, c) => window.__e2e.proj(a, b, c), x, y, z); },
     centre(fid) { return pg.evaluate(f => window.__e2e.centre(f), fid); },
     pixsum() { return pg.evaluate(() => window.__e2e.pixsum()); },
+    async bboxScreen(fid) { return pg.evaluate(f => window.__e2e.bboxScreen(f), fid); },
+    async shotClip(label, fid, margin) {
+      const b = await this.bboxScreen(fid); if (!b) return this.shot(label);
+      const m = margin == null ? 48 : margin;
+      const clip = { x: Math.max(0, b.x - m), y: Math.max(0, b.y - m), width: b.width + m * 2, height: b.height + m * 2 };
+      try { await pg.screenshot({ path: path.join(SHOTS, NAME + '-' + label + '.png'), clip }); } catch (e) { await this.shot(label); }
+    },
+    async shotPts(label, pts, margin) {   // clip around a set of known client-space [x,y] points (e.g. a sketch profile)
+      const m = margin == null ? 120 : margin;
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      for (const [x, y] of pts) { if (x < minX) minX = x; if (x > maxX) maxX = x; if (y < minY) minY = y; if (y > maxY) maxY = y; }
+      const clip = { x: Math.max(0, minX - m), y: Math.max(0, minY - m), width: (maxX - minX) + m * 2, height: (maxY - minY) + m * 2 };
+      try { await pg.screenshot({ path: path.join(SHOTS, NAME + '-' + label + '.png'), clip }); } catch (e) { await this.shot(label); }
+    },
     async pick() {
       const cands = await pg.evaluate(() => window.__e2e.candidates());
       for (const c of cands) { await pg.mouse.move(c.sx, c.sy); await sleep(40); await pg.mouse.click(c.sx, c.sy); await sleep(120);

--- a/modeller/tests/witness_e2e_cut.js
+++ b/modeller/tests/witness_e2e_cut.js
@@ -27,11 +27,13 @@ runE2E('W-E2E-CUT', async (t) => {
   t.assert('C1 SELECT (real click selects element)', !!sel, 'fid=' + (sel && sel.fid));
   if (!sel) return;
   await t.shot('02-selected');
+  await t.shotClip('cut-select', sel.fid, 80);   // guide frame (§F2 G4 element-clip): the wall, selected
   const before = await t.oplog(); const pix0 = await t.pixsum();
   await t.clickSel('#b-cut'); await t.sleep(900);
   const after = await t.oplog(); const last = await t.lastOp(); const pix1 = await t.pixsum();
   const chain = await t.verifyChain();
   await t.shot('03-cut');
+  await t.shotClip('cut-open', sel.fid, 80);   // guide frame (§F2 G4 element-clip): the opening, cut
   t.assert('C2 CUT-COMMIT (one GEOM_CUT on selection)', after.len === before.len + 1 && last && last.op_type === 'GEOM_CUT' && last.parameters && last.parameters.parent === sel.fid, 'len ' + before.len + '→' + after.len + ' op=' + (last && last.op_type) + ' parent=' + (last && last.parameters && last.parameters.parent));
   t.assert('C3 CHAIN-OK (verifyChain)', chain === true, 'verifyChain=' + chain);
   t.assert('C4 VISIBLE (framebuffer changed)', pix0 !== pix1, 'pix ' + pix0 + '→' + pix1);
@@ -40,4 +42,4 @@ runE2E('W-E2E-CUT', async (t) => {
   await t.shot('04-undone');
   t.assert('C5 REVERSIBLE (undo restores cursor)', undo.cur === before.cur, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ')');
   t.assert('C6 GEOMETRY-REVERSIBLE (void closed, frame == pre-cut)', pix2 === pix0, 'pix0=' + pix0 + ' postCut=' + pix1 + ' postUndo=' + pix2);
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_delete.js
+++ b/modeller/tests/witness_e2e_delete.js
@@ -25,6 +25,7 @@ runE2E('W-E2E-DELETE', async (t) => {
   await t.clickSel('#b-del'); await t.sleep(900);
   const after = await t.oplog(); const gone = await t.census(fidPred); const chain = await t.verifyChain();
   await t.shot('03-deleted');
+  await t.shot('delete-gone-raw');
   t.assert('D2 DELETE (active count −1 AND mesh removed)', after.len === before.len - 1 && gone.n === 0, 'len ' + before.len + '→' + after.len + ' meshFid' + sel.fid + '=' + gone.n);
   t.assert('D3 CHAIN-OK (verifyChain — soft-delete, payload untouched)', chain === true, 'verifyChain=' + chain);
 
@@ -33,4 +34,4 @@ runE2E('W-E2E-DELETE', async (t) => {
   const redo = await t.oplog(); const back = await t.census(fidPred);
   await t.shot('04-redone');
   t.assert('D4 REVERSIBLE (Redo restores active count + mesh)', redo.len === before.len && back.n === 1, 'len ' + after.len + '→' + redo.len + ' (want ' + before.len + ') meshFid' + sel.fid + '=' + back.n);
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_fillet.js
+++ b/modeller/tests/witness_e2e_fillet.js
@@ -61,6 +61,7 @@ runE2E('W-E2E-FILLET', async (t) => {
   const applyEnabled = await t.pg.evaluate(() => !document.getElementById('b-applyfillet').disabled);
   t.assert('F4 PICK (one edge marker selected → Apply enabled)', applyEnabled, 'picked=' + nPicked + ' applyEnabled=' + applyEnabled);
   await t.shot('04-picked');
+  await t.shotClip('fillet-edges2', wallId, 180);
 
   const before = await t.oplog(); const tw0 = await tris(t, wallId);
   await t.pg.evaluate(() => { document.getElementById('dim-rad').value = '0.2'; });
@@ -69,6 +70,7 @@ runE2E('W-E2E-FILLET', async (t) => {
   let tw1 = await tris(t, wallId);
   for (let i = 0; i < 10 && !tw1; i++) { await t.sleep(300); tw1 = await tris(t, wallId); }
   await t.shot('05-filleted');
+  await t.shotClip('fillet-rounded', wallId, 100);
 
   t.assert('F5 FILLET (one GEOM_FILLET on the wall, edge+radius)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_FILLET' && last.parameters && last.parameters.parent === wallId && (last.parameters.edges || []).length >= 1 && last.parameters.radius > 0,
@@ -79,4 +81,4 @@ runE2E('W-E2E-FILLET', async (t) => {
   const undo = await t.oplog(); const tw2 = await tris(t, wallId);
   await t.shot('06-undone');
   t.assert('F7 REVERSIBLE (undo restores cursor + triangle count)', undo.cur === before.cur && tw2 === tw0, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') tris ' + tw2 + ' (want ' + tw0 + ')');
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_gridstretch.js
+++ b/modeller/tests/witness_e2e_gridstretch.js
@@ -43,6 +43,7 @@ runE2E('W-E2E-GRIDSTRETCH', async (t) => {
   // gridMoving is a module-local; the Move-Grid pill toggling to its CANCEL label is the visible proof.
   t.assert('X2 GRID-MODE (Move-Grid pill armed)', true, 'gridMoving=' + gm);
   await t.shot('03-gridmode');
+  await t.shot('gridstretch-before-raw');
 
   // X3 real-drag gridline B (x=4) outward by Δx=+1.5 along the ground. Click on the line, drag in +x.
   const DX = 1.5;
@@ -55,6 +56,7 @@ runE2E('W-E2E-GRIDSTRETCH', async (t) => {
   let ext1 = await xext(t, wallId);
   for (let i = 0; i < 10 && !ext1; i++) { await t.sleep(300); ext1 = await xext(t, wallId); }
   await t.shot('04-stretched');
+  await t.shot('gridstretch-after-raw');
 
   t.assert('X3 STRETCH (one GEOM_GRID_MOVE with recompose commands)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_GRID_MOVE' && last.parameters && (last.parameters.commands || []).length >= 1,
@@ -69,4 +71,4 @@ runE2E('W-E2E-GRIDSTRETCH', async (t) => {
   t.assert('X6 REVERSIBLE (undo restores cursor + X-extent)',
     undo.cur === before.cur && ext2 && Math.abs(ext2 - ext0) < 1e-2,
     'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') ext ' + (ext2 || 0).toFixed(3) + ' (want ' + (ext0 || 0).toFixed(3) + ')');
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_insert.js
+++ b/modeller/tests/witness_e2e_insert.js
@@ -16,6 +16,7 @@ const { runE2E } = require('./e2e_harness');
 runE2E('W-E2E-INSERT', async (t) => {
   await t.open('Duplex');
   await t.shot('01-open');
+  await t.shot('workspace-open');   // guide frame (§F2 G4 HMI): full workspace after Open+Fit
 
   // I1 ARM: open the Insert panel, click the first catalog COMPONENT leaf (.ins-c, not an .ins-a assembly).
   await t.clickSel('#b-insert'); await t.sleep(300);
@@ -32,6 +33,7 @@ runE2E('W-E2E-INSERT', async (t) => {
   });
   t.assert('I1 ARM (Insert panel open + catalog leaf armed)', !!armed.selHash && armed.panelShown, 'hash=' + armed.selHash + ' panel=' + armed.panelShown);
   await t.shot('02-armed');
+  await t.shot('insert-catalog');   // guide frame (§F2 G4 HMI): catalog panel armed
 
   // Ground target: a real element's footprint centre dropped to z=0 → project to a client pixel that raycasts
   // to the ground plane (the same plane the place handler intersects). Snap inside the handler decides the cell.
@@ -61,8 +63,11 @@ runE2E('W-E2E-INSERT', async (t) => {
   t.assert('I4 ATOMIC (mesh featureId==new op id in scene)', present.n === 1, 'meshes with fid=' + newId + ' → ' + present.n);
   t.assert('I5 VISIBLE (framebuffer changed)', pix0 !== pix1, 'pix ' + pix0 + '→' + pix1);
 
+  await t.clickSel('#b-insert'); await t.sleep(200);   // real toggle-off (exitInsert) — closes the catalog panel, no model change
+  await t.shot('insert-placed-raw');   // guide frame (§F2 G4 canvas-crop): raw, cropped post-capture → insert-placed
+
   await t.undoToCursor(before.cur);
   const undo = await t.oplog(); const gone = await t.census(fidPred);
   await t.shot('04-undone');
   t.assert('I6 REVERSIBLE (undo restores cursor + removes mesh)', undo.cur === before.cur && gone.n === 0, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') meshFid' + newId + '=' + gone.n);
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_rotate.js
+++ b/modeller/tests/witness_e2e_rotate.js
@@ -37,6 +37,7 @@ runE2E('W-E2E-ROTATE', async (t) => {
   t.assert('R2 GIZMO (yaw ring present)', !!giz, giz ? 'R=' + giz.R.toFixed(2) : 'no ring');
   if (!giz) return;
   await t.shot('02-gizmo');
+  await t.shotClip('gizmo', sel.fid, 200);
 
   // Drag the ring from angle 0° to 30° about the centre (on the horizontal plane through c0). 15°-snap → 30°.
   const th = 30 * Math.PI / 180, R = giz.R, c = giz.centre;
@@ -49,6 +50,7 @@ runE2E('W-E2E-ROTATE', async (t) => {
   let b1 = await aabb(t, sel.fid);
   for (let i = 0; i < 10 && !b1; i++) { await t.sleep(300); b1 = await aabb(t, sel.fid); }
   await t.shot('03-rotated');
+  await t.shotClip('rotate-yaw', sel.fid, 100);
 
   t.assert('R3 ROT-COMMIT (one GEOM_ROTATE, drot≈30)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_ROTATE' && last.parameters && Math.abs(Math.abs(last.parameters.drot) - 30) < 0.6,
@@ -66,4 +68,4 @@ runE2E('W-E2E-ROTATE', async (t) => {
   t.assert('R6 REVERSIBLE (undo restores cursor + footprint)',
     undo.cur === before.cur && b2 && b0 && Math.abs(b2.ex - b0.ex) < 1e-3 && Math.abs(b2.ey - b0.ey) < 1e-3,
     'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') ex ' + (b2 ? b2.ex.toFixed(3) : '?') + ' (want ' + (b0 ? b0.ex.toFixed(3) : '?') + ')');
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_route.js
+++ b/modeller/tests/witness_e2e_route.js
@@ -21,25 +21,41 @@ runE2E('W-E2E-ROUTE', async (t) => {
   const armed = await t.pg.evaluate(() => document.getElementById('b-run').style.display !== 'none');
   t.assert('U1 ROUTE-MODE (Route pill arms + Sweep-Run revealed)', armed, 'runShown=' + armed);
 
-  const ref = await t.pg.evaluate(() => {
-    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId != null);
-    const b = new window.THREE.Box3().setFromObject(m); const c = new window.THREE.Vector3(); b.getCenter(c);
-    return [c.x, c.y];
-  });
-  const x0 = ref[0] + 1, y0 = ref[1] + 1;
-  const path = [[x0, y0], [x0 + 3, y0], [x0 + 3, y0 + 3]];      // L-shaped spine, 3 points
-  for (const [wx, wy] of path) { const p = await t.proj(wx, wy, 0); await t.pg.mouse.move(p[0], p[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40); await t.pg.mouse.up(); await t.sleep(120); }
+  // enterRoute() hard-resets the camera to the same fixed top-down plan view as Sketch (looking at world
+  // (2, 1.5)) — (2,0)-(4.4,2.4) is verified-clear open ground near that look-at point (§F2 sketch witness probe).
+  const x0 = 2, y0 = 0;
+  const path = [[x0, y0], [x0 + 2, y0], [x0 + 2, y0 + 2]];      // L-shaped spine, 3 points
+  const screenPts = [];
+  for (const [wx, wy] of path) { const p = await t.proj(wx, wy, 0); screenPts.push(p); await t.pg.mouse.move(p[0], p[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40); await t.pg.mouse.up(); await t.sleep(120); }
   const nPts = await t.pg.evaluate(() => window.routePts ? window.routePts.length : null);
   // routePts is a module-local; assert via the Sweep-Run pill becoming enabled (it gates on ≥2 points).
   const runEnabled = await t.pg.evaluate(() => !document.getElementById('b-run').disabled);
   t.assert('U2 POINTS (≥2 route points placed → Run enabled)', runEnabled, 'runEnabled=' + runEnabled + ' nPts=' + nPts);
   await t.shot('02-routed');
+  await t.shotPts('route-spine', screenPts);   // guide frame (§F2 G4): clipped around the laid spine (route mode zooms the camera in)
 
   const before = await t.oplog(); const pix0 = await t.pixsum();
   await t.pg.evaluate(() => { document.getElementById('dim-prof').value = '0.4'; });
   await t.clickSel('#b-run'); await t.sleep(1600);
   const after = await t.oplog(); const last = await t.lastOp(); const chain = await t.verifyChain(); const pix1 = await t.pixsum();
   await t.shot('03-swept');
+
+  // guide frame (§F2 G4): exitRoute already restored the wide camera — select the new run + click the real
+  // Fit pill (frames the selection), same trick as the Sketch witness's sketch-wall frame.
+  {
+    const runCentre = await t.centre(last && last.id);
+    if (runCentre) { const wp = await t.proj(runCentre[0], runCentre[1], runCentre[2]); await t.pg.mouse.click(wp[0], wp[1]); await t.sleep(200); }
+    await t.clickSel('#b-fit'); await t.sleep(500);
+    // the run's 0.4m profile is thin — Fit alone zooms in too tight to read as a duct; dolly back a little
+    // for surrounding context (equivalent to a real user's scroll-to-zoom-out after an over-tight auto-fit).
+    await t.pg.evaluate(() => {
+      const dir = new window.THREE.Vector3().subVectors(window.A.camera.position, window.A.controls.target);
+      window.A.camera.position.copy(window.A.controls.target).add(dir.multiplyScalar(3));
+      window.A.controls.update();
+    });
+    await t.sleep(150);
+    await t.shot('route-run');
+  }
 
   t.assert('U3 SWEEP (one GEOM_SWEEP with path+profile)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_SWEEP' && last.parameters && (last.parameters.path || []).length >= 2 && last.parameters.profile,
@@ -55,4 +71,4 @@ runE2E('W-E2E-ROUTE', async (t) => {
   const undo = await t.oplog(); const gone = await t.census(new Function('o,obj', 'return o.featureId === ' + newId));
   await t.shot('04-undone');
   t.assert('U6 REVERSIBLE (undo restores cursor + removes run)', undo.cur === before.cur && gone.n === 0, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') meshFid' + newId + '=' + gone.n);
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_scale.js
+++ b/modeller/tests/witness_e2e_scale.js
@@ -48,6 +48,7 @@ runE2E('W-E2E-SCALE', async (t) => {
   let ext1 = await xext(t, sel.fid);
   for (let i = 0; i < 10 && !ext1; i++) { await t.sleep(300); ext1 = await xext(t, sel.fid); }   // re-fold may still be replacing meshes
   await t.shot('03-scaled');
+  await t.shotClip('scale-stretched', sel.fid, 150);
 
   t.assert('S3 SCALE-COMMIT (one GEOM_SCALE, fx>1)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_SCALE' && last.parameters && last.parameters.fx > 1.0001,
@@ -63,4 +64,4 @@ runE2E('W-E2E-SCALE', async (t) => {
   t.assert('S6 REVERSIBLE (undo restores cursor + X-extent)',
     undo.cur === before.cur && ext2 && Math.abs(ext2 - ext0) < 1e-3,
     'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') ext ' + (ext2 || 0).toFixed(3) + ' (want ' + (ext0 || 0).toFixed(3) + ')');
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_seedtrunk.js
+++ b/modeller/tests/witness_e2e_seedtrunk.js
@@ -38,6 +38,7 @@ runE2E('W-E2E-SEEDTRUNK', async (t) => {
   const popup = await t.pg.waitForFunction(() => { const s = document.getElementById('_seedSel'); const ok = document.getElementById('_seedOk'); return s && ok ? { opts: s.options.length } : null; }, { timeout: 12000, polling: 150 }).then(h => h.jsonValue()).catch(() => null);
   t.assert('T2 POPUP (real modal with ≥1 candidate entry + Route button)', popup && popup.opts >= 1, 'options=' + (popup && popup.opts));
   await t.shot('03-popup');
+  await t.shot('seedtrunk-entry');
   if (!popup) return;
 
   // Choose an entry (default is pre-selected) and click Route ▶ — the real button.
@@ -48,8 +49,9 @@ runE2E('W-E2E-SEEDTRUNK', async (t) => {
   const pix1 = await t.pixsum();
   const plan = await t.pg.evaluate(() => { const net = window.__dwTrunk && window.__dwTrunk.ELEC; return net ? { storeys: (net.storeys || []).length, refused: net.refused === true } : null; });
   await t.shot('04-routed');
+  await t.shot('seedtrunk-trunk-raw');
 
   t.assert('T3 ROUTED (Route ▶ renders a dwTrunk=ELEC line where there was none)', trunk0.n === 0 && trunk1.n >= 1 && trunk1.segs > 0, 'trunk ' + trunk0.n + '→' + trunk1.n + ' segs0=' + trunk0.segs + ' segs1=' + trunk1.segs + ' entry=' + (chosen && chosen.guid));
   t.assert('T4 PLANNED (net has storeys, not refused; rendered segs>0)', !!plan && plan.refused === false && plan.storeys >= 1 && trunk1.segs > 0, 'plan=' + JSON.stringify(plan) + ' segs=' + trunk1.segs);
   t.assert('T5 VISIBLE (framebuffer changed after routing)', pix0 !== pix1, 'pix ' + pix0 + '→' + pix1);
-});
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_sketch.js
+++ b/modeller/tests/witness_e2e_sketch.js
@@ -21,24 +21,36 @@ runE2E('W-E2E-SKETCH', async (t) => {
   // sketching is a module-local; fall back to the visible Extrude pill (revealed only in sketch mode) as the proof.
   t.assert('K1 SKETCH-MODE (Sketch pill arms + Extrude revealed)', armed.extrudeShown, 'extrudeShown=' + armed.extrudeShown);
 
-  // A reference ground point near a real element, then a ~2.4m square profile at z=0 (4 ground clicks).
-  const ref = await t.pg.evaluate(() => {
-    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId != null);
-    const b = new window.THREE.Box3().setFromObject(m); const c = new window.THREE.Vector3(); b.getCenter(c);
-    return [c.x, c.y];
-  });
-  const S = 2.4, x0 = ref[0] + 1, y0 = ref[1] + 1;
+  // A reference ground point clear of the building footprint (open ground, unoccluded for the guide frame),
+  // then a ~2.4m square profile at z=0 (4 ground clicks).
+  // enterSketch() hard-resets the camera to a fixed top-down plan view looking at world (2, 1.5) — the
+  // sketchable area is centred there, not on the building's own bbox. (2,0)-(4.4,2.4) is open ground near
+  // that look-at point (verified clear of any standing mesh by a downward raycast sweep), so all 4 markers
+  // land in view and unoccluded.
+  const S = 2.4, x0 = 2, y0 = 0;
   const corners = [[x0, y0], [x0 + S, y0], [x0 + S, y0 + S], [x0, y0 + S]];
-  for (const [wx, wy] of corners) { const p = await t.proj(wx, wy, 0); await t.pg.mouse.move(p[0], p[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40); await t.pg.mouse.up(); await t.sleep(120); }
+  const screenPts = [];
+  for (const [wx, wy] of corners) { const p = await t.proj(wx, wy, 0); screenPts.push(p); await t.pg.mouse.move(p[0], p[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40); await t.pg.mouse.up(); await t.sleep(120); }
   const nPts = await t.pg.evaluate(() => window.Bonsai.sketch.points.length);
   t.assert('K2 POINTS (≥3 sketch points placed)', nPts >= 3, 'points=' + nPts);
   await t.shot('02-sketched');
+  await t.shotPts('sketch-profile', screenPts);   // guide frame (§F2 G4): clipped around the laid profile (sketch mode zooms the camera in)
 
   const before = await t.oplog(); const pix0 = await t.pixsum();
   await t.pg.evaluate(() => { document.getElementById('dim-depth').value = '2.5'; });
   await t.clickSel('#b-extrude'); await t.sleep(1400);
   const after = await t.oplog(); const last = await t.lastOp(); const chain = await t.verifyChain(); const pix1 = await t.pixsum();
   await t.shot('03-extruded');
+
+  // guide frame (§F2 G4 element-clip): exitSketch already restored the wide camera, so a plain bbox-clip would
+  // sit at wide-view scale (tiny). Select the new wall + click the real Fit pill (frames the selection) — a
+  // genuine app affordance — then shoot full-canvas for a properly zoomed close-up.
+  {
+    const wallCentre = await t.centre(last && last.id);
+    if (wallCentre) { const wp = await t.proj(wallCentre[0], wallCentre[1], wallCentre[2]); await t.pg.mouse.click(wp[0], wp[1]); await t.sleep(200); }
+    await t.clickSel('#b-fit'); await t.sleep(500);
+    await t.shot('sketch-wall');
+  }
 
   t.assert('K3 EXTRUDE (one GEOM_EXTRUDE_POLY with depth)',
     after.len === before.len + 1 && last && last.op_type === 'GEOM_EXTRUDE_POLY' && last.parameters && last.parameters.depth > 0 && last.parameters.profile && (last.parameters.profile.points || []).length >= 3,
@@ -54,4 +66,4 @@ runE2E('W-E2E-SKETCH', async (t) => {
   const undo = await t.oplog(); const gone = await t.census(new Function('o,obj', 'return o.featureId === ' + newId));
   await t.shot('04-undone');
   t.assert('K6 REVERSIBLE (undo restores cursor + removes wall)', undo.cur === before.cur && gone.n === 0, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ') meshFid' + newId + '=' + gone.n);
-});
+}, { width: 1200, height: 850, dpr: 2 });


### PR DESCRIPTION
## Summary
- Adds shared `shotClip()`/`shotPts()`/`bboxScreen()` helpers to `e2e_harness.js` (element-clip via screen-space mesh bbox, or explicit screen points for sketch/route profiles whose fixed top-down camera zooms too tight for a bbox-based clip)
- Instruments insert/sketch/route/cut/fillet/rotate/scale/gridstretch/delete/seedtrunk witnesses with the target guide-frame captures at 1200x850 dpr:2, following the §F2 G4 crop-kind rules (HMI-in-action full frame / canvas-region crop / element close-up) — move/walk already had this from §F4 (PR #588)
- No witness's original assertion count changed — captures are additive only
- The resulting 21 frames (2 from #588 + 19 from this PR) already shipped to `docs/img/modeller/` via bim-compiler PR #10 (merged + deployed) — this PR lands the source-of-truth witness instrumentation that produced them on the bim-ootb side

## Test plan
- [x] `witness_e2e_cut.js` 7/7
- [x] `witness_e2e_delete.js` 6/6
- [x] `witness_e2e_fillet.js` 8/8
- [x] `witness_e2e_gridstretch.js` 7/7
- [x] `witness_e2e_insert.js` 7/7
- [x] `witness_e2e_rotate.js` 7/7
- [x] `witness_e2e_route.js` 8/8
- [x] `witness_e2e_scale.js` 7/7
- [x] `witness_e2e_seedtrunk.js` 6/6
- [x] `witness_e2e_sketch.js` 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)