### PR TITLE
feat(viewer): status-bar message when Nav LOD (o) toggles ON/OFF

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -371,6 +371,17 @@
     _rafId = requestAnimationFrame(_tick);
   }
 
+  // 2026-07-21 user ask: momentary status-bar confirmation on toggle (same convention as Fly's
+  // "Fly stopped." — A.status.textContent). Auto-clears after 5s ONLY if nothing overwrote it.
+  var _statusClearT = null;
+  function _statusMsg(app, msg) {
+    if (!app || !app.status) return;
+    app.status.textContent = msg;
+    if (_statusClearT) clearTimeout(_statusClearT);
+    _statusClearT = setTimeout(function () {
+      if (app.status.textContent === msg) app.status.textContent = '';
+    }, 5000);
+  }
   window.toggleDlodNav = function () {
     var app = A();
     if (!_pillOn) {
@@ -381,6 +392,7 @@
       }
       _pillOn = true; window._dlodNavOn = true;
       console.log('§DLOD_NAV_TOGGLE on=true');
+      _statusMsg(app, 'Nav LOD ON — boxing far elements (o to turn off)');
       if (!_rafId) _rafId = requestAnimationFrame(_tick);
     } else {
       _pillOn = false; window._dlodNavOn = false;
@@ -388,6 +400,7 @@
       if (_engaged) { _restoreAll(app, 'pill-off'); _engaged = false; }
       _disposeBoxes();
       console.log('§DLOD_NAV_TOGGLE on=false');
+      _statusMsg(app, 'Nav LOD OFF — full detail restored');
     }
     if (app && app.markDirty) app.markDirty();
   };

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v838';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v839';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
User ask: "there should be status message to say when 'o' is ON.. and when it is OFF at least on the status bar momentarily".

- ON: `Nav LOD ON — boxing far elements (o to turn off)`; OFF: `Nav LOD OFF — full detail restored` — same `A.status.textContent` convention as Fly's "Fly stopped."
- Auto-clears after 5s only if nothing else overwrote it (other status writers keep priority).
- Witness `§STATUS_SMOKE onShown=true offShown=true` + clean 5s clear, LTU on real GPU.
- sw CACHE_VERSION → v839.

Note for the in-flight dlod_nav.js session: this adds a `_statusMsg` helper + two calls inside `toggleDlodNav` — tiny surface, rebase with `git merge origin/main` if you touch the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nFrp9J35tFknm8UM9jSLs