### PR TITLE
fix(erp): install device signer + preserve gid/sig/branch_id through relay rebase

### DIFF
--- a/erp/erp_sync_fsm.js
+++ b/erp/erp_sync_fsm.js
@@ -162,23 +162,35 @@
    *   4. re-seal the chain over the new order (sealChain full-recomputes → valid chain, §kernel)
    * Determinism ⇒ every device that rebases against the same sequencer head materialises the SAME
    * ordered log ⇒ the SAME chain tip ⇒ the SAME projection. That convergence is the whole point.
+   *
+   * Implementing ERP_MULTIUSER_CONCURRENCY_POC.md §DocAction Cross-Device Attribution S7 — Witness:
+   * W-REBASE-ATTRIB. `gid`/`branch_id`/`sig` now ride through the rewind+reapply (previously dropped,
+   * NULLing every op's group + attestation on every sync). `gid` survival keeps a DocAction fan-out
+   * (commitGroup) foldable/undoable as ONE group after a sync, not N orphaned singletons. `sig`
+   * survival matters only for v2 content-signed rows (kernel_ops.js _sigBase attests the id-independent
+   * content hash for those — a v1 row's sig attests the position-dependent chain hash and could never
+   * survive a reorder regardless of what this function does); sealChain's own `if (_signer && !sig)`
+   * guard already skips re-signing a row that arrives with a sig intact, so no kernel change was needed
+   * to make preservation "stick" — the bug was purely that rebase() blanked the column before sealChain
+   * ever got a chance to see it.
    * @returns {Promise<{applied:number, head:number}>}
    */
   async function rebase(db, kernel, sequencer) {
-    var r = db.exec('SELECT op_uuid,timestamp,op_type,parameters,input_guids,output_guid FROM kernel_ops ORDER BY id');
+    var r = db.exec('SELECT op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig FROM kernel_ops ORDER BY id');
     var local = (r.length ? r[0].values : []).map(function (row) {
-      return { op_uuid: row[0], timestamp: row[1], op_type: row[2],
-               parameters: row[3], input_guids: row[4], output_guid: row[5] };
+      return { op_uuid: row[0], timestamp: row[1], op_type: row[2], parameters: row[3],
+               input_guids: row[4], output_guid: row[5], gid: row[6], branch_id: row[7], sig: row[8] };
     });
     var pushRes = await sequencer.push(local); // idempotent ingest → canonical order (await: sync stub OR async HTTP relay)
     var canon = await sequencer.snapshot();    // the authoritative ordered log
     db.run('DELETE FROM kernel_ops');      // rewind: drop local order (ids restart at 1 — no AUTOINCREMENT)
     for (var i = 0; i < canon.length; i++) {
       var op = canon[i];
-      db.run('INSERT INTO kernel_ops (op_uuid,timestamp,op_type,parameters,input_guids,output_guid) VALUES (?,?,?,?,?,?)',
-        [op.op_uuid, op.timestamp, op.op_type, op.parameters, op.input_guids || null, op.output_guid || null]);
+      db.run('INSERT INTO kernel_ops (op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig) VALUES (?,?,?,?,?,?,?,?,?)',
+        [op.op_uuid, op.timestamp, op.op_type, op.parameters, op.input_guids || null, op.output_guid || null,
+         op.gid || null, op.branch_id || null, op.sig || null]);
     }
-    await kernel.sealChain(db);             // re-seal over the canonical order
+    await kernel.sealChain(db);             // re-seal over the canonical order (skips already-signed rows)
     console.log('§SYNC_FSM rebase applied=' + canon.length + ' head=' + (pushRes && pushRes.head != null ? pushRes.head : canon.length));
     return { applied: canon.length, head: sequencer.head() };
   }

--- a/erp/erp_sync_relay.js
+++ b/erp/erp_sync_relay.js
@@ -47,9 +47,15 @@
     if (!_url || !rows || !rows.length || typeof global.ErpRelayClient === 'undefined') return Promise.resolve(null);
     try {
       var client = global.ErpRelayClient.createRelayClient(_url);
+      // Implementing ERP_MULTIUSER_CONCURRENCY_POC.md §DocAction Cross-Device Attribution S7 —
+      // Witness: W-REBASE-ATTRIB. This whitelist independently dropped gid/branch_id/sig at the PUSH
+      // boundary — a THIRD divergent copy of the same 6-column mapping erp_sync_fsm.js's rebase() had
+      // (that fix alone was not sufficient: rebase() only preserves what the relay's canonical snapshot
+      // already contains, and this function is what puts ops INTO the relay in the first place).
       var ops = rows.map(function (r) {
         return { op_uuid: r.op_uuid, timestamp: r.timestamp, op_type: r.op_type,
-                 parameters: r.parameters, input_guids: r.input_guids, output_guid: r.output_guid };
+                 parameters: r.parameters, input_guids: r.input_guids, output_guid: r.output_guid,
+                 gid: r.gid || null, branch_id: r.branch_id || null, sig: r.sig || null };
       });
       return client.push(ops).then(function (res) {
         console.log('§SYNC_RELAY push accepted=' + res.accepted + ' skipped=' + res.skipped + ' head=' + res.head);

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -838,6 +838,19 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     catch (e) { SQL = await initSqlJs({ locateFile: function () { return 'https://cdn.jsdelivr.net/npm/sql.js-fts5@1.4.0/dist/sql-wasm.wasm'; } }); }
     window.SQL = SQL;   // exposed for the Kanban host (KanbanHost.publish needs a SQL.Database factory)
 
+    // Implementing prompts/ERP_MULTIUSER_CONCURRENCY_POC.md §DocAction Cross-Device Attribution S7 —
+    // Witness: W-REBASE-ATTRIB. Same best-effort, non-blocking idiom erp.html:224-226 already uses (A2)
+    // — install the real per-device edge signer, then opt every NEW op into v2 content-addressed signing
+    // (kernel_ops.js setContentSigning; "production posture since T2/#630" per witness_t7_incremental.js)
+    // so a sig attests the id-independent content hash, not the position-dependent chain hash — the ONLY
+    // shape of sig that can survive erp_sync_fsm.js's rebase() (reorder + re-id). Previously idempiere.html
+    // loaded erp_signer.js but never called installSigner() — every op's sig was silently NULL forever.
+    if (window.ErpSigner && window.KernelOps) {
+      ErpSigner.installSigner(window.KernelOps).then(function () {
+        KernelOps.setContentSigning(true);
+      }).catch(function (e) { console.warn('§SIGN install error', e); });
+    }
+
     // §VFS — CONSTRAINT_MITIGATION item 3 wired live: detect OPFS-vs-IndexedDB at boot (FoldEngineConstraints
     // §6 vfs_backend monitor). On GH Pages this is IDB (no COOP/COEP) — NAMED, not a silent downgrade.
     // Result stashed for future consumers; sql.js here is in-memory, so this is the monitor + no-silent-downgrade


### PR DESCRIPTION
## Summary
- `erp/idempiere.html` loaded `erp_signer.js` but never called `installSigner()` — every op's `sig` column was permanently NULL on the live product UI (the guide's "steps are re-signed under the receiving device's key" phrasing described a state that wasn't actually reachable). Now installs the real per-device ECDSA-P256 signer on boot and turns on v2 content-signing (id-independent sig, the only kind that can survive a rebase's reorder).
- `erp/erp_sync_fsm.js`'s `rebase()` and `erp/erp_sync_relay.js`'s `pushRows()` each independently whitelisted only 6 of `kernel_ops`'s 9 columns, dropping `gid`/`branch_id`/`sig` on every cross-device sync — un-grouping any `commitGroup` fan-out (e.g. a DocAction Complete) and destroying signature attribution. Both now carry all 9 columns through.

## Discovery
Fixing rebase() alone wasn't sufficient — `pushRows()` had an independent copy of the same whitelist at the push boundary, found only by running the witness rather than assumed from a single read. A third divergent copy of the same 6-column mapping, matching this lane's own recurring pattern ("3 divergent bubble-era copies", bim-compiler commit `53c07ccb0`).

Also discovered live: once a peer's real signature survives onto another device, `verifyChain`'s single-per-device-signer model correctly reports it as unverifiable (`why:"group torn", opFail:"signature"`) — not a regression, but the real remaining gap. Cross-device attribution needs `erp_key_epochs.js`'s roster-gated verify (already built + witnessed for the Teams sync path) wired onto this ERP-relay path too — spec'd as Phase 2/S8 in `bim-compiler prompts/ERP_MULTIUSER_CONCURRENCY_POC.md`, not built in this PR.

## Test plan
- [x] `W-REBASE-ATTRIB` (`bim-compiler scripts/witness_e2e_rebase_attrib.js`): 2 real `BrowserContext`s, real UI Save + real `#erp-sync-pill` click — gid/sig byte-identical pre/post-sync on both sides (8/8 preservation assertions), chain tips converge — exit 0, 27/27 🟢
- [x] Regression: same harness re-proves the base N=2 convergence guarantee (`witness_e2e_n_converge.js`'s own claim) as a side effect — tips equal, no op lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)