### PR TITLE
fix(tour): §SCRUB_BAR_LIFECYCLE — scrub bar returns after a canvas interrupt

### DIFF
--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -8,11 +8,28 @@ function setupTour(A) {
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
 
+    // §SCRUB_BAR_LIFECYCLE (user 2026-07-25: "L should check if bar panel is present, be careful not
+    // to break discovery otherwise"). SAFETY NET, deliberately narrow: if a tour is RUNNING but its
+    // control is off-screen, L restores the control instead of pausing — the user pressing L with no
+    // bar visible is asking for the control back, not asking to stop. Never fires in the normal
+    // running case (bar visible → falls straight through to the pause branch below), so ordinary
+    // L-pause behaviour and free canvas discovery are untouched.
+    if (A.walkMode && A.walkActions && A.walkActions.length > 0 && A._scrubVisible && !A._scrubVisible()) {
+      if (A._scrubShow) A._scrubShow();
+      console.log('[TOUR] §SCRUB_BAR_REVEAL tour was running with the bar hidden — restored, playback untouched idx=' + A.walkActionIdx);
+      return;
+    }
+
     if (A.walkMode) {
       A.walkMode = false;
       A.walkLastTime = 0;
       A.flyActive = false;
       if (btn) btn.classList.remove('active');
+      // §SCRUB_BAR_LIFECYCLE (D3) — the bar STAYS VISIBLE on an ✈-pause (the presenter stopped here
+      // on purpose and may still want to scrub), but it must not LIE: previously it kept showing ⏸
+      // (= playing) while nothing played, and pressing its ▶ then set _tourPaused=true, which made a
+      // later ✈-resume early-return in walkTick forever. Mark the real state instead.
+      if (A._tourPaused === false && A.tourTogglePause) A.tourTogglePause(true);
       A.status.textContent = `Walk paused at action ${A.walkActionIdx}/${A.walkActions.length} — tap ✈ to resume`;
       A.wlog(`PAUSED at action ${A.walkActionIdx}`);
       return;
@@ -26,6 +43,14 @@ function setupTour(A) {
       if (btn) btn.classList.add('active');
       var _speedBtn = document.getElementById('walk-speed-btn');
       if (_speedBtn) _speedBtn.style.display = '';
+      // §SCRUB_BAR_LIFECYCLE (D1 — user-reported live 2026-07-25: "the scrubber panel cannot reappear
+      // when user interupts canvas and drag freely... Pressing L continues the tour but the panel
+      // remains hidden"). picking.js:108 hides the bar on a canvas tap but leaves walkActionIdx
+      // intact, so the next ✈ lands HERE — and this branch never called _scrubShow, the only caller
+      // being the fresh-tour path at :339. The bar therefore stayed hidden for the whole rest of the
+      // tour. _scrubShow also calls tourTogglePause(false), which is what stops a stale _tourPaused
+      // from freezing the resumed tour (D3). Witness: W-SCRUB-RESUME-BAR.
+      if (A._scrubShow) A._scrubShow();
       A.status.textContent = `Walk resumed at action ${A.walkActionIdx}/${A.walkActions.length}`;
       A.wlog(`RESUMED at action ${A.walkActionIdx}`);
       return;
@@ -1785,6 +1810,13 @@ function setupTour(A) {
     if (tv) tv.textContent = _fmtMS(T) + ' / ' + _fmtMS(total);
   }
 
+  // §SCRUB_BAR_LIFECYCLE — single source of truth for "is the bar on screen?". Reads the DOM by id
+  // rather than the module-local _scrubPanel so any caller (including toggleFlyAround above, and the
+  // witness) asks the same question the user is actually asking: can I see the control?
+  A._scrubVisible = function() {
+    var el = document.getElementById('tour-scrub-panel');
+    return !!el && el.style.display === 'flex';
+  };
   A._scrubShow = function() {
     _scrubBuild();
     _scrubBuildTicks();

--- a/witness_tour_scrub.js
+++ b/witness_tour_scrub.js
@@ -188,8 +188,17 @@ function claim(name, pass, detail) {
       return { drift: Math.max(...p0.map((v, i) => Math.abs(v - p1[i]))), frames,
                tDrift: Math.abs(A._tourT - T0), paused: A._tourPaused };
     });
-    claim('W-SCRUB-HOLD', hold.drift === 0 && hold.tDrift === 0,
-      `paused=${hold.paused} walkTickCalls=${hold.frames} maxPoseDrift=${hold.drift} cursorDrift=${hold.tDrift} over 3000ms wall-clock`);
+    // Float tolerance on the POSE only — NOT a weakened gate (2026-07-25). The cursor must still be
+    // EXACTLY 0: that is the scrubber's own state and nothing may touch it. The pose, however, goes
+    // through A.controls.update(), and scene.js:130 sets enableDamping=true, so OrbitControls
+    // round-trips position→spherical→position on every frame of the 3s rAF wait — provably not an
+    // identity (§WATCHDOG-TOUR-SCRUB-2 Q1.2). Measured: drift=0 on three runs, then 4.44e-16
+    // (= 2^-51, ONE double ULP) on a fourth that happened to build a different tour, i.e. a different
+    // pose at T*0.42. That is float rounding, not motion. 1e-9 m is a nanometre; any real drift is
+    // 7+ orders of magnitude above it, so this still fails loudly. Raw value stays in the message.
+    const HOLD_EPS = 1e-9;
+    claim('W-SCRUB-HOLD', hold.drift < HOLD_EPS && hold.tDrift === 0,
+      `paused=${hold.paused} walkTickCalls=${hold.frames} maxPoseDrift=${hold.drift} (eps=${HOLD_EPS}) cursorDrift=${hold.tDrift} over 3000ms wall-clock`);
 
     // ── W-SCRUB-DRAG-RELEASE ──────────────────────────────────────────────────
     // Proves a drag leaves NO residue: the pose at rest after dragging to T must equal the pose of
@@ -326,17 +335,21 @@ function claim(name, pass, detail) {
                      clampedRect.right <= window.innerWidth + 0.5 &&
                      clampedRect.bottom <= window.innerHeight + 0.5;
 
-      // 3. persistence across hide → show
+      // 3. THE invariant — read it HERE, across the drags ONLY. It must not span step 4's
+      // hide→show: _scrubShow() calls tourTogglePause(false), which revives the rAF chain, so any
+      // frames landing in that window advance the cursor legitimately and would make this claim
+      // flaky (observed: poseDelta=0.26 cursorDelta=0.116 on one run, 0/0 on the next). The claim is
+      // about the DRAG writing the timeline, so measure exactly the drag.
+      const poseAfter = pose(), tAfter = A._tourT;
+      const poseDelta = Math.max(...poseAfter.map((v, i) => Math.abs(v - poseBefore[i])));
+      const cursorDelta = Math.abs(tAfter - tBefore);
+
+      // 4. persistence across hide → show (after the invariant is banked, per the note above)
       const parked = rect();
       A._scrubHide(); await sleep(20); A._scrubShow(); await sleep(30);
       const restored = rect();
       const persisted = Math.abs(restored.left - parked.left) <= 1 &&
                         Math.abs(restored.top - parked.top) <= 1;
-
-      // 4. THE invariant — the timeline never moved through any of it
-      const poseAfter = pose(), tAfter = A._tourT;
-      const poseDelta = Math.max(...poseAfter.map((v, i) => Math.abs(v - poseBefore[i])));
-      const cursorDelta = Math.abs(tAfter - tBefore);
 
       // 5. the slider still seeks after the panel has been moved (no wiring casualty)
       const sl = document.getElementById('tour-scrub-slider');
@@ -357,6 +370,69 @@ function claim(name, pass, detail) {
       `clampedInView=${pan.inView} parkedAt=${pan.left.toFixed(1)},${pan.top.toFixed(1)} ` +
       `persistedAcrossHideShow=${pan.persisted} | poseDelta=${pan.poseDelta} ` +
       `cursorDelta=${pan.cursorDelta} sliderStillSeeks=${pan.sliderStillSeeks}`);
+
+    // ── W-SCRUB-RESUME-BAR ────────────────────────────────────────────────────
+    // §SCRUB_BAR_LIFECYCLE D1/D3, user-reported live. Drives the REAL user path — a genuine
+    // pointerdown on the canvas so picking.js's own tour-abort runs — not a direct _scrubHide()
+    // call, which would test the seam instead of the behaviour.
+    const life = await page.evaluate(async () => {
+      const A = window.APP;
+      const p = document.getElementById('tour-scrub-panel');
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const shown = () => p.style.display === 'flex';
+
+      A.tourSeek(A._tourTotal * 0.3, false);       // get walkActionIdx > 0 (resume branch needs it)
+      A.tourTogglePause(false);
+      A.walkTick();
+      await sleep(30);
+      const posBefore = (() => { const r = p.getBoundingClientRect(); return { l: r.left, t: r.top }; })();
+      const idxAtAbort = A.walkActionIdx, barBeforeAbort = shown();
+
+      // 1. REAL canvas tap → picking.js:102-108 aborts the tour and hides the bar
+      const c = A.canvas || A.renderer.domElement;
+      const cr = c.getBoundingClientRect();
+      c.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 3, bubbles: true, cancelable: true,
+        clientX: cr.left + cr.width / 2, clientY: cr.top + cr.height / 2 }));
+      await sleep(50);
+      const barAfterAbort = shown(), walkAfterAbort = A.walkMode;
+
+      // 2. the user's exact next action: press ✈ / L to continue
+      A.toggleFlyAround();
+      await sleep(50);
+      const barAfterResume = shown(), walkAfterResume = A.walkMode, pausedAfterResume = A._tourPaused;
+      const posAfter = (() => { const r = p.getBoundingClientRect(); return { l: r.left, t: r.top }; })();
+      const posKept = Math.abs(posAfter.l - posBefore.l) <= 1 && Math.abs(posAfter.t - posBefore.t) <= 1;
+
+      // 3. D3 half — an ✈-pause keeps the bar VISIBLE and marks it honestly paused
+      A.toggleFlyAround();
+      await sleep(30);
+      const barOnFlyPause = shown(), pausedOnFlyPause = A._tourPaused;
+      A.toggleFlyAround(); await sleep(30);        // back to running
+
+      // 4. §SCRUB_BAR_REVEAL guard — tour RUNNING but bar hidden: L must restore the control and
+      // NOT stop playback (the user's "don't break discovery" constraint, asserted not assumed).
+      const walkPre = A.walkMode, idxPre = A.walkActionIdx;
+      A._scrubHide();                              // simulate the bar being off-screen mid-tour
+      A.walkMode = true;                           // ...while the tour is genuinely still running
+      await sleep(20);
+      A.toggleFlyAround();
+      await sleep(30);
+      const revealBar = shown(), revealWalkStillOn = A.walkMode, revealIdx = A.walkActionIdx;
+
+      return { idxAtAbort, barBeforeAbort, barAfterAbort, walkAfterAbort, barAfterResume,
+               walkAfterResume, pausedAfterResume, posKept, barOnFlyPause, pausedOnFlyPause,
+               walkPre, idxPre, revealBar, revealWalkStillOn, revealIdx };
+    });
+    claim('W-SCRUB-RESUME-BAR',
+      life.idxAtAbort > 0 && life.barBeforeAbort && !life.barAfterAbort && !life.walkAfterAbort &&
+      life.barAfterResume && life.walkAfterResume && life.pausedAfterResume === false &&
+      life.posKept && life.barOnFlyPause && life.pausedOnFlyPause === true &&
+      life.revealBar && life.revealWalkStillOn,
+      `abortedAtIdx=${life.idxAtAbort} bar before/after canvasTap=${life.barBeforeAbort}/${life.barAfterAbort} ` +
+      `walkModeAfterTap=${life.walkAfterAbort} | AFTER ✈-RESUME bar=${life.barAfterResume} ` +
+      `walkMode=${life.walkAfterResume} paused=${life.pausedAfterResume} panelPosKept=${life.posKept} ` +
+      `| ✈-PAUSE bar=${life.barOnFlyPause} paused=${life.pausedOnFlyPause} ` +
+      `| REVEAL bar=${life.revealBar} walkModeStillRunning=${life.revealWalkStillOn} (discovery not broken)`);
 
   } catch (e) {
     claim('WITNESS-RUN', false, 'threw: ' + e.message);


### PR DESCRIPTION
Fixes a user-reported defect on the live GH Pages viewer, predicted as **D1** by the independent watchdog review and then reproduced in a real console log.

## The bug
> "the scrubber panel cannot reappear when user interupts canvas and drag freely at the spot it finds interesting. Pressing L continues the tour but the panel remains hidden."

```
§PICK hits=3 chosen=0 …            ← canvas tap → picking.js:108 _scrubHide()
§SHORTCUT_FIRE key=l
[WALK] RESUMED at action 6          ← no §SCRUB_UI show; bar gone for the rest of the run
[WALK] PAUSED at action 8 → RESUMED at action 8 → PAUSED
```

**Root cause:** the resume branch (`tour.js:21-32`) sets `walkMode=true` and returns without ever calling `A._scrubShow()` — whose only caller was the fresh-tour path at `:339`. The comment at `:83` already asserted "bar lives exactly as long as the tour"; the code never implemented it.

## The fix — the invariant, not a patch
The bar is visible whenever a tour is running or resumable, and its play button reflects the real `_tourPaused`.

- **Resume branch → `_scrubShow()`.** Also closes **D3**'s frozen-resume for free: `_scrubShow` calls `tourTogglePause(false)`, so a stale `_tourPaused` can no longer make `walkTick` early-return forever.
- **✈-pause branch → `tourTogglePause(true)`, bar stays visible.** It previously showed ⏸ (= playing) while nothing played, and pressing that button could freeze a later resume.
- **New `A._scrubVisible()` + a narrow `§SCRUB_BAR_REVEAL` guard.** Per the user: *"L should check if bar panel is present, be careful not to break discovery otherwise."* If a tour is RUNNING with its control off-screen, `L` restores the control instead of pausing. It never fires when the bar is visible, so ordinary `L`-pause and free canvas discovery are untouched.
- **`picking.js` unchanged** — a canvas tap is a deliberate camera grab; hiding the bar there is correct.

## Witness
`W-SCRUB-RESUME-BAR` drives the **real** user path — a genuine `pointerdown` on the canvas so picking.js's own abort runs — rather than calling `_scrubHide()` directly, which would test the seam instead of the behaviour.

```
PASS W-SCRUB-RESUME-BAR — abortedAtIdx=11 bar before/after canvasTap=true/false
  walkModeAfterTap=false | AFTER ✈-RESUME bar=true walkMode=true paused=false
  panelPosKept=true | ✈-PAUSE bar=true paused=true
  | REVEAL bar=true walkModeStillRunning=true (discovery not broken)
```

Suite on real LTU_AHouse: **11/11 ALL PASS** (was 10/10).

## Two harness defects fixed while verifying (neither in the product)
1. **`W-SCRUB-PANEL-DRAG` was flaky by construction** — it measured its pose/cursor invariant *across* a `_scrubHide()`→`_scrubShow()`, and `_scrubShow` unpauses and revives the rAF chain, so frames in that window advanced the cursor legitimately (`0/0` twice, `0.26/0.116` once). Now measured across the drag only, which is what the claim is about.
2. **`W-SCRUB-HOLD` asserted exact-zero pose drift** through `controls.update()`, which with `enableDamping=true` round-trips position→spherical→position and is not an identity. **Verified pre-existing by direct experiment:** every run that built an `833.341719s` tour passed with `drift=0` (three runs, two on the new code); the single failure was the one run that built an `828.358772s` tour — different pose, different float rounding, `4.44e-16` = one double ULP. Tolerance is now `1e-9` m on the **pose only**; `cursorDrift` must still be exactly 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)