### PR TITLE
fix(viewer): needle-inject trusted a successful patch as proof rooms were compiled

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -889,7 +889,22 @@
           }
         } catch (e) { console.warn('[NEEDLE] §NEEDLE_PATCH_ERR ' + (e && e.message)); }
 
-        if (applied) {
+        // §NEEDLE-COMPILED-CHECK: `applied` only means the patch SQL ran without throwing — for
+        // HHS that patch is 4 lines regenerating storey_walkable_raster, NOT compiled room data
+        // (the old patch that DID carry compiled rows was retired, PR #775). Trusting `applied`
+        // alone skips RoomWalker entirely on a fresh DB, leaving raw uncompiled IfcSpace rows (no
+        // room_guid, none of the WALL-SNAP/SUSPECT-LARGE/§MULTI-RECT fixes) — and then persists
+        // that regressed state back into the IDB cache (§NEEDLE_PERSIST below), poisoning every
+        // later reload too. Same missing-column class of bug already fixed once at this file's
+        // `_roomsFromSpatialStructure` (~line 1887) via PRAGMA table_info — reuse that technique
+        // to require actual compiled evidence (a `room_guid` column), not just a successful patch.
+        var hasCompiledRooms = false;
+        try {
+          var ssColsCheck = A.dbQuery("PRAGMA table_info(spatial_structure)");
+          hasCompiledRooms = ssColsCheck.some(function(c) { return c[1] === 'room_guid'; });
+        } catch (eCols) { /* hasCompiledRooms stays false */ }
+
+        if (applied && hasCompiledRooms) {
           source = 'patch';
         } else {
           // S2.2 — walker source (any building): lazy-load the room_walker JS port, compile
@@ -906,10 +921,16 @@
           }
           if (!window.RoomWalker) throw new Error('RoomWalker unavailable after load');
           window.RoomWalker.walk(A.db, { write: true });
-          source = 'walker';
+          source = applied ? 'patch+walker' : 'walker';
         }
 
-        var cq = A.dbQuery("SELECT COUNT(*), COUNT(DISTINCT room_guid) FROM spatial_structure WHERE type='IfcSpace'");
+        var hasRoomGuidNow = false;
+        try {
+          var ssColsNow = A.dbQuery("PRAGMA table_info(spatial_structure)");
+          hasRoomGuidNow = ssColsNow.some(function(c) { return c[1] === 'room_guid'; });
+        } catch (eColsNow) { /* hasRoomGuidNow stays false */ }
+        var cq = A.dbQuery("SELECT COUNT(*), COUNT(DISTINCT " + (hasRoomGuidNow ? 'room_guid' : 'guid') +
+          ") FROM spatial_structure WHERE type='IfcSpace'");
         var rectsN = cq.length ? cq[0][0] : 0;
         var roomsN = cq.length ? cq[0][1] : 0;
         console.log('[NEEDLE] §NEEDLE_INJECT bld=' + bld + ' source=' + source + ' rooms=' + roomsN + ' rects=' + rectsN);


### PR DESCRIPTION
## Summary
- `_needleInject()` set `source='patch'` (skipping the RoomWalker compile fallback) whenever the fetched patch SQL executed without throwing.
- For HHS that patch is 4 lines regenerating `storey_walkable_raster` only — PR #775 retired the old patch that used to carry compiled room rows. So on a genuinely fresh DB (no prior IDB-persisted compile), `applied=true` but no room was ever actually compiled: `spatial_structure` kept its raw, uncompiled `IfcSpace` rows — no `room_guid`, none of WALL-SNAP/SUSPECT-LARGE/§MULTI-RECT.
- `§NEEDLE_PERSIST` then wrote that regressed state back into the IDB cache, so every later reload reproduced it. Reported live 2026-07-14: after a full storage clear, HHS showed 105 raw rooms (not the expected ~71 compiled) and the console logged `§HELPERS_QUERY_ERR no such column: room_guid` + `NEEDLE_INJECT ... rooms=0 rects=0`.
- Fix reuses the exact same-file precedent already established at `_roomsFromSpatialStructure` (~line 1887, "§MULTI-RECT guard" comment, itself fixing a prior regression from this identical missing-column class): probe `PRAGMA table_info(spatial_structure)` for a `room_guid` column as evidence of an actual compile, don't trust a successful patch exec alone. Also guards the diagnostic COUNT query in `_needleInject` the same way.

## Test plan
- [x] `node --check viewer/navigate_find.js`
- [x] Extracted the `hasCompiledRooms` check verbatim and unit-tested both branches in isolation: no `room_guid` column → `false` (walker runs); `room_guid` present → `true` (patch trusted, walker skipped)
- [ ] Real-browser HHS verification after full storage clear — pending, ask the user to confirm rooms come back to ~71 with `room_guid`-bearing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)