### PR TITLE
fix(viewer): stop throttled sky env-map regen from clobbering a staged HDRI

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2542,6 +2542,11 @@ async function setupEffects(A, renderer, scene, camera) {
     // real HDRI if already loaded, or kick off the (one-time, cached) load if not yet ready —
     // _ensureHdriEnvMap applies it itself once resolved, per the mid-photoshoot check inside it.
     _photoEnvMapSaved = A._envMap;
+    // §ALT_FRAME_LUMINANCE: HDRI is now the authoritative envMap for the whole staged session —
+    // tell scene.js's updateSky() (called on the next line, and again every subsequent Alt+S/
+    // Alt+C frame while staging stays on) not to silently overwrite it with a procedural PMREM
+    // regen from its own 2s-throttled setTimeout — see that guard for the full race explanation.
+    A._envMapHdriActive = true;
     if (_hdriEnvMap) A._envMap = _hdriEnvMap; else _ensureHdriEnvMap();
     _photoSkyWasVisible = !!(A._sky && A._sky.visible);
     if (A.sun) {
@@ -2630,6 +2635,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // §LAYER2_HDRI: restore the procedural envMap — the real HDRI is still cached for next time,
     // only the active pointer reverts (normal navigation keeps its existing sky-derived look).
     if (_photoEnvMapSaved !== null) { A._envMap = _photoEnvMapSaved; _photoEnvMapSaved = null; }
+    A._envMapHdriActive = false;  // §ALT_FRAME_LUMINANCE: scene.js's throttled regen is safe again
     if (!_photoNightWasOn && A.toggleNightMode) A.toggleNightMode();  // restores its own saved state
     if (!_photoSkyWasVisible && A._sky) A._sky.visible = false;
     if (A.sun && _photoSunPosSaved) {

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -243,8 +243,20 @@ async function setupScene(A) {
       A._envMapThrottle = true;
       setTimeout(function() {
         try {
-          var envRT = _pmrem.fromScene(_sky);
-          A._envMap = envRT.texture;
+          // §ALT_FRAME_LUMINANCE (2026-07-25): while a photoshoot/MaxQ bake has swapped A._envMap
+          // to the real photographed HDRI (effects.js _applyPhotoStaging, A._envMapHdriActive),
+          // this throttled callback must NOT stomp it back to the procedural sky-only PMREM — it
+          // fires up to 2000ms after the updateSky() call that scheduled it, which lands mid-frame
+          // on any capture loop (Alt+S/Alt+C) whose own cadence is close to that same 2000ms window,
+          // silently swapping every material's reflection source frame-to-frame and reading as an
+          // alternating bright/dark movie. Every OTHER updateSky() caller (plain nav, Time Machine)
+          // is unaffected — this flag is only ever true during a staged photoshoot.
+          if (!A._envMapHdriActive) {
+            var envRT = _pmrem.fromScene(_sky);
+            A._envMap = envRT.texture;
+          } else {
+            console.log('§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active');
+          }
         } catch(e) {}
         A._envMapThrottle = false;
       }, 2000);

--- a/witness_envmap_stomp.js
+++ b/witness_envmap_stomp.js
@@ -1,0 +1,81 @@
+// WITNESS — §ENVMAP_STOMP_GUARD (2026-07-25)
+// ISSUE IT PROVES/DISPROVES: does scene.js's updateSky() 2000ms-throttled procedural PMREM regen
+// silently overwrite the photoshoot's real HDRI envMap (A._envMap) during repeated Alt+S cycles,
+// and does A._envMapHdriActive stop it? Drives A.startStillRefine()/stopStillRefine() directly
+// (the actual shared mechanism Alt+S AND Alt+C/MaxQ both go through — effects.js
+// _applyPhotoStaging/_teardownPhotoStaging) with real per-cycle timing close to the ~2000ms
+// window, and reads back A._envMap's IDENTITY (not appearance) plus real mean pixel luminance
+// from a small canvas snapshot after each cycle — direct numeric proof, not inference from logs.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8404;
+const BLD = process.env.BLD || 'HHS_Office_Federated';
+const NCYCLES = parseInt(process.env.NCYCLES || '10', 10);
+const CYCLE_MS = parseInt(process.env.CYCLE_MS || '1900', 10);  // close to the 2000ms throttle window, matching real per-frame cadence
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    protocolTimeout: 300000,
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 640, height: 360 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  console.log(`\n${'='.repeat(78)}\n§ENVMAP_STOMP_GUARD witness — ${BLD}, ${NCYCLES} Alt+S cycles @ ~${CYCLE_MS}ms\n${'='.repeat(78)}`);
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls &&
+    typeof window.APP.startStillRefine === 'function' && window.APP._composer, { timeout: 90000 });
+  await page.waitForFunction(() => !window.APP.streaming || (window.APP.streamIdx >= (window.APP.streamQueue||[]).length),
+    { timeout: 120000, polling: 1000 }).catch(() => {});
+  console.log('--- ready ---');
+
+  const results = [];
+  for (let n = 0; n < NCYCLES; n++) {
+    await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); window.APP.startStillRefine(); });
+    await page.waitForFunction(() => window.APP._stillRefineBusy === false, { timeout: 30000, polling: 100 }).catch(() => {});
+    const r = await page.evaluate(() => {
+      try {
+        window.APP._composer.render();
+        var SZ = 32;
+        var c = document.createElement('canvas');
+        c.width = SZ; c.height = SZ;
+        var ctx = c.getContext('2d');
+        ctx.drawImage(window.APP.renderer.domElement, 0, 0, SZ, SZ);
+        var data = ctx.getImageData(0, 0, SZ, SZ).data;
+        var sum = 0, count = data.length / 4;
+        for (var p = 0; p < data.length; p += 4) sum += 0.299 * data[p] + 0.587 * data[p + 1] + 0.114 * data[p + 2];
+        return { meanLuma: sum / count, envMapHdriActive: !!window.APP._envMapHdriActive, envMapThrottle: !!window.APP._envMapThrottle };
+      } catch (e) { return { error: String(e && e.message || e) }; }
+    });
+    results.push(r);
+    console.log('cycle ' + n + ': ' + (r.error ? ('ERROR ' + r.error) : ('meanLuma=' + r.meanLuma.toFixed(2) + ' envMapHdriActive=' + r.envMapHdriActive)));
+    await new Promise(res => setTimeout(res, CYCLE_MS));
+  }
+  await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); });
+
+  console.log('\n--- §ENVMAP_STOMP_GUARD log lines seen ---');
+  logs.filter(l => l.includes('ENVMAP_STOMP_GUARD') || l.includes('LAYER2_HDRI')).forEach(l => console.log(l));
+
+  const ok = results.filter(r => !r.error);
+  var deltas = [];
+  for (var i = 1; i < ok.length; i++) deltas.push(ok[i].meanLuma - ok[i - 1].meanLuma);
+  var signFlips = 0;
+  for (var i = 1; i < deltas.length; i++) if ((deltas[i] > 0) !== (deltas[i - 1] > 0)) signFlips++;
+  var meanAbsDelta = deltas.length ? deltas.reduce((a, b) => a + Math.abs(b), 0) / deltas.length : 0;
+  console.log('\n--- deltas ---');
+  deltas.forEach((d, i) => console.log('delta[' + i + '->' + (i + 1) + ']=' + d.toFixed(2)));
+  console.log('\n§WITNESS cycles=' + ok.length + ' signFlips=' + signFlips + '/' + (deltas.length - 1) + ' meanAbsDelta=' + meanAbsDelta.toFixed(2));
+
+  const pageErrors = logs.filter(l => l.startsWith('PAGEERROR'));
+  console.log('§WITNESS pageErrors=' + pageErrors.length);
+  const alternating = deltas.length >= 3 && signFlips >= (deltas.length - 1) * 0.6 && meanAbsDelta > 1.5;
+  console.log('\n' + (alternating
+    ? 'STILL ALTERNATING — signFlips=' + signFlips + '/' + (deltas.length - 1) + ' meanAbsDelta=' + meanAbsDelta.toFixed(2) + '. Fix did NOT eliminate it.'
+    : 'STABLE — no alternating-sign pattern (signFlips=' + signFlips + '/' + (deltas.length - 1) + ', meanAbsDelta=' + meanAbsDelta.toFixed(2) + ').'));
+
+  await browser.close();
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- User-reported Alt+C movie flicker persisted after #1004. That was a real, separate fix (shadow skip-gate race) — confirmed NOT the cause of this symptom, since the live #1004 log showed a rock-stable shadow-caster count the whole capture (no streaming churn). User narrowed the symptom: "consistently alternating" bright/dark, "the way alt-s gets processed."
- Root cause: `scene.js`'s `updateSky()` has a 2000ms leading-throttle around its procedural sky-reflection PMREM regen. `effects.js`'s `_applyPhotoStaging()` (shared by Alt+S and Alt+C/MaxQ, called once per still-refine cycle) swaps `A._envMap` to the real photographed HDRI, then calls `updateSky()` on the next line — arming that same 2s timer. Since MaxQ's own per-frame cadence sits close to 2000ms too, the delayed procedural regen frequently lands mid-capture on a *later* frame, silently swapping every material's reflection source back from HDRI to a flatter procedural texture — a periodic, cadence-driven clobber.
- Fix: `A._envMapHdriActive` flag, set on staging apply, cleared on teardown; the throttled callback in `scene.js` skips the procedural regen while it's true. Added `§ENVMAP_STOMP_GUARD` log line so the guard's effect is directly observable.

## Evidence
Witnessed live (headless, `HHS_Office_Federated`, `witness_envmap_stomp.js`) — drove 10 real Alt+S cycles at ~1900ms cadence and measured real per-cycle canvas luminance (32x32 downsample, BT.601 luma), not log inference:
- `§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active` fired on **10/10 cycles** — direct proof the race fires virtually every cycle at this cadence.
- With it blocked: luminance flat/stable cycle-to-cycle (one one-time settling step, then dead-flat 24.27–24.44 for 6 consecutive cycles) — no alternating-sign pattern.
- `pageErrors=0`.

Diagnosed + fixed in the same session as #1004, per `bim-compiler` `prompts/PHOTOREAL_STILL_RENDER.md`.

## Test plan
- [x] `node --check viewer/effects.js viewer/scene.js`
- [x] Headless witness (10x Alt+S cycles, real pixel luminance) — guard fires every cycle, luminance stabilizes
- [ ] Real-GPU live trial of an actual Alt+C clip (not done this session, per this project's math/log-over-screenshot discipline — flagged open, not silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)