### PR TITLE
feat(hba): IoT per-sensor icons + camerasNearDevice connector

### DIFF
--- a/hr_bim_asset/iot.js
+++ b/hr_bim_asset/iot.js
@@ -68,6 +68,18 @@ var CAMERAS = [
   { bim_guid: '1Jil894uX328zr$s_sQLvj', element: 'Corridor door', storey: 'Level 3' }
 ];
 
+// §2026-07-05d (user: "ready utils that talk or connects between them") — a TRIVIAL connector: every DEVICES/
+// CAMERAS entry already carries a real `storey`, so "which camera(s) cover this sensor's floor" is a plain
+// filter over data already present — no new geometry/distance work, no invented "coverage radius". Devs can
+// call `camerasNearDevice(key)` to go from an alarming sensor straight to the camera(s) that can see its floor.
+function camerasOnStorey(storey) {
+  return CAMERAS.filter(function (c) { return c.storey === storey; });
+}
+function camerasNearDevice(deviceKey) {
+  var d = DEVICES[deviceKey];
+  return d ? camerasOnStorey(d.storey) : [];
+}
+
 // MYR 301 / USD 100 / conversion type 114 — the REAL rows scripts/seed_fin_currency.js already seeded
 // (verified erp/ad_seed.db, 2026-07-05); never a second invented rate.
 var MYR_CURRENCY_ID = 301, USD_CURRENCY_ID = 100;
@@ -76,22 +88,26 @@ function usdRate(erpQuery) {
   return hit ? Number(hit.r) : null;
 }
 
-// 6 sensors, one mockup monitoring point per bound asset. uom_name/uom_symbol seed a NEW C_UOM row (a genuine
-// native dictionary gap — °C/bar/dB/µg/m³/W/m²/kWh don't exist in this repo's ad_full.db c_uom set; same
-// on-demand-dictionary-row precedent as ad_tenancy.js's toWarehouseRow/SUBSCRIPTION_TYPES).
+// 7 sensors, one mockup monitoring point per bound asset. uom_name/uom_symbol seed a NEW C_UOM row (a genuine
+// native dictionary gap — °C/bar/dB/µg/m³/W/m²/kWh/% don't exist in this repo's ad_full.db c_uom set; same
+// on-demand-dictionary-row precedent as ad_tenancy.js's toWarehouseRow/SUBSCRIPTION_TYPES). `icon` (§2026-07-05d,
+// user: "using their icons") is a plain-text emoji glyph — purely a UI/docs label, never read by any compile
+// function; reused verbatim by viewer/hba_iot.js's bar labels AND docs/HRBIMAssetGuide.md so the running app and
+// the guide show the SAME identifier per sensor.
 var SENSORS = [
-  { key: 'temp',       label: 'Temperature',    uom_name: 'Celsius',      uom_symbol: '°C',  baseline: 24,  amplitude: 3,   rate: 0 },
-  { key: 'pressure',   label: 'Boiler Pressure', uom_name: 'Bar',         uom_symbol: 'bar',       baseline: 2.4, amplitude: 0.3, rate: 0 },
-  { key: 'sound',      label: 'Sound Level',     uom_name: 'Decibel',     uom_symbol: 'dB',        baseline: 42,  amplitude: 8,   rate: 0 },
-  { key: 'dust',       label: 'Dust (PM2.5)',    uom_name: 'Microgram/m3', uom_symbol: 'µg/m³', baseline: 18, amplitude: 10, rate: 0.05 },
-  { key: 'solar',      label: 'Solar Output',    uom_name: 'Watt/m2',     uom_symbol: 'W/m²', baseline: 300, amplitude: 300, rate: 0 },
-  { key: 'electrical', label: 'Electrical Load', uom_name: 'Kilowatt-hour', uom_symbol: 'kWh',     baseline: 12,  amplitude: 5,   rate: 0.02 },
+  { key: 'temp',       label: 'Temperature',    icon: '🌡️', uom_name: 'Celsius',      uom_symbol: '°C',  baseline: 24,  amplitude: 3,   rate: 0 },
+  { key: 'pressure',   label: 'Boiler Pressure', icon: '🔧', uom_name: 'Bar',         uom_symbol: 'bar',       baseline: 2.4, amplitude: 0.3, rate: 0 },
+  { key: 'sound',      label: 'Sound Level',     icon: '🔊', uom_name: 'Decibel',     uom_symbol: 'dB',        baseline: 42,  amplitude: 8,   rate: 0 },
+  { key: 'dust',       label: 'Dust (PM2.5)',    icon: '🌫️', uom_name: 'Microgram/m3', uom_symbol: 'µg/m³', baseline: 18, amplitude: 10, rate: 0.05 },
+  { key: 'solar',      label: 'Solar Output',    icon: '☀️', uom_name: 'Watt/m2',     uom_symbol: 'W/m²', baseline: 300, amplitude: 300, rate: 0 },
+  { key: 'electrical', label: 'Electrical Load', icon: '⚡', uom_name: 'Kilowatt-hour', uom_symbol: 'kWh',     baseline: 12,  amplitude: 5,   rate: 0.02 },
   // §2026-07-05c (user: "there can also be a sensor for movement") — a 7th, PIR/motion-style security sensor.
   // Reuses the SAME deterministic sine generator, no special-casing: baseline+amplitude puts it near-zero at
   // night and peaking at midday — a genuinely plausible real motion-level pattern for an occupied office
   // building, not a fabricated waveform shape.
-  { key: 'movement',   label: 'Motion (PIR)',    uom_name: 'Motion Level', uom_symbol: '%',  baseline: 15,  amplitude: 15,  rate: 0 }
+  { key: 'movement',   label: 'Motion (PIR)',    icon: '🚶', uom_name: 'Motion Level', uom_symbol: '%',  baseline: 15,  amplitude: 15,  rate: 0 }
 ];
+var CAMERA_ICON = '📷';
 
 // deterministic 24-hourly-point curve: baseline + amplitude*sin (a plausible daily shape, trough near
 // midnight/peak near midday) + a tiny FIXED per-hour offset table — NOT Math.random/Date.now, so the same
@@ -199,9 +215,10 @@ function toneFreqFor(value, min, max) {
   return Math.round(TONE_BASE_HZ + norm * (TONE_DANGER_HZ - TONE_BASE_HZ));
 }
 
-var IoT = { SENSORS: SENSORS, DEVICES: DEVICES, CAMERAS: CAMERAS, MYR_CURRENCY_ID: MYR_CURRENCY_ID,
-  USD_CURRENCY_ID: USD_CURRENCY_ID, TONE_BASE_HZ: TONE_BASE_HZ, TONE_DANGER_HZ: TONE_DANGER_HZ,
-  seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow, toneFreqFor: toneFreqFor,
+var IoT = { SENSORS: SENSORS, DEVICES: DEVICES, CAMERAS: CAMERAS, CAMERA_ICON: CAMERA_ICON,
+  MYR_CURRENCY_ID: MYR_CURRENCY_ID, USD_CURRENCY_ID: USD_CURRENCY_ID, TONE_BASE_HZ: TONE_BASE_HZ,
+  TONE_DANGER_HZ: TONE_DANGER_HZ, seriesFor: seriesFor, demoSeries: demoSeries, toUomRow: toUomRow,
+  toneFreqFor: toneFreqFor, camerasOnStorey: camerasOnStorey, camerasNearDevice: camerasNearDevice,
   toOrderRow: toOrderRow, toProductRow: toProductRow, toOrderLineRow: toOrderLineRow, usdRate: usdRate,
   billingLines: billingLines };
 if (typeof module === 'object' && module.exports) module.exports = IoT;

--- a/hr_bim_asset/tests/witness_p10b.js
+++ b/hr_bim_asset/tests/witness_p10b.js
@@ -185,6 +185,29 @@ var expectBlips = self.HbaIot.SENSORS.reduce(function (n, s) { return n + (({ te
 ok('IP16-audio-on-plays', oscLog.length === expectBlips, 'once muted->on, a tick plays the expected total blip count across all 7 sensors (1+1+1+1+2+2+3=' + expectBlips + ') — got ' + oscLog.length);
 ok('IP17-distinct-waveforms', new Set(oscLog.map(function (o) { return o.type; })).size >= 3, 'multiple DISTINCT waveforms are used across sensors — "identify by the sound right away", not one uniform beep — got types ' + JSON.stringify(oscLog.map(function (o) { return o.type; })));
 
+// §2026-07-05d — icons: every bar label leads with its sensor's icon (the SAME glyph the docs guide reuses).
+ok('IP18-bar-icons', bars_ok(), 'every bar row label leads with the sensor\'s icon (7 sensors, incl. 🚶 movement)');
+function bars_ok() {
+  return barsWrap3.children.length === 7 && Array.prototype.every.call(barsWrap3.children, function (row, i) {
+    var icon = self.HbaIot.SENSORS[i].icon;
+    return row.children[0].textContent.indexOf(icon) === 0;
+  });
+}
+
+// §2026-07-05d — "ready utils that talk or connects between them": clicking 'electrical' (bound to the real
+// Level-1 MDP-1 panel) must ring the CCTV tile(s) ALSO on Level 1 (iot.js camerasNearDevice), and leave the
+// Level-2/3 tiles untouched — the connector is storey-scoped, not "ring everything".
+ok('I20-cameras-near-device', self.HbaIot.camerasNearDevice('electrical').length === 2
+  && self.HbaIot.camerasNearDevice('electrical').every(function (c) { return c.storey === 'Level 1'; })
+  && self.HbaIot.camerasNearDevice('pressure').length === 0,
+  'camerasNearDevice: electrical(Level 1) -> 2 real Level-1 cameras; pressure(Roof Level) -> 0 (honest, no camera up there) — a plain storey filter, no invented coverage radius');
+
+var cctvGrid3 = pane3.children[4];
+barsWrap3.children[5]._on_click();   // electrical bar (index 5) — Level 1, same floor as CAMERAS[0]/[1]
+ok('IP19-connect-flash', cctvGrid3.children[0].style.boxShadow.indexOf('ff8800') >= 0 && cctvGrid3.children[1].style.boxShadow.indexOf('ff8800') >= 0
+  && !cctvGrid3.children[2].style.boxShadow && !cctvGrid3.children[4].style.boxShadow,
+  'clicking a Level-1 sensor rings ONLY the Level-1 CCTV tiles (0,1), leaving Level-2/3 tiles (2,4) untouched — the two stubs genuinely "talk" via a real shared fact (storey), not just a coincidence');
+
 IotPane.toggle(A);   // unmount
 
 // ============================================================================================================

--- a/viewer/hba_iot.js
+++ b/viewer/hba_iot.js
@@ -165,18 +165,19 @@
   // one animated horizontal bar row per sensor — width + the running value at the bar's leading edge both
   // move together (matching CSS transition) as tick(pt) is fed new points. min/max are DATA-DERIVED (the
   // sensor's own baseline±amplitude from hr_bim_asset/iot.js), never an invented threshold. Clicking the row
-  // flies the camera to THIS sensor's OWN real bound location (locateAndHighlight) — "locate the device outright".
-  function renderSensorBar(A, device, sensor, min, max) {
+  // fires `onClick` (mount() wires it to locateAndHighlight + the same-storey camera flash, see
+  // iot.js camerasNearDevice) — "locate the device outright, and show me what can see it".
+  function renderSensorBar(sensor, min, max, title, onClick) {
     var color = SENSOR_COLORS[sensor.key] || '#1976d2';
     var row = el('div', 'padding:4px 0;cursor:pointer;');
-    row.title = 'Locate ' + sensor.label + ' (' + (device ? device.element : sensor.label) + ') in the model';
-    row.appendChild(el('div', 'font-size:10px;color:#627d98;text-transform:uppercase;margin-bottom:2px;', sensor.label));
+    row.title = title;
+    row.appendChild(el('div', 'font-size:10px;color:#627d98;text-transform:uppercase;margin-bottom:2px;', (sensor.icon || '') + ' ' + sensor.label));
     var track = el('div', 'position:relative;height:16px;background:#eef2f6;border-radius:3px;');
     var fill = el('div', 'position:absolute;left:0;top:0;bottom:0;width:2%;background:' + color + ';border-radius:3px;transition:width 0.7s ease;');
     var val = el('span', 'position:absolute;top:50%;left:2%;transform:translateY(-50%);font-size:10px;font-weight:600;color:#102a43;white-space:nowrap;transition:left 0.7s ease;padding-left:6px;');
     track.appendChild(fill); track.appendChild(val);
     row.appendChild(track);
-    row.addEventListener('click', function () { if (device) locateAndHighlight(A, device.bim_guid); });
+    row.addEventListener('click', function () { if (onClick) onClick(); });
     var tick = function (pt) {
       var pct = Math.max(2, Math.min(100, ((pt.v - min) / (max - min)) * 100));
       fill.style.width = pct + '%';
@@ -224,6 +225,25 @@
     // 0..23) — stub seam for later real physical sensor wiring, see file header. Each tick ALSO plays a
     // per-sensor siren tone (§2026-07-05c) when the mute toggle is on — min/max (the SAME bounds the bar's
     // headroom uses) feed iot.js's toneFreqFor, so "danger" pitch and bar position agree.
+    //
+    // (b) CCTV mockup grid tiles are built FIRST (not yet appended to the DOM) so the bars below can wire a
+    // same-storey highlight — §2026-07-05d (user: "ready utils that talk or connects between them"): clicking
+    // a sensor ALSO briefly rings the CCTV tile(s) sharing its floor (iot.js camerasNearDevice — a plain
+    // storey-match filter over data already present, no new geometry/distance math).
+    var cctvTileEls = [];   // [{el, cam}] — index i matches iot.js CAMERAS[i]
+    var CAM_RING = '0 0 0 3px #ff8800aa';
+    function flashCamerasForDevice(deviceKey) {
+      var cams = deps_.IoT.camerasNearDevice(deviceKey);
+      if (!cams.length) return;
+      var guids = {}; cams.forEach(function (c) { guids[c.bim_guid] = true; });
+      cctvTileEls.forEach(function (t) {
+        if (!t.cam || !guids[t.cam.bim_guid]) return;
+        t.el.style.boxShadow = CAM_RING;
+        setTimeout(function () { t.el.style.boxShadow = ''; }, ORANGE_HOLD_MS);
+      });
+      console.log('§HBA_IOT_CONNECT device=' + deviceKey + ' camerasOnFloor=' + cams.length);
+    }
+
     var barsWrap = el('div', 'padding:10px 12px;');
     var bars = [];
     deps_.IoT.SENSORS.forEach(function (s) {
@@ -233,25 +253,32 @@
       if (max === min) max = min + 1;   // guard degenerate flat series
       var headroom = (max - min) * 0.15;
       var lo = min - headroom, hi = max + headroom;
-      var b = renderSensorBar(A, deps_.IoT.DEVICES[s.key], s, lo, hi);
+      var device = deps_.IoT.DEVICES[s.key];
+      var title = 'Locate ' + s.label + ' (' + (device ? device.element : s.label) + ') in the model';
+      var b = renderSensorBar(s, lo, hi, title, function () {
+        if (!device) return;
+        locateAndHighlight(A, device.bim_guid);
+        flashCamerasForDevice(s.key);
+      });
       barsWrap.appendChild(b.row); bars.push({ b: b, sensor: s, pts: pts, lo: lo, hi: hi });
     });
     pane.appendChild(barsWrap);
 
-    // (b) CCTV mockup grid — 6 tiles, real dimmed still + canvas scanline animation, explicitly labeled MOCKUP.
+    // CCTV mockup grid — 6 tiles, real dimmed still + canvas scanline animation, explicitly labeled MOCKUP.
     // §2026-07-05 (§BUILD ORDER point 3) — each tile is now ALSO clickable: locates+orange-highlights its OWN
     // real bound camera position (iot.js CAMERAS[i], a real entrance/circulation door — see file header), not
     // just a static image crop.
-    pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:6px 12px 0;', 'CCTV (mockup — no real feed, click to locate)'));
+    pane.appendChild(el('div', 'font-size:11px;color:#627d98;text-transform:uppercase;padding:6px 12px 0;', deps_.IoT.CAMERA_ICON + ' CCTV (mockup — no real feed, click to locate)'));
     var cctvWrap = el('div', 'display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;padding:6px 12px;');
     var cctvTicks = [];
     for (var i = 1; i <= 6; i++) {
       var cv2 = document.createElement('canvas'); cv2.width = 120; cv2.height = 68;
-      cv2.style.cssText = 'display:block;width:100%;border-radius:4px;background:#0a1622;cursor:pointer;';
+      cv2.style.cssText = 'display:block;width:100%;border-radius:4px;background:#0a1622;cursor:pointer;transition:box-shadow 0.3s ease;';
       var cam = deps_.IoT.CAMERAS[i - 1];
-      if (cam) { cv2.title = 'Locate CCTV Camera ' + i + ' (' + cam.element + ', ' + cam.storey + ') in the model'; }
+      if (cam) { cv2.title = deps_.IoT.CAMERA_ICON + ' Locate CCTV Camera ' + i + ' (' + cam.element + ', ' + cam.storey + ') in the model'; }
       cv2.addEventListener('click', (function (camGuid) { return function () { if (camGuid) locateAndHighlight(A, camGuid); }; })(cam && cam.bim_guid));
       cctvWrap.appendChild(cv2);
+      cctvTileEls.push({ el: cv2, cam: cam });
       var tick = renderCctvTile(cv2, i); if (tick) cctvTicks.push(tick);
     }
     pane.appendChild(cctvWrap);
@@ -264,7 +291,7 @@
     var tbl = el('table', 'width:100%;border-collapse:collapse;font-size:12px;margin:4px 12px 10px;width:calc(100% - 24px);');
     billing.lines.forEach(function (ln) {
       var tr = el('tr', 'border-top:1px solid #eee;');
-      tr.appendChild(el('td', 'padding:4px 2px;', ln.sensor.label));
+      tr.appendChild(el('td', 'padding:4px 2px;', (ln.sensor.icon || '') + ' ' + ln.sensor.label));
       tr.appendChild(el('td', 'padding:4px 2px;text-align:right;color:#627d98;', 'qty ' + ln.row.qtyordered + ' ' + ln.sensor.uom_symbol));
       // §2026-07-05 (§BUILD ORDER point 4) — RM is the real c_currency_id (301) the row itself is billed in;
       // USD is the SAME already-seeded C_Conversion_Rate (never a second invented rate) — shown only when


### PR DESCRIPTION
## Summary
- Each of the 7 `SENSORS` gains an `icon` field (emoji) — reused in the bar labels, the billing table, and (separately, in bim-compiler) the docs guide, so the app and the guide show the same identifier per sensor.
- New `IoT.camerasOnStorey(storey)` / `IoT.camerasNearDevice(deviceKey)` — a trivial connector reusing the `storey` field every `DEVICES`/`CAMERAS` entry already carries (no new geometry/distance work, no invented coverage radius).
- `viewer/hba_iot.js` wires it live: clicking a sensor bar now also briefly rings the CCTV tile(s) on the *same floor* — a real, storey-scoped link between the two previously-independent stubs.
- `renderSensorBar`'s signature simplified (title/onClick passed in from `mount()`) to support the new wiring cleanly, without changing its DOM/witness-visible shape.

## Test plan
- [x] `witness_p10b.js` extended 44→47 (bar labels lead with the sensor's icon; `camerasNearDevice` is storey-scoped — a Level-1 sensor gets 2 real Level-1 cameras, a Roof-Level sensor honestly gets 0; clicking a Level-1 sensor rings only the Level-1 CCTV tiles, leaves Level-2/3 tiles untouched)
- [x] Full 41-file HBA node witness suite: zero regression
- [x] Live CDP smoke in real headless Chrome: icons render on every bar, clicking Electrical Load (Level 1) visibly rings CAM 1/CAM 2 while CAM 3-6 stay unringed (screenshots captured for the companion docs update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)