### PR TITLE
feat(tour): TOUR_TIMELINE_SCRUB — continuous Fly Tour scrub bar (pose = f(T))

### DIFF
--- a/viewer/picking.js
+++ b/viewer/picking.js
@@ -105,6 +105,7 @@ function setupPicking(A) {
       A.walkPath = [];
       var _fb = document.getElementById('fly-btn'); if (_fb) _fb.classList.remove('active');
       document.getElementById('walk-speed-btn').style.display = 'none';
+      if (A._scrubHide) A._scrubHide();   // §TOUR_TIMELINE_SCRUB — canvas tap aborts the tour, bar goes with it
     }
     // Long-press (500ms) → volume info card (mobile-friendly right-click)
     // Only start on single-finger touch; cancel if pinch (2nd pointer) or any move

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v846';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v847';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v16 (highlight-first + SUSPECT_OPEN + wall-legal room-spine bridge — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v17 (timeline-scrub + highlight-first + SUSPECT_OPEN + wall-legal room-spine bridge — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -80,6 +80,7 @@ function setupTour(A) {
     } else {
       A.status.textContent = 'Fly stopped.';
       document.getElementById('walk-speed-btn').style.display = 'none';
+      if (A._scrubHide) A._scrubHide();   // §TOUR_TIMELINE_SCRUB — bar lives exactly as long as the tour
     }
   };
 
@@ -327,8 +328,15 @@ function setupTour(A) {
         A.walkOrbitAngle = 0;
         A.walkLastTime = 0;
         A.walkSpeedMult = 1;
+        A.tourScrubSpeed = 1;
+        A._tourPaused = false;
         document.getElementById('walk-speed-btn').style.display = '';
         document.getElementById('walk-speed-btn').textContent = '1x';
+        // §TOUR_TIMELINE_SCRUB — chain every action's end pose into the next one's start NOW, so the
+        // whole tour is a deterministic pose = f(T) before a single frame plays. Deliberately after
+        // the §TOUR_CACHE store above: the cached JSON must stay free of the runtime remaps.
+        A._tourPrepare();
+        A._scrubShow();
         A.wlog(`START cinematic tour: ${tour.length} actions`);
         A.status.textContent = `Cinematic tour: ${tour.length} actions`;
         // §IDLE-PARK: _startFlyTour runs after an async route-planning gap (buildTour/room-graph),
@@ -1097,390 +1105,599 @@ function setupTour(A) {
     return pu[lo] + (pu[hi] - pu[lo]) * f;
   }
 
-  // Action-based walkTick
+  // ═══════════ §TOUR_TIMELINE_SCRUB — the tour as a TIMELINE, pose = f(T) ═══════════
+  // Implementing FLY_TOUR_CORRIDOR_GRAPH.md §TOUR_TIMELINE_SCRUB (verdict 2026-07-25: "bespoke seek
+  // in tour.js; borrow TM's DOCTRINE and VISUAL LANGUAGE, not its code").
+  // Witnesses: W-SCRUB-DETERMINISM, W-SCRUB-HOLD, W-SCRUB-BEAT, W-SCRUB-OVERLAY.
+  //
+  // THE ONE ARCHITECTURAL MOVE (spec's own words): once the action list is known, walk it ONCE and
+  // have each action report its END pose, chaining into the next action's START pose. Every action
+  // is then eagerly inited with a STATIC start (no live-camera capture at action entry, no lazy
+  // init at walkActionT===0) and the whole tour becomes a deterministic pose = f(T) — a TIMELINE,
+  // not a playback side-effect. This is what makes random-access seeking legal at all.
+  //
+  // Why LIVE-REPLAY and not a baked video (spec §"ours quite on the fly"): cinema_maxq.js's export
+  // pipes the canvas through MediaRecorder/captureStream() to a real .webm — pre-render time, then
+  // a fixed-size frame lookup. This is the opposite: every seek recomputes the LIVE 3D scene at
+  // that exact pose, any window size, still respecting whatever is toggled on screen (night mode /
+  // Alt+G GI preview / DLOD nav) because it is a real render, not a video frame.
+  function _v3s(v) { return v.x.toFixed(4) + ',' + v.y.toFixed(4) + ',' + v.z.toFixed(4); }
+  function _smooth(t) { return t * t * (3 - 2 * t); }
+
+  // _actInit — the SAME init code forward playback always used, with the live-camera reads replaced
+  // by the chained (sPos, sTgt) start pose. Idempotent via act._inited: a re-prepare must never
+  // re-apply flyPath's meanFactor rescale of act.duration twice.
+  function _actInit(act, sPos, sTgt, nextAct) {
+    if (act._inited) return;
+    act._inited = true;
+    act._startPos = sPos.clone();
+    act._startTarget = sTgt.clone();
+    act._duration = 0;
+
+    if (act.type === 'moveTo') {
+      var dest = new THREE.Vector3(act.x, act.y + A.WALK_EYE_HEIGHT, act.z);
+      act._dist = sPos.distanceTo(dest);
+      var speed = act._dist > 5 ? Math.max(A.WALK_SPEED, act._dist / 3.0) : A.WALK_SPEED;
+      // §TOUR_TIMELINE_SCRUB: speed multipliers are NO LONGER baked into duration — they are a dt
+      // multiplier in walkTick, so _tourTotal is a stable constant the mm:ss readout can cite.
+      act._duration = Math.max(act._dist / (speed * (act.speedMul || 1)), 0.3);
+      if (act.speedMul) A.wlog('§INTERIOR_PACING moveTo "' + act.name + '" speedMul=' + act.speedMul + ' dur=' + act._duration.toFixed(1) + 's');
+      if (act.dynamicPace) {
+        var PACE_SAMPLES = 8, samplePts = [];
+        for (var si = 0; si < PACE_SAMPLES; si++) samplePts.push(act._startPos.clone().lerp(dest, si / (PACE_SAMPLES - 1)));
+        act._paceRemap = _paceBuildRemap(samplePts, function(p) { return _invPace(p.distanceTo(dest), 10, 1); });
+        if (act._paceRemap) {
+          act._duration = Math.max(act._duration * act._paceRemap.meanFactor, 0.3);
+          A.wlog('§INTERIOR_PACING moveTo "' + act.name + '" distPace min=' + act._paceRemap.minFactor.toFixed(2) + ' max=' + act._paceRemap.maxFactor.toFixed(2) + ' mean=' + act._paceRemap.meanFactor.toFixed(2) + ' dur=' + act._duration.toFixed(1) + 's');
+        }
+      }
+      if (nextAct && nextAct.lookAtX !== undefined && nextAct.lookAtZ !== undefined) {
+        act._endLookX = nextAct.lookAtX;
+        act._endLookZ = nextAct.lookAtZ;
+      }
+
+    } else if (act.type === 'lookAround') {
+      var totalDeg = act.degrees || 360;
+      if (act.lookAtX !== undefined && act.lookAtZ !== undefined) {
+        act._startRad = Math.atan2(act.lookAtX - sPos.x, act.lookAtZ - sPos.z) - totalDeg / 2 * Math.PI / 180;
+      } else {
+        act._startRad = Math.atan2(sTgt.x - sPos.x, sTgt.z - sPos.z);
+      }
+      // Exact conversion of the old walkPanAngle accumulator: it integrated a CONSTANT rate
+      // (PAN_SPEED deg/s), so elapsed-time/duration is the identical progress, now pure-from-t.
+      act._duration = Math.max(totalDeg / A.PAN_SPEED, 0.1);
+
+    } else if (act.type === 'rise') {
+      act._targetY = act.targetY + A.WALK_EYE_HEIGHT;
+      act._dy = act._targetY - sPos.y;
+      // Old form stepped a constant 1.0 m/s until |dy| < 0.05 — linear, so t-form is exact.
+      act._duration = Math.abs(act._dy) / 1.0;
+      if (act._duration < 0.05) act._duration = 0;
+
+    } else if (act.type === 'pause') {
+      act._duration = act.seconds || 1;
+
+    } else if (act.type === 'orbit') {
+      var tiltRad = (act.tiltDeg || 40) * Math.PI / 180;
+      var totalRad = act.fullCircle ? Math.PI * 2 : Math.PI;
+      act._startAngle = Math.atan2(sPos.z - act.cz, sPos.x - act.cx);
+      act._startY = sPos.y;
+      act._groundY = act.cy + A.WALK_EYE_HEIGHT;
+      var orbitHInit = act.cy + act.radius * Math.sin(tiltRad);
+      var oPts = [], OP = 10;
+      for (var oi = 0; oi < OP; oi++) {
+        var tt = oi / (OP - 1), smoothTt = _smooth(tt);
+        var angTt = act._startAngle + totalRad * smoothTt, camYtt;
+        if (tt < 0.2) { var ht = tt / 0.2; camYtt = act._startY + (orbitHInit - act._startY) * _smooth(ht); }
+        else if (tt < 0.6) camYtt = orbitHInit;
+        else { var dt2 = (tt - 0.6) / 0.4; camYtt = orbitHInit + (act._groundY - orbitHInit) * _smooth(dt2); }
+        var descTt = tt > 0.6 ? (tt - 0.6) / 0.4 : 0;
+        var tiltTt = tiltRad * (1 - descTt * descTt);
+        oPts.push(new THREE.Vector3(act.cx + Math.cos(angTt) * act.radius * Math.cos(tiltTt), camYtt,
+                                    act.cz + Math.sin(angTt) * act.radius * Math.cos(tiltTt)));
+      }
+      act._paceRemap = _paceBuildRemap(oPts, function(p) { return _invPace(Math.abs(p.y - act._groundY), 15, 1); });
+      if (act._paceRemap) {
+        act._duration = Math.max((act.duration || 8) * act._paceRemap.meanFactor, 2);
+        A.wlog('§INTERIOR_PACING orbit heightPace min=' + act._paceRemap.minFactor.toFixed(2) + ' max=' + act._paceRemap.maxFactor.toFixed(2) + ' mean=' + act._paceRemap.meanFactor.toFixed(2) + ' dur=' + act._duration.toFixed(1) + 's');
+      } else {
+        act._duration = act.duration || 8;
+      }
+
+    } else if (act.type === 'riseAndTilt') {
+      act._startY = sPos.y; act._startX = sPos.x; act._startZ = sPos.z;
+      act._duration = Math.abs(act.targetY - act._startY) < 0.1 ? 0 : 5.0;
+
+    } else if (act.type === 'flyPath') {
+      try {
+        var rawPts = act.points.map(function(p) { return new THREE.Vector3(p.x, p.y, p.z); });
+        var distToFirst = sPos.distanceTo(rawPts[0]);
+        var pts3 = distToFirst > 3 ? [sPos.clone()].concat(rawPts) : rawPts;
+        act._curve = new THREE.CatmullRomCurve3(pts3, false, 'catmullrom', 0.5);
+        act._totalLen = act._curve.getLength();
+        act._prevLook = sTgt.clone();
+        console.log('[TOUR] §FLYPATH_INIT pts=' + pts3.length + ' len=' + act._totalLen.toFixed(1) + ' dur=' + act.duration + ' first=(' + rawPts[0].x.toFixed(1) + ',' + rawPts[0].y.toFixed(1) + ',' + rawPts[0].z.toFixed(1) + ') start=(' + sPos.x.toFixed(1) + ',' + sPos.y.toFixed(1) + ',' + sPos.z.toFixed(1) + ')');
+        if (!act._totalLen || act._totalLen < 1) {
+          console.warn('[TOUR] §FLYPATH_SKIP degenerate curve len=' + act._totalLen);
+          act._degenerate = true; act._duration = 0; return;
+        }
+        act._paceRemap = _paceBuildRemap(pts3, function(p, i) { return _losPace(pts3, i); });
+        if (act._paceRemap) {
+          act.duration = Math.max((act.duration || 30) * act._paceRemap.meanFactor, 3);
+          console.log('[TOUR] §TIGHT_TURN_PACING verts=' + pts3.length + ' losRange=[' + act._paceRemap.minFactor.toFixed(2) + ',' + act._paceRemap.maxFactor.toFixed(2) + '] mean=' + act._paceRemap.meanFactor.toFixed(2) + ' dur=' + act.duration.toFixed(1) + 's');
+        }
+        act._lookAheadFrac = act._totalLen > 0 ? Math.min(0.05, LOOKAHEAD_M / act._totalLen) : 0.05;
+        console.log('[TOUR] §TARGET_BOUNDED_LOOKAHEAD totalLen=' + act._totalLen.toFixed(1) + ' lookAheadM=' + LOOKAHEAD_M + ' frac=' + act._lookAheadFrac.toFixed(4));
+        act._duration = act.duration || 30;
+      } catch (e) {
+        console.error('[TOUR] §FLYPATH_CRASH', e.message);
+        act._degenerate = true; act._duration = 0;
+      }
+    }
+    if (!(act._duration >= 0)) act._duration = 0;
+  }
+  // _actPose — PURE: given an inited action and a LINEAR time fraction, return {pos, tgt}. No live
+  // camera reads, no frame history, no side effects. Identical math to the per-frame code it
+  // replaced; the pace remaps are applied here exactly where walkTick applied them before.
+  // flyPath's tgt is the RAW look point — the _prevLook lerp is frame-history and lives in walkTick
+  // (playback) / tourSeek (snap-on-jump), never here.
+  function _actPose(act, tLinear) {
+    var t = Math.max(0, Math.min(tLinear, 1));
+    var pos = act._startPos.clone(), tgt = act._startTarget.clone();
+
+    if (act.type === 'moveTo') {
+      var s = _smooth(t);
+      if (act._paceRemap) s = _paceLookup(act._paceRemap, s);
+      var dest = new THREE.Vector3(act.x, act.y + A.WALK_EYE_HEIGHT, act.z);
+      pos.lerpVectors(act._startPos, dest, s);
+      var endTarget;
+      if (act._endLookX !== undefined) {
+        var dx = act._endLookX - act.x, dz = act._endLookZ - act.z;
+        var len = Math.hypot(dx, dz) || 1;
+        endTarget = new THREE.Vector3(act.x + dx / len * 3.0, act.y + A.WALK_EYE_HEIGHT, act.z + dz / len * 3.0);
+      } else { endTarget = dest.clone(); endTarget.z += 0.1; }
+      var aheadTarget = dest.clone(); aheadTarget.z += 0.1;
+      if (t < 0.6) {
+        tgt.lerpVectors(act._startTarget, aheadTarget, s);
+      } else {
+        var midTarget = new THREE.Vector3().lerpVectors(act._startTarget, aheadTarget, _smooth(t));
+        var turnT = (t - 0.6) / 0.4;
+        tgt.lerpVectors(midTarget, endTarget, _smooth(turnT));
+      }
+
+    } else if (act.type === 'lookAround') {
+      var totalDeg = act.degrees || 360, eased;
+      if (t < 0.15) { var p1 = t / 0.15; eased = 0.15 * _smooth(p1); }
+      else if (t > 0.85) { var p2 = (t - 0.85) / 0.15; eased = 0.85 + 0.15 * _smooth(p2); }
+      else eased = t;
+      var rad = (act._startRad || 0) + eased * totalDeg * Math.PI / 180;
+      tgt.set(pos.x + 3.0 * Math.sin(rad),
+              (act.lookAtY !== undefined) ? act.lookAtY : pos.y,
+              pos.z + 3.0 * Math.cos(rad));
+
+    } else if (act.type === 'rise') {
+      pos.y = act._startPos.y + act._dy * t;
+      tgt.y = act._startTarget.y + act._dy * t;
+
+    } else if (act.type === 'pause') {
+      /* pose held — this is the zero-drift beat by construction */
+
+    } else if (act.type === 'orbit') {
+      var tiltRad = (act.tiltDeg || 40) * Math.PI / 180;
+      var totalRad = act.fullCircle ? Math.PI * 2 : Math.PI;
+      var to = act._paceRemap ? _paceLookup(act._paceRemap, t) : t;
+      var smooth = _smooth(to);
+      var ang = act._startAngle + totalRad * smooth;
+      var orbitH = act.cy + act.radius * Math.sin(tiltRad), camY;
+      if (to < 0.2) camY = act._startY + (orbitH - act._startY) * _smooth(to / 0.2);
+      else if (to < 0.6) camY = orbitH;
+      else camY = orbitH + (act._groundY - orbitH) * _smooth((to - 0.6) / 0.4);
+      var descentProgress = to > 0.6 ? (to - 0.6) / 0.4 : 0;
+      var effectiveTilt = tiltRad * (1 - descentProgress * descentProgress);
+      var wantPos = new THREE.Vector3(act.cx + Math.cos(ang) * act.radius * Math.cos(effectiveTilt), camY,
+                                      act.cz + Math.sin(ang) * act.radius * Math.cos(effectiveTilt));
+      var wantTarget = new THREE.Vector3(act.cx, act.cy + (camY - act.cy) * descentProgress, act.cz);
+      if (to < 0.2) {
+        var bs = _smooth(to / 0.2);
+        pos.lerpVectors(act._startPos, wantPos, bs);
+        tgt.lerpVectors(act._startTarget, wantTarget, bs);
+      } else { pos.copy(wantPos); tgt.copy(wantTarget); }
+      act._lastAngle = ang;
+
+    } else if (act.type === 'riseAndTilt') {
+      var sm = _smooth(t);
+      pos.set(act._startX, act._startY + (act.targetY - act._startY) * sm, act._startZ);
+      var tr = (act.tiltDeg || 80) * Math.PI / 180 * sm;
+      var wt = new THREE.Vector3(act._startX, pos.y - 5.0 * Math.sin(tr), act._startZ + 5.0 * Math.cos(tr) * 0.1);
+      tgt.lerpVectors(act._startTarget, wt, sm);
+
+    } else if (act.type === 'flyPath') {
+      if (act._degenerate) return { pos: pos, tgt: tgt };
+      var tf = act._paceRemap ? _paceLookup(act._paceRemap, t) : t;
+      pos.copy(act._curve.getPointAt(tf));
+      tgt.copy(act._curve.getPointAt(Math.min(tf + (act._lookAheadFrac || 0.05), 0.999)));
+    }
+    return { pos: pos, tgt: tgt };
+  }
+
+  // A._tourPrepare — the build-time chain. Runs ONCE per tour activation, after walkActions is set.
+  // NOTE (deviation from the spec's literal "at the end of buildTour()"): the §TOUR_CACHE fast path
+  // (_startFlyTour, the A._tourCachedRoute branch) never calls buildTour at all — a cached route is
+  // plain JSON. Preparing at the walkActions assignment point covers BOTH paths, and it must also
+  // run AFTER the cache store so the stored JSON stays free of the runtime remaps.
+  A._tourPrepare = function() {
+    var acts = A.walkActions;
+    if (!acts || !acts.length) return;
+    var t0 = performance.now();
+    var pos = A.camera.position.clone(), tgt = A.controls.target.clone();
+    A._tourStarts = [];
+    var cum = 0;
+    for (var i = 0; i < acts.length; i++) {
+      var act = acts[i];
+      act._inited = false;
+      _actInit(act, pos, tgt, acts[i + 1]);
+      var end = _actPose(act, 1.0);
+      A._tourStarts.push(cum);
+      cum += act._duration;
+      pos = end.pos; tgt = end.tgt;
+    }
+    A._tourTotal = cum;
+    A._tourT = 0;
+    var brk = [];
+    for (var j = 0; j < acts.length; j++) brk.push(acts[j].type + ':' + acts[j]._duration.toFixed(2));
+    console.log('[TOUR] §SCRUB_PREPARE actions=' + acts.length + ' total=' + cum.toFixed(3) + 's prepMs=' + (performance.now() - t0).toFixed(1) + ' endPose=' + _v3s(pos));
+    console.log('[TOUR] §SCRUB_BEATS ' + brk.join(' | '));
+  };
+
+  // A.tourSeek — absolute random-access seek. Single writer of (walkActionIdx, walkActionT, _tourT).
+  // soft=true keeps the flyPath gaze lerp (small in-place drag deltas, the user's "smooth to play
+  // forward backward"); every other seek SNAPS _prevLook to the raw target so the pose is pure
+  // f(T) — that is what makes re-seeking the same T land on the identical frame.
+  A.tourSeek = function(T, soft) {
+    if (!A.walkActions || !A.walkActions.length || !A._tourStarts) return null;
+    T = Math.max(0, Math.min(T, A._tourTotal));
+    var lo = 0, hi = A._tourStarts.length - 1, idx = 0;
+    while (lo <= hi) {
+      var mid = (lo + hi) >> 1;
+      if (A._tourStarts[mid] <= T) { idx = mid; lo = mid + 1; } else hi = mid - 1;
+    }
+    var act = A.walkActions[idx];
+    if (!act._inited) _actInit(act, A.camera.position.clone(), A.controls.target.clone(), A.walkActions[idx + 1]);
+    A.walkActionIdx = idx;
+    A.walkActionT = T - A._tourStarts[idx];
+    var t = act._duration > 0 ? Math.min(A.walkActionT / act._duration, 1) : 0;
+    var p = _actPose(act, t);
+    A.camera.position.copy(p.pos);
+    if (act.type === 'flyPath' && !act._degenerate) {
+      if (!act._prevLook) act._prevLook = p.tgt.clone();
+      if (soft) act._prevLook.lerp(p.tgt, 0.35); else act._prevLook.copy(p.tgt);
+      A.controls.target.copy(act._prevLook);
+    } else {
+      A.controls.target.copy(p.tgt);
+    }
+    A.walkPanAngle = (act.type === 'lookAround') ? t * (act.degrees || 360) : 0;
+    if (act.type === 'orbit' && act._lastAngle !== undefined) A.walkOrbitAngle = act._lastAngle;
+    A.controls.update();
+    A._tourT = T;
+    A.walkLastTime = 0;               // next played frame must not integrate the scrub gap
+    if (A.markDirty) A.markDirty();
+    console.log('[TOUR] §SCRUB_SEEK T=' + T.toFixed(4) + ' idx=' + idx + ' t=' + t.toFixed(6) +
+                ' mode=' + (soft ? 'soft' : 'hard') + ' pos=' + _v3s(A.camera.position) + ' tgt=' + _v3s(A.controls.target));
+    return { T: T, idx: idx, t: t, pos: A.camera.position.clone(), tgt: A.controls.target.clone() };
+  };
+
+  // A.tourStepBeat — EXACT action-boundary jump (spec §4: "the reason beat boundaries must be
+  // exact, not approximate scrub positions"). dir<0 = nearest boundary strictly before the cursor.
+  A.tourStepBeat = function(dir) {
+    if (!A._tourStarts) return null;
+    var cur = A._tourT || 0, EPS = 1e-4, target = null, i;
+    if (dir < 0) {
+      for (i = A._tourStarts.length - 1; i >= 0; i--) {
+        if (A._tourStarts[i] < cur - EPS) { target = A._tourStarts[i]; break; }
+      }
+      if (target === null) target = 0;
+    } else {
+      for (i = 0; i < A._tourStarts.length; i++) {
+        if (A._tourStarts[i] > cur + EPS) { target = A._tourStarts[i]; break; }
+      }
+      if (target === null) target = A._tourTotal;
+    }
+    var r = A.tourSeek(target, false);
+    console.log('[TOUR] §SCRUB_BEAT dir=' + (dir < 0 ? 'prev' : 'next') + ' from=' + cur.toFixed(4) + ' to=' + target.toFixed(4) + ' idx=' + A.walkActionIdx);
+    _scrubAfterJump();
+    return r;
+  };
+  function _statusFor(act, t, spd) {
+    var s;
+    if (act.type === 'moveTo') s = (act.name || 'Walking...') + ' [' + spd + 'x] camY=' + A.camera.position.y.toFixed(1);
+    else if (act.type === 'lookAround') s = 'Looking around ' + (t * (act.degrees || 360)).toFixed(0) + '° [' + spd + 'x]';
+    else if (act.type === 'rise') s = (act.name || 'Rising...') + ' camY=' + A.camera.position.y.toFixed(1) + ' → ' + act._targetY.toFixed(1);
+    else if (act.type === 'orbit') s = 'Aerial sweep ' + (t * 100).toFixed(0) + '% [' + spd + 'x]';
+    else if (act.type === 'riseAndTilt') s = (act.name || "Bird's eye") + ' ' + (t * 100).toFixed(0) + '% [' + spd + 'x]';
+    else if (act.type === 'flyPath') {
+      var label = '';
+      if (act.names && act.names.length) {
+        for (var ni = Math.round(t * (act.names.length - 1)); ni >= 0; ni--) { if (act.names[ni]) { label = act.names[ni]; break; } }
+      }
+      s = (label || 'Flying...') + ' ' + (t * 100).toFixed(0) + '% [' + spd + 'x]';
+    } else return;
+    A.status.textContent = s;
+  }
+
+  function _wlogDone(act) {
+    if (act.type === 'moveTo' && act.name) A.wlog('Arrived: ' + act.name + ' camY=' + A.camera.position.y.toFixed(2));
+    else if (act.type === 'rise') A.wlog('Rise done: camY=' + A.camera.position.y.toFixed(2));
+    else if (act.type === 'orbit') A.wlog('Orbit complete');
+    else if (act.type === 'riseAndTilt') A.wlog('RiseAndTilt done: camY=' + A.camera.position.y.toFixed(2));
+    else if (act.type === 'flyPath') A.wlog('FlyPath complete');
+  }
+
+  // Action-based walkTick — now a THIN driver over the pose = f(T) timeline above: advance the
+  // cursor by dt, evaluate, apply. Every per-action formula lives in _actInit/_actPose so playback
+  // and scrub-seek can never diverge (the spec's "reusing the SAME init code forward playback uses").
   A.walkTick = function() {
     if (!A.walkMode || !A.walkActions || A.walkActions.length === 0) return;
+
+    // §TOUR_TIMELINE_SCRUB knob 3 — pause HOLDS the pose: nothing writes the camera while paused,
+    // so a presenter can hold a frame indefinitely with zero drift (W-SCRUB-HOLD).
+    if (A._tourPaused) { _scrubSync(); return; }
+
     if (A.walkActionIdx >= A.walkActions.length) {
       A.walkMode = false;
       A.flyActive = false;
       A.walkActionIdx = 0;
       A.walkActionT = 0;
       A.walkPanAngle = 0;
-      const btn = document.getElementById('fly-btn');
-      if (btn) btn.classList.remove('active');
+      var btnE = document.getElementById('fly-btn');
+      if (btnE) btnE.classList.remove('active');
       A.status.textContent = 'Tour complete.';
       A.wlog('Tour complete');
+      if (A._scrubHide) A._scrubHide();
       return;
     }
 
-    const now = performance.now();
-    const dt = A.walkLastTime > 0 ? Math.min((now - A.walkLastTime) / 1000, 0.1) : 0.016;
+    var now = performance.now();
+    var dt = A.walkLastTime > 0 ? Math.min((now - A.walkLastTime) / 1000, 0.1) : 0.016;
     A.walkLastTime = now;
 
-    const act = A.walkActions[A.walkActionIdx];
-    const spd = A.walkSpeedMult;
+    // §TOUR_TIMELINE_SCRUB knob 4 — speed is a pure dt multiplier (narration pacing: 0.5x for a
+    // presenter talking over a beat, 2x to skip ahead). Durations stay baked at 1x so _tourTotal
+    // and the mm:ss readout are stable regardless of playback speed.
+    var spd = (A.walkSpeedMult || 1) * (A.tourScrubSpeed || 1);
+    dt *= spd;
 
-    // Save pre-action state for global smoothing
-    const _prevCamPos = A.camera.position.clone();
-    const _prevTarget = A.controls.target.clone();
+    var act = A.walkActions[A.walkActionIdx];
+    if (!act._inited) _actInit(act, A.camera.position.clone(), A.controls.target.clone(), A.walkActions[A.walkActionIdx + 1]);
 
-    if (act.type === 'moveTo') {
-      if (A.walkActionT === 0) {
-        act._startPos = A.camera.position.clone();
-        act._startTarget = A.controls.target.clone();
-        act._dist = A.camera.position.distanceTo(new THREE.Vector3(act.x, act.y + A.WALK_EYE_HEIGHT, act.z));
-        const speed = act._dist > 5 ? Math.max(A.WALK_SPEED, act._dist / 3.0) : A.WALK_SPEED;
-        // §INTERIOR_PACING: speedMul is opt-in per action (only the entrance zoom-in sets it) —
-        // every other moveTo (finale bird's-eye/centre/final) is speedMul-less and unaffected.
-        act._duration = Math.max(act._dist / (speed * spd * (act.speedMul || 1)), 0.3);
-        if (act.speedMul) A.wlog(`§INTERIOR_PACING moveTo "${act.name}" speedMul=${act.speedMul} dur=${act._duration.toFixed(1)}s`);
-        // §INTERIOR_PACING dynamicPace (opt-in, entrance zoom only — see buildTour PART 2): real
-        // REMAINING DISTANCE to the entrance along the approach line — far away hastens well past
-        // the flat speedMul, genuinely nearing the entrance slows it back down. Rescales the
-        // action's own total duration (meanFactor), not just its internal distribution — a long
-        // open aerial gap should take LESS total time outright, not just relatively less within
-        // an unchanged fixed duration.
-        if (act.dynamicPace) {
-          const dest0 = new THREE.Vector3(act.x, act.y + A.WALK_EYE_HEIGHT, act.z);
-          const PACE_SAMPLES = 8;
-          const samplePts = [];
-          for (let si = 0; si < PACE_SAMPLES; si++) samplePts.push(act._startPos.clone().lerp(dest0, si / (PACE_SAMPLES - 1)));
-          act._paceRemap = _paceBuildRemap(samplePts, p => _invPace(p.distanceTo(dest0), 10, 1));
-          if (act._paceRemap) {
-            act._duration = Math.max(act._duration * act._paceRemap.meanFactor, 0.3);
-            A.wlog(`§INTERIOR_PACING moveTo "${act.name}" distPace min=${act._paceRemap.minFactor.toFixed(2)} max=${act._paceRemap.maxFactor.toFixed(2)} mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act._duration.toFixed(1)}s`);
-          }
-        }
-        // Pre-compute final look direction: if next action has lookAtX/Z, face that way on arrival
-        const nextAct = A.walkActions[A.walkActionIdx + 1];
-        if (nextAct && nextAct.lookAtX !== undefined && nextAct.lookAtZ !== undefined) {
-          act._endLookX = nextAct.lookAtX;
-          act._endLookZ = nextAct.lookAtZ;
-        }
-      }
-      A.walkActionT += dt;
-      const t = Math.min(A.walkActionT / act._duration, 1.0);
-      let s = t * t * (3 - 2 * t);
-      if (act._paceRemap) s = _paceLookup(act._paceRemap, s);
-      const dest = new THREE.Vector3(act.x, act.y + A.WALK_EYE_HEIGHT, act.z);
-      A.camera.position.lerpVectors(act._startPos, dest, s);
-      // Smoothly orient toward the next lookAround target in the last 40% of travel
-      let endTarget;
-      if (act._endLookX !== undefined) {
-        const lookDist = 3.0;
-        const dx = act._endLookX - act.x, dz = act._endLookZ - act.z;
-        const len = Math.hypot(dx, dz) || 1;
-        endTarget = new THREE.Vector3(act.x + dx/len * lookDist, act.y + A.WALK_EYE_HEIGHT, act.z + dz/len * lookDist);
-      } else {
-        endTarget = dest.clone(); endTarget.z += 0.1;
-      }
-      // Blend: first 60% look ahead (toward destination), last 40% turn toward endTarget
-      const blendStart = 0.6;
-      if (t < blendStart) {
-        const aheadTarget = dest.clone(); aheadTarget.z += 0.1;
-        A.controls.target.lerpVectors(act._startTarget, aheadTarget, s);
-      } else {
-        const aheadTarget = dest.clone(); aheadTarget.z += 0.1;
-        const midTarget = new THREE.Vector3().lerpVectors(act._startTarget, aheadTarget, t * t * (3 - 2 * t));
-        const turnT = (t - blendStart) / (1 - blendStart);
-        const turnS = turnT * turnT * (3 - 2 * turnT);
-        A.controls.target.lerpVectors(midTarget, endTarget, turnS);
-      }
-      A.controls.update();
-      A.status.textContent = `${act.name || 'Walking...'} [${spd}x] camY=${A.camera.position.y.toFixed(1)}`;
-      if (t >= 1.0) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        if (act.name) A.wlog(`Arrived: ${act.name} camY=${A.camera.position.y.toFixed(2)}`);
-      }
+    var _prevCamPos = A.camera.position.clone();
+    var _prevTarget = A.controls.target.clone();
 
-    } else if (act.type === 'lookAround') {
-      const degreesPerSec = A.PAN_SPEED * spd;
-      const totalDeg = act.degrees || 360;
-      if (A.walkPanAngle === 0 && A.walkActionT === 0) {
-        // If lookAtX/Z given, center sweep on "face inward" direction
-        if (act.lookAtX !== undefined && act.lookAtZ !== undefined) {
-          const dx = act.lookAtX - A.camera.position.x;
-          const dz = act.lookAtZ - A.camera.position.z;
-          const inwardRad = Math.atan2(dx, dz);
-          act._startRad = inwardRad - totalDeg / 2 * Math.PI / 180;
-        } else {
-          const dx = A.controls.target.x - A.camera.position.x;
-          const dz = A.controls.target.z - A.camera.position.z;
-          act._startRad = Math.atan2(dx, dz);
-        }
-      }
-      A.walkPanAngle += degreesPerSec * dt;
-      // Ease-in first 15% and ease-out last 15% for smooth start/stop
-      const progress = Math.min(A.walkPanAngle / totalDeg, 1.0);
-      let easedProgress;
-      if (progress < 0.15) {
-        const p = progress / 0.15;
-        easedProgress = 0.15 * (p * p * (3 - 2 * p));
-      } else if (progress > 0.85) {
-        const p = (progress - 0.85) / 0.15;
-        easedProgress = 0.85 + 0.15 * (p * p * (3 - 2 * p));
-      } else {
-        easedProgress = progress;
-      }
-      const rad = (act._startRad || 0) + easedProgress * totalDeg * Math.PI / 180;
-      const lookDist = 3.0;
-      A.controls.target.x = A.camera.position.x + lookDist * Math.sin(rad);
-      A.controls.target.z = A.camera.position.z + lookDist * Math.cos(rad);
-      // §ENDING: an explicit lookAtY tilts the gaze (ground-level facade shot); default stays level.
-      A.controls.target.y = (act.lookAtY !== undefined) ? act.lookAtY : A.camera.position.y;
-      A.controls.update();
-      A.status.textContent = `Looking around ${(A.walkPanAngle).toFixed(0)}° [${spd}x]`;
-      if (A.walkPanAngle >= totalDeg) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        A.walkPanAngle = 0;
-      }
-
-    } else if (act.type === 'rise') {
-      const targetY = act.targetY + A.WALK_EYE_HEIGHT;
-      const dy = targetY - A.camera.position.y;
-      if (Math.abs(dy) < 0.05) {
-        A.camera.position.y = targetY;
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        A.wlog(`Rise done: camY=${A.camera.position.y.toFixed(2)}`);
-      } else {
-        const step = Math.sign(dy) * Math.min(1.0 * spd * dt, Math.abs(dy));
-        A.camera.position.y += step;
-        A.controls.target.y += step;
-      }
-      A.controls.update();
-      A.status.textContent = `${act.name || 'Rising...'} camY=${A.camera.position.y.toFixed(1)} → ${targetY.toFixed(1)}`;
-
-    } else if (act.type === 'pause') {
-      A.walkActionT += dt;
-      if (A.walkActionT >= (act.seconds || 1)) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-      }
-
-    } else if (act.type === 'orbit') {
-      const tiltRad = (act.tiltDeg || 40) * Math.PI / 180;
-      const totalRad = act.fullCircle ? Math.PI * 2 : Math.PI;
-      if (A.walkActionT === 0) {
-        A.walkOrbitAngle = Math.atan2(A.camera.position.z - act.cz, A.camera.position.x - act.cx);
-        act._startAngle = A.walkOrbitAngle;
-        act._startY = A.camera.position.y;
-        act._groundY = act.cy + A.WALK_EYE_HEIGHT;
-        act._startTarget = A.controls.target.clone();
-        act._startPos = A.camera.position.clone();
-        A.wlog(`Orbit: r=${act.radius?.toFixed(0)} from ${(A.walkOrbitAngle*180/Math.PI).toFixed(0)}°`);
-        // §INTERIOR_PACING (user 2026-07-25: "thus aerial also affected") — sample the orbit's
-        // OWN known geometry (same formula as the per-frame code below, unremapped) at a handful
-        // of t values to measure real clearance, then remap t itself so the aerial sweep hastens
-        // over open ground and only slows for real as it nears the descent/building.
-        const orbitHInit = act.cy + act.radius * Math.sin(tiltRad);
-        const samplePts = [];
-        const PACE_SAMPLES = 10;
-        for (let si = 0; si < PACE_SAMPLES; si++) {
-          const tt = si / (PACE_SAMPLES - 1);
-          const smoothTt = tt * tt * (3 - 2 * tt);
-          const angTt = act._startAngle + totalRad * smoothTt;
-          let camYtt;
-          if (tt < 0.2) { const ht = tt / 0.2, hs = ht * ht * (3 - 2 * ht); camYtt = act._startY + (orbitHInit - act._startY) * hs; }
-          else if (tt < 0.6) camYtt = orbitHInit;
-          else { const dt2 = (tt - 0.6) / 0.4, ds = dt2 * dt2 * (3 - 2 * dt2); camYtt = orbitHInit + (act._groundY - orbitHInit) * ds; }
-          const descTt = tt > 0.6 ? (tt - 0.6) / 0.4 : 0;
-          const tiltTt = tiltRad * (1 - descTt * descTt);
-          samplePts.push(new THREE.Vector3(act.cx + Math.cos(angTt) * act.radius * Math.cos(tiltTt), camYtt,
-                                            act.cz + Math.sin(angTt) * act.radius * Math.cos(tiltTt)));
-        }
-        // Real height-above-ground at each sample (not a raycast — the ground/target height is
-        // already known geometry here), so a mostly-vertical descent actually registers: far
-        // above ground during the sweep hastens, nearing the ground for the landing slows down.
-        act._paceRemap = _paceBuildRemap(samplePts, p => _invPace(Math.abs(p.y - act._groundY), 15, 1));
-        if (act._paceRemap) {
-          act._duration = Math.max((act.duration || 8) * act._paceRemap.meanFactor, 2);
-          A.wlog(`§INTERIOR_PACING orbit heightPace min=${act._paceRemap.minFactor.toFixed(2)} max=${act._paceRemap.maxFactor.toFixed(2)} mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act._duration.toFixed(1)}s`);
-        } else {
-          act._duration = act.duration || 8;
-        }
-      }
-      const duration = act._duration || act.duration || 8;
-      A.walkActionT += dt;
-      const tLinear = Math.min(A.walkActionT / duration, 1.0);
-      const t = act._paceRemap ? _paceLookup(act._paceRemap, tLinear) : tLinear;
-      const smooth = t * t * (3 - 2 * t);
-      A.walkOrbitAngle = act._startAngle + totalRad * smooth;
-      const orbitH = act.cy + act.radius * Math.sin(tiltRad);
-      let camY;
-      if (t < 0.2) {
-        const ht = t / 0.2;
-        const hs = ht * ht * (3 - 2 * ht);
-        camY = act._startY + (orbitH - act._startY) * hs;
-      } else if (t < 0.6) {
-        camY = orbitH;
-      } else {
-        const dt2 = (t - 0.6) / 0.4;
-        const ds = dt2 * dt2 * (3 - 2 * dt2);
-        camY = orbitH + (act._groundY - orbitH) * ds;
-      }
-      const descentProgress = t > 0.6 ? (t - 0.6) / 0.4 : 0;
-      const effectiveTilt = tiltRad * (1 - descentProgress * descentProgress);
-      const camX = act.cx + Math.cos(A.walkOrbitAngle) * act.radius * Math.cos(effectiveTilt);
-      const camZ = act.cz + Math.sin(A.walkOrbitAngle) * act.radius * Math.cos(effectiveTilt);
-      // Blend from previous position/look in first 20% for smooth entry
-      const wantPos = new THREE.Vector3(camX, camY, camZ);
-      const lookY = act.cy + (camY - act.cy) * descentProgress;
-      const wantTarget = new THREE.Vector3(act.cx, lookY, act.cz);
-      if (t < 0.2) {
-        const bt = t / 0.2;
-        const bs = bt * bt * (3 - 2 * bt);
-        A.camera.position.lerpVectors(act._startPos, wantPos, bs);
-        A.controls.target.lerpVectors(act._startTarget, wantTarget, bs);
-      } else {
-        A.camera.position.copy(wantPos);
-        A.controls.target.copy(wantTarget);
-      }
-      A.controls.update();
-      A.status.textContent = `Aerial sweep ${(t * 100).toFixed(0)}% [${spd}x]`;
-      if (t >= 1.0) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        A.wlog('Orbit complete');
-      }
-
-    } else if (act.type === 'riseAndTilt') {
-      const targetY = act.targetY;
-      if (A.walkActionT === 0) {
-        act._startY = A.camera.position.y;
-        act._startX = A.camera.position.x;
-        act._startZ = A.camera.position.z;
-        act._startTarget = A.controls.target.clone();
-      }
-      const totalDist = Math.abs(targetY - act._startY);
-      if (totalDist < 0.1) { A.walkActionIdx++; A.walkActionT = 0; return; }
-      const duration = 5.0;
-      A.walkActionT += dt;
-      const t = Math.min(A.walkActionT / duration, 1.0);
-      const smooth = t * t * (3 - 2 * t);
-      A.camera.position.y = act._startY + (targetY - act._startY) * smooth;
-      const tiltRad = (act.tiltDeg || 80) * Math.PI / 180 * smooth;
-      const lookDist = 5.0;
-      const wantTarget = new THREE.Vector3(
-        act._startX,
-        A.camera.position.y - lookDist * Math.sin(tiltRad),
-        act._startZ + lookDist * Math.cos(tiltRad) * 0.1
-      );
-      // Blend from previous look direction to avoid snap
-      A.controls.target.lerpVectors(act._startTarget, wantTarget, smooth);
-      A.controls.update();
-      A.status.textContent = `${act.name || "Bird's eye"} ${(t * 100).toFixed(0)}% [${spd}x]`;
-      if (t >= 1.0) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        A.wlog(`RiseAndTilt done: camY=${A.camera.position.y.toFixed(2)}`);
-      }
-
-    } else if (act.type === 'flyPath') {
-      // Catmull-Rom spline flythrough — smooth continuous flight
-      if (A.walkActionT === 0) {
-        try {
-          const rawPts = act.points.map(p => new THREE.Vector3(p.x, p.y, p.z));
-          const camPos = A.camera.position.clone();
-          const distToFirst = camPos.distanceTo(rawPts[0]);
-          const pts3 = distToFirst > 3 ? [camPos, ...rawPts] : rawPts;
-          act._curve = new THREE.CatmullRomCurve3(pts3, false, 'catmullrom', 0.5);
-          act._totalLen = act._curve.getLength();
-          act._prevLook = A.controls.target.clone();
-          console.log(`[TOUR] §FLYPATH_INIT pts=${pts3.length} len=${act._totalLen.toFixed(1)} dur=${act.duration} first=(${rawPts[0].x.toFixed(1)},${rawPts[0].y.toFixed(1)},${rawPts[0].z.toFixed(1)}) cam=(${camPos.x.toFixed(1)},${camPos.y.toFixed(1)},${camPos.z.toFixed(1)})`);
-          // Bail if curve is degenerate
-          if (!act._totalLen || act._totalLen < 1) {
-            console.warn('[TOUR] §FLYPATH_SKIP degenerate curve len=' + act._totalLen);
-            A.walkActionIdx++; A.walkActionT = 0; return;
-          }
-          // §TIGHT_TURN_PACING (FLY_TOUR_CORRIDOR_GRAPH.md §INTERIOR_PACING_NOT_A_SPEED_FACTOR,
-          // user 2026-07-25: "even slower when too close to object or spaces as they will simply
-          // flash by meaninglessly"; 2026-07-26: "For LTU in its courtyards, it is too slow" +
-          // "the inverse distance speed law is not proper... simple maths, no overthink" — corrected
-          // from the first pass, which multiplied this clearance factor by a SEPARATE turn-angle
-          // term and produced a runaway combined range (live LTU log: up to 16x). Clearance ALONE
-          // already reads a dead-end spur as tight (walls close on every side, not just at the
-          // vertex angle) and a courtyard as open, so the second signal was redundant AND the
-          // cause of the blow-up — dropped. `meanFactor` also rescales this segment's OWN total
-          // duration (not just its internal distribution) so a genuinely open stretch actually
-          // takes less real time, not just a smaller share of a duration that was already capped
-          // by the flat 0.3x interior baseline.
-          act._paceRemap = _paceBuildRemap(pts3, (p, i) => _losPace(pts3, i));
-          if (act._paceRemap) {
-            act.duration = Math.max((act.duration || 30) * act._paceRemap.meanFactor, 3);
-            console.log(`[TOUR] §TIGHT_TURN_PACING verts=${pts3.length} losRange=[${act._paceRemap.minFactor.toFixed(2)},${act._paceRemap.maxFactor.toFixed(2)}] mean=${act._paceRemap.meanFactor.toFixed(2)} dur=${act.duration.toFixed(1)}s`);
-          }
-          // §TARGET_BOUNDED_LOOKAHEAD (2026-07-26, FLY_TOUR_DLOD_SCALE.md §23/§24) — the look-at
-          // lookahead below used to be a fixed FRACTION (0.05) of this action's own total arc
-          // length. MaxQ/Clash both bound their gaze target to something of room/clash SCALE (a
-          // few meters); MaxQ's own Beat-3 walk-out lookahead (effects.js §CINEMA_TIMING_672, also
-          // a 0.05-of-path-style fraction) only ever stays a few meters ahead because that beat's
-          // own path is short (settle point to nearest door). flyPath's action can span an entire
-          // storey's route (100+m, many rooms) — the SAME fractional mechanism there aims the gaze
-          // many meters past the current room/corridor, into far geometry through doorways/down
-          // corridors, well before the camera itself arrives. Cap the lookahead to an ABSOLUTE
-          // arc-length distance instead, independent of how long the overall route is.
-          act._lookAheadFrac = act._totalLen > 0 ? Math.min(0.05, LOOKAHEAD_M / act._totalLen) : 0.05;
-          console.log(`[TOUR] §TARGET_BOUNDED_LOOKAHEAD totalLen=${act._totalLen.toFixed(1)} lookAheadM=${LOOKAHEAD_M} frac=${act._lookAheadFrac.toFixed(4)} (was fixed 0.05)`);
-        } catch(e) {
-          console.error('[TOUR] §FLYPATH_CRASH', e.message);
-          A.walkActionIdx++; A.walkActionT = 0; return;
-        }
-      }
-      const duration = (act.duration || 30) / spd;
-      A.walkActionT += dt;
-      const tLinear = Math.min(A.walkActionT / duration, 1.0);
-      let t = tLinear;
-      if (act._paceRemap) {
-        t = _paceLookup(act._paceRemap, tLinear);
-      }
-      const pos = act._curve.getPointAt(t);
-      A.camera.position.copy(pos);
-      // §SOFTEN (user 2026-07-16: "soften the sudden switch to new track"): look further ahead
-      // (0.05 vs 0.03) and pan the gaze more gently (lerp 0.08 vs 0.15) — spur-room reversals
-      // (walk in, walk out) sweep instead of whip.
-      const lookT = Math.min(t + (act._lookAheadFrac || 0.05), 0.999);
-      const lookPt = act._curve.getPointAt(lookT);
-      if (!act._prevLook) act._prevLook = lookPt.clone();
-      act._prevLook.lerp(lookPt, 0.08);
-      A.controls.target.copy(act._prevLook);
-      A.controls.update();
-      // Find nearest named point for status
-      const nameIdx = Math.round(t * (act.names.length - 1));
-      let label = '';
-      for (let ni = nameIdx; ni >= 0; ni--) { if (act.names[ni]) { label = act.names[ni]; break; } }
-      A.status.textContent = `${label || 'Flying...'} ${(t * 100).toFixed(0)}% [${spd}x]`;
-      if (t >= 1.0) {
-        A.walkActionIdx++;
-        A.walkActionT = 0;
-        A.wlog('FlyPath complete');
-      }
-
-    } else {
-      A.walkActionIdx++;
-      A.walkActionT = 0;
+    if (!(act._duration > 0)) {           // degenerate/zero-length beat — nothing to play
+      A.walkActionIdx++; A.walkActionT = 0;
+      A._tourT = A._tourStarts ? A._tourStarts[Math.min(A.walkActionIdx, A._tourStarts.length - 1)] : 0;
+      return;
     }
 
-    // ── Adaptive smoothing: dampens SUDDEN jumps only (action transitions/reversals) —
-    // steady motion is already eased by the action itself (spline/smoothstep) and needs no
-    // second pass. FIX (2026-07-24, FLY_TOUR_DLOD_SCALE.md walkTick-vs-pvStep comparison):
-    // this used to run unconditionally with SMOOTH=0.6 even in the "steady" band, silently
-    // applying only 60% of each frame's intended step every single frame while walkActionT
-    // still advanced the full dt — a permanent ~40%-of-one-frame lag-behind, on top of
-    // whatever render cost exists, throttling real travel speed below the tour's own
-    // computed duration/speed. Now a no-op below the jump threshold; real transition jumps
-    // still get damped exactly as before.
-    const posDelta = _prevCamPos.distanceTo(A.camera.position);
-    const tgtDelta = _prevTarget.distanceTo(A.controls.target);
-    const maxDelta = Math.max(posDelta, tgtDelta);
+    A.walkActionT += dt;
+    var t = Math.min(A.walkActionT / act._duration, 1.0);
+    var p = _actPose(act, t);
+    A.camera.position.copy(p.pos);
+    if (act.type === 'flyPath' && !act._degenerate) {
+      // §SOFTEN (user 2026-07-16) — gaze smoothing stays exactly as shipped for PLAYBACK; it is
+      // frame-history dependent, which is why tourSeek snaps it instead of inheriting it.
+      if (!act._prevLook) act._prevLook = p.tgt.clone();
+      act._prevLook.lerp(p.tgt, 0.08);
+      A.controls.target.copy(act._prevLook);
+    } else {
+      A.controls.target.copy(p.tgt);
+    }
+    A.controls.update();
+    if (act.type === 'lookAround') A.walkPanAngle = t * (act.degrees || 360);
+    _statusFor(act, t, spd);
+    A._tourT = (A._tourStarts ? A._tourStarts[A.walkActionIdx] : 0) + A.walkActionT;
+
+    if (t >= 1.0) {
+      _wlogDone(act);
+      A.walkActionIdx++;
+      A.walkActionT = 0;
+      A.walkPanAngle = 0;
+    }
+    _scrubSync();
+
+    // ── Adaptive smoothing: dampens SUDDEN jumps only (action transitions/reversals) — unchanged
+    // from before §TOUR_TIMELINE_SCRUB. It is PLAYBACK-only: tourSeek writes the pure pose directly
+    // and never runs this, which is what keeps a re-seek bit-identical.
+    var posDelta = _prevCamPos.distanceTo(A.camera.position);
+    var tgtDelta = _prevTarget.distanceTo(A.controls.target);
+    var maxDelta = Math.max(posDelta, tgtDelta);
     if (maxDelta >= 0.5) {
-      const SMOOTH = maxDelta > 2 ? 0.12 : 0.3;
+      var SMOOTH = maxDelta > 2 ? 0.12 : 0.3;
       A.camera.position.lerpVectors(_prevCamPos, A.camera.position, SMOOTH);
       A.controls.target.lerpVectors(_prevTarget, A.controls.target, SMOOTH);
       A.controls.update();
     }
+  };
+  // ═══════════ §TOUR_TIMELINE_SCRUB — UI ═══════════
+  // Visual doctrine borrowed from time_machine.js's panel (376px glass, #4fc3f7 accent, native
+  // <input type=range> thumb, 3px progress bar with transition:width 0.2s) — the LOOK, not the code
+  // (TM's slider is mode-relative DAY/HR/MIN, nothing to reuse for a playhead).
+  // 🚫 NOT a rotary dial: common/history_knob.js (PR #230) was rejected outright ("hard to control,
+  // orange halo useless, no hover") and deleted. Linear bar + draggable thumb only.
+  // The bar simply APPEARS when the tour begins (user 2026-07-25, TM-style) — no reveal icon, no
+  // hidden state; the superseded record-dot design is deliberately not built.
+  var SCRUB_RES = 1000;
+  var _scrubPanel = null, _scrubSlider = null, _scrubDragging = false;
+  var _scrubLastSyncMs = 0, _scrubDragT = -1;
+
+  function _fmtMS(s) {
+    if (!(s >= 0)) s = 0;
+    var m = Math.floor(s / 60), r = Math.floor(s % 60);
+    return m + ':' + (r < 10 ? '0' : '') + r;
+  }
+  function _beatName(act, i) {
+    if (act.name) return act.name;
+    if (act.type === 'flyPath' && act.names) {
+      for (var k = 0; k < act.names.length; k++) if (act.names[k]) return act.names[k];
+    }
+    var m = { orbit: 'Aerial sweep', moveTo: 'Approach', lookAround: 'Look around', rise: 'Rise',
+              riseAndTilt: "Bird's eye", pause: 'Hold', flyPath: 'Corridor' };
+    return (m[act.type] || act.type) + ' ' + (i + 1);
+  }
+  // Re-evaluate DLOD ONCE, on scrub RELEASE — never per `input` event (per-event re-eval janks the
+  // drag; time_machine.js has no debounce at all on its own input path, :2595 — explicitly not
+  // copied). dlodTick self-throttles on a frame counter, so force this one call through.
+  function _scrubAfterJump() {
+    if (A.dlodTick) { A._dlodFrame = -1; try { A.dlodTick(); } catch (e) {} }
+    _scrubSync(true);
+  }
+
+  function _scrubBuild() {
+    if (_scrubPanel) return;
+    _scrubPanel = document.createElement('div');
+    _scrubPanel.id = 'tour-scrub-panel';
+    var tmp = document.getElementById('time-machine-panel');
+    var bottom = (tmp && tmp.style.display && tmp.style.display !== 'none') ? '260px' : '80px';
+    _scrubPanel.style.cssText =
+      'position:fixed;bottom:' + bottom + ';left:50%;transform:translateX(-50%);z-index:250;' +
+      'display:none;flex-direction:column;gap:6px;padding:10px 16px;' +
+      'background:rgba(20,20,40,0.85);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);' +
+      'border:1px solid rgba(79,195,247,0.3);border-radius:12px;' +
+      'box-shadow:0 4px 24px rgba(0,0,0,0.5);color:#e0e0e0;font-family:sans-serif;' +
+      'width:376px;user-select:none;touch-action:none;';
+    _scrubPanel.innerHTML =
+      '<div style="display:flex;align-items:center;gap:6px;width:100%">' +
+        '<span id="tour-scrub-label" style="flex:1;color:#4fc3f7;font-weight:bold;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Fly Tour</span>' +
+        '<span id="tour-scrub-time" style="font-size:13px;color:#ccc;font-variant-numeric:tabular-nums">0:00 / 0:00</span>' +
+      '</div>' +
+      '<div id="tour-scrub-ticks" style="position:relative;width:100%;height:10px"></div>' +
+      '<input id="tour-scrub-slider" type="range" min="0" max="' + SCRUB_RES + '" step="1" value="0" style="width:100%;accent-color:#4fc3f7">' +
+      '<div style="width:100%;height:3px;background:rgba(255,255,255,0.1);border-radius:2px;overflow:hidden">' +
+        '<div id="tour-scrub-progress" style="height:100%;width:0%;background:#4fc3f7;transition:width 0.2s"></div>' +
+      '</div>' +
+      '<div style="display:flex;gap:4px;width:100%;height:30px;align-items:stretch">' +
+        '<button id="tour-scrub-restart" style="width:34px;font-size:13px" title="Restart tour from the beginning">&#x21BA;</button>' +
+        '<button id="tour-scrub-prev" style="width:38px;font-size:13px" title="Previous beat (exact action boundary)">&#x25C0;&#x25C0;</button>' +
+        '<button id="tour-scrub-play" style="width:38px;font-size:14px" title="Play / pause">&#x23F8;</button>' +
+        '<button id="tour-scrub-next" style="width:38px;font-size:13px" title="Next beat (exact action boundary)">&#x25B6;&#x25B6;</button>' +
+        '<span style="flex:1"></span>' +
+        '<button class="tour-scrub-spd" data-spd="0.5" style="width:38px;font-size:11px" title="Half speed — narration pacing">0.5x</button>' +
+        '<button class="tour-scrub-spd" data-spd="1" style="width:34px;font-size:11px" title="Normal speed">1x</button>' +
+        '<button class="tour-scrub-spd" data-spd="2" style="width:34px;font-size:11px" title="Double speed — skip ahead">2x</button>' +
+      '</div>';
+    document.body.appendChild(_scrubPanel);
+    // The panel is a fixed overlay, not a canvas child — picking.js's tour-abort listener is bound
+    // to A.canvas, so panel pointers never reach it. stopPropagation is belt-and-braces.
+    _scrubPanel.addEventListener('pointerdown', function(e) { e.stopPropagation(); });
+
+    _scrubSlider = document.getElementById('tour-scrub-slider');
+    _scrubSlider.addEventListener('pointerdown', function() { _scrubDragging = true; _scrubDragT = A._tourT || 0; });
+    _scrubSlider.addEventListener('input', function() {
+      var T = (parseFloat(_scrubSlider.value) / SCRUB_RES) * (A._tourTotal || 0);
+      var prevIdx = A.walkActionIdx;
+      A.tourSeek(T, false);
+      // Keep the gaze lerp only for SMALL in-place drag deltas within one beat; a big jump or a
+      // beat change snaps (tourSeek already snapped above — re-apply softly when it was small).
+      var small = _scrubDragging && Math.abs(T - _scrubDragT) < 0.5 && prevIdx === A.walkActionIdx;
+      if (small) A.tourSeek(T, true);
+      _scrubDragT = T;
+      _scrubSync(true);
+    });
+    var release = function() {
+      if (!_scrubDragging) return;
+      _scrubDragging = false;
+      var T = (parseFloat(_scrubSlider.value) / SCRUB_RES) * (A._tourTotal || 0);
+      A.tourSeek(T, false);               // final HARD seek: the resting pose after a drag is pure f(T)
+      console.log('[TOUR] §SCRUB_RELEASE T=' + T.toFixed(4) + ' idx=' + A.walkActionIdx + ' pos=' + _v3s(A.camera.position));
+      _scrubAfterJump();
+    };
+    _scrubSlider.addEventListener('change', release);
+    _scrubSlider.addEventListener('pointerup', release);
+    _scrubSlider.addEventListener('touchend', release);
+
+    document.getElementById('tour-scrub-restart').onclick = function() { A.tourSeek(0, false); _scrubAfterJump(); console.log('[TOUR] §SCRUB_RESTART'); };
+    document.getElementById('tour-scrub-prev').onclick = function() { A.tourStepBeat(-1); };
+    document.getElementById('tour-scrub-next').onclick = function() { A.tourStepBeat(1); };
+    document.getElementById('tour-scrub-play').onclick = function() { A.tourTogglePause(); };
+    var spds = _scrubPanel.querySelectorAll('.tour-scrub-spd');
+    for (var i = 0; i < spds.length; i++) {
+      spds[i].onclick = function() { A.tourSetSpeed(parseFloat(this.getAttribute('data-spd'))); };
+    }
+  }
+
+  A.tourTogglePause = function(force) {
+    A._tourPaused = (force === undefined) ? !A._tourPaused : !!force;
+    if (!A._tourPaused) { A.walkLastTime = 0; if (A.markDirty) A.markDirty(); }
+    var b = document.getElementById('tour-scrub-play');
+    if (b) b.innerHTML = A._tourPaused ? '&#x25B6;' : '&#x23F8;';
+    console.log('[TOUR] §SCRUB_PAUSE paused=' + A._tourPaused + ' T=' + (A._tourT || 0).toFixed(4) + ' pos=' + _v3s(A.camera.position));
+    return A._tourPaused;
+  };
+
+  A.tourSetSpeed = function(mult) {
+    A.tourScrubSpeed = mult;
+    var spds = _scrubPanel ? _scrubPanel.querySelectorAll('.tour-scrub-spd') : [];
+    for (var i = 0; i < spds.length; i++) {
+      var on = parseFloat(spds[i].getAttribute('data-spd')) === mult;
+      spds[i].style.background = on ? '#4fc3f7' : '';
+      spds[i].style.color = on ? '#06121a' : '';
+    }
+    console.log('[TOUR] §SCRUB_SPEED mult=' + mult + 'x totalUnchanged=' + (A._tourTotal || 0).toFixed(2) + 's');
+  };
+
+  // Chapter ticks — one mark per action boundary, LABELLED from walkActions[] (orbit / approach /
+  // corridor / stair / room beat) via title, and clickable straight to that beat.
+  function _scrubBuildTicks() {
+    var box = document.getElementById('tour-scrub-ticks');
+    if (!box || !A._tourStarts) return;
+    box.innerHTML = '';
+    var total = A._tourTotal || 1, n = 0;
+    for (var i = 0; i < A.walkActions.length; i++) {
+      if (!(A.walkActions[i]._duration > 0)) continue;
+      var st = A._tourStarts[i];
+      var d = document.createElement('div');
+      d.title = _beatName(A.walkActions[i], i) + ' @ ' + _fmtMS(st);
+      d.setAttribute('data-t', st);
+      d.style.cssText = 'position:absolute;top:0;left:' + ((st / total) * 100).toFixed(3) + '%;' +
+        'width:2px;height:10px;background:rgba(79,195,247,0.75);border-radius:1px;cursor:pointer;transform:translateX(-1px)';
+      box.appendChild(d); n++;
+    }
+    box.onclick = function(ev) {
+      var raw = ev.target && ev.target.getAttribute ? ev.target.getAttribute('data-t') : null;
+      var tt = raw === null ? NaN : parseFloat(raw);
+      if (isFinite(tt)) { A.tourSeek(tt, false); console.log('[TOUR] §SCRUB_TICK T=' + tt.toFixed(4)); _scrubAfterJump(); }
+    };
+    console.log('[TOUR] §SCRUB_TICKS n=' + n + ' total=' + total.toFixed(2) + 's');
+  }
+
+  function _scrubSync(force) {
+    if (!_scrubPanel || _scrubPanel.style.display === 'none') return;
+    var now = performance.now();
+    if (!force && now - _scrubLastSyncMs < 100) return;   // 10Hz DOM writes, not 60
+    _scrubLastSyncMs = now;
+    var total = A._tourTotal || 0, T = A._tourT || 0;
+    var frac = total > 0 ? T / total : 0;
+    if (!_scrubDragging) _scrubSlider.value = Math.round(frac * SCRUB_RES);
+    var pb = document.getElementById('tour-scrub-progress');
+    if (pb) pb.style.width = (frac * 100).toFixed(2) + '%';
+    var lb = document.getElementById('tour-scrub-label');
+    var act = A.walkActions[Math.min(A.walkActionIdx, A.walkActions.length - 1)];
+    if (lb && act) lb.textContent = _beatName(act, A.walkActionIdx) + '  (' + (A.walkActionIdx + 1) + '/' + A.walkActions.length + ')';
+    var tv = document.getElementById('tour-scrub-time');
+    if (tv) tv.textContent = _fmtMS(T) + ' / ' + _fmtMS(total);
+  }
+
+  A._scrubShow = function() {
+    _scrubBuild();
+    _scrubBuildTicks();
+    A.tourSetSpeed(A.tourScrubSpeed || 1);
+    A.tourTogglePause(false);
+    _scrubPanel.style.display = 'flex';
+    _scrubSync(true);
+    console.log('[TOUR] §SCRUB_UI show actions=' + A.walkActions.length + ' total=' + (A._tourTotal || 0).toFixed(2) + 's bar=linear-thumb dial=none');
+  };
+  A._scrubHide = function() {
+    if (_scrubPanel) _scrubPanel.style.display = 'none';
+    A._tourPaused = false;
   };
 
   // ── Legacy path builders (kept for fallback) ──

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -837,8 +837,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
-<script src="picking.js?v=28" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
-<script src="tour.js?v=16" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
+<script src="picking.js?v=29" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
+<script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=1" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>

--- a/witness_tour_scrub.js
+++ b/witness_tour_scrub.js
@@ -1,0 +1,294 @@
+// WITNESS — FLY_TOUR_CORRIDOR_GRAPH.md §TOUR_TIMELINE_SCRUB verification.
+//
+// ISSUE EACH CLAIM PROVES/DISPROVES (Spec-First: "a tour must be inspectable, not merely seekable"):
+//   W-SCRUB-PREPARE     — does the build-time end-pose chain produce a complete, monotonic timeline?
+//                         PASS = every action has a finite _duration, _tourStarts is non-decreasing,
+//                         and sum(durations) === _tourTotal. FAIL = a lazy/undefined action remains.
+//   W-SCRUB-DETERMINISM — is pose = f(T) actually pure? PASS = seeking to the SAME T twice, with
+//                         unrelated seeks in between and in a different order, yields BIT-IDENTICAL
+//                         camera position and controls.target. FAIL = any component differs.
+//   W-SCRUB-HOLD        — can a presenter pause and hold a frame with zero drift? PASS = camera
+//                         position/target unchanged (delta 0) across ~3s of real animation frames
+//                         while paused. FAIL = any drift, however small.
+//   W-SCRUB-BEAT        — do the step buttons land on EXACT action boundaries, not approximations?
+//                         PASS = after tourStepBeat, _tourT equals a _tourStarts[] entry exactly.
+//   W-SCRUB-OVERLAY     — the user's "maintaining the overlay ie n, Alt-G/o" invariant. PASS = night
+//                         mode / GI composer / DLOD-nav flags are byte-identical before and after a
+//                         drag-scrub + release. FAIL = scrubbing reset any of them.
+//   W-SCRUB-SPEED       — is the speed knob a dt multiplier, not a timeline rescale? PASS =
+//                         _tourTotal is unchanged by tourSetSpeed(0.5/1/2).
+//   W-SCRUB-UI          — all four knob groups present, linear bar, no rotary dial.
+//
+// Whitebox doctrine: every assertion below reads REAL numeric object state (camera position,
+// controls.target, _tourT, _tourStarts) out of the live page. No screenshots, no eyeballing.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8410;
+const BLD = process.env.BLD || 'LTU_AHouse';
+const results = [];
+function claim(name, pass, detail) {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'} ${name} — ${detail}`);
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  try {
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls, { timeout: 120000 });
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 240000, polling: 2000 });
+    await page.waitForFunction(() => !window.APP.streaming, { timeout: 300000, polling: 2000 });
+    console.log('[witness] streaming drained, starting tour');
+
+    // Start the real Fly Tour (real route planning, real building, real geometry).
+    await page.evaluate(() => window.APP.toggleFlyAround());
+    await page.waitForFunction(() => window.APP.walkActions && window.APP.walkActions.length > 0 &&
+                                     window.APP._tourStarts && window.APP._tourTotal > 0,
+                               { timeout: 300000, polling: 1000 });
+
+    // ── W-SCRUB-PREPARE ───────────────────────────────────────────────────────
+    const prep = await page.evaluate(() => {
+      const A = window.APP;
+      let sum = 0, mono = true, allFinite = true, prev = -1;
+      for (let i = 0; i < A.walkActions.length; i++) {
+        const d = A.walkActions[i]._duration;
+        if (!(typeof d === 'number' && isFinite(d) && d >= 0)) allFinite = false;
+        if (A._tourStarts[i] < prev) mono = false;
+        prev = A._tourStarts[i];
+        sum += d;
+      }
+      return { n: A.walkActions.length, sum, total: A._tourTotal, mono, allFinite,
+               inited: A.walkActions.every(a => a._inited === true) };
+    });
+    claim('W-SCRUB-PREPARE', prep.allFinite && prep.mono && prep.inited && Math.abs(prep.sum - prep.total) < 1e-9,
+      `actions=${prep.n} sum=${prep.sum.toFixed(6)}s total=${prep.total.toFixed(6)}s monotonic=${prep.mono} allEagerlyInited=${prep.inited}`);
+
+    // ── W-SCRUB-DETERMINISM ───────────────────────────────────────────────────
+    // Seek to a probe set, then re-seek the SAME values in reverse order with unrelated seeks
+    // interleaved. Compare raw float components — bit-identical or it is not a timeline.
+    const det = await page.evaluate(() => {
+      const A = window.APP;
+      const snap = () => [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                          A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      const probes = [0, A._tourTotal * 0.13, A._tourTotal * 0.37, A._tourTotal * 0.62,
+                      A._tourTotal * 0.88, A._tourTotal];
+      const first = {};
+      probes.forEach(T => { A.tourSeek(T, false); first[T] = snap(); });
+      // scramble: unrelated seeks between, and revisit in reverse
+      const second = {}, deltas = [];
+      probes.slice().reverse().forEach(T => {
+        A.tourSeek(A._tourTotal * Math.random(), false);   // decoy seek
+        A.tourSeek(T, false);
+        second[T] = snap();
+        let worst = 0;
+        for (let i = 0; i < 6; i++) worst = Math.max(worst, Math.abs(first[T][i] - second[T][i]));
+        deltas.push({ T: +T.toFixed(4), worst });
+      });
+      return { deltas, worstAll: Math.max(...deltas.map(d => d.worst)), sample: first[probes[3]] };
+    });
+    claim('W-SCRUB-DETERMINISM', det.worstAll === 0,
+      `probes=${det.deltas.length} worstComponentDelta=${det.worstAll} ` +
+      det.deltas.map(d => `T=${d.T}:${d.worst}`).join(' '));
+
+    // ── W-SCRUB-BEAT ──────────────────────────────────────────────────────────
+    const beat = await page.evaluate(() => {
+      const A = window.APP;
+      A.tourSeek(A._tourTotal * 0.5, false);
+      const out = [];
+      for (let k = 0; k < 3; k++) {
+        A.tourStepBeat(-1);
+        out.push({ dir: 'prev', T: A._tourT, exact: A._tourStarts.indexOf(A._tourT) });
+      }
+      for (let k = 0; k < 3; k++) {
+        A.tourStepBeat(1);
+        out.push({ dir: 'next', T: A._tourT, exact: A._tourStarts.indexOf(A._tourT) });
+      }
+      // land on the same beat twice from different directions → same pose?
+      const b = A._tourStarts[Math.floor(A._tourStarts.length / 2)];
+      A.tourSeek(0, false); A.tourSeek(b, false);
+      const p1 = [A.camera.position.x, A.camera.position.y, A.camera.position.z];
+      A.tourSeek(A._tourTotal, false); A.tourSeek(b, false);
+      const p2 = [A.camera.position.x, A.camera.position.y, A.camera.position.z];
+      const repeat = Math.max(...p1.map((v, i) => Math.abs(v - p2[i])));
+      return { out, repeat, b };
+    });
+    const beatExact = beat.out.every(o => o.exact >= 0 || o.T === 0);
+    claim('W-SCRUB-BEAT', beatExact && beat.repeat === 0,
+      `steps=${beat.out.map(o => `${o.dir}@${o.T.toFixed(4)}[idx${o.exact}]`).join(' ')} ` +
+      `sameBeatFromBothDirections_posDelta=${beat.repeat}`);
+
+    // ── W-SCRUB-OVERLAY ───────────────────────────────────────────────────────
+    const ov = await page.evaluate(async () => {
+      const A = window.APP;
+      // Turn ON all three overlays the user named ("n, Alt-G/o") before scrubbing, so the
+      // invariant is tested in its ON state, not trivially in its default OFF state.
+      if (typeof window.toggleNightMode === 'function') window.toggleNightMode();
+      if (typeof A.toggleGIPreview === 'function') { try { await A.toggleGIPreview(true); } catch (e) {} }
+      if (typeof window.toggleDlodNav === 'function') { try { window.toggleDlodNav(); } catch (e) {} }
+      await new Promise(r => setTimeout(r, 500));
+      const before = { night: !!A._nightMode, gi: !!A._giComposerActive,
+                       dlodOn: !!window._dlodNavOn, dlodEngaged: !!window._dlodNavEngaged };
+      // simulate a real drag on the bar: input events then release
+      const sl = document.getElementById('tour-scrub-slider');
+      for (let v = 100; v <= 700; v += 60) {
+        sl.value = String(v);
+        sl.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      sl.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 300));
+      const after = { night: !!A._nightMode, gi: !!A._giComposerActive,
+                      dlodOn: !!window._dlodNavOn, dlodEngaged: !!window._dlodNavEngaged };
+      return { before, after, T: A._tourT, idx: A.walkActionIdx };
+    });
+    const ovSame = JSON.stringify(ov.before) === JSON.stringify(ov.after);
+    claim('W-SCRUB-OVERLAY', ovSame,
+      `before=${JSON.stringify(ov.before)} after=${JSON.stringify(ov.after)} landedT=${ov.T.toFixed(4)} idx=${ov.idx}`);
+
+    // ── W-SCRUB-HOLD ──────────────────────────────────────────────────────────
+    const hold = await page.evaluate(async () => {
+      const A = window.APP;
+      A.tourSeek(A._tourTotal * 0.42, false);
+      A.tourTogglePause(true);
+      const p0 = [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                  A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      const T0 = A._tourT;
+      // Drive the ACTUAL playback path directly — headless rAF is throttled, so counting animation
+      // frames would prove almost nothing. 600 explicit walkTick() calls (~10s of 60fps playback)
+      // is the real assertion that the paused branch writes neither camera nor cursor.
+      let frames = 0;
+      for (let i = 0; i < 600; i++) { A.walkTick(); frames++; }
+      const t0 = performance.now();
+      await new Promise(res => {
+        const step = () => { if (performance.now() - t0 < 3000) requestAnimationFrame(step); else res(); };
+        requestAnimationFrame(step);
+      });
+      for (let i = 0; i < 600; i++) { A.walkTick(); frames++; }
+      const p1 = [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                  A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      return { drift: Math.max(...p0.map((v, i) => Math.abs(v - p1[i]))), frames,
+               tDrift: Math.abs(A._tourT - T0), paused: A._tourPaused };
+    });
+    claim('W-SCRUB-HOLD', hold.drift === 0 && hold.tDrift === 0,
+      `paused=${hold.paused} walkTickCalls=${hold.frames} maxPoseDrift=${hold.drift} cursorDrift=${hold.tDrift} over 3000ms wall-clock`);
+
+    // ── W-SCRUB-DRAG-RELEASE ──────────────────────────────────────────────────
+    // Proves a drag leaves NO residue: the pose at rest after dragging to T must equal the pose of
+    // a cold hard seek to the same T (the gaze lerp used mid-drag must not survive the release).
+    const drag = await page.evaluate(() => {
+      const A = window.APP;
+      A.tourTogglePause(false);
+      const sl = document.getElementById('tour-scrub-slider');
+      const target = 640;                                  // slider units
+      const T = (target / 1000) * A._tourTotal;
+      A.tourSeek(0, false);
+      sl.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      for (let v = 600; v <= target; v += 8) { sl.value = String(v); sl.dispatchEvent(new Event('input', { bubbles: true })); }
+      sl.dispatchEvent(new Event('change', { bubbles: true }));
+      const afterDrag = [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                         A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      A.tourSeek(0, false); A.tourSeek(A._tourTotal, false);   // scramble
+      A.tourSeek(T, false);
+      const cold = [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                    A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      return { T, delta: Math.max(...afterDrag.map((v, i) => Math.abs(v - cold[i]))) };
+    });
+    claim('W-SCRUB-DRAG-RELEASE', drag.delta === 0,
+      `dragRestPose vs coldSeek at T=${drag.T.toFixed(4)} maxComponentDelta=${drag.delta}`);
+
+    // ── W-SCRUB-SPEED ─────────────────────────────────────────────────────────
+    const spd = await page.evaluate(() => {
+      const A = window.APP;
+      const t0 = A._tourTotal;
+      const seen = [];
+      [0.5, 2, 1].forEach(m => { A.tourSetSpeed(m); seen.push({ m, mult: A.tourScrubSpeed, total: A._tourTotal }); });
+      return { t0, seen, stable: seen.every(s => s.total === t0) };
+    });
+    claim('W-SCRUB-SPEED', spd.stable && spd.seen[2].mult === 1,
+      `total=${spd.t0.toFixed(4)}s unchanged across ${spd.seen.map(s => s.m + 'x→' + s.total.toFixed(4)).join(' ')}`);
+
+    // ── W-SCRUB-PLAYBACK ──────────────────────────────────────────────────────
+    // REGRESSION: walkTick was rewritten to drive off _actInit/_actPose. Proves ordinary forward
+    // playback still advances — cursor monotonically increasing, camera actually moving, action
+    // index progressing. (Headless rAF is throttled, so walkTick is driven with real time gaps.)
+    const play = await page.evaluate(async () => {
+      const A = window.APP;
+      A.tourSetSpeed(1);
+      A.tourSeek(0, false);
+      A.tourTogglePause(false);
+      A.walkLastTime = 0;
+      const samples = [];
+      for (let i = 0; i < 80; i++) {
+        A.walkTick();
+        samples.push({ T: A._tourT, idx: A.walkActionIdx,
+                       p: [A.camera.position.x, A.camera.position.y, A.camera.position.z] });
+        await new Promise(r => setTimeout(r, 30));
+      }
+      let mono = true, moved = 0;
+      for (let i = 1; i < samples.length; i++) {
+        if (samples[i].T < samples[i - 1].T - 1e-9) mono = false;
+        moved += Math.hypot(samples[i].p[0] - samples[i - 1].p[0],
+                            samples[i].p[1] - samples[i - 1].p[1],
+                            samples[i].p[2] - samples[i - 1].p[2]);
+      }
+      const endT = samples[samples.length - 1].T;
+      const played = [A.camera.position.x, A.camera.position.y, A.camera.position.z];
+      A.tourSeek(endT, false);      // pure timeline pose at the same cursor
+      const pure = [A.camera.position.x, A.camera.position.y, A.camera.position.z];
+      return { mono, moved, endT, idxEnd: samples[samples.length - 1].idx,
+               idxStart: samples[0].idx,
+               purityGap: Math.max(...played.map((v, i) => Math.abs(v - pure[i]))) };
+    });
+    claim('W-SCRUB-PLAYBACK', play.mono && play.moved > 1 && play.endT > 0,
+      `cursorMonotonic=${play.mono} pathTravelled=${play.moved.toFixed(3)}m endT=${play.endT.toFixed(3)}s ` +
+      `actionIdx ${play.idxStart}→${play.idxEnd} | playback-vs-pure pose gap=${play.purityGap.toFixed(4)}m ` +
+      `(expected non-zero: the shipped adaptive-jump smoothing is playback-only by design)`);
+
+    // ── W-SCRUB-UI ────────────────────────────────────────────────────────────
+    const ui = await page.evaluate(() => {
+      const q = id => !!document.getElementById(id);
+      const panel = document.getElementById('tour-scrub-panel');
+      const sl = document.getElementById('tour-scrub-slider');
+      return {
+        visible: !!panel && panel.style.display === 'flex',
+        slider: !!sl && sl.type === 'range',
+        ticks: document.getElementById('tour-scrub-ticks') ? document.getElementById('tour-scrub-ticks').children.length : 0,
+        play: q('tour-scrub-play'), prev: q('tour-scrub-prev'), next: q('tour-scrub-next'),
+        restart: q('tour-scrub-restart'),
+        speeds: document.querySelectorAll('.tour-scrub-spd').length,
+        time: document.getElementById('tour-scrub-time') ? document.getElementById('tour-scrub-time').textContent : '',
+        dial: document.querySelectorAll('.scrubknob, canvas.knob').length,
+      };
+    });
+    claim('W-SCRUB-UI', ui.visible && ui.slider && ui.ticks > 0 && ui.play && ui.prev && ui.next &&
+                        ui.restart && ui.speeds === 3 && /\d+:\d\d \/ \d+:\d\d/.test(ui.time) && ui.dial === 0,
+      `barVisible=${ui.visible} linearRangeThumb=${ui.slider} chapterTicks=${ui.ticks} ` +
+      `play/prev/next/restart=${ui.play}/${ui.prev}/${ui.next}/${ui.restart} speedBtns=${ui.speeds} ` +
+      `mmss="${ui.time}" rotaryDials=${ui.dial}`);
+
+  } catch (e) {
+    claim('WITNESS-RUN', false, 'threw: ' + e.message);
+  }
+
+  console.log('\n───── §-tagged page log (scrub only) ─────');
+  logs.filter(l => /§SCRUB|§TOUR_VERSION|PAGEERROR/.test(l)).slice(0, 60).forEach(l => console.log(l));
+  console.log('\n───── SUMMARY ─────');
+  results.forEach(r => console.log(`${r.pass ? 'PASS' : 'FAIL'} ${r.name}`));
+  const allPass = results.length > 0 && results.every(r => r.pass);
+  console.log(allPass ? 'WITNESS RESULT: ALL PASS' : 'WITNESS RESULT: FAILURES PRESENT');
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
Implements `FLY_TOUR_CORRIDOR_GRAPH.md §TOUR_TIMELINE_SCRUB` — a continuous, draggable scrub bar for the Fly Tour's own playback timeline. Separate from the discrete History event-dot system (`common/history_bar.js` untouched).

## The architectural move

At tour start, `A._tourPrepare()` walks `walkActions[]` once and chains each action's **END pose** into the next one's **START pose**. Every action is eagerly inited with a static start (no live-camera capture at action entry, no lazy init at `walkActionT === 0`), so its pose is a pure function of a time fraction. The tour becomes a TIMELINE, not a playback side-effect — and random-access seeking falls out for free.

- `A.tourSeek(T, soft)` — binary-search `_tourStarts`, evaluate, apply. Sole writer of `(walkActionIdx, walkActionT, _tourT)`.
- `walkTick` is now a thin driver over the same `_actInit`/`_actPose` pair, so playback and seek can never diverge.
- Gaze: hard seeks SNAP `flyPath._prevLook` to the raw target; the §SOFTEN lerp is kept only for small in-drag deltas.
- DLOD re-evaluated ONCE on scrub RELEASE, never per `input` event.
- Speed is a `dt` multiplier — durations stay baked at 1x so `_tourTotal` and the `mm:ss` readout are stable.

## UI — all four knob groups

The bar simply appears when the tour begins (TM-style — no reveal icon, no rotary dial; the `common/history_knob.js` rejection precedent is respected). Chapter ticks labelled from `walkActions[]`, play/pause + restart + `mm:ss / mm:ss`, 0.5x/1x/2x speed, and step-by-beat back/forward landing on exact action boundaries.

## Witnesses — real LTU_AHouse 37-action tour (18:10 total), all PASS

| Witness | Evidence |
|---|---|
| W-SCRUB-PREPARE | `actions=37 sum=1090.597263s total=1090.597263s monotonic=true allEagerlyInited=true` |
| W-SCRUB-DETERMINISM | `worstComponentDelta=0` over 6 probes re-seeked in reverse with decoy seeks interleaved |
| W-SCRUB-BEAT | exact boundaries; `sameBeatFromBothDirections_posDelta=0` |
| W-SCRUB-OVERLAY | night+GI+DLOD-nav all ON, byte-identical before/after a drag |
| W-SCRUB-HOLD | `walkTickCalls=1200 maxPoseDrift=0 cursorDrift=0` |
| W-SCRUB-DRAG-RELEASE | drag rest pose vs cold seek `maxComponentDelta=0` |
| W-SCRUB-SPEED | `_tourTotal` unchanged across 0.5x/2x/1x |
| W-SCRUB-PLAYBACK | cursor monotonic, 722.455m travelled — walkTick rewrite regression guard |
| W-SCRUB-UI | linear range thumb, 37 chapter ticks, 3 speed buttons, `rotaryDials=0` |

Reproduce: `PORT=<port> node witness_tour_scrub.js` against a static server rooted at the repo.

## Measured deviations from spec

1. Prepare runs at the `A.walkActions = tour` assignment in `_startFlyTour`, not literally "at the end of `buildTour()`" — the §TOUR_CACHE fast path never calls `buildTour` (a cached route is plain JSON), and it must run after the cache store so stored JSON stays free of runtime remaps.
2. Speed multipliers no longer bake into durations. Side effect: `orbit` previously ignored `walkSpeedMult` entirely and now honours it, like every other action type.
3. `W-SCRUB-PLAYBACK` measures a 39.8m playback-vs-pure pose gap during the opening high-radius aerial orbit. This is the **pre-existing** adaptive-jump smoothing block (unchanged by this PR) lagging behind fast motion — reported, not fixed, and playback-only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
