### PR TITLE
fix(rooms): stair extraction merges flight+assembly data instead of strict either/or

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -121,18 +121,37 @@
   // Returns { groups: {key: {guids,cx,cy,n,zlo,zhi,xlo,xhi,ylo,yhi}}, order: [key,...] (insertion order) }.
   function getStairGroups(dbQuery, log) {
     log = log || function () {};
-    var flightRows = [];
+    var flightRows = [], assemblyRows = [];
     var _stairSelect = "SELECT m.guid, m.element_name, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z" +
       ' FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid';
     try {
       flightRows = dbQuery(_stairSelect +
         " WHERE (m.ifc_class LIKE 'IfcStairFlight%' OR m.ifc_class LIKE 'IfcRampFlight%') AND t.center_z IS NOT NULL") || [];
-      if (!flightRows.length) {
-        flightRows = dbQuery(_stairSelect +
-          " WHERE (m.ifc_class LIKE 'IfcStair%' OR m.ifc_class LIKE 'IfcRamp%') AND t.center_z IS NOT NULL") || [];
-        if (flightRows.length) log('§ROOM_GRAPH_STAIR_FALLBACK assemblies=' + flightRows.length + ' (no flight rows in this building)');
-      }
     } catch (eFl) { log('§ROOM_GRAPH_STAIR_ERR ' + eFl.message); }
+    // §STAIR-FLIGHT-ASSEMBLY-MERGE (2026-07-14, real bug found via user report — Hospital: cross-
+    // floor paths universally failed, "no door-connected route", on every pair). Root cause: the
+    // OLD either/or fallback ("if flightRows.length is exactly 0, use assemblies instead") breaks
+    // the moment a SINGLE unrelated flight row exists anywhere in the building — Hospital has
+    // exactly 1 real IfcStairFlight ("Stair:Monolithic Stair:248870", an orphan, z-span only
+    // 1.1m — too short to bridge any two real storeys) alongside 61 real IfcStair ASSEMBLY rows
+    // ("Stair:180mm max riser 280mm going:*", real multi-floor stairs with real per-floor Z
+    // variants) that the strict either/or NEVER reached, because flightRows.length was 1, not 0.
+    // Fix: always query BOTH, then MERGE — an assembly-derived stair is added only if its
+    // stairBaseKey ISN'T already covered by a flight-derived group, so a building where flights
+    // and assemblies represent the SAME physical stairs (e.g. Duplex) never double-counts; a
+    // building where they're genuinely DIFFERENT stairs (Hospital) gets both.
+    var flightKeys = {};
+    flightRows.forEach(function (f) { flightKeys[stairBaseKey(f[1])] = true; });
+    try {
+      assemblyRows = dbQuery(_stairSelect +
+        " WHERE (m.ifc_class LIKE 'IfcStair%' OR m.ifc_class LIKE 'IfcRamp%') AND t.center_z IS NOT NULL") || [];
+    } catch (eAs) { log('§ROOM_GRAPH_STAIR_ASSEMBLY_ERR ' + eAs.message); }
+    var mergedAssemblyRows = assemblyRows.filter(function (a) { return !flightKeys[stairBaseKey(a[1])]; });
+    if (mergedAssemblyRows.length) {
+      log('§ROOM_GRAPH_STAIR_MERGE flightRows=' + flightRows.length + ' assemblyOnlyRows=' + mergedAssemblyRows.length +
+        ' (assembly stairs not already covered by a flight — merged in, not replacing)');
+    }
+    flightRows = flightRows.concat(mergedAssemblyRows);
 
     var groups = {}, order = [];
     flightRows.forEach(function (f) {

--- a/witness_stair_flight_assembly_merge.js
+++ b/witness_stair_flight_assembly_merge.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-STAIR-FLIGHT-ASSEMBLY-MERGE scope (READ THE LOG after every run)
+ * SCOPE: getStairGroups()'s old either/or fallback ("only use assembly rows if flightRows.length
+ * is EXACTLY 0") broke the moment a single unrelated flight existed anywhere in the building.
+ * User report: Hospital's cross-floor paths universally failed ("no door-connected route") on
+ * every pair tried, same-floor paths worked fine. Root cause confirmed: Hospital has exactly 1
+ * real IfcStairFlight (an orphan, 1.1m z-span, too short to bridge any two real storeys)
+ * alongside 61 real IfcStair ASSEMBLY rows (real multi-floor stairs) the old code never reached.
+ * ISSUES THIS EXPOSES:
+ *   M1 MERGE-WORKS — Hospital's real assembly stairs must be found and produce real E3 edges
+ *       (was stairs=0 before this fix).
+ *   M2 NO-DOUBLE-COUNT — Duplex (which has real flight data covering its real stairs) must NOT
+ *       gain extra/duplicate stair groups from this merge — same stair count as before.
+ *   M3 SOME-CROSS-FLOOR-WORKS — at least one real cross-storey room pair must now resolve a path
+ *       where none could before.
+ * RUN: node witness_stair_flight_assembly_merge.js   (from the worktree root)
+ */
+'use strict';
+const path = require('path');
+const fs = require('fs');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const RoomWalker = require('/home/red1/bim-ootb/viewer/lib/room_walker.js');
+const RoomGraph = require('./common/room_graph.js');
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+console.log('§W-STAIR-FLIGHT-ASSEMBLY-MERGE');
+
+(async () => {
+  // ── M1/M3: Hospital, real fresh compile (matches what the live Viewer actually runs) ──
+  const SQL = await initSqlJs();
+  const hdb = new SQL.Database(new Uint8Array(fs.readFileSync('/home/red1/bim-ootb/buildings/Hospital_extracted.db')));
+  const compiled = RoomWalker.compileRooms(hdb);
+  RoomWalker.writeRooms(hdb, compiled);
+  function hDbQuery(sql, params) {
+    const stmt = hdb.prepare(sql);
+    if (params) stmt.bind(params);
+    const rows = [];
+    while (stmt.step()) rows.push(stmt.get());
+    stmt.free();
+    return rows;
+  }
+  const sg = RoomGraph.getStairGroups(hDbQuery, () => {});
+  console.log('§HOSPITAL stairGroups=' + sg.order.length);
+  chk('M1 Hospital finds real assembly-derived stairs (was 1 before this fix, the orphan flight only)',
+    sg.order.length > 5, 'found=' + sg.order.length);
+
+  const graph = RoomGraph.buildGraph(hDbQuery, { log: () => {} });
+  const stairEdges = graph.edges.filter(e => e.kind === 'E3').length;
+  console.log('§HOSPITAL realE3edges=' + stairEdges);
+  chk('M1b Hospital produces real E3 (stair-crossing) edges (was 0 before this fix)', stairEdges > 0, 'edges=' + stairEdges);
+
+  const byStorey = {};
+  graph.nodes.forEach(n => { (byStorey[n.storey] = byStorey[n.storey] || []).push(n.guid); });
+  const storeys = Object.keys(byStorey);
+  let crossWorking = 0, crossTried = 0;
+  for (let i = 0; i < storeys.length && crossTried < 40; i++) {
+    for (let j = i + 1; j < storeys.length && crossTried < 40; j++) {
+      const a = byStorey[storeys[i]][0], b = byStorey[storeys[j]][0];
+      if (!a || !b) continue;
+      crossTried++;
+      if (RoomGraph.shortestPath(graph, a, b)) crossWorking++;
+    }
+  }
+  console.log('§HOSPITAL crossFloorSample=' + crossWorking + '/' + crossTried);
+  chk('M3 at least one real cross-storey room pair now resolves a path (was 0/any before this fix)', crossWorking > 0, crossWorking + '/' + crossTried);
+
+  // ── M2: Duplex, no double-counting regression ──
+  // Duplex has ZERO IfcStair assembly rows at all (only 2 real IfcStairFlight rows, one per
+  // mirrored unit — verified directly against the DB) — so the merge should add NOTHING here.
+  // Checked via the log line itself, not just the final count, so this genuinely proves "the
+  // merge added zero rows" rather than assuming a stair count that was never independently verified.
+  const ddb = new Database('/home/red1/bim-ootb/modeller/Duplex_ARC.db', { readonly: true });
+  function dDbQuery(sql) { return ddb.prepare(sql).raw(true).all(); }
+  let mergeLogFired = false;
+  const dsg = RoomGraph.getStairGroups(dDbQuery, (m) => { if (m.indexOf('STAIR_MERGE') >= 0) mergeLogFired = true; });
+  console.log('§DUPLEX stairGroups=' + dsg.order.length + ' mergeLogFired=' + mergeLogFired);
+  chk('M2 Duplex (2 real flight-only stairs, zero assembly rows) triggers NO merge at all — proves the merge only ADDS truly assembly-only stairs, never double-counts',
+    dsg.order.length === 2 && !mergeLogFired, 'found=' + dsg.order.length + ' mergeLogFired=' + mergeLogFired);
+  ddb.close();
+
+  console.log('\n§W-STAIR-FLIGHT-ASSEMBLY-MERGE DONE pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary
User report: Hospital's cross-floor paths universally failed — every pair, "no door-connected route". Same-floor paths worked fine.

Root cause: the stair extractor's fallback only used IfcStair/IfcRamp ASSEMBLY rows when the flight query returned exactly zero rows. Hospital has 1 real orphan IfcStairFlight (z-span 1.1m, too short to bridge any storeys) alongside 61 real assembly-based multi-floor stairs the strict either/or never reached. Net effect: 0 real stair-crossing edges for the whole building.

Fix: always query both, merge — an assembly stair is added only if its base name isn't already covered by a flight-derived group, so buildings where both represent the same stairs never double-count.

Measured: Hospital stairGroups 1 -> 10, real E3 edges 0 -> 6, at least one real cross-storey pair now resolves where none did before. Duplex verified via the merge's own log to trigger zero merging (no regression).

Honest note: the exact reported pair (R13->R46) is still disconnected — a separate, room-specific gap (not near any of the 6 now-working stairs), not the stair-detection bug this fixes.

## Test plan
- [x] New witness (4/4): Hospital gains real connectivity, Duplex stays untouched.
- [x] Full suite: 6 witnesses, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFx2nPckWD3GBeGmJu2N5