### PR TITLE
fix(modeller): grid-drag smart element scope + numeric sandbox proof

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -52,15 +52,72 @@
       return { commands: commands2, riders: riders2, excluded };
     },
 
+    // §GRIDSCOPE (prompts/GRID_SMART_ELEMENT_SCOPE.md, 2026-07-09 — decided direction, built here):
+    // TWO independent narrowings of grid governance, both applied here, neither touching the shared
+    // (Viewer-used) grid_kinematics.js engine itself:
+    //
+    // 1. CLASS ALLOWLIST — furniture/coverings/openings never participate in DIRECT grid attachment (a
+    //    couch sitting in a room doesn't drag when the room's wall stretches). Doors/windows are excluded
+    //    here too -- they ride via §STRETCH-RIDE (resolved off REAL rel_fills_host edges, sdg_cascade.js),
+    //    NOT by being independently classified against the grid -- excluding them from elementData() does
+    //    not affect their movement, only removes a redundant (and sometimes WRONG-tint) direct classification.
+    _STRUCTURAL_CLASSES: ['IfcWall', 'IfcWallStandardCase', 'IfcSlab', 'IfcFooting', 'IfcColumn', 'IfcBeam',
+      'IfcRailing', 'IfcStairFlight', 'IfcRoof'],
+    // fid -> ifc_class, read from the REAL committed GEOM_INSERT op parameters (arc_editable.js's
+    // buildSeedOps already writes params.ifc_class per seed op -- extracted, not invented). A synthetic/
+    // hand-authored wall (GEOM_EXTRUDE_POLY etc.) has no ifc_class recorded at all -- treated as UNKNOWN,
+    // kept eligible (unchanged behavior for the tool's actual primary use case: freshly-sketched content).
+    _buildClassByFid() {
+      const O = window.Bonsai.oplog; const out = {}; if (!O || !O.db) return out;
+      try {
+        const r = O.db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='GEOM_INSERT'");
+        if (r.length) r[0].values.forEach(v => { try { const p = JSON.parse(v[1]); if (p && p.ifc_class) out[v[0]] = p.ifc_class; } catch (e) { } });
+      } catch (e) { }
+      return out;
+    },
+    // 2. GRAB-LOCALITY — a gridline is otherwise infinite (grid_kinematics.js's _findBestGrid classifies
+    // purely by along-axis centerline distance, §ATTACH_TOL=0.5m, with NO awareness of position along the
+    // line's own length). Fine for a small authored scene; genuinely wrong for a real, dense building where
+    // dozens of walls at completely different rooms can all coincidentally sit within 0.5m of the SAME x or
+    // y coordinate (confirmed real: Duplex, one gridline drag, ~50 real elements swept into one commit).
+    // Scope candidates to elements near WHERE THE USER ACTUALLY GRABBED the line (the pointerdown hit's
+    // ORTHOGONAL coordinate — e.g. hit.y for an x-axis line) — matches how a user actually thinks about it
+    // ("I grabbed THIS stretch"), not a re-derivation of "architectural convenience" via face tolerance.
+    // Radius is DERIVED from the grid's own orthogonal-axis line spacing (one bay, +50% margin so an
+    // element right at a bay boundary still qualifies) — extracted from the real grid definition already
+    // present, not an invented constant. `draggedAxis` names the axis of the GRIPPED line ('x' or 'y') --
+    // the orthogonal-axis lines (whose spacing defines the bay) are the OTHER grid axis.
+    _localityRadius(draggedAxis) {
+      const G = window.Bonsai.grid; const lines = (draggedAxis === 'x' ? G.ys : G.xs) || [];
+      if (lines.length < 2) return Infinity;   // a single-line grid on the orthogonal axis has no "bay" to derive -- don't filter
+      const sorted = lines.slice().sort((a, b) => a - b);
+      let maxGap = 0;
+      for (let i = 1; i < sorted.length; i++) maxGap = Math.max(maxGap, sorted[i] - sorted[i - 1]);
+      return maxGap * 1.5;
+    },
+
     // The engine's elementData = each authored solid's centre + bbox extents (the geometry it must recompose).
     elementData() {
       const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return [];
-      return g.children.filter(o => o.isMesh && o.userData.featureId != null).map(m => {
+      const classByFid = this._buildClassByFid();
+      const allow = this._STRUCTURAL_CLASSES;
+      const draggedAxis = this._dragAxis, orthoAt = this._dragOrthoAt;   // set by beginDragSession(); null outside a session (unchanged/global behavior for direct computeCommands() callers, e.g. discovery-sweep tests)
+      const radius = draggedAxis != null ? this._localityRadius(draggedAxis) : Infinity;
+      return g.children.filter(o => {
+        if (!(o.isMesh && o.userData.featureId != null)) return false;
+        const cls = classByFid[o.userData.featureId];
+        if (cls != null && allow.indexOf(cls) === -1) return false;   // known class, not structural/enclosure -> exclude
+        return true;
+      }).map(m => {
         m.geometry.computeBoundingBox(); const bb = m.geometry.boundingBox;
         return { guid: m.userData.featureId,
           x: (bb.min.x + bb.max.x) / 2, y: (bb.min.y + bb.max.y) / 2, z: (bb.min.z + bb.max.z) / 2,
           bboxX: bb.max.x - bb.min.x, bboxY: bb.max.y - bb.min.y, bboxZ: bb.max.z - bb.min.z,
           ifcClass: 'IfcWall' };
+      }).filter(elem => {
+        if (draggedAxis == null || !isFinite(radius)) return true;
+        const orthoPos = draggedAxis === 'x' ? elem.y : elem.x;   // draggedAxis names the GRIPPED line's axis; the element's ORTHOGONAL coordinate is the OTHER one
+        return Math.abs(orthoPos - orthoAt) <= radius;
       });
     },
 
@@ -85,17 +142,25 @@
     // the two sibling per-frame O(n) scans (mesh-by-fid for gmTint, box-by-fid for §STRETCH-RIDE) for the
     // duration of this ONE drag session. Logged so the cache lifecycle is visible in the console, not just
     // inferred from timing.
-    beginDragSession() {
+    // §GRIDSCOPE: draggedAxis/orthoAt (OPTIONAL, both new params) are the grabbed line's axis + the
+    // pointerdown hit's orthogonal-axis coordinate (modeller.html's pointerdown handler) — feeds
+    // elementData()'s grab-locality filter above. Omitted (any pre-existing caller) ⇒ draggedAxis stays
+    // null ⇒ locality filtering is skipped entirely (byte-identical to before this change for those callers).
+    beginDragSession(draggedAxis, orthoAt) {
+      this._dragAxis = draggedAxis != null ? draggedAxis : null;
+      this._dragOrthoAt = orthoAt != null ? orthoAt : null;
       this._engine = this._buildEngine();
       this._meshCache = this._buildMeshByFid();
       this._boxCache = this._buildBoxByFid();
-      console.log(TAG + ' §SCALE_CHECK_FIX drag-session begin — attach-map + mesh/box caches built ONCE (reused every pointermove frame)');
+      console.log(TAG + ' §SCALE_CHECK_FIX drag-session begin — attach-map + mesh/box caches built ONCE (reused every pointermove frame)' +
+        (this._dragAxis != null ? (' §GRIDSCOPE axis=' + this._dragAxis + ' orthoAt=' + this._dragOrthoAt.toFixed(3) + ' radius=' + this._localityRadius(this._dragAxis).toFixed(3)) : ''));
     },
     // Called on commit/cancel — the NEXT drag (or any non-session caller) rebuilds fresh off the post-commit
     // scene, so a scene edit between drags is never served a stale attach map.
     endDragSession() {
       if (this._engine) console.log(TAG + ' §SCALE_CHECK_FIX drag-session end — caches cleared');
       this._engine = null; this._meshCache = null; this._boxCache = null;
+      this._dragAxis = null; this._dragOrthoAt = null;
     },
     // PURE recompose: use the cached attached engine if a drag session is active, else build-and-discard
     // (unchanged fallback behavior for any caller outside a session, e.g. tests).

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1860,10 +1860,15 @@ canvas.addEventListener('pointerdown', (e) => {
   if (!raycaster.ray.intersectPlane(GROUND, hit)) return;
   const gl = nearestGridline(hit.x, hit.y);
   if (gl) {
+    // §GRIDSCOPE (GRID_SMART_ELEMENT_SCOPE.md): orthoAt = the hit's coordinate on the OTHER axis from the
+    // gripped line (hit.y for an x-axis line grip) — "where along the line's length did the user grab it,"
+    // fed to beginDragSession() so elementData() can scope governance to near that point, not the whole
+    // building. Already had this data on hand (`hit`); only NEW work is passing it through.
+    const orthoAt = gl.axis === 'x' ? hit.y : hit.x;
     _dragGrid = { ...gl, downAt: gl.axis === 'x' ? hit.x : hit.y }; gmPreviewLine(gl.axis, gl.coord); setStat('drag grid ' + gl.id + ' (' + gl.axis + ')');
     // §SCALE_CHECK_FIX (Finding 1): gridline-grab = the drag session boundary — cache the attach-map engine +
     // mesh/box maps ONCE here so every pointermove frame below reuses them instead of rebuilding from scratch.
-    if (window.Bonsai.gridmove && window.Bonsai.gridmove.beginDragSession) window.Bonsai.gridmove.beginDragSession();
+    if (window.Bonsai.gridmove && window.Bonsai.gridmove.beginDragSession) window.Bonsai.gridmove.beginDragSession(gl.axis, orthoAt);
   }
 });
 canvas.addEventListener('pointermove', (e) => {

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -576,8 +576,16 @@
     ready = false; lastEx = [];
     window.__dwBuf = null; window.__dwName = null;
     window.swXEdges = null;
+    // §GRIDSCOPE-FIX (2026-07-09, same §GRID-CLEAR-LEAK family): __arcGuidByFid/__arcFidByGuid (arc_editable.js
+    // buildBridge, set at Open) were ALSO never reset here -- after a clear, the NEXT authoring session's
+    // featureIds restart from 1 and can collide with the PREVIOUS building's stale guid mapping. Confirmed
+    // real: bonsai_gridmove.js's elementData() now excludes real ARC elements from grid governance by
+    // checking this map -- without this reset, a fresh post-clear wall's featureId 1 could wrongly match a
+    // stale entry and get incorrectly excluded (caught by witness_e2e_gridstretch.js going from commands=1
+    // to commands=0 the moment that exclusion landed).
+    window.__arcGuidByFid = null; window.__arcFidByGuid = null;
     if (window.Bonsai && window.Bonsai.outliner) window.Bonsai.outliner.refresh();
-    console.log(TAG + ' §GRID-CLEAR-LEAK onClear — ready=false, __dwBuf cleared, swXEdges cleared');
+    console.log(TAG + ' §GRID-CLEAR-LEAK onClear — ready=false, __dwBuf cleared, swXEdges cleared, arc bridge cleared');
   }
 
   window.STRWalkerOutliner = {

--- a/modeller/tests/repro_gridmove_duplex_open.js
+++ b/modeller/tests/repro_gridmove_duplex_open.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// SCRATCH repro (not a permanent witness) -- reproduces the GUIDE_VISUAL_QUALITY.md observation: leaving
+// Duplex OPEN (not #b-cleared) under a synthetic grid+wall, then dragging a gridline, allegedly commits a
+// stray GEOM_MOVE instead of GEOM_GRID_MOVE. Mirrors witness_e2e_gridstretch.js's own proven X1-X6 setup,
+// MINUS the #b-clear step, to isolate whether that's really the cause.
+'use strict';
+const { runE2E } = require('./e2e_harness');
+runE2E('REPRO-GRIDMOVE-DUPLEX-OPEN', async (t) => {
+  await t.open('Duplex'); await t.shot('01-open-not-cleared');
+
+  // SAME setup as witness_e2e_gridstretch.js X1, but DELIBERATELY SKIP #b-clear.
+  const wallId = await t.pg.evaluate(async () => {
+    window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+    const O = window.Bonsai.oplog;
+    const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+    if (typeof syncHistory === 'function') syncHistory();
+    return wall.id;
+  });
+  console.log('wallId=' + wallId);
+  await t.clickSel('#b-fit'); await t.sleep(500);
+  await t.shot('02-setup-duplex-visible');
+
+  const gridMovingBefore = await t.pg.evaluate(() => typeof gridMoving !== 'undefined' ? gridMoving : 'undefined');
+  console.log('gridMoving BEFORE click=' + gridMovingBefore);
+
+  await t.clickSel('#b-gridmove'); await t.sleep(400);
+  const gridMovingAfter = await t.pg.evaluate(() => typeof gridMoving !== 'undefined' ? gridMoving : 'undefined');
+  console.log('gridMoving AFTER click=' + gridMovingAfter);
+  const dragGridState = await t.pg.evaluate(() => typeof _dragGrid !== 'undefined' ? JSON.stringify(_dragGrid) : 'undefined');
+  console.log('_dragGrid AFTER click (should be null pre-drag)=' + dragGridState);
+  await t.shot('03-gridmode-armed');
+
+  const before = await t.oplog();
+  const DX = 1.5;
+  const down = await t.proj(4, 1.5, 0);
+  const up = await t.proj(4 + DX, 1.5, 0);
+  console.log('drag down px=' + JSON.stringify(down) + ' up px=' + JSON.stringify(up));
+  await t.drag(down, up, 12);
+  await t.sleep(900);
+  const after = await t.oplog();
+  const last = await t.lastOp();
+  console.log('oplog ' + before.len + ' -> ' + after.len + ', last op_type=' + (last && last.op_type));
+  console.log(JSON.stringify(last, null, 2));
+  await t.shot('04-after-drag');
+
+  const gridMovingFinal = await t.pg.evaluate(() => typeof gridMoving !== 'undefined' ? gridMoving : 'undefined');
+  console.log('gridMoving FINAL (post-drag)=' + gridMovingFinal);
+
+  t.assert('REPRO check', true, 'see console output above for the actual op_type');
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_grid_kinematics_pure.js
+++ b/modeller/tests/witness_grid_kinematics_pure.js
@@ -1,0 +1,755 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-GRIDKINEMATICS-PURE: Tier 1 of prompts/GRID_KINEMATICS_SANDBOX_PROOF.md's sandbox
+ * (§2 Tier 1 — "pure math, zero browser, zero THREE, zero DOM, the cheapest most rigorous tier"). Proves
+ * grid_kinematics.js's own _findBestGrid/dragGrid math against HAND-COMPUTED fixtures (every expected number
+ * is worked out on paper in the comments beside each assertion, not inferred from running the code once).
+ *
+ * PROVENANCE: originally test_grid_kinematics.js at the repo root (§S270's own test, ported from S268/S269),
+ * left broken by a later repo restructure that moved grid_kinematics.js under modeller/ + viewer/ — its
+ * `require('../grid_kinematics.js')` silently pointed at a path that no longer exists (MODULE_NOT_FOUND),
+ * so it had NOT been exercised since that migration despite looking complete. Revived here, co-located with
+ * the rest of this grid subsystem's witnesses, targeting modeller/grid_kinematics.js specifically (the
+ * SCOPE this spec covers — confirmed byte-identical to viewer/grid_kinematics.js, so this also covers the
+ * shared engine). Content otherwise unchanged: same 36 checks (T1-T36), same hand arithmetic.
+ *
+ * Covers (§4 DONE WHEN's own list, all present): ATTACH (T1,T7), SPAN (T5,T9), EDGE_LEFT/EDGE_RIGHT
+ * (T3,T4,T10-T13), TRANSLATE/SCALE command math, bay-proportional interior (T20-T24), roof vertex/lift/
+ * cascade (T25-T30,T36), purity (T18), multi-axis (T31), edge cases (T33-T35).
+ */
+'use strict';
+var path = require('path');
+var GK = require(path.join(__dirname, '..', 'grid_kinematics.js'));
+var GridKinematicEngine = GK.GridKinematicEngine;
+
+// ── Minimal test harness ───────────────────────────────────────────────────
+var _pass = 0, _fail = 0, _total = 0;
+function assert(cond, msg) {
+  _total++;
+  if (cond) { _pass++; console.log('  ✓ ' + msg); }
+  else { _fail++; console.error('  ✗ FAIL: ' + msg); }
+}
+function assertApprox(actual, expected, tol, msg) {
+  assert(Math.abs(actual - expected) < tol,
+    msg + ' (expected ' + expected.toFixed(4) + ' got ' + actual.toFixed(4) + ')');
+}
+function section(name) { console.log('\n── ' + name + ' ──'); }
+
+function findCmd(commands, guid, action) {
+  for (var i = 0; i < commands.length; i++) {
+    if (commands[i].guid === guid && (!action || commands[i].action === action)) return commands[i];
+  }
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S268 — ATTACH MAP CLASSIFICATION (ported from test_s268_recompose.js)
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T1 — ATTACH: centerline within tolerance');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'W1', x: 10.1, y: 0, z: 0, bboxX: 0.08, bboxY: 3, bboxZ: 0.08, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length === 1, 'Column attached to grid A');
+  assert(map['A'][0].relation === 'ATTACH', 'Classified as ATTACH (got ' + (map['A'] ? map['A'][0].relation : 'none') + ')');
+})();
+
+section('T2 — ATTACH: outside tolerance → interior');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'W1', x: 10.8, y: 0, z: 0, bboxX: 0.2, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  var items = map['A'] || [];
+  assert(items.length === 0, 'Column too far from grid → not attached');
+  assert(engine.getInteriorElements().length === 1, 'Classified as interior');
+})();
+
+section('T3 — EDGE_RIGHT: right edge at grid');
+(function() {
+  // Wall center at 8.5, bboxX=3.0, right edge at 10.0. Grid at 10.0.
+  var engine = new GridKinematicEngine(
+    [{ guid: 'WR', x: 8.5, y: 0, z: 0, bboxX: 3.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length === 1, 'Wall attached');
+  assert(map['A'][0].relation === 'EDGE_RIGHT', 'Classified as EDGE_RIGHT');
+})();
+
+section('T4 — EDGE_LEFT: left edge at grid');
+(function() {
+  // Wall center at 11.25, bboxX=2.5, left edge at 10.0. Grid at 10.0.
+  var engine = new GridKinematicEngine(
+    [{ guid: 'WL', x: 11.25, y: 0, z: 0, bboxX: 2.5, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length === 1, 'Wall attached');
+  assert(map['A'][0].relation === 'EDGE_LEFT', 'Classified as EDGE_LEFT');
+})();
+
+section('T5 — SPAN: grid inside body');
+(function() {
+  // Wall center at 10.0, bboxX=4.0, body [8.0,12.0]. Grid at 9.0 (inside, not center).
+  var engine = new GridKinematicEngine(
+    [{ guid: 'WS', x: 10.0, y: 0, z: 0, bboxX: 4.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall' }],
+    [{ id: 'A', axis: 'x', pos: 9.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length === 1, 'Wall attached');
+  assert(map['A'][0].relation === 'SPAN', 'Classified as SPAN (got ' + (map['A'] ? map['A'][0].relation : 'none') + ')');
+})();
+
+section('T6 — Priority: EDGE wins over SPAN');
+(function() {
+  // Wall [8.0,12.0] center=10.0, bboxX=4.0. Grid at 8.05 (within 0.1m of left edge).
+  var engine = new GridKinematicEngine(
+    [{ guid: 'WP', x: 10.0, y: 0, z: 0, bboxX: 4.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall' }],
+    [{ id: 'A', axis: 'x', pos: 8.05 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'][0].relation === 'EDGE_LEFT', 'Edge at 0.05m wins over SPAN (got ' + map['A'][0].relation + ')');
+})();
+
+section('T7 — Priority: ATTACH at centerline wins');
+(function() {
+  // Wall [8.0,12.0] center=10.0, bboxX=4.0. Grid at 10.0 (exact centerline).
+  var engine = new GridKinematicEngine(
+    [{ guid: 'WC', x: 10.0, y: 0, z: 0, bboxX: 4.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'][0].relation === 'ATTACH', 'Grid at centerline → ATTACH (got ' + map['A'][0].relation + ')');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S268 — DRAG COMMANDS
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T8 — ATTACH drag → TRANSLATE');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'C1', x: 10.0, y: 0, z: 5.0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 3.0);
+  var cmd = findCmd(cmds, 'C1', 'TRANSLATE');
+  assert(cmd !== null, 'ATTACH produces TRANSLATE');
+  assertApprox(cmd.delta, 3.0, 0.001, 'Delta is +3.0');
+  assert(cmd.axis === 'x', 'Axis is x');
+})();
+
+section('T9 — SPAN drag → SCALE');
+(function() {
+  // Slab center=10, bboxX=6 → body [7,13]. Grid at 9.0 (inside, near edge).
+  var engine = new GridKinematicEngine(
+    [{ guid: 'SL1', x: 10.0, y: 0, z: 5.0, bboxX: 6.0, bboxY: 0.3, bboxZ: 8.0, ifcClass: 'IfcSlab', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 9.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 2.0);
+  var cmd = findCmd(cmds, 'SL1', 'SCALE');
+  assert(cmd !== null, 'SPAN produces SCALE');
+  assert(cmd.axis === 'x', 'Axis is x');
+  // edge='near' (9.0 closer to lo=7.0 than hi=13.0), delta=+2 → newWidth = 6 - 2 = 4
+  // scaleRatio = 4/6, newScale = 1 * 4/6
+  assertApprox(cmd.newScale, 4.0 / 6.0, 0.01, 'Scale ratio correct');
+})();
+
+section('T10 — EDGE_RIGHT +delta → SCALE (stretch)');
+(function() {
+  // Wall center=8.5, bboxX=3.0, right edge=10.0. Grid at 10.0.
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ER1', x: 8.5, y: 0, z: 0, bboxX: 3.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 2.0);
+  var cmd = findCmd(cmds, 'ER1', 'SCALE');
+  assert(cmd !== null, 'EDGE_RIGHT +delta → SCALE (stretch)');
+  // far edge: newWidth = 3.0 + 2.0 = 5.0, ratio = 5/3
+  assertApprox(cmd.newScale, 5.0 / 3.0, 0.01, 'Stretch ratio correct');
+})();
+
+section('T11 — EDGE_RIGHT -delta → TRANSLATE');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ER2', x: 8.5, y: 0, z: 0, bboxX: 3.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', -2.0);
+  var cmd = findCmd(cmds, 'ER2', 'TRANSLATE');
+  assert(cmd !== null, 'EDGE_RIGHT -delta → TRANSLATE');
+  assertApprox(cmd.delta, -2.0, 0.001, 'Delta is -2.0');
+})();
+
+section('T12 — EDGE_LEFT +delta → TRANSLATE');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'EL1', x: 11.25, y: 0, z: 0, bboxX: 2.5, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 2.0);
+  var cmd = findCmd(cmds, 'EL1', 'TRANSLATE');
+  assert(cmd !== null, 'EDGE_LEFT +delta → TRANSLATE');
+  assertApprox(cmd.delta, 2.0, 0.001, 'Delta is +2.0');
+})();
+
+section('T13 — EDGE_LEFT -delta → SCALE (stretch)');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'EL2', x: 11.25, y: 0, z: 0, bboxX: 2.5, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', -2.0);
+  var cmd = findCmd(cmds, 'EL2', 'SCALE');
+  assert(cmd !== null, 'EDGE_LEFT -delta → SCALE (stretch)');
+  // near edge: newWidth = 2.5 - (-2.0) = 4.5, ratio = 4.5/2.5
+  assertApprox(cmd.newScale, 4.5 / 2.5, 0.01, 'Stretch ratio correct');
+})();
+
+section('T14 — Adjacent walls share grid: no gap, no overlap');
+(function() {
+  // Wall A: center=8.5, bboxX=3.0, right edge=10.0 (EDGE_RIGHT)
+  // Wall B: center=11.25, bboxX=2.5, left edge=10.0 (EDGE_LEFT)
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'ADJ_A', x: 8.5, y: 0, z: 0, bboxX: 3.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 },
+      { guid: 'ADJ_B', x: 11.25, y: 0, z: 0, bboxX: 2.5, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }
+    ],
+    [{ id: 'G', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('G', 2.0);
+  // Wall A: EDGE_RIGHT +delta → stretch, new right edge = 10.0 + 2.0 = 12.0
+  // Wall B: EDGE_LEFT +delta → translate, new left edge = 10.0 + 2.0 = 12.0
+  var cmdA = findCmd(cmds, 'ADJ_A', 'SCALE');
+  var cmdB = findCmd(cmds, 'ADJ_B', 'TRANSLATE');
+  assert(cmdA !== null, 'Wall A stretches');
+  assert(cmdB !== null, 'Wall B translates');
+  assertApprox(cmdB.delta, 2.0, 0.001, 'Wall B translates by +2.0');
+  // Wall A: EDGE_RIGHT stretch far, newWidth = 3+2=5, center doesn't shift (far edge grows)
+  // Wall A new right edge = 8.5 + 5/2 = 11.0? No — SCALE far: center stays, width grows.
+  // Actually the SCALE command has translateDelta=0 for far edge. So center stays at 8.5.
+  // New half-extent = 5/2 = 2.5, right edge = 8.5 + 2.5 = 11.0
+  // Wall B: translates by +2 → new center = 13.25, left edge = 13.25 - 1.25 = 12.0
+  // Gap from 11.0 to 12.0? That's the expected behavior of the current algorithm:
+  // far-edge scale keeps center fixed, so the "stretch" only extends one side.
+  // In the original S268 code, _scaleMesh with edge='far' also doesn't shift center.
+  // The gap is filled by the user's next drag or adjacent bay-proportional.
+  // What matters: both walls got correct commands, no overlap.
+  var newA_right = 8.5 + (3.0 + 2.0) / 2;  // center + newHalfW
+  var newB_left = (11.25 + 2.0) - 2.5 / 2;  // translated center - halfW
+  assert(newA_right <= newB_left + 0.01, 'No overlap (A_right=' + newA_right.toFixed(2) + ' B_left=' + newB_left.toFixed(2) + ')');
+})();
+
+section('T15 — Adjacent walls negative delta: no gap');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'ADJ_A', x: 8.5, y: 0, z: 0, bboxX: 3.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 },
+      { guid: 'ADJ_B', x: 11.25, y: 0, z: 0, bboxX: 2.5, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }
+    ],
+    [{ id: 'G', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('G', -2.0);
+  // Wall A: EDGE_RIGHT -delta → translate by -2.0. New right edge = 10.0 - 2.0 = 8.0
+  // Wall B: EDGE_LEFT -delta → stretch. Near edge moves by -2.0. New left edge = 10.0 - 2.0 = 8.0
+  var cmdA = findCmd(cmds, 'ADJ_A', 'TRANSLATE');
+  var cmdB = findCmd(cmds, 'ADJ_B', 'SCALE');
+  assert(cmdA !== null, 'Wall A translates');
+  assert(cmdB !== null, 'Wall B stretches');
+  assertApprox(cmdA.delta, -2.0, 0.001, 'Wall A delta = -2.0');
+  // Both edges at 8.0
+  var newA_end = (8.5 - 2.0) + 3.0 / 2; // translated center + original halfExtent
+  var newB_start = 11.25 + (-2.0) - (2.5 + 2.0) / 2; // SCALE near: center shifts by delta, halfExtent grows
+  // Actually for near-edge scale: translateDelta = delta = -2.0, newWidth = 2.5 - (-(-2.0)) ...
+  // Let's just verify Wall A right edge = 8.0
+  assertApprox(newA_end, 8.0, 0.01, 'Wall A right edge at 8.0');
+})();
+
+section('T16 — Zero delta → no commands');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'W1', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 0.0);
+  assert(cmds.length === 0, 'Zero delta → empty commands');
+})();
+
+section('T17 — Unknown grid ID → no commands');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'W1', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('NONEXISTENT', 3.0);
+  assert(cmds.length === 0, 'Unknown grid → empty commands');
+})();
+
+section('T18 — Purity: input data not mutated by dragGrid');
+(function() {
+  var elem = { guid: 'P1', x: 10.0, y: 0, z: 5.0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' };
+  var origX = elem.x;
+  var origZ = elem.z;
+  var engine = new GridKinematicEngine([elem], [{ id: 'A', axis: 'x', pos: 10.0 }]);
+  engine.attachGridToElements();
+  engine.dragGrid('A', 5.0);
+  assert(elem.x === origX, 'elem.x not mutated');
+  assert(elem.z === origZ, 'elem.z not mutated');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S268 — Z-AXIS (same logic, different axis)
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T19 — Z-axis ATTACH');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ZC', x: 0, y: 0, z: 8.5, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    [{ id: '1', axis: 'z', pos: 8.7 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('1', -1.5);
+  var cmd = findCmd(cmds, 'ZC', 'TRANSLATE');
+  assert(cmd !== null && cmd.axis === 'z', 'Z-axis ATTACH → TRANSLATE on z');
+  assertApprox(cmd.delta, -1.5, 0.001, 'Delta = -1.5');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S269 — BAY-PROPORTIONAL INTERIOR
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T20 — Bay-proportional: 50% interior element');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'COL_A', x: 5.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'COL_B', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'FURN', x: 7.5, y: 0, z: 0, bboxX: 0.5, bboxY: 1, bboxZ: 0.5, ifcClass: 'IfcFurnishingElement' }
+    ],
+    [{ id: 'A', axis: 'x', pos: 5.0 }, { id: 'B', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  // Move grid B by +3.0. Bay [5,10] → [5,13]. Furniture at 50% → moves +1.5
+  var cmds = engine.dragGrid('B', 3.0);
+  var furnCmd = findCmd(cmds, 'FURN', 'TRANSLATE');
+  assert(furnCmd !== null, 'Interior furniture gets TRANSLATE');
+  assertApprox(furnCmd.delta, 1.5, 0.01, 'Bay-proportional: 50% of +3.0 = +1.5');
+})();
+
+section('T21 — Bay-proportional: bay start element → delta ≈ 0');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'COL_A', x: 5.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'COL_B', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'EDGE_ELEM', x: 5.01, y: 0, z: 0, bboxX: 0.3, bboxY: 1, bboxZ: 0.3, ifcClass: 'IfcFurnishingElement' }
+    ],
+    [{ id: 'A', axis: 'x', pos: 5.0 }, { id: 'B', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('B', 3.0);
+  // Element at bay start: t≈0, delta≈0
+  var cmd = findCmd(cmds, 'EDGE_ELEM', 'TRANSLATE');
+  if (cmd) {
+    assertApprox(cmd.delta, 0.0, 0.05, 'Bay start element barely moves');
+  } else {
+    assert(true, 'Bay start element: no command (delta < threshold)');
+  }
+})();
+
+section('T22 — Bay-proportional: unchanged bay → no move');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'CA', x: 1.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'CB', x: 5.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'CC', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'FURN2', x: 3.0, y: 0, z: 0, bboxX: 0.3, bboxY: 1, bboxZ: 0.3, ifcClass: 'IfcFurnishingElement' }
+    ],
+    [{ id: 'A', axis: 'x', pos: 1.0 }, { id: 'B', axis: 'x', pos: 5.0 }, { id: 'C', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  // Move grid C by +3.0. Bay [1,5] is unchanged. FURN2 at x=3.0 in [1,5] → no move.
+  var cmds = engine.dragGrid('C', 3.0);
+  var cmd = findCmd(cmds, 'FURN2', 'TRANSLATE');
+  if (cmd) {
+    assertApprox(cmd.delta, 0.0, 0.02, 'Unchanged bay → delta ≈ 0');
+  } else {
+    assert(true, 'Unchanged bay → no command');
+  }
+})();
+
+section('T23 — Bay-proportional: shrink bay');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'CA', x: 5.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'CB', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'FURN', x: 7.5, y: 0, z: 0, bboxX: 0.3, bboxY: 1, bboxZ: 0.3, ifcClass: 'IfcFurnishingElement' }
+    ],
+    [{ id: 'A', axis: 'x', pos: 5.0 }, { id: 'B', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  // Move grid B by -2.0. Bay [5,10] → [5,8]. Furn at 50% → new pos = 5 + 0.5*3 = 6.5, delta = -1.0
+  var cmds = engine.dragGrid('B', -2.0);
+  var cmd = findCmd(cmds, 'FURN', 'TRANSLATE');
+  assert(cmd !== null, 'Shrink bay produces command');
+  assertApprox(cmd.delta, -1.0, 0.01, 'Bay shrink: 50% of -2.0 = -1.0');
+})();
+
+section('T24 — Bay-proportional: _bayProportionalDelta direct test');
+(function() {
+  var bpd = GK._bayProportionalDelta;
+  var origGrid = [1.0, 5.0, 10.0, 15.0, 20.0, 23.5];
+  var newGrid  = [1.0, 5.0, 13.0, 15.0, 20.0, 23.5];
+
+  assertApprox(bpd(7.5, origGrid, newGrid), 1.5, 0.01, 'X=7.5 at 50% of [5,10]→[5,13] = +1.5');
+  assertApprox(bpd(5.0, origGrid, newGrid), 0.0, 0.01, 'X=5.0 at bay start = 0');
+  assertApprox(bpd(10.0, origGrid, newGrid), 3.0, 0.01, 'X=10.0 at bay end = +3.0');
+  assertApprox(bpd(8.0, origGrid, newGrid), 1.8, 0.01, 'X=8.0 at 60% = +1.8');
+  assertApprox(bpd(17.0, origGrid, newGrid), 0.0, 0.01, 'X=17.0 in unchanged bay = 0');
+  assertApprox(bpd(0.5, origGrid, newGrid), 0.0, 0.02, 'X=0.5 outside all bays = 0');
+  assertApprox(bpd(7.5, [], []), 0.0, 0.01, 'Empty grid = 0');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — ROOF VERTEX RECOMPOSITION (horizontal)
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T25 — Sloped roof: eave moves, ridge fixed');
+(function() {
+  // Synthetic pitched roof: 12 vertices (4 triangles forming a simple gable)
+  // Eave vertices at y=3.0, ridge at y=5.0. Span on X from 5.0 to 15.0.
+  var verts = new Float32Array([
+    // Eave left (2 verts near x=5.0)
+    5.0, 3.0, 0.0,    5.0, 3.0, 8.0,
+    // Ridge (2 verts at x=10.0)
+    10.0, 5.0, 0.0,   10.0, 5.0, 8.0,
+    // Eave right (2 verts near x=15.0)
+    15.0, 3.0, 0.0,   15.0, 3.0, 8.0,
+    // Slope verts between eave and ridge (at mid-height y=4.0)
+    7.5, 4.0, 0.0,    7.5, 4.0, 8.0,
+    12.5, 4.0, 0.0,   12.5, 4.0, 8.0,
+    // More eave corners
+    5.0, 3.0, 4.0,    15.0, 3.0, 4.0
+  ]);
+
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ROOF1', x: 10.0, y: 4.0, z: 4.0, bboxX: 10.0, bboxY: 2.0, bboxZ: 8.0,
+       ifcClass: 'IfcRoof', vertices: verts, scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 5.0 }, { id: 'B', axis: 'x', pos: 15.0 }]
+  );
+  engine.attachGridToElements();
+
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length > 0, 'Roof attached to grid A (eave side)');
+
+  // Drag left eave grid by +2.0
+  var cmds = engine.dragGrid('A', 2.0);
+  var roofCmd = findCmd(cmds, 'ROOF1', 'ROOF_VERTICES');
+  assert(roofCmd !== null, 'Sloped roof produces ROOF_VERTICES command');
+  assert(roofCmd.vertexDeltas instanceof Float32Array, 'vertexDeltas is Float32Array');
+
+  // Check: eave vertices (y=3.0, t=0) get full delta
+  // Ridge vertices (y=5.0, t=1) get zero
+  // Slope vertices (y=4.0, t=0.5) get half delta
+  var vd = roofCmd.vertexDeltas;
+  // Vertex 0: eave at x=5.0, y=3.0 → t=0, should get +2.0
+  assertApprox(vd[0 * 3 + 0], 2.0, 0.01, 'Eave vertex 0: full delta +2.0');
+  // Vertex 2: ridge at x=10.0, y=5.0 → not near grid A (x=5.0), so delta=0
+  assertApprox(vd[2 * 3 + 0], 0.0, 0.01, 'Ridge vertex 2: zero delta (not near grid A)');
+  // Vertex 6: slope at x=7.5, y=4.0 → may or may not be within ATTACH_TOL of grid A at x=5.0
+  // 7.5 - 5.0 = 2.5 > 0.5 tolerance → NOT attached
+  assertApprox(vd[6 * 3 + 0], 0.0, 0.01, 'Slope vertex at x=7.5 too far from grid A → zero');
+})();
+
+section('T26 — Sloped roof: t-interpolation verified');
+(function() {
+  // All vertices near grid line x=5.0, different heights
+  var verts = new Float32Array([
+    5.0, 3.0, 0.0,   // eave, t=0
+    5.1, 4.0, 0.0,   // slope, t=0.5
+    4.9, 5.0, 0.0,   // ridge, t=1.0
+    5.0, 3.5, 0.0,   // slope, t=0.25
+  ]);
+
+  var engine = new GridKinematicEngine(
+    [{ guid: 'R2', x: 5.0, y: 4.0, z: 0, bboxX: 0.2, bboxY: 2.0, bboxZ: 0.1,
+       ifcClass: 'IfcRoof', vertices: verts }],
+    [{ id: 'G', axis: 'x', pos: 5.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('G', 4.0);
+  var cmd = findCmd(cmds, 'R2', 'ROOF_VERTICES');
+  assert(cmd !== null, 'Roof produces ROOF_VERTICES');
+
+  var vd = cmd.vertexDeltas;
+  // yMin=3.0, yMax=5.0, yRange=2.0
+  // v0: t=0.0 → delta * (1-0) = 4.0
+  assertApprox(vd[0], 4.0, 0.01, 'Eave (t=0): full delta 4.0');
+  // v1: t=0.5 → delta * 0.5 = 2.0
+  assertApprox(vd[3], 2.0, 0.01, 'Slope (t=0.5): half delta 2.0');
+  // v2: t=1.0 → delta * 0 = 0
+  assertApprox(vd[6], 0.0, 0.01, 'Ridge (t=1.0): zero delta');
+  // v3: t=0.25 → delta * 0.75 = 3.0
+  assertApprox(vd[9], 3.0, 0.01, 'Slope (t=0.25): delta 3.0');
+})();
+
+section('T27 — Flat roof: all edge verts get full delta (SCALE)');
+(function() {
+  // Flat roof: all vertices at y=3.0 (yRange < 0.05)
+  var verts = new Float32Array([
+    5.0, 3.0, 0.0,   5.0, 3.01, 4.0,   5.0, 3.0, 8.0,
+    15.0, 3.0, 0.0,   15.0, 3.01, 4.0,   15.0, 3.0, 8.0,
+  ]);
+
+  var engine = new GridKinematicEngine(
+    [{ guid: 'FLAT1', x: 10.0, y: 3.0, z: 4.0, bboxX: 10.0, bboxY: 0.01, bboxZ: 8.0,
+       ifcClass: 'IfcRoof', vertices: verts, scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 5.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  var items = map['A'] || [];
+  assert(items.length > 0, 'Flat roof attached to grid');
+  assert(items[0].relation === 'ROOF_FLAT', 'Classified as ROOF_FLAT');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — ROOF LIFT (Y-axis grid)
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T28 — Roof lift: Y-axis grid → ROOF_LIFT command');
+(function() {
+  var verts = new Float32Array([
+    5.0, 3.0, 0.0,   15.0, 3.0, 0.0,
+    10.0, 5.0, 0.0,   5.0, 3.0, 8.0,
+    15.0, 3.0, 8.0,   10.0, 5.0, 8.0,
+  ]);
+
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ROOF_Y', x: 10.0, y: 4.0, z: 4.0, bboxX: 10.0, bboxY: 2.0, bboxZ: 8.0,
+       ifcClass: 'IfcRoof', vertices: verts }],
+    [{ id: 'CEIL', axis: 'y', pos: 3.0 }]  // Y-axis grid at eave height
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['CEIL'] && map['CEIL'].length > 0, 'Roof attached to Y-axis grid');
+  assert(map['CEIL'][0].relation === 'ROOF_LIFT', 'Classified as ROOF_LIFT');
+
+  var cmds = engine.dragGrid('CEIL', 0.5);
+  var cmd = findCmd(cmds, 'ROOF_Y', 'ROOF_LIFT');
+  assert(cmd !== null, 'ROOF_LIFT command produced');
+  assertApprox(cmd.deltaY, 0.5, 0.001, 'deltaY = +0.5');
+})();
+
+section('T29 — Roof lift cascade: walls scale height');
+(function() {
+  var roofVerts = new Float32Array([
+    5.0, 3.0, 0.0,   15.0, 3.0, 0.0,
+    10.0, 5.0, 0.0,
+  ]);
+
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'ROOF', x: 10.0, y: 4.0, z: 0, bboxX: 10.0, bboxY: 2.0, bboxZ: 8.0,
+        ifcClass: 'IfcRoof', vertices: roofVerts },
+      // Wall: center y=1.5, bboxY=3.0, top edge at y=3.0 (matches eave)
+      { guid: 'WALL1', x: 5.0, y: 1.5, z: 0, bboxX: 0.2, bboxY: 3.0, bboxZ: 8.0,
+        ifcClass: 'IfcWall', scaleY: 1.0 },
+      { guid: 'WALL2', x: 15.0, y: 1.5, z: 0, bboxX: 0.2, bboxY: 3.0, bboxZ: 8.0,
+        ifcClass: 'IfcWall', scaleY: 1.0 }
+    ],
+    [{ id: 'CEIL', axis: 'y', pos: 3.0 }]
+  );
+  engine.attachGridToElements();
+
+  // Check cascades were discovered
+  var roofAttach = engine.getAttachMap()['CEIL'];
+  assert(roofAttach && roofAttach.length > 0, 'Roof attached to ceiling grid');
+  var roofItem = roofAttach[0];
+  assert(roofItem.cascades.length === 2, 'Two wall cascades discovered (got ' + roofItem.cascades.length + ')');
+
+  // Drag ceiling up by +1.0
+  var cmds = engine.dragGrid('CEIL', 1.0);
+  var roofCmd = findCmd(cmds, 'ROOF', 'ROOF_LIFT');
+  assert(roofCmd !== null, 'Roof gets ROOF_LIFT');
+  assertApprox(roofCmd.deltaY, 1.0, 0.001, 'Roof deltaY = +1.0');
+
+  // Walls should get SCALE on Y axis
+  var w1Cmd = findCmd(cmds, 'WALL1', 'SCALE');
+  assert(w1Cmd !== null, 'Wall1 gets SCALE cascade');
+  assert(w1Cmd.axis === 'y', 'Wall1 scales on Y axis');
+  // origHeight=3.0, delta=1.0 → newScale = (3+1)/3 * 1 = 4/3
+  assertApprox(w1Cmd.newScale, 4.0 / 3.0, 0.01, 'Wall1 newScale = 4/3');
+  // translateDelta = delta/2 = 0.5 (center shifts up)
+  assertApprox(w1Cmd.translateDelta, 0.5, 0.01, 'Wall1 translateDelta = 0.5');
+
+  var w2Cmd = findCmd(cmds, 'WALL2', 'SCALE');
+  assert(w2Cmd !== null, 'Wall2 gets SCALE cascade');
+  assertApprox(w2Cmd.newScale, 4.0 / 3.0, 0.01, 'Wall2 newScale = 4/3');
+})();
+
+section('T30 — Roof lift: walls too far from eave → no cascade');
+(function() {
+  var roofVerts = new Float32Array([5.0, 3.0, 0.0, 10.0, 5.0, 0.0, 15.0, 3.0, 0.0]);
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'ROOF', x: 10.0, y: 4.0, z: 0, bboxX: 10.0, bboxY: 2.0, bboxZ: 8.0,
+        ifcClass: 'IfcRoof', vertices: roofVerts },
+      // Short wall: top at y=2.0, not near eave at y=3.0
+      { guid: 'SHORT', x: 5.0, y: 1.0, z: 0, bboxX: 0.2, bboxY: 2.0, bboxZ: 8.0,
+        ifcClass: 'IfcWall', scaleY: 1.0 }
+    ],
+    [{ id: 'CEIL', axis: 'y', pos: 3.0 }]
+  );
+  engine.attachGridToElements();
+  var roofAttach = engine.getAttachMap()['CEIL'];
+  var cascades = roofAttach[0].cascades;
+  assert(cascades.length === 0, 'Short wall not cascaded (top at 2.0, eave at 3.0)');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — MULTI-AXIS: element on both X and Z grids
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T31 — Element attaches to both X and Z grids independently');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'COL', x: 5.0, y: 0, z: 8.0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    [{ id: 'A', axis: 'x', pos: 5.0 }, { id: '1', axis: 'z', pos: 8.0 }]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length === 1, 'Attached to X grid');
+  assert(map['1'] && map['1'].length === 1, 'Attached to Z grid');
+
+  var cmdsX = engine.dragGrid('A', 2.0);
+  assert(cmdsX.length >= 1, 'X drag produces commands');
+  assert(cmdsX[0].axis === 'x', 'X drag → x axis command');
+
+  var cmdsZ = engine.dragGrid('1', -1.0);
+  assert(cmdsZ.length >= 1, 'Z drag produces commands');
+  assert(cmdsZ[0].axis === 'z', 'Z drag → z axis command');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — MULTIPLE ELEMENTS PER GRID
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T32 — Multiple elements per grid line');
+(function() {
+  var engine = new GridKinematicEngine(
+    [
+      { guid: 'C1', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'C2', x: 10.2, y: 0, z: 4, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' },
+      { guid: 'C3', x: 9.8, y: 0, z: 8, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }
+    ],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 1.0);
+  assert(cmds.length === 3, 'All 3 columns get commands');
+  assert(findCmd(cmds, 'C1') !== null, 'C1 gets command');
+  assert(findCmd(cmds, 'C2') !== null, 'C2 gets command');
+  assert(findCmd(cmds, 'C3') !== null, 'C3 gets command');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — EDGE CASES
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T33 — Empty elements → no crash');
+(function() {
+  var engine = new GridKinematicEngine([], [{ id: 'A', axis: 'x', pos: 10.0 }]);
+  engine.attachGridToElements();
+  var cmds = engine.dragGrid('A', 3.0);
+  assert(cmds.length === 0, 'Empty elements → no commands');
+})();
+
+section('T34 — Empty grids → no crash');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'W1', x: 10.0, y: 0, z: 0, bboxX: 0.3, bboxY: 3, bboxZ: 0.3, ifcClass: 'IfcColumn' }],
+    []
+  );
+  engine.attachGridToElements();
+  assert(engine.getInteriorElements().length === 1, 'Element classified as interior (no grids)');
+})();
+
+section('T35 — SCALE with zero-width element → falls back to TRANSLATE');
+(function() {
+  var engine = new GridKinematicEngine(
+    [{ guid: 'THIN', x: 10.0, y: 0, z: 0, bboxX: 0.0, bboxY: 3, bboxZ: 0.2, ifcClass: 'IfcWall', scaleX: 1.0 }],
+    [{ id: 'A', axis: 'x', pos: 10.0 }]
+  );
+  engine.attachGridToElements();
+  // With bboxX=0, halfExtent=0, should be ATTACH (centerline)
+  var map = engine.getAttachMap();
+  assert(map['A'][0].relation === 'ATTACH', 'Zero-width → ATTACH (centerline only)');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S270 — ROOF ON BOTH AXES (X/Z horizontal + Y lift)
+// ═══════════════════════════════════════════════════════════════════════════
+
+section('T36 — Roof attaches to X grid (horizontal) AND Y grid (lift)');
+(function() {
+  var verts = new Float32Array([
+    5.0, 3.0, 0.0,   5.0, 3.0, 8.0,
+    10.0, 5.0, 0.0,  10.0, 5.0, 8.0,
+    15.0, 3.0, 0.0,  15.0, 3.0, 8.0,
+  ]);
+  var engine = new GridKinematicEngine(
+    [{ guid: 'ROOF', x: 10.0, y: 4.0, z: 4.0, bboxX: 10.0, bboxY: 2.0, bboxZ: 8.0,
+       ifcClass: 'IfcRoof', vertices: verts }],
+    [
+      { id: 'A', axis: 'x', pos: 5.0 },
+      { id: 'B', axis: 'x', pos: 15.0 },
+      { id: 'CEIL', axis: 'y', pos: 3.0 }
+    ]
+  );
+  engine.attachGridToElements();
+  var map = engine.getAttachMap();
+  assert(map['A'] && map['A'].length > 0, 'Roof on X grid A');
+  assert(map['CEIL'] && map['CEIL'].length > 0, 'Roof on Y grid CEIL');
+
+  // X drag → ROOF_VERTICES
+  var cmdsX = engine.dragGrid('A', 2.0);
+  assert(findCmd(cmdsX, 'ROOF', 'ROOF_VERTICES') !== null, 'X drag → ROOF_VERTICES');
+
+  // Y drag → ROOF_LIFT
+  var cmdsY = engine.dragGrid('CEIL', 0.5);
+  assert(findCmd(cmdsY, 'ROOF', 'ROOF_LIFT') !== null, 'Y drag → ROOF_LIFT');
+})();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SUMMARY
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n═══════════════════════════════════════════════');
+console.log('W-GRIDKINEMATICS-PURE: ' + _pass + '/' + _total + ' PASS' + (_fail ? ' (' + _fail + ' FAIL)' : ''));
+console.log('═══════════════════════════════════════════════');
+process.exit(_fail > 0 ? 1 : 0);

--- a/modeller/tests/witness_grid_kinematics_real_duplex.js
+++ b/modeller/tests/witness_grid_kinematics_real_duplex.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-GRIDKINEMATICS-REAL-DUPLEX: Tier 3 of prompts/GRID_KINEMATICS_SANDBOX_PROOF.md's
+ * sandbox (§2 Tier 3 — "real building data, Tier 1's engine, still zero browser"). Loads Duplex_extracted.db's
+ * REAL element_transforms/elements_meta via sql.js and feeds the REAL positions DIRECTLY into Tier 1's pure
+ * grid_kinematics.js engine — bypassing bonsai_gridmove.js, THREE, and the browser entirely.
+ *
+ * ⚠ AXIS MAPPING (verified from the real code, not assumed — read this before touching the SELECT below):
+ * bonsai_grid.js's render() draws X-gridlines as Vector3(x,y0,0)->(x,y1,0) (fixed x, Y sweeps full range) and
+ * Y-gridlines as Vector3(x0,y,0)->(x1,y,0) (fixed y=storey height, X sweeps the building) — i.e. this is an
+ * ELEVATION-view grid (xs=column positions, ys=STOREY HEIGHTS), matching grid_kinematics.js's own "Y=height
+ * in Three.js" convention (its roof/ROOF_LIFT logic only makes sense with Y=height). The extracted DB stores
+ * IFC-native columns (center_z = height, center_y = plan depth) — the engine's elem.y must read the DB's
+ * center_z, and elem.z must read the DB's center_y. Confirmed empirically: DB center_z values cluster at
+ * 0 / 3.1 / 6 (real storey levels), matching bonsai_grid.js's own default ys=[0,3,6].
+ *
+ * PART A — 5 REAL elements near a real gridline (x=4, one of the product's own default xs), hand-verified
+ * against the engine's own _findBestGrid rules (ATTACH_TOL=0.5, EDGE_TOL=0.1) computed by hand from each
+ * element's REAL center_x/bbox_x below (found via a fresh query, guids hand-picked for a clean, unambiguous
+ * per-element classification):
+ *   T1/T2 ATTACH — centerline within 0.5m of x=4
+ *   T3/T4 EDGE_LEFT — left edge within 0.1m of x=4 (overrides the ATTACH also in range, per the engine's own
+ *                     documented priority: EDGE beats ATTACH)
+ *   T5    SPAN — a wide slab whose CENTER is far from x=4 (>0.5m) but whose body strictly straddles x=4
+ *
+ * PART B — independently RE-DERIVE the mass-sweep number prompts/GRID_SMART_ELEMENT_SCOPE.md's real-browser
+ * repro found (~50-100 real elements swept by ONE gridline drag on an unfiltered elementData()) from a FRESH
+ * query + the pure engine directly — not re-citing the earlier browser finding. Reproduces the EXACT grid
+ * (xs=[0,4,8], ys=[0,3]) and EXACT dragged line (gx1, x=4) from repro_gridmove_duplex_open.js /
+ * witness_gridmove_smart_scope.js, feeding ALL 253 real elements (any class, tagged 'IfcWall' — mirrors the
+ * UNFIXED bonsai_gridmove.js's own behavior before the class/locality narrowing).
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+var ROOT = path.join(__dirname, '..');
+var GK = require(path.join(ROOT, 'grid_kinematics.js'));
+
+var pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+
+initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
+  var db = new SQL.Database(fs.readFileSync(path.join(ROOT, 'Duplex_extracted.db')));
+  console.log('═══ W-GRIDKINEMATICS-REAL-DUPLEX — Tier 3: real Duplex data through the pure engine directly ═══');
+
+  // ── PART A: 5 real elements, hand-verified classification against gridline x=4 ──────────────────────
+  var GUIDS_A = [
+    '1aj$VJZFn2TxepZUBcKpvt', // ATTACH: cx≈4.030, |4.030-4|=0.030 < ATTACH_TOL(0.5)
+    '0iEHWY1$XA8eQeeULq4jpl', // ATTACH: cx≈4.030, |4.030-4|=0.030 < 0.5
+    '0dxE1Sy6nDqfpDb5vIMN_Z', // EDGE_LEFT: cx≈4.106 bboxX≈0.152 → lo=cx-half≈4.030, |4.030-4|=0.030 < EDGE_TOL(0.1)
+    '0iEHWY1$XA8eQeeULq4j_U', // EDGE_LEFT: same shape, cx≈4.106 bboxX≈0.152 → lo≈4.030
+    '2O2Fr$t4X7Zf8NOew3FK4F'  // SPAN: cx≈0.417 bboxX≈7.966 → lo≈-3.566 hi≈4.400; |cx-4|=3.583 (no ATTACH/EDGE),
+                              // but 4 strictly inside (lo+0.01, hi-0.01) → SPAN
+  ];
+  var rowsA = db.exec("SELECT guid, center_x, center_y, center_z, bbox_x, bbox_y, bbox_z FROM element_transforms " +
+    "WHERE guid IN ('" + GUIDS_A.join("','") + "')")[0].values;
+  var byGuid = {}; rowsA.forEach(function (v) { byGuid[v[0]] = v; });
+
+  chk('PART A: all 5 hand-picked guids found in the real DB', rowsA.length === 5, 'found=' + rowsA.length);
+
+  var elemsA = GUIDS_A.map(function (g) {
+    var v = byGuid[g];
+    return { guid: g, x: v[1], y: v[3], z: v[2], bboxX: v[4], bboxY: v[6], bboxZ: v[5], ifcClass: 'IfcWall' };
+  });
+  var engineA = new GK.GridKinematicEngine(elemsA, [{ id: 'gx1', axis: 'x', pos: 4 }]);
+  engineA.attachGridToElements();
+  var mapA = engineA.getAttachMap()['gx1'] || [];
+  var relByGuid = {}; mapA.forEach(function (it) { relByGuid[it.guid] = it.relation; });
+
+  chk('T1 real ATTACH #1 (' + GUIDS_A[0].slice(0, 8) + '…, cx=' + byGuid[GUIDS_A[0]][1].toFixed(3) + ')',
+    relByGuid[GUIDS_A[0]] === 'ATTACH', 'got=' + relByGuid[GUIDS_A[0]]);
+  chk('T2 real ATTACH #2 (' + GUIDS_A[1].slice(0, 8) + '…, cx=' + byGuid[GUIDS_A[1]][1].toFixed(3) + ')',
+    relByGuid[GUIDS_A[1]] === 'ATTACH', 'got=' + relByGuid[GUIDS_A[1]]);
+  chk('T3 real EDGE_LEFT #1 (' + GUIDS_A[2].slice(0, 8) + '…, cx=' + byGuid[GUIDS_A[2]][1].toFixed(3) + ' bboxX=' + byGuid[GUIDS_A[2]][4].toFixed(3) + ')',
+    relByGuid[GUIDS_A[2]] === 'EDGE_LEFT', 'got=' + relByGuid[GUIDS_A[2]]);
+  chk('T4 real EDGE_LEFT #2 (' + GUIDS_A[3].slice(0, 8) + '…, cx=' + byGuid[GUIDS_A[3]][1].toFixed(3) + ' bboxX=' + byGuid[GUIDS_A[3]][4].toFixed(3) + ')',
+    relByGuid[GUIDS_A[3]] === 'EDGE_LEFT', 'got=' + relByGuid[GUIDS_A[3]]);
+  chk('T5 real SPAN (' + GUIDS_A[4].slice(0, 8) + '…, cx=' + byGuid[GUIDS_A[4]][1].toFixed(3) + ' bboxX=' + byGuid[GUIDS_A[4]][4].toFixed(3) + ', dist=' + Math.abs(byGuid[GUIDS_A[4]][1] - 4).toFixed(3) + ')',
+    relByGuid[GUIDS_A[4]] === 'SPAN', 'got=' + relByGuid[GUIDS_A[4]]);
+
+  // ── PART B: independent re-derivation of the mass-sweep count ────────────────────────────────────────
+  // EXACT grid + dragged line from repro_gridmove_duplex_open.js / witness_gridmove_smart_scope.js.
+  var allRows = db.exec('SELECT guid, center_x, center_y, center_z, bbox_x, bbox_y, bbox_z FROM element_transforms')[0].values;
+  chk('PART B: real Duplex has the expected 253 elements (baseline cited in this spec’s §0)', allRows.length === 253, 'got=' + allRows.length);
+
+  var allElems = allRows.map(function (v) {
+    return { guid: v[0], x: v[1], y: v[3], z: v[2], bboxX: v[4], bboxY: v[6], bboxZ: v[5], ifcClass: 'IfcWall' };
+  });
+  var gridLines = [
+    { id: 'gx0', axis: 'x', pos: 0 }, { id: 'gx1', axis: 'x', pos: 4 }, { id: 'gx2', axis: 'x', pos: 8 },
+    { id: 'gy0', axis: 'y', pos: 0 }, { id: 'gy1', axis: 'y', pos: 3 }
+  ];
+  var engineB = new GK.GridKinematicEngine(allElems, gridLines);
+  engineB.attachGridToElements();
+  var gx1Count = (engineB.getAttachMap()['gx1'] || []).length;
+
+  console.log('  §MASS-SWEEP-REDERIVE gx1(x=4) governed=' + gx1Count + ' of 253 real elements ' +
+    '(prompts/GRID_SMART_ELEMENT_SCOPE.md’s own real-browser repro cited ~54; this is an INDEPENDENT ' +
+    're-derivation via the pure engine on raw DB rows, not a re-citation — close order-of-magnitude match ' +
+    'is the honest cross-check; an exact match is not expected since the real browser path reads live, ' +
+    'world-space, post-rotation THREE.js mesh bboxes while this reads raw local DB bbox_x/y/z).');
+  chk('PART B: independently re-derived count is the SAME ORDER OF MAGNITUDE as the cited ~54 (dozens, ' +
+    'not the ~3-10 the FIXED elementData() narrows to)', gx1Count >= 20 && gx1Count <= 80, 'gx1Count=' + gx1Count);
+
+  console.log('W-GRIDKINEMATICS-REAL-DUPLEX: ' + pass + ' PASS / ' + fail + ' FAIL');
+  db.close();
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('FATAL', e); process.exit(1); });

--- a/modeller/tests/witness_gridmove_adapter_fakes.js
+++ b/modeller/tests/witness_gridmove_adapter_fakes.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-GRIDMOVE-ADAPTER-FAKES: Tier 2 of prompts/GRID_KINEMATICS_SANDBOX_PROOF.md's sandbox
+ * (§2 Tier 2 — "bonsai_gridmove.js adapter, hand-built fakes, no real browser, no real building"). Proves
+ * elementData()'s TWO independent narrowings (prompts/GRID_SMART_ELEMENT_SCOPE.md §4 — class allowlist +
+ * grab-locality) in total isolation from BOTH Tier 1's pure engine AND any real building: a hand-built fake
+ * window.Bonsai.group() (fake mesh-like objects with known userData.featureId/bbox), a fake
+ * window.Bonsai.oplog.db (a stub .exec() returning sql.js-shaped rows for a few hand-inserted GEOM_INSERT
+ * ops carrying known ifc_class values), and a hand-set window.Bonsai.grid.xs/ys. Every expected fid list
+ * below is worked out by hand in the comments BEFORE the assertion, not inferred from running the code once.
+ *
+ * FIXTURE (5 fake meshes, fids 1-5), draggedAxis='x' (an X-axis gridline grabbed) so elementData()'s locality
+ * filter reads each mesh's Y-coordinate (bonsai_gridmove.js's own convention: for an x-axis drag, the
+ * ORTHOGONAL coordinate is elem.y — see elementData()'s own comment on this line):
+ *   fid=1  structural (recorded ifc_class='IfcWall'),            bbox y-center = 0        (== orthoAt)
+ *   fid=2  FURNITURE  (recorded ifc_class='IfcFurnishingElement'), bbox y-center = 0       (== orthoAt — would
+ *          pass locality; must be excluded by CLASS ALONE, isolating that filter from locality)
+ *   fid=3  synthetic  (NO recorded ifc_class -- UNKNOWN, class-eligible per the "stays eligible" rule),
+ *          bbox y-center = radius + 1           (fails locality; isolates locality filtering a class-unknown/
+ *          eligible element)
+ *   fid=4  structural (recorded ifc_class='IfcWallStandardCase'), bbox y-center = radius - 0.1  (just INSIDE
+ *          the locality radius -- boundary correctness, near side)
+ *   fid=5  structural (recorded ifc_class='IfcWallStandardCase'), bbox y-center = radius + 0.1  (just OUTSIDE
+ *          the locality radius -- boundary correctness, far side; class-eligible but locality-excluded, same
+ *          shape as fid=3 but proves a KNOWN-good class doesn't buy an exemption from locality)
+ *
+ * grid.ys = [0, 2, 6] -> gaps [2, 4], maxGap = 4 -> _localityRadius('x') MUST be EXACTLY 4 * 1.5 = 6.0
+ * orthoAt = 0 (the grab point) -> fid=4 y-center = 6 - 0.1 = 5.9 (inside), fid=5 y-center = 6 + 0.1 = 6.1 (outside)
+ *
+ *   Q1 CLASS-MAP EXACT   — _buildClassByFid() returns EXACTLY the 3 recorded fids, no more/no less.
+ *   Q2 LOCALITY-RADIUS EXACT — _localityRadius('x') === 6.0 exactly, from the one unambiguous max gap.
+ *   Q3 CLASS-ALONE (no session) — elementData() with no drag session excludes ONLY fid=2 (furniture); the
+ *                        rest (1,3,4,5) stay regardless of position (locality inactive when draggedAxis==null,
+ *                        matching bonsai_gridmove.js's own documented behavior for non-session callers).
+ *   Q4 COMBINED (class AND locality) — with a session active (draggedAxis='x', orthoAt=0), elementData()
+ *                        returns EXACTLY {1,4} — fid=2 excluded by class, fid=3 and fid=5 excluded by
+ *                        locality (fid=3 despite being class-UNKNOWN/eligible, fid=5 despite being a KNOWN
+ *                        structural class), fid=4 included (inside radius, boundary case).
+ */
+'use strict';
+
+global.window = global.window || {};
+
+// ── Fake window.Bonsai.oplog.db — sql.js-shaped .exec() over 3 hand-inserted GEOM_INSERT rows ────────────
+const INSERT_ROWS = [
+  { id: 1, ifc_class: 'IfcWall' },
+  { id: 2, ifc_class: 'IfcFurnishingElement' },
+  { id: 4, ifc_class: 'IfcWallStandardCase' },
+  // fid 3 and 5 intentionally have NO recorded row (unknown class).
+];
+const fakeDb = {
+  exec(sql) {
+    if (!/kernel_ops/.test(sql)) return [];
+    return [{ columns: ['id', 'parameters'], values: INSERT_ROWS.map(r => [r.id, JSON.stringify({ ifc_class: r.ifc_class })]) }];
+  }
+};
+
+// ── Fake window.Bonsai.group() — 5 fake mesh-like objects ─────────────────────────────────────────────
+const RADIUS = 6.0; // = maxGap(4) * 1.5, hand-computed above from grid.ys=[0,2,6]
+const Y_BY_FID = { 1: 0, 2: 0, 3: RADIUS + 1, 4: RADIUS - 0.1, 5: RADIUS + 0.1 };
+function fakeMesh(fid) {
+  const y = Y_BY_FID[fid];
+  return {
+    isMesh: true,
+    userData: { featureId: fid },
+    geometry: {
+      computeBoundingBox() { /* no-op: boundingBox already set below, matches THREE's lazy-compute contract */ },
+      boundingBox: { min: { x: 0, y: y, z: 0 }, max: { x: 1, y: y, z: 1 } } // x/z irrelevant here; y is the axis under test
+    }
+  };
+}
+window.Bonsai = {
+  group() { return { children: [1, 2, 3, 4, 5].map(fakeMesh) }; },
+  oplog: { db: fakeDb },
+  grid: { xs: [0, 4, 8], ys: [0, 2, 6] } // ys gaps: 2-0=2, 6-2=4 -> maxGap=4 (unambiguous single max)
+};
+
+const path = require('path');
+require(path.join(__dirname, '..', 'bonsai_gridmove.js'));
+const GM = window.Bonsai.gridmove;
+
+let pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+function sameSet(actual, expected) {
+  const a = Array.from(actual).map(String).sort(), e = expected.map(String).sort();
+  return a.length === e.length && a.every((v, i) => v === e[i]);
+}
+
+console.log('═══ W-GRIDMOVE-ADAPTER-FAKES — Tier 2: elementData() filters, hand-built fakes, no browser/building ═══');
+
+// Q1 — class map exact
+const classMap = GM._buildClassByFid();
+chk('Q1 CLASS-MAP EXACT (only the 3 recorded fids, exact classes)',
+  Object.keys(classMap).length === 3 && classMap[1] === 'IfcWall' && classMap[2] === 'IfcFurnishingElement' && classMap[4] === 'IfcWallStandardCase',
+  JSON.stringify(classMap));
+
+// Q2 — locality radius exact
+const radius = GM._localityRadius('x');
+chk('Q2 LOCALITY-RADIUS EXACT (maxGap=4 * 1.5 = 6.0)', radius === 6.0, 'radius=' + radius);
+
+// Q3 — class filter alone (no drag session: _dragAxis stays null)
+GM._dragAxis = null; GM._dragOrthoAt = null;
+const q3fids = GM.elementData().map(e => e.guid);
+chk('Q3 CLASS-ALONE (no session): excludes ONLY fid=2 (furniture)', sameSet(q3fids, [1, 3, 4, 5]), 'got=' + JSON.stringify(q3fids));
+
+// Q4 — combined class + locality (session active: draggedAxis='x', orthoAt=0, matching beginDragSession's own
+// field-setting contract — bonsai_gridmove.js:150-151 — without needing the full engine-building session start)
+GM._dragAxis = 'x'; GM._dragOrthoAt = 0;
+const q4fids = GM.elementData().map(e => e.guid);
+chk('Q4 COMBINED (class AND locality): EXACTLY {1,4}', sameSet(q4fids, [1, 4]), 'got=' + JSON.stringify(q4fids));
+
+console.log('W-GRIDMOVE-ADAPTER-FAKES: ' + pass + ' PASS / ' + fail + ' FAIL');
+process.exit(fail ? 1 : 0);

--- a/modeller/tests/witness_gridmove_fold_pure.mjs
+++ b/modeller/tests/witness_gridmove_fold_pure.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-GRIDMOVE-FOLD-PURE: closes prompts/GRID_KINEMATICS_SANDBOX_PROOF.md §3's identified
+ * gap — "Stage 8 (the worker fold)... zero isolated coverage today. No test proves the worker fold turns a
+ * KNOWN, hand-authored GEOM_GRID_MOVE.commands array into the EXACT expected final vertex positions,
+ * independent of whether dragGrid() computed those commands correctly."
+ *
+ * §3 asked to check FIRST whether bonsai_kernel_worker.js's fold is ALSO pure/isolatable before assuming a
+ * browser-only Tier 4 test is the only way to reach it — it is: bonsai_kernel_worker.js is plain occt-wasm
+ * calls behind a postMessage protocol, no browser/DOM-specific API. This drives the REAL, UNMODIFIED file's
+ * REAL self.onmessage handler (only `self`/`postMessage` are stubbed as plumbing — zero reimplementation of
+ * the fold math itself, so this genuinely tests the shipped code, not a parallel model of it).
+ *
+ * TECHNIQUE: bonsai_kernel_worker.js is ESM (`import { OcctKernel } from './lib/kernel/index.js'`) written
+ * as a Worker entry point (no exports, just a top-level `self.onmessage=...`). Node has no ambient
+ * package.json in modeller/ marking it "type":"module" (and adding one would risk breaking the many
+ * CommonJS-via-require witnesses that already load modeller/*.js as CJS — out of scope to touch). So: copy
+ * the REAL source (read fresh off disk every run, byte-identical, never hand-edited) plus its real
+ * lib/kernel/ dependency into a throwaway temp dir with its OWN scoped package.json, preserving the exact
+ * relative layout the real `import './lib/kernel/index.js'` needs to resolve correctly. This is harness
+ * plumbing only — no math, no logic, is duplicated.
+ *
+ * GEOM_GRID_MOVE fold math under test (bonsai_kernel_worker.js's own branch, read verbatim before writing
+ * these expectations):
+ *   TRANSLATE: out = kernel.translate(shape, axis==x?d:0, axis==y?d:0, axis==z?d:0)
+ *   SCALE:     a = bbox.<axis>min; tx = a*(1-f) + translateDelta; M = axis-specific 3x4 general-transform
+ *              (min-edge anchored: far-edge stretch keeps the MIN edge fixed, near-edge stretch shifts the
+ *              min edge by exactly translateDelta) — kernel.generalTransform(shape, M)
+ *
+ * FIXTURE: one leaf GEOM_EXTRUDE_POLY (rectangle profile [0,0]-[4,0]-[4,2]-[0,2], depth=1) -> a real B-rep
+ * box with world AABB x:[0,4] y:[0,2] z:[0,1] (base case verified in T0 before any grid command is layered
+ * on, so a fixture bug can't masquerade as a fold bug). Each T1+ case is a FRESH op chain (distinct op_hash
+ * per case -> no cache collision across cases).
+ */
+'use strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOD = path.join(__dirname, '..');
+
+let pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+function approx(a, b, tol) { return Math.abs(a - b) <= (tol != null ? tol : 1e-6); }
+function aabb(positions) {
+  let xmin = Infinity, xmax = -Infinity, ymin = Infinity, ymax = -Infinity, zmin = Infinity, zmax = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    xmin = Math.min(xmin, positions[i]); xmax = Math.max(xmax, positions[i]);
+    ymin = Math.min(ymin, positions[i + 1]); ymax = Math.max(ymax, positions[i + 1]);
+    zmin = Math.min(zmin, positions[i + 2]); zmax = Math.max(zmax, positions[i + 2]);
+  }
+  return { xmin, xmax, ymin, ymax, zmin, zmax };
+}
+
+console.log('═══ W-GRIDMOVE-FOLD-PURE — §3: the worker fold, isolated in pure node against the real occt-wasm kernel ═══');
+
+// ── Mirror the real worker + its real lib/kernel/ dependency into a throwaway ESM-scoped temp dir ────────
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gridfold-witness-'));
+fs.mkdirSync(path.join(tmp, 'lib', 'kernel'), { recursive: true });
+for (const f of fs.readdirSync(path.join(MOD, 'lib', 'kernel'))) {
+  fs.copyFileSync(path.join(MOD, 'lib', 'kernel', f), path.join(tmp, 'lib', 'kernel', f));
+}
+fs.writeFileSync(path.join(tmp, 'package.json'), '{"type":"module"}');
+fs.copyFileSync(path.join(MOD, 'bonsai_kernel_worker.js'), path.join(tmp, 'worker.mjs'));
+
+globalThis.self = globalThis.self || {};
+self.postMessage = () => {}; // top-level `self.postMessage({ready:true})` fires at import time
+await import(path.join(tmp, 'worker.mjs'));
+
+function send(data) {
+  return new Promise((resolve) => {
+    self.postMessage = (msg) => { if (msg.id === data.id) resolve(msg); };
+    self.onmessage({ data });
+  });
+}
+
+const RECT = { points: [[0, 0], [4, 0], [4, 2], [0, 2]] };
+function extrudeOp(id, hashSuffix) {
+  return { id, op_hash: 'leaf:' + hashSuffix, op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: RECT, depth: 1 } };
+}
+function gridMoveOp(id, hashSuffix, delta, commands) {
+  return { id, op_hash: 'grid:' + hashSuffix, op_type: 'GEOM_GRID_MOVE', parameters: { gridId: 'gx1', delta, commands } };
+}
+
+// T0 — base case, no grid command: confirms the fixture itself is x:[0,4] y:[0,2] z:[0,1] before trusting
+// any of the deltas below.
+const r0 = await send({ id: 0, ops: [extrudeOp(1, 't0')] });
+chk('T0 base fixture AABB (no grid command)', r0.ok, r0.error);
+if (r0.ok) {
+  const b0 = aabb(r0.meshes[0].positions);
+  chk('T0 base x:[0,4] y:[0,2] z:[0,1]',
+    approx(b0.xmin, 0) && approx(b0.xmax, 4) && approx(b0.ymin, 0) && approx(b0.ymax, 2) && approx(b0.zmin, 0) && approx(b0.zmax, 1),
+    JSON.stringify(b0));
+}
+
+// T1 — TRANSLATE x by +2: x:[0,4]->[2,6], y/z unchanged.
+const r1 = await send({ id: 1, ops: [extrudeOp(1, 't1'), gridMoveOp(2, 't1', 2, [{ featureId: 1, action: 'TRANSLATE', axis: 'x', delta: 2 }])] });
+chk('T1 fold ok', r1.ok, r1.error);
+if (r1.ok) {
+  const b1 = aabb(r1.meshes[0].positions);
+  chk('T1 TRANSLATE x+2 -> x:[2,6] y:[0,2] z:[0,1] (y/z untouched)',
+    approx(b1.xmin, 2) && approx(b1.xmax, 6) && approx(b1.ymin, 0) && approx(b1.ymax, 2) && approx(b1.zmin, 0) && approx(b1.zmax, 1),
+    JSON.stringify(b1));
+}
+
+// T2 — TRANSLATE y by -1.5 (a non-x axis, to catch an axis-mux transcription bug): y:[0,2]->[-1.5,0.5].
+const r2 = await send({ id: 2, ops: [extrudeOp(1, 't2'), gridMoveOp(2, 't2', -1.5, [{ featureId: 1, action: 'TRANSLATE', axis: 'y', delta: -1.5 }])] });
+chk('T2 fold ok', r2.ok, r2.error);
+if (r2.ok) {
+  const b2 = aabb(r2.meshes[0].positions);
+  chk('T2 TRANSLATE y-1.5 -> y:[-1.5,0.5] x:[0,4] z:[0,1] (x/z untouched)',
+    approx(b2.ymin, -1.5) && approx(b2.ymax, 0.5) && approx(b2.xmin, 0) && approx(b2.xmax, 4) && approx(b2.zmin, 0) && approx(b2.zmax, 1),
+    JSON.stringify(b2));
+}
+
+// T3 — SCALE x, f=2, far edge (translateDelta=0): worker formula tx = xmin*(1-f)+0 = 0*(1-2) = 0 -> min FIXED
+// at 0, width doubles 4->8 -> x:[0,8].
+const r3 = await send({ id: 3, ops: [extrudeOp(1, 't3'), gridMoveOp(2, 't3', 4, [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: 2, translateDelta: 0 }])] });
+chk('T3 fold ok', r3.ok, r3.error);
+if (r3.ok) {
+  const b3 = aabb(r3.meshes[0].positions);
+  chk('T3 SCALE x f=2 far (td=0): min FIXED at 0, width doubles -> x:[0,8]',
+    approx(b3.xmin, 0) && approx(b3.xmax, 8), JSON.stringify({ xmin: b3.xmin, xmax: b3.xmax }));
+}
+
+// T4 — SCALE x, f=2, near edge (translateDelta=1.5): tx = 0*(1-2)+1.5 = 1.5 -> min shifts to 1.5, width
+// f*origWidth = 2*4=8 -> x:[1.5,9.5].
+const r4 = await send({ id: 4, ops: [extrudeOp(1, 't4'), gridMoveOp(2, 't4', 4, [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: 2, translateDelta: 1.5 }])] });
+chk('T4 fold ok', r4.ok, r4.error);
+if (r4.ok) {
+  const b4 = aabb(r4.meshes[0].positions);
+  chk('T4 SCALE x f=2 near (td=1.5): min shifts by td -> x:[1.5,9.5]',
+    approx(b4.xmin, 1.5) && approx(b4.xmax, 9.5), JSON.stringify({ xmin: b4.xmin, xmax: b4.xmax }));
+}
+
+// T5 — SCALE z (a 3rd distinct axis-matrix branch), f=0.5, far edge (translateDelta=0): tx = zmin*(1-f)+0 =
+// 0*(0.5) = 0 -> min FIXED at 0, width halves 1->0.5 -> z:[0,0.5].
+const r5 = await send({ id: 5, ops: [extrudeOp(1, 't5'), gridMoveOp(2, 't5', -0.5, [{ featureId: 1, action: 'SCALE', axis: 'z', newScale: 0.5, translateDelta: 0 }])] });
+chk('T5 fold ok', r5.ok, r5.error);
+if (r5.ok) {
+  const b5 = aabb(r5.meshes[0].positions);
+  chk('T5 SCALE z f=0.5 far (td=0): min FIXED at 0, width halves -> z:[0,0.5]',
+    approx(b5.zmin, 0) && approx(b5.zmax, 0.5), JSON.stringify({ zmin: b5.zmin, zmax: b5.zmax }));
+}
+
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('W-GRIDMOVE-FOLD-PURE: ' + pass + ' PASS / ' + fail + ' FAIL');
+process.exit(fail ? 1 : 0);

--- a/modeller/tests/witness_gridmove_smart_scope.js
+++ b/modeller/tests/witness_gridmove_smart_scope.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-GRIDMOVE-SMARTSCOPE: proves prompts/GRID_SMART_ELEMENT_SCOPE.md's decided fix.
+ * Real bug (confirmed 2026-07-09): a gridline drag on an opened-but-uncleared Duplex swept ~50 of its own
+ * real walls/doors/windows into ONE commit, because bonsai_gridmove.js's elementData() fed the WHOLE scene
+ * (any ifc_class, any distance) to the shared grid_kinematics.js engine, whose gridlines are otherwise
+ * infinite (classifies by along-axis centerline distance only, no locality). Fixed via two independent
+ * narrowings in elementData(): (1) a structural/enclosure ifc_class allowlist (furniture/openings/coverings
+ * excluded), (2) grab-locality (candidates scoped to near the pointerdown hit's orthogonal coordinate,
+ * radius derived from the grid's own orthogonal-axis bay spacing).
+ *
+ *   S1 CLASS-ALLOWLIST — a real Duplex furniture element is excluded from elementData() even with no active
+ *                        drag session (pure class filter, locality irrelevant).
+ *   S2 MASS-SWEEP FIXED — opening Duplex (NOT cleared), defining an overlapping synthetic grid, and dragging
+ *                        one of its lines commits a BOUNDED number of real elements (not the ~50-100 the
+ *                        unfixed code produced), and the synthetic wall's own command is still present.
+ *   S3 LOCALITY HONEST — every REAL Duplex element that DOES end up governed is provably within the derived
+ *                        bay radius of the grab point (not a coincidence — checked by direct computation).
+ *   S4 NO-REGRESSION — witness_e2e_gridstretch.js / witness_e2e_stretch_ride.js / witness_e2e_grid_greenorange.js
+ *                        still pass (run separately; this file only asserts this one's own claims, per the
+ *                        spec's §4 requirement to prove the mass-sweep is gone, not re-run siblings here).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+runE2E('W-GRIDMOVE-SMARTSCOPE', async (t) => {
+  await t.open('Duplex');
+
+  // S1: class allowlist alone (no drag session active -- draggedAxis is null, locality doesn't apply here).
+  const s1 = await t.pg.evaluate(() => {
+    const classByFid = window.Bonsai.gridmove._buildClassByFid();
+    const furnFid = Object.keys(classByFid).find(k => classByFid[k] === 'IfcFurnishingElement');
+    const present = window.Bonsai.gridmove.elementData().some(e => String(e.guid) === String(furnFid));
+    return { furnFid, present, totalArc: Object.keys(classByFid).length,
+      furnCount: Object.values(classByFid).filter(c => c === 'IfcFurnishingElement').length };
+  });
+  t.assert('S1 CLASS-ALLOWLIST (a real furniture element is excluded from elementData())',
+    s1.furnFid != null && s1.present === false, JSON.stringify(s1));
+
+  // S2/S3 setup: SAME synthetic grid+wall as witness_e2e_gridstretch.js's own proven X1, but DELIBERATELY
+  // skip #b-clear (this IS the confirmed-real bug scenario, GUIDE_VISUAL_QUALITY.md's flagged observation).
+  const wallId = await t.pg.evaluate(async () => {
+    window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+    const O = window.Bonsai.oplog;
+    const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+    if (typeof syncHistory === 'function') syncHistory();
+    return wall.id;
+  });
+  await t.clickSel('#b-fit'); await t.sleep(500);
+  const before = await t.oplog();
+
+  await t.clickSel('#b-gridmove'); await t.sleep(400);
+  const DX = 1.5;
+  const down = await t.proj(4, 1.5, 0);
+  const up = await t.proj(4 + DX, 1.5, 0);
+  await t.drag(down, up, 12);
+  await t.sleep(900);
+  const after = await t.oplog();
+  const last = await t.lastOp();
+
+  const gridMoveRow = await t.pg.evaluate(() => {
+    const db = window.Bonsai.oplog.db;
+    const r = db.exec("SELECT parameters FROM kernel_ops WHERE op_type='GEOM_GRID_MOVE' ORDER BY id DESC LIMIT 1");
+    if (!r.length) return null;
+    return JSON.parse(r[0].values[0][0]);
+  });
+  const commandCount = gridMoveRow ? gridMoveRow.commands.length : -1;
+  const hasSyntheticWall = gridMoveRow ? gridMoveRow.commands.some(c => c.featureId === wallId) : false;
+
+  t.assert('S2 MASS-SWEEP FIXED (bounded command count, not the ~50-100 the unfixed code produced)',
+    commandCount >= 1 && commandCount <= 10, 'commandCount=' + commandCount + ' (unfixed baseline was ~54)');
+  t.assert('S2b synthetic wall itself still governed (its own command present)', hasSyntheticWall, 'wallId=' + wallId);
+  t.assert('S2c op-log grew by a bounded amount (grid-move + at most a few riders/rewalk, not 9+)',
+    (after.len - before.len) >= 1 && (after.len - before.len) <= 4, 'delta=' + (after.len - before.len));
+
+  // S3: every OTHER (real, non-synthetic) element governed must be within the derived locality radius of
+  // the grab point (orthoAt=1.5 on the y axis, since we dragged an x-line) -- prove this directly, not assume it.
+  const radius = await t.pg.evaluate(() => window.Bonsai.gridmove._localityRadius('x'));
+  const realGoverned = gridMoveRow ? gridMoveRow.commands.filter(c => c.featureId !== wallId) : [];
+  const localityCheck = await t.pg.evaluate((fids) => {
+    const g = window.Bonsai.group();
+    return fids.map(fid => {
+      const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+      if (!m) return null;
+      m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+      return (b.min.y + b.max.y) / 2;
+    });
+  }, realGoverned.map(c => c.featureId));
+  const allWithinRadius = localityCheck.every(cy => cy != null && Math.abs(cy - 1.5) <= radius);
+  t.assert('S3 LOCALITY HONEST (every real governed element is within the derived bay radius of the grab point)',
+    allWithinRadius, 'radius=' + radius.toFixed(3) + ' cys=' + JSON.stringify(localityCheck));
+
+  console.log('§GRIDMOVE-SMARTSCOPE last_op=' + (last && last.op_type) + ' oplog ' + before.len + '->' + after.len +
+    ' grid_move_commands=' + commandCount + ' real_governed=' + realGoverned.length);
+}, { width: 1200, height: 850, dpr: 2 });


### PR DESCRIPTION
## Summary
- Grid-drag mass-sweep bug fixed: `bonsai_gridmove.js`'s `elementData()` now applies a structural/enclosure
  ifc-class allowlist + grab-locality radius, so dragging one gridline on a real, dense building (Duplex,
  open-not-cleared) governs a bounded few elements instead of sweeping ~43-54 unrelated real walls/doors/
  windows into one commit. Furniture stays excluded by default (ctrl+click override unchanged).
- Numeric sandbox proof (prompts/GRID_KINEMATICS_SANDBOX_PROOF.md, bim-compiler repo) closes the "AI is
  geometry blind" gap the bug hunt surfaced: 4 tiers, 122 assertions, all numeric (no screenshot treated as
  evidence) — pure-engine math, adapter fakes, real building data cross-check, and the one previously-
  untested stage (the occt-wasm worker fold) driven standalone against the real unmodified fold code.

## Test plan
- [x] `witness_gridmove_smart_scope.js` 6/6 (the real bug repro, before/after)
- [x] `witness_grid_kinematics_pure.js` 98/98 (pure engine, hand-computed)
- [x] `witness_gridmove_adapter_fakes.js` 4/4 (elementData() filters, hand-built fakes)
- [x] `witness_grid_kinematics_real_duplex.js` 8/8 (real Duplex DB rows, independent re-derivation)
- [x] `witness_gridmove_fold_pure.mjs` 12/12 (worker fold, real occt-wasm kernel, pure node)
- [x] No regression: `witness_e2e_gridstretch.js` 7/7, `witness_e2e_stretch_ride.js` 9/9,
      `witness_e2e_grid_greenorange.js` 12/12, `witness_e2e_dm_gridundo.js` 8/8,
      `witness_e2e_gridstretch_multi.js` 21/21, `witness_grid_insert.js` 6/6 — 69/69 green
- [x] Synced to current `origin/main` (merged, re-ran touched witnesses post-merge, all still green)