### PR TITLE
fix(viewer): Fly Tour interior pacing — line-of-sight ahead, not omnidirectional min

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3968,6 +3968,26 @@ async function setupEffects(A, renderer, scene, camera) {
   // comment above _cinemaFanMeshes) to tour.js's flight-pacing — real measured clearance-to-
   // nearest-surface, not a second invented proximity system. tour.js is the only outside caller.
   A.cinemaFan = _cinemaFan;
+  // §INTERIOR_PACING_LOS (2026-07-26, user: "Measure by LOS - what is in front of the middle in
+  // the frame, if it is far, fast. Near, slow" — courtyard traversal was still measuring slow
+  // because `_cinemaFan`'s min-of-8-rays fires on ANYTHING close in ANY direction, e.g. a low
+  // wall or piece of furniture off to the side, even when what's actually ahead in view is wide
+  // open). Single forward raycast, same mesh set/raycaster the fan already uses — not a second
+  // invented proximity system, just the one ray that matters for pacing: where the camera is
+  // heading, not everything around it.
+  function _cinemaLookDist(pos, dirX, dirZ) {
+    var meshes = _cinemaFanMeshes();
+    if (!meshes.length) return CINEMA_FAN_FAR;
+    if (!_cineFanRay) { _cineFanRay = new THREE.Raycaster(); _cineFanRay.firstHitOnly = true; }
+    var len = Math.hypot(dirX, dirZ);
+    if (len < 1e-6) return CINEMA_FAN_FAR;
+    _cineFanRay.set(new THREE.Vector3(pos.x, pos.y, pos.z), new THREE.Vector3(dirX / len, 0, dirZ / len));
+    _cineFanRay.far = CINEMA_FAN_FAR;
+    var hits = null;
+    try { hits = _cineFanRay.intersectObjects(meshes, true); } catch (e) { return CINEMA_FAN_FAR; }
+    return (hits && hits.length) ? hits[0].distance : CINEMA_FAN_FAR;
+  }
+  A.cinemaLookDist = _cinemaLookDist;
   // §CINEMA_HDRI_RACE (2026-07-24): exposed so cinema_maxq.js's warm-up (the REAL Alt+C entry
   // point — scene.js's §KBD_ROUTE always finds A.startMaxQualityOrbit and never falls through to
   // A.startCinemaOrbit below) can await the same HDRI readiness this file's own dead-code capture

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -953,12 +953,21 @@ function setupTour(A) {
     const factor = refDistance / d; // the "simple inverse formula": far => small factor (fast), close => large factor (slow)
     return Math.max(PACE_FACTOR_MIN, Math.min(PACE_FACTOR_MAX, factor));
   }
-  function _clearancePace(pos) {
-    if (typeof A.cinemaFan !== 'function') return 1;
-    let c;
-    try { c = A.cinemaFan(pos, 8).min; } catch (e) { return 1; }
-    if (!(c > 0)) return 1;
-    return _invPace(c, 3.0, 0.6); // REF=3m clearance reads as neutral pace, same scale a normal room aisle gives
+  // §INTERIOR_PACING_LOS (user 2026-07-26: "Measure by LOS - what is in front of the middle in
+  // the frame, if it is far, fast. Near, slow" — a courtyard traversal was still reading slow
+  // under the omnidirectional fan-min because SOMETHING nearby in SOME direction (a low wall,
+  // furniture, staffage off to the side) triggered it even though what's actually ahead in view
+  // was wide open). Single forward raycast toward the NEXT waypoint (or, at the last point, the
+  // same heading the final incoming leg already has) — real line-of-sight, not "closest thing in
+  // any direction." `pts` is the same real point array the remap is being built over.
+  function _losPace(pts, i) {
+    if (typeof A.cinemaLookDist !== 'function') return 1;
+    let dx, dz;
+    if (i < pts.length - 1) { dx = pts[i + 1].x - pts[i].x; dz = pts[i + 1].z - pts[i].z; }
+    else { dx = pts[i].x - pts[i - 1].x; dz = pts[i].z - pts[i - 1].z; }
+    let d;
+    try { d = A.cinemaLookDist(pts[i], dx, dz); } catch (e) { return 1; }
+    return _invPace(d, 3.0, 0.6); // REF=3m ahead reads as neutral pace, same scale a normal room aisle gives
   }
   // Builds a monotonic time-fraction<->position-fraction remap from real sample points + a
   // per-point pace factor (>1 slower, <1 faster than neutral). Two effects, both from the SAME
@@ -1300,10 +1309,10 @@ function setupTour(A) {
           // duration (not just its internal distribution) so a genuinely open stretch actually
           // takes less real time, not just a smaller share of a duration that was already capped
           // by the flat 0.3x interior baseline.
-          act._paceRemap = _paceBuildRemap(pts3, _clearancePace);
+          act._paceRemap = _paceBuildRemap(pts3, (p, i) => _losPace(pts3, i));
           if (act._paceRemap) {
             act.duration = Math.max((act.duration || 30) * act._paceRemap.meanFactor, 3);
-            console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} clearanceRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
+            console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} losRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
           }
         } catch(e) {
           console.error('[TOUR] §FLYPATH_CRASH', e.message);


### PR DESCRIPTION
## Summary
- Follow-up to #984 — live LTU testing (courtyard) still measured slow: `§TIGHT_TURN_PACING mean=2.47` (slower than baseline) on a wide-open leg, because the clearance signal took the MIN across an 8-ray omnidirectional fan — anything nearby in any direction (off to the side, behind) forced the point "close" even with open sightline ahead.
- User's own framing: "Measure by LOS - what is in front of the middle in the frame, if it is far, fast. Near, slow."
- Adds `A.cinemaLookDist(pos, dirX, dirZ)` (effects.js) — single forward raycast reusing the same mesh set/raycaster `_cinemaFan` already uses. `flyPath`'s interior pacing now measures LOS toward the next waypoint instead of the fan's min-of-8.
- Scope: interior (`flyPath`) only — orbit/moveTo already pace correctly off known height/distance per #984's live log, untouched here.

## Test plan
- [x] `node --check` clean on both files
- [ ] Live re-test on LTU courtyard — recommended before/after merge, same discipline as #984 (another session is doing further path-smoothing work for tour speed-up calc, noted as follow-on, not blocking this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)