### PR TITLE
fix(viewer): default Alt+S back to AO-only fold, SSGI stays opt-in via Alt+J

### DIFF
--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -352,7 +352,14 @@ async function setupGIPoc(A, renderer, scene, camera) {
   // Alt+J itself stays a fully standalone navigable preview, untouched.
   var _stillSSGIEngaged = false, _stillSSGIWasOn = false, _stillKnobsApplied = false;
   var STILL_SSGI_FRAMES = 90;
-  A._stillSSGIEnabled = true;  // runtime-flippable (tests exercise the AO fallback path with this)
+  // §SSGI_OPTOUT_DEFAULT (2026-07-17, user directive after live testing): SSGI's still-fold
+  // replaced the AO-only fold outright (mutually exclusive composer slot, not additive — see
+  // toggleSSGIPreview) and traded a known-good, crisp N8AO contact-shadow look for a softer,
+  // less-defined result the user described as "not accurate or crisp," plus real practical
+  // fragility (the 90-frame converge is exposed to any incidental motion for up to a minute per
+  // attempt, even after the ghosting fix). Alt+S defaults back to the AO-only fold; Alt+J remains
+  // a fully manual, standalone opt-in for anyone who wants to try SSGI on its own terms.
+  A._stillSSGIEnabled = false;  // runtime-flippable (tests exercise the AO fallback path with this)
   A.startStillSSGIPhase = async function() {
     if (!A._stillSSGIEnabled) return false;
     var t0 = performance.now();


### PR DESCRIPTION
## Summary
Follow-up to #816 (ghosting fix, merged and confirmed working — two clean 90-frame convergences observed live). Live testing surfaced that even with ghosting fixed, auto-folding SSGI into Alt+S isn't a net win yet:
- Alt+J and Alt+G share one composer slot and are mutually exclusive, not additive — the SSGI fold didn't dim N8AO's contact shadows, it fully replaced them with a softer, less-defined result ("drowning the G shadow part... doesn't feel accurate or crisp", user's words, live testing).
- Even fixed, the 90-frame converge stays exposed to any incidental motion for up to ~60s per attempt in practice — a real usability cost for a still-uncertain visual gain.

## Change
One flag: `A._stillSSGIEnabled` now defaults `false`. Alt+S reverts to the known-good AO-only fold. Alt+J remains fully available as a manual, standalone opt-in — untouched, still lazy-built on first press.

No further blind tuning attempted on Alt+J's own quirks (softness vs AO, drag-time reprojection smear) — those need live A/B verification to fix safely, not more guessing.

## Test plan
- [x] Syntax-checked (`node --check`)
- [x] Clean diff vs fresh origin/main (avoided the #814 squash-collision mistake)
- [ ] User to hard-refresh and confirm Alt+S reverts to AO-only, Alt+J still opt-in-able