### PR TITLE
feat(erp): Confirm & Post — Generate-Shipments/Invoices/PO results now actually commit

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -2445,6 +2445,43 @@
     toast(op.verb.toUpperCase() + ' ' + fname(op.key) + ' — unknown op');
   }
 
+  // applyOpGroup — commit a MULTI-op result (e.g. a Generate-Shipments/-Invoices/-Order-from-Project
+  // KIND-2 CREATE_DOCUMENT + N×CREATE_LINE group, erp_engine.js's buildDoc/genShipmentLines/genInvoiceLines)
+  // as ONE atomic signed op-group. Implementing ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22 "missing commit
+  // wiring" — erp_engine.js's own header already documented the intent ("Verbs return ops[]; the kernel
+  // applies + commitOps them") but no caller ever existed for the Generate-process UI path; a working
+  // caller for the SAME shape already exists in pos_lens.js (buildSaleGroup/buildRegisterGroup →
+  // KO.commitGroup(opDb, ops.map(o=>({op_type:o.op_type,params:o})), {})) — this reuses that exact
+  // primitive+shape, wrapped in the SAME cross-tab-safe _withFreshSide hydration commitCrud already uses
+  // (none of these ops are owner-gated — every op is a fresh CREATE, matching commitCrud's own "CREATE has
+  // no prior owner to gate" note). K.commitGroup's own atomicity guarantee means every op in the group
+  // commits together or none do. cb(result) — result = {committed, gid?, ids?, sealed?, verifyOk?, reason?}.
+  function applyOpGroup(ops, cb) {
+    cb = cb || function () {};
+    if (!ops || !ops.length) { cb({ committed: false, reason: 'empty-group' }); return; }
+    var K = kernel();
+    withSidecar(function (db) {
+      if (!db || !K || typeof K.commitGroup !== 'function') { console.log('§CRUD-GROUP kernel/sql.js absent — cannot commit'); cb({ committed: false, reason: 'kernel/sql.js absent' }); return; }
+      _withFreshSide(K, function (freshDb, done) {
+        var groupOps = ops.map(function (o) { return { op_type: o.op_type, params: o }; });
+        Promise.resolve(K.commitGroup(freshDb, groupOps, _commitMeta())).then(function (res) {
+          if (!res || res.committed !== true) {
+            console.warn('§CRUD-GROUP commitGroup not-committed reason=' + (res && res.reason || '?'));
+            cb({ committed: false, reason: (res && res.reason) || 'not-committed' }); done(); return;
+          }
+          return Promise.resolve((K.verifyChainIncremental || K.verifyChain)(freshDb)).then(function (v) {
+            return _sidePersist(K, freshDb, res.ids).then(function () {
+              console.log('§CRUD-GROUP-PERSIST ops=' + res.ids.length + ' source=sidecar gid=' + res.gid + ' sealed=' + res.sealed + ' verifyChain=' + (v && v.ok ? 'ok' : 'FAIL'));
+              try { global.dispatchEvent(new CustomEvent('overlay:committed', { detail: { table: null, op_type: 'CREATE_GROUP', id: null, gid: res.gid } })); } catch (ev) {}
+              cb({ committed: true, gid: res.gid, ids: res.ids, sealed: res.sealed, verifyOk: !!(v && v.ok) });
+              done();
+            });
+          });
+        }).catch(function (er) { console.warn('§CRUD-GROUP commit error', er && er.message); cb({ committed: false, reason: 'error: ' + (er && er.message) }); done(); });
+      });
+    });
+  }
+
   // ── page-data helpers (truth-bound Edit pre-fill from the real bundle row) ──
   // recId — the record's pk value. key+'_id' is the convention; lookup is CASE-INSENSITIVE so it works on
   // glassbowl rows (lower-case cols) AND the iDempiere renderer's SELECT * rows (original-case cols, e.g.
@@ -2687,6 +2724,7 @@
 
   global.__crud = { enable: enable, disable: disable, openRing: openRing, core: CORE, store: function () { return STORE; },
                     applyOp: applyOp,   // §A1-DOC: the commit funnel, exposed for in-browser smoke
+                    applyOpGroup: applyOpGroup,   // §ORDERLINE-PARENT-FK follow-on (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22): commit a multi-op KIND-2 Generate-process result (CREATE_DOCUMENT + N×CREATE_LINE) as one atomic signed group
                     process: hostProcess,   // S1/J5: host-callable signed DocAction (iDempiere pill/bar/grid-batch → shared lane)
                     create: hostCreate,     // S2/J4: host-callable New — opens the create form directly (ring not fanned) → signed CRUD_CREATE
                     update: hostUpdate, remove: hostDelete,   // S2/J4 full-CRUD: host-callable Edit/Delete on a specific id (ring not fanned) → signed CRUD_UPDATE/DELETE

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -2725,6 +2725,30 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         : isInv
         ? r.lineCount + ' invoice line' + (r.lineCount === 1 ? '' : 's') + ' folded (QtyInvoiced = QtyOrdered − QtyInvoiced)'
         : r.lineCount + ' order line' + (r.lineCount === 1 ? '' : 's') + ' folded (Qty = PlannedQty − InvoicedQty; Price = PlannedPrice)'));
+      // §GENPROCESS-CONFIRM (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22, "missing commit wiring") — real
+      // iDempiere's own Generate-Shipments/Invoices UX is preview-then-confirm (this table IS the preview);
+      // the missing half was the commit itself. r.ops here is the SAME CREATE_DOCUMENT+N×CREATE_LINE group
+      // erp_engine.js's buildDoc already produces (its own header: "Verbs return ops[]; the kernel applies
+      // + commitOps them") — pos_lens.js's buildSaleGroup/buildRegisterGroup already commit the identical
+      // shape via KO.commitGroup; window.__crud.applyOpGroup (crud_overlay.js) wraps that same primitive.
+      var cfWrap = el('div', 'actions'); cfWrap.style.cssText = 'margin-top:10px';
+      var cfBtn = el('button', 'run', 'Confirm & Post'); cfBtn.setAttribute('data-genprocess-confirm', '1');
+      var cfMsg = el('div', 'msg'); cfMsg.style.cssText = 'margin-top:6px';
+      cfBtn.addEventListener('click', function () {
+        cfBtn.disabled = true; cfBtn.textContent = 'Posting…';
+        window.__crud.applyOpGroup(r.ops, function (out) {
+          if (!out || !out.committed) {
+            cfBtn.disabled = false; cfBtn.textContent = 'Confirm & Post';
+            cfMsg.textContent = 'Not posted: ' + ((out && out.reason) || 'unknown');
+            console.log('§GENPROCESS-CONFIRM table=' + h.table + ' committed=N reason=' + ((out && out.reason) || 'unknown'));
+            return;
+          }
+          cfBtn.textContent = 'Posted ✓'; cfBtn.style.opacity = '0.6';
+          cfMsg.textContent = (isShip ? 'Shipment' : isInv ? 'Invoice' : 'Order') + ' posted — group ' + String(out.gid).slice(0, 8) + '… · ' + out.ids.length + ' ops · signed=' + (out.verifyOk ? 'Y' : 'N');
+          console.log('§GENPROCESS-CONFIRM table=' + h.table + ' committed=Y gid=' + out.gid + ' ops=' + out.ids.length + ' verifyOk=' + out.verifyOk);
+        });
+      });
+      cfWrap.appendChild(cfBtn); pane.appendChild(cfWrap); pane.appendChild(cfMsg);
     }
     var back = el('div', null); var bb = el('button', null, 'Close');
     bb.style.cssText = 'margin-top:12px;font-size:12.5px;padding:5px 16px;border:1px solid var(--idmp-border);border-radius:6px;background:var(--idmp-panel);cursor:pointer';


### PR DESCRIPTION
## Summary
- `erp_engine.js`'s `buildDoc`/`genShipmentLines`/`genInvoiceLines` already produce a real `CREATE_DOCUMENT`+N×`CREATE_LINE` op group (its own header already documented the intent: *"Verbs return ops[]; the kernel applies + commitOps them"*), but nothing in `idempiere.html`'s Generate-process UI path ever committed it — `renderProcResult()` was a pure read-only preview. This was the TRUE remaining blocker for the whole O2C lane (`ERP_BUSINESS_CYCLE_E2E.md`) — every prior "Stage 2/3 FAIL" was always going to fail at this exact point, for every order, seed or synthetic.
- A working precedent for committing this exact op shape already existed in `pos_lens.js` (`buildSaleGroup`/`buildRegisterGroup` → `KO.commitGroup(opDb, ops.map(o=>({op_type:o.op_type,params:o})), {})`) — reused verbatim, not invented.
- `crud_overlay.js` gets `applyOpGroup(ops, cb)`: commits a multi-op result as ONE atomic signed group via the same `kernel.commitGroup()` primitive `applyOp`/`commitCrud` already use, wrapped in the same cross-tab-safe `_withFreshSide` hydration. Exposed on `window.__crud.applyOpGroup`.
- `idempiere.html`'s `renderProcResult()` gets a real **"Confirm & Post"** button on the KIND-2 op-group branch (Generate-Shipments/-Invoices/-Order-from-Project) — matching real iDempiere's own preview-then-confirm UX.

## Test plan
- [x] Syntax check on both touched files
- [x] `scripts/witness_e2e_business_cycle.js` (bim-compiler), updated to click the new Confirm button (not just the preview Run): **Stage 2 (Shipment) now PASSES for the first time in this lane** — a real signed `M_InOut` `CREATE_DOCUMENT` op is recorded (`§CRUD-GROUP-PERSIST ops=2 sealed=2 verifyChain=ok`)
- [x] No regression: Stage 1/5/6 still PASS
- [x] Stage 3 correctly unaffected (still blocked by the separate, unrelated `AD_Org_ID=NaN` casing bug — the Confirm button correctly doesn't render since the process never dispatches for that reason)

Full findings: `prompts/ERP_BUSINESS_CYCLE_E2E.md` §Fix 2026-07-22 (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)