### PR TITLE
feat(erp): T7 host wiring — ErpShard into POS host + lazy shard history; teams_pill close; W-POS-PILLBAR

### DIFF
--- a/erp/erp_shard.js
+++ b/erp/erp_shard.js
@@ -47,8 +47,10 @@
 
   var COLS = 'id,timestamp,op_type,parameters,input_guids,output_guid,prev_hash,op_hash,sig,gid,op_uuid,user_tag,undone,branch_id';
   // exportOps — the archived-shard shape: FULL rows, id order (superset of exportBranch's needs).
-  function exportOps(db) {
-    var r = db.exec('SELECT ' + COLS + ' FROM kernel_ops ORDER BY id');
+  // maxId (optional) bounds the export to the rows shard() has PINNED as this shard's contents — an op
+  // committed concurrently (id > maxId) must neither ride the archive nor be deleted (§T7-RACE).
+  function exportOps(db, maxId) {
+    var r = db.exec('SELECT ' + COLS + ' FROM kernel_ops' + (maxId != null ? ' WHERE id <= ' + Number(maxId) : '') + ' ORDER BY id');
     if (!r.length) return [];
     var names = COLS.split(',');
     return r[0].values.map(function (v) { var o = {}; names.forEach(function (c, i) { o[c] = v[i]; }); return o; });
@@ -70,6 +72,15 @@
     return { ok: true, tip: prev, len: ops.length };
   }
 
+  // _firstSnapshotPayload — the first SHARD_SNAPSHOT row in an archived ops array (the prior
+  // boundary). Scanned by op_type, not position — a §T7-RACE survivor can sit ahead of it.
+  function _firstSnapshotPayload(ops) {
+    for (var i = 0; i < ops.length; i++) {
+      if (ops[i].op_type !== 'SHARD_SNAPSHOT') continue;
+      try { var rich = JSON.parse(ops[i].parameters); return rich.payload || null; } catch (e) { return null; }
+    }
+    return null;
+  }
   function _latestSnapshotPayload(db) {
     var r = db.exec("SELECT parameters FROM kernel_ops WHERE op_type='SHARD_SNAPSHOT' ORDER BY id DESC LIMIT 1");
     if (!r.length || !r[0].values.length) return null;
@@ -109,7 +120,12 @@
     var baseTipId = Number(lastIdR[0].values[0][0]);
 
     // 2. ARCHIVE FIRST + read back + re-verify — only a CONFIRMED copy unlocks the delete (T3).
-    var ops = exportOps(db);
+    // §T7-RACE: everything below runs across awaits (crypto, the store) — a POS commitGroup CAN land
+    // mid-shard. The shard's contents are PINNED to id ≤ baseTipId: an op that arrives later is neither
+    // archived NOR deleted (step 4 deletes id ≤ baseTipId only) — it simply rides the hot log across
+    // the boundary. An op landing between verifyChain and the MAX(id) read makes av.tip ≠ v.tip below
+    // ⇒ safe ABORT (retry on the next debounce). No interleaving can lose a committed op.
+    var ops = exportOps(db, baseTipId);
     var blobKey = String(opts.key) + '::shard:' + seq;
     try { await opts.store.put(blobKey, JSON.stringify(ops)); }
     catch (e) { console.log('§SHARD ABORT archive put failed: ' + e.message); return { sharded: false, reason: 'archive put failed: ' + e.message }; }
@@ -124,37 +140,51 @@
     console.log('§SHARD archive CONFIRMED key=' + blobKey + ' ops=' + back.length + ' tip=' + av.tip.slice(0, 12) + '…');
 
     // 3. the signed snapshot op — projState is the recorded input replay re-seeds from.
+    // T7-HOST (prompts/T7_HOST_WIRING_SPEC.md §Build 1): opCounts = CUMULATIVE per-op_type counts of
+    // every op up to this boundary — a recorded INPUT for counter-style walkers (pos_lens.nextIds)
+    // that must stay collision-free on the SYNC sale path where a lazy archive fetch is impossible.
+    // Derived from the ARCHIVED array itself (prev snapshot's counts + exactly the ops this shard
+    // archives) — never from a live re-count, so a mid-shard commit can't drift/double-count it
+    // (§T7-RACE: a survivor is counted by the NEXT shard, the one that archives it).
+    var opCounts = {}; if (prev && prev.opCounts) Object.keys(prev.opCounts).forEach(function (t) { opCounts[t] = Number(prev.opCounts[t]); });
+    ops.forEach(function (o) { opCounts[o.op_type] = (opCounts[o.op_type] || 0) + 1; });
     var payload = { op_type: 'SHARD_SNAPSHOT', uuid: 'SNAPSHOT:' + seq, shardSeq: seq,
-                    baseTipId: baseTipId, baseTipHash: v.tip, count: n, archivedKey: blobKey,
-                    projState: _projState(db) };
+                    baseTipId: baseTipId, baseTipHash: v.tip, count: ops.length, archivedKey: blobKey,
+                    opCounts: opCounts, projState: _projState(db) };
     var res = await K.commitGroup(db, [{ op_type: 'SHARD_SNAPSHOT', params: { payload: payload, actor: opts.actor || 'shard' } }],
                                    { gid: opts.gid || ('shard-' + seq + '-' + v.tip.slice(0, 8)), baseTs: opts.ts });
     if (!res || res.committed !== true) return { sharded: false, reason: 'snapshot commit failed: ' + (res && res.reason) };
     var snapId = res.ids[0];
 
-    // 3b. T2 guard: with a signer installed the snapshot MUST be content-signed (v2) — a position-
-    // signed (v1) snapshot would orphan its own sig on the re-seal below. Refuse rather than corrupt.
+    // 3b. T2 guard: with a signer installed, EVERY row that survives into the re-sealed hot chain
+    // (the snapshot AND any §T7-RACE mid-shard survivor, id > baseTipId) must be content-signed (v2)
+    // — a position-signed (v1) row would orphan its own sig on the re-seal below. Refuse rather
+    // than corrupt.
     if (K._isV2) {
-      var srow = db.exec('SELECT parameters, sig FROM kernel_ops WHERE id = ' + Number(snapId));
-      var sParams = srow[0].values[0][0], sSig = srow[0].values[0][1];
-      if (sSig && !K._isV2(sParams)) {
-        console.log('§SHARD ABORT snapshot is v1-signed — enable KernelOps.setContentSigning(true) first (T2)');
+      var srows = db.exec('SELECT id, parameters, sig FROM kernel_ops WHERE id > ' + Number(baseTipId));
+      var v1row = null;
+      if (srows.length) srows[0].values.forEach(function (r) { if (!v1row && r[2] && !K._isV2(r[1])) v1row = r[0]; });
+      if (v1row != null) {
+        console.log('§SHARD ABORT v1-signed row id=' + v1row + ' would not survive the re-seal — enable KernelOps.setContentSigning(true) first (T2)');
         db.run('DELETE FROM kernel_ops WHERE id = ' + Number(snapId));   // remove ONLY the op we just added
         await K.sealChain(db);
         return { sharded: false, reason: 'content signing (v2) required with a signer — T2' };
       }
     }
 
-    // 4. drop the archived prefix, re-seal the hot chain from GENESIS (prior head is inside the
-    //    signed snapshot params). Invalidate every incremental cache — the log changed shape.
-    db.run('DELETE FROM kernel_ops WHERE id < ' + Number(snapId));
+    // 4. drop the ARCHIVED prefix ONLY (id ≤ baseTipId — a §T7-RACE survivor keeps its row), re-seal
+    //    the hot chain from GENESIS (prior head is inside the signed snapshot params). Invalidate
+    //    every incremental cache — the log changed shape.
+    db.run('DELETE FROM kernel_ops WHERE id <= ' + Number(baseTipId));
+    db.run('VACUUM');   // reclaim the deleted prefix's pages — without this the exported/persisted hot
+                        // blob KEEPS the freelist and first paint gains nothing (W-T7-HOST §T7-HOST).
     var sealed = await K.sealChain(db);
     db.__krnVerifiedTip = null;
     db.__tipFoldCache = null;
     var v2 = await K.verifyChain(db);
-    console.log('§SHARD seq=' + seq + ' archived=' + n + ' hotOps=' + v2.len + ' snapId=' + snapId +
+    console.log('§SHARD seq=' + seq + ' archived=' + ops.length + ' hotOps=' + v2.len + ' snapId=' + snapId +
                 ' verify=' + (v2.ok ? 'ok' : 'FAIL') + ' tip=' + String(v2.tip).slice(0, 12) + '…');
-    return { sharded: true, seq: seq, snapId: snapId, archivedKey: blobKey, archived: n, hotLen: v2.len, tip: v2.tip, ok: v2.ok, sealedTip: sealed.tip };
+    return { sharded: true, seq: seq, snapId: snapId, archivedKey: blobKey, archived: ops.length, hotLen: v2.len, tip: v2.tip, ok: v2.ok, sealedTip: sealed.tip };
   }
 
   // maybeShard — the opt-in trigger: shard only past a threshold (DEFAULT OFF semantics — a small
@@ -188,20 +218,51 @@
       if (!s.ok) return { ok: false, seq: seq, why: s.why, at: s.at };
       if (s.tip !== expectTip) return { ok: false, seq: seq, why: 'boundary link (tip != recorded baseTipHash)' };
       checked++;
-      // the shard's FIRST row is the previous SHARD_SNAPSHOT op (seq-1) — its recorded baseTipHash
-      // is the next (older) boundary; shard 1 starts at true GENESIS.
-      var firstSnap = null;
+      // the shard CONTAINS the previous SHARD_SNAPSHOT op (seq-1) — usually its first row, but a
+      // §T7-RACE survivor (committed mid-shard, id > that boundary's baseTipId) can precede it, so
+      // scan for it. Its recorded baseTipHash is the next (older) boundary; shard 1 starts at GENESIS.
       if (seq > 1) {
-        try { var rich = JSON.parse(s.ops[0].parameters); firstSnap = rich.payload || null; } catch (e) { firstSnap = null; }
-        if (!firstSnap || firstSnap.op_type !== 'SHARD_SNAPSHOT') return { ok: false, seq: seq, why: 'missing prior snapshot at shard head' };
-        expectTip = firstSnap.baseTipHash;
+        var headSnap = _firstSnapshotPayload(s.ops);
+        if (!headSnap) return { ok: false, seq: seq, why: 'missing prior snapshot at shard head' };
+        expectTip = headSnap.baseTipHash;
       }
     }
     console.log('§SHARD verify-archive ok shards=' + checked + ' back-to=GENESIS');
     return { ok: true, shards: checked };
   }
 
+  // loadArchivedOps — the lazy Time-Machine/fold seam (T7_HOST_WIRING_SPEC §Build 1): walk the archive
+  // BACKWARD from the hot snapshot (each shard verified internally by loadShard; boundary link = the
+  // recorded baseTipHash, the same rule verifyShards enforces), return the WHOLE archived prefix in
+  // ASCENDING op order. Cached on db.__shardArchive = {atSeq, ops} — fetched ONCE per shard generation
+  // (a newer snapshot bumps shardSeq → refetch). Tamper/missing ⇒ {ok:false, why, seq} — an HONEST
+  // refusal; callers fold hot-only and say so, never a silently-thin history.
+  async function loadArchivedOps(db, store, key) {
+    var snap = _latestSnapshotPayload(db);
+    if (!snap) return { ok: true, ops: [], shards: 0, note: 'no snapshot — nothing archived' };
+    var atSeq = Number(snap.shardSeq);
+    if (db.__shardArchive && db.__shardArchive.atSeq === atSeq) {
+      return { ok: true, ops: db.__shardArchive.ops, shards: atSeq, cached: true };
+    }
+    var expectTip = snap.baseTipHash, ops = [];
+    for (var seq = atSeq; seq >= 1; seq--) {
+      var s = await loadShard(store, key, seq);
+      if (!s.ok) { console.log('§SHARD lazy-load REFUSED seq=' + seq + ' why=' + s.why); return { ok: false, why: s.why, at: s.at, seq: seq }; }
+      if (s.tip !== expectTip) { console.log('§SHARD lazy-load REFUSED seq=' + seq + ' why=boundary link'); return { ok: false, why: 'boundary link (tip != recorded baseTipHash)', seq: seq }; }
+      ops = s.ops.concat(ops);                          // walking backward ⇒ each older shard PREPENDS
+      if (seq > 1) {                                    // next (older) boundary from this shard's contained snapshot
+        var headSnap = _firstSnapshotPayload(s.ops);    // scan, not ops[0] — a §T7-RACE survivor can precede it
+        if (!headSnap) return { ok: false, why: 'missing prior snapshot at shard head', seq: seq };
+        expectTip = headSnap.baseTipHash;
+      }
+    }
+    db.__shardArchive = { atSeq: atSeq, ops: ops };
+    console.log('§SHARD lazy-load ok shards=' + atSeq + ' archivedOps=' + ops.length + ' (verified back to GENESIS, cached)');
+    return { ok: true, ops: ops, shards: atSeq };
+  }
+
   var API = { shard: shard, maybeShard: maybeShard, loadShard: loadShard, verifyShards: verifyShards,
+              loadArchivedOps: loadArchivedOps,
               verifyShardOps: verifyShardOps, exportOps: exportOps, _projState: _projState };
   if (typeof window !== 'undefined') window.ErpShard = API;   // window-only, like kernel_ops.js
   console.log('§SHARD_LOADED erp_shard.js (T7 fix 4/4b — signed snapshot boundary, archive-confirmed, lazy-verified)');

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -4244,7 +4244,12 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       seal: window.ERP.seal, chainVerify: window.ERP.chainVerify, overlay: _overlay, el: el, status: status,
       // §S-2b seam (WH_POS_PICK_LANE W-1): persist the op log to IDB (bim_ootb_cache/dbs/idmp_kanban_proj)
       // so the warehouse-walk page can fold a deliver-later sale; same store the Kanban write path persists.
-      persist: function () { return window.KanbanHost.persist(window.ERP.opDb, _KPROJ); } });
+      persist: function () { return window.KanbanHost.persist(window.ERP.opDb, _KPROJ); },
+      // T7 host opt-in (prompts/T7_HOST_WIRING_SPEC.md §Build 5): past ~5k ops the log shards (signed
+      // snapshot boundary, archive-confirmed) and the shrunk hot blob persists = instant first paint;
+      // full-history folds lazily pull the verified archive back on demand.
+      maybeShard: function () { return window.KanbanHost.maybeShard(window.ERP.opDb, _KPROJ); },
+      archivedOps: function () { return window.KanbanHost.archivedOps(window.ERP.opDb, _KPROJ); } });
   }
   // 🍳 Kitchen Display (§T2-SPEC) — the "ordered, not yet delivered" queue: KitchenCore folds the SAME
   // published op log the POS writes (deliver-later shipments born DR) ∪ the §S-2 seed selector; Serve =
@@ -4256,7 +4261,9 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var ok = await _ensureKanbanERP();
     if (!ok || !window.ERP) { status('Kitchen: write path unavailable (window.ERP not published)'); console.log('§KDS-PILL write-path=absent'); return; }
     KitchenLens.open({ b3: _b3(window.__idmpDb), opDb: window.ERP.opDb, KO: window.KernelOps,
-      seal: window.ERP.seal, chainVerify: window.ERP.chainVerify, overlay: _overlay, el: el, status: status });
+      seal: window.ERP.seal, chainVerify: window.ERP.chainVerify, overlay: _overlay, el: el, status: status,
+      // T7 (T7_HOST_WIRING_SPEC §Build 4): pre-shard deliver-later tickets stay in the queue — lazy archive.
+      archivedOps: function () { return window.KanbanHost.archivedOps(window.ERP.opDb, _KPROJ); } });
   }
   // ⚖ Rule — THE ONE GESTURE: edit one rule → K records re-fold live, signed + reversible (RuleFold).
   function openRuleFor() {

--- a/erp/kanban_host.js
+++ b/erp/kanban_host.js
@@ -129,5 +129,45 @@
     catch (e) { log('§KANBAN-PERSIST err ' + e.message); return Promise.resolve(false); }
   }
 
-  global.KanbanHost = { publish: publish, tip: tip, persist: persist, _rows: _rows };
+  // ── T7 host wiring (prompts/T7_HOST_WIRING_SPEC.md §Build 2 — Witness: W-T7-HOST) ─────────────────
+  // The shard opt-in for the POS/kanban op log. DEFAULT OFF stays true: nothing below runs unless a
+  // page calls it. Shard blobs ride the SAME IDB store the hot blob lives in (bim_ootb_cache/dbs,
+  // keys '<projKey>::shard:<seq>').
+  var SHARD_THRESHOLD = 5000;   // the tested value — erp_shard.maybeShard default + W-T7-INC's ~4.9k log
+  function shardStore() {
+    return { get: function (k) { return idbGetBlob(IDB, STORE, k); },
+             put: function (k, v) { return idbPutBlob(IDB, STORE, k, v); } };
+  }
+  // maybeShard — call after commits (debounced by the caller): past the threshold, close the shard and
+  // PERSIST the shrunk hot blob — that persisted [snapshot + open shard] IS the instant first paint
+  // (boot/restore loads it unchanged). Below threshold: byte-identical no-op (§T7-OFF).
+  function maybeShard(projDb, projKey, opts) {
+    opts = opts || {};
+    var Sh = global.ErpShard;
+    if (!Sh) return Promise.resolve({ sharded: false, reason: 'erp_shard.js not loaded' });
+    var store = opts.store || shardStore();
+    return Sh.maybeShard(projDb, { store: store, key: projKey,
+                                   threshold: opts.threshold != null ? opts.threshold : SHARD_THRESHOLD })
+      .then(function (r) {
+        if (r && r.sharded) {
+          log('§POS-SHARD sharded key=' + projKey + ' seq=' + r.seq + ' archived=' + r.archived + ' hotOps=' + r.hotLen);
+          if (opts.persist === false) return r;               // node witness: no IDB, store injected
+          return persist(projDb, projKey).then(function () { return r; });
+        }
+        if (r && r.reason !== 'below-threshold') log('§POS-SHARD skipped key=' + projKey + ' reason=' + r.reason);
+        return r;
+      });
+  }
+  // archivedOps — the lazy history seam for full-log folds (kitchen queue, replenish pending): the
+  // archived prefix, verified backward to GENESIS, cached per shard generation. {ok:false} on
+  // tamper/missing — callers fold hot-only and SAY so (honest degradation, never fabricated history).
+  function archivedOps(projDb, projKey, opts) {
+    opts = opts || {};
+    var Sh = global.ErpShard;
+    if (!Sh || !Sh.loadArchivedOps) return Promise.resolve({ ok: true, ops: [], shards: 0, note: 'erp_shard.js not loaded' });
+    return Sh.loadArchivedOps(projDb, opts.store || shardStore(), projKey);
+  }
+
+  global.KanbanHost = { publish: publish, tip: tip, persist: persist, _rows: _rows,
+                        maybeShard: maybeShard, archivedOps: archivedOps, shardStore: shardStore };
 })(typeof window !== 'undefined' ? window : this);

--- a/erp/kitchen_lens.js
+++ b/erp/kitchen_lens.js
@@ -114,8 +114,13 @@
       return dtid == null ? null : q1(b3, 'SELECT * FROM c_doctype WHERE c_doctype_id=?', dtid) || null;
     }
 
+    // T7-HOST (prompts/T7_HOST_WIRING_SPEC.md §Build 4 — Witness: §T7-LAZY): the queue is a FULL-history
+    // fold — a deliver-later ticket older than a shard boundary is still owed to the customer. Archived
+    // (pre-shard) ops are lazily fetched ONCE at open (verified back to GENESIS by ErpShard) and prepended;
+    // a refused archive (tamper/missing) folds hot-only and SAYS so — honest, never a silently-thin queue.
+    var _archived = [];
     function currentQueue() {
-      var folded = KDS.foldTickets(_opRows(cfg.opDb));
+      var folded = KDS.foldTickets(_archived.concat(_opRows(cfg.opDb)));
       var seen = {};
       folded.forEach(function (t) { if (t.m_inout_id != null) seen[t.m_inout_id] = 1; });
       var seed = _seedTickets(b3).filter(function (t) { return !seen[t.m_inout_id]; });
@@ -195,6 +200,13 @@
     render();
     cfg.overlay('Kitchen Display', wrap);
     console.log('§KDS-OPEN tickets=' + currentQueue().length + ' (fold(opDb) ∪ §S-2 seed selector, oldest-first)');
+    if (cfg.archivedOps) {
+      Promise.resolve(cfg.archivedOps()).then(function (arch) {
+        if (arch && arch.ok === false) { console.log('§KDS-ARCHIVE REFUSED why=' + arch.why + ' seq=' + arch.seq + ' — queue folds hot log ONLY'); cfg.status('History archive unreadable (' + arch.why + ') — kitchen queue from the hot log only'); return; }
+        _archived = (arch && arch.ops) || [];
+        if (_archived.length) { render(); console.log('§KDS-ARCHIVE folded archivedOps=' + _archived.length + ' shards=' + arch.shards + ' tickets=' + currentQueue().length); }
+      }).catch(function (e) { console.log('§KDS-ARCHIVE fetch failed: ' + ((e && e.message) || e)); });
+    }
   }
 
   root.KitchenLens = { open: open };

--- a/erp/pos_lens.js
+++ b/erp/pos_lens.js
@@ -238,19 +238,40 @@
     var st = b3.prepare(sql); return st.all.apply(st, a);
   }
 
-  // count prior CREATE_DOCUMENT ops → deterministic doc ids (no Date.now/Math.random)
+  // count prior CREATE_DOCUMENT ops → deterministic doc ids (no Date.now/Math.random).
+  // T7-HOST (prompts/T7_HOST_WIRING_SPEC.md §Build 3a — Witness: §T7-COUNT): once the log shards, the
+  // hot COUNT collapses — the latest SHARD_SNAPSHOT's cumulative opCounts carries the archived count so
+  // PKs stay collision-free WITHOUT an async archive fetch (this runs SYNC on the Pay path).
+  // _archivedOpCount — the pre-shard count of an op_type from the latest SHARD_SNAPSHOT's cumulative
+  // opCounts (0 when the log has never sharded). Sync + O(1): safe on the Pay path.
+  function _archivedOpCount(opDb, opType) {
+    try {
+      var s = opDb.exec("SELECT parameters FROM kernel_ops WHERE op_type='SHARD_SNAPSHOT' ORDER BY id DESC LIMIT 1");
+      if (s.length && s[0].values.length) {
+        var pl = JSON.parse(s[0].values[0][0]).payload;
+        if (pl && pl.opCounts && pl.opCounts[opType]) return Number(pl.opCounts[opType]);
+      }
+    } catch (e) {}
+    return 0;
+  }
   function nextIds(opDb) {
     var n = 0;
     try { var r = opDb.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='CREATE_DOCUMENT'"); n = (r[0] && Number(r[0].values[0][0])) || 0; } catch (e) {}
+    n += _archivedOpCount(opDb, 'CREATE_DOCUMENT');
     var base = 910000 + n * 10;
     return { orderId: base + 1, inoutId: base + 2, invoiceId: base + 3 };
   }
 
-  function logMovements(opDb) {
+  // archivedRows — lazily-fetched pre-shard ops (T7_HOST_WIRING_SPEC §Build 3b): full-history folds
+  // below prepend these so a shard boundary never thins stock/pending arithmetic. [] until a host
+  // injects cfg.archivedOps AND the log has actually sharded.
+  function logMovements(opDb, archivedRows) {
     var ev = [], hdr = null;
     try {
       var r = opDb.exec('SELECT op_type, parameters FROM kernel_ops ORDER BY id');
-      (r[0] ? r[0].values : []).forEach(function (row) {
+      var live = (r[0] ? r[0].values : []);
+      var all = (archivedRows || []).map(function (o) { return [o.op_type, o.parameters]; }).concat(live);
+      all.forEach(function (row) {
         var p; try { p = JSON.parse(row[1]); } catch (e) { return; }
         p = p && p.params ? p.params : p;
         if (!p) return;
@@ -269,13 +290,16 @@
   // open replenish-PO C_OrderLine.qtyordered for the warehouse + open M_MovementLine.movementqty whose
   // m_locatorto_id is in the warehouse. Commit → re-generate proposes ZERO for the committed products —
   // the real ReplenishReport's open-order subtraction, no double order. Returns { pid: centiQty }.
-  function pendingInbound(opDb, b3, wh) {
+  function pendingInbound(opDb, b3, wh, archivedRows) {
     var out = {};
     try {
       var locWh = {};
       qa(b3, 'SELECT m_locator_id AS i FROM m_locator WHERE m_warehouse_id=?', wh).forEach(function (l) { locWh[l.i] = 1; });
       var r = opDb.exec('SELECT gid, op_type, parameters FROM kernel_ops ORDER BY id');
-      var rows = (r[0] ? r[0].values : []).map(function (v) {
+      var live = (r[0] ? r[0].values : []);
+      // T7-HOST: archived (pre-shard) rows fold FIRST — an open PO older than the shard boundary must
+      // still count as on-order (the no-double-order guard, §T1-SPEC lens.4).
+      var rows = (archivedRows || []).map(function (o) { return [o.gid, o.op_type, o.parameters]; }).concat(live).map(function (v) {
         var p; try { p = JSON.parse(v[2]); } catch (e) { return null; }
         p = p && p.params ? p.params : p;
         return p ? { gid: v[0], p: p } : null;
@@ -295,14 +319,14 @@
     return out;
   }
 
-  function suggestAll(b3, opDb) {
+  function suggestAll(b3, opDb, archivedRows) {
     var whs = qa(b3, "SELECT DISTINCT m_warehouse_id AS w FROM m_replenish WHERE replenishtype<>'0'");
-    var pend = logMovements(opDb), out = [];
+    var pend = logMovements(opDb, archivedRows), out = [];
     whs.forEach(function (r) {
       var locs = {};
       qa(b3, 'SELECT m_locator_id AS i FROM m_locator WHERE m_warehouse_id=?', r.w).forEach(function (l) { locs[l.i] = 1; });
       var txns = qa(b3, 'SELECT m_product_id, m_locator_id, movementtype, movementqty FROM m_transaction').filter(function (t) { return locs[t.m_locator_id]; });
-      var inbound = pendingInbound(opDb, b3, r.w);
+      var inbound = pendingInbound(opDb, b3, r.w, archivedRows);
       var rctx = {
         // §T1-SPEC core.1: qtybatchsize + m_warehousesource_id now ride the policy row (real m_replenish columns)
         replenishRows: qa(b3, "SELECT m_product_id, m_warehouse_id, level_min, level_max, replenishtype, qtybatchsize, m_warehousesource_id FROM m_replenish WHERE m_warehouse_id=? AND replenishtype<>'0'", r.w),
@@ -411,6 +435,20 @@
     };
 
     var cart = [];
+
+    // T7 host opt-in (prompts/T7_HOST_WIRING_SPEC.md §Build 3c — Witness: W-T7-HOST): after a commit
+    // lands, nudge the host's shard check on a debounce (the kernel_ops._persistToIdb 2s idiom).
+    // DEFAULT OFF — a host that doesn't inject cfg.maybeShard behaves byte-identically to before.
+    var _shardTimer = null;
+    function maybeShardSoon() {
+      if (!cfg.maybeShard) return;
+      clearTimeout(_shardTimer);
+      _shardTimer = setTimeout(function () {
+        Promise.resolve(cfg.maybeShard()).then(function (r) {
+          if (r && r.sharded) console.log('§POS-SHARD closed seq=' + r.seq + ' archived=' + r.archived + ' hotOps=' + r.hotLen);
+        }).catch(function (e) { console.log('§POS-SHARD check failed: ' + ((e && e.message) || e)); });
+      }, 2000);
+    }
 
     // U-3: track products registered THIS session (for §POS-FIRSTSELL witness)
     var _sessionProductIds = {};  // { [productId]: true }
@@ -641,12 +679,14 @@
     dock.appendChild(dockItems); dock.appendChild(dockTrigger);
     document.body.appendChild(dock);
 
+    // PILL CLOSE DECREE (user decree 2026-07-02, witness_pill_canonical W2 — DECIDED for POS in
+    // FABLE5_FOLLOWUP_2026-07-04 §Item 3, Witness: W-POS-PILLBAR §PB-DECREE): the ⋯ dock is a pill
+    // RAIL in miniature, so the universal "no outside-tap close" decree governs it even though it is
+    // not PillBuilder-hosted — ONLY the deliberate ⋯ tap toggles it. Lens overlays with their own
+    // ✕/Done affordances (scan, import, receipt, float panel) are PANELS, not rails — decree-exempt.
     dockTrigger.addEventListener('click', function () {
       var open = dockItems.classList.toggle('open');
-      if (!open) return;
-      document.addEventListener('pointerdown', function _close(ev) {
-        if (!dock.contains(ev.target)) { dockItems.classList.remove('open'); document.removeEventListener('pointerdown', _close); }
-      });
+      console.log('§POS-DOCK toggle=' + (open ? 'open' : 'close') + ' (decree: only the ⋯ tap toggles)');
     });
 
     // swipe-down to dismiss (touch)
@@ -706,9 +746,21 @@
       replHdr.textContent = 'Replenishment';
     }
 
+    // T7-HOST (T7_HOST_WIRING_SPEC §Build 3b): the replenish fold walks the FULL history — lazily
+    // fetch pre-shard ops first (panel-open path — async is fine HERE, never on the Pay path). A
+    // refused archive (tamper/missing) folds hot-only and SAYS so — honest, never silently thin.
     function generateReplenish() {
+      return Promise.resolve(cfg.archivedOps ? cfg.archivedOps() : { ok: true, ops: [] }).then(function (arch) {
+        if (arch && arch.ok === false) {
+          console.log('§POS-REPLENISH archive REFUSED why=' + arch.why + ' seq=' + arch.seq + ' — folding hot log ONLY');
+          cfg.status('History archive unreadable (' + arch.why + ') — replenishment from the hot log only');
+        }
+        return _generateReplenishNow((arch && arch.ok && arch.ops) || []);
+      });
+    }
+    function _generateReplenishNow(archivedRows) {
       staged = []; replBox.textContent = '';
-      var sugg = suggestAll(b3, cfg.opDb);
+      var sugg = suggestAll(b3, cfg.opDb, archivedRows);
       sugg.forEach(function (s) {
         var nm = q1(b3, 'SELECT name FROM m_product WHERE m_product_id=?', s.m_product_id);
         var vendor = s.m_warehousesource_id ? null : vendorOf(s.m_product_id);
@@ -807,6 +859,7 @@
               ' ops=' + ops.length + ' newVerbs=[] gid=' + res.gid + ' chainOk=' + (cv && cv.ok ? 'Y' : 'N'));
             cfg.status('Replenishment committed · ' + nPo + ' PO / ' + nMv + ' move · ' + picked.length + ' lines');
             replCommitting = false; clearStage();
+            maybeShardSoon();          // T7-HOST: debounced shard check after the replenish group
           });
         })
         .catch(function (e) {
@@ -1069,7 +1122,8 @@
 
       function priorCreateCount() {
         var r = cfg.opDb.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='CRUD_CREATE'");
-        return (r[0] && Number(r[0].values[0][0])) || 0;
+        // T7-HOST (§T7-COUNT): + the pre-shard count — the register PK band must not restart post-shard.
+        return ((r[0] && Number(r[0].values[0][0])) || 0) + _archivedOpCount(cfg.opDb, 'CRUD_CREATE');
       }
 
       return {
@@ -1311,6 +1365,7 @@
             console.log('§POS-IMPORT registered productId=' + r.productId + ' barcode=' + _state.barcode +
               ' price=' + priceStr + ' hasPhoto=' + (!!_state.imageThumb) +
               ' gid=' + res.gid + ' ops=' + res.ids.length);
+            maybeShardSoon();          // T7-HOST: debounced shard check after the register group
             _closeImport();
           })
           .catch(function (e) {
@@ -1403,6 +1458,7 @@
             rcptBtn.style.display = '';
             receipt.textContent = '✓ ' + grandTotal + ' tendered · order ' + ids.orderId + ' · group ' + String(res.gid).slice(0, 8) + '… · signed=' + chainOk;
             cart = []; renderCart();   // §T1-SPEC lens.1: replenishment no longer auto-fires after a sale
+            maybeShardSoon();          // T7-HOST: the ~5k-op cliff check rides every sale (debounced)
           });
         })
         .catch(function (e) { cfg.status('commit failed: ' + e); console.log('§POS-LIVE commit FAIL ' + e); });
@@ -1450,6 +1506,7 @@
               var whUrl = (window.location.href.split('/erp/')[0] || '..') + '/viewer/viewer.html?db=../buildings/warehouse_gardenworld.db';
               window.open(whUrl, '_blank');
               console.log('§POS-DELIVERLATER walk-tab=opened url=' + whUrl);
+              maybeShardSoon();        // T7-HOST: debounced shard check after the deliver-later group
             });
           });
         })
@@ -1470,5 +1527,10 @@
   }
 
   root.PosLens = { open: open };
+  // node-witness seam (W-T7-HOST — prompts/T7_HOST_WIRING_SPEC.md): the shard-aware pure folds only;
+  // open() stays DOM-bound and untestable headless by design.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { open: open, _t7: { nextIds: nextIds, logMovements: logMovements, pendingInbound: pendingInbound } };
+  }
   console.log('§POS-LENS loaded (dumb terminal — record, pay, send; the fold does the rest)');
 })(typeof window !== 'undefined' ? window : this);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v762';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v763';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/fixtures/pos_host.html
+++ b/erp/tests/fixtures/pos_host.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!-- Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com> — SPDX-License-Identifier: MIT
+  ⚠ DO NOT REMOVE — W-POS-PILLBAR fixture (FABLE5_FOLLOWUP_2026-07-04 §Item 3). A minimal HOST for the
+  REAL erp/pos_lens.js (same idea as teams/tests/fixtures/idmp_host.html): real sql.js seed with the
+  exact tables pos_lens queries, real KernelOps op log, real POSCore/ERPEngine — only the PAGE chrome
+  (login, kanban, pills) is absent, because the witness targets the POS pill-button bar, not the page.
+  The seed rows are witness INPUTS (the memStore idiom), not invented product data claims. -->
+<html><head><meta charset="utf-8"><title>POS pillbar fixture</title></head>
+<body>
+<div id="mountpt"></div>
+<script src="../../lib/sql-wasm-fts5.js"></script>
+<script src="../../icons.js"></script>
+<script src="../../kernel_ops.js"></script>
+<script src="../../erp_kernel.js"></script>
+<script src="../../erp_engine.js"></script>
+<script src="../../pos_core.js"></script>
+<script src="../../pos_lens.js"></script>
+<script>
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function () { return '../../lib/sql-wasm-fts5.wasm'; } });
+
+  // ── the b3 seed: ONLY what pos_lens actually SELECTs (enumerated from its q1/qa calls) ──
+  var seed = new SQL.Database();
+  seed.run([
+    "CREATE TABLE c_pos (c_pos_id INT, name TEXT, m_pricelist_id INT, c_poskeylayout_id INT, c_doctype_id INT, c_bpartnercashtrx_id INT)",
+    "INSERT INTO c_pos VALUES (100,'Fixture POS',101,102,135,118)",
+    "CREATE TABLE m_pricelist_version (m_pricelist_version_id INT, m_pricelist_id INT)",
+    "INSERT INTO m_pricelist_version VALUES (201,101)",
+    "CREATE TABLE c_poskey (c_poskey_id INT, m_product_id INT, c_poskeylayout_id INT, seqno INT, ad_client_id INT, ad_org_id INT, qty REAL)",
+    "INSERT INTO c_poskey VALUES (301,124,102,10,11,0,1),(302,125,102,20,11,0,1)",
+    "CREATE TABLE m_product (m_product_id INT, name TEXT, upc TEXT, value TEXT, isactive TEXT)",
+    "INSERT INTO m_product VALUES (124,'Fixture Oak','790000124','OAK','Y'),(125,'Fixture Elm','790000125','ELM','Y')",
+    "CREATE TABLE m_productprice (m_product_id INT, m_pricelist_version_id INT, pricestd REAL, ad_client_id INT, ad_org_id INT)",
+    "INSERT INTO m_productprice VALUES (124,201,45.5,11,0),(125,201,12.0,11,0)",
+    "CREATE TABLE c_doctype (c_doctype_id INT, name TEXT, docsubtypeso TEXT, isactive TEXT)",
+    "INSERT INTO c_doctype VALUES (135,'POS Order','WR','Y'),(136,'Standard Order','SO','Y')",
+    "CREATE TABLE c_bpartner (c_bpartner_id INT, name TEXT, isactive TEXT)",
+    "INSERT INTO c_bpartner VALUES (118,'Walk-in Fixture','Y')",
+    // queried-but-empty surfaces (replenish / register / deliver-later legs)
+    "CREATE TABLE m_replenish (m_product_id INT, m_warehouse_id INT, level_min REAL, level_max REAL, replenishtype TEXT, qtybatchsize REAL, m_warehousesource_id INT)",
+    "CREATE TABLE m_locator (m_locator_id INT, m_warehouse_id INT, isdefault TEXT)",
+    "CREATE TABLE m_transaction (m_product_id INT, m_locator_id INT, movementtype TEXT, movementqty REAL)",
+    "CREATE TABLE m_storagereservation (m_product_id INT, m_warehouse_id INT, qty REAL, issotrx TEXT)",
+    "CREATE TABLE m_product_po (m_product_id INT, c_bpartner_id INT, pricepo REAL, iscurrentvendor TEXT)",
+    "CREATE TABLE pp_product_bom (pp_product_bom_id INT, m_product_id INT)",
+    "CREATE TABLE pp_product_bomline (pp_product_bomline_id INT, pp_product_bom_id INT, m_product_id INT, qtybom REAL)",
+    "CREATE TABLE ad_table (ad_table_id INT, tablename TEXT)",
+    "CREATE TABLE ad_column (ad_column_id INT, ad_table_id INT, columnname TEXT, defaultvalue TEXT, ismandatory TEXT)",
+    "CREATE TABLE ad_sysconfig (name TEXT, value TEXT)",
+    "CREATE TABLE ad_image (ad_image_id INT, ad_client_id INT, ad_org_id INT, entitytype TEXT)"
+  ].join(';'));
+
+  // read-only better-sqlite3-shaped shim (the idempiere.html _b3 pattern, lowercased keys)
+  function b3(dbh) {
+    function lc(o) { if (!o) return o; var r = {}; for (var k in o) r[k.toLowerCase()] = o[k]; return r; }
+    function exec(sql, args, all) {
+      var st = dbh.prepare(sql), out = all ? [] : undefined;
+      try { st.bind(args.slice()); if (all) { while (st.step()) out.push(lc(st.getAsObject())); } else if (st.step()) out = lc(st.getAsObject()); }
+      finally { st.free(); } return out;
+    }
+    return { prepare: function (sql) { return {
+      get: function () { return exec(sql, [].slice.call(arguments), false); },
+      all: function () { return exec(sql, [].slice.call(arguments), true); } }; } };
+  }
+
+  var opDb = new SQL.Database();
+  window.ERPKernel.initProjection(opDb);
+
+  function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = String(txt); return e; }
+  window.PosLens.open({
+    b3: b3(seed), opDb: opDb, KO: window.KernelOps,
+    seal: function () { return window.KernelOps.sealFrom(opDb); },
+    chainVerify: function () { return (window.KernelOps.verifyChainIncremental || window.KernelOps.verifyChain)(opDb); },
+    overlay: function (title, node) { var h = el('div', '', title); h.id = 'fixture-title'; document.getElementById('mountpt').appendChild(h); document.getElementById('mountpt').appendChild(node); },
+    el: el, status: function (m) { console.log('§FIXTURE-STATUS ' + m); }
+  });
+  window.__posFixtureReady = true;
+})().catch(function (e) { console.log('§FIXTURE-FAIL ' + (e && e.message)); window.__posFixtureError = String(e && e.message); });
+</script>
+</body></html>

--- a/erp/tests/witness_pos_pillbar.js
+++ b/erp/tests/witness_pos_pillbar.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-POS-PILLBAR (FABLE5_FOLLOWUP_2026-07-04 §Item 3). The POS pill-button bar was an
+//   UNTESTED surface (flagged in the pills survey, never picked up). ISSUES THIS PROVES / DISPROVES:
+//     1. The bar RENDERS: `.pos-pill-btn` is a CSS-only legacy of §P-7 — the LIVE bar is the §R2
+//        #pos-top-bar (#pos-pill-payment + #pos-pill-scan) + the ⋯ dock (#pos-pill-import,
+//        #pos-pill-receipt). Each button carries a real svg glyph + hover title; the receipt pill is
+//        HIDDEN until a sale exists (its documented contract).
+//     2. Each button's click fires the RIGHT action (whitebox §-log + DOM state, per
+//        docs/TestArchitecture.md §Browser Testing): payment→§POS-FLOAT toggle, scan→§POS-SCAN
+//        mode=open + .active overlay, import→§POS-IMPORT mode=open, empty-cart Pay→§POS-PAY refused
+//        reason=empty-cart (the T6-guarded path refuses, never half-commits).
+//     3. §PB-DECREE — the close-decree DECISION, stated: the ⋯ dock is a pill RAIL in miniature, so
+//        the universal "no outside-tap close" decree (user decree 2026-07-02, witness_pill_canonical
+//        W2) GOVERNS it despite not being PillBuilder-hosted — only the deliberate ⋯ tap toggles.
+//        Pre-fix the dock closed on any outside pointerdown (the divergence this witness kills).
+//        Lens overlays with their own ✕/Done (scan, receipt, float) are PANELS — decree-EXEMPT.
+//   Playwright is used as the project allows: wiring/DOM checks; every VALUE assertion reads a §-log.
+//   Fixture: erp/tests/fixtures/pos_host.html — REAL pos_lens.js/POSCore/KernelOps over a real sql.js
+//   seed; only the page chrome (login/kanban) is absent.
+//   Run: node erp/tests/witness_pos_pillbar.js 2>&1 | tee build/pos_pillbar.log — then READ the log.
+'use strict';
+const path = require('path'), http = require('http'), fs = require('fs');
+const REPO = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.wasm': 'application/wasm', '.json': 'application/json' };
+function reqPw() { try { return require('playwright'); } catch (e) { return require('/home/red1/bim-ootb/tests/node_modules/playwright'); } }
+
+let fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+(async function () {
+  console.log('\n═══ W-POS-PILLBAR — the POS pill-button bar: renders · right actions · ⋯ decree ═══\n');
+  const server = http.createServer((req, res) => {
+    const p = decodeURIComponent(req.url.split('?')[0]);
+    fs.readFile(path.join(REPO, p), (e, buf) => {
+      if (e) { res.writeHead(404); res.end('404'); return; }
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      res.end(buf);
+    });
+  });
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await reqPw().chromium.launch();
+  try {
+    const logs = [];
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    page.on('console', m => logs.push(m.text()));
+    await page.goto(`http://localhost:${port}/erp/tests/fixtures/pos_host.html`, { waitUntil: 'networkidle' });
+    await page.waitForFunction('window.__posFixtureReady === true || window.__posFixtureError', { timeout: 15000 });
+    const fixErr = await page.evaluate('window.__posFixtureError || null');
+    verdict(!fixErr, '§PB-RENDER fixture booted the REAL pos_lens over a real seed', fixErr || ('§POS-LIVE=' + logs.some(l => l.indexOf('§POS-LIVE open') === 0)));
+
+    // ── §PB-RENDER — the live bar + dock render; glyph + title on every button; receipt starts hidden ──
+    const bar = await page.evaluate(() => {
+      const g = id => { const b = document.getElementById(id); return b && { svg: b.innerHTML.indexOf('<svg') >= 0, title: b.title || '', display: getComputedStyle(b).display }; };
+      return { top: !!document.getElementById('pos-top-bar'), pay: g('pos-pill-payment'), scan: g('pos-pill-scan'),
+               imp: g('pos-pill-import'), rcpt: g('pos-pill-receipt'), dock: !!document.getElementById('pos-dock') };
+    });
+    verdict(bar.top && bar.dock, '§PB-RENDER #pos-top-bar + ⋯ dock present', 'top=' + bar.top + ' dock=' + bar.dock);
+    verdict(!!bar.pay && bar.pay.svg && /pay/i.test(bar.pay.title), '§PB-RENDER payment pill: svg glyph + hover title', 'title="' + (bar.pay && bar.pay.title) + '"');
+    verdict(!!bar.scan && bar.scan.svg && /scan/i.test(bar.scan.title), '§PB-RENDER scan pill: svg glyph + hover title', 'title="' + (bar.scan && bar.scan.title) + '"');
+    verdict(!!bar.imp && bar.imp.svg && /register/i.test(bar.imp.title), '§PB-RENDER import(+) pill: svg glyph + hover title', 'title="' + (bar.imp && bar.imp.title) + '"');
+    verdict(!!bar.rcpt && bar.rcpt.display === 'none', '§PB-RENDER receipt pill HIDDEN until a sale (its contract)', 'display=' + (bar.rcpt && bar.rcpt.display));
+
+    // ── §PB-ACTION — each click fires the RIGHT action (§-log is the value check) ──
+    await page.click('#pos-pill-payment');
+    await page.waitForTimeout(150);
+    const floatOpen = await page.$eval('#pos-float-panel', n => n.classList.contains('open')).catch(() => 'absent');
+    verdict(logs.some(l => l === '§POS-FLOAT toggle=open') && floatOpen === true,
+      '§PB-ACTION payment → float pay panel opens (§POS-FLOAT toggle=open)', 'panelOpen=' + floatOpen);
+
+    // empty-cart Pay refuses honestly (the RIGHT action wired, the T6 guard upstream of any commit)
+    await page.click('#pos-float-tender');
+    await page.waitForTimeout(100);
+    verdict(logs.some(l => l === '§POS-PAY refused reason=empty-cart'),
+      '§PB-ACTION Pay with empty cart → honest refusal, NO commit', '§POS-PAY refused reason=empty-cart logged');
+    await page.click('#pos-pill-payment');                      // toggle the panel back shut
+
+    await page.click('#pos-pill-scan');
+    await page.waitForTimeout(150);
+    const scanActive = await page.$eval('#pos-scan-overlay', n => n.classList.contains('active')).catch(() => 'absent');
+    verdict(logs.some(l => l === '§POS-SCAN mode=open') && scanActive === true,
+      '§PB-ACTION scan → scan overlay active (§POS-SCAN mode=open)', 'overlayActive=' + scanActive);
+    await page.click('#pos-scan-close');                        // the overlay's own deliberate close (decree-exempt panel)
+    await page.waitForTimeout(150);
+    const scanClosed = await page.$eval('#pos-scan-overlay', n => !n.classList.contains('active'));
+    verdict(scanClosed, '§PB-ACTION scan overlay closes via its OWN Done button (panel, not rail)', 'closed=' + scanClosed);
+
+    // the import pill lives in the ⋯ dock — open the dock first (the deliberate tap)
+    await page.click('#pos-dock-trigger');
+    await page.waitForTimeout(150);
+    await page.click('#pos-pill-import');
+    await page.waitForTimeout(150);
+    verdict(logs.some(l => l === '§POS-IMPORT mode=open'), '§PB-ACTION import(+) → register overlay (§POS-IMPORT mode=open)', 'logged');
+    const impClose = await page.$('#pos-import-overlay .pos-import-close, #pos-import-close');
+    if (impClose) { await impClose.click(); await page.waitForTimeout(100); }
+
+    // ── §PB-DECREE — the ⋯ dock obeys the universal close decree: outside tap does NOT collapse ──
+    const dockSel = '#pos-dock-items';
+    const isOpen = () => page.$eval(dockSel, n => n.classList.contains('open'));
+    if (!(await isOpen())) { await page.click('#pos-dock-trigger'); await page.waitForTimeout(150); }
+    verdict(await isOpen(), '§PB-DECREE ⋯ tap opens the dock', 'open=true');
+    await page.mouse.click(640, 200);                            // far from the dock
+    await page.waitForTimeout(300);
+    verdict(await isOpen(), '§PB-DECREE OUTSIDE tap does NOT collapse the dock (decree 2026-07-02, applied — was a divergence)', 'stillOpen=' + await isOpen());
+    await page.click('#pos-dock-trigger');
+    await page.waitForTimeout(150);
+    verdict(!(await isOpen()), '§PB-DECREE only the deliberate ⋯ re-tap collapses', 'open=' + await isOpen());
+    verdict(logs.filter(l => l.indexOf('§POS-DOCK toggle=') === 0).length >= 2, '§PB-DECREE dock toggles are §-logged (every toggle = a deliberate ⋯ tap)', logs.filter(l => l.indexOf('§POS-DOCK') === 0).join(' | '));
+  } finally {
+    await browser.close(); server.close();
+  }
+  console.log('\n' + (fails === 0 ? '✅ W-POS-PILLBAR ALL PASS' : '❌ W-POS-PILLBAR ' + fails + ' FAIL') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.log('🔴 W-POS-PILLBAR CRASH: ' + (e && e.stack || e)); process.exit(1); });

--- a/erp/tests/witness_t7_incremental.js
+++ b/erp/tests/witness_t7_incremental.js
@@ -15,6 +15,25 @@
 //     §T7-SHARD  — a tampered ARCHIVED shard is DETECTED on lazy verify; clean shards chain back to
 //                  GENESIS across TWO shard generations (boundary link = recorded baseTipHash).
 //     §T7-OFF    — below-threshold maybeShard is a no-op, export bytes byte-identical (default-off).
+//   W-T7-HOST extension (prompts/T7_HOST_WIRING_SPEC.md — FABLE5_FOLLOWUP_2026-07-04 §Item 1, the
+//   POS-host wiring; extends this witness, does not replace it):
+//     §T7-HOST-OFF — below threshold THROUGH KanbanHost.maybeShard: no-op, bytes byte-identical.
+//     §T7-HOST     — past ~5k ops the host glue shards for real; measured boot-verify + blob-size drop
+//                    (the instant-first-paint proxy).
+//     §T7-COUNT    — nextIds/PK continuity across the boundary (the collision bomb the wiring would
+//                    have armed: hot COUNT collapses post-shard; opCounts keeps PKs monotonic), and
+//                    cumulative across TWO generations.
+//     §T7-LAZY     — hot-only folds VISIBLY lose pre-shard facts (the named issue), then
+//                    [archived ⊕ hot] restores them EXACTLY: kitchen queue keeps the pre-shard DR
+//                    ticket, logMovements/pendingInbound equal their pre-shard folds; archive cached.
+//     §T7-LAZY-NEG — tampered archived shard ⇒ {ok:false,'payload altered'}; missing blob ⇒
+//                    {ok:false,'missing'} — honest refusal, never a silently-thin history.
+//     §T7-RACE     — a commitGroup landing MID-SHARD (during the archive put's await) is NEVER lost:
+//                    the shard is PINNED to id ≤ baseTipId, the survivor rides the hot log across the
+//                    boundary (not archived, not deleted), the walkers scan past it for the prior
+//                    snapshot, and opCounts stays exact (the survivor is counted by the NEXT shard).
+//                    ISSUE: pre-fix, `DELETE id < snapId` deleted un-archived interleaved ops — a
+//                    silently lost signed sale.
 //   Run: node erp/tests/witness_t7_incremental.js 2>&1 | tee build/t7_incremental.log — then READ the log.
 'use strict';
 var path = require('path');
@@ -32,6 +51,10 @@ require(path.join(ERP, 'erp_shard.js'));
 require(path.join(ERP, 'erp_signer.js'));
 var K = global.window.KernelOps, TipFold = global.window.TipFold, Shard = global.window.ErpShard, Signer = global.window.ErpSigner;
 var EK = require(path.join(ERP, 'erp_kernel.js'));
+require(path.join(ERP, 'kanban_host.js'));                     // W-T7-HOST: the host glue under test
+var KH = global.window.KanbanHost;
+var PL = require(path.join(ERP, 'pos_lens.js'))._t7;           // the shard-aware pure folds (node seam)
+var KC = require(path.join(ERP, 'kitchen_core.js'));
 
 var fails = 0;
 function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
@@ -234,7 +257,160 @@ function memStore() {
   verdict(rOff.sharded === false && rOff.reason === 'below-threshold', '§T7-OFF below-threshold maybeShard is a no-op', 'n=' + rOff.n + ' threshold=' + rOff.threshold);
   verdict(b1.length === b2.length && Buffer.from(b1).equals(Buffer.from(b2)), '§T7-OFF export bytes BYTE-IDENTICAL', b1.length + ' bytes');
 
+  // ════ W-T7-HOST — the POS-host wiring end-to-end (prompts/T7_HOST_WIRING_SPEC.md) ════
+  console.log('\n═══ W-T7-HOST — KanbanHost.maybeShard/archivedOps + shard-aware POS folds ═══\n');
+  function hotRows(d) {
+    var r = d.exec('SELECT id, timestamp, op_type, parameters FROM kernel_ops ORDER BY id');
+    return (r[0] ? r[0].values : []).map(function (v) { return { id: v[0], timestamp: v[1], op_type: v[2], parameters: v[3] }; });
+  }
+  var b3mock = { prepare: function () { return { all: function () { return []; }, get: function () { return null; } }; } };
+  function grp(ops) { return ops.map(function (o) { return { op_type: o.op_type, op_uuid: o.op_uuid, params: o }; }); } // the POS commit shape, verbatim
+
+  // §T7-HOST-OFF — the host glue below threshold: byte-identical no-op (default off THROUGH the glue).
+  var dbS = new SQL.Database(); EK.initProjection(dbS);
+  for (g = 0; g < 3; g++) await commitBatch(dbS, g);
+  var hb1 = dbS.export();
+  var rHostOff = await KH.maybeShard(dbS, 'hostlog-small', { store: memStore(), persist: false });
+  var hb2 = dbS.export();
+  verdict(rHostOff.sharded === false && rHostOff.reason === 'below-threshold',
+    '§T7-HOST-OFF below-threshold host maybeShard is a no-op', 'n=' + rHostOff.n + ' threshold=' + rHostOff.threshold + ' (host default)');
+  verdict(rHostOff.threshold === 5000, '§T7-HOST-OFF host default threshold is the tested 5000', 'threshold=' + rHostOff.threshold);
+  verdict(hb1.length === hb2.length && Buffer.from(hb1).equals(Buffer.from(hb2)), '§T7-HOST-OFF export bytes BYTE-IDENTICAL', hb1.length + ' bytes');
+
+  // build the host-scale db: TWO pre-shard facts a thin fold would LOSE, then ~5k ops of noise.
+  var dbH = new SQL.Database(); EK.initProjection(dbH);
+  var createdDocs = 0;                                          // ground truth for §T7-COUNT opCounts
+  // fact A — a deliver-later kitchen ticket: order + C- shipment born DR, NEVER completed (still owed).
+  var rA = await K.commitGroup(dbH, grp([
+    { op_type: 'CREATE_DOCUMENT', op_uuid: 'u-dl-o', table: 'C_Order', c_order_id: 910001, c_bpartner_id: 118, c_pos_id: 100, c_doctype_id: 135 },
+    { op_type: 'CREATE_DOCUMENT', op_uuid: 'u-dl-io', table: 'M_InOut', m_inout_id: 910002, source_id: 910001, c_doctype_id: 120, m_warehouse_id: 50, movementtype: 'C-' },
+    { op_type: 'CREATE_LINE', op_uuid: 'u-dl-iol', table: 'M_InOutLine', source_line_id: 1, m_product_id: 124, movementqty: 2 }
+  ]), { gid: 'g-deliverlater', baseTs: 900000 });
+  if (!rA.committed) throw new Error('fact A not committed: ' + rA.reason);
+  createdDocs += 2;
+  // fact B — an OPEN replenish PO (issotrx N): its qty must keep counting as on-order (no double order).
+  var rB = await K.commitGroup(dbH, grp([
+    { op_type: 'CREATE_DOCUMENT', op_uuid: 'u-po-o', table: 'C_Order', issotrx: 'N', m_warehouse_id: 50, c_order_id: 910011 },
+    { op_type: 'CREATE_LINE', op_uuid: 'u-po-l', table: 'C_OrderLine', qtyordered: 7, m_product_id: 124 }
+  ]), { gid: 'g-openpo', baseTs: 900001 });
+  if (!rB.committed) throw new Error('fact B not committed: ' + rB.reason);
+  createdDocs += 1;
+  var tH = Date.now();
+  for (g = 0; g < 505; g++) { await commitBatch(dbH, 1000 + g); createdDocs += 1; } // each batch EK-applies 1 CREATE_DOCUMENT
+  var nH = dbH.exec('SELECT COUNT(*) FROM kernel_ops')[0].values[0][0];
+  console.log('   built host-scale log: ' + nH + ' signed ops (' + ms(tH) + 'ms), pre-shard facts: 1 DR ticket + 1 open PO\n');
+
+  // the pre-shard truths (what the folds MUST still say after the boundary):
+  var idsPre = PL.nextIds(dbH);
+  var mvPre = JSON.stringify(PL.logMovements(dbH));
+  var pendPre = JSON.stringify(PL.pendingInbound(dbH, b3mock, 50));
+  var kqPre = KC.queue(KC.foldTickets(hotRows(dbH))).map(function (t) { return t.m_inout_id; });
+  verdict(kqPre.indexOf(910002) >= 0, '§T7-HOST pre-shard: the DR ticket is queued', 'queue=' + JSON.stringify(kqPre));
+  verdict(JSON.parse(pendPre)['124'] === 700, '§T7-HOST pre-shard: open PO counts 7.00 on-order for product 124', 'pend=' + pendPre);
+
+  // §T7-HOST — shard through the host glue; measured first-paint proxies (blob size + cold boot verify).
+  var bytesPre = dbH.export().length;
+  dbH.__krnVerifiedTip = null;
+  var tBootPre = Date.now(); await K.verifyChain(dbH); tBootPre = ms(tBootPre);
+  var storeH = memStore();
+  var rHost = await KH.maybeShard(dbH, 'hostlog', { store: storeH, persist: false });
+  verdict(rHost.sharded === true && rHost.ok === true, '§T7-HOST past-threshold host maybeShard SHARDS', 'seq=' + rHost.seq + ' archived=' + rHost.archived + ' hotOps=' + rHost.hotLen);
+  var bytesPost = dbH.export().length;
+  dbH.__krnVerifiedTip = null;
+  var tBootPost = Date.now(); await K.verifyChain(dbH); tBootPost = ms(tBootPost);
+  verdict(bytesPost < bytesPre, '§T7-HOST persisted-blob size drop (first-paint payload)', bytesPre + '→' + bytesPost + ' bytes');
+  verdict(tBootPost < tBootPre, '§T7-HOST measured cold boot-verify drop', tBootPre + 'ms→' + tBootPost + 'ms (' + nH + '→' + rHost.hotLen + ' ops)');
+
+  // §T7-COUNT — PK continuity: the very next ids are IDENTICAL pre vs post shard (no collision window).
+  var idsPost = PL.nextIds(dbH);
+  verdict(idsPost.orderId === idsPre.orderId && idsPost.inoutId === idsPre.inoutId,
+    '§T7-COUNT nextIds continuity across the boundary', 'pre=' + idsPre.orderId + ' post=' + idsPost.orderId);
+  // generation 2: more sales, shard again (forced low threshold), continuity + CUMULATIVE opCounts hold.
+  var idsG2a = PL.nextIds(dbH);
+  await K.commitGroup(dbH, grp([{ op_type: 'CREATE_DOCUMENT', op_uuid: 'u-g2-o', table: 'C_Order', c_order_id: idsG2a.orderId }]), { gid: 'g-gen2', baseTs: 910000 });
+  createdDocs += 1;
+  var rHost2 = await KH.maybeShard(dbH, 'hostlog', { store: storeH, persist: false, threshold: 2 });
+  verdict(rHost2.sharded === true && rHost2.seq === 2, '§T7-COUNT generation-2 shard closes', 'seq=' + rHost2.seq);
+  var snap2 = JSON.parse(dbH.exec("SELECT parameters FROM kernel_ops WHERE op_type='SHARD_SNAPSHOT' ORDER BY id DESC LIMIT 1")[0].values[0][0]).payload;
+  verdict(Number(snap2.opCounts.CREATE_DOCUMENT) === createdDocs,
+    '§T7-COUNT opCounts CUMULATIVE across two generations', 'recorded=' + snap2.opCounts.CREATE_DOCUMENT + ' truth=' + createdDocs);
+  var idsG2b = PL.nextIds(dbH);
+  verdict(idsG2b.orderId === idsG2a.orderId + 10, '§T7-COUNT PK band stays monotonic after gen-2 shard', idsG2a.orderId + '→' + idsG2b.orderId);
+
+  // §T7-LAZY — first SHOW the loss (the named issue: hot-only folds go thin), then the lazy cure.
+  var kqThin = KC.queue(KC.foldTickets(hotRows(dbH))).map(function (t) { return t.m_inout_id; });
+  verdict(kqThin.indexOf(910002) < 0, '§T7-LAZY (issue named) hot-only kitchen fold LOSES the pre-shard DR ticket', 'thinQueue=' + JSON.stringify(kqThin));
+  verdict(JSON.stringify(PL.pendingInbound(dbH, b3mock, 50)) !== pendPre, '§T7-LAZY (issue named) hot-only pending fold LOSES the open PO', 'hot-only=' + JSON.stringify(PL.pendingInbound(dbH, b3mock, 50)));
+  var arch = await KH.archivedOps(dbH, 'hostlog', { store: storeH });
+  verdict(arch.ok === true && arch.shards === 2 && arch.ops.length > 0, '§T7-LAZY archivedOps walks 2 shards back to GENESIS', 'ops=' + arch.ops.length + ' shards=' + arch.shards);
+  var kqLazy = KC.queue(KC.foldTickets(arch.ops.concat(hotRows(dbH)))).map(function (t) { return t.m_inout_id; });
+  verdict(kqLazy.indexOf(910002) >= 0 && JSON.stringify(kqLazy) === JSON.stringify(kqPre),
+    '§T7-LAZY kitchen queue [archived ⊕ hot] == pre-shard queue (ticket still owed)', 'queue=' + JSON.stringify(kqLazy));
+  verdict(JSON.stringify(PL.logMovements(dbH, arch.ops)) === mvPre, '§T7-LAZY logMovements [archived ⊕ hot] == pre-shard fold', 'events=' + JSON.parse(mvPre).length);
+  verdict(JSON.stringify(PL.pendingInbound(dbH, b3mock, 50, arch.ops)) === pendPre, '§T7-LAZY pendingInbound [archived ⊕ hot] == pre-shard fold (no double order)', 'pend=' + pendPre);
+  var arch2 = await KH.archivedOps(dbH, 'hostlog', { store: storeH });
+  verdict(arch2.cached === true && arch2.ops.length === arch.ops.length, '§T7-LAZY second fetch serves the per-generation cache', 'cached=' + arch2.cached);
+
+  // §T7-LAZY-NEG — tamper + missing: refuse honestly, never fabricate a thin history as complete.
+  var hBlob = JSON.parse(storeH._m['hostlog::shard:1']);
+  var hOrig = hBlob[10].parameters; hBlob[10].parameters = hOrig + 'X';
+  storeH._m['hostlog::shard:1'] = JSON.stringify(hBlob);
+  dbH.__shardArchive = null;                                    // drop the cache — force a live walk
+  var archT = await KH.archivedOps(dbH, 'hostlog', { store: storeH });
+  verdict(archT.ok === false && archT.why === 'payload altered', '§T7-LAZY-NEG tampered archived shard REFUSED', 'seq=' + archT.seq + ' why=' + archT.why + ' at=' + archT.at);
+  hBlob[10].parameters = hOrig; storeH._m['hostlog::shard:1'] = JSON.stringify(hBlob);
+  var savedShard = storeH._m['hostlog::shard:2']; delete storeH._m['hostlog::shard:2'];
+  dbH.__shardArchive = null;
+  var archM = await KH.archivedOps(dbH, 'hostlog', { store: storeH });
+  verdict(archM.ok === false && archM.why === 'missing', '§T7-LAZY-NEG missing shard blob REFUSED', 'seq=' + archM.seq + ' why=' + archM.why);
+  storeH._m['hostlog::shard:2'] = savedShard;
+  dbH.__shardArchive = null;
+  var archR = await KH.archivedOps(dbH, 'hostlog', { store: storeH });
+  verdict(archR.ok === true && archR.shards === 2, '§T7-LAZY-NEG restored archive verifies again', 'ops=' + archR.ops.length);
+
+  // ── §T7-RACE — a commit landing MID-SHARD must never be lost (the pinned-prefix delete) ──
+  var dbR = new SQL.Database(); EK.initProjection(dbR);
+  for (g = 0; g < 8; g++) await commitBatch(dbR, 2000 + g);
+  var storeR = memStore();
+  var raceCommitted = false;
+  var rigStore = { _m: storeR._m, get: storeR.get, put: async function (k, v) {
+    await storeR.put(k, v);
+    if (!raceCommitted) {                                       // fire ONCE, inside the widest mid-shard await
+      raceCommitted = true;
+      var rr = await K.commitGroup(dbR, grp([{ op_type: 'CREATE_DOCUMENT', op_uuid: 'u-race', table: 'C_Order', c_order_id: 970001 }]), { gid: 'g-race', baseTs: 950000 });
+      if (!rr.committed) throw new Error('race commit failed: ' + rr.reason);
+    }
+  } };
+  var preRaceTotal = Number(dbR.exec('SELECT COUNT(*) FROM kernel_ops')[0].values[0][0]);
+  var rRace = await Shard.shard(dbR, { store: rigStore, key: 'racelog', ts: 3100000 });
+  verdict(rRace.sharded === true && rRace.ok === true, '§T7-RACE shard completes despite a mid-shard commit', 'archived=' + rRace.archived + ' hotOps=' + rRace.hotLen);
+  var survivorHot = Number(dbR.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_uuid='u-race'")[0].values[0][0]);
+  verdict(survivorHot === 1, '§T7-RACE the interleaved op SURVIVES in the hot log (was silently deleted pre-fix)', 'rows=' + survivorHot);
+  var raceBlob = JSON.parse(storeR._m['racelog::shard:1']);
+  verdict(!raceBlob.some(function (o) { return o.op_uuid === 'u-race'; }) && raceBlob.length === preRaceTotal,
+    '§T7-RACE the archive is PINNED to the pre-commit prefix (survivor not archived)', 'archived=' + raceBlob.length + ' pinned=' + preRaceTotal);
+  var raceArch = await Shard.loadArchivedOps(dbR, storeR, 'racelog');
+  var allRace = raceArch.ops.concat(Shard.exportOps(dbR));
+  var raceSeen = allRace.filter(function (o) { return o.op_uuid === 'u-race'; }).length;
+  verdict(raceArch.ok === true && raceSeen === 1 && allRace.length === preRaceTotal + 2,
+    '§T7-RACE [archived ⊕ hot] = every committed op exactly ONCE', 'total=' + allRace.length + ' (=' + preRaceTotal + ' archived + snapshot + survivor)');
+  // generation 2: the survivor now sits AHEAD of snapshot-1 inside shard 2 — the walkers must scan past it.
+  var replayPre2 = EK.replay(dbR, new SQL.Database()).hash;
+  var rRace2 = await Shard.shard(dbR, { store: storeR, key: 'racelog', ts: 3100001 });
+  verdict(rRace2.sharded === true && rRace2.seq === 2, '§T7-RACE generation-2 shard closes over the survivor', 'archived=' + rRace2.archived);
+  var raceWalk = await Shard.verifyShards(dbR, storeR, 'racelog');
+  verdict(raceWalk.ok === true && raceWalk.shards === 2, '§T7-RACE verifyShards scans past the survivor to the prior snapshot', JSON.stringify(raceWalk));
+  dbR.__shardArchive = null;
+  var raceArch2 = await Shard.loadArchivedOps(dbR, storeR, 'racelog');
+  verdict(raceArch2.ok === true && raceArch2.ops.filter(function (o) { return o.op_uuid === 'u-race'; }).length === 1,
+    '§T7-RACE lazy walk still yields the survivor exactly once across 2 generations', 'archivedOps=' + raceArch2.ops.length);
+  var snapR2 = JSON.parse(dbR.exec("SELECT parameters FROM kernel_ops WHERE op_type='SHARD_SNAPSHOT' ORDER BY id DESC LIMIT 1")[0].values[0][0]).payload;
+  verdict(Number(snapR2.opCounts.CREATE_DOCUMENT) === 8 + 1,
+    '§T7-RACE opCounts exact: survivor counted by the shard that ARCHIVES it (no drift/double-count)', 'recorded=' + snapR2.opCounts.CREATE_DOCUMENT + ' truth=9');
+  var replayPost2 = EK.replay(dbR, new SQL.Database()).hash;
+  verdict(replayPost2 === replayPre2, '§T7-RACE projection preserved across the raced generations', replayPost2);
+
   K.setSigner(null); K.setContentSigning(false);
-  console.log('\n' + (fails === 0 ? '✅ W-T7-INC ALL PASS' : '❌ W-T7-INC ' + fails + ' FAIL') + '\n');
+  console.log('\n' + (fails === 0 ? '✅ W-T7-INC + W-T7-HOST ALL PASS' : '❌ W-T7-INC/HOST ' + fails + ' FAIL') + '\n');
   process.exit(fails === 0 ? 0 : 1);
 })().catch(function (e) { console.log('🔴 W-T7-INC CRASH: ' + (e && e.stack || e)); process.exit(1); });

--- a/prompts/T7_HOST_WIRING_SPEC.md
+++ b/prompts/T7_HOST_WIRING_SPEC.md
@@ -1,0 +1,77 @@
+# ⚠ DO NOT REMOVE — T7 host wiring: ErpShard.maybeShard into the POS host + lazy shard history, 2026-07-04
+# Scope: bim-compiler prompts/FABLE5_FOLLOWUP_2026-07-04.md §Item 1 (carried from FABLE5_WRAPUP §4b —
+# "ErpShard host opt-in unwired"). Builds ON prompts/T7_INCREMENTAL_SHARD_SPEC.md (the engine, PR #636);
+# this spec is the WIRING half. Read the log after every run. Witness: W-T7-HOST (extends
+# erp/tests/witness_t7_incremental.js — extend, don't replace).
+
+## The gap being closed
+`erp/erp_shard.js` shipped (#636) but NOTHING calls it — the ~5k-op POS scale cliff is still fully live.
+The shard target is the POS/kanban op log: `window.ERP.opDb` (kanban_host projDb), persisted at
+`bim_ootb_cache/dbs/idmp_kanban_proj`. Threshold = **5000** (the tested value: erp_shard.maybeShard's
+default + the W-T7-INC ~4.9k synthetic log). The crud sidecar log (`glassbowl_kernel_ops`) is NOT
+sharded by this wiring — `__crud.readTip` / lineage-hover / kanban tips read the sidecar and are
+unaffected (verified: idempiere.html:4118 reads `__crud.readTip`, not the projDb).
+
+## Discovered pre-wiring hazards (walkers that assume the FULL log is hot)
+Naively calling maybeShard would corrupt three POS folds — each walks raw `kernel_ops` rows from t0:
+1. **`pos_lens.nextIds`** (SYNC, on the Pay path) — `COUNT(CREATE_DOCUMENT)` → deterministic PKs.
+   Post-shard the count collapses → **PK reuse/collision** with archived orders. Hard corruption.
+2. **`pos_lens.logMovements` + `pendingInbound` → `suggestAll`** — replenishment stock arithmetic
+   loses pre-shard movements/open POs → wrong suggestions + double-order (defeats the
+   pendingInbound=no-double-order guard, bc #19/#22).
+3. **`kitchen_lens._opRows` → `KitchenCore.foldTickets`** — pre-shard undelivered DR tickets vanish
+   from the KDS queue (a deliver-later sale older than the boundary is still owed to the customer).
+
+## Build (all additive; DEFAULT OFF preserved — nothing changes until a host injects the hooks)
+1. **`erp/erp_shard.js`** — snapshot payload gains cumulative **`opCounts`** ({op_type: n} over ALL ops
+   up to the boundary = prior snapshot's opCounts + this shard's rows). A recorded INPUT (period-close
+   doctrine, same as projState) for counter-style walkers that cannot await a lazy fetch. Also new
+   **`loadArchivedOps(db, store, key)`**: walk shards BACKWARD from the hot snapshot (loadShard verifies
+   each internally; boundary link = recorded baseTipHash, same rule as verifyShards), return the full
+   archived prefix ASCENDING; cache on `db.__shardArchive = {atSeq, ops}` so the fetch happens ONCE per
+   generation (a new shard bumps seq → refetch). Tamper/missing ⇒ `{ok:false, why, seq}` — callers get
+   an HONEST refusal, never a silently-thin history.
+2. **`erp/kanban_host.js`** — host glue: `shardStore()` ({get,put} over bim_ootb_cache/dbs — the same
+   IDB the blob lives in, so shard blobs ride the existing store), `maybeShard(projDb, projKey, opts)`
+   (ErpShard.maybeShard @5000 → on sharded=true PERSIST the shrunk hot blob — that IS the instant first
+   paint: boot loads [snapshot + open shard] only), `archivedOps(projDb, projKey, opts)` (lazy history
+   for scrub/fold surfaces).
+3. **`erp/pos_lens.js`** — (a) `nextIds` += latest-snapshot `opCounts.CREATE_DOCUMENT` (sync, hot-db
+   query, O(1)); (b) replenish folds accept lazily-fetched archived rows: `suggestAll(b3, opDb, archived)`
+   prepends them into logMovements/pendingInbound walks; generateReplenish awaits `cfg.archivedOps()`
+   first (panel-open path — async is fine there, NEVER on the Pay path); (c) after each successful
+   commit+chainVerify (sale / deliver-later / replenish-commit) call debounced `cfg.maybeShard()`
+   (2s, the `_persistToIdb` idiom). No cfg hooks injected → byte-identical behavior (default off).
+4. **`erp/kitchen_lens.js`** — on open, await `cfg.archivedOps()` once; `_opRows` folds
+   [archived ⊕ hot]; a failed archive fetch folds hot-only + §-warns (honest degradation).
+5. **`erp/idempiere.html`** — openPosFor injects `maybeShard` + `archivedOps`; openKitchenFor injects
+   `archivedOps` (all via KanbanHost, key `_KPROJ`).
+
+## Time-Machine decision (stated, not implicit)
+There is no dedicated op-log Time-Machine UI on the ERP pages today (Z-bar/W-pill = nav history;
+viewer TM = 4D schedule). The surfaces that DO scrub op-log history from t0 on the POS host are the
+kitchen queue fold + the replenishment pending fold — THOSE are wired to lazy `loadShard` (via
+loadArchivedOps). First paint needs only the hot blob (boot path unchanged, already small post-shard).
+The lineage hover reads the un-sharded crud sidecar — no wiring needed until that log ever shards.
+
+## Verify — W-T7-HOST (new §s appended to witness_t7_incremental.js, node, real ECDSA)
+§T7-HOST-OFF  below threshold through KanbanHost.maybeShard: no-op, export bytes byte-identical
+              (matches existing §T7-OFF, but through the HOST path).
+§T7-HOST      past ~5k ops: shards for real; measured boot-verify + blob-size drop (the first-paint
+              proxy, same methodology as §T7-SNAP's measured drop).
+§T7-COUNT     nextIds continuity: next PK id identical pre-shard vs post-shard (+ opCounts cumulative
+              across TWO generations) — no collision window.
+§T7-LAZY      kitchen foldTickets([archived ⊕ hot]) == foldTickets(pre-shard full log) — a pre-shard
+              undelivered DR ticket is STILL QUEUED post-shard; suggestAll equality pre vs post+archived.
+§T7-LAZY-NEG  tampered archived shard ⇒ loadArchivedOps {ok:false, why:'payload altered'}; MISSING
+              shard blob ⇒ {ok:false, why:'missing'} — both refuse, neither fabricates a thin history.
+§T7-RACE      a commitGroup landing MID-SHARD is never lost. DISCOVERED during this wiring: shard()
+              runs across awaits (crypto + the store) and used `DELETE id < snapId` — an op committed
+              between the archive export and the snapshot got an id below snapId ⇒ deleted but never
+              archived = a silently lost SIGNED sale. FIX (erp_shard.js): the shard is PINNED to
+              id ≤ baseTipId (export bounded, delete bounded, opCounts derived from the archived array
+              itself); a mid-shard survivor rides the hot log across the boundary, the T2 v1-sig guard
+              extends to survivors (they get re-sealed too), and verifyShards/loadArchivedOps SCAN for
+              the prior snapshot instead of assuming it is the shard's first row. An op landing between
+              verifyChain and the MAX(id) pin ⇒ av.tip ≠ v.tip ⇒ safe ABORT (retry next debounce).
+Each § prints measured/compared values; read build/t7_incremental.log before concluding.

--- a/teams/overlay/teams_pill.js
+++ b/teams/overlay/teams_pill.js
@@ -75,6 +75,19 @@ function mountTeamsPill(headerEl, opts) {
     } else {
       pane = _el('div', 'teams-pane');                            // the overlay pane (created ONLY when ON)
       pane.id = 'teams-pane';
+      // FABLE5_FOLLOWUP_2026-07-04 §Item 2 (Witness: W-TEAM-WIRE close leg): the standalone pane gets
+      // the SAME deliberate close affordance the host `.bim-panel` shell provides (`.bim-panel-close`
+      // → onClose) — a visible ✕ wired to the EXISTING close() (the pill's own toggle idiom; no new
+      // interaction, and no reliance on "click the pill again" being discoverable). float:right keeps
+      // it in normal flow so it never fights the demo's own `.teams-pane` positioning.
+      var x = _el('button', 'teams-pane-close', '✕');
+      x.type = 'button';
+      x.setAttribute('aria-label', 'Close ' + label);
+      x.title = 'Close';
+      x.style.cssText = 'float:right;margin:2px 2px 6px 8px;padding:0 6px;background:none;border:none;' +
+                        'color:inherit;font:inherit;font-size:14px;line-height:1.4;cursor:pointer;opacity:.7';
+      x.addEventListener('click', close);
+      pane.appendChild(x);
       (opts.paneHost || document.body).appendChild(pane);
     }
     if (opts.onMount) opts.onMount(pane);

--- a/teams/tests/wire_teams_pill.js
+++ b/teams/tests/wire_teams_pill.js
@@ -8,6 +8,11 @@
 //     §WIRE-OFF      — Team OFF (default) = pixel-identical: no overlay pane, no dots; chrome DOM == baseline.
 //     §WIRE-ON       — click the pill → the overlay pane mounts + dots paint onto the rows.
 //     §WIRE-REVERSIBLE — click again → pane removed + chrome DOM === the OFF baseline (off = identical, reversible).
+//     §WIRE-CLOSE-X  — FABLE5_FOLLOWUP_2026-07-04 §Item 2: the STANDALONE fallback pane carries a visible
+//                      close affordance (.teams-pane-close ✕ — the host `.bim-panel-close` analogue) and
+//                      clicking IT routes through the same close(): pane gone, pill un-pressed, OFF baseline.
+//                      ISSUE PROVED: pre-fix the standalone pane had NO close button (only the PillBuilder-
+//                      hosted variant did) — the only way out was knowing to re-click the pill.
 //   Run: node teams/tests/wire_teams_pill.js 2>&1 | tee teams/logs/wire_teams_pill.log — then READ the log.
 'use strict';
 var path = require('path'), http = require('http'), fs = require('fs');
@@ -65,11 +70,23 @@ function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok 
     });
     verdict(after.pane === false && after.html === baseline,
       '§WIRE-REVERSIBLE  off again === OFF baseline (reversible)', 'pane=' + after.pane + ' chromeIdentical=' + (after.html === baseline));
+
+    // §WIRE-CLOSE-X — re-open, then close via the pane's OWN ✕ (not the pill): same close(), same baseline.
+    await page.click('#teams-pill');
+    var xBtn = await page.$('#teams-pane .teams-pane-close');
+    verdict(!!xBtn, '§WIRE-CLOSE-X  standalone pane carries a visible close affordance', 'sel=#teams-pane .teams-pane-close');
+    if (xBtn) await xBtn.click();
+    var afterX = await page.evaluate(function () {
+      return { pane: !!document.getElementById('teams-pane'), pressed: document.getElementById('teams-pill').getAttribute('aria-pressed'),
+               html: document.getElementById('chrome').innerHTML };
+    });
+    verdict(afterX.pane === false && afterX.pressed === 'false' && afterX.html === baseline,
+      '§WIRE-CLOSE-X  ✕ routes through close(): pane gone, pill un-pressed, OFF baseline', 'pane=' + afterX.pane + ' pressed=' + afterX.pressed + ' chromeIdentical=' + (afterX.html === baseline));
   } finally {
     await browser.close(); server.close();
   }
 
-  var n = 4;
+  var n = 6;
   console.log('\n' + (fails === 0 ? '✅ W-TEAM-WIRE ' + n + '/' + n + ' PASS' : '❌ ' + fails + '/' + n + ' FAIL') + '\n');
   process.exit(fails === 0 ? 0 : 1);
 })().catch(function (e) { console.log('🔴 THREW ' + e.message + '\n' + (e.stack || '').split('\n').slice(1, 4).join('\n')); process.exit(1); });


### PR DESCRIPTION
## Summary
- Item 1: `ErpShard.maybeShard` finally has a caller (`erp/kanban_host.js` + `erp/pos_lens.js`) — the ~5k-op POS scale cliff is now defused in production, not just in the witness. Discovered + fixed 3 pre-wiring hazards (PK counter collapse, replenishment fold data loss, kitchen queue ticket loss) plus a genuine race condition (§T7-RACE: a commitGroup landing mid-shard was silently deleted without being archived — a signed sale could vanish). Full spec: `prompts/T7_HOST_WIRING_SPEC.md`.
- Item 2: `teams_pill.js` standalone fallback now has a visible close (✕), matching the existing `.bim-panel-close` idiom.
- Item 3: new `W-POS-PILLBAR` witness (`erp/tests/witness_pos_pillbar.js` + `erp/tests/fixtures/pos_host.html`) covering the POS `.pos-pill-btn` bar end-to-end.

## Test plan
- [x] W-T7-INC + W-T7-HOST all pass (62 verdicts, `build/t7_incremental.log`)
- [x] Regressions green: W-CONTENT-SIGN, W-ROSTER-VERIFY, W-CROSS-TAB-PERSIST, W-PCLOSE-ARCHIVE, W-XSS-FILENAME, W-PILL-CANON
- [x] W-TEAM-WIRE extended (6/6, §WIRE-CLOSE-X)
- [x] W-POS-PILLBAR new witness, all pass

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>