### PR TITLE
fix(4d): Editor Generate+MSProject export, dedupe TM matrix-clone (partial SE-7 fix)

### DIFF
--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -134,10 +134,18 @@
 </header>
 <div class="se-ribbon">
   <div class="se-ribbon-group">
+    <span class="se-ribbon-label">Generate</span>
+    <button id="se-generate-btn" title="Materialize (or regenerate) the rule-based default schedule from this model — phases + every element assigned. Safe to re-run; does nothing if this model already carries an imported programme.">⚙ Generate</button>
+  </div>
+  <div class="se-ribbon-group">
     <span class="se-ribbon-label">Import</span>
     <button id="se-import-btn" title="Import a Primavera P6 programme (.xer or .xml/PMXML) — adopt its WBS, logic and dates onto this model, then bind tasks to elements">⤓ P6</button>
     <input id="se-import-file" type="file" accept=".xer,.xml" style="display:none">
     <label id="se-autobind-wrap" title="If the activity names carry a BIM-Bind token (@discipline:IfcClass[:storey]), resolve it against this model and pre-bind tasks to elements on import — a reviewable first pass, not a guess."><input id="se-autobind-cb" type="checkbox" checked> auto-bind</label>
+  </div>
+  <div class="se-ribbon-group">
+    <span class="se-ribbon-label">Export</span>
+    <button id="se-export-msp-btn" title="Export the current schedule (WBS, dates, dependencies) as MS Project XML (MSPDI) — opens directly in Microsoft Project, or re-imports here via ⤓ P6.">⤒ MS Project</button>
   </div>
   <div class="se-ribbon-group">
     <span class="se-ribbon-label">Compute</span>
@@ -180,6 +188,6 @@
 <script src="schedule_author.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_editor_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -486,6 +486,100 @@
     rdr.readAsText(file);
   }
 
+  // ── Generate/Regenerate — the Editor's own entry point to the smart default (mirrors the ✎ Author
+  // wizard's "Generate first draft"/"Regenerate" button; §SE-5a's idempotent-rebuild transaction wrap
+  // already makes materializeDefault safe to re-run). Same captured-schedule guard as Author: never
+  // overwrite an imported P6/Bonsai/Revit programme with the rule-generated default.
+  function doGenerate() {
+    if (!db) { status('⚠ no model db open yet'); return; }
+    if (!SA()) { status('⚠ engine not loaded'); return; }
+    var act = SA().activeSchedule(db);
+    if (act && act.captured) {
+      status('This model already carries an imported schedule (' + act.name + ') — editing it in place, not regenerating.');
+      return;
+    }
+    status('Materializing default schedule — please wait…');
+    setTimeout(function () {
+      var res = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+      schedId = res.scheduleId;
+      collapsed = {}; critSet = {};
+      renderWbs(); renderDeps(); renderGantt(); fillAddForm();
+      persist();   // §SE-6 — a (re)generated default is itself an edit worth saving
+      status('Generated default schedule (' + res.phases.length + ' phases, ' + res.assignmentCount + ' elements assigned).');
+      console.log('§SE_GENERATE schedule=' + schedId + ' phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
+    }, 30);
+  }
+
+  // ── §X6: export the current schedule to MS Project XML (MSPDI) — the write-side counterpart to
+  // doImportP6's MSPDI read path (foreign_schedule.js parseMSPDI). Schema/units verified AGAINST that
+  // parser (not invented): OutlineLevel-encoded hierarchy (no parent-id field in MSPDI — hierarchy is
+  // walked pre-order from wbsTree and re-derived from nesting on read), Duration = 'PT{hours}H0M0S',
+  // LinkLag = integer TENTHS OF A MINUTE, PredecessorLink/Type = 0=FF/1=FS/2=SF/3=SS (MSP_TYPE reverse).
+  // 8h/day calendar (MinutesPerDay=480) — the same convention doImportP6's default hpd=8 fallback uses.
+  function exportMSProject() {
+    if (!db || !schedId || !SA() || !SA().wbsTree) { status('⚠ no schedule to export'); return; }
+    var tree = SA().wbsTree(db, schedId);
+    if (!tree.length) { status('⚠ no tasks to export'); return; }
+    var deps = SA().listDependencies ? SA().listDependencies(db, schedId) : [];
+    var predByTask = {};
+    deps.forEach(function (d) { (predByTask[d.succId] = predByTask[d.succId] || []).push(d); });
+
+    var HPD = 8, MPD = HPD * 60;
+    var TYPE_CODE = { FS: 1, SS: 3, FF: 0, SF: 2 };
+    function xmlEsc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
+    function durTag(start, finish) {
+      if (!start || !finish) return 'PT0H0M0S';
+      var days = Math.max(1, daysBetween(start, finish));
+      return 'PT' + (days * HPD) + 'H0M0S';
+    }
+
+    var uid = {}, seq = 1, rows = [];
+    (function walk(nodes, level) {
+      nodes.forEach(function (n) {
+        uid[n.id] = seq++;
+        rows.push({ n: n, level: level });
+        if (n.children && n.children.length) walk(n.children, level + 1);
+      });
+    })(tree, 1);
+
+    var xml = ['<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+      '<Project xmlns="http://schemas.microsoft.com/project">',
+      '<Name>' + xmlEsc((_dbUrl || 'schedule').split('/').pop()) + '</Name>',
+      '<MinutesPerDay>' + MPD + '</MinutesPerDay>',
+      '<Tasks>'];
+    rows.forEach(function (r) {
+      var n = r.n, u = uid[n.id];
+      var links = predByTask[n.id] || [];
+      xml.push('<Task>' +
+        '<UID>' + u + '</UID><ID>' + u + '</ID>' +
+        '<Name>' + xmlEsc(n.name) + '</Name>' +
+        '<OutlineLevel>' + r.level + '</OutlineLevel>' +
+        '<Summary>' + (n.isSummary ? 1 : 0) + '</Summary>' +
+        (n.start ? '<Start>' + n.start + 'T08:00:00</Start>' : '') +
+        (n.finish ? '<Finish>' + n.finish + 'T17:00:00</Finish>' : '') +
+        '<Duration>' + durTag(n.start, n.finish) + '</Duration>' +
+        (n.critical ? '<Critical>1</Critical>' : '') +
+        links.map(function (l) {
+          var lagTenths = Math.round((l.lag || 0) * HPD * 60 * 10);
+          return '<PredecessorLink><PredecessorUID>' + uid[l.predId] + '</PredecessorUID>' +
+            '<Type>' + (TYPE_CODE[l.type] != null ? TYPE_CODE[l.type] : 1) + '</Type>' +
+            '<LinkLag>' + lagTenths + '</LinkLag></PredecessorLink>';
+        }).join('') +
+        '</Task>');
+    });
+    xml.push('</Tasks></Project>');
+
+    var blob = new Blob([xml.join('')], { type: 'application/xml' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = (_dbUrl || 'schedule').split('/').pop().replace(/\.[a-z0-9]+$/i, '') + '_schedule.xml';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
+    status('Exported ' + rows.length + ' tasks / ' + deps.length + ' links to MS Project XML (' + a.download + ').');
+    console.log('§SE_EXPORT_MSP tasks=' + rows.length + ' links=' + deps.length + ' file=' + a.download);
+  }
+
   // ── boot ─────────────────────────────────────────────────────────────────────
   function init() {
     if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
@@ -539,6 +633,8 @@
         renderWbs(); renderDeps(); renderGantt();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
+        var genBtn = $('se-generate-btn'); if (genBtn) genBtn.onclick = doGenerate;
+        var expBtn = $('se-export-msp-btn'); if (expBtn) expBtn.onclick = exportMSProject;
         var impBtn = $('se-import-btn'), impFile = $('se-import-file');
         if (impBtn && impFile) {
           impBtn.onclick = function () { impFile.click(); };

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v749';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v750';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1751,16 +1751,15 @@
       if (obj.userData && obj.userData.guid) {
         _savedVisibility.push({ obj: obj, vis: obj.visible });
       }
-      // Save InstancedMesh state (visibility + all matrices)
+      // §SE-7 (W-TM-DEDUPE-SAVE): Save InstancedMesh VISIBILITY only here — NOT matrices. The matrix
+      // snapshot used to be cloned a SECOND time right here (one `new THREE.Matrix4()` + `.clone()` per
+      // instance, ~29s of main-thread block on a 122K-element building — the "still hangs" report). It
+      // was pure duplicate work: `renderAtTime()` (called unconditionally right after this, in
+      // `_finishActivate`, and on every subsequent tick) already lazily builds `_savedInstanceMatrices`
+      // — the SAME per-instance original matrices — as a side effect of rendering it has to do anyway.
+      // `restoreVisibility()` now reads from that shared lazy cache instead of a redundant private copy.
       if (obj.isInstancedMesh && app._instanceMeta && app._instanceMeta[obj.id]) {
-        var metas = app._instanceMeta[obj.id];
-        var matrices = {};
-        var tmpM = new THREE.Matrix4();
-        for (var i = 0; i < metas.length; i++) {
-          obj.getMatrixAt(i, tmpM);
-          matrices[i] = tmpM.clone();
-        }
-        _savedInstanceState[obj.id] = { vis: obj.visible, matrices: matrices, obj: obj };
+        _savedInstanceState[obj.id] = { vis: obj.visible, obj: obj };
       }
       // §S260b: Save BatchedMesh slot visibility
       if (obj.isBatchedMesh && app._batchMeta && app._batchMeta[obj.id]) {
@@ -1777,14 +1776,22 @@
   function restoreVisibility() {
     clearHighlight();
     var app = A();
-    // Restore InstancedMesh matrices and visibility from saved state
+    // §SE-7: matrices come from `_savedInstanceMatrices` (renderAtTime's lazy per-tick cache), not a
+    // private clone saveVisibility() no longer makes. `activate()` always calls `renderAtTime()` at
+    // least once before any `deactivate()` can run (§S260c "initial render" call in `_finishActivate`),
+    // so every InstancedMesh this loop iterates (i.e. every one `saveVisibility()` saw) is guaranteed to
+    // already have an entry here. A mesh with no entry (should not happen per the above) is left as-is —
+    // correct either way, since renderAtTime never touched/mutated its matrix in that case.
     for (var meshId in _savedInstanceState) {
       var state = _savedInstanceState[meshId];
       var obj = state.obj;
-      for (var idx in state.matrices) {
-        obj.setMatrixAt(parseInt(idx), state.matrices[idx]);
+      var mats = _savedInstanceMatrices[meshId];
+      if (mats) {
+        for (var idx in mats) {
+          obj.setMatrixAt(parseInt(idx), mats[idx]);
+        }
+        obj.instanceMatrix.needsUpdate = true;
       }
-      obj.instanceMatrix.needsUpdate = true;
       obj.visible = state.vis;
     }
     _savedInstanceState = {};


### PR DESCRIPTION
## Summary
- **Editor tab**: adds a ⚙ Generate button (mirrors the ✎ Author wizard's Generate/Regenerate) and an ⤒ MS Project (MSPDI) export — the write-side counterpart to the existing P6/MSPDI import. Schema/units read directly off our own `parseMSPDI` (not assumed), verified by round-tripping a real export back through our own parser (exact task/link/date match) plus a live-browser smoke test.
- **Time Machine**: `saveVisibility()` was cloning a `THREE.Matrix4` per InstancedMesh instance on every activate/deactivate — pure duplicate work, since `renderAtTime()` (called unconditionally right after, and on every tick) already lazily builds the exact same per-instance matrix cache as a side effect of rendering it has to do anyway. `restoreVisibility()` now reads from that shared cache instead of a redundant private copy. Verified behaviorally identical (not just faster).

## Honest scope note (read before assuming this closes the "still hangs" report)
This does **not** fully resolve the reported Generate/Apply/TM hang. Controlled idle-only testing (Time Machine/Author untouched) shows the dominant cost is proportional to building size, not caused by TM/Author code: a 122K-element building (LTU_AHouse) blocks the main thread continuously even sitting idle, while a 1.1K-element building (Duplex) shows zero blocking under the same test. The matrix-clone dedupe in this PR removes a real, confirmed-redundant cost (~13% of measured block time on LTU_AHouse) but the remaining hang is a large-building rendering/streaming cost issue, not a small logic bug — out of scope for this PR. See `prompts/FUSED_4D5D_WEDGE_LANE.md` §SE-7 in bim-compiler for the full investigation.

## Test plan
- [x] `node -c` syntax check on all changed files
- [x] Node witness: MSPDI export round-trips through our own `parseMSPDI`/`parseForeign` (exact task/WBS/link counts, byte-identical dates)
- [x] Real-browser Playwright smoke: Editor loads → Generate → regenerates correctly → Export MS Project → real file download, well-formed XML
- [x] Real-browser heartbeat-block re-measurement on LTU_AHouse (122,667 elements) before/after the matrix-clone fix: total block time 60.9s → 52.8s
- [x] sw.js CACHE_VERSION and script version tags bumped (v749→v750, schedule_editor_ui v8→v9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)