### PR TITLE
§THIN-GRAPH-RECURE — one ✈ press self-cures stale compiled rooms

### DIFF
--- a/viewer/main.js
+++ b/viewer/main.js
@@ -164,7 +164,7 @@ async function initViewer() {
         // (getStairGroups() reuse), so room_graph.js must already exist by the time this runs.
         '../common/hallway_backbone.js?v=1',
         // v49 (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-16): A.ensureRooms + A.getRoomGraph extraction.
-        'navigate_find.js?v=52',
+        'navigate_find.js?v=53',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -941,6 +941,10 @@
         // (G1), applied directly to the LIVE db rather than a pre-load buffer.
         var applied = false;
         try {
+          // §THIN-GRAPH-RECURE: a re-cure pass skips the patch source — the patch is exactly
+          // what produced the rooms being re-cured (or was frame-dropped already); straight to
+          // the walker.
+          if (opts.skipPatch) throw new Error('skipPatch');
           var r = await fetch(patchUrl);
           if (r.ok) {
             var sqlText = await r.text();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v776';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v777';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v10 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v11 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -77,6 +77,34 @@ function setupTour(A) {
           ' status=' + (res && res.status) + ' source=' + ((res && res.source) || 'none') +
           ' rooms=' + (res && res.rooms != null ? res.rooms : '-'));
       }
+      // §THIN-GRAPH-RECURE (2026-07-17, third independent live report): rooms can be present,
+      // in-frame AND compiler-owned yet still route-thin — a stale weak compile persisted in
+      // IDB that neither the presence check nor §PATCH-FRAME-GUARD can fault. Probe the route
+      // once; if it rejects and EVERY room is compiler-owned (RM_ prefix — real IfcSpace
+      // extractions are never touched), re-cure with the current walker (skipPatch: the patch
+      // is what produced these rooms) and let buildTour rebuild on the fresh set. One attempt,
+      // no loop — the inject mechanism exists to cure poor data (user doctrine).
+      try {
+        if (A.flyActive && A.ensureRooms && A.getRoomGraph && window.RoomGraph) {
+          let probe = null;
+          try { probe = A._buildGraphRoute({}); } catch (ep) { probe = null; }
+          if (!probe) {
+            let compiledOnly = false;
+            try {
+              const r = A.db.exec("SELECT COUNT(*), COUNT(CASE WHEN guid LIKE 'RM\\_%' ESCAPE '\\' THEN 1 END)" +
+                " FROM spatial_structure WHERE type='IfcSpace'");
+              const t = r.length ? r[0].values[0][0] : 0, c = r.length ? r[0].values[0][1] : 0;
+              compiledOnly = t > 0 && t === c;
+            } catch (ec) { /* compiledOnly stays false */ }
+            if (compiledOnly) {
+              const rc = await A.ensureRooms({ force: true, skipPatch: true });
+              console.log('[TOUR] §FLY_RECURE status=' + (rc && rc.status) +
+                ' source=' + ((rc && rc.source) || '-') +
+                ' rooms=' + (rc && rc.rooms != null ? rc.rooms : '-'));
+            }
+          }
+        }
+      } catch (er) { console.warn('[TOUR] §FLY_RECURE_ERR ' + (er && er.message)); }
     } catch (e) {
       console.warn('[TOUR] §FLY_PREP_ERR ' + (e && e.message));
     }


### PR DESCRIPTION
Completes the cure chain from #832/#833. Rooms can be present, in-frame AND compiler-owned yet still route-thin (stale weak compile persisted in IndexedDB) — nothing existing can fault them, the tour rejects, and the user is stuck doing manual needle/IDB surgery (three live reports).

Now the Fly prepare step probes the route once; on reject with every room compiler-owned (`RM_` — real IfcSpace extractions are never touched), it re-cures via `ensureRooms({force, skipPatch})` and rebuilds. One attempt, no loop. `skipPatch` because the patch is exactly what produced the rooms being re-cured.

Witness (`fly_recure.log`, imported TerminalMerged meta + in-frame thin RM_ rooms staged, single L press):
```
§FLY_ROUTE_REJECT … visited=3/11 → legacy tour        (probe)
§NEEDLE_INJECT … source=walker rooms=46
§FLY_RECURE status=injected source=walker rooms=46
§FLY_ROUTE storeys=6 stops=12/12 corridorStops=3 stairUp=…Aras_01 stairDown=…Aras_03
CINE-GRAPH(34acts) flying
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)