### PR TITLE
feat(erp): P2P Material Receipt unblocked, real signed M_MatchPO emitted

### DIFF
--- a/erp/ad_modelval.js
+++ b/erp/ad_modelval.js
@@ -201,6 +201,20 @@
     function w(info) { return (info.warnings = info.warnings || []); }
     function chg(info, col) { return !!(info.recordOld && info.record && String(info.recordOld[col]) !== String(info.record[col])); }
     var H = [
+      ['MInOut.movementTypeFromWindow', function (ctx, info) {
+        // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 2 — Witness: W-RECEIPT-MOVEMENTTYPE. Mirrors
+        // MOrder.docTypeTargetDefault's ctx.issotrx thread (ad_modelval.js ~line 131): crud_ops.json's
+        // m_inout entry declares no C_DocType_ID field, so movementTypeDerive below (which reads an
+        // already-set C_DocType_ID) can never fire for a manually-created record — this is the ONLY seam
+        // where the per-window signal (ctx.movementtype, threaded from the AD_Tab's own WhereClause, e.g.
+        // Material Receipt tab 296's "MovementType IN ('V+')") can reach the new row at all.
+        var r = info.record;
+        if (!r.movementtype && /^[A-Z][+-]$/.test((ctx && ctx.movementtype) || '')) {
+          d(info).movementtype = ctx.movementtype;
+          if (!r.issotrx) d(info).issotrx = ctx.movementtype.charAt(0) === 'C' ? 'Y' : 'N';
+        }
+        return null;
+      }],
       ['MInOut.movementTypeDerive', function (ctx, info) {   // :1306-1308 ∘ getMovementType:1275-1287
         var r = info.record;
         if (info.recordOld && !chg(info, 'c_doctype_id')) return null;   // fires on new record or doctype change
@@ -248,10 +262,26 @@
     function chg(info, col) { return !!(info.recordOld && info.record && String(info.recordOld[col]) !== String(info.record[col])); }
     function pick(r, info, col) { var dv = info.derived && info.derived[col]; return dv != null ? dv : r[col]; }
     var H = [
+      ['MInvoice.issotrxFromWindow', function (ctx, info) {
+        // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 4 — Witness: W-INVOICE-ISSOTRX. c_invoice's real
+        // AD_Tab family (263 "IsSOTrx='Y'", 290/470 "IsSOTrx='N'") already matches the EXISTING
+        // window.APP._createIsSOTrx regex (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-21) — but crud_ops.json's
+        // c_invoice entry declares no IsSOTrx field, so nothing ever wrote ctx.issotrx onto the new record
+        // itself (MOrder's docTypeTargetDefault derives BOTH doctype AND issotrx together; MInvoice's own
+        // docTypeTargetDefault below only READS r.issotrx, assuming something upstream already set it — for
+        // an auto-generated invoice that's DOC_SPECS.createInvoice's header(); for a MANUAL create (only
+        // possible via the Create-Lines-From-PO/Receipt picker, §Fix 4) this hook is that missing seam.
+        var r = info.record;
+        if (!r.issotrx && (ctx && (ctx.issotrx === 'Y' || ctx.issotrx === 'N'))) d(info).issotrx = ctx.issotrx;
+        return null;
+      }],
       ['MInvoice.bpDefaults', function (ctx, info) {         // :1147-1149 ∘ setBPartner:631-673 — location + term/pricelist/rule from the BP
         var r = info.record;
         if (Number(r.c_bpartner_location_id) > 0) return null;
-        var so = r.issotrx === 'Y';
+        // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 4 — pick() (not bare r.issotrx) sees issotrxFromWindow's
+        // derived value too, same-pass (hooks share one `info`, only `info.record` itself stays the static
+        // pre-hook snapshot — this is the existing derived-fallback convention priceListDefault already uses).
+        var so = pick(r, info, 'issotrx') === 'Y';
         var bp = db.prepare('SELECT paymentrule,c_paymentterm_id,po_paymentterm_id,m_pricelist_id,po_pricelist_id FROM c_bpartner WHERE c_bpartner_id=?').get(Number(r.c_bpartner_id));
         if (!bp) return null;
         var pt = so ? bp.c_paymentterm_id : bp.po_paymentterm_id;      // :638-644
@@ -294,7 +324,10 @@
       ['MInvoice.docTypeTargetDefault', function (ctx, info) {  // :1190-1194 ∘ setC_DocTypeTarget_ID:804-822 — ARI/API by SO flag
         var r = info.record;
         if (Number(r.c_doctypetarget_id) > 0) return null;
-        var dt = db.prepare("SELECT c_doctype_id FROM c_doctype WHERE docbasetype=? AND ad_org_id IN (0,?) AND isactive='Y' ORDER BY isdefault DESC, ad_org_id DESC, c_doctype_id").get(r.issotrx === 'Y' ? 'ARI' : 'API', Number(r.ad_org_id));
+        // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 4 — pick() sees issotrxFromWindow's derived value (same
+        // convention as bpDefaults above); without it a manually-created Purchase invoice always fell through
+        // to the bare r.issotrx (undefined) branch, which is truthy-false too but for the WRONG reason.
+        var dt = db.prepare("SELECT c_doctype_id FROM c_doctype WHERE docbasetype=? AND ad_org_id IN (0,?) AND isactive='Y' ORDER BY isdefault DESC, ad_org_id DESC, c_doctype_id").get(pick(r, info, 'issotrx') === 'Y' ? 'ARI' : 'API', Number(r.ad_org_id));
         if (dt) d(info).c_doctypetarget_id = dt.c_doctype_id;
         return null;
       }],

--- a/erp/crud_ops.json
+++ b/erp/crud_ops.json
@@ -95,6 +95,12 @@
       { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
         "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
       { "col": "movementdate", "label": "Movement Date", "type": "date", "required": true, "default": "today" },
+      { "col": "m_warehouse_id", "label": "Warehouse (ID)", "type": "number", "required": false,
+        "note": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — Java header field (org.compiere.model.MInOut header), manual entry same as C_Order.M_PriceList_ID; required for a Purchase (vendor) receipt, since InOutGenerate's SO-only fold never populates it here." },
+      { "col": "c_bpartner_id", "label": "Business Partner (ID)", "type": "number", "required": false,
+        "note": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — same header extension; a vendor receipt's BPartner is entered manually (real Java: MInOut header, not derived) — see CreateFromInOut/createLineFrom for how PO lines are then pulled in against this header." },
+      { "col": "c_order_id", "label": "Purchase Order (ID)", "type": "number", "required": false,
+        "note": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — the PO this receipt is against; lines are pulled from this order's lines via the Create-Lines-From-PO picker (§Fix 2), mirroring org.compiere.process.CreateFromInOut." },
       { "col": "description", "label": "Description", "type": "string", "required": false, "default": "" },
       { "col": "docstatus", "label": "Status", "type": "list", "ref": "docStatus", "required": true, "default": "DR" }
     ]
@@ -103,13 +109,18 @@
   "c_invoice": {
     "op": "o2c", "ordinal": 3, "kind": "bubble", "tab": "Data",
     "title": "Invoice",
-    "verbs": ["update", "delete", "process"],
+    "verbs": ["create", "update", "delete", "process"],
     "docAction": { "action": "CO", "from": "DR", "to": "CO", "requires": ["dateinvoiced"], "oracle": "org.compiere.model.MInvoice.completeIt()" },
     "ownerGated": true,
+    "createNote": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — 'create' is reachable ONLY via the Create-Invoice-Lines-from-PO/Receipt picker (§Fix 4, mirrors org.compiere.process.CreateFromInvoice), never a bare blank invoice — grandtotal stays derived, never typed (see grandtotal note below), matching the real Java's price-always-copied-from-the-order-line rule.",
     "fields": [
       { "col": "documentno", "label": "Document No", "type": "string", "required": true, "default": "auto",
         "validation": { "regex": "^[0-9]+$", "valRule": "docno_numeric" } },
       { "col": "dateinvoiced", "label": "Date Invoiced", "type": "date", "required": true, "default": "today" },
+      { "col": "c_bpartner_id", "label": "Business Partner (ID)", "type": "number", "required": false,
+        "note": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — a vendor invoice's BPartner (Sales invoices derive it from the order; this is the Purchase-side manual header field)." },
+      { "col": "c_order_id", "label": "Purchase Order (ID)", "type": "number", "required": false,
+        "note": "Implementing ERP_P2P_INVOICE_MATCH.md §Fix 1 — the PO this vendor invoice is against; lines pulled via §Fix 4's picker." },
       { "col": "grandtotal", "label": "Grand Total", "type": "number", "readonly": true,
         "note": "derived by replaying the log against the order/shipment — not entered (help_ops c_invoice: 'derived by replaying the log, not stored twice')" },
       { "col": "description", "label": "Description", "type": "string", "required": false, "default": "" },

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -1591,6 +1591,11 @@
       // the right-side default doctype instead of always the client's Standard Sales doctype. Only ever read
       // for the derivation-if-unset case (existing docTypeTarget on an UPDATE is left alone regardless).
       if (app._createIsSOTrx === 'Y' || app._createIsSOTrx === 'N') ctx.issotrx = app._createIsSOTrx;
+      // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 2 — the M_InOut sibling of the IsSOTrx thread above:
+      // window.APP._createMovementType is set by idempiere.html's buildForm() from the active AD_Tab's own
+      // WhereClause (M_InOut's real per-window signal is MovementType, e.g. Material Receipt tab 296's
+      // "MovementType IN ('V+')" — verified against ad_seed.db, not assumed).
+      if (/^[A-Z][+-]$/.test(app._createMovementType || '')) ctx.movementtype = app._createMovementType;
     } catch (e) {}
     return ctx;
   }
@@ -1891,9 +1896,21 @@
   // pattern): the bundle carries no c_ordertax (a fresh order's invoice tax legs are non-derivable) and
   // post_resolver is not mounted — the omission is LOGGED, never faked. Ship/Invoice creation still works.
   // cb(fanout|null): null → the honest status-only group (engine absent / non-CO / no policy / re-complete).
+  // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 3/5 — Witness: W-FOLD-MATCHPO/W-FOLD-MATCHINV. Generalized
+  // from c_order-only to also dispatch m_inout (Receipt CO → M_MatchPO, completeReceipt) and c_invoice
+  // (Invoice CO → M_MatchInv, completeInvoice — already written in erp_engine.js, just never reached this
+  // dispatcher before). Same CO/success/re-complete gate, same withBundle/SELECT*/lower-case convention —
+  // only the per-table body differs (each table's own completeFanout<X> below).
   function completeFanout(op, cb) {
-    if (!(op.key === 'c_order' && op.action === 'CO' && op.to === 'CO' && op.outcome === 'success')) { cb(null); return; }
-    if (op.from === 'CO') { console.log('§SO-COMPLETE fan-out skipped: already CO (no duplicate consequence docs)'); cb(null); return; }
+    if (!(op.action === 'CO' && op.to === 'CO' && op.outcome === 'success')) { cb(null); return; }
+    if (op.from === 'CO') { console.log('§' + fname(op.key) + '-COMPLETE fan-out skipped: already CO (no duplicate consequence docs)'); cb(null); return; }
+    if (op.key === 'c_order')  { completeFanoutOrder(op, cb);   return; }
+    if (op.key === 'm_inout')  { completeFanoutReceipt(op, cb); return; }
+    if (op.key === 'c_invoice') { completeFanoutInvoice(op, cb); return; }
+    cb(null);
+  }
+
+  function completeFanoutOrder(op, cb) {
     var E = (typeof global.ERPEngine !== 'undefined') ? global.ERPEngine : null;
     if (!E || typeof E.completeOrder !== 'function' || typeof withBundle !== 'function' || op.id == null) {
       console.log('§SO-COMPLETE fan-out gated: ' + (E ? 'bundle/id absent' : 'ERPEngine not mounted') + ' → status-only group (honest)');
@@ -1918,6 +1935,82 @@
         fanout = ops.length ? { ops: ops, glGate: 'no-order-side-acct/tax-linkage' } : null;
       } catch (er) { console.log('§SO-COMPLETE fan-out error ' + (er && er.message) + ' → status-only group'); fanout = null; }
       cb(fanout);
+    });
+  }
+
+  // _rawRows — SELECT * against the raw bundle, lower-cased columns, plain array of objects. Shared by the
+  // two fold-based fanouts below (Implementing ERP_P2P_INVOICE_MATCH.md §Fix 3/5).
+  function _rawRows(db, sql) {
+    var r = db.exec(sql);
+    if (!r.length) return [];
+    return r[0].values.map(function (v) { var o = {}; r[0].columns.forEach(function (c, i) { o[String(c).toLowerCase()] = v[i]; }); return o; });
+  }
+
+  // completeFanoutReceipt — M_InOut Complete → M_MatchPO (Implementing ERP_P2P_INVOICE_MATCH.md §Fix 3).
+  // Unlike completeFanoutOrder's raw-bundle SELECT (which only ever finds a SEED row — a manually-created
+  // Receipt lives ONLY as CRUD_CREATE ops in the sidecar's kernel_ops, per §Fix 2026-07-21's own listTip/
+  // readTip discovery for renderOrderPicker), this reads via CORE.listTip fold — baseRows (raw, usually
+  // empty for a fresh tenant) overlaid with every CRUD_CREATE for m_inout/m_inoutline. No DOCPOLICY gate —
+  // real Java (MInOut.completeIt()) gates purely on IsSOTrx, which completeReceipt() itself checks.
+  function completeFanoutReceipt(op, cb) {
+    var E = (typeof global.ERPEngine !== 'undefined') ? global.ERPEngine : null;
+    if (!E || typeof E.completeReceipt !== 'function' || typeof withBundle !== 'function' || typeof withSidecar !== 'function' || op.id == null) {
+      console.log('§RECEIPT-COMPLETE fan-out gated: ' + (E ? 'bundle/sidecar/id absent' : 'ERPEngine not mounted') + ' → status-only group (honest)');
+      cb(null); return;
+    }
+    withBundle(function (db) {
+      var baseHdr = _rawRows(db, 'SELECT * FROM m_inout');
+      var baseLines = _rawRows(db, 'SELECT * FROM m_inoutline');
+      withSidecar(function (sdb) {
+        var fanout = null;
+        try {
+          var hdrRows = baseHdr, lineRows = baseLines;
+          if (sdb) {
+            try { var f1 = CORE.listTip(sdb, 'm_inout', 'm_inout_id', baseHdr, null); hdrRows = (f1 && f1.rows) || baseHdr; } catch (e1) {}
+            try { var f2 = CORE.listTip(sdb, 'm_inoutline', 'm_inoutline_id', baseLines, null); lineRows = (f2 && f2.rows) || baseLines; } catch (e2) {}
+          }
+          var receipt = hdrRows.filter(function (r) { return String(r.m_inout_id) === String(op.id); })[0];
+          if (!receipt) { console.log('§RECEIPT-COMPLETE fan-out gated: receipt ' + op.id + ' not found (bundle+sidecar) → status-only'); cb(null); return; }
+          var lines = lineRows.filter(function (r) { return String(r.m_inout_id) === String(op.id); });
+          var ops = E.completeReceipt(receipt, lines, null).filter(function (o) { return o.op_type !== 'SET_STATUS'; });
+          console.log('§RECEIPT-FANOUT receipt=' + op.id + ' issotrx=' + receipt.issotrx + ' lines=' + lines.length + ' matchPoOps=' + ops.length);
+          fanout = ops.length ? { ops: ops, glGate: 'none' } : null;
+        } catch (er) { console.log('§RECEIPT-COMPLETE fan-out error ' + (er && er.message) + ' → status-only group'); fanout = null; }
+        cb(fanout);
+      });
+    });
+  }
+
+  // completeFanoutInvoice — C_Invoice Complete → M_MatchInv (Implementing ERP_P2P_INVOICE_MATCH.md §Fix 5).
+  // erp_engine.js's completeInvoice() was written earlier (O2C lane) but never reached the live UI's
+  // dispatcher until this fix — same listTip-fold convention as completeFanoutReceipt above (a manually-
+  // created vendor invoice is equally sidecar-only, never in the raw bundle).
+  function completeFanoutInvoice(op, cb) {
+    var E = (typeof global.ERPEngine !== 'undefined') ? global.ERPEngine : null;
+    if (!E || typeof E.completeInvoice !== 'function' || typeof withBundle !== 'function' || typeof withSidecar !== 'function' || op.id == null) {
+      console.log('§INVOICE-COMPLETE fan-out gated: ' + (E ? 'bundle/sidecar/id absent' : 'ERPEngine not mounted') + ' → status-only group (honest)');
+      cb(null); return;
+    }
+    withBundle(function (db) {
+      var baseHdr = _rawRows(db, 'SELECT * FROM c_invoice');
+      var baseLines = _rawRows(db, 'SELECT * FROM c_invoiceline');
+      withSidecar(function (sdb) {
+        var fanout = null;
+        try {
+          var hdrRows = baseHdr, lineRows = baseLines;
+          if (sdb) {
+            try { var f1 = CORE.listTip(sdb, 'c_invoice', 'c_invoice_id', baseHdr, null); hdrRows = (f1 && f1.rows) || baseHdr; } catch (e1) {}
+            try { var f2 = CORE.listTip(sdb, 'c_invoiceline', 'c_invoiceline_id', baseLines, null); lineRows = (f2 && f2.rows) || baseLines; } catch (e2) {}
+          }
+          var invoice = hdrRows.filter(function (r) { return String(r.c_invoice_id) === String(op.id); })[0];
+          if (!invoice) { console.log('§INVOICE-COMPLETE fan-out gated: invoice ' + op.id + ' not found (bundle+sidecar) → status-only'); cb(null); return; }
+          var lines = lineRows.filter(function (r) { return String(r.c_invoice_id) === String(op.id); });
+          var ops = E.completeInvoice(invoice, lines, null).filter(function (o) { return o.op_type !== 'SET_STATUS'; });
+          console.log('§INVOICE-FANOUT invoice=' + op.id + ' issotrx=' + invoice.issotrx + ' lines=' + lines.length + ' matchInvOps=' + ops.length);
+          fanout = ops.length ? { ops: ops, glGate: 'none' } : null;
+        } catch (er) { console.log('§INVOICE-COMPLETE fan-out error ' + (er && er.message) + ' → status-only group'); fanout = null; }
+        cb(fanout);
+      });
     });
   }
 

--- a/erp/erp_engine.js
+++ b/erp/erp_engine.js
@@ -273,10 +273,28 @@ function completeInvoice(invoice, lines, policy) {
   return ops;
 }
 
+// completeReceipt — the M_InOut doc-action's PO-side delta, the sibling completeInvoice() emits on the
+// invoice side. Implementing ERP_P2P_INVOICE_MATCH.md §Fix 3 — Witness: W-FOLD-MATCHPO. Real Java
+// (MInOut.completeIt(), line 2079-2096): for each receipt line linked to a PO line
+// (`!IsSOTrx && C_OrderLine_ID<>0`), create ONE M_MatchPO junction (PO-line ⋈ receipt-line @
+// MovementQty). Same shape as completeInvoice's M_MatchInv emission — a single junction record rides the
+// existing CREATE_LINE kernel op, no buildDoc. The invoice-created-before-shipment edge case (real Java
+// also emits M_MatchPO from MInvoice.completeIt() ~line 2134) is NAMED-DEFERRED — this lane's witness path
+// is receipt-first (PO → Receipt → Invoice), the mainline order real users follow.
+function completeReceipt(receipt, lines, policy) {
+  var ops = [{ op_type: 'SET_STATUS', table: 'M_InOut', id: receipt.m_inout_id, doc_status: 'CO' }];
+  if (receipt.issotrx === 'N') {
+    (lines || []).forEach(function (l) {
+      if (l.c_orderline_id) ops.push({ op_type: 'CREATE_LINE', table: 'M_MatchPO', c_orderline_id: l.c_orderline_id, m_inoutline_id: l.m_inoutline_id, m_product_id: l.m_product_id, qty: l.movementqty });
+    });
+  }
+  return ops;
+}
+
 return {
   resolveCtx: resolveCtx, dialectShim: dialectShim, evalGuard: evalGuard,
   match: match, buildDoc: buildDoc, DOC_SPECS: DOC_SPECS, explodeBOM: explodeBOM,
   movementSign: movementSign, qtyOnHand: qtyOnHand, reversePosting: reversePosting,
-  VERBS: VERBS, completeOrder: completeOrder, completeInvoice: completeInvoice
+  VERBS: VERBS, completeOrder: completeOrder, completeInvoice: completeInvoice, completeReceipt: completeReceipt
 };
 });

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -2836,6 +2836,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         window.APP = window.APP || {};
         var _wc = tab.whereClause && /\bIsSOTrx\s*=\s*'([YN])'/i.exec(tab.whereClause);
         window.APP._createIsSOTrx = _wc ? _wc[1].toUpperCase() : null;
+        // Implementing ERP_P2P_INVOICE_MATCH.md §Fix 2 — Witness: W-RECEIPT-MOVEMENTTYPE. The M_InOut
+        // real AD_Tab family splits Shipment (257, "MovementType IN ('C-')") vs Material Receipt (296,
+        // "MovementType IN ('V+')") vs the return tabs (52371/53276) by MovementType, NOT IsSOTrx (verified
+        // live against ad_seed.db — M_InOut carries no IsSOTrx-pattern WhereClause anywhere) — the SAME
+        // per-window signal as the IsSOTrx case above, different column. Same stash-scoped-to-this-create
+        // pattern as _createIsSOTrx.
+        var _wcMt = tab.whereClause && /\bMovementType\s+IN\s*\(\s*'([A-Z][+-])'/i.exec(tab.whereClause);
+        window.APP._createMovementType = _wcMt ? _wcMt[1].toUpperCase() : null;
         // §ORDERLINE-PARENT-FK (ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22, "order-LINE stale parent FK") —
         // a child tab's (tabLevel>0) New form has a locked/readonly parent-link column (e.g.
         // C_OrderLine.C_Order_ID) but nothing ever seeded its value with the actual parent record's pk:


### PR DESCRIPTION
## Summary
- Ports the Purchase-side of the O2C→P2P closer (ERP_P2P_INVOICE_MATCH.md, bim-compiler), extracted from real iDempiere Java (`CreateFromInOut`/`CreateFromInvoice`, `MInOut.completeIt()`/`MInvoice.completeIt()`, `MMatchPO`/`MMatchInv`) before any code was written.
- Confirms `InOutGenerate`/`InvoiceGenerate`'s existing Sales-only gates are faithful to real Java, not bugs — the Purchase side uses manual header entry + completion-time match emission instead.
- Adds `m_warehouse_id`/`c_bpartner_id`/`c_order_id` to `m_inout`, a `"create"` verb + `c_bpartner_id`/`c_order_id` to `c_invoice`.
- Adds per-window `movementtype`/`issotrx` derivation for a manually-created `m_inout` (real AD_Tab WhereClause is `MovementType`, not `IsSOTrx`, unlike `c_order`) and the equivalent `issotrx`-from-window seam for `c_invoice`.
- Adds `completeReceipt()` (M_InOut Complete → M_MatchPO), generalizes `completeFanout` from `c_order`-only to also dispatch `m_inout`/`c_invoice`, and fixes it to fold fresh (sidecar-only) rows via `CORE.listTip` instead of a raw bundle SELECT (same class of gap the O2C lane's `renderOrderPicker` fix already found — caught here before shipping).

## Test plan
- [x] `scripts/witness_p2p_invoice_match.js` (bim-compiler) driven end-to-end through the real UI: create PO → complete → create Material Receipt against it → complete → **real signed `M_MatchPO` CREATE_LINE op observed, `verifyChain=ok`** (log: `build/erp/witness_p2p_invoice_match.log`).
- [x] `node --check` clean on all touched `.js`/extracted `<script>` blocks.
- [ ] M_MatchInv (Vendor Invoice side) not yet closed — `C_InvoiceLine.M_InOutLine_ID`/`C_OrderLine_ID` are hard `IsReadOnly='Y'` in the real AD dictionary too (confirmed live), so a follow-on fix (seed-before-render, mirroring the existing child-tab parent-FK seeding pattern) is named precisely in `ERP_P2P_INVOICE_MATCH.md §Fix 2026-07-23`, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)