### PR TITLE
feat(erp): Kitchen Display lens + POS HMI restyle onto app palette (erp sw v757)

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -556,7 +556,12 @@
      ring/pay/complete earcons pos_lens.js fires via window.__sfx.play, no per-button tick spam). Guarded:
      pos_lens._sfx no-ops if absent. -->
 <script src="../viewer/sfx.js?v=1" onerror="console.warn('§POS-AUDIO sfx.js absent — POS earcons silent (guarded)')"></script>
-<script src="pos_lens.js?v=9"></script>
+<script src="pos_lens.js?v=10"></script>
+<!-- Kitchen Display (RESUME_POS_KITCHEN_EINVOICE_OPS_PANELS §T2-SPEC) — queue = FOLD over the op log
+     (KitchenCore, == bim-compiler build/erp source of truth, W-KDS-QUEUE headless) + the dumb-terminal
+     lens (KitchenLens). Serve rides pos_core's completeShipmentOps — load AFTER pos_core. -->
+<script src="kitchen_core.js?v=1"></script>
+<script src="kitchen_lens.js?v=1"></script>
 <!-- §P-11 receipt QR (order ref URL, not payable EMVCo — POS_ADDON_SPEC §P-11 rails-honesty note) -->
 <script src="qrcode.min.js"></script>
 <!-- NINJA EXCEL (bim-compiler internal/NinjaExcelAdaptation.md §6.2, W-NINJA-PILL) — Excel-as-report-binder
@@ -4236,6 +4241,18 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       // so the warehouse-walk page can fold a deliver-later sale; same store the Kanban write path persists.
       persist: function () { return window.KanbanHost.persist(window.ERP.opDb, _KPROJ); } });
   }
+  // 🍳 Kitchen Display (§T2-SPEC) — the "ordered, not yet delivered" queue: KitchenCore folds the SAME
+  // published op log the POS writes (deliver-later shipments born DR) ∪ the §S-2 seed selector; Serve =
+  // ONE signed group riding completeShipmentOps. Same write-path bootstrap as openPosFor.
+  async function openKitchenFor() {
+    console.log('§KDS-PILL action=open');
+    if (!_session) { status('Log in first'); return; }
+    if (!window.KitchenLens || !window.KitchenCore || !window.POSCore) { status('Kitchen lens not loaded.'); return; }
+    var ok = await _ensureKanbanERP();
+    if (!ok || !window.ERP) { status('Kitchen: write path unavailable (window.ERP not published)'); console.log('§KDS-PILL write-path=absent'); return; }
+    KitchenLens.open({ b3: _b3(window.__idmpDb), opDb: window.ERP.opDb, KO: window.KernelOps,
+      seal: window.ERP.seal, chainVerify: window.ERP.chainVerify, overlay: _overlay, el: el, status: status });
+  }
   // ⚖ Rule — THE ONE GESTURE: edit one rule → K records re-fold live, signed + reversible (RuleFold).
   function openRuleFor() {
     console.log('§RULE-PILL action=open');
@@ -4321,7 +4338,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     window.IdmpPillActions = {
       dashboard: openDashboard,   // unified multi-view (Graph/Cards/Pivot/List/Timeline) — replaces the 3 separate lens pills
       graph: openGraphFor, kanban: openKanbanFor, pivot: openPivotFor,   // kept: openDashboard fans into them
-      rule: openRuleFor, pos: openPosFor,
+      rule: openRuleFor, pos: openPosFor, kitchen: openKitchenFor,
       share: _shareCurrent, home: function () { location.href = '../index.html?home=1'; },   // "Exit" → the Matrix landing (app-shell front door), RESUME_IDMP_FIDELITY leg 2
       erpdoc: openReadCompare,
       // RED PILL — abstract ZOOM ACROSS (zoom_across.js): collect the cross-surface destinations available for

--- a/erp/kitchen_core.js
+++ b/erp/kitchen_core.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/**
+ * kitchen_core.js — the Kitchen Display fold (RESUME_POS_KITCHEN_EINVOICE_OPS_PANELS.md §T2-SPEC).
+ *
+ * A kitchen queue is "ordered, not yet delivered" — on this event-sourced substrate that is a FOLD
+ * over the op log, NOT a new table: buildDeliverLaterGroup births the shipment DR ("sent to kitchen"),
+ * completeShipmentOps (pos_core.js §S-4, FSM-gated) completes it ("served"). This module adds ZERO
+ * business verbs — it only folds kernel_ops rows into tickets and filters the open ones.
+ *
+ * Separation contract (same as pos_core.js): PURE. No DB import, no Date.now/Math.random/DOM.
+ * The host feeds parsed op rows and renders the result (dumb-terminal rule).
+ *
+ * Witness: W-KDS-QUEUE (scripts/poc_kitchen_queue.js) — read build/erp/poc_kitchen_queue.log.
+ */
+'use strict';
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.KitchenCore = factory();
+  }
+})(typeof window !== 'undefined' ? window : this, function () {
+
+  // ── foldTickets: kernel_ops rows (id order) → tickets ─────────────────────────────────────────
+  // rows = [{op_type, parameters, timestamp?}] — parameters JSON already parsed OR a string; the op
+  // payload may sit at p or p.params (the logMovements precedent, pos_lens.js). Walk in id order:
+  //   CREATE_DOCUMENT C_Order            → order info (c_bpartner_id, c_pos_id) by c_order_id
+  //   CREATE_LINE C_OrderLine            → qtyordered by source_line_id (the doc's QtyOrdered side)
+  //   CREATE_DOCUMENT M_InOut (mv 'C-')  → OPEN a ticket, docstatus DR by absence of SET_STATUS
+  //   CREATE_LINE M_InOutLine            → attach to the ticket just opened (in-group order holds)
+  //   SET_STATUS M_InOut                 → transition that ticket's docstatus (CO = served/delivered)
+  function foldTickets(rows) {
+    var orders = {}, tickets = [], byInout = {}, curTicket = null, seq = 0;
+    (rows || []).forEach(function (row) {
+      var p = row.parameters;
+      if (typeof p === 'string') { try { p = JSON.parse(p); } catch (e) { return; } }
+      p = p && p.params ? p.params : p;
+      if (!p || !p.table) return;
+      seq++;
+      if (p.op_type === 'CREATE_DOCUMENT' && p.table === 'C_Order') {
+        orders[p.c_order_id] = { c_bpartner_id: p.c_bpartner_id, c_pos_id: p.c_pos_id, c_doctype_id: p.c_doctype_id };
+      } else if (p.op_type === 'CREATE_DOCUMENT' && p.table === 'M_InOut') {
+        curTicket = {
+          m_inout_id: p.m_inout_id, c_order_id: p.source_id, c_doctype_id: p.c_doctype_id,
+          m_warehouse_id: p.m_warehouse_id, movementtype: p.movementtype,
+          docstatus: 'DR', seq: seq, timestamp: row.timestamp != null ? row.timestamp : null, lines: []
+        };
+        tickets.push(curTicket);
+        if (p.m_inout_id != null) byInout[p.m_inout_id] = curTicket;
+      } else if (p.op_type === 'CREATE_LINE' && p.table === 'M_InOutLine' && curTicket) {
+        curTicket.lines.push({ source_line_id: p.source_line_id, m_product_id: p.m_product_id, movementqty: p.movementqty });
+      } else if (p.op_type === 'SET_STATUS' && p.table === 'M_InOut') {
+        var t = byInout[p.id];
+        if (t) t.docstatus = p.doc_status;
+      }
+    });
+    // enrich each ticket with its order info (partner — the counterparty the ticket serves)
+    tickets.forEach(function (t) {
+      var o = orders[t.c_order_id];
+      if (o) { t.c_bpartner_id = o.c_bpartner_id; t.c_pos_id = o.c_pos_id; }
+    });
+    return tickets;
+  }
+
+  // ── queue: the open kitchen — customer shipments (C-) still DR/IP, oldest first ────────────────
+  // ≡ "WHERE QtyDelivered < QtyOrdered ORDER BY order date" projected onto the event-sourced substrate:
+  // a WR cash-and-carry sale completes its M_InOut IN-group (SET_STATUS CO folds before queue() runs),
+  // so only deliver-later shipments — the undelivered lines — remain. FSM order = op-log id order.
+  function queue(tickets) {
+    return (tickets || [])
+      .filter(function (t) { return t.movementtype === 'C-' && (t.docstatus === 'DR' || t.docstatus === 'IP'); })
+      .sort(function (a, b) { return a.seq - b.seq; });
+  }
+
+  // ── serveOps: "served" = complete the ticket's shipment through pos_core's OWN §S-4 verb ───────
+  // POS injected (browser: window.POSCore; node: require) — no import here, no fork of the FSM gate:
+  // confirm-demanding doctypes refuse (reason=confirm-gated), double-serve refuses (not-open).
+  // Full-qty serve: pickedQtyOf omitted → completeShipmentOps takes each line's movementqty verbatim.
+  function serveOps(POS, ticket, dtRow) {
+    if (!ticket || ticket.m_inout_id == null) return { ok: false, reason: 'no-ticket' };
+    return POS.completeShipmentOps(
+      { m_inout_id: ticket.m_inout_id, docstatus: ticket.docstatus },
+      ticket.lines, dtRow, {});
+  }
+
+  return { foldTickets: foldTickets, queue: queue, serveOps: serveOps };
+});

--- a/erp/kitchen_lens.js
+++ b/erp/kitchen_lens.js
@@ -1,0 +1,195 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// kitchen_lens.js — the Kitchen Display lens (RESUME_POS_KITCHEN_EINVOICE_OPS_PANELS.md §T2-SPEC).
+//
+// DUMB TERMINAL by construction (the pos_lens.js discipline): this file renders tickets and SENDS —
+// the queue is KitchenCore.foldTickets/queue over the page's published op log ∪ the §S-2 seed
+// selector on b3 (open C- shipments, the SAME query the warehouse walk routes); serve is ONE signed
+// group through kernel_ops.commitGroup riding pos_core's OWN completeShipmentOps (FSM + confirm gate
+// intact — a confirm-demanding doctype renders GATED, never silently serveable). No document state,
+// no qty math, no status logic live here. Witness: W-KDS-QUEUE (headless, bim-compiler) + live §-logs.
+//
+// HMI: the APP baseline palette (#121218/#e8e8ed/#6c9fff, success #5fd08a — idempiere.html's own
+// .posted-balance.is-balanced green), NOT the POS lens's legacy green-on-black.
+//
+// Host contract (idempiere.html openKitchenFor — mirrors openPosFor):
+//   KitchenLens.open({ b3, opDb, KO, seal, chainVerify, overlay, el, status })
+'use strict';
+(function (root) {
+
+  var _stylesInjected = false;
+  function _injectStyles() {
+    if (_stylesInjected) return; _stylesInjected = true;
+    var s = document.createElement('style');
+    s.textContent = [
+      '#kds-wrap { display:flex;flex-direction:column;gap:10px;max-height:74vh;overflow:auto;padding:8px;color:#e8e8ed; }',
+      '#kds-bar  { display:flex;align-items:center;gap:10px;padding:6px 12px;border:1px solid #33334a;border-radius:24px;background:#16161d; }',
+      '#kds-count{ flex:1;text-align:center;font-size:18px;font-weight:bold;color:#6c9fff;letter-spacing:.4px; }',
+      '.kds-bar-btn { width:34px;height:34px;border-radius:50%;border:1px solid #33334a;background:#1a1a24;color:#e8e8ed;',
+      '               cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;transition:background .15s; }',
+      '.kds-bar-btn:hover { background:rgba(108,159,255,0.16); }',
+      '#kds-list { display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:10px;align-content:start; }',
+      '.kds-ticket { display:flex;flex-direction:column;border:1px solid #33334a;border-radius:10px;background:#16161d;overflow:hidden; }',
+      '.kds-ticket-hdr { display:flex;justify-content:space-between;align-items:baseline;gap:8px;padding:8px 12px;',
+      '                  background:#1a1a24;border-bottom:1px solid #33334a;font-size:13px;font-weight:bold;color:#6c9fff; }',
+      '.kds-ticket-time { font-size:11px;font-weight:normal;color:#8b8b9e; }',
+      '.kds-ticket-bp  { padding:4px 12px 0;font-size:12px;color:#a9a9b8; }',
+      '.kds-lines      { padding:6px 12px;flex:1; }',
+      '.kds-line       { display:flex;justify-content:space-between;font-size:13px;padding:3px 0;border-bottom:1px solid #22222e;color:#e8e8ed; }',
+      '.kds-line-qty   { color:#6c9fff;font-weight:bold;margin-right:8px; }',
+      '.kds-serve      { margin:8px 12px 12px;padding:9px;border-radius:8px;border:1px solid #33334a;',
+      '                  background:rgba(95,208,138,0.12);color:#5fd08a;cursor:pointer;font-size:13px;font-weight:bold;',
+      '                  transition:background .15s; }',
+      '.kds-serve:hover { background:rgba(95,208,138,0.24); }',
+      '.kds-serve.gated { background:#1a1a24;color:#8b8b9e;cursor:default;border-style:dashed; }',
+      '#kds-empty { padding:32px;text-align:center;color:#8b8b9e;font-size:14px; }'
+    ].join('\n');
+    document.head.appendChild(s);
+  }
+
+  function _svgIcon(key, sz) {
+    var ic = window.ICONS && window.ICONS[key];
+    if (!ic) return '';
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="' + (sz || 16) + '" height="' + (sz || 16) +
+      '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"' +
+      ' stroke-linecap="round" stroke-linejoin="round">' + ic.svg + '</svg>';
+  }
+
+  function q1(b3, sql) {
+    var a = []; for (var i = 2; i < arguments.length; i++) a.push(arguments[i]);
+    var st = b3.prepare(sql); return st.get.apply(st, a);
+  }
+  function qa(b3, sql) {
+    var a = []; for (var i = 2; i < arguments.length; i++) a.push(arguments[i]);
+    var st = b3.prepare(sql); return st.all.apply(st, a);
+  }
+
+  // op rows in the shape KitchenCore.foldTickets consumes (id order — the W-KDS-QUEUE reader, verbatim)
+  function _opRows(opDb) {
+    try {
+      var r = opDb.exec('SELECT id, timestamp, op_type, parameters FROM kernel_ops ORDER BY id');
+      return (r[0] ? r[0].values : []).map(function (v) { return { id: v[0], timestamp: v[1], op_type: v[2], parameters: v[3] }; });
+    } catch (e) { return []; }
+  }
+
+  // §S-2 seed selector on b3 (the walk's honest source) UNIONED under the op-log fold: ledger rows
+  // that already sit in the physical db as open POS shipments. Dedup by m_inout_id — op-log wins
+  // (it carries the newer status walk). JOIN precedent = pos_lens.js tiles (c_poskey→m_product→price).
+  function _seedTickets(b3) {
+    var hdrs = qa(b3,
+      "SELECT io.m_inout_id, io.c_order_id, io.c_doctype_id, io.m_warehouse_id, io.movementtype, " +
+      "io.docstatus, o.c_bpartner_id, o.c_pos_id FROM m_inout io JOIN c_order o ON o.c_order_id=io.c_order_id " +
+      "WHERE io.docstatus IN ('DR','IP') AND io.movementtype='C-' AND o.c_pos_id IS NOT NULL");
+    return hdrs.map(function (h, i) {
+      h.seq = -1000 + i; h.timestamp = null;   // seed rows sort strictly BEFORE every log op (oldest-first)
+      h.lines = qa(b3, 'SELECT c_orderline_id AS source_line_id, m_product_id, movementqty FROM m_inoutline WHERE m_inout_id=? ORDER BY m_inoutline_id', h.m_inout_id);
+      return h;
+    });
+  }
+
+  function open(cfg) {
+    _injectStyles();
+    var b3 = cfg.b3, el = cfg.el, KDS = root.KitchenCore, POS = root.POSCore;
+    if (!KDS || !POS) { cfg.status('Kitchen core not loaded.'); return; }
+
+    var wrap = el('div'); wrap.id = 'kds-wrap';
+    var bar = el('div'); bar.id = 'kds-bar';
+    var count = el('div'); count.id = 'kds-count';
+    var refreshBtn = el('button'); refreshBtn.className = 'kds-bar-btn'; refreshBtn.title = 'Refresh queue';
+    refreshBtn.innerHTML = _svgIcon('clock', 16) || '⟳';
+    bar.appendChild(count); bar.appendChild(refreshBtn);
+    var list = el('div'); list.id = 'kds-list';
+    wrap.appendChild(bar); wrap.appendChild(list);
+
+    function nameOf(pid) {
+      var r = q1(b3, 'SELECT name FROM m_product WHERE m_product_id=?', pid);
+      return r ? r.name : ('Product ' + pid);
+    }
+    function bpOf(bpid) {
+      if (bpid == null) return '';
+      var r = q1(b3, 'SELECT name FROM c_bpartner WHERE c_bpartner_id=?', bpid);
+      return r ? r.name : ('BP ' + bpid);
+    }
+    function dtOf(dtid) {
+      return dtid == null ? null : q1(b3, 'SELECT * FROM c_doctype WHERE c_doctype_id=?', dtid) || null;
+    }
+
+    function currentQueue() {
+      var folded = KDS.foldTickets(_opRows(cfg.opDb));
+      var seen = {};
+      folded.forEach(function (t) { if (t.m_inout_id != null) seen[t.m_inout_id] = 1; });
+      var seed = _seedTickets(b3).filter(function (t) { return !seen[t.m_inout_id]; });
+      return KDS.queue(seed.concat(folded));
+    }
+
+    function serve(ticket, dt, btn) {
+      var g = KDS.serveOps(POS, ticket, dt);
+      if (!g.ok) { cfg.status('Serve refused: ' + g.reason); console.log('§KDS-SERVE REFUSED inout=' + ticket.m_inout_id + ' reason=' + g.reason); return; }
+      btn.disabled = true;
+      cfg.KO.commitGroup(cfg.opDb, g.ops.map(function (o) { return { op_type: o.op_type, params: o }; }), {})
+        .then(function (res) {
+          return Promise.resolve(cfg.seal ? cfg.seal() : null).then(function () {
+            return cfg.chainVerify ? cfg.chainVerify() : { ok: false };
+          }).then(function (cv) {
+            console.log('§KDS-SERVE inout=' + ticket.m_inout_id + ' order=' + ticket.c_order_id +
+              ' M_InOut→CO gid=' + res.gid + ' chainOk=' + (cv && cv.ok ? 'Y' : 'N'));
+            cfg.status('Served · order ' + ticket.c_order_id + ' · shipment ' + ticket.m_inout_id + ' CO');
+            render();
+          });
+        })
+        .catch(function (e) { btn.disabled = false; cfg.status('Serve commit failed: ' + e); console.log('§KDS-SERVE FAIL ' + e); });
+    }
+
+    function render() {
+      list.textContent = '';
+      var queue = currentQueue();
+      count.textContent = queue.length + ' open ticket' + (queue.length === 1 ? '' : 's');
+      if (!queue.length) {
+        var empty = el('div'); empty.id = 'kds-empty';
+        empty.textContent = 'No open kitchen tickets — deliver-later orders land here.';
+        list.appendChild(empty);
+        console.log('§KDS-EMPTY queue=0');
+        return;
+      }
+      queue.forEach(function (t) {
+        var card = document.createElement('div'); card.className = 'kds-ticket';
+        card.setAttribute('data-inout', t.m_inout_id);
+        var hdr = document.createElement('div'); hdr.className = 'kds-ticket-hdr';
+        var ord = document.createElement('span'); ord.textContent = 'Order ' + t.c_order_id;
+        var time = document.createElement('span'); time.className = 'kds-ticket-time';
+        time.textContent = t.timestamp ? new Date(Number(t.timestamp)).toLocaleTimeString() : 'seed';
+        hdr.appendChild(ord); hdr.appendChild(time);
+        var bp = document.createElement('div'); bp.className = 'kds-ticket-bp'; bp.textContent = bpOf(t.c_bpartner_id);
+        var lines = document.createElement('div'); lines.className = 'kds-lines';
+        t.lines.forEach(function (l) {
+          var row = document.createElement('div'); row.className = 'kds-line';
+          var nm = document.createElement('span');
+          var qty = document.createElement('span'); qty.className = 'kds-line-qty'; qty.textContent = Number(l.movementqty) + ' ×';
+          nm.appendChild(qty); nm.appendChild(document.createTextNode(nameOf(l.m_product_id)));
+          row.appendChild(nm); lines.appendChild(row);
+        });
+        var dt = dtOf(t.c_doctype_id);
+        var gated = !!(dt && (dt.ispickqaconfirm === 'Y' || dt.isshipconfirm === 'Y'));
+        var btn = document.createElement('button'); btn.className = 'kds-serve' + (gated ? ' gated' : '');
+        if (gated) {
+          btn.textContent = 'Confirm-gated — complete via Ship Confirmation';
+          console.log('§KDS-GATED inout=' + t.m_inout_id + ' dt=' + t.c_doctype_id + ' (IsPickQAConfirm/IsShipConfirm — inout_confirm owns it)');
+        } else {
+          btn.innerHTML = _svgIcon('check', 14) + ' Serve';
+          btn.addEventListener('click', function () { serve(t, dt, btn); });
+        }
+        card.appendChild(hdr); card.appendChild(bp); card.appendChild(lines); card.appendChild(btn);
+        list.appendChild(card);
+      });
+    }
+
+    refreshBtn.addEventListener('click', function () { render(); console.log('§KDS-REFRESH manual'); });
+
+    render();
+    cfg.overlay('Kitchen Display', wrap);
+    console.log('§KDS-OPEN tickets=' + currentQueue().length + ' (fold(opDb) ∪ §S-2 seed selector, oldest-first)');
+  }
+
+  root.KitchenLens = { open: open };
+  console.log('§KDS-LENS loaded (dumb terminal — the queue is a fold, serve is one signed group)');
+})(typeof window !== 'undefined' ? window : this);

--- a/erp/pills_idmp.json
+++ b/erp/pills_idmp.json
@@ -48,6 +48,15 @@
       "note": "POS_ADDON_SPEC §P-1 — the point-of-sale lens (openPosFor → PosLens.open): c_poskey tile grid, sealed master prices, Complete = ONE signed group (order+ship+invoice+backflush, WR from the dictionary), replenishment fold after. shopping-cart glyph (Lucide verbatim). §AD-GATE showWhen:pos-station — surfaces only when the tenant carries a c_pos row (window.IdmpPillPosGate, mirrors the Posting-Preview data-gate)."
     },
     {
+      "id": "kitchen",
+      "name": "Kitchen",
+      "key": "",
+      "icon": "clipboard",
+      "showWhen": "pos-station",
+      "order": 4.6,
+      "note": "RESUME_POS_KITCHEN_EINVOICE_OPS_PANELS §T2-SPEC — Kitchen Display (openKitchenFor → KitchenLens.open): the 'ordered, not yet delivered' queue = KitchenCore fold over the op log (deliver-later shipments born DR) ∪ the §S-2 seed selector; Serve = ONE signed group riding pos_core completeShipmentOps (confirm-gate + FSM intact). W-KDS-QUEUE headless witness. Same §AD-GATE showWhen:pos-station as the POS pill (a kitchen without a station is meaningless)."
+    },
+    {
       "id": "warehouse",
       "name": "Warehouse Walk",
       "key": "",

--- a/erp/pos_lens.js
+++ b/erp/pos_lens.js
@@ -36,18 +36,18 @@
       '#pos-grid  { display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;flex:1;align-content:start;width:100%; }',
 
       /* U-1: album card style */
-      '.pos-card { display:flex;flex-direction:column;border:1px solid #2a6;border-radius:10px;',
-      '            background:#0b1f17;color:#cfe;cursor:pointer;overflow:hidden;',
+      '.pos-card { display:flex;flex-direction:column;border:1px solid #33334a;border-radius:10px;',
+      '            background:#16161d;color:#e8e8ed;cursor:pointer;overflow:hidden;',
       '            transition:background .15s,transform .1s;user-select:none; }',
-      '.pos-card:hover { background:#133a22; }',
+      '.pos-card:hover { background:rgba(108,159,255,0.16); }',
       '.pos-card:active { transform:scale(0.96); }',
-      '.pos-card-img { width:100%;height:100px;object-fit:cover;background:#071409;',
-      '               display:flex;align-items:center;justify-content:center;color:#3a7;flex-shrink:0; }',
+      '.pos-card-img { width:100%;height:100px;object-fit:cover;background:#121218;',
+      '               display:flex;align-items:center;justify-content:center;color:#55556a;flex-shrink:0; }',
       '.pos-card-img img { width:100%;height:100px;object-fit:cover;display:block; }',
       '.pos-card-img svg { opacity:.45; }',
       '.pos-card-name { font-size:11px;padding:5px 6px 2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis; }',
-      '.pos-card-price { font-size:15px;font-weight:bold;color:#8fd;padding:0 6px 7px;letter-spacing:.3px; }',
-      '.pos-card.flash { background:#1d4a2e !important;transform:scale(0.94); }',
+      '.pos-card-price { font-size:15px;font-weight:bold;color:#cdd6e4;padding:0 6px 7px;letter-spacing:.3px; }',
+      '.pos-card.flash { background:rgba(95,208,138,0.24) !important;transform:scale(0.94); }',
 
       /* §P-6 mobile layout — scoped @media ≤640px (desktop two-col row UNCHANGED — falsifier) */
       '@media (max-width:640px) {',
@@ -61,71 +61,78 @@
       /* §P-7 pill icon bar */
       '#pos-pill-bar  { display:flex;gap:6px;margin-bottom:8px;align-items:center; }',
       '.pos-pill-btn  { display:flex;align-items:center;gap:4px;padding:5px 10px;',
-      '                 border:1px solid #2a6;border-radius:20px;background:#0b1f17;',
-      '                 color:#cfe;cursor:pointer;font-size:12px;transition:background .15s; }',
-      '.pos-pill-btn:hover { background:#133a22; }',
-      '.pos-pill-btn.active { background:#1d4a2e;border-color:#4dcc88; }',
+      '                 border:1px solid #33334a;border-radius:20px;background:#16161d;',
+      '                 color:#e8e8ed;cursor:pointer;font-size:12px;transition:background .15s; }',
+      '.pos-pill-btn:hover { background:rgba(108,159,255,0.16); }',
+      '.pos-pill-btn.active { background:rgba(95,208,138,0.24);border-color:#5fd08a; }',
       '.pos-pill-btn svg { flex-shrink:0; }',
 
       /* §P-8 scan overlay */
       '#pos-scan-overlay { display:none;position:fixed;inset:0;background:#000d;z-index:9500;',
       '                    flex-direction:column;align-items:center;justify-content:flex-start;padding-top:8vh; }',
       '#pos-scan-overlay.active { display:flex; }',
-      '#pos-scan-video  { width:min(340px,92vw);border:2px solid #2a6;border-radius:8px;background:#000; }',
-      '#pos-scan-input  { margin-top:12px;padding:8px 14px;border-radius:6px;border:1px solid #2a6;',
-      '                   background:#0b1f17;color:#cfe;font-size:16px;width:min(340px,92vw);text-align:center; }',
-      '#pos-scan-hint   { color:#8fd;font-size:13px;margin-top:6px; }',
-      '#pos-scan-total  { color:#4dcc88;font-size:26px;font-weight:bold;margin-top:10px;transition:opacity .25s; }',
+      '#pos-scan-video  { width:min(340px,92vw);border:2px solid #33334a;border-radius:8px;background:#000; }',
+      '#pos-scan-input  { margin-top:12px;padding:8px 14px;border-radius:6px;border:1px solid #33334a;',
+      '                   background:#16161d;color:#e8e8ed;font-size:16px;width:min(340px,92vw);text-align:center; }',
+      '#pos-scan-hint   { color:#cdd6e4;font-size:13px;margin-top:6px; }',
+      '#pos-scan-total  { color:#5fd08a;font-size:26px;font-weight:bold;margin-top:10px;transition:opacity .25s; }',
       '#pos-scan-total.flash { opacity:.1; }',
-      '#pos-scan-msg    { color:#fa8;font-size:13px;margin-top:4px;min-height:18px; }',
-      '#pos-scan-close  { margin-top:16px;padding:8px 24px;border-radius:6px;border:1px solid #2a6;',
-      '                   background:#0b1f17;color:#cfe;cursor:pointer;font-size:14px; }',
+      '#pos-scan-msg    { color:#ff6b6b;font-size:13px;margin-top:4px;min-height:18px; }',
+      '#pos-scan-close  { margin-top:16px;padding:8px 24px;border-radius:6px;border:1px solid #33334a;',
+      '                   background:#16161d;color:#e8e8ed;cursor:pointer;font-size:14px; }',
 
       /* §R2-1/§R2-2 top bar: [🛒 cart-toggle]  RUNNING TOTAL  …  [scan QR] */
       '#pos-top-bar     { display:flex;align-items:center;gap:8px;margin-bottom:8px;',
-      '                   padding:6px 12px;border:1px solid #2a6;border-radius:24px;background:#0b1f17; }',
-      '.pos-top-btn     { width:36px;height:36px;border-radius:50%;border:1px solid #2a6;background:#0d1f14;',
-      '                   color:#cfe;cursor:pointer;display:flex;align-items:center;justify-content:center;',
+      '                   padding:6px 12px;border:1px solid #33334a;border-radius:24px;background:#16161d; }',
+      '.pos-top-btn     { width:36px;height:36px;border-radius:50%;border:1px solid #33334a;background:#1a1a24;',
+      '                   color:#e8e8ed;cursor:pointer;display:flex;align-items:center;justify-content:center;',
       '                   padding:0;flex-shrink:0;transition:background .15s; }',
-      '.pos-top-btn:hover { background:#1a5040; }',
-      '#pos-top-total   { flex:1;text-align:center;font-size:24px;font-weight:bold;color:#4dcc88;letter-spacing:.5px; }',
+      '.pos-top-btn:hover { background:rgba(95,208,138,0.24); }',
+      '#pos-top-total   { flex:1;text-align:center;font-size:24px;font-weight:bold;color:#5fd08a;letter-spacing:.5px; }',
 
       /* §R2-3/§R2-4 the pay panel — RIMS RETIRED, draggable via the grab header */
       '#pos-float-panel { position:fixed;bottom:70px;right:20px;z-index:9500;',
       '                   width:min(340px,calc(100vw - 20px));',
-      '                   background:#0d1f14;border:1px solid #2a6;border-radius:12px;',
+      '                   background:#1a1a24;border:1px solid #33334a;border-radius:12px;',
       '                   display:none;flex-direction:column;box-shadow:0 8px 32px #000a; }',
       '#pos-float-panel.open { display:flex; }',
       '.pos-drag-hdr    { display:flex;align-items:center;gap:8px;padding:8px 12px;cursor:grab;',
-      '                   color:#8fd;font-size:13px;font-weight:bold;user-select:none;touch-action:none;',
-      '                   border-bottom:1px solid #1a3d24;border-radius:12px 12px 0 0;background:#0b1c14; }',
-      '.pos-drag-grip   { color:#456;font-size:14px;letter-spacing:-2px; }',
-      '.pos-section-hdr { padding:6px 12px 2px;color:#6a9;font-size:11px;font-weight:bold; }',
+      '                   color:#cdd6e4;font-size:13px;font-weight:bold;user-select:none;touch-action:none;',
+      '                   border-bottom:1px solid rgba(255,255,255,0.08);border-radius:12px 12px 0 0;background:#121218; }',
+      '.pos-drag-grip   { color:#55556a;font-size:14px;letter-spacing:-2px; }',
+      '.pos-section-hdr { padding:6px 12px 2px;color:#9aa4b8;font-size:11px;font-weight:bold; }',
       '.pos-items-body  { padding:0 12px 4px;overflow-y:auto;max-height:24vh; }',
       '#pos-float-cart  { margin-bottom:2px; }',
       '.pos-float-cart-line { display:flex;justify-content:space-between;',
-      '                       color:#cfe;font-size:12px;padding:3px 0;border-bottom:1px solid #112; }',
+      '                       color:#e8e8ed;font-size:12px;padding:3px 0;border-bottom:1px solid #22222e; }',
       '.pos-pay-row     { display:flex;justify-content:flex-end;padding:6px 12px; }',
-      '#pos-float-tender { width:52px;height:44px;border-radius:10px;border:1px solid #4dcc88;',
-      '                    background:#11331f;color:#4dcc88;cursor:pointer;',
+      '#pos-float-tender { width:52px;height:44px;border-radius:10px;border:1px solid #5fd08a;',
+      '                    background:rgba(95,208,138,0.12);color:#5fd08a;cursor:pointer;',
       '                    display:flex;align-items:center;justify-content:center;padding:0;transition:background .15s; }',
-      '#pos-float-tender:hover { background:#1a5040; }',
-      '#pos-float-bp    { box-sizing:border-box;margin:2px 12px;width:calc(100% - 24px);padding:5px;background:#071409;',
-      '                   border:1px solid #2a6;border-radius:6px;color:#cfe;font-size:12px; }',
-      '#pos-float-receipt { margin:2px 12px 4px;font-size:11px;color:#9cb;min-height:14px; }',
-      '.pos-repl-body   { padding:0 12px 8px;overflow-y:auto;max-height:20vh; }',
+      '#pos-float-tender:hover { background:rgba(95,208,138,0.24); }',
+      '#pos-float-bp    { box-sizing:border-box;margin:2px 12px;width:calc(100% - 24px);padding:5px;background:#121218;',
+      '                   border:1px solid #33334a;border-radius:6px;color:#e8e8ed;font-size:12px; }',
+      '#pos-float-receipt { margin:2px 12px 4px;font-size:11px;color:#9aa4b8;min-height:14px; }',
+      '.pos-repl-body   { padding:0 12px 8px;overflow-y:auto;max-height:22vh; }',
+      /* §T1.6 HMI — replenish rows are stylesheet classes now (were 11px inline cssText) */
+      '.pos-replenish-row { display:block;width:100%;text-align:left;margin:3px 0;padding:6px 8px;',
+      '                     border-radius:6px;border:1px solid #33334a;background:#16161d;',
+      '                     color:#e8e8ed;cursor:pointer;font-size:12px;line-height:1.35;transition:background .15s; }',
+      '.pos-replenish-row:hover { background:rgba(108,159,255,0.16); }',
+      '.pos-replenish-row.no-vendor { border-color:#555;background:#121218;color:#9aa4b8;cursor:default; }',
+      '.pos-replenish-row.no-vendor:hover { background:#121218; }',
       /* §D-3 ⋯ dock */
       '#pos-dock        { position:fixed;bottom:20px;right:20px;z-index:9550;',
       '                   display:flex;flex-direction:column;align-items:flex-end;gap:5px; }',
-      '#pos-dock-trigger{ width:36px;height:36px;border-radius:50%;border:1px solid #2a6;',
-      '                   background:#0b1f17;color:#cfe;cursor:pointer;font-size:18px;',
+      '#pos-dock-trigger{ width:36px;height:36px;border-radius:50%;border:1px solid #33334a;',
+      '                   background:#16161d;color:#e8e8ed;cursor:pointer;font-size:18px;',
       '                   display:flex;align-items:center;justify-content:center; }',
       '#pos-dock-items  { display:none;flex-direction:column;align-items:flex-end;gap:5px; }',
       '#pos-dock-items.open { display:flex; }',
-      '.pos-dock-item   { width:36px;height:36px;border-radius:50%;border:1px solid #2a6;',
-      '                   background:#0b1f17;color:#cfe;cursor:pointer;',
+      '.pos-dock-item   { width:36px;height:36px;border-radius:50%;border:1px solid #33334a;',
+      '                   background:#16161d;color:#e8e8ed;cursor:pointer;',
       '                   display:flex;align-items:center;justify-content:center;padding:0; }',
-      '.pos-dock-item:hover { background:#133a22; }',
+      '.pos-dock-item:hover { background:rgba(108,159,255,0.16); }',
       /* §R2-3 the receipt-preview modal is retired (single Pay icon completes directly) */
 
       /* U-3: import overlay */
@@ -133,52 +140,52 @@
       '                      flex-direction:column;align-items:center;justify-content:flex-start;',
       '                      padding-top:6vh;overflow-y:auto; }',
       '#pos-import-overlay.active { display:flex; }',
-      '#pos-import-card { background:#0d1f14;border:1px solid #2a6;border-radius:12px;padding:20px 24px;',
+      '#pos-import-card { background:#1a1a24;border:1px solid #33334a;border-radius:12px;padding:20px 24px;',
       '                   max-width:min(400px,96vw);width:100%;box-sizing:border-box; }',
-      '#pos-import-title { color:#8fd;font-size:14px;font-weight:bold;margin-bottom:14px;',
-      '                    border-bottom:1px solid #2a6;padding-bottom:8px; }',
+      '#pos-import-title { color:#cdd6e4;font-size:14px;font-weight:bold;margin-bottom:14px;',
+      '                    border-bottom:1px solid #33334a;padding-bottom:8px; }',
       '#pos-import-steps { display:flex;gap:4px;margin-bottom:14px; }',
       '.pos-import-step  { flex:1;padding:4px 2px;text-align:center;font-size:11px;',
-      '                    border-radius:4px;color:#6a9;border:1px solid #1a3d24; }',
-      '.pos-import-step.active { color:#4dcc88;border-color:#2a6;background:#071409; }',
-      '.pos-import-step.done { color:#3a7;background:#071409; }',
+      '                    border-radius:4px;color:#9aa4b8;border:1px solid rgba(255,255,255,0.08); }',
+      '.pos-import-step.active { color:#5fd08a;border-color:#33334a;background:#121218; }',
+      '.pos-import-step.done { color:#55556a;background:#121218; }',
       '#pos-import-body  { min-height:80px; }',
-      '#pos-import-video { width:min(300px,86vw);border:2px solid #2a6;border-radius:8px;background:#000;display:block; }',
+      '#pos-import-video { width:min(300px,86vw);border:2px solid #33334a;border-radius:8px;background:#000;display:block; }',
       '#pos-import-canvas { display:none; }',
       '.pos-import-btn   { display:inline-flex;align-items:center;gap:6px;padding:9px 20px;',
-      '                    border-radius:8px;border:1px solid #2a6;background:#0b1f17;',
-      '                    color:#cfe;cursor:pointer;font-size:13px;margin-top:8px; }',
+      '                    border-radius:8px;border:1px solid #33334a;background:#16161d;',
+      '                    color:#e8e8ed;cursor:pointer;font-size:13px;margin-top:8px; }',
       '.pos-import-btn:disabled { opacity:.4;cursor:default; }',
       '.pos-import-input { width:100%;box-sizing:border-box;padding:8px 12px;margin-top:8px;',
-      '                    border-radius:6px;border:1px solid #2a6;',
-      '                    background:#071409;color:#cfe;font-size:15px; }',
-      '#pos-import-hint  { color:#8fd;font-size:12px;margin-top:8px; }',
+      '                    border-radius:6px;border:1px solid #33334a;',
+      '                    background:#121218;color:#e8e8ed;font-size:15px; }',
+      '#pos-import-hint  { color:#cdd6e4;font-size:12px;margin-top:8px; }',
       '#pos-import-thumb { max-width:120px;max-height:120px;border-radius:6px;',
       '                    display:none;margin-top:8px;object-fit:cover; }',
-      '#pos-import-err   { color:#fa8;font-size:12px;margin-top:6px;min-height:16px; }',
+      '#pos-import-err   { color:#ff6b6b;font-size:12px;margin-top:6px;min-height:16px; }',
       '#pos-import-close { margin-top:12px;display:block;width:100%;padding:9px;border-radius:8px;',
-      '                    border:1px solid #556;background:#0b1209;color:#9cb;cursor:pointer;font-size:13px; }',
+      '                    border:1px solid #556;background:#16161d;color:#9aa4b8;cursor:pointer;font-size:13px; }',
 
       /* §P-11 receipt overlay */
       '#pos-receipt-overlay { display:none;position:fixed;inset:0;background:#0009;z-index:9600;',
       '                       align-items:center;justify-content:center; }',
       '#pos-receipt-overlay.active { display:flex; }',
-      '#pos-receipt-card { background:#0d1f14;border:1px solid #2a6;border-radius:12px;padding:20px 24px;',
+      '#pos-receipt-card { background:#1a1a24;border:1px solid #33334a;border-radius:12px;padding:20px 24px;',
       '                    max-width:min(400px,96vw);width:100%;max-height:90vh;overflow-y:auto; }',
-      '.pos-rcpt-header  { color:#8fd;font-size:13px;margin-bottom:10px;border-bottom:1px solid #2a6;padding-bottom:6px; }',
-      '.pos-rcpt-line    { display:flex;justify-content:space-between;color:#cfe;font-size:13px;padding:4px 0;border-bottom:1px solid #132; }',
+      '.pos-rcpt-header  { color:#cdd6e4;font-size:13px;margin-bottom:10px;border-bottom:1px solid #33334a;padding-bottom:6px; }',
+      '.pos-rcpt-line    { display:flex;justify-content:space-between;color:#e8e8ed;font-size:13px;padding:4px 0;border-bottom:1px solid #22222e; }',
       '.pos-rcpt-line.last { transition:opacity .4s; }',
-      '#pos-rcpt-total   { font-size:30px;font-weight:bold;color:#4dcc88;text-align:center;margin:14px 0 6px; }',
+      '#pos-rcpt-total   { font-size:30px;font-weight:bold;color:#5fd08a;text-align:center;margin:14px 0 6px; }',
       '#pos-rcpt-qr      { text-align:center;margin:10px 0; }',
       '#pos-rcpt-qr canvas,#pos-rcpt-qr svg,#pos-rcpt-qr img { display:block;margin:0 auto; }',
       /* U-4: DEMO payment QR styles */
-      '#pos-pay-qr       { text-align:center;margin:14px 0 6px;padding-top:12px;border-top:1px solid #2a6; }',
+      '#pos-pay-qr       { text-align:center;margin:14px 0 6px;padding-top:12px;border-top:1px solid #33334a; }',
       '#pos-pay-qr-label { font-weight:bold;color:#fa0;font-size:13px;margin-bottom:6px; }',
       '#pos-pay-qr-wrap  { margin:6px 0; }',
       '#pos-pay-qr-wrap canvas,#pos-pay-qr-wrap svg,#pos-pay-qr-wrap img { display:block;margin:0 auto; }',
-      '#pos-pay-qr-caption { color:#8fd;font-size:11px;margin-top:4px; }',
+      '#pos-pay-qr-caption { color:#cdd6e4;font-size:11px;margin-top:4px; }',
       '#pos-receipt-close{ display:block;width:100%;margin-top:14px;padding:10px;border-radius:8px;',
-      '                    border:1px solid #2a6;background:#134;color:#cfe;cursor:pointer;font-size:14px; }'
+      '                    border:1px solid #33334a;background:rgba(108,159,255,0.24);color:#e8e8ed;cursor:pointer;font-size:14px; }'
     ].join('\n');
     document.head.appendChild(s);
   }
@@ -630,9 +637,8 @@
         var row = el('button', 'pos-replenish-row',
           '· ' + (nm ? nm.name : s.m_product_id) + ' → order ' + s.qtytoorder +
           ' (wh ' + s.m_warehouse_id + ')' + (vendor ? ' ← ' + vendor.c_bpartner_id : ' [no vendor]'));
-        row.style.cssText = 'display:block;width:100%;text-align:left;margin:2px 0;padding:4px 6px;border-radius:4px;' +
-          'border:1px solid ' + (vendor ? '#2a6' : '#553') + ';background:' + (vendor ? '#0b1f17' : '#1a1209') +
-          ';color:' + (vendor ? '#cfe' : '#987') + ';cursor:' + (vendor ? 'pointer' : 'default') + ';font-size:11px';
+        // §T1.6 HMI — class-styled rows (stylesheet above), vendor-less rows visibly inert
+        if (!vendor) row.classList.add('no-vendor');
         if (vendor) {
           row.addEventListener('click', function () {
             var enriched = [Object.assign({}, s, { c_bpartner_id: vendor.c_bpartner_id, pricepo: vendor.pricepo })];
@@ -691,7 +697,7 @@
           var qr = window.qrcode(10, 'M'); qr.addData(rcptUrl); qr.make(); ov.qrEl.innerHTML = qr.createSvgTag(3, 2);
         } catch (e) { ov.qrEl.textContent = rcptUrl; }
       } else {
-        var a = document.createElement('a'); a.href = rcptUrl; a.style.cssText = 'color:#4dcc88;font-size:11px;word-break:break-all'; a.textContent = rcptUrl;
+        var a = document.createElement('a'); a.href = rcptUrl; a.style.cssText = 'color:#5fd08a;font-size:11px;word-break:break-all'; a.textContent = rcptUrl;
         ov.qrEl.appendChild(a);
       }
       console.log('§POS-RECEIPT orderId=' + orderId + ' grandTotal=' + grandTotal + ' chainOk=' + chainOk + ' linesN=' + saleCart.length);
@@ -1038,7 +1044,7 @@
         barcodeInput.placeholder = 'Barcode / UPC — scan or type + Enter';
         ie.body.appendChild(barcodeInput);
 
-        var scanHint = _buildDyn('div', ''); scanHint.style.cssText = 'color:#8fd;font-size:11px;margin-top:6px;';
+        var scanHint = _buildDyn('div', ''); scanHint.style.cssText = 'color:#cdd6e4;font-size:11px;margin-top:6px;';
         var hasBD = typeof BarcodeDetector !== 'undefined';
         if (hasBD) {
           scanHint.textContent = 'BarcodeDetector active — point camera at barcode OR type above.';
@@ -1282,7 +1288,7 @@
 
     // station info inside the items body (visible when items drawer is open)
     var stationInfo = document.createElement('div');
-    stationInfo.style.cssText = 'color:#6a9;font-size:11px;margin-bottom:6px;padding-bottom:4px;border-bottom:1px solid #1a3d24';
+    stationInfo.style.cssText = 'color:#9aa4b8;font-size:11px;margin-bottom:6px;padding-bottom:4px;border-bottom:1px solid rgba(255,255,255,0.08)';
     stationInfo.textContent = pos.name + ' · wh ' + pos.m_warehouse_id + ' · pricelist v' + plv.v;
     itemsBody.insertBefore(stationInfo, cartBox);
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v756';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v757';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -102,6 +102,8 @@ const PRECACHE_ASSETS = [
   'pos_core.js',       // POS_ADDON_SPEC §P-1..§P-4 — POS fold glue (window.POSCore), == bim-compiler build/erp source
   'img_store.js',      // POS_KILLER_DEMO E-3 — device-local images folder (IDB, window.ImgStore), == bim-compiler build/erp source
   'pos_lens.js',       // POS_ADDON_SPEC — dumb-terminal POS lens (window.PosLens): record/pay/SEND, zero client state
+  'kitchen_core.js',   // §T2-SPEC Kitchen Display fold (window.KitchenCore, W-KDS-QUEUE), == bim-compiler build/erp source
+  'kitchen_lens.js',   // §T2-SPEC Kitchen Display lens (window.KitchenLens): fold-rendered tickets, Serve = one signed group
   'sfx.json',          // §R2-AUDIO — ERP-surface SFX config (subtle POS earcons; sfx.js itself rides the viewer scope)
   'ninja_excel.js',   // NINJA EXCEL — Excel-as-report-binder engine (read/gate/run/verify; == bim-compiler build/erp)
   'ninja_rule.js',    // NINJA EXCEL — RULE tier: business phrase → SQL candidates from the AD dictionary (§7)


### PR DESCRIPTION
Implements `RESUME_POS_KITCHEN_EINVOICE_OPS_PANELS.md` §T2-SPEC (Kitchen Display) + §T1.6-SPEC (POS HMI restyle) — the two Fable5-assigned threads of the 2026-07-03 research pass.

## Kitchen Display (new)
- **kitchen_core.js** — the queue is a FOLD over the op log: open `C-` shipments (deliver-later sales born DR), oldest-first FIFO; serve rides pos_core's own `completeShipmentOps` (confirm-gate + double-serve FSM intact). **Zero new business verbs.** Source of truth mirrored to bim-compiler `build/erp/`.
- **kitchen_lens.js** — dumb-terminal ticket cards (fold(opDb) ∪ §S-2 seed selector; product/partner names JOINed per the pos_lens precedent); Serve = ONE signed group through `kernel_ops.commitGroup`.
- Pill `kitchen` (showWhen:pos-station) + `openKitchenFor`; sw **v757**.

## POS HMI restyle (§THREAD 1 step 6 — mechanical, zero logic)
Green-on-black → the app's own dark-slate/blue baseline (every value extracted from erp.html/idmp_pills/idempiere.html — money keeps green via the app's is-balanced `#5fd08a`). Replenish rows: 11px inline cssText → stylesheet classes, 12px + spacing. IDs/§-tags untouched.

## Witnesses
- **W-KDS-QUEUE 12/12** headless (`bim-compiler scripts/poc_kitchen_queue.js`): fold correctness, WR-sales-never-queue, serve→CO+chain, confirm-gate, double-serve refused, empty-log-empty-queue, FIFO.
- **W-KDS-LIVE PASS** real-user-path chromium (`poc_kds_live.js`): login → gated pill → empty-honest → POS ring → deliver-later → ticket queues with ordered==shipped==shown qty maths → Serve (chainOk=Y) → kitchen empties.
- **W-POS-LIVE PASS** regression after restyle (16 tiles, signed sale, replenish fold, §POS-CENT balanced).
- Screenshots eyeballed (POS + ticket card).

Thread 1 steps 1-5 (staged replenishment review) = Opus lane, not here. Thread 3 (E-Invoice) stays research-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)