### PR TITLE
feat(ui): "processing..." pulse on Alt+S/Alt+P Palette icons

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -1199,7 +1199,7 @@ async function setupEffects(A, renderer, scene, camera) {
   // P people, T trees" when done. Cached on later toggles → jumps straight to done. No polling:
   // hooks each unique texture's image 'load' event; the sprite also pops in the frame as it loads.
   function _trackStaffageLoading() {
-    if (!A.status || !_photoStaffage) return;
+    if (!A.status || !_photoStaffage) { A._populateBusy = false; return; }
     var c = _photoStaffage.userData.counts || { people: 0, trees: 0, cars: 0 };
     var doneMsg = '✓ Scene populated — ' + c.people + ' people, ' + c.trees + ' trees, ' + (c.cars || 0) + ' cars';
     var seen = [], texs = [];
@@ -1210,10 +1210,10 @@ async function setupEffects(A, renderer, scene, camera) {
     function loaded() { var n = 0; for (var i = 0; i < texs.length; i++) { var im = texs[i].image; if (im && im.complete && im.naturalWidth) n++; } return n; }
     function paint() {
       var n = loaded();
-      if (n >= total) { A.status.textContent = doneMsg; if (A.markDirty) A.markDirty(); }
+      if (n >= total) { A.status.textContent = doneMsg; A._populateBusy = false; if (A.markDirty) A.markDirty(); }
       else A.status.textContent = '⏳ Populating scene… ' + n + '/' + total;
     }
-    if (!total) { A.status.textContent = doneMsg; return; }
+    if (!total) { A.status.textContent = doneMsg; A._populateBusy = false; return; }
     paint();
     texs.forEach(function(t) {
       var im = t.image;
@@ -1437,6 +1437,12 @@ async function setupEffects(A, renderer, scene, camera) {
   A.togglePopulate = function() {
     var firstEver = !_populateOn;
     _populateOn = true;
+    // §CINEMA_ROW_BUSY (2026-07-18, user ask: "processing..." feedback on the icon itself, not
+    // just the status bar — slower machines' first cutout-decode can take a few secs). Cleared by
+    // _trackStaffageLoading below (every real exit, not a guessed timeout — see that function) once
+    // every texture is loaded, the SAME signal that already drives the "⏳ Populating…"→
+    // "✓ Scene populated" status-bar text.
+    A._populateBusy = true;
     if (A.status) A.status.textContent = '⏳ Populating scene…';
     var freshBuilding = !_photoStaffage || _populateBuilding !== A.activeBuilding;
     if (freshBuilding) {
@@ -2262,13 +2268,17 @@ async function setupEffects(A, renderer, scene, camera) {
     }
   }
   function _startStillAOPhase() {
-    if (!STILL_AO_ENABLED || !A._composer) return;
+    // §CINEMA_ROW_BUSY: every early-return below is a real "nothing more will converge" exit for
+    // THIS still — clear busy here rather than guess a timeout (a fixed timer either fires too
+    // early on a genuinely slow machine — the exact case this flag exists for — or leaves busy
+    // stuck true too long on a fast one; explicit exit coverage has neither failure mode).
+    if (!STILL_AO_ENABLED || !A._composer) { A._stillRefineBusy = false; return; }
     var t0 = performance.now();
     _ensureStillAO().then(function(ao) {
-      if (!ao) return;
+      if (!ao) { A._stillRefineBusy = false; return; }
       // the world may have moved on during the async import — only fold AO into a still that is
       // still frozen, and never fight the GI composer or the cinema loop for the canvas
-      if (!A._stillRefineActive || _stillRefineRAF || A._giComposerActive || _cinemaActive) return;
+      if (!A._stillRefineActive || _stillRefineRAF || A._giComposerActive || _cinemaActive) { A._stillRefineBusy = false; return; }
       _stillAODepthDirty = true;
       ao.pass.firstFrame();
       ao.adapter.enabled = true;
@@ -2288,6 +2298,7 @@ async function setupEffects(A, renderer, scene, camera) {
         if (f >= STILL_AO_FRAMES) {
           console.log('§PHOTO_AO done frames=' + f + ' totalMs=' + Math.round(performance.now() - t0) +
             ' avgRenderMs=' + (renderMs / f).toFixed(1) + ' (frozen with AO — stays until interaction)');
+          A._stillRefineBusy = false;   // §CINEMA_ROW_BUSY: real completion — icon drops "processing"
           return;
         }
         _stillAORAF = requestAnimationFrame(stepAO);
@@ -2296,6 +2307,7 @@ async function setupEffects(A, renderer, scene, camera) {
   }
   function _teardownStillRefine(reason, keepStaging) {
     A._stillRefineActive = false;
+    A._stillRefineBusy = false;   // §CINEMA_ROW_BUSY safety net — any exit path clears "processing"
     if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
     if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
     _stopStillAOPhase(reason);  // §PHOTO_AO: disable the still-only AO pass on ANY exit path
@@ -2336,6 +2348,14 @@ async function setupEffects(A, renderer, scene, camera) {
     // so both active at once fight over every frame. One at a time.
     if (A._giComposerActive && typeof A.toggleGIPreview === 'function') A.toggleGIPreview(false);
     A._stillRefineActive = true;
+    // §CINEMA_ROW_BUSY (2026-07-18, user ask: "processing..." feedback, slower machines take a
+    // few secs): distinct from _stillRefineActive, which stays true for the WHOLE frozen-still
+    // lifetime (converging AND showing the finished result) — this is true only while the 16-sample
+    // TAA + AO/SSGI fold is still actually converging. Cleared at every real completion point
+    // (_startStillAOPhase's f>=STILL_AO_FRAMES branch, the SSGI done callback) and as a safety net
+    // in _teardownStillRefine (every cancel/interaction/cinema-handoff exit), so it can never get
+    // stuck true.
+    A._stillRefineBusy = true;
     A._composerEnabled = true;   // teardown RECOMPUTES from SSAO/Outline state (§GI_HANDOFF_GHOST_FIX) — no save needed
     A._taaPass.accumulate = true;
     A._taaPass.accumulateIndex = -1;

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -537,6 +537,7 @@ async function setupGIPoc(A, renderer, scene, camera) {
     _ssgiKickConverge(STILL_SSGI_FRAMES, function() {
       if (_stillSSGIEngaged) console.log('§PHOTO_SSGI done totalMs=' + Math.round(performance.now() - t0) +
         ' (frozen with GI — stays until interaction)');
+      A._stillRefineBusy = false;   // §CINEMA_ROW_BUSY: real completion on the opt-in SSGI path too
     });
     return true;
   };

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -400,8 +400,14 @@ function setupPanels(A) {
     cinemaRow.style.cssText = 'gap:8px;align-items:center;justify-content:center';
 
     function _refreshCinemaRowIcons() {
-      stillBtn.classList.toggle('active', !!A._stillRefineActive);
-      populateBtn.classList.toggle('active', !!(A.populateActive && A.populateActive()));
+      // §CINEMA_ROW_BUSY: busy (pulsing) takes priority over active (steady) — both flags can be
+      // true at once (e.g. _stillRefineActive is true for the whole frozen-still lifetime, busy
+      // only while it's still converging) so busy must be checked first to show the right state.
+      stillBtn.classList.toggle('busy', !!A._stillRefineBusy);
+      stillBtn.classList.toggle('active', !A._stillRefineBusy && !!A._stillRefineActive);
+      var populateOn = !!(A.populateActive && A.populateActive());
+      populateBtn.classList.toggle('busy', !!A._populateBusy);
+      populateBtn.classList.toggle('active', !A._populateBusy && populateOn);
     }
 
     var stillBtn = A.icon('aperture', { size: 18, title: 'Still Refine (Alt+S)', onClick: function() {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -93,6 +93,11 @@
   }
   .bim-panel .bim-slider-row button:hover { background: rgba(255,255,255,0.1); }
   .bim-panel .bim-slider-row button.active { color: #4fc3f7; }
+  /* §CINEMA_ROW_BUSY (2026-07-18): distinct "processing..." pulse — steady active=done/showing,
+     pulsing busy=still working (16-sample TAA/AO fold, cutout texture decode) so a slow machine
+     doesn't read as "did nothing happen" during the few-seconds gap. */
+  .bim-panel .bim-slider-row button.busy { color: #4fc3f7; animation: bimBusyPulse 0.9s ease-in-out infinite; }
+  @keyframes bimBusyPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
   .bim-panel .bim-slider-row button svg { width: 18px; height: 18px; pointer-events: none; }
   .bim-panel .bim-slider-row input[type=range] {
     flex: 1; accent-color: #4fc3f7; cursor: pointer; min-width: 0;


### PR DESCRIPTION
## Summary
- Adds a distinct pulsing "busy" state to the Alt+S (Still Refine) / Alt+P (Populate) icons in the Palette panel (follow-up to #874), so a slow machine doesn't read as "did nothing happen" during the few-seconds gap before either finishes.
- `A._stillRefineBusy` / `A._populateBusy`: true from click, cleared only at a real completion signal — never a guessed timer. First draft used a blind 6s `setTimeout` fallback; live-verified via Playwright under real system load, it fired ~13s **before** the AO fold actually finished (~24s total that run) — the exact failure this feature exists to prevent. Replaced with explicit coverage of every real exit branch in `_startStillAOPhase` / `_trackStaffageLoading` instead.
- CSS: `.bim-slider-row button.busy` — pulsing opacity, same accent color as `.active`; busy takes priority in the toggle logic since `_stillRefineActive` stays true for the whole frozen-still lifetime, not just while converging.

## Test plan
- [x] `node -c` all touched files
- [x] Live-verified via Playwright: polled `A._stillRefineBusy` and the button's DOM class together across a full run on this (loaded) shared machine — TAA converge at ~12s elapsed, AO fold still correctly `busy=true`/`domClass=busy` at ~24s elapsed, no premature clear
- [ ] CI (fast-checks + e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)