### PR TITLE
feat(viewer): MaxQ movie replaces live-capture orbit at cinema icon / Alt+C

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -126,6 +126,7 @@
     if (A._stillRefineActive || A._stillRefineBusy) A.stopStillRefine(true);
     var nFrames = opts.frames || MAXQ_N_FRAMES, fps = opts.fps || MAXQ_FPS;
     _active = true; _cancel = false;
+    A._maxqActive = true;   // mirror for the cinema icon's busy/done check (panels.js)
     var tgt = A.controls.target.clone();
     var dx = A.camera.position.x - tgt.x, dy = A.camera.position.y - tgt.y, dz = A.camera.position.z - tgt.z;
     var radius = Math.hypot(dx, dz), height = dy, az0 = Math.atan2(dz, dx);
@@ -179,15 +180,13 @@
       _restoreRandom();
       _idbDestroy(db);
       _active = false; _cancel = false;
+      A._maxqActive = false;
     }
   }
 
-  // capture-phase so no bubbling handler can swallow it; witnessed (headless) that synthetic
-  // keydown delivery can lag behind a running cook — the explicit cancel API below is the
-  // guaranteed path either way.
-  document.addEventListener('keydown', function(e) {
-    if (e.altKey && (e.key === 'm' || e.key === 'M')) { e.preventDefault(); start(); }
-  }, true);
+  // No own key binding: Alt+C (scene.js §KBD_ROUTE) and the Palette cinema icon (panels.js)
+  // are the triggers — this feature REPLACES the live-capture orbit at that icon per user spec.
+  // start() while running = cancel (toggle), same as pressing the icon again.
   function cancel() {
     console.log('§MAXQ_CANCEL requested active=' + _active);
     if (_active) _cancel = true;

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -422,15 +422,21 @@ function setupPanels(A) {
     }});
     cinemaRow.appendChild(populateBtn);
 
-    var cinemaBtn = A.icon('video', { size: 18, title: 'Cinema Orbit (Alt+C)', onClick: function() {
-      if (typeof A.startCinemaOrbit !== 'function') return;
-      if (A._stillRefineActive) { console.log('§CINEMA_ORBIT skip — still-refine/cinema already active'); return; }
-      cinemaBtn.classList.add('active'); cinemaBtn.style.pointerEvents = 'none';
-      A.startCinemaOrbit();
+    // §MAXQ: this icon now runs the Max-Quality Orbiter export (each frame a full Alt+S fold,
+    // ~8 min for the 24s clip). Click while running = cancel (start() toggles), so the icon
+    // stays CLICKABLE during the cook — no pointerEvents lock like the old live-capture orbit.
+    // Old A.startCinemaOrbit stays console-callable as the quick live-capture fallback.
+    var cinemaBtn = A.icon('video', { size: 18, title: 'MaxQ Movie (Alt+C — press again to cancel)', onClick: function() {
+      if (typeof A.startMaxQualityOrbit !== 'function') {
+        if (typeof A.startCinemaOrbit === 'function' && !A._stillRefineActive) A.startCinemaOrbit();
+        return;
+      }
+      A.startMaxQualityOrbit();
+      cinemaBtn.classList.add('active');
       var _checkDone = setInterval(function() {
-        if (A._stillRefineActive) return;
+        if (A._maxqActive || A._stillRefineActive) return;
         clearInterval(_checkDone);
-        cinemaBtn.classList.remove('active'); cinemaBtn.style.pointerEvents = '';
+        cinemaBtn.classList.remove('active');
         _refreshCinemaRowIcons();
       }, 500);
     }});

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1230,7 +1230,7 @@ async function setupScene(A) {
       // §CINEMA_SHORTCUT (2026-07-17, user: "Cinema has no shortcut and not in Help box among the
       // others"): same keyboard-only pattern as Zoom above — Cinema Orbit lives as a row inside the
       // Sunglass panel, not its own pill, so it was never in _mainPillActions and never surfaced here.
-      all.push({ seq: 'ALT+C', name: 'Cinema Orbit', icon: '', action: function() { if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); }, children: null });
+      all.push({ seq: 'ALT+C', name: 'MaxQ Movie', icon: '', action: function() { if (typeof A.startMaxQualityOrbit === 'function') A.startMaxQualityOrbit(); else if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); }, children: null });
       // §PHOTO_POPULATE (2026-07-17): Alt+P adds fabricated staffage (people + trees) for the
       // presentation shot — its own toggle, separate from Alt+S's clean extract-only still.
       all.push({ seq: 'ALT+P', name: 'Populate (people + trees)', icon: '', action: function() { if (typeof A.togglePopulate === 'function') A.togglePopulate(); }, children: null });
@@ -1844,7 +1844,7 @@ async function setupScene(A) {
     // Alt+C, distinct namespace from plain 'c' (Clash), no conflict). Previously only reachable via
     // the Sunglass panel's Cinema row (panels.js) — user separately confirmed Cinema Orbit works
     // fine without ever pressing Alt+S first, just adjust the starting camera view and go.
-    if (e.altKey && (e.key === 'c' || e.key === 'C')) { e.preventDefault(); if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); console.log('§KBD_ROUTE Alt+C → cinema orbit'); return; }
+    if (e.altKey && (e.key === 'c' || e.key === 'C')) { e.preventDefault(); if (typeof A.startMaxQualityOrbit === 'function') A.startMaxQualityOrbit(); else if (typeof A.startCinemaOrbit === 'function') A.startCinemaOrbit(); console.log('§KBD_ROUTE Alt+C → MaxQ movie (toggle=cancel)'); return; }
     // §PHOTO_POPULATE (2026-07-17): Alt+P toggles the fabricated staffage layer (people + trees),
     // separate from Alt+S. Distinct namespace from plain 'p' — no conflict.
     if (e.altKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); if (typeof A.togglePopulate === 'function') A.togglePopulate(); console.log('§KBD_ROUTE Alt+P → populate (staffage)'); return; }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v802';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v803';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Follow-up to #884 per user spec: the cinema icon and Alt+C now trigger the Max-Quality Orbiter export (press again to cancel); Alt+M binding removed; `A.startCinemaOrbit` remains as console/fallback. Icon stays clickable during the cook (click = cancel) and tracks the new `A._maxqActive` flag. sw v803. Witnessed headless: Alt+C → §MAXQ_START, toggle → §MAXQ_CANCEL, clean state after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)