### PR TITLE
test(teams): real dual-session E2E for Teams overlay + fix dead presence-subscribe bug

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -4004,7 +4004,7 @@ window.__ensureDiscWalker = async function () {
     ['Author', 'Sketch a profile, Insert a catalog component (assemble, don\'t draw), Cut an opening, Route an MEP run, Fillet an edge. Every edit is one signed op in the log.'],
     ['History', 'Scrub the bottom timeline to fold the model to any point; Ctrl+Z / Ctrl+⇧Z undo/redo. Geometry is a deterministic fold over the signed op-log.'],
     ['Save / Export', 'Your edits auto-save to the signed op-log (restored on your next visit, per building). Pill ▸ Export offers Native .db (the full-fidelity signed op-log, conventionally saved into IFC/BimDB/ — re-opens via Open ▸ local .db), IFC4, or a BCF 2.1 issue.'],
-    ['Teams', 'Pill ▸ Teams (top-right of the bar) — click to see who else is on this scene. Off by default; first click turns on presence dots + a pane, same as ?teams=1.']
+    ['Teams', 'Pill ▸ Teams (top-right of the bar) — click to see who else is editing THIS MODEL right now: presence dots + a blame/chat pane over the design op-log. Off by default; first click turns it on, same as ?teams=1. This is <i>authoring</i> collaboration (Modeller + ERP chrome) — a different feature from "HBA" (tenancy/IoT/occupancy pills), which is a separate <i>Viewer-only</i> operations overlay for a live building and does not exist in the Modeller.']
   ];
   let panel = null;
   function build() {

--- a/modeller/teams_embed.js
+++ b/modeller/teams_embed.js
@@ -62,7 +62,7 @@
     return 0;
   }
 
-  var _handle = null, _conn = null;
+  var _handle = null, _conn = null, _peerBeats = [], _pane = null, _renderPresence = null;
 
   function init(opts) {
     opts = opts || {};
@@ -74,6 +74,19 @@
       // bind the awareness bus to the suite's shared channel (default 'bim_teams'); presence is distinguished
       // by message kind, so it never collides with the host's other bus traffic. Cross-product meets here.
       _conn = (C && C.goLive) ? C.goLive(global, { channel: opts.channel || 'bim_teams' }) : C;
+      // §E2E-CROSS fix (TEAMS_OVERLAY_LIVE_E2E_TEST.md): the send-side heartbeat existed, but nothing ever
+      // SUBSCRIBED to the bus, so a peer's beat was silently dropped (window.__teamsPeerBeats was read here
+      // but never written anywhere in the codebase — a real dual-session E2E reproduced it: each session only
+      // ever saw its own row). Subscribe ONCE at init and re-render the open pane live on each peer heartbeat.
+      try {
+        if (_conn && _conn.bus && _conn.bus.on) {
+          _conn.bus.on(opts.channel || 'bim_teams', function (msg) {
+            if (!msg || msg.kind !== 'presence') return;
+            _peerBeats.push(msg);
+            if (_pane && _renderPresence) _renderPresence(_pane);
+          });
+        }
+      } catch (e) { log('bus.on err ' + e.message); }
 
       // a self-created floating mount (top-right) — nothing exists until ON, so OFF stays pixel-identical.
       var mount = document.createElement('div'); mount.id = 'teams-embed-mount';
@@ -85,6 +98,23 @@
       var fidOf = opts.docOf || function (row) { return row.getAttribute('data-fid'); };
       var me = opts.user || global.TeamsEmbedUser || 'me';
       var loc = opts.location || { discipline: 'ARC' };
+
+      function renderPresence(pane) {
+        var old = pane.querySelector('.teams-presence-list'); if (old) old.parentNode.removeChild(old);
+        var wrap = document.createElement('div'); wrap.className = 'teams-presence-list';
+        var beats = [PR.makePresence({ user: me, product: 'bim', location: loc, ts: _nowTs(opts) })].concat(_peerBeats);
+        var folded = PR.foldPresence(beats, { now: _nowTs(opts), activeMs: opts.activeMs != null ? opts.activeMs : 60000 });
+        PR.presenceDots(folded).forEach(function (p) {
+          var r = document.createElement('div'); r.style.cssText = 'display:flex;gap:8px;align-items:center;padding:5px 0;border-bottom:1px dashed #2c303a';
+          r.innerHTML = '<span style="display:inline-grid;place-items:center;width:18px;height:18px;border-radius:50%;font-size:9px;font-weight:700;color:#fff;background:' + p.color + (p.faded ? ';opacity:.4' : '') + '">' + p.initials + '</span>' +
+            '<span style="font-weight:600">' + p.user + '</span><span style="font-size:11px;font-weight:700;color:#7f8aa0">' + p.product.toUpperCase() + '</span>' +
+            '<span style="font-size:12px;color:#7f8aa0">' + p.locText + '</span>';
+          wrap.appendChild(r);
+        });
+        pane.appendChild(wrap);
+        log('presence re-rendered (' + folded.length + ' peer' + (folded.length === 1 ? '' : 's') + ')');
+      }
+      _renderPresence = renderPresence;
 
       function onMount(pane) {
         var ops = _hostOps(opts);
@@ -105,26 +135,20 @@
             row.appendChild(wrap);
           });
         }
-        // 2) presence — emit my BIM heartbeat on the shared bus + fold what's present (self + any peers).
-        var beats = [PR.makePresence({ user: me, product: 'bim', location: loc, ts: _nowTs(opts) })];
-        try { if (_conn && _conn.bus) { _conn.bus.send(opts.channel || 'bim_teams', beats[0]); } } catch (e) {}
-        (global.__teamsPeerBeats || []).forEach(function (h) { if (h && h.kind === 'presence') beats.push(h); });
-        var folded = PR.foldPresence(beats, { now: _nowTs(opts), activeMs: opts.activeMs != null ? opts.activeMs : 60000 });
+        // 2) presence — emit my BIM heartbeat on the shared bus (peers pick it up via THEIR bus.on
+        //    subscription above); render self + any peer beats already collected via _peerBeats.
+        var mine = PR.makePresence({ user: me, product: 'bim', location: loc, ts: _nowTs(opts) });
+        try { if (_conn && _conn.bus) { _conn.bus.send(opts.channel || 'bim_teams', mine); } } catch (e) {}
 
         var h = document.createElement('h3'); h.textContent = 'Teams · presence';
         h.style.cssText = 'font:600 11px system-ui;letter-spacing:.06em;text-transform:uppercase;color:#7f8aa0;margin:0 0 8px';
         pane.appendChild(h);
-        PR.presenceDots(folded).forEach(function (p) {
-          var r = document.createElement('div'); r.style.cssText = 'display:flex;gap:8px;align-items:center;padding:5px 0;border-bottom:1px dashed #2c303a';
-          r.innerHTML = '<span style="display:inline-grid;place-items:center;width:18px;height:18px;border-radius:50%;font-size:9px;font-weight:700;color:#fff;background:' + p.color + (p.faded ? ';opacity:.4' : '') + '">' + p.initials + '</span>' +
-            '<span style="font-weight:600">' + p.user + '</span><span style="font-size:11px;font-weight:700;color:#7f8aa0">' + p.product.toUpperCase() + '</span>' +
-            '<span style="font-size:12px;color:#7f8aa0">' + p.locText + '</span>';
-          pane.appendChild(r);
-        });
+        _pane = pane;
+        renderPresence(pane);
         if (!ops.length) { var e0 = document.createElement('div'); e0.style.cssText = 'color:#7f8aa0;font:12px system-ui;margin-top:8px'; e0.textContent = 'No element activity on this scene yet.'; pane.appendChild(e0); }
         log('ON — presence emitted (' + me + '/bim), ' + (ops.length ? 'dots on rows' : 'no host ops'));
       }
-      function onUnmount() { Array.prototype.forEach.call(document.querySelectorAll('.teams-row-dots'), function (n) { n.remove(); }); }
+      function onUnmount() { _pane = null; Array.prototype.forEach.call(document.querySelectorAll('.teams-row-dots'), function (n) { n.remove(); }); }
 
       _handle = TP.mountTeamsPill(mount, { label: 'Teams overlay', paneHost: document.body, onMount: onMount, onUnmount: onUnmount });
       global.__teamsEmbedReady = true;

--- a/teams/tests/witness_e2e_dual_presence_modeller.js
+++ b/teams/tests/witness_e2e_dual_presence_modeller.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ⚠ DO NOT REMOVE — prompts/TEAMS_OVERLAY_LIVE_E2E_TEST.md. A REAL two-user E2E over the LIVE Modeller
+//   embed (modeller/teams_embed.js). Two scenarios, both driven through the ACTUAL production affordances
+//   (#b-teams → #teams-pill clicks, no page.evaluate() into engine internals):
+//
+//   SCENARIO 1 (§SEP-*) — TWO SEPARATE Playwright BrowserContexts, i.e. two real, independent browser
+//   profiles/devices (project doctrine: real user path, not one context faking two). THE FINDING: this
+//   correctly, REPRODUCIBLY shows each session sees only ITS OWN presence row, never the peer's —
+//   because BroadcastChannel is scoped per storage partition and NEVER crosses separate contexts, even on
+//   the same http origin (proven directly against the raw platform API in §BC-CONTROL, no app code
+//   involved). This is a platform fact, not a bug in teams_embed.js: no amount of patching the Modeller
+//   embed can make two genuinely separate real users see each other's Tier-1 heartbeat this way. Real
+//   cross-device presence would need to ride the durable Tier-2 transport (teams/transport.js pushOps/
+//   pullOps, already witnessed at the engine level via W-ERP-SYNC/W-REMOTE) — which is NOT wired into the
+//   live embed today.
+//
+//   SCENARIO 2 (§SAME-*) — TWO TABS in the SAME BrowserContext (one real user, two windows — the one case
+//   BroadcastChannel actually covers). Proves a REAL bug found+fixed along the way: modeller/teams_embed.js
+//   sent its own heartbeat but never SUBSCRIBED to the bus — `window.__teamsPeerBeats` was read every time
+//   a pane opened but NEVER WRITTEN anywhere in the codebase (confirmed by grep before this fix), so even
+//   same-profile peers were invisible to each other. Fixed: init() now calls `_conn.bus.on(...)` once and
+//   live re-renders the open pane on every peer heartbeat. This scenario is the genuine regression test for
+//   that fix.
+//   Run: node teams/tests/witness_e2e_dual_presence_modeller.js 2>&1 | tee teams/logs/e2e_dual_presence.log
+'use strict';
+var path = require('path'), http = require('http'), fs = require('fs');
+var ROOT = path.join(__dirname, '..', '..');   // repo root — modeller/ and teams/ are siblings here
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream' };
+function reqPw() { try { return require('playwright'); } catch (e) { return require('/home/red1/bim-ootb/tests/node_modules/playwright'); } }
+
+var fails = 0;
+function verdict(ok, label, detail) { if (!ok) fails++; console.log('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+// presence rows are the DIRECT children of .teams-presence-list (one per identity). Select leaf rows only
+// (`> div`) — a descendant `div span` count would double-count via the wrapper div itself.
+async function paneUsers(page) {
+  return page.$$eval('#teams-pane .teams-presence-list > div', function (rows) {
+    return rows.map(function (r) { return r.textContent.trim(); });
+  });
+}
+async function turnOnTeams(page, who, log) {
+  await page.waitForSelector('#b-teams', { timeout: 8000 });
+  await page.click('#b-teams');                                    // real click #1 — mounts the (closed) pill
+  await page.waitForSelector('#teams-pill', { timeout: 8000 });
+  var pressed = await page.getAttribute('#teams-pill', 'aria-pressed');
+  if (pressed !== 'true') await page.click('#teams-pill');         // real click #2 — opens the pane (onMount)
+  await page.waitForSelector('#teams-pane', { timeout: 8000 });
+  log('§E2E-MOUNT ' + who + ' pane mounted');
+}
+function log(m) { console.log('   ' + m); }
+
+(async function () {
+  var server = http.createServer(function (req, res) {
+    var p = decodeURIComponent(req.url.split('?')[0]);
+    var fp = path.join(ROOT, p);
+    if (!fp.startsWith(ROOT) || !fs.existsSync(fp) || fs.statSync(fp).isDirectory()) { res.writeHead(404); res.end('nf'); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(fp)] || 'application/octet-stream' });
+    fs.createReadStream(fp).pipe(res);
+  });
+  await new Promise(function (r) { server.listen(0, r); });
+  var port = server.address().port;
+  var url = 'http://localhost:' + port + '/modeller/modeller.html';
+  var browser = await reqPw().chromium.launch();
+
+  try {
+    // ── raw-platform control: does BroadcastChannel cross two separate contexts at all, with NO app
+    //    code involved? Settles whether any later failure is a teams_embed.js bug or a platform fact. ──
+    console.log('\n═══ §BC-CONTROL — raw BroadcastChannel across two separate contexts (no app code) ═══\n');
+    var cc1 = await browser.newContext(), cc2 = await browser.newContext();
+    var cp1 = await cc1.newPage(), cp2 = await cc2.newPage();
+    await cp1.goto(url, { waitUntil: 'load' }); await cp2.goto(url, { waitUntil: 'load' });
+    await cp1.evaluate(function () { window.__log = []; window.__ch = new BroadcastChannel('e2e_control'); window.__ch.onmessage = function (e) { window.__log.push(e.data); }; });
+    await cp2.evaluate(function () { window.__log = []; window.__ch = new BroadcastChannel('e2e_control'); window.__ch.onmessage = function (e) { window.__log.push(e.data); }; });
+    await cp1.evaluate(function () { window.__ch.postMessage({ from: 'ctx1' }); });
+    await cp2.waitForTimeout(300);
+    var gotOn2 = await cp2.evaluate(function () { return window.__log; });
+    verdict(gotOn2.length === 0, '§BC-CONTROL separate contexts do NOT share BroadcastChannel (platform fact)', 'ctx2 received=' + JSON.stringify(gotOn2));
+    await cc1.close(); await cc2.close();
+
+    // ── SCENARIO 1: two SEPARATE contexts through the real production UI ──
+    console.log('\n═══ §SEP — two SEPARATE Playwright contexts (real independent users), live Modeller Teams embed ═══\n');
+    var ctxA = await browser.newContext(), ctxB = await browser.newContext();
+    var pageA = await ctxA.newPage(), pageB = await ctxB.newPage();
+    var errA = [], errB = [];
+    pageA.on('pageerror', function (e) { errA.push(e.message); });
+    pageB.on('pageerror', function (e) { errB.push(e.message); });
+    await pageA.goto(url, { waitUntil: 'load' }); await pageB.goto(url, { waitUntil: 'load' });
+    await pageA.evaluate(function () { window.TeamsEmbedUser = 'alice'; });
+    await pageB.evaluate(function () { window.TeamsEmbedUser = 'bob'; });
+    await turnOnTeams(pageA, 'sessionA(alice)', log);
+    await turnOnTeams(pageB, 'sessionB(bob)', log);
+    await pageA.waitForTimeout(400); await pageB.waitForTimeout(400);
+    var sepA = await paneUsers(pageA), sepB = await paneUsers(pageB);
+    console.log('   §E2E-EMIT sessionA rows: ' + JSON.stringify(sepA));
+    console.log('   §E2E-EMIT sessionB rows: ' + JSON.stringify(sepB));
+    verdict(sepA.some(function (t) { return /alice/.test(t); }), '§SEP-SELF sessionA sees its own (alice) row', 'rows=' + JSON.stringify(sepA));
+    verdict(sepB.some(function (t) { return /bob/.test(t); }), '§SEP-SELF sessionB sees its own (bob) row', 'rows=' + JSON.stringify(sepB));
+    // EXPECTED (not a bug): separate contexts never see the peer — matches §BC-CONTROL. Documented, not chased.
+    verdict(!sepA.some(function (t) { return /bob/.test(t); }) && !sepB.some(function (t) { return /alice/.test(t); }),
+      '§SEP-NO-CROSS confirms: two genuinely separate sessions do NOT see each other (matches §BC-CONTROL, not fixable at this layer)',
+      'A=' + JSON.stringify(sepA) + ' B=' + JSON.stringify(sepB));
+    verdict(errA.length === 0 && errB.length === 0, '§SEP-NOERR 0 page errors both sessions', 'A=' + JSON.stringify(errA) + ' B=' + JSON.stringify(errB));
+    await ctxA.close(); await ctxB.close();
+
+    // ── SCENARIO 2: SAME context, two tabs (one real user, two windows) — the regression test for the fix ──
+    console.log('\n═══ §SAME — two tabs, ONE context (the case BroadcastChannel actually covers) ═══\n');
+    var ctxS = await browser.newContext();
+    var pageC = await ctxS.newPage(), pageD = await ctxS.newPage();
+    var errC = [], errD = [];
+    pageC.on('pageerror', function (e) { errC.push(e.message); });
+    pageD.on('pageerror', function (e) { errD.push(e.message); });
+    await pageC.goto(url, { waitUntil: 'load' }); await pageD.goto(url, { waitUntil: 'load' });
+    await pageC.evaluate(function () { window.TeamsEmbedUser = 'carol'; });
+    await pageD.evaluate(function () { window.TeamsEmbedUser = 'dave'; });
+    await turnOnTeams(pageC, 'tabC(carol)', log);
+    await turnOnTeams(pageD, 'tabD(dave)', log);
+    await pageC.waitForTimeout(400); await pageD.waitForTimeout(400);
+    var sameC = await paneUsers(pageC), sameD = await paneUsers(pageD);
+    console.log('   §E2E-EMIT tabC rows: ' + JSON.stringify(sameC));
+    console.log('   §E2E-EMIT tabD rows: ' + JSON.stringify(sameD));
+    verdict(sameC.some(function (t) { return /carol/.test(t); }), '§SAME-SELF tabC sees its own (carol) row', 'rows=' + JSON.stringify(sameC));
+    verdict(sameD.some(function (t) { return /dave/.test(t); }), '§SAME-SELF tabD sees its own (dave) row', 'rows=' + JSON.stringify(sameD));
+    // tabC (opened AFTER tabD) sees tabD immediately — the fix delivers a heartbeat sent after tabC subscribed.
+    verdict(sameC.some(function (t) { return /dave/.test(t); }), '§SAME-CROSS tabC (carol, later joiner) sees peer dave\'s row LIVE (the fix)', 'rows=' + JSON.stringify(sameC));
+    // NAMED LIMITATION (not silently patched): tabD subscribed BEFORE carol's one-shot heartbeat existed —
+    // there is no periodic re-beat and no "who's here" query, so a peer present BEFORE you subscribed stays
+    // invisible until they re-announce (e.g. close+reopen their pane). Proven here: dave does NOT see carol
+    // yet (order-dependent gap) — until carol re-announces, after which dave (already subscribed) DOES catch it.
+    verdict(!sameD.some(function (t) { return /carol/.test(t); }), '§SAME-GAP (named, not fixed) tabD does NOT yet see the earlier-joined carol — no periodic heartbeat/replay exists', 'rows=' + JSON.stringify(sameD));
+    // tabC re-announces (close+reopen — a real click cycle) → a NEW carol heartbeat fires AFTER dave's
+    // subscription was already live, so dave (already listening) picks it up: proves the gap is closeable
+    // by re-announcing, not a dead subscription.
+    await pageC.click('#teams-pill'); await pageC.click('#teams-pill');
+    await pageC.waitForSelector('#teams-pane'); await pageD.waitForTimeout(300);
+    var sameD2 = await paneUsers(pageD);
+    console.log('   §E2E-EMIT tabD rows after carol re-announces: ' + JSON.stringify(sameD2));
+    verdict(sameD2.some(function (t) { return /carol/.test(t); }), '§SAME-CATCHUP tabD sees carol once she re-announces (subscription IS live, just no auto-replay)', 'rows=' + JSON.stringify(sameD2));
+    verdict(errC.length === 0 && errD.length === 0, '§SAME-NOERR 0 page errors both tabs', 'C=' + JSON.stringify(errC) + ' D=' + JSON.stringify(errD));
+    await ctxS.close();
+  } finally {
+    await browser.close(); server.close();
+  }
+
+  var n = 11;
+  console.log('\n' + (fails === 0 ? '✅ W-E2E-DUAL-PRESENCE ' + n + '/' + n + ' PASS' : '❌ ' + fails + '/' + n + ' FAIL — see 🔴 lines above') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(function (e) { console.log('🔴 THREW ' + e.message + '\n' + (e.stack || '').split('\n').slice(1, 6).join('\n')); process.exit(1); });


### PR DESCRIPTION
## Summary
Per `bim-compiler/prompts/TEAMS_OVERLAY_LIVE_E2E_TEST.md`.

- **§0 pre-flight**: clarified the Modeller's in-app `#b-guide` "Teams" section to explicitly
  distinguish it from HBA (a separate, Viewer-only overlay that doesn't exist in the Modeller —
  this was the user-confirmed confusing overlap). Reconfirmed in code that the Teams/HBA seam
  split (`feedback_hba_teams_share_hhs_no_collision`) still holds: Teams never touches
  `viewer/panels.js`, panels.js still carries only the one `hbaFM` entry.
- **Real dual-user path traced first**: fork/edit/post-it/bundle/gate/merge has **zero clickable
  UI** anywhere — `teams.html` renders a hardcoded static scenario, all S1-S12 "DONE" witnesses
  call engine functions directly in Node, never through rendered DOM. Scoped the E2E to the one
  piece with real production UI: the live Modeller presence embed (`#b-teams` → `#teams-pill`).
- **New witness** `teams/tests/witness_e2e_dual_presence_modeller.js` drives TWO real Playwright
  `BrowserContext`s through the actual click path and found + fixed a real bug:
  `modeller/teams_embed.js` sent its own presence heartbeat but never subscribed to the bus —
  `window.__teamsPeerBeats` was read on every render but never written anywhere in the codebase,
  so a peer's presence was always invisible. Fixed by wiring `_conn.bus.on()` once at init and
  live re-rendering the open pane on each peer heartbeat.
- Empirically confirmed + documented a **platform fact** (not a bug): `BroadcastChannel` never
  crosses separate `BrowserContext`s, so two genuinely separate real users (two profiles/devices)
  can never see each other's presence this way — only two tabs of the same browser profile.
- Named (not silently patched) a second real gap: a peer who joined **before** your subscription
  stays invisible until they re-announce — no periodic heartbeat or "who's here" replay exists yet.

## Test plan
- [x] `node teams/tests/witness_e2e_dual_presence_modeller.js` → 11/11 PASS
- [x] `node modeller/tests/wire_teams_embed_modeller.js` → 4/4 PASS (existing regression, unaffected)
- [x] `node teams/tests/run_all.js` → 26/26 files, ALL PASS
- [x] `node teams/tests/{ui_consistent,wire_teams_pill,tabs_consistent,find_placement_dom}.js` → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)