### PR TITLE
fix(schedule): cap concurrent crews per trade project-wide, cascading floor-by-floor

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -86,45 +86,51 @@ function getSMMSection(ifcClass) {
 // ============================================================================
 // LABOR RATES — hardcoded fallback (from boq_export.py)
 // ============================================================================
+// max_crews: §CREW-CAP (2026-07-18) — how many independent crews of this trade work the site
+// SIMULTANEOUSLY project-wide (not per-floor/per-band — schedule_gate.js caps against this total,
+// shared across every level). Matches the same class of estimating assumption as rate_per_day/
+// crew_size already here (CIDB 2024-derived, not extracted from IFC) — editable via the Settings
+// JSON editor / rates/sequence_rules.json the same way. Modest defaults for a large commercial
+// project; bump for a genuinely huge/fast-tracked site, lower for a small one.
 var LABOR_RATES = {
   HVAC_TECH: {
-    rate_per_day: 185, crew_size: 2, trade: 'HVAC Technician (Skilled)',
+    rate_per_day: 185, crew_size: 2, max_crews: 2, trade: 'HVAC Technician (Skilled)',
     productivity: {IfcDuct:18,IfcDuctSegment:18,IfcDuctFitting:12,IfcFlowMovingDevice:4,IfcEnergyConversionDevice:3,IfcFlowTerminal:12,IfcAirTerminal:20}
   },
   PLUMBER: {
-    rate_per_day: 165, crew_size: 2, trade: 'Pipefitter (Skilled)',
+    rate_per_day: 165, crew_size: 2, max_crews: 2, trade: 'Pipefitter (Skilled)',
     productivity: {IfcPipe:25,IfcPipeSegment:25,IfcPipeFitting:15,IfcFlowSegment:20,IfcFlowFitting:15,IfcFlowStorageDevice:4,IfcFlowTreatmentDevice:4,IfcDistributionElement:8,IfcValve:20,IfcFireSuppressionTerminal:25}
   },
   ELECTRICIAN: {
-    rate_per_day: 175, crew_size: 2, trade: 'Electrician (Skilled)',
+    rate_per_day: 175, crew_size: 2, max_crews: 2, trade: 'Electrician (Skilled)',
     productivity: {IfcCableCarrier:30,IfcCableCarrierSegment:30,IfcLightFixture:20,IfcOutlet:25,IfcElectricAppliance:15,IfcFlowController:10,IfcAlarm:25,IfcController:10}
   },
   STEEL_ERECTOR: {
-    rate_per_day: 195, crew_size: 4, trade: 'Steel Erector (Skilled)',
+    rate_per_day: 195, crew_size: 4, max_crews: 3, trade: 'Steel Erector (Skilled)',
     productivity: {IfcBeam:8,IfcColumn:6,IfcPlate:12,IfcMember:10}
   },
   CONCRETE_GANG: {
-    rate_per_day: 145, crew_size: 6, trade: 'Concrete Gang (Mixed)',
+    rate_per_day: 145, crew_size: 6, max_crews: 3, trade: 'Concrete Gang (Mixed)',
     productivity: {IfcSlab:35,IfcFooting:6,IfcPile:4,IfcReinforcingBar:50,IfcRamp:3,IfcRampFlight:3}
   },
   MASON: {
-    rate_per_day: 155, crew_size: 3, trade: 'Mason (Skilled) + Laborers',
+    rate_per_day: 155, crew_size: 3, max_crews: 2, trade: 'Mason (Skilled) + Laborers',
     productivity: {IfcWall:12,IfcWallStandardCase:12,IfcOpeningElement:20,IfcBuildingElementPart:15}
   },
   CARPENTER: {
-    rate_per_day: 165, crew_size: 2, trade: 'Carpenter (Skilled)',
+    rate_per_day: 165, crew_size: 2, max_crews: 2, trade: 'Carpenter (Skilled)',
     productivity: {IfcDoor:6,IfcWindow:6,IfcStair:2,IfcStairFlight:3,IfcRailing:15,IfcCurtainWall:8}
   },
   ROOFER: {
-    rate_per_day: 175, crew_size: 3, trade: 'Roofer (Skilled)',
+    rate_per_day: 175, crew_size: 3, max_crews: 1, trade: 'Roofer (Skilled)',
     productivity: {IfcRoof:25}
   },
   FINISHER: {
-    rate_per_day: 135, crew_size: 2, trade: 'Finisher (Skilled)',
+    rate_per_day: 135, crew_size: 2, max_crews: 2, trade: 'Finisher (Skilled)',
     productivity: {IfcCovering:20,IfcFurniture:8,IfcFurnishingElement:8}
   },
   LABORER: {
-    rate_per_day: 95, crew_size: 1, trade: 'General Laborer',
+    rate_per_day: 95, crew_size: 1, max_crews: 1, trade: 'General Laborer',
     productivity: {}
   },
 };

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -260,6 +260,7 @@
     "HVAC_TECH": {
       "rate_per_day": 185,
       "crew_size": 2,
+      "max_crews": 2,
       "trade": "HVAC Technician (Skilled)",
       "productivity": {
         "IfcDuct": 18,
@@ -274,6 +275,7 @@
     "PLUMBER": {
       "rate_per_day": 165,
       "crew_size": 2,
+      "max_crews": 2,
       "trade": "Pipefitter (Skilled)",
       "productivity": {
         "IfcPipe": 25,
@@ -291,6 +293,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 175,
       "crew_size": 2,
+      "max_crews": 2,
       "trade": "Electrician (Skilled)",
       "productivity": {
         "IfcCableCarrier": 30,
@@ -306,6 +309,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 195,
       "crew_size": 4,
+      "max_crews": 3,
       "trade": "Steel Erector (Skilled)",
       "productivity": {
         "IfcBeam": 8,
@@ -317,6 +321,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 145,
       "crew_size": 6,
+      "max_crews": 3,
       "trade": "Concrete Gang (Mixed)",
       "productivity": {
         "IfcSlab": 35,
@@ -330,6 +335,7 @@
     "MASON": {
       "rate_per_day": 155,
       "crew_size": 3,
+      "max_crews": 2,
       "trade": "Mason (Skilled) + Laborers",
       "productivity": {
         "IfcWall": 12,
@@ -341,6 +347,7 @@
     "CARPENTER": {
       "rate_per_day": 165,
       "crew_size": 2,
+      "max_crews": 2,
       "trade": "Carpenter (Skilled)",
       "productivity": {
         "IfcDoor": 6,
@@ -354,6 +361,7 @@
     "ROOFER": {
       "rate_per_day": 175,
       "crew_size": 3,
+      "max_crews": 1,
       "trade": "Roofer (Skilled)",
       "productivity": {
         "IfcRoof": 25
@@ -362,6 +370,7 @@
     "FINISHER": {
       "rate_per_day": 135,
       "crew_size": 2,
+      "max_crews": 2,
       "trade": "Finisher (Skilled)",
       "productivity": {
         "IfcCovering": 20,
@@ -372,6 +381,7 @@
     "LABORER": {
       "rate_per_day": 95,
       "crew_size": 1,
+      "max_crews": 1,
       "trade": "General Laborer",
       "productivity": {}
     }

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
 // SPDX-License-Identifier: MIT
 /* schedule_gate.js — §gate (2026-05-30, two-pass: geometry + trade order)
+ *                     §CREW-CAP (2026-07-18, real-world crew count)
  * Support-gate FALLBACK scheduler for generated 4D (Time Machine) = "synthetic 4D" organised by
  * phase/task, the same shape a captured MS Project / IFC programme would have. Pure + app-agnostic
  * so the browser (time_machine.js) and the Node witness (tests/test_schedule_gate.js) run identical code.
@@ -16,12 +17,27 @@
  * ε = 0.05m: a support need only start just below me — the thin slab a chair/duct sits on (~0.2m
  * below) counts. (ε=0.5 wrongly skipped it → furniture/flow floated.) Scope: GENERATED fallback only;
  * captured IFC 4D is absorbed verbatim by the overlay AFTER this. No CPM/dependency solving (planner's).
+ *
+ * §CREW-CAP: user, live on Hospital — "It is an impossible timed Gantt chart to have all such work
+ * at once, and within each the items should have a cascading flow." Root cause: the resource-
+ * availability key used to be `resource + '|' + Z-band`, giving EVERY distinct 3m Z-slice (~one per
+ * floor) its OWN independent, uncapped crew — a 14-storey building spun up 14+ simultaneous
+ * STEEL_ERECTOR crews with no shared labor pool, so every level's Superstructure appeared to build
+ * in parallel instead of cascading floor-by-floor like a real site. Fixed: a FIXED, small number of
+ * crew "slots" per resource (maxCrews param — default MAX_CREWS_DEFAULT if not supplied, or a
+ * per-resource lookup object), shared PROJECT-WIDE (not per-band) and shared ACROSS both passes
+ * (a resource like CONCRETE_GANG appears in both — foundations in PASS A, ramps in PASS B — real
+ * crews don't duplicate across passes). Elements are already processed bottom-up by base_z (PASS A)
+ * / by trade-then-base_z (PASS B), so capping crews naturally produces cascading: lower/earlier
+ * elements claim the limited crews first, later ones wait for both their structural dependency
+ * (geoGate) AND crew availability — exactly the two waits a real site has.
  */
 (function (global) {
   'use strict';
   var CELL = 4;     // m — XY grid cell for the spatial support index
   var EPS  = 0.05;  // m — a support must start at least this far below me (excludes same-level peers)
   var GAP  = 0.5;   // m — audit: a support tops within this of my base (the thing I bear on)
+  var MAX_CREWS_DEFAULT = 3;  // §CREW-CAP: fallback crew count per resource when no lookup is given
 
   function cellsOf(e) {
     var o = [], i, j;
@@ -40,10 +56,27 @@
   }
 
   // elements: [{ guid, x0,x1,y0,y1, base_z, top_z, seq, storey, resource, installSecs }] (seq<=4 = structure)
+  // maxCrews: optional — a plain number (uniform cap for every resource) or a { resource: N } lookup
+  //   (e.g. built from LABOR_RATES[resource].max_crews). Falls back to MAX_CREWS_DEFAULT per resource
+  //   when omitted or a resource has no entry. Shared PROJECT-WIDE across both passes (not per-band,
+  //   not per-Level) — see §CREW-CAP header comment.
   // returns { guid: { start, end } } ms.
-  function computeSchedule(elements, baseMs, scaleFactor) {
+  function computeSchedule(elements, baseMs, scaleFactor, maxCrews) {
     baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
     var grid = {}, out = {}, c, cs, k, arr, S;
+    function crewCapFor(resource) {
+      if (typeof maxCrews === 'number') return maxCrews;
+      if (maxCrews && maxCrews[resource]) return maxCrews[resource];
+      return MAX_CREWS_DEFAULT;
+    }
+    var crews = {};  // resource -> [nextFreeMs, nextFreeMs, ...] (length = that resource's crew cap)
+    function claimCrew(resource) {                 // earliest-available of this resource's N crew slots
+      var cap = crewCapFor(resource);
+      var slots = crews[resource] || (crews[resource] = new Array(cap).fill(baseMs));
+      var idx = 0;
+      for (var i = 1; i < slots.length; i++) if (slots[i] < slots[idx]) idx = i;
+      return { time: slots[idx], commit: function (end) { slots[idx] = end; } };
+    }
     function geoGate(el) {                 // latest finish of XY-overlapping structure rising from below
       var g = baseMs; cs = cellsOf(el);
       for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
@@ -58,28 +91,31 @@
         cs = cellsOf(el); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec); }
       return end;
     }
-    // PASS A — structure, bottom-up by base_z (supports scheduled before what rests on them)
+    // PASS A — structure, bottom-up by base_z (supports scheduled before what rests on them).
+    // §CREW-CAP: crew slot is picked PROJECT-WIDE per resource, not per Z-band — lower floors claim
+    // the limited crews first (processing order is already bottom-up), higher floors cascade behind.
     var struct = elements.filter(function (e) { return e.seq <= 4; })
       .sort(function (a, b) { return (a.base_z - b.base_z) || (a.seq - b.seq); });
-    var rcA = {};
     struct.forEach(function (el) {
-      var rk = el.resource + '|' + Math.floor(el.top_z / 3);
-      var start = Math.max(geoGate(el), rcA[rk] || baseMs);
-      rcA[rk] = place(el, start);
+      var slot = claimCrew(el.resource);
+      var start = Math.max(geoGate(el), slot.time);
+      slot.commit(place(el, start));
     });
     // PASS B — non-structure, by trade then base_z, on the COMPLETED structure grid.
     // Per-Level trade gate: trade k waits for all lower trades (s<k) in its Level → MEP late, furniture last.
+    // §CREW-CAP: same shared project-wide crew pool as PASS A (a resource like CONCRETE_GANG appears
+    // in both — foundations here, ramps there — real crews don't duplicate across passes).
     var nonst = elements.filter(function (e) { return e.seq > 4; })
       .sort(function (a, b) { return (a.seq - b.seq) || (a.base_z - b.base_z); });
-    var phaseTrade = {}, rcB = {};
+    var phaseTrade = {};
     nonst.forEach(function (el) {
       var ph = collapsePhase(el.storey);
       var pt = phaseTrade[ph] || {}, tg = baseMs, s;
       for (s in pt) if (+s < el.seq && pt[s] > tg) tg = pt[s];
-      var rk = el.resource + '|' + ph;
-      var start = Math.max(geoGate(el), tg, rcB[rk] || baseMs);
+      var slot = claimCrew(el.resource);
+      var start = Math.max(geoGate(el), tg, slot.time);
       var end = place(el, start);
-      rcB[rk] = end;
+      slot.commit(end);
       (phaseTrade[ph] = phaseTrade[ph] || {});
       if (!(phaseTrade[ph][el.seq] > end)) phaseTrade[ph][el.seq] = end;
     });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v794';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v795';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2701,8 +2701,13 @@
     // schedule_gate.js (unit-tested: tests/test_schedule_gate.js → 0/1970 floating on real Hospital
     // geometry vs 1127/1970 before). Captured IFC 4D still OVERWRITES the covered subset VERBATIM in
     // the overlay pass below — this governs only the GENERATED fallback timing. No CPM/deps (planner's).
+    // §CREW-CAP (2026-07-18): real-world crew count per trade — see schedule_gate.js header.
+    // LABOR_RATES[resource].max_crews (rates.js / rates/sequence_rules.json), falls back to
+    // schedule_gate.js's own MAX_CREWS_DEFAULT for any resource without an explicit value.
+    var _maxCrews = {};
+    for (var _mcRes in LR) if (LR[_mcRes].max_crews) _maxCrews[_mcRes] = LR[_mcRes].max_crews;
     var _sched = (typeof ScheduleGate !== 'undefined' && ScheduleGate.computeSchedule)
-      ? ScheduleGate.computeSchedule(elements, baseMs, scaleFactor) : null;
+      ? ScheduleGate.computeSchedule(elements, baseMs, scaleFactor, _maxCrews) : null;
     if (!_sched) { console.warn('§SUPPORT_CHECK ScheduleGate.js not loaded — generated 4D aborted'); return false; }
 
     // §S280h: ONE transaction + prepared statement (batched INSERTs — avoids the multi-second freeze).
@@ -3579,9 +3584,10 @@
   // already generated+cached a schedule under the old (buggy) logic; only a version bump does,
   // since it changes the cache KEY and makes the old entry an orphaned miss. Do NOT rely on
   // manual cacheDel/tmRefoldSchedule for this class of fix — that requires the user to know to
-  // do it. v2 (2026-07-18): locale_loader.js productivity-map deep-merge fix — see
+  // do it. v2 (2026-07-18): locale_loader.js productivity-map deep-merge fix. v3 (2026-07-18):
+  // schedule_gate.js §CREW-CAP fix (uncapped per-Z-band crews → capped project-wide pool) — see
   // prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2.
-  var _GANTT_CACHE_VERSION = 2;
+  var _GANTT_CACHE_VERSION = 3;
 
   function _cacheKey(prefix) {
     var app = A();


### PR DESCRIPTION
## Summary
User, live on Hospital with a screenshot: mini-Gantt showed every Level's Superstructure bar bunched together right after Substructure. "It is an impossible timed Gantt chart to have all such work at once, and within each the items should have a cascading flow."

Root cause: `schedule_gate.js`'s resource-availability key was `resource + Z-band`, giving every distinct 3m Z-slice its own independent, uncapped crew. A 9-storey building spun up as many simultaneous STEEL_ERECTOR/CONCRETE_GANG crews as it had bands, with no shared labor pool.

## Fix
- New `LABOR_RATES[resource].max_crews` field (same estimating-assumption category as existing `rate_per_day`/`crew_size`, editable via `rates.js`/`rates/sequence_rules.json`) — default 3 for major trades, 1-2 for smaller specialty ones.
- `schedule_gate.js`: crews are now a fixed number of slots per resource, shared project-wide (not per-band) and across both scheduler passes.
- `time_machine.js`: `_GANTT_CACHE_VERSION` v2->v3 (schedule-generation logic change — a browser with an already-cached v2 schedule needs this to regenerate rather than serve the stale unbounded-parallelism pattern forever).
- `sw.js`: `CACHE_VERSION` v794->v795, per this project's deploy convention.

## Test plan
- [x] `node --check` on all changed files, JSON validated
- [x] `tests/test_schedule_gate.js` still passes: 0/1970 beams, 0/7127 members, 0/35 slabs floating — crew capping doesn't touch the structural-support gate
- [x] Per-Level Superstructure completion (p10/p90 percentiles, not just min/max) verified cascading cleanly bottom-up on real Hospital geometry, before and after
- [x] Live-verified via headless browser against this worktree — numbers match the offline Node replica order-of-magnitude
- [x] Cache-bust verified: seeded a fake `gantt:v2:{building}` entry, confirmed `activate()` ignores it and regenerates fresh under v3