### PR TITLE
feat(erp): kernel T1 — PIN attribution as audit metadata, device key stays the signer (W-T1-ATTRIB)

### DIFF
--- a/erp/erp_attrib.js
+++ b/erp/erp_attrib.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// erp_attrib.js — T1 (employee attribution): PIN/login as AUDIT METADATA on the op, NOT a signing key.
+// Spec: bim-compiler prompts/FABLE5_WRAPUP_2026-07-03.md §Item 3 (user-locked 2026-07-03) +
+//       prompts/KERNEL_TIMEBOMB_AUDIT_2026-07-03.md §T1 (the employee-attribution sub-gap).
+// Witness: W-T1-ATTRIB (teams/tests/poc_teams_t1_attrib.js).
+//
+// The device already holds the REAL cryptographic identity (#630: erp_key_epochs HQ-signed roster —
+// the device key signs every op). What was still open is EMPLOYEE-grain attribution: `actor` was a
+// self-minted localStorage tag and maker-checker compared self-asserted name strings — two typed
+// names defeated four-eyes. This module closes that WITHOUT re-opening multi-signer key management:
+//   • the employee identifies at ACTION time (PIN) against an ORG-SUPPLIED directory — NON-INVENT:
+//     an unknown PIN resolves to null (refused), never a guessed identity;
+//   • the resolved identity is recorded ALONGSIDE the op (rich parameters `attrib` / cosign
+//     params.attrib) — content-signed BY THE DEVICE KEY, so attribution cannot be rewritten after
+//     the fact without breaking the signature;
+//   • the signature chain is UNCHANGED — still one device key, zero per-PIN keys (W-T1-ATTRIB §d).
+// PINs are never stored, transported, or logged raw: the directory holds sha256(pin) only.
+(function () {
+  'use strict';
+  var subtle = (typeof crypto !== 'undefined' && crypto.subtle) ? crypto.subtle : null;
+
+  function _hex(buf) {
+    return Array.from(new Uint8Array(buf)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+  }
+
+  // hashPin(pin) -> Promise<sha256 hex>. The ONLY form a PIN ever takes at rest or in a directory.
+  function hashPin(pin) {
+    if (!subtle) return Promise.reject(new Error('erp_attrib: crypto.subtle unavailable'));
+    if (typeof pin !== 'string' || pin.length === 0) return Promise.reject(new Error('erp_attrib: empty PIN'));
+    return subtle.digest('SHA-256', new TextEncoder().encode('erpattrib1|' + pin)).then(_hex);
+  }
+
+  // makeDirectory(entries) — entries = [{ empId, name, pinHash }] (ORG-supplied roster of employees).
+  // Returns { <pinHash>: {emp, name} }. Deterministic + strict: a duplicate pinHash is AMBIGUOUS
+  // identity and throws (two employees may not share a PIN); empId must be a plain token.
+  function makeDirectory(entries) {
+    var dir = {};
+    (entries || []).forEach(function (e) {
+      if (!e || typeof e.empId !== 'string' || !/^[\w.@-]+$/.test(e.empId)) throw new Error('erp_attrib: bad empId');
+      if (typeof e.pinHash !== 'string' || !/^[0-9a-f]{64}$/.test(e.pinHash)) throw new Error('erp_attrib: bad pinHash for ' + e.empId);
+      if (dir[e.pinHash]) throw new Error('erp_attrib: duplicate PIN (ambiguous identity: ' + dir[e.pinHash].emp + ' vs ' + e.empId + ')');
+      dir[e.pinHash] = { emp: e.empId, name: e.name != null ? String(e.name) : e.empId };
+    });
+    return dir;
+  }
+
+  // identify(pin, directory) -> Promise<{emp, name, m:'pin'} | null>. NON-INVENT: null when unknown.
+  function identify(pin, directory) {
+    return hashPin(pin).then(function (h) {
+      var hit = directory && directory[h];
+      return hit ? { emp: hit.emp, name: hit.name, m: 'pin' } : null;
+    });
+  }
+
+  // attrib(identity, deviceActor) — the metadata object recorded on ops: WHO (employee, from PIN)
+  // on WHICH device (the signing identity's actor tag). Both are recorded INPUTS, never derived.
+  function attrib(identity, deviceActor) {
+    if (!identity || !identity.emp) throw new Error('erp_attrib: no identity');
+    return { emp: identity.emp, name: identity.name, m: identity.m || 'pin', dev: String(deviceActor || '') };
+  }
+
+  var API = { hashPin: hashPin, makeDirectory: makeDirectory, identify: identify, attrib: attrib };
+  if (typeof window !== 'undefined') window.ErpAttrib = API;   // window-only, like kernel_ops.js/erp_signer.js
+  console.log('§T1_ATTRIB_LOADED erp_attrib.js (PIN → audit metadata; device key still the only signer)');
+})();

--- a/erp/erp_kernel.js
+++ b/erp/erp_kernel.js
@@ -190,6 +190,10 @@ function apply(db, ops, ctx) {
     var res = applyOne(db, op, state);
     // RICH op (§0.6 keystone): payload (now carrying the recorded uuid) + actor + before/after + lineage GUIDs.
     var rich = { payload: op, actor: actor, before: res.before, after: res.after, lineage: { input_guids: res.input_guids, output_guid: res.output_guid } };
+    // T1 (W-T1-ATTRIB, FABLE5_WRAPUP §3): employee attribution rides the CONTENT-SIGNED parameters as
+    // audit metadata — user_tag stays the device actor (owner-gate grain unchanged), the sig stays the
+    // device key. Conditional: absent ctx.attrib → byte-identical rich op (back-compat, default-off).
+    if (ctx.attrib) rich.attrib = ctx.attrib;
     db.run('INSERT INTO kernel_ops (op_uuid, timestamp, op_type, parameters, input_guids, output_guid, user_tag) VALUES (?,?,?,?,?,?,?)',
       [op.op_uuid, ts + gseq, op.op_type, JSON.stringify(rich), JSON.stringify(res.input_guids), res.output_guid, actor]);
     committed++; ids.push(res.output_guid);

--- a/erp/erp_seam.js
+++ b/erp/erp_seam.js
@@ -138,7 +138,8 @@ function makeSeam(cfg) {
     }
     // (c) apply through the kernel (state-machine legal → handler → kernel-owned write).
     var cellCtx = { wfmc: wfmc, guards: [], query: function (s, p) { return projQ(projDb, s, p); },
-                    actor: ctx.actor || 'local', baseTs: intent.baseTs || 5000 };
+                    actor: ctx.actor || 'local', baseTs: intent.baseTs || 5000,
+                    attrib: ctx.attrib || null };   // T1: employee PIN attribution → rich op (audit metadata)
     var doc = {}; Object.keys(intent).forEach(function (k) { doc[k] = intent[k]; });
     var r = K.dispatch(projDb, cellCtx, doc);
     if (!r.ok) return { rejected: true, why: r.stage + ':' + r.reason };

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -534,6 +534,8 @@
   catch (e) { console.warn('§OP_UPCASTER install failed', e); }
 </script>
 <script src="erp_signer.js?v=1"></script>
+<!-- T1 (W-T1-ATTRIB): PIN → employee attribution as audit metadata; device key stays the only signer. -->
+<script src="erp_attrib.js?v=1"></script>
 <script src="erp_kernel.js?v=1"></script>
 <script src="erp_seam.js?v=1"></script>
 <script src="kanban_lens.js?v=4"></script>

--- a/erp/kanban_host.js
+++ b/erp/kanban_host.js
@@ -92,6 +92,23 @@
       chainVerify: function () { return global.KernelOps.verifyChain(projDb); }          // {ok,len,tip} incl. sig
     };
     log('§SEAM-LIVE window.ERP published: dispatch,verify,seal,chainVerify · actor=' + ctx.actor + ' grants=' + grants.length + ' pubKey=' + (ctx.pubKey ? 'Y' : 'none'));
+    // T1 (W-T1-ATTRIB, FABLE5_WRAPUP §3): PIN → employee attribution as AUDIT METADATA. cfg.attribDirectory
+    // is the ORG-supplied {sha256(pin) → {emp,name}} map (ErpAttrib.makeDirectory). Identity rides ctx.attrib
+    // → rich op parameters (content-signed by the DEVICE key — no per-PIN keys, no new trust root). No
+    // directory / unknown PIN → REFUSED, never guessed (non-invent). Default-off: nothing changes till used.
+    ctx.attrib = null;
+    global.ERP.identify = function (pin) {
+      var A = global.ErpAttrib;
+      if (!A) { log('§T1_ATTRIB REFUSED — erp_attrib.js not loaded'); return Promise.resolve({ ok: false, why: 'erp_attrib.js not loaded' }); }
+      if (!cfg.attribDirectory) { log('§T1_ATTRIB REFUSED — no attribDirectory supplied'); return Promise.resolve({ ok: false, why: 'no attribDirectory' }); }
+      return A.identify(pin, cfg.attribDirectory).then(function (id) {
+        if (!id) { log('§T1_ATTRIB REFUSED — unknown PIN (identity never guessed)'); return { ok: false, why: 'unknown PIN' }; }
+        ctx.attrib = A.attrib(id, ctx.actor);
+        log('§T1_ATTRIB identified emp=' + id.emp + ' dev=' + ctx.actor + ' (metadata only — device key still signs)');
+        return { ok: true, emp: id.emp, name: id.name };
+      });
+    };
+    global.ERP.identifyClear = function () { ctx.attrib = null; log('§T1_ATTRIB cleared'); };
     return { projDb: projDb, ctx: ctx };
   }
 

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v760';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v761';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -48,6 +48,7 @@ const PRECACHE_ASSETS = [
   'erp_replay.js',
   'erp_search.js',
   'erp_signer.js',
+  'erp_attrib.js',     // T1 (W-T1-ATTRIB): PIN → audit-metadata attribution (device key stays the signer)
   '../common/about_diy.js',  // ABOUT_BOX_CONSOLIDATE.md — shared About/DIY modal (replaces migrate_showme.js here)
   'migrate_agent.js',
   'overlay_kit.js',    // CONSISTENCY_FINISH.md §K-1 — shared import-overlay toolbox (window.OverlayKit)

--- a/teams/erp/cosign.js
+++ b/teams/erp/cosign.js
@@ -49,6 +49,7 @@ function submit(log, args) {
   var op = _op(args.id, args.ts, args.author, args.role, 'SUBMIT', args.doc,
     { group: group, amount: args.amount, legal: args.legal != null ? args.legal : '',
       to: 'Submitted', fields: args.fields });
+  if (args.attrib) op.params.attrib = args.attrib;   // T1: {emp, dev} PIN attribution — signed with the op
   return { ok: true, log: _append(log, op), op: op, group: group };
 }
 
@@ -59,6 +60,7 @@ function approve(log, args) {
   var op = _op(args.id, args.ts, args.author, args.role, 'APPROVE', args.doc,
     { group: args.group != null ? args.group : args.doc, legal: args.legal != null ? args.legal : '',
       to: 'Approved' });
+  if (args.attrib) op.params.attrib = args.attrib;   // T1: {emp, dev} PIN attribution — signed with the op
   return { ok: true, log: _append(log, op), op: op };
 }
 
@@ -95,12 +97,23 @@ function coSignState(ops, doc, opts) {
   var base = { doc: doc, maker: maker.author, group: group, amount: amount };
 
   // the binding checker: an APPROVE on the same group, after the maker, by a DIFFERENT eligible author.
-  var checker = null, sawSelf = false, sawIneligible = false;
+  // T1 (W-T1-ATTRIB, FABLE5_WRAPUP §3): attribution-aware four-eyes. When BOTH ops carry recorded PIN
+  // attribution (params.attrib = {emp, dev} — audit metadata, signed with the op), enforce at EMPLOYEE
+  // and DEVICE grain: same emp = self-approval even across devices/typed names; same dev = one keyboard
+  // typed both identities (the "two typed names" bypass the audit flagged). opts.attribRequired makes an
+  // UNATTRIBUTED op ineligible entirely (PIN-at-action-time policy). Absent attribution + no flag →
+  // behaviour identical to before (back-compat, W-COSIGN unchanged). NON-INVENT: never flips on a guess.
+  var mA = (maker.params || {}).attrib || null;
+  var checker = null, sawSelf = false, sawIneligible = false, sawSameDevice = false, sawUnattributed = false;
   approvals.forEach(function (op) {
     if (checker) return;
     if ((op.params || {}).group !== group) return;             // must bind THIS submission
     if (op.ts < maker.ts) return;                              // an approval can't precede its submission
-    if (op.author === maker.author) { sawSelf = true; return; }            // four-eyes breach
+    var cA = (op.params || {}).attrib || null;
+    if (opts.attribRequired && (!mA || !cA)) { sawUnattributed = true; return; }   // PIN identity mandatory
+    if (mA && cA && cA.emp === mA.emp) { sawSelf = true; return; }        // same employee (PIN) — four-eyes breach
+    if (mA && cA && cA.dev === mA.dev) { sawSameDevice = true; return; }  // same device typed both identities
+    if (op.author === maker.author) { sawSelf = true; return; }            // four-eyes breach (name grain)
     if (!eligible(op.author, op.role)) { sawIneligible = true; return; }    // not an eligible checker
     checker = op;
   });
@@ -111,6 +124,8 @@ function coSignState(ops, doc, opts) {
       reason: 'co-signed: ' + maker.author + ' → ' + checker.author });
   return Object.assign(base, { status: 'Submitted',
     reason: sawSelf ? 'REFUSE: self-approval (four-eyes)'
+      : sawSameDevice ? 'REFUSE: same device (four-eyes needs two devices)'
+      : sawUnattributed ? 'REFUSE: checker/maker unattributed (PIN identity required)'
       : sawIneligible ? 'REFUSE: checker not eligible'
       : 'awaiting checker' });
 }

--- a/teams/tests/poc_teams_t1_attrib.js
+++ b/teams/tests/poc_teams_t1_attrib.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-T1-ATTRIB (FABLE5_WRAPUP_2026-07-03 §Item 3 + KERNEL_TIMEBOMB_AUDIT §T1):
+//   PIN/login is AUDIT METADATA attached to the op — NOT a new signing key. The device key (#630
+//   roster) stays the only cryptographic identity; the employee PIN identity is recorded alongside
+//   the op (content-signed) and maker-checker enforces it at employee AND device grain.
+//     §ATTRIB-SAMEDEV  — (a) same-device, two DIFFERENT PINs maker/checker → REFUSED (one keyboard
+//                        typed both identities — the "two typed names" bypass, now dead).
+//     §ATTRIB-SAMEPIN  — (b) same PIN across two devices (typed names differ!) → REFUSED self-approval.
+//     §ATTRIB-LEGIT    — (c) different PIN + different device → Approved.
+//     §ATTRIB-REQUIRED — opts.attribRequired: an UNATTRIBUTED (typed-name-only) checker is ineligible.
+//     §ATTRIB-BACKCOMPAT— no attribution anywhere + no flag → coSignState behaves exactly as before.
+//     §ATTRIB-PIN      — ErpAttrib.identify: unknown PIN → null (non-invent), known PIN → directory row.
+//     §ATTRIB-CHAIN    — (d) REAL erp kernel: two different-PIN sessions on ONE device commit ops;
+//                        sealChain signs with the ONE device key; verifyChain green; a FOREIGN key
+//                        fails to verify those sigs (sigs bind the device key, not the PIN); the
+//                        rich parameters carry attrib.emp per session; user_tag stays device-grain;
+//                        an op committed with NO attribution carries NO attrib field (byte back-compat).
+//   Run: node teams/tests/poc_teams_t1_attrib.js 2>&1 | tee teams/logs/t1_attrib.log — then READ the log.
+'use strict';
+var path = require('path');
+if (!global.window) global.window = {};
+if (!global.crypto || !global.crypto.subtle) global.crypto = require('crypto').webcrypto;
+function reqSql() {
+  var tries = ['sql.js', '/home/red1/bim-ootb/node_modules/sql.js', path.join(__dirname, '..', '..', 'node_modules', 'sql.js')];
+  for (var i = 0; i < tries.length; i++) { try { return require(tries[i]); } catch (e) {} }
+  throw new Error('sql.js not resolvable');
+}
+var ERP = path.join(__dirname, '..', '..', 'erp');
+require(path.join(ERP, 'kernel_ops.js'));            // → window.KernelOps
+require(path.join(ERP, 'erp_attrib.js'));            // → window.ErpAttrib
+var KernelOps = global.window.KernelOps;
+var ErpAttrib = global.window.ErpAttrib;
+var ERPKernel = require(path.join(ERP, 'erp_kernel.js'));
+var X = require(path.join(__dirname, '..', 'erp', 'cosign.js'));
+var ErpSignerFactory = (function () {                 // erp_signer.js is window-only
+  require(path.join(ERP, 'erp_signer.js'));
+  return global.window.ErpSigner;
+})();
+
+var fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+(async function () {
+  console.log('\n═══ W-T1-ATTRIB — PIN identity = audit metadata on the op; device key stays the only signer ═══\n');
+  var T = 1000, eligible = function (a, r) { return r === 'Mgr' || r === 'Clerk'; };
+
+  // ── (a) §ATTRIB-SAMEDEV — two different PINs typed on ONE device: REFUSED. ──
+  var log1 = [];
+  log1 = X.submit(log1, { id: 's1', ts: T, author: 'alice', role: 'Clerk', doc: 'PO-1', amount: 9000,
+                          attrib: { emp: 'alice', dev: 'device:D1' } }).log;
+  log1 = X.approve(log1, { id: 'a1', ts: T + 1, author: 'bob', role: 'Mgr', doc: 'PO-1',
+                           attrib: { emp: 'bob', dev: 'device:D1' } }).log;
+  var st1 = X.coSignState(log1, 'PO-1', { eligible: eligible });
+  verdict(st1.status === 'Submitted' && /same device/.test(st1.reason),
+    '§ATTRIB-SAMEDEV two PINs, one device REFUSED', 'PO-1=' + st1.status + ' (' + st1.reason + ')');
+
+  // ── (b) §ATTRIB-SAMEPIN — same PIN identity across devices, typed names DIFFER: self-approval. ──
+  var log2 = [];
+  log2 = X.submit(log2, { id: 's2', ts: T, author: 'alice', role: 'Clerk', doc: 'PO-2', amount: 9000,
+                          attrib: { emp: 'alice', dev: 'device:D1' } }).log;
+  log2 = X.approve(log2, { id: 'a2', ts: T + 1, author: 'totally-not-alice', role: 'Mgr', doc: 'PO-2',
+                           attrib: { emp: 'alice', dev: 'device:D2' } }).log;
+  var st2 = X.coSignState(log2, 'PO-2', { eligible: eligible });
+  verdict(st2.status === 'Submitted' && /self-approval/.test(st2.reason),
+    '§ATTRIB-SAMEPIN same PIN, forged typed name REFUSED', 'PO-2=' + st2.status + ' (' + st2.reason + ')');
+
+  // ── (c) §ATTRIB-LEGIT — different PIN + different device: Approved. ──
+  var log3 = [];
+  log3 = X.submit(log3, { id: 's3', ts: T, author: 'alice', role: 'Clerk', doc: 'PO-3', amount: 9000,
+                          attrib: { emp: 'alice', dev: 'device:D1' } }).log;
+  log3 = X.approve(log3, { id: 'a3', ts: T + 1, author: 'bob', role: 'Mgr', doc: 'PO-3',
+                           attrib: { emp: 'bob', dev: 'device:D2' } }).log;
+  var st3 = X.coSignState(log3, 'PO-3', { eligible: eligible });
+  verdict(st3.status === 'Approved' && st3.checker === 'bob',
+    '§ATTRIB-LEGIT different PIN + device Approved', 'PO-3=' + st3.status + ' checker=' + st3.checker);
+
+  // ── §ATTRIB-REQUIRED — typed-name-only (no PIN) checker is ineligible under attribRequired. ──
+  var log4 = [];
+  log4 = X.submit(log4, { id: 's4', ts: T, author: 'alice', role: 'Clerk', doc: 'PO-4', amount: 9000,
+                          attrib: { emp: 'alice', dev: 'device:D1' } }).log;
+  log4 = X.approve(log4, { id: 'a4', ts: T + 1, author: 'bob', role: 'Mgr', doc: 'PO-4' }).log;  // no attrib
+  var st4 = X.coSignState(log4, 'PO-4', { eligible: eligible, attribRequired: true });
+  verdict(st4.status === 'Submitted' && /unattributed/.test(st4.reason),
+    '§ATTRIB-REQUIRED unattributed checker REFUSED', 'PO-4=' + st4.status + ' (' + st4.reason + ')');
+  var st4b = X.coSignState(log4, 'PO-4', { eligible: eligible });
+  verdict(st4b.status === 'Approved',
+    '§ATTRIB-REQUIRED same log passes WITHOUT the flag (policy is opt-in)', 'PO-4=' + st4b.status);
+
+  // ── §ATTRIB-BACKCOMPAT — zero attribution anywhere → pre-T1 behaviour byte-for-byte. ──
+  var log5 = [];
+  log5 = X.submit(log5, { id: 's5', ts: T, author: 'alice', role: 'Clerk', doc: 'PO-5', amount: 9000 }).log;
+  log5 = X.approve(log5, { id: 'a5', ts: T + 1, author: 'bob', role: 'Mgr', doc: 'PO-5' }).log;
+  var st5 = X.coSignState(log5, 'PO-5', { eligible: eligible });
+  verdict(st5.status === 'Approved' && st5.checker === 'bob',
+    '§ATTRIB-BACKCOMPAT unattributed log behaves as before', 'PO-5=' + st5.status);
+  verdict(!('attrib' in (log5[0].params || {})),
+    '§ATTRIB-BACKCOMPAT no attrib field minted when none given', 'params keys=' + Object.keys(log5[0].params).join(','));
+
+  // ── §ATTRIB-PIN — directory identify: known PIN resolves, unknown PIN → null (non-invent). ──
+  var dir = ErpAttrib.makeDirectory([
+    { empId: 'alice', name: 'Alice A', pinHash: await ErpAttrib.hashPin('1234') },
+    { empId: 'bob',   name: 'Bob B',   pinHash: await ErpAttrib.hashPin('5678') }
+  ]);
+  var idA = await ErpAttrib.identify('1234', dir);
+  var idZ = await ErpAttrib.identify('0000', dir);
+  verdict(idA && idA.emp === 'alice' && idA.m === 'pin', '§ATTRIB-PIN known PIN → directory identity', JSON.stringify(idA));
+  verdict(idZ === null, '§ATTRIB-PIN unknown PIN → null (never guessed)', 'got=' + JSON.stringify(idZ));
+  var dup = null;
+  try { ErpAttrib.makeDirectory([{ empId: 'x', pinHash: await ErpAttrib.hashPin('9') }, { empId: 'y', pinHash: await ErpAttrib.hashPin('9') }]); }
+  catch (e) { dup = e.message; }
+  verdict(!!dup && /duplicate PIN/.test(dup), '§ATTRIB-PIN duplicate PIN throws (ambiguous identity refused)', dup);
+
+  // ── (d) §ATTRIB-CHAIN — REAL kernel: attribution is metadata; the sig chain is the device key's. ──
+  var SQL = await reqSql()();
+  var db = new SQL.Database(); ERPKernel.initProjection(db);
+  var deviceKp = await ErpSignerFactory.mintKeypair();
+  var foreignKp = await ErpSignerFactory.mintKeypair();
+  KernelOps.setSigner(ErpSignerFactory.makeSigner(deviceKp));
+
+  // session 1: alice (PIN) on device:D1 — session 2: bob (PIN) on the SAME device, SAME key.
+  ERPKernel.apply(db, [{ op_type: 'CREATE_DOCUMENT', uuid: 'DOC:SO-1', table: 'C_Order', doc_status: 'DR' }],
+    { actor: 'device:D1', baseTs: 1000, attrib: { emp: 'alice', m: 'pin', dev: 'device:D1' } });
+  ERPKernel.apply(db, [{ op_type: 'SET_STATUS', uuid: 'DOC:SO-1', table: 'C_Order', id: 1, doc_status: 'CO' }],
+    { actor: 'device:D1', baseTs: 2000, attrib: { emp: 'bob', m: 'pin', dev: 'device:D1' } });
+  ERPKernel.apply(db, [{ op_type: 'CREATE_DOCUMENT', uuid: 'DOC:SO-2', table: 'C_Order', doc_status: 'DR' }],
+    { actor: 'device:D1', baseTs: 3000 });                       // NO attribution — back-compat row
+
+  await KernelOps.sealChain(db);
+  var v = await KernelOps.verifyChain(db);
+  verdict(v.ok === true, '§ATTRIB-CHAIN sealed chain verifies under the ONE device key', 'len=' + v.len + ' tip=' + String(v.tip).slice(0, 12) + '…');
+
+  var rows = db.exec('SELECT parameters, user_tag, sig FROM kernel_ops ORDER BY id')[0].values;
+  var p0 = JSON.parse(rows[0][0]), p1 = JSON.parse(rows[1][0]), p2 = JSON.parse(rows[2][0]);
+  verdict(p0.attrib && p0.attrib.emp === 'alice' && p1.attrib && p1.attrib.emp === 'bob',
+    '§ATTRIB-CHAIN rich params carry per-session PIN identity', 'op1.emp=' + (p0.attrib && p0.attrib.emp) + ' op2.emp=' + (p1.attrib && p1.attrib.emp));
+  verdict(!('attrib' in p2), '§ATTRIB-CHAIN unattributed op carries NO attrib field (byte back-compat)', 'keys=' + Object.keys(p2).join(','));
+  verdict(rows[0][1] === 'device:D1' && rows[1][1] === 'device:D1',
+    '§ATTRIB-CHAIN user_tag stays DEVICE-grain (owner-gate unchanged)', 'user_tag=' + rows[0][1] + ',' + rows[1][1]);
+  verdict(rows.every(function (r) { return r[2] && r[2].length > 0; }),
+    '§ATTRIB-CHAIN every op signed (device key present on all rows)');
+
+  // the sigs must bind the DEVICE key, not the PIN: a foreign key REFUSES to verify them.
+  KernelOps.setSigner(ErpSignerFactory.makeSigner(foreignKp));
+  var vf = await KernelOps.verifyChain(db);
+  verdict(vf.ok === false, '§ATTRIB-CHAIN a FOREIGN key fails sig-verify (sigs are the device key\'s, not per-PIN)',
+    'ok=' + vf.ok + ' why=' + (vf.why || vf.at || ''));
+  KernelOps.setSigner(null);
+
+  console.log('\n' + (fails === 0 ? '✅ W-T1-ATTRIB ALL PASS' : '❌ W-T1-ATTRIB ' + fails + ' FAIL') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.log('🔴 W-T1-ATTRIB CRASH: ' + (e && e.stack || e)); process.exit(1); });


### PR DESCRIPTION
## Summary
FABLE5_WRAPUP_2026-07-03 §Item 3. Closes the T1 employee-attribution gap (audit: two typed names defeated maker-checker) WITHOUT re-opening multi-signer key management (#630's roster/device key untouched):
- Employee identifies at action time (PIN vs an org-supplied sha256 directory — unknown PIN refused, never guessed); identity recorded ALONGSIDE the op in the content-signed rich parameters (`attrib`), so it cannot be re-attributed without breaking the device signature.
- `user_tag` stays device-grain (owner-gate unchanged); signature chain unchanged — no per-PIN keys.
- Maker-checker upgraded: same-PIN (self-approval, even with a forged typed name) and same-DEVICE (two PINs on one keyboard) both refused; `attribRequired` policy makes unattributed checkers ineligible. Default-off: unattributed logs behave exactly as before.

## Witness
- `node teams/tests/poc_teams_t1_attrib.js` → **W-T1-ATTRIB ALL PASS (16 🟢)**: §ATTRIB-SAMEDEV (a), §ATTRIB-SAMEPIN (b), §ATTRIB-LEGIT (c), §ATTRIB-CHAIN (d: one device key signs two PIN sessions; foreign key fails verify; back-compat op byte-identical), §ATTRIB-REQUIRED, §ATTRIB-BACKCOMPAT, §ATTRIB-PIN.
- Full teams suite: **26/26 witness files PASS** incl. W-COSIGN 6/6 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)