### PR TITLE
fix(modeller): DiscWalker fixtures no longer z-fight against their own instanced twin

### DIFF
--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -568,6 +568,12 @@ async function xrayReveal(on) {
   if (!on) {
     _xrayOn = false;
     await window.Bonsai.oplog.scrubTo(window.Bonsai.oplog.length);   // re-fold the signed log = authoritative restore
+    // §DW-DEDUP-RENDER: scrubTo's re-fold rebuilds every individual mesh FRESH from the op-log (default
+    // material, not deduped) — without this, a disc-walked fixture's individual fold-copy would come back
+    // fully opaque/visible post-restore, un-doing the dedup and reintroducing the z-fight next redraw.
+    // _redrawAllDiscWalks re-applies it (and rebuilds the InstancedMesh buckets) the same way every other
+    // refold path (undo/redo, commit) already does.
+    _redrawAllDiscWalks();
     if (window.A && A.requestRender) A.requestRender();
     console.log('§MODELLER xray off');
     return { on: false, glass: 0, glow: 0 };
@@ -3786,6 +3792,31 @@ function _renderDiscWalk(disc, placements) {
     ' (lod400=rule-mined REAL mesh from shared mesh.db [§LIVEWIRE], lod300=matched real catalog mesh, lod200=measured POC box; honest tally, never silently "fixed")');
   if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
   try { _applyShadowFlags(); } catch (e) { }   // §POLISH3 §V6: new buckets get cast/receive flags (or trip the perf guard)
+  // §DW-DEDUP-RENDER (DW_FIXTURE_DOUBLE_RENDER_FINDING.md G1-G3, visual z-fighting confirmed 2026-07-17
+  // chasing a guide screenshot): the standard commit path ALSO folds every disc-walked placement as an
+  // individual op-log mesh (same mechanism every ARC element uses, for signed provenance/undo) — that mesh
+  // and this function's InstancedMesh bucket both stayed visible forever, at two independently-computed
+  // (near but not bit-identical) positions, z-fighting. That individual mesh is NOT dead weight, though —
+  // W-E2E-INSTPICK's own P2 relies on it being the click-to-identify target (window.Bonsai._selSet resolves
+  // via ITS featureId → the signed _dw op, full identity). A first attempt that set `.visible = false`
+  // fixed the z-fighting but broke picking (the ray no longer hits it at all, falling through to whatever
+  // ARC mesh sits behind). Fix instead by making it invisible to RENDERING only — transparent, opacity 0,
+  // no depth write — while leaving `.visible = true` so raycasting/pick keeps working exactly as before.
+  try {
+    var _dwOps = window.Bonsai.oplog._geomOps();
+    var _dwFids = {};
+    _dwOps.forEach(function (o) { if (o.parameters && o.parameters._dw && o.parameters._dw.disc === disc) _dwFids[o.id] = 1; });
+    var _dwHidden = 0;
+    window.Bonsai.group().children.forEach(function (o) {
+      if (o.isMesh && o.material && o.userData && _dwFids[o.userData.featureId] && !o.userData.__dwDedupDone) {
+        if (!o.userData.__dwDedupOwnMat) { o.material = o.material.clone(); o.userData.__dwDedupOwnMat = true; }
+        o.material.transparent = true; o.material.opacity = 0; o.material.depthWrite = false; o.material.needsUpdate = true;
+        o.userData.__dwDedupDone = true;
+        _dwHidden++;
+      }
+    });
+    if (_dwHidden) console.log('§DW-DEDUP-RENDER disc=' + disc + ' hid=' + _dwHidden + ' individual fold-copies (instanced twin is the visible one, twin stays pickable)');
+  } catch (e) { console.warn('§DW-DEDUP-RENDER failed ' + (e && e.message)); }
 }
 window.__renderDiscWalk = _renderDiscWalk;   // §8E-2b test hook: deterministic disc-walk render for W-DW-DENSITY-TE
 // §DISCWALK-ALL-FLASH: "each element flashes ORANGE as it resolves, then settles to its real colour" — a

--- a/modeller/tests/witness_dw_dedup_render.js
+++ b/modeller/tests/witness_dw_dedup_render.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * W-DW-DEDUP-RENDER — regression witness for DW_FIXTURE_DOUBLE_RENDER_FINDING.md G1-G3, visually
+ * confirmed 2026-07-17 chasing a guide-shot close-up (a ceiling light z-fought into a garbled oval).
+ * Every disc-walked fixture folds BOTH as an individual op-log mesh (signed provenance/undo, same
+ * mechanism every ARC element uses) AND as an InstancedMesh bucket (perf). Both used to stay fully
+ * visible/opaque forever at two independently-computed near-but-not-identical positions → z-fighting.
+ * Fix: the individual fold-copy goes opacity:0/transparent (RENDER-invisible) while staying
+ * `visible:true` (still raycastable — window.Bonsai._selSet pick-to-identify depends on it, W-E2E-INSTPICK
+ * P2). Assert this holds after a fresh walk AND survives xrayReveal(true)->xrayReveal(false) (a full
+ * op-log re-fold that rebuilds every individual mesh from scratch with default material — the first
+ * fix attempt didn't re-apply after that path and silently regressed).
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const { chromium } = require(path.join(process.env.HOME, 'bim-ootb', 'tests', 'node_modules', 'playwright'));
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.css': 'text/css', '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function serve() {
+  return new Promise(resolve => {
+    const srv = http.createServer((req, res) => {
+      const p = decodeURIComponent(req.url.split('?')[0]);
+      const fp = path.join(ROOT, p === '/' ? 'modeller/modeller.html' : p);
+      fs.readFile(fp, (e, buf) => {
+        if (e) { res.statusCode = 404; return res.end('nf'); }
+        res.setHeader('Content-Type', MIME[path.extname(fp)] || 'application/octet-stream');
+        res.setHeader('Accept-Ranges', 'bytes');
+        res.end(buf);
+      });
+    });
+    srv.listen(0, () => resolve(srv));
+  });
+}
+
+async function openAndWalk(pg, key, disc) {
+  await pg.click('#b-open'); await sleep(200);
+  await pg.click(`#m-open-panel .mo-row[data-key="${key}"]`);
+  let lastN = -1, stable = 0, deadline = Date.now() + 120000;
+  while (Date.now() < deadline) {
+    const n = await pg.evaluate(() => { const g = window.Bonsai.group && window.Bonsai.group(); return g ? g.children.length : -1; });
+    if (n === lastN) { stable++; if (stable >= 8) break; } else { stable = 0; lastN = n; }
+    await sleep(250);
+  }
+  await pg.click(`#bo-tree [data-disc="${disc}"]`).catch(() => {});
+  const wdl = Date.now() + 60000;
+  while (Date.now() < wdl) {
+    const done = await pg.evaluate(d => window.__dwLastCommitDisc === d, disc);
+    if (done) break;
+    await sleep(300);
+  }
+  await sleep(1000);
+}
+
+async function dedupState(pg, disc) {
+  return pg.evaluate(d => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const fids = new Set();
+    ops.forEach(o => { if (o.parameters && o.parameters._dw && o.parameters._dw.disc === d) fids.add(o.id); });
+    const g = window.Bonsai.group();
+    let total = 0, deduped = 0, stillOpaqueVisible = 0, missing = 0;
+    fids.forEach(fid => {
+      const mesh = g.children.find(o => o.isMesh && o.userData && o.userData.featureId === fid);
+      total++;
+      if (!mesh) { missing++; return; }
+      const m = mesh.material;
+      const isDeduped = mesh.visible === true && m.transparent === true && m.opacity < 0.01;
+      if (isDeduped) deduped++; else stillOpaqueVisible++;
+    });
+    return { total, deduped, stillOpaqueVisible, missing };
+  }, disc);
+}
+
+(async () => {
+  const srv = await serve(); const port = srv.address().port;
+  const browser = await chromium.launch();
+  const pg = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+  const logs = [];
+  pg.on('console', m => logs.push(m.text()));
+  await pg.goto(`http://localhost:${port}/modeller/modeller.html`, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('window.__sceneReady === true && !!window.SQL && !!window.Bonsai', null, { timeout: 30000 });
+
+  let pass = 0, fail = 0;
+  function chk(name, cond, extra) { if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); } else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); } }
+  console.log('═══ W-DW-DEDUP-RENDER — individual fold-copy vs InstancedMesh, chase-to-zero ═══');
+
+  // Duplex ELEC — fresh walk
+  await openAndWalk(pg, 'Duplex', 'ELEC');
+  const s1 = await dedupState(pg, 'ELEC');
+  chk('D1 Duplex fresh-walk: every disc-walked feature deduped', s1.total > 0 && s1.deduped === s1.total && s1.missing === 0,
+    JSON.stringify(s1));
+
+  // survive an xrayReveal(true) -> xrayReveal(false) full re-fold (the gap the first fix attempt missed)
+  await pg.evaluate(() => window.__xrayReveal(true));
+  await sleep(500);
+  await pg.evaluate(() => window.__xrayReveal(false));
+  await sleep(500);
+  const s2 = await dedupState(pg, 'ELEC');
+  chk('D2 Duplex post-xray-restore: still every feature deduped (scrubTo refold re-applies)', s2.total > 0 && s2.deduped === s2.total && s2.missing === 0,
+    JSON.stringify(s2));
+
+  // SampleCastle — a second, larger building
+  await openAndWalk(pg, 'SampleCastle', 'ELEC');
+  const s3 = await dedupState(pg, 'ELEC');
+  chk('D3 SampleCastle fresh-walk: every disc-walked feature deduped', s3.total > 0 && s3.deduped === s3.total && s3.missing === 0,
+    JSON.stringify(s3));
+
+  const errs = logs.filter(l => /PAGEERROR/.test(l));
+  chk('D4 NO-ERROR', errs.length === 0, errs.slice(0, 3).join(' | '));
+
+  console.log(`W-DW-DEDUP-RENDER: ${pass} PASS / ${fail} FAIL`);
+  await browser.close(); srv.close();
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.log('❌ UNCAUGHT ' + String(e && e.message || e)); process.exit(1); });


### PR DESCRIPTION
## Summary
- `DW_FIXTURE_DOUBLE_RENDER_FINDING.md` G1-G3 (2026-07-13): every disc-walked fixture folds BOTH as an individual op-log mesh (signed provenance/undo) AND as an InstancedMesh bucket (perf), both fully visible/opaque forever at two independently-computed positions. Filed as "NOT YET INVESTIGATED" for visual impact — confirmed here: a ceiling light z-fought into a garbled oval next to a cleanly-rendered fan.
- Fix: the individual fold-copy goes `opacity:0`/`transparent` (invisible to rendering) while staying `visible:true` — pick/identify (`window.Bonsai._selSet`) still resolves off it.
- Closes a second gap found while verifying: `xrayReveal(false)`'s restore does a full op-log re-fold that rebuilds individual meshes with default (non-deduped) material — nothing re-applied the fix afterward. `_redrawAllDiscWalks()` now runs after that path too.

## Test plan
- [x] New `witness_dw_dedup_render.js`: 0/102 (Duplex) and 0/270 (SampleCastle) fixtures left double-rendering, including after a full xray-toggle re-fold cycle
- [x] `witness_modeller_disc_walk.js` 8/8, `witness_xray_poc.js` GATE=true, `witness_xray_sc_duplex.js` both PASS, `witness_e2e_walk_all_disciplines.js` 10/10, `witness_dw_honest_fallback.js` clean
- [x] `witness_e2e_instpick.js` P2/P2b/P3 confirmed already-failing on unmodified `origin/main` (via `git stash`) before this change — pre-existing, unrelated, not touched here
- [x] Visual: close-up screenshot before/after — dark z-fight artifacts gone, fan and light both render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)