### PR TITLE
fix(viewer): Fly Tour flyPath — bound look-ahead to absolute distance, not fraction of total path

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3968,6 +3968,26 @@ async function setupEffects(A, renderer, scene, camera) {
   // comment above _cinemaFanMeshes) to tour.js's flight-pacing — real measured clearance-to-
   // nearest-surface, not a second invented proximity system. tour.js is the only outside caller.
   A.cinemaFan = _cinemaFan;
+  // §INTERIOR_PACING_LOS (2026-07-26, user: "Measure by LOS - what is in front of the middle in
+  // the frame, if it is far, fast. Near, slow" — courtyard traversal was still measuring slow
+  // because `_cinemaFan`'s min-of-8-rays fires on ANYTHING close in ANY direction, e.g. a low
+  // wall or piece of furniture off to the side, even when what's actually ahead in view is wide
+  // open). Single forward raycast, same mesh set/raycaster the fan already uses — not a second
+  // invented proximity system, just the one ray that matters for pacing: where the camera is
+  // heading, not everything around it.
+  function _cinemaLookDist(pos, dirX, dirZ) {
+    var meshes = _cinemaFanMeshes();
+    if (!meshes.length) return CINEMA_FAN_FAR;
+    if (!_cineFanRay) { _cineFanRay = new THREE.Raycaster(); _cineFanRay.firstHitOnly = true; }
+    var len = Math.hypot(dirX, dirZ);
+    if (len < 1e-6) return CINEMA_FAN_FAR;
+    _cineFanRay.set(new THREE.Vector3(pos.x, pos.y, pos.z), new THREE.Vector3(dirX / len, 0, dirZ / len));
+    _cineFanRay.far = CINEMA_FAN_FAR;
+    var hits = null;
+    try { hits = _cineFanRay.intersectObjects(meshes, true); } catch (e) { return CINEMA_FAN_FAR; }
+    return (hits && hits.length) ? hits[0].distance : CINEMA_FAN_FAR;
+  }
+  A.cinemaLookDist = _cinemaLookDist;
   // §CINEMA_HDRI_RACE (2026-07-24): exposed so cinema_maxq.js's warm-up (the REAL Alt+C entry
   // point — scene.js's §KBD_ROUTE always finds A.startMaxQualityOrbit and never falls through to
   // A.startCinemaOrbit below) can await the same HDRI readiness this file's own dead-code capture

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -948,6 +948,11 @@ function setupTour(A) {
   // (walls close on every side) without a second signal compounding on top of it.
   const PACE_FACTOR_MIN = 0.35;     // fastest allowed (far/open) — ~3x hasten
   const PACE_FACTOR_MAX = 4.0;      // slowest allowed (right up against a surface/target)
+  const LOOKAHEAD_M = 5;             // §TARGET_BOUNDED_LOOKAHEAD — absolute gaze-ahead distance for
+                                      // flyPath, same scale as the clearance/LOS reference distances
+                                      // above; independent of total path length (see the flyPath init
+                                      // block below for why the old fixed-fraction version broke on
+                                      // long multi-room routes).
   function _invPace(distance, refDistance, minDistance) {
     const d = Math.max(distance, minDistance);
     const factor = refDistance / d; // the "simple inverse formula": far => small factor (fast), close => large factor (slow)
@@ -1314,6 +1319,18 @@ function setupTour(A) {
             act.duration = Math.max((act.duration || 30) * act._paceRemap.meanFactor, 3);
             console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} losRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
           }
+          // §TARGET_BOUNDED_LOOKAHEAD (2026-07-26, FLY_TOUR_DLOD_SCALE.md §23/§24) — the look-at
+          // lookahead below used to be a fixed FRACTION (0.05) of this action's own total arc
+          // length. MaxQ/Clash both bound their gaze target to something of room/clash SCALE (a
+          // few meters); MaxQ's own Beat-3 walk-out lookahead (effects.js §CINEMA_TIMING_672, also
+          // a 0.05-of-path-style fraction) only ever stays a few meters ahead because that beat's
+          // own path is short (settle point to nearest door). flyPath's action can span an entire
+          // storey's route (100+m, many rooms) — the SAME fractional mechanism there aims the gaze
+          // many meters past the current room/corridor, into far geometry through doorways/down
+          // corridors, well before the camera itself arrives. Cap the lookahead to an ABSOLUTE
+          // arc-length distance instead, independent of how long the overall route is.
+          act._lookAheadFrac = act._totalLen > 0 ? Math.min(0.05, LOOKAHEAD_M / act._totalLen) : 0.05;
+          console.log(`[TOUR] §TARGET_BOUNDED_LOOKAHEAD totalLen=${act._totalLen.toFixed(1)} lookAheadM=${LOOKAHEAD_M} frac=${act._lookAheadFrac.toFixed(4)} (was fixed 0.05)`);
         } catch(e) {
           console.error('[TOUR] §FLYPATH_CRASH', e.message);
           A.walkActionIdx++; A.walkActionT = 0; return;
@@ -1331,7 +1348,7 @@ function setupTour(A) {
       // §SOFTEN (user 2026-07-16: "soften the sudden switch to new track"): look further ahead
       // (0.05 vs 0.03) and pan the gaze more gently (lerp 0.08 vs 0.15) — spur-room reversals
       // (walk in, walk out) sweep instead of whip.
-      const lookT = Math.min(t + 0.05, 0.999);
+      const lookT = Math.min(t + (act._lookAheadFrac || 0.05), 0.999);
       const lookPt = act._curve.getPointAt(lookT);
       if (!act._prevLook) act._prevLook = lookPt.clone();
       act._prevLook.lerp(lookPt, 0.08);

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -953,12 +953,21 @@ function setupTour(A) {
     const factor = refDistance / d; // the "simple inverse formula": far => small factor (fast), close => large factor (slow)
     return Math.max(PACE_FACTOR_MIN, Math.min(PACE_FACTOR_MAX, factor));
   }
-  function _clearancePace(pos) {
-    if (typeof A.cinemaFan !== 'function') return 1;
-    let c;
-    try { c = A.cinemaFan(pos, 8).min; } catch (e) { return 1; }
-    if (!(c > 0)) return 1;
-    return _invPace(c, 3.0, 0.6); // REF=3m clearance reads as neutral pace, same scale a normal room aisle gives
+  // §INTERIOR_PACING_LOS (user 2026-07-26: "Measure by LOS - what is in front of the middle in
+  // the frame, if it is far, fast. Near, slow" — a courtyard traversal was still reading slow
+  // under the omnidirectional fan-min because SOMETHING nearby in SOME direction (a low wall,
+  // furniture, staffage off to the side) triggered it even though what's actually ahead in view
+  // was wide open). Single forward raycast toward the NEXT waypoint (or, at the last point, the
+  // same heading the final incoming leg already has) — real line-of-sight, not "closest thing in
+  // any direction." `pts` is the same real point array the remap is being built over.
+  function _losPace(pts, i) {
+    if (typeof A.cinemaLookDist !== 'function') return 1;
+    let dx, dz;
+    if (i < pts.length - 1) { dx = pts[i + 1].x - pts[i].x; dz = pts[i + 1].z - pts[i].z; }
+    else { dx = pts[i].x - pts[i - 1].x; dz = pts[i].z - pts[i - 1].z; }
+    let d;
+    try { d = A.cinemaLookDist(pts[i], dx, dz); } catch (e) { return 1; }
+    return _invPace(d, 3.0, 0.6); // REF=3m ahead reads as neutral pace, same scale a normal room aisle gives
   }
   // Builds a monotonic time-fraction<->position-fraction remap from real sample points + a
   // per-point pace factor (>1 slower, <1 faster than neutral). Two effects, both from the SAME
@@ -1300,10 +1309,10 @@ function setupTour(A) {
           // duration (not just its internal distribution) so a genuinely open stretch actually
           // takes less real time, not just a smaller share of a duration that was already capped
           // by the flat 0.3x interior baseline.
-          act._paceRemap = _paceBuildRemap(pts3, _clearancePace);
+          act._paceRemap = _paceBuildRemap(pts3, (p, i) => _losPace(pts3, i));
           if (act._paceRemap) {
             act.duration = Math.max((act.duration || 30) * act._paceRemap.meanFactor, 3);
-            console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} clearanceRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
+            console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} losRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
           }
         } catch(e) {
           console.error('[TOUR] §FLYPATH_CRASH', e.message);


### PR DESCRIPTION
## Summary
- Follow-up to the MaxQ/Clash-vs-Fly-Tour smoothness investigation (`bim-compiler` `prompts/Viewer/FLY_TOUR_DLOD_SCALE.md` §21-§24). Stacked on #985 (not yet merged) — this diff will shrink to just the new commit once #985 lands.
- MaxQ's dive and Clash's fly-to both derive their gaze target + distance from something bounded (room extent, clash overlap size). `flyPath`'s look-at used a fixed 0.05-of-total-arc-length lookahead — fine for MaxQ/Clash's own short bounded beats, but on `flyPath`'s full-storey multi-room routes (100+m) that fraction put the gaze tens of meters ahead, through doorways/down corridors into geometry the camera hadn't reached.
- Caps the lookahead to an absolute arc-length distance (`LOOKAHEAD_M=5`) instead of a fraction of total path length. Short actions (already ≤5m at 0.05) are unaffected.

## Live verification (not synthetic, not screenshot-judged)
Real browser, LTU_AHouse, `renderer.info.render.triangles` — same camera position both times, only look-at orientation changed:
- Mean triangles across one interior leg (555.7m, 23 pts, 25 sampled points): 5,105,832 → 4,179,055 (18% reduction)
- Worst single point: 9,412,644 → 1,403,138 triangles (6.7x), lookahead distance 14.3m → 5.1m at that point
- 9/25 points improved >10%, 2/25 slightly worse, 14/25 near-parity (wall/turn already within 5m under the old lookahead too)

Full writeup: `bim-compiler` `prompts/Viewer/FLY_TOUR_CORRIDOR_GRAPH.md` §TARGET_BOUNDED_LOOKAHEAD.

## Test plan
- [x] `node --check` clean
- [x] Live triangle-count A/B on LTU_AHouse (above)
- [ ] User to live-watch the resulting camera feel (this fixes exposed-geometry cost, not yet confirmed to also read better/not-worse visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)