### PR TITLE
fix(modeller): cross_edges.js abuts uses real per-element AABB, not coarse bbox

### DIFF
--- a/modeller/cross_edges.js
+++ b/modeller/cross_edges.js
@@ -14,7 +14,25 @@
  * shared-face contact (provenance 'derived:face-touch'); NO proximity radius, NO IFC class names (grep-clean).
  *
  * AABB convention (scripts/backfill_bbox.py): element_transforms.bbox_k = FULL extent (maxK-minK),
- * center_k = (minK+maxK)/2 → minK = center_k - bbox_k/2, maxK = center_k + bbox_k/2.
+ * center_k = (minK+maxK)/2 → minK = center_k - bbox_k/2, maxK = center_k + bbox_k/2. This is a FALLBACK
+ * only (§REAL-AABB below) — measured to disagree with the actual rendered scene on 924/9817 (9.4%) of a
+ * real building's abuts pairs (SampleCastle, RESUME_SESSION_2026-07-04_GATE_BACKPROP.md item 3 audit), not
+ * a narrow edge case.
+ *
+ * §REAL-AABB (2026-07-04 fix): `element_transforms.center_xyz`/`bbox_xyz` is a coarser measure than the
+ * REAL per-element vertex blob (`component_geometries`/`base_geometries`, keyed by `element_instances.
+ * geometry_hash`) `bonsai_library.js`'s `foldInsert` actually renders — the two disagree whenever a real
+ * blob is resolvable (SampleCastle resolves 100% of its 3225 elements; most classes, not just furniture,
+ * show a real mismatch). Where a real blob IS resolvable, `_readBoxes()` now computes the TRUE world AABB
+ * straight from it — `real_geometry.js`'s own documented ground truth: world = center_xyz + R(rotation_z)·
+ * rawVert, for every raw vertex (envelope of the ROTATED+TRANSLATED mesh, not just a centre-shift) —
+ * reusing `RealGeometry.buildGeometryIndex` (a sibling pure-DB module, same design as this file) rather
+ * than re-deriving the same decode/dedup logic. Yaw-only (`rotation_z`): every building measured so far has
+ * `rotation_x=rotation_y=0` (arc_editable.js's own recon, §ARC-3AXIS) — a genuinely 3-axis-rotated element
+ * falls back to the coarse bbox below rather than risk an under-tested quaternion port (same conservative
+ * non-invent choice arc_editable.js made). Falls back to the coarse `element_transforms` bbox when no real
+ * blob resolves (RealGeometry absent, no `geometry_hash`, missing blob, or degenerate <3 verts) — today's
+ * behaviour, unchanged for that case.
  *
  * Scale: sweep-and-prune on X (sort by minX, active window pruned by maxX) → near-linear on the 48k
  * Terminal substrate, replacing the Python rtree candidate query. Pure over the DB (node-witnessable).
@@ -22,6 +40,61 @@
 (function (window) {
   'use strict';
   var TOL = 0.03, MIN_OVERLAP = 0.02;   // metres — identical to the Python defaults (W-SDG-ABUTS)
+
+  // Soft dependency — real_geometry.js is a sibling "pure over the DB, dual-export" module (same design
+  // philosophy as this file); absent (older page, load-order race, or a witness that doesn't need it) →
+  // gracefully degrades to the coarse element_transforms bbox everywhere (unchanged prior behaviour).
+  // Resolved LAZILY (at call time, inside _getRealGeometry() below), NOT at IIFE-load time: modeller.html's
+  // <script> order loads this file BEFORE real_geometry.js, so a module-scope `var` capture here would see
+  // `window.RealGeometry` still undefined and freeze that null forever (caught live: abuts stayed at the
+  // OLD pre-fix count in the browser even though window.RealGeometry was present moments later).
+  var _requiredRealGeometry;   // node-only cache of the require() result — window.RealGeometry itself is
+                                // ALWAYS re-checked fresh (cheap property read, matches this codebase's own
+                                // "check window.X fresh at call time" pattern elsewhere, e.g. STRWalkerOutliner).
+  function _getRealGeometry() {
+    if (typeof window !== 'undefined' && window.RealGeometry) return window.RealGeometry;
+    if (_requiredRealGeometry !== undefined) return _requiredRealGeometry;
+    _requiredRealGeometry = (typeof require === 'function') ? (function () { try { return require('./real_geometry.js'); } catch (e) { return null; } })() : null;
+    return _requiredRealGeometry;
+  }
+
+  // §REAL-AABB — world AABB of a REAL vertex blob: rotate every raw vertex by yaw (rotation_z, radians)
+  // about Z, translate by the placement anchor (center_xyz), envelope the result. Mirrors real_geometry.js's
+  // own documented convention (world = center + R·rawVert) — NOT bonsai_library.js's recenter/anchorOffset
+  // detour (that exists for RENDERING reasons over a symmetric-local-origin mesh; an AABB just needs the
+  // raw vertices transformed directly, same final numbers, fewer steps).
+  function _realAabb(positions, cx, cy, cz, rz) {
+    var cs = Math.cos(rz), sn = Math.sin(rz);
+    var mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity, mnz = Infinity, mxz = -Infinity;
+    for (var i = 0; i < positions.length; i += 3) {
+      var x = positions[i], y = positions[i + 1], z = positions[i + 2];
+      var wx = cs * x - sn * y + cx, wy = sn * x + cs * y + cy, wz = z + cz;
+      if (wx < mnx) mnx = wx; if (wx > mxx) mxx = wx;
+      if (wy < mny) mny = wy; if (wy > mxy) mxy = wy;
+      if (wz < mnz) mnz = wz; if (wz > mxz) mxz = wz;
+    }
+    return [mnx, mxx, mny, mxy, mnz, mxz];
+  }
+
+  // Build guid -> RAW vertex blob (un-recentred: recentred positions + anchorOffset added back per vertex —
+  // see real_geometry.js's own `recenter()` for why positions/anchorOffset are split that way; this undoes
+  // the split to get the blob real_geometry.js's own header says the world formula operates on directly).
+  function _buildRealVerts(db, geoDb) {
+    var RealGeometry = _getRealGeometry();
+    if (!RealGeometry || !RealGeometry.buildGeometryIndex) return null;
+    var idx;
+    try { idx = RealGeometry.buildGeometryIndex(db, geoDb); } catch (e) { return null; }
+    if (!idx || !idx.table) return null;
+    var out = {};
+    Object.keys(idx.byGuid).forEach(function (guid) {
+      var hash = idx.byGuid[guid], rc = hash != null ? idx.resolved[hash] : null;
+      if (!rc) return;
+      var ao = rc.anchorOffset, p = rc.positions, raw = new Float32Array(p.length);
+      for (var i = 0; i < p.length; i += 3) { raw[i] = p[i] + ao[0]; raw[i + 1] = p[i + 1] + ao[1]; raw[i + 2] = p[i + 2] + ao[2]; }
+      out[guid] = raw;
+    });
+    return out;
+  }
 
   // Is the AABB pair (a,b) a FACE-TOUCH? Returns {axis, gap_m, contact_m2} or null. Exact port of the
   // witnessed Python _face_touch — references NO IFC class. a,b = [minX,maxX,minY,maxY,minZ,maxZ].
@@ -41,15 +114,23 @@
     return { axis: 'XYZ'[axis], gap_m: Math.abs(ov[axis]), contact_m2: ov[o0] * ov[o1] };
   }
 
-  // Read the pristine bboxes from element_transforms → [{guid, aabb}]. AABB = center ± bbox/2.
-  function _readBoxes(db) {
+  // Read the AABBs → [{guid, aabb}]. §REAL-AABB: prefer the TRUE world AABB from the real per-element
+  // vertex blob (rotated by yaw + translated by center_xyz) when resolvable; fall back to the coarse
+  // `element_transforms` bbox ± convention otherwise (today's original behaviour for that case, unchanged).
+  function _readBoxes(db, geoDb) {
     var boxes = [];
+    var realVerts = _buildRealVerts(db, geoDb);
     try {
-      var r = db.exec("SELECT guid, center_x, center_y, center_z, bbox_x, bbox_y, bbox_z " +
+      var r = db.exec("SELECT guid, center_x, center_y, center_z, bbox_x, bbox_y, bbox_z, rotation_x, rotation_y, rotation_z " +
                       "FROM element_transforms WHERE bbox_x IS NOT NULL");
       if (r.length) r[0].values.forEach(function (v) {
-        var cx = v[1], cy = v[2], cz = v[3], bx = v[4], by = v[5], bz = v[6];
-        boxes.push({ guid: v[0], aabb: [cx - bx / 2, cx + bx / 2, cy - by / 2, cy + by / 2, cz - bz / 2, cz + bz / 2] });
+        var guid = v[0], cx = v[1], cy = v[2], cz = v[3], bx = v[4], by = v[5], bz = v[6];
+        var rx = v[7], ry = v[8], rz = v[9];
+        var raw = realVerts ? realVerts[guid] : null;
+        var aabb = (raw && Math.abs(rx || 0) < 1e-9 && Math.abs(ry || 0) < 1e-9)
+          ? _realAabb(raw, cx, cy, cz, rz || 0)
+          : [cx - bx / 2, cx + bx / 2, cy - by / 2, cy + by / 2, cz - bz / 2, cz + bz / 2];
+        boxes.push({ guid: guid, aabb: aabb });
       });
     } catch (e) { /* no element_transforms / no bbox → no geometric edges (graceful) */ }
     return boxes;
@@ -60,7 +141,7 @@
   function deriveAdjacency(db, opts) {
     opts = opts || {};
     var tol = opts.tol != null ? opts.tol : TOL, minOv = opts.minOverlap != null ? opts.minOverlap : MIN_OVERLAP;
-    var boxes = _readBoxes(db);
+    var boxes = _readBoxes(db, opts.geoDb);
     // sweep-and-prune on X: sort by minX, keep an active window of boxes whose maxX still reaches the cursor.
     boxes.sort(function (p, q) { return p.aabb[0] - q.aabb[0]; });
     var edges = [], active = [];
@@ -104,7 +185,7 @@
   function deriveDatumsAnchored(db, opts) {
     opts = opts || {};
     var tol = opts.tol != null ? opts.tol : 0.05, minSupport = opts.minSupport != null ? opts.minSupport : 3;
-    var boxes = _readBoxes(db);
+    var boxes = _readBoxes(db, opts.geoDb);
     var byGuid = {}; boxes.forEach(function (e) { byGuid[e.guid] = e.aabb; });
     var datums = [], anchored = [], datumId = 0;
     for (var ax = 0; ax < 3; ax++) {
@@ -145,7 +226,7 @@
     var byAxis = { 0: [], 1: [], 2: [] };
     (datums || []).forEach(function (d) { byAxis['XYZ'.indexOf(d.axis)].push([d.datum_id, d.coord]); });
     function nearest(arr, face) { var best = null, bd = Infinity; for (var i = 0; i < arr.length; i++) { var dd = Math.abs(arr[i][1] - face); if (dd < bd) { bd = dd; best = arr[i]; } } return best; }
-    var boxes = _readBoxes(db), spans = [];
+    var boxes = _readBoxes(db, opts.geoDb), spans = [];
     boxes.forEach(function (e) {
       var b = e.aabb;
       for (var ax = 0; ax < 3; ax++) {

--- a/modeller/tests/witness_cross_edges_real_aabb.js
+++ b/modeller/tests/witness_cross_edges_real_aabb.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-XEDGE-REAL-AABB scope
+ * SCOPE: RESUME_SESSION_2026-07-04_GATE_BACKPROP.md §OPEN item 3 — cross_edges.js's `_readBoxes()` read the
+ * COARSE `element_transforms.center_xyz`/`bbox_xyz` convention directly, which disagrees with the REAL
+ * per-element geometry `bonsai_library.js`'s `foldInsert` actually renders (measured via the real browser
+ * open path: SampleCastle showed 924/9817, 9.4%, of its abuts pairs disagreeing — real architectural
+ * elements, not a furniture-only edge case; SampleHouse's 2 editable pairs were BOTH false positives, ~215mm
+ * and ~391mm actually separated in the live render, not touching at all). Fix: `_readBoxes()` now computes
+ * the TRUE world AABB from the real per-element vertex blob (rotate by yaw + translate by center_xyz —
+ * `real_geometry.js`'s own documented ground truth) when resolvable, falling back to the coarse bbox
+ * otherwise. This is a HEADLESS BROWSER witness (drives the real Open flow, real live-mesh AABBs) — the
+ * value witness `witness_sdg_gate.js`/pure-node scripts can't see the REAL render (registerRealGeometry is
+ * browser-wired only). Read the §-log after every run.
+ *
+ * CLAIMS:
+ *   G1 OPEN-OK        — SampleHouse .db-open lands editable meshes + swXEdges.
+ *   G2 NO-FALSE-TOUCH  — SampleHouse's 2 OLD (pre-fix) editable abuts pairs (wall↔furniture, fid 1/30 and
+ *                        5/32) are GONE from the corrected edge set — the live render confirms they are NOT
+ *                        actually touching (both genuinely separated, ~215-391mm, confirmed by direct AABB
+ *                        gap measurement on the real meshes).
+ *   G3 REAL-PAIRS-FOUND — the corrected edge set finds >0 editable-editable pairs (the true wall/floor/
+ *                        wall-corner adjacency a small house actually has — completely missing pre-fix).
+ *   G4 LIVE-AGREEMENT  — EVERY editable-editable pair the corrected cross_edges.js reports is ALSO confirmed
+ *                        touching (|overlap| <= 30mm + 1mm floating-point boundary slack on the touch axis)
+ *                        when measured DIRECTLY on the live rendered meshes (_gateBoxes()-equivalent) — the
+ *                        exact property item 3 found broken (was 924/9817, 9.4%, on SampleCastle pre-fix,
+ *                        real mismatches of 65-391mm; post-fix 0 real disagreements — the only pairs sitting
+ *                        near the tolerance boundary are within 0.0007mm of it, confirmed float noise, not a
+ *                        real gap, hence the slack).
+ *   G5 NO-ERROR        — zero pageerror.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+function overlaps(a, b) { const ov = []; for (let k = 0; k < 3; k++) { const lo = Math.max(a[2*k], b[2*k]), hi = Math.min(a[2*k+1], b[2*k+1]); ov.push(hi - lo); } return ov; }
+function touchAxis(a, b) { const ov = overlaps(a, b); let k = 0; for (let i = 1; i < 3; i++) if (Math.abs(ov[i]) < Math.abs(ov[k])) k = i; return { axis: k, ov: ov[k] }; }
+const TOL = 0.03;
+// Boundary slack: cross_edges.js's derivation and the live THREE.js mesh's own computeBoundingBox() are two
+// INDEPENDENT float computations of the same real quantity — pairs sitting almost exactly ON the 30mm
+// threshold can land a sub-millimetre's width of floating-point noise on either side of it (confirmed via a
+// direct SampleCastle probe: 75/13282 pairs "disagreed" post-fix, every one within 0.0007mm of the boundary,
+// none anywhere close to a real mismatch — pre-fix real mismatches were 65-391mm, orders of magnitude larger).
+// 1mm is generous slack for that noise while still failing on anything resembling a real disagreement.
+const BOUNDARY_SLACK = 0.001;
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  console.log('═══ W-XEDGE-REAL-AABB — cross_edges.js real per-element AABB correction (headless, real render) ═══');
+
+  for (const building of ['SampleHouse', 'SampleCastle']) {
+    console.log('--- ' + building + ' ---');
+    const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850 });
+    const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+    await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+    await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai', { timeout: 30000 }).catch(() => {});
+    await pg.click('#b-open'); await sleep(200);
+    await pg.click(`.mo-row[data-key="${building}"]`);
+    await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => false);
+    await sleep(building === 'SampleCastle' ? 3500 : 2000);
+
+    const result = await pg.evaluate(() => {
+      const g = window.Bonsai.group(); const boxes = {};
+      g.children.forEach(m => { if (m.isMesh && m.userData && m.userData.featureId != null) {
+        m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+        boxes[m.userData.featureId] = [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z];
+      }});
+      const X = window.swXEdges || {}, fbg = window.__arcFidByGuid || {};
+      const editablePairs = (X.abuts || []).map(e => ({ e, a: fbg[e.a], b: fbg[e.b] })).filter(p => p.a != null && p.b != null);
+      return { totalMeshes: Object.keys(boxes).length, boxes, editablePairs, dwName: window.__dwName, abutsTotal: (X.abuts || []).length };
+    });
+
+    chk('G1 OPEN-OK (' + building + ', editable meshes + swXEdges present)',
+      result.dwName === building && result.totalMeshes > 0 && result.abutsTotal > 0,
+      'meshes=' + result.totalMeshes + ' abutsTotal=' + result.abutsTotal);
+
+    if (building === 'SampleHouse') {
+      const hasFalsePair = result.editablePairs.some(p => (p.a === 1 && p.b === 30) || (p.a === 30 && p.b === 1) || (p.a === 5 && p.b === 32) || (p.a === 32 && p.b === 5));
+      chk('G2 NO-FALSE-TOUCH (the 2 pre-fix wall↔furniture false positives are GONE)', !hasFalsePair,
+        'editablePairs=' + result.editablePairs.length);
+    }
+
+    chk('G3 REAL-PAIRS-FOUND (' + building + ' — corrected edge set finds real adjacency)',
+      result.editablePairs.length > 10, 'editablePairs=' + result.editablePairs.length);
+
+    let disagree = 0, checked = 0; const disagreements = [];
+    result.editablePairs.forEach(p => {
+      if (!result.boxes[p.a] || !result.boxes[p.b]) return;
+      checked++;
+      const t = touchAxis(result.boxes[p.a], result.boxes[p.b]);
+      if (Math.abs(t.ov) > TOL + BOUNDARY_SLACK) { disagree++; disagreements.push('a=' + p.a + ' b=' + p.b + ' ov_mm=' + (t.ov * 1000).toFixed(1)); }
+    });
+    chk('G4 LIVE-AGREEMENT (' + building + ' — every corrected abuts pair confirmed touching on the LIVE render, 0 disagreement)',
+      disagree === 0 && checked > 0, 'checked=' + checked + ' disagree=' + disagree + (disagreements.length ? ' ' + disagreements.slice(0, 3).join(' | ') : ''));
+
+    chk('G5 NO-ERROR (' + building + ' — zero pageerror)', errs.length === 0, errs.slice(0, 2).join(' | '));
+    await pg.close();
+  }
+
+  console.log('W-XEDGE-REAL-AABB: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await br.close(); server.close();
+  process.exit(fail ? 1 : 0);
+})();

--- a/modeller/tests/witness_sdg_gate_smoke.js
+++ b/modeller/tests/witness_sdg_gate_smoke.js
@@ -28,13 +28,27 @@ function serve() { return new Promise(function (r) { var s = http.createServer(f
   await page.waitForFunction(function () { return !!(window.__arcFidByGuid && Object.keys(window.__arcFidByGuid).length > 0) && !!(window.SdgGate); }, { timeout: 25000 }).catch(function () {});
   await page.waitForTimeout(400);
 
-  // pick the two MOST-SEPARATED editable elements (guaranteed unrelated) → moving A onto B is a clean clash
+  // pick the two MOST-SEPARATED editable elements (guaranteed unrelated) → moving A onto B is a clean clash.
+  // §XEDGE-REAL-AABB regression (cross_edges.js now correctly resolves real per-element abuts — see
+  // RESUME_SESSION_2026-07-04_GATE_BACKPROP.md item 3 / witness_cross_edges_real_aabb.js): the "clean lift"
+  // leg needs an element with ZERO real abuts edges (e.g. a wall resting flush on the floor slab now
+  // correctly reads as touching it — lifting it away is a REAL, correct abuts-realign ORANGE, not a bug).
+  // bestA is picked from the isolated set for the lift; bestB stays "most separated from bestA" over ALL
+  // boxes for the clash-drive leg (unaffected by this constraint).
   var plan = await page.evaluate(function () {
     var g = window.Bonsai.group(); var boxes = [];
     g.children.forEach(function (m) { if (m.isMesh && m.userData && m.userData.featureId != null && window.__arcGuidByFid[m.userData.featureId] != null) { m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox; boxes.push({ fid: m.userData.featureId, c: [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2] }); } });
+    var fbg = window.__arcFidByGuid || {}, X = window.swXEdges || {}, touched = {};
+    (X.abuts || []).forEach(function (e) { var a = fbg[e.a], b = fbg[e.b]; if (a != null) touched[a] = 1; if (b != null) touched[b] = 1; });
+    var isolated = boxes.filter(function (bx) { return !touched[bx.fid]; });
+    var pool = isolated.length ? isolated : boxes;   // graceful: if somehow everything abuts, fall back (old behaviour)
     var bestA = null, bestB = null, bd = -1;
-    for (var i = 0; i < boxes.length; i++) for (var j = i + 1; j < boxes.length; j++) { var d = Math.hypot(boxes[i].c[0] - boxes[j].c[0], boxes[i].c[1] - boxes[j].c[1], boxes[i].c[2] - boxes[j].c[2]); if (d > bd) { bd = d; bestA = boxes[i]; bestB = boxes[j]; } }
-    return { aFid: bestA.fid, bFid: bestB.fid, delta: [bestB.c[0] - bestA.c[0], bestB.c[1] - bestA.c[1], bestB.c[2] - bestA.c[2]], n: boxes.length };
+    for (var i = 0; i < pool.length; i++) for (var j = 0; j < boxes.length; j++) {
+      if (pool[i].fid === boxes[j].fid) continue;
+      var d = Math.hypot(pool[i].c[0] - boxes[j].c[0], pool[i].c[1] - boxes[j].c[1], pool[i].c[2] - boxes[j].c[2]);
+      if (d > bd) { bd = d; bestA = pool[i]; bestB = boxes[j]; }
+    }
+    return { aFid: bestA.fid, bFid: bestB.fid, delta: [bestB.c[0] - bestA.c[0], bestB.c[1] - bestA.c[1], bestB.c[2] - bestA.c[2]], n: boxes.length, isolatedN: isolated.length };
   });
   chk('G1 substrate ready (editable elements + SdgGate loaded)', plan.n > 0 && plan.aFid != null, 'elements=' + plan.n);
 


### PR DESCRIPTION
## Summary
- Resolves `RESUME_SESSION_2026-07-04_GATE_BACKPROP.md` item 3 (PR #647's flagged-not-fixed cross_edges.js frame-consistency gap).
- **Correction to an earlier same-session finding**: a first pure-node audit wrongly concluded this was furniture-only / 0-disagreement-on-SampleCastle. It never called `registerRealGeometry` (browser-only wiring), so it measured the wrong render path. Re-measured via the real browser Open flow: **SampleCastle showed 924/9817 (9.4%) real disagreement** — architectural elements (walls/slabs), not an edge case.
- Fix: `cross_edges.js`'s `_readBoxes()` now computes the true world AABB from the real per-element vertex blob (rotate by yaw + translate by `center_xyz`, `real_geometry.js`'s own documented convention) when resolvable, reusing `RealGeometry.buildGeometryIndex` — falling back to the coarse `element_transforms` bbox otherwise (unchanged for that case).
- Two bugs caught by the browser witness during implementation and fixed: a stale `window.RealGeometry` capture (script load-order race) and a smoke-test assumption that no longer held once the fix correctly detects a real floor-contact abuts edge.

## Test plan
- [x] New `witness_cross_edges_real_aabb.js` (puppeteer, real Open flow) 9/9 — SampleHouse (47 real pairs found, 0 live-render disagreement, 2 old false positives gone) + SampleCastle (13282 pairs, 0 disagreement, down from 924 pre-fix).
- [x] No regression: `witness_sdg_gate.js` 11/11, `witness_sdg_cascade.js` 7/7, `witness_stretch_ride.js` 9/9, `witness_e2e_stretch_ride.js` 9/9, `witness_e2e_walk_ifcopen.js` 18/18, `witness_e2e_gridstretch.js` 7/7, `witness_e2e_gridstretch_multi.js` 21/21, `witness_grid_clear_leak_round2.js` 5/5.
- [x] `witness_sdg_gate_smoke.js` 6/6 (fixed for the new-correct behavior) + `witness_sdg_cascade_smoke.js` 6/6 (playwright, unaffected).
- [x] Perf: SampleCastle (3225 elements) `deriveAdjacency` 155ms; Terminal (48k elements, no split-geoDb wired yet) 1.4s, unchanged from pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)