### PR TITLE
fix(viewer): contain ground reflectivity to S+J, mid-value default, rename dial to 'reflect'

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -922,16 +922,24 @@ async function setupEffects(A, renderer, scene, camera) {
       shader.uniforms.uPuddleRadii.value[i] = _puddleRadii[i];
     }
   }
-  // §GROUND_WETNESS_OVERRIDE (2026-07-17, user: "can we change the J 'metal' dial to control its
-  // reflectiveness" — wiring the tune HUD's metal-strength slider to this SAME puddle mechanism,
-  // full-surface instead of small circles. 0 = off, 1 = the whole ground at puddle-strength
+  // §GROUND_WETNESS_OVERRIDE (2026-07-17, user: "we have to contain what we want only within S
+  // and J. When S is ON, it is all reflective ground... The J reflect dial will control its effect.
+  // When J is off, it persists for the session"): 0 = off, 1 = the whole ground at puddle-strength
   // wetness (roughness 0.08, darkened) uniformly, independent of the small random puddle patches
-  // (both can coexist — max() below, whichever reads wetter at a given pixel wins).
+  // (both can coexist — max() below, whichever reads wetter at a given pixel wins). Contained to
+  // Alt+S: staging auto-applies a mid-value default (GROUND_WETNESS_STAGE_DEFAULT below) the FIRST
+  // time this session, tunable live via Alt+J's "reflect" dial from there — once the user touches
+  // it, their value persists for the rest of the session (across S/J toggling, until page reload),
+  // never auto-reset back to the default.
+  var GROUND_WETNESS_STAGE_DEFAULT = 0.5;
+  var _groundWetnessUserSet = false;
   A._groundWetnessOverride = 0;
-  A._setGroundWetness = function(v) {
+  A._setGroundWetness = function(v, _isUserAction) {
     _wireGroundPuddleShader();  // safe no-op if already wired (Alt+S may have wired it first)
     A._groundWetnessOverride = Math.max(0, Math.min(1, v));
-    console.log('§GROUND_WETNESS_OVERRIDE value=' + A._groundWetnessOverride);
+    if (_isUserAction !== false) _groundWetnessUserSet = true;  // default true — only the internal
+    // staging auto-default call below passes false, so it never overrides a user's own choice
+    console.log('§GROUND_WETNESS_OVERRIDE value=' + A._groundWetnessOverride + ' userSet=' + _groundWetnessUserSet);
     if (A.markDirty) A.markDirty();
   };
   function _wireGroundPuddleShader() {
@@ -1046,6 +1054,10 @@ async function setupEffects(A, renderer, scene, camera) {
     // §PHOTO_VARIATION: roll (or keep locked) the shared seed before anything below reads it.
     if (!_photoVariationLocked || A._photoPaintSeed == null) A._photoPaintSeed = Math.random();
     _wireGroundPuddleShader();
+    // §GROUND_WETNESS_OVERRIDE: "when S is ON, it is all reflective ground" by default — only the
+    // FIRST time this session and only if the user hasn't already dialed their own value via Alt+J
+    // (that choice persists across S/J toggling, per the user's own spec — never stomped here).
+    if (!_groundWetnessUserSet) A._setGroundWetness(GROUND_WETNESS_STAGE_DEFAULT, false);
     var _pbbox = _buildingBBoxIfc();
     if (_pbbox) _buildGroundPuddles((_pbbox.xMin + _pbbox.xMax) / 2, (_pbbox.yMin + _pbbox.yMax) / 2);
     console.log('§PHOTO_PAINT_SEED seed=' + A._photoPaintSeed.toFixed(4) + ' locked=' + _photoVariationLocked +

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -343,24 +343,18 @@ async function setupGIPoc(A, renderer, scene, camera) {
     { key: 'denoiseIterations', min: 1, max: 5, step: 1 },
     { key: 'denoiseKernel', min: 1, max: 6, step: 1 }
   ];
-  // §GROUND_TUNE (2026-07-17, user ask, "ground too dark... can it be reflective/glassy... put
-  // under J"): A.ground.material is a plain THREE.MeshStandardMaterial (scene.js) — roughness/
-  // envMapIntensity/metalness are live-safe uniforms, no shader recompile, so these are cheap to
-  // drag same as the SSGI uniform knobs. NOT the same as literally mirroring the skyline
-  // silhouette's individual window lights (that needs a planar reflection/SSR — separate, bigger
-  // feature, not this).
-  // §METALNESS_ADD (2026-07-17, user: "reflection has no clear impact... turn the whole ground to
-  // puddle completely just to see the impact"): roughness/envMapIntensity alone stayed subtle
-  // because a non-metal surface (metalness=0, the ground's base value) only reflects ~4% of light
-  // at most viewing angles regardless of roughness — real dielectric physics, not a bug. metalness
-  // is the lever that actually makes a full-strength reflection obvious, for the diagnostic ask.
-  // Deliberately NOT reusing the existing patch-based puddle shader (effects.js, Alt+S-only,
-  // private closure) — that's a separate, already-shipped feature; wiring into it from this file
-  // risks breaking it for a quick test that doesn't need it.
+  // §GROUND_TUNE (2026-07-17, user ask, "ground too dark... reflective... put under J"):
+  // roughness/envMapIntensity are plain THREE.MeshStandardMaterial uniforms (scene.js), cheap to
+  // drag live, no shader recompile.
+  // §REFLECT_DIAL (2026-07-17, renamed per user: "change from metal name and function" — this dial
+  // no longer touches material.metalness at all. It drives A._groundWetnessOverride (effects.js
+  // §GROUND_WETNESS_OVERRIDE), the full-surface puddle-wetness mechanism auto-engaged at a mid
+  // value when Alt+S stages, contained to S+J per the user's own scoping — NOT a permanent base
+  // material change (that approach was tried and reverted, scene.js §GROUND_METALLIC_REVERT).
   var GROUND_TUNE_KNOBS = [
     { key: 'roughness', min: 0.05, max: 1, step: 0.01, target: 'ground' },
     { key: 'envMapIntensity', min: 0, max: 2, step: 0.05, target: 'ground' },
-    { key: 'metalness', label: 'metal strength (reflectiveness)', min: 0, max: 1, step: 0.01, target: 'ground' }
+    { key: 'reflect', label: 'reflect', min: 0, max: 1, step: 0.01, target: 'ground' }
   ];
   function _tuneRowFor(k, getVal, setVal) {
     var row = document.createElement('div');
@@ -438,13 +432,14 @@ async function setupGIPoc(A, renderer, scene, camera) {
       GROUND_TUNE_KNOBS.forEach(function(k) {
         hud.appendChild(_tuneRowFor(k,
           function() {
-            // metal-strength drives the puddle shader's full-surface wetness override (user ask);
-            // other ground knobs (roughness/envMapIntensity) still read/write the base material.
-            if (k.key === 'metalness') return A._groundWetnessOverride || 0;
+            // 'reflect' drives the puddle shader's full-surface wetness override (user-set, so it
+            // marks persistent — see A._setGroundWetness); other ground knobs still read/write the
+            // base material directly.
+            if (k.key === 'reflect') return A._groundWetnessOverride || 0;
             var v = A.ground.material[k.key]; return (v !== undefined) ? v : k.min;
           },
           function(v) {
-            if (k.key === 'metalness' && A._setGroundWetness) { A._setGroundWetness(v); return; }
+            if (k.key === 'reflect' && A._setGroundWetness) { A._setGroundWetness(v); return; }
             A.ground.material[k.key] = v; A.ground.material.needsUpdate = true;
           }
         ));

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -312,11 +312,11 @@ async function setupScene(A) {
   // Ground plane — positioned after DB load to sit below the lowest building
   const ground = new THREE.Mesh(
     new THREE.PlaneGeometry(50000, 50000),
-    // §GROUND_METALLIC (2026-07-17, user directive: "I want the whole ground metallic. Not when
-    // J. That can control the reflection" — a permanent base state, not tied to Alt+J's on/off;
-    // the tune HUD's sliders adjust this metallic base live, they don't toggle it into existence).
-    // Was roughness:0.95/metalness:0.0 (matte earth, §S276b) — now permanently reflective.
-    new THREE.MeshStandardMaterial({ color: 0x5C4033, roughness: 0.15, metalness: 0.85, envMapIntensity: 1.5, side: THREE.DoubleSide })
+    // §GROUND_METALLIC_REVERT (2026-07-17, user: "We have to contain what we want only within S
+    // and J" — a permanent base metallic material was the wrong shape for this ask; superseded by
+    // the wetness-override mechanism (effects.js §GROUND_WETNESS_OVERRIDE), auto-applied when Alt+S
+    // stages and tunable via Alt+J's dial. Reverted to the original earth-brown matte default.
+    new THREE.MeshStandardMaterial({ color: 0x5C4033, roughness: 0.95, metalness: 0.0, envMapIntensity: 0.15, side: THREE.DoubleSide })  // §S276b: earth brown, subtle sky reflection (0.15)
   );
   ground.rotation.x = -Math.PI / 2;
   ground.receiveShadow = true;


### PR DESCRIPTION
## Summary
Consolidates the ground-reflectivity back-and-forth per explicit user scoping: "We have to contain what we want only within S and J. When S is ON, it is all reflective ground... The J reflect dial will control its effect. When J is off, it persists for the session."

## Changes
1. Reverted #825's permanent metallic base material back to the original earth-brown matte default — "no impact desired" on normal usage, explicit.
2. Never shipped the pending ground-visibility-by-default change — discarded.
3. Alt+S staging auto-applies a mid-value (0.5) ground-wetness default the first time each session (existing puddle-wetness mechanism from #826) — reflective ground on S, contained to S.
4. Ground dial renamed metalness → **reflect**, no longer touches `material.metalness` — purely drives the wetness override. Once adjusted, the user's value persists for the rest of the session (never auto-reset by the staging default again).

## Test plan
- [x] Syntax-checked (3 files)
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, confirm normal nav (Shadow off) ground behavior is back to original; Alt+S shows reflective ground by default; Alt+J's "reflect" dial adjusts and persists across S/J toggling