### PR TITLE
feat(modeller): shared real-placement gate + fix hardcoded fixture boxes

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -254,9 +254,13 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
 <!-- Connect Scene broker (prompts/CONNECT_SCENE_SPEC.md): shared cross-surface CONTEXT (selection/timeline/
      identity) over the one signed op-log; surfaces stay separate, only context crosses. Opt-in toggle. -->
 <script src="../viewer/connect_scene.js?v=2" onerror="console.warn('§CONNECT LOAD_FAIL connect_scene.js')"></script>
+<!-- Real-placement gate (WalkerDoctrine.md §10): the ONE shared resolveRealPlacement() every leaf placement
+     (fixture, pipe, future component) must route through instead of inventing a bbox constant. Loaded BEFORE
+     routewalker.js, whose _rwPlaceFromBOM (Path B fixture placement) is its first wired call site. -->
+<script src="real_placement_resolver.js?v=1" onerror="console.warn('§RPR LOAD_FAIL real_placement_resolver.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
-<script src="routewalker.js?v=5" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
+<script src="routewalker.js?v=6" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
 <!-- DiscWalker: the ONE shared discipline-walker engine (Placer/Router/Gate) reading the MEASURED
      terminal_rules.db (mined off Terminal). Supersedes the thin mep_rw.db recipes for the disc-node walk —
      every disc walks on ANY opened building from rules measured off a real coordinated building. -->

--- a/modeller/real_placement_resolver.js
+++ b/modeller/real_placement_resolver.js
@@ -1,0 +1,143 @@
+/**
+ * real_placement_resolver.js — ONE shared gate every leaf placement (fixture, pipe, future component) is
+ * FORCED through before it renders a bbox. docs/internal/WalkerDoctrine.md §10 (2026-07-07, user directive):
+ * §8/§9 found the SAME hardcoded-constant violation independently at 6+ call sites across TWO walker files
+ * (routewalker.js's `RW_PIPE_NOMINAL_MM` cross-section AND its `_rwPlaceFromBOM` fixture box, both flat
+ * constants standing in for real product data) — patching each site by hand only guarantees a third recurs.
+ * This module is the structural fix: `resolveRealPlacement()` is the ONE function every leaf-placement call
+ * site should route through instead of reading `ad_product_dim` (or inventing a box) independently.
+ *
+ * Contract (§10's own spec, verbatim):
+ *   resolveRealPlacement({discipline, category, ifc_class, productHint, ...context})
+ *     MATCH    -> {width, depth, height, anchor, matchedProductId, source} — real, sourced, citable.
+ *     NO MATCH -> THROWS a WalkerGapError (code='WALKER_GAP') carrying full search context. The caller MUST
+ *                 catch it, log it VISIBLY (console.error), and count the placement as refused. It must
+ *                 NEVER catch-and-substitute a constant — that silent substitution is the exact violation
+ *                 this gate exists to make structurally hard to reintroduce (§4/§8's REFUSE-beats-fabricate
+ *                 rule, generalized here to every leaf placement, not just pipes or fixtures).
+ *
+ * Source of truth: library/component_library.db's `ad_product_dim` table (bim-compiler repo — NOT shipped
+ * into this modeller's own served tree, so unlike a live sql.js DB read, its real width/depth/height/
+ * conn_points rows are extracted here ONCE as a small, cited, non-invent table). This mirrors two already
+ * doctrine-compliant precedents in this same codebase: disc_walker.js's `MEP_REAL_FITTINGS` (§7 — a real
+ * mini-BOM RosettaStone extract, replayed + cited rather than recomputed) and bonsai_library.js's `CATALOG`
+ * (real mesh components extracted NON-INVENT from the same component_library.db family). "Extract once,
+ * replay, cite the source row" — not a live per-call DB read, and not a fuzzy/semantic guess.
+ *
+ * Extraction command (2026-07-07), every row below copied verbatim from its output — no value here was typed
+ * from memory or "close enough" rounded:
+ *   sqlite3 -header -column library/component_library.db "SELECT product_id, product_type, width, depth,
+ *     height, requires_host, conn_points FROM ad_product_dim WHERE product_id IN ('FIXTURE_TOILET',
+ *     'FIXTURE_SINK','FIXTURE_SHOWER','FIXTURE_WATER_HEATER','ELEC_OUTLET','ELEC_SWITCH','ELEC_LIGHT',
+ *     'FP_SPRINKLER','FP_SMOKE');"
+ */
+(function (ROOT) {
+  'use strict';
+  var TAG = '§RPR';
+
+  // REAL rows, verbatim from ad_product_dim (library/component_library.db). Dimensions are FULL extents in
+  // metres (matches this codebase's own element_transforms.bbox_x/y/z convention — see routewalker.js's
+  // `_rwAabbOverlap`, which halves whatever is passed in). `conn_points` is the real anchor/shim JSON column
+  // ("[{"face":"BACK","type":"WASTE"},...]") — the same shape as `ad_assembly_connector`'s
+  // face/connector_type rows, just embedded per-product instead of per-assembly.
+  var REAL_PRODUCT_DIM = {
+    FIXTURE_TOILET:       { product_type: 'FIXTURE',    width: 0.4,   depth: 0.7,  height: 0.4,
+      requires_host: 'FLOOR',   conn_points: [{ face: 'BACK', type: 'WASTE' }, { face: 'LEFT', type: 'SUPPLY' }] },
+    FIXTURE_SINK:         { product_type: 'FIXTURE',    width: 0.5,   depth: 0.45, height: 0.2,
+      requires_host: 'WALL',    conn_points: [{ face: 'BACK', type: 'WASTE' }, { face: 'BACK', type: 'SUPPLY' }] },
+    FIXTURE_SHOWER:       { product_type: 'FIXTURE',    width: 0.9,   depth: 0.9,  height: 2.1,
+      requires_host: 'FLOOR',   conn_points: [{ face: 'WALL', type: 'SUPPLY' }, { face: 'FLOOR', type: 'WASTE' }] },
+    FIXTURE_WATER_HEATER: { product_type: 'FIXTURE',    width: 0.55,  depth: 0.25, height: 0.55,
+      requires_host: 'WALL',    conn_points: [] },
+    ELEC_OUTLET:          { product_type: 'ELECTRICAL', width: 0.085, depth: 0.04, height: 0.085,
+      requires_host: 'WALL',    conn_points: [{ face: 'BACK', type: 'ELEC' }] },
+    ELEC_SWITCH:          { product_type: 'ELECTRICAL', width: 0.085, depth: 0.04, height: 0.085,
+      requires_host: 'WALL',    conn_points: [{ face: 'BACK', type: 'ELEC' }] },
+    ELEC_LIGHT:           { product_type: 'ELECTRICAL', width: 0.3,   depth: 0.3,  height: 0.1,
+      requires_host: 'CEILING', conn_points: [{ face: 'TOP', type: 'ELEC' }] },
+    FP_SPRINKLER:         { product_type: 'FP',         width: 0.1,   depth: 0.1,  height: 0.15,
+      requires_host: 'CEILING', conn_points: [{ face: 'TOP', type: 'FP' }] },
+    FP_SMOKE:             { product_type: 'FP',         width: 0.12,  depth: 0.12, height: 0.05,
+      requires_host: 'CEILING', conn_points: [{ face: 'TOP', type: 'ELEC' }] }
+  };
+
+  // Curated ALIAS map: a caller's `productHint` (e.g. routewalker.js's `ad_space_type_mep_bom.mep_product_id`
+  // values — 'TOILET','OUTLET',...) -> the real `ad_product_dim.product_id` it names the SAME physical item
+  // as. This is a disclosed 1:1 IDENTITY map, not fuzzy/semantic matching. Deliberately NOT aliased (left to
+  // hard-fail honestly): OUTLET_20A / OUTLET_GFCI (component_library.db has no dedicated row — a 20A or GFCI
+  // faceplate may be a different real size, so reusing ELEC_OUTLET's numbers would be INVENTING an
+  // equivalence, not extracting one), EMERGENCY_LIGHT (a battery-backup unit may differ physically from
+  // ELEC_LIGHT — no real row to confirm either way), and AIRCON_POINT / CEILING_FAN / DATA_POINT /
+  // EXHAUST_FAN / SUPPLY_DIFFUSER / FRIDGE / FLOOR_TRAP / WASHING_TAP (no product row in component_library.db
+  // under any of these names at all — genuinely no real match today).
+  var PRODUCT_ALIAS = {
+    TOILET:    'FIXTURE_TOILET',
+    SINK:      'FIXTURE_SINK',
+    OUTLET:    'ELEC_OUTLET',
+    SWITCH:    'ELEC_SWITCH',
+    LIGHT:     'ELEC_LIGHT',
+    SPRINKLER: 'FP_SPRINKLER'
+  };
+
+  function WalkerGapError(msg, gap) {
+    var e = new Error(msg);
+    e.name = 'WalkerGapError';
+    e.code = 'WALKER_GAP';
+    e.gap = gap;
+    return e;
+  }
+
+  /**
+   * resolveRealPlacement(ctx) — ctx: {discipline, category, ifc_class, productHint, assemblyHint}
+   * `productHint`/`category` is the lookup key (either an exact ad_product_dim.product_id, e.g. 'FIXTURE_SINK',
+   * or a curated PRODUCT_ALIAS key, e.g. 'SINK'). Returns real dims+anchor on match; THROWS WalkerGapError on
+   * no match — see module header for the full contract. Never returns a fabricated default.
+   */
+  function resolveRealPlacement(ctx) {
+    ctx = ctx || {};
+    var productHint = ctx.productHint || ctx.category || null;
+    var productId = null, dim = null;
+
+    if (productHint && Object.prototype.hasOwnProperty.call(REAL_PRODUCT_DIM, productHint)) {
+      productId = productHint; dim = REAL_PRODUCT_DIM[productId];
+    } else if (productHint && Object.prototype.hasOwnProperty.call(PRODUCT_ALIAS, productHint)) {
+      productId = PRODUCT_ALIAS[productHint]; dim = REAL_PRODUCT_DIM[productId];
+    }
+
+    if (!dim) {
+      var gap = {
+        discipline: ctx.discipline || null,
+        category: ctx.category || null,
+        ifc_class: ctx.ifc_class || null,
+        productHint: productHint,
+        searched: {
+          exactProductIdTable: 'ad_product_dim (' + Object.keys(REAL_PRODUCT_DIM).length + ' rows embedded)',
+          aliasTable: 'PRODUCT_ALIAS (' + Object.keys(PRODUCT_ALIAS).length + ' curated identities)',
+          aliasHadKeyButNoRow: !!(productHint && Object.prototype.hasOwnProperty.call(PRODUCT_ALIAS, productHint) && !dim)
+        }
+      };
+      console.error(TAG + ' §RPR-HARDFAIL no real ad_product_dim match for productHint=' + productHint +
+        ' discipline=' + gap.discipline + ' category=' + gap.category + ' ifc_class=' + gap.ifc_class +
+        ' — REFUSED (no fabricated box; caller must skip this placement, not substitute a constant)');
+      throw new WalkerGapError('WALKER_GAP: no real placement data for productHint=' + (productHint || '(none)'), gap);
+    }
+
+    console.log(TAG + ' §RPR-MATCH productHint=' + productHint + ' -> product_id=' + productId +
+      ' dims(w,d,h)=' + dim.width + ',' + dim.depth + ',' + dim.height + ' source=ad_product_dim');
+    return {
+      width: dim.width, depth: dim.depth, height: dim.height,
+      anchor: { requires_host: dim.requires_host, conn_points: dim.conn_points },
+      matchedProductId: productId,
+      source: 'library/component_library.db:ad_product_dim:' + productId
+    };
+  }
+
+  var API = {
+    resolveRealPlacement: resolveRealPlacement,
+    REAL_PRODUCT_DIM: REAL_PRODUCT_DIM,
+    PRODUCT_ALIAS: PRODUCT_ALIAS,
+    WalkerGapError: WalkerGapError
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  ROOT.RealPlacementResolver = API;
+})(typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : this));

--- a/modeller/routewalker.js
+++ b/modeller/routewalker.js
@@ -1172,7 +1172,7 @@ function _rwPlaceFromBOM(buildingDb, buildingName, rooms, arcEnvelope) {
       var real;
       try {
         var RPR = (typeof window !== 'undefined' && window.RealPlacementResolver) ||
-          (typeof RealPlacementResolver !== 'undefined' ? RealPlacementResolver : null);
+          (typeof globalThis !== 'undefined' && globalThis.RealPlacementResolver) || null;
         if (!RPR) throw new Error('RealPlacementResolver module not loaded');
         real = RPR.resolveRealPlacement({ discipline: info.disc, category: product, ifc_class: info.cls, productHint: product });
       } catch (e) {

--- a/modeller/routewalker.js
+++ b/modeller/routewalker.js
@@ -133,7 +133,7 @@ function rwWalk(buildingDb, buildingName, opts) {
   var anchorKey = _rwFindAnchorKey(buildingName, dbBldName);
   var hasAnchors = anchorKey !== null;
 
-  var result = { fixtures: 0, pipes: 0, clashSkipped: 0, total: 0 };
+  var result = { fixtures: 0, pipes: 0, clashSkipped: 0, total: 0, fixturesRefused: 0 };
 
   if (hasAnchors && !opts.forceRegen) {
     // Path A: pattern walk using pre-mined anchors (Java port)
@@ -150,6 +150,7 @@ function rwWalk(buildingDb, buildingName, opts) {
     console.log('§RW_PATH_B building=' + dbBldName + ' rooms=' + rooms.length);
     var bomResult = _rwPlaceFromBOM(buildingDb, dbBldName, rooms, arcEnvelope);
     result.fixtures += bomResult.placed;
+    result.fixturesRefused += (bomResult.refused || 0);
 
     // If no pre-mined anchors, also generate pipe runs from placed fixtures
     if (!hasAnchors || opts.forceRegen) {
@@ -161,6 +162,7 @@ function rwWalk(buildingDb, buildingName, opts) {
 
   result.total = result.fixtures + result.pipes;
   console.log('§RW_WALK building=' + buildingName + ' fixtures=' + result.fixtures +
+              ' fixturesRefused=' + result.fixturesRefused +
               ' pipes=' + result.pipes + ' clashSkipped=' + result.clashSkipped +
               ' total=' + result.total);
   return result;
@@ -1023,7 +1025,7 @@ function _rwClassifyRoom(name, areaSqm) {
  * Reads ad_space_type_mep_bom + ad_placement_offset + _shim_attributes.
  */
 function _rwPlaceFromBOM(buildingDb, buildingName, rooms, arcEnvelope) {
-  var placed = 0;
+  var placed = 0, refused = 0, refusedList = [];
 
   // Load placement offsets (keyed by rule name)
   var offsets = {};
@@ -1069,27 +1071,45 @@ function _rwPlaceFromBOM(buildingDb, buildingName, rooms, arcEnvelope) {
 
       var info = RW_IFC_MAP[product] || RW_IFC_MAP._DEFAULT;
 
+      // WalkerDoctrine.md §10 / real_placement_resolver.js: the ONE shared gate every leaf placement routes
+      // through instead of a hardcoded box. Real dims are the SAME for every q in this product's qty loop
+      // (per-product, not per-instance), so resolve once per BOM row. NO MATCH -> honest refuse: this product
+      // is skipped entirely for this room (never a fabricated 0.15x0.15x0.15 box) and counted in `refused`.
+      var real;
+      try {
+        var RPR = (typeof window !== 'undefined' && window.RealPlacementResolver) ||
+          (typeof RealPlacementResolver !== 'undefined' ? RealPlacementResolver : null);
+        if (!RPR) throw new Error('RealPlacementResolver module not loaded');
+        real = RPR.resolveRealPlacement({ discipline: info.disc, category: product, ifc_class: info.cls, productHint: product });
+      } catch (e) {
+        refused += qty;
+        refusedList.push({ product: product, room: room.storey + '/' + room.type, qty: qty, reason: (e && e.message) || String(e) });
+        console.error('§RW_BOM_PLACE_REFUSE product=' + product + ' room=' + room.storey + '/' + room.type +
+          ' qty=' + qty + ' reason=' + ((e && e.message) || e) + ' — WALKER_GAP, no fabricated box, skipped');
+        return;
+      }
+
       for (var q = 0; q < qty; q++) {
         // Compute XYZ from room bbox + placement offset
         var pos = _rwComputePosition(room, offset, hostSurface, q, qty);
 
-        // Check ARC clash
-        if (_rwClashesWithArc(pos.x, pos.y, pos.z, 0.1, 0.1, 0.1, arcEnvelope)) continue;
+        // Check ARC clash (real dims, not a flat constant)
+        if (_rwClashesWithArc(pos.x, pos.y, pos.z, real.width, real.depth, real.height, arcEnvelope)) continue;
 
         var guid = _rwGuid(product);
         _rwInsertElement(buildingDb, guid, info.cls,
           product + ' ' + room.storey + (qty > 1 ? ' #' + (q + 1) : ''),
           buildingName, room.storey, info.disc, info.rgba,
           pos.x, pos.y, pos.z,
-          0.15, 0.15, 0.15  // fixture bbox — small
+          real.width, real.depth, real.height  // real ad_product_dim bbox — WalkerDoctrine.md §9/§10
         );
         placed++;
       }
     });
   });
 
-  console.log('§RW_BOM_PLACE rooms=' + rooms.length + ' fixtures=' + placed);
-  return { placed: placed };
+  console.log('§RW_BOM_PLACE rooms=' + rooms.length + ' fixtures=' + placed + ' refused=' + refused);
+  return { placed: placed, refused: refused, refusedList: refusedList };
 }
 
 /**

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v32';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v33';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -64,6 +64,7 @@ const PRECACHE_ASSETS = [
   'walker_confidence.js',
   'grid_kinematics.js',
   'kernel_ops.js',
+  'real_placement_resolver.js',   // WalkerDoctrine.md §10 — shared real-placement gate (routewalker.js's first call site)
   'routewalker.js',
   // Cross-surface broker — lives in viewer/ (shared), precache for offline Connect.
   '../viewer/connect_scene.js',

--- a/modeller/tests/witness_real_placement_resolver.js
+++ b/modeller/tests/witness_real_placement_resolver.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-REAL-PLACEMENT-GATE scope (read this block first)
+ * SCOPE: docs/internal/WalkerDoctrine.md §10 — ONE shared real-placement gate every leaf placement is forced
+ *   through, built as real_placement_resolver.js and wired into routewalker.js's `_rwPlaceFromBOM` ("Path B",
+ *   §9 finding #1 — the path most non-Terminal buildings use for MEP fixtures). Before this change EVERY
+ *   fixture (toilet, sink, light, switch, outlet, sprinkler, ...) got an identical hardcoded 0.15x0.15x0.15m
+ *   box regardless of its real size. This gate proves THREE things, each naming the issue it disproves/proves:
+ *   (a) REAL DIMS REPLACE THE BOX: a fixture WITH a real ad_product_dim match (TOILET/SINK/SWITCH/LIGHT/
+ *       SPRINKLER/OUTLET) is written into the building DB's element_transforms.bbox_x/y/z at its REAL measured
+ *       size, not the old flat 0.15,0.15,0.15 — checked against the exact library/component_library.db numbers
+ *       (FIXTURE_TOILET=0.4x0.7x0.4, ELEC_OUTLET=0.085x0.04x0.085, etc.), not approximated.
+ *   (b) HONEST HARD-FAIL IS REACHABLE, NOT DEAD CODE: a product with NO real ad_product_dim row (EXHAUST_FAN/
+ *       FLOOR_TRAP/OUTLET_GFCI in a real BATHROOM recipe; AIRCON_POINT/CEILING_FAN/SUPPLY_DIFFUSER in a real
+ *       BEDROOM recipe — genuinely absent from component_library.db, not a constructed edge case) is REFUSED
+ *       (WalkerGapError, §RPR-HARDFAIL logged, counted in `result.refused`/`result.fixturesRefused`) on a real
+ *       `rwWalk`/`_rwPlaceFromBOM` run, never silently defaulted to a box.
+ *   (c) REGRESSION: `rwWalk`'s Path B (fixtures placed for matched products) keeps working end to end (DB
+ *       round-trip: element_transforms rows actually land with the real dims, not merely "attempted").
+ *
+ * A REAL, DISCLOSED, PRE-EXISTING GAP found while building this witness (not introduced by this change, not
+ * fixed here — out of THIS task's scope, flagged for the person reconciling worktrees): the repo's own
+ * resident files (modeller/Duplex_extracted.db, SampleHouse_extracted.db) carry an `elements_meta` table with
+ * NO `building` column, while `_rwDetectRooms`/`_rwLoadArcEnvelope`'s IfcSpace query and `_rwInsertElement`'s
+ * INSERT both reference `elements_meta.building`. On these exact resident files this makes room-detection
+ * silently fall through to 0 rooms (Path B never even runs) and pipe-inserts silently fail per-row (caught by
+ * `_rwInsertElement`'s own try/catch, logged §RW_INSERT_FAIL, never a thrown error) — independent of this
+ * task's fixture-bbox fix. Section (PROD) below drives the real `#m-open-panel` Duplex resident to document
+ * this measured, not assumed. Sections (a)/(b)/(c)'s PASS/FAIL gates run against a schema-correct building DB
+ * (elements_meta WITH its building column) built in this witness, using the SAME real `mep_rw.db` BOM/offset
+ * recipe rows Path B queries in production — i.e. this isolates "does resolveRealPlacement + _rwPlaceFromBOM's
+ * wiring work" from "does this one committed resident file's schema match what the walker code expects."
+ * Log Mandate: every claim below is backed by a printed § line, read from THIS run's own log, not assumed.
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'puppeteer'));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+const server = http.createServer((q, r) => { let p = decodeURIComponent(q.url.split('?')[0]); if (p === '/') p = '/modeller/modeller.html';
+  let fp = path.join(ROOT, p);
+  if (p === '/modeller/mep_rw.db' && !fs.existsSync(fp)) fp = path.join(ROOT, 'viewer', 'mep_rw.db');
+  fs.readFile(fp, (e, b) => { if (e) { r.writeHead(404); r.end('404'); return; } r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }); r.end(b); }); });
+
+// Ground-truth real dims — read directly from library/component_library.db's ad_product_dim (2026-07-07),
+// quoted here for the assertion, not re-derived (same numbers embedded in real_placement_resolver.js).
+const GT = {
+  TOILET:    { w: 0.4,   d: 0.7,  h: 0.4   },  // FIXTURE_TOILET
+  OUTLET:    { w: 0.085, d: 0.04, h: 0.085 },  // ELEC_OUTLET
+  SWITCH:    { w: 0.085, d: 0.04, h: 0.085 },  // ELEC_SWITCH
+  LIGHT:     { w: 0.3,   d: 0.3,  h: 0.1   },  // ELEC_LIGHT
+  SPRINKLER: { w: 0.1,   d: 0.1,  h: 0.15  },  // FP_SPRINKLER
+  SINK:      { w: 0.5,   d: 0.45, h: 0.2   }   // FIXTURE_SINK
+};
+const OLD_BOX = 0.15;
+// Products with NO real ad_product_dim row today (genuinely absent, not constructed), present in the REAL
+// BATHROOM/BEDROOM mep_rw.db recipes — must REFUSE.
+const NO_MATCH = ['EXHAUST_FAN', 'FLOOR_TRAP', 'OUTLET_GFCI', 'AIRCON_POINT', 'CEILING_FAN', 'SUPPLY_DIFFUSER'];
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'] });
+  const pg = await br.newPage();
+  const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 300)));
+  const logs = []; pg.on('console', m => { const t = m.text(); if (/^§(RW|RPR)/.test(t)) logs.push(t); });
+
+  console.log('═══ W-REAL-PLACEMENT-GATE — real ad_product_dim replaces hardcoded 0.15 fixture box, honest hard-fail proven reachable ═══');
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.Bonsai && !!window.RealPlacementResolver && typeof window.rwWalk === "function"', { timeout: 30000 }).catch(() => {});
+
+  // ── (PROD) disclosed pre-existing gap check, real resident, informational only (not gated pass/fail) ──
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
+  await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  await sleep(1000);
+  const prod = await pg.evaluate(async () => {
+    await window.rwInit(window.SQL, './');
+    const bdb = new window.SQL.Database(new Uint8Array(window.__dwBuf));
+    const hasBuildingCol = bdb.exec("PRAGMA table_info(elements_meta)")[0].values.some(v => v[1] === 'building');
+    const result = window.rwWalk(bdb, window.__dwName);
+    bdb.close();
+    return { hasBuildingCol: hasBuildingCol, result: result };
+  });
+
+  // ── (a)/(b)/(c) controlled, schema-correct building DB + the REAL mep_rw.db BOM recipe (BATHROOM+BEDROOM) ──
+  const out = await pg.evaluate(async () => {
+    const SQL = window.SQL;
+    const bdb = new SQL.Database();
+    bdb.run("CREATE TABLE elements_meta (guid TEXT PRIMARY KEY, ifc_class TEXT, element_name TEXT, building TEXT, storey TEXT, discipline TEXT, material_rgba TEXT)");
+    bdb.run("CREATE TABLE element_transforms (guid TEXT PRIMARY KEY, center_x REAL, center_y REAL, center_z REAL, rotation_x REAL, rotation_y REAL, rotation_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL)");
+    // FOUR thin perimeter walls per storey (a real room shape, not a solid filled cube) — needed so
+    // _rwDetectRooms's storey-fallback aggregate (AVG center / MAX bbox over these 4 wall rows) approximates
+    // the room's OWN envelope, while _rwLoadArcEnvelope's per-wall clash check only blocks the thin perimeter,
+    // not the whole interior (a single filling box would clash-skip every fixture placed inside it — wrong).
+    function addWall(guid, storey, cx, cy, cz, bx, by, bz) {
+      bdb.run("INSERT INTO elements_meta (guid, ifc_class, element_name, building, storey, discipline) VALUES (?, 'IfcWall', ?, 'W_RPR_TEST', ?, 'ARC')", [guid, guid, storey]);
+      bdb.run("INSERT INTO element_transforms (guid, center_x, center_y, center_z, rotation_x, rotation_y, rotation_z, bbox_x, bbox_y, bbox_z) VALUES (?, ?, ?, ?, 0,0,0, ?, ?, ?)", [guid, cx, cy, cz, bx, by, bz]);
+    }
+    function addRoom(prefix, storey, cx, cy, half) {
+      const t = 0.15, span = half * 2;
+      addWall(prefix + '-N', storey, cx, cy + half, 1.5, span, t, 3);
+      addWall(prefix + '-S', storey, cx, cy - half, 1.5, span, t, 3);
+      addWall(prefix + '-E', storey, cx + half, cy, 1.5, t, span, 3);
+      addWall(prefix + '-W', storey, cx - half, cy, 1.5, t, span, 3);
+    }
+    addRoom('R1', 'BATHROOM', 5, 5, 2.5);
+    addRoom('R2', 'BEDROOM', 20, 20, 2.5);
+
+    await window.rwInit(SQL, './');
+    const result = window.rwWalk(bdb, 'W_RPR_TEST');
+    const r = bdb.exec(
+      "SELECT m.element_name, m.storey, t.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m " +
+      "JOIN element_transforms t ON m.guid = t.guid WHERE m.guid LIKE 'RW2D-%'"
+    );
+    const rows = r.length ? r[0].values : [];
+    bdb.close();
+    return { result: result, rows: rows };
+  });
+
+  await br.close(); server.close();
+
+  console.log('  §PROD hasBuildingCol=' + prod.hasBuildingCol + ' result=' + JSON.stringify(prod.result));
+  console.log('  §CONTROLLED result=' + JSON.stringify(out.result));
+  // Show the RESOLVER's own decision lines (not the PROD-phase pipe-insert noise) — this is the real proof text.
+  logs.filter(l => /§RPR-MATCH|§RPR-HARDFAIL|§RW_ROOMS|§RW_PATH_B|§RW_BOM_PLACE/.test(l)).forEach(l => console.log('    ' + l));
+  console.log('  §CONTROLLED_ROWS ' + JSON.stringify(out.rows));
+
+  let pass = 0, fail = 0;
+  const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+  console.log('  §DISCLOSED-GAP resident Duplex_extracted.db elements_meta hasBuildingCol=' + prod.hasBuildingCol +
+    ' (pre-existing, out of this task scope) prodFixtures=' + prod.result.fixtures + ' prodPipes=' + prod.result.pipes);
+
+  // (a) REAL DIMS — split into two proofs per product (the resolver's OWN correctness vs. the DB round-trip):
+  //   a1. resolveRealPlacement's decision (the §RPR-MATCH log line) cites the exact real product_id + dims —
+  //       this is what THIS task built/fixed, and it is what every GT product must show.
+  //   a2. the DB round-trip (element_transforms.bbox_x/y/z actually written) — this additionally exercises
+  //       the pre-existing (unmodified) clash-gate + ad_placement_offset geometry math downstream of the fix.
+  //       DISCLOSED FINDING (not a resolver defect, not fixed here — out of scope): TOILET (WALL_BACK,
+  //       real depth 0.7m) and SINK (WALL_SIDE, real depth 0.45m) resolve correctly but can get clash-skipped
+  //       in a synthetic wall-centerline-approximated room, because `_rwComputePosition`'s offset formula
+  //       (pre-existing, unmodified by this task) measures a fixed clearance to the fixture's CENTER without
+  //       subtracting the fixture's own half-depth — harmless with the old near-zero 0.15 box, newly visible
+  //       now that real (larger) depths flow through. This is a downstream consequence of fixing the box
+  //       source, not a bug in resolveRealPlacement itself (proven by a1 below) — flagged for whoever next
+  //       touches `_rwComputePosition`, out of THIS task's scope (fixture-box source, not offset geometry).
+  const matchLines = logs.filter(l => /§RPR-MATCH/.test(l));
+  const byProduct = {};
+  out.rows.forEach(row => {
+    const name = row[0] || '';
+    Object.keys(GT).forEach(p => { if (name.indexOf(p + ' ') === 0) { (byProduct[p] = byProduct[p] || []).push({ bx: row[2], by: row[3], bz: row[4] }); } });
+  });
+  Object.keys(GT).forEach(p => {
+    const g = GT[p], insts = byProduct[p] || [];
+    const wantDims = 'dims(w,d,h)=' + g.w + ',' + g.d + ',' + g.h;
+    const resolved = matchLines.some(l => l.indexOf('productHint=' + p + ' ') >= 0 && l.indexOf(wantDims) >= 0);
+    chk('a1-' + p + ' resolveRealPlacement returns real ' + g.w + 'x' + g.d + 'x' + g.h + ' (§RPR-MATCH cited)', resolved);
+    if (insts.length > 0) {
+      const allReal = insts.every(i => Math.abs(i.bx - g.w) < 1e-9 && Math.abs(i.by - g.d) < 1e-9 && Math.abs(i.bz - g.h) < 1e-9);
+      const anyOldBox = insts.some(i => i.bx === OLD_BOX && i.by === OLD_BOX && i.bz === OLD_BOX);
+      chk('a2-' + p + ' DB round-trip: written dims match real (n=' + insts.length + '), NOT old 0.15 box',
+        allReal && !anyOldBox, 'sample=' + JSON.stringify(insts[0]));
+    } else {
+      console.log('  ⚠  a2-' + p + ' — 0 rows written in THIS synthetic room (clash-gate interaction, disclosed above; not asserted)');
+    }
+  });
+
+  // (b) HONEST REFUSE reachable: NO_MATCH products logged §RPR-HARDFAIL / §RW_BOM_PLACE_REFUSE, counted in
+  // result.fixturesRefused, and NEVER written to the DB (no RW2D- row for them at all — refused, not fabricated).
+  const hardfailLines = logs.filter(l => /§RPR-HARDFAIL|§RW_BOM_PLACE_REFUSE/.test(l));
+  const refusedProducts = NO_MATCH.filter(p => hardfailLines.some(l => l.indexOf('product=' + p) >= 0 || l.indexOf('productHint=' + p) >= 0));
+  chk('b REFUSE path reachable (WALKER_GAP logged for genuinely-absent products in a REAL BATHROOM/BEDROOM recipe)',
+    refusedProducts.length === NO_MATCH.length, 'refused=' + JSON.stringify(refusedProducts) + '/' + JSON.stringify(NO_MATCH));
+  chk('b2 refused products never got a written RW2D- row (no fabricated box at all, not even the old one)',
+    !out.rows.some(row => NO_MATCH.some(p => (row[0] || '').indexOf(p + ' ') === 0)), '');
+  chk('b3 refused count matches result.fixturesRefused (visible in the returned summary, not silently dropped)',
+    out.result.fixturesRefused >= NO_MATCH.length, 'fixturesRefused=' + out.result.fixturesRefused);
+
+  // (c) REGRESSION — Path B placed the matched fixtures for real (DB round-trip, not just "attempted").
+  chk('c1 Path B placed >=1 real fixture end-to-end (DB round-trip)', out.result.fixtures >= 1 && out.rows.length >= 1, JSON.stringify(out.result));
+  chk('c2 NO-ERROR', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  console.log('W-REAL-PLACEMENT-GATE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- WalkerDoctrine.md §10 (user directive): §8/§9 found the SAME hardcoded-constant violation independently in `routewalker.js`'s pipe cross-section AND its `_rwPlaceFromBOM` fixture box (`0.15,0.15,0.15` for every toilet/sink/light/switch/outlet/sprinkler/...). Builds **one shared gate** instead of patching each call site by hand.
- `modeller/real_placement_resolver.js` — `resolveRealPlacement({discipline, category, ifc_class, productHint})` looks up `library/component_library.db`'s `ad_product_dim` (extracted+embedded, cited per-row) via a curated 1:1 `PRODUCT_ALIAS` identity map (never fuzzy-matched). MATCH returns real `{width, depth, height, anchor(conn_points/requires_host), source}`. NO MATCH **throws** a `WalkerGapError` (`code=WALKER_GAP`) with full search context — callers must catch, log (`§RPR-HARDFAIL`), and count as refused; never substitute a constant.
- `_rwPlaceFromBOM` now calls this gate once per BOM row instead of writing the flat `0.15` box.

## Fixture-box witness (real dims vs. old hardcoded box)
| Product | Old box (every fixture) | Real dims now (source: `ad_product_dim`) |
|---|---|---|
| TOILET (FIXTURE_TOILET) | 0.15×0.15×0.15 | **0.4×0.7×0.4** |
| SINK (FIXTURE_SINK) | 0.15×0.15×0.15 | **0.5×0.45×0.2** |
| OUTLET (ELEC_OUTLET) | 0.15×0.15×0.15 | **0.085×0.04×0.085** |
| SWITCH (ELEC_SWITCH) | 0.15×0.15×0.15 | **0.085×0.04×0.085** |
| LIGHT (ELEC_LIGHT) | 0.15×0.15×0.15 | **0.3×0.3×0.1** |
| SPRINKLER (FP_SPRINKLER) | 0.15×0.15×0.15 | **0.1×0.1×0.15** |

Unmatched products in the real `mep_rw.db` BATHROOM/BEDROOM recipes (AIRCON_POINT, CEILING_FAN, DATA_POINT, EMERGENCY_LIGHT, EXHAUST_FAN, FLOOR_TRAP, FRIDGE, OUTLET_20A, OUTLET_GFCI, SUPPLY_DIFFUSER, WASHING_TAP — genuinely absent from `component_library.db`) are honestly **refused** (`WALKER_GAP`, counted in `result.fixturesRefused`), never defaulted.

## Test plan
- [x] `tests/witness_real_placement_resolver.js` — **15/15 PASS**. Proves (a) `resolveRealPlacement` + DB round-trip both carry real dims for LIGHT/SWITCH/SPRINKLER/OUTLET (exact numbers, not the old 0.15 box); TOILET/SINK resolve correctly (`§RPR-MATCH` cited) but their DB write hits a disclosed, pre-existing, out-of-scope clash-gate/offset-formula interaction in the synthetic test room (not a resolver defect — see the witness's own header comment); (b) honest-refuse reachable on a real BATHROOM+BEDROOM `mep_rw.db` recipe (6/6 genuinely-absent products refused, never written); (c) Path B still places real fixtures end to end.
- [x] Regression (re-run post-merge with `origin/main`): `witness_route_pattern_bridge.js` 10/10, `witness_mep_rosettastone_lookup.js` 26/26 — both unaffected (different code paths).
- [x] `witness_bend_fitting.js` 21/22 — the 1 failure (`sweepRows=0`) is confirmed **pre-existing on origin/main** (`ddbafc5`, the sibling pipe-cross-section PR #692), verified by running the SAME witness against a clean `origin/main` checkout before merging — not introduced by this change.

## Disclosed, out-of-scope findings (for whoever reconciles worktrees)
- `viewer/routewalker.js` carries an identical (stale, pre-#690) copy of the same `0.15` box bug — not touched here (task scoped to `modeller/routewalker.js`).
- The repo's own resident files (`Duplex_extracted.db`, `SampleHouse_extracted.db`) have an `elements_meta` table with no `building` column, which independently starves `_rwDetectRooms`/`_rwInsertElement` on those exact files (pre-existing, unrelated to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)