### PR TITLE
feat(tour): §SCRUB_PANEL_DRAG — draggable Fly Tour scrub panel

### DIFF
--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -1588,6 +1588,7 @@ function setupTour(A) {
     // The panel is a fixed overlay, not a canvas child — picking.js's tour-abort listener is bound
     // to A.canvas, so panel pointers never reach it. stopPropagation is belt-and-braces.
     _scrubPanel.addEventListener('pointerdown', function(e) { e.stopPropagation(); });
+    _scrubWireDrag();
 
     _scrubSlider = document.getElementById('tour-scrub-slider');
     _scrubSlider.addEventListener('pointerdown', function() { _scrubDragging = true; _scrubDragT = A._tourT || 0; });
@@ -1622,6 +1623,104 @@ function setupTour(A) {
     for (var i = 0; i < spds.length; i++) {
       spds[i].onclick = function() { A.tourSetSpeed(parseFloat(this.getAttribute('data-spd'))); };
     }
+  }
+
+  // ═══════════ §SCRUB_PANEL_DRAG — movable panel (FLY_TOUR_CORRIDOR_GRAPH.md §SCRUB_PANEL_DRAG) ═══
+  // WHY: §2 item 2 of the usage review asked whether the always-on bar competes with the cinematic
+  // view. Moving it answers that WITHOUT reopening the rejected hidden/reveal-icon design — the
+  // presenter parks it off whatever they are showing, and it stays put across beats and reloads.
+  // The panel is the ONLY thing that moves: a panel drag must never write the timeline (W-SCRUB-
+  // PANEL-DRAG asserts A._tourT and the camera pose are byte-identical across a drag).
+  var SCRUB_POS_KEY = 'bim.tourScrub.pos';
+  var _scrubDragPan = null;            // {dx, dy, id} while a panel drag is live, else null
+
+  // Clamp fully on-screen — a drag aimed off-viewport parks at the edge, the panel is never lost.
+  function _scrubClampPos(left, top) {
+    var w = _scrubPanel.offsetWidth, h = _scrubPanel.offsetHeight;
+    return { left: Math.max(0, Math.min(left, window.innerWidth - w)),
+             top:  Math.max(0, Math.min(top,  window.innerHeight - h)) };
+  }
+  // Shipped default is bottom-centre via left:50% + translateX(-50%). Freeze that into explicit
+  // left/top px measured from the CURRENT rect, so the first grab cannot shift under the cursor.
+  function _scrubFreezePos() {
+    if (_scrubPanel.style.transform === 'none') return;
+    var r = _scrubPanel.getBoundingClientRect();
+    _scrubPanel.style.transform = 'none';
+    _scrubPanel.style.bottom = 'auto';
+    _scrubPanel.style.left = r.left + 'px';
+    _scrubPanel.style.top = r.top + 'px';
+  }
+  function _scrubApplyPos(left, top, why) {
+    _scrubFreezePos();
+    var c = _scrubClampPos(left, top);
+    var clamped = (c.left !== left || c.top !== top);
+    _scrubPanel.style.left = c.left + 'px';
+    _scrubPanel.style.top = c.top + 'px';
+    if (why) console.log('[TOUR] §SCRUB_PANEL_POS ' + why + ' left=' + c.left.toFixed(1) +
+                         ' top=' + c.top.toFixed(1) + ' clamped=' + clamped);
+    return c;
+  }
+  function _scrubSavePos() {
+    try {
+      var r = _scrubPanel.getBoundingClientRect();
+      localStorage.setItem(SCRUB_POS_KEY, JSON.stringify({ left: r.left, top: r.top }));
+    } catch (e) {}
+  }
+  // Restore on every show — re-clamped, because the viewport may have resized since it was stored.
+  function _scrubRestorePos() {
+    var raw = null;
+    try { raw = localStorage.getItem(SCRUB_POS_KEY); } catch (e) {}
+    if (!raw) return false;
+    var p; try { p = JSON.parse(raw); } catch (e) { return false; }
+    if (!p || !isFinite(p.left) || !isFinite(p.top)) return false;
+    _scrubApplyPos(p.left, p.top, 'restore');
+    return true;
+  }
+  function _scrubResetPos() {
+    try { localStorage.removeItem(SCRUB_POS_KEY); } catch (e) {}
+    var tmp = document.getElementById('time-machine-panel');
+    _scrubPanel.style.bottom = (tmp && tmp.style.display && tmp.style.display !== 'none') ? '260px' : '80px';
+    _scrubPanel.style.top = 'auto';
+    _scrubPanel.style.left = '50%';
+    _scrubPanel.style.transform = 'translateX(-50%)';
+    console.log('[TOUR] §SCRUB_PANEL_POS reset left=50% (bottom-centre default restored)');
+  }
+
+  function _scrubWireDrag() {
+    // Handle = the panel BACKGROUND only. The slider, the four knob groups and the clickable
+    // chapter ticks keep their exact shipped behaviour — a pointerdown on any of them is not a drag.
+    _scrubPanel.addEventListener('pointerdown', function(e) {
+      if (e.target.closest && e.target.closest('input,button,#tour-scrub-ticks')) return;
+      _scrubFreezePos();
+      var r = _scrubPanel.getBoundingClientRect();
+      _scrubDragPan = { dx: e.clientX - r.left, dy: e.clientY - r.top, id: e.pointerId,
+                        from: { left: r.left, top: r.top } };
+      try { _scrubPanel.setPointerCapture(e.pointerId); } catch (err) {}
+      e.preventDefault();
+    });
+    _scrubPanel.addEventListener('pointermove', function(e) {
+      if (!_scrubDragPan || e.pointerId !== _scrubDragPan.id) return;
+      _scrubApplyPos(e.clientX - _scrubDragPan.dx, e.clientY - _scrubDragPan.dy, null);
+      e.preventDefault();
+    });
+    var end = function(e) {
+      if (!_scrubDragPan || (e.pointerId !== undefined && e.pointerId !== _scrubDragPan.id)) return;
+      var f = _scrubDragPan.from;
+      _scrubDragPan = null;
+      try { _scrubPanel.releasePointerCapture(e.pointerId); } catch (err) {}
+      var r = _scrubPanel.getBoundingClientRect();
+      _scrubSavePos();
+      console.log('[TOUR] §SCRUB_PANEL_DRAG from=' + f.left.toFixed(1) + ',' + f.top.toFixed(1) +
+                  ' to=' + r.left.toFixed(1) + ',' + r.top.toFixed(1) +
+                  ' T=' + (A._tourT || 0).toFixed(4) + ' (timeline untouched)');
+    };
+    _scrubPanel.addEventListener('pointerup', end);
+    _scrubPanel.addEventListener('pointercancel', end);
+    // Double-click the background → back to the shipped bottom-centre default.
+    _scrubPanel.addEventListener('dblclick', function(e) {
+      if (e.target.closest && e.target.closest('input,button,#tour-scrub-ticks')) return;
+      _scrubResetPos();
+    });
   }
 
   A.tourTogglePause = function(force) {
@@ -1692,6 +1791,7 @@ function setupTour(A) {
     A.tourSetSpeed(A.tourScrubSpeed || 1);
     A.tourTogglePause(false);
     _scrubPanel.style.display = 'flex';
+    _scrubRestorePos();          // §SCRUB_PANEL_DRAG — survives tour stop/restart and reload
     _scrubSync(true);
     console.log('[TOUR] §SCRUB_UI show actions=' + A.walkActions.length + ' total=' + (A._tourTotal || 0).toFixed(2) + 's bar=linear-thumb dial=none');
   };

--- a/witness_tour_scrub.js
+++ b/witness_tour_scrub.js
@@ -18,6 +18,12 @@
 //   W-SCRUB-SPEED       — is the speed knob a dt multiplier, not a timeline rescale? PASS =
 //                         _tourTotal is unchanged by tourSetSpeed(0.5/1/2).
 //   W-SCRUB-UI          — all four knob groups present, linear bar, no rotary dial.
+//   W-SCRUB-PANEL-DRAG  — §SCRUB_PANEL_DRAG: is the panel movable WITHOUT becoming a second way to
+//                         scrub? PASS = the panel rect moves by the exact synthesized delta, clamps
+//                         inside the viewport when dragged off-screen, the position survives
+//                         hide→show, AND _tourT + camera pose are UNCHANGED by the drag (the
+//                         "nothing broken" assertion — moving the chrome must never write the
+//                         timeline). FAIL = any pose/cursor movement, or a lost/unclamped panel.
 //
 // Whitebox doctrine: every assertion below reads REAL numeric object state (camera position,
 // controls.target, _tourT, _tourStarts) out of the live page. No screenshots, no eyeballing.
@@ -278,6 +284,79 @@ function claim(name, pass, detail) {
       `barVisible=${ui.visible} linearRangeThumb=${ui.slider} chapterTicks=${ui.ticks} ` +
       `play/prev/next/restart=${ui.play}/${ui.prev}/${ui.next}/${ui.restart} speedBtns=${ui.speeds} ` +
       `mmss="${ui.time}" rotaryDials=${ui.dial}`);
+
+    // ── W-SCRUB-PANEL-DRAG ────────────────────────────────────────────────────
+    // §SCRUB_PANEL_DRAG. Synthesizes real PointerEvents on the panel BACKGROUND (not the slider,
+    // not a button) and reads back the rect + the timeline state. The pose/cursor invariant is the
+    // point of this witness: the panel is chrome, the timeline is data, and they must not touch.
+    const pan = await page.evaluate(async () => {
+      const A = window.APP;
+      const p = document.getElementById('tour-scrub-panel');
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const rect = () => { const r = p.getBoundingClientRect(); return { left: r.left, top: r.top }; };
+      const pose = () => [A.camera.position.x, A.camera.position.y, A.camera.position.z,
+                          A.controls.target.x, A.controls.target.y, A.controls.target.z];
+      // grab a point on the panel background: just inside the top edge, clear of the label row's
+      // controls (the header <span>s are not input/button so they drag — that is intended).
+      const send = (type, x, y) => p.dispatchEvent(new PointerEvent(type, {
+        pointerId: 7, clientX: x, clientY: y, bubbles: true, cancelable: true }));
+
+      A.tourSeek(A._tourTotal * 0.4, false);
+      A.tourTogglePause(true);                 // hold the pose so any drift is the drag's fault
+      await sleep(50);
+      const before = rect(), poseBefore = pose(), tBefore = A._tourT;
+
+      // 1. exact-delta move
+      const DX = -120, DY = -90;
+      send('pointerdown', before.left + 40, before.top + 6);
+      send('pointermove', before.left + 40 + DX, before.top + 6 + DY);
+      send('pointerup',   before.left + 40 + DX, before.top + 6 + DY);
+      await sleep(30);
+      const after = rect();
+      const dx = after.left - before.left, dy = after.top - before.top;
+      const exact = Math.abs(dx - DX) <= 1 && Math.abs(dy - DY) <= 1;
+
+      // 2. clamp — drag hard off the top-left; must park at the edge, never leave the viewport
+      send('pointerdown', after.left + 40, after.top + 6);
+      send('pointermove', -5000, -5000);
+      send('pointerup',   -5000, -5000);
+      await sleep(30);
+      const clampedRect = p.getBoundingClientRect();
+      const inView = clampedRect.left >= -0.5 && clampedRect.top >= -0.5 &&
+                     clampedRect.right <= window.innerWidth + 0.5 &&
+                     clampedRect.bottom <= window.innerHeight + 0.5;
+
+      // 3. persistence across hide → show
+      const parked = rect();
+      A._scrubHide(); await sleep(20); A._scrubShow(); await sleep(30);
+      const restored = rect();
+      const persisted = Math.abs(restored.left - parked.left) <= 1 &&
+                        Math.abs(restored.top - parked.top) <= 1;
+
+      // 4. THE invariant — the timeline never moved through any of it
+      const poseAfter = pose(), tAfter = A._tourT;
+      const poseDelta = Math.max(...poseAfter.map((v, i) => Math.abs(v - poseBefore[i])));
+      const cursorDelta = Math.abs(tAfter - tBefore);
+
+      // 5. the slider still seeks after the panel has been moved (no wiring casualty)
+      const sl = document.getElementById('tour-scrub-slider');
+      const tPre = A._tourT;
+      sl.value = String(Math.round(0.75 * 1000));
+      sl.dispatchEvent(new Event('input', { bubbles: true }));
+      await sleep(30);
+      const sliderStillSeeks = Math.abs(A._tourT - tPre) > 1;
+
+      A.tourTogglePause(false);
+      return { exact, dx, dy, inView, persisted, poseDelta, cursorDelta, sliderStillSeeks,
+               left: clampedRect.left, top: clampedRect.top };
+    });
+    claim('W-SCRUB-PANEL-DRAG',
+      pan.exact && pan.inView && pan.persisted && pan.poseDelta === 0 && pan.cursorDelta === 0 &&
+      pan.sliderStillSeeks,
+      `movedBy=${pan.dx.toFixed(1)},${pan.dy.toFixed(1)} exactDelta=${pan.exact} ` +
+      `clampedInView=${pan.inView} parkedAt=${pan.left.toFixed(1)},${pan.top.toFixed(1)} ` +
+      `persistedAcrossHideShow=${pan.persisted} | poseDelta=${pan.poseDelta} ` +
+      `cursorDelta=${pan.cursorDelta} sliderStillSeeks=${pan.sliderStillSeeks}`);
 
   } catch (e) {
     claim('WITNESS-RUN', false, 'threw: ' + e.message);


### PR DESCRIPTION
Implements `FLY_TOUR_CORRIDOR_GRAPH.md §SCRUB_PANEL_DRAG` (spec written before the code, per Spec-First).

## Why
The Hospital usage review (`§SCRUB_USAGE_HOSPITAL`) left §2 item 2 open: does the always-on scrub bar compete with the cinematic view during a presentation? A movable panel answers that **without** reopening the rejected hidden/reveal-icon design — the presenter parks it off whatever they're showing, and it stays put across beats and reloads.

## What
- **Handle = the panel background only.** A `pointerdown` whose target is `input`, `button` or `#tour-scrub-ticks` does not start a drag, so the timeline slider, the four knob groups and the clickable chapter ticks keep their exact shipped behaviour.
- **No jump on first grab** — the shipped `left:50%` + `translateX(-50%)` default is frozen into explicit `left/top` px measured from the current rect.
- **Clamped fully on-screen** — an off-viewport drag parks at the edge; the panel can never be lost.
- **Persisted** to `localStorage['bim.tourScrub.pos']`, restored (re-clamped) on every `_scrubShow`.
- **Double-click the background** resets to the bottom-centre default.
- **Pointer capture** so a fast drag leaving the panel keeps tracking.

## Witness
`W-SCRUB-PANEL-DRAG` added to `witness_tour_scrub.js`. The assertion that matters is the last pair — the panel is chrome, the timeline is data, and moving one must never write the other:

```
PASS W-SCRUB-PANEL-DRAG — movedBy=-120.0,-90.0 exactDelta=true clampedInView=true
  parkedAt=0.0,0.0 persistedAcrossHideShow=true
  | poseDelta=0 cursorDelta=0 sliderStillSeeks=true
```

Full suite on real LTU_AHouse, headless, real geometry: **10/10 ALL PASS** (was 9/9). No screenshots in the evidence chain.

## Not in this PR
An independent watchdog review of the already-merged #999 (recorded as `§WATCHDOG-TOUR-SCRUB-2`) found 7 pre-existing defects in the shipped scrubber, 3 medium — none introduced here, none fixed here. Filed separately rather than folded in, per `feedback_separation_of_concern.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)