### PR TITLE
feat(gate): §UBBL-DEMO — 5th sdg_gate case, static UBBL-style room-size demo indicator (By-Law 42 subset)

### DIFF
--- a/modeller/sdg_gate.js
+++ b/modeller/sdg_gate.js
@@ -136,5 +136,52 @@
     return { red: red, orange: orange };
   }
 
-  return { evaluate: evaluate, penetration: penetration, faceGap: faceGap, overlaps: overlaps, CLASH_TOL: CLASH_TOL, CLEARANCE: CLEARANCE };
+  // (5) UBBL ROOM SIZE — DEMO INDICATOR (STATIC, not part of evaluate()'s delta contract).
+  // Implementing UBBL_RULES_GATE.md §2 (bim-compiler prompts) — Witness: W-UBBL-ROOM-DEMO.
+  // Unlike cases (1)-(4), which are delta-honest edit checks (a pre-existing as-extracted condition is
+  // NEVER flagged), this case is a static per-room inspection of as-extracted `spatial_structure`
+  // IfcSpace rows — the pre-existing state is exactly what it reports on. Folding it into evaluate()
+  // would violate that file-level doctrine, so it is a separate pure entry point emitting the 5th kind.
+  // NON-INVENT: the ONLY two thresholds wired are the two independently-verified numbers from
+  // UBBL_RULES_GATE.md §1b (By-Law 42): "all other rooms" floor area >= 6.5 m² and headroom >= 2.5 m.
+  // The 11 m² / 9.3 m² first/second-habitable-room tiers and any per-room-TYPE threshold are
+  // deliberately NOT built — they need a room-order/type classifier that does not exist (§1c BLOCKED);
+  // inventing a type mapping to unlock them would violate PRIME RULE. Demo/mockup scope only
+  // (user decision 2026-07-05): every output carries UBBL_DEMO_LABEL verbatim — it is an indicator,
+  // NOT a compliance verdict, and the label is the guardrail against it silently becoming one.
+  var UBBL_MIN_AREA = 6.5;      // m² — By-Law 42 "all other rooms" minimum (verified, spec §1b)
+  var UBBL_MIN_HEADROOM = 2.5;  // m  — By-Law 42 minimum headroom height (verified, spec §1b)
+  var UBBL_DEMO_LABEL = "UBBL-style demo indicator (By-Law 42, 'all other rooms' minimum only) — not a compliance verdict";
+
+  // ubblRoomSizeDemo(spaces, opts) → {kind:'ubbl-room-size', checked, flagged:[…], label}. PURE.
+  //   spaces = [{guid, name, size_x, size_y, size_z}, …]  (spatial_structure rows, type='IfcSpace' —
+  //            Duplex-extractor schema; SampleHouse predates it and has no such table: caller's concern)
+  //   opts   = {minArea, minHeadroom} — explicit params like CLEARANCE, defaults are the §1b numbers
+  // Rooms with NULL/missing dims are reported under `unmeasured`, never guessed at (non-invent).
+  function ubblRoomSizeDemo(spaces, opts) {
+    opts = opts || {};
+    var minArea = opts.minArea != null ? opts.minArea : UBBL_MIN_AREA;
+    var minHeadroom = opts.minHeadroom != null ? opts.minHeadroom : UBBL_MIN_HEADROOM;
+    var flagged = [], unmeasured = [], checked = 0;
+    (spaces || []).forEach(function (s) {
+      if (s == null || s.size_x == null || s.size_y == null || s.size_z == null) {
+        unmeasured.push({ kind: 'ubbl-room-size', guid: s && s.guid, name: s && s.name, label: UBBL_DEMO_LABEL });
+        return;
+      }
+      checked++;
+      var area = s.size_x * s.size_y;
+      var belowArea = area < minArea, belowHeadroom = s.size_z < minHeadroom;
+      if (belowArea || belowHeadroom) {
+        flagged.push({
+          kind: 'ubbl-room-size', guid: s.guid, name: s.name,
+          size_x: +s.size_x.toFixed(3), size_y: +s.size_y.toFixed(3), size_z: +s.size_z.toFixed(3),
+          area: +area.toFixed(3), belowArea: belowArea, belowHeadroom: belowHeadroom,
+          minArea: minArea, minHeadroom: minHeadroom, label: UBBL_DEMO_LABEL
+        });
+      }
+    });
+    return { kind: 'ubbl-room-size', checked: checked, flagged: flagged, unmeasured: unmeasured, label: UBBL_DEMO_LABEL };
+  }
+
+  return { evaluate: evaluate, ubblRoomSizeDemo: ubblRoomSizeDemo, penetration: penetration, faceGap: faceGap, overlaps: overlaps, CLASH_TOL: CLASH_TOL, CLEARANCE: CLEARANCE, UBBL_MIN_AREA: UBBL_MIN_AREA, UBBL_MIN_HEADROOM: UBBL_MIN_HEADROOM, UBBL_DEMO_LABEL: UBBL_DEMO_LABEL };
 });

--- a/modeller/tests/witness_ubbl_room_demo.js
+++ b/modeller/tests/witness_ubbl_room_demo.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * W-UBBL-ROOM-DEMO — §UBBL-DEMO value witness (PURE NODE, REAL Duplex). The 5th sdg_gate case:
+ * ubblRoomSizeDemo() — a STATIC per-room UBBL-style DEMO indicator over as-extracted `spatial_structure`
+ * IfcSpace rows (NOT delta-based like cases 1-4; a pre-existing undersized room is exactly what it
+ * reports). Implementing UBBL_RULES_GATE.md §2 (bim-compiler prompts). DEMO/MOCKUP SCOPE ONLY
+ * (user decision 2026-07-05) — every output must carry the not-a-compliance-verdict label verbatim.
+ * Only the two independently-verified By-Law 42 numbers are wired: area >= 6.5 m² ("all other rooms"
+ * floor), headroom >= 2.5 m. No 11/9.3 m² tiers, no per-type thresholds (spec §1c: classifier BLOCKED).
+ *
+ *   U1 real data      — Duplex's REAL spatial_structure has exactly 21 IfcSpace rooms, all measured
+ *                       (issue: does the extraction actually feed the gate 21 real rooms, or fewer?)
+ *   U2 real flags     — the gate names EXACTLY the rooms whose measured size_x*size_y < 6.5 m²
+ *                       (recomputed independently in this witness from the same DB rows — the witness
+ *                       does not trust the gate's own arithmetic), incl. spec §2's example A104
+ *                       (1.456×2.171 = 3.161 m²) (issue: does the gate flag the right real rooms with
+ *                       the right measured numbers — no false positives, no misses?)
+ *   U3 real headroom  — zero Duplex rooms sit below 2.5 m (min measured size_z = 2.581) — so the
+ *                       belowHeadroom branch CANNOT be proven on real data; U4b covers it
+ *                       (issue: is "no headroom flags" a real measurement result, not a dead branch?)
+ *   U4 synthetic fire — a 1m×1m fixture room IS flagged belowArea (issue: does the gate silently pass
+ *                       an obviously undersized room? must be NO)
+ *   U4b synthetic hdr — a 3m×3m×2.0m fixture IS flagged belowHeadroom (issue: is the headroom branch
+ *                       dead code given no real Duplex room can trip it? must be NO)
+ *   U5 label          — EVERY output (summary + each flagged row) carries the demo-indicator label
+ *                       VERBATIM (issue: can any result escape the not-a-compliance-verdict guardrail?)
+ *   U6 non-invent     — thresholds are explicit params (raise minArea to 30 ⇒ more rooms flag);
+ *                       nothing hardcoded beyond the two §1b defaults
+ *   U7 non-invent     — a room with NULL dims goes to `unmeasured`, never guessed at
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+
+var ROOT = path.join(__dirname, '..');
+var SdgGate = require(path.join(ROOT, 'sdg_gate.js'));
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'Duplex_extracted.db');
+
+var LABEL = "UBBL-style demo indicator (By-Law 42, 'all other rooms' minimum only) — not a compliance verdict";
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
+  console.log('═══ W-UBBL-ROOM-DEMO — §UBBL-DEMO static room-size indicator (node, REAL Duplex) ═══');
+  var db = new SQL.Database(fs.readFileSync(DBPATH));
+  var res = db.exec("SELECT guid, name, size_x, size_y, size_z FROM spatial_structure WHERE type='IfcSpace' ORDER BY name");
+  var spaces = (res[0] ? res[0].values : []).map(function (v) {
+    return { guid: v[0], name: v[1], size_x: v[2], size_y: v[3], size_z: v[4] };
+  });
+
+  // U1 — real data: 21 measured rooms reach the gate
+  var out = SdgGate.ubblRoomSizeDemo(spaces);
+  console.log('§UBBL-DEMO checked=' + out.checked + ' flagged=' + out.flagged.length + ' unmeasured=' + out.unmeasured.length);
+  chk('U1 real data: Duplex feeds exactly 21 measured IfcSpace rooms', out.checked === 21 && out.unmeasured.length === 0, 'checked=' + out.checked);
+
+  // U2 — real flags: witness recomputes the below-area set INDEPENDENTLY from the same DB rows
+  var expectBelow = spaces.filter(function (s) { return s.size_x * s.size_y < 6.5; }).map(function (s) { return s.name; }).sort();
+  var gotBelow = out.flagged.filter(function (f) { return f.belowArea; }).map(function (f) { return f.name; }).sort();
+  out.flagged.forEach(function (f) {
+    console.log('§UBBL-DEMO FLAG ' + f.name + ' ' + f.size_x + '×' + f.size_y + '=' + f.area + 'm² z=' + f.size_z + 'm'
+      + (f.belowArea ? ' <' + f.minArea + 'm²' : '') + (f.belowHeadroom ? ' <' + f.minHeadroom + 'm' : ''));
+  });
+  chk('U2 real flags: gate names exactly the measured below-6.5m² rooms (no misses, no false positives)',
+    JSON.stringify(gotBelow) === JSON.stringify(expectBelow) && gotBelow.length > 0,
+    'gate=[' + gotBelow + '] recomputed=[' + expectBelow + ']');
+  var a104 = out.flagged.find(function (f) { return f.name === 'A104'; });
+  chk('U2b spec §2 example A104: 1.456×2.171 = 3.161 m² < 6.5 (verified against live DB, not copied)',
+    !!a104 && a104.belowArea && Math.abs(a104.area - 3.161) < 0.001 && Math.abs(a104.size_x - 1.456) < 0.001 && Math.abs(a104.size_y - 2.171) < 0.001,
+    a104 ? a104.size_x + '×' + a104.size_y + '=' + a104.area + 'm²' : 'A104 NOT FLAGGED');
+
+  // U3 — real headroom: no Duplex room is below 2.5m, and that matches the raw measurements
+  var minZ = Math.min.apply(null, spaces.map(function (s) { return s.size_z; }));
+  var hdrFlags = out.flagged.filter(function (f) { return f.belowHeadroom; });
+  chk('U3 real headroom: zero rooms below 2.5m — consistent with min measured size_z',
+    hdrFlags.length === 0 && minZ >= 2.5, 'minZ=' + minZ.toFixed(3) + 'm hdrFlags=' + hdrFlags.length);
+
+  // U4 — synthetic fire: does the gate silently pass an obviously undersized room? Must be NO.
+  var tiny = SdgGate.ubblRoomSizeDemo([{ guid: 'FIX1', name: 'FIXTURE-1x1', size_x: 1, size_y: 1, size_z: 2.6 }]);
+  var tf = tiny.flagged[0];
+  chk('U4 synthetic 1m×1m fixture fires belowArea (gate does NOT silently pass an undersized room)',
+    tiny.flagged.length === 1 && tf.belowArea && !tf.belowHeadroom && Math.abs(tf.area - 1) < 1e-9,
+    'flagged=' + JSON.stringify(tiny.flagged));
+
+  // U4b — synthetic headroom: the belowHeadroom branch is not dead code (U3 shows real data can't trip it)
+  var low = SdgGate.ubblRoomSizeDemo([{ guid: 'FIX2', name: 'FIXTURE-LOW', size_x: 3, size_y: 3, size_z: 2.0 }]);
+  var lf = low.flagged[0];
+  chk('U4b synthetic 2.0m-headroom fixture fires belowHeadroom (branch not dead despite no real trigger)',
+    low.flagged.length === 1 && lf.belowHeadroom && !lf.belowArea, 'flagged=' + JSON.stringify(low.flagged));
+
+  // U5 — label: EVERY output carries the demo-indicator label verbatim
+  var allOuts = [out, tiny, low];
+  var labelOk = allOuts.every(function (o) {
+    return o.label === LABEL && o.flagged.every(function (f) { return f.label === LABEL; })
+      && o.unmeasured.every(function (u) { return u.label === LABEL; });
+  });
+  chk('U5 label: summary + every flagged row says the not-a-compliance-verdict label VERBATIM', labelOk, labelOk ? '"' + out.label + '"' : 'LABEL MISSING/DRIFTED');
+
+  // U6 — non-invent: thresholds are explicit params, not buried constants
+  var strict = SdgGate.ubblRoomSizeDemo(spaces, { minArea: 30 });
+  var below30 = spaces.filter(function (s) { return s.size_x * s.size_y < 30; }).length;
+  chk('U6 non-invent: minArea is an explicit param (30m² ⇒ recomputed count matches)',
+    strict.flagged.filter(function (f) { return f.belowArea; }).length === below30,
+    'flagged@30=' + strict.flagged.length + ' recomputed=' + below30);
+
+  // U7 — non-invent: NULL dims are reported unmeasured, never guessed
+  var nul = SdgGate.ubblRoomSizeDemo([{ guid: 'FIX3', name: 'FIXTURE-NULL', size_x: null, size_y: 2, size_z: 2.6 }]);
+  chk('U7 non-invent: a NULL-dim room goes to unmeasured (checked=0, flagged=0 — no guessing)',
+    nul.checked === 0 && nul.flagged.length === 0 && nul.unmeasured.length === 1 && nul.unmeasured[0].name === 'FIXTURE-NULL',
+    JSON.stringify(nul.unmeasured));
+
+  console.log('W-UBBL-ROOM-DEMO: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });


### PR DESCRIPTION
Implements `bim-compiler prompts/UBBL_RULES_GATE.md` §2 — **DEMO/MOCKUP SCOPE ONLY** (user decision 2026-07-05). Witness: **W-UBBL-ROOM-DEMO**.

## What
A 5th gate case alongside `clash`/`door-out`/`door-crush`/`clearance`/`abuts-realign` in `modeller/sdg_gate.js`: `ubblRoomSizeDemo(spaces, opts)`, kind `ubbl-room-size`. Static per-room indicator over as-extracted `spatial_structure` `IfcSpace` rows (Duplex only — SampleHouse predates the extractor version with that table).

**Design note:** NOT folded into `evaluate()` — cases 1-4 are delta-honest edit checks (pre-existing as-extracted state is never flagged); this case is a static inspection of exactly that state, so it's a separate pure entry point in the same module.

## Non-invent
Only the two independently-verified thresholds from spec §1b (By-Law 42): area ≥ 6.5 m² ("all other rooms" floor) and headroom ≥ 2.5 m. The 11/9.3 m² room-order tiers and per-type thresholds are **not** built (spec §1c: room-order/type classifier BLOCKED). Every output carries verbatim: *"UBBL-style demo indicator (By-Law 42, 'all other rooms' minimum only) — not a compliance verdict"*.

## Witness (real Duplex data, 9/9 PASS)
- 21 rooms checked, 8 flagged below 6.5 m² by measured value: A104/B104 1.456×2.171=**3.161 m²**, A105/B105 1.014×3.750=**3.804 m²**, A204 **4.731 m²**, B204 **4.755 m²**, A205 **1.419 m²**, B205 **1.396 m²**
- 0 rooms below 2.5 m headroom (min measured size_z = 2.581 m) — synthetic 2.0 m fixture proves the branch isn't dead
- Synthetic 1×1 m fixture fires belowArea (gate does not silently pass an undersized room)
- Thresholds are explicit params; NULL-dim rooms go to `unmeasured`, never guessed
- Regression: `witness_sdg_gate.js` 11/11 PASS (existing cases untouched). `witness_sdg_gate_smoke.js` fails identically on pristine main (missing `playwright` module — pre-existing env issue, not this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)