### PR TITLE
fix(erp): child-tab New forms seed their locked parent-link FK with the real parent pk

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -1207,6 +1207,26 @@
         console.log('§CRUD-LIST col=' + f.col + ' cur="' + cur + '" options=' + lo.length + ' selected="' + (sel || '(first)') + '"');
       } else if (f.type === 'fk' && typeof withBundle === 'function') {
         var keep = el.value;
+        // §ORDERLINE-PARENT-FK (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22) — a readonly fk (a child tab's
+        // locked parent-link column, e.g. C_OrderLine.C_Order_ID, or any other read-only fk) must KEEP its
+        // seeded/current value verbatim. The full LIST query below is scoped to the raw base table and can
+        // NEVER include a synthetic/overlay-only row (a freshly created parent, negative pk) — repopulating
+        // from it silently replaced a correct-but-unmatched value with whichever row sorted first (the
+        // actual root cause of the order-line-gets-a-stale-parent bug). Look up just THIS row's friendly
+        // label instead of the full list; if the pk isn't a real base row (synthetic), fall back to showing
+        // the raw value — correct, just not pretty, same degrade-gracefully convention used elsewhere.
+        if (f.readonly) {
+          if (keep === '' || keep == null) return;
+          withBundle(function (db) {
+            try {
+              var t = f.ref, pk = t + '_id', nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
+              var res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + ' WHERE ' + pk + '=' + Number(keep));
+              var label = (res.length && res[0].values.length) ? (res[0].values[0][1] + ' (' + res[0].values[0][0] + ')') : keep;
+              el.innerHTML = '<option value="' + esc(keep) + '" selected>' + esc(label) + '</option>';
+            } catch (er) {}
+          });
+          return;
+        }
         withBundle(function (db) {
           try {
             var t = f.ref, pk = t + '_id', nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
@@ -1420,6 +1440,11 @@
       if (!e || !CORE.verbEnabled(e, 'create')) { console.log('§INPLACE-NEW table=' + key + ' skipped (create not permitted)'); if (typeof opts.onUnsupported === 'function') opts.onUnsupported(); return; }
       var vals = CORE.defaultsFor(e, today());
       _seedDocNoPreview(e, vals);
+      // §ORDERLINE-PARENT-FK (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22) — opts.seedVals lets the host
+      // (idempiere.html, for a child tab's locked parent-link column) inject a value defaultsFor() has no
+      // way to know — AD_Column.DefaultValue is empty for a parent-link FK by convention (it's set
+      // programmatically, never via a column default). Optional; every other caller is unaffected.
+      if (opts.seedVals) { var _sk = Object.keys(opts.seedVals); for (var _si = 0; _si < _sk.length; _si++) vals[_sk[_si]] = opts.seedVals[_sk[_si]]; }
       renderInline('create', e, vals, null, null, host, opts);
     });
   }

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -2812,6 +2812,26 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         window.APP = window.APP || {};
         var _wc = tab.whereClause && /\bIsSOTrx\s*=\s*'([YN])'/i.exec(tab.whereClause);
         window.APP._createIsSOTrx = _wc ? _wc[1].toUpperCase() : null;
+        // §ORDERLINE-PARENT-FK (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22, "order-LINE stale parent FK") —
+        // a child tab's (tabLevel>0) New form has a locked/readonly parent-link column (e.g.
+        // C_OrderLine.C_Order_ID) but nothing ever seeded its value with the actual parent record's pk:
+        // defaultsFor() only resolves AD_Column.DefaultValue (empty here, by real iDempiere convention —
+        // the parent link is set programmatically, never via a column default), so the field rendered
+        // empty, then populateRefs()'s FK dropdown (never matching that empty value against any real row)
+        // silently fell through to whichever row sorts first — an ARBITRARY, WRONG parent order. Reuses the
+        // SAME naming-convention parent-column resolution renderActiveTab() already uses for GRID filtering
+        // (pKey = the parent tab's own key column name, matched by identity against the child table — real
+        // iDempiere's GridTab.getLinkColumnName() convention) to seed the value BEFORE the form renders.
+        var seedVals = null, _lvl = tab.tabLevel || 0;
+        if (_lvl > 0) {
+          var _w = _curWin(), _pIdx = -1;
+          for (var _pi = _activeTabIdx - 1; _pi >= 0; _pi--) { if ((_w.tabs[_pi].tabLevel || 0) === _lvl - 1) { _pIdx = _pi; break; } }
+          if (_pIdx >= 0) {
+            var _pTab = _w.tabs[_pIdx], _pKey = _keyCol(_pTab), _pPk = _selByLevel[_lvl - 1];
+            if (_pPk != null && _pKey && _colExists(tab.tableName, _pKey)) { seedVals = {}; seedVals[_pKey.toLowerCase()] = _pPk; }
+          }
+        }
+        if (seedVals) opts.seedVals = seedVals;
         if (copyFrom != null) window.__crud.copyInline(tn, copyFrom, nmount, opts);
         else window.__crud.createInline(tn, nmount, opts);
       });


### PR DESCRIPTION
## Summary
- A child tab's (tabLevel>0) New form has a locked/readonly parent-link column (e.g. `C_OrderLine.C_Order_ID`) but nothing ever seeded its value with the actual parent record's pk. The field rendered empty, then `populateRefs()`'s FK-dropdown re-population (never matching that empty value against any real row) silently fell through to whichever row the raw base-table query happened to list first — confirmed live: a line created under a fresh Sales Order (id `-1`) landed with `c_order_id=100`, an unrelated pre-existing seed order.
- Same class of bug `W-SO-CHILD-BIND` (#928) already fixed once, but a separate, deeper instance — that fix closed the gap at the GRID-FILTER level; this is the child row's own STORED FK value at CREATE time.
- Fix: `buildForm()` computes the parent-link column via the same naming-convention resolution `renderActiveTab()` already uses for grid filtering, and seeds it through a new optional `opts.seedVals` on `createInline()`. `populateRefs()` no longer blindly repopulates a READONLY fk select from the raw base table (which can never include a synthetic/overlay-only parent) — it looks up just that one row's friendly label instead.

## Test plan
- [x] Syntax check on both touched files
- [x] `scripts/witness_e2e_business_cycle.js` (bim-compiler): Generate-Shipments now computes a REAL line for the fresh order (`dispatched=Y ok=Y rows=1`, was `rows=0`) — confirms the order line's own data (product/qty/parent) is now fully correct end-to-end
- [x] No regression

Full findings: `prompts/ERP_BUSINESS_CYCLE_E2E.md` §Fix 2026-07-22 (bim-compiler repo). Verifying this fix surfaced the actual remaining blocker for Stage 2/3: Generate-Shipments/Invoices compute a correct result but there is no wiring anywhere that commits it to the op-log — `renderProcResult()` is read-only display, `applyOp`/`commitCrud` are never called for a Generate-process result. Confirmed via grep (zero hits) rather than assumed. This is a missing feature, not a bug fix, and is out of scope here — named in the doc as the next, much larger frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)