### PR TITLE
feat(viewer): Alt+S still-refine — progressive TAA supersample on idle

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -134,12 +134,9 @@ async function setupEffects(A, renderer, scene, camera) {
   A.toggleStillRefine = function() {
     if (A._stillRefineActive) A.stopStillRefine(); else A.startStillRefine();
   };
-  // Any real interaction already routes through A.markDirty() (main.js) — chain onto it so
-  // a still-in-progress refine cancels the instant the user touches the canvas, same guarantee
-  // the user asked for ("touching canvas will disable/disappear").
-  var _origMarkDirty = A.markDirty;
-  A.markDirty = function() {
-    if (A._stillRefineActive) A.stopStillRefine();
-    if (_origMarkDirty) _origMarkDirty();
-  };
+  // §STILL_REFINE cancellation lives in main.js, on the actual pointerdown/wheel/controls-start
+  // signals — NOT here on markDirty. Confirmed live (2026-07-15, real user) that markDirty fires
+  // from far more than "user touched the canvas" (e.g. the history bar's own event-sniffer
+  // refreshing itself right after logging the very Alt+S keypress that started the refine),
+  // which self-cancelled the refine within the same keypress. Precise interaction signals only.
 }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -101,6 +101,20 @@ async function setupEffects(A, renderer, scene, camera) {
   A._stillRefineActive = false;
   var _stillRefineRAF = null;
   var _stillRefinePrevComposerEnabled = false;
+  // §STILL_REFINE_TEARDOWN (2026-07-15, real-user bug): natural completion used to skip this —
+  // A._taaPass.accumulate stayed true and A._composerEnabled stayed forced-on forever afterward,
+  // so every subsequent normal render kept re-painting the FROZEN accumulated image instead of a
+  // fresh live frame (accumulateIndex>=16 short-circuits TAARenderPass's sampling loop but still
+  // re-blends the stale _sampleRenderTarget). That's exactly the "blurred/multi-shot after moving
+  // the camera" the user hit live. Both the done-path and the cancel-path must reset the SAME
+  // state — only the log line differs.
+  function _teardownStillRefine(reason) {
+    A._stillRefineActive = false;
+    if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
+    if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
+    A._composerEnabled = _stillRefinePrevComposerEnabled;
+    console.log('§STILL_REFINE ' + reason);
+  }
   A.startStillRefine = function() {
     if (!A._composer || !A._taaPass || A._stillRefineActive) return;
     A._stillRefineActive = true;
@@ -113,23 +127,14 @@ async function setupEffects(A, renderer, scene, camera) {
       if (!A._stillRefineActive) return;
       A._composer.render();
       var idx = A._taaPass.accumulateIndex;
-      if (idx >= 16) {
-        A._stillRefineActive = false;
-        _stillRefineRAF = null;
-        console.log('§STILL_REFINE done accumulateIndex=' + idx);
-        return;
-      }
+      if (idx >= 16) { _teardownStillRefine('done accumulateIndex=' + idx); return; }
       _stillRefineRAF = requestAnimationFrame(step);
     }
     _stillRefineRAF = requestAnimationFrame(step);
   };
   A.stopStillRefine = function() {
     if (!A._stillRefineActive) return;
-    A._stillRefineActive = false;
-    if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
-    if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
-    A._composerEnabled = _stillRefinePrevComposerEnabled;
-    console.log('§STILL_REFINE cancelled (interaction)');
+    _teardownStillRefine('cancelled (interaction)');
   };
   A.toggleStillRefine = function() {
     if (A._stillRefineActive) A.stopStillRefine(); else A.startStillRefine();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -22,10 +22,11 @@ async function setupEffects(A, renderer, scene, camera) {
   }
 
   try {
-    // §S277c: Parallel import — all 5 addons load concurrently, not sequentially
-    var [_ecMod, _rpMod, _ssaoMod, _outMod, _opMod] = await Promise.all([
+    // §S277c: Parallel import — all 6 addons load concurrently, not sequentially
+    var [_ecMod, _rpMod, _taaMod, _ssaoMod, _outMod, _opMod] = await Promise.all([
       import('./lib/EffectComposer.js'),
       import('./lib/RenderPass.js'),
+      import('./lib/TAARenderPass.js'),
       import('./lib/SSAOPass.js'),
       import('./lib/OutlinePass.js'),
       import('./lib/OutputPass.js')
@@ -35,8 +36,12 @@ async function setupEffects(A, renderer, scene, camera) {
     _composer.setSize(window.innerWidth, window.innerHeight);
     _composer.setPixelRatio(renderer.getPixelRatio());
 
-    // Pass 1: Base scene render
-    var _renderPass = new _rpMod.RenderPass(scene, camera);
+    // §NIGHT-STILL-REFINE (2026-07-15, user ask): Pass 1 is a TAARenderPass instead of a plain
+    // RenderPass — with `.accumulate=false` (default) it behaves identically to RenderPass, zero
+    // added cost during normal navigation. `A.startStillRefine()` below flips accumulate=true and
+    // drives 16 jittered-camera accumulation samples across idle frames to build a crisp
+    // supersampled still; any interaction (markDirty, wrapped below) cancels it immediately.
+    var _renderPass = new _taaMod.TAARenderPass(scene, camera);
     _composer.addPass(_renderPass);
 
     // Pass 2: SSAO — contact shadows in room corners, pipe junctions
@@ -67,7 +72,8 @@ async function setupEffects(A, renderer, scene, camera) {
     A._ssaoPass = _ssaoPass;
     A._outlinePass = _outlinePass;
     A._renderPass = _renderPass;
-    console.log('§EFFECTS_INIT loaded — RenderPass + SSAO + Outline + Output');
+    A._taaPass = _renderPass;
+    console.log('§EFFECTS_INIT loaded — TAARenderPass + SSAO + Outline + Output');
   } catch(e) {
     console.warn('§EFFECTS_INIT_FAIL ' + e.message + ' — falling back to direct render');
     A._composer = null;
@@ -88,5 +94,52 @@ async function setupEffects(A, renderer, scene, camera) {
     if (color) A._outlinePass.visibleEdgeColor.set(color);
     A._outlinePass.enabled = objects && objects.length > 0;
     A._composerEnabled = A._outlinePass.enabled || (A._ssaoPass && A._ssaoPass.enabled);
+  };
+
+  // §NIGHT-STILL-REFINE (2026-07-15, user ask): progressive TAA still — accumulates 16 jittered
+  // samples across idle frames into a crisp supersampled image, cancels on any interaction.
+  A._stillRefineActive = false;
+  var _stillRefineRAF = null;
+  var _stillRefinePrevComposerEnabled = false;
+  A.startStillRefine = function() {
+    if (!A._composer || !A._taaPass || A._stillRefineActive) return;
+    A._stillRefineActive = true;
+    _stillRefinePrevComposerEnabled = A._composerEnabled;
+    A._composerEnabled = true;
+    A._taaPass.accumulate = true;
+    A._taaPass.accumulateIndex = -1;
+    console.log('§STILL_REFINE start samples=16');
+    function step() {
+      if (!A._stillRefineActive) return;
+      A._composer.render();
+      var idx = A._taaPass.accumulateIndex;
+      if (idx >= 16) {
+        A._stillRefineActive = false;
+        _stillRefineRAF = null;
+        console.log('§STILL_REFINE done accumulateIndex=' + idx);
+        return;
+      }
+      _stillRefineRAF = requestAnimationFrame(step);
+    }
+    _stillRefineRAF = requestAnimationFrame(step);
+  };
+  A.stopStillRefine = function() {
+    if (!A._stillRefineActive) return;
+    A._stillRefineActive = false;
+    if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
+    if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
+    A._composerEnabled = _stillRefinePrevComposerEnabled;
+    console.log('§STILL_REFINE cancelled (interaction)');
+  };
+  A.toggleStillRefine = function() {
+    if (A._stillRefineActive) A.stopStillRefine(); else A.startStillRefine();
+  };
+  // Any real interaction already routes through A.markDirty() (main.js) — chain onto it so
+  // a still-in-progress refine cancels the instant the user touches the canvas, same guarantee
+  // the user asked for ("touching canvas will disable/disappear").
+  var _origMarkDirty = A.markDirty;
+  A.markDirty = function() {
+    if (A._stillRefineActive) A.stopStillRefine();
+    if (_origMarkDirty) _origMarkDirty();
   };
 }

--- a/viewer/lib/SSAARenderPass.js
+++ b/viewer/lib/SSAARenderPass.js
@@ -1,0 +1,205 @@
+// §S277: Three.js r185 SSAARenderPass — window.THREE instead of ES import
+const { AdditiveBlending, Color, HalfFloatType, ShaderMaterial, UniformsUtils, WebGLRenderTarget } = window.THREE;
+import { Pass, FullScreenQuad } from './Pass.js';
+import { CopyShader } from './CopyShader.js';
+
+class SSAARenderPass extends Pass {
+
+	constructor( scene, camera, clearColor = 0x000000, clearAlpha = 0 ) {
+
+		super();
+
+		this.scene = scene;
+		this.camera = camera;
+		this.sampleLevel = 4;
+		this.unbiased = true;
+		this.stencilBuffer = false;
+		this.clearColor = clearColor;
+		this.clearAlpha = clearAlpha;
+
+		// internals
+
+		this._sampleRenderTarget = null;
+
+		this._oldClearColor = new Color();
+
+		this._copyUniforms = UniformsUtils.clone( CopyShader.uniforms );
+
+		this._copyMaterial = new ShaderMaterial(	{
+			uniforms: this._copyUniforms,
+			vertexShader: CopyShader.vertexShader,
+			fragmentShader: CopyShader.fragmentShader,
+			transparent: true,
+			depthTest: false,
+			depthWrite: false,
+			premultipliedAlpha: true,
+			blending: AdditiveBlending
+		} );
+
+		this._fsQuad = new FullScreenQuad( this._copyMaterial );
+
+	}
+
+	dispose() {
+
+		if ( this._sampleRenderTarget ) {
+
+			this._sampleRenderTarget.dispose();
+			this._sampleRenderTarget = null;
+
+		}
+
+		this._copyMaterial.dispose();
+
+		this._fsQuad.dispose();
+
+	}
+
+	setSize( width, height ) {
+
+		if ( this._sampleRenderTarget )	this._sampleRenderTarget.setSize( width, height );
+
+	}
+
+	render( renderer, writeBuffer, readBuffer/*, deltaTime, maskActive */ ) {
+
+		if ( ! this._sampleRenderTarget ) {
+
+			this._sampleRenderTarget = new WebGLRenderTarget( readBuffer.width, readBuffer.height, { type: HalfFloatType, stencilBuffer: this.stencilBuffer } );
+			this._sampleRenderTarget.texture.name = 'SSAARenderPass.sample';
+
+		}
+
+		const jitterOffsets = _JitterVectors[ Math.max( 0, Math.min( this.sampleLevel, 5 ) ) ];
+
+		const autoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		renderer.getClearColor( this._oldClearColor );
+		const oldClearAlpha = renderer.getClearAlpha();
+
+		const baseSampleWeight = 1.0 / jitterOffsets.length;
+		const roundingRange = 1 / 32;
+		this._copyUniforms[ 'tDiffuse' ].value = this._sampleRenderTarget.texture;
+
+		const viewOffset = {
+
+			fullWidth: readBuffer.width,
+			fullHeight: readBuffer.height,
+			offsetX: 0,
+			offsetY: 0,
+			width: readBuffer.width,
+			height: readBuffer.height
+
+		};
+
+		const originalViewOffset = Object.assign( {}, this.camera.view );
+
+		if ( originalViewOffset.enabled ) Object.assign( viewOffset, originalViewOffset );
+
+		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
+		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
+
+			const jitterOffset = jitterOffsets[ i ];
+
+			if ( this.camera.setViewOffset ) {
+
+				this.camera.setViewOffset(
+
+					viewOffset.fullWidth, viewOffset.fullHeight,
+
+					viewOffset.offsetX + jitterOffset[ 0 ] * 0.0625, viewOffset.offsetY + jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
+
+					viewOffset.width, viewOffset.height
+
+				);
+
+			}
+
+			let sampleWeight = baseSampleWeight;
+
+			if ( this.unbiased ) {
+
+				const uniformCenteredDistribution = ( - 0.5 + ( i + 0.5 ) / jitterOffsets.length );
+				sampleWeight += roundingRange * uniformCenteredDistribution;
+
+			}
+
+			this._copyUniforms[ 'opacity' ].value = sampleWeight;
+			renderer.setClearColor( this.clearColor, this.clearAlpha );
+			renderer.setRenderTarget( this._sampleRenderTarget );
+			renderer.clear();
+			renderer.render( this.scene, this.camera );
+
+			renderer.setRenderTarget( this.renderToScreen ? null : writeBuffer );
+
+			if ( i === 0 ) {
+
+				renderer.setClearColor( 0x000000, 0.0 );
+				renderer.clear();
+
+			}
+
+			this._fsQuad.render( renderer );
+
+		}
+
+		if ( this.camera.setViewOffset && originalViewOffset.enabled ) {
+
+			this.camera.setViewOffset(
+
+				originalViewOffset.fullWidth, originalViewOffset.fullHeight,
+
+				originalViewOffset.offsetX, originalViewOffset.offsetY,
+
+				originalViewOffset.width, originalViewOffset.height
+
+			);
+
+		} else if ( this.camera.clearViewOffset ) {
+
+			this.camera.clearViewOffset();
+
+		}
+
+		renderer.autoClear = autoClear;
+		renderer.setClearColor( this._oldClearColor, oldClearAlpha );
+
+	}
+
+}
+
+// Jitter vectors on a [-8,8) integer grid, mapped to [-0.5,0.5) by scaling 1/16.
+const _JitterVectors = [
+	[
+		[ 0, 0 ]
+	],
+	[
+		[ 4, 4 ], [ - 4, - 4 ]
+	],
+	[
+		[ - 2, - 6 ], [ 6, - 2 ], [ - 6, 2 ], [ 2, 6 ]
+	],
+	[
+		[ 1, - 3 ], [ - 1, 3 ], [ 5, 1 ], [ - 3, - 5 ],
+		[ - 5, 5 ], [ - 7, - 1 ], [ 3, 7 ], [ 7, - 7 ]
+	],
+	[
+		[ 1, 1 ], [ - 1, - 3 ], [ - 3, 2 ], [ 4, - 1 ],
+		[ - 5, - 2 ], [ 2, 5 ], [ 5, 3 ], [ 3, - 5 ],
+		[ - 2, 6 ], [ 0, - 7 ], [ - 4, - 6 ], [ - 6, 4 ],
+		[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ]
+	],
+	[
+		[ - 4, - 7 ], [ - 7, - 5 ], [ - 3, - 5 ], [ - 5, - 4 ],
+		[ - 1, - 4 ], [ - 2, - 2 ], [ - 6, - 1 ], [ - 4, 0 ],
+		[ - 7, 1 ], [ - 1, 2 ], [ - 6, 3 ], [ - 3, 3 ],
+		[ - 7, 6 ], [ - 3, 6 ], [ - 5, 7 ], [ - 1, 7 ],
+		[ 5, - 7 ], [ 1, - 6 ], [ 6, - 5 ], [ 4, - 4 ],
+		[ 2, - 3 ], [ 7, - 2 ], [ 1, - 1 ], [ 4, - 1 ],
+		[ 2, 1 ], [ 6, 2 ], [ 0, 4 ], [ 4, 4 ],
+		[ 2, 5 ], [ 7, 5 ], [ 5, 6 ], [ 3, 7 ]
+	]
+];
+
+export { SSAARenderPass };

--- a/viewer/lib/TAARenderPass.js
+++ b/viewer/lib/TAARenderPass.js
@@ -1,0 +1,181 @@
+// §S277: Three.js r185 TAARenderPass — window.THREE instead of ES import
+const { HalfFloatType, WebGLRenderTarget } = window.THREE;
+import { SSAARenderPass } from './SSAARenderPass.js';
+
+// Temporal Anti-Aliasing render pass. When there is no motion in the scene, accumulates
+// jittered camera samples across frames to build a high-quality anti-aliased still.
+class TAARenderPass extends SSAARenderPass {
+
+	constructor( scene, camera, clearColor, clearAlpha ) {
+
+		super( scene, camera, clearColor, clearAlpha );
+
+		this.sampleLevel = 0;
+		this.accumulate = false;
+		this.accumulateIndex = - 1;
+
+		// internals
+
+		this._sampleRenderTarget = null;
+		this._holdRenderTarget = null;
+
+	}
+
+	render( renderer, writeBuffer, readBuffer, deltaTime/*, maskActive*/ ) {
+
+		if ( this.accumulate === false ) {
+
+			super.render( renderer, writeBuffer, readBuffer, deltaTime );
+
+			this.accumulateIndex = - 1;
+			return;
+
+		}
+
+		const jitterOffsets = _JitterVectors[ 5 ];
+
+		if ( this._sampleRenderTarget === null ) {
+
+			this._sampleRenderTarget = new WebGLRenderTarget( readBuffer.width, readBuffer.height, { type: HalfFloatType } );
+			this._sampleRenderTarget.texture.name = 'TAARenderPass.sample';
+
+		}
+
+		if ( this._holdRenderTarget === null ) {
+
+			this._holdRenderTarget = new WebGLRenderTarget( readBuffer.width, readBuffer.height, { type: HalfFloatType } );
+			this._holdRenderTarget.texture.name = 'TAARenderPass.hold';
+
+		}
+
+		if ( this.accumulateIndex === - 1 ) {
+
+			super.render( renderer, this._holdRenderTarget, readBuffer, deltaTime );
+
+			this.accumulateIndex = 0;
+
+		}
+
+		const autoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		renderer.getClearColor( this._oldClearColor );
+		const oldClearAlpha = renderer.getClearAlpha();
+
+		const sampleWeight = 1.0 / ( jitterOffsets.length );
+
+		if ( this.accumulateIndex >= 0 && this.accumulateIndex < jitterOffsets.length ) {
+
+			this._copyUniforms[ 'opacity' ].value = sampleWeight;
+			this._copyUniforms[ 'tDiffuse' ].value = writeBuffer.texture;
+
+			// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
+			const numSamplesPerFrame = Math.pow( 2, this.sampleLevel );
+			for ( let i = 0; i < numSamplesPerFrame; i ++ ) {
+
+				const j = this.accumulateIndex;
+				const jitterOffset = jitterOffsets[ j ];
+
+				if ( this.camera.setViewOffset ) {
+
+					this.camera.setViewOffset( readBuffer.width, readBuffer.height,
+						jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
+						readBuffer.width, readBuffer.height );
+
+				}
+
+				renderer.setRenderTarget( writeBuffer );
+				renderer.setClearColor( this.clearColor, this.clearAlpha );
+				renderer.clear();
+				renderer.render( this.scene, this.camera );
+
+				renderer.setRenderTarget( this._sampleRenderTarget );
+				if ( this.accumulateIndex === 0 ) {
+
+					renderer.setClearColor( 0x000000, 0.0 );
+					renderer.clear();
+
+				}
+
+				this._fsQuad.render( renderer );
+
+				this.accumulateIndex ++;
+
+				if ( this.accumulateIndex >= jitterOffsets.length ) break;
+
+			}
+
+			if ( this.camera.clearViewOffset ) this.camera.clearViewOffset();
+
+		}
+
+		renderer.setClearColor( this.clearColor, this.clearAlpha );
+		const accumulationWeight = this.accumulateIndex * sampleWeight;
+
+		if ( accumulationWeight > 0 ) {
+
+			this._copyUniforms[ 'opacity' ].value = 1.0;
+			this._copyUniforms[ 'tDiffuse' ].value = this._sampleRenderTarget.texture;
+			renderer.setRenderTarget( writeBuffer );
+			renderer.clear();
+			this._fsQuad.render( renderer );
+
+		}
+
+		if ( accumulationWeight < 1.0 ) {
+
+			this._copyUniforms[ 'opacity' ].value = 1.0 - accumulationWeight;
+			this._copyUniforms[ 'tDiffuse' ].value = this._holdRenderTarget.texture;
+			renderer.setRenderTarget( writeBuffer );
+			this._fsQuad.render( renderer );
+
+		}
+
+		renderer.autoClear = autoClear;
+		renderer.setClearColor( this._oldClearColor, oldClearAlpha );
+
+	}
+
+	dispose() {
+
+		super.dispose();
+
+		if ( this._holdRenderTarget ) this._holdRenderTarget.dispose();
+
+	}
+
+}
+
+const _JitterVectors = [
+	[
+		[ 0, 0 ]
+	],
+	[
+		[ 4, 4 ], [ - 4, - 4 ]
+	],
+	[
+		[ - 2, - 6 ], [ 6, - 2 ], [ - 6, 2 ], [ 2, 6 ]
+	],
+	[
+		[ 1, - 3 ], [ - 1, 3 ], [ 5, 1 ], [ - 3, - 5 ],
+		[ - 5, 5 ], [ - 7, - 1 ], [ 3, 7 ], [ 7, - 7 ]
+	],
+	[
+		[ 1, 1 ], [ - 1, - 3 ], [ - 3, 2 ], [ 4, - 1 ],
+		[ - 5, - 2 ], [ 2, 5 ], [ 5, 3 ], [ 3, - 5 ],
+		[ - 2, 6 ], [ 0, - 7 ], [ - 4, - 6 ], [ - 6, 4 ],
+		[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ]
+	],
+	[
+		[ - 4, - 7 ], [ - 7, - 5 ], [ - 3, - 5 ], [ - 5, - 4 ],
+		[ - 1, - 4 ], [ - 2, - 2 ], [ - 6, - 1 ], [ - 4, 0 ],
+		[ - 7, 1 ], [ - 1, 2 ], [ - 6, 3 ], [ - 3, 3 ],
+		[ - 7, 6 ], [ - 3, 6 ], [ - 5, 7 ], [ - 1, 7 ],
+		[ 5, - 7 ], [ 1, - 6 ], [ 6, - 5 ], [ 4, - 4 ],
+		[ 2, - 3 ], [ 7, - 2 ], [ 1, - 1 ], [ 4, - 1 ],
+		[ 2, 1 ], [ 6, 2 ], [ 0, 4 ], [ 4, 4 ],
+		[ 2, 5 ], [ 7, 5 ], [ 5, 6 ], [ 3, 7 ]
+	]
+];
+
+export { TAARenderPass };

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -662,6 +662,13 @@ async function initViewer() {
   var _orbitDPR = window._isMobile ? 0.75 : Math.min(_fullDPR, 1);  // §S274: mobile=0.75x during drag
   var _orbiting = false;
   APP.controls.addEventListener('start', function() {
+    // §STILL_REFINE: a real drag/touch beginning is the "touching canvas" signal the still-refine
+    // spec asked for — cancel here, NOT from the generic _startLoop choke point (that also fires
+    // from keydown/markDirty on things unrelated to touching the canvas, e.g. the history bar's
+    // own event-sniffer refreshing itself right after logging the Alt+S keypress that started the
+    // refine — confirmed live, 2026-07-15: start->cancelled within the same event, nothing the
+    // user actually touched in between).
+    if (APP._stillRefineActive && typeof APP.stopStillRefine === 'function') APP.stopStillRefine();
     _startLoop(); // §IDLE-PARK: drag begins → revive the loop if parked
     if (!_orbiting && APP.streamedCount > 5000) {
       _orbiting = true;
@@ -684,11 +691,6 @@ async function initViewer() {
   // guarantees exactly ONE rAF chain — fixes the S287 focus/pageshow + async-init double-loop
   // (which ran render twice per frame). Witness: §RENDER_LOOP start total= must stay 1.
   function _startLoop() {
-    // §STILL_REFINE: _startLoop is the universal choke point every interaction path funnels
-    // through (pointerdown/wheel/keydown/controls-change all call it directly, markDirty calls
-    // it too) — cancel a still-in-progress TAA refine here, not just via markDirty, so a plain
-    // click/drag that never sets _needsRender through markDirty still cancels it correctly.
-    if (APP._stillRefineActive && typeof APP.stopStillRefine === 'function') APP.stopStillRefine();
     if (_rafId) return;                       // already running — never double
     _loopStarts++;
     _needsRender = true;
@@ -709,8 +711,11 @@ async function initViewer() {
   // §IDLE-PARK: belt-and-suspenders — ANY user input revives a parked loop, regardless of
   // which feature it triggers (fly/walk/streaming started by a click after idle). _startLoop
   // is guarded, and these fire only on real interaction, so a truly idle scene stays parked.
-  window.addEventListener('pointerdown', _startLoop);
-  window.addEventListener('wheel', _startLoop, { passive: true });
+  // §STILL_REFINE: cancel on the actual touch/scroll signal — deliberately NOT on keydown (that
+  // fires for every key including Alt+S itself, and for incidental logging-triggered wakes).
+  function _cancelStillRefine() { if (APP._stillRefineActive && typeof APP.stopStillRefine === 'function') APP.stopStillRefine(); }
+  window.addEventListener('pointerdown', function() { _cancelStillRefine(); _startLoop(); });
+  window.addEventListener('wheel', function() { _cancelStillRefine(); _startLoop(); }, { passive: true });
   window.addEventListener('keydown', _startLoop);
   // §S276: WebGPURenderer compiles shader pipelines per material. On 122K scenes with 100+
   // materials, synchronous compilation during render() times out the main thread.

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -684,6 +684,11 @@ async function initViewer() {
   // guarantees exactly ONE rAF chain — fixes the S287 focus/pageshow + async-init double-loop
   // (which ran render twice per frame). Witness: §RENDER_LOOP start total= must stay 1.
   function _startLoop() {
+    // §STILL_REFINE: _startLoop is the universal choke point every interaction path funnels
+    // through (pointerdown/wheel/keydown/controls-change all call it directly, markDirty calls
+    // it too) — cancel a still-in-progress TAA refine here, not just via markDirty, so a plain
+    // click/drag that never sets _needsRender through markDirty still cancels it correctly.
+    if (APP._stillRefineActive && typeof APP.stopStillRefine === 'function') APP.stopStillRefine();
     if (_rafId) return;                       // already running — never double
     _loopStarts++;
     _needsRender = true;

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1768,6 +1768,9 @@ async function setupScene(A) {
     // Alt+Z = 3-state cycle Off→X-Ray→Bbox→Off (Blender Alt+Z convention, extended). Alt+X
     // deleted — merged into this single cycle, see A.cycleXrayBboxMode (tools.js).
     if (e.altKey && (e.key === 'z' || e.key === 'Z')) { e.preventDefault(); if (typeof A.cycleXrayBboxMode === 'function') A.cycleXrayBboxMode(); console.log('§KBD_ROUTE Alt+Z → xray-cycle'); if (window.S) window.S('KBD_ROUTE', 'Alt+Z → xray-cycle', { xray: true }); return; }
+    // Alt+S = still-refine — progressive TAA supersample of the current camera view (2026-07-15,
+    // user ask). Cancels itself on any interaction via the A.markDirty() wrap in effects.js.
+    if (e.altKey && (e.key === 's' || e.key === 'S')) { e.preventDefault(); if (typeof A.toggleStillRefine === 'function') A.toggleStillRefine(); console.log('§KBD_ROUTE Alt+S → still-refine'); return; }
     if (e.key === 'F1') { e.preventDefault(); console.log('§KBD_ROUTE F1 → help'); showCommandPalette(); return; }
     if (e.key === 'F11') { e.preventDefault(); console.log('§KBD_ROUTE F11 → fullscreen'); A.toggleFullscreen(); return; }
     // Ctrl/Cmd+S = Save Building, Ctrl/Cmd+O = Open Building — preventDefault suppresses the browser's


### PR DESCRIPTION
## Summary
- Idle-only, opt-in still-render mode (`Alt+S`): 16-sample jittered-camera TAA accumulation for a crisp supersampled still. Zero cost during normal navigation — `TAARenderPass.accumulate` defaults false, identical to a plain `RenderPass` until triggered.
- Two real bugs found via live user testing this session, both fixed:
  1. Cancellation was hooked on the generic `_startLoop()`/`markDirty()` choke points, which fire from far more than actual canvas interaction — self-cancelled on its own trigger keypress. Moved to the precise pointerdown/wheel/controls-start signals in `main.js`.
  2. Natural completion never reset `accumulate`/`_composerEnabled`, leaving the composer frozen on the stale accumulated image after the camera moved. Both paths now share one `_teardownStillRefine()`.

Cherry-picked from `fix/night-mode-window-glow` onto fresh `main` (night-mode itself already merged via #798; this branch had since accumulated the still-refine work on top, which was never in a PR).

## Test plan
- [x] Verified live via headless Chrome (`§EFFECTS_INIT loaded — TAARenderPass + SSAO + Outline + Output`, `§STILL_REFINE start samples=16` → `§STILL_REFINE done accumulateIndex=16`, clean teardown)
- [x] `node --check` on effects.js/main.js; TAA/SSAA render pass modules confirmed loading in-browser (ES modules, not node-checkable directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)