### PR TITLE
feat(viewer): §MAXQ_LOADED version fingerprint + ETA in frame logs/status

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -7,6 +7,11 @@
 // retired TM exporter). Single tab = serial: ~1.3s/frame → 360 frames ≈ 8 min cook + 24s stitch.
 (function() {
   'use strict';
+  // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
+  // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
+  // on every behavior change to this module.
+  var MAXQ_V = 'v4 (cinema-path + cancel-saves-partial + eta)';
+  console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
                          // staging captures mid-restore sun-tint/exposure values as "original"
@@ -178,9 +183,13 @@
         await _idbPut(db, i, blob);
         framesDone = i + 1;
         if (i % 15 === 0 || i === nFrames - 1) {
-          console.log('§MAXQ_FRAME i=' + i + '/' + nFrames + ' elapsedMs=' + Math.round(performance.now() - t0));
-          _status('🎬 MaxQ frame ' + (i + 1) + '/' + nFrames + ' — ' +
-            Math.round((performance.now() - t0) / 1000) + 's (Alt+C / cinema icon cancels + saves partial)');
+          var _el = performance.now() - t0;
+          var _eta = i > 0 ? Math.round((_el / (i + 1)) * (nFrames - i - 1) / 1000) : -1;
+          console.log('§MAXQ_FRAME i=' + i + '/' + nFrames + ' elapsedMs=' + Math.round(_el) +
+            ' perFrameMs=' + (i > 0 ? Math.round(_el / (i + 1)) : 0) + ' etaSec=' + _eta);
+          _status('🎬 MaxQ frame ' + (i + 1) + '/' + nFrames + ' — ' + Math.round(_el / 1000) + 's, ~' +
+            (_eta >= 0 ? Math.ceil(_eta / 60) + ' min left' : 'estimating') +
+            ' (Alt+C / cinema icon cancels + saves partial)');
         }
       }
       if (A._stillRefineActive) A.stopStillRefine(true);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v805';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v806';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Logs must self-identify (user: 'make the logs tell u'): `§MAXQ_LOADED v4` at load; `§MAXQ_FRAME` gains `perFrameMs=`/`etaSec=`; status line shows '~N min left'. Motivated by the live Hospital cook running 4.7s/frame (~28 min) with nothing in the log saying so. sw v806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)