### PR TITLE
fix(viewer): Zoom Across never revealed the #find-selected ERP drawer

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -4224,6 +4224,22 @@
     };
 
     // ── Zoom-Across SCOPE consume (ZOOM_ACROSS_SCOPE_SESSION §SPEC) ─────────────────────────────────────────
+    // §BUGFIX 2026-07-13 (user report: "the ERP drawer at the bottom does not appear [after Zoom Across
+    // lands]; only when exiting the building and back to it, it is") — root cause: A.focusElement only
+    // does the 3D highlight (ghost/outline/zoom); it never touches #find-selected (the bottom bar with
+    // the cost figure + "› ERP" push + "open ↗"/"iDempiere ↗" links). Every OTHER selection path (a
+    // single result-item click, line ~3940; a storey/disc GROUP tap, line ~3117) explicitly reveals that
+    // bar via elSelected.style.display='flex' + _updateSelCost(set,label) — applyFindScope (the THIRD
+    // selection path, boot-time auto-Find from the ERP pill) never did. Re-entering the building later
+    // hits one of the other two paths, which is why a manual re-select "fixed" it. Mirrors the GROUP-tap
+    // fix (§FIND_MULTISEL, line ~3117) exactly — same reveal, same _updateSelCost call.
+    function _revealSelectedBar(set, label) {
+      var elSelText = document.getElementById('find-selected-text');
+      if (!set || !set.size) { if (elSelected) elSelected.style.display = 'none'; return; }
+      if (elSelText) elSelText.textContent = label;
+      if (elSelected) elSelected.style.display = 'flex';
+      try { _updateSelCost(set, label); } catch (e) { console.log('§ZOOM-SCOPE_BAR_ERR ' + e.message); }
+    }
     // The ERP "Zoom Across" pill cold-opens the viewer with ?find=<scope>; we run the INCUMBENT Find on it and
     // light the matches with the SAME highlighter a pick/Find-zoom uses (A.focusElement). NO parallel highlighter.
     //   scope = a comma-separated guid set  → focus those elements directly.
@@ -4240,7 +4256,9 @@
       // guid-set: has a comma OR isn't an Ifc* class token → treat as explicit element ids.
       if (scope.indexOf(',') >= 0 || !/^ifc[a-z]/i.test(scope)) {
         var guids = scope.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
-        var lit = A.focusElement(new Set(guids), { item: guids.length === 1 });
+        var guidSet = new Set(guids);
+        var lit = A.focusElement(guidSet, { item: guids.length === 1 });
+        _revealSelectedBar(guidSet, guids.length === 1 ? ('Zoom Across · 1 item') : ('Zoom Across · ' + guids.length + ' items'));
         if (tmOpen && guids.length) {
           try { window.tmJumpToElement(guids[0]); } catch (e) {}   // TM consumes: jump to its construction moment
           console.log('§ZOOM-SCOPE route=tm kind=guids n=' + guids.length + ' moment=' + guids[0]);
@@ -4256,6 +4274,7 @@
       runSearch();
       var set = new Set((nav.results || []).map(function (r) { return r.guid; }).filter(Boolean));
       if (set.size) A.focusElement(set, { item: false });
+      _revealSelectedBar(set, friendlyClass(scope) + ' · ' + set.size + (set.size === 1 ? ' item' : ' items'));
       if (tmOpen && set.size) {
         var firstG = (nav.results || []).map(function (r) { return r.guid; }).filter(Boolean)[0];
         if (firstG) { try { window.tmJumpToElement(firstG); } catch (e) {} }   // TM consumes the class's first element

--- a/viewer/tests/poc_zoom_scope_live.js
+++ b/viewer/tests/poc_zoom_scope_live.js
@@ -52,9 +52,19 @@ const grab = re => { for (const l of log) { const m = re.exec(l); if (m) return 
 
   // A/B — the boot ?find handler should have auto-applied the scope. Give it a beat, then assert.
   await page.waitForTimeout(3000);
-  const cls = grab(/§ZOOM-SCOPE kind=class scope="([^"]+)" matches=(\d+)/);
+  // §BUGFIX 2026-07-13: the log line grew a "route=find|tm " prefix (§ARCH-OWNERSHIP, TM-if-open else
+  // Find) after this regex was written — it never matched since, so A/A2/C below were silently absent
+  // (not failing loudly; `grab` just returns null and cls[2]>0 skipped). Widened to tolerate the prefix.
+  const cls = grab(/§ZOOM-SCOPE route=\w+ kind=class scope="([^"]+)" matches=(\d+)/);
   verdict(!!cls && cls[1] === SCOPE && Number(cls[2]) > 0, 'A — ?find auto-ran Find on the class, matches>0', cls ? (cls[1] + ' matches=' + cls[2]) : 'absent');
   verdict(seen(/§FOCUS_ELEM guids=\d+ lit=[1-9]/), 'B — matches lit via the Find highlighter (focusElement), not a parallel one');
+  // §BUGFIX 2026-07-13 (user report: "the ERP drawer at the bottom does not appear" after Zoom Across) —
+  // A.focusElement only does the 3D highlight; #find-selected (cost + › ERP push + iDempiere ↗ links) was
+  // never revealed by this boot path (every OTHER selection path — item click, storey/disc group tap —
+  // already did). See navigate_find.js _revealSelectedBar, wired into both applyFindScope branches.
+  const barVisible = await page.evaluate(() => { var e = document.getElementById('find-selected'); return !!e && getComputedStyle(e).display !== 'none'; });
+  const barText = await page.evaluate(() => { var e = document.getElementById('find-selected-text'); return e ? e.textContent : ''; });
+  verdict(barVisible && barText.length > 0, 'D — #find-selected (the ERP drawer) is REVEALED with a label after a class scope lands', 'visible=' + barVisible + ' text="' + barText + '"');
 
   // expected count cross-check against the raw DB (non-invent: the fold must equal the data)
   const dbCount = await page.evaluate((c) => {
@@ -70,8 +80,11 @@ const grab = re => { for (const l of log) { const m = re.exec(l); if (m) return 
     await page.evaluate((g) => window.APP.applyFindScope(g.join(',')), guids);
     await page.waitForTimeout(800);
   }
-  const gv = grab(/§ZOOM-SCOPE kind=guids n=(\d+) lit=(\d+)/);
+  const gv = grab(/§ZOOM-SCOPE route=\w+ kind=guids n=(\d+) lit=(\d+)/);
   verdict(!!gv && Number(gv[1]) === guids.length && Number(gv[2]) > 0, 'C — guid-set scope focuses those exact elements', gv ? ('n=' + gv[1] + ' lit=' + gv[2]) : 'absent');
+  const barVisible2 = await page.evaluate(() => { var e = document.getElementById('find-selected'); return !!e && getComputedStyle(e).display !== 'none'; });
+  const barText2 = await page.evaluate(() => { var e = document.getElementById('find-selected-text'); return e ? e.textContent : ''; });
+  verdict(guids.length === 0 || (barVisible2 && barText2.length > 0), 'E — #find-selected also revealed after a guid-set scope lands', 'visible=' + barVisible2 + ' text="' + barText2 + '"');
 
   verdict(errs.length === 0, '0 pageerrors', errs.length ? errs.slice(0, 3).join(' | ') : 'clean');
 


### PR DESCRIPTION
## Summary
- `A.applyFindScope` (the boot-time consumer of the ERP "Zoom Across" pill's `?find=<scope>` param) only ran `A.focusElement`, which does the 3D highlight but never touched `#find-selected` — the bottom bar with the cost figure, the "› ERP" push button, and the "open ↗"/"iDempiere ↗" deep-links. Every other selection path (single result click, storey/disc group tap) already revealed that bar; this boot path was missed. Re-entering the building hits one of the other paths, which is why a manual re-select "fixed" it.
- New `_revealSelectedBar(set, label)` mirrors the existing group-tap reveal, wired into both `applyFindScope` branches.
- Also fixed a stale regex in `poc_zoom_scope_live.js` (assertions A/A2/C were silently absent since a `route=find|tm ` prefix was added to the log line and the regex never updated — confirmed failing identically on a clean `origin/main` checkout, unrelated to this fix).

## Test plan
- [x] `node viewer/tests/poc_zoom_scope_live.js` — 8/8 PASS (regex fix + new D/E assertions)
- [x] Confirmed 2/8 fail (exactly D/E) against pre-fix `navigate_find.js` via `git stash`
- [x] Localhost screenshot: `?find=IfcBuildingElementProxy` landing shows the drawer with cost + "› ERP" live

🤖 Generated with [Claude Code](https://claude.com/claude-code)