### PR TITLE
feat(modeller): §V8 T/S arm rotate/scale gizmo sub-modes (POLISH3 item 10)

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1575,6 +1575,7 @@ function buildMoveGizmo() {
   }
   moveGizmo.traverse(o => { o.renderOrder = 1000; });          // draw over the solids like the insert ghost
   moveGizmo.position.copy(c); scene.add(moveGizmo);
+  if (armedSub) applyArmDim();                                  // §V8: re-apply T/S arm dimming across gizmo rebuilds (post-commit)
   if (window.A && A.requestRender) A.requestRender();
 }
 function clearMoveGizmo() { if (moveGizmo) { scene.remove(moveGizmo); moveGizmo.traverse(o => { if (o.geometry) o.geometry.dispose(); if (o.material) o.material.dispose(); }); moveGizmo = null; } }
@@ -1732,6 +1733,7 @@ function enterMove() {
 }
 function exitMove() {
   moving = false; _moveDrag = null; bMove.innerHTML = MV_MOVE; bMove.classList.remove('on'); controls.enabled = true; applyModeCursor();
+  armedSub = null; window.__rsArm = null;                       // §V8: leaving Move always clears the T/S arm
   dimLabelHide();                                               // §V7
   if (dimMove) dimMove.style.display = 'none';
   if (dimRot) dimRot.style.display = 'none';
@@ -1739,6 +1741,44 @@ function exitMove() {
   clearMoveGizmo(); clearMoveGhost(); clearSnapMarker();
 }
 bMove.onclick = () => moving ? exitMove() : enterMove();
+// §V8 T/S sub-mode arming (RESUME_MODELLER_POLISH3.md §V8 — Witness: W-E2E-RSARM). R stays Insert (decided
+// 2026-07-03: it already has toolbar+rotate-while-inserting double duty); T ("turn") arms the rotate ring,
+// S arms the scale cubes. Arming is AFFORDANCE ONLY — matching handles keep full opacity, the rest dim, the
+// status line says what to drag; the drag itself still commits through the untouched rotZ/scale pointer
+// handlers, so no fold or commit path changes here.
+let armedSub = null;                                            // null | 'rot' | 'scale'
+function _armSetOf(o) { const ax = (o.userData && o.userData.moveAxis) || ''; return ax === 'rotZ' ? 'rot' : (ax.indexOf('scale') === 0 ? 'scale' : 'move'); }
+function applyArmDim() {
+  if (moveGizmo) moveGizmo.traverse(o => {
+    if (!o.isMesh || !o.material) return;
+    // base opacity lives on the MATERIAL: arrow shaft+tip SHARE one material, so a per-object record
+    // captures the already-dimmed value on the second traversal and restore re-dims (W-E2E-RSARM first RED)
+    if (o.material.userData._baseOpacity == null) o.material.userData._baseOpacity = o.material.opacity;
+    o.material.opacity = (!armedSub || _armSetOf(o) === armedSub || _armSetOf(o.parent) === armedSub) ? o.material.userData._baseOpacity : 0.15;
+  });
+  window.__rsArm = armedSub ? { kind: armedSub } : null;        // W-E2E-RSARM oracle
+  if (window.A && A.requestRender) A.requestRender();
+}
+function armSubMode(kind) {
+  if (sketching || routing || edgePicking || gridMoving || inserting) return;
+  if (selectedId == null && !moving) { setStat((kind === 'rot' ? 'rotate' : 'scale') + ': select an object first'); return; }
+  if (!moving) enterMove();
+  if (!moving || !moveGizmo) return;                            // enterMove refused (no selection / no gizmo)
+  if (armedSub === kind) {
+    armedSub = null; applyArmDim();
+    setStat((kind === 'rot' ? 'rotate' : 'scale') + ': disarmed'); console.log('§RSARM disarmed=' + kind); return;
+  }
+  const has = { rot: false, scale: false };
+  moveGizmo.traverse(o => { const s = _armSetOf(o); if (s !== 'move') has[s] = true; });
+  if (!has[kind]) {                                             // same gates as buildMoveGizmo — never arm a handle that isn't offered
+    setStat(kind === 'rot' ? 'rotate: ring not offered on this selection' : 'scale: cubes only on a single catalog component');
+    console.log('§RSARM refuse=' + kind); return;
+  }
+  armedSub = kind; applyArmDim();
+  setStat(kind === 'rot' ? 'rotate armed — drag the yellow ring (Shift = free, else 15° snap), T disarms'
+    : 'scale armed — drag a cube out (edge-anchored), S disarms');
+  console.log('§RSARM armed=' + kind);
+}
 function moveDragPlane(axis, c0) {                             // x/y/xy → horizontal plane through c0; z → vertical plane facing camera
   if (axis === 'z') { const n = new THREE.Vector3(); camera.getWorldDirection(n); n.z = 0; if (n.lengthSq() < 1e-6) n.set(0, 1, 0); n.normalize(); return new THREE.Plane().setFromNormalAndCoplanarPoint(n, c0); }
   return new THREE.Plane(new THREE.Vector3(0, 0, 1), -c0.z);
@@ -2020,6 +2060,13 @@ window.addEventListener('keydown', (e) => {
   if (/^(INPUT|TEXTAREA)$/.test((e.target && e.target.tagName) || '')) return;
   if ((e.key === 'm' || e.key === 'M') && !sketching && !routing && !edgePicking && !gridMoving && !inserting) {
     if (selectedId != null || moving) { e.preventDefault(); bMove.onclick(); }
+  }
+  // §V8 (RESUME_MODELLER_POLISH3.md §V8 — Witness: W-E2E-RSARM): T arms the rotate ring ("turn"), S arms the
+  // scale cubes — Move-gizmo sub-mode arming only; R stays Insert (decided 2026-07-03). Ctrl/Meta/Alt skipped
+  // so Ctrl+S stays the browser's save and no chord ever arms by accident.
+  if ((e.key === 't' || e.key === 'T' || e.key === 's' || e.key === 'S') && !e.ctrlKey && !e.metaKey && !e.altKey &&
+      !sketching && !routing && !edgePicking && !gridMoving && !inserting) {
+    if (selectedId != null || moving) { e.preventDefault(); armSubMode((e.key === 't' || e.key === 'T') ? 'rot' : 'scale'); }
   }
   // G toggles snap-to-geometry while moving (suppress the inference like SketchUp's Alt) — re-preview the live drag.
   if ((e.key === 'g' || e.key === 'G') && moving) {
@@ -3594,6 +3641,9 @@ console.log('§MODELLER scene ready supported=' + (window.Bonsai ? window.Bonsai
       h += '<div class="hp-row" style="opacity:.85"><span class="hp-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></span><span class="hp-name">Cancel current mode</span>' + _kbd('Esc') + '</div>';
       // §P7: G (snap-to-geometry toggle while moving) was a real, working shortcut the panel never listed.
       h += '<div class="hp-row" style="opacity:.85"><span class="hp-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/><circle cx="12" cy="12" r="3"/></svg></span><span class="hp-name">Snap-to-geometry on/off (while moving)</span>' + _kbd('G') + '</div>';
+      // §V8: T/S arm the Move gizmo's rotate-ring / scale-cube sub-modes (R stays Insert — decided 2026-07-03).
+      h += '<div class="hp-row" style="opacity:.85"><span class="hp-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg></span><span class="hp-name">Arm rotate ring (turn, in Move)</span>' + _kbd('T') + '</div>';
+      h += '<div class="hp-row" style="opacity:.85"><span class="hp-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="1"/><path d="M14 4v6h6"/></svg></span><span class="hp-name">Arm scale cubes (in Move)</span>' + _kbd('S') + '</div>';
       hpanel.innerHTML = h;
     }
     help.onclick = e => { e.stopPropagation(); const open = hpanel.style.display !== 'block'; if (open) buildHelp();

--- a/modeller/tests/witness_e2e_rsarm.js
+++ b/modeller/tests/witness_e2e_rsarm.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-RSARM: real-keypress witness for §V8 (prompts/RESUME_MODELLER_POLISH3.md §V8).
+ * SCOPE: T arms the Move gizmo's rotate ring ("turn"), S arms the scale cubes — sub-mode ARMING only
+ * (R stays Insert, decided 2026-07-03). Arming is affordance (opacity dim + status hint); the drag still
+ * commits through the untouched rotZ/scale pointer paths. Read the log after every run.
+ *
+ * ⚠ FIRST-RED FINDING (probe-verified): a FIXED 0.6m cube drag on a ~long wall gives f≈1.1 which the
+ * 0.25-snap rounds to ×1.00 → "scale: no change", NO commit — the raycast was fine (probe hit scaleX
+ * clean). Drag distance must scale with the extent (dW = 0.6·ext, the proven W-E2E-SCALE recipe).
+ * Order is scale-then-rotate mirroring W-E2E-NUMROT (GEOM_SCALE folds on LOCAL axes).
+ *
+ * CLAIMS:
+ *   A1 ARM-T-AUTOENTER — 't' on a selected insert (NOT in Move) enters Move AND arms rot: __rsArm.kind='rot',
+ *                        ring keeps base opacity while a move arrow + a scale cube dim below it.
+ *   A2 SWITCH-S        — 's' switches the arm to scale: cubes full opacity, ring dimmed.
+ *   A3 DRAG-SCALE      — cube drag while armed commits exactly ONE GEOM_SCALE (exactly one axis factor ≠ 1),
+ *                        and the arm SURVIVES the post-commit gizmo rebuild (__rsArm still 'scale').
+ *   A4 SWITCH-T        — 't' switches back to rot on the REBUILT gizmo (ring full, cubes dimmed).
+ *   A5 DRAG-ROT        — ring drag while armed commits exactly ONE GEOM_ROTATE drot≈30 (right op type).
+ *   A6 TOGGLE-OFF      — 't' again disarms: __rsArm null, ring/cube/arrow opacities all back at base
+ *                        (arrow restore proves the shared-material _baseOpacity fix — first-RED finding).
+ *   A7 GUARDS+ESC      — Ctrl+S arms nothing; typing 's' inside #dim-move arms nothing; 't' re-arms and
+ *                        Esc exits Move + clears the arm.
+ *   (+ harness NO-ERROR: no pageerror across the sequence.)
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+// opacity snapshot of one handle per set, keyed by moveAxis (ring=rotZ 0.9, cube=scaleX/Y/Z 0.95, arrow=x 0.92)
+const handleOps = (t) => t.pg.evaluate(() => {
+  const gz = window.A.scene.getObjectByName('MoveGizmo'); if (!gz) return null;
+  const out = { ring: null, cube: null, arrow: null };
+  gz.traverse(o => {
+    if (!o.isMesh || !o.material) return;
+    const ax = (o.userData && o.userData.moveAxis) || '';
+    if (ax === 'rotZ') out.ring = o.material.opacity;
+    else if (ax.indexOf('scale') === 0 && out.cube == null) out.cube = o.material.opacity;
+    else if (ax === 'x' && out.arrow == null) out.arrow = o.material.opacity;
+  });
+  return out;
+});
+const arm = (t) => t.pg.evaluate(() => window.__rsArm ? window.__rsArm.kind : null);
+const ringInfo = (t) => t.pg.evaluate(() => {
+  const gz = window.A.scene.getObjectByName('MoveGizmo'); if (!gz) return null;
+  let ring = null; gz.traverse(o => { if (o.userData && o.userData.moveAxis === 'rotZ') ring = o; });
+  if (!ring) return null;
+  const c = new window.THREE.Vector3(); gz.getWorldPosition(c);
+  const R = (ring.geometry && ring.geometry.parameters && ring.geometry.parameters.radius) || 0.9;
+  return { c: [c.x, c.y, c.z], R };
+});
+
+runE2E('W-E2E-RSARM', async (t) => {
+  await t.open('Duplex');
+  const sel = await t.pick({ prefer: 'wall' });                 // a real insert — satisfies BOTH gizmo gates
+  if (!sel) { t.assert('pick insert', false, 'no selection'); return; }
+
+  // A1 — 't' from plain selection (not in Move): auto-enter Move + arm rot + dim the other handle sets
+  await t.pg.keyboard.press('t'); await t.sleep(500);
+  const st1 = await t.pg.evaluate(() => ({ moving: document.getElementById('b-move').classList.contains('on') }));
+  const ops1 = await handleOps(t); const a1 = await arm(t);
+  t.assert('A1 ARM-T-AUTOENTER (Move entered, rot armed, others dimmed)',
+    st1.moving && a1 === 'rot' && ops1 && ops1.ring > 0.8 && ops1.arrow < 0.2 && ops1.cube < 0.2,
+    'moving=' + st1.moving + ' arm=' + a1 + ' ops=' + JSON.stringify(ops1));
+  await t.frameElement(sel.fid, 0.35);
+
+  // A2 — 's' switches the arm to scale
+  await t.pg.keyboard.press('s'); await t.sleep(300);
+  const ops2 = await handleOps(t); const a2 = await arm(t);
+  t.assert('A2 SWITCH-S (scale armed: cubes full, ring dimmed)',
+    a2 === 'scale' && ops2 && ops2.cube > 0.8 && ops2.ring < 0.2,
+    'arm=' + a2 + ' ops=' + JSON.stringify(ops2));
+
+  // A3 — drag a scale cube outward (centre→cube direction: cubes sit on the insert's LOCAL axes, §Q1;
+  // unrotated element = the proven W-E2E-SCALE drag geometry, see header ⚠)
+  const gc = await t.pg.evaluate(() => {
+    const gz = window.A.scene.getObjectByName('MoveGizmo'); if (!gz) return null;
+    let cube = null; gz.traverse(o => { if (o.userData && o.userData.moveAxis === 'scaleX') cube = o; });
+    if (!cube) return null;
+    const w = new window.THREE.Vector3(); cube.getWorldPosition(w);
+    const c = new window.THREE.Vector3(); gz.getWorldPosition(c);
+    return { cube: [w.x, w.y, w.z], c: [c.x, c.y, c.z] };
+  });
+  if (!gc) { t.assert('A3 DRAG-SCALE', false, 'no scaleX cube'); return; }
+  const ext0 = await t.pg.evaluate(f => { const g = window.Bonsai.group();
+    const m = g.children.find(o => o.isMesh && o.userData.featureId === f); if (!m) return 0;
+    m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox; return b.max.x - b.min.x; }, sel.fid);
+  const od = [gc.cube[0] - gc.c[0], gc.cube[1] - gc.c[1], gc.cube[2] - gc.c[2]];
+  const oL = Math.hypot(od[0], od[1], od[2]) || 1, dW = Math.max(0.6, 0.6 * ext0);   // see header ⚠: f≈1.6 → 0.25-snap 1.5, never the ×1.00 dead-zone
+  const sdown = await t.proj(gc.cube[0], gc.cube[1], gc.cube[2]);
+  const sup = await t.proj(gc.cube[0] + od[0] / oL * dW, gc.cube[1] + od[1] / oL * dW, gc.cube[2] + od[2] / oL * dW);
+  const log0 = await t.oplog();
+  await t.drag(sdown, sup, 10); await t.sleep(1500);
+  const log1 = await t.oplog(); const scOp = await t.lastOp(); const a3 = await arm(t);
+  const fac = scOp && scOp.parameters ? [scOp.parameters.fx, scOp.parameters.fy, scOp.parameters.fz] : [];
+  t.assert('A3 DRAG-SCALE (one GEOM_SCALE while armed, arm survives rebuild)',
+    log1.len === log0.len + 1 && scOp && scOp.op_type === 'GEOM_SCALE' && fac.filter(f => f !== 1).length === 1 && a3 === 'scale',
+    'len ' + log0.len + '→' + log1.len + ' op=' + (scOp && scOp.op_type) + ' f=' + JSON.stringify(fac) + ' arm=' + a3);
+
+  // A4 — 't' switches back to rot on the rebuilt gizmo
+  await t.pg.keyboard.press('t'); await t.sleep(300);
+  const ops4 = await handleOps(t); const a4 = await arm(t);
+  t.assert('A4 SWITCH-T (rot armed on rebuilt gizmo: ring full, cubes dimmed)',
+    a4 === 'rot' && ops4 && ops4.ring > 0.8 && ops4.cube < 0.2,
+    'arm=' + a4 + ' ops=' + JSON.stringify(ops4));
+
+  // A5 — drag the ring 30° while armed → exactly ONE GEOM_ROTATE
+  const giz = await ringInfo(t);
+  if (!giz) { t.assert('A5 DRAG-ROT', false, 'no ring'); return; }
+  const th = 30 * Math.PI / 180;
+  const rdown = await t.proj(giz.c[0] + giz.R, giz.c[1], giz.c[2]);
+  const rup = await t.proj(giz.c[0] + giz.R * Math.cos(th), giz.c[1] + giz.R * Math.sin(th), giz.c[2]);
+  await t.drag(rdown, rup, 12); await t.sleep(1500);
+  const log2 = await t.oplog(); const rotOp = await t.lastOp();
+  t.assert('A5 DRAG-ROT (one GEOM_ROTATE drot≈30 while armed)',
+    log2.len === log1.len + 1 && rotOp && rotOp.op_type === 'GEOM_ROTATE' && Math.abs(Math.abs(rotOp.parameters.drot) - 30) < 0.6,
+    'len ' + log1.len + '→' + log2.len + ' op=' + (rotOp && rotOp.op_type) + ' drot=' + (rotOp && rotOp.parameters && rotOp.parameters.drot));
+
+  // A6 — 't' again disarms: everything back at base opacity (incl. the shared-material arrows)
+  await t.pg.keyboard.press('t'); await t.sleep(300);
+  const ops6 = await handleOps(t); const a6 = await arm(t);
+  t.assert('A6 TOGGLE-OFF (disarmed, base opacities restored incl. arrows)',
+    a6 === null && ops6 && ops6.ring > 0.8 && ops6.cube > 0.8 && ops6.arrow > 0.8,
+    'arm=' + a6 + ' ops=' + JSON.stringify(ops6));
+
+  // A7 — guards, then Esc clears: Ctrl+S no-arm, typing in a field no-arm, 't' re-arms, Esc exits + clears
+  await t.pg.keyboard.down('Control'); await t.pg.keyboard.press('s'); await t.pg.keyboard.up('Control'); await t.sleep(200);
+  const aCtrl = await arm(t);
+  await t.pg.click('#dim-move'); await t.pg.type('#dim-move', 's'); await t.sleep(200);
+  const aType = await arm(t);
+  await t.pg.evaluate(() => { const d = document.getElementById('dim-move'); d.value = ''; d.blur(); });
+  await t.pg.keyboard.press('t'); await t.sleep(300);
+  const a7pre = await arm(t);
+  await t.pg.keyboard.press('Escape'); await t.sleep(300);
+  const st7 = await t.pg.evaluate(() => ({ moving: document.getElementById('b-move').classList.contains('on'), arm: window.__rsArm ? window.__rsArm.kind : null }));
+  t.assert('A7 GUARDS+ESC (Ctrl+S no-arm, typed no-arm, re-arm then Esc clears)',
+    aCtrl === null && aType === null && a7pre === 'rot' && !st7.moving && st7.arm === null,
+    'ctrl=' + aCtrl + ' typed=' + aType + ' pre=' + a7pre + ' moving=' + st7.moving + ' arm=' + st7.arm);
+}, { width: 1200, height: 850, dpr: 1 });

--- a/prompts/RESUME_MODELLER_POLISH3.md
+++ b/prompts/RESUME_MODELLER_POLISH3.md
@@ -91,17 +91,28 @@ Logs saved under `modeller/tests/logs/` and READ before any DONE claim.
   SAME number the status bar computes (never a second math path): move `ΔX +1.20m` (snapped delta), rotate
   `+15°`, scale `X ×1.25`, grid-drag `A Δ0.60m`. Hidden on commit/cancel/exit. Seam: `dimLabelShow(text,pos)` /
   `dimLabelHide()` + `window.__dimLabel` witness oracle.
-- **§V8 R/S shortcuts (item 10): ⛔ BLOCKED — needs the user/Sonnet nod the research spec already flagged,**
-  plus a NEW fact found here: the industry `R`=rotate convention COLLIDES with the modeller's existing
-  `R`=Insert shortcut (modeller.html SHORTCUTS map + help panel). Arming rotate/scale sub-modes is mechanical
-  once keys are chosen; choosing keys (rebind Insert? pick other letters?) is a user-facing UX decision, not
-  an EXTRACT. One question: which bindings — (a) keep R=Insert, use e.g. `T`(turn)/`S`(scale), or (b) rebind
-  Insert (Blender uses Shift+A) and take R/S?
+- **§V8 R/S shortcuts (item 10): ✅ DECIDED 2026-07-03 (user delegated: "please decide for me") → option (a).**
+  Keep `R`=Insert (it already has double duty — toolbar Insert + rotate-while-inserting; rebinding breaks
+  muscle memory/help/witnesses for zero gain); add **`T`=arm the rotate ring ("turn") and `S`=arm the scale
+  cubes** as Move-gizmo sub-mode ARMING keys (SketchUp precedent S=scale). SPEC: on `T`/`S` (not typing, no
+  Ctrl/Meta/Alt — Ctrl+S stays browser-save, no other mode active): selection exists → enter Move if needed →
+  if the matching handle set is offered by the gizmo's existing gates (ring = all selected INSERT/SOLID,
+  cubes = single INSERT) arm it — matching handles keep full opacity, all other handles dim, status hint says
+  what to drag; gate not met → refuse with a hint, arm nothing. Same key again = disarm (restore all).
+  Arming changes NO fold and NO commit path — the drag still commits through the untouched rotZ/scale
+  pointer handlers; arming is affordance only. Esc/exit-Move clears the arm. Oracle: `window.__rsArm`,
+  §-tag `§RSARM`. Help panel gains T/S keyboard rows (R row untouched).
 
 - **W-E2E-FLOATDIM** (§V7): real move-gizmo drag held mid-drag → a `dimLabel` sprite is IN the scene, its
   text equals the status bar's snapped delta (same number, maths-compared), positioned within the element's
   neighbourhood (≤ diag of the drag), constant-screen-size scale > 0; release → hidden. Rotate ring drag →
   `°` text matches the snapped angle. No pageerror.
+- **W-E2E-RSARM** (§V8): real keypress path on a real selected insert — `T` (outside Move) auto-enters Move
+  AND arms rot (`__rsArm.kind==='rot'`, non-ring handles dimmed below base opacity); ring drag while armed
+  commits exactly ONE `GEOM_ROTATE` (the right op type); `S` switches the arm to scale (cubes full, ring
+  dimmed); cube drag commits exactly ONE `GEOM_SCALE`; `S` again disarms (opacities restored to base);
+  `Ctrl+S` arms NOTHING; typing `s` inside a dim-* input arms NOTHING; Esc exits Move and clears the arm.
+  No pageerror.
 
 ## # DONE appendix (fill as items land — every claim needs a § log line)
 
@@ -117,3 +128,13 @@ Logs saved under `modeller/tests/logs/` and READ before any DONE claim.
   ghost ≤5cm, +30° on the ring, hidden on release). Regression: W-E2E-MOVE 9/9 · W-E2E-ROTATE 7/7 ·
   W-E2E-SCALE 7/7 · W-E2E-GRIDSTRETCH 7/7 (logs modeller/tests/logs/). §V8 (item 10 R/S shortcuts) stays
   ⛔ BLOCKED on the key-binding question above.
+- 2026-07-03 §V8 SHIPPED (lane/modeller-polish-5) — T/S Move-gizmo sub-mode arming per the decision above
+  (R kept as Insert). W-E2E-RSARM 8/8 (§RSARM log lines; logs modeller/tests/logs/w_e2e_rsarm.log): T
+  auto-enters Move + arms rot with the other handle sets dimmed, armed drags commit exactly one
+  GEOM_SCALE/GEOM_ROTATE through the untouched pointer paths, arm survives the post-commit gizmo rebuild,
+  toggle-off restores base opacities, Ctrl+S / typing guards hold, Esc clears. TWO first-RED findings:
+  (1) arrow shaft+tip SHARE one material → base opacity must be recorded on the material, not per-object
+  (restore re-dimmed arrows otherwise); (2) a fixed 0.6m cube drag 0.25-snaps to ×1.00 on a long wall
+  (probe-verified the raycast was fine) → witness drags 0.6·ext like W-E2E-SCALE. Regression: W-E2E-MOVE
+  9/9 · W-E2E-ROTATE 7/7 · W-E2E-SCALE 7/7 · W-E2E-NUMROT 7/7 · W-E2E-FLOATDIM 6/6. Help panel gained
+  T/S keyboard rows.


### PR DESCRIPTION
## §V8 — item 10 R/S shortcuts (decision: keep R=Insert, T/S arm sub-modes)

Per the 2026-07-03 user-delegated decision in `prompts/RESUME_MODELLER_COMPETITIVE_POLISH.md` / `RESUME_MODELLER_POLISH3.md` §V8:

- **T** arms the Move gizmo's rotate ring ("turn"), **S** arms the scale cubes — SketchUp precedent.
- Arming is **affordance only**: matching handles keep base opacity, the others dim to 0.15, status hint says what to drag. The drag commits through the **untouched** rotZ/scale pointer paths — no fold, no commit-path change.
- Auto-enters Move from a plain selection; same key toggles off; Esc/exit-Move clears; Ctrl/Meta/Alt chords + typing-in-field guarded (Ctrl+S stays browser save); gates mirror buildMoveGizmo — refuses with a hint when the handle set isn't offered.
- Help panel: T/S keyboard rows added (R row untouched).
- First-RED fix: arrow shaft+tip share one material → base opacity recorded on the **material**, not per-object (restore re-dimmed arrows otherwise).

## Witnesses (logs in modeller/tests/logs/)
- **W-E2E-RSARM 8/8** — real keypresses + real drags: auto-enter+arm, armed ring drag → ONE GEOM_ROTATE drot=30, armed cube drag → ONE GEOM_SCALE fx=1.5, arm survives post-commit rebuild, toggle-off restores base opacities, Ctrl+S/typed guards, Esc clears, NO-ERROR.
- Regression: W-E2E-MOVE 9/9 · W-E2E-ROTATE 7/7 · W-E2E-SCALE 7/7 · W-E2E-NUMROT 7/7 · W-E2E-FLOATDIM 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)