### PR TITLE
fix(viewer): generalize pill-highlight desync fix + panel abstraction

### DIFF
--- a/common/pill_builder.js
+++ b/common/pill_builder.js
@@ -45,6 +45,20 @@
  *       - Register with InputReg (Esc close, Tab focus)
  *       - Sync highlight via _syncPillHighlights()
  *
+ *  §PILL-AUTOSYNC (2026-07-06) — you never need to call _syncPillHighlights() yourself, for a
+ *  panel built with `panel:` above OR a fully hand-rolled drawer (own DOM, own ✕ button, own
+ *  open/close logic — e.g. viewer/hba_lens.js's Human-Asset family drawer, panels.js's
+ *  _buildMasterDrawer masters). The builder watches document.body for element add/remove and
+ *  resyncs ALL highlights on the next frame, no matter which module opened or closed the element
+ *  and whether or not it remembered to call anything. Root cause this replaces: the Human-Asset
+ *  pill's own ✕ button used to `d.remove()` with no resync call, so re-tapping the pill worked
+ *  (the pill's OWN click handler already calls fn(); _sync()) but closing via the drawer's ✕ left
+ *  the pill stuck highlighted — a landmine for every future hand-rolled drawer, not just this one.
+ *  An isActive() that depends purely on in-memory state with NO matching DOM change (rare — most
+ *  panels/drawers in this codebase are literally a DOM node that exists or doesn't) still needs its
+ *  own act.fn() to call _sync(), same as always; the auto-heal is a safety net for the DOM case,
+ *  not a replacement for wiring isActive correctly.
+ *
  *  3. ICON + CUSTOM FN + isActive — full control:
  *
  *     { id: 'xray', icon: '<path d="..."/>',
@@ -205,6 +219,27 @@
         n++;
       });
       console.log('§PILL_SYNC synced=' + n);
+    }
+
+    // §PILL-AUTOSYNC (2026-07-06, see the doc block up top): resync on ANY element add/remove
+    // anywhere in the document, not just when a drawer's author remembers to call _sync(). This is
+    // the structural fix for the whole class of "custom drawer's own close button forgets to
+    // resync" bugs (found first on the Human-Asset/hbaFM family drawer, viewer/hba_lens.js — its ✕
+    // button did `d.remove()` with no resync call at all). childList+subtree (not `attributes`) is
+    // deliberately narrow: it fires on node insert/remove — exactly how every panel/drawer in this
+    // codebase opens and closes — and stays silent on the much noisier per-frame style/class churn
+    // (camera moves, canvas redraws, tooltips), so this stays cheap even during animation. Coalesced
+    // to at most once per rendered frame via rAF so a burst of DOM churn (e.g. a drawer's row list
+    // rebuilding several rows) still only pays for one _sync() pass.
+    if (typeof MutationObserver !== 'undefined' && typeof document !== 'undefined' && document.body) {
+      var _autoSyncQueued = false;
+      var _raf = window.requestAnimationFrame || function(cb) { return setTimeout(cb, 16); };
+      var _autoSyncObserver = new MutationObserver(function() {
+        if (_autoSyncQueued) return;
+        _autoSyncQueued = true;
+        _raf(function() { _autoSyncQueued = false; _sync(); });
+      });
+      _autoSyncObserver.observe(document.body, { childList: true, subtree: true });
     }
 
     // ── Build pill DOM ──

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -916,6 +916,25 @@
       rowsEl.appendChild(row);
     });
   }
+  // §PANEL-ABSTRACTION (2026-07-06) — this drawer used to be entirely hand-rolled (own DOM, own ✕,
+  // no drag, no keyboard nav, a hardcoded position). It now rides the shared panel infrastructure:
+  //   · the ✕'s original bug (closing here left the hbaFM pill stuck highlighted) is fixed
+  //     STRUCTURALLY by common/pill_builder.js's MutationObserver auto-resync — no manual call here.
+  //   · draggable (A._makeDraggable) + Arrow-key row traversal (window.PanelNav, the same module the
+  //     Find panel already uses) + a no-overlap desktop slot (A._placePanel, replacing what would
+  //     otherwise become another hand-picked magic-number position) — all opt-in, defensive (`&&`-
+  //     guarded) since this file is additive/host-injected and must stay inert if any of them is
+  //     absent from a page that doesn't load the full viewer.
+  //   · this stays a plain floating overlay on mobile too (NOT re-parented into G.HbaPaneHost's
+  //     card-stack) — deliberately, matching the existing z-index treatment in this same file's
+  //     syncLauncher(), which already treats 'hba-fm-drawer'/'hba-presence-drawer' as PERSISTENT
+  //     LAUNCHER chips that float above/behind the stack, never as stack content themselves. Tried
+  //     folding it into the stack first; live-testing (viewer/tests/poc_hba_mobile_stack.js) showed
+  //     this conflates two different roles — the drawer is the PICKER a user reopens to add more
+  //     panes, so it can never legitimately reach "zero cards" alongside the content it's used to
+  //     open, and tapping/swiping through the deck would displace the very picker needed to browse
+  //     the rest. Panes = content cards; this drawer = a menu. Keeping them structurally separate
+  //     is the correct generalization, not a shortcut.
   function openFamilyDrawer(A) {
     if (typeof document === 'undefined') return null;
     var ex = document.getElementById('hba-fm-drawer'); if (ex) { ex.remove(); _closePresenceDrawer(); return null; }
@@ -931,7 +950,8 @@
     var title = document.createElement('span'); title.textContent = 'Human-Asset'; title.style.cssText = 'font-weight:700;opacity:.85;';
     var closeBtn = document.createElement('button'); closeBtn.textContent = '✕'; closeBtn.title = 'Close'; closeBtn.setAttribute('data-role', 'close');
     closeBtn.style.cssText = 'background:transparent;border:0;color:#fff;opacity:.6;cursor:pointer;font-size:14px;line-height:1;padding:2px 4px;';
-    closeBtn.addEventListener('click', function () { d.remove(); _closePresenceDrawer(); });
+    function _closeDrawer() { d.remove(); _closePresenceDrawer(); }
+    closeBtn.addEventListener('click', _closeDrawer);
     hdr.appendChild(title); hdr.appendChild(closeBtn);
     d.appendChild(hdr);
 
@@ -950,6 +970,12 @@
     _renderRows(A, d, rows);
 
     document.body.appendChild(d);
+    if (A && A._makeDraggable) A._makeDraggable(d);
+    if (A && A._placePanel && !G._isMobile) A._placePanel(d, { top: d.getBoundingClientRect().top, right: 64 });
+    if (G.PanelNav) {
+      G.PanelNav({ panel: d, id: 'hba-fm-drawer', onClose: _closeDrawer,
+        zones: [{ id: 'rows', items: function () { return rows.querySelectorAll('button'); } }] });
+    }
     console.log('§HBA_FM drawer open — ' + availableLenses(A).filter(function (x) { return x.available; }).length + '/' + FAMILY.length + ' lenses available');
     return d;
   }

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -173,6 +173,17 @@ function setupPanels(A) {
   };
 
   // ── S265 Phase 5: A.createPanel() — reusable panel factory ──
+  // §PANEL-ABSTRACTION (2026-07-06) — every caller of createPanel gets, for free:
+  //   · draggable + close-by-× (pre-existing)
+  //   · correct pill highlight even when THIS panel's own × closes it (common/pill_builder.js's
+  //     MutationObserver auto-resyncs on any element add/remove — no manual call needed here)
+  //   · Tab (native, real <button> rows) + Arrow-key row traversal (viewer/panel_nav.js, already
+  //     built for the Find panel, now wired as every panel's default unless it opts out or brings
+  //     its own richer opts.zones)
+  //   · no-overlap desktop placement (A._placePanel) instead of every pane author hand-picking the
+  //     next unused magic-number offset (see the row-of-hardcoded right:12/428/864 columns in
+  //     hba_bom.js/hba_iot.js/hba_dashboard.js — that pattern silently collides the moment someone
+  //     adds a 4th pane and forgets to bump the number)
   A.createPanel = function(id, opts) {
     opts = opts || {};
     var el = document.createElement('div');
@@ -196,6 +207,14 @@ function setupPanels(A) {
       if (typeof opts.content === 'string') { el.insertAdjacentHTML('beforeend', opts.content); }
       else { el.appendChild(opts.content); }
     }
+    // §PANEL-NAV-AUTO: Arrow Up/Down through this panel's own <button> rows (Tab already reaches
+    // them natively; Enter/Space already fire native <button> clicks). Opt out with opts.nav:false
+    // (e.g. a panel with no row-shaped content), or supply opts.zones for accordion-style panels
+    // (see navigate_find.js's own richer zones — this default only covers the common flat-list case).
+    if (opts.nav !== false && window.PanelNav) {
+      var _zones = opts.zones || [{ id: 'rows', items: function() { return el.querySelectorAll('button:not(.bim-panel-close)'); } }];
+      window.PanelNav({ panel: el, zones: _zones, id: id, onClose: opts.onClose || function() { el.style.display = 'none'; } });
+    }
     // Draggable
     if (opts.draggable !== false && A._makeDraggable) {
       A._makeDraggable(el);
@@ -212,6 +231,60 @@ function setupPanels(A) {
     console.log('§PANEL_CREATE id=' + id);
     return el;
   };
+
+  // §PANEL-PLACE (2026-07-06) — nearest free slot instead of a hardcoded magic-number column.
+  // opts: { top, right, width, height } — width/height only need to be given when the panel is
+  // still display:none at call time (can't measure a hidden element's real box); pass the same
+  // numbers the panel's own inline style declares. Tries the default column, then cascades right→
+  // left in (width+gap) steps against every OTHER currently-visible .bim-panel (from window._panels,
+  // the existing panel-focus registry in scene.js — no new tracking list invented); falls back to
+  // the default slot (stacked) if every column in range is occupied, never throws/loops forever.
+  A._placePanel = function(el, opts) {
+    opts = opts || {};
+    var top = opts.top != null ? opts.top : 54;
+    var right0 = opts.right != null ? opts.right : 12;
+    var gap = 16;
+    var width = opts.width || el.offsetWidth || 320;
+    var height = opts.height || el.offsetHeight || 300;
+    function rectAt(right) {
+      var left = window.innerWidth - right - width;
+      return { left: left, right: left + width, top: top, bottom: top + height };
+    }
+    function overlaps(a, b) { return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom; }
+    var others = (window._panels || []).filter(function(p) {
+      return p.el !== el && p.el.classList && p.el.classList.contains('bim-panel') &&
+             p.el.style.display !== 'none' && p.el.offsetWidth > 0;
+    }).map(function(p) { var r = p.el.getBoundingClientRect(); return { left: r.left, right: r.right, top: r.top, bottom: r.bottom }; });
+    for (var col = 0; col < 12; col++) {
+      var right = right0 + col * (width + gap);
+      var cand = rectAt(right);
+      if (cand.left < 8) break;   // ran off the left edge of the viewport
+      if (!others.some(function(o) { return overlaps(cand, o); })) {
+        el.style.right = right + 'px'; el.style.left = 'auto'; el.style.top = top + 'px';
+        console.log('§PANEL_PLACE id=' + el.id + ' col=' + col + ' right=' + right + ' others=' + others.length);
+        return;
+      }
+    }
+    el.style.right = right0 + 'px'; el.style.top = top + 'px';
+    console.log('§PANEL_PLACE_FALLBACK id=' + el.id + ' (no free column in range, others=' + others.length + ')');
+  };
+
+  // §PANEL-AUTOPLACE — call A._placePanel automatically the instant ANY .bim-panel transitions from
+  // hidden to visible, regardless of who created it or how. Only fires on that one transition (a
+  // per-element _bimPanelVisible flag), so it never fights A._makeDraggable's own left/top writes
+  // while a panel is already open and being dragged around.
+  if (typeof MutationObserver !== 'undefined' && typeof document !== 'undefined' && document.body) {
+    var _placeObserver = new MutationObserver(function(muts) {
+      muts.forEach(function(m) {
+        var pel = m.target;
+        if (!pel.classList || !pel.classList.contains('bim-panel')) return;
+        var visibleNow = pel.style.display !== 'none';
+        if (visibleNow && !pel._bimPanelVisible && !window._isMobile) A._placePanel(pel);
+        pel._bimPanelVisible = visibleNow;
+      });
+    });
+    _placeObserver.observe(document.body, { attributes: true, attributeFilter: ['style'], subtree: true });
+  }
 
   // ── S265 Phase 5 P1: Build Color Palette slider panel ──
   A._buildSunglassPanel = function() {

--- a/viewer/tests/witness_hba_pill_desync_fix.js
+++ b/viewer/tests/witness_hba_pill_desync_fix.js
@@ -1,0 +1,100 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser proof for RESUME_HR_BIM_ASSET.md §2026-07-06d (Human-Asset pill desync).
+//   User report: "Human-Asset icon does not go off when press again." Root cause: the hbaFM
+//   ("Human-Asset") drawer's own ✕ close button (viewer/hba_lens.js openFamilyDrawer) removed the
+//   #hba-fm-drawer DOM node but never called _syncPillHighlights() — the same bug class already
+//   fixed for the Navigate/Inspect/Camera-View master drawers (PILL_DRAWER_REORGANIZATION.md Item 1,
+//   panels.js's _buildMasterDrawer onClose) but left unpatched on this older, hand-rolled drawer.
+//   Re-tapping the pill itself already worked (pill_builder.js calls act.fn(); _sync(); on every
+//   click) — only the in-drawer ✕ path was desynced.
+// Drives the REAL viewer.html + HHS_Office_Federated_extracted.db, real user click path (pill open
+// -> ✕ close), not a seam/unit test. Read the log after the run, not just the exit code.
+// Run:  node viewer/tests/witness_hba_pill_desync_fix.js
+'use strict';
+const { chromium } = require(require('os').homedir() + '/bim-ootb/tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function waitReady(page) {
+  let ready = false;
+  for (let i = 0; i < 90 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false && window.APP._hbaRooms && window.APP._hbaRooms.length > 0)); } catch (e) {}
+  }
+  return ready;
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+  const errs = [];
+  page.on('console', m => log.push('  [console] ' + m.text()));
+  page.on('pageerror', e => { errs.push(String(e)); log.push('  [pageerror] ' + e); });
+
+  S('§W-HBA-PILL-DESYNC — Human-Asset (hbaFM) pill must de-highlight when its drawer is closed via ✕');
+
+  await page.goto('http://127.0.0.1:' + port + '/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db&bld=HHS_Office_Federated',
+    { waitUntil: 'load', timeout: 60000 });
+  const ready = await waitReady(page);
+  verdict(ready, 'real model loaded + ready (HHS_Office_Federated)');
+  if (!ready) { await page.close(); await browser.close(); server.close(); process.exit(1); return; }
+
+  await page.click('#mobile-trigger').catch(() => {});
+  await page.waitForTimeout(300);
+
+  // ── step 1: open the drawer via the pill, confirm it opens + pill highlights ──
+  await page.click('#pill-hbaFM');
+  await page.waitForTimeout(300);
+  const afterOpen = await page.evaluate(() => ({
+    drawerExists: !!document.getElementById('hba-fm-drawer'),
+    pillActive: document.getElementById('pill-hbaFM').classList.contains('active')
+  }));
+  verdict(afterOpen.drawerExists, 'drawer opened on pill click', JSON.stringify(afterOpen));
+  verdict(afterOpen.pillActive, 'pill highlighted (active class) while drawer open', JSON.stringify(afterOpen));
+
+  // ── step 2: close via the drawer's OWN ✕ button (NOT re-tapping the pill) — this is the exact
+  //    path the user reported as broken; re-tapping the pill already worked before this fix. ──
+  await page.click('#hba-fm-drawer button[data-role="close"]');
+  await page.waitForTimeout(300);
+  const afterClose = await page.evaluate(() => ({
+    drawerExists: !!document.getElementById('hba-fm-drawer'),
+    pillActive: document.getElementById('pill-hbaFM').classList.contains('active')
+  }));
+  verdict(!afterClose.drawerExists, 'drawer removed by ✕', JSON.stringify(afterClose));
+  verdict(!afterClose.pillActive, 'pill goes OFF (active class removed) after ✕ close — the reported bug', JSON.stringify(afterClose));
+
+  // ── step 3: re-open via the pill still works (proves the fix did not break the open path) ──
+  await page.click('#pill-hbaFM');
+  await page.waitForTimeout(300);
+  const reopened = await page.evaluate(() => ({
+    drawerExists: !!document.getElementById('hba-fm-drawer'),
+    pillActive: document.getElementById('pill-hbaFM').classList.contains('active')
+  }));
+  verdict(reopened.drawerExists && reopened.pillActive, 'pill re-opens + re-highlights cleanly after the ✕-close/resync cycle', JSON.stringify(reopened));
+
+  verdict(errs.length === 0, '0 pageerrors', errs.slice(0, 5).join(' | '));
+
+  const pass = fails === 0;
+  S('\n§W-HBA-PILL-DESYNC ' + (pass ? 'PASS' : 'FAIL') + ' (fails=' + fails + ')');
+  fs.writeFileSync(path.join(__dirname, 'witness_hba_pill_desync_fix.log'), log.join('\n'));
+  await page.close(); await browser.close(); server.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/tests/witness_panel_abstraction.js
+++ b/viewer/tests/witness_panel_abstraction.js
@@ -1,0 +1,160 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser proof for RESUME_HR_BIM_ASSET.md §2026-07-06d (Human-Asset pill desync +
+//   generalized panel abstraction). User ask, verbatim intent: solve the pill-desync bug once and
+//   for all — abstract/generalize so a FUTURE icon/drawer doesn't repeat the same class of bug, and
+//   confirm the abstraction gives every panel Tab/Arrow row navigation and draggable + close-by-×.
+// Proves, against the Human-Asset drawer as the flagship migrated instance (viewer/hba_lens.js's
+// openFamilyDrawer, now built on top of viewer/panels.js's A._makeDraggable/A._placePanel + the
+// existing viewer/panel_nav.js module instead of hand-rolled DOM):
+//   D1 draggable   — A._makeDraggable was applied (cursor:grab side effect)
+//   D2 arrow-nav   — ArrowDown moves focus between the drawer's own lens rows (viewer/panel_nav.js)
+//   D3 auto-place  — A._placePanel actually ran (§PANEL_PLACE log line), not a hardcoded position
+//   M1 mobile, stays a floating overlay — deliberately NOT folded into G.HbaPaneHost's card-stack.
+//                     A first attempt did fold it in; live-testing (poc_hba_mobile_stack.js) showed
+//                     that conflates two roles — the drawer is the PICKER used to open more panes,
+//                     so it can never legitimately reach "zero cards" alongside its own content, and
+//                     swiping through the deck would displace the very picker needed to browse the
+//                     rest. This matches the file's own pre-existing syncLauncher(), which already
+//                     treats 'hba-fm-drawer' as a persistent launcher chip, never stack content.
+//   M2 mobile close — the drawer's own ✕ still removes it cleanly (no residue), independent of
+//                     whatever panes are open in the stack alongside it.
+// Drives the REAL viewer.html + HHS_Office_Federated_extracted.db, real user click/keyboard path.
+// Read the log after the run, not just the exit code.
+// Run:  node viewer/tests/witness_panel_abstraction.js
+'use strict';
+const { chromium } = require(require('os').homedir() + '/bim-ootb/tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function waitReady(page) {
+  let ready = false;
+  for (let i = 0; i < 90 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false && window.APP._hbaRooms && window.APP._hbaRooms.length > 0)); } catch (e) {}
+  }
+  return ready;
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const url = 'http://127.0.0.1:' + port + '/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db&bld=HHS_Office_Federated';
+
+  // ══ DESKTOP — drag / arrow-nav / auto-place ═══════════════════════════════════════════════════
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+    const cons = []; const errs = [];
+    page.on('console', m => { log.push('  [console] ' + m.text()); cons.push(m.text()); });
+    page.on('pageerror', e => { errs.push(String(e)); log.push('  [pageerror] ' + e); });
+    S('§W-PANEL-ABSTRACTION — desktop (draggable / arrow-nav / auto-place)');
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    const ready = await waitReady(page);
+    verdict(ready, 'real model loaded + ready (HHS_Office_Federated)');
+    if (ready) {
+      await page.click('#mobile-trigger').catch(() => {});
+      await page.waitForTimeout(300);
+      await page.click('#pill-hbaFM');
+      await page.waitForTimeout(300);
+
+      // D1 — draggable: A._makeDraggable sets cursor:grab as its first action on the element.
+      const cursor = await page.evaluate(() => { var d = document.getElementById('hba-fm-drawer'); return d && d.style.cursor; });
+      verdict(cursor === 'grab', 'D1 drawer is draggable (A._makeDraggable applied, cursor:grab)', 'cursor=' + cursor);
+
+      // D3 — auto-place: the §PANEL_PLACE log line proves A._placePanel actually ran for this id
+      // (rather than the drawer keeping its old hardcoded fixed position untouched).
+      const placed = cons.some(c => c.indexOf('§PANEL_PLACE') >= 0 && c.indexOf('hba-fm-drawer') >= 0);
+      verdict(placed, 'D3 A._placePanel ran for the drawer (§PANEL_PLACE log line seen)', cons.filter(c => c.indexOf('PANEL_PLACE') >= 0).join(' | '));
+
+      // D2 — arrow-nav: PanelNav only routes ArrowDown to a panel once scene.js's panel-focus model
+      // (_focusedPanel) actually points at it — that happens on a real pointerdown ANYWHERE inside
+      // the panel (viewer/scene.js's _registerPanel), not a bare DOM .focus() call. Click the drawer
+      // header (neutral — not a lens-row button, so it doesn't also toggle a lens) to establish
+      // focus, THEN drive two ArrowDown presses and confirm PanelNav's own row highlight (§panel_nav.js
+      // _highlightItem) lands on row 0 then row 1 (its zone starts at index -1, so the FIRST
+      // ArrowDown lands on the first row, not the second).
+      const rowIds = await page.evaluate(() => Array.from(document.querySelectorAll('#hba-fm-rows button:not([disabled])')).map(b => b.getAttribute('data-lens')));
+      if (rowIds.length >= 2) {
+        await page.click('#hba-fm-drawer div:has-text("Human-Asset")').catch(() => {});
+        await page.keyboard.press('ArrowDown');
+        await page.waitForTimeout(150);
+        const out0 = await page.evaluate((id) => { var b = document.querySelector('#hba-fm-rows button[data-lens="' + id + '"]'); return b && b.style.outline; }, rowIds[0]);
+        await page.keyboard.press('ArrowDown');
+        await page.waitForTimeout(150);
+        const out0b = await page.evaluate((id) => { var b = document.querySelector('#hba-fm-rows button[data-lens="' + id + '"]'); return b && b.style.outline; }, rowIds[0]);
+        const out1 = await page.evaluate((id) => { var b = document.querySelector('#hba-fm-rows button[data-lens="' + id + '"]'); return b && b.style.outline; }, rowIds[1]);
+        verdict(!!out0 && out0.indexOf('none') < 0, 'D2a first ArrowDown highlights row 0 (zone starts at index -1)', 'row0.outline=' + out0);
+        verdict((!out0b || out0b.indexOf('none') >= 0 || out0b === '') && !!out1 && out1.indexOf('none') < 0,
+          'D2b second ArrowDown moves the highlight from row 0 to row 1', 'row0.outline=' + out0b + ' row1.outline=' + out1);
+      } else {
+        verdict(false, 'D2 ArrowDown moves PanelNav focus across rows', 'SKIPPED — fewer than 2 available rows in this building: ' + JSON.stringify(rowIds));
+      }
+
+      verdict(errs.length === 0, '0 pageerrors (desktop)', errs.slice(0, 5).join(' | '));
+    }
+    await page.close();
+  }
+
+  // ══ MOBILE — drawer stays a floating overlay (deliberately outside HbaPaneHost's stack) ══════
+  {
+    // hasTouch/isMobile make navigator.maxTouchPoints > 0 true under real Chromium, so
+    // viewer/config.js's OWN detection (`window._isMobile = 'ontouchstart' in window ||
+    // navigator.maxTouchPoints > 0`) naturally computes true — an addInitScript override would get
+    // clobbered the moment config.js's <script> runs later in the same page load.
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+    const errs = [];
+    page.on('console', m => log.push('  [console] ' + m.text()));
+    page.on('pageerror', e => { errs.push(String(e)); log.push('  [pageerror] ' + e); });
+    S('§W-PANEL-ABSTRACTION — mobile @390px (Human-Asset drawer stays a floating overlay)');
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    const ready = await waitReady(page);
+    verdict(ready, 'real model loaded + ready, mobile (HHS_Office_Federated)');
+    if (ready) {
+      await page.click('#mobile-trigger').catch(() => {});
+      await page.waitForTimeout(300);
+      await page.click('#pill-hbaFM');
+      await page.waitForTimeout(400);
+
+      // M1 — the drawer opens fine on mobile and is NOT one of HbaPaneHost's cards (it stays the
+      // separate launcher chip syncLauncher() already assumes it is).
+      const st1 = await page.evaluate(() => ({
+        drawerExists: !!document.getElementById('hba-fm-drawer'),
+        inStack: !!(window.HbaPaneHost && window.HbaPaneHost._state().ids.indexOf('hba-fm-drawer') >= 0)
+      }));
+      verdict(st1.drawerExists && !st1.inStack, 'M1 drawer opens on mobile as a floating overlay, NOT a HbaPaneHost stack card', JSON.stringify(st1));
+
+      // M2 — the drawer's own ✕ still removes it cleanly, independent of the (empty, here) stack.
+      try {
+        await page.click('#hba-fm-drawer button[data-role="close"]', { timeout: 5000 });
+      } catch (e) { log.push('  [M2 click error] ' + e); }
+      await page.waitForTimeout(300);
+      const goneCheck = await page.evaluate(() => !document.getElementById('hba-fm-drawer'));
+      verdict(goneCheck, 'M2 ✕ removes the drawer cleanly on mobile (zero residue)');
+
+      verdict(errs.length === 0, '0 pageerrors (mobile)', errs.slice(0, 5).join(' | '));
+    }
+    await page.close();
+  }
+
+  await browser.close(); server.close();
+  const pass = fails === 0;
+  S('\n§W-PANEL-ABSTRACTION ' + (pass ? 'PASS' : 'FAIL') + ' (fails=' + fails + ')');
+  fs.writeFileSync(path.join(__dirname, 'witness_panel_abstraction.log'), log.join('\n'));
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Human-Asset pill stayed highlighted after its drawer's own ✕ closed it — same bug class as `PILL_DRAWER_REORGANIZATION.md` Item 1 (already fixed for the other 3 master drawers), never back-ported here.
- Generalized instead of patching one pill: `common/pill_builder.js` gets a `MutationObserver`-based auto-resync (any panel add/remove anywhere resyncs all pill highlights, no manual call needed from future drawers).
- `A.createPanel()` (`viewer/panels.js`) gains Arrow-key row navigation (wiring the existing-but-unused `panel_nav.js`) and `A._placePanel()`, a no-overlap desktop placement helper replacing hardcoded per-pane magic-number column offsets already present in `hba_bom.js`/`hba_iot.js`/`hba_dashboard.js`.
- The Human-Asset drawer (`viewer/hba_lens.js`) migrated onto this shared infrastructure as the flagship instance (draggable, arrow-nav, no-overlap placement).
- Tried folding the drawer into the existing mobile card-stack (`HbaPaneHost`) too; live-testing surfaced a real design conflict (picker vs. content lifecycle) — reverted that specific piece, kept it a floating overlay on mobile, consistent with the file's own pre-existing `syncLauncher()` treatment.

## Test plan
- [x] `node viewer/tests/witness_hba_pill_desync_fix.js` — new, proves the original bug fixed
- [x] `node viewer/tests/witness_panel_abstraction.js` — new, proves draggable/arrow-nav/placement + mobile floating-overlay behavior
- [x] `node viewer/tests/witness_hba_outline_panel_fixes.js` — pre-existing regression, unaffected
- [x] `node viewer/tests/poc_hba_mobile_stack.js` — pre-existing 6-pane mobile stack regression, unaffected
- [x] `node hr_bim_asset/tests/witness_family.js` — node-level family API, unaffected

Full write-up: `prompts/RESUME_HR_BIM_ASSET.md` §2026-07-06d (bim-compiler, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)