### PR TITLE
fix(viewer): Find-panel select hang on large buildings — shader in material.userData made every clone JSON-serialize GLSL+textures

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -960,7 +960,9 @@ async function setupEffects(A, renderer, scene, camera) {
           '  diffuseColor.rgb *= mix(1.0, 0.72, wetness);',  // wet patches read darker/more saturated
           '}'
         ].join('\n'));
-      mat.userData.puddleShader = shader;
+      // §TRIPLANAR_CLONE_BOMB (see streaming.js): plain property, never userData — userData is
+      // JSON-round-tripped by Material.copy() on every clone.
+      mat._puddleShader = shader;
       shader.uniforms.uPuddleActive.value = A._stillRefineActive ? 1.0 : 0.0;
       _applyPuddleUniforms(shader);
     };
@@ -968,7 +970,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // this session for the triplanar shader (§TRIPLANAR_RECOMPILE_FIX) — re-assert every frame
     // instead of relying on a single push at compile time.
     mat.onBeforeRender = function() {
-      var sh = mat.userData.puddleShader;
+      var sh = mat._puddleShader;
       if (sh) { sh.uniforms.uPuddleActive.value = A._stillRefineActive ? 1.0 : 0.0; _applyPuddleUniforms(sh); }
     };
     mat.needsUpdate = true;

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -562,7 +562,12 @@ function setupStreaming(A) {
             '  roughnessFactor *= mix(0.6, 1.4, triRough);',
             '}'
           ].join('\n'));
-        mat.userData.triplanarShader = shader;
+        // §TRIPLANAR_CLONE_BOMB: plain property, NEVER mat.userData — Material.copy() deep-copies
+        // userData via JSON.parse(JSON.stringify(...)), so a shader stored there made every
+        // material.clone() (_buildShapeMeshes on any Find-panel select) serialize the full GLSL
+        // source + every uniform INCLUDING textures/envMap — a multi-second main-thread stall per
+        // tap on a large building (live LTU hang, 2026-07-16). A clone recompiles fresh anyway.
+        mat._triplanarShader = shader;
         // §TRIPLANAR_RECOMPILE_FIX: three.js can silently recompile a material's program
         // (fresh onBeforeCompile call, fresh default-valued uniforms) in response to renderer
         // state changes — observed here on the very first still-refine frame, which reset
@@ -574,7 +579,7 @@ function setupStreaming(A) {
         shader.uniforms.uPaintSeed.value = A._photoPaintSeed || 0;
       };
       mat.onBeforeRender = function() {
-        var sh = mat.userData.triplanarShader;
+        var sh = mat._triplanarShader;
         if (sh) {
           sh.uniforms.uTriActive.value = A._stillRefineActive ? 1.0 : 0.0;
           sh.uniforms.uPaintSeed.value = A._photoPaintSeed || 0;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v766';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v767';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -816,7 +816,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=1" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
@@ -826,7 +826,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=51" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=53" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=54" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=7" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
## Regression (from #805, 2026-07-15 22:46)
The triplanar recompile-fix stored the live compiled shader in `mat.userData.triplanarShader`. three's `Material.copy()` deep-copies userData via `JSON.parse(JSON.stringify(...))` — so every `material.clone()`, which `_buildShapeMeshes` does per unique material on **every Find-panel selection**, serialized the full GLSL source + every uniform **including textures and the envMap render-target**.

User's live LTU log (2026-07-16, Firefox): tap "Plan 1" → `§INSTROWS_CACHED rows=122330` → `THREE.Texture: Unable to serialize Texture.` ×118 → hang. Reproduced on Duplex with a prototype-instrumented probe; stack: `Material.copy → JSON.stringify ← _buildShapeMeshes (navigate_find.js:1756/3347)`.

## Fix
Plain properties (`mat._triplanarShader` / `mat._puddleShader`) — `Material.copy()` never touches ad-hoc properties, and a clone recompiles fresh via its own `onBeforeCompile` anyway. 2+2 sites, repo-wide grep confirms no other references.

## Witness
Same probe on the fixed tree: **zero** toJSON calls / serialize warnings; `§STOREY_SELECT` output byte-identical to the broken run (`focus=50 solid=50 hl=47 overlays=47`) + `§FIND_COST` intact. Cache-busts: streaming v53→54, effects v1→2, sw v766→v767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)