### PR TITLE
fix(viewer): §MAXQ_IDB — MaxQ bake no longer deadlocks silently on IndexedDB open

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v7 (rolling ETA + screen wake-lock)';
+  var MAXQ_V = 'v8 (idb open-deadlock guard: timeout + onblocked + pre-purge)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -50,12 +50,53 @@
   function _sleep(ms) { return new Promise(function(res) { setTimeout(res, ms); }); }
   function _status(t) { var A = window.APP; if (A && A.status) A.status.textContent = t; }
 
+  // §MAXQ_IDB — open must NEVER hang silently. An earlier run that exited abnormally (or a second
+  // app tab still holding a connection) leaves _idbDestroy's deleteDatabase() pending-blocked, and
+  // every later open() then queues behind it FOREVER with no event, no error, no log — the exact
+  // "stuck right after §MAXQ_PREVIEW done, zero further lines" report (LTU, v810/MAXQ v7).
+  // Three guards: track+close our own connection, purge any pending delete BEFORE opening, and
+  // race the whole thing against a timeout so a block surfaces as a clean §MAXQ_FAIL abort.
+  var IDB_OPEN_TIMEOUT_MS = 5000;
+  var _db = null;
+  function _idbDelete() {
+    return new Promise(function(res) {
+      var rq;
+      try { rq = indexedDB.deleteDatabase(IDB_NAME); } catch (e) { return res(false); }
+      rq.onsuccess = function() { res(true); };
+      rq.onerror = function() { res(false); };
+      rq.onblocked = function() {
+        console.warn('§MAXQ_IDB_BLOCKED delete blocked — another tab holds ' + IDB_NAME + ' open');
+        res(false);
+      };
+      setTimeout(function() { res(false); }, IDB_OPEN_TIMEOUT_MS);
+    });
+  }
   function _idbOpen() {
     return new Promise(function(res, rej) {
-      var rq = indexedDB.open(IDB_NAME, 1);
+      var settled = false;
+      var timer = setTimeout(function() {
+        if (settled) return;
+        settled = true;
+        rej(new Error('idb-open-timeout'));
+      }, IDB_OPEN_TIMEOUT_MS);
+      var done = function(fn, arg) {
+        if (settled) { try { if (arg && arg.close) arg.close(); } catch (e) {} return; }
+        settled = true; clearTimeout(timer); fn(arg);
+      };
+      var rq;
+      try { rq = indexedDB.open(IDB_NAME, 1); } catch (e) { return done(rej, e); }
       rq.onupgradeneeded = function() { rq.result.createObjectStore(IDB_STORE); };
-      rq.onsuccess = function() { res(rq.result); };
-      rq.onerror = function() { rej(rq.error); };
+      rq.onsuccess = function() {
+        var db = rq.result;
+        // A later version-change request (another tab, or our own next-run delete) must not find
+        // this connection still open — close on demand instead of becoming the zombie blocker.
+        db.onversionchange = function() { try { db.close(); } catch (e) {} if (_db === db) _db = null; };
+        done(res, db);
+      };
+      rq.onerror = function() { done(rej, rq.error || new Error('idb-open-error')); };
+      rq.onblocked = function() {
+        console.warn('§MAXQ_IDB_BLOCKED open blocked behind a pending delete of ' + IDB_NAME);
+      };
     });
   }
   function _idbPut(db, k, v) {
@@ -72,7 +113,11 @@
       rq.onerror = function() { rej(rq.error); };
     });
   }
-  function _idbDestroy(db) { try { db.close(); indexedDB.deleteDatabase(IDB_NAME); } catch (e) {} }
+  function _idbDestroy(db) {
+    try { if (db) db.close(); } catch (e) {}
+    if (_db === db) _db = null;
+    return _idbDelete();
+  }
 
   // Deterministic staging randomness for the duration of each trigger — identical PRNG sequence
   // every frame → zero paint/puddle/skyline-sparkle flicker (staffage is NOT re-placed here; the
@@ -216,16 +261,8 @@
       }
       console.log('§MAXQ_PREVIEW done — camera restored, commencing capture');
     }
-    var db = await _idbOpen();
+    var db = null;
     var framesDone = 0;
-    // Warm-up fold (discarded): staging's async assets (sunset HDRI envMap, AO bundle, textures)
-    // must be resident BEFORE frame 0, or early frames bake a different global lighting baseline
-    // than later ones (whole-building tint shift — measured 21.6dB vs 24.3dB PSNR in the PoC).
-    _status('🎬 MaxQ warming up…');
-    A.startStillRefine();
-    await _waitFoldDone(30000);
-    A.stopStillRefine(true);
-    await _raf2(); await _sleep(3000);
     var t0 = performance.now();
     // §MAXQ_ETA_ROLLING (user 2026-07-19: "74 mins... suddenly 38... now 33.. it is not accurate"):
     // lifetime-average ETA is poisoned by the expensive early frames (indoor prelude close-ups cost
@@ -233,6 +270,22 @@
     // current phase's real rate.
     var _etaPrev = t0, _etaRecent = [];
     try {
+      // IDB first, INSIDE the guard: this open used to sit bare between the preview and the warm-up,
+      // so a blocked open froze the run with zero log lines, _active stuck true (swallowing the next
+      // Alt+C as a cancel-toggle) and the wake lock held. Failing fast here also avoids paying the
+      // warm-up fold before discovering the store is unusable.
+      await _idbDelete();
+      db = _db = await _idbOpen();
+      console.log('§MAXQ_IDB_READY store opened');
+      // Warm-up fold (discarded): staging's async assets (sunset HDRI envMap, AO bundle, textures)
+      // must be resident BEFORE frame 0, or early frames bake a different global lighting baseline
+      // than later ones (whole-building tint shift — measured 21.6dB vs 24.3dB PSNR in the PoC).
+      _status('🎬 MaxQ warming up…');
+      A.startStillRefine();
+      await _waitFoldDone(30000);
+      A.stopStillRefine(true);
+      await _raf2(); await _sleep(3000);
+      t0 = _etaPrev = performance.now();
       for (var i = 0; i < nFrames; i++) {
         if (_cancel) { console.log('§MAXQ_CANCEL i=' + i); break; }
         if (A._stillRefineActive) A.stopStillRefine(true);
@@ -279,13 +332,20 @@
       }
     } catch (e) {
       console.warn('§MAXQ_FAIL ' + e.message);
-      _status('🎬 MaxQ failed: ' + e.message);
+      _status('🎬 MaxQ failed: ' + e.message +
+        (e.message === 'idb-open-timeout' ? ' — close other tabs of this app and retry' : ''));
     } finally {
       _restoreRandom();
-      _idbDestroy(db);
+      // A throw mid-fold (e.g. the idb-open abort) skips the in-try stop — staging would otherwise
+      // stay frozen on screen with the composer accumulating.
+      try { if (A._stillRefineActive) A.stopStillRefine(true); } catch (e2) {}
+      // Recoverability FIRST: clearing the store can itself block for seconds behind the very
+      // zombie connection that failed this run, and until these flags reset the next Alt+C is
+      // swallowed as a cancel-toggle. Cleanup must never gate the ability to retry.
       _active = false; _cancel = false;
       A._maxqActive = false;
       _wakeRelease();
+      await _idbDestroy(db);
     }
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v810';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v811';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_maxq_idb_deadlock.js
+++ b/witness_maxq_idb_deadlock.js
@@ -1,0 +1,96 @@
+// WITNESS — §MAXQ_IDB open-deadlock guard (PHOTOREAL_STILL_RENDER.md §OPEN BUG 2026-07-19).
+// ISSUE PROVEN/DISPROVEN: a pending-blocked deleteDatabase() makes every later indexedDB.open()
+// queue forever, so MaxQ froze after "§MAXQ_PREVIEW done" with ZERO further log lines, _active
+// stuck true and the wake lock held.
+//   CASE A (zombie): a foreign connection + pending delete must produce a clean §MAXQ_FAIL
+//                    idb-open-timeout within ~15s, NOT a silent hang.
+//   CASE B (regression): a normal short bake must still complete (§MAXQ_DONE), unaffected.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const URL = 'http://localhost:8477/viewer/viewer.html?db=buildings/Duplex_extracted.db';
+const IDB_NAME = 'bim_ootb_cinema_maxq';
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 900, height: 600 });
+  const logs = [];
+  page.on('console', m => { const t = m.text(); logs.push(t); if (/§MAXQ|§STILL_REFINE start/.test(t)) console.log('  [page] ' + t); });
+  page.on('pageerror', e => { logs.push('PAGEERROR ' + e.message); console.log('  [pageerror] ' + e.message); });
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // wait for the app + maxq module
+  await page.waitForFunction(() => window.APP && window.APP.startMaxQualityOrbit && window.APP.camera, { timeout: 90000 });
+  await new Promise(r => setTimeout(r, 8000));  // let streaming settle
+  console.log('LOADED. MAXQ_V line: ' + (logs.find(l => l.startsWith('§MAXQ_LOADED')) || 'MISSING'));
+
+  // ---------- CASE A: zombie connection + pending blocked delete ----------
+  console.log('\n=== CASE A — zombie connection, delete left pending/blocked ===');
+  const zombie = await page.evaluate((name) => new Promise((res) => {
+    const rq = indexedDB.open(name, 1);
+    rq.onupgradeneeded = () => { try { rq.result.createObjectStore('frames'); } catch (e) {} };
+    rq.onsuccess = () => {
+      window.__zombieDb = rq.result;          // held open on purpose, never closed, no onversionchange
+      const del = indexedDB.deleteDatabase(name);  // -> blocked, stays PENDING, queues later opens
+      del.onblocked = () => { window.__zombieDelBlocked = true; };
+      setTimeout(() => res({ held: true, blocked: !!window.__zombieDelBlocked }), 1200);
+    };
+    rq.onerror = () => res({ held: false });
+  }), IDB_NAME);
+  console.log('  zombie set up: ' + JSON.stringify(zombie));
+
+  const tA = Date.now();
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ frames: 2, preview: false }); });
+  // in-page wait, but polled from node with a hard ceiling — a HANG is the failure we are testing for
+  let caseADone = false;
+  while (Date.now() - tA < 45000) {
+    if (logs.some(l => l.includes('§MAXQ_FAIL'))) { caseADone = true; break; }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  const elapsedA = Date.now() - tA;
+  const failLine = logs.find(l => l.includes('§MAXQ_FAIL')) || '';
+  const blockedLine = logs.find(l => l.includes('§MAXQ_IDB_BLOCKED')) || '';
+  const stateA = await page.evaluate(() => ({ active: !!window.APP._maxqActive, still: !!window.APP._stillRefineActive }));
+  console.log('  elapsed=' + elapsedA + 'ms  failed=' + caseADone);
+  console.log('  §MAXQ_FAIL      : ' + (failLine || 'NONE  <-- HANG, bug NOT fixed'));
+  console.log('  §MAXQ_IDB_BLOCKED: ' + (blockedLine || 'none'));
+  console.log('  post-state      : ' + JSON.stringify(stateA) + '  (both must be false = recoverable)');
+  const passA = caseADone && /idb-open-timeout/.test(failLine) && !stateA.active && !stateA.still && elapsedA < 30000;
+  console.log('  CASE A: ' + (passA ? 'PASS' : 'FAIL'));
+
+  // release the zombie so case B is a clean environment
+  await page.evaluate(() => { try { window.__zombieDb.close(); } catch (e) {} });
+  await new Promise(r => setTimeout(r, 1500));
+
+  // ---------- CASE B: normal short bake still works ----------
+  console.log('\n=== CASE B — regression, normal 2-frame bake ===');
+  const nBefore = logs.length;
+  const tB = Date.now();
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ frames: 2, preview: false }); });
+  let caseBDone = false;
+  while (Date.now() - tB < 180000) {
+    const tail = logs.slice(nBefore);
+    if (tail.some(l => l.includes('§MAXQ_DONE'))) { caseBDone = true; break; }
+    if (tail.some(l => l.includes('§MAXQ_FAIL'))) break;
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  const tail = logs.slice(nBefore);
+  console.log('  elapsed=' + (Date.now() - tB) + 'ms');
+  console.log('  §MAXQ_IDB_READY : ' + (tail.find(l => l.includes('§MAXQ_IDB_READY')) || 'NONE'));
+  console.log('  §MAXQ_FRAME     : ' + (tail.filter(l => l.includes('§MAXQ_FRAME')).join(' | ') || 'NONE'));
+  console.log('  §MAXQ_DONE      : ' + (tail.find(l => l.includes('§MAXQ_DONE')) || 'NONE'));
+  console.log('  §MAXQ_FAIL      : ' + (tail.find(l => l.includes('§MAXQ_FAIL')) || 'none'));
+  const stateB = await page.evaluate(() => ({ active: !!window.APP._maxqActive }));
+  const passB = caseBDone && !stateB.active;
+  console.log('  CASE B: ' + (passB ? 'PASS' : 'FAIL'));
+
+  const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+  console.log('\npageerrors: ' + errs.length + (errs.length ? ' -> ' + errs.join(' | ') : ''));
+  console.log('\nVERDICT: ' + (passA && passB && !errs.length ? 'PASS — deadlock aborts cleanly, normal bake unaffected'
+                                                             : 'FAIL'));
+  await browser.close();
+  process.exit(passA && passB && !errs.length ? 0 : 1);
+})();


### PR DESCRIPTION
Fixes the open bug recorded in `bim-compiler prompts/PHOTOREAL_STILL_RENDER.md` §OPEN BUG (2026-07-19, LTU): Alt+C → preview flies fine → `§MAXQ_PREVIEW done — commencing capture` → **nothing**. No warm-up, no `§MAXQ_FRAME`, no error.

## Root cause (confirmed by a control witness, not inferred)
A pending-blocked `deleteDatabase()` — left behind by an earlier abnormal exit or a second tab of the app — makes every later `indexedDB.open()` queue **forever**, firing no event at all. `var db = await _idbOpen()` sat bare between the preview and the warm-up, outside the `try/finally`, so the hang produced no `§MAXQ_FAIL` and ran no cleanup.

Control run on the pre-fix build reproduces the report exactly, including the follow-on the user hit:

```
§MAXQ_START frames=2 … / §MAXQ_WAKELOCK acquired
  (45s of total silence — no §MAXQ_FAIL, _maxqActive stuck true)
§MAXQ_CANCEL requested          <- the next Alt+C swallowed as a cancel-toggle
```

## Fixes
- `_idbOpen()`: 5s timeout → rejects `idb-open-timeout`; `onblocked` → `§MAXQ_IDB_BLOCKED`; tracks the connection and sets `db.onversionchange = close` so MaxQ never becomes the zombie blocker itself.
- `_idbDelete()`: awaitable, with `onblocked` + timeout, replacing the fire-and-forget delete.
- Open moved **inside** `try/finally` and **before** the warm-up fold — fails in 5s instead of after a minute of wasted work, and always reaches `§MAXQ_FAIL` + cleanup. Pre-purges any pending delete at run start (idempotent hygiene).
- `finally`: reset `_active`/`_maxqActive`/wake lock **before** awaiting cleanup — the delete can itself block for seconds, and until those flags clear the retry is swallowed. (This was caught by the witness after the first fix round; the abort was clean but still unrecoverable.)
- Stop still-refine in `finally` so a mid-fold throw can't leave staging frozen on screen.

## Witness
`scratchpad/witness_maxq_idb.js`, headless SwiftShader, Duplex:

| Case | v7 (before) | v8 (after) |
|---|---|---|
| A — zombie connection + pending delete | hang, 45s, no log line, `_maxqActive` true | `§MAXQ_FAIL idb-open-timeout` at 10.0s, flags cleared, retry works |
| B — normal 2-frame bake (regression) | — | `§MAXQ_IDB_READY` → 2× `§MAXQ_FRAME` → `§MAXQ_STITCH` → `§MAXQ_DONE` |

Zero pageerrors in both cases. `MAXQ_LOADED v8`, sw `v811`.

Not yet confirmed on the user's real LTU repro — the witness proves the deadlock class aborts cleanly, and the control proves that class produced the exact reported silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)