### PR TITLE
fix(offline): precache EffectComposer/SSAO/Outline/TAA modules

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v792';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v793';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -29,6 +29,20 @@ const SHELL_LIBS = [
   'lib/sql-wasm.wasm',
   'lib/chart.umd.min.js',
   'lib/FileSaver.min.js',
+  // §EFFECTS_COMPOSER_OFFLINE: setupEffects() (effects.js) dynamic-imports these 6 unconditionally
+  // on every desktop (non-mobile) load, before streaming.js starts — not gated behind a keypress
+  // like Alt+P/Alt+S. ~56KB total, trivial next to the libs above. Were never precached; on a
+  // genuine offline+uncached load each import() rejects (sw.js's cacheFirst() synthesizes a 503 on
+  // a failed fetch), caught by setupEffects()'s own try/catch (§EFFECTS_INIT_FAIL, degrades to
+  // direct render) — not a crash, but silently drops SSAO shadows, the pick/clash/Find outline
+  // highlight, and Alt+S Still-Refine. SHELL not DEFERRED: unlike web-ifc/xlsx these aren't behind
+  // an optional feature, so they should be as guaranteed-present as the libs above.
+  'lib/EffectComposer.js',
+  'lib/RenderPass.js',
+  'lib/TAARenderPass.js',
+  'lib/SSAOPass.js',
+  'lib/OutlinePass.js',
+  'lib/OutputPass.js',
 ];
 // DEFERRED — heavy, feature-gated; cache-on-first-use OR via the offline-download button.
 const DEFERRED_LIBS = [


### PR DESCRIPTION
## Summary
- `setupEffects()` (`effects.js:9`) dynamic-imports 6 modules (`EffectComposer.js`, `RenderPass.js`, `TAARenderPass.js`, `SSAOPass.js`, `OutlinePass.js`, `OutputPass.js`) unconditionally on every desktop (non-mobile) load, before `setupStreaming()` starts — not gated behind Alt+P/Alt+S or any other keypress.
- None were ever added to `sw.js`'s precache lists. On a genuine offline+uncached load, each `import()` rejects (sw.js's `cacheFirst()` synthesizes a 503 on the failed fetch), caught by `setupEffects()`'s own `try/catch` → `§EFFECTS_INIT_FAIL`, degrades to direct render. Not a crash, but silently drops SSAO contact shadows, the orange pick/clash/Find outline highlight, and Alt+S Still-Refine (which no-ops via its own guard, `effects.js:1919`).
- ~56KB total — added to `SHELL_LIBS` (auto-installed on service-worker install), not the `DEFERRED_LIBS`-style bucket used for `fix/staffage-offline-precache` (#860), since these aren't behind an optional feature toggle the way web-ifc/xlsx or the staffage textures are.
- `CACHE_VERSION` v792 → v793.

Same root-cause class as #860 (asset added to the app, never mirrored into `sw.js`), found while explaining what happens when `setupEffects()`'s imports fail offline.

## Test plan
- [x] `node -c viewer/sw.js` — syntax OK
- [x] Verified all 6 `lib/*.js` paths exist and match `setupEffects()`'s `import()` list exactly
- [x] Traced full failure path in code: rejected `Promise.all` → caught by `setupEffects()`'s `try/catch` → `A._composer = null` → every consumer (`scene.js:778`, `navigate_find.js:3479/4945`, `effects.js:1919`, `main.js:850-851/863-864`) is null-guarded — confirms graceful degrade, not a crash, prior to this fix
- [ ] CI (fast-checks + e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)