### PR TITLE
fix(rooms): hallway_backbone.js was never actually loaded in the browser

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -150,6 +150,16 @@ async function initViewer() {
         // v3 (PATH_LEGAL_SEGMENTS.md, 2026-07-13): same-storey chord legality + visibility-graph
         // detour — a returning browser's cached v2 never draws the courtyard-void fix without this bump.
         '../common/room_graph.js?v=3',
+        // §HALLWAY-BACKBONE-NOT-LOADED (2026-07-14, real bug found via live browser check — every
+        // corridor/spine/Hall-Corridor-label feature built this session had been silently no-oping
+        // in the browser, despite passing every Node-based witness, because this line never
+        // existed): room_graph.js's buildGraph() reads window.HallwayBackbone (used for E5/E6/E7/E8
+        // spine wiring, corridor-room backprop, and classifyCorridorRooms' Type-tree label) but the
+        // script that DEFINES it was never added to this load list. Must load AFTER room_graph.js
+        // (room_graph.js's HallwayBackbone read happens inside buildGraph(), called later — fine)
+        // but hallway_backbone.js itself reads window.RoomGraph at its OWN top-level IIFE execution
+        // (getStairGroups() reuse), so room_graph.js must already exist by the time this runs.
+        '../common/hallway_backbone.js?v=1',
         'navigate_find.js?v=48',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',


### PR DESCRIPTION
## Summary — the root cause of the entire "corridors missing" thread this session

Verified live in an actual browser (Playwright against the real dev server), not just Node witnesses. **`common/hallway_backbone.js` was never added to `main.js`'s dynamic module-load list.** Every witness this session passed because Node's `require()` resolves the file regardless of what any HTML references — but the browser only loads what `main.js` tells it to. `room_graph.js`'s `if (HallwayBackbone) { ... }` guard was silently no-oping in every real session all week.

Confirmed directly: `window.HallwayBackbone` was `undefined` on a live HHS load before this fix.

This explains everything reported this session: paths still floating after the spine fix "shipped," zero Hall/Corridor labels on any building, zero effect from corridor-room-backprop. The fixes that DID visibly help (stair run-ends, detour locality, flight/assembly merge) are the ones that live entirely inside `room_graph.js` and don't depend on this missing script.

Fix: add the script to the load list, positioned after `room_graph.js` (dependency order — `hallway_backbone.js` reads `window.RoomGraph` at its own top-level execution).

## Test plan
- [x] Verified LIVE: loaded HHS via a real headless-Chromium session against `python3 -m http.server`, opened Find panel, switched Room -> Type. Before: one group "INTERNAL_DOORPART (105)". After: two groups, "INTERNAL_DOORPART (74)" + "Hall / Corridor (32)" — confirmed via console log AND a screenshot of the rendered tree.
- [x] All 6 offline witnesses still green (load-order fix, no logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFx2nPckWD3GBeGmJu2N5