### PR TITLE
feat(modeller): M1 — bridge ARC-derived anchors into routewalker.js pattern engine

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -623,6 +623,133 @@
     return { segs: segs, byRule: byRule };
   }
 
+  // ── PATTERN-TOPOLOGY BRIDGE (RESUME_MODELLER_WALK_SUBSTRATE.md §CAMPAIGN M1, REDIRECTED 2026-07-07: bridge
+  // ARC-derived anchors into routewalker.js's ALREADY-PROVEN ad_mep_pattern engine — do not reinvent a second,
+  // less-tested generation mechanism here) ──────────────────────────────────────────────────────────────────
+  // routewalker.js's _rwApplyPattern/_rwPairSegments is a faithful JS port of RouteWalker.java (same node-type
+  // mapping, same nearest-unmatched-anchor pairing, same GRADIENT slope rule, same ARC-clash skip — the engine
+  // DAGCompiler's RouteWalkerTest.java exercises 7/7 against HospitalAuckland, PR #450/#456). It is normally
+  // anchor-DEPENDENT: it reads PRE-MINED ad_mep_anchor rows keyed to one of 3 hardcoded building names via
+  // mep_rw.db (the "drop a BOM assembly" flow, modeller.html autoRouteMEP). This bridges the SAME pairing engine
+  // to an ARBITRARY opened ARC-only building by deriving the anchor roles LIVE, mirroring defaultSeed()'s own
+  // technique (a real element, heuristically picked, human-confirmable):
+  //   METER   = the service-entry door (defaultSeed, IfcDoor)            — CW's mains connection point.
+  //   STACK   = the nearest real stair/riser core (defaultSeed, IfcStair) — SP's vertical drain-stack point
+  //             (ad_mep_anchor's schema has no separate STACK anchor_type — a METER-typed anchor becomes a
+  //             STACK NODE only when the pattern discipline is SP; _rwToNodeType's own mapping, unchanged here).
+  //   FIXTURE = this discipline's OWN measured density-placed fixtures (place()) — already non-invented.
+  //   JUNCTION= real corridor WAYPOINTS, sampled off SeedTrunk.planTrunk's already-proven, wall-avoiding
+  //             Dijkstra backbone (reuses seed_trunk's corridor derivation for WAYPOINT POSITIONS ONLY — the
+  //             actual pairing/gradient/clash DECISION is routewalker's own _rwPairSegments, untouched).
+  // SCOPE, MEASURED not assumed: `ad_mep_pattern` carries rows for exactly two disciplines, 'CW' (pressurised
+  // cold-water supply) and 'SP' (gravity soil/waste drain) — both PLUMBING sub-networks (routewalker.js's own
+  // RW_DISC_TO_COORD: CW/SP→DWATER/DRAIN, same table PLB→DWATER). So this bridges disc_walker's 'PLB' discipline
+  // to a CW pass + an SP pass. ELEC/ACMV/FP have ZERO ad_mep_pattern rows (checked directly against ERP.db) —
+  // they honestly REFUSE via this bridge (no pattern to walk), which is the correct refuse-beats-fabricate
+  // answer, not a bug: covering them would need someone to MINE+author their own pattern rows first (a data
+  // task), not a code generalization this bridge can manufacture. NON-INVENT: every anchor is a real element
+  // position (door/stair/measured-generated-fixture) or a real wall-avoiding corridor waypoint; the pairing/
+  // gradient/clash logic is routewalker.js's own proven code, called, never re-implemented.
+  var _RW_PATTERN_DISC = { PLB: ['CW', 'SP'] };                 // disc_walker disc -> routewalker pattern discipline(s)
+  // real IfcStair columns, deduped by XY (mirrors modeller.html's own _seedRisers) — the riser/STACK candidates
+  // SeedTrunk climbs and this bridge treats as the SP discipline's STACK proxy.
+  function _risers(bdb) {
+    var r = _rows(bdb, "SELECT m.guid g, t.center_x x, t.center_y y FROM elements_meta m JOIN element_transforms t " +
+      "ON m.guid=t.guid WHERE m.ifc_class LIKE '%Stair%'");
+    var out = [];
+    r.forEach(function (s) { if (!out.some(function (o) { return Math.hypot(o.x - s.x, o.y - s.y) < 0.5; })) out.push(s); });
+    return out;
+  }
+  // Sample SeedTrunk's corridor backbone every `step` metres into JUNCTION-role waypoint anchors. Pure position
+  // derivation — no pairing decision made here (that is entirely _rwPairSegments' job on the anchors we hand it).
+  function _corridorJunctions(bdb, seed, placements, sub, opts) {
+    var ST = (opts && opts.SeedTrunk) || ROOT.SeedTrunk;
+    if (!ST) return [];
+    var risers = _risers(bdb);
+    var net = ST.planTrunk(bdb, placements, seed, risers, { storeys: sub, groundStorey: seed.storey });
+    if (net.refused === true) return [];
+    var STEP = (opts && opts.junctionStep > 0) ? opts.junctionStep : 3, out = [], seen = {}, n = 0;
+    net.storeys.forEach(function (st) {
+      (st.edges || []).forEach(function (poly) {
+        var acc = 0;
+        for (var i = 1; i < poly.length; i++) {
+          var a = poly[i - 1], b = poly[i];
+          acc += Math.sqrt((b[0] - a[0]) * (b[0] - a[0]) + (b[1] - a[1]) * (b[1] - a[1]) + (b[2] - a[2]) * (b[2] - a[2]));
+          if (acc >= STEP) {
+            var k = b[0].toFixed(2) + ',' + b[1].toFixed(2) + ',' + b[2].toFixed(2);
+            if (!seen[k]) { seen[k] = 1; out.push({ anchorId: 'JN' + (n++), anchorType: 'GENERIC', x: b[0], y: b[1], z: b[2], storey: st.name }); }
+            acc = 0;
+          }
+        }
+      });
+    });
+    return out;
+  }
+  function routePattern(disc, bdb, opts) {
+    opts = opts || {};
+    var loadSteps = opts.loadPatternSteps || ROOT._rwLoadPatternSteps;
+    var pair = opts.pairSegments || ROOT._rwPairSegments;
+    var loadArc = opts.loadArcEnvelope || ROOT._rwLoadArcEnvelope;
+    if (typeof loadSteps !== 'function' || typeof pair !== 'function') {
+      return { segs: [], refused: true, reason: 'routewalker.js pattern engine not loaded' };
+    }
+    // routewalker.js's _rwLoadPatternSteps reads its OWN module-scope _rwDb (populated only after rwInit(SQL,
+    // baseUrl) resolves, today only awaited by the BOM-drop flow's _rwReadyOnce()). Rather than reach into that
+    // async init from here (this function stays sync, like routeChains/place — no new async surface on the
+    // live walk path), honestly refuse when it hasn't run yet; the caller wires rwInit() before Walk (see
+    // RESUME_MODELLER_WALK_SUBSTRATE.md M1 follow-on note) or passes opts.loadPatternSteps/opts.pairSegments
+    // directly (a witness's own explicit rwInit, as this file's tests do).
+    if (!opts.loadPatternSteps && !(opts.rwReady != null ? opts.rwReady : ROOT._rwReady)) {
+      return { segs: [], refused: true, reason: 'routewalker.js mep_rw.db pattern table not loaded (call rwInit first)' };
+    }
+    var rwDiscs = (opts.rwPatternDisc || _RW_PATTERN_DISC)[disc];
+    if (!rwDiscs) return { segs: [], refused: true, reason: 'no ad_mep_pattern coverage for ' + disc + ' (CW/SP only, PLB-mapped)' };
+    var sub = opts.storeys || substrate(bdb);
+    if (!sub.length) return { segs: [], refused: true, reason: 'no habitable storeys' };
+    var placements = opts.placements || place(disc, sub, bdb);
+    if (!placements.length) return { segs: [], refused: true, reason: 'no measured placement rule for ' + disc };
+    var seed = (opts.seed && opts.seed.guid) ? opts.seed : defaultSeed(bdb, {});
+    if (seed.refused) return { segs: [], refused: true, reason: seed.reason };
+    var riser = defaultSeed(bdb, { classes: ['IfcStair'] });    // STACK proxy; refusal here is honest (e.g. single-storey)
+    var junctions = _corridorJunctions(bdb, seed, placements, sub, opts);
+    var fixtureAnchors = placements.map(function (p, i) {
+      return { anchorId: 'FX' + i, anchorType: 'FIXTURE', x: p.x, y: p.y, z: p.z, storey: p.storey };
+    });
+    var arcEnv = opts.arcEnvelope || (typeof loadArc === 'function' ? loadArc(bdb) : []);
+    var segs = [], byRule = [];
+    rwDiscs.forEach(function (rwd) {
+      // Defensive boundary: routewalker.js's rwInit has a KNOWN latent bug (found this pass, not fixed here —
+      // out of scope, a separate file with its own witness suite) — it sets its readiness flag TRUE before
+      // confirming mep_rw.db actually parsed (a failed/404 fetch can leave _rwReady=true over a garbage DB
+      // handle); the first real query against it then throws deep inside loadSteps/pair. That must never crash
+      // the WHOLE walk (refuse-beats-fabricate applies to engine failures too, not just missing data) — so this
+      // pass is try/catched into an honest per-rwd skip, exactly like assemble()'s own try/catch in modeller.html.
+      try {
+        var steps = loadSteps(rwd, opts.buildingType || 'GENERIC');
+        if (!steps.length) { byRule.push({ from: 'pattern:' + rwd, to: disc, mode: rwd, segs: 0, noNbr: 0, skipped: 'no-pattern-steps' }); return; }
+        // METER role: the door-seed feeds CW's mains entry; the stair-riser feeds SP's STACK (via _rwToNodeType's
+        // own METER->STACK mapping for discipline='SP') — kept SEPARATE per pass so a stair is never mistaken for
+        // a cold-water main and a door is never mistaken for a drain stack.
+        var meterAnchor = (rwd === 'SP')
+          ? (riser.refused ? null : { anchorId: 'STK0', anchorType: 'METER', x: riser.x, y: riser.y, z: riser.z, storey: riser.storey })
+          : { anchorId: 'MTR0', anchorType: 'METER', x: seed.x, y: seed.y, z: seed.z, storey: seed.storey };
+        if (!meterAnchor) { byRule.push({ from: 'pattern:' + rwd, to: disc, mode: rwd, segs: 0, noNbr: 0, skipped: 'no-stack-riser' }); return; }
+        var anchors = fixtureAnchors.concat(junctions, [meterAnchor]);
+        var out = [];
+        pair(rwd, steps, anchors, arcEnv, out);
+        out.forEach(function (s) {
+          segs.push({ disc: disc, rule: 'pattern:' + rwd, from_kind: 'RW_' + rwd, to_kind: 'RW_' + rwd,
+            from: s.from, to: s.to, storey: s.storey, mode: 'pattern-bridge', axis: s.axis });
+        });
+        byRule.push({ from: 'pattern:' + rwd, to: disc, mode: rwd, segs: out.length, noNbr: 0, steps: steps.length, anchors: anchors.length });
+      } catch (e) {
+        byRule.push({ from: 'pattern:' + rwd, to: disc, mode: rwd, segs: 0, noNbr: 0, skipped: 'engine-error: ' + (e && e.message) });
+      }
+    });
+    return { segs: segs, refused: false, seed: seed, riser: riser.refused ? null : riser, byRule: byRule,
+      anchorCounts: { fixture: fixtureAnchors.length, junction: junctions.length } };
+  }
+
   // ── ROUTE → ASSEMBLE bridge (docs/WalkerDoctrine.md roadmap #3) ──────────────────────────────────
   // routeChains gives the real nn-NETWORK (segments between real extracted element guids). assemble() turns that
   // network into instantiated catalog PARTS: at each routed NODE (a real element endpoint), instantiate the matching
@@ -979,11 +1106,22 @@
     }
     var chains = route(disc, bdb);
     var rc = routeChains(disc, bdb);                         // LIVE nn-chain geometry (real on MEP-rich bldgs, 0 on residents)
+    // §CAMPAIGN M1 bridge: routeChains legitimately returns 0 on an ARC-only building (no real MEP elements
+    // exist to nn-pair — that is the whole reason the discipline needs GENERATING). When it does, try the
+    // ARC-derived-anchors → routewalker.js pattern-topology bridge (routePattern, PLB-only per its own measured
+    // ad_mep_pattern coverage) before falling back to an honest 0. opts.noPattern=true restores the old
+    // byte-identical behaviour (used by generalization/regression checks that want routeChains in isolation).
+    var patternInfo = null;
+    if (!rc.segs.length && !(opts && opts.noPattern)) {
+      var pat = routePattern(disc, bdb, { placements: placements, buildingType: buildingName });
+      if (!pat.refused && pat.segs.length) { rc = { segs: pat.segs, byRule: pat.byRule }; patternInfo = pat; }
+      else if (pat.refused) console.log(TAG + ' §WALK-PATTERN disc=' + disc + ' bldg=' + buildingName + ' REFUSE ' + pat.reason);
+    }
     console.log(TAG + ' §WALK disc=' + disc + ' bldg=' + buildingName + ' placed=' + placements.length +
       ' chains=' + chains.length + ' chainSegs=' + rc.segs.length + ' storeys=' + sub.length +
       (rc.byRule.length ? ' [' + rc.byRule.map(function (b) { return b.from.replace('Ifc', '') + '→' + b.to.replace('Ifc', '') + ':' + (b.skipped || (b.segs + '/' + (b.segs + b.noNbr))); }).join(' ') + ']' : ''));
     return { disc: disc, refused: false, placed: placements.length, placements: placements, hostBind: hbInfo,
-      chains: chains, chainSegs: rc.segs, chainByRule: rc.byRule, storeys: sub.length };
+      chains: chains, chainSegs: rc.segs, chainByRule: rc.byRule, storeys: sub.length, patternBridge: patternInfo };
   }
 
   // ── SEED PICKER (human-in-the-loop service entry; W-SEED-TRUNK / W-SEED-DEFAULT) ──────────────────
@@ -1034,7 +1172,7 @@
   }
 
   var API = { dwInit: dwInit, dwOpen: dwOpen, dwBorrow: dwBorrow, dwBorrowFile: dwBorrowFile, dwWalk: dwWalk, assemble: assemble, connectorFor: connectorFor, connectorEnrich: connectorEnrich, substrate: substrate, place: place, hostBind: hostBind,
-    route: route, routeChains: routeChains, gate: gate, repRules: repRules, order: order, clearance: clearance,
+    route: route, routeChains: routeChains, routePattern: routePattern, gate: gate, repRules: repRules, order: order, clearance: clearance,
     hostWalls: hostWalls, countPer: countPer, occupancy: occupancy, defaultSeed: defaultSeed,
     _shimForDisc: _shimForDisc, _shimForFixture: _shimForFixture, _loadRuleShims: _loadRuleShims,
     disciplines: disciplines, loadedFile: loadedFile, _ready: function () { return _ready; } };

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -3121,6 +3121,14 @@ async function _discWalkOne(disc, ctx, opts) {
     try { await window.DiscWalker.dwInit(window.SQL, './', window._dwRules(name || window.__dwName)); }
     catch (e) { setStat(disc + ' — rules not available'); console.warn('§DISC-WALK dwInit failed ' + (e && e.message)); return { refused: true, reason: 'rules not available', placed: 0 }; }
     await window._dwEnsureBorrow();   // residential builds borrow FP/sprinkler from terminal_rules (doctrine §2)
+    // §CAMPAIGN M1: lazy-load mep_rw.db's ad_mep_pattern table (SAME _rwReadyOnce the BOM-drop flow already
+    // uses) so DiscWalker.dwWalk's routeChains-0 → routePattern bridge (disc_walker.js) can pair ARC-derived
+    // anchors through routewalker.js's proven pattern engine instead of refusing for "not loaded yet". Gated
+    // on disc==='PLB' — the ONLY discipline routePattern's _RW_PATTERN_DISC map covers today (ad_mep_pattern
+    // has CW/SP rows only) — so ELEC/ACMV/FP/STR walks never pay this fetch+parse cost for a bridge they can't
+    // use (W-E2E-WALK's own timing gate caught the unconditional version adding latency to every discipline).
+    // Best-effort: a failed/slow fetch does NOT block the walk — routePattern's own guard refuses honestly.
+    if (disc === 'PLB') { try { await _rwReadyOnce(); } catch (e) { /* routePattern refuses cleanly if this never resolves */ } }
     if (!window.__dwBuf) { setStat(disc + ' — open a building first'); console.log('§DISC-WALK ' + disc + ' no-building (open a resident first)'); return { refused: true, reason: 'no building open', placed: 0 }; }
     var bdb = new window.SQL.Database(new Uint8Array(window.__dwBuf));   // read-only re-open of the open building
     var w = window.DiscWalker.dwWalk(disc, bdb, name || window.__dwName || '');

--- a/modeller/routewalker.js
+++ b/modeller/routewalker.js
@@ -73,9 +73,13 @@ async function rwInit(SQL, baseUrl) {
   var url = (baseUrl || '') + MEP_RW_DB_URL;
   try {
     var buf = await _rwFetchCached(url);
-    _rwDb = new SQL.Database(new Uint8Array(buf));
-    _rwReady = true;
-    var counts = _rwDb.exec(
+    var db = new SQL.Database(new Uint8Array(buf));
+    // §M1-FIX: validate via a REAL query BEFORE flipping _rwReady — `new SQL.Database(garbageBuf)` (e.g. a
+    // 404 body that slipped past _rwFetchCached) does not always throw at construction; the first real query
+    // is what surfaces "file is not a database". _rwReady used to flip true BEFORE this query, so a failed
+    // load left it wrongly true over a dead _rwDb handle — every later caller (routePattern's bridge included)
+    // would then skip its own "not ready" guard and crash deep inside a real query instead of refusing cleanly.
+    var counts = db.exec(
       "SELECT (SELECT COUNT(*) FROM ad_space_type_mep_bom) as bom, " +
       "(SELECT COUNT(*) FROM ad_mep_pattern) as pat, " +
       "(SELECT COUNT(*) FROM ad_mep_anchor) as anc, " +
@@ -83,6 +87,7 @@ async function rwInit(SQL, baseUrl) {
       "(SELECT COUNT(*) FROM _shim_attributes) as shim, " +
       "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='arc_envelope') as has_arc"
     );
+    _rwDb = db; _rwReady = true;
     var r = counts[0].values[0];
     console.log('§RW_INIT mep_rw.db loaded bom=' + r[0] + ' patterns=' + r[1] +
                 ' anchors=' + r[2] + ' offsets=' + r[3] + ' shims=' + r[4] + ' arc_env=' + r[5]);
@@ -1236,13 +1241,29 @@ function _rwInsertElement(db, guid, ifcClass, name, building, storey, disc, rgba
 // IndexedDB cache for mep_rw.db
 // ═══════════════════════════════════════════════════════════════
 
+// §M1-FIX (found + fixed this pass, pre-existing latent bug — NOT introduced by the pattern bridge, just the
+// first thing that actually exercised this code path on a fresh IFC-open session): two real bugs, both now
+// defended —
+// (1) `bim_ootb_cache` can be created by ANOTHER caller first (disc_walker.js's own _openCacheDB, no version,
+//     no store) at version 1 with NO 'dbs' object store. This function's `indexedDB.open(…, 1)` then sees "no
+//     version change needed" → onupgradeneeded never fires → `idb.transaction('dbs', …)` throws NotFoundError
+//     SYNCHRONOUSLY inside a DOM event handler — a throw there is NOT caught by the wrapping `new Promise`
+//     executor (it's a callback, not a continuation of it) and surfaces as an UNCAUGHT pageerror that bypasses
+//     every .catch() in the chain (confirmed live: W-E2E-WALK-IFCOPEN G4-G6 failed with exactly this
+//     DOMException on a fresh IFC-open session). Fixed: guard every `idb.transaction('dbs', …)` in try/catch,
+//     falling back to a bare fetch on failure — mirrors disc_walker.js's own `_idbGet`/`_idbPut` defensive style.
+// (2) The two fallback fetch branches (get.onerror/req.onerror) never checked `resp.ok` — a 404 response body
+//     was silently accepted as if it were the database (confirmed live: a 404 "404" text body passed straight
+//     to `new SQL.Database()`, throwing "file is not a database"). Fixed: same `if (!resp.ok) throw` guard the
+//     primary path already had.
 function _rwFetchCached(url) {
   return new Promise(function(resolve, reject) {
     var req = indexedDB.open('bim_ootb_cache', 1);
-    req.onupgradeneeded = function() { req.result.createObjectStore('dbs'); };
+    req.onupgradeneeded = function() { if (!req.result.objectStoreNames.contains('dbs')) req.result.createObjectStore('dbs'); };
     req.onsuccess = function() {
-      var idb = req.result;
-      var tx = idb.transaction('dbs', 'readonly');
+      var idb = req.result, tx;
+      try { tx = idb.transaction('dbs', 'readonly'); }
+      catch (e) { console.warn('§RW_CACHE_TX_FAIL ' + e.message + ' — bare fetch'); fetch(url).then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.arrayBuffer(); }).then(resolve).catch(reject); return; }
       var get = tx.objectStore('dbs').get('rw_' + url);
       get.onsuccess = function() {
         if (get.result) {
@@ -1263,11 +1284,11 @@ function _rwFetchCached(url) {
         }
       };
       get.onerror = function() {
-        fetch(url).then(function(r) { return r.arrayBuffer(); }).then(resolve).catch(reject);
+        fetch(url).then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.arrayBuffer(); }).then(resolve).catch(reject);
       };
     };
     req.onerror = function() {
-      fetch(url).then(function(r) { return r.arrayBuffer(); }).then(resolve).catch(reject);
+      fetch(url).then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.arrayBuffer(); }).then(resolve).catch(reject);
     };
   });
 }

--- a/modeller/tests/witness_route_pattern_bridge.js
+++ b/modeller/tests/witness_route_pattern_bridge.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ROUTE-PATTERN-BRIDGE scope (read this block first)
+ * SCOPE: RESUME_MODELLER_WALK_SUBSTRATE.md §CAMPAIGN M1, REDIRECTED 2026-07-07 — "bridge ARC-derived anchors
+ *   into routewalker.js's already-proven ad_mep_pattern engine, don't reinvent generation in disc_walker.js/
+ *   seed_trunk.js." This gate MEASURES two claims, not assumes them:
+ *   (1) On an ARC-only building (Duplex — verified zero real MEP/pipe/fixture elements_meta rows), routeChains
+ *       ('PLB', bdb) is honestly 0 (nothing real to nn-pair) BEFORE the bridge, and disc_walker.js's new
+ *       routePattern() bridge — derived METER=door-seed, STACK=stair-riser, FIXTURE=place()'s own measured
+ *       output, JUNCTION=SeedTrunk corridor waypoints — makes DiscWalker.dwWalk('PLB',…).chainSegs flip 0→N by
+ *       calling routewalker.js's OWN _rwPairSegments (the function RouteWalker.java's Java-side W-PATTERN-CW/
+ *       W-PATTERN-SP 7/7 tests exercise the ported logic of), not a second nn/Dijkstra mechanism.
+ *   (2) Discipline-agnostic check, MEASURED not assumed: `ad_mep_pattern` carries rows for exactly CW+SP
+ *       (both PLUMBING sub-networks — routewalker.js's own RW_DISC_TO_COORD maps CW/SP/PLB all to DWATER/DRAIN).
+ *       ELEC/ACMV have ZERO ad_mep_pattern rows, so the SAME bridge must HONESTLY REFUSE for them (not silently
+ *       stay 0 as if untried, and not fabricate a network) — this is the "measure it, don't assume" instruction.
+ *   Drives the REAL production path (window.discWalk — the Outliner "Walk" row's handler, per
+ *   feedback_test_real_user_path_not_seams) for the render/commit/undo integration, PLUS a direct engine-seam
+ *   check (DiscWalker.routeChains/dwWalk) for the byRule/anchor-count numbers a screenshot can't show.
+ * THE WORKING SWIFTSHADER FLAGS: --use-gl=angle --use-angle=swiftshader (precedent witness_dw_pixelprobe.js).
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+// NOTE (found this pass, logged not fixed here — separate pre-existing regression, not M1's scope): the live
+// isolated modeller serves modeller.html from GH Pages `modeller/` but routewalker.js fetches `mep_rw.db`
+// relative to THAT page — and mep_rw.db is git-tracked/deployed only under `viewer/` (confirmed: GH Pages
+// modeller/mep_rw.db → 404 live; viewer/mep_rw.db → 200). So the BOM-drop auto-route (autoRouteMEP) is
+// currently non-functional on the real isolated modeller, unrelated to this bridge. This witness's local
+// server fixture-serves it at the modeller-relative path the code expects, so THIS bridge (a disc_walker.js/
+// modeller.html change, independent of where mep_rw.db is hosted) can be measured correctly.
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  let fp = path.join(ROOT, p);
+  if (p === '/modeller/mep_rw.db' && !fs.existsSync(fp)) fp = path.join(ROOT, 'viewer', 'mep_rw.db');
+  fs.readFile(fp, (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  const logs = []; pg.on('console', m => { const t = m.text(); if (/^§(DW|RW)/.test(t)) logs.push(t); });
+
+  console.log('═══ W-ROUTE-PATTERN-BRIDGE — Duplex (ARC-only) PLB: routeChains 0 → routePattern bridge N, + honest ELEC/ACMV refuse ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai && typeof window.discWalk==="function"', { timeout: 30000 }).catch(() => {});
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(1500);
+
+  // ── PREMISE: routeChains('PLB', bdb) is honestly 0 on this ARC-only building (measured, not assumed) ──
+  const premise = await pg.evaluate(async () => {
+    await window.DiscWalker.dwInit(window.SQL, './', window._dwRules(window.__dwName));
+    await window._dwEnsureBorrow();
+    const bdb = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+    const rc = window.DiscWalker.routeChains('PLB', bdb);
+    const arcMepRows = bdb.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class LIKE '%Pipe%' OR ifc_class LIKE '%Sanitary%' OR ifc_class LIKE '%FlowTerminal%'")[0].values[0][0];
+    bdb.close();
+    return { routeChainsSegs: rc.segs.length, arcMepRows: arcMepRows };
+  });
+
+  // ── ENGINE SEAM: direct dwWalk (both WITHOUT and WITH the pattern bridge) for the byRule/anchor numbers ──
+  const engine = await pg.evaluate(async () => {
+    await window.rwInit(window.SQL, './');   // load mep_rw.db's ad_mep_pattern table (SAME lazy-init the BOM-drop flow uses)
+    const bdb1 = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+    const noPattern = window.DiscWalker.dwWalk('PLB', bdb1, window.__dwName, { noPattern: true });
+    bdb1.close();
+    const bdb2 = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+    const withPattern = window.DiscWalker.dwWalk('PLB', bdb2, window.__dwName);
+    bdb2.close();
+    // discipline-agnostic check: ELEC/ACMV have NO ad_mep_pattern rows — must honestly refuse, not silently 0
+    const bdb3 = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+    const elecPattern = window.DiscWalker.routePattern('ELEC', bdb3, {});
+    const acmvPattern = window.DiscWalker.routePattern('ACMV', bdb3, {});
+    bdb3.close();
+    return {
+      noPatternSegs: noPattern.chainSegs.length,
+      withPatternSegs: withPattern.chainSegs.length,
+      byRule: withPattern.chainByRule,
+      anchorCounts: withPattern.patternBridge && withPattern.patternBridge.anchorCounts,
+      seedGuid: withPattern.patternBridge && withPattern.patternBridge.seed && withPattern.patternBridge.seed.guid,
+      riser: withPattern.patternBridge && withPattern.patternBridge.riser,
+      elecRefused: elecPattern.refused, elecReason: elecPattern.reason,
+      acmvRefused: acmvPattern.refused, acmvReason: acmvPattern.reason
+    };
+  });
+
+  // ── REAL PRODUCTION PATH: window.discWalk('PLB', …) — the Outliner "Walk" handler — render + commit ──
+  const before = await pg.evaluate(() => ({ oplogLen: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor }));
+  await pg.evaluate(() => window.discWalk('PLB', { building: window.__dwName }));
+  const completed = await pg.waitForFunction(() => window.__dwLastCommitDisc === 'PLB', { timeout: 25000, polling: 250 }).then(() => true).catch(() => false);
+  // PLB has a non-zero chainSegs (the bridge), so _discWalkOne ALSO awaits _commitDiscChains after
+  // _commitDiscWalk — a second, separate signed commit with its OWN sentinel (__dwLastChainDisc). Waiting on
+  // __dwLastCommitDisc alone races the chain commit (seen once as a flaky undo — plbObjs/instances not cleared).
+  const chainCommitted = await pg.waitForFunction(() => window.__dwLastChainDisc === 'PLB', { timeout: 25000, polling: 250 }).then(() => true).catch(() => false);
+  await sleep(400);
+  const after = await pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    const kids = root ? root.children : [];
+    const chainTubes = kids.filter(o => o.userData && o.userData.dwChain === 'PLB');
+    return { oplogLen: window.Bonsai.oplog.length, cur: window.Bonsai.oplog.cursor,
+      n: (window.__dwWalks && window.__dwWalks.PLB || []).length, chainTubes: chainTubes.length };
+  });
+  const chain = await pg.evaluate(async () => { try { const db = await window.Bonsai.oplog._ensureDb(); const v = await window.KernelOps.verifyChain(db); return !!v.ok; } catch (e) { return 'ERR:' + e.message; } });
+  // undo back to pre-walk (reversibility, mirrors W-E2E-WALK's own W6)
+  await pg.evaluate(c => { const s = document.getElementById('hist-slider'); s.value = c; s.dispatchEvent(new Event('input', { bubbles: true })); }, before.cur);
+  await sleep(600);
+  // undo signal = RENDERED instances (mirrors W-E2E-WALK's own W6) — window.__dwWalks[disc] is walk-time
+  // bookkeeping only, never wired to the op-log cursor/history-scrub, so it's the wrong field to check here.
+  const undo = await pg.evaluate(() => {
+    const g = window.Bonsai.group(); const root = g && g.children.find(o => o.userData && o.userData.dwRoot);
+    const kids = root ? root.children : [];
+    const plb = kids.filter(o => o.userData && o.userData.dwDisc === 'PLB');
+    const instances = plb.reduce((a, o) => a + (o.isInstancedMesh ? (o.count || 0) : 0), 0);
+    return { cur: window.Bonsai.oplog.cursor, plbObjs: plb.length, instances: instances };
+  });
+
+  await br.close(); server.close();
+
+  console.log('  §PREMISE ' + JSON.stringify(premise));
+  console.log('  §ENGINE ' + JSON.stringify(engine));
+  console.log('  §PRODPATH completed=' + completed + ' before=' + JSON.stringify(before) + ' after=' + JSON.stringify(after));
+  console.log('  §CHAIN verifyChain=' + chain);
+  console.log('  §UNDO ' + JSON.stringify(undo));
+  logs.slice(0, 40).forEach(l => console.log('    ' + l));
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  chk('P1 PREMISE routeChains=0 on ARC-only Duplex', premise.routeChainsSegs === 0 && premise.arcMepRows === 0, JSON.stringify(premise));
+  chk('P2 noPattern (opts.noPattern) stays 0 — old behaviour byte-identical', engine.noPatternSegs === 0, 'noPatternSegs=' + engine.noPatternSegs);
+  chk('P3 BRIDGE flips 0→N via routewalker.js pattern engine', engine.withPatternSegs > 0, 'withPatternSegs=' + engine.withPatternSegs);
+  chk('P4 CW+SP both produced segments (byRule)', engine.byRule && engine.byRule.filter(b => b.mode === 'CW' && b.segs > 0).length > 0 && engine.byRule.filter(b => b.mode === 'SP' && b.segs > 0).length > 0, JSON.stringify(engine.byRule));
+  chk('P5 anchors are REAL (seed=door guid, riser=stair, junctions>0)', !!engine.seedGuid && !!engine.riser && engine.anchorCounts && engine.anchorCounts.junction > 0, JSON.stringify({ seedGuid: engine.seedGuid, riser: engine.riser, anchorCounts: engine.anchorCounts }));
+  chk('P6 DISCIPLINE-AGNOSTIC CHECK, measured: ELEC/ACMV honestly REFUSE (no ad_mep_pattern rows), not silent-0', engine.elecRefused === true && engine.acmvRefused === true, 'elec=' + engine.elecReason + ' acmv=' + engine.acmvReason);
+  chk('P7 REAL PRODUCTION PATH renders the bridged chain (dwChain tubes)', completed && chainCommitted && after.chainTubes > 0, 'completed=' + completed + ' chainCommitted=' + chainCommitted + ' chainTubes=' + after.chainTubes);
+  chk('P8 COMMITTED (op-log grew, signed chain verifies)', after.oplogLen > before.oplogLen && chain === true, 'oplog ' + before.oplogLen + '→' + after.oplogLen + ' verifyChain=' + chain);
+  chk('P9 REVERSIBLE (undo clears PLB walk, cursor restored)', undo.instances === 0 && undo.cur === before.cur, JSON.stringify(undo));
+  chk('P10 NO-ERROR', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  console.log('W-ROUTE-PATTERN-BRIDGE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- `RESUME_MODELLER_WALK_SUBSTRATE.md` §CAMPAIGN M1 (redirected 2026-07-07): bridges live ARC-derived anchors (METER=door-seed, STACK=stair-riser, FIXTURE=measured placements, JUNCTION=SeedTrunk corridor waypoints) into `routewalker.js`'s already-proven `_rwApplyPattern`/`_rwPairSegments` pattern engine, instead of building a second generation mechanism in `disc_walker.js`/`seed_trunk.js`.
- Measured (not assumed) scope: `ad_mep_pattern` covers only CW+SP (plumbing sub-networks) → bridges disc_walker's `PLB` discipline; ELEC/ACMV honestly refuse (no pattern data) — verified by witness, not claimed.
- Found + fixed two pre-existing latent bugs in `routewalker.js` this pass surfaced (not introduced): an uncatchable IndexedDB pageerror on fresh IFC-open sessions, and `_rwReady` flipping true before validating the DB actually parsed.

## Test plan
- [x] `witness_route_pattern_bridge.js` (new, 10/10): routeChains 0→N via the bridge on ARC-only Duplex, CW+SP segments from real anchors, ELEC/ACMV honest refusal, real production path (`window.discWalk`) renders+commits+reverses.
- [x] Regression: `W-E2E-WALK` 8/8, `W-E2E-WALK-ALL` 10/10, `W-E2E-WALK-IFCOPEN` 18/18 (was 12/18 before the routewalker.js fixes — traced and fixed), `W-SEED-TRUNK-RENDER` 8/8.
- [x] `W-TERMINAL-WALKALL-PERF` fails identically on unpatched `origin/main` (pre-existing puppeteer DOM-detach flake, confirmed unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)