### PR TITLE
feat(modeller): §STRETCH-RIDE — openings ride grid-stretch via rel_fills_host

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -43,16 +43,50 @@
         delta: c.delta, newScale: c.newScale, translateDelta: c.translateDelta, edge: c.edge }));
     },
 
+    // §STRETCH-RIDE snapshot: pre-stretch AABBs of every authored mesh, the SAME shape modeller.html's own
+    // _gateBoxes() builds for the conformity gate — SdgCascade.stretchRide needs the rider's + host's PRE-edit
+    // boxes to derive the induced move (see sdg_cascade.js header). Read BEFORE this drag's commit so it's honest.
+    _boxByFid() {
+      const g = window.Bonsai.group && window.Bonsai.group(); const out = {}; if (!g) return out;
+      g.children.forEach(m => { if (m.isMesh && m.userData && m.userData.featureId != null) {
+        m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+        out[m.userData.featureId] = [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z]; } });
+      return out;
+    },
+
     // Commit ONE signed GEOM_GRID_MOVE per drag-release; the worker folds the recompose deterministically.
+    // Implementing RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE — Witness: W-STRETCH-RIDE.
     async commit(gridId, delta) {
-      const commands = this.computeCommands(gridId, delta);
+      let commands = this.computeCommands(gridId, delta);
+      let riders = [];
+      // §STRETCH-RIDE: a hosted opening must NOT divorce or scale when its host wall is grid-stretched — the
+      // engine classifies EVERY authored mesh independently (doors/windows included), so strip any rider's OWN
+      // command and induce ONE rigid move instead, resolved ONLY over the REAL rel_fills_host edges through the
+      // §ARC-1 bridge (non-invent — never a proximity heuristic). Absent the bridge (no fills data for this
+      // resident, e.g. SampleCastle — see RESUME_CASCADE_INTO_STRETCH.md recon) stretchRide already no-ops
+      // byte-identically, so this branch is a pure regression-safe extension, never a behavior change when unfed.
+      if (window.SdgCascade && window.SdgCascade.stretchRide &&
+          window.__arcGuidByFid && window.__arcFidByGuid && window.swXEdges && window.swXEdges.fills) {
+        const boxByFid = this._boxByFid();
+        const ride = window.SdgCascade.stretchRide(commands, window.__arcGuidByFid, window.__arcFidByGuid, window.swXEdges.fills, boxByFid);
+        commands = ride.commands; riders = ride.riders;
+        if (riders.length) console.log(TAG + ' §STRETCH-RIDE stripped=' + riders.length + ' rider cmd(s) → induced move instead: ' + riders.map(r => r.featureId).join(','));
+      }
       const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_GRID_MOVE',
         parameters: { gridId, delta, commands } }, {});
       // The authoring gridline advances via Grid.foldFromOplog — a FOLD of the op-log fired on this commit's
       // bonsai:oplog event — NOT mutated here, so undo/redo/scrub revert it deterministically (M1 fix).
       console.log(TAG + ' commit grid=' + gridId + ' delta=' + delta + ' cmds=' + commands.length +
         ' verify=' + res.verify + ' tris=' + res.triangleCount);
-      return { ...res, commands };
+      // §STRETCH-RIDE: one induced GEOM_MOVE per rider, same signed-op idiom as commitMove's hosted-by ride
+      // (modeller.html commitMove ~line 1532-1534) — a SEPARATE op so undo/scrub/rosetta treat it like any move.
+      for (const r of riders) {
+        const rr = await window.Bonsai.oplog.commit({ op_type: 'GEOM_MOVE',
+          parameters: { parent: r.featureId, dx: r.dx, dy: r.dy, dz: r.dz, induced: 'hosted-by' } }, {});
+        console.log(TAG + ' §STRETCH-RIDE hosted-by rider=' + r.featureId + ' induced dx=' + r.dx.toFixed(3) +
+          ' dy=' + r.dy.toFixed(3) + ' dz=' + r.dz.toFixed(3) + ' verify=' + rr.verify);
+      }
+      return { ...res, commands, riders };
     }
   };
   window.Bonsai = window.Bonsai || {};

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1162,10 +1162,16 @@ async function commitGridMove() {
   try {
     const res = await window.Bonsai.gridmove.commit(id, delta);
     // §STRETCH-1 (W-SDG-GATE): gate the STRETCH like a move — RED (a stretched wall now clashing, or a door fallen
-    // out of its host) / ORANGE (clearance). The changed set = the engine's recompose commands' featureIds.
-    const gateMsg = _runGate(_gateBefore, (res.commands || []).map(c => c.featureId).filter(f => f != null));
+    // out of its host) / ORANGE (clearance). The changed set = the engine's recompose commands' featureIds
+    // PLUS §STRETCH-RIDE riders (RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE — Witness: W-STRETCH-RIDE): a rider's
+    // OWN command was STRIPPED by gridmove.commit (it moved via an induced GEOM_MOVE instead), so it would
+    // otherwise be invisible to the gate's changed set — the door-out oracle must still check it moved.
+    const gateMsg = _runGate(_gateBefore, (res.commands || []).map(c => c.featureId).filter(f => f != null)
+      .concat((res.riders || []).map(r => r.featureId)));
     window.__lastGate = gateMsg;
-    setStat('grid ' + id + ' moved ' + delta.toFixed(2) + '  recomposed=' + res.commands.length + '  verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
+    setStat('grid ' + id + ' moved ' + delta.toFixed(2) + '  recomposed=' + res.commands.length +
+      (res.riders && res.riders.length ? ('  §STRETCH-RIDE riders=' + res.riders.length) : '') +
+      '  verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
     audioCue('commit'); exitGridMove(); syncHistory();
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER gridmove fail ' + err); }
 }

--- a/modeller/sdg_cascade.js
+++ b/modeller/sdg_cascade.js
@@ -15,6 +15,63 @@
 })(typeof window !== 'undefined' ? window : this, function () {
   'use strict';
 
+  // stretchRide(commands, guidByFid, fidByGuid, fills, boxByFid) → { commands, riders }
+  // Implementing RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE — Witness: W-STRETCH-RIDE.
+  // A grid edit's per-feature commands (gridmove.computeCommands) classify EVERY authored mesh independently —
+  // doors/windows included — so a filling can receive its own TRANSLATE (divorcing from a scaled host) or its own
+  // SCALE (a stretched door — wrong). The REAL rel_fills_host relation overrides the engine's independent view:
+  //   - the rider's OWN commands are STRIPPED from the list (returned `commands`), and
+  //   - the rider gets ONE induced move (returned `riders`: [{featureId, dx, dy, dz}]) derived from its HOST's
+  //     commands applied IN ORDER to the rider's pre-stretch centre c and the host's pre-stretch min m on the
+  //     command axis — the SAME anchored-min mapping the fold applies to the host itself (bonsai_library.js
+  //     foldInsert gridCmds branch / bonsai_kernel_worker.js):
+  //       TRANSLATE {delta d}:            c += d;  m += d                    (rider delta accumulates +d)
+  //       SCALE {newScale f, translateDelta t}:  c' = f·c + m·(1−f) + t;  m += t   (delta accumulates (f−1)·(c−m)+t)
+  //     ⇒ the rider keeps its PROPORTIONAL position along the host ((c−m)/extent invariant) and its extent NEVER
+  //     changes (no SCALE ever reaches a filling). A filling whose host has NO command keeps its own engine command
+  //     untouched (it attached to a gridline on its own merit). NON-INVENT: host↔filling comes ONLY from the
+  //     recovered rel_fills_host edges through the §ARC-1 bridge — no proximity heuristics.
+  //   boxByFid: featureId → [minx,maxx,miny,maxy,minz,maxz] AABBs snapshotted BEFORE the commit (the _gateBoxes
+  //   shape). A rider or host with no pre-state box is SKIPPED whole (no ride, no strip — byte-identical fallback:
+  //   never strip a command we cannot honestly replace). Pure — no window/THREE access.
+  function stretchRide(commands, guidByFid, fidByGuid, fills, boxByFid) {
+    var out = { commands: commands, riders: [] };
+    if (!Array.isArray(commands) || !commands.length || !guidByFid || !fidByGuid || !Array.isArray(fills) || !boxByFid) return out;
+    var AX = { x: 0, y: 1, z: 2 };
+    var byFid = {};                                             // host featureId → its commands, IN LIST ORDER
+    for (var i = 0; i < commands.length; i++) { var cm = commands[i]; if (cm && cm.featureId != null) (byFid[cm.featureId] = byFid[cm.featureId] || []).push(cm); }
+    var riders = [], ridden = {};                               // ridden: rider fid → 1 (dedupe + strip set)
+    for (var j = 0; j < fills.length; j++) {
+      var e = fills[j];
+      var hfid = fidByGuid[e.host_guid], rfid = fidByGuid[e.filling_guid];
+      if (hfid == null || rfid == null || !byFid[hfid]) continue;   // ride ONLY when the HOST has a command
+      if (ridden[rfid]) continue;                                   // one ride per filling (first host wins)
+      var hb = boxByFid[hfid], rb = boxByFid[rfid];
+      if (!hb || !rb) continue;                                     // no honest pre-state → leave the engine's view alone
+      var c3 = [(rb[0] + rb[1]) / 2, (rb[2] + rb[3]) / 2, (rb[4] + rb[5]) / 2];   // rider pre-stretch centre
+      var m3 = [hb[0], hb[2], hb[4]];                                             // host pre-stretch min per axis
+      var d3 = [0, 0, 0], cmds = byFid[hfid];
+      for (var k = 0; k < cmds.length; k++) {
+        var cmd = cmds[k], a = AX[cmd.axis];
+        if (a == null) continue;                                    // axis-less command (ROOF_LIFT) → no plan-axis ride
+        if (cmd.action === 'TRANSLATE') {
+          var d = cmd.delta || 0; c3[a] += d; m3[a] += d; d3[a] += d;
+        } else {                                                    // SCALE semantics — mirror the fold's else-branch
+          var f = cmd.newScale != null ? cmd.newScale : 1, t = cmd.translateDelta || 0;
+          var nc = f * c3[a] + m3[a] * (1 - f) + t;
+          d3[a] += nc - c3[a]; c3[a] = nc; m3[a] += t;
+        }
+      }
+      ridden[rfid] = 1;
+      if (Math.abs(d3[0]) > 1e-12 || Math.abs(d3[1]) > 1e-12 || Math.abs(d3[2]) > 1e-12)
+        riders.push({ featureId: rfid, dx: d3[0], dy: d3[1], dz: d3[2] });
+    }
+    if (!Object.keys(ridden).length) return out;                    // no rider touched → the input list, untouched
+    out.commands = commands.filter(function (c) { return !(c && c.featureId != null && ridden[c.featureId]); });
+    out.riders = riders;
+    return out;
+  }
+
   // ridersFor(movedFids, guidByFid, fidByGuid, fills, movedSet?) → [riderFid]
   //   the hosted FILLINGS of the moved HOSTS, deduped, excluding anything already in the moved set. Pure.
   //   guidByFid: featureId → guid (window.__arcGuidByFid)   fidByGuid: guid → featureId (window.__arcFidByGuid)
@@ -37,5 +94,5 @@
     return out;
   }
 
-  return { ridersFor: ridersFor };
+  return { ridersFor: ridersFor, stretchRide: stretchRide };
 });

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v30';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v31';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_e2e_stretch_ride.js
+++ b/modeller/tests/witness_e2e_stretch_ride.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-STRETCH-RIDE: real-user, maths-asserted E2E of §STRETCH-RIDE (grid-stretch a wall must
+ * NOT divorce or scale its hosted door/window). Implementing RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE —
+ * Witness: W-STRETCH-RIDE. Read the log after every run.
+ *
+ * Real production path (real toolbar + real drag hook), REAL SampleHouse (7 rel_fills_host rows, §ARC-1 substrate
+ * auto-seeded on Open — see str_walker_outliner.js _seedArcEditable). No hardcoded featureIds: the host/gridline/
+ * delta/rider are DISCOVERED live from the app's own engine (window.Bonsai.gridmove.computeCommands) cross-checked
+ * against the REAL rel_fills_host edges (window.swXEdges.fills) through the §ARC-1 bridge — a resident can drift
+ * (extraction re-run, id renumber) without invalidating this witness.
+ *
+ *   E1 DISCOVER  — sweep the REAL grid lines × a few deltas via computeCommands (no commit) for a SCALE command on
+ *                  a featureId that IS a real rel_fills_host HOST, whose filling is genuinely hosted pre-stretch
+ *                  (mirrors sdg_gate.js's own withinXY pre-check, tol=0.05 — same discipline as the T2c node-witness
+ *                  fix, so this picks the SAME kind of honest pair, not door=13's known-unhosted outlier).
+ *   E2 RIDE      — window.__gridStretch(id, delta) (the real production hook, modeller.html) commits the drag.
+ *                  Read back the LIVE scene: the rider door's mesh geometry EXTENT is unchanged (no scale reached
+ *                  it), its centre moved (the ride fired), and window.__lastGate shows no NEW door-out RED.
+ *   E3 OP-LOG    — exactly one induced GEOM_MOVE with parameters.induced==='hosted-by' for the rider is in the REAL
+ *                  op-log after the commit, and the committed GEOM_GRID_MOVE's parameters.commands contains NO
+ *                  entry for the rider's featureId (its own command was stripped, not merely overridden).
+ *   E4 VISIBLE   — pixel-readback (the spec's explicit open rigor item, not an eyeball check): project the rider
+ *                  door mesh's world bbox centre to screen space and gl.readPixels a small rect around it POST-ride;
+ *                  assert non-background colour, mesh.visible===true, material.opacity>0, in-frustum.
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+runE2E('W-E2E-STRETCH-RIDE', async (t) => {
+  await t.open('SampleHouse'); await t.shot('01-open');
+
+  // §ARC-1 substrate seeds ASYNC on Open (str_walker_outliner.js _forkEditable → _fetchGeoDb → _seedArcEditable) —
+  // wait for the bridge + REAL cross-edges to be live before discovering a pair (non-invent: never race the seed).
+  await t.pg.waitForFunction(() => !!(window.__arcFidByGuid && window.__arcGuidByFid && window.swXEdges && window.swXEdges.fills && window.swXEdges.fills.length), { timeout: 20000 }).catch(() => {});
+
+  // in-page helpers: discovery (E1), live-scene readback (E2/E4). No hardcoded featureIds anywhere below.
+  const disc = await t.pg.evaluate(() => {
+    function withinXY(box, pt, tol) { tol = tol || 0; return pt[0] >= box[0] - tol && pt[0] <= box[1] + tol && pt[1] >= box[2] - tol && pt[1] <= box[3] + tol; }
+    function boxOf(fid) {
+      const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+      if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+      return [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z];
+    }
+    function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+    const fbg = window.__arcFidByGuid, gbf = window.__arcGuidByFid, fills = window.swXEdges.fills;
+    const lines = window.Bonsai.gridmove.gridLines();      // REAL authoring grid, current state
+    const deltas = [1, -1, 2, -2, 0.5, -0.5, 1.5, -1.5, 3, -3, 4, -4];
+    for (const line of lines) {
+      for (const d of deltas) {
+        let cmds; try { cmds = window.Bonsai.gridmove.computeCommands(line.id, d); } catch (e) { continue; }
+        for (const c of cmds) {
+          if (c.action !== 'SCALE') continue;
+          const hostGuid = gbf[c.featureId]; if (hostGuid == null) continue;
+          // a host can have MULTIPLE filling rows (SampleHouse host=3 has 2: door=7 hosted, door=13 NOT — the
+          // T2c node-witness finding). Try each candidate edge and take the FIRST that genuinely qualifies,
+          // don't stop at fills.find()'s first row blindly (that was the T2c bug in the node witness too).
+          const edges = fills.filter(e => e.host_guid === hostGuid && fbg[e.filling_guid] != null);
+          const hb = boxOf(c.featureId); if (!hb) continue;
+          for (const edge of edges) {
+            const doorFid = fbg[edge.filling_guid];
+            const rb = boxOf(doorFid); if (!rb) continue;
+            if (!withinXY(hb, centreOf(rb), 0.05)) continue;    // the SAME honest pre-check the production gate uses
+            return { gridId: line.id, delta: d, hostFid: c.featureId, doorFid: doorFid, hostGuid, doorGuid: edge.filling_guid };
+          }
+        }
+      }
+    }
+    return null;
+  });
+  console.log('  §STRETCH-RIDE E1 discovered ' + JSON.stringify(disc));
+  t.assert('E1 DISCOVER (real gridline+delta yields a SCALE on a genuinely-hosted rel_fills_host HOST)', !!disc, JSON.stringify(disc));
+  await t.shot('02-discovered');
+
+  if (!disc) { console.log('  §STRETCH-RIDE E1 FAILED — no qualifying pair found, skipping E2-E4'); return; }
+
+  // pre-ride live-scene snapshot of the RIDER (door/window) — extent + centre, and the op-log length.
+  const pre = await t.pg.evaluate((fid) => {
+    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+    if (!m) return null;
+    m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+    return { dims: [b.max.x - b.min.x, b.max.y - b.min.y, b.max.z - b.min.z], centre: [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2] };
+  }, disc.doorFid);
+  const before = await t.oplog();
+
+  // E2 — RIDE: the real production hook (modeller.html window.__gridStretch → commitGridMove → Bonsai.gridmove.commit).
+  await t.pg.evaluate((id, d) => window.__gridStretch(id, d), disc.gridId, disc.delta);
+  await t.sleep(900);
+
+  const post = await t.pg.evaluate((fid) => {
+    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+    if (!m) return null;
+    m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+    return { dims: [b.max.x - b.min.x, b.max.y - b.min.y, b.max.z - b.min.z], centre: [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2] };
+  }, disc.doorFid);
+  const lastGate = await t.pg.evaluate(() => window.__lastGate || '');
+  const after = await t.oplog();
+
+  const dimDelta = pre && post ? Math.max(...pre.dims.map((v, i) => Math.abs(v - post.dims[i]))) : Infinity;
+  const centreShift = pre && post ? Math.hypot(...pre.centre.map((v, i) => v - post.centre[i])) : 0;
+  console.log('  §STRETCH-RIDE E2 pre.dims=' + JSON.stringify(pre && pre.dims) + ' post.dims=' + JSON.stringify(post && post.dims) + ' dimDelta=' + dimDelta.toExponential(2));
+  console.log('  §STRETCH-RIDE E2 pre.centre=' + JSON.stringify(pre && pre.centre) + ' post.centre=' + JSON.stringify(post && post.centre) + ' centreShift=' + centreShift.toFixed(4) + 'm');
+  console.log('  §STRETCH-RIDE E2 lastGate="' + lastGate + '" oplog ' + before.len + '→' + after.len);
+  await t.shot('03-post-ride');
+
+  t.assert('E2a RIDE — rider mesh extent UNCHANGED (no scale reached it, tol 1e-4)', dimDelta < 1e-4, 'dimDelta=' + dimDelta.toExponential(2));
+  t.assert('E2b RIDE — rider mesh centre MOVED (the ride fired)', centreShift > 0.01, 'centreShift=' + centreShift.toFixed(4) + 'm');
+  t.assert('E2c RIDE — gate shows no door-out RED (legitimate stretch)', !/RED/.test(lastGate) || !/door-out/.test(lastGate), 'lastGate="' + lastGate + '"');
+
+  // E3 — real op-log: exactly one induced GEOM_MOVE {induced:'hosted-by', parent:doorFid} for the rider, and the
+  // committed GEOM_GRID_MOVE's own parameters.commands has NO entry for the rider (stripped, not just overridden).
+  const opCheck = await t.pg.evaluate((doorFid, beforeLen) => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const added = ops.slice(beforeLen);
+    const gridMove = added.find(o => o.op_type === 'GEOM_GRID_MOVE');
+    const inducedMoves = added.filter(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.induced === 'hosted-by' && o.parameters.parent === doorFid);
+    const strippedOk = !gridMove || !(gridMove.parameters.commands || []).some(c => c.featureId === doorFid);
+    return { addedTypes: added.map(o => o.op_type), inducedCount: inducedMoves.length, strippedOk, gridMoveCmds: gridMove ? gridMove.parameters.commands.length : null };
+  }, disc.doorFid, before.len);
+  console.log('  §STRETCH-RIDE E3 ' + JSON.stringify(opCheck));
+  t.assert('E3a OP-LOG — exactly ONE induced GEOM_MOVE {induced:hosted-by, parent:rider} for the rider', opCheck.inducedCount === 1, JSON.stringify(opCheck));
+  t.assert('E3b OP-LOG — the committed GEOM_GRID_MOVE carries NO entry for the rider (stripped)', opCheck.strippedOk, JSON.stringify(opCheck));
+
+  // E4 — pixel-readback visibility (open rigor item): project the rider's post-ride world bbox centre to screen
+  // space and readPixels a small rect around it; assert non-background colour + visible + opaque + in-frustum.
+  const vis = await t.pg.evaluate((fid) => {
+    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+    if (!m) return { ok: false, reason: 'no mesh' };
+    const box = new window.THREE.Box3().setFromObject(m);
+    if (!isFinite(box.min.x)) return { ok: false, reason: 'no bbox' };
+    const c = new window.THREE.Vector3(); box.getCenter(c);
+    const r = window.A.renderer, cam = window.A.camera;
+    r.render(window.A.scene, cam);
+    const v = c.clone().project(cam);
+    const cv = r.domElement, rect = cv.getBoundingClientRect();
+    const clientX = (v.x * 0.5 + 0.5) * rect.width + rect.left, clientY = (-v.y * 0.5 + 0.5) * rect.height + rect.top;
+    const inFrustum = v.z >= -1 && v.z <= 1 && clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+    const gl = r.getContext();
+    const bw = gl.drawingBufferWidth, bh = gl.drawingBufferHeight;
+    const sx = bw / rect.width, sy = bh / rect.height;
+    const bx = Math.round((clientX - rect.left) * sx), byTop = Math.round((clientY - rect.top) * sy);
+    const half = 10;
+    const x0 = Math.max(0, bx - half), w = Math.min(half * 2, bw - x0);
+    const yTop0 = Math.max(0, byTop - half), h = Math.min(half * 2, bh - yTop0);
+    const y0 = Math.max(0, bh - yTop0 - h);            // WebGL readPixels is bottom-left origin
+    let nonBg = 0, total = 0;
+    const bg = window.A.scene.background;              // the REAL clear colour, read live (non-invent)
+    const bgArr = bg ? [Math.round(bg.r * 255), Math.round(bg.g * 255), Math.round(bg.b * 255)] : [0, 0, 0];
+    if (w > 0 && h > 0) {
+      const px = new Uint8Array(w * h * 4);
+      gl.readPixels(x0, y0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      for (let i = 0; i < px.length; i += 4) {
+        total++;
+        const dist = Math.abs(px[i] - bgArr[0]) + Math.abs(px[i + 1] - bgArr[1]) + Math.abs(px[i + 2] - bgArr[2]);
+        if (dist > 20) nonBg++;
+      }
+    }
+    return { ok: true, inFrustum, visible: m.visible, opacity: m.material ? m.material.opacity : null,
+      nonBg, total, bg: bgArr, rectPx: { x0, y0, w, h }, clientXY: [Math.round(clientX), Math.round(clientY)] };
+  }, disc.doorFid);
+  console.log('  §STRETCH-RIDE E4 ' + JSON.stringify(vis));
+  await t.shotClip('04-rider-visible', disc.doorFid, 60);
+  t.assert('E4a VISIBLE — rider is in-frustum, mesh.visible, opacity>0', vis.ok && vis.inFrustum && vis.visible === true && (vis.opacity == null || vis.opacity > 0), JSON.stringify(vis));
+  t.assert('E4b VISIBLE — readPixels around the rider finds non-background pixels (rasterized, not just data-visible)', vis.ok && vis.total > 0 && vis.nonBg > 0, 'nonBg=' + vis.nonBg + '/' + vis.total);
+}, { width: 1280, height: 860, dpr: 2 });

--- a/modeller/tests/witness_stretch_ride.js
+++ b/modeller/tests/witness_stretch_ride.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-STRETCH-RIDE: §STRETCH-RIDE value witness (PURE NODE, REAL SampleHouse).
+ * Implementing RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE — Witness: W-STRETCH-RIDE. Read the log after every run.
+ *
+ * Issue under test: gridmove.elementData() feeds EVERY authored mesh to the GridKinematicEngine tagged 'IfcWall' —
+ * doors/windows included — so the engine classifies fillings INDEPENDENTLY of their host wall. A filling could
+ * receive its own TRANSLATE (divorcing from a scaled host) or its own SCALE (a stretched door — wrong).
+ * SdgCascade.stretchRide overrides the engine's independent view with the REAL rel_fills_host relation: strip the
+ * rider's own commands, induce ONE move from the HOST's commands (anchored-min mapping, same as the fold).
+ *
+ * Substrate is REAL: SampleHouse_extracted.db rel_fills_host rows (CrossEdges), the §ARC-1 seed bridge
+ * (ArcEditable.seedArc), and pre-stretch AABBs measured off the REAL foldInsert geometry (bonsai_library).
+ *
+ *   T1 TRANSLATE-EXACT — host TRANSLATE d ⇒ rider delta EXACTLY d on that axis (0 on others); rider−host offset
+ *                        invariant under the ride (proves: no divorce on a translated host).
+ *   T2 SCALE-PROPORTIONAL — host SCALE ⇒ rider centre remapped so (c−m)/extent is preserved math-exact; the rider
+ *                        receives NO scale (extent unchanged — riders carry only dx/dy/dz); its own engine command
+ *                        is STRIPPED; new centre stays inside the folded (production-fold) host footprint
+ *                        (proves: no stretched door, no divorce, fold-consistent).
+ *   T3 ROSETTA          — apply the stretch then its exact inverse ⇒ rider centre returns to start within 1e-9
+ *                        (proves: the ride is invertible, no drift accumulates).
+ *   T4 NON-INVENT       — an element with NO rel_fills_host edge gets NO induced move and keeps its own commands;
+ *                        a filling whose HOST has no command keeps its own command too (attached on its own merit)
+ *                        (proves: rides ONLY on recovered edges, never a heuristic).
+ *   T5 STACKED          — TRANSLATE then SCALE on the same host, in order, compose to the closed-form expected
+ *                        centre f·(c+d) + (m+d)(1−f) + t (proves: in-order composition matches the fold's replay).
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];   // the _gateBoxes shape
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+// withinXY — mirrors sdg_gate.js's own oracle (point-in-box on X AND Y, tol=0.05): a door's CENTRE inside its
+// host's plan footprint. The T2c fix (2026-07-02) picks its host/door PAIR by this SAME pre-check the production
+// gate uses, instead of blindly taking fills[0] — see witness header T2 note + RESUME_CASCADE_INTO_STRETCH.md
+// §STRETCH-RIDE 2026-07-02 update (SampleHouse host=3 has TWO filling rows; door=13 fails this pre-check even
+// BEFORE any edit — a real multi-segment-wall extraction characteristic the production gate would never flag
+// either way, so it is the WRONG pair to test "stays inside" against; door=7 passes and is the honest pick).
+function withinXY(box, pt, tol) {
+  tol = tol || 0;
+  return pt[0] >= box[0] - tol && pt[0] <= box[1] + tol && pt[1] >= box[2] - tol && pt[1] <= box[3] + tol;
+}
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-STRETCH-RIDE — openings ride grid-stretch via rel_fills_host (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+
+  // §ARC-1 substrate: seed → ops + fid↔guid bridge; REAL fills edges from CrossEdges
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+
+  // REAL pre-stretch AABBs off the production fold (every seeded fid), the boxByFid input
+  var boxByFid = {};
+  Object.keys(opByFid).forEach(function (fid) {
+    boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions);
+  });
+  // pick a REAL host→filling pair with both endpoints seeded AND genuinely hosted pre-stretch (T2c fix, 2026-07-02):
+  // SampleHouse host=3 has TWO filling rows ({door=13} + {door=7}); fills[0] happened to be door=13, whose real AABB
+  // centre sits ~0.44m outside host=3's own x-range even BEFORE any stretch — not a bug, a real multi-segment-wall
+  // extraction characteristic the production gate's own pre-check (sdg_gate.js withinXY, tol=0.05) would also
+  // decline to guard. Select programmatically the SAME way the gate does, so the witness stays robust to db changes.
+  var edge = fills.find(function (e) {
+    var hf = fbg[e.host_guid], rf = fbg[e.filling_guid];
+    if (hf == null || rf == null || !boxByFid[hf] || !boxByFid[rf]) return false;
+    return withinXY(boxByFid[hf], centreOf(boxByFid[rf]), 0.05);
+  });
+  var hostFid = fbg[edge.host_guid], doorFid = fbg[edge.filling_guid];
+  var fillFids = {}; fills.forEach(function (e) { if (fbg[e.filling_guid] != null) fillFids[fbg[e.filling_guid]] = 1; if (fbg[e.host_guid] != null) fillFids[fbg[e.host_guid]] = 1; });
+  var loneFid = +Object.keys(opByFid).find(function (f) { return !fillFids[f]; });
+  chk('T0 substrate: seeded bridge + real fills + host/door/lone picked',
+    seed.committed > 0 && fills.length > 0 && hostFid != null && doorFid != null && loneFid != null && boxByFid[hostFid] && boxByFid[doorFid],
+    'seeded=' + seed.committed + ' fills=' + fills.length + ' host=' + hostFid + ' door=' + doorFid + ' lone=' + loneFid);
+
+  var hb = boxByFid[hostFid], rb = boxByFid[doorFid];
+  var c0 = centreOf(rb), h0 = centreOf(hb);
+
+  // ── T1: host TRANSLATE d → rider delta EXACT; offset invariant ──────────────────────────────────
+  var D = 1.25;
+  var r1 = SdgCascade.stretchRide([{ featureId: hostFid, action: 'TRANSLATE', axis: 'x', delta: D }], gbf, fbg, fills, boxByFid);
+  var rid1 = r1.riders.find(function (r) { return r.featureId === doorFid; });
+  var hostKept = r1.commands.some(function (c) { return c.featureId === hostFid; });
+  chk('T1 host TRANSLATE → rider delta EXACT (same axis, same d); host command kept; offset invariant',
+    rid1 && rid1.dx === D && rid1.dy === 0 && rid1.dz === 0 && hostKept &&
+    Math.abs(((c0[0] + rid1.dx) - (h0[0] + D)) - (c0[0] - h0[0])) === 0,
+    'rider=' + JSON.stringify(rid1));
+
+  // ── T2: host SCALE → rider proportional, NOT scaled, own command STRIPPED, inside folded host ───
+  var f = 1.4, t = 0;                                       // far-edge stretch: newScale=f, translateDelta=0
+  var scaleCmd = { featureId: hostFid, action: 'SCALE', axis: 'x', newScale: f, translateDelta: t, edge: 'far' };
+  var engineDoorCmd = { featureId: doorFid, action: 'SCALE', axis: 'x', newScale: 1.2, translateDelta: 0, edge: 'far' };   // the BUG: the engine's independent view of the filling
+  var r2 = SdgCascade.stretchRide([scaleCmd, engineDoorCmd], gbf, fbg, fills, boxByFid);
+  var rid2 = r2.riders.find(function (r) { return r.featureId === doorFid; });
+  var doorStripped = !r2.commands.some(function (c) { return c.featureId === doorFid; });
+  // expected mapping: c' = f·c + m·(1−f) + t, m = host min x
+  var m = hb[0], ext = hb[1] - hb[0];
+  var cExp = f * c0[0] + m * (1 - f) + t;
+  // ratio preserved: (c−m)/ext == (c'−m')/(f·ext), m' = m + t
+  var ratio0 = (c0[0] - m) / ext, ratio1 = ((c0[0] + (rid2 ? rid2.dx : NaN)) - (m + t)) / (f * ext);
+  // fold-consistency: fold the HOST through the PRODUCTION gridCmds branch → rider centre must land inside it
+  var hostFolded = bboxOf(Library.foldInsert({ id: hostFid, op_type: 'GEOM_INSERT', parameters: opByFid[hostFid].params }, null, [scaleCmd]).positions);
+  var cNew = c0[0] + (rid2 ? rid2.dx : NaN);
+  chk('T2a host SCALE → rider centre remapped proportionally ((c−m)/extent preserved, math-exact)',
+    rid2 && Math.abs(cNew - cExp) < 1e-12 && Math.abs(ratio0 - ratio1) < 1e-12,
+    'c ' + c0[0].toFixed(4) + '→' + cNew.toFixed(4) + ' ratio ' + ratio0.toFixed(6) + '→' + ratio1.toFixed(6));
+  chk('T2b rider receives NO scale (induced move only — extent can never change) + own engine cmd STRIPPED',
+    rid2 && !('newScale' in rid2) && rid2.dy === 0 && rid2.dz === 0 && doorStripped &&
+    r2.commands.length === 1 && r2.commands[0].featureId === hostFid,
+    'riders carry only dx/dy/dz; commands=' + JSON.stringify(r2.commands.map(function (c) { return c.featureId + ':' + c.action; })));
+  // T2c fix (2026-07-02): the door only receives a delta on the command's OWN axis (x here — T2b proved dy=dz=0),
+  // so the honest containment check is TWO-axis point-in-box (mirrors sdg_gate.js withinXY, tol=0.05) — x against
+  // the host's SCALED range, y against the host's (unchanged) y-range as a sanity that this pair is genuinely
+  // hosted, not just x-lucky.
+  var ptAfter = [cNew, c0[1], c0[2]];
+  chk('T2c rider centre stays inside the PRODUCTION-fold stretched host footprint on BOTH axes (X scaled, Y unchanged sanity) — mirrors sdg_gate.js withinXY tol=0.05',
+    rid2 && ptAfter[0] >= hostFolded[0] - 0.05 && ptAfter[0] <= hostFolded[1] + 0.05 &&
+    ptAfter[1] >= hb[2] - 0.05 && ptAfter[1] <= hb[3] + 0.05 &&
+    Math.abs((hostFolded[1] - hostFolded[0]) - f * ext) < 1e-6,
+    'c\'=[' + ptAfter[0].toFixed(4) + ',' + ptAfter[1].toFixed(4) + '] hostFoldedX=[' + hostFolded[0].toFixed(4) + ',' + hostFolded[1].toFixed(4) + '] hostY=[' + hb[2].toFixed(4) + ',' + hb[3].toFixed(4) + ']');
+  // T2d — the ACTUAL "no door-out RED" proof: replicate sdg_gate.js's own door-out oracle inline (line ~78:
+  // `withinXY(before[h], centre(before[f]), 0.05) && !withinXY(after[h], centre(after[f]), 0.05)` ⇒ RED) over this
+  // REAL host/door pair. The pair must (a) genuinely qualify pre-stretch (preHosted true — proves door=7 is the
+  // honest pick, not door=13) and (b) the gate's own check must find it STILL hosted after the ride (no RED fires).
+  var preHosted = withinXY(hb, c0, 0.05);
+  var afterHosted = withinXY(hostFolded, ptAfter, 0.05);
+  var gateWouldFireDoorOut = preHosted && !afterHosted;
+  chk('T2d gate-equivalent (sdg_gate.js door-out oracle replicated inline): pair genuinely hosted pre-stretch AND stays hosted post-ride ⇒ no door-out RED for a legitimate stretch',
+    preHosted && afterHosted && !gateWouldFireDoorOut,
+    'preHosted=' + preHosted + ' afterHosted=' + afterHosted + ' doorOutRED=' + gateWouldFireDoorOut);
+
+  // ── T3: rosetta — stretch then exact inverse → rider centre back to start within 1e-9 ──────────
+  // post-stretch state: host box mapped by the anchored-min SCALE; rider box shifted by its induced delta
+  var boxAfter = {}; Object.keys(boxByFid).forEach(function (k) { boxAfter[k] = boxByFid[k].slice(); });
+  boxAfter[hostFid] = hostFolded;
+  boxAfter[doorFid] = [rb[0] + rid2.dx, rb[1] + rid2.dx, rb[2], rb[3], rb[4], rb[5]];
+  var inv = { featureId: hostFid, action: 'SCALE', axis: 'x', newScale: 1 / f, translateDelta: 0, edge: 'far' };
+  var r3 = SdgCascade.stretchRide([inv], gbf, fbg, fills, boxAfter);
+  var rid3 = r3.riders.find(function (r) { return r.featureId === doorFid; });
+  var cBack = (boxAfter[doorFid][0] + boxAfter[doorFid][1]) / 2 + (rid3 ? rid3.dx : NaN);
+  chk('T3 rosetta: stretch f then 1/f → rider centre returns to start (≤1e-9)',
+    rid3 && Math.abs(cBack - c0[0]) <= 1e-9, 'err=' + Math.abs(cBack - c0[0]).toExponential(2));
+
+  // ── T4: non-invent — no edge ⇒ no ride, no strip; filling whose host has NO command keeps its own ──
+  var loneCmd = { featureId: loneFid, action: 'SCALE', axis: 'x', newScale: 1.3, translateDelta: 0 };
+  var r4a = SdgCascade.stretchRide([loneCmd], gbf, fbg, fills, boxByFid);
+  var r4b = SdgCascade.stretchRide([{ featureId: doorFid, action: 'TRANSLATE', axis: 'x', delta: 0.5 }], gbf, fbg, fills, boxByFid);
+  chk('T4 non-invent: no rel_fills_host edge → no induced move + own commands NOT stripped; door whose host has NO command keeps its own command',
+    r4a.riders.length === 0 && r4a.commands.length === 1 && r4a.commands[0] === loneCmd &&
+    r4b.riders.length === 0 && r4b.commands.length === 1 && r4b.commands[0].featureId === doorFid,
+    'lone kept=' + r4a.commands.length + ' doorOwn kept=' + r4b.commands.length);
+
+  // ── T5: stacked TRANSLATE then SCALE on the same host, in order ─────────────────────────────────
+  var r5 = SdgCascade.stretchRide([
+    { featureId: hostFid, action: 'TRANSLATE', axis: 'x', delta: D },
+    scaleCmd
+  ], gbf, fbg, fills, boxByFid);
+  var rid5 = r5.riders.find(function (r) { return r.featureId === doorFid; });
+  var cExp5 = f * (c0[0] + D) + (m + D) * (1 - f) + t;      // closed form: translate both c and m, then anchored-min scale
+  chk('T5 stacked TRANSLATE→SCALE compose in order to the closed-form centre',
+    rid5 && Math.abs((c0[0] + rid5.dx) - cExp5) < 1e-12,
+    'c\'=' + (c0[0] + (rid5 ? rid5.dx : NaN)).toFixed(6) + ' want=' + cExp5.toFixed(6));
+
+  console.log('W-STRETCH-RIDE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });


### PR DESCRIPTION
## Summary
- Implements bim-compiler `prompts/RESUME_CASCADE_INTO_STRETCH.md` §STRETCH-RIDE: when a grid edit TRANSLATEs or SCALEs a wall, its hosted doors/windows no longer divorce or get scaled — the ride is resolved ONLY over the real `rel_fills_host` relation through the §ARC-1 bridge (non-invent, no proximity heuristics).
- `bonsai_gridmove.js`: `SdgCascade.stretchRide` strips a rider's own engine-generated command and commits one induced `GEOM_MOVE {induced:'hosted-by'}` instead (TRANSLATE rides the delta; SCALE keeps proportional position, extent never changes).
- `modeller.html`: the conformity gate's changed-set now includes riders so the door-out oracle still checks them.
- Absent the §ARC-1 bridge (e.g. SampleCastle, which has zero `rel_fills_host` rows in both its DB and source IFC — verified, not a gap), `stretchRide` no-ops byte-identically — confirmed by the untouched regression suite.

## Witnesses
- `W-STRETCH-RIDE` (node, real SampleHouse data): 9/9 — TRANSLATE-exact, SCALE-proportional-no-scale, rosetta-invertible, non-invent, stacked-commands, gate-equivalent door-out oracle.
- `W-E2E-STRETCH-RIDE` (headless chromium, real user path incl. pixel-readback visibility assertion): 9/9.
- Regression (all independently re-run by the reviewing session, not agent-reported only): `witness_sdg_cascade` 7/7, `witness_arc_editable(+smoke)` 10/10+8/8, `witness_e2e_lod_match` 6/6, `witness_e2e_move` 9/9, `witness_sdg_gate(+smoke)` 6/6+6/6.
- `witness_stretch_gate_smoke.js` S4 fails identically before and after this change (confirmed by checking out the pre-change versions of every touched file and re-running the unchanged test file) — pre-existing, out of scope.

## Test plan
- [x] Node witnesses re-run independently by the reviewing session
- [x] Headless e2e witness re-run independently, including live pixel-readback
- [x] Full regression suite re-run post-rebase onto latest `origin/main`
- [x] Pre-existing S4 failure isolated via before/after file checkout, confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)