### PR TITLE
fix(viewer): bump navigate_find.js cache-bust to v=46

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -144,7 +144,7 @@ async function initViewer() {
         // consumed by navigate_find.js's Room axis "Path" sub-mode. Same lazy-load rationale as
         // room_habitability.js above (only needed alongside navigate_find.js itself).
         '../common/room_graph.js?v=1',
-        'navigate_find.js?v=45',
+        'navigate_find.js?v=46',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',


### PR DESCRIPTION
## Summary
PRs #747 (room-box purple highlight) and #748 (DISC friendly labels) both changed
navigate_find.js's content after #746 set the `?v=45` cache-bust param, without
bumping it further — a browser that fetched `navigate_find.js?v=45` before #747/#748
landed keeps serving that stale copy indefinitely (the lazy-load URL never changes
again). This bumps it to v=46 so the fetch URL changes and picks up the latest content.

`viewer/sw.js` CACHE_VERSION is already at v744 (bumped independently by #751) — no
SW change needed here, this is the one remaining stale-cache path.

## Test plan
- [x] node --check viewer/main.js
- [x] Single-line, non-functional change (cache-bust param only)