### PR TITLE
fix(schedule-editor): stop Generate/materialize freezing the tab, add MSP-style polish

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -100,6 +100,13 @@
     _ensureWideTasks(db);   // migrate any legacy-thin tasks table → the widened DDL `_cap` reads
     db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
 
+    // §SE-5a: one transaction around the whole rebuild (delete + insert). Without this, sql.js pays
+    // per-statement implicit-commit overhead on EVERY row — for a large building (tens of thousands of
+    // elements) that is a multi-second, unbroken main-thread block (measured 4.3s/63k els, 10.4s/123k
+    // els pre-fix) long enough to trip Chrome's "Page Unresponsive" prompt. Batching is the standard
+    // SQLite bulk-write fix, not a new algorithm. Same rows, same order, same output — write cost only.
+    db.run('BEGIN TRANSACTION');
+
     // Idempotent rebuild: drop any prior authored rows for this schedule.
     var oldIds = [];
     var pr = db.exec("SELECT task_id FROM tasks WHERE schedule_id='" + schedId + "'");
@@ -156,6 +163,8 @@
     });
     stmtTk.free();
     stmtTe.free();
+
+    db.run('COMMIT');   // §SE-5a — single commit for the whole rebuild
 
     console.log('§AUTHOR_MATERIALIZE schedule=' + schedId + ' mode=' + (blank ? 'blank' : 'dated') +
       ' phases=' + outPhases.length + ' leafTasks=' + outPhases.length +
@@ -223,6 +232,7 @@
       "' AND (is_summary IS NULL OR is_summary=0) ORDER BY rowid");
     var ids = (lr.length && lr[0].values.length) ? lr[0].values.map(function (r) { return r[0]; }) : [];
     var cursor = 0;
+    db.run('BEGIN TRANSACTION');   // §SE-5a — same per-statement-overhead fix as materializeDefault
     ids.forEach(function (tid) {
       var s = _addDays(start, cursor), f = _addDays(start, cursor + phaseDays);
       db.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
@@ -231,6 +241,7 @@
     });
     db.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
       [start, _addDays(start, cursor), scheduleId]);
+    db.run('COMMIT');
     console.log('§AUTHOR_SCHEDULE schedule=' + scheduleId + ' phases=' + ids.length + ' from=' + start + ' span=' + cursor + 'd');
     return { scheduled: ids.length, start: start, span: cursor };
   }
@@ -589,6 +600,35 @@
     return { ok: true, taskId: tid, parent: parent };
   }
 
+  // reparentTask(db, scheduleId, taskId, newParentId) — §SE-5b Indent/Outdent: move one WBS node under a
+  // different parent (or to root when newParentId is null). Refuses self, unknown task/parent, and any
+  // move that would create a cycle (newParentId is taskId or one of its own descendants). A newly-indented
+  // leaf inherits nothing (it keeps its own dates/assignments — only its position in the tree changes);
+  // the caller (UI) is responsible for picking a sensible newParentId (indent = previous sibling, outdent =
+  // current grandparent). Returns { ok, taskId, wbsParent } or { ok:false, reason }.
+  function reparentTask(db, scheduleId, taskId, newParentId) {
+    function fail(reason) { console.log('§SE_REPARENT_FAIL task=' + taskId + ' newParent=' + newParentId + ' reason=' + reason); return { ok: false, reason: reason }; }
+    if (!taskId) return fail('missing_id');
+    if (newParentId && newParentId === taskId) return fail('self_parent');
+    var tr = db.exec('SELECT wbs_parent FROM tasks WHERE task_id=? AND schedule_id=?', [taskId, scheduleId]);
+    if (!tr.length || !tr[0].values.length) return fail('no_such_task');
+    if (newParentId) {
+      var pr = db.exec('SELECT 1 FROM tasks WHERE task_id=? AND schedule_id=?', [newParentId, scheduleId]);
+      if (!pr.length || !pr[0].values.length) return fail('no_such_parent');
+      // cycle guard: walk newParentId's ancestor chain; if it reaches taskId, the move would loop.
+      var cur = newParentId, seen = {}, guard = 0;
+      while (cur && !seen[cur] && guard++ < 10000) {
+        if (cur === taskId) return fail('cycle');
+        seen[cur] = true;
+        var ar = db.exec('SELECT wbs_parent FROM tasks WHERE task_id=?', [cur]);
+        cur = (ar.length && ar[0].values.length) ? ar[0].values[0][0] : null;
+      }
+    }
+    db.run('UPDATE tasks SET wbs_parent=? WHERE task_id=?', [newParentId || null, taskId]);
+    console.log('§SE_REPARENT task=' + taskId + ' -> parent=' + (newParentId || '(root)'));
+    return { ok: true, taskId: taskId, wbsParent: newParentId || null };
+  }
+
   // breakdownByAttribute(db, scheduleId, taskId, attr) — auto-split a leaf phase's assigned elements into
   // child sub-tasks grouped by an elements_meta attribute (storey | ifc_class/type | discipline). Each
   // distinct value → child "<parent> · <value>" (DETERMINISTIC id parentId__<slug(value)> so a peer replay
@@ -644,6 +684,7 @@
     computeCpm: computeCpm,
     moveTask: moveTask,
     addTask: addTask,
+    reparentTask: reparentTask,
     breakdownByAttribute: breakdownByAttribute
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -15,14 +15,25 @@
   * { box-sizing: border-box; }
   body { margin: 0; font: 13px/1.45 -apple-system, Segoe UI, Roboto, sans-serif;
          background: #11151c; color: #d8e0ea; }
-  header { display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+  header { display: flex; align-items: center; gap: 12px; padding: 8px 16px;
            background: linear-gradient(180deg, #1b2230, #161b25); border-bottom: 1px solid #2a3342; }
   header h1 { font-size: 15px; margin: 0; font-weight: 600; color: #eaf1fb; }
   header .sub { color: #7d8aa0; font-size: 11px; }
-  #se-import-btn { margin-left: auto; background: #243042; border: 1px solid #34465e; color: #cdd7e4;
+  #se-bld { color: #4fc3f7; font-size: 11px; margin-left: auto; }
+  /* Ribbon — grouped button clusters, MS-Project-style, separated by thin dividers */
+  .se-ribbon { display: flex; align-items: center; gap: 0; padding: 6px 16px; background: #161b24;
+               border-bottom: 1px solid #232c3a; flex-wrap: wrap; }
+  .se-ribbon-group { display: flex; align-items: center; gap: 5px; padding: 0 12px;
+                     border-right: 1px solid #232c3a; }
+  .se-ribbon-group:last-child { border-right: none; }
+  .se-ribbon-label { font-size: 9px; text-transform: uppercase; letter-spacing: .06em; color: #566177;
+                     margin-right: 4px; }
+  #se-import-btn { background: #243042; border: 1px solid #34465e; color: #cdd7e4;
     font-size: 12px; padding: 4px 10px; border-radius: 4px; cursor: pointer; }
   #se-import-btn:hover { background: #2c3a50; }
-  #se-bld { color: #4fc3f7; font-size: 11px; margin-left: 12px; }
+  .zoom-btn { background: #1c2430; border: 1px solid #313c4d; color: #9fb0c6; cursor: pointer;
+              padding: 3px 9px; font-size: 11px; border-radius: 4px; }
+  .zoom-btn.active { background: #1f6feb; border-color: #1f6feb; color: #fff; font-weight: 600; }
   #se-status { padding: 6px 16px; background: #0d1118; color: #9fb0c6; font-size: 11px;
                border-bottom: 1px solid #222b38; min-height: 26px; }
   main { display: grid; grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.2fr); gap: 0;
@@ -34,6 +45,7 @@
   /* WBS outline */
   .se-wbs-row { display: flex; align-items: center; gap: 6px; padding: 3px 4px; border-radius: 4px;
                 white-space: nowrap; }
+  .se-wbs-row:nth-child(even) { background: #151a24; }
   .se-wbs-row:hover { background: #1a2230; }
   .se-twisty { width: 12px; color: #5e6b80; cursor: default; user-select: none; }
   .se-wbs-row .se-twisty:hover { color: #9fb0c6; }
@@ -42,6 +54,11 @@
   .se-badge { font-size: 10px; color: #76d1a0; background: #16271f; padding: 1px 6px;
               border-radius: 8px; }
   .se-dates { font-size: 10px; color: #6f7d93; margin-left: 6px; }
+  .se-row-actions { margin-left: auto; display: inline-flex; gap: 3px; align-items: center; }
+  .se-row-actions button { font-size: 10px; line-height: 1; padding: 2px 6px; cursor: pointer; }
+  .se-indent-btn { color: #9fb0c6; }
+  .se-indent-btn:disabled { opacity: .3; cursor: default; }
+  .se-add-sub-btn { color: #76d1a0; }
   /* CPM: critical rail + float */
   .se-wbs-row.se-critical { box-shadow: inset 3px 0 0 #e0556b; }
   .se-float { font-size: 10px; margin-left: 6px; }
@@ -77,6 +94,16 @@
   .g-handle:hover { color: #fff; }
   .g-link-mode .g-bar { outline: 1px dashed #4a6fa5; }
   .gantt-empty { color: #6f7d93; font-style: italic; padding: 14px 4px; }
+  .g-row:nth-child(even) { background: #151a24; }
+  /* §SE-5b milestone diamond — a 0-day task */
+  .g-milestone { position: absolute; top: 4px; width: 16px; height: 16px; background: #e0b070;
+                 transform: rotate(45deg); margin-left: -8px; box-shadow: 0 1px 2px rgba(0,0,0,.4); }
+  .g-milestone.crit { background: #d2475c; }
+  /* §SE-5b today marker — vertical line across the whole Gantt body */
+  .g-today-line { position: absolute; top: -16px; bottom: 0; width: 1px; background: #4fc3f7;
+                  z-index: 1; opacity: .6; pointer-events: none; }
+  .g-today-line::before { content: 'today'; position: absolute; top: -14px; left: 3px; font-size: 9px;
+                           color: #4fc3f7; opacity: 1; }
   /* dependency rows */
   .se-dep-row { display: flex; align-items: center; gap: 8px; padding: 5px 4px;
                 border-bottom: 1px solid #1c2531; }
@@ -102,12 +129,28 @@
 <body>
 <header>
   <h1>Schedule Editor</h1>
-  <span class="sub">WBS outline + dependencies</span>
-  <button id="se-import-btn" title="Import a Primavera P6 programme (.xer or .xml/PMXML) — adopt its WBS, logic and dates onto this model, then bind tasks to elements">⤓ Import P6</button>
-  <input id="se-import-file" type="file" accept=".xer,.xml" style="display:none">
-  <label id="se-autobind-wrap" title="If the activity names carry a BIM-Bind token (@discipline:IfcClass[:storey]), resolve it against this model and pre-bind tasks to elements on import — a reviewable first pass, not a guess."><input id="se-autobind-cb" type="checkbox" checked> auto-bind by convention</label>
+  <span class="sub">WBS &middot; Dependencies &middot; CPM &middot; Gantt</span>
   <span id="se-bld">—</span>
 </header>
+<div class="se-ribbon">
+  <div class="se-ribbon-group">
+    <span class="se-ribbon-label">Import</span>
+    <button id="se-import-btn" title="Import a Primavera P6 programme (.xer or .xml/PMXML) — adopt its WBS, logic and dates onto this model, then bind tasks to elements">⤓ P6</button>
+    <input id="se-import-file" type="file" accept=".xer,.xml" style="display:none">
+    <label id="se-autobind-wrap" title="If the activity names carry a BIM-Bind token (@discipline:IfcClass[:storey]), resolve it against this model and pre-bind tasks to elements on import — a reviewable first pass, not a guess."><input id="se-autobind-cb" type="checkbox" checked> auto-bind</label>
+  </div>
+  <div class="se-ribbon-group">
+    <span class="se-ribbon-label">Compute</span>
+    <button id="se-cpm-btn" title="Critical-path forward/backward pass over the dependency graph">▶ CPM</button>
+    <span id="se-cpm-out"></span>
+  </div>
+  <div class="se-ribbon-group">
+    <span class="se-ribbon-label">Zoom</span>
+    <button class="zoom-btn" data-zoom="day" title="Show daily ticks">Day</button>
+    <button class="zoom-btn" data-zoom="week" title="Show weekly ticks">Week</button>
+    <button class="zoom-btn" data-zoom="month" title="Show monthly ticks">Month</button>
+  </div>
+</div>
 <div id="se-status">Initialising…</div>
 <main>
   <section class="pane left">
@@ -116,10 +159,6 @@
   </section>
   <section class="pane right">
     <h2>Dependencies</h2>
-    <div class="se-toolbar">
-      <button id="se-cpm-btn" title="Critical-path forward/backward pass over the dependency graph">▶ Compute CPM</button>
-      <span id="se-cpm-out"></span>
-    </div>
     <div id="se-deps"></div>
     <div class="se-add">
       <label>Add link:</label>
@@ -138,9 +177,9 @@
 </section>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
-<script src="schedule_sync.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
+<script src="schedule_editor_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -15,6 +15,11 @@
   var db = null, schedId = null, sync = null;
   var collapsed = {};   // task_id -> true when its subtree is collapsed
   var critSet = {};     // task_id -> true after a CPM run (drives the red rail + bold links)
+  // §SE-5b: Gantt tick-density zoom (Day/Week/Month). The chart always fits the WHOLE project span into
+  // the available width (no pan/scroll) — "zoom" here changes how granular the axis ticks/labels are,
+  // not the visible time range. Honest framing: a scale-zoom (with panning) is the natural next slice.
+  var _zoom = 'week';
+  var ZOOM_MIN_STEP = { day: 1, week: 7, month: 30 };
 
   function $(id) { return document.getElementById(id); }
   function status(msg) { var s = $('se-status'); if (s) s.textContent = msg; console.log('§SE_UI ' + msg); }
@@ -53,6 +58,20 @@
     }
   }
 
+  // ── §SE-5b WBS tree lookups (indent/outdent need "where does this node sit") ────────────────
+  function _findNode(roots, id) {
+    for (var i = 0; i < roots.length; i++) {
+      if (roots[i].id === id) return roots[i];
+      var f = _findNode(roots[i].children || [], id);
+      if (f) return f;
+    }
+    return null;
+  }
+  function _siblingsAndIndex(roots, node) {
+    var container = node.parent ? ((_findNode(roots, node.parent) || {}).children || []) : roots;
+    return { siblings: container, index: container.indexOf(node) };
+  }
+
   // ── STEP 1: collapsible WBS outline ──────────────────────────────────────────
   function renderWbs() {
     var host = $('se-wbs'); if (!host) return;
@@ -76,15 +95,23 @@
           tf <= 0 ? 'critical' : ('float ' + tf + 'd')));
       }
       if (node.start) row.appendChild(el('span', 'se-dates', node.start + (node.finish ? ' → ' + node.finish : '')));
-      // §SE-WBS deepen-the-tree actions: ＋ add a sub-task (any node) · break a populated leaf down by attribute
-      var act = el('span'); act.style.cssText = 'margin-left:auto;display:inline-flex;gap:4px;align-items:center';
-      var addBtn = el('button', null, '＋'); addBtn.title = 'Add a sub-task under ' + node.name;
-      addBtn.style.cssText = 'font-size:11px;line-height:1;padding:1px 5px;cursor:pointer';
+      // §SE-WBS deepen-the-tree actions: outdent/indent · add a sub-task (any node) · break a leaf down
+      var act = el('span', 'se-row-actions');
+      if (node.parent) {
+        var si = _siblingsAndIndex(roots, node);
+        var outBtn = el('button', 'se-indent-btn', '⇤'); outBtn.title = 'Outdent (promote one level)';
+        outBtn.onclick = function (ev) { ev.stopPropagation(); doOutdent(node.id); };
+        act.appendChild(outBtn);
+        var inBtn = el('button', 'se-indent-btn', '⇥'); inBtn.title = 'Indent (nest under the previous row)';
+        inBtn.disabled = si.index <= 0;
+        inBtn.onclick = function (ev) { ev.stopPropagation(); doIndent(node.id); };
+        act.appendChild(inBtn);
+      }
+      var addBtn = el('button', 'se-add-sub-btn', '+'); addBtn.title = 'Add a sub-task under ' + node.name;
       addBtn.onclick = function (ev) { ev.stopPropagation(); doAddTask(node.id, node.name); };
       act.appendChild(addBtn);
       if (!node.isSummary && node.guidCount > 1) {
         var sel = el('select'); sel.title = 'Break this phase into sub-tasks grouped by…';
-        sel.style.cssText = 'font-size:10px;padding:0 2px;cursor:pointer';
         sel.appendChild(new Option('break by…', ''));
         ['storey', 'type', 'discipline'].forEach(function (o) { sel.appendChild(new Option(o, o)); });
         sel.onclick = function (ev) { ev.stopPropagation(); };
@@ -96,6 +123,33 @@
       if (hasKids && !collapsed[node.id]) node.children.forEach(function (c) { walk(c, depth + 1); });
     }
     roots.forEach(function (r) { walk(r, 0); });
+  }
+
+  // §SE-5b indent/outdent — reparent one WBS node relative to its current position, broadcast the
+  // signed op so peer surfaces converge, then refreshFold() (invalidates stale CPM, re-renders all).
+  function doIndent(taskId) {
+    var roots = SA().wbsTree(db, schedId);
+    var node = _findNode(roots, taskId); if (!node) return;
+    var si = _siblingsAndIndex(roots, node);
+    if (si.index <= 0) { status('Cannot indent - no preceding row at this level to nest under'); return; }
+    var newParent = si.siblings[si.index - 1].id;
+    var r = SA().reparentTask(db, schedId, taskId, newParent);
+    if (!r.ok) { status('Indent refused - ' + r.reason); return; }
+    broadcast({ op: 'reparent', schedId: schedId, taskId: taskId, wbsParent: newParent });
+    collapsed[newParent] = false;
+    status('Indented "' + node.name + '" under "' + si.siblings[si.index - 1].name + '"');
+    refreshFold();
+  }
+  function doOutdent(taskId) {
+    var roots = SA().wbsTree(db, schedId);
+    var node = _findNode(roots, taskId); if (!node || !node.parent) { status('Cannot outdent - already at top level'); return; }
+    var parentNode = _findNode(roots, node.parent);
+    var newParent = parentNode ? parentNode.parent : null;
+    var r = SA().reparentTask(db, schedId, taskId, newParent);
+    if (!r.ok) { status('Outdent refused - ' + r.reason); return; }
+    broadcast({ op: 'reparent', schedId: schedId, taskId: taskId, wbsParent: newParent });
+    status('Outdented "' + node.name + '"');
+    refreshFold();
   }
 
   // §SE-WBS — deepen the WBS: add a sub-task, or auto-split a phase by an element attribute. Each edit runs
@@ -200,9 +254,10 @@
     var chartW = Math.max(240, (host.clientWidth || 700) - labelW - 8);
     var pxPerDay = chartW / totalDays;
 
-    // axis: a tick roughly every ~7 days (snap to weeks), labelled with the date.
+    // axis: tick DENSITY follows the Day/Week/Month zoom pick (whole span always fits — no pan yet).
     var axis = el('div', 'g-axis');
-    var stepDays = Math.max(7, Math.ceil(totalDays / 8 / 7) * 7);
+    var baseStep = ZOOM_MIN_STEP[_zoom] || 7;
+    var stepDays = Math.max(baseStep, Math.ceil(totalDays / 8 / baseStep) * baseStep);
     for (var d = 0; d <= totalDays; d += stepDays) {
       var tick = el('div', 'g-tick', addDays(min, d));
       tick.style.left = (d * pxPerDay) + 'px';
@@ -210,27 +265,54 @@
     }
     host.appendChild(axis);
 
+    // §SE-5b today marker — a vertical line at "now" if it falls inside the rendered span.
+    var todayISO = new Date().toISOString().slice(0, 10);
+    if (todayISO >= min && todayISO <= max) {
+      var todayLine = el('div', 'g-today-line');
+      todayLine.style.left = (daysBetween(min, todayISO) * pxPerDay) + 'px';
+      todayLine.title = 'Today (' + todayISO + ')';
+      host.appendChild(todayLine);
+    }
+
     leaves.forEach(function (n) {
       var dur = daysBetween(n.start, n.finish);
       var off = daysBetween(min, n.start);
       var row = el('div', 'g-row');
       row.appendChild(el('div', 'g-label', n.name));
       var track = el('div', 'g-track');
-      var bar = el('div', 'g-bar' + (n.critical ? ' crit' : ''), dur + 'd');
-      bar.style.left = (off * pxPerDay) + 'px';
-      bar.style.width = Math.max(8, dur * pxPerDay) + 'px';
-      bar.dataset.task = n.id;
-      bar.title = n.name + '  ' + n.start + ' → ' + n.finish + (n.totalFloat != null ? '  (float ' + n.totalFloat + 'd)' : '');
-      _wireBarDrag(bar, n, off, pxPerDay);
-      var handle = el('div', 'g-handle', '▸');
-      handle.title = 'drag onto another bar to link (FS)';
-      _wireLinkDrag(handle, n);
-      bar.appendChild(handle);
-      track.appendChild(bar);
+      // §SE-5b milestone — a 0-day task (start===finish) renders as a diamond, not a bar.
+      if (dur === 0) {
+        var ms = el('div', 'g-milestone' + (n.critical ? ' crit' : ''));
+        ms.style.left = (off * pxPerDay) + 'px';
+        ms.dataset.task = n.id;
+        ms.title = n.name + '  ' + n.start + ' (milestone)';
+        track.appendChild(ms);
+      } else {
+        var bar = el('div', 'g-bar' + (n.critical ? ' crit' : ''), dur + 'd');
+        bar.style.left = (off * pxPerDay) + 'px';
+        bar.style.width = Math.max(8, dur * pxPerDay) + 'px';
+        bar.dataset.task = n.id;
+        bar.title = n.name + '  ' + n.start + ' → ' + n.finish + (n.totalFloat != null ? '  (float ' + n.totalFloat + 'd)' : '');
+        _wireBarDrag(bar, n, off, pxPerDay);
+        var handle = el('div', 'g-handle', '▸');
+        handle.title = 'drag onto another bar to link (FS)';
+        _wireLinkDrag(handle, n);
+        bar.appendChild(handle);
+        track.appendChild(bar);
+      }
       row.appendChild(track);
       host.appendChild(row);
     });
-    console.log('§SE_GANTT bars=' + leaves.length + ' span=' + min + '..' + max + ' days=' + totalDays);
+    console.log('§SE_GANTT bars=' + leaves.length + ' span=' + min + '..' + max + ' days=' + totalDays + ' zoom=' + _zoom);
+  }
+
+  // §SE-5b — switch tick-density zoom and re-render; keeps the active button highlighted.
+  function setZoom(z) {
+    if (!ZOOM_MIN_STEP[z] || z === _zoom) return;
+    _zoom = z;
+    document.querySelectorAll('.zoom-btn').forEach(function (b) { b.classList.toggle('active', b.dataset.zoom === z); });
+    renderGantt();
+    console.log('§SE_ZOOM ' + z);
   }
 
   // drag a bar horizontally → reschedule (snap to whole days, duration locked).
@@ -419,15 +501,26 @@
       })
       .then(function () {
         var act = SA().activeSchedule(db);
-        if (!act) {
-          // Blank model → seed the smart default so there's a schedule to edit (rates.js globals).
-          var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
-          schedId = 'SCH_AUTHORED';
-          status('Seeded default schedule (' + resM.phases.length + ' phases) — ' + url.split('/').pop());
-        } else {
+        if (act) {
           schedId = act.id;
           status('Editing ' + (act.name || act.id) + ' (' + act.taskCount + ' tasks)' + (act.captured ? ' — imported' : ''));
+          return;
         }
+        // Blank model → seed the smart default so there's a schedule to edit (rates.js globals).
+        // §SE-5a fixed the multi-second freeze (transaction-wrapped bulk write), but a large building
+        // is still real work (~1-2s) — paint a "please wait" status FIRST (setTimeout yields one frame
+        // to the renderer) so the tab visibly acknowledges the load instead of looking frozen.
+        status('Materializing default schedule for ' + url.split('/').pop() + ' — please wait…');
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+            schedId = 'SCH_AUTHORED';
+            status('Seeded default schedule (' + resM.phases.length + ' phases) — ' + url.split('/').pop());
+            resolve();
+          }, 30);
+        });
+      })
+      .then(function () {
         var b = $('se-bld'); if (b) b.textContent = url.split('/').pop() + '  •  ' + (schedId);
         // §SE-4: live cross-surface sync — emit our ops + replay peers' ops on our db.
         if (global.ScheduleSync) { sync = global.ScheduleSync.create(); sync.listen(db, onSynced); }
@@ -439,12 +532,16 @@
           impBtn.onclick = function () { impFile.click(); };
           impFile.onchange = function () { if (impFile.files && impFile.files[0]) doImportP6(impFile.files[0]); impFile.value = ''; };
         }
+        document.querySelectorAll('.zoom-btn').forEach(function (b) {
+          b.classList.toggle('active', b.dataset.zoom === _zoom);
+          b.onclick = function () { setZoom(b.dataset.zoom); };
+        });
         window.addEventListener('resize', renderGantt);
       })
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }
 
-  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm };
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm, setZoom: setZoom };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })(typeof window !== 'undefined' ? window : this);

--- a/viewer/schedule_sync.js
+++ b/viewer/schedule_sync.js
@@ -27,6 +27,7 @@
       // §SE-WBS structural edits — deterministic (explicit taskId / stable child ids) so peers converge.
       case 'addtask':   return SA().addTask(db, op.schedId, { taskId: op.taskId, name: op.name, wbsParent: op.wbsParent });
       case 'breakdown': return SA().breakdownByAttribute(db, op.schedId, op.taskId, op.attr);
+      case 'reparent':  return SA().reparentTask(db, op.schedId, op.taskId, op.wbsParent);
       default:       return { ok: false, reason: 'unknown_op:' + (op.op || '?') };
     }
   }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v746';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v747';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- Root cause of the reported "browser crash": `materializeDefault` ran one INSERT/DELETE per element with no explicit SQL transaction — sql.js paid per-statement commit overhead on every row. Measured 4.3s/63k elements, 10.4s/123k elements of unbroken main-thread block (long enough to trip Chrome's Page-Unresponsive prompt).
- Wrapped the bulk delete+insert (`materializeDefault`) and the per-task date-lay-out loop (`scheduleContiguous`) in a single transaction: 8.6x / 6.3x faster, identical output (same assignment/phase counts).
- Editor's auto-seed-on-blank-load now paints a "please wait" status *before* the heavy call runs, so a large building visibly acknowledges the load instead of looking frozen.
- First MS-Project-style polish slice on the `↗ Editor` tab: indent/outdent (new `reparentTask` engine verb + cycle guard, synced cross-tab via the existing `schedule_sync.js` broadcast), Day/Week/Month Gantt zoom, a today marker line, milestone-diamond rendering for 0-day tasks, and a grouped ribbon toolbar (Import / Compute / Zoom) replacing the ad-hoc header buttons.
- `sw.js` `CACHE_VERSION` bumped v746→v747; changed script tags version-bumped so a deployed tab picks up the fix instead of a stale SW-cached copy.

## Test plan
- [x] `node -c` syntax check on all changed files
- [x] `eslint viewer/schedule_author.js viewer/schedule_editor_ui.js viewer/schedule_sync.js viewer/sw.js` — clean, exit 0
- [x] W-SCHED-REPARENT 11/11 (node, real SampleHouse_extracted.db, whitebox §-log): indent/outdent reparent, cycle guard, self-parent guard, unknown-task/parent guards, outdent-to-root
- [x] 10/10 headless Chromium checks (real Duplex_extracted.db): paint-before-compute status, load+seed with no crash, indent click fires `§SE_REPARENT` + re-renders, all 3 zoom buttons wire + emit `§SE_ZOOM`, Gantt renders
- [x] Full Editor-tab open→fetch→auto-seed→render on the largest local building (LTU_AHouse, 122,667 elements): **2.0s total, no crash** — down from the bug's ~10s+ freeze risk on this same building
- [x] Re-ran the same real-DB timing probe pre/post fix: Hospital 4040ms→467ms, LTU_AHouse 7174ms→1131ms materialize; full click-equivalent LTU_AHouse 10.4s→~1.7s

Full spec + witness detail: `prompts/FUSED_4D5D_WEDGE_LANE.md` §SE-5/§SE-5a/§SE-5b (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)