### PR TITLE
fix(rooms): needle-inject invalidation forgot the corridor-label cache

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -958,7 +958,14 @@
         // S4 — ungrey + refresh: invalidate the room-graph cache so PATH mode sees the new
         // rooms without a reload, then re-probe/re-render (the pill removes itself once
         // spaceCount > 0 — see _renderNeedle's own gate).
+        // §CORRIDOR-LABEL-CACHE-BUST (2026-07-14, real bug found via user report): needle-inject
+        // recompiles rooms (HHS: 14 -> 71 real rooms) but this invalidation only ever cleared
+        // _pathGraphCache — _corridorLabelsCache (added later, same per-building caching pattern)
+        // was never included here, so a Type-tree opened BEFORE needle-inject finished could stay
+        // stuck showing "no Hall/Corridor" for the rest of the session even after real corridor
+        // rooms existed. Same fix, same site, same reason.
         _pathGraphCache = null; _pathGraphBld = null;
+        _corridorLabelsCache = null; _corridorLabelsBld = null;
         _renderAxes();
         buildTree();
       } catch (e) {


### PR DESCRIPTION
## Summary
- Needle-inject's completion handler explicitly invalidates \`_pathGraphCache\` so Path mode sees newly-compiled rooms without a reload — but \`_corridorLabelsCache\` (added later, same pattern) was never included at that site. A Type-tree opened before needle-inject finished stays stuck showing no Hall/Corridor entries for the rest of the session.
- Verified with real data: HHS's fresh live compile is 71 rooms (not the static 14-room snapshot), and classifyCorridorRooms() against that finds 29 real corridor rooms — the label should show, and now will once this cache is busted at the same time as the path graph cache.
- Also documented (not fixed, separate issue): the reported "cuts through air between doors and stairs" is a genuine corridor-coverage gap for that specific area of HHS (Level 2's backbone chains are fragmented and don't reach ~20m to the stair) — `_detourForChord` is correctly reporting failure rather than fabricating a route.

## Test plan
- [x] All 5 witnesses green, 0 regressions (cache-invalidation timing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFx2nPckWD3GBeGmJu2N5