### PR TITLE
§MAJORITY-LEGAL tour gate — reject mostly-wall-illegal routes

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v777';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v778';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v11 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v12 (occupant-graph corridors/stairs — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -405,7 +405,12 @@ function setupTour(A) {
     // Terminal 10/89 residual, HHS 0/50). What IS gated: a route that barely exists — a thin
     // graph (this local Duplex snapshot: 5 approx nodes, 3 edges, most stops unreachable) must
     // fall back to the legacy tour, not ship a worse flight.
-    if (!g.edges.length || visitedStops < 2 || visitedStops < stops.length * 0.5) {
+    // §MAJORITY-LEGAL (2026-07-17, Duplex regression witness): a route whose chords are MOSTLY
+    // wall-illegal is junk data passing the coverage gate (Duplex: 2/2 = 100% illegal on a
+    // 3-pt route after v2 walker connected its 2 approx rooms). Engine residual stays welcome
+    // (Terminal 10/89≈11%, HHS 0/50); majority-illegal rejects.
+    if (!g.edges.length || visitedStops < 2 || visitedStops < stops.length * 0.5 ||
+        (checkedChords > 0 && illegalChords * 2 > checkedChords)) {
       console.log('[TOUR] §FLY_ROUTE_REJECT edges=' + g.edges.length + ' visited=' + visitedStops +
         '/' + stops.length + ' illegalChords=' + illegalChords + ' → legacy tour');
       return null;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -831,7 +831,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
-<script src="tour.js?v=10" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
+<script src="tour.js?v=12" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>


### PR DESCRIPTION
Post-#834 regression sweep: the v2 walker's better binding let Duplex's thin approx-room graph pass the coverage gate with a 3-pt route where 100% of chords cross walls — worse than its legacy tour. The gate now also rejects when illegal chords exceed half of checked. Engine residual stays welcome (Terminal 11%, HHS 7%, Clinic 0%, imported TerminalMerged 18% — all pass); junk (100%) rejects to the legacy tour.

Regression witnesses: Duplex → legacy CINE(7acts,9pts) exactly as pre-#812; Clinic/HHS routes unchanged with zero guard/re-cure lines; frame-guard + re-cure behavior on the imported building unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)