### PR TITLE
fix(viewer): SSGI tune HUD wasn't showing — stale still-refine guard

### DIFF
--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -387,8 +387,13 @@ async function setupGIPoc(A, renderer, scene, camera) {
       A._giComposer = _ssgiComposer;       // reuse main.js's existing _giComposer render branch
       A._giComposerActive = true;
       if (A._composerEnabled) A._composerEnabled = false;
-      // tune HUD only for a plain standalone Alt+J press, not the (now default-off) still-fold
-      if (!A._stillRefineActive) _ssgiShowTuneHUD();
+      // §TUNE_HUD_FIX (2026-07-17, user report: "still do not see any J panel"): the
+      // A._stillRefineActive guard was meant to skip the HUD during the auto still-fold, but the
+      // still-fold defaults OFF now (#817) — so toggleSSGIPreview(true) is ALWAYS a direct/manual
+      // call at this point, and the guard just blocked the panel in the most common real workflow
+      // (Alt+S freezes a still, which stays "active" until interaction, then Alt+J pressed after
+      // it — exactly when A._stillRefineActive is true). Always show it.
+      _ssgiShowTuneHUD();
     } else {
       A._ssgiActive = false;
       A._giComposerActive = false;


### PR DESCRIPTION
## Summary
Follow-up to #818. The tune HUD's show-call was gated on \`!A._stillRefineActive\`, meant to suppress it during the auto still-fold engagement — but that path defaults off now (#817), so the guard just blocked the panel in the most common real workflow (Alt+S freezes a still, stays active until interaction, then Alt+J pressed after it). User confirmed live: no panel appeared. Removed the stale guard.

## Test plan
- [x] Syntax-checked
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, Alt+S then Alt+J, confirm panel now appears bottom-left