### PR TITLE
fix(viewer): §STAFFAGE — cars can NEVER be indoors

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -972,11 +972,11 @@ async function setupEffects(A, renderer, scene, camera) {
   //           "a big potting space", and a real planting court is open to the sky — which this probe
   //           reports as Infinity, so courtyards/terraces keep their trees while the Terminal
   //           concourse (finite roof, however high) never gets one. Plus 2.5m canopy clearance.
-  //   CAR     indoors ONLY under a LOW deck (<=4.5m): a car park, loading bay or porte-cochère is a
-  //           plausible place for a parked car; a concourse/hall/atrium is not. Ceiling height is the
-  //           one real-geometry quantity that separates them — a clearance-only rule cannot, because
-  //           a big hall has MORE clearance than a car park, not less. Plus 2.5m radial clearance.
-  var _CLR_PERSON = 0.45, _CLR_TREE = 2.5, _CLR_CAR = 2.5, _CAR_INDOOR_MAX_CEIL = 4.5;
+  //   CAR     needs OPEN SKY — a car is NEVER inside a building (user ruling 2026-07-20: "Cars can
+  //           never be in building"). The earlier ≤4.5m-ceiling car-park allowance is RETIRED: it was
+  //           only ever proven on its rejection side (no test building had a real covered car park),
+  //           and the user's rule is absolute. Same open-sky test as a tree, plus 2.5m body clearance.
+  var _CLR_PERSON = 0.45, _CLR_TREE = 2.5, _CLR_CAR = 2.5;
   var _clrRej = {};
   function _clrReject(kind, reason, got, need) {
     _clrRej[kind + ':' + reason] = (_clrRej[kind + ':' + reason] || 0) + 1;
@@ -1003,9 +1003,7 @@ async function setupEffects(A, renderer, scene, camera) {
       return true;
     }
     if (kind === 'car') {
-      if (ceil !== Infinity && ceil > _CAR_INDOOR_MAX_CEIL) {
-        _clrReject('car', 'indoor-hall', ceil, '<=' + _CAR_INDOOR_MAX_CEIL + 'm ceiling or open sky'); return false;
-      }
+      if (ceil !== Infinity) { _clrReject('car', 'indoor', ceil, 'open sky'); return false; }
       var cc = _clearRadius(meshes, feetPos, _CLR_CAR);
       if (cc < _CLR_CAR) { _clrReject('car', 'body-clearance', cc, _CLR_CAR + 'm'); return false; }
       return true;
@@ -3096,7 +3094,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v4 (§CINEMA_SIMPLE + §STAFFAGE_CLEARANCE BVH indoor/space gate)';
+  var EFFECTS_V = 'v5 (§STAFFAGE cars never indoors + §CINEMA_SIMPLE)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v818';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v819';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_staffage_indoor_clearance.js
+++ b/witness_staffage_indoor_clearance.js
@@ -106,9 +106,9 @@ function auditInPage() {
     } else if (kind === 'car') {
       out.cars++;
       const ce = ceilingAbove(p);
-      // A car under a LOW deck (car park / loading bay / porte-cochere) is legitimate; a car under a
-      // high concourse roof is the reported defect.
-      if (ce !== Infinity && ce > 4.5) { out.badIndoor++; out.detail.push(`car indoor-hall ceiling=${ce.toFixed(1)}m`); }
+      // User ruling 2026-07-20: "Cars can never be in building." ANY car under a real roof is a defect
+      // now — the ≤4.5m car-park allowance is retired. Same open-sky bar as a tree.
+      if (ce !== Infinity) { out.badIndoor++; out.detail.push(`car indoor ceiling=${ce.toFixed(1)}m`); }
     }
   }
   return out;


### PR DESCRIPTION
User ruling (2026-07-20): **"Cars can never be in building."**

Retires the ≤4.5m car-park ceiling allowance from #903. `_spaceOK(car)` now uses the **same open-sky gate as a tree** — any car under a real roof is rejected. `_CAR_INDOOR_MAX_CEIL` deleted; `§STAFFAGE_REJECT kind=car reason=indoor`.

## Why this is safe
Strictly **subtractive and monotonic**: the removed branch only ever *admitted* cars (car parks), so it cannot add an indoor car and cannot reject an outdoor one (outdoor = `ceil===Infinity`, untouched). The car gate is now **byte-identical to the tree gate**, which #903's witness proved at `badIndoor=0` on Terminal.

## Witness — stated honestly
A fresh AFTER browser probe on Terminal returned **zero cars-under-roof and zero pageerrors**, but placed nothing (only 510/63k elements streamed in headless SwiftShader within budget) — so **INCONCLUSIVE as a placement witness, not proof**, recorded as such. Oracle in `witness_staffage_indoor_clearance.js` updated to the absolute rule for a proper before/after on a warm load next session.

EFFECTS_V v5, sw v819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)