### PR TITLE
feat(hba): §BOM-ERP-CENTERED — BIM BOM lives in native iDempiere pp_product_bom (W-HBA-BOM-GOVERNED 6/6)

### DIFF
--- a/hr_bim_asset/ad_bom.js
+++ b/hr_bim_asset/ad_bom.js
@@ -1,32 +1,34 @@
 // Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
 // SPDX-License-Identifier: MIT
-// ⚠ DO NOT REMOVE — BIM RECIPE TREE COMPILED ONTO NATIVE iDempiere MRP `pp_product_bom`/`pp_product_bomline`
-//   (bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE, Stage 2). The BOM PRINCIPLE
-//   (one parent, N children each with a quantity, recursive) projected onto the REAL, live MRP pair — the
-//   cleanest AD fit found across the whole thread (pp_product_bom carries NO doc-lifecycle columns, so a static
-//   BIM recipe needs no workflow/approval handling — §DESIGN-BOM-COMPILE finding).
+// ⚠ DO NOT REMOVE — BIM RECIPE TREE **LIVES IN** NATIVE iDempiere `pp_product_bom`/`pp_product_bomline`
+//   (bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE + §BOM-ERP-CENTERED). The
+//   BOM PRINCIPLE (one parent, N children each with a quantity, recursive) is expressed as REAL rows in the
+//   stock iDempiere MRP pair — the cleanest AD fit in the whole thread (pp_product_bom carries NO doc-lifecycle
+//   columns, so a static BIM recipe needs no workflow/approval handling).
 //
-//   ⚠ RUNTIME-SOURCE GAP (honest, flagged not hidden): the SOURCE this compiles FROM — m_bom/m_bom_line
-//   (library/schema_snapshot_bom.sql, walked by DAGCompiler/BOMWalker.java) — is **bim-compiler's** transient
-//   Java pipeline output (library/*_BOM.db, deleted every run by scripts/rebuild_erp.sh). It is NOT present
-//   viewer-side in bim-ootb (the streamed building DBs carry spatial_structure/elements_meta/element_transforms
-//   but NO bom table — verified live 2026-07-03). So this module is the PURE, WITNESSED TRANSFORM (proven
-//   against a real-SHAPED fixture in tests/witness_ad_bom.js); LIVE viewer wiring awaits a viewer-side BOM
-//   source (either bim-compiler emitting a persisted *_BOM.db the viewer can fetch, or the compile running
-//   bim-compiler-side). Do NOT fabricate a BOM source to make it "live" — that would violate the PRIME RULE.
+//   ★ ERP-CENTERED (user directive 2026-07-03: "the Java era is not source of truth, the ERP is; all BIM data
+//   models are ERP-centered"). The AUTHORITY for the BOM is iDempiere — the pp_product_bom rows SEEDED into
+//   erp/ad_seed.db by scripts/seed_hba_bom.js from the REAL IFC extraction (a building's own
+//   rel_contained_in_space room→elements containment). The BIM BOM panel is a LENS (readBom, an AD_InfoWindow
+//   JOIN pp_product_bom⋈pp_product_bomline⋈M_Product⋈M_Locator⋈M_Warehouse) over those rows — never a store.
+//   The Java `m_bom`/`m_bom_line` (X_M_BOM.java / schema_snapshot_bom.sql / BOMWalker.java) is a TRANSITIONAL
+//   MIGRATION SOURCE being ABSORBED into the one iDempiere base ([[project_erp_one_base_doctrine]]), NOT an
+//   authority anything reads from. This module is therefore two ERP-native halves:
+//     (1) the SEED row-builders (toBomRow/toBomLineRow/compileBom) — the ONE shape definition the seed reuses,
+//         fed by the real building extraction (never Java m_bom); and
+//     (2) readBom(erpQuery) — the lens read over the real seeded rows (the panel's data source).
 //
-//   ⚠ TWO "M_Product" LANDMINE (load-bearing, §DESIGN-BOM-COMPILE item ⚠): m_bom_line.child_product_id is a
-//   TEXT id into library/component_library.db's OWN internal M_Product catalog — NOT the real AD dictionary's
-//   integer m_product_id that pp_product_bomline FKs into. The caller MUST pass a `productResolver` that maps
-//   the BIM-catalog TEXT id → the real AD m_product_id already minted by ProductRegistrar.java / ad_tenancy.js
-//   toProductRow for that same guid. This module NEVER mints a competing Product identity; a line whose child
-//   does not resolve is SKIPPED (non-invent), never given a fabricated FK.
+//   ⚠ TWO "M_Product" IDENTITY DISCIPLINE (load-bearing): a BIM element's guid is NOT an AD id. compileBom
+//   resolves each guid → the REAL AD m_product_id (seeded by seed_hba_bom.js / minted by ad_tenancy.js
+//   toProductRow / ProductRegistrar.java for that same guid) via an injected `productResolver`. This module
+//   NEVER mints a competing Product identity; a node/line whose product does not resolve is SKIPPED
+//   (non-invent), never given a fabricated FK.
 //
-//   ⚠ bomtype='B' (BIM) — §DESIGN-BOM-COMPILE item 1: pp_product_bom.BOMType is AD_Ref_List 347 ("M_BOM Type").
-//   'B'="BIM" is NOT a stock value (A/C/F/K/M/O/P/R/S) — it must be added as an AD_Ref_List row (a Stage-1 SEED
-//   step, the same "extend the dictionary with a missing master value" idiom as C_UOM/M_Warehouse). That seed
-//   is NOT yet done (flagged for whoever seeds the BOM source). Accepted tradeoff: a 'B' BOM is invisible to
-//   native costing/MRP/production-explosion (which hardcode 'A') — correct for a structural/spatial BIM recipe.
+//   bomtype='B' (BIM) — pp_product_bom.BOMType is AD_Ref_List 347 ("M_BOM Type"). 'B'="BIM" is NOT a stock
+//   value (A/C/F/K/M/O/P/R/S); seed_hba_bom.js ADDS the AD_Ref_List row (the "extend the dictionary with a
+//   missing master value" idiom, exact iDempiere mapping — real AD_Ref_List columns, FK to AD_Reference 347).
+//   Accepted tradeoff: a 'B' BOM is invisible to native costing/MRP/production-explosion (which hardcode 'A')
+//   — correct for a structural/spatial BIM recipe (not a manufacturing plan).
 'use strict';
 (function () {
 var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
@@ -95,8 +97,41 @@ function compileBom(nodes, productResolver, opts) {
   return W ? W.stamp(out, opts.locale || 'en') : out;
 }
 
+// ★ ERP-CENTERED LENS READ — the BIM BOM panel's data source. Reads the REAL seeded pp_product_bom rows back
+// through the native JOIN (the AD_InfoWindow lens seed_hba_bom.js also declares): every assembly + its
+// components resolve pp_product_bom→M_Product(assembly)→M_Locator(room)→M_Warehouse(building) and each line
+// →M_Product(component). `erpQuery` = the SAME sync ad_seed.db reader ad_tenancy/ad_payroll use (A.erpQuery /
+// a witness handle). Honest empty when no db / no 'B' BOMs. opts.m_warehouse_id scopes to one building.
+// Returns { assemblies: [{ bom_id, assembly_guid, assembly_name, room, building, lines: [{line_id,
+// component_guid, component_name, qty}] }], _watermark } — NOTHING is stored here; it is purely a lens.
+function readBom(erpQuery, opts) {
+  opts = opts || {};
+  if (typeof erpQuery !== 'function') return W ? W.stamp({ assemblies: [] }, opts.locale || 'en') : { assemblies: [] };
+  var where = "WHERE H.BOMType='B'", params = [];
+  if (opts.m_warehouse_id != null) { where += ' AND W.M_Warehouse_ID=?'; params.push(opts.m_warehouse_id); }
+  var sql = 'SELECT H.PP_Product_BOM_ID AS bom_id, HP.Value AS assembly_guid, HP.Name AS assembly_name,'
+    + ' W.Name AS building, L.Value AS room, BL.PP_Product_BOMLine_ID AS line_id, CP.Value AS component_guid,'
+    + ' CP.Name AS component_name, BL.QtyBOM AS qty'
+    + ' FROM PP_Product_BOM H JOIN M_Product HP ON H.M_Product_ID=HP.M_Product_ID'
+    + ' LEFT JOIN M_Locator L ON HP.M_Locator_ID=L.M_Locator_ID'
+    + ' LEFT JOIN M_Warehouse W ON L.M_Warehouse_ID=W.M_Warehouse_ID'
+    + ' JOIN PP_Product_BOMLine BL ON BL.PP_Product_BOM_ID=H.PP_Product_BOM_ID'
+    + ' JOIN M_Product CP ON BL.M_Product_ID=CP.M_Product_ID ' + where + ' ORDER BY H.PP_Product_BOM_ID, BL.Line';
+  var rows;
+  try { rows = erpQuery(sql, params); } catch (e) { rows = []; }
+  var byBom = {}, order = [];
+  (rows || []).forEach(function (r) {
+    var b = byBom[r.bom_id];
+    if (!b) { b = byBom[r.bom_id] = { bom_id: r.bom_id, assembly_guid: r.assembly_guid, assembly_name: r.assembly_name,
+      room: r.room, building: r.building, lines: [] }; order.push(r.bom_id); }
+    b.lines.push({ line_id: r.line_id, component_guid: r.component_guid, component_name: r.component_name, qty: r.qty });
+  });
+  var out = { assemblies: order.map(function (id) { return byBom[id]; }) };
+  return W ? W.stamp(out, opts.locale || 'en') : out;
+}
+
 var AD = { BOM_TYPE_BIM: BOM_TYPE_BIM, BOM_USE_MASTER: BOM_USE_MASTER,
-  toBomRow: toBomRow, toBomLineRow: toBomLineRow, compileBom: compileBom };
+  toBomRow: toBomRow, toBomLineRow: toBomLineRow, compileBom: compileBom, readBom: readBom };
 if (typeof module === 'object' && module.exports) module.exports = AD;
 else (typeof self !== 'undefined' ? self : this).HbaAdBom = AD;
 })();

--- a/hr_bim_asset/tests/witness_ad_bom.js
+++ b/hr_bim_asset/tests/witness_ad_bom.js
@@ -1,10 +1,11 @@
 // Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
 // SPDX-License-Identifier: MIT
-// ⚠ DO NOT REMOVE — W-HBA-AD-BOM witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE,
-//   Stage 2). Proves ad_bom.js compiles a BIM recipe tree onto the native pp_product_bom/pp_product_bomline
-//   pair with the thread's non-invent discipline. NOTE (honest): the SOURCE (m_bom/m_bom_line) is bim-compiler's
-//   transient Java output, NOT present viewer-side in bim-ootb (see ad_bom.js header) — so this witnesses the
-//   PURE TRANSFORM against a real-SHAPED fixture; live wiring awaits a viewer-side BOM source. Each check names
+// ⚠ DO NOT REMOVE — W-HBA-AD-BOM witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-BOM-COMPILE +
+//   §BOM-ERP-CENTERED). Proves the ad_bom.js TRANSFORM (toBomRow/toBomLineRow/compileBom) — the shape-builders
+//   scripts/seed_hba_bom.js reuses to write the native pp_product_bom/pp_product_bomline rows — with the
+//   non-invent discipline the whole thread rests on. (The BOM now LIVES in iDempiere, sourced from the REAL IFC
+//   extraction, read back by ad_bom.readBom — proven end-to-end by W-HBA-BOM-GOVERNED against the shipped
+//   ad_seed.db; THIS witness pins the transform in isolation against a real-shaped fixture.) Each check names
 //   the issue it proves:
 //     • BOM0 — every emitted row's keys ⊆ the REAL pp_product_bom / pp_product_bomline columns (independently
 //       sourced via PRAGMA table_info against bim-compiler build/erp/ad_full.db, 2026-07-03).

--- a/hr_bim_asset/tests/witness_bom_governed.js
+++ b/hr_bim_asset/tests/witness_bom_governed.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-BOM-GOVERNED witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md §BOM-ERP-CENTERED).
+//   The durable regression proof that the BIM BOM now LIVES in iDempiere (native pp_product_bom seeded by
+//   scripts/seed_hba_bom.js) and the panel reads it as a LENS (ad_bom.readBom) — the ERP is the source of
+//   truth, not the Java m_bom. Reads the SHIPPED erp/ad_seed.db (not a fixture). Each check names its issue:
+//     • BG1 — AD_Ref_List carries 'B'=BIM for AD_Reference 347 (the exact-mapped dictionary extension).
+//     • BG2 — ad_bom.readBom returns the real assemblies+components (13 rooms / 88 lines for HHS).
+//     • BG3 — every assembly resolves to the pinned HHS building + every line to a real component M_Product.
+//     • BG4 — every assembly_guid is a real seeded M_Locator room (no fabricated assembly).
+//     • BG5 — EXACT MAP: every seeded PP_Product_BOM.BOMType resolves in the dictionary (0 deviating enums).
+//     • BG6 — side effect: ad_tenancy.toProductRow now RESOLVES a room guid to the real seeded M_Product
+//       (tenancy product governance completed — a real AD id, not a compile-time mint).
+//   Run: NODE_PATH=$HOME/bim-ootb/node_modules node hr_bim_asset/tests/witness_bom_governed.js
+'use strict';
+var fs = require('fs'), path = require('path'), initSqlJs = require('sql.js');
+var ADB = require('../ad_bom'), ADT = require('../ad_tenancy');
+var LOCS = require('../fixtures/hhs_room_locators.json');
+var SEED = path.join(__dirname, '..', '..', 'erp', 'ad_seed.db');
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-BOM-GOVERNED ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+function fin() { var p = checks.filter(Boolean).length; console.log('§W-HBA-BOM-GOVERNED ' + (p === checks.length ? 'PASS' : 'FAIL') + ' ' + p + '/' + checks.length); process.exit(p === checks.length ? 0 : 1); }
+
+initSqlJs().then(function (SQL) {
+  var db = new SQL.Database(fs.readFileSync(SEED));
+  function eq(sql, params) {
+    var r = db.exec(sql, params || []); if (!r.length) return [];
+    var cs = r[0].columns; return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+  }
+  function scalar(sql, p) { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values[0][0] : null; }
+
+  ok('BG1-reflist-b', Number(scalar("SELECT COUNT(*) FROM AD_Ref_List WHERE AD_Reference_ID=347 AND Value='B'")) === 1,
+     "AD_Ref_List has Value='B' (BIM) for AD_Reference 347");
+
+  var lens = ADB.readBom(eq, { m_warehouse_id: LOCS.m_warehouse_id });
+  var totalLines = lens.assemblies.reduce(function (s, a) { return s + a.lines.length; }, 0);
+  var dbLines = Number(scalar("SELECT COUNT(*) FROM PP_Product_BOMLine BL JOIN PP_Product_BOM H ON BL.PP_Product_BOM_ID=H.PP_Product_BOM_ID WHERE H.BOMType='B'"));
+  ok('BG2-readbom-real', lens.assemblies.length > 0 && totalLines === dbLines && totalLines > 0,
+     'ad_bom.readBom returns ' + lens.assemblies.length + ' assemblies / ' + totalLines + ' component lines == the seeded rows');
+  ok('BG3-lens-resolved', lens.assemblies.every(function (a) { return a.building === LOCS.warehouse_value; })
+     && lens.assemblies.every(function (a) { return a.lines.length > 0 && a.lines.every(function (l) { return l.component_guid && l.component_name != null; }); }),
+     'every assembly lands in the HHS building and every line resolves to a real component M_Product');
+  ok('BG4-assembly-is-room', lens.assemblies.every(function (a) { return LOCS.locators[a.assembly_guid] != null; }),
+     'every assembly_guid is a real Stage-1 seeded M_Locator room (no fabricated assembly) — ' + lens.assemblies.length + ' rooms');
+
+  var badType = Number(scalar("SELECT COUNT(*) FROM PP_Product_BOM H WHERE H.BOMType IS NOT NULL AND NOT EXISTS (SELECT 1 FROM AD_Ref_List r WHERE r.AD_Reference_ID=347 AND r.Value=H.BOMType)"));
+  ok('BG5-exact-map', badType === 0, 'every PP_Product_BOM.BOMType resolves in the AD_Ref_List dictionary (0 deviating enums — exact iDempiere mapping)');
+
+  // BG6 — tenancy product governance side effect: a room guid now resolves to the real seeded M_Product.
+  var roomGuid = lens.assemblies[0].assembly_guid;
+  var prodGov = ADT.toProductRow({ guid: roomGuid, name: roomGuid }, 42, function () { return 1; }, eq);
+  var prodMint = ADT.toProductRow({ guid: roomGuid, name: roomGuid }, 42, function () { return 1; });
+  var realId = Number(scalar('SELECT M_Product_ID FROM M_Product WHERE Value=?', [roomGuid]));
+  ok('BG6-tenancy-product-governed', prodGov.m_product_id === realId && realId > 1 && prodMint.m_product_id === 1,
+     'ad_tenancy.toProductRow resolves room "' + roomGuid + '" to the real seeded M_Product ' + realId + ' (mint fallback = 1)');
+
+  db.close();
+  fin();
+}).catch(function (e) { console.log('§W-HBA-BOM-GOVERNED FAIL — ' + e.message + '\n' + e.stack); process.exit(1); });

--- a/hr_bim_asset/tests/witness_erp_govern_wire.js
+++ b/hr_bim_asset/tests/witness_erp_govern_wire.js
@@ -30,6 +30,7 @@ self.HbaOccupancy = require('../occupancy');
 self.HbaAdPayroll = require('../ad_payroll');
 self.HbaAdTenancy = require('../ad_tenancy');
 self.HbaAdAttendance = require('../ad_attendance');
+self.HbaAdBom = require('../ad_bom');
 self.HbaIot = require('../iot');
 var HBALens = require('../../viewer/hba_lens');   // exports the API incl. the §STAGE2 witness hooks
 
@@ -73,6 +74,11 @@ initSqlJs().then(function (SQL) {
      && spec.rows.every(function (r) { return (r.C_BPartner_ID === 1001 || r.C_BPartner_ID === 1002) && r.M_Locator_ID != null && r.HR_Process_ID != null; })
      && (spec.rows.length + spec.skipped.length) === sessCount,
      'A._hbaAttendanceSpec: ' + spec.rows.length + '/' + sessCount + ' sessions → real C_Attendance rows (every FK real, none lost)');
+  // WIRE4 — §BOM-ERP-CENTERED: _regovern reads the native BOM as a lens over the real seeded pp_product_bom.
+  var bom = A._hbaBomSpec;
+  ok('WIRE4-bom-lens', bom && bom.assemblies.length > 0
+     && bom.assemblies.every(function (a) { return a.building === 'HHS_Office_Federated' && a.lines.length > 0; }),
+     'A._hbaBomSpec: ' + (bom ? bom.assemblies.length : 0) + ' BIM assemblies read as a lens over real pp_product_bom (ERP is the authority, not Java m_bom)');
 
   db.close();
   fin();

--- a/scripts/seed_hba_bom.js
+++ b/scripts/seed_hba_bom.js
@@ -1,0 +1,269 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// ⚠ DO NOT REMOVE — seed_hba_bom.js — W-HBA-BOM-SEED reproducible seed + self-witness.
+//
+// Implementing bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §BOM-ERP-CENTERED (user directive
+// 2026-07-03: "the Java era is not source of truth, the ERP is; all BIM data models are ERP-centered; set it
+// right at source, exact mapping to iDempiere"). Makes iDempiere the AUTHORITY for the BIM BOM: the recipe tree
+// LIVES in the NATIVE stock tables pp_product_bom/pp_product_bomline (already present in ad_seed.db — NOT
+// Ninja-staged, unlike C_Attendance), sourced from the REAL IFC extraction (a building's own
+// rel_contained_in_space room→elements containment), NOT from the Java m_bom transient. The BIM BOM panel is a
+// LENS (ad_bom.readBom / the AD_InfoWindow declared below) over these rows. Read the log after every run.
+//
+//   1. AD_Ref_List 'B'=BIM for AD_Reference 347 ("M_BOM Type") — the missing master value (stock has
+//      A/C/F/K/M/O/P/R/S, no BIM). EXACT MAP: cloned from a real AD_Ref_List row of 347 (every column the real
+//      table populates), only Value/Name/id/UU overridden — never a hand-built partial row.
+//   2. M_Product_Category per distinct ifc_class among the contained elements (Value=ifc_class) — the element's
+//      real category. (M_Product_Category.IFC_Class is a runtime-ERP bolt-on ABSENT from ad_seed.db's pristine
+//      mirror, so the ifc_class rides Value/Name — exact to what THIS db has.)
+//   3. M_Product for every room (the ASSEMBLY: IsBOM='Y', M_Locator_ID = the Stage-1 seeded locator, category
+//      IfcSpace) + every contained element (the LEAF: IsBOM='N', category=its ifc_class). Value=guid — so
+//      ad_tenancy.js toProductRow's match-by-guid ALSO resolves to these now (tenancy product governance,
+//      completed as a side effect). Proto-cloned from a real M_Product row → exact column set.
+//   4. pp_product_bom header per room (m_product_id=room-product, BOMType='B', BOMUse='M') + pp_product_bomline
+//      per contained element (m_product_id=element-product, QtyBOM=1, Line ordinal, ComponentType='CO'). Row
+//      SHAPE from ad_bom.js's OWN toBomRow/toBomLineRow builders (one shape definition, reused) with REAL DB ids.
+//   5. AD_InfoWindow BOM lens (ad_bom.readBom's exact JOIN) + AD_InfoColumn rows — the panel's data source.
+//   6. SELF-WITNESS (W-HBA-BOM-SEED): AD_Ref_List 'B' present; every seeded BOMType='B' resolves in the
+//      dictionary (FK integrity); the lens JOIN is LOSSLESS (every pp_product_bomline resolves
+//      pp_product_bom→M_Product→M_Locator→M_Warehouse to the pinned HHS building); header count == rooms with
+//      members. NAMES the issue it proves: the BIM BOM is now an iDempiere-native store read as a lens.
+//
+// IDEMPOTENT: find-or-create everywhere (a 2nd run adds 0). Deterministic: fixed NOW, no Date.now/random.
+// EXTRACT-only: the BOM tree is the building's OWN rel_contained_in_space; every AD row proto-cloned from a
+// real row of the target table (exact iDempiere mapping, per the user's "set right at source" directive).
+//
+// Run: NODE_PATH=$HOME/bim-ootb/node_modules node scripts/seed_hba_bom.js   (writes erp/ad_seed.db in place)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+
+const ROOT = path.join(__dirname, '..');
+const SEED = path.join(ROOT, 'erp', 'ad_seed.db');
+const BUILDING_DB = path.join(ROOT, 'buildings', 'HHS_Office_Federated_extracted.db');
+const LOCS = require(path.join(ROOT, 'hr_bim_asset', 'fixtures', 'hhs_room_locators.json'));
+const AdBom = require(path.join(ROOT, 'hr_bim_asset', 'ad_bom.js'));
+
+const NOW = '2026-07-03 00:00:00';
+const REF_BOMTYPE = 347;                       // AD_Reference "M_BOM Type"
+const C_UOM_EACH = 100;                        // stock 'Each' UOM (verified live)
+const INFO_BASE = 7700000;                     // BOM lens id (attendance used 7600000)
+
+function scalar(db, sql, p) { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values[0][0] : null; }
+function rows(db, sql, p) {
+  var r = db.exec(sql, p || []); if (!r.length) return [];
+  var cs = r[0].columns;
+  return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+}
+function ins(db, table, obj) {
+  var ks = Object.keys(obj);
+  db.run('INSERT INTO ' + table + ' (' + ks.join(',') + ') VALUES (' + ks.map(function () { return '?'; }).join(',') + ')',
+    ks.map(function (k) { return obj[k]; }));
+}
+// proto-clone: read a REAL row of `table` (matching whereSql), keep its populated columns, apply overrides.
+// Guarantees EXACT iDempiere mapping — every column the real table actually populates is present, no partial row.
+function protoClone(db, table, whereSql, params, overrides) {
+  var r = db.exec('SELECT * FROM ' + table + (whereSql ? (' WHERE ' + whereSql) : '') + ' LIMIT 1', params || []);
+  if (!r.length || !r[0].values.length) return null;
+  var proto = {}; r[0].columns.forEach(function (c, i) { if (r[0].values[0][i] != null) proto[c] = r[0].values[0][i]; });
+  return Object.assign({}, proto, overrides);
+}
+function nextIdFactory(db, table, idCol) {
+  var n = Number(scalar(db, 'SELECT COALESCE(MAX(' + idCol + '),0) FROM ' + table)) || 0;
+  return function () { return ++n; };
+}
+
+(async function () {
+  var fails = 0;
+  function L(m) { console.log(m); }
+  function must(tag, cond, msg) { L('§W-HBA-BOM-SEED ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); if (!cond) fails++; }
+
+  if (!fs.existsSync(SEED)) { L('§SEED_HBA_BOM FAIL — erp/ad_seed.db not found'); process.exit(1); }
+  if (!fs.existsSync(BUILDING_DB)) { L('§SEED_HBA_BOM FAIL — building DB not found: ' + BUILDING_DB); process.exit(1); }
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(fs.readFileSync(SEED));
+  const bdb = new SQL.Database(fs.readFileSync(BUILDING_DB));
+  var added = { reflist: 0, categories: 0, products: 0, headers: 0, lines: 0, info: 0 };
+
+  // ── 1. AD_Ref_List 'B'=BIM for AD_Reference 347 ──────────────────────────────────────────────────────────
+  var refBid = scalar(db, 'SELECT AD_Ref_List_ID FROM AD_Ref_List WHERE AD_Reference_ID=? AND Value=?', [REF_BOMTYPE, 'B']);
+  if (refBid == null) {
+    var nextRef = nextIdFactory(db, 'AD_Ref_List', 'AD_Ref_List_ID');
+    var row = protoClone(db, 'AD_Ref_List', 'AD_Reference_ID=?', [REF_BOMTYPE],
+      { AD_Ref_List_ID: nextRef(), Value: 'B', Name: 'BIM', Description: 'BIM structural/spatial recipe (BIM OOTB)',
+        Created: NOW, Updated: NOW, CreatedBy: 100, UpdatedBy: 100, AD_Ref_List_UU: 'hba-refl-bomtype-b' });
+    if (!row) { must('REFLIST-PROTO', false, 'no proto AD_Ref_List row for AD_Reference 347'); }
+    else { ins(db, 'AD_Ref_List', row); added.reflist++; L('§SEED_BOM_REFLIST ADD Value=B (BIM) → AD_Reference 347, id=' + row.AD_Ref_List_ID); }
+  } else L('§SEED_BOM_REFLIST SKIP Value=B exists id=' + refBid);
+
+  // ── 2. read the REAL BOM source: the building's rel_contained_in_space (room→elements) ───────────────────
+  var contain = rows(bdb, 'SELECT space_guid, element_guid FROM rel_contained_in_space');
+  var metaRows = rows(bdb, 'SELECT guid, ifc_class, element_name FROM elements_meta');
+  var metaByGuid = {}; metaRows.forEach(function (m) { metaByGuid[m.guid] = m; });
+  // rooms = containment spaces that ARE Stage-1 seeded locators (real, resolvable). members per room.
+  var roomMembers = {};
+  contain.forEach(function (c) {
+    if (LOCS.locators[c.space_guid] == null) return;   // only rooms with a real seeded M_Locator
+    (roomMembers[c.space_guid] = roomMembers[c.space_guid] || []).push(c.element_guid);
+  });
+  var roomGuids = Object.keys(roomMembers).sort();
+  L('§SEED_BOM_SOURCE rooms=' + roomGuids.length + ' (with real locators) containment_rows=' + contain.length
+    + ' total_members=' + roomGuids.reduce(function (s, g) { return s + roomMembers[g].length; }, 0));
+
+  // ── 3a. M_Product_Category per distinct ifc_class (+ IfcSpace for rooms) ─────────────────────────────────
+  var nextCat = nextIdFactory(db, 'M_Product_Category', 'M_Product_Category_ID');
+  var catByClass = {};
+  function ensureCategory(ifcClass) {
+    if (catByClass[ifcClass] != null) return catByClass[ifcClass];
+    var id = scalar(db, 'SELECT M_Product_Category_ID FROM M_Product_Category WHERE Value=?', [ifcClass]);
+    if (id == null) {
+      id = nextCat();
+      var row = protoClone(db, 'M_Product_Category', null, [], { M_Product_Category_ID: id, Value: ifcClass,
+        Name: ifcClass, Description: 'BIM element category (ifc_class) — BIM OOTB', Created: NOW, Updated: NOW,
+        CreatedBy: 100, UpdatedBy: 100, M_Product_Category_UU: 'hba-cat-' + ifcClass.toLowerCase() });
+      ins(db, 'M_Product_Category', row); added.categories++;
+    }
+    catByClass[ifcClass] = id; return id;
+  }
+  var classes = {};
+  roomGuids.forEach(function (g) { roomMembers[g].forEach(function (e) { var m = metaByGuid[e]; if (m && m.ifc_class) classes[m.ifc_class] = 1; }); });
+  Object.keys(classes).forEach(ensureCategory);
+  ensureCategory('IfcSpace');   // room assembly category
+  L('§SEED_BOM_CAT categories added=' + added.categories + ' (' + Object.keys(catByClass).length + ' distinct ifc_class incl IfcSpace)');
+
+  // ── 3b. M_Product for rooms (assembly) + elements (leaf) — proto-cloned, Value=guid ──────────────────────
+  var nextProd = nextIdFactory(db, 'M_Product', 'M_Product_ID');
+  var prodByGuid = {};
+  function ensureProduct(guid, name, isBom, catId, locatorId) {
+    if (prodByGuid[guid] != null) return prodByGuid[guid];
+    var id = scalar(db, 'SELECT M_Product_ID FROM M_Product WHERE Value=?', [guid]);
+    if (id == null) {
+      id = nextProd();
+      var ov = { M_Product_ID: id, Value: guid, Name: name || guid, IsBOM: isBom, C_UOM_ID: C_UOM_EACH,
+        M_Product_Category_ID: catId, ProductType: 'I', IsStocked: 'N', IsPurchased: 'N', IsSold: 'N',
+        IsSummary: 'N', Description: 'BIM element (BIM OOTB) — real extraction guid', Created: NOW, Updated: NOW,
+        CreatedBy: 100, UpdatedBy: 100, M_Product_UU: 'hba-prod-' + guid.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 28) };
+      if (locatorId != null) ov.M_Locator_ID = locatorId;
+      var row = protoClone(db, 'M_Product', null, [], ov);
+      ins(db, 'M_Product', row); added.products++;
+    }
+    prodByGuid[guid] = id; return id;
+  }
+  var spaceCat = catByClass['IfcSpace'];
+  roomGuids.forEach(function (g) {
+    ensureProduct(g, g, 'Y', spaceCat, LOCS.locators[g]);   // room = assembly (IsBOM='Y'), bound to its locator
+    roomMembers[g].forEach(function (e) {
+      var m = metaByGuid[e]; var cls = (m && m.ifc_class) || 'IfcBuildingElementProxy';
+      ensureProduct(e, (m && m.element_name) || e, 'N', ensureCategory(cls), null);
+    });
+  });
+  L('§SEED_BOM_PROD M_Product added=' + added.products + ' (rooms + distinct contained elements, Value=guid)');
+
+  // ── 4. pp_product_bom header per room + pp_product_bomline per element — ad_bom.js builders, REAL ids ─────
+  var nextHdr = nextIdFactory(db, 'PP_Product_BOM', 'PP_Product_BOM_ID');
+  var nextLn = nextIdFactory(db, 'PP_Product_BOMLine', 'PP_Product_BOMLine_ID');
+  function stdCols(o) { o.AD_Client_ID = 11; o.AD_Org_ID = 0; o.IsActive = 'Y'; o.Created = NOW; o.CreatedBy = 100; o.Updated = NOW; o.UpdatedBy = 100; return o; }
+  roomGuids.forEach(function (g) {
+    var roomProd = prodByGuid[g];
+    var existing = scalar(db, "SELECT PP_Product_BOM_ID FROM PP_Product_BOM WHERE M_Product_ID=? AND BOMType='B'", [roomProd]);
+    var hdrId = existing != null ? existing : nextHdr();
+    if (existing == null) {
+      // ad_bom.toBomRow = the ONE shape definition; feed it the real header id + the resolved parent product.
+      var hrow = AdBom.toBomRow({ bom_id: g, bom_name: g }, roomProd, function () { return hdrId; });
+      hrow.c_uom_id = C_UOM_EACH;
+      // ad_bom emits lowercase; the physical table is case-insensitive — normalise to the seed's PascalCase idiom.
+      ins(db, 'PP_Product_BOM', stdCols({ PP_Product_BOM_ID: hdrId, M_Product_ID: hrow.m_product_id,
+        Value: hrow.value, Name: hrow.name, BOMType: hrow.bomtype, BOMUse: hrow.bomuse, C_UOM_ID: C_UOM_EACH,
+        Description: 'BIM room recipe (BIM OOTB)', ValidFrom: NOW, PP_Product_BOM_UU: 'hba-bom-' + g.toLowerCase() }));
+      added.headers++;
+    }
+    roomMembers[g].forEach(function (e, i) {
+      var childProd = prodByGuid[e];
+      if (scalar(db, 'SELECT PP_Product_BOMLine_ID FROM PP_Product_BOMLine WHERE PP_Product_BOM_ID=? AND M_Product_ID=?', [hdrId, childProd]) != null) return;
+      var lnId = nextLn();
+      var lrow = AdBom.toBomLineRow({ qty: 1, component_type: 'CO' }, hdrId, childProd, function () { return lnId; }, i + 1);
+      ins(db, 'PP_Product_BOMLine', stdCols({ PP_Product_BOMLine_ID: lnId, PP_Product_BOM_ID: hdrId,
+        M_Product_ID: lrow.m_product_id, QtyBOM: lrow.qtybom, Line: lrow.line, ComponentType: lrow.componenttype,
+        C_UOM_ID: C_UOM_EACH, PP_Product_BOMLine_UU: 'hba-bomln-' + hdrId + '-' + lnId }));
+      added.lines++;
+    });
+  });
+  L('§SEED_BOM_ROWS pp_product_bom headers added=' + added.headers + ' pp_product_bomline added=' + added.lines);
+
+  // ── 5. AD_InfoWindow BOM lens (ad_bom.readBom's exact JOIN) ───────────────────────────────────────────────
+  var FROM = 'PP_Product_BOM H JOIN M_Product HP ON H.M_Product_ID=HP.M_Product_ID'
+    + ' LEFT JOIN M_Locator L ON HP.M_Locator_ID=L.M_Locator_ID'
+    + ' LEFT JOIN M_Warehouse W ON L.M_Warehouse_ID=W.M_Warehouse_ID'
+    + ' JOIN PP_Product_BOMLine BL ON BL.PP_Product_BOM_ID=H.PP_Product_BOM_ID'
+    + ' JOIN M_Product CP ON BL.M_Product_ID=CP.M_Product_ID';
+  var attTableId = scalar(db, "SELECT AD_Table_ID FROM AD_Table WHERE lower(TableName)='pp_product_bom'");
+  if (scalar(db, 'SELECT ad_infowindow_id FROM ad_infowindow WHERE ad_infowindow_id=?', [INFO_BASE]) == null) {
+    ins(db, 'ad_infowindow', { ad_infowindow_id: INFO_BASE, ad_client_id: 11, ad_org_id: 0, isactive: 'Y',
+      created: NOW, createdby: 100, updated: NOW, updatedby: 100, name: 'BIM BOM',
+      description: 'BIM recipe lens — assembly/component over the real MRP BOM (ERP-centered)',
+      ad_table_id: attTableId, entitytype: 'U', fromclause: FROM, whereclause: "H.BOMType='B'",
+      orderbyclause: 'H.PP_Product_BOM_ID, BL.Line', isvalid: 'Y', isdefault: 'N', isdistinct: 'N', seqno: 10,
+      ad_infowindow_uu: 'hba-infowin-bom' });
+    added.info++;
+    L('§SEED_BOM_INFOWIN ADD id=' + INFO_BASE + ' fromclause = ad_bom.readBom JOIN');
+  } else L('§SEED_BOM_INFOWIN SKIP exists id=' + INFO_BASE);
+  var INFO_COLS = [
+    { name: 'Assembly', sel: 'HP.Name', col: 'AssemblyName' },
+    { name: 'Building', sel: 'W.Name', col: 'WarehouseName' },
+    { name: 'Room', sel: 'L.Value', col: 'LocatorValue' },
+    { name: 'Component', sel: 'CP.Name', col: 'ComponentName' },
+    { name: 'Component GUID', sel: 'CP.Value', col: 'ComponentValue' },
+    { name: 'Qty', sel: 'BL.QtyBOM', col: 'QtyBOM' }
+  ];
+  INFO_COLS.forEach(function (c, i) {
+    var id = INFO_BASE + 1 + i;
+    if (scalar(db, 'SELECT ad_infocolumn_id FROM ad_infocolumn WHERE ad_infocolumn_id=?', [id]) != null) return;
+    ins(db, 'ad_infocolumn', { ad_infocolumn_id: id, ad_client_id: 11, ad_org_id: 0, isactive: 'Y', created: NOW,
+      createdby: 100, updated: NOW, updatedby: 100, name: c.name, ad_infowindow_id: INFO_BASE, entitytype: 'U',
+      selectclause: c.sel, columnname: c.col, seqno: (i + 1) * 10, isdisplayed: 'Y', isquerycriteria: 'N',
+      ad_infocolumn_uu: 'hba-bominfocol-' + c.col.toLowerCase() });
+    added.info++;
+  });
+  L('§SEED_BOM_INFOCOL cols=' + INFO_COLS.length);
+
+  // ── 6. SELF-WITNESS ──────────────────────────────────────────────────────────────────────────────────────
+  must('REFLIST-B', scalar(db, 'SELECT COUNT(*) FROM AD_Ref_List WHERE AD_Reference_ID=? AND Value=?', [REF_BOMTYPE, 'B']) == 1,
+    "AD_Ref_List carries Value='B' (BIM) for AD_Reference 347 (exact-mapped dictionary extension)");
+  var badType = Number(scalar(db, "SELECT COUNT(*) FROM PP_Product_BOM H WHERE H.BOMType IS NOT NULL AND NOT EXISTS (SELECT 1 FROM AD_Ref_List r WHERE r.AD_Reference_ID=" + REF_BOMTYPE + " AND r.Value=H.BOMType)"));
+  must('BOMTYPE-FK', badType === 0, 'every PP_Product_BOM.BOMType resolves in the AD_Ref_List dictionary (0 orphans) — no deviating enum');
+
+  // lens JOIN LOSSLESS — every bomline for a 'B' BOM resolves through the full chain to the pinned HHS building.
+  var joined = rows(db, 'SELECT BL.PP_Product_BOMLine_ID AS line, W.Name AS building, L.Value AS room, CP.Value AS comp'
+    + ' FROM ' + FROM + " WHERE H.BOMType='B' ORDER BY BL.PP_Product_BOMLine_ID");
+  var totalLines = Number(scalar(db, "SELECT COUNT(*) FROM PP_Product_BOMLine BL JOIN PP_Product_BOM H ON BL.PP_Product_BOM_ID=H.PP_Product_BOM_ID WHERE H.BOMType='B'"));
+  must('LENS-JOIN-LOSSLESS', joined.length === totalLines && totalLines > 0,
+    'BOM lens JOIN resolves ALL ' + totalLines + ' pp_product_bomline rows (assembly→M_Product→M_Locator→M_Warehouse + component) — joined=' + joined.length);
+  must('LENS-BUILDING', joined.length > 0 && joined.every(function (r) { return r.building === LOCS.warehouse_value; }),
+    'every BOM line lands in the pinned HHS building (' + LOCS.warehouse_value + ')');
+  var hdrCount = Number(scalar(db, "SELECT COUNT(*) FROM PP_Product_BOM WHERE BOMType='B'"));
+  must('HEADER-PER-ROOM', hdrCount === roomGuids.length,
+    'ONE pp_product_bom header per room-with-members (' + hdrCount + '/' + roomGuids.length + ')');
+
+  // readBom lens read (the panel's actual data path) covers every line
+  function erpQuery(sql, params) {
+    var r = db.exec(sql, params || []); if (!r.length) return [];
+    var cs = r[0].columns; return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+  }
+  var lensOut = AdBom.readBom(erpQuery, { m_warehouse_id: LOCS.m_warehouse_id });
+  var lensLines = lensOut.assemblies.reduce(function (s, a) { return s + a.lines.length; }, 0);
+  must('READBOM-LENS', lensOut.assemblies.length === roomGuids.length && lensLines === totalLines,
+    'ad_bom.readBom returns ' + lensOut.assemblies.length + ' assemblies / ' + lensLines + ' component lines == the seeded rows (the panel reads the ERP as a lens)');
+
+  // ── write-back + summary ────────────────────────────────────────────────────────────────────────────────
+  var changed = added.reflist + added.categories + added.products + added.headers + added.lines + added.info;
+  if (changed > 0 && fails === 0) { fs.writeFileSync(SEED, Buffer.from(db.export())); L('§SEED_HBA_BOM WROTE erp/ad_seed.db (' + changed + ' additions)'); }
+  else if (fails === 0) L('§SEED_HBA_BOM NO-OP — seed already current (idempotent 2nd run)');
+  else L('§SEED_HBA_BOM NOT WRITTEN — ' + fails + ' witness failure(s), DB left untouched');
+  L('§W-HBA-BOM-SEED ' + (fails === 0 ? 'PASS' : 'FAIL') + ' — summary ' + JSON.stringify(added));
+  db.close(); bdb.close();
+  process.exit(fails === 0 ? 0 : 1);
+})();

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -12,7 +12,7 @@
   var G = (typeof self !== 'undefined' ? self : this);
 
   // the WITNESSED engine (loaded as <script> before this file → self.Hba* globals)
-  function HBA() { return { O: G.HbaOverlay, B: G.HbaBinding, M: G.HbaModels, L: G.HbaLens, T: G.HbaTimeline, A: G.HbaAttendance, OC: G.HbaOccupancy, AD: G.HbaAdPayroll, Lv: G.HbaLeave, ADT: G.HbaAdTenancy, ADA: G.HbaAdAttendance, IoT: G.HbaIot }; }
+  function HBA() { return { O: G.HbaOverlay, B: G.HbaBinding, M: G.HbaModels, L: G.HbaLens, T: G.HbaTimeline, A: G.HbaAttendance, OC: G.HbaOccupancy, AD: G.HbaAdPayroll, Lv: G.HbaLeave, ADT: G.HbaAdTenancy, ADA: G.HbaAdAttendance, ADB: G.HbaAdBom, IoT: G.HbaIot }; }
   function ready() { var h = HBA(); return !!(h.O && h.B && h.M); }
 
   // hex '#2e7d32' | int → int for THREE emissive.setHex
@@ -357,10 +357,19 @@
         locatorMap: h.ADA.locatorMapFromLocators(locRows) });
       n++;
     }
+    // §BOM-ERP-CENTERED — read the BIM BOM as a LENS over the real seeded pp_product_bom (ad_bom.readBom), the
+    // ERP being the authority (never the Java m_bom). Scoped to THIS building's warehouse. Stage 3 renders a
+    // BOM pane off this spec; here we make the governed lens data available. Honest empty if no 'B' BOMs.
+    if (h.ADB && h.ADB.readBom) {
+      var whId = (A._hbaTenancySpec && A._hbaTenancySpec.warehouse) ? A._hbaTenancySpec.warehouse.m_warehouse_id : null;
+      A._hbaBomSpec = h.ADB.readBom(eq, whId != null ? { m_warehouse_id: whId } : {});
+      n++;
+    }
     console.log('§HBA_GOVERN on — re-compiled ' + n + ' governable spec(s) off real ad_seed.db (payroll _governed='
       + !!(A._hbaPayrollSpec && A._hbaPayrollSpec._governed)
       + ' warehouse=' + (A._hbaTenancySpec ? A._hbaTenancySpec.warehouse.m_warehouse_id : 'n/a')
-      + ' C_Attendance=' + (A._hbaAttendanceSpec ? (A._hbaAttendanceSpec.rows.length + '/' + (A._hbaAttendanceSpec.rows.length + A._hbaAttendanceSpec.skipped.length)) : 'n/a') + ')');
+      + ' C_Attendance=' + (A._hbaAttendanceSpec ? (A._hbaAttendanceSpec.rows.length + '/' + (A._hbaAttendanceSpec.rows.length + A._hbaAttendanceSpec.skipped.length)) : 'n/a')
+      + ' BOM=' + (A._hbaBomSpec ? (A._hbaBomSpec.assemblies.length + ' assemblies') : 'n/a') + ')');
     if (A.markDirty) A.markDirty();
   }
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -912,6 +912,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../hr_bim_asset/avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hr avatars.js')"></script>
 <script src="../hr_bim_asset/ad_tenancy.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_tenancy.js')"></script>
 <script src="../hr_bim_asset/ad_attendance.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_attendance.js')"></script>
+<script src="../hr_bim_asset/ad_bom.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_bom.js')"></script>
 <script src="../hr_bim_asset/iot.js?v=1" onerror="console.warn('§LOAD_FAIL hr iot.js')"></script>
 <script src="hba_lens.js?v=5" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
 <script src="hba_avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hba_avatars.js')"></script>


### PR DESCRIPTION
**User directive (2026-07-03):** *"the Java era is not source of truth, the ERP is; all BIM data models are ERP-centered; set it right at source, exact mapping to iDempiere."*

This corrects the BOM lane, which had framed the Java `m_bom` transient (`X_M_BOM.java`/`BOMWalker.java`/`schema_snapshot_bom.sql`) as the authority. Now the BIM BOM **lives in iDempiere** and the panel reads it as a **lens**.

## The fix
- **`scripts/seed_hba_bom.js`** — seeds the recipe tree into the **native stock** `pp_product_bom`/`pp_product_bomline` (already present in `ad_seed.db` — no Ninja needed, unlike C_Attendance) from the **real IFC extraction** (HHS's own `rel_contained_in_space` room→elements), **not** Java `m_bom`. Seeds: `AD_Ref_List 'B'`=BIM for AD_Reference 347 · `M_Product_Category` per ifc_class · `M_Product` per room (`IsBOM='Y'`, bound to its `M_Locator`) + per element (`Value=guid`) · **13** `pp_product_bom` headers + **88** `pp_product_bomline` · an `AD_InfoWindow` BOM lens.
- **Exact mapping (the "set right at source" part):** every AD row is **proto-cloned from a real row of the target table** — no hand-built partial rows, no deviating enums (`componenttype='CO'`, `bomtype` FK-valid in the dictionary). Self-witness `W-HBA-BOM-SEED` **6/6**, idempotent (2nd run adds 0).
- **`ad_bom.js` reframed** — header now states the BOM lives in iDempiere; Java `m_bom` demoted to a **transitional migration source being absorbed** ([[project_erp_one_base_doctrine]]), not an authority. **NEW `readBom(erpQuery)`** — the lens read over the real seeded rows (the panel's data source). The builders are reused by the seed as the one shape definition.
- **`viewer/hba_lens.js`** — `_regovern` reads `A._hbaBomSpec` via `readBom` over `A.erpQuery` (`BOM=13 assemblies`); `ad_bom.js` loaded in `viewer.html`. Additive; the BOM **pane UI** is Stage 3.
- **Side effect:** seeding room/element `M_Product`s (`Value=guid`) **completes `ad_tenancy.toProductRow` governance** — a room guid now resolves to a real seeded `M_Product`, not a compile-time mint.

## Witnesses
- **`W-HBA-BOM-SEED` 6/6** (seed self-witness) — AD_Ref_List 'B' present, BOMType FK-valid, **lens JOIN lossless 88/88** (`pp_product_bom→M_Product→M_Locator→M_Warehouse` + component), header-per-room, idempotent.
- **`W-HBA-BOM-GOVERNED` 6/6** — `readBom` over the **shipped `ad_seed.db`**: 13 assemblies / 88 lines, exact-map, tenancy product governed.
- **`W-HBA-ERP-GOVERN-WIRE` now 5/5** — `_regovern` produces the BOM lens spec.
- Full `hr_bim_asset` suite **38/38 green**.

## Doctrine
Every BIM data model is now an iDempiere-native table or a lens over one; the only BIM-native exception is pure geometry (keyed by the same guid identities). Java-era schemas are migration sources, absorbed — never authorities. Stage 3 (Fable5): a BOM pane off `A._hbaBomSpec` + the live headless smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)