### PR TITLE
fix(cinema+staffage): R2 space floor-level pref, R3 swoop reinstated, R1 seated-pax fallback

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -1830,6 +1830,45 @@ async function setupEffects(A, renderer, scene, camera) {
     // blind (it misses anything the DB's bbox columns misreport, and this file already records that
     // bboxes lie about floors). Re-test every walker's FINAL world position against real triangles.
     var _iSolids = _solidMeshes();
+    // §STAFFAGE_SIT_OPEN_FLOOR (R1 fix, 2026-07-20 user ruling): "There are no more sitting pax in
+    // the Terminal hall though there are seats. They can always have their seats in open area floor
+    // anyway just for semblance." Measured root cause (probe, not eyeballed): Terminal's furniture
+    // set has only 4 rows that pass §STAFFAGE_SEAT_CLASS as real single seats out of 176, and this
+    // camera's frustum+16m-range test finds ZERO of them in view on every press
+    // (`§STAFFAGE_SEAT_CLASS ... inViewSeats=0`) — the real-seat candidate pool is simply too thin,
+    // not a clearance-gate rejection (the real-seat loop above has never called `_spaceOK`; the only
+    // `pax`-kind rejections logged here are the WALK loop's own, below). User ruling: a seated figure
+    // does NOT need a real chair OR an adjacent table — fall back to open floor when real seats are
+    // scarce/out of view, up to the same SIT_CAP. Reuses the walk aisle's own candidate pool
+    // (already ground-clear via the occupancy grid) so this never needs its own scan, and shares its
+    // `_spaceOK('pax',...)` clearance gate — since these figures are NOT anchored to any furniture,
+    // that gate correctly applies to them (unlike a real-seat figure, which overlaps its own chair by
+    // construction and must never be gated on that overlap — PR #898's exemption stays as-is: no new
+    // gate was added to the real-seat loop above, because it was never the cause of this defect).
+    var sitFallbackNeed = Math.max(0, SIT_CAP - placedSit);
+    var sitFallbackPick = [];
+    for (var sfi = 0; sfi < walkCand.length && sitFallbackPick.length < sitFallbackNeed; sfi++) {
+      var cwc = walkCand[sfi], clash = false;
+      for (var wj2 = 0; wj2 < wpick.length; wj2++) { if (Math.hypot(cwc[0] - wpick[wj2][0], cwc[1] - wpick[wj2][1]) < 3) { clash = true; break; } }
+      if (!clash) for (var sj2 = 0; sj2 < sitFallbackPick.length; sj2++) { if (Math.hypot(cwc[0] - sitFallbackPick[sj2][0], cwc[1] - sitFallbackPick[sj2][1]) < 2) { clash = true; break; } }
+      if (!clash) sitFallbackPick.push(cwc);
+    }
+    var placedSitFallback = 0, _sitFbSnapRej = 0, _sitFbClrRej = 0;
+    for (var sf = 0; sf < sitFallbackPick.length; sf++) {
+      var sfWy = floorY(sitFallbackPick[sf][3], sitFallbackPick[sf][4], ifcFloorZ);
+      var sfSnapped = _groundSnapY(sitFallbackPick[sf][0], Math.max(sfWy, floorYval) + 1.8, sitFallbackPick[sf][1]);
+      if (sfSnapped === null) { _sitFbSnapRej++; continue; }
+      sfWy = sfSnapped;
+      if (!_spaceOK(_iSolids, 'pax', new THREE.Vector3(sitFallbackPick[sf][0], sfWy, sitFallbackPick[sf][1]))) { _sitFbClrRej++; continue; }
+      var sfSpr = _addStaffageSprite(sitPoses[(placedSit + placedSitFallback) % sitPoses.length],
+        new THREE.Vector3(sitFallbackPick[sf][0], sfWy, sitFallbackPick[sf][1]), true, true);
+      sfSpr.userData.interior = true;
+      sfSpr.userData.sitOpenFloor = true;   // no real seat anchor — semblance only, per user ruling
+      _photoStaffageInFrame.push(sfSpr); placedSitFallback++;
+    }
+    console.log('§STAFFAGE_SIT_FALLBACK need=' + sitFallbackNeed + ' tried=' + sitFallbackPick.length +
+      ' placed=' + placedSitFallback + ' rejSnap=' + _sitFbSnapRej + ' rejClearance=' + _sitFbClrRej +
+      ' (open-floor semblance, no seat/table required)');
     var _walkClrRej = 0;
     var _walkYLog = [], _snapLanded = 0, _snapRejected = 0;
     for (var m = 0; m < wpick.length; m++) {
@@ -1854,7 +1893,9 @@ async function setupEffects(A, renderer, scene, camera) {
       var vx = wpick[wv][0] + A.modelOffset.x, vy = -wpick[wv][1] + A.modelOffset.y;
       if (aisleGrid.free(vx, vy, 0.5)) aisleWcOk++;
     }
-    console.log('§PHOTO_STAFFAGE_INTERIOR inside=1 inView=' + cand.length + ' sit=' + placedSit + ' walk=' + placedWalk + ' walkTried=' + aisleWalkTried + ' rejectedInObject=' + aisleRejectedInObject);
+    console.log('§PHOTO_STAFFAGE_INTERIOR inside=1 inView=' + cand.length + ' sit=' + (placedSit + placedSitFallback) +
+      ' (seat=' + placedSit + ' openFloor=' + placedSitFallback + ') walk=' + placedWalk +
+      ' walkTried=' + aisleWalkTried + ' rejectedInObject=' + aisleRejectedInObject);
     console.log('§STAFFAGE_WALK_CLEAR src=aisle ok=' + aisleWcOk + '/' + wpick.length);
     console.log('§STAFFAGE_WALK_FLOOR_Y ' + (_walkYLog.length ? _walkYLog.join(' ') : 'none'));
     console.log('§STAFFAGE_WALK_CLEARANCE rejInMesh=' + _walkClrRej + ' placed=' + placedWalk);
@@ -3077,9 +3118,25 @@ async function setupEffects(A, renderer, scene, camera) {
   var CINEMA_EYE_M = 1.7;       // standing eye height above the floor actually under that point
   var CINEMA_LOOKDOWN_DEG = 45; // the exterior act's look-down angle
   var CINEMA_SUN_GUARD_DEG = 35;// Sun within this of the emergence heading → hold the look-down
+  // §CINEMA_SWOOP (R3 fix, 2026-07-20 — reinstated, deleted by the §CINEMA_SIMPLE cleanup #902; user:
+  // "It no longer levels off to hit the Sun reflect... I deleted §CINEMA_SWOOP" / "the user wants it
+  // BACK — it is part of the normal script, not gimmickry"). Same constants as the pre-#902 build —
+  // only the host mechanism changed (the final orbit act, not the old push-in/band-ease loop). The
+  // reflection reads best with the sun roughly BEHIND the camera, i.e. when the orbiting camera's own
+  // azimuth matches the Sun's azimuth — a full 360° orbit crosses that exactly once, guaranteed,
+  // general to any building/sun angle. Dip the tilt toward building/eye level in a smooth window
+  // around that crossing so the film passes low and facing the glint at least once.
+  var CINEMA_SWOOP_HALF_SEC = 2.0, CINEMA_SWOOP_TILT_DEG = 4;
   var CINEMA_FAN_RAYS = 32;     // BVH horizontal fan: "am I facing a wall / where is open"
   var CINEMA_FAN_FAR = 60;      // metres; no hit inside this = open in that bearing
   var CINEMA_FAN_NUDGE_MAX = 3; // metres the settle point may slide toward the open side
+  var CINEMA_ENCLOSED_THRESHOLD = 0.6; // BVH fan fraction that counts as "genuinely enclosed"
+  var CINEMA_INSIDE_FLOOR_GAP_MAX = 10; // metres: camera must be within this of the floor directly
+                                         // beneath it to count as "standing in a space" — otherwise
+                                         // the downward raycast tunnelled through a roof gap/skylight
+                                         // to a distant unrelated slab (measured live: a roof-top start
+                                         // over an opening snapped clean through to the ground slab,
+                                         // ~35m below, which is NOT "already inside", it's on the roof)
   // Exit cost = dist × (1 − FACE_GAIN·facingDot) × perimFactor. facingDot=+1 (door dead ahead) →
   // 0.2×dist; facingDot=−1 (door behind you) → 1.8×dist — a 9× swing, so a door behind you must be
   // nearly an order of magnitude nearer to win. This asymmetry is the entire "myriad of paths"
@@ -3094,7 +3151,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v5 (§STAFFAGE cars never indoors + §CINEMA_SIMPLE)';
+  var EFFECTS_V = 'v6 (§CINEMA_SPACE floor-level+already-inside R2, §CINEMA_SWOOP reinstated R3, §STAFFAGE_SIT_OPEN_FLOOR R1)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).
@@ -3167,6 +3224,19 @@ async function setupEffects(A, renderer, scene, camera) {
     var hits = null;
     try { hits = _cineFanRay.intersectObjects(meshes, true); } catch (e) { return null; }
     return (hits && hits.length) ? hits[0].point.y : null;
+  }
+  // §CINEMA_SPACE floor-level preference (R2 fix, 2026-07-20): "largest enclosed" alone picks the
+  // roof attic/plant volume on Terminal and Hospital — an enclosed space is not necessarily the
+  // hero space. z is the space's own zLevelFrac = (centreZ - buildingZmin)/(buildingZmax-buildingZmin),
+  // NEVER the storey stack (slab-stack(46) mezzanine bug makes storey index useless). Peaks across
+  // the low-to-mid band where a ground/main-level concourse sits; falls off steeply toward the roof
+  // (the repeatedly-reported bug) and gently toward the very bottom (a legitimate slab-level ground
+  // floor still centres around z≈0.05-0.1, so the bottom taper must not crush it too).
+  function _cinemaFloorLevelWeight(z) {
+    z = Math.max(0, Math.min(1, z));
+    var top = (z <= 0.55) ? 1 : Math.max(0.03, 1 - (z - 0.55) / 0.35);
+    var bot = (z >= 0.06) ? 1 : Math.max(0.25, z / 0.06);
+    return top * bot;
   }
 
   // §CINEMA_PATH: the ONE shared path plan — flown identically by the live Alt+C capture and by
@@ -3244,67 +3314,114 @@ async function setupEffects(A, renderer, scene, camera) {
     var yaw0 = Math.atan2(_dir0.z, _dir0.x);
     var pitch0 = Math.asin(Math.max(-1, Math.min(1, _dir0.y)));
 
-    // ══ The dive target: the LARGEST INTERIOR SPACE NEAREST THE CENTRE ════════════════════════
-    // "Largest space NEAREST TO the centre" beats the strict geometric centre — on a big building
-    // the centroid can land in a service core, and the beat has to land somewhere that reads as a
-    // space. Rank the building's REAL rooms (IfcSpace rects from the room graph — extracted, never
-    // invented) by area discounted by distance from the centre. No minimum-size gate and no skip
-    // path: every film dives, on every building, per §CINEMA_SIMPLE decision 3.
-    var roomGraph = null;
-    try { roomGraph = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null; } catch (eG) { roomGraph = null; }
-    var spaceCands = [];
-    if (roomGraph && roomGraph.nodesByGuid && arcBbox) {
-      var ctrIx = (arcBbox.xMin + arcBbox.xMax) / 2, ctrIy = (arcBbox.yMin + arcBbox.yMax) / 2;
-      for (var rk in roomGraph.nodesByGuid) {
-        var rn = roomGraph.nodesByGuid[rk];
-        if (!rn || rn.kind !== 'room' || !rn.rects || !rn.rects.length) continue;
-        var ar = 0;
-        for (var ri = 0; ri < rn.rects.length; ri++)
-          ar += Math.abs(rn.rects[ri].x1 - rn.rects[ri].x0) * Math.abs(rn.rects[ri].y1 - rn.rects[ri].y0);
-        if (!(ar > 0)) continue;
-        var dCtr = Math.hypot(rn.cx - ctrIx, rn.cy - ctrIy);
-        spaceCands.push({ name: rn.name || rn.guid, area: ar, dCtr: dCtr,
-                          ifc: { ix: rn.cx, iy: rn.cy, iz: rn.cz },
-                          score: ar / (1 + dCtr / Math.max(1, envelope * 0.5)) });
-      }
-      spaceCands.sort(function(a, b) { return b.score - a.score; });
-    }
-    if (arcBbox) spaceCands.push({ name: 'bbox-centre', area: 0, dCtr: 0, score: -1,
-      ifc: { ix: (arcBbox.xMin + arcBbox.xMax) / 2, iy: (arcBbox.yMin + arcBbox.yMax) / 2,
-             iz: arcBbox.zMin + (arcBbox.zMax - arcBbox.zMin) * 0.15 } });
-    // ENCLOSURE TEST — the BVH fan is what makes "largest INTERIOR space" mean something. Measured
-    // on Duplex: the top-scoring IfcSpace by area×centrality was a 135m² ROOF TERRACE whose fan
-    // reported 32/32 bearings clear to the 60m horizon — outdoors, not a room. So evaluate the top
-    // few candidates with a real fan and take the best-scoring one that is actually ENCLOSED
-    // (majority of bearings hit geometry). If none is — a building with no interior at all — the
-    // top scorer is still used: no minimum-size gate, no skip path (§CINEMA_SIMPLE decision 3).
+    // ══ §CINEMA_SPACE — already-inside short-circuit (R2 fix, 2026-07-20 user ruling) ═══════════
+    // "The orbit does look for nearest largest area which hits the roof attic area when it is
+    // looking into the hall. Thus if u are there, then dont look for the next. Only when outside...
+    // simply avoid [attic/basement]." If the camera's OWN position is already inside a genuinely
+    // enclosed space, settle there — the largest-space search below is only for an outside/on-top
+    // start with no containing space.
+    var camIfc0 = _cinemaThree2Ifc(camPos0.x, camPos0.y, camPos0.z);
+    var zSpan0 = arcBbox ? Math.max(1e-3, arcBbox.zMax - arcBbox.zMin) : 1;
+    var zLevelFrac0 = (camIfc0 && arcBbox) ? Math.max(0, Math.min(1, (camIfc0.iz - arcBbox.zMin) / zSpan0)) : 0.5;
+    var fy0 = _cinemaFloorY(camPos0.x, camPos0.z, camPos0.y + 2.5);
+    if (fy0 === null) fy0 = _cinemaFloorY(camPos0.x, camPos0.z, camPos0.y + 25);
+    // A near-floor gap does NOT mean "already inside" — measured live on Terminal: a roof-top start
+    // placed over a skylight/gap tunnelled clean through to the GROUND slab ~35m below, which read as
+    // 100% enclosed down there but the camera was never near it. "Already inside" requires the floor
+    // actually be under the camera, not just any floor the ray eventually hit.
+    var floorGap0 = (fy0 === null) ? Infinity : Math.abs(camPos0.y - fy0);
+    var st0 = { x: camPos0.x, y: (fy0 === null ? camPos0.y : fy0) + CINEMA_EYE_M, z: camPos0.z };
+    var fan0 = _cinemaFan(st0, CINEMA_FAN_RAYS);
+    var hit0 = 0;
+    for (var fi0 = 0; fi0 < fan0.free.length; fi0++) if (fan0.free[fi0] < CINEMA_FAN_FAR - 0.01) hit0++;
+    var frac0 = hit0 / fan0.free.length;
+    var alreadyInside = frac0 >= CINEMA_ENCLOSED_THRESHOLD && floorGap0 < CINEMA_INSIDE_FLOOR_GAP_MAX;
+
     var diveIfc = null, diveName = 'centre', diveArea = 0, diveSrc = 'bbox-centre';
     var dive3 = null, floorY = null, settle = null, fan = null, nudgeL = 0;
     var enclosedFrac = 0, triedSpaces = 0, rejectedOpen = [];
-    for (var ci2 = 0; ci2 < Math.min(spaceCands.length, 6); ci2++) {
-      var cand = spaceCands[ci2];
-      triedSpaces++;
-      var c3 = A.ifc2three(cand.ifc.ix, cand.ifc.iy, cand.ifc.iz);
-      // Eye level = the REAL floor under that point + 1.7m, from a downward raycast against
-      // rendered triangles. Cast from just above the space's own elevation so a multi-storey
-      // building resolves THIS storey's slab rather than the roof.
-      var fy = _cinemaFloorY(c3.x, c3.z, c3.y + 2.5);
-      if (fy === null) fy = _cinemaFloorY(c3.x, c3.z, c3.y + 25);
-      if (fy === null && arcBbox) fy = A.ifc2three(0, 0, arcBbox.zMin).y;
-      var st = { x: c3.x, y: (fy === null ? c3.y : fy) + CINEMA_EYE_M, z: c3.z };
-      var f = _cinemaFan(st, CINEMA_FAN_RAYS);
-      var hit = 0;
-      for (var fi = 0; fi < f.free.length; fi++) if (f.free[fi] < CINEMA_FAN_FAR - 0.01) hit++;
-      var frac = hit / f.free.length;
-      if (!settle || frac > enclosedFrac) {   // remember the most-enclosed one seen so far
-        diveIfc = cand.ifc; diveName = cand.name; diveArea = cand.area;
-        diveSrc = (cand.score < 0) ? 'bbox-centre' : 'room-graph';
-        dive3 = c3; floorY = fy; settle = { x: st.x, y: st.y, z: st.z }; fan = f; enclosedFrac = frac;
+
+    if (alreadyInside) {
+      diveIfc = camIfc0; diveName = 'already-inside'; diveArea = 0; diveSrc = 'already-inside';
+      dive3 = { x: camPos0.x, y: camPos0.y, z: camPos0.z };
+      floorY = fy0; settle = { x: st0.x, y: st0.y, z: st0.z }; fan = fan0; enclosedFrac = frac0;
+      console.log('§CINEMA_SPACE cand=already-inside area=n/a zLevelFrac=' + zLevelFrac0.toFixed(3) +
+        ' enclosed=' + (frac0 * 100).toFixed(0) + '% floorGap=' + floorGap0.toFixed(1) +
+        'm chosen=true (settled — no search, per already-inside rule)');
+    } else {
+      // ══ The dive target: the LARGEST INTERIOR SPACE NEAREST THE CENTRE, AT FLOOR LEVEL ═══════
+      // "Largest space NEAREST TO the centre" beats the strict geometric centre — on a big building
+      // the centroid can land in a service core, and the beat has to land somewhere that reads as a
+      // space. Rank the building's REAL rooms (IfcSpace rects from the room graph — extracted, never
+      // invented) by area discounted by distance from the centre AND by floor-level-ness
+      // (_cinemaFloorLevelWeight, R2 fix — zLevelFrac from the space's OWN Z, never the storey
+      // stack). No minimum-size gate and no skip path: every film dives, on every building, per
+      // §CINEMA_SIMPLE decision 3 — floor-level only re-ranks which space, it never skips the dive.
+      var roomGraph = null;
+      try { roomGraph = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null; } catch (eG) { roomGraph = null; }
+      var spaceCands = [];
+      if (roomGraph && roomGraph.nodesByGuid && arcBbox) {
+        var ctrIx = (arcBbox.xMin + arcBbox.xMax) / 2, ctrIy = (arcBbox.yMin + arcBbox.yMax) / 2;
+        for (var rk in roomGraph.nodesByGuid) {
+          var rn = roomGraph.nodesByGuid[rk];
+          if (!rn || rn.kind !== 'room' || !rn.rects || !rn.rects.length) continue;
+          var ar = 0;
+          for (var ri = 0; ri < rn.rects.length; ri++)
+            ar += Math.abs(rn.rects[ri].x1 - rn.rects[ri].x0) * Math.abs(rn.rects[ri].y1 - rn.rects[ri].y0);
+          if (!(ar > 0)) continue;
+          var dCtr = Math.hypot(rn.cx - ctrIx, rn.cy - ctrIy);
+          var zLevelFrac = Math.max(0, Math.min(1, (rn.cz - arcBbox.zMin) / zSpan0));
+          var flw = _cinemaFloorLevelWeight(zLevelFrac);
+          spaceCands.push({ guid: rn.guid, name: rn.name || rn.guid, area: ar, dCtr: dCtr, zLevelFrac: zLevelFrac,
+                            ifc: { ix: rn.cx, iy: rn.cy, iz: rn.cz },
+                            score: (ar / (1 + dCtr / Math.max(1, envelope * 0.5))) * flw });
+        }
+        spaceCands.sort(function(a, b) { return b.score - a.score; });
       }
-      if (frac >= 0.6) break;                 // genuinely enclosed — take it, it is the best-scoring such
-      rejectedOpen.push(cand.name + '@' + (frac * 100).toFixed(0) + '%');
+      if (arcBbox) spaceCands.push({ guid: 'bbox-centre', name: 'bbox-centre', area: 0, dCtr: 0, score: -1, zLevelFrac: 0.15,
+        ifc: { ix: (arcBbox.xMin + arcBbox.xMax) / 2, iy: (arcBbox.yMin + arcBbox.yMax) / 2,
+               iz: arcBbox.zMin + (arcBbox.zMax - arcBbox.zMin) * 0.15 } });
+      // ENCLOSURE TEST — the BVH fan is what makes "largest INTERIOR space" mean something. Measured
+      // on Duplex: the top-scoring IfcSpace by area×centrality was a 135m² ROOF TERRACE whose fan
+      // reported 32/32 bearings clear to the 60m horizon — outdoors, not a room. Measured on Terminal
+      // and Hospital (R2): enclosed alone still picked a roof attic/plant volume — the floor-level
+      // weight above is what keeps that candidate off the top of the shortlist in the first place.
+      // Evaluate the top few candidates with a real fan and take the best-scoring one that is
+      // actually ENCLOSED (majority of bearings hit geometry). If none is — a building with no
+      // interior at all — the top scorer is still used: no minimum-size gate, no skip path.
+      var spaceCandLog = [];
+      for (var ci2 = 0; ci2 < Math.min(spaceCands.length, 6); ci2++) {
+        var cand = spaceCands[ci2];
+        triedSpaces++;
+        var c3 = A.ifc2three(cand.ifc.ix, cand.ifc.iy, cand.ifc.iz);
+        // Eye level = the REAL floor under that point + 1.7m, from a downward raycast against
+        // rendered triangles. Cast from just above the space's own elevation so a multi-storey
+        // building resolves THIS storey's slab rather than the roof.
+        var fy = _cinemaFloorY(c3.x, c3.z, c3.y + 2.5);
+        if (fy === null) fy = _cinemaFloorY(c3.x, c3.z, c3.y + 25);
+        if (fy === null && arcBbox) fy = A.ifc2three(0, 0, arcBbox.zMin).y;
+        var st = { x: c3.x, y: (fy === null ? c3.y : fy) + CINEMA_EYE_M, z: c3.z };
+        var f = _cinemaFan(st, CINEMA_FAN_RAYS);
+        var hit = 0;
+        for (var fi = 0; fi < f.free.length; fi++) if (f.free[fi] < CINEMA_FAN_FAR - 0.01) hit++;
+        var frac = hit / f.free.length;
+        spaceCandLog.push({ guid: cand.guid, name: cand.name, area: cand.area, zLevelFrac: cand.zLevelFrac, enclosedFrac: frac });
+        if (!settle || frac > enclosedFrac) {   // remember the most-enclosed one seen so far
+          diveIfc = cand.ifc; diveName = cand.name; diveArea = cand.area;
+          diveSrc = (cand.score < 0) ? 'bbox-centre' : 'room-graph';
+          dive3 = c3; floorY = fy; settle = { x: st.x, y: st.y, z: st.z }; fan = f; enclosedFrac = frac;
+        }
+        if (frac >= CINEMA_ENCLOSED_THRESHOLD) break; // genuinely enclosed — take it, best-scoring such
+        rejectedOpen.push(cand.name + '@' + (frac * 100).toFixed(0) + '%');
+      }
+      if (!settle) { settle = { x: pivot.x, y: pivot.y, z: pivot.z }; fan = _cinemaFan(settle, CINEMA_FAN_RAYS); }
+      for (var sl = 0; sl < spaceCandLog.length; sl++) {
+        var sc = spaceCandLog[sl];
+        console.log('§CINEMA_SPACE cand=' + sc.guid + ' area=' + sc.area.toFixed(1) +
+          ' zLevelFrac=' + sc.zLevelFrac.toFixed(3) + ' enclosed=' + (sc.enclosedFrac * 100).toFixed(0) + '%' +
+          ' chosen=' + (sc.name === diveName));
+      }
     }
-    if (!settle) { settle = { x: pivot.x, y: pivot.y, z: pivot.z }; fan = _cinemaFan(settle, CINEMA_FAN_RAYS); }
     // BVH fan nudge: slide toward the open side so we land in the MIDDLE of the space rather than
     // against a wall. Bounded, so it can never wander out of the room. When the pose is nose-to-a-
     // wall this IS the "backing away" the spec asks for.
@@ -3488,6 +3605,29 @@ async function setupEffects(A, renderer, scene, camera) {
       ' lookdown=' + (lookdownTilt * 180 / Math.PI).toFixed(1) + '° entryTilt=' +
       (entryTilt * 180 / Math.PI).toFixed(1) + '° orbitRadius=' + orbitRadius.toFixed(1));
 
+    // ══ Beat boundaries, in normalized time. Fixed SECONDS, so a longer film gets a longer orbit,
+    // never a longer dive (§CINEMA_SIMPLE: the dive is time-boxed at 4s and must not be clamped).
+    // Computed BEFORE _orbitPose (moved up from after it, R3 fix) because the swoop window below
+    // needs tR + durationSec to convert its SECONDS half-width into the orbit's own u-domain, and
+    // _orbitPose(0) is called immediately below to seed the Beat 4 handoff target. ══════════════
+    var tD = Math.min(0.30, CINEMA_DIVE_SEC / durationSec);
+    var tS = Math.min(0.42, tD + CINEMA_SPIN_SEC / durationSec);
+    var tO = Math.min(0.62, tS + CINEMA_OUT_SEC / durationSec);
+    var tR = Math.min(0.72, tO + CINEMA_RISE_SEC / durationSec);
+    console.log('§CINEMA_BEATS dive=' + tD.toFixed(3) + ' spin=' + tS.toFixed(3) + ' out=' + tO.toFixed(3) +
+      ' rise=' + tR.toFixed(3) + ' (dur=' + durationSec.toFixed(1) + 's) route=' + outRoute +
+      ' waypoints=' + outWp.length + ' pathLen=' + totalLen.toFixed(1) +
+      ' spinDeg=' + Math.round(dYaw * 180 / Math.PI));
+
+    // ══ §CINEMA_SWOOP reinstated (R3 fix) — where in the final orbit's u-domain (0..1 over the
+    // WHOLE 360° ending act) the camera's azimuth crosses the Sun's. swoopHalfU converts the fixed
+    // SECONDS half-width into that domain using the ending act's real duration, (1-tR)*durationSec.
+    var swoopU = (((sunAz - exitAz) % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI) / (2 * Math.PI);
+    var swoopHalfU = CINEMA_SWOOP_HALF_SEC / Math.max(1e-3, (1 - tR) * durationSec);
+    var swoopTiltRad = THREE.MathUtils.degToRad(CINEMA_SWOOP_TILT_DEG);
+    console.log('§CINEMA_SWOOP swoopU=' + swoopU.toFixed(3) + ' (~' + (swoopU * (1 - tR) * durationSec).toFixed(1) +
+      's into the final orbit) halfU=' + swoopHalfU.toFixed(3) + ' tiltDeg=' + CINEMA_SWOOP_TILT_DEG);
+
     // ══ The standard ending: one plain orbit off the side we emerged on, with the classic wide
     // pull-back flourish. Same close for EVERY film (§CINEMA_SIMPLE decision 2 — the reciprocal
     // ending is retired). No handoff branch, hence no ~10.8m step. ═══════════════════════════════
@@ -3495,6 +3635,16 @@ async function setupEffects(A, renderer, scene, camera) {
       u = Math.max(0, Math.min(1, u));
       var az = exitAz + u * Math.PI * 2;
       var tilt = entryTilt + (lookdownTilt - entryTilt) * (holdU > 0 ? _cinemaSmoothstep(u / holdU) : 1);
+      // §CINEMA_SWOOP: once per loop, as the orbit's azimuth crosses the Sun's, dip the tilt toward
+      // building/eye level so the film passes low and facing the glint at least once (R3 fix — this
+      // is the SAME sun-awareness as the hold above, just acting DURING the orbit rather than at its
+      // start; verify both together per the spec).
+      var swoopDelta = Math.abs(u - swoopU);
+      swoopDelta = Math.min(swoopDelta, 1 - swoopDelta); // wrap-around near u=0/1
+      if (swoopHalfU > 0 && swoopDelta < swoopHalfU) {
+        var swoopW = 1 - _cinemaSmoothstep(swoopDelta / swoopHalfU);
+        tilt = tilt + (swoopTiltRad - tilt) * swoopW;
+      }
       // Ellipse ramps in from exactly 0 at u=0 so the orbit begins precisely where the rise ended.
       var ell = 1 + CINEMA_ELLIPTICITY * _cinemaSmoothstep(u / 0.15) * Math.cos(2 * (az - exitAz));
       var radius = orbitRadius * ell;
@@ -3507,17 +3657,6 @@ async function setupEffects(A, renderer, scene, camera) {
                z: pivot.z + hr * Math.sin(az), tx: pivot.x, ty: pivot.y, tz: pivot.z };
     }
     var orbitStart = _orbitPose(0);
-
-    // ══ Beat boundaries, in normalized time. Fixed SECONDS, so a longer film gets a longer orbit,
-    // never a longer dive (§CINEMA_SIMPLE: the dive is time-boxed at 4s and must not be clamped). ══
-    var tD = Math.min(0.30, CINEMA_DIVE_SEC / durationSec);
-    var tS = Math.min(0.42, tD + CINEMA_SPIN_SEC / durationSec);
-    var tO = Math.min(0.62, tS + CINEMA_OUT_SEC / durationSec);
-    var tR = Math.min(0.72, tO + CINEMA_RISE_SEC / durationSec);
-    console.log('§CINEMA_BEATS dive=' + tD.toFixed(3) + ' spin=' + tS.toFixed(3) + ' out=' + tO.toFixed(3) +
-      ' rise=' + tR.toFixed(3) + ' (dur=' + durationSec.toFixed(1) + 's) route=' + outRoute +
-      ' waypoints=' + outWp.length + ' pathLen=' + totalLen.toFixed(1) +
-      ' spinDeg=' + Math.round(dYaw * 180 / Math.PI));
 
     function poseAt(tNorm) {
       tNorm = Math.max(0, Math.min(1, tNorm));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v821';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v822';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cinema_r1_sit_fallback.js
+++ b/witness_cinema_r1_sit_fallback.js
@@ -1,0 +1,144 @@
+// WITNESS — §STAFFAGE_SIT_OPEN_FLOOR (R1, PHOTOREAL_STILL_RENDER.md "LIVE TRIAL REGRESSIONS").
+// ISSUE IT PROVES/DISPROVES: "There are no more sitting pax in the Terminal hall though there are
+// seats" — measured root cause (this session, r1_probe_before.txt): Terminal's furniture set has
+// only 4 rows that pass §STAFFAGE_SEAT_CLASS as real seats out of 176, and none land in this camera's
+// view/16m range on ANY of 3 presses (`§STAFFAGE_SEAT_CLASS ... inViewSeats=0`, sit=0 every time).
+// User ruling: a seated figure needs no real chair or adjacent table — fall back to open floor
+// "just for semblance". This drives the REAL _updateInFrameInterior (via A.togglePopulate()) inside
+// the Terminal/Hospital hall and asserts:
+//   (a) cumulative seated pax placed over 3 presses is >0 (the exact negation of the reported defect;
+//       BEFORE-fix logs captured this session show sit=0/openFloor=0 on every press, every building
+//       tested — see r1_probe_before.txt),
+//   (b) EVERY open-floor seated figure (userData.sitOpenFloor === true) independently re-audits as
+//       CLEAR of real geometry (>= 0.4m — the `_CLR_PERSON` bar minus float slack), re-derived from a
+//       fresh BVH raycast against the rendered scene, never asking the placement code whether it
+//       thinks it did the right thing (same discipline as witness_staffage_indoor_clearance.js).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8399;
+const CASES = [
+  { name: 'Terminal', db: '/buildings/Terminal_extracted.db', frac: 0.30 },
+  { name: 'Hospital', db: '/buildings/Hospital_extracted.db', frac: 0.30 },
+];
+
+function auditInPage() {
+  const A = window.APP, THREE = window.THREE;
+  const grp = A._photoStaffageGroup;
+  if (!grp) return { err: 'no staffage group' };
+  const solids = [];
+  A.scene.traverse(o => {
+    if (!(o.isMesh || o.isInstancedMesh || o.isBatchedMesh)) return;
+    if (!o.visible) return;
+    if (o.userData && o.userData.staffageKind !== undefined) return;
+    if (o.parent === grp) return;
+    if (A.sky && o === A.sky) return;
+    solids.push(o);
+  });
+  const ray = new THREE.Raycaster();
+  const hit = (origin, dir, far) => {
+    ray.set(origin, dir); ray.far = far;
+    let hs; try { hs = ray.intersectObjects(solids, false); } catch (e) { return Infinity; }
+    for (const h of hs) if (!h.object.isSprite) return h.distance;
+    return Infinity;
+  };
+  const clearRadius = (p, need) => {
+    let min = need;
+    for (const h of [0.25, 1.2]) {
+      const o = new THREE.Vector3(p.x, p.y + h, p.z);
+      for (let a = 0; a < 16; a++) {
+        const t = (a / 16) * Math.PI * 2;
+        const d = hit(o, new THREE.Vector3(Math.cos(t), 0, Math.sin(t)), need);
+        if (d < min) min = d;
+      }
+    }
+    return min;
+  };
+  let seatSit = 0, openFloorSit = 0, badOpenFloor = 0;
+  const detail = [];
+  for (const c of grp.children) {
+    const ud = c.userData || {};
+    if (ud.staffageKind && ud.staffageKind !== 'people') continue;
+    if (!ud.interior) continue;
+    if (ud.sitAnchorIfc) { seatSit++; continue; }         // real-seat anchored — PR #898 exempt
+    if (ud.sitOpenFloor) {
+      openFloorSit++;
+      const cr = clearRadius(c.position, 0.45);
+      if (cr < 0.4) { badOpenFloor++; detail.push(`openFloor inMesh clear=${cr.toFixed(2)}m`); }
+    }
+  }
+  return { seatSit, openFloorSit, badOpenFloor, detail };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    protocolTimeout: 300000,
+  });
+  let allPass = true;
+
+  for (const kase of CASES) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 800 });
+    const logs = [];
+    page.on('console', m => { const t = m.text(); if (/§|Error/.test(t)) logs.push(t); });
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    console.log(`\n${'='.repeat(78)}\n${kase.name}\n${'='.repeat(78)}`);
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=${kase.db}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 90000, polling: 2000 });
+    await new Promise(r => setTimeout(r, 15000));
+
+    const cam = await page.evaluate((frac) => {
+      const A = window.APP, THREE = window.THREE;
+      const r = A.dbQuery('SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y),MIN(center_z),MAX(center_z) FROM element_transforms WHERE center_x IS NOT NULL');
+      const [x0, x1, y0, y1, z0] = r[0];
+      const eyeIfc = [x0 + (x1 - x0) * frac, (y0 + y1) / 2, z0 + 1.7];
+      const tgtIfc = [x0 + (x1 - x0) * (frac + 0.55), (y0 + y1) / 2, z0 + 1.7];
+      const e = A.ifc2three(eyeIfc[0], eyeIfc[1], eyeIfc[2]);
+      const t = A.ifc2three(tgtIfc[0], tgtIfc[1], tgtIfc[2]);
+      A.camera.position.set(e.x, e.y, e.z);
+      A.camera.lookAt(new THREE.Vector3(t.x, t.y, t.z));
+      A.camera.updateMatrixWorld(true);
+      if (A.controls) { A.controls.target.set(t.x, t.y, t.z); A.controls.update(); }
+      return { eyeIfc };
+    }, kase.frac);
+    console.log('  camera: ' + JSON.stringify(cam));
+
+    const before = logs.length;
+    for (let i = 0; i < 3; i++) {
+      await page.evaluate(() => window.APP.togglePopulate());
+      await new Promise(r => setTimeout(r, 6000));
+    }
+    await new Promise(r => setTimeout(r, 3000));
+    const tail = logs.slice(before);
+    tail.filter(l => /STAFFAGE_SEAT_CLASS|STAFFAGE_SIT_FALLBACK|PHOTO_STAFFAGE_INTERIOR/.test(l)).forEach(l => console.log('    ' + l));
+
+    const audit = await page.evaluate(auditInPage);
+    console.log('  audit: ' + JSON.stringify(audit));
+
+    const sitTotalLines = tail.filter(l => l.startsWith('§PHOTO_STAFFAGE_INTERIOR'));
+    const sitCounts = sitTotalLines.map(l => { const m = l.match(/sit=(\d+)/); return m ? parseInt(m[1], 10) : 0; });
+    const maxSitSeen = sitCounts.length ? Math.max(...sitCounts) : 0;
+
+    const checks = [
+      ['at least one §PHOTO_STAFFAGE_INTERIOR line logged', sitTotalLines.length > 0],
+      ['seated pax placed (sit>0) at least once across 3 presses — the reported defect was sit=0 every time', maxSitSeen > 0],
+      ['audit found open-floor seated figures (openFloorSit>0)', !audit.err && audit.openFloorSit > 0],
+      ['ZERO in-mesh violations among open-floor seated figures (independent BVH re-derivation)', !audit.err && audit.badOpenFloor === 0],
+    ];
+    checks.forEach(([label, ok]) => { console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${label}`); if (!ok) allPass = false; });
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log('  PAGEERRORS: ' + errs.join(' | ')); allPass = false; }
+    await page.close();
+  }
+
+  console.log(`\n${'='.repeat(78)}\nVERDICT: ${allPass ? 'PASS — open-floor seated pax now place, none in-mesh' : 'FAIL'}\n`);
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cinema_r2_floor_level.js
+++ b/witness_cinema_r2_floor_level.js
@@ -1,0 +1,133 @@
+// WITNESS — §CINEMA_SPACE R2 fix (PHOTOREAL_STILL_RENDER.md "R2 STILL BROKEN after v818").
+// ISSUE IT PROVES/DISPROVES: the dive target selection picked the roof attic / plant space over the
+// main concourse on Terminal AND Hospital, because "largest enclosed" alone has no floor-level sense
+// and the "already inside a space" case was re-running the search instead of settling in place.
+//   PASS = for each building:
+//     (a) OUTSIDE start -> chosen space's zLevelFrac is low-to-mid (<0.6), never ~1.0 (attic),
+//         and is genuinely enclosed (>=60%).
+//     (b) ALREADY-INSIDE start (camera placed at a real room's own centre) -> the short-circuit
+//         fires (§CINEMA_SPACE cand=already-inside chosen=true), no candidate search log is emitted.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8399;
+const BUILDINGS = (process.env.BLDS || 'Terminal,Hospital').split(',');
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls && window.APP.cinemaPathPlan,
+      { timeout: 90000 });
+    await new Promise(r => setTimeout(r, 9000));  // let streaming + bbox settle
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+
+    // ── (a) OUTSIDE start: well clear of the footprint, above the roof, looking down ──
+    const before1 = logs.length;
+    const out1 = await page.evaluate(async () => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      const r = A.dbQuery('SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y),MIN(center_z),MAX(center_z) FROM element_transforms');
+      const [x0, x1, y0, y1, z0, z1] = r[0];
+      const c = A.ifc2three((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2);
+      const env = Math.max(x1 - x0, y1 - y0);
+      const rad = env * 1.5, tilt = 25 * Math.PI / 180, az = 0.9;
+      A.controls.target.set(c.x, c.y, c.z);
+      A.camera.position.set(
+        c.x + rad * Math.cos(tilt) * Math.cos(az),
+        c.y + rad * Math.sin(tilt) + env * 0.3,  // pushed well above the roof too
+        c.z + rad * Math.cos(tilt) * Math.sin(az)
+      );
+      A.controls.update();
+      const plan = A.cinemaPathPlan(24);
+      return { ok: !!plan };
+    });
+    const tail1 = logs.slice(before1);
+    if (!out1 || !out1.ok) { console.log('  OUTSIDE: PLAN FAILED'); allPass = false; }
+    const spaceLines1 = tail1.filter(l => l.startsWith('§CINEMA_SPACE'));
+    const chosenLine1 = spaceLines1.find(l => / chosen=true/.test(l));
+    const diveLine1 = tail1.find(l => l.startsWith('§CINEMA_DIVE'));
+    console.log('  OUTSIDE start:');
+    spaceLines1.forEach(l => console.log('    ' + l));
+    console.log('    ' + (diveLine1 || 'NO §CINEMA_DIVE LINE'));
+    let zFrac1 = null, enclosed1 = null, alreadyInside1 = false;
+    if (chosenLine1) {
+      alreadyInside1 = chosenLine1.startsWith('§CINEMA_SPACE cand=already-inside');
+      const m = chosenLine1.match(/zLevelFrac=([\d.]+)/);
+      const e = chosenLine1.match(/enclosed=([\d.]+)%/);
+      zFrac1 = m ? parseFloat(m[1]) : null;
+      enclosed1 = e ? parseFloat(e[1]) : null;
+    }
+    const outsideChecks = [
+      ['§CINEMA_SPACE chosen line present', !!chosenLine1],
+      ['not the already-inside short-circuit (camera was placed outside)', !alreadyInside1],
+      // 0.85 not 0.6: a legitimate upper floor (e.g. Terminal's departure level) can sit mid-0.5s-0.6s
+      // and must not be rejected as "attic" — the real attic/roof reads ~0.9-1.0 (measured: Terminal's
+      // "Aras Bumbung" roof room = 0.946). The acceptance bar is "clearly not the roof", not "ground only".
+      ['chosen zLevelFrac is low-to-mid (<0.85), never ~1.0 (attic)', zFrac1 !== null && zFrac1 < 0.85],
+      ['chosen space is genuinely enclosed (>=60%)', enclosed1 !== null && enclosed1 >= 60],
+    ];
+    outsideChecks.forEach(([label, ok]) => { console.log(`    [${ok ? 'PASS' : 'FAIL'}] ${label}`); if (!ok) allPass = false; });
+
+    // ── (b) ALREADY-INSIDE start: camera placed at a real room's own centre, floor level ──
+    const before2 = logs.length;
+    const out2 = await page.evaluate(async () => {
+      const A = window.APP;
+      const g = A.getRoomGraph ? A.getRoomGraph() : null;
+      if (!g || !g.nodesByGuid) return { ok: false, reason: 'no room graph' };
+      let best = null, bestArea = -1;
+      for (const k in g.nodesByGuid) {
+        const rn = g.nodesByGuid[k];
+        if (!rn || rn.kind !== 'room' || !rn.rects || !rn.rects.length) continue;
+        let ar = 0;
+        for (const rc of rn.rects) ar += Math.abs(rc.x1 - rc.x0) * Math.abs(rc.y1 - rc.y0);
+        if (ar > bestArea) { bestArea = ar; best = rn; }
+      }
+      if (!best) return { ok: false, reason: 'no room candidate' };
+      const c3 = A.ifc2three(best.cx, best.cy, best.cz);
+      A.camera.position.set(c3.x, c3.y + 1.7, c3.z);
+      A.controls.target.set(c3.x + 5, c3.y + 1.7, c3.z);
+      A.camera.lookAt(c3.x + 5, c3.y + 1.7, c3.z);
+      A.controls.update();
+      const plan = A.cinemaPathPlan(24);
+      return { ok: !!plan, room: best.name || best.guid };
+    });
+    const tail2 = logs.slice(before2);
+    if (!out2 || !out2.ok) { console.log('  ALREADY-INSIDE: SETUP/PLAN FAILED (' + (out2 && out2.reason) + ')'); allPass = false; }
+    const spaceLines2 = tail2.filter(l => l.startsWith('§CINEMA_SPACE'));
+    console.log('  ALREADY-INSIDE start (room="' + (out2 && out2.room) + '"):');
+    spaceLines2.forEach(l => console.log('    ' + l));
+    const shortCircuited = spaceLines2.length === 1 && spaceLines2[0].startsWith('§CINEMA_SPACE cand=already-inside') &&
+      / chosen=true/.test(spaceLines2[0]);
+    const insideChecks = [
+      ['already-inside short-circuit fired, no candidate search', shortCircuited],
+    ];
+    insideChecks.forEach(([label, ok]) => { console.log(`    [${ok ? 'PASS' : 'FAIL'}] ${label}`); if (!ok) allPass = false; });
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log('   PAGEERRORS: ' + errs.join(' | ')); allPass = false; }
+    await page.close();
+  }
+
+  console.log(`\n${'='.repeat(78)}\nVERDICT: ${allPass ? 'PASS — dive lands in the concourse, already-inside settles in place' : 'FAIL'}\n`);
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cinema_r3_swoop.js
+++ b/witness_cinema_r3_swoop.js
@@ -1,0 +1,170 @@
+// WITNESS — §CINEMA_SWOOP reinstated (R3, PHOTOREAL_STILL_RENDER.md "LIVE TRIAL REGRESSIONS").
+// ISSUE IT PROVES/DISPROVES: the §CINEMA_SIMPLE cleanup (#902) deleted §CINEMA_SWOOP — the film no
+// longer levels off to catch the Sun's reflection during the final orbit. This drives the REAL
+// _cinemaPathPlan and samples poseAt() across the final orbit act to confirm the tilt actually dips
+// toward CINEMA_SWOOP_TILT_DEG at the sun-crossing and is UNCHANGED away from it. Also exercises the
+// Sun-hold branch (hold=true), never proven to fire before (per the doctrine, R3 and Sun-hold are the
+// same sun-awareness — verify together).
+//   PASS = for each building:
+//     (a) §CINEMA_SWOOP log line present with a finite swoopU/halfU.
+//     (b) sampled tilt at the swoop crossing is measurably CLOSER to CINEMA_SWOOP_TILT_DEG(=4°) than
+//         the no-swoop baseline tilt at that same u.
+//     (c) sampled tilt far from the crossing (>=2x halfU away) matches the no-swoop baseline closely.
+//     (d) with the Sun forced onto the exit heading, §CINEMA_SUN reports hold=true, holdU>0, and the
+//         orbit's OPENING tilt (u near 0) is measurably shallower than the plain look-down angle.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8399;
+const BUILDINGS = (process.env.BLDS || 'Terminal,Hospital').split(',');
+const SWOOP_TILT_DEG = 4;
+
+function grab(lines, tag, re) {
+  const l = lines.find(t => t.startsWith(tag));
+  const m = l && l.match(re);
+  return m ? parseFloat(m[1]) : null;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls && window.APP.cinemaPathPlan,
+      { timeout: 90000 });
+    await new Promise(r => setTimeout(r, 9000));
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 90000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+
+    // ── (a)+(b)+(c): a normal outside pose, sample the final orbit for the dip ──
+    const before1 = logs.length;
+    const plan1 = await page.evaluate(async () => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      const r = A.dbQuery('SELECT MIN(center_x),MAX(center_x),MIN(center_y),MAX(center_y),MIN(center_z),MAX(center_z) FROM element_transforms');
+      const [x0, x1, y0, y1, z0, z1] = r[0];
+      const c = A.ifc2three((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2);
+      const env = Math.max(x1 - x0, y1 - y0);
+      const rad = env * 1.5, tilt = 25 * Math.PI / 180, az = 0.9;
+      A.controls.target.set(c.x, c.y, c.z);
+      A.camera.position.set(c.x + rad * Math.cos(tilt) * Math.cos(az), c.y + rad * Math.sin(tilt) + env * 0.3, c.z + rad * Math.cos(tilt) * Math.sin(az));
+      A.controls.update();
+      const plan = A.cinemaPathPlan(24);
+      if (!plan) return null;
+      // sample the WHOLE final orbit act densely, deriving tilt from the returned camera position
+      // (poseAt gives x/y/z + target, not the raw tilt scalar, so recover it from geometry).
+      const pivot = plan.pivot;
+      const rise = plan.beats.rise;
+      const samples = [];
+      for (let i = 0; i <= 400; i++) {
+        const u = i / 400;
+        const tNorm = rise + u * (1 - rise);
+        const p = plan.poseAt(tNorm);
+        const dx = p.x - pivot.x, dz = p.z - pivot.z, dy = p.y - pivot.y;
+        const horiz = Math.hypot(dx, dz);
+        const tiltDeg = Math.atan2(dy, horiz) * 180 / Math.PI;
+        samples.push({ u, tiltDeg });
+      }
+      return { ok: true, samples, rise };
+    });
+    const tail1 = logs.slice(before1);
+    const swoopLine = tail1.find(l => l.startsWith('§CINEMA_SWOOP'));
+    const sunLine = tail1.find(l => l.startsWith('§CINEMA_SUN'));
+    console.log('  ' + (swoopLine || 'NO §CINEMA_SWOOP LINE'));
+    console.log('  ' + (sunLine || 'NO §CINEMA_SUN LINE'));
+
+    const swoopU = grab(tail1, '§CINEMA_SWOOP', /swoopU=([\d.]+)/);
+    const halfU = grab(tail1, '§CINEMA_SWOOP', /halfU=([\d.]+)/);
+    const entryTiltDeg = grab(tail1, '§CINEMA_SUN', /entryTilt=(-?[\d.]+)/);
+    const lookdownDeg = grab(tail1, '§CINEMA_SUN', /lookdown=(-?[\d.]+)/);
+    const holdU0 = grab(tail1, '§CINEMA_SUN', /holdU=([\d.]+)/);
+
+    let dipOk = false, farOk = true, dipMagnitude = null, farMaxDev = 0;
+    if (plan1 && plan1.ok && swoopU !== null && halfU !== null && entryTiltDeg !== null && lookdownDeg !== null) {
+      const baseline = (u) => entryTiltDeg + (lookdownDeg - entryTiltDeg) * (holdU0 > 0 ? smoothstep(u / holdU0) : 1);
+      function smoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
+      let bestNear = null, bestNearDelta = Infinity;
+      for (const s of plan1.samples) {
+        let d = Math.abs(s.u - swoopU); d = Math.min(d, 1 - d);
+        if (d < bestNearDelta) { bestNearDelta = d; bestNear = s; }
+      }
+      if (bestNear) {
+        const base = baseline(bestNear.u);
+        dipMagnitude = base - bestNear.tiltDeg; // positive = dipped toward level (lower tilt)
+        dipOk = dipMagnitude > 3; // measurably closer to the SWOOP_TILT_DEG=4deg floor than baseline
+      }
+      for (const s of plan1.samples) {
+        let d = Math.abs(s.u - swoopU); d = Math.min(d, 1 - d);
+        if (d >= 2 * halfU) {
+          const base = baseline(s.u);
+          const dev = Math.abs(base - s.tiltDeg);
+          if (dev > farMaxDev) farMaxDev = dev;
+        }
+      }
+      farOk = farMaxDev < 0.5; // matches baseline closely away from the crossing
+    }
+    console.log(`    swoopU=${swoopU} halfU=${halfU} dipMagnitude=${dipMagnitude === null ? 'n/a' : dipMagnitude.toFixed(2)}deg farMaxDev=${farMaxDev.toFixed(3)}deg`);
+    const checksA = [
+      ['§CINEMA_SWOOP line present with finite swoopU/halfU', swoopU !== null && halfU !== null && isFinite(swoopU) && isFinite(halfU)],
+      ['tilt measurably dips (>3deg) toward the swoop floor at the crossing', dipOk],
+      ['tilt away from the crossing matches the no-swoop baseline (<0.5deg dev)', farOk],
+    ];
+    checksA.forEach(([label, ok]) => { console.log(`    [${ok ? 'PASS' : 'FAIL'}] ${label}`); if (!ok) allPass = false; });
+
+    // ── (d): force the Sun onto the exit heading, confirm hold=true fires ──
+    const before2 = logs.length;
+    const plan2 = await page.evaluate(async (exitAzDeg) => {
+      const A = window.APP;
+      // Move the Sun so its azimuth (as seen from the pivot) lands ON the exit heading — forces
+      // sunHold=true regardless of where the camera happened to start (the branch that was never
+      // exercised before, per the doctrine).
+      const rad = exitAzDeg * Math.PI / 180;
+      const dist = 5000;
+      A.sun.position.set(Math.cos(rad) * dist, A.sun.position.y, Math.sin(rad) * dist);
+      const plan = A.cinemaPathPlan(24);
+      if (!plan) return null;
+      const pivot = plan.pivot;
+      const p0 = plan.poseAt(plan.beats.rise); // orbit opening, u≈0
+      const dx = p0.x - pivot.x, dz = p0.z - pivot.z, dy = p0.y - pivot.y;
+      const openTiltDeg = Math.atan2(dy, Math.hypot(dx, dz)) * 180 / Math.PI;
+      return { ok: true, openTiltDeg };
+    }, (grab(tail1, '§CINEMA_SUN', /exitAz=(-?[\d.]+)/) || 0));
+    const tail2 = logs.slice(before2);
+    const sunLine2 = tail2.find(l => l.startsWith('§CINEMA_SUN'));
+    console.log('  Sun forced onto exit heading:');
+    console.log('    ' + (sunLine2 || 'NO §CINEMA_SUN LINE'));
+    const hold2 = sunLine2 && / hold=true/.test(sunLine2);
+    const holdU2 = grab(tail2, '§CINEMA_SUN', /holdU=([\d.]+)/);
+    const lookdown2 = grab(tail2, '§CINEMA_SUN', /lookdown=(-?[\d.]+)/);
+    const checksB = [
+      ['Sun-hold branch fires (hold=true) when Sun is on the exit heading', !!hold2],
+      ['holdU > 0', holdU2 !== null && holdU2 > 0],
+      ['orbit opening tilt is shallower than the plain look-down (held back)', plan2 && plan2.ok && lookdown2 !== null && plan2.openTiltDeg < lookdown2 - 5],
+    ];
+    checksB.forEach(([label, ok]) => { console.log(`    [${ok ? 'PASS' : 'FAIL'}] ${label}`); if (!ok) allPass = false; });
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log('   PAGEERRORS: ' + errs.join(' | ')); allPass = false; }
+    await page.close();
+  }
+
+  console.log(`\n${'='.repeat(78)}\nVERDICT: ${allPass ? 'PASS — swoop dips at the sun-crossing, Sun-hold verified firing' : 'FAIL'}\n`);
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
Fixes the three §CINEMA_SIMPLE live-trial regressions from `bim-compiler prompts/PHOTOREAL_STILL_RENDER.md`, top-to-bottom per the spec's sequencing (R2 → R3 → R1).

- **R2** — Alt+C dive landed in the roof attic on Terminal AND Hospital, not the main hall. Added a floor-level preference (`_cinemaFloorLevelWeight`, using each space's own Z within the ARC bbox — never the storey stack) to the room-candidate ranking, plus an "already inside a space → settle there" short-circuit guarded against a roof-top downward raycast tunnelling through a gap to an unrelated slab.
- **R3** — `§CINEMA_SWOOP` (levels off to catch the Sun's reflection) was deleted by the `§CINEMA_SIMPLE` cleanup (#902). Reinstated in the new exterior-act orbit; also exercised the Sun-hold branch for the first time (forced the Sun onto the exit heading — previously unproven).
- **R1** — Terminal hall showed zero seated pax. Root cause: only 4/176 furniture rows classify as real seats, none land in view. Added an open-floor fallback ("just for semblance", per user ruling) using the same ground-clear aisle candidates + clearance gate the walk pass already uses.

`EFFECTS_V` v5→v6, `CACHE_VERSION` v821→v822.

## Test plan
- [x] R2: `witness_cinema_r2_floor_level.js` — Terminal + Hospital, outside-start and already-inside-start, both PASS (chosen zLevelFrac 0.597/0.089 vs attic's 0.946, 100% enclosed, already-inside short-circuit fires with zero search).
- [x] R3: `witness_cinema_r3_swoop.js` — Terminal + Hospital, tilt dips ~41° at the sun-crossing and matches baseline elsewhere (<0.5° dev); Sun-hold forced and verified firing (hold=true, holdU>0) on both.
- [x] R1: `witness_cinema_r1_sit_fallback.js` — Terminal + Hospital, seated pax go from sit=0 every press to placing open-floor figures, 0 in-mesh (independent BVH re-audit).
- [x] `node --check` on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)