### PR TITLE
feat(modeller): onboard Ifc4_Revit as a new ARC-only resident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !modeller/Terminal_geo.db
 !modeller/terminal_rules.db
 !modeller/mep_rw.db
+!modeller/Ifc4_Revit_extracted.db
 *.bin
 node_modules/
 test-results/

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -39,7 +39,8 @@
     { key: 'SampleCastle', label: 'SampleCastle · column-framed',      db: 'SampleCastle_extracted.db', v: 2 },
     { key: 'SampleCastle-ARC', label: 'SampleCastle · ARC only (diagnostic)', db: 'SampleCastle_ARC_extracted.db', v: 1 },
     { key: 'Terminal',     label: 'Terminal · column-framed (oracle)', db: 'Terminal_meta.db',          v: 1,
-      geoDb: 'Terminal_geo.db', geoV: 1 }
+      geoDb: 'Terminal_geo.db', geoV: 1 },
+    { key: 'Ifc4_Revit',   label: 'Ifc4_Revit · all-discipline reference', db: 'Ifc4_Revit_extracted.db', v: 1 }
   ];
 
   // The modeller's own GH-Pages playground base — modeller.html and its resident DBs now share the

--- a/modeller/tests/smoke_ifc4revit.js
+++ b/modeller/tests/smoke_ifc4revit.js
@@ -1,0 +1,8 @@
+const { runE2E } = require('./e2e_harness');
+runE2E('W-ARC-ONLY-SMOKE-Ifc4Revit', async (t) => {
+  await t.open('Ifc4_Revit');
+  const meshCount = await t.pg.evaluate(() => window.Bonsai.group().children.filter(o => o.isMesh).length);
+  t.assert('Ifc4_Revit opens with real meshes rendered', meshCount > 0, 'meshCount=' + meshCount);
+  console.log('§SMOKE Ifc4_Revit meshCount=' + meshCount);
+  await t.shot('smoke-Ifc4Revit');
+});


### PR DESCRIPTION
## Summary
- §NEXT item 4, `prompts/Modeller/DISC_Walker/RESUME_MESH_DEDUP_AND_ONBOARDING.md` — onboards `Ifc4_Revit` (best size-to-richness ratio of the surveyed candidates: all 7 disciplines, 43.4MB, prioritized over `Hospital_3`).
- Stripped `elements_meta`/`element_instances`/`element_transforms` to `discipline='ARC'` only (same cascade as the existing 4 residents; this building's schema has no `rel_contained_in_space` table). `VACUUM`ed: 43,421,696 → 39,710,720 bytes.
- 1983 ARC elements, 1934 with a real geometry instance — 49 `IfcCurtainWall`/`IfcRoof`/`IfcStair` elements lack an instance row in the **source extraction itself** (confirmed pre-existing against the untouched original, not introduced by this strip).
- `component_geometries` (3724 rows) left untouched — single file, no `geoDb` split needed (well under the 100MB GH blob limit, and avoids the IDB-race regression found in the (reverted) mesh.db-consolidation attempt for item 3).

## Test plan
- [x] Real headless-browser smoke test `W-ARC-ONLY-SMOKE-Ifc4Revit`: `meshCount=1934`, 0 errors
- [x] No regression on existing residents (`SampleHouse` re-tested clean after the shared registry edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)