### PR TITLE
fix(modeller): §WALKALL-TERMINAL-SCALE — Walk-ALL smooth at real Terminal scale

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -2384,18 +2384,27 @@ function _flashSettleDisc(disc) {
       }, HOLD);
       return;
     }
+    // §WALKALL-TERMINAL-SCALE fix (W-TERMINAL-WALKALL-PERF): the old setInterval(DURATION/n) settled ONE
+    // instance per tick — but setInterval clamps near ~4ms, so any n in the thousands blew straight through
+    // the DURATION budget (measured at REAL Terminal scale: ACMV n=2829 took 39,319ms against a 1200ms
+    // budget, sceneElements=35552 < threshold=50000 so the proxy guard never fired — and 35,552 IS our
+    // largest real building, the exact scale the guard was written for). Time-budgeted rAF batch instead:
+    // each frame settles every instance whose share of DURATION has elapsed, so the stagger LOOK is kept
+    // and the wall-clock is ≤ DURATION + one frame at ANY n / any render cost. Same instances, same colours,
+    // same log line — only the scheduling changed.
     var DURATION = Math.min(1200, Math.max(200, total * 6)), n = idx.length, k = 0, startT = Date.now();
-    var timer = setInterval(function () {
+    var step = function () {
+      var due = Math.min(n, Math.ceil(n * (Date.now() - startT) / DURATION));
+      while (k < due) { var e = idx[k]; e.im.setColorAt(e.i, e.base); e.im.instanceColor.needsUpdate = true; k++; }
+      if (window.A && A.requestRender) A.requestRender();
       if (k >= n) {
-        clearInterval(timer);
-        if (window.A && A.requestRender) A.requestRender();
-        console.log('§DISCWALK-ALL-FLASH ' + disc + ' per-instance instances=' + total + ' ms=' + (Date.now() - startT));
+        console.log('§DISCWALK-ALL-FLASH ' + disc + ' per-instance instances=' + total + ' ms=' + (Date.now() - startT) + ' budgetMs=' + DURATION);
         resolve();
         return;
       }
-      var e = idx[k]; e.im.setColorAt(e.i, e.base); e.im.instanceColor.needsUpdate = true; k++;
-      if (window.A && A.requestRender) A.requestRender();
-    }, DURATION / n);
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
   });
 }
 // §DISCWALK-ALL: loops DiscWalker.disciplines() SEQUENTIALLY (never parallel — _discGate() re-folds the
@@ -2602,27 +2611,39 @@ function _renderDiscChains(disc, segs) {
 }
 async function _commitDiscChains(disc, segs) {
   var O = window.Bonsai && window.Bonsai.oplog; if (!O) return 0;
-  var color = DW_COLOR[disc] || 0xc0c0c0;
   var capMax = window.DW_CHAIN_COMMIT_CAP || 120;
   var cap = Math.min(segs.length, capMax);
-  var committed = 0;
-  for (var i = 0; i < cap; i++) {                     // commit optimistically (LEAF append, no per-commit re-fold)
+  // §WALKALL-TERMINAL-SCALE fix (W-TERMINAL-WALKALL-PERF): was a loop of `cap` awaited O.commit() — each one
+  // seals the chain + full verifyChain + Outliner repaint + autosave; measured at REAL Terminal scale that's
+  // ~1.6-2s PER SWEEP (§KRN_CHAIN verify over 38k rows + a 51k-row Outliner paint each time) → minutes per
+  // chained discipline inside Walk-ALL. Batch into ONE signed group instead — the exact pattern
+  // _commitDiscWalk (above) already uses for the same reason ("267-fixture ELEC walk FROZE the UI for 112s").
+  // Same ops, same parameters._dw identity payload, same row-granular undo (undo() toggles per ROW, not per
+  // gid — W-ROUTER-NNCHAIN N6 unaffected); one seal, one verify, one fold, one repaint. The old per-commit
+  // {color} opt is dropped, not lost: any re-fold already forgot it (B-rep solids fall back to fold-level
+  // colour — see bonsai_kernel.js "PER-MESH colour wins" comment), and the final scrubTo here always re-folded.
+  var ops = [];
+  for (var i = 0; i < cap; i++) {
     var s = segs[i];
-    var op = { op_type: 'GEOM_SWEEP',
-      parameters: { profile: { w: 0.05, h: 0.05 }, path: [s.from.slice(), s.to.slice()],
-                    _dw: { disc: s.disc, rule: s.rule, from_kind: s.from_kind, to_kind: s.to_kind,
-                           from_guid: s.from_guid, to_guid: s.to_guid, gap: s.gap } } };
-    try { var res = await O.commit(op, { color: color }); if (res) committed++; }
-    catch (e) { console.warn('§ROUTER-CHAIN-COMMIT fail i=' + i + ' ' + (e && e.message)); }
+    ops.push({ op_type: 'GEOM_SWEEP',
+      params: { profile: { w: 0.05, h: 0.05 }, path: [s.from.slice(), s.to.slice()],
+                _dw: { disc: s.disc, rule: s.rule, from_kind: s.from_kind, to_kind: s.to_kind,
+                       from_guid: s.from_guid, to_guid: s.to_guid, gap: s.gap } } });
+  }
+  var committed = 0;
+  if (ops.length) {
+    try { var res = await O.commitSeedGroup(ops, 'dwchain-' + disc + '-' + O.length); committed = (res.ids || []).length; }
+    catch (e) { console.warn('§ROUTER-CHAIN-COMMIT batch fail ' + (e && e.message)); }
   }
   if (committed) {
-    await O.scrubTo(O.length);                        // ONE authoritative re-fold (mirrors RouteWalker autoRouteMEP)
+    // commitSeedGroup already folded the chain authoritatively (no scrubTo needed) — restore decoration
     _redrawAllDiscWalks();
     if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     syncHistory(); audioCue('rollout');
   }
   console.log('§ROUTER-CHAIN-COMMIT disc=' + disc + ' folded=' + committed + '/' + segs.length +
-    (segs.length > cap ? ' (cap=' + capMax + ', occt-bounded; full ' + segs.length + ' rendered live)' : ''));
+    (segs.length > cap ? ' (cap=' + capMax + ', occt-bounded; full ' + segs.length + ' rendered live)' : '') +
+    ' (1 signed group)');
   window.__dwLastChainDisc = disc;                    // sentinel for witnesses
   return committed;
 }

--- a/modeller/tests/witness_e2e_walkall_terminal_scale.js
+++ b/modeller/tests/witness_e2e_walkall_terminal_scale.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-TERMINAL-WALKALL-PERF scope (read the log after every run)
+ * SCOPE: REAL Terminal-scale exercise of the "Walk ALL Disciplines" perf guard (§4 of the walk-all spec) —
+ * the ONE thing witness_e2e_walk_all_disciplines.js §B honestly did NOT do (it lowered the threshold on
+ * Duplex-scale data). Opens the REAL Terminal resident, clicks the REAL Outliner row [data-bnode="dw-all"]
+ * with DW_ALL_PROXY_THRESHOLD left at its production default (50000), and asserts by MATHS (not eyes).
+ *
+ * ISSUE THIS PROVES/DISPROVES: "the >50k perf-guard branch was never exercised at real Terminal scale —
+ * does the guard fire correctly there, and does the animation stay smooth?"
+ * BASELINE RUN (pre-fix, main cb7bc17, log logs/terminal_walkall_perf.log): sceneElements=35552 <
+ * threshold=50000 → proxyMode=false (guard never fires on our LARGEST real building), and the un-guarded
+ * per-instance flash took 39,319ms for ACMV n=2829 against its own 1200ms budget; _commitDiscChains then
+ * committed up to DW_CHAIN_COMMIT_CAP sweeps ONE AT A TIME at ~1.6-2s each (full verifyChain + 51k-row
+ * Outliner repaint per sweep). That IS the misbehaviour. This witness re-runs the identical real-user path
+ * against the §WALKALL-TERMINAL-SCALE fix and asserts:
+ *   T1 SCENE-SCALE     — the opened Terminal scene really is Terminal-scale (>30k group children, sampled
+ *                        AFTER the fold settles — the baseline run sampled at 5000 mid-fold, a witness bug).
+ *   T2 GUARD-DECISION  — proxyMode matches sceneTotal-vs-threshold arithmetic (right decision, real number).
+ *   T3 COMPLETES       — __dwAllDone within budget; walked+refused covers the whole roster (no hang).
+ *   T4 FLASH-BUDGET    — EVERY §DISCWALK-ALL-FLASH per-instance line reports ms ≤ budgetMs + 4000 (slack =
+ *                        a few software-GL frames; the pre-fix baseline was 33x OVER budget, unmistakable).
+ *   T5 CHAIN-BATCH     — every §ROUTER-CHAIN-COMMIT line carries "(1 signed group)" (no per-sweep loop).
+ *   T6 NO-ERROR        — zero pageerror.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = process.env.WALKALL_ROOT || path.join(__dirname, '..', '..');
+const OUT = path.join(__dirname, 'e2e_shots'); try { fs.mkdirSync(OUT, { recursive: true }); } catch (e) {}
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); });
+});
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const br = await puppeteer.launch({ headless: 'new', protocolTimeout: 1200000, args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+  console.log('═══ W-TERMINAL-WALKALL-PERF — REAL Terminal, default threshold=50000, ROOT=' + ROOT + ' ═══');
+  const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850, deviceScaleFactor: 1 });
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  const slog = []; pg.on('console', m => { const t = m.text(); if (/^§/.test(t)) { slog.push(t); console.log('  ' + t); } });
+
+  const t0 = Date.now();
+  await pg.goto(`http://localhost:${server.address().port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 120000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai && typeof window.discWalkAll === "function"', { timeout: 60000 });
+  await pg.click('#b-open'); await sleep(300);
+  await pg.click('#m-open-panel .mo-row[data-key="Terminal"]');
+  // Wait for the SETTLED Terminal-scale scene (the ARC seed fold lands 35k+ children), not just __dwBuf.
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 600000 });
+  await pg.waitForFunction(() => window.Bonsai.group && window.Bonsai.group() && window.Bonsai.group().children.length > 30000, { timeout: 600000, polling: 1000 });
+  await sleep(4000);
+  console.log('  §T-OPEN Terminal open+seeded in ' + ((Date.now() - t0) / 1000).toFixed(1) + 's');
+
+  const pre = await pg.evaluate(() => {
+    const g = window.Bonsai.group();
+    return { sceneTotal: g.children.length, threshold: window.DW_ALL_PROXY_THRESHOLD, rowExists: !!document.querySelector('[data-bnode="dw-all"]') };
+  });
+  console.log('  §T-PRE ' + JSON.stringify(pre));
+
+  // The real user action: click the Outliner "Walk ALL Disciplines" row. Default threshold untouched.
+  const tWalk = Date.now();
+  await pg.click('[data-bnode="dw-all"]');
+  const done = await pg.waitForFunction(() => window.__dwAllDone === true, { timeout: 1140000, polling: 500 }).then(() => true).catch(() => false);
+  const walkMs = Date.now() - tWalk;
+  const result = await pg.evaluate(() => window.__dwAllResult || null);
+  console.log('  §T-WALK done=' + done + ' wallMs=' + walkMs);
+  console.log('  §T-RESULT ' + JSON.stringify(result));
+  await pg.screenshot({ path: path.join(OUT, 'terminal-walkall-done.png') }).catch(() => {});
+
+  const expectedProxy = pre.sceneTotal > pre.threshold;
+  const rosterCovered = result && Array.isArray(result.disciplines) &&
+    (result.walked.map(w => w.disc).concat(result.refused.map(r => r.disc)).sort().join(',') === result.disciplines.slice().sort().join(','));
+
+  // T4: parse EVERY per-instance flash line — ms must be within budget (+slack for software-GL frames)
+  const flashLines = slog.filter(l => /§DISCWALK-ALL-FLASH .* per-instance /.test(l));
+  const flashParsed = flashLines.map(l => { const m = l.match(/per-instance instances=(\d+) ms=(\d+) budgetMs=(\d+)/); return m ? { n: +m[1], ms: +m[2], budget: +m[3] } : null; }).filter(Boolean);
+  const flashOk = flashParsed.length === flashLines.length && flashParsed.every(f => f.ms <= f.budget + 4000);
+  // T5: every chain-commit line is a single signed group
+  const chainLines = slog.filter(l => /§ROUTER-CHAIN-COMMIT disc=/.test(l));
+  const chainOk = chainLines.every(l => / \(1 signed group\)/.test(l));
+
+  chk('T1 SCENE-SCALE (>30k group children — real Terminal, not a fixture)', pre.sceneTotal > 30000, 'sceneTotal=' + pre.sceneTotal + ' threshold=' + pre.threshold);
+  chk('T2 GUARD-DECISION (proxyMode == sceneTotal>threshold arithmetic)', result && result.proxyMode === expectedProxy, 'proxyMode=' + (result && result.proxyMode) + ' expected=' + expectedProxy);
+  chk('T3 COMPLETES (dwAllDone, roster covered, no hang)', done && rosterCovered, 'done=' + done + ' wallMs=' + walkMs + ' walked=' + JSON.stringify(result && result.walked) + ' refused=' + JSON.stringify(result && result.refused));
+  chk('T4 FLASH-BUDGET (every per-instance flash ≤ budget+4s; baseline was 39.3s over a 1.2s budget)', flashParsed.length > 0 && flashOk, flashParsed.map(f => f.n + '→' + f.ms + 'ms/≤' + f.budget).join(' '));
+  chk('T5 CHAIN-BATCH (every §ROUTER-CHAIN-COMMIT is 1 signed group)', chainOk, chainLines.length + ' chain line(s): ' + chainLines.map(l => l.slice(0, 90)).join(' ‖ '));
+  chk('T6 NO-ERROR', errs.length === 0, errs.slice(0, 3).join(' | '));
+
+  await br.close(); server.close();
+  console.log('W-TERMINAL-WALKALL-PERF: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); process.exit(2); });

--- a/modeller/tests/witness_modeller_router_nnchain.js
+++ b/modeller/tests/witness_modeller_router_nnchain.js
@@ -88,13 +88,18 @@ async function openResident(page, key) {
   var nSeg = parseInt((walkLog.match(/chainSegs=(\d+)/) || [0, 0])[1], 10);
   chk('N1 walk PLB → chainSegs>0 (Router routes real nn-chains)', nSeg > 0, walkLog || 'no walk log');
 
-  // N2 chains rendered as 3D lines
+  // N2 chains rendered in the DiscWalker root. STALE-CHECK FIX (found via W-TERMINAL-WALKALL-PERF regression
+  // sweep, failed IDENTICALLY on unmodified main): §DW-TUBE upgraded the chain render from LineSegments to
+  // InstancedMesh cylinder tubes (userData.dwChain unchanged) and this check was never updated — it counted
+  // isLineSegments only, so it has been asserting 0 > 0 since the tube upgrade. Count tube instances (and
+  // keep LineSegments for back-compat with any pre-tube build).
   var lineSegs = await page.evaluate(function () {
     var g = window.Bonsai.group && window.Bonsai.group(); if (!g) return -1;
     var root = g.children.find(function (o) { return o.userData && o.userData.dwRoot; }); if (!root) return 0;
-    return root.children.filter(function (o) { return o.isLineSegments && o.userData.dwChain; }).reduce(function (n, o) { return n + (o.geometry.getAttribute('position').count / 2); }, 0);
+    return root.children.filter(function (o) { return (o.isInstancedMesh || o.isLineSegments) && o.userData.dwChain; })
+      .reduce(function (n, o) { return n + (o.isInstancedMesh ? (o.count || 0) : o.geometry.getAttribute('position').count / 2); }, 0);
   });
-  chk('N2 chains rendered as 3D lines in DiscWalker root', lineSegs > 0, 'lineSegments=' + lineSegs);
+  chk('N2 chains rendered as 3D tubes in DiscWalker root', lineSegs > 0, 'tubeSegments=' + lineSegs);
 
   // N3 + N5 chain commit logged + cap honored
   var commitLog = logs.find(function (l) { return /§ROUTER-CHAIN-COMMIT disc=PLB/.test(l); }) || '';


### PR DESCRIPTION
## What (item 1 of RESUME_MODELLER_LOD400_REAL_GEOMETRY.md 2026-07-02 PM UPDATE)

Ran "Walk ALL Disciplines" on the REAL Terminal (35,552 scene meshes, production threshold 50000, real Outliner row click) for the first time — the perf guard had only ever been exercised via a threshold-lowered simulation on Duplex. **It misbehaves**, and this PR fixes it.

## Baseline (measured, log in PR discussion)
- `§DISCWALK-ALL start … sceneElements=35552 threshold=50000 proxyMode=false` — the >50k guard **never fires on our largest real building** (the ~48k figure is meta rows; the scene is 35,552 children).
- Un-guarded per-instance flash at that scale: `§DISCWALK-ALL-FLASH ACMV per-instance instances=2829 ms=39319` — **39.3s against its own 1200ms budget** (setInterval ~4ms clamp × n, plus render cost per tick).
- `_commitDiscChains` committed up to `DW_CHAIN_COMMIT_CAP` sweeps **one at a time**, each sealing + full-verifying a 38k-row chain + repainting a 51k-row Outliner (~1.6–2s per sweep) → minutes per chained discipline.

## Fix (scheduling only — ops, parameters, colours, log tags unchanged)
- `_flashSettleDisc`: time-budgeted rAF batch settle (each frame settles every instance whose share of DURATION has elapsed). Stagger look kept; wall-clock ≤ DURATION + 1 frame at ANY n.
- `_commitDiscChains`: ONE signed group via `commitSeedGroup` — the exact pattern `_commitDiscWalk` already uses for the same measured reason ("267-fixture ELEC walk froze the UI for 112s"). Same `parameters._dw` payload; undo stays row-granular (N6 proven).

## Post-fix, same real-Terminal run
ACMV 2829→**1416ms**, ELEC 4943→**1206ms**, FP 3041→1204ms, STR 2771→1254ms, roof **74,629→1242ms**; every `§ROUTER-CHAIN-COMMIT` = 1 signed group. With the budget fix, proxyMode=false at Terminal is now the CORRECT decision (belt-and-braces guard retained for >50k).

## Witnesses (all re-run by the orchestrating session, logs read)
- **NEW** `witness_e2e_walkall_terminal_scale.js` — W-TERMINAL-WALKALL-PERF **6/6** at real Terminal scale (the standing regression this card existed for; ~8 min headless).
- W-E2E-WALK-ALL **10/10**, W-E2E-WALK **8/8** (Duplex behaviour unchanged).
- W-ROUTER-NNCHAIN **8/8** — includes fixing its stale N2 (counted LineSegments; the §DW-TUBE render is InstancedMesh tubes; it failed 7/1 **identically on unmodified main** — pre-existing staleness, now honest: tubeSegments=4314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)