### PR TITLE
fix(time-machine): bump _GANTT_CACHE_VERSION 3→4 (§STOREY-Z fix missed the cache-bust)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v796';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v797';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3613,8 +3613,10 @@
   // manual cacheDel/tmRefoldSchedule for this class of fix — that requires the user to know to
   // do it. v2 (2026-07-18): locale_loader.js productivity-map deep-merge fix. v3 (2026-07-18):
   // schedule_gate.js §CREW-CAP fix (uncapped per-Z-band crews → capped project-wide pool) — see
-  // prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2.
-  var _GANTT_CACHE_VERSION = 3;
+  // prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2. v4 (2026-07-18): §STOREY-Z
+  // no-storey-element reassignment (PR #869) — Item 6. Missed on first landing (user hit exactly
+  // this "hard reset didn't fix it" symptom); this bump is that fix's second half.
+  var _GANTT_CACHE_VERSION = 4;
 
   function _cacheKey(prefix) {
     var app = A();


### PR DESCRIPTION
## Summary
- PR #869 shipped the §STOREY-Z fix but missed bumping `_GANTT_CACHE_VERSION` — the same class of gap Item 4 (#853/#862) already hit once. Any browser that already generated+cached a schedule under the old `injectGantt()` keeps serving it from IndexedDB forever; a hard reset does not clear it, only a version bump does.
- User hit this live: "still not happening though hard reset."
- Also bumps `sw.js` `CACHE_VERSION` v796→v797 per this project's per-deploy convention.

## Test plan
- [x] `node --check` on both files passes
- [x] Seeded a fake `gantt:v3:Hospital` IDB cache entry, confirmed `activate()` ignores it entirely (no `§GANTT_CACHE_HIT`) and regenerates fresh under v4 (`§GANTT_STOREY_Z reassigned=9457`)