### PR TITLE
Fly tour round 6 — corridor-spine itinerary, type dedupe, per-storey budget, stair-flight climbs

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v773';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v774';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v9 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v10 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -189,7 +189,6 @@ function setupTour(A) {
     const g = A.getRoomGraph();
     if (!g || !g.nodes || g.nodes.length < 2) return null;
 
-    const K = 4;
     // Bucket rooms by storey. Corridors (backprop 'Hall / Corridor' nodes + compiled
     // SUSPECT_ELONGATED — a real corridor is usually one of these, see spec §R4) become cruise
     // stops; other SUSPECT_* rooms are never destinations (§ROOM-FORM: review candidates).
@@ -206,6 +205,9 @@ function setupTour(A) {
       stN[n.storey] = (stN[n.storey] || 0) + 1;
     }
     const storeys = Object.keys(byStorey).sort((a, b) => stZSum[a] / stN[a] - stZSum[b] / stN[b]);
+    // §R6-BUDGET (Hospital live-report: "lingers too long on first floor"): rooms per storey
+    // scale DOWN as storey count grows — tall buildings get a tighter, corridor-dominant tour.
+    const K = storeys.length >= 4 ? 2 : storeys.length === 3 ? 3 : 4;
 
     // Entrance: the lowest exit node (E4 — a real non-room door), when the building has one.
     let entrance = null;
@@ -224,25 +226,53 @@ function setupTour(A) {
     // the edge set to be routable AT ALL; isolated nodes are dropped up front.
     const edgeGuids = {};
     for (const e of g.edges) { edgeGuids[e.a] = true; edgeGuids[e.b] = true; }
-    let isolatedDropped = 0;
+    // §R6-TYPE-DEDUPE (user: "not go to same type of rooms"): real IfcSpace names carry the
+    // room's function (Ward, WC, Office…) — visit the FIRST of each name-type only, tour-wide.
+    // Compiled rooms (object_type COMPILED, names like "R28") carry no semantic type → exempt.
+    const seenType = {};
+    function typeToken(n) {
+      if (String(n.label || '').indexOf('COMPILED') >= 0) return null;
+      const t = String(n.name || '').toLowerCase().replace(/[0-9]+/g, ' ')
+        .replace(/[^a-zÀ-￿ ]+/g, ' ').replace(/\s+/g, ' ').trim();
+      return t.length >= 2 ? t : null;
+    }
+    let isolatedDropped = 0, typeDeduped = 0;
     const stops = [];
     for (const st of storeys) {
       const b = byStorey[st];
       b.corridors.sort((a, c) => c.area - a.area);
       b.rooms.sort((a, c) => c.area - a.area);
-      const picks = (b.corridors.length ? [b.corridors[0]] : []).concat(b.rooms.slice(0, K));
+      // §R6-CORRIDOR-SPINE (user: "stick more to long corridors and hallways"): corridors are
+      // the tour's spine — up to 3 cruise stops per storey (was 1), rooms are brief detours.
+      const picks = b.corridors.slice(0, 3);
+      let roomsTaken = 0;
+      for (const r of b.rooms) {
+        if (roomsTaken >= K) break;
+        const tok = typeToken(r.node);
+        if (tok && seenType[tok]) { typeDeduped++; continue; }
+        if (tok) seenType[tok] = true;
+        picks.push(r);
+        roomsTaken++;
+      }
       for (const r of picks) {
         if (edgeGuids[r.guid]) stops.push(r);
         else isolatedDropped++;
       }
     }
-    if (isolatedDropped) console.log('[TOUR] §FLY_ROUTE_ISOLATED dropped=' + isolatedDropped);
+    if (isolatedDropped || typeDeduped) console.log('[TOUR] §FLY_ROUTE_ISOLATED dropped=' +
+      isolatedDropped + ' typeDeduped=' + typeDeduped);
     if (!stops.length) { console.log('[TOUR] §FLY_ROUTE_REJECT reason=no-stops → legacy tour'); return null; }
 
-    // §S3 — the largest confirmed room per storey gets the pause + look-around beat.
+    // §S3 — the largest room actually PICKED per storey gets the pause + look-around beat
+    // (§R6: dedupe/budget may drop the storey's largest room; corridors keep moving, no beat).
     const pauseGuids = {};
-    for (const st of storeys) {
-      if (byStorey[st].rooms.length) pauseGuids[byStorey[st].rooms[0].guid] = true;
+    const pausedStorey = {};
+    for (const s of stops) {
+      const st = s.node.storey;
+      if (pausedStorey[st]) continue;
+      if (byStorey[st].corridors.indexOf(s) >= 0) continue;
+      pauseGuids[s.guid] = true;
+      pausedStorey[st] = true;
     }
 
     // Chain the stops through the graph (Dijkstra, legalized — see room_graph.js).
@@ -294,11 +324,23 @@ function setupTour(A) {
     const pts = [];
     const ifcTrail = [];
     let circWps = 0;
+    let prevPg = null, prevN = null;
     for (const pg of pathGuids) {
       const n = g.nodesByGuid[pg];
       if (!n || n.cx === undefined) continue;
       const fz = (n.kind === 'stairwp') ? n.cz : (storeyZ[n.storey] !== undefined ? storeyZ[n.storey] : n.cz);
       const tp = A.ifc2three(n.cx, n.cy, fz);
+      // §R6-STAIR-FLIGHT (user: "really go up stairs"): a lo↔hi hop on the SAME stair gets a
+      // mid-flight point (halfway along the flight's own measured run), so the camera tracks
+      // base → landing → top instead of one smoothed diagonal. Both endpoints are real stairwp
+      // node positions; the midpoint is their measured interpolation, nothing invented.
+      if (n.kind === 'stairwp' && prevN && prevN.kind === 'stairwp' &&
+          String(pg).replace(/::(lo|hi)$/, '') === String(prevPg).replace(/::(lo|hi)$/, '')) {
+        const mtp = A.ifc2three((prevN.cx + n.cx) / 2, (prevN.cy + n.cy) / 2, (prevN.cz + n.cz) / 2);
+        pts.push({ x: mtp.x, y: mtp.y + A.WALK_EYE_HEIGHT, z: mtp.z, name: '', pause: null });
+        ifcTrail.push({ storey: n.storey, cx: (prevN.cx + n.cx) / 2, cy: (prevN.cy + n.cy) / 2, vertical: true });
+      }
+      prevPg = pg; prevN = n;
       if (n.kind === 'doorwp' || n.kind === 'circ' || n.kind === 'spine') circWps++;
       // §HEADS-UP (user 2026-07-16: "moving across storeys, having heads up where are the open
       // spaces"): arriving on a NEW storey up a stair gets a 'storey' look-around beat before
@@ -562,6 +604,9 @@ function setupTour(A) {
       // ═══ Big building: full interior flyPath + finale ═══
       // §S3 — split the spline at each storey's largest room for a pause + look-around beat;
       // no pause marks (legacy route) ⇒ one flyPath exactly as before.
+      // §R6-PACE: flat 3.5 m/s makes a long hospital path a multi-minute crawl — beyond 300m of
+      // interior path, pace up to 4.5 m/s (still walking-film speed, ~22% shorter).
+      const flySpd = pathLen > 300 ? 4.5 : 3.5;
       const splits = pauseIdx.filter((v, i, arr) => v.i > 1 && v.i < flyPts.length - 2 &&
         arr.findIndex(w => w.i === v.i) === i).sort((a, b) => a.i - b.i);
       const segments = [];
@@ -575,7 +620,7 @@ function setupTour(A) {
         for (let i = 1; i < pts.length; i++)
           segLen += Math.hypot(pts[i].x-pts[i-1].x, pts[i].y-pts[i-1].y, pts[i].z-pts[i-1].z);
         actions.push({type:'flyPath', points: pts, names: flyNames.slice(segments[sI].from, segments[sI].to + 1),
-                      duration: Math.max(segLen / 3.5, segments.length === 1 ? 8 : 3)});
+                      duration: Math.max(segLen / flySpd, segments.length === 1 ? 8 : 3)});
         if (sI < segments.length - 1 && segments[sI].beat) {
           // room beat = full survey; storey arrival = shorter heads-up sweep of the open spaces.
           actions.push({type:'pause', seconds: 0.4});

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -831,7 +831,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
-<script src="tour.js?v=9" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
+<script src="tour.js?v=10" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>


### PR DESCRIPTION
Follow-up to #812, from user live-review on Hospital ("lingers too long on first floor", "stick more to long corridors and hallways", "really go up stairs", "not go to same type of rooms"):

- **§R6-BUDGET** — rooms per storey scale down with storey count (4+ storeys → 2, was flat 4): tall buildings stop lingering per floor.
- **§R6-CORRIDOR-SPINE** — up to 3 corridor cruise stops per storey (was 1); corridors are the spine, rooms are brief detours.
- **§R6-TYPE-DEDUPE** — real IfcSpace names dedupe by normalized name-type tour-wide (visit the first Ward, skip the rest); compiled rooms exempt (no semantic names).
- **§R6-STAIR-FLIGHT** — same-stair lo↔hi hops get a measured mid-flight point: the camera tracks base → landing → top instead of a smoothed diagonal.
- **§R6-PACE** — interior paths >300m fly at 4.5 m/s.

## Witnesses (localhost, headless; §-logs)
- Hospital: 22 stops over 7 storeys, **corridorStops=12**, CINE-GRAPH accepted, stream-wait honored
- Terminal: 18→14 stops, corridor cruises 3→5, pts 125→89, stairs up+down intact
- Clinic: 9→7 stops, illegal chords 0/33, ghost=1 shell still gated during tour

🤖 Generated with [Claude Code](https://claude.com/claude-code)