### PR TITLE
fix(viewer): wetness now boosts metalness too, tune panel no longer leaks into Alt+S teardown

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -970,6 +970,9 @@ async function setupEffects(A, renderer, scene, camera) {
         ].join('\n'))
         .replace('#include <roughnessmap_fragment>', [
           '#include <roughnessmap_fragment>',
+          'float uGroundWetness = 0.0;',  // declared OUTSIDE the if (top-level in main()) so the
+          // later metalnessmap_fragment injection below — which runs after this chunk in three.js's
+          // standard MeshStandardMaterial ordering — can read the same value.
           'if (uPuddleActive > 0.5) {',   // uniform branch — near-zero cost when off (normal nav)
           '  float wetness = uWetnessOverride;',  // full-surface base, small puddles can only add to it
           '  for (int pi = 0; pi < 8; pi++) {',
@@ -978,9 +981,19 @@ async function setupEffects(A, renderer, scene, camera) {
           '    float w = 1.0 - smoothstep(uPuddleRadii[pi] * 0.55, uPuddleRadii[pi], d);',
           '    wetness = max(wetness, w);',
           '  }',
+          '  uGroundWetness = wetness;',
           '  roughnessFactor = mix(roughnessFactor, 0.08, wetness);',
           '  diffuseColor.rgb *= mix(1.0, 0.72, wetness);',  // wet patches read darker/more saturated
           '}'
+        ].join('\n'))
+        // §WETNESS_METALNESS (2026-07-17, user: "still not auto reflect"): roughness alone stays
+        // subtle on a zero-metalness dielectric (real physics — see #822/#824 investigation). Wet
+        // areas now also push metalness up, which is what actually makes a puddle read as
+        // reflective rather than just "less matte." metalnessmap_fragment runs after
+        // roughnessmap_fragment in three.js's standard chunk order, so uGroundWetness is available.
+        .replace('#include <metalnessmap_fragment>', [
+          '#include <metalnessmap_fragment>',
+          'if (uPuddleActive > 0.5) { metalnessFactor = mix(metalnessFactor, 0.85, uGroundWetness); }'
         ].join('\n'));
       // §TRIPLANAR_CLONE_BOMB (see streaming.js): plain property, never userData — userData is
       // JSON-round-tripped by Material.copy() on every clone.

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -393,6 +393,16 @@ async function setupGIPoc(A, renderer, scene, camera) {
       'position:fixed; bottom:60px; left:12px; width:260px; ' +
       'background:rgba(30,30,30,0.92); color:#eee; font:11px/1.4 monospace; ' +
       'padding:10px; border-radius:6px; pointer-events:auto; z-index:800;';
+    // §PANEL_S_LEAK_FIX (2026-07-17, user: "closing of J it seems close the S effect, which should
+    // not... S effect should be closed by Alt-S toggle again or a move on canvas"): main.js has a
+    // global window pointerdown listener that treats ANY click outside the 3D canvas — Find panel,
+    // toolbar, ANY UI chrome — as a real action and fully tears down Alt+S's still-refine
+    // (deliberate, pre-existing behavior: "when i select an item it breaks to old nature"). This
+    // whole panel is UI chrome, so EVERY slider drag (not just the close button) would leak out and
+    // kill a live Alt+S still mid-adjustment — exactly what live-tuning during a still needs to
+    // NOT do. Stop pointerdown at the panel container so nothing inside it (sliders, close button)
+    // ever bubbles to window; Alt+S still only ever ends via Alt+S itself or real canvas movement.
+    hud.addEventListener('pointerdown', function(e) { e.stopPropagation(); });
     // §HUD_CLOSE_BTN (2026-07-17, user: "can the J panel have a close button without turning off
     // its effect? When user wants effect off its just Alt+J again"): _ssgiHideTuneHUD only ever
     // removes the DOM panel — it never touches A._ssgiActive/the effect itself (same style as


### PR DESCRIPTION
## Summary
Two bugs found from live testing:

1. **"still not auto reflect"** — puddle/wetness shader only lowered roughness and darkened color, never touched metalness. A zero-metalness surface stays subtle regardless of roughness (real physics, established in #822). Wet areas now also push metalness toward 0.85.
2. **"closing of J it seems close the S effect, which should not"** — main.js's global pointerdown listener treats any click outside the 3D canvas as a real action and tears down Alt+S. The tune HUD is UI chrome, so every slider drag (not just the close button) was leaking out and killing a live Alt+S mid-adjustment. Fixed by stopping pointerdown propagation at the whole panel container — Alt+S now only ever ends via Alt+S itself or real canvas movement.

## Test plan
- [x] Syntax-checked (both files)
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, confirm Alt+S auto-reflect is now visibly reflective, and dragging any panel slider (or closing via ×) no longer cancels the Alt+S still