### PR TITLE
feat(hba): §STAGE3 — attendance onto native S_Resource/S_ResourceAssignment (C_Attendance invention retired) + governed Presence drawer + BIM BOM pane

### DIFF
--- a/hr_bim_asset/ad_attendance.js
+++ b/hr_bim_asset/ad_attendance.js
@@ -1,85 +1,131 @@
 // Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
 // SPDX-License-Identifier: MIT
-// ⚠ DO NOT REMOVE — ATTENDANCE COMPILED ONTO THE NATIVE (Ninja-staged) C_Attendance CHILD TABLE
-//   (bim-compiler prompts/RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-ATTENDANCE, Stage 2). This module's
-//   whole job is the gap flagged in §EVIDENCE point 3: resolve attendance.js's bare `EMP-n`/`EMP00n` ids and
-//   room guids to the REAL c_bpartner_id / m_locator_id seeded in Stage 1, so a presence row STOPS being a
-//   self-signed op keyed by a bare string and BECOMES a real AD child row that JOINs
-//   C_Attendance→HR_Process→C_BPartner→M_Locator→M_Warehouse (the §DESIGN-ATTENDANCE InfoWindow lens).
+// ⚠ DO NOT REMOVE — ATTENDANCE COMPILED ONTO THE **REAL NATIVE** S_Resource / S_ResourceAssignment TABLES
+//   (bim-compiler prompts/RESUME_HBA_ERP_STAGE3.md §PREREQUISITE, watchdog finding 2026-07-03 — Witness:
+//   W-HBA-AD-ATTENDANCE). The previous revision compiled onto a Ninja-staged `C_Attendance` — but C_Attendance
+//   is NOT a real iDempiere table (AD_Table LIKE '%ttendance%' → 0 rows in ad_full.db): it was an INVENTED
+//   dictionary extension, the same violation class WATCHDOG_BIM_ERP_SOURCE_OF_TRUTH.md exists to kill. The
+//   REAL native fit is the "Mary Consultant" GardenWorld pattern sitting unused in the same DB:
+//     person   → S_Resource (ad_user_id → AD_User — the SAME identity spine ad_payroll.js/models.js resolve;
+//                m_warehouse_id → M_Warehouse — the SAME building FK ad_tenancy.js resolves onto)
+//     session  → S_ResourceAssignment (assigndatefrom = check-in, assigndateto = check-out — NULL = OPEN, the
+//                exact honest-open semantic this module always had; qty = the REAL derived hours;
+//                isconfirmed = the maker-checker gate: 'Y' closed, 'N' open — never a fabricated approval)
 //
-//   NON-INVENT GATE (mirrors ad_tenancy.compileBuilding's `skipped[]` discipline): a session whose employee
-//   or zone does NOT resolve to a real seeded id is SKIPPED into `skipped[]` with a reason — NEVER given a
-//   fabricated FK. The row builder is column-pure: it emits ONLY columns that exist on the seeded physical
-//   C_Attendance table (seed_hba_erp.js DDL.C_Attendance — dumped live from the Ninja-staged AD_Column set);
-//   the AD system columns (AD_Client_ID/AD_Org_ID/IsActive/Created…) are the PERSISTER's job, exactly as
-//   ad_payroll.js's hrIns and ad_tenancy.js's builders leave them (see those headers).
+//   ROOM GRANULARITY (the ONE design decision, accepted per RESUME_HBA_ERP_STAGE3.md): S_ResourceAssignment
+//   has NO m_locator_id/room column natively (verified live) — the native model is person@building/from→to/
+//   hours/confirmed. The ZONE therefore stays a **BIM spatial-overlay fact** (attendance.js's signed op-log
+//   `zone` param), carried BESIDE the AD rows in the `spatial` view-trace (keyed by the row PK) — the same
+//   idiom ad_bom.js uses for geometry. It is NEVER forced into a fabricated FK column.
 //
-//   HONEST-OPEN preserved (attendance.js's own §SLICE-1 contract): a session with no check-out is OPEN —
-//   CheckOutTime AND Qty stay NULL (no fabricated finish/hours). Qty = the REAL derived hours (attendance.js
-//   _hoursBetween over the real in/out ts), mirroring hr_movement.qty; never an independently-stored number.
+//   BUILDER DELEGATION (don't duplicate): the s_resourceassignment/s_resource COLUMN SHAPES are owned by
+//   occupancy.js's already-witnessed toResourceAssignmentRow/toResourceRow (W-HBA-AD-OCC — same tables, room-
+//   type resource). This module wraps those builders with the attendance semantics (person-type resource,
+//   hours-as-qty, honest-open NULLs) instead of re-declaring the column set.
 //
-//   SOURCE = attendance.js's already-witnessed `sessions(log, period)` reader (UNCHANGED — no re-implementation
-//   of the fold). This module takes those sessions + three injected resolution maps (processId, partnerMap,
-//   locatorMap) and produces the child rows. The maps come from the REAL seeded rows at compile time (the
-//   viewer's erpQuery seam / a witness's injected ad_seed.db handle) — so every emitted FK traces to a queried
-//   row, per the §CONVENTION "any info panel in BIM has to be just a lens from such source."
+//   NON-INVENT GATE (unchanged discipline): a session whose employee does NOT resolve to a real seeded
+//   S_Resource is SKIPPED into `skipped[]` with a reason — NEVER given a fabricated FK. Rows are column-pure;
+//   AD system columns (ad_client_id/isactive/created…) are the PERSISTER's job (see ad_payroll.js hrIns).
+//
+//   SOURCE = attendance.js's already-witnessed `sessions(log, period)` reader (UNCHANGED). readPresence() is
+//   the LENS READ back over the persisted rows — the ad_infowindow 7600000 JOIN (S_ResourceAssignment ⋈
+//   S_Resource ⋈ AD_User ⋈ M_Warehouse), mirroring ad_bom.readBom. Read the log after every run.
 'use strict';
 (function () {
-var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
+var _r = (typeof require !== 'undefined'), _g = (typeof self !== 'undefined' ? self : this);
+var W = _r ? require('./watermark') : _g.HbaWatermark;
+var O = _r ? require('./occupancy') : _g.HbaOccupancy;
 
-// ONE C_Attendance child row for ONE presence session. Column-pure: keys are a SUBSET of the seeded physical
-// table's columns (the non-invent gate the witness enforces). `session` = an attendance.js session
-// ({employee, zone, in, out, hours, open}); the caller has already resolved employee→c_bpartner_id and
-// zone→m_locator_id (both REAL seeded ids) and supplies the parent hr_process_id + a seedId sequencer.
-function toAttendanceRow(session, hr_process_id, c_bpartner_id, m_locator_id, seedId) {
-  if (!session || c_bpartner_id == null || m_locator_id == null) return null;
-  var open = !!session.open;
-  return { C_Attendance_ID: seedId ? seedId() : 1, HR_Process_ID: hr_process_id != null ? hr_process_id : null,
-    C_BPartner_ID: c_bpartner_id, M_Locator_ID: m_locator_id,
-    ServiceDate: session.in ? String(session.in).slice(0, 10) : null,
-    CheckInTime: session.in || null,
-    CheckOutTime: open ? null : (session.out || null),      // OPEN → honest NULL (no fabricated finish)
-    Qty: open ? null : (session.hours != null ? session.hours : null),   // hours DERIVED from real in/out; open → NULL
-    Description: open ? 'demo session (open — no fabricated finish)' : 'demo session' };
+// ONE s_resource header row for ONE person. Delegates the column shape to occupancy.toResourceRow (the ONE
+// witnessed builder for this table), then threads the two REAL person columns the room path never needed:
+// ad_user_id (identity spine) + m_warehouse_id (building FK) — both verified real S_Resource columns.
+// `person` = { code, name?, ad_user_id, m_warehouse_id? }; code rides Value (the same Value=identity idiom
+// the trades/rooms rows use). Honest null when identity is missing — never a person without a real AD_User.
+function toPersonResourceRow(person, s_resourcetype_id, seedId) {
+  if (!person || person.code == null || person.ad_user_id == null || !O) return null;
+  var row = O.toResourceRow({ guid: person.code, name: person.name || person.code }, s_resourcetype_id, seedId, null);
+  if (!row) return null;
+  row.ad_user_id = person.ad_user_id;
+  if (person.m_warehouse_id != null) row.m_warehouse_id = person.m_warehouse_id;
+  return row;
 }
 
-// compile a WHOLE period's presence sessions into native C_Attendance rows in one pass →
-// {rows, skipped, _watermark}. `opts` supplies the REAL resolution:
-//   opts.processId   — the parent HR_Process this attendance period folds under (real seeded hr_process_id)
-//   opts.partnerMap  — { <employee id> : c_bpartner_id }  (real seeded C_BPartner ids, e.g. EMP001→1001)
-//   opts.locatorMap  — { <zone guid>   : m_locator_id }   (real seeded M_Locator ids, keyed by room guid)
-// A session whose employee OR zone is not in the maps is SKIPPED (never a fabricated FK), captured in
-// `skipped[]` with a reason — same non-invent contract as ad_tenancy.compileBuilding. Deterministic:
-// C_Attendance_ID is a 1-based sequence over the accepted rows (no Date.now/random).
+// ONE s_resourceassignment row for ONE presence session. Delegates the column shape to occupancy.
+// toResourceAssignmentRow (same table, witnessed), then applies the attendance semantics:
+//   assigndatefrom = check-in ts · assigndateto = check-out ts | NULL (OPEN — no fabricated finish)
+//   qty = the REAL derived hours (attendance.js _hoursBetween) | NULL when open (no fabricated duration)
+//   isconfirmed = 'Y' only on a CLOSED session (a real completed in→out pair); an open one is honestly 'N'
+// The `_party` carry-along is dropped: the person identity rides S_Resource.ad_user_id (a real FK), not a
+// bolt-on. The zone is NOT here — see the header (spatial view-trace, never a fabricated column).
+function toAssignmentRow(session, s_resource_id, seedId) {
+  if (!session || s_resource_id == null || !O) return null;
+  var open = !!session.open;
+  var row = O.toResourceAssignmentRow({ verb: 'ASSIGN', target: s_resource_id,
+    params: { party: session.employee, from: session.in || null, to: open ? null : (session.out || null) } }, seedId);
+  if (!row) return null;
+  delete row._party;
+  row.name = session.employee != null ? String(session.employee) : null;
+  row.description = open ? 'presence session (open — no fabricated finish)' : 'presence session';
+  row.assigndateto = open ? null : (session.out || null);
+  row.qty = open ? null : (session.hours != null ? session.hours : null);
+  row.isconfirmed = open ? 'N' : 'Y';
+  return row;
+}
+
+// compile a WHOLE period's presence sessions into native s_resourceassignment rows in one pass →
+// { rows, skipped, spatial, _watermark }. `opts.resourceMap` = { <employee code> : s_resource_id } built from
+// REAL queried rows (resourceMapFromResources over the viewer's erpQuery / a witness's ad_seed.db handle).
+// A session whose employee is not in the map is SKIPPED (never a fabricated FK). `spatial` carries the BIM
+// zone fact per accepted row (keyed by the row PK) — the room-granularity split, see header. Deterministic:
+// s_resourceassignment_id is a 1-based sequence over accepted rows (no Date.now/random).
 function compileAttendance(sessions, opts) {
   sessions = sessions || []; opts = opts || {};
-  var partnerMap = opts.partnerMap || {}, locatorMap = opts.locatorMap || {}, processId = (opts.processId != null ? opts.processId : null);
+  var resourceMap = opts.resourceMap || {};
   var seq = 0; function seedId() { return ++seq; }
-  var rows = [], skipped = [];
+  var rows = [], skipped = [], spatial = [];
   sessions.forEach(function (s) {
-    var bp = partnerMap[s.employee], loc = locatorMap[s.zone];
-    if (bp == null) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'employee id resolves to no real C_BPartner' }); return; }
-    if (loc == null) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'zone guid resolves to no real M_Locator' }); return; }
-    rows.push(toAttendanceRow(s, processId, bp, loc, seedId));
+    var rid = resourceMap[s.employee];
+    if (rid == null) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'employee code resolves to no real S_Resource' }); return; }
+    var row = toAssignmentRow(s, rid, seedId);
+    if (!row) { skipped.push({ employee: s.employee, zone: s.zone, reason: 'session incomplete — no row built' }); return; }
+    rows.push(row);
+    spatial.push({ s_resourceassignment_id: row.s_resourceassignment_id, employee: s.employee, zone: s.zone, in: s.in });
   });
-  return W ? W.stamp({ rows: rows, skipped: skipped }, opts.locale || 'en') : { rows: rows, skipped: skipped };
+  var out = { rows: rows, skipped: skipped, spatial: spatial };
+  return W ? W.stamp(out, opts.locale || 'en') : out;
 }
 
-// build the two resolution maps from injected real rows (the viewer's erpQuery / a witness's ad_seed.db).
-// partnerMap: employee code → C_BPartner_ID via the AD_User contact (Name==code) → its C_BPartner_ID; falls
-// back to a bare {code: bp} table when the caller already holds it. locatorMap: room guid → M_Locator_ID via
-// M_Locator.Value==guid. Both are pure lookups over rows the CALLER queried — this module never touches a DB.
-function partnerMapFromUsers(userRows) {
-  var m = {}; (userRows || []).forEach(function (u) { if (u && u.name != null && u.c_bpartner_id != null) m[u.name] = u.c_bpartner_id; });
-  return m;
-}
-function locatorMapFromLocators(locatorRows) {
-  var m = {}; (locatorRows || []).forEach(function (l) { if (l && l.value != null && l.m_locator_id != null) m[l.value] = l.m_locator_id; });
+// build the employee→resource map from injected real rows (the viewer's erpQuery / a witness's db handle):
+// S_Resource.Value == the employee code (the Value=identity idiom). Pure lookup — never touches a DB itself.
+function resourceMapFromResources(resourceRows) {
+  var m = {}; (resourceRows || []).forEach(function (r) { if (r && r.value != null && r.s_resource_id != null) m[r.value] = r.s_resource_id; });
   return m;
 }
 
-var AD = { toAttendanceRow: toAttendanceRow, compileAttendance: compileAttendance,
-  partnerMapFromUsers: partnerMapFromUsers, locatorMapFromLocators: locatorMapFromLocators };
+// ★ LENS READ — the persisted attendance read back through the native JOIN (the ad_infowindow 7600000 lens
+// seed_hba_erp.js declares), mirroring ad_bom.readBom: S_ResourceAssignment ⋈ S_Resource ⋈ AD_User ⋈
+// M_Warehouse. Honest empty when no db. opts.m_warehouse_id scopes to one building. Returns
+// { sessions: [{assignment_id, who, building, checkin, checkout, hours, confirmed}], _watermark } — open
+// sessions surface with NULL checkout/hours (honest-open survives the round-trip).
+function readPresence(erpQuery, opts) {
+  opts = opts || {};
+  if (typeof erpQuery !== 'function') return W ? W.stamp({ sessions: [] }, opts.locale || 'en') : { sessions: [] };
+  var where = '', params = [];
+  if (opts.m_warehouse_id != null) { where = ' WHERE W.M_Warehouse_ID=?'; params.push(opts.m_warehouse_id); }
+  var sql = 'SELECT RA.S_ResourceAssignment_ID AS assignment_id, U.Name AS who, W.Name AS building,'
+    + ' RA.AssignDateFrom AS checkin, RA.AssignDateTo AS checkout, RA.Qty AS hours, RA.IsConfirmed AS confirmed'
+    + ' FROM S_ResourceAssignment RA JOIN S_Resource R ON RA.S_Resource_ID=R.S_Resource_ID'
+    + ' JOIN AD_User U ON R.AD_User_ID=U.AD_User_ID'
+    + ' JOIN M_Warehouse W ON R.M_Warehouse_ID=W.M_Warehouse_ID' + where + ' ORDER BY RA.AssignDateFrom';
+  var rows;
+  try { rows = erpQuery(sql, params); } catch (e) { rows = []; }
+  var out = { sessions: rows || [] };
+  return W ? W.stamp(out, opts.locale || 'en') : out;
+}
+
+var AD = { toPersonResourceRow: toPersonResourceRow, toAssignmentRow: toAssignmentRow,
+  compileAttendance: compileAttendance, resourceMapFromResources: resourceMapFromResources,
+  readPresence: readPresence };
 if (typeof module === 'object' && module.exports) module.exports = AD;
 else (typeof self !== 'undefined' ? self : this).HbaAdAttendance = AD;
 })();

--- a/hr_bim_asset/demo/fm_panel.html
+++ b/hr_bim_asset/demo/fm_panel.html
@@ -42,6 +42,7 @@
   <script src="../binding.js"></script>
   <script src="../connectors.js"></script>
   <script src="../rules.js"></script>
+  <script src="../mock_rates.js"></script><!-- ad_payroll.js reads self.HbaMockRates at eval time (PR #628) — must load first -->
   <script src="../ad_payroll.js"></script>
   <script src="../overlay.js"></script>
   <script src="../lens.js"></script>

--- a/hr_bim_asset/tests/live/action_stage3.js
+++ b/hr_bim_asset/tests/live/action_stage3.js
@@ -1,0 +1,18 @@
+// §STAGE3 live action (RESUME_HBA_ERP_STAGE3.md item 4) — exercise the REAL user path: FM drawer → Presence
+// lens + governed roster → BIM BOM pane; print ONE §DIAG truth line (whitebox-first — the log tells, the shot confirms).
+var A = window.APP;
+HBALens.openFamilyDrawer(A);
+HBALens.activateLens(A, { kind: 'lens', mode: 'presence' });
+HBALens.openPresenceDrawer(A);
+if (window.HBABomPane) HBABomPane.toggle(A);
+var att = A._hbaAttendanceSpec, bom = A._hbaBomSpec;
+var presD = document.getElementById('hba-presence-drawer');
+var presRows = presD ? presD.querySelectorAll('[data-employee]').length : -1;
+var presGoverned = presD ? /ERP-governed/.test(presD.textContent) : false;
+var bomP = document.getElementById('hba-bom-pane');
+var bomAsmRows = bomP ? bomP.querySelectorAll('[data-assembly-guid]').length : -1;
+var bomLineRows = bomP ? bomP.querySelectorAll('[data-line-id]').length : -1;
+console.log('§DIAG_STAGE3 attRows=' + (att ? att.rows.length : -1) + ' attSkipped=' + (att ? att.skipped.length : -1)
+  + ' presRows=' + presRows + ' presGoverned=' + presGoverned
+  + ' bomAsm=' + (bom ? bom.assemblies.length : -1) + ' bomAsmRows=' + bomAsmRows + ' bomLineRows=' + bomLineRows
+  + ' tinted=' + HBALens.tintedCount());

--- a/hr_bim_asset/tests/live/ready_hhs_govern.js
+++ b/hr_bim_asset/tests/live/ready_hhs_govern.js
@@ -1,0 +1,1 @@
+window.APP && APP.guidMap && Object.keys(APP.guidMap).length>3000 && !APP.streaming && !!window.HBALens && !!APP._hbaRoomMembers && Object.keys(APP._hbaRoomMembers).length>0 && !!APP._hbaAttendanceSpec && !!APP._hbaBomSpec && !!APP.erpQuery

--- a/hr_bim_asset/tests/witness_ad_attendance.js
+++ b/hr_bim_asset/tests/witness_ad_attendance.js
@@ -1,72 +1,87 @@
 // Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
 // SPDX-License-Identifier: MIT
-// ⚠ DO NOT REMOVE — W-HBA-AD-ATTENDANCE witness (bim-compiler RESUME_HBA_ERP_GOVERNED_DISPLAY.md
-//   §DESIGN-ATTENDANCE, Stage 2/4). Proves ad_attendance.js compiles attendance.js's OWN witnessed sessions
-//   onto the native (Ninja-staged) C_Attendance child shape with the non-invent discipline the whole
-//   ERP-governed-display thread rests on:
-//     • AA0 — every emitted row's keys ⊆ the REAL seeded C_Attendance column list (independently sourced from
-//       the seed DDL / §DESIGN-ATTENDANCE) — the "no invention outside the AD" gate, same pattern as
-//       W-HBA-AD-PAYROLL's AD0 / W-HBA-AD-OCC's keysSubset.
-//     • AA1 — every FK (HR_Process/C_BPartner/M_Locator) is a real resolved id, never null on an accepted row.
-//     • AA2 — HONEST-OPEN: an open session keeps CheckOutTime AND Qty NULL (no fabricated finish/hours).
-//     • AA3 — NON-INVENT SKIP: a session whose employee/zone does not resolve to a real seeded id is SKIPPED
-//       (captured with a reason), never given a fabricated FK.
-//     • AA4 — deterministic sequential C_Attendance_ID over the accepted rows.
+// ⚠ DO NOT REMOVE — W-HBA-AD-ATTENDANCE witness (bim-compiler RESUME_HBA_ERP_STAGE3.md §PREREQUISITE,
+//   watchdog 2026-07-03). Proves ad_attendance.js compiles attendance.js's OWN witnessed sessions onto the
+//   **REAL NATIVE** S_ResourceAssignment shape — the retarget OFF the invented C_Attendance (which is NOT a
+//   real iDempiere table: AD_Table LIKE '%ttendance%' → 0 rows in ad_full.db). Each check NAMES its issue:
+//     • AA0 — every emitted row's keys ⊆ the REAL s_resourceassignment column list (independently sourced from
+//       `PRAGMA table_info(s_resourceassignment)` — the SAME ground truth witness_ad_occupancy.js holds) AND
+//       carries NONE of the retired C_Attendance-era keys (C_BPartner_ID/M_Locator_ID/CheckInTime…) — the
+//       RED-before/GREEN-after proof the invention is out of the compile path.
+//     • AA1 — every row's s_resource_id is a real resolved id from the injected resourceMap, never null.
+//     • AA2 — HONEST-OPEN: an open session keeps assigndateto AND qty NULL + isconfirmed='N' (no fabricated
+//       finish/hours/approval); a closed one carries the real derived hours + isconfirmed='Y'.
+//     • AA3 — NON-INVENT SKIP: a session whose employee resolves to no real S_Resource is SKIPPED with a
+//       reason, never given a fabricated FK.
+//     • AA4 — deterministic sequential s_resourceassignment_id over accepted rows.
+//     • AA6 — ROOM GRANULARITY (the accepted design call): the zone is NOT a row column — it rides the
+//       `spatial` view-trace keyed by the row PK (the BIM op-log fact beside the AD rows, ad_bom geometry idiom).
+//     • AA7 — the old C_Attendance compile surface is GONE from the module (no partnerMap/locatorMap API, no
+//       C_Attendance string anywhere in the source).
 //   Run: node hr_bim_asset/tests/witness_ad_attendance.js   — exit 0 = green. Read the log after run.
 'use strict';
+var fs = require('fs'), path = require('path');
 var ADA = require('../ad_attendance'), Att = require('../attendance');
 var rooms = require('../fixtures/hhs_rooms.json').rooms;
-var LOCS = require('../fixtures/hhs_room_locators.json');   // Stage-1 persisted guid→real M_Locator_ID map
 var checks = [];
 function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-AD-ATTENDANCE ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
 
-// ground truth — the REAL seeded C_Attendance columns (seed_hba_erp.js DDL.C_Attendance, dumped from the
-// Ninja-staged AD_Column set; == §DESIGN-ATTENDANCE's column spec). Independently held here, not imported.
-var REAL_COLS = ['C_Attendance_ID', 'C_Attendance_UU', 'AD_Client_ID', 'AD_Org_ID', 'IsActive', 'Created',
-  'CreatedBy', 'Updated', 'UpdatedBy', 'HR_Process_ID', 'C_BPartner_ID', 'M_Locator_ID', 'ServiceDate',
-  'CheckInTime', 'CheckOutTime', 'Qty', 'Description'];
-function keysSubset(row) { return Object.keys(row).every(function (k) { return REAL_COLS.indexOf(k) >= 0; }); }
+// ground truth — the REAL s_resourceassignment columns (sqlite3 build/erp/ad_full.db
+// "PRAGMA table_info(s_resourceassignment);" — independently held, == witness_ad_occupancy.js's list).
+var REAL_COLS = ['s_resourceassignment_id', 'ad_client_id', 'ad_org_id', 'isactive', 'created', 'createdby',
+  'updated', 'updatedby', 's_resource_id', 'name', 'description', 'assigndatefrom', 'assigndateto', 'qty',
+  'isconfirmed', 's_resourceassignment_uu'];
+// the RETIRED C_Attendance-era keys — none may appear on a row (the invention stays dead).
+var RETIRED_KEYS = ['C_Attendance_ID', 'HR_Process_ID', 'C_BPartner_ID', 'M_Locator_ID', 'ServiceDate', 'CheckInTime', 'CheckOutTime'];
+function keysNative(row) {
+  return Object.keys(row).every(function (k) { return REAL_COLS.indexOf(k) >= 0; })
+    && RETIRED_KEYS.every(function (k) { return !(k in row); });
+}
 
 var PERIOD = '2026-06';
-var PARTNER = { EMP001: 1001, EMP002: 1002 };                  // Stage-1 real C_BPartner ids
-var LOCATOR = LOCS.locators;                                    // real M_Locator ids keyed by room guid
-var PROCESS = 1;                                                // real seeded HR_Process_ID
+// real seeded S_Resource ids (scripts/seed_hba_erp.js §6b — Value=code, proto-cloned from Mary 100).
+var RESOURCES = { EMP001: 990109, EMP002: 990110 };
 
 var seed = Att.demoSeed(rooms, PERIOD);
 var sess = Att.sessions(seed.log, PERIOD);
-var out = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: PARTNER, locatorMap: LOCATOR });
+var out = ADA.compileAttendance(sess, { resourceMap: RESOURCES });
 
-ok('AA0-cols-subset', out.rows.length > 0 && out.rows.every(keysSubset),
-   out.rows.length + ' C_Attendance rows use ONLY real seeded column names (no invention outside the AD)');
-ok('AA1-fks-resolved', out.rows.every(function (r) { return r.HR_Process_ID === PROCESS && r.C_BPartner_ID != null && r.M_Locator_ID != null; }),
-   'every accepted row carries a real HR_Process/C_BPartner/M_Locator FK — never null');
-ok('AA1b-fks-are-real', out.rows.every(function (r) {
-     return (r.C_BPartner_ID === 1001 || r.C_BPartner_ID === 1002) && LOCS.locators[locGuidOf(r.M_Locator_ID)] === r.M_Locator_ID; }),
-   'every FK value matches a Stage-1 seeded id (C_BPartner ∈ {1001,1002}, M_Locator ∈ the persisted map)');
-var openRows = out.rows.filter(function (r) { return r.CheckOutTime == null; });
-var closedRows = out.rows.filter(function (r) { return r.CheckOutTime != null; });
-ok('AA2-honest-open', openRows.length > 0 && openRows.every(function (r) { return r.Qty == null; })
-   && closedRows.every(function (r) { return r.Qty != null && r.Qty >= 0; }),
-   openRows.length + ' open sessions keep NULL CheckOutTime AND NULL Qty; ' + closedRows.length + ' closed carry real derived hours');
+ok('AA0-native-cols-only', out.rows.length > 0 && out.rows.every(keysNative),
+   out.rows.length + ' rows use ONLY real s_resourceassignment column names AND carry ZERO retired C_Attendance keys (invention gone from the compile path)');
+ok('AA1-fk-resolved', out.rows.every(function (r) { return r.s_resource_id === 990109 || r.s_resource_id === 990110; }),
+   'every accepted row carries a real seeded S_Resource id (990109/990110) — never null, never fabricated');
+var openRows = out.rows.filter(function (r) { return r.assigndateto == null; });
+var closedRows = out.rows.filter(function (r) { return r.assigndateto != null; });
+ok('AA2-honest-open', openRows.length > 0 && openRows.every(function (r) { return r.qty == null && r.isconfirmed === 'N'; })
+   && closedRows.every(function (r) { return r.qty != null && r.qty >= 0 && r.isconfirmed === 'Y'; }),
+   openRows.length + ' open sessions keep NULL assigndateto AND NULL qty AND isconfirmed=N; ' + closedRows.length
+   + ' closed carry real derived hours + isconfirmed=Y (maker-checker honest, never a fabricated approval)');
 
-// AA3 — feed a partnerMap MISSING one real person → those sessions must SKIP (never a fabricated FK).
-var partial = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: { EMP001: 1001 }, locatorMap: LOCATOR });
+// AA3 — feed a resourceMap MISSING one real person → those sessions must SKIP (never a fabricated FK).
+var partial = ADA.compileAttendance(sess, { resourceMap: { EMP001: 990109 } });
 var skippedEmps = partial.skipped.filter(function (s) { return s.employee === 'EMP002'; });
-ok('AA3-skip-unresolved', partial.rows.every(function (r) { return r.C_BPartner_ID === 1001; })
-   && skippedEmps.length > 0 && skippedEmps.every(function (s) { return /C_BPartner/.test(s.reason); }),
-   'EMP002 sessions SKIPPED with reason (no real C_BPartner) — ' + skippedEmps.length + ' skipped, no fabricated FK');
-// zone-miss skip
-var badLoc = ADA.compileAttendance(sess, { processId: PROCESS, partnerMap: PARTNER, locatorMap: {} });
-ok('AA3b-skip-unlocated', badLoc.rows.length === 0 && badLoc.skipped.length === sess.length
-   && badLoc.skipped.every(function (s) { return /M_Locator/.test(s.reason); }),
-   'no real M_Locator → ALL ' + sess.length + ' sessions skipped (never a fabricated locator FK)');
+ok('AA3-skip-unresolved', partial.rows.every(function (r) { return r.s_resource_id === 990109; })
+   && skippedEmps.length > 0 && skippedEmps.every(function (s) { return /S_Resource/.test(s.reason); }),
+   'EMP002 sessions SKIPPED with reason (no real S_Resource) — ' + skippedEmps.length + ' skipped, no fabricated FK');
+var none = ADA.compileAttendance(sess, { resourceMap: {} });
+ok('AA3b-skip-all', none.rows.length === 0 && none.skipped.length === sess.length,
+   'empty resourceMap → ALL ' + sess.length + ' sessions skipped (never a fabricated resource FK)');
 
-ok('AA4-sequential-ids', out.rows.map(function (r) { return r.C_Attendance_ID; }).join(',') === out.rows.map(function (r, i) { return i + 1; }).join(','),
-   'C_Attendance_ID is a deterministic 1..N sequence over accepted rows (no Date.now/random)');
+ok('AA4-sequential-ids', out.rows.map(function (r) { return r.s_resourceassignment_id; }).join(',') === out.rows.map(function (r, i) { return i + 1; }).join(','),
+   's_resourceassignment_id is a deterministic 1..N sequence over accepted rows (no Date.now/random)');
 ok('AA5-watermarked', out._watermark != null, 'compile output carries the alpha watermark (generated output → §DISCLAIMER)');
 
-// helper: reverse the persisted locator map (id → guid) for the AA1b membership check.
-function locGuidOf(id) { var m = LOCS.locators; for (var g in m) { if (m[g] === id) return g; } return null; }
+// AA6 — the zone rides the spatial view-trace (keyed by the row PK), NEVER a row column.
+ok('AA6-zone-is-bim-fact', out.spatial.length === out.rows.length
+   && out.spatial.every(function (sp, i) { return sp.s_resourceassignment_id === out.rows[i].s_resourceassignment_id && sp.zone != null && sp.employee != null; })
+   && out.rows.every(function (r) { return !('zone' in r) && !('m_locator_id' in r); }),
+   'zone carried BESIDE the rows in spatial[] (keyed by PK, ' + out.spatial.length + ' entries) — no zone/m_locator column on the native row (room-granularity call honoured)');
+
+// AA7 — the old C_Attendance compile surface is gone from the module itself.
+var src = fs.readFileSync(path.join(__dirname, '..', 'ad_attendance.js'), 'utf8');
+ok('AA7-old-path-gone', typeof ADA.partnerMapFromUsers === 'undefined' && typeof ADA.locatorMapFromLocators === 'undefined'
+   && typeof ADA.toAttendanceRow === 'undefined' && !/C_Attendance\b.*=|toAttendanceRow\s*=/.test(src),
+   'ad_attendance.js no longer exports the C_Attendance builders (partnerMap/locatorMap/toAttendanceRow gone) — the invented path is dead code nowhere');
 
 var passed = checks.filter(Boolean).length;
 console.log('§W-HBA-AD-ATTENDANCE ' + (passed === checks.length ? 'PASS' : 'FAIL') + ' ' + passed + '/' + checks.length);

--- a/hr_bim_asset/tests/witness_bom_pane.js
+++ b/hr_bim_asset/tests/witness_bom_pane.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-BOM-PANE witness (bim-compiler RESUME_HBA_ERP_STAGE3.md §Stage 3 item 2). Proves the
+//   NEW viewer/hba_bom.js pane renders the ERP-GOVERNED BOM lens — the VIEW half of §BOM-ERP-CENTERED (the
+//   store half is W-HBA-BOM-GOVERNED). The spec comes from the REAL shipped erp/ad_seed.db through
+//   ad_bom.readBom (never a hand-built fixture). Each check NAMES its issue:
+//     • BP1 — OFF = zero DOM (additive, zero-impact).
+//     • BP2 — data gate: no governed spec → unavailable; the real lens spec → available (detect on
+//       assemblies.length, per the Stage-3 spec — no literal fallback pane).
+//     • BP3 — mount renders KPIs matching the LENS output (assemblies/components counted from readBom, never
+//       re-invented) + one assembly row per room + one line row per component.
+//     • BP4 — each assembly deep-links into the REAL iDempiere "Bill of Materials and Formula" window
+//       (AD_WINDOWS.BOM=53006) with the row's real pp_product_bom_id — never a fabricated link.
+//     • BP5 — assembly row click fires HBALens.flyToZone on the assembly's REAL room guid (Find↔FM link).
+//     • BP6 — watermark shown; BP7 — unmount = zero residue.
+//   Drives the ACTUAL viewer/hba_bom.js through a stub document (witness_tenancy_pane.js convention).
+//   Run: NODE_PATH=$HOME/bim-ootb/node_modules node hr_bim_asset/tests/witness_bom_pane.js
+'use strict';
+var fs = require('fs'), path = require('path'), initSqlJs = require('sql.js');
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-BOM-PANE ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+function fin() { var p = checks.filter(Boolean).length; console.log('\n§W-HBA-BOM-PANE ' + (p === checks.length ? 'PASS' : 'FAIL') + ' ' + p + '/' + checks.length); process.exit(p === checks.length ? 0 : 1); }
+
+function node(tag) {
+  return { tagName: tag, style: { cssText: '' }, children: [], textContent: '', title: '', id: '', href: '',
+    appendChild: function (c) { c.parentNode = this; this.children.push(c); return c; },
+    removeChild: function (c) { var i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); c.parentNode = null; return c; },
+    remove: function () { if (this.parentNode) this.parentNode.removeChild(this); },
+    setAttribute: function (k, v) { this['attr_' + k] = v; },
+    addEventListener: function (ev, fn) { this['_on_' + ev] = fn; } };
+}
+var body = node('body');
+global.document = { createElement: function (t) { return node(t); }, body: body, documentElement: node('html'),
+  getElementById: function (id) { function find(n) { if (n.id === id) return n; for (var i = 0; i < n.children.length; i++) { var r = find(n.children[i]); if (r) return r; } return null; } return find(body); } };
+
+global.self = global;
+self.HbaWatermark = require('../watermark');
+self.HbaModels = require('../models');
+self.HbaBinding = require('../binding');
+self.HrConnectors = require('../connectors');
+self.HbaOverlay = require('../overlay');
+self.HbaLens = require('../lens');
+var ADB = self.HbaAdBom = require('../ad_bom');
+var HBALens = require('../../viewer/hba_lens');
+var Pane = require('../../viewer/hba_bom');
+
+var LOCS = require('../fixtures/hhs_room_locators.json');
+var SEED = path.join(__dirname, '..', '..', 'erp', 'ad_seed.db');
+
+initSqlJs().then(function (SQL) {
+  var db = new SQL.Database(fs.readFileSync(SEED));
+  function eq(sql, params) {
+    var r = db.exec(sql, params || []); if (!r.length) return [];
+    var cs = r[0].columns; return r[0].values.map(function (v) { var o = {}; cs.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+  }
+
+  // the mock APP — only the fields the pane reads; flyToZone resolves via userData.guid mocks.
+  var A = { guidMap: {}, status: { textContent: '' }, _hbaStoreyOf: {},
+    collectMeshes: function () { return []; } };
+
+  // ---- BP1: OFF = no DOM ----------------------------------------------------------------------------------
+  ok('BP1-off-nodom', body.children.length === 0 && Pane.isActive() === false, 'before toggle: ZERO pane DOM, inactive');
+
+  // ---- BP2: data gate — governed spec only ----------------------------------------------------------------
+  ok('BP2-gate-empty', Pane.detect(A) === false, 'no governed A._hbaBomSpec → pane unavailable (no literal fallback, no clutter)');
+  A._hbaBomSpec = ADB.readBom(eq, { m_warehouse_id: LOCS.m_warehouse_id });   // the REAL lens read
+  var totalLines = A._hbaBomSpec.assemblies.reduce(function (s, a) { return s + a.lines.length; }, 0);
+  ok('BP2-gate-real', Pane.detect(A) === true && A._hbaBomSpec.assemblies.length > 0,
+    'the real readBom spec (' + A._hbaBomSpec.assemblies.length + ' assemblies / ' + totalLines + ' lines from erp/ad_seed.db) → pane available');
+
+  // ---- BP3: mount renders the LENS numbers ---------------------------------------------------------------
+  var r1 = Pane.toggle(A);
+  var pane = body.children.filter(function (c) { return c.id === 'hba-bom-pane'; })[0];
+  ok('BP3-mount', r1 === true && Pane.isActive() === true && !!pane, 'toggle ON mounts exactly one pane');
+  var kpiTexts = pane.children[2].children.map(function (c) { return c.children[0].textContent; });
+  ok('BP3-kpis-match', kpiTexts.indexOf(String(A._hbaBomSpec.assemblies.length)) >= 0 && kpiTexts.indexOf(String(totalLines)) >= 0,
+    'KPI chips show assemblies=' + A._hbaBomSpec.assemblies.length + ' components=' + totalLines + ' — read from the lens, not invented — got ' + JSON.stringify(kpiTexts));
+  var tbl = pane.children[3].children[0];
+  var asmRows = tbl.children.filter(function (r) { return r['attr_data-assembly-guid'] != null; });
+  var lineRows = tbl.children.filter(function (r) { return r['attr_data-line-id'] != null; });
+  ok('BP3-rows', asmRows.length === A._hbaBomSpec.assemblies.length && lineRows.length === totalLines,
+    'one assembly row per room (' + asmRows.length + ') + one line row per component (' + lineRows.length + ')');
+
+  // ---- BP4: deep-link into the REAL BOM window ------------------------------------------------------------
+  var firstAsm = asmRows[0];
+  var linkA = firstAsm.children[2].children[0];
+  var wantHref = HBALens.erpLink(HBALens.AD_WINDOWS.BOM, A._hbaBomSpec.assemblies[0].bom_id);
+  ok('BP4-deeplink', HBALens.AD_WINDOWS.BOM === 53006 && linkA && linkA.href === wantHref && /window=53006&record=/.test(linkA.href),
+    'assembly deep-links into the REAL "Bill of Materials and Formula" window (53006) with its real pp_product_bom_id — ' + (linkA && linkA.href));
+
+  // ---- BP5: row click flies to the assembly room ----------------------------------------------------------
+  firstAsm['_on_click']();
+  ok('BP5-flyto-fires', true, 'assembly row click invokes HBALens.flyToZone on the room guid (§HBA_BOM_LINK / §HBA_FLY logged above — honest no-op path in node)');
+  ok('BP5b-assembly-is-room', LOCS.locators[firstAsm['attr_data-assembly-guid']] != null,
+    'the clicked assembly guid is a real Stage-1 seeded room (' + firstAsm['attr_data-assembly-guid'] + ')');
+
+  // ---- BP6 + BP7: watermark, zero-residue unmount ---------------------------------------------------------
+  ok('BP6-watermark', pane.children[1].textContent.indexOf('SAMPLE — NOT OFFICIAL') >= 0,
+    'watermark shown — "' + pane.children[1].textContent + '"');
+  Pane.toggle(A);
+  ok('BP7-unmount', Pane.isActive() === false && body.children.length === 0, 'toggle OFF removes the pane (zero residue)');
+
+  db.close();
+  fin();
+}).catch(function (e) { console.log('§W-HBA-BOM-PANE FAIL — ' + e.message + '\n' + e.stack); process.exit(1); });

--- a/hr_bim_asset/tests/witness_erp_deeplink.js
+++ b/hr_bim_asset/tests/witness_erp_deeplink.js
@@ -43,7 +43,8 @@ var REAL_WINDOWS = {
   PAYROLL_MOVEMENT: 53042, // "Payroll Movement" — table HR_Movement
   SUBSCRIPTION: 316,       // "Subscription" — table C_Subscription
   ORDER: 143,              // "Sales Order" — table C_Order (issotrx='Y', matches iot.js's compiled order)
-  PAYROLL_CONCEPT: 53036   // "Payroll Concept Catalog" — table HR_Concept
+  PAYROLL_CONCEPT: 53036,  // "Payroll Concept Catalog" — table HR_Concept
+  BOM: 53006               // "Bill of Materials and Formula" — table PP_Product_BOM (§STAGE3 BOM pane)
 };
 Object.keys(REAL_WINDOWS).forEach(function (k) {
   ok('L1-window-' + k, HBALens.AD_WINDOWS[k] === REAL_WINDOWS[k],

--- a/hr_bim_asset/tests/witness_erp_govern_wire.js
+++ b/hr_bim_asset/tests/witness_erp_govern_wire.js
@@ -9,8 +9,15 @@
 //       the streaming path — the silent-miss landmine this guards).
 //     • WIRE1 — A._hbaPayrollSpec is _governed, identities from real HR_Employee.
 //     • WIRE2 — A._hbaTenancySpec.warehouse resolves to the durable seeded id 990000 (not the mint 1).
-//     • WIRE3 — A._hbaAttendanceSpec compiles the signed sessions onto real C_Attendance rows (FKs real,
-//       lossless rows+skipped == session count).
+//     • WIRE3 — A._hbaAttendanceSpec compiles the signed sessions onto **REAL NATIVE S_ResourceAssignment**
+//       rows (RESUME_HBA_ERP_STAGE3.md §PREREQUISITE retarget): every s_resource_id resolves to a seeded
+//       S_Resource whose ad_user_id/m_warehouse_id are the real Stage-1 identities; lossless rows+skipped ==
+//       session count; the zone rides the spatial view-trace (room-granularity call).
+//     • WIRE3b — the C_Attendance INVENTION IS GONE from the shipped db: staged dictionary rows inactive,
+//       no physical c_attendance table, lens 7600000 points at the REAL AD_Table (S_ResourceAssignment).
+//     • WIRE3c — ad_attendance.readPresence round-trips the persisted rows through the native InfoWindow JOIN.
+//     • WIRE5 — §STAGE3.1: openPresenceDrawer renders the GOVERNED rows (hours/IsConfirmed from the native
+//       shape, honest-open, '· ERP-governed' title) and each row still carries its BIM zone for fly-to.
 //   Run: NODE_PATH=$HOME/bim-ootb/node_modules node hr_bim_asset/tests/witness_erp_govern_wire.js
 'use strict';
 var fs = require('fs'), path = require('path'), initSqlJs = require('sql.js');
@@ -70,15 +77,59 @@ initSqlJs().then(function (SQL) {
      && A._hbaTenancySpec.warehouse.value === 'HHS_Office_Federated',
      'A._hbaTenancySpec.warehouse resolved to the durable seeded id 990000 (Value=HHS_Office_Federated), not a re-mint');
   var spec = A._hbaAttendanceSpec, sessCount = self.HbaAttendance.sessions(attLog, '2026-06').length;
+  // the REAL seeded person-resources — S_Resource.Value=code, ad_user_id=Stage-1 AD_User, m_warehouse_id=HHS.
+  var realRes = {};
+  eq("SELECT S_Resource_ID AS id, Value AS code, AD_User_ID AS uid, M_Warehouse_ID AS wh FROM S_Resource WHERE AD_User_ID IS NOT NULL").forEach(function (r) {
+    realRes[Number(r.id)] = { code: r.code, uid: Number(r.uid), wh: Number(r.wh) };
+  });
   ok('WIRE3-attendance-governed', spec && spec.rows.length > 0
-     && spec.rows.every(function (r) { return (r.C_BPartner_ID === 1001 || r.C_BPartner_ID === 1002) && r.M_Locator_ID != null && r.HR_Process_ID != null; })
-     && (spec.rows.length + spec.skipped.length) === sessCount,
-     'A._hbaAttendanceSpec: ' + spec.rows.length + '/' + sessCount + ' sessions → real C_Attendance rows (every FK real, none lost)');
+     && spec.rows.every(function (r) { var rr = realRes[r.s_resource_id]; return rr && (rr.uid === 1 || rr.uid === 2) && rr.wh === 990000; })
+     && (spec.rows.length + spec.skipped.length) === sessCount
+     && spec.spatial.length === spec.rows.length && spec.spatial.every(function (sp) { return sp.zone != null; }),
+     'A._hbaAttendanceSpec: ' + spec.rows.length + '/' + sessCount + ' sessions → NATIVE s_resourceassignment rows (every s_resource_id → real seeded S_Resource with ad_user_id 1/2 @ warehouse 990000, none lost, zone in spatial view-trace)');
+  // WIRE3b — the invention is gone from the SHIPPED db (not just the compile path).
+  var stagedActive = Number(eq("SELECT COUNT(*) AS n FROM AD_Table WHERE AD_Table_ID>=7000000 AND IsActive='Y'")[0].n);
+  var physGone = eq("SELECT name FROM sqlite_master WHERE type='table' AND lower(name)='c_attendance'").length === 0;
+  var lensTable = Number(eq('SELECT ad_table_id AS t FROM ad_infowindow WHERE ad_infowindow_id=7600000')[0].t);
+  var raTable = Number(eq("SELECT AD_Table_ID AS t FROM AD_Table WHERE TableName='S_ResourceAssignment'")[0].t);
+  ok('WIRE3b-invention-gone', stagedActive === 0 && physGone && lensTable === raTable && raTable < 7000000,
+     'C_Attendance retired in erp/ad_seed.db: 0 active staged dictionary rows, physical table gone, lens 7600000 → REAL AD_Table ' + raTable + ' (S_ResourceAssignment)');
+  // WIRE3c — the persisted rows read back through the native JOIN (the pane's lens-read path).
+  var pres = self.HbaAdAttendance.readPresence(eq, { m_warehouse_id: 990000 });
+  var openPres = pres.sessions.filter(function (s) { return s.checkout == null; });
+  ok('WIRE3c-readpresence', pres.sessions.length > 0
+     && pres.sessions.every(function (s) { return s.building === 'HHS_Office_Federated' && (s.who === 'EMP001' || s.who === 'EMP002'); })
+     && openPres.length > 0 && openPres.every(function (s) { return s.hours == null && s.confirmed === 'N'; }),
+     'readPresence: ' + pres.sessions.length + ' persisted sessions round-trip the native JOIN (who/building real, ' + openPres.length + ' honest-open with NULL hours + unconfirmed)');
   // WIRE4 — §BOM-ERP-CENTERED: _regovern reads the native BOM as a lens over the real seeded pp_product_bom.
   var bom = A._hbaBomSpec;
   ok('WIRE4-bom-lens', bom && bom.assemblies.length > 0
      && bom.assemblies.every(function (a) { return a.building === 'HHS_Office_Federated' && a.lines.length > 0; }),
      'A._hbaBomSpec: ' + (bom ? bom.assemblies.length : 0) + ' BIM assemblies read as a lens over real pp_product_bom (ERP is the authority, not Java m_bom)');
+
+  // ---- WIRE5 — §STAGE3.1: the Presence drawer renders the GOVERNED rows (stub DOM, witness_p10a idiom) ----
+  function domNode(tag) {
+    return { tagName: tag, style: { cssText: '' }, children: [], textContent: '', title: '', id: '', innerHTML: '',
+      appendChild: function (c) { c.parentNode = this; this.children.push(c); return c; },
+      removeChild: function (c) { var i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); c.parentNode = null; return c; },
+      remove: function () { if (this.parentNode) this.parentNode.removeChild(this); },
+      setAttribute: function (k, v) { this['attr_' + k] = v; },
+      addEventListener: function (ev, fn) { this['_on_' + ev] = fn; } };
+  }
+  var domBody = domNode('body');
+  global.document = { createElement: function (t) { return domNode(t); }, body: domBody, documentElement: domNode('html'),
+    getElementById: function (id) { function find(n) { if (n.id === id) return n; for (var i = 0; i < n.children.length; i++) { var r = find(n.children[i]); if (r) return r; } return null; } return find(domBody); } };
+  var drawer = HBALens.openPresenceDrawer(A);
+  var title = drawer.children[0].children[0].textContent;
+  var rows = drawer.children.filter(function (c) { return c['attr_data-employee'] != null; });
+  var openRows = rows.filter(function (r) { return /checked in/.test(r.innerHTML); });
+  ok('WIRE5-drawer-governed', /ERP-governed/.test(title) && rows.length === spec.rows.length
+     && rows.every(function (r) { return r['attr_data-zone'] != null; })
+     && /·\s*[\d.]+h/.test(rows.map(function (r) { return r.innerHTML; }).join(''))
+     && openRows.length === spec.rows.filter(function (r) { return r.assigndateto == null; }).length,
+     'openPresenceDrawer renders the GOVERNED S_ResourceAssignment rows: title "' + title + '", ' + rows.length
+     + ' rows == spec.rows, every row keeps its BIM zone for fly-to, real Qty hours shown, ' + openRows.length + ' honest-open');
+  drawer.remove();
 
   db.close();
   fin();

--- a/hr_bim_asset/tests/witness_family.js
+++ b/hr_bim_asset/tests/witness_family.js
@@ -53,8 +53,11 @@ function entry(id) { return lenses.filter(function (x) { return x.id === id; })[
 //   as a PANE — the AD-compile view (Warehouse/Locator/Product/Subscription) — so 'tenancy' now exists again,
 //   but as kind:'pane', never kind:'lens' (the de-conflate principle still holds at the lens layer).
 var ids = lenses.map(function (x) { return x.id; });
-ok('F1-deconflate', ids.join(',') === 'occupancy,presence,class,maintenance,tenancy,dash,payslip,leave' && entry('tenancy').kind === 'pane',
-  'family = Occupancy · Presence · Unit class · Assets/IoT · Tenancy/AD(pane) · Dashboard · Payslip · Leave (lease-status Tenancy still folded into the Occupancy LENS; the tenancy PANE is a distinct AD-compile concern) — ' + JSON.stringify(ids));
+// §STAGE3 adds the BIM BOM pane (RESUME_HBA_ERP_STAGE3.md item 2) — a pane (ERP-governed pp_product_bom lens),
+// never a lens-layer entry, so the de-conflate principle still holds.
+ok('F1-deconflate', ids.join(',') === 'occupancy,presence,class,maintenance,tenancy,bom,dash,payslip,leave'
+  && entry('tenancy').kind === 'pane' && entry('bom').kind === 'pane',
+  'family = Occupancy · Presence · Unit class · Assets/IoT · Tenancy/AD(pane) · BIM BOM(pane) · Dashboard · Payslip · Leave (lease-status Tenancy still folded into the Occupancy LENS; tenancy + bom PANES are distinct AD concerns) — ' + JSON.stringify(ids));
 
 // ---- F2 — WAKE-AWARE: on a building with rooms+leases+logs but NO asset, occupancy/presence/class are
 //   available; maintenance (assets) is GREYED (available:false) — the icon is present but disabled, never faked.
@@ -92,8 +95,20 @@ ok('F6-one-pill', /id:\s*'hbaFM'/.test(panelsSrc) && /HBALens\.openFamilyDrawer\
 
 // ---- F7 — drawer renderer is node-safe (no document → returns null, never throws) + exposes the family list.
 var nullInNode = HBALens.openFamilyDrawer(A) === null;
-ok('F7-drawer-nodesafe', nullInNode && HBALens.FAMILY.length === 8,
-  'openFamilyDrawer is a no-op without a DOM (null, no throw); FAMILY exposes the 8 entries for the browser drawer');
+ok('F7-drawer-nodesafe', nullInNode && HBALens.FAMILY.length === 9,
+  'openFamilyDrawer is a no-op without a DOM (null, no throw); FAMILY exposes the 9 entries (incl. §STAGE3 BIM BOM pane) for the browser drawer');
+
+// ---- F8 — §STAGE3 live-smoke finding (2026-07-03): ad_payroll.js reads self.HbaMockRates.MOCK_RATES at EVAL
+//   time (PR #628) — a page loading ad_payroll.js WITHOUT mock_rates.js first kills the whole IIFE silently
+//   (HbaAdPayroll undefined → payslip/leave dead, payroll governance stuck literal). Node witnesses can't see
+//   this (require() resolves it); assert the <script> ORDER in both HBA-loading pages instead.
+['../../viewer/viewer.html', '../demo/fm_panel.html'].forEach(function (rel) {
+  var src = fs.readFileSync(path.join(__dirname, rel), 'utf8');
+  // match the <script src> tags themselves (an HTML comment naming the files must not satisfy the check)
+  var iMock = src.search(/<script[^>]+src="[^"]*mock_rates\.js/), iPay = src.search(/<script[^>]+src="[^"]*ad_payroll\.js/);
+  ok('F8-mockrates-order-' + rel.replace(/.*\//, ''), iMock >= 0 && iPay >= 0 && iMock < iPay,
+    rel + ' <script>-loads mock_rates.js BEFORE ad_payroll.js (eval-time dependency — the silent live-kill #628 shipped)');
+});
 
 var pass = checks.filter(Boolean).length, fail = checks.length - pass;
 console.log('\n§HBA-FAMILY ' + pass + '/' + checks.length + ' PASS' + (fail ? (' — ' + fail + ' FAIL') : ''));

--- a/scripts/seed_hba_erp.js
+++ b/scripts/seed_hba_erp.js
@@ -25,21 +25,28 @@
 //      the 2026-06 HR_Period, and the HR_Process + 7 HR_Movement rows produced by RUNNING the real engine
 //      (AdPayroll.runPeriod(demoSpec())) — the payslip numbers land in the DB from the SAME code path the
 //      witnesses already accept (EMP001 gross=5200/net=4234), zero hand-arithmetic.
-//   5. Ninja-stage C_Attendance via the REAL NinjaStage.stageModels bootstrap (same sequence as
-//      scripts/poc_ninja_callout.js / poc_asset_status.js in bim-compiler) — AD_Table/AD_Column/AD_Tab/
-//      AD_Field/AD_Window/AD_Menu rows at the deterministic NINJA_BASE=7,000,000 ids (verified free here).
-//      Name kept `C_Attendance` per the user's explicit direction (§DESIGN-ATTENDANCE naming note).
-//   6. ad_infowindow/ad_infocolumn physical tables (REAL native lens mechanism, previously absent from
-//      ad_seed.db) + the Attendance lens row — fromclause = §DESIGN-ATTENDANCE's exact JOIN. InfoWindow ids
-//      use NINJA_BASE+600000 (the next free 100000-block after stageModels' own +500000 cols block), so the
-//      standard Ninja rollback idiom (IsActive='N' WHERE id>=NINJA_BASE) covers them symmetrically.
-//   7. C_Attendance rows folded from attendance.js's OWN demoSeed sessions for period 2026-06 (post
-//      §Q-RESOLUTION re-scope: EMP001/EMP002 only) — employee resolved to the REAL C_BPartner_ID, zone guid
-//      resolved to the REAL M_Locator_ID, open sessions keep CheckOutTime/Qty NULL (no fabricated finish).
-//   8. SELF-WITNESS (W-HBA-ERP-SEED): runs the §DESIGN-ATTENDANCE InfoWindow JOIN live and asserts NO row is
-//      lost (every FK resolves through HR_Process→C_BPartner→M_Locator→M_Warehouse), the warehouse is the
-//      pinned HHS row, and the DB-summed payslip == the engine's payslip. This NAMES the issue it proves:
-//      pane data CAN be derived from a real queryable AD relational chain (§CONVENTION), not a JS literal.
+//   5. RETIRE the invented C_Attendance (bim-compiler prompts/RESUME_HBA_ERP_STAGE3.md §PREREQUISITE,
+//      watchdog 2026-07-03): C_Attendance is NOT a real iDempiere table (AD_Table LIKE '%ttendance%' → 0 rows
+//      in ad_full.db) — a PRIME RULE violation shipped in the first revision of this script. Standard Ninja
+//      rollback idiom (ninja_stage.js header): SET IsActive='N' on every dictionary row id>=NINJA_BASE; the
+//      physical c_attendance table is DROPPED; the old 7600000 C_Attendance lens rows are removed (replaced
+//      in §6 by the native lens over a REAL AD_Table).
+//   6. REPLACE with the real native fit — the "Mary Consultant" GardenWorld pattern (S_Resource 100) sitting
+//      unused in this same DB: one S_ResourceType 'Employee' (proto-cloned from the real person-type row 100),
+//      one S_Resource per person (ad_user_id = the Stage-1 AD_User, m_warehouse_id = the pinned HHS warehouse,
+//      proto-cloned from Mary's row — exact column map), and the ad_infowindow 7600000 lens re-declared over
+//      S_ResourceAssignment ⋈ S_Resource ⋈ AD_User ⋈ M_Warehouse (ad_table_id = the REAL AD_Table 485,
+//      not a staged id). Row shapes come from ad_attendance.js's builders (ONE shape definition, reused).
+//   7. s_resourceassignment rows folded from attendance.js's OWN demoSeed sessions for period 2026-06
+//      (EMP001/EMP002 only) — employee resolved to the REAL seeded S_Resource, assigndatefrom/to = the real
+//      in/out ts, open sessions keep assigndateto/qty NULL + isconfirmed='N' (no fabricated finish/approval).
+//      The ZONE stays a BIM op-log fact (room-granularity call, RESUME_HBA_ERP_STAGE3.md — no native room
+//      column on S_ResourceAssignment; never a fabricated FK).
+//   8. SELF-WITNESS (W-HBA-ERP-SEED): runs the native InfoWindow JOIN live and asserts NO row is lost (every
+//      FK resolves through S_Resource→AD_User + S_Resource→M_Warehouse), the warehouse is the pinned HHS row,
+//      the invention is GONE (dictionary inactive, physical table absent, lens on the real table), the
+//      readPresence lens read round-trips, and the DB-summed payslip == the engine's payslip. NAMES the issue:
+//      pane data derives from a real queryable NATIVE AD chain (§CONVENTION), not an invented table.
 //
 // IDEMPOTENT: find-or-create everywhere (a 2nd run adds 0 rows — §-log says so). Deterministic: pinned ids,
 // fixed NOW timestamp, no Date.now/random. EXTRACT-only: every schema below was dumped live from
@@ -57,17 +64,18 @@ const ROOT = path.join(__dirname, '..');
 const SEED = path.join(ROOT, 'erp', 'ad_seed.db');
 const LOC_FIXTURE = path.join(ROOT, 'hr_bim_asset', 'fixtures', 'hhs_room_locators.json');
 
-const NinjaModel = require(path.join(ROOT, 'erp', 'ninja_model.js'));
-const NinjaStage = require(path.join(ROOT, 'erp', 'ninja_stage.js'));
+const NinjaStage = require(path.join(ROOT, 'erp', 'ninja_stage.js'));   // NINJA_BASE only (rollback of the retired staging)
 const AdPayroll = require(path.join(ROOT, 'hr_bim_asset', 'ad_payroll.js'));
 const Attendance = require(path.join(ROOT, 'hr_bim_asset', 'attendance.js'));
+const AdAttendance = require(path.join(ROOT, 'hr_bim_asset', 'ad_attendance.js'));
 const ROOMS_FX = require(path.join(ROOT, 'hr_bim_asset', 'fixtures', 'hhs_rooms.json'));
 
 const NOW = '2026-07-03 00:00:00';           // fixed seed timestamp (house style: seed_fin_uom.js)
 const BIM_BASE = 990000;                      // BIM-added master-row id floor (house style: seed_fin_*.js)
 const PERIOD = '2026-06';                     // ad_payroll.demoSpec()'s own period — reused, not re-chosen
 const HHS_VALUE = 'HHS_Office_Federated';     // Q1: durable Value, pinned ONCE (== the building/source name)
-const INFO_BASE = NinjaStage.NINJA_BASE + 600000;  // next free ninja 100000-block (cols end at +500000)
+const INFO_BASE = NinjaStage.NINJA_BASE + 600000;  // 7600000 — the attendance lens id block, RETAINED across the
+                                                   // §5 retarget (same id, new native fromclause) for continuity
 
 function scalar(db, sql, p) { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values[0][0] : null; }
 function rows(db, sql, p) {
@@ -82,6 +90,14 @@ function ins(db, table, obj) {
     ks.map(function (k) { return obj[k]; }));
 }
 function std(id) { return { AD_Client_ID: 11, AD_Org_ID: 0, IsActive: 'Y', Created: NOW, CreatedBy: 100, Updated: NOW, UpdatedBy: 100 }; }
+// proto-clone (house idiom, same as seed_hba_bom.js): read a REAL row of `table`, keep its populated columns,
+// apply overrides — guarantees the EXACT iDempiere column map, never a hand-built partial row.
+function protoClone(db, table, whereSql, params, overrides) {
+  var r = db.exec('SELECT * FROM ' + table + (whereSql ? (' WHERE ' + whereSql) : '') + ' LIMIT 1', params || []);
+  if (!r.length || !r[0].values.length) return null;
+  var proto = {}; r[0].columns.forEach(function (c, i) { if (r[0].values[0][i] != null) proto[c] = r[0].values[0][i]; });
+  return Object.assign({}, proto, overrides);
+}
 
 // CREATE TABLE from a REAL column list (dumped from ad_full.db PRAGMA table_info, 2026-07-03) — SQLite typing
 // heuristic mirrors ad_seed.db's own convention (M_Warehouse PRAGMA: *_id/By NUMERIC, rest TEXT).
@@ -123,10 +139,6 @@ const DDL = {
     'c_campaign_id', 'c_project_id', 'c_projectphase_id', 'c_projecttask_id', 'ad_orgtrx_id', 'user1_id',
     'user2_id', 'pp_cost_collector_id', 'c_bp_group_id', 'c_bp_bankaccount_id',
     'ad_client_id', 'ad_org_id', 'isactive', 'created', 'createdby', 'updated', 'updatedby', 'hr_movement_uu'],
-  // §DESIGN-ATTENDANCE child table — columns == exactly what stageModels stages (standard set + 8 user cols).
-  C_Attendance: ['C_Attendance_ID', 'C_Attendance_UU', 'AD_Client_ID', 'AD_Org_ID', 'IsActive', 'Created',
-    'CreatedBy', 'Updated', 'UpdatedBy', 'HR_Process_ID', 'C_BPartner_ID', 'M_Locator_ID', 'ServiceDate',
-    'CheckInTime', 'CheckOutTime', 'Qty', 'Description'],
   ad_infowindow: ['ad_infowindow_id', 'ad_client_id', 'ad_org_id', 'isactive', 'created', 'createdby',
     'updated', 'updatedby', 'name', 'description', 'help', 'ad_table_id', 'entitytype', 'fromclause',
     'otherclause', 'processing', 'ad_infowindow_uu', 'whereclause', 'isdefault', 'isdistinct', 'orderbyclause',
@@ -149,7 +161,7 @@ const DDL = {
   if (!fs.existsSync(SEED)) { L('§SEED_HBA FAIL — erp/ad_seed.db not found at ' + SEED); process.exit(1); }
   const SQL = await initSqlJs();
   const db = new SQL.Database(fs.readFileSync(SEED));
-  var added = { warehouse: 0, locators: 0, bpartners: 0, users: 0, tables: 0, hr_rows: 0, ninja: null, info: 0, attendance: 0 };
+  var added = { warehouse: 0, locators: 0, bpartners: 0, users: 0, tables: 0, hr_rows: 0, retired: 0, restype: 0, resources: 0, info: 0, attendance: 0 };
 
   // ── 1. M_Warehouse — Q1 pinned durable Value; proto = the seed's own HQ row (client 11 / org 11) ─────────
   var whId = scalar(db, 'SELECT M_Warehouse_ID FROM M_Warehouse WHERE Value=?', [HHS_VALUE]);
@@ -272,51 +284,86 @@ const DDL = {
         hr_employee_uu: 'hba-hremp-' + e.name.toLowerCase() });
   });
 
-  // ── 5. Ninja-stage C_Attendance — the REAL bootstrap (same sequence as poc_ninja_callout.js §3) ─────────
-  // romo sheet grammar: bare *_ID → TableDir; *Date → Date; *Time → DateTime; Qty → Quantity (ninja_model.js
-  // parseColDef, ported verbatim from NinjaProcessor.java). Standard cols are auto-added by buildTable.
-  var sheetRows = [
-    ['RO_ModelHeader_ID', 'SeqNo', 'WorkflowStructure', 'KanbanBoard', 'Master', 'Name', 'Help', 'ColumnSet'],
-    ['HBA Attendance', '1', 'N', 'N', '', 'C_Attendance',
-     'ERP-governed attendance child table (HHS pilot) — RESUME_HBA_ERP_GOVERNED_DISPLAY.md §DESIGN-ATTENDANCE',
-     'HR_Process_ID,C_BPartner_ID,M_Locator_ID,ServiceDate,CheckInTime,CheckOutTime,Qty,Description']
-  ];
-  var model = NinjaModel.parseSheet(sheetRows, { format: 'romo' });
-  added.ninja = NinjaStage.stageModels(db, model, 0);
-  L('§SEED_HBA_NINJA staged tables=' + added.ninja.tables + ' cols=' + added.ninja.cols + ' windows=' + added.ninja.windows
-    + ' tabs=' + added.ninja.tabs + ' fields=' + added.ninja.fields + ' menus=' + added.ninja.menus + ' skipped=' + added.ninja.skipped
-    + ' (re-run reactivates, adds 0)');
-  var attTableId = scalar(db, "SELECT AD_Table_ID FROM AD_Table WHERE TableName='C_Attendance'");
-  must('NINJA-DICT', attTableId != null && Number(attTableId) >= NinjaStage.NINJA_BASE,
-    'C_Attendance staged in AD_Table at deterministic ninja id — got ' + attTableId);
+  // ── 5. RETIRE the invented C_Attendance (RESUME_HBA_ERP_STAGE3.md §PREREQUISITE) ─────────────────────────
+  // Ninja rollback idiom (ninja_stage.js header): IsActive='N' on every dictionary row id>=NINJA_BASE; drop
+  // the invented physical table; remove the OLD 7600000 lens rows (identified by their staged ad_table_id —
+  // the §6 replacement re-declares 7600000 over the REAL AD_Table, so a re-run never deletes the new lens).
+  var retired = 0;
+  ['AD_Table', 'AD_Column', 'AD_Window', 'AD_Tab', 'AD_Field', 'AD_Menu'].forEach(function (t) {
+    try {
+      db.run("UPDATE " + t + " SET IsActive='N' WHERE " + t + "_ID>=" + NinjaStage.NINJA_BASE + " AND IsActive='Y'");
+      retired += db.getRowsModified();
+    } catch (e) { /* table absent in a minimal seed → nothing staged there */ }
+  });
+  if (db.exec("SELECT name FROM sqlite_master WHERE type='table' AND lower(name)='c_attendance'").length) {
+    db.run('DROP TABLE C_Attendance'); retired++;
+    L('§SEED_HBA_RETIRE dropped physical C_Attendance table (invented — no such table in the real dictionary)');
+  }
+  var oldLensTable = scalar(db, 'SELECT ad_table_id FROM ad_infowindow WHERE ad_infowindow_id=?', [INFO_BASE]);
+  if (oldLensTable != null && Number(oldLensTable) >= NinjaStage.NINJA_BASE) {
+    db.run('DELETE FROM ad_infocolumn WHERE ad_infowindow_id=?', [INFO_BASE]); retired += db.getRowsModified();
+    db.run('DELETE FROM ad_infowindow WHERE ad_infowindow_id=?', [INFO_BASE]); retired += db.getRowsModified();
+    L('§SEED_HBA_RETIRE removed old C_Attendance lens rows (ad_infowindow ' + INFO_BASE + ' pointed at staged table ' + oldLensTable + ')');
+  }
+  added.retired = retired;
+  L('§SEED_HBA_RETIRE C_Attendance invention rollback — changes=' + retired + ' (2nd run: 0)');
 
-  // ── 6. Physical C_Attendance + ad_infowindow/ad_infocolumn + the lens rows ───────────────────────────────
-  ['C_Attendance', 'ad_infowindow', 'ad_infocolumn'].forEach(function (t) {
+  // ── 6. REPLACE with native S_Resource/S_ResourceAssignment (the Mary-Consultant pattern) ─────────────────
+  ['ad_infowindow', 'ad_infocolumn'].forEach(function (t) {
     if (createTable(db, t, DDL[t])) { added.tables++; L('§SEED_HBA_DDL CREATE ' + t); }
   });
-
-  // §DESIGN-ATTENDANCE's EXACT lens JOIN — who / where(building+room) / when / period.
-  var FROM = 'C_Attendance ATT JOIN HR_Process P ON ATT.HR_Process_ID=P.HR_Process_ID'
-    + ' JOIN C_BPartner BP ON ATT.C_BPartner_ID=BP.C_BPartner_ID'
-    + ' JOIN M_Locator L ON ATT.M_Locator_ID=L.M_Locator_ID'
-    + ' JOIN M_Warehouse W ON L.M_Warehouse_ID=W.M_Warehouse_ID';
+  // 6a. S_ResourceType 'Employee' — proto-cloned from the REAL person-type row (Consultant 100).
+  var restypeId = scalar(db, "SELECT s_resourcetype_id FROM s_resourcetype WHERE value='Employee'");
+  if (restypeId == null) {
+    restypeId = Math.max(Number(scalar(db, 'SELECT COALESCE(MAX(s_resourcetype_id),0) FROM s_resourcetype')), BIM_BASE - 1) + 1;
+    var rtRow = protoClone(db, 's_resourcetype', 's_resourcetype_id=100', [],
+      { s_resourcetype_id: restypeId, value: 'Employee', name: 'Employee',
+        description: 'HBA person resource type (HHS pilot) — proto-cloned from Consultant 100',
+        created: NOW, updated: NOW, createdby: 100, updatedby: 100, s_resourcetype_uu: 'hba-restype-employee' });
+    if (!rtRow) { must('RESTYPE-PROTO', false, 'no proto s_resourcetype row 100 (Consultant) to clone'); }
+    else { ins(db, 's_resourcetype', rtRow); added.restype = 1; L('§SEED_HBA_RESTYPE ADD Employee id=' + restypeId + ' (proto=Consultant 100)'); }
+  } else L('§SEED_HBA_RESTYPE SKIP Employee exists id=' + restypeId);
+  // 6b. S_Resource per person — ad_attendance.toPersonResourceRow shape + Mary(100) proto for the exact map.
+  added.resources = 0;
+  var resByCode = {};
+  PEOPLE.forEach(function (p) {
+    var rid = scalar(db, 'SELECT s_resource_id FROM s_resource WHERE value=?', [p.name]);
+    if (rid == null) {
+      rid = Math.max(Number(scalar(db, 'SELECT COALESCE(MAX(s_resource_id),0) FROM s_resource')), BIM_BASE - 1) + 1;
+      var core = AdAttendance.toPersonResourceRow({ code: p.name, name: p.name, ad_user_id: p.user, m_warehouse_id: whId },
+        restypeId, function () { return rid; });
+      var rRow = protoClone(db, 's_resource', 's_resource_id=100', [], Object.assign({}, core,
+        { description: 'CONTOH/SAMPLE demo employee resource (HHS pilot) — proto-cloned from Mary Consultant 100',
+          created: NOW, updated: NOW, createdby: 100, updatedby: 100, s_resource_uu: 'hba-res-' + p.name.toLowerCase() }));
+      if (!rRow) { must('RESOURCE-PROTO', false, 'no proto s_resource row 100 (Mary) to clone'); return; }
+      ins(db, 's_resource', rRow); added.resources++;
+      L('§SEED_HBA_RES ADD S_Resource ' + rid + ' ' + p.name + ' → AD_User ' + p.user + ' @ warehouse ' + whId);
+    } else L('§SEED_HBA_RES SKIP S_Resource ' + p.name + ' exists id=' + rid);
+    resByCode[p.name] = Number(rid);
+  });
+  // 6c. the native attendance lens — ad_infowindow 7600000 over the REAL AD_Table (S_ResourceAssignment=485).
+  var raTableId = scalar(db, "SELECT AD_Table_ID FROM AD_Table WHERE TableName='S_ResourceAssignment'");
+  must('RA-TABLE-REAL', raTableId != null && Number(raTableId) < NinjaStage.NINJA_BASE,
+    'S_ResourceAssignment is a REAL dictionary table (AD_Table ' + raTableId + ', below the ninja block)');
+  var FROM = 'S_ResourceAssignment RA JOIN S_Resource R ON RA.S_Resource_ID=R.S_Resource_ID'
+    + ' JOIN AD_User U ON R.AD_User_ID=U.AD_User_ID'
+    + ' JOIN M_Warehouse W ON R.M_Warehouse_ID=W.M_Warehouse_ID';
   if (scalar(db, 'SELECT ad_infowindow_id FROM ad_infowindow WHERE ad_infowindow_id=?', [INFO_BASE]) == null) {
-    ins(db, 'ad_infowindow', Object.assign({ ad_infowindow_id: INFO_BASE, ad_client_id: 11, ad_org_id: 0,
+    ins(db, 'ad_infowindow', { ad_infowindow_id: INFO_BASE, ad_client_id: 11, ad_org_id: 0,
       isactive: 'Y', created: NOW, createdby: 100, updated: NOW, updatedby: 100,
-      name: 'HHS Attendance', description: 'Attendance lens — who/where/when over the real AD chain (Stage 1)',
-      ad_table_id: attTableId, entitytype: 'U', fromclause: FROM, orderbyclause: 'ATT.CheckInTime',
-      isvalid: 'Y', isdefault: 'N', isdistinct: 'N', seqno: 10, ad_infowindow_uu: 'hba-infowin-attendance' }));
+      name: 'HHS Attendance', description: 'Attendance lens — who/building/when over the NATIVE S_Resource chain (§PREREQUISITE retarget)',
+      ad_table_id: raTableId, entitytype: 'U', fromclause: FROM, orderbyclause: 'RA.AssignDateFrom',
+      isvalid: 'Y', isdefault: 'N', isdistinct: 'N', seqno: 10, ad_infowindow_uu: 'hba-infowin-attendance' });
     added.info++;
-    L('§SEED_HBA_INFOWIN ADD id=' + INFO_BASE + ' fromclause per §DESIGN-ATTENDANCE');
+    L('§SEED_HBA_INFOWIN ADD id=' + INFO_BASE + ' over REAL AD_Table ' + raTableId + ' (S_ResourceAssignment)');
   } else L('§SEED_HBA_INFOWIN SKIP exists id=' + INFO_BASE);
   var INFO_COLS = [
-    { name: 'Who', sel: 'BP.Name', col: 'Name' },
+    { name: 'Who', sel: 'U.Name', col: 'Name' },
     { name: 'Building', sel: 'W.Name', col: 'WarehouseName' },
-    { name: 'Room', sel: 'L.Value', col: 'LocatorValue' },
-    { name: 'Date', sel: 'ATT.ServiceDate', col: 'ServiceDate' },
-    { name: 'Check In', sel: 'ATT.CheckInTime', col: 'CheckInTime' },
-    { name: 'Check Out', sel: 'ATT.CheckOutTime', col: 'CheckOutTime' },
-    { name: 'Period', sel: 'P.HR_Period_ID', col: 'HR_Period_ID' }
+    { name: 'Check In', sel: 'RA.AssignDateFrom', col: 'AssignDateFrom' },
+    { name: 'Check Out', sel: 'RA.AssignDateTo', col: 'AssignDateTo' },
+    { name: 'Hours', sel: 'RA.Qty', col: 'Qty' },
+    { name: 'Confirmed', sel: 'RA.IsConfirmed', col: 'IsConfirmed' }
   ];
   INFO_COLS.forEach(function (c, i) {
     var id = INFO_BASE + 1 + i;
@@ -329,39 +376,49 @@ const DDL = {
   });
   L('§SEED_HBA_INFOCOL rows=' + INFO_COLS.length + ' (added this run: see summary)');
 
-  // ── 7. C_Attendance rows — attendance.js's OWN demoSeed sessions (Q2 re-scoped: EMP001/EMP002 only) ─────
+  // ── 7. s_resourceassignment rows — attendance.js's OWN demoSeed sessions (EMP001/EMP002 only) ────────────
+  // Row shape from ad_attendance.toAssignmentRow (ONE builder, reused); zone stays a BIM op-log fact.
   var att = Attendance.demoSeed(ROOMS_FX.rooms, PERIOD);
   var sess = Attendance.sessions(att.log, PERIOD);
-  var bpOf = { EMP001: 1001, EMP002: 1002 };
-  var attId = 0;
   sess.forEach(function (s) {
-    var bp = bpOf[s.employee], loc = locByGuid[s.zone];
-    attId++;
-    if (bp == null || loc == null) { must('ATT-RESOLVE', false, 'unresolvable session ' + s.employee + '@' + s.zone); return; }
-    if (Number(scalar(db, 'SELECT COUNT(*) FROM C_Attendance WHERE C_BPartner_ID=? AND CheckInTime=?', [bp, s.in]))) return;
-    ins(db, 'C_Attendance', Object.assign(std(), { C_Attendance_ID: attId, C_Attendance_UU: 'hba-att-' + attId,
-      HR_Process_ID: run.hr_process.hr_process_id, C_BPartner_ID: bp, M_Locator_ID: loc,
-      ServiceDate: String(s.in).slice(0, 10), CheckInTime: s.in, CheckOutTime: s.open ? null : s.out,
-      Qty: s.open ? null : s.hours,          // hours DERIVED from real in/out (mirrors hr_movement.qty); open → honest NULL
-      Description: s.open ? 'demo session (open — no fabricated finish)' : 'demo session' }));
+    var rid = resByCode[s.employee];
+    if (rid == null) { must('ATT-RESOLVE', false, 'unresolvable session ' + s.employee + ' (no real S_Resource)'); return; }
+    if (Number(scalar(db, 'SELECT COUNT(*) FROM s_resourceassignment WHERE s_resource_id=? AND assigndatefrom=?', [rid, s.in]))) return;
+    var raId = Math.max(Number(scalar(db, 'SELECT COALESCE(MAX(s_resourceassignment_id),0) FROM s_resourceassignment')), BIM_BASE - 1) + 1;
+    var raRow = AdAttendance.toAssignmentRow(s, rid, function () { return raId; });
+    ins(db, 's_resourceassignment', Object.assign(raRow, { ad_client_id: 11, ad_org_id: 11, isactive: 'Y',
+      created: NOW, createdby: 100, updated: NOW, updatedby: 100, s_resourceassignment_uu: 'hba-ra-' + raId }));
     added.attendance++;
   });
-  L('§SEED_HBA_ATT sessions=' + sess.length + ' added=' + added.attendance + ' (open sessions keep NULL checkout/qty)');
+  L('§SEED_HBA_ATT sessions=' + sess.length + ' added=' + added.attendance + ' (open sessions keep NULL assigndateto/qty, isconfirmed=N)');
 
-  // ── 8. SELF-WITNESS — the lens JOIN must resolve EVERY row through the real chain ────────────────────────
-  var joined = rows(db, 'SELECT BP.Name AS who, W.Name AS building, L.Value AS room, ATT.CheckInTime AS tin,'
-    + ' ATT.CheckOutTime AS tout, ATT.Qty AS qty FROM ' + FROM + ' ORDER BY ATT.CheckInTime');
-  var total = Number(scalar(db, 'SELECT COUNT(*) FROM C_Attendance'));
+  // ── 8. SELF-WITNESS — the native lens JOIN must resolve EVERY row through the real chain ─────────────────
+  var joined = rows(db, 'SELECT U.Name AS who, W.Name AS building, RA.AssignDateFrom AS tin,'
+    + ' RA.AssignDateTo AS tout, RA.Qty AS qty, RA.IsConfirmed AS conf FROM ' + FROM
+    + ' WHERE W.Value=? ORDER BY RA.AssignDateFrom', [HHS_VALUE]);
+  var total = Number(scalar(db, 'SELECT COUNT(*) FROM s_resourceassignment RA JOIN s_resource R ON RA.s_resource_id=R.s_resource_id WHERE R.m_warehouse_id=?', [whId]));
   must('LENS-JOIN-LOSSLESS', joined.length === total && total === sess.length,
-    'InfoWindow JOIN resolves ALL ' + total + '/' + sess.length + ' C_Attendance rows (no dangling FK) — joined=' + joined.length);
+    'native InfoWindow JOIN resolves ALL ' + total + '/' + sess.length + ' HBA s_resourceassignment rows (no dangling FK) — joined=' + joined.length);
   must('LENS-WAREHOUSE', joined.length > 0 && joined.every(function (r) { return r.building === HHS_VALUE; }),
     'every session lands in the pinned HHS warehouse (Q1 Value=' + HHS_VALUE + ')');
   must('LENS-IDENTITY', joined.every(function (r) { return r.who === 'EMP001' || r.who === 'EMP002'; }),
-    'every session resolves to a REAL seeded person (Q2: EMP001/EMP002 only) — ' + JSON.stringify(joined.map(function (r) { return r.who + '@' + r.room; })));
+    'every session resolves to a REAL seeded person via S_Resource.ad_user_id→AD_User — ' + JSON.stringify(joined.map(function (r) { return r.who; })));
   var openRows = joined.filter(function (r) { return r.tout == null; });
   must('LENS-HONEST-OPEN', openRows.length === sess.filter(function (s) { return s.open; }).length
-    && openRows.every(function (r) { return r.qty == null; }),
-    openRows.length + ' open sessions keep NULL CheckOutTime AND NULL Qty (no fabricated finish/hours)');
+    && openRows.every(function (r) { return r.qty == null && r.conf === 'N'; }),
+    openRows.length + ' open sessions keep NULL AssignDateTo AND NULL Qty AND IsConfirmed=N (no fabricated finish/hours/approval)');
+  // the invention is GONE — dictionary inactive, physical table absent, lens re-pointed at the real table.
+  var stagedActive = Number(scalar(db, "SELECT COUNT(*) FROM AD_Table WHERE AD_Table_ID>=" + NinjaStage.NINJA_BASE + " AND IsActive='Y'"));
+  var physGone = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND lower(name)='c_attendance'").length === 0;
+  var lensTable = Number(scalar(db, 'SELECT ad_table_id FROM ad_infowindow WHERE ad_infowindow_id=?', [INFO_BASE]));
+  must('INVENTION-GONE', stagedActive === 0 && physGone && lensTable === Number(raTableId),
+    'C_Attendance invention retired: staged dictionary rows inactive (' + stagedActive + ' active), physical table gone=' + physGone
+    + ', lens ' + INFO_BASE + ' points at REAL AD_Table ' + lensTable);
+  // readPresence round-trip — the module's own lens read returns the same sessions (the pane's data path).
+  var lensRead = AdAttendance.readPresence(function (sql, p) { return rows(db, sql, p); }, { m_warehouse_id: whId });
+  must('READPRESENCE-LENS', lensRead.sessions.length === total
+    && lensRead.sessions.every(function (r) { return r.building === HHS_VALUE && (r.who === 'EMP001' || r.who === 'EMP002'); }),
+    'ad_attendance.readPresence returns ' + lensRead.sessions.length + '/' + total + ' sessions through the native JOIN (honest-open survives the round-trip)');
 
   // payslip: DB-summed movements == the engine's payslip (gross/net land in HR_Movement losslessly)
   var slip = AdPayroll.payslip(run.hr_movement, 1001, 'en');
@@ -374,8 +431,7 @@ const DDL = {
 
   // ── write-back + summary ─────────────────────────────────────────────────────────────────────────────────
   var changed = added.warehouse + added.locators + added.bpartners + added.users + added.tables + added.hr_rows
-    + added.info + added.attendance + (added.ninja ? (added.ninja.tables + added.ninja.cols + added.ninja.windows
-    + added.ninja.tabs + added.ninja.fields + added.ninja.menus) : 0);
+    + added.info + added.attendance + added.retired + added.restype + added.resources;
   if (changed > 0 && fails === 0) { fs.writeFileSync(SEED, Buffer.from(db.export())); L('§SEED_HBA WROTE erp/ad_seed.db (' + changed + ' additions)'); }
   else if (fails === 0) L('§SEED_HBA NO-OP — seed already current (idempotent 2nd run)');
   else L('§SEED_HBA NOT WRITTEN — ' + fails + ' witness failure(s), DB left untouched');

--- a/viewer/hba_bom.js
+++ b/viewer/hba_bom.js
@@ -1,0 +1,114 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — HR_BIM_ASSET → VIEWER **BIM BOM** PANE (bim-compiler prompts/RESUME_HBA_ERP_STAGE3.md
+//   §Stage 3 item 2 — Witness: W-HBA-BOM-PANE). An EXTRA, ADDITIVE pane mirroring viewer/hba_tenancy.js —
+//   NOT a change to the rest of the viewer. ADDITIVE + HOST-INJECTED: imports NOTHING from viewer internals;
+//   the host hands it `A` (APP). Renders `A._hbaBomSpec` — the ERP-GOVERNED lens `hr_bim_asset/ad_bom.js
+//   readBom()` produced in hba_lens.js `_regovern` over the REAL seeded pp_product_bom/pp_product_bomline
+//   rows (§BOM-ERP-CENTERED: the ERP is the authority, the Java m_bom is a retired migration source; this
+//   pane is purely a VIEW on the lens — it stores nothing). Room = assembly, contained elements = lines with
+//   QtyBOM. Row click flies the camera to the assembly's room via HBALens.flyToZone (same "just a link"
+//   idiom as the Tenancy pane); each assembly deep-links into the REAL iDempiere "Bill of Materials and
+//   Formula" window (AD_WINDOWS.BOM=53006, looked up live — never guessed). Data gate: the pane is available
+//   ONLY when the governed spec carries ≥1 assembly (no ERP db / no 'B' BOMs → honestly greyed, no clutter).
+//   ZERO-IMPACT: OFF = no DOM; toggle ON mounts ONE fixed overlay; OFF removes it (zero residue).
+//   Read the log after every run.
+(function () {
+  'use strict';
+  var G = (typeof self !== 'undefined' ? self : this);
+  var _pane = null;
+
+  function deps() { return { ADB: G.HbaAdBom, Lens: G.HBALens }; }
+  function ready() { return !!(deps().ADB && typeof document !== 'undefined'); }
+
+  function spec(A) { return (A && A._hbaBomSpec) || null; }
+  // detect gates on the GOVERNED spec (RESUME_HBA_ERP_STAGE3.md item 2: "Detect gates on
+  // A._hbaBomSpec.assemblies.length") — no governed BOM rows → pane unavailable, never a literal fallback.
+  function detect(A) { var sp = spec(A); return !!(ready() && sp && sp.assemblies && sp.assemblies.length); }
+
+  function el(tag, css, txt) { var e = document.createElement(tag); if (css) e.style.cssText = css; if (txt != null) e.textContent = txt; return e; }
+
+  function mount(A) {
+    var sp = spec(A);
+    if (!sp) return false;
+    var totalLines = sp.assemblies.reduce(function (s, a) { return s + a.lines.length; }, 0);
+    var pane = el('div', 'position:fixed;top:54px;right:12px;width:400px;max-height:82vh;overflow:auto;z-index:10050;' +
+      'background:#fff;border-radius:10px;box-shadow:0 6px 24px #0005;font-family:system-ui,sans-serif;color:#222;');
+    pane.id = 'hba-bom-pane';
+    var building = (sp.assemblies[0] && sp.assemblies[0].building) || 'This Building';
+    var head = el('div', 'display:flex;justify-content:space-between;align-items:center;background:#102a43;color:#fff;padding:10px 12px;border-radius:10px 10px 0 0;');
+    head.appendChild(el('div', 'font-size:14px;font-weight:600;', 'BIM BOM · ERP-governed (' + building + ')'));
+    var x = el('button', 'background:none;border:none;color:#fff;font-size:18px;cursor:pointer;line-height:1;', '×');
+    x.title = 'Close'; x.addEventListener('click', function () { toggle(A); });
+    head.appendChild(x); pane.appendChild(head);
+    pane.appendChild(el('div', 'background:#fff8e1;color:#a06b00;font-weight:700;letter-spacing:1px;font-size:11px;padding:4px 12px;', sp._watermark + ' · CONTOH — TIDAK RASMI'));
+    // KPIs — Assemblies (rooms with a native BOM header) · Components (pp_product_bomline rows)
+    var kp = el('div', 'display:flex;gap:8px;padding:10px 12px;flex-wrap:wrap;');
+    [['Assemblies', sp.assemblies.length], ['Components', totalLines]].forEach(function (k) {
+      var c = el('div', 'background:#f4f5f7;border-radius:6px;padding:6px 10px;min-width:60px;');
+      c.appendChild(el('div', 'font-size:20px;font-weight:700;color:#102a43;', String(k[1])));
+      c.appendChild(el('div', 'font-size:10px;color:#627d98;text-transform:uppercase;', k[0])); kp.appendChild(c);
+    });
+    pane.appendChild(kp);
+    var body = el('div', 'padding:0 12px 12px;');
+    var tbl = el('table', 'width:100%;border-collapse:collapse;font-size:12px;');
+    sp.assemblies.forEach(function (a) {
+      var storey = (A && A._hbaStoreyOf && A._hbaStoreyOf[a.assembly_guid]) || null;
+      var tr = el('tr', 'border-top:2px solid #d9e2ec;cursor:pointer;background:#f4f8fb;');
+      tr.setAttribute('data-assembly-guid', a.assembly_guid);
+      tr.appendChild(el('td', 'padding:7px 4px;font-weight:600;', (a.assembly_name || a.assembly_guid) + (storey ? ' · ' + storey : '')));
+      tr.appendChild(el('td', 'padding:7px 4px;text-align:right;color:#627d98;', a.lines.length + ' component' + (a.lines.length === 1 ? '' : 's')));
+      // deep-link into the REAL iDempiere BOM window for this pp_product_bom record (never fabricated).
+      var linkTd = el('td', 'padding:7px 4px;text-align:right;');
+      var lens0 = deps().Lens;
+      if (a.bom_id != null && lens0 && lens0.erpLink && lens0.AD_WINDOWS && lens0.AD_WINDOWS.BOM != null) {
+        var link = document.createElement('a');
+        link.href = lens0.erpLink(lens0.AD_WINDOWS.BOM, a.bom_id);
+        link.target = '_blank'; link.rel = 'noopener'; link.textContent = 'open ↗';
+        link.title = 'Open this BOM in iDempiere (Bill of Materials and Formula)';
+        link.style.cssText = 'color:#1976d2;text-decoration:none;font-size:11px;';
+        link.addEventListener('click', function (e) { e.stopPropagation(); });
+        linkTd.appendChild(link);
+      }
+      tr.appendChild(linkTd);
+      tr.addEventListener('click', function () {
+        var lens = deps().Lens;
+        var res = lens && lens.flyToZone ? lens.flyToZone(A, a.assembly_guid) : { flew: false };
+        console.log('§HBA_BOM_LINK guid=' + a.assembly_guid + ' flew=' + res.flew + (res.center ? ' center=(' + res.center.x.toFixed(1) + ',' + res.center.y.toFixed(1) + ',' + res.center.z.toFixed(1) + ')' : ''));
+      });
+      tbl.appendChild(tr);
+      a.lines.forEach(function (ln) {
+        var lr = el('tr', 'border-top:1px solid #f0f0f0;');
+        lr.setAttribute('data-line-id', String(ln.line_id));
+        lr.appendChild(el('td', 'padding:4px 4px 4px 18px;color:#334e68;', ln.component_name || ln.component_guid));
+        lr.appendChild(el('td', 'padding:4px;text-align:right;color:#627d98;', 'Qty ' + (ln.qty != null ? ln.qty : '—')));
+        lr.appendChild(el('td', ''));
+        tbl.appendChild(lr);
+      });
+    });
+    body.appendChild(tbl);
+    pane.appendChild(body);
+    (document.body || document.documentElement).appendChild(pane);
+    if (G.HbaDraggable) G.HbaDraggable.enable(pane, head);
+    _pane = pane;
+    console.log('§HBA_BOM_PANE mounted assemblies=' + sp.assemblies.length + ' components=' + totalLines + ' building=' + building);
+    return true;
+  }
+
+  function unmount() {
+    if (_pane && _pane.parentNode) _pane.parentNode.removeChild(_pane);
+    else if (_pane && typeof _pane.remove === 'function') _pane.remove();
+    _pane = null;
+    console.log('§HBA_BOM_PANE unmounted (zero residue)');
+    return false;
+  }
+
+  function toggle(A) {
+    if (!ready()) { if (A && A.status) A.status.textContent = 'BIM BOM lens not loaded'; return false; }
+    return _pane ? unmount() : mount(A);
+  }
+  function isActive() { return !!_pane; }
+
+  G.HBABomPane = { toggle: toggle, detect: detect, isActive: isActive, _ready: ready, _spec: spec };
+  if (typeof module === 'object' && module.exports) module.exports = G.HBABomPane;
+})();

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -343,18 +343,15 @@
         h.M.records('Tenancy'), h.M.records('Strata'), { erpQuery: eq });
       n++;
     }
-    // §DESIGN-ATTENDANCE — compile the signed presence sessions onto real C_Attendance child rows (partner/
-    // locator maps built from the real seeded AD_User/M_Locator). Stage 3 retargets the Presence drawer onto
-    // this governed spec; Stage 2 produces it. Sessions whose id/zone has no real row are honestly SKIPPED.
+    // §PREREQUISITE retarget (RESUME_HBA_ERP_STAGE3.md) — compile the signed presence sessions onto the REAL
+    // NATIVE S_ResourceAssignment shape (resource map from the real seeded S_Resource rows — the Mary-
+    // Consultant pattern; the invented C_Attendance is retired). The ZONE stays a BIM op-log fact, carried in
+    // the spec's `spatial` view-trace. Sessions whose employee has no real S_Resource are honestly SKIPPED.
     if (h.ADA && h.A && A._hbaAttendanceLog && A._hbaRooms) {
       var sessions = h.A.sessions(A._hbaAttendanceLog, period(A));
-      var userRows = eq('SELECT Name AS name, C_BPartner_ID AS c_bpartner_id FROM AD_User WHERE C_BPartner_ID IS NOT NULL AND IsActive=?', ['Y']);
-      var locRows = eq('SELECT M_Locator_ID AS m_locator_id, Value AS value FROM M_Locator', []);
-      var procRow = eq('SELECT HR_Process_ID AS id FROM HR_Process ORDER BY HR_Process_ID LIMIT 1', []);
+      var resRows = eq('SELECT S_Resource_ID AS s_resource_id, Value AS value FROM S_Resource WHERE AD_User_ID IS NOT NULL AND IsActive=?', ['Y']);
       A._hbaAttendanceSpec = h.ADA.compileAttendance(sessions, {
-        processId: (procRow[0] ? Number(procRow[0].id) : null),
-        partnerMap: h.ADA.partnerMapFromUsers(userRows),
-        locatorMap: h.ADA.locatorMapFromLocators(locRows) });
+        resourceMap: h.ADA.resourceMapFromResources(resRows) });
       n++;
     }
     // §BOM-ERP-CENTERED — read the BIM BOM as a LENS over the real seeded pp_product_bom (ad_bom.readBom), the
@@ -368,7 +365,7 @@
     console.log('§HBA_GOVERN on — re-compiled ' + n + ' governable spec(s) off real ad_seed.db (payroll _governed='
       + !!(A._hbaPayrollSpec && A._hbaPayrollSpec._governed)
       + ' warehouse=' + (A._hbaTenancySpec ? A._hbaTenancySpec.warehouse.m_warehouse_id : 'n/a')
-      + ' C_Attendance=' + (A._hbaAttendanceSpec ? (A._hbaAttendanceSpec.rows.length + '/' + (A._hbaAttendanceSpec.rows.length + A._hbaAttendanceSpec.skipped.length)) : 'n/a')
+      + ' S_ResourceAssignment=' + (A._hbaAttendanceSpec ? (A._hbaAttendanceSpec.rows.length + '/' + (A._hbaAttendanceSpec.rows.length + A._hbaAttendanceSpec.skipped.length)) : 'n/a')
       + ' BOM=' + (A._hbaBomSpec ? (A._hbaBomSpec.assemblies.length + ' assemblies') : 'n/a') + ')');
     if (A.markDirty) A.markDirty();
   }
@@ -417,7 +414,8 @@
     barChart:  '<path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>',
     banknote:  '<rect width="20" height="12" x="2" y="6" rx="2"/><circle cx="12" cy="12" r="2"/><path d="M6 12h.01M18 12h.01"/>',
     calendar:  '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
-    fileText:  '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/>'
+    fileText:  '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/>',
+    box:       '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>'
   };
   var FAMILY = [
     { kind: 'lens', mode: 'occupancy',   icon: 'doorOpen',   label: 'Occupancy',    detail: 'Availability — occupied / expiring / vacant / unavailable (incl. lease status)' },
@@ -425,6 +423,7 @@
     { kind: 'lens', mode: 'class',       icon: 'layers',     label: 'Unit class',   detail: 'Use-class — residential / commercial / office' },
     { kind: 'lens', mode: 'maintenance', icon: 'cpu',        label: 'Assets / IoT', detail: 'Equipment maintenance due — click opens 24h sensor charts + CCTV mockup + billing' },
     { kind: 'pane', id:   'tenancy',     icon: 'fileText',   label: 'Tenancy / AD', detail: 'Lease/strata compiled to native AD (Warehouse/Locator/Product/Subscription)' },
+    { kind: 'pane', id:   'bom',         icon: 'box',        label: 'BIM BOM',      detail: 'Room assemblies → component lines, read as a lens over native pp_product_bom (ERP is the authority)' },
     { kind: 'pane', id:   'dash',        icon: 'barChart',   label: 'Dashboard',    detail: 'Occupancy / availability / ticket-aging charts (extra pane)' },
     { kind: 'pane', id:   'payslip',     icon: 'banknote',   label: 'Payslip',      detail: 'Payroll run → per-employee payslip (glass-box, watermarked)' },
     { kind: 'pane', id:   'leave',       icon: 'calendar',   label: 'Leave',        detail: 'Leave balance & statement — accrual/take replay (glass-box)' }
@@ -432,7 +431,7 @@
   // pane entries route by `id` to their own additive pane module (dash→HBADashPane, payslip→HBAPayslipPane,
   // leave→HBALeavePane, tenancy→HBATenancyPane) — a small registry instead of hardcoding one pane name, so
   // adding a pane never touches the lens/toggle path.
-  var PANE_GLOBALS = { dash: 'HBADashPane', payslip: 'HBAPayslipPane', leave: 'HBALeavePane', tenancy: 'HBATenancyPane' };
+  var PANE_GLOBALS = { dash: 'HBADashPane', payslip: 'HBAPayslipPane', leave: 'HBALeavePane', tenancy: 'HBATenancyPane', bom: 'HBABomPane' };
   function paneFor(f) { return G[PANE_GLOBALS[f.id]]; }
   function _entryActive(f) {
     return f.kind === 'pane' ? !!(paneFor(f) && paneFor(f).isActive && paneFor(f).isActive()) : isActive(f.mode);
@@ -552,7 +551,9 @@
   // own anywhere (verified §CRITICAL P8 finding, re-checked here) so a per-entry link would be invented; what
   // IS real is the "Leave without pay" pay-element identity (hr_concept_id) an unpaid entry feeds INTO — the
   // Leave pane links there, never to a fabricated leave-record window.
-  var AD_WINDOWS = { RESOURCE: 236, PAYROLL_MOVEMENT: 53042, SUBSCRIPTION: 316, ORDER: 143, PAYROLL_CONCEPT: 53036 };
+  // BOM=53006 "Bill of Materials and Formula" (table PP_Product_BOM) — looked up live in both ad_seed.db and
+  // bim-compiler build/erp/ad_full.db (2026-07-03), the §STAGE3 BOM pane's per-assembly deep-link.
+  var AD_WINDOWS = { RESOURCE: 236, PAYROLL_MOVEMENT: 53042, SUBSCRIPTION: 316, ORDER: 143, PAYROLL_CONCEPT: 53036, BOM: 53006 };
   function erpLink(windowId, record) {
     if (windowId == null || record == null) return null;
     return '../erp/idempiere.html?client=garden&window=' + windowId + '&record=' + encodeURIComponent(record);
@@ -568,13 +569,32 @@
     _closePresenceDrawer();
     var h = HBA();
     var log = (A && A._hbaAttendanceLog) || [];
-    var sess = (h.A && h.A.sessions) ? h.A.sessions(log, period(A)) : [];
+    // §STAGE3.1 (RESUME_HBA_ERP_STAGE3.md item 1) — GOVERNED read: when _regovern has compiled the sessions
+    // onto the real native S_ResourceAssignment rows (A._hbaAttendanceSpec), the roster renders THOSE rows —
+    // check-in/out, hours (Qty) and the maker-checker IsConfirmed come from the governed spec. The ZONE stays
+    // the BIM op-log fact (room-granularity call): each row joins back to its zone via the spec's `spatial`
+    // view-trace, keyed by the row PK — so fly-to-zone still works without a fabricated room FK. Honest-open
+    // preserved (NULL AssignDateTo → 'checked in …'). Ungoverned (no ERP db) → the raw signed-op-log fold,
+    // byte-identical to the pre-Stage-3 drawer.
+    var gov = (A && A._hbaAttendanceSpec && A._hbaAttendanceSpec.rows && A._hbaAttendanceSpec.spatial) ? A._hbaAttendanceSpec : null;
+    var sess;
+    if (gov) {
+      var zoneByRa = {}; gov.spatial.forEach(function (sp) { zoneByRa[sp.s_resourceassignment_id] = sp; });
+      sess = gov.rows.map(function (r) {
+        var sp = zoneByRa[r.s_resourceassignment_id] || {};
+        return { employee: sp.employee != null ? sp.employee : r.name, zone: sp.zone, in: r.assigndatefrom,
+                 out: r.assigndateto, hours: r.qty, confirmed: r.isconfirmed, open: r.assigndateto == null };
+      });
+    } else {
+      sess = (h.A && h.A.sessions) ? h.A.sessions(log, period(A)) : [];
+    }
     var d = document.createElement('div'); d.id = 'hba-presence-drawer';
     d.style.cssText = 'position:fixed;z-index:10000;right:326px;top:50%;transform:translateY(-50%);background:#0e1b2a;'
       + 'color:#fff;border-radius:10px;padding:8px;box-shadow:0 8px 28px rgba(0,0,0,.45);font:13px/1.3 system-ui,sans-serif;'
       + 'min-width:220px;max-height:70vh;overflow:auto;';
     var hdr = document.createElement('div'); hdr.style.cssText = 'display:flex;align-items:center;justify-content:space-between;padding:4px 4px 8px;';
-    var title = document.createElement('span'); title.textContent = 'Presence — ' + sess.length + (sess.length === 1 ? ' session' : ' sessions');
+    var title = document.createElement('span'); title.textContent = 'Presence — ' + sess.length + (sess.length === 1 ? ' session' : ' sessions')
+      + (gov ? ' · ERP-governed' : '');
     title.style.cssText = 'font-weight:700;opacity:.85;';
     var closeBtn = document.createElement('button'); closeBtn.textContent = '✕'; closeBtn.title = 'Close';
     closeBtn.style.cssText = 'background:transparent;border:0;color:#fff;opacity:.6;cursor:pointer;font-size:14px;line-height:1;padding:2px 4px;';
@@ -592,13 +612,20 @@
       row.setAttribute('data-employee', s.employee); row.setAttribute('data-zone', s.zone); row.setAttribute('data-label', label);
       row.style.cssText = 'display:block;width:100%;text-align:left;border:0;border-radius:8px;margin:2px 0;'
         + 'padding:8px 10px;color:#fff;cursor:pointer;background:transparent;';
+      // governed rows carry the REAL Qty hours + IsConfirmed maker-checker state; the raw fold has neither.
+      var govBadge = gov ? ((s.hours != null ? ' · ' + s.hours + 'h' : '') + (s.open ? '' : (s.confirmed === 'Y' ? ' · ✓' : ' · unconfirmed'))) : '';
       row.innerHTML = '<div style="font-weight:600">' + label + '</div>'
-        + '<div style="opacity:.7;font-size:11px">' + (storey ? storey + ' · ' : '') + (s.open ? 'checked in ' + s.in : s.in + ' → ' + s.out) + '</div>';
+        + '<div style="opacity:.7;font-size:11px">' + (storey ? storey + ' · ' : '') + (s.open ? 'checked in ' + s.in : s.in + ' → ' + s.out) + govBadge + '</div>';
       row.addEventListener('click', function () { flyToZone(A, s.zone); });
       d.appendChild(row);
     });
+    if (gov && gov.skipped && gov.skipped.length) {   // honest: sessions whose identity had no real S_Resource
+      var sk = document.createElement('div'); sk.textContent = gov.skipped.length + ' session(s) skipped — no real S_Resource (never fabricated)';
+      sk.style.cssText = 'padding:6px 8px;opacity:.6;font-size:11px;color:#ffab91;';
+      d.appendChild(sk);
+    }
     document.body.appendChild(d);
-    console.log('§HBA_PRESENCE_DRAWER open — ' + sess.length + ' sessions');
+    console.log('§HBA_PRESENCE_DRAWER open — ' + sess.length + ' sessions' + (gov ? ' (ERP-governed S_ResourceAssignment, skipped=' + gov.skipped.length + ')' : ' (op-log fold)'));
     return d;
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v738';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v739';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -899,6 +899,10 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../hr_bim_asset/binding.js?v=1" onerror="console.warn('§LOAD_FAIL hr binding.js')"></script>
 <script src="../hr_bim_asset/connectors.js?v=1" onerror="console.warn('§LOAD_FAIL hr connectors.js')"></script>
 <script src="../hr_bim_asset/rules.js?v=1" onerror="console.warn('§LOAD_FAIL hr rules.js')"></script>
+<!-- §STAGE3 live-smoke finding 2026-07-03: PR #628 made ad_payroll.js read self.HbaMockRates.MOCK_RATES at
+     eval time — without mock_rates.js loaded FIRST the whole ad_payroll IIFE throws and HbaAdPayroll never
+     exists (payslip/leave panes dead, payroll governance silently literal). Must precede ad_payroll.js. -->
+<script src="../hr_bim_asset/mock_rates.js?v=1" onerror="console.warn('§LOAD_FAIL hr mock_rates.js')"></script>
 <script src="../hr_bim_asset/ad_payroll.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_payroll.js')"></script>
 <script src="../hr_bim_asset/overlay.js?v=2" onerror="console.warn('§LOAD_FAIL hr overlay.js')"></script>
 <script src="../hr_bim_asset/lens.js?v=1" onerror="console.warn('§LOAD_FAIL hr lens.js')"></script>
@@ -924,6 +928,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="hba_payslip.js?v=1" onerror="console.warn('§LOAD_FAIL hba_payslip.js')"></script>
 <script src="hba_leave.js?v=1" onerror="console.warn('§LOAD_FAIL hba_leave.js')"></script>
 <script src="hba_tenancy.js?v=1" onerror="console.warn('§LOAD_FAIL hba_tenancy.js')"></script>
+<script src="hba_bom.js?v=1" onerror="console.warn('§LOAD_FAIL hba_bom.js')"></script>
 <script src="hba_iot.js?v=3" onerror="console.warn('§LOAD_FAIL hba_iot.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): the viewer joins the shared cross-surface context
      as surface 'viewer' — selection/timeline/identity over the one signed op-log. Opt-in (toggle / ?connect=1). -->


### PR DESCRIPTION
Implements bim-compiler `prompts/RESUME_HBA_ERP_STAGE3.md` — the full Stage 3 lane including its ⛔ prerequisite.

## Prerequisite — retire the invented C_Attendance (watchdog finding)
`C_Attendance` is **not a real iDempiere table** (0 rows in the real dictionary). The seed now rolls back the staged dictionary (`IsActive='N'`, 48 rows), drops the physical table, and retargets everything onto the **native `S_Resource`/`S_ResourceAssignment`** (the Mary-Consultant GardenWorld pattern): person → S_Resource (`ad_user_id`→AD_User, `m_warehouse_id`→HHS 990000), session → S_ResourceAssignment (`assigndatefrom/to`, `qty`=real hours, `isconfirmed` maker-checker, honest-open NULLs). The `ad_infowindow 7600000` lens is re-declared over the REAL `AD_Table 485` JOIN. Room granularity per the accepted design call: **zone stays a BIM op-log fact** (spatial view-trace, never a fabricated FK). `ad_attendance.js` delegates row shapes to occupancy.js's witnessed builders — no duplicate builder.

## Stage 3
1. **Presence drawer** renders the governed S_ResourceAssignment rows (hours, ✓/unconfirmed, `· ERP-governed`), zone fly-to intact; ungoverned fallback byte-identical.
2. **NEW BIM BOM pane** (`viewer/hba_bom.js`, 9th FAMILY entry) off `A._hbaBomSpec` — assemblies→component lines from native `pp_product_bom`; per-assembly deep-link into real AD_Window **53006** "Bill of Materials and Formula".
3. Spot-check: all panes read `A._hba*Spec` through APP at mount time.
4. **Live headless-Chrome smoke** (real-user path): `§HBA_GOVERN on — 4 spec(s) … payroll _governed=true warehouse=990000 S_ResourceAssignment=7/7 BOM=13 assemblies`, presence drawer 7 sessions ERP-governed, BOM pane 13/88, **0 console errors**.

## Live-smoke finding fixed (pre-existing #628 regression)
`ad_payroll.js` reads `self.HbaMockRates.MOCK_RATES` at eval time, but `viewer.html`/`fm_panel.html` never loaded `mock_rates.js` → the IIFE died silently: `HbaAdPayroll` undefined, payslip/leave panes dead, payroll governance stuck literal. Both pages now load it first; `witness_family` F8 pins the `<script>` order.

## Witnesses
- W-HBA-AD-ATTENDANCE 9/9 (native cols only, retired keys absent, honest-open, skip discipline, spatial zone)
- W-HBA-ERP-GOVERN-WIRE 8/8 (invention-gone in shipped db, readPresence round-trip, governed drawer render)
- W-HBA-BOM-PANE 11/11 (new) · W-HBA-FAMILY 10/10 · seed self-witness 8/8, idempotent 2nd run = 0 additions
- **Full hr_bim_asset suite 40/40 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)