### PR TITLE
feat(hba): IoT per-device positions + Product/Order persistence + orange highlight + USD/RM

### DIFF
--- a/hr_bim_asset/iot.js
+++ b/hr_bim_asset/iot.js
@@ -7,9 +7,66 @@
 //   Date.now — reproducible, watermarked CONTOH/SAMPLE, never claimed as a real read). The ERP-link half stays
 //   non-invent on the SHAPE: a reading compiles onto the REAL native c_order/c_orderline/c_uom columns
 //   (verified build/erp/ad_full.db PRAGMA table_info — see RESUME_HR_BIM_ASSET.md §P10b-CHECK), same
-//   "Compile not Model" discipline as ad_tenancy.js. Read the log after run.
+//   "Compile not Model" discipline as ad_tenancy.js.
+//
+//   §2026-07-05 (RESUME_HR_BIM_ASSET.md §2026-07-04d §BUILD ORDER) — two follow-on fixes, same non-invent
+//   discipline as ad_tenancy.js's §STAGE2:
+//   1. **Per-device position** (was: all 6 sensors shared the ONE `models.js Asset` AHU-03 guid — "zoom to the
+//      sensor" always landed on the same spot). `DEVICES`/`CAMERAS` below bind EACH sensor/camera to its OWN
+//      REAL element guid in `buildings/HHS_Office_Federated_extracted.db` (queried live this session — never a
+//      fabricated position): `temp` reuses AHU-03 verbatim (unchanged); `pressure`→the real rooftop "Outdoor
+//      AHU" plant unit; `sound`/`dust`→two other real Level-2 supply diffusers (the same IfcFlowTerminal class
+//      AHU-03 already used, just distinct instances); `solar`→the real Roof Level sun-shading floor slab;
+//      `electrical`→the real Level-1 Main Distribution Panel (MDP-1). `CAMERAS` are 6 real entrance/circulation
+//      doors, 2 per storey (Level 1/2/3) — the standard CCTV placement idiom, not a random pick.
+//   2. **Product/Order persistence** — `toUomRow`/`toProductRow`/`toOrderRow`/`toOrderLineRow` gain the SAME
+//      `_one(erpQuery,...)` match-or-create idiom `ad_tenancy.js` already uses: governed (erpQuery present, a
+//      real seeded row matches) → reuse the durable seeded id; ungoverned → the prior deterministic mint,
+//      BYTE-IDENTICAL (every existing witness that passes no erpQuery is unaffected).
+//   3. **Currency** — `c_currency_id` set to the REAL already-seeded MYR row (301, `scripts/seed_fin_currency.js`)
+//      — a sensor's a local-site utility/security cost, MYR is the natural billing currency. USD equivalent is
+//      read from the SAME already-seeded `C_Conversion_Rate` (301→100), never a second invented rate; absent
+//      erpQuery → usd stays null (honest, no rate to convert with).
+//   Read the log after run.
 'use strict';
 var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
+
+// §STAGE2 idiom (ad_tenancy.js) — MATCH-OR-CREATE against the REAL seeded AD rows when erpQuery is present;
+// absent/no-match → the deterministic mint. `_one` never throws (a missing table/bad db degrades honestly).
+function _one(erpQuery, sql, params) {
+  if (typeof erpQuery !== 'function') return null;
+  try { var r = erpQuery(sql, params || []); return (r && r.length) ? r[0] : null; } catch (e) { return null; }
+}
+function _num(v) { return (v == null) ? v : Number(v); }
+
+// one real bound element per sensor (guid/ifc_class/storey verified live against
+// buildings/HHS_Office_Federated_extracted.db, 2026-07-05 — see file header point 1). `temp` is the pre-existing
+// AHU-03 binding (models.js Asset), kept identical so every pre-existing witness/flyToZone target is unchanged.
+var DEVICES = {
+  temp:       { bim_guid: '04i7IlvuLBuOmBXGMxmbgo', element: 'Supply Diffuser (AHU-03)', storey: 'Level 3' },
+  pressure:   { bim_guid: '39q4vWPDPE3QeBugdA373d', element: 'Outdoor AHU — rooftop mechanical plant', storey: 'Roof Level' },
+  sound:      { bim_guid: '07A8OFMrj5IeMQd6aflvMZ', element: 'Supply Diffuser (Level 2)', storey: 'Level 2' },
+  dust:       { bim_guid: '0B2Nysi4bEIBgg6BXJzBCa', element: 'Supply Diffuser (Level 2)', storey: 'Level 2' },
+  solar:      { bim_guid: '3XrBtx9eX7mQE6EqWHPey$', element: 'Roof sun-shading floor', storey: 'Roof Level' },
+  electrical: { bim_guid: '1Atj4lkpv3qwTaPKeAZIaj', element: 'Main Distribution Panel MDP-1', storey: 'Level 1' }
+};
+// 6 real entrance/circulation doors, 2 per storey — CCTV placement idiom, not a random pick.
+var CAMERAS = [
+  { bim_guid: '0LmR_Oafz6LvpHnBLJOGi$', element: 'Entrance door', storey: 'Level 1' },
+  { bim_guid: '1UDlgEuSLAZ9OyOKOB0RyW', element: 'Entrance door', storey: 'Level 1' },
+  { bim_guid: '0Z1xu3E5b8zPJTx3GNZg8Y', element: 'Corridor door', storey: 'Level 2' },
+  { bim_guid: '0lKZdaAjTCjBh_cVCMRZrh', element: 'Corridor door', storey: 'Level 2' },
+  { bim_guid: '0TgQK$gCn8wu43pHf2VHup', element: 'Corridor door', storey: 'Level 3' },
+  { bim_guid: '1Jil894uX328zr$s_sQLvj', element: 'Corridor door', storey: 'Level 3' }
+];
+
+// MYR 301 / USD 100 / conversion type 114 — the REAL rows scripts/seed_fin_currency.js already seeded
+// (verified erp/ad_seed.db, 2026-07-05); never a second invented rate.
+var MYR_CURRENCY_ID = 301, USD_CURRENCY_ID = 100;
+function usdRate(erpQuery) {
+  var hit = _one(erpQuery, "SELECT multiplyrate AS r FROM C_Conversion_Rate WHERE c_currency_id=? AND c_currency_id_to=? AND isactive='Y'", [MYR_CURRENCY_ID, USD_CURRENCY_ID]);
+  return hit ? Number(hit.r) : null;
+}
 
 // 6 sensors, one mockup monitoring point per bound asset. uom_name/uom_symbol seed a NEW C_UOM row (a genuine
 // native dictionary gap — °C/bar/dB/µg/m³/W/m²/kWh don't exist in this repo's ad_full.db c_uom set; same
@@ -48,45 +105,81 @@ function demoSeries(assetId, hours) {
 }
 
 // ---- native C_UOM row — a new dictionary entry for a physical unit this repo's ad_full.db doesn't carry yet
-// (verified — see file header). ONE row per sensor kind, created on demand (same precedent as ad_tenancy.js
+// (verified — see file header). §STAGE2 — match-or-create by Name; else mint (same precedent as ad_tenancy.js
 // toWarehouseRow / SUBSCRIPTION_TYPES).
-function toUomRow(sensor, seedId) {
+function toUomRow(sensor, seedId, erpQuery) {
+  var hit = _one(erpQuery, 'SELECT C_UOM_ID AS id FROM C_UOM WHERE Name=?', [sensor.uom_name]);
+  if (hit) return { c_uom_id: _num(hit.id), name: sensor.uom_name, uomsymbol: sensor.uom_symbol };
   return { c_uom_id: seedId ? seedId() : 1, name: sensor.uom_name, uomsymbol: sensor.uom_symbol };
 }
 
 // ---- native C_Order header — ONE order per building+period grouping the sensor billing lines (mirrors
 // ad_tenancy.toWarehouseRow's "one row per building, created since none exists yet for a demo building").
-function toOrderRow(buildingName, period, seedId) {
-  return { c_order_id: seedId ? seedId() : 1, documentno: 'IOT-' + buildingName + '-' + period, docstatus: 'DR', issotrx: 'Y' };
+// §STAGE2 — match-or-create by DocumentNo (deterministic per building+period, so a re-run resolves the SAME order).
+function toOrderRow(buildingName, period, seedId, erpQuery) {
+  var documentno = 'IOT-' + buildingName + '-' + period;
+  var hit = _one(erpQuery, 'SELECT C_Order_ID AS id FROM C_Order WHERE DocumentNo=?', [documentno]);
+  if (hit) return { c_order_id: _num(hit.id), documentno: documentno, docstatus: 'DR', issotrx: 'Y' };
+  return { c_order_id: seedId ? seedId() : 1, documentno: documentno, docstatus: 'DR', issotrx: 'Y' };
+}
+
+// ---- native M_Product row — ONE per device (sensor or camera), Value=a stable device id (matches
+// models.js Asset.iot_device's own naming, e.g. 'IOT-TEMP-HHS') so the SAME device always resolves to the SAME
+// product. §STAGE2 — match-or-create by Value; else mint. m_locator_id stays honestly null — this building's
+// rel_contained_in_space table (queried live, 2026-07-05) does not cover these specific elements, so there is no
+// real per-room containment fact to attach (never fabricate one), unlike ad_tenancy.js's room Products.
+function toProductRow(deviceKey, label, seedId, erpQuery) {
+  var value = 'IOT-' + deviceKey.toUpperCase() + '-HHS';
+  var hit = _one(erpQuery, 'SELECT M_Product_ID AS id, Name AS name FROM M_Product WHERE Value=?', [value]);
+  if (hit) return { m_product_id: _num(hit.id), value: value, name: hit.name || label, m_locator_id: null };
+  return { m_product_id: seedId ? seedId() : 1, value: value, name: label, m_locator_id: null };
 }
 
 // ---- native C_OrderLine — the reading AT THE LATEST hour, billed as qty(reading) x uom(the sensor's physical
 // unit). priceactual is a nominal CONTOH/SAMPLE rate per unit — no sourced tariff exists for a mockup sensor.
+// c_currency_id = the REAL already-seeded MYR row (301) — a site utility/security cost bills in the local
+// currency (see file header point 3).
 function toOrderLineRow(sensor, reading, c_order_id, m_product_id, c_uom_id, line, seedId) {
   var price = 0.5;
+  var linenetamt = Math.round(reading.v * price * 100) / 100;
   return { c_orderline_id: seedId ? seedId() : 1, c_order_id: c_order_id, line: line, m_product_id: m_product_id,
-    c_uom_id: c_uom_id, qtyordered: reading.v, priceactual: price, linenetamt: Math.round(reading.v * price * 100) / 100 };
+    c_uom_id: c_uom_id, qtyordered: reading.v, priceactual: price, linenetamt: linenetamt, c_currency_id: MYR_CURRENCY_ID };
 }
 
-// compile ONE asset's latest readings into a billable order — {order, lines:[{row, sensor, reading, uom}],
-// _watermark}. m_product_id per sensor is a SEQUENTIAL demo id — a sensor has no real M_Product row anywhere
-// in this repo yet (same honest new-row precedent as the other compile functions, not a catalog lookup).
-function billingLines(assetId, series, buildingName, period) {
-  var order = toOrderRow(buildingName || 'This Building', period || 'latest');
+// compile ONE asset's latest readings into a billable order — {order, lines:[{row, sensor, reading, uom, usd}],
+// cameras:[{row, camera}], _watermark}. opts.erpQuery (optional, §STAGE2) governs every compile function above —
+// absent → the prior deterministic mint, byte-identical to every existing (no-erpQuery) witness/caller.
+// `usd` per line is the REAL seeded MYR→USD C_Conversion_Rate applied to linenetamt — null when ungoverned
+// (no rate to convert with, never a fabricated one). Cameras get a M_Product row too (no billing line — a
+// camera has no metered "reading" to charge for), per §BUILD ORDER point "cameras...compile as real M_Product".
+function billingLines(assetId, series, buildingName, period, opts) {
+  opts = opts || {};
+  var erpQuery = opts.erpQuery;
+  var order = toOrderRow(buildingName || 'This Building', period || 'latest', null, erpQuery);
+  var rate = usdRate(erpQuery);
   var lines = [], line = 0, uomSeq = 0, prodSeq = 0;
   SENSORS.forEach(function (s) {
     var pts = series[s.key] || [];
     var reading = pts[pts.length - 1]; if (!reading) return;
-    var uom = toUomRow(s, function () { return ++uomSeq; });
-    var m_product_id = ++prodSeq;
+    var uom = toUomRow(s, function () { return ++uomSeq; }, erpQuery);
+    var device = DEVICES[s.key];
+    var prod = toProductRow(s.key, s.label + ' (' + (device ? device.element : assetId) + ')', function () { return ++prodSeq; }, erpQuery);
     line += 10;
-    var row = toOrderLineRow(s, reading, order.c_order_id, m_product_id, uom.c_uom_id, line);
-    lines.push({ row: row, sensor: s, reading: reading, uom: uom });
+    var row = toOrderLineRow(s, reading, order.c_order_id, prod.m_product_id, uom.c_uom_id, line, function () { return line; });
+    var usd = (rate != null) ? Math.round(row.linenetamt * rate * 100) / 100 : null;
+    lines.push({ row: row, sensor: s, reading: reading, uom: uom, product: prod, usd: usd });
   });
-  return W.stamp({ order: order, lines: lines }, 'en');
+  var cameras = CAMERAS.map(function (c, i) {
+    var prod = toProductRow('cam' + (i + 1), 'CCTV Camera ' + (i + 1) + ' (' + c.element + ', ' + c.storey + ')',
+      function () { return ++prodSeq; }, erpQuery);
+    return { row: prod, camera: c };
+  });
+  return W.stamp({ order: order, lines: lines, cameras: cameras, _governed: !!erpQuery }, 'en');
 }
 
-var IoT = { SENSORS: SENSORS, seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow,
-  toOrderRow: toOrderRow, toOrderLineRow: toOrderLineRow, billingLines: billingLines };
+var IoT = { SENSORS: SENSORS, DEVICES: DEVICES, CAMERAS: CAMERAS, MYR_CURRENCY_ID: MYR_CURRENCY_ID,
+  USD_CURRENCY_ID: USD_CURRENCY_ID, seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow,
+  toOrderRow: toOrderRow, toProductRow: toProductRow, toOrderLineRow: toOrderLineRow, usdRate: usdRate,
+  billingLines: billingLines };
 if (typeof module === 'object' && module.exports) module.exports = IoT;
 else (typeof self !== 'undefined' ? self : this).HbaIot = IoT;

--- a/hr_bim_asset/tests/witness_p10b.js
+++ b/hr_bim_asset/tests/witness_p10b.js
@@ -41,6 +41,40 @@ ok('I7-uom-per-sensor', billing.lines.every(function (l) { return l.uom.uomsymbo
 ok('I8-latest-reading', billing.lines[0].reading.h === 23 && billing.lines[0].row.qtyordered === billing.lines[0].reading.v,
   'the billed qty is the LATEST hourly reading (h=23), read from the series, not invented');
 
+// §2026-07-05 (RESUME_HR_BIM_ASSET.md §2026-07-04d §BUILD ORDER) — per-device positions, Product/Order
+// persistence (§STAGE2 match-or-create), USD/RM currency.
+var devGuids = Object.keys(IoT.DEVICES).map(function (k) { return IoT.DEVICES[k].bim_guid; });
+ok('I9-devices-distinct', devGuids.length === 6 && new Set(devGuids).size === 6,
+  'DEVICES carries 6 DISTINCT real guids — sensors no longer all share the single AHU-03 position');
+ok('I9b-temp-unchanged', IoT.DEVICES.temp.bim_guid === require('../models').records('Asset')[0].bim_guid,
+  'the temp sensor still binds to the pre-existing models.js Asset AHU-03 guid — byte-identical, not renumbered');
+var camGuids = IoT.CAMERAS.map(function (c) { return c.bim_guid; });
+ok('I10-cameras-distinct', camGuids.length === 6 && new Set(camGuids).size === 6, 'CAMERAS carries 6 distinct real guids (real HHS doors)');
+
+// governed match-or-create: a stub erpQuery backed by an in-memory row set proves billingLines resolves the
+// REAL ids (not the internal ++counter mint) and _governed flips true — same §STAGE2 idiom as ad_tenancy.js.
+var stubRows = { uom: {}, product: {}, order: null, rate: 0.25 };
+function stubErpQuery(sql, params) {
+  if (/FROM C_UOM/.test(sql)) { var u = stubRows.uom[params[0]]; return u ? [{ id: u }] : []; }
+  if (/FROM M_Product/.test(sql)) { var p = stubRows.product[params[0]]; return p ? [{ id: p, name: params[0] }] : []; }
+  if (/FROM C_Order /.test(sql)) { return stubRows.order != null ? [{ id: stubRows.order }] : []; }
+  if (/C_Conversion_Rate/.test(sql)) { return [{ r: stubRows.rate }]; }
+  return [];
+}
+IoT.SENSORS.forEach(function (s, i) { stubRows.uom[s.uom_name] = 9000 + i; stubRows.product['IOT-' + s.key.toUpperCase() + '-HHS'] = 9100 + i; });
+stubRows.order = 9200;
+var govBilling = IoT.billingLines('AHU-03', s1.series, 'HHS_Office_Federated', '24h', { erpQuery: stubErpQuery });
+ok('I11-governed', govBilling._governed === true, 'billingLines() with a matching erpQuery reports _governed:true');
+ok('I12-governed-ids', govBilling.order.c_order_id === 9200 && govBilling.lines.every(function (l, i) { return l.row.m_product_id === 9100 + i; }),
+  'governed compile resolves the REAL seeded order/product ids from erpQuery, not a fresh internal mint');
+ok('I13-usd-rate', govBilling.lines.every(function (l) { return l.usd === Math.round(l.row.linenetamt * 0.25 * 100) / 100; }),
+  'usd is the linenetamt converted via the (stub, standing in for the real seeded) MYR→USD rate');
+var ungovBilling = IoT.billingLines('AHU-03', s1.series, 'HHS_Office_Federated', '24h');
+ok('I14-usd-honest-null', ungovBilling.lines.every(function (l) { return l.usd === null; }),
+  'no erpQuery → usd stays null (honest — no rate to convert with, never a fabricated FX)');
+ok('I15-cameras-products', govBilling.cameras.length === 6 && govBilling.cameras.every(function (c) { return typeof c.row.m_product_id === 'number'; }),
+  'each of the 6 cameras ALSO compiles a real M_Product row (no billing line — no metered reading to charge)');
+
 // ============================================================================================================
 // (2) viewer/hba_iot.js
 // ============================================================================================================
@@ -63,16 +97,54 @@ ok('IP1-off-nodom', body.children.length === 0 && IotPane.isActive() === false, 
 ok('IP2-gate-nomatch', IotPane.detect({ guidMap: { '1': 'not-a-real-guid' } }) === false, 'no bound asset guid in this building → unavailable, no clutter');
 ok('IP3-gate-match', IotPane.detect(A) === true, 'the asset guid resolves in guidMap → available (SAME gate as the maintenance lens)');
 
+// §2026-07-05 — stub HBALens (recording calls) so the per-device fly/orange-tint wiring (locateAndHighlight)
+// is witnessable without a real THREE/camera, same convention as flyToZone's own {flew,guid,center} return.
+var flyCalls = [], tintCalls = [], restoreCount = 0;
+self.HBALens = {
+  flyToZone: function (Aarg, guid) { flyCalls.push(guid); },
+  buildMeshPort: function () { return { setTint: function (guid, color) { tintCalls.push({ guid: guid, color: color }); }, restoreAll: function () { restoreCount++; } }; },
+  erpLink: function (w, r) { return '#w=' + w + '&r=' + r; }, AD_WINDOWS: { ORDER: 143 }
+};
+
 var r1 = IotPane.toggle(A);
 var pane = body.children.filter(function (c) { return c.id === 'hba-iot-pane'; })[0];
 ok('IP4-mount', r1 === true && IotPane.isActive() === true && !!pane, 'toggle ON mounts exactly one IoT pane');
+var barsWrap = pane.children[2];
 var cctvGrid = pane.children.filter(function (c) { return c.style.cssText.indexOf('grid-template-columns:1fr 1fr 1fr') >= 0; })[0];
 ok('IP5-cctv-tiles', cctvGrid && cctvGrid.children.length === 6, '6 CCTV mockup tiles rendered — got ' + (cctvGrid && cctvGrid.children.length));
 var billTbl = pane.children[pane.children.length - 1];
 ok('IP6-billing-rows', billTbl.children.length === 6, '6 billing rows (one per sensor) rendered in the ERP table — got ' + billTbl.children.length);
 
+// per-device fly target — clicking the "pressure" bar (index 1) must fly to ITS OWN guid, NOT the shared AHU-03
+// asset guid every bar used to fly to (the bug §BUILD ORDER point 2 fixed).
+barsWrap.children[1]._on_click();
+ok('IP7-per-device-fly', flyCalls[0] === self.HbaIot.DEVICES.pressure.bim_guid && flyCalls[0] !== assetGuid,
+  'clicking the pressure bar flies to its OWN real guid, distinct from the shared AHU-03 asset guid');
+ok('IP8-orange-tint', tintCalls[0] && tintCalls[0].color === 0xff8800 && tintCalls[0].guid === flyCalls[0],
+  'the click also holds a distinct 0xff8800 ORANGE tint on the same guid (not flyToZone\'s own 0xffcc00 arrival pulse)');
+
+// CCTV tile click — tile 3 (0-indexed 2) must fly to CAMERAS[2]'s own guid, distinct per tile.
+cctvGrid.children[2]._on_click();
+ok('IP9-cctv-fly', flyCalls[1] === self.HbaIot.CAMERAS[2].bim_guid, 'clicking CCTV tile 3 locates its OWN real camera guid (CAMERAS[2]), not a shared position');
+
+// RM/USD display — ungoverned (no A.erpQuery) mount shows RM only; a governed remount (A.erpQuery present) also
+// shows the ≈USD sub-line.
+var rmRow = billTbl.children[0];
+var amtTd = rmRow.children[2];
+ok('IP10-rm-shown', amtTd.textContent.indexOf('RM ') === 0, 'the billing amount is labelled RM (the real seeded MYR currency), not a bare number — got "' + amtTd.textContent + '"');
+ok('IP11-usd-honest-absent', amtTd.children.length === 0, 'ungoverned (no erpQuery): no ≈USD sub-line — honest, no rate to convert with');
+
+IotPane.toggle(A);   // unmount
+A.erpQuery = stubErpQuery;
+IotPane.toggle(A);   // remount, governed
+var pane2 = body.children.filter(function (c) { return c.id === 'hba-iot-pane'; })[0];
+var billTbl2 = pane2.children[pane2.children.length - 1];
+var amtTd2 = billTbl2.children[0].children[2];
+ok('IP12-usd-governed', amtTd2.children.length === 1 && amtTd2.children[0].textContent.indexOf('≈ USD') === 0,
+  'governed (A.erpQuery present, a real conversion rate resolves): the ≈USD sub-line renders — got "' + (amtTd2.children[0] && amtTd2.children[0].textContent) + '"');
+
 IotPane.toggle(A);
-ok('IP7-unmount', IotPane.isActive() === false && body.children.length === 0, 'toggle OFF removes the pane, destroys charts, stops the CCTV loop (zero residue)');
+ok('IP13-unmount', IotPane.isActive() === false && body.children.length === 0, 'toggle OFF removes the pane, destroys charts, stops the CCTV loop (zero residue)');
 
 // ============================================================================================================
 // (3) viewer/hba_draggable.js

--- a/scripts/seed_hba_erp.js
+++ b/scripts/seed_hba_erp.js
@@ -578,10 +578,87 @@ const DDL = {
   must('WINDOW316-LIVE', win316 === 'Subscription',
     'the Tenancy pane\'s own AD_WINDOWS.SUBSCRIPTION=316 link now resolves (was silently dead — window row absent from ad_seed.db\'s curated extract)');
 
+  // ── 11. C_UOM + M_Product + C_Order/C_OrderLine — IoT devices (§2026-07-05, RESUME_HR_BIM_ASSET.md
+  // §2026-07-04d §BUILD ORDER items 2/4/5) ────────────────────────────────────────────────────────────────────
+  // iot.js billingLines()'s m_product_id/c_order_id/c_orderline_id were a SEQUENTIAL IN-MEMORY MINT — same
+  // "compiled but never persisted" gap this section's §9 already fixed for C_Subscription. Two-phase, same
+  // idiom as §2/§9: (a) insert the master rows here with PROPER MAX-based ids (never the internal ++counter —
+  // that would collide with real existing M_Product/C_UOM/C_Order ids); (b) THEN call IoT.billingLines() with
+  // erpQuery so its OWN match-or-create (iot.js §STAGE2) resolves every id back to the row just inserted —
+  // _governed:true proves it, never the mint fallback. All 4 tables are REAL, already-physical (298/43/110/18
+  // rows respectively per PRAGMA — no createTable needed, unlike HR_*).
+  added.iot_uom = 0; added.iot_product = 0; added.iot_order = 0; added.iot_orderline = 0;
+  function nextId(table, idCol) { return Math.max(Number(scalar(db, 'SELECT COALESCE(MAX(' + idCol + '),0) FROM ' + table)), BIM_BASE - 1) + 1; }
+  var IoT = require(path.join(ROOT, 'hr_bim_asset', 'iot.js'));
+  IoT.SENSORS.forEach(function (s) {
+    if (scalar(db, 'SELECT C_UOM_ID FROM C_UOM WHERE Name=?', [s.uom_name]) != null) return;
+    var id = nextId('C_UOM', 'C_UOM_ID');
+    ins(db, 'C_UOM', { C_UOM_ID: id, AD_Client_ID: 11, AD_Org_ID: 0, IsActive: 'Y', Created: NOW, CreatedBy: 100,
+      Updated: NOW, UpdatedBy: 100, UOMSymbol: s.uom_symbol, Name: s.uom_name,
+      Description: 'CONTOH/SAMPLE IoT sensor physical unit (HHS pilot) — dictionary gap, real column shape',
+      StdPrecision: 2, CostingPrecision: 2, IsDefault: 'N', UOMType: 'O', C_UOM_UU: 'hba-iot-uom-' + s.key });
+    added.iot_uom++;
+    L('§SEED_HBA_IOT_UOM ADD ' + s.uom_name + ' id=' + id);
+  });
+  var DEVICE_PRODUCTS = IoT.SENSORS.map(function (s) { return { key: s.key, label: s.label + ' (' + (IoT.DEVICES[s.key] || {}).element + ')' }; })
+    .concat(IoT.CAMERAS.map(function (c, i) { return { key: 'cam' + (i + 1), label: 'CCTV Camera ' + (i + 1) + ' (' + c.element + ', ' + c.storey + ')' }; }));
+  DEVICE_PRODUCTS.forEach(function (d) {
+    var value = 'IOT-' + d.key.toUpperCase() + '-HHS';
+    if (scalar(db, 'SELECT M_Product_ID FROM M_Product WHERE Value=?', [value]) != null) return;
+    var id = nextId('M_Product', 'M_Product_ID');
+    ins(db, 'M_Product', { M_Product_ID: id, AD_Client_ID: 11, AD_Org_ID: 0, IsActive: 'Y', Created: NOW,
+      CreatedBy: 100, Updated: NOW, UpdatedBy: 100, Value: value, Name: d.label,
+      Description: 'CONTOH/SAMPLE IoT device compiled as a real M_Product (HHS pilot) — BOM PRINCIPLE: the BIM-bound device IS the product',
+      IsSummary: 'N', IsStocked: 'N', IsPurchased: 'N', IsSold: 'N', IsBOM: 'N', IsInvoicePrintDetails: 'Y',
+      IsPickListPrintDetails: 'Y', IsVerified: 'N', Discontinued: 'N', Processing: 'N', ProductType: 'S',
+      IsWebStoreFeatured: 'N', IsSelfService: 'N', IsDropShip: 'N', IsExcludeAutoDelivery: 'N', istoformule: 'N',
+      IsKanban: 'N', IsManufactured: 'N', IsPhantom: 'N', IsOwnBox: 'N', IsAutoProduce: 'N',
+      M_Product_UU: 'hba-iot-prod-' + d.key });
+    added.iot_product++;
+    L('§SEED_HBA_IOT_PRODUCT ADD ' + value + ' id=' + id);
+  });
+  var iotDocNo = 'IOT-' + HHS_VALUE + '-latest';
+  if (scalar(db, 'SELECT C_Order_ID FROM C_Order WHERE DocumentNo=?', [iotDocNo]) == null) {
+    var ordId = nextId('C_Order', 'C_Order_ID');
+    ins(db, 'C_Order', { C_Order_ID: ordId, AD_Client_ID: 11, AD_Org_ID: 0, IsActive: 'Y', Created: NOW,
+      CreatedBy: 100, Updated: NOW, UpdatedBy: 100, IsSOTrx: 'Y', DocumentNo: iotDocNo, DocStatus: 'DR',
+      DocAction: 'CO', Processed: 'N',
+      Description: 'CONTOH/SAMPLE IoT sensor billing order (HHS pilot) — utility/security readings compiled to real C_OrderLine rows',
+      DateOrdered: NOW, M_Warehouse_ID: whId, C_Currency_ID: IoT.MYR_CURRENCY_ID, IsDiscountPrinted: 'N',
+      C_Order_UU: 'hba-iot-order-latest' });
+    added.iot_order++;
+    L('§SEED_HBA_IOT_ORDER ADD ' + iotDocNo + ' id=' + ordId + ' warehouse=' + whId + ' currency=MYR(' + IoT.MYR_CURRENCY_ID + ')');
+  }
+  var eq = function (sql, p) { return rows(db, sql, p); };
+  var iotAsset = Models.records('Asset')[0];
+  var iotSeries = IoT.demoSeries(iotAsset.asset, 24);
+  var iotBilling = IoT.billingLines(iotAsset.asset, iotSeries.series, HHS_VALUE, 'latest', { erpQuery: eq });
+  must('IOT-GOVERNED', !!iotBilling._governed, 'iot.js billingLines() resolved every C_UOM/M_Product/C_Order match against the REAL rows just inserted (governed, not a throwaway mint)');
+  iotBilling.lines.forEach(function (ln) {
+    if (Number(scalar(db, 'SELECT COUNT(*) FROM C_OrderLine WHERE C_Order_ID=? AND M_Product_ID=?', [ln.row.c_order_id, ln.row.m_product_id]))) return;
+    var lnId = nextId('C_OrderLine', 'C_OrderLine_ID');
+    ins(db, 'C_OrderLine', { C_OrderLine_ID: lnId, AD_Client_ID: 11, AD_Org_ID: 0, IsActive: 'Y', Created: NOW,
+      CreatedBy: 100, Updated: NOW, UpdatedBy: 100, C_Order_ID: ln.row.c_order_id, Line: ln.row.line,
+      Description: ln.sensor.label + ' — latest reading', M_Product_ID: ln.row.m_product_id, M_Warehouse_ID: whId,
+      C_UOM_ID: ln.row.c_uom_id, QtyOrdered: ln.row.qtyordered, C_Currency_ID: ln.row.c_currency_id,
+      PriceActual: ln.row.priceactual, LineNetAmt: ln.row.linenetamt, C_OrderLine_UU: 'hba-iot-line-' + ln.sensor.key });
+    added.iot_orderline++;
+  });
+  L('§SEED_HBA_IOT_LINES lines=' + iotBilling.lines.length + ' added=' + added.iot_orderline
+    + ' cameras(M_Product only)=' + iotBilling.cameras.length);
+  must('IOT-PRODUCT-COUNT', Number(scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'")) === 12,
+    '12 real M_Product rows (6 sensors + 6 cameras) — got ' + scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'"));
+  var usdRate = IoT.usdRate(eq);
+  must('IOT-USD-RATE-REAL', usdRate != null, 'iot.js usdRate() resolved the REAL already-seeded MYR(301)->USD(100) C_Conversion_Rate, not a fabricated one — rate=' + usdRate);
+  var lineJoin = rows(db, 'SELECT L.LineNetAmt AS rm, L.C_Currency_ID AS cur FROM C_OrderLine L JOIN C_Order O ON L.C_Order_ID=O.C_Order_ID WHERE O.DocumentNo=?', [iotDocNo]);
+  must('IOT-LINES-MYR', lineJoin.length === 6 && lineJoin.every(function (r) { return Number(r.cur) === IoT.MYR_CURRENCY_ID; }),
+    'all 6 persisted C_OrderLine rows bill in the real MYR currency row (301) — got ' + lineJoin.length + ' rows');
+
   // ── write-back + summary ─────────────────────────────────────────────────────────────────────────────────
   var changed = added.warehouse + added.locators + added.bpartners + added.users + added.tables + added.hr_rows
     + added.info + added.attendance + added.retired + added.restype + added.resources + (added.leave || 0)
-    + (added.tenant_bp || 0) + (added.subtypes || 0) + (added.subscriptions || 0);
+    + (added.tenant_bp || 0) + (added.subtypes || 0) + (added.subscriptions || 0)
+    + added.iot_uom + added.iot_product + added.iot_order + added.iot_orderline;
   if (changed > 0 && fails === 0) { fs.writeFileSync(SEED, Buffer.from(db.export())); L('§SEED_HBA WROTE erp/ad_seed.db (' + changed + ' additions)'); }
   else if (fails === 0) L('§SEED_HBA NO-OP — seed already current (idempotent 2nd run)');
   else L('§SEED_HBA NOT WRITTEN — ' + fails + ' witness failure(s), DB left untouched');

--- a/viewer/hba_iot.js
+++ b/viewer/hba_iot.js
@@ -13,16 +13,22 @@
 //   section (hba_dashboard.js still uses Chart.js for its own KPI trend charts — untouched). Each bar's
 //   tick(pt) setter is the STUB SEAM for later real physical sensor wiring: swap the setInterval driver for a
 //   real telemetry callback and the same rows/bars update — nothing else in this file needs to change. Each
-//   bar is one distinct colour (SENSOR_COLORS) and clicking it flies the camera to the bound asset's real
-//   location via HBALens.flyToZone — so "there's a live sensor" also means "here's exactly where it is".
-//   (b) a 2x3 CCTV grid — plain <canvas>, now painted from a REAL dimmed still photo (`hba_cctv_still.jpg`,
-//   user-supplied ContaCam capture, copied into this repo — NOT a feed of THIS building, still captioned
-//   MOCKUP) with a scanline overlay + a diagonal "STUB READY" watermark (this tile is the placeholder seam
-//   for later real physical camera wiring, not a claim of a live feed), NO invented video/GIF asset, NO
-//   external URL fetch (PRIME RULE). (c) the
-//   ERP billing table — iot.billingLines() rendered as sensor/reading/uom/C_OrderLine qty·price·net,
-//   watermarked. ZERO-IMPACT: OFF = no DOM; toggle ON mounts ONE fixed overlay; toggle OFF removes it +
-//   stops all animation timers (zero residue). Read the log after run.
+//   bar is one distinct colour (SENSOR_COLORS) and clicking it flies the camera to THAT SENSOR'S OWN real
+//   bound position (locateAndHighlight — §2026-07-05: iot.js DEVICES, one real guid per sensor, no longer all
+//   6 sharing the single PM_Asset AHU-03 guid) + holds a distinct ORANGE tint — "there's a live sensor" also
+//   means "here's exactly where it is". (b) a 2x3 CCTV grid — plain <canvas>, now painted from a REAL dimmed
+//   still photo (`hba_cctv_still.jpg`, user-supplied ContaCam capture, copied into this repo — NOT a feed of
+//   THIS building, still captioned MOCKUP) with a scanline overlay + a diagonal "STUB READY" watermark (this
+//   tile is the placeholder seam for later real physical camera wiring, not a claim of a live feed), NO
+//   invented video/GIF asset, NO external URL fetch (PRIME RULE); §2026-07-05: each tile is ALSO clickable,
+//   locating+highlighting its OWN real bound camera position (iot.js CAMERAS, 6 real entrance/circulation
+//   doors). (c) the ERP billing table — iot.billingLines() rendered as sensor/reading/uom/C_OrderLine
+//   qty·RM·≈USD (§2026-07-05: c_currency_id=the real seeded MYR row, USD via the real seeded conversion rate,
+//   never a fabricated FX) · an "open ↗" deep-link into the real persisted C_Order/C_OrderLine (once
+//   scripts/seed_hba_erp.js §11 has run — see that script's header), watermarked. `boundAssets`/`detect` still
+//   gate the PANE'S visibility on the pre-existing single PM_Asset (AHU-03) record — unchanged, low-risk; only
+//   the PER-DEVICE fly/tint target changed. ZERO-IMPACT: OFF = no DOM; toggle ON mounts ONE fixed overlay;
+//   toggle OFF removes it + stops all animation timers (zero residue). Read the log after run.
 (function () {
   'use strict';
   var G = (typeof self !== 'undefined' ? self : this);
@@ -93,21 +99,38 @@
   // the reference Bonsai federation/river panel's per-channel colour coding, no invented data behind it).
   var SENSOR_COLORS = { temp: '#1976d2', pressure: '#7b1fa2', sound: '#00897b', dust: '#ef6c00', solar: '#fbc02d', electrical: '#43a047' };
 
+  // §2026-07-05 (§BUILD ORDER point 3) — "locate the device outright": fly the camera to its OWN real bound
+  // position (iot.js DEVICES/CAMERAS, one per device — no longer every device sharing the single AHU-03 guid)
+  // AND hold a distinct ORANGE tint (0xff8800) on it — deliberately a different hue from flyToZone's own brief
+  // 0xffcc00 arrival pulse (1.6s, auto-restoring) so "you clicked THIS device" stays visible after the fly
+  // finishes, not just during the flight. Self-restoring (setTimeout→restoreAll), zero residue, same discipline
+  // as every other HBA tint. Honest no-op (flyToZone's own §HBA_FLY log) when the guid has no rendered member.
+  var ORANGE = 0xff8800, ORANGE_HOLD_MS = 4000;
+  function locateAndHighlight(A, guid) {
+    if (!G.HBALens || !G.HBALens.flyToZone) return;
+    G.HBALens.flyToZone(A, guid);
+    if (G.HBALens.buildMeshPort) {
+      var port = G.HBALens.buildMeshPort(A);
+      port.setTint(guid, ORANGE);
+      setTimeout(function () { port.restoreAll(); }, ORANGE_HOLD_MS);
+    }
+  }
+
   // one animated horizontal bar row per sensor — width + the running value at the bar's leading edge both
   // move together (matching CSS transition) as tick(pt) is fed new points. min/max are DATA-DERIVED (the
   // sensor's own baseline±amplitude from hr_bim_asset/iot.js), never an invented threshold. Clicking the row
-  // flies the camera to the bound asset's real location (HBALens.flyToZone) — "locate the device outright".
-  function renderSensorBar(A, asset, sensor, min, max) {
+  // flies the camera to THIS sensor's OWN real bound location (locateAndHighlight) — "locate the device outright".
+  function renderSensorBar(A, device, sensor, min, max) {
     var color = SENSOR_COLORS[sensor.key] || '#1976d2';
     var row = el('div', 'padding:4px 0;cursor:pointer;');
-    row.title = 'Locate ' + asset.asset + ' in the model';
+    row.title = 'Locate ' + sensor.label + ' (' + (device ? device.element : sensor.label) + ') in the model';
     row.appendChild(el('div', 'font-size:10px;color:#627d98;text-transform:uppercase;margin-bottom:2px;', sensor.label));
     var track = el('div', 'position:relative;height:16px;background:#eef2f6;border-radius:3px;');
     var fill = el('div', 'position:absolute;left:0;top:0;bottom:0;width:2%;background:' + color + ';border-radius:3px;transition:width 0.7s ease;');
     var val = el('span', 'position:absolute;top:50%;left:2%;transform:translateY(-50%);font-size:10px;font-weight:600;color:#102a43;white-space:nowrap;transition:left 0.7s ease;padding-left:6px;');
     track.appendChild(fill); track.appendChild(val);
     row.appendChild(track);
-    row.addEventListener('click', function () { if (G.HBALens && G.HBALens.flyToZone) G.HBALens.flyToZone(A, asset.bim_guid); });
+    row.addEventListener('click', function () { if (device) locateAndHighlight(A, device.bim_guid); });
     var tick = function (pt) {
       var pct = Math.max(2, Math.min(100, ((pt.v - min) / (max - min)) * 100));
       fill.style.width = pct + '%';
@@ -122,7 +145,11 @@
     if (!assets.length) return false;
     var deps_ = deps(), asset = assets[0];
     var seriesSpec = deps_.IoT.demoSeries(asset.asset, 24);
-    var billing = deps_.IoT.billingLines(asset.asset, seriesSpec.series, (A && A.buildingName) || 'This Building', seriesSpec.hours + 'h');
+    // §2026-07-05 — pass A.erpQuery (the SAME sync seam Tenancy/Payroll already reuse, set once ad_seed.db
+    // loads) so billingLines() resolves the REAL persisted C_UOM/M_Product/C_Order/C_Currency rows
+    // (scripts/seed_hba_erp.js §11) instead of the ungoverned in-memory mint. Absent → prior mint, unchanged.
+    var billing = deps_.IoT.billingLines(asset.asset, seriesSpec.series, (A && A.buildingName) || 'This Building',
+      seriesSpec.hours + 'h', { erpQuery: A && A.erpQuery });
 
     var pane = el('div', 'position:fixed;top:54px;right:12px;width:420px;max-height:86vh;overflow:auto;z-index:10050;' +
       'background:#fff;border-radius:10px;box-shadow:0 6px 24px #0005;font-family:system-ui,sans-serif;color:#222;');
@@ -145,18 +172,24 @@
       var min = Math.min.apply(null, vals), max = Math.max.apply(null, vals);
       if (max === min) max = min + 1;   // guard degenerate flat series
       var headroom = (max - min) * 0.15;
-      var b = renderSensorBar(A, asset, s, min - headroom, max + headroom);
+      var b = renderSensorBar(A, deps_.IoT.DEVICES[s.key], s, min - headroom, max + headroom);
       barsWrap.appendChild(b.row); bars.push({ b: b, sensor: s, pts: pts });
     });
     pane.appendChild(barsWrap);
 
-    // (b) CCTV mockup grid — 6 tiles, real dimmed still + canvas scanline animation, explicitly labeled MOCKUP
-    pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:6px 12px 0;', 'CCTV (mockup — no real feed)'));
+    // (b) CCTV mockup grid — 6 tiles, real dimmed still + canvas scanline animation, explicitly labeled MOCKUP.
+    // §2026-07-05 (§BUILD ORDER point 3) — each tile is now ALSO clickable: locates+orange-highlights its OWN
+    // real bound camera position (iot.js CAMERAS[i], a real entrance/circulation door — see file header), not
+    // just a static image crop.
+    pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:6px 12px 0;', 'CCTV (mockup — no real feed, click to locate)'));
     var cctvWrap = el('div', 'display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;padding:6px 12px;');
     var cctvTicks = [];
     for (var i = 1; i <= 6; i++) {
       var cv2 = document.createElement('canvas'); cv2.width = 120; cv2.height = 68;
-      cv2.style.cssText = 'display:block;width:100%;border-radius:4px;background:#0a1622;';
+      cv2.style.cssText = 'display:block;width:100%;border-radius:4px;background:#0a1622;cursor:pointer;';
+      var cam = deps_.IoT.CAMERAS[i - 1];
+      if (cam) { cv2.title = 'Locate CCTV Camera ' + i + ' (' + cam.element + ', ' + cam.storey + ') in the model'; }
+      cv2.addEventListener('click', (function (camGuid) { return function () { if (camGuid) locateAndHighlight(A, camGuid); }; })(cam && cam.bim_guid));
       cctvWrap.appendChild(cv2);
       var tick = renderCctvTile(cv2, i); if (tick) cctvTicks.push(tick);
     }
@@ -172,7 +205,12 @@
       var tr = el('tr', 'border-top:1px solid #eee;');
       tr.appendChild(el('td', 'padding:4px 2px;', ln.sensor.label));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', 'qty ' + ln.row.qtyordered + ' ' + ln.sensor.uom_symbol));
-      tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#2e7d32;font-weight:600;', ln.row.linenetamt.toFixed(2)));
+      // §2026-07-05 (§BUILD ORDER point 4) — RM is the real c_currency_id (301) the row itself is billed in;
+      // USD is the SAME already-seeded C_Conversion_Rate (never a second invented rate) — shown only when
+      // resolvable (governed/erpQuery present), an honest dash otherwise (no fabricated FX).
+      var amtTd = el('td', 'padding:4px 2px;text-align:right;color:#2e7d32;font-weight:600;', 'RM ' + ln.row.linenetamt.toFixed(2));
+      if (ln.usd != null) amtTd.appendChild(el('div', 'font-weight:400;color:#627d98;font-size:10px;', '≈ USD ' + ln.usd.toFixed(2)));
+      tr.appendChild(amtTd);
       // §P11 — deep-link this billing line into the real C_Order it compiled onto (management billing follow-up).
       var linkTd = el('td', 'padding:4px 2px;text-align:right;');
       if (ln.row.c_order_id != null && G.HBALens && G.HBALens.erpLink) {


### PR DESCRIPTION
## Summary
- 6 IoT sensors + 6 CCTV cameras now bind to their OWN real HHS_Office_Federated element guids (queried live against `buildings/HHS_Office_Federated_extracted.db`) instead of all sharing the single AHU-03 position — clicking a sensor bar or CCTV tile flies the camera to a distinct real location and holds a distinct orange (0xff8800) tint, separate from `flyToZone`'s own yellow arrival pulse.
- `iot.js`'s `toUomRow`/`toProductRow`/`toOrderRow` gain the same `_one(erpQuery,...)` match-or-create idiom `ad_tenancy.js` already uses; `scripts/seed_hba_erp.js` §11 persists real `C_UOM`/`M_Product`/`C_Order`/`C_OrderLine` rows (12 devices' M_Products + 6 order lines) so the pane's existing "open ↗" Order deep-link (`AD_WINDOWS.ORDER=143`) now resolves to a real record instead of an in-memory mint.
- Billing table shows RM (the real already-seeded MYR currency row) plus a ≈USD equivalent via the already-seeded `C_Conversion_Rate` — never a fabricated FX rate.

Continues `RESUME_HR_BIM_ASSET.md` §2026-07-04d §BUILD ORDER (items 1/2/3/4/5); item 6 not started (audio effects, queued separately as §P10c).

## Test plan
- [x] `witness_p10b.js` extended: 36/36 (new I9–I15 engine checks, IP7–IP13 pane checks — per-device fly target, orange tint distinct from yellow pulse, governed vs ungoverned USD, camera Products)
- [x] Full 41-file HBA node witness suite re-run: zero regression
- [x] `scripts/seed_hba_erp.js` run twice: 1st pass adds 25 rows + all self-witnesses PASS, 2nd pass is a true no-op (idempotent)
- [x] Live CDP smoke against `demo/fm_panel.html` in real headless Chrome: mount/6 bars/6 CCTV tiles/6 billing rows, clicking the pressure bar and CCTV tile 3 fires `§HBA_FLY` with the exact expected distinct real guids, RM display correct, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)