### PR TITLE
fix(rooms): port containment storey-alias fix to room_walker.js (JS twin)

### DIFF
--- a/viewer/lib/room_walker.js
+++ b/viewer/lib/room_walker.js
@@ -24,7 +24,7 @@
   // constant in scripts/compile_rooms.py (py/js parity discipline). 'v2' continues the existing
   // lib/room_walker.js?v=2 loader lineage rather than restarting at an arbitrary v1.
   // Stage 2 writes it to rooms_meta after each compile; nothing reads it yet (stage 3).
-  var ROOM_WALKER_V = 'v2 (§LOCAL-FRAME + §RASTER-EPS, post-§SUSPECT-LARGE)';
+  var ROOM_WALKER_V = 'v3 (§LOCAL-FRAME + §RASTER-EPS + §CONTAINMENT-ALIAS, post-§SUSPECT-LARGE)';
 
   var RES = 0.20;          // grid cell size (m)
   var MIN_AREA = 4.0;      // m^2 — drop slivers / wall cavities
@@ -159,6 +159,21 @@
       if (d < bd) { bd = d; best = anchorNames[i]; }
     }
     return best;
+  }
+
+  // §CONTAINMENT-ALIAS (bim-compiler CONTAINMENT_LTU_STOREY_ALIAS.md, py+js parity —
+  // ROOM_WALKER_PHASE_INVARIANCE convention): each discipline's source IFC spells the same
+  // physical floor differently (ARC "VÅNING N", STR "VÅN N", MEP "Plan N"/"Storey N" — measured
+  // via Z-band clustering, LTU_AHouse: all four spellings' center_z bands match for the same N).
+  // Rooms are detected ARC-only, so the containment join must canonicalize BOTH sides onto one
+  // key or every non-ARC element is silently excluded (LTU: 83.7% of elements are MEP, zero
+  // matched before this). Returns null for anything that isn't a known numbered-floor form
+  // (Unknown/TAKPLAN/Ref./etc.) — never guessed here, Z-band resolved in the caller instead.
+  var FLOOR_ALIAS_RE = /^(?:V[ÅA]NING|V[ÅA]N|PLAN|STOREY)\s*0*([0-9]+)$/i;
+  function _canonicalFloor(storey) {
+    if (!storey) return null;
+    var m = FLOOR_ALIAS_RE.exec(String(storey).trim());
+    return m ? ('F' + m[1]) : null;
   }
 
   function storeyWalls(db, vertMin, anchors) {
@@ -1290,19 +1305,47 @@
       db.run('CREATE TABLE rel_contained_in_space (space_guid TEXT, element_guid TEXT)');
     }
     db.run("DELETE FROM rel_contained_in_space WHERE space_guid LIKE 'RM\\_%' ESCAPE '\\'");
-    var els = _rows(db, "SELECT m.guid g, m.storey st, t.center_x ex, t.center_y ey FROM elements_meta m " +
+    var els = _rows(db, "SELECT m.guid g, m.storey st, t.center_x ex, t.center_y ey, t.center_z ez FROM elements_meta m " +
       "JOIN element_transforms t ON t.guid=m.guid WHERE t.center_x IS NOT NULL");
     var byst = {};
+    // §CONTAINMENT-ALIAS: per-canonical-floor Z anchor, built from the (ARC-only) rooms' own cz —
+    // lets a non-numbered storey label (Unknown/TAKPLAN/Ref.) be Z-band resolved to its nearest
+    // real floor, same nearest-anchor technique as _assignByZ above, keyed on canonical floors
+    // rather than raw ARC storey strings (those don't exist yet for the other disciplines).
+    var floorAnchorsAcc = {};
+    allrooms.forEach(function (r) {
+      if (r.suspect) return;
+      var cf = _canonicalFloor(r.storey);
+      if (cf !== null) (floorAnchorsAcc[cf] = floorAnchorsAcc[cf] || []).push(r.cz);
+    });
+    var floorAnchors = {};
+    Object.keys(floorAnchorsAcc).forEach(function (cf) {
+      var v = floorAnchorsAcc[cf];
+      floorAnchors[cf] = v.reduce(function (s, x) { return s + x; }, 0) / v.length;
+    });
+    var floorAnchorNames = Object.keys(floorAnchors).sort();
+    function _joinKey(storey, cz) {
+      var cf = _canonicalFloor(storey);
+      if (cf !== null) return cf;
+      if (cz === null || cz === undefined || !floorAnchorNames.length) return storey; // unresolvable — raw fallback, no regression
+      var best = null, bd = Infinity;
+      for (var i = 0; i < floorAnchorNames.length; i++) {
+        var d = Math.abs(cz - floorAnchors[floorAnchorNames[i]]);
+        if (d < bd) { bd = d; best = floorAnchorNames[i]; }
+      }
+      return best;
+    }
     // §ROOM-FORM: SUSPECT rooms get no element containment — an unreviewed corridor/void must not
     // capture elements away from real rooms.
     allrooms.forEach(function (r) {
       if (r.suspect) return;
-      (byst[r.storey] = byst[r.storey] || []).push(r);
+      var k = _joinKey(r.storey, r.cz);
+      (byst[k] = byst[k] || []).push(r);
     });
     var relStmt = db.prepare('INSERT INTO rel_contained_in_space (space_guid, element_guid) VALUES (?,?)');
     var rel = 0;
     els.forEach(function (e) {
-      var candidates = byst[e.st] || [];
+      var candidates = byst[_joinKey(e.st, e.ez)] || [];
       for (var i = 0; i < candidates.length; i++) {
         var r = candidates[i];
         // §MULTI-RECT: contained iff inside ANY of the room's rects; the rel row keys the

--- a/witness_containment_alias_js.js
+++ b/witness_containment_alias_js.js
@@ -1,0 +1,68 @@
+// witness_containment_alias_js.js — parity check for the room_walker.js port of
+// bim-compiler's CONTAINMENT_LTU_STOREY_ALIAS.md fix (§CONTAINMENT-ALIAS).
+// Mirrors bim-compiler/scripts/witness_containment_alias.py exactly, against the JS engine
+// that actually runs client-side. PASS = same shape as the Python result: total containment
+// rows increase, MEP disciplines that were zero become non-zero, room rect count unchanged,
+// zero SUSPECT-room leakage.
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+
+const SRC = process.argv[2] || '/home/red1/bim-compiler/deploy/buildings/LTU_AHouse_extracted.db';
+const BASE_REF = process.argv[3] || 'origin/main';
+
+function byDiscipline(db) {
+  const q = (sql) => db.exec(sql);
+  const rows = q(`SELECT m.discipline, COUNT(*) c FROM rel_contained_in_space rcs
+                  JOIN elements_meta m ON m.guid = rcs.element_guid GROUP BY m.discipline`);
+  const byDisc = {};
+  if (rows.length) rows[0].values.forEach(([d, c]) => { byDisc[d] = c; });
+  const total = q(`SELECT COUNT(*) FROM rel_contained_in_space`)[0].values[0][0];
+  const rects = q(`SELECT COUNT(*) FROM spatial_structure WHERE type='IfcSpace' AND guid LIKE 'RM\\_%' ESCAPE '\\'`)[0].values[0][0];
+  const suspectLeak = q(`SELECT COUNT(*) FROM rel_contained_in_space rcs
+                          JOIN spatial_structure ss ON ss.room_guid = rcs.space_guid
+                          WHERE ss.predefined_type LIKE 'SUSPECT_%'`)[0].values[0][0];
+  return { total, rects, suspectLeak, byDisc };
+}
+
+(async () => {
+  const SQL = await initSqlJs();
+  const buf = fs.readFileSync(SRC);
+
+  // ORIGINAL: fetch pre-fix room_walker.js from BASE_REF, load into an isolated vm-like require
+  const tmp = '/tmp/wt-containment-alias-js/.witness-scratch';
+  fs.mkdirSync(tmp, { recursive: true });
+  const origPath = path.join(tmp, 'room_walker_ORIGINAL.js');
+  execSync(`git -C /home/red1/bim-ootb show ${BASE_REF}:viewer/lib/room_walker.js > ${origPath}`);
+  delete require.cache[require.resolve(origPath)];
+  const RoomWalkerOriginal = require(origPath);
+
+  delete require.cache[require.resolve('/tmp/wt-containment-alias-js/viewer/lib/room_walker.js')];
+  const RoomWalkerCurrent = require('/tmp/wt-containment-alias-js/viewer/lib/room_walker.js');
+
+  const dbBefore = new SQL.Database(new Uint8Array(buf));
+  RoomWalkerOriginal.walk(dbBefore, { write: true });
+  const b = byDiscipline(dbBefore);
+
+  const dbAfter = new SQL.Database(new Uint8Array(buf));
+  RoomWalkerCurrent.walk(dbAfter, { write: true });
+  const a = byDiscipline(dbAfter);
+
+  console.log('BEFORE: total=' + b.total + ' rects=' + b.rects + ' suspectLeak=' + b.suspectLeak + ' byDisc=' + JSON.stringify(b.byDisc));
+  console.log('AFTER:  total=' + a.total + ' rects=' + a.rects + ' suspectLeak=' + a.suspectLeak + ' byDisc=' + JSON.stringify(a.byDisc));
+
+  const wasZero = Object.keys(a.byDisc).filter(d => !b.byDisc[d]);
+  const newNonzeroMep = wasZero.filter(d => a.byDisc[d] > 0 && d !== 'ARC' && d !== 'STR');
+
+  const pass = a.total > b.total && newNonzeroMep.length > 0 &&
+               a.rects === b.rects && a.suspectLeak === 0 && b.suspectLeak === 0;
+
+  if (pass) {
+    console.log(`PASS — containment rows ${b.total} -> ${a.total}, newly-covered: ${JSON.stringify(newNonzeroMep)}, rects unchanged (${a.rects}), zero suspect leakage`);
+  } else {
+    console.log(`FAIL — total ${b.total}->${a.total}, newNonzeroMep=${JSON.stringify(newNonzeroMep)}, rects ${b.rects}->${a.rects}, suspectLeak b=${b.suspectLeak} a=${a.suspectLeak}`);
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+  process.exit(pass ? 0 : 1);
+})().catch(e => { console.log('CRASH: ' + (e.stack || e.message)); process.exit(1); });


### PR DESCRIPTION
## Summary
- bim-compiler PR #55 fixed `compile_rooms.py`'s `rel_contained_in_space` join (keyed on exact storey-string equality, silently excluding non-ARC disciplines whose source IFC spells the same floor differently — ARC "VÅNING N" vs STR "VÅN N" vs MEP "Plan N"/"Storey N"). That fix alone never reaches real users: `room_walker.js` is the client-side engine that actually compiles rooms for whatever building a user loads (`A.ensureRooms`, the needle self-heal path), and it had the identical bug.
- Ports the fix verbatim: `_canonicalFloor()` + a `_joinKey()` closure, same regex, same Z-band fallback technique the file already uses for Unknown-storey reassignment.
- `ROOM_WALKER_V` bumped v2→v3 so the existing stage-3 version-stamp self-heal (`§NEEDLE_VERSION_STALE`) recompiles any already-loaded building once it goes stale — **no DB redistribution/OCI upload needed**, this is exactly the propagation mechanism the version stamp exists for.

## Test plan
- [x] `witness_containment_alias_js.js` (sql.js, mirrors the Python witness exactly): LTU_AHouse containment rows 314 → 30,409 — **identical** numbers and per-discipline breakdown to the Python fix.
- [x] Regression: HHS_Office_Federated, Duplex, SampleHouse, Terminal — byte-identical before/after, matching the Python regression results.
- [x] `node --check viewer/lib/room_walker.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)