### PR TITLE
feat(modeller): geometry truth chain — §DB_IDENTITY + §RENDER_FIDELITY

### DIFF
--- a/modeller/buildings_manifest.json
+++ b/modeller/buildings_manifest.json
@@ -1,0 +1,116 @@
+{
+  "_spec": "GEOMETRY_TRUTH_CHAIN.md §S1 — generated, never hand-edited. Regenerate: node scripts/gen_buildings_manifest.js",
+  "_note": "geoCovered/geoMissing are the JOIN across the (meta db, geo substrate) PAIR. geoRowsInMetaDb=0 is HEALTHY for ARC residents.",
+  "generated": "2026-07-19",
+  "substrates": {
+    "mesh.db": {
+      "geometries": 9198
+    }
+  },
+  "buildings": [
+    {
+      "key": "SampleHouse",
+      "db": "SampleHouse_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 60,
+      "instances": 58,
+      "distinctHashes": 46,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 58,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "Duplex",
+      "db": "Duplex_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 218,
+      "instances": 215,
+      "distinctHashes": 155,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 215,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "SampleCastle",
+      "db": "SampleCastle_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 3342,
+      "instances": 3225,
+      "distinctHashes": 1924,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 3225,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "HHS",
+      "db": "HHS_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 2560,
+      "instances": 2527,
+      "distinctHashes": 619,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 2527,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "Clinic",
+      "db": "Clinic_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 2620,
+      "instances": 2586,
+      "distinctHashes": 1467,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 2586,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "Hospital",
+      "db": "Hospital_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 14641,
+      "instances": 14409,
+      "distinctHashes": 3568,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 14409,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "HospitalGarage",
+      "db": "Garage_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 1271,
+      "instances": 1252,
+      "distinctHashes": 476,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 1252,
+      "geoMissing": 0,
+      "coveragePct": 100
+    },
+    {
+      "key": "Terminal",
+      "db": "Terminal_ARC.db",
+      "geoDb": "mesh.db",
+      "meta": 35552,
+      "instances": 35552,
+      "distinctHashes": 917,
+      "geoRowsInMetaDb": 0,
+      "geoSubstrate": "mesh.db",
+      "geoCovered": 35552,
+      "geoMissing": 0,
+      "coveragePct": 100
+    }
+  ]
+}

--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -353,6 +353,93 @@
     } catch (e) { console.warn(TAG + ' replay failed', e && e.message); }
   }
 
+  // ── GEOMETRY_TRUTH_CHAIN.md §S2 — `§DB_IDENTITY`, link 1's witness ──────────────────────────────
+  // ONE line per building open declaring WHICH copy actually resolved and whether it matches the
+  // generated manifest (§S1). Additive and non-blocking by contract: it only ever logs — a mismatch
+  // warns loudly, it NEVER refuses a load.
+  //
+  // WHY THE JOIN, NOT A ROW COUNT (S0(a), 2026-07-20): an ARC resident's own `component_geometries`
+  // is legitimately ABSENT — its meshes live in the shared mesh.db, linked by
+  // `element_instances(guid, geometry_hash)`. Reporting a bare per-file `geo=0` reads a 100%-healthy
+  // pair as broken; that exact misread burned a session on Hospital_ARC.db. So `geo=` here is the
+  // COVERED count across the resolved PAIR, and the pair is named in the line.
+  //
+  // WHAT THIS CATCHES THAT NOTHING ELSE DID (S0(c)): whole-substrate loss. When the geo db 404s, the
+  // seed silently falls back to meta-only and renders 12-tri boxes for EVERY element while
+  // `§GEOM-HARDFAIL total=0` reports all-clean (it only detects per-element breaks INSIDE a
+  // substrate that loaded). `geo=0/215 substrate=ABSENT` is that state, stated out loud.
+  var _manifest = null, _manifestTried = false;
+  function _loadManifest() {
+    if (_manifestTried) return Promise.resolve(_manifest);
+    _manifestTried = true;
+    return fetch(_modellerBase() + 'buildings_manifest.json')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (j) { _manifest = j; return j; })
+      .catch(function () { return null; });   // absent manifest is ALLOWED (logged as manifest=absent)
+  }
+
+  function _count(db, sql) {
+    try { var r = db.exec(sql); return (r.length && r[0].values.length) ? r[0].values[0][0] : 0; }
+    catch (e) { return null; }               // null = table absent (distinct from a real 0)
+  }
+
+  function _dbIdentity(key, bdb, gdb, geoBuf) {
+    try {
+      var res = null;
+      for (var i = 0; i < RESIDENTS.length; i++) if (RESIDENTS[i].key === key) res = RESIDENTS[i];
+      var meta = _count(bdb, 'SELECT COUNT(*) FROM elements_meta;');
+      var inst = _count(bdb, 'SELECT COUNT(*) FROM element_instances;');
+      // The geometry substrate that ACTUALLY resolved: the separate geo db if it loaded, else the
+      // meta db itself (the documented fallback) — never an assumption about which was intended.
+      var sub = gdb || bdb, subName = gdb ? (res && res.geoDb) : (res && res.db);
+      var subRows = _count(sub, 'SELECT COUNT(*) FROM component_geometries;');
+      var covered = null;
+      if (subRows) {
+        // Coverage across the pair. Same-db case is a plain join; split-db needs the hash set
+        // pulled over, since sql.js cannot ATTACH across two Database instances.
+        if (gdb) {
+          var have = {}, hr = null;
+          try { hr = sub.exec('SELECT geometry_hash FROM component_geometries;'); } catch (e) { hr = null; }
+          if (hr && hr.length) for (var h = 0; h < hr[0].values.length; h++) have[hr[0].values[h][0]] = 1;
+          var ir = null;
+          try { ir = bdb.exec('SELECT geometry_hash FROM element_instances;'); } catch (e) { ir = null; }
+          covered = 0;
+          if (ir && ir.length) for (var j = 0; j < ir[0].values.length; j++) if (have[ir[0].values[j][0]]) covered++;
+        } else {
+          covered = _count(bdb, 'SELECT COUNT(*) FROM element_instances i WHERE EXISTS' +
+            '(SELECT 1 FROM component_geometries g WHERE g.geometry_hash = i.geometry_hash);');
+        }
+      } else {
+        covered = 0;                          // no substrate rows reachable → nothing can resolve
+      }
+
+      _loadManifest().then(function (mf) {
+        var verdict = 'absent', exp = null;
+        if (mf && mf.buildings) {
+          for (var k = 0; k < mf.buildings.length; k++) if (mf.buildings[k].key === key) exp = mf.buildings[k];
+          if (exp) verdict = (exp.meta === meta && exp.instances === inst && exp.geoCovered === covered)
+            ? 'match' : 'MISMATCH';
+        }
+        var substrateState = (res && res.geoDb && !gdb) ? 'ABSENT(' + res.geoDb + ' failed to load)'
+          : (subName || 'self');
+        var line = TAG + ' §DB_IDENTITY name=' + key + ' path=' + (res ? res.db : '?') +
+          ' meta=' + meta + ' inst=' + inst + ' geo=' + covered + '/' + inst +
+          ' substrate=' + substrateState + ' substrateRows=' + subRows +
+          ' manifest=' + verdict;
+        if (verdict === 'MISMATCH') {
+          console.warn(line + ' — EXPECTED meta=' + exp.meta + ' inst=' + exp.instances +
+            ' geo=' + exp.geoCovered + ' (this build is NOT the manifested copy; render may be stale/partial)');
+        } else if (inst > 0 && covered === 0) {
+          // Manifest-clean but zero resolvable geometry = the silent-box state. Always loud.
+          console.warn(line + ' — ZERO geometry resolves for ' + inst + ' instances: every element will' +
+            ' render as a 12-tri box proxy (GEOMETRY_TRUTH_CHAIN.md §S0(c))');
+        } else {
+          console.log(line);
+        }
+      });
+    } catch (e) { console.warn(TAG + ' §DB_IDENTITY failed for ' + key + ' — ' + (e && e.message)); }
+  }
+
   // §GEO-SPLIT: lazily fetch+cache a resident's SEPARATE geometry-mesh db (Terminal_geo.db), reusing the
   // exact same IndexedDB cache pattern (_idbGetDb/_idbPutDb, its own URL key so it caches independently of
   // the meta db) — cache-first, else fetch+persist. Residents with no `geoDb` field resolve null IMMEDIATELY,
@@ -416,6 +503,7 @@
         try { gdb = new window.SQL.Database(new Uint8Array(geoBuf)); }
         catch (e) { console.error(TAG + ' §GEOM-HARDFAIL geoDb open failed for ' + key + ' — falling back to meta-only (no real geometry)', e && e.message); gdb = null; }
       }
+      _dbIdentity(key, bdb, gdb, geoBuf);   // §S2 — declare the resolved pair BEFORE seeding (log-only, never blocks)
       window.ArcEditable.seedArc(bdb, {
         // §LOD400-STALL: skip commitSeedGroup's default full verifyChain() for the ARC seed — it always seeds
         // into a FRESH mo_<building> instance (nothing pre-existing to lose coverage on), so the redundant

--- a/modeller/tests/witness_render_fidelity.js
+++ b/modeller/tests/witness_render_fidelity.js
@@ -1,0 +1,139 @@
+// WITNESS: GEOMETRY_TRUTH_CHAIN.md §S3 — render-time FIDELITY (link 2 of the truth chain).
+//
+// THE ISSUE THIS PROVES OR DISPROVES: "did REAL geometry reach the scene, or box proxies?"
+// On 2026-07-01 the Modeller rendered 3,225/3,225 SampleCastle elements as 12-triangle bounding
+// boxes — 100% fake — and ALL 32 Modeller witnesses stayed green, because every one of them
+// asserts something a box satisfies IDENTICALLY to a real mesh (counts, bbox centres/extents,
+// pixel-diffs). The only detector that ever fired was a human eye on a screenshot.
+//
+// This witness asserts the ONE metric a box cannot fake: the triangle census. A box is exactly 12
+// triangles; real meshes are not. Measured separation (2026-07-20, S0): Duplex green 126.8
+// tris/element vs 12.0 when the geometry substrate is missing — 10.6×, unambiguous.
+//
+// AND IT ASSERTS WHAT THE OLD GUARDS MISS: in that same broken run `§GEOM-HARDFAIL total=0` and
+// `§BLOB_MISS`=0 — both existing guards reported ALL CLEAN while rendering 100% boxes, because
+// they only detect per-element breaks INSIDE a substrate that loaded, never whole-substrate loss.
+// So hardFail/blobMiss are recorded here but are NOT sufficient; tris/element is load-bearing.
+//
+// GREEN + RED, both required (a tripwire never shown to trip is not a tripwire):
+//   node modeller/tests/witness_render_fidelity.js            → all fixtures verdict=REAL
+//   BREAK=1 node modeller/tests/witness_render_fidelity.js    → verdict=FAKE, and this script
+//                                                               exits NON-ZERO if it does not trip
+// The RED case injects the fault at the loader's own seam (a resident's geoDb repointed at a
+// nonexistent file, taking the shipped meta-only fallback). NO DB FILE IS EVER TOUCHED — per the
+// user's standing 2026-07-19 do-not-touch-DBs directive.
+//
+// Requires a static server for the worktree (default :8399, the standing sandbox).
+
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8399;
+const BREAK = process.env.BREAK === '1';
+// Default fixtures: seconds-to-~1min. Hospital/Terminal fulls are opt-in (FIXTURES=... , ~6 min each).
+const FIXTURES = (process.env.FIXTURES || 'SampleHouse,Duplex,SampleCastle,HHS').split(',');
+const URL = `http://localhost:${PORT}/modeller/modeller.html`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Baselines MEASURED 2026-07-20 (S0), never invented. A box population sits at exactly 12.0;
+// the lowest real fixture measured 73.6. 24 = 2× the box signature: comfortably above every
+// possible all-box run, comfortably below every measured real one.
+const BOX_TRIS = 12;
+const REAL_MIN_TPE = 24;
+
+function census() {
+  const A = window.A;
+  if (!A || !A.scene) return { err: 'no scene' };
+  let tris = 0, meshes = 0, batched = 0, instanced = 0, standalone = 0;
+  A.scene.traverse(o => {
+    const g = o.geometry;
+    if (!g || !o.visible) return;
+    let t = 0;
+    if (g.index) t = g.index.count / 3;
+    else if (g.attributes && g.attributes.position) t = g.attributes.position.count / 3;
+    if (o.isInstancedMesh) { t *= o.count; instanced++; }
+    else if (o.isBatchedMesh) { batched++; }
+    else if (o.isMesh) { standalone++; }
+    else return;
+    tris += t; meshes++;
+  });
+  return { tris: Math.round(tris), meshes, batched, instanced, standalone };
+}
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  const results = [];
+  let failures = 0;
+
+  try {
+    for (const key of FIXTURES) {
+      const ctx = await browser.newContext({ serviceWorkers: 'block', viewport: { width: 1200, height: 800 } });
+      const page = await ctx.newPage();
+      const logs = [];
+      page.on('console', m => logs.push(m.text()));
+      page.on('pageerror', e => logs.push('PAGEERR: ' + e.message));
+
+      if (BREAK) await page.addInitScript(() => { window.__BREAK_GEO = true; });
+      await page.goto(URL, { waitUntil: 'domcontentloaded' });
+      await page.waitForFunction(() => window.STRWalkerOutliner && window.A && window.A.scene, { timeout: 60000 });
+      await sleep(1500);
+
+      const res = await page.evaluate((k) => {
+        const SW = window.STRWalkerOutliner;
+        const r = SW._residents.find(x => x.key === k);
+        if (!r) return { err: 'no resident ' + k };
+        if (window.__BREAK_GEO) r.geoDb = 'NO_SUCH_mesh.db';   // fault injection; no DB file touched
+        SW._openResident(r);
+        return { db: r.db, geoDb: r.geoDb || null };
+      }, key);
+      if (res.err) { console.log(`§RENDER_FIDELITY building=${key} ERROR ${res.err}`); failures++; await ctx.close(); continue; }
+
+      // The §GEOM-HARDFAIL summary is the end-of-seed marker.
+      let seeded = false;
+      for (let i = 0; i < 180; i++) {
+        if (logs.some(l => /§GEOM-HARDFAIL total=/.test(l))) { seeded = true; break; }
+        await sleep(2000);
+      }
+      await sleep(3000);
+
+      const c = await page.evaluate(census);
+      const hfLine = logs.find(l => /§GEOM-HARDFAIL total=/.test(l)) || '';
+      const hardFail = parseInt((hfLine.match(/total=(\d+)/) || [, '0'])[1], 10);
+      const elements = parseInt((hfLine.match(/of (\d+)/) || [, '0'])[1], 10);
+      const blobMiss = logs.filter(l => /§BLOB_MISS|§RANGE_BLOB_MISS/.test(l)).length;
+      const idLine = logs.find(l => /§DB_IDENTITY/.test(l)) || '(none)';
+      const tpe = elements > 0 ? c.tris / elements : 0;
+
+      // verdict: REAL = comfortably above the box signature. FAKE = at/below it (all-box).
+      // PARTIAL = in between, i.e. a mixed population — still a failure, still worth naming.
+      let verdict = 'FAKE';
+      if (tpe >= REAL_MIN_TPE) verdict = 'REAL';
+      else if (tpe > BOX_TRIS * 1.05) verdict = 'PARTIAL';
+
+      console.log(`§RENDER_FIDELITY building=${key} tris=${c.tris} elements=${elements} ` +
+        `trisPerElement=${tpe.toFixed(1)} blobMiss=${blobMiss} hardFail=${hardFail} verdict=${verdict}`);
+      console.log('  ' + idLine.replace(/^\S+\s/, ''));
+      if (!seeded) console.log('  ⚠ seed marker never appeared — census may be premature');
+
+      results.push({ key, verdict, tpe: +tpe.toFixed(1), tris: c.tris, elements, blobMiss, hardFail, seeded });
+
+      if (BREAK) {
+        // RED: the tripwire MUST trip, and MUST prove it caught what the old guards did not.
+        if (verdict === 'REAL') { console.log(`  ✗ RED FAIL ${key}: fault injected but verdict=REAL — tripwire did not trip`); failures++; }
+        else {
+          console.log(`  ✓ RED OK ${key}: verdict=${verdict} at ${tpe.toFixed(1)} tris/element (box signature=${BOX_TRIS})`);
+          if (hardFail === 0 && blobMiss === 0)
+            console.log(`  ✓ RED CONFIRMS §S0(c): old guards silent (hardFail=0 blobMiss=0) while 100% boxes render`);
+        }
+      } else {
+        if (verdict !== 'REAL') { console.log(`  ✗ GREEN FAIL ${key}: verdict=${verdict} at ${tpe.toFixed(1)} tris/element`); failures++; }
+        if (blobMiss > 0) { console.log(`  ✗ GREEN FAIL ${key}: blobMiss=${blobMiss}`); failures++; }
+        if (hardFail > 0) { console.log(`  ✗ GREEN FAIL ${key}: hardFail=${hardFail}`); failures++; }
+      }
+      await ctx.close();
+    }
+  } finally { await browser.close(); }
+
+  console.log('\n§RENDER_FIDELITY_SUMMARY mode=' + (BREAK ? 'RED(fault-injected)' : 'GREEN') +
+    ' fixtures=' + results.length + ' failures=' + failures);
+  console.log(JSON.stringify(results, null, 1));
+  process.exit(failures ? 1 : 0);
+})();

--- a/scripts/gen_buildings_manifest.js
+++ b/scripts/gen_buildings_manifest.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// GEOMETRY_TRUTH_CHAIN.md §S1 — generate `modeller/buildings_manifest.json`.
+//
+// NON-INVENT: every number here is COUNTed out of the actual .db files on disk. Nothing is typed
+// by hand, nothing is defaulted. Regenerate on demand; commit the JSON (text — the DB-binary ban
+// is unaffected).
+//
+// THE POINT (S0(a), 2026-07-20): a building's identity is a PAIR — a meta db plus the geometry
+// substrate it joins against — never a single file. `Hospital_ARC.db` has ZERO `component_geometries`
+// and is nonetheless 100% covered, because its meshes live in the shared `mesh.db` and the link is
+// `element_instances(guid, geometry_hash)`. A per-file `geo=` count reads that healthy pair as
+// broken; that misreading cost a full session. So the manifest records `geoCovered`/`geoMissing`
+// — the JOIN — as the authoritative figure.
+//
+// Usage: node scripts/gen_buildings_manifest.js [--check]
+//   (no args)  rewrite modeller/buildings_manifest.json
+//   --check    verify the committed manifest still matches the DBs; exit 1 on drift (CI-able)
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const MODELLER = path.join(ROOT, 'modeller');
+const OUT = path.join(MODELLER, 'buildings_manifest.json');
+
+// The residents table is the source of truth for WHICH pairs exist — parsed out of the shipped
+// loader rather than duplicated here, so the manifest can never describe a pairing the app doesn't use.
+function readResidents() {
+  const src = fs.readFileSync(path.join(MODELLER, 'str_walker_outliner.js'), 'utf8');
+  const block = src.match(/var RESIDENTS = \[([\s\S]*?)\];/);
+  if (!block) throw new Error('RESIDENTS table not found in str_walker_outliner.js — loader changed shape');
+  const rows = [];
+  for (const line of block[1].split('\n')) {
+    const key = line.match(/key:\s*'([^']+)'/);
+    const db = line.match(/[^o]db:\s*'([^']+)'/);
+    if (!key || !db) continue;
+    const geoDb = line.match(/geoDb:\s*'([^']+)'/);
+    rows.push({ key: key[1], db: db[1], geoDb: geoDb ? geoDb[1] : null });
+  }
+  if (!rows.length) throw new Error('RESIDENTS parsed to zero rows — parser is stale');
+  return rows;
+}
+
+function sqlite(file, sql) {
+  try {
+    // stderr silenced: "no such table: component_geometries" is the EXPECTED, HEALTHY reading of an
+    // ARC resident (its meshes live in the paired mesh.db). Surfacing it as an error is exactly the
+    // misread S0(a) documented. A genuinely absent file is caught by fs.existsSync above.
+    return execFileSync('sqlite3', [file, sql], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch (e) { return null; }
+}
+function count(file, sql) {
+  const r = sqlite(file, sql);
+  const n = r === null || r === '' ? null : parseInt(r, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function describe(res) {
+  const dbPath = path.join(MODELLER, res.db);
+  if (!fs.existsSync(dbPath)) return { key: res.key, db: res.db, error: 'MISSING FILE' };
+
+  const rec = {
+    key: res.key,
+    db: res.db,
+    geoDb: res.geoDb,
+    meta: count(dbPath, 'SELECT COUNT(*) FROM elements_meta;'),
+    instances: count(dbPath, 'SELECT COUNT(*) FROM element_instances;'),
+    distinctHashes: count(dbPath, 'SELECT COUNT(DISTINCT geometry_hash) FROM element_instances;'),
+    // geometry rows in the meta db ITSELF — usually 0 for ARC residents, and that is HEALTHY.
+    // Recorded only so a reader can see the split; it is NOT the coverage figure.
+    geoRowsInMetaDb: count(dbPath, 'SELECT COUNT(*) FROM component_geometries;') || 0
+  };
+
+  // THE authoritative number: how many element instances actually resolve a mesh, across the pair.
+  const geoPath = res.geoDb ? path.join(MODELLER, res.geoDb) : dbPath;
+  if (!fs.existsSync(geoPath)) {
+    rec.geoSubstrate = res.geoDb;
+    rec.geoSubstrateMissing = true;
+    rec.geoCovered = 0;
+    rec.geoMissing = rec.instances;
+  } else {
+    rec.geoSubstrate = res.geoDb || res.db;
+    rec.geoCovered = count(dbPath,
+      `ATTACH '${geoPath}' AS m; SELECT COUNT(*) FROM element_instances i ` +
+      `WHERE EXISTS(SELECT 1 FROM m.component_geometries g WHERE g.geometry_hash = i.geometry_hash);`);
+    rec.geoMissing = (rec.instances != null && rec.geoCovered != null) ? rec.instances - rec.geoCovered : null;
+  }
+  rec.coveragePct = (rec.instances > 0 && rec.geoCovered != null)
+    ? +(100 * rec.geoCovered / rec.instances).toFixed(2) : null;
+  return rec;
+}
+
+function build() {
+  const residents = readResidents();
+  const buildings = residents.map(describe);
+  const substrates = {};
+  for (const r of residents) {
+    if (!r.geoDb || substrates[r.geoDb]) continue;
+    const p = path.join(MODELLER, r.geoDb);
+    substrates[r.geoDb] = fs.existsSync(p)
+      ? { geometries: count(p, 'SELECT COUNT(*) FROM component_geometries;') }
+      : { missing: true };
+  }
+  return {
+    _spec: 'GEOMETRY_TRUTH_CHAIN.md §S1 — generated, never hand-edited. Regenerate: node scripts/gen_buildings_manifest.js',
+    _note: 'geoCovered/geoMissing are the JOIN across the (meta db, geo substrate) PAIR. geoRowsInMetaDb=0 is HEALTHY for ARC residents.',
+    generated: new Date().toISOString().slice(0, 10),
+    substrates,
+    buildings
+  };
+}
+
+// Compare ignoring the generated date — a date-only diff is not drift.
+function stripDate(m) { const c = JSON.parse(JSON.stringify(m)); delete c.generated; return c; }
+
+const manifest = build();
+const check = process.argv.includes('--check');
+
+if (check) {
+  if (!fs.existsSync(OUT)) { console.error('§MANIFEST_CHECK FAIL — no manifest at ' + OUT); process.exit(1); }
+  const committed = JSON.parse(fs.readFileSync(OUT, 'utf8'));
+  const drift = JSON.stringify(stripDate(committed)) !== JSON.stringify(stripDate(manifest));
+  for (const b of manifest.buildings) {
+    console.log(`§MANIFEST building=${b.key} db=${b.db} geoDb=${b.geoDb} meta=${b.meta} ` +
+      `inst=${b.instances} covered=${b.geoCovered} missing=${b.geoMissing} cov=${b.coveragePct}%`);
+  }
+  console.log('§MANIFEST_CHECK ' + (drift ? 'DRIFT — committed manifest no longer matches the DBs' : 'match'));
+  process.exit(drift ? 1 : 0);
+}
+
+fs.writeFileSync(OUT, JSON.stringify(manifest, null, 2) + '\n');
+for (const b of manifest.buildings) {
+  console.log(`§MANIFEST building=${b.key} db=${b.db} geoDb=${b.geoDb} meta=${b.meta} ` +
+    `inst=${b.instances} covered=${b.geoCovered} missing=${b.geoMissing} cov=${b.coveragePct}%`);
+}
+console.log('§MANIFEST_WRITE ' + OUT + ' buildings=' + manifest.buildings.length);


### PR DESCRIPTION
Implements `GEOMETRY_TRUTH_CHAIN.md` §S1–S3 (bim-compiler `6f4be35e7`). The app now **proves** it renders real data instead of trusting that it does.

## The blind spot this closes

On 2026-07-01 the Modeller rendered 3,225/3,225 SampleCastle elements as 12-triangle boxes — 100% fake — and **all 32 Modeller witnesses stayed green**. Every one asserts something a box satisfies identically to a real mesh (counts, bbox centres/extents, pixel-diffs). The only detector that fired was a human eye on a screenshot.

That blind spot is **still live today**, and this PR demonstrates it. Fault-injected (loader's geo substrate 404s, taking its documented meta-only fallback):

| building | tris | elements | tris/element | §GEOM-HARDFAIL | §BLOB_MISS |
|---|---|---|---|---|---|
| Duplex | 2,354 | 196 | **12.0** | **0** | **0** |
| SampleCastle | 38,702 | 3,225 | **12.0** | **0** | **0** |

Both pre-existing guards report *all clean* while 100% of elements are box proxies — they only detect per-element breaks *inside* a substrate that loaded, never whole-substrate loss. SampleCastle's 38,702 vs the predicted 3,225 × 12 = 38,700 reproduces the original scar to within 2 triangles.

## What's added

- **S1 `scripts/gen_buildings_manifest.js` → `modeller/buildings_manifest.json`** — generated, never hand-typed; parses the shipped RESIDENTS table so it can't describe a pairing the app doesn't use. `--check` exits 1 on drift.
- **S2 `§DB_IDENTITY`** in `str_walker_outliner.js` — one line per open declaring the resolved pair. Log-only, never blocks a load.
- **S3 `modeller/tests/witness_render_fidelity.js`** — triangle census, GREEN and RED.

## A correction worth reading

The spec's own backstory claimed `Hospital_ARC.db` has "ZERO geometry, only boxes CAN render from it." **That is false.** It reads the ARC db in isolation and misses the shared `mesh.db` pairing — Hospital actually resolves 14,409/14,409. All 8 residents measure 100% coverage.

A building's identity is a **pair** (meta db + geo substrate, joined on `element_instances.geometry_hash`), never a single file. A bare per-file `geo=` count reads a healthy pair as broken — that misread cost a full session. So the manifest and `§DB_IDENTITY` record the **join**, and the spec's original red case (assert `Hospital_ARC geo=0`) was retargeted: it would have hard-coded the very blindness that caused the loss.

## Verification

GREEN 4/4 REAL, exit 0, all `manifest=match`, zero warns:

| building | tris | elements | tris/element |
|---|---|---|---|
| SampleHouse | 24,564 | 38 | 646.4 |
| Duplex | 24,852 | 196 | 126.8 |
| SampleCastle | 237,504 | 3,225 | 73.6 |
| HHS | 335,240 | 1,077 | 311.3 |

Baselines measured, never invented: box = 12.0 exactly, lowest real = 73.6, threshold 24 (~3× margin both sides). **No DB file was touched** — the red case injects at the loader seam, honouring the 2026-07-19 directive.

`witness_e2e_lod_match.js` A3/A4 fail on this branch **and byte-identically on untouched `origin/main`** — pre-existing, not a regression. Triangles match exactly; only vert counts diverge → witness GIGO on the vert expectation. Flagged for its own lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)