### PR TITLE
fix(viewer): §STAFFAGE_SEAT_CLASS — seated staffage no longer placed inside tables

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -1531,17 +1531,63 @@ async function setupEffects(A, renderer, scene, camera) {
       return false;
     }
     var SIT_CAP = 2, WALK_CAP = 2;
+    // §STAFFAGE_SEAT_CLASS (2026-07-20, user: "sitting figures placed INSIDE tables") — ROOT CAUSE of
+    // that defect: this query used to select EVERY IfcFurniture/IfcFurnishingElement row and drop a
+    // seated sprite at the chosen element's own center_x/center_y. A table, desk, counter or nurse
+    // station is furniture too, so a sit pick could land a figure at the geometric centre of a table
+    // — i.e. inside it. Measured on the real shipped DBs (read-only queries, nothing mutated):
+    //   Hospital  201 furniture = 160 M_Chair* + 37 M_Table* + 4 nurse stations/info desks
+    //             (chairs bbox 0.47-0.68m plan, tables 1.52-2.4m, stations 12.7-25.5m)
+    //   Clinic    118 furniture, ZERO seats — all cabinets/countertops
+    //   Terminal  176 furniture, canteen tables + desks + one real 'Chair - Desk (2)' family
+    // There is NO predefined_type column in elements_meta (schema: guid, ifc_class, element_name,
+    // storey, discipline, material_name, material_rgba, building) — so seat-ness must come from the
+    // element_name family + the real bbox. Both are extracted, neither is invented.
+    //
+    // TWO NAMING LANDMINES, both confirmed in real data — do not "simplify" this classifier:
+    //  1. `M_Table-Dining Round w Chairs:1525mm Diameter` — 21 Hospital rows are TABLES whose name
+    //     contains "Chairs". A naive LIKE '%chair%' calls them chairs and re-creates this exact bug.
+    //  2. `Chair - Desk (2)` (Terminal) — a genuine chair whose name contains "Desk". Excluding on
+    //     any non-seat token anywhere in the name would wrongly drop it.
+    // Resolved by TOKEN POSITION within the Revit family name (the text before the first ':', which
+    // is where the family name lives in every DB checked): classification goes to whichever token
+    // appears FIRST. "M_Table-..." -> table; "Chair - Desk..." -> chair. Plus a size guard: a single
+    // seat is <=1.2m in plan, which drops combined units such as Terminal's
+    // `Waiting_Room_Seat_-_4St_1Tbl_3750` (4 seats + 1 table in one 3.75m element — seating, but its
+    // centre is the TABLE, so seating a figure there reproduces the bug).
+    // NOTE a chair legitimately overlapping a table bbox is NOT this defect: Hospital's dining chairs
+    // ring a `M_Table-Dining Round w Chairs` whose bbox spans the whole setting, so 159/160 chair
+    // centres fall inside a table bbox by construction. A person seated at a table is supposed to
+    // overlap it. The defect is the ANCHOR being a table, which is what this classifier removes.
+    // ZERO-CASE IS CORRECT HERE: a building whose furniture carries no seat information (LTU_AHouse's
+    // names are bare codes — "-", "WC", "KÖK3"; Clinic is all casework) places NO seated figures.
+    // Per this file's own doctrine that is the right outcome — never fabricate a seat position.
+    var _SEAT_RE = /chair|seat|stool|sofa|bench|couch|settee|\bstol/i;
+    var _NONSEAT_RE = /table|desk|counter|station|cabinet|shelv|shelf|\bbed\b|bord|sk[aå]p|bokhyll|worktop|\btbl\b|entertainment|\btop\b/i;
+    function _isSeat(name, bboxX, bboxY) {
+      var fam = String(name || '').split(':')[0];
+      var s = _SEAT_RE.exec(fam); if (!s) return false;
+      var n = _NONSEAT_RE.exec(fam); if (n && n.index < s.index) return false;
+      // a real single seat is <=1.2m in plan — guards against combined seat+table units and any
+      // oversized assembly that happens to carry a seat token.
+      return (bboxX == null || bboxX <= 1.2) && (bboxY == null || bboxY <= 1.2);
+    }
+    A._staffageIsSeat = _isSeat;   // exposed for the §STAFFAGE_SEAT_CLASS witness harness
     // furniture currently in the view frustum, near the camera
-    var furn = A.dbQuery("SELECT et.center_x, et.center_y, et.center_z, et.bbox_z FROM element_transforms et JOIN elements_meta em ON et.guid=em.guid WHERE em.ifc_class IN ('IfcFurniture','IfcFurnishingElement') AND et.center_x IS NOT NULL") || [];
-    var _v = new THREE.Vector3(), cand = [];
+    var furn = A.dbQuery("SELECT et.center_x, et.center_y, et.center_z, et.bbox_z, em.element_name, et.bbox_x, et.bbox_y FROM element_transforms et JOIN elements_meta em ON et.guid=em.guid WHERE em.ifc_class IN ('IfcFurniture','IfcFurnishingElement') AND et.center_x IS NOT NULL") || [];
+    var _v = new THREE.Vector3(), cand = [], seatTotal = 0, rejNonSeat = 0;
     for (var i = 0; i < furn.length; i++) {
       var f = furn[i], p = A.ifc2three(f[0], f[1], f[2]);
+      // §STAFFAGE_SEAT_CLASS: only a real seat may receive a seated figure.
+      if (!_isSeat(f[4], f[5], f[6])) { rejNonSeat++; continue; }
+      seatTotal++;
       _v.copy(p).project(A.camera);
       if (Math.abs(_v.x) < 0.9 && Math.abs(_v.y) < 0.95 && _v.z > -1 && _v.z < 1) {
         var dist = Math.hypot(p.x - cam.x, p.y - cam.y, p.z - cam.z);
         if (dist < 16 && !_nearExistingIF(p, 1.5) && !_nearRealEntourage(p)) cand.push([f[0], f[1], f[2], f[3], dist]);
       }
     }
+    console.log('§STAFFAGE_SEAT_CLASS furn=' + furn.length + ' seats=' + seatTotal + ' rejNonSeat=' + rejNonSeat + ' inViewSeats=' + cand.length);
     // §STAFFAGE_SHUFFLE: random draw among all in-view/in-range candidates, not always nearest-first
     // — "repeatedly adds on... in random placings" applies indoors too, clash (_spreadPick's minDist)
     // is still the guardrail.
@@ -1572,11 +1618,17 @@ async function setupEffects(A, renderer, scene, camera) {
     // in view — the camera is always on the correct local floor, furniture may not be nearby.
     var floorYval = picked.length ? floorY(picked[0][0], picked[0][1], picked[0][2]) : (cam.y - 1.6);
     var placedSit = 0, placedWalk = 0;
-    // SITTING → on the in-view furniture (seated on real chairs)
+    // SITTING → on the in-view SEAT furniture (real chairs only — see §STAFFAGE_SEAT_CLASS above)
     for (var k = 0; k < picked.length; k++) {
       var s = picked[k], pos = A.ifc2three(s[0], s[1], s[2]); pos.y = floorY(s[0], s[1], s[2]);
       var spr = _addStaffageSprite(sitPoses[k % sitPoses.length], pos, true, true);
-      spr.userData.interior = true; _photoStaffageInFrame.push(spr); placedSit++;
+      spr.userData.interior = true;
+      // §STAFFAGE_SIT_ANCHOR: record the IFC-space seat this figure was placed on, so the witness can
+      // re-test every placed sitting figure against the real furniture bboxes independently of the
+      // placement search (non-tautological — same discipline as §STAFFAGE_WALK_CLEAR).
+      spr.userData.sitAnchorIfc = { x: s[0], y: s[1], z: s[2] };
+      _photoStaffageInFrame.push(spr); placedSit++;
+      console.log('§STAFFAGE_SIT_ANCHOR ifc=(' + s[0].toFixed(2) + ',' + s[1].toFixed(2) + ') seat=1');
     }
     // WALKING → in the AISLE: floor points ahead of the camera, in view, and clear of EVERY solid
     // (occupancy grid — walls/columns/furniture/equipment/MEP, not just furniture-distance) — so

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v812';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v813';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_staffage_sit_not_in_table.js
+++ b/witness_staffage_sit_not_in_table.js
@@ -1,0 +1,157 @@
+// WITNESS — §STAFFAGE_SEAT_CLASS: seated staffage figures must never be placed inside a table.
+//
+// ISSUE PROVEN/DISPROVEN (user report 2026-07-20: "sitting figures are being placed INSIDE tables"):
+//   _updateInFrameInterior() selected seat anchors with
+//     WHERE em.ifc_class IN ('IfcFurniture','IfcFurnishingElement')
+//   — no chair-vs-table discrimination at all — and dropped the seated sprite at the chosen
+//   element's own center_x/center_y. A table, desk, counter or nurse station IS furniture, so a
+//   sit pick could anchor a figure at the geometric centre of a table, i.e. inside it.
+//
+// THE INVARIANT THIS TEST MEASURES (re-derived from the DB, independent of the placement search —
+// it does not ask the code "did you think this was a seat", it re-tests the FINAL world positions):
+//   badSit = # of placed SITTING sprites whose IFC (x,y) falls inside the plan bbox of a furniture
+//            element that is NOT a seat, AND which have no seat element within 0.4m.
+//   The 0.4m seat-adjacency exemption matters and is not a fudge: Hospital's dining chairs ring a
+//   `M_Table-Dining Round w Chairs` element whose bbox spans the whole setting, so 159/160 chair
+//   centres legitimately fall inside a table bbox. A person seated AT a table is supposed to
+//   overlap it. A figure anchored to a seat is 0.0m from that seat; a figure anchored to a table
+//   centre is ~0.7-0.9m from the nearest chair. 0.4m separates the two cleanly.
+//
+// PASS BAR: before-fix badSit > 0 (the bug is real and this test can see it);
+//           after-fix  badSit = 0 on every building tested.
+// A run where both are 0 proves NOTHING and must be reported as an inconclusive test, not a pass.
+//
+// Serves two trees: :8482 = origin/main (before), :8481 = the fix (after). Same DBs, same camera,
+// same presses — the ONLY difference is viewer/effects.js.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const AFTER = 'http://localhost:8481';
+const BEFORE = 'http://localhost:8482';
+
+// Buildings with real furniture. Hospital is the discriminating case (160 chairs + 37 tables +
+// 4 nurse stations). Clinic is the zero-seat control (118 furniture, all casework, no chairs).
+const CASES = [
+  // Dining hall: 8 `M_Table-Dining Round w Chairs` (1.5m) each ringed by 6 M_Chair-Breuer. Mixed
+  // seats + tables in one frame — the realistic case.
+  { bld: 'Hospital-dining', dbBld: 'Hospital', db: 'buildings/Hospital_extracted.db', camIfc: [37.7, 115.6, 173.6], lookIfc: [40.9, 115.0, 172.4] },
+  // ED nurse stations: the ONLY furniture in this neighbourhood is 3 nurse stations (18-25m wide,
+  // zero chairs). Any sit figure placed here is necessarily anchored to a non-seat.
+  { bld: 'Hospital-station', dbBld: 'Hospital', db: 'buildings/Hospital_extracted.db', camIfc: [60.0, 65.2, 174.5], lookIfc: [64.9, 65.2, 172.9] },
+  // Clinic: 118 furniture rows, ZERO seats (all cabinets/countertops). Every sit figure the old
+  // code places here is by definition on a non-seat; the fix must place none at all.
+  { bld: 'Clinic', dbBld: 'Clinic', db: 'buildings/Clinic_extracted.db', camIfc: [-33.0, 44.0, 2.0], lookIfc: [-29.0, 44.0, 0.9] },
+];
+
+// The seat rule, re-implemented here on purpose so the witness does not import the code under test.
+function isSeat(name, bx, by) {
+  const fam = String(name || '').split(':')[0];
+  const s = /chair|seat|stool|sofa|bench|couch|settee|\bstol/i.exec(fam);
+  if (!s) return false;
+  const n = /table|desk|counter|station|cabinet|shelv|shelf|\bbed\b|bord|sk[aå]p|bokhyll|worktop|\btbl\b|entertainment|\btop\b/i.exec(fam);
+  if (n && n.index < s.index) return false;
+  return (bx == null || bx <= 1.2) && (by == null || by <= 1.2);
+}
+
+async function run(base, label, c) {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1000, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  const url = `${base}/viewer/viewer.html?db=${c.db}&bld=${c.dbBld}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 });
+  await page.waitForFunction(() => window.APP && window.APP.dbQuery && window.APP.camera && window.APP.togglePopulate, { timeout: 120000 });
+  await new Promise(r => setTimeout(r, 12000)); // let the DB open + some geometry stream
+
+  // Park the camera inside, looking at a real furniture cluster (IFC coords measured from the DB).
+  if (c.camIfc) {
+    await page.evaluate((cam, look) => {
+      const A = window.APP;
+      const p = A.ifc2three(cam[0], cam[1], cam[2]);
+      const l = A.ifc2three(look[0], look[1], look[2]);
+      A.camera.position.set(p.x, p.y, p.z);
+      A.camera.lookAt(l.x, l.y, l.z);
+      A.camera.updateMatrixWorld(true);
+      if (A.controls) { A.controls.target.set(l.x, l.y, l.z); A.controls.update(); }
+    }, c.camIfc, c.lookIfc);
+    await new Promise(r => setTimeout(r, 1500));
+  }
+
+  // Three Alt+P presses — additive, so this samples more placements than a single press.
+  for (let i = 0; i < 5; i++) {
+    await page.evaluate(() => window.APP.togglePopulate());
+    await new Promise(r => setTimeout(r, 2500));
+  }
+
+  // Pull the FINAL placed positions + the real furniture table straight from the running page.
+  const data = await page.evaluate(() => {
+    const A = window.APP;
+    const rows = (A._getStaffageInstances && A._getStaffageInstances()) || [];
+    const furn = A.dbQuery(
+      "SELECT em.element_name, et.center_x, et.center_y, et.bbox_x, et.bbox_y " +
+      "FROM element_transforms et JOIN elements_meta em ON et.guid=em.guid " +
+      "WHERE em.ifc_class IN ('IfcFurniture','IfcFurnishingElement') AND et.center_x IS NOT NULL") || [];
+    return { rows, furn };
+  });
+
+  // rows: [kind, file, ifcX, ifcY, ifcZ, rotY]
+  const sit = data.rows.filter(r => /sitting/i.test(r[1] || ''));
+  const seats = data.furn.filter(f => isSeat(f[0], f[3], f[4]));
+  const nonSeats = data.furn.filter(f => !isSeat(f[0], f[3], f[4]));
+
+  let bad = 0;
+  const badDetail = [];
+  for (const s of sit) {
+    const x = s[2], y = s[3];
+    const hit = nonSeats.find(b => Math.abs(x - b[1]) <= (b[3] || 0) / 2 && Math.abs(y - b[2]) <= (b[4] || 0) / 2);
+    if (!hit) continue;
+    const nearSeat = seats.some(q => Math.hypot(x - q[1], y - q[2]) <= 0.4);
+    if (!nearSeat) { bad++; badDetail.push(`(${x.toFixed(2)},${y.toFixed(2)}) inside "${String(hit[0]).split(':')[0]}"`); }
+  }
+
+  const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+  const seatClass = logs.filter(l => l.includes('§STAFFAGE_SEAT_CLASS'));
+  const interior = logs.filter(l => l.includes('§PHOTO_STAFFAGE_INTERIOR'));
+
+  console.log(`\n--- ${c.bld} / ${label} ---`);
+  console.log(`  furniture=${data.furn.length} seats=${seats.length} nonSeats=${nonSeats.length}`);
+  console.log(`  placedSitFigures=${sit.length}   badSit(inside a non-seat bbox, no seat within 0.4m)=${bad}`);
+  badDetail.slice(0, 6).forEach(d => console.log(`    BAD ${d}`));
+  seatClass.slice(0, 3).forEach(l => console.log(`  [page] ${l}`));
+  interior.slice(0, 3).forEach(l => console.log(`  [page] ${l}`));
+  if (errs.length) errs.slice(0, 5).forEach(e => console.log(`  ${e}`));
+  else console.log('  pageerrors=0');
+
+  await browser.close();
+  return { bld: c.bld, label, sit: sit.length, bad, errs: errs.length };
+}
+
+(async () => {
+  const results = [];
+  for (const c of CASES) {
+    results.push(await run(BEFORE, 'BEFORE (origin/main)', c));
+    results.push(await run(AFTER, 'AFTER  (fix)', c));
+  }
+
+  console.log('\n================ VERDICT ================');
+  let pass = true, sawBug = false;
+  for (const c of CASES) {
+    const b = results.find(r => r.bld === c.bld && r.label.startsWith('BEFORE'));
+    const a = results.find(r => r.bld === c.bld && r.label.startsWith('AFTER'));
+    console.log(`${c.bld.padEnd(10)} BEFORE sit=${b.sit} bad=${b.bad}   |   AFTER sit=${a.sit} bad=${a.bad}`);
+    if (b.bad > 0) sawBug = true;
+    if (a.bad !== 0) pass = false;
+    if (a.errs > 0) pass = false;
+  }
+  if (!sawBug) {
+    console.log('INCONCLUSIVE — no building reproduced badSit>0 before the fix; this test proved nothing.');
+    process.exit(2);
+  }
+  console.log(pass ? 'PASS — bug reproduced before, zero after, no page errors.' : 'FAIL');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## The bug

User report: Alt+P photoreal staffage places **sitting figures INSIDE tables**.

## Root cause (established by DB query, not assumption)

`_updateInFrameInterior()` selected sit anchors with:

```sql
WHERE em.ifc_class IN ('IfcFurniture','IfcFurnishingElement')
```

— **no chair-vs-table discrimination at all** — then dropped the seated sprite at the chosen element's own `center_x`/`center_y`. Tables, desks, counters and nurse stations are furniture too, so a sit pick could anchor a figure at the geometric centre of a table, i.e. inside it.

Measured on the real shipped DBs (read-only, nothing mutated):

| building | furniture | seats | non-seats |
|---|---|---|---|
| Hospital | 201 | 160 `M_Chair*` (0.47-0.68m plan) | 37 `M_Table*` (1.5-2.4m) + 4 nurse stations/info desks (12.7-25.5m) |
| Clinic | 118 | **0** | 118 — all cabinets/countertops |
| Terminal | 176 | 4 | canteen tables, desks, combined seat+table units |

## The fix

`elements_meta` has **no `predefined_type` column** (schema: `guid, ifc_class, element_name, storey, discipline, material_name, material_rgba, building`), so seat-ness comes from the real `element_name` family plus the real bbox. Both extracted, neither invented.

Two naming landmines, both confirmed in real data, both resolved by **token position within the Revit family name** (text before the first `:`) — classification goes to whichever token appears first:

1. `M_Table-Dining Round w Chairs:1525mm Diameter` — 21 Hospital rows are **tables** whose name contains "Chairs". A naive `LIKE '%chair%'` recreates this exact bug.
2. `Chair - Desk (2)` (Terminal) — a **genuine chair** whose name contains "Desk". Excluding on any non-seat token anywhere would wrongly drop it.

Plus a `<=1.2m` plan size guard, which drops combined units such as Terminal's `Waiting_Room_Seat_-_4St_1Tbl_3750` (4 seats + 1 table in one 3.75m element — seating, but its centre is the *table*).

### What is deliberately NOT changed

A chair legitimately overlapping a table bbox is **not** this defect. Hospital's dining chairs ring a `M_Table-Dining Round w Chairs` whose bbox spans the whole setting, so 159/160 chair centres fall inside a table bbox by construction. A person seated at a table is supposed to overlap it. The defect is the *anchor* being a table.

### Zero-case is correct and deliberate

A building whose furniture carries no seat information — LTU_AHouse's names are bare codes (`-`, `WC`, `KÖK3`), Clinic is all casework — now places **no seated figures** rather than a fabricated one. This follows the zero-case discipline this feature already runs on.

## Witness

`witness_staffage_sit_not_in_table.js` (puppeteer). Two trees served with identical DBs, camera and press counts; the only difference is `viewer/effects.js` — `:8482` = `origin/main` (before), `:8481` = this branch (after).

`badSit` = placed sitting sprites whose IFC (x,y) falls inside a **non-seat** furniture bbox with **no seat within 0.4m**. It is re-derived from the DB against the final world positions, independent of the placement search. The 0.4m exemption separates a figure anchored to a seat (0.0m) from one anchored to a table centre (~0.7-0.9m to the nearest chair).

| case | BEFORE | AFTER |
|---|---|---|
| Hospital-dining (mixed chairs + tables) | sit=8 **bad=0** | sit=9 **bad=0** — no regression |
| Hospital-station (ED nurse stations, no chairs) | sit=1 **bad=1** — `ED Nurse Station1` | sit=0 **bad=0** |
| Clinic (zero seats, all casework) | sit=7 **bad=7** — counter tops, base cabinets | sit=0 **bad=0** |

The harness exits `2` (INCONCLUSIVE) if no building reproduces `bad>0` before the fix, so a run where both sides are zero cannot masquerade as a pass — that guard fired on the first attempt and forced better camera placement.

Zero page errors in all six runs.

## Other

- New `§` tags: `§STAFFAGE_SEAT_CLASS` (`furn`/`seats`/`rejNonSeat`/`inViewSeats`), `§STAFFAGE_SIT_ANCHOR` (per-figure seat IFC position).
- `sw.js` `CACHE_VERSION` v812 → v813.
- `eslint` clean; `audit_sw_precache` 108/108.
- `audit_specs.js` fails on `38-sh-dx-2d-runtime.spec.js` (5 SKIP paths) — **pre-existing**, byte-identical output on `origin/main`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)