### PR TITLE
fix(erp): §PCLOSE-RACE — pin period-close compaction boundary before archive await

### DIFF
--- a/erp/erp_period_close.js
+++ b/erp/erp_period_close.js
@@ -65,6 +65,12 @@
     return { equal: max === 0, maxDiffCents: max };
   }
 
+  function _maxId(db) {
+    var r = db.exec('SELECT MAX(id) FROM kernel_ops');
+    if (!r.length || r[0].values[0][0] == null) return 0;
+    return Number(r[0].values[0][0]);
+  }
+
   // ── _snapshotLog — the full signed pre-close rows as a self-describing cold-archive array.
   //    Every mutating + chain column travels so the archive is independently verifiable AND re-foldable
   //    (foldBalances reads op_type + parameters). This is what the DELETE is about to destroy.
@@ -103,6 +109,15 @@
     if (!pre.ok) throw new Error('closePeriod: pre-close chain does not verify (brokeAt=' + pre.brokeAt + ' ' + pre.why + ')');
     var prevTip = pre.tip, archived = pre.len;
 
+    // §PCLOSE-RACE (feedback_toctou_race_scrutiny_pattern.md, same shape as erp_shard.js §T7-RACE):
+    // pin the compaction boundary HERE, synchronously, BEFORE the archiveSink await below — never
+    // derive it from ckptId (minted AFTER that await). A concurrent commit landing during the await
+    // (e.g. a POS sale mid period-close) gets id > baseTipId: it was not in the archived snapshot, so
+    // it must NOT be deleted either — it rides the hot log across the boundary, uncompacted, and is
+    // picked up whole by the next fold. Witness: erp/tests/witness_pclose_race.js (pre-fix: FAIL, the
+    // racing op vanished — archived nowhere, deleted anyway).
+    var baseTipId = _maxId(db);
+
     // 2. fold the live ops → closing balances (integer cents).
     var live = kernel.replayOps(db);
     var closing = foldBalances(live, null).bal;
@@ -111,7 +126,7 @@
     //    a confirmation. No sink ⇒ no compaction (retain history). Sink rejects ⇒ THROW (destroy nothing).
     var willCompact = false, archiveRef = null;
     if (archiveSink) {
-      var snapshot = _snapshotLog(db, null);                 // the whole live log, pre-checkpoint
+      var snapshot = _snapshotLog(db, baseTipId + 1);        // the live log up to the PINNED boundary
       var res = await archiveSink(snapshot);
       if (!res || !res.ok) {
         throw new Error('closePeriod: archive NOT confirmed (' + ((res && res.reason) || 'sink returned !ok') +
@@ -126,11 +141,12 @@
 
     // 4. commit ONE checkpoint op carrying the deterministic payload (+ the archive ref); re-stamp to ts.
     var ckptId = kernel.commitOp(db, CKPT_TYPE,
-      { period: period, closing_balances: closing, prev_tip: prevTip, archive_ref: archiveRef });
+      { period: period, closing_balances: closing, prev_tip: prevTip, archive_ref: archiveRef, base_tip_id: baseTipId });
     db.run('UPDATE kernel_ops SET timestamp=? WHERE id=?', [ts, ckptId]);
 
-    // 5. compact ONLY when the archive was confirmed: drop every pre-checkpoint op from the LIVE log.
-    if (willCompact) db.run('DELETE FROM kernel_ops WHERE id < ?', [ckptId]);
+    // 5. compact ONLY when the archive was confirmed: drop the ARCHIVED prefix ONLY (id <= baseTipId —
+    //    a §PCLOSE-RACE survivor, id > baseTipId, keeps its row and is never touched here).
+    if (willCompact) db.run('DELETE FROM kernel_ops WHERE id <= ?', [baseTipId]);
 
     // 6. re-seal the (possibly compacted) live log; the new tip is the fingerprint of [PERIOD_CLOSE].
     var sealRes = await kernel.sealChain(db);

--- a/erp/tests/witness_pclose_race.js
+++ b/erp/tests/witness_pclose_race.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — §PCLOSE-RACE: constructed witness for the TOCTOU shape flagged in
+//   feedback_toctou_race_scrutiny_pattern.md against erp_period_close.js closePeriod():
+//     1. snapshot = _snapshotLog(db, null)   -- captured BEFORE the archiveSink await
+//     2. await archiveSink(snapshot)          -- event-loop yields here
+//     3. ckptId = kernel.commitOp(...)        -- boundary MINTED AFTER the await
+//     4. db.run('DELETE FROM kernel_ops WHERE id < ckptId')  -- deletes by the POST-await boundary
+//   If a real op is committed to kernel_ops DURING the archiveSink await (simulating a concurrent
+//   POS sale mid period-close), it gets id < ckptId (since ckptId is minted after) but was NOT in
+//   the snapshot (captured before) — so it would be silently deleted, never archived, never replayed.
+//   Run: node erp/tests/witness_pclose_race.js 2>&1 | tee build/pclose_race.log
+'use strict';
+var path = require('path');
+if (!global.window) global.window = {};
+if (!global.crypto || !global.crypto.subtle) global.crypto = require('crypto').webcrypto;
+function reqSql() {
+  var tries = ['sql.js', '/home/red1/bim-ootb/node_modules/sql.js', path.join(__dirname, '..', '..', 'node_modules', 'sql.js')];
+  for (var i = 0; i < tries.length; i++) { try { return require(tries[i]); } catch (e) {} }
+  throw new Error('sql.js not resolvable');
+}
+var ERP = path.join(__dirname, '..');
+require(path.join(ERP, 'kernel_ops.js'));
+require(path.join(ERP, 'erp_period_close.js'));
+var K = global.window.KernelOps, PC = global.window.ErpPeriodClose;
+
+var fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+(async function () {
+  var SQL = await reqSql()();
+  var db = new SQL.Database();
+
+  K.commitOp(db, 'POST', { account: 'A', cents: 1000 });
+  K.commitOp(db, 'POST', { account: 'B', cents: -1000 });
+  var preRaceCount = db.exec('SELECT COUNT(*) FROM kernel_ops')[0].values[0][0];
+  console.log('§PCLOSE-RACE-SETUP preRaceCount=' + preRaceCount);
+
+  var raceCommitted = false;
+  var raceId = null;
+  var archiveSink = function (snapshot) {
+    return new Promise(function (resolve) {
+      // fire the "concurrent commit" INSIDE the archive await window — a sale landing mid-close.
+      if (!raceCommitted) {
+        raceCommitted = true;
+        raceId = K.commitOp(db, 'POST', { account: 'RACE', cents: 4413 });
+        console.log('§PCLOSE-RACE-FIRE committed op id=' + raceId + ' during archiveSink await; snapshot had ' + snapshot.length + ' rows (pre-race)');
+      }
+      setTimeout(function () { resolve({ ok: true, ref: 'archive-1' }); }, 10);
+    });
+  };
+
+  var kernel = { sealChain: K.sealChain, verifyChain: K.verifyChain, replayOps: K.replayOps, commitOp: K.commitOp };
+  var res = await PC.closePeriod(db, kernel, null, { period: 1, ts: 5000, archiveSink: archiveSink });
+  console.log('§PCLOSE-RACE-RESULT compacted=' + res.compacted + ' archived=' + res.archived + ' liveLen=' + res.liveLen + ' ckptTip=' + (res.tip || '').slice(0, 12));
+
+  var survivorRow = db.exec("SELECT id FROM kernel_ops WHERE id=" + Number(raceId));
+  var survives = survivorRow.length > 0 && survivorRow[0].values.length > 0;
+  verdict(survives, '§PCLOSE-RACE the mid-close concurrent op (id=' + raceId + ') SURVIVES in the hot log', survives ? 'present' : 'MISSING — silently deleted, never archived (signed op vanished)');
+
+  var replay = K.replayOps(db);
+  var raceInReplay = replay.some(function (o) { return o.id === raceId; });
+  verdict(raceInReplay, '§PCLOSE-RACE the survivor is reachable by replay (fold does not silently drop it)', 'foundInReplay=' + raceInReplay);
+
+  console.log('§PCLOSE-RACE-VERDICT ' + (fails === 0 ? 'PASS (no loss)' : 'FAIL (' + fails + ' — TOCTOU confirmed: concurrent op lost)'));
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.error('PROBE-ERR', e); process.exit(2); });


### PR DESCRIPTION
## Summary
- Watchdog audit (2026-07-04) for the TOCTOU shape found in §T7-RACE (`erp_shard.js`): capture-boundary → await → delete-by-a-boundary. `closePeriod()` in `erp_period_close.js` had the same shape — the compaction DELETE used `ckptId`, minted *after* the `archiveSink` await, instead of a boundary pinned *before* it.
- A concurrent commit landing during the archive await (e.g. a POS sale mid period-close) got `id < ckptId` but was never in the pre-await archive snapshot → silently deleted, never archived. Proven with a constructed race witness (`erp/tests/witness_pclose_race.js`), pre-fix: FAIL (op vanished, gone from both hot log and archive).
- Fix mirrors the existing T7 fix: pin `baseTipId = MAX(id)` synchronously before the await; snapshot and delete both key off that pin, not the post-await checkpoint id. The racing op now survives in the hot log and is folded whole by the next replay.

## Test plan
- [x] New witness `erp/tests/witness_pclose_race.js` — pre-fix FAILs (op lost), post-fix PASSes (op survives + is replay-reachable)
- [x] Existing `erp/tests/witness_pclose_archive.js` (W-PCLOSE-ARCHIVE) still all-green — no regression to the T3 archive-first gate
- [ ] `erp/tests/poc_period_close_wire.js` (Playwright browser wiring test) not re-run in this worktree — missing `tests/node_modules/playwright` (worktree-local gitignore gap, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)