### PR TITLE
fix(tests): retarget W-UX-DISC B5/B6 MEP-refusal oracle SampleCastle -> Clinic

### DIFF
--- a/modeller/tests/witness_modeller_disc_walk.js
+++ b/modeller/tests/witness_modeller_disc_walk.js
@@ -3,7 +3,9 @@
  * W-UX-DISC — headless witness for "Disc = walker" (RESUME_MODELLER_UX_OUTLINER_PILL §W-UX-4):
  *   • a discipline node in the bom-graph is a clickable WALKER entry point (carries data-disc + a ▶ glyph)
  *   • click STR → SURFACES the real STR walk (swbInit done at Open) + expands the STR Walker tab
- *   • click MEP on SampleCastle → RouteWalker has no anchors for it → HONEST refusal, NO fabricated run
+ *   • click MEP on Clinic → generic 'MEP' has no measured rule in terminal_rules.db → HONEST refusal, NO fabricated run
+ *     (retargeted from SampleCastle 2026-07-11 — SampleCastle_ARC.db is ARC-only since feat/embed-8-arc-buildings;
+ *      see bim-compiler prompts/WITNESS_SAMPLECASTLE_MEP_STALE.md. Clinic_ARC.db: ARC|1984 MEP|99 PLB|3 STR|534.)
  *
  * Wiring gate (TestArchitecture §Browser Testing); the STR walk VALUES are proven by the node W-STR-* suite.
  * Serves viewer/ + the repo modeller/ residents (the live ../modeller/<db> playground).
@@ -77,14 +79,26 @@ async function openResidentAndSeed(page, key) {
   var strTabOpen = await page.evaluate(function () { return window.Bonsai.outliner._collapsed['tcat|strwalk'] === false; });
   chk('B4 STR Walker tab expanded on STR click', strTabOpen);
 
-  // ── MEP disc → honest refusal (SampleCastle has MEP but RouteWalker has no anchors for it) ───────
-  await openResidentAndSeed(page, 'SampleCastle');
+  // ── MEP disc → honest refusal (Clinic ships MEP|99 meta rows, but the generic 'MEP' disc has NO
+  //    measured rule in terminal_rules.db — Clinic is column-framed → _dwRules routes it there) ─────
+  // Retargeted from SampleCastle (WITNESS_SAMPLECASTLE_MEP_STALE.md, 2026-07-11): SampleCastle_ARC.db
+  // is ARC-only (ARC|3342, zero MEP rows) since feat/embed-8-arc-buildings, so its MEP node no longer
+  // exists — a test-oracle drift, same pattern fix/terminal-oracle-source (PR #725) fixed elsewhere.
+  await openResidentAndSeed(page, 'Clinic');
   var mepEl = await page.waitForSelector('#bo-tree [data-disc="MEP"]', { timeout: 30000 }).catch(function () { return null; });
-  chk('B5 SampleCastle exposes an MEP disc node', !!mepEl);
+  chk('B5 Clinic exposes an MEP disc node', !!mepEl);
 
   logs.length = 0;
   var sweepsBefore = await page.evaluate(function () { return (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP'; }).length : 0; });
-  await page.click('#bo-tree [data-disc="MEP"]');
+  // Harness robustness: if B5 found no MEP node this click throws — catch it (and skip it entirely
+  // when mepEl is null, so we don't burn page.click's own 30s selector timeout) so B6-B8 still tally
+  // as honest FAILs instead of the whole suite crashing on an uncaught TimeoutError.
+  if (mepEl) {
+    try { await page.click('#bo-tree [data-disc="MEP"]'); }
+    catch (e) { logs.push('HARNESS click [data-disc="MEP"] threw: ' + e.message); }
+  } else {
+    logs.push('HARNESS no [data-disc="MEP"] node — click skipped, B6 will tally as FAIL');
+  }
   // discWalk MEP is async (rwInit + route); wait for its honest-refusal (or routed) log to land
   await page.waitForTimeout(900);
   var sweepsAfter = await page.evaluate(function () { return (window.Bonsai.oplog && window.Bonsai.oplog.db) ? window.Bonsai.oplog._geomOps().filter(function (o) { return o.op_type === 'GEOM_SWEEP'; }).length : 0; });


### PR DESCRIPTION
## Summary
`SampleCastle_ARC.db` is genuinely ARC-only from source (confirmed deliberate — even the pre-embed `SampleCastle_extracted.db` has zero MEP rows), so `witness_modeller_disc_walk.js`'s B5/B6 (MEP disc node → honest refusal) was asserting against a building that can never have an MEP disc node to click. Retargeted to Clinic (real MEP rows, correctly triggers an honest refusal via `terminal_rules.db`). Also fixes a real crash-on-missing-node bug in the harness.

Follow-up to `prompts/WITNESS_SAMPLECASTLE_MEP_STALE.md`, dispatched after Manager+Sonnet jointly confirmed #724 (`fable/dwprobe-dedup`) was wrongly blocked by this same stale assertion.

## Test plan
- [x] `witness_modeller_disc_walk.js`: 8/8 PASS (re-verified independently by both Fable and Manager).
- [x] Only the one test file changed, no database touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)