### PR TITLE
fix(erp): cleanVals lets hook-derived CREATE fields ride the op

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -157,9 +157,22 @@
     if (type === 'number' || type === 'fk') return Number(val);
     return String(val);
   }
-  function cleanVals(entry, values) {
+  // ON CREATE ONLY: also carry any hook-derived, undeclared column already merged into `values` (saveForm's
+  // fireBeforeSaveHooks callback, crud_overlay.js ~line 1242) — a beforeSave default with no form field (e.g.
+  // M_Warehouse_ID) must still persist on the new row. gatherVals() only ever seeds `values` from entry.fields,
+  // so any OTHER key present is provably hook-derived, never stray UI state. UPDATE keeps the tight declared-only
+  // guard (unchanged) since that path never merges undeclared keys into `values` in the first place.
+  function cleanVals(entry, values, verb) {
     var out = {};
-    (entry.fields || []).forEach(function (f) { var c = coerce(f.type, values[f.col]); if (c != null) out[f.col] = c; });
+    var declared = {};
+    (entry.fields || []).forEach(function (f) { declared[f.col] = true; var c = coerce(f.type, values[f.col]); if (c != null) out[f.col] = c; });
+    if (verb === 'create' && values) {
+      Object.keys(values).forEach(function (k) {
+        if (declared[k]) return;
+        var v = values[k];
+        if (v != null && v !== '') out[k] = v;
+      });
+    }
     return out;
   }
 
@@ -209,7 +222,7 @@
     ctx = ctx || {};
     var base = { key: entry.key, table: entry.key, verb: verb, ownerGated: !!entry.ownerGated, op_uuid: ctx.opUuid || null };
     if (verb === 'create') {
-      base.op_type = 'CRUD_CREATE'; base.fields = cleanVals(entry, values); base.cas = entry.cas || null;
+      base.op_type = 'CRUD_CREATE'; base.fields = cleanVals(entry, values, verb); base.cas = entry.cas || null;
       // Task 1 — iDempiere setStandardDefaults parity: carry actor+tenant onto the op; listTip materialises them
       var _cActor = ctx.actor != null ? ctx.actor : sessionActor();
       var _cCid   = ctx.clientId != null ? ctx.clientId : sessionClientId();


### PR DESCRIPTION
## Summary
- `cleanVals()` in `erp/crud_overlay.js` only copied keys declared in an entry's `crud_ops.json` field list, so a `beforeSave` hook's derived-but-undeclared column (e.g. `c_order`'s `M_Warehouse_ID`, which has no form field) was correctly merged into `vals` at save time but silently stripped back out inside `buildOp('create')`, never reaching the signed `CRUD_CREATE` op.
- Fix: on CREATE only, `cleanVals` now also passes through any undeclared key already present in `values` — provably scoped to hook-derived columns, since `gatherVals()` never seeds `values` from anything else. `buildOp`'s one call site now passes `verb` through.

## Test plan
- [x] `node --check erp/crud_overlay.js`
- [x] `scripts/witness_e2e_business_cycle.js` (bim-compiler) re-run against this worktree: `M_Warehouse_ID=NaN` → `M_Warehouse_ID=103`; Generate Shipments moves from `dispatched=N reason=param-validation-failed` to `dispatched=Y`
- [x] No regression: Stage 1 (SalesOrder) still PASS, Stage 6 (PurchaseOrder, same create path) still PASS with identical derived-field set

Full findings: `prompts/ERP_BUSINESS_CYCLE_E2E.md` §Fix 2026-07-21 (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)