### PR TITLE
feat(viewer): metal-strength dial drives full-surface puddle wetness, HUD close button

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -922,6 +922,18 @@ async function setupEffects(A, renderer, scene, camera) {
       shader.uniforms.uPuddleRadii.value[i] = _puddleRadii[i];
     }
   }
+  // §GROUND_WETNESS_OVERRIDE (2026-07-17, user: "can we change the J 'metal' dial to control its
+  // reflectiveness" — wiring the tune HUD's metal-strength slider to this SAME puddle mechanism,
+  // full-surface instead of small circles. 0 = off, 1 = the whole ground at puddle-strength
+  // wetness (roughness 0.08, darkened) uniformly, independent of the small random puddle patches
+  // (both can coexist — max() below, whichever reads wetter at a given pixel wins).
+  A._groundWetnessOverride = 0;
+  A._setGroundWetness = function(v) {
+    _wireGroundPuddleShader();  // safe no-op if already wired (Alt+S may have wired it first)
+    A._groundWetnessOverride = Math.max(0, Math.min(1, v));
+    console.log('§GROUND_WETNESS_OVERRIDE value=' + A._groundWetnessOverride);
+    if (A.markDirty) A.markDirty();
+  };
   function _wireGroundPuddleShader() {
     if (_groundPuddleShaderWired || !A.ground) return;
     _groundPuddleShaderWired = true;
@@ -931,6 +943,7 @@ async function setupEffects(A, renderer, scene, camera) {
       shader.uniforms.uPuddleCount = { value: 0 };
       shader.uniforms.uPuddleCenters = { value: (new Array(8)).fill(null).map(function() { return new THREE.Vector2(); }) };
       shader.uniforms.uPuddleRadii = { value: new Float32Array(8) };
+      shader.uniforms.uWetnessOverride = { value: 0.0 };
       shader.vertexShader = shader.vertexShader
         .replace('#include <common>', '#include <common>\nvarying vec3 vGroundWorldPos;')
         .replace('#include <worldpos_vertex>', [
@@ -944,12 +957,13 @@ async function setupEffects(A, renderer, scene, camera) {
           'uniform float uPuddleActive;',
           'uniform int uPuddleCount;',
           'uniform vec2 uPuddleCenters[8];',
-          'uniform float uPuddleRadii[8];'
+          'uniform float uPuddleRadii[8];',
+          'uniform float uWetnessOverride;'
         ].join('\n'))
         .replace('#include <roughnessmap_fragment>', [
           '#include <roughnessmap_fragment>',
           'if (uPuddleActive > 0.5) {',   // uniform branch — near-zero cost when off (normal nav)
-          '  float wetness = 0.0;',
+          '  float wetness = uWetnessOverride;',  // full-surface base, small puddles can only add to it
           '  for (int pi = 0; pi < 8; pi++) {',
           '    if (pi >= uPuddleCount) break;',
           '    float d = distance(vGroundWorldPos.xz, uPuddleCenters[pi]);',
@@ -963,7 +977,8 @@ async function setupEffects(A, renderer, scene, camera) {
       // §TRIPLANAR_CLONE_BOMB (see streaming.js): plain property, never userData — userData is
       // JSON-round-tripped by Material.copy() on every clone.
       mat._puddleShader = shader;
-      shader.uniforms.uPuddleActive.value = A._stillRefineActive ? 1.0 : 0.0;
+      shader.uniforms.uPuddleActive.value = (A._stillRefineActive || A._groundWetnessOverride > 0) ? 1.0 : 0.0;
+      shader.uniforms.uWetnessOverride.value = A._groundWetnessOverride;
       _applyPuddleUniforms(shader);
     };
     // §PHOTO_PUDDLE self-heal: same recompile-resets-uniforms landmine already found+fixed once
@@ -971,7 +986,11 @@ async function setupEffects(A, renderer, scene, camera) {
     // instead of relying on a single push at compile time.
     mat.onBeforeRender = function() {
       var sh = mat._puddleShader;
-      if (sh) { sh.uniforms.uPuddleActive.value = A._stillRefineActive ? 1.0 : 0.0; _applyPuddleUniforms(sh); }
+      if (sh) {
+        sh.uniforms.uPuddleActive.value = (A._stillRefineActive || A._groundWetnessOverride > 0) ? 1.0 : 0.0;
+        sh.uniforms.uWetnessOverride.value = A._groundWetnessOverride;
+        _applyPuddleUniforms(sh);
+      }
     };
     mat.needsUpdate = true;
   }

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -360,14 +360,14 @@ async function setupGIPoc(A, renderer, scene, camera) {
   var GROUND_TUNE_KNOBS = [
     { key: 'roughness', min: 0.05, max: 1, step: 0.01, target: 'ground' },
     { key: 'envMapIntensity', min: 0, max: 2, step: 0.05, target: 'ground' },
-    { key: 'metalness', min: 0, max: 1, step: 0.01, target: 'ground' }
+    { key: 'metalness', label: 'metal strength (reflectiveness)', min: 0, max: 1, step: 0.01, target: 'ground' }
   ];
   function _tuneRowFor(k, getVal, setVal) {
     var row = document.createElement('div');
     row.style.cssText = 'display:flex; align-items:center; gap:6px; margin:4px 0;';
     var label = document.createElement('span');
-    label.textContent = k.key;
-    label.style.cssText = 'width:130px; flex-shrink:0;';
+    label.textContent = k.label || k.key;
+    label.style.cssText = 'width:170px; flex-shrink:0; font-size:10px;';
     var input = document.createElement('input');
     input.type = 'range';
     input.min = k.min; input.max = k.max; input.step = k.step;
@@ -399,6 +399,17 @@ async function setupGIPoc(A, renderer, scene, camera) {
       'position:fixed; bottom:60px; left:12px; width:260px; ' +
       'background:rgba(30,30,30,0.92); color:#eee; font:11px/1.4 monospace; ' +
       'padding:10px; border-radius:6px; pointer-events:auto; z-index:800;';
+    // §HUD_CLOSE_BTN (2026-07-17, user: "can the J panel have a close button without turning off
+    // its effect? When user wants effect off its just Alt+J again"): _ssgiHideTuneHUD only ever
+    // removes the DOM panel — it never touches A._ssgiActive/the effect itself (same style as
+    // cost_panel.js's own close button) — so reusing it here is exactly "hide the UI, keep
+    // rendering." Alt+J still works normally afterward to actually turn SSGI off.
+    var closeBtn = document.createElement('span');
+    closeBtn.textContent = '✕';
+    closeBtn.style.cssText = 'position:absolute; top:6px; right:8px; cursor:pointer; font-size:13px; color:#888;';
+    closeBtn.title = 'Hide panel (SSGI stays on — Alt+J to turn it off)';
+    closeBtn.addEventListener('pointerup', function(e) { e.stopPropagation(); _ssgiHideTuneHUD(); });
+    hud.appendChild(closeBtn);
     var title = document.createElement('div');
     title.textContent = 'SSGI tune (Alt+J live)';
     title.style.cssText = 'font-weight:bold; margin-bottom:6px; color:#8cf;';
@@ -426,8 +437,16 @@ async function setupGIPoc(A, renderer, scene, camera) {
       hud.appendChild(gTitle);
       GROUND_TUNE_KNOBS.forEach(function(k) {
         hud.appendChild(_tuneRowFor(k,
-          function() { var v = A.ground.material[k.key]; return (v !== undefined) ? v : k.min; },
-          function(v) { A.ground.material[k.key] = v; A.ground.material.needsUpdate = true; }
+          function() {
+            // metal-strength drives the puddle shader's full-surface wetness override (user ask);
+            // other ground knobs (roughness/envMapIntensity) still read/write the base material.
+            if (k.key === 'metalness') return A._groundWetnessOverride || 0;
+            var v = A.ground.material[k.key]; return (v !== undefined) ? v : k.min;
+          },
+          function(v) {
+            if (k.key === 'metalness' && A._setGroundWetness) { A._setGroundWetness(v); return; }
+            A.ground.material[k.key] = v; A.ground.material.needsUpdate = true;
+          }
         ));
       });
     }


### PR DESCRIPTION
## Summary
Two follow-up requests from live testing:

1. **"can we change the J 'metal' dial to control its reflectiveness"** — the metal-strength slider now drives the existing puddle shader's wetness uniformly across the whole ground (roughness 0.08, darkened) instead of just the raw material metalness property, via a new `uWetnessOverride` uniform. Coexists with the existing small random puddle patches (max() — whichever is wetter wins). `A._setGroundWetness(v)` self-wires the shader on first call, works independent of Alt+S.
2. **"can the J panel have a close button without turning off its effect?"** — added a × button reusing the existing `_ssgiHideTuneHUD` (already only removes the DOM panel, never touches the effect state). Alt+J remains the normal, unchanged on/off toggle.

Not included: the ground-visibility-by-default change is still pending user confirmation on its Shadow-off impact — not part of this PR.

## Test plan
- [x] Syntax-checked (both files)
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, Alt+J, drag metal-strength slider, confirm whole-ground wetness effect; test × close button keeps effect running