### PR TITLE
fix(rooms): §HALLWAY-BACKBONE — room paths hug real corridors, not open space

### DIFF
--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -114,6 +114,35 @@
     return bucket;
   }
 
+  // §CORRIDOR-WIDTH (2026-07-14): the corridor's own SIDE walls run the SAME axis as the bucket
+  // (unlike growToWall's END caps, which run perpendicular) — find the nearest one flanking
+  // runCoord on each side, so the backbone carries a REAL measured width, not just a centerline.
+  // WHY: room_graph.js's `_pointWalkable()` falls back to "is this point inside a compiled room
+  // rect" when a storey has no walkable raster — by that fallback's own documented design, real
+  // open corridor floor (no room modeled there) reads as illegal. Feeding this measured width back
+  // into that legality test (see room_graph.js wiring) lets a real, wall-bounded corridor register
+  // as walkable even without a raster, instead of every corridor chord failing detour.
+  var DEFAULT_HALF_WIDTH = 1.2; // m — only used when no flanking wall is found on that side (rare: an open-plan edge)
+  function bucketWidth(bucket, walls) {
+    var rc = bucket.runCoord, lo = bucket.span.lo, hi = bucket.span.hi;
+    var nearAbove = null, nearBelow = null;
+    walls.forEach(function (w) {
+      var wWideX = w.bx >= w.by;
+      var wAxis = wWideX ? 'x' : 'y';
+      if (wAxis !== bucket.axis) return; // only the corridor's OWN side walls (same run direction)
+      var alongC = (bucket.axis === 'x') ? w.cx : w.cy;
+      var alongHalf = (bucket.axis === 'x') ? (w.bx / 2) : (w.by / 2);
+      if (alongC + alongHalf < lo || alongC - alongHalf > hi) return; // must run alongside this corridor
+      var perpC = (bucket.axis === 'x') ? w.cy : w.cx;
+      var perpHalf = (bucket.axis === 'x') ? (w.by / 2) : (w.bx / 2);
+      if (perpC >= rc) { var d = (perpC - perpHalf) - rc; if (d >= -WALL_CROSS_SLACK && (nearAbove === null || d < nearAbove)) nearAbove = Math.max(d, 0); }
+      else { var d2 = rc - (perpC + perpHalf); if (d2 >= -WALL_CROSS_SLACK && (nearBelow === null || d2 < nearBelow)) nearBelow = Math.max(d2, 0); }
+    });
+    bucket.halfWidthHi = (nearAbove !== null) ? nearAbove : DEFAULT_HALF_WIDTH;
+    bucket.halfWidthLo = (nearBelow !== null) ? nearBelow : DEFAULT_HALF_WIDTH;
+    return bucket;
+  }
+
   // Point-to-AABB distance (same convention as room_graph.js's rectDist): 0 if inside, else
   // Euclidean distance to the nearest edge/corner.
   function _rectDist(x0, y0, x1, y1, px, py) {
@@ -240,6 +269,7 @@
     var buckets = correlateDoorEdges(edges);
     var joined = joinDoorways(buckets);
     joined.forEach(function (b) { growToWall(b, wallsByStorey[b.storey] || []); });
+    joined.forEach(function (b) { bucketWidth(b, wallsByStorey[b.storey] || []); });
 
     var stairGroupsResult = RoomGraph ? RoomGraph.getStairGroups(dbQuery, log) : { groups: {} };
     joined.forEach(function (b) { terminateAtStair(b, stairGroupsResult.groups); });
@@ -270,9 +300,21 @@
     return { buckets: buckets, joined: joined, chains: allChains, crossings: allCrossings, stats: stats };
   }
 
+  // A bucket's real walkable footprint as an AABB rect — span along its axis, measured
+  // (or default) half-width perpendicular. Used by room_graph.js's _pointWalkable() fallback so a
+  // real corridor registers as walkable even on a storey with no raster.
+  function bucketRect(b) {
+    var perpLo = b.runCoord - (b.halfWidthLo != null ? b.halfWidthLo : DEFAULT_HALF_WIDTH);
+    var perpHi = b.runCoord + (b.halfWidthHi != null ? b.halfWidthHi : DEFAULT_HALF_WIDTH);
+    return (b.axis === 'x')
+      ? { x0: b.span.lo, x1: b.span.hi, y0: perpLo, y1: perpHi }
+      : { x0: perpLo, x1: perpHi, y0: b.span.lo, y1: b.span.hi };
+  }
+
   var API = {
     doorEdge: doorEdge, correlateDoorEdges: correlateDoorEdges, joinDoorways: joinDoorways,
-    growToWall: growToWall, terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
+    growToWall: growToWall, bucketWidth: bucketWidth, bucketRect: bucketRect,
+    terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
     buildBackbone: buildBackbone
   };
   ROOT.HallwayBackbone = API;

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -1,0 +1,280 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * hallway_backbone.js — §HALLWAY-BACKBONE (2026-07-14, bim-compiler
+ * prompts/FUNCTIONAL_SPACE_MGMT_NEXT_SESSION.md). Compiles a real, door+wall-grounded corridor
+ * spine per storey from the SAME building db common/room_graph.js already reads. Verb chain
+ * (matches the spec doc's step numbering 1:1):
+ *   1. doorEdge(door)        — wall-run-axis from the door's OWN bbox aspect ratio.
+ *   2. correlateDoorEdges()  — bucket-matrix keyed by (storey, axis, roundedRunCoord).
+ *   3. joinDoorways()        — buckets with >=3 aligned doors = hallway-candidate.
+ *   4. growToWall()          — extend the bucket's span until a REAL perpendicular wall caps it.
+ *   5. terminateAtStair()    — an open (uncapped) end near a stair is a connecting space, not a
+ *                              dead-end. Reuses room_graph.js's getStairGroups() — WalkerDoctrine
+ *                              §10, the ONE trusted stair extractor, not a fresh ad-hoc query.
+ *   6. walkBackbone()        — union-find merge of buckets whose grown spans cross (T-junction),
+ *                              then an ordered walk of each resulting chain (serves BOTH path
+ *                              routing/escape-route AND a flythrough camera path from the same
+ *                              structure — user's explicit ask, one structure two consumers).
+ *
+ * WHY: room_graph.js's shortestPath() currently rescues a room's lone door onto ONE
+ * per-storey `CIRC::<storey>` blob (see room_graph.js buildGraph() E2) and its _legalizePath()
+ * detour only re-routes a chord that CROSSES A WALL — a chord that stays in open space but cuts
+ * diagonally across a real corridor (not hugging its centerline) is "legal" and never detoured.
+ * Both are why a rendered room-to-room path can visibly float through open space instead of
+ * following the real hallway/stairway route (user-reported, 2026-07-14). This module's spine
+ * nodes are meant to REPLACE that single blob with real, ordered waypoints along the actual
+ * corridor, so shortestPath()'s own Dijkstra naturally routes through them — not just a rendering
+ * patch. escapeRoute() reuses the exact same graph, so it inherits the fix for free, no separate
+ * feature.
+ *
+ * DESIGN PRINCIPLE (user, 2026-07-14): the bucket/array-set is deliberately generic (storey, axis,
+ * runCoord) — not hard-wired to doors only. Any element that corroborates a space's identity
+ * (railings, stairs, walls, doors) can roll into the same structure later; this file's `doorEdge`
+ * is one instance of an "edge contributor," not the only one that will ever exist.
+ *
+ * Caller contract: same dual-mode `dbQuery(sql)` -> array-of-row-arrays convention as
+ * room_graph.js — DB/file I/O-free, runs identically in-browser and in a node witness script.
+ */
+(function () {
+  'use strict';
+  var ROOT = (typeof window !== 'undefined') ? window : {};
+  var RoomGraph = (typeof module !== 'undefined' && module.exports) ? require('./room_graph.js') : ROOT.RoomGraph;
+
+  // §RUN_COORD_TOL: bucket-rounding width for "these doors share the same wall run." Grounded in
+  // real wall-thickness scale (typical interior wall 0.15-0.3m; this is generous slack for
+  // wall-centerline-vs-face offset across a building's doors, not fitted to one building's data).
+  var RUN_COORD_TOL = 0.6;
+  var MIN_DOORS_FOR_HALLWAY = 3;
+  // §STAIR_CLEARANCE: movement-clearance tolerance, per user's own steer ("stairs movement space
+  // can be of say 2 meter height flow onto the stairs contour").
+  var STAIR_CLEARANCE = 2.0;
+  // Slack added to a wall's own half-thickness when testing whether it actually crosses a
+  // corridor's runCoord line (real walls are rasterized transforms, not infinitely thin planes).
+  var WALL_CROSS_SLACK = 0.3;
+
+  // ── 1. doorEdge ──────────────────────────────────────────────────────────────────────────────
+  // d: {guid, name, storey, cx, cy, bx, by}. rotation_z is NOT used — measured across this
+  // extracted data (2026-07-14 scratch session) as always 0, unusable as an axis signal. The
+  // door's OWN bbox aspect ratio is the real, measured signal instead: a door wide in X sits in a
+  // wall that runs along X (cluster candidates share Y); wide in Y sits in a Y-running wall.
+  function doorEdge(d) {
+    var wideX = d.bx >= d.by;
+    return wideX
+      ? { guid: d.guid, name: d.name, storey: d.storey, axis: 'x', runCoord: d.cy, alongCoord: d.cx, cx: d.cx, cy: d.cy }
+      : { guid: d.guid, name: d.name, storey: d.storey, axis: 'y', runCoord: d.cx, alongCoord: d.cy, cx: d.cx, cy: d.cy };
+  }
+
+  // ── 2. correlateDoorEdges ────────────────────────────────────────────────────────────────────
+  function correlateDoorEdges(edges) {
+    var buckets = {}, order = [];
+    edges.forEach(function (e) {
+      var rounded = Math.round(e.runCoord / RUN_COORD_TOL) * RUN_COORD_TOL;
+      var key = e.storey + '|' + e.axis + '|' + rounded.toFixed(2);
+      if (!buckets[key]) {
+        buckets[key] = { key: key, storey: e.storey, axis: e.axis, runCoord: rounded, doors: [] };
+        order.push(key);
+      }
+      buckets[key].doors.push(e);
+    });
+    return order.map(function (k) { return buckets[k]; });
+  }
+
+  // ── 3. joinDoorways ──────────────────────────────────────────────────────────────────────────
+  function joinDoorways(buckets) {
+    return buckets.filter(function (b) { return b.doors.length >= MIN_DOORS_FOR_HALLWAY; });
+  }
+
+  // ── 4. growToWall ────────────────────────────────────────────────────────────────────────────
+  // walls: array of {cx,cy,bx,by} (real IfcWall% only — columns/beams deliberately excluded per
+  // user, "ignore supporting columns/beams for convenience"). A capping wall runs PERPENDICULAR to
+  // this bucket's axis (a cross-wall stopping the corridor) — a wall running the SAME way as the
+  // bucket is more of the corridor's own side wall, not a cap.
+  function growToWall(bucket, walls) {
+    var alongs = bucket.doors.map(function (d) { return d.alongCoord; });
+    var lo = Math.min.apply(null, alongs), hi = Math.max.apply(null, alongs);
+    var rc = bucket.runCoord;
+    var loCap = null, hiCap = null;
+    walls.forEach(function (w) {
+      var wWideX = w.bx >= w.by;
+      var wAxis = wWideX ? 'x' : 'y';
+      if (wAxis === bucket.axis) return; // must run the OTHER way to cap this corridor
+      var alongC = (bucket.axis === 'x') ? w.cx : w.cy;
+      var perpLo = (bucket.axis === 'x') ? (w.cy - w.by / 2) : (w.cx - w.bx / 2);
+      var perpHi = (bucket.axis === 'x') ? (w.cy + w.by / 2) : (w.cx + w.bx / 2);
+      if (rc < perpLo - WALL_CROSS_SLACK || rc > perpHi + WALL_CROSS_SLACK) return; // doesn't cross this line
+      if (alongC <= lo && (loCap === null || alongC > loCap)) loCap = alongC;
+      if (alongC >= hi && (hiCap === null || alongC < hiCap)) hiCap = alongC;
+    });
+    bucket.span = { lo: (loCap !== null) ? loCap : lo, hi: (hiCap !== null) ? hiCap : hi };
+    bucket.openLo = (loCap === null);
+    bucket.openHi = (hiCap === null);
+    return bucket;
+  }
+
+  // Point-to-AABB distance (same convention as room_graph.js's rectDist): 0 if inside, else
+  // Euclidean distance to the nearest edge/corner.
+  function _rectDist(x0, y0, x1, y1, px, py) {
+    var dx = Math.max(x0 - px, 0, px - x1);
+    var dy = Math.max(y0 - py, 0, py - y1);
+    return Math.hypot(dx, dy);
+  }
+
+  // ── 5. terminateAtStair ──────────────────────────────────────────────────────────────────────
+  // stairGroups: the `groups` map from RoomGraph.getStairGroups(dbQuery, log) — the ONE trusted
+  // stair extractor (WalkerDoctrine §10), reused here rather than a fresh ad-hoc IfcStair% query.
+  function terminateAtStair(bucket, stairGroups, storeyOf) {
+    var rc = bucket.runCoord;
+    function endPoint(along) {
+      return (bucket.axis === 'x') ? { x: along, y: rc } : { x: rc, y: along };
+    }
+    function nearestStair(pt) {
+      var best = null, bestD = Infinity;
+      Object.keys(stairGroups).forEach(function (key) {
+        var gr = stairGroups[key];
+        if (gr.xlo === Infinity) return; // no XY footprint captured (defensive, shouldn't happen)
+        var d = _rectDist(gr.xlo, gr.ylo, gr.xhi, gr.yhi, pt.x, pt.y);
+        if (d < bestD) { bestD = d; best = key; }
+      });
+      return { key: best, dist: bestD };
+    }
+    if (bucket.openLo) {
+      var r = nearestStair(endPoint(bucket.span.lo));
+      bucket.stairLo = (r.dist <= STAIR_CLEARANCE) ? r.key : null;
+      bucket.stairLoDist = r.dist;
+    }
+    if (bucket.openHi) {
+      var r2 = nearestStair(endPoint(bucket.span.hi));
+      bucket.stairHi = (r2.dist <= STAIR_CLEARANCE) ? r2.key : null;
+      bucket.stairHiDist = r2.dist;
+    }
+    return bucket;
+  }
+
+  // ── 6. walkBackbone ──────────────────────────────────────────────────────────────────────────
+  // Union-find merge of buckets whose grown spans CROSS (T-junction): an x-run bucket's runCoord
+  // falls inside a y-run bucket's span, AND that y-run bucket's runCoord falls inside the x-run
+  // bucket's span. Returns { chains: [[bucket,...ordered...], ...] } — each chain is an ORDERED
+  // path (not just a graph), per the user's explicit ask: the same structure feeds both path
+  // routing (door-to-door must have a clear corridor-hugging route) and a flythrough camera path.
+  function walkBackbone(buckets) {
+    var n = buckets.length;
+    var parent = buckets.map(function (_, i) { return i; });
+    function find(i) { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; } return i; }
+    function union(a, b) { var ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb; }
+
+    var crossings = []; // {a,b,x,y} — real crossing points, kept for ordering + rendering
+    for (var i = 0; i < n; i++) {
+      for (var j = i + 1; j < n; j++) {
+        var A = buckets[i], B = buckets[j];
+        if (A.storey !== B.storey || A.axis === B.axis) continue;
+        var xB = (A.axis === 'x') ? B.runCoord : A.runCoord; // the shared crossing point
+        var yB = (A.axis === 'x') ? A.runCoord : B.runCoord;
+        var aAlong = (A.axis === 'x') ? xB : yB;
+        var bAlong = (B.axis === 'x') ? xB : yB;
+        var aIn = aAlong >= A.span.lo - WALL_CROSS_SLACK && aAlong <= A.span.hi + WALL_CROSS_SLACK;
+        var bIn = bAlong >= B.span.lo - WALL_CROSS_SLACK && bAlong <= B.span.hi + WALL_CROSS_SLACK;
+        if (aIn && bIn) {
+          union(i, j);
+          crossings.push({ a: i, b: j, x: xB, y: yB });
+        }
+      }
+    }
+
+    var groups = {};
+    for (var k = 0; k < n; k++) { var r = find(k); (groups[r] = groups[r] || []).push(k); }
+
+    var chains = Object.keys(groups).map(function (r) {
+      var idxs = groups[r];
+      // Order the chain by a simple traversal: start at a bucket with only one crossing (a real
+      // end), walk crossing-to-crossing. Falls back to insertion order if the chain has no clean
+      // single-degree start (e.g. a loop) — never invents a position, just doesn't over-claim order.
+      var memberSet = {}; idxs.forEach(function (ix) { memberSet[ix] = true; });
+      var localCross = crossings.filter(function (c) { return memberSet[c.a] && memberSet[c.b]; });
+      var degree = {}; idxs.forEach(function (ix) { degree[ix] = 0; });
+      localCross.forEach(function (c) { degree[c.a]++; degree[c.b]++; });
+      var starts = idxs.filter(function (ix) { return degree[ix] <= 1; });
+      var startIdx = starts.length ? starts[0] : idxs[0];
+      var visited = {}, ordered = [], cur = startIdx;
+      while (cur !== undefined && !visited[cur]) {
+        visited[cur] = true; ordered.push(cur);
+        var next = localCross.find(function (c) { return (c.a === cur || c.b === cur) && !visited[c.a === cur ? c.b : c.a]; });
+        cur = next ? (next.a === cur ? next.b : next.a) : undefined;
+      }
+      idxs.forEach(function (ix) { if (!visited[ix]) ordered.push(ix); }); // stray members (loop remnants), appended not dropped
+      return {
+        buckets: ordered.map(function (ix) { return buckets[ix]; }),
+        crossings: localCross,
+        storey: buckets[idxs[0]].storey
+      };
+    });
+    return { chains: chains, crossings: crossings };
+  }
+
+  // ── Orchestrator ─────────────────────────────────────────────────────────────────────────────
+  // dbQuery: same convention as room_graph.js. opts.log optional. Returns
+  // { buckets, joined, chains, crossings, stats }.
+  function buildBackbone(dbQuery, opts) {
+    opts = opts || {};
+    var log = opts.log || function () {};
+
+    var doorRows = dbQuery("SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, " +
+      "COALESCE(t.bbox_x,0) bx, COALESCE(t.bbox_y,0) by2 " +
+      "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+      "WHERE m.ifc_class LIKE 'IfcDoor%' AND m.discipline='ARC' AND t.center_x IS NOT NULL") || [];
+    var wallRows = dbQuery("SELECT m.storey, t.center_x, t.center_y, COALESCE(t.bbox_x,0) bx, COALESCE(t.bbox_y,0) by2 " +
+      "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+      "WHERE m.ifc_class LIKE 'IfcWall%' AND m.discipline='ARC' AND t.center_x IS NOT NULL") || [];
+
+    var edges = doorRows.map(function (d) {
+      return doorEdge({ guid: d[0], name: d[1], storey: d[2] || '', cx: d[3], cy: d[4], bx: d[5], by: d[6] });
+    });
+    var wallsByStorey = {};
+    wallRows.forEach(function (w) {
+      var st = w[0] || '';
+      (wallsByStorey[st] = wallsByStorey[st] || []).push({ cx: w[1], cy: w[2], bx: w[3], by: w[4] });
+    });
+
+    var buckets = correlateDoorEdges(edges);
+    var joined = joinDoorways(buckets);
+    joined.forEach(function (b) { growToWall(b, wallsByStorey[b.storey] || []); });
+
+    var stairGroupsResult = RoomGraph ? RoomGraph.getStairGroups(dbQuery, log) : { groups: {} };
+    joined.forEach(function (b) { terminateAtStair(b, stairGroupsResult.groups); });
+
+    var byStorey = {};
+    joined.forEach(function (b) { (byStorey[b.storey] = byStorey[b.storey] || []).push(b); });
+    var allChains = [], allCrossings = [];
+    Object.keys(byStorey).forEach(function (st) {
+      var r = walkBackbone(byStorey[st]);
+      allChains = allChains.concat(r.chains);
+      allCrossings = allCrossings.concat(r.crossings);
+    });
+
+    var openEnds = 0, stairTerminated = 0;
+    joined.forEach(function (b) {
+      if (b.openLo) { openEnds++; if (b.stairLo) stairTerminated++; }
+      if (b.openHi) { openEnds++; if (b.stairHi) stairTerminated++; }
+    });
+    var stats = {
+      doors: doorRows.length, walls: wallRows.length, buckets: buckets.length,
+      joined: joined.length, chains: allChains.length, crossings: allCrossings.length,
+      openEnds: openEnds, stairTerminated: stairTerminated, stairGroups: stairGroupsResult.order.length
+    };
+    log('§HALLWAY_BACKBONE buckets=' + stats.buckets + ' joined=' + stats.joined + ' chains=' + stats.chains +
+      ' crossings=' + stats.crossings + ' openEnds=' + stats.openEnds + ' stairTerminated=' + stats.stairTerminated +
+      ' stairGroups=' + stats.stairGroups);
+
+    return { buckets: buckets, joined: joined, chains: allChains, crossings: allCrossings, stats: stats };
+  }
+
+  var API = {
+    doorEdge: doorEdge, correlateDoorEdges: correlateDoorEdges, joinDoorways: joinDoorways,
+    growToWall: growToWall, terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
+    buildBackbone: buildBackbone
+  };
+  ROOT.HallwayBackbone = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})();

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -99,6 +99,63 @@
     return n.replace(INDEX_SUFFIX_RE, '');
   }
 
+  // §STAIR-GROUPS (extracted from buildGraph's E3 logic, 2026-07-14 §HALLWAY-BACKBONE) — the ONE
+  // trusted stair extractor for this codebase (WalkerDoctrine §10). §STAIR-CLASS-FALLBACK
+  // (SampleCastle, 2026-07-13): flights (IfcStairFlight/IfcRampFlight) are PREFERRED — proven
+  // z-span behavior on Terminal/JKR/Duplex — but some real buildings model stairs ONLY as
+  // IfcStair/IfcRamp ASSEMBLIES (SampleCastle: 9 IfcStair, zero flights). If the flight query
+  // returns nothing, fall back to the assembly classes; never mix both (a building with both —
+  // Duplex — would double-count the same physical stair). Deliberately NO discipline filter — real
+  // data (Clinic) shows the primary flight rows split ARC (the "Concrete Pan" stairs) vs STR (the
+  // "Monolithic Concrete Stair") for the SAME building; an ARC-only filter would silently drop the
+  // STR-tagged physical stair. Groups by stairBaseKey() so a multi-flight physical stair (Run 1/
+  // Run 2, or a trailing ":N" flight index) counts as ONE stair, not one per flight — verified
+  // against Clinic's real elements_meta 2026-07-14: 8 flight rows -> 4 stair groups + 1 ramp group
+  // (Ramp:150mm Concrete ADA Ramp), matching the trusted Building Parts Taxonomy ground truth of 4
+  // stairs, where three different ad-hoc `ifc_class LIKE 'IfcStair%'` phrasings returned 7/8/13.
+  // §XY-FOOTPRINT (2026-07-14, §HALLWAY-BACKBONE): also tracks each group's real XY bbox extent
+  // (xlo/xhi/ylo/yhi, from every flight row's own bbox_x/bbox_y) — needed by
+  // common/hallway_backbone.js's terminateAtStair() for a real bbox-rect distance test, not just a
+  // mean-center point. Additive only — the existing E3 z-bridging consumer (cx/cy/n/zlo/zhi) is
+  // untouched.
+  // Returns { groups: {key: {guids,cx,cy,n,zlo,zhi,xlo,xhi,ylo,yhi}}, order: [key,...] (insertion order) }.
+  function getStairGroups(dbQuery, log) {
+    log = log || function () {};
+    var flightRows = [];
+    var _stairSelect = "SELECT m.guid, m.element_name, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z" +
+      ' FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid';
+    try {
+      flightRows = dbQuery(_stairSelect +
+        " WHERE (m.ifc_class LIKE 'IfcStairFlight%' OR m.ifc_class LIKE 'IfcRampFlight%') AND t.center_z IS NOT NULL") || [];
+      if (!flightRows.length) {
+        flightRows = dbQuery(_stairSelect +
+          " WHERE (m.ifc_class LIKE 'IfcStair%' OR m.ifc_class LIKE 'IfcRamp%') AND t.center_z IS NOT NULL") || [];
+        if (flightRows.length) log('§ROOM_GRAPH_STAIR_FALLBACK assemblies=' + flightRows.length + ' (no flight rows in this building)');
+      }
+    } catch (eFl) { log('§ROOM_GRAPH_STAIR_ERR ' + eFl.message); }
+
+    var groups = {}, order = [];
+    flightRows.forEach(function (f) {
+      var key = stairBaseKey(f[1]);
+      if (!groups[key]) {
+        groups[key] = { guids: [], cx: 0, cy: 0, n: 0, zlo: Infinity, zhi: -Infinity,
+          xlo: Infinity, xhi: -Infinity, ylo: Infinity, yhi: -Infinity };
+        order.push(key);
+      }
+      var gr = groups[key];
+      gr.guids.push(f[0]);
+      var cx = f[2], cy = f[3], cz = f[4], bx = f[5] || 0, by = f[6] || 0, bz = f[7] || 0;
+      gr.cx += cx; gr.cy += cy; gr.n++;
+      gr.zlo = Math.min(gr.zlo, cz - bz / 2);
+      gr.zhi = Math.max(gr.zhi, cz + bz / 2);
+      gr.xlo = Math.min(gr.xlo, cx - bx / 2);
+      gr.xhi = Math.max(gr.xhi, cx + bx / 2);
+      gr.ylo = Math.min(gr.ylo, cy - by / 2);
+      gr.yhi = Math.max(gr.yhi, cy + by / 2);
+    });
+    return { groups: groups, order: order };
+  }
+
   // Build the room-adjacency graph from the SAME building db the Room Lens already reads.
   // Returns { nodes:[{guid,name,label,storey,rects,cx,cy}] (ROOM NODES ONLY — see file header),
   //           edges:[{a,b,doorGuid,doorName,storey,kind,ambiguous?}],
@@ -180,7 +237,51 @@
       return cg;
     }
 
+    // §HALLWAY-BACKBONE (2026-07-14): a room's lone door used to rescue onto ONE per-storey
+    // `CIRC::<storey>` blob (see circNode above) — every E2-rescued door on a floor collapsed to
+    // the SAME point, so two rooms both reached only via E2 measured zero distance apart no matter
+    // how far the real hallway actually runs between them, and the rendered path floated straight
+    // through open space instead of hugging the corridor (user-reported, 2026-07-14). Fix: build a
+    // real, wall-grounded corridor spine (common/hallway_backbone.js) and rescue each E2 door onto
+    // its NEAREST real spine waypoint instead of the shared blob, with spine waypoints chained to
+    // each other by real-distance edges along the actual corridor. Falls back to the OLD single-
+    // blob behavior per storey if the backbone build finds nothing there (short/doorless corridor,
+    // or the module isn't available) — never worse than before, never invents a spine that isn't
+    // grounded in real doors+walls.
     var edges = [], deadend = 0, orphan = 0, ambiguous = 0, nonRoomDoors = 0, e2 = 0;
+    var HallwayBackbone = (typeof module !== 'undefined' && module.exports) ? require('./hallway_backbone.js') : ROOT.HallwayBackbone;
+    var spineByStorey = {}; // storey -> [{guid,cx,cy}]
+    if (HallwayBackbone) {
+      try {
+        var backbone = HallwayBackbone.buildBackbone(dbQuery, { log: log });
+        backbone.joined.forEach(function (b, bi) {
+          var mid = (b.span.lo + b.span.hi) / 2;
+          var scx = (b.axis === 'x') ? mid : b.runCoord;
+          var scy = (b.axis === 'x') ? b.runCoord : mid;
+          var sg = 'SPINE::' + b.key;
+          nodes[sg] = { guid: sg, kind: 'spine', name: 'Corridor — ' + b.storey, storey: b.storey, cx: scx, cy: scy, cz: storeyZ[b.storey] };
+          order.push(sg);
+          b._spineGuid = sg;
+          (spineByStorey[b.storey] = spineByStorey[b.storey] || []).push(nodes[sg]);
+        });
+        backbone.crossings.forEach(function (c) {
+          var a = backbone.joined[c.a], b = backbone.joined[c.b];
+          if (!a || !b || !a._spineGuid || !b._spineGuid) return;
+          var w = Math.hypot(nodes[a._spineGuid].cx - nodes[b._spineGuid].cx, nodes[a._spineGuid].cy - nodes[b._spineGuid].cy);
+          edges.push({ a: a._spineGuid, b: b._spineGuid, doorGuid: null, doorName: 'Corridor junction', storey: a.storey, kind: 'E5', w: w });
+        });
+        log('§HALLWAY_BACKBONE_WIRED spineNodes=' + backbone.joined.length + ' spineEdges=' + backbone.crossings.length +
+          ' storeys=' + Object.keys(spineByStorey).length);
+      } catch (eBb) { log('§HALLWAY_BACKBONE_ERR ' + eBb.message); }
+    }
+    function nearestSpine(storey, px, py) {
+      var pts = spineByStorey[storey];
+      if (!pts || !pts.length) return null;
+      var best = null, bestD = Infinity;
+      pts.forEach(function (p) { var d = Math.hypot(p.cx - px, p.cy - py); if (d < bestD) { bestD = d; best = p; } });
+      return best;
+    }
+
     doorRows.forEach(function (d) {
       var guid = d[0], name = d[1] || '', storey = d[2] || '', dx = d[3], dy = d[4], dz = d[5], bx = d[6] || 0, by = d[7] || 0;
       if (!isRoomDoor(name)) { nonRoomDoors++; return; }
@@ -209,50 +310,31 @@
         if (!nodes[guid]) nodes[guid] = { guid: guid, kind: 'doorwp', name: name, storey: storey, cx: dx, cy: dy, cz: dz };
       } else if (cands.length === 1) {
         deadend++; e2++;
-        var cg = circNode(storey, dx, dy, dz);
+        // §HALLWAY-BACKBONE: rescue onto the NEAREST real corridor spine point for this storey
+        // when one exists (real distance, real hallway) — falls back to the old single per-storey
+        // blob only when no backbone was built here (e.g. too few doors to form a corridor).
+        var nearSpine = nearestSpine(storey, dx, dy);
+        var cg = nearSpine ? nearSpine.guid : circNode(storey, dx, dy, dz);
         // §API-COMPAT-WAYPOINT: register the door's OWN real guid as a rendering waypoint for this
         // circ hop (see shortestPath() below) — a real position, not a storey centroid.
         if (!nodes[guid]) nodes[guid] = { guid: guid, kind: 'doorwp', name: name, storey: storey, cx: dx, cy: dy, cz: dz };
-        edges.push({ a: cands[0].lg, b: cg, doorGuid: guid, doorName: name, storey: storey, kind: 'E2', wpA: null, wpB: guid });
+        var e2w = nearSpine ? Math.hypot(nearSpine.cx - dx, nearSpine.cy - dy) : undefined;
+        edges.push({ a: cands[0].lg, b: cg, doorGuid: guid, doorName: name, storey: storey, kind: 'E2', wpA: null, wpB: guid, w: e2w });
       } else {
         orphan++;
       }
     });
 
     // ── E3: stair/ramp flights bridge two storeys' circulation nodes ──
-    // §STAIR-CLASS-FALLBACK (SampleCastle, 2026-07-13): flights (IfcStairFlight/IfcRampFlight) are
-    // PREFERRED — proven z-span behavior on Terminal/JKR/Duplex — but some real buildings model
-    // stairs ONLY as IfcStair/IfcRamp ASSEMBLIES (SampleCastle: 9 IfcStair, zero flights → zero E3
-    // edges → every cross-storey path refused, user-reported §ROOM_PATH_NOT_FOUND). If the flight
-    // query returns nothing, fall back to the assembly classes; never mix both (a building with
-    // both — Duplex — would double-count the same physical stair).
-    var flightRows = [];
-    var _stairSelect = "SELECT m.guid, m.element_name, t.center_x, t.center_y, t.center_z, t.bbox_z" +
-      ' FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid';
-    try {
-      flightRows = dbQuery(_stairSelect +
-        " WHERE (m.ifc_class LIKE 'IfcStairFlight%' OR m.ifc_class LIKE 'IfcRampFlight%') AND t.center_z IS NOT NULL") || [];
-      if (!flightRows.length) {
-        flightRows = dbQuery(_stairSelect +
-          " WHERE (m.ifc_class LIKE 'IfcStair%' OR m.ifc_class LIKE 'IfcRamp%') AND t.center_z IS NOT NULL") || [];
-        if (flightRows.length) log('§ROOM_GRAPH_STAIR_FALLBACK assemblies=' + flightRows.length + ' (no flight rows in this building)');
-      }
-    } catch (eFl) { log('§ROOM_GRAPH_STAIR_ERR ' + eFl.message); }
-
-    var flightGroups = {}, flightGroupOrder = [];
-    flightRows.forEach(function (f) {
-      var key = stairBaseKey(f[1]);
-      if (!flightGroups[key]) {
-        flightGroups[key] = { guids: [], cx: 0, cy: 0, n: 0, zlo: Infinity, zhi: -Infinity };
-        flightGroupOrder.push(key);
-      }
-      var gr = flightGroups[key];
-      gr.guids.push(f[0]);
-      gr.cx += f[2]; gr.cy += f[3]; gr.n++;
-      var cz = f[4], bz = f[5] || 0;
-      gr.zlo = Math.min(gr.zlo, cz - bz / 2);
-      gr.zhi = Math.max(gr.zhi, cz + bz / 2);
-    });
+    // §STAIR-GROUPS: extracted to getStairGroups() below (2026-07-14, §HALLWAY-BACKBONE) so a
+    // second consumer (common/hallway_backbone.js's terminateAtStair) can reuse the SAME trusted
+    // flight-first/assembly-fallback query + physical-stair grouping instead of a fresh ad-hoc
+    // IfcStair% query — WalkerDoctrine §10, one function not a new one. Verified against Clinic's
+    // real data 2026-07-14: yields exactly 4 physical stairs (the trusted Building Parts Taxonomy
+    // ground truth), where a naive `ifc_class LIKE 'IfcStair%'` count returns 7/8/13 depending on
+    // phrasing — this function is the one to call, not a new query.
+    var stairGroupsResult = getStairGroups(dbQuery, log);
+    var flightGroups = stairGroupsResult.groups, flightGroupOrder = stairGroupsResult.order;
 
     var e3 = 0, e3Skipped = 0;
     var _e3Seen = {};
@@ -641,7 +723,10 @@
     while (cur !== fromGuid) {
       var p = core.prev[cur];
       if (!p) return null; // defensive — should not happen if dist[toGuid] finite
-      doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
+      // §HALLWAY-BACKBONE E5 (corridor-junction) hops carry no real elements_meta guid — this
+      // file's own invariant is "doors[] = real doors only" (see G1 witness), so they contribute
+      // to `path` (a real, wall-grounded position either way) but not to the exposed doors list.
+      if (p.edge.doorGuid) doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
       var publicCur = _publicHop(graph, cur, p.edge, p.arriveSide);
       path[0] = publicCur; // replace the just-pushed guid with its public form
       path.unshift(p.from);
@@ -682,7 +767,10 @@
     while (cur !== fromGuid) {
       var p = prev[cur];
       if (!p) { log('§ESCAPE_ROUTE from=' + fromGuid + ' RECONSTRUCT_FAIL'); return null; }
-      doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
+      // §HALLWAY-BACKBONE E5 (corridor-junction) hops carry no real elements_meta guid — this
+      // file's own invariant is "doors[] = real doors only" (see G1 witness), so they contribute
+      // to `path` (a real, wall-grounded position either way) but not to the exposed doors list.
+      if (p.edge.doorGuid) doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
       path[0] = _publicHop(graph, cur, p.edge, p.arriveSide);
       path.unshift(p.from);
       cur = p.from;
@@ -694,7 +782,8 @@
 
   var API = {
     buildGraph: buildGraph, degree: degree, components: components, shortestPath: shortestPath,
-    escapeRoute: escapeRoute, isRoomDoor: isRoomDoor, stairBaseKey: stairBaseKey, DOOR_BUFFER_SLACK: DOOR_BUFFER_SLACK
+    escapeRoute: escapeRoute, isRoomDoor: isRoomDoor, stairBaseKey: stairBaseKey, DOOR_BUFFER_SLACK: DOOR_BUFFER_SLACK,
+    getStairGroups: getStairGroups
   };
   ROOT.RoomGraph = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -251,6 +251,11 @@
     var edges = [], deadend = 0, orphan = 0, ambiguous = 0, nonRoomDoors = 0, e2 = 0;
     var HallwayBackbone = (typeof module !== 'undefined' && module.exports) ? require('./hallway_backbone.js') : ROOT.HallwayBackbone;
     var spineByStorey = {}; // storey -> [{guid,cx,cy}]
+    // §CORRIDOR-WIDTH: real, wall-measured corridor rects (see hallway_backbone.js bucketRect) fed
+    // into _pointWalkable()'s room-rects fallback — WITHOUT this, a storey with no walkable raster
+    // treats genuine open corridor floor (no room modeled there) as illegal, so a legality detour
+    // can never succeed through it no matter how many spine candidate points are added.
+    var corridorRectsByStorey = {};
     if (HallwayBackbone) {
       try {
         var backbone = HallwayBackbone.buildBackbone(dbQuery, { log: log });
@@ -263,6 +268,7 @@
           order.push(sg);
           b._spineGuid = sg;
           (spineByStorey[b.storey] = spineByStorey[b.storey] || []).push(nodes[sg]);
+          (corridorRectsByStorey[b.storey] = corridorRectsByStorey[b.storey] || []).push(HallwayBackbone.bucketRect(b));
         });
         backbone.crossings.forEach(function (c) {
           var a = backbone.joined[c.a], b = backbone.joined[c.b];
@@ -489,6 +495,7 @@
       nodesByGuid: nodes, // superset: room + circ + exit + waypoint entries, see file header
       rasters: rasters, // §G3-REVISED: {storey: StoreyRaster instance}, see shortestPath()
       roomRectsByStorey: roomRectsByStorey, // §G3-REVISED fallback when a storey has no raster
+      corridorRectsByStorey: corridorRectsByStorey, // §CORRIDOR-WIDTH: real backbone corridor rects, same fallback
       stats: { doors: doorRows.length, nonRoomDoors: nonRoomDoors,
         edges: edges.filter(function (e) { return e.kind === 'E1'; }).length,
         deadend: deadend, orphan: orphan, ambiguous: ambiguous,
@@ -613,11 +620,24 @@
     var raster = graph.rasters && graph.rasters[storey];
     if (raster) return raster.contains(px, py);
     var rects = graph.roomRectsByStorey && graph.roomRectsByStorey[storey];
-    if (!rects || !rects.length) return null;
-    for (var i = 0; i < rects.length; i++) {
-      var rc = rects[i];
-      if (px >= rc.x0 - DOOR_BUFFER_SLACK && px <= rc.x1 + DOOR_BUFFER_SLACK &&
-        py >= rc.y0 - DOOR_BUFFER_SLACK && py <= rc.y1 + DOOR_BUFFER_SLACK) return true;
+    // §CORRIDOR-WIDTH: real, wall-measured corridor rects (hallway_backbone.js bucketRect) — see
+    // that fix's comment above the caller for WHY this is a different, stronger-evidence case than
+    // just widening DOOR_BUFFER_SLACK (a courtyard-sized void still correctly fails; a corridor
+    // only gets a rect here when it's an ACTUAL wall-bounded run with >=3 real doors).
+    var corridors = graph.corridorRectsByStorey && graph.corridorRectsByStorey[storey];
+    if ((!rects || !rects.length) && (!corridors || !corridors.length)) return null;
+    if (rects) {
+      for (var i = 0; i < rects.length; i++) {
+        var rc = rects[i];
+        if (px >= rc.x0 - DOOR_BUFFER_SLACK && px <= rc.x1 + DOOR_BUFFER_SLACK &&
+          py >= rc.y0 - DOOR_BUFFER_SLACK && py <= rc.y1 + DOOR_BUFFER_SLACK) return true;
+      }
+    }
+    if (corridors) {
+      for (var j = 0; j < corridors.length; j++) {
+        var cc = corridors[j];
+        if (px >= cc.x0 && px <= cc.x1 && py >= cc.y0 && py <= cc.y1) return true;
+      }
     }
     return false;
   }
@@ -651,7 +671,16 @@
     var pts = [{ id: null, x: ax, y: ay }, { id: null, x: bx, y: by }];
     Object.keys(graph.nodesByGuid).forEach(function (g) {
       var n = graph.nodesByGuid[g];
-      if (n.kind === 'doorwp' && n.storey === storey) pts.push({ id: g, x: n.cx, y: n.cy });
+      // §HALLWAY-BACKBONE: real corridor spine points are ALSO valid detour candidates, not just
+      // doorwp — a door-only visibility graph can genuinely have no legal edge between two doors
+      // that face each other across an open corridor (every straight door-to-door chord crosses
+      // the gap the raster marks non-walkable near a jutting wall corner), even though a real
+      // route along the corridor's own centerline exists. Observed live on Clinic First Floor
+      // before this fix: `§PATH_LEGAL_DETOUR_FAIL ... no legal detour among 139 doors` — the
+      // chord was then left AS-IS, undetoured, i.e. still crossing a wall. Adding spine nodes only
+      // ADDS candidate points/edges to this visibility graph — it can only turn a FAIL into a real
+      // route, never remove an already-legal one.
+      if ((n.kind === 'doorwp' || n.kind === 'spine') && n.storey === storey) pts.push({ id: g, x: n.cx, y: n.cy });
     });
     var n = pts.length, adj = [];
     for (var i = 0; i < n; i++) adj.push([]);

--- a/witness_backbone_routing.js
+++ b/witness_backbone_routing.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-BACKBONE-ROUTING scope (READ THE LOG after every run)
+ * SCOPE: room_graph.js's E2 "lone-door rescue" now targets the nearest real corridor spine
+ * waypoint (common/hallway_backbone.js) instead of a single per-storey CIRC blob — this witness
+ * proves the FIX, not just the backbone module in isolation (see witness_hallway_backbone.js for
+ * that). ISSUE THIS EXPOSES: before this fix, two rooms both rescued via E2 on the same storey
+ * measured ZERO distance apart no matter how far the real hallway ran between them (the shared
+ * blob), which is the root cause of a rendered room-to-room path floating straight through open
+ * space instead of hugging the corridor (user-reported, 2026-07-14).
+ * RUN: node witness_backbone_routing.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const RoomGraph = require('./common/room_graph.js');
+
+const DB_PATH = '/home/red1/bim-ootb/buildings/Clinic_extracted.db';
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+console.log('§W-BACKBONE-ROUTING building=' + DB_PATH);
+const db = new Database(DB_PATH, { readonly: true });
+function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+
+const graph = RoomGraph.buildGraph(dbQuery, { log: (m) => console.log('  ' + m) });
+
+const spineNodes = Object.keys(graph.nodesByGuid).filter(g => graph.nodesByGuid[g].kind === 'spine');
+const circNodes = Object.keys(graph.nodesByGuid).filter(g => graph.nodesByGuid[g].kind === 'circ');
+console.log('§NODE_KINDS spine=' + spineNodes.length + ' circ=' + circNodes.length + ' rooms=' + graph.nodes.length);
+chk('G1 real corridor spine nodes were wired into the graph (not just the fallback blob)', spineNodes.length > 0, 'spine=' + spineNodes.length);
+
+const e2edges = graph.edges.filter(e => e.kind === 'E2');
+const e2ToSpine = e2edges.filter(e => spineNodes.indexOf(e.b) >= 0);
+console.log('§E2_RESCUE total=' + e2edges.length + ' toSpine=' + e2ToSpine.length + ' toBlobFallback=' + (e2edges.length - e2ToSpine.length));
+chk('G2 at least some E2 rescues now target a real spine waypoint, not the old blob', e2ToSpine.length > 0, 'toSpine=' + e2ToSpine.length);
+
+// Distinct spine targets used by E2 on the SAME storey must have DIFFERENT positions (proves the
+// old "every E2 door on this floor collapses to ONE point" bug is gone).
+const byStorey = {};
+e2ToSpine.forEach(e => { (byStorey[e.storey] = byStorey[e.storey] || new Set()).add(e.b); });
+let anyStoreyMultiSpine = false, exampleStorey = null;
+Object.keys(byStorey).forEach(st => { if (byStorey[st].size > 1) { anyStoreyMultiSpine = true; exampleStorey = st; } });
+if (exampleStorey) console.log('§DISTINCT_TARGETS storey="' + exampleStorey + '" distinct spine targets=' + byStorey[exampleStorey].size);
+chk('G3 E2-rescued doors on the SAME storey land on DIFFERENT real spine points (not one shared blob)',
+  anyStoreyMultiSpine, exampleStorey ? ('storey=' + exampleStorey + ' distinctTargets=' + byStorey[exampleStorey].size) : 'n/a');
+
+// Real distance check: two different E2 edges into the SAME spine-network storey must carry
+// REAL (non-zero, geometrically distinct) weights, not the old implicit "0" of a shared blob.
+if (e2ToSpine.length >= 2) {
+  const weights = e2ToSpine.map(e => e.w).filter(w => typeof w === 'number');
+  const distinctWeights = new Set(weights.map(w => w.toFixed(2))).size;
+  console.log('§E2_WEIGHTS sample=' + weights.slice(0, 8).map(w => w.toFixed(2)).join(',') + ' distinctValues=' + distinctWeights + '/' + weights.length);
+  chk('G4 E2 rescue distances are real measured values (mostly non-zero, not a uniform 0)',
+    weights.filter(w => w > 0.01).length > weights.length * 0.5, 'nonZero=' + weights.filter(w => w > 0.01).length + '/' + weights.length);
+}
+
+// Pick a real multi-hop room pair through the spine and confirm the rendered path visits
+// GEOMETRICALLY DISTINCT points (proves it hugs the corridor's real shape, not a straight
+// teleport through one fixed blob position).
+const roomsByStorey = {};
+graph.nodes.forEach(n => { (roomsByStorey[n.storey] = roomsByStorey[n.storey] || []).push(n.guid); });
+let demo = null;
+Object.keys(roomsByStorey).forEach(st => {
+  if (demo) return;
+  const rs = roomsByStorey[st];
+  for (let i = 0; i < rs.length && !demo; i++) {
+    for (let j = i + 1; j < rs.length && !demo; j++) {
+      const r = RoomGraph.shortestPath(graph, rs[i], rs[j]);
+      if (r && r.path.length >= 4) demo = { a: rs[i], b: rs[j], result: r, storey: st };
+    }
+  }
+});
+if (demo) {
+  const pts = demo.result.path.map(g => graph.nodesByGuid[g]).filter(Boolean);
+  const uniquePositions = new Set(pts.map(p => p.cx.toFixed(1) + ',' + p.cy.toFixed(1))).size;
+  console.log('§DEMO_PATH storey="' + demo.storey + '" ' + demo.a + ' -> ' + demo.b +
+    ' hops=' + demo.result.path.length + ' distance=' + demo.result.distance.toFixed(2) +
+    ' uniquePositions=' + uniquePositions);
+  console.log('    points: ' + pts.map(p => '(' + p.cx.toFixed(1) + ',' + p.cy.toFixed(1) + ' ' + p.kind + ')').join(' -> '));
+  chk('G5 a real multi-hop room-to-room path visits geometrically DISTINCT waypoints (hugs the corridor, does not float through one collapsed point)',
+    uniquePositions === pts.length, 'uniquePositions=' + uniquePositions + '/' + pts.length);
+} else {
+  console.log('§DEMO_PATH no >=4-hop same-storey room pair found to demo (non-fatal, small sample)');
+}
+
+console.log('\n§W-BACKBONE-ROUTING DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/witness_hallway_backbone.js
+++ b/witness_hallway_backbone.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-HALLWAY-BACKBONE scope (READ THE LOG after every run)
+ * SCOPE: common/hallway_backbone.js exercised against the REAL Clinic building — same building
+ * §HALLWAY-BACKBONE's scratch-script investigation (bim-compiler
+ * prompts/FUNCTIONAL_SPACE_MGMT_NEXT_SESSION.md) verified the algorithm on before that code was
+ * deleted per housekeeping. This is a REBUILD, not a byte-for-byte port (the scratch code is gone) —
+ * numbers here are freshly measured against real data, not asserted to match the old scratch run's
+ * exact counts.
+ * DB: full merged extraction (all disciplines), NOT the ARC-only modeller/Clinic_ARC.db — the
+ * trusted stair extractor (room_graph.js getStairGroups) needs the STR-tagged "Monolithic Concrete
+ * Stair" that Clinic's ARC-only extract omits (verified 2026-07-14: Clinic_ARC.db has 6 stairflight
+ * rows / 3 physical stairs; the full extracted.db has 8 rows / 4 physical stairs — the real,
+ * trusted count, matching Building Parts Taxonomy's live-shipped answer).
+ * RUN: node witness_hallway_backbone.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const HallwayBackbone = require('./common/hallway_backbone.js');
+const RoomGraph = require('./common/room_graph.js');
+
+const DB_PATH = '/home/red1/bim-ootb/buildings/Clinic_extracted.db';
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+console.log('§W-HALLWAY-BACKBONE building=' + DB_PATH);
+const db = new Database(DB_PATH, { readonly: true });
+function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+
+// ── Independent ground truth: stair count, re-derived directly (not via the module) ──
+const stairFlightRows = dbQuery("SELECT m.element_name FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+  "WHERE (m.ifc_class LIKE 'IfcStairFlight%' OR m.ifc_class LIKE 'IfcRampFlight%') AND t.center_z IS NOT NULL");
+const RUN_SUFFIX_RE = /\s+Run\s+\d+$/, INDEX_SUFFIX_RE = /:\d+$/;
+function baseKey(n) { n = String(n || ''); return RUN_SUFFIX_RE.test(n) ? n.replace(RUN_SUFFIX_RE, '') : n.replace(INDEX_SUFFIX_RE, ''); }
+const gtGroups = new Set(stairFlightRows.map(r => baseKey(r[0])));
+const gtStairs = [...gtGroups].filter(k => /Stair/i.test(k));
+const gtRamps = [...gtGroups].filter(k => /Ramp/i.test(k));
+console.log('§GROUND-TRUTH flight_rows=' + stairFlightRows.length + ' stair_groups=' + gtStairs.length + ' ramp_groups=' + gtRamps.length);
+chk('G0 real stair count matches trusted Building Parts Taxonomy ground truth (4)', gtStairs.length === 4, 'stairs=' + gtStairs.length);
+
+// ── getStairGroups() reused correctly ──
+const sg = RoomGraph.getStairGroups(dbQuery, () => {});
+const sgStairs = sg.order.filter(k => /Stair/i.test(k));
+chk('G1 RoomGraph.getStairGroups() (the reused trusted extractor) also yields 4 stairs', sgStairs.length === 4, 'stairs=' + sgStairs.length);
+sgStairs.forEach(k => { const g = sg.groups[k]; console.log('    stair "' + k + '" footprint x=[' + g.xlo.toFixed(1) + ',' + g.xhi.toFixed(1) + '] y=[' + g.ylo.toFixed(1) + ',' + g.yhi.toFixed(1) + '] z=[' + g.zlo.toFixed(1) + ',' + g.zhi.toFixed(1) + ']'); });
+
+// ── Full backbone build ──
+const t0 = Date.now();
+const result = HallwayBackbone.buildBackbone(dbQuery, { log: (m) => console.log('  ' + m) });
+console.log('§TIMING buildBackbone took ' + (Date.now() - t0) + 'ms');
+
+chk('G2 doors and walls were actually read (non-zero)', result.stats.doors > 0 && result.stats.walls > 0,
+  'doors=' + result.stats.doors + ' walls=' + result.stats.walls);
+chk('G3 at least one hallway-candidate bucket joined (>=3 aligned doors)', result.stats.joined > 0, 'joined=' + result.stats.joined);
+chk('G4 at least one backbone chain formed', result.stats.chains > 0, 'chains=' + result.stats.chains);
+
+// ── Real-data spot check: the biggest chain should span many real doors, not a handful ──
+const chainsBySize = result.chains.slice().sort((a, b) => {
+  const da = a.buckets.reduce((s, bk) => s + bk.doors.length, 0);
+  const db_ = b.buckets.reduce((s, bk) => s + bk.doors.length, 0);
+  return db_ - da;
+});
+if (chainsBySize.length) {
+  const big = chainsBySize[0];
+  const doorTouches = big.buckets.reduce((s, bk) => s + bk.doors.length, 0);
+  console.log('§BIGGEST_CHAIN storey=' + big.storey + ' buckets=' + big.buckets.length + ' doorTouches=' + doorTouches +
+    ' crossings=' + big.crossings.length);
+  chk('G5 biggest chain plausibly a real multi-segment corridor (>=3 buckets, >=15 door touches)',
+    big.buckets.length >= 3 && doorTouches >= 15, 'buckets=' + big.buckets.length + ' doorTouches=' + doorTouches);
+  chk('G6 chain ordering is crossing-backed, not invented (>=1 real crossing for a multi-bucket chain)',
+    big.buckets.length === 1 || big.crossings.length >= big.buckets.length - 1,
+    'buckets=' + big.buckets.length + ' crossings=' + big.crossings.length);
+}
+
+// ── Stair-termination: how many open ends now resolve to a real trusted stair ──
+console.log('§STAIR_TERMINATION openEnds=' + result.stats.openEnds + ' stairTerminated=' + result.stats.stairTerminated +
+  ' (' + (result.stats.openEnds ? (100 * result.stats.stairTerminated / result.stats.openEnds).toFixed(0) : 0) + '%)');
+
+console.log('\n§W-HALLWAY-BACKBONE DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
- Root cause: `room_graph.js`'s door-rescue (a room's lone door, no 2nd room neighbor) collapsed EVERY such door on a storey onto one shared `CIRC::<storey>` blob — two rooms reached only via that rescue measured **zero distance apart** regardless of real corridor length, which is why a rendered room-to-room path could float straight through open space instead of following the hallway.
- New `common/hallway_backbone.js`: compiles a real, door+wall-grounded corridor spine per storey (doorEdge → correlateDoorEdges → joinDoorways → growToWall → terminateAtStair → walkBackbone). Reuses `room_graph.js`'s stair extractor (now exported as `getStairGroups()`) rather than a fresh ad-hoc query.
- `room_graph.js`: door rescue now targets the nearest real spine waypoint (chained by real-distance edges) instead of the shared blob, with a clean fallback to old behavior when no backbone exists on a storey (never worse than before).
- `_detourForChord`'s chord-legality detour now also considers spine points, and each corridor bucket carries a real measured width (from its own flanking walls) fed into `_pointWalkable`'s room-rects fallback — closes the gap where a real corridor read as "illegal" (no room modeled there) and could never be detoured through.

## Test plan
- [x] `witness_room_graph_path.js` (Duplex) — 15/15, zero regression (building too small for a backbone, confirms clean fallback).
- [x] `witness_hallway_backbone.js` (Clinic) — 7/7. 4/4 real stairs matching Building Parts Taxonomy ground truth (was 0/41 stair-terminations working in the pre-code scratch investigation, root-caused there to wrong ad-hoc stair counts).
- [x] `witness_backbone_routing.js` (Clinic) — 5/5. 103/103 door-rescues now hit real distinct spine points (was 1 shared blob), real non-zero distances (5.13m/0.18m/3.21m etc, not uniform 0), a 9-hop path threading 2 real corridor waypoints around an actual dogleg.
- [ ] Not verified against a *compiled* building with a real walkable raster (tested against raw/uncompiled Clinic extract, no raster locally available) — should hold at least as well in production, worth a spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFx2nPckWD3GBeGmJu2N5