### PR TITLE
fix(viewer): Room Lens selected-room cuboid — dispose previous highlight before drawing new one

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1763,11 +1763,32 @@
       A.scene.add(mesh);
       return mesh;
     }
+    // §ROOM-CUBOID-STALE-FIX (2026-07-13, user-reported screenshot RoomOverSize.png): every call
+    // pushed a NEW fill/wire/wireOuter trio into `_roomBoxes` under the SAME fixed guid keys, but
+    // never removed the PREVIOUS trio first — the dim-other-shells pass in _roomSelect() (which
+    // runs before this) only lowers old cuboid meshes to opacity 0.04, it never disposes them, so
+    // an earlier-selected (possibly larger) room's cuboid lingered in the scene as a faint ghost
+    // box — most visible in its wireframe (depthTest:false → always draws on top regardless of
+    // opacity). Strip any existing cuboid entries first so exactly ONE selected-room cuboid exists.
+    function _clearRoomCuboid() {
+      var kept = [];
+      _roomBoxes.forEach(function(rb) {
+        if (rb.guid === '_cuboidFill' || rb.guid === '_cuboidWireOuter' || rb.guid === '_cuboidWire') {
+          if (rb.mesh) {
+            if (rb.mesh.parent) rb.mesh.parent.remove(rb.mesh);
+            if (rb.mesh.geometry) rb.mesh.geometry.dispose();
+            if (rb.mesh.material) rb.mesh.material.dispose();
+          }
+        } else kept.push(rb);
+      });
+      _roomBoxes = kept;
+    }
     // §ROOM-CUBOID: the SELECTED room as a crisp soft-purple box — faint translucent fill + a bright
     // WIREFRAME of the 12 cuboid edges that shines THROUGH geometry (depthTest off), so the room
     // reads as a clean volume from any angle. Both tracked in _roomBoxes for disposal.
     function _drawRoomCuboid(center, size) {
       if (!A.scene || typeof THREE === 'undefined') return;
+      _clearRoomCuboid();
       var boxGeo = new THREE.BoxGeometry(size.x, size.y, size.z);
       var fillMat = new THREE.MeshBasicMaterial({ color: 0x9c6ade, transparent: true, opacity: 0.5,
         depthWrite: false, side: THREE.DoubleSide });


### PR DESCRIPTION
## Summary
- User-reported via screenshot (`~/Pictures/Screenshots/RoomOverSize.png`): selecting a room in
  the Room Lens shows the correct purple cuboid, but an older, larger wireframe box from a
  PREVIOUS selection also lingers faintly in the scene.
- Root cause: `_drawRoomCuboid()` in `viewer/navigate_find.js` pushed a new fill/wire/wireOuter
  mesh trio into `_roomBoxes` on every call under fixed guid keys, but never removed the previous
  trio first. `_roomSelect()`'s "dim other shells" pass only lowers old cuboid opacity to 0.04, it
  never disposes — and the wireframe uses `depthTest:false`, so even a 4%-opacity ghost box always
  renders on top and stays visible.
- Fix: strip existing cuboid entries (remove from scene + dispose geometry/material) before adding
  the new trio — same dispose-before-create pattern `_clearRoomBoxes()` already uses elsewhere in
  this file, just scoped to the single selected-room cuboid.

## Test plan
- [x] Real Viewer, real HHS building served over HTTP, real UI taps (Find panel -> Room axis ->
      tap 3 different rooms in sequence, via Playwright dispatching the actual `pointerup` event
      the row's tap handler listens for).
- [x] Cuboid-tagged scene mesh count (`userData._roomShell` + fill/wire colors) stayed exactly 3
      after each of 3 sequential room selections. Before the fix this would grow by 3 every tap
      (3 -> 6 -> 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)