### PR TITLE
fix(modeller): DiscWalker fixtures never borrow cat[0]'s mesh for an unmatched class

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -3946,14 +3946,26 @@ async function _commitDiscWalk(disc, placements) {
       continue;
     }
     var found = cat.find(function (c) { return c.ifc_class === p.ifc_class; });
-    var hash = found ? found.hash : (cat[0] ? cat[0].hash : null);
-    if (!hash) continue;
+    if (!found) {
+      // §DW-HONEST-FALLBACK (DW_FIXTURE_DOUBLE_RENDER_FINDING.md G5, 2026-07-13): NEVER borrow cat[0]'s
+      // mesh for an unmatched class — that folded every unmatched fixture as the catalog's first item,
+      // e.g. a full-height Column per outlet (measured on SampleCastle: h=4.0m boxes, unoccluded X-ray
+      // "spikes"). Same honest-MEASURED-box convention as the §LIVEWIRE geometry_hash branch above:
+      // no catalog hash borrowed, render the real measured footprint (or a small honest default).
+      var fbx = p.bx > 0 ? p.bx : 0.18, fby = p.by > 0 ? p.by : 0.18, fbz = p.bz > 0 ? p.bz : 0.18;
+      ops.push({ op_type: 'GEOM_INSERT',
+        params: { bbox: [-fbx / 2, fbx / 2, -fby / 2, fby / 2, -fbz / 2, fbz / 2],
+                  placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +(p.z - fbz / 2).toFixed(4), rot: +((p.yaw || 0) * 180 / Math.PI).toFixed(4) },
+                  lod: '200', color: color,
+                  _dw: { disc: p.disc, storey: p.storey || '', prov: p.prov || '', ifc: p.ifc_class, host: p.host || null } } });
+      continue;
+    }
     // §DW-ROT-UNIT (W-DW-ROT-UNITS): p.yaw is RADIANS (disc_walker hostBind Math.PI/2 / wall rotation_z);
     // placement.rot is DEGREES everywhere it is consumed (bonsai_library place(), bonsai_gridmove yawRadByFid)
     // — convert at this commit boundary, the same §ARC-ROT-UNIT pattern as arc_editable.js buildSeedOps.
     // Measured unfixed: folded fixture painted at 1.57° instead of 90° (Δ88.43°, dw_rot_units_BEFORE.log).
     ops.push({ op_type: 'GEOM_INSERT',
-      params: { hash: hash, placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +p.z.toFixed(4), rot: (p.yaw || 0) * 180 / Math.PI },
+      params: { hash: found.hash, placement: { x: +p.x.toFixed(4), y: +p.y.toFixed(4), z: +p.z.toFixed(4), rot: (p.yaw || 0) * 180 / Math.PI },
                 lod: '200', color: color,
                 _dw: { disc: p.disc, storey: p.storey || '', prov: p.prov || '', ifc: p.ifc_class, host: p.host || null } } });
   }

--- a/modeller/tests/witness_dw_honest_fallback.js
+++ b/modeller/tests/witness_dw_honest_fallback.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * W-DW-HONEST-FALLBACK — regression witness for DW_FIXTURE_DOUBLE_RENDER_FINDING.md G5 (2026-07-13):
+ * DiscWalker fixtures with no rule-mined geometry_hash AND no catalog match for their ifc_class used to
+ * fall back to cat[0] — the catalog's first entry, borrowed regardless of class — e.g. a full-height
+ * Column box for an electrical outlet (measured on SampleCastle: h=4.0m, unoccluded "spikes" under X-ray).
+ * Fixed in modeller.html's disc-walk commit loop: an unmatched class now renders an honest measured/
+ * default box (same §LIVEWIRE convention as the geometry_hash branch), never a borrowed catalog mesh.
+ *
+ * SampleCastle's ELEC catalog match is independently known to be EMPTY for every placed ifc_class here
+ * (confirmed live: catalogHash=0/325 even pre-fix's alternative removed) — so on THIS building/discipline,
+ * ANY hash-based fixture render is provably the cat[0] bug, never a legitimate match. Assertion: 0/325
+ * fixtures render via a borrowed hash, 0/325 exceed 1.5m in any dimension.
+ */
+'use strict';
+var http = require('http'), fs = require('fs'), path = require('path');
+var { chromium } = require(path.join(process.env.HOME, 'bim-ootb', 'tests', 'node_modules', 'playwright'));
+
+var ROOT = path.join(__dirname, '..', '..');
+var MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+
+function serve() {
+  return new Promise(function (resolve) {
+    var srv = http.createServer(function (req, res) {
+      var p = decodeURIComponent(req.url.split('?')[0]);
+      var fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, function (e, buf) {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, function () { resolve(srv); });
+  });
+}
+
+(async function () {
+  var srv = await serve();
+  var port = srv.address().port;
+  var logs = [];
+  var browser = await chromium.launch();
+  var page = await browser.newPage();
+  page.on('console', function (m) { logs.push(m.text()); });
+  page.on('pageerror', function (e) { logs.push('PAGEERROR ' + e.message); });
+
+  await page.goto('http://localhost:' + port + '/modeller/modeller.html', { waitUntil: 'load', timeout: 30000 });
+  await page.waitForFunction(function () { return window.__sceneReady === true && !!window.SQL && !!window.Bonsai; }, { timeout: 25000 }).catch(function () {});
+
+  await page.click('#b-open'); await page.waitForTimeout(200);
+  await page.click('#m-open-panel .mo-row[data-key="SampleCastle"]');
+  var lastN = -1, stable = 0;
+  var deadline = Date.now() + 120000;
+  while (Date.now() < deadline) {
+    var n = await page.evaluate(function () { var g = window.Bonsai.group && window.Bonsai.group(); return g ? g.children.length : -1; });
+    if (n === lastN) { stable++; if (stable >= 8) break; } else { stable = 0; lastN = n; }
+    await page.waitForTimeout(250);
+  }
+  console.log('§OPEN SampleCastle children=' + lastN);
+  // snapshot pre-walk children (uuids) so we can isolate exactly the NEW individual fold-copy meshes
+  await page.evaluate(function () {
+    var g = window.Bonsai.group();
+    window.__preWalkUUIDs = {}; g.children.forEach(function (o) { window.__preWalkUUIDs[o.uuid] = true; });
+  });
+
+  await page.click('#bo-tree [data-disc="ELEC"]').catch(function (e) { console.log('  click ELEC failed: ' + e.message); });
+  await page.waitForTimeout(2500);
+  // wait for commit to settle (child count stable again, post-walk)
+  lastN = -1; stable = 0; deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    var n2 = await page.evaluate(function () { var g = window.Bonsai.group && window.Bonsai.group(); return g ? g.children.length : -1; });
+    if (n2 === lastN) { stable++; if (stable >= 6) break; } else { stable = 0; lastN = n2; }
+    await page.waitForTimeout(250);
+  }
+  console.log('§WALK children=' + lastN);
+
+  // Query the signed op-log directly (source of truth for what committed, sidesteps THREE mesh/userData
+  // plumbing entirely) — every GEOM_INSERT whose params carry _dw is one of DiscWalker's individual
+  // fold-copies (same mechanism every ARC element uses, per DW_FIXTURE_DOUBLE_RENDER_FINDING.md G1).
+  var sample = await page.evaluate(function () {
+    var ops = window.Bonsai.oplog._geomOps ? window.Bonsai.oplog._geomOps() : [];
+    var out = [];
+    ops.forEach(function (o) {
+      var params = o.parameters || null;   // kernel_ops column name (bonsai_oplog.js _geomOps), not "params"
+      if (!params) return;
+      var dw = params._dw;
+      if (!dw) return;
+      var h, w, d, via;
+      if (params.bbox) { w = params.bbox[1] - params.bbox[0]; d = params.bbox[3] - params.bbox[2]; h = params.bbox[5] - params.bbox[4]; via = 'bbox'; }
+      else if (params.hash) { via = 'hash:' + params.hash; h = w = d = null; }
+      out.push({ ifc: dw.ifc, disc: dw.disc, via: via, h: h != null ? +h.toFixed(3) : null, w: w != null ? +w.toFixed(3) : null, d: d != null ? +d.toFixed(3) : null });
+    });
+    return out;
+  });
+  console.log('§SAMPLE individual DW fold-copies n=' + sample.length);
+  var tall = sample.filter(function (s) { return s.h >= 1.5 || s.w >= 1.5 || s.d >= 1.5; });
+  // SampleCastle's ELEC catalog match is independently known to be EMPTY for every placed ifc_class
+  // (confirmed via instrumented run, 2026-07-17: catalogHash=0/325 even with the fix removing the cat[0]
+  // borrow) — so ANY hash-based render here is provably the old wrong-class/wrong-size cat[0] borrow,
+  // not a legitimate catalog match. bbox-based = the honest fallback (fixed); hash-based = the bug (unfixed).
+  var borrowed = sample.filter(function (s) { return s.via && s.via.indexOf('hash:') === 0; });
+  console.log('§RESULT tallOrWide(>=1.5m)=' + tall.length + '/' + sample.length + '  cat0Borrowed=' + borrowed.length + '/' + sample.length);
+  if (tall.length) console.log('  examples: ' + JSON.stringify(tall.slice(0, 5)));
+  if (borrowed.length) console.log('  borrowed examples: ' + JSON.stringify(borrowed.slice(0, 5)));
+  if (!tall.length && !borrowed.length) console.log('  max dim seen: ' + JSON.stringify(sample.slice().sort(function (a, b) { return Math.max(b.h||0, b.w||0, b.d||0) - Math.max(a.h||0, a.w||0, a.d||0); })[0]));
+
+  console.log(logs.filter(function (l) { return /PAGEERROR|§DISC-WALK|§DW-FOLD-DEBUG/.test(l); }).join('\n'));
+  await browser.close();
+  srv.close();
+  process.exit((tall.length || borrowed.length) ? 1 : 0);
+})().catch(function (e) { console.log('❌ UNCAUGHT ' + String(e && e.message || e)); process.exit(1); });


### PR DESCRIPTION
## Summary
- `DW_FIXTURE_DOUBLE_RENDER_FINDING.md` G5 (2026-07-13): a DiscWalker fixture with no catalog match and no rule-mined `geometry_hash` fell back to `cat[0]` — the catalog's first entry, borrowed regardless of class (e.g. a full-height Column box for an electrical outlet).
- Root cause of the "wall spikes" visual on SampleCastle's X-ray reveal — measured pre-fix: 6 sampled largest individual fold-copy meshes all `h=4.0m`.
- Fix mirrors the existing `§LIVEWIRE` geometry_hash branch's own convention: render the honest measured bbox instead of borrowing a catalog mesh.
- Does NOT fix the separate, already-documented alpha-accumulation finding in the same file (SampleCastle's ~3225 stacked semi-transparent surfaces still compound visually even with correctly-sized meshes) — orthogonal rendering-tuning question, out of scope here.

## Test plan
- [x] New `witness_dw_honest_fallback.js`: SampleCastle ELEC walk (325 fixtures, confirmed zero legitimate catalog matches for any placed class in this building)
- [x] Before (unmodified main): 325/325 fixtures borrowed the identical hash (literal `cat[0]`, one hash across 325 different `ifc_class`es)
- [x] After (this fix): 0/325 borrowed, 0/325 exceed 1.5m in any dimension, real sizes 0.03-0.14m
- [x] Re-ran clean in a fresh worktree off current `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)