### PR TITLE
fix(modeller): de-duplicate Ctrl+Z/Ctrl+Y (one keypress fired two undos)

### DIFF
--- a/common/history_bar.js
+++ b/common/history_bar.js
@@ -113,7 +113,11 @@ window.HistoryBar = (function () {
       _depth = _migrateDepth(_storedDepth) || _migrateDepth(_cfg.defaultDepth()) || 'high';
     }
     catch (e) { _depth = _migrateDepth(_cfg.defaultDepth()) || 'high'; }
-    if (!_configured) { _wireKeyboard(); _wireCrossTab(); _configured = true; }
+    // skipKeyboard: an app that already owns Ctrl+Z/Ctrl+Y itself (with its own undo/redo UI wrap-up —
+    // audio cue, status text, selection sync) opts out of this module's OWN document-level keyboard
+    // wiring, so one keypress doesn't fire the underlying undo/redo twice. Default false — every other
+    // app keeps wiring keyboard here exactly as before.
+    if (!_configured) { if (!_cfg.skipKeyboard) _wireKeyboard(); _wireCrossTab(); _configured = true; }
     _syncTapKnob();                     // ONE KNOB: push the loaded depth onto the §-tap at startup
     if (_cfg.treeKey) _persistLoad();   // restore persisted universes for this building (item 4)
     console.log('§HIST_CONFIGURE source=' + _cfg.source + ' depth=' + _depth + ' host=' + (_cfg.mountHostId || 'body') + ' treeKey=' + (_cfg.treeKey || '-'));

--- a/modeller/modeller_history.js
+++ b/modeller/modeller_history.js
@@ -86,6 +86,11 @@
     profiles: PROFILES,
     depthKey: 'bim.hist.depth.modeller',   // own namespace — never inherits a stale Viewer/iDempiere stop
     ignorePersistedDepth: true,            // Modeller has no breadth-knob UI — always boot at defaultDepth()
+    // modeller.html's OWN window-level Ctrl+Z/Ctrl+Y (doUndo/doRedo) already owns undo/redo here, with its
+    // own UI wrap-up (audio cue, status text, selection clear, syncHistory). Without this, both that
+    // listener AND history_bar's document-level one fired on the SAME keypress → one Ctrl+Z silently ran
+    // TWO undos (found by witness_e2e_dm_gridundo.js U6, 2026-07-08).
+    skipKeyboard: true,
     defaultDepth: function () { return 'high'; },
     restore: _restore,
     sharedKey: 'bim.docHistory',


### PR DESCRIPTION
Since PR #675, `modeller_history.js`'s `HB.configure()` armed `common/history_bar.js`'s own document-level Ctrl+Z/Ctrl+Y listener on top of `modeller.html`'s pre-existing window-level one (`doUndo`/`doRedo`) — both called the same underlying undo, so one real Ctrl+Z silently destroyed two ops instead of one.

Fix: `history_bar.js` gains a `skipKeyboard` config flag (default `false`, every other app unaffected); `modeller_history.js` sets it, since `modeller.html`'s own listener already owns Ctrl+Z/Ctrl+Y with its correct UI wrap-up (audio cue, status text, `syncHistory`).

`witness_e2e_dm_gridundo.js`'s U6 (pinned KNOWN-RED 2026-07-08 by PR #706's direct-manip witness batch) now passes: 8/8, `undosFired=1`.

Note: `viewer/grid_drag.js` has the same dual-listener shape — not fixed here, flagged for its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)