### PR TITLE
feat(modeller): ONE Export menu — Native .db (full-fidelity signed op-log) + IFC + BCF

### DIFF
--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -92,6 +92,31 @@
       return this.length;
     },
 
+    // §EXPORT-NATIVE (prompts/EXPORT_MENU_NATIVE_DB.md — Witness: W-E2E-EXPORT-DB): load a native .db
+    // (a signed kernel_ops op-log exported by Export ▸ Native .db) as the CURRENT model — the symmetric
+    // READ of Bonsai.exportDb's sealChain→db.export() write. Discriminated + routed by _openBuffer (the
+    // same code path #b-open uses) on its kernel_ops table; building-substrate .db files never reach here.
+    // Verify the imported chain, fold to tip, persist under the current key. NON-INVENT: bytes are the model.
+    async importBytes(u8) {
+      await this._ensureDb();                             // SQL runtime + edge signer ready
+      if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache();
+      const SQL = await window.initSqlJs({ locateFile: f => new URL('lib/' + f, _base).href });   // cached module
+      if (this.db) { try { this.db.close(); } catch (e) { } }
+      this.db = new SQL.Database(u8);
+      window.KernelOps.ensureTable(this.db);
+      // restore the group counter — the exact _ensureDb idiom (both minted gid prefixes, §P8)
+      this._n = 0;
+      try { const r = this.db.exec("SELECT gid FROM kernel_ops WHERE gid LIKE 'geom-grp-%' OR gid LIKE 'gesture-grp-%'"); if (r.length) this._n = r[0].values.reduce((m, v) => Math.max(m, parseInt(String(v[0]).replace(/^(geom|gesture)-grp-/, '')) || 0), 0); } catch (e) { }
+      let v = null;
+      try { v = await window.KernelOps.verifyChain(this.db); } catch (e) { console.warn(TAG + ' import verify threw ' + e); }
+      this._cursor = this.length;
+      await this._foldUpto(this._cursor);
+      this._save();                                       // the imported model persists like any authored one
+      this._emit();
+      console.log(TAG + ' §EXPORT-NATIVE imported ops=' + this.length + ' verify=' + !!(v && v.ok) + ' cursor=' + this._cursor);
+      return { ops: this.length, verify: !!(v && v.ok) };
+    },
+
     // §MO — point the op-log at a per-building EDITABLE INSTANCE (key 'mo_<building>'). The loaded
     // building DB (the fetched meta.db) is the PRISTINE REFERENCE — it lives in IndexedDB and is never
     // written here; this op-log is the editable fold and persists to localStorage under its OWN key. So

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -162,8 +162,7 @@
   <input id="dim-rad" type="number" step="0.05" min="0.01" value="0.1" title="Fillet / chamfer radius (m)" style="display:none;width:50px;box-sizing:border-box;background:#13151a;border:1px solid #2c303a;border-radius:5px;color:#c7cdd8;padding:5px;font-size:11px;outline:none">
   <button id="b-insert" disabled title="Insert a library component (assemble, don't draw)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16.5 9.4 7.55 4.24"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.29 7 12 12 20.71 7"/><line x1="12" x2="12" y1="22" y2="12"/></svg><span>Insert</span></button>
   <button id="b-lod" disabled style="display:none" title="Refine the selected component's level of detail (same signed row)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/></svg><span>LOD 200</span></button>
-  <button id="b-ifc" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>IFC</span></button>
-  <button id="b-bcf" disabled title="Export a BCF 2.1 issue (.bcfzip) — current view + selection as Component references"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><circle cx="11" cy="14" r="2"/><path d="m14.5 17.5-1.7-1.7"/></svg><span>BCF</span></button>
+  <button id="b-export" disabled title="Export — Native .db (full fidelity: the signed op-log), IFC4, or a BCF 2.1 issue"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>Export</span></button>
   <button id="b-guide" title="Modeller User Guide — how to Open, walk, edit & export"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg><span>Guide</span></button>
   <button id="b-del" disabled title="Delete selected (Del)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Z"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/></svg><span>Delete</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
@@ -187,7 +186,7 @@
 <script src="lib/sql-wasm.js" onerror="console.warn('§OPLOG LOAD_FAIL sql-wasm.js')"></script>
 <script src="kernel_ops.js?v=9" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
-<script src="bonsai_oplog.js?v=6" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<script src="bonsai_oplog.js?v=7" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
 <script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
@@ -220,7 +219,7 @@
 <script src="../geomapping/classify_geom.js?v=1" onerror="console.warn('§GEOMAP LOAD_FAIL classify_geom.js')"></script>
 <script src="../geomapping/geomap_bridge.js?v=1" onerror="console.warn('§GEOMAP LOAD_FAIL geomap_bridge.js')"></script>
 <script src="str_walker_bridge.js?v=4" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_bridge.js')"></script>
-<script src="str_walker_outliner.js?v=12" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
+<script src="str_walker_outliner.js?v=13" onerror="console.warn('§STRWALK LOAD_FAIL str_walker_outliner.js')"></script>
 <!-- Bonsai library: insert a real catalog component (assemble, don't draw) as ONE signed GEOM_INSERT op @ LOD. -->
 <script src="bonsai_library.js?v=17" onerror="console.warn('§LIBRARY LOAD_FAIL bonsai_library.js')"></script>
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
@@ -2095,21 +2094,22 @@ if (dimScale) dimScale.addEventListener('keydown', (e) => {
   commitScale(m[1].toLowerCase(), +f.toFixed(4));
 });
 
-// ── IFC EXPORT ──────────────────────────────────────────────────────────────────────────────────
-const bIfc = document.getElementById('b-ifc');
-bIfc.onclick = async () => {
+// ── EXPORT MENU (prompts/EXPORT_MENU_NATIVE_DB.md — Witness: W-E2E-EXPORT-DB) ───────────────────
+// ONE Export pill (#b-export) replaces the two flat #b-ifc/#b-bcf pills; a small chooser (the exact
+// #m-open-panel idiom from initOpenChooser) offers Native .db / IFC / BCF. IFC + BCF handler bodies
+// are UNCHANGED (pure UI move); Native .db is the NEW symmetric save of what #b-open loads.
+async function doIfcExport() {
   if (window.Bonsai.oplog.length === 0) { setStat('author something first'); return; }
   setStat('exporting IFC…');
   try {
     const r = await window.Bonsai.ifc.exportModel({ name: 'bonsai_model.ifc' });
     setStat('IFC exported  walls=' + r.walls + '  openings=' + r.openings + '  ' + r.bytes.length + ' bytes (downloaded)'); audioCue('export');
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§IFC export fail ' + err); }
-};
-// ── BCF EXPORT (§Q3 RESUME_MODELLER_POLISH2.md — Witness: W-E2E-BCF) ────────────────────────────
-// One real .bcfzip: current camera as the BCF viewpoint, canvas snapshot, selection (+ an active §Q2
-// instance pick with a real guid) as Component references. Mirrors the bIfc handler pattern exactly.
-const bBcf = document.getElementById('b-bcf');
-bBcf.onclick = () => {
+}
+// (§Q3 RESUME_MODELLER_POLISH2.md — Witness: W-E2E-BCF) One real .bcfzip: current camera as the BCF
+// viewpoint, canvas snapshot, selection (+ an active §Q2 instance pick with a real guid) as Component
+// references. Mirrors the IFC handler pattern exactly.
+function doBcfExport() {
   if (!window.Bonsai.bcf) { setStat('BCF module not loaded'); return; }
   setStat('exporting BCF…');
   try {
@@ -2117,7 +2117,80 @@ bBcf.onclick = () => {
     setStat('BCF exported  topic=' + r.topicGuid.slice(0, 8) + '  components=' + r.components.length + '  ' + r.bytes.length + ' bytes (downloaded)');
     audioCue('export');
   } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§BCF export fail ' + err); }
+}
+// NATIVE .db EXPORT — the FULL-fidelity artifact (signed op-log + hash chain; IFC/BCF are lossy
+// translations). Same writer _persistToIdb uses (sealChain → db.export().buffer — kernel_ops.js),
+// same download idiom as bonsai_ifc.js/bcf_export.js. opts.download===false returns bytes only
+// (the witness seam, mirroring ifc.exportModel). Re-opens via #b-open ▸ "Open local .db…".
+window.Bonsai.exportDb = async function (opts) {
+  const O = window.Bonsai.oplog;
+  if (!O || !O.db || O.length === 0) { setStat('author something first'); return null; }
+  const seal = await window.KernelOps.sealChain(O.db);   // the seal _persistToIdb does — never skipped
+  const bytes = O.db.export();                           // same native writer as kernel_ops _persistToIdb
+  console.log('§EXPORT-NATIVE ops=' + O.length + ' sealed=' + seal.sealed + ' tip=' + seal.tip.slice(0, 12) + ' bytes=' + bytes.length);
+  if (!opts || opts.download !== false) {
+    try {
+      const blob = new Blob([bytes], { type: 'application/octet-stream' });   // same download idiom as bonsai_ifc.js
+      const a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+      a.download = (window.__dwName || 'model') + '.db'; document.body.appendChild(a); a.click();
+      setTimeout(() => { URL.revokeObjectURL(a.href); a.remove(); }, 1000);
+    } catch (e) { console.warn('§EXPORT-NATIVE download failed ' + e); }
+  }
+  return { bytes, sealed: seal.sealed, tip: seal.tip };
 };
+async function doDbExport() {
+  setStat('exporting .db…');
+  try {
+    const r = await window.Bonsai.exportDb();
+    if (r) { setStat('.db exported  ops=' + window.Bonsai.oplog.length + '  tip=' + r.tip.slice(0, 8) + '  ' + r.bytes.length + ' bytes (downloaded)'); audioCue('export'); }
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§EXPORT-NATIVE fail ' + err); }
+}
+// The chooser — the SAME small-panel idiom as initOpenChooser's #m-open-panel (build/close/outside-click).
+(function initExportMenu() {
+  const bExport = document.getElementById('b-export');
+  if (!bExport) return;
+  const ITEMS = [
+    { key: 'native', icon: '⛁', label: 'Native .db', sub: 'full fidelity — the signed op-log', run: doDbExport },
+    { key: 'ifc', icon: '⬇', label: 'IFC (IFC4)', sub: 'geometry translation via web-ifc', run: doIfcExport },
+    { key: 'bcf', icon: '⚑', label: 'BCF issue (.bcfzip)', sub: 'current view + selection', run: doBcfExport }
+  ];
+  let panel = null;
+  function build() {
+    panel = document.createElement('div'); panel.id = 'm-export-panel';
+    panel.style.cssText = 'position:fixed;bottom:74px;right:70px;z-index:41;width:248px;display:none;padding:10px;' +
+      'background:rgba(20,22,30,0.94);border:1px solid #2c303a;border-radius:12px;color:#c7cdd8;' +
+      'font:12px system-ui,sans-serif;backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);' +
+      'box-shadow:0 8px 30px rgba(0,0,0,0.5)';
+    let h = '<div style="font-size:10px;letter-spacing:.14em;color:#5b6473;margin:2px 4px 8px">EXPORT</div>';
+    ITEMS.forEach(function (it) {
+      h += '<div class="me-row" data-key="' + it.key + '" style="display:flex;align-items:center;gap:9px;padding:7px 8px;' +
+        'border-radius:8px;cursor:pointer"><span style="width:20px;text-align:center">' + it.icon + '</span>' +
+        '<span>' + it.label + '<br><span style="color:#5b6473;font-size:10.5px">' + it.sub + '</span></span></div>';
+    });
+    panel.innerHTML = h;
+    document.body.appendChild(panel);
+    panel.querySelectorAll('.me-row').forEach(function (d) {
+      d.onmouseover = function () { d.style.background = '#23262e'; };
+      d.onmouseout = function () { d.style.background = 'transparent'; };
+      d.onclick = function () {
+        const it = ITEMS.filter(function (x) { return x.key === d.getAttribute('data-key'); })[0];
+        close();
+        if (it) { console.log('§EXPORT-MENU pick=' + it.key); it.run(); }
+      };
+    });
+  }
+  function close() { if (panel) panel.style.display = 'none'; bExport.classList.remove('on'); }
+  bExport.onclick = function (e) {
+    e.stopPropagation();
+    if (!panel) build();
+    const open = panel.style.display !== 'block';
+    panel.style.display = open ? 'block' : 'none'; bExport.classList.toggle('on', open);
+    console.log('§EXPORT-MENU open=' + open + ' items=' + ITEMS.length);
+  };
+  document.addEventListener('pointerdown', function (e) {
+    if (panel && panel.style.display === 'block' && !panel.contains(e.target) && !bExport.contains(e.target)) close();
+  });
+})();
 
 // ── INSERT LIBRARY COMPONENT (§OOTB Item 2: assemble, don't draw) ───────────────────────────────
 // A picked catalog component is placed on the grid as ONE signed GEOM_INSERT op-row; geometry folds
@@ -2532,7 +2605,7 @@ window.addEventListener('keydown', (e) => {
   else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedId != null && !sketching && !routing) { e.preventDefault(); deleteSelected(); }
 });
 
-bClear.disabled = bSketch.disabled = bIfc.disabled = bBcf.disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = false;
+bClear.disabled = bSketch.disabled = document.getElementById('b-export').disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = false;
 window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
 // Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
 // NOTE: the modeller's Outliner is an AUTHORING tree only — it deliberately carries NO 4D/5D info; that is the
@@ -3542,7 +3615,7 @@ window.__ensureDiscWalker = async function () {
     ['3D Grid', 'The grid is the primary handle. Grid shows/hides the datums; Move Grid drags a gridline so attached walls RECOMPOSE — stretch, not scale (openings stay host-constrained).'],
     ['Author', 'Sketch a profile, Insert a catalog component (assemble, don\'t draw), Cut an opening, Route an MEP run, Fillet an edge. Every edit is one signed op in the log.'],
     ['History', 'Scrub the bottom timeline to fold the model to any point; Ctrl+Z / Ctrl+⇧Z undo/redo. Geometry is a deterministic fold over the signed op-log.'],
-    ['Save / Export', 'Your edits auto-save to the signed op-log (restored on your next visit, per building). IFC exports a standards IFC4 file from the same log.']
+    ['Save / Export', 'Your edits auto-save to the signed op-log (restored on your next visit, per building). Pill ▸ Export offers Native .db (the full-fidelity signed op-log — re-opens via Open ▸ local .db), IFC4, or a BCF 2.1 issue.']
   ];
   let panel = null;
   function build() {

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -118,6 +118,19 @@
     if (!window.SQL) { console.warn(TAG + ' sql.js not ready'); return false; }
     try {
       var db = new window.SQL.Database(new Uint8Array(buf));
+      // §EXPORT-NATIVE (prompts/EXPORT_MENU_NATIVE_DB.md — Witness: W-E2E-EXPORT-DB): a NATIVE op-log .db
+      // (Export ▸ Native .db) carries a kernel_ops table — no resident/substrate .db does (probed all 8,
+      // 2026-07-03). Route it to the op-log import (the symmetric read of the export) instead of the
+      // walker; every building-substrate .db falls through byte-identically to the path below.
+      var isNative = false;
+      try { isNative = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='kernel_ops'").length > 0; } catch (e) { }
+      if (isNative) {
+        db.close();
+        console.log(TAG + ' §EXPORT-NATIVE "' + name + '" is a native op-log .db → oplog import');
+        var O = window.Bonsai && window.Bonsai.oplog;
+        if (O && O.importBytes) { O.importBytes(new Uint8Array(buf)); return true; }
+        console.warn(TAG + ' §EXPORT-NATIVE oplog.importBytes unavailable — cannot open'); return false;
+      }
       // Stash the open buffer + name so the disc-walker (DiscWalker.dwWalk) can re-open this building
       // read-only on a discipline click (this db is closed below after seeding). NON-INVENT substrate.
       window.__dwBuf = buf; window.__dwName = name;

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v31';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v32';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/bonsai_ifc_live.js
+++ b/modeller/tests/bonsai_ifc_live.js
@@ -5,7 +5,7 @@
 // exported bytes and confirm the wall/opening/voids-relation counts AND the wall's profile polygon +
 // extrude depth round-trip exactly. Completes author -> sign -> export (W-KERNEL-WEBIFC, now in-viewer).
 const http = require('http'), fs = require('fs'), path = require('path');
-const VIEWER = path.join('/tmp/wt-bonsai', 'viewer');
+const VIEWER = path.join(__dirname, '..');   // serve THIS tree's modeller/ (was a stale hardcoded /tmp/wt-bonsai path)
 const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
   '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };

--- a/modeller/tests/pill_declutter_live.js
+++ b/modeller/tests/pill_declutter_live.js
@@ -26,8 +26,11 @@ const server = http.createServer((q, r) => {
   const r = await pg.evaluate(async () => {
     const out = {}; const O = window.Bonsai.oplog, L = window.Bonsai.library;
     const has = id => !!document.getElementById(id);
-    out.removed = { wall: has('b-wall'), open: has('b-open'), undo: has('b-undo'), redo: has('b-redo') };  // all should be false
-    out.survivors = { del: has('b-del'), insert: has('b-insert'), clear: has('b-clear'), ifc: has('b-ifc') };  // all true
+    // NOTE (2026-07-03): the old "Opening" pill's id `b-open` was legitimately RE-USED by the shipped
+    // Open-a-building chooser (W-UX-1, RESUME_MODELLER_UX_OUTLINER_PILL) — so `b-open` existing is now
+    // CORRECT, not clutter. The stale `open:false` expectation kept this witness red on main for months.
+    out.removed = { wall: has('b-wall'), undo: has('b-undo'), redo: has('b-redo') };  // all should be false
+    out.survivors = { del: has('b-del'), insert: has('b-insert'), clear: has('b-clear'), exp: has('b-export'), open: has('b-open') };  // all true (#b-export = the one Export menu, ex #b-ifc/#b-bcf; #b-open = the W-UX-1 chooser)
     // functional Ctrl+Z: commit one insert via the real path, then fire the keyboard verb → active length drops
     O.clear();
     const hash = L.catalog().find(c => c.ifc_class === 'IfcDoor').hash;
@@ -54,7 +57,8 @@ const server = http.createServer((q, r) => {
   const checks = {
     noPageError:   pageErr === null,
     wallGone:      r.removed.wall === false,
-    openGone:      r.removed.open === false,
+    openKept:      r.survivors.open === true,      // b-open now = the W-UX-1 Open chooser (see NOTE above)
+    exportKept:    r.survivors.exp === true,       // the ONE Export menu pill (ex #b-ifc/#b-bcf)
     undoBtnGone:   r.removed.undo === false,
     redoBtnGone:   r.removed.redo === false,
     delKept:       r.survivors.del === true,

--- a/modeller/tests/witness_e2e_bcf.js
+++ b/modeller/tests/witness_e2e_bcf.js
@@ -85,8 +85,10 @@ runE2E('W-E2E-BCF', async (t) => {
   const magic = png.length > 8 && png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4E && png[3] === 0x47;
   t.assert('B5 SNAPSHOT (PNG magic, >1KB rendered frame)', magic && png.length > 1024, 'bytes=' + png.length);
 
-  // B6 — the real toolbar button drives the same path
-  await t.clickSel('#b-bcf'); await t.sleep(600);
+  // B6 — the real toolbar path drives the same export: Export pill ▸ BCF menu row (the flat #b-bcf
+  // button was consolidated into the #b-export menu — prompts/EXPORT_MENU_NATIVE_DB.md; handler unchanged).
+  await t.clickSel('#b-export'); await t.sleep(250);
+  await t.clickSel('#m-export-panel .me-row[data-key="bcf"]'); await t.sleep(600);
   const stat = await t.pg.evaluate(() => document.getElementById('stat').textContent);
-  t.assert('B6 BUTTON (#b-bcf → "BCF exported" in #stat)', /BCF exported/.test(stat), 'stat="' + stat.slice(0, 70) + '"');
+  t.assert('B6 BUTTON (#b-export ▸ BCF → "BCF exported" in #stat)', /BCF exported/.test(stat), 'stat="' + stat.slice(0, 70) + '"');
 }, { width: 1200, height: 850, dpr: 1 });

--- a/modeller/tests/witness_e2e_export_db.js
+++ b/modeller/tests/witness_e2e_export_db.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-EXPORT-DB: witness for the Export menu + native .db export
+ * (prompts/EXPORT_MENU_NATIVE_DB.md — Item 6, FABLE5_WRAPUP_2026-07-03). Read the log after every run.
+ *
+ * ISSUE IT PROVES: #b-open loaded a local .db but there was NO symmetric save — the only writer of the
+ * native format (sealChain → db.export().buffer) was kernel_ops' IndexedDB auto-persist. Only the two
+ * LOSSY translations (IFC, BCF) had toolbar buttons. This proves the ONE Export menu ships the
+ * FULL-fidelity native .db out of the app and back IN through the same door #b-open uses, losslessly.
+ *
+ * CLAIMS:
+ *   E1 MENU        — #b-export in #bar + enabled; #b-ifc/#b-bcf GONE from the DOM; clicking opens
+ *                    #m-export-panel with exactly the 3 rows native/ifc/bcf.
+ *   E2 NATIVE ROW  — the real menu click (Export ▸ Native .db) runs the handler (#stat ".db exported",
+ *                    §EXPORT-NATIVE logged with sealed count + tip).
+ *   E3 CHAIN       — the exported bytes verify clean in a FRESH SQL.Database: KernelOps.verifyChain ok
+ *                    AND every row carries op_hash (the seal was NOT skipped).
+ *   E4 ROUND-TRIP  — the exported .db re-opens via the REAL #b-open ▸ "Open local .db…" file-chooser
+ *                    path; after re-open: op count, chain tip and folded mesh census reproduce, and a
+ *                    re-export is BYTE-IDENTICAL (sha256(b1) == sha256(b2)) — same standard as the IFC
+ *                    re-import check (modeller.html ?ifc=demo).
+ *   E5 IFC ROW     — Export ▸ IFC drives the UNCHANGED exportModel handler (#stat "IFC exported").
+ *                    (Export ▸ BCF is proven by W-E2E-BCF B6, updated to the menu path.)
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+const crypto = require('crypto');
+const fs = require('fs'), path = require('path'), os = require('os');
+
+runE2E('W-E2E-EXPORT-DB', async (t) => {
+  await t.open('Duplex');
+
+  // settle: the ARC seed group commits shortly after open — wait until the op-log length is stable.
+  let len = -1;
+  for (let i = 0; i < 40; i++) {
+    const l = await t.pg.evaluate(() => window.Bonsai.oplog.length);
+    if (l > 0 && l === len) break;
+    len = l; await t.sleep(500);
+  }
+  // one REAL authored op beyond the seed, so the round-trip carries a user edit too (pill_declutter idiom).
+  await t.pg.evaluate(async () => {
+    await window.Bonsai.library.ready();
+    const c = window.Bonsai.library.catalog().find(c => c.ifc_class === 'IfcDoor') || window.Bonsai.library.catalog()[0];
+    await window.Bonsai.oplog.commit({ op_type: 'GEOM_INSERT', parameters: { hash: c.hash, placement: { x: 1, y: 1, z: 0, rot: 0 }, lod: '200' } });
+  });
+  const lenBefore = await t.pg.evaluate(() => window.Bonsai.oplog.length);
+  console.log('  §EXPDB oplog settled ops=' + lenBefore);
+
+  // E1 — the ONE Export menu (and the old flat buttons are gone)
+  const ui0 = await t.pg.evaluate(() => ({
+    exp: (() => { const b = document.getElementById('b-export'); return b ? { inBar: !!b.closest('#bar'), disabled: b.disabled } : null; })(),
+    ifc: !!document.getElementById('b-ifc'), bcf: !!document.getElementById('b-bcf')
+  }));
+  await t.clickSel('#b-export'); await t.sleep(250);
+  const menu = await t.pg.evaluate(() => {
+    const p = document.getElementById('m-export-panel');
+    if (!p || p.style.display !== 'block') return { open: false };
+    return { open: true, rows: [].slice.call(p.querySelectorAll('.me-row')).map(d => d.getAttribute('data-key')) };
+  });
+  t.assert('E1 MENU (#b-export enabled in #bar, #b-ifc/#b-bcf GONE, 3 rows native/ifc/bcf)',
+    ui0.exp && ui0.exp.inBar && !ui0.exp.disabled && !ui0.ifc && !ui0.bcf &&
+    menu.open && JSON.stringify(menu.rows) === JSON.stringify(['native', 'ifc', 'bcf']),
+    'exp=' + JSON.stringify(ui0.exp) + ' oldBtns=' + ui0.ifc + '/' + ui0.bcf + ' rows=' + JSON.stringify(menu.rows));
+
+  // E2 — the real Native .db menu row runs the handler
+  await t.clickSel('#m-export-panel .me-row[data-key="native"]'); await t.sleep(900);
+  const stat2 = await t.pg.evaluate(() => document.getElementById('stat').textContent);
+  const nativeLog = t.slog.filter(l => /^§EXPORT-NATIVE ops=/.test(l)).pop() || '';
+  t.assert('E2 NATIVE ROW (menu click → ".db exported" + §EXPORT-NATIVE sealed log)',
+    /\.db exported/.test(stat2) && /sealed=\d+ tip=/.test(nativeLog),
+    'stat="' + stat2.slice(0, 60) + '" log="' + nativeLog.slice(0, 80) + '"');
+
+  // bytes b1 through the SAME function the row calls (download suppressed — the exportModel seam idiom)
+  const ex1 = await t.pg.evaluate(async () => {
+    const r = await window.Bonsai.exportDb({ download: false });
+    let b64 = ''; const u8 = r.bytes, CH = 32766;
+    for (let i = 0; i < u8.length; i += CH) b64 += btoa(String.fromCharCode.apply(null, u8.subarray(i, Math.min(i + CH, u8.length))));
+    return { b64, n: u8.length, tip: r.tip, sealed: r.sealed };
+  });
+  const b1 = Buffer.from(ex1.b64, 'base64');
+  const sha1 = crypto.createHash('sha256').update(b1).digest('hex');
+  console.log('  §EXPDB b1 bytes=' + ex1.n + ' sealed=' + ex1.sealed + ' tip=' + ex1.tip.slice(0, 12) + ' sha256=' + sha1.slice(0, 16));
+
+  // E3 — the exported BYTES verify clean in a fresh db (seal not skipped)
+  const chain = await t.pg.evaluate(async (b64) => {
+    const bin = atob(b64); const u8 = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+    const db = new window.SQL.Database(u8);
+    const v = await window.KernelOps.verifyChain(db);
+    const tot = db.exec('SELECT COUNT(*), COUNT(op_hash) FROM kernel_ops')[0].values[0];
+    db.close();
+    return { ok: !!(v && v.ok), len: v && v.len, rows: tot[0], sealedRows: tot[1] };
+  }, ex1.b64);
+  // rows = ALL kernel_ops rows (O.length counts only GEOM% ops — a superset check, every row sealed)
+  t.assert('E3 CHAIN (verifyChain green on the exported bytes, every row sealed)',
+    chain.ok && chain.rows >= lenBefore && chain.rows === chain.sealedRows,
+    'ok=' + chain.ok + ' rows=' + chain.rows + ' (geomOps=' + lenBefore + ') sealed=' + chain.sealedRows);
+
+  // E4 — ROUND-TRIP through the REAL #b-open ▸ "Open local .db…" file-chooser path.
+  // The model is CLEARED first so everything that comes back provably comes from the exported FILE.
+  const meshesBefore = await t.pg.evaluate(() => window.Bonsai.group().children.filter(o => o.isMesh && o.userData.featureId != null).length);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wexpdb-'));
+  const dbPath = path.join(dir, 'Duplex.db');
+  fs.writeFileSync(dbPath, b1);
+  const cleared = await t.pg.evaluate(() => { window.Bonsai.oplog.clear(); return { len: window.Bonsai.oplog.length, meshes: window.Bonsai.group().children.filter(o => o.isMesh && o.userData.featureId != null).length }; });
+  console.log('  §EXPDB cleared len=' + cleared.len + ' meshes=' + cleared.meshes + ' (scene provably rebuilt from the file next)');
+  await t.clickSel('#b-open'); await t.sleep(250);
+  const [chooser] = await Promise.all([
+    t.pg.waitForFileChooser({ timeout: 10000 }),
+    t.pg.click('#m-open-panel .mo-row[data-key="__local"]')
+  ]);
+  await chooser.accept([dbPath]);
+  await t.pg.waitForFunction((n) => window.Bonsai.oplog.length === n, { timeout: 30000 }, lenBefore).catch(() => {});
+  await t.sleep(1200);   // fold settles
+  const importLog = t.slog.filter(l => /§EXPORT-NATIVE imported/.test(l)).pop() || '';
+  const after = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    const r = await window.Bonsai.exportDb({ download: false });
+    let b64 = ''; const u8 = r.bytes, CH = 32766;
+    for (let i = 0; i < u8.length; i += CH) b64 += btoa(String.fromCharCode.apply(null, u8.subarray(i, Math.min(i + CH, u8.length))));
+    return { len: O.length, tip: r.tip, b64, n: u8.length,
+      meshes: window.Bonsai.group().children.filter(o => o.isMesh && o.userData.featureId != null).length };
+  });
+  const b2 = Buffer.from(after.b64, 'base64');
+  const sha2 = crypto.createHash('sha256').update(b2).digest('hex');
+  console.log('  §EXPDB round-trip len=' + after.len + '/' + lenBefore + ' tip=' + after.tip.slice(0, 12) +
+    ' meshes=' + after.meshes + '/' + meshesBefore + ' sha256(b2)=' + sha2.slice(0, 16) + ' importLog="' + importLog.slice(0, 90) + '"');
+  t.assert('E4 ROUND-TRIP (re-open via the real #b-open local door → ops+tip+mesh census reproduce, re-export BYTE-IDENTICAL)',
+    /verify=true/.test(importLog) && after.len === lenBefore && after.tip === ex1.tip &&
+    after.meshes === meshesBefore && sha1 === sha2 && b1.length === b2.length,
+    'len=' + after.len + '/' + lenBefore + ' tipEq=' + (after.tip === ex1.tip) + ' meshEq=' + (after.meshes === meshesBefore) +
+    ' bytes=' + b1.length + '/' + b2.length + ' shaEq=' + (sha1 === sha2));
+
+  // E5 — Export ▸ IFC re-triggers the UNCHANGED handler
+  await t.clickSel('#b-export'); await t.sleep(250);
+  await t.clickSel('#m-export-panel .me-row[data-key="ifc"]');
+  await t.pg.waitForFunction(() => /IFC exported|FAIL/.test(document.getElementById('stat').textContent), { timeout: 60000 }).catch(() => {});
+  const stat5 = await t.pg.evaluate(() => document.getElementById('stat').textContent);
+  t.assert('E5 IFC ROW (menu click → "IFC exported" via the unchanged exportModel handler)',
+    /IFC exported/.test(stat5), 'stat="' + stat5.slice(0, 70) + '"');
+}, { width: 1200, height: 850, dpr: 1 });

--- a/modeller/tests/witness_modeller_pill_verbs.js
+++ b/modeller/tests/witness_modeller_pill_verbs.js
@@ -3,7 +3,7 @@
  * W-UX-VERBS — headless witness for the pill-rail verbs (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-5).
  *   • UserGuide  — NEW pill #b-guide opens a self-contained modeller guide overlay (the gap this slice fills)
  *   • 3D Grid    — #b-grid pill is present + enabled; clicking toggles the grid datums (already shipped)
- *   • Export/IFC — #b-ifc pill present + enabled (the export verb, already shipped)
+ *   • Export — #b-export pill present + enabled (the ONE export menu: Native .db / IFC / BCF)
  *   • History    — the #hist-slider timeline surface is present (already shipped)
  * Every #bar button auto-joins the rail + the ? help registry, so these are all discoverable pills.
  * Pure-UI wiring gate; serves viewer/ only (no building DB needed).
@@ -51,12 +51,12 @@ function serve() {
 
   var present = await page.evaluate(function () {
     function btn(id) { var b = document.getElementById(id); return b ? { exists: true, disabled: b.disabled, inBar: b.closest('#bar') != null } : { exists: false }; }
-    return { guide: btn('b-guide'), grid: btn('b-grid'), ifc: btn('b-ifc'), open: btn('b-open'),
+    return { guide: btn('b-guide'), grid: btn('b-grid'), exp: btn('b-export'), open: btn('b-open'),
       hist: !!document.getElementById('hist-slider') };
   });
   chk('D1 UserGuide pill #b-guide present in the rail', present.guide.exists && present.guide.inBar);
   chk('D2 3D Grid pill #b-grid present + enabled', present.grid.exists && present.grid.inBar && !present.grid.disabled, 'disabled=' + present.grid.disabled);
-  chk('D3 Export/IFC pill #b-ifc present + enabled', present.ifc.exists && present.ifc.inBar && !present.ifc.disabled, 'disabled=' + present.ifc.disabled);
+  chk('D3 Export pill #b-export present + enabled (the one Export menu, ex #b-ifc/#b-bcf)', present.exp.exists && present.exp.inBar && !present.exp.disabled, 'disabled=' + present.exp.disabled);
   chk('D4 History timeline (#hist-slider) present', present.hist);
 
   // UserGuide overlay opens with the real sections

--- a/prompts/EXPORT_MENU_NATIVE_DB.md
+++ b/prompts/EXPORT_MENU_NATIVE_DB.md
@@ -1,0 +1,44 @@
+# ⚠ DO NOT REMOVE — SPEC: Export menu + native .db export (Item 6, FABLE5_WRAPUP_2026-07-03)
+# Scope: modeller ONLY (modeller.html + bonsai_oplog.js + str_walker_outliner.js + sw.js + tests).
+# Read the log after every run — exit code is not evidence.
+
+## Problem
+`#b-open` loads a local `.db`, but there is NO symmetric save/export of the native format. The only
+writer of the native format is `kernel_ops.js` `_persistToIdb` (`sealChain` → `db.export().buffer`),
+wired only into auto-persist. Native `.db` (signed op-log, hash chain) is the only FULL-fidelity
+artifact of an authoring session; IFC (`#b-ifc`) and BCF (`#b-bcf`) are lossy translations — yet only
+the lossy two had toolbar buttons, as two flat pills.
+
+## Decision (locked by user+watchdog 2026-07-03 — do not re-litigate)
+ONE "Export" toolbar pill (`#b-export`) replaces `#b-ifc` + `#b-bcf`, opening a small chooser menu
+(REUSING the `#m-open-panel` chooser idiom from `initOpenChooser` — same builder/close/outside-click
+pattern, id `#m-export-panel`, rows `.me-row`) with three items:
+
+1. **Native .db** — NEW: `window.Bonsai.exportDb(opts)` — `KernelOps.sealChain(O.db)` (the same seal
+   `_persistToIdb` does — never skipped) → `O.db.export()` → Blob → `<building-name>.db` via the
+   existing ObjectURL/a.download idiom (bonsai_ifc.js / bcf_export.js — no new mechanism).
+   `opts.download===false` returns bytes without the download (witness seam, mirrors `exportModel`).
+2. **IFC** — the EXISTING `bIfc` handler body unchanged (`window.Bonsai.ifc.exportModel`), menu-triggered.
+3. **BCF** — the EXISTING `exportBcf({})` handler body unchanged, menu-triggered.
+
+The standalone `#b-ifc` / `#b-bcf` buttons are REMOVED (not hidden) once reachable from the menu.
+
+## Symmetric read (required for round-trip)
+The exported native `.db` must re-open through the SAME code path `#b-open` uses (`_openBuffer`).
+A native op-log `.db` is discriminated by its `kernel_ops` table — VERIFIED absent from all 8
+resident/rules `.db` files (probe 2026-07-03) — and routed to NEW `OpLog.importBytes(u8)`:
+close current db → open bytes → `ensureTable` → restore group counter (the `_ensureDb` idiom) →
+`verifyChain` → fold to tip → `_save()` → emit. Building-substrate `.db` files take the walker
+path byte-identically as before (additive branch, checked first, no change to their flow).
+
+## Witness contract (W-E2E-EXPORT-DB, modeller/tests/witness_e2e_export_db.js)
+(a) ROUND-TRIP — author real ops, export bytes b1, re-open b1 via the REAL `#b-open` ▸ "Open local
+    .db…" file-chooser path, re-export bytes b2: `sha256(b1) == sha256(b2)` (probe proved seal→
+    export→import→re-seal→export is byte-identical: same 16384 bytes, same tip) + op count + tip
+    hash + folded scene mesh census reproduce.
+(b) CHAIN — `KernelOps.verifyChain` over a FRESH `SQL.Database(b1)` is green (seal not skipped).
+(c) UI — `#b-export` menu exists with the 3 rows; `#b-ifc`/`#b-bcf` GONE from the DOM; the real
+    menu clicks drive the unchanged IFC/BCF handlers (#stat "IFC exported"/"BCF exported").
+PLUS: IFC + BCF bytes byte-identical main-vs-branch (fixed inputs, sha256), existing W-BONSAI-IFC
+re-import check + W-E2E-BCF re-run green (B6 updated to the menu path — the old button is gone by
+design; B1–B5 assertions untouched).


### PR DESCRIPTION
Item 6 of bim-compiler `prompts/FABLE5_WRAPUP_2026-07-03.md` (decision locked by user+watchdog 2026-07-03). Spec: `prompts/EXPORT_MENU_NATIVE_DB.md` (this PR).

## What
- **ONE `#b-export` toolbar pill** replaces the two flat `#b-ifc`/`#b-bcf` pills (both REMOVED from the DOM). The chooser reuses the exact `#m-open-panel` idiom from `initOpenChooser` (`#m-export-panel`, `.me-row`): **Native .db / IFC / BCF**.
- **Native .db (NEW)** — `Bonsai.exportDb`: `KernelOps.sealChain` (the same seal `_persistToIdb` does — never skipped) → op-log `db.export()` → Blob → `<building>.db` via the existing bonsai_ifc/bcf_export download idiom (no new mechanism). `{download:false}` returns bytes (witness seam, mirrors `exportModel`).
- **IFC / BCF** — existing handler bodies UNCHANGED, just menu-triggered.
- **Symmetric read** — `_openBuffer` (the same `#b-open` code path) routes a `kernel_ops`-bearing `.db` (no resident/substrate db carries that table — probed all 8) to new `OpLog.importBytes`: verifyChain → fold to tip → persist. Substrate `.db` flow untouched.
- `sw.js` v31→v32; script-tag cache busters bumped.

## Witness evidence (every claim § log-read)
| Witness | Result |
|---|---|
| **W-E2E-EXPORT-DB** (new, `modeller/tests/witness_e2e_export_db.js`) | **6/6 PASS** |
| W-E2E-BCF (B6 → menu path; B1–B5 untouched) | 7/7 PASS |
| W-BONSAI-IFC (`?ifc=demo` re-import check; stale `/tmp/wt-bonsai` path fixed) | PASS |
| W-UX-VERBS (D3 → `#b-export`) | 9/9 PASS |
| W-PILL-DECLUTTER (stale `openGone` expectation corrected — was red on main) | PASS |

**(a) Round-trip:** Duplex + 1 authored insert → export b1 (200704 B, `sha256 488e48ea…`, `tip 8d09213c1ec5`) → `O.clear()` → re-open b1 via the REAL `#b-open ▸ Open local .db…` file chooser → ops 254/254, tip equal, mesh census 254/254, re-export **byte-identical** (`sha256(b2) == sha256(b1)`).
**(b) Chain:** `verifyChain` green on the exported BYTES in a fresh `SQL.Database`; 254/254 rows sealed (`§EXPORT-NATIVE ops=254 sealed=254`).
**(c) IFC/BCF unchanged:** fixed-input captures main-vs-branch — BCF zip **raw byte-identical** (`sha256 837db24b…` both). IFC **identical after normalizing web-ifc's own `FILE_NAME` wall-clock timestamp** (`sha256 db58cc46…` both); that one field differs even between two runs on *unmodified main* (`28e19392…` vs `15180f57…`) — inherent to the format writer, not this change.

## Deviations
- `witness_e2e_bcf.js` B6 and the two pill witnesses updated to the new real user path (`#b-ifc`/`#b-bcf` removal is mandated by the locked decision); all value assertions untouched.
- `pill_declutter_live.js` was already red on origin/main (stale `openGone` — the `b-open` id was legitimately re-used by the shipped W-UX-1 Open chooser); expectation corrected, witness now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)