### PR TITLE
perf(time-machine): Phase 2 — delta skip under Shadow/Alt-G + BatchedMesh skip

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v822';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v823';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -892,6 +892,11 @@
   // Above this cursor jump, skipping stops paying (too many meshes have events anyway) and the
   // full path is cheaper. 7 days: a playback tick is minutes, a drag-scrub is months.
   var _INCR_MAX_SPAN_MS = 7 * 24 * 3600 * 1000;
+  // §PERF_INCR Phase 2: last tick's app._shadowOn, to detect the OFF<->ON edge. Batched/Instanced
+  // castShadow/receiveShadow flags are only (re)computed on ticks that aren't skipped, so a mesh
+  // skipped across a shadow toggle would keep a stale flag. Force one full pass on the edge tick
+  // only -- not for the whole time shadows stay on, which is what the old blanket gate did.
+  var _lastShadowOn = null;
 
   // Staleness signature — keyed ONLY on the element-mesh set, via A._metaGen (bumped by
   // streaming/city at the four sites that mutate _batchMeta/_instanceMeta). O(1).
@@ -1057,19 +1062,26 @@
     // §S260d: All particle effects removed
 
     // §PERF_INCR: decide delta vs full for THIS tick.
-    // Full is required (not merely allowed) when: index missing/stale, no previous cursor, the
-    // shadow pass needs the complete _placedMeshes list, or the jump is large enough that skipping
-    // saves nothing. A long scrub legitimately changes tens of thousands of elements -- forcing
-    // delta there would be SLOWER than the full path, which is the failure this guard prevents.
+    // Full is required (not merely allowed) when: index missing/stale, no previous cursor, shadows
+    // just toggled (see _lastShadowOn above), or the jump is large enough that skipping saves
+    // nothing. A long scrub legitimately changes tens of thousands of elements -- forcing delta
+    // there would be SLOWER than the full path, which is the failure this guard prevents.
+    // §PERF_INCR Phase 2: shadows staying ON/OFF steady-state does NOT need a blanket full-mode
+    // gate -- _placedMeshes/_frontierCentroids/_shadowCasters are built in the single-mesh branch
+    // below, which is unconditional (never skipped) regardless of _incrOK. Only the EDGE tick
+    // (shadow flag flips) needs a forced full pass, to (re)seed Batched/Instanced shadow flags.
     var _sig = _tmSceneSig(app);
     if (!_evMesh || _sig !== _evSig) _tmBuildEventIndex(app, lingerMs);
     var _dLo = Math.min(_prevCursor, cursorMs), _dHi = Math.max(_prevCursor, cursorMs);
-    var _incrOK = !!_evMesh && _prevCursor != null && !app._shadowOn &&
+    var _shadowNow = !!app._shadowOn;
+    var _shadowJustToggled = (_lastShadowOn !== null && _lastShadowOn !== _shadowNow);
+    var _incrOK = !!_evMesh && _prevCursor != null && !_shadowJustToggled &&
                   (_dHi - _dLo) <= _INCR_MAX_SPAN_MS && _incrPrimed;
     // W-INCR-EQUIV hook: the verification harness sets window.__forceFull to re-render the SAME
     // cursor via the full path, so the two results can be diffed. Test-only; no production effect.
     if (window.__forceFull) { _incrOK = false; window.__forceFull = false; }
     if (_incrOK) _incrStats.delta++; else _incrStats.full++;
+    _lastShadowOn = _shadowNow;
 
     var _perfT0 = performance.now(), _perfObjs = 0, _perfSkipped = 0;
     app.scene.traverse(function(obj) {
@@ -1142,6 +1154,10 @@
 
       // ── BatchedMesh (per-slot GUIDs in _batchMeta) — S260 ──
       if (obj.isBatchedMesh && app._batchMeta && app._batchMeta[obj.id]) {
+        // §PERF_INCR Phase 2: same event index already indexes _batchMeta guids (see
+        // _tmBuildEventIndex) but this branch never consulted it -- LTU's BatchedMesh-consolidated
+        // geometry (8 draw calls) got ZERO benefit from Phase 1, only InstancedMesh did.
+        if (_incrOK && !_tmHasEventIn(_evMesh[obj.id], _dLo, _dHi)) { _perfSkipped++; return; }
         var bmetas = app._batchMeta[obj.id];
         var anyVis = false;
         var _bmHasFrontier = false;
@@ -4580,7 +4596,7 @@
 
   // S265 Phase 3: Expose TM state for share URL
   window.tmGetState = function() {
-    return { active: _active, cursor: _cursor };
+    return { active: _active, cursor: _cursor, projectStart: _projectStart, projectEnd: _projectEnd };
   };
 
   // §PHASE_LENS exposure: let other modules (Find panel Phase axis) lazily
@@ -4602,4 +4618,42 @@
   // the incremental (delta) path deterministically without the cinema UI. Diagnostic only.
   window.__tmStep = function (dms) { if (!_active) return null; _gspRoll++;
     renderAtTime(Math.min(_projectEnd, _cursor + (dms || 3600000))); return window.__tmTrav; };
+  // W-INCR-EQUIV test hook: jump to an ABSOLUTE cursor (clamped to project bounds), for the
+  // forward/backward/random-scrub/jump-to-start-end sweep TM_INCREMENTAL_RENDER_PERF.md §5 requires.
+  // Diagnostic only, mirrors __tmStep's no-op-if-inactive contract.
+  window.__tmSetCursor = function (absMs) {
+    if (!_active) return null;
+    renderAtTime(Math.max(_projectStart, Math.min(_projectEnd, absMs)));
+    return window.__tmTrav;
+  };
+  // W-INCR-EQUIV test hook: snapshot every visible guid + its slot visibility, for diffing the
+  // delta path against the window.__forceFull full-path re-render at the same cursor.
+  window.__tmSnapshotVisible = function () {
+    if (!_active) return null;
+    var app = A();
+    var out = { mesh: [], batched: {}, instanced: {} };
+    app.scene.traverse(function (obj) {
+      if (!obj.userData) return;
+      if (obj.userData.guid) { if (obj.visible) out.mesh.push(obj.userData.guid); return; }
+      if (obj.isBatchedMesh && app._batchMeta && app._batchMeta[obj.id]) {
+        var bmetas = app._batchMeta[obj.id], vis = {};
+        for (var bi = 0; bi < bmetas.length; bi++) {
+          vis[bmetas[bi].guid] = !!(obj.getVisibleAt ? obj.getVisibleAt(bmetas[bi].slotId) : obj.visible);
+        }
+        out.batched[obj.id] = vis;
+        return;
+      }
+      if (obj.isInstancedMesh && app._instanceMeta && app._instanceMeta[obj.id]) {
+        var metas = app._instanceMeta[obj.id], ivis = {};
+        var _snapM4 = window.__tmSnapshotVisible._m4 || (window.__tmSnapshotVisible._m4 = new THREE.Matrix4());
+        for (var mi = 0; mi < metas.length; mi++) {
+          obj.getMatrixAt(mi, _snapM4);
+          ivis[metas[mi].guid] = !(_snapM4.elements[0] === 0 && _snapM4.elements[5] === 0 && _snapM4.elements[10] === 0);
+        }
+        out.instanced[obj.id] = ivis;
+      }
+    });
+    out.mesh.sort();
+    return out;
+  };
 })();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -1014,7 +1014,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=527')
+  navigator.serviceWorker.register('sw.js?v=528')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }

--- a/witness_incr_shadow_equiv.js
+++ b/witness_incr_shadow_equiv.js
@@ -1,0 +1,144 @@
+// WITNESS — W-INCR-EQUIV (TM_INCREMENTAL_RENDER_PERF.md §5), Phase 2 scope.
+// ISSUE IT PROVES/DISPROVES: Phase 2 removes the blanket `!app._shadowOn` gate on the delta-skip
+// path and adds a skip check to the BatchedMesh branch (previously only InstancedMesh had one).
+// This is a pure perf refactor — the acceptance bar is ZERO visible-guid/slot-visibility mismatch
+// between the delta path and a forced full-path re-render at the SAME cursor, WITH shadows on.
+//   PASS = for each building, across forward playback, backward playback, random scrubs, and
+//   jump-to-start/end, every cursor tested reports §INCR_VERIFY mismatch=0.
+//   FAIL = any mismatch>0 — the delta path diverged from ground truth and must block the change.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8410;
+const BUILDINGS = (process.env.BLDS || 'Hospital,LTU').split(',');
+
+function diffSnapshots(a, b) {
+  var mism = 0, details = [];
+  function cmpMesh() {
+    var sa = new Set(a.mesh), sb = new Set(b.mesh);
+    sa.forEach(function (g) { if (!sb.has(g)) { mism++; details.push('mesh- ' + g); } });
+    sb.forEach(function (g) { if (!sa.has(g)) { mism++; details.push('mesh+ ' + g); } });
+  }
+  function cmpSlotMap(kind) {
+    var ma = a[kind], mb = b[kind];
+    var ids = new Set(Object.keys(ma).concat(Object.keys(mb)));
+    ids.forEach(function (id) {
+      var va = ma[id] || {}, vb = mb[id] || {};
+      var guids = new Set(Object.keys(va).concat(Object.keys(vb)));
+      guids.forEach(function (g) {
+        if (!!va[g] !== !!vb[g]) { mism++; details.push(kind + ' ' + id + ':' + g + ' ' + va[g] + '!=' + vb[g]); }
+      });
+    });
+  }
+  cmpMesh();
+  cmpSlotMap('batched');
+  cmpSlotMap('instanced');
+  return { mism: mism, details: details.slice(0, 10) };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    try {
+
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls,
+      { timeout: 120000 });
+    await new Promise(r => setTimeout(r, 8000)); // let streaming settle
+
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 180000, polling: 2000 });
+
+    // Turn shadows ON (off -> grass) BEFORE activating TM, matching the real user path (Shadow/Alt-G).
+    await page.evaluate(() => { window.APP.toggleShadow(); });
+
+    // Activate TM and wait for the timeline to be ready.
+    await page.evaluate(() => { window.toggleTimeMachine(); });
+    const ready = await page.waitForFunction(() => {
+      const st = window.tmGetState && window.tmGetState();
+      return st && st.active && st.projectEnd > st.projectStart;
+    }, { timeout: 90000 }).then(() => true).catch(() => false);
+
+    if (!ready) {
+      console.log(`${BLD}: FAIL — TM never became active/ready`);
+      allPass = false;
+      await page.close();
+      continue;
+    }
+
+    const state0 = await page.evaluate(() => window.tmGetState());
+    const shadowOn = await page.evaluate(() => !!window.APP._shadowOn);
+    console.log(`${BLD}: projectStart=${state0.projectStart} projectEnd=${state0.projectEnd} shadowOn=${shadowOn}`);
+
+    // Prime: one full pass at project start (also seeds _incrPrimed for later delta ticks).
+    await page.evaluate((ps) => window.__tmSetCursor(ps), state0.projectStart);
+
+    const span = state0.projectEnd - state0.projectStart;
+    const tick = Math.max(60000, Math.round(span / 2000)); // small step relative to project length
+
+    // Build the cursor sweep: forward playback, backward playback, random scrubs, jump-to-start/end.
+    // Kept small (representative, not exhaustive) — each entry costs 2 full traverses + 2 snapshots
+    // over the whole scene under puppeteer/swiftshader, which is expensive at Hospital/LTU scale.
+    const cursors = [];
+    let c = state0.projectStart + tick;
+    for (let i = 0; i < 6; i++) { cursors.push(c); c += tick; if (c > state0.projectEnd) break; }
+    let cb = state0.projectEnd - tick;
+    for (let i = 0; i < 6; i++) { cursors.push(cb); cb -= tick; if (cb < state0.projectStart) break; }
+    for (let i = 0; i < 5; i++) cursors.push(state0.projectStart + Math.random() * span);
+    cursors.push(state0.projectStart, state0.projectEnd);
+
+    let totalMism = 0, deltaCount = 0, fullCount = 0, crashed = false;
+    for (const cur of cursors) {
+      try {
+        const r = await page.evaluate(async (cur) => {
+          const snapA = window.__tmSetCursor(cur);
+          const visA = window.__tmSnapshotVisible();
+          window.__forceFull = true;
+          const snapB = window.__tmSetCursor(cur);
+          const visB = window.__tmSnapshotVisible();
+          return { modeA: snapA && snapA.mode, modeB: snapB && snapB.mode, visA, visB };
+        }, cur);
+        const d = diffSnapshots(r.visA, r.visB);
+        totalMism += d.mism;
+        if (r.modeA === 'delta') deltaCount++; else fullCount++;
+        console.log(`§INCR_VERIFY cursor=${Math.round(cur)} mismatch=${d.mism} modeA=${r.modeA}` +
+          (d.mism ? ' SAMPLE=' + JSON.stringify(d.details) : ''));
+      } catch (e) {
+        console.log(`${BLD}: CRASH at cursor=${Math.round(cur)}: ${e.message}`);
+        crashed = true;
+        break;
+      }
+    }
+
+    console.log(`${BLD}: TOTAL mismatch=${totalMism}  cursorsTested=${cursors.length}  deltaMode=${deltaCount} fullMode=${fullCount}`);
+    if (totalMism > 0 || crashed) allPass = false;
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log(`${BLD}: PAGE ERRORS:\n` + errs.join('\n')); allPass = false; }
+
+    } catch (e) {
+      console.log(`${BLD}: SETUP CRASH: ${e.message}`);
+      allPass = false;
+    }
+    try { await page.close(); } catch (e) {}
+  }
+
+  await browser.close();
+  console.log('\n' + (allPass ? 'W-INCR-EQUIV PASS' : 'W-INCR-EQUIV FAIL'));
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_incr_shadow_perf.js
+++ b/witness_incr_shadow_perf.js
@@ -1,0 +1,89 @@
+// WITNESS — W-INCR-PERF (TM_INCREMENTAL_RENDER_PERF.md §5), Phase 2 scope.
+// ISSUE IT PROVES/DISPROVES: does removing the blanket !app._shadowOn gate on _incrOK, plus wiring
+// the delta skip into the BatchedMesh branch, actually cut §PERF_TRAVERSE ms with shadows ON?
+//   Run once against a BEFORE server (origin/main, pre-Phase-2) and once against an AFTER server
+//   (this session's worktree) on the SAME PORT env var swap, same building, same tick sequence.
+//   PASS/FAIL is judged by comparing the two runs' printed mean/median/p90, not by this script alone.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8410;
+const BLD = process.env.BLD || 'LTU_AHouse';
+const N = parseInt(process.env.N || '40', 10);
+const TICK_MS = parseInt(process.env.TICK_MS || '3600000', 10); // 1 simulated hour/tick, matches __tmStep default
+
+function pct(arr, p) {
+  const s = arr.slice().sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.floor(p * s.length));
+  return s[idx];
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  try {
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    console.log(`PORT=${PORT} BLD=${BLD} N=${N} TICK_MS=${TICK_MS}`);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls,
+      { timeout: 120000 });
+    await new Promise(r => setTimeout(r, 8000));
+
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 180000, polling: 2000 });
+
+    await page.evaluate(() => { window.APP.toggleShadow(); }); // off -> grass (shadows ON)
+    await page.evaluate(() => { window.toggleTimeMachine(); });
+    const ready = await page.waitForFunction(() => {
+      const st = window.tmGetState && window.tmGetState();
+      return st && st.active && st.projectEnd > st.projectStart;
+    }, { timeout: 120000 }).then(() => true).catch(() => false);
+
+    if (!ready) { console.log(`${BLD}: FAIL — TM never became active/ready`); process.exit(1); }
+
+    const state0 = await page.evaluate(() => window.tmGetState());
+    const shadowOn = await page.evaluate(() => !!window.APP._shadowOn);
+    console.log(`${BLD}: projectStart=${state0.projectStart} projectEnd=${state0.projectEnd} shadowOn=${shadowOn}`);
+
+    // Jump near the middle of the timeline (plenty of placed + some frontier), then step forward N times.
+    const mid = state0.projectStart + (state0.projectEnd - state0.projectStart) * 0.4;
+    await page.evaluate((m) => {
+      // No __tmSetCursor on the BEFORE server (pre-Phase-2) — use __tmStep's own cursor advance instead.
+      return window.__tmStep ? window.__tmStep(m) : null;
+    }, mid - state0.projectStart);
+
+    const samples = [];
+    for (let i = 0; i < N; i++) {
+      const trav = await page.evaluate((dms) => window.__tmStep(dms), TICK_MS);
+      if (trav) samples.push(trav);
+    }
+
+    const ms = samples.map(s => s.ms);
+    const deltaN = samples.filter(s => s.mode === 'delta').length;
+    const fullN = samples.filter(s => s.mode === 'full').length;
+    const mean = ms.reduce((a, b) => a + b, 0) / (ms.length || 1);
+    console.log(`§PERF_TRAVERSE_SUMMARY n=${ms.length} mean=${mean.toFixed(2)}ms median=${pct(ms, 0.5).toFixed(2)}ms ` +
+      `p90=${pct(ms, 0.9).toFixed(2)}ms min=${Math.min(...ms).toFixed(2)} max=${Math.max(...ms).toFixed(2)} ` +
+      `deltaMode=${deltaN} fullMode=${fullN}`);
+    console.log('RAW=' + JSON.stringify(samples));
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) console.log('PAGE ERRORS:\n' + errs.join('\n'));
+  } catch (e) {
+    console.log('CRASH: ' + e.message);
+    process.exitCode = 1;
+  } finally {
+    try { await page.close(); } catch (e) {}
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- Removes the blanket `!app._shadowOn` gate on the delta-skip path — replaced with a toggle-EDGE-only force-full (`_lastShadowOn`), so delta mode runs the rest of the time shadows stay on.
- Wires the existing event index into the BatchedMesh branch (only InstancedMesh had the skip before) — LTU's BatchedMesh-consolidated geometry (8 draw calls) got zero benefit from Phase 1 until now.
- Two new test-only hooks: `window.__tmSetCursor`, `window.__tmSnapshotVisible` (mirror the existing `__tmStep`/`__tmTrav` pattern) for driving the W-INCR-EQUIV sweep.
- `sw.js` CACHE_VERSION v822→v823 (time_machine.js/viewer.html are precached).

Follows `TM_INCREMENTAL_RENDER_PERF.md` Phase 2 scope exactly.

## Test plan
- [x] W-INCR-EQUIV: 19 cursors each on Hospital + LTU_AHouse — forward/backward playback, random scrubs, jump-to-start/end, forced full-path comparison — WITH shadows on. `mismatch=0` on both.
- [x] `node --check` on all three edited files.
- [ ] Real-hardware perf numbers (mean/median/p90 traverse ms before/after) — headless swiftshader witness was unreliable under this session's heavy machine load (14+ load average) and LTU_AHouse's local test copy lacks the meta/geo split newer large buildings use, so absolute ms weren't captured this session. Equivalence is the blocking gate per TM_INCREMENTAL_RENDER_PERF.md §5 and it's clean; perf numbers to follow from real-hardware profiling (`window.__tmTrav`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)