### PR TITLE
feat(viewer): Alt+C for Cinema Orbit, add to Help palette, panel clicks soft-cancel not full-cancel

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -735,10 +735,31 @@ async function initViewer() {
   // (Find panel, toolbar, any UI chrome) is a real selection/action (full teardown, matches "when i
   // select an item it breaks to old nature" exactly, unchanged from today's behavior for UI clicks).
   function _cancelStillRefineSoft() { if (_photoCycleEngaged() && typeof APP.softStopStillRefine === 'function') APP.softStopStillRefine(); }
+  // §PANEL_REGISTRY_SOFT_CANCEL (2026-07-17, user: "during flight we cannot disturb the panel as
+  // closing it stops the Alt-S and it be recording onwards non S... Pill registry is an abstract
+  // handling"): this was a blind binary check — canvas = soft, EVERYTHING else = full teardown —
+  // which never consulted window._panels (scene.js's own registry, populated via InputReg.register
+  // from every pill-built panel, Sunglass/Cinema included). Touching any registered UI panel (tune
+  // HUD, Sunglass, future panels) doesn't need to fully exit photo mode/cinema recording any more
+  // than a camera-drag does — soft-cancel (keep staging, only restart the TAA polish) is the right
+  // default for panel interaction in general. Find-panel's own "selecting a result exits photo
+  // mode" behavior is untouched — that comes from focusElement's own separate teardown path when a
+  // real result is clicked, not from this generic listener, so this stays general/abstract instead
+  // of a one-off allowlist of panel ids.
+  function _insideRegisteredPanel(target) {
+    var panels = window._panels || [];
+    for (var i = 0; i < panels.length; i++) {
+      if (panels[i].el && panels[i].el.contains(target)) return true;
+    }
+    return false;
+  }
   var _photoCanvasDown = null;
   window.addEventListener('pointerdown', function(e) {
     if (APP.renderer && e.target === APP.renderer.domElement) {
       _photoCanvasDown = { x: e.clientX, y: e.clientY };
+      _cancelStillRefineSoft();
+    } else if (_insideRegisteredPanel(e.target)) {
+      _photoCanvasDown = null;
       _cancelStillRefineSoft();
     } else {
       _photoCanvasDown = null;

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1174,6 +1174,10 @@ async function setupScene(A) {
       // §ZOOM: keyboard-only shortcuts (NOT pills) — surfaced in the Help listing for discoverability
       all.push({ seq: '+', name: 'Zoom In',  icon: '', action: function() { _shortcuts['+'](); }, children: null });
       all.push({ seq: '-', name: 'Zoom Out', icon: '', action: function() { _shortcuts['-'](); }, children: null });
+      // §CINEMA_SHORTCUT (2026-07-17, user: "Cinema has no shortcut and not in Help box among the
+      // others"): same keyboard-only pattern as Zoom above — Cinema Orbit lives as a row inside the
+      // Sunglass panel, not its own pill, so it was never in _mainPillActions and never surfaced here.
+      all.push({ seq: 'ALT+C', name: 'Cinema Orbit', icon: '', action: function() { if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); }, children: null });
       var matches = all.filter(function(e) {
         return e.name.toLowerCase().indexOf(f) >= 0 || e.seq.toLowerCase().indexOf(f) >= 0;
       });
@@ -1780,6 +1784,11 @@ async function setupScene(A) {
     // §GI_POC (sandbox spike, feat/ssgi-composer-poc, isolated branch — not a shipped feature)
     if (e.altKey && (e.key === 'g' || e.key === 'G')) { e.preventDefault(); if (typeof A.toggleGIPreview === 'function') A.toggleGIPreview(); console.log('§KBD_ROUTE Alt+G → GI preview (N8AO POC)'); return; }
     if (e.altKey && (e.key === 'j' || e.key === 'J')) { e.preventDefault(); if (typeof A.toggleSSGIPreview === 'function') A.toggleSSGIPreview(); console.log('§KBD_ROUTE Alt+J → SSGI preview (realism-effects spike)'); return; }
+    // §CINEMA_SHORTCUT (2026-07-17, user: "Cinema... no shortcut... What do u suggest?" — confirmed
+    // Alt+C, distinct namespace from plain 'c' (Clash), no conflict). Previously only reachable via
+    // the Sunglass panel's Cinema row (panels.js) — user separately confirmed Cinema Orbit works
+    // fine without ever pressing Alt+S first, just adjust the starting camera view and go.
+    if (e.altKey && (e.key === 'c' || e.key === 'C')) { e.preventDefault(); if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); console.log('§KBD_ROUTE Alt+C → cinema orbit'); return; }
     if (e.key === 'F1') { e.preventDefault(); console.log('§KBD_ROUTE F1 → help'); showCommandPalette(); return; }
     if (e.key === 'F11') { e.preventDefault(); console.log('§KBD_ROUTE F11 → fullscreen'); A.toggleFullscreen(); return; }
     // Ctrl/Cmd+S = Save Building, Ctrl/Cmd+O = Open Building — preventDefault suppresses the browser's


### PR DESCRIPTION
## Summary
Three related fixes from live feedback:

1. **Cinema Orbit shortcut**: Alt+C (confirmed with user — distinct namespace from plain 'c'=Clash, no conflict), dispatches directly to `A.startCinemaOrbit()`. Works without Alt+S first, per user confirmation.
2. **Help palette listing**: added Cinema Orbit using the existing "keyboard-only shortcut, not a pill" pattern (same as Zoom In/Out) — it lives inside the Sunglass panel, so it was never in `_mainPillActions` and never surfaced in F1's Help listing.
3. **Panel-interaction leak into Alt+S teardown**: `main.js`'s global pointerdown listener never consulted `window._panels` (the existing panel registry, populated via `InputReg.register`). Any registered-panel click now soft-cancels (keeps staging) instead of fully tearing down — general fix covering every panel, not a one-off allowlist. Find-panel's own selection-exits-photo-mode behavior is untouched (separate mechanism, `focusElement`'s own teardown).

## Test plan
- [x] Syntax-checked (3 files)
- [x] Clean diff vs fresh origin/main
- [ ] User to hard-refresh, confirm Alt+C starts Cinema Orbit, it appears in F1 Help, and touching the Sunglass panel during a recording no longer breaks it