### PR TITLE
feat(modeller): §I5 per-instance hide inside a single InstancedMesh (Item 5, W-E2E-INSTHIDE 14/14)

### DIFF
--- a/build/probe_frontmost.js
+++ b/build/probe_frontmost.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// # ⚠ DO NOT REMOVE — probe 3 (not a witness): WHO is frontmost at a walked ELEC instance's screen position
+// after the walk commit folds authored twins? For each sampled record: raycast frontmost object (authored
+// mesh w/ _dw op? instanced marker?), then pixel-change with (i) instance hidden, (ii) instance+twin hidden.
+// Read the log after the run; exit code is not evidence.
+'use strict';
+const { runE2E } = require('../modeller/tests/e2e_harness');
+runE2E('PROBE-FRONTMOST', async (t) => {
+  await t.open('Duplex');
+  await t.pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  await t.pg.waitForFunction(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    return !!(root && root.children.some(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC'));
+  }, { timeout: 30000 }).catch(() => {});
+  await t.sleep(3500);
+  const res = await t.pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+    const ims = root.children.filter(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC' && o.userData.dwSub)
+      .sort((a, b) => b.count - a.count);
+    const im = ims[0]; const sub = im.userData.dwSub; const W = window.__dwWalks.ELEC;
+    const cam = window.A.camera, ctl = window.A.controls, r = window.A.renderer;
+    const ops = window.Bonsai.oplog._geomOps();
+    function block(sx, sy) {
+      r.render(window.A.scene, window.A.camera);
+      const gl = r.getContext(); const cv = r.domElement; const rect = cv.getBoundingClientRect();
+      const bw = gl.drawingBufferWidth, bh = gl.drawingBufferHeight;
+      const gx = Math.round((sx - rect.left) * bw / rect.width), gy = Math.round(bh - (sy - rect.top) * bh / rect.height);
+      const px = new Uint8Array(24 * 24 * 4);
+      gl.readPixels(Math.max(0, gx - 12), Math.max(0, gy - 12), 24, 24, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      let h = 0; for (let k = 0; k < px.length; k++) h = (h * 31 + px[k]) >>> 0;
+      return h;
+    }
+    const rc = new window.THREE.Raycaster();
+    const out = [];
+    for (let i = 0; i < sub.length && out.length < 8; i += 17) {
+      const p = sub[i]; if (!p || p.gated || p.clash) continue;
+      const idx = W.indexOf(p); if (idx < 0) continue;
+      cam.position.set(p.x + 1.6, p.y - 1.6, p.z + 0.9); ctl.target.set(p.x, p.y, p.z); ctl.update();
+      const v = new window.THREE.Vector3(p.x, p.y, p.z).project(cam);
+      const cv = r.domElement, rect = cv.getBoundingClientRect();
+      const sx = (v.x * 0.5 + 0.5) * rect.width + rect.left, sy = (-v.y * 0.5 + 0.5) * rect.height + rect.top;
+      // raycast exactly like pickAt: visible group meshes + visible dwRoot instanced buckets
+      rc.setFromCamera(new window.THREE.Vector2(v.x, v.y), cam);
+      const list = g.children.filter(o => o.isMesh && o.visible)
+        .concat(root.children.filter(o => (o.isInstancedMesh || o.isMesh) && o.visible));
+      const hits = rc.intersectObjects(list, false);
+      const front = hits[0] || null;
+      let kind = 'none', fid = null, dw = null, sameRec = false, dist = null;
+      if (front) {
+        dist = +front.distance.toFixed(3);
+        if (front.object.isInstancedMesh && front.object.userData.dwSub) {
+          kind = 'instance'; sameRec = front.object.userData.dwSub[front.instanceId] === p;
+        } else if (front.object.userData && front.object.userData.featureId != null) {
+          kind = 'authored'; fid = front.object.userData.featureId;
+          const op = ops.find(o => o.id === fid);
+          dw = op && op.parameters && op.parameters._dw ? op.parameters._dw.disc : null;
+        } else kind = front.object.type;
+      }
+      // second hit info (is the instance right behind?)
+      let second = null;
+      if (hits[1]) second = (hits[1].object.isInstancedMesh ? 'instance(same=' +
+        (hits[1].object.userData.dwSub && hits[1].object.userData.dwSub[hits[1].instanceId] === p) + ')' :
+        'mesh fid=' + hits[1].object.userData.featureId) + ' d=' + hits[1].distance.toFixed(3);
+      // pixel change: instance only, then instance+authored-twin
+      const before = block(sx, sy);
+      window.Bonsai.setPlacementVisible('ELEC', idx, false);
+      const afterInst = block(sx, sy);
+      let twinFid = null;
+      if (kind === 'authored' && dw === 'ELEC') { const m = g.children.find(o => o.userData.featureId === fid); if (m) { m.visible = false; twinFid = fid; } }
+      const afterBoth = block(sx, sy);
+      if (twinFid != null) { const m = g.children.find(o => o.userData.featureId === twinFid); if (m) m.visible = true; }
+      window.Bonsai.setPlacementVisible('ELEC', idx, true);
+      out.push({ i, idx, kind, fid, dw, sameRec, dist, second,
+        chInst: before !== afterInst, chBoth: before !== afterBoth });
+    }
+    return { imCount: im.count, probed: out, opsWithDw: ops.filter(o => o.parameters && o.parameters._dw && o.parameters._dw.disc === 'ELEC').length };
+  });
+  console.log('  §PROBE3 imCount=' + res.imCount + ' authoredDwOps=' + res.opsWithDw);
+  res.probed.forEach(o => console.log('  §PROBE3 ' + JSON.stringify(o)));
+  t.assert('probe ran (see §PROBE3 lines)', res.probed.length > 0, '');
+}, { width: 1200, height: 850, dpr: 1 });

--- a/build/probe_inst_frontmost.js
+++ b/build/probe_inst_frontmost.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// # ⚠ DO NOT REMOVE — probe 4 (not a witness): is a walked ELEC INSTANCE ever the frontmost raycast hit
+// (needed for a genuine instance-level hover/pick exclusion claim)? Samples records × screen offsets from a
+// per-record camera; also: does the instance become frontmost after its authored twin is hidden (V1 API)?
+// Read the log after the run; exit code is not evidence.
+'use strict';
+const { runE2E } = require('../modeller/tests/e2e_harness');
+runE2E('PROBE-INST-FRONTMOST', async (t) => {
+  await t.open('Duplex');
+  await t.pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  await t.pg.waitForFunction(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    return !!(root && root.children.some(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC'));
+  }, { timeout: 30000 }).catch(() => {});
+  await t.sleep(3500);
+  const res = await t.pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+    const ims = root.children.filter(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC' && o.userData.dwSub)
+      .sort((a, b) => b.count - a.count);
+    const im = ims[0]; const sub = im.userData.dwSub; const W = window.__dwWalks.ELEC;
+    const cam = window.A.camera, ctl = window.A.controls;
+    const ops = window.Bonsai.oplog._geomOps();
+    const key = p => (+p.x).toFixed(4) + '|' + (+p.y).toFixed(4) + '|' + (+p.z).toFixed(4);
+    const fidByKey = {};
+    ops.forEach(o => { const pm = o.parameters; if (pm && pm._dw && pm._dw.disc === 'ELEC' && pm.placement)
+      (fidByKey[pm.placement.x.toFixed(4) + '|' + pm.placement.y.toFixed(4) + '|' + pm.placement.z.toFixed(4)] =
+        fidByKey[pm.placement.x.toFixed(4) + '|' + pm.placement.y.toFixed(4) + '|' + pm.placement.z.toFixed(4)] || []).push(o.id); });
+    const rc = new window.THREE.Raycaster();
+    function frontAt(ndcX, ndcY) {
+      rc.setFromCamera(new window.THREE.Vector2(ndcX, ndcY), cam);
+      const list = g.children.filter(o => o.isMesh && o.visible)
+        .concat(root.children.filter(o => (o.isInstancedMesh || o.isMesh) && o.visible));
+      return rc.intersectObjects(list, false)[0] || null;
+    }
+    const out = [];
+    for (let i = 0; i < sub.length && out.length < 10; i += 13) {
+      const p = sub[i]; if (!p || p.gated || p.clash) continue;
+      const idx = W.indexOf(p); if (idx < 0) continue;
+      cam.position.set(p.x + 1.6, p.y - 1.6, p.z + 0.9); ctl.target.set(p.x, p.y, p.z); ctl.update();
+      const v0 = new window.THREE.Vector3(p.x, p.y, p.z).project(cam);
+      // 5x5 NDC offsets ±0.12 around the record
+      let natural = 0, afterTwinHide = 0, total = 0, sampleNat = null, sampleAfter = null;
+      const fids = fidByKey[key(p)] || [];
+      for (let dx = -2; dx <= 2; dx++) for (let dy = -2; dy <= 2; dy++) {
+        const nx = v0.x + dx * 0.06, ny = v0.y + dy * 0.06; total++;
+        const h = frontAt(nx, ny);
+        if (h && h.object === im && h.object.userData.dwSub[h.instanceId] === p) { natural++; if (!sampleNat) sampleNat = [nx, ny]; }
+      }
+      // hide authored twin(s) via the §V1 production API, re-sample
+      fids.forEach(f => window.Bonsai.setFeatureVisible(f, false));
+      for (let dx = -2; dx <= 2; dx++) for (let dy = -2; dy <= 2; dy++) {
+        const nx = v0.x + dx * 0.06, ny = v0.y + dy * 0.06;
+        const h = frontAt(nx, ny);
+        if (h && h.object === im && h.object.userData.dwSub[h.instanceId] === p) { afterTwinHide++; if (!sampleAfter) sampleAfter = [nx, ny]; }
+      }
+      fids.forEach(f => window.Bonsai.setFeatureVisible(f, true));
+      out.push({ i, idx, twinFids: fids, natural: natural + '/' + total, afterTwinHide: afterTwinHide + '/' + total });
+    }
+    return { probed: out };
+  });
+  res.probed.forEach(o => console.log('  §PROBE4 ' + JSON.stringify(o)));
+  t.assert('probe ran (see §PROBE4 lines)', res.probed.length > 0, '');
+}, { width: 1200, height: 850, dpr: 1 });

--- a/build/probe_inst_rows.js
+++ b/build/probe_inst_rows.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// # ⚠ DO NOT REMOVE — probe (not a witness): after a REAL ELEC walk on Duplex, which InstancedMesh
+// instances carry guids that have Outliner leaf rows? Read the log after the run; exit code is not evidence.
+'use strict';
+const { runE2E } = require('../modeller/tests/e2e_harness');
+runE2E('PROBE-INST-ROWS', async (t) => {
+  await t.open('Duplex');
+  await t.pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  await t.pg.waitForFunction(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    return !!(root && root.children.some(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC'));
+  }, { timeout: 30000 }).catch(() => {});
+  await t.sleep(3000);
+  const st = await t.pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+    const ims = root ? root.children.filter(o => o.isInstancedMesh && o.userData.dwSub) : [];
+    if (window.Bonsai.outliner) { window.Bonsai.outliner._collapsed = {}; window.Bonsai.outliner._paint(); }
+    const out = [];
+    ims.forEach((im, k) => {
+      const sub = im.userData.dwSub;
+      const withGuid = sub.filter(p => p && p.guid).length;
+      // how many of those guids have an outliner leaf row in the tree fold (not just DOM — DOM is windowed)
+      const roots = (window.Bonsai.outliner && window.Bonsai.outliner._lastRoots) || {};
+      const ids = new Set();
+      const walk = n => { ids.add(String(n.id)); (n.children || []).forEach(walk); };
+      Object.keys(roots).forEach(key => (roots[key] || []).forEach(walk));
+      const inTree = sub.filter(p => p && p.guid && ids.has(String(p.guid))).length;
+      out.push({ k, disc: im.userData.dwDisc || null, asm: im.userData.dwAsm || null, chain: im.userData.dwChain || null,
+        count: im.count, withGuid, inTree, sample: (sub.find(p => p && p.guid) || {}).guid || null });
+    });
+    // also: total element leaf nodes in tree + how many resolve to fid bridge
+    const roots = (window.Bonsai.outliner && window.Bonsai.outliner._lastRoots) || {};
+    let leaves = 0, bridged = 0;
+    const fidByGuid = window.__arcFidByGuid || {};
+    const walk2 = n => { if (n.kind === 'element') { leaves++; if (fidByGuid[n.id] != null) bridged++; } (n.children || []).forEach(walk2); };
+    Object.keys(roots).forEach(key => (roots[key] || []).forEach(walk2));
+    return { ims: out, leaves, bridged };
+  });
+  console.log('  §PROBE ims=' + JSON.stringify(st.ims, null, 1));
+  console.log('  §PROBE leaves=' + st.leaves + ' bridged=' + st.bridged);
+  t.assert('probe ran (see §PROBE lines)', true, '');
+}, { width: 1200, height: 850, dpr: 1 });

--- a/build/probe_pixels.js
+++ b/build/probe_pixels.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// # ⚠ DO NOT REMOVE — probe 2 (not a witness): after a REAL ELEC walk on Duplex, does hiding ONE instance
+// (new §I5 setPlacementVisible) change pixels at its screen position, given the folded authored twins at the
+// same xyz? Measures per-record so the witness can target a genuinely visible instance. Read the log.
+'use strict';
+const { runE2E } = require('../modeller/tests/e2e_harness');
+runE2E('PROBE-INSTHIDE-PIXELS', async (t) => {
+  await t.open('Duplex');
+  await t.pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  await t.pg.waitForFunction(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    return !!(root && root.children.some(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC'));
+  }, { timeout: 30000 }).catch(() => {});
+  await t.sleep(3500);
+  const res = await t.pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+    const ims = root.children.filter(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC' && o.userData.dwSub)
+      .sort((a, b) => b.count - a.count);
+    const im = ims[0]; const sub = im.userData.dwSub; const W = window.__dwWalks.ELEC;
+    const cam = window.A.camera, ctl = window.A.controls, r = window.A.renderer;
+    function block(sx, sy) {
+      r.render(window.A.scene, window.A.camera);
+      const gl = r.getContext(); const cv = r.domElement; const rect = cv.getBoundingClientRect();
+      const bw = gl.drawingBufferWidth, bh = gl.drawingBufferHeight;
+      const gx = Math.round((sx - rect.left) * bw / rect.width), gy = Math.round(bh - (sy - rect.top) * bh / rect.height);
+      const px = new Uint8Array(24 * 24 * 4);
+      gl.readPixels(Math.max(0, gx - 12), Math.max(0, gy - 12), 24, 24, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      let h = 0; for (let k = 0; k < px.length; k++) h = (h * 31 + px[k]) >>> 0;
+      return h;
+    }
+    const out = [];
+    let tried = 0;
+    for (let i = 0; i < sub.length && out.length < 12 && tried < 40; i++) {
+      const p = sub[i]; if (!p || p.gated || p.clash) continue;
+      tried++;
+      const idx = W.indexOf(p); if (idx < 0) continue;
+      cam.position.set(p.x + 1.6, p.y - 1.6, p.z + 0.9); ctl.target.set(p.x, p.y, p.z); ctl.update();
+      const v = new window.THREE.Vector3(p.x, p.y, p.z).project(cam);
+      const cv = r.domElement, rect = cv.getBoundingClientRect();
+      const sx = (v.x * 0.5 + 0.5) * rect.width + rect.left, sy = (-v.y * 0.5 + 0.5) * rect.height + rect.top;
+      const before = block(sx, sy);
+      const twins = window.Bonsai.setPlacementVisible('ELEC', idx, false);
+      const after = block(sx, sy);
+      window.Bonsai.setPlacementVisible('ELEC', idx, true);
+      const restored = block(sx, sy);
+      out.push({ i, idx, twins, changed: before !== after, roundtrip: before === restored, z: +p.z.toFixed(2) });
+    }
+    return { imCount: im.count, probed: out };
+  });
+  console.log('  §PROBE2 imCount=' + res.imCount);
+  res.probed.forEach(o => console.log('  §PROBE2 ' + JSON.stringify(o)));
+  const changed = res.probed.filter(o => o.changed).length;
+  console.log('  §PROBE2 summary changed=' + changed + '/' + res.probed.length +
+    ' roundtripOK=' + res.probed.filter(o => o.roundtrip).length);
+  t.assert('probe ran (see §PROBE2 lines)', res.probed.length > 0, '');
+}, { width: 1200, height: 850, dpr: 1 });

--- a/modeller/bonsai_outliner.js
+++ b/modeller/bonsai_outliner.js
@@ -326,6 +326,7 @@
         const mark = (n) => {
           let h = false;
           if (n.kind === 'element') h = fidByGuid[n.id] != null || !isNaN(+n.id);
+          if (n.dwp) h = true;   // §I5 (W-E2E-INSTHIDE): a walked-instance row acts via setPlacementVisible
           if (n.disc) h = true;
           (n.children || []).forEach(c => { if (mark(c)) h = true; });
           n._hidable = h; return h;
@@ -335,7 +336,11 @@
 
       // ── SEEDED TREE section (ARC LEADS, W-UX-3) — re-rendered only when its HTML actually changes ──────────
       let treesHtml = '';
-      treeCats.forEach(cat => { const r = this._treeHtml(cat, match); treesHtml += r.html; total += r.total; shown += r.shown; });
+      treeCats.forEach(cat => {
+        // §I5: a hideWhenEmpty category with an empty fold contributes NOTHING (no dead header pre-walk)
+        if (cat.hideWhenEmpty && !(this._lastRoots[cat.key] || []).length) return;
+        const r = this._treeHtml(cat, match); treesHtml += r.html; total += r.total; shown += r.shown;
+      });
       let treeBuilt = false;
       if (treesHtml !== this._treesCache) {
         const c = tree.querySelector('#bo-trees'); c.innerHTML = treesHtml; this._wireTrees(c, treeCats);
@@ -533,6 +538,10 @@
           const fid = fidByGuid[n.id] != null ? fidByGuid[n.id] : (isNaN(+n.id) ? null : +n.id);
           if (fid != null && B.setFeatureVisible && B.setFeatureVisible(fid, false)) applied++;
         }
+        // §I5 (SPEC_INSTANCE_HIDE.md §I5d — Witness: W-E2E-INSTHIDE): a walked-instance node hides its
+        // exact (im, instanceId) twins inside the InstancedMesh bucket(s) + the folded authored _dw twin
+        // (§I5b-TWIN) — the §V1-deferred per-instance leg. n.dwp.asm=true → an assembly part (§I5b-ASM).
+        if (n.dwp && B.setPlacementVisible) applied += B.setPlacementVisible(n.dwp.disc, n.dwp.idx, false, n.dwp.asm);
         if (n.disc && B.setDiscVisible) applied += B.setDiscVisible(n.disc, false);
         (n.children || []).forEach(hideNode);
       };
@@ -570,7 +579,12 @@
             // building DB — fly the camera there (frameElementByGuid, elements_meta⋈element_transforms).
             // Only when the DB has no row (or no DB is open) does the honest toast remain.
             if (isNaN(num)) {
-              if (window.Bonsai.frameElementByGuid && window.Bonsai.frameElementByGuid(id)) {
+              // §I5: a Walked-Fixtures row (dwp|disc|idx) identifies + frames its exact instance — the
+              // production pickInstance path, not the "walked fixtures render as one batch" toast (stale
+              // since §Q2 landed instance identity).
+              if (window.Bonsai.frameInstanceRow && window.Bonsai.frameInstanceRow(id)) {
+                console.log(TAG + ' §OLSYNC instrow id=' + String(id).slice(0, 18) + ' (identified + framed walked instance)');
+              } else if (window.Bonsai.frameElementByGuid && window.Bonsai.frameElementByGuid(id)) {
                 console.log(TAG + ' §OLSYNC instframe guid=' + String(id).slice(0, 12) + ' (framed from real element_transforms row)');
               } else {
                 if (window.toast) window.toast('no 3D pick for generated elements yet — walked fixtures render as one batch', 'info');

--- a/modeller/dw_instances_outliner.js
+++ b/modeller/dw_instances_outliner.js
@@ -1,0 +1,77 @@
+/**
+ * BIM OOTB — Walked-Fixtures Outliner category (per-instance rows for disc-walker InstancedMesh buckets).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// dw_instances_outliner.js — Implementing prompts/SPEC_INSTANCE_HIDE.md §I5d — Witness: W-E2E-INSTHIDE.
+// (FABLE5_WRAPUP_2026-07-03 Item 5: the per-instance leg §POLISH3 §V1 deferred per §DECISIONS-2.)
+//
+// A REGISTERED Outliner category (the outliner's designed extension seam, Bonsai.outliner.addCategory) that
+// folds window.__dwWalks — the disc-walker's live placement arrays, the SAME record objects every
+// InstancedMesh bucket's userData.dwSub references (§Q2 identity) — into per-instance rows:
+//
+//   Walked Fixtures
+//     ELEC · generated            (disc group — eye hides the whole walk, via child recursion)
+//       LightFixture (230)        (class group)
+//         LightFixture #17 …      (LEAF, id 'dwp|ELEC|17' → n.dwp={disc,idx}; eye hides THIS instance)
+//
+// The leaves render THROUGH bonsai_outliner's existing §V4 windowed path (OL_CHUNK=250 per sibling list +
+// "… show N more") — only the open window's rows materialise eye elements; nothing here renders all rows.
+// idx = index into window.__dwWalks[disc] (stable across redraws — a redraw re-renders the same records).
+// NON-INVENT: rows are folded 1:1 from the walker's own records (ifc_class/storey/gate flags), nothing added.
+// hideWhenEmpty: no walk ⇒ the category contributes no header (no dead chrome before the first walk).
+(function () {
+  'use strict';
+  var TAG = '§DWINST';
+  if (typeof window === 'undefined') return;
+
+  // ONE disc group folder: class groups → leaves. asm=false folds a __dwWalks placement list
+  // (id dwp|disc|idx), asm=true a __dwAssembly part list (id dwa|disc|idx — §I5b-ASM: pure-instanced
+  // buckets, no authored twin; the leaf's eye hides the exact instanceId the same way).
+  function discGroup(disc, list, asm) {
+    var byCls = {}, order = [];
+    list.forEach(function (p, idx) {
+      var cls = (p && p.ifc_class) || (p && p.piece_type) || 'Unknown';
+      if (!byCls[cls]) { byCls[cls] = []; order.push(cls); }
+      byCls[cls].push({ p: p, idx: idx });
+    });
+    var pre = asm ? 'dwa|' : 'dwp|';
+    var kids = order.map(function (cls) {
+      var short = String(cls).replace(/^Ifc/, '');
+      return {
+        id: (asm ? 'dwac|' : 'dwc|') + disc + '|' + cls, label: short, kind: 'class',
+        children: byCls[cls].map(function (e) {
+          // gate flags surfaced 1:1 (⛔ clash / ⚠ gated) — same semantics as the 3-material render split
+          return { id: pre + disc + '|' + e.idx, kind: 'element',
+            dwp: { disc: disc, idx: e.idx, asm: asm },
+            label: short + ' #' + e.idx + (e.p.clash ? ' ⛔' : (e.p.gated ? ' ⚠' : '')),
+            sub: e.p.storey || (asm && e.p.guid ? String(e.p.guid).slice(0, 10) : '') };
+        })
+      };
+    });
+    return { id: (asm ? 'dwga|' : 'dwg|') + disc, label: disc + (asm ? ' · assembly' : ' · generated'),
+      kind: 'disc-group', children: kids };
+  }
+
+  function tree() {
+    var roots = [];
+    var W = window.__dwWalks || {};
+    Object.keys(W).forEach(function (disc) {
+      if (W[disc] && W[disc].length) roots.push(discGroup(disc, W[disc], false));
+    });
+    var A = window.__dwAssembly || {};
+    Object.keys(A).forEach(function (disc) {
+      if (A[disc] && A[disc].length) roots.push(discGroup(disc, A[disc], true));
+    });
+    return roots;
+  }
+
+  window.DWInstancesOutliner = {
+    register: function () {
+      if (window.Bonsai && window.Bonsai.outliner)
+        window.Bonsai.outliner.addCategory({ key: 'dwinst', label: 'Walked Fixtures', tree: tree, hideWhenEmpty: true });
+      console.log(TAG + ' registered — per-instance rows for walked InstancedMesh buckets (eye = §I5 instance hide)');
+    },
+    _tree: tree
+  };
+})();

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -198,7 +198,7 @@
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=9" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=10" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
 <script src="bom_tree.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
 <script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
@@ -233,6 +233,9 @@
      terminal_rules.db (mined off Terminal). Supersedes the thin mep_rw.db recipes for the disc-node walk —
      every disc walks on ANY opened building from rules measured off a real coordinated building. -->
 <script src="disc_walker.js?v=6" onerror="console.warn('§DW LOAD_FAIL disc_walker.js')"></script>
+<!-- §I5 per-instance hide (SPEC_INSTANCE_HIDE.md §I5d): Walked-Fixtures Outliner category — one row per
+     walked instance (windowed via §V4 OL_CHUNK), eye = hide that exact instanceId. Witness: W-E2E-INSTHIDE. -->
+<script src="dw_instances_outliner.js?v=1" onerror="console.warn('§DWINST LOAD_FAIL dw_instances_outliner.js')"></script>
 <script src="seed_trunk.js?v=1" onerror="console.warn('§ST LOAD_FAIL seed_trunk.js')"></script>
 <!-- §TEAMS-EMBED — GATED Teams overlay over the live scene (teams/ROADMAP.md §S11). ONE inert guarded script:
      OFF by default (no flag) → init() returns immediately, NO pill/pane/module-fetch = pixel-identical. ON
@@ -819,11 +822,110 @@ window.Bonsai.setDiscVisible = (disc, vis) => {
   if (window.A && A.requestRender) A.requestRender();
   return n;
 };
+// ── §I5 PER-INSTANCE HIDE (Implementing prompts/SPEC_INSTANCE_HIDE.md §I5a-§I5e — Witness: W-E2E-INSTHIDE;
+// FABLE5_WRAPUP_2026-07-03 Item 5, the leg §V1 deferred per §DECISIONS-2). Hide ONE instance inside a walked
+// InstancedMesh bucket, keyed by the §Q2 identity (instanceId i ↔ dwSub[i] record). Technique: save the exact
+// instance matrix (16 floats) then write a ZERO-BASIS matrix (rotation/scale columns zeroed, translation kept)
+// → no fragments; show restores the saved floats VERBATIM (round-trip byte-equality, asserted). A record can be
+// instanced into SEVERAL buckets (_renderDiscWalk renders all/gated/clash overlays from the same records) — the
+// ref map is keyed by the RECORD, so hide/show hits every twin. Session LENS like §V1: a re-walk/re-fold that
+// rebuilds buckets resets it. Hidden instances are UNPICKABLE via the explicit pickAt filter (§I5c) — the
+// zero-basis degeneracy alone is NOT the contract.
+window.__dwInstVer = 0;                                   // bumped on every bucket build/clear → ref-map cache key
+let _instRefCache = null;
+function _instRefMap() {
+  const g = window.Bonsai.group && window.Bonsai.group();
+  const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+  if (_instRefCache && _instRefCache.ver === window.__dwInstVer && _instRefCache.root === root) return _instRefCache.map;
+  const map = new Map();                                   // placement RECORD → [{im,i}] twins (§Q2 object identity)
+  if (root) root.children.forEach(im => {
+    if (!im.isInstancedMesh || !Array.isArray(im.userData.dwSub)) return;
+    im.userData.dwSub.forEach((p, i) => {
+      if (!p || typeof p !== 'object') return;
+      let a = map.get(p); if (!a) map.set(p, a = []);
+      a.push({ im: im, i: i });
+    });
+  });
+  _instRefCache = { ver: window.__dwInstVer, root: root, map: map };
+  return map;
+}
+const _ihM4 = new THREE.Matrix4();
+function _setInstanceHidden(im, i, hide) {
+  const hid = im.userData.dwHidden || (im.userData.dwHidden = new Set());
+  const store = im.userData.dwHiddenMat || (im.userData.dwHiddenMat = new Map());
+  if (hide === hid.has(i)) return false;                   // idempotent — never double-save (round-trip safety)
+  if (hide) {
+    im.getMatrixAt(i, _ihM4);
+    store.set(i, _ihM4.elements.slice());                  // the EXACT prior matrix — §I5b round-trip contract
+    const z = _ihM4.elements; for (let k = 0; k < 12; k++) z[k] = 0;   // zero basis, keep translation → no fragments
+    im.setMatrixAt(i, _ihM4);
+    hid.add(i);
+  } else {
+    const el = store.get(i); if (!el) return false;
+    im.setMatrixAt(i, _ihM4.fromArray(el));                // restore verbatim
+    store.delete(i); hid.delete(i);
+  }
+  im.instanceMatrix.needsUpdate = true;
+  return true;
+}
+window.Bonsai.isInstanceHidden = (im, i) => !!(im && im.userData && im.userData.dwHidden && im.userData.dwHidden.has(i));
+// §I5b-TWIN (measured, build/probe_frontmost.log): a committed walk placement ALSO folds an authored GEOM_INSERT
+// mesh at the SAME xyz (parameters._dw, _commitDiscWalk) which wins the raycast and fully covers the marker —
+// hiding only the instance changes ZERO pixels. The placement's fids are matched by _dw.disc + placement xyz
+// toFixed(4) (the exact rounding _commitDiscWalk wrote).
+function _dwTwinFids(disc, rec) {
+  const O = window.Bonsai.oplog; if (!O || !O._geomOps || rec.x == null) return [];
+  const kx = (+rec.x).toFixed(4), ky = (+rec.y).toFixed(4), kz = (+rec.z).toFixed(4);
+  const out = [];
+  (O._geomOps() || []).forEach(o => {
+    const pm = o.parameters;
+    if (pm && pm._dw && pm._dw.disc === disc && pm.placement &&
+        (+pm.placement.x).toFixed(4) === kx && (+pm.placement.y).toFixed(4) === ky && (+pm.placement.z).toFixed(4) === kz) out.push(o.id);
+  });
+  return out;
+}
+// Outliner seam (§I5d): hide/show ONE walked placement (disc + index into window.__dwWalks[disc]; asm=true →
+// window.__dwAssembly[disc], §I5b-ASM) across every bucket that instanced it, PLUS its folded authored _dw
+// twin mesh(es) (§I5b-TWIN — without this leg the eye visibly does nothing, measured probe_pixels.log 0/12).
+// Returns the number of twins toggled — 0 = nothing to act on (honest no-op).
+window.Bonsai.setPlacementVisible = (disc, idx, vis, asm) => {
+  const rec = (asm ? ((window.__dwAssembly && window.__dwAssembly[disc]) || [])
+                   : ((window.__dwWalks && window.__dwWalks[disc]) || []))[idx];
+  if (!rec) return 0;
+  const refs = _instRefMap().get(rec) || [];
+  let n = 0;
+  refs.forEach(ref => { if (_setInstanceHidden(ref.im, ref.i, !vis)) n++; });
+  if (!asm) _dwTwinFids(disc, rec).forEach(fid => { if (window.Bonsai.setFeatureVisible(fid, vis)) n++; });
+  if (n) {
+    if (window.A && A.requestRender) A.requestRender();
+    console.log('§INSTHIDE disc=' + disc + ' idx=' + idx + ' vis=' + !!vis + ' asm=' + !!asm + ' twins=' + n);
+  }
+  return n;
+};
+// §I5d: a "Walked Fixtures" Outliner row CLICK identifies (the SAME production pickInstance a canvas pick uses)
+// + frames its instance — instead of the stale "no 3D pick" toast. dwp|<disc>|<idx> (walk) / dwa|… (assembly).
+window.Bonsai.frameInstanceRow = (rowId) => {
+  const m = /^(dwp|dwa)\|(.+)\|(\d+)$/.exec(String(rowId || '')); if (!m) return false;
+  const rec = (m[1] === 'dwa' ? ((window.__dwAssembly && window.__dwAssembly[m[2]]) || [])
+                              : ((window.__dwWalks && window.__dwWalks[m[2]]) || []))[+m[3]];
+  if (!rec) return false;
+  const refs = _instRefMap().get(rec) || []; if (!refs.length) return false;
+  pickInstance(refs[0].im, refs[0].i);
+  const x = rec.x != null ? rec.x : (rec.pos ? rec.pos[0] : 0),
+        y = rec.y != null ? rec.y : (rec.pos ? rec.pos[1] : 0),
+        z = rec.z != null ? rec.z : (rec.pos ? rec.pos[2] : 0);
+  return _frameTo(new THREE.Vector3(x, y, z), 1.5, m[1] + '=' + m[2] + '/' + m[3]);
+};
 window.Bonsai.setAllVisible = () => {                     // reset before deterministically re-applying every hidden subtree
   const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return;
   g.children.forEach(o => {
     if (o.isMesh && o.userData.featureId != null) o.visible = true;
-    if (o.userData && o.userData.dwRoot) o.children.forEach(c => { c.visible = true; });
+    if (o.userData && o.userData.dwRoot) o.children.forEach(c => {
+      c.visible = true;
+      // §I5: the reset leg also restores every per-instance hide (then _applyHidden re-applies the hidden set)
+      if (c.isInstancedMesh && c.userData.dwHidden && c.userData.dwHidden.size)
+        Array.from(c.userData.dwHidden).forEach(i => _setInstanceHidden(c, i, false));
+    });
   });
   _selOutlines.forEach(o => { o.line.visible = true; });
   if (window.A && A.requestRender) A.requestRender();
@@ -974,7 +1076,15 @@ function pickAt(clientX, clientY, opts) {
   raycaster.setFromCamera(ndc, camera);
   // §V1: o.visible filter — hidden means hidden (unpickable), see _dwPickables note.
   const list = g.children.filter(o => o.isMesh && o.visible).concat(_dwPickables(opts && opts.hover));
-  return raycaster.intersectObjects(list, false)[0] || null;   // sorted by distance — nearest wins, authored or instanced
+  // §I5c (W-E2E-INSTHIDE c): a hidden INSTANCE is unpickable too — skip its hits so the ray falls through to
+  // the object behind (or nothing). §V1's bucket-level filter stays in _dwPickables; this is the per-instance
+  // leg, and it covers EVERY hover/click/shift-click path (they all raycast through here).
+  const hits = raycaster.intersectObjects(list, false);   // sorted by distance — nearest SURVIVING hit wins
+  for (let k = 0; k < hits.length; k++) {
+    if (hits[k].object.isInstancedMesh && window.Bonsai.isInstanceHidden(hits[k].object, hits[k].instanceId)) continue;
+    return hits[k];
+  }
+  return null;
 }
 // ── MARQUEE (shift-drag box) ───────────────────────────────────────────────────────────────────
 // Bare left-drag is OrbitControls' rotate, so SHIFT is the multi gesture (no conflict). A CAPTURE-phase pointerdown
@@ -2583,6 +2693,7 @@ if (!window.SQL && window.initSqlJs) {
 // resident or a local .db. RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-1/§W-UX-3.
 if (window.BOMTreeOutliner) window.BOMTreeOutliner.register();   // ARC = the lead containment tree
 if (window.STRWalkerOutliner) window.STRWalkerOutliner.register();   // STR Walker result tab + grid-drag re-walk
+if (window.DWInstancesOutliner) window.DWInstancesOutliner.register();   // §I5 Walked Fixtures — per-instance rows/eyes
 console.log('§MODELLER outliner ready — ARC (bom-graph) leads + STR Walker tab (Open via the pill rail)');
 
 // ── DISC = WALKER (W-UX-4): a discipline node in the bom-graph is a WALKER entry point. Clicking it dispatches
@@ -2702,6 +2813,7 @@ function _clearDiscWalk(disc) {
   root.children.slice().forEach(function (o) { if (o.userData && (o.userData.dwDisc === disc || o.userData.dwAsm === disc)) root.remove(o); });
   delete window.__dwWalks[disc];
   if (window.__dwAssembly) delete window.__dwAssembly[disc];
+  window.__dwInstVer++;   // §I5: bucket set changed → invalidate the record→(im,i) ref map
 }
 // §LOD-SEAM (docs/WalkerDoctrine.md §5): a GENERATED fixture's render geometry is selected by its semantic
 // prim KIND (disc_walker._primFor → p.prim: sprinkler/diffuser/light/outlet/alarm/valve/run/box). POC = a BOX
@@ -2802,6 +2914,7 @@ function _renderDiscWalk(disc, placements) {
       (enriched[0].connector.assembly_id + ' ' + enriched[0].connector.face + '→' + enriched[0].connector.connects_to) +
       ', standoff=' + enriched[0].standoff_m + 'm)');
   }
+  window.__dwInstVer++;   // §I5: fresh buckets → invalidate the record→(im,i) ref map (hidden lens resets, §V1 doctrine)
   console.log('§DW-PRIM disc=' + disc + ' n=' + placements.length + ' classes=' + Object.keys(byCls).length + ' [' + dims.join(' ') + ']');
   console.log('§DW-PRIM-LOD disc=' + disc + ' lod300=' + lod300N + ' lod200=' + lod200N +
     ' (Bug-2 partial fix: lod300=matched real catalog mesh, lod200=unchanged POC box; honest gap, not silently "fixed")');
@@ -2937,6 +3050,7 @@ function _renderDiscAssembly(disc, parts) {
   var root = _dwRoot(); if (!root) return;
   root.children.slice().forEach(function (o) { if (o.userData && o.userData.dwAsm === disc) root.remove(o); });   // clear prior
   window.__dwAssembly[disc] = parts;
+  window.__dwInstVer++;   // §I5: bucket set changed (cleared here, maybe rebuilt below) → invalidate the ref map
   if (!parts || !parts.length) { if (window.A && A.requestRender) A.requestRender(); return; }
   var base = DW_COLOR[disc] || 0xc0c0c0;
   var mat = new THREE.MeshStandardMaterial({ color: base, emissive: base, emissiveIntensity: 0.4, metalness: 0.2, roughness: 0.5 });
@@ -2976,6 +3090,7 @@ function _renderDiscAssembly(disc, parts) {
   }
   console.log('§DW-ASM-RENDER disc=' + disc + ' parts=' + parts.length + ' classes=' + Object.keys(byCls).length +
     ' connectorEdges=' + (verts.length / 6));
+  if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();   // §I5d: assembly parts get Walked-Fixtures rows too
   if (window.A && A.requestRender) A.requestRender();
 }
 // Cross-disc gate: re-fold ALL currently-walked disciplines through the measured place-order + clearances

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v31';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v32';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -55,6 +55,7 @@ const PRECACHE_ASSETS = [
   'sdg_cascade.js',
   'sdg_gate.js',
   'disc_walker.js',
+  'dw_instances_outliner.js',   // §I5 Walked Fixtures per-instance rows (W-E2E-INSTHIDE)
   'teams_embed.js',   // §TEAMS-EMBED — gated Teams overlay (off by default = inert; lazy-loads teams/ when ON)
   'seed_trunk.js',
   'str_walker.js',

--- a/modeller/tests/witness_e2e_instance_hide.js
+++ b/modeller/tests/witness_e2e_instance_hide.js
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-INSTHIDE scope (read this block first)
+ * SCOPE: real-user witness for §I5 per-instance hide (prompts/SPEC_INSTANCE_HIDE.md; FABLE5_WRAPUP Item 5).
+ *   Real production path: open Duplex → production discWalk('ELEC') → real eye-glyph clicks on the NEW
+ *   "Walked Fixtures" Outliner rows; the pure-instanced leg renders assembly parts through the production
+ *   seam __dwRender.assembly (W-E2E-INSTPICK P2b precedent) and eye-clicks THEIR rows.
+ *   Claims are readPixels block hashes (fixed camera), instance-matrix float equality and real mouse
+ *   pick/hover behaviour — maths, not eyes. Read the log after every run; exit code is not evidence.
+ *
+ * Issues under test (each names what it proves):
+ *   H0 NO-DEAD-HEADER — hideWhenEmpty: before any walk the category contributes NO header; after the walk
+ *                      the "Walked Fixtures" header + dwp rows exist (§I5d).
+ *   H1 HIDE-ONE      — eye on ONE walked-placement row removes its pixels (instance zero-basis §I5b + the
+ *                      folded authored _dw twin §I5b-TWIN — measured: instance-only changes NOTHING,
+ *                      build/probe_pixels.log 0/12); a sibling placement's 24px block AND a keeper's block
+ *                      stay BYTE-IDENTICAL (siblings in the SAME InstancedMesh survive).
+ *   H2 ZERO-BASIS    — the hidden instance's matrix: rotation/scale columns (e[0..11]) all 0, translation
+ *                      (e[12..14]) preserved verbatim.
+ *   H3 WALK-UNPICK   — a real mouse click at the hidden placement's spot never re-identifies it (neither
+ *                      its authored twin fid nor an instance pick of its record).
+ *   H4 ROUND-TRIP    — eye again: instance matrix byte-equals the pre-hide 16 floats AND the pixel block
+ *                      byte-equals the pre-hide read (twin visible again).
+ *   H5 ASM-PIXELS    — pure-instanced leg (assembly bucket, NO twin): eye on a part row alone removes its
+ *                      pixels; the sibling part's block is byte-identical — per-instance hide inside a
+ *                      single InstancedMesh proven with zero mesh-twin help.
+ *   H6 ASM-CONTROL   — pre-hide control: real hover tints the instance (0x9be7ff at instanceId), real
+ *                      click identifies it (__instPickActive guid) — so H7's negatives are meaningful.
+ *   H7 ASM-UNPICK    — hidden instance: real click at its spot never identifies it; real hover never
+ *                      tints it (§I5c — invisible ≠ unpickable was §V1's lesson, extended per-instance).
+ *   H8 ASM-ROUNDTRIP — eye again: matrix byte-equals + pixel block byte-equals the pre-hide read.
+ *   H9 MULTI         — 3 placements hidden in the SAME InstancedMesh: all zero-basis, all pixel-gone,
+ *                      keeper block byte-identical; none re-identifies on a real click; show-all restores
+ *                      every matrix + every block byte-identically (dwHidden empty).
+ *   H10 WINDOWED     — with OL_CHUNK=50 the big class renders EXACTLY 50 dwp rows + one "… show N more"
+ *                      row (never the full list); every RENDERED dwp row carries a live eye (§I5d/§V4).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+runE2E('W-E2E-INSTHIDE', async (t) => {
+  const pg = t.pg;
+  await t.open('Duplex');
+
+  // H0a — pre-walk: hideWhenEmpty category contributes no header
+  const pre = await pg.evaluate(() => !!document.querySelector('[data-tcat="dwinst"]'));
+
+  await pg.evaluate(() => window.discWalk('ELEC', { building: 'Duplex' }));
+  await pg.waitForFunction(() => window.__dwLastCommitDisc === 'ELEC', { timeout: 60000 }).catch(() => {});
+  await t.sleep(3000);   // batched commitSeedGroup fold settles
+
+  // rig: expand everything + paint (P4 idiom), install helpers
+  const post = await pg.evaluate(() => {
+    const ol = window.Bonsai.outliner; ol._collapsed = {}; ol._paint();
+    window.__ih = {
+      im: null,   // the big ELEC bucket (set by discover)
+      block(x, y, z) {   // 24x24 readPixels hash at the projected world point — fixed camera contract
+        const r = window.A.renderer; r.render(window.A.scene, window.A.camera);
+        const gl = r.getContext(); const bw = gl.drawingBufferWidth, bh = gl.drawingBufferHeight;
+        const v = new window.THREE.Vector3(x, y, z).project(window.A.camera);
+        const gx = Math.round((v.x * 0.5 + 0.5) * bw), gy = Math.round((v.y * 0.5 + 0.5) * bh);
+        const px = new Uint8Array(24 * 24 * 4);
+        gl.readPixels(Math.max(0, gx - 12), Math.max(0, gy - 12), 24, 24, gl.RGBA, gl.UNSIGNED_BYTE, px);
+        let h = 0; for (let k = 0; k < px.length; k++) h = (h * 31 + px[k]) >>> 0;
+        return h;
+      },
+      spot(x, y, z) {    // client px of a world point (for real mouse gestures)
+        const v = new window.THREE.Vector3(x, y, z).project(window.A.camera);
+        const rect = window.A.renderer.domElement.getBoundingClientRect();
+        return [(v.x * 0.5 + 0.5) * rect.width + rect.left, (-v.y * 0.5 + 0.5) * rect.height + rect.top];
+      },
+      mat(im, i) { const m = new window.THREE.Matrix4(); im.getMatrixAt(i, m); return Array.from(m.elements); },
+      asmIm() { const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+        return root.children.find(o => o.isInstancedMesh && o.userData.dwAsm === 'ASMH'); },
+      twinsOf(rec) {
+        const ops = window.Bonsai.oplog._geomOps() || [];
+        const kx = (+rec.x).toFixed(4), ky = (+rec.y).toFixed(4), kz = (+rec.z).toFixed(4);
+        return ops.filter(o => { const pm = o.parameters;
+          return pm && pm._dw && pm._dw.disc === 'ELEC' && pm.placement &&
+            (+pm.placement.x).toFixed(4) === kx && (+pm.placement.y).toFixed(4) === ky &&
+            (+pm.placement.z).toFixed(4) === kz; }).map(o => o.id);
+      },
+      // Find a FIXED camera pose + 5 walked placements (same big InstancedMesh) whose authored twin is the
+      // frontmost raycast hit at its own projected spot (⇒ hiding the placement must change those pixels),
+      // pairwise ≥70px apart on screen. Camera is LEFT at the successful pose.
+      discover() {
+        const g = window.Bonsai.group(); const root = g.children.find(o => o.userData && o.userData.dwRoot);
+        const im = root.children.filter(o => o.isInstancedMesh && o.userData.dwDisc === 'ELEC' && o.userData.dwSub)
+          .sort((a, b) => b.count - a.count)[0];
+        if (!im) return null;
+        this.im = im;
+        const sub = im.userData.dwSub, W = window.__dwWalks.ELEC;
+        const cam = window.A.camera, ctl = window.A.controls, r = window.A.renderer;
+        const rc = new window.THREE.Raycaster();
+        for (let a = 0; a < sub.length; a += 7) {
+          const anc = sub[a]; if (!anc || anc.gated || anc.clash) continue;
+          cam.position.set(anc.x + 2.4, anc.y - 2.4, anc.z + 1.4); ctl.target.set(anc.x, anc.y, anc.z); ctl.update();
+          r.render(window.A.scene, window.A.camera);
+          const rect = r.domElement.getBoundingClientRect();
+          const found = [];
+          for (let i = 0; i < sub.length; i++) {
+            const p = sub[i]; if (!p || p.gated || p.clash) continue;
+            const idx = W.indexOf(p); if (idx < 0) continue;
+            const tf = this.twinsOf(p); if (!tf.length) continue;
+            const v = new window.THREE.Vector3(p.x, p.y, p.z).project(cam); if (v.z > 1) continue;
+            const sx = (v.x * 0.5 + 0.5) * rect.width + rect.left, sy = (-v.y * 0.5 + 0.5) * rect.height + rect.top;
+            if (sx < rect.left + 40 || sx > rect.right - 40 || sy < rect.top + 40 || sy > rect.bottom - 40) continue;
+            rc.setFromCamera(new window.THREE.Vector2(v.x, v.y), cam);
+            const list = g.children.filter(o => o.isMesh && o.visible)
+              .concat(root.children.filter(o => (o.isInstancedMesh || o.isMesh) && o.visible));
+            const hits = rc.intersectObjects(list, false);
+            if (!hits.length) continue;
+            const h0 = hits[0];
+            if (!(h0.object.userData && tf.includes(h0.object.userData.featureId))) continue;
+            // reject co-located foreign geometry near the front (a 2nd fixture at the same xyz — measured
+            // probe_frontmost.log idx=129 — would keep the pixels alive and fake a RED)
+            let clean = true;
+            for (let k = 1; k < hits.length && hits[k].distance - h0.distance < 0.2; k++) {
+              const o = hits[k];
+              const own = (o.object === im && im.userData.dwSub[o.instanceId] === p) ||
+                          (o.object.userData && tf.includes(o.object.userData.featureId));
+              if (!own) { clean = false; break; }
+            }
+            if (!clean) continue;
+            if (found.some(f => Math.hypot(f.sx - sx, f.sy - sy) < 70)) continue;
+            found.push({ idx, i, sx, sy, x: p.x, y: p.y, z: p.z, twins: tf });
+            if (found.length >= 5) break;
+          }
+          if (found.length >= 5) return { found, count: im.count };
+        }
+        return null;
+      }
+    };
+    return { header: !!document.querySelector('[data-tcat="dwinst"]'),
+      rows: document.querySelectorAll('[data-bnode^="dwp|ELEC|"]').length };
+  });
+  t.assert('H0 NO-DEAD-HEADER (no header pre-walk; header + dwp rows post-walk)',
+    pre === false && post.header === true && post.rows > 0, 'pre=' + pre + ' post=' + JSON.stringify(post));
+
+  const eye = async (rowId) => {   // the REAL user gesture: scroll the row into view, click ITS eye glyph
+    await pg.evaluate(id => { const d = document.querySelector('[data-bnode="' + id + '"]'); if (d) d.scrollIntoView({ block: 'center' }); }, rowId);
+    await pg.click('[data-bnode="' + rowId + '"] .bn-eye'); await t.sleep(300);
+  };
+
+  // ── H1..H4: the WALK leg (placement = instance twin + folded authored _dw twin) ────────────────
+  const dset = await pg.evaluate(() => window.__ih.discover());
+  console.log('  §IH-DISCOVER ' + JSON.stringify(dset && dset.found.map(f => ({ idx: f.idx, i: f.i, twins: f.twins }))));
+  t.assert('H1-rig discovery found 5 twin-frontmost placements in ONE InstancedMesh (count=' + (dset && dset.count) + ')',
+    !!dset && dset.found.length === 5, dset ? '' : 'no pose found');
+  if (!dset) return;
+  const [T, S, K, M2, M3] = dset.found;
+
+  const b0 = await pg.evaluate((T2, S2, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), s: window.__ih.block(S2.x, S2.y, S2.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    mat: window.__ih.mat(window.__ih.im, T2.i)
+  }), T, S, K);
+
+  await eye('dwp|ELEC|' + T.idx);   // HIDE — real eye click on the Walked Fixtures row
+
+  const h1 = await pg.evaluate((T2, S2, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), s: window.__ih.block(S2.x, S2.y, S2.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    mat: window.__ih.mat(window.__ih.im, T2.i),
+    hidden: window.Bonsai.isInstanceHidden(window.__ih.im, T2.i)
+  }), T, S, K);
+  t.assert('H1 HIDE-ONE (target block CHANGED; sibling + keeper blocks byte-identical; siblings survive)',
+    h1.t !== b0.t && h1.s === b0.s && h1.k === b0.k,
+    'T ' + b0.t + '→' + h1.t + ' S ' + b0.s + '→' + h1.s + ' K ' + b0.k + '→' + h1.k);
+  t.assert('H2 ZERO-BASIS (e[0..11]=0, translation e[12..14] preserved verbatim)',
+    h1.hidden && h1.mat.slice(0, 12).every(v => v === 0) &&
+    h1.mat[12] === b0.mat[12] && h1.mat[13] === b0.mat[13] && h1.mat[14] === b0.mat[14],
+    'mat=' + JSON.stringify(h1.mat.map(v => +v.toFixed(3))));
+
+  // H3 — real mouse click at the hidden placement's spot: never re-identifies it
+  await pg.mouse.move(T.sx, T.sy); await t.sleep(80);
+  await pg.mouse.down(); await t.sleep(50); await pg.mouse.up(); await t.sleep(300);
+  const h3 = await pg.evaluate((T2) => {
+    const sel = Array.from(window.Bonsai._selSet || []);
+    const ip = window.__instPickActive || null;
+    const rec = window.__dwWalks.ELEC[T2.idx];
+    return { selHitTwin: sel.some(f => T2.twins.includes(f)),
+      ipHitRec: !!(ip && ip.disc === 'ELEC' && Math.abs(ip.x - rec.x) < 1e-6 && Math.abs(ip.y - rec.y) < 1e-6 && Math.abs(ip.z - rec.z) < 1e-6),
+      sel, ip };
+  }, T);
+  t.assert('H3 WALK-UNPICK (hidden placement: click never re-identifies twin fid nor instance record)',
+    !h3.selHitTwin && !h3.ipHitRec, JSON.stringify({ sel: h3.sel, ip: h3.ip && h3.ip.i }));
+  // cleanup: deselect whatever the fall-through ray hit, park the mouse OFF the canvas (outliner strip)
+  await pg.evaluate(() => window.Bonsai.selectMany([]));
+  await pg.keyboard.press('Escape'); await pg.mouse.move(60, 8); await t.sleep(250);
+
+  // H4 — SHOW: eye again → matrix + pixels byte-equal the pre-hide reads
+  await eye('dwp|ELEC|' + T.idx);
+  const h4 = await pg.evaluate((T2, S2, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), s: window.__ih.block(S2.x, S2.y, S2.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    mat: window.__ih.mat(window.__ih.im, T2.i),
+    hidden: window.Bonsai.isInstanceHidden(window.__ih.im, T2.i)
+  }), T, S, K);
+  t.assert('H4 ROUND-TRIP (matrix 16/16 byte-equal + target block byte-equals pre-hide read)',
+    !h4.hidden && h4.mat.length === 16 && h4.mat.every((v, j) => v === b0.mat[j]) && h4.t === b0.t && h4.s === b0.s && h4.k === b0.k,
+    'matEq=' + h4.mat.every((v, j) => v === b0.mat[j]) + ' T ' + h1.t + '→' + h4.t + ' (pre ' + b0.t + ')');
+
+  // ── H9: MULTI — 3 placements hidden in the SAME InstancedMesh ──────────────────────────────────
+  const m0 = await pg.evaluate((T2, M2b, M3b, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), m2: window.__ih.block(M2b.x, M2b.y, M2b.z),
+    m3: window.__ih.block(M3b.x, M3b.y, M3b.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    mats: [T2.i, M2b.i, M3b.i].map(i => window.__ih.mat(window.__ih.im, i))
+  }), T, M2, M3, K);
+  await eye('dwp|ELEC|' + T.idx); await eye('dwp|ELEC|' + M2.idx); await eye('dwp|ELEC|' + M3.idx);
+  const m1 = await pg.evaluate((T2, M2b, M3b, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), m2: window.__ih.block(M2b.x, M2b.y, M2b.z),
+    m3: window.__ih.block(M3b.x, M3b.y, M3b.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    zero: [T2.i, M2b.i, M3b.i].every(i => window.__ih.mat(window.__ih.im, i).slice(0, 12).every(v => v === 0)),
+    nHidden: window.__ih.im.userData.dwHidden.size
+  }), T, M2, M3, K);
+  // pick-exclusion at all 3 spots (real clicks), then deterministic cleanup
+  let noneIdent = true;
+  for (const C of [T, M2, M3]) {
+    await pg.mouse.move(C.sx, C.sy); await t.sleep(60);
+    await pg.mouse.down(); await t.sleep(40); await pg.mouse.up(); await t.sleep(250);
+    const r = await pg.evaluate((C2) => {
+      const sel = Array.from(window.Bonsai._selSet || []); const ip = window.__instPickActive || null;
+      const rec = window.__dwWalks.ELEC[C2.idx];
+      return sel.some(f => C2.twins.includes(f)) ||
+        !!(ip && ip.disc === 'ELEC' && Math.abs(ip.x - rec.x) < 1e-6 && Math.abs(ip.y - rec.y) < 1e-6 && Math.abs(ip.z - rec.z) < 1e-6);
+    }, C);
+    if (r) noneIdent = false;
+    await pg.evaluate(() => window.Bonsai.selectMany([]));
+    await pg.keyboard.press('Escape');
+  }
+  await pg.mouse.move(60, 8); await t.sleep(250);
+  await eye('dwp|ELEC|' + T.idx); await eye('dwp|ELEC|' + M2.idx); await eye('dwp|ELEC|' + M3.idx);   // show-all
+  const m2r = await pg.evaluate((T2, M2b, M3b, K2) => ({
+    t: window.__ih.block(T2.x, T2.y, T2.z), m2: window.__ih.block(M2b.x, M2b.y, M2b.z),
+    m3: window.__ih.block(M3b.x, M3b.y, M3b.z), k: window.__ih.block(K2.x, K2.y, K2.z),
+    mats: [T2.i, M2b.i, M3b.i].map(i => window.__ih.mat(window.__ih.im, i)),
+    nHidden: window.__ih.im.userData.dwHidden.size
+  }), T, M2, M3, K);
+  const matsEq = m2r.mats.every((m, j) => m.every((v, k2) => v === m0.mats[j][k2]));
+  t.assert('H9 MULTI (3 hidden in ONE InstancedMesh: pixels gone ×3, zero-basis ×3, keeper identical, ' +
+    'none re-identifies, show-all restores every matrix + block; dwHidden 3→0)',
+    m1.t !== m0.t && m1.m2 !== m0.m2 && m1.m3 !== m0.m3 && m1.k === m0.k && m1.zero && m1.nHidden === 3 &&
+    noneIdent && matsEq && m2r.t === m0.t && m2r.m2 === m0.m2 && m2r.m3 === m0.m3 && m2r.k === m0.k && m2r.nHidden === 0,
+    'hidden=' + m1.nHidden + '→' + m2r.nHidden + ' noneIdent=' + noneIdent + ' matsEq=' + matsEq +
+    ' blocks T ' + m0.t + '→' + m1.t + '→' + m2r.t);
+
+  // ── H5..H8: the pure-instanced ASSEMBLY leg (no authored twin — W-E2E-INSTPICK P2b precedent) ───
+  await pg.evaluate(() => {
+    const parts = [0, 1, 2, 3].map(i => ({ disc: 'ASMH', guid: 'ASMH_PART_' + i, ifc_class: 'IfcDuctSegment',
+      piece_type: 'run', pos: [30 + i * 1.5, -30, 1.2], dir: [0, 0, 1], diameter_mm: 300, length_mm: 600 }));
+    window.__dwRender.assembly('ASMH', parts);
+    const c = window.A.camera, ct = window.A.controls;
+    c.position.set(30 + 1.8, -30 - 1.8, 2.1); ct.target.set(30 + 0.75, -30, 1.2); ct.update();
+    window.A.renderer.render(window.A.scene, window.A.camera);
+    const ol = window.Bonsai.outliner; ol._collapsed = {}; ol._paint();
+  });
+  await t.sleep(300);
+  const P0 = [30, -30, 1.2], P1 = [31.5, -30, 1.2];
+  const a0 = await pg.evaluate((p0, p1) => ({
+    b0: window.__ih.block(p0[0], p0[1], p0[2]), b1: window.__ih.block(p1[0], p1[1], p1[2]),
+    mat: window.__ih.mat(window.__ih.asmIm(), 0),
+    spot0: window.__ih.spot(p0[0], p0[1], p0[2]),
+    rowThere: !!document.querySelector('[data-bnode="dwa|ASMH|0"]')
+  }), P0, P1);
+
+  // H6 — controls: hover tints instance 0, click identifies it (so H7's negatives mean something)
+  await pg.mouse.move(a0.spot0[0], a0.spot0[1]); await t.sleep(250);
+  const hov = await pg.evaluate(() => { const im = window.__ih.asmIm();
+    return im.instanceColor ? [im.instanceColor.getX(0), im.instanceColor.getY(0), im.instanceColor.getZ(0)] : null; });
+  await pg.mouse.down(); await t.sleep(50); await pg.mouse.up(); await t.sleep(250);
+  const pick = await pg.evaluate(() => window.__instPickActive || null);
+  await pg.keyboard.press('Escape'); await pg.mouse.move(60, 8); await t.sleep(250);
+  const HOVER = [0x9b / 255, 0xe7 / 255, 1];
+  const hovOn = hov && hov.every((v, j) => Math.abs(v - HOVER[j]) < 0.02);
+  t.assert('H6 ASM-CONTROL (visible instance: hover tint 0x9be7ff at i=0 + click identifies guid)',
+    !!(hovOn && pick && pick.disc === 'ASMH' && pick.i === 0 && pick.guid === 'ASMH_PART_0'),
+    'hov=' + JSON.stringify(hov && hov.map(v => +v.toFixed(3))) + ' pick=' + JSON.stringify(pick && { disc: pick.disc, i: pick.i, guid: pick.guid }));
+
+  // H5 — eye on the assembly part row: pixels gone with NO twin help; sibling part byte-identical
+  t.assert('H5-rig assembly row dwa|ASMH|0 rendered in the Outliner', a0.rowThere, '');
+  await eye('dwa|ASMH|0');
+  const a1 = await pg.evaluate((p0, p1) => { const im = window.__ih.asmIm(); return {
+    b0: window.__ih.block(p0[0], p0[1], p0[2]), b1: window.__ih.block(p1[0], p1[1], p1[2]),
+    mat: window.__ih.mat(im, 0), hidden: window.Bonsai.isInstanceHidden(im, 0) }; }, P0, P1);
+  t.assert('H5 ASM-PIXELS (pure instance hide: part0 block CHANGED, sibling part1 byte-identical, zero-basis)',
+    a1.hidden && a1.b0 !== a0.b0 && a1.b1 === a0.b1 && a1.mat.slice(0, 12).every(v => v === 0),
+    'b0 ' + a0.b0 + '→' + a1.b0 + ' b1 ' + a0.b1 + '→' + a1.b1);
+
+  // H7 — hidden instance: real click never identifies, real hover never tints
+  await pg.mouse.move(a0.spot0[0], a0.spot0[1]); await t.sleep(250);
+  const hov2 = await pg.evaluate(() => { const im = window.__ih.asmIm();
+    return im.instanceColor ? [im.instanceColor.getX(0), im.instanceColor.getY(0), im.instanceColor.getZ(0)] : [1, 1, 1]; });
+  await pg.mouse.down(); await t.sleep(50); await pg.mouse.up(); await t.sleep(250);
+  const pick2 = await pg.evaluate(() => window.__instPickActive || null);
+  const hov2On = hov2.every((v, j) => Math.abs(v - HOVER[j]) < 0.02);
+  t.assert('H7 ASM-UNPICK (hidden instance: click never identifies it, hover never tints it)',
+    !hov2On && !(pick2 && pick2.guid === 'ASMH_PART_0'),
+    'hov=' + JSON.stringify(hov2.map(v => +v.toFixed(3))) + ' pick=' + JSON.stringify(pick2 && pick2.guid));
+  await pg.mouse.move(60, 8); await t.sleep(250);
+
+  // H8 — show again: matrix + block byte-equal
+  await eye('dwa|ASMH|0');
+  const a2 = await pg.evaluate((p0) => { const im = window.__ih.asmIm(); return {
+    b0: window.__ih.block(p0[0], p0[1], p0[2]), mat: window.__ih.mat(im, 0),
+    hidden: window.Bonsai.isInstanceHidden(im, 0) }; }, P0);
+  t.assert('H8 ASM-ROUNDTRIP (matrix 16/16 + pixel block byte-equal pre-hide)',
+    !a2.hidden && a2.mat.every((v, j) => v === a0.mat[j]) && a2.b0 === a0.b0,
+    'b0 ' + a1.b0 + '→' + a2.b0 + ' (pre ' + a0.b0 + ')');
+
+  // ── H10: WINDOWED — OL_CHUNK=50 renders EXACTLY the window for the big class, every row has an eye ─
+  const win = await pg.evaluate(() => {
+    window.OL_CHUNK = 50;
+    const ol = window.Bonsai.outliner; ol._chunkWin = {}; ol._paint();
+    const W = window.__dwWalks.ELEC;
+    const byCls = {}; W.forEach(p => { const c = (p && p.ifc_class) || 'Unknown'; byCls[c] = (byCls[c] || 0) + 1; });
+    const big = Object.keys(byCls).sort((a, b) => byCls[b] - byCls[a])[0];
+    const idxBig = new Set(); W.forEach((p, i) => { if (((p && p.ifc_class) || 'Unknown') === big) idxBig.add(i); });
+    const rows = Array.from(document.querySelectorAll('[data-bnode^="dwp|ELEC|"]'));
+    const bigRows = rows.filter(r => idxBig.has(+r.getAttribute('data-bnode').split('|')[2]));
+    const res = {
+      big: big, bigCount: byCls[big], bigRows: bigRows.length,
+      more: !!document.querySelector('[data-more="dwc|ELEC|' + big + '"]'),
+      eyes: rows.every(r => !!r.querySelector('.bn-eye')), totalRows: rows.length
+    };
+    window.OL_CHUNK = 250; ol._chunkWin = {}; ol._paint();   // restore
+    return res;
+  });
+  t.assert('H10 WINDOWED (OL_CHUNK=50: big class ' + win.big + ' (' + win.bigCount + ') renders EXACTLY 50 rows + "… show more"; every rendered row has an eye)',
+    win.bigCount > 50 && win.bigRows === 50 && win.more === true && win.eyes === true,
+    JSON.stringify(win));
+
+  t.slog.filter(l => /^§(INSTHIDE|OLEYE|DWINST)/.test(l)).slice(0, 14).forEach(l => console.log('  ' + l));
+}, { width: 1280, height: 860, dpr: 1 });

--- a/prompts/SPEC_INSTANCE_HIDE.md
+++ b/prompts/SPEC_INSTANCE_HIDE.md
@@ -1,0 +1,97 @@
+# ⚠ DO NOT REMOVE — SPEC: per-instance hide inside a single THREE.InstancedMesh (§I5)
+Scope: bim-compiler `prompts/FABLE5_WRAPUP_2026-07-03.md` Item 5 (decision locked by user).
+Read the log after every run — exit code is not evidence.
+
+## §I5 — Per-instance hide (extends §POLISH3 §V1 eye-toggle, keyed by §Q2 instanceId identity)
+
+Ground truth measured first (build/probe_inst_rows.log, real ELEC walk on Duplex): walked fixtures
+render as `dwDisc` InstancedMesh buckets whose `userData.dwSub[i]` records carry NO guid and have NO
+Outliner rows today — §V1 hides whole buckets only ("per-instance hide DEFERRED per §DECISIONS-2").
+This spec implements that deferred leg.
+
+### §I5a Identity
+The §Q2 contract is the identity: `hit.instanceId i ↔ im.userData.dwSub[i]` (array REFERENCE into
+`window.__dwWalks[disc]`). One placement RECORD can be instanced into SEVERAL buckets
+(`_renderDiscWalk` renders all/gated/clash overlays from the same record objects) — so the hide map
+is keyed by the RECORD (object identity), resolving to every `{im, i}` twin. Outliner row key:
+`dwp|<disc>|<idx>` where idx = index into `window.__dwWalks[disc]` (stable across redraws — the
+records are the same objects the redraw re-renders).
+
+### §I5b Hide technique (round-trip contract)
+Hide = save the exact instance matrix (all 16 floats) on the mesh
+(`im.userData.dwHiddenMat: Map(i → float[16])`), then write a ZERO-BASIS matrix (rotation/scale
+columns zeroed, translation kept) → the instance rasterises no fragments. Show = restore the saved
+16 floats verbatim (`W-E2E-INSTHIDE` asserts byte-equality) and drop the entry.
+`im.userData.dwHidden: Set(i)` is the live hidden set. Session LENS like §V1: a re-walk/re-fold that
+rebuilds buckets resets it (documented, not persisted).
+
+### §I5b-TWIN The folded authored twin (measured ground truth — build/probe_frontmost.log)
+A committed walk placement exists TWICE in the scene: the InstancedMesh marker (dwSub) AND a folded
+authored `GEOM_INSERT` mesh `_commitDiscWalk` committed with `parameters._dw` + the SAME xyz (toFixed(4)).
+Measured on a real ELEC walk (probe_pixels.log, probe_frontmost.log): the authored twin wins the raycast
+at EVERY sampled spot and fully covers the marker — hiding only the instance changes ZERO pixels
+(0/12), hiding instance+twin changes them (chBoth=true). The authored `_dw` twins have NO Outliner row
+of their own (base categories fold only Walls/Openings), so the dwp row is the ONLY per-fixture row.
+⇒ CONTRACT: `setPlacementVisible` hides/({shows}) the placement = every `{im,i}` instance twin
+(zero-basis, §I5b) AND every authored `_dw` twin mesh (matched by `_dw.disc` + placement xyz toFixed(4),
+via the §V1 `setFeatureVisible` leg). Anything less renders an eye that visibly does nothing.
+
+### §I5b-ASM Assembly buckets (the pure-instanced leg)
+`_renderDiscAssembly` buckets (`userData.dwAsm`, dwSub = part records from `window.__dwAssembly[disc]`)
+are InstancedMesh-ONLY — never committed, no authored twin (W-E2E-INSTPICK P2b precedent). They get the
+same rows (`dwa|<disc>|<idx>`, `n.dwp.asm=true`) and the same per-instance hide; this is where a real
+mouse click/hover genuinely reaches the INSTANCE frontmost, so the §I5c pick/hover-exclusion claims are
+proven here directly (on the walk side the twin covers the marker at every sampled angle —
+probe_inst_frontmost.log: natural frontmost 0/25 across 10 records).
+
+### §I5c Unpickable (hover AND click)
+THREE's Raycaster does not honour our hidden set by contract (§V1 already learned invisible ≠
+unpickable). `pickAt` — the ONE raycast every hover/click/shift-click path uses — filters the sorted
+intersection list: a hit on `(im, instanceId)` present in `dwHidden` is SKIPPED, so the ray falls
+through to the object behind (or nothing). `window.Bonsai.isInstanceHidden(im, i)` is the predicate.
+(The zero-basis matrix also degenerates the triangles, but the explicit filter is the CONTRACT.)
+
+### §I5d Outliner rows (inside the §V4 window)
+New REGISTERED category (the outliner's designed extension seam, `addCategory`):
+`modeller/dw_instances_outliner.js` — "Walked Fixtures": disc group → ifc_class group → one leaf
+per placement (`n.dwp = {disc, idx}`), folded from `window.__dwWalks` each paint. Leaves render
+THROUGH the existing `_renderNodes` windowed path (OL_CHUNK=250 per sibling list + "… show N more")
+— only the open window's rows materialise eye elements; NOTHING renders all rows. Category hidden
+when no walk exists (`hideWhenEmpty` — no dead header). `_hidable` marking honours `n.dwp`;
+`_applyHidden` maps a hidden dwp node → `window.Bonsai.setPlacementVisible(disc, idx, false)`
+(deterministic reset-then-reapply, unchanged §V1 flow). Group eyes (class/disc) recurse for free.
+
+### §I5e Scene seams (modeller.html)
+- `window.Bonsai.setPlacementVisible(disc, idx, vis, asm)` → toggles every `{im,i}` instance twin of
+  the record (asm=true resolves idx into `window.__dwAssembly[disc]` instead of `__dwWalks`) AND, for
+  walk records, every folded authored `_dw` twin mesh (§I5b-TWIN); returns the total twin count
+  (0 = nothing to act on, honest). Logs `§INSTHIDE`.
+- `window.Bonsai.isInstanceHidden(im, i)` → pick-filter predicate.
+- `window.Bonsai.setAllVisible()` extended: restores every per-instance hide (the §V1 deterministic
+  reset leg).
+- `window.Bonsai.frameInstanceRow(rowId)` → a dwp row CLICK identifies (production `pickInstance`)
+  + frames the instance (same `_frameTo` tail), instead of the stale "no 3D pick" toast.
+- Record→refs map cached per `window.__dwInstVer` (bumped by `_renderDiscWalk` /
+  `_renderDiscAssembly` / `_clearDiscWalk`).
+
+### §I5f Witness — W-E2E-INSTHIDE (modeller/tests/witness_e2e_instance_hide.js, real chromium)
+Real user path: open Duplex → production `discWalk('ELEC')` → real eye-glyph clicks on Outliner rows;
+the pure-instanced leg renders assembly parts through the production seam `__dwRender.assembly`
+(W-E2E-INSTPICK P2b precedent) and eye-clicks THEIR rows.
+Claims (each a § line + maths, readPixels blocks at projected instance positions, fixed camera):
+  (a) HIDE-ONE     — eye on one walked-placement row: its pixel block changes (instance zero-basis +
+                     authored twin hidden, §I5b-TWIN); a sibling placement's block AND an
+                     always-visible keeper's block stay BYTE-IDENTICAL.
+  (b) ROUND-TRIP   — eye again: instance matrix byte-equals the pre-hide 16 floats AND the pixel
+                     block byte-equals the pre-hide read (twin visible again).
+  (c) UNPICKABLE   — on a pure-instanced assembly bucket (instance IS the frontmost hit, measured):
+                     pre-hide control = real hover tints the instance + real click identifies it
+                     (`__instPickActive` that record); after the row eye, real hover never tints it and
+                     a real click never identifies it. Walk leg too: hidden placement's spot never
+                     re-identifies its fixture.
+  (d) MULTI        — 3 instances hidden in the SAME InstancedMesh: all zero-basis + all excluded
+                     from pick; keeper still rendered; show-all restores every matrix + block.
+  (e) WINDOWED     — with OL_CHUNK=50: exactly 50 dwp rows rendered for the big class + a
+                     "… show more" row; every RENDERED row has a live eye (no full-list render).
+Regression gate: witness_e2e_oleye, witness_e2e_olvirt, witness_e2e_instpick, witness_e2e_olfilter
+re-run green; logs saved under build/ and READ.


### PR DESCRIPTION
## What (FABLE5_WRAPUP_2026-07-03 Item 5 — user-locked)

Per-instance eye-toggle inside a single `THREE.InstancedMesh`, keyed by the #620 §Q2 instanceId identity — the leg #625 §V1 explicitly deferred. Spec: `prompts/SPEC_INSTANCE_HIDE.md`.

- **NEW Outliner category "Walked Fixtures"** (`modeller/dw_instances_outliner.js`, the registered `addCategory` seam): one leaf per walked placement (`dwp|disc|idx`) and per assembly part (`dwa|disc|idx`), rendered **through the §V4 `OL_CHUNK=250` windowed path** — never all rows; `hideWhenEmpty` = no dead header before the first walk.
- **`Bonsai.setPlacementVisible(disc, idx, vis, asm)`**: hide = save the exact instance matrix (16 floats) → write a zero-basis matrix (no fragments); show = restore **verbatim** (byte-equality asserted). Covers every `{im,i}` twin of the record **plus the folded authored `_dw` twin mesh** — measured ground truth (probe scripts in `build/`): the authored twin from `_commitDiscWalk` wins the raycast at every sampled spot, so instance-only hide changes **zero pixels** (0/12) and the `_dw` twins have no Outliner row of their own; without this leg the eye visibly does nothing.
- **`pickAt` per-instance filter (§I5c)**: hits on `(im, instanceId) ∈ dwHidden` are skipped in the sorted intersection list — hidden means unpickable for **every** hover/click/shift-click path (§V1 lesson: THREE's Raycaster does not skip invisible/degenerate on its own contract).
- `setAllVisible` restores per-instance hides (the deterministic §V1 reset-then-reapply flow); `__dwInstVer` invalidates the record→refs map on every bucket rebuild (session lens, like §V1).
- Walked-Fixtures row click now identifies + frames via production `pickInstance` (`frameInstanceRow`) instead of the stale "no 3D pick for generated elements" toast.
- `sw.js` v32 (+`dw_instances_outliner.js` precache), `bonsai_outliner.js?v=10`.

## Witness — W-E2E-INSTHIDE (real chromium, real eye-glyph clicks): **14 PASS / 0 FAIL**

`modeller/tests/witness_e2e_instance_hide.js` — Duplex + production `discWalk('ELEC')` + production `__dwRender.assembly` (the W-E2E-INSTPICK P2b pure-instanced precedent):

- H0 no dead header pre-walk; 267 rows post-walk
- H1 HIDE-ONE: target 24px readPixels block CHANGED, sibling + keeper blocks **byte-identical** (`89690752→4204799576`, S/K unchanged)
- H2 zero-basis: `e[0..11]=0`, translation preserved verbatim
- H3 walk-leg unpick: click at hidden spot never re-identifies (twin fid ∉ sel, `__instPickActive=null`)
- H4 round-trip: matrix 16/16 byte-equal + block byte-equals pre-hide
- H5 pure-instance pixels (assembly, NO twin): part0 gone, sibling part1 byte-identical
- H6 control: hover tint `[0.608,0.906,1]` + click identifies `ASMH_PART_0` (so the negatives mean something)
- H7 hidden instance: click never identifies, hover never tints (`[1,1,1]`, pick=null)
- H8 asm round-trip byte-equal
- H9 MULTI: 3 hidden in ONE InstancedMesh — pixels gone ×3, zero-basis ×3, keeper identical, none re-identifies, show-all restores every matrix + block, `dwHidden 3→0`
- H10 WINDOWED: `OL_CHUNK=50` → big class (IfcFlowTerminal, 230) renders **exactly 50** rows + one "… show more"; every rendered row has a live eye

## Regression gate (all re-run green, logs read)

W-E2E-OLEYE 5/5 · W-E2E-OLVIRT 5/5 · W-E2E-INSTPICK 7/7 · W-E2E-OLFILTER 4/4 · W-OL-SYNC 6/6

## Deviations from the pre-cut spec (documented in SPEC_INSTANCE_HIDE.md §I5b-TWIN/§I5b-ASM)

1. **Authored-twin leg added** to `setPlacementVisible` — measured necessity (probes committed), not scope creep: the eye is a no-op without it.
2. **Assembly buckets folded into the category too** — the pure-instanced surface where a real mouse genuinely reaches the instance frontmost; this is where the pick/hover-exclusion claims are proven directly (on the walk side the twin covers the marker at every sampled angle, 0/25 × 10 records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)