### PR TITLE
fix(time-machine): DLOD Phase 3 boxes → wireframe, not solid

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v828';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v829';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -528,10 +528,11 @@
     for (var di = 0; di < discs.length; di++) {
       var disc = discs[di], drows = byDisc[disc];
       var color = app.DISC_COLORS[disc] || app.DEFAULT_COLOR;
-      // §4: solid, discipline-colored, slightly emissive — deliberately NOT the wireframe ghost
-      // look (_buildMergedGhost) so it reads as "not yet detailed" per feedback_no_fake_lod_unbreakable.md,
-      // matching the load-time placeholder's established visual language (streaming.js _drawBboxPlaceholders).
-      var mat = new THREE.MeshLambertMaterial({ color: color, emissive: color, emissiveIntensity: 0.15 });
+      // 2026-07-20 user testing on LTU (day159, 106K/122K placed): solid boxes read as a wholesale
+      // LOD400 loss the instant the toggle engages, not a graceful proxy — switched to wireframe
+      // (user ask) matching _drawBboxPlaceholders' actual established look (streaming.js:221),
+      // same as the load-time placeholder language feedback_no_fake_lod_unbreakable.md points at.
+      var mat = new THREE.MeshBasicMaterial({ color: color, wireframe: true, transparent: true, opacity: 0.4 });
       var im = new THREE.InstancedMesh(geo, mat, drows.length);
       im.frustumCulled = false;
       im.userData.isBboxPlaceholder = true; // §S260d proven pick-exclusion (picking.js:257) — same flag as load-time boxes

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -923,7 +923,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=61" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=62" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>


### PR DESCRIPTION
## Summary
- Live LTU testing showed the solid emissive box material read as a wholesale LOD400 loss the
  instant the toggle engaged (106K/122K elements already placed at day159 → almost the whole
  building falls outside the active window this late in construction).
- Switched box material to wireframe + 0.4 opacity, matching the existing load-time
  `_drawBboxPlaceholders` look — same visual language, reads as "not yet detailed" not "broken."

## Test plan
- [x] `node --check` clean
- [ ] Visual re-check on LTU (user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)