### PR TITLE
fix(viewer): Nav LOD discoverable in Navigate drawer + 'o' shortcut

### DIFF
--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1397,7 +1397,9 @@ function setupPanels(A) {
       // FLY_TOUR_DLOD_SCALE.md §9: nav-scope DLOD pill — sibling of Fly Tour (must be reachable
       // during tours/orbit, unlike TM's tm-lod which dies with the TM panel). Same box glyph as
       // tm-lod. Default OFF; no-ops with a toast on <50k-element buildings (§DLOD_NAV_GATE).
-      { id: 'dlodnav',    name: 'Nav LOD (large bldgs)', pill: false,
+      // 2026-07-21 user feedback: key 'o' (bOx; 'b' is Background) + listed in Navigate drawer —
+      // v1 registered the entry but put it in NO drawer id-list, so the icon rendered nowhere.
+      { id: 'dlodnav',    name: 'Nav LOD (large bldgs)', key: 'o', pill: false,
         icon: '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>',
         fn: function() { if (typeof window.toggleDlodNav === 'function') window.toggleDlodNav(); },
         isActive: function() { return !!window._dlodNavOn; },
@@ -1675,7 +1677,7 @@ function setupPanels(A) {
     // §FLY_TO_NAVIGATE (2026-07-18, user ask): Fly Tour is camera navigation, not inspection — moved
     // from Inspect to Navigate. id/key/fn/isActive on the shared 'fly' entry above are unchanged;
     // this only changes which drawer lists it.
-    var _navigateDrawer = _buildMasterDrawer('navigate', 'Navigate', ['find', 'roleFilter', 'worldhist', 'docHist', 'home', 'walk', 'fly']);
+    var _navigateDrawer = _buildMasterDrawer('navigate', 'Navigate', ['find', 'roleFilter', 'worldhist', 'docHist', 'home', 'walk', 'fly', 'dlodnav']);
     var _inspectDrawer  = _buildMasterDrawer('inspect',  'Inspect',  ['measure', 'clash', 'xray', 'section', 'tm', 'report']);
     var _camviewDrawer  = _buildMasterDrawer('camview',  'Camera / View', ['precision', 'cam-reset', 'cam-pivot']);
 

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -896,6 +896,7 @@ async function setupScene(A) {
     'z':  function() { if (window.UniversalHistory && UniversalHistory.toggleOpen) UniversalHistory.toggleOpen(); }, // §UHIST: open/close the per-page timeline bar (Ctrl+Z = undo, bound in universal_history.js)
     'w':  function() { if (window.WholeHistory && WholeHistory.toggleOpen) WholeHistory.toggleOpen(); }, // §WHIST: open/close the cross-page World-history overlay (HISTORY_KNOB_DIAL.md)
     'l':  function() { if (typeof window.toggleFlyAround === 'function') window.toggleFlyAround(); },
+    'o':  function() { if (typeof window.toggleDlodNav === 'function') window.toggleDlodNav(); }, // FLY_TOUR_DLOD_SCALE.md §9: nav LOD boxes (bOx; plain o — Ctrl+O stays open-model)
     'v':  function() { if (typeof window.toggleSfx === 'function') window.toggleSfx(); },
     's':  function() { if (typeof A.screenshot === 'function') A.screenshot(); },
     'n':  function() { if (typeof window.toggleNightMode === 'function') window.toggleNightMode(); },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v836';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v837';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Follow-up to #935 (user feedback: "Cant find icon ... should give a shortcut key for box (is b used?)").

- v1 registered the 'dlodnav' action but listed it in NO drawer id-list → the icon rendered nowhere. Now in the **Navigate drawer**, right under Fly Tour.
- Shortcut **o** (bOx — 'b' is taken by Background); bound in scene.js `_shortcuts`; Ctrl+O (open model) untouched. Row label shows `Nav LOD (large bldgs) · o`.
- Smoke (§-logs): `§SHORTCUT_FIRE key=o` → `§DLOD_NAV_GATE ... verdict=too-small` on Duplex (correct no-op+toast); `§DRAWER_BUILD id=navigate` row `drawer-row-dlodnav` present. Input-registry audit pass=9 fail=0.
- sw CACHE_VERSION → v837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nFrp9J35tFknm8UM9jSLs