### PR TITLE
fix(sw): bump CACHE_VERSION v792 -> v793

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v792';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v793';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
Housekeeping catch-up: this project's own `GH_DEPLOY.md` deploy workflow requires bumping `viewer/sw.js`'s `CACHE_VERSION` on every deploy so the service worker purges old caches on activate. Skipped across all three of this session's merged fixes (#852, #853, #859).

## Test plan
- [x] `node --check`