### PR TITLE
feat(hba): IoT audio sirens (§P10c) + wider device zoom + movement/PIR sensor

### DIFF
--- a/hr_bim_asset/iot.js
+++ b/hr_bim_asset/iot.js
@@ -27,6 +27,13 @@
 //      — a sensor's a local-site utility/security cost, MYR is the natural billing currency. USD equivalent is
 //      read from the SAME already-seeded `C_Conversion_Rate` (301→100), never a second invented rate; absent
 //      erpQuery → usd stays null (honest, no rate to convert with).
+//
+//   §2026-07-05b (§P10c, user: "just simple tones but goes high pitch indicating danger") — `toneFreqFor` is
+//   the PURE, deterministic sonification mapping: a sensor's CURRENT reading position within its OWN observed
+//   min/max range (the exact bounds `viewer/hba_iot.js`'s bar already computes for its headroom — never a
+//   fabricated "danger threshold") maps to a pitch between TONE_BASE_HZ (calm/low) and TONE_DANGER_HZ (the
+//   extreme end of the sensor's own range = "danger", high-pitched). The actual Web Audio playback lives in
+//   viewer/hba_iot.js (DOM/browser-only); this stays pure so it is node-witnessable without an AudioContext.
 //   Read the log after run.
 'use strict';
 var W = (typeof require !== 'undefined') ? require('./watermark') : (typeof self !== 'undefined' ? self : this).HbaWatermark;
@@ -48,7 +55,8 @@ var DEVICES = {
   sound:      { bim_guid: '07A8OFMrj5IeMQd6aflvMZ', element: 'Supply Diffuser (Level 2)', storey: 'Level 2' },
   dust:       { bim_guid: '0B2Nysi4bEIBgg6BXJzBCa', element: 'Supply Diffuser (Level 2)', storey: 'Level 2' },
   solar:      { bim_guid: '3XrBtx9eX7mQE6EqWHPey$', element: 'Roof sun-shading floor', storey: 'Roof Level' },
-  electrical: { bim_guid: '1Atj4lkpv3qwTaPKeAZIaj', element: 'Main Distribution Panel MDP-1', storey: 'Level 1' }
+  electrical: { bim_guid: '1Atj4lkpv3qwTaPKeAZIaj', element: 'Main Distribution Panel MDP-1', storey: 'Level 1' },
+  movement:   { bim_guid: '3XrBtx9eX7mQE6EqWHPfzR', element: 'Entrance door (motion/PIR)', storey: 'Level 1' }
 };
 // 6 real entrance/circulation doors, 2 per storey — CCTV placement idiom, not a random pick.
 var CAMERAS = [
@@ -77,7 +85,12 @@ var SENSORS = [
   { key: 'sound',      label: 'Sound Level',     uom_name: 'Decibel',     uom_symbol: 'dB',        baseline: 42,  amplitude: 8,   rate: 0 },
   { key: 'dust',       label: 'Dust (PM2.5)',    uom_name: 'Microgram/m3', uom_symbol: 'µg/m³', baseline: 18, amplitude: 10, rate: 0.05 },
   { key: 'solar',      label: 'Solar Output',    uom_name: 'Watt/m2',     uom_symbol: 'W/m²', baseline: 300, amplitude: 300, rate: 0 },
-  { key: 'electrical', label: 'Electrical Load', uom_name: 'Kilowatt-hour', uom_symbol: 'kWh',     baseline: 12,  amplitude: 5,   rate: 0.02 }
+  { key: 'electrical', label: 'Electrical Load', uom_name: 'Kilowatt-hour', uom_symbol: 'kWh',     baseline: 12,  amplitude: 5,   rate: 0.02 },
+  // §2026-07-05c (user: "there can also be a sensor for movement") — a 7th, PIR/motion-style security sensor.
+  // Reuses the SAME deterministic sine generator, no special-casing: baseline+amplitude puts it near-zero at
+  // night and peaking at midday — a genuinely plausible real motion-level pattern for an occupied office
+  // building, not a fabricated waveform shape.
+  { key: 'movement',   label: 'Motion (PIR)',    uom_name: 'Motion Level', uom_symbol: '%',  baseline: 15,  amplitude: 15,  rate: 0 }
 ];
 
 // deterministic 24-hourly-point curve: baseline + amplitude*sin (a plausible daily shape, trough near
@@ -177,8 +190,18 @@ function billingLines(assetId, series, buildingName, period, opts) {
   return W.stamp({ order: order, lines: lines, cameras: cameras, _governed: !!erpQuery }, 'en');
 }
 
+// §2026-07-05b — pitch = the reading's position within [min,max] (its own observed range), never a fabricated
+// threshold. min===max (degenerate) → mid-range tone, not a divide-by-zero.
+var TONE_BASE_HZ = 220, TONE_DANGER_HZ = 880;
+function toneFreqFor(value, min, max) {
+  var span = max - min;
+  var norm = span ? Math.max(0, Math.min(1, (value - min) / span)) : 0.5;
+  return Math.round(TONE_BASE_HZ + norm * (TONE_DANGER_HZ - TONE_BASE_HZ));
+}
+
 var IoT = { SENSORS: SENSORS, DEVICES: DEVICES, CAMERAS: CAMERAS, MYR_CURRENCY_ID: MYR_CURRENCY_ID,
-  USD_CURRENCY_ID: USD_CURRENCY_ID, seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow,
+  USD_CURRENCY_ID: USD_CURRENCY_ID, TONE_BASE_HZ: TONE_BASE_HZ, TONE_DANGER_HZ: TONE_DANGER_HZ,
+  seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow, toneFreqFor: toneFreqFor,
   toOrderRow: toOrderRow, toProductRow: toProductRow, toOrderLineRow: toOrderLineRow, usdRate: usdRate,
   billingLines: billingLines };
 if (typeof module === 'object' && module.exports) module.exports = IoT;

--- a/hr_bim_asset/tests/witness_p10b.js
+++ b/hr_bim_asset/tests/witness_p10b.js
@@ -20,8 +20,8 @@ global.self = global;
 self.HbaWatermark = require('../watermark');
 var IoT = self.HbaIot = require('../iot');
 
-ok('I1-catalog', IoT.SENSORS.length === 6 && IoT.SENSORS.map(function (s) { return s.key; }).join(',') === 'temp,pressure,sound,dust,solar,electrical',
-  'the 6 sensors named by the user (temp/boiler pressure/sound/dust/solar/electrical) are ALL present');
+ok('I1-catalog', IoT.SENSORS.length === 7 && IoT.SENSORS.map(function (s) { return s.key; }).join(',') === 'temp,pressure,sound,dust,solar,electrical,movement',
+  'the 6 sensors named by the user (temp/boiler pressure/sound/dust/solar/electrical) + movement/PIR (§2026-07-05c) are ALL present');
 var s1 = IoT.demoSeries('AHU-03', 24), s2 = IoT.demoSeries('AHU-03', 24);
 ok('I2-deterministic', JSON.stringify(s1) === JSON.stringify(s2),
   'demoSeries is DETERMINISTIC — same asset+hours -> byte-identical output twice (no Math.random/Date.now)');
@@ -32,7 +32,7 @@ ok('I4-watermark', s1._watermark === 'SAMPLE — NOT OFFICIAL', 'the series is w
 var billing = IoT.billingLines('AHU-03', s1.series, 'HHS_Office_Federated', '24h');
 ok('I5-native-order', /^IOT-/.test(billing.order.documentno) && billing.order.docstatus === 'DR',
   'toOrderRow compiles onto the real c_order columns (documentno/docstatus/issotrx)');
-ok('I6-native-lines', billing.lines.length === 6 && billing.lines.every(function (l) {
+ok('I6-native-lines', billing.lines.length === 7 && billing.lines.every(function (l) {
   return typeof l.row.c_orderline_id === 'number' && l.row.c_order_id === billing.order.c_order_id
     && typeof l.row.qtyordered === 'number' && typeof l.row.c_uom_id === 'number' && typeof l.row.linenetamt === 'number';
 }), 'ONE billable c_orderline PER sensor, real column shape (c_order_id/qtyordered/c_uom_id/linenetamt) — ' + billing.lines.length + ' lines');
@@ -44,8 +44,8 @@ ok('I8-latest-reading', billing.lines[0].reading.h === 23 && billing.lines[0].ro
 // §2026-07-05 (RESUME_HR_BIM_ASSET.md §2026-07-04d §BUILD ORDER) — per-device positions, Product/Order
 // persistence (§STAGE2 match-or-create), USD/RM currency.
 var devGuids = Object.keys(IoT.DEVICES).map(function (k) { return IoT.DEVICES[k].bim_guid; });
-ok('I9-devices-distinct', devGuids.length === 6 && new Set(devGuids).size === 6,
-  'DEVICES carries 6 DISTINCT real guids — sensors no longer all share the single AHU-03 position');
+ok('I9-devices-distinct', devGuids.length === 7 && new Set(devGuids).size === 7,
+  'DEVICES carries 7 DISTINCT real guids (6 original + movement) — sensors no longer all share the single AHU-03 position');
 ok('I9b-temp-unchanged', IoT.DEVICES.temp.bim_guid === require('../models').records('Asset')[0].bim_guid,
   'the temp sensor still binds to the pre-existing models.js Asset AHU-03 guid — byte-identical, not renumbered');
 var camGuids = IoT.CAMERAS.map(function (c) { return c.bim_guid; });
@@ -74,6 +74,12 @@ ok('I14-usd-honest-null', ungovBilling.lines.every(function (l) { return l.usd =
   'no erpQuery → usd stays null (honest — no rate to convert with, never a fabricated FX)');
 ok('I15-cameras-products', govBilling.cameras.length === 6 && govBilling.cameras.every(function (c) { return typeof c.row.m_product_id === 'number'; }),
   'each of the 6 cameras ALSO compiles a real M_Product row (no billing line — no metered reading to charge)');
+
+// §2026-07-05c — toneFreqFor: pure, deterministic pitch-vs-danger mapping (user: "high pitch indicating danger").
+ok('I16-tone-low', IoT.toneFreqFor(10, 10, 20) === IoT.TONE_BASE_HZ, 'the reading AT the range floor -> the calm/low base pitch (220Hz)');
+ok('I17-tone-high', IoT.toneFreqFor(20, 10, 20) === IoT.TONE_DANGER_HZ, 'the reading AT the range ceiling -> the high/danger pitch (880Hz)');
+ok('I18-tone-mid', IoT.toneFreqFor(15, 10, 20) === Math.round((IoT.TONE_BASE_HZ + IoT.TONE_DANGER_HZ) / 2), 'a mid-range reading -> a mid pitch');
+ok('I19-tone-degenerate', IoT.toneFreqFor(5, 5, 5) === Math.round((IoT.TONE_BASE_HZ + IoT.TONE_DANGER_HZ) / 2), 'min===max (degenerate range) -> mid-range tone, no divide-by-zero');
 
 // ============================================================================================================
 // (2) viewer/hba_iot.js
@@ -113,7 +119,7 @@ var barsWrap = pane.children[2];
 var cctvGrid = pane.children.filter(function (c) { return c.style.cssText.indexOf('grid-template-columns:1fr 1fr 1fr') >= 0; })[0];
 ok('IP5-cctv-tiles', cctvGrid && cctvGrid.children.length === 6, '6 CCTV mockup tiles rendered — got ' + (cctvGrid && cctvGrid.children.length));
 var billTbl = pane.children[pane.children.length - 1];
-ok('IP6-billing-rows', billTbl.children.length === 6, '6 billing rows (one per sensor) rendered in the ERP table — got ' + billTbl.children.length);
+ok('IP6-billing-rows', billTbl.children.length === 7, '7 billing rows (one per sensor, incl. movement) rendered in the ERP table — got ' + billTbl.children.length);
 
 // per-device fly target — clicking the "pressure" bar (index 1) must fly to ITS OWN guid, NOT the shared AHU-03
 // asset guid every bar used to fly to (the bug §BUILD ORDER point 2 fixed).
@@ -145,6 +151,41 @@ ok('IP12-usd-governed', amtTd2.children.length === 1 && amtTd2.children[0].textC
 
 IotPane.toggle(A);
 ok('IP13-unmount', IotPane.isActive() === false && body.children.length === 0, 'toggle OFF removes the pane, destroys charts, stops the CCTV loop (zero residue)');
+
+// §2026-07-05c — zoom distance (locateAndHighlight passes {dist:18} to flyToZone, wider than the shared
+// default of 8, per user: "zooms to the device, not too near, surrounding") + per-sensor siren audio, OFF by
+// default, ON only after the mute button is clicked (the required user-gesture to start an AudioContext).
+var flyOpts = null;
+self.HBALens.flyToZone = function (Aarg, guid, opts) { flyCalls.push(guid); flyOpts = opts; };
+function FakeAudioNode() { this.frequency = { setValueAtTime: function () {}, exponentialRampToValueAtTime: function () {} };
+  this.gain = { setValueAtTime: function () {}, exponentialRampToValueAtTime: function () {} }; this.type = null; }
+FakeAudioNode.prototype.connect = function () {}; FakeAudioNode.prototype.start = function () {}; FakeAudioNode.prototype.stop = function () {};
+var oscLog = [];
+function FakeAudioContext() { this.currentTime = 0; this.state = 'running'; this.destination = {}; }
+FakeAudioContext.prototype.createOscillator = function () { var o = new FakeAudioNode(); oscLog.push(o); return o; };
+FakeAudioContext.prototype.createGain = function () { return new FakeAudioNode(); };
+FakeAudioContext.prototype.resume = function () {};
+global.AudioContext = FakeAudioContext;
+var capturedTick = null;
+global.setInterval = function (fn) { capturedTick = fn; return 999; };
+global.clearInterval = function () {};
+
+IotPane.toggle(A);   // mount — captures the tick callback, does NOT invoke it yet
+var pane3 = body.children.filter(function (c) { return c.id === 'hba-iot-pane'; })[0];
+var barsWrap3 = pane3.children[2];
+barsWrap3.children[1]._on_click();   // pressure bar, same as IP7
+ok('IP14-zoom-dist', flyOpts && flyOpts.dist === 18 && flyOpts.dist > 8, 'clicking a device passes a WIDER zoom distance (18) than flyToZone\'s shared default (8) — "not too near", surrounding stays visible');
+
+ok('IP15-audio-off-default', capturedTick && (capturedTick(), oscLog.length === 0), 'a bar tick with audio OFF (default) plays ZERO tones — opt-in, zero-impact by default');
+
+var muteBtn = pane3.children[0].children[1];   // head: [title, mute, close]
+muteBtn._on_click();
+capturedTick();
+var expectBlips = self.HbaIot.SENSORS.reduce(function (n, s) { return n + (({ temp: 1, pressure: 1, sound: 1, dust: 1, solar: 2, electrical: 2, movement: 3 })[s.key] || 1); }, 0);
+ok('IP16-audio-on-plays', oscLog.length === expectBlips, 'once muted->on, a tick plays the expected total blip count across all 7 sensors (1+1+1+1+2+2+3=' + expectBlips + ') — got ' + oscLog.length);
+ok('IP17-distinct-waveforms', new Set(oscLog.map(function (o) { return o.type; })).size >= 3, 'multiple DISTINCT waveforms are used across sensors — "identify by the sound right away", not one uniform beep — got types ' + JSON.stringify(oscLog.map(function (o) { return o.type; })));
+
+IotPane.toggle(A);   // unmount
 
 // ============================================================================================================
 // (3) viewer/hba_draggable.js

--- a/scripts/seed_hba_erp.js
+++ b/scripts/seed_hba_erp.js
@@ -646,13 +646,17 @@ const DDL = {
   });
   L('§SEED_HBA_IOT_LINES lines=' + iotBilling.lines.length + ' added=' + added.iot_orderline
     + ' cameras(M_Product only)=' + iotBilling.cameras.length);
-  must('IOT-PRODUCT-COUNT', Number(scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'")) === 12,
-    '12 real M_Product rows (6 sensors + 6 cameras) — got ' + scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'"));
+  // §2026-07-05c — expected counts DERIVE from DEVICE_PRODUCTS/iotBilling.lines (never a hardcoded literal) so
+  // adding/removing a sensor (e.g. the movement/PIR sensor) can't silently desync this self-witness again.
+  var expectProducts = DEVICE_PRODUCTS.length;
+  must('IOT-PRODUCT-COUNT', Number(scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'")) === expectProducts,
+    expectProducts + ' real M_Product rows (' + IoT.SENSORS.length + ' sensors + ' + IoT.CAMERAS.length + ' cameras) — got '
+    + scalar(db, "SELECT COUNT(*) FROM M_Product WHERE Value LIKE 'IOT-%-HHS'"));
   var usdRate = IoT.usdRate(eq);
   must('IOT-USD-RATE-REAL', usdRate != null, 'iot.js usdRate() resolved the REAL already-seeded MYR(301)->USD(100) C_Conversion_Rate, not a fabricated one — rate=' + usdRate);
   var lineJoin = rows(db, 'SELECT L.LineNetAmt AS rm, L.C_Currency_ID AS cur FROM C_OrderLine L JOIN C_Order O ON L.C_Order_ID=O.C_Order_ID WHERE O.DocumentNo=?', [iotDocNo]);
-  must('IOT-LINES-MYR', lineJoin.length === 6 && lineJoin.every(function (r) { return Number(r.cur) === IoT.MYR_CURRENCY_ID; }),
-    'all 6 persisted C_OrderLine rows bill in the real MYR currency row (301) — got ' + lineJoin.length + ' rows');
+  must('IOT-LINES-MYR', lineJoin.length === iotBilling.lines.length && lineJoin.every(function (r) { return Number(r.cur) === IoT.MYR_CURRENCY_ID; }),
+    'all ' + iotBilling.lines.length + ' persisted C_OrderLine rows bill in the real MYR currency row (301) — got ' + lineJoin.length + ' rows');
 
   // ── write-back + summary ─────────────────────────────────────────────────────────────────────────────────
   var changed = added.warehouse + added.locators + added.bpartners + added.users + added.tables + added.hr_rows

--- a/viewer/hba_iot.js
+++ b/viewer/hba_iot.js
@@ -95,9 +95,9 @@
     };
   }
 
-  // one distinct accent colour per sensor — purely visual differentiation between the 6 racing bars (matches
+  // one distinct accent colour per sensor — purely visual differentiation between the racing bars (matches
   // the reference Bonsai federation/river panel's per-channel colour coding, no invented data behind it).
-  var SENSOR_COLORS = { temp: '#1976d2', pressure: '#7b1fa2', sound: '#00897b', dust: '#ef6c00', solar: '#fbc02d', electrical: '#43a047' };
+  var SENSOR_COLORS = { temp: '#1976d2', pressure: '#7b1fa2', sound: '#00897b', dust: '#ef6c00', solar: '#fbc02d', electrical: '#43a047', movement: '#c62828' };
 
   // §2026-07-05 (§BUILD ORDER point 3) — "locate the device outright": fly the camera to its OWN real bound
   // position (iot.js DEVICES/CAMERAS, one per device — no longer every device sharing the single AHU-03 guid)
@@ -105,14 +105,60 @@
   // 0xffcc00 arrival pulse (1.6s, auto-restoring) so "you clicked THIS device" stays visible after the fly
   // finishes, not just during the flight. Self-restoring (setTimeout→restoreAll), zero residue, same discipline
   // as every other HBA tint. Honest no-op (flyToZone's own §HBA_FLY log) when the guid has no rendered member.
-  var ORANGE = 0xff8800, ORANGE_HOLD_MS = 4000;
+  // §2026-07-05c (user: "zooms to the device, not too near, surrounding") — DEVICE_ZOOM_DIST widens
+  // flyToZone's own default (8) so the shot is an establishing view of the device's room/plant/entrance, not a
+  // nose-to-mesh close-up; flyToZone itself is UNCHANGED for every other caller (opts.dist defaults to 8).
+  var ORANGE = 0xff8800, ORANGE_HOLD_MS = 4000, DEVICE_ZOOM_DIST = 18;
   function locateAndHighlight(A, guid) {
     if (!G.HBALens || !G.HBALens.flyToZone) return;
-    G.HBALens.flyToZone(A, guid);
+    G.HBALens.flyToZone(A, guid, { dist: DEVICE_ZOOM_DIST });
     if (G.HBALens.buildMeshPort) {
       var port = G.HBALens.buildMeshPort(A);
       port.setTint(guid, ORANGE);
       setTimeout(function () { port.restoreAll(); }, ORANGE_HOLD_MS);
+    }
+  }
+
+  // §2026-07-05c (§P10c, user: "just simple tones but goes high pitch indicating danger" / "a combi of sirens
+  // ... for respective sensors" / "identify by the sound right away") — a distinct waveform+blip-count PER
+  // sensor so the SOUND ALONE identifies which sensor is alarming, independent of the shared pitch-vs-danger
+  // mapping (iot.js toneFreqFor). Only 4 native Web Audio waveforms exist, so 2 pairs share a waveform but
+  // differ in blip count (a single sustained tone vs a quick double/triple chirp) — still 7 distinct signatures.
+  var SENSOR_TONE = {
+    temp: { wave: 'sine', blips: 1 }, pressure: { wave: 'square', blips: 1 }, sound: { wave: 'triangle', blips: 1 },
+    dust: { wave: 'sawtooth', blips: 1 }, solar: { wave: 'sine', blips: 2 }, electrical: { wave: 'square', blips: 2 },
+    movement: { wave: 'triangle', blips: 3 }
+  };
+  var _audioCtx = null, _audioOn = false;
+  function ensureAudioCtx() {
+    if (_audioCtx) return _audioCtx;
+    var Ctx = G.AudioContext || G.webkitAudioContext;
+    if (!Ctx) return null;
+    _audioCtx = new Ctx();
+    return _audioCtx;
+  }
+  // one short "whoop" per blip: frequency ramps from 0.85x up to the target (a quick siren-like rise), a fast
+  // attack/decay gain envelope (low peak gain 0.05 — several sensors alarming together must not be jarring,
+  // "a combi of sirens" not a wall of noise). OFF by default (_audioOn) — every other HBA additive surface's
+  // zero-impact-off convention; the mute button's click is also the required user-gesture to start/resume ctx.
+  function playSiren(sensorKey, freq) {
+    if (!_audioOn) return;
+    var ctx = ensureAudioCtx(); if (!ctx) return;
+    var tone = SENSOR_TONE[sensorKey] || { wave: 'sine', blips: 1 };
+    var blipMs = 150, gapMs = 70;
+    for (var i = 0; i < tone.blips; i++) {
+      (function (delay) {
+        var t0 = ctx.currentTime + delay / 1000;
+        var osc = ctx.createOscillator(), gain = ctx.createGain();
+        osc.type = tone.wave;
+        osc.frequency.setValueAtTime(freq * 0.85, t0);
+        osc.frequency.exponentialRampToValueAtTime(Math.max(freq, 40), t0 + blipMs / 1000);
+        gain.gain.setValueAtTime(0.0001, t0);
+        gain.gain.exponentialRampToValueAtTime(0.05, t0 + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.0001, t0 + blipMs / 1000);
+        osc.connect(gain); gain.connect(ctx.destination);
+        osc.start(t0); osc.stop(t0 + blipMs / 1000 + 0.02);
+      })(i * (blipMs + gapMs));
     }
   }
 
@@ -156,14 +202,28 @@
     pane.id = 'hba-iot-pane';
     var head = el('div', 'display:flex;justify-content:space-between;align-items:center;background:#102a43;color:#fff;padding:10px 12px;border-radius:10px 10px 0 0;');
     head.appendChild(el('div', 'font-size:14px;font-weight:600;', 'Assets / IoT · ' + asset.asset + ' (mockup)'));
+    // §2026-07-05c — mute/unmute toggle, OFF by default (opt-in, zero-impact — same discipline as every other
+    // HBA additive surface). The click IS the required user-gesture to create/resume the AudioContext.
+    var mute = el('button', 'background:none;border:none;color:#fff;font-size:16px;cursor:pointer;line-height:1;margin-right:8px;',
+      _audioOn ? '🔊' : '🔇');
+    mute.title = 'Toggle per-sensor alarm tones';
+    mute.addEventListener('click', function () {
+      _audioOn = !_audioOn;
+      mute.textContent = _audioOn ? '🔊' : '🔇';
+      if (_audioOn) { var ctx = ensureAudioCtx(); if (ctx && ctx.state === 'suspended') ctx.resume(); }
+      console.log('§HBA_IOT_AUDIO ' + (_audioOn ? 'on' : 'off'));
+    });
+    head.appendChild(mute);
     var x = el('button', 'background:none;border:none;color:#fff;font-size:18px;cursor:pointer;line-height:1;', '×');
     x.title = 'Close'; x.addEventListener('click', function () { toggle(A); });
     head.appendChild(x); pane.appendChild(head);
     pane.appendChild(el('div', 'background:#fff8e1;color:#a06b00;font-weight:700;letter-spacing:1px;font-size:11px;padding:4px 12px;',
       seriesSpec._watermark + ' · CONTOH — TIDAK RASMI · synthetic mockup, not a real sensor read'));
 
-    // (a) 6 animated horizontal sensor bars, driven by the last-24h series (loops hour 0..23) — stub seam for
-    // later real physical sensor wiring, see file header.
+    // (a) animated horizontal sensor bars (one per SENSORS entry), driven by the last-24h series (loops hour
+    // 0..23) — stub seam for later real physical sensor wiring, see file header. Each tick ALSO plays a
+    // per-sensor siren tone (§2026-07-05c) when the mute toggle is on — min/max (the SAME bounds the bar's
+    // headroom uses) feed iot.js's toneFreqFor, so "danger" pitch and bar position agree.
     var barsWrap = el('div', 'padding:10px 12px;');
     var bars = [];
     deps_.IoT.SENSORS.forEach(function (s) {
@@ -172,8 +232,9 @@
       var min = Math.min.apply(null, vals), max = Math.max.apply(null, vals);
       if (max === min) max = min + 1;   // guard degenerate flat series
       var headroom = (max - min) * 0.15;
-      var b = renderSensorBar(A, deps_.IoT.DEVICES[s.key], s, min - headroom, max + headroom);
-      barsWrap.appendChild(b.row); bars.push({ b: b, sensor: s, pts: pts });
+      var lo = min - headroom, hi = max + headroom;
+      var b = renderSensorBar(A, deps_.IoT.DEVICES[s.key], s, lo, hi);
+      barsWrap.appendChild(b.row); bars.push({ b: b, sensor: s, pts: pts, lo: lo, hi: hi });
     });
     pane.appendChild(barsWrap);
 
@@ -236,7 +297,11 @@
     if (typeof setInterval === 'function') {
       _barTimer = setInterval(function () {
         hourIdx = (hourIdx + 1) % 24;
-        bars.forEach(function (r) { r.b.tick(r.pts[hourIdx]); });
+        bars.forEach(function (r) {
+          var pt = r.pts[hourIdx];
+          r.b.tick(pt);
+          if (_audioOn) playSiren(r.sensor.key, deps_.IoT.toneFreqFor(pt.v, r.lo, r.hi));
+        });
       }, 900);
     }
     // paint every CCTV tile once immediately (rAF alone can be throttled/parked in some hosts, e.g. a

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -491,7 +491,12 @@
     return null;
   }
 
-  function flyToZone(A, guid) {
+  // opts.dist (§2026-07-05c, user: "zooms to the device, not too near — surrounding") — the establishing-shot
+  // distance from the target centroid; default 8 (unchanged, every pre-existing caller). IoT's device zoom
+  // passes a larger value so the surrounding context (the room/plant/entrance the device sits in) stays visible
+  // — a "wow, here's the room this thing lives in" shot, not a nose-to-the-mesh close-up.
+  function flyToZone(A, guid, opts) {
+    opts = opts || {};
     if (!A || !A.guidMap || !ready()) { console.log('§HBA_FLY no-op guid=' + guid + ' (no engine/guidMap)'); return { flew: false, reason: 'no-engine' }; }
     var want = HBA().B.zoneMeshGuids(guid, A.guidMap, A._hbaRoomMembers || null);
     if (!want.length) { console.log('§HBA_FLY no-op guid=' + guid + ' (no rendered members)'); return { flew: false, reason: 'no-members' }; }
@@ -519,7 +524,7 @@
     pts.forEach(function (p) { cx += p.x; cy += p.y; cz += p.z; });
     var n = pts.length, center = { x: cx / n, y: cy / n, z: cz / n };
     if (A.camera && A.controls && typeof THREE !== 'undefined' && typeof requestAnimationFrame === 'function') {
-      var c3 = new THREE.Vector3(center.x, center.y, center.z), dist = 8;
+      var c3 = new THREE.Vector3(center.x, center.y, center.z), dist = opts.dist || 8;
       var end = c3.clone().add(new THREE.Vector3(0.5, 0.5, 0.7).normalize().multiplyScalar(dist));
       var start = A.camera.position.clone(), t = 0;
       (function anim() {


### PR DESCRIPTION
## Summary
- New 7th sensor, **Motion (PIR)**, bound to a real HHS entrance door — reuses the existing deterministic sine generator (daytime-peak pattern reads as a plausible real motion-level curve, no special-casing) and auto-flows through the Product/UOM/billing persistence shipped in #652.
- **Per-sensor siren tones**: each 24h bar tick now plays a short Web Audio tone when enabled. Pitch rises the closer the reading sits to its own observed range ceiling (`toneFreqFor` — pure, deterministic, never a fabricated "danger threshold"). Each sensor gets a distinct waveform + blip-count combination so the **sound alone** identifies which sensor is alarming. OFF by default (opt-in, zero-impact) — one mute/unmute button in the pane header, whose click also satisfies the browser's user-gesture requirement to start the AudioContext.
- **Wider device zoom**: `flyToZone(A, guid, opts)` gains an optional `opts.dist` (default 8, unchanged for every pre-existing caller). The IoT pane's device zoom now requests distance 18 so clicking a sensor/camera shows the surrounding room/plant/entrance context, not a nose-to-mesh close-up.

Resolves the open §P10c design questions via user dialogue this session (live-tick reuse of the existing bar animation, simple-tone-with-rising-pitch mapping, mute-default-off).

## Test plan
- [x] `witness_p10b.js` extended 36→44 (movement catalog present, `toneFreqFor` pure-function pitch mapping, zoom-dist opts capture, audio off-by-default, audio-on-after-mute-click with the expected total blip count across all 7 sensors and ≥3 distinct waveforms)
- [x] Fixed a stale hardcoded "12 products / 6 lines" self-witness in `scripts/seed_hba_erp.js` to derive counts from `DEVICE_PRODUCTS`/`iotBilling.lines` instead — can't silently desync again when the sensor catalog grows
- [x] Full 41-file HBA node witness suite: zero regression
- [x] `scripts/seed_hba_erp.js` re-run: PASS, then a true idempotent no-op on the 2nd run
- [x] Live CDP smoke against `demo/fm_panel.html` in real headless Chrome: mute button starts 🔇, toggles to 🔊 on click with `§HBA_IOT_AUDIO on` logged, movement bar's own title/fly-target resolve to its own real guid, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)