### PR TITLE
fix(sw): stop treating room_walker.js as an immutable lib/ vendor file

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v748';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v749';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -218,6 +218,12 @@ const _PRECACHE_SET = new Set(PRECACHE_ASSETS);
 // Precached files use cache-first — freshness guaranteed by CACHE_VERSION bump on deploy.
 function isNetworkFirst(url) {
   var base = url.split('?')[0];
+  // room_walker.js lives under lib/ by folder placement only — it's OUR frequently-changing
+  // room logic (PR #773/#776/#779 all touched it), not a third-party immutable vendor lib.
+  // The blanket lib/ rule below silently starved it of the network-first path for 3 straight
+  // deploys (found 2026-07-14, prompts/FUNCTIONAL_SPACE_MGMT_NEXT_SESSION.md §CACHE-LANDMINE) —
+  // exempt it explicitly rather than trusting folder placement to imply immutability.
+  if (base.endsWith('/lib/room_walker.js')) return true;
   // lib/ files are versioned and immutable — always cache-first
   if (base.includes('/lib/')) return false;
   // CDN fallback assets are also immutable — cache-first


### PR DESCRIPTION
## Summary
- `isNetworkFirst()` in `viewer/sw.js` hard-coded "anything under `/lib/` = cache-first forever" — meant for true vendor libs (three.js, sql-wasm), but `room_walker.js` sits in `lib/` by folder placement only.
- PR #773/#776/#779 all changed `room_walker.js`; none of those fixes reached a returning browser — a `CACHE_VERSION` bump wouldn't even have helped, since the `/lib/` check short-circuits before that logic runs.
- Confirmed live 2026-07-14 against the real HHS building: console showed `§ROOM_GRAPH edges=11 deadend=75 orphan=47`, matching neither the pre-fix (16/73/44) nor post-fix (27/66/40) numbers from #779's own commit message, and `habitable=70` rooms when #779 says the raster was regenerated for 71.
- Same pattern recurred once before (unmerged branch `fix/room-graph-cache-bust`) — `CACHE_VERSION` bumps are a band-aid that keeps getting missed; this exempts the one file that changes often instead.

## Test plan
- [x] `node --check viewer/sw.js`
- [x] Extracted `isNetworkFirst()` verbatim and unit-tested it in isolation: `room_walker.js` → network-first (was cache-first); real vendor libs (`three.module.min.js`, `sql-wasm.wasm`) unaffected, still cache-first; unknown project JS still defaults network-first.
- [x] Served the worktree locally, curl-verified `sw.js` and `viewer/lib/room_walker.js` both 200 and the new `CACHE_VERSION`/exemption lines are present in the served bytes.
- [ ] Full-clear + reload verification in a real browser against HHS — pending (see bim-compiler `prompts/FUNCTIONAL_SPACE_MGMT_NEXT_SESSION.md` §CACHE-LANDMINE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)