### PR TITLE
50k-scale selection perf fix + kill pill-rail auto-reorder

### DIFF
--- a/common/pill_builder.js
+++ b/common/pill_builder.js
@@ -104,32 +104,32 @@
     var _rail = opts.layout === 'rail';   // viewer L-PATH rail (buttons position:fixed); erp strips stay CSS flow
     var HOLD_MS = 450;
 
-    // ── Config persistence: { order: [], hidden: [] } ──
+    // §STATIC-RAIL (user, 2026-07-06): bump-to-end-on-click is gone (see the click handlers
+    // below), but browsers that already clicked their way to a scrambled order have that
+    // scramble sitting in localStorage from before this fix — a version bump discards any
+    // saved order from an older version, so the fixed _defaultOrder actually takes effect.
+    var _ORDER_VERSION = 2;
+    // ── Config persistence: { order: [], hidden: [], orderVersion } ──
     function _getConfig() {
       try {
         var s = localStorage.getItem(_CFG_KEY);
         if (s) {
           var cfg = JSON.parse(s);
           // Migration: old format was plain array (order only)
-          if (Array.isArray(cfg)) return { order: cfg, hidden: [] };
+          if (Array.isArray(cfg)) return { order: _defaultOrder.slice(), hidden: [] };
+          if (cfg.orderVersion !== _ORDER_VERSION) return { order: _defaultOrder.slice(), hidden: cfg.hidden || [] };
           return { order: cfg.order || _defaultOrder.slice(), hidden: cfg.hidden || [] };
         }
       } catch(e) {}
       return { order: _defaultOrder.slice(), hidden: [] };
     }
     function _setConfig(cfg) {
+      cfg.orderVersion = _ORDER_VERSION;   // stamp so this save survives the next load (only a
+                                            // pre-§STATIC-RAIL save gets discarded, see _getConfig)
       try { localStorage.setItem(_CFG_KEY, JSON.stringify(cfg)); } catch(e) {}
       console.log('§SETTINGS_SAVE items=' + cfg.order.length + ' hidden=' + (cfg.hidden ? cfg.hidden.length : 0));
     }
     function _getOrder() { return _getConfig().order; }
-    function _bumpAction(id) {
-      var cfg = _getConfig();
-      var idx = cfg.order.indexOf(id);
-      if (idx >= 0) cfg.order.splice(idx, 1);
-      cfg.order.push(id);
-      _setConfig(cfg);
-      return cfg.order;
-    }
     function _resetConfig() {
       try { localStorage.removeItem(_CFG_KEY); } catch(e) {}
       console.log('§SETTINGS_RESET defaults restored');
@@ -256,14 +256,18 @@
           btn.addEventListener('pointerup', function(e) {
             e.stopPropagation(); _cancelHold();
             if (_held) { _held = false; return; }
-            _bumpAction(act.id); act.fn(); _sync();
+            // §STATIC-RAIL (user, 2026-07-06): was _bumpAction(act.id) here — moved the clicked
+            // icon to the end of the order + re-saved, so the rail visibly reshuffled on every
+            // click. Rail order is now fixed (see _defaultOrder / §ORDER_VERSION below); manual
+            // reordering is still available, opt-in, via the Settings pill editor only.
+            act.fn(); _sync();
             console.log('§PILL action=' + act.id);
           });
           btn.addEventListener('pointerleave', _cancelHold);
           btn.addEventListener('pointercancel', _cancelHold);
         } else if (act.fn) {
           btn.addEventListener('pointerup', function(e) {
-            e.stopPropagation(); _bumpAction(act.id);
+            e.stopPropagation();
             act.fn(); _sync();
             console.log('§PILL action=' + act.id);
           });

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -3471,8 +3471,20 @@
       _clearShapeOverlays();
       _clearHlOverlay();
       if (A.setOutline) A.setOutline([]);
-      if (!A.xrayOn && A.toggleXray) { A.toggleXray(); _hlXrayWasOff = true; } // x-ray path: rest → transparent
-      _dimXrayTo(0.1);                                                          // §DEPTH: rest = 0.1 ghost
+      // §PERF-50K (user, 2026-07-06): full per-material X-Ray (A.toggleXray iterates every
+      // material, flips transparent/opacity/side, forces a pipeline recompile) was ALWAYS
+      // auto-engaged here on every selection — fine at small scale, but "too heavy" once a
+      // building crosses ~50k elements (the same threshold time_machine.js already uses for
+      // its own perf cliff, LARGE_BUILDING). Above that, obscure the rest via the cheap
+      // VISIBILITY-only A.filterByGuids (the same primitive Alt+X's ghost/bbox mode already
+      // uses) instead of touching material state at all. Below threshold: unchanged.
+      var _bigBuilding = (A.activeBuildingTotal || 0) > 50000;
+      if (_bigBuilding) {
+        if (A.filterByGuids) A.filterByGuids(set);   // hide everything except the selection
+      } else {
+        if (!A.xrayOn && A.toggleXray) { A.toggleXray(); _hlXrayWasOff = true; } // x-ray path: rest → transparent
+        _dimXrayTo(0.1);                                                          // §DEPTH: rest = 0.1 ghost
+      }
       // color=null → opaque clone of each element's REAL material; solidOpacity=1 → fully solid.
       var _ovBefore = _shapeOverlays.length;
       var lit = _buildShapeMeshes(set, null, 1, null);
@@ -3494,7 +3506,8 @@
       if (opts.frame !== false) zoomed = (opts.item === false) ? _zoomToGroup(set) : _zoomToGuids(set, 1.1);
       if (A.markDirty) A.markDirty();
       console.log('[RP-TB] §FOCUS_ELEM guids=' + set.size + ' lit=' + lit + ' outline=' + _ovMeshes.length +
-        ' frame=' + (opts.frame !== false) + ' zoom=' + (zoomed ? 'fit' : 'none') + ' xray=' + (A.xrayOn ? 'on' : 'off'));
+        ' frame=' + (opts.frame !== false) + ' zoom=' + (zoomed ? 'fit' : 'none') + ' xray=' + (A.xrayOn ? 'on' : 'off') +
+        ' mode=' + (_bigBuilding ? 'filter-cheap(>50k)' : 'xray-dim'));
       return lit;
     };
     // Read-only teardown — drop the focus overlay + restore x-ray (same path as a lens reset).


### PR DESCRIPTION
## Summary
Two user-reported issues, unrelated to each other, fixed together since both surfaced in the same testing round:

1. **Selection auto-obscure too heavy at scale.** `A.focusElement()` (fires on every 3D pick, Find zoom-to, and history-restore) always engaged full per-material X-Ray to ghost the rest of the building. That's a real per-material transparency mutation across every cached material plus a GPU pipeline recompile — fine under ~50k elements, too heavy above it (the original design intent, per the user, was cheap obscure above that scale instead of the heavy X-Ray path). Fixed: above `A.activeBuildingTotal > 50000`, use `A.filterByGuids` (visibility-only — the same primitive the Alt+X ghost mode already uses) instead.

2. **Pill rail visibly reshuffled on every click.** `pill_builder.js` moved the clicked icon to the end of a persisted order on every tap. Removed; manual reordering is still available opt-in via the Settings pill editor. Added a version stamp so any already-scrambled saved order from before this fix gets discarded on next load.

## Test plan
- [x] Rail order identical before/after clicking several icons
- [x] Synthetically-injected stale (pre-fix, no version stamp) scrambled order gets discarded on reload, fixed order wins
- [x] `focusElement` logs `mode=xray-dim` at real scale (~6830 elements)
- [x] `focusElement` logs `mode=filter-cheap(>50k)` when `activeBuildingTotal` forced above threshold
- [x] Selection highlight overlay confirmed present + visible under the cheap-filter path
- [x] 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)