### PR TITLE
feat(room-path): raster-constrained A* polyline — the drawn route hugs real floor (§13 Stage B)

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -1134,6 +1134,199 @@
     return out;
   }
 
+  // ════════════════════════════════════════════════════════════════════════════════════════════
+  // §RASTER-ASTAR (Stage B — VIEWER_FIND_PANEL_ROOM_ACCURACY.md §13, 2026-07-22): the ACTUAL walked
+  // polyline. `_legalizePath` above still owns the logical `path`/`doors`/`distance` (and the
+  // §PATH_LEGAL_DETOUR_FAIL metric the raster witnesses measure) — UNTOUCHED. This computes an
+  // ADDITIVE `result.polyline`: between two consecutive same-storey path anchors it grid-searches
+  // (A*) the storey's own walkable evidence (`_pointWalkable` — raster-first, room+corridor-rect
+  // fallback, null=no-data) so the drawn line HUGS real floor by construction, instead of the old
+  // straight chord + sparse door-visibility detour that §11 measured cutting through walls/atrium
+  // air. It changes ONLY geometry, never which rooms/doors the route uses. Honest degrade preserved:
+  // where `_pointWalkable` returns null (no floor data at all for the storey) the straight segment is
+  // the only non-invented route; where A* finds no on-floor route it also falls back to straight
+  // (same "never fabricate, never fail" contract the old detour honoured). Reuses storey_raster.js's
+  // contains() via _pointWalkable — no second raster representation is built.
+  var ASTAR_CELL = 0.25;          // fine grid step (local pass) — matches raster res / PATH_LEGAL_SAMPLE_RES
+  var ASTAR_WINDOW_MARGIN = 6.0;  // local-search window padding around the chord bbox (DETOUR_LOCALITY spirit)
+  var ASTAR_WIDEN_MARGIN = 28.0;  // bounded wider-pass padding (covers a 20-30m spine-to-spine corridor route)
+  var ASTAR_WIDEN_CELL = 0.5;     // coarser cell for the wider pass (corridors are >=1m; verification re-tests fine)
+  var ASTAR_MAX_CELLS = 400000;   // safety cap per grid; beyond it the pass abandons -> straight
+
+  // Tiny binary min-heap keyed by .f — keeps A* fast even on the storey-wide widen pass (a linear
+  // open-set scan is O(N^2) and would stall on Hospital-scale grids; measured, not assumed).
+  function _Heap() { this.a = []; }
+  _Heap.prototype.push = function (n) { var a = this.a; a.push(n); var i = a.length - 1; while (i > 0) { var p = (i - 1) >> 1; if (a[p].f <= a[i].f) break; var t = a[p]; a[p] = a[i]; a[i] = t; i = p; } };
+  _Heap.prototype.pop = function () { var a = this.a; if (!a.length) return null; var top = a[0], last = a.pop(); if (a.length) { a[0] = last; var i = 0, n = a.length; for (;;) { var l = 2 * i + 1, r = l + 1, s = i; if (l < n && a[l].f < a[s].f) s = l; if (r < n && a[r].f < a[s].f) s = r; if (s === i) break; var t = a[s]; a[s] = a[i]; a[i] = t; i = s; } } return top; };
+  _Heap.prototype.size = function () { return this.a.length; };
+
+  function _storeyExtent(graph, storey) {
+    var r = graph.rasters && graph.rasters[storey];
+    if (r) return { x0: r.x0, y0: r.y0, x1: r.x0 + r.cols * r.res, y1: r.y0 + r.rows * r.res };
+    var ext = null;
+    ['roomRectsByStorey', 'corridorRectsByStorey'].forEach(function (k) {
+      var rects = graph[k] && graph[k][storey]; if (!rects) return;
+      rects.forEach(function (rc) {
+        if (!ext) ext = { x0: rc.x0, y0: rc.y0, x1: rc.x1, y1: rc.y1 };
+        else { ext.x0 = Math.min(ext.x0, rc.x0); ext.y0 = Math.min(ext.y0, rc.y0); ext.x1 = Math.max(ext.x1, rc.x1); ext.y1 = Math.max(ext.y1, rc.y1); }
+      });
+    });
+    return ext;
+  }
+
+  // 8-connected A* over a bounded window; cell walkable iff _pointWalkable(cell center)===true.
+  // Returns {cells:[{c,r}...], wx0, wy0, cell} or null (no window fit / no route / start|goal unsnappable).
+  function _astarGrid(graph, storey, ax, ay, bx, by, win, cellSize) {
+    var cell = cellSize || ASTAR_CELL, wx0 = win.x0, wy0 = win.y0;
+    var cols = Math.max(1, Math.ceil((win.x1 - win.x0) / cell)), rows = Math.max(1, Math.ceil((win.y1 - win.y0) / cell));
+    if (cols * rows > ASTAR_MAX_CELLS) return null;
+    function cw(c, r) { return _pointWalkable(graph, storey, wx0 + (c + 0.5) * cell, wy0 + (r + 0.5) * cell) === true; }
+    function inb(c, r) { return c >= 0 && r >= 0 && c < cols && r < rows; }
+    function toCell(x, y) { return { c: Math.floor((x - wx0) / cell), r: Math.floor((y - wy0) / cell) }; }
+    function snap(c0) {
+      if (inb(c0.c, c0.r) && cw(c0.c, c0.r)) return c0;
+      var R = Math.ceil(1.2 / cell) + 1; // snap a room-center/door-wp onto floor within ~1.2m
+      for (var rad = 1; rad <= R; rad++) for (var dc = -rad; dc <= rad; dc++) for (var dr = -rad; dr <= rad; dr++) {
+        if (Math.max(Math.abs(dc), Math.abs(dr)) !== rad) continue;
+        var c = c0.c + dc, r = c0.r + dr; if (inb(c, r) && cw(c, r)) return { c: c, r: r };
+      }
+      return null;
+    }
+    var s = snap(toCell(ax, ay)), g = snap(toCell(bx, by));
+    if (!s || !g) return null;
+    var idx = function (c, r) { return r * cols + c; };
+    var goalI = idx(g.c, g.r), gscore = {}, came = {}, closed = {};
+    gscore[idx(s.c, s.r)] = 0;
+    function h(c, r) { var dc = Math.abs(c - g.c), dr = Math.abs(r - g.r); return (dc + dr) + (Math.SQRT2 - 2) * Math.min(dc, dr); }
+    var heap = new _Heap(); heap.push({ i: idx(s.c, s.r), c: s.c, r: s.r, f: h(s.c, s.r) });
+    var dirs = [[1, 0, 1], [-1, 0, 1], [0, 1, 1], [0, -1, 1], [1, 1, Math.SQRT2], [1, -1, Math.SQRT2], [-1, 1, Math.SQRT2], [-1, -1, Math.SQRT2]];
+    var expansions = 0;
+    while (heap.size()) {
+      var cur = heap.pop();
+      if (cur.i === goalI) {
+        var out = [], ci = goalI; while (ci != null) { var cc = ci % cols, rr = (ci - cc) / cols; out.push({ c: cc, r: rr }); ci = came[ci]; }
+        out.reverse(); return { cells: out, wx0: wx0, wy0: wy0, cell: cell };
+      }
+      if (closed[cur.i]) continue; closed[cur.i] = 1;
+      if (++expansions > ASTAR_MAX_CELLS) return null;
+      for (var d = 0; d < 8; d++) {
+        var nc = cur.c + dirs[d][0], nr = cur.r + dirs[d][1];
+        if (!inb(nc, nr) || !cw(nc, nr)) continue;
+        // no diagonal corner-cutting: both orthogonal neighbours must also be walkable
+        if (dirs[d][2] > 1 && (!cw(cur.c + dirs[d][0], cur.r) || !cw(cur.c, cur.r + dirs[d][1]))) continue;
+        var ni = idx(nc, nr); if (closed[ni]) continue;
+        var ng = gscore[cur.i] + dirs[d][2];
+        if (gscore[ni] == null || ng < gscore[ni]) { gscore[ni] = ng; came[ni] = cur.i; heap.push({ i: ni, c: nc, r: nr, f: ng + h(nc, nr) }); }
+      }
+    }
+    return null;
+  }
+
+  // Greedy line-of-sight string-pull: collapse a dense cell path to its minimal turn points, keeping
+  // only vertices where the straight run to the next kept point would cross non-walkable space (same
+  // _chordIllegalCount legality test the rest of this file uses). Turns ~120 grid cells into a handful.
+  function _simplifyLOS(graph, storey, pts) {
+    if (pts.length <= 2) return pts.slice();
+    var out = [pts[0]], i = 0;
+    while (i < pts.length - 1) {
+      var j = pts.length - 1;
+      for (; j > i + 1; j--) { if (_chordIllegalCount(graph, storey, pts[i].x, pts[i].y, pts[j].x, pts[j].y) === 0) break; }
+      out.push(pts[j]); i = j;
+    }
+    return out;
+  }
+
+  // Interior walked points between two same-storey anchors (a,b excluded — caller re-adds them).
+  // Returns: [] = a straight segment IS the honest route (chord already on-floor, or no floor data);
+  //          [p,...] = A* found an on-floor route (these turn points);
+  //          null = A* was attempted (chord illegal, data present) but found NO on-floor route — the
+  //                 caller decides whether to keep a synthetic bypass anchor or degrade to straight.
+  function _astarHop(graph, a, b) {
+    var storey = a.storey;
+    var hasData = (graph.rasters && graph.rasters[storey]) ||
+      (graph.roomRectsByStorey && graph.roomRectsByStorey[storey] && graph.roomRectsByStorey[storey].length) ||
+      (graph.corridorRectsByStorey && graph.corridorRectsByStorey[storey] && graph.corridorRectsByStorey[storey].length);
+    if (!hasData) return [];
+    if (_chordIllegalCount(graph, storey, a.cx, a.cy, b.cx, b.cy) === 0) return []; // fast path — most hops
+    // Local pass first at fine res (fast, handles the common short corridor jog), then a BOUNDED wider
+    // pass at a coarser cell (§WIDEN-BOUNDED): the widen window is capped to the chord bbox + a large
+    // margin (not the whole storey — that made a cross-wing Hospital path stack several full-storey A*
+    // passes, measured 205ms max) and searched at 0.5m cells (corridors are >=1m wide, so coarser is
+    // safe; the end-to-end §ON-FLOOR-GUARANTEE verification below re-tests at fine res regardless, so
+    // any coarseness error just degrades to null → honest straight, never a bad line). Keeps a single
+    // interactive click well under budget while still rescuing the 20-30m spine-to-spine corridor routes.
+    var m = ASTAR_WINDOW_MARGIN;
+    var localWin = { x0: Math.min(a.cx, b.cx) - m, y0: Math.min(a.cy, b.cy) - m, x1: Math.max(a.cx, b.cx) + m, y1: Math.max(a.cy, b.cy) + m };
+    var res = _astarGrid(graph, storey, a.cx, a.cy, b.cx, b.cy, localWin, ASTAR_CELL);
+    if (!res) {
+      var W = ASTAR_WIDEN_MARGIN;
+      var wideWin = { x0: Math.min(a.cx, b.cx) - W, y0: Math.min(a.cy, b.cy) - W, x1: Math.max(a.cx, b.cx) + W, y1: Math.max(a.cy, b.cy) + W };
+      res = _astarGrid(graph, storey, a.cx, a.cy, b.cx, b.cy, wideWin, ASTAR_WIDEN_CELL);
+    }
+    if (!res) return null; // A* genuinely found no on-floor route — caller degrades honestly
+    var pts = res.cells.map(function (cl) { return { x: res.wx0 + (cl.c + 0.5) * res.cell, y: res.wy0 + (cl.r + 0.5) * res.cell }; });
+    var simp = _simplifyLOS(graph, storey, pts);
+    // trim a snapped endpoint that sits right on top of the anchor the caller re-adds (avoids a hairline stub)
+    if (simp.length && Math.hypot(simp[0].x - a.cx, simp[0].y - a.cy) < ASTAR_CELL) simp.shift();
+    if (simp.length && Math.hypot(simp[simp.length - 1].x - b.cx, simp[simp.length - 1].y - b.cy) < ASTAR_CELL) simp.pop();
+    // §ON-FLOOR-GUARANTEE (Stage B): only return a route that is VERIFIABLY on real floor end to end —
+    // including the two anchor connectors (a -> first turn point, last -> b) the LOS pass didn't test.
+    // If the snapped route still leaves any illegal sample (e.g. a rect-fallback building whose A* path
+    // hugs rect cells but the a->simp connector crosses an uncovered doorway seam), return null so the
+    // caller degrades to the original straight/synthetic route instead of drawing a subtly-off-floor
+    // line. This is what makes "the polyline stays on real floor" a guarantee, not a best-effort.
+    var chain = [{ x: a.cx, y: a.cy }]; for (var s = 0; s < simp.length; s++) chain.push(simp[s]); chain.push({ x: b.cx, y: b.cy });
+    var bad = 0; for (var q = 0; q + 1 < chain.length; q++) bad += _chordIllegalCount(graph, storey, chain[q].x, chain[q].y, chain[q + 1].x, chain[q + 1].y);
+    if (bad > 0) return null;
+    return simp;
+  }
+
+  // §POLYLINE: the additive floor-hugging geometry for result.polyline — world {x,y,z} points. Rooms/
+  // doors/circ anchors from `path` are kept as-is; A* interior points are spliced between same-storey
+  // pairs; a cross-storey (stair) pair keeps its straight vertical segment (no raster spans floors).
+  function _polyPt(n) { return { x: n.cx, y: n.cy, z: (n.cz || 0) }; }
+  function _buildPolyline(graph, path) {
+    if (!path || !path.length) return [];
+    var anchors = [];
+    for (var pi = 0; pi < path.length; pi++) { var nn = graph.nodesByGuid[path[pi]]; if (nn) anchors.push(nn); }
+    if (!anchors.length) return [];
+    var out = [];
+    function pushPt(p) {
+      var L = out.length ? out[out.length - 1] : null;
+      if (!L || Math.hypot(L.x - p.x, L.y - p.y) > 1e-6 || Math.abs((L.z || 0) - (p.z || 0)) > 1e-6) out.push(p);
+    }
+    function pushInterior(hop, z) { for (var k = 0; k < hop.length; k++) pushPt({ x: hop[k].x, y: hop[k].y, z: z }); }
+    pushPt(_polyPt(anchors[0]));
+    var i = 0;
+    while (i + 1 < anchors.length) {
+      var a = anchors[i];
+      // §CIRC-NOT-A-WALKPOINT (Stage B, the key §11 finding proven on real data): a `circ` node is a
+      // per-storey circulation-hub CENTROID (stair-group average), NOT a walked floor point — measured
+      // on HHS/Terminal it routinely sits on a DISCONNECTED raster island, so A* cannot reach it and
+      // every room→…→circ→…→room chord degraded to the old straight (off-floor) line. It is a
+      // TOPOLOGICAL connector; the real walk goes spine→spine along the corridor it bridges. So when the
+      // next anchor is a circ, TRY A* straight from `a` to the anchor AFTER it (bypassing circ): if A*
+      // routes it on real floor (verified: HHS spine→spine straight=61 illegal → A* polyline=0), take
+      // that and drop circ from the DRAWN line (never from `path` — room list/markers keep it). If A*
+      // can't (e.g. a rect-fallback building whose doorways aren't rect-covered — Clinic), KEEP circ and
+      // fall through to the normal per-segment handling, so a raster-less building is never made WORSE
+      // than before. Cross-storey never relies on circ (those surface as real `stairwp` via _publicHop).
+      if (anchors[i + 1].kind === 'circ' && i + 2 < anchors.length && a.storey != null && a.storey === anchors[i + 2].storey) {
+        var c = anchors[i + 2];
+        var bypass = _astarHop(graph, a, c);
+        if (bypass !== null) { pushInterior(bypass, (a.cz || 0)); pushPt(_polyPt(c)); i += 2; continue; }
+      }
+      var b = anchors[i + 1];
+      if (a.storey != null && a.storey === b.storey) {
+        var hop = _astarHop(graph, a, b);
+        if (hop && hop.length) pushInterior(hop, (a.cz || 0));
+      }
+      pushPt(_polyPt(b));
+      i += 1;
+    }
+    return out;
+  }
+
   // Dijkstra shortest path over the FULL occupant graph. SAME SIGNATURE / SAME RESULT SHAPE as
   // before ({path, doors, distance}) — every existing consumer (viewer/navigate_find.js) needs
   // zero edits: `path` entries still resolve via `graph.nodesByGuid[g]` to a real {cx,cy,cz,name}
@@ -1159,7 +1352,9 @@
       cur = p.from;
     }
     path = _legalizePath(graph, path);
-    return { path: path, doors: doors, distance: core.dist[toGuid] };
+    // §RASTER-ASTAR: additive floor-hugging geometry (see _buildPolyline). path/doors/distance are
+    // unchanged — polyline is the ONLY new field, consumed by navigate_find.js for the drawn line.
+    return { path: path, doors: doors, distance: core.dist[toGuid], polyline: _buildPolyline(graph, path) };
   }
 
   // §ESCAPE-ROUTE (OCCUPANT_PATHFINDER.md SPEC — "falls out" of shortestPath, not a separate

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -160,7 +160,7 @@ async function initViewer() {
         // (x8, never removes) any edge touching one so room→room routing prefers corridors.
         // v7 (same doc §10, 2026-07-22): pass ignoreDoorExemption:true so real door-carrying service
         // rooms are tagged too (the door-exempt display default missed them); exclude CORRIDOR_ROOM nodes.
-        '../common/room_graph.js?v=7',
+        '../common/room_graph.js?v=8',
         // §HALLWAY-BACKBONE-NOT-LOADED (2026-07-14, real bug found via live browser check — every
         // corridor/spine/Hall-Corridor-label feature built this session had been silently no-oping
         // in the browser, despite passing every Node-based witness, because this line never
@@ -172,7 +172,7 @@ async function initViewer() {
         // (getStairGroups() reuse), so room_graph.js must already exist by the time this runs.
         '../common/hallway_backbone.js?v=1',
         // v49 (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-16): A.ensureRooms + A.getRoomGraph extraction.
-        'navigate_find.js?v=55',
+        'navigate_find.js?v=56',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1256,13 +1256,24 @@
         }
       });
       if (A.scene && A.ifc2three && typeof THREE !== 'undefined') {
+        // markers sit at the logical room/door waypoints (unchanged) …
         var pts = result.path.map(function(g) {
           var n = graph.nodesByGuid[g];
           var c = A.ifc2three(n.cx, n.cy, n.cz || 0);
           return new THREE.Vector3(c.x, c.y + 0.05, c.z); // +0.05 lift so the line clears room-shell faces
         });
+        // … but the connecting LINE follows result.polyline — the real A*-on-walkable-raster route
+        // (common/room_graph.js §RASTER-ASTAR, VIEWER_FIND_PANEL_ROOM_ACCURACY.md §13) — so it HUGS
+        // real floor instead of cutting straight between graph waypoints (which §11 measured slicing
+        // through walls / open atrium air). Additive: path/doors/distance and every marker/room-list/
+        // zoom consumer below are UNCHANGED. Falls back to the room-center points if a stale cached
+        // room_graph.js (pre-Stage-B) returns no polyline — never breaks the drawn line.
+        var linePts = (result.polyline && result.polyline.length > 1) ? result.polyline.map(function(p) {
+          var c = A.ifc2three(p.x, p.y, p.z || 0);
+          return new THREE.Vector3(c.x, c.y + 0.05, c.z);
+        }) : pts;
         if (pts.length > 1) {
-          var geo = new THREE.BufferGeometry().setFromPoints(pts);
+          var geo = new THREE.BufferGeometry().setFromPoints(linePts);
           // §PATH_ORANGE (ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md §2/§9, 2026-07-15, supersedes the
           // earlier neon-green §PATH_NEON): bright orange reads cleanly against BOTH the purple
           // (habitable) and blue (corridor) room-shell category colors §9 introduced — green risked

--- a/witness_room_path_raster_polyline.js
+++ b/witness_room_path_raster_polyline.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ROOM-PATH-RASTER-POLYLINE scope (READ THE LOG after every run)
+ * SCOPE: bim-compiler VIEWER_FIND_PANEL_ROOM_ACCURACY.md §13 (Stage B) — common/room_graph.js
+ * shortestPath() now returns an ADDITIVE `polyline`: the real walked route computed by A* over the
+ * storey's walkable raster (§RASTER-ASTAR), so the DRAWN line HUGS real floor instead of the old
+ * straight chord + door-visibility detour §11 measured cutting through walls/atrium air. Key finding
+ * (proven here): the synthetic `circ` circulation-hub CENTROID sits on a disconnected raster island,
+ * so the polyline bypasses it and routes the flanking corridor spines directly (§CIRC-NOT-A-WALKPOINT).
+ * path/doors/distance are UNTOUCHED (the door-visibility legalizer + its §PATH_LEGAL_DETOUR_FAIL metric
+ * the raster witnesses assert stay byte-identical). Proves: (G1) on raster-backed buildings the polyline
+ * is ~fully on-floor where the old straight path was not, and NEVER worse anywhere (on-floor guarantee);
+ * (G2) path/doors/distance byte-identical to origin/main; (G3) real interactive A* timing on the largest
+ * building; (G4) honest degrade with no raster / no data.
+ * RUN: node witness_room_path_raster_polyline.js   (needs buildings/*.db present)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const { execSync } = require('child_process');
+
+const RG = require('./common/room_graph.js');
+// "before" = origin/main's committed module (this branch is off origin/main), loaded from git so the
+// regression compare is against real shipped code, not a hand-copy. It must live in common/ so its own
+// relative requires (./storey_raster.js etc.) resolve.
+const BEFORE_SRC = execSync('git show origin/main:common/room_graph.js', { cwd: __dirname }).toString();
+const beforePath = path.join(__dirname, 'common', '_room_graph_before_' + process.pid + '.js');
+fs.writeFileSync(beforePath, BEFORE_SRC);
+const RGbefore = require(beforePath);
+process.on('exit', () => { try { fs.unlinkSync(beforePath); } catch (e) {} });
+
+const BLD = '/home/red1/bim-ootb/buildings';
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+function load(dbFile, patches, modeller) {
+  const tmp = '/tmp/_wpoly_' + Math.random().toString(36).slice(2) + '.db';
+  fs.copyFileSync(path.join(modeller ? path.join(__dirname, 'modeller') : BLD, dbFile), tmp);
+  const db = new Database(tmp);
+  (patches || []).forEach(p => { const f = path.join(__dirname, p); if (fs.existsSync(f)) db.exec(fs.readFileSync(f, 'utf8')); });
+  return { db, tmp, dbQuery: (q) => db.prepare(q).raw(true).all() };
+}
+// storey of a path (single-storey pairs only): the common storey of all its real (non-stairwp) nodes.
+function pathStorey(g, p) {
+  let st = null;
+  for (const guid of p) { const n = g.nodesByGuid[guid]; if (!n || n.storey == null || n.kind === 'stairwp') continue; if (st == null) st = n.storey; else if (st !== n.storey) return null; }
+  return st;
+}
+function seqIllegal(g, storey, pts) { let ill = 0; for (let i = 0; i + 1 < pts.length; i++) ill += RG.chordIllegalCount(g, storey, pts[i].x, pts[i].y, pts[i + 1].x, pts[i + 1].y); return ill; }
+function nodePts(g, p) { return p.map(guid => { const n = g.nodesByGuid[guid]; return { x: n.cx, y: n.cy }; }); }
+
+// polyline floor-legality across single-storey pairs: OLD straight (path node centres) vs NEW polyline.
+function legality(label, dbFile, patches, modeller) {
+  const { db, tmp, dbQuery } = load(dbFile, patches, modeller);
+  const g = RG.buildGraph(dbQuery, { log: () => {} });
+  const rooms = g.nodes.filter(n => n.kind === 'room');
+  let single = 0, oldPts = 0, newPts = 0, improved = 0, worse = 0, withPoly = 0;
+  const realLog = console.log; console.log = () => {};
+  for (let i = 0; i < rooms.length; i++) for (let j = i + 1; j < rooms.length; j++) {
+    const r = RG.shortestPath(g, rooms[i].guid, rooms[j].guid);
+    if (!r || !r.polyline) continue; if (r.polyline.length) withPoly++;
+    const st = pathStorey(g, r.path); if (st == null) continue; single++;
+    const o = seqIllegal(g, st, nodePts(g, r.path)), n = seqIllegal(g, st, r.polyline);
+    oldPts += o; newPts += n; if (n < o) improved++; if (n > o) worse++;
+  }
+  console.log = realLog; db.close(); fs.unlinkSync(tmp);
+  const red = oldPts ? (100 * (oldPts - newPts) / oldPts) : 0;
+  console.log('§POLY_LEGALITY ' + label + ' singleStoreyPairs=' + single + ' withPolyline=' + withPoly +
+    ' OLD_illegalPts=' + oldPts + ' NEW_illegalPts=' + newPts + ' reduction=' + red.toFixed(1) + '% improvedPairs=' + improved + ' worsePairs=' + worse);
+  return { single, oldPts, newPts, red, improved, worse };
+}
+
+// path/doors/distance byte-identical to origin/main
+function regression(label, dbFile, patches, modeller) {
+  const src = load(dbFile, patches, modeller);
+  const g = RG.buildGraph(src.dbQuery, { log: () => {} });
+  const gB = RGbefore.buildGraph(src.dbQuery, { log: () => {} });
+  const rooms = g.nodes.filter(n => n.kind === 'room');
+  let cmp = 0, id = 0, firstDiff = null;
+  const realLog = console.log; console.log = () => {};
+  for (let i = 0; i < rooms.length; i++) for (let j = i + 1; j < rooms.length; j++) {
+    const rN = RG.shortestPath(g, rooms[i].guid, rooms[j].guid), rO = RGbefore.shortestPath(gB, rooms[i].guid, rooms[j].guid);
+    cmp++;
+    const same = (rN === null && rO === null) || (rN && rO && JSON.stringify(rN.path) === JSON.stringify(rO.path) &&
+      JSON.stringify(rN.doors) === JSON.stringify(rO.doors) && Math.abs(rN.distance - rO.distance) < 1e-9);
+    if (same) id++; else if (!firstDiff) firstDiff = rooms[i].guid + '>' + rooms[j].guid;
+  }
+  console.log = realLog; src.db.close(); fs.unlinkSync(src.tmp);
+  console.log('§POLY_NOREG ' + label + ' compared=' + cmp + ' identical=' + id + (firstDiff ? ' firstDiff=' + firstDiff : ''));
+  return { cmp, id };
+}
+
+// interactive A* timing on the largest raster-backed building — sample CONNECTED pairs (skip nulls) so
+// the number reflects real A* work, not disconnected-component early-outs.
+function timing(label, dbFile, patches) {
+  const { db, tmp, dbQuery } = load(dbFile, patches);
+  const g = RG.buildGraph(dbQuery, { log: () => {} });
+  const rooms = g.nodes.filter(n => n.kind === 'room');
+  const realLog = console.log; console.log = () => {};
+  let n = 0, ms = 0, maxMs = 0, sumPts = 0, connected = 0;
+  for (let i = 0; i < rooms.length && connected < 300; i++) for (let j = i + 1; j < rooms.length && connected < 300; j++) {
+    const t0 = process.hrtime.bigint();
+    const r = RG.shortestPath(g, rooms[i].guid, rooms[j].guid);
+    const dt = Number(process.hrtime.bigint() - t0) / 1e6;
+    n++;
+    if (r && r.polyline && r.polyline.length) { connected++; ms += dt; if (dt > maxMs) maxMs = dt; sumPts += r.polyline.length; }
+  }
+  console.log = realLog; db.close(); fs.unlinkSync(tmp);
+  const per = connected ? ms / connected : 0;
+  console.log('§POLY_TIMING ' + label + ' storeys=' + Object.keys(g.rasters || {}).length + ' rooms=' + rooms.length +
+    ' connectedPathsTimed=' + connected + ' avgMsPerPath=' + per.toFixed(2) + ' maxMsPerPath=' + maxMs.toFixed(2) +
+    ' avgPolyPts=' + (sumPts / Math.max(1, connected)).toFixed(1));
+  return { per, maxMs, connected };
+}
+
+// ═══ RUN ═══
+const term = legality('Terminal(raster,splitDB)', 'Terminal_meta.db', ['viewer/buildings/patches/Terminal_meta.db.sql']);
+const hhs = legality('HHS(raster)', 'HHS_Office_Federated_extracted.db', ['viewer/buildings/patches/HHS_Office_Federated_extracted.db.sql']);
+const clinic = legality('Clinic(rect-fallback)', 'Clinic_extracted.db', []);
+const dup = legality('Duplex(rect-fallback)', 'Duplex_ARC.db', [], true);
+
+chk('G0 shortestPath returns a polyline (raster-backed pairs carry a real floor-hugging route)',
+  term.single > 0 && hhs.single > 0 && term.oldPts > 0, 'Terminal pairs=' + term.single + ' HHS pairs=' + hhs.single);
+chk('G1a Terminal(raster): polyline is ON FLOOR — old straight path had ' + term.oldPts + ' illegal pts, polyline reduces >=99%',
+  term.red >= 99 && term.oldPts > 0, 'reduction=' + term.red.toFixed(1) + '% (new=' + term.newPts + ')');
+chk('G1b HHS(raster): polyline reduces the old straight-path off-floor sampling by >=95% (circ-island bypass)',
+  hhs.red >= 95 && hhs.oldPts > 0, 'reduction=' + hhs.red.toFixed(1) + '% old=' + hhs.oldPts + ' new=' + hhs.newPts + ' improvedPairs=' + hhs.improved);
+chk('G1c ON-FLOOR GUARANTEE: the polyline is NEVER worse than the old straight path (0 worse pairs on every building)',
+  term.worse === 0 && hhs.worse === 0 && clinic.worse === 0 && dup.worse === 0,
+  'worsePairs T=' + term.worse + ' HHS=' + hhs.worse + ' Clinic=' + clinic.worse + ' Duplex=' + dup.worse);
+
+const regT = regression('Terminal', 'Terminal_meta.db', ['viewer/buildings/patches/Terminal_meta.db.sql']);
+const regH = regression('HHS', 'HHS_Office_Federated_extracted.db', ['viewer/buildings/patches/HHS_Office_Federated_extracted.db.sql']);
+const regJ = regression('JKR', 'JKR_extracted.db', ['viewer/buildings/patches/JKR_extracted.db.sql']);
+const regD = regression('Duplex', 'Duplex_ARC.db', [], true);
+chk('G2 path/doors/distance byte-identical to origin/main on all buildings (polyline is purely additive)',
+  regT.id === regT.cmp && regH.id === regH.cmp && regJ.id === regJ.cmp && regD.id === regD.cmp && (regT.cmp + regH.cmp + regJ.cmp + regD.cmp) > 0,
+  'T=' + regT.id + '/' + regT.cmp + ' HHS=' + regH.id + '/' + regH.cmp + ' JKR=' + regJ.id + '/' + regJ.cmp + ' Duplex=' + regD.id + '/' + regD.cmp);
+
+chk('G4 no-raster building (Clinic/Duplex rect fallback) still routes polylines, never regresses legality (honest degrade)',
+  clinic.red >= 0 && dup.red >= 0 && clinic.single > 0 && dup.single > 0,
+  'Clinic red=' + clinic.red.toFixed(1) + '% Duplex red=' + dup.red.toFixed(1) + '%');
+
+const tHosp = timing('Hospital', 'Hospital_extracted.db', ['viewer/buildings/patches/Hospital_extracted.db.sql']);
+chk('G3 interactive A* timing on the largest building stays well under an interactive click budget (avg <50ms, max <150ms)',
+  tHosp.per < 50 && tHosp.maxMs < 150 && tHosp.connected > 0, 'avgMs=' + tHosp.per.toFixed(2) + ' maxMs=' + tHosp.maxMs.toFixed(2) + ' timed=' + tHosp.connected);
+
+console.log('\n§W-ROOM-PATH-RASTER-POLYLINE DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Stage B of the walkable-raster / real-routing task (VIEWER_FIND_PANEL_ROOM_ACCURACY.md §13)

### The problem (§11)
The Find-Panel route line cut through walls / open atrium air because it drew **straight chords between synthetic graph waypoints** (room centers, CIRC/SPINE centroids) and "legalized" them post-hoc against a coarse signal via a sparse door-visibility detour — which §11 measured failing on 90-100% of multi-hop paths. §11 concluded the real fix is *"the drawn polyline follows real walkable space instead of straight lines between graph waypoints legalized post-hoc."*

### The fix — a real A* over the walkable raster, additive and zero-risk to the logical route
`shortestPath()` gains **one new field, `polyline`**: world `{x,y,z}` points computed by A* over `_pointWalkable` (raster-first via `storey_raster.js`'s `contains()`, room+corridor-rect fallback, `null`=no-data). **`path`/`doors`/`distance` and the `_legalizePath` door-detour (+ its `§PATH_LEGAL_DETOUR_FAIL` metric the raster witnesses assert) are UNTOUCHED** — byte-identical to origin/main on every building. The viewer's connecting `THREE.Line` now follows `result.polyline`; markers / room-list / zoom are unchanged.

Three findings made it work on real data:
- **§CIRC-NOT-A-WALKPOINT** (the key §11 diagnosis, now proven): the `circ` node is a per-storey circulation-hub **centroid** (a stair-group average), not a walked point — it sits on a **disconnected raster island**, so A* can't reach it and every `room→…→circ→…→room` chord degraded to the old straight line. The polyline **bypasses circ and routes the flanking corridor spines directly** (verified: HHS spine→spine straight = 61 illegal → A* polyline = 0). It is never dropped from `path` (room list/markers keep it); cross-storey never relies on it (`_publicHop` substitutes real `stairwp`).
- **§ON-FLOOR-GUARANTEE**: A* only returns a route **verified on-floor end to end** (including the anchor connectors); otherwise `null` → the caller keeps the original straight/synthetic route. So the polyline is provably **never worse** than before, and where the raster connects the endpoints it is **100% on real floor by construction**.
- **Perf**: local fine-grid pass, then a **bounded, coarser widen pass** (not full-storey — that stacked several storey-wide A* per cross-wing path, measured 205ms). Reuses `storey_raster.js` — no second raster representation.

### Witness — `witness_room_path_raster_polyline.js`, 7/7
- **Terminal** (raster, the Stage-A split-DB build): old straight **1152 illegal pts → polyline 0** (100%, 48 pairs fixed).
- **HHS** (raster): **11866 → 90** illegal pts (**99.2%**, 322 pairs fixed) via the circ-island bypass.
- **ON-FLOOR GUARANTEE**: 0 worse pairs on Terminal/HHS/Clinic/Duplex.
- **Regression** path/doors/distance byte-identical to origin/main: Terminal 903/903, HHS 5460/5460, JKR 2145/2145, Duplex 210/210.
- **Honest degrade**: Clinic/Duplex (rect fallback, doorway seams genuinely uncrossable) never regress.
- **Timing** on Hospital (largest, 156 rooms / 7 storeys): **avg 34.9ms / max 126ms** per path — well within an interactive click budget.

Full existing suite green: `room_graph_path` 15/15, `room_graph_utility_penalty` 9/9, `backbone_routing` 10/10, `corridor_room_backprop` 5/5, `full_connectivity` 6/6, `hallway_backbone` 7/7, `corridor_type_label` 5/5, `stair_flight_assembly_merge` 4/4, JKR/HHS/Terminal raster witnesses all green. (`witness_terminal_room_coordinate_fix` fails 2/5 — confirmed **pre-existing on origin/main**, a drifted §24 fixture, unrelated to this additive change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9ynxZzBktCXekz2P45HwF