### PR TITLE
feat(schedule): PMXML/XER writers — close the P6 write-back gap

### DIFF
--- a/erp/tests/xer_pmxml_writer_witness.js
+++ b/erp/tests/xer_pmxml_writer_witness.js
@@ -1,0 +1,161 @@
+// xer_pmxml_writer_witness.js — W-XER-ROUNDTRIP / W-PMXML-ROUNDTRIP (prompts/XER_PMXML_WRITER_LANE.md §4).
+//
+// toPMXML/toXER (foreign_schedule.js) are the write-side counterpart to parsePMXML/parseXER. The bar is
+// a ROUND TRIP: take an authored schedule, run it through ScheduleAuthor.wbsTree/listDependencies (the
+// SAME input exportMSProject already reads), serialize with the new writer, RE-PARSE the writer's own
+// output with our OWN existing reader, and diff the re-parsed rows against the true SOURCE — the file
+// as it existed before any of our code touched it. mismatch=0 or the writer is wrong, not the witness.
+//
+// Two fixtures, per §4:
+//   XER   — the GENUINELY P6-EMITTED sample.xer already fetched/verified by real_xer_witness.js (same
+//           URL+sha, cached at the same path so this witness doesn't re-download). Real P6 export.
+//   PMXML — no real-P6-emitted PMXML sample exists in this repo or is cited anywhere (checked). Falls
+//           back to tests/fixtures/Hospital_GW_Programme.xml, the repo's own committed demo fixture
+//           (tests/gen_foreign_schedule.js) — SYNTHETIC dates/durations, but a real forward/backward CPM
+//           pass and real Hospital element classes. Flagged explicitly, not claimed as real-P6 proof.
+//
+// Known, PRE-EXISTING (not-this-writer's) lossy transforms excluded from the mismatch tally, logged
+// separately as "explained" diffs: WBS code (toScheduleData never stores it — dropped before the writer
+// ever sees the tree), status_code (toScheduleData maps the raw P6 code, e.g. TK_NotStart, to a display
+// string, e.g. "Not Started" — the writer cannot recover a raw code it was never given).
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var https = require('https');
+var crypto = require('crypto');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, '..', '..', 'viewer');
+
+var SRC_URL = 'https://raw.githubusercontent.com/ASHspace/PrimeveraXEREditor/main/src/test/java/resources/sample.xer';
+var SRC_SHA = '68ce5f0bb2b534d5ba192e3ad8241025d74ae45e94209f11731d42d32f18f82b';
+var REAL_XER = process.env.REAL_XER || path.join(require('os').tmpdir(), 'real_p6_sample.xer');
+var PMXML_FIXTURE = path.join(__dirname, '..', '..', 'tests', 'fixtures', 'Hospital_GW_Programme.xml');
+
+var FS_ = require(path.join(VIEWER, 'foreign_schedule.js'));
+var SA = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-WRITER PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-WRITER FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function sha(buf) { return crypto.createHash('sha256').update(buf).digest('hex'); }
+function stripNS(id) { return id == null ? id : String(id).replace(/^[AW]:/, ''); }
+function feq(a, b, eps) { eps = eps || 1e-6; if (a == null || b == null) return a == b; return Math.abs(parseFloat(a) - parseFloat(b)) < eps; }
+
+function ensureFile() {
+  return new Promise(function (resolve) {
+    if (fs.existsSync(REAL_XER)) return resolve(true);
+    var f = fs.createWriteStream(REAL_XER);
+    // family:4 — this sandbox's outbound IPv6 route is unreachable (ENETUNREACH); force IPv4 so the
+    // fetch doesn't spuriously SKIP a witness that's actually available over the network.
+    var u = new URL(SRC_URL);
+    var req = https.get({ hostname: u.hostname, path: u.pathname + u.search, family: 4 }, function (res) {
+      if (res.statusCode !== 200) { res.resume(); fs.unlink(REAL_XER, function () {}); return resolve(false); }
+      res.pipe(f); f.on('finish', function () { f.close(function () { resolve(true); }); });
+    });
+    req.on('error', function () { try { fs.unlinkSync(REAL_XER); } catch (e) {} resolve(false); });
+    req.setTimeout(8000, function () { req.destroy(); resolve(false); });
+  });
+}
+
+// ── shared round-trip runner: origParsed (a reader's own neutral parse of the SOURCE file) → adopt →
+// wbsTree/listDependencies (writer's real input contract) → write → re-parse own output → diff vs SOURCE.
+function roundTrip(label, origParsed, writeFn, reparseFn) {
+  var data = FS_.toScheduleData(origParsed);
+  var db = new SQL.Database();
+  FS_.adoptIntoDb(db, data);
+  var schedId = data.schedules[0].id;
+  var tree = SA.wbsTree(db, schedId);
+  var deps = SA.listDependencies(db, schedId);
+  var out = writeFn(tree, deps, { hpd: origParsed.project.hpd, projectId: origParsed.project.id, projectName: origParsed.project.name });
+  var reparsed = reparseFn(out);
+
+  var mismatch = 0, explained = 0, details = [];
+
+  // WBS hierarchy: id (stripped) + name + parent (stripped) must match the source exactly.
+  var origWbsById = {}; origParsed.wbs.forEach(function (w) { origWbsById[String(w.id)] = w; });
+  reparsed.wbs.forEach(function (w) {
+    var oid = stripNS(w.id), orig = origWbsById[oid];
+    if (!orig) { mismatch++; details.push('WBS ' + oid + ' missing from source'); return; }
+    if (String(w.name) !== String(orig.name)) { mismatch++; details.push('WBS ' + oid + ' name "' + w.name + '" != "' + orig.name + '"'); }
+    var wParent = stripNS(w.parent), oParent = (orig.parent != null ? String(orig.parent) : null);
+    if ((wParent || null) !== (oParent || null)) { mismatch++; details.push('WBS ' + oid + ' parent "' + wParent + '" != "' + oParent + '"'); }
+    // code: NOT compared — toScheduleData never stores WBS code, so the writer never has it (explained, §5).
+    explained++;
+  });
+  check(label + '-wbs-count', reparsed.wbs.length === origParsed.wbs.length, reparsed.wbs.length + '/' + origParsed.wbs.length);
+
+  // Activities: name, start, finish, durDays, totalFloatDays, freeFloatDays, critical must match source.
+  var origActById = {}; origParsed.activities.forEach(function (a) { origActById[String(a.id)] = a; });
+  reparsed.activities.forEach(function (a) {
+    var oid = stripNS(a.id), orig = origActById[oid];
+    if (!orig) { mismatch++; details.push('Activity ' + oid + ' missing from source'); return; }
+    if (String(a.name).trim() !== String(orig.name).trim()) { mismatch++; details.push('Activity ' + oid + ' name "' + a.name + '" != "' + orig.name + '"'); }
+    if (String(a.start) !== String(orig.start)) { mismatch++; details.push('Activity ' + oid + ' start ' + a.start + ' != ' + orig.start); }
+    if (String(a.finish) !== String(orig.finish)) { mismatch++; details.push('Activity ' + oid + ' finish ' + a.finish + ' != ' + orig.finish); }
+    if (!feq(a.durDays, orig.durDays)) { mismatch++; details.push('Activity ' + oid + ' durDays ' + a.durDays + ' != ' + orig.durDays); }
+    if (!feq(a.totalFloatDays, orig.totalFloatDays)) { mismatch++; details.push('Activity ' + oid + ' totalFloatDays ' + a.totalFloatDays + ' != ' + orig.totalFloatDays); }
+    if (!feq(a.freeFloatDays, orig.freeFloatDays)) { mismatch++; details.push('Activity ' + oid + ' freeFloatDays ' + a.freeFloatDays + ' != ' + orig.freeFloatDays); }
+    if (!!a.critical !== !!orig.critical) { mismatch++; details.push('Activity ' + oid + ' critical ' + a.critical + ' != ' + orig.critical); }
+    // status: NOT compared — toScheduleData maps the raw P6 status code to a display string before the
+    // writer ever sees it (e.g. TK_NotStart -> "Not Started"); the raw code is unrecoverable (explained, §5).
+    explained++;
+  });
+  check(label + '-activity-count', reparsed.activities.length === origParsed.activities.length, reparsed.activities.length + '/' + origParsed.activities.length);
+
+  // Relationships: (predId,succId) stripped, type, lagDays must match source. Match by pred+succ pair
+  // (P6 pred/succ pairs are unique per network — no duplicate edges in either fixture).
+  var origRelByPair = {};
+  origParsed.relationships.forEach(function (r) { origRelByPair[r.pred + '>' + r.succ] = r; });
+  reparsed.relationships.forEach(function (r) {
+    var pred = stripNS(r.pred), succ = stripNS(r.succ), key = pred + '>' + succ;
+    var orig = origRelByPair[key];
+    if (!orig) { mismatch++; details.push('Relationship ' + key + ' missing from source'); return; }
+    if (r.type !== orig.type) { mismatch++; details.push('Relationship ' + key + ' type ' + r.type + ' != ' + orig.type); }
+    if (!feq(r.lagDays, orig.lagDays)) { mismatch++; details.push('Relationship ' + key + ' lagDays ' + r.lagDays + ' != ' + orig.lagDays); }
+  });
+  check(label + '-relationship-count', reparsed.relationships.length === origParsed.relationships.length, reparsed.relationships.length + '/' + origParsed.relationships.length);
+
+  if (mismatch) details.slice(0, 20).forEach(function (d) { console.log('  ' + label + ' MISMATCH: ' + d); });
+  return { mismatch: mismatch, explained: explained, out: out };
+}
+
+var SQL;
+(async function () {
+  SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+
+  // ── W-XER-ROUNDTRIP — real P6-emitted sample.xer ──────────────────────────────────────────────────
+  var xerOk = await ensureFile();
+  if (!xerOk) {
+    console.log('§XER_ROUNDTRIP SKIP real .xer unavailable (no network + no local $REAL_XER) — cited: ' + SRC_URL);
+  } else {
+    var xerTxt = fs.readFileSync(REAL_XER, 'utf8');
+    var gotSha = sha(Buffer.from(fs.readFileSync(REAL_XER)));
+    check('xer-provenance-sha', gotSha === SRC_SHA, 'sha256 ' + gotSha.slice(0, 16) + '… matches the cited real P6 export');
+    var origXer = FS_.parseXER(xerTxt);
+    var rXer = roundTrip('xer', origXer, FS_.toXER, FS_.parseXER);
+    console.log('§XER_ROUNDTRIP mismatch=' + rXer.mismatch + ' explained=' + rXer.explained +
+      ' (source=REAL P6 sample.xer, ' + origXer.wbs.length + ' wbs / ' + origXer.activities.length +
+      ' activities / ' + origXer.relationships.length + ' relationships)');
+  }
+
+  // ── W-PMXML-ROUNDTRIP — repo's committed demo fixture (SYNTHETIC dates, NOT a real P6 export) ──────
+  if (!fs.existsSync(PMXML_FIXTURE)) {
+    console.log('§PMXML_ROUNDTRIP SKIP fixture not found: ' + PMXML_FIXTURE + ' (run node tests/gen_foreign_schedule.js)');
+  } else {
+    console.log('§PMXML_ROUNDTRIP_SOURCE fixture=' + PMXML_FIXTURE + ' — SYNTHETIC demo plan (tests/gen_foreign_schedule.js), ' +
+      'NOT a real P6-emitted file (no real-P6 PMXML sample is cited/available in this repo). Real element ' +
+      'classes + a real forward/backward CPM pass, but dates/durations are authored, not P6-exported.');
+    var pmxmlTxt = fs.readFileSync(PMXML_FIXTURE, 'utf8');
+    var origPmxml = FS_.parsePMXML(pmxmlTxt);
+    var rPmxml = roundTrip('pmxml', origPmxml, FS_.toPMXML, FS_.parsePMXML);
+    console.log('§PMXML_ROUNDTRIP mismatch=' + rPmxml.mismatch + ' explained=' + rPmxml.explained +
+      ' (source=SYNTHETIC tests/fixtures/Hospital_GW_Programme.xml, ' + origPmxml.wbs.length + ' wbs / ' +
+      origPmxml.activities.length + ' activities / ' + origPmxml.relationships.length + ' relationships)');
+  }
+
+  console.log('\n§W-WRITER SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§W-WRITER ERROR', e && e.stack || e); process.exit(1); });

--- a/viewer/foreign_schedule.js
+++ b/viewer/foreign_schedule.js
@@ -163,6 +163,157 @@
     };
   }
 
+  // ── PMXML writer (prompts/XER_PMXML_WRITER_LANE.md §3.1) — the write-side counterpart to parsePMXML.
+  // toPMXML(tree, deps, opts): SAME input contract exportMSProject already reads —
+  //   tree = ScheduleAuthor.wbsTree(db, scheduleId) forest (isSummary WBS nodes + leaf Activity nodes,
+  //          each carrying id/parent/name/start/finish/critical/totalFloat/freeFloat/durDays/status)
+  //   deps = ScheduleAuthor.listDependencies(db, scheduleId) [{predId,succId,type,lag}]
+  // The READER is the schema authority: every tag emitted here is one _tag()/parsePMXML above reads back
+  // (Id/Name/WBSObjectId/PlannedStartDate/PlannedFinishDate/PlannedDuration/TotalFloat/FreeFloat/Status,
+  // WBS ObjectId/Code/Name/ParentObjectId, Relationship PredecessorActivityId/SuccessorActivityId/Type/Lag).
+  // Ids pass through UNCHANGED (already namespaced 'W:'/'A:' by toScheduleData) — a fixed point of our
+  // own reader, not a new numbering scheme. NON-INVENT: fields the tree doesn't carry (WBS code, EPS-level
+  // activity codes, resource assignments, global calendars, baselines) are left OUT, never fabricated —
+  // see the §PMXML_WRITE_LOSSY log below.
+  var _PMXML_TYPE_NAME = { FS: 'Finish to Start', SS: 'Start to Start', FF: 'Finish to Finish', SF: 'Start to Finish' };
+  function _xmlEsc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
+  function toPMXML(tree, deps, opts) {
+    opts = opts || {};
+    var hpd = opts.hpd || 8;
+    var projectId = opts.projectId || 'EXPORT';
+    var projectName = opts.projectName || 'Exported Schedule';
+    var calendarName = opts.calendarName || 'Standard';
+
+    var wbsRows = [], actRows = [];
+    (function walk(nodes) {
+      (nodes || []).forEach(function (n) {
+        if (n.isSummary) wbsRows.push(n); else actRows.push(n);
+        if (n.children && n.children.length) walk(n.children);
+      });
+    })(tree);
+
+    var x = [];
+    x.push('<?xml version="1.0" encoding="UTF-8"?>');
+    x.push('<APIBusinessObjects xmlns="http://xmlns.oracle.com/Primavera/P6/V8.2/API/BusinessObjects">');
+    x.push('  <Project>');
+    x.push('    <Id>' + _xmlEsc(projectId) + '</Id>');
+    x.push('    <Name>' + _xmlEsc(projectName) + '</Name>');
+    x.push('    <Calendar>');
+    x.push('      <ObjectId>CAL1</ObjectId>');
+    x.push('      <Name>' + _xmlEsc(calendarName) + '</Name>');
+    x.push('      <HoursPerDay>' + hpd + '</HoursPerDay>');
+    x.push('    </Calendar>');
+    wbsRows.forEach(function (n) {
+      x.push('    <WBS>');
+      x.push('      <ObjectId>' + _xmlEsc(n.id) + '</ObjectId>');
+      x.push('      <Code>' + _xmlEsc(n.id) + '</Code>');
+      x.push('      <Name>' + _xmlEsc(n.name) + '</Name>');
+      x.push('      <ParentObjectId>' + (n.parent ? _xmlEsc(n.parent) : '') + '</ParentObjectId>');
+      x.push('    </WBS>');
+    });
+    actRows.forEach(function (n) {
+      var durHrs = (n.durDays != null ? n.durDays * hpd : '');
+      var tfHrs = (n.totalFloat != null ? parseFloat(n.totalFloat) * hpd : '');
+      var ffHrs = (n.freeFloat != null ? parseFloat(n.freeFloat) * hpd : '');
+      x.push('    <Activity>');
+      x.push('      <Id>' + _xmlEsc(n.id) + '</Id>');
+      x.push('      <Name>' + _xmlEsc(n.name) + '</Name>');
+      x.push('      <WBSObjectId>' + (n.parent ? _xmlEsc(n.parent) : '') + '</WBSObjectId>');
+      x.push('      <PlannedDuration>' + durHrs + '</PlannedDuration>');
+      x.push('      <PlannedStartDate>' + (n.start ? n.start + 'T08:00:00' : '') + '</PlannedStartDate>');
+      x.push('      <PlannedFinishDate>' + (n.finish ? n.finish + 'T17:00:00' : '') + '</PlannedFinishDate>');
+      x.push('      <TotalFloat>' + tfHrs + '</TotalFloat>');
+      if (n.freeFloat != null) x.push('      <FreeFloat>' + ffHrs + '</FreeFloat>');
+      if (n.status) x.push('      <Status>' + _xmlEsc(n.status) + '</Status>');
+      x.push('    </Activity>');
+    });
+    deps.forEach(function (d) {
+      x.push('    <Relationship>');
+      x.push('      <PredecessorActivityId>' + _xmlEsc(d.predId) + '</PredecessorActivityId>');
+      x.push('      <SuccessorActivityId>' + _xmlEsc(d.succId) + '</SuccessorActivityId>');
+      x.push('      <Type>' + (_PMXML_TYPE_NAME[d.type] || 'Finish to Start') + '</Type>');
+      x.push('      <Lag>' + ((d.lag || 0) * hpd) + '</Lag>');
+      x.push('    </Relationship>');
+    });
+    x.push('  </Project>');
+    x.push('</APIBusinessObjects>');
+
+    console.log('§PMXML_WRITE_LOSSY fields=WBS.code(synthetic=id, original code dropped upstream by ' +
+      'toScheduleData), Activity.EPS-level-activity-codes(never carried past P6 itself), ' +
+      'resource-assignments(no resource model in this schedule shape), global-calendars(single project ' +
+      'calendar only), baselines(no baseline round-trip — separate P6 import procedure) — see ' +
+      'XER_PMXML_WRITER_LANE.md §5');
+    return x.join('\n') + '\n';
+  }
+
+  // ── XER writer (prompts/XER_PMXML_WRITER_LANE.md §3.2) — the write-side counterpart to parseXER.
+  // toXER(tree, deps, opts): SAME (tree, deps) input as toPMXML above. Tab-delimited %T/%F/%R, ERMHDR
+  // first line (the reader sniffs /^\s*(ERMHDR|%T)/). Emits PROJECT/CALENDAR/PROJWBS/TASK/TASKPRED —
+  // exactly the tables parseXER's rows() reads. Relationship types via the INVERSE of REL_FROM_XER;
+  // lag via the inverse of hoursToDays (days*hpd → lag_hr_cnt), same convention as PMXML above.
+  var _XER_TYPE = {}; Object.keys(REL_FROM_XER).forEach(function (k) { _XER_TYPE[REL_FROM_XER[k]] = k; });
+  function toXER(tree, deps, opts) {
+    opts = opts || {};
+    var hpd = opts.hpd || 8;
+    var projectId = opts.projectId || 'EXPORT';
+    var projectName = opts.projectName || 'Exported Schedule';
+    var calendarName = opts.calendarName || 'Standard';
+    var TAB = '\t', L = [];
+    function row(tag, cells) { L.push([tag].concat(cells).join(TAB)); }
+
+    var wbsRows = [], actRows = [];
+    (function walk(nodes) {
+      (nodes || []).forEach(function (n) {
+        if (n.isSummary) wbsRows.push(n); else actRows.push(n);
+        if (n.children && n.children.length) walk(n.children);
+      });
+    })(tree);
+
+    L.push(['ERMHDR', '19.12', new Date().toISOString().slice(0, 10), 'Project', 'admin', 'admin', '', 'USD', projectId].join(TAB));
+
+    row('%T', ['PROJECT']);
+    row('%F', ['proj_id', 'proj_short_name', 'clndr_id']);
+    row('%R', [1, projectId, 1]);
+
+    row('%T', ['CALENDAR']);
+    row('%F', ['clndr_id', 'clndr_name', 'day_hr_cnt']);
+    row('%R', [1, calendarName, hpd]);
+
+    row('%T', ['PROJWBS']);
+    row('%F', ['wbs_id', 'proj_id', 'parent_wbs_id', 'wbs_short_name', 'wbs_name', 'proj_node_flag']);
+    wbsRows.forEach(function (n) {
+      row('%R', [n.id, 1, n.parent || '', n.id, n.name, n.parent ? 'N' : 'Y']);
+    });
+
+    row('%T', ['TASK']);
+    row('%F', ['task_id', 'proj_id', 'wbs_id', 'task_code', 'task_name', 'task_type',
+      'target_drtn_hr_cnt', 'target_start_date', 'target_end_date',
+      'total_float_hr_cnt', 'free_float_hr_cnt', 'driving_path_flag', 'status_code']);
+    actRows.forEach(function (n) {
+      row('%R', [n.id, 1, n.parent || '', n.id, n.name, 'TT_Task',
+        (n.durDays != null ? n.durDays * hpd : ''),
+        (n.start ? n.start + ' 08:00' : ''), (n.finish ? n.finish + ' 17:00' : ''),
+        (n.totalFloat != null ? parseFloat(n.totalFloat) * hpd : ''),
+        (n.freeFloat != null ? parseFloat(n.freeFloat) * hpd : ''),
+        (n.critical ? 'Y' : 'N'), (n.status || '')]);
+    });
+
+    row('%T', ['TASKPRED']);
+    row('%F', ['task_pred_id', 'task_id', 'pred_task_id', 'pred_type', 'lag_hr_cnt']);
+    deps.forEach(function (d, i) {
+      row('%R', [i + 1, d.succId, d.predId, (_XER_TYPE[d.type] || 'PR_FS'), (d.lag || 0) * hpd]);
+    });
+
+    L.push('%E');
+
+    console.log('§XER_WRITE_LOSSY fields=PROJWBS.wbs_short_name(synthetic=id, original code dropped ' +
+      'upstream by toScheduleData), TASK.rsrc/activity-codes(no resource/EPS-code model in this schedule ' +
+      'shape — P6 itself drops EPS-level codes on cross-DB import), CALENDAR(single project calendar ' +
+      'only, no global-calendar set), baselines(no BASELINE table — separate P6 import procedure) — see ' +
+      'XER_PMXML_WRITER_LANE.md §5');
+    return L.join('\n') + '\n';
+  }
+
   // ── MSPDI reader: MS Project XML (schemas.microsoft.com/project) ─────────────────────────────────
   // Differs from P6: no separate WBS objects — summary tasks ARE the WBS, hierarchy from OutlineLevel;
   // durations are ISO PT#H#M#S; TotalSlack/LinkLag are integers in TENTHS OF A MINUTE; relationship
@@ -389,7 +540,8 @@
   }
 
   var API = { parseXER: parseXER, parsePMXML: parsePMXML, parseMSPDI: parseMSPDI, parseForeign: parseForeign,
-    toScheduleData: toScheduleData, adoptIntoDb: adoptIntoDb, parseBindToken: parseBindToken, autoBind: autoBind };
+    toScheduleData: toScheduleData, adoptIntoDb: adoptIntoDb, parseBindToken: parseBindToken, autoBind: autoBind,
+    toPMXML: toPMXML, toXER: toXER };
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else (global || globalThis).ForeignSchedule = API;
 })(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -318,15 +318,22 @@
     var r;
     try {
       r = db.exec('SELECT task_id, wbs_parent, name, is_summary, schedule_start, schedule_finish, ' +
-        'is_critical, total_float FROM tasks WHERE schedule_id=? ', [scheduleId]);
+        'is_critical, total_float, free_float, schedule_duration, status FROM tasks WHERE schedule_id=? ', [scheduleId]);
     } catch (e) { return []; }
     if (!r.length || !r[0].values.length) return [];
     var nodes = {}, ids = {};
+    // §XER/PMXML writer (prompts/XER_PMXML_WRITER_LANE.md §3.3): freeFloat/durDays/status are ADDITIVE
+    // fields — already stored in the wide `tasks` table by adoptIntoDb, just not read here before this.
+    // No schema change, no new columns; existing callers never destructured these and are unaffected.
     r[0].values.forEach(function (row) {
       ids[row[0]] = true;
+      var durM = /^P(-?\d+(?:\.\d+)?)D$/.exec(row[9] || '');
       nodes[row[0]] = { id: row[0], parent: row[1], name: row[2] || row[0],
         isSummary: !!row[3], start: row[4] || null, finish: row[5] || null,
         critical: row[6] === 1, totalFloat: (row[7] != null ? row[7] : null),
+        freeFloat: (row[8] != null ? row[8] : null),
+        durDays: (durM ? parseFloat(durM[1]) : null),
+        status: row[10] || null,
         guidCount: 0, children: [] };
     });
     // Element counts per task (the "N elements" badge on a leaf).

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -146,6 +146,8 @@
   <div class="se-ribbon-group">
     <span class="se-ribbon-label">Export</span>
     <button id="se-export-msp-btn" title="Export the current schedule (WBS, dates, dependencies) as MS Project XML (MSPDI) — opens directly in Microsoft Project, or re-imports here via ⤓ P6.">⤒ MS Project</button>
+    <button id="se-export-pmxml-btn" title="Export the current schedule as Primavera P6 PMXML (APIBusinessObjects XML) — the format every documented P6 export path uses; re-imports here via ⤓ P6. Some fields (WBS code, EPS-level activity codes, resource assignments, global calendars, baselines) are not carried — P6 itself drops most of these on cross-DB import.">⤒ P6 XML</button>
+    <button id="se-export-xer-btn" title="Export the current schedule as Primavera XER — the older tab-delimited P6 interchange, for P6 installs that still prefer it over PMXML. Same known-lossy fields as ⤒ P6 XML.">⤒ P6 XER</button>
   </div>
   <div class="se-ribbon-group">
     <span class="se-ribbon-label">Compute</span>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -580,6 +580,38 @@
     console.log('§SE_EXPORT_MSP tasks=' + rows.length + ' links=' + deps.length + ' file=' + a.download);
   }
 
+  // ── §X7: export the current schedule to Primavera P6 PMXML / XER (prompts/XER_PMXML_WRITER_LANE.md)
+  // — the write-side counterpart to doImportP6's PMXML/XER read path (foreign_schedule.js parsePMXML/
+  // parseXER). SAME (tree, deps) input exportMSProject already reads — ForeignSchedule.toPMXML/toXER
+  // are pure serializers, no new data plumbing. W-XER-ROUNDTRIP/W-PMXML-ROUNDTRIP (erp/tests/
+  // xer_pmxml_writer_witness.js) prove mismatch=0 re-parsing the writer's own output with our reader.
+  function _exportP6(kind, writeFn, ext, mime, label) {
+    if (!db || !schedId || !SA() || !SA().wbsTree) { status('⚠ no schedule to export'); return; }
+    var FSx = global.ForeignSchedule;
+    if (!FSx || !FSx[writeFn]) { status('⚠ foreign_schedule.js not loaded'); return; }
+    var tree = SA().wbsTree(db, schedId);
+    if (!tree.length) { status('⚠ no tasks to export'); return; }
+    var deps = SA().listDependencies ? SA().listDependencies(db, schedId) : [];
+    var name = (_dbUrl || 'schedule').split('/').pop().replace(/\.[a-z0-9]+$/i, '');
+    var out = FSx[writeFn](tree, deps, { hpd: 8, projectId: schedId, projectName: name });
+
+    var blob = new Blob([out], { type: mime });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = name + '_schedule.' + ext;
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
+
+    var leafCount = 0; (function walk(ns) { (ns || []).forEach(function (n) { if (!n.isSummary) leafCount++; walk(n.children); }); })(tree);
+    status('Exported ' + leafCount + ' tasks / ' + deps.length + ' links to ' + label + ' (' + a.download +
+      '). Some fields (WBS code, EPS-level activity codes, resource assignments, global calendars, ' +
+      'baselines) are not carried — P6 itself drops most of these on cross-DB import.');
+    console.log('§SE_EXPORT_' + kind + ' tasks=' + leafCount + ' links=' + deps.length + ' file=' + a.download);
+  }
+  function exportPMXML() { _exportP6('PMXML', 'toPMXML', 'xml', 'application/xml', 'Primavera PMXML'); }
+  function exportXER() { _exportP6('XER', 'toXER', 'xer', 'text/plain', 'Primavera XER'); }
+
   // ── boot ─────────────────────────────────────────────────────────────────────
   function init() {
     if (!SA() || !SA().wbsTree) { status('engine not loaded'); return; }
@@ -635,6 +667,8 @@
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
         var genBtn = $('se-generate-btn'); if (genBtn) genBtn.onclick = doGenerate;
         var expBtn = $('se-export-msp-btn'); if (expBtn) expBtn.onclick = exportMSProject;
+        var expPmxmlBtn = $('se-export-pmxml-btn'); if (expPmxmlBtn) expPmxmlBtn.onclick = exportPMXML;
+        var expXerBtn = $('se-export-xer-btn'); if (expXerBtn) expXerBtn.onclick = exportXER;
         var impBtn = $('se-import-btn'), impFile = $('se-import-file');
         if (impBtn && impFile) {
           impBtn.onclick = function () { impFile.click(); };
@@ -656,7 +690,7 @@
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }
 
-  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm, setZoom: setZoom };
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm, setZoom: setZoom, exportMSProject: exportMSProject, exportPMXML: exportPMXML, exportXER: exportXER };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- Implements `prompts/XER_PMXML_WRITER_LANE.md` in full: `toPMXML(tree, deps, opts)` and `toXER(tree, deps, opts)` in `viewer/foreign_schedule.js`, the write-side counterpart to the existing `parsePMXML`/`parseXER` readers. Closes the last documented interop gap — a P6 shop previously got `XER-in → MSPDI-out`, which their P6 can't reingest natively.
- Both writers consume the exact same `(tree, deps)` shape `exportMSProject` already reads (`ScheduleAuthor.wbsTree` + `listDependencies`) — pure serializers, no new data plumbing. The reader stays the schema authority: every tag/field written is one the existing reader reads back.
- `ScheduleAuthor.wbsTree()` gains 3 additive fields (`freeFloat`, `durDays`, `status`) — already stored in the wide `tasks` table by `adoptIntoDb`, just never read back out before. Existing callers destructure only, unaffected; verified via the full existing schedule test suite (all green, see test plan).
- Wired into the Schedule Editor export ribbon beside "⤒ MS Project": new "⤒ P6 XML" / "⤒ P6 XER" buttons (`viewer/schedule_editor.html`, `viewer/schedule_editor_ui.js`).
- Known, P6-itself-drops-these-too losses are documented via `§XER_WRITE_LOSSY`/`§PMXML_WRITE_LOSSY` console logs and the export button tooltips, not silently fixed: WBS code (already dropped upstream by `toScheduleData`), `status_code` (mapped to a display string before the writer ever sees it), EPS-level activity codes, resource assignments, global calendars, baselines.

## Test plan
- [x] `node -c` syntax check on all 4 modified JS files.
- [x] New witness `erp/tests/xer_pmxml_writer_witness.js` (W-XER-ROUNDTRIP / W-PMXML-ROUNDTRIP): serialize → re-parse with our own reader → diff against the true source.
  - **XER**: against a GENUINELY P6-emitted `sample.xer` (same cited external fixture as `erp/tests/real_xer_witness.js`, sha-verified) — `§XER_ROUNDTRIP mismatch=0` (6 wbs / 52 activities / 61 relationships).
  - **PMXML**: no real-P6-emitted PMXML sample exists in this repo or is cited anywhere (checked) — falls back to the repo's own committed synthetic demo fixture `tests/fixtures/Hospital_GW_Programme.xml`, flagged explicitly as such in the witness log, not claimed as real-P6 proof — `§PMXML_ROUNDTRIP mismatch=0` (6 wbs / 14 activities / 14 relationships).
- [x] Re-ran the full existing schedule test suite after the `wbsTree()` change: `schedule_move_witness.js` 7/7, `schedule_cpm_witness.js` 10/10, `schedule_editor_witness.js` 19/19, `schedule_sync_witness.js` 11/11, `real_xer_witness.js` 12/12 — all still pass.
- [ ] W-P6-REAL (human-gated, out of scope for this PR per spec §4/§6): a genuine Oracle P6 import of the writer's output needs a P6 licence. Round-trip mismatch=0 proves internal consistency, not that real P6 accepts the file.

Out of scope per spec §6 (not attempted): resource levelling, baseline round-trip, EPS/activity-code preservation, live P6 DB connection, changing the readers, the bind-token scheme, or `toScheduleData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)