### PR TITLE
fix(erp): kernel timebomb T2+T1 — content-addressed signing + roster/key-epoch verify on import (sw v760)

### DIFF
--- a/erp/erp_key_epochs.js
+++ b/erp/erp_key_epochs.js
@@ -1,0 +1,165 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// erp_key_epochs.js — T1 trust root (bim-compiler prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION)
+// — Witness: W-ROSTER-VERIFY. PORTED from bim-compiler build/erp/erp_key_epochs.js (W-ROTATE, witnessed
+// §ROTATE-OP/§HISTORY-VALID/§FUTURE-GATED/§REVOKE in scripts/poc_rotate.js) — excavated doctrine
+// (DistributedERP.md §228/§290/§445), NOT fresh design. Two upgrades over the POC module:
+//
+//   1. CONTENT-AWARE MESSAGES (composes on T2/W-CONTENT-SIGN): a v2 row's sig attests the CONTENT hash
+//      (KernelOps._contentHash — no id, no prev), a v1 row's sig attests op_hash. So roster verification
+//      works across a MERGE (ids renumbered) for v2 rows — the property T1 needs and v1 could never give.
+//   2. DEVICE-LEVEL CENTRAL ROSTER: a signed { devices: {device_id → pubJwk}, genesisKid } list, HQ-signed
+//      under a PINNED key (the erp_snapshot_sign.js PINNED_PUBKEY pattern — the verifier trusts the pinned
+//      HQ key out-of-band, never a key carried inside the payload). Epoch verification draws pubByKid +
+//      genesisKid from the VERIFIED roster only.
+//
+// Model (unchanged from the witnessed POC — burn-not-reattribute, DECIDED):
+//   • The genesis device key is active from the first op.
+//   • ROTATE {kind:'ROTATE', newKid, signed_by} must be COUNTER-SIGNED by the OUTGOING (active) key;
+//     it installs newKid for ops AFTER it. History keeps verifying under the old key — never re-signed.
+//   • REVOKE {kind:'REVOKE', revokedKid, newKid?, signed_by} kills the revoked key's FUTURE ops; its PAST
+//     ops stay valid (it really did author them). Optional newKid installs the successor.
+//   • A normal op {signed_by} is valid iff that kid is ACTIVE at its seq, not revoked, sig verifies.
+// This module COMPOSES on the kernel (like erp_period_close.js): KernelOps.verifyChain = integrity+order
+// (key-independent); this is the AUTHENTICITY layer. It does not bloat kernel_ops.js.
+(function () {
+  'use strict';
+
+  function _kernel() {
+    if (typeof window !== 'undefined' && window.KernelOps) return window.KernelOps;
+    if (typeof global !== 'undefined' && global.window && global.window.KernelOps) return global.window.KernelOps;
+    return null;
+  }
+  function _snapSign() {
+    if (typeof module !== 'undefined' && module.exports) { try { return require('./erp_snapshot_sign.js'); } catch (e) {} }
+    if (typeof window !== 'undefined' && window.ErpSnapshotSign) return window.ErpSnapshotSign;
+    return null;
+  }
+
+  // ── ROSTER — the HQ-signed device list (T1's central trust root) ──────────────────────────────
+  // payload = { devices: { device_id/kid → pubJwk }, genesisKid, note? } — serialized with the kernel's
+  // stableStringify (the T2 canonical) so the signed bytes are deterministic and delimiter-safe.
+  function _rosterMessage(payload) {
+    var K = _kernel();
+    if (!K || !K.stableStringify) throw new Error('erp_key_epochs: KernelOps.stableStringify required (load kernel_ops.js ≥ v11)');
+    return 'roster1|' + K.stableStringify(payload);   // domain-separated from op/content hashes
+  }
+  // signRoster — HQ signs the roster payload (opts.sign defaults to ErpSnapshotSign.signTip).
+  async function signRoster(payload, hqPrivJwk, opts) {
+    opts = opts || {};
+    var sign = opts.sign || (_snapSign() && _snapSign().signTip);
+    if (!sign) throw new Error('erp_key_epochs: no sign fn (erp_snapshot_sign.js not loaded?)');
+    return { payload: payload, sig: await sign(hqPrivJwk, _rosterMessage(payload)) };
+  }
+  // verifyRoster — verify the roster under the PINNED HQ key (opts.hqPub, default = the pinned key in
+  // erp_snapshot_sign.js). A tampered roster (any swapped device key) fails — the key list is not advisory.
+  async function verifyRoster(signedRoster, opts) {
+    opts = opts || {};
+    var S = _snapSign();
+    var verify = opts.verify || (S && function (msg, sig, pub) { return S.verifyTip(msg, sig, pub); });
+    var hqPub = opts.hqPub || (S && S.PINNED_PUBKEY);
+    if (!verify || !hqPub) return { ok: false, why: 'no verify fn / HQ pubkey' };
+    if (!signedRoster || !signedRoster.payload || !signedRoster.sig) return { ok: false, why: 'roster missing payload/sig' };
+    var ok = await verify(_rosterMessage(signedRoster.payload), signedRoster.sig, hqPub);
+    if (!ok) { console.log('§ROSTER verify FAIL — signature invalid under the pinned HQ key'); return { ok: false, why: 'roster signature invalid' }; }
+    console.log('§ROSTER verify OK devices=' + Object.keys(signedRoster.payload.devices || {}).length +
+                ' genesis=' + signedRoster.payload.genesisKid);
+    return { ok: true, roster: signedRoster.payload };
+  }
+
+  // ── EPOCH VERIFICATION ─────────────────────────────────────────────────────────────────────────
+  // _sigMessage(op) — what this op's sig attests: v2 rows → the T2 content hash; v1 rows → op_hash.
+  async function _sigMessage(op, opts) {
+    var K = _kernel();
+    var isV2 = (opts && opts.isV2) || (K && K._isV2);
+    var contentHash = (opts && opts.contentHash) || (K && K._contentHash);
+    if (isV2 && contentHash && isV2(op.parameters)) return contentHash(op);
+    return op.op_hash;
+  }
+
+  // verifyEpochSigsOps(ops, opts) — the CORE walk, over an ARRAY (the transport/merge unit — same rows
+  // exportBranch emits). Applies ROTATE/REVOKE transitions in seq order, verifying every op under the key
+  // valid AT ITS seq (DistributedERP.md §290 — the key-epoch map).
+  //   opts = { roster: signedRoster (HQ-verified here) | pubByKid + genesisKid (direct, tests),
+  //            verify: async(msgHex, sigHex, pubJwk)->bool, hqPub?, contentHash?, isV2? }
+  //   returns { ok, len, brokeAt?, why?, activeKid }
+  async function verifyEpochSigsOps(ops, opts) {
+    opts = opts || {};
+    var S = _snapSign();
+    var verify = opts.verify || (S && function (msg, sig, pub) { return S.verifyTip(msg, sig, pub); });
+    if (!verify) return { ok: false, why: 'no verify fn' };
+    var pubByKid = opts.pubByKid, activeKid = opts.genesisKid;
+    if (opts.roster) {                                   // the central-roster path (production)
+      var rv = await verifyRoster(opts.roster, opts);
+      if (!rv.ok) return { ok: false, why: rv.why, brokeAt: null };
+      pubByKid = rv.roster.devices; activeKid = rv.roster.genesisKid;
+    }
+    if (!pubByKid || !activeKid) return { ok: false, why: 'no roster/pubByKid+genesisKid' };
+    var revoked = {};                                    // kid → the id at/after which it is rejected
+    ops = ops || [];
+    for (var i = 0; i < ops.length; i++) {
+      var o = ops[i], id = o.id;
+      if (o.op_hash == null) return _fail(id, 'unsealed (hash chain not sealed)');
+      var p = o.parameters; try { p = JSON.parse(p); } catch (e) { p = {}; }
+      var signer = p.signed_by, kind = p.kind || 'NORMAL';
+      var msg = await _sigMessage(o, opts);
+      var pendingActive = null;
+
+      if (kind === 'ROTATE') {
+        // must be counter-signed by the OUTGOING (currently-active) key.
+        if (signer !== activeKid) return _fail(id, 'ROTATE not counter-signed by outgoing key (signer=' + signer + ' active=' + activeKid + ')');
+        if (!(await verify(msg, o.sig, pubByKid[activeKid]))) return _fail(id, 'ROTATE counter-signature invalid under outgoing key ' + activeKid);
+        if (!pubByKid[p.newKid]) return _fail(id, 'ROTATE installs unknown key ' + p.newKid + ' (not in the roster)');
+        pendingActive = p.newKid;
+      } else if (kind === 'REVOKE') {
+        // signed by the current authority (the active key) — graceful offboarding / compromise recovery.
+        if (signer !== activeKid) return _fail(id, 'REVOKE not authorised by active key (signer=' + signer + ' active=' + activeKid + ')');
+        if (!(await verify(msg, o.sig, pubByKid[activeKid]))) return _fail(id, 'REVOKE signature invalid under active key ' + activeKid);
+        revoked[p.revokedKid] = id;                      // burn-not-reattribute: future rejected, past kept
+        if (p.newKid) {
+          if (!pubByKid[p.newKid]) return _fail(id, 'REVOKE installs unknown key ' + p.newKid + ' (not in the roster)');
+          pendingActive = p.newKid;
+        }
+      } else {
+        // normal op: the signer must be the ACTIVE key, not revoked, with a valid signature.
+        if (!pubByKid[signer]) return _fail(id, 'op signed by key ' + signer + ' NOT in the roster (forged foreign key)');
+        if (revoked[signer] != null && id >= revoked[signer]) return _fail(id, 'op signed by REVOKED key ' + signer + ' (revoked at ' + revoked[signer] + ')');
+        if (signer !== activeKid) return _fail(id, 'op signed by non-active key ' + signer + ' (active=' + activeKid + ') — superseded key cannot sign new ops');
+        if (!(await verify(msg, o.sig, pubByKid[signer]))) return _fail(id, 'signature invalid under ' + signer);
+      }
+      if (pendingActive) activeKid = pendingActive;
+    }
+    console.log('§EPOCH verifyEpochSigs OK len=' + ops.length + ' finalActiveKid=' + activeKid);
+    return { ok: true, len: ops.length, activeKid: activeKid };
+  }
+
+  // verifyEpochSigs(db, opts) — the db-side variant (the kernel verify path): SELECT then delegate.
+  async function verifyEpochSigs(db, opts) {
+    var r = db.exec('SELECT id, op_uuid, timestamp, op_type, parameters, input_guids, output_guid, op_hash, sig, user_tag FROM kernel_ops ORDER BY id');
+    if (!r.length) return { ok: true, len: 0, activeKid: (opts && opts.genesisKid) || null };
+    var cols = r[0].columns;
+    var ops = r[0].values.map(function (v) { var o = {}; cols.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+    return verifyEpochSigsOps(ops, opts);
+  }
+
+  function _fail(id, why) { console.log('§EPOCH verify FAIL at id=' + id + ' why=' + why); return { ok: false, brokeAt: id, why: why }; }
+
+  // singleKeyVerify — the NO-EPOCH baseline (the §FALSIFIER straw man): one fixed key forges forever.
+  // Kept from the POC only to witness the contrast against verifyEpochSigs.
+  async function singleKeyVerify(db, opts) {
+    var r = db.exec('SELECT id, op_hash, sig FROM kernel_ops ORDER BY id');
+    if (!r.length) return { ok: true, len: 0 };
+    var rows = r[0].values;
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i][1] == null) return { ok: false, brokeAt: rows[i][0], why: 'unsealed' };
+      if (!(await opts.verify(rows[i][1], rows[i][2], opts.pub))) return { ok: false, brokeAt: rows[i][0], why: 'signature invalid' };
+    }
+    return { ok: true, len: rows.length };
+  }
+
+  var _api = { signRoster: signRoster, verifyRoster: verifyRoster,
+    verifyEpochSigs: verifyEpochSigs, verifyEpochSigsOps: verifyEpochSigsOps, singleKeyVerify: singleKeyVerify };
+  if (typeof module !== 'undefined' && module.exports) { module.exports = _api; }
+  if (typeof window !== 'undefined') { window.ErpKeyEpochs = _api; }
+  if (typeof console !== 'undefined') { console.log('§EPOCH_LOADED v2 (roster + key-epoch verification, content-aware — T1/W-ROSTER-VERIFY)'); }
+})();

--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -82,7 +82,7 @@
     // Forward-reconciled from the app's erp/ copy on the §INTEG-COLLAPSE (2026-06-08); the substrate's
     // byte-stable period-close replay depends on it. See prompts/ERP_SUBSTRATE_INTEGRATION.md §ARCHIVE.
     var stamp = (ts != null) ? ts : Date.now();
-    var vParams = _stamp(opType, params);                  // D2: brand schema version into params (signed) if wired
+    var vParams = _stampSigv(_stamp(opType, params));      // D2 schema version + T2 `_sigv:2` (both signed facts)
     db.run(
       'INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid) ' +
       'VALUES (?, ?, ?, ?, ?, ?)',
@@ -181,6 +181,66 @@
   // never in this module. Leave unset for W-CHAIN-only (tamper-evidence without signatures).
   function setSigner(signer) { _signer = signer; }
 
+  // T2 (prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION, bim-compiler) — Witness: W-CONTENT-SIGN.
+  // CONTENT-ADDRESSED SIGNING, additive-version (no flag-day, history never re-signed):
+  //   v1 (default, everything before T2): sig attests over op_hash — which hashes _canonical incl. the
+  //       LOCAL rowid `id`, so any renumbering (a merge) breaks every signature (§T2 permanence trap).
+  //   v2 (opt-in via setContentSigning(true)): NEW ops are stamped `_sigv:2` INSIDE parameters (a SIGNED
+  //       fact, same pattern as D2's `_sv`) and their sig attests over sha256('cs2|' + _canonicalV2(op))
+  //       — a JSON-canonical payload with NO id and NO prev_hash, so the sig survives id shifts and is
+  //       the merge/roster trust object (T1). The CHAIN (op_hash) formula is UNCHANGED for all rows —
+  //       v1 canonical incl. id stays the local integrity+order layer; only what the sig ATTESTS differs.
+  //   Gate = dedicated `_sigv`, NOT D2's `_sv`: `_sv` is the per-op-type SCHEMA version (op_upcaster.js);
+  //       reusing it would flip signature semantics whenever an op type's schema bumps — wrong coupling.
+  //   Coverage: _canonicalV2 keeps input_guids/output_guid (the spec's shorthand field list omitted them;
+  //       dropping them would let a re-sealed exported branch alter guids without breaking the sig —
+  //       NEVER shrink signed coverage). `actor` (user_tag, default 'local') is a PLACEHOLDER field —
+  //       identity binds to it in T1 (roster), it is just part of the signed payload here.
+  var _sigCanonical = 1;
+  function setContentSigning(on) { _sigCanonical = on ? 2 : 1; }
+
+  // stable, RECURSIVELY key-sorted serialization — MUST AGREE byte-for-byte with teams/connectors.js
+  // stableStringify (the teams canonical): one algorithm across kernel + teams closes the '|' delimiter
+  // injection (two field partitions can no longer collide to one signed payload — W-CONTENT-SIGN §CS-DELIM).
+  function stableStringify(v) {
+    if (v === null || v === undefined || typeof v !== 'object') return JSON.stringify(v === undefined ? null : v);
+    if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+    return '{' + Object.keys(v).sort().map(function (k) {
+      return JSON.stringify(k) + ':' + stableStringify(v[k]);
+    }).join(',') + '}';
+  }
+
+  // _canonicalV2 — the content-addressed signable payload. Field values are the STORED column values
+  // verbatim (parameters as its stored TEXT — never reparsed/renormalised, so the hash is stable).
+  function _canonicalV2(op) {
+    return stableStringify({
+      actor: (op.user_tag != null ? op.user_tag : 'local'),   // placeholder until T1 binds identity
+      in_guids: (op.input_guids != null ? op.input_guids : null),
+      op_type: op.op_type,
+      op_uuid: (op.op_uuid != null ? op.op_uuid : null),
+      out_guid: (op.output_guid != null ? op.output_guid : null),
+      params: (op.parameters != null ? op.parameters : null),
+      ts: op.timestamp
+    });
+  }
+  // 'cs2|' domain-separates the content hash from chain hashes (a sig over one can never replay as the other).
+  function _contentHash(op) { return _sha256('cs2|' + _canonicalV2(op)); }
+
+  // _isV2(paramStr) — is this row content-signed? Read the SIGNED `_sigv` marker out of stored parameters.
+  function _isV2(paramStr) {
+    if (typeof paramStr !== 'string' || paramStr.indexOf('"_sigv"') === -1) return false;
+    try { return JSON.parse(paramStr)._sigv === 2; } catch (e) { return false; }
+  }
+  // _sigBase — the message a row's signature attests: v2 → content hash; v1 → the chain hash (as before).
+  function _sigBase(op, chainHash) { return _isV2(op.parameters) ? _contentHash(op) : Promise.resolve(chainHash); }
+  // stamp `_sigv:2` into an op's params OBJECT when content-signing is on (copy — never mutate the caller's).
+  function _stampSigv(params) {
+    if (_sigCanonical !== 2 || !params || typeof params !== 'object') return params;
+    var out = {}; for (var k in params) if (Object.prototype.hasOwnProperty.call(params, k)) out[k] = params[k];
+    out._sigv = 2;
+    return out;
+  }
+
   // D2 (prompts/D2_REMEDY_VERSIONING.md): an optional version-stamper that brands every NEW op's params with
   // its schema version BEFORE hashing — so the version is a signed fact. fn(opType, params) -> params'. Wired
   // by ERP.OpUpcaster.install(KernelOps) at app boot; UNSET = legacy behaviour (ops carry no _sv = version 1).
@@ -218,15 +278,16 @@
   // compaction keeps the chain correct over the current log. Signs ops lacking a sig if a signer is set.
   async function sealChain(db) {
     ensureTable(db);
-    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig FROM kernel_ops ORDER BY id');
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig,op_uuid,user_tag FROM kernel_ops ORDER BY id');
     if (!r.length) return { sealed: 0, tip: GENESIS };
     var rows = r[0].values, prev = GENESIS, sealed = 0;
     for (var i = 0; i < rows.length; i++) {
       var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
-                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5],
+                 op_uuid: rows[i][7], user_tag: rows[i][8] };
       var sig = rows[i][6];
       var h = await _sha256(prev + '|' + _canonical(op));
-      if (_signer && !sig) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      if (_signer && !sig) { try { sig = await _signer.sign(await _sigBase(op, h)); } catch (e) { sig = null; } }
       db.run('UPDATE kernel_ops SET prev_hash=?, op_hash=?, sig=? WHERE id=?', [prev, h, sig || null, op.id]);
       prev = h; sealed++;
     }
@@ -249,15 +310,16 @@
   async function sealFrom(db, fromTip) {
     ensureTable(db);
     var tip = fromTip || _lastSealedTip(db);
-    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig FROM kernel_ops WHERE id > ' + tip.id + ' ORDER BY id');
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,sig,op_uuid,user_tag FROM kernel_ops WHERE id > ' + tip.id + ' ORDER BY id');
     if (!r.length) { return { sealed: 0, tip: tip.hash, fromId: tip.id }; }
     var rows = r[0].values, prev = tip.hash, sealed = 0;
     for (var i = 0; i < rows.length; i++) {
       var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
-                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5],
+                 op_uuid: rows[i][7], user_tag: rows[i][8] };
       var sig = rows[i][6];
       var h = await _sha256(prev + '|' + _canonical(op));
-      if (_signer && !sig) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      if (_signer && !sig) { try { sig = await _signer.sign(await _sigBase(op, h)); } catch (e) { sig = null; } }
       db.run('UPDATE kernel_ops SET prev_hash=?, op_hash=?, sig=? WHERE id=?', [prev, h, sig || null, op.id]);
       prev = h; sealed++;
     }
@@ -355,7 +417,8 @@
     for (var i = 0; i < opsArray.length; i++) {
       var src = opsArray[i];
       var params = src.params != null ? src.params : src.parameters;
-      params = _stamp(src.op_type, params);                  // D2: brand schema version (signed) if wired
+      params = _stampSigv(_stamp(src.op_type, params));      // D2 schema version + T2 `_sigv:2` (object params only —
+                                                             // a pre-stringified params string stays v1-signed)
       // §I-J (W-RATE-INPUT) — currency-determinism precondition: a conversion-bearing op MUST carry its
       // recorded rate inputs (rate/rateDate/rateSource), else the WHOLE group is rejected (all-or-none,
       // commits NOTHING). Today nothing is conversion-bearing → inert but enforced. NEVER looks up a rate.
@@ -373,11 +436,13 @@
       var uuid = src.op_uuid || src.opUuid ||
                  ((typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : null);
       var row = { id: nextId + i, timestamp: baseTs, op_type: src.op_type, parameters: paramStr,
-                  input_guids: inStr, output_guid: outG || null, op_uuid: uuid };
+                  input_guids: inStr, output_guid: outG || null, op_uuid: uuid,
+                  user_tag: 'local' };   // T2: must equal the column DEFAULT the INSERT below produces —
+                                         // _canonicalV2 hashes user_tag, staging and verify must agree.
       var h = await _sha256(prev + '|' + _canonical(row));
       row.op_hash = h; row.prev_hash = prev;
       var sig = null;
-      if (_signer) { try { sig = await _signer.sign(h); } catch (e) { sig = null; } }
+      if (_signer) { try { sig = await _signer.sign(await _sigBase(row, h)); } catch (e) { sig = null; } }
       row.sig = sig;
       staged.push(row); opHashes.push(h); prev = h;
     }
@@ -434,12 +499,13 @@
   // "tamper at op N" exactly as scripts/poc_chain.js does.
   async function verifyChain(db) {
     ensureTable(db);
-    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid FROM kernel_ops ORDER BY id');
+    var r = db.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,op_uuid,user_tag FROM kernel_ops ORDER BY id');
     if (!r.length) return { ok: true, len: 0, tip: GENESIS };
     var rows = r[0].values, prev = GENESIS;
     for (var i = 0; i < rows.length; i++) {
       var op = { id: rows[i][0], timestamp: rows[i][1], op_type: rows[i][2],
-                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5] };
+                 parameters: rows[i][3], input_guids: rows[i][4], output_guid: rows[i][5],
+                 op_uuid: rows[i][10], user_tag: rows[i][11] };
       var storedPrev = rows[i][6], storedHash = rows[i][7], sig = rows[i][8], gid = rows[i][9];
       var fail = null;
       if (storedHash == null) { fail = 'unsealed'; }
@@ -447,7 +513,8 @@
       else {
         var h = await _sha256(prev + '|' + _canonical(op));
         if (h !== storedHash) { fail = 'payload altered'; }
-        else if (_signer && !(await _signer.verify(storedHash, sig))) { fail = 'signature'; }
+        // T2 (W-CONTENT-SIGN): the sig attests the CONTENT hash for v2 rows, op_hash for v1 rows.
+        else if (_signer && !(await _signer.verify(await _sigBase(op, storedHash), sig))) { fail = 'signature'; }
       }
       if (fail) {
         // Implementing ENGINE_FULL_ERP_ISSUES.md §I-K — Witness: W-OPGROUP
@@ -675,8 +742,13 @@
     branchOps:    branchOps,     // BLUE FUTURE (W-BLUE-FUTURE): the ops of a speculative branch (id order)
     discardBranch: discardBranch, // BLUE FUTURE: shirk the blues — fold the whole branch away atomically
     acceptBranchUpTo: acceptBranchUpTo, // BLUE FUTURE: long-click a blue dot → accept-up-to-here (chain stays valid)
-    _storedTipIsAncestor: _storedTipIsAncestor // T6 (W-CROSS-TAB-PERSIST): the multi-tab clobber guard (pure)
+    _storedTipIsAncestor: _storedTipIsAncestor, // T6 (W-CROSS-TAB-PERSIST): the multi-tab clobber guard (pure)
+    setContentSigning: setContentSigning, // T2 (W-CONTENT-SIGN): opt NEW ops into v2 content-addressed sigs
+    stableStringify: stableStringify,     // T2: the shared canonical serializer (agrees with teams/connectors.js)
+    _canonicalV2: _canonicalV2,           // T2: content-addressed signable payload (no id/prev — merge-safe)
+    _contentHash: _contentHash,           // T2: sha256('cs2|' + _canonicalV2) — what a v2 sig attests (async)
+    _isV2: _isV2                          // T2: is this row content-signed? (reads the SIGNED _sigv marker)
   };
 
-  console.log('§KERNEL_OPS_LOADED v10 (W-CHAIN/W-SIGN/G-IDENTITY/W-OPGROUP/W-RATE-INPUT/W-BLUE-FUTURE/W-EMIT/T6-persist-guard)');
+  console.log('§KERNEL_OPS_LOADED v11 (W-CHAIN/W-SIGN/G-IDENTITY/W-OPGROUP/W-RATE-INPUT/W-BLUE-FUTURE/W-EMIT/T6-persist-guard/T2-content-sign)');
 })();

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v759';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v760';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -59,6 +59,7 @@ const PRECACHE_ASSETS = [
   'system_monitor.js', // SYSTEM_ADMIN_LANE §6 — iDempiere System Monitor (serverless reframe, window.SystemMonitor)
   'plugin_release.js', // SYSTEM_ADMIN_LANE §6 — Plugin Management + gated Release/Update (window.PluginRelease)
   'erp_snapshot_sign.js', // ECDSA P-256 signer (UMD, window.ErpSnapshotSign) — signs the genesis bundle head
+  'erp_key_epochs.js', // T1 (W-ROSTER-VERIFY): HQ-signed device roster + ROTATE/REVOKE key epochs on verify/import
   '14-sap-chain.json', // SAP /DMO/ Flight PoC oracle (fetch-fold-install demo data; user can replace via file-drop)
   'idmp_session.js',
   'erp_descriptor.js',  // DESCRIPTOR SEAM (IDEMPIERE_2.md pivot, renderer #2) — one chrome, N dictionaries; AD = first descriptor

--- a/erp/tests/witness_content_sign.js
+++ b/erp/tests/witness_content_sign.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-CONTENT-SIGN (bim-compiler prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION, T2).
+//   THE ISSUE PROVED/DISPROVED: signatures bind to the LOCAL rowid — _canonical hashes `op.id` and the sig
+//   attests over op_hash — so any id shift (a merge renumbering, the audit's §T2 permanence trap) breaks
+//   EVERY signature, and the '|'-joined canonical lets two distinct field partitions collide to one hash
+//   (delimiter injection, audit security#6). Roster verification across a merge (T1) is impossible until
+//   signatures survive renumbering.
+//   THE FIX PROVED (ADDITIVE-VERSION, the spec's recommended path — no flag-day, no re-seal of history):
+//   ops stamped `_sigv:2` (a SIGNED fact inside parameters) are CONTENT-SIGNED — sig attests a JSON-canonical
+//   (stableStringify, agrees with teams/connectors.js) payload over op_uuid|timestamp|op_type|parameters|
+//   input_guids|output_guid|actor — NO id, NO prev. v1 rows verify exactly as before; the CHAIN (op_hash)
+//   is byte-identical for all rows (v1 canonical incl. id — the local integrity/order layer is untouched).
+//     §CS-V1-REGRESSION — a v1 log (content-signing OFF, the default) seals/signs/verifies UNCHANGED;
+//                         chain tip byte-identical across rebuilds AND to the v1 formula recomputed here.
+//     §CS-RENUMBER      — THE MERGE PROPERTY: a v2-signed log survives a simulated id renumbering
+//                         (ids +100, re-seal) — sigs still verify. The SAME flow under v1 FAILS 'signature'.
+//     §CS-DELIM         — '|'-bearing params re-partitioned to a v1-colliding canonical do NOT collide
+//                         under _canonicalV2 (JSON escaping closes delimiter injection).
+//     §CS-TAMPER        — a v2 row's parameters altered + whole chain RE-SEALED by the attacker still
+//                         fails 'signature' (the sig binds CONTENT, not the recomputable chain).
+//     §CS-MIXED         — v1 rows then v2 rows in ONE log: verifyChain OK (per-op canonical pick).
+//     §CS-GROUP         — commitGroup path: a v2 group commits, verifies, and survives renumbering.
+//   NON-INVENT: real erp/kernel_ops.js + erp/erp_snapshot_sign.js (ECDSA P-256) driven in node over sql.js.
+//   §-log first — READ witness_content_sign.log before any conclusion.
+//   Run (cwd = worktree root): node erp/tests/witness_content_sign.js 2>&1 | tee erp/tests/witness_content_sign.log
+'use strict';
+var path = require('path');
+if (!global.window) global.window = {};
+if (!global.crypto || !global.crypto.subtle) global.crypto = require('crypto').webcrypto;
+function reqSql() {
+  var tries = ['sql.js', '/home/red1/bim-ootb/node_modules/sql.js',
+               path.join(__dirname, '..', '..', 'node_modules', 'sql.js')];
+  for (var i = 0; i < tries.length; i++) { try { return require(tries[i]); } catch (e) {} }
+  throw new Error('sql.js not resolvable');
+}
+var ERP = path.join(__dirname, '..');
+require(path.join(ERP, 'kernel_ops.js'));
+var K = global.window.KernelOps;
+var SIGN = require(path.join(ERP, 'erp_snapshot_sign.js'));
+
+var fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+var _real = console.log; function mute() { console.log = function () {}; } function unmute() { console.log = _real; }
+
+// tolerate the pre-fix kernel (RED run): missing seams become no-ops so asserts go RED, not harness-crash.
+var setCS = K.setContentSigning || function () { _real('   (setContentSigning MISSING — pre-T2 kernel, expect RED)'); };
+var BASE_TS = 1700000000000;
+
+async function makeSigner() {
+  var kp = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  var priv = await crypto.subtle.exportKey('jwk', kp.privateKey);
+  var pub = await crypto.subtle.exportKey('jwk', kp.publicKey);
+  return { pub: pub,
+    sign: function (msgHex) { return SIGN.signTip(priv, msgHex); },
+    verify: function (msgHex, sigHex) { return SIGN.verifyTip(msgHex, sigHex, pub); } };
+}
+function seed3(SQL) {   // deterministic 3-op log (fixed uuids + ts)
+  var db = new SQL.Database();
+  K.ensureTable(db);
+  K.commitOp(db, 'POST', { account: 'cash', cents: 100, memo: 'a|b' }, ['g1'], 'o1', 'u-1', BASE_TS + 1);
+  K.commitOp(db, 'POST', { account: 'sales', cents: -100 }, ['g2'], 'o2', 'u-2', BASE_TS + 2);
+  K.commitOp(db, 'MOVE', { from: 'w1', to: 'w2', qty: 3 }, null, null, 'u-3', BASE_TS + 3);
+  return db;
+}
+function renumber(db) { db.run('UPDATE kernel_ops SET id = id + 100'); }
+function tipOf(db) { var r = db.exec('SELECT op_hash FROM kernel_ops ORDER BY id DESC LIMIT 1'); return r.length ? r[0].values[0][0] : null; }
+async function sha256hex(s) {
+  var buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(s));
+  return Array.from(new Uint8Array(buf)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+}
+
+(async function () {
+  console.log('\n═══ W-CONTENT-SIGN — v2 content-addressed signing, additive over v1 chain (T2) ═══\n');
+  var SQL = await reqSql()();
+  var signer = await makeSigner();
+
+  // ── §CS-V1-REGRESSION — default (content-signing OFF) is byte-for-byte the v1 kernel ──
+  console.log('§CS-V1-REGRESSION — existing v1 logs seal/sign/verify unchanged');
+  mute();
+  setCS(false);
+  K.setSigner(signer);
+  var v1a = seed3(SQL); await K.sealChain(v1a);
+  var v1b = seed3(SQL); await K.sealChain(v1b);
+  var rV1 = await K.verifyChain(v1a);
+  unmute();
+  verdict(rV1.ok === true, '§CS-V1-REGRESSION v1 log verifies (chain + sig)', 'ok=' + rV1.ok + ' len=' + rV1.len);
+  verdict(tipOf(v1a) === tipOf(v1b), '§CS-V1-REGRESSION rebuild → byte-identical tip', String(tipOf(v1a)).slice(0, 12) + '…');
+  // recompute the tip with the v1 formula IN-WITNESS: proves the chain bytes are the pre-T2 formula.
+  var rows = v1a.exec('SELECT id,timestamp,op_type,parameters,input_guids,output_guid FROM kernel_ops ORDER BY id')[0].values;
+  var prev = '0'.repeat(64);
+  for (var i = 0; i < rows.length; i++) {
+    var c = rows[i][0] + '|' + rows[i][1] + '|' + rows[i][2] + '|' + (rows[i][3] || '') + '|' + (rows[i][4] || '') + '|' + (rows[i][5] || '');
+    prev = await sha256hex(prev + '|' + c);
+  }
+  verdict(prev === tipOf(v1a), '§CS-V1-REGRESSION chain tip == v1 canonical formula (chain bytes untouched by T2)', prev.slice(0, 12) + '…');
+
+  // ── §CS-RENUMBER — the merge property: v2 sigs survive id renumbering; v1 sigs do not ──
+  console.log('\n§CS-RENUMBER — a v2-signed op survives a simulated id renumbering; v1 fails');
+  mute();
+  setCS(false);
+  var dOld = seed3(SQL); await K.sealChain(dOld);
+  renumber(dOld); await K.sealChain(dOld);            // re-seal after the shift (recomputes op_hash, keeps sigs)
+  var rOld = await K.verifyChain(dOld);
+  setCS(true);
+  var dNew = seed3(SQL); await K.sealChain(dNew);
+  var rNewBefore = await K.verifyChain(dNew);
+  renumber(dNew); await K.sealChain(dNew);
+  var rNew = await K.verifyChain(dNew);
+  setCS(false);
+  unmute();
+  verdict(rOld.ok === false && rOld.why === 'signature', '§CS-RENUMBER v1 sig BREAKS on renumber (the documented trap)', 'ok=' + rOld.ok + ' why=' + rOld.why);
+  verdict(rNewBefore.ok === true, '§CS-RENUMBER v2 log verifies before the shift', 'ok=' + rNewBefore.ok);
+  verdict(rNew.ok === true, '§CS-RENUMBER v2 sig SURVIVES renumber (ids +100, re-sealed) — merge-safe', 'ok=' + rNew.ok + (rNew.why ? ' why=' + rNew.why : ''));
+
+  // ── §CS-DELIM — '|' re-partitioning collides under v1 canonical, NOT under v2 ──
+  console.log('\n§CS-DELIM — two distinct field partitions must not share one canonical');
+  var A = { id: 1, timestamp: 5, op_type: 'POST', parameters: 'P', input_guids: 'X|Y', output_guid: 'O', op_uuid: 'u-A', user_tag: 'local' };
+  var B = { id: 1, timestamp: 5, op_type: 'POST', parameters: 'P|X', input_guids: 'Y', output_guid: 'O', op_uuid: 'u-A', user_tag: 'local' };
+  var v1collide = (A.id + '|' + A.timestamp + '|' + A.op_type + '|' + A.parameters + '|' + A.input_guids + '|' + A.output_guid) ===
+                  (B.id + '|' + B.timestamp + '|' + B.op_type + '|' + B.parameters + '|' + B.input_guids + '|' + B.output_guid);
+  verdict(v1collide === true, '§CS-DELIM v1 canonical COLLIDES (the flaw, shown live)', 'A==B under v1');
+  var c2A = K._canonicalV2 ? K._canonicalV2(A) : null;
+  var c2B = K._canonicalV2 ? K._canonicalV2(B) : null;
+  verdict(c2A != null && c2B != null && c2A !== c2B, '§CS-DELIM v2 canonical does NOT collide (JSON escaping closes injection)',
+          c2A == null ? '_canonicalV2 MISSING' : 'distinct');
+
+  // ── §CS-TAMPER — altered v2 content fails even after the attacker re-seals the whole chain ──
+  console.log('\n§CS-TAMPER — the v2 sig binds content: tamper + full re-seal still rejects');
+  mute();
+  setCS(true);
+  var dT = seed3(SQL); await K.sealChain(dT);
+  dT.run("UPDATE kernel_ops SET parameters = replace(parameters, '100', '999') WHERE id = 1");
+  await K.sealChain(dT);                              // attacker re-seals — chain now self-consistent again
+  var rT = await K.verifyChain(dT);
+  setCS(false);
+  unmute();
+  verdict(rT.ok === false && rT.why === 'signature', '§CS-TAMPER altered params + re-sealed chain → sig REJECTS', 'ok=' + rT.ok + ' why=' + rT.why);
+
+  // ── §CS-MIXED — v1 history + v2 new rows in ONE log verify together (the additive contract) ──
+  console.log('\n§CS-MIXED — v1 rows and v2 rows coexist in one verifying log');
+  mute();
+  setCS(false);
+  var dM = seed3(SQL); await K.sealChain(dM);         // 3 v1 rows
+  setCS(true);
+  K.commitOp(dM, 'POST', { account: 'new', cents: 7 }, null, null, 'u-4', BASE_TS + 4);   // v2 row
+  await K.sealChain(dM);
+  var rM = await K.verifyChain(dM);
+  var svRow = dM.exec("SELECT parameters FROM kernel_ops ORDER BY id DESC LIMIT 1")[0].values[0][0];
+  setCS(false);
+  unmute();
+  verdict(rM.ok === true && rM.len === 4, '§CS-MIXED mixed log verifies (per-op canonical pick)', 'ok=' + rM.ok + ' len=' + rM.len);
+  verdict(/"_sigv":2/.test(svRow), '§CS-MIXED the v2 row carries _sigv:2 INSIDE signed parameters', svRow.slice(0, 60));
+
+  // ── §CS-GROUP — the commitGroup staging path signs v2 and survives renumbering too ──
+  console.log('\n§CS-GROUP — commitGroup v2 group verifies and survives renumbering');
+  mute();
+  setCS(true);
+  var dG = new SQL.Database(); K.ensureTable(dG);
+  var g = await K.commitGroup(dG, [
+    { op_type: 'POST', params: { account: 'cash', cents: 50 }, op_uuid: 'u-g1' },
+    { op_type: 'POST', params: { account: 'sales', cents: -50 }, op_uuid: 'u-g2' }
+  ], { gid: 'g-cs', baseTs: BASE_TS + 10 });
+  var rG1 = await K.verifyChain(dG);
+  renumber(dG); await K.sealChain(dG);
+  var rG2 = await K.verifyChain(dG);
+  setCS(false);
+  K.setSigner(null);
+  unmute();
+  verdict(g.committed === true && g.ids.length === 2, '§CS-GROUP v2 group commits atomically', 'ids=' + g.ids.join(','));
+  verdict(rG1.ok === true, '§CS-GROUP group log verifies', 'ok=' + rG1.ok + (rG1.why ? ' why=' + rG1.why : ''));
+  verdict(rG2.ok === true, '§CS-GROUP group sigs survive renumbering (staging path content-signs)', 'ok=' + rG2.ok + (rG2.why ? ' why=' + rG2.why : ''));
+
+  console.log('\n' + (fails ? '🔴 W-CONTENT-SIGN ' + fails + ' FAIL' : '🟢 W-CONTENT-SIGN ALL PASS'));
+  process.exit(fails ? 1 : 0);
+})().catch(function (e) { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/erp/tests/witness_roster_verify.js
+++ b/erp/tests/witness_roster_verify.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-ROSTER-VERIFY (bim-compiler prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION, T1).
+//   THE ISSUE PROVED/DISPROVED: the merge/import path (teams/erp/erp_sync.js importBranch) checked the
+//   KEYLESS chain only — a forged op signed by ANY key (or none of ours) with a self-consistently re-sealed
+//   chain was SILENTLY ACCEPTED into the peer's World (audit T1/security#1). And the kernel's single
+//   module-global _signer knows one key forever — no rotation, no revocation (forge-forever, audit §T1).
+//   THE FIX PROVED (PORTED from witnessed doctrine — scripts/poc_rotate.js W-ROTATE + DistributedERP.md
+//   §228/§290/§445 — NOT fresh design): erp/erp_key_epochs.js = HQ-signed device roster (pinned-key
+//   pattern) + key-epoch map (ROTATE counter-signed by the outgoing key; REVOKE = burn-not-reattribute),
+//   verifying every op under the key valid AT ITS seq, over the T2 CONTENT hash for v2 rows (merge-safe).
+//   Wired onto importBranch via opts.roster.
+//     §RV-ROSTER          — HQ-signed roster verifies; a roster with ONE swapped device key REJECTS.
+//     §RV-ROTATE          — ROTATE counter-signed by the outgoing key installs the new key; a ROTATE
+//                           signed by a stranger REJECTS.
+//     §RV-HISTORY         — ops before the rotation still verify under the OLD key (never re-signed).
+//     §RV-FUTURE          — after rotation the OLD key REJECTS, the NEW key ACCEPTS.
+//     §RV-REVOKE          — a revoked key's FUTURE op REJECTS; its PAST ops stay valid.
+//     §RV-RENUMBER-EPOCH  — the T2×T1 payoff: a branch WITH a rotation, ids renumbered (merge), still
+//                           roster-verifies (v2 content sigs are id-independent).
+//     §RV-IMPORT-FORGE    — a forged foreign-key op in a re-sealed branch: TODAY's keyless import path
+//                           accepts it (the gap, shown live); roster-gated import REJECTS it.
+//     §RV-IMPORT-RENUMBER — a renumbered honest branch imports + replays under the roster gate.
+//   NON-INVENT: real erp/kernel_ops.js (T2 content signing ON) + erp/erp_snapshot_sign.js ECDSA P-256 +
+//   real teams/erp/erp_sync.js import path, driven in node over sql.js.
+//   §-log first — READ witness_roster_verify.log before any conclusion.
+//   Run (cwd = worktree root): node erp/tests/witness_roster_verify.js 2>&1 | tee erp/tests/witness_roster_verify.log
+'use strict';
+var path = require('path');
+if (!global.window) global.window = {};
+if (!global.crypto || !global.crypto.subtle) global.crypto = require('crypto').webcrypto;
+function reqSql() {
+  var tries = ['sql.js', '/home/red1/bim-ootb/node_modules/sql.js',
+               path.join(__dirname, '..', '..', 'node_modules', 'sql.js')];
+  for (var i = 0; i < tries.length; i++) { try { return require(tries[i]); } catch (e) {} }
+  throw new Error('sql.js not resolvable');
+}
+var ERP = path.join(__dirname, '..');
+require(path.join(ERP, 'kernel_ops.js'));
+var K = global.window.KernelOps;
+var SIGN = require(path.join(ERP, 'erp_snapshot_sign.js'));
+var EP = null; try { EP = require(path.join(ERP, 'erp_key_epochs.js')); } catch (e) {}
+var ERPKernel = require(path.join(ERP, 'erp_kernel.js'));
+var Sync = require(path.join(__dirname, '..', '..', 'teams', 'erp', 'erp_sync.js'));
+var C = require(path.join(__dirname, '..', '..', 'teams', 'connectors.js'));
+var sha256sync = C._util.sha256;
+var HOST = { KernelOps: K, ERPKernel: ERPKernel, ErpKeyEpochs: EP };
+
+var fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+var _real = console.log; function mute() { console.log = function () {}; } function unmute() { console.log = _real; }
+var BASE_TS = 1700000000000;
+
+// ── key registry: kid → {priv, pub}; op params carry only the kid (key material out-of-band) ──
+var KEYS = {};
+async function genKey(kid) {
+  var kp = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  KEYS[kid] = { priv: await crypto.subtle.exportKey('jwk', kp.privateKey),
+                pub:  await crypto.subtle.exportKey('jwk', kp.publicKey) };
+}
+function devices() { return { K0: KEYS.K0.pub, K1: KEYS.K1.pub, K2: KEYS.K2.pub }; }
+var verifyFn = function (msg, sig, pub) { return SIGN.verifyTip(msg, sig, pub); };
+
+// commit an op naming its signer kid, T2 content signing ON, deterministic uuid/ts.
+var _seq = 0;
+function add(db, opType, params, kid) {
+  _seq++;
+  params.signed_by = kid;
+  return K.commitOp(db, opType, params, null, null, 'u-' + _seq, BASE_TS + _seq);
+}
+// seal the chain (integrity, kernel-signer OFF), then sign each row with the key its params name —
+// v2 rows over their CONTENT hash (K._contentHash), exactly what production edge devices do post-T2.
+async function sealAndSign(db, signWithOverride) {
+  await K.sealChain(db);
+  var r = db.exec('SELECT id, op_uuid, timestamp, op_type, parameters, input_guids, output_guid, op_hash, user_tag FROM kernel_ops WHERE sig IS NULL ORDER BY id');
+  var rows = r.length ? r[0].values : [];
+  for (var i = 0; i < rows.length; i++) {
+    var op = { id: rows[i][0], op_uuid: rows[i][1], timestamp: rows[i][2], op_type: rows[i][3],
+               parameters: rows[i][4], input_guids: rows[i][5], output_guid: rows[i][6],
+               op_hash: rows[i][7], user_tag: rows[i][8] };
+    var kid = JSON.parse(op.parameters).signed_by;
+    var msg = (K._isV2 && K._isV2(op.parameters)) ? await K._contentHash(op) : op.op_hash;
+    var priv = (signWithOverride && signWithOverride[op.id]) || KEYS[kid].priv;
+    db.run('UPDATE kernel_ops SET sig=? WHERE id=?', [await SIGN.signTip(priv, msg), op.id]);
+  }
+}
+// renumber an EXPORTED array (the merge simulation): shift ids, re-derive the v1 chain over the array.
+function renumberBranch(ops, shift) {
+  var prev = '0'.repeat(64);
+  return ops.map(function (src) {
+    var o = {}; Object.keys(src).forEach(function (k) { o[k] = src[k]; });
+    o.id = o.id + shift;
+    var canon = o.id + '|' + o.timestamp + '|' + o.op_type + '|' + (o.parameters || '') + '|' + (o.input_guids || '') + '|' + (o.output_guid || '');
+    o.prev_hash = prev; o.op_hash = sha256sync(prev + '|' + canon); prev = o.op_hash;
+    return o;
+  });
+}
+function docOp(n, kid) {   // a replayable CREATE_DOCUMENT (mirrors poc_teams_erp_sync shapes)
+  return { payload: { op_type: 'CREATE_DOCUMENT', uuid: 'DOC:SO-' + n, table: 'C_Order', doc_status: 'DR' }, actor: 'ap' };
+}
+
+(async function () {
+  console.log('\n═══ W-ROSTER-VERIFY — HQ-signed device roster + ROTATE/REVOKE key epochs on the verify/import path (T1) ═══\n');
+  var SQL = await reqSql()();
+  await genKey('K0'); await genKey('K1'); await genKey('K2'); await genKey('HQ'); await genKey('FORGE');
+  if (K.setContentSigning) K.setContentSigning(true); else _real('   (setContentSigning MISSING — pre-T2 kernel)');
+  var mk = function () { return new SQL.Database(); };
+
+  // ── §RV-ROSTER — the HQ-signed device list is the trust root; tampering it fails the pinned check ──
+  console.log('§RV-ROSTER — HQ-signed roster verifies; a swapped device key REJECTS');
+  var roster = null, rosterOk = { ok: false }, rosterTampered = { ok: true };
+  if (EP) {
+    mute();
+    roster = await EP.signRoster({ devices: devices(), genesisKid: 'K0' }, KEYS.HQ.priv);
+    rosterOk = await EP.verifyRoster(roster, { hqPub: KEYS.HQ.pub });
+    var evil = JSON.parse(JSON.stringify(roster));
+    evil.payload.devices.K1 = KEYS.FORGE.pub;          // HQ never signed this key for K1
+    rosterTampered = await EP.verifyRoster(evil, { hqPub: KEYS.HQ.pub });
+    unmute();
+  }
+  verdict(!!EP, '§RV-ROSTER erp_key_epochs.js loads (ported module present)', EP ? 'loaded' : 'MISSING');
+  verdict(rosterOk.ok === true, '§RV-ROSTER HQ-signed roster verifies under the pinned HQ key', 'ok=' + rosterOk.ok);
+  verdict(rosterTampered.ok === false, '§RV-ROSTER roster with a swapped device key is REJECTED', 'why=' + rosterTampered.why);
+  var RO = { roster: roster, hqPub: KEYS.HQ ? KEYS.HQ.pub : null };
+
+  // ── §RV-ROTATE / §RV-HISTORY — counter-signed rotation; the past stays old-key-anchored ──
+  console.log('\n§RV-ROTATE / §RV-HISTORY — counter-signed ROTATE installs the new key; history untouched');
+  mute();
+  var dbA = mk(); K.ensureTable(dbA); _seq = 0;
+  add(dbA, 'POST', { account: 'cash', cents: 1 }, 'K0');
+  add(dbA, 'POST', { account: 'cash', cents: 2 }, 'K0');
+  add(dbA, 'ROTATE', { kind: 'ROTATE', newKid: 'K1' }, 'K0');           // counter-signed by outgoing K0
+  add(dbA, 'POST', { account: 'cash', cents: 3 }, 'K1');
+  await sealAndSign(dbA);
+  var vA = EP ? await EP.verifyEpochSigs(dbA, RO) : { ok: false };
+  var dbBad = mk(); K.ensureTable(dbBad); _seq = 0;
+  add(dbBad, 'POST', { account: 'cash', cents: 1 }, 'K0');
+  add(dbBad, 'ROTATE', { kind: 'ROTATE', newKid: 'K1' }, 'K1');         // stranger-signed — NOT the outgoing key
+  add(dbBad, 'POST', { account: 'cash', cents: 2 }, 'K1');
+  await sealAndSign(dbBad);
+  var vBad = EP ? await EP.verifyEpochSigs(dbBad, RO) : { ok: true };
+  // history: op id=1 (pre-rotation, K0) verifies under K0 directly, not under K1.
+  var r1 = dbA.exec('SELECT op_uuid,timestamp,op_type,parameters,input_guids,output_guid,op_hash,user_tag FROM kernel_ops WHERE id=1')[0].values[0];
+  var op1 = { op_uuid: r1[0], timestamp: r1[1], op_type: r1[2], parameters: r1[3], input_guids: r1[4], output_guid: r1[5], op_hash: r1[6], user_tag: r1[7] };
+  var msg1 = (K._contentHash && K._isV2 && K._isV2(op1.parameters)) ? await K._contentHash(op1) : op1.op_hash;
+  var sig1 = dbA.exec('SELECT sig FROM kernel_ops WHERE id=1')[0].values[0][0];
+  var histOld = await SIGN.verifyTip(msg1, sig1, KEYS.K0.pub);
+  var histNew = await SIGN.verifyTip(msg1, sig1, KEYS.K1.pub);
+  unmute();
+  verdict(vA.ok === true && vA.activeKid === 'K1', '§RV-ROTATE valid ROTATE accepted; active key advanced K0→K1', 'active=' + vA.activeKid);
+  verdict(vBad.ok === false, '§RV-ROTATE stranger-signed ROTATE is REJECTED', 'why=' + vBad.why);
+  verdict(histOld === true && histNew === false, '§RV-HISTORY pre-rotation op verifies under OLD key only (past never re-signed)', 'old=' + histOld + ' new=' + histNew);
+
+  // ── §RV-FUTURE — after S the old key rejects, the new key accepts ──
+  console.log('\n§RV-FUTURE — post-rotation: OLD key rejected, NEW key accepted');
+  mute();
+  var dbOld = mk(); K.ensureTable(dbOld); _seq = 0;
+  add(dbOld, 'POST', { account: 'x', cents: 1 }, 'K0');
+  add(dbOld, 'ROTATE', { kind: 'ROTATE', newKid: 'K1' }, 'K0');
+  add(dbOld, 'POST', { account: 'x', cents: 2 }, 'K0');                 // OLD key after rotation
+  await sealAndSign(dbOld);
+  var vOld = EP ? await EP.verifyEpochSigs(dbOld, RO) : { ok: true };
+  unmute();
+  verdict(vOld.ok === false && vOld.brokeAt === 3, '§RV-FUTURE post-rotation OLD-key op is REJECTED at id=3', 'brokeAt=' + vOld.brokeAt + ' why=' + vOld.why);
+  verdict(vA.ok === true, '§RV-FUTURE the same position signed by the NEW key is ACCEPTED (dbA id=4)', 'ok=' + vA.ok);
+
+  // ── §RV-REVOKE — burn-not-reattribute: future dies, past stays ──
+  console.log('\n§RV-REVOKE — a revoked key loses the future, keeps the past');
+  mute();
+  var dbR = mk(); K.ensureTable(dbR); _seq = 0;
+  add(dbR, 'POST', { account: 'x', cents: 1 }, 'K0');
+  add(dbR, 'ROTATE', { kind: 'ROTATE', newKid: 'K1' }, 'K0');
+  add(dbR, 'POST', { account: 'x', cents: 2 }, 'K1');                   // genuine K1 op BEFORE revocation
+  add(dbR, 'REVOKE', { kind: 'REVOKE', revokedKid: 'K1', newKid: 'K2' }, 'K1');   // K1 offboards → K2
+  add(dbR, 'POST', { account: 'x', cents: 3 }, 'K2');
+  await sealAndSign(dbR);
+  var vR = EP ? await EP.verifyEpochSigs(dbR, RO) : { ok: false };
+  var dbF = mk(); K.ensureTable(dbF); _seq = 0;
+  add(dbF, 'POST', { account: 'x', cents: 1 }, 'K0');
+  add(dbF, 'ROTATE', { kind: 'ROTATE', newKid: 'K1' }, 'K0');
+  add(dbF, 'POST', { account: 'x', cents: 2 }, 'K1');
+  add(dbF, 'REVOKE', { kind: 'REVOKE', revokedKid: 'K1', newKid: 'K2' }, 'K1');
+  add(dbF, 'POST', { account: 'x', cents: 3 }, 'K2');
+  add(dbF, 'POST', { account: 'x', cents: 4 }, 'K1');                   // forged: revoked K1 reused
+  await sealAndSign(dbF);
+  var vF = EP ? await EP.verifyEpochSigs(dbF, RO) : { ok: true };
+  unmute();
+  verdict(vR.ok === true && vR.activeKid === 'K2', '§RV-REVOKE graceful offboard verifies; successor K2 active', 'active=' + vR.activeKid);
+  verdict(vF.ok === false && vF.brokeAt === 6, '§RV-REVOKE a FUTURE op by the revoked key is REJECTED', 'brokeAt=' + vF.brokeAt + ' why=' + vF.why);
+
+  // ── §RV-RENUMBER-EPOCH — the T2×T1 payoff: rotation branch survives a merge renumbering ──
+  console.log('\n§RV-RENUMBER-EPOCH — a rotated branch, ids renumbered, still roster-verifies (content sigs)');
+  mute();
+  var expA = Sync.exportBranch(dbA, {});
+  var renA = renumberBranch(expA, 100);
+  var chainA = Sync.erpVerifyChain(renA);
+  var vRen = EP ? await EP.verifyEpochSigsOps(renA, RO) : { ok: false };
+  unmute();
+  verdict(chainA.ok === true, '§RV-RENUMBER-EPOCH renumbered branch re-chains cleanly (ids 101…)', 'len=' + chainA.len);
+  verdict(vRen.ok === true && vRen.activeKid === 'K1', '§RV-RENUMBER-EPOCH sigs + ROTATE still verify after renumbering — merge-safe', 'ok=' + vRen.ok + ' active=' + (vRen.activeKid || '?') + (vRen.why ? ' why=' + vRen.why : ''));
+
+  // ── §RV-IMPORT-FORGE — the security#1 gap closed at the import seam ──
+  console.log('\n§RV-IMPORT-FORGE — forged foreign-key op: keyless import accepts (the gap), roster import REJECTS');
+  mute();
+  var origin = mk(); ERPKernel.initProjection(origin); _seq = 0;
+  add(origin, 'CREATE_DOCUMENT', docOp(1, 'K0'), 'K0');
+  add(origin, 'CREATE_DOCUMENT', docOp(2, 'K0'), 'K0');
+  await sealAndSign(origin);
+  // the attacker: appends an op CLAIMING signed_by=K0 but signed with FORGE's key, re-seals the chain.
+  var attack = mk(); K.ensureTable(attack);
+  Sync.exportBranch(origin, {}).forEach(function (o) {
+    attack.run('INSERT INTO kernel_ops (id,op_uuid,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,branch_id,user_tag) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      [o.id, o.op_uuid, o.timestamp, o.op_type, o.parameters, o.input_guids, o.output_guid, o.prev_hash, o.op_hash, o.sig, o.gid, o.branch_id, o.user_tag != null ? o.user_tag : 'local']);
+  });
+  _seq = 2;
+  add(attack, 'CREATE_DOCUMENT', docOp(99, 'K0'), 'K0');               // claims K0…
+  await sealAndSign(attack, { 3: KEYS.FORGE.priv });                   // …but FORGE signs it
+  var forgedOps = Sync.exportBranch(attack, {});
+  var chainForged = Sync.erpVerifyChain(forgedOps);
+  var legacyAccepted = false, legacyHash = null;
+  try { var leg = Sync.importBranch(forgedOps, HOST, mk); legacyAccepted = !!(leg && leg.projectionHash); legacyHash = leg && leg.projectionHash; } catch (e) {}
+  var rosterRejected = false, rosterWhy = null;
+  try {
+    var res = Sync.importBranch(forgedOps, HOST, mk, RO);
+    if (res && typeof res.then === 'function') { await res; }
+    else if (!EP) { throw new Error('legacy path ignored opts (pre-T1 erp_sync)'); }
+  } catch (e) { rosterRejected = true; rosterWhy = e.message; }
+  unmute();
+  verdict(chainForged.ok === true, '§RV-IMPORT-FORGE the forged branch\'s CHAIN is self-consistent (chain alone cannot catch it)', 'len=' + chainForged.len);
+  verdict(legacyAccepted === true, '§RV-IMPORT-FORGE keyless import ACCEPTS the forgery (the documented pre-T1 gap, live)', 'hash=' + String(legacyHash).slice(0, 12) + '…');
+  verdict(rosterRejected === true && /signature invalid|REJECTED/.test(rosterWhy || ''), '§RV-IMPORT-FORGE roster-gated import REJECTS the forgery', String(rosterWhy).slice(0, 80));
+
+  // ── §RV-IMPORT-RENUMBER — an honest renumbered branch imports + replays under the roster gate ──
+  console.log('\n§RV-IMPORT-RENUMBER — honest renumbered branch roster-imports and replays');
+  mute();
+  var honest = Sync.exportBranch(origin, {});
+  var renH = renumberBranch(honest, 500);
+  var impOk = false, impActive = null, impHash = null, impErr = null;
+  try {
+    var imp = await Sync.importBranch(renH, HOST, mk, RO);
+    impOk = !!(imp && imp.projectionHash && imp.sigCheck && imp.sigCheck.ok);
+    impActive = imp.sigCheck && imp.sigCheck.activeKid; impHash = imp.projectionHash;
+  } catch (e) { impErr = e.message; }
+  var originHash = ERPKernel.replay(origin, mk()).hash;
+  unmute();
+  verdict(impOk === true && impActive === 'K0', '§RV-IMPORT-RENUMBER renumbered honest branch ACCEPTED (sigs id-independent)', impErr ? 'ERR=' + impErr : 'active=' + impActive);
+  verdict(impHash === originHash, '§RV-IMPORT-RENUMBER peer replay == origin projectionHash (byte-identical World)', String(impHash).slice(0, 12) + '… == ' + String(originHash).slice(0, 12) + '…');
+
+  if (K.setContentSigning) K.setContentSigning(false);
+  console.log('\n' + (fails ? '🔴 W-ROSTER-VERIFY ' + fails + ' FAIL' : '🟢 W-ROSTER-VERIFY ALL PASS'));
+  process.exit(fails ? 1 : 0);
+})().catch(function (e) { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/teams/erp/erp_sync.js
+++ b/teams/erp/erp_sync.js
@@ -47,25 +47,52 @@ function exportBranch(db, opts) {
   opts = opts || {};
   var where = '';
   if (opts.branchId != null && opts.branchId !== '*') where = ' WHERE branch_id = ' + JSON.stringify(String(opts.branchId));
-  var r = db.exec('SELECT id,op_uuid,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,branch_id FROM kernel_ops' + where + ' ORDER BY id');
+  var r = db.exec('SELECT id,op_uuid,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,branch_id,user_tag FROM kernel_ops' + where + ' ORDER BY id');
   if (!r.length) return [];
   var cols = r[0].columns;
   return r[0].values.map(function (v) { var o = {}; cols.forEach(function (c, i) { o[c] = v[i]; }); return o; });
 }
 
-// importBranch(ops, host, makeDb) — a remote peer materialises a pulled branch: rebuild its kernel_ops
-// rows verbatim, then erp_kernel.replay → projectionHash. The replay re-applies the stored rich payloads
-// (frozen effects) so the rebuilt World is byte-identical to the origin's. Returns {projectionHash, ops}.
-function importBranch(ops, host, makeDb) {
+// importBranch(ops, host, makeDb, opts) — a remote peer materialises a pulled branch: rebuild its
+// kernel_ops rows verbatim, then erp_kernel.replay → projectionHash. The replay re-applies the stored rich
+// payloads (frozen effects) so the rebuilt World is byte-identical to the origin's. Returns {projectionHash, ops}.
+//
+// T1 (W-ROSTER-VERIFY, KERNEL_HARDENING_BATCH1_SPEC §NEXT SESSION): pass opts.roster (the HQ-signed device
+// roster) to CLOSE the audit's security#1 gap — without it this path checked the keyless chain only, so a
+// forged foreign-key op with a self-consistent re-sealed chain was SILENTLY ACCEPTED. With opts.roster the
+// import is gated on erp_key_epochs.verifyEpochSigsOps (roster + ROTATE/REVOKE key-epoch map; v2 rows
+// verified over their T2 content hash so a merge-renumbered branch still verifies) and THROWS on any
+// forged/rotated-away/revoked signature. ADDITIVE: opts absent → legacy sync behaviour, byte-identical.
+// With opts.roster the function is ASYNC (returns a Promise — signature verification is webcrypto).
+function importBranch(ops, host, makeDb, opts) {
   host = host || (typeof window !== 'undefined' ? window : {});
+  if (opts && opts.roster) {
+    var EP = opts.epochs || host.ErpKeyEpochs ||
+             (typeof require !== 'undefined' ? require('../../erp/erp_key_epochs.js') : null) ||
+             (typeof self !== 'undefined' ? self.ErpKeyEpochs : null);
+    if (!EP) throw new Error('erp_sync: opts.roster given but erp_key_epochs.js not loadable');
+    var chain = erpVerifyChain(ops || []);
+    if (!chain.ok) throw new Error('erp_sync: import REJECTED — chain ' + chain.why + ' at ' + chain.at);
+    return EP.verifyEpochSigsOps(ops, opts).then(function (sv) {
+      if (!sv.ok) throw new Error('erp_sync: import REJECTED — ' + sv.why + (sv.brokeAt != null ? ' (op id=' + sv.brokeAt + ')' : ''));
+      console.log('§SYNC_IMPORT roster-verified len=' + sv.len + ' activeKid=' + sv.activeKid);
+      var out = _materialize(ops, host, makeDb);
+      out.sigCheck = sv;
+      return out;
+    });
+  }
+  return _materialize(ops, host, makeDb);
+}
+function _materialize(ops, host, makeDb) {
   var KernelOps = host.KernelOps, ERPKernel = host.ERPKernel;
   if (!ERPKernel) throw new Error('erp_sync: host.ERPKernel required for importBranch');
   var logDb = makeDb();
   if (KernelOps && KernelOps.ensureTable) KernelOps.ensureTable(logDb);
   else logDb.run('CREATE TABLE IF NOT EXISTS kernel_ops (id INTEGER PRIMARY KEY, op_uuid TEXT, timestamp INTEGER, op_type TEXT, parameters TEXT, input_guids TEXT, output_guid TEXT, undone INTEGER DEFAULT 0, prev_hash TEXT, op_hash TEXT, sig TEXT, gid TEXT, branch_id TEXT)');
   (ops || []).forEach(function (o) {
-    logDb.run('INSERT INTO kernel_ops (id,op_uuid,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,branch_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-      [o.id, o.op_uuid, o.timestamp, o.op_type, o.parameters, o.input_guids, o.output_guid, o.prev_hash, o.op_hash, o.sig, o.gid, o.branch_id]);
+    // user_tag rides along (T2 _canonicalV2 hashes it as `actor`) — default 'local' preserves old exports.
+    logDb.run('INSERT INTO kernel_ops (id,op_uuid,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,branch_id,user_tag) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      [o.id, o.op_uuid, o.timestamp, o.op_type, o.parameters, o.input_guids, o.output_guid, o.prev_hash, o.op_hash, o.sig, o.gid, o.branch_id, (o.user_tag != null ? o.user_tag : 'local')]);
   });
   var projDb = makeDb();
   var rep = ERPKernel.replay(logDb, projDb);


### PR DESCRIPTION
Spec: bim-compiler `prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION` (T2→T1, additive-canonical). Kernel v10→v11, erp sw v760.

## T2 — content-addressed signing (W-CONTENT-SIGN 14/14, RED-first)
- v2 ops (opt-in `setContentSigning`) sign a `stableStringify` content payload (no `id`, no `prev`) — sigs survive merge renumbering; `'|'` delimiter injection closed. v1 history verifies unchanged; **chain bytes untouched** (witnessed against the v1 formula).
- Documented deviations from the spec shorthand: dedicated `_sigv` gate (not D2 `_sv` — schema-version coupling), and `input_guids`/`output_guid` kept in the signed payload (never shrink signed coverage).

## T1 — roster + ROTATE/REVOKE on the import path (W-ROSTER-VERIFY 17/17, RED-first)
- PORTED from witnessed doctrine (`scripts/poc_rotate.js` W-ROTATE + `erp_key_epochs.js`, DistributedERP §228/§290/§445) — new `erp/erp_key_epochs.js`: HQ-signed device roster (pinned-key pattern) + key epochs; verify each op under the key valid at its seq, over the T2 content hash for v2 rows.
- `importBranch(..., opts.roster)` now REJECTS a forged foreign-key op that today imports silently (witnessed live: keyless path accepts, roster path throws). Legacy calls byte-identical.

## Evidence
- RED logs captured pre-fix (4-fail T2 / 12-fail T1); GREEN after. Regression: W-CROSS-TAB-PERSIST, W-PCLOSE-ARCHIVE, teams suite 25/25 all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)