### PR TITLE
docs(teams): retire the Viewer Find-panel embed plan (Modeller+ERP only)

### DIFF
--- a/prompts/RESUME_TEAMS_UI_CONSISTENCY.md
+++ b/prompts/RESUME_TEAMS_UI_CONSISTENCY.md
@@ -1,11 +1,23 @@
 <!-- Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com> · SPDX-License-Identifier: MIT -->
 # ⚠ DO NOT REMOVE — RESUME: Teams overlay UI CONSISTENCY (dedicated session)
 
+> ⛔ **RETIRED 2026-07-05 (user decision): Teams does NOT embed in the Viewer.** Everything in §R1 and §R6
+> below about a Viewer Find-panel **Teams facet icon** / **Storey→Rooms WHO-dots** was a design-only plan —
+> it was never wired into `viewer.html` (confirmed by grep: zero `teams_embed.js`/`find_placement.js`
+> references there, and zero open/merged PRs touch it). The user confirmed Teams is only useful embedded in
+> **Modeller + ERP** (presence/collaboration during design + on ERP docs); HBA already owns the Viewer's
+> operate-phase Storey→Rooms Find-panel facet row (Tenancy/IoT), and adding a Teams facet there would be a
+> second, redundant way to comment on the same building on top of the Viewer's existing Share/Issues tools.
+> `teams/overlay/find_placement.js` + its demo fixture/witnesses stay in the repo as a proven-but-unused POC
+> (§P5 "demo before embed" — the demo step happened, the embed step is now cancelled, not "not yet done").
+> Do not resume §R1 (Viewer facet row) or §R6 (Viewer Find-panel placement) below without a fresh user GO.
+
 **Scope:** make every Teams overlay widget / pane / tab consistent in **schema + aesthetics** with the host
-product it embeds into (BIM Viewer/Modeller `viewer/panels.js`; ERP `erp/idempiere.html` iDempiere chrome).
-The Teams overlay must **speak the host's visual language, never impose its own** — that consistency IS the
-universal-optics thesis (one overlay, design→operate). **Read the log after every run** (Log Mandate). Honour
-this preamble until `✅ DONE` or retired. Spec-first: this file is the spec; witness before chrome.
+product it embeds into (**Modeller** `viewer/panels.js` icon/panel factory; **ERP** `erp/idempiere.html`
+iDempiere chrome — see the retirement note above: NOT the Viewer). The Teams overlay must **speak the host's
+visual language, never impose its own** — that consistency IS the universal-optics thesis (one overlay,
+design→operate). **Read the log after every run** (Log Mandate). Honour this preamble until `✅ DONE` or
+retired. Spec-first: this file is the spec; witness before chrome.
 
 > Triggered 2026-07-01 in the Teams design dialogue (user: "ensure the UI widgets/panes/tabs are consistent
 > schema, aesthetics" + "use icons instead of labels in the Find Panel"). The data feed is already done +
@@ -29,7 +41,8 @@ this preamble until `✅ DONE` or retired. Spec-first: this file is the spec; wi
   1-3d #f9a825 / 3-7d #fb8c00 / >7d #c62828`.
 
 ## 1. The consistency requirements (the spec)
-- **R1 — Icon, not label — for the WHOLE facet axis.** The entire Find-panel facet row is icon-driven, not just
+- **R1 (⛔ RETIRED 2026-07-05 — Viewer Find-panel facet icon, see banner above; kept verbatim for history,
+  do not build against it) — Icon, not label — for the WHOLE facet axis.** The entire Find-panel facet row is icon-driven, not just
   the Teams lens: **Storey | Disc | Material | Tenancy | IoT | Teams** are ALL Lucide glyphs from the ONE
   (⚠ **Phase is NO LONGER a Find-Panel facet** — see §1a: it was a pre-Modeller Time-Machine relic; the Modeller
   now owns the 4D Phase/5D dimension natively. Drop `Phase`/`clock` from the Viewer facet row.)
@@ -55,10 +68,12 @@ this preamble until `✅ DONE` or retired. Spec-first: this file is the spec; wi
 - **R5 — Identity vs State colour MUST be distinguishable.** The signer-hued identity dots (`dot_layer` `colorOf`)
   must NOT collide with HR's state palette (R0) — reserve a hue family or use a ring/badge so "who" never reads as
   "state." When Teams shows STATE, reuse HR's exact palette.
-- **R6 — Find-panel placement (OPERATE-phase pivot — see §1a).** WHO-dots append to the SAME Storey→Rooms result
-  rows, AFTER the state chip, anchored by room guid (`docOf = row => row.guid`); storey-level cluster `+N` matches
-  HR's density-dot grammar. The DESIGN-phase counterpart pivots Role×Project→Element on the Modeller Outliner (same
-  `dotLayerModel`, `anchorOf = element/task`). Both grouped by Role; smart-search (`erp_search.js`) is the entry.
+- **R6 (⛔ RETIRED 2026-07-05 — Viewer Find-panel placement, see banner above; kept verbatim for history, do
+  not build against it) — Find-panel placement (OPERATE-phase pivot — see §1a).** WHO-dots append to the SAME
+  Storey→Rooms result rows, AFTER the state chip, anchored by room guid (`docOf = row => row.guid`); storey-level
+  cluster `+N` matches HR's density-dot grammar. The DESIGN-phase counterpart (Role×Project→Element on the
+  Modeller Outliner, `dotLayerModel`/`anchorOf = element/task`) is NOT retired — that half lives on Modeller,
+  which stays in scope.
 
 ## 1a. SETTLED ARCHITECTURE — the People dimension (resolved 2026-07-01, after a drift check)
 > ⚠ **ANTI-DRIFT (root cause, do not repeat):** the 2026-07-01 drift came from anchoring Teams on
@@ -149,7 +164,11 @@ The overlay now SPEAKS THE HOST LANGUAGE when a host factory is injected:
 Storey/Disc/Material/Tenancy/IoT) belong to the **HR/viewer Find-Panel icon-ification** (§2), which already owns
 `viewer/panels.js`. Add them there, to the ONE registry — do NOT fork from the Teams lane.
 
-## ✅ R6 DONE — Find-panel placement: ONE Role×Spine matrix, two renderings (2026-07-01)
+## ✅ R6 DONE (POC only — the OPERATE half is ⛔ RETIRED 2026-07-05, see banner) — Find-panel placement: ONE Role×Spine matrix, two renderings (2026-07-01)
+> "DONE" below means the standalone engine + `find_rows.html` fixture, never `viewer.html` (confirmed: zero
+> references to `find_placement.js` in any Viewer file, any commit, any PR). The DESIGN/Modeller-Outliner
+> rendering stays in scope; the OPERATE/Viewer-Find-panel rendering does not proceed without a fresh user GO.
+
 **W-FIND-PLACEMENT 8/8** (node engine) + **W-FIND-PLACEMENT-DOM 4/4** (chromium render). New module
 `teams/overlay/find_placement.js` (REUSES dot_layer — colorOf · dotLayerModel · clusterByAnchor, no fork):
 - **`placementModel(ops, spine, opts)`** folds the op-log onto a spine; the SAME engine renders both pivots,

--- a/teams/ROADMAP.md
+++ b/teams/ROADMAP.md
@@ -8,7 +8,8 @@
 > phase-shaped partition Discipline⇄Role · spine Project⇄Zone · author/consume split · THREE timelines ·
 > context-free-git Blue-dot · smart-search entry · Dashboard-graph feed). ⚠ START FROM THE MODELLER/PROJECT SPINE
 > (anti-drift). Coordinate icon-not-label with the HR lane. Live data feed already DONE: `teams/erp/teams_embed_ops.js`,
-> W-EMBED-OPS 7/7.
+> W-EMBED-OPS 7/7. **⛔ 2026-07-05: the Viewer Find-panel facet-icon/Storey→Rooms half of that plan is RETIRED —
+> Teams embeds in Modeller + ERP only (user decision). See the retirement banner at the top of that file.**
 > **Phases A–F (S1–S12) ✅ ALL DONE & witnessed.** §S10 (W-S10 16/16) · §S11 (W-XPRESENCE 7/7) · §S12
 > (W-S12 13/13); the gated production embed is CODE-LANDED + in-app verified (W-EMBED-WIRE 4/4). Phase F is DRAINED.
 > Run the §G gate first (`node teams/tests/run_all.js` = **22 green** + `wire_teams_pill.js` 4/4 + `erp/tests/
@@ -93,7 +94,7 @@ Impact: none.
 **S8 · ERP sync over GH/OCI — ✅ DONE (W-ERP-SYNC 7/7; transport verifier now injectable, default unchanged; live GH/OCI smoke deferred to S9 deploy).** point `teams/transport.js` `pushOps/pullOps` at the ERP `kernel_ops` log (one branch
 per role/`branch_id`); CAS shared masters (BPartner/Product/acctschema). Witness **W-ERP-SYNC** (remote peer pulls an
 ERP branch, verifies, replays to the **same projectionHash**). Live smoke on GH+OCI like `teams/demo/`. Impact: none (transport).
-**S9 · Pill + embed + deploy — ✅ DONE (W-TEAM-WIRE 4/4 chromium; standalone page deployed live GH-raw + OCI; Team-OFF pixel-identical proven). Phase E COMPLETE. NOTE: the line-edit into PRODUCTION kanban_host.js is the gated follow-up (off-by-default launcher proven standalone first, per §P5) — not landed in the live app this slice.** a **distinct Teams pill** (2-person icon) in `kanban_host`/ERP chrome via
+**S9 · Pill + embed + deploy — ✅ DONE (W-TEAM-WIRE 4/4 chromium; standalone page deployed live GH-raw + OCI; Team-OFF pixel-identical proven). Phase E COMPLETE. UPDATE (2026-07-05): the "not landed in the live app" note below was stale — the `erp/idempiere.html` line-edit landed in the SAME PR #593 (`erp/teams_embed.js` + `<script src="teams_embed.js">` in idempiere.html, W-EMBED-WIRE 4/4) and is live in production ERP chrome today; confirmed via git log, not just re-cited from this doc. Same for `modeller/teams_embed.js` (Modeller-side, `#b-teams` pill).** a **distinct Teams pill** (2-person icon) in `kanban_host`/ERP chrome via
 `pill_builder.js` (NOT `redpill`/`ZoomAcross`); overlay mounts in a pane/iframe. Witness **W-TEAM-WIRE** + the
 **Team-OFF pixel-identical** check. EXPLICIT GO → deploy. Impact: chrome (flag-guarded; off = identical).
 

--- a/teams/UI_CONSISTENCY_GUIDE.md
+++ b/teams/UI_CONSISTENCY_GUIDE.md
@@ -1,10 +1,17 @@
 <!-- Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com> · SPDX-License-Identifier: MIT -->
 # Teams Overlay — UI Consistency Guide
 
-**Scope.** The Teams overlay must SPEAK THE HOST'S VISUAL LANGUAGE (BIM Viewer/Modeller `viewer/panels.js`;
-ERP iDempiere `--idmp-*` chrome) and NEVER impose its own — that consistency IS the universal-optics thesis
-(one overlay, design→operate). Spec = `prompts/RESUME_TEAMS_UI_CONSISTENCY.md`. This guide is the dev/verify
-companion: what was built, how each requirement is met, and **the exact whitebox `§` log line that proves it**.
+> ⛔ **Teams does NOT embed in the Viewer (user decision, 2026-07-05).** It embeds in **Modeller**
+> (`viewer/panels.js` icon/panel factory, consumed read-only) and **ERP** (`--idmp-*` chrome) only. The
+> `overlay/find_placement.js` row below describes a Viewer Find-panel "operate" placement that was built as
+> a standalone POC + demo fixture and never wired into `viewer.html` — see the retirement note in
+> `prompts/RESUME_TEAMS_UI_CONSISTENCY.md` for the full detail. Its DESIGN/Modeller half stays in scope.
+
+**Scope.** The Teams overlay must SPEAK THE HOST'S VISUAL LANGUAGE (**Modeller** `viewer/panels.js` icon/panel
+factory; **ERP** iDempiere `--idmp-*` chrome) and NEVER impose its own — that consistency IS the
+universal-optics thesis (one overlay, design→operate). Spec = `prompts/RESUME_TEAMS_UI_CONSISTENCY.md`. This
+guide is the dev/verify companion: what was built, how each requirement is met, and **the exact whitebox `§`
+log line that proves it**.
 
 > **Lane rule (non-negotiable).** This lane touches `teams/` ONLY. `viewer/panels.js` is the HBA/viewer seam
 > (a conflict magnet) — Teams CONSUMES the host factory at runtime, it does not edit it. Facet-icon registry
@@ -14,7 +21,7 @@ companion: what was built, how each requirement is met, and **the exact whitebox
 | File | Role |
 |---|---|
 | `overlay/teams_pill.js` | Host-aware launcher — pill via `host.icon('share')`, pane via `host.createPanel` → `.bim-panel`; self-contained glyph + `.teams-pane` fallback off-host. |
-| `overlay/find_placement.js` | R6 engine — one Role×Spine matrix, design (Project→Element) + operate (Storey→Rooms), storey `+N` rollup. Reuses `dot_layer`. |
+| `overlay/find_placement.js` | R6 engine — one Role×Spine matrix, design (Project→Element, IN SCOPE — Modeller Outliner) + operate (Storey→Rooms, ⛔ RETIRED — was a Viewer Find-panel POC, never wired). Reuses `dot_layer`. |
 | `overlay/teams_tabs.js` | R3 tab shell — the ONE canonical `.tabs > .tab(.on)[data-t]` + `.pane#pane-<id>` markup (verbatim from `teams.html`). |
 | `overlay/embed_outliner.js` | R3 content — fills Tree(blame)/Chat(op-log)/Dashboard(involvement) into the tab shell from existing folds. |
 | `erp/teams_dashboard.js` | §1b — HR-schema Chart.js config builders (involvement/flow/gate/aging/presence), watermarked, `Date.now`-free. |
@@ -32,8 +39,8 @@ value, not a pass/fail string (Log Mandate: exit code is not evidence).
 | **R5** dot ≠ state | identity `colorOf` (hsl) ∉ HR state palette | `ui_consistent.js` | `§UI-DOTID … dot=rgb(215, 66, 78)` |
 | **OFF** pixel-identical | no overlay DOM until ON; reversible | `ui_consistent.js` / `wire_teams_pill.js` | `§UI-OFF … pane=false dots=0` |
 | **no silent fail** | 0 console.error / pageerror | `ui_consistent.js` (+ dom + tabs) | `§UI-NOERR … errs=0` |
-| **R6** placement | one Role×Spine matrix, 2 anchorOf | `poc_teams_find_placement.js` | `§SAME-ENGINE design=[1,2,5] operate=[1,2,5]` · `§STOREY-ROLLUP L2 badge=+3` |
-| **R6** render | dots after state chip, storey `+N` | `find_placement_dom.js` | `§FP-AFTER-CHIP ok=true` · `§FP-STOREY-N {"L1":"+3","L2":"+5"}` |
+| **R6** placement (design half IN SCOPE, operate/Viewer half ⛔ RETIRED) | one Role×Spine matrix, 2 anchorOf | `poc_teams_find_placement.js` | `§SAME-ENGINE design=[1,2,5] operate=[1,2,5]` · `§STOREY-ROLLUP L2 badge=+3` |
+| **R6** render (proves the standalone fixture only — never wired into `viewer.html`) | dots after state chip, storey `+N` | `find_placement_dom.js` | `§FP-AFTER-CHIP ok=true` · `§FP-STOREY-N {"L1":"+3","L2":"+5"}` |
 | **R3** one tab schema | embed data-t === `teams.html` data-t | `tabs_consistent.js` | `§TABS-PARITY embed=["tree","chat","dash"] teams.html=["tree","chat","dash"]` |
 | **§1b** dashboard | HR-schema configs from folds | `poc_teams_dashboard.js` | `§INVOLVE data=[3,2]` · `§AGING data=[1,0,1,0]` · `§NO-DATENOW noDateNow=true` |
 | **§3b.2** PERT gate | dep/cycle/resource conflicts | `poc_teams_pert_gate.js` | `§DEP-VIOLATION roofViol={…"by":3}` · `§CYCLE cycles=[["A","B"]]` |


### PR DESCRIPTION
## Summary
Follow-up to #661. User decision (2026-07-05): Teams is only useful embedded in **Modeller + ERP**,
not the Viewer — HBA already owns the Viewer's operate-phase Storey/Tenancy/IoT Find-panel facet
row, and a Teams facet there would just be a second, redundant way to comment on the same building
on top of the Viewer's existing Share/Issues tools.

- Marked **R1** (Viewer facet-icon row) and the **OPERATE half of R6** (Storey→Rooms Find-panel
  placement) in `prompts/RESUME_TEAMS_UI_CONSISTENCY.md` as retired, with a banner at the top so a
  future session doesn't try to execute them without a fresh GO. `find_placement.js`'s
  design/Modeller-Outliner half stays in scope (that one's real, just never embedded either — see
  below).
- Mirrored the same clarification into `teams/UI_CONSISTENCY_GUIDE.md` and the `teams/ROADMAP.md`
  entry-point banner (the doc a new session reads first).
- Fixed a genuinely stale claim while in there: `ROADMAP.md`'s S9 note said the ERP `kanban_host`
  line-edit was "not landed in the live app" — `git log` shows it landed in the same original PR
  #593 and has been live in production `idempiere.html` the whole time (`W-EMBED-WIRE 4/4`). Not an
  outstanding item, just a stale doc.

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)