### PR TITLE
fix(viewer): chunk nav-DLOD restore + fix FPS_MODE dlod= tag

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -506,25 +506,47 @@
            q.x.toFixed(3) + ',' + q.y.toFixed(3) + ',' + q.z.toFixed(3) + ',' + q.w.toFixed(3);
   }
 
-  function _restoreAll(app, reason) {
+  // §FPS_MODE finding (2026-07-23): the old _restoreAll was a single synchronous loop over the
+  // whole box index — measured 2.5-3.6s frame_ms spike on LTU_AHouse (122k) on every disengage,
+  // worse than the cold-engage burst it mirrors. Chunked the same way _evalChunk already is
+  // (EVAL_CHUNK per rAF tick). _restoreFlush lets a re-engage force-finish a still-draining
+  // restore synchronously first, so _buildBoxes never races a stale in-flight drain — bounded to
+  // "whatever's left undone" rather than always the full 122k.
+  var _restoreFlush = null;
+  function _restoreAllNow(app, reason, onDone) {
     _roomReset(); // §ROOM_OCCL: disengage clears current-room state (index stays, building-keyed)
     _cancelFadesSnap(app);
-    if (_boxIndex) {
-      for (var guid in _boxIndex) {
-        var e = _boxIndex[guid];
+    var idx = _boxIndex, ridx = _realIndex;
+    var guids = idx ? Object.keys(idx) : [];
+    var i = 0;
+    function runTo(end) {
+      for (; i < end; i++) {
+        var guid = guids[i], e = idx[guid];
         if (e.state === 'box') {
-          var r = _realIndex && _realIndex[guid];
+          var r = ridx && ridx[guid];
           _setBoxInstance(e, false);
           if (r) _showReal(r);
           e.state = 'real';
         }
       }
     }
-    // Belt-and-braces: if a filter turned on while we were engaged, reassert it after restore
-    if (app.activeGuidFilter && app.filterByGuids) app.filterByGuids(app.activeGuidFilter);
-    else if ((app.activeStoreyFilter !== null && app.activeStoreyFilter !== undefined) && app.filterStorey) app.filterStorey(app.activeStoreyFilter);
-    if (app.markDirty) app.markDirty();
-    console.log('§DLOD_NAV_DISENGAGE reason=' + reason + ' mutations=' + _stats.mutations);
+    function finish() {
+      runTo(guids.length); // no-op if step() already finished the loop
+      _restoreFlush = null;
+      // Belt-and-braces: if a filter turned on while we were engaged, reassert it after restore
+      if (app.activeGuidFilter && app.filterByGuids) app.filterByGuids(app.activeGuidFilter);
+      else if ((app.activeStoreyFilter !== null && app.activeStoreyFilter !== undefined) && app.filterStorey) app.filterStorey(app.activeStoreyFilter);
+      if (app.markDirty) app.markDirty();
+      console.log('§DLOD_NAV_DISENGAGE reason=' + reason + ' mutations=' + _stats.mutations);
+      if (onDone) onDone();
+    }
+    function step() {
+      runTo(Math.min(i + EVAL_CHUNK, guids.length));
+      if (i < guids.length) requestAnimationFrame(step);
+      else finish();
+    }
+    _restoreFlush = finish;
+    step();
   }
 
   function _tick() {
@@ -533,14 +555,15 @@
     var app = A();
     var block = _gateBlockReason(app);
     if (block) {
-      if (_engaged) { _restoreAll(app, block); _engaged = false; _lastCamSig = null; }
+      if (_engaged) { _engaged = false; window._dlodNavEngaged = false; _lastCamSig = null; _restoreAllNow(app, block); }
       _rafId = requestAnimationFrame(_tick); // stay alive; re-engage when the gate clears
       return;
     }
     if (!_engaged) {
+      if (_restoreFlush) _restoreFlush(); // finish any still-draining restore before rebuilding the index
       if (!_buildBoxes(app)) { _rafId = requestAnimationFrame(_tick); return; }
       _buildRealIndex(app);
-      _engaged = true; _lastCamSig = null;
+      _engaged = true; window._dlodNavEngaged = true; _lastCamSig = null;
       console.log('§DLOD_NAV_ENGAGE bld=' + app.activeBuilding + ' elements=' + app.activeBuildingTotal);
     }
     // §ROOM_OCCL (§13): evaluated only when the console lever is on; the else-branch is a pure
@@ -612,10 +635,14 @@
     } else {
       _pillOn = false; window._dlodNavOn = false;
       if (_rafId) { cancelAnimationFrame(_rafId); _rafId = null; }
-      if (_engaged) { _restoreAll(app, 'pill-off'); _engaged = false; }
-      _disposeBoxes();
       console.log('§DLOD_NAV_TOGGLE on=false');
       _statusMsg(app, 'Nav LOD OFF — full detail restored');
+      if (_engaged) {
+        _engaged = false; window._dlodNavEngaged = false;
+        _restoreAllNow(app, 'pill-off', _disposeBoxes); // dispose only once the chunked drain finishes
+      } else {
+        _disposeBoxes();
+      }
     }
     if (app && app.markDirty) app.markDirty();
   };

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -677,8 +677,11 @@ async function initViewer() {
     if (_fpsN && (now - _fpsLastLogT) >= 2000) {
       var mean = +(_fpsSum / _fpsN).toFixed(1);
       var disp = APP.xrayOn ? 'xray' : ((typeof window.ghostXrayOn === 'function' && window.ghostXrayOn()) ? 'bbox' : 'solid');
+      // dlod= reads _dlodNavEngaged (actually classifying/boxing), not the pill-pressed _dlodNavOn —
+      // a gate-blocked press (streaming/find-isolation/etc, see dlod_nav.js _gateBlockReason) does
+      // nothing at all, and tagging those frames "on" would silently poison this exact comparison.
       console.log('§FPS_MODE mean=' + mean + ' max=' + _fpsMax.toFixed(1) + ' n=' + _fpsN +
-        ' dlod=' + (window._dlodNavOn ? 'on' : 'off') + ' disp=' + disp +
+        ' dlod=' + (window._dlodNavEngaged ? 'on' : 'off') + ' disp=' + disp +
         ' fly=' + (APP.flyActive ? 1 : 0) + ' orbit=' + (_orbiting ? 1 : 0));
       _fpsSum = 0; _fpsN = 0; _fpsMax = 0; _fpsLastLogT = now;
     }


### PR DESCRIPTION
## Summary
Two fixes surfaced by this session's `§FPS_MODE` data on LTU_AHouse (122k elements):

1. **Chunk the disengage restore.** `_restoreAll` was a single synchronous loop over the whole box index — measured **2.5-3.6s frame_ms spike** on every disengage (turning `'o'` off), worse than the cold-engage burst it mirrors. Now chunked the same way `_evalChunk` already is (`EVAL_CHUNK` per rAF tick, `_restoreAllNow`). A re-engage while a restore is still draining force-flushes it synchronously first (`_restoreFlush`), so `_buildBoxes` never races a stale in-flight drain.
2. **Fix `§FPS_MODE`'s `dlod=` tag.** It read pill-pressed intent (`_dlodNavOn`), not actual engagement (`_engaged`) — a gate-blocked press (streaming/find-isolation/etc, see #974) tagged frames `dlod=on` while nav-DLOD did nothing, which would have silently poisoned the exact on/off comparison this sampler exists to make. Now reads `window._dlodNavEngaged`, a live mirror of `_engaged`.

## Test plan
- [x] `node --check viewer/dlod_nav.js viewer/main.js`
- [ ] Live check: toggle `'o'` off on a large building mid-flight, confirm no multi-second freeze and `§DLOD_NAV_DISENGAGE` still logs correctly after the chunked drain completes
- [ ] Live check: press `'o'` while gate-blocked (e.g. still streaming) — confirm `§FPS_MODE` shows `dlod=off` for that stretch, not `dlod=on`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>