### PR TITLE
fix(hba): pill tooltip, IoT table redundancy, fly-to-zone instanced-mesh bug, bar colors

### DIFF
--- a/viewer/hba_iot.js
+++ b/viewer/hba_iot.js
@@ -12,7 +12,9 @@
 //   horizontal with the running value printed at the bar's leading edge; NO Chart.js dependency for this
 //   section (hba_dashboard.js still uses Chart.js for its own KPI trend charts — untouched). Each bar's
 //   tick(pt) setter is the STUB SEAM for later real physical sensor wiring: swap the setInterval driver for a
-//   real telemetry callback and the same rows/bars update — nothing else in this file needs to change.
+//   real telemetry callback and the same rows/bars update — nothing else in this file needs to change. Each
+//   bar is one distinct colour (SENSOR_COLORS) and clicking it flies the camera to the bound asset's real
+//   location via HBALens.flyToZone — so "there's a live sensor" also means "here's exactly where it is".
 //   (b) a 2x3 CCTV grid — plain <canvas>, now painted from a REAL dimmed still photo (`hba_cctv_still.jpg`,
 //   user-supplied ContaCam capture, copied into this repo — NOT a feed of THIS building, still captioned
 //   MOCKUP) with a scanline overlay + a diagonal "STUB READY" watermark (this tile is the placeholder seam
@@ -87,17 +89,25 @@
     };
   }
 
+  // one distinct accent colour per sensor — purely visual differentiation between the 6 racing bars (matches
+  // the reference Bonsai federation/river panel's per-channel colour coding, no invented data behind it).
+  var SENSOR_COLORS = { temp: '#1976d2', pressure: '#7b1fa2', sound: '#00897b', dust: '#ef6c00', solar: '#fbc02d', electrical: '#43a047' };
+
   // one animated horizontal bar row per sensor — width + the running value at the bar's leading edge both
   // move together (matching CSS transition) as tick(pt) is fed new points. min/max are DATA-DERIVED (the
-  // sensor's own baseline±amplitude from hr_bim_asset/iot.js), never an invented threshold.
-  function renderSensorBar(sensor, min, max) {
-    var row = el('div', 'padding:4px 0;');
+  // sensor's own baseline±amplitude from hr_bim_asset/iot.js), never an invented threshold. Clicking the row
+  // flies the camera to the bound asset's real location (HBALens.flyToZone) — "locate the device outright".
+  function renderSensorBar(A, asset, sensor, min, max) {
+    var color = SENSOR_COLORS[sensor.key] || '#1976d2';
+    var row = el('div', 'padding:4px 0;cursor:pointer;');
+    row.title = 'Locate ' + asset.asset + ' in the model';
     row.appendChild(el('div', 'font-size:10px;color:#627d98;text-transform:uppercase;margin-bottom:2px;', sensor.label));
     var track = el('div', 'position:relative;height:16px;background:#eef2f6;border-radius:3px;');
-    var fill = el('div', 'position:absolute;left:0;top:0;bottom:0;width:2%;background:#1976d2;border-radius:3px;transition:width 0.7s ease;');
+    var fill = el('div', 'position:absolute;left:0;top:0;bottom:0;width:2%;background:' + color + ';border-radius:3px;transition:width 0.7s ease;');
     var val = el('span', 'position:absolute;top:50%;left:2%;transform:translateY(-50%);font-size:10px;font-weight:600;color:#102a43;white-space:nowrap;transition:left 0.7s ease;padding-left:6px;');
     track.appendChild(fill); track.appendChild(val);
     row.appendChild(track);
+    row.addEventListener('click', function () { if (G.HBALens && G.HBALens.flyToZone) G.HBALens.flyToZone(A, asset.bim_guid); });
     var tick = function (pt) {
       var pct = Math.max(2, Math.min(100, ((pt.v - min) / (max - min)) * 100));
       fill.style.width = pct + '%';
@@ -135,7 +145,7 @@
       var min = Math.min.apply(null, vals), max = Math.max.apply(null, vals);
       if (max === min) max = min + 1;   // guard degenerate flat series
       var headroom = (max - min) * 0.15;
-      var b = renderSensorBar(s, min - headroom, max + headroom);
+      var b = renderSensorBar(A, asset, s, min - headroom, max + headroom);
       barsWrap.appendChild(b.row); bars.push({ b: b, sensor: s, pts: pts });
     });
     pane.appendChild(barsWrap);
@@ -152,15 +162,16 @@
     }
     pane.appendChild(cctvWrap);
 
-    // (c) ERP billing table — iot.billingLines() -> real c_orderline shape
+    // (c) ERP billing table — iot.billingLines() -> real c_orderline shape. The reading itself is already
+    // shown live by the bar above (§P10d) — this table carries only what the bars DON'T: qty billed + net
+    // amount, i.e. the actual ERP compile, not a second copy of the sensor value.
     pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:8px 12px 0;',
       'Billable — ' + billing.order.documentno));
     var tbl = el('table', 'width:100%;border-collapse:collapse;font-size:12px;margin:4px 12px 10px;width:calc(100% - 24px);');
     billing.lines.forEach(function (ln) {
       var tr = el('tr', 'border-top:1px solid #eee;');
       tr.appendChild(el('td', 'padding:4px 2px;', ln.sensor.label));
-      tr.appendChild(el('td', 'padding:4px 2px;text-align:right;', ln.reading.v + ' ' + ln.sensor.uom_symbol));
-      tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', 'qty ' + ln.row.qtyordered));
+      tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', 'qty ' + ln.row.qtyordered + ' ' + ln.sensor.uom_symbol));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#2e7d32;font-weight:600;', ln.row.linenetamt.toFixed(2)));
       tbl.appendChild(tr);
     });

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -376,16 +376,50 @@
   // {flew, guid, center} synchronously (witnessable without a real THREE/camera) and, when a real
   // camera+controls+THREE ARE present, also performs the actual browser fly. Honest no-op (logged, flew:false)
   // when the zone has no rendered members in THIS building — never a fabricated position.
+  // world position for one guidTargets() resolution — slot===null is a whole regular/merged mesh (getWorldPosition);
+  // a non-null slot is one instance/batch index within an InstancedMesh/BatchedMesh (§INSTANCED-TINT's `_N` suffix)
+  // — those carry NO per-instance Object3D, so the position must come from getMatrixAt() premultiplied by the
+  // mesh's own matrixWorld, the SAME math buildMeshPort's setTint already relies on for per-slot tinting.
+  function _posForTarget(m, slot) {
+    if (slot == null) {
+      if (m.getWorldPosition && typeof THREE !== 'undefined') { var wp = new THREE.Vector3(); m.getWorldPosition(wp); return wp; }
+      return m.position || null;
+    }
+    if (m.getMatrixAt && typeof THREE !== 'undefined') {
+      var mat = new THREE.Matrix4(); m.getMatrixAt(slot, mat);
+      if (m.matrixWorld) mat.premultiply(m.matrixWorld);
+      return new THREE.Vector3().setFromMatrixPosition(mat);
+    }
+    return null;
+  }
+
   function flyToZone(A, guid) {
     if (!A || !A.guidMap || !ready()) { console.log('§HBA_FLY no-op guid=' + guid + ' (no engine/guidMap)'); return { flew: false, reason: 'no-engine' }; }
     var want = HBA().B.zoneMeshGuids(guid, A.guidMap, A._hbaRoomMembers || null);
     if (!want.length) { console.log('§HBA_FLY no-op guid=' + guid + ' (no rendered members)'); return { flew: false, reason: 'no-members' }; }
-    var set = {}; want.forEach(function (g) { set[g] = true; });
-    var meshes = A.collectMeshes ? A.collectMeshes(function (o) { return o.userData && set[o.userData.guid]; }) : [];
-    if (!meshes.length) { console.log('§HBA_FLY no-op guid=' + guid + ' (no matching mesh)'); return { flew: false, reason: 'no-mesh' }; }
+    var pts = [];
+    // §INSTANCED-TINT reuse — the SAME meshId/slot resolution buildMeshPort uses for tinting (the naive
+    // `userData.guid` match below misses every instanced/batched target — HHS's 716 instanced groups are
+    // exactly the bug this was silently eating: "no matching mesh" on a real building with real members).
+    if (A.collectMeshes) {
+      var targets = HBA().B.guidTargets(want, A.guidMap);
+      if (targets.length) {
+        var byId = {};
+        A.collectMeshes(function (o) { return o.isMesh || o.isInstancedMesh || o.isBatchedMesh; }).forEach(function (o) { byId[o.id] = o; });
+        targets.forEach(function (t) {
+          var m = byId[t.meshId]; if (!m) return;
+          var p = _posForTarget(m, t.slot); if (p) pts.push(p);
+        });
+      }
+      if (!pts.length) {   // fallback — plain userData.guid match (regular meshes, and node-witness mocks)
+        var set = {}; want.forEach(function (g) { set[g] = true; });
+        A.collectMeshes(function (o) { return o.userData && set[o.userData.guid]; }).forEach(function (o) { if (o.position) pts.push(o.position); });
+      }
+    }
+    if (!pts.length) { console.log('§HBA_FLY no-op guid=' + guid + ' (no matching mesh)'); return { flew: false, reason: 'no-mesh' }; }
     var cx = 0, cy = 0, cz = 0;
-    meshes.forEach(function (m) { var p = m.position || { x: 0, y: 0, z: 0 }; cx += p.x; cy += p.y; cz += p.z; });
-    var n = meshes.length, center = { x: cx / n, y: cy / n, z: cz / n };
+    pts.forEach(function (p) { cx += p.x; cy += p.y; cz += p.z; });
+    var n = pts.length, center = { x: cx / n, y: cy / n, z: cz / n };
     if (A.camera && A.controls && typeof THREE !== 'undefined' && typeof requestAnimationFrame === 'function') {
       var c3 = new THREE.Vector3(center.x, center.y, center.z), dist = 8;
       var end = c3.clone().add(new THREE.Vector3(0.5, 0.5, 0.7).normalize().multiplyScalar(dist));
@@ -399,6 +433,12 @@
         if (A.markDirty) A.markDirty();
         if (t < 1) requestAnimationFrame(anim);
       })();
+      // a brief highlight pulse at the destination — so the fly is unmistakably "here's the thing", not just a
+      // camera move to an empty-looking spot. Reuses buildMeshPort's own tint math (regular + instanced/batched);
+      // self-restoring, so it never leaves a stray tint behind (zero residue, same discipline as every HBA lens).
+      var pulsePort = buildMeshPort(A);
+      pulsePort.setTint(guid, 0xffcc00);
+      setTimeout(function () { pulsePort.restoreAll(); }, 1600);
     }
     console.log('§HBA_FLY guid=' + guid + ' center=(' + center.x.toFixed(1) + ',' + center.y.toFixed(1) + ',' + center.z.toFixed(1) + ')');
     return { flew: true, guid: want[0], center: center };

--- a/viewer/pill_builder.js
+++ b/viewer/pill_builder.js
@@ -200,7 +200,7 @@
         if (act.pill === false) return;
         if (hidden.indexOf(act.id) >= 0) return;
         var btn = document.createElement('button');
-        btn.title = act.id;
+        btn.title = act.name || act.id;
         btn.id = 'pill-' + act.id;
         if (act.img) btn.innerHTML = '<img src="' + act.img + '" width="20" height="20" style="pointer-events:none">';
         else if (act.icon) btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + act.icon + '</svg>';
@@ -211,7 +211,7 @@
         if (_wrongPlatform) {
           btn.style.opacity = '0.35'; btn.style.cursor = 'not-allowed';
           var _msg = act.platform === 'mobile' ? 'Mobile use' : 'Desktop use';
-          btn.title = act.id + ' — ' + _msg;
+          btn.title = (act.name || act.id) + ' — ' + _msg;
           btn.addEventListener('pointerup', function(e) {
             e.stopPropagation();
             if (A.status) A.status.textContent = _msg;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -789,7 +789,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
 <script src="effects.js?v=1" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
-<script src="pill_builder.js?v=2" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
+<script src="pill_builder.js?v=3" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=6" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
@@ -912,7 +912,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../hr_bim_asset/avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hr avatars.js')"></script>
 <script src="../hr_bim_asset/ad_tenancy.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_tenancy.js')"></script>
 <script src="../hr_bim_asset/iot.js?v=1" onerror="console.warn('§LOAD_FAIL hr iot.js')"></script>
-<script src="hba_lens.js?v=4" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
+<script src="hba_lens.js?v=5" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
 <script src="hba_avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hba_avatars.js')"></script>
 <script src="hba_draggable.js?v=1" onerror="console.warn('§LOAD_FAIL hba_draggable.js')"></script>
 <!-- Chart.js (local, already precached in sw.js) — the HBA Dashboard pane's per-storey / trend / ticket-aging
@@ -922,7 +922,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="hba_payslip.js?v=1" onerror="console.warn('§LOAD_FAIL hba_payslip.js')"></script>
 <script src="hba_leave.js?v=1" onerror="console.warn('§LOAD_FAIL hba_leave.js')"></script>
 <script src="hba_tenancy.js?v=1" onerror="console.warn('§LOAD_FAIL hba_tenancy.js')"></script>
-<script src="hba_iot.js?v=2" onerror="console.warn('§LOAD_FAIL hba_iot.js')"></script>
+<script src="hba_iot.js?v=3" onerror="console.warn('§LOAD_FAIL hba_iot.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context
      as surface 'viewer' — selection/timeline/identity over the one signed op-log. Opt-in (toggle / ?connect=1). -->
 <script src="connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>


### PR DESCRIPTION
Follow-up to #609 (post-review fixes from actually using the live deploy):

- **Pill tooltip**: `pill_builder.js` hardcoded `btn.title = act.id`, so every pill's hover tooltip showed the internal id (e.g. `hbaFM`) instead of its display name. Now uses `act.name` — fixes this for every pill in the toolbar, not just Human-Asset.
- **IoT billing table**: dropped the redundant "reading" column — it duplicated both the value already shown live by the new animated bar above it AND the qty column (literally the same number, shown 3x). Table now carries only what the bars don't: qty(+unit) and net amount.
- **IoT bars**: 6 distinct accent colors (was one repeated blue) + clicking a bar flies the camera to the bound asset's real location.
- **Presence "select a person → zoom" bug**: root cause was `flyToZone`'s mesh lookup only matching regular (non-instanced) meshes via `userData.guid`. HHS_Office_Federated renders most geometry as instanced/batched groups (§INSTANCED-TINT), which are keyed differently — so real clicks were silently hitting "no matching mesh". Now reuses the same `guidTargets()` + `getMatrixAt()` resolution `buildMeshPort` already uses for tinting. Also added a brief self-restoring highlight pulse at the destination so the fly reads as "here's the thing", not an unexplained camera move.

## Test plan
- [x] `node hr_bim_asset/tests/witness_*.js` — full suite still green
- [x] Real-browser verification (Chromium via Puppeteer, HHS_Office_Federated): pill tooltip reads "Human-Asset", 6 distinct bar colors + click flies camera to the asset, presence roster click now actually moves the camera (confirmed broken before this fix, confirmed working after)
- [x] Clean cherry-pick off fresh `origin/main` (avoids the squash-merge branch-history collision from #609)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>