### PR TITLE
feat(erp): multi-device roster verification for cross-device DocAction attribution

### DIFF
--- a/erp/erp_key_epochs.js
+++ b/erp/erp_key_epochs.js
@@ -144,6 +144,55 @@
 
   function _fail(id, why) { console.log('§EPOCH verify FAIL at id=' + id + ' why=' + why); return { ok: false, brokeAt: id, why: why }; }
 
+  // verifyMultiDeviceOps(ops, opts) — Implementing ERP_MULTIUSER_CONCURRENCY_POC.md §DocAction
+  // Cross-Device Attribution S8 (corrected) — Witness: W-MULTI-DEVICE-VERIFY.
+  //
+  // verifyEpochSigsOps (above) enforces a SINGLE `activeKid` at every position — correct for its own
+  // job (one device rotating/revoking its OWN key over time, the Teams importBranch path) but WRONG
+  // for N devices that are all simultaneously, independently valid signers with no rotation between
+  // them (confirmed by probe 2026-07-21: two concurrent devices with no ROTATE op between them —
+  // verifyEpochSigsOps REJECTS the second one outright, "superseded key cannot sign new ops"). That
+  // would break the exact N-device concurrent convergence witness_e2e_n_converge.js/W-N10-CONCURRENT-
+  // TODAY already proved works.
+  //
+  // This is the correct model for THAT case: each op's `signed_by` kid is looked up directly in a flat
+  // roster and its sig verified against THAT kid's own pubkey, INDEPENDENT of every other op's signer —
+  // no state carried between ops, no rotation/revocation semantics (a device that wants those uses
+  // verifyEpochSigsOps on its OWN single-writer branch instead — this function does not replace that).
+  // Only v2 (content-signed) rows are attributable at all (a v1 sig can't survive a rebase/renumber
+  // regardless, per kernel_ops.js _sigBase) — a v1 row or one with no `signed_by` is skipped (counted,
+  // not failed): pre-S8 ops and rows from a device that never installed a kid stay valid but anonymous.
+  //   opts = { roster: {kid→pubJwk} (direct — a witness/test roster; HQ-signed DISTRIBUTION over the
+  //            relay is Phase 3, not this), verify: async(msgHex,sigHex,pubJwk)->bool, contentHash?,
+  //            isV2? }
+  //   returns { ok, len, attributed:{id→kid}, anonymous:[id,...], brokeAt?, why? }
+  async function verifyMultiDeviceOps(ops, opts) {
+    opts = opts || {};
+    var S = _snapSign();
+    var verify = opts.verify || (S && function (msg, sig, pub) { return S.verifyTip(msg, sig, pub); });
+    if (!verify) return { ok: false, why: 'no verify fn' };
+    var pubByKid = opts.roster || opts.pubByKid;
+    if (!pubByKid) return { ok: false, why: 'no roster/pubByKid' };
+    var attributed = {}, anonymous = [];
+    ops = ops || [];
+    for (var i = 0; i < ops.length; i++) {
+      var o = ops[i], id = o.id;
+      if (o.op_hash == null) return _fail(id, 'unsealed (hash chain not sealed)');
+      var K = _kernel();
+      var isV2 = (opts.isV2) || (K && K._isV2);
+      if (!(isV2 && isV2(o.parameters))) { anonymous.push(id); continue; }   // v1 or no content-sign: skip, don't fail
+      var p = o.parameters; try { p = JSON.parse(p); } catch (e) { p = {}; }
+      var signer = p.signed_by;
+      if (!signer) { anonymous.push(id); continue; }   // v2 but no kid stamped (signer never installed one)
+      if (!pubByKid[signer]) return _fail(id, 'op signed by key ' + signer + ' NOT in the roster (forged/unknown device)');
+      var msg = await _sigMessage(o, opts);
+      if (!(await verify(msg, o.sig, pubByKid[signer]))) return _fail(id, 'signature invalid under ' + signer + ' (forged or wrong key)');
+      attributed[id] = signer;
+    }
+    console.log('§EPOCH verifyMultiDevice OK len=' + ops.length + ' attributed=' + Object.keys(attributed).length + ' anonymous=' + anonymous.length);
+    return { ok: true, len: ops.length, attributed: attributed, anonymous: anonymous };
+  }
+
   // singleKeyVerify — the NO-EPOCH baseline (the §FALSIFIER straw man): one fixed key forges forever.
   // Kept from the POC only to witness the contrast against verifyEpochSigs.
   async function singleKeyVerify(db, opts) {
@@ -158,8 +207,9 @@
   }
 
   var _api = { signRoster: signRoster, verifyRoster: verifyRoster,
-    verifyEpochSigs: verifyEpochSigs, verifyEpochSigsOps: verifyEpochSigsOps, singleKeyVerify: singleKeyVerify };
+    verifyEpochSigs: verifyEpochSigs, verifyEpochSigsOps: verifyEpochSigsOps, singleKeyVerify: singleKeyVerify,
+    verifyMultiDeviceOps: verifyMultiDeviceOps };   // S8: N concurrently-valid devices, no rotation state
   if (typeof module !== 'undefined' && module.exports) { module.exports = _api; }
   if (typeof window !== 'undefined') { window.ErpKeyEpochs = _api; }
-  if (typeof console !== 'undefined') { console.log('§EPOCH_LOADED v2 (roster + key-epoch verification, content-aware — T1/W-ROSTER-VERIFY)'); }
+  if (typeof console !== 'undefined') { console.log('§EPOCH_LOADED v3 (roster + key-epoch verification + multi-device concurrent verify, content-aware — T1/W-ROSTER-VERIFY/W-MULTI-DEVICE-VERIFY)'); }
 })();

--- a/erp/erp_signer.js
+++ b/erp/erp_signer.js
@@ -74,15 +74,27 @@
 
   // installSigner — the one call the page makes on load: load-or-mint the edge key and hand the
   // kernel its signer. After this, sealChain signs each op_hash and verifyChain checks it.
+  // S8 (W-MULTI-DEVICE-VERIFY): the pubkey is exported BEFORE setSigner() so it can be passed as this
+  // device's own roster kid — KernelOps stamps it into every new v2 op's params as `signed_by`, letting
+  // a roster-gated verifier attribute the op to the device that actually signed it. Also exports the
+  // SAME public key as a JWK (API.pubKeyJwk) — erp_key_epochs.js's verify path (erp_snapshot_sign.js
+  // verifyTip) imports JWK, not the SPKI hex `signed_by` uses as the stable identity string; a device
+  // shares pubKeyJwk out-of-band (or via a future roster-distribution step, Phase 3, not this) so a peer
+  // can actually check its signature — the kid and the verifiable key material are deliberately separate.
   function installSigner(KernelOps, opts) {
     opts = opts || {};
     return loadOrMint(opts.dbName).then(function (kp) {
-      KernelOps.setSigner(makeSigner(kp));
-      return subtle.exportKey('spki', kp.publicKey).then(function (pub) {
-        API.pubKeyHex = _hex(pub);   // expose the edge pubKey so ctx can carry identity (ENGINE_CONTRACT §2)
+      return Promise.all([subtle.exportKey('spki', kp.publicKey), subtle.exportKey('jwk', kp.publicKey)]).then(function (r) {
+        API.pubKeyHex = _hex(r[0]);   // stable identity string (ENGINE_CONTRACT §2) — also the S8 roster kid
+        API.pubKeyJwk = r[1];         // verifiable key material for a roster-gated verifier
+        KernelOps.setSigner(makeSigner(kp), API.pubKeyHex);
         console.log('§SIGN installed alg=ECDSA-P256 pubkey=' + API.pubKeyHex.slice(0, 16) + '… custody=idb-nonextractable');
         return kp;
-      }).catch(function () { console.log('§SIGN installed alg=ECDSA-P256 custody=idb-nonextractable'); return kp; });
+      }).catch(function () {
+        KernelOps.setSigner(makeSigner(kp));   // pubkey export failed — still sign, just no roster kid
+        console.log('§SIGN installed alg=ECDSA-P256 custody=idb-nonextractable');
+        return kp;
+      });
     });
   }
 

--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -179,10 +179,16 @@
   // is NOT part of the hash, so the chain stays byte-identical across devices while sigs vary.
   var GENESIS = '0'.repeat(64);
   var _signer = null;   // optional { sign: async(hashHex)->sigHex, verify: async(hashHex,sigHex)->bool }
+  var _signerKid = null;   // optional: this device's own roster identity (its pubKeyHex) — see setSigner
 
   // Set an edge signer to turn on W-SIGN. Key custody lives at the edge (the device/merchant),
   // never in this module. Leave unset for W-CHAIN-only (tamper-evidence without signatures).
-  function setSigner(signer) { _signer = signer; }
+  // kid (optional) — Implementing ERP_MULTIUSER_CONCURRENCY_POC.md §DocAction Cross-Device Attribution S8
+  // — Witness: W-MULTI-DEVICE-VERIFY. This device's own roster identity (its pubKeyHex, from
+  // erp_signer.js installSigner()), stamped into every NEW v2 op's params as `signed_by` (see
+  // _stampSigv below) so a roster-gated verifier elsewhere can attribute the op to the device that
+  // actually signed it. Omit for W-SIGN-only (signing on, no cross-device attribution stamped).
+  function setSigner(signer, kid) { _signer = signer; _signerKid = kid || null; }
 
   // T2 (prompts/KERNEL_HARDENING_BATCH1_SPEC.md §NEXT SESSION, bim-compiler) — Witness: W-CONTENT-SIGN.
   // CONTENT-ADDRESSED SIGNING, additive-version (no flag-day, history never re-signed):
@@ -241,6 +247,11 @@
     if (_sigCanonical !== 2 || !params || typeof params !== 'object') return params;
     var out = {}; for (var k in params) if (Object.prototype.hasOwnProperty.call(params, k)) out[k] = params[k];
     out._sigv = 2;
+    // S8 (W-MULTI-DEVICE-VERIFY): stamp the signing device's own roster kid alongside _sigv:2 — a
+    // SIGNED fact (inside the v2-content-hashed payload), same additive pattern as _sigv itself. Only
+    // meaningful for v2 rows (a v1 sig can't survive a rebase/renumber regardless — attribution would
+    // be moot), so bundled into this same gate rather than a separate flag.
+    if (_signerKid) out.signed_by = _signerKid;
     return out;
   }
 


### PR DESCRIPTION
## Summary
Closes the loop opened by PR #930 and the guide's "opt-in per-step signing" callout: each device now signs its own edits with its own key, that signature survives a cross-device sync (#930), and this PR adds the piece that lets a peer actually *verify* it.

- `erp_key_epochs.js`'s existing `verifyEpochSigsOps` enforces a single `activeKid` per position — a key-rotation/revocation state machine, correct for its own job (Teams `importBranch`, one device handing off its key over time). Probed standalone before writing any production code: it **rejects a second concurrently-active device outright** with no `ROTATE` between them — exactly the shape two real devices' relay-merged commits produce. Wiring it onto the ERP-relay path as originally planned would have broken the N-device convergence this lane already proved works (`witness_e2e_n_converge.js`, N=10 clean).
- New `verifyMultiDeviceOps(ops, {roster, verify})`: per-op independent verification against a flat roster, no rotation state — the correct model for N simultaneously-valid devices. `ROTATE`/`REVOKE`/`verifyEpochSigsOps` are untouched.
- `setSigner(signer, kid)` takes an optional kid; `_stampSigv()` stamps `signed_by` alongside the existing `_sigv:2` marker (same additive seam, no new call sites). `erp_signer.js` now exports the device pubkey as both the stable hex kid and (new) JWK verification material.

## Scope
Roster **distribution** (two devices that have never met learning each other's keys automatically) is explicitly out of scope — the witness constructs the roster directly, same convention `witness_roster_verify.js` already uses for the Teams path. This PR proves the mechanism works and is forgery-resistant; wiring a live "share device key" UI is a separate follow-up.

## Test plan
- [x] `W-MULTI-DEVICE-VERIFY` (`bim-compiler scripts/witness_e2e_rebase_attrib.js`): 2 real `BrowserContext`s, real UI Save + real relay sync — both devices' post-sync ops correctly attributed to their real originating device; a tampered roster entry correctly rejected — exit 0, 37/37 🟢
- [x] Regression: `erp/tests/witness_roster_verify.js` (Teams path, untouched by this PR) re-run unmodified — exit 0, all pass, 0 🔴

🤖 Generated with [Claude Code](https://claude.com/claude-code)