### PR TITLE
fix(viewer): MaxQ waits for geometry streaming before baking (§MAXQ_STREAM_FIRST)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -331,6 +331,29 @@
     _active = true; _cancel = false;
     A._maxqActive = true;   // mirror for the cinema icon's busy/done check (panels.js)
     _wakeAcquire();
+    // §MAXQ_STREAM_FIRST (user report, LTU_AHouse/122k: preview correctly showed boxes for speed,
+    // but the bake should auto-switch to solid — investigation found the boxes were NOT a
+    // deliberate LOD choice: dlod_nav.js already fully disengages the instant A._maxqActive is set
+    // above, every frame, so it can't be the source. cinema_maxq.js had zero references to
+    // A.streaming — the boxes are the geometry-streaming pipeline's own unpromoted-element
+    // placeholders bleeding through because nothing waited for them. Same fix as tour.js's
+    // §FLY_STREAM_WAIT, reused not reinvented: wait for streaming to fully drain BEFORE the preview
+    // even starts, so neither the preview nor the bake ever shows a placeholder — a mid-clip switch
+    // would still visibly pop in the baked video, waiting first avoids that entirely.)
+    var _streamWaitedMs = 0;
+    while (A.streaming && !_cancel) {
+      _status('🎬 Waiting for geometry to finish streaming…');
+      await new Promise(function(r) { setTimeout(r, 500); });
+      _streamWaitedMs += 500;
+    }
+    if (_streamWaitedMs) console.log('§MAXQ_STREAM_WAIT ms=' + _streamWaitedMs);
+    if (_cancel) {
+      console.log('§MAXQ_CANCEL during stream-wait — nothing baked, nothing saved');
+      _status('🎬 MaxQ cancelled');
+      _active = false; _cancel = false; A._maxqActive = false;
+      _wakeRelease();
+      return;
+    }
     // §CINEMA_PATH: fly the SAME orbit-path formula as the live-capture Cinema Orbit (push-in to
     // fill-frame → hold → band, sun-glint swoop, elliptical radius, pull-back flourish) — shared
     // plan from effects.js. Fallback: plain circle at current radius/height if the plan API is


### PR DESCRIPTION
## Summary
User report: on LTU_AHouse (122k elements), the 10s MaxQ preview correctly showed boxes for speed, but the bake should have auto-switched to solid geometry — it didn't. Investigation ruled out `dlod_nav.js` (already fully disengages the instant `A._maxqActive` is set, every frame) — `cinema_maxq.js` had zero references to `A.streaming` at all. The boxes are the geometry-streaming pipeline's own unpromoted-element placeholders bleeding through, because nothing waited for streaming to finish on large buildings still mid-stream when Alt+C is pressed.

Reuses the exact pattern `tour.js`'s `§FLY_STREAM_WAIT` already established for Fly Tour: wait for `A.streaming` to fully drain **before** the preview even starts, rather than trying to detect and switch mid-flight (which would still visibly pop in the baked video).

## Test plan
- [x] `node --check viewer/cinema_maxq.js` — syntax OK
- [x] Headless witness (HHS fixture, `A.streaming` forced true/false to test the gate deterministically — real 122k-element streaming under SwiftShader software rendering is too slow to reliably exercise here): waits while `streaming=true`, logs `§MAXQ_STREAM_WAIT ms=<n>` once cleared, proceeds to `§MAXQ_PREVIEW`
- [x] Cancel-during-wait: a second Alt+C press aborts cleanly with `§MAXQ_CANCEL during stream-wait`, nothing baked/saved

## Not verified here
Real-hardware timing on an actual >50k-element building mid-stream (same real-GPU gap noted in bim-ootb#942) — the gate logic itself is proven, the real-world wait duration on real hardware is not measured in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrveBhsavqNFKEN5DPxp3k