### PR TITLE
fix(time-machine): startPlayback wrap warps render via renderAtTime — last cursor-pre-mutation sites

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v825';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v826';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2799,14 +2799,20 @@
     stopPlayback();
     _playing = true;
     _playDir = dir;
-    if (dir < 0 && _cursor <= _projectStart) _cursor = _projectEnd;
+    // §PERF_INCR_FIX (part 2, live LTU report post-#912): these wrap-around warps mutated _cursor
+    // SILENTLY — no render. The next playTick's renderAtTime then derived _prevCursor from the
+    // already-warped value, so the delta window was (start, start+1tick]: only hour-0/1 events got
+    // applied and the fully-built end-state scene stayed on canvas ("first second of play at Hour 0
+    // does not clear"). Same calling-convention bug family as #912 — warp via renderAtTime (full
+    // span → mode=full → every mesh updated), never by assigning _cursor directly.
+    if (dir < 0 && _cursor <= _projectStart) renderAtTime(_projectEnd);
     // §S260e: Opening = construction starts from empty, camera orbits for context
     var _willOpen = _camFollow && dir > 0 && _cineStoryboard.length &&
       (_cursor >= _projectEnd || _cursor <= _projectStart + 1);
-    if (dir > 0 && _cursor >= _projectEnd) _cursor = _projectStart;
+    if (dir > 0 && _cursor >= _projectEnd) renderAtTime(_projectStart);
 
     if (_willOpen) {
-      _cursor = _projectStart; // start empty — construction builds while camera orbits
+      if (_cursor > _projectStart) renderAtTime(_projectStart); // start empty — construction builds while camera orbits
       var app = A();
       if (app && app.camera && app.controls) {
         // §S260e: Opening — 10s orbit, camera starts below grade for foundation visibility

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -1014,7 +1014,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=530')
+  navigator.serviceWorker.register('sw.js?v=531')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
 }

--- a/witness_jump_to_start_clear.js
+++ b/witness_jump_to_start_clear.js
@@ -1,0 +1,91 @@
+// WITNESS — "Jump to Start doesn't clear the canvas" live report (2026-07-20, post-#912).
+// ISSUE IT PROVES/DISPROVES: user reports that after scrubbing forward (building progresses),
+// clicking Jump-to-Start (⏮ tm-start-btn) does NOT show an empty/pre-construction canvas — the
+// scene stays as it was, until the user scrubs a bit, which then "fixes" it.
+//   PASS = built-guid count at t=projectStart, reached via the REAL tm-start-btn click after having
+//   scrubbed forward first, is 0 (or matches a fresh full-render at projectStart exactly).
+//   FAIL = built count after clicking Jump-to-Start is > 0 (stale, matching the reported bug).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8412;
+const BLD = process.env.BLD || 'Hospital';
+
+function countBuilt(vis) {
+  return vis.mesh.length +
+    Object.values(vis.batched || {}).reduce((a, v) => a + Object.values(v).filter(Boolean).length, 0) +
+    Object.values(vis.instanced || {}).reduce((a, v) => a + Object.values(v).filter(Boolean).length, 0);
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  let pass = false;
+  try {
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls, { timeout: 120000 });
+    await new Promise(r => setTimeout(r, 8000));
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 180000, polling: 2000 });
+
+    await page.evaluate(() => { window.APP.toggleShadow(); }); // shadows ON — matches the reported condition
+    await page.evaluate(() => { window.toggleTimeMachine(); });
+    const ready = await page.waitForFunction(() => {
+      const st = window.tmGetState && window.tmGetState();
+      return st && st.active && st.projectEnd > st.projectStart;
+    }, { timeout: 180000 }).then(() => true).catch(() => false);
+    if (!ready) { console.log('FAIL — TM never activated'); process.exit(1); }
+
+    const state0 = await page.evaluate(() => window.tmGetState());
+
+    // Scrub forward to ~40% via the REAL slider input event (onSlide), not a test hook — matches
+    // "user scrubs, things build" from the report, and primes _incrPrimed via a real render path.
+    await page.evaluate(() => {
+      const slider = document.getElementById('tm-slider');
+      slider.value = 50; // mid-range of the default 0-100 slider
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await new Promise(r => setTimeout(r, 500));
+    const visMid = await page.evaluate(() => window.__tmSnapshotVisible());
+    console.log('built count after scrubbing forward: ' + countBuilt(visMid));
+
+    // Now click the REAL Jump-to-Start button.
+    await page.click('#tm-start-btn');
+    await new Promise(r => setTimeout(r, 500));
+    const visStart = await page.evaluate(() => window.__tmSnapshotVisible());
+    const builtAtStart = countBuilt(visStart);
+    console.log('built count after clicking Jump-to-Start: ' + builtAtStart);
+
+    // Ground truth: force a full-path re-render at the SAME cursor (projectStart) and compare.
+    await page.evaluate(() => { window.__forceFull = true; window.__tmSetCursor(window.tmGetState().projectStart); });
+    const visStartFull = await page.evaluate(() => window.__tmSnapshotVisible());
+    const builtAtStartFull = countBuilt(visStartFull);
+    console.log('built count via forced full-path at same cursor: ' + builtAtStartFull);
+
+    pass = builtAtStart === 0 && builtAtStartFull === 0;
+    console.log(pass ? 'PASS — Jump-to-Start correctly shows an empty canvas'
+                      : 'FAIL — stale/non-empty canvas after Jump-to-Start (builtAtStart=' + builtAtStart +
+                        ', groundTruth=' + builtAtStartFull + ')');
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log('PAGE ERRORS:\n' + errs.join('\n')); pass = false; }
+  } catch (e) {
+    console.log('CRASH: ' + e.message);
+    pass = false;
+  } finally {
+    try { await page.close(); } catch (e) {}
+    await browser.close();
+  }
+  process.exit(pass ? 0 : 1);
+})();

--- a/witness_play_at_end_clears.js
+++ b/witness_play_at_end_clears.js
@@ -1,0 +1,96 @@
+// WITNESS — "first second of play at Hour 0 does not clear the canvas" live report (2026-07-20,
+// post-#912, LTU). ISSUE IT PROVES/DISPROVES: startPlayback()'s wrap-around warps assigned _cursor
+// directly (no render), so the first playTick's delta window was (start, start+1tick] — the
+// fully-built end-state scene never got hidden until a manual scrub (the user's workaround).
+//   PASS = after TM activates at projectEnd (full building visible) and the REAL ▶ button starts
+//   playback (wrap to start), the visible-built count a moment into playback EQUALS the forced
+//   full-path ground truth at the same cursor (and both are far below the end-state count).
+//   FAIL = visible count stays at/near the end-state count (stale canvas, the reported bug).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8415;
+const BLD = process.env.BLD || 'Hospital';
+
+function countBuilt(vis) {
+  return vis.mesh.length +
+    Object.values(vis.batched || {}).reduce((a, v) => a + Object.values(v).filter(Boolean).length, 0) +
+    Object.values(vis.instanced || {}).reduce((a, v) => a + Object.values(v).filter(Boolean).length, 0);
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  let pass = false;
+  try {
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls, { timeout: 120000 });
+    await new Promise(r => setTimeout(r, 8000));
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 180000, polling: 2000 });
+
+    await page.evaluate(() => { window.APP.toggleShadow(); }); // shadows ON — matches the live condition
+    await page.evaluate(() => { window.toggleTimeMachine(); });
+    const ready = await page.waitForFunction(() => {
+      const st = window.tmGetState && window.tmGetState();
+      return st && st.active && st.projectEnd > st.projectStart;
+    }, { timeout: 180000 }).then(() => true).catch(() => false);
+    if (!ready) { console.log('FAIL — TM never activated'); process.exit(1); }
+    await new Promise(r => setTimeout(r, 1000));
+
+    // TM activation renders at projectEnd — the full building. This is the bug precondition.
+    const visEnd = await page.evaluate(() => window.__tmSnapshotVisible());
+    const builtAtEnd = countBuilt(visEnd);
+    console.log('built count at activation (projectEnd): ' + builtAtEnd);
+
+    // REAL ▶ press: startPlayback(+1) with _cursor >= projectEnd → the wrap-around warp under test.
+    const preFwdIdx = logs.length;
+    await page.click('#tm-fwd-btn');
+    await new Promise(r => setTimeout(r, 1500));      // a few playback ticks into hour 0-3
+    await page.click('#tm-stop-btn');                 // pause so the cursor holds still
+    await new Promise(r => setTimeout(r, 300));
+    const visPlay = await page.evaluate(() => window.__tmSnapshotVisible());
+    const builtAfterPlay = countBuilt(visPlay);
+    const cursorNow = await page.evaluate(() => window.tmGetState().cursor);
+    console.log('built count a moment into playback-from-end: ' + builtAfterPlay +
+      ' (cursor=' + Math.round(cursorNow) + ')');
+
+    // Ground truth: forced full-path re-render at the SAME cursor.
+    await page.evaluate(() => { window.__forceFull = true; window.__tmSetCursor(window.tmGetState().cursor); });
+    const visFull = await page.evaluate(() => window.__tmSnapshotVisible());
+    const builtFull = countBuilt(visFull);
+    console.log('built count via forced full-path at same cursor: ' + builtFull);
+
+    // PASS needs equivalence AND a real discrimination margin: early-playback truth must be far
+    // below the end-state count, or the scenario never exercised the wrap (e.g. empty schedule).
+    pass = builtAfterPlay === builtFull && builtFull < builtAtEnd * 0.5 && builtAtEnd > 0;
+    console.log(pass ? 'PASS — playback from end starts from a correctly cleared canvas'
+                     : 'FAIL — stale canvas after ▶ at end (afterPlay=' + builtAfterPlay +
+                       ' groundTruth=' + builtFull + ' endState=' + builtAtEnd + ')');
+
+    console.log('ALL perf/incr lines from ▶ press onward:\n' +
+      logs.slice(preFwdIdx).filter(l => /§PERF_TRAVERSE|§PERF_INCR|§CINE_OPENING|§TM_PLAY|§TM_/.test(l)).join('\n'));
+
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) { console.log('PAGE ERRORS:\n' + errs.join('\n')); pass = false; }
+  } catch (e) {
+    console.log('CRASH: ' + (e.stack || e.message));
+    console.log('last 30 page-log lines:\n' + logs.slice(-30).join('\n'));
+    pass = false;
+  } finally {
+    try { await page.close(); } catch (e) {}
+    await browser.close();
+  }
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
Completes the #912 audit: startPlayback's three wrap-around warps assigned `_cursor` silently (no render), leaving the first playback tick a tiny delta window over a stale end-state scene — the live LTU "play at Hour 0 doesn't clear the canvas until scrub" report. Warps now go through `renderAtTime(target)` (full span → full mode). Zero direct `_cursor` assignments remain outside `renderAtTime`.

Witness: fixed build 6500→0, matches forced-full ground truth, no PAGEERROR. Honest caveat in the commit message: headless Hospital control could not reproduce the live symptom (streaming re-flush self-heals) — live LTU verdict pending from the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)