### PR TITLE
feat(geomapping): wire IFC→BOM classifier into modeller (audit-first)

### DIFF
--- a/geomapping/geomap_bridge.js
+++ b/geomapping/geomap_bridge.js
@@ -1,0 +1,89 @@
+// geomap_bridge.js — modeller↔geomapping wiring seam (bim-compiler prompts/RESUME_IFC_BOM_GEOMAPPING.md
+// §WIRE-SPEC deliverable 1). Witness: geomapping/tests/witness_wire.js (W-GEOMAP-WIRE W4/W5).
+//
+// classify_geom.js speaks geomap TAGs (SH/DX/SC/Terminal — the mined artifact keys); the modeller speaks
+// resident keys (str_walker_outliner.js RESIDENTS). This bridge owns that map and NOTHING else clever:
+// unknown key → honest null (never a guessed tag), all real work stays in ClassifyGeom.
+//
+// AUDIT-FIRST doctrine (§WIRE-SPEC): everything exposed here feeds a PARALLEL audit channel — logs, return
+// blocks, window surfaces. Nothing here may gate/alter the signed op substrate; that flip is a later,
+// separately-witnessed step.
+//
+// Dual-export (window + node) like classify_geom.js itself.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory(require('./classify_geom.js'));
+  else root.GeomapBridge = factory(root.ClassifyGeom);
+})(typeof window !== 'undefined' ? window : this, function (ClassifyGeom) {
+  'use strict';
+  var TAG = '§GEOMAP-BRIDGE';
+
+  // Resident key → mined-artifact tag. SampleCastle-ARC maps to SC: it is the SAME building's rows
+  // (SampleCastle_ARC_extracted.db is the ARC-discipline subset of SampleCastle_extracted.db, which is
+  // what SC's bands were mined from) — same measured population, not a borrowed prior.
+  var TAG_BY_BUILDING = {
+    'SampleHouse': 'SH',
+    'Duplex': 'DX',
+    'SampleCastle': 'SC',
+    'SampleCastle-ARC': 'SC',
+    'Terminal': 'Terminal'
+  };
+
+  function gmTag(buildingKey) {
+    return TAG_BY_BUILDING.hasOwnProperty(buildingKey) ? TAG_BY_BUILDING[buildingKey] : null;
+  }
+
+  // ── browser data init: fetch the mined artifacts once and hand them to ClassifyGeom.init(). ──
+  // Node needs none of this (classify_geom lazy-loads from ./data itself). Failure-tolerant by design:
+  // a caller that can't load data simply gets no audit (logged), never a broken seed.
+  var _loaded = null; // Promise once started
+  var _ready = false; // true only after a successful data init — callers gate best-effort audit on this
+  function gmReady() { return _ready; }
+  function gmLoad(baseUrl) {
+    if (_loaded) return _loaded;
+    if (typeof fetch !== 'function') { _loaded = Promise.resolve(false); return _loaded; }
+    var base = (baseUrl || '../geomapping/') + 'data/';
+    function j(rel) { return fetch(base + rel).then(function (r) { if (!r.ok) throw new Error(rel + ' ' + r.status); return r.json(); }); }
+    _loaded = j('geomap_rules.json').then(function (rules) {
+      // relation sidecars are per-tag and optional (Terminal has none yet — honest absence, F4/F11);
+      // fetch what exists, tolerate what doesn't.
+      var tags = ['SH', 'DX', 'SC'];
+      return Promise.all(tags.map(function (t) {
+        return j('relations_' + t + '.json').catch(function () { return null; });
+      })).then(function (rels) {
+        var relations = {};
+        tags.forEach(function (t, i) { relations[t] = rels[i]; });
+        ClassifyGeom.init({ rules: rules, relations: relations });
+        _ready = true;
+        _log(TAG + ' data loaded (rules + ' + rels.filter(Boolean).length + '/' + tags.length + ' relation sidecars)');
+        return true;
+      });
+    }).catch(function (e) {
+      _log(TAG + ' data load FAILED (' + (e && e.message) + ') — geomap audit unavailable, seeding unaffected');
+      return false;
+    });
+    return _loaded;
+  }
+
+  // ── thin wrappers: resident key in, honest refuse out when the key/tag/data has no answer ──
+  function gmDescribe(buildingKey, ifcClass) {
+    var t = gmTag(buildingKey);
+    return t ? ClassifyGeom.describe(t, ifcClass) : null;
+  }
+  // validator use (tier 2 claimedClass): is this element's measured dims inside its OWN class's measured band?
+  function gmValidate(buildingKey, dims, ifcClass) {
+    var t = gmTag(buildingKey);
+    if (!t) return { tier: 0, class_or_fact: 'unknown', confidence: 0, why: 'building key "' + buildingKey + '" has no mined geomap tag — refusing to guess', frame: null };
+    return ClassifyGeom.classify({ building: t, dims: dims, ifc_class: ifcClass });
+  }
+  // full per-element signal (Tier 1 first via guid, else Tier 2) — walker_confidence.wcGeomapSignal's input.
+  function gmSignal(buildingKey, el) {
+    var t = gmTag(buildingKey);
+    if (!t) return { tier: 0, class_or_fact: 'unknown', confidence: 0, why: 'building key "' + buildingKey + '" has no mined geomap tag — refusing to guess', frame: null };
+    return ClassifyGeom.classify({ building: t, guid: el.guid, dims: el.dims, ifc_class: el.ifc_class });
+  }
+
+  function _log(m) { if (typeof console !== 'undefined') console.log(m); }
+
+  return { gmTag: gmTag, gmLoad: gmLoad, gmReady: gmReady, gmDescribe: gmDescribe, gmValidate: gmValidate,
+    gmSignal: gmSignal, TAG_BY_BUILDING: TAG_BY_BUILDING, TAG: TAG };
+});

--- a/geomapping/tests/witness_wire.js
+++ b/geomapping/tests/witness_wire.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// witness_wire.js — W-GEOMAP-WIRE (bim-compiler prompts/RESUME_IFC_BOM_GEOMAPPING.md §WIRE-SPEC).
+// PURE NODE (sql.js, real modeller/Duplex_extracted.db). Read the §-log, not the exit code alone.
+//
+// ISSUES PROVED (each check names the failure it would expose):
+//   W1 ops-untouched   audit layer present vs absent → op arrays DEEP-EQUAL. Exposes: the geomap wiring
+//                      perturbing the signed op substrate (the one thing §WIRE-SPEC forbids).
+//   W2 audit-honest    checked+noBand == seeded ops; every flag carries guid+z+why. Exposes: silent
+//                      double-count / uncited flags.
+//   W3 test-bites      ONE in-memory corrupted bbox → that guid IS flagged. Exposes: a validator that
+//                      never fires (the furniture-floating mechanism must actually bite).
+//   W4 signal-mapping  wcGeomapSignal maps tier1→1.0 / tier2→measured / tier0→0, why non-empty always.
+//                      Exposes: fabricated confidence where the artifact refused.
+//   W5 honest-tag      unknown building key → null tag + tier-0 refuse. Exposes: guessed tags.
+//   W6 sweep-runs      CLI sweep on the real repo Duplex db: checked>0, flag-rate ≤ 0.15 (measured
+//                      own-class in-band 93-96% ⇒ ~5% expected; the LOG carries the exact number).
+'use strict';
+var fs = require('fs'), path = require('path'), cp = require('child_process');
+
+global.window = global.window || {};
+global.fetch = undefined;
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var GROOT = path.join(__dirname, '..');            // geomapping/
+var REPO = path.join(GROOT, '..');                 // repo root
+var MOD = path.join(REPO, 'modeller');
+
+var Bridge = require(path.join(GROOT, 'geomap_bridge.js'));
+var CG = require(path.join(GROOT, 'classify_geom.js'));
+var ArcEditable = require(path.join(MOD, 'arc_editable.js'));
+var WC = require(path.join(MOD, 'walker_confidence.js'));
+
+var initSqlJs = require(path.join(MOD, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(MOD, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(MOD, 'Duplex_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('§W-GEOMAP-WIRE PASS: ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('§W-GEOMAP-WIRE FAIL: ' + name + (extra ? '  ' + extra : '')); }
+}
+
+initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
+  console.log('═══ W-GEOMAP-WIRE — audit-first geomap wiring (node, REAL Duplex) ═══');
+  var buf = fs.readFileSync(DBPATH);
+  var classify = { validate: function (cls, dims) { return Bridge.gmValidate('Duplex', dims, cls); } };
+
+  // ── W1: ops byte-identical with vs without the audit layer ──
+  var dbA = new SQL.Database(buf);
+  var plain = ArcEditable.buildSeedOps(dbA);
+  dbA.close();
+  var dbB = new SQL.Database(buf);
+  var audited = ArcEditable.buildSeedOps(dbB, undefined, { classify: classify });
+  dbB.close();
+  chk('W1 ops deep-equal with/without classify (substrate untouched)',
+    JSON.stringify(plain.ops) === JSON.stringify(audited.ops),
+    '(' + plain.ops.length + ' ops)');
+  chk('W1 plain run has NO geomap block (old callers see zero new surface)', plain.geomap == null);
+
+  // ── W2: audit accounting is honest ──
+  var g = audited.geomap;
+  chk('W2 audit block present when classify injected', !!g);
+  chk('W2 checked+noBand == seeded ops (every element accounted once)',
+    !!g && g.checked + g.noBand === audited.ops.length,
+    '(checked=' + (g && g.checked) + ' noBand=' + (g && g.noBand) + ' ops=' + audited.ops.length + ')');
+  chk('W2 every flag carries guid+z+why (cited, never bare)',
+    !!g && g.flagged.every(function (f) { return f.guid && typeof f.z === 'number' && f.why; }),
+    '(flagged=' + (g && g.flagged.length) + ' inBandRate=' + (g && g.inBandRate) + ')');
+
+  // ── W3: negative control — corrupt ONE element's bbox in-memory, it MUST get flagged ──
+  var dbC = new SQL.Database(buf);
+  // pick a seeded element of a banded class that is currently NOT flagged (so the corruption alone flips it)
+  var target = null;
+  var flaggedSet = {};
+  g.flagged.forEach(function (f) { flaggedSet[f.guid] = 1; });
+  for (var i = 0; i < audited.ops.length; i++) {
+    var op = audited.ops[i];
+    var cls = op.params.ifc_class;
+    if (flaggedSet[op.outputGuid]) continue;
+    var probe = Bridge.gmValidate('Duplex', [1, 1, 1], cls); // banded class? (dims irrelevant for tier check)
+    if (probe.tier === 2) { target = op.outputGuid; break; }
+  }
+  chk('W3 fixture: found an unflagged banded-class element to corrupt', !!target, '(' + target + ')');
+  dbC.run("UPDATE element_transforms SET bbox_x=bbox_x*100, bbox_y=bbox_y*100, bbox_z=bbox_z*100 WHERE guid='" + target + "'");
+  var corrupted = ArcEditable.buildSeedOps(dbC, undefined, { classify: classify });
+  dbC.close();
+  var nowFlagged = corrupted.geomap.flagged.some(function (f) { return f.guid === target; });
+  chk('W3 corrupted element IS flagged (the validator bites — furniture-floating mechanism)', nowFlagged,
+    '(flagged ' + corrupted.geomap.flagged.length + ' vs baseline ' + g.flagged.length + ')');
+
+  // ── W4: wcGeomapSignal maps each tier's measured number through, never fabricates ──
+  var relDX = JSON.parse(fs.readFileSync(path.join(GROOT, 'data', 'relations_DX.json'), 'utf8'));
+  var relGuid = Object.keys(relDX.elements).sort().find(function (gu) { return relDX.elements[gu].storey; });
+  var s1 = WC.wcGeomapSignal(CG.classify({ building: 'DX', guid: relGuid }));
+  chk('W4 tier1 → conf 1.0 + why', s1.tier === 1 && s1.conf === 1.0 && !!s1.why, '(' + relGuid + ')');
+  var t2res = CG.classify({ building: 'DX', dims: [0.1, 0.9, 2.1] });
+  var s2 = WC.wcGeomapSignal(t2res);
+  chk('W4 tier2 → the result\'s own MEASURED confidence', s2.tier === 2 && s2.conf === t2res.confidence && s2.conf > 0 && s2.conf < 1,
+    '(conf=' + s2.conf + ')');
+  var s0 = WC.wcGeomapSignal(CG.classify({ building: 'DX', guid: 'no-such-guid-anywhere' }));
+  chk('W4 tier0 refuse → conf 0 + the refusal\'s why', s0.tier === 0 && s0.conf === 0 && /refus/i.test(s0.why));
+
+  // ── W5: honest tag mapping ──
+  chk('W5 known keys map (Duplex→DX, SampleCastle-ARC→SC, Terminal→Terminal)',
+    Bridge.gmTag('Duplex') === 'DX' && Bridge.gmTag('SampleCastle-ARC') === 'SC' && Bridge.gmTag('Terminal') === 'Terminal');
+  var refuse = Bridge.gmValidate('NopeBuilding', [1, 1, 1], 'IfcWall');
+  chk('W5 unknown key → null tag + tier-0 refuse (never a guessed tag)',
+    Bridge.gmTag('NopeBuilding') === null && refuse.tier === 0 && /refus/i.test(refuse.why));
+
+  // ── W6: the CLI sweep runs on the real repo db and reports a sane measured rate ──
+  var out = cp.execFileSync('node', [path.join(GROOT, 'validate_extraction.js'), DBPATH, 'Duplex'], { encoding: 'utf8' });
+  process.stdout.write(out);
+  var m = out.match(/checked=(\d+) flagged=(\d+) \(flag-rate ([\d.]+)\)/);
+  chk('W6 sweep SUMMARY present with checked>0', !!m && parseInt(m[1], 10) > 0, m && '(checked=' + m[1] + ')');
+  chk('W6 flag-rate ≤ 0.15 (measured in-band 93-96% ⇒ expected ~5%; bound catches gross misuse)',
+    !!m && parseFloat(m[3]) <= 0.15, m && '(rate=' + m[3] + ')');
+
+  console.log('§W-GEOMAP-WIRE RESULT: ' + (fail ? 'RED' : 'GREEN') + ' (' + pass + ' pass, ' + fail + ' fail)');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) {
+  console.log('§W-GEOMAP-WIRE FATAL ' + (e && e.stack));
+  process.exit(1);
+});

--- a/geomapping/tests/witness_wire_smoke.js
+++ b/geomapping/tests/witness_wire_smoke.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// witness_wire_smoke.js — §GEOMAP-WIRE browser smoke (headless Chromium, self-served). SECONDARY to the
+// node value witness (witness_wire.js W1-W6) per docs/TestArchitecture.md §Browser Testing: this proves
+// WIRING ONLY — the scripts load un-collided, the bridge data fetch really happens, the real user path
+// (click Open → resident seeds) emits the §GEOMAP-VALIDATE audit, and window.__gmSeedAudit is readable.
+//
+// ISSUE PROVED: node module-isolation HIDES browser global-collision/load-order bugs
+// (feedback_browser_iife_wrap_engines — the HBA burn) — only a live page catches a bridge that never
+// loads, a fetch path that 404s, or a gmReady() race that silently disables the audit forever.
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ §GEOMAP-WIRE-SMOKE — live bridge + seed audit (headless) ═══');
+
+  // G1 bridge data really loaded (fetch path + init, not just script parse)
+  await page.waitForFunction(function () { return window.GeomapBridge && window.GeomapBridge.gmReady() === true; }, { timeout: 15000 }).catch(function () {});
+  var ready = await page.evaluate(function () { return !!(window.GeomapBridge && window.GeomapBridge.gmReady()); });
+  chk('G1 GeomapBridge loaded + data fetched (gmReady)', ready,
+    logs.filter(function (l) { return l.indexOf('§GEOMAP-BRIDGE') === 0; }).slice(0, 1).join(''));
+
+  // G2 the REAL user path (click Open → SampleHouse) seeds WITH the audit
+  await page.click('#b-open'); await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="SampleHouse"]');
+  await page.waitForFunction(function () {
+    return !!(window.__gmSeedAudit && window.__gmSeedAudit.SampleHouse);
+  }, { timeout: 25000 }).catch(function () {});
+  var audit = await page.evaluate(function () { return (window.__gmSeedAudit && window.__gmSeedAudit.SampleHouse) || null; });
+  chk('G2 seed ran the audit → window.__gmSeedAudit.SampleHouse present', !!audit,
+    audit && ('checked=' + audit.checked + ' flagged=' + audit.flagged.length + ' noBand=' + audit.noBand + ' inBandRate=' + audit.inBandRate));
+  chk('G2b audit accounting sane (checked>0)', !!audit && audit.checked > 0);
+
+  // G3 the §GEOMAP-VALIDATE summary hit the live console (the whitebox §-log-first channel)
+  var sumLine = logs.find(function (l) { return l.indexOf('§GEOMAP-VALIDATE summary') > -1; });
+  chk('G3 §GEOMAP-VALIDATE summary line emitted in live console', !!sumLine, sumLine && sumLine.slice(0, 120));
+
+  // G4 zero load failures / pageerrors with the new scripts present
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('G4 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 2).join(' | '));
+
+  console.log('§GEOMAP-WIRE-SMOKE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.log('§GEOMAP-WIRE-SMOKE FATAL ' + (e && e.stack)); process.exit(1); });

--- a/geomapping/validate_extraction.js
+++ b/geomapping/validate_extraction.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// validate_extraction.js — extraction-correctness sweep (bim-compiler RESUME_IFC_BOM_GEOMAPPING.md
+// §WIRE-SPEC deliverable 4; witness W-GEOMAP-WIRE W6). Read the §-log, not the exit code alone.
+//
+// ISSUE THIS PROVES/EXPOSES: an extracted element whose MEASURED dims sit outside its OWN class's
+// measured band is real data-integrity signal (broken extraction, wrong units, corrupted transform) —
+// the mechanism that would have caught the 2026-07-01 furniture-floating bug (bad center_z/bbox_z)
+// BEFORE it ever hit a screenshot. Measured expectation: own-class in-band 93-96% (geomap_rules.json
+// per-building `measured`), so a healthy db flags ~5%; a gross extraction fault flags far more.
+//
+// Usage: node geomapping/validate_extraction.js <path/to/X_extracted.db> <buildingKeyOrTag> [--cap N]
+//   e.g.: node geomapping/validate_extraction.js modeller/Duplex_extracted.db Duplex
+// Accepts either a modeller resident key (Duplex) or a raw geomap tag (DX). Honest-refuse on unknown.
+'use strict';
+var fs = require('fs'), path = require('path');
+var Bridge = require('./geomap_bridge.js');
+var CG = require('./classify_geom.js');
+
+var TAG = '§GEOMAP-SWEEP';
+var argv = process.argv.slice(2);
+var capIdx = argv.indexOf('--cap');
+var CAP = capIdx > -1 ? (parseInt(argv[capIdx + 1], 10) || 20) : 20;
+var args = argv.filter(function (a, i) { return !a.startsWith('--') && (capIdx === -1 || i !== capIdx + 1); });
+
+if (args.length < 2) {
+  console.log('usage: node geomapping/validate_extraction.js <X_extracted.db> <buildingKeyOrTag> [--cap N]');
+  process.exit(2);
+}
+var dbPath = args[0];
+var KNOWN_TAGS = ['SH', 'DX', 'SC', 'Terminal'];
+var tag = Bridge.gmTag(args[1]) || (KNOWN_TAGS.indexOf(args[1]) > -1 ? args[1] : null);
+if (!tag) {
+  console.log(TAG + ' REFUSE: "' + args[1] + '" is neither a known resident key nor a mined geomap tag — no bands to validate against, refusing to guess');
+  process.exit(2);
+}
+
+var MODLIB = path.join(__dirname, '..', 'modeller', 'lib');
+var initSqlJs = require(path.join(MODLIB, 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(MODLIB, 'sql-wasm.wasm'));
+
+initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
+  var db = new SQL.Database(fs.readFileSync(dbPath));
+  var r = db.exec(
+    'SELECT m.guid, m.ifc_class, t.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m ' +
+    'JOIN element_transforms t ON t.guid = m.guid ORDER BY m.guid');
+  var rows = r.length ? r[0].values : [];
+  var checked = 0, flagged = [], noBand = 0, noDims = 0;
+  rows.forEach(function (v) {
+    var guid = v[0], cls = v[1], bx = v[2], by = v[3], bz = v[4];
+    if (!(bx > 0) || !(by > 0) || !(bz > 0)) { noDims++; return; } // degenerate/NULL bbox — not validatable, not a band flag
+    // tag already resolved above (resident key OR raw tag) — call the classifier on the tag directly.
+    var res = CG.classify({ building: tag, dims: [bx, by, bz], ifc_class: cls });
+    if (res.tier === 2) {
+      checked++;
+      if (!res.class_or_fact.in_band) flagged.push({ guid: guid, ifc_class: cls, z: res.class_or_fact.z, dims: [bx, by, bz] });
+    } else noBand++; // class has <3 samples / no band in the artifact — honest refuse, NOT a flag
+  });
+  flagged.slice(0, CAP).forEach(function (f) {
+    console.log(TAG + ' FLAG guid=' + f.guid + ' class=' + f.ifc_class + ' z=' + f.z +
+      ' dims=' + f.dims.map(function (d) { return d.toFixed(3); }).join('x') + 'm outside own-class measured band');
+  });
+  if (flagged.length > CAP) console.log(TAG + ' ...' + (flagged.length - CAP) + ' more flag(s), re-run with --cap to see all');
+  var rate = checked ? Math.round(1000 * flagged.length / checked) / 1000 : null;
+  console.log(TAG + ' SUMMARY db=' + dbPath + ' tag=' + tag + ' rows=' + rows.length +
+    ' checked=' + checked + ' flagged=' + flagged.length + ' (flag-rate ' + rate + ')' +
+    ' noBand=' + noBand + ' noDims=' + noDims +
+    ' — measured own-class in-band expectation ~93-96% ⇒ healthy flag-rate ~0.04-0.07; well above that = real extraction signal');
+  db.close();
+  process.exit(0);
+}).catch(function (e) {
+  console.log(TAG + ' ERROR ' + (e && e.message));
+  process.exit(1);
+});

--- a/modeller/arc_editable.js
+++ b/modeller/arc_editable.js
@@ -108,7 +108,16 @@
   // building's mesh substrate lives in its own file (§GEO-SPLIT, Terminal_geo.db vs Terminal_meta.db). Defaults
   // to `db` — every existing single-file call site (SampleHouse/Duplex/SampleCastle/SampleCastle-ARC, every
   // pure-node witness) is byte-identical, unchanged.
-  function buildSeedOps(db, geoDb) {
+  // opts (OPTIONAL, §GEOMAP-WIRE audit channel — bim-compiler RESUME_IFC_BOM_GEOMAPPING.md §WIRE-SPEC):
+  //   opts.classify = { validate(cls, dims3) } — injected geomap validator (GeomapBridge.gmValidate curried
+  //   with the building key). AUDIT-FIRST: this NEVER touches op params/order/count — witness W-GEOMAP-WIRE W1
+  //   proves ops byte-identical with/without it. Results land in the returned `geomap` block + §GEOMAP-VALIDATE
+  //   logs only. Absent (every pre-existing caller + pure-node witnesses) ⇒ zero new code paths run.
+  function buildSeedOps(db, geoDb, opts) {
+    opts = opts || {};
+    var gm = opts.classify && typeof opts.classify.validate === 'function' ? opts.classify : null;
+    var gmAudit = gm ? { checked: 0, flagged: [], noBand: 0 } : null;
+    var GM_FLAG_LOG_CAP = 20; // Terminal-scale seeds: log the first N flags individually, summarize the rest
     var hasDisc = _hasDiscipline(db);
     var where = hasDisc ? "m.discipline='ARC'"
       : '(' + ARC_CLASSES.map(function (c) { return "m.ifc_class='" + c + "'"; }).join(' OR ') + ')';
@@ -144,6 +153,23 @@
           console.error(TAG + ' §GEOM-HARDFAIL guid=' + guid + ' class=' + cls + ' no real geometry — skipped, not rendered');
           skipped.push({ guid: guid, ifc_class: cls, reason: 'no-real-geometry' }); return;
         }
+      }
+      // §GEOMAP-VALIDATE (audit-only — see opts.classify contract above): own-class measured-band check on the
+      // MEASURED dims. tier 2 ⇒ counted (in-band or flagged with z + why); tier 0 ⇒ noBand (class has no
+      // measured band / building has no rules — honest refuse, NOT a flag). Never touches the op below.
+      if (gm) {
+        var gv = null;
+        try { gv = gm.validate(cls, [bx, by, bz]); } catch (e) { gv = null; }
+        if (gv && gv.tier === 2) {
+          gmAudit.checked++;
+          if (!gv.class_or_fact.in_band) {
+            gmAudit.flagged.push({ guid: guid, ifc_class: cls, z: gv.class_or_fact.z, why: gv.why });
+            if (gmAudit.flagged.length <= GM_FLAG_LOG_CAP) {
+              _log(TAG + ' §GEOMAP-VALIDATE FLAG guid=' + guid + ' class=' + cls + ' z=' + gv.class_or_fact.z +
+                ' dims=' + bx.toFixed(3) + 'x' + by.toFixed(3) + 'x' + bz.toFixed(3) + 'm outside own-class measured band');
+            }
+          }
+        } else gmAudit.noBand++;
       }
       var bbox = [-bx / 2, bx / 2, -by / 2, by / 2, -bz / 2, bz / 2];   // MEASURED local box, centred in x/y/z (kept
       // on every op regardless of match — audit trail: what was actually measured, vs what mesh got stamped).
@@ -201,8 +227,18 @@
       }
       ops.push({ op_type: 'GEOM_INSERT', params: params, outputGuid: guid });
     });
+    if (gmAudit) {
+      var gmRate = gmAudit.checked ? Math.round(1000 * (gmAudit.checked - gmAudit.flagged.length) / gmAudit.checked) / 1000 : null;
+      if (gmAudit.flagged.length > GM_FLAG_LOG_CAP) {
+        _log(TAG + ' §GEOMAP-VALIDATE ...' + (gmAudit.flagged.length - GM_FLAG_LOG_CAP) + ' more flag(s) suppressed (all carried in the returned geomap.flagged)');
+      }
+      _log(TAG + ' §GEOMAP-VALIDATE summary checked=' + gmAudit.checked + ' flagged=' + gmAudit.flagged.length +
+        ' noBand=' + gmAudit.noBand + ' inBandRate=' + gmRate +
+        ' (audit-only: op substrate untouched; measured own-class in-band expectation ~93-96%, see geomap_rules.json)');
+      gmAudit.inBandRate = gmRate;
+    }
     return { ops: ops, skipped: skipped, discipline: hasDisc ? 'ARC' : 'fallback', matched: matched, unmatched: unmatched, tilted: tilted,
-      geomAssets: geomAssets, realResolved: realResolved, hardfail: hardfail, geomTable: geomIdx.table };
+      geomAssets: geomAssets, realResolved: realResolved, hardfail: hardfail, geomTable: geomIdx.table, geomap: gmAudit };
   }
 
   // buildBridge(ops, ids) — ops[i] committed as kernel_ops row ids[i] (== its featureId). Build both directions
@@ -233,7 +269,9 @@
   async function seedArc(buildingDb, io) {
     io = io || {};
     var name = io.building || 'building';
-    var built = buildSeedOps(buildingDb, io.geoDb);
+    // io.classify (OPTIONAL, §GEOMAP-WIRE): threaded straight through to buildSeedOps's audit channel —
+    // absent for every pre-existing caller, and provably incapable of altering the committed ops (W1).
+    var built = buildSeedOps(buildingDb, io.geoDb, io.classify ? { classify: io.classify } : undefined);
     if (io.registerGeometry && built.geomAssets.length) {
       try { io.registerGeometry(built.geomAssets); } catch (e) { _log(TAG + ' §REAL-GEOM registerGeometry failed ' + (e && e.message)); }
     }
@@ -262,7 +300,8 @@
     _log(TAG + ' §GEOM-HARDFAIL total=' + built.hardfail + ' of ' + (built.ops.length + built.hardfail) +
       ' (geomTable=' + (built.geomTable || 'none') + ' realResolved=' + built.realResolved + '/' + built.ops.length + ')');
     return { committed: ids.length, skipped: built.skipped.length, ids: ids, bridge: bridge, ops: built.ops,
-      matched: built.matched, unmatched: built.unmatched, tilted: built.tilted, realResolved: built.realResolved, hardfail: built.hardfail };
+      matched: built.matched, unmatched: built.unmatched, tilted: built.tilted, realResolved: built.realResolved, hardfail: built.hardfail,
+      geomap: built.geomap };
   }
 
   function _log(m) { if (typeof console !== 'undefined') console.log(m); }

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -203,15 +203,20 @@
 <!-- Real per-element geometry (component_geometries/base_geometries) — read+recentre, no THREE/DOM deps.
      Loaded BEFORE arc_editable.js (its factory takes window.RealGeometry as a dependency). -->
 <script src="real_geometry.js?v=1" onerror="console.warn('§REALGEOM LOAD_FAIL real_geometry.js')"></script>
-<script src="arc_editable.js?v=3" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
+<script src="arc_editable.js?v=4" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
 <script src="sdg_cascade.js?v=1" onerror="console.warn('§SDG LOAD_FAIL sdg_cascade.js')"></script>
 <script src="sdg_gate.js?v=1" onerror="console.warn('§GATE LOAD_FAIL sdg_gate.js')"></script>
 <!-- STR Walker (STR_ROUTEWALKING_SPEC.md): STR is a WALKED discipline. Open an STR building → walk the structure
      (skeleton f(grid) + tessellated systems); a grid drag re-walks + surfaces a cited structural exception. -->
 <script src="str_walker.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL str_walker.js')"></script>
-<script src="walker_confidence.js?v=1" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
+<script src="walker_confidence.js?v=2" onerror="console.warn('§STRWALK LOAD_FAIL walker_confidence.js')"></script>
+<!-- §GEOMAP-WIRE (RESUME_IFC_BOM_GEOMAPPING.md §WIRE-SPEC): IFC→BOM classifier + bridge — AUDIT-ONLY channel
+     (op substrate provably untouched, W-GEOMAP-WIRE W1). Load-failure tolerant: the ARC seed gates on
+     window.GeomapBridge && gmReady(), so a missing/failed script just means "no audit", never a broken seed. -->
+<script src="../geomapping/classify_geom.js?v=1" onerror="console.warn('§GEOMAP LOAD_FAIL classify_geom.js')"></script>
+<script src="../geomapping/geomap_bridge.js?v=1" onerror="console.warn('§GEOMAP LOAD_FAIL geomap_bridge.js')"></script>
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=11" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_outliner.js?v=12" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=17" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -47,6 +47,11 @@
   // NO OCI: the modeller is fully isolated from the viewer's cloud hosting (§101 Drift Law).
   function _modellerBase() { return './'; }   // modeller.html now lives IN modeller/ → residents are same-dir
 
+  // §GEOMAP-WIRE: start the geomap artifact fetch NOW (module init) so it usually beats the (multi-MB)
+  // resident DB fetch and the ARC seed's best-effort audit finds gmReady()===true. Failure-tolerant by
+  // contract: load failure logs once inside gmLoad and every consumer degrades to "no audit".
+  if (typeof window !== 'undefined' && window.GeomapBridge) window.GeomapBridge.gmLoad('../geomapping/');
+
   function tabRows() {
     var d = window.swbTabData && window.swbTabData();
     if (!d) return [{ id: 'sw-empty', label: 'Open a resident (▾) or local .db (🏗) to walk', sub: '' }];
@@ -270,11 +275,23 @@
         // §GEO-SPLIT: undefined for every non-split resident (bdb itself carries the geometry tables, exactly
         // as before); the opened Terminal_geo.db handle for Terminal.
         geoDb: gdb || undefined,
+        // §GEOMAP-WIRE (RESUME_IFC_BOM_GEOMAPPING.md §WIRE-SPEC): best-effort AUDIT channel — own-class
+        // measured-band check on every seeded element (return block + §GEOMAP-VALIDATE logs; op substrate
+        // provably untouched, W-GEOMAP-WIRE W1). Gated on the bridge's data actually having loaded (gmLoad
+        // kicked off at module init below); not ready / not loaded ⇒ undefined ⇒ seed byte-identical to today.
+        classify: (window.GeomapBridge && window.GeomapBridge.gmReady())
+          ? { validate: function (cls, dims) { return window.GeomapBridge.gmValidate(key, dims, cls); } }
+          : undefined,
         building: key
       }).then(function (r) {
         console.log(TAG + ' §ARC-SEED-WIRE ' + key + ' editable ARC elements=' + r.committed + ' skipped=' + r.skipped +
           ' realGeom=' + (r.realResolved || 0) + ' hardfail=' + (r.hardfail || 0) +
           ' (featureId↔guid bridge ready)');
+        // §GEOMAP-WIRE: surface the audit for the Outliner (read-only; null when the bridge wasn't ready)
+        if (r.geomap) {
+          window.__gmSeedAudit = window.__gmSeedAudit || {};
+          window.__gmSeedAudit[key] = r.geomap;
+        }
       // §LOD400-STALL: a seed failure here used to be console.warn-only — easy to miss (no pageerror, no UI
       // hint) and the exact way Terminal silently never loaded any geometry. console.error makes it a loud,
       // impossible-to-miss line in devtools/CI logs (still just a log line — no new UI surface, per scope).

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v27';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v28';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -66,6 +66,13 @@ const PRECACHE_ASSETS = [
   'routewalker.js',
   // Cross-surface broker — lives in viewer/ (shared), precache for offline Connect.
   '../viewer/connect_scene.js',
+  // §GEOMAP-WIRE — IFC→BOM classifier + bridge + mined artifacts (audit channel; offline parity with online).
+  '../geomapping/classify_geom.js',
+  '../geomapping/geomap_bridge.js',
+  '../geomapping/data/geomap_rules.json',
+  '../geomapping/data/relations_SH.json',
+  '../geomapping/data/relations_DX.json',
+  '../geomapping/data/relations_SC.json',
 ];
 
 self.addEventListener('install', (event) => {

--- a/modeller/walker_confidence.js
+++ b/modeller/walker_confidence.js
@@ -97,9 +97,26 @@ function wcEce(samples, confFn, nBins) {
   return wcReliability(mapped, nBins).ece;
 }
 
+// ── §GEOMAP-WIRE (bim-compiler RESUME_IFC_BOM_GEOMAPPING.md §WIRE-SPEC deliverable 3): per-element
+// Tier-1/2/0 confidence + why from a ClassifyGeom/GeomapBridge result — the REAL, measured classification
+// signal walkers can consume instead of each inventing its own heuristic. This is a SEPARATE channel from
+// the guard-margin path above: it must NEVER silently replace the calibrated wcCalibrated display (that
+// number is RosettaStone-earned; this one is the geomap artifact's own measured rate). Mapping is a pure
+// read-through of what each tier already measured — nothing asserted here:
+//   tier 1 → conf 1.0  (relational read-through; ground-truth agreement measured 100%, witness_geomap_tier1.py)
+//   tier 2 → the result's OWN confidence (the building's measured split-half top-1 / in-band rate)
+//   tier 0 → conf 0    (honest refuse — carries the refusal's why, never a fabricated number)
+function wcGeomapSignal(classifyResult) {
+  if (!classifyResult) return { conf: 0, tier: 0, why: 'no classify result — refusing to fabricate a confidence' };
+  var t = classifyResult.tier | 0;
+  var conf = t === 1 ? 1.0 : (t === 2 ? _clamp01(classifyResult.confidence) : 0);
+  return { conf: conf, tier: t, why: classifyResult.why || 'result carried no why (should not happen — ClassifyGeom always cites)' };
+}
+
 var _wcApi = {
   WC_CALIBRATION: WC_CALIBRATION, wcCalibrated: wcCalibrated,
-  wcRaw: wcRaw, wcReliability: wcReliability, wcFitIsotonic: wcFitIsotonic, wcEce: wcEce
+  wcRaw: wcRaw, wcReliability: wcReliability, wcFitIsotonic: wcFitIsotonic, wcEce: wcEce,
+  wcGeomapSignal: wcGeomapSignal
 };
 if (typeof module !== 'undefined' && module.exports) module.exports = _wcApi;
 if (typeof window !== 'undefined') Object.keys(_wcApi).forEach(function (k) { window[k] = _wcApi[k]; });


### PR DESCRIPTION
Implements bim-compiler `RESUME_IFC_BOM_GEOMAPPING.md` §WIRE-SPEC (§NEXT-SESSION-TASKS item 1 — `classify_geom.js` had zero consumers until this).

## What
- **`geomapping/geomap_bridge.js`** (new) — resident-key→geomap-tag map (honest null on unknown key), browser data init (fetch → `ClassifyGeom.init`, failure-tolerant), `gmDescribe/gmValidate/gmSignal` + `gmReady` gate.
- **`modeller/arc_editable.js`** — optional `classify` audit channel in `buildSeedOps`/`seedArc`: every seeded element's measured dims checked against its OWN class's measured band. **Audit-first: committed ops are provably byte-identical with/without it (W1)** — results live only in the returned `geomap` block + `§GEOMAP-VALIDATE` logs.
- **`modeller/walker_confidence.js`** — `wcGeomapSignal`: per-element Tier-1/2/0 confidence+why, pure read-through of the measured artifact. Separate channel from the RosettaStone-calibrated display.
- **`geomapping/validate_extraction.js`** (new CLI) — extraction-correctness sweep; the mechanism that would have caught the furniture-floating bug pre-screenshot. Real Duplex: checked=212, flagged=7, rate=0.033 (measured in-band expectation 93–96%).
- Browser wiring: modeller.html includes, `gmLoad` at init, best-effort inject into the ARC seed, `window.__gmSeedAudit` surface, sw.js v28 + precache.

## Witnesses (all re-run locally, logs read)
- **W-GEOMAP-WIRE 14/14 GREEN** (node, real Duplex db) — incl. W3 negative control (corrupted bbox IS flagged).
- **§GEOMAP-WIRE-SMOKE 5/5 GREEN** (real chromium, real click-Open path: bridge data fetch, live `§GEOMAP-VALIDATE` summary, no LOAD_FAIL).
- Regression: W-ARC-EDITABLE 10/10, §ARC-SEED-SMOKE 8/8, W-GEOMAP GREEN.

## Honest scope
LOD300 mesh-stamping still uses the 3-item catalog; flipping the measured bands to be AUTHORITATIVE over which mesh renders is a later, separately-witnessed step (stated in §WIRE-SPEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)