### PR TITLE
fix(history): back-arrow no longer mints a spurious forward dot mid-scrub

### DIFF
--- a/common/history_tap.js
+++ b/common/history_tap.js
@@ -31,7 +31,7 @@
     SFX_NAV: 1, SFX_SUSPEND: 1, SFX_RESUME: 1, SFX_INIT: 1, SFX_CONFIG: 1, FILTER_GUIDS: 1, GRID_SCISSORS: 1,
     KBD_SEQ_ENGINE: 1, KBD_SEQ_FIRE: 1, KBD_SEQ: 1, BBOX: 1, BBOX_PLACEHOLDERS: 1, BBOX_CLEARED: 1,
     EVT: 1, RESTORE: 1, HIST_PUSH: 1, HIST_UNDO: 1, HIST_REDO: 1, KRN_CHAIN: 1, KRN_PERSIST: 1,
-    HIST_TAP_DOT: 1, HIST_DEPTH: 1,                                 // the bar's tap-drain echo (anti-recursion)
+    HIST_TAP_DOT: 1, HIST_DEPTH: 1, HIST_VIEWNAV: 1,                // the bar's tap-drain echo (anti-recursion)
     // ERP boot/infra + cross-page-log echo (HISTORY_TAP_TO_IDEMPIERE §SESSION — from the REAL idempiere
     // firehose; all infra on the viewer too): VFS=storage-backend probe · AD_PARSER=tip-miss parse churn ·
     // IDEMPIERE=shard load · WHOLE=whole_history's own §WHOLE-REC/NAV/LANDED echo (also recursion-guard).
@@ -103,6 +103,7 @@
   // "total recording" means total ACTIONS, not total console output. (Explicit S() acts bypass this.)
   var LIFECYCLE = /_(LOADED|READY|INIT|DONE|WIRED?|MODULE|VERSION|REGISTER|CHECK|AUDIT|PROBE|FETCHED|FLUSH|STREAM|DETAIL|MISS_READ|WRITE_OK|QUERY|RESULT|DETECT|RECOLOR|EARLY|FROM_POSITIONS)$|^(UPGRADE|CACHE|BVH|BOOTSTRAP|SPLIT|GEO|DB|DS|SW|PWA|FOG|ENV|SKY|TONE|GROUND|BATCHED|BLOB|INSTANCED|PROGRESSIVE|NORMALS|CENTRES|HASH|DIFF|HELPERS|PANELS|LISTNAV|QUOTA|OFFSET|MAIN|COLOR_MGMT|LENSFLARE|EFFECTS|SITECAM|NLP|MEASURE|SHARE|RECORD|ERROR_REPORTER|GHOSTGLASS|UI_PILL|PILL|MOBILE)/;
   function feedCrumb(tag, label) {
+    if (_applyingView) return;              // restore-driven setter logs (e.g. §XRAY from write()) are NOT a new act
     if (DENY_TAG[tag] || LIFECYCLE.test(tag) || NOISE_LABEL.test(label)) return;  // firehose + lifecycle + intra-tag noise
     var n = all.length;                                             // dedupe vs the last few (explicit S() + its console.log overlap)
     for (var i = n - 1; i >= 0 && i >= n - 3; i--) if (all[i].tag === tag && all[i].label === label) return;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -829,7 +829,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
-<script src="../common/history_tap.js?v=6" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
+<script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
 <script src="scene.js?v=51" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>

--- a/witness_history_viewnav_backarrow.js
+++ b/witness_history_viewnav_backarrow.js
@@ -1,0 +1,105 @@
+// witness_history_viewnav_backarrow.js — witness prompts/HISTORY_KNOB_SIGNAL_TAP.md §BUG (2026-07-12).
+// PROVES: back-arrow (#hist-back → viewStepBack) does NOT spawn a spurious forward dot / snap the view
+// cursor to the tip when the restored moment's write() drives a real setter (A.toggleXray → §XRAY).
+// Root cause under test: history_tap.js feedCrumb() didn't gate on isApplying(), and §HIST_VIEWNAV was
+// missing from DENY_TAG, so a restore-driven §XRAY line got queued and flushed by the NEXT §HIST_VIEWNAV
+// line once isApplying() reset — minting a bogus §HIST_PUSH right after the back-press.
+// NOTE on padding: feedCrumb() has an unrelated anti-duplicate heuristic (skip if the same tag+label
+// appeared in the last 3 sniffed crumbs) that would otherwise mask this bug in a short synthetic session
+// (a real ~100-dot session, like the user's repro log, always has unrelated crumbs in between). We inject
+// a few distinct §MAT_SELECT padding lines between the xray toggles purely to clear that dedupe window —
+// this does not fabricate the mechanism under test: the actual signal (toggleXray → restore → #hist-back
+// click) is 100% real DOM/API calls, only the "session has other stuff in it" filler is synthetic.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8955;
+const URL = `http://127.0.0.1:${PORT}/viewer/viewer.html?db=/modeller/Duplex_extracted.db&bld=Duplex`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({ serviceWorkers: 'block' });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(() => {
+      const A = window.A || window.APP;
+      return A && A.db && A.activeBuilding;
+    }, { timeout: 60000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+    await page.waitForFunction(() => { const A = window.A || window.APP; return A && A.streaming === false; }, { timeout: 60000 }).catch(e => console.log('STREAM_WAIT_FAIL ' + e.message));
+    await sleep(1200);
+
+    if (!(await page.evaluate(() => !!window.UniversalHistory))) {
+      console.log('SETUP_FAIL no UniversalHistory'); await browser.close(); process.exit(1);
+    }
+    await page.evaluate(() => { window.UniversalHistory.open(); });
+    await sleep(200);
+
+    // ── SETUP: xray ON (dot0) → 4 distinct padding crumbs (clears the dedupe window) → xray OFF (tip) ──
+    logs.length = 0;
+    await page.evaluate(() => { window.toggleXray(); });         // dot0: XRAY on=true
+    await sleep(120);
+    await page.evaluate(() => {
+      for (let i = 1; i <= 4; i++) console.log('§MAT_SELECT padding-' + i);  // distinct tag+label each
+    });
+    await sleep(120);
+    await page.evaluate(() => { window.toggleXray(); });         // tip: XRAY on=false
+    await sleep(150);
+    console.log('--- SETUP (xray on → 4 padding dots → xray off=tip) ---');
+    console.log(logs.filter(l => l.includes('§XRAY') || l.includes('§MAT_SELECT') || l.includes('§HIST_PUSH')).join('\n'));
+
+    // ── press #hist-back TWICE (the real user gesture) — read §HIST_VIEWNAV idx each time ──
+    logs.length = 0;
+    const backBtn = await page.$('#hist-back');
+    if (!backBtn) { console.log('SETUP_FAIL #hist-back not found'); await browser.close(); process.exit(1); }
+    await backBtn.click();
+    await sleep(250);
+    const afterFirst = logs.slice();
+    logs.length = 0;
+    await backBtn.click();
+    await sleep(250);
+    const afterSecond = logs.slice();
+
+    console.log('--- §1 FIRST BACK-PRESS (raw log) ---');
+    console.log(afterFirst.join('\n'));
+    console.log('--- §2 SECOND BACK-PRESS (raw log) ---');
+    console.log(afterSecond.join('\n'));
+
+    function idxOf(lines) {
+      for (const l of lines) { const m = /§HIST_VIEWNAV idx=(-?\d+)/.exec(l); if (m) return parseInt(m[1], 10); }
+      return null;
+    }
+    function bogusAfterViewnav(lines) {
+      // a §HIST_PUSH or §HIST_TAP_DOT AFTER the §HIST_VIEWNAV line in the same batch = the bug
+      // (the restore's own setter-echo got flushed as a brand-new forward dot).
+      const vIdx = lines.findIndex(l => l.includes('§HIST_VIEWNAV'));
+      if (vIdx === -1) return false;
+      return lines.slice(vIdx + 1).some(l => l.includes('§HIST_PUSH') || l.includes('§HIST_TAP_DOT'));
+    }
+
+    const idx1 = idxOf(afterFirst), idx2 = idxOf(afterSecond);
+    const bogus1 = bogusAfterViewnav(afterFirst), bogus2 = bogusAfterViewnav(afterSecond);
+
+    console.log('--- §3 ASSERTIONS ---');
+    console.log('idx after 1st back=' + idx1 + ', idx after 2nd back=' + idx2 +
+      ' (want: idx2 = idx1-1, i.e. monotonic step-back, NOT snapped to tip)');
+    console.log('bogus §HIST_PUSH/§HIST_TAP_DOT after 1st §HIST_VIEWNAV: ' + bogus1 + ' (want: false)');
+    console.log('bogus §HIST_PUSH/§HIST_TAP_DOT after 2nd §HIST_VIEWNAV: ' + bogus2 + ' (want: false)');
+    const monotonic = (idx1 !== null && idx2 !== null && idx2 === idx1 - 1);
+    console.log('monotonic step-back: ' + monotonic + ' (want: true)');
+
+    const pass = !bogus1 && !bogus2 && monotonic;
+    console.log(pass ? 'RESULT: PASS — back-arrow steps back cleanly, no spurious forward dot' :
+      'RESULT: FAIL — back-arrow mints a spurious dot / snaps the view cursor forward (the bug this witness proves)');
+
+    await browser.close();
+    process.exit(pass ? 0 : 1);
+  } catch (e) {
+    console.log('WITNESS_ERROR ' + (e && e.stack || e));
+    await browser.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- Cherry-picks a fix diagnosed/coded/witnessed 2026-07-12→13 (`prompts/HISTORY_KNOB_SIGNAL_TAP.md` §BUG) whose branch was pushed 2026-07-16 but never opened as a PR — it silently never reached `main`, which is the actual cause of the "world/history broken again" report on 2026-07-20.
- `common/history_tap.js`: `feedCrumb()` now gates on `_applyingView` (symmetric with `recordEvent()`'s existing gate), and `HIST_VIEWNAV` was added to `DENY_TAG` — closing a gap where a restore-driven `§XRAY` log line got queued, then flushed by the very next `§HIST_VIEWNAV` line once `isApplying()` reset, minting a bogus tip dot right after a back-press.
- `viewer/viewer.html`: cache-bust bump for `history_tap.js` (v7).

## Test plan
- [x] `node --check common/history_tap.js` clean
- [x] Re-ran `witness_history_viewnav_backarrow.js` fresh against this branch (not reused from the stale branch) — real `#hist-back` DOM clicks + real `A.toggleXray()`, on localhost against `viewer/viewer.html?db=/modeller/Duplex_extracted.db&bld=Duplex`. `RESULT: PASS` — monotonic step-back, no spurious `§HIST_PUSH`/`§HIST_TAP_DOT` after either back-press.
- [x] Isolated worktree, `node --check` on both changed files, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)