### PR TITLE
fix+feat(modeller): git-faithful fork/undo/redo via shared history_bar.js

### DIFF
--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -414,14 +414,23 @@
       console.log(TAG + ' undo id=' + top + (ids.length > 1 ? ' §GESTURE-UNDO group=' + topRow.gid + ' rows=' + ids.length : '') + ' active=' + this.length);
       return { undone: top, group: ids.length > 1 ? ids : undefined };
     },
-    // Redo = reactivate the most-recent undone feature, walking UP any undone ancestor chain (keep the invariant).
+    // Redo = reactivate the EARLIEST-undone feature (LIFO: the row closest to the active boundary — the
+    // one undo() removed MOST RECENTLY), walking UP any undone ancestor chain (keep the invariant).
     // §P8: a gesture group reactivates whole (mirror of the group undo above), each member still ancestor-walked.
+    // §MODELLER_REDO_ORDER (MODELLER_GIT_FAITHFUL_HISTORY.md Phase 1): was `undoneRows[undoneRows.length-1]`
+    // — the HIGHEST-id undone row ("most recently created"), which is the OPPOSITE of correct LIFO redo and
+    // diverged from the proven invariant both `viewer/kernel_ops.js redoOp` and `erp/kernel_ops.js redoOp`
+    // already use (`ORDER BY id ASC LIMIT 1` = lowest-id undone first). Confirmed by trace: rows 1,2,3 active,
+    // undo() twice → undone={2,3} in that order; correct redo() must reactivate 2 first (it was undone LAST,
+    // i.e. it sits nearest the active/undone boundary), not 3. The old code picked 3 first — wrong order even
+    // with zero forking involved, and the root enabler of a later fork silently resurrecting alongside a
+    // diverged edit once a tree layer is added on top (see file header WHY #3/#4).
     async redo() {
       if (!this.db) return { redone: null };
       const all = this._allGeom(); const undoneRows = all.filter(o => o.undone);
       if (!undoneRows.length) return { redone: null };
       const byId = new Map(all.map(o => [o.id, o]));
-      const topRow = undoneRows[undoneRows.length - 1], top = topRow.id;
+      const topRow = undoneRows[0], top = topRow.id;
       const seeds = this._isGestureGid(topRow.gid) ? undoneRows.filter(o => o.gid === topRow.gid) : [topRow];
       const on = [];
       seeds.forEach(s => { let cur = s; while (cur && cur.undone && on.indexOf(cur.id) < 0) { on.push(cur.id); cur = cur.parent != null ? byId.get(cur.parent) : null; } });

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -188,7 +188,12 @@
 <script src="lib/sql-wasm.js" onerror="console.warn('§OPLOG LOAD_FAIL sql-wasm.js')"></script>
 <script src="kernel_ops.js?v=9" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
-<script src="bonsai_oplog.js?v=7" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<script src="bonsai_oplog.js?v=8" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<!-- §MODELLER-GIT-HISTORY (MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2): the SAME git-faithful fork/undo/redo
+     tree engine the Viewer runs (common/history_bar.js), reused — not a second branch mechanism. The
+     adapter wraps Bonsai.oplog.commit/commitGesture so every real edit lands as one tree node. -->
+<script src="../common/history_bar.js?v=1" onerror="console.warn('§MHIST LOAD_FAIL history_bar.js')"></script>
+<script src="modeller_history.js?v=1" onerror="console.warn('§MHIST LOAD_FAIL modeller_history.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
 <script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
@@ -2949,8 +2954,33 @@ window.addEventListener('keydown', (e) => {                       // R rotates t
 // Undo/Redo carry NO pill button — the history scrubber is the visible retreat (a strict superset). They live on
 // as the Ctrl+Z / Ctrl+⇧Z keyboard verbs (doUndo/doRedo) and a row in the ? help panel.
 const bDel = document.getElementById('b-del');
-async function doUndo() { const r = await window.Bonsai.oplog.undo(); if (r.undone != null) { if (selectedId === r.undone) highlight(null); audioCue('clear'); setStat('undo #' + r.undone); syncHistory(); } }
-async function doRedo() { const r = await window.Bonsai.oplog.redo(); if (r.redone != null) { audioCue('tick'); setStat('redo #' + r.redone); syncHistory(); } }
+// §MODELLER-GIT-HISTORY (MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2): route through ModellerHistory (=
+// common/history_bar.js, the SAME git-faithful tree the Viewer's Ctrl+Z uses — viewer/grid_drag.js:836-855
+// is the exact same defensive pattern: shared-timeline call first, raw oplog only if the tree never
+// mounted). This keeps the tree's cursor from silently desyncing from the real op-log (the "shadow
+// tracker" bug the Viewer's own history_bar.js header explicitly calls out and forbids).
+async function doUndo() {
+  const MH = window.ModellerHistory;
+  if (MH && MH.undo) {
+    MH.undo();                                    // sync: moves the tree cursor + fires the real oplog.undo()
+    const r = await (MH.pending() || Promise.resolve({}));
+    if (r.undone != null) { if (selectedId === r.undone) highlight(null); audioCue('clear'); setStat('undo #' + r.undone); }
+    syncHistory();
+    return;
+  }
+  const r = await window.Bonsai.oplog.undo(); if (r.undone != null) { if (selectedId === r.undone) highlight(null); audioCue('clear'); setStat('undo #' + r.undone); syncHistory(); }
+}
+async function doRedo() {
+  const MH = window.ModellerHistory;
+  if (MH && MH.redo) {
+    MH.redo();
+    const r = await (MH.pending() || Promise.resolve({}));
+    if (r.redone != null) { audioCue('tick'); setStat('redo #' + r.redone); }
+    syncHistory();
+    return;
+  }
+  const r = await window.Bonsai.oplog.redo(); if (r.redone != null) { audioCue('tick'); setStat('redo #' + r.redone); syncHistory(); }
+}
 async function deleteSelected() {
   const ids = selectedIds.size ? Array.from(selectedIds) : (selectedId != null ? [selectedId] : []);
   if (!ids.length) return;

--- a/modeller/modeller_history.js
+++ b/modeller/modeller_history.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// modeller_history.js — the MODELLER ADAPTER onto the shared common/history_bar.js (HistoryBar).
+// prompts/MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2: reuse the SAME git-faithful tree engine the Viewer
+// already runs (mirrors viewer/universal_history.js's role exactly) — no new branch mechanism invented.
+// This file supplies only: (a) push() calls wired onto Bonsai.oplog.commit/commitGesture, (b) one
+// restore(entry,forward) that calls Bonsai.oplog.undo()/redo() (Phase 1's fixed, correctly-ordered
+// primitives), (c) Modeller's significant op types. HistoryBar owns the tree/fork/coalesce/persistence.
+(function () {
+  'use strict';
+  if (!window.HistoryBar) { console.warn('§MHIST_NO_MODULE common/history_bar.js not loaded'); return; }
+  var HB = window.HistoryBar;
+
+  // (c) every real GEOM op-type Modeller commits, plus the BUILDING_OPEN milestone (readonly, mirrors
+  // the Viewer's own BUILDING_OPEN handling — "nothing to flip", just a dot marking where edits began).
+  // Modeller has no breadth-ladder UI (no knob pill) — ONE profile, always on, own depthKey so a stale
+  // Viewer/iDempiere depth setting in shared localStorage can never suppress Modeller's own dots.
+  var OP_TYPES = { 'BUILDING_OPEN': true, 'GEOM_EXTRUDE': true, 'GEOM_EXTRUDE_POLY': true,
+    'GEOM_SWEEP': true, 'GEOM_CUT': true, 'GEOM_FILLET': true, 'GEOM_GRID_MOVE': true,
+    'GEOM_MOVE': true, 'GEOM_ROTATE': true, 'GEOM_SCALE': true, 'GEOM_INSERT': true,
+    'GEOM_OPENING': true, 'STR_WALK_EDIT': true };
+  var PROFILES = { high: { op: OP_TYPES } };
+  PROFILES.all = PROFILES.high; PROFILES.doc = PROFILES.high;   // legacy aliases HistoryBar falls back to
+
+  function _humanLabel(opType, p) {
+    p = p || {};
+    if (opType === 'BUILDING_OPEN') return 'Opened ' + (p.building || p.name || 'building');
+    if (opType === 'GEOM_GRID_MOVE') return 'Grid ' + (p.label || p.gridId || '') + ' move';
+    if (opType === 'GEOM_CUT') return 'Cut';
+    if (opType === 'GEOM_FILLET') return 'Fillet';
+    if (opType === 'GEOM_ROTATE') return 'Rotate';
+    if (opType === 'GEOM_SCALE') return 'Scale';
+    if (opType === 'GEOM_MOVE') return 'Move';
+    if (opType === 'GEOM_INSERT') return 'Insert';
+    if (opType === 'GEOM_OPENING') return 'Opening';
+    if (opType === 'GEOM_SWEEP') return 'Sweep';
+    if (opType === 'STR_WALK_EDIT') return 'STR re-walk';
+    return opType.replace(/^GEOM_/, '').replace(/_/g, ' ').toLowerCase();
+  }
+
+  // Push ONE node per commit-worth-of-rows (a single commit() row, or a whole commitGesture() group —
+  // exactly the unit Bonsai.oplog.undo()/redo() already treats as one atomic LIFO step, Phase 1 fixed).
+  function _push(opType, params, opts) {
+    opts = opts || {};
+    HB.push({ bucket: 'op', kind: 'op', type: opType, label: _humanLabel(opType, params),
+      readonly: !!opts.readonly, opId: opts.opId, gid: opts.gid, params: params || {},
+      ref: (opType === 'BUILDING_OPEN' && params && params.building) ? { building: params.building, db: params.db } : null,
+      sigKey: 'op:' + opType + ':' + (opts.gid || opts.opId || '') });
+  }
+
+  // Building-open milestone — called from str_walker_outliner.js's _openBuffer on success (the single
+  // chokepoint every Open path — resident/local-.db/local-.ifc — folds through). READ-ONLY: restore()
+  // does nothing for it (same as the Viewer's BUILDING_OPEN — "a read-only milestone, nothing to flip"),
+  // it exists purely to anchor the edit trail's root per building.
+  function recordBuildingOpen(name) {
+    _push('BUILDING_OPEN', { building: name }, { readonly: true });
+  }
+
+  // restore(entry, forward) — the ONE thing only Modeller can do: replay a step of ITS OWN model.
+  // BUILDING_OPEN is read-only (nothing to flip). Every other entry is a real GEOM/STR edit — forward
+  // ⇒ Bonsai.oplog.redo() (Phase 1: correctly picks the lowest-id-undone row/group next), backward ⇒
+  // Bonsai.oplog.undo(). Neither call takes a target id — both always act on the current LIFO boundary,
+  // which HistoryBar's tree-walk (undo to common ancestor, then redo down the target path) keeps in
+  // exact lockstep with, by construction (paths in the tree are chronological commit order).
+  //
+  // ASYNC NOTE: HistoryBar's undo()/redo()/switchToId() call restore() SYNCHRONOUSLY (viewer's kernel
+  // calls are plain sql.js, no await needed) — but Modeller's own undo()/redo() are `async` (they await
+  // an OCCT worker re-fold). The tree-cursor move itself is safe fire-and-forget: Bonsai.oplog's row
+  // SELECTION + the `undone`-flag flip both happen SYNCHRONOUSLY at the top of undo()/redo(), before
+  // their one `await` (the visual re-fold) — so back-to-back tree steps stay logically correct even
+  // without awaiting; only the FOLD (visual) could theoretically resolve out of order under rapid
+  // multi-step calls. `doUndo`/`doRedo` (single human keypress at a time) never hits that; a future
+  // Phase 3 multi-step branch-switch UI should await `pending()` between steps before firing the next.
+  var _pending = null;
+  function pending() { return _pending; }
+  function _restore(entry, forward) {
+    var O = window.Bonsai && window.Bonsai.oplog;
+    if (!entry || !O) { _pending = null; return; }
+    if (entry.type === 'BUILDING_OPEN') { _pending = null; return; }   // read-only milestone — nothing to flip
+    _pending = (forward ? O.redo() : O.undo());
+    _pending.catch(function (e) { console.warn('§MHIST_RESTORE_ERR', e); });
+  }
+
+  HB.configure({
+    source: 'modeller',
+    profiles: PROFILES,
+    depthKey: 'bim.hist.depth.modeller',   // own namespace — never inherits a stale Viewer/iDempiere stop
+    ignorePersistedDepth: true,            // Modeller has no breadth-knob UI — always boot at defaultDepth()
+    defaultDepth: function () { return 'high'; },
+    restore: _restore,
+    sharedKey: 'bim.docHistory',
+    channel: 'bim_history',
+    docTypes: { 'BUILDING_OPEN': true }    // mirror building-open milestones to the cross-page WholeHistory log
+  });
+
+  // Wrap commit()/commitGesture() — record EVERY real edit as it lands. deleteFeature()/commitSeedGroup()
+  // are intentionally NOT wrapped yet (deleteFeature flags EXISTING rows rather than committing a new one —
+  // doesn't fit the "one push per new commit" shape; commitSeedGroup is the one-time whole-building ARC
+  // seed, never Ctrl+Z'd row-by-row in practice) — flagged as a follow-up in
+  // prompts/MODELLER_GIT_FAITHFUL_HISTORY.md, not silently half-wired.
+  (function wrapCommits() {
+    var O = window.Bonsai && window.Bonsai.oplog;
+    if (!O || O.__mhistWrapped) { if (!O) setTimeout(wrapCommits, 200); return; }
+    var origCommit = O.commit, origGesture = O.commitGesture;
+    O.commit = async function (op, opts) {
+      var r = await origCommit.call(this, op, opts);
+      try { _push(op.op_type, op.parameters, { opId: r && r.id }); } catch (e) { console.warn('§MHIST_REC_ERR', e); }
+      return r;
+    };
+    O.commitGesture = async function (opsArray) {
+      var r = await origGesture.call(this, opsArray);
+      try {
+        // one node for the WHOLE gesture — label off its first op, gid carries the group for restore's
+        // undo()/redo() (which already treats a gesture-grp gid as one atomic LIFO step, §P8).
+        var first = (opsArray && opsArray[0]) || {};
+        _push(first.op_type || 'GEOM_MOVE', first.params, { gid: r && r.gid, opId: r && r.id });
+      } catch (e) { console.warn('§MHIST_REC_ERR', e); }
+      return r;
+    };
+    O.__mhistWrapped = true;
+    console.log('§MHIST_WRAP commit/commitGesture wrapped');
+  })();
+
+  window.ModellerHistory = {
+    recordBuildingOpen: recordBuildingOpen,
+    undo: HB.undo, redo: HB.redo, jumpTo: HB.jumpTo, pending: pending,
+    switchToId: HB.switchToId, tips: HB.tips, dumpTree: HB.dumpTree, setTreeKey: HB.setTreeKey,
+    open: HB.open, toggleOpen: HB.toggleOpen, list: HB.list
+  };
+  console.log('§MHIST_READY source=modeller profile=high ops=' + Object.keys(OP_TYPES).length);
+})();

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -158,6 +158,13 @@
       // Ensure the shared DiscWalker engine + the "Walk · Disciplines" roster are ready for this building
       // (lazy-loads terminal_rules.db; lets an ABSENT discipline be walked). Fire-and-forget.
       if (window.__ensureDiscWalker) window.__ensureDiscWalker();
+      // §MODELLER-GIT-HISTORY (MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2): ONE read-only BUILDING_OPEN
+      // milestone anchoring this building's edit tree — mirrors the Viewer's own BUILDING_OPEN handling
+      // exactly (nothing to flip on undo/redo, it just roots the trail). Fires for every Open path
+      // (resident/local-.db/local-.ifc all fold through this one chokepoint). Best-effort, never-throw.
+      if (ready && window.ModellerHistory && window.ModellerHistory.recordBuildingOpen) {
+        try { window.ModellerHistory.recordBuildingOpen(name); } catch (e) { console.warn(TAG + ' §MHIST record failed', e && e.message); }
+      }
       console.log(TAG + ' init from "' + name + '" ready=' + ready);
       return ready;
     } catch (e) { console.warn(TAG + ' open failed', e && e.message); return false; }

--- a/modeller/tests/witness_modeller_git_history.js
+++ b/modeller/tests/witness_modeller_git_history.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-MODELLER-GIT-HISTORY: headless-Chrome witness against the REAL production
+ * stack (modeller.html → bonsai_oplog.js → common/history_bar.js → modeller_history.js), not a
+ * reimplementation. Read the log after every run — exit code alone is not evidence.
+ * Spec: prompts/MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2.
+ *
+ * Issue under test: does forking (undo, then a DIFFERENT edit) actually PRESERVE the abandoned branch
+ * recoverably, or does it silently corrupt/compound like the pre-Phase-1 flat model would? This is the
+ * concrete scenario traced in the file header: commit A,B,C → undo×2 (back to A) → commit D (diverges)
+ * → the tree must show TWO tips (C and D), and switching back to C's tip must restore EXACTLY {A,B,C}
+ * active — not {A,B,C,D} compounded, and not corrupted/lost.
+ *
+ * Checks:
+ *   G1 building-open milestone recorded (§MHIST_READY + a BUILDING_OPEN tree node)
+ *   G2 three commits push three tree nodes on one line (no forking yet)
+ *   G3 undo×2 leaves the tree cursor on node A, tree UNCHANGED (kids preserved, not truncated)
+ *   G4 a NEW commit after undo FORKS a sibling (§HIST_FORK logged) — tree now has 2 tips
+ *   G5 switchToId back to the OLD branch's tip restores EXACTLY {A,B,C} active — not compounded with D
+ *   G6 switchToId to the NEW branch's tip restores EXACTLY {A,D} active — the old branch untouched
+ *   G7 signed chain still verifies after all the toggling
+ *   G8 no script LOAD_FAIL / pageerror
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+// Same readiness gate as witness_modeller_dw_oplog.js's openResident — critically, waits for the
+// resident's own ARC-seed (commitSeedGroup, a batch of kernel_ops INSERTs) to fully SETTLE, not just
+// for the db to exist. Getting this wrong races the test's own commits against the seed's still-in-
+// flight writes, which corrupts "highest active id" assumptions the LIFO undo/redo invariant relies on.
+async function openResident(page, key) {
+  await page.click('#b-open');
+  await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="' + key + '"]');
+  await page.waitForFunction(function () {
+    var t = window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree();
+    return !!t && Object.keys(t.nodes).some(function (id) { return t.nodes[id].kind === 'disc'; });
+  }, null, { timeout: 25000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.DiscWalker && window.DiscWalker._ready(); }, null, { timeout: 25000 }).catch(function () {});
+  await page.waitForFunction(function () { return window.Bonsai && window.Bonsai.library && (window.Bonsai.library.catalog() || []).length > 0; }, null, { timeout: 10000 }).catch(function () {});
+  await page.waitForTimeout(500);
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-MODELLER-GIT-HISTORY — fork-preserving undo/redo (headless, SampleHouse) ═══');
+
+  await openResident(page, 'SampleHouse');
+
+  // SampleHouse's own ARC-seed (commitSeedGroup, NOT wrapped into HistoryBar — see modeller_history.js's
+  // "intentionally NOT wrapped" note) leaves a bunch of PRE-EXISTING active rows before any test commit
+  // fires. Every "exactly {...} active" assertion below must be baselined against this set, or it wrongly
+  // reads "undo did nothing" when really it's just comparing against the wrong universe.
+  var preExisting = await page.evaluate(function () {
+    return window.Bonsai.oplog._allGeom().filter(function (o) { return !o.undone; }).map(function (o) { return o.id; });
+  });
+  function withBase(ids) { return preExisting.concat(ids).sort(function (a, b) { return a - b; }); }
+
+  // G1 — the Open path recorded a BUILDING_OPEN milestone (best-effort chokepoint in _openBuffer)
+  var g1 = await page.evaluate(function () {
+    var MH = window.ModellerHistory;
+    return { hasMH: !!MH, tree: MH ? MH.dumpTree() : null };
+  });
+  chk('G1 building-open milestone recorded', !!(g1.hasMH && g1.tree && g1.tree.nodes >= 1),
+    'nodes=' + (g1.tree && g1.tree.nodes) + ' shape=' + (g1.tree && g1.tree.shape));
+
+  // G2 — three standalone commits (A,B,C) push three tree nodes, one line, no fork
+  var g2 = await page.evaluate(async function () {
+    var O = window.Bonsai.oplog;
+    var a = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 1, h: 0.2 }, dir: [0, 0, 1] } }, {});
+    var b = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 2, h: 0.2 }, dir: [0, 0, 1] } }, {});
+    var c = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 3, h: 0.2 }, dir: [0, 0, 1] } }, {});
+    return { a: a.id, b: b.id, c: c.id, tree: window.ModellerHistory.dumpTree() };
+  });
+  chk('G2 three commits push three tree nodes, one line (no fork)',
+    g2.tree.nodes === g1.tree.nodes + 3 && g2.tree.tips.length === 1,
+    'nodes ' + g1.tree.nodes + '→' + g2.tree.nodes + ' tips=' + g2.tree.tips.length + ' shape=' + g2.tree.shape);
+
+  // G3 — undo x2 (the SAME ModellerHistory.undo() doUndo() calls internally — doUndo itself lives inside
+  //      modeller.html's <script type="module"> scope, not reachable as window.doUndo from outside) walks
+  //      the tree cursor back to A; tree structure UNCHANGED (kids/nodes preserved — the fork-don't-wipe
+  //      contract, checked BEFORE any fork happens).
+  async function stepUndo(pg) {
+    await pg.evaluate(async function () {
+      var MH = window.ModellerHistory;
+      MH.undo();
+      await (MH.pending() || Promise.resolve());
+    });
+  }
+  await stepUndo(page);
+  await page.waitForTimeout(150);
+  await stepUndo(page);
+  await page.waitForTimeout(150);
+  var g3 = await page.evaluate(function () {
+    var O = window.Bonsai.oplog;
+    return { active: O._allGeom().filter(function (o) { return !o.undone; }).map(function (o) { return o.id; }).sort(function (x, y) { return x - y; }),
+      tree: window.ModellerHistory.dumpTree() };
+  });
+  var wantG3 = withBase([g2.a]);
+  chk('G3 undo×2 leaves cursor on A (baseline+A only), tree structure UNCHANGED (not truncated)',
+    JSON.stringify(g3.active) === JSON.stringify(wantG3) && g3.tree.nodes === g2.tree.nodes,
+    'active=' + JSON.stringify(g3.active) + ' want=' + JSON.stringify(wantG3) + '  nodes=' + g3.tree.nodes + ' (want ' + g2.tree.nodes + ')');
+
+  // G4 — a NEW commit (D) after undo FORKS a sibling universe (does not silently wipe B,C)
+  logs.length = 0;
+  var g4a = await page.evaluate(async function () {
+    var O = window.Bonsai.oplog;
+    var d = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 4, h: 0.2 }, dir: [0, 0, 1] } }, {});
+    return { d: d.id };
+  });
+  await page.waitForTimeout(150);
+  var forkLog = logs.find(function (l) { return /§HIST_FORK/.test(l); }) || '';
+  var g4 = await page.evaluate(function () { return window.ModellerHistory.dumpTree(); });
+  chk('G4 new edit after undo FORKS a sibling (§HIST_FORK logged, 2 tips now)',
+    forkLog.length > 0 && g4.tips.length === 2, 'forkLog="' + forkLog + '" tips=' + g4.tips.length + ' shape=' + g4.shape);
+
+  // G5 — switch back to the OLD (abandoned, onMain:false) branch's tip restores EXACTLY {A,B,C} active,
+  //      NOT compounded with D. This is the exact corruption scenario traced in bonsai_oplog.js's
+  //      pre-Phase-1 redo() bug once a tree sits on top of it — proves Phase 1 + Phase 2 together close it.
+  var newTip = g4.tips.filter(function (t) { return t.onMain; })[0];
+  var oldTip = g4.tips.filter(function (t) { return !t.onMain; })[0];
+  var g5 = await page.evaluate(function (tipSeq) {
+    window.ModellerHistory.switchToId(tipSeq);
+    var O = window.Bonsai.oplog;
+    return { active: O._allGeom().filter(function (o) { return !o.undone; }).map(function (o) { return o.id; }).sort(function (a, b) { return a - b; }) };
+  }, oldTip && oldTip.id);
+  var wantOld = withBase([g2.a, g2.b, g2.c]);
+  chk('G5 switch to OLD branch tip restores EXACTLY baseline+{A,B,C}, NOT compounded with D', !!oldTip &&
+    JSON.stringify(g5.active) === JSON.stringify(wantOld), 'active=' + JSON.stringify(g5.active) + ' want=' + JSON.stringify(wantOld));
+
+  // G6 — switch DIRECTLY from one abandoned branch's tip to a DIFFERENT branch's tip (skipping the
+  // trunk). KNOWN GAP (see MODELLER_GIT_FAITHFUL_HISTORY.md "Found: multi-branch switchToId gap"):
+  // _switchToNode's undo-to-ancestor walk (undoing C,B) leaves {B,C} freshly undone ALONGSIDE D's
+  // pre-existing undone flag, so the kernel's lowest-id-undone-first redo (Phase 1's own fix — correct
+  // for the single-abandoned-branch case G5 just proved) picks B, not D. Not attempted to "fix" here —
+  // a real fix needs a TARGETED redo(id) primitive in the shared kernel (viewer/kernel_ops.js AND
+  // modeller/kernel_ops.js), out of scope for a Modeller-only pass. Kept RED and documented, not hidden.
+  var g6 = await page.evaluate(function (tipSeq) {
+    window.ModellerHistory.switchToId(tipSeq);
+    var O = window.Bonsai.oplog;
+    return { active: O._allGeom().filter(function (o) { return !o.undone; }).map(function (o) { return o.id; }).sort(function (a, b) { return a - b; }) };
+  }, newTip && newTip.id);
+  var wantNew = withBase([g2.a, g4a.d]);
+  chk('G6 [KNOWN GAP, not fixed] switch DIRECTLY between two non-trunk branches picks the wrong row', !!newTip &&
+    JSON.stringify(g6.active) === JSON.stringify(wantNew), 'active=' + JSON.stringify(g6.active) + ' want=' + JSON.stringify(wantNew));
+
+  // G7 — the signed chain still verifies after all this toggling (undone flag is outside the signed payload)
+  var g7 = await page.evaluate(function () { return window.Bonsai.oplog.verify(); });
+  chk('G7 signed chain still verifies after fork/switch toggling', g7.ok === true, 'tip=' + String(g7.tip).slice(0, 12));
+
+  // G8 — no load failures / page errors anywhere in the run
+  var bad = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('G8 no script LOAD_FAIL / pageerror', bad.length === 0, bad.join(' | '));
+
+  console.log('W-MODELLER-GIT-HISTORY: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('FATAL', e); process.exit(1); });

--- a/modeller/tests/witness_modeller_redo_order.js
+++ b/modeller/tests/witness_modeller_redo_order.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-MODELLER-REDO-ORDER: node witness against the REAL bonsai_oplog.js + REAL
+ * kernel_ops.js (sql.js chain). Read the log after every run — exit code alone is not evidence.
+ * Spec: prompts/MODELLER_GIT_FAITHFUL_HISTORY.md Phase 1.
+ *
+ * Issue under test: redo() picked `undoneRows[undoneRows.length-1]` — the HIGHEST-id undone row
+ * ("most recently created"), the OPPOSITE of correct LIFO redo order. The proven invariant, already
+ * live in both viewer/kernel_ops.js redoOp and erp/kernel_ops.js redoOp, is "redo the LOWEST-id undone
+ * row" (the one nearest the active/undone boundary — the one undo() removed MOST RECENTLY). Fixed to
+ * `undoneRows[0]`.
+ *
+ * Checks:
+ *   R1 baseline   — 3 standalone commits (ids rising), all active
+ *   R2 undo-twice — undo() ×2 ⇒ the two HIGHEST ids are undone, lowest survives active
+ *   R3 redo-order — ONE redo() reactivates the LOWER of the two undone ids first (not the higher one)
+ *   R4 redo-again — a SECOND redo() brings back the remaining (higher) id — full restore, correct order
+ *   R5 chain      — verifyChain ok throughout (undone flag is outside the signed payload)
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+
+// ── node shims for the window-IIFE modules ──
+global.window = global.window || {};
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+var _store = {};
+global.localStorage = { getItem: k => (k in _store ? _store[k] : null), setItem: (k, v) => { _store[k] = String(v); }, removeItem: k => { delete _store[k]; } };
+
+var ROOT = path.join(__dirname, '..');
+require(path.join(ROOT, 'kernel_ops.js'));            // → window.KernelOps
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+window.initSqlJs = function () { return initSqlJs({ wasmBinary: wasmBinary }); };
+window.Bonsai = { foldChainToScene: async function (ops) { return { solids: ops.length, triangleCount: 0 }; },
+  author: async function () { return { triangleCount: 0 }; },
+  clearKernelCache: function () {} };
+require(path.join(ROOT, 'bonsai_oplog.js'));          // → window.Bonsai.oplog (REAL, node-shimmed)
+var O = window.Bonsai.oplog;
+
+var pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+function activeIds() { return O._allGeom().filter(o => !o.undone).map(o => o.id).sort((a, b) => a - b); }
+function undoneIds() { return O._allGeom().filter(o => o.undone).map(o => o.id).sort((a, b) => a - b); }
+
+(async function () {
+  console.log('═══ W-MODELLER-REDO-ORDER — redo() picks lowest-id-undone first (REAL oplog + kernel_ops chain) ═══');
+  await O._ensureDb();
+
+  // R1 — 3 standalone commits, no gesture/parent relation between them
+  var s1 = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { w: 1 } }, {});
+  var s2 = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { w: 2 } }, {});
+  var s3 = await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { w: 3 } }, {});
+  chk('R1 baseline all 3 active', JSON.stringify(activeIds()) === JSON.stringify([s1.id, s2.id, s3.id]),
+    'active=' + JSON.stringify(activeIds()));
+
+  // R2 — undo the two most recent (LIFO: highest-id active goes first, each undo())
+  await O.undo();   // removes s3 (highest active)
+  await O.undo();   // removes s2 (now-highest active)
+  chk('R2 undo-twice leaves lowest (s1) active, {s2,s3} undone',
+    JSON.stringify(activeIds()) === JSON.stringify([s1.id]) && JSON.stringify(undoneIds()) === JSON.stringify([s2.id, s3.id]),
+    'active=' + JSON.stringify(activeIds()) + ' undone=' + JSON.stringify(undoneIds()));
+
+  // R3 — the FIRST redo must bring back s2 (lowest undone id = nearest the active boundary),
+  //      NOT s3 (highest undone id = "most recently created", the pre-fix bug's pick).
+  var r1 = await O.redo();
+  chk('R3 redo-order picks LOWER undone id (s2) first, not higher (s3)', r1.redone === s2.id,
+    'redone=' + r1.redone + ' want=' + s2.id + ' (bug would redone=' + s3.id + ')');
+  chk('R3 s3 still undone after first redo', undoneIds().indexOf(s3.id) >= 0 && activeIds().indexOf(s2.id) >= 0);
+
+  // R4 — the second redo brings back s3, completing correct-order full restore
+  var r2 = await O.redo();
+  chk('R4 redo-again completes restore in order', r2.redone === s3.id && JSON.stringify(activeIds()) === JSON.stringify([s1.id, s2.id, s3.id]),
+    'redone=' + r2.redone + ' active=' + JSON.stringify(activeIds()));
+
+  // R5 — chain still verifies after all the toggling
+  var v = await O.verify();
+  chk('R5 chain-intact after undo/redo toggling', v.ok === true, 'tip=' + String(v.tip).slice(0, 12));
+
+  console.log('W-MODELLER-REDO-ORDER ' + (fail ? 'FAIL' : 'PASS') + '  pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('FATAL', e); process.exit(1); });


### PR DESCRIPTION
## Summary
- **Phase 1 (fix):** `bonsai_oplog.js` `redo()` picked the highest-id undone row — opposite of the proven LIFO invariant in `viewer/kernel_ops.js`/`erp/kernel_ops.js` (lowest-id-undone-first). Fixed; new witness proves 3/6 red on old code, 6/6 green fixed.
- **Phase 2 (feature):** Reuses the Viewer's own `common/history_bar.js` git-faithful tree engine for Modeller (no new branch mechanism invented) — `modeller_history.js` wraps `commit`/`commitGesture`, records a `BUILDING_OPEN` milestone, routes Ctrl+Z/Ctrl+⇧Z through the tree.
- Live witness proves the core ask: undo → different edit → switch back to the abandoned branch restores it exactly, not compounded with the new one.
- **One found, documented, deliberately-unfixed gap** (G6 in the witness): switching directly between two non-trunk branches picks the wrong row — a latent limitation of the shared `history_bar.js` + kernel `redo()`-by-guess design that predates this PR and equally affects the Viewer. Needs a targeted `redo(id)` kernel primitive; out of scope here. Documented in `prompts/MODELLER_GIT_FAITHFUL_HISTORY.md` (bim-compiler repo).

Spec: `prompts/MODELLER_GIT_FAITHFUL_HISTORY.md`.

## Test plan
- [x] `witness_modeller_redo_order.js` 6/6 PASS (non-vacuous: 3/6 fail on pre-fix code)
- [x] `witness_modeller_git_history.js` 7/8 PASS (G6 is a documented known gap, not hidden)
- [x] All named regression witnesses re-run clean: `witness_gesture_undo.js`, `witness_modeller_dw_oplog.js`, `witness_modeller_router_nnchain.js`, `bonsai_rotate_solid_live.js`, `bonsai_scale_live.js`, `witness_e2e_save.js`
- [x] Phase 3 (UI swap) not attempted — `history_bar.js` never `.open()`'d, today's `#hist-slider` UI unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)