### PR TITLE
fix(viewer): bump TOUR_CACHE_VER v12→v13 — §HL-FIRST was masked by a stale cached route

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v842';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v843';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -144,7 +144,13 @@ function setupTour(A) {
   // §TOUR_VERSION (route algorithm changes bust it), element/door/room counts from the DB (a new
   // extraction or a room recompile busts it), and the rendered-building-set size (city tours append
   // extra orbit actions — a different set must not replay a single-building route).
-  var TOUR_CACHE_VER = 'v12'; // keep in lockstep with the §TOUR_VERSION banner above
+  // ⚠ LOCKSTEP WITH §TOUR_VERSION — bumping the banner without bumping THIS silently replays the
+  // OLD route from IDB for every user who toured that building before the deploy. Missed on the
+  // §HL-FIRST ship (banner → v13, this stayed v12); the user's live Hospital log caught it
+  // (§TOUR_CACHE store … key=…:v12:…). The key's other components are DB counts — they bust on a
+  // re-extraction or room recompile, never on a code change. This constant is the ONLY thing that
+  // invalidates a cached route when the routing ALGORITHM changes.
+  var TOUR_CACHE_VER = 'v13'; // keep in lockstep with the §TOUR_VERSION banner above
   function _tourCacheKey() {
     try {
       var r = A.db.exec(

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -838,7 +838,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
-<script src="tour.js?v=13" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
+<script src="tour.js?v=14" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>


### PR DESCRIPTION
**Shipped defect from #989.** The `§TOUR_VERSION` banner went to v13; `TOUR_CACHE_VER` (`tour.js:147`, whose own comment says *"keep in lockstep with the §TOUR_VERSION banner above"*) stayed **v12**.

The cache key is `tmTourCache:<bld>:<VER>:<elements-doors-spaces>:<renderedSet>`. Its other components are DB counts — they bust on a re-extraction or a room recompile, **never on a code change**. `TOUR_CACHE_VER` is the only component that invalidates a cached route when the routing *algorithm* changes, which is exactly what §HL-FIRST was.

**Effect:** anyone who had toured a building before the v13 deploy replayed the OLD pre-highlight-first route out of IDB and saw no change whatsoever.

### How it was caught
The user's own live GH Pages log (Hospital, RTX 4060). Highlight-first *did* run there — `§FLY_HL_FIRST mainHall="≈ Level 1 Hall/Corridor 2" area=219.4 ascent="≈ Level 4 Hall/Corridor 2"/Level 4`, `flyPts` i=1 = the main hall, i=3–5 a real 3-point stair climb (y −5.6 → −0.9 → 4.1) — but only because the walker had just injected 214 fresh rooms, so the cache **missed and stored** instead of hitting:

```
§TOUR_CACHE store idb actions=43 bytes=10234 key=tmTourCache:Hospital:v12:63415-440-317:1
```

That stored key is the bug in one line: a v13 algorithm persisted under a v12 key.

### Verification
The key-construction site (`tour.js:154-158`) is a plain string concat, so the same building now yields `tmTourCache:Hospital:v13:63415-440-317:1` — a different key, every pre-v13 cached route misses once and is recomputed. No harness: substituting a constant into a string concatenation has no runtime branch to witness, and pretending otherwise would be theatre.

Also adds a ⚠ LOCKSTEP comment at the constant so the next banner bump can't repeat it.

`viewer.html` `tour.js?v=14` · `sw.js` CACHE_VERSION v843

🤖 Generated with [Claude Code](https://claude.com/claude-code)