### PR TITLE
fix(viewer): SSGI still-fold ghosting — camera-pose guard + SVGF hard-reset

### DIFF
--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -170,18 +170,50 @@ async function setupGIPoc(A, renderer, scene, camera) {
   // loop park again (zero steady-state cost — same discipline as still-refine's own RAF).
   var SSGI_CONVERGE_FRAMES = 90;   // ~1.5s at 60fps — matches the "settles in 1-2s" acceptance tell
   var _ssgiConvergeLeft = 0, _ssgiConvergeRAF = null, _ssgiOrigMarkDirty = null, _ssgiConvergeDone = null;
+  var _ssgiConvergeFrames = SSGI_CONVERGE_FRAMES, _ssgiConvergeSig = null, _ssgiConvergeRestartLogged = false;
+  // §SSGI_CONVERGE_CAMGUARD (2026-07-17, user-observed ghosting/see-through-floors on real hardware):
+  // this loop used to drive frames blindly with no camera-pose check. effects.js's TAA still-refine
+  // loop has an equivalent guard for the exact same reason (§STILL_REFINE_RESTART comment there) —
+  // OrbitControls inertial damping can still be gliding (no pointer events fire during the glide),
+  // and this app's on-demand render loop only resumes calling controls.update() once something
+  // starts driving frames again, which this converge loop itself does. Blending SSGI's temporal
+  // buffer across a moving viewpoint is exactly what produced the ghosted/doubled geometry and
+  // see-through floors in the reported screenshot — this library's BatchedMesh velocity/reprojection
+  // support is unverified (see §SSGI_PORT comment above), so don't trust reprojection to compensate;
+  // restart the frame budget from scratch on any pose change, same discipline as TAA.
+  function _ssgiCamSig() {
+    if (!camera) return '';
+    var p = camera.position, q = camera.quaternion;
+    return p.x.toFixed(4) + ',' + p.y.toFixed(4) + ',' + p.z.toFixed(4) + ',' +
+           q.x.toFixed(5) + ',' + q.y.toFixed(5) + ',' + q.z.toFixed(5) + ',' + q.w.toFixed(5);
+  }
   function _ssgiKickConverge(frames, onDone) {
-    _ssgiConvergeLeft = frames || SSGI_CONVERGE_FRAMES;
+    _ssgiConvergeFrames = frames || SSGI_CONVERGE_FRAMES;
+    _ssgiConvergeLeft = _ssgiConvergeFrames;
     if (onDone) _ssgiConvergeDone = onDone;  // latch even if a kick loop is already running —
     // the toggle's own markDirty starts a plain kick first, and the fold's onDone must survive it
     if (_ssgiConvergeRAF) return;
     var _driven = 0;
+    _ssgiConvergeSig = _ssgiCamSig();
+    _ssgiConvergeRestartLogged = false;
     (function step() {
       _ssgiConvergeRAF = null;
       if (!A._ssgiActive || _ssgiConvergeLeft <= 0) {
         var cb = _ssgiConvergeDone; _ssgiConvergeDone = null;
         if (cb) { console.log('§SSGI_CONVERGE done framesDriven=' + _driven + ' active=' + A._ssgiActive); cb(); }
         return;
+      }
+      var sigNow = _ssgiCamSig();
+      if (sigNow !== _ssgiConvergeSig) {
+        _ssgiConvergeSig = sigNow;
+        _ssgiConvergeLeft = _ssgiConvergeFrames;
+        _driven = 0;
+        if (!_ssgiConvergeRestartLogged) {
+          console.log('§SSGI_CONVERGE_RESTART cam-moved — accumulation restarted');
+          _ssgiConvergeRestartLogged = true;
+        }
+      } else {
+        _ssgiConvergeRestartLogged = false;
       }
       _ssgiConvergeLeft--; _driven++;
       if (_ssgiOrigMarkDirty) _ssgiOrigMarkDirty.call(A);  // original — the wrap would re-arm the counter

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -171,21 +171,31 @@ async function setupGIPoc(A, renderer, scene, camera) {
   var SSGI_CONVERGE_FRAMES = 90;   // ~1.5s at 60fps — matches the "settles in 1-2s" acceptance tell
   var _ssgiConvergeLeft = 0, _ssgiConvergeRAF = null, _ssgiOrigMarkDirty = null, _ssgiConvergeDone = null;
   var _ssgiConvergeFrames = SSGI_CONVERGE_FRAMES, _ssgiConvergeSig = null, _ssgiConvergeRestartLogged = false;
-  // §SSGI_CONVERGE_CAMGUARD (2026-07-17, user-observed ghosting/see-through-floors on real hardware):
-  // this loop used to drive frames blindly with no camera-pose check. effects.js's TAA still-refine
-  // loop has an equivalent guard for the exact same reason (§STILL_REFINE_RESTART comment there) —
-  // OrbitControls inertial damping can still be gliding (no pointer events fire during the glide),
-  // and this app's on-demand render loop only resumes calling controls.update() once something
-  // starts driving frames again, which this converge loop itself does. Blending SSGI's temporal
-  // buffer across a moving viewpoint is exactly what produced the ghosted/doubled geometry and
-  // see-through floors in the reported screenshot — this library's BatchedMesh velocity/reprojection
-  // support is unverified (see §SSGI_PORT comment above), so don't trust reprojection to compensate;
-  // restart the frame budget from scratch on any pose change, same discipline as TAA.
+  // §SSGI_CONVERGE_CAMGUARD (2026-07-17, user-observed ghosting/see-through-floors on real hardware,
+  // reviewed+refined by a second session — see commit body): this loop used to drive frames blindly
+  // with no camera-pose check. effects.js's TAA still-refine loop has an equivalent guard for the
+  // same underlying reason (§STILL_REFINE_RESTART comment there) — OrbitControls inertial damping can
+  // still be gliding (no pointer events fire during the glide). Correction on the first pass of this
+  // fix: SSGI IS velocity-reprojected, not blind to motion like raw TAA — the actual hole is that a
+  // slow damping glide stays under the per-pixel velocity threshold (didMove≈0), so full-accumulate
+  // keeps blending across a genuinely (if slowly) drifting pose, which the reprojection can't catch
+  // by design. A pose-signature restart catches exactly what the velocity test can't. Resetting the
+  // JS-side frame counter alone isn't enough though — it doesn't clear the SVGF temporal buffer that
+  // already blended the polluted frames, so a ghost that already blended in would only fade rather
+  // than drop. Verified in the vendored bundle source: the library's own reactive knob setters
+  // (spp/thickness/distance/etc, makeOptionsReactive) call `this.svgf.svgfTemporalReprojectPass.
+  // reset()` on change — a cheap, safe, idempotent uniform flip (`reset(){this.fullscreenMaterial.
+  // uniforms.reset.value=!0}`). Call that same public path directly on pose-change detection.
   function _ssgiCamSig() {
     if (!camera) return '';
     var p = camera.position, q = camera.quaternion;
     return p.x.toFixed(4) + ',' + p.y.toFixed(4) + ',' + p.z.toFixed(4) + ',' +
            q.x.toFixed(5) + ',' + q.y.toFixed(5) + ',' + q.z.toFixed(5) + ',' + q.w.toFixed(5);
+  }
+  function _ssgiResetAccumulation() {
+    if (A._ssgiEffect && A._ssgiEffect.svgf && A._ssgiEffect.svgf.svgfTemporalReprojectPass) {
+      A._ssgiEffect.svgf.svgfTemporalReprojectPass.reset();
+    }
   }
   function _ssgiKickConverge(frames, onDone) {
     _ssgiConvergeFrames = frames || SSGI_CONVERGE_FRAMES;
@@ -207,6 +217,7 @@ async function setupGIPoc(A, renderer, scene, camera) {
       if (sigNow !== _ssgiConvergeSig) {
         _ssgiConvergeSig = sigNow;
         _ssgiConvergeLeft = _ssgiConvergeFrames;
+        _ssgiResetAccumulation();  // hard-clear the polluted SVGF buffer, not just the frame counter
         _driven = 0;
         if (!_ssgiConvergeRestartLogged) {
           console.log('§SSGI_CONVERGE_RESTART cam-moved — accumulation restarted');


### PR DESCRIPTION
## Summary
Supersedes #814 (closed — that branch was already squash-merged in #813, stacking new commits on it collided with main's squash history / DIRTY). Same fix, cherry-picked clean onto fresh `origin/main`.

- Live testing on #813's deployed build (v773) surfaced ghosted/doubled geometry and see-through floors in the Alt+S SSGI still-fold on real hardware (screenshot: doubled roof-terrace geometry, semi-transparent stacked floors).
- Root cause: `_ssgiKickConverge`'s 90-frame accumulation loop had no camera-pose check, unlike TAA's still-refine loop (`§STILL_REFINE_RESTART`) which guards the same failure mode — OrbitControls damping can still be gliding when the loop starts (no pointer events fire during the glide). SSGI *is* velocity-reprojected (not blind to motion like raw TAA), but a slow damping glide can sit under the per-pixel velocity threshold, so full-accumulate keeps blending across a genuinely drifting pose.
- Fix, two commits:
  1. Pose-signature restart on the converge loop (same technique as TAA's `_camSig()`), resetting the frame budget on any detected pose change.
  2. Also hard-resets the library's own SVGF temporal buffer on that same trigger (`svgf.svgfTemporalReprojectPass.reset()` — confirmed in the vendored bundle source that the library's own reactive knob setters call this same path) — restarting the JS-side counter alone doesn't clear already-blended ghost data, only stops adding more.

## Test plan
- [x] Syntax-checked (`node --check`)
- [x] Clean cherry-pick onto fresh `origin/main`, verified non-DIRTY diff
- [ ] User to hard-refresh and re-test Alt+S on real hardware — the original bug report