### PR TITLE
fix(modeller): oplog.clear() purges IDB fallback; stop re-attempting doomed localStorage.setItem

### DIFF
--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -120,6 +120,27 @@
         } catch (e) { resolve(false); }
       });
     },
+    // §AUTOSAVE_FIX companion — clear()'s IndexedDB counterpart to localStorage.removeItem (Witness:
+    // W-E2E-OPLOG-CLEAR-IDB). Same defensive shape as _idbGet/_idbPut above: try/catch around indexedDB.open,
+    // every error path resolve(false), never throw. A missing store means nothing to delete → resolve(false).
+    _idbDelete(key) {
+      return new Promise((resolve) => {
+        try {
+          const rq = indexedDB.open('bim_ootb_cache');
+          rq.onsuccess = () => {
+            const idb = rq.result;
+            if (!idb.objectStoreNames.contains('oplog_fallback')) { resolve(false); return; }
+            try {
+              const tx = idb.transaction('oplog_fallback', 'readwrite');
+              tx.objectStore('oplog_fallback').delete(key);
+              tx.oncomplete = () => resolve(true);
+              tx.onerror = () => resolve(false);
+            } catch (e) { resolve(false); }
+          };
+          rq.onerror = () => resolve(false);
+        } catch (e) { resolve(false); }
+      });
+    },
     // Restore precedence: localStorage first (the common case, zero async cost); if empty, check the IDB
     // fallback (a prior save that overflowed localStorage). If BOTH exist (localStorage held an older,
     // pre-overflow save; IDB holds a later fallback save, or vice versa on a since-cleared localStorage),
@@ -243,7 +264,13 @@
     // clearing it in _foldUpto() alone (the originally drafted fix) would MISS the LEAF-commit path (bonsai_
     // oplog.js commit(): LEAF ops skip _foldUpto and append optimistically, but still _emit()).
     _emit() { this._opsCache = null; try { window.dispatchEvent(new CustomEvent('bonsai:oplog')); } catch (e) { } this._save(); },
-    clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; try { localStorage.removeItem(this._KEY); } catch (e) { } if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache(); this._emit(); },
+    // clear() empties BOTH persisted copies of this._KEY — localStorage AND the §AUTOSAVE_FIX IndexedDB fallback
+    // (the _loadBytesEither precedence comment above PROMISES "clear() ... empties both keys together"; before this
+    // fix only localStorage was removed, so a Terminal-scale model whose autosave had overflowed into IDB silently
+    // RESURRECTED from the stale IDB entry on the next open of the same key). The IDB purge is fire-and-forget —
+    // same style as _save()'s _idbPut — because no clear() call site awaits it; the synchronous localStorage
+    // removal + in-memory reset semantics stay exactly as before. Witness: W-E2E-OPLOG-CLEAR-IDB.
+    clear() { if (this.db) { try { this.db.close(); } catch (e) { } } this.db = null; this._n = 0; this._cursor = 0; try { localStorage.removeItem(this._KEY); } catch (e) { } this._idbDelete(this._KEY); if (window.Bonsai && window.Bonsai.clearKernelCache) window.Bonsai.clearKernelCache(); this._emit(); },
 
     // Read the live GEOM ops out of the signed log, mapped to fold-op shape (parent rides in parameters).
     // §OUTLINER-STALL: memoized on db-object identity (auto-invalidates on setModelKey/reload/clear, which all

--- a/modeller/bonsai_oplog.js
+++ b/modeller/bonsai_oplog.js
@@ -162,26 +162,40 @@
     // correct in-session but silently did NOT survive a reload. Now: fall back to the IndexedDB store above so
     // the edit actually persists, and surface a one-time visible toast (reusing modeller.html's existing
     // window.toast() mechanism — no new UI-notice code) so a silent-forever failure never recurs either.
+    // §AUTOSAVE_FIX STICKY (SCALE_CHECK_TERMINAL_FINDINGS_2026-07-05.md Finding 4 — UPDATE 2026-07-07, Witness:
+    // W-E2E-OPLOG-CLEAR-IDB K7-K9): once ONE save has overflowed localStorage, every later save this session is
+    // doomed too (the op-log only grows — kernel_ops is append-only) — yet _save() re-attempted the synchronous
+    // setItem on EVERY _emit(), throwing+catching a real QuotaExceededError per edit for the rest of the session
+    // (the repeated "§OPLOG autosave FAILED ... QuotaExceededError" spam a real user saw twice in one session).
+    // _useIdbOnly remembers the first failure and skips straight to the IDB fallback path from then on. The
+    // fallback write + one-time toast logic itself is UNCHANGED — factored into _saveIdbFallback() so the catch
+    // path and the sticky skip-path share it (no duplicated toast/_idbFallbackNotified logic).
+    _useIdbOnly: false,
+    _saveIdbFallback(bytes) {
+      this._idbPut(this._KEY, bytes).then((ok) => {
+        if (ok) {
+          console.log(TAG + ' §AUTOSAVE_FIX path=idb_fallback bytes=' + bytes.length + ' key=' + this._KEY);
+          if (!this._idbFallbackNotified && window.toast) {
+            this._idbFallbackNotified = true;
+            window.toast('This model is too large for quick-save storage — now autosaving via a larger backup store (your edits are safe).', 'info');
+          }
+        } else {
+          console.error(TAG + ' §AUTOSAVE_FIX path=idb_fallback FAILED bytes=' + bytes.length + ' key=' + this._KEY + ' — this edit may NOT survive a reload');
+          if (window.toast) window.toast('⚠ Autosave failed — this edit may not survive a reload. Use Export ▸ Native .db to be safe.', 'error');
+        }
+      });
+    },
     _save() {
       if (!this.db) return;
       let bytes;
       try { bytes = this.db.export(); } catch (e) { console.error(TAG + ' autosave FAILED — could not export db ' + e); return; }
+      if (this._useIdbOnly) { this._saveIdbFallback(bytes); return; }   // sticky: don't re-run the doomed setItem
       try {
         localStorage.setItem(this._KEY, this._b64(bytes));
       } catch (e) {
         console.error(TAG + ' autosave FAILED to localStorage (edits stay in-session; falling back to IndexedDB) ' + e);
-        this._idbPut(this._KEY, bytes).then((ok) => {
-          if (ok) {
-            console.log(TAG + ' §AUTOSAVE_FIX path=idb_fallback bytes=' + bytes.length + ' key=' + this._KEY);
-            if (!this._idbFallbackNotified && window.toast) {
-              this._idbFallbackNotified = true;
-              window.toast('This model is too large for quick-save storage — now autosaving via a larger backup store (your edits are safe).', 'info');
-            }
-          } else {
-            console.error(TAG + ' §AUTOSAVE_FIX path=idb_fallback FAILED bytes=' + bytes.length + ' key=' + this._KEY + ' — this edit may NOT survive a reload');
-            if (window.toast) window.toast('⚠ Autosave failed — this edit may not survive a reload. Use Export ▸ Native .db to be safe.', 'error');
-          }
-        });
+        this._useIdbOnly = true;                                        // remember: this session's saves go to IDB now
+        this._saveIdbFallback(bytes);
       }
     },
 

--- a/modeller/tests/witness_e2e_oplog_clear_idb.js
+++ b/modeller/tests/witness_e2e_oplog_clear_idb.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-OPLOG-CLEAR-IDB scope (read the log after every run)
+ * SCOPE: bonsai_oplog.js clear() vs the §AUTOSAVE_FIX IndexedDB fallback store
+ * (SCALE_CHECK_TERMINAL_FINDINGS_2026-07-05.md Finding 4 introduced the fallback; this witness covers its
+ * missing DELETE leg). clear() removed ONLY localStorage[this._KEY] — it never purged the 'oplog_fallback'
+ * entry in the 'bim_ootb_cache' IndexedDB database, even though _loadBytesEither()'s precedence comment
+ * promises "only clear() shrinks it, which empties both keys together".
+ *
+ * ISSUE THIS PROVES/DISPROVES: "clearing a model whose autosave overflowed into the IDB fallback silently
+ * resurrects the cleared edits on the next open of the same key" — was TRUE (localStorage empty → restore
+ * precedence ALWAYS trusts a found IDB entry, hit by a real Terminal-scale user), now FALSE (clear() also
+ * fires _idbDelete(this._KEY); the entry is measurably gone from IndexedDB after clear()).
+ *
+ * Real browser, real IndexedDB, real op-log commit for the bytes. The one engineered step: the prior
+ * overflow save is simulated by calling the REAL O._idbPut(key, realExportedBytes) directly (the exact
+ * write _save()'s quota-failure branch performs — see witness_e2e_autosave_idb_fallback.js, which already
+ * proves that branch end-to-end) instead of building an actual multi-MB Terminal log just to overflow the
+ * quota. The delete claim is then asserted by querying IndexedDB RAW (indexedDB.open → store.get), NOT via
+ * the module's own _idbGet — an independent oracle, not the code under test grading itself.
+ *
+ * CLAIMS:
+ *   K1 SETUP     — a real signed op committed; localStorage holds the key (the normal-path save happened).
+ *   K2 PRECOND   — the IDB fallback entry EXISTS before clear() (raw query; real exported db bytes) — the
+ *                  exact stale-copy state the bug resurrects from. A second key (mo_OtherBuilding) is also
+ *                  planted to prove K6.
+ *   K3 CLEAR     — window.Bonsai.oplog.clear() runs (the same call bClear.onclick and 20+ other sites make).
+ *   K4 LS-REGR   — localStorage.getItem(key) is null after clear() (the pre-existing behaviour, unbroken).
+ *   K5 IDB-GONE  — raw IndexedDB get(key) → undefined after clear() (THE fixed claim, asserted directly).
+ *   K6 SCOPED    — mo_OtherBuilding's entry SURVIVES (clear() deletes its own key, not the whole store —
+ *                  another building's overflow save must never be collateral damage).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+runE2E('W-E2E-OPLOG-CLEAR-IDB', async (t) => {
+  // K1 — one real signed op on the scratch model; _emit()→_save() persists it to localStorage.
+  const setup = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 1, h: 1 }, dir: [0, 0, 2.5] } });
+    return { len: O.length, key: O._KEY, lsHasKey: !!localStorage.getItem(O._KEY) };
+  });
+  t.assert('K1 SETUP a real signed op committed and autosaved to localStorage', setup.len > 0 && setup.lsHasKey, JSON.stringify(setup));
+
+  // Independent oracle: RAW IndexedDB read (not O._idbGet — the module must not grade itself).
+  await t.pg.evaluate(() => {
+    window.__rawIdbGet = (key) => new Promise((resolve) => {
+      const rq = indexedDB.open('bim_ootb_cache');
+      rq.onsuccess = () => {
+        const idb = rq.result;
+        if (!idb.objectStoreNames.contains('oplog_fallback')) { resolve({ storeExists: false, present: false, len: 0 }); return; }
+        const g = idb.transaction('oplog_fallback', 'readonly').objectStore('oplog_fallback').get(key);
+        g.onsuccess = () => resolve({ storeExists: true, present: g.result !== undefined, len: g.result ? g.result.length : 0 });
+        g.onerror = () => resolve({ storeExists: true, present: false, err: true });
+      };
+      rq.onerror = () => resolve({ err: true, present: false });
+    });
+  });
+
+  // K2 — simulate the prior overflow save with the REAL _idbPut and the REAL exported db bytes; plant a
+  // second building's entry too (K6's scoped-delete proof).
+  const pre = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    const bytes = O.db.export();                       // real signed op-log bytes, not invented payload
+    await O._idbPut(O._KEY, bytes);                    // the exact write _save()'s quota-failure branch makes
+    await O._idbPut('mo_OtherBuilding', bytes);        // another building's fallback save (must survive clear)
+    return { own: await window.__rawIdbGet(O._KEY), other: await window.__rawIdbGet('mo_OtherBuilding') };
+  });
+  t.assert('K2 PRECOND IDB fallback entry exists BEFORE clear() (raw query — the stale copy the bug resurrects from)',
+    pre.own.present && pre.own.len > 0 && pre.other.present, JSON.stringify(pre));
+
+  // K3 — the real clear() call (same call the #b-clear button and every "open different resident" flow makes),
+  // then wait for the fire-and-forget _idbDelete to complete (same 400ms settle the autosave witness uses).
+  const cleared = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    const key = O._KEY;
+    O.clear();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return { key, len: O.length, ls: localStorage.getItem(key), own: await window.__rawIdbGet(key), other: await window.__rawIdbGet('mo_OtherBuilding') };
+  });
+  t.assert('K3 CLEAR ran and reset the in-memory log', cleared.len === 0, 'len=' + cleared.len);
+  t.assert('K4 LS-REGR localStorage key removed by clear() (pre-existing behaviour intact)', cleared.ls === null, 'ls=' + JSON.stringify(cleared.ls));
+  t.assert('K5 IDB-GONE raw IndexedDB get(key) is undefined after clear() — the fallback entry is PURGED, nothing left to resurrect',
+    cleared.own.storeExists === true && cleared.own.present === false, JSON.stringify(cleared.own));
+  t.assert('K6 SCOPED another building\'s fallback entry (mo_OtherBuilding) survives — clear() deletes its own key only',
+    cleared.other.present === true && cleared.other.len > 0, JSON.stringify(cleared.other));
+  console.log('  §OPLOG_CLEAR_IDB_WITNESS key=' + cleared.key + ' ls=' + JSON.stringify(cleared.ls) + ' idbPresent=' + cleared.own.present + ' otherPresent=' + cleared.other.present);
+}, { width: 900, height: 700, dpr: 1 });

--- a/modeller/tests/witness_e2e_oplog_clear_idb.js
+++ b/modeller/tests/witness_e2e_oplog_clear_idb.js
@@ -7,10 +7,17 @@
  * entry in the 'bim_ootb_cache' IndexedDB database, even though _loadBytesEither()'s precedence comment
  * promises "only clear() shrinks it, which empties both keys together".
  *
- * ISSUE THIS PROVES/DISPROVES: "clearing a model whose autosave overflowed into the IDB fallback silently
- * resurrects the cleared edits on the next open of the same key" — was TRUE (localStorage empty → restore
- * precedence ALWAYS trusts a found IDB entry, hit by a real Terminal-scale user), now FALSE (clear() also
- * fires _idbDelete(this._KEY); the entry is measurably gone from IndexedDB after clear()).
+ * ISSUE THIS PROVES/DISPROVES (leg 1, K1-K6): "clearing a model whose autosave overflowed into the IDB
+ * fallback silently resurrects the cleared edits on the next open of the same key" — was TRUE (localStorage
+ * empty → restore precedence ALWAYS trusts a found IDB entry, hit by a real Terminal-scale user), now FALSE
+ * (clear() also fires _idbDelete(this._KEY); the entry is measurably gone from IndexedDB after clear()).
+ *
+ * ISSUE THIS PROVES/DISPROVES (leg 2, K7-K9 — Finding 4 UPDATE 2026-07-07, sticky fallback): "_save()
+ * re-attempts the doomed synchronous localStorage.setItem on EVERY save after one quota overflow, throwing+
+ * catching a real QuotaExceededError per edit for the rest of the session (the repeated console-error spam a
+ * real user saw twice in one session)" — was TRUE (no memory of the prior failure), now FALSE (_useIdbOnly
+ * flips on the first failure; the second _save() measurably never calls localStorage.setItem again — counted
+ * by a spy wrapper — and goes straight to the same _idbPut fallback path).
  *
  * Real browser, real IndexedDB, real op-log commit for the bytes. The one engineered step: the prior
  * overflow save is simulated by calling the REAL O._idbPut(key, realExportedBytes) directly (the exact
@@ -29,6 +36,12 @@
  *   K5 IDB-GONE  — raw IndexedDB get(key) → undefined after clear() (THE fixed claim, asserted directly).
  *   K6 SCOPED    — mo_OtherBuilding's entry SURVIVES (clear() deletes its own key, not the whole store —
  *                  another building's overflow save must never be collateral damage).
+ *   K7 STICKY-1  — the FIRST quota-failed _save() attempts localStorage.setItem exactly once (spy count)
+ *                  and flips _useIdbOnly to true.
+ *   K8 STICKY-2  — a SECOND _save() in the same session NEVER touches localStorage.setItem again (spy count
+ *                  unchanged) and _useIdbOnly stays true — the doomed re-attempt spam is gone.
+ *   K9 STICKY-IDB— the sticky-path save still genuinely lands in IndexedDB (raw query, real bytes) — the
+ *                  skip is a shortcut TO the fallback, not a silently-dropped save.
  */
 'use strict';
 const { runE2E } = require('./e2e_harness');
@@ -85,4 +98,35 @@ runE2E('W-E2E-OPLOG-CLEAR-IDB', async (t) => {
   t.assert('K6 SCOPED another building\'s fallback entry (mo_OtherBuilding) survives — clear() deletes its own key only',
     cleared.other.present === true && cleared.other.len > 0, JSON.stringify(cleared.other));
   console.log('  §OPLOG_CLEAR_IDB_WITNESS key=' + cleared.key + ' ls=' + JSON.stringify(cleared.ls) + ' idbPresent=' + cleared.own.present + ' otherPresent=' + cleared.other.present);
+
+  // ── Leg 2: sticky IDB-only autosave (Finding 4 UPDATE 2026-07-07) ────────────────────────────────────────
+  // K7-K9 — commit a fresh real op (clear() above left the log empty; commit re-creates the db), then force
+  // ONE quota failure via a COUNTING setItem spy (the same simulated-QuotaExceededError idiom
+  // witness_e2e_autosave_idb_fallback.js already uses) and prove the second _save() never re-attempts setItem.
+  const sticky = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    await O.commit({ op_type: 'GEOM_EXTRUDE', parameters: { profile: { w: 2, h: 1 }, dir: [0, 0, 1.5] } });
+    const flagBefore = O._useIdbOnly;
+    const origSet = localStorage.setItem.bind(localStorage);
+    let setItemCalls = 0;
+    localStorage.setItem = () => { setItemCalls++; throw new DOMException('simulated quota exceeded', 'QuotaExceededError'); };
+    let callsAfterFirst, flagAfterFirst, callsAfterSecond, flagAfterSecond;
+    try {
+      O._save();                                              // 1st save: attempts setItem → fails → flips sticky
+      callsAfterFirst = setItemCalls; flagAfterFirst = O._useIdbOnly;
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      O._save();                                              // 2nd save: must SKIP setItem entirely
+      callsAfterSecond = setItemCalls; flagAfterSecond = O._useIdbOnly;
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    } finally { localStorage.setItem = origSet; }
+    const idb = await window.__rawIdbGet(O._KEY);
+    return { flagBefore, callsAfterFirst, flagAfterFirst, callsAfterSecond, flagAfterSecond, idb };
+  });
+  t.assert('K7 STICKY-1 first quota failure attempted setItem exactly once and flipped _useIdbOnly false→true',
+    sticky.flagBefore === false && sticky.callsAfterFirst === 1 && sticky.flagAfterFirst === true, JSON.stringify(sticky));
+  t.assert('K8 STICKY-2 second _save() NEVER called localStorage.setItem again (spy count unchanged) — no repeated doomed attempt',
+    sticky.callsAfterSecond === 1 && sticky.flagAfterSecond === true, 'calls=' + sticky.callsAfterFirst + '→' + sticky.callsAfterSecond);
+  t.assert('K9 STICKY-IDB the sticky-path save genuinely landed in IndexedDB (raw query) — skipped setItem is a shortcut TO the fallback, not a dropped save',
+    sticky.idb.present === true && sticky.idb.len > 0, JSON.stringify(sticky.idb));
+  console.log('  §OPLOG_STICKY_WITNESS setItemCalls first=' + sticky.callsAfterFirst + ' second=' + sticky.callsAfterSecond + ' useIdbOnly=' + sticky.flagAfterSecond + ' idbLen=' + sticky.idb.len);
 }, { width: 900, height: 700, dpr: 1 });


### PR DESCRIPTION
## Summary
Two related bugs in `bonsai_oplog.js`'s persistence layer, found while investigating a real user's Terminal-scale (35k+ element) session — both documented and scoped in `bim-compiler` repo's `prompts/SCALE_CHECK_TERMINAL_FINDINGS_2026-07-05.md` Finding 4 and its 2026-07-07 update.

### Fix 1 — `clear()` didn't purge the `§AUTOSAVE_FIX` IndexedDB fallback entry
`clear()` only ever called `localStorage.removeItem(this._KEY)`. When a Terminal-scale session's autosave overflows into the IndexedDB fallback (real, working, documented mechanism — not touched here), `clear()` left that IDB entry behind. A later session reopening a building under the same key would find no localStorage entry but a stale IDB one, and `_loadBytesEither()` always trusts a found IDB entry when localStorage is empty — silently resurrecting edits the user explicitly cleared. Reachable from 20+ call sites (Clear button, every "open a different resident" flow, several tests).

Fix: new `_idbDelete(key)` (mirrors `_idbGet`/`_idbPut`'s exact defensive shape), fired fire-and-forget from `clear()` right after the `localStorage.removeItem` — `clear()` stays fully synchronous, zero call-site changes needed.

### Fix 2 — `_save()` re-attempted the doomed `localStorage.setItem` on every commit
Once localStorage's quota is exceeded once in a Terminal-scale session, EVERY subsequent commit still tried `localStorage.setItem` first, threw the same `QuotaExceededError`, and fell back — repeating a guaranteed-failing synchronous attempt on every single edit for the rest of the session (the source of repeated `§OPLOG autosave FAILED` console spam a real user saw twice in one session). Data safety was never at risk (the IDB fallback + one-time toast already worked correctly) — purely a repeated-doomed-attempt efficiency/noise issue.

Fix: sticky `_useIdbOnly` flag, set `true` on first quota failure, checked at the top of `_save()` to skip straight to the IDB path thereafter. The IDB-put + one-time-toast logic was factored into a shared `_saveIdbFallback(bytes)` used by both the catch path and the sticky early-return — no duplicated toast logic.

## Changes
- `modeller/bonsai_oplog.js` only

## Test plan
- [x] New witness `witness_e2e_oplog_clear_idb.js` — 10/10 PASS via real headless Puppeteer + real IndexedDB (K5 asserted via a RAW `indexedDB.open→store.get` oracle, not the module's own accessor, to genuinely prove the entry is gone). Confirmed to FAIL pre-fix on both bugs independently (K5 6/7 against unfixed `clear()`; K8 8/10 against pre-sticky `_save()`) before passing 10/10 post-fix. K6 proves `clear()` is scoped to its own key only (`mo_OtherBuilding` survives). K7/K8/K9 prove the sticky path: first failure attempts `setItem` once and flips the flag, second `_save()` never calls `setItem` again, and the sticky-path save genuinely lands in IndexedDB.
- [x] Regression sweep: `witness_e2e_autosave_idb_fallback.js` 8/8 · `witness_e2e_export_db.js` (exercises `oplog.clear()` mid-flow) 6/6 · `bonsai_tier1_live.js` (heavy `clear()`+commit user) PASS. One pre-existing unrelated breakage noted, not caused by this change: `bonsai_persist_live.js` hardcodes a `/tmp/wt-bonsai/viewer` path that no longer exists since the #550 trilogy-folder refactor — its coverage is superseded by the autosave witness's passing restore assertions, left untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)