### PR TITLE
fix(viewer): §ROOM_PATH — split the misnamed rooms=[] into stops=[] and via=[]

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1352,7 +1352,15 @@
         _clearPathHighlight();
         return null;
       }
-      var roomNames = result.path.map(function(g) { return graph.nodesByGuid[g].name; });
+      // §STOPS-VS-VIA: `rooms=[...]` used to list EVERY path anchor under a field named "rooms", which
+      // is how the field came to read "12 rooms" for a 4-room route (the rest were corridor spine, door
+      // and stair waypoints). Split it: `stops=` is the real room/exit sequence, `via=` is the way
+      // between them. Same data, no extra query, and each field now means what it says.
+      var stopNames = [], viaNames = [];
+      result.path.forEach(function(g) {
+        var n = graph.nodesByGuid[g] || {};
+        if (n.kind === 'room' || n.kind === 'exit') stopNames.push(n.name); else viaNames.push(n.name);
+      });
       var doorGuids = result.doors.map(function(d) { return d.guid; });
       // §ROOM_PATH_PRECISION (2026-07-25, §14's summary-first rule applied to this line): the old
       // form printed `hops=<doors.length> rooms=[<every path node's name>]`, which read as "12 rooms,
@@ -1371,7 +1379,7 @@
         ' hops=' + result.doors.length + ' portals=' + Object.keys(distinctDoors).length +
         ' anchors={' + Object.keys(counts).map(function(k) { return k + ':' + counts[k]; }).join(' ') + '}' +
         ' polyPts=' + ((result.polyline || []).length) +
-        ' rooms=[' + roomNames.join(',') + ']' +
+        ' stops=[' + stopNames.join(',') + '] via=[' + viaNames.join(',') + ']' +
         ' doors=[' + doorGuids.join(',') + '] distance=' + result.distance.toFixed(2) + 'm' +
         (repeated.length ? ' repeatedPortals=[' + repeated.map(function(g) { return g + 'x' + distinctDoors[g]; }).join(',') + ']' : ''));
       _drawPathHighlight(graph, result);

--- a/witness_room_path_ui.js
+++ b/witness_room_path_ui.js
@@ -138,7 +138,7 @@ const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  '
   const pathLogLine = logs.filter(l => l.indexOf('§ROOM_PATH from=') >= 0).slice(-1)[0] || '';
   console.log('  ' + pathLogLine);
   chk('§ROOM_PATH log line carries the route AND the §ROOM_PATH_PRECISION fields (portals/anchors/polyPts)',
-    /§ROOM_PATH from=.+ to=.+ hops=\d+ portals=\d+ anchors=\{[^}]*\} polyPts=\d+ rooms=\[.*\] doors=\[.*\]/.test(pathLogLine),
+    /§ROOM_PATH from=.+ to=.+ hops=\d+ portals=\d+ anchors=\{[^}]*\} polyPts=\d+ stops=\[.*\] via=\[.*\] doors=\[.*\]/.test(pathLogLine),
     pathLogLine || 'not found');
 
   const treeText = await pg.evaluate(() => { const t = document.getElementById('find-tree'); return t ? t.textContent : ''; });


### PR DESCRIPTION
Follow-up to #1006 (`VIEWER_FIND_PANEL_ROOM_ACCURACY.md` §17). This commit was on the #1006 branch but was **orphaned by the squash-merge** (pushed just before auto-merge fired), so it is re-landed off fresh `origin/main` per `CLAUDE.md` §Concurrent branches.

`rooms=[...]` in `§ROOM_PATH` listed EVERY path anchor, which is how the field came to read "12 rooms" for a 4-room route — the other 8 were corridor-spine, door and stair waypoints. That is the same conflation that made the Find panel render a door as numbered stop 4 (fixed in #1006 by `§PATH_PANEL_KINDS`); this fixes it in the log too. `stops=` is the real room/exit sequence, `via=` is the way between them.

Live-verified in the real browser, `witness_room_path_ui.js` **13/13**:

```
§ROOM_PATH from=≈ Level 1 R1 to=≈ Level 1 R2 hops=2 portals=2 anchors={room:2 doorwp:2} polyPts=4
  stops=[≈ Level 1 R1,≈ Level 1 R2] via=[M_Single-Flush:...146596,M_Single-Flush:...146678]
  doors=[1hOSvn6df7F8_7GcBWlRGQ,1hOSvn6df7F8_7GcBWlRH8] distance=17.14m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNJzNLy8mdRkpEp1h1Kx6b