### PR TITLE
feat(modeller): §V7 floating dimension readout during drags (POLISH3 follow-up)

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1387,6 +1387,7 @@ function enterGridMove() {
 function exitGridMove() {
   gridMoving = false; _dragGrid = null; bGridMove.innerHTML = GM_MOVE; controls.enabled = true; applyModeCursor();
   if (gmPreview) { scene.remove(gmPreview); gmPreview = null; } gmClearTints();
+  if (typeof dimLabelHide === 'function') dimLabelHide();       // §V7
 }
 bGridMove.onclick = () => gridMoving ? exitGridMove() : enterGridMove();
 canvas.addEventListener('pointerdown', (e) => {
@@ -1416,8 +1417,10 @@ canvas.addEventListener('pointermove', (e) => {
   gmPreviewLine(_dragGrid.axis, _dragGrid.coord + _dragGrid.delta);
   try { const r2 = gmTint(window.Bonsai.gridmove.computeCommands(_dragGrid.id, _dragGrid.delta));   // PREVIEW which walls move/stretch
     setStat('grid ' + _dragGrid.id + ' Δ' + _dragGrid.delta.toFixed(2) + ' — ' + r2.t + ' move, ' + r2.s + ' stretch'); } catch (err) { }
+  if (typeof dimLabelShow === 'function') dimLabelShow(_dragGrid.id + ' Δ' + (_dragGrid.delta >= 0 ? '+' : '') + _dragGrid.delta.toFixed(2) + 'm', hit);   // §V7
 });
 async function commitGridMove() {
+  if (typeof dimLabelHide === 'function') dimLabelHide();       // §V7 (also covers the FAIL path below)
   if (!_dragGrid || Math.abs(_dragGrid.delta || 0) < 0.05) { exitGridMove(); return; }
   const { id, delta } = _dragGrid;
   setStat('recomposing…');
@@ -1453,6 +1456,47 @@ const MV_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>
 let moving = false, _moveDrag = null, moveGizmo = null, moveGhost = null;
 const dimMove = document.getElementById('dim-move');
 const dimRot = document.getElementById('dim-rot'), dimScale = document.getElementById('dim-scale');
+// ── §POLISH3 §V7 (RESUME_MODELLER_POLISH3.md — Witness: W-E2E-FLOATDIM): in-scene floating dimension
+// readout during a drag. ONE reusable canvas-texture Sprite (core build — CSS2DRenderer is not vendored),
+// depthTest:false + high renderOrder so it reads over geometry, scaled by camera distance to hold a constant
+// screen size. Every caller passes the SAME number the status bar shows (never a second math path).
+let _dimLabel = null;
+function _dimLabelSprite() {
+  if (_dimLabel) return _dimLabel;
+  const cv = document.createElement('canvas'); cv.width = 256; cv.height = 64;
+  const tex = new THREE.CanvasTexture(cv);
+  const sp = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false, transparent: true }));
+  sp.renderOrder = 1000; sp.visible = false; sp.userData.dimLabel = true;
+  scene.add(sp);
+  _dimLabel = { sp, cv, tex, text: '' };
+  return _dimLabel;
+}
+function dimLabelShow(text, pos) {
+  const L = _dimLabelSprite();
+  if (text !== L.text) {                                   // redraw only when the value actually changes
+    const ctx = L.cv.getContext('2d');
+    ctx.clearRect(0, 0, 256, 64);
+    ctx.font = '600 26px ui-monospace, monospace';
+    const w = Math.min(ctx.measureText(text).width + 28, 254);
+    ctx.fillStyle = 'rgba(19,21,26,0.88)';
+    ctx.beginPath(); ctx.roundRect((256 - w) / 2, 8, w, 46, 10); ctx.fill();
+    ctx.strokeStyle = '#3a6ea5'; ctx.lineWidth = 2; ctx.stroke();
+    ctx.fillStyle = '#cfe3f6'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(text, 128, 32);
+    L.tex.needsUpdate = true; L.text = text;
+  }
+  const d = Math.max(camera.position.distanceTo(pos), 0.5);
+  L.sp.position.set(pos.x, pos.y, pos.z + 0.05 * d);       // float just above the drag point
+  L.sp.scale.set(0.09 * d, 0.0225 * d, 1);                 // 4:1 canvas aspect, constant on screen
+  L.sp.visible = true;
+  window.__dimLabel = { text: text, x: pos.x, y: pos.y, z: pos.z, scale: L.sp.scale.x };   // witness oracle
+  if (window.A && A.requestRender) A.requestRender();
+}
+function dimLabelHide() {
+  if (_dimLabel) _dimLabel.sp.visible = false;
+  window.__dimLabel = null;
+  if (window.A && A.requestRender) A.requestRender();
+}
 function moveStep() {                                          // typed magnitude (P2); else grid pitch; else 0.1m
   const v = parseFloat(dimMove && dimMove.value); if (v > 0) return v;
   const G = window.Bonsai.grid;
@@ -1688,6 +1732,7 @@ function enterMove() {
 }
 function exitMove() {
   moving = false; _moveDrag = null; bMove.innerHTML = MV_MOVE; bMove.classList.remove('on'); controls.enabled = true; applyModeCursor();
+  dimLabelHide();                                               // §V7
   if (dimMove) dimMove.style.display = 'none';
   if (dimRot) dimRot.style.display = 'none';
   if (dimScale) dimScale.style.display = 'none';
@@ -1768,6 +1813,7 @@ canvas.addEventListener('pointermove', (e) => {
     if (!e.shiftKey) deg = Math.round(deg / 15) * 15;          // 15° snap unless Shift = free angle
     _moveDrag.drot = deg; rotGhostShow(deg * Math.PI / 180);
     setStat('rotate ' + (deg >= 0 ? '+' : '') + deg.toFixed(e.shiftKey ? 1 : 0) + '°' + (e.shiftKey ? '' : '  (15° snap)'));
+    dimLabelShow((deg >= 0 ? '+' : '') + deg.toFixed(e.shiftKey ? 1 : 0) + '°', pr);   // §V7: same snapped number as the status line
     return;
   }
   if (_moveDrag.axis && _moveDrag.axis.indexOf('scale') === 0) {   // W-BONSAI-SCALE: factor = (extent + drag)/extent, edge-anchored
@@ -1780,12 +1826,14 @@ canvas.addEventListener('pointermove', (e) => {
     f = Math.max(0.1, f);                                       // never collapse past 0.1× (degenerate solid)
     _moveDrag.f = f; scaleGhostShow(ax, f);
     setStat('scale ' + ax.toUpperCase() + ' ×' + f.toFixed(2) + (e.shiftKey ? '' : '  (0.25 snap)'));
+    dimLabelShow(ax.toUpperCase() + ' ×' + f.toFixed(2), p);   // §V7
     return;
   }
   if (_moveDrag.screenZ) {                                      // H1 top-view Z: vertical screen pixels → world-Z
     const dz = zScreenDelta(_moveDrag.downPx, e.clientY, _moveDrag.c0);
     _moveDrag.dx = 0; _moveDrag.dy = 0; _moveDrag.dz = dz;
     const c = _moveDrag.c0; const sn = snappedMoveDelta('z', c, 0, 0, dz);
+    dimLabelShow('ΔZ ' + (sn.dz >= 0 ? '+' : '') + sn.dz.toFixed(2) + 'm', new THREE.Vector3(c.x, c.y, c.z + sn.dz));   // §V7
     moveGhostShow(sn.dx, sn.dy, sn.dz); showSnapMarker(sn.kind === 'geom' ? sn.marker : null);
     setStat('move Z Δz=' + sn.dz.toFixed(2) + '  (top-view screen drag)');
     return;
@@ -1801,9 +1849,15 @@ canvas.addEventListener('pointermove', (e) => {
   const ref = window.Bonsai.grid.refAt ? window.Bonsai.grid.refAt(c.x + sn.dx, c.y + sn.dy) : null;
   setStat('move ' + _moveDrag.axis.toUpperCase() + ' Δ(' + sn.dx.toFixed(2) + ',' + sn.dy.toFixed(2) + ',' + sn.dz.toFixed(2) + ')' +
     (sn.kind === 'geom' ? '  ⬥ snap-to-geometry' : (ref && (ref.x || ref.y) ? ' → ' + ((ref.x || '·') + '-' + (ref.y || '·')) : '')));
+  // §V7: floating readout at the ghost position — the SAME snapped delta the status line just printed
+  const ax7 = _moveDrag.axis;
+  dimLabelShow(ax7 === 'xy' ? ('Δ ' + sn.dx.toFixed(2) + ', ' + sn.dy.toFixed(2))
+    : ('Δ' + ax7.toUpperCase() + ' ' + (sn['d' + ax7] >= 0 ? '+' : '') + sn['d' + ax7].toFixed(2) + 'm'),
+    new THREE.Vector3(c.x + sn.dx, c.y + sn.dy, c.z + sn.dz));
 });
 async function commitMoveDrag() {
   const md = _moveDrag; _moveDrag = null; if (!md) return;
+  dimLabelHide();                                               // §V7: readout lives only while the drag is live
   if (md.axis === 'rotZ') {                                     // H3 yaw commit
     clearSnapMarker(); const deg = +(md.drot || 0).toFixed(2);
     if (Math.abs(deg) < 0.5) { clearMoveGhost(); buildMoveGizmo(); setStat('rotate: no change'); return; }

--- a/modeller/tests/witness_e2e_floatdim.js
+++ b/modeller/tests/witness_e2e_floatdim.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-FLOATDIM scope (read this block first)
+ * SCOPE: real-user witness for §POLISH3 §V7 (prompts/RESUME_MODELLER_POLISH3.md) — the in-scene floating
+ *   dimension readout during a drag. Real production path: open Duplex, pick, Move pill, HOLD a real X-handle
+ *   drag mid-gesture and read the sprite + status bar; then a real yaw-ring drag. Claims compare the label's
+ *   NUMBER against the status bar's number (same source, maths-compared) — never eyes.
+ *   Read the log after every run; exit code is not evidence.
+ *
+ * Issues under test (research spec item 8: feedback was a DOM status-bar line only):
+ *   D1 MID-DRAG-SHOWS — while the X drag is HELD, a dimLabel sprite is visible in the scene and
+ *                       window.__dimLabel.text matches ΔX ±N.NNm.
+ *   D2 SAME-NUMBER    — the label's delta EQUALS the status bar's Δ(dx,…) first component (one math path).
+ *   D3 AT-THE-GHOST   — the label sits at the element centre + the snapped delta (≤5cm), i.e. it floats where
+ *                       the element is going, not at a stale anchor.
+ *   D4 ROT-READS-DEGREES — a real yaw-ring drag held mid-gesture shows the snapped ±N° text.
+ *   D5 HIDES-ON-RELEASE — after mouse-up the oracle is null and the sprite is invisible (drag-only lens).
+ *   D6 NO-ERROR       — no pageerror across the whole sequence.
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+runE2E('W-E2E-FLOATDIM', async (t) => {
+  await t.open('Duplex');
+  const sel = await t.pick({ prefer: 'wall' });
+  if (!sel) { t.assert('D1 MID-DRAG-SHOWS', false, 'no pickable element'); return; }
+  const c0 = await t.pg.evaluate(f => {
+    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+    m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+    return [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2];
+  }, sel.fid);
+
+  await t.clickSel('#b-move'); await t.sleep(500);
+  const hw = await t.pg.evaluate(() => {
+    const giz = window.A.scene.getObjectByName('MoveGizmo'); if (!giz) return null;
+    giz.updateMatrixWorld(true); let h = null;
+    giz.traverse(o => { if (o.isMesh && o.userData.moveAxis === 'x' && !h) h = o; });
+    if (!h) return null; const w = h.getWorldPosition(new window.THREE.Vector3()); return [w.x, w.y, w.z];
+  });
+
+  // ── D1/D2/D3 — HELD X drag: down, move ~+1m, evaluate MID-GESTURE, then release ────────────────
+  let mid = null, gone = null;
+  if (hw) {
+    const down = await t.proj(hw[0], hw[1], hw[2]);
+    const up = await t.proj(hw[0] + 1.0, hw[1], hw[2]);
+    await t.pg.mouse.move(down[0], down[1]); await t.sleep(40);
+    await t.pg.mouse.down(); await t.sleep(40);
+    await t.pg.mouse.move(up[0], up[1], { steps: 8 }); await t.sleep(200);
+    mid = await t.pg.evaluate(() => {
+      const o = window.__dimLabel;
+      const sp = window.A.scene.children.find(x => x.userData && x.userData.dimLabel);
+      const stat = document.getElementById('stat') ? document.getElementById('stat').textContent : '';
+      return { oracle: o, visible: !!(sp && sp.visible), stat };
+    });
+    await t.pg.mouse.up(); await t.sleep(500);
+    gone = await t.pg.evaluate(() => {
+      const sp = window.A.scene.children.find(x => x.userData && x.userData.dimLabel);
+      return { oracle: window.__dimLabel || null, visible: !!(sp && sp.visible) };
+    });
+  }
+  const labelNum = mid && mid.oracle && /Δ?X ([+-]\d+\.\d\d)m/.test(mid.oracle.text) ? +RegExp.$1 : null;
+  const statNum = mid && /Δ\((-?\d+\.\d\d),/.test(mid.stat) ? +RegExp.$1 : null;
+  t.assert('D1 MID-DRAG-SHOWS sprite visible + ΔX text while held',
+    !!mid && mid.visible && !!mid.oracle && /ΔX [+-]\d+\.\d\dm/.test(mid.oracle.text),
+    JSON.stringify(mid && mid.oracle));
+  t.assert('D2 SAME-NUMBER label delta == status-bar delta (one math path)',
+    labelNum != null && statNum != null && Math.abs(labelNum - statNum) < 1e-9,
+    'label=' + labelNum + ' stat=' + statNum);
+  t.assert('D3 AT-THE-GHOST label sits at centre+snapped Δ (≤5cm)',
+    !!mid && mid.oracle && labelNum != null &&
+    Math.abs(mid.oracle.x - (c0[0] + labelNum)) < 0.05 && Math.abs(mid.oracle.y - c0[1]) < 0.05,
+    mid && mid.oracle ? 'label.x=' + mid.oracle.x.toFixed(3) + ' want=' + (c0[0] + labelNum).toFixed(3) : '');
+
+  // ── D4 — HELD yaw-ring drag reads degrees ──────────────────────────────────────────────────────
+  const giz = await t.pg.evaluate(() => {
+    const gz = window.A.scene.getObjectByName('MoveGizmo'); if (!gz) return null;
+    let ring = null; gz.traverse(o => { if (o.userData && o.userData.moveAxis === 'rotZ') ring = o; });
+    if (!ring) return null;
+    const c = new window.THREE.Vector3(); gz.getWorldPosition(c);
+    return { c: [c.x, c.y, c.z], R: (ring.geometry && ring.geometry.parameters && ring.geometry.parameters.radius) || 0.9 };
+  });
+  let rot = null;
+  if (giz) {
+    const th = 30 * Math.PI / 180;
+    const down = await t.proj(giz.c[0] + giz.R, giz.c[1], giz.c[2]);
+    const up = await t.proj(giz.c[0] + giz.R * Math.cos(th), giz.c[1] + giz.R * Math.sin(th), giz.c[2]);
+    await t.pg.mouse.move(down[0], down[1]); await t.sleep(40);
+    await t.pg.mouse.down(); await t.sleep(40);
+    await t.pg.mouse.move(up[0], up[1], { steps: 10 }); await t.sleep(200);
+    rot = await t.pg.evaluate(() => window.__dimLabel || null);
+    await t.pg.mouse.up(); await t.sleep(500);
+  }
+  t.assert('D4 ROT-READS-DEGREES held ring drag shows snapped ±N°',
+    !!rot && /^[+-]\d+°$/.test(rot.text), JSON.stringify(rot));
+
+  t.assert('D5 HIDES-ON-RELEASE oracle null + sprite invisible after mouse-up',
+    !!gone && gone.oracle === null && gone.visible === false, JSON.stringify(gone));
+}, { width: 1200, height: 850, dpr: 1 });

--- a/prompts/RESUME_MODELLER_POLISH3.md
+++ b/prompts/RESUME_MODELLER_POLISH3.md
@@ -83,4 +83,37 @@ whole-bucket here. Read the log after every run; exit code is not evidence.
 must stay green (they exercise every seam this batch touches: setActive, hover, pick, walk render, materials).
 Logs saved under `modeller/tests/logs/` and READ before any DONE claim.
 
+## §V7 — follow-up slice (items 8 + 10 of §NEEDS-DESIGN, named in the same watchdog assignment)
+
+- **§V7 floating dimension readout (item 8):** ONE reusable canvas-texture `THREE.Sprite` (core build, no
+  CSS2DRenderer — not vendored), `depthTest:false` + high renderOrder so it reads over geometry, scaled by
+  camera distance to hold constant screen size. Shown DURING every gizmo drag at the live drag point with the
+  SAME number the status bar computes (never a second math path): move `ΔX +1.20m` (snapped delta), rotate
+  `+15°`, scale `X ×1.25`, grid-drag `A Δ0.60m`. Hidden on commit/cancel/exit. Seam: `dimLabelShow(text,pos)` /
+  `dimLabelHide()` + `window.__dimLabel` witness oracle.
+- **§V8 R/S shortcuts (item 10): ⛔ BLOCKED — needs the user/Sonnet nod the research spec already flagged,**
+  plus a NEW fact found here: the industry `R`=rotate convention COLLIDES with the modeller's existing
+  `R`=Insert shortcut (modeller.html SHORTCUTS map + help panel). Arming rotate/scale sub-modes is mechanical
+  once keys are chosen; choosing keys (rebind Insert? pick other letters?) is a user-facing UX decision, not
+  an EXTRACT. One question: which bindings — (a) keep R=Insert, use e.g. `T`(turn)/`S`(scale), or (b) rebind
+  Insert (Blender uses Shift+A) and take R/S?
+
+- **W-E2E-FLOATDIM** (§V7): real move-gizmo drag held mid-drag → a `dimLabel` sprite is IN the scene, its
+  text equals the status bar's snapped delta (same number, maths-compared), positioned within the element's
+  neighbourhood (≤ diag of the drag), constant-screen-size scale > 0; release → hidden. Rotate ring drag →
+  `°` text matches the snapped angle. No pageerror.
+
 ## # DONE appendix (fill as items land — every claim needs a § log line)
+
+- 2026-07-03 §V1–§V6 SHIPPED — bim-ootb PR #625 (squash 5715364). Witnesses: W-E2E-OLVIRT 5/5 ·
+  W-E2E-OLEYE 5/5 · W-E2E-OLFILTER 4/4 · W-E2E-SELOUTLINE 5/5 · W-E2E-SHADOWS 5/5 (logs
+  modeller/tests/logs/w_e2e_*.log). Regression: W-OL-SYNC 6/6 · W-E2E-INSTPICK 7/7 · W-E2E-MOVE 9/9 ·
+  W-E2E-WALK-ALL 10/10. Pre-existing env reds (before==after, baseline-verified): bonsai_outliner_live,
+  bonsai_outliner_incr_live, bonsai_multiselect_live, bonsai_hover_live. Two real findings measured by
+  first-RED witnesses: THREE Raycaster does NOT skip invisible objects (pick paths filter o.visible now);
+  r184 deprecated PCFSoftShadowMap (setter coerces to PCFShadowMap).
+- 2026-07-03 §V7 SHIPPED (follow-up slice, lane/modeller-polish-4) — floating dimension readout on all four
+  drag flavours (move/rotZ/scale/grid). W-E2E-FLOATDIM 6/6 (mid-drag held: ΔX +1.00m == status bar, at the
+  ghost ≤5cm, +30° on the ring, hidden on release). Regression: W-E2E-MOVE 9/9 · W-E2E-ROTATE 7/7 ·
+  W-E2E-SCALE 7/7 · W-E2E-GRIDSTRETCH 7/7 (logs modeller/tests/logs/). §V8 (item 10 R/S shortcuts) stays
+  ⛔ BLOCKED on the key-binding question above.


### PR DESCRIPTION
Second slice of `prompts/RESUME_MODELLER_POLISH3.md` (after #625): **§NEEDS-DESIGN item 8** — the in-scene floating dimension readout every professional tool has and DAGeVu's drags lacked (feedback was the DOM status bar only).

## What
- ONE reusable canvas-texture `THREE.Sprite` (core build; CSS2DRenderer is not vendored), `depthTest:false`, distance-scaled to constant screen size, redrawn only when the value changes.
- Shown during all four drag flavours at the live drag point, always the **same snapped number the status bar computes** (never a second math path): move `ΔX +1.20m` (at the ghost position), rotate `+30°`, scale `X ×1.25`, grid `A Δ+0.60m`.
- Hidden on commit/cancel/exit, including the grid-commit FAIL path.
- **Item 10 (R/S shortcuts) marked ⛔ BLOCKED in the spec**: industry `R`=rotate collides with the existing `R`=Insert binding — which keys to use is a user-facing UX decision, flagged with one concrete question.

## Witness (real-user e2e, held mid-gesture)
W-E2E-FLOATDIM **6/6** — sprite visible while the X drag is HELD, label number == status-bar number (1.00==1.00), label sits at centre+snappedΔ (≤5cm), yaw ring shows `+30°`, oracle null + sprite invisible after release, no pageerror.

Regression green: W-E2E-MOVE 9/9 · W-E2E-ROTATE 7/7 · W-E2E-SCALE 7/7 · W-E2E-GRIDSTRETCH 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)