### PR TITLE
fix(pos): cart panel + dock survive the POS overlay's native close

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3129,14 +3129,17 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   }
 
   // ── Pill rail (mobile-style, right edge) — Posted · Graph · Kanban · Install · Migrate (Odoo effects). ──
-  function _overlay(title, node) {
+  // onClose (optional, §BUGFIX 2026-07-13): callers that mount extra body-level chrome alongside `node`
+  // (POS lens's cart float panel + ⋯ dock — see pos_lens.js) pass a teardown so it fires on EVERY close
+  // path (✕ tap, back-gesture), not just their own explicit exit button. Unused callers are unaffected.
+  function _overlay(title, node, onClose) {
     _injectPostedCSS(); _injectPillCSS();
     var prev = $('posted-overlay'); if (prev && prev.parentNode) prev.parentNode.removeChild(prev);
     var ov = el('div'); ov.id = 'posted-overlay';
     var hd = el('div', 'posted-ov-hd', title);
     var x = el('span', 'posted-ov-x', '✕');
     var unbind = window.AcctsPosted.bindBack(close);
-    function close() { if (ov.parentNode) ov.parentNode.removeChild(ov); if (unbind) unbind(); }
+    function close() { if (ov.parentNode) ov.parentNode.removeChild(ov); if (unbind) unbind(); if (typeof onClose === 'function') { try { onClose(); } catch (e) {} } }
     x.addEventListener('click', close); hd.appendChild(x);
     ov.appendChild(hd); ov.appendChild(node); document.body.appendChild(ov);
   }

--- a/erp/pos_lens.js
+++ b/erp/pos_lens.js
@@ -408,6 +408,13 @@
     var b3 = cfg.b3, el = cfg.el;
     var pos = q1(b3, 'SELECT * FROM c_pos LIMIT 1');
     if (!pos) { cfg.status('No POS station (c_pos) in this tenant'); return; }
+    // §BUGFIX 2026-07-13 (user report: "shop cart pill does not close when we exited") — the overlay's
+    // native ✕ only tore down #posted-overlay, not the body-level cart float/dock (see the onClose hook
+    // below for the real fix); a stray pair could survive a prior visit. Guard re-open: never stack a
+    // second float/dock on top of a leftover one.
+    ['pos-float-panel', 'pos-dock'].forEach(function (id) {
+      var stale = document.getElementById(id); if (stale && stale.parentNode) stale.parentNode.removeChild(stale);
+    });
     var plv = q1(b3, 'SELECT m_pricelist_version_id AS v FROM m_pricelist_version WHERE m_pricelist_id=?', pos.m_pricelist_id);
     var tiles = qa(b3,
       'SELECT k.c_poskey_id, k.m_product_id, p.name, pp.pricestd FROM c_poskey k ' +
@@ -654,14 +661,23 @@
       (dtSO ? ' doctype=' + dtSO.c_doctype_id + ' ship=' + dtSO.c_doctypeshipment_id : '') +
       ' (dictionary-gated docsubtypeso=SO)');
 
+    // §BUGFIX 2026-07-13 (user report: "shop cart pill does not close when we exited") — root cause:
+    // the overlay's native ✕ only tore down #posted-overlay; the cart float panel + ⋯ dock live at
+    // document.body level (outside the overlay) and were left floating over iDempiere.html. Fix: pass
+    // this as the overlay's onClose (below, cfg.overlay(...)) so EVERY close path (✕ tap, back-gesture)
+    // disposes them too — one teardown, reused by the dock Home button as well (it now just clicks the
+    // overlay's own ✕ so the whole app has exactly one "POS is closed" moment).
+    function _disposePosChrome() {
+      [floatPanel, dock].forEach(function (n) { if (n && n.parentNode) n.parentNode.removeChild(n); });
+      console.log('§POS-HOME closed dispose=float+dock');
+    }
     // §D-3 ⋯ dock — home · import · receipt · deliver-later (data-gated) — reveal-up
     var homeBtn   = document.createElement('button'); homeBtn.className = 'pos-dock-item'; homeBtn.title = 'Close POS';
     homeBtn.innerHTML = _svgIcon('home', 18);
     homeBtn.addEventListener('pointerup', function () {
-      var ov = document.getElementById('posted-overlay'); if (ov && ov.parentNode) ov.parentNode.removeChild(ov);
-      // dispose POS-owned body floats (not inside the overlay — must be removed explicitly)
-      [floatPanel, dock].forEach(function (n) { if (n && n.parentNode) n.parentNode.removeChild(n); });
-      console.log('§POS-HOME closed dispose=float+modal+dock');
+      // trigger the SAME close the overlay's own ✕ uses, so onClose (→ _disposePosChrome) always fires.
+      var x = document.querySelector('#posted-overlay .posted-ov-x');
+      if (x) x.click(); else _disposePosChrome();   // fallback if the overlay DOM ever changes shape
     });
     var importBtn = document.createElement('button'); importBtn.className = 'pos-dock-item'; importBtn.id = 'pos-pill-import';
     importBtn.title = 'Register a new product (snap · scan · price)';
@@ -1520,7 +1536,7 @@
     itemsBody.insertBefore(stationInfo, cartBox);
 
     renderCart();
-    cfg.overlay('POS — ' + pos.name, wrap);
+    cfg.overlay('POS — ' + pos.name, wrap, _disposePosChrome);
     console.log('§POS-LIVE open station=' + pos.c_pos_id + ' tiles=' + tiles.length + ' priced=' + tiles.length + ' handAuthored=0');
     // §T1-SPEC lens.1: no auto-fire on open — replenishment is generated on the explicit button
     console.log('§POS-REPLENISH-IDLE trigger=#pos-repl-generate (staged review; nothing proposed until asked)');

--- a/erp/tests/poc_pos_close_leak.js
+++ b/erp/tests/poc_pos_close_leak.js
@@ -1,0 +1,90 @@
+// poc_pos_close_leak.js — W-POS-CLOSE-LEAK. §BUGFIX 2026-07-13 (user report: "shop cart pill does not
+//   close when we exited"). ISSUE THIS PROVES / DISPROVES: does closing the POS lens via the overlay's
+//   OWN native ✕ (the obvious top-right close, distinct from the buried ⋯→Home dock button) actually
+//   tear down every POS-owned DOM node, or does the body-level cart float panel + ⋯ dock survive and
+//   keep floating over iDempiere.html?
+//   Root cause fixed: `_overlay()` (idempiere.html) gained an optional onClose param; pos_lens.js wires
+//   its float/dock teardown through it so EVERY close path (✕ tap, dock Home tap) shares one dispose.
+//   §-log first (per docs/TestArchitecture.md §Browser Testing); Playwright drives the REAL idempiere.html
+//   over the real GardenWorld seed (mirrors poc_zoom_across.js's login pattern).
+// Run: node erp/tests/poc_pos_close_leak.js 2>&1 | tee build/pos_close_leak.log — then READ the log.
+'use strict';
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright');
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json', '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm', '.mjs': 'text/javascript', '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/erp/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (e) { res.writeHead(404); res.end('404 ' + p); return; } res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(b); });
+});
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = []; const W = (ok, m) => log.push((ok ? '🟢' : '🔴') + ' ' + m);
+
+(async () => {
+  await new Promise(r => server.listen(0, r)); const port = server.address().port;
+  const browser = await chromium.launch(); const page = await browser.newPage({ viewport: { width: 1100, height: 800 } });
+  const cons = []; page.on('console', m => cons.push(m.text())); page.on('pageerror', e => cons.push('PAGEERR ' + e));
+
+  await page.goto(`http://localhost:${port}/erp/idempiere.html?login=GardenAdmin`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  let gate = false;
+  for (let i = 0; i < 60; i++) { gate = await page.evaluate(() => typeof window.IdmpPillPosGate === 'function' && window.IdmpPillPosGate()).catch(() => false); if (gate) break; await sleep(1000); }
+  W(gate, '§gate IdmpPillPosGate() true (GardenWorld tenant carries a c_pos row)');
+  if (!gate) { console.log(log.join('\n')); console.log('\n❌ W-POS-CLOSE-LEAK cannot proceed — no POS station in seed'); await browser.close(); server.close(); process.exit(1); return; }
+
+  // open POS the real way: the rail pill, not a direct function call
+  await page.evaluate(() => { const t = document.getElementById('idmp-pill-trigger'); if (t) t.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(500);
+  await page.evaluate(() => { const b = document.getElementById('pill-pos'); if (b) b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(600);
+  const opened = await page.evaluate(() => !!document.getElementById('posted-overlay') && !!document.getElementById('pos-float-panel') && !!document.getElementById('pos-dock'));
+  W(opened, 'POS opened: #posted-overlay + #pos-float-panel + #pos-dock all present');
+
+  // open the cart float panel (the "shop cart pill" itself, #pos-pill-payment) so it's visibly IN USE
+  await page.click('#pos-pill-payment');
+  await sleep(200);
+  const floatOpen = await page.$eval('#pos-float-panel', n => n.classList.contains('open')).catch(() => false);
+  W(floatOpen, 'cart float panel opened via #pos-pill-payment (§POS-FLOAT toggle=open)');
+
+  // ── THE ACTUAL BUG: close via the overlay's OWN native ✕ (the obvious "exit" gesture) ──
+  await page.click('#posted-overlay .posted-ov-x');
+  await sleep(300);
+  const afterX = await page.evaluate(() => ({
+    overlay: !!document.getElementById('posted-overlay'),
+    float: !!document.getElementById('pos-float-panel'),
+    dock: !!document.getElementById('pos-dock')
+  }));
+  W(!afterX.overlay, '✕ close removes #posted-overlay', JSON.stringify(afterX));
+  W(!afterX.float, '✕ close ALSO removes #pos-float-panel (was the leak — cart pill stuck floating)', JSON.stringify(afterX));
+  W(!afterX.dock, '✕ close ALSO removes #pos-dock (⋯ dock, was the leak)', JSON.stringify(afterX));
+  W(cons.some(l => l === '§POS-HOME closed dispose=float+dock'), '§POS-HOME logged the teardown on the ✕ path (not just dock-Home)');
+
+  // ── re-open POS after a ✕ close — must be a single clean instance, never a stacked duplicate ──
+  cons.length = 0;
+  await page.evaluate(() => { const b = document.getElementById('pill-pos'); if (b) b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await sleep(600);
+  const reopened = await page.evaluate(() => ({
+    floats: document.querySelectorAll('#pos-float-panel').length,
+    docks: document.querySelectorAll('#pos-dock').length,
+    overlays: document.querySelectorAll('#posted-overlay').length
+  }));
+  W(reopened.floats === 1 && reopened.docks === 1 && reopened.overlays === 1, 'reopen after ✕-close → exactly ONE of each (no stacked duplicates)', JSON.stringify(reopened));
+
+  // ── the dock Home path (⋯ → home icon) still fully closes too ──
+  await page.evaluate(() => { const t = document.getElementById('pos-dock-trigger'); if (t) t.dispatchEvent(new PointerEvent('click', { bubbles: true })); });
+  await sleep(200);
+  const homeBtns = await page.$$('#pos-dock-items .pos-dock-item');
+  if (homeBtns[0]) await homeBtns[0].dispatchEvent('pointerup');
+  await sleep(300);
+  const afterHome = await page.evaluate(() => ({
+    overlay: !!document.getElementById('posted-overlay'),
+    float: !!document.getElementById('pos-float-panel'),
+    dock: !!document.getElementById('pos-dock')
+  }));
+  W(!afterHome.overlay && !afterHome.float && !afterHome.dock, '⋯ → Home still fully closes (overlay+float+dock)', JSON.stringify(afterHome));
+
+  console.log(log.join('\n'));
+  const pass = log.filter(l => l.startsWith('🟢')).length;
+  console.log('\nW-POS-CLOSE-LEAK ' + pass + '/' + log.length);
+  fs.writeFileSync(path.join(__dirname, 'poc_pos_close_leak.log'), log.join('\n') + '\n\n' + cons.filter(t => /§POS|PAGEERR/.test(t)).slice(0, 40).join('\n'));
+  await browser.close(); server.close(); process.exit(pass === log.length ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });


### PR DESCRIPTION
## Summary
- The POS cart float panel (`#pos-float-panel`) and ⋯ dock (`#pos-dock`) mount on `document.body`, outside `#posted-overlay` (the shared modal `_overlay()` creates). Only the buried ⋯→Home button disposed all three; the overlay's own native ✕ only removed `#posted-overlay`, leaving the cart pill/dock stuck floating over iDempiere.html.
- `_overlay(title, node, onClose)` gains an optional `onClose`, fired from its internal `close()` (covers ✕ tap and the back-gesture). `pos_lens.js` wires float+dock teardown through it; the dock Home button now triggers the same close path instead of duplicating the logic. Added a defensive guard on POS (re)open that clears any stale float/dock first.

## Test plan
- [x] `node erp/tests/poc_pos_close_leak.js` — 9/9 PASS (new witness)
- [x] Confirmed 4/9 against pre-fix code via `git stash` — fails exactly the leak assertions, proving the witness catches the regression
- [x] `node erp/tests/witness_pos_pillbar.js` — 15/15 PASS (no regression)
- [x] `node erp/tests/poc_zoom_across.js` — 8/8 PASS (no regression)
- [x] Localhost screenshots: cart open → click ✕ → clean iDempiere, nothing left floating

🤖 Generated with [Claude Code](https://claude.com/claude-code)