### PR TITLE
feat(viewer): R room-cycle + Home fill-frame keyboard shortcuts

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -907,6 +907,174 @@ async function setupScene(A) {
     console.log('§ZOOM dir=' + dir + ' ' + (dir > 0 ? 'in' : 'out'));
   }
 
+  // ══════════════════════════════════════════════════════════════
+  // ROOM_CYCLE_HOME_SHORTCUTS.md — plain R cycles to progressively smaller rooms by real area;
+  // plain Home resets the cycle + fits a tight exterior view. Fully independent of Alt+C
+  // Cinema/MaxQ (no shared state, never calls startMaxQualityOrbit/startCinemaOrbit).
+  // ══════════════════════════════════════════════════════════════
+  var _roomCycleList = null;   // [{guid,area,name,cx,cy,cz,sx,sy}] sorted area DESC — IFC-space centers
+  var _roomCycleIdx = -1;      // -1 = fresh/reset; 0 = largest; clamps at list.length-1
+  var _roomCycleBld = null;    // building the list was built for — a building switch forces a rebuild
+
+  // "Largest" per ROOM_CYCLE_HOME_SHORTCUTS.md §Spec: SUM(size_x*size_y) GROUP BY room_guid over
+  // spatial_structure (existing columns — no schema change), excluding SUSPECT_* (compiler's own
+  // low-confidence flag, same filter class as Alt+C's §CINEMA_SPACE_ENCLOSED_SKIP). `room_guid` is
+  // only present after room_walker.js's writeRooms() ALTERs it in (§MULTI-RECT compiled rooms) —
+  // real/un-compiled IfcSpace data has no such column, same schema-tolerance fallback (bare `guid`)
+  // navigate_find.js/room_graph.js/hallway_backbone.js already use everywhere else.
+  function _buildRoomAreaList() {
+    if (!A.dbQuery) return [];
+    var hasRoomGuid = false;
+    try {
+      var cols = A.dbQuery('PRAGMA table_info(spatial_structure)');
+      hasRoomGuid = cols.some(function(c) { return c[1] === 'room_guid'; });
+    } catch (e) { /* table missing — rows below will just come back empty */ }
+    var rg = hasRoomGuid ? 'room_guid' : 'guid';
+    var rows = A.dbQuery(
+      'SELECT ' + rg + ' AS rg, SUM(size_x * size_y) AS area FROM spatial_structure ' +
+      "WHERE type='IfcSpace' AND " + rg + ' IS NOT NULL ' +
+      "AND (predefined_type IS NULL OR predefined_type NOT LIKE 'SUSPECT\\_%' ESCAPE '\\') " +
+      'GROUP BY ' + rg + ' ORDER BY area DESC');
+    var list = [];
+    for (var i = 0; i < rows.length; i++) {
+      var guid = rows[i][0], area = rows[i][1];
+      if (!guid || !(area > 0)) continue;
+      // Primary rect row (§MULTI-RECT: guid === room_guid is the un-suffixed first sub-rect) —
+      // its own center/size is the room's anchor position, not an average across sub-rects.
+      var pr = A.dbQuery('SELECT name, center_x, center_y, center_z, size_x, size_y ' +
+        "FROM spatial_structure WHERE type='IfcSpace' AND guid = ?", [guid]);
+      if (!pr.length) continue;
+      list.push({ guid: guid, area: area, name: pr[0][0] || guid,
+        cx: pr[0][1], cy: pr[0][2], cz: pr[0][3], sx: pr[0][4], sy: pr[0][5] });
+    }
+    return list;
+  }
+
+  // The building's main entrance = the lowest-cz 'exit' node of the room/corridor graph — reused
+  // verbatim from tour.js's own entrance pick (never reimplemented, per the spec's Confirmed facts).
+  function _graphEntrance(graph) {
+    if (!graph || !graph.nodesByGuid) return null;
+    var entrance = null;
+    for (var k in graph.nodesByGuid) {
+      var n = graph.nodesByGuid[k];
+      if (n.kind === 'exit' && (!entrance || n.cz < entrance.cz)) entrance = n;
+    }
+    return entrance ? { cx: entrance.cx, cy: entrance.cy, cz: entrance.cz } : null;
+  }
+
+  // A specific room's OWN doorway — any graph edge touching this room's guid that carries a real
+  // doorGuid (E1/E2/E4), reusing the door-carrying-room routing tag (bim-ootb#03a6cb7) rather than
+  // reinventing door detection. Every such door is registered in graph.nodesByGuid (kind 'doorwp'/
+  // 'exit') with its own real measured position — never a storey centroid.
+  function _roomOwnDoor(graph, roomGuid) {
+    if (!graph || !graph.edges) return null;
+    for (var i = 0; i < graph.edges.length; i++) {
+      var e = graph.edges[i];
+      if (!e.doorGuid) continue;
+      if (e.a === roomGuid || e.b === roomGuid) {
+        var dn = graph.nodesByGuid && graph.nodesByGuid[e.doorGuid];
+        if (dn) return { cx: dn.cx, cy: dn.cy, cz: dn.cz };
+      }
+    }
+    return null;
+  }
+
+  // Point the camera at `room` (controls.target = room's own center, per spec) so its view
+  // direction leans toward `facing` (entrance for the largest room, own doorway for the rest) —
+  // i.e. the camera is positioned on the OPPOSITE side of the room from `facing`, so continuing
+  // forward from the camera through the room center points at the facing point's bearing.
+  function _faceRoom(room, facing, facingSrc) {
+    var roomC3 = A.ifc2three(room.cx, room.cy, room.cz);
+    var roomSpan = Math.max(room.sx || 0, room.sy || 0, 4);
+    var dist = Math.max(4, roomSpan * 1.5); // same 1.5 fit-margin convention as streaming.js §CAMERA
+    var camPos;
+    if (facing) {
+      var facing3 = A.ifc2three(facing.cx, facing.cy, facing.cz);
+      var dx = facing3.x - roomC3.x, dz = facing3.z - roomC3.z;
+      var horiz = Math.hypot(dx, dz);
+      var ux = horiz > 1e-6 ? dx / horiz : 1, uz = horiz > 1e-6 ? dz / horiz : 0;
+      camPos = { x: roomC3.x - ux * dist * 0.6, y: roomC3.y + dist * 0.8, z: roomC3.z - uz * dist * 0.6 };
+    } else {
+      facingSrc = 'none';
+      camPos = { x: roomC3.x + dist * 0.6, y: roomC3.y + dist * 0.8, z: roomC3.z + dist * 0.6 };
+    }
+    A.camera.position.set(camPos.x, camPos.y, camPos.z);
+    A.controls.target.set(roomC3.x, roomC3.y, roomC3.z);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+    return facingSrc;
+  }
+
+  async function _cycleRoom() {
+    if (!A.camera || !A.controls || typeof THREE === 'undefined' || !A.dbQuery) {
+      console.log('§ROOM_CYCLE no-op reason=no-engine'); return;
+    }
+    // Lazy-load the Navigate bundle — A.ensureRooms/A.getRoomGraph live there (78KB saved on first
+    // paint; same warm-up pattern effects.js's §CINEMA_ROOMS already uses for the same reason).
+    if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) {
+      try { await A.loadNavigate(); } catch (e) { console.log('§ROOM_CYCLE loadNavigate_err=' + e.message); return; }
+    }
+    if (typeof A.ensureRooms === 'function') {
+      try { await A.ensureRooms({}); } catch (e) { console.log('§ROOM_CYCLE ensureRooms_err=' + e.message); }
+    }
+    if (_roomCycleIdx < 0 || _roomCycleBld !== A.activeBuilding) {
+      _roomCycleList = _buildRoomAreaList();
+      _roomCycleBld = A.activeBuilding;
+      _roomCycleIdx = -1;
+    }
+    if (!_roomCycleList || !_roomCycleList.length) { console.log('§ROOM_CYCLE no-op reason=no-rooms'); return; }
+    if (_roomCycleIdx < _roomCycleList.length - 1) _roomCycleIdx++;  // clamp at the smallest, never wrap
+    var room = _roomCycleList[_roomCycleIdx];
+    var graph = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
+    var isFirst = _roomCycleIdx === 0;
+    // §JUDGMENT-CALL (spec "Out of scope", flagged not user-confirmed): room #2+ faces its OWN
+    // doorway rather than the global entrance — falls back to the entrance if the room has no
+    // tagged door edge (e.g. an isolated/no-door compiled room) so a facing is still attempted.
+    var facing = isFirst ? _graphEntrance(graph) : (_roomOwnDoor(graph, room.guid) || _graphEntrance(graph));
+    var facingSrc = isFirst ? 'entrance' : (_roomOwnDoor(graph, room.guid) ? 'own-door' : 'entrance-fallback');
+    facingSrc = _faceRoom(room, facing, facing ? facingSrc : 'none');
+    console.log('§ROOM_CYCLE press=' + (_roomCycleIdx + 1) + ' guid=' + room.guid +
+      ' area=' + room.area.toFixed(1) + ' name=' + room.name + ' facing=' + facingSrc);
+  }
+
+  // Fit the camera to a TIGHT (zero-margin) exterior view of the whole building's
+  // element_transforms bbox — byte-identical elevation/azimuth ratio (0.6,0.8,0.6) and buildingCentres
+  // target as the initial-load §CAMERA framing (streaming.js, confirmed via grep before copying),
+  // just with the padding multiplier dropped from 1.5 to 1.0 (the 80m floor is a degenerate-envelope
+  // safety clamp, not "margin", so it stays).
+  function _homeFillFrame() {
+    if (!A.camera || !A.controls || !A.dbQuery || typeof THREE === 'undefined') {
+      console.log('§ROOM_HOME no-op reason=no-engine'); return;
+    }
+    var bboxQ = A.dbQuery(A._hasBbox
+      ? 'SELECT MAX(bbox_x), MAX(bbox_y), MAX(bbox_z), MIN(center_x), MAX(center_x), MIN(center_y), MAX(center_y), MIN(center_z), MAX(center_z) FROM element_transforms'
+      : 'SELECT NULL, NULL, NULL, MIN(center_x), MAX(center_x), MIN(center_y), MAX(center_y), MIN(center_z), MAX(center_z) FROM element_transforms');
+    var envW = 500, envD = 500, envH = 100;
+    if (bboxQ.length > 0 && bboxQ[0][3] != null) {
+      var xMin = bboxQ[0][3], xMax = bboxQ[0][4], yMin = bboxQ[0][5], yMax = bboxQ[0][6], zMin = bboxQ[0][7], zMax = bboxQ[0][8];
+      envW = xMax - xMin; envD = yMax - yMin; envH = zMax - zMin;
+    }
+    if (envW < 1 && A.buildingCentres && Object.keys(A.buildingCentres).length > 0) {
+      var bc0 = Object.values(A.buildingCentres)[0];
+      envW = Math.max(50, Math.sqrt(bc0.count) * 2); envD = envW; envH = envW * 0.5;
+    }
+    var envelope = Math.max(envW, envD, envH);
+    var dist = Math.max(80, envelope * 1.0);  // §ZERO_MARGIN: was envelope*1.5 at load time
+    var firstBc = (A.buildingCentres && Object.keys(A.buildingCentres).length) ? Object.values(A.buildingCentres)[0] : null;
+    var ctr = firstBc ? A.ifc2three(firstBc.ix, firstBc.iy, firstBc.iz) : A.ifc2three(0, 0, 0);
+    A.camera.position.set(ctr.x + dist * 0.6, ctr.y + dist * 0.8, ctr.z + dist * 0.6);
+    A.controls.target.set(ctr.x, ctr.y, ctr.z);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+    console.log('§ROOM_HOME reset=cycle+frame bbox=' + envW.toFixed(0) + 'x' + envD.toFixed(0) + 'x' + envH.toFixed(0) + 'm dist=' + dist.toFixed(0) + 'm');
+  }
+
+  function _homeResetAndFrame() {
+    _roomCycleIdx = -1;   // next R press goes back to the largest room
+    _homeFillFrame();
+  }
+  A._roomCycle = { list: function() { return _roomCycleList; }, idx: function() { return _roomCycleIdx; } }; // exposed for tests
+
   var _shortcuts = {
     '+':  function() { _zoomStep(1); },             // zoom in
     '-':  function() { _zoomStep(-1); },            // zoom out
@@ -1115,6 +1283,9 @@ async function setupScene(A) {
     // the pill-drawer reorg (§DELETIONS, e433ac4) but this binding + window.toggleRecord() were
     // left behind, throwing ReferenceError: _recBtn is not defined on every press. No live caller
     // left anywhere in the codebase — matches the reorg's own "no longer in use, delete" verdict.
+    // ROOM_CYCLE_HOME_SHORTCUTS.md (2026-07-22): 'r' reused for Room Cycle — plain R is confirmed
+    // free (grepped), unrelated to the retired Record binding above.
+    'r':  function() { _cycleRoom(); },
     'a':  function() { if (typeof window.resetCamOrbit === 'function') window.resetCamOrbit(); },   // Reset cam (Anchor) — precision-cam cluster w/ CapsLock+Q
     'q':  function() { if (typeof window.toggleCamPivot === 'function') window.toggleCamPivot(); },  // Auto-Pivot toggle
     'Ctrl+S': function() { if (A.saveModelDb) A.saveModelDb(); },   // Save Building → native Save As…
@@ -1958,6 +2129,19 @@ async function setupScene(A) {
         _focusedPanel.nav.onTypeahead(e.key);
         return;
       }
+    }
+
+    // ROOM_CYCLE_HOME_SHORTCUTS.md — plain Home resets the R-cycle + fits a tight exterior frame,
+    // but ONLY in the genuine gap where Home is otherwise unclaimed: placed AFTER the _focusedPanel
+    // block above (so a focused list-nav panel keeps owning Home for jump-to-top, case 2 in the
+    // spec's Confirmed facts) and guarded off whenever corridor-nav is active (navigate_engine.js's
+    // own separate keydown listener already owns Home for route-reset via A._nav.active, case 1) —
+    // NOT placed in the top "always-on modifiers" section, which runs before the panel-focus check
+    // and would wrongly steal case 2.
+    if (noMod && notInput && e.key === 'Home' && !(A._nav && A._nav.active) && !_focusedPanel) {
+      e.preventDefault();
+      _homeResetAndFrame();
+      return;
     }
 
     if (!noMod || !notInput) { console.log('§KBD_ROUTE drop key=' + e.key + ' noMod=' + noMod + ' notInput=' + notInput); return; }

--- a/viewer/tests/witness_room_cycle_home_2026-07-22.js
+++ b/viewer/tests/witness_room_cycle_home_2026-07-22.js
@@ -1,0 +1,268 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: bim-compiler prompts/Viewer/ROOM_CYCLE_HOME_SHORTCUTS.md — two new global keyboard
+// shortcuts (plain R = cycle camera to progressively smaller rooms by real area; plain Home =
+// reset the R-cycle + fit a tight/zero-margin exterior view), landed in viewer/scene.js. This
+// witness proves, on the real HHS_Office_Federated_extracted.db fixture (headless Chromium, the
+// project's standard fixture for room/entrance work), the 5 assertions in the spec's Witness plan:
+//   (a) first R press lands on the DB-verified largest room — cross-checked against an
+//       INDEPENDENTLY-written aggregation (fetch every IfcSpace row, group/sum/filter SUSPECT_ in
+//       plain JS in THIS script) rather than re-running scene.js's own SQL string.
+//   (b) 3 successive R presses produce strictly non-increasing area, no duplicate room_guid.
+//   (c) Home mid-cycle, then R again, returns to the SAME largest-room guid as (a).
+//   (d) Home while the Find panel has keyboard focus still moves ITS OWN list cursor to the top
+//       (§KBD_ROUTE panel=find key=Home fires) — NOT stolen by the new §ROOM_HOME handler.
+//   (e) Home while corridor-nav (A._nav.active) is running still resets the route to its start
+//       (real §NAV_MOVE_CAM wp=0 fires via navigate_engine.js's own separate listener) — NOT
+//       stolen either.
+// §-log first — READ tests/witness_room_cycle_home_2026-07-22.log before any conclusion. No
+// screenshots — log values + DB cross-check only, per the FUNDAMENTAL LAW.
+// Run:  node viewer/tests/witness_room_cycle_home_2026-07-22.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '\u{1F7E2}' : '\u{1F534}') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+// Poll the live `cons` buffer until at least `count` NEW lines (indices >= sinceIdx) contain
+// `matchSubstr`, or `timeoutMs` elapses — the first R press is slow (A.loadNavigate() fetches
+// ~10 lazy JS modules + A.ensureRooms()'s first-call room-graph build), a fixed short sleep races
+// it. Returns the matching lines found (may be fewer than `count` on timeout).
+async function waitForLines(page, cons, sinceIdx, matchSubstr, count, timeoutMs) {
+  const start = Date.now();
+  let found = [];
+  while (Date.now() - start < timeoutMs) {
+    found = cons.slice(sinceIdx).filter(t => t.indexOf(matchSubstr) >= 0);
+    if (found.length >= count) return found;
+    await page.waitForTimeout(150);
+  }
+  return found;
+}
+
+async function waitReady(page) {
+  let ready = false;
+  for (let i = 0; i < 90 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false)); } catch (e) {}
+  }
+  return ready;
+}
+
+// Parse a §ROOM_CYCLE line into {press,guid,area,name,facing}.
+function parseRoomCycle(line) {
+  const m = /§ROOM_CYCLE press=(\d+) guid=(\S+) area=([\d.]+) name=(.*?) facing=(\S+)/.exec(line);
+  if (!m) return null;
+  return { press: +m[1], guid: m[2], area: +m[3], name: m[4], facing: m[5] };
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => { cons.push(m.text()); });
+
+  S('── witness_room_cycle_home (HHS_Office_Federated) ──');
+  await page.goto('http://127.0.0.1:' + server.address().port +
+    '/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db&bld=HHS_Office_Federated',
+    { waitUntil: 'load', timeout: 60000 });
+  const ready = await waitReady(page);
+  verdict(ready, 'real model loaded + ready (HHS_Office_Federated)');
+  if (!ready) {
+    S('\n❌ ABORT — model never became ready');
+    fs.writeFileSync(path.join(__dirname, 'witness_room_cycle_home_2026-07-22.log'), log.join('\n') + '\n');
+    await browser.close(); server.close(); process.exit(1);
+  }
+
+  // ══ Independent ground-truth: fetch every IfcSpace row, aggregate/filter in THIS script's own
+  // plain-JS logic (not scene.js's SQL string) — a real cross-check, not a rubber-stamp of the
+  // production query. Runs against the SAME live self-healed A.db (A.ensureRooms already ran once
+  // via the first 'r' press below) — the on-disk fixture has no room_guid column until the
+  // in-browser self-heal ALTERs it in; that's the fixture's real, current, on-disk state, per
+  // ROOM_CYCLE_HOME_SHORTCUTS.md's own Confirmed facts, not an assumption.
+  async function independentLargestRooms() {
+    return page.evaluate(() => {
+      const A = window.APP;
+      const cols = A.dbQuery('PRAGMA table_info(spatial_structure)');
+      const hasRoomGuid = cols.some(c => c[1] === 'room_guid');
+      const rgIdx = hasRoomGuid ? 'has' : 'no';
+      const rows = A.dbQuery('SELECT guid, ' + (hasRoomGuid ? 'room_guid' : 'guid') +
+        ', size_x, size_y, predefined_type FROM spatial_structure WHERE type=\'IfcSpace\'');
+      const groups = {};
+      for (const r of rows) {
+        const rg = r[1];
+        const ptype = r[4] || '';
+        if (!rg) continue;
+        if (ptype.indexOf('SUSPECT_') === 0) continue;
+        const area = (r[2] || 0) * (r[3] || 0);
+        groups[rg] = (groups[rg] || 0) + area;
+      }
+      const list = Object.keys(groups).map(g => ({ guid: g, area: groups[g] })).filter(x => x.area > 0);
+      list.sort((a, b) => b.area - a.area);
+      return { rgIdx, list };
+    });
+  }
+
+  // ── §ROOM_CYCLE press 1: R ──
+  let sinceIdx = cons.length;
+  await page.keyboard.press('r');
+  let raw = await waitForLines(page, cons, sinceIdx, '§ROOM_CYCLE', 1, 15000); // slow first call: A.loadNavigate() + A.ensureRooms()
+  let lines = raw.map(parseRoomCycle).filter(Boolean);
+  verdict(lines.length >= 1, 'first R press emitted a §ROOM_CYCLE line', 'lines=' + lines.length);
+  const p1 = lines[0];
+  if (p1) S('     [console] press=1 guid=' + p1.guid + ' area=' + p1.area + ' name="' + p1.name + '" facing=' + p1.facing);
+
+  const gt = await independentLargestRooms();
+  S('     [info] independent cross-check: room_guid column ' + gt.rgIdx + ', ' + gt.list.length + ' rooms, top=' +
+    (gt.list[0] ? gt.list[0].guid + '@' + gt.list[0].area.toFixed(1) : 'none'));
+
+  // (a) first R press lands on the DB-verified largest room
+  const aOk = !!p1 && !!gt.list[0] && p1.guid === gt.list[0].guid && Math.abs(p1.area - gt.list[0].area) < 0.5;
+  verdict(aOk, '(a) first R press == independently-computed largest room',
+    p1 && gt.list[0] ? 'scene.js=' + p1.guid + '@' + p1.area.toFixed(1) + ' independent=' + gt.list[0].guid + '@' + gt.list[0].area.toFixed(1) : 'missing data');
+
+  // ── §ROOM_CYCLE presses 2 and 3: R, R ──
+  sinceIdx = cons.length;
+  await page.keyboard.press('r');
+  await waitForLines(page, cons, sinceIdx, '§ROOM_CYCLE', 1, 3000);
+  await page.keyboard.press('r');
+  await waitForLines(page, cons, sinceIdx, '§ROOM_CYCLE', 2, 3000);
+  lines = cons.slice(sinceIdx).filter(t => t.indexOf('§ROOM_CYCLE') >= 0).map(parseRoomCycle).filter(Boolean);
+  verdict(lines.length === 2, '2 more R presses each emitted one §ROOM_CYCLE line', 'lines=' + lines.length);
+  lines.forEach(l => S('     [console] press=' + l.press + ' guid=' + l.guid + ' area=' + l.area + ' name="' + l.name + '" facing=' + l.facing));
+  const seq = [p1, ...lines].filter(Boolean);
+
+  // (b) 3 successive R presses: strictly non-increasing area, no duplicate guid
+  let nonIncreasing = true;
+  for (let i = 1; i < seq.length; i++) if (seq[i].area > seq[i - 1].area + 1e-6) nonIncreasing = false;
+  const guids = seq.map(s => s.guid);
+  const noDup = new Set(guids).size === guids.length;
+  verdict(seq.length === 3, '(b) captured all 3 presses', 'count=' + seq.length);
+  verdict(nonIncreasing, '(b) area is non-increasing across the 3 presses', JSON.stringify(seq.map(s => s.area)));
+  verdict(noDup, '(b) no duplicate room_guid across the 3 presses', JSON.stringify(guids));
+
+  // ── (c) Home mid-cycle, then R again → back to the SAME largest-room guid as (a) ──
+  sinceIdx = cons.length;
+  await page.keyboard.press('Home');
+  const homeLines1 = await waitForLines(page, cons, sinceIdx, '§ROOM_HOME', 1, 3000);
+  verdict(homeLines1.length >= 1, '(c) Home (no panel focus, no active nav) emitted §ROOM_HOME', 'lines=' + homeLines1.length);
+  if (homeLines1[0]) S('     [console] ' + homeLines1[0]);
+
+  sinceIdx = cons.length;
+  await page.keyboard.press('r');
+  raw = await waitForLines(page, cons, sinceIdx, '§ROOM_CYCLE', 1, 3000);
+  lines = raw.map(parseRoomCycle).filter(Boolean);
+  const p1b = lines[0];
+  verdict(!!p1b && p1b.press === 1, '(c) R after Home is press=1 again (cycle index reset)', p1b ? 'press=' + p1b.press : 'no line');
+  verdict(!!p1b && !!p1 && p1b.guid === p1.guid, '(c) R after Home returns to the SAME largest-room guid as (a)',
+    p1b && p1 ? 'after-home=' + p1b.guid + ' step-a=' + p1.guid : 'missing data');
+
+  // ── (d) Home while the Find panel has keyboard focus — real user path: rail pill →
+  // Navigate drawer → Find row → click inside the panel to focus it (pointerdown, same
+  // convention _registerPanel's own listener uses), same as witness_room_box_purple_2026-07-12.js. ──
+  await page.waitForFunction(() => window._mainPillActions && window._mainPillActions.length > 0, { timeout: 15000 }).catch(() => {});
+  await page.click('#mobile-trigger', { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(300);
+  async function tap(id) {
+    return page.evaluate((eid) => {
+      const el = document.getElementById(eid);
+      if (!el) return false;
+      el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      return true;
+    }, id);
+  }
+  const railHit = await tap('pill-navigate');
+  const rowHit = await tap('drawer-row-find');
+  verdict(railHit && rowHit, 'Find panel opened via real rail-pill → drawer-row path', 'rail=' + railHit + ' row=' + rowHit);
+  await page.waitForTimeout(400);
+  const focusHit = await page.evaluate(() => {
+    const el = document.getElementById('find-name');
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    return true;
+  });
+  await page.waitForTimeout(200);
+  const focusedId = await page.evaluate(() => (window._panels || []).find(p => p.el && p.el.style.boxShadow) ?
+    (window._panels.find(p => p.el.style.boxShadow) || {}).id : null);
+  verdict(focusHit && focusedId === 'find', 'Find panel is the keyboard-focused panel (_focusedPanel.id==="find")', 'focusedId=' + focusedId);
+
+  cons.length = 0;
+  await page.keyboard.press('Home');
+  await page.waitForTimeout(400);
+  const dHomeStolen = cons.filter(t => t.indexOf('§ROOM_HOME') >= 0);
+  const dPanelRoute = cons.filter(t => t.indexOf('§KBD_ROUTE panel=find key=Home') >= 0);
+  verdict(dHomeStolen.length === 0, '(d) §ROOM_HOME did NOT fire (not stolen from the focused panel)', 'lines=' + dHomeStolen.length);
+  verdict(dPanelRoute.length >= 1, '(d) Home was routed to the Find panel\'s own list-nav (§KBD_ROUTE panel=find key=Home), existing behavior preserved',
+    'lines=' + dPanelRoute.length);
+  if (dPanelRoute[0]) S('     [console] ' + dPanelRoute[0]);
+
+  // Blur the panel before the corridor-nav case so it doesn't shadow that guard too.
+  await page.evaluate(() => { if (window._blurPanel) window._blurPanel(); });
+  await page.waitForTimeout(200);
+
+  // ── (e) Home while A._nav.active (real corridor-nav session) — call the SAME production
+  // A.startNavigation() the Find panel's own ▶ Navigate button calls, with a real target row
+  // pulled from element_transforms/elements_meta (never invented), trying a few real doors until
+  // one produces a real walkable path (§NAV_START / nav.active===true). ──
+  const navResult = await page.evaluate(async () => {
+    const A = window.APP;
+    if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+    const rows = A.dbQuery(
+      "SELECT m.guid, m.ifc_class, m.element_name, m.storey, t.center_x, t.center_y, t.center_z " +
+      "FROM elements_meta m JOIN element_transforms t ON m.guid = t.guid " +
+      "WHERE m.ifc_class IN ('IfcDoor','IfcDoorStandardCase') AND m.building = ? LIMIT 12", [A.activeBuilding || '']);
+    for (const r of rows) {
+      const target = { guid: r[0], ifc_class: r[1], element_name: r[2], storey: r[3], cx: r[4], cy: r[5], cz: r[6] };
+      A.startNavigation(target);
+      if (A._nav && A._nav.active) return { ok: true, guid: r[0], storey: r[3], candidates: rows.length };
+    }
+    return { ok: false, candidates: rows.length };
+  });
+  verdict(navResult.ok, '(e) real corridor-nav session started (A.startNavigation succeeded on a real door target)',
+    JSON.stringify(navResult));
+
+  if (navResult.ok) {
+    // Advance a step first so resetToStart (stepIdx -> 0) is an observable, non-trivial change.
+    await page.evaluate(() => { if (window.APP.advanceNavStep) window.APP.advanceNavStep(); });
+    await page.waitForTimeout(300);
+    const stepBefore = await page.evaluate(() => window.APP._nav ? window.APP._nav.stepIdx : null);
+
+    cons.length = 0;
+    await page.keyboard.press('Home');
+    await page.waitForTimeout(400);
+    const eHomeStolen = cons.filter(t => t.indexOf('§ROOM_HOME') >= 0);
+    const eNavReset = cons.filter(t => t.indexOf('§NAV_MOVE_CAM wp=0/') >= 0);
+    const stepAfter = await page.evaluate(() => window.APP._nav ? window.APP._nav.stepIdx : null);
+    const activeAfter = await page.evaluate(() => window.APP._nav ? window.APP._nav.active : null);
+    verdict(eHomeStolen.length === 0, '(e) §ROOM_HOME did NOT fire (not stolen while corridor-nav is active)', 'lines=' + eHomeStolen.length);
+    verdict(eNavReset.length >= 1, '(e) corridor-nav\'s own Home handler fired (§NAV_MOVE_CAM wp=0/… — real resetToStart)',
+      'lines=' + eNavReset.length);
+    verdict(activeAfter === true, '(e) A._nav.active is still true after Home (route reset, not exited)', 'active=' + activeAfter);
+    verdict(stepBefore > 0 && stepAfter === 0, '(e) A._nav.stepIdx actually reset to 0 (real state change, not just a log line)',
+      'before=' + stepBefore + ' after=' + stepAfter);
+    if (eNavReset[0]) S('     [console] ' + eNavReset[0]);
+  }
+
+  await page.close(); await ctx.close();
+  await browser.close();
+  server.close();
+
+  S('\n' + (fails === 0 ? '✅ ALL PASS' : '❌ ' + fails + ' FAILED'));
+  fs.writeFileSync(path.join(__dirname, 'witness_room_cycle_home_2026-07-22.log'), log.join('\n') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -830,7 +830,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=51" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=52" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=54" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>


### PR DESCRIPTION
## Summary
- `R` (plain, no modifier): cycles the camera to progressively smaller rooms by real area (largest first), computed via `SUM(size_x*size_y) GROUP BY room_guid` over the existing `spatial_structure` columns — no schema change. Largest room faces the building's main entrance (reusing `tour.js`'s entrance-node detection); rooms #2+ face their own doorway (door-carrying-room routing tag), falling back to the global entrance if untagged.
- `Home` (plain): resets the `R` cycle index to 0 **and** fits the camera to a tight, zero-margin exterior view — same keypress, reusing the load-time camera elevation/azimuth ratio rather than inventing a new angle. Scoped (`!(A._nav && A._nav.active) && !_focusedPanel`) so it does not regress the two existing narrower `Home` claims (corridor-nav route-reset, focused-panel list-navigation).
- Fully independent of Alt+C Cinema/MaxQ orbit — no shared call path.

Spec: `prompts/Viewer/ROOM_CYCLE_HOME_SHORTCUTS.md` (bim-compiler repo).

## Test plan
- [x] `viewer/tests/witness_room_cycle_home_2026-07-22.js` — real `HHS_Office_Federated_extracted.db`, headless Chromium, 15/15 assertions pass (largest-room cross-checked against an independently-written DB query; 3 presses non-increasing area/no dupes; Home-then-R returns to the same largest room; Home preserves Find panel's own list-nav when focused; Home preserves corridor-nav route-reset when a real nav session is active, verified via `stepIdx` genuinely resetting 1→0).
- [x] Regression: `witness_find_panel_hidden_onload_2026-07-11.js` — all pass.
- [x] Regression: `witness_room_box_purple_2026-07-12.js` — 2 pre-existing failures confirmed present on unmodified `origin/main` via `git stash` (unrelated color-drift issue, not introduced by this change).
- [x] `eslint viewer/scene.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)