### PR TITLE
fix(cinema): §CINEMA_POV_CONTINUITY — the film must BEGIN at the authored pose

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3184,7 +3184,14 @@ async function setupEffects(A, renderer, scene, camera) {
           tilt = tilt + (swoopTiltRad - tilt) * Math.min(1, swoopW);
         }
         // §CINEMA_ANCHOR: the element you parked against modulates the path's wobble.
-        radius *= 1 + CINEMA_ELLIPTICITY * character.ellip * Math.cos(2 * (azimuth - b.startAzimuth));
+        // §CINEMA_POV_CONTINUITY (user 2026-07-19: "Start of preview it does not continue from POV
+        // as was OK before"): the ellipse peaks at cos(0)=1, i.e. at tNorm=0 — so the very first
+        // frame sat ~15% FURTHER OUT than the pose the user actually authored (measured 6.73m on a
+        // 44.9m start). The film has to BEGIN exactly where the camera is, or the opening reads as
+        // a snap. Ramp the modulation in across Act I so it is identically zero at t=0 and full by
+        // the time the push-in beat ends. Character/ellipticity are unchanged thereafter.
+        var ellipW = _cinemaSmoothstep(pushInEndT > 0 ? Math.min(1, tNorm / pushInEndT) : 1);
+        radius *= 1 + CINEMA_ELLIPTICITY * character.ellip * ellipW * Math.cos(2 * (azimuth - b.startAzimuth));
         // ══ Act III — the reciprocal (§CINEMA_PAPER_BOAT P4) ══
         // WAS: a fixed ×1.4 pull-back. NOW: eases to the pose DERIVED FROM THE OPENING — the same
         // angle of attack, pulled away by however intimate the start was, hovering as far over the

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v814';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v815';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Live user report: *"Start of preview i can see it does not continue from POV as was OK before. It right away do a turn at own flat angle, After that only, there is a sudden cut to the right POV."*

## Measured, not guessed
`poseAt(0)` sat **6.73m away from the actual camera** on a 44.9m-radius start.

Cause: the elliptical radius modulation peaks at `cos(0) = 1` — *exactly* at `tNorm=0` — so the very first frame inflated the authored radius by ~15% (more with an anchor character: railing's 2.2× → ~33%). The opening snapped outward before it moved, which is precisely "does not continue from POV".

## Fix
Ramp the ellipticity in across Act I (smoothstep over `pushInEndT`) so it is identically zero at `t=0` and full once the push-in beat ends. Behaviour after Act I is unchanged.

The start pose is the authoring interface — the film has to start where the user actually put the camera (§CINEMA_AUTHORED_POSE P1).

## Probe evidence
`probe_path_continuity.js`, Duplex, two poses:

| | before | after |
|---|---|---|
| `poseAt(0)` vs camera, wide pose | **6.732 m** | **0.000 m** |
| `poseAt(0)` vs camera, tight lobby | 0.000 m | 0.000 m |
| largest per-frame step, wide | 1.32 m | 1.10 m |
| spikes >4× median, wide | none | none |

## NOT fixed here — do not assume it is gone
A large mid-film discontinuity **remains on tight starts**: up to **21m in a single frame** around `t=0.525`, clustered through the sun-glint swoop window (7.7 / 11.3 / 14.2 / 16.3 / 17.7 / 18.8m on consecutive frames). This is almost certainly the user's *"sudden cut"*. Separate defect, not yet root-caused, and it is **unknown whether it predates #897**. Shipping the verified half rather than bundling it with an unfinished diagnosis.

sw v815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)