### PR TITLE
fix(sw): bump CACHE_VERSION v813 → v814 — two merged PRs both claimed v813

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v813';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v814';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
**Cache-key collision between two parallel PRs. No code change — one line in `sw.js`.**

PR #897 (§CINEMA_RECIPROCAL) and PR #898 (§STAFFAGE_SEAT_CLASS) were developed concurrently and each bumped `v812 → v813`. #897 merged and **deployed first**, so `v813` is already live on GitHub Pages carrying only the cinema change. #898 then merged carrying the same version number.

**Without this bump:** any browser that already cached `v813` keeps serving the #897-era `effects.js` and never receives the staffage seat-class fix. `effects.js` is cache-first precached — this is the exact silent-stale-code landmine this repo has already lost a session to.

Verified before opening: **both** changes are present in `main`'s `effects.js` (cinema markers and `§STAFFAGE_SEAT_CLASS`/`rejNonSeat` all there). The merge itself was clean; only the cache key was wrong.

Per `CLAUDE.md`'s sw.js conflict rule — take the **higher** version, never resolve by dropping a hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)