### PR TITLE
fix(sw): serve buildings/patches/*.sql network-first — an updated DB patch could never reach a client

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v847';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v848';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -284,6 +284,20 @@ function isNetworkFirst(url) {
   // Precached local files — cache-first (CACHE_VERSION bump purges + refreshes)
   var filename = base.split('/').pop();
   if (_PRECACHE_SET.has(filename)) return false;
+  // §SQL-PATCH-NETWORK-FIRST (2026-07-25, measured on a real user session —
+  // VIEWER_FIND_PANEL_ROOM_ACCURACY.md §17): `buildings/patches/*.sql` used to fall through to
+  // cacheFirst, because only .html/.js were network-first and .sql matched nothing. That silently
+  // breaks THE PROJECT'S OWN DB-CHANGE DOCTRINE (CLAUDE.md §DB CHANGES): every DB fix ships as a
+  // small .sql applied at load by A._applyPendingPatch(), so an UPDATED patch could never reach an
+  // already-installed client — the SW kept serving the first body it ever cached. Proven live: the
+  // regenerated Hospital walkable raster went to OCI at 07:45:18Z, and a session SIX HOURS later
+  // (rooms_meta.built_at 13:37:44Z) still compiled against the OLD raster — its saved db carries the
+  // pre-fix Level 1 signature (x0=-0.0147 cols=304 rows=332 instead of x0=-12.5998 cols=403 rows=372)
+  // and its console reproduced all three pre-fix §PATH_LEGAL_DETOUR_FAIL legs exactly
+  // (34.2m/96, 39.5m/135, 10.1m/34). With the live patch applied to that same saved db: zero
+  // DETOUR_FAIL. networkFirst (not no-cache) keeps the offline PWA path intact — it falls back to the
+  // cached body when the network is gone, which is what §38-offline-pwa needs.
+  if (base.endsWith('.sql')) return true;
   // Unknown JS/HTML not in precache list — network-first (safe default)
   if (base.endsWith('.html') || base.endsWith('.js')) return true;
   return false;

--- a/witness_sw_sql_patch_route.js
+++ b/witness_sw_sql_patch_route.js
@@ -1,0 +1,25 @@
+// W-SW-SQL-ROUTE: does the SW route a .sql patch network-first (fresh on deploy) while keeping the
+// offline fallback? Exercises the real isNetworkFirst() from viewer/sw.js — no browser needed, the
+// function is pure string routing. Names the issue it proves: an UPDATED buildings/patches/*.sql must
+// reach an already-installed client (cacheFirst never could).
+const fs = require('fs');
+const src = fs.readFileSync((process.argv[2] || __dirname) + '/viewer/sw.js', 'utf8');
+// isNetworkFirst + its two dependencies are self-contained; evaluate them in a tiny sandbox.
+const body = src.slice(src.indexOf('function isNetworkFirst'), src.indexOf('self.addEventListener(\'fetch\''));
+const pre = src.match(/const PRECACHE_ASSETS = \[[\s\S]*?\];/)[0];
+const cdn = src.match(/const CDN_ASSETS = \[[\s\S]*?\];/)[0];
+const setLine = src.match(/const _PRECACHE_SET = [^;]+;/)[0];
+const fn = new Function(pre + '\n' + cdn + '\n' + setLine + '\n' + body + '\nreturn isNetworkFirst;')();
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const B = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/';
+chk('A1 a DB patch script is network-first (an updated raster patch reaches installed clients)',
+  fn(B + 'buildings/patches/Hospital_meta.db.sql') === true);
+chk('A2 the _extracted twin too', fn(B + 'buildings/patches/Hospital_extracted.db.sql') === true);
+chk('A3 a local-served patch path too', fn('http://localhost:8901/buildings/patches/Terminal_meta.db.sql') === true);
+chk('B1 .wasm stays cache-first (immutable, no regression)', fn(B + 'viewer/lib/sql-wasm.wasm') === false);
+chk('B2 lib/ stays cache-first', fn(B + 'viewer/lib/three.min.js') === false);
+chk('B3 CDN asset stays cache-first', fn('https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js') === false);
+chk('C1 .js still network-first', fn(B + 'viewer/navigate_find.js') === true);
+console.log('\n§W-SW-SQL-ROUTE DONE pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Found by a real user session on top of #1006, not theorised. Detail: `VIEWER_FIND_PANEL_ROOM_ACCURACY.md` §17.

The SW routed only `.html`/`.js` network-first; everything else — **including `buildings/patches/*.sql`** — fell through to `cacheFirst`. That silently breaks this project's own DB-change doctrine (`CLAUDE.md` §DB CHANGES): every DB fix ships as a small `.sql` applied at load by `A._applyPendingPatch()`, so an **updated** patch always lost to the first body the SW ever cached.

**Evidence (measured, on the user's own save):** the regenerated Hospital walkable raster went to OCI at **07:45:18Z**; a session **six hours later** (`rooms_meta.built_at` 13:37:44Z) still compiled against the OLD raster — its saved db carries the pre-fix Level 1 signature (`x0=-0.0147 cols=304 rows=332`, not `x0=-12.5998 cols=403 rows=372`) and its console reproduced all three pre-fix legs exactly:

```
§PATH_LEGAL_DETOUR_FAIL storey=Level 1 cause=WALKABLE_ISLANDS len=34.2m illegal=96 candidates=128
§PATH_LEGAL_DETOUR_FAIL storey=Level 4 cause=WALKABLE_ISLANDS len=39.5m illegal=135 candidates=97
§PATH_LEGAL_DETOUR_FAIL storey=Level 4 cause=WALKABLE_ISLANDS len=10.1m illegal=34  candidates=97
```

Applying the **live** patch to that same saved db: **zero DETOUR_FAIL**, `legalized=9 detoured=3`. The engine fix was fine; the delivery was not. (Note the `cause=WALKABLE_ISLANDS` in that log is itself #1006 working — pre-#1006 those endpoints were `ENDPOINT_OFF_FLOOR`.)

**Fix:** `.sql` → network-first, plus `CACHE_VERSION` v847→v848 so already-installed clients purge the stale cached patch on activate. `networkFirst` (not `no-store`) preserves the offline PWA path — it falls back to the cached body when the network is gone.

**Witness:** `witness_sw_sql_patch_route.js` (W-SW-SQL-ROUTE) exercises the real `isNetworkFirst()`: **7/7 here, 4/7 against `origin/main`** — A1/A2/A3 fail there, which is exactly the gap. B1/B2/B3 confirm `.wasm`/`lib/`/CDN stay cache-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNJzNLy8mdRkpEp1h1Kx6b