### PR TITLE
fix(tour): §TOUR_CACHE self-heals on quota-exceeded

### DIFF
--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -161,6 +161,47 @@ function setupTour(A) {
       }
     } catch (e) {}
   };
+  // §TOUR_CACHE_EVICT (TOUR_ROUTE_CACHE.md §4, 2026-07-20): nothing else ever removed a
+  // tmTourCache key — old TOUR_CACHE_VER generations, other buildings, other DB-recompile counts
+  // all coexist forever and can fill the origin's real localStorage quota, after which EVERY
+  // future store silently fails (never a crash, but the 41×-faster cache never engages again).
+  // Two-part self-heal: (1) drop stale-version keys unconditionally, cheap, no error needed to
+  // trigger it; (2) on an actual quota error, drop every OTHER tmTourCache key and retry once —
+  // makes the very next Fly press benefit, not just a hand-cleared profile.
+  function _tourCachePruneStale() {
+    var removed = 0;
+    try {
+      for (var i = localStorage.length - 1; i >= 0; i--) {
+        var k = localStorage.key(i);
+        if (k && k.indexOf('tmTourCache:') === 0 && k.indexOf(':' + TOUR_CACHE_VER + ':') === -1) {
+          localStorage.removeItem(k); removed++;
+        }
+      }
+    } catch (e) {}
+    if (removed) console.log('[TOUR] §TOUR_CACHE_PRUNE stale-version removed=' + removed);
+  }
+  _tourCachePruneStale(); // once per module setup (page load) — cheap, unconditional
+  function _tourCacheEvictAndRetry(key, json) {
+    var removed = 0, bytesFreed = 0;
+    try {
+      for (var i = localStorage.length - 1; i >= 0; i--) {
+        var k = localStorage.key(i);
+        if (k && k.indexOf('tmTourCache:') === 0 && k !== key) {
+          var v = localStorage.getItem(k);
+          bytesFreed += (v ? v.length : 0);
+          localStorage.removeItem(k); removed++;
+        }
+      }
+    } catch (e) { return false; }
+    console.log('[TOUR] §TOUR_CACHE_EVICT removed=' + removed + ' bytes_freed=' + bytesFreed);
+    try {
+      localStorage.setItem(key, json);
+      return true;
+    } catch (e2) {
+      console.log('[TOUR] §TOUR_CACHE store-skip (post-evict) ' + (e2 && e2.message));
+      return false;
+    }
+  }
 
   // The original fly-start body (tour build + orbit fallback), unchanged except for extraction.
   A._startFlyTour = function(btn) {
@@ -197,13 +238,16 @@ function setupTour(A) {
           }
         }
         if (!_fromCache && _ck) {
-          try {
-            var _json = JSON.stringify(tour);
-            if (_json.length < 1500000) { // localStorage budget guard — skip absurd routes, keep the rest of the app's keys safe
-              localStorage.setItem(_ck, _json);
-              console.log('[TOUR] §TOUR_CACHE store actions=' + tour.length + ' bytes=' + _json.length + ' key=' + _ck);
+          var _json = JSON.stringify(tour);
+          if (_json.length < 1500000) { // localStorage budget guard — skip absurd routes, keep the rest of the app's keys safe
+            var _stored = false;
+            try { localStorage.setItem(_ck, _json); _stored = true; }
+            catch (e) {
+              console.log('[TOUR] §TOUR_CACHE store-skip ' + (e && e.message));
+              _stored = _tourCacheEvictAndRetry(_ck, _json); // §TOUR_CACHE_EVICT — see fn above
             }
-          } catch (e) { console.log('[TOUR] §TOUR_CACHE store-skip ' + (e && e.message)); }
+            if (_stored) console.log('[TOUR] §TOUR_CACHE store actions=' + tour.length + ' bytes=' + _json.length + ' key=' + _ck);
+          }
         }
         A.walkMode = true;
         A.walkActions = tour;

--- a/witness_tour_cache_evict.html
+++ b/witness_tour_cache_evict.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>W-TOUR-CACHE-EVICT harness</title></head>
+<body>
+<div id="walk-speed-btn" style="display:none"></div>
+<script src="viewer/tour.js"></script>
+<script>
+  // Minimal stub of APP — only what setupTour()/A._startFlyTour() touch on the code path under test.
+  window.A = {
+    activeBuilding: 'WitnessBld',
+    buildingsRendered: new Set(['WitnessBld']),
+    buildingCentres: {},
+    db: { exec: function() { return [{ values: [[100, 10, 20]] }]; } }, // elCount, doorCount, roomCount
+    wlog: function(msg) { console.log('[wlog] ' + msg); },
+    status: { textContent: '' }
+  };
+  setupTour(window.A);
+  // setupTour() assigns the REAL A.buildTour (which needs a full elements_meta/element_transforms
+  // schema our db stub doesn't have) — override AFTER setup with a small fixed stand-in. This
+  // witness proves the CACHE STORE/EVICT path, not the route-planning algorithm (already proven
+  // separately by witness_tour_cache.js / W-TOUR-CACHE).
+  window.A.buildTour = function() {
+    return [
+      { type: 'orbit', dur: 5 },
+      { type: 'flyPath', pts: 3, dur: 10 },
+      { type: 'pause' }
+    ];
+  };
+  window.__runTest = function() {
+    A.walkMode = false; A.walkActions = null; A.walkActionIdx = 0;
+    try {
+      A._startFlyTour(null);
+    } catch (e) {
+      return { error: e.message, stack: e.stack };
+    }
+    return { walkMode: A.walkMode, actions: A.walkActions ? A.walkActions.length : 0 };
+  };
+</script>
+</body></html>

--- a/witness_tour_cache_evict.js
+++ b/witness_tour_cache_evict.js
@@ -1,0 +1,120 @@
+// WITNESS — TOUR_ROUTE_CACHE.md §4 (W-TOUR-CACHE-EVICT).
+// ISSUE IT PROVES/DISPROVES: once localStorage's real per-origin quota is exhausted, EVERY future
+// `§TOUR_CACHE store` attempt failed silently forever (`store-skip The quota has been exceeded.`),
+// live-reported on LTU. The fix should self-heal: on a quota error, evict other tmTourCache keys
+// and retry once — the very NEXT Fly press must succeed, not just a hand-cleared profile.
+//   PASS = with localStorage pre-filled to quota with junk tmTourCache: keys, calling
+//   A._startFlyTour() logs §TOUR_CACHE_EVICT (removed>0) followed by §TOUR_CACHE store (not a
+//   second store-skip), and A.walkMode becomes true with the expected action count.
+//   FAIL = store-skip with no successful retry, or an uncaught exception.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = __dirname;
+const PORT = 8931;
+
+function serve() {
+  return http.createServer((req, res) => {
+    const p = path.join(ROOT, decodeURIComponent(req.url.split('?')[0]));
+    fs.readFile(p, (err, data) => {
+      if (err) { res.writeHead(404); res.end('not found: ' + p); return; }
+      res.writeHead(200, { 'Content-Type': p.endsWith('.js') ? 'application/javascript' : 'text/html' });
+      res.end(data);
+    });
+  }).listen(PORT);
+}
+
+(async () => {
+  const server = serve();
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+
+  // --- Part A: stale-version prune fires unconditionally at module setup, no error needed ---
+  const pageA = await browser.newPage();
+  const logsA = [];
+  pageA.on('console', m => logsA.push(m.text()));
+  await pageA.evaluateOnNewDocument(() => {
+    localStorage.setItem('tmTourCache:OldBld:v9:1-1-1:1', '{"stale":true}');   // dead version
+    localStorage.setItem('tmTourCache:OldBld:v11:1-1-1:1', '{"stale":true}'); // dead version
+    localStorage.setItem('tmTourCache:OldBld:v12:1-1-1:1', '{"live":true}');  // current version — must survive
+  });
+  await pageA.goto(`http://localhost:${PORT}/witness_tour_cache_evict.html`, { waitUntil: 'load' });
+  const afterPrune = await pageA.evaluate(() => {
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i++) keys.push(localStorage.key(i));
+    return keys;
+  });
+  const pruneLogged = logsA.some(l => l.includes('§TOUR_CACHE_PRUNE stale-version removed=2'));
+  const staleGone = !afterPrune.includes('tmTourCache:OldBld:v9:1-1-1:1') && !afterPrune.includes('tmTourCache:OldBld:v11:1-1-1:1');
+  const liveSurvived = afterPrune.includes('tmTourCache:OldBld:v12:1-1-1:1');
+  const prunePass = pruneLogged && staleGone && liveSurvived;
+  console.log('PART A (stale-version prune): ' + (prunePass ? 'PASS' : 'FAIL') +
+    ' — pruneLogged=' + pruneLogged + ' staleGone=' + staleGone + ' liveSurvived=' + liveSurvived +
+    ' remainingKeys=' + JSON.stringify(afterPrune));
+  await pageA.close();
+
+  // --- Part B: quota-exceeded self-heal (eviction + retry) ---
+  const page = await browser.newPage();
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  await page.goto(`http://localhost:${PORT}/witness_tour_cache_evict.html`, { waitUntil: 'load' });
+
+  // Fill localStorage to real quota with junk tmTourCache: keys — reproduces the live LTU state
+  // (many stale building/version entries accumulated over a testing history) without needing
+  // months of real usage.
+  const fillResult = await page.evaluate(() => {
+    let i = 0, lastErr = null;
+    // Coarse pass: 200KB chunks until the first failure (fast).
+    try {
+      while (i < 200) {
+        localStorage.setItem('tmTourCache:JunkBld' + i + ':v1:1-1-1:1', 'x'.repeat(200000));
+        i++;
+      }
+    } catch (e) { lastErr = e.message; }
+    // Fine pass: shrink the chunk size geometrically to top off remaining headroom so even a
+    // TINY future write (like the ~80-byte real tour JSON) also fails — the actual live LTU
+    // state, not just "one big write didn't fit."
+    let size = 100000, fineWrites = 0;
+    while (size >= 8) {
+      try {
+        localStorage.setItem('tmTourCache:JunkFine' + i + '_' + size, 'x'.repeat(size));
+        i++; fineWrites++;
+      } catch (e) { lastErr = e.message; size = Math.floor(size / 2); }
+    }
+    // Confirm true exhaustion: even a 1-byte write must now fail.
+    let trulyFull = false;
+    try { localStorage.setItem('tmTourCache:__probe__', 'x'); localStorage.removeItem('tmTourCache:__probe__'); }
+    catch (e) { trulyFull = true; }
+    return { keysWritten: i, fineWrites, lastErr, totalKeys: localStorage.length, trulyFull };
+  });
+  console.log('FILL: wrote ' + fillResult.keysWritten + ' junk keys (' + fillResult.fineWrites +
+    ' in the fine pass), localStorage now has ' + fillResult.totalKeys + ' keys, trulyFull=' +
+    fillResult.trulyFull);
+
+  if (!fillResult.trulyFull) {
+    console.log('FAIL: could not reproduce true quota exhaustion (even a 1-byte write still fit)');
+    await browser.close(); server.close(); process.exit(1);
+  }
+
+  // Now call _startFlyTour directly — same call the live Fly-button press makes after prepare.
+  const result = await page.evaluate(() => window.__runTest());
+  await browser.close(); server.close();
+
+  console.log('--- console log ---');
+  logs.forEach(l => console.log(l));
+  console.log('--- result ---', JSON.stringify(result));
+
+  const sawEvict = logs.some(l => l.includes('§TOUR_CACHE_EVICT'));
+  const sawStoreSuccess = logs.some(l => /§TOUR_CACHE store actions=/.test(l));
+  const sawPostEvictSkip = logs.some(l => l.includes('store-skip (post-evict)'));
+  const partBPass = sawEvict && sawStoreSuccess && !sawPostEvictSkip && result.walkMode === true && result.actions === 3;
+  console.log('PART B (quota-exceeded self-heal): ' + (partBPass ? 'PASS' : 'FAIL') +
+    ' — evict=' + sawEvict + ' storeOk=' + sawStoreSuccess + ' postEvictSkip=' + sawPostEvictSkip + ' walkMode=' + result.walkMode);
+
+  const pass = prunePass && partBPass;
+  console.log(pass ? 'OVERALL PASS' : 'OVERALL FAIL');
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Live LTU report: Fly Tour's route cache (`TOUR_ROUTE_CACHE.md`, shipped #917) stopped storing entirely once the origin's localStorage quota filled up from accumulated stale `tmTourCache:` keys (old algorithm versions, other buildings, other DB-recompile counts — nothing ever evicted them). Every Fly press then paid the full route-planning pass **twice** with zero cache benefit.
- Two-part self-heal in `viewer/tour.js`: (1) prune stale-`TOUR_CACHE_VER` keys unconditionally once per page load, (2) on an actual quota error, evict every other `tmTourCache:` key and retry the store once — the very next Fly press benefits.
- Full root-cause writeup: `prompts/TOUR_ROUTE_CACHE.md` §4 (bim-compiler repo).

## Test plan
- [x] `node --check viewer/tour.js`
- [x] W-TOUR-CACHE-EVICT (`witness_tour_cache_evict.js`): isolated harness, both parts PASS
  - Part A: stale-version keys pruned at setup, current-version key survives
  - Part B: localStorage filled to true exhaustion, confirms `store-skip` → `§TOUR_CACHE_EVICT` → successful retry `§TOUR_CACHE store` → `walkMode=true`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>