### PR TITLE
feat(hba): §HBA-ERP-GOV Stage 2 — compile-layer reads real seeded AD rows (W-HBA-ERP-GOVERNED 9/9)

### DIFF
--- a/hr_bim_asset/ad_attendance.js
+++ b/hr_bim_asset/ad_attendance.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — ATTENDANCE COMPILED ONTO THE NATIVE (Ninja-staged) C_Attendance CHILD TABLE
+//   (bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-ATTENDANCE, Stage 2). This module's
+//   whole job is the gap flagged in §EVIDENCE point 3: resolve attendance.js's bare `EMP-n`/`EMP00n` ids and
+//   room guids to the REAL c_bpartner_id / m_locator_id seeded in Stage 1, so a presence row STOPS being a
+//   self-signed op keyed by a bare string and BECOMES a real AD child row that JOINs
+//   C_Attendance→HR_Process→C_BPartner→M_Locator→M_Warehouse (the §DESIGN-ATTENDANCE InfoWindow lens).
+//
+//   NON-INVENT GATE (mirrors ad_tenancy.compileBuilding's `skipped[]` discipline): a session whose employee
+//   or zone does NOT resolve to a real seeded id is SKIPPED into `skipped[]` with a reason — NEVER given a
+//   fabricated FK. The row builder is column-pure: it emits ONLY columns that exist on the seeded physical
+//   C_Attendance table (seed_hba_erp.js DDL.C_Attendance — dumped live from the Ninja-staged AD_Column set);
+//   the AD system columns (AD_Client_ID/AD_Org_ID/IsActive/Created…) are the PERSISTER's job, exactly as
+//   ad_payroll.js's hrIns and ad_tenancy.js's builders leave them (see those headers).
+//
+//   HONEST-OPEN preserved (attendance.js's own §SLICE-1 contract): a session with no check-out is OPEN —
+//   CheckOutTime AND Qty stay NULL (no fabricated finish/hours). Qty = the REAL derived hours (attendance.js
+//   _hoursBetween over the real in/out ts), mirroring hr_movement.qty; never an independently-stored number.
+//
+//   SOURCE = attendance.js's already-witnessed `sessions(log, period)` reader (UNCHANGED — no re-implementation
+//   of the fold). This module takes those sessions + three injected resolution maps (processId, partnerMap,
+//   locatorMap) and produces the child rows. The maps come from the REAL seeded rows at compile time (the
+//   viewer's erpQuery seam / a witness's injected ad_seed.db handle) — so every emitted FK traces to a queried
+//   row, per the §CONVENTION "any info panel in BIM has to be just a lens from such source."
+'use strict';
+(function () {
+var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
+
+// ONE C_Attendance child row for ONE presence session. Column-pure: keys are a SUBSET of the seeded physical
+// table's columns (the non-invent gate the witness enforces). `session` = an attendance.js session
+// ({employee, zone, in, out, hours, open}); the caller has already resolved employee→c_bpartner_id and
+// zone→m_locator_id (both REAL seeded ids) and supplies the parent hr_process_id + a seedId sequencer.
+function toAttendanceRow(session, hr_process_id, c_bpartner_id, m_locator_id, seedId) {
+  if (!session || c_bpartner_id == null || m_locator_id == null) return null;
+  var open = !!session.open;
+  return { C_Attendance_ID: seedId ? seedId() : 1, HR_Process_ID: hr_process_id != null ? hr_process_id : null,
+    C_BPartner_ID: c_bpartner_id, M_Locator_ID: m_locator_id,
+    ServiceDate: session.in ? String(session.in).slice(0, 10) : null,
+    CheckInTime: session.in || null,
+    CheckOutTime: open ? null : (session.out || null),      // OPEN → honest NULL (no fabricated finish)
+    Qty: open ? null : (session.hours != null ? session.hours : null),   // hours DERIVED from real in/out; open → NULL
+    Description: open ? 'demo session (open — no fabricated finish)' : 'demo session' };
+}
+
+// compile a WHOLE period's presence sessions into native C_Attendance rows in one pass →
+// {rows, skipped, _watermark}. `opts` supplies the REAL resolution:
+//   opts.processId   — the parent HR_Process this attendance period folds under (real seeded hr_process_id)
+//   opts.partnerMap  — { <employee id> : c_bpartner_id }  (real seeded C_BPartner ids, e.g. EMP001→1001)
+//   opts.locatorMap  — { <zone guid>   : m_locator_id }   (real seeded M_Locator ids, keyed by room guid)
+// A session whose employee OR zone is not in the maps is SKIPPED (never a fabricated FK), captured in
+// `skipped[]` with a reason — same non-invent contract as ad_tenancy.compileBuilding. Deterministic:
+// C_Attendance_ID is a 1-based sequence over the accepted rows (no Date.now/random).
+function compileAttendance(sessions, opts) {
+  sessions = sessions || []; opts = opts || {};
+  var partnerMap = opts.partnerMap || {}, locatorMap = opts.locatorMap || {}, processId = (opts.processId != null ? opts.processId : null);
+  var seq = 0; function seedId() { return ++seq; }
+  var rows = [], skipped = [];
+  sessions.forEach(function (s) {
+    var bp = partnerMap[s.employee], loc = locatorMap[s.zone];
+    if (bp == null) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'employee id resolves to no real C_BPartner' }); return; }
+    if (loc == null) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'zone guid resolves to no real M_Locator' }); return; }
+    rows.push(toAttendanceRow(s, processId, bp, loc, seedId));
+  });
+  return W ? W.stamp({ rows: rows, skipped: skipped }, opts.locale || 'en') : { rows: rows, skipped: skipped };
+}
+
+// build the two resolution maps from injected real rows (the viewer's erpQuery / a witness's ad_seed.db).
+// partnerMap: employee code → C_BPartner_ID via the AD_User contact (Name==code) → its C_BPartner_ID; falls
+// back to a bare {code: bp} table when the caller already holds it. locatorMap: room guid → M_Locator_ID via
+// M_Locator.Value==guid. Both are pure lookups over rows the CALLER queried — this module never touches a DB.
+function partnerMapFromUsers(userRows) {
+  var m = {}; (userRows || []).forEach(function (u) { if (u && u.name != null && u.c_bpartner_id != null) m[u.name] = u.c_bpartner_id; });
+  return m;
+}
+function locatorMapFromLocators(locatorRows) {
+  var m = {}; (locatorRows || []).forEach(function (l) { if (l && l.value != null && l.m_locator_id != null) m[l.value] = l.m_locator_id; });
+  return m;
+}
+
+var AD = { toAttendanceRow: toAttendanceRow, compileAttendance: compileAttendance,
+  partnerMapFromUsers: partnerMapFromUsers, locatorMapFromLocators: locatorMapFromLocators };
+if (typeof module === 'object' && module.exports) module.exports = AD;
+else (typeof self !== 'undefined' ? self : this).HbaAdAttendance = AD;
+})();

--- a/hr_bim_asset/ad_bom.js
+++ b/hr_bim_asset/ad_bom.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — BIM RECIPE TREE COMPILED ONTO NATIVE iDempiere MRP `pp_product_bom`/`pp_product_bomline`
+//   (bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE, Stage 2). The BOM PRINCIPLE
+//   (one parent, N children each with a quantity, recursive) projected onto the REAL, live MRP pair — the
+//   cleanest AD fit found across the whole thread (pp_product_bom carries NO doc-lifecycle columns, so a static
+//   BIM recipe needs no workflow/approval handling — §DESIGN-BOM-COMPILE finding).
+//
+//   ⚠ RUNTIME-SOURCE GAP (honest, flagged not hidden): the SOURCE this compiles FROM — m_bom/m_bom_line
+//   (library/schema_snapshot_bom.sql, walked by DAGCompiler/BOMWalker.java) — is **bim-compiler's** transient
+//   Java pipeline output (library/*_BOM.db, deleted every run by scripts/rebuild_erp.sh). It is NOT present
+//   viewer-side in bim-ootb (the streamed building DBs carry spatial_structure/elements_meta/element_transforms
+//   but NO bom table — verified live 2026-07-03). So this module is the PURE, WITNESSED TRANSFORM (proven
+//   against a real-SHAPED fixture in tests/witness_ad_bom.js); LIVE viewer wiring awaits a viewer-side BOM
+//   source (either bim-compiler emitting a persisted *_BOM.db the viewer can fetch, or the compile running
+//   bim-compiler-side). Do NOT fabricate a BOM source to make it "live" — that would violate the PRIME RULE.
+//
+//   ⚠ TWO "M_Product" LANDMINE (load-bearing, §DESIGN-BOM-COMPILE item ⚠): m_bom_line.child_product_id is a
+//   TEXT id into library/component_library.db's OWN internal M_Product catalog — NOT the real AD dictionary's
+//   integer m_product_id that pp_product_bomline FKs into. The caller MUST pass a `productResolver` that maps
+//   the BIM-catalog TEXT id → the real AD m_product_id already minted by ProductRegistrar.java / ad_tenancy.js
+//   toProductRow for that same guid. This module NEVER mints a competing Product identity; a line whose child
+//   does not resolve is SKIPPED (non-invent), never given a fabricated FK.
+//
+//   ⚠ bomtype='B' (BIM) — §DESIGN-BOM-COMPILE item 1: pp_product_bom.BOMType is AD_Ref_List 347 ("M_BOM Type").
+//   'B'="BIM" is NOT a stock value (A/C/F/K/M/O/P/R/S) — it must be added as an AD_Ref_List row (a Stage-1 SEED
+//   step, the same "extend the dictionary with a missing master value" idiom as C_UOM/M_Warehouse). That seed
+//   is NOT yet done (flagged for whoever seeds the BOM source). Accepted tradeoff: a 'B' BOM is invisible to
+//   native costing/MRP/production-explosion (which hardcode 'A') — correct for a structural/spatial BIM recipe.
+'use strict';
+(function () {
+var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
+
+var BOM_TYPE_BIM = 'B';                 // the BIM bomtype (AD_Ref_List extension — see header)
+// bom_type (BUILDING/FLOOR/ROOM/SET/ITEM, m_bom CHECK) → bomuse is a free classification; carried as the
+// business bom_type via `value`/`name`; bomuse defaults to 'M' (Master) — the only universally-safe stock value.
+var BOM_USE_MASTER = 'M';
+
+// ONE pp_product_bom HEADER row for a BOM node. Column-pure (keys ⊆ real pp_product_bom columns — the witness
+// enforces the subset). `m_product_id` = the PARENT element's REAL AD Product (resolved by the caller, same
+// identity ad_tenancy.js toProductRow mints per guid). Geometry stays OUT of the row (no AD column) — it rides
+// the view-trace wrapper compileBom returns, never forced into a fabricated column.
+function toBomRow(node, m_product_id, seedId) {
+  if (!node || m_product_id == null) return null;
+  return { pp_product_bom_id: seedId ? seedId() : 1, m_product_id: m_product_id,
+    value: node.bom_id != null ? String(node.bom_id) : null,
+    name: node.bom_name || (node.bom_id != null ? String(node.bom_id) : null),
+    bomtype: BOM_TYPE_BIM, bomuse: BOM_USE_MASTER,
+    c_uom_id: (node.c_uom_id != null ? node.c_uom_id : null) };
+}
+
+// ONE pp_product_bomline CHILD row. `child_m_product_id` = the CHILD element's REAL AD Product (resolved).
+// `qtybom` = the recipe quantity (m_bom_line.qty); `line` = the sequence ordinal. componenttype mapped from
+// the source component_type when present (else left null — never guessed).
+function toBomLineRow(line, pp_product_bom_id, child_m_product_id, seedId, seq) {
+  if (!line || pp_product_bom_id == null || child_m_product_id == null) return null;
+  return { pp_product_bomline_id: seedId ? seedId() : 1, pp_product_bom_id: pp_product_bom_id,
+    m_product_id: child_m_product_id, qtybom: (line.qty != null ? line.qty : 1),
+    line: (seq != null ? seq * 10 : 10),
+    componenttype: (line.component_type != null ? line.component_type : null) };
+}
+
+// compile a FLAT, parent-tagged BOM node list (the BOMWalker "flattened with parent context" shape — each node
+// = one BOM header + its immediate lines) onto native pp_product_bom + pp_product_bomline rows.
+//   nodes: [{ bom_id, bom_name, bom_type, product_ref, c_uom_id?,
+//             origin_x/y/z?, aabb_width/depth/height_mm?,                        (BIM-only geometry, view-trace)
+//             lines: [{ child_product_id, qty, role?, component_type?, dx?,dy?,dz?, rotation_rule?, ... }] }]
+//   productResolver: (ref) => real AD m_product_id | null   (maps BIM-catalog TEXT id/guid → real AD id)
+// Returns { headers, lines, skipped, geometry, _watermark }. `headers`/`lines` are column-pure AD rows;
+// `geometry` is the [{pp_product_bom_id, origin/aabb/placement…}] view-trace wrapper (the BIM facts with NO AD
+// column, kept honestly beside the rows, never fabricated into a column). A node whose PARENT product does not
+// resolve, or a line whose CHILD product does not resolve, is SKIPPED with a reason (non-invent).
+function compileBom(nodes, productResolver, opts) {
+  nodes = nodes || []; opts = opts || {};
+  var resolve = (typeof productResolver === 'function') ? productResolver : function () { return null; };
+  var seqH = 0, seqL = 0;
+  var seedH = function () { return ++seqH; }, seedL = function () { return ++seqL; };
+  var headers = [], lines = [], skipped = [], geometry = [];
+  nodes.forEach(function (node) {
+    var parentId = resolve(node.product_ref != null ? node.product_ref : node.bom_id);
+    if (parentId == null) { skipped.push({ bom_id: node.bom_id, kind: 'header', reason: 'parent product_ref resolves to no real AD M_Product' }); return; }
+    var header = toBomRow(node, parentId, seedH); headers.push(header);
+    // BIM-only geometry — no AD column exists; carried as a view-trace wrapper keyed by the header PK.
+    geometry.push({ pp_product_bom_id: header.pp_product_bom_id, bom_type: node.bom_type || null,
+      target_ifc_class: node.target_ifc_class || null,
+      origin_x: node.origin_x, origin_y: node.origin_y, origin_z: node.origin_z,
+      aabb_width_mm: node.aabb_width_mm, aabb_depth_mm: node.aabb_depth_mm, aabb_height_mm: node.aabb_height_mm });
+    (node.lines || []).forEach(function (ln, i) {
+      var childId = resolve(ln.child_product_id);
+      if (childId == null) { skipped.push({ bom_id: node.bom_id, child: ln.child_product_id, kind: 'line', reason: 'child_product_id resolves to no real AD M_Product' }); return; }
+      lines.push(toBomLineRow(ln, header.pp_product_bom_id, childId, seedL, i + 1));
+    });
+  });
+  var out = { headers: headers, lines: lines, skipped: skipped, geometry: geometry };
+  return W ? W.stamp(out, opts.locale || 'en') : out;
+}
+
+var AD = { BOM_TYPE_BIM: BOM_TYPE_BIM, BOM_USE_MASTER: BOM_USE_MASTER,
+  toBomRow: toBomRow, toBomLineRow: toBomLineRow, compileBom: compileBom };
+if (typeof module === 'object' && module.exports) module.exports = AD;
+else (typeof self !== 'undefined' ? self : this).HbaAdBom = AD;
+})();

--- a/hr_bim_asset/ad_payroll.js
+++ b/hr_bim_asset/ad_payroll.js
@@ -171,12 +171,38 @@ function payslip(hr_movement, c_bpartner_id, locale) {
   return W ? W.stamp(out, locale || 'en') : out;
 }
 
-// demonstrator payroll spec for the P7 viewer pane — the SAME EMP001/EMP002 identities+concepts already
-// accepted by witness_ad_payroll.js AD1 (EMP001 gross=5200/net=4234) — reused, not re-invented. Payroll
-// identity (c_bpartner_id) has no spatial binding to check (unlike Occupancy/Asset), so this seeds
-// unconditionally rather than gating on a guid resolving — the honesty gate here is "reuse the accepted
-// numbers", not "resolve to a mesh".
-function demoSpec() {
+// ---- §STAGE2 — demoSpec resolves its employee IDENTITIES from the REAL seeded rows -----------------------
+// RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2: `demoSpec` gains an optional `erpQuery` (a SYNC ad_seed.db
+// reader — the viewer's A.erpQuery seam / a witness's injected handle). When present it JOINs the REAL seeded
+// HR_Employee⋈C_BPartner rows (Stage 1 §3/§4) so `c_bpartner_id`/`name` TRACE TO A QUERIED ROW instead of a
+// literal. The pay-RULE inputs (`base`/`conceptIds`) are NOT employee-master columns — they stay the demo
+// payroll config (already flagged demo/unsourced, §RESEARCH GATE) keyed by the real employee code. The
+// resulting run is numerically IDENTICAL to the seeded HR_Movement rows (proven equal by W-HBA-ERP-SEED
+// PAYSLIP-DB==ENGINE) — so the displayed payslip already traces to the seeded rows; this closes the identity
+// half. No db / no rows → the prior literal (all existing witnesses call demoSpec() argless → unchanged).
+var DEMO_PAY_CONFIG = {   // demo pay-rule inputs, keyed by employee code (base salary + which concepts apply)
+  EMP001: { base: 5000, conceptIds: ['BASE', 'ALLOWANCE', 'EPF', 'PCB'] },
+  EMP002: { base: 3000, conceptIds: ['BASE', 'ALLOWANCE', 'EPF'] }
+};
+function _num2(v) { return (v == null) ? v : Number(v); }
+function _employeesFromDb(erpQuery) {
+  if (typeof erpQuery !== 'function') return null;
+  try {
+    var r = erpQuery('SELECT e.HR_Employee_ID AS id, e.Code AS code, e.Name AS name, e.C_BPartner_ID AS c_bpartner_id '
+      + 'FROM HR_Employee e WHERE e.IsActive=? ORDER BY e.HR_Employee_ID', ['Y']);
+    if (!r || !r.length) return null;
+    return r.map(function (row) { return { id: _num2(row.id), code: row.code, name: row.name, c_bpartner_id: _num2(row.c_bpartner_id) }; });
+  } catch (e) { return null; }
+}
+function demoSpec(erpQuery) {
+  var emps = _employeesFromDb(erpQuery);
+  if (emps) {
+    return { period: '2026-06', actor: 'hba', locale: 'en', _governed: true,
+      employees: emps.map(function (e) {
+        var cfg = DEMO_PAY_CONFIG[e.code] || DEMO_PAY_CONFIG[e.name] || { base: 0, conceptIds: ['BASE'] };
+        return { c_bpartner_id: e.c_bpartner_id, name: e.name || e.code, base: cfg.base, conceptIds: cfg.conceptIds };
+      }) };
+  }
   return { period: '2026-06', actor: 'hba', locale: 'en', employees: [
     { c_bpartner_id: 1001, name: 'EMP001', base: 5000, conceptIds: ['BASE', 'ALLOWANCE', 'EPF', 'PCB'] },
     { c_bpartner_id: 1002, name: 'EMP002', base: 3000, conceptIds: ['BASE', 'ALLOWANCE', 'EPF'] }

--- a/hr_bim_asset/ad_tenancy.js
+++ b/hr_bim_asset/ad_tenancy.js
@@ -57,15 +57,32 @@ function propertyUnits(m_warehouse_id, locatorRows) {
 (function () {
 var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
 
+// §STAGE2 — MATCH-OR-CREATE against the REAL seeded AD rows (RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2,
+// §IMPLICATIONS point 2 "identity-key stability is the crux design risk"). `erpQuery(sql, params)` is a SYNC
+// reader over the loaded ad_seed.db (the viewer's A.erpQuery seam / a witness's injected handle) returning an
+// array of row-objects; ABSENT (undefined/null) → every builder falls back to the prior deterministic mint, so
+// every existing node witness (which passes no erpQuery) is byte-for-byte unchanged. `_one` returns the first
+// matched row or null, never throws (a missing table / bad db degrades to the mint path, honest no-op).
+function _one(erpQuery, sql, params) {
+  if (typeof erpQuery !== 'function') return null;
+  try { var r = erpQuery(sql, params || []); return (r && r.length) ? r[0] : null; } catch (e) { return null; }
+}
+function _num(v) { return (v == null) ? v : Number(v); }
+
 // ---- native C_SubscriptionType rows — ONE demo cadence per profile, both real columns only ------------------
 var SUBSCRIPTION_TYPES = {
   MONTHLY_RENT: { c_subscriptiontype_id: 1, name: 'Monthly Rent', description: 'Residential/commercial unit lease, billed monthly', frequencytype: 'M', frequency: 1 },
   QUARTERLY_STRATA_FEE: { c_subscriptiontype_id: 2, name: 'Quarterly Strata Fee', description: 'Owner maintenance/sinking-fund charge, billed quarterly', frequencytype: 'M', frequency: 3 }
 };
 
-// ONE M_Warehouse row per building — new, since a demo building like HHS_Office_Federated has none yet
-// (unlike GardenWorld/Terminal, which already have real M_Warehouse rows in ad_full.db).
-function toWarehouseRow(buildingName, seedId) {
+// ONE M_Warehouse row per building. §STAGE2 — MATCH-OR-CREATE by Value: when `erpQuery` is present, resolve
+// the REAL seeded warehouse row (Q1 pinned Value='HHS_Office_Federated' at id 990000, seed_hba_erp.js §1) so
+// the building's identity is the DURABLE seeded id, NOT a blind `1` re-minted every compile (the §IMPLICATIONS
+// pt-2 determinism landmine — GeoMapping W-GEOMAP-TIER1 discipline). No match (a building not yet seeded, or no
+// db loaded) → the prior deterministic mint, unchanged. Value is the match key exactly as pinned in Stage 1.
+function toWarehouseRow(buildingName, seedId, erpQuery) {
+  var hit = _one(erpQuery, 'SELECT M_Warehouse_ID AS id, Value AS value, Name AS name FROM M_Warehouse WHERE Value=?', [buildingName]);
+  if (hit) return { m_warehouse_id: _num(hit.id), value: hit.value, name: hit.name || hit.value };
   return { m_warehouse_id: seedId ? seedId() : 1, value: buildingName, name: buildingName };
 }
 
@@ -77,15 +94,24 @@ function toWarehouseRow(buildingName, seedId) {
 // ⚠ MLocator.get() coalesces by (warehouse,X,Y,Z) — rooms on one storey share an ABL address, so locator
 // identity rides on value=guid; never create/look up room locators via the combination. room = { guid, name,
 // storey, block? } (fixture shape).
-function toLocatorRow(room, m_warehouse_id, seedId) {
+function toLocatorRow(room, m_warehouse_id, seedId, erpQuery) {
   if (!room || !room.guid) return null;
-  return { m_locator_id: seedId ? seedId() : 1, m_warehouse_id: m_warehouse_id, value: room.guid,
+  // §STAGE2 — resolve the REAL seeded M_Locator for this room (seed_hba_erp.js §2 persisted one per HHS room,
+  // keyed Value=guid under the warehouse) so the room's spatial address is the durable seeded id; else mint.
+  var hit = _one(erpQuery, 'SELECT M_Locator_ID AS id FROM M_Locator WHERE M_Warehouse_ID=? AND Value=?', [m_warehouse_id, room.guid]);
+  var id = hit ? _num(hit.id) : (seedId ? seedId() : 1);
+  return { m_locator_id: id, m_warehouse_id: m_warehouse_id, value: room.guid,
     x: room.block || '0', y: '0', z: room.storey || '0', isdefault: 'N' };
 }
 
-// the leasable unit itself — an M_Product row whose m_locator_id names its real room/zone.
-function toProductRow(room, m_locator_id, seedId) {
+// the leasable unit itself — an M_Product row whose m_locator_id names its real room/zone. §STAGE2 — reuse a
+// REAL seeded M_Product row (Value=guid) when one exists; else mint (Stage 1 seeded no per-room Products, so
+// this ordinarily mints a deterministic compile-projection id over the resolved locator — honest, not a
+// fabricated master).
+function toProductRow(room, m_locator_id, seedId, erpQuery) {
   if (!room || !room.guid) return null;
+  var hit = _one(erpQuery, 'SELECT M_Product_ID AS id, Name AS name FROM M_Product WHERE Value=?', [room.guid]);
+  if (hit) return { m_product_id: _num(hit.id), value: room.guid, name: hit.name || room.name || room.guid, m_locator_id: m_locator_id };
   return { m_product_id: seedId ? seedId() : 1, value: room.guid, name: room.name || room.guid, m_locator_id: m_locator_id };
 }
 
@@ -119,16 +145,17 @@ function toUserRow(person) {
 // a locator for it) into `skipped[]` with a reason, not silently dropped. `units` is DERIVED via propertyUnits
 // (never a stored duplicate of the room count). Subscriptions come back WRAPPED {row, unit_guid, kind, storey}
 // — `row` stays column-pure AD; the wrapper is caller/view trace only, never written back as an AD column.
-function compileBuilding(buildingName, rooms, leases, strata) {
-  rooms = rooms || []; leases = leases || []; strata = strata || [];
+function compileBuilding(buildingName, rooms, leases, strata, opts) {
+  rooms = rooms || []; leases = leases || []; strata = strata || []; opts = opts || {};
+  var erpQuery = opts.erpQuery;   // §STAGE2 — SYNC ad_seed.db reader (viewer A.erpQuery / witness handle) or null
   var seq = { loc: 0, prod: 0, sub: 0 };
   var seedLoc = function () { return ++seq.loc; }, seedProd = function () { return ++seq.prod; }, seedSub = function () { return ++seq.sub; };
-  var warehouse = toWarehouseRow(buildingName, function () { return 1; });
+  var warehouse = toWarehouseRow(buildingName, function () { return 1; }, erpQuery);
   var byGuid = {}; rooms.forEach(function (r) { byGuid[r.guid] = r; });
   var locators = [], products = [], productIdByGuid = {};
   rooms.forEach(function (r) {
-    var loc = toLocatorRow(r, warehouse.m_warehouse_id, seedLoc); locators.push(loc);
-    var prod = toProductRow(r, loc.m_locator_id, seedProd); products.push(prod); productIdByGuid[r.guid] = prod.m_product_id;
+    var loc = toLocatorRow(r, warehouse.m_warehouse_id, seedLoc, erpQuery); locators.push(loc);
+    var prod = toProductRow(r, loc.m_locator_id, seedProd, erpQuery); products.push(prod); productIdByGuid[r.guid] = prod.m_product_id;
   });
   var subscriptions = [], skipped = [];
   function compileCharge(record, kind, subType, refField, partyField) {

--- a/hr_bim_asset/models.js
+++ b/hr_bim_asset/models.js
@@ -120,12 +120,39 @@ function toAssetRow(asset) {
 
 function model(name) { return MODELS[name]; }
 function records(name) { return (MODELS[name] || {}).records || []; }
+
+// §STAGE2 (RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2) — resolve an Official contact from the REAL seeded
+// AD_User row when an ad_seed.db reader (`erpQuery`, the viewer's A.erpQuery seam / a witness handle) is
+// supplied. Stage 1 seeded AD_User 1/2 for EMP001/EMP002 with real EMail/Phone/C_BPartner_ID (seed §3); the
+// tenant/overflow contacts (BP-TEN-*, EMP-1..EMP-4) have NO real AD_User by design (the accepted 2-person
+// tradeoff), so those honestly fall back to the literal record. This is a DB-first-per-name JOIN, never a
+// blanket replace: a name with a real AD_User is GOVERNED, a name without stays literal — the honest gap.
+function _adUserByName(erpQuery, name) {
+  if (typeof erpQuery !== 'function' || !name) return null;
+  try {
+    var r = erpQuery('SELECT AD_User_ID AS ad_user_id, Name AS name, EMail AS email, Phone AS phone, '
+      + 'C_BPartner_ID AS c_bpartner_id FROM AD_User WHERE Name=? AND IsActive=?', [name, 'Y']);
+    if (!r || !r.length) return null;
+    var u = r[0];
+    return { ad_user_id: Number(u.ad_user_id), name: u.name, email: u.email || null, phone: u.phone || null,
+      c_bpartner_id: (u.c_bpartner_id == null ? null : Number(u.c_bpartner_id)), _governed: true };
+  } catch (e) { return null; }
+}
+// the Official set, GOVERNED where a real AD_User backs the name (else the literal record verbatim). No
+// erpQuery → the pure literal set (every existing caller unchanged).
+function officialRecords(erpQuery) {
+  var lit = records('Official');
+  if (typeof erpQuery !== 'function') return lit;
+  return lit.map(function (o) { return _adUserByName(erpQuery, o.name) || o; });
+}
 // §P10a lookup — resolve a bare code (attendance `employee` id, lease `party`/`tenant`) to its AD_User contact
-// record. Honest miss: returns null rather than fabricating a name for a code with no Official row.
-function officialByName(name) {
-  return records('Official').filter(function (o) { return o.name === name; })[0] || null;
+// record. §STAGE2: DB-first when erpQuery supplied (real AD_User), literal fallback (honest miss → null, never
+// a fabricated name for a code with no Official row and no real user).
+function officialByName(name, erpQuery) {
+  return _adUserByName(erpQuery, name) || records('Official').filter(function (o) { return o.name === name; })[0] || null;
 }
 
-var M = { MODELS: MODELS, model: model, records: records, toAssetRow: toAssetRow, officialByName: officialByName };
+var M = { MODELS: MODELS, model: model, records: records, toAssetRow: toAssetRow,
+  officialByName: officialByName, officialRecords: officialRecords };
 if (typeof module === 'object' && module.exports) module.exports = M;
 else (typeof self !== 'undefined' ? self : this).HbaModels = M;

--- a/hr_bim_asset/occupancy.js
+++ b/hr_bim_asset/occupancy.js
@@ -201,20 +201,54 @@ function toResourceAssignmentRow(assignOp, seedId) {
 function toResourceTypeRow(seedId) {
   return { s_resourcetype_id: seedId ? seedId() : 1, name: 'Room' };
 }
-function toResourceRow(room, s_resourcetype_id, seedId) {
+// §DESIGN-RESOURCE-AVAILABILITY (RESUME_HBA_ERP_GOVERNED_DISPLAY.md, 2026-07-03) — `isavailable` and
+// `percentutilization` are REAL S_Resource columns (verified against build/erp/ad_full.db PRAGMA — the
+// witness_erp_deeplink.js `s_resource` REAL_COLS list carries both). They were previously a hardcoded
+// `isavailable:'Y'` for EVERY room (a fabricated constant that never consulted the already-witnessed 21/21
+// ASSIGN/RELEASE/UNAVAIL signed-replay availability() engine). This threads the REPLAYED state onto the real
+// columns instead:
+//   • isavailable — the NATIVE master on/off gate ("is this resource in service / bookable at all"). Set 'N'
+//     ONLY when the room's replayed state is 'unavailable' (a real S_ResourceUnAvailable blackout / maintenance
+//     — genuinely out of service). occupied/expiring/vacant are all 'Y' (the resource EXISTS and is schedulable;
+//     WHO holds it WHEN is tracked by S_ResourceAssignment slots, not by flipping the master gate). This is the
+//     honest native semantics — never a guessed flag.
+//   • percentutilization — the room's REAL utilization from occupancy.pivot() (occupiedPeriods/totalPeriods),
+//     ×100 to the column's percentage grain. A currently-inert dictionary column (no native engine consumes it)
+//     populated meaningfully from a value we already compute — non-invent, the source already exists+is witnessed.
+// `avail` = { state, percentutilization } supplied by compileResources from the SAME signed occupancy replay
+// the Occupancy lens uses. ABSENT (avail null) → back-compat: master 'Y', no percentutilization (the prior
+// behaviour verbatim — every existing witness that calls compileResources(rooms) with no log stays green).
+function toResourceRow(room, s_resourcetype_id, seedId, avail) {
   if (!room || !room.guid) return null;
-  return { s_resource_id: seedId ? seedId() : 1, value: room.guid, name: room.name || room.guid,
-    s_resourcetype_id: s_resourcetype_id, isavailable: 'Y' };
+  var row = { s_resource_id: seedId ? seedId() : 1, value: room.guid, name: room.name || room.guid,
+    s_resourcetype_id: s_resourcetype_id, isavailable: (avail && avail.state === 'unavailable') ? 'N' : 'Y' };
+  if (avail && avail.percentutilization != null) row.percentutilization = avail.percentutilization;
+  return row;
 }
 // compile the WHOLE building's rooms into S_Resource headers in one pass — {resourceType, resources:[{row,guid}],
 // _watermark}. ONE resource type shared by every room (real rooms only — never fabricates a resource for a
-// guid that isn't in `rooms`).
-function compileResources(rooms) {
-  rooms = rooms || [];
+// guid that isn't in `rooms`). §DESIGN-RESOURCE-AVAILABILITY: when `opts.log` (the signed occupancy op-log,
+// e.g. A._hbaOccupancyLog) + `opts.period`/`opts.periods` are supplied, each room's real availability state +
+// utilization are REPLAYED (never stored/guessed) and threaded onto the row's real isavailable/
+// percentutilization columns. No log → unchanged legacy behaviour (master 'Y', no utilization).
+function compileResources(rooms, opts) {
+  rooms = rooms || []; opts = opts || {};
   var seq = 0; function seedId() { return ++seq; }
   var resourceType = toResourceTypeRow(function () { return 1; });
-  var resources = rooms.map(function (r) { return { row: toResourceRow(r, resourceType.s_resourcetype_id, seedId), guid: r.guid }; });
-  return W.stamp({ resourceType: resourceType, resources: resources }, 'en');
+  var log = opts.log || null, period = opts.period || null;
+  var periods = opts.periods || (period ? [period] : null);
+  // pivot over the SAME rooms so VACANT rooms still get a (0%) utilization — allResources = the real room guids.
+  var pv = (log && periods && periods.length) ? pivot(log, periods, { allResources: rooms.map(function (r) { return r.guid; }), storeyOf: opts.storeyOf }) : null;
+  var resources = rooms.map(function (r) {
+    var avail = null;
+    if (log) {
+      var st = period ? availability(log, r.guid, period, opts).state : null;
+      var util = (pv && pv.byRoom[r.guid]) ? Math.round(pv.byRoom[r.guid].utilization * 100) : null;
+      avail = { state: st, percentutilization: util };
+    }
+    return { row: toResourceRow(r, resourceType.s_resourcetype_id, seedId, avail), guid: r.guid };
+  });
+  return W.stamp({ resourceType: resourceType, resources: resources }, opts.locale || 'en');
 }
 
 var O = { assign: assign, release: release, unavailable: unavailable, availability: availability,

--- a/hr_bim_asset/tests/witness_ad_attendance.js
+++ b/hr_bim_asset/tests/witness_ad_attendance.js
@@ -1,0 +1,73 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-AD-ATTENDANCE witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md
+//   §DESIGN-ATTENDANCE, Stage 2/4). Proves ad_attendance.js compiles attendance.js's OWN witnessed sessions
+//   onto the native (Ninja-staged) C_Attendance child shape with the non-invent discipline the whole
+//   ERP-governed-display thread rests on:
+//     • AA0 — every emitted row's keys ⊆ the REAL seeded C_Attendance column list (independently sourced from
+//       the seed DDL / §DESIGN-ATTENDANCE) — the "no invention outside the AD" gate, same pattern as
+//       W-HBA-AD-PAYROLL's AD0 / W-HBA-AD-OCC's keysSubset.
+//     • AA1 — every FK (HR_Process/C_BPartner/M_Locator) is a real resolved id, never null on an accepted row.
+//     • AA2 — HONEST-OPEN: an open session keeps CheckOutTime AND Qty NULL (no fabricated finish/hours).
+//     • AA3 — NON-INVENT SKIP: a session whose employee/zone does not resolve to a real seeded id is SKIPPED
+//       (captured with a reason), never given a fabricated FK.
+//     • AA4 — deterministic sequential C_Attendance_ID over the accepted rows.
+//   Run: node hr_bim_asset/tests/witness_ad_attendance.js   — exit 0 = green. Read the log after run.
+'use strict';
+var ADA = require('../ad_attendance'), Att = require('../attendance');
+var rooms = require('../fixtures/hhs_rooms.json').rooms;
+var LOCS = require('../fixtures/hhs_room_locators.json');   // Stage-1 persisted guid→real M_Locator_ID map
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-AD-ATTENDANCE ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+
+// ground truth — the REAL seeded C_Attendance columns (seed_hba_erp.js DDL.C_Attendance, dumped from the
+// Ninja-staged AD_Column set; == §DESIGN-ATTENDANCE's column spec). Independently held here, not imported.
+var REAL_COLS = ['C_Attendance_ID', 'C_Attendance_UU', 'AD_Client_ID', 'AD_Org_ID', 'IsActive', 'Created',
+  'CreatedBy', 'Updated', 'UpdatedBy', 'HR_Process_ID', 'C_BPartner_ID', 'M_Locator_ID', 'ServiceDate',
+  'CheckInTime', 'CheckOutTime', 'Qty', 'Description'];
+function keysSubset(row) { return Object.keys(row).every(function (k) { return REAL_COLS.indexOf(k) >= 0; }); }
+
+var PERIOD = '2026-06';
+var PARTNER = { EMP001: 1001, EMP002: 1002 };                  // Stage-1 real C_BPartner ids
+var LOCATOR = LOCS.locators;                                    // real M_Locator ids keyed by room guid
+var PROCESS = 1;                                                // real seeded HR_Process_ID
+
+var seed = Att.demoSeed(rooms, PERIOD);
+var sess = Att.sessions(seed.log, PERIOD);
+var out = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: PARTNER, locatorMap: LOCATOR });
+
+ok('AA0-cols-subset', out.rows.length > 0 && out.rows.every(keysSubset),
+   out.rows.length + ' C_Attendance rows use ONLY real seeded column names (no invention outside the AD)');
+ok('AA1-fks-resolved', out.rows.every(function (r) { return r.HR_Process_ID === PROCESS && r.C_BPartner_ID != null && r.M_Locator_ID != null; }),
+   'every accepted row carries a real HR_Process/C_BPartner/M_Locator FK — never null');
+ok('AA1b-fks-are-real', out.rows.every(function (r) {
+     return (r.C_BPartner_ID === 1001 || r.C_BPartner_ID === 1002) && LOCS.locators[locGuidOf(r.M_Locator_ID)] === r.M_Locator_ID; }),
+   'every FK value matches a Stage-1 seeded id (C_BPartner ∈ {1001,1002}, M_Locator ∈ the persisted map)');
+var openRows = out.rows.filter(function (r) { return r.CheckOutTime == null; });
+var closedRows = out.rows.filter(function (r) { return r.CheckOutTime != null; });
+ok('AA2-honest-open', openRows.length > 0 && openRows.every(function (r) { return r.Qty == null; })
+   && closedRows.every(function (r) { return r.Qty != null && r.Qty >= 0; }),
+   openRows.length + ' open sessions keep NULL CheckOutTime AND NULL Qty; ' + closedRows.length + ' closed carry real derived hours');
+
+// AA3 — feed a partnerMap MISSING one real person → those sessions must SKIP (never a fabricated FK).
+var partial = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: { EMP001: 1001 }, locatorMap: LOCATOR });
+var skippedEmps = partial.skipped.filter(function (s) { return s.employee === 'EMP002'; });
+ok('AA3-skip-unresolved', partial.rows.every(function (r) { return r.C_BPartner_ID === 1001; })
+   && skippedEmps.length > 0 && skippedEmps.every(function (s) { return /C_BPartner/.test(s.reason); }),
+   'EMP002 sessions SKIPPED with reason (no real C_BPartner) — ' + skippedEmps.length + ' skipped, no fabricated FK');
+// zone-miss skip
+var badLoc = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: PARTNER, locatorMap: {} });
+ok('AA3b-skip-unlocated', badLoc.rows.length === 0 && badLoc.skipped.length === sess.length
+   && badLoc.skipped.every(function (s) { return /M_Locator/.test(s.reason); }),
+   'no real M_Locator → ALL ' + sess.length + ' sessions skipped (never a fabricated locator FK)');
+
+ok('AA4-sequential-ids', out.rows.map(function (r) { return r.C_Attendance_ID; }).join(',') === out.rows.map(function (r, i) { return i + 1; }).join(','),
+   'C_Attendance_ID is a deterministic 1..N sequence over accepted rows (no Date.now/random)');
+ok('AA5-watermarked', out._watermark != null, 'compile output carries the alpha watermark (generated output → §DISCLAIMER)');
+
+// helper: reverse the persisted locator map (id → guid) for the AA1b membership check.
+function locGuidOf(id) { var m = LOCS.locators; for (var g in m) { if (m[g] === id) return g; } return null; }
+
+var passed = checks.filter(Boolean).length;
+console.log('§W-HBA-AD-ATTENDANCE ' + (passed === checks.length ? 'PASS' : 'FAIL') + ' ' + passed + '/' + checks.length);
+process.exit(passed === checks.length ? 0 : 1);

--- a/hr_bim_asset/tests/witness_ad_bom.js
+++ b/hr_bim_asset/tests/witness_ad_bom.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-AD-BOM witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE,
+//   Stage 2). Proves ad_bom.js compiles a BIM recipe tree onto the native pp_product_bom/pp_product_bomline
+//   pair with the thread's non-invent discipline. NOTE (honest): the SOURCE (m_bom/m_bom_line) is bim-compiler's
+//   transient Java output, NOT present viewer-side in bim-ootb (see ad_bom.js header) — so this witnesses the
+//   PURE TRANSFORM against a real-SHAPED fixture; live wiring awaits a viewer-side BOM source. Each check names
+//   the issue it proves:
+//     • BOM0 — every emitted row's keys ⊆ the REAL pp_product_bom / pp_product_bomline columns (independently
+//       sourced via PRAGMA table_info against bim-compiler build/erp/ad_full.db, 2026-07-03).
+//     • BOM1 — bomtype='B' (BIM), qtybom threads from the recipe qty, deterministic line ordinals.
+//     • BOM2 — the TWO-M_Product LANDMINE: the BIM-catalog TEXT child_product_id is resolved to a DIFFERENT real
+//       AD m_product_id via productResolver; a child that does not resolve is SKIPPED (never a fabricated FK).
+//     • BOM3 — a node whose PARENT product does not resolve is SKIPPED (no orphan header).
+//     • BOM4 — BIM-only geometry rides the view-trace wrapper (keyed by the header PK), never forced into an AD column.
+//   Run: node hr_bim_asset/tests/witness_ad_bom.js
+'use strict';
+var ADB = require('../ad_bom');
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-AD-BOM ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+
+// ground truth — REAL columns (PRAGMA table_info, bim-compiler build/erp/ad_full.db, 2026-07-03).
+var REAL = {
+  pp_product_bom: ['value', 'name', 'documentno', 'revision', 'description', 'copyfrom', 'created', 'createdby',
+    'help', 'isactive', 'ad_client_id', 'm_changenotice_id', 'm_product_id', 'pp_product_bom_id', 'processing',
+    'updated', 'updatedby', 'validfrom', 'validto', 'm_attributesetinstance_id', 'ad_org_id', 'bomtype', 'bomuse',
+    'c_uom_id', 'pp_product_bom_uu'],
+  pp_product_bomline: ['feature', 'ad_org_id', 'assay', 'backflushgroup', 'c_uom_id', 'componenttype', 'created',
+    'createdby', 'description', 'forecast', 'help', 'isactive', 'iscritical', 'isqtypercentage', 'issuemethod',
+    'leadtimeoffset', 'line', 'm_attributesetinstance_id', 'm_changenotice_id', 'm_product_id',
+    'pp_product_bomline_id', 'pp_product_bom_id', 'qtybom', 'qtybatch', 'scrap', 'updated', 'updatedby',
+    'validfrom', 'ad_client_id', 'validto', 'costallocationperc', 'pp_product_bomline_uu']
+};
+function keysSubset(row, t) { return Object.keys(row).every(function (k) { return REAL[t].indexOf(k) >= 0; }); }
+
+// real-SHAPED fixture: a ROOM BOM (parent = the room's own element) with two furniture children — the shape
+// BOMWalker flattens m_bom/m_bom_line into. child_product_id values are BIM-catalog TEXT ids (the landmine).
+var nodes = [
+  { bom_id: 'BOM-RM1', bom_name: 'Room 1 recipe', bom_type: 'ROOM', product_ref: 'GUID-ROOM-1',
+    target_ifc_class: 'IfcSpace', origin_x: 1000, origin_y: 2000, origin_z: 0,
+    aabb_width_mm: 4000, aabb_depth_mm: 3000, aabb_height_mm: 2800,
+    lines: [{ child_product_id: 'CAT-CHAIR', qty: 4, component_type: 'Component' },
+            { child_product_id: 'CAT-DESK', qty: 1, component_type: 'Component' },
+            { child_product_id: 'CAT-UNKNOWN', qty: 9 }] },        // deliberately unresolvable → must SKIP
+  { bom_id: 'BOM-NOPARENT', bom_name: 'orphan', bom_type: 'ROOM', product_ref: 'GUID-MISSING',
+    lines: [{ child_product_id: 'CAT-CHAIR', qty: 1 }] }             // parent unresolvable → header SKIP
+];
+// the two-M_Product resolver: BIM-catalog TEXT id → real AD integer m_product_id (a DIFFERENT id space).
+var AD_ID = { 'GUID-ROOM-1': 5001, 'CAT-CHAIR': 6001, 'CAT-DESK': 6002 };   // GUID-MISSING / CAT-UNKNOWN absent
+function resolver(ref) { return AD_ID[ref] != null ? AD_ID[ref] : null; }
+
+var out = ADB.compileBom(nodes, resolver);
+
+ok('BOM0-header-cols', out.headers.length === 1 && out.headers.every(function (h) { return keysSubset(h, 'pp_product_bom'); }),
+   'pp_product_bom header uses ONLY real AD_Column names');
+ok('BOM0b-line-cols', out.lines.length === 2 && out.lines.every(function (l) { return keysSubset(l, 'pp_product_bomline'); }),
+   'every pp_product_bomline row uses ONLY real AD_Column names');
+var h0 = out.headers[0];
+ok('BOM1-bimtype', h0.bomtype === 'B' && h0.bomuse === 'M' && h0.m_product_id === 5001 && h0.value === 'BOM-RM1',
+   'header bomtype=B (BIM), parent m_product_id=5001 (the resolved real AD id, not the guid)');
+ok('BOM1b-qty-line', out.lines[0].qtybom === 4 && out.lines[1].qtybom === 1
+   && out.lines[0].line === 10 && out.lines[1].line === 20,
+   'qtybom threads from the recipe qty (4,1); line ordinals deterministic (10,20)');
+ok('BOM2-two-product-resolve', out.lines.every(function (l) { return l.m_product_id === 6001 || l.m_product_id === 6002; }),
+   'child m_product_id is the RESOLVED real AD id (6001/6002), NEVER the BIM-catalog TEXT id — two-M_Product landmine handled');
+var childSkips = out.skipped.filter(function (s) { return s.kind === 'line'; });
+ok('BOM2b-child-skip', childSkips.length === 1 && childSkips[0].child === 'CAT-UNKNOWN',
+   'the unresolvable child (CAT-UNKNOWN) is SKIPPED with a reason — no fabricated FK');
+var headerSkips = out.skipped.filter(function (s) { return s.kind === 'header'; });
+ok('BOM3-parent-skip', headerSkips.length === 1 && headerSkips[0].bom_id === 'BOM-NOPARENT' && out.headers.length === 1,
+   'the parent-unresolvable node is SKIPPED (no orphan header emitted)');
+var g0 = out.geometry[0];
+ok('BOM4-geometry-viewtrace', out.geometry.length === 1 && g0.pp_product_bom_id === h0.pp_product_bom_id
+   && g0.origin_x === 1000 && g0.aabb_width_mm === 4000 && h0.origin_x === undefined && h0.aabb_width_mm === undefined,
+   'BIM geometry (origin/aabb) rides the view-trace wrapper keyed by the header PK — NOT forced onto the AD row');
+ok('BOM5-watermarked', out._watermark != null, 'compile output carries the alpha watermark');
+
+var passed = checks.filter(Boolean).length;
+console.log('§W-HBA-AD-BOM ' + (passed === checks.length ? 'PASS' : 'FAIL') + ' ' + passed + '/' + checks.length);
+process.exit(passed === checks.length ? 0 : 1);

--- a/hr_bim_asset/tests/witness_erp_govern_wire.js
+++ b/hr_bim_asset/tests/witness_erp_govern_wire.js
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-ERP-GOVERN-WIRE witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2).
+//   Proves the VIEWER wiring (viewer/hba_lens.js _regovern) — not just the compile modules — actually swaps the
+//   literal specs for GOVERNED ones off the real erp/ad_seed.db. Drives the exact seam the browser drives:
+//   self.Hba* engine globals + a mock APP (A) carrying the real HHS rooms + a real-db erpQuery, then calls the
+//   exported _regovern hook. NAMES the issue: the real-user seeding path produces ERP-governed pane specs.
+//     • WIRE0 — _buildingName EXTRACTS 'HHS_Office_Federated' from project_metadata (A.buildingName is unset in
+//       the streaming path — the silent-miss landmine this guards).
+//     • WIRE1 — A._hbaPayrollSpec is _governed, identities from real HR_Employee.
+//     • WIRE2 — A._hbaTenancySpec.warehouse resolves to the durable seeded id 990000 (not the mint 1).
+//     • WIRE3 — A._hbaAttendanceSpec compiles the signed sessions onto real C_Attendance rows (FKs real,
+//       lossless rows+skipped == session count).
+//   Run: NODE_PATH=$HOME/bim-ootb/node_modules node hr_bim_asset/tests/witness_erp_govern_wire.js
+'use strict';
+var fs = require('fs'), path = require('path'), initSqlJs = require('sql.js');
+// ---- stand up the browser-side globals the way viewer/viewer.html <script> loading does ----
+global.self = global; global.window = global;
+self.HbaWatermark = require('../watermark');
+self.HbaModels = require('../models');
+self.HbaBinding = require('../binding');
+self.HbaConnectors = require('../connectors');
+self.HbaRules = require('../rules');
+self.HbaOverlay = require('../overlay');
+self.HbaLens = require('../lens');
+self.HbaTimeline = require('../timeline');
+self.HbaAttendance = require('../attendance');
+self.HbaLeave = require('../leave');
+self.HbaOccupancy = require('../occupancy');
+self.HbaAdPayroll = require('../ad_payroll');
+self.HbaAdTenancy = require('../ad_tenancy');
+self.HbaAdAttendance = require('../ad_attendance');
+self.HbaIot = require('../iot');
+var HBALens = require('../../viewer/hba_lens');   // exports the API incl. the §STAGE2 witness hooks
+
+var ROOT = path.join(__dirname, '..', '..');
+var SEED = path.join(ROOT, 'erp', 'ad_seed.db');
+var ROOMS_FX = require('../fixtures/hhs_rooms.json');
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-GOVERN-WIRE ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+function fin() { var p = checks.filter(Boolean).length; console.log('§W-HBA-ERP-GOVERN-WIRE ' + (p === checks.length ? 'PASS' : 'FAIL') + ' ' + p + '/' + checks.length); process.exit(p === checks.length ? 0 : 1); }
+
+initSqlJs().then(function (SQL) {
+  var db = new SQL.Database(fs.readFileSync(SEED));
+  function eq(sql, params) {
+    var r = db.exec(sql, params || []); if (!r.length) return [];
+    var cs = r[0].columns;
+    return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+  }
+  // mock APP — exactly the fields _regovern reads. dbQuery answers the building_name probe from the model DB
+  // (here the real HHS project_metadata value); markDirty is a no-op.
+  var rooms = ROOMS_FX.rooms.map(function (r) { return { guid: r.guid, name: r.name || r.guid, storey: r.storey || null }; });
+  var attLog = self.HbaAttendance.demoSeed(rooms, '2026-06').log;
+  var A = {
+    _hbaRooms: rooms, _hbaAttendanceLog: attLog, _hbaPeriod: '2026-06',
+    dbQuery: function (sql) { return /building_name/.test(sql) ? [['HHS_Office_Federated']] : []; },
+    markDirty: function () {}
+  };
+
+  ok('WIRE0-extract-name', HBALens._buildingName(A) === 'HHS_Office_Federated' && A.buildingName === undefined,
+     '_buildingName EXTRACTS "HHS_Office_Federated" from project_metadata even though A.buildingName is unset (streaming-path landmine guarded)');
+
+  HBALens._regovern(A, eq);   // drive the real governance swap
+
+  ok('WIRE1-payroll-governed', A._hbaPayrollSpec && A._hbaPayrollSpec._governed === true
+     && A._hbaPayrollSpec.employees.map(function (e) { return e.c_bpartner_id; }).sort().join(',') === '1001,1002',
+     'A._hbaPayrollSpec is _governed with c_bpartner_ids [1001,1002] from real HR_Employee');
+  ok('WIRE2-tenancy-governed', A._hbaTenancySpec && A._hbaTenancySpec.warehouse.m_warehouse_id === 990000
+     && A._hbaTenancySpec.warehouse.value === 'HHS_Office_Federated',
+     'A._hbaTenancySpec.warehouse resolved to the durable seeded id 990000 (Value=HHS_Office_Federated), not a re-mint');
+  var spec = A._hbaAttendanceSpec, sessCount = self.HbaAttendance.sessions(attLog, '2026-06').length;
+  ok('WIRE3-attendance-governed', spec && spec.rows.length > 0
+     && spec.rows.every(function (r) { return (r.C_BPartner_ID === 1001 || r.C_BPartner_ID === 1002) && r.M_Locator_ID != null && r.HR_Process_ID != null; })
+     && (spec.rows.length + spec.skipped.length) === sessCount,
+     'A._hbaAttendanceSpec: ' + spec.rows.length + '/' + sessCount + ' sessions → real C_Attendance rows (every FK real, none lost)');
+
+  db.close();
+  fin();
+}).catch(function (e) { console.log('§W-HBA-ERP-GOVERN-WIRE FAIL — ' + e.message + '\n' + e.stack); process.exit(1); });

--- a/hr_bim_asset/tests/witness_erp_governed.js
+++ b/hr_bim_asset/tests/witness_erp_governed.js
@@ -1,0 +1,108 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-ERP-GOVERNED witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2).
+//   The CRUX proof of the whole thread's §CONVENTION: with the REAL Stage-1 seeded erp/ad_seed.db injected as
+//   the compile layer's `erpQuery`, every displayed identity/id TRACES TO A QUERIED ROW instead of a JS
+//   literal — and WITHOUT the db it falls back byte-identically to the literal (so the 33 existing witnesses
+//   stay green). Each check NAMES the issue it proves (CLAUDE.md test mandate):
+//     • G1 — the id=1 blind-mint determinism LANDMINE (§IMPLICATIONS pt2) is fixed: toWarehouseRow resolves the
+//       DURABLE seeded M_Warehouse id (990000), not `1`.
+//     • G2 — compileBuilding's whole warehouse+locator identity comes from the seeded rows when governed.
+//     • G3 — payroll demoSpec's employee identities (c_bpartner_id) come from real HR_Employee⋈C_BPartner, and
+//       the engine's payslip == the DB-summed HR_Movement (display already traces to the seeded rows).
+//     • G4 — models.officialByName is GOVERNED for a real AD_User (EMP001) and honestly LITERAL for a name with
+//       no real user (BP-TEN-1) — a DB-first-per-name join, never a blanket replace.
+//     • G5 — §DESIGN-RESOURCE-AVAILABILITY: toResourceRow threads the REAL signed-replay availability onto
+//       isavailable/percentutilization (no more hardcoded 'Y').
+//     • G6 — FALLBACK: no erpQuery → every builder returns the prior literal (zero-regression guarantee).
+//   Run: NODE_PATH=$HOME/bim-ootb/node_modules node hr_bim_asset/tests/witness_erp_governed.js
+'use strict';
+var fs = require('fs'), path = require('path');
+var initSqlJs = require('sql.js');
+var ADT = require('../ad_tenancy'), ADP = require('../ad_payroll'), M = require('../models'), OC = require('../occupancy');
+var ROOT = path.join(__dirname, '..', '..');
+var SEED = path.join(ROOT, 'erp', 'ad_seed.db');
+var rooms = require('../fixtures/hhs_rooms.json').rooms;
+
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-ERP-GOVERNED ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+function fin() { var p = checks.filter(Boolean).length; console.log('§W-HBA-ERP-GOVERNED ' + (p === checks.length ? 'PASS' : 'FAIL') + ' ' + p + '/' + checks.length); process.exit(p === checks.length ? 0 : 1); }
+
+initSqlJs().then(function (SQL) {
+  if (!fs.existsSync(SEED)) { console.log('§W-HBA-ERP-GOVERNED FAIL — erp/ad_seed.db not found'); process.exit(1); }
+  var db = new SQL.Database(fs.readFileSync(SEED));
+  // the SYNC erpQuery seam — returns [{col:val,…}] row-objects, the exact shape the viewer's A.erpQuery hands
+  // the compile modules. Never throws to the module (module guards its own try, but keep the seam honest).
+  function erpQuery(sql, params) {
+    var r = db.exec(sql, params || []); if (!r.length) return [];
+    var cs = r[0].columns;
+    return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+  }
+  var HHS = 'HHS_Office_Federated';
+
+  // ── G1 — warehouse id resolution (the determinism landmine) ───────────────────────────────────────────────
+  var whMint = ADT.toWarehouseRow(HHS, function () { return 1; });                       // no db → mint
+  var whGov = ADT.toWarehouseRow(HHS, function () { return 1; }, erpQuery);              // db  → resolve
+  ok('G1-warehouse-resolve', whMint.m_warehouse_id === 1 && whGov.m_warehouse_id === 990000 && whGov.value === HHS,
+     'toWarehouseRow: literal mints id=1, GOVERNED resolves the durable seeded id=990000 (Value=' + whGov.value + ')');
+
+  // ── G2 — whole-building tenancy compile governed off the seeded warehouse+locators ────────────────────────
+  var govBld = ADT.compileBuilding(HHS, rooms, M.records('Tenancy'), M.records('Strata'), { erpQuery: erpQuery });
+  var seededLoc = {};
+  erpQuery('SELECT M_Locator_ID AS id, Value AS value FROM M_Locator WHERE M_Warehouse_ID=990000').forEach(function (r) { seededLoc[r.value] = Number(r.id); });
+  var locGoverned = govBld.locators.filter(function (l) { return seededLoc[l.value] === l.m_locator_id; }).length;
+  ok('G2-building-governed', govBld.warehouse.m_warehouse_id === 990000 && locGoverned > 0
+     && govBld.locators.every(function (l) { return l.m_warehouse_id === 990000; }),
+     'compileBuilding: warehouse=990000, ' + locGoverned + '/' + govBld.locators.length + ' locators resolved to their real seeded M_Locator id');
+
+  // ── G3 — payroll identities from real rows + engine==DB numbers ────────────────────────────────────────────
+  var specLit = ADP.demoSpec();
+  var specGov = ADP.demoSpec(erpQuery);
+  var realEmp = erpQuery('SELECT Code AS code, C_BPartner_ID AS bp FROM HR_Employee ORDER BY HR_Employee_ID');
+  var idsGov = specGov.employees.map(function (e) { return e.c_bpartner_id; }).sort();
+  var idsReal = realEmp.map(function (e) { return Number(e.bp); }).sort();
+  ok('G3a-payroll-identity', specGov._governed === true && !specLit._governed
+     && JSON.stringify(idsGov) === JSON.stringify(idsReal) && idsReal.length === 2,
+     'demoSpec(erpQuery) is _governed and its c_bpartner_ids ' + JSON.stringify(idsGov) + ' come from real HR_Employee rows');
+  var run = ADP.runPeriod(specGov);
+  var slip = ADP.payslip(run.hr_movement, 1001, 'en');
+  var dbGross = Number(erpQuery("SELECT SUM(amount) AS g FROM HR_Movement WHERE c_bpartner_id=1001 AND accountsign='+'")[0].g);
+  var dbNet = Number(erpQuery("SELECT ROUND(SUM(CASE WHEN accountsign='+' THEN amount ELSE -amount END),2) AS n FROM HR_Movement WHERE c_bpartner_id=1001")[0].n);
+  ok('G3b-engine==db', slip.gross === dbGross && slip.net === dbNet,
+     'governed run payslip (gross=' + slip.gross + ' net=' + slip.net + ') == DB-summed HR_Movement (gross=' + dbGross + ' net=' + dbNet + ')');
+
+  // ── G4 — official DB-first-per-name join (governed real, literal gap) ─────────────────────────────────────
+  var realUser = erpQuery('SELECT AD_User_ID AS id, EMail AS email, Phone AS phone, C_BPartner_ID AS bp FROM AD_User WHERE Name=?', ['EMP001'])[0];
+  var offGov = M.officialByName('EMP001', erpQuery);
+  var offLit = M.officialByName('EMP001');
+  var offTen = M.officialByName('BP-TEN-1', erpQuery);   // no real AD_User seeded → honest literal fallback
+  ok('G4a-official-governed', offGov && offGov._governed === true && offGov.email === realUser.email
+     && offGov.phone === realUser.phone && offGov.c_bpartner_id === Number(realUser.bp) && !offLit._governed,
+     'officialByName("EMP001") GOVERNED — email/phone/c_bpartner_id trace to the real AD_User row (literal is not _governed)');
+  ok('G4b-official-literal-gap', offTen && !offTen._governed && offTen.c_bpartner_id == null,
+     'officialByName("BP-TEN-1") honestly falls back to the literal (no real AD_User → the accepted 2-person tradeoff, never fabricated)');
+
+  // ── G5 — occupancy availability threaded from the signed replay (§DESIGN-RESOURCE-AVAILABILITY) ────────────
+  // build a tiny signed occupancy log: room[0] UNAVAIL over the period, room[1] vacant (no op).
+  var g0 = rooms[0].guid, g1 = rooms[1].guid, period = '2026-03';
+  var log = [];
+  var u = OC.unavailable({ resource: g0, from: '2026-03', to: '2026-04', reason: 'renovation', ts: '2026-03-01T00:00:00Z' }, null, 'GENESIS');
+  if (u.op) log.push(u.op);
+  var resSpec = OC.compileResources([{ guid: g0, name: 'R0' }, { guid: g1, name: 'R1' }], { log: log, period: period, periods: [period] });
+  var r0 = resSpec.resources[0].row, r1 = resSpec.resources[1].row;
+  ok('G5-availability-real', r0.isavailable === 'N' && r1.isavailable === 'Y'
+     && r0.percentutilization != null && r1.percentutilization != null,
+     'toResourceRow: UNAVAIL room isavailable=N, vacant room isavailable=Y, both carry real percentutilization (' + r0.percentutilization + '/' + r1.percentutilization + ') — no hardcoded Y');
+  // and no-log = legacy behaviour (master Y, no percentutilization)
+  var legacy = OC.compileResources([{ guid: g0, name: 'R0' }]).resources[0].row;
+  ok('G5b-availability-legacy', legacy.isavailable === 'Y' && legacy.percentutilization === undefined,
+     'no occupancy log → legacy toResourceRow verbatim (isavailable=Y, no percentutilization) — zero regression');
+
+  // ── G6 — FALLBACK: no erpQuery → literal identity everywhere ───────────────────────────────────────────────
+  ok('G6-fallback-literal', ADT.toWarehouseRow(HHS, function () { return 1; }).m_warehouse_id === 1
+     && ADP.demoSpec().employees[0].c_bpartner_id === 1001 && !ADP.demoSpec()._governed,
+     'no db injected → toWarehouseRow mints 1, demoSpec is the literal (the zero-regression fallback the 33 witnesses rely on)');
+
+  db.close();
+  fin();
+}).catch(function (e) { console.log('§W-HBA-ERP-GOVERNED FAIL — ' + e.message + '\n' + e.stack); process.exit(1); });

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -12,7 +12,7 @@
   var G = (typeof self !== 'undefined' ? self : this);
 
   // the WITNESSED engine (loaded as <script> before this file → self.Hba* globals)
-  function HBA() { return { O: G.HbaOverlay, B: G.HbaBinding, M: G.HbaModels, L: G.HbaLens, T: G.HbaTimeline, A: G.HbaAttendance, OC: G.HbaOccupancy, AD: G.HbaAdPayroll, Lv: G.HbaLeave, ADT: G.HbaAdTenancy, IoT: G.HbaIot }; }
+  function HBA() { return { O: G.HbaOverlay, B: G.HbaBinding, M: G.HbaModels, L: G.HbaLens, T: G.HbaTimeline, A: G.HbaAttendance, OC: G.HbaOccupancy, AD: G.HbaAdPayroll, Lv: G.HbaLeave, ADT: G.HbaAdTenancy, ADA: G.HbaAdAttendance, IoT: G.HbaIot }; }
   function ready() { var h = HBA(); return !!(h.O && h.B && h.M); }
 
   // hex '#2e7d32' | int → int for THREE emissive.setHex
@@ -270,10 +270,18 @@
       }
       // §P11 — compile each REAL room into a native S_Resource header row (Dashboard's "hover a Resource"
       // deep-link needs a real numeric s_resource_id per room; see occupancy.js compileResources header).
+      // §DESIGN-RESOURCE-AVAILABILITY (Stage 2) — thread the SAME signed occupancy replay (A._hbaOccupancyLog,
+      // seeded just above) so isavailable/percentutilization are the room's REAL availability, not a hardcoded 'Y'.
       if (!A._hbaResourceSpec && h.OC && h.OC.compileResources && rooms.length) {
-        A._hbaResourceSpec = h.OC.compileResources(rooms);
-        console.log('§HBA_RES compiled ' + A._hbaResourceSpec.resources.length + ' S_Resource rows from ' + rooms.length + ' rooms');
+        A._hbaResourceSpec = h.OC.compileResources(rooms, { log: A._hbaOccupancyLog || null,
+          period: period(A), periods: [period(A)],
+          storeyOf: function (g) { return (A._hbaStoreyOf && A._hbaStoreyOf[g]) || 'Unknown'; } });
+        var unavail = A._hbaResourceSpec.resources.filter(function (r) { return r.row.isavailable === 'N'; }).length;
+        console.log('§HBA_RES compiled ' + A._hbaResourceSpec.resources.length + ' S_Resource rows from ' + rooms.length + ' rooms (real availability: ' + unavail + ' unavailable, percentutilization threaded)');
       }
+      // §STAGE2 — now that the literal specs are seeded, attempt ERP-governance (async ad_seed.db load →
+      // re-compile the ERP-sourced specs off real rows). ADDITIVE: a failure leaves the literal specs standing.
+      _ensureErpGovern(A);
     } catch (e) { /* no spatial_structure → honest no-op (density falls back to S?) */ }
   }
 
@@ -281,6 +289,79 @@
   function period(A) {
     if (A && A._hbaPeriod) return A._hbaPeriod;
     var d = new Date(); return d.getFullYear() + '-' + ('0' + (d.getMonth() + 1)).slice(-2);
+  }
+
+  // §STAGE2 (RESUME_HBA_ERP_GOVERNED_DISPLAY.md Stage 2) — the ERP-GOVERNANCE seam. ADDITIVE + ZERO-IMPACT:
+  // the seeding gate above already seeds LITERAL specs (unchanged — panes work immediately, every existing
+  // witness/behaviour intact). This lazily loads the REAL erp/ad_seed.db (the SAME db navigate_find.js's
+  // _ensureErpDb loads) and, ONCE it is available, RE-COMPILES the governable specs (payroll identities,
+  // tenancy warehouse/locators, attendance→C_Attendance) off the real seeded rows, then swaps them in. If the
+  // SQL factory / cachedFetch seam is absent (off the ERP-capable page), or the fetch fails, or the db lacks
+  // the HHS rows, NOTHING changes — the literal specs stand (the fallback the module builders guarantee).
+  var _erpDb = null, _erpTried = false;
+  function _erpQueryFrom(db) {
+    return function (sql, params) {                         // SYNC reader → [{col:val,…}] row-objects
+      var r = db.exec(sql, params || []); if (!r.length) return [];
+      var cs = r[0].columns;
+      return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+    };
+  }
+  function _ensureErpGovern(A) {
+    if (_erpTried || !A) return;                            // one attempt per session (governance is monotonic)
+    _erpTried = true;
+    var SQL = A._SQL || G.SQL || G._SQL_CACHED;             // viewer caches the sql.js factory as A._SQL; absent off the ERP page
+    var fetchDb = A.cachedFetch || (G.APP && G.APP.cachedFetch);
+    if (!SQL || typeof fetchDb !== 'function') { console.log('§HBA_GOVERN skip — no SQL/cachedFetch seam (literal specs stand)'); return; }
+    Promise.resolve(fetchDb('../erp/ad_seed.db'))
+      .then(function (buf) {
+        _erpDb = new SQL.Database(new Uint8Array(buf));
+        var eq = _erpQueryFrom(_erpDb);
+        A.erpQuery = eq;                                    // expose the sync seam (Stage 3 panes/lenses reuse it)
+        _regovern(A, eq);
+      })
+      .catch(function (e) { console.log('§HBA_GOVERN skip — ad_seed.db load failed: ' + e.message + ' (literal specs stand)'); });
+  }
+  // recompute ONLY the ERP-sourced specs off the real rows and swap them in (idempotent). The signed op-logs /
+  // leave / request specs are untouched. Honest no-op per spec if a dependency (rooms/engine) is missing.
+  // the REAL building name — the warehouse MATCH KEY (Value). A.buildingName is unset in the streaming path,
+  // so EXTRACT it from the model's own project_metadata (the SAME source seed_hba_erp.js pinned the warehouse
+  // Value from — 'HHS_Office_Federated'); honest fallback to A.buildingName only when the model lacks the row.
+  function _buildingName(A) {
+    try {
+      if (typeof A.dbQuery === 'function') {
+        var rows = A.dbQuery("SELECT value FROM project_metadata WHERE key='building_name'");
+        if (rows && rows[0] && rows[0][0]) return rows[0][0];
+      }
+    } catch (e) { /* no project_metadata → honest fallback below */ }
+    return A.buildingName || 'This Building';
+  }
+  function _regovern(A, eq) {
+    var h = HBA(), n = 0, bname = _buildingName(A);
+    if (h.AD && h.AD.demoSpec) { A._hbaPayrollSpec = h.AD.demoSpec(eq); n++; }
+    if (h.ADT && h.ADT.compileBuilding && h.M && A._hbaRooms) {
+      A._hbaTenancySpec = h.ADT.compileBuilding(bname, A._hbaRooms,
+        h.M.records('Tenancy'), h.M.records('Strata'), { erpQuery: eq });
+      n++;
+    }
+    // §DESIGN-ATTENDANCE — compile the signed presence sessions onto real C_Attendance child rows (partner/
+    // locator maps built from the real seeded AD_User/M_Locator). Stage 3 retargets the Presence drawer onto
+    // this governed spec; Stage 2 produces it. Sessions whose id/zone has no real row are honestly SKIPPED.
+    if (h.ADA && h.A && A._hbaAttendanceLog && A._hbaRooms) {
+      var sessions = h.A.sessions(A._hbaAttendanceLog, period(A));
+      var userRows = eq('SELECT Name AS name, C_BPartner_ID AS c_bpartner_id FROM AD_User WHERE C_BPartner_ID IS NOT NULL AND IsActive=?', ['Y']);
+      var locRows = eq('SELECT M_Locator_ID AS m_locator_id, Value AS value FROM M_Locator', []);
+      var procRow = eq('SELECT HR_Process_ID AS id FROM HR_Process ORDER BY HR_Process_ID LIMIT 1', []);
+      A._hbaAttendanceSpec = h.ADA.compileAttendance(sessions, {
+        processId: (procRow[0] ? Number(procRow[0].id) : null),
+        partnerMap: h.ADA.partnerMapFromUsers(userRows),
+        locatorMap: h.ADA.locatorMapFromLocators(locRows) });
+      n++;
+    }
+    console.log('§HBA_GOVERN on — re-compiled ' + n + ' governable spec(s) off real ad_seed.db (payroll _governed='
+      + !!(A._hbaPayrollSpec && A._hbaPayrollSpec._governed)
+      + ' warehouse=' + (A._hbaTenancySpec ? A._hbaTenancySpec.warehouse.m_warehouse_id : 'n/a')
+      + ' C_Attendance=' + (A._hbaAttendanceSpec ? (A._hbaAttendanceSpec.rows.length + '/' + (A._hbaAttendanceSpec.rows.length + A._hbaAttendanceSpec.skipped.length)) : 'n/a') + ')');
+    if (A.markDirty) A.markDirty();
   }
 
   // toggle a lens ON/OFF. ON → drive the WITNESSED engine through the real MeshPort, GATED by A.guidMap so a
@@ -633,7 +714,8 @@
     maintenanceSchedule: maintenanceSchedule, availableLenses: availableLenses, familyHasData: familyHasData,
     familyActive: familyActive, activateLens: activateLens, openFamilyDrawer: openFamilyDrawer, FAMILY: FAMILY, _ready: ready,
     flyToZone: flyToZone, openPresenceDrawer: openPresenceDrawer, closePresenceDrawer: _closePresenceDrawer,
-    erpLink: erpLink, AD_WINDOWS: AD_WINDOWS };
+    erpLink: erpLink, AD_WINDOWS: AD_WINDOWS,
+    _regovern: _regovern, _buildingName: _buildingName, _ensureErpGovern: _ensureErpGovern };  // §STAGE2 — witness hooks (additive)
   if (typeof module === 'object' && module.exports) { module.exports = G.HBALens; return; }   // node witness — no DOM gate
 
   // ---- DATA-GATE poll (mirrors viewer/wh_walk.js): flip the pill icons ON only when a lens detects ------

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -911,6 +911,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../hr_bim_asset/dashboard.js?v=1" onerror="console.warn('§LOAD_FAIL hr dashboard.js')"></script>
 <script src="../hr_bim_asset/avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hr avatars.js')"></script>
 <script src="../hr_bim_asset/ad_tenancy.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_tenancy.js')"></script>
+<script src="../hr_bim_asset/ad_attendance.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_attendance.js')"></script>
 <script src="../hr_bim_asset/iot.js?v=1" onerror="console.warn('§LOAD_FAIL hr iot.js')"></script>
 <script src="hba_lens.js?v=5" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
 <script src="hba_avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hba_avatars.js')"></script>


### PR DESCRIPTION
Implements `prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md` §STAGED-PLAN **Stage 2** (Opus) — the compile-layer rewrite that makes every HBA pane spec COMPILE from the real Stage-1 seeded `ad_seed.db` (PR #621) instead of a JS literal that merely mimics the AD row shape.

## Design — injected-query seam, literal fallback (house-style host-injection)
Each compile module gains an optional **sync `erpQuery(sql,params)→rows`**. Present → resolves against the real seeded rows. Absent → today's witnessed literal path — so **all 33 existing witnesses stay green** and the viewer stays zero-impact when the ERP db isn't loaded. New witnesses inject the *real* `ad_seed.db` to prove "every displayed field traces to a queried row."

## Compile layer (`hr_bim_asset/`)
- **NEW `ad_attendance.js`** — resolves signed presence sessions onto the Ninja-staged `C_Attendance` child rows (real `C_BPartner`/`M_Locator`/`HR_Process` FKs; unresolved → honest SKIP; open session → NULL `CheckOutTime`+`Qty`). `W-HBA-AD-ATTENDANCE` 8/8.
- **`ad_tenancy.js`** — `toWarehouseRow`/`toLocatorRow`/`toProductRow` + `compileBuilding` MATCH-OR-CREATE by Value/guid → kills the **id=1 blind-mint determinism landmine** (§IMPLICATIONS pt2): HHS resolves to the durable seeded `M_Warehouse` **990000**, not a re-mint.
- **`ad_payroll.js`** — `demoSpec(erpQuery)` resolves identities from real `HR_Employee⋈C_BPartner`; the engine run stays numerically identical to seeded `HR_Movement`.
- **`models.js`** — `officialByName`/`officialRecords` DB-first-per-name over real `AD_User` (governed where a real user exists, honest literal for contacts that have none).
- **`occupancy.js`** — §DESIGN-RESOURCE-AVAILABILITY: `toResourceRow` threads the real signed-replay availability onto `isavailable`/`percentutilization` (no more hardcoded `'Y'`).
- **NEW `ad_bom.js`** — pure BIM-recipe→`pp_product_bom`/`pp_product_bomline` transform per §DESIGN-BOM-COMPILE (`bomtype='B'`, two-`M_Product` resolver landmine handled, geometry as view-trace). **FLAGGED:** no viewer-side BOM source exists in bim-ootb yet (bim-compiler transient output) — witnessed as the pure transform. `W-HBA-AD-BOM` 9/9.

## Viewer wiring (additive, zero-regression)
- **`hba_lens.js`** — lazy `ad_seed.db` loader exposing a sync `A.erpQuery`; the seeding gate seeds literal FIRST then RE-GOVERNS the ERP-sourced specs on db arrival. `_buildingName` EXTRACTS the warehouse match key from `project_metadata` (`A.buildingName` is unset in the streaming path — silent-miss landmine guarded).
- **`viewer.html`** — load `ad_attendance.js`.

## Witnesses
- **`W-HBA-ERP-GOVERNED` 9/9** (crux) — injects the real `ad_seed.db`, proves every identity/id traces to a queried row; governed payslip **gross=5200/net=4234 == seeded HR_Movement**; and the no-db fallback is byte-identical.
- **`W-HBA-ERP-GOVERN-WIRE` 4/4** — drives `_regovern` with browser-style globals → `warehouse=990000`, `C_Attendance 7/7`.
- Full `hr_bim_asset` suite **37/37 green**. `ad_seed.db` read-only (untouched).

## Follow-ups (not this PR)
- **Stage 3 (Fable5)** — pane read-through-lens (Presence drawer → `C_Attendance`→`AD_InfoWindow`) + a **live headless-Chrome smoke** of the async governance path.
- BOM: seed a viewer-side source + the `AD_Ref_List 'B'` (BIM) row before `ad_bom.js` can govern live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)