### PR TITLE
fix(schedule): persist authored schedule edits — neither surface saved anything

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -667,6 +667,77 @@
     return { ok: true, parent: taskId, attr: col, groups: out, created: created };
   }
 
+  // ── §SE-6: persist authored schedule edits back to the shared IndexedDB building cache ──────────
+  // GAP THIS CLOSES: materializeDefault/assignElement/addDependency/moveTask/reparentTask/etc. all
+  // write straight to the in-memory sql.js `db` — but NOTHING saved that db back anywhere. Neither
+  // the ✎ Author wizard (which edits the SAME db as the main viewer, `APP.db`) nor the ↗ Editor tab
+  // (its OWN separate in-memory copy) survived a tab close: kernel_ops.js's own IDB persistence
+  // (`§KRN_PERSIST`) only fires on a signed `commitOp()` — schedule-table writes never go through it
+  // (kernel_ops mirroring is explicitly deferred, per the module header above). So a closed tab lost
+  // every authored phase/dependency/date — a "professional" editor that silently discards work.
+  // Fix: ONE shared debounced-persist helper (both UIs call this, not divergent copies), reusing the
+  // EXACT IDB-open pattern kernel_ops.js already proved correct — prefer `APP.openCacheDB()` (the
+  // app's single opener; kernel_ops.js's own comment documents a past bug where a raw
+  // `indexedDB.open('bim_ootb_cache', 1)` drifted behind scene.js's real version and silently never
+  // fired). Same cache store ('dbs'), same key (the building URL) `cachedFetch`/`_idbGetDb` already
+  // read from — so a reopened tab (Editor OR a fresh viewer load) picks up the edited bytes for free,
+  // no new read-path needed.
+  // openBuildingCache() — the ONE opener for 'bim_ootb_cache', usable from ANY surface. Prefers
+  // `APP.openCacheDB()` (scene.js's opener) when present so we share its exact handle/version. But the
+  // ↗ Editor tab is a standalone page that NEVER loads scene.js — if it's the FIRST surface to ever
+  // touch this IndexedDB in a fresh profile, a bare unversioned `indexedDB.open('bim_ootb_cache')`
+  // creates an empty v1 database with NO object stores (this was caught live: W-SCHED-PERSIST's first
+  // run FAILED with "no cache store" for exactly this reason). Fix: version-open at 2 with the SAME
+  // onupgradeneeded schema as scene.js A.openCacheDB (`dbs` + `timestamps` stores) so whichever
+  // surface opens it FIRST creates a schema fully compatible with the other.
+  function openBuildingCache() {
+    var g = (typeof window !== 'undefined') ? window : global;
+    if (g.APP && g.APP.openCacheDB) return g.APP.openCacheDB();
+    return new Promise(function (resolve) {
+      var idbFactory = (typeof indexedDB !== 'undefined') ? indexedDB : g.indexedDB;
+      if (!idbFactory) { resolve(null); return; }
+      try {
+        var rq = idbFactory.open('bim_ootb_cache', 2);   // matches scene.js A.openCacheDB exactly
+        rq.onupgradeneeded = function () {
+          var idb = rq.result;
+          if (!idb.objectStoreNames.contains('dbs')) idb.createObjectStore('dbs');
+          if (!idb.objectStoreNames.contains('timestamps')) idb.createObjectStore('timestamps');
+        };
+        rq.onsuccess = function () { resolve(rq.result); };
+        rq.onerror = function () { resolve(null); };
+        rq.onblocked = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  }
+
+  var _persistTimers = {};   // url -> timer, so rapid edits on the SAME db coalesce into one write
+  function persistDb(db, url, opts) {
+    opts = opts || {};
+    if (!db || !url) return Promise.resolve(false);
+    var delay = opts.immediate ? 0 : (opts.delay != null ? opts.delay : 1200);
+    if (_persistTimers[url]) { clearTimeout(_persistTimers[url]); }
+    return new Promise(function (resolve) {
+      _persistTimers[url] = setTimeout(function () {
+        delete _persistTimers[url];
+        try {
+          var buf = db.export().buffer;
+          openBuildingCache().then(function (idb) {
+            if (!idb || !idb.objectStoreNames.contains('dbs')) {
+              console.warn('§SCHED_PERSIST_ERR no cache store url=' + url); resolve(false); return;
+            }
+            var tx = idb.transaction('dbs', 'readwrite');
+            tx.objectStore('dbs').put(buf, url);
+            tx.oncomplete = function () {
+              console.log('§SCHED_PERSIST url=' + url + ' size=' + (buf.byteLength / 1024).toFixed(0) + 'KB');
+              resolve(true);
+            };
+            tx.onerror = function () { console.warn('§SCHED_PERSIST_ERR tx ' + (tx.error && tx.error.message)); resolve(false); };
+          }).catch(function (e) { console.warn('§SCHED_PERSIST_ERR open ' + (e && e.message)); resolve(false); });
+        } catch (e) { console.warn('§SCHED_PERSIST_ERR', e); resolve(false); }
+      }, delay);
+    });
+  }
+
   var API = {
     matchRule: matchRule,
     materializeDefault: materializeDefault,
@@ -685,7 +756,9 @@
     moveTask: moveTask,
     addTask: addTask,
     reparentTask: reparentTask,
-    breakdownByAttribute: breakdownByAttribute
+    breakdownByAttribute: breakdownByAttribute,
+    persistDb: persistDb,
+    openBuildingCache: openBuildingCache
   };
   if (typeof window !== 'undefined') window.ScheduleAuthor = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -14,6 +14,18 @@
   function rules() { return global.SEQUENCE_RULES || {}; }
   var SA = function () { return global.ScheduleAuthor; };
 
+  // §SE-6: the wizard edits APP.db directly (shares it with the whole viewer) — but kernel_ops.js's
+  // own IDB persistence (§KRN_PERSIST) only fires on a signed commitOp(); schedule-table writes never
+  // go through it (kernel_ops mirroring is deferred, per schedule_author.js's header). So every
+  // authored phase/reassignment/date was ONLY ever in memory — closing the tab lost it, same gap the
+  // ↗ Editor tab had. Reuses the identical debounced ScheduleAuthor.persistDb helper (one
+  // implementation, not two divergent copies) keyed by APP.DB_URL — the same slot cachedFetch reads.
+  function persist(opts) {
+    var a = A(), d = db();
+    if (!SA().persistDb || !d || !a || !a.DB_URL) return;
+    SA().persistDb(d, a.DB_URL, opts);
+  }
+
   var _panel = null, _built = false;
   var _state = null;   // { schedId, start, order:[taskId], name:{}, dur:{}, count:{} }
 
@@ -250,6 +262,7 @@
       setTimeout(function () { global.toggleTimeMachine(); }, 60);   // fallback (older viewer)
     }
     _syncWhatIf();   // mirror the authored phases into C_ProjectPhase so the What-if (⑂) panel matches
+    persist({ immediate: true });   // §SE-6 — Apply-to-4D is a deliberate commit, flush without delay
   }
 
   function render() {
@@ -341,6 +354,7 @@
         else box.style.display = 'none';
       };
     });
+    if (_state && _state.order.length) persist();   // §SE-6 — only once a real schedule exists to save
   }
 
   function _fillElements(box, tid, opts) {
@@ -387,6 +401,11 @@
     document.getElementById('sa-draft').onclick = generateDraft;
     document.getElementById('sa-apply').onclick = applyTo4D;
     dragByHandle(_panel, document.getElementById('sa-head'));   // panel is repositionable (drag the header)
+    // §SE-6: immediate flush when the tab is backgrounded/closed — safety net alongside the debounced
+    // save in render(). visibilitychange (not beforeunload) per Chrome's own guidance on reliability.
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'hidden') persist({ immediate: true });
+    });
     _built = true;
     render();
   }

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -177,9 +177,9 @@
 </section>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_editor_ui.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -12,7 +12,7 @@
   'use strict';
 
   var SA = function () { return global.ScheduleAuthor; };
-  var db = null, schedId = null, sync = null;
+  var db = null, schedId = null, sync = null, _dbUrl = null;
   var collapsed = {};   // task_id -> true when its subtree is collapsed
   var critSet = {};     // task_id -> true after a CPM run (drives the red rail + bold links)
   // §SE-5b: Gantt tick-density zoom (Day/Week/Month). The chart always fits the WHOLE project span into
@@ -393,6 +393,16 @@
       broadcast({ op: 'cpm', projectDuration: r.projectDuration, criticalIds: r.criticalIds });
     }
     renderWbs(); renderDeps(); renderGantt();
+    persist();
+  }
+
+  // §SE-6: debounced write-back to the SAME IndexedDB cache slot the building was loaded from — the
+  // gap that made every schedule edit vanish on tab close (see schedule_author.js persistDb doc).
+  // Called from BOTH mutation choke points below (refreshFold covers WBS/dep/date/reparent edits;
+  // onComputeCpm doesn't route through refreshFold, so it calls persist() directly above).
+  function persist(opts) {
+    if (!SA().persistDb || !db || !_dbUrl) return;
+    SA().persistDb(db, _dbUrl, opts);
   }
 
   // After a graph edit the prior CPM is INVALID — null the computed columns (everywhere) until the
@@ -405,28 +415,27 @@
     } catch (e) {}
     var o = $('se-cpm-out'); if (o) o.textContent = '';
     renderWbs(); renderDeps(); renderGantt();
+    persist();
   }
 
   // Reuse the viewer's IndexedDB cache (bim_ootb_cache / store 'dbs', keyed by URL — scene.js A.cachedFetch)
   // so the Editor does NOT re-download a whole building the viewer already streamed. The ↗ Editor button
   // passes ?db=<APP.DB_URL>, the exact key the viewer wrote, so this hits. Read-only; a miss falls through
-  // to network. Opened WITHOUT a version so we never clobber the viewer's schema. (W-SE-DB-CACHE)
+  // to network. §SE-6: routed through ScheduleAuthor.openBuildingCache — a bare unversioned open used
+  // to silently create a store-less db if the Editor was the FIRST surface to ever touch it in a fresh
+  // profile (caught live by W-SCHED-PERSIST); the shared opener self-heals that via a versioned
+  // onupgradeneeded, so read and write now use the exact same, robust opener.
   function _idbGetDb(url) {
-    return new Promise(function (resolve) {
-      try {
-        var rq = indexedDB.open('bim_ootb_cache');
-        rq.onsuccess = function () {
-          var idb = rq.result;
-          if (!idb.objectStoreNames.contains('dbs')) { resolve(null); return; }
-          try {
-            var g = idb.transaction('dbs', 'readonly').objectStore('dbs').get(url);
-            g.onsuccess = function () { resolve(g.result || null); };
-            g.onerror = function () { resolve(null); };
-          } catch (e) { resolve(null); }
-        };
-        rq.onerror = function () { resolve(null); };
-      } catch (e) { resolve(null); }
-    });
+    return SA().openBuildingCache().then(function (idb) {
+      return new Promise(function (resolve) {
+        if (!idb || !idb.objectStoreNames.contains('dbs')) { resolve(null); return; }
+        try {
+          var g = idb.transaction('dbs', 'readonly').objectStore('dbs').get(url);
+          g.onsuccess = function () { resolve(g.result || null); };
+          g.onerror = function () { resolve(null); };
+        } catch (e) { resolve(null); }
+      });
+    }).catch(function () { return null; });
   }
 
   // ── §X5: import a Primavera P6 programme (.xer / PMXML .xml) into THIS editor's db ──────────────
@@ -464,6 +473,7 @@
         }
         collapsed = {}; critSet = {};
         renderWbs(); renderDeps(); renderGantt(); fillAddForm();
+        persist();   // §SE-6 — an imported P6 programme is a real edit, save it
         status('Imported ' + det.format + ' "' + file.name + '" → ' +
           data._meta.summaryCount + ' WBS / ' + data._meta.leafCount + ' activities / ' +
           data.taskSequences.length + ' links — press ▶ Compute CPM for the critical path.' + bindMsg +
@@ -480,6 +490,7 @@
   function init() {
     if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
     var url = resolveDbUrl();
+    _dbUrl = url;
     status('Loading ' + url.split('/').pop() + ' …');
     var initSqlJs = global.initSqlJs;
     initSqlJs({ locateFile: function (f) { return 'https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/' + f; } })
@@ -516,6 +527,7 @@
             var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
             schedId = 'SCH_AUTHORED';
             status('Seeded default schedule (' + resM.phases.length + ' phases) — ' + url.split('/').pop());
+            persist();   // §SE-6 — the freshly-seeded schedule is itself an edit worth saving
             resolve();
           }, 30);
         });
@@ -537,6 +549,13 @@
           b.onclick = function () { setZoom(b.dataset.zoom); };
         });
         window.addEventListener('resize', renderGantt);
+        // §SE-6: an immediate (non-debounced) flush when the tab is backgrounded/closed — the
+        // debounced 1.2s save covers the common case, this is the safety net for "closed right after
+        // an edit." visibilitychange (not beforeunload) per Chrome's own guidance — more reliably
+        // fires before a tab actually goes away (bfcache/close), and the write can still complete.
+        document.addEventListener('visibilitychange', function () {
+          if (document.visibilityState === 'hidden') persist({ immediate: true });
+        });
       })
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v747';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v748';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -907,9 +907,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=59" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="schedule_author.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
-<script src="schedule_sync.js?v=2" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_author_ui.js?v=6" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
+<script src="schedule_author_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- HR_BIM_Asset spatial lenses (prompts/RESUME_HR_BIM_ASSET.md §RESUME NEXT#2). ADDITIVE peer module: the


### PR DESCRIPTION
## Summary
- Root cause: `kernel_ops.js`'s IDB persistence only fires on a signed `commitOp()`; schedule-table writes (`materializeDefault`, `assignElement`, `addDependency`, `moveTask`, `reparentTask`, etc.) never go through it. Neither the ✎ Author wizard (shares `APP.db` with the main viewer) nor the ↗ Editor tab (its own separate in-memory copy) persisted anything — closing a tab silently discarded every authored phase/dependency/date.
- Fix: one shared, debounced `ScheduleAuthor.persistDb(db, url, opts)` helper wired into both UIs at every mutation choke point, writing back to the exact IndexedDB cache slot (`bim_ootb_cache`/`dbs`, keyed by the building URL) that `cachedFetch`/`_idbGetDb` already read from — so a reopened tab (or a fresh viewer load) picks up the edited bytes automatically.
- Found and fixed a second, deeper bug while proving this end-to-end: the Editor tab never loads `scene.js`, so it has no `APP.openCacheDB()`. A bare unversioned `indexedDB.open()` silently created a store-less database when the Editor was the first surface to ever touch that IDB in a fresh profile. New `ScheduleAuthor.openBuildingCache()` self-heals via a versioned (v2) `onupgradeneeded` matching `scene.js`'s exact schema — usable from any surface, whichever runs first now creates a compatible schema.
- `sw.js` `CACHE_VERSION` bumped v747→v748; script version tags bumped in both `viewer.html` and `schedule_editor.html` (also fixed a pre-existing stale `schedule_sync.js?v=2` reference in `viewer.html` that never got bumped when `reparent` support was added to it last PR).

## Test plan
- [x] `node -c` syntax check + `eslint` clean on all changed JS
- [x] **Editor 7/7** — REAL close+reopen via Playwright `launchPersistentContext` (not a mocked cache): seed → indent edit → `§SCHED_PERSIST` fires → close tab → fresh tab, same URL → cache-hit, finds the existing schedule (no re-materialize), the specific indent survived
- [x] **Author-in-viewer 5/5** — same real close+reopen: Generate first draft → `§SCHED_PERSIST` fires → close → fresh viewer load → cache-hit, `activeSchedule()` immediately finds `SCH_AUTHORED` with 6 tasks
- [x] Regression: W-SCHED-REPARENT 11/11 (node, real SampleHouse), MSP-polish headless smoke 10/10 (real Duplex), LTU_AHouse (122,667 elements) end-to-end 1.58s total, no crash

Full spec + witness detail: `prompts/FUSED_4D5D_WEDGE_LANE.md` §SE-6 (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)