### PR TITLE
fix(rates): locale productivity deep-merge + gantt cache version bump

### DIFF
--- a/viewer/locale_loader.js
+++ b/viewer/locale_loader.js
@@ -187,9 +187,33 @@
     if (localeData.rates_default && typeof RATES_DEFAULT !== 'undefined') {
       RATES_DEFAULT = localeData.rates_default;
     }
+    // §LOCALE-PRODUCTIVITY-MERGE: locale files intentionally ship PARTIAL productivity tables
+    // (a locale author only needs to override the trades/classes their region's rates actually
+    // differ on — real construction productivity DOES vary by country, this is legitimate, not
+    // a bug). A whole-object replace here would silently DROP every IFC class the locale file
+    // doesn't happen to list, collapsing them to injectGantt()'s generic 120s/element fallback
+    // (confirmed: en_US.js lists only IfcBeam/IfcColumn for STEEL_ERECTOR, so IfcPlate/IfcMember
+    // fell back to 120s vs their real ~2400-2880s — a 20-24x schedule-duration corruption, root
+    // cause of prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2). Merge instead:
+    // scalar trade fields (rate_per_day/crew_size/trade name) replace wholesale — a locale's
+    // day-rate IS a complete override — but productivity merges class-by-class so classes the
+    // locale doesn't mention keep their canonical (rates.js / sequence_rules.json) value.
     if (localeData.labor_rates && typeof LABOR_RATES !== 'undefined') {
       for (var key in localeData.labor_rates) {
-        if (localeData.labor_rates.hasOwnProperty(key)) LABOR_RATES[key] = localeData.labor_rates[key];
+        if (!localeData.labor_rates.hasOwnProperty(key)) continue;
+        var locTrade = localeData.labor_rates[key];
+        if (!LABOR_RATES[key]) { LABOR_RATES[key] = locTrade; continue; }
+        for (var field in locTrade) {
+          if (!locTrade.hasOwnProperty(field)) continue;
+          if (field === 'productivity') {
+            LABOR_RATES[key].productivity = LABOR_RATES[key].productivity || {};
+            for (var cls in locTrade.productivity) {
+              if (locTrade.productivity.hasOwnProperty(cls)) LABOR_RATES[key].productivity[cls] = locTrade.productivity[cls];
+            }
+          } else {
+            LABOR_RATES[key][field] = locTrade[field];
+          }
+        }
       }
     }
     if (localeData.equipment_rates && typeof EQUIPMENT_RATES !== 'undefined') {

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3568,15 +3568,26 @@
 
   // ══════════════════════════════════════════════════════════════════
   // §S260c: JSON CACHE — persist Gantt schedule + Movie Script in IDB
-  // Keys: "gantt:{building}" and "movie:{building}"
+  // Keys: "gantt:v{N}:{building}" and "movie:{building}"
   // Same IDB store as DB file cache. Tiny (100-500KB) vs DB files (10-170MB).
   // Clear Cache on landing deletes entire IDB → next session recomputes.
-  // ══════════════════════════════════════════════════════════════════
+  //
+  // §GANTT_CACHE_VERSION: bump this whenever schedule-GENERATION logic changes in a way that
+  // would make an already-cached schedule wrong (rate/productivity tables, sequence rules,
+  // schedule_gate.js gating logic). A cached 'gantt' entry survives indefinitely otherwise —
+  // §GANTT_CACHE_HIT trusts it forever, so a logic fix alone does NOT reach a browser that
+  // already generated+cached a schedule under the old (buggy) logic; only a version bump does,
+  // since it changes the cache KEY and makes the old entry an orphaned miss. Do NOT rely on
+  // manual cacheDel/tmRefoldSchedule for this class of fix — that requires the user to know to
+  // do it. v2 (2026-07-18): locale_loader.js productivity-map deep-merge fix — see
+  // prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2.
+  var _GANTT_CACHE_VERSION = 2;
 
   function _cacheKey(prefix) {
     var app = A();
     var bld = (app && app.activeBuilding) || 'unknown';
-    return prefix + ':' + bld;
+    var v = (prefix === 'gantt') ? ('v' + _GANTT_CACHE_VERSION + ':') : '';
+    return prefix + ':' + v + bld;
   }
 
   // Read JSON from IDB cache. Returns parsed object or null.


### PR DESCRIPTION
## Summary
- `locale_loader.js` top-level-replaced `LABOR_RATES[trade]` with each locale file's productivity map instead of deep-merging it. Locale files intentionally ship partial tables (a locale only needs to override the classes its region differs on); the replace silently dropped every unlisted IFC class, collapsing them to `injectGantt()`'s generic 120s/element fallback (20-60x too fast). 14 of 18 shipped locales hit this. Root cause of `prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md` Item 2 ("Superstructure built within an hour").
- Fix: scalar trade fields still replace wholesale (a locale's day-rate is a legitimate complete override), but `productivity` now merges class-by-class — a locale's override stays intentional and localized, unlisted classes keep their canonical rate.
- Second commit: version-bumped the IDB `gantt` schedule cache key so browsers that already cached a schedule under the old buggy logic get a clean cache miss and regenerate correctly, instead of serving the stale schedule forever.

## Test plan
- [x] `node --check` on both changed files
- [x] Live-browser verification (Hospital, en_US locale): `IfcPlate`/`IfcMember`/`IfcFooting`/`IfcPile` productivity now retain canonical values instead of falling back to 120s; `en_US`'s own `IfcColumn`/`IfcBeam` overrides still apply
- [x] Corrected schedule verified: Superstructure span 145.4 days (bugged) -> 370.2 days; whole-project 255.3 -> 403.6 days
- [x] Cache-bust verified: seeded a fake entry under the old unversioned cache key, confirmed `activate()` misses it and regenerates fresh under the new key