### PR TITLE
fix(viewer): Fly Tour pacing — narrow inverse-distance clamp range, less extreme

### DIFF
--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -946,8 +946,12 @@ function setupTour(A) {
   // term (that stacking produced the other live bug — `combinedFactorRange=[0.35,16.00]`, a
   // runaway 16x local slowdown): clearance alone already reads as "tight" for a dead-end spur
   // (walls close on every side) without a second signal compounding on top of it.
-  const PACE_FACTOR_MIN = 0.35;     // fastest allowed (far/open) — ~3x hasten
-  const PACE_FACTOR_MAX = 4.0;      // slowest allowed (right up against a surface/target)
+  // §PACE_RANGE_TAMPER (2026-07-26, user live-review: interior slowed to "near dead stop" near a
+  // wall/object and aerial orbit ran "way too fast" — both symptoms of the SAME clamp being too
+  // wide (0.35-4.0, an 11x swing). Narrowed to a more graceful range; the inverse formula itself
+  // (_invPace below) is untouched — this only tightens how far it's allowed to swing.
+  const PACE_FACTOR_MIN = 0.5;      // fastest allowed (far/open) — 2x hasten
+  const PACE_FACTOR_MAX = 2.0;      // slowest allowed (right up against a surface/target) — 2x slow
   const LOOKAHEAD_M = 5;             // §TARGET_BOUNDED_LOOKAHEAD — absolute gaze-ahead distance for
                                       // flyPath, same scale as the clearance/LOS reference distances
                                       // above; independent of total path length (see the flyPath init


### PR DESCRIPTION
## Summary
Live user review on top of #985's LOS pacing found the shared 0.35-4.0 clamp on the inverse-distance pacing formula (`_invPace`) swung too hard both ways:
- Interior `flyPath` slowed to a near dead stop right next to a wall/object.
- Aerial orbit ran way too fast throughout (any height beyond ~30m already pins the factor at its floor, so this affected the WHOLE orbit, not one instant).

Both are the clamp being too wide, not the formula itself — narrowed `PACE_FACTOR_MIN`/`MAX` from 0.35-4.0 to 0.5-2.0. `_invPace` itself and every call site (LOS/moveTo/orbit) untouched.

## Verification (plain Node script, no browser — checking the numbers, not the feel)
| distance/height | old factor | new factor |
|---|---|---|
| interior, d=0.6m (touching wall) | 4.00 (4x slow) | 2.00 (2x slow) |
| interior, d=1m | 3.00 | 2.00 |
| orbit, h=60-150m (typical height) | 0.35 (2.86x fast, pinned) | 0.50 (2x fast, pinned) |

Neutral point (factor=1) unchanged in both cases — only the extremes are pulled in.

## Test plan
- [x] `node --check` clean
- [x] Numeric verification of clamp behavior at representative distances/heights
- [ ] User to confirm the graceful feel live

🤖 Generated with [Claude Code](https://claude.com/claude-code)