### PR TITLE
Time Machine: Alt+G N8AO ambient-occlusion during playback (auto, single-pass)

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1210,8 +1210,24 @@
     if (_varVisible) drawVariance();   // §S1 — variance drawer tracks the scrub (hairline + phase-under-cursor)
 
     if (app.markDirty) app.markDirty();
-    // Force immediate render — mobile browsers defer rAF until touch
-    if (app.renderer && app.scene && app.camera) app.renderer.render(app.scene, app.camera);
+    // Force immediate render — mobile browsers defer rAF until touch.
+    // §TM_GI_RENDER (2026-07-17): honor the Alt+G N8AO composer here directly, in SINGLE-PASS mode.
+    // Two facts force this exact shape: (1) TM's desktop render gate wakes, draws ONE frame, then
+    // self-parks the rAF chain (main.js §S286 "§IDLE_GATE park — 0 frames"), so N8AO's temporal
+    // accumulation (accumulate:true) can NEVER converge on a static-camera scrub — it's frozen at a
+    // partial buffer, and whether firstFrame()'s clear won the race with the main loop's own composer
+    // render decided clean-vs-ghost => the intermittent ghost the user saw. Single-pass AO
+    // (accumulate=false) produces a COMPLETE frame in the one render the gate allows. (2) rendering
+    // through the composer here (not raw) makes the AO frame deterministic in this call, not racing
+    // the main loop. No-op unless Alt+G is already engaged. accumulate is restored to true in
+    // deactivate() so a normal (non-TM) Alt+G keeps its converged-still quality.
+    if (app._giComposer && app._giComposerActive) {
+      if (app._giN8aoPass && app._giN8aoPass.configuration) app._giN8aoPass.configuration.accumulate = false;
+      if (!renderAtTime._giLogged) { console.log('§TM_GI_RENDER Time Machine → Alt+G N8AO composer, single-pass (accumulate off)'); renderAtTime._giLogged = true; }
+      app._giComposer.render();
+    } else if (app.renderer && app.scene && app.camera) {
+      app.renderer.render(app.scene, app.camera);
+    }
     updateStatus();
     _broadcastTimeline();   // §S3 — realtime cross-tab scrub + pinpoint the item the data is addressing
   }
@@ -3761,6 +3777,11 @@
     var varBtn = document.getElementById('tm-var'); if (varBtn) varBtn.classList.remove('tm-active');
     var varBox = document.getElementById('tm-var-box'); if (varBox) varBox.classList.remove('open');
     toggleDashDOM(false);
+    // §TM_GI_RENDER restore: renderAtTime forced N8AO single-pass (accumulate off) for TM's
+    // one-frame-then-park render gate. Hand it back to converged-still mode so a plain Alt+G outside
+    // Time Machine regains its multi-frame accumulation quality. Reset the once-per-session log latch too.
+    if (app && app._giN8aoPass && app._giN8aoPass.configuration) app._giN8aoPass.configuration.accumulate = true;
+    renderAtTime._giLogged = false;
     _active = false;
     if (app) app._tmOn = false;  // exposed for pill isActive highlight (panels.js 'tm' entry)
     _panel.style.display = 'none';

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -20,6 +20,7 @@
   function A() { return window.APP || window.A; }
 
   var _active = false;
+  var _tmEnabledGI = false;   // §TM_GI_AUTO: did TM itself switch Alt+G on? (→ TM switches it off on close)
   var _panel = null;
   var _mode = 'DAY';
   var _ops = [];          // all ops sorted by start_ts
@@ -3712,6 +3713,18 @@
   function _finishActivate(app) {
     _active = true;
     app._tmOn = true;  // exposed for pill isActive highlight (panels.js 'tm' entry)
+    // §TM_GI_AUTO (2026-07-17): auto-engage the Alt+G N8AO ambient-occlusion composer so every
+    // Time Machine playback gets contact-shadow grounding without a manual Alt+G press. renderAtTime
+    // runs it single-pass (see §TM_GI_RENDER) to fit TM's one-frame-then-park render gate. Only flip
+    // it if it wasn't ALREADY on — if the user engaged Alt+G themselves, leave it on when TM closes;
+    // deactivate() only auto-offs the instances TM itself switched on. No-op on mobile
+    // (toggleGIPreview is a no-op there) and harmless if the GI POC failed to load.
+    _tmEnabledGI = false;
+    if (!app._giComposerActive && typeof app.toggleGIPreview === 'function') {
+      _tmEnabledGI = true;
+      try { Promise.resolve(app.toggleGIPreview(true)).then(function (ok) { console.log('§TM_GI_AUTO enabled=' + !!ok); }); }
+      catch (e) { console.warn('§TM_GI_AUTO fail ' + e.message); _tmEnabledGI = false; }
+    }
     _activeBuildingCount = app.activeBuildingTotal || 0;
     _isLargeBuilding = _activeBuildingCount > LARGE_BUILDING;
     if (_isLargeBuilding) console.log('§S259_TM_LITE elements=' + app.activeBuildingTotal + ' — sparks disabled (>50K)');
@@ -3782,6 +3795,13 @@
     // Time Machine regains its multi-frame accumulation quality. Reset the once-per-session log latch too.
     if (app && app._giN8aoPass && app._giN8aoPass.configuration) app._giN8aoPass.configuration.accumulate = true;
     renderAtTime._giLogged = false;
+    // §TM_GI_AUTO off: only switch Alt+G off if TM itself turned it on — a user who engaged Alt+G
+    // manually before/independently of TM keeps it on. Order matters: restore accumulate=true FIRST
+    // (above) so the composer is already back in converged mode if it stays on for the manual case.
+    if (_tmEnabledGI && app && app._giComposerActive && typeof app.toggleGIPreview === 'function') {
+      try { app.toggleGIPreview(false); console.log('§TM_GI_AUTO off (TM-owned)'); } catch (e) {}
+    }
+    _tmEnabledGI = false;
     _active = false;
     if (app) app._tmOn = false;  // exposed for pill isActive highlight (panels.js 'tm' entry)
     _panel.style.display = 'none';


### PR DESCRIPTION
## What
Time Machine playback now renders through the **Alt+G N8AO ambient-occlusion composer**, giving construction-sequence playback real contact-shadow grounding — auto-engaged, no manual keypress needed.

## Why it wasn't already free
Playing with Alt+G on *looked* free while the camera orbited (the main render loop honors the GI composer). But two problems surfaced on live test:
- **Static-camera scrub ghosted, intermittently.** Root cause (confirmed via `§IDLE_GATE` logs): the desktop render gate wakes, draws ONE frame, then self-parks the rAF chain (`main.js §S286`). N8AO's temporal accumulation (`accumulate:true`) needs a continuous multi-frame loop to converge — with one-frame-then-park it never does, and `firstFrame()`'s clear racing the main-loop composer render decided clean-vs-ghost per scrub.
- Time Machine self-renders via `renderAtTime` with a **raw** `renderer.render` that bypassed the composer entirely.

## Fix (2 commits)
1. **`renderAtTime` → GI composer, single-pass** (`accumulate=false`). A complete AO frame in the one render the gate allows: deterministic, no buffer to go stale, no ghost. `accumulate` restored to `true` on `deactivate()` so a normal (non-TM) Alt+G keeps its converged-still quality.
2. **Auto-engage on activate / auto-off on deactivate** — but only the instances TM itself turned on; a user who pressed Alt+G manually keeps it on after TM closes.

## Safety
- No-op unless the GI composer is available; **no-op on mobile** (`toggleGIPreview` is a no-op there).
- Default (Alt+G-off, non-TM) rendering is byte-identical.

## Verified (localhost, HHS_Office_Federated)
`§TM_GI_RENDER` + `§TM_GI_AUTO enabled=true` fire; full playback ran clean — cinema beats, night/day cycle, triplanar materials, zero errors; scrub deterministic (no ghost).

Witness tags: `§TM_GI_RENDER`, `§TM_GI_AUTO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)