### PR TITLE
fix(time-machine): streaming re-sweeps TM visibility (reland — #856 orphaned)

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1301,6 +1301,9 @@ function setupStreaming(A) {
       console.log('§CONTRACT_CHECK batch=' + _ca_batch + ' instanced=' + _ca_inst +
         ' guidMap=' + _ca_guid + ' streamed=' + A.streamedCount + ' orphans=' + _ca_orphan);
     }
+    // §TM_STREAM_RESWEEP: newly-flushed geometry defaults to visible — if Time Machine is
+    // active, sweep it against the current cursor (no-op when TM isn't active).
+    if (window.tmResweep) window.tmResweep();
   };
 
   // §S261: Bbox-only BatchedMesh flush — ONE flush, all elements start as bbox cubes.
@@ -1469,6 +1472,8 @@ function setupStreaming(A) {
       ' draw_calls=' + drawCalls + ' skip=' + skipCount +
       ' start=real reserved_mb=' + reservedMB);
     document.getElementById('s-meshes').textContent = drawCalls.toLocaleString() + ' draw calls (DLOD)';
+    // §TM_STREAM_RESWEEP: see _flushInstanced — same reasoning, DLOD bbox flush path.
+    if (window.tmResweep) window.tmResweep();
   };
 
   // §S260c: Consolidate fragmented BatchedMesh from progressive flushes into one set.
@@ -1618,6 +1623,9 @@ function setupStreaming(A) {
       ' elements=' + totalElements + ' ms=' + ms);
     document.getElementById('s-meshes').textContent = newDrawCalls.toLocaleString() + ' draw calls';
     if (A.markDirty) A.markDirty();
+    // §TM_STREAM_RESWEEP: see _flushInstanced — consolidation rebuilds BatchedMesh objects
+    // (new object identities), so this needs its own sweep even though nothing NEW streamed in.
+    if (window.tmResweep) window.tmResweep();
   };
 
   // DB init

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4105,4 +4105,15 @@
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. Returns its boolean (count>0 / false); callers cache.
   window.tmGenerateTimeline = function() { return injectGantt(); };
+
+  // §TM_STREAM_RESWEEP: streaming.js has no awareness of Time Machine — new BatchedMesh/
+  // InstancedMesh geometry that finishes streaming in AFTER the current cursor's renderAtTime()
+  // pass defaults to its normal (fully-visible) state and is never swept to match the active
+  // cursor until the NEXT cursor change. On a large building (Hospital: 63K elements) streaming
+  // can take 10s+ seconds, so a user sitting at 0Hr (cursor never moves) sees the scene fill back
+  // up with fully-visible late-arriving geometry that should still be hidden. Confirmed present
+  // on baseline `a13bb0d` too (pre-dates this session — not a regression, a longstanding gap).
+  // streaming.js calls this (feature-detected, optional — same pattern as window.__sfxTM) after
+  // each flush; no-ops when TM isn't active, so zero cost/behavior change for non-TM viewing.
+  window.tmResweep = function() { if (_active) renderAtTime(_cursor); };
 })();


### PR DESCRIPTION
## Summary
Re-lands PR #853's follow-up work — the original #856 was mistakenly stacked on the `fix/locale-productivity-deep-merge` branch instead of `main`. When #853 squash-merged into `main` first, #856's own merge never actually landed its diff into `main` (its commits are only reachable from the now-stale `fix/tm-stream-resweep` branch, not `main`). User re-tested live after all three PRs showed "merged" and still hit the bug — that's why: the fix never actually shipped. Cherry-picked cleanly (`1e00ff2`) onto current `main` (which now also includes #854/#855/#857).

Same fix as #856:
- `streaming.js` had zero awareness of Time Machine: new BatchedMesh/InstancedMesh geometry defaults to visible and is never swept against the active TM cursor until the cursor itself changes.
- `time_machine.js` exposes `window.tmResweep()` (no-op when TM isn't active).
- `streaming.js` calls it from the three geometry-flush completion points.

## Test plan
- [x] `node --check` on both files
- [x] Re-verified live against CURRENT `main` (post #854/#855/#857): `batchVisibleSlots`/`instVisible` stay pinned at 0 for a full 20s window sitting at 0Hr while `batchTotalSlots`/`instTotal` keep growing (2151 -> 8159) from streaming — confirms the fix still holds against latest main, not just the original branch point