### PR TITLE
fix(modeller): thread hostBind's yaw into disc-walk render (Bug B)

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -3605,7 +3605,13 @@ function _renderDiscWalk(disc, placements) {
     function _mesh(sub, mat) {
       if (!sub.length) return;
       var im = new THREE.InstancedMesh(geo, mat, sub.length);
-      sub.forEach(function (p, i) { m.makeTranslation(p.x, p.y, p.z); im.setMatrixAt(i, m); });
+      // §ROTATION-BOUND Bug B: disc_walker already computes a real per-placement `yaw` (wall/run orientation —
+      // e.g. hostBind's SIDE/TOP/BOTTOM/CENTER branches, place()'s host-wall branch) but this renderer ignored it,
+      // always drawing an axis-aligned box (translation-only matrix). `_renderDiscAssembly` (below) already does
+      // this correctly via a quaternion; here `yaw` is a single Z-axis angle (0 or π/2 today), so a plain
+      // makeRotationZ + setPosition is the matching minimal fix. `p.yaw` is undefined for array/density placements
+      // (no host) → `|| 0` reproduces today's axis-aligned render exactly for every non-host-bound placement.
+      sub.forEach(function (p, i) { m.makeRotationZ(p.yaw || 0); m.setPosition(p.x, p.y, p.z); im.setMatrixAt(i, m); });
       im.instanceMatrix.needsUpdate = true; im.userData.dwDisc = disc;
       im.userData.dwSub = sub;   // §Q2 (W-E2E-INSTPICK): instanceId i ↔ sub[i] — array REFERENCE, no per-instance objects
       root.add(im);


### PR DESCRIPTION
## Summary
- `_renderDiscWalk`'s `_mesh()` never applied a placement's `yaw` to its InstancedMesh transform, always rendering an axis-aligned box even for host-bound fixtures that carry a real, computed orientation.
- Fixes it with the minimal correct change (`makeRotationZ(p.yaw||0)` + `setPosition`), mirroring the pattern already used correctly in the sibling `_renderDiscAssembly`.
- This is **Bug B only** from `prompts/Modeller/DISC_Walker/RESUME_DISC_WALKER_ENVELOPE_BOUND.md`'s `§ROTATION-BOUND` section (bim-compiler repo). Bug A (hostBind's SIDE-mount *position* — a separate, deeper root cause: `element_transforms.center_x/y` is a raw IFC placement origin, not a wall's true midpoint) is still open and intentionally NOT touched here — it needs a scope decision (re-extract vs. approximate) before any fix lands.

## Test plan
- [x] Verified in a real headless-Chrome render (puppeteer): drove a live ELEC/Duplex `hostBind` walk, read back the rendered `InstancedMesh` matrices via `getMatrixAt` + `decompose`, confirmed rotation (Z-Euler) and position both match the placement's `yaw`/`x`/`y`/`z` to float precision, across all 4 fixture classes present.
- [x] Placements with no `yaw` (array/density, no host) render identically to before (`p.yaw || 0` preserves the old translation-only behaviour).
- [x] Ran `modeller/tests/witness_dw_pixelprobe.js` — same 3 PASS/3 FAIL as an unmodified `origin/main` baseline (confirmed via a side-by-side worktree diff), so the pre-existing failures are unrelated to this change, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)