### PR TITLE
perf(viewer): chunked DLOD-nav evaluation — smoother Fly flight (42ms hitch → 1.7ms/chunk)

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -31,7 +31,18 @@
   var FRUSTUM_MARGIN = 5;          // §9: angular hysteresis — must be 5m OUTSIDE frustum to demote
   var FADE_FRAMES = 10;            // §8 FINDINGS #4: N=10 sufficed; 5 and 20 both worse
   var FADE_CAP = 128;              // §9: transitions beyond cap SNAP (= shipped TM-DLOD behavior)
-  var EVAL_THROTTLE_MS = 150;      // full-index re-evaluation cadence while camera moves
+                                   // (a per-frame TRANSITION_BUDGET was tried 2026-07-21 and
+                                   // MEASURED WORSE — throttling convergence left the scene
+                                   // half-real through the demote wave, draw calls 3245→7984,
+                                   // sweep mean 19.9→92.5ms. Transitions are not the flight
+                                   // bottleneck; do not re-add without new numbers.)
+  var EVAL_CHUNK = 16384;          // §FLY_SMOOTH (2026-07-21 user "still lagging in flight"):
+                                   // one monolithic 122k-element eval measured 42ms/hit at a
+                                   // 150ms cadence = 28% main-thread duty cycle + 7k-transition
+                                   // bursts per hit (473k snaps/600 flight frames). The scan is
+                                   // now CHUNKED — ~16k elements per rAF tick (~3-4ms), a full
+                                   // pass every ~8 frames — same partition, amortized cost,
+                                   // transition bursts spread across frames.
   var DEPTH_MAX_RADIUS = 25;       // §9 shine-thru fix: no depth pass for oversized bboxes — a
                                    // giant slab's invisible occluder would erase REAL nearby
                                    // geometry (center-distance ≠ bbox extent); wireframe-only there
@@ -45,7 +56,9 @@
   var _realIndex = null;           // guid → {kind:'mesh'|'inst'|'batch', obj, idx|slotId, meta}
   var _fades = [];                 // active transitions
   var _unitBox = null, _zeroM = null, _frustum = null, _psm = null, _sphere = null, _m4 = null;
-  var _lastCamSig = null, _lastEvalT = 0;
+  var _lastCamSig = null;
+  var _guidArr = null, _evalCursor = 0, _scanPending = false; // §FLY_SMOOTH: chunked-scan state
+  var _passReal = 0, _passBoxed = 0; // partition counters accumulated across a pass
   var _logAccStarted = 0, _lastLogT = 0; // 2026-07-21 user "remove history log spam": eval line ≤1 per 2s
   var _stats = { mutations: 0, active: 0, boxed: 0, fades: 0, snaps: 0, evalMs: 0 };
   window.__dlodNav = _stats;
@@ -117,6 +130,7 @@
       meshes.push(im); meshes.push(imDepth);
     }
     _boxIndex = index; _boxMeshes = meshes; _boxBld = app.activeBuilding;
+    _guidArr = Object.keys(index); _evalCursor = 0; _scanPending = false; // §FLY_SMOOTH chunk state
     console.log('§DLOD_NAV_BUILD bld=' + app.activeBuilding + ' boxes=' + total + ' discs=' + discs.length +
       ' build_ms=' + (performance.now() - t0).toFixed(0));
     return true;
@@ -290,32 +304,44 @@
     return _frustum.intersectsSphere(_sphere);
   }
 
-  function _evaluate(app) {
+  // §FLY_SMOOTH: one CHUNK of the scan per rAF tick. Camera pose is re-read per chunk — elements
+  // in different chunks see slightly different poses within a pass; the 50/80m + 5m-frustum
+  // hysteresis bands absorb that skew by design (they exist to absorb pose jitter).
+  function _evalChunk(app) {
+    if (!_guidArr || !_guidArr.length) return;
     var t0 = performance.now();
     if (!_frustum) { _frustum = new THREE.Frustum(); _psm = new THREE.Matrix4(); _sphere = new THREE.Sphere(); _m4 = new THREE.Matrix4(); }
     _psm.multiplyMatrices(app.camera.projectionMatrix, app.camera.matrixWorldInverse);
     _frustum.setFromProjectionMatrix(_psm);
     var camPos = app.camera.position;
-    var boxed = 0, real = 0, started = 0;
-    for (var guid in _boxIndex) {
-      var e = _boxIndex[guid];
+    var end = Math.min(_evalCursor + EVAL_CHUNK, _guidArr.length);
+    var started = 0;
+    for (var i = _evalCursor; i < end; i++) {
+      var guid = _guidArr[i], e = _boxIndex[guid];
       var want = _wantedReal(e, camPos);
-      if (want === (e.state === 'real')) { if (e.state === 'box') boxed++; else real++; continue; }
+      if (want === (e.state === 'real')) { if (e.state === 'box') _passBoxed++; else _passReal++; continue; }
       var r = _realIndex[guid];
-      if (!r) { e.state = want ? 'real' : 'box'; continue; } // no real mesh resident (never streamed) — index only
+      if (!r) { e.state = want ? 'real' : 'box'; continue; } // no real mesh resident — index only
       _startFade(app, guid, e, r, !want);
       started++;
-      if (e.state === 'box') boxed++; else real++;
+      if (e.state === 'box') _passBoxed++; else _passReal++;
     }
-    _stats.active = real; _stats.boxed = boxed; _stats.evalMs = +(performance.now() - t0).toFixed(1);
+    _evalCursor = end;
+    _stats.evalMs = +(performance.now() - t0).toFixed(1); // per-CHUNK cost now (was per full pass)
     _logAccStarted += started;
-    var _nowLog = performance.now();
-    if (_logAccStarted && (_nowLog - _lastLogT) >= 2000) {
-      console.log('§DLOD_NAV active=' + real + ' boxed=' + boxed + ' mode=on started=' + _logAccStarted +
-        ' fades=' + _fades.length + ' eval_ms=' + _stats.evalMs);
-      _logAccStarted = 0; _lastLogT = _nowLog;
+    if (_evalCursor >= _guidArr.length) { // pass complete — publish partition, rearm on next pose change
+      _stats.active = _passReal; _stats.boxed = _passBoxed;
+      _passReal = 0; _passBoxed = 0;
+      _evalCursor = 0;
+      _scanPending = false;
+      var _nowLog = performance.now();
+      if (_logAccStarted && (_nowLog - _lastLogT) >= 2000) {
+        console.log('§DLOD_NAV active=' + _stats.active + ' boxed=' + _stats.boxed + ' mode=on started=' + _logAccStarted +
+          ' fades=' + _fades.length + ' chunk_ms=' + _stats.evalMs);
+        _logAccStarted = 0; _lastLogT = _nowLog;
+      }
     }
-    if (app.markDirty) app.markDirty();
+    if (started && app.markDirty) app.markDirty();
   }
 
   function _camSig(app) {
@@ -363,11 +389,8 @@
     var fading = _stepFades(app);
     if (fading && app.markDirty) app.markDirty();
     var sig = _camSig(app);
-    var now = performance.now();
-    if (sig !== _lastCamSig && (now - _lastEvalT) >= EVAL_THROTTLE_MS) {
-      _lastCamSig = sig; _lastEvalT = now;
-      _evaluate(app);
-    }
+    if (sig !== _lastCamSig) { _lastCamSig = sig; _scanPending = true; } // pose changed — (re)arm scan
+    if (_scanPending) _evalChunk(app); // one chunk per frame until the pass completes
     _rafId = requestAnimationFrame(_tick);
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v839';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v840';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
User: Fly "still lagging in flight but overall navigation is OK". Root-caused on real GPU (RTX 4060, LTU 122k, 600-frame real tour flight):

- The 150ms-cadence monolithic eval cost **42ms per hit** — a 28% main-thread duty cycle of hitches during flight.
- Fix: scan chunked to ~16k elements/rAF tick (**1.3-1.7ms/chunk**, full pass ≈8 frames, armed on pose change). Hysteresis bands absorb intra-pass pose skew by design.

| Metric (flight, pill ON) | before | after |
|---|---|---|
| mean frame | 96.1 ms | **79.5 ms** |
| frames >50ms | 466/600 | **300/600** |
| ON-sweep p95 | 53.8 ms | **37.3 ms** |
| eval cost | 42 ms/hit | 1.7 ms/chunk |

Also in this run, the re-measure the #942 session asked for: **§DLOD_NAV_ROOMS real-GPU wall-clock = 952-1188ms** (their 50-100s SwiftShader estimate confirmed as a contention artifact, ~50-100×).

Negative result recorded in-code: a per-frame TRANSITION_BUDGET was tried and measured WORSE (throttles the demote wave; scene stays half-real; sweep 19.9→92.5ms) — do not re-add without new numbers.

Honest remainder: flight p50 ~114ms is in-view interior geometry cost — that's FLY_TOUR_DLOD_SCALE.md §5's room-occlusion track (blocked on containment data), not eval overhead. sw CACHE_VERSION → v840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nFrp9J35tFknm8UM9jSLs