### PR TITLE
feat(viewer): dramatic whole-ground reflectivity preset on tune HUD open

### DIFF
--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -386,8 +386,41 @@ async function setupGIPoc(A, renderer, scene, camera) {
     row.appendChild(label); row.appendChild(input); row.appendChild(val);
     return row;
   }
+  // §GROUND_TEST_PRESET (2026-07-17, user: "make the whole ground metal type so that turning it
+  // up can see whole impact. The puddles are too small... I can turn it down if unwanted"): the
+  // ground's own base material (scene.js) defaults to roughness:0.95/metalness:0.0 — matte earth,
+  // barely reflective at any envMapIntensity (real dielectric physics, not a bug — see #822).
+  // The separate patch-based puddle shader (effects.js, Alt+S-only) only wets small circles, not
+  // the whole plane, which is the "puddles too small" complaint. Rather than touching that
+  // separate already-shipped feature, apply a dramatic WHOLE-GROUND preset when the tune HUD
+  // opens — low roughness, high metalness, boosted envMapIntensity — so the reflectivity impact
+  // is obvious immediately, and restore the original values when the HUD closes (Alt+J off) so
+  // normal day-to-day ground appearance is untouched outside this testing session. The sliders
+  // remain live on top of the preset, exactly the "turn it down if unwanted" ask.
+  var _groundOrig = null;
+  function _applyGroundTestPreset() {
+    if (!A.ground || !A.ground.material || _groundOrig) return;
+    var m = A.ground.material;
+    _groundOrig = { roughness: m.roughness, metalness: m.metalness, envMapIntensity: m.envMapIntensity };
+    m.roughness = 0.15; m.metalness = 0.85; m.envMapIntensity = 1.5;
+    m.needsUpdate = true;
+    console.log('§GROUND_TEST_PRESET applied roughness=0.15 metalness=0.85 envMapIntensity=1.5 (was ' +
+      JSON.stringify(_groundOrig) + ')');
+  }
+  function _restoreGroundPreset() {
+    if (!_groundOrig) return;
+    if (A.ground && A.ground.material) {
+      var m = A.ground.material;
+      m.roughness = _groundOrig.roughness; m.metalness = _groundOrig.metalness;
+      m.envMapIntensity = _groundOrig.envMapIntensity;
+      m.needsUpdate = true;
+      console.log('§GROUND_TEST_PRESET restored ' + JSON.stringify(_groundOrig));
+    }
+    _groundOrig = null;
+  }
   function _ssgiShowTuneHUD() {
     if (_tuneHud || !A._ssgiEffect) return;
+    _applyGroundTestPreset();
     var hud = document.createElement('div');
     hud.id = 'ssgiTuneHud';
     hud.style.cssText =
@@ -431,6 +464,7 @@ async function setupGIPoc(A, renderer, scene, camera) {
   }
   function _ssgiHideTuneHUD() {
     if (_tuneHud) { _tuneHud.remove(); _tuneHud = null; }
+    _restoreGroundPreset();
   }
 
   A._ssgiActive = false;


### PR DESCRIPTION
## Summary
User ask after testing #822's ground sliders: "make the whole ground metal type so that turning it up can see whole impact. The puddles are too small... I can turn it down if unwanted."

Ground's base material defaults to roughness:0.95/metalness:0.0 — real dielectric physics means it stays subtle at any envMapIntensity. The separate patch-based puddle shader (Alt+S-only, different file) only wets small circles, not the whole plane — a different feature, not touched here.

## Change
Opening the tune HUD (Alt+J on) now auto-applies a dramatic whole-ground preset (roughness 0.15, metalness 0.85, envMapIntensity 1.5) so the reflectivity impact is obvious immediately. Original values saved and restored on close (Alt+J off), so normal navigation ground appearance is untouched outside the testing session. Sliders stay live on top — dial down if unwanted, per the ask.

## Test plan
- [x] Syntax-checked
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, Alt+J, confirm ground is dramatically reflective by default and reverts on Alt+J off