### PR TITLE
feat(viewer): §MAXQ_MP4 — MaxQ exports mp4/H.264 (plays on iPhone/WhatsApp)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v8 (idb open-deadlock guard: timeout + onblocked + pre-purge)';
+  var MAXQ_V = 'v9 (mp4/H.264 via WebCodecs + hand-rolled mux; webm fallback intact)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -151,6 +151,120 @@
     c.width = w; c.height = h;
     c.getContext('2d').drawImage(A.renderer.domElement, 0, 0, w, h);
     return new Promise(function(res) { c.toBlob(res, 'image/webp', 0.92); });
+  }
+
+  // §MAXQ_MP4 — mp4/H.264 stitch (preferred path). Spec: PHOTOREAL_STILL_RENDER.md §MAXQ_MP4 SPEC.
+  // WHY: the webm/VP9 the MediaRecorder path produces does not play on iPhone or in WhatsApp, which
+  // is the entire distribution channel this movie exists for. mp4/H.264 plays everywhere.
+  // Returns true if an mp4 was produced and downloaded; false = caller must run the webm fallback.
+  // Every failure mode is a clean `return false` with a §MAXQ_MP4_FALLBACK reason — never a throw,
+  // because losing a finished bake to a muxing bug would be far worse than shipping webm.
+  var MP4_CODECS = [
+    'avc1.640034',  // High 5.2 — headroom for large canvases
+    'avc1.4d0034',  // Main 5.2
+    'avc1.42003c',  // Baseline 6.0 (widest device compatibility, if the encoder takes the level)
+    'avc1.640028',  // High 4.0
+    'avc1.42001f'   // Baseline 3.1 — the universally-supported floor
+  ];
+  async function _stitchMp4(db, framesDone, fps, w, h) {
+    var A = window.APP;
+    if (typeof VideoEncoder === 'undefined' || typeof VideoFrame === 'undefined') {
+      console.log('§MAXQ_MP4_FALLBACK reason=no-webcodecs (VideoEncoder/VideoFrame unavailable)');
+      return false;
+    }
+    if (!window.MP4Mux || typeof window.MP4Mux.mux !== 'function') {
+      console.log('§MAXQ_MP4_FALLBACK reason=no-muxer (lib/mp4_mux.js not loaded — stale precache?)');
+      return false;
+    }
+    // H.264 requires even dimensions; the renderer really does hand us odd sizes (1854x963 seen live).
+    var ew = w & ~1, eh = h & ~1;
+    // Photoreal architectural footage — generous bitrate, this is a deliverable not a stream.
+    var bitrate = Math.min(50e6, Math.max(2e6, Math.round(ew * eh * fps * 0.2)));
+    var enc = null, chosen = null, avcC = null, chunks = [], encErr = null;
+    var t0 = performance.now();
+    try {
+      for (var ci = 0; ci < MP4_CODECS.length; ci++) {
+        var codec = MP4_CODECS[ci];
+        var cfg = { codec: codec, width: ew, height: eh, bitrate: bitrate, framerate: fps,
+                    avc: { format: 'avc' }, latencyMode: 'quality' };
+        var sup = false;
+        try { sup = (await VideoEncoder.isConfigSupported(cfg)).supported; } catch (e) { sup = false; }
+        console.log('§MAXQ_MP4 probe codec=' + codec + ' supported=' + sup);
+        if (!sup) continue;
+        // Mozilla bug 1918769: isConfigSupported can answer true and configure() then throws.
+        // Only a real configure() proves the codec — never trust the capability query alone.
+        try {
+          enc = new VideoEncoder({
+            output: function(chunk, md) {
+              if (md && md.decoderConfig && md.decoderConfig.description && !avcC) {
+                var d = md.decoderConfig.description;
+                avcC = new Uint8Array(d.buffer ? d.buffer.slice(d.byteOffset, d.byteOffset + d.byteLength) : d);
+              }
+              var buf = new Uint8Array(chunk.byteLength);
+              chunk.copyTo(buf);
+              // cts = presentation timestamp; chunks arrive in DECODE order, so the muxer needs
+              // this to emit a ctts box when the encoder reorders (Firefox uses B-frames).
+              chunks.push({ data: buf, key: chunk.type === 'key', cts: chunk.timestamp });
+            },
+            error: function(e) { encErr = e.message || String(e); }
+          });
+          enc.configure(cfg);
+          chosen = codec;
+          break;
+        } catch (e2) {
+          console.log('§MAXQ_MP4 probe codec=' + codec + ' configure-threw=' + e2.name + ':' + e2.message);
+          try { if (enc) enc.close(); } catch (e3) {}
+          enc = null;
+        }
+      }
+      if (!enc) { console.log('§MAXQ_MP4_FALLBACK reason=no-usable-h264-codec'); return false; }
+      console.log('§MAXQ_MP4 configured codec=' + chosen + ' size=' + ew + 'x' + eh +
+        ' bitrate=' + bitrate + ' fps=' + fps + ' frames=' + framesDone);
+      _status('🎬 MaxQ encoding mp4/H.264 (' + framesDone + ' frames)…');
+
+      var cv = document.createElement('canvas');
+      cv.width = ew; cv.height = eh;
+      var cx = cv.getContext('2d');
+      var usPerFrame = 1e6 / fps, gop = Math.max(1, Math.round(fps * 2));
+      for (var i = 0; i < framesDone; i++) {
+        var bmp = await createImageBitmap(await _idbGet(db, i));
+        cx.drawImage(bmp, 0, 0);
+        bmp.close();
+        var vf = new VideoFrame(cv, { timestamp: Math.round(i * usPerFrame), duration: Math.round(usPerFrame) });
+        enc.encode(vf, { keyFrame: (i % gop) === 0 });
+        vf.close();
+        // Backpressure — the encoder is the slow end here, not IDB.
+        while (enc.encodeQueueSize > 8) await _sleep(5);
+        if (encErr) throw new Error('encoder-error: ' + encErr);
+      }
+      await enc.flush();
+      try { enc.close(); } catch (e4) {}
+      enc = null;
+      if (encErr) throw new Error('encoder-error: ' + encErr);
+      if (!chunks.length) { console.log('§MAXQ_MP4_FALLBACK reason=zero-chunks'); return false; }
+      if (!avcC) { console.log('§MAXQ_MP4_FALLBACK reason=no-avcC-description'); return false; }
+      var encMs = Math.round(performance.now() - t0);
+      var totalBytes = 0;
+      for (var k = 0; k < chunks.length; k++) totalBytes += chunks[k].data.length;
+      console.log('§MAXQ_MP4 encoded chunks=' + chunks.length + ' bytes=' + totalBytes +
+        ' avcCBytes=' + avcC.length + ' ms=' + encMs +
+        ' (no real-time replay — ' + (framesDone / fps).toFixed(1) + 's of footage)');
+
+      var mp4 = window.MP4Mux.mux({ width: ew, height: eh, fps: fps, avcC: avcC, samples: chunks });
+      var blob = new Blob([mp4], { type: 'video/mp4' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'BIM_MaxQ_' + (A.activeBuilding || 'building') + '_' + Date.now() + '.mp4';
+      document.body.appendChild(a); a.click(); document.body.removeChild(a);
+      setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
+      console.log('§MAXQ_DONE frames=' + framesDone + ' bytes=' + blob.size + ' type=video/mp4 codec=' + chosen);
+      _status('🎬 MaxQ mp4 saved (' + (blob.size / 1e6).toFixed(1) + ' MB) — plays on iPhone/WhatsApp');
+      return true;
+    } catch (e) {
+      console.log('§MAXQ_MP4_FALLBACK reason=' + (e && e.message ? e.message : String(e)));
+      try { if (enc && enc.state !== 'closed') enc.close(); } catch (e5) {}
+      return false;
+    }
   }
 
   async function _stitch(db, framesDone, fps, w, h) {
@@ -326,7 +440,12 @@
       if (framesDone >= (_cancel ? fps : 1)) {
         if (_cancel) console.log('§MAXQ_CANCEL_PARTIAL stitching ' + framesDone + ' frames (' +
           (framesDone / fps).toFixed(1) + 's of footage)');
-        await _stitch(db, framesDone, fps, w, h);
+        // §MAXQ_MP4: mp4/H.264 first (plays on iPhone/WhatsApp), webm MediaRecorder as fallback.
+        // opts.forceWebm=true skips mp4 entirely — that is how the fallback path stays witnessed.
+        var mp4ok = false;
+        if (opts.forceWebm) console.log('§MAXQ_MP4_FALLBACK reason=forced-webm (opts.forceWebm)');
+        else mp4ok = await _stitchMp4(db, framesDone, fps, w, h);
+        if (!mp4ok) await _stitch(db, framesDone, fps, w, h);
       } else if (_cancel) {
         _status('🎬 MaxQ cancelled at frame ' + framesDone + ' — under 1s of footage, nothing saved');
       }

--- a/viewer/lib/mp4_mux.js
+++ b/viewer/lib/mp4_mux.js
@@ -1,0 +1,286 @@
+// §MAXQ_MP4 — minimal ISO-BMFF (MP4) muxer for a single H.264/AVC video track.
+// Spec: bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §MAXQ_MP4 SPEC (2026-07-19).
+//
+// HAND-ROLLED, not vendored: no third-party code, no CDN, no license question — every byte here
+// is auditable against ISO/IEC 14496-12 (ISO base media file format) and 14496-15 (AVC in ISOBMFF).
+// Written for the MaxQ exporter, which already has every encoded chunk in memory before muxing,
+// so this is a non-fragmented, write-once muxer — no fMP4 complexity needed.
+//
+// Layout is FASTSTART: ftyp -> moov -> mdat. moov-last would also be legal, but moov-first is what
+// mobile players and messaging apps (the whole reason this feature exists) want.
+//
+// The avcC payload is the encoder's own AVCDecoderConfigurationRecord, taken verbatim from
+// EncodedVideoChunkMetadata.decoderConfig.description when the VideoEncoder runs avc:{format:'avc'}.
+// It is NOT reconstructed here — nothing about the bitstream is invented by this file.
+(function() {
+  'use strict';
+
+  function u32(n) { return [(n >>> 24) & 255, (n >>> 16) & 255, (n >>> 8) & 255, n & 255]; }
+  function u16(n) { return [(n >>> 8) & 255, n & 255]; }
+  function str4(s) { return [s.charCodeAt(0), s.charCodeAt(1), s.charCodeAt(2), s.charCodeAt(3)]; }
+
+  // A box is [size][type][payload...]; payload parts may be arrays or Uint8Arrays.
+  function box(type, parts) {
+    var len = 8, i, flat = [];
+    for (i = 0; i < parts.length; i++) {
+      var p = parts[i];
+      if (p instanceof Uint8Array) len += p.length; else len += p.length;
+      flat.push(p);
+    }
+    var out = new Uint8Array(len), o = 0, j;
+    out.set(u32(len), 0); out.set(str4(type), 4); o = 8;
+    for (i = 0; i < flat.length; i++) {
+      var q = flat[i];
+      if (q instanceof Uint8Array) { out.set(q, o); o += q.length; }
+      else { for (j = 0; j < q.length; j++) out[o++] = q[j]; }
+    }
+    return out;
+  }
+  function fullBox(type, version, flags, parts) {
+    return box(type, [[version, (flags >>> 16) & 255, (flags >>> 8) & 255, flags & 255]].concat(parts));
+  }
+
+  var UNITY_MATRIX = [
+    0x00, 0x01, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0x00, 0x01, 0x00, 0x00, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0x40, 0x00, 0x00, 0x00
+  ];
+
+  // ---- avcC sanity + in-band recovery ---------------------------------------------------------
+  // MEASURED 2026-07-19: Firefox 148's `decoderConfig.description` is MALFORMED — it emits each
+  // parameter set with its NAL header byte DUPLICATED (SPS `67 67 64 00 28…`, length 24 for a
+  // 23-byte SPS; PPS `68 68 eb…`). ffmpeg decodes it only by luck ("sps_id 1 out of range"), and a
+  // strict mobile player would reject the file outright. Chrome's record is clean.
+  // Firefox does, however, put a correct SPS/PPS IN-BAND ahead of the first IDR. So: parse the
+  // encoder's record, and if the parameter sets don't self-identify correctly, rebuild the record
+  // from the in-band NALs. Nothing is invented — the bytes still come from the encoder either way.
+  function parseAvcC(a) {
+    try {
+      if (!a || a.length < 7 || a[0] !== 1) return null;
+      var o = 5, nsps = a[o] & 0x1f, i, len, sets = { sps: [], pps: [] };
+      o++;
+      for (i = 0; i < nsps; i++) {
+        len = (a[o] << 8) | a[o + 1]; o += 2;
+        if (o + len > a.length) return null;
+        sets.sps.push(a.subarray(o, o + len)); o += len;
+      }
+      var npps = a[o]; o++;
+      for (i = 0; i < npps; i++) {
+        len = (a[o] << 8) | a[o + 1]; o += 2;
+        if (o + len > a.length) return null;
+        sets.pps.push(a.subarray(o, o + len)); o += len;
+      }
+      return sets;
+    } catch (e) { return null; }
+  }
+  function avcCLooksValid(a) {
+    var s = parseAvcC(a);
+    if (!s || !s.sps.length || !s.pps.length) return false;
+    // A well-formed SPS NAL is `nal_unit_type == 7` followed by profile_idc — a duplicated header
+    // byte shows up as byte[1] also carrying nal_unit_type 7, which no real profile_idc does.
+    for (var i = 0; i < s.sps.length; i++) {
+      if ((s.sps[i][0] & 0x1f) !== 7) return false;
+      if (s.sps[i].length > 1 && (s.sps[i][1] & 0x1f) === 7 && (s.sps[i][1] & 0x60) === (s.sps[i][0] & 0x60)) return false;
+    }
+    for (var j = 0; j < s.pps.length; j++) {
+      if ((s.pps[j][0] & 0x1f) !== 8) return false;
+      if (s.pps[j].length > 1 && (s.pps[j][1] & 0x1f) === 8 && (s.pps[j][1] & 0x60) === (s.pps[j][0] & 0x60)) return false;
+    }
+    return true;
+  }
+  // Scan a length-prefixed (AVCC) sample for its in-band SPS (type 7) / PPS (type 8) NALs.
+  function inbandParamSets(sample) {
+    var sps = null, pps = null, o = 0, d = sample;
+    while (o + 4 <= d.length) {
+      var len = (d[o] << 24 >>> 0) + (d[o + 1] << 16) + (d[o + 2] << 8) + d[o + 3];
+      o += 4;
+      if (len <= 0 || o + len > d.length) break;
+      var t = d[o] & 0x1f;
+      if (t === 7 && !sps) sps = d.subarray(o, o + len);
+      else if (t === 8 && !pps) pps = d.subarray(o, o + len);
+      o += len;
+    }
+    return (sps && pps) ? { sps: sps, pps: pps } : null;
+  }
+  function buildAvcC(sps, pps) {
+    var out = [1, sps[1], sps[2], sps[3], 0xff, 0xe1, (sps.length >> 8) & 255, sps.length & 255];
+    var arr = out.concat(Array.prototype.slice.call(sps));
+    arr = arr.concat([1, (pps.length >> 8) & 255, pps.length & 255]);
+    arr = arr.concat(Array.prototype.slice.call(pps));
+    return new Uint8Array(arr);
+  }
+
+  /**
+   * mux({width, height, fps, avcC, samples}) -> Uint8Array
+   *   width/height : encoded frame size in pixels (must match the SPS; even numbers)
+   *   fps          : frames per second (integer or fractional)
+   *   avcC         : Uint8Array — AVCDecoderConfigurationRecord from decoderConfig.description
+   *   samples      : [{data: Uint8Array, key: bool, cts: microseconds}] in DECODE order
+   *                  (WebCodecs delivers output chunks in decode order; `cts` is chunk.timestamp)
+   * Timing: mdhd timescale = round(fps*1000), every sample delta = 1000. Exact for any fps, and
+   * avoids the sub-frame rounding a 1000-timescale would introduce at e.g. 15 or 29.97 fps.
+   * B-FRAMES: Firefox's encoder reorders (decode order != presentation order), so a `ctts` box is
+   * emitted whenever the supplied `cts` values disagree with the decode timeline. Without it the
+   * player shows a few frames in the wrong order — measured, not theoretical.
+   */
+  function mux(opts) {
+    var w = opts.width, h = opts.height;
+    var samples = opts.samples, n = samples.length;
+    var avcC = opts.avcC;
+    if (!n) throw new Error('mp4mux: no samples');
+    var avcCSource = 'encoder';
+    if (!avcCLooksValid(avcC)) {
+      var key0 = null;
+      for (i = 0; i < n; i++) if (samples[i].key) { key0 = samples[i].data; break; }
+      var ib = key0 ? inbandParamSets(key0) : null;
+      if (!ib) throw new Error('mp4mux: avcC malformed and no in-band SPS/PPS to rebuild from');
+      avcC = buildAvcC(ib.sps, ib.pps);
+      avcCSource = 'in-band-rebuild';
+    }
+    if (!avcC || !avcC.length) throw new Error('mp4mux: missing avcC decoder description');
+
+    var timescale = Math.max(1, Math.round(opts.fps * 1000));
+    var sampleDelta = 1000;
+    var trackDuration = n * sampleDelta;                        // in mdhd timescale
+    var MVHD_TS = 1000;                                          // movie timescale = ms
+    var movieDuration = Math.round(trackDuration / timescale * MVHD_TS);
+
+    var totalMdat = 0, i;
+    for (i = 0; i < n; i++) totalMdat += samples[i].data.length;
+
+    var ftyp = box('ftyp', [
+      str4('isom'), u32(512),
+      str4('isom'), str4('iso2'), str4('avc1'), str4('mp41')
+    ]);
+
+    // ---- sample tables -------------------------------------------------------------------
+    var stts = fullBox('stts', 0, 0, [u32(1), u32(n), u32(sampleDelta)]);
+
+    // ctts (composition offsets) — only when the encoder reordered. Offsets are normalised by the
+    // minimum so they are all >= 0 and version-0 (unsigned) ctts stays legal; subtracting a
+    // constant only shifts the whole track's presentation start, never the relative order.
+    var ctts = null, reordered = false, firstCts = 0;
+    var haveCts = true;
+    for (i = 0; i < n; i++) if (typeof samples[i].cts !== 'number') { haveCts = false; break; }
+    if (haveCts) {
+      var offs = [], minOff = Infinity;
+      for (i = 0; i < n; i++) {
+        var ctsTs = Math.round(samples[i].cts * timescale / 1e6);
+        var o = ctsTs - i * sampleDelta;
+        offs.push(o);
+        if (o < minOff) minOff = o;
+      }
+      for (i = 0; i < n; i++) { offs[i] -= minOff; if (offs[i] !== 0) reordered = true; }
+      if (reordered) {
+        // Normalising to non-negative ctts (version 0, the maximally-compatible form) pushes the
+        // first presented sample off t=0 by the reorder delay. An edit list maps it back so the
+        // clip starts on its first frame instead of a fraction of a second of nothing.
+        firstCts = Infinity;
+        for (i = 0; i < n; i++) firstCts = Math.min(firstCts, offs[i] + i * sampleDelta);
+        // Run-length encode into ctts entries.
+        var entries = [], run = 1;
+        for (i = 1; i <= n; i++) {
+          if (i < n && offs[i] === offs[i - 1]) { run++; continue; }
+          entries.push([run, offs[i - 1]]); run = 1;
+        }
+        var cbody = u32(entries.length), ei;
+        for (ei = 0; ei < entries.length; ei++) cbody = cbody.concat(u32(entries[ei][0])).concat(u32(entries[ei][1]));
+        ctts = fullBox('ctts', 0, 0, [cbody]);
+      }
+    }
+    try {
+      console.log('§MAXQ_MP4 mux samples=' + n + ' avcC=' + avcCSource +
+        ' ctts=' + (ctts ? 'yes (B-frame reorder)' : 'no') + ' timescale=' + timescale);
+    } catch (e) {}
+
+    var syncs = [];
+    for (i = 0; i < n; i++) if (samples[i].key) syncs.push(i + 1);   // stss is 1-based
+    // If every sample is a keyframe, stss is optional and may be omitted (all-sync is the default).
+    var stss = (syncs.length === n) ? null : (function() {
+      var body = u32(syncs.length), k;
+      for (k = 0; k < syncs.length; k++) body = body.concat(u32(syncs[k]));
+      return fullBox('stss', 0, 0, [body]);
+    })();
+
+    // One sample per chunk — keeps stsc trivial and stco a straight per-sample offset table.
+    var stsc = fullBox('stsc', 0, 0, [u32(1), u32(1), u32(1), u32(1)]);
+
+    var szBody = u32(0).concat(u32(n));                            // sample_size=0 -> per-sample table
+    for (i = 0; i < n; i++) szBody = szBody.concat(u32(samples[i].data.length));
+    var stsz = fullBox('stsz', 0, 0, [szBody]);
+
+    function buildStco(baseOffset) {
+      var body = u32(n), off = baseOffset, k;
+      for (k = 0; k < n; k++) { body = body.concat(u32(off)); off += samples[k].data.length; }
+      return fullBox('stco', 0, 0, [body]);
+    }
+
+    var avc1 = box('avc1', [
+      [0, 0, 0, 0, 0, 0],          // reserved
+      u16(1),                      // data_reference_index
+      u16(0), u16(0),              // pre_defined, reserved
+      u32(0), u32(0), u32(0),      // pre_defined[3]
+      u16(w), u16(h),
+      u32(0x00480000), u32(0x00480000),  // 72 dpi h/v resolution
+      u32(0),                      // reserved
+      u16(1),                      // frame_count
+      new Uint8Array(32),          // compressorname (32 bytes, zeroed)
+      u16(0x0018),                 // depth
+      [0xff, 0xff],                // pre_defined = -1
+      box('avcC', [avcC])
+    ]);
+    var stsd = fullBox('stsd', 0, 0, [u32(1), avc1]);
+
+    function buildMoov(stco) {
+      var parts = [stsd, stts];
+      if (ctts) parts.push(ctts);
+      if (stss) parts.push(stss);
+      parts.push(stsc, stsz, stco);
+      var stbl = box('stbl', parts);
+      var dinf = box('dinf', [box('dref', [[0, 0, 0, 0], u32(1), fullBox('url ', 0, 1, [])])]);
+      var minf = box('minf', [fullBox('vmhd', 0, 1, [u16(0), u16(0), u16(0), u16(0)]), dinf, stbl]);
+      var hdlr = fullBox('hdlr', 0, 0, [
+        u32(0), str4('vide'), u32(0), u32(0), u32(0),
+        (function() { var s = 'VideoHandler\0', a = [], k; for (k = 0; k < s.length; k++) a.push(s.charCodeAt(k)); return a; })()
+      ]);
+      var mdhd = fullBox('mdhd', 0, 0, [u32(0), u32(0), u32(timescale), u32(trackDuration), u16(0x55c4), u16(0)]);
+      var mdia = box('mdia', [mdhd, hdlr, minf]);
+      var tkhd = fullBox('tkhd', 0, 3, [   // flags 3 = track_enabled | track_in_movie
+        u32(0), u32(0), u32(1), u32(0), u32(movieDuration),
+        u32(0), u32(0), u16(0), u16(0), u16(0), u16(0),
+        UNITY_MATRIX, u32(w * 65536), u32(h * 65536)
+      ]);
+      var trakParts = [tkhd];
+      if (firstCts > 0) {
+        trakParts.push(box('edts', [fullBox('elst', 0, 0, [
+          u32(1), u32(movieDuration), u32(firstCts), u16(1), u16(0)   // rate 1.0 as 16.16
+        ])]));
+      }
+      trakParts.push(mdia);
+      var trak = box('trak', trakParts);
+      var mvhd = fullBox('mvhd', 0, 0, [
+        u32(0), u32(0), u32(MVHD_TS), u32(movieDuration),
+        u32(0x00010000), u16(0x0100), u16(0), u32(0), u32(0),
+        UNITY_MATRIX, u32(0), u32(0), u32(0), u32(0), u32(0), u32(0), u32(2)
+      ]);
+      return box('moov', [mvhd, trak]);
+    }
+
+    // Two-pass: stco entries are fixed 4 bytes, so a moov built with placeholder offsets has the
+    // SAME size as the final one — measure it, then rebuild with the real mdat payload offsets.
+    var probeMoov = buildMoov(buildStco(0));
+    var mdatStart = ftyp.length + probeMoov.length + 8;   // +8 = mdat header
+    var moov = buildMoov(buildStco(mdatStart));
+    if (moov.length !== probeMoov.length) throw new Error('mp4mux: moov size drifted between passes');
+
+    var out = new Uint8Array(ftyp.length + moov.length + 8 + totalMdat), o = 0;
+    out.set(ftyp, o); o += ftyp.length;
+    out.set(moov, o); o += moov.length;
+    out.set(u32(8 + totalMdat), o); o += 4;
+    out.set(str4('mdat'), o); o += 4;
+    for (i = 0; i < n; i++) { out.set(samples[i].data, o); o += samples[i].data.length; }
+    return out;
+  }
+
+  window.MP4Mux = { mux: mux };
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v811';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v812';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -113,6 +113,7 @@ const PRECACHE_ASSETS = [
   'loader.js',
   'effects.js',
   'cinema_maxq.js',
+  'lib/mp4_mux.js',   // §MAXQ_MP4 — hand-rolled mp4 muxer; missing => MaxQ silently falls back to webm
   'input_registry.js',
   'scene.js',
   'streaming.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -823,7 +823,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
-<script src="cinema_maxq.js?v=1" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
+<script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>

--- a/witness_maxq_mp4.js
+++ b/witness_maxq_mp4.js
@@ -1,0 +1,129 @@
+// WITNESS — §MAXQ_MP4 mp4/H.264 export (PHOTOREAL_STILL_RENDER.md §MAXQ_MP4 SPEC 2026-07-19).
+// ISSUE PROVEN/DISPROVEN: the MaxQ movie shipped as webm/VP9, which does NOT play on iPhone or in
+// WhatsApp — the sharing blocker for the outreach audience. Does a real in-app bake now produce a
+// VALID, PLAYABLE mp4/H.264, and does the webm path still work when mp4 is unavailable?
+//   CASE A (mp4): a short bake must log §MAXQ_MP4 configured + §MAXQ_DONE type=video/mp4 and the
+//                 DOWNLOADED FILE must pass ffprobe as container=mp4 codec=h264 with the right
+//                 frame count. A file that downloads but does not play is a FAIL.
+//   CASE B (fallback): with mp4 forced off, the untouched MediaRecorder path must still reach
+//                 §MAXQ_DONE with a webm — this feature is additive, it must not break the old one.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const URL = 'http://localhost:8477/viewer/viewer.html?db=buildings/Duplex_extracted.db';
+const DL = '/tmp/maxq_mp4_witness_dl';
+const FRAMES = 6, FPS = 15;
+
+function ffprobe(file) {
+  const out = execFileSync('ffprobe', ['-v', 'error', '-show_format', '-show_streams',
+    '-count_frames', '-select_streams', 'v:0', '-of', 'default=noprint_wrappers=1', file],
+    { encoding: 'utf8' });
+  const g = k => (out.match(new RegExp('^' + k + '=(.*)$', 'm')) || [])[1];
+  return { codec: g('codec_name'), fmt: g('format_name'), w: g('width'), h: g('height'),
+           frames: g('nb_read_frames'), dur: g('duration'), profile: g('profile'),
+           fps: g('r_frame_rate'), start: g('start_time'), raw: out };
+}
+function ffdecode(file) {
+  try { execFileSync('ffmpeg', ['-v', 'error', '-i', file, '-f', 'null', '-'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }); return ''; }
+  catch (e) { return (e.stderr || '').trim(); }
+}
+function newestIn(dir, ext) {
+  const f = fs.readdirSync(dir).filter(n => n.endsWith(ext)).map(n => path.join(dir, n));
+  if (!f.length) return null;
+  return f.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
+}
+
+(async () => {
+  fs.rmSync(DL, { recursive: true, force: true });
+  fs.mkdirSync(DL, { recursive: true });
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 900, height: 600 });
+  const cdp = await page.createCDPSession();
+  await cdp.send('Browser.setDownloadBehavior', { behavior: 'allow', downloadPath: DL });
+
+  const logs = [];
+  page.on('console', m => { const t = m.text(); logs.push(t); if (/§MAXQ/.test(t)) console.log('  [page] ' + t); });
+  page.on('pageerror', e => { logs.push('PAGEERROR ' + e.message); console.log('  [pageerror] ' + e.message); });
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startMaxQualityOrbit && window.APP.camera, { timeout: 90000 });
+  await new Promise(r => setTimeout(r, 8000));
+  console.log('LOADED. ' + (logs.find(l => l.startsWith('§MAXQ_LOADED')) || '§MAXQ_LOADED MISSING'));
+  const muxLoaded = await page.evaluate(() => !!(window.MP4Mux && window.MP4Mux.mux));
+  console.log('window.MP4Mux present: ' + muxLoaded);
+
+  async function bake(opts, label, timeoutMs) {
+    const n0 = logs.length, t0 = Date.now();
+    await page.evaluate(o => { window.APP.startMaxQualityOrbit(o); }, opts);
+    while (Date.now() - t0 < timeoutMs) {
+      const tail = logs.slice(n0);
+      if (tail.some(l => l.includes('§MAXQ_DONE'))) break;
+      if (tail.some(l => l.includes('§MAXQ_FAIL'))) break;
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    await new Promise(r => setTimeout(r, 3000));   // let the download land
+    console.log('  ' + label + ' elapsed=' + (Date.now() - t0) + 'ms');
+    return logs.slice(n0);
+  }
+
+  // ---------- CASE A: mp4 ----------
+  console.log('\n=== CASE A — mp4/H.264, ' + FRAMES + ' frames @ ' + FPS + 'fps ===');
+  const tailA = await bake({ frames: FRAMES, fps: FPS, preview: false }, 'CASE A', 240000);
+  const doneA = tailA.find(l => l.includes('§MAXQ_DONE')) || '';
+  const cfgA = tailA.find(l => l.includes('§MAXQ_MP4 configured')) || '';
+  const encA = tailA.find(l => l.includes('§MAXQ_MP4 encoded')) || '';
+  const muxA = tailA.find(l => l.includes('§MAXQ_MP4 mux ')) || '';
+  const fbA = tailA.find(l => l.includes('§MAXQ_MP4_FALLBACK')) || '';
+  console.log('  §MAXQ_MP4 configured : ' + (cfgA || 'NONE'));
+  console.log('  §MAXQ_MP4 encoded    : ' + (encA || 'NONE'));
+  console.log('  §MAXQ_MP4 mux        : ' + (muxA || 'NONE'));
+  console.log('  §MAXQ_MP4_FALLBACK   : ' + (fbA || 'none (good)'));
+  console.log('  §MAXQ_DONE           : ' + (doneA || 'NONE'));
+
+  const mp4File = newestIn(DL, '.mp4');
+  let probeA = null, decA = 'no file';
+  if (mp4File) {
+    probeA = ffprobe(mp4File);
+    decA = ffdecode(mp4File);
+    console.log('  FILE: ' + mp4File + '  ' + fs.statSync(mp4File).size + ' bytes');
+    console.log('  ffprobe: container=' + probeA.fmt + ' codec=' + probeA.codec + ' profile=' + probeA.profile +
+      ' ' + probeA.w + 'x' + probeA.h + ' fps=' + probeA.fps + ' frames=' + probeA.frames +
+      ' dur=' + probeA.dur + ' start=' + probeA.start);
+    console.log('  full-decode stderr: ' + (decA || '(clean)'));
+  } else {
+    console.log('  FILE: NONE DOWNLOADED');
+  }
+  const passA = !!mp4File && !!probeA &&
+    /mp4/.test(probeA.fmt || '') && probeA.codec === 'h264' &&
+    Number(probeA.frames) === FRAMES && decA === '' &&
+    /type=video\/mp4/.test(doneA) && !fbA;
+  console.log('  CASE A: ' + (passA ? 'PASS' : 'FAIL'));
+
+  // ---------- CASE B: webm fallback still works ----------
+  console.log('\n=== CASE B — forced webm fallback (the untouched MediaRecorder path) ===');
+  const tailB = await bake({ frames: FRAMES, fps: FPS, preview: false, forceWebm: true }, 'CASE B', 240000);
+  const doneB = tailB.find(l => l.includes('§MAXQ_DONE')) || '';
+  const fbB = tailB.find(l => l.includes('§MAXQ_MP4_FALLBACK')) || '';
+  const stitchB = tailB.find(l => l.includes('§MAXQ_STITCH')) || '';
+  console.log('  §MAXQ_MP4_FALLBACK : ' + (fbB || 'NONE'));
+  console.log('  §MAXQ_STITCH       : ' + (stitchB || 'NONE'));
+  console.log('  §MAXQ_DONE         : ' + (doneB || 'NONE'));
+  const webmFile = newestIn(DL, '.webm');
+  if (webmFile) console.log('  FILE: ' + webmFile + '  ' + fs.statSync(webmFile).size + ' bytes');
+  const passB = /type=video\/webm/.test(doneB) && !!stitchB && !!webmFile;
+  console.log('  CASE B: ' + (passB ? 'PASS' : 'FAIL'));
+
+  const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+  console.log('\npageerrors: ' + errs.length + (errs.length ? ' -> ' + errs.join(' | ') : ''));
+  const ok = passA && passB && !errs.length;
+  console.log('\nVERDICT: ' + (ok ? 'PASS — valid playable mp4/H.264, webm fallback intact' : 'FAIL'));
+  await browser.close();
+  process.exit(ok ? 0 : 1);
+})();


### PR DESCRIPTION
Spec: `bim-compiler prompts/PHOTOREAL_STILL_RENDER.md` §MAXQ_MP4 SPEC (2026-07-19) — `§NEXT-SESSION BACKLOG` item 1.

## Why
The MaxQ movie shipped as webm/VP9. **webm does not play on iPhone or in WhatsApp** — for the outreach audience that is the entire distribution channel, so the container, not the pixels, was the blocker.

## What
- **`viewer/lib/mp4_mux.js` (new)** — hand-rolled ISO-BMFF muxer, single AVC track, faststart (`ftyp`/`moov`/`mdat`). Hand-rolled rather than vendored: no CDN, no third-party code, no license question, and every byte is auditable against ISO/IEC 14496-12/-15. Two-pass `moov` so `stco` offsets are exact. `avcC` is the encoder's own `decoderConfig.description` — nothing about the bitstream is invented.
- **`_stitchMp4()` in `cinema_maxq.js`** — WebCodecs `VideoEncoder`, codec candidates probed high→baseline, each gated on `isConfigSupported` **and** a real `configure()` (Mozilla bug 1918769: `isConfigSupported` can answer `true` and then throw). Encodes straight from the IDB frames, so stitching is no longer pinned to 1× wall-clock. Even-dimension crop — the renderer really does emit odd sizes (1854×963 seen live).
- **The webm path is unchanged and is the fallback.** No WebCodecs / no usable codec / no muxer (stale precache) / any throw / zero chunks / no `avcC` → `§MAXQ_MP4_FALLBACK reason=…` and the original `_stitch()` runs. `opts.forceWebm` exercises it on purpose, which is how it stays witnessed.

## Support matrix — measured on this machine, not assumed
| Browser | `isConfigSupported(avc1.*)` | real configure+encode |
|---|---|---|
| Chrome 150 headless (branded) | true | OK |
| Firefox 148 | true | OK |
| either, `prefer-hardware` | false | n/a |

Firefox routes H.264 encode through the *system* libavcodec/libx264 on Linux, so it works here but is not universal (a stripped `ffmpeg-free` distro has no encoder). Distro/Playwright *chromium* builds (`proprietary_codecs=false`) also fail where branded Chrome works. The webm fallback is a real, exercised path — not dead code.

## Two Firefox defects found by measurement, handled in the muxer
1. **Firefox 148's `decoderConfig.description` is malformed** — each parameter set carries a *duplicated* NAL header byte (SPS `67 67 64 00 28…`, 24 bytes for a 23-byte SPS). ffmpeg decodes it only by luck (`sps_id 1 out of range`); a strict mobile player would reject the file. Firefox does emit a correct SPS/PPS **in-band**, so the muxer validates the record and rebuilds it from the in-band NALs when it fails → `§MAXQ_MP4 mux avcC=in-band-rebuild`. Chrome's record is clean and used as-is.
2. **Firefox's encoder uses B-frames** — decode order ≠ presentation order, and without a `ctts` box a few frames play out of order. `ctts` (plus an edit list so the clip still starts at t=0) is emitted whenever the chunk timestamps disagree with the decode timeline.

## Witness
`witness_maxq_mp4.js` — headless puppeteer, ANGLE/SwiftShader, real `Duplex_extracted.db`:

- **CASE A (mp4)** 6-frame bake → `§MAXQ_MP4 configured codec=avc1.640034` → `§MAXQ_DONE frames=6 bytes=80353 type=video/mp4`. Downloaded file `ffprobe`: `container=mov,mp4,m4a codec=h264 profile=High 900x600 fps=15/1 frames=6 dur=0.400 start=0.000`; full `ffmpeg` decode clean.
- **CASE B (fallback)** `forceWebm` → `§MAXQ_MP4_FALLBACK` → `§MAXQ_STITCH` → `§MAXQ_DONE type=video/webm;codecs=vp9` + real `.webm` download.
- 0 pageerrors. **VERDICT: PASS.**

**Firefox, same real app + real DB** (Playwright FF148), 30-frame bake → `§MAXQ_MP4 mux avcC=in-band-rebuild ctts=yes (B-frame reorder)` → `§MAXQ_DONE type=video/mp4`; `ffprobe` h264 High 900×600, 30 frames, `dur=2.000 start=0.000 has_b_frames=2`, PTS monotonic, decode clean. Both Firefox repairs fire on the real user path.

Muxer also unit-witnessed standalone (30 synthetic frames, real WebCodecs, both browsers) → valid mp4 in each.

`MAXQ_V` → `v9`, `sw.js CACHE_VERSION` → `v812`, `lib/mp4_mux.js` added to `PRECACHE_ASSETS` + `viewer.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)