### PR TITLE
feat(viewer): 'o' DLOD-nav warms rooms via existing ensureRooms path (idle-deferred)

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -382,6 +382,27 @@
       _pillOn = true; window._dlodNavOn = true;
       console.log('§DLOD_NAV_TOGGLE on=true');
       if (!_rafId) _rafId = requestAnimationFrame(_tick);
+      // §DLOD_NAV_ROOMS: a >50k-element building crossing the nav-LOD gate is the same "about to
+      // navigate seriously" signal Fly Tour already treats as "make sure rooms are fresh"
+      // (tour.js's A._prepareGraphTour: A.loadNavigate() then A.ensureRooms()) — reuses that exact
+      // call, not a fork. Deferred via requestIdleCallback (same idiom as effects.js's staffage
+      // preload and navigate_find.js's ghost-shell build) rather than fired immediately: measured
+      // live, loadNavigate()'s 10-script chain contends hard with an in-flight geometry-streaming
+      // pipeline on exactly the large buildings this gate targets — firing it the instant 'o' is
+      // pressed risks competing with the box-proxy's own frame budget for the one thing DLOD-nav
+      // exists to protect. Idle-deferred, this only warms rooms up opportunistically once the main
+      // thread is actually free, for whatever Find/Fly/Cinema feature runs next.
+      if (app && app.loadNavigate) {
+        var _warmRooms = function() {
+          app.loadNavigate().then(function() {
+            return app.ensureRooms ? app.ensureRooms({}) : null;
+          }).then(function(res) {
+            if (res) console.log('§DLOD_NAV_ROOMS status=' + res.status + ' source=' + (res.source || 'none') + ' rooms=' + (res.rooms != null ? res.rooms : '-'));
+          }).catch(function(e) { console.warn('§DLOD_NAV_ROOMS_ERR ' + (e && e.message)); });
+        };
+        if (window.requestIdleCallback) window.requestIdleCallback(_warmRooms, { timeout: 8000 });
+        else setTimeout(_warmRooms, 5000);
+      }
     } else {
       _pillOn = false; window._dlodNavOn = false;
       if (_rafId) { cancelAnimationFrame(_rafId); _rafId = null; }


### PR DESCRIPTION
## Summary
- Confirmed `dlod_nav.js` (the `'o'`-shortcut nav-LOD box-proxy) is room-blind by design today — zero references to `ensureRooms`/`RoomWalker`/`room_graph`. Unlike Fly Tour, Find panel, and Cinema/MaxQ (which all reach `A.ensureRooms()` before doing their own thing), the `'o'` toggle never warmed up compiled rooms.
- `toggleDlodNav()`'s engage branch now fires the exact same `A.loadNavigate()` → `A.ensureRooms({})` call `tour.js`'s `A._prepareGraphTour()` already uses — **reuse, not a fork**.
- Deferred via `requestIdleCallback` (same idiom already used in `effects.js`'s staffage preload and `navigate_find.js`'s ghost-shell build), not fired immediately.

## Why idle-deferred, not immediate
Measured live (headless Chromium, LTU_AHouse, 122,330 elements — the exact building class this gate targets): firing `loadNavigate()` immediately on 'o' press took 50-100+ seconds to resolve, dominated by main-thread contention with LTU_AHouse's own in-flight geometry-streaming pipeline (per-script instrumentation showed uneven multi-second gaps between small file loads, consistent with a starved main thread, not slow scripts). Firing this the instant 'o' is pressed risked competing with the box-proxy's own frame budget — the one thing DLOD-nav exists to protect.

## Test plan
- [x] `node --check viewer/dlod_nav.js` — syntax OK
- [x] Headless witness (LTU_AHouse, 122,330 elements): `toggleDlodNav()` returns synchronously (3ms), `§DLOD_NAV_TOGGLE on=true` fires immediately, unaffected by the room warm-up
- [x] Confirmed via `git status` that no shared state/logic in the box-proxy tick loop was touched — only the engage branch gained a deferred, independent call

## Known limitation — not resolved here
The 50-100s figure was measured under headless Chromium with SwiftShader software rendering (no real GPU available in this environment) — PR #935's own witness used an RTX 4060 for the same building at 17ms/frame, so this is likely a severe overestimate of real-hardware cost, not a real-world benchmark. What's hardware-independent: `loadNavigate()`'s script execution is single-threaded JS work sharing the main thread with the streaming/promote pipeline (CPU-bound, not GPU-bound) — some contention is real on any hardware, just probably far less severe. A real-GPU re-measurement (the machine used for W-DLOD-NAV-PERF) would close this out properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrveBhsavqNFKEN5DPxp3k