### PR TITLE
fix(graph): §G1-EXIT-IS-A-LIFT-DOOR step 1 — an `exit` node was a lift door; stop creating it

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -753,29 +753,24 @@
     if (circBridges) log('§CIRC_SPINE_BRIDGE bridged=' + circBridges);
 
 
-    // ── E4: escape — the existing nonRoomDoors detection becomes an N-EXIT node (free fire-escape
-    // target); connect the nearest room-or-circ node on that storey (real distance, not invented).
-    var exits = 0, e4 = 0;
-    doorRows.forEach(function (d) {
-      var guid = d[0], name = d[1] || '', storey = d[2] || '', dx = d[3], dy = d[4], dz = d[5];
-      if (isRoomDoor(name)) return; // only the name-filtered set — see file header
-      var exitGuid = 'EXIT::' + guid;
-      nodes[exitGuid] = { guid: exitGuid, kind: 'exit', name: 'Exit — ' + (name || guid), storey: storey,
-        cx: dx, cy: dy, cz: dz };
-      order.push(exitGuid); exits++;
-      var best = null, bestD = Infinity;
-      order.forEach(function (lg) {
-        var g = nodes[lg];
-        if (g.guid === exitGuid || g.storey !== storey) return;
-        if (g.kind !== 'room' && g.kind !== 'circ') return;
-        var dd = Math.hypot(g.cx - dx, g.cy - dy);
-        if (dd < bestD) { bestD = dd; best = lg; }
-      });
-      if (best) {
-        edges.push({ a: best, b: exitGuid, doorGuid: guid, doorName: name, storey: storey, kind: 'E4', w: bestD });
-        e4++;
-      }
-    });
+    // ── E4: REMOVED 2026-07-26 — §G1-EXIT-IS-A-LIFT-DOOR (OCCUPANT_PATHFINDER.md, work order step 1).
+    // E4 used to turn every door that FAILED `isRoomDoor()` into an `EXIT::` node "free fire-escape
+    // target". But `isRoomDoor()` is a LIFT-NAME test (`NON_ROOM_DOOR_NAMES` = liftdeur/lift/elevator/
+    // aufzug/fahrstuhl/hoist, ported from compile_rooms.py for the ROOM test, above at §DOOR-NOT-ROOM).
+    // Nothing in it — or anywhere else in this codebase — ever tested whether a door faces OUTSIDE.
+    // Measured over the fleet's 1633 ARC doors: the ONLY building that produced exits was Terminal,
+    // with 5 — and all five are elevator doors ("Side_opening_ElevatorLift_Door_with_Call_buttons…").
+    // That shipped two live wrong answers: the Fly Tour's `entrance` (= lowest exit node) was a LIFT
+    // DOOR on Terminal — the source of its 2 residual wall-illegal chords, logged
+    // `§PATH_LEGAL_DETOUR_FAIL cause=ENDPOINT_OFF_FLOOR` because a lift car is not walkable floor —
+    // and `escapeRoute()`, once wired, would have routed EGRESS TO A LIFT.
+    // So `exits` is now 0 fleet-wide. That is the HONEST state, not a regression: 6 of the 7 measured
+    // buildings already had 0, so every consumer's no-exit path (tour.js §HL-ORIGIN, scene.js
+    // _graphEntrance→'none', effects.js §CINEMA_EXIT→`exitSrc=db-doors`) is already the common path.
+    // A real exit node returns when the MEASURED exterior test lands (work order step 2: sample either
+    // side of a door against the storey walkable raster + footprint — proven feasible, HHS yields 3
+    // candidates of 133 doors). Do NOT restore a name-based or synthesised exit: see that doc.
+    var exits = 0;   // kept so the §ROOM_GRAPH log line and stats.exits keep their shape (now always 0)
 
     var circCount = order.filter(function (lg) { return nodes[lg].kind === 'circ'; }).length;
     log('§ROOM_GRAPH nodes=' + roomOrder.length + ' doors=' + doorRows.length + ' nonRoomDoors=' + nonRoomDoors +

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -160,7 +160,7 @@ async function initViewer() {
         // (x8, never removes) any edge touching one so room→room routing prefers corridors.
         // v7 (same doc §10, 2026-07-22): pass ignoreDoorExemption:true so real door-carrying service
         // rooms are tagged too (the door-exempt display default missed them); exclude CORRIDOR_ROOM nodes.
-        '../common/room_graph.js?v=11',
+        '../common/room_graph.js?v=12',
         // §HALLWAY-BACKBONE-NOT-LOADED (2026-07-14, real bug found via live browser check — every
         // corridor/spine/Hall-Corridor-label feature built this session had been silently no-oping
         // in the browser, despite passing every Node-based witness, because this line never

--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -3,7 +3,7 @@
 // tour.js — Fly around, cinematic tour, walk-through engine, path building
 function setupTour(A) {
   // FLY_TOUR_CORRIDOR_GRAPH.md — build banner: proves which tour build a tab is running.
-  console.log('[TOUR] §TOUR_VERSION v18 (timeline-scrub + highlight-first + SUSPECT_OPEN + wall-legal room-spine bridge + A* polyline flight — FLY_TOUR_CORRIDOR_GRAPH.md)');
+  console.log('[TOUR] §TOUR_VERSION v19 (timeline-scrub + highlight-first + SUSPECT_OPEN + wall-legal room-spine bridge + A* polyline flight + no lift-door entrance — FLY_TOUR_CORRIDOR_GRAPH.md)');
 
   A.toggleFlyAround = function() {
     const btn = document.getElementById('fly-btn');  // §S280: may be null (pill removed button)
@@ -176,7 +176,7 @@ function setupTour(A) {
   // (§TOUR_CACHE store … key=…:v12:…). The key's other components are DB counts — they bust on a
   // re-extraction or room recompile, never on a code change. This constant is the ONLY thing that
   // invalidates a cached route when the routing ALGORITHM changes.
-  var TOUR_CACHE_VER = 'v17'; // keep in lockstep with the §TOUR_VERSION banner above
+  var TOUR_CACHE_VER = 'v18'; // keep in lockstep with the §TOUR_VERSION banner above
   function _tourCacheKey() {
     try {
       var r = A.db.exec(

--- a/witness_exit_not_a_lift.js
+++ b/witness_exit_not_a_lift.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-EXIT-NOT-A-LIFT scope (READ THE LOG after every run)
+ * SCOPE: bim-compiler OCCUPANT_PATHFINDER.md §G1-EXIT-IS-A-LIFT-DOOR, work-order step 1 —
+ * `common/room_graph.js` E4 turned every door FAILING `isRoomDoor()` into an `EXIT::` node, but that
+ * predicate is a LIFT-NAME test (`NON_ROOM_DOOR_NAMES`), not an exterior test. Terminal's 5 "exits"
+ * were 5 elevator doors, which made the Fly Tour's `entrance` a lift door and would have made
+ * `escapeRoute()` route egress INTO A LIFT.
+ *
+ * ISSUE IT PROVES/DISPROVES — one wrong answer removed, nothing else moved:
+ *   (G1) NO node of kind 'exit' survives on any building, and specifically none sourced from a
+ *        lift-named door. BEFORE (origin/main) must show Terminal's 5 to prove the fixture is real —
+ *        a witness that passes because the bug was never there proves nothing.
+ *   (G2) The ROUTING graph is otherwise byte-identical: room/circ/stairwp/spine/doorwp node counts,
+ *        non-E4 edge counts, and room→room PATHABILITY (the metric G2/#1006 moved) all unchanged.
+ *   (G3) Terminal's Fly Tour improves and nothing else changes: its 2 residual wall-illegal chords
+ *        (the legs to/from the lift-door "entrance", cause=ENDPOINT_OFF_FLOOR) go to ZERO, and every
+ *        building's visited-stop count is unchanged.
+ *   (G4) Every consumer's no-exit path is ALREADY the common path — asserted by counting how many
+ *        buildings had 0 exits BEFORE the change (6 of 7). This is what makes the change low-risk.
+ *
+ * RUN: node witness_exit_not_a_lift.js   (needs buildings/*.db present)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { execSync } = require('child_process');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+
+const RG = require('./common/room_graph.js');
+// BEFORE = origin/main's shipped module, loaded from git (must live in common/ so its own relative
+// requires resolve). Same pattern as witness_room_path_raster_polyline.js.
+const beforePath = path.join(__dirname, 'common', '_room_graph_before_' + process.pid + '.js');
+fs.writeFileSync(beforePath, execSync('git show origin/main:common/room_graph.js', { cwd: __dirname }).toString());
+const RGbefore = require(beforePath);
+process.on('exit', () => { try { fs.unlinkSync(beforePath); } catch (e) {} });
+const BEFORE_TOUR = execSync('git show origin/main:viewer/tour.js', { cwd: __dirname }).toString();
+const AFTER_TOUR = fs.readFileSync(path.join(__dirname, 'viewer', 'tour.js'), 'utf8');
+
+const BLD = '/home/red1/bim-ootb/buildings';
+const LIFT_NAMES = ['liftdeur', 'lift', 'elevator', 'aufzug', 'fahrstuhl', 'hoist'];
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+const CASES = [
+  ['Terminal', 'Terminal_extracted.db', ['buildings/patches/Terminal_extracted.db.sql']],   // the ONLY building with exits — the fixture
+  ['Hospital', 'Hospital_extracted.db', ['buildings/patches/Hospital_extracted.db.sql']],
+  ['Clinic', 'Clinic_extracted.db', []],
+  ['HHS', 'HHS_Office_Federated_extracted.db', ['buildings/patches/HHS_Office_Federated_extracted.db.sql']],
+  ['LTU_AHouse', 'LTU_AHouse_extracted.db', []],
+  ['JKR', 'JKR_extracted.db', ['buildings/patches/JKR_extracted.db.sql']],
+  ['Duplex', 'Duplex_extracted.db', []],
+];
+
+function load(dbFile, patches) {
+  const tmp = '/tmp/_wexit_' + Math.random().toString(36).slice(2) + '.db';
+  fs.copyFileSync(path.join(BLD, dbFile), tmp);
+  const db = new Database(tmp);
+  (patches || []).forEach(p => { const f = path.join(__dirname, p); if (fs.existsSync(f)) db.exec(fs.readFileSync(f, 'utf8')); });
+  return { db, tmp, dbQuery: q => db.prepare(q).raw(true).all() };
+}
+function kindCounts(g) {
+  const c = {};
+  for (const k in g.nodesByGuid) { const n = g.nodesByGuid[k]; c[n.kind] = (c[n.kind] || 0) + 1; }
+  return c;
+}
+// room→room pathability over a fixed sample — the metric #1006 moved; it must NOT move here.
+function pathability(MOD, g, cap) {
+  const rooms = g.nodes.filter(n => n.kind === 'room');
+  let tried = 0, ok = 0;
+  for (let i = 0; i < rooms.length && tried < cap; i++) {
+    const a = rooms[i], b = rooms[(i * 7 + 3) % rooms.length];
+    if (a.guid === b.guid) continue;
+    tried++;
+    const sp = MOD.shortestPath(g, a.guid, b.guid);
+    if (sp && sp.path && sp.path.length > 1) ok++;
+  }
+  return { tried, ok };
+}
+// Run a tour.js build against an already-built graph (same harness as W-TOUR-POLYLINE-PATH).
+function runTour(src, g, dbQuery) {
+  const logs = [];
+  const A = {
+    modelOffset: { x: 0, y: 0, z: 0 }, WALK_EYE_HEIGHT: 1.6,
+    ifc2three: (ix, iy, iz) => ({ x: ix, y: iz, z: -iy }),
+    wlog: () => {}, getRoomGraph: () => g, dbQuery: dbQuery,
+    db: { exec: sql => { const r = dbQuery(sql); return r.length ? [{ values: r }] : []; } },
+  };
+  const ctx = {
+    console: { log: (...a) => logs.push(a.join(' ')), warn: (...a) => logs.push('WARN ' + a.join(' ')), error: (...a) => logs.push('ERR ' + a.join(' ')) },
+    window: { RoomGraph: null }, document: { getElementById: () => null },
+    performance: { now: () => Date.now() }, setTimeout: () => 0, clearTimeout: () => {}, requestAnimationFrame: () => 0,
+  };
+  return { A, ctx, logs, src };
+}
+function tourRoute(src, RGmod, g, dbQuery) {
+  const h = runTour(src, g, dbQuery);
+  h.ctx.window.RoomGraph = RGmod;
+  vm.createContext(h.ctx);
+  vm.runInContext(h.src, h.ctx, { filename: 'tour.js' });
+  h.ctx.setupTour(h.A);
+  const storeyZ = h.A._tourStoreyZ();
+  const route = h.A._buildGraphRoute(storeyZ);
+  return { route, logs: h.logs, storeyZ };
+}
+// independent illegal-chord measure over the flown points (same method as W-TOUR-POLYLINE-PATH)
+function chords(RGmod, g, route, storeyZ) {
+  if (!route) return { checked: 0, illegal: 0 };
+  const zs = Object.keys(storeyZ).map(k => ({ st: k, z: storeyZ[k] }));
+  const storeyOf = y => { const fz = y - 1.6; let b = null, bd = Infinity; for (const e of zs) { const d = Math.abs(e.z - fz); if (d < bd) { bd = d; b = e.st; } } return bd <= 0.05 ? b : null; };
+  let checked = 0, illegal = 0;
+  for (let i = 1; i < route.pts.length; i++) {
+    const a = route.pts[i - 1], b = route.pts[i];
+    const sa = storeyOf(a.y), sb = storeyOf(b.y);
+    if (sa === null || sb === null || sa !== sb) continue;
+    checked++;
+    if (RGmod.chordIllegalCount(g, sa, a.x, -a.z, b.x, -b.z) > 0) illegal++;
+  }
+  return { checked, illegal };
+}
+const visitedOf = logs => { const l = logs.find(x => x.indexOf('§FLY_ROUTE ') >= 0) || ''; const m = l.match(/stops=(\d+)\/(\d+)/); return m ? m[1] + '/' + m[2] : 'n/a'; };
+
+console.log('══ W-EXIT-NOT-A-LIFT — an `exit` node was a lift door; removing it must break nothing ══\n');
+let buildingsWithExitsBefore = 0, buildingsTotal = 0;
+for (const [label, dbFile, patches] of CASES) {
+  if (!fs.existsSync(path.join(BLD, dbFile))) { console.log('— ' + label + ': db missing, skipped'); continue; }
+  const { db, tmp, dbQuery } = load(dbFile, patches);
+  const realLog = console.log; console.log = () => {};
+  let gB, gA;
+  try { gB = RGbefore.buildGraph(dbQuery, { log: () => {} }); gA = RG.buildGraph(dbQuery, { log: () => {} }); }
+  finally { console.log = realLog; }
+  buildingsTotal++;
+
+  const cB = kindCounts(gB), cA = kindCounts(gA);
+  const exitsB = cB.exit || 0, exitsA = cA.exit || 0;
+  if (exitsB > 0) buildingsWithExitsBefore++;
+
+  // which door names produced the BEFORE exits — proves the source really was the lift filter
+  const liftNamed = [];
+  for (const k in gB.nodesByGuid) {
+    const n = gB.nodesByGuid[k];
+    if (n.kind !== 'exit') continue;
+    liftNamed.push(LIFT_NAMES.some(w => String(n.name || '').toLowerCase().indexOf(w) >= 0));
+  }
+  const e4B = gB.edges.filter(e => e.kind === 'E4').length, e4A = gA.edges.filter(e => e.kind === 'E4').length;
+  const nonE4B = gB.edges.length - e4B, nonE4A = gA.edges.length - e4A;
+  const pB = pathability(RGbefore, gB, 60), pA = pathability(RG, gA, 60);
+
+  console.log('── ' + label + '  exits ' + exitsB + ' → ' + exitsA + '  E4 edges ' + e4B + ' → ' + e4A +
+    '  other edges ' + nonE4B + ' → ' + nonE4A + '  pathable ' + pB.ok + '/' + pB.tried + ' → ' + pA.ok + '/' + pA.tried);
+
+  chk(label + ': G1 no exit node survives', exitsA === 0, exitsB + ' → 0');
+  if (exitsB > 0) {
+    chk(label + ': G1 the BEFORE exits really were lift-named doors (fixture is real)',
+      liftNamed.length > 0 && liftNamed.every(Boolean), liftNamed.length + '/' + liftNamed.length + ' lift-named');
+    chk(label + ': G1 all E4 edges gone with them', e4A === 0, e4B + ' → 0');
+  }
+  chk(label + ': G2 routing node counts unchanged (room/circ/stairwp/spine/doorwp)',
+    ['room', 'circ', 'stairwp', 'spine', 'doorwp'].every(k => (cB[k] || 0) === (cA[k] || 0)),
+    ['room', 'circ', 'stairwp', 'spine', 'doorwp'].map(k => k + '=' + (cA[k] || 0)).join(' '));
+  chk(label + ': G2 non-E4 edge count unchanged', nonE4B === nonE4A, nonE4B + ' → ' + nonE4A);
+  chk(label + ': G2 room→room pathability unchanged', pB.ok === pA.ok && pB.tried === pA.tried,
+    pB.ok + '/' + pB.tried + ' → ' + pA.ok + '/' + pA.tried);
+
+  // G3 — the tour, BEFORE build vs AFTER build, each against its own graph
+  const rB = tourRoute(BEFORE_TOUR, RGbefore, gB, dbQuery);
+  const rA = tourRoute(AFTER_TOUR, RG, gA, dbQuery);
+  if (rB.route && rA.route) {
+    const chB = chords(RGbefore, gB, rB.route, rB.storeyZ), chA = chords(RG, gA, rA.route, rA.storeyZ);
+    console.log('   tour: illegalChords ' + chB.illegal + '/' + chB.checked + ' → ' + chA.illegal + '/' + chA.checked +
+      '  visitedStops ' + visitedOf(rB.logs) + ' → ' + visitedOf(rA.logs));
+    chk(label + ': G3 tour illegal chords never worse', chA.illegal <= chB.illegal, chB.illegal + ' → ' + chA.illegal);
+    chk(label + ': G3 visited stops unchanged', visitedOf(rB.logs) === visitedOf(rA.logs), visitedOf(rA.logs));
+  } else {
+    chk(label + ': G3 tour fallback status unchanged', (!!rB.route) === (!!rA.route),
+      (rB.route ? 'route' : 'legacy') + ' → ' + (rA.route ? 'route' : 'legacy'));
+  }
+  db.close(); fs.unlinkSync(tmp);
+}
+
+console.log('');
+chk('G4 the no-exit path was ALREADY the common path before this change',
+  buildingsTotal - buildingsWithExitsBefore >= buildingsTotal - 1,
+  (buildingsTotal - buildingsWithExitsBefore) + ' of ' + buildingsTotal +
+  ' buildings already had exits=0 (tour.js §HL-ORIGIN, scene.js _graphEntrance→none, effects.js §CINEMA_EXIT→db-doors)');
+
+console.log('\n' + (fail ? '❌ FAIL ' : '✅ PASS ') + pass + ' passed, ' + fail + ' failed');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
`OCCUPANT_PATHFINDER.md §G1-EXIT-IS-A-LIFT-DOOR` **work-order step 1** — split out from G1 as an active-correctness fix, not a blocked feature.

## The defect
`room_graph.js` E4 turned every door that FAILED `isRoomDoor()` into an `EXIT::` node — "a free fire-escape target". But that predicate is a **lift-name test**: `NON_ROOM_DOOR_NAMES = ['liftdeur','lift','elevator','aufzug','fahrstuhl','hoist']`, ported from `compile_rooms.py` for the *room* test. Nothing in the codebase ever tested whether a door faces outside.

Measured over the fleet's 1,633 ARC doors, exactly one building produced exits: **Terminal, 5 — all five elevator doors** (`Side_opening_ElevatorLift_Door_with_Call_buttons…`). Two consequences, both live rather than hypothetical:

1. The Fly Tour's `entrance` is the lowest exit node, so **Terminal's tour entrance was a lift door** — and that is precisely the residual #1012 measured: its only 2 remaining wall-illegal chords were the legs to and from it, logged `§PATH_LEGAL_DETOUR_FAIL cause=ENDPOINT_OFF_FLOOR`, because a lift car is not walkable floor.
2. `escapeRoute()` (still zero callers) would have routed **egress into a lift** — the one thing fire egress must never do.

`isRoomDoor()` stays exactly where it belongs: the room test at `:464`, where a lift door genuinely is not a room door. `nonRoomDoors=5` still reports on Terminal; only the exit-node creation keyed on it is gone.

## Witness — W-EXIT-NOT-A-LIFT, 45/45
BEFORE = `git show origin/main:common/room_graph.js` loaded alongside the new one, so the compare is against shipped code.

| gate | result |
|---|---|
| G1 no exit node survives | Terminal 5 → 0; all 5 confirmed lift-named (the fixture is real, not a bug that was never there); E4 edges 5 → 0 |
| G2 routing graph unmoved | room/circ/stairwp/spine/doorwp counts, non-E4 edge counts, and room→room pathability **byte-identical on all 7 buildings** |
| G3 the tour | Terminal illegal chords **2/91 → 0/84** — zero. Visited stops unchanged everywhere (14/14, 22/22, 7/7, 13/15, 8/10, 4/5, 2/2) |
| G4 risk | **6 of 7 buildings already had `exits=0`**, so every consumer's no-exit path — `tour.js` §HL-ORIGIN, `scene.js` `_graphEntrance`→`'none'`, `effects.js` §CINEMA_EXIT→`exitSrc=db-doors` — was already the common path. This moves Terminal onto it; it does not open a new one. |

**Live browser** (real ✈ path on Terminal, §-log values only): `§ROOM_GRAPH … exits=0`, `§FLY_ROUTE … illegalChords=0/84 polyPts=2 polyLegs=2/14` — identical to the harness. `§TOUR_VERSION v19`, `§TOUR_CACHE … :v18:`.

Cache versions bumped in lockstep: `room_graph.js?v=11→v12` (graph semantics changed), `§TOUR_VERSION` v18→v19, `TOUR_CACHE_VER` v17→v18 (a returning Terminal user would otherwise replay the cached lift-door route).

## Known and intended
Terminal loses its descent finale (`stairDown=-`) — it no longer has a lift door to misname as an entrance. A real entrance returns with the **measured** exterior test (step 2: sample either side of a door against the storey walkable raster + footprint; proven feasible — HHS yields 3 candidates of 133 doors, the first a glass entrance). Steps 2–4 are a separate lane; raster coverage is the gating work there (Clinic/Terminal/LTU ship no `storey_walkable_raster` table at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)