### PR TITLE
fix(rooms): corridor plausibility framework — width bounds, common-sense filter, shape guard, full connectivity

### DIFF
--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -55,6 +55,64 @@
   // corridor's runCoord line (real walls are rasterized transforms, not infinitely thin planes).
   var WALL_CROSS_SLACK = 0.3;
 
+  // §COMMON-SENSE-FILTER (2026-07-14, user's own framing): a real walkway/corridor (1) is not
+  // itself a room, (2) is not implausibly wide, (3) does not float in mid air, (4) is always
+  // grounded — connected to doors, a stair edge, or bounded within real walls. This is the same
+  // shape of problem established indoor-routing/space-boundary tools solve (IFC 2nd-level space
+  // boundary generation, Revit Room/Space boundary resolution, space-syntax axial-map tools): a
+  // bounded ray-cast to the NEAREST plausible bounding surface, never an unbounded "nearest match
+  // regardless of distance" search. Two small named verbs formalize that shared shape so both
+  // growToWall() (END caps, perpendicular walls) and bucketWidth() (SIDE walls, same-axis walls)
+  // apply the SAME plausibility discipline instead of each re-inventing its own ad hoc bound.
+  //   - wallLiesFlatAgainst(offset, minOffset, maxOffset): is this candidate wall's measured
+  //     offset from the reference coordinate within a physically sane window? Too close (~0) is
+  //     usually a self-match (the bucket's own host wall, or a door reveal/jamb stub) rather than
+  //     a real bounding surface; too far is a coincidentally-aligned wall from an unrelated part
+  //     of the building. minOffset=0 disables the "too close" half of the test (growToWall's end
+  //     caps run PERPENDICULAR to the bucket's own doors, so there's no self-match risk there —
+  //     only bucketWidth's SIDE-wall search, which scans SAME-axis walls, needs the floor too).
+  function wallLiesFlatAgainst(offset, minOffset, maxOffset) {
+    if (offset < minOffset || offset > maxOffset) return null;
+    return offset;
+  }
+  //   - distanceToEnclosure(x, y, envelope): 0 if the point sits within the building's own real
+  //     wall-derived footprint (+ a small tolerance for wall thickness), else how far outside it
+  //     sits. Backstops wallLiesFlatAgainst's per-wall bound with a whole-building sanity check —
+  //     the concrete symptom this guards ("half corridor... drawn perpendicular into mid air
+  //     outside building", user report 2026-07-14) is a corridor rect extending past where any
+  //     real wall exists at all, not just past ONE plausible flanking wall.
+  var ENCLOSURE_TOLERANCE = 0.5; // m — generous for one wall's thickness + measurement slack
+  function distanceToEnclosure(x, y, envelope) {
+    if (!envelope) return 0; // no envelope data — nothing to check against, don't false-flag
+    var dx = Math.max(envelope.x0 - x, 0, x - envelope.x1);
+    var dy = Math.max(envelope.y0 - y, 0, y - envelope.y1);
+    var d = Math.hypot(dx, dy);
+    return (d <= ENCLOSURE_TOLERANCE) ? 0 : d;
+  }
+  //   - buildingEnvelope(walls): the real wall-derived footprint for one storey's worth of walls
+  //     (reuses the SAME wall rows buildBackbone() already fetched — no new query). A plain bbox
+  //     union, same convention as room_habitability.js's envelopeFromTransforms but wall-only and
+  //     per-storey (a corridor must stay within ITS OWN floor's footprint, not the whole building's).
+  function buildingEnvelope(walls) {
+    if (!walls || !walls.length) return null;
+    var x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity;
+    walls.forEach(function (w) {
+      x0 = Math.min(x0, w.cx - w.bx / 2); x1 = Math.max(x1, w.cx + w.bx / 2);
+      y0 = Math.min(y0, w.cy - w.by / 2); y1 = Math.max(y1, w.cy + w.by / 2);
+    });
+    return { x0: x0, x1: x1, y0: y0, y1: y1 };
+  }
+  //   - isGrounded(bucket): a real walkway is "always connected to either/and doors, stairs edge,
+  //     within walls" (user's own phrasing) — reject a bucket that is open on BOTH ends with NO
+  //     stair anchor on EITHER end. That shape has nothing tying it to the building at all beyond
+  //     its own door cluster: not a real hallway/circulation space, just a coincidental door
+  //     alignment (>=3 doors is a necessary but not sufficient signal on its own).
+  function isGrounded(bucket) {
+    var loOk = !bucket.openLo || !!bucket.stairLo;
+    var hiOk = !bucket.openHi || !!bucket.stairHi;
+    return loOk || hiOk; // at least ONE end must be wall-capped or stair-anchored
+  }
+
   // ── 1. doorEdge ──────────────────────────────────────────────────────────────────────────────
   // d: {guid, name, storey, cx, cy, bx, by}. rotation_z is NOT used — measured across this
   // extracted data (2026-07-14 scratch session) as always 0, unusable as an axis signal. The
@@ -92,6 +150,16 @@
   // user, "ignore supporting columns/beams for convenience"). A capping wall runs PERPENDICULAR to
   // this bucket's axis (a cross-wall stopping the corridor) — a wall running the SAME way as the
   // bucket is more of the corridor's own side wall, not a cap.
+  // §END-CAP-REACH-BOUND (2026-07-14, part of §COMMON-SENSE-FILTER above — "not in mid air"): this
+  // loop used to accept the nearest capping wall regardless of how far beyond the outermost door it
+  // sat. Real live data (Clinic + HHS dump, this session) shows genuine end-cap reach almost always
+  // under ~5m past the last door; two measured outliers (8.99m, 13.56m, both HHS) are exactly the
+  // shape of a coincidentally cross-axis-aligned wall from an unrelated part of the building, the
+  // SAME failure mode §CORRIDOR-WIDTH-BOUNDS fixed for the perpendicular (side) dimension — this is
+  // its along-axis (end) counterpart, using the SAME wallLiesFlatAgainst() bound (no MIN needed
+  // here: this wall runs perpendicular to the bucket, so it can never be the bucket's own host
+  // wall — no self-match risk the way bucketWidth's side-wall scan has).
+  var MAX_END_REACH = 8.0;
   function growToWall(bucket, walls) {
     var alongs = bucket.doors.map(function (d) { return d.alongCoord; });
     var lo = Math.min.apply(null, alongs), hi = Math.max.apply(null, alongs);
@@ -105,8 +173,8 @@
       var perpLo = (bucket.axis === 'x') ? (w.cy - w.by / 2) : (w.cx - w.bx / 2);
       var perpHi = (bucket.axis === 'x') ? (w.cy + w.by / 2) : (w.cx + w.bx / 2);
       if (rc < perpLo - WALL_CROSS_SLACK || rc > perpHi + WALL_CROSS_SLACK) return; // doesn't cross this line
-      if (alongC <= lo && (loCap === null || alongC > loCap)) loCap = alongC;
-      if (alongC >= hi && (hiCap === null || alongC < hiCap)) hiCap = alongC;
+      if (alongC <= lo && (loCap === null || alongC > loCap) && wallLiesFlatAgainst(lo - alongC, 0, MAX_END_REACH) !== null) loCap = alongC;
+      if (alongC >= hi && (hiCap === null || alongC < hiCap) && wallLiesFlatAgainst(alongC - hi, 0, MAX_END_REACH) !== null) hiCap = alongC;
     });
     bucket.span = { lo: (loCap !== null) ? loCap : lo, hi: (hiCap !== null) ? hiCap : hi };
     bucket.openLo = (loCap === null);
@@ -157,8 +225,8 @@
       if (alongC + alongHalf < lo || alongC - alongHalf > hi) return; // must run alongside this corridor
       var perpC = (bucket.axis === 'x') ? w.cy : w.cx;
       var perpHalf = (bucket.axis === 'x') ? (w.by / 2) : (w.bx / 2);
-      if (perpC >= rc) { var d = (perpC - perpHalf) - rc; if (d >= MIN_SIDE_OFFSET && d <= MAX_SIDE_OFFSET && (nearAbove === null || d < nearAbove)) nearAbove = d; }
-      else { var d2 = rc - (perpC + perpHalf); if (d2 >= MIN_SIDE_OFFSET && d2 <= MAX_SIDE_OFFSET && (nearBelow === null || d2 < nearBelow)) nearBelow = d2; }
+      if (perpC >= rc) { var d = wallLiesFlatAgainst((perpC - perpHalf) - rc, MIN_SIDE_OFFSET, MAX_SIDE_OFFSET); if (d !== null && (nearAbove === null || d < nearAbove)) nearAbove = d; }
+      else { var d2 = wallLiesFlatAgainst(rc - (perpC + perpHalf), MIN_SIDE_OFFSET, MAX_SIDE_OFFSET); if (d2 !== null && (nearBelow === null || d2 < nearBelow)) nearBelow = d2; }
     });
     bucket.halfWidthHi = (nearAbove !== null) ? nearAbove : DEFAULT_HALF_WIDTH;
     bucket.halfWidthLo = (nearBelow !== null) ? nearBelow : DEFAULT_HALF_WIDTH;
@@ -305,6 +373,29 @@
     var stairGroupsResult = RoomGraph ? RoomGraph.getStairGroups(dbQuery, log) : { groups: {} };
     joined.forEach(function (b) { terminateAtStair(b, stairGroupsResult.groups); });
 
+    // §COMMON-SENSE-FILTER (2026-07-14) — two final sanity gates before a bucket is trusted as a
+    // real walkway, applied AFTER width/span/stair-termination are all known:
+    //  - isGrounded(): reject a bucket open on BOTH ends with no stair anchor on either — nothing
+    //    ties it to the building beyond a coincidental door alignment.
+    //  - distanceToEnclosure(): reject a bucket whose own measured rect corner sits outside that
+    //    STOREY's real wall-derived footprint — the concrete "floating in mid air outside the
+    //    building" symptom, as a whole-building backstop beyond the per-wall bounds above.
+    var envelopeByStorey = {};
+    Object.keys(wallsByStorey).forEach(function (st) { envelopeByStorey[st] = buildingEnvelope(wallsByStorey[st]); });
+    var droppedUngrounded = 0, droppedOutsideEnvelope = 0;
+    joined = joined.filter(function (b) {
+      if (!isGrounded(b)) { droppedUngrounded++; return false; }
+      var env = envelopeByStorey[b.storey];
+      var rc = bucketRect(b);
+      var corners = [[rc.x0, rc.y0], [rc.x0, rc.y1], [rc.x1, rc.y0], [rc.x1, rc.y1]];
+      var outside = corners.some(function (c) { return distanceToEnclosure(c[0], c[1], env) > 0; });
+      if (outside) { droppedOutsideEnvelope++; return false; }
+      return true;
+    });
+    if (droppedUngrounded || droppedOutsideEnvelope) {
+      log('§COMMON_SENSE_FILTER droppedUngrounded=' + droppedUngrounded + ' droppedOutsideEnvelope=' + droppedOutsideEnvelope);
+    }
+
     var byStorey = {};
     joined.forEach(function (b) { (byStorey[b.storey] = byStorey[b.storey] || []).push(b); });
     var allChains = [], allCrossings = [];
@@ -439,7 +530,10 @@
     doorEdge: doorEdge, correlateDoorEdges: correlateDoorEdges, joinDoorways: joinDoorways,
     growToWall: growToWall, bucketWidth: bucketWidth, bucketRect: bucketRect,
     terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
-    buildBackbone: buildBackbone, classifyCorridorRooms: classifyCorridorRooms
+    buildBackbone: buildBackbone, classifyCorridorRooms: classifyCorridorRooms,
+    // §COMMON-SENSE-FILTER verbs — exported individually so a sandbox can test each in isolation
+    wallLiesFlatAgainst: wallLiesFlatAgainst, distanceToEnclosure: distanceToEnclosure,
+    buildingEnvelope: buildingEnvelope, isGrounded: isGrounded
   };
   ROOT.HallwayBackbone = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -94,7 +94,20 @@
     enclosureTolerance: 0.5,
     // §CORRIDOR-OVERLAP-FRACTION — a room must have this fraction of its own area inside the
     // matched bucket to count as "on the corridor", not just its centroid.
-    minOverlapFraction: 0.5
+    minOverlapFraction: 0.5,
+    // §CORRIDOR-SHAPE (2026-07-14, user-reported: "Type.Hall/Corridor are still non corridors but
+    // mere rooms"). The overlap-fraction guard alone still lets a small, roughly SQUARE room
+    // through if it's simply small enough to sit almost entirely inside a bucket rect — real live
+    // data (Clinic, all 17 rooms classified before this fix): 11 of the 17 were near-square
+    // closets/small-office-shaped rooms (aspect ratio 1.08-1.44, area 4.7-11.4m² — e.g. "First
+    // Floor R10" at 2.4x2.2m, aspect 1.09), clearly not corridors despite high overlap fraction;
+    // the other 6 were genuinely elongated (aspect 1.88-3.86, e.g. "Second Floor R7" at 16.0x4.6m,
+    // aspect 3.48) and DO look like real corridor segments. A real corridor is elongated BY
+    // DEFINITION — that shape is what makes it a walkway rather than a room. 1.8 sits right below
+    // that real cluster's low end (1.88), cleanly separating the 6 genuine ones from the 11 boxy
+    // false positives (confirmed: applying this bound moved Clinic's classifiedRooms 17->6,
+    // dropping exactly those 11, keeping exactly those 6 — see debug dump, not eyeballed).
+    minAspectRatio: 1.8
   };
 
   // §COMMON-SENSE-FILTER (2026-07-14, user's own framing): a real walkway/corridor (1) is not
@@ -477,6 +490,21 @@
       : { x0: perpLo, x1: perpHi, y0: b.span.lo, y1: b.span.hi };
   }
 
+  // §CORRIDOR-SHAPE (2026-07-14, user-reported: "Type.Hall/Corridor are still non corridors but
+  // mere rooms" — see DEFAULT_PROFILE.minAspectRatio's own comment for the real measured evidence).
+  // A real corridor is elongated BY DEFINITION — that shape is what makes it a walkway rather than
+  // a room — so classifyCorridorRooms() rejects a candidate whose own union bounding box (across
+  // all its §MULTI-RECT sub-rects — a shape property of the ROOM, not of which bucket it might
+  // match, hence checked once per room, not per candidate) isn't elongated enough. Promoted to a
+  // module-level primitive (matching wallLiesFlatAgainst/distanceToEnclosure/etc.) so it's
+  // independently sandbox-testable, not buried inside classifyCorridorRooms().
+  function unionAspectRatio(ownRects) {
+    var x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity;
+    ownRects.forEach(function (rr) { x0 = Math.min(x0, rr.x0); x1 = Math.max(x1, rr.x1); y0 = Math.min(y0, rr.y0); y1 = Math.max(y1, rr.y1); });
+    var w = x1 - x0, h = y1 - y0;
+    return (w > 0 && h > 0) ? Math.max(w, h) / Math.min(w, h) : 0;
+  }
+
   // ── 5b. commonSenseFilter ────────────────────────────────────────────────────────────────────
   // Composes isGrounded() + distanceToEnclosure() into the single (3)+(4) gate from
   // §COMMON-SENSE-FILTER above — "not in mid air" + "always connected to doors/stairs/walls".
@@ -573,6 +601,7 @@
     var result = {};
     Object.keys(rects).forEach(function (lg) {
       var r = rects[lg];
+      if (unionAspectRatio(r.ownRects) < profile.minAspectRatio) return; // not elongated enough to be a real corridor, regardless of overlap
       var cx = r.sumX / r.n, cy = r.sumY / r.n;
       var candidates = bucketsByStorey[r.storey];
       if (!candidates) return;
@@ -600,7 +629,7 @@
     // the 4 primitives it's built from are exported too so a sandbox can test each in isolation.
     commonSenseFilter: commonSenseFilter,
     wallLiesFlatAgainst: wallLiesFlatAgainst, distanceToEnclosure: distanceToEnclosure,
-    buildingEnvelope: buildingEnvelope, isGrounded: isGrounded,
+    buildingEnvelope: buildingEnvelope, isGrounded: isGrounded, unionAspectRatio: unionAspectRatio,
     // DEFAULT_PROFILE — the single consolidated source of every tunable plausibility number (see
     // §PLAUSIBILITY-PROFILE above). Exported read-only-by-convention so a caller can build a
     // variant profile via `Object.assign({}, HallwayBackbone.DEFAULT_PROFILE, {maxSideOffset: 4})`

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -123,6 +123,28 @@
   // into that legality test (see room_graph.js wiring) lets a real, wall-bounded corridor register
   // as walkable even without a raster, instead of every corridor chord failing detour.
   var DEFAULT_HALF_WIDTH = 1.2; // m — only used when no flanking wall is found on that side (rare: an open-plan edge)
+  // §CORRIDOR-WIDTH-BOUNDS (2026-07-14, user-reported: false-positive rate + a mis-ID'd corridor
+  // shell on Clinic Second Floor, "taking the narrow wall next to it"). bucketWidth()'s wall scan
+  // had NO plausibility bounds on the flanking-wall distance — two failure modes confirmed on real
+  // live data (see §HOW-TO-TEST-LIVE dump this session):
+  //  - TOO CLOSE: the corridor's OWN door-hosting wall runs the SAME axis as the corridor (doors are
+  //    cut INTO it), so it always satisfies this loop's "runs alongside" test too, at ~0 offset from
+  //    rc — `Math.max(d, 0)` then clamped that self-match in as the "nearest" wall, collapsing the
+  //    whole side to 0. Confirmed live: Clinic Second Floor's runCoord=45 bucket (8 doors) came out
+  //    halfWidthLo=halfWidthHi=0.00 — a literal zero-thickness rect, not a walkable corridor.
+  //  - TOO FAR: with no real nearby flanking wall, the loop still accepted whatever same-axis wall
+  //    was nearest even if that was a coincidentally-aligned wall far across the building. Confirmed
+  //    live on HHS: halfWidthLo up to ~7.8m on one side, ballooning bucketRect() into an 8m-wide
+  //    strip that then swallowed large unrelated rooms (e.g. a 242m² room, 57% area overlap) as
+  //    false-positive "Hall / Corridor" matches.
+  // Both bounded the same way: a candidate wall must sit between MIN and MAX_SIDE_OFFSET from rc to
+  // count as a real flanking wall; outside that window it's "no wall found on this side" (same
+  // fallback as before — DEFAULT_HALF_WIDTH). MIN is bigger than 2x a real wall's thickness
+  // (0.15-0.3m, see RUN_COORD_TOL comment above) so a host-wall self-match never qualifies; MAX is
+  // generous even for a wide hospital double-loaded corridor (~3.6m total width) without accepting
+  // an implausible cross-building match.
+  var MIN_SIDE_OFFSET = 0.5;
+  var MAX_SIDE_OFFSET = 3.0;
   function bucketWidth(bucket, walls) {
     var rc = bucket.runCoord, lo = bucket.span.lo, hi = bucket.span.hi;
     var nearAbove = null, nearBelow = null;
@@ -135,8 +157,8 @@
       if (alongC + alongHalf < lo || alongC - alongHalf > hi) return; // must run alongside this corridor
       var perpC = (bucket.axis === 'x') ? w.cy : w.cx;
       var perpHalf = (bucket.axis === 'x') ? (w.by / 2) : (w.bx / 2);
-      if (perpC >= rc) { var d = (perpC - perpHalf) - rc; if (d >= -WALL_CROSS_SLACK && (nearAbove === null || d < nearAbove)) nearAbove = Math.max(d, 0); }
-      else { var d2 = rc - (perpC + perpHalf); if (d2 >= -WALL_CROSS_SLACK && (nearBelow === null || d2 < nearBelow)) nearBelow = Math.max(d2, 0); }
+      if (perpC >= rc) { var d = (perpC - perpHalf) - rc; if (d >= MIN_SIDE_OFFSET && d <= MAX_SIDE_OFFSET && (nearAbove === null || d < nearAbove)) nearAbove = d; }
+      else { var d2 = rc - (perpC + perpHalf); if (d2 >= MIN_SIDE_OFFSET && d2 <= MAX_SIDE_OFFSET && (nearBelow === null || d2 < nearBelow)) nearBelow = d2; }
     });
     bucket.halfWidthHi = (nearAbove !== null) ? nearAbove : DEFAULT_HALF_WIDTH;
     bucket.halfWidthLo = (nearBelow !== null) ? nearBelow : DEFAULT_HALF_WIDTH;
@@ -354,12 +376,19 @@
       ' FROM spatial_structure s LEFT JOIN spatial_structure p ON p.guid = s.parent_guid' +
       " WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL AND s.size_x IS NOT NULL") || [];
 
-    var rects = {}; // logicalGuid -> {storey, sumX, sumY, n}
+    // rects: logicalGuid -> {storey, sumX, sumY, n, ownRects: [{x0,x1,y0,y1,area}]}. A logical room
+    // can be a §MULTI-RECT union of several spatial_structure rows (see navigate_find.js's own
+    // dedup comment) — ownRects keeps each row's own footprint so the overlap-fraction guard below
+    // can measure against the room's REAL total area, not just its averaged centroid.
+    var rects = {};
     spaceRows.forEach(function (r) {
       var logicalGuid = r[2] || r[0];
       var storey = r[1] || '';
-      if (!rects[logicalGuid]) rects[logicalGuid] = { storey: storey, sumX: 0, sumY: 0, n: 0 };
-      rects[logicalGuid].sumX += r[3]; rects[logicalGuid].sumY += r[4]; rects[logicalGuid].n++;
+      if (!rects[logicalGuid]) rects[logicalGuid] = { storey: storey, sumX: 0, sumY: 0, n: 0, ownRects: [] };
+      var g = rects[logicalGuid];
+      g.sumX += r[3]; g.sumY += r[4]; g.n++;
+      var sx = r[5], sy = r[6];
+      g.ownRects.push({ x0: r[3] - sx / 2, x1: r[3] + sx / 2, y0: r[4] - sy / 2, y1: r[4] + sy / 2, area: sx * sy });
     });
 
     var bucketsByStorey = {};
@@ -367,18 +396,39 @@
       (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push({ rect: bucketRect(b), chain: b._chainIndex != null ? b._chainIndex : null });
     });
 
+    function rectOverlapArea(a, c) {
+      var ox = Math.max(0, Math.min(a.x1, c.x1) - Math.max(a.x0, c.x0));
+      var oy = Math.max(0, Math.min(a.y1, c.y1) - Math.max(a.y0, c.y0));
+      return ox * oy;
+    }
+
+    // §CORRIDOR-OVERLAP-FRACTION (2026-07-14, user-reported false-positive rate — 31/32 "Hall /
+    // Corridor" matches on HHS were not real corridors). Centroid-inside-bucketRect ALONE is too
+    // permissive: a generously-sized bucket rect (even after §CORRIDOR-WIDTH-BOUNDS above) can still
+    // swallow a room many times its own size whose centroid merely happens to fall inside it. Require
+    // the room's OWN measured footprint to substantially OVERLAP the bucket rect too — same
+    // overlap-area discipline room_graph.js's §CORRIDOR-ROOM-BACKPROP already uses for the inverse
+    // check (there: skip injecting a synthetic corridor room where a real room already sits). Here:
+    // a room only counts as "on the corridor" if at least half its own area sits inside the bucket —
+    // a real hallway segment (itself compiled as one or more IfcSpace rows) satisfies this trivially
+    // (its own footprint effectively IS the corridor strip); an adjacent office/room whose centroid
+    // drifted into an oversized rect does not.
+    var MIN_OVERLAP_FRACTION = 0.5;
     var result = {};
     Object.keys(rects).forEach(function (lg) {
       var r = rects[lg];
       var cx = r.sumX / r.n, cy = r.sumY / r.n;
       var candidates = bucketsByStorey[r.storey];
       if (!candidates) return;
+      var totalArea = r.ownRects.reduce(function (s, rr) { return s + rr.area; }, 0);
       for (var i = 0; i < candidates.length; i++) {
         var rc = candidates[i].rect;
-        if (cx >= rc.x0 && cx <= rc.x1 && cy >= rc.y0 && cy <= rc.y1) {
-          result[lg] = { chain: candidates[i].chain };
-          break;
-        }
+        var inside = cx >= rc.x0 && cx <= rc.x1 && cy >= rc.y0 && cy <= rc.y1;
+        if (!inside) continue;
+        var overlapArea = r.ownRects.reduce(function (s, rr) { return s + rectOverlapArea(rr, rc); }, 0);
+        if (totalArea > 0 && (overlapArea / totalArea) < MIN_OVERLAP_FRACTION) continue; // centroid drifted in, but the room's own body mostly sits outside — not really on this corridor
+        result[lg] = { chain: candidates[i].chain };
+        break;
       }
     });
     log('§CORRIDOR_TYPE_LABEL classifiedRooms=' + Object.keys(result).length + ' / ' + Object.keys(rects).length);

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -14,10 +14,27 @@
  *   5. terminateAtStair()    — an open (uncapped) end near a stair is a connecting space, not a
  *                              dead-end. Reuses room_graph.js's getStairGroups() — WalkerDoctrine
  *                              §10, the ONE trusted stair extractor, not a fresh ad-hoc query.
+ *   5b. commonSenseFilter()  — §COMMON-SENSE-FILTER (2026-07-14, user's own framing): a real
+ *                              walkway (1) is not a room, (2) is not too wide, (3) does not float
+ *                              in mid air, (4) is always connected to doors/stairs/walls. (1)+(2)
+ *                              are enforced inside growToWall/bucketWidth/classifyCorridorRooms;
+ *                              this step composes (3)+(4) — isGrounded() + distanceToEnclosure()
+ *                              — into one gate, run after stair-termination and before chains are
+ *                              built, so only real, grounded, enclosed buckets ever join a chain.
  *   6. walkBackbone()        — union-find merge of buckets whose grown spans cross (T-junction),
  *                              then an ordered walk of each resulting chain (serves BOTH path
  *                              routing/escape-route AND a flythrough camera path from the same
  *                              structure — user's explicit ask, one structure two consumers).
+ *
+ * §PLAUSIBILITY-PROFILE: every tunable number governing "is this a real corridor" (door count,
+ * width bounds, end-cap reach, stair clearance, overlap fraction, ...) lives in ONE object,
+ * DEFAULT_PROFILE, instead of scattered magic constants. Every step function takes an OPTIONAL
+ * trailing `profile` argument (buildBackbone/classifyCorridorRooms take it via `opts.profile`)
+ * defaulting to DEFAULT_PROFILE — omitting it (every call site today) reproduces today's exact
+ * numbers. This is a pure reorganization for inspectability, plus a ready extension point: this
+ * project's WalkerDoctrine already parameterizes walk behavior by BUILDING-CLASS, so a future
+ * per-class corridor profile (e.g. a wider default for an institutional/hospital class) is a
+ * drop-in caller-side change, not a structural one — see DEFAULT_PROFILE's own comment.
  *
  * WHY: room_graph.js's shortestPath() currently rescues a room's lone door onto ONE
  * per-storey `CIRC::<storey>` blob (see room_graph.js buildGraph() E2) and its _legalizePath()
@@ -43,17 +60,42 @@
   var ROOT = (typeof window !== 'undefined') ? window : {};
   var RoomGraph = (typeof module !== 'undefined' && module.exports) ? require('./room_graph.js') : ROOT.RoomGraph;
 
-  // §RUN_COORD_TOL: bucket-rounding width for "these doors share the same wall run." Grounded in
-  // real wall-thickness scale (typical interior wall 0.15-0.3m; this is generous slack for
-  // wall-centerline-vs-face offset across a building's doors, not fitted to one building's data).
-  var RUN_COORD_TOL = 0.6;
-  var MIN_DOORS_FOR_HALLWAY = 3;
-  // §STAIR_CLEARANCE: movement-clearance tolerance, per user's own steer ("stairs movement space
-  // can be of say 2 meter height flow onto the stairs contour").
-  var STAIR_CLEARANCE = 2.0;
-  // Slack added to a wall's own half-thickness when testing whether it actually crosses a
-  // corridor's runCoord line (real walls are rasterized transforms, not infinitely thin planes).
-  var WALL_CROSS_SLACK = 0.3;
+  // §PLAUSIBILITY-PROFILE (2026-07-14, consolidated from what were 6 separate scattered `var`
+  // constants across this file). EVERY tunable number that decides "is this a real corridor" now
+  // lives in ONE place instead of being spread across doorEdge/growToWall/bucketWidth/etc — a
+  // single, inspectable, swappable framework rather than ad hoc magic numbers per function. Every
+  // step function below takes an OPTIONAL trailing `profile` argument defaulting to this object —
+  // omitting it (the current behavior of every existing call site, in this file and in
+  // room_graph.js/navigate_find.js) reproduces EXACTLY today's numbers, so this is a pure
+  // reorganization, not a behavior change. The extension point is deliberate but NOT yet used for
+  // anything beyond today's one profile: this project's own WalkerDoctrine already parameterizes
+  // walk behavior by BUILDING-CLASS (residential vs Terminal-reference), so a future per-class
+  // corridor profile (e.g. a wider default for a hospital/institutional class) is a natural fit
+  // here WITHOUT any structural change — just a second profile object and a caller passing it in.
+  var DEFAULT_PROFILE = {
+    // bucket-rounding width for "these doors share the same wall run." Grounded in real
+    // wall-thickness scale (typical interior wall 0.15-0.3m; generous slack for
+    // wall-centerline-vs-face offset across a building's doors, not fitted to one building).
+    runCoordTol: 0.6,
+    minDoorsForHallway: 3,
+    // movement-clearance tolerance, per user's own steer ("stairs movement space can be of say
+    // 2 meter height flow onto the stairs contour").
+    stairClearance: 2.0,
+    // slack added to a wall's own half-thickness when testing whether it actually crosses a
+    // corridor's runCoord line (real walls are rasterized transforms, not infinitely thin planes).
+    wallCrossSlack: 0.3,
+    // §CORRIDOR-WIDTH-BOUNDS / §END-CAP-REACH-BOUND (2026-07-14) — see wallLiesFlatAgainst below
+    // for what these bound and why (host-wall self-match vs coincidental cross-building match).
+    minSideOffset: 0.5,
+    maxSideOffset: 3.0,
+    defaultHalfWidth: 1.2, // only used when no flanking wall is found on a side (rare: open-plan edge)
+    maxEndReach: 8.0,
+    // §COMMON-SENSE-FILTER — generous for one wall's thickness + measurement slack.
+    enclosureTolerance: 0.5,
+    // §CORRIDOR-OVERLAP-FRACTION — a room must have this fraction of its own area inside the
+    // matched bucket to count as "on the corridor", not just its centroid.
+    minOverlapFraction: 0.5
+  };
 
   // §COMMON-SENSE-FILTER (2026-07-14, user's own framing): a real walkway/corridor (1) is not
   // itself a room, (2) is not implausibly wide, (3) does not float in mid air, (4) is always
@@ -61,9 +103,10 @@
   // shape of problem established indoor-routing/space-boundary tools solve (IFC 2nd-level space
   // boundary generation, Revit Room/Space boundary resolution, space-syntax axial-map tools): a
   // bounded ray-cast to the NEAREST plausible bounding surface, never an unbounded "nearest match
-  // regardless of distance" search. Two small named verbs formalize that shared shape so both
+  // regardless of distance" search. Small named primitives formalize that shared shape so both
   // growToWall() (END caps, perpendicular walls) and bucketWidth() (SIDE walls, same-axis walls)
-  // apply the SAME plausibility discipline instead of each re-inventing its own ad hoc bound.
+  // apply the SAME plausibility discipline instead of each re-inventing its own ad hoc bound; see
+  // commonSenseFilter() further down for how they compose into the (3)+(4) gate.
   //   - wallLiesFlatAgainst(offset, minOffset, maxOffset): is this candidate wall's measured
   //     offset from the reference coordinate within a physically sane window? Too close (~0) is
   //     usually a self-match (the bucket's own host wall, or a door reveal/jamb stub) rather than
@@ -71,23 +114,25 @@
   //     of the building. minOffset=0 disables the "too close" half of the test (growToWall's end
   //     caps run PERPENDICULAR to the bucket's own doors, so there's no self-match risk there —
   //     only bucketWidth's SIDE-wall search, which scans SAME-axis walls, needs the floor too).
+  //     Deliberately profile-free (plain numeric bounds in, in/out of window out) — it's the one
+  //     generic low-level primitive every higher-level step feeds ITS OWN profile values into.
   function wallLiesFlatAgainst(offset, minOffset, maxOffset) {
     if (offset < minOffset || offset > maxOffset) return null;
     return offset;
   }
-  //   - distanceToEnclosure(x, y, envelope): 0 if the point sits within the building's own real
-  //     wall-derived footprint (+ a small tolerance for wall thickness), else how far outside it
-  //     sits. Backstops wallLiesFlatAgainst's per-wall bound with a whole-building sanity check —
-  //     the concrete symptom this guards ("half corridor... drawn perpendicular into mid air
-  //     outside building", user report 2026-07-14) is a corridor rect extending past where any
-  //     real wall exists at all, not just past ONE plausible flanking wall.
-  var ENCLOSURE_TOLERANCE = 0.5; // m — generous for one wall's thickness + measurement slack
-  function distanceToEnclosure(x, y, envelope) {
+  //   - distanceToEnclosure(x, y, envelope, profile): 0 if the point sits within the building's
+  //     own real wall-derived footprint (+ a small tolerance for wall thickness), else how far
+  //     outside it sits. Backstops wallLiesFlatAgainst's per-wall bound with a whole-building
+  //     sanity check — the concrete symptom this guards ("half corridor... drawn perpendicular
+  //     into mid air outside building", user report 2026-07-14) is a corridor rect extending past
+  //     where any real wall exists at all, not just past ONE plausible flanking wall.
+  function distanceToEnclosure(x, y, envelope, profile) {
+    profile = profile || DEFAULT_PROFILE;
     if (!envelope) return 0; // no envelope data — nothing to check against, don't false-flag
     var dx = Math.max(envelope.x0 - x, 0, x - envelope.x1);
     var dy = Math.max(envelope.y0 - y, 0, y - envelope.y1);
     var d = Math.hypot(dx, dy);
-    return (d <= ENCLOSURE_TOLERANCE) ? 0 : d;
+    return (d <= profile.enclosureTolerance) ? 0 : d;
   }
   //   - buildingEnvelope(walls): the real wall-derived footprint for one storey's worth of walls
   //     (reuses the SAME wall rows buildBackbone() already fetched — no new query). A plain bbox
@@ -106,7 +151,8 @@
   //     within walls" (user's own phrasing) — reject a bucket that is open on BOTH ends with NO
   //     stair anchor on EITHER end. That shape has nothing tying it to the building at all beyond
   //     its own door cluster: not a real hallway/circulation space, just a coincidental door
-  //     alignment (>=3 doors is a necessary but not sufficient signal on its own).
+  //     alignment (>=3 doors is a necessary but not sufficient signal on its own). No profile
+  //     needed — purely structural (openLo/openHi/stairLo/stairHi), no tunable number involved.
   function isGrounded(bucket) {
     var loOk = !bucket.openLo || !!bucket.stairLo;
     var hiOk = !bucket.openHi || !!bucket.stairHi;
@@ -126,10 +172,11 @@
   }
 
   // ── 2. correlateDoorEdges ────────────────────────────────────────────────────────────────────
-  function correlateDoorEdges(edges) {
+  function correlateDoorEdges(edges, profile) {
+    profile = profile || DEFAULT_PROFILE;
     var buckets = {}, order = [];
     edges.forEach(function (e) {
-      var rounded = Math.round(e.runCoord / RUN_COORD_TOL) * RUN_COORD_TOL;
+      var rounded = Math.round(e.runCoord / profile.runCoordTol) * profile.runCoordTol;
       var key = e.storey + '|' + e.axis + '|' + rounded.toFixed(2);
       if (!buckets[key]) {
         buckets[key] = { key: key, storey: e.storey, axis: e.axis, runCoord: rounded, doors: [] };
@@ -141,8 +188,9 @@
   }
 
   // ── 3. joinDoorways ──────────────────────────────────────────────────────────────────────────
-  function joinDoorways(buckets) {
-    return buckets.filter(function (b) { return b.doors.length >= MIN_DOORS_FOR_HALLWAY; });
+  function joinDoorways(buckets, profile) {
+    profile = profile || DEFAULT_PROFILE;
+    return buckets.filter(function (b) { return b.doors.length >= profile.minDoorsForHallway; });
   }
 
   // ── 4. growToWall ────────────────────────────────────────────────────────────────────────────
@@ -159,8 +207,8 @@
   // its along-axis (end) counterpart, using the SAME wallLiesFlatAgainst() bound (no MIN needed
   // here: this wall runs perpendicular to the bucket, so it can never be the bucket's own host
   // wall — no self-match risk the way bucketWidth's side-wall scan has).
-  var MAX_END_REACH = 8.0;
-  function growToWall(bucket, walls) {
+  function growToWall(bucket, walls, profile) {
+    profile = profile || DEFAULT_PROFILE;
     var alongs = bucket.doors.map(function (d) { return d.alongCoord; });
     var lo = Math.min.apply(null, alongs), hi = Math.max.apply(null, alongs);
     var rc = bucket.runCoord;
@@ -172,9 +220,9 @@
       var alongC = (bucket.axis === 'x') ? w.cx : w.cy;
       var perpLo = (bucket.axis === 'x') ? (w.cy - w.by / 2) : (w.cx - w.bx / 2);
       var perpHi = (bucket.axis === 'x') ? (w.cy + w.by / 2) : (w.cx + w.bx / 2);
-      if (rc < perpLo - WALL_CROSS_SLACK || rc > perpHi + WALL_CROSS_SLACK) return; // doesn't cross this line
-      if (alongC <= lo && (loCap === null || alongC > loCap) && wallLiesFlatAgainst(lo - alongC, 0, MAX_END_REACH) !== null) loCap = alongC;
-      if (alongC >= hi && (hiCap === null || alongC < hiCap) && wallLiesFlatAgainst(alongC - hi, 0, MAX_END_REACH) !== null) hiCap = alongC;
+      if (rc < perpLo - profile.wallCrossSlack || rc > perpHi + profile.wallCrossSlack) return; // doesn't cross this line
+      if (alongC <= lo && (loCap === null || alongC > loCap) && wallLiesFlatAgainst(lo - alongC, 0, profile.maxEndReach) !== null) loCap = alongC;
+      if (alongC >= hi && (hiCap === null || alongC < hiCap) && wallLiesFlatAgainst(alongC - hi, 0, profile.maxEndReach) !== null) hiCap = alongC;
     });
     bucket.span = { lo: (loCap !== null) ? loCap : lo, hi: (hiCap !== null) ? hiCap : hi };
     bucket.openLo = (loCap === null);
@@ -190,7 +238,6 @@
   // open corridor floor (no room modeled there) reads as illegal. Feeding this measured width back
   // into that legality test (see room_graph.js wiring) lets a real, wall-bounded corridor register
   // as walkable even without a raster, instead of every corridor chord failing detour.
-  var DEFAULT_HALF_WIDTH = 1.2; // m — only used when no flanking wall is found on that side (rare: an open-plan edge)
   // §CORRIDOR-WIDTH-BOUNDS (2026-07-14, user-reported: false-positive rate + a mis-ID'd corridor
   // shell on Clinic Second Floor, "taking the narrow wall next to it"). bucketWidth()'s wall scan
   // had NO plausibility bounds on the flanking-wall distance — two failure modes confirmed on real
@@ -205,15 +252,14 @@
   //    live on HHS: halfWidthLo up to ~7.8m on one side, ballooning bucketRect() into an 8m-wide
   //    strip that then swallowed large unrelated rooms (e.g. a 242m² room, 57% area overlap) as
   //    false-positive "Hall / Corridor" matches.
-  // Both bounded the same way: a candidate wall must sit between MIN and MAX_SIDE_OFFSET from rc to
-  // count as a real flanking wall; outside that window it's "no wall found on this side" (same
-  // fallback as before — DEFAULT_HALF_WIDTH). MIN is bigger than 2x a real wall's thickness
-  // (0.15-0.3m, see RUN_COORD_TOL comment above) so a host-wall self-match never qualifies; MAX is
-  // generous even for a wide hospital double-loaded corridor (~3.6m total width) without accepting
-  // an implausible cross-building match.
-  var MIN_SIDE_OFFSET = 0.5;
-  var MAX_SIDE_OFFSET = 3.0;
-  function bucketWidth(bucket, walls) {
+  // Both bounded the same way: a candidate wall must sit between profile.minSideOffset and
+  // .maxSideOffset from rc to count as a real flanking wall; outside that window it's "no wall
+  // found on this side" (same fallback as before — profile.defaultHalfWidth). minSideOffset is
+  // bigger than 2x a real wall's thickness (0.15-0.3m, see runCoordTol comment above) so a
+  // host-wall self-match never qualifies; maxSideOffset is generous even for a wide hospital
+  // double-loaded corridor (~3.6m total width) without accepting an implausible cross-building match.
+  function bucketWidth(bucket, walls, profile) {
+    profile = profile || DEFAULT_PROFILE;
     var rc = bucket.runCoord, lo = bucket.span.lo, hi = bucket.span.hi;
     var nearAbove = null, nearBelow = null;
     walls.forEach(function (w) {
@@ -225,11 +271,11 @@
       if (alongC + alongHalf < lo || alongC - alongHalf > hi) return; // must run alongside this corridor
       var perpC = (bucket.axis === 'x') ? w.cy : w.cx;
       var perpHalf = (bucket.axis === 'x') ? (w.by / 2) : (w.bx / 2);
-      if (perpC >= rc) { var d = wallLiesFlatAgainst((perpC - perpHalf) - rc, MIN_SIDE_OFFSET, MAX_SIDE_OFFSET); if (d !== null && (nearAbove === null || d < nearAbove)) nearAbove = d; }
-      else { var d2 = wallLiesFlatAgainst(rc - (perpC + perpHalf), MIN_SIDE_OFFSET, MAX_SIDE_OFFSET); if (d2 !== null && (nearBelow === null || d2 < nearBelow)) nearBelow = d2; }
+      if (perpC >= rc) { var d = wallLiesFlatAgainst((perpC - perpHalf) - rc, profile.minSideOffset, profile.maxSideOffset); if (d !== null && (nearAbove === null || d < nearAbove)) nearAbove = d; }
+      else { var d2 = wallLiesFlatAgainst(rc - (perpC + perpHalf), profile.minSideOffset, profile.maxSideOffset); if (d2 !== null && (nearBelow === null || d2 < nearBelow)) nearBelow = d2; }
     });
-    bucket.halfWidthHi = (nearAbove !== null) ? nearAbove : DEFAULT_HALF_WIDTH;
-    bucket.halfWidthLo = (nearBelow !== null) ? nearBelow : DEFAULT_HALF_WIDTH;
+    bucket.halfWidthHi = (nearAbove !== null) ? nearAbove : profile.defaultHalfWidth;
+    bucket.halfWidthLo = (nearBelow !== null) ? nearBelow : profile.defaultHalfWidth;
     return bucket;
   }
 
@@ -244,7 +290,8 @@
   // ── 5. terminateAtStair ──────────────────────────────────────────────────────────────────────
   // stairGroups: the `groups` map from RoomGraph.getStairGroups(dbQuery, log) — the ONE trusted
   // stair extractor (WalkerDoctrine §10), reused here rather than a fresh ad-hoc IfcStair% query.
-  function terminateAtStair(bucket, stairGroups, storeyOf) {
+  function terminateAtStair(bucket, stairGroups, profile) {
+    profile = profile || DEFAULT_PROFILE;
     var rc = bucket.runCoord;
     function endPoint(along) {
       return (bucket.axis === 'x') ? { x: along, y: rc } : { x: rc, y: along };
@@ -261,12 +308,12 @@
     }
     if (bucket.openLo) {
       var r = nearestStair(endPoint(bucket.span.lo));
-      bucket.stairLo = (r.dist <= STAIR_CLEARANCE) ? r.key : null;
+      bucket.stairLo = (r.dist <= profile.stairClearance) ? r.key : null;
       bucket.stairLoDist = r.dist;
     }
     if (bucket.openHi) {
       var r2 = nearestStair(endPoint(bucket.span.hi));
-      bucket.stairHi = (r2.dist <= STAIR_CLEARANCE) ? r2.key : null;
+      bucket.stairHi = (r2.dist <= profile.stairClearance) ? r2.key : null;
       bucket.stairHiDist = r2.dist;
     }
     return bucket;
@@ -287,7 +334,8 @@
   // Second-Floor bucket. Confirmed live: a phantom `spine(First Floor)->spine(Second Floor)`
   // edge with no real stair between them. Object references have no such ambiguity — safe to
   // compare by `===` since these are the SAME objects returned in `joined`/`chains`.
-  function walkBackbone(buckets) {
+  function walkBackbone(buckets, profile) {
+    profile = profile || DEFAULT_PROFILE;
     var n = buckets.length;
     var parent = buckets.map(function (_, i) { return i; });
     function find(i) { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; } return i; }
@@ -302,8 +350,8 @@
         var yB = (A.axis === 'x') ? A.runCoord : B.runCoord;
         var aAlong = (A.axis === 'x') ? xB : yB;
         var bAlong = (B.axis === 'x') ? xB : yB;
-        var aIn = aAlong >= A.span.lo - WALL_CROSS_SLACK && aAlong <= A.span.hi + WALL_CROSS_SLACK;
-        var bIn = bAlong >= B.span.lo - WALL_CROSS_SLACK && bAlong <= B.span.hi + WALL_CROSS_SLACK;
+        var aIn = aAlong >= A.span.lo - profile.wallCrossSlack && aAlong <= A.span.hi + profile.wallCrossSlack;
+        var bIn = bAlong >= B.span.lo - profile.wallCrossSlack && bAlong <= B.span.hi + profile.wallCrossSlack;
         if (aIn && bIn) {
           union(i, j);
           crossings.push({ a: A, b: B, x: xB, y: yB });
@@ -347,6 +395,7 @@
   function buildBackbone(dbQuery, opts) {
     opts = opts || {};
     var log = opts.log || function () {};
+    var profile = opts.profile || DEFAULT_PROFILE;
 
     var doorRows = dbQuery("SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, " +
       "COALESCE(t.bbox_x,0) bx, COALESCE(t.bbox_y,0) by2 " +
@@ -365,42 +414,32 @@
       (wallsByStorey[st] = wallsByStorey[st] || []).push({ cx: w[1], cy: w[2], bx: w[3], by: w[4] });
     });
 
-    var buckets = correlateDoorEdges(edges);
-    var joined = joinDoorways(buckets);
-    joined.forEach(function (b) { growToWall(b, wallsByStorey[b.storey] || []); });
-    joined.forEach(function (b) { bucketWidth(b, wallsByStorey[b.storey] || []); });
+    var buckets = correlateDoorEdges(edges, profile);
+    var joined = joinDoorways(buckets, profile);
+    joined.forEach(function (b) { growToWall(b, wallsByStorey[b.storey] || [], profile); });
+    joined.forEach(function (b) { bucketWidth(b, wallsByStorey[b.storey] || [], profile); });
 
     var stairGroupsResult = RoomGraph ? RoomGraph.getStairGroups(dbQuery, log) : { groups: {} };
-    joined.forEach(function (b) { terminateAtStair(b, stairGroupsResult.groups); });
+    joined.forEach(function (b) { terminateAtStair(b, stairGroupsResult.groups, profile); });
 
-    // §COMMON-SENSE-FILTER (2026-07-14) — two final sanity gates before a bucket is trusted as a
-    // real walkway, applied AFTER width/span/stair-termination are all known:
-    //  - isGrounded(): reject a bucket open on BOTH ends with no stair anchor on either — nothing
-    //    ties it to the building beyond a coincidental door alignment.
-    //  - distanceToEnclosure(): reject a bucket whose own measured rect corner sits outside that
-    //    STOREY's real wall-derived footprint — the concrete "floating in mid air outside the
-    //    building" symptom, as a whole-building backstop beyond the per-wall bounds above.
+    // §COMMON-SENSE-FILTER (2026-07-14) — final gate before a bucket is trusted as a real walkway,
+    // applied AFTER width/span/stair-termination are all known. See commonSenseFilter() (step 5b)
+    // for the composed (3)+(4) rule; never a silent drop — logged below when it fires.
     var envelopeByStorey = {};
     Object.keys(wallsByStorey).forEach(function (st) { envelopeByStorey[st] = buildingEnvelope(wallsByStorey[st]); });
-    var droppedUngrounded = 0, droppedOutsideEnvelope = 0;
-    joined = joined.filter(function (b) {
-      if (!isGrounded(b)) { droppedUngrounded++; return false; }
-      var env = envelopeByStorey[b.storey];
-      var rc = bucketRect(b);
-      var corners = [[rc.x0, rc.y0], [rc.x0, rc.y1], [rc.x1, rc.y0], [rc.x1, rc.y1]];
-      var outside = corners.some(function (c) { return distanceToEnclosure(c[0], c[1], env) > 0; });
-      if (outside) { droppedOutsideEnvelope++; return false; }
-      return true;
-    });
-    if (droppedUngrounded || droppedOutsideEnvelope) {
-      log('§COMMON_SENSE_FILTER droppedUngrounded=' + droppedUngrounded + ' droppedOutsideEnvelope=' + droppedOutsideEnvelope);
+    var filterResult = commonSenseFilter(joined, envelopeByStorey, profile);
+    joined = filterResult.kept;
+    if (filterResult.dropped.length) {
+      var reasonCounts = {};
+      filterResult.dropped.forEach(function (d) { reasonCounts[d.reason] = (reasonCounts[d.reason] || 0) + 1; });
+      log('§COMMON_SENSE_FILTER dropped=' + filterResult.dropped.length + ' reasons=' + JSON.stringify(reasonCounts));
     }
 
     var byStorey = {};
     joined.forEach(function (b) { (byStorey[b.storey] = byStorey[b.storey] || []).push(b); });
     var allChains = [], allCrossings = [];
     Object.keys(byStorey).forEach(function (st) {
-      var r = walkBackbone(byStorey[st]);
+      var r = walkBackbone(byStorey[st], profile);
       r.chains.forEach(function (ch) {
         var chainIndex = allChains.length + r.chains.indexOf(ch);
         ch.buckets.forEach(function (b) { b._chainIndex = chainIndex; });
@@ -429,12 +468,38 @@
   // A bucket's real walkable footprint as an AABB rect — span along its axis, measured
   // (or default) half-width perpendicular. Used by room_graph.js's _pointWalkable() fallback so a
   // real corridor registers as walkable even on a storey with no raster.
-  function bucketRect(b) {
-    var perpLo = b.runCoord - (b.halfWidthLo != null ? b.halfWidthLo : DEFAULT_HALF_WIDTH);
-    var perpHi = b.runCoord + (b.halfWidthHi != null ? b.halfWidthHi : DEFAULT_HALF_WIDTH);
+  function bucketRect(b, profile) {
+    profile = profile || DEFAULT_PROFILE;
+    var perpLo = b.runCoord - (b.halfWidthLo != null ? b.halfWidthLo : profile.defaultHalfWidth);
+    var perpHi = b.runCoord + (b.halfWidthHi != null ? b.halfWidthHi : profile.defaultHalfWidth);
     return (b.axis === 'x')
       ? { x0: b.span.lo, x1: b.span.hi, y0: perpLo, y1: perpHi }
       : { x0: perpLo, x1: perpHi, y0: b.span.lo, y1: b.span.hi };
+  }
+
+  // ── 5b. commonSenseFilter ────────────────────────────────────────────────────────────────────
+  // Composes isGrounded() + distanceToEnclosure() into the single (3)+(4) gate from
+  // §COMMON-SENSE-FILTER above — "not in mid air" + "always connected to doors/stairs/walls".
+  // Runs AFTER growToWall/bucketWidth/terminateAtStair (span, width, and stair-anchoring must
+  // already be known) and BEFORE walkBackbone (only grounded, enclosed buckets should ever join a
+  // chain). buckets: array of joined buckets (post width/span/stair). envelopeByStorey: storey ->
+  // buildingEnvelope() result for that storey. Returns { kept, dropped } — kept is the filtered
+  // array (feed straight into walkBackbone/classifyCorridorRooms); dropped is
+  // [{bucket, reason}] with reason one of 'ungrounded' | 'outside-envelope', for diagnostics —
+  // buildBackbone() logs a summary rather than dropping silently.
+  function commonSenseFilter(buckets, envelopeByStorey, profile) {
+    profile = profile || DEFAULT_PROFILE;
+    var kept = [], dropped = [];
+    buckets.forEach(function (b) {
+      if (!isGrounded(b)) { dropped.push({ bucket: b, reason: 'ungrounded' }); return; }
+      var env = envelopeByStorey ? envelopeByStorey[b.storey] : null;
+      var rc = bucketRect(b, profile);
+      var corners = [[rc.x0, rc.y0], [rc.x0, rc.y1], [rc.x1, rc.y0], [rc.x1, rc.y1]];
+      var outside = corners.some(function (c) { return distanceToEnclosure(c[0], c[1], env, profile) > 0; });
+      if (outside) { dropped.push({ bucket: b, reason: 'outside-envelope' }); return; }
+      kept.push(b);
+    });
+    return { kept: kept, dropped: dropped };
   }
 
   // §CORRIDOR-TYPE-LABEL (2026-07-14, user ask: "long corridors well named under Type.Hall/
@@ -451,6 +516,7 @@
   function classifyCorridorRooms(dbQuery, opts) {
     opts = opts || {};
     var log = opts.log || function () {};
+    var profile = opts.profile || DEFAULT_PROFILE;
     var backbone = buildBackbone(dbQuery, opts);
     if (!backbone.joined.length) return {};
 
@@ -484,7 +550,7 @@
 
     var bucketsByStorey = {};
     backbone.joined.forEach(function (b, bi) {
-      (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push({ rect: bucketRect(b), chain: b._chainIndex != null ? b._chainIndex : null });
+      (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push({ rect: bucketRect(b, profile), chain: b._chainIndex != null ? b._chainIndex : null });
     });
 
     function rectOverlapArea(a, c) {
@@ -504,7 +570,6 @@
     // a real hallway segment (itself compiled as one or more IfcSpace rows) satisfies this trivially
     // (its own footprint effectively IS the corridor strip); an adjacent office/room whose centroid
     // drifted into an oversized rect does not.
-    var MIN_OVERLAP_FRACTION = 0.5;
     var result = {};
     Object.keys(rects).forEach(function (lg) {
       var r = rects[lg];
@@ -517,7 +582,7 @@
         var inside = cx >= rc.x0 && cx <= rc.x1 && cy >= rc.y0 && cy <= rc.y1;
         if (!inside) continue;
         var overlapArea = r.ownRects.reduce(function (s, rr) { return s + rectOverlapArea(rr, rc); }, 0);
-        if (totalArea > 0 && (overlapArea / totalArea) < MIN_OVERLAP_FRACTION) continue; // centroid drifted in, but the room's own body mostly sits outside — not really on this corridor
+        if (totalArea > 0 && (overlapArea / totalArea) < profile.minOverlapFraction) continue; // centroid drifted in, but the room's own body mostly sits outside — not really on this corridor
         result[lg] = { chain: candidates[i].chain };
         break;
       }
@@ -531,9 +596,17 @@
     growToWall: growToWall, bucketWidth: bucketWidth, bucketRect: bucketRect,
     terminateAtStair: terminateAtStair, walkBackbone: walkBackbone,
     buildBackbone: buildBackbone, classifyCorridorRooms: classifyCorridorRooms,
-    // §COMMON-SENSE-FILTER verbs — exported individually so a sandbox can test each in isolation
+    // §COMMON-SENSE-FILTER — commonSenseFilter is the composed (3)+(4) gate buildBackbone() uses;
+    // the 4 primitives it's built from are exported too so a sandbox can test each in isolation.
+    commonSenseFilter: commonSenseFilter,
     wallLiesFlatAgainst: wallLiesFlatAgainst, distanceToEnclosure: distanceToEnclosure,
-    buildingEnvelope: buildingEnvelope, isGrounded: isGrounded
+    buildingEnvelope: buildingEnvelope, isGrounded: isGrounded,
+    // DEFAULT_PROFILE — the single consolidated source of every tunable plausibility number (see
+    // §PLAUSIBILITY-PROFILE above). Exported read-only-by-convention so a caller can build a
+    // variant profile via `Object.assign({}, HallwayBackbone.DEFAULT_PROFILE, {maxSideOffset: 4})`
+    // and pass it as `opts.profile` to buildBackbone()/classifyCorridorRooms() — the extension
+    // point for a future building-class-specific profile, not used by any caller today.
+    DEFAULT_PROFILE: DEFAULT_PROFILE
   };
   ROOT.HallwayBackbone = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -681,6 +681,55 @@
     return comp;
   }
 
+  // §FULL-CONNECTIVITY (2026-07-14, user ask: "is there a simple test where every door can go to
+  // any other door via a covered path... is there no gap?"). components() above deliberately stays
+  // ROOM-ONLY (E1 edges only, a pre-existing honesty metric the spec doesn't ask to extend — see
+  // its own comment). This is the NEW, COMPLETE version: same union-find shape, but walks the
+  // FULL adjacency shortestPath()'s Dijkstra already uses (graph.nodesByGuid — the documented
+  // superset of rooms + circ/spine + stair + exit + waypoint nodes — and ALL edge kinds E1-E8, not
+  // just E1). A door only ever appears in this graph AS an edge (E1/E2/E7 carry doorGuid/doorName),
+  // never as its own node — so "every door reaches every other door with no gap" is exactly the
+  // question "is this full graph ONE connected component" (fullyConnected === true, components===1
+  // for a non-empty graph). Where it's NOT, `sizes`/`comp` let a caller name the actual isolated
+  // island(s) by node guid — see witness_full_connectivity.js for the concrete report pattern.
+  function fullConnectivity(graph) {
+    // §NOT-EVERY-NODE-IS-A-VERTEX (2026-07-14, real bug found building this): `graph.nodesByGuid`
+    // is a superset that also holds 'doorwp'/'stairwp' entries which are PURE POSITION LOOKUPS for
+    // two entirely separate on-demand systems (_detourForChord's per-chord visibility graph;
+    // shortestPath's path-rendering waypoint substitution) — most of them are NEVER an edge
+    // endpoint in `graph.edges` at all. Seeding the node universe from nodesByGuid wholesale
+    // produced ~200 phantom size-1 "islands" on Clinic that were never real gaps, just unused
+    // lookup entries. The correct universe: every 'room'/'circ'/'exit' node (the real destinations
+    // that must be reachable — a genuinely doorless room SHOULD show as a real isolated island)
+    // UNION every guid that actually appears as an edge endpoint (covers bridging nodes that ARE
+    // real graph vertices, e.g. spine/orphan-doorwp-via-E7, without also pulling in the untouched
+    // majority of doorwp/stairwp entries that never appear in `graph.edges` at all).
+    var adj = {};
+    function ensure(g) { if (!adj[g]) adj[g] = []; }
+    Object.keys(graph.nodesByGuid || {}).forEach(function (g) {
+      var n = graph.nodesByGuid[g];
+      if (n && (n.kind === 'room' || n.kind === 'circ' || n.kind === 'exit')) ensure(g);
+    });
+    (graph.edges || []).forEach(function (e) {
+      ensure(e.a); ensure(e.b);
+      adj[e.a].push(e.b); adj[e.b].push(e.a);
+    });
+    var comp = {}, cid = 0, sizes = [];
+    Object.keys(adj).forEach(function (g) {
+      if (comp[g] != null) return;
+      var stack = [g], size = 0; comp[g] = cid;
+      while (stack.length) {
+        var u = stack.pop(); size++;
+        adj[u].forEach(function (v) { if (comp[v] == null) { comp[v] = cid; stack.push(v); } });
+      }
+      sizes.push(size); cid++;
+    });
+    var totalNodes = Object.keys(adj).length;
+    var largestComponent = sizes.length ? Math.max.apply(null, sizes) : 0;
+    return { comp: comp, components: cid, sizes: sizes, totalNodes: totalNodes,
+      largestComponent: largestComponent, fullyConnected: totalNodes > 0 && cid === 1 };
+  }
+
   // §OCCUPANT-DIJKSTRA: walks the FULL graph — rooms + circ + exit nodes, E1-E4 edges — weighted by
   // real 3D distance (E1: room-center to room-center, unchanged formula so Duplex's existing
   // door-connected paths are byte-identical, see OCCUPANT_PATHFINDER.md W-PATH-DUPLEX-REGRESSION;
@@ -984,9 +1033,9 @@
   }
 
   var API = {
-    buildGraph: buildGraph, degree: degree, components: components, shortestPath: shortestPath,
-    escapeRoute: escapeRoute, isRoomDoor: isRoomDoor, stairBaseKey: stairBaseKey, DOOR_BUFFER_SLACK: DOOR_BUFFER_SLACK,
-    getStairGroups: getStairGroups
+    buildGraph: buildGraph, degree: degree, components: components, fullConnectivity: fullConnectivity,
+    shortestPath: shortestPath, escapeRoute: escapeRoute, isRoomDoor: isRoomDoor,
+    stairBaseKey: stairBaseKey, DOOR_BUFFER_SLACK: DOOR_BUFFER_SLACK, getStairGroups: getStairGroups
   };
   ROOT.RoomGraph = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/sandbox_corridor_width.js
+++ b/sandbox_corridor_width.js
@@ -144,5 +144,35 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { f
     bucket.openHi === false && bucket.span.hi === 17, 'openHi=' + bucket.openHi + ' span.hi=' + bucket.span.hi);
 }
 
+// ── Test G: commonSenseFilter — the composed (3)+(4) gate, tested as ONE unit ──
+{
+  const grounded = { storey: 'L1', openLo: false, openHi: false, runCoord: 0, span: { lo: 0, hi: 10 }, halfWidthLo: 1.2, halfWidthHi: 1.2 };
+  const floating = { storey: 'L1', openLo: true, openHi: true, stairLo: null, stairHi: null, runCoord: 0, span: { lo: 0, hi: 10 }, halfWidthLo: 1.2, halfWidthHi: 1.2 };
+  const outsideEnv = { storey: 'L1', openLo: false, openHi: false, runCoord: 100, span: { lo: 0, hi: 10 }, halfWidthLo: 1.2, halfWidthHi: 1.2 };
+  const envelopeByStorey = { L1: { x0: -5, x1: 15, y0: -5, y1: 15 } };
+  const result = HB.commonSenseFilter([grounded, floating, outsideEnv], envelopeByStorey);
+  chk('G1 grounded + within-envelope bucket kept', result.kept.indexOf(grounded) >= 0);
+  chk('G2 floating bucket (both ends open, no stair) dropped with reason=ungrounded',
+    result.dropped.some(d => d.bucket === floating && d.reason === 'ungrounded'));
+  chk('G3 bucket whose rect sits outside its storey envelope dropped with reason=outside-envelope',
+    result.dropped.some(d => d.bucket === outsideEnv && d.reason === 'outside-envelope'));
+  chk('G4 kept array excludes both rejected buckets', result.kept.length === 1);
+}
+
+// ── Test H: DEFAULT_PROFILE is a real, usable extension point — override without touching source ──
+{
+  const bucket = { axis: 'x', runCoord: 0, span: { lo: 0, hi: 10 } };
+  const wideProfile = Object.assign({}, HB.DEFAULT_PROFILE, { maxSideOffset: 10 });
+  const walls = [['ignored']]; // unused placeholder, bucketWidth reads wall objects not this
+  const farWall = { cx: 5, cy: 6, bx: 10, by: 0.2 }; // 5.9m net offset — rejected by DEFAULT_PROFILE, accepted by wideProfile
+  HB.bucketWidth(bucket, [farWall]); // default profile: 5.9m > maxSideOffset(3.0) -> falls back to default
+  const defaultResultWidth = bucket.halfWidthHi;
+  const bucket2 = { axis: 'x', runCoord: 0, span: { lo: 0, hi: 10 } };
+  HB.bucketWidth(bucket2, [farWall], wideProfile);
+  chk('H1 default profile rejects the far wall (falls back to defaultHalfWidth)', defaultResultWidth === HB.DEFAULT_PROFILE.defaultHalfWidth);
+  chk('H2 override profile (maxSideOffset=10) accepts the SAME far wall at its real offset',
+    Math.abs(bucket2.halfWidthHi - 5.9) < 0.01, 'halfWidthHi=' + bucket2.halfWidthHi);
+}
+
 console.log('\n§SANDBOX_CORRIDOR_WIDTH DONE pass=' + pass + ' fail=' + fail);
 process.exit(fail ? 1 : 0);

--- a/sandbox_corridor_width.js
+++ b/sandbox_corridor_width.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * SANDBOX (not a witness) — synthetic geometry, known expected values, isolates the two formula
+ * fixes in common/hallway_backbone.js (§CORRIDOR-WIDTH-BOUNDS, §CORRIDOR-OVERLAP-FRACTION) from
+ * any real building's data noise. Run: node sandbox_corridor_width.js
+ */
+'use strict';
+const HB = require('./common/hallway_backbone.js');
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { fail++; console.log('  FAIL ' + n + '  ' + (x || '')); } };
+
+// ── Test A: bucketWidth rejects a host-wall self-match (offset ~0) ──
+// A bucket of x-run doors at runCoord y=0, span x:[0,10]. Two walls:
+//  W1: the door-hosting wall itself, runs along x, centered AT y=0 (offset ~0 from rc) — must be
+//      rejected as a flanking candidate (too close — this is the same wall the doors sit in).
+//  W2: the REAL opposite corridor wall, 2.0m away at y=2.0 — must be the one actually picked.
+{
+  const bucket = { axis: 'x', runCoord: 0, span: { lo: 0, hi: 10 } };
+  const walls = [
+    { cx: 5, cy: 0.05, bx: 10, by: 0.2 },   // host wall: centered almost on rc, thin
+    { cx: 5, cy: 2.0, bx: 10, by: 0.2 }     // real flanking wall, 2.0m away (net offset ~1.9)
+  ];
+  HB.bucketWidth(bucket, walls);
+  chk('A1 host-wall self-match (offset~0) NOT accepted as flanking wall',
+    bucket.halfWidthHi > 1.0, 'halfWidthHi=' + bucket.halfWidthHi);
+  chk('A2 real flanking wall at ~1.9m net offset IS the accepted width',
+    Math.abs(bucket.halfWidthHi - 1.9) < 0.01, 'halfWidthHi=' + bucket.halfWidthHi);
+}
+
+// ── Test B: bucketWidth rejects an implausibly-far same-axis wall, falls back to default ──
+{
+  const bucket = { axis: 'x', runCoord: 0, span: { lo: 0, hi: 10 } };
+  const walls = [
+    { cx: 5, cy: 40, bx: 10, by: 0.2 }   // 40m away — a coincidentally-aligned cross-building wall
+  ];
+  HB.bucketWidth(bucket, walls);
+  chk('B1 implausibly-far wall (40m) rejected, falls back to DEFAULT_HALF_WIDTH',
+    bucket.halfWidthHi === 1.2, 'halfWidthHi=' + bucket.halfWidthHi);
+}
+
+// ── Test C: bucketWidth accepts a wall right at the edge of the plausible window ──
+{
+  const bucket = { axis: 'x', runCoord: 0, span: { lo: 0, hi: 10 } };
+  const walls = [
+    { cx: 5, cy: 1.5, bx: 10, by: 0.2 }   // net offset 1.4 — inside [0.5, 3.0]
+  ];
+  HB.bucketWidth(bucket, walls);
+  chk('C1 wall within [MIN,MAX] window accepted at its real measured offset',
+    Math.abs(bucket.halfWidthHi - 1.4) < 0.01, 'halfWidthHi=' + bucket.halfWidthHi);
+}
+
+// ── Test D: classifyCorridorRooms overlap-fraction guard ──
+// Fake dbQuery: one joined-worthy door cluster (>=3 doors along x at y=0, spanning x:[0,20]) plus a
+// wide flanking wall each side so bucketWidth gives a real ~2m-total corridor width. Two IfcSpace
+// rows: ROOM_CORRIDOR sits fully inside the corridor strip (must classify); ROOM_BIG is a large
+// room whose centroid drifts just inside the strip but whose own body sits mostly outside it (must
+// NOT classify — this is the exact HHS false-positive shape: R18, 242m², frac=0.570 -> now testing
+// a deliberately LOW-fraction case to confirm the guard actually rejects it).
+{
+  const rows = {
+    doors: [
+      // 3 doors along x, all with cy~0 (their host wall run), wide-in-X bbox -> axis 'x'
+      ['D1','Door1','L1', 2, 0, 1.0, 0.2],
+      ['D2','Door2','L1', 8, 0, 1.0, 0.2],
+      ['D3','Door3','L1', 14, 0, 1.0, 0.2]
+    ],
+    // wallRows column order (see buildBackbone): storey, center_x, center_y, bbox_x, bbox_y
+    walls: [
+      // host wall (must be excluded from width calc — offset ~0 on the "below" side)
+      ['L1', 8, 0.0, 20, 0.2],
+      // real opposite flanking wall, 2.0m north of the doors' wall
+      ['L1', 8, 2.0, 20, 0.2]
+    ],
+    spaces: [
+      // ROOM_CORRIDOR: fully inside the resulting corridor strip (y in [-1.2(default lo), 2.0])
+      ['S_CORR', 'L1', null, 8, 0.5, 12, 1.5],
+      // ROOM_BIG: centroid (8, 1.5) sits inside the corridor strip's y-range, but the room's own
+      // 6x10 body extends far beyond it (y:[-3.5,6.5]) — most of its area is OUTSIDE the strip (a
+      // real room bordering the corridor, not part of it)
+      ['S_BIG', 'L1', null, 8, 1.5, 6, 10]
+    ]
+  };
+  function dbQuery(sql) {
+    if (/IfcDoor/.test(sql)) return rows.doors;
+    if (/IfcWall/.test(sql)) return rows.walls;
+    if (/PRAGMA table_info/.test(sql)) return [[0,'guid'],[1,'name'],[2,'room_guid']];
+    if (/IfcSpace/.test(sql)) return rows.spaces;
+    return [];
+  }
+  const backbone = HB.buildBackbone(dbQuery, { log: () => {} });
+  chk('D0 sandbox door cluster actually joined into a bucket', backbone.joined.length === 1, 'joined=' + backbone.joined.length);
+  if (backbone.joined.length) {
+    const b = backbone.joined[0];
+    console.log('  sandbox bucket halfWidthLo=' + b.halfWidthLo + ' halfWidthHi=' + b.halfWidthHi + ' span=' + JSON.stringify(b.span));
+  }
+  const labels = HB.classifyCorridorRooms(dbQuery, { log: () => {} });
+  chk('D1 ROOM_CORRIDOR (fully inside strip) classified as corridor', !!labels['S_CORR'], JSON.stringify(labels));
+  chk('D2 ROOM_BIG (centroid-only drift, body mostly outside) REJECTED by overlap-fraction guard', !labels['S_BIG'], JSON.stringify(labels));
+}
+
+console.log('\n§SANDBOX_CORRIDOR_WIDTH DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/sandbox_corridor_width.js
+++ b/sandbox_corridor_width.js
@@ -69,7 +69,12 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { f
       // host wall (must be excluded from width calc — offset ~0 on the "below" side)
       ['L1', 8, 0.0, 20, 0.2],
       // real opposite flanking wall, 2.0m north of the doors' wall
-      ['L1', 8, 2.0, 20, 0.2]
+      ['L1', 8, 2.0, 20, 0.2],
+      // end-cap walls (wide-in-y, perpendicular to the x-run bucket) just past the outermost doors
+      // on each side — needed so isGrounded()/distanceToEnclosure() accept this as a real, walled
+      // walkway rather than a floating door alignment (§COMMON-SENSE-FILTER).
+      ['L1', 0, 1.0, 0.2, 4],
+      ['L1', 16, 1.0, 0.2, 4]
     ],
     spaces: [
       // ROOM_CORRIDOR: fully inside the resulting corridor strip (y in [-1.2(default lo), 2.0])
@@ -96,6 +101,47 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { f
   const labels = HB.classifyCorridorRooms(dbQuery, { log: () => {} });
   chk('D1 ROOM_CORRIDOR (fully inside strip) classified as corridor', !!labels['S_CORR'], JSON.stringify(labels));
   chk('D2 ROOM_BIG (centroid-only drift, body mostly outside) REJECTED by overlap-fraction guard', !labels['S_BIG'], JSON.stringify(labels));
+}
+
+// ── Test E: wallLiesFlatAgainst / distanceToEnclosure / isGrounded — unit-level, no DB needed ──
+{
+  chk('E1 wallLiesFlatAgainst: offset inside [min,max] returns the offset', HB.wallLiesFlatAgainst(1.4, 0.5, 3.0) === 1.4);
+  chk('E2 wallLiesFlatAgainst: offset below min (self-match shape) rejected', HB.wallLiesFlatAgainst(0.05, 0.5, 3.0) === null);
+  chk('E3 wallLiesFlatAgainst: offset above max (cross-building shape) rejected', HB.wallLiesFlatAgainst(40, 0.5, 3.0) === null);
+  chk('E4 wallLiesFlatAgainst: min=0 disables the "too close" half (growToWall use)', HB.wallLiesFlatAgainst(0.01, 0, 8) === 0.01);
+
+  const env = { x0: 0, x1: 20, y0: 0, y1: 10 };
+  chk('E5 distanceToEnclosure: point well inside returns 0', HB.distanceToEnclosure(10, 5, env) === 0);
+  chk('E6 distanceToEnclosure: point just past the boundary (within tolerance) still 0', HB.distanceToEnclosure(20.3, 5, env) === 0);
+  chk('E7 distanceToEnclosure: point clearly outside returns a positive distance', HB.distanceToEnclosure(25, 5, env) > 0, 'd=' + HB.distanceToEnclosure(25, 5, env));
+  chk('E8 distanceToEnclosure: no envelope data never false-flags', HB.distanceToEnclosure(999, 999, null) === 0);
+
+  chk('E9 isGrounded: both ends wall-capped -> grounded', HB.isGrounded({ openLo: false, openHi: false }));
+  chk('E10 isGrounded: one end open but stair-anchored -> still grounded', HB.isGrounded({ openLo: true, stairLo: 'S1', openHi: false }));
+  chk('E11 isGrounded: BOTH ends open with no stair anchor -> floating, rejected', !HB.isGrounded({ openLo: true, openHi: true, stairLo: null, stairHi: null }));
+}
+
+// ── Test F: growToWall rejects an implausibly-far end-cap wall (MAX_END_REACH), same shape as
+// the width bug but along the corridor's own axis ("not in mid air", user's item 3) ──
+{
+  const bucket = { axis: 'x', runCoord: 0, doors: [{ alongCoord: 2 }, { alongCoord: 8 }, { alongCoord: 14 }] };
+  const walls = [
+    // a perpendicular (y-run) wall crossing rc=0, but 30m past the last door (14) — a
+    // coincidentally cross-axis-aligned wall from an unrelated part of the building
+    { cx: 44, cy: 1, bx: 0.2, by: 4 }
+  ];
+  HB.growToWall(bucket, walls);
+  chk('F1 implausibly-far end-cap (30m past last door) rejected, end stays open',
+    bucket.openHi === true && bucket.span.hi === 14, 'openHi=' + bucket.openHi + ' span.hi=' + bucket.span.hi);
+}
+{
+  const bucket = { axis: 'x', runCoord: 0, doors: [{ alongCoord: 2 }, { alongCoord: 8 }, { alongCoord: 14 }] };
+  const walls = [
+    { cx: 17, cy: 1, bx: 0.2, by: 4 }   // 3m past the last door — well within MAX_END_REACH
+  ];
+  HB.growToWall(bucket, walls);
+  chk('F2 plausible end-cap (3m past last door) accepted',
+    bucket.openHi === false && bucket.span.hi === 17, 'openHi=' + bucket.openHi + ' span.hi=' + bucket.span.hi);
 }
 
 console.log('\n§SANDBOX_CORRIDOR_WIDTH DONE pass=' + pass + ' fail=' + fail);

--- a/sandbox_corridor_width.js
+++ b/sandbox_corridor_width.js
@@ -82,7 +82,12 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { f
       // ROOM_BIG: centroid (8, 1.5) sits inside the corridor strip's y-range, but the room's own
       // 6x10 body extends far beyond it (y:[-3.5,6.5]) — most of its area is OUTSIDE the strip (a
       // real room bordering the corridor, not part of it)
-      ['S_BIG', 'L1', null, 8, 1.5, 6, 10]
+      ['S_BIG', 'L1', null, 8, 1.5, 6, 10],
+      // ROOM_SQUARE: small (1.0x1.0), fully inside the strip (100% overlap fraction — would have
+      // passed the OLD overlap-only guard) but near-square (aspect 1.0) — the exact real-world
+      // shape found on Clinic (e.g. "First Floor R10", 2.4x2.2m, aspect 1.09): a closet/small-room
+      // whose small size lets it hide entirely inside an oversized corridor rect, not a corridor.
+      ['S_SQUARE', 'L1', null, 5, 0.3, 1.0, 1.0]
     ]
   };
   function dbQuery(sql) {
@@ -101,6 +106,16 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { f
   const labels = HB.classifyCorridorRooms(dbQuery, { log: () => {} });
   chk('D1 ROOM_CORRIDOR (fully inside strip) classified as corridor', !!labels['S_CORR'], JSON.stringify(labels));
   chk('D2 ROOM_BIG (centroid-only drift, body mostly outside) REJECTED by overlap-fraction guard', !labels['S_BIG'], JSON.stringify(labels));
+  chk('D3 ROOM_SQUARE (100% overlap but near-square, aspect~1.0) REJECTED by shape guard', !labels['S_SQUARE'], JSON.stringify(labels));
+}
+
+// ── Test I: unionAspectRatio — the shape primitive, tested directly ──
+{
+  chk('I1 a long thin rect (12x1.5) measures a high aspect ratio', Math.abs(HB.unionAspectRatio([{ x0: 0, x1: 12, y0: 0, y1: 1.5 }]) - 8) < 0.01);
+  chk('I2 a near-square rect (2.4x2.2) measures aspect close to 1.0',
+    Math.abs(HB.unionAspectRatio([{ x0: 0, x1: 2.4, y0: 0, y1: 2.2 }]) - (2.4 / 2.2)) < 0.01);
+  chk('I3 a multi-rect (§MULTI-RECT) room unions across ALL its sub-rects, not just the first',
+    HB.unionAspectRatio([{ x0: 0, x1: 1, y0: 0, y1: 1 }, { x0: 1, x1: 10, y0: 0, y1: 1 }]) === 10);
 }
 
 // ── Test E: wallLiesFlatAgainst / distanceToEnclosure / isGrounded — unit-level, no DB needed ──

--- a/sandbox_full_connectivity.js
+++ b/sandbox_full_connectivity.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * SANDBOX (not a witness) — hand-built graphs with known connectivity, isolating
+ * RoomGraph.fullConnectivity() from real-building data noise. Answers the user's own question
+ * (2026-07-14): "is there a simple test where every door can go to any other door via a covered
+ * path, no gap?" — this IS that test; these checks prove its core logic before trusting it on
+ * real data (see witness_full_connectivity.js for the real-building report).
+ * Run: node sandbox_full_connectivity.js
+ */
+'use strict';
+const RG = require('./common/room_graph.js');
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  OK ' + n); } else { fail++; console.log('  FAIL ' + n + '  ' + (x || '')); } };
+
+// ── Test A: a fully-connected graph (chain room-circ-room) reports fullyConnected=true ──
+{
+  const graph = {
+    nodesByGuid: {
+      R1: { kind: 'room' }, R2: { kind: 'room' }, C1: { kind: 'circ' }
+    },
+    edges: [
+      { a: 'R1', b: 'C1', kind: 'E2', doorGuid: 'D1' },
+      { a: 'C1', b: 'R2', kind: 'E2', doorGuid: 'D2' }
+    ]
+  };
+  const fc = RG.fullConnectivity(graph);
+  chk('A1 fully-connected 3-node graph reports components=1', fc.components === 1, 'components=' + fc.components);
+  chk('A2 fullyConnected flag is true', fc.fullyConnected === true);
+  chk('A3 totalNodes counts all 3 real nodes', fc.totalNodes === 3, 'totalNodes=' + fc.totalNodes);
+  chk('A4 largestComponent equals totalNodes when fully connected', fc.largestComponent === 3);
+}
+
+// ── Test B: a real gap — one room with NO edge at all must show as its own isolated island ──
+{
+  const graph = {
+    nodesByGuid: { R1: { kind: 'room' }, R2: { kind: 'room' }, R3: { kind: 'room' } },
+    edges: [{ a: 'R1', b: 'R2', kind: 'E1', doorGuid: 'D1' }]   // R3 has no edge at all
+  };
+  const fc = RG.fullConnectivity(graph);
+  chk('B1 a real doorless room produces components=2 (the gap IS detected)', fc.components === 2, 'components=' + fc.components);
+  chk('B2 fullyConnected is false', fc.fullyConnected === false);
+  chk('B3 R3 sits in its own size-1 island', fc.sizes.indexOf(1) >= 0 && fc.comp.R3 !== fc.comp.R1, JSON.stringify(fc.comp));
+}
+
+// ── Test C: the doorwp/stairwp-inflation bug this fix closes — a lookup-only waypoint node that
+// is NEVER an edge endpoint must NOT be counted as a phantom island (real bug found building this:
+// Clinic showed ~200 fake size-1 islands from exactly this before the fix) ──
+{
+  const graph = {
+    nodesByGuid: {
+      R1: { kind: 'room' }, R2: { kind: 'room' },
+      DW1: { kind: 'doorwp' },   // registered for detour lookups, never wired into any edge
+      SW1: { kind: 'stairwp' }   // registered for path-render lookups, never wired into any edge
+    },
+    edges: [{ a: 'R1', b: 'R2', kind: 'E1', doorGuid: 'D1' }]
+  };
+  const fc = RG.fullConnectivity(graph);
+  chk('C1 fully connected (the 2 real rooms) despite 2 untouched lookup-only nodes present', fc.fullyConnected === true, 'components=' + fc.components);
+  chk('C2 totalNodes counts only the 2 real rooms, NOT the 2 lookup-only nodes', fc.totalNodes === 2, 'totalNodes=' + fc.totalNodes);
+}
+
+// ── Test D: a doorwp node that IS wired into a real edge (§G7 orphan-door-to-spine, E7) DOES
+// count — the fix must not blanket-exclude doorwp, only the untouched ones ──
+{
+  const graph = {
+    nodesByGuid: { R1: { kind: 'room' }, SPINE1: { kind: 'spine' }, DW_ORPHAN: { kind: 'doorwp' } },
+    edges: [
+      { a: 'R1', b: 'SPINE1', kind: 'E6' },
+      { a: 'DW_ORPHAN', b: 'SPINE1', kind: 'E7' }   // a real E7 edge — DW_ORPHAN must be a real vertex
+    ]
+  };
+  const fc = RG.fullConnectivity(graph);
+  chk('D1 an edge-wired doorwp (E7) IS included and connected', fc.fullyConnected === true && fc.totalNodes === 3,
+    'totalNodes=' + fc.totalNodes + ' fullyConnected=' + fc.fullyConnected);
+}
+
+console.log('\n§SANDBOX_FULL_CONNECTIVITY DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2186,15 +2186,19 @@
     // would correctly return null for it (nothing to query), so build the SAME {name,storey,
     // rectCount,cx,cy,cz,sx,sy,sz} shape directly from the room graph's own node instead — real
     // measured position/span either way, just a different (in-memory, not DB) source. sz (height)
-    // has no measured value for a synthetic hallway node — 3.0m is a generic floor-to-ceiling
-    // placeholder, not a measured number; documented as such, not silently invented as if real.
+    // has no measured real ceiling for a synthetic hallway node — per user steer (2026-07-14): this
+    // box is for PATH-OF-MOVEMENT first, not volumetric/ceiling accuracy, so a 2.0m human-clearance
+    // height is enough even where the real ceiling is much taller (a foyer/atrium-fronted corridor,
+    // say) — same movement-clearance convention as common/hallway_backbone.js's STAIR_CLEARANCE.
+    // Real ceiling height (for equipment placement etc) is Modeller's job later, not this walkway box.
+    var CORRIDOR_BOX_CLEARANCE_HEIGHT = 2.0;
     function _corridorRoomBBox(guid) {
       var graph = _roomGraphFor();
       var n = graph && graph.nodesByGuid && graph.nodesByGuid[guid];
       if (!n || n.kind !== 'room' || !n.rects || !n.rects.length) return null;
       var rc = n.rects[0];
       return { name: n.name, storey: n.storey, rectCount: 1,
-        cx: n.cx, cy: n.cy, cz: n.cz, sx: rc.x1 - rc.x0, sy: rc.y1 - rc.y0, sz: 3.0 };
+        cx: n.cx, cy: n.cy, cz: n.cz, sx: rc.x1 - rc.x0, sy: rc.y1 - rc.y0, sz: CORRIDOR_BOX_CLEARANCE_HEIGHT };
     }
 
     function _roomSelect(guid) {

--- a/witness_corridor_type_label.js
+++ b/witness_corridor_type_label.js
@@ -30,38 +30,67 @@ const backbone = HallwayBackbone.buildBackbone(dbQuery, { log: () => {} });
 const bucketsByStorey = {};
 backbone.joined.forEach(b => { (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push(HallwayBackbone.bucketRect(b)); });
 
+// §CORRIDOR-OVERLAP-FRACTION (2026-07-14): re-derive with the room's own FOOTPRINT, not just its
+// centroid — a room only counts as "on the corridor" if >=50% of its own area sits inside the
+// bucket rect (see common/hallway_backbone.js classifyCorridorRooms). Centroid-inside alone is no
+// longer sufficient ground truth (that was the false-positive bug this fix closes: a large room's
+// centroid can drift inside an oversized rect while its own body sits mostly outside it).
 const hasRoomGuid = dbQuery('PRAGMA table_info(spatial_structure)').some(c => c[1] === 'room_guid');
-const spaceRows = dbQuery("SELECT s.guid, p.name" + (hasRoomGuid ? ', s.room_guid' : ', NULL') + ", s.center_x, s.center_y " +
+const spaceRows = dbQuery("SELECT s.guid, p.name" + (hasRoomGuid ? ', s.room_guid' : ', NULL') +
+  ", s.center_x, s.center_y, s.size_x, s.size_y " +
   "FROM spatial_structure s LEFT JOIN spatial_structure p ON p.guid = s.parent_guid " +
-  "WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL");
-const centroidByGuid = {};
-spaceRows.forEach(r => { const lg = r[2] || r[0]; if (!centroidByGuid[lg]) centroidByGuid[lg] = { storey: r[1], cx: r[3], cy: r[4] }; });
+  "WHERE s.type='IfcSpace' AND s.center_x IS NOT NULL AND s.size_x IS NOT NULL");
+const roomByGuid = {}; // logicalGuid -> {storey, ownRects: [{x0,x1,y0,y1,area}], cx, cy}
+spaceRows.forEach(r => {
+  const lg = r[2] || r[0];
+  if (!roomByGuid[lg]) roomByGuid[lg] = { storey: r[1], ownRects: [], sumX: 0, sumY: 0, n: 0 };
+  const g = roomByGuid[lg];
+  const sx = r[5], sy = r[6];
+  g.ownRects.push({ x0: r[3] - sx / 2, x1: r[3] + sx / 2, y0: r[4] - sy / 2, y1: r[4] + sy / 2, area: sx * sy });
+  g.sumX += r[3]; g.sumY += r[4]; g.n++;
+});
+function rectOverlapArea(a, c) {
+  const ox = Math.max(0, Math.min(a.x1, c.x1) - Math.max(a.x0, c.x0));
+  const oy = Math.max(0, Math.min(a.y1, c.y1) - Math.max(a.y0, c.y0));
+  return ox * oy;
+}
+function bestOverlapFraction(g, rects) {
+  const totalArea = g.ownRects.reduce((s, rr) => s + rr.area, 0);
+  if (totalArea <= 0) return 0;
+  let best = 0;
+  rects.forEach(rc => {
+    const ov = g.ownRects.reduce((s, rr) => s + rectOverlapArea(rr, rc), 0);
+    best = Math.max(best, ov / totalArea);
+  });
+  return best;
+}
+const MIN_OVERLAP_FRACTION = 0.5;
 
 let allVerified = true, checkedCount = 0;
 guids.forEach(lg => {
-  const c = centroidByGuid[lg];
-  if (!c) { allVerified = false; return; }
-  const rects = bucketsByStorey[c.storey] || [];
-  const hit = rects.some(rc => c.cx >= rc.x0 && c.cx <= rc.x1 && c.cy >= rc.y0 && c.cy <= rc.y1);
-  if (!hit) allVerified = false;
+  const g = roomByGuid[lg];
+  if (!g) { allVerified = false; return; }
+  const rects = bucketsByStorey[g.storey] || [];
+  const frac = bestOverlapFraction(g, rects);
+  if (frac < MIN_OVERLAP_FRACTION) allVerified = false;
   checkedCount++;
 });
-chk('G2 every classified room independently re-verified to sit inside a real backbone rect', allVerified, 'checked=' + checkedCount);
+chk('G2 every classified room independently re-verified to have >=' + MIN_OVERLAP_FRACTION +
+  ' of its own area inside a real backbone rect (not just centroid)', allVerified, 'checked=' + checkedCount);
 
-// Rooms that were NOT classified as corridor must genuinely NOT sit in any bucket rect (no
-// false-negative check needed for a display override, but confirm the classifier isn't
-// over-matching — spot check a random non-classified room).
-const nonMatched = Object.keys(centroidByGuid).filter(g => !result[g]);
+// Rooms that were NOT classified as corridor must genuinely NOT meet the overlap-fraction bar
+// either — confirms the classifier isn't under- or over-matching against its own stated rule.
+const nonMatched = Object.keys(roomByGuid).filter(g => !result[g]);
 let overMatchFound = false;
 nonMatched.slice(0, 40).forEach(lg => {
-  const c = centroidByGuid[lg];
-  const rects = bucketsByStorey[c.storey] || [];
-  const hit = rects.some(rc => c.cx >= rc.x0 && c.cx <= rc.x1 && c.cy >= rc.y0 && c.cy <= rc.y1);
-  if (hit) overMatchFound = true;
+  const g = roomByGuid[lg];
+  const rects = bucketsByStorey[g.storey] || [];
+  const frac = bestOverlapFraction(g, rects);
+  if (frac >= MIN_OVERLAP_FRACTION) overMatchFound = true;
 });
-chk('G3 no false negatives in a 40-room sample (a room truly inside a bucket rect was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
+chk('G3 no false negatives in a 40-room sample (a room meeting the overlap-fraction bar was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
 
-console.log('§SAMPLE classified=' + guids.length + ' total=' + Object.keys(centroidByGuid).length +
+console.log('§SAMPLE classified=' + guids.length + ' total=' + Object.keys(roomByGuid).length +
   ' chains touched=' + new Set(guids.map(g => result[g].chain)).size);
 
 console.log('\n§W-CORRIDOR-TYPE-LABEL DONE pass=' + pass + ' fail=' + fail);

--- a/witness_corridor_type_label.js
+++ b/witness_corridor_type_label.js
@@ -65,30 +65,37 @@ function bestOverlapFraction(g, rects) {
   return best;
 }
 const MIN_OVERLAP_FRACTION = 0.5;
+// §CORRIDOR-SHAPE (2026-07-14): ground truth also requires the shape bound now — a room must be
+// BOTH >=50% overlapping AND elongated enough (see common/hallway_backbone.js's
+// DEFAULT_PROFILE.minAspectRatio) to independently re-verify as "should be classified corridor".
+const MIN_ASPECT_RATIO = HallwayBackbone.DEFAULT_PROFILE.minAspectRatio;
+function meetsCorridorBar(g, rects) {
+  return bestOverlapFraction(g, rects) >= MIN_OVERLAP_FRACTION &&
+    HallwayBackbone.unionAspectRatio(g.ownRects) >= MIN_ASPECT_RATIO;
+}
 
 let allVerified = true, checkedCount = 0;
 guids.forEach(lg => {
   const g = roomByGuid[lg];
   if (!g) { allVerified = false; return; }
   const rects = bucketsByStorey[g.storey] || [];
-  const frac = bestOverlapFraction(g, rects);
-  if (frac < MIN_OVERLAP_FRACTION) allVerified = false;
+  if (!meetsCorridorBar(g, rects)) allVerified = false;
   checkedCount++;
 });
-chk('G2 every classified room independently re-verified to have >=' + MIN_OVERLAP_FRACTION +
-  ' of its own area inside a real backbone rect (not just centroid)', allVerified, 'checked=' + checkedCount);
+chk('G2 every classified room independently re-verified to meet BOTH the overlap-fraction (>=' +
+  MIN_OVERLAP_FRACTION + ') and shape (aspect>=' + MIN_ASPECT_RATIO + ') bars, not just centroid',
+  allVerified, 'checked=' + checkedCount);
 
-// Rooms that were NOT classified as corridor must genuinely NOT meet the overlap-fraction bar
-// either — confirms the classifier isn't under- or over-matching against its own stated rule.
+// Rooms that were NOT classified as corridor must genuinely NOT meet BOTH bars either — confirms
+// the classifier isn't under- or over-matching against its own stated rule.
 const nonMatched = Object.keys(roomByGuid).filter(g => !result[g]);
 let overMatchFound = false;
 nonMatched.slice(0, 40).forEach(lg => {
   const g = roomByGuid[lg];
   const rects = bucketsByStorey[g.storey] || [];
-  const frac = bestOverlapFraction(g, rects);
-  if (frac >= MIN_OVERLAP_FRACTION) overMatchFound = true;
+  if (meetsCorridorBar(g, rects)) overMatchFound = true;
 });
-chk('G3 no false negatives in a 40-room sample (a room meeting the overlap-fraction bar was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
+chk('G3 no false negatives in a 40-room sample (a room meeting BOTH bars was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
 
 console.log('§SAMPLE classified=' + guids.length + ' total=' + Object.keys(roomByGuid).length +
   ' chains touched=' + new Set(guids.map(g => result[g].chain)).size);

--- a/witness_full_connectivity.js
+++ b/witness_full_connectivity.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-FULL-CONNECTIVITY scope (READ THE LOG after every run)
+ * SCOPE: common/room_graph.js's NEW fullConnectivity() — answers the user's literal question
+ * (2026-07-14): "is there a simple test where every door can go to any other door via a covered
+ * path... is there no gap?" This is the FULL-GRAPH connectivity answer (all edge kinds E1-E8,
+ * all nodes — rooms + circ/spine + stair + exit), as opposed to components() (pre-existing,
+ * deliberately room-only via E1 doors alone — a different, narrower metric).
+ * PASS BAR: this witness does NOT assert fullyConnected===true — that would be asserting a
+ * property of the BUILDING DATA, not of the code. It reports the honest current state (component
+ * count, sizes, and the actual isolated node names for every non-largest component) so the gap is
+ * NAMED, not just counted — per the "tests expose issues" discipline. Green here means "the
+ * function itself runs and its own internal invariants hold" (sizes sum to totalNodes, at least
+ * one component exists, etc.), NOT "this building has no gaps."
+ * RUN: node witness_full_connectivity.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const RoomGraph = require('./common/room_graph.js');
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+function reportBuilding(name, dbPath) {
+  console.log('\n§BUILDING ' + name + ' (' + dbPath + ')');
+  const db = new Database(dbPath, { readonly: true });
+  function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+  const graph = RoomGraph.buildGraph(dbQuery, { log: () => {} });
+  const fc = RoomGraph.fullConnectivity(graph);
+
+  chk(name + ': fullConnectivity() ran and produced a self-consistent result',
+    fc.sizes.reduce((a, b) => a + b, 0) === fc.totalNodes,
+    'sizes sum=' + fc.sizes.reduce((a, b) => a + b, 0) + ' totalNodes=' + fc.totalNodes);
+  chk(name + ': at least one node/component found (graph not empty)', fc.totalNodes > 0 && fc.components > 0);
+
+  const doorEdgeCount = graph.edges.filter(e => e.doorGuid).length;
+  console.log('  totalNodes=' + fc.totalNodes + ' components=' + fc.components +
+    ' largestComponent=' + fc.largestComponent + ' (' + (100 * fc.largestComponent / fc.totalNodes).toFixed(1) + '%)' +
+    ' doorEdges=' + doorEdgeCount + ' fullyConnected=' + fc.fullyConnected);
+
+  if (!fc.fullyConnected) {
+    // Name every component's members (not just its size) so the actual gap is identified —
+    // group node guids by component id, sorted smallest-first (the islands, not the main mass).
+    const byComp = {};
+    Object.keys(fc.comp).forEach(g => { const c = fc.comp[g]; (byComp[c] = byComp[c] || []).push(g); });
+    const compIds = Object.keys(byComp).sort((a, b) => byComp[a].length - byComp[b].length);
+    console.log('  §GAP_REPORT ' + fc.components + ' disconnected islands (excluding the largest):');
+    compIds.slice(0, -1).forEach(cid => {
+      const members = byComp[cid].map(g => {
+        const n = graph.nodesByGuid[g];
+        return n ? (n.kind + ':' + (n.name || g) + '@' + (n.storey || '?')) : g;
+      });
+      console.log('    island(size=' + members.length + '): ' + members.slice(0, 8).join(', ') + (members.length > 8 ? ', ...' : ''));
+    });
+  }
+  db.close();
+}
+
+reportBuilding('Clinic', '/home/red1/bim-ootb/buildings/Clinic_extracted.db');
+reportBuilding('HHS (raw, pre-patch — see §HOW-TO-TEST-LIVE, real count differs live)', '/home/red1/bim-ootb/buildings/HHS_Office_Federated_extracted.db');
+reportBuilding('Duplex', '/home/red1/bim-ootb/buildings/Duplex_extracted.db');
+
+console.log('\n§W-FULL-CONNECTIVITY DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
- Bounds corridor bucket width/end-reach against two real failure modes: a self-matching host wall collapsing width to zero, and an implausible cross-building wall ballooning it (confirmed live on Clinic + HHS).
- Adds an overlap-fraction guard + an aspect-ratio shape guard to `classifyCorridorRooms()` — a room must substantially overlap AND be elongated to count as "Hall / Corridor", not just have its centroid drift into an oversized rect. Clinic's false-positive classifications dropped from 31/32 (session start) to 6 genuinely elongated corridor segments.
- Formalizes width/reach/grounding/envelope checks into named, reusable, profile-driven verbs (`DEFAULT_PROFILE`, `commonSenseFilter`, `wallLiesFlatAgainst`, `distanceToEnclosure`, `unionAspectRatio`) instead of scattered magic constants — a pure reorganization, verified via witness re-run showing byte-identical stats before/after.
- Adds `RoomGraph.fullConnectivity()`: is every door reachable from every other via a covered path (all edge kinds, not just doors-between-rooms)? Answers this directly for the first time — found and fixed a real bug in the process (waypoint-lookup nodes inflating phantom "islands").
- Unrelated small fix bundled from the same session: `viewer/navigate_find.js`'s corridor-shell render box now uses a 2.0m movement-clearance height instead of a hardcoded 3.0m ceiling placeholder (path-of-movement box, not volumetric accuracy).

## Test plan
- [x] `sandbox_corridor_width.js` — 30 synthetic-geometry unit checks (width bounds, common-sense filter, profile override extension point, shape guard)
- [x] `sandbox_full_connectivity.js` — 10 synthetic-graph unit checks (fully-connected case, real gap detection, phantom-island bug reproduced+fixed, edge-wired waypoint still counted)
- [x] `witness_hallway_backbone.js`, `witness_corridor_room_backprop.js`, `witness_corridor_type_label.js`, `witness_full_connectivity.js` — all green against real Clinic/HHS/Duplex data

🤖 Generated with [Claude Code](https://claude.com/claude-code)