### PR TITLE
fix(staffage): Alt+P camera-room avoidance — dd floor + lateral-fan scaling

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -1798,8 +1798,22 @@ async function setupEffects(A, renderer, scene, camera) {
     var ifcFloorZ = floorYval + A.modelOffset.z;
     var aisleGrid = _buildOccupancyGrid(ifcFloorZ - 0.3, ifcFloorZ + 2.0);
     var walkCand = [], _np = new THREE.Vector3(), aisleWalkTried = 0, aisleRejectedInObject = 0;
-    for (var dd = 4; dd <= 13; dd += 3) {
-      for (var lat = -4.5; lat <= 4.5; lat += 3) {
+    // §STAFFAGE_CAMROOM (2026-07-22): floor was 4m, which in a small/typical room lands past the far
+    // wall or inside _CLR_PERSON clearance of it, emptying the candidate pool and reading as "avoids
+    // the camera's own room" (prompts/PHOTOREAL_STILL_RENDER.md §SPEC ONLY — Issue 1). Lowered the
+    // floor to 1.5m and widened the step so the SAME 5-band spread still reaches all the way to 13m
+    // (was 4 bands, 4/7/10/13 — a bare `dd=1.5` with the old step-3 would have DROPPED the 13m band
+    // instead of adding a near one, net-losing far-room reach). _spaceOK()'s existing clearance check
+    // still rejects anything actually too close to camera/geometry — no new camera-avoidance rule.
+    for (var dd = 1.5; dd <= 13; dd += 2.875) {
+      // §STAFFAGE_CAMROOM_FAN: lat's old fixed ±4.5m span was tuned for the far band (dd=13, a
+      // ~19° half-angle off dead-ahead) — reused verbatim at dd=1.5 it demands a 72° swing, which
+      // fails the frustum test on EVERY sample (confirmed live: walkTried/rejectedInObject came out
+      // byte-identical before/after the dd-floor-only fix — the new near band contributed zero
+      // candidates). Scale the lateral fan with dd so every band keeps roughly the SAME angular
+      // cone as the proven far band, instead of a fixed metric width that only works far out.
+      var _latMax = dd * (4.5 / 13);
+      for (var lat = -_latMax; lat <= _latMax; lat += Math.max(_latMax * 0.66, 0.1)) {
         var wx = cam.x + fwd.x * dd + rightV.x * lat, wz = cam.z + fwd.z * dd + rightV.z * lat;
         _np.set(wx, floorYval + 1.0, wz).project(A.camera);
         if (Math.abs(_np.x) > 0.85 || Math.abs(_np.y) > 0.9 || _np.z < -1 || _np.z > 1) continue;

--- a/witness_one_spot.js
+++ b/witness_one_spot.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// One spot, one phase, one process — avoids whatever caused repeated in-process browser
+// relaunches to hang (2nd+ puppeteer.launch() in the same node process reliably stalled).
+// Usage: node witness_one_spot.js <before|after> <A|B|C>
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs = require('fs');
+const path = require('path');
+const PORT = 8493;
+const EFFECTS = path.join(__dirname, 'viewer/effects.js');
+const DD_FIXED = '    for (var dd = 1.5; dd <= 13; dd += 2.875) {';
+const DD_OLD = '    for (var dd = 4; dd <= 13; dd += 3) {';
+const LAT_FIXED = '      var _latMax = dd * (4.5 / 13);\n      for (var lat = -_latMax; lat <= _latMax; lat += Math.max(_latMax * 0.66, 0.1)) {';
+const LAT_OLD = '      for (var lat = -4.5; lat <= 4.5; lat += 3) {';
+
+const HHS_SPOTS = {
+  A: { eye3: [-6.65, -4.82, 15.82], target3: [3.35, -4.82, 15.82] },
+  B: { eye3: [-6.65, -4.82, 20.78], target3: [-6.65, -4.82, 10.78] },
+  C: { eye3: [-12.78, -4.82, 17.47], target3: [-12.78, -4.82, 27.47] },
+};
+
+const phase = process.argv[2], spotName = process.argv[3];
+if (!['before', 'after'].includes(phase) || !HHS_SPOTS[spotName]) {
+  console.error('usage: node witness_one_spot.js <before|after> <A|B|C>'); process.exit(1);
+}
+const spot = HHS_SPOTS[spotName];
+
+function ensurePhase(target) {
+  const src = fs.readFileSync(EFFECTS, 'utf8');
+  const isFixed = src.includes(DD_FIXED) && src.includes(LAT_FIXED);
+  const isOld = src.includes(DD_OLD) && src.includes(LAT_OLD);
+  if (!isFixed && !isOld) throw new Error('file in neither known state — drifted, aborting');
+  if (target === 'before' && isFixed) {
+    fs.writeFileSync(EFFECTS, src.replace(DD_FIXED, DD_OLD).replace(LAT_FIXED, LAT_OLD));
+  } else if (target === 'after' && isOld) {
+    fs.writeFileSync(EFFECTS, src.replace(DD_OLD, DD_FIXED).replace(LAT_OLD, LAT_FIXED));
+  }
+}
+
+(async () => {
+  ensurePhase(phase);
+  console.log('on-disk: ' + fs.readFileSync(EFFECTS, 'utf8').split('\n').filter(l => l.includes('for (var dd') || l.includes('for (var lat')).join(' | '));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox',
+           '--enable-unsafe-swiftshader', '--disable-dev-shm-usage'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  const lines = [];
+  page.on('console', m => { const t = m.text(); if (/§/.test(t)) lines.push(t); });
+  page.on('pageerror', e => lines.push('PAGEERROR ' + e.message));
+
+  const url = `http://localhost:${PORT}/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db&bld=HHS_Office_Federated&cb=${Date.now()}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  const streamed = await page.waitForFunction(() => {
+    const A = window.APP || window.A;
+    if (!A || !A.scene) return false;
+    let n = 0; A.scene.traverse(o => { if (o.isMesh || o.isInstancedMesh || o.isBatchedMesh) n++; });
+    return n > 50 ? n : false;
+  }, { timeout: 90000, polling: 3000 }).then(h => h.jsonValue()).catch(() => 0);
+  console.log('streamed: ' + streamed);
+  if (!streamed) { await browser.close(); console.log('RESULT err=no geometry streamed'); process.exit(1); }
+  await new Promise(r => setTimeout(r, 12000));
+
+  await page.evaluate((spot) => {
+    const A = window.APP || window.A, THREE = window.THREE;
+    A.camera.position.set(...spot.eye3);
+    A.camera.lookAt(new THREE.Vector3(...spot.target3));
+    A.camera.updateMatrixWorld(true);
+    if (A.controls) { A.controls.target.set(...spot.target3); A.controls.update(); }
+  }, spot);
+
+  await page.evaluate(() => { const A = window.APP || window.A; A.togglePopulate(); });
+  await new Promise(r => setTimeout(r, 6000));
+
+  const distances = await page.evaluate(() => {
+    const A = window.APP || window.A;
+    const camPos = A.camera.position;
+    const ds = [];
+    A.scene.traverse(o => { if (o.userData && o.userData.interior === true) ds.push(+camPos.distanceTo(o.position).toFixed(2)); });
+    return ds.sort((a, b) => a - b);
+  });
+
+  await browser.close();
+  const interiorLine = lines.filter(l => /§PHOTO_STAFFAGE_INTERIOR/.test(l)).pop() || null;
+  console.log('interiorLine: ' + interiorLine);
+  console.log('distances: ' + JSON.stringify(distances));
+  console.log(`RESULT phase=${phase} spot=${spotName} ${interiorLine} distances=${JSON.stringify(distances)}`);
+  process.exit(0);
+})().catch(e => { console.error('SCRIPT ERROR', e); process.exit(1); });


### PR DESCRIPTION
## Summary
- `_updateInFrameInterior()`'s aisle-candidate search (`viewer/effects.js`) had a 4m forward-distance floor that landed candidates past a small room's far wall — the reported "Alt+P avoids placing pax in my own room" behavior.
- Lowering the floor alone was proven inert: the candidate search's lateral fan (±4.5m) was a fixed metric width tuned for the far band; reused at the new near band it demanded a 72° off-axis swing that the frustum test rejected on every sample (confirmed live — walkTried/rejectedInObject came out byte-identical before/after a floor-only change).
- Fixed both together: dd floor lowered to 1.5m (step widened so the same 5-band spread still reaches 13m), and the lateral fan now scales with `dd` to keep a constant angular cone at every distance.
- No new "avoid camera" rule added — `_spaceOK()`'s existing clearance check still does all real rejection work.

Full write-up: `prompts/PHOTOREAL_STILL_RENDER.md` §"Issue 1 (Alt+P camera-room avoidance) — FIXED" (bim-compiler repo).

## Test plan
- [x] `node witness_one_spot.js <before|after> <A|B|C>` against real HHS_Office_Federated geometry, 3 genuinely tight rooms discovered via grid-scan + raycast (nearestWall 0.8-1.3m)
- [x] Spot B (nearestWall=1.3m): nearest placed pax 8.35m → 1.68m — clear win
- [x] Spots A/C (nearestWall 0.8-1.0m): pool size unchanged (no regression) — likely a physical limit at that tightness, not chased further
- [x] `node -c viewer/effects.js` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)