### PR TITLE
fix(time-machine): streaming re-sweeps TM visibility on new geometry arrival

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1293,6 +1293,9 @@ function setupStreaming(A) {
       console.log('§CONTRACT_CHECK batch=' + _ca_batch + ' instanced=' + _ca_inst +
         ' guidMap=' + _ca_guid + ' streamed=' + A.streamedCount + ' orphans=' + _ca_orphan);
     }
+    // §TM_STREAM_RESWEEP: newly-flushed geometry defaults to visible — if Time Machine is
+    // active, sweep it against the current cursor (no-op when TM isn't active).
+    if (window.tmResweep) window.tmResweep();
   };
 
   // §S261: Bbox-only BatchedMesh flush — ONE flush, all elements start as bbox cubes.
@@ -1461,6 +1464,8 @@ function setupStreaming(A) {
       ' draw_calls=' + drawCalls + ' skip=' + skipCount +
       ' start=real reserved_mb=' + reservedMB);
     document.getElementById('s-meshes').textContent = drawCalls.toLocaleString() + ' draw calls (DLOD)';
+    // §TM_STREAM_RESWEEP: see _flushInstanced — same reasoning, DLOD bbox flush path.
+    if (window.tmResweep) window.tmResweep();
   };
 
   // §S260c: Consolidate fragmented BatchedMesh from progressive flushes into one set.
@@ -1610,6 +1615,9 @@ function setupStreaming(A) {
       ' elements=' + totalElements + ' ms=' + ms);
     document.getElementById('s-meshes').textContent = newDrawCalls.toLocaleString() + ' draw calls';
     if (A.markDirty) A.markDirty();
+    // §TM_STREAM_RESWEEP: see _flushInstanced — consolidation rebuilds BatchedMesh objects
+    // (new object identities), so this needs its own sweep even though nothing NEW streamed in.
+    if (window.tmResweep) window.tmResweep();
   };
 
   // DB init

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4105,4 +4105,15 @@
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. Returns its boolean (count>0 / false); callers cache.
   window.tmGenerateTimeline = function() { return injectGantt(); };
+
+  // §TM_STREAM_RESWEEP: streaming.js has no awareness of Time Machine — new BatchedMesh/
+  // InstancedMesh geometry that finishes streaming in AFTER the current cursor's renderAtTime()
+  // pass defaults to its normal (fully-visible) state and is never swept to match the active
+  // cursor until the NEXT cursor change. On a large building (Hospital: 63K elements) streaming
+  // can take 10s+ seconds, so a user sitting at 0Hr (cursor never moves) sees the scene fill back
+  // up with fully-visible late-arriving geometry that should still be hidden. Confirmed present
+  // on baseline `a13bb0d` too (pre-dates this session — not a regression, a longstanding gap).
+  // streaming.js calls this (feature-detected, optional — same pattern as window.__sfxTM) after
+  // each flush; no-ops when TM isn't active, so zero cost/behavior change for non-TM viewing.
+  window.tmResweep = function() { if (_active) renderAtTime(_cursor); };
 })();


### PR DESCRIPTION
## Summary
Stacked on #853 (branched from it, since it's not yet merged).

- `streaming.js` has zero awareness of Time Machine: new BatchedMesh/InstancedMesh geometry that finishes streaming in defaults to visible and is never swept against the active TM cursor until the cursor itself changes.
- On a large building (Hospital: 63K elements) streaming can take 10+ seconds, so a user sitting at 0Hr (cursor pinned, no playback) watches the scene fill back up with fully-visible late-arriving geometry.
- Confirmed present on pre-session baseline `a13bb0d` — not a regression from this session's other fixes, a longstanding gap.

## Fix
- `time_machine.js` exposes `window.tmResweep()` (no-op when TM isn't active).
- `streaming.js` calls it from the three geometry-flush completion points (`_flushInstanced`, `_flushBboxBatched`, `_consolidateBatched`).

## Test plan
- [x] `node --check` on both files
- [x] Live reproduction (Hospital, activate TM immediately after DB load, jump to 0Hr, poll for 20s): before fix, `batchVisibleSlots` grew 1976/2151 -> 10134/10309 while cursor never moved, on both current code and baseline `a13bb0d`
- [x] Same reproduction against the fix: `batchVisibleSlots`/`instVisible` stay pinned at 0 for the full 20s while totals keep growing (2151 -> 8159), confirming late arrivals now start correctly hidden