### PR TITLE
fix(graph): §BRIDGE-WALL-LEGAL — gate room-spine bridges on a measured chord (corrects #995's numbers)

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -708,58 +708,6 @@
     });
     if (circBridges) log('§CIRC_SPINE_BRIDGE bridged=' + circBridges);
 
-    // ── §ROOM-SPINE-BRIDGE (OCCUPANT_PATHFINDER.md §ROOM-SPINE-BRIDGE, 2026-07-25) ──
-    // A room with ZERO edges is unroutable: §CONNECTED-STOPS drops it, Find cannot path to it, and
-    // on Hospital that stranded 42 rooms (room-pair pathability 56.2%) INCLUDING the building's
-    // largest space (315.7 m² atrium, deg=0). Measured cause: E1 is door-based, and a low-enclosure
-    // space has no door on its boundary — the very property that earns it SUSPECT_OPEN. Two fixes
-    // were falsified on the real fixture before this one: widening the door slack (cannot reach the
-    // 22 rooms whose nearest door is 8-10m, and needs a 5x constant move for the atrium), and
-    // room-to-room rect adjacency (0 of 42 stranded rooms have a neighbour ROOM rect within RES —
-    // compiled rooms do not tile the floor). What IS in reach is CIRCULATION: all 42 have a spine/
-    // circ node nearby, the atrium's is 1.31m away. So an open space connects through an OPENING
-    // ONTO A CORRIDOR, not through a door to another room — and that is an edge this engine already
-    // knows how to make: identical shape to the §ISLAND_BRIDGE circ-per-chain edge above, which
-    // already bridges up to 51.97m on this same building. No new constant, no threshold, no cap:
-    // nearest real spine point, real measured distance, logged for audit.
-    var roomBridges = 0;
-    var _degSoFar = {};
-    edges.forEach(function (e) {
-      _degSoFar[e.a] = (_degSoFar[e.a] || 0) + 1;
-      _degSoFar[e.b] = (_degSoFar[e.b] || 0) + 1;
-    });
-    order.forEach(function (lg) {
-      var g = nodes[lg];
-      if (g.kind !== 'room' || _degSoFar[lg]) return;
-      var pts = spineByStorey[g.storey];
-      if (!pts || !pts.length) return;
-      var best = null, bestD = Infinity;
-      pts.forEach(function (p) {
-        // rect distance, not centroid: a long room's centre can be far from a corridor its EDGE
-        // touches (the atrium reads 1.31m by rect, much further by centre).
-        var d;
-        if (g.rects && g.rects.length) {
-          d = Infinity;
-          for (var ri = 0; ri < g.rects.length; ri++) {
-            var rc = g.rects[ri];
-            var ddx = Math.max(0, Math.max(rc.x0 - p.cx, p.cx - rc.x1));
-            var ddy = Math.max(0, Math.max(rc.y0 - p.cy, p.cy - rc.y1));
-            var dd = Math.hypot(ddx, ddy);
-            if (dd < d) d = dd;
-          }
-        } else {
-          d = Math.hypot(p.cx - g.cx, p.cy - g.cy);
-        }
-        if (d < bestD) { bestD = d; best = p; }
-      });
-      if (!best) return;
-      edges.push({ a: lg, b: best.guid, doorGuid: null, doorName: 'Opening onto corridor',
-                   storey: g.storey, kind: 'E6', w: bestD, wpA: best.guid });
-      roomBridges++;
-      log('§ROOM_SPINE_BRIDGE room="' + (g.name || lg) + '" storey=' + g.storey +
-          ' spine=' + best.guid + ' dist=' + bestD.toFixed(2) + 'm');
-    });
-    if (roomBridges) log('§ROOM_SPINE_BRIDGE bridged=' + roomBridges);
 
     // ── E4: escape — the existing nonRoomDoors detection becomes an N-EXIT node (free fire-escape
     // target); connect the nearest room-or-circ node on that storey (real distance, not invented).
@@ -808,6 +756,75 @@
       if (!roomRectsByStorey[g.storey]) roomRectsByStorey[g.storey] = [];
       g.rects.forEach(function (rc) { roomRectsByStorey[g.storey].push(rc); });
     });
+
+    // ── §ROOM-SPINE-BRIDGE + §BRIDGE-WALL-LEGAL (OCCUPANT_PATHFINDER.md, 2026-07-25) ──
+    // A room with ZERO edges is unroutable: §CONNECTED-STOPS drops it, Find cannot path to it, and
+    // on Hospital that stranded 42 rooms (room-pair pathability 56.2%) INCLUDING the building's
+    // largest space (315.7 m² atrium). E1 is door-based, and a low-enclosure space has no door on
+    // its boundary — the property that earns it SUSPECT_OPEN. Two alternatives were falsified on a
+    // real fixture first: widening the door slack (cannot reach rooms whose nearest door is 8-10m;
+    // needs a 5x constant move) and room-to-room rect adjacency (0 of 42 have a neighbour ROOM rect
+    // within RES — compiled rooms do not tile the floor). Circulation IS in reach: the atrium's
+    // nearest spine point is 1.31m away.
+    // §BRIDGE-WALL-LEGAL — the review's correction, and it is the point of the whole edge: an
+    // UNVALIDATED bridge is an INVENTED PASSAGE. The first cut emitted 40 bridges of which 17
+    // exceeded 15m and the longest was 45.7m, each stored as doorName 'Opening onto corridor' with
+    // doorGuid null — Find would happily route a user through 45.7m of solid wall. So the segment
+    // must be MEASURED, not asserted: sample room-centre -> spine point and require ZERO illegal
+    // samples via the engine's own _chordIllegalCount (raster when the storey has one, room/corridor
+    // rects otherwise — the same predicate shortestPath's legalizer already trusts). This block
+    // therefore lives HERE, after `rasters` and `roomRectsByStorey` exist, not up beside the circ
+    // bridge. Candidates are tried nearest-first and the first LEGAL one wins; if none is legal the
+    // room stays deg-0 ON PURPOSE. A graph that admits a gap is recoverable; one that invents a
+    // passage produces confidently wrong egress/MEP/quantity answers downstream.
+    var roomBridges = 0, bridgeRejected = 0;
+    var _legalCtx = { rasters: rasters, roomRectsByStorey: roomRectsByStorey,
+                      corridorRectsByStorey: corridorRectsByStorey };
+    var _degSoFar = {};
+    edges.forEach(function (e) {
+      _degSoFar[e.a] = (_degSoFar[e.a] || 0) + 1;
+      _degSoFar[e.b] = (_degSoFar[e.b] || 0) + 1;
+    });
+    order.forEach(function (lg) {
+      var g = nodes[lg];
+      if (g.kind !== 'room' || _degSoFar[lg]) return;
+      var pts = spineByStorey[g.storey];
+      if (!pts || !pts.length) return;
+      // rect distance ranks candidates (a long room's centre can be far from a corridor its EDGE
+      // touches); the LEGALITY test uses centre->spine, which is the segment a router actually draws.
+      var ranked = pts.map(function (p) {
+        var d;
+        if (g.rects && g.rects.length) {
+          d = Infinity;
+          for (var ri = 0; ri < g.rects.length; ri++) {
+            var rc = g.rects[ri];
+            var ddx = Math.max(0, Math.max(rc.x0 - p.cx, p.cx - rc.x1));
+            var ddy = Math.max(0, Math.max(rc.y0 - p.cy, p.cy - rc.y1));
+            var dd = Math.hypot(ddx, ddy);
+            if (dd < d) d = dd;
+          }
+        } else {
+          d = Math.hypot(p.cx - g.cx, p.cy - g.cy);
+        }
+        return { p: p, d: d };
+      }).sort(function (a, b) { return a.d - b.d; });
+      for (var k = 0; k < ranked.length; k++) {
+        var sp = ranked[k].p;
+        if (_chordIllegalCount(_legalCtx, g.storey, g.cx, g.cy, sp.cx, sp.cy) > 0) continue;
+        var w = Math.hypot(sp.cx - g.cx, sp.cy - g.cy);
+        edges.push({ a: lg, b: sp.guid, doorGuid: null, doorName: 'Opening onto corridor',
+                     storey: g.storey, kind: 'E6', w: w, wpA: sp.guid });
+        roomBridges++;
+        log('§ROOM_SPINE_BRIDGE room="' + (g.name || lg) + '" storey=' + g.storey +
+            ' spine=' + sp.guid + ' gap=' + ranked[k].d.toFixed(2) + 'm walk=' + w.toFixed(2) + 'm');
+        return;
+      }
+      bridgeRejected++;
+      log('§ROOM_SPINE_BRIDGE_REJECT room="' + (g.name || lg) + '" storey=' + g.storey +
+          ' candidates=' + ranked.length + ' nearest=' + ranked[0].d.toFixed(2) + 'm — no wall-legal chord');
+    });
+    if (roomBridges || bridgeRejected)
+      log('§ROOM_SPINE_BRIDGE bridged=' + roomBridges + ' rejected=' + bridgeRejected);
 
     return {
       nodes: roomOrder.map(function (lg) { return nodes[lg]; }), // §API-COMPAT: room-only, see file header

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -160,7 +160,7 @@ async function initViewer() {
         // (x8, never removes) any edge touching one so room→room routing prefers corridors.
         // v7 (same doc §10, 2026-07-22): pass ignoreDoorExemption:true so real door-carrying service
         // rooms are tagged too (the door-exempt display default missed them); exclude CORRIDOR_ROOM nodes.
-        '../common/room_graph.js?v=10',
+        '../common/room_graph.js?v=11',
         // §HALLWAY-BACKBONE-NOT-LOADED (2026-07-14, real bug found via live browser check — every
         // corridor/spine/Hall-Corridor-label feature built this session had been silently no-oping
         // in the browser, despite passing every Node-based witness, because this line never

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v845';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v846';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v15 (highlight-first + SUSPECT_OPEN + room-spine bridge — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v16 (highlight-first + SUSPECT_OPEN + wall-legal room-spine bridge — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -150,7 +150,7 @@ function setupTour(A) {
   // (§TOUR_CACHE store … key=…:v12:…). The key's other components are DB counts — they bust on a
   // re-extraction or room recompile, never on a code change. This constant is the ONLY thing that
   // invalidates a cached route when the routing ALGORITHM changes.
-  var TOUR_CACHE_VER = 'v15'; // keep in lockstep with the §TOUR_VERSION banner above
+  var TOUR_CACHE_VER = 'v16'; // keep in lockstep with the §TOUR_VERSION banner above
   function _tourCacheKey() {
     try {
       var r = A.db.exec(


### PR DESCRIPTION
**Completion of #995, not a follow-up.** Review finding, accepted in full: an unvalidated bridge is an **invented passage**.

#995's first cut emitted **40 bridges — 37 longer than 2 m, 17 over 15 m, longest 45.7 m** — each stored as `doorName: 'Opening onto corridor'`, `doorGuid: null`. Find would route a user through 45.7 m of solid wall and draw it on screen. "Illegal-chord ratio" understated this; it isn't route aesthetics.

### Fix
The bridge block moves to **after** `rasters` and `roomRectsByStorey` are built — it was above them, which is why the test couldn't run there. Each candidate spine point is tried nearest-first, and the segment **room-centre → spine** is sampled through the engine's own `_chordIllegalCount` (raster where the storey has one, room/corridor rects otherwise — the same predicate `shortestPath`'s legalizer already trusts). First **legal** candidate wins.

If no candidate is legal the room **stays deg-0 on purpose**. A graph that admits a gap is recoverable; one that invents a passage produces confidently wrong egress / MEP / quantity answers downstream. A new `§ROOM_SPINE_BRIDGE_REJECT` line makes every refusal auditable.

### Measured — this corrects #995's headline
| fixture | bridged / rejected | pathability |
|---|---|---|
| Hospital, **no raster** | 5 / 35 | 56.2% → **59.6%** |
| Hospital, **+ raster** | 9 / 31 | 56.2% → **62.4%** |
| Terminal | — | 75.9% → **79.6%** (deg0 6→5) |
| HHS / Clinic / Duplex / SampleHouse / SampleCastle | — | unchanged |

**#995 claimed 86.2% (Hospital) and 95.7% (Terminal). Those were 56.2% and 75.9% of real connectivity plus unvalidated bridges.** The gated figures above are the real ones.

### It also reverses the atrium win — stated plainly
With the **real raster** applied, R14's straight chord to its nearest spine point is **not walkable**, so the 315.7 m² atrium is correctly refused an edge and stays unreachable — the Fly Tour reverts to the 219 m² corridor. Without raster data the rect fallback accepts the same chord (`R14 deg=1`). That difference *is* the difference between asserting and measuring.

The atrium needs a connection that routes **around** obstruction, not a straight bridge. Filed, not hidden.

### Consequence worth noting
The raster is better evidence in **both** directions — it accepts 9 bridges where the rect fallback accepts 5, while correctly rejecting R14. That makes the G2 raster deployment a **correctness dependency, not an optimisation**.

`room_graph.js?v=11` · `tour.js` v16 · `TOUR_CACHE_VER` v16 · `sw.js` v846

🤖 Generated with [Claude Code](https://claude.com/claude-code)