### PR TITLE
fix(viewer): Fly Tour — SUSPECT_OPEN rooms are eligible highlight destinations

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v843';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v844';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v13 (highlight-first: main hall → stairs → rest — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v14 (highlight-first + SUSPECT_OPEN halls eligible — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -150,7 +150,7 @@ function setupTour(A) {
   // (§TOUR_CACHE store … key=…:v12:…). The key's other components are DB counts — they bust on a
   // re-extraction or room recompile, never on a code change. This constant is the ONLY thing that
   // invalidates a cached route when the routing ALGORITHM changes.
-  var TOUR_CACHE_VER = 'v13'; // keep in lockstep with the §TOUR_VERSION banner above
+  var TOUR_CACHE_VER = 'v14'; // keep in lockstep with the §TOUR_VERSION banner above
   function _tourCacheKey() {
     try {
       var r = A.db.exec(
@@ -449,7 +449,16 @@ function setupTour(A) {
     // Bucket rooms by storey. Corridors (backprop 'Hall / Corridor' nodes + compiled
     // SUSPECT_ELONGATED — a real corridor is usually one of these, see spec §R4) become cruise
     // stops; other SUSPECT_* rooms are never destinations (§ROOM-FORM: review candidates).
+    // §SUSPECT-OPEN-ELIGIBLE (OCCUPANT_PATHFINDER.md §G3-FINAL, user live report "still does not
+    // show large space", 2026-07-25): SUSPECT_OPEN is the ONE exception. It is a room-DETECTION
+    // confidence flag meaning "enclosure fraction below SUSPECT_OPEN_ENCLOSURE" — i.e. the space is
+    // OPEN — which is precisely what a hall or atrium IS. Measured on the user's saved live Hospital
+    // (~/Projects/BIM_DB/Hospital.db, an exact repro of the live console): the building's LARGEST
+    // room is 315.7 m² and carries SUSPECT_OPEN, so the old blanket exclusion hid it and the tour
+    // fell back to a 219 m² × 3.3m corridor. 62 of 214 rooms were excluded this way.
+    // SUSPECT_NO_DOOR stays excluded — that one is a genuine reachability doubt, not a shape.
     const byStorey = {}, stZSum = {}, stN = {};
+    let suspectOpenAdmitted = 0;
     for (const n of g.nodes) {
       const lbl = String(n.label || '');
       let area = 0;
@@ -457,7 +466,10 @@ function setupTour(A) {
       if (!byStorey[n.storey]) byStorey[n.storey] = { corridors: [], rooms: [] };
       const rec = { guid: n.guid, node: n, area };
       if (lbl.indexOf('Hall / Corridor') >= 0 || lbl.indexOf('SUSPECT_ELONGATED') >= 0) byStorey[n.storey].corridors.push(rec);
-      else if (lbl.indexOf('SUSPECT_') < 0) byStorey[n.storey].rooms.push(rec);
+      else if (lbl.indexOf('SUSPECT_') < 0 || lbl.indexOf('SUSPECT_OPEN') >= 0) {
+        if (lbl.indexOf('SUSPECT_OPEN') >= 0) suspectOpenAdmitted++;
+        byStorey[n.storey].rooms.push(rec);
+      }
       stZSum[n.storey] = (stZSum[n.storey] || 0) + n.cz;
       stN[n.storey] = (stN[n.storey] || 0) + 1;
     }
@@ -566,7 +578,8 @@ function setupTour(A) {
       console.log('[TOUR] §FLY_HL_FIRST mainHall="' + (mainHall.node.name || mainHall.guid) + '" area=' +
         mainHall.area.toFixed(1) + ' storey=' + mainHall.node.storey +
         ' ascent=' + (ascent ? '"' + (ascent.node.name || ascent.guid) + '"/' + ascent.node.storey : '-') +
-        ' extras=' + (picked.length - (ascent ? 2 : 1)) + ' stops=' + stops.length);
+        ' extras=' + (picked.length - (ascent ? 2 : 1)) + ' stops=' + stops.length +
+        ' suspectOpenAdmitted=' + suspectOpenAdmitted);  // §SUSPECT-OPEN-ELIGIBLE
     }
 
     // §S3 — the largest room actually PICKED per storey gets the pause + look-around beat

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -838,7 +838,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
-<script src="tour.js?v=14" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
+<script src="tour.js?v=15" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>


### PR DESCRIPTION
`OCCUPANT_PATHFINDER.md` §G3-FINAL. User live on Hospital: *"still does not show large space."* Root-caused on the user's own Save-DB export (`~/Projects/BIM_DB/Hospital.db`), which reproduces the live console exactly (`nodes=224 doors=440 edges=61 deadend=194 orphan=185`).

### The bug
`SUSPECT_OPEN` is a room-**detection confidence** flag meaning "enclosure fraction below `SUSPECT_OPEN_ENCLOSURE`" — i.e. *the space is open*, which is precisely what a hall or atrium **is**. §S2's blanket "never `SUSPECT_*` as destinations" therefore excluded exactly the spaces a tour wants: **62 of Hospital's 214 rooms, including its three largest.** `SUSPECT_NO_DOOR` stays excluded — that one is a genuine reachability doubt, not a shape.

### Witness — 7 buildings, BEFORE/AFTER, real `tour.js` loaded verbatim in a Node harness
| building | suspectOpenAdmitted | stops | illegalChords |
|---|---|---|---|
| Hospital (live fixture) | **10** | 18 → 17 | 18/74 → 17/76 (24.3% → **22.4%**) |
| Terminal | 0 | unchanged | unchanged |
| HHS | 0 | unchanged | unchanged |
| Clinic | 0 | unchanged | unchanged |
| Duplex | 0 | unchanged | unchanged |
| SampleHouse | 0 | unchanged | unchanged |
| SampleCastle | 0 | unchanged (still legacy) | unchanged |

**Zero regression** — no other building in the corpus has a `SUSPECT_OPEN` room at all, so every field is byte-identical to `origin/main`.

### Honest limit — this does NOT yet fix the reported symptom
Hospital's **315.7 m²** hall (its largest room, *bigger* than the shipped offline compile's 294 m²) has **`edges=0`** — it is isolated in the room graph, so `§CONNECTED-STOPS` drops it before ranking. 9 of the 10 `SUSPECT_OPEN` rooms are connected; the biggest is not. Same root cause: the low enclosure that flags it `SUSPECT_OPEN` is why no door binds to it. Making that room reachable is `OCCUPANT_PATHFINDER.md` G1/G3 work, not routing.

This change is still correct and necessary — it removes a filter that was hiding real halls fleet-wide — it just isn't sufficient on its own.

`tour.js` v14 · `TOUR_CACHE_VER` v14 (lockstep, the miss from #989) · `viewer.html` `tour.js?v=15` · `sw.js` v844

🤖 Generated with [Claude Code](https://claude.com/claude-code)