### PR TITLE
fix(time-machine): §PERF_INCR index thrashed every tick on LTU (net regression from v820)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v820';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v821';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -893,15 +893,17 @@
   // full path is cheaper. 7 days: a playback tick is minutes, a drag-scrub is months.
   var _INCR_MAX_SPAN_MS = 7 * 24 * 3600 * 1000;
 
-  // Cheap staleness signature: mesh COUNT alone misses a consolidation that merges 3 meshes into
-  // 3 different ones, so fold the ids in too. O(#meshes) (~tens), not O(#elements).
-  // O(1). The first version walked all ~10,823 _batchMeta keys EVERY tick with a string->number
-  // conversion per key; that cost ~9ms and made SCRUB (which falls back to the full path and gets
-  // no benefit from the index) 25% SLOWER than before the optimisation -- measured, 36.75ms ->
-  // 45.81ms mean. Streaming/city now bump A._metaGen at the four sites that mutate the meta
-  // tables, so staleness detection is a counter compare instead of a scan.
+  // Staleness signature — keyed ONLY on the element-mesh set, via A._metaGen (bumped by
+  // streaming/city at the four sites that mutate _batchMeta/_instanceMeta). O(1).
+  // ⚠ DO NOT fold in scene.children.length. It changes EVERY playback tick for reasons unrelated
+  // to the mesh set — group-spark sprites add/remove, SFX, stars, bloom — which made the signature
+  // flip every tick, rebuilt the 108ms event index every tick on LTU (16k meshes / 367k events),
+  // AND reset _incrPrimed so the skip never engaged (mode=full skipped=0 forever). Net: ~158ms/tick
+  // of self-inflicted JS on LTU, slower than no optimisation. The index depends only on which guids
+  // live in which meshes; that changes only via streaming/eviction, which bump _metaGen. Nothing
+  // else may invalidate it.
   function _tmSceneSig(app) {
-    return (app._metaGen | 0) + ':' + (app.scene ? app.scene.children.length : 0);
+    return '' + (app._metaGen | 0);
   }
 
   // Build meshId -> sorted transition timestamps. One pass over _ops + the meta tables.
@@ -1243,9 +1245,14 @@
       }
     });
 
-    if (_gspRoll % 10 === 0) console.log('§PERF_TRAVERSE ms=' + (performance.now() - _perfT0).toFixed(1) +
+    var _travMs = performance.now() - _perfT0;
+    if (_gspRoll % 10 === 0) console.log('§PERF_TRAVERSE ms=' + _travMs.toFixed(1) +
       ' objs=' + _perfObjs + ' skipped=' + _perfSkipped + ' mode=' + (_incrOK ? 'delta' : 'full') +
       ' span=' + Math.round((_dHi - _dLo) / 3600000) + 'h cand=' + (_gspCand.length / 3));
+    // Diagnostic hook (harmless, cheap): last-traverse stats for perf verification without relying
+    // on the throttled log. Read via window.__tmTrav in a probe.
+    window.__tmTrav = { ms: +_travMs.toFixed(1), objs: _perfObjs, skipped: _perfSkipped,
+                        mode: _incrOK ? 'delta' : 'full' };
     _incrPrimed = true;   // a full pass has now established slot state for every mesh
     // §GROUP_SPARK: emit AFTER the traverse — capping and per-group random selection need the
     // whole candidate set, which spawn-as-you-find (the reverted #866 shape) cannot provide.
@@ -4591,4 +4598,8 @@
   // streaming.js calls this (feature-detected, optional — same pattern as window.__sfxTM) after
   // each flush; no-ops when TM isn't active, so zero cost/behavior change for non-TM viewing.
   window.tmResweep = function() { if (_active) renderAtTime(_cursor); };
+  // Test hook: simulate a playback tick (small cursor advance + roll bump) so a probe can exercise
+  // the incremental (delta) path deterministically without the cinema UI. Diagnostic only.
+  window.__tmStep = function (dms) { if (!_active) return null; _gspRoll++;
+    renderAtTime(Math.min(_projectEnd, _cursor + (dms || 3600000))); return window.__tmTrav; };
 })();


### PR DESCRIPTION
A user's live LTU (125k) log showed the §PERF_INCR shipped in v820 was making playback **slower**:

```
§PERF_INCR_INDEX built meshes=16102 events=366996 ms=108.0   ← rebuilt every tick
§PERF_TRAVERSE ms=50.0 objs=16141 skipped=0 mode=full        ← skip never engaged
```

**Root cause:** `_tmSceneSig()` folded `scene.children.length` into the staleness signature. That count changes every playback tick (group-spark sprites, SFX, stars, bloom add/remove children) — unrelated to the element-mesh set. So the signature flipped every tick → rebuilt the 108ms index every tick → reset `_incrPrimed` → forced `mode=full` forever. ~158ms/tick of self-inflicted JS on LTU, worse than no optimisation.

**Fix:** key the signature only on `A._metaGen` (bumped by streaming/city where `_batchMeta`/`_instanceMeta` actually mutate).

**Verified (LTU + Hospital, headless):**
- index rebuilds during 40 playback ticks: **0** (was per-tick)
- traverse mode: **delta** every tick (was full)
- equivalence gate on Hospital: **18/18 mismatch=0** (correctness intact)

LTU's true skip magnitude couldn't be measured headless (streams too slowly under software WebGL to fully load), but it's the same path that skips 9901/10841 on Hospital. Real-GPU confirmation is the user's re-test.

sw CACHE_VERSION v820→v821.