### PR TITLE
fix(viewer): Find panel Disc axis shows friendly discipline words, not raw codes

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2616,11 +2616,13 @@
       var set = new Set();
       try {
         var ph = labels.map(function() { return '?'; }).join(',');
+        // `labels` are always raw codes (data-find-parent values) — the query never sees the friendly word.
         A.dbQuery("SELECT guid FROM elements_meta WHERE " + col + " IN (" + ph + ")", labels)
           .forEach(function(r) { set.add(r[0]); });
       } catch (e) { console.warn('[RP-TB] §AXIS_GROUP_ERR', e.message); }
-      // top-level group: storey/disc solid, building 0.2.
-      _drillSelect(set, labels.join(', '), (mode === 'storey' ? 'STOREY' : 'DISC') + '_SELECT', { isItem: false });
+      // top-level group: storey/disc solid, building 0.2. Display-only friendly relabel for disc.
+      var _dispLabels = (mode === 'disc') ? labels.map(friendlyDisc) : labels;
+      _drillSelect(set, _dispLabels.join(', '), (mode === 'storey' ? 'STOREY' : 'DISC') + '_SELECT', { isItem: false });
     }
 
     // §RP-SHAPE L4: storey/disc → type → INDIVIDUAL ITEM. Lazy children for a Type leaf.
@@ -2818,6 +2820,10 @@
 
     function _treeNode(label, count, level, opts) {
       opts = opts || {};
+      // §DISC_LABELS display-only relabel: `value` is the underlying identity used for
+      // multi-select/query/data-find-parent (defaults to `label` — unchanged for every other
+      // axis). Disc mode passes opts.value = the raw code while `label` carries the friendly word.
+      var value = (opts.value !== undefined && opts.value !== null) ? opts.value : label;
       var row = document.createElement('div');
       row.className = 'find-tree-row'; // §FOCUS: tag every row (any depth) so the last-clicked gets the band
       var isParent = level === 0;
@@ -2847,8 +2853,10 @@
       row.appendChild(arrow);
       row.appendChild(text);
       row.appendChild(badge);
-      // §NAV_FIND_002: tag parent rows so multi-select range/highlight can read DOM order
-      if (isParent) row.setAttribute('data-find-parent', label);
+      // §NAV_FIND_002: tag parent rows so multi-select range/highlight can read DOM order.
+      // Tag with `value` (raw code for disc, same as label elsewhere) — this is what
+      // _selDiscs/_axisGroupSelect/the SQL query actually key on, never the friendly text.
+      if (isParent) row.setAttribute('data-find-parent', value);
 
       // Hover
       row.addEventListener('pointerenter', function() {
@@ -2907,18 +2915,19 @@
           var ctrl = e.ctrlKey || e.metaKey;
           var shift = e.shiftKey;
           var mod = shift ? 'shift' : (ctrl ? 'ctrl' : 'plain');
+          // §DISC_LABELS: identity/selection keys off `value` (raw code), never the friendly `label`.
           if (shift && _anchor !== null) {
             var labels = _orderedParentLabels();
-            var ai = labels.indexOf(_anchor), bi = labels.indexOf(label);
+            var ai = labels.indexOf(_anchor), bi = labels.indexOf(value);
             if (ai >= 0 && bi >= 0) {
               sel.clear();
               for (var k = Math.min(ai, bi); k <= Math.max(ai, bi); k++) sel.add(labels[k]);
-            } else { sel.clear(); sel.add(label); _anchor = label; }
+            } else { sel.clear(); sel.add(value); _anchor = value; }
           } else if (ctrl) {
-            if (sel.has(label)) sel.delete(label); else sel.add(label);
-            _anchor = label;
+            if (sel.has(value)) sel.delete(value); else sel.add(value);
+            _anchor = value;
           } else {
-            sel.clear(); sel.add(label); _anchor = label;
+            sel.clear(); sel.add(value); _anchor = value;
           }
           _applyParentHighlight();
           var arr = Array.from(sel);
@@ -2929,7 +2938,9 @@
           // single result-item click (line ~3027), so a group's cost + push button were never visible.
           var _elSelText = document.getElementById('find-selected-text');
           if (arr.length) {
-            if (_elSelText) _elSelText.textContent = arr.join(', ') + ' · ' + arr.length + ' ' + _treeMode + (arr.length > 1 ? 's' : '');
+            // Display friendly words for disc mode; storey codes are already human (e.g. "Level 1").
+            var _dispArr = (_treeMode === 'disc') ? arr.map(friendlyDisc) : arr;
+            if (_elSelText) _elSelText.textContent = _dispArr.join(', ') + ' · ' + arr.length + ' ' + _treeMode + (arr.length > 1 ? 's' : '');
             elSelected.style.display = 'flex';
           } else {
             elSelected.style.display = 'none';
@@ -3026,7 +3037,10 @@
         if (!disc) return;
         if (filter && disc.toLowerCase().indexOf(filter) < 0) return;
 
-        var node = _treeNode(disc, discCnt, 0, {
+        // §DISC_LABELS: render the friendly word, but `value: disc` keeps the raw code as the
+        // multi-select/query identity (data-find-parent, _selDiscs, A.filterDisc — unchanged).
+        var node = _treeNode(friendlyDisc(disc), discCnt, 0, {
+          value: disc,
           children: true,
           multiSelect: true, // §NAV_FIND_002: _doTap manages selection + filter
           onExpand: function(container) {
@@ -3042,7 +3056,7 @@
                 container.appendChild(_treeNode(friendlyClass(ifc), tp[1], 1, {
                   children: true, // §RP-SHAPE L4: arrow expands → individual items
                   // §RP-SHAPE: tap a Type leaf → light that type's shapes, discipline solid, rest 0.2
-                  onTap: function() { _typeShapeDrill('discipline', disc, ifc, friendlyClass(ifc) + ' @ ' + disc); },
+                  onTap: function() { _typeShapeDrill('discipline', disc, ifc, friendlyClass(ifc) + ' @ ' + friendlyDisc(disc)); },
                   onExpand: function(c) { if (c._loaded) return; c._loaded = true; _typeItemChildren(c, 'discipline', disc, ifc); }
                 }));
               });
@@ -3635,6 +3649,16 @@
       return c;
     }
 
+    // §OUTLINER_TAXONOMY_REDESIGN.md §2 Layer 1: DISPLAY-ONLY word mapping for the raw discipline
+    // CODE stored in elements_meta.discipline (ACMV/ELEC/PLB/FP/MEP/STR/ARC). Every filter/query/
+    // A.filterDisc still runs on the raw code — this only swaps the rendered text. Fixed list, no
+    // invented mapping for a code outside it (unmapped code falls back to itself, never blank).
+    var DISC_LABELS = {
+      ACMV: 'Air-Conditioning', ELEC: 'Electrical', PLB: 'Plumbing', PLMB: 'Plumbing',
+      FP: 'Fire Protection', STR: 'Structure', ARC: 'Architecture', MEP: 'Mechanical & Electrical'
+    };
+    function friendlyDisc(code) { return DISC_LABELS[code] || code; }
+
     function classIcon(ifcClass) {
       var c = (ifcClass || '').toLowerCase();
       if (c.includes('door')) return '\uD83D\uDEAA';
@@ -3741,7 +3765,7 @@
         document.getElementById('info-guid').textContent = rows[0][2] || '—';
         document.getElementById('info-building').textContent = rows[0][3] || '—';
         document.getElementById('info-storey').textContent = rows[0][4] || '—';
-        document.getElementById('info-disc').textContent = rows[0][5] || '—';
+        document.getElementById('info-disc').textContent = rows[0][5] ? friendlyDisc(rows[0][5]) : '—';
         document.getElementById('info-material').textContent = rows[0][6] || '—';
         document.getElementById('info-panel').style.display = 'block';
         var snagRow = document.getElementById('snag-btn-row');

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -87,6 +87,16 @@ var ICONS = {
   waypoints:   { svg: '<circle cx="12" cy="4.5" r="2.5"/><path d="m10.2 6.3-3.9 3.9"/><circle cx="4.5" cy="12" r="2.5"/><path d="M7 12h10"/><circle cx="19.5" cy="12" r="2.5"/><path d="m13.8 17.7 3.9-3.9"/><circle cx="12" cy="19.5" r="2.5"/>', trl: null, key: null, desc: 'Untangle Graph' }
 };
 
+// §OUTLINER_TAXONOMY_REDESIGN.md §2 Layer 1: DISPLAY-ONLY word mapping for the raw discipline
+// CODE (ACMV/ELEC/PLB/FP/MEP/STR/ARC) as stored in elements_meta.discipline / BOM discipline
+// names. Every filter/query/DocCanvas.setActiveDisc still runs on the raw code — this only
+// swaps rendered text. Fixed list, unmapped code falls back to itself (never blank/invented).
+var DISC_LABELS = {
+  ACMV: 'Air-Conditioning', ELEC: 'Electrical', PLB: 'Plumbing', PLMB: 'Plumbing',
+  FP: 'Fire Protection', STR: 'Structure', ARC: 'Architecture', MEP: 'Mechanical & Electrical'
+};
+function friendlyDisc(code) { return DISC_LABELS[code] || code; }
+
 // HISTORY_KNOB_DIAL.md — the W pill's long-press drawer.
 //   §2026-07-06: Z (docHist) moved OUT to its own row in the Navigate drawer (see panels.js
 //   _actions 'docHist') — only the dangerous bomb (clear history, warns first) stays hidden here.
@@ -939,7 +949,7 @@ function setupPanels(A) {
             row.appendChild(ic);
             // Label
             var lbl = document.createElement('span');
-            lbl.textContent = d;
+            lbl.textContent = friendlyDisc(d);
             lbl.style.cssText = 'color:' + (_discColorMap[d] || '#ccc') + ';font:bold 13px monospace;';
             row.appendChild(lbl);
             // Active indicator

--- a/viewer/tests/witness_disc_friendly_labels_2026-07-12.js
+++ b/viewer/tests/witness_disc_friendly_labels_2026-07-12.js
@@ -1,0 +1,233 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: prompts/Viewer/OUTLINER_TAXONOMY_REDESIGN.md §2 Layer 1 — the Find panel's Disc axis
+// (and the Doc Canvas discipline popup in panels.js) rendered the RAW discipline CODE stored in
+// elements_meta.discipline (ACMV/ELEC/PLB/FP/MEP/STR/ARC) straight to the user with no friendly
+// word anywhere. Fix (navigate_find.js + panels.js, both DISPLAY-ONLY):
+//   - navigate_find.js: DISC_LABELS/friendlyDisc(); _buildDiscTree() now calls
+//     _treeNode(friendlyDisc(disc), discCnt, 0, { value: disc, ... }) — `_treeNode` gained an
+//     `opts.value` (defaults to label) so the multi-select set / data-find-parent / SQL filter
+//     keep keying off the RAW code while the rendered text is the friendly word. Every downstream
+//     query (_axisGroupSelect → "WHERE discipline IN (...)") still receives raw codes.
+//   - panels.js: same DISC_LABELS/friendlyDisc(), wired into the Doc Canvas discipline popup
+//     label (`lbl.textContent`); DocCanvas.setActiveDisc(d,...) still gets the raw code `d`.
+// This witness proves, on the REAL loaded Duplex building (light/fast, disciplines MEP/ARC/STR
+// all present, all three in the fixed DISC_LABELS map so no "invented" fallback is exercised):
+//   1. Real user path to open Find (rail pill -> drawer row Find), same convention as
+//      witness_isolate_zoom_2026-07-12.js — do not invent a different open path.
+//   2. Cycle the axis toggle to 'disc' — every top-level tree row's RENDERED TEXT is the friendly
+//      word (e.g. "Structure"), never the raw code, while its `data-find-parent` attribute (the
+//      actual multi-select/query identity) stays the RAW code (e.g. "STR") — proves the
+//      label/value decoupling, not just a cosmetic string swap that would break filtering.
+//   3. Tapping a disc row still filters correctly on the RAW code: [RP-TB] §FIND_MULTISEL logs
+//      sel=[STR] (raw, not "Structure"), the #find-selected-text status bar shows the FRIENDLY
+//      word, and the row's own count badge matches a direct SQL COUNT for that raw discipline
+//      code (before/after: badge count is read from the SAME query the tree itself ran, so a
+//      mismatch here would mean the display swap silently broke the underlying filter).
+//   4. panels.js's friendlyDisc() (a separate, independently-scoped copy — panels.js is a plain
+//      top-level script, not a closure like navigate_find.js) maps every DISC_LABELS key
+//      correctly and falls back to the raw code for an unmapped one (never blank/invented).
+// §-log first — READ tests/witness_disc_friendly_labels_2026-07-12.log before any conclusion.
+// Run:  timeout 90 node viewer/tests/witness_disc_friendly_labels_2026-07-12.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function waitReady(page) {
+  let ready = false;
+  for (let i = 0; i < 60 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false)); } catch (e) {}
+  }
+  return ready;
+}
+
+async function tap(page, id) {
+  const hit = await page.evaluate((eid) => {
+    const el = document.getElementById(eid);
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, id);
+  await page.waitForTimeout(400);
+  return hit;
+}
+
+async function cycleAxisTo(page, targetAxis) {
+  for (let i = 0; i < 6; i++) {
+    const cur = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      return b ? b.getAttribute('data-axis') : null;
+    });
+    if (cur === targetAxis) return cur;
+    const clicked = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      if (!b) return false;
+      b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      return true;
+    });
+    if (!clicked) return null;
+    await page.waitForTimeout(300);
+  }
+  return page.evaluate(() => {
+    const b = document.getElementById('find-axis-toggle');
+    return b ? b.getAttribute('data-axis') : null;
+  });
+}
+
+// The fixed mapping this witness expects (mirrors navigate_find.js/panels.js DISC_LABELS —
+// kept here ONLY as the independent expected-value oracle, not shared code with the fix).
+const EXPECT = { ACMV: 'Air-Conditioning', ELEC: 'Electrical', PLB: 'Plumbing', PLMB: 'Plumbing',
+  FP: 'Fire Protection', STR: 'Structure', ARC: 'Architecture', MEP: 'Mechanical & Electrical' };
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+
+  S('── witness_disc_friendly_labels (Duplex) ──');
+  await page.goto('http://127.0.0.1:' + server.address().port +
+    '/viewer/viewer.html?db=buildings/Duplex_extracted.db',
+    { waitUntil: 'networkidle' });
+  const ready = await waitReady(page);
+  verdict(ready, 'real model loaded + ready (Duplex)');
+  if (!ready) {
+    S('\n❌ ABORT — model never became ready');
+    fs.writeFileSync(path.join(__dirname, 'witness_disc_friendly_labels_2026-07-12.log'), log.join('\n') + '\n');
+    await browser.close(); server.close(); process.exit(1);
+  }
+
+  // 0. panels.js friendlyDisc() — plain top-level global, cheap to check directly without
+  // driving the whole Doc Canvas UI (which needs BOM storeys/disciplines data to open its popup).
+  const panelsCheck = await page.evaluate((expect) => {
+    if (typeof window.friendlyDisc !== 'function') return { ok: false, reason: 'window.friendlyDisc missing' };
+    const out = {};
+    Object.keys(expect).forEach(k => { out[k] = window.friendlyDisc(k); });
+    out['ZZZ_UNMAPPED'] = window.friendlyDisc('ZZZ_UNMAPPED'); // never blank/invented — falls back to itself
+    return { ok: true, out: out };
+  }, EXPECT);
+  verdict(panelsCheck.ok, 'panels.js window.friendlyDisc() is a global function');
+  if (panelsCheck.ok) {
+    let allMatch = true;
+    Object.keys(EXPECT).forEach(k => { if (panelsCheck.out[k] !== EXPECT[k]) allMatch = false; });
+    verdict(allMatch, 'panels.js friendlyDisc() maps every DISC_LABELS code correctly', JSON.stringify(panelsCheck.out));
+    verdict(panelsCheck.out['ZZZ_UNMAPPED'] === 'ZZZ_UNMAPPED', 'panels.js friendlyDisc() falls back to the raw code for an unmapped code (never blank/invented)');
+  }
+
+  // 1. Real user path: rail pill Navigate -> drawer row Find -> A.openFindPanel('')
+  await page.waitForFunction(() => window._mainPillActions && window._mainPillActions.length > 0, { timeout: 15000 }).catch(() => {});
+  await page.click('#mobile-trigger', { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(300);
+  const railHit = await tap(page, 'pill-navigate');
+  verdict(railHit, 'Navigate rail pill (#pill-navigate) present + tapped');
+  const rowHit = await tap(page, 'drawer-row-find');
+  verdict(rowHit, 'Find drawer row (#drawer-row-find) present + tapped (fires A.openFindPanel(""))');
+  await page.waitForTimeout(500);
+
+  // 2. Cycle to the Disc axis.
+  const axisDisc = await cycleAxisTo(page, 'disc');
+  verdict(axisDisc === 'disc', 'Disc axis reachable via toggle', 'axis=' + axisDisc);
+  if (axisDisc !== 'disc') {
+    S('\n❌ ABORT — could not reach Disc axis');
+    fs.writeFileSync(path.join(__dirname, 'witness_disc_friendly_labels_2026-07-12.log'), log.join('\n') + '\n');
+    await browser.close(); server.close(); process.exit(1);
+  }
+  await page.waitForTimeout(300);
+
+  // 3. Every top-level disc row: rendered TEXT = friendly word, data-find-parent (the actual
+  // multi-select/query identity) = RAW code. Also cross-check the badge count against a direct
+  // SQL COUNT for that raw code (proves the underlying filter query is untouched by the relabel).
+  const rows = await page.evaluate((expect) => {
+    const els = Array.from(document.querySelectorAll('.find-tree-row[data-find-parent]'));
+    return els.map(el => {
+      const value = el.getAttribute('data-find-parent');
+      const textSpan = el.children[1], badgeSpan = el.children[2];
+      const sqlCount = window.APP.dbQuery('SELECT COUNT(*) FROM elements_meta WHERE discipline = ?', [value])[0][0];
+      return {
+        value: value,
+        renderedText: textSpan ? textSpan.textContent : null,
+        badgeText: badgeSpan ? badgeSpan.textContent : null,
+        sqlCount: sqlCount
+      };
+    });
+  }, EXPECT);
+  verdict(rows.length > 0, 'Disc axis rendered at least one top-level row', 'n=' + rows.length);
+  S('     [info] disc rows: ' + JSON.stringify(rows));
+
+  rows.forEach(r => {
+    const expected = EXPECT[r.value] || r.value;
+    verdict(r.renderedText === expected, 'disc="' + r.value + '" renders friendly text "' + expected + '"',
+      'got="' + r.renderedText + '"');
+    verdict(r.renderedText !== r.value || !EXPECT[r.value] || EXPECT[r.value] === r.value,
+      'disc="' + r.value + '" renders WORD not raw code (unless the mapping IS identity)',
+      'rendered="' + r.renderedText + '" raw="' + r.value + '"');
+    verdict(r.badgeText === '(' + r.sqlCount + ')', 'disc="' + r.value + '" badge count matches direct SQL COUNT (filter untouched)',
+      'badge=' + r.badgeText + ' sql=' + r.sqlCount);
+  });
+
+  // 4. Tap one row (STR — Structure, Duplex's smallest disc group) and confirm the underlying
+  // multi-select/filter still keys off the RAW code, while the status bar shows the friendly word.
+  const strRow = rows.find(r => r.value === 'STR');
+  if (strRow) {
+    cons.length = 0;
+    const tapped = await page.evaluate((val) => {
+      const row = document.querySelector('.find-tree-row[data-find-parent="' + val + '"]');
+      if (!row) return false;
+      const text = row.children[1];
+      text.dispatchEvent(new PointerEvent('pointerup', { bubbles: false }));
+      return true;
+    }, 'STR');
+    verdict(tapped, 'STR disc row tapped (text/onTap = multi-select)');
+    await page.waitForTimeout(400);
+
+    const multiselLines = cons.filter(t => t.indexOf('§FIND_MULTISEL') >= 0);
+    verdict(multiselLines.length >= 1, '§FIND_MULTISEL logged', 'lines=' + multiselLines.length);
+    multiselLines.forEach(l => S('     [console] ' + l));
+    const rawInLog = multiselLines.some(l => l.indexOf('sel=[STR]') >= 0);
+    verdict(rawInLog, '§FIND_MULTISEL sel=[STR] uses the RAW code (not "Structure") — filter/query untouched');
+
+    const selText = await page.evaluate(() => {
+      const el = document.getElementById('find-selected-text');
+      return el ? el.textContent : null;
+    });
+    verdict(!!selText && selText.indexOf('Structure') === 0, '#find-selected-text status bar shows the FRIENDLY word', 'text="' + selText + '"');
+    verdict(!!selText && selText.indexOf('STR') !== 0, '#find-selected-text does NOT lead with the raw code', 'text="' + selText + '"');
+
+    // data-active row after tap must be the SAME raw-code row (selection identity survived the relabel).
+    const activeVal = await page.evaluate(() => {
+      const el = document.querySelector('.find-tree-row[data-active="1"]');
+      return el ? el.getAttribute('data-find-parent') : null;
+    });
+    verdict(activeVal === 'STR', 'the highlighted (data-active) row is keyed on RAW code "STR"', 'active=' + activeVal);
+  } else {
+    verdict(false, 'STR disc row present in Duplex to drive the tap check (unexpected building composition)');
+  }
+
+  await page.close(); await ctx.close();
+  await browser.close();
+  server.close();
+
+  S('\n' + (fails === 0 ? '✅ ALL PASS' : '❌ ' + fails + ' FAILED'));
+  fs.writeFileSync(path.join(__dirname, 'witness_disc_friendly_labels_2026-07-12.log'), log.join('\n') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- The Find panel's Disc axis tree, its multi-select status bar, the IFC info panel, and the Doc Canvas discipline popup rendered `elements_meta.discipline` raw codes (ACMV/ELEC/PLB/FP/MEP/STR/ARC) directly to the user — no friendly-word mapping existed anywhere (`OUTLINER_TAXONOMY_REDESIGN.md` §2 Layer 1).
- Adds a small `DISC_LABELS`/`friendlyDisc()` lookup (fixed list, unmapped code falls back to itself — never blank/invented) independently in `viewer/navigate_find.js` and `viewer/panels.js`.
- `_treeNode()` gained an `opts.value` (defaults to `label`) so the Disc tree's multi-select set / `data-find-parent` / SQL filter keep keying off the RAW code while only the rendered text changes. `A.filterDisc` and every discipline query are untouched — display-only relabel.

## Test plan
- [x] `node -c` syntax check on both files
- [x] `timeout 90 node viewer/tests/witness_disc_friendly_labels_2026-07-12.js` — 22/22 pass on Duplex (disciplines MEP/ARC/STR):
  - every Disc row renders the friendly word ("Mechanical & Electrical"/"Architecture"/"Structure"), `data-find-parent` stays the raw code
  - row badge count matches a direct SQL `COUNT(*)` for that raw code (filter query untouched)
  - tapping a row logs `§FIND_MULTISEL sel=[STR]` (raw code, not "Structure") and the status bar shows the friendly word
  - `panels.js`'s `window.friendlyDisc()` maps every code correctly and falls back to the raw code for an unmapped one

🤖 Generated with [Claude Code](https://claude.com/claude-code)