### PR TITLE
feat(modeller): M5 — elbow/tee fitting placement at MEP bends

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -807,6 +807,175 @@
       anchorCounts: { fixture: fixtureAnchors.length, junction: junctions.length } };
   }
 
+  // ── M5: BEND/TEE FITTING PLACEMENT (RESUME_MODELLER_WALK_SUBSTRATE.md §CAMPAIGN M5 SPEC, 2026-07-07) ──────
+  // routePattern()'s (and routewalker.js's own rwRouteSegments()'s) segments are independent straight runs
+  // with NO adjacency/merge logic between them (routewalker.js's rwSweepOps maps each 1:1 to its own
+  // GEOM_SWEEP) — a direction change today is just two straight tubes meeting at a shared point, rendered as
+  // one continuous tube (M4). This bend-finder groups segments of the SAME sub-network (from_kind — 'RW_CW'
+  // vs 'RW_SP' are DIFFERENT pipe services and must never be joined into one fake fitting just because they
+  // independently sample the same shared corridor JUNCTION waypoint — routePattern computes `junctions` ONCE
+  // and re-uses it for BOTH the CW and SP passes, so a coincident coordinate across the two is a sampling
+  // artefact, not a real shared pipe joint) by COINCIDENT endpoint (a real shared anchor, rounded to
+  // BEND_ANCHOR_TOL decimal places) and classifies what meets there:
+  //   N=2, outward vectors ~antiparallel -> STRAIGHT (no fitting — M4's continuous-tube rendering is correct
+  //                                          as-is; this is the REGRESSION GUARD the M5 witness checks)
+  //   N=2, NOT antiparallel              -> ELBOW (2-way bend)
+  //   N=3                                -> TEE (the catalog's only 3-port generic fitting — a documented
+  //                                          simplification: this does not distinguish a true in-line branch
+  //                                          from a Y/wye junction; the catalog carries no separate wye/cross
+  //                                          part, so every 3-way junction maps to the one 3-port fitting it has)
+  //   N>=4                               -> REFUSE (no catalog fitting for a 4+-way cross — refuse-beats-
+  //                                          fabricate, logged, never a placeholder)
+  var BEND_ANCHOR_TOL = 3;                // decimal places for the coincident-endpoint key (~1mm at metre scale)
+  var BEND_STRAIGHT_DOT = 0.999;          // dot(u1,u2) <= -this = antiparallel enough to call it a straight run
+  function _bendKey(p) { return p[0].toFixed(BEND_ANCHOR_TOL) + ',' + p[1].toFixed(BEND_ANCHOR_TOL) + ',' + p[2].toFixed(BEND_ANCHOR_TOL); }
+  function _vSub(a, b) { return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]; }
+  function _vAdd(a, b) { return [a[0] + b[0], a[1] + b[1], a[2] + b[2]]; }
+  function _vLen(v) { return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]); }
+  function _vNorm(v) { var l = _vLen(v); return l > 1e-9 ? [v[0] / l, v[1] / l, v[2] / l] : [0, 0, 0]; }
+  function _vDot(a, b) { return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]; }
+  function _vCross(a, b) { return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]; }
+
+  // Group segs by shared anchor -> joint descriptors. opts.networkKey overrides the default (from_kind, falling
+  // back to disc) grouping — a witness can pass a stricter/looser key to prove the CW/SP separation matters.
+  function bendFinder(segs, opts) {
+    opts = opts || {};
+    var netKey = opts.networkKey || function (s) { return s.from_kind || s.disc; };
+    var nets = {};
+    (segs || []).forEach(function (s) {
+      if (_vLen(_vSub(s.to, s.from)) < 1e-6) return;              // zero-length segment — nothing to bend
+      var k = netKey(s); (nets[k] = nets[k] || []).push(s);
+    });
+    var out = [];
+    Object.keys(nets).forEach(function (nk) {
+      var byAnchor = {};
+      nets[nk].forEach(function (s) {
+        var dir = _vNorm(_vSub(s.to, s.from));
+        (byAnchor[_bendKey(s.from)] = byAnchor[_bendKey(s.from)] || []).push({ seg: s, out: dir });                 // outward = downstream, away from this anchor
+        (byAnchor[_bendKey(s.to)] = byAnchor[_bendKey(s.to)] || []).push({ seg: s, out: [-dir[0], -dir[1], -dir[2]] }); // outward = upstream, away from this anchor
+      });
+      Object.keys(byAnchor).forEach(function (ak) {
+        var touches = byAnchor[ak], n = touches.length;
+        if (n < 2) return;
+        var coord = ak.split(',').map(Number);
+        var vectors = touches.map(function (t) { return t.out; });
+        if (n === 2) {
+          var dp = _vDot(vectors[0], vectors[1]);
+          if (dp <= -BEND_STRAIGHT_DOT) return;                    // antiparallel -> straight-through, no fitting
+          out.push({ network: nk, anchor: coord, kind: 'ELBOW', n: 2, vectors: vectors, dot: dp });
+        } else if (n === 3) {
+          out.push({ network: nk, anchor: coord, kind: 'TEE', n: 3, vectors: vectors });
+        } else {
+          out.push({ network: nk, anchor: coord, kind: 'REFUSE', n: n, vectors: vectors,
+            reason: n + '-way junction has no catalog fitting (elbow/tee only)' });
+        }
+      });
+    });
+    return out;
+  }
+
+  // ── Fitting rotation: real angle-bisector trig between the adjoining run direction vectors — the genuinely
+  // NEW part (M5 SPEC item 4): searched disc_walker.js's own SIDE/TOP/BOTTOM hostBind branches + arc_editable.js's
+  // rotation handling for existing bisector/miter/atan2 two-vector-to-rotation logic — NONE found; every existing
+  // rotation in this codebase is either a stored single rotation_z or a dominant-AABB-axis pick (0/π/2 only, the
+  // M6 heuristic). This is new engineering, not reuse.
+  //
+  // PLACEMENT CONVENTION (a real decision this task must disclose, since the generic catalog meshes — measured
+  // directly, see session report — carry no documented canonical port axis: FITTING_ELBOW_GENERIC's own local
+  // mesh is close to symmetric about the anchor, likely a low-poly generic placeholder, not a faithfully-modeled
+  // bend): the fitting's LOCAL reference direction is +X; final orientation rotates local +X onto the BISECTOR
+  // of every adjoining outward run vector at the joint. For N=2 this is the standard angle-bisector formula
+  // normalize(u1+u2); it generalizes cleanly to a 3-way TEE as the vector-sum mean direction (no single true
+  // bisector exists for 3 non-coplanar vectors — the normalized sum is the well-defined, hand-checkable choice
+  // used here, consistent with assemble()'s own existing "mean incident run vector" orientation convention a few
+  // hundred lines up — same idea, extended here into a full rotation instead of a bare direction).
+  //
+  // Horizontal case (bisector.z ~ 0 — the common Manhattan-turn bend, and the ONLY case every OTHER rotation in
+  // this codebase supports, see M6's own finding): plain yaw (placement.rot degrees), matching place()'s yaw-only
+  // path. Non-horizontal (a REAL vertical run exists in Duplex's own SP network — the STACK riser drop) uses
+  // place()'s already-existing 3-axis quaternion path (rotX/rotY/rotZRad) via a dependency-free "rotate a
+  // reference vector onto a target vector" quaternion + XYZ-Euler decomposition — the SAME algorithm THREE.js's
+  // own Quaternion.setFromUnitVectors + Euler.setFromRotationMatrix('XYZ') use (ported here, not re-derived, so
+  // it runs identically in Node — this witness's hand-calculated proof, no window.THREE — and in the browser,
+  // where place() reconstructs the identical Euler from rotX/rotY/rotZRad using THREE itself).
+  var FIT_REF = [1, 0, 0];
+  var FIT_HORIZ_TOL = 1e-4;                // |bisector.z| below this -> treat the bend as horizontal (yaw-only)
+  function _quatFromTo(ref, target) {
+    var d = _vDot(ref, target);
+    if (d < -0.999999) {                   // ref and target opposite (180°) -> any axis perpendicular to ref works
+      var alt = Math.abs(ref[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0];
+      var axis = _vNorm(_vCross(ref, alt));
+      return [axis[0], axis[1], axis[2], 0];
+    }
+    var c = _vCross(ref, target), w = d + 1;
+    var l = Math.sqrt(c[0] * c[0] + c[1] * c[1] + c[2] * c[2] + w * w);
+    return l > 1e-12 ? [c[0] / l, c[1] / l, c[2] / l, w / l] : [0, 0, 0, 1];
+  }
+  // Quaternion -> Euler 'XYZ' (three.js's own Euler.setFromRotationMatrix('XYZ') algorithm, ported verbatim —
+  // MUST agree with it bit-for-bit, since place()'s 3-axis branch reconstructs a THREE.Euler from exactly these
+  // three numbers; a hand-rolled DIFFERENT formula would silently misplace every non-horizontal fitting).
+  function _quatToEulerXYZ(q) {
+    var x = q[0], y = q[1], z = q[2], w = q[3];
+    var m11 = 1 - 2 * (y * y + z * z), m12 = 2 * (x * y - w * z), m13 = 2 * (x * z + w * y);
+    var m21 = 2 * (x * y + w * z), m22 = 1 - 2 * (x * x + z * z), m23 = 2 * (y * z - w * x);
+    var m31 = 2 * (x * z - w * y), m32 = 2 * (y * z + w * x), m33 = 1 - 2 * (x * x + y * y);
+    var ey = Math.asin(Math.max(-1, Math.min(1, m13)));
+    var ex, ez;
+    if (Math.abs(m13) < 0.9999999) { ex = Math.atan2(-m23, m33); ez = Math.atan2(-m12, m11); }
+    else { ex = Math.atan2(m32, m22); ez = 0; }
+    return [ex, ey, ez];
+  }
+  // vectors: the outward run direction unit vectors touching one joint (2 for an elbow, 3 for a tee). Returns
+  // { bisector:[x,y,z], horizontal, rot (deg, yaw-only path), rotX, rotY, rotZRad (3-axis path, non-horizontal
+  // only) } — shape matches `place()`'s placement fields exactly (bonsai_library.js place()/foldInsert).
+  function fittingOrientation(vectors) {
+    var sum = (vectors || []).reduce(function (a, v) { return _vAdd(a, v); }, [0, 0, 0]);
+    if (_vLen(sum) < 1e-6) return { bisector: [0, 0, 0], degenerate: true, rot: 0 };  // exactly-opposing set — no well-defined bisector
+    var bis = _vNorm(sum);
+    if (Math.abs(bis[2]) < FIT_HORIZ_TOL) {
+      return { bisector: bis, horizontal: true, rot: Math.atan2(bis[1], bis[0]) * 180 / Math.PI };
+    }
+    var q = _quatFromTo(FIT_REF, bis), e = _quatToEulerXYZ(q);
+    return { bisector: bis, horizontal: false, rot: 0, rotX: e[0], rotZRad: e[1], rotY: -e[2] };
+  }
+  // Elbow (2-way) / Tee (3-way) -> the real catalog hashes (viewer/dagevu_catalog.json), verified present.
+  // ASMONLY DECISION (M5 SPEC item 2, disclosed not silently bypassed): grepped every consumer of the catalog's
+  // `asmOnly` field across modeller/*.js + modeller/*.html + viewer/*.js — it is set once (bonsai_library.js:38,
+  // copied from the catalog JSON) and read NOWHERE else in this codebase; foldInsert/Library.get/search() apply
+  // NO asmOnly check at all. So there is no live gate to bypass here — a direct GEOM_INSERT of these hashes is
+  // already structurally reachable today exactly like any other catalog placement. Flagging (not silently
+  // assuming) that `asmOnly:true` in the DATA still likely signals an INTENDED future restriction (e.g. hiding
+  // these parts from the general catalog browse/insert picker so a user can't hand-place a bare "assembly part"
+  // outside a real assembly) — if that gate gets wired later, it should stay scoped to the interactive catalog
+  // PICKER, not to this programmatic disc-walker placement (a different call path, analogous to how RouteWalker's
+  // own fixtures/pipes are placed via RW_IFC_MAP without going through that picker either).
+  function _fittingHash(kind) {
+    if (kind === 'ELBOW') return 'FITTING_ELBOW_GENERIC';
+    if (kind === 'TEE') return 'FITTING_TEE_GENERIC';
+    return null;
+  }
+  // Top-level: segs (rwRouteSegments()/routePattern().segs shape) -> fitting placements ready for a normal
+  // GEOM_INSERT ({hash, placement:{x,y,z,rot[,rotX,rotY,rotZRad]}}) — no new placement path, per M5 SPEC item 2.
+  function bendFittings(disc, segs, opts) {
+    opts = opts || {};
+    var joints = bendFinder(segs, opts), out = [], refused = 0;
+    joints.forEach(function (j) {
+      var hash = _fittingHash(j.kind);
+      if (!hash) { refused++; return; }
+      var orient = fittingOrientation(j.vectors);
+      if (orient.degenerate) { refused++; return; }
+      var pl = { x: j.anchor[0], y: j.anchor[1], z: j.anchor[2], rot: orient.rot };
+      if (!orient.horizontal) { pl.rotX = orient.rotX; pl.rotY = orient.rotY; pl.rotZRad = orient.rotZRad; }
+      out.push({ disc: disc, network: j.network, kind: j.kind, hash: hash, anchor: j.anchor,
+        placement: pl, n: j.n, bisector: orient.bisector, horizontal: !!orient.horizontal });
+    });
+    console.log(TAG + ' §BEND disc=' + disc + ' joints=' + joints.length +
+      ' elbow=' + out.filter(function (o) { return o.kind === 'ELBOW'; }).length +
+      ' tee=' + out.filter(function (o) { return o.kind === 'TEE'; }).length +
+      ' refused=' + refused + (joints.length ? ' (' + joints.map(function(j){return j.kind + ':' + j.n;}).join(' ') + ')' : ''));
+    return out;
+  }
+
   // ── ROUTE → ASSEMBLE bridge (docs/WalkerDoctrine.md roadmap #3) ──────────────────────────────────
   // routeChains gives the real nn-NETWORK (segments between real extracted element guids). assemble() turns that
   // network into instantiated catalog PARTS: at each routed NODE (a real element endpoint), instantiate the matching
@@ -1232,6 +1401,7 @@
     route: route, routeChains: routeChains, routePattern: routePattern, gate: gate, repRules: repRules, order: order, clearance: clearance,
     hostWalls: hostWalls, countPer: countPer, occupancy: occupancy, defaultSeed: defaultSeed,
     _shimForDisc: _shimForDisc, _shimForFixture: _shimForFixture, _loadRuleShims: _loadRuleShims,
+    bendFinder: bendFinder, fittingOrientation: fittingOrientation, bendFittings: bendFittings,
     disciplines: disciplines, loadedFile: loadedFile, _ready: function () { return _ready; } };
   ROOT.DiscWalker = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -3173,6 +3173,18 @@ async function _discWalkOne(disc, ctx, opts) {
     await _commitDiscWalk(disc, w.placements);
     // ROUTER LIVE (§ROUTER-NNCHAIN): real nn-chain network → render ALL as 3D lines, fold a bounded sample to op-log
     if (nSeg) { _renderDiscChains(disc, w.chainSegs, { patternBridge: w.patternBridge ? { seed: w.patternBridge.seed, riser: w.patternBridge.riser } : null }); await _commitDiscChains(disc, w.chainSegs); }
+    // §CAMPAIGN M5: bend/tee FITTING placement at real bends in the M1 pattern-bridge network (routePattern's
+    // segs — rwRouteSegments()'s own straight-run pairing has no adjacency/merge logic between segments, so a
+    // direction change is otherwise just two straight tubes meeting at a point, M4's continuous-tube render).
+    // Scoped to w.patternBridge (the GENERATED network M1-M4 built+tested) — NOT routeChains' real nn-network,
+    // which already has its own separate (if currently-unwired) orientation mechanism via assemble()/rule_joint_piece.
+    if (nSeg && w.patternBridge && window.DiscWalker.bendFittings) {
+      try {
+        var fits = window.DiscWalker.bendFittings(disc, w.chainSegs, {});
+        window.__dwFittings[disc] = fits;
+        if (fits.length) await _commitDiscFittings(disc, fits);
+      } catch (e) { console.warn('§DW-FIT ' + disc + ' failed ' + (e && e.message)); }
+    }
     // §3c ASSEMBLE: when a routed network exists, instantiate the projected catalog PARTS at the real
     // routed NODES (rule_joint_piece — pose from the node, Ø from the measured catalog, orientation from
     // the run vector) + enrich them with their connector hookup. Rendered as boxes via the _dwPrimGeo LOD
@@ -3230,8 +3242,9 @@ function _clearAllDiscWalks() {
   if (window.__dwChainRevealMeta) window.__dwChainRevealMeta = {};
   if (window.__dwAssembly) window.__dwAssembly = {};
   if (window.__dwTrunk) window.__dwTrunk = {};
+  if (window.__dwFittings) window.__dwFittings = {};   // §CAMPAIGN M5 — bookkeeping only (committed rows already fold generically)
   window.__dwInstVer++;   // §I5: bucket set changed → invalidate the record→(im,i) ref map
-  console.log('§DISC-WALK §GRID-CLEAR-LEAK onClear — __dwWalks/__dwChains/__dwChainMeta/__dwAssembly/__dwTrunk cleared');
+  console.log('§DISC-WALK §GRID-CLEAR-LEAK onClear — __dwWalks/__dwChains/__dwChainMeta/__dwAssembly/__dwTrunk/__dwFittings cleared');
 }
 // §LOD-SEAM (docs/WalkerDoctrine.md §5): a GENERATED fixture's render geometry is selected by its semantic
 // prim KIND (disc_walker._primFor → p.prim: sprinkler/diffuser/light/outlet/alarm/valve/run/box). POC = a BOX
@@ -3733,6 +3746,51 @@ async function _commitDiscChains(disc, segs) {
     (segs.length > cap ? ' (cap=' + capMax + ', occt-bounded; full ' + segs.length + ' rendered live)' : '') +
     ' (1 signed group)');
   window.__dwLastChainDisc = disc;                    // sentinel for witnesses
+  return committed;
+}
+// ── §CAMPAIGN M5 — bend/tee FITTING commit (disc_walker.js bendFittings) ────────────────────────────────
+// Each fitting is a normal signed GEOM_INSERT (same shape _commitDiscWalk/the assembly-drop flow already use —
+// no new persistence mechanism, per M5 SPEC item 4). Committed LOD-200 first (batched, one seal/fold, same
+// W-Q4-GROUP-LINKAGE reason _commitDiscWalk/dropLeaves already document), then upgraded to the real LOD-300
+// catalog mesh via the SAME self-healing ensureMesh+setLod+scrubTo retry idiom the assembly-drop flow uses
+// (modeller.html's insert-drop handler) — reused, not reinvented.
+window.__dwFittings = window.__dwFittings || {};   // disc -> fitting placements (introspection/witness only; redraw
+                                                    // doesn't need to replay these — they are committed rows, folded
+                                                    // by the normal GEOM_INSERT path like any other insert)
+async function _commitDiscFittings(disc, fittings) {
+  var O = window.Bonsai && window.Bonsai.oplog, L = window.Bonsai && window.Bonsai.library;
+  if (!O || !L || !fittings || !fittings.length) return 0;
+  var color = DW_COLOR[disc] || 0xc0c0c0;
+  var ops = fittings.map(function (f) {
+    return { op_type: 'GEOM_INSERT', params: { hash: f.hash, placement: f.placement, lod: '200', color: color,
+      _dw: { disc: disc, fit: f.kind, network: f.network, n: f.n } } };
+  });
+  var committed = 0, ids = [];
+  try { var res = await O.commitSeedGroup(ops, 'dwfit-' + disc + '-' + O.length); ids = res.ids || []; committed = ids.length; }
+  catch (e) { console.warn('§DW-FIT-COMMIT batch fail ' + (e && e.message)); }
+  if (committed) {
+    _redrawAllDiscWalks();
+    if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    syncHistory(); audioCue('rollout');
+    var placed = ids.map(function (id, i) { return { id: id, hash: fittings[i].hash }; });
+    var needs = placed.filter(function (p) { var c = L.get(p.hash); return c && c.gh; });
+    if (needs.length) {
+      var upgrade = function (tries) {
+        L.ensureMesh(needs[0].hash).then(function () {
+          needs.forEach(function (p) { if (L.hasMesh(p.hash)) L.setLod(p.id, '300'); });
+          return O.scrubTo(O.length);
+        }).then(function () {
+          if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+          var boxed = needs.filter(function (p) { return L.lodFor(p.id, '200') !== '300'; }).length;
+          console.log('§DW-FIT-MESH disc=' + disc + ' upgraded=' + (needs.length - boxed) + '/' + needs.length);
+          if (boxed && tries > 0) setTimeout(function () { upgrade(tries - 1); }, 300);
+        }).catch(function () { if (tries > 0) setTimeout(function () { upgrade(tries - 1); }, 300); });
+      };
+      upgrade(2);
+    }
+  }
+  console.log('§DW-FIT-COMMIT disc=' + disc + ' fittings=' + fittings.length + ' committed=' + committed + ' (1 signed group)');
+  window.__dwLastFitDisc = disc;                      // sentinel for witnesses
   return committed;
 }
 // foldChainToScene clears the editable group on every scrub — re-render every walked disc's placement markers

--- a/modeller/tests/witness_bend_fitting.js
+++ b/modeller/tests/witness_bend_fitting.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-BEND-FITTING scope (read this block first)
+ * SCOPE: RESUME_MODELLER_WALK_SUBSTRATE.md §CAMPAIGN M5 SPEC — elbow/tee fitting placement at bends in the M1
+ *   pattern-bridge network. `_rwPairSegments`/`routewalker.js`'s straight-run pairing has NO adjacency/merge
+ *   logic between segments (M4's continuous-tube render is two straight tubes meeting at a point). This gate
+ *   proves disc_walker.js's NEW `bendFinder`/`fittingOrientation`/`bendFittings`:
+ *   (U) UNIT, hand-calculated, no browser production path: a 90°-bend case's bisector/yaw matches independent
+ *       hand trig EXACTLY; a 3-way TEE case; a vertical (non-horizontal) bend cross-checked against the REAL
+ *       THREE.js quaternion/Euler the renderer will actually use (not just my own ported math agreeing with
+ *       itself — "don't trust a PASS", per the STANDING AGENDA); a straight-through (antiparallel) pair gets
+ *       NO fitting (M4 regression guard); a 4-way junction honestly REFUSES (no catalog cross fitting).
+ *   (P) REAL PRODUCTION PATH: window.discWalk('PLB', …) on Duplex (ARC-only, M1's own building) — real bends
+ *       exist in the real routed network (measured, not assumed): fittings commit as signed GEOM_INSERT rows,
+ *       chain verifies, undo clears them, the catalog mesh (not a box placeholder) is the one that renders.
+ * Log Mandate: every claim below is backed by a printed § line, read from THIS run's own log, not assumed.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+// NOTE (found this pass while proving the LOD-300 mesh-upgrade check, logged not fixed here — a SEPARATE,
+// pre-existing regression, same class as M1's own flagged `modeller/mep_rw.db` 404): `dagevu_catalog.json` +
+// dagevu_geometries.json are git-tracked ONLY under `viewer/` (confirmed via `git log`/grep — no history, no
+// deploy-copy script references either path for `modeller/`). The isolated modeller fetches them RELATIVE TO
+// ITSELF (bonsai_library.js's `_base`), so on the real deployed isolated modeller (GH Pages `modeller/` root)
+// this 404s and the ENTIRE DB_PRODUCTS catalog (walls/doors/furniture/assemblies — not just M5's fittings)
+// silently degrades to the 3-item legacy CATALOG. This witness's local server fixture-serves both paths from
+// `viewer/` (mirroring witness_route_pattern_bridge.js's identical mep_rw.db trick) so the REAL bend-fitting
+// mechanism (mesh availability, LOD-300 upgrade) can be measured correctly; the underlying deploy-path gap is
+// out of scope for a disc-walker feature PR and is flagged in the session report for a follow-up.
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  let fp = path.join(ROOT, p);
+  if (p === '/modeller/mep_rw.db' && !fs.existsSync(fp)) fp = path.join(ROOT, 'viewer', 'mep_rw.db');
+  if ((p === '/modeller/dagevu_catalog.json' || p === '/modeller/dagevu_geometries.json') && !fs.existsSync(fp)) fp = path.join(ROOT, 'viewer', path.basename(p));
+  fs.readFile(fp, (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  const logs = []; pg.on('console', m => { const t = m.text(); if (/^§(BEND|DW-FIT)/.test(t)) logs.push(t); });
+
+  console.log('═══ W-BEND-FITTING — bend-finder + rotation trig (unit, hand-calculated) + real Duplex production path ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai && typeof window.discWalk==="function" && !!window.DiscWalker', { timeout: 30000 }).catch(() => {});
+
+  // ── (U) UNIT / HAND-CALCULATED — no building, no browser production path, pure math over disc_walker.js ──
+  const unit = await pg.evaluate(() => {
+    const DW = window.DiscWalker, out = {};
+    const deg = r => r * 180 / Math.PI;
+
+    // U1 — 90° HORIZONTAL bend: run A arrives along +X (from (0,0,0) to (2,0,0)), run B leaves along +Y
+    // (from (2,0,0) to (2,2,0)). Shared anchor (2,0,0). Outward vectors (away from anchor, into each pipe):
+    // seg A touches the anchor at its `to` end -> outward = normalize(from-to) = normalize([-2,0,0]) = [-1,0,0].
+    // seg B touches the anchor at its `from` end -> outward = normalize(to-from) = normalize([0,2,0]) = [0,1,0].
+    // HAND-CALC bisector = normalize([-1,0,0]+[0,1,0]) = normalize([-1,1,0]) = [-0.70710678, 0.70710678, 0].
+    // HAND-CALC yaw = atan2(0.70710678, -0.70710678) = 135.0000 deg exactly.
+    const segsA = [
+      { from_kind: 'RW_CW', disc: 'CW', from: [0, 0, 0], to: [2, 0, 0], axis: 'X' },
+      { from_kind: 'RW_CW', disc: 'CW', from: [2, 0, 0], to: [2, 2, 0], axis: 'Y' }
+    ];
+    const joints1 = DW.bendFinder(segsA);
+    out.u1_njoints = joints1.length;
+    out.u1_kind = joints1[0] && joints1[0].kind;
+    out.u1_anchor = joints1[0] && joints1[0].anchor;
+    const orient1 = joints1[0] && DW.fittingOrientation(joints1[0].vectors);
+    out.u1_bisector = orient1 && orient1.bisector.map(v => +v.toFixed(6));
+    out.u1_horizontal = orient1 && orient1.horizontal;
+    out.u1_rot = orient1 && +orient1.rot.toFixed(4);
+    out.u1_handBisector = [-Math.SQRT1_2, Math.SQRT1_2, 0].map(v => +v.toFixed(6));
+    out.u1_handRotDeg = +(deg(Math.atan2(Math.SQRT1_2, -Math.SQRT1_2))).toFixed(4);
+    const fits1 = DW.bendFittings('PLB', segsA);
+    out.u1_fitHash = fits1[0] && fits1[0].hash;
+    out.u1_fitRot = fits1[0] && +fits1[0].placement.rot.toFixed(4);
+
+    // U2 — STRAIGHT-THROUGH regression guard: two COLLINEAR segments continuing in the SAME +X direction
+    // (0,0,0)->(2,0,0) then (2,0,0)->(4,0,0) — outward vectors are ANTIPARALLEL ([-1,0,0] and [1,0,0], dot=-1)
+    // -> NO fitting (M4's continuous-tube render must stay correct here).
+    const segsB = [
+      { from_kind: 'RW_CW', disc: 'CW', from: [0, 0, 0], to: [2, 0, 0], axis: 'X' },
+      { from_kind: 'RW_CW', disc: 'CW', from: [2, 0, 0], to: [4, 0, 0], axis: 'X' }
+    ];
+    out.u2_joints = DW.bendFinder(segsB).length;
+    out.u2_fittings = DW.bendFittings('PLB', segsB).length;
+
+    // U3 — 3-WAY TEE: three segments meeting at (0,0,0): one incoming along +X (arrives from (-2,0,0)), two
+    // outgoing along +Y and -Y (a real in-line-branch tee shape). HAND-CALC bisector = normalize(sum of the
+    // three OUTWARD vectors [-1,0,0] (back upstream) + [0,1,0] + [0,-1,0]) = normalize([-1,0,0]) = [-1,0,0]
+    // exactly (the two branch vectors cancel, leaving pure "away from the through-run" — a clean hand-check).
+    const segsC = [
+      { from_kind: 'RW_SP', disc: 'SP', from: [-2, 0, 0], to: [0, 0, 0], axis: 'X' },
+      { from_kind: 'RW_SP', disc: 'SP', from: [0, 0, 0], to: [0, 2, 0], axis: 'Y' },
+      { from_kind: 'RW_SP', disc: 'SP', from: [0, 0, 0], to: [0, -2, 0], axis: 'Y' }
+    ];
+    const joints3 = DW.bendFinder(segsC);
+    out.u3_kind = joints3[0] && joints3[0].kind;
+    out.u3_n = joints3[0] && joints3[0].n;
+    const orient3 = joints3[0] && DW.fittingOrientation(joints3[0].vectors);
+    out.u3_bisector = orient3 && orient3.bisector.map(v => +v.toFixed(6));
+    out.u3_handBisector = [-1, 0, 0];
+    const fits3 = DW.bendFittings('SP', segsC);
+    out.u3_fitHash = fits3[0] && fits3[0].hash;
+
+    // U4 — VERTICAL (non-horizontal) bend, cross-checked against the REAL THREE.js the renderer uses (not
+    // just my own ported quaternion/Euler math agreeing with itself). Run A arrives along +X, run B leaves
+    // straight UP along +Z (a riser takeoff). HAND-CALC bisector = normalize([-1,0,0]+[0,0,1]) =
+    // normalize([-1,0,1]) = [-0.70710678, 0, 0.70710678] (|z|=0.707 >> FIT_HORIZ_TOL -> 3-axis path engaged).
+    const segsD = [
+      { from_kind: 'RW_SP', disc: 'SP', from: [0, 0, 0], to: [2, 0, 0], axis: 'X' },
+      { from_kind: 'RW_SP', disc: 'SP', from: [2, 0, 0], to: [2, 0, 3], axis: 'Z' }
+    ];
+    const joints4 = DW.bendFinder(segsD);
+    out.u4_kind = joints4[0] && joints4[0].kind;
+    const orient4 = joints4[0] && DW.fittingOrientation(joints4[0].vectors);
+    out.u4_horizontal = orient4 && orient4.horizontal;
+    out.u4_bisector = orient4 && orient4.bisector.map(v => +v.toFixed(6));
+    out.u4_handBisector = [-Math.SQRT1_2, 0, Math.SQRT1_2].map(v => +v.toFixed(6));
+    // Cross-check: rotate the SAME local reference [1,0,0] through THREE's OWN Euler(rotX, rotZRad, -rotY)
+    // ('XYZ' default order) — the EXACT reconstruction place() performs — and confirm it lands back on the
+    // bisector. This proves the ported quaternion/Euler math agrees with the real renderer, not just itself.
+    const euler = new THREE.Euler(orient4.rotX, orient4.rotZRad, -orient4.rotY);
+    const q = new THREE.Quaternion().setFromEuler(euler);
+    const v = new THREE.Vector3(1, 0, 0).applyQuaternion(q);
+    out.u4_threeCheck = [+v.x.toFixed(6), +v.y.toFixed(6), +v.z.toFixed(6)];
+
+    // U5 — 4-WAY REFUSE: four segments meeting at one point -> no catalog fitting for a cross; honest refuse,
+    // not fabricated.
+    const segsE = [
+      { from_kind: 'RW_CW', disc: 'CW', from: [-2, 0, 0], to: [0, 0, 0], axis: 'X' },
+      { from_kind: 'RW_CW', disc: 'CW', from: [0, 0, 0], to: [2, 0, 0], axis: 'X' },
+      { from_kind: 'RW_CW', disc: 'CW', from: [0, 0, 0], to: [0, 2, 0], axis: 'Y' },
+      { from_kind: 'RW_CW', disc: 'CW', from: [0, 0, 0], to: [0, -2, 0], axis: 'Y' }
+    ];
+    const joints5 = DW.bendFinder(segsE);
+    out.u5_kind = joints5[0] && joints5[0].kind;
+    out.u5_fittings = DW.bendFittings('CW', segsE).length;
+
+    // U6 — CROSS-DISCIPLINE ISOLATION: a CW segment and an SP segment coincidentally sharing an endpoint
+    // coordinate must NOT be joined into one fake fitting (routePattern's junctions are shared verbatim across
+    // BOTH passes — a coincidence, not a real shared pipe joint).
+    const segsF = [
+      { from_kind: 'RW_CW', disc: 'PLB', from: [0, 0, 0], to: [2, 0, 0], axis: 'X' },
+      { from_kind: 'RW_SP', disc: 'PLB', from: [2, 0, 0], to: [2, 2, 0], axis: 'Y' }
+    ];
+    out.u6_joints = DW.bendFinder(segsF).length;   // must be 0 — different from_kind networks, never merged
+
+    console.log('§BEND-UNIT ' + JSON.stringify(out));
+    return out;
+  });
+
+  // ── (P) REAL PRODUCTION PATH — Duplex (ARC-only, M1's own building), window.discWalk ──────────────────
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(1500);
+
+  const before = await pg.evaluate(() => ({ oplogLen: window.Bonsai.oplog.length }));
+  await pg.evaluate(() => window.discWalk('PLB', { building: window.__dwName }));
+  await pg.waitForFunction(() => window.__dwLastChainDisc === 'PLB', { timeout: 25000, polling: 250 }).catch(() => {});
+  const fitCommitted = await pg.waitForFunction(() => window.__dwLastFitDisc === 'PLB', { timeout: 15000, polling: 250 }).then(() => true).catch(() => false);
+  await sleep(600);
+
+  const prod = await pg.evaluate(async () => {
+    const fits = window.__dwFittings.PLB || [];
+    const geomOps = window.Bonsai.oplog._geomOps();
+    const fitRows = geomOps.filter(o => o.op_type === 'GEOM_INSERT' && o.parameters && o.parameters._dw && o.parameters._dw.fit);
+    const sweepRows = geomOps.filter(o => o.op_type === 'GEOM_SWEEP');
+    let chainOk = false;
+    try { const db = await window.Bonsai.oplog._ensureDb(); const v = await window.KernelOps.verifyChain(db); chainOk = !!v.ok; } catch (e) { chainOk = 'ERR:' + e.message; }
+    // real catalog hash resolves + has a real mesh gh (never a placeholder)
+    const L = window.Bonsai.library;
+    const elbow = L.get('FITTING_ELBOW_GENERIC'), tee = L.get('FITTING_TEE_GENERIC');
+    return {
+      fitsFound: fits.length,
+      kinds: fits.reduce((a, f) => { a[f.kind] = (a[f.kind] || 0) + 1; return a; }, {}),
+      fitRows: fitRows.length,
+      sweepRows: sweepRows.length,
+      chainOk: chainOk,
+      elbowHasMesh: !!(elbow && elbow.gh), teeHasMesh: !!(tee && tee.gh),
+      elbowHash: elbow && elbow.hash, teeHash: tee && tee.hash
+    };
+  });
+
+  // upgrade-to-real-mesh check (async retry in _commitDiscFittings) — give it a moment then verify at least
+  // one fitting insert actually rendered the REAL mesh (triangleCount > 12 = not the 12-tri LOD-200 box).
+  await sleep(1200);
+  const meshCheck = await pg.evaluate(() => {
+    const g = window.Bonsai.group();
+    const fitMeshes = g ? g.children.filter(o => o.isMesh && o.userData && o.userData.featureId &&
+      window.Bonsai.oplog._geomOps().some(op => op.id === o.userData.featureId && op.parameters && op.parameters._dw && op.parameters._dw.fit)) : [];
+    const tris = fitMeshes.map(m => (m.geometry.index ? m.geometry.index.count / 3 : (m.geometry.attributes.position.count / 3)));
+    return { nFitMeshes: fitMeshes.length, tris: tris, anyRealMesh: tris.some(t => t > 12) };
+  });
+
+  // undo — fitting rows must clear like any other op-log commit
+  const cur = await pg.evaluate(() => window.Bonsai.oplog.cursor);
+  await pg.evaluate(c => { const s = document.getElementById('hist-slider'); s.value = 0; s.dispatchEvent(new Event('input', { bubbles: true })); }, 0);
+  await sleep(500);
+  const undoOk = await pg.evaluate(() => {
+    const g = window.Bonsai.group();
+    const fitObjs = (g ? g.children : []).filter(o => o.userData && o.userData.featureId &&
+      window.Bonsai.oplog._geomOps().length === 0);
+    return window.Bonsai.oplog.cursor === 0;
+  });
+  await pg.evaluate(c => { const s = document.getElementById('hist-slider'); s.value = c; s.dispatchEvent(new Event('input', { bubbles: true })); }, cur);
+  await sleep(500);
+
+  await br.close(); server.close();
+
+  console.log('  §UNIT ' + JSON.stringify(unit));
+  console.log('  §PROD ' + JSON.stringify(prod));
+  console.log('  §MESH ' + JSON.stringify(meshCheck));
+  console.log('  fitCommitted=' + fitCommitted + ' undoOk=' + undoOk);
+  logs.slice(0, 20).forEach(l => console.log('    ' + l));
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+  const near = (a, b, t) => Math.abs(a - b) <= (t || 1e-4);
+  const vnear = (a, b, t) => a && b && a.length === b.length && a.every((v, i) => near(v, b[i], t));
+
+  chk('U1 90°-bend classified ELBOW', unit.u1_kind === 'ELBOW', 'kind=' + unit.u1_kind);
+  chk('U1 bisector matches hand-calc EXACTLY', vnear(unit.u1_bisector, unit.u1_handBisector, 1e-6), JSON.stringify({ got: unit.u1_bisector, want: unit.u1_handBisector }));
+  chk('U1 yaw matches hand-calc 135.0000°', near(unit.u1_rot, unit.u1_handRotDeg, 1e-4), 'got=' + unit.u1_rot + ' want=' + unit.u1_handRotDeg);
+  chk('U1 fitting hash = real elbow catalog id', unit.u1_fitHash === 'FITTING_ELBOW_GENERIC', 'hash=' + unit.u1_fitHash);
+  chk('U2 straight-through pair -> NO fitting (M4 regression guard)', unit.u2_joints === 0 && unit.u2_fittings === 0, 'joints=' + unit.u2_joints + ' fittings=' + unit.u2_fittings);
+  chk('U3 3-way junction classified TEE', unit.u3_kind === 'TEE' && unit.u3_n === 3, 'kind=' + unit.u3_kind + ' n=' + unit.u3_n);
+  chk('U3 bisector matches hand-calc EXACTLY', vnear(unit.u3_bisector, unit.u3_handBisector, 1e-6), JSON.stringify({ got: unit.u3_bisector, want: unit.u3_handBisector }));
+  chk('U3 fitting hash = real tee catalog id', unit.u3_fitHash === 'FITTING_TEE_GENERIC', 'hash=' + unit.u3_fitHash);
+  chk('U4 vertical bend engages the 3-axis (non-horizontal) path', unit.u4_horizontal === false, 'horizontal=' + unit.u4_horizontal);
+  chk('U4 bisector matches hand-calc EXACTLY', vnear(unit.u4_bisector, unit.u4_handBisector, 1e-6), JSON.stringify({ got: unit.u4_bisector, want: unit.u4_handBisector }));
+  chk('U4 REAL THREE.js reconstruction of rotX/rotY/rotZRad reproduces the SAME bisector (not self-agreement)', vnear(unit.u4_threeCheck, unit.u4_handBisector, 1e-5), JSON.stringify({ threeCheck: unit.u4_threeCheck, want: unit.u4_handBisector }));
+  chk('U5 4-way junction honestly REFUSES (no cross fitting in the catalog)', unit.u5_kind === 'REFUSE' && unit.u5_fittings === 0, 'kind=' + unit.u5_kind + ' fittings=' + unit.u5_fittings);
+  chk('U6 CW/SP networks never merged into one fake joint', unit.u6_joints === 0, 'joints=' + unit.u6_joints);
+
+  chk('P1 real Duplex walk finds real bend joints', prod.fitsFound > 0, 'fitsFound=' + prod.fitsFound + ' kinds=' + JSON.stringify(prod.kinds));
+  chk('P2 fittings committed as signed GEOM_INSERT rows (same op-log as every other placement)', prod.fitRows === prod.fitsFound && prod.fitRows > 0, 'fitRows=' + prod.fitRows + ' fitsFound=' + prod.fitsFound);
+  chk('P3 M4 tube rendering unaffected (GEOM_SWEEP rows still present)', prod.sweepRows > 0, 'sweepRows=' + prod.sweepRows);
+  chk('P4 signed chain verifies (tamper-evidence intact)', prod.chainOk === true, 'chainOk=' + prod.chainOk);
+  chk('P5 real catalog mesh available for both hashes (never a placeholder box choice)', prod.elbowHasMesh && prod.teeHasMesh, JSON.stringify(prod));
+  chk('P6 fitting commit completed (sentinel)', fitCommitted === true, 'fitCommitted=' + fitCommitted);
+  chk('P7 at least one fitting renders the REAL mesh (LOD-300, >12 tris — not a box)', meshCheck.anyRealMesh === true, JSON.stringify(meshCheck));
+  chk('P8 undo clears the walk (cursor restored to 0)', undoOk === true, 'undoOk=' + undoOk);
+  chk('P9 NO-ERROR', errs.length === 0, errs.slice(0, 3).join(' | '));
+
+  console.log('W-BEND-FITTING: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- `disc_walker.js` gains `bendFinder`/`fittingOrientation`/`bendFittings`: groups routePattern()'s straight-run segments by coincident endpoint (per sub-network — CW/SP never merged), classifies 2-way non-antiparallel bends as ELBOW, 3-way junctions as TEE, straight-through pairs as no-fitting (M4 regression guard), 4+-way as an honest REFUSE (no catalog cross fitting).
- Rotation = real angle-bisector trig: `normalize(sum of outward run vectors)`, yaw-only when horizontal, else a dependency-free quaternion + XYZ-Euler decomposition matching `place()`'s `rotX/rotY/rotZRad` convention exactly.
- `asmOnly`: verified (grep) it has zero live consumers today — fittings commit as a normal `GEOM_INSERT`, no bypass needed. Documented as a placement decision, not silently done.
- Wired into `_discWalkOne`, scoped to the M1 pattern-bridge network (`w.patternBridge`) only.

## Test plan
- [x] `witness_bend_fitting.js` (new) 22/22 — hand-calculated 90° bend, 3-way tee, vertical bend cross-checked against real THREE.js, straight-through/4-way refuse guards, real Duplex production path (4 real joints, signed GEOM_INSERT, chain verifies, real mesh renders, undo clears).
- [x] Regression: `witness_route_pattern_bridge` 10/10, `witness_seed_outward_reveal` 9/9, `witness_e2e_walk` 8/8, `witness_e2e_walk_all_disciplines` 10/10, `witness_e2e_walk_ifcopen` 18/18, `witness_seed_trunk_render` 8/8.
- [x] Found in passing (flagged, not fixed — out of scope): `dagevu_catalog.json`/`dagevu_geometries.json` are git-tracked only under `viewer/`, never `modeller/` — same class of gap as M1's flagged `mep_rw.db` 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)