### PR TITLE
feat(viewer): log active CACHE_VERSION at page onset (§BUILD_VERSION)

### DIFF
--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -1018,6 +1018,17 @@ if('serviceWorker' in navigator){
   navigator.serviceWorker.register('sw.js?v=532')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
+  // §BUILD_VERSION_STAMP: log the ACTIVE (controlling) service worker's CACHE_VERSION at page
+  // onset — a one-line answer to "is this tab running the latest deploy" without hunting for a
+  // later feature-specific log line. No controller yet = this load isn't SW-controlled (first
+  // visit, or the SW just updated and hasn't taken over) — reload once to get a controller.
+  if(navigator.serviceWorker.controller){
+    var _bvCh=new MessageChannel();
+    _bvCh.port1.onmessage=function(ev){console.log('§BUILD_VERSION '+(ev.data&&ev.data.version||'?')+' (sw-controlled)')};
+    navigator.serviceWorker.controller.postMessage({type:'GET_PRECACHE'},[_bvCh.port2]);
+  } else {
+    console.log('§BUILD_VERSION (no active controller yet — reload once to confirm)');
+  }
 }
 // §S283: Capture beforeinstallprompt early — scene.js reads window._installPrompt
 window._installPrompt = null;


### PR DESCRIPTION
## Summary
- User request while live-testing today's deploys: a one-line, at-load answer to "is this tab running the latest build," instead of hunting for a feature-specific log line that may or may not fire in a given session.
- Reuses the existing `GET_PRECACHE` message-channel handler in `sw.js` (already returns `CACHE_VERSION`, previously only queried on the manual "check for updates" click) — now also fires automatically right after service-worker registration on every page load.
- Logs `§BUILD_VERSION v<n> (sw-controlled)` when a controller is active, or a "no active controller yet — reload once" note on the very first uncontrolled load (fresh install / just-updated SW hasn't taken over yet).

## Test plan
- [x] Headless (puppeteer, fresh profile then reload): load 1 (no controller) → the reload-once note; load 2 (SW controlling) → `§BUILD_VERSION v840 (sw-controlled)`, matching `sw.js`'s `CACHE_VERSION` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)