### PR TITLE
fix(rooms): Hospital corridor join-ratio (4.5%→17.8%) + baseline witness + 2 room-lens fixes

### DIFF
--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -8,7 +8,8 @@
  * spine per storey from the SAME building db common/room_graph.js already reads. Verb chain
  * (matches the spec doc's step numbering 1:1):
  *   1. doorEdge(door)        — wall-run-axis from the door's OWN bbox aspect ratio.
- *   2. correlateDoorEdges()  — bucket-matrix keyed by (storey, axis, roundedRunCoord).
+ *   2. correlateDoorEdges()  — per (storey, axis), single-linkage gap-clusters doors by runCoord
+ *                              (see §GAP-CLUSTER-BUCKETING below — not a fixed rounding grid).
  *   3. joinDoorways()        — buckets with >=3 aligned doors = hallway-candidate.
  *   4. growToWall()          — extend the bucket's span until a REAL perpendicular wall caps it.
  *   5. terminateAtStair()    — an open (uncapped) end near a stair is a connecting space, not a
@@ -185,19 +186,53 @@
   }
 
   // ── 2. correlateDoorEdges ────────────────────────────────────────────────────────────────────
+  // §GAP-CLUSTER-BUCKETING (2026-07-15, bim-compiler prompts/ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md
+  // §15/§16): was fixed-grid rounding (`Math.round(runCoord/tol)*tol`) — two doors genuinely
+  // `tol` or closer together in real space still landed in DIFFERENT buckets whenever their raw
+  // runCoords straddled a grid boundary (e.g. tol=0.6: 10.36 rounds to 10.2, 10.56 rounds to 10.8
+  // — 0.6 apart on the grid despite being only 0.20m apart in reality). This is a pure artifact of
+  // the absolute grid's fixed phase, not a real geometric signal, and it fragments real door
+  // clusters into many singletons. Measured live 2026-07-15 on Hospital_extracted.db: 251/336
+  // grid-buckets held exactly 1 door (avg 1.3 doors/bucket — Hospital's floorplan is large with
+  // doors legitimately spread across many distinct wall runs, but the grid boundary was ALSO
+  // splitting doors that belonged together). Replaced with single-linkage gap clustering: per
+  // (storey, axis) group, sort by runCoord, start a new bucket only when the gap to the PREVIOUS
+  // door exceeds `tol` — the geometrically correct question ("is this door within tol of its
+  // nearest neighbor on this wall run"), immune to absolute grid phase. `runCoord` is now the
+  // cluster's mean (a real measured value, not a rounded grid line) — downstream growToWall/
+  // bucketWidth/walkBackbone already compare against it with their own slack tolerances
+  // (wallCrossSlack/minSideOffset/maxSideOffset), so a non-grid-aligned value is not a new
+  // assumption. Measured effect at the SAME tol=0.6, before any threshold was touched: Hospital
+  // joined(>=3 doors) buckets 15->43 (336->241 total buckets); Clinic 38->41 (113->97 total);
+  // HHS unchanged at 15 (39->31 total) — an improvement or a hold on all three, not a trade-off.
   function correlateDoorEdges(edges, profile) {
     profile = profile || DEFAULT_PROFILE;
-    var buckets = {}, order = [];
+    var groups = {};
     edges.forEach(function (e) {
-      var rounded = Math.round(e.runCoord / profile.runCoordTol) * profile.runCoordTol;
-      var key = e.storey + '|' + e.axis + '|' + rounded.toFixed(2);
-      if (!buckets[key]) {
-        buckets[key] = { key: key, storey: e.storey, axis: e.axis, runCoord: rounded, doors: [] };
-        order.push(key);
-      }
-      buckets[key].doors.push(e);
+      var k = e.storey + '|' + e.axis;
+      (groups[k] = groups[k] || []).push(e);
     });
-    return order.map(function (k) { return buckets[k]; });
+    var buckets = [];
+    Object.keys(groups).forEach(function (k) {
+      var sorted = groups[k].slice().sort(function (a, b) { return a.runCoord - b.runCoord; });
+      var cluster = [];
+      function flush() {
+        if (!cluster.length) return;
+        var sum = 0;
+        cluster.forEach(function (d) { sum += d.runCoord; });
+        var rc = sum / cluster.length;
+        buckets.push({ key: k + '|' + rc.toFixed(2), storey: cluster[0].storey, axis: cluster[0].axis, runCoord: rc, doors: cluster.slice() });
+      }
+      sorted.forEach(function (e) {
+        if (cluster.length && (e.runCoord - cluster[cluster.length - 1].runCoord) > profile.runCoordTol) {
+          flush();
+          cluster = [];
+        }
+        cluster.push(e);
+      });
+      flush();
+    });
+    return buckets;
   }
 
   // ── 3. joinDoorways ──────────────────────────────────────────────────────────────────────────

--- a/common/hallway_backbone.js
+++ b/common/hallway_backbone.js
@@ -108,7 +108,24 @@
     // that real cluster's low end (1.88), cleanly separating the 6 genuine ones from the 11 boxy
     // false positives (confirmed: applying this bound moved Clinic's classifiedRooms 17->6,
     // dropping exactly those 11, keeping exactly those 6 — see debug dump, not eyeballed).
-    minAspectRatio: 1.8
+    minAspectRatio: 1.8,
+    // §CORRIDOR-DISTINCT-NEIGHBORS (2026-07-15, user's own framing: a real corridor "is not room,
+    // is larger, has doors leading onto it from RESPECTIVE [plural] rooms"). minAspectRatio alone
+    // doesn't generalize past the building it was grounded on: measured live on LTU_AHouse
+    // (369 real rooms, much bigger/more irregular footprints than Clinic) — 36 rooms passed the
+    // aspect-ratio+overlap gate, but 20 of them connect to ZERO or ONE distinct other room via a
+    // real door (using the SAME door-to-2-nearest-rooms resolution room_graph.js's own E1 edges
+    // already trust — not a new heuristic, reused ground truth), i.e. narrow dead-end slivers, not
+    // a shared through-space. The 16 kept span neighbors=3..22 — plausible real junctions. Applying
+    // the SAME >=2 bound to Clinic (where minAspectRatio was originally grounded) drops exactly the
+    // 5 zero-neighbor slivers (size 1.2-1.8m x 3-5.4m, obviously not walkways) and one single-
+    // neighbor room, keeping the 3 highest-connectivity ones — including "Second Floor R7"
+    // (16.0x4.6m, neighbors=9), the ORIGINAL doc comment's own canonical true-positive example
+    // above, confirming this signal agrees with the aspect-ratio grounding rather than replacing
+    // it. AND-combined with minAspectRatio (not a replacement) — can only make the gate STRICTER,
+    // never reclassify something aspect-ratio already excluded, so it cannot regress a
+    // building whose classification already reads correct.
+    minDistinctNeighborRooms: 2
   };
 
   // §COMMON-SENSE-FILTER (2026-07-14, user's own framing): a real walkway/corridor (1) is not
@@ -616,6 +633,43 @@
       (bucketsByStorey[b.storey] = bucketsByStorey[b.storey] || []).push({ rect: bucketRect(b, profile), chain: b._chainIndex != null ? b._chainIndex : null });
     });
 
+    // §CORRIDOR-DISTINCT-NEIGHBORS: distinct-other-room count per logical room, via the SAME
+    // door-to-2-nearest-rooms resolution room_graph.js's own E1 edges use (reused ground truth —
+    // `RoomGraph.isRoomDoor` name filter + the identical rect-distance/buffer discipline —
+    // not a new heuristic invented here). A room only counts a neighbor if a real door sits within
+    // its own rect(s) AND that same door's OTHER nearest room is a DIFFERENT logical room.
+    var neighborsByGuid = {};
+    if (RoomGraph) {
+      try {
+        var _doorRows = dbQuery('SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, t.bbox_x, t.bbox_y' +
+          ' FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid' +
+          " WHERE m.ifc_class LIKE 'IfcDoor%' AND m.discipline='ARC' AND t.center_x IS NOT NULL") || [];
+        var DOOR_BUF_SLACK = 0.20; // same constant room_graph.js's own E1 resolution uses
+        function _rd(rc, px, py) {
+          var dx = Math.max(rc.x0 - px, 0, px - rc.x1), dy = Math.max(rc.y0 - py, 0, py - rc.y1);
+          return Math.hypot(dx, dy);
+        }
+        _doorRows.forEach(function (d) {
+          var dname = d[1] || '', dstorey = d[2] || '', dx = d[3], dy = d[4], bx = d[5] || 0, by = d[6] || 0;
+          if (!RoomGraph.isRoomDoor(dname)) return;
+          var buf = Math.max(bx, by) / 2 + DOOR_BUF_SLACK;
+          var cands = [];
+          Object.keys(rects).forEach(function (lg) {
+            var g = rects[lg];
+            if (g.storey !== dstorey) return;
+            var best = Infinity;
+            for (var i = 0; i < g.ownRects.length; i++) best = Math.min(best, _rd(g.ownRects[i], dx, dy));
+            if (best <= buf) cands.push({ lg: lg, dist: best });
+          });
+          if (cands.length < 2) return;
+          cands.sort(function (p, q) { return p.dist - q.dist; });
+          var a = cands[0].lg, b = cands[1].lg;
+          (neighborsByGuid[a] = neighborsByGuid[a] || new Set()).add(b);
+          (neighborsByGuid[b] = neighborsByGuid[b] || new Set()).add(a);
+        });
+      } catch (eNb) { log('§CORRIDOR_NEIGHBORS_ERR ' + eNb.message); }
+    }
+
     function rectOverlapArea(a, c) {
       var ox = Math.max(0, Math.min(a.x1, c.x1) - Math.max(a.x0, c.x0));
       var oy = Math.max(0, Math.min(a.y1, c.y1) - Math.max(a.y0, c.y0));
@@ -637,6 +691,8 @@
     Object.keys(rects).forEach(function (lg) {
       var r = rects[lg];
       if (unionAspectRatio(r.ownRects) < profile.minAspectRatio) return; // not elongated enough to be a real corridor, regardless of overlap
+      var neighborCount = neighborsByGuid[lg] ? neighborsByGuid[lg].size : 0;
+      if (neighborCount < profile.minDistinctNeighborRooms) return; // §CORRIDOR-DISTINCT-NEIGHBORS: not a shared through-space — 0/1 real doors to a DIFFERENT room means a dead-end sliver, not a corridor, regardless of shape
       var cx = r.sumX / r.n, cy = r.sumY / r.n;
       var candidates = bucketsByStorey[r.storey];
       if (!candidates) return;

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -837,10 +837,34 @@
   // real-world point actually walked) — never exposed directly; substituted with the specific
   // door/stair waypoint the arriving EDGE carries, so the drawn line hugs the real walk instead of
   // bending toward an invented storey centroid (OCCUPANT_PATHFINDER.md SPEC).
-  function _publicHop(graph, arrivedGuid, edge, arriveSide) {
+  // §CIRC-DUAL-BRIDGE (2026-07-15, §18 item 5 — user-reported live: a rendered path visibly cuts
+  // straight through open space on an L-shaped HHS floor instead of hugging the walkway).
+  // `hasDeparture`: true when this CIRC node is a genuine MIDDLE hop — edges on BOTH sides (one
+  // bridging IN via `edge`, one already-processed bridging further OUT toward toGuid). The old
+  // unconditional substitution always used only the ARRIVAL edge's own wp (which, for a same-
+  // storey chain-to-chain bridge, is just the arriving spine's OWN point — a redundant duplicate
+  // of the node already adjacent to it) and silently discarded the departure edge's real distance
+  // entirely — measured live on HHS: a `SPINE::Level 1|y|-4.65 -> SPINE::Level 1|y|10.56` chord
+  // (18.3m, meant to be TWO real hops via the stair core, 3.8m + 15.5m) rendered as ONE straight
+  // line, 58/75 sampled points illegal (`§PATH_LEGAL_DETOUR_FAIL`). Neither edge's wp field can
+  // fix this — both sides only ever point back to "the far spine's own guid", there is no third
+  // coordinate recorded anywhere for the bridge itself. CIRC's own (cx,cy) — real, measured
+  // (stair-flight-derived), not invented — is the honest middle point in that case: keep it
+  // un-substituted rather than collapse it away.
+  // §SCOPE-GUARD (found via regression, not guessed): the suppression below is deliberately
+  // narrowed to BOTH edges being 'E6' (the same-storey chain-to-chain bridge this bug is specific
+  // to) — an EARLIER, broader "any departure edge" version silently broke the cross-floor stair
+  // case too (`CIRC::First Floor <-> CIRC::Second Floor`, kind 'E3'), which genuinely NEEDS its
+  // substitution (a real `stairwp` point) and was working correctly before — confirmed by
+  // witness_backbone_routing.js's G0c / witness_corridor_room_backprop.js's B3 both regressing
+  // when the guard was too broad, both green again once narrowed to E6-only. Every other
+  // combination (E2/E3 involved on either side) keeps the ORIGINAL unconditional substitution
+  // behavior, unchanged.
+  function _publicHop(graph, arrivedGuid, edge, arriveSide, departEdge) {
     var n = graph.nodesByGuid[arrivedGuid];
     if (!n || n.kind === 'room' || n.kind === 'exit') return arrivedGuid;
     if (n.kind === 'circ' && edge) {
+      if (departEdge && edge.kind === 'E6' && departEdge.kind === 'E6') return arrivedGuid;
       var wp = (arriveSide === 'a') ? edge.wpA : edge.wpB;
       if (wp && graph.nodesByGuid[wp]) return wp;
     }
@@ -881,10 +905,26 @@
           py >= rc.y0 - DOOR_BUFFER_SLACK && py <= rc.y1 + DOOR_BUFFER_SLACK) return true;
       }
     }
+    // §CORRIDOR-RECT-SLACK (2026-07-15, §18 item 5 — user-reported live: a rendered path visibly
+    // cuts straight through open space on an L-shaped HHS floor instead of hugging the walkway).
+    // This branch had NO tolerance at all, unlike the room-rects branch just above (which forgives
+    // DOOR_BUFFER_SLACK on every edge) — a sampled point sitting a few cm outside a corridor
+    // bucket's rect (real wall thickness / measurement rounding, or the small gap where two
+    // adjacent corridor buckets meet at a T-junction/corner) registered as illegal with zero
+    // margin. Measured live on HHS (14 rooms, 91 real pairs): 173/253=68% of directed room pairs
+    // hit >=1 `§PATH_LEGAL_DETOUR_FAIL` chord before this fix — the detour visibility graph's own
+    // candidate-to-candidate edges suffer the identical zero-margin test, so a sparse-coverage
+    // building can end up with NO legal detour at all, and `_legalizePath`'s honest-degrade leaves
+    // the original illegal straight chord in the rendered path. Fixed with the SAME wall-thickness
+    // slack `hallway_backbone.js`'s own `wallCrossSlack` already uses for this exact class of
+    // problem ("real walls are rasterized transforms, not infinitely thin planes") — not a new
+    // magic number.
+    var CORRIDOR_RECT_SLACK = 0.3;
     if (corridors) {
       for (var j = 0; j < corridors.length; j++) {
         var cc = corridors[j];
-        if (px >= cc.x0 && px <= cc.x1 && py >= cc.y0 && py <= cc.y1) return true;
+        if (px >= cc.x0 - CORRIDOR_RECT_SLACK && px <= cc.x1 + CORRIDOR_RECT_SLACK &&
+          py >= cc.y0 - CORRIDOR_RECT_SLACK && py <= cc.y1 + CORRIDOR_RECT_SLACK) return true;
       }
     }
     return false;
@@ -1026,6 +1066,7 @@
     var core = _dijkstraCore(graph, adj, fromGuid, toGuid);
     if (!core) return null;
     var path = [toGuid], doors = [], cur = toGuid;
+    var departEdge = null; // §CIRC-DUAL-BRIDGE: the edge used to LEAVE `cur` toward toGuid, from the prior iteration
     while (cur !== fromGuid) {
       var p = core.prev[cur];
       if (!p) return null; // defensive — should not happen if dist[toGuid] finite
@@ -1033,9 +1074,10 @@
       // file's own invariant is "doors[] = real doors only" (see G1 witness), so they contribute
       // to `path` (a real, wall-grounded position either way) but not to the exposed doors list.
       if (p.edge.doorGuid) doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
-      var publicCur = _publicHop(graph, cur, p.edge, p.arriveSide);
+      var publicCur = _publicHop(graph, cur, p.edge, p.arriveSide, departEdge);
       path[0] = publicCur; // replace the just-pushed guid with its public form
       path.unshift(p.from);
+      departEdge = p.edge;
       cur = p.from;
     }
     path = _legalizePath(graph, path);
@@ -1070,6 +1112,7 @@
     });
     if (!bestExit) { log('§ESCAPE_ROUTE from=' + fromGuid + ' NO_EXIT_REACHABLE'); return null; }
     var path = [bestExit], doors = [], cur = bestExit;
+    var departEdge = null; // §CIRC-DUAL-BRIDGE: same tracking as shortestPath() — see _publicHop's own comment
     while (cur !== fromGuid) {
       var p = prev[cur];
       if (!p) { log('§ESCAPE_ROUTE from=' + fromGuid + ' RECONSTRUCT_FAIL'); return null; }
@@ -1077,8 +1120,9 @@
       // file's own invariant is "doors[] = real doors only" (see G1 witness), so they contribute
       // to `path` (a real, wall-grounded position either way) but not to the exposed doors list.
       if (p.edge.doorGuid) doors.unshift({ guid: p.edge.doorGuid, name: p.edge.doorName });
-      path[0] = _publicHop(graph, cur, p.edge, p.arriveSide);
+      path[0] = _publicHop(graph, cur, p.edge, p.arriveSide, departEdge);
       path.unshift(p.from);
+      departEdge = p.edge;
       cur = p.from;
     }
     var result = { path: path, doors: doors, distance: dist[bestExit], exitGuid: bestExit };

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2465,19 +2465,37 @@
       if (isCorridorRoom) selCategory = 'corridor';
       else { var rbMatch = _roomBoxes.filter(function(rb) { return rb.guid === guid; })[0];
         if (rbMatch && rbMatch.category) selCategory = rbMatch.category; }
+      // §CUBOID-PAINT-ORDER (2026-07-15, user-reported live testing: "purple does not shine thru
+      // in solid or x-ray mode, only bbox mode"): _drawRoomCuboid()'s shine-through trick
+      // (depthTest:false + a high renderOrder, both the §BORDER_STRONG wire and #797's
+      // §FILL-SHINE-THROUGH glow) only controls PAINT ORDER when the renderer actually sorts by
+      // renderOrder. Selecting a room in the Find panel ALWAYS auto-enables X-Ray if it wasn't
+      // already on (see the `!A.xrayOn && A.toggleXray` calls a few lines below, inside
+      // _drillSelect's caller chain) — and A.toggleXray() sets `A.renderer.sortObjects =
+      // !A.xrayOn` (viewer/tools.js, a real perf optimization for X-Ray's many-material update).
+      // With sortObjects FALSE, three.js ignores renderOrder entirely and paints in raw
+      // scene-graph traversal order instead — so whichever mesh was ADDED to the scene LAST wins
+      // the pixel, regardless of renderOrder. _drawRoomCuboid() used to run BEFORE _drillSelect()
+      // below, so the cuboid was added FIRST and _drillSelect's own context/ghost overlay meshes
+      // (added after) painted OVER it — hiding the "shines through" glow specifically in the
+      // sortObjects=false state this feature normally runs in. "Bbox" mode only looked unaffected
+      // because it replaces most real geometry with thin wireframes, leaving little solid pixel
+      // coverage to reveal the same underlying bug. Fix: call _drillSelect FIRST so the cuboid is
+      // always the LAST thing added to the scene each selection — correct on top regardless of
+      // sortObjects state, no change to the X-Ray perf optimization itself.
       if (bound.size && zoomBox) {
-        _drawRoomCuboid(zoomBox.center, zoomBox.size, selCategory);
         var _clip = _boxClipPlanes(zoomBox.center, zoomBox.size, 0.7);   // confine the ancestor shell to the cuboid (+0.7m)
         console.log('[RP-TA] §ROOM_HIGHLIGHT mode=cuboid guid=' + guid + ' bound=' + bound.size +
           ' box=' + zoomBox.size.x.toFixed(1) + 'x' + zoomBox.size.y.toFixed(1) + 'x' + zoomBox.size.z.toFixed(1) + ' margin=0.7');
         _drillSelect(bound, name, 'ROOM_SELECT', { isItem: true, parentSet: storeySet, zoomBox: zoomBox, clipPlanes: _clip, zoomMult: 1.8, suppressHighlight: true });
+        _drawRoomCuboid(zoomBox.center, zoomBox.size, selCategory);
       } else if (bound.size) {
         console.log('[RP-TA] §ROOM_HIGHLIGHT mode=bounding-elements guid=' + guid + ' (no zoomBox available)');
         _drillSelect(bound, name, 'ROOM_SELECT', { isItem: true, parentSet: storeySet, zoomBox: zoomBox, zoomMult: 1.8 });
       } else {
-        if (zoomBox) _drawRoomCuboid(zoomBox.center, zoomBox.size, selCategory);
         console.log('[RP-TA] §ROOM_HIGHLIGHT mode=' + (zoomBox ? 'cuboid' : 'cuboid-fallback') + ' guid=' + guid + ' (no bounding mesh found)');
         _drillSelect(storeySet || new Set([guid]), name, 'ROOM_SELECT', { isItem: false, zoomBox: zoomBox });
+        if (zoomBox) _drawRoomCuboid(zoomBox.center, zoomBox.size, selCategory);
       }
     }
 

--- a/witness_corridor_type_label.js
+++ b/witness_corridor_type_label.js
@@ -69,9 +69,46 @@ const MIN_OVERLAP_FRACTION = 0.5;
 // BOTH >=50% overlapping AND elongated enough (see common/hallway_backbone.js's
 // DEFAULT_PROFILE.minAspectRatio) to independently re-verify as "should be classified corridor".
 const MIN_ASPECT_RATIO = HallwayBackbone.DEFAULT_PROFILE.minAspectRatio;
-function meetsCorridorBar(g, rects) {
+
+// §CORRIDOR-DISTINCT-NEIGHBORS (2026-07-15): independently re-derive distinct-other-room door
+// adjacency from scratch (same door-to-2-nearest-rooms resolution room_graph.js's own E1 edges
+// use) — a room must ALSO connect to >=minDistinctNeighborRooms DIFFERENT rooms via a real door to
+// count, not just satisfy shape+overlap. Reused ground truth, not trusting classifyCorridorRooms'
+// own internal computation of the same thing.
+const RoomGraph = require('./common/room_graph.js');
+const MIN_NEIGHBORS = HallwayBackbone.DEFAULT_PROFILE.minDistinctNeighborRooms;
+const doorRows = dbQuery("SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, t.bbox_x, t.bbox_y" +
+  " FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid" +
+  " WHERE m.ifc_class LIKE 'IfcDoor%' AND m.discipline='ARC' AND t.center_x IS NOT NULL");
+const DOOR_BUF_SLACK = 0.20;
+function rd(rc, px, py) {
+  const dx = Math.max(rc.x0 - px, 0, px - rc.x1), dy = Math.max(rc.y0 - py, 0, py - rc.y1);
+  return Math.hypot(dx, dy);
+}
+const neighborsByGuid = {};
+doorRows.forEach(d => {
+  const dname = d[1] || '', dstorey = d[2] || '', dx = d[3], dy = d[4], bx = d[5] || 0, by = d[6] || 0;
+  if (!RoomGraph.isRoomDoor(dname)) return;
+  const buf = Math.max(bx, by) / 2 + DOOR_BUF_SLACK;
+  const cands = [];
+  Object.keys(roomByGuid).forEach(lg => {
+    const g = roomByGuid[lg];
+    if (g.storey !== dstorey) return;
+    let best = Infinity;
+    g.ownRects.forEach(rr => { best = Math.min(best, rd(rr, dx, dy)); });
+    if (best <= buf) cands.push({ lg, dist: best });
+  });
+  if (cands.length < 2) return;
+  cands.sort((p, q) => p.dist - q.dist);
+  const a = cands[0].lg, b = cands[1].lg;
+  (neighborsByGuid[a] = neighborsByGuid[a] || new Set()).add(b);
+  (neighborsByGuid[b] = neighborsByGuid[b] || new Set()).add(a);
+});
+function meetsCorridorBar(g, rects, lg) {
+  const neighborCount = neighborsByGuid[lg] ? neighborsByGuid[lg].size : 0;
   return bestOverlapFraction(g, rects) >= MIN_OVERLAP_FRACTION &&
-    HallwayBackbone.unionAspectRatio(g.ownRects) >= MIN_ASPECT_RATIO;
+    HallwayBackbone.unionAspectRatio(g.ownRects) >= MIN_ASPECT_RATIO &&
+    neighborCount >= MIN_NEIGHBORS;
 }
 
 let allVerified = true, checkedCount = 0;
@@ -79,12 +116,12 @@ guids.forEach(lg => {
   const g = roomByGuid[lg];
   if (!g) { allVerified = false; return; }
   const rects = bucketsByStorey[g.storey] || [];
-  if (!meetsCorridorBar(g, rects)) allVerified = false;
+  if (!meetsCorridorBar(g, rects, lg)) allVerified = false;
   checkedCount++;
 });
-chk('G2 every classified room independently re-verified to meet BOTH the overlap-fraction (>=' +
-  MIN_OVERLAP_FRACTION + ') and shape (aspect>=' + MIN_ASPECT_RATIO + ') bars, not just centroid',
-  allVerified, 'checked=' + checkedCount);
+chk('G2 every classified room independently re-verified to meet ALL THREE bars — overlap-fraction (>=' +
+  MIN_OVERLAP_FRACTION + '), shape (aspect>=' + MIN_ASPECT_RATIO + '), and distinct-neighbor-rooms (>=' +
+  MIN_NEIGHBORS + ') — not just centroid', allVerified, 'checked=' + checkedCount);
 
 // Rooms that were NOT classified as corridor must genuinely NOT meet BOTH bars either — confirms
 // the classifier isn't under- or over-matching against its own stated rule.
@@ -93,12 +130,28 @@ let overMatchFound = false;
 nonMatched.slice(0, 40).forEach(lg => {
   const g = roomByGuid[lg];
   const rects = bucketsByStorey[g.storey] || [];
-  if (meetsCorridorBar(g, rects)) overMatchFound = true;
+  if (meetsCorridorBar(g, rects, lg)) overMatchFound = true;
 });
-chk('G3 no false negatives in a 40-room sample (a room meeting BOTH bars was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
+chk('G3 no false negatives in a 40-room sample (a room meeting ALL THREE bars was not silently skipped)', !overMatchFound, 'sampled=' + Math.min(40, nonMatched.length));
 
 console.log('§SAMPLE classified=' + guids.length + ' total=' + Object.keys(roomByGuid).length +
   ' chains touched=' + new Set(guids.map(g => result[g].chain)).size);
+
+// §CORRIDOR-DISTINCT-NEIGHBORS regression guard (2026-07-15): before this fix, Clinic classified 9
+// rooms via shape+overlap alone — 6 of those had 0-1 distinct neighboring rooms (narrow slivers,
+// e.g. "First Floor R22" 1.4x5.4m connecting to nothing), confirmed false positives. This asserts
+// the fix's actual effect: strictly fewer classified than the shape+overlap-only count, and none of
+// the survivors are zero-neighbor dead ends.
+const shapeOverlapOnlyCount = Object.keys(roomByGuid).filter(lg => {
+  const g = roomByGuid[lg];
+  const rects = bucketsByStorey[g.storey] || [];
+  return bestOverlapFraction(g, rects) >= MIN_OVERLAP_FRACTION &&
+    HallwayBackbone.unionAspectRatio(g.ownRects) >= MIN_ASPECT_RATIO;
+}).length;
+chk('G4 distinct-neighbor gate actually prunes false positives (fewer classified than shape+overlap alone would give)',
+  guids.length < shapeOverlapOnlyCount, 'withGate=' + guids.length + ' shapeOverlapOnly=' + shapeOverlapOnlyCount);
+chk('G5 no classified room is a zero/one-neighbor dead end (the exact false-positive shape this gate targets)',
+  guids.every(lg => (neighborsByGuid[lg] ? neighborsByGuid[lg].size : 0) >= MIN_NEIGHBORS));
 
 console.log('\n§W-CORRIDOR-TYPE-LABEL DONE pass=' + pass + ' fail=' + fail);
 process.exit(fail ? 1 : 0);

--- a/witness_hospital_corridor_baseline.js
+++ b/witness_hospital_corridor_baseline.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-HOSPITAL-CORRIDOR-BASELINE scope (READ THE LOG after every run)
+ * SCOPE: bim-compiler prompts/ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md §15 found Hospital's real wall
+ * geometry only joins 15/336 (4.5%) of candidate corridor-wall buckets into a walkBackbone() chain
+ * — far below Clinic (33.6%) and HHS (38.5%) — which starves room-to-room routing of a real
+ * corridor to hug on most inter-wing paths (user-reported: "Hospital corridors not accurate and
+ * hampers room to room paths"). This witness is a BASELINE CAPTURE, not a fix: it exists so the
+ * NEXT session can loosen walkBackbone()'s join thresholds and prove the change on TWO axes at
+ * once from ONE run — (a) Hospital's join ratio must MEASURABLY IMPROVE past this file's recorded
+ * floor, not just "still pass", and (b) Clinic/HHS's join ratios must not regress below their
+ * CURRENT measured values, which this file also pins. Do not raise the Hospital floor without a
+ * real re-measurement — that would silently launder the still-open bug.
+ * RUN: node witness_hospital_corridor_baseline.js   (from the worktree root)
+ */
+'use strict';
+const Database = require(require('path').join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const HallwayBackbone = require('./common/hallway_backbone.js');
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+function measure(name, dbPath) {
+  const db = new Database(dbPath, { readonly: true });
+  function dbQuery(sql) { return db.prepare(sql).raw(true).all(); }
+  const result = HallwayBackbone.buildBackbone(dbQuery, { log: (m) => console.log('  [' + name + '] ' + m) });
+  db.close();
+  const s = result.stats;
+  const ratio = s.buckets ? (100 * s.joined / s.buckets) : 0;
+  console.log('§CORRIDOR_JOIN_RATIO building=' + name + ' buckets=' + s.buckets + ' joined=' + s.joined +
+    ' ratio=' + ratio.toFixed(1) + '% chains=' + s.chains + ' crossings=' + s.crossings);
+  return { stats: s, ratio: ratio };
+}
+
+const hospital = measure('Hospital', '/home/red1/bim-ootb/buildings/Hospital_extracted.db');
+const clinic = measure('Clinic', '/home/red1/bim-ootb/buildings/Clinic_extracted.db');
+const hhs = measure('HHS', '/home/red1/bim-ootb/buildings/HHS_Office_Federated_extracted.db');
+
+// ── Hospital: document the CURRENT broken state as a floor, not a target. Measured 2026-07-15:
+// buckets=336 joined=15 (4.5%). Any threshold tuning must push this ratio UP — if a future run
+// still lands at or below this floor, the fix did not actually help Hospital's real geometry. ──
+chk('G1 Hospital corridor join ratio matches the §15 measured baseline (buckets=336 joined=15, ~4.5%) — NOT a target, the documented starting point for the next threshold-tuning session',
+  hospital.stats.buckets === 336 && hospital.stats.joined === 15,
+  'buckets=' + hospital.stats.buckets + ' joined=' + hospital.stats.joined + ' ratio=' + hospital.ratio.toFixed(1) + '%');
+chk('G2 Hospital chain count matches the §15 baseline (11 chains formed from those 15 joined buckets)',
+  hospital.stats.chains === 11, 'chains=' + hospital.stats.chains);
+
+// ── Regression guard: Clinic/HHS's CURRENT join ratios must hold. A join-threshold change that
+// helps Hospital by accidentally over-joining unrelated wall segments elsewhere would show up here
+// as a ratio INCREASE past what real corridor geometry supports — flag any drop below today's
+// measured floor as a regression on buildings whose witnesses already pass. ──
+chk('G3 Clinic join ratio has not regressed below its §15-measured baseline (33.6%)',
+  clinic.ratio >= 33.6 - 0.5, 'ratio=' + clinic.ratio.toFixed(1) + '%');
+chk('G4 HHS join ratio has not regressed below its §15-measured baseline (38.5%)',
+  hhs.ratio >= 38.5 - 0.5, 'ratio=' + hhs.ratio.toFixed(1) + '%');
+
+// ── The actual finding this witness exists to prove: Hospital's ratio is dramatically worse than
+// either building whose routing already works, i.e. this is a real geometry-recognition gap, not
+// noise from a small sample. ──
+chk('G5 Hospital join ratio is far below both Clinic and HHS (the real, still-open gap — not a fixed threshold quirk)',
+  hospital.ratio < clinic.ratio / 2 && hospital.ratio < hhs.ratio / 2,
+  'hospital=' + hospital.ratio.toFixed(1) + '% clinic=' + clinic.ratio.toFixed(1) + '% hhs=' + hhs.ratio.toFixed(1) + '%');
+
+console.log('\n§W-HOSPITAL-CORRIDOR-BASELINE DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/witness_hospital_corridor_baseline.js
+++ b/witness_hospital_corridor_baseline.js
@@ -2,15 +2,18 @@
 /**
  * # ⚠ DO NOT REMOVE — W-HOSPITAL-CORRIDOR-BASELINE scope (READ THE LOG after every run)
  * SCOPE: bim-compiler prompts/ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md §15 found Hospital's real wall
- * geometry only joins 15/336 (4.5%) of candidate corridor-wall buckets into a walkBackbone() chain
- * — far below Clinic (33.6%) and HHS (38.5%) — which starves room-to-room routing of a real
+ * geometry only joined 15/336 (4.5%) of candidate corridor-wall buckets into a walkBackbone()
+ * chain — far below Clinic (33.6%) and HHS (38.5%) — which starved room-to-room routing of a real
  * corridor to hug on most inter-wing paths (user-reported: "Hospital corridors not accurate and
- * hampers room to room paths"). This witness is a BASELINE CAPTURE, not a fix: it exists so the
- * NEXT session can loosen walkBackbone()'s join thresholds and prove the change on TWO axes at
- * once from ONE run — (a) Hospital's join ratio must MEASURABLY IMPROVE past this file's recorded
- * floor, not just "still pass", and (b) Clinic/HHS's join ratios must not regress below their
- * CURRENT measured values, which this file also pins. Do not raise the Hospital floor without a
- * real re-measurement — that would silently launder the still-open bug.
+ * hampers room to room paths"). §16 (2026-07-15) traced this to `correlateDoorEdges()`'s
+ * fixed-rounding-grid bucketing splitting doors that were geometrically close together whenever
+ * their raw runCoords straddled a grid boundary — a pure artifact of the grid's fixed phase, not a
+ * real signal — and replaced it with single-linkage gap clustering (see that function's own
+ * §GAP-CLUSTER-BUCKETING comment in common/hallway_backbone.js). This witness now GUARDS that fix:
+ * Hospital's join ratio must stay at least at its new measured floor (not regress back toward
+ * 4.5%), and Clinic/HHS must not regress below THEIR new floors either — a further threshold
+ * change that helps one building by over-joining unrelated segments elsewhere would show up as an
+ * implausible ratio jump past what real corridor geometry supports.
  * RUN: node witness_hospital_corridor_baseline.js   (from the worktree root)
  */
 'use strict';
@@ -36,23 +39,25 @@ const hospital = measure('Hospital', '/home/red1/bim-ootb/buildings/Hospital_ext
 const clinic = measure('Clinic', '/home/red1/bim-ootb/buildings/Clinic_extracted.db');
 const hhs = measure('HHS', '/home/red1/bim-ootb/buildings/HHS_Office_Federated_extracted.db');
 
-// ── Hospital: document the CURRENT broken state as a floor, not a target. Measured 2026-07-15:
-// buckets=336 joined=15 (4.5%). Any threshold tuning must push this ratio UP — if a future run
-// still lands at or below this floor, the fix did not actually help Hospital's real geometry. ──
-chk('G1 Hospital corridor join ratio matches the §15 measured baseline (buckets=336 joined=15, ~4.5%) — NOT a target, the documented starting point for the next threshold-tuning session',
-  hospital.stats.buckets === 336 && hospital.stats.joined === 15,
+// ── Hospital: §16's gap-cluster-bucketing fix (common/hallway_backbone.js correlateDoorEdges())
+// measured 2026-07-15: buckets=241 joined=43 (17.8%), up from the pre-fix 336/15 (4.5%) — a real
+// ~4x improvement, not a threshold loosening. This is now a FLOOR: a future change must not push
+// Hospital's ratio back down toward the old 4.5%, and should only raise this floor alongside a
+// fresh, real re-measurement (never bump the number without rerunning this file first). ──
+chk('G1 Hospital corridor join ratio at least matches the §16 post-fix baseline (buckets=241 joined=43, ~17.8%) — a floor, not a ceiling',
+  hospital.stats.joined >= 43 && hospital.ratio >= 17.8 - 0.5,
   'buckets=' + hospital.stats.buckets + ' joined=' + hospital.stats.joined + ' ratio=' + hospital.ratio.toFixed(1) + '%');
-chk('G2 Hospital chain count matches the §15 baseline (11 chains formed from those 15 joined buckets)',
-  hospital.stats.chains === 11, 'chains=' + hospital.stats.chains);
+chk('G2 Hospital chain count at least matches the §16 post-fix baseline (16 chains)',
+  hospital.stats.chains >= 16, 'chains=' + hospital.stats.chains);
 
-// ── Regression guard: Clinic/HHS's CURRENT join ratios must hold. A join-threshold change that
-// helps Hospital by accidentally over-joining unrelated wall segments elsewhere would show up here
-// as a ratio INCREASE past what real corridor geometry supports — flag any drop below today's
-// measured floor as a regression on buildings whose witnesses already pass. ──
-chk('G3 Clinic join ratio has not regressed below its §15-measured baseline (33.6%)',
-  clinic.ratio >= 33.6 - 0.5, 'ratio=' + clinic.ratio.toFixed(1) + '%');
-chk('G4 HHS join ratio has not regressed below its §15-measured baseline (38.5%)',
-  hhs.ratio >= 38.5 - 0.5, 'ratio=' + hhs.ratio.toFixed(1) + '%');
+// ── Regression guard: Clinic/HHS's §16 post-fix join ratios must hold too — the SAME fix improved
+// both (33.6%->42.3%, 38.5%->48.4%), so these are their new floors. A further threshold change
+// that helps one building by over-joining unrelated wall segments elsewhere would show up here as
+// an implausible ratio jump, not just a drop — flag either direction as worth a second look. ──
+chk('G3 Clinic join ratio has not regressed below its §16 post-fix baseline (42.3%)',
+  clinic.ratio >= 42.3 - 0.5, 'ratio=' + clinic.ratio.toFixed(1) + '%');
+chk('G4 HHS join ratio has not regressed below its §16 post-fix baseline (48.4%)',
+  hhs.ratio >= 48.4 - 0.5, 'ratio=' + hhs.ratio.toFixed(1) + '%');
 
 // ── The actual finding this witness exists to prove: Hospital's ratio is dramatically worse than
 // either building whose routing already works, i.e. this is a real geometry-recognition gap, not


### PR DESCRIPTION
## Summary
- New `witness_hospital_corridor_baseline.js`: regression net that pins Hospital's corridor join-ratio as a floor (was previously unmeasured) and pins Clinic/HHS ratios as floors so a threshold change can't help Hospital by regressing the other two.
- Root cause fix: `correlateDoorEdges()`'s fixed-rounding grid bucketed two doors into different buckets whenever they straddled a grid boundary, even when genuinely close in real space. Replaced with single-linkage gap clustering (same tolerance, no threshold loosened). Measured: Hospital join ratio 4.5%→17.8% (chains 11→16, real corridor-hop edges 4→37), Clinic 33.6%→42.3%, HHS 38.5%→48.4% — all three improved, not a Hospital-only trade-off.
- Corridor classifier now requires doors from ≥2 distinct neighbor rooms (AND-combined with existing aspect-ratio/overlap gates) — drops narrow dead-end slivers that were passing the old shape-only test. Measured: Clinic 9→3, LTU_AHouse 36→21 false positives dropped, HHS unaffected (its entries come from a separate backprop mechanism). `witness_corridor_type_label.js` gained 2 assertions.
- Chain-to-chain stair bridge (`CIRC` node with edges on both sides, both kind `E6`) now renders its own real (cx,cy) instead of collapsing to a duplicate/misleading point — fixes visible "path cuts through open space" x-crossings on long corridors. Narrowed to E6-both-sides only after a broader first attempt regressed the cross-floor stair case (caught by witness, reverted to the narrow guard).
- Room-cuboid selected-room fill now shines through in X-Ray mode (`sortObjects=false` made three.js ignore `renderOrder`) — fixed by reordering so the cuboid draws after the drill-select overlay, not before.

## Test plan
- [x] `witness_hospital_corridor_baseline.js` 5/5 (G1-G4 pin current ratios as floors, G5 asserts Hospital's gap vs Clinic/HHS)
- [x] `witness_backbone_routing.js` 10/10
- [x] `witness_hallway_backbone.js` 7/7
- [x] `witness_corridor_room_backprop.js` 5/5
- [x] `witness_full_connectivity.js` 6/6
- [x] `witness_corridor_type_label.js` 5/5 (was 3/3, +2 new assertions)
- [x] `witness_stair_flight_assembly_merge.js` 4/4
- [x] `witness_room_graph_path.js` 15/15
- [x] Room-cuboid X-Ray shine-through verified live via Playwright + console inspection

Known open item, not addressed here: Hospital's 17.8% ratio is still well below Clinic/HHS's ~45% — remaining gap is genuine wing-to-wing corridor segments with no detected walkway between them, real building geometry not a bucketing artifact. Tracked in `bim-compiler/prompts/ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md` §19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)