### PR TITLE
fix(sw): bump CACHE_VERSION v745→v746 for split-DB pair fix

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v745';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v746';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Follow-up to #764 — that PR changed streaming.js after v745 was already active, so its fix never reached a live browser via the cache-first SW precache. See commit message for detail.