### PR TITLE
fix(viewer): §CINEMA_GHOST_RESET — Alt+C leaves ghost bbox/x-ray shell stuck visible

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -315,6 +315,18 @@
       return;
     }
     if (A._stillRefineActive || A._stillRefineBusy) A.stopStillRefine(true);
+    // §CINEMA_GHOST_RESET (2026-07-21, broadened): the ghost bbox shell can be on either because a
+    // Find-panel lens auto-engaged it OR because the user manually cycled Alt+Z to Bbox mode
+    // (tools.js `cycleXrayBboxMode`) — neither case was ever cleared before starting the orbit, so
+    // a cinematic film could show the wireframe shell for its whole duration. See navigate_find.js
+    // §CINEMA_GHOST_RESET (keys off visibility, not just auto-ownership).
+    if (typeof A.resetCinemaGhostLens === 'function') A.resetCinemaGhostLens();
+    // Same problem, same fix, for X-Ray: the SAME Alt+Z cycle can leave X-Ray engaged (transparent
+    // geometry) instead of Bbox — equally wrong for a "photoreal" cinematic film, however it got on.
+    if (A.xrayOn && typeof A.toggleXray === 'function') {
+      A.toggleXray();
+      console.log('§CINEMA_XRAY_RESET x-ray was on, turned off before orbit');
+    }
     var nFrames = opts.frames || MAXQ_N_FRAMES, fps = opts.fps || MAXQ_FPS;
     _active = true; _cancel = false;
     A._maxqActive = true;   // mirror for the cinema icon's busy/done check (panels.js)

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3177,7 +3177,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v8 (§CINEMA_SPACE simplified to largest-only, §CINEMA_SUN_ORDER sunFirst/sunLast, §CINEMA_END_DECEL, §CINEMA_BEAT_OVERLAP)';
+  var EFFECTS_V = 'v10 (§CINEMA_GHOST_RESET — Alt+C resets a lens-owned ghost bbox shell before orbiting)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).
@@ -3809,6 +3809,11 @@ async function setupEffects(A, renderer, scene, camera) {
       return;
     }
     _cinemaActive = true;  // claim BEFORE the await below — a second Alt+C during the import tick must not double-start
+    // §CINEMA_GHOST_RESET (2026-07-21): same fix as cinema_maxq.js's live Alt+C path — see
+    // navigate_find.js §CINEMA_GHOST_RESET. This function is currently dead code (scene.js's
+    // §KBD_ROUTE always finds A.startMaxQualityOrbit defined and never falls through here), kept in
+    // sync for consistency in case that routing ever changes.
+    if (typeof A.resetCinemaGhostLens === 'function') A.resetCinemaGhostLens();
     // §CINEMA_SSAA lazy-load: the module is already in the browser's module map on any load where
     // A._composer exists (TAARenderPass.js imports it), so this resolves from cache in a microtask
     // — no network fetch, works offline.

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -4220,6 +4220,24 @@
       console.log('[S233] §FIND_CLOSE restored=none kept=[' + _kept.join(',') + ']');
     }
     A.closeFindPanel = closeFindPanel; // exposed for nlp.js bar close
+    // §CINEMA_GHOST_RESET (2026-07-21, broadened after user correction — the ghost shell can be
+    // visible for TWO independent reasons that don't track each other: auto-engaged by a Find-panel
+    // lens (_mgLensOwned=true, torn down by closeFindPanel/_setTreeMode/etc.) OR manually toggled via
+    // the Alt+Z 3-state cycle (tools.js `cycleXrayBboxMode` → `toggleMergedGhost`, which flips
+    // `_mergedGhost.visible` alone and NEVER touches `_mgLensOwned` — confirmed reading it directly).
+    // The original version of this fix only checked `_mgLensOwned`, so a manually-toggled-on ghost
+    // (e.g. cycled to Bbox mode via Alt+Z, or via the old Alt+X before it was merged into that cycle)
+    // survived into Alt+C untouched — likely the actual scenario hit live, since no Find-panel drill
+    // was involved. Fixed to key off VISIBILITY, not ownership — a cinematic film should never show
+    // the ghost shell regardless of how it got turned on.
+    A.resetCinemaGhostLens = function() {
+      if (_mergedGhost && _mergedGhost.visible) {
+        _mergedGhost.visible = false;
+        if (A.filterByGuids) A.filterByGuids(null); // restore solids — mirrors toggleMergedGhost's own off-path
+        var _wasAuto = _mgLensOwned; _mgLensOwned = false;
+        console.log('[MG] §CINEMA_GHOST_RESET hidden (' + (_wasAuto ? 'lens-owned' : 'manually toggled') + ', cinema orbit starting)');
+      }
+    };
     elClose.onclick = closeFindPanel;
     // §S275 (user): tap OUTSIDE the Find panel must NOT close it — only Esc or the × button do.
     // The outside-tap-to-close handler was removed; the panel stays put while you click the model.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v832';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v834';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- Alt+C (cinema orbit / MaxQ movie) never cleared the ghost bbox shell or X-Ray, whichever way either got turned on — Find-panel auto-engage (already reset by PR #921 on close/axis-switch) OR the user manually cycling Alt+Z (Off→X-Ray→Bbox→Off).
- Confirmed live with the user's actual reported scenario: no Find panel touched at all, just Alt+Z ×2 then Alt+C — the ghost shell survived the whole orbit.
- `A.resetCinemaGhostLens()` now keys off `_mergedGhost.visible` directly (not just the `_mgLensOwned` auto-ownership flag), and `cinema_maxq.js`'s `start()` also force-clears `A.xrayOn` if engaged.

## Test plan
- [x] `node --check` clean on all 3 touched files
- [x] Live headless repro (Puppeteer, real `KeyboardEvent` Alt+Z ×2 then Alt+C, no Find panel): Terminal shows `ghostOn:true` → `ghostOn:false` right after Alt+C, with the `§CINEMA_GHOST_RESET hidden (manually toggled, cinema orbit starting)` log line
- [ ] User to confirm on a real browser session (headless swiftshader is a slow approximation of real GPU per this project's own testing notes)

Full writeup: `prompts/PHOTOREAL_STILL_RENDER.md` §CINEMA_GHOST_RESET (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqyeCotrVuWj7ndyyZVFor