### PR TITLE
fix(4d): index kernel_ops.output_guid — the real Generate/Apply hang (O(n²))

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v750';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v751';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2434,6 +2434,13 @@
       'id INTEGER PRIMARY KEY, timestamp INTEGER NOT NULL,' +
       'op_type TEXT NOT NULL, parameters TEXT NOT NULL,' +
       'input_guids TEXT, output_guid TEXT, undone INTEGER DEFAULT 0)');
+    // §SE-7c: the T3 overlay pass below runs one UPDATE ... WHERE op_type=? AND output_guid=? PER
+    // ELEMENT (up to 122K times on a large building) — with no index, each is a full table scan of
+    // kernel_ops itself (also up to 122K rows), i.e. O(n^2). This index turns it into an indexed
+    // lookup per UPDATE — the actual dominant cost behind "regenerate Time Machine after a schedule
+    // change is slow" (materializeDefault's own writes were already fixed by §SE-5; this is a
+    // DIFFERENT table/query, never indexed). IF NOT EXISTS — safe to re-run, no data change.
+    db.run('CREATE INDEX IF NOT EXISTS idx_kernel_ops_guid ON kernel_ops(output_guid)');
 
     // ── T3 (§3.1): probe for a usable captured native IFC 4D schedule ──────────
     // If present + parseable, the generative timeline is rebased onto the real

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -906,7 +906,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=59" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=60" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>


### PR DESCRIPTION
## Summary
User pinpointed this precisely: it's Generate/Apply that hangs (not Time Machine viewing), and it's a SQL-write cost, not scene rendering. Traced to `injectGantt()`'s T3 overlay pass — the step that patches the generic per-element schedule with the real authored/captured task dates once a schedule exists. It runs one `UPDATE kernel_ops SET ... WHERE op_type='ELEMENT_PLACE' AND output_guid=?` **per element** (up to 122,667 times on a large building). `kernel_ops` had no index on `output_guid`, so every UPDATE was a full table scan of `kernel_ops` itself (also up to 122,667 rows) — O(n²).

Fix: `CREATE INDEX IF NOT EXISTS idx_kernel_ops_guid ON kernel_ops(output_guid)` right after the table's creation.

## Measured impact (real browser, real LTU_AHouse building, 122,667 elements)
- Before: the overlay pass alone took **34,000–123,000ms** (highly variable run to run, consistent with O(n²) contention under concurrent load).
- After: **1,273ms** for the same 122,667-row overlay. A 25–100x speedup on the exact step the user identified.

## Safety
An index changes performance only, never query/update results (SQLite semantics). Confirmed correct output on the same live test (100% coverage, matching pre-fix expected behavior: `covered=122667 generated=0 total=122667 pct=100`). `W-AUTHOR-4D-BLANK` 16/16 and `test_schedule_gate.js` still pass unchanged.

## Honest scope note
This fixes the specific O(n²) bug, not every remaining millisecond. When Time Machine is already actively rendering while Apply fires, a separate, already-diagnosed ambient per-frame render cost (`prompts/FUSED_4D5D_WEDGE_LANE.md` §SE-7 in bim-compiler) still compounds on top — a different issue, out of scope here.

## Test plan
- [x] `node -c` syntax check
- [x] Real-browser heartbeat/log-timestamp measurement, before vs after, isolating the overlay pass specifically
- [x] `W-AUTHOR-4D-BLANK` 16/16 (existing witness, unaffected)
- [x] `test_schedule_gate.js` PASS (existing witness, unaffected)
- [x] sw.js CACHE_VERSION and script version tag bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)