### PR TITLE
feat(hba): class-tint perimeter outline + mobile card-stack spec

### DIFF
--- a/hr_bim_asset/tests/witness_class_outline.js
+++ b/hr_bim_asset/tests/witness_class_outline.js
@@ -1,0 +1,116 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — W-HBA-CLASS-OUTLINE witness (§2026-07-05e, user: "make the spaces tint shine thru? at
+//   least their outer total perimeter"). The existing class-tint (setTint) only recolors a room's rendered
+//   CONTAINED members (small real fixtures, per §REAL-BIND) — from a wide shot that reads as barely visible.
+//   This proves `bindStoreysFromModel` extracts each room's REAL IfcSpace footprint (center_x/y/z, size_x/y/z
+//   — genuine bounds from `spatial_structure`, verified live against buildings/HHS_Office_Federated_extracted.db
+//   2026-07-05: RM_Level_1_1..4 all carry real, non-overlapping footprints ~1.2-1.8m apart) into
+//   A._hbaRoomFootprint, and that toggling the 'class' lens draws a wireframe outline box per LINKED room at
+//   its real footprint, coloured to match its tint — honestly skipping any room with no real size extracted
+//   (never a placeholder box), and cleaning up on toggle-off/switch (zero residue, same discipline as every
+//   other HBA overlay). Run: node hr_bim_asset/tests/witness_class_outline.js
+'use strict';
+var checks = [];
+function ok(tag, cond, msg) { checks.push(!!cond); console.log('§HBA-CLASS-OUTLINE ' + (cond ? 'PASS' : 'FAIL') + ' ' + tag + ' — ' + msg); }
+
+// ---- minimal THREE shim — just enough surface for buildMeshPort's Color use + the new outline geometry -----
+function Color() { this._h = 0xffffff; }
+Color.prototype.setHex = function (v) { this._h = v >>> 0; return this; };
+Color.prototype.getHex = function () { return this._h; };
+function BoxGeometry(x, y, z) { this.args = [x, y, z]; this.disposed = false; }
+BoxGeometry.prototype.dispose = function () { this.disposed = true; };
+function EdgesGeometry(geo) { this.src = geo; this.disposed = false; }
+EdgesGeometry.prototype.dispose = function () { this.disposed = true; };
+function LineBasicMaterial(opts) { this.color = opts.color; this.linewidth = opts.linewidth; this.disposed = false; }
+LineBasicMaterial.prototype.dispose = function () { this.disposed = true; };
+function LineSegments(geo, mat) { this.geometry = geo; this.material = mat; this.position = { x: 0, y: 0, z: 0, set: function (x, y, z) { this.x = x; this.y = y; this.z = z; } }; }
+function Group() { this.name = ''; this.children = []; }
+Group.prototype.add = function (o) { this.children.push(o); };
+global.THREE = { Color: Color, BoxGeometry: BoxGeometry, EdgesGeometry: EdgesGeometry, LineBasicMaterial: LineBasicMaterial, LineSegments: LineSegments, Group: Group };
+
+global.self = global;
+self.HbaWatermark = require('../watermark');
+self.HbaModels = require('../models');
+self.HbaBinding = require('../binding');
+self.HbaOverlay = require('../overlay');
+self.HbaLens = require('../lens');
+self.HbaTimeline = require('../timeline');
+var HBALens = require('../../viewer/hba_lens');
+
+// ---- stub scene (records add/remove calls; no real THREE.Scene needed) --------------------------------------
+function makeScene() {
+  var kids = [];
+  return { children: kids, add: function (o) { kids.push(o); }, remove: function (o) { var i = kids.indexOf(o); if (i >= 0) kids.splice(i, 1); } };
+}
+
+// ---- stub A.dbQuery — spatial_structure rows for 2 REAL rooms (real footprint) + 1 room with NO size (honest
+// gap, e.g. a degenerate/partial IFC export) — mirrors the exact live column order this session verified.
+var ROWS = [
+  // guid, storey-name, predefined_type, center_x, center_y, center_z, size_x, size_y, size_z
+  ['RM_A', 'Level 1', 'INTERNAL', -0.118, -9.72, 1.686, 1.6, 4.6, 3.158],
+  ['RM_B', 'Level 1', 'INTERNAL', 2.782, -9.72, 1.686, 1.8, 4.6, 3.158],
+  ['RM_NOSIZE', 'Level 1', 'INTERNAL', 99, 99, 99, null, null, null]   // honest gap — no real size extracted
+];
+function makeAPP() {
+  var A = {
+    guidMap: { '1': 'MEMBER_A', '2': 'MEMBER_B' },     // rooms themselves are NOT rendered (§REAL-BIND)
+    status: { textContent: '' }, _dirty: 0, markDirty: function () { this._dirty++; },
+    collectMeshes: function () { return []; },
+    scene: makeScene(),
+    dbQuery: function (sql) {
+      if (/FROM spatial_structure/.test(sql)) return ROWS;
+      return [];
+    }
+  };
+  return A;
+}
+
+var A = makeAPP();
+HBALens.bindStoreysFromModel(A);
+ok('F1-footprint-extracted', A._hbaRoomFootprint && A._hbaRoomFootprint.RM_A && A._hbaRoomFootprint.RM_B,
+  'bindStoreysFromModel populates A._hbaRoomFootprint for rooms with a real spatial_structure size — got ' + JSON.stringify(Object.keys(A._hbaRoomFootprint || {})));
+ok('F2-footprint-values', A._hbaRoomFootprint.RM_A.cx === -0.118 && A._hbaRoomFootprint.RM_A.sx === 1.6 && A._hbaRoomFootprint.RM_A.sy === 4.6,
+  'the footprint carries the REAL extracted center/size verbatim (RM_A: cx=-0.118, sx=1.6, sy=4.6) — got ' + JSON.stringify(A._hbaRoomFootprint.RM_A));
+ok('F3-honest-no-size', !A._hbaRoomFootprint.RM_NOSIZE,
+  'a spatial_structure row with NO real size (null) gets NO footprint entry — honest gap, never a placeholder box');
+
+// ---- toggle 'class' on: models.js Tenancy/Strata already declare unit_class for real guids — but this witness
+// uses its OWN room guids (RM_A/RM_B), so seed a MINIMAL classRows-compatible path via A._hbaSpaceClass (the
+// REAL model predefined_type path classRows/classOf reads FIRST, per its own §CLASS facet priority).
+A._hbaSpaceClass = { RM_A: 'office', RM_B: 'commercial' };
+// classRows() only walks Tenancy/Strata records for zones — inject 2 synthetic-but-real-shaped Tenancy leases
+// bound to RM_A/RM_B so classRows() has something to resolve+classify (classOf() prefers A._hbaSpaceClass anyway).
+var Models = self.HbaModels;
+Models.MODELS = Models.MODELS || {};
+var origRecords = Models.records;
+Models.records = function (name) {
+  if (name === 'Tenancy') return [{ unit_guid: 'RM_A', unit_class: 'office' }, { unit_guid: 'RM_B', unit_class: 'commercial' }];
+  if (name === 'Strata') return [];
+  return origRecords(name);
+};
+A._hbaRoomMembers = { RM_A: ['MEMBER_A'], RM_B: ['MEMBER_B'] };   // §REAL-BIND — rendered contained members
+
+var onResult = HBALens.toggle(A, 'class');
+ok('F4-class-on', onResult === true && A.scene.children.length === 1,
+  'toggling class ON adds EXACTLY ONE outline group to the scene — got ' + A.scene.children.length);
+var group = A.scene.children[0];
+ok('F5-outline-per-linked-room', group.name === 'hba-class-outlines' && group.children.length === 2,
+  'the outline group carries one LineSegments per LINKED+footprinted room (RM_A, RM_B) — got ' + (group && group.children.length));
+var lineA = group.children.filter(function (l) { return l.position.x === -0.118; })[0];
+ok('F6-outline-position-real', !!lineA && lineA.position.y === -9.72 && lineA.position.z === 1.686,
+  'each outline is positioned at its room\'s REAL extracted center — RM_A at (-0.118,-9.72,1.686)');
+ok('F7-outline-color-matches-tint', group.children.every(function (l) { return typeof l.material.color === 'number' && l.material.color > 0; }),
+  'each outline\'s colour is the SAME class colour as its tint, hex-converted (never a separate invented palette) — got ' + JSON.stringify(group.children.map(function (l) { return l.material.color.toString(16); })));
+
+// ---- toggle OFF: zero residue — the outline group is removed from the scene, its geometry/material disposed.
+var geosBefore = group.children.map(function (l) { return l.geometry; });
+HBALens.toggle(A, 'class');
+ok('F8-outline-cleared', A.scene.children.length === 0, 'toggling class OFF removes the outline group from the scene — zero residue');
+ok('F9-geometry-disposed', geosBefore.every(function (g) { return g.disposed; }), 'every outline\'s EdgesGeometry is disposed on clear (no leaked THREE resources)');
+
+Models.records = origRecords;   // restore
+
+var pass = checks.filter(Boolean).length, fail = checks.length - pass;
+console.log('\n§HBA-CLASS-OUTLINE ' + pass + '/' + checks.length + ' PASS' + (fail ? (' — ' + fail + ' FAIL') : ''));
+process.exit(fail ? 1 : 0);

--- a/prompts/RESUME_HBA_MOBILE_CARD_STACK.md
+++ b/prompts/RESUME_HBA_MOBILE_CARD_STACK.md
@@ -1,0 +1,255 @@
+# ⚠ DO NOT REMOVE — SPEC ONLY (no implementation until this doc is reviewed)
+# Mobile Card-Stack for HBA Panes — Design Spec
+
+**Scope:** Mobile-only presentation of the HBA "Human-Asset" panes as a swipeable, scrollable
+navigation card-stack. Desktop behaviour is **unchanged** (fixed overlay + drag-by-header).
+**Read the log after every run.** This is a spec; no code lands until it is approved.
+
+**Author's note on the non-invent rule:** this feature touches NO data/geometry/DB — it is a pure
+DOM/interaction layer over panes that already render. So "extract, don't invent" is satisfied
+trivially. The only judgment calls here are UX; §7 flags which I made confidently vs. which are
+genuinely open for the user.
+
+---
+
+## 0. Ground truth (what exists today — verified in `/tmp/wt-iot-persist/viewer`)
+
+- **6 pane modules**, all identical shape: `hba_dashboard.js` (`HBADashPane`), `hba_payslip.js`
+  (`HBAPayslipPane`), `hba_leave.js` (`HBALeavePane`), `hba_tenancy.js` (`HBATenancyPane`),
+  `hba_bom.js` (`HBABomPane`), `hba_iot.js` (`HBAIotPane`). Public API each: `mount(A)` /
+  `toggle(A)` / `detect(A)` / `isActive()`.
+- **Every pane's `mount()` ends with the SAME two lines** (verified line-for-line):
+  ```js
+  (document.body || document.documentElement).appendChild(pane);
+  if (G.HbaDraggable) G.HbaDraggable.enable(pane, head);   // §P10b — drag by the header
+  ```
+  (dashboard 96-97, payslip 96-97, tenancy 94-95, bom 91-92, iot 317-318, leave 116-117).
+- Each `pane` is `el('div', 'position:fixed;top:54px;right:12px;width:340-420px;max-height:82-86vh;
+  overflow:auto;z-index:10050;...')` with id `hba-<name>-pane`, a `head` element (title + × close),
+  content below. `× ` calls `toggle(A)` → `unmount()` → `_pane.parentNode.removeChild(_pane)`.
+- `hba_iot.js` runs **live timers** (`_barTimer` setInterval, `_cctvTimer` rAF) that `unmount()` stops.
+  → the host must NOT re-create/clone pane DOM (would orphan timers + event listeners). It must
+  **re-parent the SAME live node**.
+- **Orchestration:** `hba_lens.js` `openFamilyDrawer(A)` renders a 9-row drawer (`FAMILY` array);
+  `activateLens(A, entry)` routes pane rows to `paneFor(entry).toggle(A)`; lens rows to
+  `toggle(A, mode)`. Panes stack at the SAME `top:54px;right:12px` anchor → the problem.
+- **Mobile detection ALREADY EXISTS:** `config.js:7` → `window._isMobile = ('ontouchstart' in window
+  || navigator.maxTouchPoints > 0);` — read by pill_builder/scene/clash_matrix/streaming/etc. **Reuse
+  it. Do not invent a parallel system.**
+- **A proven gesture engine ALREADY EXISTS:** `swipe.js` → `window.SwipeStack` (LEFT/RIGHT=prev/next,
+  UP=drill, DOWN=back; pointer-capture; `THRESHOLD_PX=80`, `SNAP_MS=200`, translate+fade+snap-back).
+  **BUT** it renders cards from `{id, html}` **HTML strings via `innerHTML`** — it cannot host the
+  panes' live DOM (event handlers + iot timers die). → **Reuse its gesture MATH & constants by
+  reference; do NOT use it as the container.**
+- `hba_draggable.js` `HbaDraggable.enable(pane, head)` is desktop-only in spirit; it is a no-op-safe
+  DOM utility. It stays exactly as is; the host simply won't call it on mobile.
+- Script load order (`viewer.html` 921-932): `hba_lens` → `hba_draggable` → panes. New file loads
+  **between draggable (923) and the panes (927)**.
+
+---
+
+## 1. Interaction model
+
+One full-screen host layer, `#hba-card-stack` (`position:fixed;inset:0;z-index:10060` — one above the
+panes' `10050`), created lazily the first time a pane is presented on mobile. Two visual states.
+
+### 1a. Peek-deck state (home)
+- The stack's default view: opened panes shown as a **vertical scrollable deck of card-headers** —
+  each card is a strip showing the pane's title (reused from its `head`) + a 1-line summary sliver,
+  ~64px tall, stacked with a slight overlap/shadow so it reads as a physical deck.
+- Container is `overflow-y:auto` → **scrolls when more cards than fit the screen** (requirement 2).
+- The pane's full content is present but height-clamped/hidden in this state (see §2 CSS).
+- **Tap a card → push it full-screen** (requirement 3).
+- The family drawer (launcher) opens as a bottom-sheet in front of the deck (see §2d).
+
+### 1b. Full-screen state
+- The tapped card expands to fill the viewport; **its content (the pane's own DOM) fills the screen**
+  — the host neutralises the pane's fixed 340-420px width via scoped CSS so it becomes 100% × 100%.
+- A slim top bar shows the pane title, a **‹ back** affordance (minimise to deck), and the pane's own
+  × (close/remove) stays where the pane drew it.
+
+### 1c. Navigation semantics — push/pop (requirement 4)
+Distinguish **minimise** (keep the pane open, return to deck) from **close** (remove the pane):
+
+| Action | Meaning | Effect |
+|---|---|---|
+| Tap a deck card | push | focus = that card, go full-screen (`_nav.push(i)`) |
+| Swipe **down** / tap **‹ back** | minimise (pop) | focus → previous `_nav` entry (usually the deck); **pane stays open** |
+| Pane's **×** button | close (remove) | pane `unmount()`s (its own code), host drops it from `_cards`, pops nav → deck |
+| Swipe **left / right** in full-screen | switch card | focus moves to adjacent open card **without returning to the deck** (carousel) |
+
+This is the push/pop the user asked for: open several panes → they pile into the deck → tap one to go
+full-screen → close (×) or back (swipe-down) → land on the deck → pick a *different* card "from where
+they left off." Left/right lets you flip between full-screen cards directly (the user's "swipe to
+switch between full-screen cards without going back to the stack first").
+
+**Gesture thresholds (adopted from `swipe.js`, confident default):** horizontal/vertical delta >
+`min(80px, cardWidth*0.3)`; snap-back at `200ms ease`; pointer-capture on `pointerdown`. Swipe-to-
+**dismiss/remove** (a hard down-fling that deletes a card) is **deliberately excluded from phase 1** to
+avoid accidental data loss — down = minimise only. Whether to add fling-to-remove, and its threshold,
+is an open question (§7).
+
+---
+
+## 2. Where it hooks into the architecture
+
+**New shared module `viewer/hba_mobile_stack.js` exposing `G.HbaPaneHost`.** It is the *single* place
+the desktop/mobile split lives. Panes stay dumb; `hba_lens.js` is untouched.
+
+### 2a. The one pane change (× 6 panes) — a 2-line → 1-line swap
+Replace each pane's mount-tail:
+```js
+(document.body || document.documentElement).appendChild(pane);
+if (G.HbaDraggable) G.HbaDraggable.enable(pane, head);
+```
+with:
+```js
+(G.HbaPaneHost ? G.HbaPaneHost.present
+  : function (p, h) { (document.body || document.documentElement).appendChild(p); if (G.HbaDraggable) G.HbaDraggable.enable(p, h); }
+)(pane, head, A);
+```
+The inline fallback preserves today's behaviour for node witnesses / if the module fails to load.
+**No other pane internals change.** `unmount()` stays byte-identical — its `removeChild(_pane)` works
+whether the parent is `document.body` (desktop) or a card slot (mobile).
+
+### 2b. `HbaPaneHost.present(pane, head, A)` — the branch
+```
+present(pane, head, A):
+  if (!window._isMobile):
+      document.body.appendChild(pane)
+      HbaDraggable.enable(pane, head)          // EXACT current desktop path
+      return
+  // mobile:
+  ensureStackEl()                              // lazy-build #hba-card-stack + scoped <style>
+  slot = el('div','', ) with class 'hba-card'  // wrapper the host owns
+  slot.appendChild(pane)                        // re-parent the LIVE node (timers/handlers intact)
+  _cards.push({ id: pane.id, pane, head, slot, title: head.textContent })
+  observeRemoval(slot, pane)                    // MutationObserver → auto-drop on pane's own removeChild
+  focus(_cards.length - 1)                       // newest pane opens full-screen (confident default, §7)
+  render()
+```
+
+### 2c. Teardown with ZERO extra pane changes
+The host attaches a `MutationObserver(childList)` to each `slot`. When the pane's own `unmount()` runs
+`removeChild(_pane)`, the slot goes empty → the observer drops that entry from `_cards`, pops `_nav`,
+and `render()`s the deck. So pane `unmount()` needs **no** host-awareness. (Alternative if an observer
+is unwanted: expose `HbaPaneHost.release(paneEl)` and add one line to each `unmount()` — but the
+observer keeps the per-pane diff to the single §2a line. Prefer the observer.)
+
+### 2d. The launcher drawer on mobile (small, optional-in-phase-4)
+`hba_lens.js openFamilyDrawer` is a *launcher* and can stay functionally as is (a pane row tap calls
+`paneFor(entry).toggle(A)` → `mount()` → `HbaPaneHost.present` → card pushed full-screen). For polish,
+the host exposes `HbaPaneHost.styleDrawer(drawerEl)` that `openFamilyDrawer` MAY call to reflow the
+drawer as a bottom-sheet on mobile. This is the ONLY optional `hba_lens.js` touch and is deferred to
+phase 4; if skipped, the existing right-anchored drawer still works as the launcher.
+
+**Functions that change:** the 6 panes' single mount-tail line; new `hba_mobile_stack.js`; one
+`<script>` tag in `viewer.html` (+ any other host html that loads the panes). **Functions that do NOT
+change:** every pane's `mount` body / `unmount` / `toggle` / `detect`; all of `hba_lens.js` (drawer
+polish optional); `hba_draggable.js`; `swipe.js`; `config.js`.
+
+---
+
+## 3. Desktop / mobile split
+
+- Single source: **`window._isMobile`** (config.js:7). `HbaPaneHost.present` branches on it and nothing
+  else. Desktop → identical to today (append to body + `HbaDraggable.enable`), so desktop is provably
+  a no-op change.
+- config.js's `_isMobile` (`ontouchstart || maxTouchPoints>0`) is the correct UI-layout variant. The
+  renderer files use a stricter `maxTouchPoints>0 && screen.width<1024` — **not** reused here (a touch
+  laptop should still get cards; acceptable). Optionally also gate on `window.innerWidth <= 900` if a
+  large touchscreen should keep the desktop overlay — flagged as a minor open call (§7), default = plain
+  `_isMobile`.
+- Detection is read **once per `present()` call** (not cached), so a rotate/resize between opens is
+  honoured without extra listeners.
+
+---
+
+## 4. State (plain JS in `hba_mobile_stack.js` — no framework)
+
+```js
+var _stackEl = null;         // #hba-card-stack host (lazy)
+var _cards   = [];           // [{ id, pane, head, slot, title }] — ORDER = open order (the deck)
+var _focus   = -1;           // index of full-screen card; -1 = peek-deck (home)
+var _nav     = [-1];         // navigation history of _focus values → push/pop
+```
+- **open order** = `_cards` array order (deck top-to-bottom).
+- **which is full-screen** = `_focus` (-1 = none / deck).
+- **push/pop history** = `_nav` (last entry is current focus). `back()` = `_nav.pop()` then focus the
+  new last. `close(i)` = splice `_cards[i]`, rebuild `_nav` to drop `i`, focus `-1`.
+- No per-card scroll/gesture state persists between renders beyond `_startX/_startY/_dragging` (mirrors
+  swipe.js). All derived; nothing stored that a re-render can't rebuild.
+
+---
+
+## 5. Rendering / CSS approach (concrete)
+
+Host injects ONE scoped `<style>` once (in `ensureStackEl`). Panes are re-parented, never restyled
+inline (keeps them uniform + reversible):
+```css
+#hba-card-stack { position:fixed; inset:0; z-index:10060; overflow-y:auto;
+  -webkit-overflow-scrolling:touch; background:#0b1620; display:flex; flex-direction:column; }
+/* neutralise the pane's fixed 340-420px overlay geometry once inside a card */
+#hba-card-stack .hba-card > [id^="hba-"] {
+  position:static !important; top:auto; right:auto; left:auto;
+  width:100% !important; max-width:100% !important; box-shadow:none !important; }
+/* peek strip in deck state — content clamped to the header height */
+#hba-card-stack.deck .hba-card { max-height:64px; overflow:hidden; margin:6px 8px; border-radius:12px;
+  box-shadow:0 4px 14px #0007; }
+/* full-screen focused card fills the viewport, its body scrolls internally */
+#hba-card-stack.fs   .hba-card.focus > [id^="hba-"] { height:100vh; max-height:100vh !important;
+  border-radius:0; overflow:auto; }
+#hba-card-stack.fs   .hba-card:not(.focus) { display:none; }
+```
+- Deck vs full-screen = toggling a class on `#hba-card-stack` (`deck` / `fs`) + `focus` on one card.
+  No layout math in JS beyond gesture translate.
+- `[id^="hba-"]` matches every pane id (`hba-leave-pane`, `hba-iot-pane`, …) → **zero per-pane CSS.**
+- Gesture drag = set `slot.style.transform = translate(dx,dy)` on `pointermove`, snap-back / commit on
+  `pointerup` (copy swipe.js 127-186 math), `touch-action:none;user-select:none` on the focused card.
+
+---
+
+## 6. Phased build order (smallest safe increment first)
+
+- **Phase 0 — this spec.** (done on approval)
+- **Phase 1 — prove the mechanism, ONE pane.** Ship `hba_mobile_stack.js` with `present()` where the
+  **desktop path is byte-identical to today** (regression-proof: desktop untouched). Wire ONLY
+  `hba_leave.js` (simplest, no timers) to call it. Mobile path = single card, straight to full-screen,
+  content fills the viewport, pane's × closes it (MutationObserver teardown). No deck, no gestures yet.
+  Witness: `§HBASTACK present id=hba-leave-pane mobile=true focus=0`; desktop witness proves the append
+  path unchanged.
+- **Phase 2 — the deck + scroll + push/pop.** Peek-deck render for N cards, tap-to-fullscreen, ‹ back /
+  swipe-down = minimise, × = close→deck, scroll when overflowing. Wire a 2nd pane (`hba_payslip.js`) to
+  prove multi-card ordering + nav. Witness `_cards`/`_focus`/`_nav` transitions.
+- **Phase 3 — gestures.** Left/right carousel between full-screen cards; down = minimise. Port swipe.js
+  gesture math + constants (THRESHOLD_PX, SNAP_MS, pointer-capture). Witness gesture→state changes.
+- **Phase 4 — wire the rest.** `hba_dashboard`, `hba_tenancy`, `hba_bom`, `hba_iot` (verify iot timers
+  survive re-parent + still stop on unmount). Optional `openFamilyDrawer` bottom-sheet via
+  `styleDrawer`. Witness all 6 present/close cleanly, zero residue.
+- **Phase 5 — hardening.** Rotate/resize, deep-link fly-to while a card is full-screen, back-button /
+  Esc, audit for the `#b-clear`/grid-clear state-leak class (per MEMORY.md) on `_cards`/`_nav`.
+
+Each phase is independently shippable and leaves desktop untouched.
+
+---
+
+## 7. What I'm NOT deciding (open questions for the user)
+
+UX calls I made **confidently** (mine as design author): reuse `window._isMobile`; reuse swipe.js
+gesture math + 80px/200ms constants rather than SwipeStack-the-container; minimise-vs-close split
+(down=minimise, ×=remove); scoped-CSS re-parent over inline restyle; MutationObserver teardown;
+newest-pane-opens-full-screen on present.
+
+Genuinely **open** (please confirm — not facts I can extract, real product choices):
+1. **Fling-to-remove gesture?** Phase 1 has down=minimise, ×=remove only. Add a hard down-fling (or
+   long-swipe-up) that *deletes* a card, and at what velocity/px threshold? (Default: none — safer.)
+2. **On `present`, focus the new card full-screen, or drop it into the deck?** I defaulted to
+   full-screen (matches "tap opens it"; opening from the drawer implies intent to view). Confirm.
+3. **Large touchscreen (tablet/touch-laptop):** cards, or keep the desktop draggable overlay above some
+   viewport width? Default = plain `_isMobile` (touch ⇒ cards). Add an `innerWidth<=900` gate?
+4. **Drawer form on mobile:** keep the existing right-anchored list as the launcher, or reflow it to a
+   bottom-sheet (phase 4 `styleDrawer`)? Default = keep as-is, polish later.
+5. **Animation timing:** adopting swipe.js `SNAP_MS=200`. Fine, or a specific feel you want?
+
+No data/geometry decisions arise in this feature (pure presentation) — the non-invent rule has nothing
+to bite on here.

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -176,7 +176,8 @@
     try {
       var rows;
       try {
-        rows = A.dbQuery("SELECT s.guid, p.name, s.predefined_type FROM spatial_structure s LEFT JOIN spatial_structure p "
+        rows = A.dbQuery("SELECT s.guid, p.name, s.predefined_type, s.center_x, s.center_y, s.center_z, s.size_x, s.size_y, s.size_z "
+          + "FROM spatial_structure s LEFT JOIN spatial_structure p "
           + "ON s.parent_guid=p.guid AND p.type='IfcBuildingStorey' WHERE s.type='IfcSpace'");
       } catch (eSp) { rows = []; }   // a building with NO spatial_structure (e.g. a warehouse) → §AISLE-ZONES fallback below
       var map = {}; (rows || []).forEach(function (r) { if (r[0] && r[1]) map[r[0]] = r[1]; });
@@ -189,6 +190,20 @@
       var sc = {}; (rows || []).forEach(function (r) { var pt = (r[2] || '').toUpperCase(); if (CLS[pt]) sc[r[0]] = CLS[pt]; });
       A._hbaSpaceClass = sc;
       if (Object.keys(sc).length) console.log('§HBA_CLASS mapped ' + Object.keys(sc).length + ' rooms→use-class from model predefined_type');
+      // §2026-07-05e (user: "make the spaces tint shine thru? at least their outer total perimeter") — a room's
+      // REAL IfcSpace footprint (center_x/y/z, size_x/y/z — genuine extracted bounds, NOT a fabricated shape or
+      // a fragile "nearest real wall" proximity guess, which a same-session check found ambiguous: this
+      // building's rooms sit only 2.4-2.9m apart, closer than several real walls sit to any one room's centre,
+      // so a radius/nearest-wall heuristic would risk bleeding one room's colour onto its neighbour's wall).
+      // Honestly absent (no entry) for any room whose row lacks a real size (never a placeholder box).
+      var fp = {};
+      (rows || []).forEach(function (r) {
+        if (r[0] && r[6] != null && r[7] != null && r[8] != null) {
+          fp[r[0]] = { cx: r[3], cy: r[4], cz: r[5], sx: r[6], sy: r[7], sz: r[8] };
+        }
+      });
+      A._hbaRoomFootprint = fp;
+      if (Object.keys(fp).length) console.log('§HBA_FOOTPRINT bound ' + Object.keys(fp).length + ' rooms→real IfcSpace footprint (center+size)');
       // stash the real rooms + seed a (watermarked, demonstrator) occupancy ledger so the Occupancy lens +
       // Dashboard pane have data on a building that carries rooms. ADDITIVE: sets only A._hba* fields.
       var rooms = Object.keys(map).map(function (g) { return { guid: g, storey: map[g] }; });
@@ -373,11 +388,46 @@
     if (A.markDirty) A.markDirty();
   }
 
+  // §2026-07-05e — real-footprint PERIMETER OUTLINE (user: "make the spaces tint shine thru... their outer
+  // total perimeter"). The existing MeshPort tint (setTint) can only recolor a room's rendered CONTAINED
+  // members (small real fixtures) since an IfcSpace room usually isn't its own mesh — from a wide shot that
+  // reads as barely-visible. This draws an ADDITIONAL wireframe box at the room's own REAL IfcSpace bounds
+  // (A._hbaRoomFootprint, extracted center+size — see bindStoreysFromModel), coloured the SAME as its tint, so
+  // the room's actual footprint is visibly outlined even when its contained members are tiny/hidden. Pure
+  // ADDITIVE THREE geometry (mirrors hba_avatars.js's own-scene-Group precedent) — never touches/replaces any
+  // existing mesh material. Honest no-op per room when no real footprint was extracted (never a placeholder box).
+  var _outlineGroup = null;
+  function _clearOutlines(A) {
+    if (!_outlineGroup) return;
+    if (A && A.scene && A.scene.remove) A.scene.remove(_outlineGroup);
+    _outlineGroup.children.forEach(function (o) { if (o.geometry) o.geometry.dispose(); if (o.material) o.material.dispose(); });
+    _outlineGroup = null;
+  }
+  function _drawOutlines(A, plan) {
+    _clearOutlines(A);
+    if (typeof THREE === 'undefined' || !A || !A.scene || !A._hbaRoomFootprint) return 0;
+    var group = new THREE.Group(); group.name = 'hba-class-outlines';
+    var drawn = 0;
+    (plan.linked || []).forEach(function (guid) {
+      var fp = A._hbaRoomFootprint[guid]; if (!fp) return;               // honest no-op — no real footprint extracted
+      var tint = plan.tints[guid]; if (!tint) return;
+      var geo = new THREE.BoxGeometry(fp.sx, fp.sy, fp.sz);
+      var edges = new THREE.EdgesGeometry(geo);
+      var mat = new THREE.LineBasicMaterial({ color: toHex(tint.color), linewidth: 2 });
+      var lines = new THREE.LineSegments(edges, mat);
+      lines.position.set(fp.cx, fp.cy, fp.cz);
+      group.add(lines); geo.dispose(); drawn++;
+    });
+    if (drawn) { A.scene.add(group); _outlineGroup = group; }
+    return drawn;
+  }
+
   // toggle a lens ON/OFF. ON → drive the WITNESSED engine through the real MeshPort, GATED by A.guidMap so a
   // non-matching guid never tints (honest). OFF (or switching mode) → full restore (zero residue).
   function toggle(A, mode) {
     if (!ready()) { if (A && A.status) A.status.textContent = 'HR overlay not loaded'; return false; }
     if (_port) { _port.restoreAll(); _port = null; }            // clear prior mode first (one mode at a time)
+    _clearOutlines(A);                                          // §2026-07-05e — perimeter outlines ride the SAME one-mode-at-a-time rule
     if (G.HBAAvatars && G.HBAAvatars.isActive()) G.HBAAvatars.unmount(A);   // §AVATAR-LOD — avatars ride the presence lens; clear them with it
     if (_active === mode) { _active = null; console.log('§HBA_LENS off mode=' + mode); if (A.markDirty) A.markDirty(); return false; }
     var h = HBA();
@@ -395,8 +445,10 @@
     // §AVATAR-LOD (P6) — when Presence lights up, stand a little person in each room where a real check-in put
     // one, with an LOD ladder (dot→mini→full) + hover card. Additive; unmounted above when the lens clears.
     if (mode === 'presence' && G.HBAAvatars) { try { G.HBAAvatars.mount(A); } catch (e) { console.warn('§HBA_AVATARS mount skipped: ' + e.message); } }
+    // §2026-07-05e — class tint additionally draws each linked room's REAL footprint outline (see _drawOutlines).
+    var outlined = (mode === 'class') ? _drawOutlines(A, plan) : 0;
     if (A.status) A.status.textContent = 'HR · ' + mode + ' · ' + n + ' unit' + (n === 1 ? '' : 's') + ' lit' + (plan.unlinked.length ? ' (' + plan.unlinked.length + ' un-linked)' : '');
-    console.log('§HBA_LENS on mode=' + mode + ' lit=' + n + ' unlinked=' + plan.unlinked.length + ' linked=[' + plan.linked.join(',') + ']');
+    console.log('§HBA_LENS on mode=' + mode + ' lit=' + n + ' unlinked=' + plan.unlinked.length + ' linked=[' + plan.linked.join(',') + ']' + (mode === 'class' ? ' outlined=' + outlined : ''));
     if (A.markDirty) A.markDirty();
     return true;
   }
@@ -779,7 +831,7 @@
     flyToZone: flyToZone, openPresenceDrawer: openPresenceDrawer, closePresenceDrawer: _closePresenceDrawer,
     erpLink: erpLink, AD_WINDOWS: AD_WINDOWS,
     _regovern: _regovern, _buildingName: _buildingName, _ensureErpGovern: _ensureErpGovern,
-    _consumeFindGuid: _consumeFindGuid };  // §STAGE2 / §2026-07-04c — witness hooks (additive)
+    _consumeFindGuid: _consumeFindGuid, bindStoreysFromModel: bindStoreysFromModel };  // §STAGE2 / §2026-07-04c / §2026-07-05e — witness hooks (additive)
   if (typeof module === 'object' && module.exports) { module.exports = G.HBALens; return; }   // node witness — no DOM gate
 
   // ---- DATA-GATE poll (mirrors viewer/wh_walk.js): flip the pill icons ON only when a lens detects ------


### PR DESCRIPTION
## Summary
- The class-tint lens only recolored a room's rendered *contained members* (small real fixtures) — invisible from a wide shot. Checked a "nearest real wall" proximity fix first and rejected it: this building's rooms sit only 2.4-2.9m apart, closer together than several real walls sit to any single room's centre, so a radius-based guess would bleed one room's colour onto its neighbour's wall.
- Found a cleaner real signal: `spatial_structure` carries a genuine extracted IfcSpace center+size per room. `bindStoreysFromModel` now also extracts this into `A._hbaRoomFootprint`; toggling the 'class' lens draws a real wireframe box per linked room at its own footprint, coloured to match its tint, cleaned up on toggle-off. Honest no-op for any room without a real extracted size.
- A background Opus agent produced a grounded spec for the mobile swipeable-card-stack ask — `prompts/RESUME_HBA_MOBILE_CARD_STACK.md`. Found real existing infra to reuse (`window._isMobile`, a pre-existing `swipe.js`/`SwipeStack` gesture engine) instead of inventing a parallel system. Spec only, no implementation yet.

## Test plan
- [x] New `witness_class_outline.js` 9/9 (footprint extraction, honest gap on missing size, one outline per linked+footprinted room at its real position/colour, zero-residue cleanup + geometry disposal)
- [x] Full 43-file HBA node witness suite: zero regression
- [x] Live CDP smoke against the real HHS building: the outline box actually renders (visible orange wireframe box on the commercial-class room, screenshot captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)