### PR TITLE
feat(disc_walker): room-type-aware _spaceTypeFor() fallback, gated to measured signal (PLB/FP)

### DIFF
--- a/modeller/disc_walker.js
+++ b/modeller/disc_walker.js
@@ -21,6 +21,14 @@
   'use strict';
   var TAG = '§DW';
   var ROOT = (typeof window !== 'undefined') ? window : {};
+  // §ROOM-TYPE-WEIGHT (prompts/DISC_WALK_ROOM_TYPE_AWARE.md, 2026-07-11): geometry-based room-type
+  // classifier (modeller/room_type_classifier.js, ported verbatim from bim-compiler) — used ONLY as a
+  // FALLBACK inside _spaceTypeFor() below, when a space's real LABEL does not resolve via the existing
+  // rule_space_type/rule_space_alias string match. Dual-mode load, same convention as every other
+  // sibling module this file already reaches for (RoomTypeClassifier = require(...) in Node, or
+  // window.RoomTypeClassifier in browser once modeller/room_type_classifier.js is <script>-tagged).
+  var RoomTypeClassifier = (typeof window !== 'undefined') ? window.RoomTypeClassifier :
+    (typeof require !== 'undefined' ? (function () { try { return require('./room_type_classifier.js'); } catch (e) { return null; } })() : null);
   var _db = null, _ready = false, _loadedFile = null;
   // §BORROW — per-discipline source map (docs/WalkerDoctrine.md §2). The PRIMARY _db is the building-class
   // ruleset (e.g. duplex_rules.db for residential). A discipline ABSENT from the residential set (e.g. FP/
@@ -30,6 +38,20 @@
   // a borrowed discipline reuses that DB's MEASURED rows; nothing is fabricated.
   var _borrow = {};                                              // disc -> borrowed sql.js db handle
   function _dbFor(disc) { return _borrow[disc] || _db; }
+  // §ROOM-TYPE-WEIGHT state: opt-in, defaults OFF (null) — every existing caller that never invokes
+  // dwSetRoomTypeConfig gets byte-identical behavior (label match only, exactly as before this change).
+  var _roomTypeConfig = null;
+  function dwSetRoomTypeConfig(config) { _roomTypeConfig = config || null; return !!_roomTypeConfig; }
+  // MEASURED disc->room-type density correlation (build/measure_disc_room_type_density.js, real Duplex
+  // MEP data, 2026-07-11): PLB and FP each show a real, replicated categorical presence/absence signal
+  // by classified room type (PLB concentrates in BATHROOM/UTILITY, ~0 elsewhere; FP concentrates in
+  // FOYER, ~0 elsewhere including HALLWAY) — see prompts/DISC_WALK_ROOM_TYPE_AWARE.md for the full table.
+  // ELEC is present in EVERY room type (no discriminating presence signal, only a density gradient that
+  // n=2-per-type cannot separate from noise) and ACMV has ZERO real elements in the only real MEP
+  // substrate this repo has (Duplex — real Malaysian residential units use split-unit A/C, not ducted
+  // diffusers) — both are honestly EXCLUDED here, never forced. Adding a disc to this set requires a
+  // NEW measured citation, not an assumption.
+  var ROOM_TYPE_MEASURED_DISCS = { PLB: true, FP: true };
   // Register/clear a borrowed discipline source. dwBorrow('FP', terminalDb) → FP rules read from terminalDb.
   function dwBorrow(disc, db) { if (db) _borrow[disc] = db; else delete _borrow[disc]; return _borrow; }
   // Browser borrow-by-FILE (docs/WalkerDoctrine.md §2): IDB-cached load + open + register a borrowed discipline
@@ -243,14 +265,51 @@
   // LongName → schedule space_type: normalize (upper, spaces→_, strip trailing numbering — the
   // same normalization H6's deriveSpaceType applied), then direct rule_space_type match, then
   // rule_space_alias ('LIVING_ROOM'→LIVING, 'HALLWAY'→CORRIDOR, ...). null = no schedule (skip).
-  function _spaceTypeFor(disc, label) {
-    if (!label) return null;
-    var norm = String(label).toUpperCase().replace(/[\s]+/g, '_').replace(/[_\s]*\d+$/, '').trim();
-    if (!norm) return null;
+  //
+  // §ROOM-TYPE-WEIGHT FALLBACK (prompts/DISC_WALK_ROOM_TYPE_AWARE.md): when the LABEL match above
+  // finds nothing (e.g. a synthetic COMPILED room with no semantic name — the case this repo's
+  // shipped non-Duplex/Terminal buildings mostly are), and the caller has loaded a room-type config
+  // (dwSetRoomTypeConfig) AND this disc has a real MEASURED density signal (ROOM_TYPE_MEASURED_DISCS —
+  // today: PLB, FP only; ELEC/ACMV honestly excluded, see that const's comment), classify the space's
+  // OWN bbox geometry (area+aspect, same features the classifier trains on) and use ITS type as a
+  // second-chance space_type — but ONLY after validating the classifier's `canonical_type` (or its own
+  // type name) actually exists in this disc's rule_space_type, so this NEVER returns a type the
+  // schedule tables don't recognize. Zero regression: this branch is unreachable whenever the label
+  // match above already succeeded, and unreachable entirely until dwSetRoomTypeConfig is called.
+  function _spaceTypeFor(disc, sp) {
+    var label = (sp && typeof sp === 'object') ? sp.label : sp;   // back-compat: a bare string still works
     var db = _dbFor(disc);
-    if (_rows(db, "SELECT 1 FROM rule_space_type WHERE value='" + _esc(norm) + "'").length) return norm;
-    var a = _rows(db, "SELECT space_type_id st FROM rule_space_alias WHERE alias='" + _esc(norm) + "'");
-    return a.length ? a[0].st : null;
+    if (label) {
+      var norm = String(label).toUpperCase().replace(/[\s]+/g, '_').replace(/[_\s]*\d+$/, '').trim();
+      if (norm) {
+        if (_rows(db, "SELECT 1 FROM rule_space_type WHERE value='" + _esc(norm) + "'").length) return norm;
+        var a = _rows(db, "SELECT space_type_id st FROM rule_space_alias WHERE alias='" + _esc(norm) + "'");
+        if (a.length) return a[0].st;
+      }
+    }
+    // ── geometry fallback ──
+    if (!_roomTypeConfig || !RoomTypeClassifier || !ROOM_TYPE_MEASURED_DISCS[disc]) return null;
+    if (!sp || typeof sp !== 'object' || sp.x0 == null || sp.x1 == null || sp.y0 == null || sp.y1 == null) return null;
+    var feats = RoomTypeClassifier.featuresFromRects([{
+      size_x: sp.x1 - sp.x0, size_y: sp.y1 - sp.y0, center_x: (sp.x0 + sp.x1) / 2, center_y: (sp.y0 + sp.y1) / 2
+    }]);
+    if (!feats) return null;
+    var result = RoomTypeClassifier.classifyRoom(feats, _roomTypeConfig);
+    if (result.unclassified || !result.type) return null;
+    var tmpl = _roomTypeConfig.templates && _roomTypeConfig.templates[result.type];
+    var candidates = [];
+    if (tmpl && tmpl.canonical_type) candidates.push(String(tmpl.canonical_type).toUpperCase());
+    candidates.push(result.type);
+    for (var i = 0; i < candidates.length; i++) {
+      if (_rows(db, "SELECT 1 FROM rule_space_type WHERE value='" + _esc(candidates[i]) + "'").length) {
+        console.log(TAG + ' §DW-ROOMTYPE ' + disc + ' space "' + (label || sp.guid || '?') + '" — no label match, ' +
+          'geometry classifier -> ' + result.type + ' (conf=' + (result.confidence * 100).toFixed(1) +
+          '%, area=' + feats.area.toFixed(2) + 'm2 aspect=' + feats.aspect.toFixed(2) + ') -> space_type=' +
+          candidates[i] + ' [measured signal: build/measure_disc_room_type_density.js]');
+        return candidates[i];
+      }
+    }
+    return null;
   }
 
   // Ported VERBATIM from SpaceScheduleDAO.resolveQty (§6.12.4 §8): per_area first;
@@ -392,7 +451,7 @@
     var avoidAll = opts.avoid || [];
     var out = [], refused = {}, skipped = [], used = 0;
     all.forEach(function (sp) {
-      var stype = _spaceTypeFor(disc, sp.label);
+      var stype = _spaceTypeFor(disc, sp);
       if (!stype) { skipped.push(sp.label); return; }
       var sched = _rows(_dbFor(disc), "SELECT * FROM rule_space_schedule WHERE disc='" + _esc(disc) +
         "' AND space_type_id='" + _esc(stype) + "'");
@@ -2202,7 +2261,8 @@
   var API = { dwInit: dwInit, dwOpen: dwOpen, dwBorrow: dwBorrow, dwBorrowFile: dwBorrowFile, dwWalk: dwWalk, assemble: assemble, connectorFor: connectorFor, connectorEnrich: connectorEnrich, substrate: substrate, place: place, hostBind: hostBind,
     route: route, routeChains: routeChains, routePattern: routePattern, gate: gate, repRules: repRules, order: order, clearance: clearance,
     hostWalls: hostWalls, countPer: countPer, occupancy: occupancy, defaultSeed: defaultSeed, spaceAsStorey: spaceAsStorey,
-    spacesOf: spacesOf, placeSchedule: placeSchedule,
+    spacesOf: spacesOf, placeSchedule: placeSchedule, dwSetRoomTypeConfig: dwSetRoomTypeConfig,
+    _spaceTypeFor: _spaceTypeFor, ROOM_TYPE_MEASURED_DISCS: ROOM_TYPE_MEASURED_DISCS,
     _shimForDisc: _shimForDisc, _shimForFixture: _shimForFixture, _loadRuleShims: _loadRuleShims,
     _trueMidpoint: _trueMidpoint,
     bendFinder: bendFinder, fittingOrientation: fittingOrientation, bendFittings: bendFittings,

--- a/modeller/room_templates.json
+++ b/modeller/room_templates.json
@@ -1,0 +1,232 @@
+{
+  "_provenance": "Mechanical JSON transcription of bim-compiler config/room_templates.yaml (2026-07-11) — every mean/std/tier value here is MEASURED (see that file's header for the full non-invent discipline + Duplex/SampleHouse source citation). Regenerate with: node -e \"const y=require('js-yaml'),fs=require('fs');fs.writeFileSync('modeller/room_templates.json', JSON.stringify(y.load(fs.readFileSync('config/room_templates.yaml','utf8')),null,2))\" from bim-compiler. Do not hand-edit numbers here — edit the yaml and regenerate.",
+  "std_floor_fraction": 0.15,
+  "unclassified_z_threshold": 2,
+  "templates": {
+    "BEDROOM": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex, SampleHouse]",
+      "tier": "primary",
+      "canonical_type": "BEDROOM",
+      "n": 5,
+      "examples": [
+        "Duplex:A202(Bedroom 1)",
+        "Duplex:B202(Bedroom 1)",
+        "Duplex:A203(Bedroom 2)",
+        "Duplex:B203(Bedroom 2)",
+        "SampleHouse:2 - Bedroom"
+      ],
+      "area_m2": {
+        "mean": 21.62,
+        "std": 3.102,
+        "min": 15.42,
+        "max": 23.17
+      },
+      "aspect_ratio": {
+        "mean": 1.605,
+        "std": 0.16,
+        "min": 1.29,
+        "max": 1.69
+      },
+      "door_count": {
+        "mean": 1,
+        "std": 0,
+        "n": 5
+      }
+    },
+    "BATHROOM": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex]",
+      "tier": "primary",
+      "canonical_type": "BATHROOM",
+      "n": 4,
+      "examples": [
+        "Duplex:A104(Bathroom 1)",
+        "Duplex:B104(Bathroom 1)",
+        "Duplex:A204(Bathroom 2)",
+        "Duplex:B204(Bathroom 2)"
+      ],
+      "area_m2": {
+        "mean": 3.952,
+        "std": 0.791,
+        "min": 3.16,
+        "max": 4.75
+      },
+      "aspect_ratio": {
+        "mean": 1.767,
+        "std": 0.276,
+        "min": 1.49,
+        "max": 2.05
+      },
+      "door_count": {
+        "mean": 2,
+        "std": 1,
+        "n": 4
+      }
+    },
+    "KITCHEN": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex]",
+      "tier": "primary",
+      "canonical_type": "KITCHEN",
+      "n": 2,
+      "examples": [
+        "Duplex:A103(Kitchen)",
+        "Duplex:B103(Kitchen)"
+      ],
+      "area_m2": {
+        "mean": 12.954,
+        "std": 0,
+        "min": 12.95,
+        "max": 12.95
+      },
+      "aspect_ratio": {
+        "mean": 2.605,
+        "std": 0,
+        "min": 2.6,
+        "max": 2.61
+      },
+      "door_count": {
+        "mean": 0,
+        "std": 0,
+        "n": 2
+      }
+    },
+    "LIVING_ROOM": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex, SampleHouse]",
+      "tier": "primary",
+      "canonical_type": "LIVING",
+      "n": 3,
+      "examples": [
+        "Duplex:A102(Living Room)",
+        "Duplex:B102(Living Room)",
+        "SampleHouse:1 - Living room"
+      ],
+      "area_m2": {
+        "mean": 35.985,
+        "std": 11.773,
+        "min": 27.66,
+        "max": 52.63
+      },
+      "aspect_ratio": {
+        "mean": 1.355,
+        "std": 0.206,
+        "min": 1.21,
+        "max": 1.65
+      },
+      "door_count": {
+        "mean": 1.333,
+        "std": 0.471,
+        "n": 3
+      }
+    },
+    "FOYER": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex]",
+      "tier": "supplementary",
+      "canonical_type": "LOBBY",
+      "n": 2,
+      "examples": [
+        "Duplex:A101(Foyer)",
+        "Duplex:B101(Foyer)"
+      ],
+      "area_m2": {
+        "mean": 20.319,
+        "std": 0,
+        "min": 20.32,
+        "max": 20.32
+      },
+      "aspect_ratio": {
+        "mean": 4.264,
+        "std": 0,
+        "min": 4.26,
+        "max": 4.26
+      },
+      "door_count": {
+        "mean": 3,
+        "std": 0,
+        "n": 2
+      }
+    },
+    "HALLWAY": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex]",
+      "tier": "supplementary",
+      "canonical_type": "CORRIDOR",
+      "n": 2,
+      "examples": [
+        "Duplex:A201(Hallway)",
+        "Duplex:B201(Hallway)"
+      ],
+      "area_m2": {
+        "mean": 10.415,
+        "std": 0,
+        "min": 10.41,
+        "max": 10.41
+      },
+      "aspect_ratio": {
+        "mean": 2.697,
+        "std": 0,
+        "min": 2.7,
+        "max": 2.7
+      },
+      "door_count": {
+        "mean": 4,
+        "std": 0,
+        "n": 2
+      }
+    },
+    "UTILITY": {
+      "confidence": "measured",
+      "source": "measured, buildings: [Duplex]",
+      "tier": "primary",
+      "canonical_type": null,
+      "n": 2,
+      "examples": [
+        "Duplex:A205(Utility)",
+        "Duplex:B205(Utility)"
+      ],
+      "area_m2": {
+        "mean": 1.408,
+        "std": 0.012,
+        "min": 1.4,
+        "max": 1.42
+      },
+      "aspect_ratio": {
+        "mean": 1.65,
+        "std": 0.014,
+        "min": 1.64,
+        "max": 1.66
+      },
+      "door_count": {
+        "mean": 3,
+        "std": 0,
+        "n": 2
+      }
+    }
+  },
+  "exceptions": {
+    "ENTRANCE_HALL": {
+      "building": "SampleHouse",
+      "example": "3 - Entrance hall",
+      "area_m2": 8.69,
+      "aspect_ratio": 2.28,
+      "note": "Not merged into FOYER or HALLWAY despite semantic proximity — different word, no invented synonym mapping. Would promote to a template on a second real occurrence.\n"
+    },
+    "STAIR": {
+      "building": "Duplex",
+      "example": "A105 (Stair)",
+      "area_m2": 3.8,
+      "aspect_ratio": 3.7,
+      "note": "z-height 5.68m (spatial_structure.size_z), well above every real room's ~2.6-2.9m — almost certainly a stairwell shaft, not a floor-level room. Kept as an exception so a future TYPE classifier revision can special-case tall-and-narrow footprints rather than folding STAIR into the size/aspect templates above.\n"
+    },
+    "ROOM": {
+      "building": "Duplex",
+      "example": "B105 (Room)",
+      "area_m2": 3.8,
+      "aspect_ratio": 3.7,
+      "note": "Identical footprint AND z-height to STAIR above (near-certainly the mirrored B-side stairwell, generically labeled \"Room\" instead of \"Stair\" in the source IFC — a labeling inconsistency in the source data, not a compiler bug). Kept SEPARATE from STAIR per its own label — merging same-dimension-different-label rows would be exactly the \"invented synonym mapping\" this file's discipline forbids. Flagged for manual review, not corrected.\n"
+    }
+  }
+}

--- a/modeller/room_type_classifier.js
+++ b/modeller/room_type_classifier.js
@@ -1,0 +1,190 @@
+// room_type_classifier.js — §ROOM-TYPE size+aspect-ratio TEMPLATE classifier
+// (prompts/ROOM_TYPE_TEMPLATE_CLASSIFIER.md, 2026-07-11, MANAGER-assigned).
+//
+// PORTED VERBATIM from bim-compiler build/room_type_classifier.js (2026-07-11,
+// prompts/DISC_WALK_ROOM_TYPE_AWARE.md) — byte-identical, same dual-mode module, no logic changed.
+// Consumer: modeller/disc_walker.js's _spaceTypeFor() geometry-classifier FALLBACK (only for
+// disciplines with a real MEASURED density signal — see disc_walker.js's ROOM_TYPE_MEASURED_DISCS
+// comment and bim-compiler build/measure_disc_room_type_density.js for the measurement).
+//
+// Scores an already-compiled, already-habitability-filtered room (area + aspect ratio, computed
+// from spatial_structure size_x/size_y — summed across a §MULTI-RECT rect-set when room_guid
+// groups multiple rows) against config/room_templates.yaml's PROBABILISTIC templates — a soft
+// independent-Gaussian likelihood per feature, NOT a hard lookup table or a fixed cutoff. Returns
+// the best-matching type WITH a confidence number; low-confidence rooms are explicitly refused
+// (`(unclassified)`), never forced into a category — same refuse-to-guess discipline as bim-ootb
+// `common/room_habitability.js`'s `spaceHabitable()`.
+//
+// NON-INVENT: every template's mean/std in config/room_templates.yaml is either FITTED from this
+// project's own real compiled room geometry (`confidence: measured`) or, if ever added later, an
+// explicitly cited external source (`confidence: prior`) — this module never invents a number of
+// its own; see config/room_templates.yaml's header comment for the full discipline and the
+// landmine (3 already-conflicting hand-typed "UBBL bedroom size" values elsewhere in this repo)
+// it exists to not repeat.
+//
+// Dual-mode (Node `require` + browser `<script>` global), same convention as room_walker.js /
+// bim-ootb common/room_habitability.js — module.exports when present, window.RoomTypeClassifier
+// otherwise. Depends only on a pre-parsed templates object (see loadTemplateConfig below); no
+// direct file/DB I/O here so it can run identically in-browser (fetch+js-yaml) or in Node (fs+
+// js-yaml, see build/witness_room_type_classifier.js for the Node-side loader).
+//
+// §DOOR-ACCESS (prompts/ROOM_TYPE_DOOR_ACCESS_SIGNAL.md, 2026-07-11): a SECOND signal —
+// countAdjacentDoors() + an optional 3rd quadrature dimension in scoreTemplate()/classifyRoom() —
+// added alongside the original area+aspect scorer (unchanged math when door data isn't supplied).
+// See build/measure_door_counts.js for how config/room_templates.yaml's `door_count` bands were
+// measured from Duplex/SampleHouse ground truth, same non-invent discipline as area/aspect.
+(function () {
+  'use strict';
+  var TAG = '§ROOM-TYPE';
+  var ROOT = (typeof window !== 'undefined') ? window : {};
+
+  // Same trailing-mirrored-digit-strip convention as bim-ootb common/room_habitability.js's
+  // spaceHabitable() label normalization (ported, not re-derived) + a leading-ordinal-prefix
+  // strip for SampleHouse's "1 - Living room" LongName convention. See config/room_templates.yaml
+  // METHODOLOGY comment for why this does NOT become a synonym dictionary across different words.
+  function normalizeLabel(label) {
+    var s = String(label == null ? '' : label).trim();
+    s = s.replace(/^\d+\s*[-.]\s*/, '');             // leading "1 - " / "2. "
+    s = s.toUpperCase().replace(/\s+/g, '_');
+    s = s.replace(/_?\d+$/, '');                      // trailing "_1"/"1" mirrored-unit suffix
+    return s;
+  }
+
+  // area + aspect ratio from a rect-set (array of {size_x, size_y}) — §8 MULTI-RECT: area is a
+  // plain sum (sub-rects are non-overlapping by construction, verified W-ROOM-FILL), aspect ratio
+  // is computed on the BOUNDING ENVELOPE of the set (ROOM_INJECTION_HYBRID.md §8 recipe), not any
+  // single sub-rect. For a single-rect room the envelope IS that one rect, so the two paths agree.
+  function featuresFromRects(rects) {
+    if (!rects || !rects.length) return null;
+    var area = 0, x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity;
+    for (var i = 0; i < rects.length; i++) {
+      var r = rects[i];
+      if (r.size_x == null || r.size_y == null) continue;
+      area += r.size_x * r.size_y;
+      var cx = r.center_x, cy = r.center_y;
+      if (cx != null) { x0 = Math.min(x0, cx - r.size_x / 2); x1 = Math.max(x1, cx + r.size_x / 2); }
+      if (cy != null) { y0 = Math.min(y0, cy - r.size_y / 2); y1 = Math.max(y1, cy + r.size_y / 2); }
+    }
+    if (area <= 0) return null;
+    var envX = (x1 > x0) ? (x1 - x0) : rects[0].size_x;
+    var envY = (y1 > y0) ? (y1 - y0) : rects[0].size_y;
+    var aspect = (envX > 0 && envY > 0) ? Math.max(envX, envY) / Math.min(envX, envY) : null;
+    return { area: area, aspect: aspect, envX: envX, envY: envY };
+  }
+
+  // §DOOR-ACCESS (prompts/ROOM_TYPE_DOOR_ACCESS_SIGNAL.md, 2026-07-11): count of real doors
+  // adjacent to a room's rect-set — the SECOND discriminating signal, alongside area+aspect.
+  // Reuses scripts/compile_rooms.py's own door-adjacency buffer test (_door_adjacent: buf =
+  // max(door.bbox_x, door.bbox_y)/2 + DOOR_BUFFER_SLACK), extended from a boolean "has-door" check
+  // to a COUNT — this does NOT rebuild compile_rooms.py's door-rescue/door-partition DECISION logic
+  // (which walls get rasterized into which pocket, §4 non-goal); it only reads the already-decided
+  // room footprint + real IfcDoor geometry. DOOR_BUFFER_SLACK below is PORTED as-is (0.20m =
+  // compile_rooms.py's RES constant), not a new invented number.
+  //
+  // Caller contract (this module stays DB/file-I/O-free, same convention as featuresFromRects):
+  // `doors` must already be pre-filtered to the room's OWN STOREY (mirrors compile_rooms.py's
+  // storey_doors() grouping doors by storey before testing adjacency — an un-storey-filtered test
+  // was measured to badly over-count on Duplex, see build/measure_door_counts.js log). A door
+  // counts once even if it touches multiple sub-rects of a §MULTI-RECT room.
+  var DOOR_BUFFER_SLACK = 0.20; // ported from scripts/compile_rooms.py DOOR_BUFFER_SLACK/RES
+  function countAdjacentDoors(rects, doors) {
+    if (!rects || !rects.length || !doors || !doors.length) return 0;
+    var count = 0;
+    for (var i = 0; i < doors.length; i++) {
+      var d = doors[i];
+      if (d.center_x == null || d.center_y == null) continue;
+      var buf = Math.max(d.bbox_x || 0, d.bbox_y || 0) / 2 + DOOR_BUFFER_SLACK;
+      var hit = false;
+      for (var j = 0; j < rects.length && !hit; j++) {
+        var r = rects[j];
+        if (r.center_x == null || r.center_y == null || r.size_x == null || r.size_y == null) continue;
+        var rx0 = r.center_x - r.size_x / 2, rx1 = r.center_x + r.size_x / 2;
+        var ry0 = r.center_y - r.size_y / 2, ry1 = r.center_y + r.size_y / 2;
+        if (rx0 - buf <= d.center_x && d.center_x <= rx1 + buf && ry0 - buf <= d.center_y && d.center_y <= ry1 + buf)
+          hit = true;
+      }
+      if (hit) count++;
+    }
+    return count;
+  }
+
+  // Effective std at classify time: smooths a degenerate/underestimated measured std toward
+  // std_floor_fraction * mean. See config/room_templates.yaml header — the stored std is always
+  // the RAW measured value; this floor is applied here only, never baked into the config.
+  function effStd(measuredStd, mean, floorFraction) {
+    var floor = Math.abs(mean) * floorFraction;
+    return Math.max(measuredStd, floor, 1e-6); // 1e-6 absolute floor: never literally divide by 0
+  }
+
+  // Independent-feature Gaussian likelihood (unnormalized) + combined quadrature z-distance.
+  // §DOOR-ACCESS: a 3rd dimension (zDoor) joins the quadrature IFF the template carries a measured
+  // `door_count` stat AND the caller supplied `features.doorCount` — graceful degradation to the
+  // original 2D area+aspect score otherwise (e.g. a caller that hasn't wired door adjacency, or a
+  // template with no promoted door_count band). Never a hard filter/veto — same soft-likelihood
+  // shape as the existing 2 dimensions, per ROOM_TYPE_DOOR_ACCESS_SIGNAL.md §2's "second dimension
+  // in the confidence score" option (picked over a hard filter: see that doc's write-up for why).
+  function scoreTemplate(features, tmpl, floorFraction) {
+    var aStd = effStd(tmpl.area_m2.std, tmpl.area_m2.mean, floorFraction);
+    var pStd = effStd(tmpl.aspect_ratio.std, tmpl.aspect_ratio.mean, floorFraction);
+    var zArea = (features.area - tmpl.area_m2.mean) / aStd;
+    var zAspect = (features.aspect - tmpl.aspect_ratio.mean) / pStd;
+    var zSq = zArea * zArea + zAspect * zAspect;
+    var zDoor = null;
+    if (tmpl.door_count && features.doorCount != null) {
+      var dStd = effStd(tmpl.door_count.std, tmpl.door_count.mean, floorFraction);
+      zDoor = (features.doorCount - tmpl.door_count.mean) / dStd;
+      zSq += zDoor * zDoor;
+    }
+    var z = Math.sqrt(zSq);
+    var likelihood = Math.exp(-0.5 * zSq);
+    return { z: z, zArea: zArea, zAspect: zAspect, zDoor: zDoor, likelihood: likelihood };
+  }
+
+  // classifyRoom(features, config) -> { type, confidence, z, scores:[{type,likelihood,z,posterior}],
+  //   unclassified: bool, why }
+  // features = { area, aspect } (m^2, dimensionless). config = parsed config/room_templates.yaml
+  // (templates + std_floor_fraction + unclassified_z_threshold — see loadTemplateConfig).
+  function classifyRoom(features, config) {
+    if (!features || features.area == null || features.aspect == null)
+      return { type: null, confidence: 0, unclassified: true, why: 'no-features', scores: [] };
+    var floorFraction = config.std_floor_fraction != null ? config.std_floor_fraction : 0.15;
+    var names = Object.keys(config.templates || {});
+    var scores = names.map(function (name) {
+      var s = scoreTemplate(features, config.templates[name], floorFraction);
+      return { type: name, likelihood: s.likelihood, z: s.z, zArea: s.zArea, zAspect: s.zAspect };
+    });
+    if (!scores.length) return { type: null, confidence: 0, unclassified: true, why: 'no-templates', scores: [] };
+    var sumLik = scores.reduce(function (a, s) { return a + s.likelihood; }, 0);
+    scores.forEach(function (s) { s.posterior = sumLik > 0 ? s.likelihood / sumLik : 0; });
+    scores.sort(function (a, b) { return b.likelihood - a.likelihood; });
+    var best = scores[0];
+    var threshold = config.unclassified_z_threshold != null ? config.unclassified_z_threshold : 2.0;
+    if (best.z > threshold) {
+      return { type: null, confidence: best.posterior, unclassified: true, z: best.z,
+        why: 'z=' + best.z.toFixed(2) + '>' + threshold + ' (nearest=' + best.type + ')',
+        nearest: best.type, scores: scores };
+    }
+    return { type: best.type, confidence: best.posterior, unclassified: false, z: best.z, scores: scores };
+  }
+
+  // loadTemplateConfig(parsedYaml) — thin validation/normalization pass over a js-yaml-parsed
+  // config/room_templates.yaml object. Does NOT parse YAML itself (kept dependency-free/dual-mode
+  // — caller supplies the already-parsed object, e.g. via js-yaml in Node or a browser YAML lib).
+  function loadTemplateConfig(parsed) {
+    if (!parsed || typeof parsed !== 'object') throw new Error(TAG + ' loadTemplateConfig: empty config');
+    if (!parsed.templates) throw new Error(TAG + ' loadTemplateConfig: no templates{} block');
+    return parsed;
+  }
+
+  var API = {
+    normalizeLabel: normalizeLabel,
+    featuresFromRects: featuresFromRects,
+    countAdjacentDoors: countAdjacentDoors,
+    DOOR_BUFFER_SLACK: DOOR_BUFFER_SLACK,
+    scoreTemplate: scoreTemplate,
+    classifyRoom: classifyRoom,
+    loadTemplateConfig: loadTemplateConfig,
+  };
+  ROOT.RoomTypeClassifier = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})();

--- a/modeller/tests/witness_disc_room_type_weight.js
+++ b/modeller/tests/witness_disc_room_type_weight.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-DW-ROOMTYPE scope (read this block first)
+ * SCOPE: prompts/DISC_WALK_ROOM_TYPE_AWARE.md — proves the room-type-aware geometry-classifier
+ * FALLBACK added to disc_walker.js's _spaceTypeFor() (2026-07-11). The fallback only fires when
+ * (a) a space's real label does NOT resolve via rule_space_type/rule_space_alias, (b) a room-type
+ * config has been loaded via dwSetRoomTypeConfig(), and (c) the discipline is one with a real
+ * MEASURED density signal (ROOM_TYPE_MEASURED_DISCS = {PLB, FP} — see build/measure_disc_room_type_
+ * density.js in bim-compiler for the measurement this is cited to). ELEC/ACMV are excluded on the
+ * SAME measurement (no discriminating signal found — ELEC present in every room type, ACMV has 0
+ * real elements in the only real MEP substrate). Read the log after every run.
+ *
+ * CLAIMS:
+ *   W1 OFF-BY-DEFAULT — before dwSetRoomTypeConfig is ever called, an unlabeled space's _spaceTypeFor
+ *                        returns null for every disc, IDENTICAL to pre-change behavior (zero regression
+ *                        for every caller that never opts in).
+ *   W2 FALLBACK-FIRES  — after loading the config, an UNLABELED bathroom-shaped space resolves to
+ *                        space_type=BATHROOM for disc=PLB (a measured-signal disc).
+ *   W3 DISC-GATED      — the SAME unlabeled bathroom-shaped space, same config loaded, returns null
+ *                        for disc=ELEC (not a measured-signal disc — honest refuse, not silently
+ *                        applied everywhere).
+ *   W4 LABEL-WINS      — a space WITH a real matching label ("Bathroom 1") resolves via the existing
+ *                        label path and is NEVER overridden by the geometry fallback, even when loaded.
+ *   W5 FOYER-FP        — an unlabeled FOYER-shaped space resolves for disc=FP (the second measured
+ *                        signal) but not for disc=ACMV (unmeasured).
+ *   W6 REGRESSION      — placeSchedule() end-to-end on a small synthetic Duplex-like substrate (real
+ *                        duplex_rules.db) produces IDENTICAL placement counts with the config loaded vs
+ *                        not loaded, for a building where every room already carries a real label (the
+ *                        Duplex-shape scenario) — proves the fallback is additive-only, never a rewrite.
+ */
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('sql.js');
+
+var ROOT = path.join(__dirname, '..', '..');
+var DW = require(path.join(ROOT, 'modeller', 'disc_walker.js'));
+var RoomTypeConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'modeller', 'room_templates.json'), 'utf8'));
+var LOG = path.join(ROOT, 'logs', 'witness_disc_room_type_weight_' +
+  new Date().toISOString().replace(/[:.]/g, '').slice(0, 15) + '.log');
+
+var _lines = [];
+function log(s) { _lines.push(s); console.log(s); }
+var pass = 0, fail = 0;
+function assert(claim, cond, detail) {
+  if (cond) { pass++; log('  ✅ ' + claim + ' — ' + detail); }
+  else { fail++; log('  ❌ ' + claim + ' — ' + detail); }
+}
+
+function rows(db, sql) {
+  var r = db.exec(sql); if (!r.length) return [];
+  return r[0].values.map(function (v) { var o = {}; r[0].columns.forEach(function (c, i) { o[c] = v[i]; }); return o; });
+}
+function loadDb(SQL, file) { return new SQL.Database(new Uint8Array(fs.readFileSync(file))); }
+
+// A synthetic building db (elements_meta + element_transforms) with two spaces:
+//  - a REAL-labeled bathroom ("Bathroom 1", matches rule_space_type directly)
+//  - an UNLABELED bathroom-shaped space (generic synthetic name, mirrors a COMPILED room with no
+//    semantic label — the exact gap the geometry fallback exists to close)
+//  - an UNLABELED foyer-shaped space
+// Dimensions taken from config/room_templates.yaml's own measured means (BATHROOM area=3.952m2
+// aspect=1.767; FOYER area=20.319m2 aspect=4.264) so the classifier scores them near-zero-z.
+function buildSyntheticDb(SQL) {
+  var db = new SQL.Database();
+  db.run('CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT, element_name TEXT, discipline TEXT, storey TEXT)');
+  db.run('CREATE TABLE element_transforms (guid TEXT, center_x REAL, center_y REAL, center_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL)');
+  function addSpace(guid, label, cx, cy, bx, by) {
+    db.run("INSERT INTO elements_meta VALUES ('" + guid + "','IfcSpace','" + label + "','ARC','L1')");
+    db.run('INSERT INTO element_transforms VALUES (\'' + guid + '\',' + cx + ',' + cy + ',1.4,' + bx + ',' + by + ',2.6)');
+  }
+  // BATHROOM template: area=3.952 aspect=1.767 -> pick bx=2.639, by=1.497 (area=3.951, aspect=1.763)
+  addSpace('LABELED_BATH', 'Bathroom 1', 0, 0, 2.639, 1.497);
+  addSpace('SYNTH_BATH', 'SPACE_042', 10, 0, 2.639, 1.497);       // no semantic label
+  // FOYER template: area=20.319 aspect=4.264 -> bx=9.290, by=2.179 (area=20.24, aspect=4.264)
+  addSpace('SYNTH_FOYER', 'SPACE_099', 20, 0, 9.290, 2.179);      // no semantic label
+  return db;
+}
+
+(async function main() {
+  log('═══ W-DW-ROOMTYPE — room-type-aware geometry-classifier FALLBACK in disc_walker.js _spaceTypeFor() ═══');
+  var SQL = await initSqlJs();
+
+  var RULES = path.join(ROOT, 'modeller', 'duplex_rules.db');
+  var rdb = loadDb(SQL, RULES);
+  DW.dwOpen(rdb);
+
+  var sdb = buildSyntheticDb(SQL);
+  var spaces = DW.spacesOf(sdb);
+  log('§DW-ROOMTYPE synthetic spaces: ' + spaces.map(function (s) { return s.label; }).join(', '));
+  var labeledBath = spaces.filter(function (s) { return s.guid === 'LABELED_BATH'; })[0];
+  var synthBath = spaces.filter(function (s) { return s.guid === 'SYNTH_BATH'; })[0];
+  var synthFoyer = spaces.filter(function (s) { return s.guid === 'SYNTH_FOYER'; })[0];
+  assert('M0 SPACES-FOUND', !!labeledBath && !!synthBath && !!synthFoyer,
+    'all 3 synthetic spaces enumerated by spacesOf(): ' + spaces.length);
+
+  // ── W1 OFF-BY-DEFAULT ──
+  log('');
+  log('─── W1 OFF-BY-DEFAULT ───');
+  var beforePLB = DW._spaceTypeFor('PLB', synthBath);
+  var beforeFP = DW._spaceTypeFor('FP', synthFoyer);
+  assert('W1 OFF-BY-DEFAULT', beforePLB === null && beforeFP === null,
+    'before dwSetRoomTypeConfig: unlabeled spaces resolve to null for PLB(' + beforePLB + ') and FP(' + beforeFP +
+    ') — identical to pre-change behavior, zero regression for callers that never opt in');
+
+  // ── load config, now the fallback is reachable ──
+  var loaded = DW.dwSetRoomTypeConfig(RoomTypeConfig);
+  log('§DW-ROOMTYPE dwSetRoomTypeConfig loaded=' + loaded + ' templates=[' + Object.keys(RoomTypeConfig.templates).join(', ') + ']');
+
+  // ── W2 FALLBACK-FIRES (PLB, measured signal) ──
+  log('');
+  log('─── W2 FALLBACK-FIRES ───');
+  var afterPLB = DW._spaceTypeFor('PLB', synthBath);
+  assert('W2 FALLBACK-FIRES', afterPLB === 'BATHROOM',
+    'unlabeled bathroom-shaped space (area=3.95m2 aspect=1.76) -> PLB space_type=' + afterPLB + ' (expected BATHROOM)');
+
+  // ── W3 DISC-GATED (ELEC, no measured signal) ──
+  log('');
+  log('─── W3 DISC-GATED ───');
+  var afterELEC = DW._spaceTypeFor('ELEC', synthBath);
+  assert('W3 DISC-GATED', afterELEC === null,
+    'SAME unlabeled bathroom-shaped space, config loaded, disc=ELEC -> ' + afterELEC +
+    ' (expected null — ELEC has no measured discriminating signal, honestly excluded from ROOM_TYPE_MEASURED_DISCS)');
+  log('§DW-ROOMTYPE ROOM_TYPE_MEASURED_DISCS=' + JSON.stringify(DW.ROOM_TYPE_MEASURED_DISCS));
+
+  // ── W4 LABEL-WINS ──
+  log('');
+  log('─── W4 LABEL-WINS ───');
+  var labeledPLB = DW._spaceTypeFor('PLB', labeledBath);
+  assert('W4 LABEL-WINS', labeledPLB === 'BATHROOM',
+    'real-labeled space ("Bathroom 1") resolves via the existing label path -> ' + labeledPLB +
+    ' (same result as the geometry fallback here BY COINCIDENCE of the synthetic dims — the important claim is ' +
+    'this NEVER queries the classifier when a label already resolved; see source: label branch returns before ' +
+    'the geometry block is reached)');
+
+  // ── W5 FOYER-FP ──
+  log('');
+  log('─── W5 FOYER-FP ───');
+  var foyerFP = DW._spaceTypeFor('FP', synthFoyer);
+  var foyerACMV = DW._spaceTypeFor('ACMV', synthFoyer);
+  assert('W5 FOYER-FP', foyerFP === 'LOBBY' && foyerACMV === null,
+    'unlabeled foyer-shaped space (area=20.24m2 aspect=4.26) -> FP space_type=' + foyerFP +
+    ' (expected LOBBY, FOYER\'s canonical_type in rule_space_type vocabulary) ; ACMV=' + foyerACMV +
+    ' (expected null — ACMV has 0 real elements in the measured substrate, no signal to cite)');
+
+  // ── W6 REGRESSION — placeSchedule end-to-end identical with/without config loaded, when every
+  // real room already carries a resolvable label (the actual Duplex shape: this proves the fallback
+  // never fires, let alone changes anything, once the label path already succeeds for 100% of spaces).
+  log('');
+  log('─── W6 REGRESSION (placeSchedule identical whether or not the fallback is loaded) ───');
+  var allLabeled = new SQL.Database();
+  allLabeled.run('CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT, element_name TEXT, discipline TEXT, storey TEXT)');
+  allLabeled.run('CREATE TABLE element_transforms (guid TEXT, center_x REAL, center_y REAL, center_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL, rotation_x REAL, rotation_y REAL, rotation_z REAL)');
+  allLabeled.run("INSERT INTO elements_meta VALUES ('B1','IfcSpace','Bathroom 1','ARC','L1')");
+  allLabeled.run('INSERT INTO element_transforms VALUES (\'B1\',0,0,1.4,2.639,1.497,2.6,0,0,0)');
+  var rdb2 = loadDb(SQL, RULES); DW.dwOpen(rdb2);
+  var withoutCfg = DW.placeSchedule('PLB', allLabeled, {});
+  DW.dwSetRoomTypeConfig(RoomTypeConfig);
+  var withCfg = DW.placeSchedule('PLB', allLabeled, {});
+  assert('W6 REGRESSION', withoutCfg.placements.length === withCfg.placements.length &&
+    withoutCfg.spacesUsed === withCfg.spacesUsed && withoutCfg.skippedSpaces.length === withCfg.skippedSpaces.length,
+    'placeSchedule on an all-labeled substrate: without config=' + withoutCfg.placements.length + ' placements/' +
+    withoutCfg.spacesUsed + ' spacesUsed, with config=' + withCfg.placements.length + ' placements/' + withCfg.spacesUsed +
+    ' spacesUsed — identical, the fallback never engages once labels already resolve');
+
+  log('');
+  log('───────────────────────────────────────────────');
+  log('W-DW-ROOMTYPE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  try { fs.mkdirSync(path.dirname(LOG), { recursive: true }); fs.writeFileSync(LOG, _lines.join('\n')); log('§LOG ' + LOG); } catch (e) {}
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
- `prompts/DISC_WALK_ROOM_TYPE_AWARE.md` (bim-compiler): measured real discipline x room-type element density on the only real MEP-bearing substrate with per-room space data (Duplex — Terminal has 0 real IfcSpace rows, honestly refused as a substrate).
- Found real, replicated categorical signal for PLB (concentrates in BATHROOM/UTILITY, ~0 elsewhere) and FP (concentrates in FOYER, ~0 elsewhere).
- Wires the two real signals into `disc_walker.js`'s `_spaceTypeFor()` as an opt-in geometry-classifier FALLBACK (`modeller/room_type_classifier.js`, ported from bim-compiler + `modeller/room_templates.json`) — off by default, byte-identical behavior when not configured (proven by witness W1/W6).
- ELEC/ACMV explicitly refused (no measured discriminating signal) — `ROOM_TYPE_MEASURED_DISCS={"PLB":true,"FP":true}` only.

## Test plan
- [x] CI fast-checks + e2e-tests (auto-merge armed, squash)
- [x] `modeller/tests/witness_disc_room_type_weight.js` 7/7 PASS (re-run after rebase onto current main, this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)