### PR TITLE
Staffage: seat trees on ground (floating fix) + sprite plumbing

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -166,13 +166,17 @@ async function setupEffects(A, renderer, scene, camera) {
     { file: 'people/person_sitting_formal_male.png',     h: 1.20, place: 'in' },
     { file: 'people/person_sitting_casual_female.png',   h: 1.15, place: 'in' }
   ];
+  // pad = fraction of the PNG that is transparent BELOW the visible trunk base (measured from the
+  // actual cutouts). The sprite is bottom-anchored, so without this the trunk floats pad*h above
+  // ground (poplar's 20% = ~2.2m float). Seat each tree by lowering it pad*h so the trunk meets
+  // the ground; the empty image bottom then falls below the ground plane (clipped, invisible).
   var _STAFFAGE_TREES = [
-    { file: 'trees/tree_oak_big.png',        h: 9.5 },
-    { file: 'trees/tree_linden_big_old.png', h: 10.0 },
-    { file: 'trees/tree_poplar.png',         h: 11.0 },
-    { file: 'trees/tree_oak_young.png',      h: 6.0 },
-    { file: 'trees/tree_beech.png',          h: 7.0 },
-    { file: 'trees/tree_linden_city.png',    h: 8.0 }
+    { file: 'trees/tree_oak_big.png',        h: 9.5,  pad: 0.022 },
+    { file: 'trees/tree_linden_big_old.png', h: 10.0, pad: 0.065 },
+    { file: 'trees/tree_poplar.png',         h: 11.0, pad: 0.200 },
+    { file: 'trees/tree_oak_young.png',      h: 6.0,  pad: 0.062 },
+    { file: 'trees/tree_beech.png',          h: 7.0,  pad: 0.043 },
+    { file: 'trees/tree_linden_city.png',    h: 8.0,  pad: 0.038 }
   ];
   var _photoFacadeLights = [];  // [{mid:{x,z}(three), normalThree:{x,z}, up:PointLight, down:PointLight}]
   var PHOTO_FACADE_UP_BASE = 9, PHOTO_FACADE_DOWN_BASE = 7;
@@ -689,7 +693,13 @@ async function setupEffects(A, renderer, scene, camera) {
     // bbox.zMin / furniture-bottom doesn't match the RENDERED ground plane (which sits at
     // _calcGroundY's ground-floor-slab level, ~0.3m higher). Snap every figure's feet to the actual
     // ground plane the user sees, so nobody sinks. Ground-floor placement, so this is the right floor.
-    if (_staffageGroundY != null) spr.position.y = _staffageGroundY;
+    // §PHOTO_STAFFAGE_PAD (user: "some trees floating a bit"): the cutout has transparent padding
+    // below its visible base (measured per asset — trees 2-20%, people 0%), so lower it by pad*h so
+    // the VISIBLE base sits on the ground. baseOffset lets the witness read the visible base, not the
+    // image-bottom anchor.
+    var _padY = entry.h * (entry.pad || 0);
+    spr.userData.baseOffset = _padY;
+    if (_staffageGroundY != null) spr.position.y = _staffageGroundY - _padY;
     function _size() {
       var img = tex.image;
       var aspect = (img && img.width && img.height) ? (img.width / img.height) : 0.5;
@@ -842,7 +852,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // §-witness the feet-on-ground invariant IN the log (readable from any real session's console,
     // no browser needed): every sprite's feet Y minus the rendered ground Y — must be 0,0.
     var _fMin = Infinity, _fMax = -Infinity;
-    _photoStaffage.children.forEach(function(s) { var dy = s.position.y - _staffageGroundY; if (dy < _fMin) _fMin = dy; if (dy > _fMax) _fMax = dy; });
+    _photoStaffage.children.forEach(function(s) { var dy = (s.position.y + (s.userData.baseOffset || 0)) - _staffageGroundY; if (dy < _fMin) _fMin = dy; if (dy > _fMax) _fMax = dy; });
     if (!_photoStaffage.children.length) { _fMin = 0; _fMax = 0; }
     console.log('§PHOTO_STAFFAGE people=' + placedP + ' trees=' + placedT + ' pSrc=' + pSrc + ' feetDy=[' + _fMin.toFixed(2) + ',' + _fMax.toFixed(2) + '] groundY=' + _staffageGroundY.toFixed(2) + ' build_ms=' + (performance.now() - _bt0).toFixed(0) + ' pts=' + allPts.length + ' (realPeople=' + realPeople + ' realTrees=' + realTrees + ')');
   }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -684,7 +684,7 @@ async function setupEffects(A, renderer, scene, camera) {
     _staffageTexCache[path] = tex;
     return tex;
   }
-  function _addStaffageSprite(entry, threePos, isPerson) {
+  function _addStaffageSprite(entry, threePos, isPerson, keepY) {
     var tex = _staffageTex(entry.file);
     var spr = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, alphaTest: 0.5, depthWrite: true }));
     spr.center.set(0.5, 0);                 // anchor bottom-centre → the figure stands on the ground
@@ -699,7 +699,10 @@ async function setupEffects(A, renderer, scene, camera) {
     // image-bottom anchor.
     var _padY = entry.h * (entry.pad || 0);
     spr.userData.baseOffset = _padY;
-    if (_staffageGroundY != null) spr.position.y = _staffageGroundY - _padY;
+    // keepY = interior in-frame figure on an upper storey: keep the given floor Z, don't snap to the
+    // building's ground plane (which would drop it to the ground floor). Still apply the pad offset.
+    if (keepY) spr.position.y = threePos.y - _padY;
+    else if (_staffageGroundY != null) spr.position.y = _staffageGroundY - _padY;
     function _size() {
       var img = tex.image;
       var aspect = (img && img.width && img.height) ? (img.width / img.height) : 0.5;
@@ -711,6 +714,7 @@ async function setupEffects(A, renderer, scene, camera) {
     else spr.scale.set(entry.h * 0.5, entry.h, 1);   // provisional until the image arrives
     _photoStaffage.add(spr);
     if (isPerson) _photoStaffagePeople.push(spr);
+    return spr;
   }
   // §PHOTO_STAFFAGE: place cutouts derived from THIS building's real bbox + IfcDoor rows, but ONLY
   // for a category the building has NO real entourage for (real RPC people/trees are handled by the

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v779';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v780';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Follow-up to #839 (started fresh off main per the squash-merge-reuse rule).

- **Floating trees fixed:** tree cutout PNGs have 2–20% transparent padding below the visible
  trunk (poplar 20% → ~2.2m float at h=11m; people PNGs 0%). Measured per asset; lower each tree
  by pad·h so the visible base meets the ground. `§PHOTO_STAFFAGE feetDy` witness now reads the
  visible base, still [0.00,0.00].
- `_addStaffageSprite` returns the sprite + accepts an optional `keepY` (inert plumbing for the
  upcoming interior-framing / per-floor placement).
- sw.js CACHE_VERSION v779 → v780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)