### PR TITLE
feat(modeller): wire the World-History "W" pill

### DIFF
--- a/common/whole_history.js
+++ b/common/whole_history.js
@@ -103,8 +103,10 @@
   var MODE_KEY = 'bim.whole.mode';        // 'whole' | 'this'
   // root-relative path to each surface (resolved against the mounting page's rootPrefix).
   var PATHS = { viewer: 'viewer/viewer.html', idempiere: 'erp/idempiere.html',
-    glassbowl: 'erp/glassbowl.html', gravity: 'erp/glassbowl_gravity.html', landing: 'index.html' };
-  var PAGE_LABEL = { viewer: 'Viewer', idempiere: 'iDempiere', glassbowl: 'Glassbowl', gravity: 'Gravity', landing: 'Home' };
+    glassbowl: 'erp/glassbowl.html', gravity: 'erp/glassbowl_gravity.html', landing: 'index.html',
+    modeller: 'modeller/modeller.html' };
+  var PAGE_LABEL = { viewer: 'Viewer', idempiere: 'iDempiere', glassbowl: 'Glassbowl', gravity: 'Gravity',
+    landing: 'Home', modeller: 'Modeller' };
 
   var _page = null;        // this surface's page id (set in mount)
   var _rootPrefix = '';    // relative path from this page to the site root ('' landing, '../' nested)
@@ -237,7 +239,15 @@
   function _hhmm(ts) { try { var d = new Date(ts); function p(n) { return (n < 10 ? '0' : '') + n; } return p(d.getHours()) + ':' + p(d.getMinutes()); } catch (e) { return ''; } }
 
   function _ensureDom() {
-    if (_launch || typeof document === 'undefined') return;
+    // §WORLD-HIST-MODELLER-FIX: guard on _panel, not _launch. Every launcher:false surface (idempiere/
+    // glassbowl/gravity/modeller) never sets _launch (it's only built inside the `_launcher !== false`
+    // branch below), so the old `if (_launch ...)` guard never fired — open() calls _ensureDom()
+    // unconditionally on every toggle, rebuilding a DUPLICATE #whole-hist-panel (+ a duplicate
+    // #whole-hist-style) each time, silently orphaning the previous one in the DOM. Invisible to a real
+    // user (the module's own closure vars always point at the newest panel, so behaviour looked correct)
+    // but real DOM/style bloat over a session, and it broke `document.getElementById('whole-hist-panel')`
+    // lookups (returns the first, dead copy) — caught live by witness_modeller_worldhist_pill.js.
+    if (_panel || typeof document === 'undefined') return;
     var st = document.createElement('style'); st.id = 'whole-hist-style';
     st.textContent =
       '#whole-hist-launch{position:fixed;left:14px;bottom:16px;z-index:60;width:38px;height:38px;border-radius:50%;' +

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -164,6 +164,7 @@
   <button id="b-lod" disabled style="display:none" title="Refine the selected component's level of detail (same signed row)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/></svg><span>LOD 200</span></button>
   <button id="b-export" disabled title="Export — Native .db (full fidelity: the signed op-log), IFC4, or a BCF 2.1 issue"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg><span>Export</span></button>
   <button id="b-save" disabled title="Save — clash-check + auto-heal, then write a physical-DB snapshot (blocks on residual RED)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/></svg><span>Save</span></button>
+  <button id="b-worldhist" title="World History: cross-page timeline (Viewer, iDempiere, Gravity, Modeller)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9.5" cy="12" r="6.5"/><circle cx="14.5" cy="12" r="6.5"/></svg><span>History</span></button>
   <button id="b-guide" title="Modeller User Guide — how to Open, walk, edit & export"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg><span>Guide</span></button>
   <button id="b-del" disabled title="Delete selected (Del)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Z"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/></svg><span>Delete</span></button>
   <button id="b-clear" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg><span>Clear</span></button>
@@ -189,6 +190,22 @@
 <script src="kernel_ops.js?v=9" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
 <script src="bonsai_oplog.js?v=8" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<!-- §WORLD-HIST-MODELLER (RESUME_WORLD_HISTORY_DEDUP_RESTORE.md 4-step handoff): the SAME cross-page
+     "W" log (common/whole_history.js) the Viewer/iDempiere/Gravity already write to. Loaded BEFORE
+     history_bar.js so its internal WholeHistory.record mirror (the BUILDING_OPEN doc-type) has a live
+     target instead of silently falling back to the un-deduped inline write. Modeller follows the viewer
+     LANE PARTITION — W only (open/view the log), no fork/refold, no long-press bomb-clear drawer (that
+     richer pill-drawer framework belongs to viewer/panels.js + erp/idmp_pills.js, not this page). -->
+<script src="../common/whole_history.js?v=1" onerror="console.warn('§WHOLE LOAD_FAIL whole_history.js')"></script>
+<script>
+if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'modeller', rootPrefix: '../', launcher: false });
+(function () {
+  var btn = document.getElementById('b-worldhist');
+  if (!btn) return;
+  if (!window.WholeHistory) { btn.disabled = true; return; }
+  btn.addEventListener('click', function () { WholeHistory.toggleOpen(); });
+})();
+</script>
 <!-- §MODELLER-GIT-HISTORY (MODELLER_GIT_FAITHFUL_HISTORY.md Phase 2): the SAME git-faithful fork/undo/redo
      tree engine the Viewer runs (common/history_bar.js), reused — not a second branch mechanism. The
      adapter wraps Bonsai.oplog.commit/commitGesture so every real edit lands as one tree node. -->

--- a/modeller/tests/witness_modeller_worldhist_pill.js
+++ b/modeller/tests/witness_modeller_worldhist_pill.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-MODELLER-WORLDHIST: headless-Chrome witness for the Modeller "W" pill wiring
+ * (prompts/RESUME_WORLD_HISTORY_DEDUP_RESTORE.md's 4-step handoff, finally picked up). Drives the REAL
+ * production stack (modeller.html -> common/whole_history.js -> common/history_bar.js ->
+ * modeller_history.js -> str_walker_outliner.js's _openBuffer), not a reimplementation.
+ * Read the log after every run — exit code alone is not evidence.
+ *
+ * Checks:
+ *   W1 whole_history.js loads + WholeHistory.mount() fires for page=modeller (§WHOLE-MOUNT logged)
+ *   W2 #b-worldhist pill present in the #bar rail, enabled
+ *   W3 clicking #b-worldhist opens the World History panel (#whole-hist-panel.show)
+ *   W4 clicking it again closes the panel (toggleOpen)
+ *   W5 opening a resident (SampleHouse) fires ONE BUILDING_OPEN doc-event into the SHARED cross-page
+ *      log (localStorage['bim.docHistory']) with page==='modeller' — the actual gap this closes: before
+ *      this wiring, whole_history.js was never loaded in Modeller, so the mirror silently had nowhere to
+ *      write and no card ever showed up for a Modeller building-open.
+ *   W6 re-opening the panel afterward renders that modeller row (pageLabel 'Modeller')
+ *   W7 no script LOAD_FAIL / pageerror
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require('playwright');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+// Same readiness gate as witness_modeller_git_history.js's openResident.
+async function openResident(page, key) {
+  await page.click('#b-open');
+  await page.waitForTimeout(120);
+  await page.click('#m-open-panel .mo-row[data-key="' + key + '"]');
+  await page.waitForFunction(function () {
+    var t = window.BOMTreeOutliner && window.BOMTreeOutliner._currentTree && window.BOMTreeOutliner._currentTree();
+    return !!t && Object.keys(t.nodes).some(function (id) { return t.nodes[id].kind === 'disc'; });
+  }, null, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(500);
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL; }, { timeout: 25000 }).catch(function () {});
+  await page.waitForTimeout(300);
+
+  var pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-MODELLER-WORLDHIST — the “W” pill wiring (headless, SampleHouse) ═══');
+
+  var mountLogged = logs.some(function (l) { return /§WHOLE-MOUNT page=modeller/.test(l); });
+  chk('W1 §WHOLE-MOUNT page=modeller logged (whole_history.js loaded + mounted)', mountLogged);
+
+  var present = await page.evaluate(function () {
+    var b = document.getElementById('b-worldhist');
+    return b ? { exists: true, disabled: b.disabled, inBar: b.closest('#bar') != null } : { exists: false };
+  });
+  chk('W2 #b-worldhist pill present in the rail, enabled', present.exists && present.inBar && !present.disabled,
+    JSON.stringify(present));
+
+  await page.click('#b-worldhist');
+  await page.waitForTimeout(200);
+  var openedNow = await page.evaluate(function () {
+    var p = document.getElementById('whole-hist-panel');
+    return !!(p && p.classList.contains('show'));
+  });
+  chk('W3 click opens #whole-hist-panel', openedNow);
+
+  // Close via the panel's own X button — the panel is a full-viewport modal (z-index 61 > #bar's 11),
+  // so it correctly COVERS the pill itself; closing is by design via #whole-hist-x or a backdrop click,
+  // never by re-clicking the now-covered trigger (same contract as idempiere/glassbowl/gravity).
+  await page.click('#whole-hist-x');
+  await page.waitForTimeout(200);
+  var closedNow = await page.evaluate(function () {
+    var p = document.getElementById('whole-hist-panel');
+    return !(p && p.classList.contains('show'));
+  });
+  chk('W4 the panel\'s own X button closes it (toggleOpen)', closedNow);
+
+  // Baseline: how many modeller rows exist in the shared log BEFORE opening a resident (should be 0 —
+  // a fresh page + fresh localStorage per test run).
+  var before = await page.evaluate(function () {
+    try { return (JSON.parse(localStorage.getItem('bim.docHistory') || '[]')).filter(function (e) { return e.page === 'modeller'; }).length; } catch (e) { return -1; }
+  });
+
+  await openResident(page, 'SampleHouse');
+  await page.waitForTimeout(300);
+
+  var after = await page.evaluate(function () {
+    try { return JSON.parse(localStorage.getItem('bim.docHistory') || '[]'); } catch (e) { return []; }
+  });
+  var modellerRows = after.filter(function (e) { return e.page === 'modeller'; });
+  chk('W5 opening SampleHouse writes exactly ONE modeller BUILDING_OPEN row into the shared cross-page log',
+    before === 0 && modellerRows.length === 1 && modellerRows[0].kind === 'op',
+    'before=' + before + ' after=' + modellerRows.length + ' row=' + JSON.stringify(modellerRows[0]));
+
+  await page.click('#b-worldhist');
+  await page.waitForTimeout(200);
+  var rendered = await page.evaluate(function () {
+    var body = document.getElementById('whole-hist-body') || document.getElementById('whole-stretch');
+    return body ? body.textContent : '';
+  });
+  chk('W6 the panel renders the modeller row (pageLabel "Modeller")', /Modeller/.test(rendered), rendered.slice(0, 200));
+
+  var loadFail = logs.filter(function (l) { return /LOAD_FAIL|PAGEERROR/.test(l); });
+  chk('W7 no script LOAD_FAIL / pageerror', loadFail.length === 0, loadFail.slice(0, 3).join(' | '));
+
+  console.log('W-MODELLER-WORLDHIST: ' + pass + ' PASS / ' + fail + ' FAIL');
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- Closes the Part 1 gap from `prompts/RESUME_WORLD_HISTORY_DEDUP_RESTORE.md` (bim-compiler repo) — Modeller never loaded `common/whole_history.js`, so opening a building never surfaced a cross-page World-History card.
- Wires the 4-step handoff: loads `whole_history.js`, mounts it (`page:'modeller'`, `launcher:false` — follows the viewer/iDempiere/Gravity lane, W-only, no fork/refold, no bomb-clear drawer), adds a `#b-worldhist` pill to the rail wired to `WholeHistory.toggleOpen()`, registers `modeller` in `PATHS`/`PAGE_LABEL`.
- `record()` on building-open was already wired via `modeller_history.js`'s existing `recordBuildingOpen()` → `history_bar.js`'s mirror — it was a silent no-op with nowhere to write until now.
- Bonus fix: `whole_history.js`'s `_ensureDom()` idempotency guard checked `_launch`, which every `launcher:false` surface (idempiere/glassbowl/gravity, now modeller) never sets — so `open()` rebuilt a duplicate `#whole-hist-panel` on every toggle. Invisible to real users (closures always pointed at the newest panel) but real DOM bloat, and it broke `getElementById` lookups — caught live by the new witness.

## Test plan
- [x] New `modeller/tests/witness_modeller_worldhist_pill.js` — 7/7 PASS, drives the real stack (opens a real SampleHouse resident, confirms exactly one deduped `modeller` row lands in the shared `bim.docHistory` log, panel renders it)
- [x] Re-ran all 5 existing `poc_whole_*.js` witnesses — still PASS
- [x] Re-ran `witness_modeller_redo_order.js` (6/6), `witness_modeller_git_history.js` (7/8, the 1 fail is the pre-documented G6 gap), `witness_modeller_pill_verbs.js` (8/9, the 1 fail — D5 section count — confirmed pre-existing on clean `origin/main`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)