### PR TITLE
§PATCH-FRAME-GUARD — never trust room patches from another building/frame

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -164,7 +164,7 @@ async function initViewer() {
         // (getStairGroups() reuse), so room_graph.js must already exist by the time this runs.
         '../common/hallway_backbone.js?v=1',
         // v49 (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-16): A.ensureRooms + A.getRoomGraph extraction.
-        'navigate_find.js?v=51',
+        'navigate_find.js?v=52',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -909,7 +909,27 @@
         else state = 'none'; // real extraction present
       } catch (e) { state = 'zero'; /* table missing */ }
       if (state === 'none') return { status: 'present', real: true };
-      if (state === 'recompute' && !opts.force) return { status: 'present', real: false };
+      if (state === 'recompute' && !opts.force) {
+        // §PATCH-FRAME-GUARD (boot half, 2026-07-17): the loader's self-heal applies
+        // patches/<dbFile>.sql on EVERY load — a wrong-building patch (see the needle-side guard
+        // below for the observed case) poisons the db before any press, and "rooms present"
+        // would trust it forever. Compiler-owned rooms sitting OUTSIDE the building's own element
+        // extent are objective corruption, not user data: fall through and recompile. Rooms
+        // without coordinates to compare keep the existing trust-present behavior.
+        var inFrame = true;
+        try {
+          var _e0 = A.dbQuery("SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y)" +
+            " FROM element_transforms WHERE center_x IS NOT NULL")[0];
+          var _r0 = A.dbQuery("SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y)" +
+            " FROM spatial_structure WHERE type='IfcSpace' AND center_x IS NOT NULL")[0];
+          if (_e0 && _r0 && _r0[0] !== null && _e0[0] !== null) {
+            inFrame = _r0[1] >= _e0[0] && _r0[0] <= _e0[1] &&
+                      _r0[3] >= _e0[2] && _r0[2] <= _e0[3];
+          }
+        } catch (eIf) { /* inFrame stays true */ }
+        if (inFrame) return { status: 'present', real: false };
+        console.warn('[NEEDLE] §NEEDLE_FRAME_STALE compiled rooms outside building extent — recompiling');
+      }
       var bld = A.activeBuilding || '';
       var url = A.DB_URL || '';
       var dir = url.slice(0, url.lastIndexOf('/') + 1);
@@ -947,7 +967,36 @@
           hasCompiledRooms = ssColsCheck.some(function(c) { return c[1] === 'room_guid'; });
         } catch (eCols) { /* hasCompiledRooms stays false */ }
 
+        // §PATCH-FRAME-GUARD (2026-07-17, found live via user console log): a patch fetched by
+        // dbFile name can belong to a DIFFERENT building/frame than the db's actual content —
+        // observed: Terminal_extracted.db.sql (OCI, extracted frame x≈630..695) applied onto
+        // imported TerminalMerged content (x≈88..150). The rooms landed ~550m off the walls,
+        // every door orphaned, and the walker never ran because room_guid existed
+        // (§NEEDLE-COMPILED-CHECK trusted mere presence). Trust a patch only when its compiled
+        // rooms actually sit ON this building: the room-center extent must INTERSECT the
+        // element extent — pure measured comparison, no thresholds.
+        var frameOk = false;
         if (applied && hasCompiledRooms) {
+          try {
+            var _ext = A.dbQuery("SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y)" +
+              " FROM element_transforms WHERE center_x IS NOT NULL")[0];
+            var _rext = A.dbQuery("SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y)" +
+              " FROM spatial_structure WHERE type='IfcSpace' AND center_x IS NOT NULL")[0];
+            if (_ext && _rext && _rext[0] !== null && _ext[0] !== null) {
+              frameOk = _rext[1] >= _ext[0] && _rext[0] <= _ext[1] &&
+                        _rext[3] >= _ext[2] && _rext[2] <= _ext[3];
+            }
+          } catch (eFg) { /* frameOk stays false */ }
+          if (!frameOk) {
+            console.warn('[NEEDLE] §NEEDLE_PATCH_MISMATCH patch rooms outside building extent — dropping patch rooms, walker takes over');
+            try {
+              A.db.run("DELETE FROM spatial_structure WHERE guid LIKE 'RM\\_%' ESCAPE '\\' OR guid LIKE 'STC\\_%' ESCAPE '\\';" +
+                       "DELETE FROM rel_contained_in_space WHERE space_guid LIKE 'RM\\_%' ESCAPE '\\';");
+            } catch (eDel) { console.warn('[NEEDLE] §NEEDLE_PATCH_MISMATCH cleanup err ' + (eDel && eDel.message)); }
+          }
+        }
+
+        if (applied && hasCompiledRooms && frameOk) {
           source = 'patch';
         } else {
           // S2.2 — walker source (any building): lazy-load the room_walker JS port, compile

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v775';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v776';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Found live via the user's console: the needle and boot self-heal applied `Terminal_extracted.db.sql` (extracted frame, x≈630–695) onto imported TerminalMerged content (x≈88–150) — rooms landed ~550m off the walls, all doors orphaned, the walker never ran, and every 💉 press re-poisoned and persisted.

Two-half guard, pure measured extent-intersection:
- **Needle half**: after a patch applies, its compiled-room extent must intersect the building's element extent — mismatch → `§NEEDLE_PATCH_MISMATCH`, drop `RM_`/`STC_` rows, walker takes over.
- **Boot half**: `ensureRooms` finding compiler-owned rooms *outside* the element extent (poisoned by the boot self-heal before any press) → `§NEEDLE_FRAME_STALE`, recompiles instead of trusting.

Witness (`diag5_guard.log`, wrong-frame patch deliberately staged): boot poison → FRAME_STALE → PATCH_MISMATCH → `source=patch+walker rooms=46` (v2 walker) → graph e1=16, the level at which the Fly tour routes 12/12.

After deploy: a poisoned browser self-cures on the next ✈ or 💉 press — no manual IndexedDB surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)