### PR TITLE
fix(viewer): cache-bust room_graph.js v=2 (occupant graph + stair chaining reach live browsers)

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -143,7 +143,7 @@ async function initViewer() {
         // VIEWER_FIND_PANEL_ROOM_ACCURACY.md §7 — room-to-room adjacency graph + pathfinding,
         // consumed by navigate_find.js's Room axis "Path" sub-mode. Same lazy-load rationale as
         // room_habitability.js above (only needed alongside navigate_find.js itself).
-        '../common/room_graph.js?v=1',
+        '../common/room_graph.js?v=2',
         'navigate_find.js?v=48',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',


### PR DESCRIPTION
Two shipped engine changes (#759, #763) behind an unchanged ?v=1 — returning browsers keep the stale room graph. Same one-line convention as #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jx78TyWKJdHhhreXtFqmbh