### PR TITLE
fix(erp): C_Order.DeliveryRule/InvoiceRule derive real AD_Column defaults

### DIFF
--- a/erp/ad_modelval.js
+++ b/erp/ad_modelval.js
@@ -151,6 +151,22 @@
         }
         return null;
       }],
+      ['MOrder.deliveryInvoiceRuleDefault', function (ctx, info) {
+        // §DR-IR-LAST-MILE (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-21, "DeliveryRule/InvoiceRule undeclared") —
+        // NOT a beforeSave line in real MOrder.java: DeliveryRule/InvoiceRule are AD_Column DefaultValue
+        // fields, applied at NEW-record time by the window layer, not by the model's beforeSave. This engine
+        // has no such "apply AD_Column default at NEW" seam yet, and c_order's crud_ops.json entry (like
+        // M_Warehouse_ID/IsSOTrx above) declares no visible field for either — genShipmentLines/
+        // genInvoiceLines (ad_process.js) silently treat an undefined rule as "named-deferred", so every
+        // freshly-created order produced zero shippable/invoiceable lines regardless of DocStatus/IsSOTrx/
+        // Warehouse all being correct. Values are the REAL AD_Column.DefaultValue rows for C_Order in the
+        // seed (queried live: DeliveryRule='F' Force, InvoiceRule='I' Immediate — confirmed, not assumed;
+        // Availability was the initial guess and would have been WRONG).
+        var r = info.record;
+        if (!r.deliveryrule) d(info).deliveryrule = 'F';
+        if (!r.invoicerule) d(info).invoicerule = 'I';
+        return null;
+      }],
       ['MOrder.paymentTermDefault', function (ctx, info) {   // :1315-1327  IsDefault='Y' payment term
         var r = info.record;
         if (!Number(r.c_paymentterm_id)) {


### PR DESCRIPTION
## Summary
- `c_order`'s `crud_ops.json` entry declares no `deliveryrule`/`invoicerule` field, and no hook derived either — so `genShipmentLines()`/`genInvoiceLines()` (`ad_process.js`) silently treated every freshly-created order's undefined rule as "named-deferred," producing zero shippable/invoiceable lines regardless of DocStatus/IsSOTrx/Warehouse all being correct (PRs #944/#948/#953).
- Fix: new `MOrder.deliveryInvoiceRuleDefault` beforeSave hook fills both when unset, using the REAL `AD_Column.DefaultValue` rows for `C_Order` in the seed (queried live, not assumed) — `DeliveryRule='F'` (Force), `InvoiceRule='I'` (Immediate). Matches the same "curated subset, hook fills the mandatory rest" convention already used for `M_Warehouse_ID`/`IsSOTrx`.

## Test plan
- [x] `node --check erp/ad_modelval.js`
- [x] `scripts/witness_e2e_business_cycle.js` (bim-compiler): both Stage 1 (SO) and Stage 6 (PO) now derive `deliveryrule:"F" invoicerule:"I"` (previously absent from both)
- [x] No regression

Full findings: `prompts/ERP_BUSINESS_CYCLE_E2E.md` §Fix 2026-07-21/22 (bim-compiler repo). Verifying this fix also surfaced a SEPARATE, deeper bug — a freshly-created order LINE's `C_Order_ID` gets a stale/wrong value (the currently-selected seed order, not the new order) at create time, distinct from the already-fixed W-SO-CHILD-BIND (which only fixed the grid-filter level, not order-line-creation itself) — named in the doc, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)