### PR TITLE
fix(room-graph): utility-room routing penalty in shared Dijkstra weighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ erp/tests/*.png
 erp/tests/*.log
 modeller/tests/*.png
 tests/*.png
+
+# W-UTIL-PENALTY witness regenerates this from a pinned SHA — never commit it
+common/_room_graph_before.js

--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -79,9 +79,30 @@
   // §G3-REVISED (PATH_LEGAL_SEGMENTS.md) — pack/unpack + lookup for the offline-precomputed
   // per-storey walkable raster (scripts/build_storey_walkable_raster.js). Dual-mode like this file.
   var StoreyRaster = (typeof module !== 'undefined' && module.exports) ? require('./storey_raster.js') : ROOT.StoreyRaster;
+  // §UTILITY-ROUTING-PENALTY (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10, 2026-07-22) — the utility-room
+  // classifier, dual-mode loaded exactly like HallwayBackbone/StoreyRaster above. Reused (not
+  // reinvented) from common/room_habitability.js `classifyUtilityRooms()` — the SAME real element-
+  // composition signal (ACMV IfcFlowSegment duct-dominance or pure IfcFooting) already used by the
+  // Type-lens display (viewer/navigate_find.js), batched for perf (proven safe on Hospital's 311
+  // rooms). buildGraph() below uses it to TAG utility room nodes; _buildAdjacency() applies a
+  // routing-cost penalty (NOT removal) to any edge touching one — see UTILITY_EDGE_PENALTY.
+  var RoomHabitability = (typeof module !== 'undefined' && module.exports) ? require('./room_habitability.js') : ROOT.RoomHabitability;
 
   // Ported verbatim from scripts/compile_rooms.py — see file header. Not a new number.
   var DOOR_BUFFER_SLACK = 0.20;
+  // §UTILITY-ROUTING-PENALTY: cost multiplier applied in _buildAdjacency() to any weighted edge
+  // that touches a utility-classified room node (node.isUtility). This is the "penalise, prefer
+  // circulation" design target VIEWER_FIND_PANEL_ROOM_ACCURACY.md §9/§10 named — a cabling/service
+  // room stays REACHABLE (a maintenance-access "find path to the closet" query still resolves, just
+  // costs more), but ordinary room→room routing never treats it as an equal-weight circulation hop.
+  // Value chosen (not tuned to a fixture): real room-center-to-room-center edges in these buildings
+  // run ~3–12m and a corridor alternative "a few hops longer" adds ~10–40m; ×8 makes even a single
+  // ~5m utility hop cost ~40m, and a THROUGH-route (two touching edges, entry+exit, both penalised)
+  // cost ~80m — reliably losing to any realistic corridor detour a few hops longer — while staying
+  // finite (a multiplier, never Infinity/edge-removal, so reachability is preserved per §10's own
+  // "do NOT hard-exclude" requirement). A path whose destination IS the utility room pays the
+  // penalty on only its single arrival edge, which is fine/expected.
+  var UTILITY_EDGE_PENALTY = 8;
   // §DOOR-NOT-ROOM ported verbatim from scripts/compile_rooms.py NON_ROOM_DOOR_NAMES.
   var NON_ROOM_DOOR_NAMES = ['liftdeur', 'lift', 'elevator', 'aufzug', 'fahrstuhl', 'hoist'];
   function isRoomDoor(name) {
@@ -302,6 +323,40 @@
         if (corridorRoomsInjected || corridorRoomsSkippedOverlap) log('§CORRIDOR_ROOM_BACKPROP injected=' + corridorRoomsInjected +
           ' skippedOverlap=' + corridorRoomsSkippedOverlap + ' / ' + backbone.joined.length + ' joined buckets');
       } catch (eBb0) { log('§CORRIDOR_ROOM_BACKPROP_ERR ' + eBb0.message); backbone = null; }
+    }
+
+    // §UTILITY-ROUTING-PENALTY (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10, 2026-07-22): classify every
+    // real room node by real element COMPOSITION (RoomHabitability.classifyUtilityRooms — see the
+    // require's own comment) and TAG utility rooms with node.isUtility. _buildAdjacency() then
+    // penalises (never removes) any edge touching a tagged node, so ordinary room→room routing
+    // prefers a corridor over cutting through a cabling/service room while keeping it reachable.
+    // Descriptor shape ({guid,cx,cy,sx,sy,storey}) mirrors navigate_find.js's two existing call
+    // sites; sx/sy are derived here from each logical room's UNION rect bbox (§MULTI-RECT aware —
+    // an L-shaped room's several sub-rects collapse to one covering box, same as a single-rect
+    // room degenerates to its own rect), with the box center used for cx/cy so the descriptor is
+    // self-consistent for the classifier's element range-scan. Batched call — 2 SQL queries total
+    // regardless of room count (the Hospital-311 perf fix baked into classifyUtilityRooms).
+    // Defensive: module absent / query error → no tags, penalty never fires, graph unchanged.
+    var utilityRoomCount = 0;
+    if (RoomHabitability && RoomHabitability.classifyUtilityRooms) {
+      try {
+        var utilDescs = roomOrder.map(function (lg) {
+          var g = nodes[lg];
+          var minx = Infinity, maxx = -Infinity, miny = Infinity, maxy = -Infinity;
+          g.rects.forEach(function (rc) {
+            if (rc.x0 < minx) minx = rc.x0; if (rc.x1 > maxx) maxx = rc.x1;
+            if (rc.y0 < miny) miny = rc.y0; if (rc.y1 > maxy) maxy = rc.y1;
+          });
+          return { guid: lg, cx: (minx + maxx) / 2, cy: (miny + maxy) / 2,
+            sx: maxx - minx, sy: maxy - miny, storey: g.storey };
+        });
+        var utilMap = RoomHabitability.classifyUtilityRooms(utilDescs, dbQuery) || {};
+        Object.keys(utilMap).forEach(function (guid) {
+          if (nodes[guid]) { nodes[guid].isUtility = true; nodes[guid].utilityWhy = utilMap[guid]; utilityRoomCount++; }
+        });
+        if (utilityRoomCount) log('§ROOM_GRAPH_UTILITY utilityRooms=' + utilityRoomCount +
+          ' (routing penalty x' + UTILITY_EDGE_PENALTY + ' on touching edges, not removed)');
+      } catch (eUtil) { log('§ROOM_GRAPH_UTILITY_ERR ' + eUtil.message); }
     }
 
     var doorRows = [];
@@ -804,6 +859,15 @@
         w = (typeof e.w === 'number') ? e.w : Math.hypot(
           graph.nodesByGuid[a].cx - graph.nodesByGuid[b].cx, graph.nodesByGuid[a].cy - graph.nodesByGuid[b].cy);
       }
+      // §UTILITY-ROUTING-PENALTY (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10): an edge with a utility-
+      // classified room at EITHER end (tagged in buildGraph, see UTILITY_EDGE_PENALTY's comment)
+      // costs UTILITY_EDGE_PENALTY× its real distance — so Dijkstra prefers a corridor route a few
+      // hops longer over cutting through a cabling/service room, yet the room stays reachable (a
+      // finite multiplier, never removed). Both shortestPath() and escapeRoute() consume this
+      // adjacency, so both inherit the preference (an emergency exit route also shouldn't thread a
+      // service room when a corridor exists). No-op on every graph with no utility-tagged node.
+      var na = graph.nodesByGuid[a], nb = graph.nodesByGuid[b];
+      if ((na && na.isUtility) || (nb && nb.isUtility)) w *= UTILITY_EDGE_PENALTY;
       adj[a].push({ to: b, w: w, e: e, arriveSide: 'b' });
       adj[b].push({ to: a, w: w, e: e, arriveSide: 'a' });
     });

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -152,7 +152,10 @@ async function initViewer() {
         // v4 (2026-07-15, §ISLAND_BRIDGE): ambiguous-residual-candidate rescue (E9) + circ-per-chain
         // bridge (E6) — a returning browser's cached v3 would keep reporting the pre-fix island counts.
         // v5 (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-16): expose chordIllegalCount witness helper.
-        '../common/room_graph.js?v=5',
+        // v6 (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10, 2026-07-22): §UTILITY-ROUTING-PENALTY — buildGraph()
+        // tags utility rooms via RoomHabitability.classifyUtilityRooms; _buildAdjacency() penalises
+        // (x8, never removes) any edge touching one so room→room routing prefers corridors.
+        '../common/room_graph.js?v=6',
         // §HALLWAY-BACKBONE-NOT-LOADED (2026-07-14, real bug found via live browser check — every
         // corridor/spine/Hall-Corridor-label feature built this session had been silently no-oping
         // in the browser, despite passing every Node-based witness, because this line never

--- a/witness_room_graph_utility_penalty.js
+++ b/witness_room_graph_utility_penalty.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-UTIL-PENALTY scope (READ THE LOG after every run)
+ * SCOPE: common/room_graph.js §UTILITY-ROUTING-PENALTY (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10,
+ * 2026-07-22). buildGraph() tags utility rooms via RoomHabitability.classifyUtilityRooms();
+ * _buildAdjacency() multiplies (never removes) any edge touching a tagged node by
+ * UTILITY_EDGE_PENALTY (=8). Both shortestPath() and escapeRoute() consume that adjacency.
+ *
+ * ISSUES THIS PROVES / DISPROVES (each check names its issue):
+ *   A1 CLASSIFY-WIRED  — real Clinic: classifyUtilityRooms is actually called from buildGraph and
+ *                        tags the 7 utility rooms onto the graph's own room nodes (node.isUtility).
+ *   A2 STRUCTURAL-FINDING (honest) — on ALL current real fixtures every utility-classified room is a
+ *                        DOORLESS sealed void (classifyUtilityRooms excludes any room with a nearby
+ *                        door; graph edges REQUIRE a nearby door), so those rooms carry ZERO routing
+ *                        edges and the penalty is a present-day NO-OP for them. Reported, not hidden —
+ *                        the screenshot's door-carrying through-hop rooms are NOT flagged by this
+ *                        classifier by design (§10 point 4). Follow-up named in the doc.
+ *   B1 MULTIPLIER-MATH — a directly-connected real room pair's shortest-path distance is exactly
+ *                        ×UTILITY_EDGE_PENALTY when one endpoint is tagged utility (the weighting is
+ *                        the real multiplier, computed from real center-to-center distance).
+ *   B2 REROUTE / B2b COST+REACHABLE — a real Clinic through-hop room, force-tagged utility (the
+ *                        "clearest available real-data reproduction" §10's witness section asks for,
+ *                        since no real utility room has an edge): a room→room query that USED it as a
+ *                        mid-hop now AVOIDS it when a corridor/alternative exists (B2), or — when it is
+ *                        the only route — still resolves at higher cost, never null (B2b). Proves both
+ *                        "prefer circulation" AND "stays reachable".
+ *   B3 REACHABLE-AS-DEST — a path whose DESTINATION is the (force-tagged) utility room still returns a
+ *                        valid non-null result (single arrival-edge penalty), never unreachable.
+ *   C  NO-REGRESSION    — a building with no utility rooms in play (Duplex): NEW module's paths are
+ *                        byte-identical (path array + distance) to the origin/main "before" module.
+ *
+ * RUN: node witness_room_graph_utility_penalty.js   (from the worktree root)
+ */
+'use strict';
+const path = require('path');
+const fs = require('fs');
+const cp = require('child_process');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+// "before" = room_graph.js at the pinned pre-change commit (origin/main at dispatch). Regenerated
+// on demand next to the live siblings so its own require('./storey_raster.js') etc. resolve; the
+// file is gitignored (never committed). Pinning a SHA keeps this deterministic across future merges.
+const BEFORE_SHA = '0269cec';
+const BEFORE_PATH = path.join(__dirname, 'common', '_room_graph_before.js');
+if (!fs.existsSync(BEFORE_PATH)) {
+  fs.writeFileSync(BEFORE_PATH, cp.execSync('git show ' + BEFORE_SHA + ':common/room_graph.js', { cwd: __dirname, maxBuffer: 1 << 24 }));
+}
+const RG = require('./common/room_graph.js');                 // NEW (under test)
+const RGbefore = require('./common/_room_graph_before.js');   // origin/main "before" (gitignored, regenerated)
+const RH = require('./common/room_habitability.js');
+
+const CLINIC = '/home/red1/bim-ootb/buildings/Clinic_extracted.db';
+const DUPLEX = '/home/red1/bim-ootb/buildings/Duplex_extracted.db';
+const PEN = 8; // UTILITY_EDGE_PENALTY — kept in sync with room_graph.js's own constant, asserted below
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+function openQ(p) { const db = new Database(p, { readonly: true }); return { db: db, q: (sql, prm) => db.prepare(sql).raw(true).all(...(prm || [])) }; }
+const roomList = (g, p) => p.filter(x => g.nodesByGuid[x] && g.nodesByGuid[x].kind === 'room');
+
+console.log('§W-UTIL-PENALTY');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Part A — real Clinic classification + honest structural finding
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n§CLINIC classification + structural finding');
+{
+  const { db, q } = openQ(CLINIC);
+  const logs = [];
+  const g = RG.buildGraph(q, { log: m => { logs.push(m); } });
+  const utilLine = logs.find(l => l.indexOf('§ROOM_GRAPH_UTILITY ') === 0) || '(none)';
+  console.log('  §log: ' + utilLine);
+
+  const tagged = g.nodes.filter(n => n.isUtility);
+  chk('A1 CLASSIFY-WIRED buildGraph tagged the real utility rooms via classifyUtilityRooms',
+    tagged.length === 7, 'tagged=' + tagged.length + ' [' + tagged.map(n => n.guid).join(',') + ']');
+
+  // cross-check: same set the classifier returns directly
+  const descs = g.nodes.map(n => {
+    let a = Infinity, b = -Infinity, c = Infinity, d = -Infinity;
+    n.rects.forEach(r => { a = Math.min(a, r.x0); b = Math.max(b, r.x1); c = Math.min(c, r.y0); d = Math.max(d, r.y1); });
+    return { guid: n.guid, cx: (a + b) / 2, cy: (c + d) / 2, sx: b - a, sy: d - c, storey: n.storey };
+  });
+  const direct = RH.classifyUtilityRooms(descs, q);
+  chk('A1b tags match classifyUtilityRooms output exactly',
+    tagged.every(n => direct[n.guid]) && Object.keys(direct).length === tagged.length,
+    'directKeys=' + Object.keys(direct).length);
+
+  const edgeCount = g2 => n => g2.edges.filter(e => e.a === n.guid || e.b === n.guid).length;
+  const withEdges = tagged.filter(n => edgeCount(g)(n) > 0);
+  console.log('  §UTIL_EDGELESS ' + tagged.map(n => n.guid + '(edges=' + edgeCount(g)(n) + ',' + n.utilityWhy + ')').join(' '));
+  chk('A2 STRUCTURAL-FINDING every real utility room is a doorless void with ZERO routing edges → penalty is a present-day no-op for them (reported honestly, see doc §10 follow-up)',
+    withEdges.length === 0, 'utilityRoomsWithEdges=' + withEdges.length + '/' + tagged.length);
+  db.close();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Part B — penalty MECHANISM on the real Clinic graph (constructed real-data reproduction)
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n§CLINIC penalty mechanism (force-tag on the real graph)');
+{
+  const { db, q } = openQ(CLINIC);
+  const g = RG.buildGraph(q, { log: () => {} });
+
+  // B1 — MULTIPLIER MATH: a directly-connected real room pair, 1 E1 edge, exact ×PEN.
+  //   Find an E1 edge whose two endpoints are rooms and whose direct edge is their shortest path.
+  let e1 = g.edges.find(e => e.kind === 'E1' && g.nodesByGuid[e.a].kind === 'room' && g.nodesByGuid[e.b].kind === 'room');
+  const A = e1.a, B = e1.b;
+  const before = RG.shortestPath(g, A, B);
+  g.nodesByGuid[A].isUtility = true;
+  const after = RG.shortestPath(g, A, B);
+  delete g.nodesByGuid[A].isUtility;
+  const ratio = after.distance / before.distance;
+  console.log('  §MULTIPLIER pair=' + A + '->' + B + ' d_before=' + before.distance.toFixed(4) + ' d_after=' + after.distance.toFixed(4) + ' ratio=' + ratio.toFixed(4));
+  chk('B1 MULTIPLIER-MATH tagging one endpoint multiplies the touching edge weight by exactly UTILITY_EDGE_PENALTY',
+    Math.abs(ratio - PEN) < 1e-6 && !!after, 'ratio=' + ratio.toFixed(4) + ' expected=' + PEN);
+
+  // B2 — REROUTE / B2b COST+REACHABLE around a real through-hop.
+  //   M is the degree-37 real hub RM_First_Floor_20; RM_First_Floor_29->RM_First_Floor_39 routes
+  //   THROUGH it. Force-tag M utility (the honest constructed repro — no real utility room has an edge).
+  const M = 'RM_First_Floor_20', pA = 'RM_First_Floor_29', pB = 'RM_First_Floor_39';
+  const p0 = RG.shortestPath(g, pA, pB);
+  const wentThrough = p0 && p0.path.indexOf(M) >= 0;
+  g.nodesByGuid[M].isUtility = true;
+  const p1 = RG.shortestPath(g, pA, pB);
+  g.nodesByGuid[M].isUtility = false;
+  console.log('  §THRUHOP ' + pA + '->' + pB + ' before rooms=[' + roomList(g, p0.path).join(',') + '] d=' + p0.distance.toFixed(2));
+  console.log('  §THRUHOP ' + pA + '->' + pB + ' M=' + M + ' tagged: rooms=[' + roomList(g, p1.path).join(',') + '] d=' + p1.distance.toFixed(2) + ' avoidsM=' + (p1.path.indexOf(M) < 0));
+  chk('B2-pre confirms the OLD route used the (to-be-tagged) room as a mid through-hop', wentThrough, 'through=' + wentThrough);
+  const avoided = p1 && p1.path.indexOf(M) < 0;
+  const costlierButReachable = p1 && p1.path.indexOf(M) >= 0 && p1.distance > p0.distance;
+  chk('B2 REROUTE/B2b either the route now AVOIDS the tagged utility room, or (M being the only route) it stays reachable at higher cost — never null',
+    !!p1 && (avoided || costlierButReachable), avoided ? 'REROUTED-around-M' : (costlierButReachable ? 'costlier+reachable(only-route)' : 'FAIL'));
+
+  // B2c — an explicit real REROUTE: RM_First_Floor_1 -> RM_First_Floor_2 normally threads through
+  //   RM_First_Floor_9 as a mid-hop; tagging RF9 utility makes the route AVOID it (hub RF20 -> RF2
+  //   direct) — a real "prefer circulation over cutting through" reroute, slightly longer, non-null.
+  const rrA = 'RM_First_Floor_1', rrB = 'RM_First_Floor_2', rrM = 'RM_First_Floor_9';
+  const rr0 = RG.shortestPath(g, rrA, rrB);
+  g.nodesByGuid[rrM].isUtility = true;
+  const rr1 = RG.shortestPath(g, rrA, rrB);
+  g.nodesByGuid[rrM].isUtility = false;
+  console.log('  §REROUTE_EXAMPLE ' + rrA + '->' + rrB + ' before=[' + roomList(g, rr0.path).join(',') + '](d=' + rr0.distance.toFixed(2) + ') after=[' + roomList(g, rr1.path).join(',') + '](d=' + rr1.distance.toFixed(2) + ') avoids ' + rrM + '=' + (rr1.path.indexOf(rrM) < 0));
+  chk('B2c REROUTE-EXAMPLE a real room→room route that used a room as a mid through-hop now AVOIDS it (in favour of a corridor/direct alternative) once it is tagged utility, and still resolves',
+    rr0.path.indexOf(rrM) >= 0 && !!rr1 && rr1.path.indexOf(rrM) < 0,
+    'before-through=' + (rr0.path.indexOf(rrM) >= 0) + ' after-avoids=' + (rr1 && rr1.path.indexOf(rrM) < 0));
+
+  // B3 — REACHABLE-AS-DESTINATION: path whose destination IS the tagged utility room resolves non-null.
+  g.nodesByGuid[M].isUtility = true;
+  const dest = RG.shortestPath(g, pA, M);
+  g.nodesByGuid[M].isUtility = false;
+  const destUntagged = RG.shortestPath(g, pA, M);
+  console.log('  §DEST_REACHABLE ' + pA + '->' + M + '(tagged) d=' + (dest ? dest.distance.toFixed(2) : 'null') + ' vs untagged d=' + (destUntagged ? destUntagged.distance.toFixed(2) : 'null'));
+  chk('B3 REACHABLE-AS-DEST a maintenance-access query whose destination is the utility room still returns a valid non-null path (higher cost, never unreachable)',
+    !!dest && dest.distance >= destUntagged.distance, dest ? ('d=' + dest.distance.toFixed(2)) : 'NULL');
+  db.close();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Part C — no-regression on a building with no utility rooms in play (Duplex)
+// ─────────────────────────────────────────────────────────────────────────────
+function noRegression(dbPath, label, limit) {
+  const { db, q } = openQ(dbPath);
+  const gNew = RG.buildGraph(q, { log: () => {} });
+  const gOld = RGbefore.buildGraph(q, { log: () => {} });
+  const util = gNew.nodes.filter(n => n.isUtility);
+  const utilWithEdges = util.filter(n => gNew.edges.some(e => e.a === n.guid || e.b === n.guid));
+  console.log('  §NOREG_' + label + ' utilityRooms=' + util.length + ' ofWhichWithEdges=' + utilWithEdges.length);
+  // Invariant that makes this a real no-regression, not luck: any utility room present is edgeless,
+  // so the penalty branch is inert and paths cannot change (the structural finding, re-confirmed).
+  chk('C0-' + label + ' utility rooms present (if any) are edgeless → penalty branch is inert here',
+    utilWithEdges.length === 0, 'utilityRooms=' + util.length + ' withEdges=' + utilWithEdges.length);
+
+  const rooms = gNew.nodes.map(n => n.guid);
+  let compared = 0, identical = 0, firstDiff = null;
+  const LIMIT = Math.min(rooms.length, limit);
+  for (let i = 0; i < LIMIT; i++) for (let j = i + 1; j < LIMIT; j++) {
+    const pN = RG.shortestPath(gNew, rooms[i], rooms[j]);
+    const pO = RGbefore.shortestPath(gOld, rooms[i], rooms[j]);
+    compared++;
+    const same = (pN === null && pO === null) ||
+      (pN && pO && JSON.stringify(pN.path) === JSON.stringify(pO.path) && Math.abs(pN.distance - pO.distance) < 1e-9);
+    if (same) identical++; else if (!firstDiff) firstDiff = rooms[i] + '->' + rooms[j];
+  }
+  console.log('  §NOREG_' + label + ' compared=' + compared + ' identical=' + identical + (firstDiff ? ' firstDiff=' + firstDiff : ''));
+  chk('C1-' + label + ' every path byte-identical (path + distance) to the origin/main module',
+    identical === compared && compared > 0, identical + '/' + compared + ' identical');
+  db.close();
+}
+// Duplex: 2 edgeless utility rooms present → proves the penalty stays inert even when a building
+// DOES carry utility rooms (as long as they're the doorless voids the classifier flags).
+noRegression(DUPLEX, 'DUPLEX', 22);
+// JKR: a building with genuinely ZERO utility rooms in play — the literal "no utility rooms" case.
+noRegression('/home/red1/bim-ootb/buildings/JKR_extracted.db', 'JKR', 20);
+
+console.log('\n§W-UTIL-PENALTY DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What

`VIEWER_FIND_PANEL_ROOM_ACCURACY.md §10` — ordinary room→room Path routing treated cabling/service rooms as equal-weight circulation hops (screenshots `MIssBehindCutThruAir.png`/`MissCOback2doors.png`). Fix, scoped to `common/room_graph.js` `buildGraph()`/`_buildAdjacency()` only:

- Wire `RoomHabitability.classifyUtilityRooms()` into `buildGraph()` (batched — 2 SQL queries total, the perf shape already proven safe on Hospital's 311 rooms) and **tag** utility room nodes `node.isUtility`.
- In `_buildAdjacency()`, multiply any edge touching a tagged node by `UTILITY_EDGE_PENALTY` (=8) — a **penalty, not removal**, so utility rooms stay reachable (maintenance-access "find path to the cabling closet" still resolves) while never winning against a corridor a few hops longer. Both `shortestPath()` and `escapeRoute()` consume the shared adjacency and inherit the preference.
- Room descriptor `sx`/`sy` derived from each logical room's union rect bbox (§MULTI-RECT aware), mirroring `navigate_find.js`'s two existing call sites. `room_graph.js?v=5→v=6` cache-bust.

## Penalty value
×8: real room-center edges run ~3–12 m; a corridor alternative a few hops longer adds ~10–40 m; ×8 makes even a single ~5 m utility hop cost ~40 m and a *through*-route (two touching edges) ~80 m — reliably losing to any realistic detour, while finite (reachability preserved).

## Honest finding (in the witness + doc §10)
On **every** current real fixture, the rooms `classifyUtilityRooms()` flags are **doorless sealed voids with ZERO routing edges** (the classifier excludes any room with a nearby door; graph edges *require* a nearby door), so the penalty is a present-day **no-op for them** — and the screenshot's door-carrying through-hops aren't flagged by the classifier's door-exclusion (§10 point 4). This ships the correct in-scope mechanism; a pathfinding-specific utility signal (relaxing the door-exclusion for routing) is the named follow-up. Mechanism proven by force-tagging real routed rooms.

## Witness — `witness_room_graph_utility_penalty.js`, **12/12 green**
Real Clinic/Duplex/JKR `_extracted.db`, `better-sqlite3`, §-logged, self-contained (regenerates the "before" module from a pinned SHA):
- Clinic: `classifyUtilityRooms` tags 7 utility rooms onto graph nodes; all 7 (+ Duplex's 2) have 0 edges.
- Multiplier math exact ×8; a real through-hop reroutes around the tagged room (`RF1→RF2`: `[1,12,20,9,2]`→`[1,12,20,2]`); reachable-as-destination preserved (non-null, higher cost).
- No regression: Duplex 10/10 + JKR 190/190 paths byte-identical to origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9ynxZzBktCXekz2P45HwF