### PR TITLE
feat(bonsai): Tier 1 kernel shoulders — REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT

### DIFF
--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -32,7 +32,7 @@
     init() {
       if (this._worker) return this._worker;
       if (!this.isSupported()) { console.warn(TAG + ' unsupported host (needs WASM tail-calls + Worker)'); return null; }
-      const url = new URL('bonsai_kernel_worker.js?v=6', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET)
+      const url = new URL('bonsai_kernel_worker.js?v=7', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET) · v7: Tier 1 shoulders GEOM_REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT + listFaces
       this._worker = new Worker(url.href, { type: 'module' });
       this._worker.onmessage = (e) => {
         const d = e.data || {};
@@ -118,6 +118,20 @@
       });
     },
 
+    // §FACE-PICK (Tier 1 GEOM_SHELL/GEOM_DRAFT): ask the worker for the face midpoints of a parent feature's
+    // solid (canonical getSubShapes('face') order). Mirrors queryEdges() exactly — the picked indices ride a
+    // GEOM_SHELL (facesToRemove) or GEOM_DRAFT (the one pulled face) op.
+    queryFaces(parentId) {
+      const w = this.init();
+      if (!w) return Promise.reject(new Error('bonsai unsupported'));
+      const ops = (window.Bonsai.oplog && window.Bonsai.oplog._geomOps) ? window.Bonsai.oplog._geomOps() : [];
+      const id = ++this._seq;
+      return new Promise((resolve, reject) => {
+        this._pending.set(id, { resolve, reject });
+        w.postMessage({ id, listFaces: { ops, parentId } });
+      });
+    },
+
     // Fold a whole op-log CHAIN -> array of mesh payloads (the feature tree, evaluated in one pass).
     // seedBoxes (optional): {featureId: {c1,c2}} pre-seeds B-rep boxes for box-like inserts that are cut/fillet
     // targets (§CUT-ON-ARC) so the worker can subtract a void from a baked ARC wall.
@@ -187,8 +201,13 @@
       // box (seedBoxes) and rendered by the worker (with the void subtracted) — NOT host-side (else the uncut baked
       // mesh would paint over the cut). Rotated/non-box inserts return null from _insertCutBox → stay host-side
       // (the cut handler refuses them up front, so no dead op reaches here).
+      // Tier 1 (§GAP-TO-COMPETITIVE): GEOM_SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT are ALSO
+      // parent-mutating ops on a worker B-rep solid (same class as GEOM_CUT/GEOM_FILLET) — an ARC-seeded
+      // box-like insert must be promoted for these too, or shelling/drafting a seeded box would throw
+      // "parent not found" exactly like an un-promoted cut did before §CUT-ON-ARC.
+      const PARENT_MUTATING = new Set(['GEOM_CUT', 'GEOM_FILLET', 'GEOM_SHELL', 'GEOM_OFFSET', 'GEOM_FILLET_VARIABLE', 'GEOM_CHAMFER_DIST_ANGLE', 'GEOM_DRAFT']);
       const cutFilletParents = new Set();
-      for (const o of ops) { if (o.op_type === 'GEOM_CUT' || o.op_type === 'GEOM_FILLET') { const P = typeof o.parameters === 'string' ? JSON.parse(o.parameters) : o.parameters; if (P && P.parent != null) cutFilletParents.add(P.parent); } }
+      for (const o of ops) { if (PARENT_MUTATING.has(o.op_type)) { const P = typeof o.parameters === 'string' ? JSON.parse(o.parameters) : o.parameters; if (P && P.parent != null) cutFilletParents.add(P.parent); } }
       const seedBoxes = {}; const promoted = new Set();
       for (const o of ops) {
         if (o.op_type !== 'GEOM_INSERT' || !cutFilletParents.has(o.id)) continue;

--- a/modeller/bonsai_kernel_worker.js
+++ b/modeller/bonsai_kernel_worker.js
@@ -111,6 +111,28 @@ function applyFeature(kernel, op) {
     wireHandles.forEach(w => kernel.release(w));
     return solid;
   }
+  if (op.op_type === 'GEOM_REVOLVE') {            // BRepPrimAPI_MakeRevol via kernel.revolve — Tier 1 §GAP-TO-COMPETITIVE,
+    // highest-value shoulder: axisymmetric solids (round columns, tanks/vessels, turned parts) have NO authoring
+    // path today. Reuses GEOM_EXTRUDE_POLY's profile.points ring format EXACTLY (planegcs-solved polygon), just
+    // revolved about a caller-supplied axis instead of extruded along a direction. LEAF: builds a fresh
+    // self-contained solid from its OWN parameters (profile+axis+angle), no `parent` reference — same class as
+    // GEOM_SWEEP/GEOM_LOFT (checked against buildSolids()'s branching below: falls into the terminal `else`
+    // applyFeature() branch, not a parent-lookup branch), so bonsai_oplog.js's LEAF whitelist includes it.
+    const pts = P.profile.points;
+    const z = P.profile.z || 0;
+    const edges = [];
+    for (let i = 0; i < pts.length; i++) {
+      const a = pts[i], b = pts[(i + 1) % pts.length];
+      edges.push(kernel.makeLineEdge({ x: a[0], y: a[1], z }, { x: b[0], y: b[1], z }));
+    }
+    const wire = kernel.makeWire(edges);
+    const face = kernel.makeFace(wire);
+    const axis = P.axis;   // { point:{x,y,z}, direction:{x,y,z} } — SAME shape as GEOM_ROTATE's axis object below
+    const angleRad = P.angleRad != null ? P.angleRad : 2 * Math.PI;   // default: full revolution
+    const solid = kernel.revolve(face, axis, angleRad);
+    edges.forEach(e => kernel.release(e)); kernel.release(wire); kernel.release(face);
+    return solid;
+  }
   if (op.op_type === 'GEOM_OPENING') {            // IfcRelVoidsElement: base solid CUT by a void box
     const baseRect = kernel.makeRectangle(P.profile.w, P.profile.h);
     const wall = kernel.extrude(baseRect, P.dir[0], P.dir[1], P.dir[2]); kernel.release(baseRect);
@@ -257,6 +279,20 @@ function edgeMidpoints(kernel, solid) {
   return out;
 }
 
+// Face midpoints of a solid in CANONICAL getSubShapes('face') order — the §FACE-PICK input device for
+// GEOM_SHELL (facesToRemove) and GEOM_DRAFT (the one pulled face), mirroring edgeMidpoints() above exactly.
+// Midpoint = bbox centre (exact for the planar faces of our box/extrude solids); index is stable across a
+// deterministic re-fold, so a face picked by index resolves to the same face on replay.
+function faceMidpoints(kernel, solid) {
+  const faces = kernel.getSubShapes(solid, 'face');
+  const out = faces.map((f, i) => {
+    const b = kernel.getBoundingBox(f, false);
+    return { i, mid: [(b.xmin + b.xmax) / 2, (b.ymin + b.ymax) / 2, (b.zmin + b.zmax) / 2] };
+  });
+  faces.forEach(f => kernel.release(f));
+  return out;
+}
+
 // THE FEATURE-TREE FOLD (solids map): an ordered op-log -> a set of live solids. GEOM_CUT and GEOM_FILLET
 // modify their referenced parent solid IN PLACE (the child references a prior feature by id), so the op-log
 // IS the feature tree and the rendered geometry is a pure fold of the chain — replaying ops[0..k] = history.
@@ -301,6 +337,91 @@ function buildSolids(kernel, ops, seedBoxes) {
       const r = P.radius != null ? P.radius : 0.1;
       const result = (P.kind === 'chamfer') ? kernel.chamfer(pe.shape, sel, r) : kernel.fillet(pe.shape, sel, r);
       all.forEach(e => kernel.release(e));            // local edge subshapes (parent cached → NOT released)
+      shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
+    } else if (op.op_type === 'GEOM_SHELL') {          // BRepOffsetAPI_MakeThickSolid via kernel.shell — hollow a
+      // solid to a wall thickness (cast-then-hollow modeling). PARENT-MUTATING like GEOM_FILLET (mutates the
+      // referenced solid in place, same solids-map key), NOT a leaf — checked against kernel.shell's real signature
+      // `shell(solid, facesToRemove, thickness, tolerance)` :286 of lib/kernel/index.js, which takes an existing
+      // solid. facesToRemove = face HANDLES (kernel.#withU32 marshals them), so P.faces are INDICES into the
+      // canonical getSubShapes('face') order (mirrors GEOM_FILLET's P.edges indices) — resolved via `listFaces`
+      // §FACE-PICK below, stable across deterministic re-folds.
+      const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_SHELL parent ' + op.parent + ' not found');
+      if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
+      _stats.rebuilt++;
+      const allFaces = kernel.getSubShapes(pe.shape, 'face');           // canonical order — must match faceMidpoints()
+      const remove = (P.faces || []).map(i => allFaces[i]).filter(s => s != null);
+      const thickness = P.thickness != null ? P.thickness : 0.1;
+      const tolerance = P.tolerance != null ? P.tolerance : 1e-3;       // coarser legacy tolerance (kernel doc: survives more inputs)
+      const result = kernel.shell(pe.shape, remove, thickness, tolerance);
+      allFaces.forEach(f => kernel.release(f));            // local face subshapes (parent cached → NOT released)
+      shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
+    } else if (op.op_type === 'GEOM_OFFSET') {         // BRepOffsetAPI_MakeOffsetShape via kernel.offset — grows/
+      // shrinks ALL faces of a solid by `distance` uniformly. PARENT-MUTATING (kernel.offset(solid,...) takes an
+      // existing solid — real signature `offset(solid, distance, tolerance)` :298, NO face-list arg at all, simpler
+      // than assumed in the task brief: it is a whole-solid operation, not a per-face pick).
+      const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_OFFSET parent ' + op.parent + ' not found');
+      if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
+      _stats.rebuilt++;
+      const distance = P.distance != null ? P.distance : 0.1;
+      const tolerance = P.tolerance != null ? P.tolerance : 1e-3;
+      const result = kernel.offset(pe.shape, distance, tolerance);
+      shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
+    } else if (op.op_type === 'GEOM_FILLET_VARIABLE') {   // BRepFilletAPI_MakeFillet(law) via kernel.filletVariable —
+      // a fillet whose radius VARIES start→end along ONE edge. PARENT-MUTATING like GEOM_FILLET. Real signature
+      // `filletVariable(solid, edge, startRadius, endRadius)` :1096 takes a SINGLE edge HANDLE (not an array like
+      // plain fillet/chamfer) — verified directly against lib/kernel/index.js, not assumed by analogy. P.edges[0]
+      // (an index into the SAME canonical getSubShapes('edge') order GEOM_FILLET's edge-pick already resolves) is
+      // used as the one edge; extra indices are ignored (documented, not silently dropped — see witness).
+      const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_FILLET_VARIABLE parent ' + op.parent + ' not found');
+      if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
+      _stats.rebuilt++;
+      const all = kernel.getSubShapes(pe.shape, 'edge');               // canonical order — same as GEOM_FILLET
+      const edgeIdx = (P.edges && P.edges.length) ? P.edges[0] : 0;
+      const edge = all[edgeIdx];
+      const r0 = P.startRadius != null ? P.startRadius : 0.05, r1 = P.endRadius != null ? P.endRadius : 0.2;
+      const result = kernel.filletVariable(pe.shape, edge, r0, r1);
+      all.forEach(e => kernel.release(e));
+      shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
+    } else if (op.op_type === 'GEOM_CHAMFER_DIST_ANGLE') {   // BRepFilletAPI_MakeChamfer(dist,angle) via
+      // kernel.chamferDistAngle — a chamfer variant taking distance+angle instead of one distance. PARENT-MUTATING
+      // like GEOM_FILLET's `kind:'chamfer'`; kept as its OWN op_type (not folded into GEOM_FILLET's kind switch)
+      // per the task's per-op witness requirement. Real signature `chamferDistAngle(solid, edges, distance,
+      // angleDeg)` :272 — `edges` IS an array (unlike filletVariable's single edge) and `angleDeg` is DEGREES
+      // (verified against the param name, not radians like most of this kernel's other angle args).
+      const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_CHAMFER_DIST_ANGLE parent ' + op.parent + ' not found');
+      if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
+      _stats.rebuilt++;
+      const all = kernel.getSubShapes(pe.shape, 'edge');
+      const sel = (P.edges || []).map(i => all[i]).filter(s => s != null);
+      const distance = P.distance != null ? P.distance : 0.1;
+      const angleDeg = P.angleDeg != null ? P.angleDeg : 45;
+      const result = kernel.chamferDistAngle(pe.shape, sel, distance, angleDeg);
+      all.forEach(e => kernel.release(e));
+      shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
+    } else if (op.op_type === 'GEOM_DRAFT') {          // BRepOffsetAPI_DraftAngle via kernel.draft — a draft/pull
+      // angle applied to ONE face (precast/formwork use). PARENT-MUTATING. Real signature `draft(shape, face,
+      // angleRad, direction)` :301 takes a SINGLE face HANDLE (not an array) — mirrors filletVariable's
+      // single-edge shape. P.faces[0] (an index into the SAME canonical getSubShapes('face') order GEOM_SHELL
+      // resolves via `listFaces`) is the one face.
+      // ⚠ VERIFIED CONVENTION (probed directly against this vendored wasm build, NOT assumed from generic
+      // OCCT docs — see the Tier 1 session's `direction` investigation): `direction` must be the PICKED
+      // FACE'S OWN OUTWARD NORMAL for a genuine taper on a SIDE (vertical) face — any angleRad then produces
+      // a real shift. A direction that does NOT match the face's own normal (e.g. a generic vertical "pull"
+      // vector on a side face) is accepted WITHOUT throwing but is a silent geometric no-op. Drafting a
+      // horizontal (top/bottom) face with its own normal as direction THROWS a WebAssembly exception (a
+      // degenerate neutral-plane case for a cap face). So GEOM_DRAFT is scoped here to SIDE faces only,
+      // `direction` == that face's own outward normal — the caller (UI/witness) is responsible for supplying
+      // a correct normal, same discipline as GEOM_FILLET/SHELL expecting real edge/face indices.
+      const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_DRAFT parent ' + op.parent + ' not found');
+      if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
+      _stats.rebuilt++;
+      const allFaces = kernel.getSubShapes(pe.shape, 'face');
+      const faceIdx = (P.faces && P.faces.length) ? P.faces[0] : 0;
+      const face = allFaces[faceIdx];
+      const angleRad = P.angleRad != null ? P.angleRad : 0.1;
+      const dir = P.direction || { x: 0, y: 0, z: 1 };
+      const result = kernel.draft(pe.shape, face, angleRad, dir);
+      allFaces.forEach(f => kernel.release(f));
       shapeCache.set(key, result); solids.set(op.parent, { shape: result, hash: key });
     } else if (op.op_type === 'GEOM_MOVE') {          // free translate of one referenced solid (W-BONSAI-MOVE PATH A)
       // A signed GEOM_MOVE references a prior feature by `parent` and TRANSLATES its solid IN PLACE, so a later
@@ -447,6 +568,15 @@ self.onmessage = async (e) => {
       const pe = solids.get(parentId);
       const edges = pe ? edgeMidpoints(kernel, pe.shape) : [];   // solids are cached shapes — do NOT release
       self.postMessage({ id, ok: true, edges });
+      return;
+    }
+    if (e.data.listFaces) {                          // §FACE-PICK (GEOM_SHELL/GEOM_DRAFT): fold to the parent
+      // solid, report its face midpoints in canonical order — the SAME device shape as listEdges above.
+      const { ops: cops, parentId } = e.data.listFaces;
+      const solids = buildSolids(kernel, cops);
+      const pe = solids.get(parentId);
+      const faces = pe ? faceMidpoints(kernel, pe.shape) : [];   // solids are cached shapes — do NOT release
+      self.postMessage({ id, ok: true, faces });
       return;
     }
     if (ops) {                                       // CHAIN fold (feature tree) -> array of meshes

--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -299,7 +299,14 @@
       // GEOM_ARRAY's shape (which all resolve+mutate/replace a referenced prior feature). Decided explicitly,
       // not defaulted — checked against buildSolids()'s branching in bonsai_kernel_worker.js, where GEOM_LOFT
       // falls into the same terminal `else` (applyFeature) branch as GEOM_SWEEP, not the parent-lookup branches.
-      const LEAF = op.op_type === 'GEOM_EXTRUDE' || op.op_type === 'GEOM_EXTRUDE_POLY' || op.op_type === 'GEOM_SWEEP' || op.op_type === 'GEOM_LOFT';
+      // Tier 1 (§GAP-TO-COMPETITIVE, prompts/BONSAI_KERNEL_RESEARCH.md): GEOM_REVOLVE joins this LEAF set for
+      // the SAME reason as GEOM_LOFT — its profile+axis+angle payload builds a fresh self-contained solid with
+      // NO `parent` reference (checked against bonsai_kernel_worker.js applyFeature(), the terminal-else branch).
+      // GEOM_SHELL/GEOM_OFFSET/GEOM_FILLET_VARIABLE/GEOM_CHAMFER_DIST_ANGLE/GEOM_DRAFT are DELIBERATELY
+      // EXCLUDED — each references a `parent` and MUTATES that solid in place (same class as GEOM_CUT/
+      // GEOM_FILLET, checked against the same file's buildSolids() parent-lookup branches for each), so they
+      // must take the authoritative re-fold like GEOM_CUT/GEOM_FILLET do, not the optimistic leaf append.
+      const LEAF = op.op_type === 'GEOM_EXTRUDE' || op.op_type === 'GEOM_EXTRUDE_POLY' || op.op_type === 'GEOM_SWEEP' || op.op_type === 'GEOM_LOFT' || op.op_type === 'GEOM_REVOLVE';
       if (!LEAF) {
         r = await this._foldUpto();                              // mutates a referenced solid → authoritative re-fold
       } else {

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -182,14 +182,14 @@
 <div id="stat">booting…</div>
 
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->
-<script src="bonsai_kernel.js?v=5" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
+<script src="bonsai_kernel.js?v=6" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
 <!-- Bonsai 2D sketch front: planegcs constraint solver -> solved profile -> GEOM_EXTRUDE_POLY. -->
 <script src="bonsai_sketch.js?v=1" onerror="console.warn('§SKETCH LOAD_FAIL bonsai_sketch.js')"></script>
 <!-- Signed op-log engine (shipped kernel_ops: hash chain + edge signature) + sql.js it commits into. -->
 <script src="lib/sql-wasm.js" onerror="console.warn('§OPLOG LOAD_FAIL sql-wasm.js')"></script>
 <script src="kernel_ops.js?v=9" onerror="console.warn('§OPLOG LOAD_FAIL kernel_ops.js')"></script>
 <!-- Bonsai feature tree: the SIGNED op-log; geometry is a fold over it; history scrubber replays the recipe. -->
-<script src="bonsai_oplog.js?v=8" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
+<script src="bonsai_oplog.js?v=9" onerror="console.warn('§OPLOG LOAD_FAIL bonsai_oplog.js')"></script>
 <!-- §WORLD-HIST-MODELLER (RESUME_WORLD_HISTORY_DEDUP_RESTORE.md 4-step handoff): the SAME cross-page
      "W" log (common/whole_history.js) the Viewer/iDempiere/Gravity already write to. Loaded BEFORE
      history_bar.js so its internal WholeHistory.record mirror (the BUILDING_OPEN doc-type) has a live
@@ -1445,6 +1445,9 @@ function featLabel(op) {
     case 'GEOM_EXTRUDE_POLY': return 'Wall'; case 'GEOM_EXTRUDE': return 'Wall';
     case 'GEOM_CUT': return 'Opening'; case 'GEOM_SWEEP': return 'Route'; case 'GEOM_LOFT': return 'Loft';
     case 'GEOM_FILLET': return P.kind === 'chamfer' ? 'Chamfer' : 'Round'; case 'GEOM_GRID_MOVE': return 'Grid move';
+    case 'GEOM_REVOLVE': return 'Revolve'; case 'GEOM_SHELL': return 'Shell'; case 'GEOM_OFFSET': return 'Offset';
+    case 'GEOM_FILLET_VARIABLE': return 'Var. Fillet'; case 'GEOM_CHAMFER_DIST_ANGLE': return 'Chamfer∠';
+    case 'GEOM_DRAFT': return 'Draft';
     case 'GEOM_INSERT': { const c = window.Bonsai.library && window.Bonsai.library.get(P.hash); return c ? c.ifc_class.replace('Ifc', '') : 'Component'; }
     default: return op.op_type.replace('GEOM_', '');
   }
@@ -2588,7 +2591,11 @@ let _asmGhost = null;   // M7: cached rich assembly-ghost child cluster (rebuilt
 function isInsert(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && o.op_type === 'GEOM_INSERT'; }
 // standalone B-rep solids the worker can spin in place (GEOM_ROTATE): extrude/poly walls, swept runs, filleted solids,
 // lofted solids (GEOM_LOFT — a fresh self-contained solid like GEOM_SWEEP, so it belongs in this set too).
-const SOLID_OPS = new Set(['GEOM_EXTRUDE', 'GEOM_EXTRUDE_POLY', 'GEOM_SWEEP', 'GEOM_FILLET', 'GEOM_LOFT']);
+// Tier 1 (§GAP-TO-COMPETITIVE): GEOM_REVOLVE (fresh self-contained solid, same class as GEOM_LOFT) + the 5
+// parent-mutating shoulders (GEOM_SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT) — included alongside
+// GEOM_FILLET for the SAME reason GEOM_FILLET already is (defensive completeness for a pick-by-id lookup).
+const SOLID_OPS = new Set(['GEOM_EXTRUDE', 'GEOM_EXTRUDE_POLY', 'GEOM_SWEEP', 'GEOM_FILLET', 'GEOM_LOFT',
+  'GEOM_REVOLVE', 'GEOM_SHELL', 'GEOM_OFFSET', 'GEOM_FILLET_VARIABLE', 'GEOM_CHAMFER_DIST_ANGLE', 'GEOM_DRAFT']);
 function isSolid(id) { const o = window.Bonsai.oplog._geomOps().find(o => o.id === id); return !!o && SOLID_OPS.has(o.op_type); }
 function lodTargetId() { return (selectedId != null && isInsert(selectedId)) ? selectedId : lastInsertId; }
 function paintLod() {
@@ -3047,6 +3054,29 @@ window.Bonsai.outliner.addCategory({ key: 'arrays', label: 'Arrays', match: op =
 window.Bonsai.outliner.addCategory({ key: 'lofts', label: 'Lofts', match: op => op.op_type === 'GEOM_LOFT',
   node: op => ({ id: op.id, label: 'Loft',
     sub: (op.parameters.wires ? op.parameters.wires.length : 0) + 'w' + (op.parameters.ruled ? ' ·ruled' : ' ·smooth') }) });
+// Tier 1 (prompts/BONSAI_KERNEL_RESEARCH.md §GAP-TO-COMPETITIVE) — one flat category per op, same convention
+// as routes/fillets/gridmoves/lofts above. Revolve is a fresh solid (own `id`, like Loft); the other 5 mutate
+// a referenced parent in place (own row `id` shown as a distinct feature, `⮡ parent` sub like Fillets does).
+window.Bonsai.outliner.addCategory({ key: 'revolves', label: 'Revolves', match: op => op.op_type === 'GEOM_REVOLVE',
+  node: op => ({ id: op.id, label: 'Revolve',
+    sub: (op.parameters.angleRad != null ? (op.parameters.angleRad * 180 / Math.PI).toFixed(0) : '360') + '°' }) });
+window.Bonsai.outliner.addCategory({ key: 'shells', label: 'Shells', match: op => op.op_type === 'GEOM_SHELL',
+  node: op => ({ id: op.parameters.parent, label: 'Shell',
+    sub: '⮡ ' + op.parameters.parent + ' ·t=' + (op.parameters.thickness != null ? op.parameters.thickness : 0.1) + 'm' }) });
+window.Bonsai.outliner.addCategory({ key: 'offsets', label: 'Offsets', match: op => op.op_type === 'GEOM_OFFSET',
+  node: op => ({ id: op.parameters.parent, label: 'Offset',
+    sub: '⮡ ' + op.parameters.parent + ' ·d=' + (op.parameters.distance != null ? op.parameters.distance : 0.1) + 'm' }) });
+window.Bonsai.outliner.addCategory({ key: 'filletvars', label: 'Var. Fillets', match: op => op.op_type === 'GEOM_FILLET_VARIABLE',
+  node: op => ({ id: op.parameters.parent, label: 'Var. Fillet',
+    sub: '⮡ ' + op.parameters.parent + ' ·' + (op.parameters.startRadius != null ? op.parameters.startRadius : 0.05) +
+      '→' + (op.parameters.endRadius != null ? op.parameters.endRadius : 0.2) }) });
+window.Bonsai.outliner.addCategory({ key: 'chamferdas', label: 'Chamfers∠', match: op => op.op_type === 'GEOM_CHAMFER_DIST_ANGLE',
+  node: op => ({ id: op.parameters.parent, label: 'Chamfer∠',
+    sub: '⮡ ' + op.parameters.parent + ' ·' + (op.parameters.distance != null ? op.parameters.distance : 0.1) +
+      'm@' + (op.parameters.angleDeg != null ? op.parameters.angleDeg : 45) + '°' }) });
+window.Bonsai.outliner.addCategory({ key: 'drafts', label: 'Drafts', match: op => op.op_type === 'GEOM_DRAFT',
+  node: op => ({ id: op.parameters.parent, label: 'Draft',
+    sub: '⮡ ' + op.parameters.parent + ' ·' + ((op.parameters.angleRad != null ? op.parameters.angleRad : 0.1) * 180 / Math.PI).toFixed(1) + '°' }) });
 // Components category: inserted library components (§OOTB Item 2 = assemble, don't draw). Registered via the seam.
 // §LOD400-STALL fix #4: match EXCLUDES raw-bbox (hash-less) inserts — the ARC-seed substrate (arc_editable.js,
 // no `params.hash`, a MEASURED bbox instead) is not a user-placed catalog component; it already has its own

--- a/modeller/tests/bonsai_tier1_live.js
+++ b/modeller/tests/bonsai_tier1_live.js
@@ -1,0 +1,277 @@
+// W-BONSAI-TIER1 — Bonsai modeller: Tier 1 kernel shoulders (prompts/BONSAI_KERNEL_RESEARCH.md
+// §GAP-TO-COMPETITIVE Tier 1): GEOM_REVOLVE / GEOM_SHELL / GEOM_OFFSET / GEOM_FILLET_VARIABLE /
+// GEOM_CHAMFER_DIST_ANGLE / GEOM_DRAFT. Same recipe + witness style as bonsai_loft_live.js — driven
+// PURELY through the signed op-log (O.commit()), no canvas pointer dispatch. Per-op checks: real solid
+// (non-zero triangles, via the AUTHORITATIVE commit()/scrub() return value — never a scene-mesh lookup
+// across an oplog.clear(), which (unlike the real bClear button — see modeller.html bClear.onclick,
+// which empties the THREE group BEFORE calling oplog.clear()) does not itself wipe stale meshes; this
+// witness mirrors that same clearAll() discipline explicitly, see helper below), determinism (scrub
+// back/fwd + COLD cache re-fold reproduces identical tris), tamper-evidence (verifyChain fails), and —
+// where the op has a real second parameter (angle/radius range/distance) — a comparative check that the
+// parameter ACTUALLY changes the result (not a no-op wrapper). Outliner: one row per op-type category.
+const http = require('http'), fs = require('fs'), path = require('path');
+const VIEWER = path.join(__dirname, '..');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.map': 'application/json' };
+const server = http.createServer((q, r) => {
+  let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller.html';
+  fs.readFile(path.join(VIEWER, p), (e, b) => {
+    if (e) { r.writeHead(404); r.end('404 ' + p); return; }
+    r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b);
+  });
+});
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  pg.on('pageerror', e => console.log('  ERR ' + String(e).slice(0, 300)));
+  pg.on('console', m => { const t = m.text(); if (/§TIER1|§KRN|§OPLOG/.test(t)) console.log('  ' + t); });
+  await pg.goto(`http://localhost:${port}/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction("window.Bonsai && window.Bonsai.library && window.Bonsai.library.ready && window.Bonsai.oplog", { timeout: 30000 }).catch(() => {});
+  await pg.evaluate(() => window.Bonsai.library.ready());
+
+  const r = await pg.evaluate(async () => {
+    const O = window.Bonsai.oplog, out = {};
+    const sleep = ms => new Promise(res => setTimeout(res, ms));
+    // clearAll() mirrors the REAL bClear button (modeller.html bClear.onclick): empty the THREE group
+    // FIRST, then oplog.clear() — oplog.clear() alone does not wipe scene meshes (LEAF ops optimistically
+    // APPEND, never remove), so a bare O.clear() between two LEAF commits leaves a stale mesh with the
+    // SAME reused featureId (ids restart at 1 on every fresh empty db) sitting in the group.
+    function clearAll() { const g = window.Bonsai.group(); if (g) { while (g.children.length) g.remove(g.children[0]); } O.clear(); }
+    const meshOf = fid => { const g = window.Bonsai.group(); return g && g.children.find(o => o.isMesh && o.userData.featureId === fid); };
+    const dims = fid => {
+      const m = meshOf(fid); if (!m) return null;
+      m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+      const nv = m.geometry.attributes.position ? m.geometry.attributes.position.count : 0;
+      const tris = m.geometry.index ? m.geometry.index.count / 3 : nv / 3;
+      return { ex: +(b.max.x - b.min.x).toFixed(3), ey: +(b.max.y - b.min.y).toFixed(3), ez: +(b.max.z - b.min.z).toFixed(3),
+        minx: +b.min.x.toFixed(3), miny: +b.min.y.toFixed(3), minz: +b.min.z.toFixed(3), nv, tris };
+    };
+    const settle = async (fid, pred) => { for (let i = 0; i < 100; i++) { const d = dims(fid); if (d && pred(d)) return d; await sleep(50); } return dims(fid); };
+    const WALLPTS = [[0, 0], [2, 0], [2, 2], [0, 2]];   // a 2x2x2 cube (depth 2) — shared parent for every parent-mutating op below
+    const BOX_CENTROID = [1, 1, 1];   // WALLPTS extruded depth 2 -> a 2x2x2 cube centred here
+    // GEOM_DRAFT's verified real convention (see bonsai_kernel_worker.js GEOM_DRAFT comment): `direction`
+    // must be the picked face's OWN outward normal for a real taper on a side face. For our axis-aligned
+    // box, the outward normal is the axis of largest |mid - centroid|, signed by that difference.
+    function faceNormalOf(face) {
+      const d = [face.mid[0] - BOX_CENTROID[0], face.mid[1] - BOX_CENTROID[1], face.mid[2] - BOX_CENTROID[2]];
+      const a = d.map(Math.abs); const axis = a[0] >= a[1] && a[0] >= a[2] ? 0 : (a[1] >= a[2] ? 1 : 2);
+      const n = [0, 0, 0]; n[axis] = d[axis] > 0 ? 1 : -1;
+      return { x: n[0], y: n[1], z: n[2] };
+    }
+
+    // Common determinism+tamper harness for a NON-LEAF parent-mutating op (SHELL/OFFSET/FILLET_VARIABLE/
+    // CHAMFER_DIST_ANGLE/DRAFT): commit a fresh wall, apply the op, prove (1) real solid (tris>0, != plain
+    // box's 12), (2) scrub back (op undone -> plain box, 12 tris) -> forward (op back, SAME tris),
+    // (3) COLD cache re-fold (clearKernelCache + scrub to tip) reproduces the identical tris, (4) tamper
+    // caught. Returns the raw numbers for the CALLER to add op-specific comparative assertions.
+    async function testParentOp(label, opType, buildParams) {
+      clearAll(); await sleep(50);
+      const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: WALLPTS }, depth: 2 } }, { color: 0x9fb4c8 });
+      const wd = await settle(wall.id, x => x && x.nv > 0);
+      const baseTris = wd ? wd.tris : null;   // 12 (plain box)
+      let edges = null, faces = null;
+      if (buildParams.length >= 3) edges = (await window.Bonsai.queryEdges(wall.id)).edges;
+      if (buildParams.length >= 4) faces = (await window.Bonsai.queryFaces(wall.id)).faces;
+      const params = buildParams(wall.id, wd, edges, faces);
+      const res = await O.commit({ op_type: opType, parameters: params }, { color: 0xd08a3e });
+      const d = await settle(wall.id, x => x && x.tris === res.triangleCount);
+      const tris = d ? d.tris : null;
+
+      const n = O.length;   // 2: [wall, op]
+      await O.scrubTo(n - 1);
+      const backTris = (dims(wall.id) || {}).tris;
+      await O.scrubTo(n);
+      const fwd = await settle(wall.id, x => x && x.tris === tris);
+      const fwdTris = fwd ? fwd.tris : null;
+
+      await window.Bonsai.clearKernelCache();
+      await O.scrubTo(O.length);
+      const coldRebuilt = (window.Bonsai._lastRegenStats && window.Bonsai._lastRegenStats.rebuilt) || 0;
+      const cold = await settle(wall.id, x => x && x.tris === tris);
+      const coldTris = cold ? cold.tris : null;
+
+      O.db.run("UPDATE kernel_ops SET parameters = ? WHERE id = ?", [JSON.stringify({ tampered: true }), res.id]);
+      const tamperCaught = !(await O.verify()).ok;
+
+      console.log('§TIER1 ' + label + ' baseTris=' + baseTris + ' tris=' + tris + ' backTris=' + backTris +
+        ' fwdTris=' + fwdTris + ' coldRebuilt=' + coldRebuilt + ' coldTris=' + coldTris + ' tamperCaught=' + tamperCaught +
+        ' verify=' + res.verify + ' signed=' + res.signed + ' dbbox=' + JSON.stringify(d ? [d.ex, d.ey, d.ez] : null));
+      return { label, wallId: wall.id, opId: res.id, edges, faces, baseTris, tris, backTris, fwdTris, coldRebuilt, coldTris,
+        tamperCaught, verify: res.verify, signed: res.signed, ex: d && d.ex, ey: d && d.ey, ez: d && d.ez };
+    }
+
+    try {
+      window.Bonsai.grid.show(false);
+
+      // ══════════ PART A — GEOM_REVOLVE (LEAF, highest-value Tier 1 op) ══════════
+      // Axis IN the profile's own plane (z=0, axis=X — a Z axis would keep every point in its own z=const
+      // plane = a degenerate flat annulus, NOT a solid; an in-plane axis genuinely sweeps the profile
+      // through 3D). Profile = radius-1..2, length-0..2 rectangle -> a hollow tube/column when revolved.
+      clearAll(); await sleep(50);
+      const TUBE = [[0, 1], [2, 1], [2, 2], [0, 2]];
+      const AXIS_X = { point: { x: 0, y: 0, z: 0 }, direction: { x: 1, y: 0, z: 0 } };
+      const fullRev = await O.commit({ op_type: 'GEOM_REVOLVE',
+        parameters: { profile: { points: TUBE, z: 0 }, axis: AXIS_X, angleRad: 2 * Math.PI } }, { color: 0xd08a3e });
+      await settle(fullRev.id, x => x && x.nv > 0);
+      out.revolveFullTris = fullRev.triangleCount; out.revolveFullLeaf = fullRev.appended === true;
+      console.log('§TIER1 revolve-full tris=' + out.revolveFullTris + ' leafAppended=' + out.revolveFullLeaf + ' signed=' + fullRev.signed + ' verify=' + fullRev.verify);
+
+      clearAll(); await sleep(50);
+      const halfRev = await O.commit({ op_type: 'GEOM_REVOLVE',
+        parameters: { profile: { points: TUBE, z: 0 }, axis: AXIS_X, angleRad: Math.PI / 2 } }, { color: 0xd08a3e });
+      await settle(halfRev.id, x => x && x.nv > 0);
+      out.revolveHalfTris = halfRev.triangleCount;   // angleRad actually changes the result — the "not a no-op wrapper" proof
+      console.log('§TIER1 revolve-quarter tris=' + out.revolveHalfTris);
+
+      // determinism (COLD cache re-fold) + tamper, on a fresh single-op chain
+      clearAll(); await sleep(50);
+      const revA = await O.commit({ op_type: 'GEOM_REVOLVE', parameters: { profile: { points: TUBE, z: 0 }, axis: AXIS_X, angleRad: 2 * Math.PI } });
+      await settle(revA.id, x => x && x.nv > 0);
+      await window.Bonsai.clearKernelCache();
+      await O.scrubTo(O.length);
+      out.revolveColdRebuilt = (window.Bonsai._lastRegenStats && window.Bonsai._lastRegenStats.rebuilt) || 0;
+      const revCold = await settle(revA.id, x => x && x.nv > 0);
+      out.revolveColdMatch = revCold && revCold.tris === out.revolveFullTris;
+      O.db.run("UPDATE kernel_ops SET parameters = ? WHERE id = ?", [JSON.stringify({ tampered: true }), revA.id]);
+      out.revolveTamperCaught = !(await O.verify()).ok;
+      console.log('§TIER1 revolve-determinism coldRebuilt=' + out.revolveColdRebuilt + ' coldMatch=' + out.revolveColdMatch + ' tamperCaught=' + out.revolveTamperCaught);
+
+      // ══════════ PART B — GEOM_SHELL (non-LEAF, face-pick) ══════════
+      // Remove the TOP face (highest mid.z) of the 2x2x2 box, thickness 0.3 -> an open-top hollow box.
+      const shellR = await testParentOp('shell', 'GEOM_SHELL', (parentId, wd, edges, faces) => {
+        const top = faces.slice().sort((a, b) => b.mid[2] - a.mid[2])[0];
+        out._shellFaceCount = faces.length;   // a box has 6 faces
+        return { parent: parentId, faces: [top.i], thickness: 0.3, tolerance: 1e-3 };
+      });
+      out.shell = shellR;
+
+      // ══════════ PART C — GEOM_OFFSET (non-LEAF, whole-solid, no pick device) ══════════
+      const offsetGrow = await testParentOp('offset-grow', 'GEOM_OFFSET', (parentId) => ({ parent: parentId, distance: 0.3, tolerance: 1e-3 }));
+      out.offsetGrow = offsetGrow;
+      const offsetShrink = await testParentOp('offset-shrink', 'GEOM_OFFSET', (parentId) => ({ parent: parentId, distance: -0.3, tolerance: 1e-3 }));
+      out.offsetShrink = offsetShrink;
+
+      // ══════════ PART D — GEOM_FILLET_VARIABLE (non-LEAF, single-edge-pick) ══════════
+      // Vary radius 0.05->0.4 along the LONGEST (vertical, length=2) edge; compare against a plain
+      // constant-radius GEOM_FILLET on the SAME edge to prove the variable-radius result is genuinely
+      // different topology (not silently collapsing to one of the two constants).
+      const filletVarR = await testParentOp('fillet-variable', 'GEOM_FILLET_VARIABLE', (parentId, wd, edges) => {
+        const longest = edges.slice().sort((a, b) => b.len - a.len)[0];
+        out._fvEdgeLen = longest.len; out._fvEdgeIdx = longest.i;
+        return { parent: parentId, edges: [longest.i], startRadius: 0.05, endRadius: 0.4 };
+      });
+      out.filletVariable = filletVarR;
+      // comparison: same edge, CONSTANT radius 0.4 (the variable's own end radius) via the EXISTING GEOM_FILLET
+      clearAll(); await sleep(50);
+      const cwall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: WALLPTS }, depth: 2 } });
+      await settle(cwall.id, x => x && x.nv > 0);
+      const constFillet = await O.commit({ op_type: 'GEOM_FILLET', parameters: { parent: cwall.id, edges: [out._fvEdgeIdx], radius: 0.4, kind: 'fillet' } });
+      const cd = await settle(cwall.id, x => x && x.tris === constFillet.triangleCount);
+      out.constFilletTris = cd ? cd.tris : null;
+      console.log('§TIER1 fillet-variable-vs-constant varTris=' + out.filletVariable.tris + ' constTris=' + out.constFilletTris);
+
+      // ══════════ PART E — GEOM_CHAMFER_DIST_ANGLE (non-LEAF, edge-pick) ══════════
+      // Same longest edge, distance 0.3 @ angle 30° — proves a real, non-degenerate chamfered solid
+      // (tris grows from the plain box's 12). HONEST CAVEAT (probed directly, not guessed): a single
+      // new planar bevel face on a symmetric corner edge keeps the SAME triangle COUNT regardless of
+      // the exact angle value (topology is angle-invariant here; only vertex positions shift), so a
+      // tris-based "vs a 45°-equivalent symmetric chamfer" comparison is NOT a valid oracle for this
+      // simple box+single-edge case — dropped rather than forced; the angle-sensitivity proof for this
+      // Tier lives in PART A (revolve angleRad) and PART D (fillet_variable start/end radius) instead.
+      const chamferDAR = await testParentOp('chamfer-dist-angle', 'GEOM_CHAMFER_DIST_ANGLE', (parentId, wd, edges) => {
+        const longest = edges.slice().sort((a, b) => b.len - a.len)[0];
+        out._cdaEdgeIdx = longest.i;
+        return { parent: parentId, edges: [longest.i], distance: 0.3, angleDeg: 30 };
+      });
+      out.chamferDistAngle = chamferDAR;
+
+      // ══════════ PART F — GEOM_DRAFT (non-LEAF, single-face-pick) ══════════
+      // Pull a SIDE face (mid.z near mid-height, i.e. NOT top/bottom) by 0.5 rad, direction = that
+      // face's OWN outward normal (the verified-real convention — see bonsai_kernel_worker.js's GEOM_DRAFT
+      // comment and faceNormalOf() above; an arbitrary vertical "pull vector" was directly probed and
+      // found to be a silent geometric no-op on a side face, and horizontal top/bottom faces throw).
+      const draftR = await testParentOp('draft', 'GEOM_DRAFT', (parentId, wd, edges, faces) => {
+        const side = faces.filter(f => Math.abs(f.mid[2] - 1) < 0.1)[0] || faces.find(f => Math.abs(f.mid[2] - 0) > 0.1 && Math.abs(f.mid[2] - 2) > 0.1);
+        out._draftFaceIdx = side ? side.i : 0;
+        const dir = faceNormalOf(side);
+        out._draftDir = dir;
+        return { parent: parentId, faces: [side ? side.i : 0], angleRad: 0.5, direction: dir };
+      });
+      out.draft = draftR;
+
+      // ══════════ PART G — OUTLINER: one row per Tier 1 op-type category, no paint regression ══════════
+      // A SEPARATE wall per op (not one wall chained through all 6) — each parent-mutating op invalidates the
+      // PRIOR edge/face index resolution of its own parent (shell/offset change the solid's topology, so an
+      // edge index resolved before them may no longer be valid after — exactly the failure PART G hit before
+      // this fix), so a real building models each feature on its OWN geometry, same as PARTs B-F's isolation.
+      clearAll(); await sleep(50);
+      window.Bonsai.outliner.refresh();
+      const t0 = performance.now(); window.Bonsai.outliner.refresh(); const baselineMs = performance.now() - t0;
+      await O.commit({ op_type: 'GEOM_REVOLVE', parameters: { profile: { points: TUBE, z: 0 }, axis: AXIS_X, angleRad: 2 * Math.PI } });
+      async function freshWall() { const w = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: WALLPTS }, depth: 2 } }); await settle(w.id, x => x && x.nv > 0); return w; }
+      const wShell = await freshWall();
+      const topF = (await window.Bonsai.queryFaces(wShell.id)).faces.slice().sort((a, b) => b.mid[2] - a.mid[2])[0];
+      await O.commit({ op_type: 'GEOM_SHELL', parameters: { parent: wShell.id, faces: [topF.i], thickness: 0.2, tolerance: 1e-3 } });
+      const wOffset = await freshWall();
+      await O.commit({ op_type: 'GEOM_OFFSET', parameters: { parent: wOffset.id, distance: 0.1, tolerance: 1e-3 } });
+      const wFV = await freshWall();
+      const fvE = (await window.Bonsai.queryEdges(wFV.id)).edges.slice().sort((a, b) => b.len - a.len)[0];
+      await O.commit({ op_type: 'GEOM_FILLET_VARIABLE', parameters: { parent: wFV.id, edges: [fvE.i], startRadius: 0.02, endRadius: 0.1 } });
+      const wCDA = await freshWall();
+      const cdaE = (await window.Bonsai.queryEdges(wCDA.id)).edges.slice().sort((a, b) => b.len - a.len)[0];
+      await O.commit({ op_type: 'GEOM_CHAMFER_DIST_ANGLE', parameters: { parent: wCDA.id, edges: [cdaE.i], distance: 0.1, angleDeg: 20 } });
+      const wDraft = await freshWall();
+      const sideF = (await window.Bonsai.queryFaces(wDraft.id)).faces.filter(f => Math.abs(f.mid[2] - 1) < 0.1)[0];
+      await O.commit({ op_type: 'GEOM_DRAFT', parameters: { parent: wDraft.id, faces: [sideF.i], angleRad: 0.5, direction: faceNormalOf(sideF) } });
+      window.Bonsai.outliner.refresh();
+      const t1 = performance.now(); window.Bonsai.outliner.refresh(); const tier1Ms = performance.now() - t1;
+      out.outlinerBaselineMs = +baselineMs.toFixed(2); out.outlinerTier1Ms = +tier1Ms.toFixed(2);
+      out.outlinerOk = tier1Ms < 200;
+      const grps = Array.from(document.querySelectorAll('#bonsai-outliner [data-grp]')).map(d => d.getAttribute('data-grp'));
+      out.categoriesPresent = ['revolves', 'shells', 'offsets', 'filletvars', 'chamferdas', 'drafts'].every(k => grps.includes(k));
+      console.log('§TIER1 outliner baselineMs=' + out.outlinerBaselineMs + ' tier1Ms=' + out.outlinerTier1Ms + ' categoriesPresent=' + out.categoriesPresent + ' grps=' + JSON.stringify(grps));
+
+    } catch (e) { out.error = String(e && e.message || e); console.warn('§TIER1 fail ' + e + (e && e.stack ? '\n' + e.stack : '')); }
+    return out;
+  });
+
+  await br.close(); server.close();
+  console.log('  §TIER1 ' + JSON.stringify(r));
+  const P = r;
+  // parentOpOk = the PLUMBING invariant every non-LEAF Tier 1 op must satisfy (real solid, deterministic
+  // scrub/cold-refold, tamper-evident) — deliberately does NOT require "tris != baseTris" here, since a
+  // real geometric change is not always tri-count-visible (offset-shrink keeps the same box topology;
+  // a single-face chamfer/draft bevel can too) — see the per-op "actually changed" checks below instead.
+  const parentOpOk = (o) => o && o.tris > 0 && o.backTris === o.baseTris &&
+    o.fwdTris === o.tris && o.coldRebuilt > 0 && o.coldTris === o.tris && o.tamperCaught === true && o.verify === true;
+  const checks = {
+    revolveReal:        P.revolveFullTris > 0,
+    revolveLeaf:         P.revolveFullLeaf === true,
+    revolveAngleMatters: P.revolveHalfTris > 0 && P.revolveFullTris !== P.revolveHalfTris,
+    revolveColdRebuiltReal: P.revolveColdRebuilt > 0,
+    revolveColdMatch:    P.revolveColdMatch === true,
+    revolveTamperCaught: P.revolveTamperCaught === true,
+    shellOk:             parentOpOk(P.shell),
+    shellChanged:        P.shell && P.shell.tris !== P.shell.baseTris,          // 12 -> 28 (opened+hollowed)
+    offsetGrowOk:        parentOpOk(P.offsetGrow),
+    offsetShrinkOk:      parentOpOk(P.offsetShrink),
+    offsetGrowVsShrink:  P.offsetGrow && P.offsetShrink && P.offsetGrow.ex > P.offsetShrink.ex,   // distance sign actually matters
+    filletVariableOk:    parentOpOk(P.filletVariable),
+    filletVariableChanged: P.filletVariable && P.filletVariable.tris !== P.filletVariable.baseTris,
+    filletVariableDistinctFromConstant: P.filletVariable && P.filletVariable.tris !== P.constFilletTris,
+    chamferDistAngleOk:  parentOpOk(P.chamferDistAngle),
+    chamferDistAngleChanged: P.chamferDistAngle && P.chamferDistAngle.tris !== P.chamferDistAngle.baseTris,   // 12 -> 16 (real bevel)
+    draftOk:             parentOpOk(P.draft),
+    draftChanged:        P.draft && (P.draft.ex !== 2 || P.draft.ey !== 2 || P.draft.ez !== 2),   // real bbox shift (see PART F caveat)
+    outlinerNoRegress:   P.outlinerOk === true,
+    outlinerCategories:  P.categoriesPresent === true
+  };
+  const pass = Object.values(checks).every(Boolean) && !r.error;
+  console.log('  §TIER1 VERDICT ' + (pass ? 'PASS' : 'FAIL') + ' — ' +
+    Object.entries(checks).map(([k, v]) => k + '=' + v).join(' ') + (r.error ? ' error=' + r.error : ''));
+  console.log('── W-BONSAI-TIER1 ' + (pass ? 'PASS' : 'FAIL') + ' ──');
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.log('FATAL ' + e); process.exit(1); });


### PR DESCRIPTION
## Summary
Wires the 6 already-exported occt bindings flagged as Tier 1 "cheap shoulders" in `prompts/BONSAI_KERNEL_RESEARCH.md` §GAP-TO-COMPETITIVE, following the exact recipe `GEOM_LOFT` (#688) proved: worker case + LEAF-set entry + Outliner category + witness, no new math.

- **`GEOM_REVOLVE`** (`kernel.revolve`) — LEAF, fresh self-contained solid (profile+axis+angle, no parent). Highest-value op in this tier: first axisymmetric-solid authoring path (round columns/tanks/turned parts). Axis must lie IN the profile's own plane for a real solid.
- **`GEOM_SHELL`** (`kernel.shell`) — non-LEAF, parent-mutating. New `listFaces`/`queryFaces` §FACE-PICK device mirrors the existing edge-pick.
- **`GEOM_OFFSET`** (`kernel.offset`) — non-LEAF. Simpler than assumed: whole-solid distance+tolerance, no face list.
- **`GEOM_FILLET_VARIABLE`** (`kernel.filletVariable`) — non-LEAF. Real signature takes a SINGLE edge (not an array) + start/end radius.
- **`GEOM_CHAMFER_DIST_ANGLE`** (`kernel.chamferDistAngle`) — non-LEAF, edge array + distance + angleDeg (degrees).
- **`GEOM_DRAFT`** (`kernel.draft`) — non-LEAF, single face. Verified by direct probing: `direction` must be the picked face's own outward normal for a real taper; an unrelated direction is silently a no-op; horizontal faces throw. Documented in-code for the next caller.

**LEAF classification:** only `GEOM_REVOLVE` joins the optimistic-append whitelist (own solid, no parent ref — same class as `GEOM_SWEEP`/`GEOM_LOFT`). The other 5 mutate a referenced parent (same class as `GEOM_CUT`/`GEOM_FILLET`) and take the authoritative re-fold.

## Test plan
- [x] `modeller/tests/bonsai_tier1_live.js` (W-BONSAI-TIER1) — PASS. Per op: real non-degenerate solid, scrub back/forward determinism, COLD kernel-cache re-fold reproduces identical triangle counts, tamper breaks `verifyChain`; comparative parameter-sensitivity checks (revolve angle, fillet_variable radius range). Outliner: 6 new categories, no paint-time regression.
- [x] No regression: `bonsai_loft_live.js` / `bonsai_array_live.js` re-run, both still PASS.
- [x] `bonsai_fillet_live.js` / `bonsai_sweep_live.js` / `bonsai_signed_live.js` / `bonsai_recipe_live.js` independently confirmed to already FAIL identically on a clean, unmodified checkout of this same branch (pre-existing canvas/WebGL-rendering environment issue in this sandbox — none of them exercise any new op type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)