### PR TITLE
fix(viewer): keyboard shortcuts dead on touch-capable desktops + dead Record binding

### DIFF
--- a/viewer/config.js
+++ b/viewer/config.js
@@ -4,7 +4,12 @@
 
 // §S282b: Platform detection — set once, before any UI module reads it.
 // pill_builder.js, scene.js, time_machine.js all read window._isMobile at init.
-window._isMobile = ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+// Touch capability alone isn't enough — touchscreen laptops/2-in-1s/desktop monitors are
+// touch-capable but not mobile. Require a narrow screen too, matching the width-gated
+// _isMobile already used locally in effects.js/streaming.js. Without this, every keyboard
+// shortcut (scene.js's keydown handler returns immediately when window._isMobile is true)
+// silently stops firing on any touch-capable desktop.
+window._isMobile = (('ontouchstart' in window || navigator.maxTouchPoints > 0) && window.screen.width < 1024);
 
 function setupConfig(A) {
   const _params = new URLSearchParams(location.search);

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -778,54 +778,6 @@ async function setupScene(A) {
   };
   window.addEventListener('resize', A._onResize);
 
-  // ── §S277d: Movie Maker — canvas recording to MP4 ──
-  // Desktop only. MediaRecorder + canvas.captureStream.
-  A._recording = false;
-  A._mediaRecorder = null;
-  A._recordChunks = [];
-  // §S280: Record removed from pill — accessible via Help palette (R shortcut)
-  console.log('§RECORD_READY MediaRecorder=' + (typeof MediaRecorder !== 'undefined'));
-  window.toggleRecord = function() {
-    if (A._recording) {
-      // Stop recording
-      if (A._mediaRecorder && A._mediaRecorder.state !== 'inactive') A._mediaRecorder.stop();
-      return;
-    }
-    // Start recording
-    try {
-      var stream = A.canvas.captureStream(30);  // 30fps
-      var options = { mimeType: 'video/webm;codecs=vp9' };
-      if (!MediaRecorder.isTypeSupported(options.mimeType)) {
-        options = { mimeType: 'video/webm;codecs=vp8' };
-        if (!MediaRecorder.isTypeSupported(options.mimeType)) {
-          options = { mimeType: 'video/webm' };
-        }
-      }
-      A._recordChunks = [];
-      A._mediaRecorder = new MediaRecorder(stream, options);
-      A._mediaRecorder.ondataavailable = function(e) { if (e.data.size > 0) A._recordChunks.push(e.data); };
-      A._mediaRecorder.onstop = function() {
-        A._recording = false;
-        if (_recBtn) { _recBtn.style.background = ''; _recBtn.style.color = ''; _recBtn.classList.remove('active'); }
-        var blob = new Blob(A._recordChunks, { type: options.mimeType });
-        var url = URL.createObjectURL(blob);
-        var a = document.createElement('a');
-        a.href = url;
-        a.download = 'bim-ootb-' + new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19) + '.webm';
-        a.click();
-        URL.revokeObjectURL(url);
-        console.log('§RECORD_STOP chunks=' + A._recordChunks.length + ' size=' + (blob.size / 1024 / 1024).toFixed(1) + 'MB');
-        A._recordChunks = [];
-      };
-      A._mediaRecorder.start(100);  // collect data every 100ms
-      A._recording = true;
-      if (_recBtn) { _recBtn.style.background = '#ff2222'; _recBtn.style.color = '#fff'; _recBtn.classList.add('active'); }
-      console.log('§RECORD_START mime=' + options.mimeType + ' fps=30');
-    } catch(e) {
-      console.warn('§RECORD_FAIL ' + e.message);
-    }
-  };
-
   // ══════════════════════════════════════════════════════════════
   // S251: Key Sequence Engine + Command Palette + Panel Focus
   // Implementing S251_keyboard_modes.md — Witness: W-KBD
@@ -1055,7 +1007,10 @@ async function setupScene(A) {
       if (typeof A.toggleMeasure === 'function') A.toggleMeasure();
     },
     // §S280: -/+/= panel toggle removed — [] button replaces (single=F11, double=toggle panels)
-    'r':  function() { if (typeof toggleRecord === 'function') toggleRecord(); },
+    // 'r' (Record/Movie Maker) removed — the pill button + its DOM ref (_recBtn) were deleted in
+    // the pill-drawer reorg (§DELETIONS, e433ac4) but this binding + window.toggleRecord() were
+    // left behind, throwing ReferenceError: _recBtn is not defined on every press. No live caller
+    // left anywhere in the codebase — matches the reorg's own "no longer in use, delete" verdict.
     'a':  function() { if (typeof window.resetCamOrbit === 'function') window.resetCamOrbit(); },   // Reset cam (Anchor) — precision-cam cluster w/ CapsLock+Q
     'q':  function() { if (typeof window.toggleCamPivot === 'function') window.toggleCamPivot(); },  // Auto-Pivot toggle
     'Ctrl+S': function() { if (A.saveModelDb) A.saveModelDb(); },   // Save Building → native Save As…


### PR DESCRIPTION
## Summary
- `window._isMobile` (config.js) was gated on touch capability alone, unlike the width-checked `_isMobile` used elsewhere (effects.js/streaming.js). On any touch-capable desktop (touchscreen laptop, 2-in-1, touch monitor) this silently killed scene.js's entire keydown handler — reported as "Ctrl+O/Q/A/etc. don't work". Aligned to the existing width-gated pattern (`navigator.maxTouchPoints > 0 && screen.width < 1024`).
- Removed the dead `'r'` (Record/Movie Maker) shortcut binding and `window.toggleRecord()` — leftover from the pill-drawer reorg (`e433ac4`) which deleted the record button + its `_recBtn` DOM ref but missed these two remaining callers. Every `r` press threw `ReferenceError: _recBtn is not defined`.

## Test plan
- [x] Live-verified via headless Playwright against a real building (`Duplex_extracted.db`), not code-reading alone
- [x] R/Q/A/Ctrl+O all fire clean, 0 pageerrors
- [x] Simulated touch-capable desktop viewport (`hasTouch:true`, 1400×900) now resolves `_isMobile=false` and routes Ctrl+O correctly — this exact scenario was broken pre-fix
- [x] Full re-sweep of all 17 letter/ctrl shortcuts (Q/A/M/R/C/X/T/L/N/B/V/H/I/F/P/Z/W) post-fix — 0 pageerrors, no regressions