### PR TITLE
fix(modeller): #b-clear leaks STR-walker module state into later grid-drags

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -456,7 +456,7 @@ async function author(op, color) {
     audioCue('author');
   } catch (e) { setStat('FAIL ' + (e && e.message || e)); console.warn('§BONSAI author fail ' + e); }
 }
-bClear.onclick = () => { const g = window.Bonsai.group && window.Bonsai.group(); if (g) { while (g.children.length) g.remove(g.children[0]); } window.Bonsai.oplog.clear(); selectedId = null; selectedMesh = null; selectedIds = new Set(); window.Bonsai._selSet = selectedIds; if (typeof bCut !== 'undefined') bCut.disabled = true; if (typeof syncHistory === 'function') syncHistory(); _xrayOn = false; if (typeof paintXray === 'function') paintXray(); setStat('cleared'); };
+bClear.onclick = () => { const g = window.Bonsai.group && window.Bonsai.group(); if (g) { while (g.children.length) g.remove(g.children[0]); } window.Bonsai.oplog.clear(); selectedId = null; selectedMesh = null; selectedIds = new Set(); window.Bonsai._selSet = selectedIds; if (typeof bCut !== 'undefined') bCut.disabled = true; if (typeof syncHistory === 'function') syncHistory(); _xrayOn = false; if (typeof paintXray === 'function') paintXray(); if (window.STRWalkerOutliner && window.STRWalkerOutliner.onClear) window.STRWalkerOutliner.onClear(); setStat('cleared'); };
 
 // ── X-RAY REVEAL (step D) ───────────────────────────────────────────────────────────────────────
 // Mirror of the Viewer's ghostglass.js glass→glow doctrine (opacity 0.06 glass; emissive glow + depthTest off so

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -491,12 +491,25 @@
     console.log(TAG + ' wrapped Bonsai.gridmove.commit → STR re-walk on grid drag');
   }
 
+  // §GRID-CLEAR-LEAK (prompts/GRID_CLEAR_STATE_LEAK_FIX.md, decision B — narrow reset): `#b-clear` clears
+  // the THREE scene + op-log but is not the walker's own module — so it must call back into here to drop
+  // `ready` (and the stashed __dwBuf/__dwName substrate pointer) too. Without this, wrapGridMove's
+  // `if (ready && …)` guard survives a Clear and can re-walk a building that's no longer on-canvas,
+  // colliding on kernel_ops.id against the freshly-reset op-log (safe rollback, but a spurious error).
+  function onClear() {
+    ready = false; lastEx = [];
+    window.__dwBuf = null; window.__dwName = null;
+    if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    console.log(TAG + ' §GRID-CLEAR-LEAK onClear — ready=false, __dwBuf cleared');
+  }
+
   window.STRWalkerOutliner = {
     register: function () {
       if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.addCategory(category());
       wrapGridMove();
       console.log(TAG + ' registered — STR Walker category + grid-drag re-walk (the wedge); Open re-homed to the pill rail');
     },
+    onClear: onClear,
     _openStrDb: openStrDb, _openIfcFile: openIfcFile, _category: category,
     _openResident: openResident, _openBuffer: _openBuffer, _residents: RESIDENTS, _modellerBase: _modellerBase
   };

--- a/modeller/tests/witness_e2e_gridstretch_multi.js
+++ b/modeller/tests/witness_e2e_gridstretch_multi.js
@@ -20,20 +20,14 @@
  * CLAIMS per resident/open-mode pair (X1-X6 = witness_e2e_gridstretch.js's own numbering, reused verbatim):
  *   X1 SETUP, X2 GRID-MODE, X3 STRETCH, X4 CHAIN-OK, X5 ATOMIC, X6 REVERSIBLE.
  *
- * ⚠ KNOWN RED (X7, SampleCastle leg only) — a REAL, REPRODUCIBLE finding, not test flakiness (traced via a
- * step-tagged console/pageerror diagnostic, not guessed): `#b-clear` resets the THREE scene + the op-log, but
- * NOT `str_walker_outliner.js`'s own module-local STR-walker state (`ready`/the loaded column-girder skeleton
- * — see its `register()`/`_openBuffer` closure vars). So after opening SampleCastle (real STR skeleton: 23
- * columns/13 girders) → Clear → author an UNRELATED synthetic grid+wall → drag a gridline, `wrapGridMove`'s
- * `if (ready && window.swbOnGridMove)` guard is STILL true from the cleared building, and fires a real STR
- * re-walk against SampleCastle's still-resident (in-memory, not on-canvas) skeleton. That re-walk's 4 computed
- * STR ops collide on `kernel_ops.id` with the freshly-reset op-log's own counter and roll back
- * (`§KRN_GROUP ROLLBACK … committedRows=0 (all-or-NONE)` — the SAFE outcome: no partial/corrupt commit, just
- * a loud rejected-toast + 4 console errors). Confirmed NOT a timing artifact (reran twice, byte-identical
- * repro both times; ruled out async ARC-seed race first — SampleCastle's 3261-op substrate was already
- * fully loaded and stable before Clear was ever clicked). NOT fixed here — the correct fix touches `#b-clear`'s
- * contract (should it reset EVERY walker module's state, not just THREE+oplog?) which is a design-scope
- * question, not a 2-line patch, so left for a deliberate follow-up rather than an autonomous fix mid-session.
+ * §GRID-CLEAR-LEAK — FIXED (prompts/GRID_CLEAR_STATE_LEAK_FIX.md, decision B — narrow reset, 2026-07-04).
+ * Was: `#b-clear` reset the THREE scene + the op-log, but NOT `str_walker_outliner.js`'s own module-local
+ * STR-walker state (`ready`/the loaded column-girder skeleton), so a grid-drag after Clear could re-walk a
+ * cleared building's still-resident (in-memory) skeleton and collide on `kernel_ops.id` against the freshly-
+ * reset op-log — a safe rollback but a spurious rejected-toast + console errors. Fix: `str_walker_outliner.js`
+ * exposes `STRWalkerOutliner.onClear()` (resets `ready`/`lastEx`/`window.__dwBuf`/`window.__dwName`), wired
+ * into `#b-clear`'s onclick in modeller.html. Narrow scope per the decision doc — does not touch DiscWalker/
+ * CrossEdges/bom-graph module state (unaudited, left for a future full-reset pass if ever needed).
  * Read the §-log after every run — exit code alone is not evidence (CLAUDE.md Log Mandate).
  */
 'use strict';


### PR DESCRIPTION
## Summary
- `prompts/GRID_CLEAR_STATE_LEAK_FIX.md` decision **B (narrow reset)**: `#b-clear` reset the THREE scene + op-log but not `str_walker_outliner.js`'s own module-local `ready`/`__dwBuf` state, so a grid-drag after Clear could re-walk a cleared building's still-resident skeleton and collide on `kernel_ops.id` against the freshly-reset op-log (safe rollback, but a spurious error toast + 4 console errors).
- `STRWalkerOutliner.onClear()` now resets `ready`/`lastEx`/`window.__dwBuf`/`window.__dwName`, wired into `#b-clear`'s onclick in `modeller.html`.
- Narrow scope per the decision doc — does not touch `DiscWalker`/`CrossEdges`/bom-graph module state (unaudited, left for a future full-reset pass if ever needed).

## Test plan
- [x] `node modeller/tests/witness_e2e_gridstretch_multi.js` — 21/21 (X7 NO-ERROR now green on the SampleCastle leg, was KNOWN RED)
- [x] `node modeller/tests/witness_e2e_gridstretch.js` — 7/7 (no regression)
- [x] `node modeller/tests/witness_e2e_walk_ifcopen.js` — 18/18 (no regression, shares `str_walker_outliner.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)