### PR TITLE
feat(rooms): §ROOM_WALKER_VERSION_STAMP stage 3 — HHS-only version-check pilot

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -891,6 +891,21 @@
       elAxisBar.appendChild(btn);
     }
 
+    // §ROOM_WALKER_VERSION_STAMP (ROOM_INJECTOR_NEEDLE.md) — shared lazy-loader for the
+    // room_walker.js port, used both by the version-check gate below and S2.2's actual compile,
+    // so the script is fetched at most once per page regardless of which caller needs it first.
+    async function _ensureRoomWalkerLoaded() {
+      if (window.RoomWalker) return;
+      await new Promise(function(resolve, reject) {
+        var s = document.createElement('script');
+        s.src = 'lib/room_walker.js?v=3'; // v3: §ROOM_WALKER_VERSION_STAMP stages 1+2 (ROOM_INJECTOR_NEEDLE.md)
+        s.onload = function() { resolve(); };
+        s.onerror = function() { reject(new Error('room_walker.js load failed')); };
+        document.head.appendChild(s);
+      });
+      if (!window.RoomWalker) throw new Error('RoomWalker unavailable after load');
+    }
+
     // ══ FLY_TOUR_CORRIDOR_GRAPH.md §S1 — A.ensureRooms: the ONE shared injection core ══
     // Extracted verbatim from _needleInject (ROOM_INJECTOR_NEEDLE.md S2+S3+S4's cache half) so the
     // Fly tour can run the SAME patch→walker→IDB sequence without forking it. Semantics:
@@ -938,8 +953,31 @@
                       _r0[3] >= _e0[2] && _r0[2] <= _e0[3];
           }
         } catch (eIf) { /* inFrame stays true */ }
-        if (inFrame) return { status: 'present', real: false };
-        console.warn('[NEEDLE] §NEEDLE_FRAME_STALE compiled rooms outside building extent — recompiling');
+        // §ROOM_WALKER_VERSION_STAMP stage 3 (ROOM_INJECTOR_NEEDLE.md) — HHS-ONLY PILOT. Before
+        // trusting an in-frame compiled set, check its stamped algorithm version against the
+        // current ROOM_WALKER_V. Missing rooms_meta (every building compiled before this shipped,
+        // including HHS's confirmed-stale 14-room set) or a version mismatch counts as stale, same
+        // treatment as §PATCH-FRAME-GUARD above. Scoped to HHS_Office_Federated_extracted.db only
+        // — the spec's own risk-cliff guidance is to watch ONE building settle to "recompute once,
+        // then stable, no repeat trigger" before trusting this fleet-wide. Loading room_walker.js
+        // here to read its version constant does NOT itself trigger a recompute (compileRooms is a
+        // separate call, made only in the S2.2 fall-through below) — cheap, cached after first hit.
+        var versionStale = false, storedV = null;
+        var _dbFileNow = (A.DB_URL || '').slice((A.DB_URL || '').lastIndexOf('/') + 1).split('?')[0];
+        if (inFrame && _dbFileNow === 'HHS_Office_Federated_extracted.db') {
+          try {
+            await _ensureRoomWalkerLoaded();
+            var _rmv = A.dbQuery("SELECT version FROM rooms_meta WHERE id=1");
+            storedV = _rmv.length ? _rmv[0][0] : null;
+            versionStale = storedV !== window.RoomWalker.ROOM_WALKER_V;
+          } catch (eV) { versionStale = true; /* no rooms_meta table = compiled before this shipped */ }
+          if (versionStale) {
+            console.warn('[NEEDLE] §NEEDLE_VERSION_STALE bld=HHS_Office_Federated stored=' + storedV +
+              ' current=' + (window.RoomWalker && window.RoomWalker.ROOM_WALKER_V) + ' — recompiling');
+          }
+        }
+        if (inFrame && !versionStale) return { status: 'present', real: false };
+        if (!inFrame) console.warn('[NEEDLE] §NEEDLE_FRAME_STALE compiled rooms outside building extent — recompiling');
       }
       var bld = A.activeBuilding || '';
       var url = A.DB_URL || '';
@@ -1017,16 +1055,7 @@
           // S2.2 — walker source (any building): lazy-load the room_walker JS port, compile
           // deterministically from walls/doors. Refuses honestly (roomsWritten=0) if the
           // building lacks them — never invents rooms.
-          if (!window.RoomWalker) {
-            await new Promise(function(resolve, reject) {
-              var s = document.createElement('script');
-              s.src = 'lib/room_walker.js?v=3'; // v3: §ROOM_WALKER_VERSION_STAMP stages 1+2 (ROOM_INJECTOR_NEEDLE.md)
-              s.onload = function() { resolve(); };
-              s.onerror = function() { reject(new Error('room_walker.js load failed')); };
-              document.head.appendChild(s);
-            });
-          }
-          if (!window.RoomWalker) throw new Error('RoomWalker unavailable after load');
+          await _ensureRoomWalkerLoaded();
           window.RoomWalker.walk(A.db, { write: true });
           source = applied ? 'patch+walker' : 'walker';
         }


### PR DESCRIPTION
## Summary
- `_ensureRoomsCore()`'s trust-check now compares stored `rooms_meta.version` against the loaded `room_walker.js`'s `ROOM_WALKER_V` before trusting a compiled room set — scoped to `HHS_Office_Federated_extracted.db` only, per `prompts/Viewer/ROOM_INJECTOR_NEEDLE.md`'s §ROOM_WALKER_VERSION_STAMP risk-cliff guidance (land on one building, watch it settle, before trusting fleet-wide).
- Missing `rooms_meta` (every building compiled before stage 2 shipped — bim-ootb#934) or a version mismatch falls through to the existing patch+walker recompute path, which stamps `rooms_meta` on completion, so the same building trusts on every later load until the algorithm version changes.
- Extracted the `room_walker.js` lazy-load into a shared `_ensureRoomWalkerLoaded()` helper (previously duplicated).
- Directly unblocks HHS's Alt+C dive-target fix: `cinema_maxq.js`/`effects.js` both call `A.ensureRooms({})` with no `force` during dive prep, so HHS's stale 14-room set is now replaced automatically.

## Test plan (headless Chromium, real `HHS_Office_Federated_extracted.db` fixture — 14 rooms, no `rooms_meta`, matching the confirmed-stale bug exactly)
- [x] First `ensureRooms({})` call: `§NEEDLE_VERSION_STALE` fires, recompiles 14 → 73 rooms, stamps `rooms_meta`, persists to IDB (75.7MB)
- [x] Same-session second call: trusts, zero recompute
- [x] 3 full page reloads against the same browser IndexedDB: reload 1 recompiles, reloads 2 and 3 both trust — "recompute once, then stable, no repeat trigger" per the spec's acceptance bar
- [x] Recompiled set carries current-algorithm classifications (SUSPECT_OPEN/SUSPECT_LARGE/INTERNAL) the stale compile predates, including a 281.6m² Level 3 room the pre-fix compile never saw — the class of room the already-shipped cinema-space-enclosed-skip filter (#933) needs present to pick a real dive target
- [x] `node --check viewer/navigate_find.js` — syntax OK

## Known residual risk (named in the spec, not solved here)
No cross-tab lock on the shared IDB cache slot — two tabs both self-healing HHS simultaneously could race on the persist write. Pre-existing risk for the manual needle button; stage 3 only changes when the same path triggers. Left unaddressed per the spec's pilot framing — worth monitoring before widening past HHS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrveBhsavqNFKEN5DPxp3k