### PR TITLE
fix(viewer): Find-panel tab freeze on large buildings — skip expensive parentSet SOLID overlay in shell mode

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -3287,7 +3287,23 @@
         // §SLIDING-WINDOW: ghost shell = far context. Keep ONLY the immediate parent SOLID (peers of an
         // item / the floor of a layer); the selection draws solid+highlighted on top. Grandparent+ drop
         // into the shell. Hide the base (shell covers it), NO x-ray. Drill deeper → window slides down.
-        if (parentSet) layers.push({ set: parentSet, op: 1.0 });   // immediate parent SOLID
+        // §PERF-FREEZE-FIX (2026-07-16): a whole-storey parentSet drawn SOLID means _buildShapeMeshes
+        // clones a real (often shader-perturbed via onBeforeCompile — see streaming.js _getMaterial)
+        // material per unique hash/class group for EVERY element in it, fresh on every tap (never
+        // cached) — cheap for a handful of peers, but on a large building's storey (thousands of
+        // elements, many disciplines) this clone storm is what froze the tab (live user report:
+        // "Script terminated by timeout" stack landing inside _buildShapeMeshes's clone loop, fired
+        // from this exact RAF1 ancestor-layer build on a Find-panel room/corridor tap on Terminal).
+        // _shell mode now auto-triggers for large buildings (`_isLargeBuilding()` above), so this
+        // path — previously reached mostly via manual Alt+X or mobile on SMALL buildings, where a
+        // storey-sized parentSet is small too — now fires on EVERY Find-panel tap on Terminal/
+        // Hospital, where a storey can be thousands of elements. The ghost shell already IS "the far
+        // context" per this block's own comment above, so skip the redundant expensive solid draw
+        // once parentSet is too big to be cheap — reusing the SAME 1500-element fast-path cutoff
+        // `_buildShapeMeshes` itself already uses for its row-query threshold (line ~1667) rather
+        // than inventing a new number. Small parentSets (mobile-bbox-shell on a normal-size building)
+        // keep the existing solid-parent behavior unchanged — this only skips the large case that froze.
+        if (parentSet && parentSet.size <= 1500) layers.push({ set: parentSet, op: 1.0 });   // immediate parent SOLID (small only)
         if (A.filterByGuids) A.filterByGuids(new Set());           // hide base — shell is the surroundings
         baseOp = 'shell';
       } else {


### PR DESCRIPTION
## Summary
- `_drillSelect`'s ghost-shell branch (`navigate_find.js`) was drawing the tapped room's whole storey as a SOLID overlay — cloning a real (often shader-perturbed) material per unique discipline/class group, fresh on every tap, uncached. On large buildings (Terminal, Hospital) this is what produced the live "Script terminated by timeout" freeze reported by the user.
- `#796`/§14 made ghost-shell mode auto-trigger for buildings over 25,000 elements, which is what exposed this month-old latent cost on every Find-panel room/corridor tap.
- Fix: skip that SOLID parent overlay when the parent set is large (>1500 elements, same threshold `_buildShapeMeshes` already uses internally), relying on the already-active ghost shell for context instead. Small parent sets (mobile-bbox-shell on normal buildings) are unchanged.

## Test plan
- [x] `node --check viewer/navigate_find.js` — clean
- [x] Full Playwright run against local `HHS_Office_Federated_extracted.db`: open Find panel, cycle Storey→Disc→Room axis, 15 tree-row clicks — zero errors, zero hangs
- [x] Reproduced the exact reported freeze locally against the real Terminal DB (48,428 elements): tapped the same room (`≈ Aras 01 R1` / `RM_Aras_01_1`) from the user's original report. Before the fix: click → `§INSTROWS_CACHED rows=48428` (full-building join) → dead silence. After the fix: click → `§ROOM_HIGHLIGHT` fires immediately → `§INSTROWS_SET rows=6 of set=6 (direct, no full join)` — the expensive path never runs. Page stayed alive/responsive through a 30s observation window, zero page errors.
- [ ] User to spot-check live against the deployed viewer once merged

Full writeup: `bim-compiler` repo, `prompts/ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md` §25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)