### PR TITLE
fix(offline): precache Alt+P staffage textures

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -158,6 +158,14 @@ async function setupEffects(A, renderer, scene, camera) {
                                        // so _updateInFrameInterior must not double-populate it indoors
   var _staffageTexCache = {};
   var _STAFFAGE_BASE = 'textures/staffage/';
+  // §STAFFAGE_OFFLINE (2026-07-18): adding/removing a `file:` entry below or in _STAFFAGE_TREES?
+  // Mirror it in viewer/sw.js's STAFFAGE_ASSETS list too. These pngs load via _STAFFAGE_BASE, not
+  // one of sw.js's normal precached paths, so a file only listed here silently falls through to
+  // cacheFirst()'s catch-all — works fine online, synthesizes a 503 when actually offline (the
+  // fetch fails and there's nothing cached to fall back to). This bit the original 12-file ship
+  // (PR #845): the textures existed and worked live, but were never added to sw.js, so offline mode
+  // (and the "Make available offline" button) silently shipped without them. Fixed in
+  // fix/staffage-offline-precache — keep both lists in sync from here on.
   // {file, h(real-world metres)}; width derived from the loaded image's aspect ratio, not hardcoded.
   // role: 'stand' = at entrances; 'sit' = on real furniture (chairs); 'walk' = in circulation
   // (aisles / open floor CLEAR of furniture — a walker standing among chairs reads wrong, user:

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v791';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v792';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -37,8 +37,26 @@ const DEFERRED_LIBS = [
   'lib/xlsx.full.min.js',      // ~0.9MB — only on boq_charts.html / spreadsheet export
   'lib/exceljs.min.js',        // ~0.9MB — only on Excel export
 ];
+// §STAFFAGE_OFFLINE: Alt+P populate-staffage sprite cutouts (~4.2MB, PR #845) — shipped without
+// ever being added here, so they fell through to the default cacheFirst() path: cache miss + a
+// failed real fetch (offline) synthesizes a 503 (see cacheFirst()'s catch below), breaking Alt+P
+// offline even after "Make available offline". Feature-gated like DEFERRED_LIBS, not auto-installed.
+const STAFFAGE_ASSETS = [
+  'textures/staffage/people/person_sitting_casual_female.png',
+  'textures/staffage/people/person_sitting_formal_male.png',
+  'textures/staffage/people/person_standing_casual_male.png',
+  'textures/staffage/people/person_standing_gesture_female.png',
+  'textures/staffage/people/person_walking_gym_female.png',
+  'textures/staffage/people/person_walking_shopping_female.png',
+  'textures/staffage/trees/tree_beech.png',
+  'textures/staffage/trees/tree_linden_big_old.png',
+  'textures/staffage/trees/tree_linden_city.png',
+  'textures/staffage/trees/tree_oak_big.png',
+  'textures/staffage/trees/tree_oak_young.png',
+  'textures/staffage/trees/tree_poplar.png',
+];
 // FULL set (back-compat): GET_PRECACHE returns this so the offline button = full offline.
-const LOCAL_LIBS = [...SHELL_LIBS, ...DEFERRED_LIBS];
+const LOCAL_LIBS = [...SHELL_LIBS, ...DEFERRED_LIBS, ...STAFFAGE_ASSETS];
 
 // CDN fallback URLs — cached opportunistically if loader falls back to them
 const CDN_ASSETS = [

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -41,6 +41,8 @@ const DEFERRED_LIBS = [
 // ever being added here, so they fell through to the default cacheFirst() path: cache miss + a
 // failed real fetch (offline) synthesizes a 503 (see cacheFirst()'s catch below), breaking Alt+P
 // offline even after "Make available offline". Feature-gated like DEFERRED_LIBS, not auto-installed.
+// SOURCE OF TRUTH is effects.js's _STAFFAGE_PEOPLE/_STAFFAGE_TREES — this list must mirror it
+// exactly (see the matching comment there). Add/remove a staffage png in BOTH places, same PR.
 const STAFFAGE_ASSETS = [
   'textures/staffage/people/person_sitting_casual_female.png',
   'textures/staffage/people/person_sitting_formal_male.png',


### PR DESCRIPTION
## Summary
- The 12 Alt+P staffage textures (6 people + 6 trees, ~4.2MB, PR #845) were never added to `viewer/sw.js`'s precache lists — they fell through to the default `cacheFirst()` path, which synthesizes a `503` on a failed real fetch (i.e. actually offline). Broke Alt+P offline even after clicking "Make available offline" (`GET_PRECACHE` never listed them).
- Added a `STAFFAGE_ASSETS` group to `LOCAL_LIBS`, same pattern as the existing `DEFERRED_LIBS` (cache-on-first-use online, or via the offline-download button). Not added to the auto-install `SHELL_LIBS` — 4.2MB is comparable to what §PRECACHE-TRIM deliberately kept off the install path.
- `CACHE_VERSION` v791 → v792.
- Added cross-reference comments in `effects.js` (`_STAFFAGE_PEOPLE`/`_STAFFAGE_TREES`, the source of truth) and `sw.js` (`STAFFAGE_ASSETS`) so the next texture add/remove doesn't silently drift again.

## Test plan
- [x] `node -c viewer/sw.js` / `node -c viewer/effects.js` — syntax OK
- [x] Verified all 12 paths in `STAFFAGE_ASSETS` exist on disk and match `effects.js`'s `_STAFFAGE_BASE` + file list exactly
- [x] Confirmed `_startOfflineDownload()`/`_cacheAllAssets()` in `scene.js` consumes `GET_PRECACHE`'s `libs` field (now includes `STAFFAGE_ASSETS`) with no further wiring needed
- [ ] CI (fast-checks + e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)