### PR TITLE
feat(hba): §P11 — deep-link HBA panes into iDempiere ERP

### DIFF
--- a/hr_bim_asset/ad_payroll.js
+++ b/hr_bim_asset/ad_payroll.js
@@ -165,7 +165,8 @@ function payslip(hr_movement, c_bpartner_id, locale) {
   var out = { c_bpartner_id: c_bpartner_id, gross: gross, net: net,
     lines: rows.map(function (r) {
       var v = Object.keys(CONCEPTS).filter(function (k) { return CONCEPTS[k].hr_concept_id === r.hr_concept_id; })[0];
-      return { concept: v, name: CONCEPTS[v] ? CONCEPTS[v].name : v, accountsign: r.accountsign, amount: r.amount, trace: r.description };
+      return { concept: v, name: CONCEPTS[v] ? CONCEPTS[v].name : v, accountsign: r.accountsign, amount: r.amount,
+        trace: r.description, hr_movement_id: r.hr_movement_id };   // §P11 — the real native PK, surfaced for the deep-link view
     }) };
   return W ? W.stamp(out, locale || 'en') : out;
 }

--- a/hr_bim_asset/demo/fm_panel.html
+++ b/hr_bim_asset/demo/fm_panel.html
@@ -83,6 +83,7 @@
     var leaveLogs = {}; payEmps.forEach(function(e){ leaveLogs[e.id] = self.HbaLeave.demoLog(e.id); });
     A._hbaLeaveSpec = { period: null, policy: null, locale: 'en', employees: payEmps, log: leaveLogs };   // P8 — same reasoning
     A._hbaTenancySpec = self.HbaAdTenancy.compileBuilding('HHS_Office_Federated', rooms, self.HbaModels.records('Tenancy'), self.HbaModels.records('Strata'));   // §P10-BUILD/§P10a
+    A._hbaResourceSpec = self.HbaOccupancy.compileResources(rooms);   // §P11 — Dashboard's "hover a Resource" deep-link source
     window.APP = A;
     // open the REAL family drawer (the same call panels.js makes)
     var d = self.HBALens.openFamilyDrawer(A);

--- a/hr_bim_asset/occupancy.js
+++ b/hr_bim_asset/occupancy.js
@@ -191,9 +191,36 @@ function toResourceAssignmentRow(assignOp, seedId) {
     assigndatefrom: p.from, assigndateto: p.to, qty: 1, isconfirmed: 'Y', _party: p.party };
 }
 
+// COMPILE (not model) — a REAL `s_resource` header row for a room (§P11, RESUME_HR_BIM_ASSET.md, deep-link
+// "hover a Resource" ask). Columns verified against build/erp/ad_full.db `PRAGMA table_info(s_resource)`:
+// value/name/s_resourcetype_id/isavailable are real. `s_resourcetype_id` needs a REAL S_ResourceType row —
+// this repo's ad_full.db only carries Consultant(100)/Plants(50000)/Work Center(50001), none of which fit
+// "Room" — so ONE new dictionary row is compiled on demand, the SAME "extend the dictionary with the missing
+// master row" precedent already used by ad_tenancy.js's toWarehouseRow and iot.js's toUomRow, never forced
+// onto an ill-fitting existing type.
+function toResourceTypeRow(seedId) {
+  return { s_resourcetype_id: seedId ? seedId() : 1, name: 'Room' };
+}
+function toResourceRow(room, s_resourcetype_id, seedId) {
+  if (!room || !room.guid) return null;
+  return { s_resource_id: seedId ? seedId() : 1, value: room.guid, name: room.name || room.guid,
+    s_resourcetype_id: s_resourcetype_id, isavailable: 'Y' };
+}
+// compile the WHOLE building's rooms into S_Resource headers in one pass — {resourceType, resources:[{row,guid}],
+// _watermark}. ONE resource type shared by every room (real rooms only — never fabricates a resource for a
+// guid that isn't in `rooms`).
+function compileResources(rooms) {
+  rooms = rooms || [];
+  var seq = 0; function seedId() { return ++seq; }
+  var resourceType = toResourceTypeRow(function () { return 1; });
+  var resources = rooms.map(function (r) { return { row: toResourceRow(r, resourceType.s_resourcetype_id, seedId), guid: r.guid }; });
+  return W.stamp({ resourceType: resourceType, resources: resources }, 'en');
+}
+
 var O = { assign: assign, release: release, unavailable: unavailable, availability: availability,
   occupancyAt: occupancyAt, resources: resources, lensRows: lensRows, pivot: pivot, linkRequest: linkRequest,
-  summary: summary, fingerprint: fingerprint, demoSeed: demoSeed, toResourceAssignmentRow: toResourceAssignmentRow };
+  summary: summary, fingerprint: fingerprint, demoSeed: demoSeed, toResourceAssignmentRow: toResourceAssignmentRow,
+  toResourceTypeRow: toResourceTypeRow, toResourceRow: toResourceRow, compileResources: compileResources };
 if (typeof module === 'object' && module.exports) module.exports = O;
 else (typeof self !== 'undefined' ? self : this).HbaOccupancy = O;
 })();

--- a/hr_bim_asset/tests/witness_erp_deeplink.js
+++ b/hr_bim_asset/tests/witness_erp_deeplink.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-ERP-DEEPLINK witness (prompts/RESUME_HR_BIM_ASSET.md §P11, user 2026-07-02). Proves
+//   the cross-app deep-link from HBA panes into the real iDempiere ERP UI: (1) every AD_Window_ID hba_lens.js
+//   ships is the REAL id LOOKED UP from build/erp/ad_full.db (`SELECT AD_Window_ID,Name FROM AD_Window`), not
+//   guessed — this witness holds an INDEPENDENTLY-typed copy of those numbers, sourced the same way, so it
+//   can't grade its own homework; (2) erpLink() builds the SAME URL shape navigate_find.js's proven
+//   `_surfaceExistingOrder` deep-link already uses; (3) the new occupancy.js S_Resource compile is a
+//   NON-INVENT GATE (keys ⊆ real s_resource/s_resourcetype columns, independently sourced PRAGMA table_info);
+//   (4) ad_payroll.js's payslip() reader now surfaces the REAL hr_movement_id per line (the PK the Payslip
+//   pane's deep-link needs) matching the actual emitted movement, not a re-numbered view id.
+//   Run: node hr_bim_asset/tests/witness_erp_deeplink.js
+'use strict';
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-ERP-DEEPLINK ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+
+var fs = require('fs'), path = require('path');
+global.self = global;
+self.HbaWatermark  = require('../watermark');
+self.HbaModels     = require('../models');
+self.HbaBinding    = require('../binding');
+self.HrConnectors  = require('../connectors');
+self.HbaOverlay    = require('../overlay');
+self.HbaLens       = require('../lens');
+self.HbaTimeline   = require('../timeline');
+self.HbaAttendance = require('../attendance');
+var Oc = require('../occupancy'); self.HbaOccupancy = Oc;
+self.HbaRequest    = require('../request');
+self.HbaDashboard  = require('../dashboard');
+var AD = require('../ad_payroll'); self.HbaAdPayroll = AD;
+var ADT = require('../ad_tenancy'); self.HbaAdTenancy = ADT;
+var IoT = require('../iot'); self.HbaIot = IoT;
+var Lv = require('../leave'); self.HbaLeave = Lv;
+var HBALens = require('../../viewer/hba_lens');
+
+ok('L0-load', HBALens && typeof HBALens.erpLink === 'function' && HBALens.AD_WINDOWS,
+  'hba_lens.js exports erpLink() + AD_WINDOWS');
+
+// ---- L1: NON-INVENT GATE on the window ids — independently sourced, same values ---------------------------
+// ground truth: sqlite3 build/erp/ad_full.db "SELECT AD_Window_ID,Name FROM AD_Window WHERE ..."
+var REAL_WINDOWS = {
+  RESOURCE: 236,           // "Resource" — table S_Resource
+  PAYROLL_MOVEMENT: 53042, // "Payroll Movement" — table HR_Movement
+  SUBSCRIPTION: 316,       // "Subscription" — table C_Subscription
+  ORDER: 143,              // "Sales Order" — table C_Order (issotrx='Y', matches iot.js's compiled order)
+  PAYROLL_CONCEPT: 53036   // "Payroll Concept Catalog" — table HR_Concept
+};
+Object.keys(REAL_WINDOWS).forEach(function (k) {
+  ok('L1-window-' + k, HBALens.AD_WINDOWS[k] === REAL_WINDOWS[k],
+    'AD_WINDOWS.' + k + ' = ' + HBALens.AD_WINDOWS[k] + ' matches the independently-sourced AD_Window_ID ' + REAL_WINDOWS[k]);
+});
+
+// ---- L2: erpLink() builds the SAME URL shape as navigate_find.js's proven _surfaceExistingOrder link --------
+var url = HBALens.erpLink(236, 12345);
+ok('L2-url-shape', url === '../erp/idempiere.html?client=garden&window=236&record=12345',
+  'erpLink(236,12345) = "' + url + '" — same client=garden + window/record query shape as the proven BIM→Project deep-link');
+ok('L2-null-record', HBALens.erpLink(236, null) === null && HBALens.erpLink(null, 1) === null,
+  'erpLink refuses to build a URL with a missing window or record — never a dangling/wrong link');
+
+// ---- L3: occupancy.js S_Resource compile — NON-INVENT GATE (independently sourced columns) ------------------
+var REAL_COLS = {
+  s_resource: ['s_resource_id', 'ad_client_id', 'ad_org_id', 'isactive', 'created', 'createdby', 'updated',
+    'updatedby', 'value', 'name', 'description', 's_resourcetype_id', 'm_warehouse_id', 'isavailable',
+    'ad_user_id', 'chargeableqty', 'percentutilization', 'dailycapacity', 'ismanufacturingresource',
+    'waitingtime', 'manufacturingresourcetype', 'queuingtime', 'planninghorizon', 's_resource_uu'],
+  s_resourcetype: ['s_resourcetype_id', 'ad_client_id', 'ad_org_id', 'isactive', 'created', 'createdby',
+    'updated', 'updatedby', 'value', 'name', 'description', 'issingleassignment', 'c_uom_id',
+    'allowuomfractions', 'timeslotstart', 'timeslotend', 'istimeslot', 'isdateslot', 'onsunday', 'onmonday',
+    'ontuesday', 'onwednesday', 'onthursday', 'onfriday', 'onsaturday', 'm_product_category_id',
+    'c_taxcategory_id', 'chargeableqty', 's_resourcetype_uu']
+};
+function keysSubset(row, table) { return Object.keys(row).every(function (k) { return REAL_COLS[table].indexOf(k) >= 0; }); }
+
+var FX = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'hhs_rooms.json'), 'utf8'));
+var rooms = FX.rooms.slice(0, 3);
+var spec = Oc.compileResources(rooms);
+ok('L3-resourcetype-shape', keysSubset(spec.resourceType, 's_resourcetype'), 's_resourcetype row uses ONLY real AD_Column names');
+ok('L3-resource-shapes', spec.resources.every(function (r) { return keysSubset(r.row, 's_resource'); }),
+  'every s_resource row uses ONLY real AD_Column names');
+ok('L3-one-per-room', spec.resources.length === rooms.length && spec.resources.every(function (r, i) { return r.guid === rooms[i].guid && r.row.value === rooms[i].guid; }),
+  'ONE s_resource row per REAL room, value=the room guid — never a fabricated resource for a room not in the fixture');
+ok('L3-sequential-ids', spec.resources.map(function (r) { return r.row.s_resource_id; }).join(',') === rooms.map(function (r, i) { return i + 1; }).join(','),
+  's_resource_id is a sequential numeric PK (1..N) — a real deep-link record id, not the room guid text');
+ok('L3-shared-type', spec.resources.every(function (r) { return r.row.s_resourcetype_id === spec.resourceType.s_resourcetype_id; }),
+  'every room resource shares the ONE compiled "Room" S_ResourceType — a genuine new dictionary row (Consultant/Plants/Work Center don\'t fit), same on-demand precedent as C_UOM/M_Warehouse');
+
+// ---- L4: payslip() reader surfaces the REAL hr_movement_id per line (what the Payslip deep-link uses) -------
+var run = AD.runPeriod(AD.demoSpec());
+var slip = AD.payslip(run.hr_movement, 1001, 'en');
+var realIds = run.hr_movement.filter(function (m) { return m.c_bpartner_id === 1001; }).map(function (m) { return m.hr_movement_id; }).sort();
+var slipIds = slip.lines.map(function (l) { return l.hr_movement_id; }).sort();
+ok('L4-real-movement-ids', slip.lines.every(function (l) { return l.hr_movement_id != null; }) && JSON.stringify(slipIds) === JSON.stringify(realIds),
+  'every payslip() line carries the REAL hr_movement_id of the movement it groups from — exactly the ids in run.hr_movement (' + realIds.join(',') + '), not re-numbered by the view');
+
+// ---- L5: sanity — the other two deep-link sources (C_Subscription, C_Order/Line) already carry real PKs ------
+var tenSpec = ADT.compileBuilding('HHS_Office_Federated', rooms, self.HbaModels.records('Tenancy'), self.HbaModels.records('Strata'));
+ok('L5-subscription-pk', tenSpec.subscriptions.every(function (s) { return s.row.c_subscription_id != null; }),
+  'ad_tenancy.compileBuilding subscriptions already carry a real c_subscription_id (§P10-BUILD, unchanged) — the Tenancy pane link source');
+var series = IoT.demoSeries('TEST-ASSET', 24);
+var billing = IoT.billingLines('TEST-ASSET', series.series, 'HHS_Office_Federated', '24h');
+ok('L5-order-pk', billing.order.c_order_id != null && billing.lines.every(function (l) { return l.row.c_order_id === billing.order.c_order_id && l.row.c_orderline_id != null; }),
+  'iot.billingLines already carries a real c_order_id/c_orderline_id (§P10b, unchanged) — the IoT billing pane link source');
+
+// ---- L6: Leave has NO native AD table of its own — its deep-link target is the REAL "Leave without pay"
+//   hr_concept identity it feeds, not a fabricated leave-record window (verified §CRITICAL P8 finding). -------
+var log = Lv.demoLog('EMP001');
+var mayEntries = Lv.classify(log, 'EMP001').filter(function (r) { return r.period === '2026-05' && r.unpaidDays > 0; });
+ok('L6-unpaid-entry-exists', mayEntries.length === 2 && mayEntries[0].unpaidDays === 3 && mayEntries[1].unpaidDays === 1,
+  'the demo log genuinely has unpaid entries in 2026-05 (the 5d annual take splits 2 paid/3 unpaid against a 2d balance, plus a 1d unpaid-type take) — the rows the Leave pane link gates on, not every row');
+ok('L6-concept-id-real', AD.CONCEPTS.UNPAID_LEAVE.hr_concept_id === 5,
+  'ad_payroll.CONCEPTS.UNPAID_LEAVE.hr_concept_id = 5 — the SAME real hr_concept row already compiled+witnessed by W-HBA-AD-PAYROLL, reused (not a new id minted for the link)');
+var leaveLink = HBALens.erpLink(HBALens.AD_WINDOWS.PAYROLL_CONCEPT, AD.CONCEPTS.UNPAID_LEAVE.hr_concept_id);
+ok('L6-link-shape', leaveLink === '../erp/idempiere.html?client=garden&window=53036&record=5',
+  'Leave pane link = "' + leaveLink + '" — Payroll Concept Catalog window, record=the real UNPAID_LEAVE concept id');
+
+var pass = checks.filter(Boolean).length, fail = checks.length - pass;
+console.log('\n§HBA-ERP-DEEPLINK ' + pass + '/' + checks.length + ' PASS' + (fail ? (' — ' + fail + ' FAIL') : ''));
+process.exit(fail ? 1 : 0);

--- a/viewer/hba_dashboard.js
+++ b/viewer/hba_dashboard.js
@@ -8,6 +8,10 @@
 //   removes it + destroys its charts (zero residue). It never touches the 3D scene, other panels, or sw.js.
 //   Data source = host-injected A._hbaOccupancyLog / A._hbaRequestLog (seeded from the model's real rooms by
 //   hba_lens.js); honest empty when none. Read the log after run.
+//   §P11 (RESUME_HR_BIM_ASSET.md §P11, user 2026-07-02) — a "Resources" list under the charts, one row per
+//   real room (dash.pivot.byRoom, already computed by occupancy.pivot — no new numbers), each with an
+//   "open ↗" deep-link into the room's real S_Resource row in iDempiere (A._hbaResourceSpec, compiled by
+//   occupancy.js compileResources via hba_lens.js). Honest no-link when a room hasn't compiled a resource yet.
 (function () {
   'use strict';
   var G = (typeof self !== 'undefined' ? self : this);
@@ -59,6 +63,36 @@
       var cv = document.createElement('canvas'); cv.style.cssText = 'display:block;';
       wrap.appendChild(cv); pane.appendChild(wrap); canvases.push(cv);
     });
+    // §P11 — Resources list: one row per real room (dash.pivot.byRoom), storey + utilization, "open ↗" into
+    // the room's compiled S_Resource row (A._hbaResourceSpec) when one exists (honest no-link otherwise).
+    var resById = {};
+    ((A._hbaResourceSpec && A._hbaResourceSpec.resources) || []).forEach(function (r) { if (r.row) resById[r.guid] = r.row.s_resource_id; });
+    var roomName = {}; (A._hbaRooms || []).forEach(function (r) { roomName[r.guid] = r.name || r.guid; });
+    var byRoom = dash.pivot.byRoom, roomGuids = Object.keys(byRoom).sort();
+    var linked = 0;
+    if (roomGuids.length) {
+      pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:8px 12px 0;', 'Resources'));
+      var tbl = el('table', 'width:100%;border-collapse:collapse;font-size:12px;margin:4px 12px 10px;width:calc(100% - 24px);');
+      roomGuids.forEach(function (guid) {
+        var rb = byRoom[guid], sResId = resById[guid];
+        var tr = el('tr', 'border-top:1px solid #eee;');
+        tr.appendChild(el('td', 'padding:4px 2px;', roomName[guid] || guid));
+        tr.appendChild(el('td', 'padding:4px 2px;color:#627d98;', rb.storey || '—'));
+        tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', Math.round(rb.utilization * 100) + '%'));
+        var linkTd = el('td', 'padding:4px 2px;text-align:right;');
+        if (sResId != null && G.HBALens && G.HBALens.erpLink) {
+          var a = document.createElement('a');
+          a.href = G.HBALens.erpLink(G.HBALens.AD_WINDOWS.RESOURCE, sResId);
+          a.target = '_blank'; a.rel = 'noopener'; a.textContent = 'open ↗';
+          a.title = 'Open this room’s Resource record in iDempiere';
+          a.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+          linkTd.appendChild(a); linked++;
+        }
+        tr.appendChild(linkTd);
+        tbl.appendChild(tr);
+      });
+      pane.appendChild(tbl);
+    }
     (document.body || document.documentElement).appendChild(pane);
     if (G.HbaDraggable) G.HbaDraggable.enable(pane, head);   // §P10b — drag by the header
     if (pane.offsetHeight) { /* force a reflow so the canvases have layout before Chart measures them */ }
@@ -67,7 +101,7 @@
       try { _charts.push(new G.Chart(canvases[i], cfg)); } catch (e) { console.warn('§HBA_DASH chart err ' + e.message); }
     });
     _pane = pane;
-    console.log('§HBA_DASH mounted rooms=' + dash.kpi.rooms + ' util=' + dash.kpi.avgUtilization + ' open=' + dash.kpi.openTickets);
+    console.log('§HBA_DASH mounted rooms=' + dash.kpi.rooms + ' util=' + dash.kpi.avgUtilization + ' open=' + dash.kpi.openTickets + ' resourceLinks=' + linked);
     return true;
   }
 

--- a/viewer/hba_iot.js
+++ b/viewer/hba_iot.js
@@ -173,6 +173,17 @@
       tr.appendChild(el('td', 'padding:4px 2px;', ln.sensor.label));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', 'qty ' + ln.row.qtyordered + ' ' + ln.sensor.uom_symbol));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#2e7d32;font-weight:600;', ln.row.linenetamt.toFixed(2)));
+      // §P11 — deep-link this billing line into the real C_Order it compiled onto (management billing follow-up).
+      var linkTd = el('td', 'padding:4px 2px;text-align:right;');
+      if (ln.row.c_order_id != null && G.HBALens && G.HBALens.erpLink) {
+        var a = document.createElement('a');
+        a.href = G.HBALens.erpLink(G.HBALens.AD_WINDOWS.ORDER, ln.row.c_order_id);
+        a.target = '_blank'; a.rel = 'noopener'; a.textContent = 'open ↗';
+        a.title = 'Open ' + billing.order.documentno + ' in iDempiere — billable, ready for management follow-up';
+        a.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+        linkTd.appendChild(a);
+      }
+      tr.appendChild(linkTd);
       tbl.appendChild(tr);
     });
     pane.appendChild(tbl);

--- a/viewer/hba_leave.js
+++ b/viewer/hba_leave.js
@@ -14,7 +14,7 @@
   var G = (typeof self !== 'undefined' ? self : this);
   var _pane = null, _sel = null;
 
-  function deps() { return { Lv: G.HbaLeave }; }
+  function deps() { return { Lv: G.HbaLeave, AD: G.HbaAdPayroll, Lens: G.HBALens }; }
   function ready() { return !!(deps().Lv && typeof document !== 'undefined'); }
 
   // the spec driving this pane — host-injected (per-building demo employees) or honestly absent.
@@ -43,12 +43,27 @@
     body.appendChild(el('div', 'font-size:11px;color:' + (sum.chainOk ? '#2e7d32' : '#c62828') + ';padding:2px 0 6px;',
       sum.chainOk ? '✓ signed chain verifies' : '✗ chain tamper detected'));
     var tbl = el('table', 'width:100%;border-collapse:collapse;font-size:12px;');
+    // §P11 — Leave has NO native AD table of its own (verified §CRITICAL P8 finding) — an unpaid entry's
+    // REAL AD identity is the "Leave without pay" pay-element it feeds INTO (ad_payroll.js CONCEPTS.UNPAID_LEAVE,
+    // hr_concept_id), not a fabricated leave-record window. Only entries that actually carry unpaid days get
+    // the link — an honest reflection of "this is what would post to payroll", not every row.
+    var d = deps(), concept = d.AD && d.AD.CONCEPTS && d.AD.CONCEPTS.UNPAID_LEAVE;
     sum.entries.forEach(function (r) {
       var tr = el('tr', 'border-top:1px solid #eee;');
       tr.appendChild(el('td', 'padding:4px 2px;', r.period + ' · ' + r.type));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;', r.days + 'd'));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:' + (r.unpaidDays > 0 ? '#c62828' : '#627d98') + ';',
         r.unpaidDays > 0 ? (r.unpaidDays + 'd unpaid') : 'paid'));
+      var linkTd = el('td', 'padding:4px 2px;text-align:right;');
+      if (r.unpaidDays > 0 && concept && d.Lens && d.Lens.erpLink) {
+        var a = document.createElement('a');
+        a.href = d.Lens.erpLink(d.Lens.AD_WINDOWS.PAYROLL_CONCEPT, concept.hr_concept_id);
+        a.target = '_blank'; a.rel = 'noopener'; a.textContent = 'open ↗';
+        a.title = 'Open the native "Leave without pay" payroll concept this feeds';
+        a.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+        linkTd.appendChild(a);
+      }
+      tr.appendChild(linkTd);
       tbl.appendChild(tr);
     });
     body.appendChild(tbl);

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -268,6 +268,12 @@
         A._hbaTenancySpec = h.ADT.compileBuilding(A.buildingName || 'This Building', rooms, h.M.records('Tenancy'), h.M.records('Strata'));
         console.log('§HBA_TEN compiled tenancy spec — units=' + A._hbaTenancySpec.units + ' subscriptions=' + A._hbaTenancySpec.subscriptions.length + ' skipped=' + A._hbaTenancySpec.skipped.length);
       }
+      // §P11 — compile each REAL room into a native S_Resource header row (Dashboard's "hover a Resource"
+      // deep-link needs a real numeric s_resource_id per room; see occupancy.js compileResources header).
+      if (!A._hbaResourceSpec && h.OC && h.OC.compileResources && rooms.length) {
+        A._hbaResourceSpec = h.OC.compileResources(rooms);
+        console.log('§HBA_RES compiled ' + A._hbaResourceSpec.resources.length + ' S_Resource rows from ' + rooms.length + ' rooms');
+      }
     } catch (e) { /* no spatial_structure → honest no-op (density falls back to S?) */ }
   }
 
@@ -444,6 +450,24 @@
     return { flew: true, guid: want[0], center: center };
   }
 
+  // §P11 (RESUME_HR_BIM_ASSET.md §P11, user 2026-07-02) — cross-app deep-link from an HBA pane into the real
+  // iDempiere ERP UI, reusing the SAME URL shape navigate_find.js's `_surfaceExistingOrder` already proved
+  // (`../erp/idempiere.html?client=garden&window=<AD_Window_ID>&record=<pk>`), NOT a new mechanism. Every id
+  // below was LOOKED UP from this repo's own `build/erp/ad_full.db` (`SELECT AD_Window_ID,Name FROM AD_Window`),
+  // never guessed — RESOURCE=236 "Resource" (table S_Resource), PAYROLL_MOVEMENT=53042 "Payroll Movement"
+  // (table HR_Movement), SUBSCRIPTION=316 "Subscription" (table C_Subscription), ORDER=143 "Sales Order"
+  // (table C_Order, issotrx='Y' matches iot.js's compiled order header). ONE shared source so every pane wires
+  // the same numbers instead of re-typing them.
+  // PAYROLL_CONCEPT=53036 "Payroll Concept Catalog" (table HR_Concept) — Leave has NO native AD table of its
+  // own anywhere (verified §CRITICAL P8 finding, re-checked here) so a per-entry link would be invented; what
+  // IS real is the "Leave without pay" pay-element identity (hr_concept_id) an unpaid entry feeds INTO — the
+  // Leave pane links there, never to a fabricated leave-record window.
+  var AD_WINDOWS = { RESOURCE: 236, PAYROLL_MOVEMENT: 53042, SUBSCRIPTION: 316, ORDER: 143, PAYROLL_CONCEPT: 53036 };
+  function erpLink(windowId, record) {
+    if (windowId == null || record == null) return null;
+    return '../erp/idempiere.html?client=garden&window=' + windowId + '&record=' + encodeURIComponent(record);
+  }
+
   // §P10a — Presence roster (user 2026-07-02): a second small drawer beside the FM drawer, listing every
   // attendance session for the current period. Person resolved via MODELS.Official by attendance's own
   // `employee` id — an honest miss shows the bare code, never a fabricated name (attendance's auto-generated
@@ -608,7 +632,8 @@
   G.HBALens = { detect: detect, toggle: toggle, isActive: isActive, buildMeshPort: buildMeshPort, tintedCount: tintedCount,
     maintenanceSchedule: maintenanceSchedule, availableLenses: availableLenses, familyHasData: familyHasData,
     familyActive: familyActive, activateLens: activateLens, openFamilyDrawer: openFamilyDrawer, FAMILY: FAMILY, _ready: ready,
-    flyToZone: flyToZone, openPresenceDrawer: openPresenceDrawer, closePresenceDrawer: _closePresenceDrawer };
+    flyToZone: flyToZone, openPresenceDrawer: openPresenceDrawer, closePresenceDrawer: _closePresenceDrawer,
+    erpLink: erpLink, AD_WINDOWS: AD_WINDOWS };
   if (typeof module === 'object' && module.exports) { module.exports = G.HBALens; return; }   // node witness — no DOM gate
 
   // ---- DATA-GATE poll (mirrors viewer/wh_walk.js): flip the pill icons ON only when a lens detects ------

--- a/viewer/hba_payslip.js
+++ b/viewer/hba_payslip.js
@@ -44,9 +44,20 @@
       var tr = el('tr', 'border-top:1px solid #eee;');
       tr.appendChild(el('td', 'padding:4px 2px;', l.name));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:' + (l.accountsign === '+' ? '#2e7d32' : '#c62828') + ';', (l.accountsign === '+' ? '+' : '-') + l.amount));
+      // §P11 — deep-link this movement line into its real hr_movement AD record (Payroll Movement window).
+      var linkTd = el('td', 'padding:4px 2px;text-align:right;');
+      if (l.hr_movement_id != null && G.HBALens && G.HBALens.erpLink) {
+        var a = document.createElement('a');
+        a.href = G.HBALens.erpLink(G.HBALens.AD_WINDOWS.PAYROLL_MOVEMENT, l.hr_movement_id);
+        a.target = '_blank'; a.rel = 'noopener'; a.textContent = 'open ↗';
+        a.title = 'Open this movement in iDempiere Payroll Movement';
+        a.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+        linkTd.appendChild(a);
+      }
+      tr.appendChild(linkTd);
       tbl.appendChild(tr);
       var trace = el('tr', '');
-      var td2 = el('td', 'padding:0 2px 6px;color:#627d98;font-size:10px;', l.trace); td2.colSpan = 2;
+      var td2 = el('td', 'padding:0 2px 6px;color:#627d98;font-size:10px;', l.trace); td2.colSpan = 3;
       trace.appendChild(td2); tbl.appendChild(trace);
     });
     body.appendChild(tbl);

--- a/viewer/hba_tenancy.js
+++ b/viewer/hba_tenancy.js
@@ -64,6 +64,20 @@
       tr.appendChild(el('td', 'padding:6px 4px;color:#627d98;', s.storey || '—'));
       tr.appendChild(el('td', 'padding:6px 4px;text-align:right;', cadenceName(s.row.c_subscriptiontype_id)));
       tr.appendChild(el('td', 'padding:6px 4px;text-align:right;color:#627d98;', (s.row.startdate || '—') + '→' + (s.row.renewaldate || '—')));
+      // §P11 — "balanced" deep-link into the real C_Subscription record, alongside the existing flyToZone
+      // click (stopPropagation so the anchor doesn't also fire the row's camera-fly).
+      var linkTd = el('td', 'padding:6px 4px;text-align:right;');
+      var lens0 = deps().Lens;
+      if (s.row.c_subscription_id != null && lens0 && lens0.erpLink) {
+        var a = document.createElement('a');
+        a.href = lens0.erpLink(lens0.AD_WINDOWS.SUBSCRIPTION, s.row.c_subscription_id);
+        a.target = '_blank'; a.rel = 'noopener'; a.textContent = 'open ↗';
+        a.title = 'Open this subscription in iDempiere';
+        a.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+        a.addEventListener('click', function (e) { e.stopPropagation(); });
+        linkTd.appendChild(a);
+      }
+      tr.appendChild(linkTd);
       tr.addEventListener('click', function () {
         var lens = deps().Lens;
         var res = lens && lens.flyToZone ? lens.flyToZone(A, s.unit_guid) : { flew: false };


### PR DESCRIPTION
## Summary
- Cross-app deep-link from every HR_BIM_Asset pane that already shows a real AD-compiled record into its actual iDempiere ERP window — reuses `navigate_find.js`'s proven `?client=garden&window=<id>&record=<pk>` URL shape, not a new mechanism.
- Every `AD_Window_ID` was looked up from `build/erp/ad_full.db` (`SELECT AD_Window_ID,Name FROM AD_Window`), never guessed: Resource=236, Payroll Movement=53042, Subscription=316, Sales Order=143, Payroll Concept Catalog=53036.
- **Dashboard** — each real room now compiles a native `S_Resource` header row (new `occupancy.js compileResources`, an on-demand "Room" `S_ResourceType` since Consultant/Plants/Work Center don't fit — same precedent as `C_UOM`/`M_Warehouse`); Resources list links to window 236.
- **Payslip** — `payslip()` now surfaces the real `hr_movement_id` per line; links to window 53042.
- **Leave** — verified it has NO native AD table of its own; an unpaid entry instead links to the real "Leave without pay" `hr_concept` it feeds into on payroll → window 53036 (never a fabricated leave-record window).
- **Tenancy** — existing `c_subscription_id` → window 316, alongside the existing camera fly-to click.
- **IoT billing** — existing `c_order_id` → window 143 ("ready for management billing follow-up").

## Test plan
- [x] New `hr_bim_asset/tests/witness_erp_deeplink.js` — 19/19 PASS (window-id ground truth, URL shape, S_Resource non-invent gate, real PK passthrough on every pane's source).
- [x] Full HBA node witness suite (34 files) re-run — zero regression.
- [x] Live chromium smoke (`cdp_shot.js` against `demo/fm_panel.html`) — opened all 5 panes, confirmed real `href`s render (`window=236/53042/53036/316/143`, correct `record=`), 0 console errors, screenshots captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)