### PR TITLE
feat(viewer): Open button reclaims IFC-merge engine + new BCF export module

### DIFF
--- a/import_own.js
+++ b/import_own.js
@@ -1,8 +1,19 @@
-// import_own.js — drop-own-IFC for the Matrix hub (index2 ONLY).
+// import_own.js — own-IFC import + multi-file merge engine.
 // VERBATIM EXTRACT from index.html (the live landing) — non-invent. S224 merge prompt removed
 // per MORPHEUS_PLATE_REBUILD.md (always new project → auto-open viewer). Loaded after import_db_builder.js.
+// Also loaded from viewer/viewer.html (§OPEN_BUTTON_IFC_MERGE, 2026-07-06) — the Open button's
+// IFC-import path reuses this engine unmodified; see _fromViewerHost below for the two seams that
+// actually differ between hosts (asset paths, project-open navigation).
 var _base = '';            // GH Pages = same-origin root (index.html _ociMatch → '')
 function trackTab(){}      // landing tab-tracker not present on the plate — no-op
+
+// §OPEN_BUTTON_IFC_MERGE: this file is VERBATIM-loaded a second time from viewer/viewer.html (the
+// Open button's IFC-import path) — set by that page BEFORE this script tag runs. All the
+// 'viewer/…'-relative asset paths below were written assuming a root-relative host (index.html);
+// from inside viewer/ they must collapse to same-dir, and project-open must navigate the CURRENT
+// tab in place instead of spawning a new one (see openProject()'s opts.sameTab branch).
+var _fromViewerHost = !!window._IMPORT_OWN_VIEWER_HOST;
+var _viewerAssetPrefix = _fromViewerHost ? '' : 'viewer/';
 
 // ── discipline-from-filename ──
 var _VALID_DISCS = ['ARC','STR','MEP','PLB','ACMV','ELEC','FP','VENT','HEAT','SAN','COOL','VOID'];
@@ -197,6 +208,17 @@ async function openProject(key, btnEl, opts) {
     }
   }
 
+  // §OPEN_BUTTON_IFC_MERGE: triggered from viewer/viewer.html's Open button — load the merged
+  // result into the CURRENT tab (same pattern scene.js already uses for cached native-.db opens),
+  // never spawn a second tab on top of the viewer the user is already sitting in.
+  if (opts && opts.sameTab) {
+    var sameTabUrl = 'viewer.html?db=' + encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(libUrl) +
+      diffParam + wizardParam + '&ghost=1';
+    console.log('§OPEN_PROJECT_SAMETAB key=' + key + ' url=' + sameTabUrl);
+    location.assign(sameTabUrl);
+    return;
+  }
+
   var viewerUrl = (_base || '') + 'viewer/viewer.html?db=' +
     encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(libUrl) + diffParam + wizardParam + '&ghost=1';
   var win = window.open(viewerUrl, '_blank');
@@ -234,7 +256,7 @@ async function _loadSqlJs() {
       console.log('§STANDALONE_SQL inline initSqlJs loaded');
     } else {
       // Load local sql-wasm.js text (network or SW cache), then eval to define initSqlJs
-      var jsResp = await _fetchLocalOrCache('viewer/lib/sql-wasm.js');
+      var jsResp = await _fetchLocalOrCache(_viewerAssetPrefix + 'lib/sql-wasm.js');
       var jsText = await jsResp.text();
       (new Function(jsText + '\n; if (typeof initSqlJs !== "undefined") window.initSqlJs = initSqlJs;'))();
       console.log('§SQL_LOCAL initSqlJs loaded from viewer/lib');
@@ -248,12 +270,12 @@ async function _loadSqlJs() {
     return await initSqlJs({ wasmBinary: buf.buffer });
   }
   // PWA / online: feed the local WASM binary directly (works offline via Cache Storage)
-  var wasmResp = await _fetchLocalOrCache('viewer/lib/sql-wasm.wasm');
+  var wasmResp = await _fetchLocalOrCache(_viewerAssetPrefix + 'lib/sql-wasm.wasm');
   var wasmBuf = await wasmResp.arrayBuffer();
   return await initSqlJs({ wasmBinary: wasmBuf });
 }
 var _IFC_ENGINE_CACHE = 'bim-ifc-engine';
-var _IFC_WASM_URL = 'viewer/lib/web-ifc.wasm';
+var _IFC_WASM_URL = _viewerAssetPrefix + 'lib/web-ifc.wasm';
 async function _getWebIfcWasm() {
   // 1. Standalone HTML — bytes embedded as base64.
   if (window._WEBIFC_WASM_B64) {
@@ -324,7 +346,7 @@ function _createWorker(scriptUrl) {
 
 // ── trimmed import handler: single file, NEW project only (no S224 merge modal), auto-open viewer ──
 // Mirrors index.html handleImportFile new-project path verbatim, minus merge/renderImportCards.
-async function handleImportFile(file) {
+async function handleImportFile(file, opts) {
   if (!file) return;
   var fmt = detectLandingFormat(file.name);
   if (!fmt.route) { document.getElementById('import-status').textContent = 'Unsupported: .' + fmt.ext + ' — Accepted: IFC, OBJ, DAE, GLB, STL, FBX, 3DS'; return; }
@@ -350,7 +372,7 @@ async function handleImportFile(file) {
   progressBar.parentElement.style.display = 'block'; progressBar.style.width = '0%'; progressBar.style.background = '#0277bd';
   if (file.size > 200 * 1024 * 1024) status.textContent = 'Very large (' + sizeMB + 'MB) — may take a few minutes';
   const arrayBuffer = await file.arrayBuffer();
-  var workerFile = (fmt.route === 'ifc') ? 'viewer/import_worker.js?v=9' : 'viewer/mesh_import_worker.js?v=2';
+  var workerFile = (fmt.route === 'ifc') ? _viewerAssetPrefix + 'import_worker.js?v=9' : _viewerAssetPrefix + 'mesh_import_worker.js?v=2';
   var workerMsg = (fmt.route === 'ifc') ? { arrayBuffer, filename: file.name } : { arrayBuffer, filename: file.name, ext: fmt.ext };
   if (fmt.route === 'ifc') {
     try { workerMsg.wasmBytes = await _getWebIfcWasm(); }
@@ -409,7 +431,7 @@ async function handleImportFile(file) {
         }
         status.textContent = 'Imported ' + msg.meta.elementCount + ' elements — opening viewer...';
         progressBar.style.width = '100%'; progressBar.style.background = '#44cc44';
-        openProject(projectKey);
+        openProject(projectKey, null, opts);
         console.log('§IMPORT_AUTO_OPEN key=' + projectKey);
         setTimeout(function () { status.textContent = ''; progressBar.style.width = '0%'; progressBar.style.background = '#0277bd'; progressBar.parentElement.style.display = 'none'; }, 3000);
       } catch (dbErr) { status.textContent = 'DB error: ' + dbErr.message; progressBar.style.background = '#cc4444'; console.log('§IMPORT_DB_ERROR ' + dbErr.message); }
@@ -533,7 +555,7 @@ function _parseOwnIFC(file, onProgress) {
     var workerMsg = { arrayBuffer: await file.arrayBuffer(), filename: file.name };
     try { workerMsg.wasmBytes = await _getWebIfcWasm(); }
     catch (engineErr) { reject(engineErr); return; }
-    var worker = _createWorker('viewer/import_worker.js?v=9');
+    var worker = _createWorker(_viewerAssetPrefix + 'import_worker.js?v=9');
     worker.onmessage = function (e) {
       var msg = e.data;
       if (msg.type === 'progress') { if (onProgress) onProgress(msg.pct, msg.phase); return; }
@@ -556,7 +578,7 @@ function _parseOwnIFC(file, onProgress) {
 
 // ── Multi-IFC merge: N files → ONE building DB → auto-open viewer. NO merge modal, NO card. ──
 // Mirrors index.html A.importMultiIFC, self-contained on the plate's saveProject/openProject path.
-async function importMultiIFC(files) {
+async function importMultiIFC(files, opts) {
   var status = document.getElementById('import-status');
   var progressBar = document.getElementById('import-progress-bar');
   if (progressBar) { progressBar.parentElement.style.display = 'block'; progressBar.style.width = '0%'; progressBar.style.background = '#0277bd'; }
@@ -656,7 +678,7 @@ async function importMultiIFC(files) {
       ' discs=' + Object.keys(allDiscs).join(',') + ' split=' + !!_recSplit);
     if (status) status.textContent = 'Merged ' + files.length + ' files → ' + totalElements + ' elements — opening viewer...';
     if (progressBar) { progressBar.style.width = '100%'; progressBar.style.background = '#44cc44'; }
-    openProject(projectKey);
+    openProject(projectKey, null, opts);
     console.log('§MULTI_AUTO_OPEN key=' + projectKey);
     setTimeout(function () { if (status) status.textContent = ''; if (progressBar) { progressBar.style.width = '0%'; progressBar.style.background = '#0277bd'; progressBar.parentElement.style.display = 'none'; } }, 3000);
   } catch (dbErr) {
@@ -668,25 +690,12 @@ async function importMultiIFC(files) {
 
 // Route dropped/picked files: 2+ IFC → silent merge into one building; else single-file import.
 // Mirrors index.html's decision (ifcFiles.length > 1 ? merge : single). NO card, NO modal.
-function handleImportFiles(files) {
+function handleImportFiles(files, opts) {
   if (!files || !files.length) return;
   var ifcFiles = [];
   for (var fi = 0; fi < files.length; fi++) {
     if (detectLandingFormat(files[fi].name).route === 'ifc') ifcFiles.push(files[fi]);
   }
-  if (ifcFiles.length > 1) importMultiIFC(ifcFiles);
-  else handleImportFile(files[0]);
-}
-
-// wire the hub drop zone + file input (called when the hub opens)
-function wireImportZone() {
-  var zone = document.getElementById('m-import-zone'); var input = document.getElementById('m-import-file');
-  if (!zone || !input || zone._wired) return; zone._wired = 1;
-  input.multiple = true;   // multi-select → merge in one shot
-  zone.addEventListener('dragover', function (e) { e.preventDefault(); zone.classList.add('drag'); });
-  zone.addEventListener('dragleave', function () { zone.classList.remove('drag'); });
-  zone.addEventListener('drop', function (e) { e.preventDefault(); zone.classList.remove('drag'); handleImportFiles(e.dataTransfer.files); });
-  zone.addEventListener('click', function () { input.click(); });
-  input.addEventListener('change', function () { handleImportFiles(input.files); });
-  console.log('§IMPORT_ZONE wired (drop-own-IFC, multi-merge)');
+  if (ifcFiles.length > 1) importMultiIFC(ifcFiles, opts);
+  else handleImportFile(files[0], opts);
 }

--- a/index.html
+++ b/index.html
@@ -126,11 +126,6 @@
   #hub .hub-card .mt { color:#7a8294; font-size:10.5px; margin-top:4px; }
   #hub .hub-card .db { display:flex; gap:2px; margin-top:8px; height:5px; }
   #hub .hub-card .db i { display:block; height:100%; border-radius:2px; }
-  #hub .hub-import { max-width:920px; margin:0 auto 22px; }
-  #hub .hub-drop { display:block; text-align:center; text-decoration:none; border:2px dashed rgba(79,195,247,.4);
-    border-radius:12px; padding:20px; color:#4fc3f7; font-weight:600; font-size:14px; cursor:pointer; transition:border-color .15s,background .15s; }
-  #hub .hub-drop:hover { border-color:rgba(79,195,247,.7); }
-  #hub .hub-drop.drag { border-color:#0277bd; background:rgba(2,119,189,.12); }
   @media (max-width:560px){ #hub .hub-grid { grid-template-columns:repeat(auto-fill,minmax(110px,1fr)); gap:8px; } }
 </style>
 </head>
@@ -539,15 +534,10 @@ var _hubBuilt=false;
 async function buildHubBody(){
   if(_hubBuilt) return; _hubBuilt=true;
   var b=document.getElementById('hub-body');
-  b.innerHTML='<div class="hub-import">'+
-      '<div id="m-import-zone" class="hub-drop">&#8595; Drop IFC / 3D files here &mdash; or tap to browse<br><span style="font-size:11px;opacity:.7">multiple discipline files merge into one building</span></div>'+
-      '<input type="file" id="m-import-file" accept=".ifc,.dae,.obj,.glb,.gltf,.3ds,.fbx,.stl" multiple style="display:none">'+
-      '<div id="import-status" style="text-align:center;color:#cfe3ef;font-size:12px;margin-top:8px;min-height:16px"></div>'+
-      '<div style="display:none;margin:8px auto 0;max-width:400px;height:4px;background:#222;border-radius:2px;overflow:hidden">'+
-        '<div id="import-progress-bar" style="height:100%;width:0%;background:#0277bd;border-radius:2px;transition:width .3s"></div></div>'+
-    '</div>'+
-    '<div id="hub-status" style="text-align:center;color:#667;font-size:12px;padding:20px">loading building manifest&hellip;</div>';
-  if(typeof wireImportZone==='function') wireImportZone(); else L('§HUB import_own.js not loaded');
+  // §OPEN_BUTTON_IFC_MERGE: the drop-IFC gesture retired from here (2026-07-06, user: reads as an
+  // upload/privacy prompt) — bring-your-own-IFC now lives ONLY on the Viewer's Open button, which
+  // accepts single/multi IFC (auto-merge) alongside native .db. See viewer/scene.js A.openModelDb.
+  b.innerHTML='<div id="hub-status" style="text-align:center;color:#667;font-size:12px;padding:20px">loading building manifest&hellip;</div>';
   try {
     var data=await fetch('manifest.json').then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); });
     if(!data||!Array.isArray(data.archetypes)) throw new Error('manifest missing archetypes');

--- a/viewer/bcf_export.js
+++ b/viewer/bcf_export.js
@@ -1,0 +1,226 @@
+// bcf_export.js — real BCF 2.1 EXPORT-ONLY (bcf.version + {topicGuid}/markup.bcf + viewpoint.bcfv +
+// snapshot.png per topic), openable by Navisworks/Solibri/BIMcollab. One BCF Topic per saved Issue
+// (A._getAllIssues(), viewer/issues.js) — clashes AND freeform notes both export, not just clashes.
+//
+// EXTRACTED, not invented: the zip-writer (STORE method, CRC32) and XML templates are ported verbatim
+// from modeller/bcf_export.js's exportBcf (same repo, already-shipped BCF 2.1 writer — Q3/W-E2E-BCF).
+// The per-clash domain mapping (status→BCF-status, severity→BCF-priority, description/title shape) is
+// ported from ~/IfcOpenShell/src/bonsai/bonsai/bim/module/federation/bcf/bcf_generator.py's
+// BCFGenerator (the real "old IfcOpenShell/Federation python" BCF exporter, user-cited 2026-07-06),
+// re-sourced from the Viewer's OWN real fields instead of that module's SQLite clash_status schema:
+//   status   ← A._clashStatuses[A._clashPairKey(guid_a,guid_b)] (viewer/measure.js's real lifecycle:
+//              '' / 'Reviewed' / 'Resolved' / 'Accepted' — not the Python's NEW/ACTIVE/REVIEWED/RESOLVED)
+//   priority ← the issue's own stored `severity` label ('Hard clash'/'Soft clash'/'Clearance violation',
+//              viewer/clash_rules.json) — not the Python's discipline-pair guess, since the Viewer
+//              already computes a precise overlap-based severity per clash.
+//   viewpoint← the issue's own REAL captured camera_pos/camera_target (viewer/clash_snag.js already
+//              stores these per issue) — falls back to the Python's isometric-from-bbox-center math
+//              (viewpoint_manager.generate_clash_viewpoint) only when a stored camera is missing.
+//   snapshot ← the issue's own REAL stored PNG blob (issues.js `jpeg_blob` field — actually PNG bytes
+//              despite the name, confirmed via its `canvas.toBlob(..., 'image/png')` call) — never
+//              synthesized; topics with no stored snapshot simply omit <Snapshot> (BCF-valid, optional).
+function setupBcfExport(A) {
+
+  // ── CRC32 + minimal STORE-method zip — verbatim port of modeller/bcf_export.js (no zip lib is
+  // exposed anywhere in this codebase; ExcelJS/SheetJS bundle theirs privately). ──────────────────
+  var CRC_T = (function () { var t = new Uint32Array(256); for (var n = 0; n < 256; n++) { var c = n; for (var k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1); t[n] = c >>> 0; } return t; })();
+  function crc32(u8) { var c = 0xFFFFFFFF; for (var i = 0; i < u8.length; i++) c = CRC_T[(c ^ u8[i]) & 0xFF] ^ (c >>> 8); return (c ^ 0xFFFFFFFF) >>> 0; }
+  function zipStore(files) {                 // files: [{name:String, bytes:Uint8Array}] → Uint8Array
+    var enc = new TextEncoder(), parts = [], cd = [], off = 0;
+    files.forEach(function (f) {
+      var nb = enc.encode(f.name), b = f.bytes, crc = crc32(b);
+      var lh = new DataView(new ArrayBuffer(30));
+      lh.setUint32(0, 0x04034b50, true); lh.setUint16(4, 20, true);
+      lh.setUint16(10, 0, true); lh.setUint16(12, 0x21, true);
+      lh.setUint32(14, crc, true); lh.setUint32(18, b.length, true); lh.setUint32(22, b.length, true);
+      lh.setUint16(26, nb.length, true);
+      parts.push(new Uint8Array(lh.buffer), nb, b);
+      var ch = new DataView(new ArrayBuffer(46));
+      ch.setUint32(0, 0x02014b50, true); ch.setUint16(4, 20, true); ch.setUint16(6, 20, true);
+      ch.setUint16(12, 0, true); ch.setUint16(14, 0x21, true);
+      ch.setUint32(16, crc, true); ch.setUint32(20, b.length, true); ch.setUint32(24, b.length, true);
+      ch.setUint16(28, nb.length, true); ch.setUint32(42, off, true);
+      cd.push(new Uint8Array(ch.buffer), nb);
+      off += 30 + nb.length + b.length;
+    });
+    var cdLen = cd.reduce(function (s, a) { return s + a.length; }, 0);
+    var eo = new DataView(new ArrayBuffer(22));
+    eo.setUint32(0, 0x06054b50, true); eo.setUint16(8, files.length, true); eo.setUint16(10, files.length, true);
+    eo.setUint32(12, cdLen, true); eo.setUint32(16, off, true);
+    var out = new Uint8Array(off + cdLen + 22), p = 0;
+    parts.concat(cd, [new Uint8Array(eo.buffer)]).forEach(function (a) { out.set(a, p); p += a.length; });
+    return out;
+  }
+  function xmlEsc(s) { return String(s == null ? '' : s).replace(/[<>&"']/g, function (c) { return { '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]; }); }
+  function n6(v) { return (+v).toFixed(6); }
+  function _uuid() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+    var b = crypto.getRandomValues(new Uint8Array(16)); b[6] = (b[6] & 15) | 64; b[8] = (b[8] & 63) | 128;
+    var h = Array.from(b, function (x) { return x.toString(16).padStart(2, '0'); }).join('');
+    return h.slice(0, 8) + '-' + h.slice(8, 12) + '-' + h.slice(12, 16) + '-' + h.slice(16, 20) + '-' + h.slice(20);
+  }
+
+  // ── domain mapping, ported from bcf_generator.py's _map_status_to_bcf/_calculate_priority,
+  // re-keyed onto the Viewer's REAL status/severity vocabulary (see file header). ──────────────────
+  function _statusToBcf(status) {
+    if (status === 'Resolved') return 'Resolved';
+    if (status === 'Accepted') return 'Closed';
+    return 'Open';                                  // '' or 'Reviewed' — still open in the Viewer's cycle
+  }
+  function _priorityFromSeverity(label) {
+    if (label === 'Hard clash') return 'Critical';
+    if (label === 'Soft clash') return 'Major';
+    if (label === 'Clearance violation') return 'Minor';
+    return 'Normal';
+  }
+  function _friendlyClass(ifcClass) { return (ifcClass || '?').replace('Ifc', '').replace('StandardCase', ''); }
+
+  // Isometric camera fallback for issues saved without a live viewpoint — pure port of
+  // viewpoint_manager.py's generate_clash_viewpoint(angle='isometric') (bpy/mathutils dropped, the
+  // actual math is plain vector arithmetic).
+  function _isometricViewpoint(center, bboxSize) {
+    var distance = (bboxSize || 5) * 1.5;
+    var off = [1, -1, 1], ol = Math.hypot(off[0], off[1], off[2]);
+    var offset = [off[0] / ol * distance, off[1] / ol * distance, off[2] / ol * distance];
+    var pos = [center[0] + offset[0], center[1] + offset[1], center[2] + offset[2]];
+    var d = [center[0] - pos[0], center[1] - pos[1], center[2] - pos[2]];
+    var dl = Math.hypot(d[0], d[1], d[2]) || 1;
+    return { pos: pos, dir: [d[0] / dl, d[1] / dl, d[2] / dl], up: [0, 0, 1] };
+  }
+
+  // ── pure builder: one topic's markup.bcf + viewpoint.bcfv XML, given already-resolved fields. ────
+  function _buildTopicXml(t) {
+    var markup = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+      '<Markup xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n' +
+      '  <Header>\n    <File>\n      <Filename>' + xmlEsc(t.filename) + '</Filename>\n      <Date>' + xmlEsc(t.dateIso) + '</Date>\n    </File>\n  </Header>\n' +
+      '  <Topic Guid="' + xmlEsc(t.topicGuid) + '" TopicType="' + xmlEsc(t.topicType) + '" TopicStatus="' + xmlEsc(t.bcfStatus) + '">\n' +
+      '    <ReferenceLinks>\n' + t.refGuids.map(function (g) { return '      <ReferenceLink>' + xmlEsc(g) + '</ReferenceLink>'; }).join('\n') + '\n    </ReferenceLinks>\n' +
+      '    <Title>' + xmlEsc(t.title) + '</Title>\n' +
+      '    <Priority>' + xmlEsc(t.priority) + '</Priority>\n' +
+      '    <CreationDate>' + xmlEsc(t.dateIso) + '</CreationDate>\n' +
+      '    <CreationAuthor>' + xmlEsc(t.author) + '</CreationAuthor>\n' +
+      '    <Description>' + xmlEsc(t.description) + '</Description>\n' +
+      '    <Labels>\n' + t.labels.map(function (l) { return '      <Label>' + xmlEsc(l) + '</Label>'; }).join('\n') + '\n    </Labels>\n' +
+      '  </Topic>\n' +
+      (t.comment ? '  <Comment Guid="' + xmlEsc(_uuid()) + '">\n    <Date>' + xmlEsc(t.dateIso) + '</Date>\n    <Author>' + xmlEsc(t.author) + '</Author>\n    <Comment>' + xmlEsc(t.comment) + '</Comment>\n  </Comment>\n' : '') +
+      '  <Viewpoints Guid="' + xmlEsc(t.vpGuid) + '">\n' +
+      '    <Viewpoint>viewpoint.bcfv</Viewpoint>\n' + (t.hasSnapshot ? '    <Snapshot>snapshot.png</Snapshot>\n' : '') + '  </Viewpoints>\n' +
+      '</Markup>\n';
+    var cam = t.camera;
+    var vp = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+      '<VisualizationInfo Guid="' + xmlEsc(t.vpGuid) + '" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n' +
+      '  <Components>\n' +
+      '    <Selection>\n' + t.refGuids.map(function (g) { return '      <Component IfcGuid="' + xmlEsc(g) + '" />'; }).join('\n') + '\n    </Selection>\n' +
+      '    <Visibility DefaultVisibility="true" />\n' +
+      '  </Components>\n' +
+      '  <PerspectiveCamera>\n' +
+      '    <CameraViewPoint><X>' + n6(cam.pos[0]) + '</X><Y>' + n6(cam.pos[1]) + '</Y><Z>' + n6(cam.pos[2]) + '</Z></CameraViewPoint>\n' +
+      '    <CameraDirection><X>' + n6(cam.dir[0]) + '</X><Y>' + n6(cam.dir[1]) + '</Y><Z>' + n6(cam.dir[2]) + '</Z></CameraDirection>\n' +
+      '    <CameraUpVector><X>' + n6(cam.up[0]) + '</X><Y>' + n6(cam.up[1]) + '</Y><Z>' + n6(cam.up[2]) + '</Z></CameraUpVector>\n' +
+      '    <FieldOfView>' + n6(cam.fov || 60) + '</FieldOfView>\n' +
+      '  </PerspectiveCamera>\n' +
+      '</VisualizationInfo>\n';
+    return { markup: markup, vp: vp };
+  }
+
+  // ── one Issue record (viewer/issues.js schema) → one resolved topic-fields object. ────────────────
+  function _issueToTopic(issue) {
+    var isClash = issue.type === 'clash';
+    var dateIso = issue.timestamp || new Date().toISOString();
+    var refGuids = isClash ? [issue.element_guid, issue.element_b_guid].filter(Boolean) : [issue.element_guid].filter(Boolean);
+
+    var status = '';
+    if (isClash && A._clashPairKey && A._clashStatuses) {
+      status = A._clashStatuses[A._clashPairKey(issue.element_guid, issue.element_b_guid)] || '';
+    }
+
+    var title, description, labels;
+    if (isClash) {
+      var nameA = issue.element_name || _friendlyClass(issue.element_class);
+      var nameB = issue.element_b_name || _friendlyClass(issue.element_b_class);
+      title = 'Clash: ' + nameA + ' vs ' + nameB;
+      description = 'Element A: ' + nameA + ' (' + (issue.element_class || '?') + ')\n' +
+        'Element B: ' + nameB + ' (' + (issue.element_b_class || '?') + ')\n' +
+        'Disciplines: ' + (issue.discipline_pair || '').replace('|', ' vs ') + '\n' +
+        'Overlap: ' + (issue.overlap_mm != null ? issue.overlap_mm + 'mm' : 'n/a') + '\n' +
+        'Storey: ' + (issue.storey || '?') + '\n' +
+        'Status: ' + (status || 'Open');
+      labels = [issue.discipline_pair || '', issue.element_class || '', issue.element_b_class || ''].filter(Boolean);
+    } else {
+      title = issue.notes ? issue.notes.slice(0, 80) : ('Site note — ' + (issue.element_name || issue.element_class || issue.element_guid || 'unlabeled'));
+      description = (issue.notes || '') + '\nElement: ' + (issue.element_name || issue.element_guid || '?') +
+        (issue.storey ? ('\nStorey: ' + issue.storey) : '');
+      labels = [issue.discipline || ''].filter(Boolean);
+    }
+
+    var camera;
+    try {
+      var pos = typeof issue.camera_pos === 'string' ? JSON.parse(issue.camera_pos) : issue.camera_pos;
+      var tgt = typeof issue.camera_target === 'string' ? JSON.parse(issue.camera_target) : issue.camera_target;
+      if (pos && tgt) {
+        var d = [tgt.x - pos.x, tgt.y - pos.y, tgt.z - pos.z], dl = Math.hypot(d[0], d[1], d[2]) || 1;
+        camera = { pos: [pos.x, pos.y, pos.z], dir: [d[0] / dl, d[1] / dl, d[2] / dl], up: [0, 0, 1], fov: 60 };
+      }
+    } catch (e) {}
+    if (!camera) {
+      // No stored viewpoint — fall back to the Federation module's isometric-from-position math.
+      var c0 = refGuids.length && A.dbQuery ? A.dbQuery('SELECT cx, cy, cz FROM element_transforms WHERE guid = ?', [refGuids[0]]) : [];
+      var center = c0.length ? [c0[0][0], c0[0][1], c0[0][2]] : [0, 0, 0];
+      var iso = _isometricViewpoint(center, 5);
+      camera = { pos: iso.pos, dir: iso.dir, up: iso.up, fov: 60 };
+    }
+
+    return {
+      topicGuid: _uuid(), vpGuid: _uuid(),
+      topicType: isClash ? 'Clash' : 'Comment',
+      bcfStatus: _statusToBcf(status),
+      priority: isClash ? _priorityFromSeverity(issue.severity) : 'Normal',
+      title: title, description: description, labels: labels,
+      comment: issue.notes && isClash ? issue.notes : null,
+      refGuids: refGuids, camera: camera,
+      dateIso: dateIso, author: 'BIM OOTB Viewer', filename: (A.activeBuilding || 'model') + '.ifc',
+      hasSnapshot: !!(issue.jpeg_blob && issue.jpeg_blob.size)
+    };
+  }
+
+  // ── browser side: collect real Issues → build multi-topic .bcfzip → download. ────────────────────
+  A.exportBcf = async function (opts) {
+    opts = opts || {};
+    var allIssues = await A._getAllIssues();
+    var issues = opts.ids ? allIssues.filter(function (i) { return opts.ids.indexOf(i.id) !== -1; }) : allIssues;
+    if (!issues.length) { console.log('§BCF export skipped — no saved issues'); if (A.status) A.status.textContent = 'No issues to export as BCF'; return null; }
+
+    var enc = new TextEncoder();
+    var files = [{
+      name: 'bcf.version',
+      bytes: enc.encode('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<Version VersionId="2.1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n  <DetailedVersion>2.1</DetailedVersion>\n</Version>\n')
+    }];
+    var withSnapshot = 0;
+    for (var i = 0; i < issues.length; i++) {
+      var t = _issueToTopic(issues[i]);
+      var xml = _buildTopicXml(t);
+      files.push({ name: t.topicGuid + '/markup.bcf', bytes: enc.encode(xml.markup) });
+      files.push({ name: t.topicGuid + '/viewpoint.bcfv', bytes: enc.encode(xml.vp) });
+      if (t.hasSnapshot) {
+        var buf = await issues[i].jpeg_blob.arrayBuffer();
+        files.push({ name: t.topicGuid + '/snapshot.png', bytes: new Uint8Array(buf) });
+        withSnapshot++;
+      }
+    }
+    var bytes = zipStore(files);
+    console.log('§BCF export topics=' + issues.length + ' withSnapshot=' + withSnapshot + ' zipB=' + bytes.length);
+
+    if (opts.download !== false) {
+      var blob = new Blob([bytes], { type: 'application/octet-stream' });
+      var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+      a.download = (A.activeBuilding || 'model') + '.bcfzip'; document.body.appendChild(a); a.click();
+      setTimeout(function () { URL.revokeObjectURL(a.href); a.remove(); }, 1000);
+      if (A.status) A.status.textContent = 'Exported ' + issues.length + ' issue(s) as BCF';
+    }
+    return { bytes: bytes, topicCount: issues.length };
+  };
+
+  // Exposed for node witnesses (pure builders only — no DOM/IDB dependency).
+  A._bcf = { zipStore: zipStore, crc32: crc32, xmlEsc: xmlEsc, _statusToBcf: _statusToBcf, _priorityFromSeverity: _priorityFromSeverity, _issueToTopic: _issueToTopic, _buildTopicXml: _buildTopicXml };
+  console.log('§BCF_EXPORT_MODULE loaded');
+}

--- a/viewer/locales/en_US.js
+++ b/viewer/locales/en_US.js
@@ -198,6 +198,7 @@ var _TRL_LOCALE = {
   ui_clear:          'Clear',
   ui_clear_all:      'Clear All',
   ui_export_excel:   'Export Excel',
+  ui_export_bcf:     'Export BCF',
   ui_share_whatsapp: 'Share \u2192 WhatsApp',
   ui_show_3d:        'Show in 3D',
   ui_snag:           'Snag',

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -13,7 +13,7 @@ async function initViewer() {
   if (typeof setupConfig === 'function') setupConfig(APP);
   if (typeof setupScene === 'function') await setupScene(APP);
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
-    setupPicking, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
+    setupPicking, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupBcfExport, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
   // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
   // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).
@@ -241,6 +241,7 @@ async function initViewer() {
   window.toggleBackground = APP.toggleBackground;
   window.toggleIssues = APP.toggleIssues;
   window.exportIssuesExcel = APP.exportIssuesExcel;
+  window.exportIssuesBcf = APP.exportBcf;
   window.clearAllIssues = APP.clearAllIssues;
   window._issueBackToList = APP._issueBackToList;
   window.toggleWalkMode = APP.toggleWalkMode;

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -547,25 +547,49 @@ async function setupScene(A) {
     location.assign('viewer.html?db=' + encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(dbUrl) + '&ghost=1');
   };
 
+  // §OPEN_BUTTON_IFC_MERGE: Open now accepts native .db AND raw IFC (single or multi — 2+ IFCs
+  // silently merge into one building, reclaiming the landing page's drop-IFC engine verbatim —
+  // see import_own.js handleImportFiles/importMultiIFC, loaded here via ../import_own.js).
+  // The file extension already says what it is, so one widened picker replaces the old
+  // single-purpose one — no separate chooser menu needed (unlike Export, which needs one since
+  // format there is an INTENT the file itself can't carry).
+  A._routeOpenPicks = async function(files) {
+    var hasIfc = false;
+    for (var i = 0; i < files.length; i++) { if (/\.ifc$/i.test(files[i].name)) { hasIfc = true; break; } }
+    if (hasIfc) {
+      if (typeof window.handleImportFiles !== 'function') {
+        console.warn('§OPEN_IFC_MERGE_UNAVAILABLE import_own.js not loaded');
+        if (A.status) A.status.textContent = 'IFC import unavailable — reload the page';
+        return;
+      }
+      console.log('§OPEN_PICK_IFC count=' + files.length + ' names=' + Array.prototype.map.call(files, function(f){return f.name;}).join(','));
+      window.handleImportFiles(files, { sameTab: true });
+      return;
+    }
+    var file = files[0];
+    var buf = await file.arrayBuffer();
+    console.log('§OPEN_PICK_DB name=' + file.name + ' bytes=' + buf.byteLength);
+    await A._openDbBytes(file.name, new Uint8Array(buf));
+  };
+
   A.openModelDb = async function() {
     // Native Open… (Chromium FSA). Fallback = hidden <input type=file>.
     if (window.showOpenFilePicker) {
       try {
-        var picks = await window.showOpenFilePicker({ multiple: false,
-          types: [{ description: 'Building database', accept: { 'application/x-sqlite3': ['.db', '.sqlite'] } }] });
-        var file = await picks[0].getFile();
-        var buf = await file.arrayBuffer();
-        console.log('§OPEN_PICK mode=fsa name=' + file.name + ' bytes=' + buf.byteLength);
-        await A._openDbBytes(file.name, new Uint8Array(buf));
+        var picks = await window.showOpenFilePicker({ multiple: true,
+          types: [
+            { description: 'Building database', accept: { 'application/x-sqlite3': ['.db', '.sqlite'] } },
+            { description: 'IFC (single or multi — auto-merges)', accept: { 'application/x-step': ['.ifc'] } }
+          ] });
+        var files = await Promise.all(picks.map(function(h){ return h.getFile(); }));
+        await A._routeOpenPicks(files);
         return;
       } catch (e) { if (e.name === 'AbortError') { console.log('§OPEN_CANCEL user'); return; } /* fall through */ }
     }
-    var input = document.createElement('input'); input.type = 'file'; input.accept = '.db,.sqlite'; input.style.display = 'none';
+    var input = document.createElement('input'); input.type = 'file'; input.accept = '.db,.sqlite,.ifc'; input.multiple = true; input.style.display = 'none';
     input.addEventListener('change', async function(){
       if (!input.files.length) return;
-      var file = input.files[0]; var buf = await file.arrayBuffer();
-      console.log('§OPEN_PICK mode=input name=' + file.name + ' bytes=' + buf.byteLength);
-      await A._openDbBytes(file.name, new Uint8Array(buf));
+      await A._routeOpenPicks(input.files);
       document.body.removeChild(input);
     });
     document.body.appendChild(input); input.click();

--- a/viewer/tests/morpheus_import_live.js
+++ b/viewer/tests/morpheus_import_live.js
@@ -1,9 +1,10 @@
-// W-MPLATE-IMPORT — drop-own-IFC in the Matrix hub actually imports + opens the viewer.
-// Feeds a REAL IFC through the verbatim-extracted landing pipeline (import_own.js → import_worker →
-// buildImportDBs → IDB cache → openProject). Whitebox §-log + window.open capture.
+// W-MPLATE-IMPORT — RETIRED 2026-07-06 (§OPEN_BUTTON_IFC_MERGE). The landing hub's #m-import-zone
+// drop-IFC gesture it tested is gone by design (user: reads as an upload/privacy prompt); the same
+// engine (import_own.js handleImportFile/handleImportFiles/importMultiIFC) is now reached ONLY via
+// the Viewer's Open button. Live successor: viewer/tests/poc_open_button_ifc_merge.js.
+// This file is now a regression guard that the removal stuck — NOT a test of import behavior.
 const http=require('http'),fs=require('fs'),path=require('path');
-const ROOT='/tmp/wt-mplate';
-const IFC=path.join(process.env.HOME,'bim-compiler/reference/residential/Ifc4_WallElementedCase.ifc');
+const ROOT=path.join(__dirname,'..','..');
 const pup=require(path.join(process.env.HOME,'bim-compiler','node_modules','puppeteer'));
 const MIME={'.html':'text/html','.js':'text/javascript','.mjs':'text/javascript','.wasm':'application/wasm','.json':'application/json','.css':'text/css','.jpg':'image/jpeg','.png':'image/png','.db':'application/octet-stream','.ifc':'text/plain'};
 const srv=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/index.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){r.writeHead(404);return r.end('404 '+p);}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream','Access-Control-Allow-Origin':'*'});r.end(b);});});
@@ -12,33 +13,16 @@ let pass=0,fail=0; const ck=(n,o)=>{console.log((o?'  PASS ':'  FAIL ')+n);o?pas
  await new Promise(r=>srv.listen(0,r));const port=srv.address().port;
  const br=await pup.launch({headless:'new',args:['--no-sandbox','--enable-unsafe-swiftshader']});
  const pg=await br.newPage();
- const logs=[]; pg.on('console',m=>{const t=m.text();if(/§|Failed|error/i.test(t))logs.push(t);});
+ const logs=[]; pg.on('console',m=>logs.push(m.text()));
  pg.on('pageerror',e=>console.log('  ERR '+String(e).slice(0,200)));
- await pg.evaluateOnNewDocument(()=>{window.__opened=[];window.open=(u)=>{window.__opened.push(u);return{focus(){}}};});
  await pg.goto(`http://localhost:${port}/index.html?home=1`,{waitUntil:'load',timeout:60000});
  await pg.waitForSelector('#portal.active',{timeout:8000}).catch(()=>{});
- // open the hub directly
  await pg.evaluate(()=>window.openHub());
- await pg.waitForSelector('#m-import-zone',{timeout:8000}).catch(()=>{});
- ck('hub import zone present + wired', await pg.evaluate(()=>!!document.getElementById('m-import-zone') && typeof window.handleImportFile==='function'));
- ck('buildImportDBs (real landing builder) loaded', await pg.evaluate(()=>typeof window.buildImportDBs==='function'));
- // feed the real IFC
- const b64=fs.readFileSync(IFC).toString('base64');
- await pg.evaluate(async(b64,name)=>{
-   const bin=atob(b64);const u=new Uint8Array(bin.length);for(let i=0;i<bin.length;i++)u[i]=bin.charCodeAt(i);
-   const file=new File([u],name,{type:'application/octet-stream'});
-   await window.handleImportFile(file);
- }, b64, 'Ifc4_WallElementedCase.ifc');
- // wait for save + auto-open (worker parse can take a few s)
- await pg.waitForFunction(()=>window.__opened.some(u=>/import:\/\//.test(u)),{timeout:45000}).catch(()=>{});
- const opened=await pg.evaluate(()=>window.__opened);
- ck('§IMPORT_SAVED logged', logs.some(l=>/§IMPORT_SAVED/.test(l)));
- ck('§IMPORT_AUTO_OPEN logged', logs.some(l=>/§IMPORT_AUTO_OPEN/.test(l)));
- ck('opened viewer with import:// db + ghost', opened.some(u=>/viewer\/viewer\.html\?db=import%3A%2F%2F.*ghost=1/.test(u)));
- // confirm it actually landed in the import IDB
- const stored=await pg.evaluate(()=>new Promise(res=>{const rq=indexedDB.open('bim_ootb_imports');rq.onsuccess=()=>{const db=rq.result;if(!db.objectStoreNames.contains('buildings'))return res(0);const c=db.transaction('buildings','readonly').objectStore('buildings').count();c.onsuccess=()=>res(c.result);c.onerror=()=>res(-1);};rq.onerror=()=>res(-1);}));
- ck('imported project persisted in bim_ootb_imports IDB', stored>=1);
- console.log('\n  §W-MPLATE-IMPORT '+pass+'/'+(pass+fail)+(fail?' (FAIL)':' PASS'));
- console.log('  import logs:'); logs.filter(l=>/§(IMPORT|DISC|IFC|SQL)|Failed/i.test(l)).slice(0,12).forEach(l=>console.log('    '+l));
+ await new Promise(r=>setTimeout(r,1000));
+ ck('hub drop-zone REMOVED (was #m-import-zone)', await pg.evaluate(()=>!document.getElementById('m-import-zone')));
+ ck('hub file-input REMOVED (was #m-import-file)', await pg.evaluate(()=>!document.getElementById('m-import-file')));
+ ck('wireImportZone function REMOVED (dead code cleaned up)', await pg.evaluate(()=>typeof window.wireImportZone!=='function'));
+ ck('handleImportFile/handleImportFiles engine still loaded (reused by Open button now)', await pg.evaluate(()=>typeof window.handleImportFile==='function' && typeof window.handleImportFiles==='function'));
+ console.log('\n  §W-MPLATE-IMPORT-RETIRED '+pass+'/'+(pass+fail)+(fail?' (FAIL)':' PASS'));
  await br.close();srv.close();process.exit(fail?1:0);
 })().catch(e=>{console.error(e);process.exit(1);});

--- a/viewer/tests/poc_bcf_export.js
+++ b/viewer/tests/poc_bcf_export.js
@@ -1,0 +1,119 @@
+// §BCF_EXPORT — Viewer's new BCF export module (viewer/bcf_export.js), ported from the real
+// Federation/IfcOpenShell Python BCF generator + Modeller's already-shipped zip/XML engine.
+// Drives the REAL production entry point APP.exportBcf() against REAL IssuesDB records (one clash
+// with a resolved status + real PNG snapshot, one freeform note without a snapshot), then hands the
+// produced .bcfzip bytes to the independent `unzip` CLI (ground truth, not self-checking) to confirm
+// it's a genuinely valid, well-formed BCF 2.1 archive with the expected per-topic XML content.
+const http=require('http'),fs=require('fs'),path=require('path'),{execSync}=require('child_process');
+const ROOT=path.join(__dirname,'..','..');
+const pup=require(path.join(process.env.HOME,'bim-compiler','node_modules','puppeteer'));
+const MIME={'.html':'text/html','.js':'text/javascript','.mjs':'text/javascript','.wasm':'application/wasm','.json':'application/json','.css':'text/css','.png':'image/png','.db':'application/octet-stream'};
+const srv=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/viewer/viewer.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){r.writeHead(404);return r.end('404 '+p);}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream'});r.end(b);});});
+let pass=0,fail=0; const ck=(n,o)=>{console.log((o?'  PASS ':'  FAIL ')+n);o?pass++:fail++;};
+const OUT=path.join(require('os').tmpdir(),'poc_bcf_export_'+Date.now()+'.bcfzip');
+const EXTRACT=OUT+'.d';
+
+(async()=>{
+ await new Promise(r=>srv.listen(0,r)); const port=srv.address().port;
+ const br=await pup.launch({headless:'new',args:['--no-sandbox','--enable-unsafe-swiftshader']});
+ const pg=await br.newPage();
+ const logs=[]; pg.on('console',m=>logs.push(m.text()));
+ const pageErrors=[]; pg.on('pageerror',e=>pageErrors.push(String(e)));
+
+ await pg.goto(`http://localhost:${port}/viewer/viewer.html`,{waitUntil:'load',timeout:60000});
+ await pg.waitForFunction(()=>window.APP && typeof window.APP.exportBcf==='function',{timeout:20000}).catch(()=>{});
+
+ ck('bcf_export.js loaded — no §LOAD_FAIL', !logs.some(l=>l.includes('LOAD_FAIL')));
+ ck('APP.exportBcf wired (setupBcfExport ran)', await pg.evaluate(()=>typeof window.APP.exportBcf==='function'));
+ ck('APP._bcf pure builders exposed for unit checks', await pg.evaluate(()=>!!(window.APP._bcf && window.APP._bcf.zipStore && window.APP._bcf._issueToTopic)));
+
+ // Pure-function unit checks — real Viewer status/severity vocab → BCF vocab (ported mapping).
+ const mapChecks = await pg.evaluate(()=>{
+   const b = window.APP._bcf;
+   return {
+     resolvedToOpen: b._statusToBcf('') === 'Open',
+     reviewedToOpen: b._statusToBcf('Reviewed') === 'Open',
+     resolvedToResolved: b._statusToBcf('Resolved') === 'Resolved',
+     acceptedToClosed: b._statusToBcf('Accepted') === 'Closed',
+     hardToCritical: b._priorityFromSeverity('Hard clash') === 'Critical',
+     softToMajor: b._priorityFromSeverity('Soft clash') === 'Major',
+     clearanceToMinor: b._priorityFromSeverity('Clearance violation') === 'Minor',
+   };
+ });
+ ck('status mapping (\'\'/Reviewed→Open, Resolved→Resolved, Accepted→Closed)', mapChecks.resolvedToOpen && mapChecks.reviewedToOpen && mapChecks.resolvedToResolved && mapChecks.acceptedToClosed);
+ ck('priority mapping (Hard→Critical, Soft→Major, Clearance→Minor)', mapChecks.hardToCritical && mapChecks.softToMajor && mapChecks.clearanceToMinor);
+
+ // Real 1x1 PNG bytes (smallest valid PNG) for the clash issue's snapshot.
+ const pngB64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+ // Insert REAL issue records into the REAL issues IndexedDB (viewer/issues.js A._openIssuesDB),
+ // exactly the shape A._saveClashIssue / A._saveIssueToLog would write.
+ const seeded = await pg.evaluate(async (pngB64) => {
+   function b64ToU8(b64){const bin=atob(b64);const u=new Uint8Array(bin.length);for(let i=0;i<bin.length;i++)u[i]=bin.charCodeAt(i);return u;}
+   const pngBlob = new Blob([b64ToU8(pngB64)], {type:'image/png'});
+   window.APP._clashPairKey = window.APP._clashPairKey || function(a,b){return a+'|'+b;};
+   window.APP._clashStatuses = window.APP._clashStatuses || {};
+   window.APP._clashStatuses[window.APP._clashPairKey('GUID_WALL_001','GUID_DUCT_002')] = 'Resolved';
+   const db = await window.APP._openIssuesDB();
+   const tx = db.transaction('issues','readwrite');
+   const store = tx.objectStore('issues');
+   store.add({
+     type:'clash', jpeg_blob: pngBlob, timestamp: new Date().toISOString(),
+     element_guid:'GUID_WALL_001', element_class:'IfcWall', element_name:'Wall-01',
+     building:'PocTestBuilding', storey:'L1', discipline:'STR|MEP', notes:'needs reroute',
+     element_b_guid:'GUID_DUCT_002', element_b_class:'IfcDuctSegment', element_b_name:'Duct-02',
+     discipline_pair:'STR|MEP', overlap_mm: 42, severity:'Hard clash',
+     camera_pos: JSON.stringify({x:10,y:5,z:8}), camera_target: JSON.stringify({x:0,y:0,z:0}),
+     deep_link:'', gps_lat:null, gps_lng:null, gps_accuracy:null, compass_heading:null
+   });
+   store.add({
+     type:'note', jpeg_blob:null, timestamp: new Date().toISOString(),
+     element_guid:'GUID_DOOR_003', element_class:'IfcDoor', element_name:'Door-03',
+     building:'PocTestBuilding', storey:'L2', discipline:'ARC',
+     notes:'Door swing clashes with corridor furniture layout'
+   });
+   await new Promise((res,rej)=>{tx.oncomplete=res;tx.onerror=rej;});
+   db.close();
+   return true;
+ }, pngB64);
+ ck('seeded 2 real issue records into IssuesDB', seeded === true);
+
+ const exportResult = await pg.evaluate(async () => {
+   try { const r = await window.APP.exportBcf({ download: false }); return { ok:true, topicCount: r.topicCount, byteLength: r.bytes.length, bytesB64: btoa(String.fromCharCode(...r.bytes)) }; }
+   catch (e) { return { ok:false, error: e.message }; }
+ });
+ ck('APP.exportBcf({download:false}) resolved without throwing', exportResult.ok);
+ ck('exported 2 topics (1 clash + 1 note)', exportResult.topicCount === 2);
+ ck('§BCF export log line present', logs.some(l=>/§BCF export topics=2/.test(l)));
+ ck('zero page errors', pageErrors.length === 0);
+
+ // Write real bytes to disk, validate with the INDEPENDENT unzip CLI (not our own code).
+ fs.writeFileSync(OUT, Buffer.from(exportResult.bytesB64, 'base64'));
+ let unzipList = '', unzipTestOk = false;
+ try {
+   unzipTestOk = execSync(`unzip -t "${OUT}"`).toString().includes('No errors detected');
+   unzipList = execSync(`unzip -l "${OUT}"`).toString();
+   fs.mkdirSync(EXTRACT, { recursive: true });
+   execSync(`unzip -o -q "${OUT}" -d "${EXTRACT}"`);
+ } catch (e) { unzipList = 'UNZIP_FAILED: ' + e.message; }
+ ck('independent unzip CLI: archive integrity OK (CRC valid)', unzipTestOk);
+ ck('archive contains bcf.version', unzipList.includes('bcf.version'));
+ ck('archive contains 2 markup.bcf + 2 viewpoint.bcfv (one per topic)', (unzipList.match(/markup\.bcf/g)||[]).length === 2 && (unzipList.match(/viewpoint\.bcfv/g)||[]).length === 2);
+ ck('archive contains exactly 1 snapshot.png (clash only, note has none)', (unzipList.match(/snapshot\.png/g)||[]).length === 1);
+
+ const topicDirs = fs.readdirSync(EXTRACT).filter(d => fs.statSync(path.join(EXTRACT,d)).isDirectory());
+ const clashMarkup = topicDirs.map(d => fs.readFileSync(path.join(EXTRACT,d,'markup.bcf'),'utf8')).find(x => x.includes('TopicType="Clash"'));
+ const noteMarkup = topicDirs.map(d => fs.readFileSync(path.join(EXTRACT,d,'markup.bcf'),'utf8')).find(x => x.includes('TopicType="Comment"'));
+ ck('clash topic: TopicStatus="Resolved" (real severity Hard clash + real status Resolved)', !!clashMarkup && clashMarkup.includes('TopicStatus="Resolved"'));
+ ck('clash topic: Priority=Critical (Hard clash → Critical)', !!clashMarkup && clashMarkup.includes('<Priority>Critical</Priority>'));
+ ck('clash topic: ReferenceLinks carry the REAL element guids', !!clashMarkup && clashMarkup.includes('GUID_WALL_001') && clashMarkup.includes('GUID_DUCT_002'));
+ ck('clash topic: Title uses real element names', !!clashMarkup && clashMarkup.includes('Wall-01') && clashMarkup.includes('Duct-02'));
+ ck('note topic: TopicStatus="Open" (no clash-status lifecycle → default Open)', !!noteMarkup && noteMarkup.includes('TopicStatus="Open"'));
+ ck('note topic: ReferenceLinks carry the real single element guid', !!noteMarkup && noteMarkup.includes('GUID_DOOR_003'));
+
+ console.log('\n  §BCF_EXPORT '+pass+'/'+(pass+fail)+(fail?' (FAIL)':' PASS'));
+ if (fail) { console.log('  unzip -l:\n'+unzipList); console.log('  pageErrors:', pageErrors); }
+ try { fs.rmSync(OUT); fs.rmSync(EXTRACT, {recursive:true, force:true}); } catch(e) {}
+ await br.close(); srv.close();
+ process.exit(fail ? 1 : 0);
+})().catch(e=>{console.error(e);process.exit(1);});

--- a/viewer/tests/poc_open_button_ifc_merge.js
+++ b/viewer/tests/poc_open_button_ifc_merge.js
@@ -1,0 +1,55 @@
+// §OPEN_BUTTON_IFC_MERGE — the Viewer's Open button now accepts native .db AND raw IFC (single or
+// multi — 2+ IFCs silently merge into one building), reclaiming import_own.js's engine (previously
+// only reachable from the landing hub's now-removed #m-import-zone — see morpheus_import_live.js).
+// Drives the REAL production entry point APP._routeOpenPicks (the same function A.openModelDb calls
+// once the native file-picker resolves — that dialog itself can't be automated, everything downstream
+// is unmodified production code: parse → merge → cache write → same-tab navigate → reload → render).
+const http=require('http'),fs=require('fs'),path=require('path');
+const ROOT=path.join(__dirname,'..','..');
+const IFC_A=path.join(process.env.HOME,'bim-compiler/reference/residential/Ifc2x3_Duplex_Architecture.ifc');
+const IFC_B=path.join(process.env.HOME,'bim-compiler/reference/residential/Ifc2x3_Duplex_MEP.ifc');
+const pup=require(path.join(process.env.HOME,'bim-compiler','node_modules','puppeteer'));
+const MIME={'.html':'text/html','.js':'text/javascript','.mjs':'text/javascript','.wasm':'application/wasm','.json':'application/json','.css':'text/css','.jpg':'image/jpeg','.png':'image/png','.db':'application/octet-stream','.ifc':'text/plain'};
+const srv=http.createServer((q,r)=>{let p=decodeURIComponent(q.url.split('?')[0]);if(p==='/')p='/viewer/viewer.html';fs.readFile(path.join(ROOT,p),(e,b)=>{if(e){r.writeHead(404);return r.end('404 '+p);}r.writeHead(200,{'Content-Type':MIME[path.extname(p)]||'application/octet-stream','Access-Control-Allow-Origin':'*'});r.end(b);});});
+let pass=0,fail=0; const ck=(n,o)=>{console.log((o?'  PASS ':'  FAIL ')+n);o?pass++:fail++;};
+(async()=>{
+ await new Promise(r=>srv.listen(0,r));const port=srv.address().port;
+ const br=await pup.launch({headless:'new',args:['--no-sandbox','--enable-unsafe-swiftshader']});
+ const pg=await br.newPage();
+ const logs=[]; pg.on('console',m=>logs.push(m.text()));
+ const pageErrors=[]; pg.on('pageerror',e=>pageErrors.push(String(e)));
+
+ await pg.goto(`http://localhost:${port}/viewer/viewer.html`,{waitUntil:'load',timeout:60000});
+ await pg.waitForFunction(()=>window.APP && typeof window.APP._routeOpenPicks==='function',{timeout:20000}).catch(()=>{});
+
+ ck('import_own.js loaded — no §LOAD_FAIL', !logs.some(l=>l.includes('LOAD_FAIL')));
+ ck('_fromViewerHost=true (asset paths collapsed to same-dir)', await pg.evaluate(()=>window._fromViewerHost===true));
+ ck('APP._routeOpenPicks wired (widened Open picker)', await pg.evaluate(()=>typeof window.APP._routeOpenPicks==='function'));
+ ck('handleImportFiles reachable (reused engine, not reinvented)', await pg.evaluate(()=>typeof window.handleImportFiles==='function'));
+
+ // Real 2-discipline merge (ARC+MEP, same building) through the real Open-button entry point.
+ const b64A=fs.readFileSync(IFC_A).toString('base64'), b64B=fs.readFileSync(IFC_B).toString('base64');
+ const callResult = await pg.evaluate(async (bA,bB)=>{
+   function toFile(b64,name){const bin=atob(b64);const u=new Uint8Array(bin.length);for(let i=0;i<bin.length;i++)u[i]=bin.charCodeAt(i);return new File([u],name,{type:'application/octet-stream'});}
+   try { await window.APP._routeOpenPicks([toFile(bA,'Ifc2x3_Duplex_Architecture.ifc'), toFile(bB,'Ifc2x3_Duplex_MEP.ifc')]); return {ok:true}; }
+   catch(e){ return {ok:false, error:e.message}; }
+ }, b64A, b64B);
+ ck('APP._routeOpenPicks(2 IFCs) resolved without throwing', callResult.ok);
+
+ await pg.waitForFunction(()=>location.search.includes('db=import'),{timeout:45000}).catch(()=>{});
+ const urlAfterMerge = pg.url();
+ ck('same-tab navigate (NOT a new window) to merged import:// db', /db=import%3A%2F%2F.*ghost=1/.test(urlAfterMerge));
+ ck('§MULTI_IMPORT_DONE (both files merged, one building)', logs.some(l=>/§MULTI_IMPORT_DONE.*files=2/.test(l)));
+ ck('§OPEN_PROJECT_SAMETAB (not §OPEN_POPUP_BLOCKED / window.open)', logs.some(l=>l.includes('§OPEN_PROJECT_SAMETAB')));
+
+ // Let the reloaded page (new import:// db) actually boot the merged scene.
+ await pg.waitForFunction(()=>window.APP && window.APP.scene,{timeout:20000}).catch(()=>{});
+ await new Promise(r=>setTimeout(r,3000));
+ const meshCount = await pg.evaluate(()=>window.APP && window.APP.scene ? window.APP.scene.children.length : -1);
+ ck('reloaded viewer rendered the merged scene (children>0)', meshCount>0);
+ ck('zero page errors across the whole flow', pageErrors.length===0);
+
+ console.log('\n  §W-OPEN-BUTTON-IFC-MERGE '+pass+'/'+(pass+fail)+(fail?' (FAIL)':' PASS'));
+ if (fail) { console.log('  logs:'); logs.filter(l=>/§|error/i.test(l)).slice(-20).forEach(l=>console.log('    '+l)); console.log('  pageErrors:', pageErrors); }
+ await br.close();srv.close();process.exit(fail?1:0);
+})().catch(e=>{console.error(e);process.exit(1);});

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -858,6 +858,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="semantic_enrichment.js?v=1"></script>
 <script src="scene_to_db.js?v=1"></script>
 <script src="import_db_builder.js?v=2"></script>
+<script>window._IMPORT_OWN_VIEWER_HOST = true;</script>
+<script src="../import_own.js?v=1" onerror="console.warn('§LOAD_FAIL import_own.js — Open-button IFC merge disabled')"></script>
 <script src="diff.js?v=4"></script>
 <script src="variation_order.js?v=2"></script>
 <script src="import.js?v=3"></script>
@@ -1007,6 +1009,26 @@ window.addEventListener('beforeinstallprompt', function(e) {
   window._installPrompt = e;
   console.log('§PWA_INSTALL prompt captured (early)');
 });
+</script>
+
+<!-- §OPEN_BUTTON_IFC_MERGE: reused verbatim from import_own.js (landing-page engine), which reads/writes
+     these two ids directly — including toggling the progress bar's wrapper to display:block while a
+     merge runs (parse can take tens of seconds per file). Styled as a slim fixed top bar here rather
+     than hidden, so that toggle renders as an intentional overlay instead of an unstyled flash; a
+     MutationObserver also mirrors #import-status text into the Viewer's own visible A.status line. -->
+<div id="import-status" style="position:fixed;top:0;left:0;right:0;z-index:9999;text-align:center;color:#cfe3ef;font-size:12px;padding:4px;background:rgba(20,22,32,.85);display:none"></div>
+<div style="display:none;position:fixed;top:0;left:0;right:0;height:3px;background:#222;z-index:9999">
+  <div id="import-progress-bar" style="height:100%;width:0%;background:#0277bd;transition:width .3s"></div>
+</div>
+<script>
+(function(){
+  var src = document.getElementById('import-status');
+  if (!src || !window.MutationObserver) return;
+  new MutationObserver(function(){
+    src.style.display = src.textContent ? 'block' : 'none';
+    if (window.APP && APP.status && src.textContent) APP.status.textContent = src.textContent;
+  }).observe(src, { childList: true, characterData: true, subtree: true });
+})();
 </script>
 </body>
 </html>

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -517,6 +517,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
   <h3><span data-trl="ui_issues_title">Issues</span> <span class="panel-toggle" onclick="toggleIssues()">&times;</span></h3>
   <div class="issues-toolbar">
     <button onclick="exportIssuesExcel();event.stopPropagation()">&#128196; <span data-trl="ui_export_excel">Export Excel</span></button>
+    <button onclick="exportIssuesBcf();event.stopPropagation()">&#128230; <span data-trl="ui_export_bcf">Export BCF</span></button>
     <button onclick="clearAllIssues();event.stopPropagation()" style="background:#663333;border-color:#884444">&#128465; <span data-trl="ui_clear_all">Clear All</span></button>
   </div>
   <div id="issues-list"></div>
@@ -829,6 +830,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>
 <script src="share.js?v=2" onerror="console.warn('§LOAD_FAIL share.js')"></script>
 <script src="issues.js?v=5" onerror="console.warn('§LOAD_FAIL issues.js')"></script>
+<script src="bcf_export.js?v=1" onerror="console.warn('§LOAD_FAIL bcf_export.js')"></script>
 <script src="excel.js?v=4" onerror="console.warn('§LOAD_FAIL excel.js')"></script>
 <script src="walk.js?v=7" onerror="console.warn('§LOAD_FAIL walk.js')"></script>
 <!-- SPATIAL_PICKING_SPEC §S-2..§S-5 — the warehouse pick-walk addon: wh_route.js (UMD of bim-compiler


### PR DESCRIPTION
## Summary
Both halves of `bim-compiler prompts/OPEN_BUTTON_IFC_BCF_MERGE.md` — Open-button item done first, BCF-export item added as a follow-up commit on this same branch/PR since it continues the same backlog entry.

**1. Open button reclaims the drop-IFC multi-merge engine**
- Open now accepts native `.db` AND raw IFC (single or multi — 2+ auto-merge into one building), reusing `import_own.js`'s existing multi-IFC-merge engine verbatim rather than reinventing it.
- The landing page's `#m-import-zone` drop-box is retired — flagged by the user as reading like an upload/privacy prompt. Open is now the single, normal-convention entry point for any supported input.
- `import_own.js` is loaded a second time, from `viewer/viewer.html`. Its `viewer/`-relative asset paths now collapse correctly via `_fromViewerHost`/`_viewerAssetPrefix`. `openProject()` gained `opts.sameTab` so a merge triggered from Open navigates the CURRENT tab instead of spawning a second one.

**2. New BCF 2.1 export module (Viewer had none)**
- Ported, not invented: the zip/XML writer is a verbatim port of Modeller's already-shipped `modeller/bcf_export.js`; the domain mapping (topic shape, status→BCF-status, severity→BCF-priority) is ported from the real Federation/IfcOpenShell Python BCF generator (`~/IfcOpenShell/src/bonsai/bonsai/bim/module/federation/bcf/bcf_generator.py` + `viewpoint_manager.py`) — re-sourced onto the Viewer's own real fields (clash status lifecycle, severity labels, stored camera/snapshot per issue) instead of that module's SQLite schema.
- One BCF Topic per saved `viewer/issues.js` Issue — both clashes (TopicType=Clash) and freeform site notes (TopicType=Comment).
- New "Export BCF" button in the existing Issues panel toolbar, next to Export Excel.

## Test plan
- [x] `viewer/tests/poc_open_button_ifc_merge.js` — real ARC+MEP reference IFCs through the real Open-button entry point, full round trip. 10/10 PASS.
- [x] `viewer/tests/morpheus_import_live.js` — retired to a regression guard confirming the drop-zone removal stuck. 4/4 PASS.
- [x] `viewer/tests/poc_bcf_export.js` — seeds real Issue records (one clash w/ real PNG snapshot, one note) into the real IndexedDB, drives the real `APP.exportBcf()`, then validates the produced `.bcfzip` with the independent `unzip` CLI (archive integrity + per-topic XML content), not self-checking. 20/20 PASS. Snapshot separately confirmed a genuinely valid PNG via `file`.
- [x] Manual smoke of `index.html` hub post-removal — catalog cards render normally, 0 console errors.

Generated with Claude Code.
