### PR TITLE
feat(rooms): backward-propagate corridor backbone into real rooms + Type.Hall/Corridor

### DIFF
--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -188,13 +188,22 @@
   // bucket's span. Returns { chains: [[bucket,...ordered...], ...] } — each chain is an ORDERED
   // path (not just a graph), per the user's explicit ask: the same structure feeds both path
   // routing (door-to-door must have a clear corridor-hugging route) and a flythrough camera path.
+  // §CROSSING-IDENTITY (2026-07-14, real bug found via user screenshot): crossings/chains
+  // reference the actual BUCKET OBJECTS, not positional array indices. buildBackbone() calls this
+  // function once PER STOREY (a fresh, separately-indexed `buckets` array each time) — an
+  // index-based crossing (`{a:i, b:j}`) would only be valid relative to THAT call's own local
+  // array, but was being looked up against the GLOBAL cross-storey `joined` array by the caller
+  // (room_graph.js), so a First-Floor local index could silently resolve to a completely different
+  // Second-Floor bucket. Confirmed live: a phantom `spine(First Floor)->spine(Second Floor)`
+  // edge with no real stair between them. Object references have no such ambiguity — safe to
+  // compare by `===` since these are the SAME objects returned in `joined`/`chains`.
   function walkBackbone(buckets) {
     var n = buckets.length;
     var parent = buckets.map(function (_, i) { return i; });
     function find(i) { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; } return i; }
     function union(a, b) { var ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb; }
 
-    var crossings = []; // {a,b,x,y} — real crossing points, kept for ordering + rendering
+    var crossings = []; // {a,b,x,y} — a and b are real bucket OBJECTS (see §CROSSING-IDENTITY)
     for (var i = 0; i < n; i++) {
       for (var j = i + 1; j < n; j++) {
         var A = buckets[i], B = buckets[j];
@@ -207,7 +216,7 @@
         var bIn = bAlong >= B.span.lo - WALL_CROSS_SLACK && bAlong <= B.span.hi + WALL_CROSS_SLACK;
         if (aIn && bIn) {
           union(i, j);
-          crossings.push({ a: i, b: j, x: xB, y: yB });
+          crossings.push({ a: A, b: B, x: xB, y: yB });
         }
       }
     }
@@ -217,26 +226,26 @@
 
     var chains = Object.keys(groups).map(function (r) {
       var idxs = groups[r];
+      var idxBuckets = idxs.map(function (ix) { return buckets[ix]; });
       // Order the chain by a simple traversal: start at a bucket with only one crossing (a real
       // end), walk crossing-to-crossing. Falls back to insertion order if the chain has no clean
       // single-degree start (e.g. a loop) — never invents a position, just doesn't over-claim order.
-      var memberSet = {}; idxs.forEach(function (ix) { memberSet[ix] = true; });
-      var localCross = crossings.filter(function (c) { return memberSet[c.a] && memberSet[c.b]; });
-      var degree = {}; idxs.forEach(function (ix) { degree[ix] = 0; });
-      localCross.forEach(function (c) { degree[c.a]++; degree[c.b]++; });
-      var starts = idxs.filter(function (ix) { return degree[ix] <= 1; });
-      var startIdx = starts.length ? starts[0] : idxs[0];
-      var visited = {}, ordered = [], cur = startIdx;
-      while (cur !== undefined && !visited[cur]) {
-        visited[cur] = true; ordered.push(cur);
-        var next = localCross.find(function (c) { return (c.a === cur || c.b === cur) && !visited[c.a === cur ? c.b : c.a]; });
+      var localCross = crossings.filter(function (c) { return idxBuckets.indexOf(c.a) >= 0 && idxBuckets.indexOf(c.b) >= 0; });
+      var degree = new Map(); idxBuckets.forEach(function (b) { degree.set(b, 0); });
+      localCross.forEach(function (c) { degree.set(c.a, degree.get(c.a) + 1); degree.set(c.b, degree.get(c.b) + 1); });
+      var starts = idxBuckets.filter(function (b) { return degree.get(b) <= 1; });
+      var startB = starts.length ? starts[0] : idxBuckets[0];
+      var visited = new Set(), ordered = [], cur = startB;
+      while (cur !== undefined && !visited.has(cur)) {
+        visited.add(cur); ordered.push(cur);
+        var next = localCross.find(function (c) { return (c.a === cur || c.b === cur) && !visited.has(c.a === cur ? c.b : c.a); });
         cur = next ? (next.a === cur ? next.b : next.a) : undefined;
       }
-      idxs.forEach(function (ix) { if (!visited[ix]) ordered.push(ix); }); // stray members (loop remnants), appended not dropped
+      idxBuckets.forEach(function (b) { if (!visited.has(b)) ordered.push(b); }); // stray members (loop remnants), appended not dropped
       return {
-        buckets: ordered.map(function (ix) { return buckets[ix]; }),
+        buckets: ordered,
         crossings: localCross,
-        storey: buckets[idxs[0]].storey
+        storey: idxBuckets[0].storey
       };
     });
     return { chains: chains, crossings: crossings };

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -279,6 +279,10 @@
     var allChains = [], allCrossings = [];
     Object.keys(byStorey).forEach(function (st) {
       var r = walkBackbone(byStorey[st]);
+      r.chains.forEach(function (ch) {
+        var chainIndex = allChains.length + r.chains.indexOf(ch);
+        ch.buckets.forEach(function (b) { b._chainIndex = chainIndex; });
+      });
       allChains = allChains.concat(r.chains);
       allCrossings = allCrossings.concat(r.crossings);
     });
@@ -311,11 +315,72 @@
       : { x0: perpLo, x1: perpHi, y0: b.span.lo, y1: b.span.hi };
   }
 
+  // §CORRIDOR-TYPE-LABEL (2026-07-14, user ask: "long corridors well named under Type.Hall/
+  // Corridor" — resume doc §OPEN #2's UX ask, superseded signal now the verified backbone instead
+  // of the old undercounting hallwayness() formula). DISPLAY-TIME classification only — does NOT
+  // rewrite spatial_structure/predefined_type (that's compile-time, Sacred-file/mined-pipeline
+  // territory, a bigger cross-repo change); a caller (e.g. the Find panel's Type-grouped room
+  // tree) asks "which already-compiled rooms sit on a real hallway spine" and overrides the
+  // DISPLAYED label only, non-destructively, for any already-compiled/patched building without a
+  // new extraction run. A room qualifies iff its own rect-set CENTROID falls inside a joined
+  // (>=3-door) bucket's real measured rect (bucketRect) on the same storey — real, measured
+  // evidence (the bucket only exists because of real doors + real walls), not a shape/area guess.
+  // Returns a map: { logicalRoomGuid: { chain: chainIndex|null } } for every matched room.
+  function classifyCorridorRooms(dbQuery, opts) {
+    opts = opts || {};
+    var log = opts.log || function () {};
+    var backbone = buildBackbone(dbQuery, opts);
+    if (!backbone.joined.length) return {};
+
+    var hasRoomGuid = false;
+    try {
+      var cols = dbQuery('PRAGMA table_info(spatial_structure)') || [];
+      hasRoomGuid = cols.some(function (c) { return c[1] === 'room_guid'; });
+    } catch (eCols) { /* stays false */ }
+
+    // storey name comes via the parent IfcBuildingStorey row's own name — same join-through-parent
+    // convention room_graph.js buildGraph() and navigate_find.js's room tree both already use.
+    var spaceRows = dbQuery("SELECT s.guid, p.name" + (hasRoomGuid ? ', s.room_guid' : ', NULL') +
+      ', s.center_x, s.center_y, s.size_x, s.size_y' +
+      ' FROM spatial_structure s LEFT JOIN spatial_structure p ON p.guid = s.parent_guid' +
+      " WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL AND s.size_x IS NOT NULL") || [];
+
+    var rects = {}; // logicalGuid -> {storey, sumX, sumY, n}
+    spaceRows.forEach(function (r) {
+      var logicalGuid = r[2] || r[0];
+      var storey = r[1] || '';
+      if (!rects[logicalGuid]) rects[logicalGuid] = { storey: storey, sumX: 0, sumY: 0, n: 0 };
+      rects[logicalGuid].sumX += r[3]; rects[logicalGuid].sumY += r[4]; rects[logicalGuid].n++;
+    });
+
+    var bucketsByStorey = {};
+    backbone.joined.forEach(function (b, bi) {
+      (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push({ rect: bucketRect(b), chain: b._chainIndex != null ? b._chainIndex : null });
+    });
+
+    var result = {};
+    Object.keys(rects).forEach(function (lg) {
+      var r = rects[lg];
+      var cx = r.sumX / r.n, cy = r.sumY / r.n;
+      var candidates = bucketsByStorey[r.storey];
+      if (!candidates) return;
+      for (var i = 0; i < candidates.length; i++) {
+        var rc = candidates[i].rect;
+        if (cx >= rc.x0 && cx <= rc.x1 && cy >= rc.y0 && cy <= rc.y1) {
+          result[lg] = { chain: candidates[i].chain };
+          break;
+        }
+      }
+    });
+    log('§CORRIDOR_TYPE_LABEL classifiedRooms=' + Object.keys(result).length + ' / ' + Object.keys(rects).length);
+    return result;
+  }
+
   var API = {
     doorEdge: doorEdge, correlateDoorEdges: correlateDoorEdges, joinDoorways: joinDoorways,
     growToWall: growToWall, bucketWidth: bucketWidth, bucketRect: bucketRect,
     terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
-    buildBackbone: buildBackbone
+    buildBackbone: buildBackbone, classifyCorridorRooms: classifyCorridorRooms
   };
   ROOT.HallwayBackbone = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -232,7 +232,7 @@
     if (HallwayBackbone) {
       try {
         backbone = HallwayBackbone.buildBackbone(dbQuery, { log: log });
-        var corridorRoomsInjected = 0, corridorRoomsSkippedOverlap = 0;
+        var corridorRoomsInjected = 0, corridorRoomsSkippedOverlap = 0, corridorRoomIndexByStorey = {};
         // §OVERLAP-GUARD (real bug found+fixed same session, before this ever shipped): a
         // centroid-only "is this space covered" test is NOT enough — a corridor bucket's grown
         // WIDTH can still substantially overlap a real compiled room's rect even when the bucket's
@@ -259,7 +259,8 @@
           });
           if (overlapsRealRoom) { corridorRoomsSkippedOverlap++; return; } // a real compiled room already occupies (part of) this space — don't shadow it
           var crg = 'CORRIDOR_ROOM::' + b.key;
-          nodes[crg] = { guid: crg, kind: 'room', name: '≈ ' + b.storey + ' Hall/Corridor', label: 'Hall / Corridor',
+          var crIdx = (corridorRoomIndexByStorey[b.storey] = (corridorRoomIndexByStorey[b.storey] || 0) + 1);
+          nodes[crg] = { guid: crg, kind: 'room', name: '≈ ' + b.storey + ' Hall/Corridor ' + crIdx, label: 'Hall / Corridor',
             storey: b.storey, rects: [rc], cx: bcx, cy: bcy, cz: storeyZ[b.storey] };
           order.push(crg); roomOrder.push(crg);
           b._corridorRoomGuid = crg;

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -271,7 +271,10 @@
           (corridorRectsByStorey[b.storey] = corridorRectsByStorey[b.storey] || []).push(HallwayBackbone.bucketRect(b));
         });
         backbone.crossings.forEach(function (c) {
-          var a = backbone.joined[c.a], b = backbone.joined[c.b];
+          // §CROSSING-IDENTITY: c.a/c.b are real bucket OBJECTS (see hallway_backbone.js
+          // walkBackbone) — do NOT index into backbone.joined with them (that was the bug: a
+          // per-storey-local index treated as a global one, producing phantom cross-storey edges).
+          var a = c.a, b = c.b;
           if (!a || !b || !a._spineGuid || !b._spineGuid) return;
           var w = Math.hypot(nodes[a._spineGuid].cx - nodes[b._spineGuid].cx, nodes[a._spineGuid].cy - nodes[b._spineGuid].cy);
           edges.push({ a: a._spineGuid, b: b._spineGuid, doorGuid: null, doorName: 'Corridor junction', storey: a.storey, kind: 'E5', w: w });
@@ -441,6 +444,30 @@
       }
       _e3Chain(sA, sB, gr, key);
     });
+
+    // §CIRC-SPINE-BRIDGE (2026-07-14, real regression found via user screenshot + HHS report):
+    // E3's stair edges connect circA<->circB (the per-storey CIRC blob, still created here
+    // unconditionally for stair-bridging even though E2 now prefers a real spine waypoint over
+    // it). On a storey where a backbone WAS built, E2 never rescues onto CIRC anymore — so CIRC
+    // silently became an ISLAND: reachable from a real stair, reachable from nothing else, no path
+    // could ever cross that floor transition even though a real stair genuinely connects it.
+    // Confirmed live: Clinic First Floor R10 -> Second Floor R5 returned a real (if imperfect)
+    // path before this session's spine-wiring change, then NULL after it — a straight regression,
+    // not an improvement. Fix: bridge every CIRC node into its own storey's nearest real spine
+    // point (real distance, same nearestSpine() helper E2 already uses) so the two subgraphs merge
+    // into one connected network again. No-op (never created, nothing to bridge) on a storey with
+    // no backbone — same graceful-degrade discipline as the rest of this feature.
+    var circBridges = 0;
+    order.forEach(function (lg) {
+      var g = nodes[lg];
+      if (g.kind !== 'circ') return;
+      var sp = nearestSpine(g.storey, g.cx, g.cy);
+      if (!sp) return;
+      var w = Math.hypot(sp.cx - g.cx, sp.cy - g.cy);
+      edges.push({ a: lg, b: sp.guid, doorGuid: null, doorName: 'Corridor junction', storey: g.storey, kind: 'E6', w: w });
+      circBridges++;
+    });
+    if (circBridges) log('§CIRC_SPINE_BRIDGE bridged=' + circBridges);
 
     // ── E4: escape — the existing nonRoomDoors detection becomes an N-EXIT node (free fire-escape
     // target); connect the nearest room-or-circ node on that storey (real distance, not invented).

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -789,7 +789,12 @@
       // chord was then left AS-IS, undetoured, i.e. still crossing a wall. Adding spine nodes only
       // ADDS candidate points/edges to this visibility graph — it can only turn a FAIL into a real
       // route, never remove an already-legal one.
-      if ((n.kind === 'doorwp' || n.kind === 'spine') && n.storey === storey) pts.push({ id: g, x: n.cx, y: n.cy });
+      // §CIRC-DETOUR-CANDIDATE (2026-07-14): a CIRC node — the stair-bridging hub E3/E6 hang off —
+      // was NOT a detour candidate either, same class of gap as spine's own fix above. A chord
+      // touching the CIRC<->SPINE bridge (E6) or a room's old CIRC fallback rescue could be illegal
+      // with zero rescue options even after adding spine, because the CIRC point itself was never
+      // offered as an intermediate stop. Additive only, same as spine.
+      if ((n.kind === 'doorwp' || n.kind === 'spine' || n.kind === 'circ') && n.storey === storey) pts.push({ id: g, x: n.cx, y: n.cy });
     });
     var n = pts.length, adj = [];
     for (var i = 0; i < n; i++) adj.push([]);

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -212,6 +212,64 @@
     Object.keys(storeyZSum).forEach(function (s) { storeyZ[s] = storeyZSum[s] / storeyZN[s]; });
     var storeysSorted = Object.keys(storeyZ).sort(function (a, b) { return storeyZ[a] - storeyZ[b]; });
 
+    // §CORRIDOR-ROOM-BACKPROP (2026-07-14, user's own framing: "backward propagation"). The
+    // corridor backbone (hallway_backbone.js) is built from RAW doors+walls — independent of room
+    // compilation. When it finds a real, door+wall-verified hallway with NO compiled room there at
+    // all, that is evidence room-compilation MISSED a real space, not evidence to discard — the
+    // SAME standard this codebase already trusts for §DOOR-RESCUE (compile_rooms.py: "a door
+    // proves a pocket is a room"). Measured on HHS (sparse-wall federated, only 14 compiled rooms
+    // for the whole building): 12 of 15 real hallway buckets had NO room there at all. Injecting
+    // them as real 'room' nodes HERE (before the E1/E2 door loop below runs) means a door sitting
+    // in one of these corridors gets a REAL E1 two-room edge instead of a lone-door E2 rescue, AND
+    // these corridors become real, selectable Path endpoints — the Find panel's From/To picker
+    // enumerates `graph.nodes` directly (§API-COMPAT), so a room injected into `roomOrder` here is
+    // automatically visible there, same as any real compiled room. This also delivers this
+    // session's earlier "Type.Hall/Corridor" label directly — these nodes ARE that type by
+    // construction (see `label`), not a separate classification pass over already-compiled data.
+    // `backbone` is reused (not rebuilt) by the spine/E2 wiring further below.
+    var HallwayBackbone = (typeof module !== 'undefined' && module.exports) ? require('./hallway_backbone.js') : ROOT.HallwayBackbone;
+    var backbone = null;
+    if (HallwayBackbone) {
+      try {
+        backbone = HallwayBackbone.buildBackbone(dbQuery, { log: log });
+        var corridorRoomsInjected = 0, corridorRoomsSkippedOverlap = 0;
+        // §OVERLAP-GUARD (real bug found+fixed same session, before this ever shipped): a
+        // centroid-only "is this space covered" test is NOT enough — a corridor bucket's grown
+        // WIDTH can still substantially overlap a real compiled room's rect even when the bucket's
+        // own centroid sits outside that room. Confirmed on Clinic: a corridor rect nearly
+        // engulfed real room RM_First_Floor_10 (5.0m^2 of ~5.3m^2 overlap) while its centroid was
+        // outside R10 by more than the old 1m tolerance — R10 then LOST both of its own doors to
+        // the corridor room in the E1 distance tie-break, going from 1 real edge to ZERO (a room
+        // that used to be reachable became completely disconnected). Real rect-overlap-area test
+        // instead: skip injection if the candidate corridor rect overlaps ANY real room by more
+        // than a physically meaningful amount (0.5m^2 — bigger than wall-thickness/measurement
+        // slop, far smaller than a real room) — never let a synthetic room shadow a real one.
+        function rectOverlapArea(a, c) {
+          var ox = Math.max(0, Math.min(a.x1, c.x1) - Math.max(a.x0, c.x0));
+          var oy = Math.max(0, Math.min(a.y1, c.y1) - Math.max(a.y0, c.y0));
+          return ox * oy;
+        }
+        backbone.joined.forEach(function (b) {
+          var rc = HallwayBackbone.bucketRect(b);
+          var bcx = (rc.x0 + rc.x1) / 2, bcy = (rc.y0 + rc.y1) / 2;
+          var overlapsRealRoom = roomOrder.some(function (lg) {
+            var g = nodes[lg];
+            if (g.storey !== b.storey) return false;
+            return g.rects.some(function (r) { return rectOverlapArea(r, rc) > 0.5; });
+          });
+          if (overlapsRealRoom) { corridorRoomsSkippedOverlap++; return; } // a real compiled room already occupies (part of) this space — don't shadow it
+          var crg = 'CORRIDOR_ROOM::' + b.key;
+          nodes[crg] = { guid: crg, kind: 'room', name: '≈ ' + b.storey + ' Hall/Corridor', label: 'Hall / Corridor',
+            storey: b.storey, rects: [rc], cx: bcx, cy: bcy, cz: storeyZ[b.storey] };
+          order.push(crg); roomOrder.push(crg);
+          b._corridorRoomGuid = crg;
+          corridorRoomsInjected++;
+        });
+        if (corridorRoomsInjected || corridorRoomsSkippedOverlap) log('§CORRIDOR_ROOM_BACKPROP injected=' + corridorRoomsInjected +
+          ' skippedOverlap=' + corridorRoomsSkippedOverlap + ' / ' + backbone.joined.length + ' joined buckets');
+      } catch (eBb0) { log('§CORRIDOR_ROOM_BACKPROP_ERR ' + eBb0.message); backbone = null; }
+    }
+
     var doorRows = [];
     try {
       doorRows = dbQuery('SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y' +
@@ -248,17 +306,15 @@
     // blob behavior per storey if the backbone build finds nothing there (short/doorless corridor,
     // or the module isn't available) — never worse than before, never invents a spine that isn't
     // grounded in real doors+walls.
-    var edges = [], deadend = 0, orphan = 0, ambiguous = 0, nonRoomDoors = 0, e2 = 0;
-    var HallwayBackbone = (typeof module !== 'undefined' && module.exports) ? require('./hallway_backbone.js') : ROOT.HallwayBackbone;
+    var edges = [], deadend = 0, orphan = 0, ambiguous = 0, nonRoomDoors = 0, e2 = 0, orphanRescued = 0;
     var spineByStorey = {}; // storey -> [{guid,cx,cy}]
     // §CORRIDOR-WIDTH: real, wall-measured corridor rects (see hallway_backbone.js bucketRect) fed
     // into _pointWalkable()'s room-rects fallback — WITHOUT this, a storey with no walkable raster
     // treats genuine open corridor floor (no room modeled there) as illegal, so a legality detour
     // can never succeed through it no matter how many spine candidate points are added.
     var corridorRectsByStorey = {};
-    if (HallwayBackbone) {
+    if (backbone) {
       try {
-        var backbone = HallwayBackbone.buildBackbone(dbQuery, { log: log });
         backbone.joined.forEach(function (b, bi) {
           var mid = (b.span.lo + b.span.hi) / 2;
           var scx = (b.axis === 'x') ? mid : b.runCoord;
@@ -269,6 +325,15 @@
           b._spineGuid = sg;
           (spineByStorey[b.storey] = spineByStorey[b.storey] || []).push(nodes[sg]);
           (corridorRectsByStorey[b.storey] = corridorRectsByStorey[b.storey] || []).push(HallwayBackbone.bucketRect(b));
+          // §CORRIDOR-ROOM-BACKPROP bridge: a bucket that got a synthetic room node (above, before
+          // the door loop) needs a real edge to its OWN spine node too — without this it's only
+          // reachable via whichever of its own doors also happen to E1-touch another real room,
+          // cut off from the crossing/long-distance network same as the CIRC-SPINE-BRIDGE gap was.
+          if (b._corridorRoomGuid) {
+            var crRoom = nodes[b._corridorRoomGuid];
+            var crw = Math.hypot(crRoom.cx - scx, crRoom.cy - scy);
+            edges.push({ a: b._corridorRoomGuid, b: sg, doorGuid: null, doorName: 'Corridor junction', storey: b.storey, kind: 'E8', w: crw });
+          }
         });
         backbone.crossings.forEach(function (c) {
           // §CROSSING-IDENTITY: c.a/c.b are real bucket OBJECTS (see hallway_backbone.js
@@ -331,6 +396,22 @@
         edges.push({ a: cands[0].lg, b: cg, doorGuid: guid, doorName: name, storey: storey, kind: 'E2', wpA: null, wpB: guid, w: e2w });
       } else {
         orphan++;
+        // §ORPHAN-SPINE-RESCUE (2026-07-14): a door with ZERO room candidates used to get NO graph
+        // presence at all — dropped silently, even when it sits right on a real corridor. Common
+        // on sparse-wall federated buildings (HHS: 117/133 doors orphaned, only 14 rooms compiled
+        // for the whole building — most floor area was never compiled into a room, so most doors
+        // can't reach one). This does NOT invent a room connection (there is genuinely no compiled
+        // room here) — it only reconnects the door into the real spine network it's already
+        // measured to sit near, so isolated pockets of real corridor (reachable only via these
+        // orphan doors) stop being unreachable islands. Additive only, never touches E1/E2's own
+        // room-facing logic.
+        var orphanSpine = nearestSpine(storey, dx, dy);
+        if (orphanSpine) {
+          if (!nodes[guid]) nodes[guid] = { guid: guid, kind: 'doorwp', name: name, storey: storey, cx: dx, cy: dy, cz: dz };
+          var ow = Math.hypot(orphanSpine.cx - dx, orphanSpine.cy - dy);
+          edges.push({ a: guid, b: orphanSpine.guid, doorGuid: guid, doorName: name, storey: storey, kind: 'E7', w: ow });
+          orphanRescued++;
+        }
       }
     });
 
@@ -496,7 +577,7 @@
     var circCount = order.filter(function (lg) { return nodes[lg].kind === 'circ'; }).length;
     log('§ROOM_GRAPH nodes=' + roomOrder.length + ' doors=' + doorRows.length + ' nonRoomDoors=' + nonRoomDoors +
       ' edges=' + edges.filter(function (e) { return e.kind === 'E1'; }).length +
-      ' deadend=' + deadend + ' orphan=' + orphan + ' ambiguous=' + ambiguous +
+      ' deadend=' + deadend + ' orphan=' + orphan + ' orphanRescued=' + orphanRescued + ' ambiguous=' + ambiguous +
       ' circ=' + circCount + ' stairs=' + e3 + ' (skipped=' + e3Skipped + ') exits=' + exits + ' e2=' + e2);
 
     // §G3-REVISED (PATH_LEGAL_SEGMENTS.md): read-only lookup of the offline-precomputed per-storey
@@ -525,7 +606,7 @@
       corridorRectsByStorey: corridorRectsByStorey, // §CORRIDOR-WIDTH: real backbone corridor rects, same fallback
       stats: { doors: doorRows.length, nonRoomDoors: nonRoomDoors,
         edges: edges.filter(function (e) { return e.kind === 'E1'; }).length,
-        deadend: deadend, orphan: orphan, ambiguous: ambiguous,
+        deadend: deadend, orphan: orphan, orphanRescued: orphanRescued, ambiguous: ambiguous,
         circ: circCount, stairs: e3, stairsSkipped: e3Skipped, exits: exits, e2: e2 }
     };
   }

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2173,11 +2173,29 @@
 
     // §RP-SHAPE: tap a room → light its real CONTENTS (rel_contained_in_space) in cyan,
     // keep that storey solid, rest at 0.2 (same drill as Phase/Material). No box.
+    // §CORRIDOR-ROOM-BACKPROP (2026-07-14): a `CORRIDOR_ROOM::*` guid has NO spatial_structure row
+    // — it's a synthetic room node injected by room_graph.js's buildGraph() for a real, door+wall-
+    // verified hallway bucket that room-compilation never turned into a room. _roomUnionBBox()
+    // would correctly return null for it (nothing to query), so build the SAME {name,storey,
+    // rectCount,cx,cy,cz,sx,sy,sz} shape directly from the room graph's own node instead — real
+    // measured position/span either way, just a different (in-memory, not DB) source. sz (height)
+    // has no measured value for a synthetic hallway node — 3.0m is a generic floor-to-ceiling
+    // placeholder, not a measured number; documented as such, not silently invented as if real.
+    function _corridorRoomBBox(guid) {
+      var graph = _roomGraphFor();
+      var n = graph && graph.nodesByGuid && graph.nodesByGuid[guid];
+      if (!n || n.kind !== 'room' || !n.rects || !n.rects.length) return null;
+      var rc = n.rects[0];
+      return { name: n.name, storey: n.storey, rectCount: 1,
+        cx: n.cx, cy: n.cy, cz: n.cz, sx: rc.x1 - rc.x0, sy: rc.y1 - rc.y0, sz: 3.0 };
+    }
+
     function _roomSelect(guid) {
       var set = new Set(), name = guid, storeySet = null, zoomBox = null;
-      try { _surfaceConstructionLink(guid, guid); } catch (e) {}
+      var isCorridorRoom = guid.indexOf('CORRIDOR_ROOM::') === 0;
+      if (!isCorridorRoom) { try { _surfaceConstructionLink(guid, guid); } catch (e) {} }
       try {
-        var rw = _roomUnionBBox(guid);
+        var rw = isCorridorRoom ? _corridorRoomBBox(guid) : _roomUnionBBox(guid);
         if (rw) { name = rw.name || guid; var storey = rw.storey;
           if (storey) { storeySet = new Set();
             A.dbQuery("SELECT guid FROM elements_meta WHERE storey = ?", [storey])
@@ -2339,7 +2357,27 @@
           if (!byGroup[gk]) { byGroup[gk] = []; order.push(gk); }
           byGroup[gk].push({ key: logicalGuid, label: r[1] || '(unnamed)' });
         });
+        // §CORRIDOR-ROOM-BACKPROP: `graph.nodes` (from _roomGraphFor(), same source the Path
+        // sub-mode already uses) includes `CORRIDOR_ROOM::*` synthetic nodes for real hallway
+        // buckets with NO spatial_structure row at all — the SQL query above can never see these,
+        // it only reads real rows. Add them here so "return more results" (user ask) actually
+        // reaches the Type/Storey tree too, not just the Path picker (which already lists them for
+        // free via graph.nodes). Real, measured position/span either way — see _corridorRoomBBox.
+        var corridorRoomCount = 0;
+        try {
+          var pathGraph = _roomGraphFor();
+          if (pathGraph) {
+            pathGraph.nodes.forEach(function (n) {
+              if (n.guid.indexOf('CORRIDOR_ROOM::') !== 0) return;
+              var gk2 = (_roomGroupBy === 'type') ? 'Hall / Corridor' : (n.storey || '(no storey)');
+              if (!byGroup[gk2]) { byGroup[gk2] = []; order.push(gk2); }
+              byGroup[gk2].push({ key: n.guid, label: n.name });
+              corridorRoomCount++;
+            });
+          }
+        } catch (eCr) { console.warn('[RP-T3] §CORRIDOR_ROOM_TREE_ERR', eCr.message); }
         if (dupRects) console.log('[RP-T3] §ROOM_TREE_DEDUP collapsed ' + dupRects + ' §MULTI-RECT sub-rect row(s) into their logical room entry');
+        if (corridorRoomCount) console.log('[RP-T3] §CORRIDOR_ROOM_TREE added ' + corridorRoomCount + ' backprop-injected corridor room(s)');
         order.forEach(function(gk) {
           var groupRooms = byGroup[gk];
           var kids = groupRooms.map(function(rm) {

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1018,6 +1018,24 @@
       return g;
     }
 
+    // §CORRIDOR-TYPE-LABEL (2026-07-14, user ask): Type-grouped room tree DISPLAY-only override —
+    // a room whose centroid sits on a real, door+wall-verified hallway backbone
+    // (common/hallway_backbone.js) shows as "Hall / Corridor" in the Type view instead of whatever
+    // generic predefined_type it was compiled with. Never rewrites spatial_structure — same
+    // per-building cache convention as _roomGraphFor() above.
+    var _corridorLabelsCache = null, _corridorLabelsBld = null;
+    function _corridorLabelsFor() {
+      var HB = (typeof window !== 'undefined') && window.HallwayBackbone;
+      if (!HB || !A.dbQuery) return {};
+      if (_corridorLabelsCache && _corridorLabelsBld === A.activeBuilding) return _corridorLabelsCache;
+      var labels = {};
+      try {
+        labels = HB.classifyCorridorRooms(A.dbQuery, { log: function(m) { console.log('[RP-CORRIDOR] ' + m); } });
+      } catch (eHb) { console.warn('[RP-CORRIDOR] §CORRIDOR_LABEL_ERR', eHb.message); }
+      _corridorLabelsCache = labels; _corridorLabelsBld = A.activeBuilding;
+      return labels;
+    }
+
     function _clearPathHighlight() {
       _pathExtraMeshes.forEach(function(m) {
         if (m.parent) m.parent.remove(m);
@@ -2300,6 +2318,7 @@
             " FROM spatial_structure s LEFT JOIN spatial_structure p ON p.guid = s.parent_guid" +
             " WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL ORDER BY p.name, s.name");
         } catch(e) { console.warn('[RP-TA] §ROOM_TREE_ERR', e.message); }
+        var corridorLabels = (_roomGroupBy === 'type') ? _corridorLabelsFor() : {};
         var byGroup = {}, order = [], typed = 0, seenLogical = {}, dupRects = 0;
         rooms.forEach(function(r) {
           // §ROOM-TYPE-FALLTHROUGH (VIEWER_FIND_PANEL_ROOM_ACCURACY.md Task 2): object_type
@@ -2307,9 +2326,13 @@
           // so fall through to predefined_type (r[4], e.g. INTERNAL_DOORPART/INTERNAL_SMALL/
           // INTERNAL) instead of masking it. Real IfcSpace rows (object_type a real IFC type, e.g.
           // 'Office') still group by object_type first, unchanged.
-          var typeKey = (r[3] && r[3] !== 'COMPILED') ? r[3] : r[4];
-          var gk = (_roomGroupBy === 'type') ? (typeKey || '(untyped)') : (r[2] || '(no storey)');
           var logicalGuid = r[5] || r[0];   // room_guid, falling back to this row's own guid
+          // §CORRIDOR-TYPE-LABEL: a real hallway-backbone match OVERRIDES whatever generic
+          // predefined_type this room compiled with — takes priority over the fallthrough below,
+          // since it's a stronger, door+wall-verified signal, not a compile-time placeholder.
+          var corridorMatch = corridorLabels[logicalGuid];
+          var typeKey = corridorMatch ? 'Hall / Corridor' : ((r[3] && r[3] !== 'COMPILED') ? r[3] : r[4]);
+          var gk = (_roomGroupBy === 'type') ? (typeKey || '(untyped)') : (r[2] || '(no storey)');
           if (seenLogical[logicalGuid]) { dupRects++; return; }   // §MULTI-RECT: 1 entry per logical room
           seenLogical[logicalGuid] = true;
           if (_roomGroupBy === 'type' && typeKey) typed++;

--- a/witness_backbone_routing.js
+++ b/witness_backbone_routing.js
@@ -54,6 +54,32 @@ if (e2ToSpine.length >= 2) {
     weights.filter(w => w > 0.01).length > weights.length * 0.5, 'nonZero=' + weights.filter(w => w > 0.01).length + '/' + weights.length);
 }
 
+// ── §CIRC-SPINE-BRIDGE regression guard (2026-07-14, found via a real user screenshot: Clinic
+// First Floor R10 -> Second Floor R5 returned a path with a PHANTOM cross-storey spine-to-spine
+// edge — walkBackbone() ran per-storey and returned crossing indices LOCAL to that storey's own
+// array, but room_graph.js looked them up as GLOBAL indices into the full cross-storey `joined`
+// array, so a First-Floor local index could silently resolve to an unrelated Second-Floor bucket.
+// Fixed by making crossings reference bucket OBJECTS, not positional indices. That fix then
+// exposed a SECOND real bug: E2 rescuing onto the nearest spine (instead of the old CIRC blob)
+// left E3's stair-bridging CIRC nodes as an unreachable island whenever a backbone existed on
+// that storey — cross-floor paths returned null where they used to work. Fixed with a
+// circ-to-nearest-spine bridge edge (kind E6). Both must hold together, permanently. ──
+chk('G0 no E5 (corridor-junction) edge ever connects two DIFFERENT storeys',
+  graph.edges.filter(e => e.kind === 'E5').every(e => graph.nodesByGuid[e.a].storey === graph.nodesByGuid[e.b].storey),
+  'E5 edges=' + graph.edges.filter(e => e.kind === 'E5').length);
+const spineStoreys = new Set(spineNodes.map(g => graph.nodesByGuid[g].storey));
+const circOnSpineStoreys = circNodes.filter(g => spineStoreys.has(graph.nodesByGuid[g].storey));
+const bridgedCirc = circOnSpineStoreys.filter(g => graph.edges.some(e => e.kind === 'E6' && (e.a === g || e.b === g)));
+chk('G0b every CIRC node on a storey that HAS a spine is bridged into it (not an island) — a storey with no backbone at all (e.g. a doorless footing level) is correctly exempt',
+  circOnSpineStoreys.length === 0 || bridgedCirc.length === circOnSpineStoreys.length,
+  'circOnSpineStoreys=' + circOnSpineStoreys.length + ' bridged=' + bridgedCirc.length + ' (total circ=' + circNodes.length + ')');
+{
+  const r10r5 = RoomGraph.shortestPath(graph, 'RM_First_Floor_10', 'RM_Second_Floor_5');
+  chk('G0c a known real cross-floor pair (First Floor R10 -> Second Floor R5) is reachable via a REAL stair',
+    !!(r10r5 && r10r5.path.some(g => graph.nodesByGuid[g].kind === 'stairwp')),
+    r10r5 ? ('distance=' + r10r5.distance.toFixed(1) + ' hops=' + r10r5.path.length) : 'NULL (regressed)');
+}
+
 // Pick a real multi-hop room pair through the spine and confirm the rendered path visits
 // GEOMETRICALLY DISTINCT points (proves it hugs the corridor's real shape, not a straight
 // teleport through one fixed blob position).

--- a/witness_corridor_room_backprop.js
+++ b/witness_corridor_room_backprop.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-CORRIDOR-ROOM-BACKPROP scope (READ THE LOG after every run)
+ * SCOPE: room_graph.js's §CORRIDOR-ROOM-BACKPROP — the hallway backbone (built from RAW doors+
+ * walls, independent of room compilation) injects a real 'room' node for every joined bucket that
+ * has NO compiled room there at all. User's own framing: "backward propagation" — evidence found
+ * by the routing layer flows back into the room layer instead of staying siloed.
+ * ISSUES THIS EXPOSES:
+ *   B1 REAL-GAIN — HHS (sparse-wall federated, only 14 compiled rooms for the whole building)
+ *       must show a MEASURED increase in reachable room-pairs, not just more total rooms.
+ *   B2 NO-SHADOW — a real bug found+fixed same session: a centroid-only "already covered" test
+ *       let a corridor rect (span+width) substantially overlap and steal a real room's own doors
+ *       (RM_First_Floor_10 went from 1 edge to 0 before the fix). A real rect-overlap-area guard
+ *       replaced it. This witness proves NO injected corridor room ever overlaps a real room by
+ *       more than the guard's own threshold, on both buildings.
+ *   B3 NO-REGRESSION — Clinic's already-verified R10->R5 real-stair path must still resolve.
+ * RUN: node witness_corridor_room_backprop.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const RoomGraph = require('./common/room_graph.js');
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+function rectOverlapArea(a, c) {
+  const ox = Math.max(0, Math.min(a.x1, c.x1) - Math.max(a.x0, c.x0));
+  const oy = Math.max(0, Math.min(a.y1, c.y1) - Math.max(a.y0, c.y0));
+  return ox * oy;
+}
+
+function reachablePairs(graph) {
+  const rooms = graph.nodes.map(n => n.guid);
+  let reachable = 0, total = 0;
+  for (let i = 0; i < rooms.length; i++) for (let j = i + 1; j < rooms.length; j++) {
+    total++;
+    if (RoomGraph.shortestPath(graph, rooms[i], rooms[j])) reachable++;
+  }
+  return { reachable, total };
+}
+
+function noShadowCheck(graph, label) {
+  const corridorRooms = graph.nodes.filter(n => n.guid.indexOf('CORRIDOR_ROOM::') === 0);
+  const realRooms = graph.nodes.filter(n => n.guid.indexOf('CORRIDOR_ROOM::') !== 0);
+  let worstOverlap = 0;
+  corridorRooms.forEach(cr => {
+    realRooms.forEach(rr => {
+      if (rr.storey !== cr.storey) return;
+      rr.rects.forEach(rc => { worstOverlap = Math.max(worstOverlap, rectOverlapArea(rc, cr.rects[0])); });
+    });
+  });
+  chk('B2 (' + label + ') no injected corridor room overlaps a real room by more than the 0.5m^2 guard threshold',
+    worstOverlap <= 0.5, 'corridorRooms=' + corridorRooms.length + ' worstOverlap=' + worstOverlap.toFixed(2) + 'm^2');
+}
+
+console.log('§W-CORRIDOR-ROOM-BACKPROP');
+
+// ── HHS: the real-gain case ──
+{
+  const db = new Database('/home/red1/bim-ootb/buildings/HHS_Office_Federated_extracted.db', { readonly: true });
+  function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+  const graph = RoomGraph.buildGraph(dbQuery, { log: () => {} });
+  const r = reachablePairs(graph);
+  const pct = 100 * r.reachable / r.total;
+  console.log('§HHS rooms=' + graph.nodes.length + ' reachable=' + r.reachable + '/' + r.total + ' (' + pct.toFixed(1) + '%)');
+  chk('B1 HHS reachable-pair percentage measurably improved beyond the pre-backprop baseline (17.6%)', pct > 25, pct.toFixed(1) + '%');
+  noShadowCheck(graph, 'HHS');
+  db.close();
+}
+
+// ── Clinic: the no-regression + no-shadow case ──
+{
+  const db = new Database('/home/red1/bim-ootb/buildings/Clinic_extracted.db', { readonly: true });
+  function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+  const graph = RoomGraph.buildGraph(dbQuery, { log: () => {} });
+  noShadowCheck(graph, 'Clinic');
+  const r10r5 = RoomGraph.shortestPath(graph, 'RM_First_Floor_10', 'RM_Second_Floor_5');
+  chk('B3 Clinic\'s known real cross-floor pair (First Floor R10 -> Second Floor R5) still resolves via a real stair',
+    !!(r10r5 && r10r5.path.some(g => graph.nodesByGuid[g].kind === 'stairwp')),
+    r10r5 ? ('distance=' + r10r5.distance.toFixed(1) + ' hops=' + r10r5.path.length) : 'NULL');
+  const r10 = graph.nodesByGuid['RM_First_Floor_10'];
+  const r10Edges = graph.edges.filter(e => e.a === 'RM_First_Floor_10' || e.b === 'RM_First_Floor_10').length;
+  chk('B3b RM_First_Floor_10 (the room that lost all its edges pre-fix) has real edges again', r10Edges > 0, 'edges=' + r10Edges);
+  db.close();
+}
+
+console.log('\n§W-CORRIDOR-ROOM-BACKPROP DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/witness_corridor_type_label.js
+++ b/witness_corridor_type_label.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-CORRIDOR-TYPE-LABEL scope (READ THE LOG after every run)
+ * SCOPE: common/hallway_backbone.js's classifyCorridorRooms() — the Find panel's Type-grouped
+ * room tree DISPLAY override (user ask, 2026-07-14: "long corridors well named under Type.Hall/
+ * Corridor"). DOES NOT touch spatial_structure/predefined_type — display-time only, see
+ * viewer/navigate_find.js's _corridorLabelsFor() wiring for the consumer.
+ * RUN: node witness_corridor_type_label.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const HallwayBackbone = require('./common/hallway_backbone.js');
+
+const DB_PATH = '/home/red1/bim-ootb/buildings/Clinic_extracted.db';
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+console.log('§W-CORRIDOR-TYPE-LABEL building=' + DB_PATH);
+const db = new Database(DB_PATH, { readonly: true });
+function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+
+const result = HallwayBackbone.classifyCorridorRooms(dbQuery, { log: (m) => console.log('  ' + m) });
+const guids = Object.keys(result);
+chk('G1 at least some real rooms classified as corridor', guids.length > 0, 'count=' + guids.length);
+
+// Independent re-check: every classified room's own centroid must ACTUALLY fall inside a real
+// joined bucket's measured rect — re-derive from scratch, don't just trust classifyCorridorRooms'
+// own verdict.
+const backbone = HallwayBackbone.buildBackbone(dbQuery, { log: () => {} });
+const bucketsByStorey = {};
+backbone.joined.forEach(b => { (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push(HallwayBackbone.bucketRect(b)); });
+
+const hasRoomGuid = dbQuery('PRAGMA table_info(spatial_structure)').some(c => c[1] === 'room_guid');
+const spaceRows = dbQuery("SELECT s.guid, p.name" + (hasRoomGuid ? ', s.room_guid' : ', NULL') + ", s.center_x, s.center_y " +
+  "FROM spatial_structure s LEFT JOIN spatial_structure p ON p.guid = s.parent_guid " +
+  "WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL");
+const centroidByGuid = {};
+spaceRows.forEach(r => { const lg = r[2] || r[0]; if (!centroidByGuid[lg]) centroidByGuid[lg] = { storey: r[1], cx: r[3], cy: r[4] }; });
+
+let allVerified = true, checkedCount = 0;
+guids.forEach(lg => {
+  const c = centroidByGuid[lg];
+  if (!c) { allVerified = false; return; }
+  const rects = bucketsByStorey[c.storey] || [];
+  const hit = rects.some(rc => c.cx >= rc.x0 && c.cx <= rc.x1 && c.cy >= rc.y0 && c.cy <= rc.y1);
+  if (!hit) allVerified = false;
+  checkedCount++;
+});
+chk('G2 every classified room independently re-verified to sit inside a real backbone rect', allVerified, 'checked=' + checkedCount);
+
+// Rooms that were NOT classified as corridor must genuinely NOT sit in any bucket rect (no
+// false-negative check needed for a display override, but confirm the classifier isn't
+// over-matching — spot check a random non-classified room).
+const nonMatched = Object.keys(centroidByGuid).filter(g => !result[g]);
+let overMatchFound = false;
+nonMatched.slice(0, 40).forEach(lg => {
+  const c = centroidByGuid[lg];
+  const rects = bucketsByStorey[c.storey] || [];
+  const hit = rects.some(rc => c.cx >= rc.x0 && c.cx <= rc.x1 && c.cy >= rc.y0 && c.cy <= rc.y1);
+  if (hit) overMatchFound = true;
+});
+chk('G3 no false negatives in a 40-room sample (a room truly inside a bucket rect was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
+
+console.log('§SAMPLE classified=' + guids.length + ' total=' + Object.keys(centroidByGuid).length +
+  ' chains touched=' + new Set(guids.map(g => result[g].chain)).size);
+
+console.log('\n§W-CORRIDOR-TYPE-LABEL DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
Follow-up to #782 (squash-merged, but auto-merge fired before these 5 commits were pushed — they were orphaned on the branch until this rebase caught it). Same branch, rebased onto current main.

- `feat(rooms): Type-grouped room tree labels real corridors as "Hall / Corridor"` — `classifyCorridorRooms()`, display-time Type label for already-compiled rooms overlapping a backbone bucket.
- `fix(rooms): two real bugs found via user screenshot — phantom cross-storey edge + orphaned stairs` — walkBackbone() crossing-identity fix (per-storey local index treated as global) + CIRC-SPINE bridge (E2's spine-rescue orphaned E3's stair mechanism).
- `feat(rooms): backward-propagate the corridor backbone into real room nodes` — the big one. Backbone buckets with NO compiled room get injected as real room nodes, before the E1/E2 door loop runs. Overlap-guard fix included (a real regression found+fixed same session before it ever shipped — corridor rect swallowing a real room's doors).
- `feat(rooms): surface backprop-injected corridor rooms under Type/Storey trees, not just Path picker` — the Type/Storey tree queries spatial_structure directly and never saw synthetic rooms; wired in via the same cached room graph, plus a working zoom/highlight path for guids with no DB row.
- `fix(rooms): CIRC nodes were missing from the chord-detour candidate set` — completeness fix, measured zero effect locally, kept because safe and consistent.

## Test plan
- [x] 5 witnesses, all green: `witness_room_graph_path.js` (15/15, Duplex regression), `witness_hallway_backbone.js` (7/7), `witness_backbone_routing.js` (8/8), `witness_corridor_type_label.js` (3/3), `witness_corridor_room_backprop.js` (5/5).
- [x] HHS reachable room-pairs measured 17.6% -> 38.0% (real, not assumed).
- [x] Zero regression on Clinic/Duplex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFx2nPckWD3GBeGmJu2N5