### PR TITLE
fix(viewer): NEEDLE_VERSION_STALE/FRAME_STALE log at console.log, not warn

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -973,12 +973,17 @@
             versionStale = storedV !== window.RoomWalker.ROOM_WALKER_V;
           } catch (eV) { versionStale = true; /* no rooms_meta table = compiled before this shipped */ }
           if (versionStale) {
-            console.warn('[NEEDLE] §NEEDLE_VERSION_STALE bld=' + (_dbFileNow || A.activeBuilding) + ' stored=' + storedV +
+            // §LOG-CLARITY (2026-07-21, live confusion found via user testing): this line was
+            // console.warn — invisible whenever DevTools' console filter has "Warnings" unchecked,
+            // which made a real, correctly-firing recompile look like it never ran. Every other
+            // step of this same pipeline (§NEEDLE_INJECT/§NEEDLE_STAMP/§NEEDLE_PERSIST below) is
+            // console.log; matching that here removes the filter-dependent blind spot.
+            console.log('[NEEDLE] §NEEDLE_VERSION_STALE bld=' + (_dbFileNow || A.activeBuilding) + ' stored=' + storedV +
               ' current=' + (window.RoomWalker && window.RoomWalker.ROOM_WALKER_V) + ' — recompiling');
           }
         }
         if (inFrame && !versionStale) return { status: 'present', real: false };
-        if (!inFrame) console.warn('[NEEDLE] §NEEDLE_FRAME_STALE compiled rooms outside building extent — recompiling');
+        if (!inFrame) console.log('[NEEDLE] §NEEDLE_FRAME_STALE compiled rooms outside building extent — recompiling');
       }
       var bld = A.activeBuilding || '';
       var url = A.DB_URL || '';


### PR DESCRIPTION
## Summary
- Found live while testing today's fixes on Hospital: `§NEEDLE_VERSION_STALE`/`§NEEDLE_FRAME_STALE` were logged via `console.warn`, invisible whenever DevTools' console filter has "Warnings" unchecked — a real, correctly-firing recompile looked like it never ran.
- Both downgraded to `console.log`, matching the rest of this same pipeline (`§NEEDLE_INJECT`/`§NEEDLE_STAMP`/`§NEEDLE_PERSIST`) — these are normal/expected events on this path, not warnings.

## Test plan
- [x] `node --check viewer/navigate_find.js`
- [x] Confirmed live on Hospital (production trace, not headless): the full NEEDLE chain now visible at `console.log` level end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)