### PR TITLE
fix(offline-gateway): stop network leaks once building data is already cached

### DIFF
--- a/tests/witness/witness_offline_gateway_leak.js
+++ b/tests/witness/witness_offline_gateway_leak.js
@@ -1,0 +1,56 @@
+// Targeted witness for §OFFLINE-GATEWAY-LEAK fix.
+// Cleaner claim under test: once sfx.json is precached, the network layer must NEVER be touched
+// for it again — proven by aborting any actual network attempt for it via context.route() and
+// confirming the route handler is never invoked (i.e. the SW served it purely from Cache API,
+// never called fetch() internally). page.on('request') is NOT reliable for this (it also fires
+// for requests fully answered by a Service Worker's cache, so counting those over-reports "leaks").
+const { chromium } = require('../node_modules/playwright');
+
+const BASE = process.env.WITNESS_BASE_URL || 'http://localhost:8080/bim-ootb/viewer';
+const VIEWER_URL = `${BASE}/viewer.html?db=/buildings/Duplex_extracted.db&lib=/buildings/Duplex_library.db`;
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.on('console', msg => console.log('[console] ' + msg.text()));
+  page.on('pageerror', e => console.log('[pageerror] ' + e.message));
+
+  // ── Pass 1: online, cold — populate SW cache (install event precaches sfx.json now) ──
+  await page.goto(VIEWER_URL, { waitUntil: 'load' });
+  await page.waitForFunction(() => window.APP && window.APP.scene, { timeout: 20000 });
+  await page.waitForTimeout(3000); // let SW install/precache settle
+  console.log('§WITNESS PASS1_ONLINE_LOAD done');
+
+  // ── Pass 2: block the actual network layer for sfx.json entirely, then reload online ──
+  // If the route handler NEVER fires, the SW never attempted a real fetch() for it (cache-first
+  // served straight from Cache API) — that's the fix. If it fires, the old network-first leak
+  // is still present.
+  let sfxNetworkTouched = false;
+  await context.route('**/sfx.json', route => { sfxNetworkTouched = true; route.abort(); });
+
+  const pageErrors = [];
+  page.on('pageerror', e => pageErrors.push(e.message));
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForFunction(() => window.APP && window.APP.scene, { timeout: 20000 });
+  await page.waitForTimeout(3000);
+  console.log('§WITNESS PASS2_SFX_NETWORK_TOUCHED=' + sfxNetworkTouched + ' (must be false — the old code ALWAYS touched network here)');
+  console.log('§WITNESS PASS2_PAGE_ERRORS=' + pageErrors.length + (pageErrors.length ? ' ' + JSON.stringify(pageErrors) : ''));
+
+  // ── Pass 3: true offline — context.setOffline(true), reload, building must still render ──
+  await context.unroute('**/sfx.json');
+  await context.setOffline(true);
+  await page.reload({ waitUntil: 'load' }).catch(e => console.log('§WITNESS PASS3_RELOAD_NAV_ERR ' + e.message));
+  const rendered = await page.waitForFunction(() => window.APP && window.APP.scene && window.APP.db, { timeout: 20000 })
+    .then(() => true).catch(() => false);
+  if (!rendered) {
+    const statusText = await page.evaluate(() => (document.getElementById('status') || {}).textContent || '(no #status)').catch(() => '(eval failed)');
+    console.log('§WITNESS PASS3_STATUS_TEXT=' + statusText);
+  }
+  console.log('§WITNESS PASS3_OFFLINE_RENDERED=' + rendered);
+
+  await browser.close();
+  const pass = !sfxNetworkTouched && rendered;
+  console.log('§WITNESS DONE sfxLeakFixed=' + (!sfxNetworkTouched) + ' offlineWorks=' + rendered);
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.error('§WITNESS FATAL ' + e.stack); process.exit(1); });

--- a/viewer/city.js
+++ b/viewer/city.js
@@ -654,7 +654,14 @@ function setupCity(A) {
       // inline → (2) libDb = db (mirrors streaming.js A.libDb = A.db). Else → (3) fetch library.
       let _split = false;
       if (metaUrl !== extUrl) {
-        try { const h = await fetch(metaUrl, { method: 'HEAD' }); _split = h.ok; } catch (e) { _split = false; }
+        // §OFFLINE-GATEWAY-LEAK: check IndexedDB before the network — an archetype already
+        // downloaded must resolve split-mode from cache, not re-probe the network every load.
+        const _metaCached = await A._checkCache(metaUrl);
+        if (_metaCached) {
+          _split = true;
+        } else {
+          try { const h = await fetch(metaUrl, { method: 'HEAD' }); _split = h.ok; } catch (e) { _split = false; }
+        }
       }
       let _mode, _mainDb, _auxDb, _mainMB = 0, _auxMB = 0;
       try {

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1361,9 +1361,11 @@ function setupStreaming(A) {
     if (metaUrl === A.DB_URL) metaUrl = A.DB_URL.replace(/\.db$/, '_meta.db');
     if (metaUrl !== A.DB_URL) {
       try {
-        // For import:// URLs, use IDB _checkCache instead of HEAD fetch
-        if (A.DB_URL.startsWith('import://')) {
-          _splitMode = await A._checkCache(metaUrl);
+        // §OFFLINE-GATEWAY-LEAK: check IndexedDB before ever touching the network — a repeat/offline
+        // open of a building already downloaded must not re-probe the network to rediscover split-mode.
+        var _metaCached = await A._checkCache(metaUrl);
+        if (_metaCached || A.DB_URL.startsWith('import://')) {
+          _splitMode = !!_metaCached;
         } else {
           var headResp = await fetch(metaUrl, { method: 'HEAD' });
           _splitMode = headResp.ok;
@@ -1528,12 +1530,19 @@ function setupStreaming(A) {
     } else {
       // ── Single DB — always full download. Range streaming only works with split DBs
       // (split = meta instant + geo range). Without split, metadata scanning via range is too chatty.
+      // §OFFLINE-GATEWAY-LEAK: this size check is diagnostic-only (feeds one log line) — it must not
+      // touch the network for a building already sitting in IndexedDB.
       var _dbSize = 0;
-      try {
-        var headR = await fetch(A.DB_URL, { method: 'HEAD' });
-        _dbSize = parseInt(headR.headers.get('Content-Length') || '0', 10);
-      } catch(e) {}
-      console.log(`[S260] §DB_SIZE_CHECK size=${(_dbSize/1024/1024).toFixed(0)}MB`);
+      var _dbCached = await A._checkCache(A.DB_URL);
+      if (_dbCached) {
+        _dbSize = _dbCached.byteLength;
+      } else {
+        try {
+          var headR = await fetch(A.DB_URL, { method: 'HEAD' });
+          _dbSize = parseInt(headR.headers.get('Content-Length') || '0', 10);
+        } catch(e) {}
+      }
+      console.log(`[S260] §DB_SIZE_CHECK size=${(_dbSize/1024/1024).toFixed(0)}MB src=${_dbCached ? 'cache' : 'network'}`);
 
       // ── §S281: Single-DB instant bboxes — try the tiny positions.bin sidecar first (the same one
       // split builds use), so the wireframe preview paints before the full _extracted.db downloads.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v740';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v741';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -182,6 +182,9 @@ const PRECACHE_ASSETS = [
   // earth/paved are lazy (cacheFirst caches on first selection).
   'ground_config.json',
   'textures/ground/grass_1k.jpg',
+  // §OFFLINE-GATEWAY-LEAK: was hardcoded network-first ("during tuning") — precached like every
+  // other config file now so it stops re-hitting the network once cached.
+  'sfx.json',
 ];
 
 self.addEventListener('install', (event) => {
@@ -229,7 +232,6 @@ function isNetworkFirst(url) {
   }
   // Precached local files — cache-first (CACHE_VERSION bump purges + refreshes)
   var filename = base.split('/').pop();
-  if (filename === 'sfx.json') return true;   // sfx config — always fresh (network-first) during tuning
   if (_PRECACHE_SET.has(filename)) return false;
   // Unknown JS/HTML not in precache list — network-first (safe default)
   if (base.endsWith('.html') || base.endsWith('.js')) return true;


### PR DESCRIPTION
## Summary
User-flagged bug during the offline-install (§S283) reliability review: "when DBs are loaded in
IndexedDB, sometimes it still [goes online]." Three call sites bypassed `sw.js`'s cache-first
gateway entirely, each firing an unconditional network request before ever checking
IndexedDB/Cache API:

- `viewer/sw.js` — `sfx.json` was hardcoded network-first ("during tuning", a stale debug
  carve-out). Now precached like every other config file.
- `viewer/streaming.js` — the single-DB size check and the split-DB `_meta.db` detect each fired
  an unconditional HEAD probe before checking `A._checkCache()`. Now check cache first, only
  probing the network on a genuine cache miss.
- `viewer/city.js` — same split-DB detect pattern in the city/archetype auto-load path.

Bumped `CACHE_VERSION` (v740→v741) since the precache list changed.

## Test plan
- [x] `node --check` on all 3 changed files
- [x] New witness `tests/witness/witness_offline_gateway_leak.js`: loads a building online, then
      proves via `context.route()` that `sfx.json`'s network layer is never touched again once
      precached (route handler never invoked), and confirms `context.setOffline(true)` + reload
      still renders the building purely from IndexedDB. Ran locally, exit 0.
- [ ] Not wired into `ci.yml` — the existing offline-PWA Playwright specs
      (`38-offline-pwa.spec.js`, `s283-pwa-install.spec.js`) have pre-existing, unrelated
      environment issues (a hardcoded `/dev/index.html` path from a personal-machine layout —
      already documented in `GH_DEPLOY_ISSUES.md` Issue 4 — and a `beforeinstallprompt` timing
      issue in headless Chromium) that would make CI red for reasons unrelated to this fix.
      Flagged as a separate follow-up, not fixed here to avoid scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)