### PR TITLE
fix(viewer): Find-panel close-leak recovery + Hall/Corridor shell reveal

### DIFF
--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -4350,6 +4350,13 @@
       if (A.filterByGuids) A.filterByGuids(null);
       _roomLensReset();
       _highlightLensReset();
+      // §REVEAL-LEAK-ON-EXIT (2026-07-26, user-reported live testing: category-reveal doors and the
+      // Path highlight survived a Find-panel close/reopen): _roomLensReset() only tears down
+      // _roomBoxes — the category reveal's OWN door meshes (_revealDoorMeshes) and the Path
+      // sub-mode's line/markers (_pathExtraMeshes) are separate arrays neither reset touches. Clear
+      // both explicitly, same as every other overlay this open path already resets.
+      _clearCategoryReveal();
+      _clearPathHighlight();
       if (elIsoBar) elIsoBar.style.display = 'none';
       _phaseCache = null; // fresh timeline per open (building may have changed)
       _probeCacheResult = null; // §PROBE-DEDUP: fresh probe per open too, same reasoning
@@ -4385,6 +4392,12 @@
       // cruft — always tear them down on close so nothing lingers invisibly.
       _roomLensReset();
       _highlightLensReset();
+      // §REVEAL-LEAK-ON-EXIT (2026-07-26, user-reported live testing): same gap as openFindPanel's
+      // fresh-open reset above — _roomLensReset() never touches _revealDoorMeshes (category-reveal
+      // brown doors) or _pathExtraMeshes (Path sub-mode line+markers), both separate arrays. Without
+      // this they survive closeFindPanel() and leak into the scene after the panel is gone.
+      _clearCategoryReveal();
+      _clearPathHighlight();
       // §PICK-BBOX-LEAK (user): the picking.js-owned bbox (window._pickHighlight, a LineSegments
       // EdgesGeometry) is a SHARED global cleared only when a NEW pick happens — clearHighlight()
       // above disposes it ONLY when it === the Find-local _highlight (and early-returns when that's

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -2767,12 +2767,25 @@
         if (m.material) m.material.dispose();
       });
       _revealDoorMeshes = [];
+      // §CORRIDOR-REVEAL-SHELL: a shell _revealCategoryGroup added for a backprop CORRIDOR_ROOM::*
+      // guid was never part of the base Room Lens batch (_roomLensOn never draws one for it) — DROP
+      // it entirely here rather than just dimming, or it lingers as a phantom faint box forever
+      // (until the whole lens resets on axis-switch/panel-close, a much later teardown).
+      var kept = [];
       _roomBoxes.forEach(function(rb) {
+        if (rb.mesh && rb.mesh.userData && rb.mesh.userData._revealAdded) {
+          if (rb.mesh.parent) rb.mesh.parent.remove(rb.mesh);
+          if (rb.mesh.geometry) rb.mesh.geometry.dispose();
+          if (rb.mesh.material) rb.mesh.material.dispose();
+          return;
+        }
         if (rb.mesh && rb.mesh.material && rb.mesh.userData && rb.mesh.userData._roomShell) {
           rb.mesh.material.opacity = 0.10;   // §RP-SHELL's own baseline shine-through opacity
           rb.mesh.material.needsUpdate = true;
         }
+        kept.push(rb);
       });
+      _roomBoxes = kept;
       _categoryRevealOn = null;
       if (A.markDirty) A.markDirty();
     }
@@ -2858,18 +2871,45 @@
       _clearCategoryReveal(); // mutually exclusive — switching categories clears the previous one first
       var guidSet = {};
       (groupRooms || []).forEach(function(rm) { guidSet[rm.key] = true; });
-      var brightened = 0;
+      var brightened = 0, matchedGuids = {};
       _roomBoxes.forEach(function(rb) {
         if (rb.mesh && rb.mesh.material && guidSet[rb.guid]) {
           rb.mesh.material.opacity = 0.55;   // same "brightened" level _drawPathHighlight already uses for path-member shells
           rb.mesh.material.needsUpdate = true;
           brightened++;
+          matchedGuids[rb.guid] = true;
+        }
+      });
+      // §CORRIDOR-REVEAL-SHELL (2026-07-26, user-reported live testing: tapping "Hall / Corridor"
+      // lit doors brown but left every shell dark — confirmed in a live console capture,
+      // `§CATEGORY_REVEAL on gk="Hall / Corridor" rooms=0 doors=59`): a `CORRIDOR_ROOM::*` guid (the
+      // §CORRIDOR-ROOM-BACKPROP synthetic hallway bucket, real door+wall-verified but with NO
+      // spatial_structure row) never gets a shell in `_roomBoxes` — `_allRoomVolumes()` only queries
+      // real rows, same reason `_roomSelect` needs its own `isCorridorRoom`/`_corridorRoomBBox`
+      // branch instead of the normal `_roomBoxes` lookup. The `rooms=0` case above is exactly a
+      // Hall/Corridor group made ENTIRELY of these backprop entries — nothing in `_roomBoxes` could
+      // ever match. Draw a fresh shell for each unmatched member here, same helper `_roomSelect`
+      // already uses for the single-room case — real measured position/span, not invented — and
+      // start it already brightened (0.55) since it's created FOR this reveal, never dim-then-skip.
+      var addedShells = 0;
+      Object.keys(guidSet).forEach(function(g) {
+        if (matchedGuids[g] || g.indexOf('CORRIDOR_ROOM::') !== 0) return;
+        var rw = _corridorRoomBBox(g);
+        if (!rw || rw.cx == null || rw.sx == null || !A.ifc2three || typeof THREE === 'undefined') return;
+        var cc = A.ifc2three(rw.cx, rw.cy, rw.cz);
+        var center = new THREE.Vector3(cc.x, cc.y, cc.z);
+        var size = new THREE.Vector3(Math.max(rw.sx || 0.5, 0.5), Math.max(rw.sz || 0.5, 0.5), Math.max(rw.sy || 0.5, 0.5));
+        var mesh = _drawRoomShell(center, size, 0.55, _categoryColor('corridor').fill);
+        if (mesh) {
+          mesh.userData._revealAdded = true; // §CORRIDOR-REVEAL-SHELL: never part of the base Room Lens batch — _clearCategoryReveal must DISPOSE it, not just dim it, or it leaks into every later view
+          _roomBoxes.push({ guid: g, name: rw.name, mesh: mesh, center: center, size: size, category: 'corridor' });
+          addedShells++; brightened++;
         }
       });
       _revealDoorMeshes = _spawnDoorMeshesForRooms(Object.keys(guidSet));
       _categoryRevealOn = gk;
       if (A.markDirty) A.markDirty();
-      console.log('[RP-TA] §CATEGORY_REVEAL on gk="' + gk + '" rooms=' + brightened + ' doors=' + _revealDoorMeshes.length);
+      console.log('[RP-TA] §CATEGORY_REVEAL on gk="' + gk + '" rooms=' + brightened + ' addedShells=' + addedShells + ' doors=' + _revealDoorMeshes.length);
     }
 
     // §RP sub-toggle row [A | B | ...] — a small N-pill regroup control inside a lens tree.

--- a/viewer/tests/witness_corridor_reveal_shell_2026-07-26.js
+++ b/viewer/tests/witness_corridor_reveal_shell_2026-07-26.js
@@ -1,0 +1,196 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// SCOPE: user-reported live testing (2026-07-26, real console capture on Hospital) — tapping "Hall /
+// Corridor" lit 59 brown doors but the log itself proved zero shells brightened:
+//   [RP-TA] §CATEGORY_REVEAL on gk="Hall / Corridor" rooms=0 doors=59
+// Root cause (navigate_find.js _revealCategoryGroup): a "Hall / Corridor" group can be made ENTIRELY
+// of §CORRIDOR-ROOM-BACKPROP synthetic `CORRIDOR_ROOM::*` guids — real, door+wall-verified hallway
+// buckets with NO spatial_structure row, so _allRoomVolumes() never gave them a shell in _roomBoxes.
+// _revealCategoryGroup only brightened EXISTING _roomBoxes entries, so a corridor bucket with no real
+// rooms at all (Hospital's case) brightened nothing, while _doorPositionsForRooms (reads the room
+// GRAPH directly, which DOES have these nodes) still found doors fine — hence doors>0, rooms=0.
+// Fix: for any group member whose guid is unmatched AND starts with CORRIDOR_ROOM::, draw a FRESH
+// shell via _corridorRoomBBox() (the same helper _roomSelect's single-room path already uses for
+// this exact guid shape) in the corridor category color, tagged userData._revealAdded so
+// _clearCategoryReveal() disposes it (never lets it leak as a phantom box after toggle-off).
+// This witness proves, on Hospital (the user's own real fixture, real corridor backprop count):
+//   1. Real user path to open Find -> Room axis -> Type sub-toggle -> tap "Hall / Corridor" headline.
+//   2. §CATEGORY_REVEAL log line now shows rooms>=1 (not 0) and addedShells>=1.
+//   3. The scene contains mesh(es) tagged userData._revealAdded, colored the corridor blue 0x0277bd
+//      (ROOM_CATEGORY_COLORS.corridor.fill) — reads the real running scene, not a guess.
+//   4. Tapping the SAME headline again (toggle off) removes every _revealAdded mesh — no leak.
+// §-log first — READ tests/witness_corridor_reveal_shell_2026-07-26.log before any conclusion.
+// Run:  timeout 180 node viewer/tests/witness_corridor_reveal_shell_2026-07-26.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function waitReady(page, maxSec) {
+  let ready = false;
+  for (let i = 0; i < maxSec && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false)); } catch (e) {}
+  }
+  return ready;
+}
+
+async function tap(page, id) {
+  const hit = await page.evaluate((eid) => {
+    const el = document.getElementById(eid);
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, id);
+  await page.waitForTimeout(400);
+  return hit;
+}
+
+async function cycleAxisTo(page, targetAxis) {
+  for (let i = 0; i < 6; i++) {
+    const cur = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      return b ? b.getAttribute('data-axis') : null;
+    });
+    if (cur === targetAxis) return cur;
+    const clicked = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      if (!b) return false;
+      b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      return true;
+    });
+    if (!clicked) return null;
+    await page.waitForTimeout(300);
+  }
+  return page.evaluate(() => {
+    const b = document.getElementById('find-axis-toggle');
+    return b ? b.getAttribute('data-axis') : null;
+  });
+}
+
+async function clickButtonByText(page, containerSelector, text) {
+  return page.evaluate(([sel, t]) => {
+    const container = document.querySelector(sel);
+    if (!container) return false;
+    const btns = Array.from(container.querySelectorAll('button'));
+    const btn = btns.find(b => b.textContent.trim() === t);
+    if (!btn) return false;
+    btn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, [containerSelector, text]);
+}
+
+async function tapTreeGroupHeadline(page, label) {
+  return page.evaluate((lbl) => {
+    const row = document.querySelector('.find-tree-row[data-find-parent="' + lbl + '"]');
+    if (!row) return false;
+    const text = row.children[1];
+    if (!text) return false;
+    text.dispatchEvent(new PointerEvent('pointerup', { bubbles: false }));
+    return true;
+  }, label);
+}
+
+function revealAddedMeshes(page) {
+  return page.evaluate(() => {
+    const out = [];
+    if (window.APP && window.APP.scene) {
+      window.APP.scene.traverse((o) => {
+        if (o.userData && o.userData._revealAdded && o.material && o.material.color) {
+          out.push({ hex: '#' + o.material.color.getHexString(), opacity: o.material.opacity });
+        }
+      });
+    }
+    return out;
+  });
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => { cons.push(m.text()); });
+
+  const DB = process.env.WITNESS_DB || 'buildings/HHS_Office_Federated_extracted.db';
+  S('── witness_corridor_reveal_shell (' + DB + ') ──');
+  await page.goto('http://127.0.0.1:' + server.address().port +
+    '/viewer/viewer.html?db=' + DB,
+    { waitUntil: 'load', timeout: 60000 });
+  const ready = await waitReady(page, 150); // large split-DB fixtures need real time
+  verdict(ready, 'real model loaded + ready (Hospital)');
+  if (!ready) {
+    S('\n❌ ABORT — model never became ready');
+    fs.writeFileSync(path.join(__dirname, 'witness_corridor_reveal_shell_2026-07-26.log'), log.join('\n') + '\n');
+    await browser.close(); server.close(); process.exit(1);
+  }
+
+  await page.waitForFunction(() => window._mainPillActions && window._mainPillActions.length > 0, { timeout: 15000 }).catch(() => {});
+  await page.click('#mobile-trigger', { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(300);
+
+  verdict(await tap(page, 'pill-navigate'), 'Navigate rail pill tapped');
+  verdict(await tap(page, 'drawer-row-find'), 'Find drawer row tapped');
+  await page.waitForTimeout(500);
+  verdict((await cycleAxisTo(page, 'room')) === 'room', 'Room axis reachable');
+  verdict(await clickButtonByText(page, '#find-tree', 'Type'), 'Type sub-toggle clicked');
+  await page.waitForTimeout(500);
+  const hasCorridorGroup = await page.evaluate(() =>
+    !!document.querySelector('.find-tree-row[data-find-parent="Hall / Corridor"]'));
+  verdict(hasCorridorGroup, 'a "Hall / Corridor" group row exists in Type mode');
+  if (!hasCorridorGroup) {
+    S('\n❌ ABORT — no Hall / Corridor group found');
+    fs.writeFileSync(path.join(__dirname, 'witness_corridor_reveal_shell_2026-07-26.log'), log.join('\n') + '\n');
+    await page.close(); await ctx.close(); await browser.close(); server.close(); process.exit(1);
+  }
+
+  cons.length = 0;
+  verdict(await tapTreeGroupHeadline(page, 'Hall / Corridor'), 'Hall / Corridor headline tapped (fires _revealCategoryGroup)');
+  await page.waitForTimeout(800);
+  const revealLine = cons.find(l => l.indexOf('[RP-TA] §CATEGORY_REVEAL on') === 0);
+  S('     [console] ' + (revealLine || '(none)'));
+  const roomsM = revealLine && /rooms=(\d+)/.exec(revealLine);
+  const addedM = revealLine && /addedShells=(\d+)/.exec(revealLine);
+  const roomsN = roomsM ? parseInt(roomsM[1], 10) : -1;
+  const addedN = addedM ? parseInt(addedM[1], 10) : -1;
+  verdict(roomsN >= 1, '§CATEGORY_REVEAL now reports rooms>=1 (was rooms=0 on the user\'s live capture)', 'rooms=' + roomsN);
+  verdict(addedN >= 1, '§CATEGORY_REVEAL reports addedShells>=1 (the new backprop-corridor shell draw fired)', 'addedShells=' + addedN);
+
+  const meshes = await revealAddedMeshes(page);
+  S('     [info] scene _revealAdded meshes: ' + JSON.stringify(meshes));
+  verdict(meshes.length === addedN, 'scene mesh count matches the §-logged addedShells count', 'scene=' + meshes.length + ' logged=' + addedN);
+  verdict(meshes.length > 0 && meshes.every(m => m.hex === '#0277bd'), 'every added shell is the corridor blue 0x0277bd', JSON.stringify(meshes.map(m => m.hex)));
+  verdict(meshes.length > 0 && meshes.every(m => Math.abs(m.opacity - 0.55) < 0.01), 'every added shell starts already brightened (0.55), not dim-then-skipped');
+
+  // Toggle off — same headline tap again — must dispose every _revealAdded mesh.
+  verdict(await tapTreeGroupHeadline(page, 'Hall / Corridor'), 'Hall / Corridor headline tapped again (toggle off)');
+  await page.waitForTimeout(500);
+  const meshesAfter = await revealAddedMeshes(page);
+  S('     [info] scene _revealAdded meshes after toggle-off: ' + meshesAfter.length);
+  verdict(meshesAfter.length === 0, 'zero _revealAdded shells remain after toggling the reveal off — no leak');
+
+  await page.close(); await ctx.close();
+  await browser.close();
+  server.close();
+
+  S('\n' + (fails === 0 ? '✅ ALL PASS' : '❌ ' + fails + ' FAILED'));
+  fs.writeFileSync(path.join(__dirname, 'witness_corridor_reveal_shell_2026-07-26.log'), log.join('\n') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})();

--- a/viewer/tests/witness_find_close_no_leak_2026-07-26.js
+++ b/viewer/tests/witness_find_close_no_leak_2026-07-26.js
@@ -1,0 +1,261 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// SCOPE: user-reported live testing (2026-07-26) — "the doors also got left behind when we exit
+// Find Panel. Path is also not cleaned up upon exit." Root cause: closeFindPanel() (navigate_find.js)
+// called _roomLensReset()+_highlightLensReset() but neither of those touches _revealDoorMeshes (the
+// Hall/Corridor-etc category-reveal's brown door meshes, a module-level array separate from
+// _roomBoxes) or _pathExtraMeshes (the Path sub-mode's orange line+markers) — both leaked into the
+// scene forever after close. Fix: closeFindPanel() (and openFindPanel()'s fresh-open reset, for the
+// same reason) now also call _clearCategoryReveal() and _clearPathHighlight().
+// This witness proves, on Duplex (small/fast, real rooms+doors, real corridor connectivity):
+//   1. Real user path to open Find -> Room axis -> Type sub-toggle -> tap "Hall / Corridor" headline
+//      (fires _revealCategoryGroup) -> brown door marker(s) appear in the scene.
+//   2. Closing the panel (the real #find-close button, same as a user click) leaves ZERO
+//      userData._doorMarker meshes in the scene — proves the category-reveal leak is gone.
+//   3. Re-opening Find -> Room axis -> Path sub-toggle -> pick two connected rooms -> Find Path ->
+//      an orange (0xff9100) path line/marker appears in the scene.
+//   4. Closing the panel again leaves ZERO 0xff9100-colored meshes — proves the Path leak is gone.
+// §-log first — READ tests/witness_find_close_no_leak_2026-07-26.log before any conclusion.
+// Run:  timeout 120 node viewer/tests/witness_find_close_no_leak_2026-07-26.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+async function waitReady(page) {
+  let ready = false;
+  for (let i = 0; i < 90 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap && Object.keys(window.APP.guidMap).length > 0
+      && window.APP.streaming === false)); } catch (e) {}
+  }
+  return ready;
+}
+
+async function tap(page, id) {
+  const hit = await page.evaluate((eid) => {
+    const el = document.getElementById(eid);
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, id);
+  await page.waitForTimeout(400);
+  return hit;
+}
+
+async function cycleAxisTo(page, targetAxis) {
+  for (let i = 0; i < 6; i++) {
+    const cur = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      return b ? b.getAttribute('data-axis') : null;
+    });
+    if (cur === targetAxis) return cur;
+    const clicked = await page.evaluate(() => {
+      const b = document.getElementById('find-axis-toggle');
+      if (!b) return false;
+      b.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      return true;
+    });
+    if (!clicked) return null;
+    await page.waitForTimeout(300);
+  }
+  return page.evaluate(() => {
+    const b = document.getElementById('find-axis-toggle');
+    return b ? b.getAttribute('data-axis') : null;
+  });
+}
+
+async function clickButtonByText(page, containerSelector, text) {
+  return page.evaluate(([sel, t]) => {
+    const container = document.querySelector(sel);
+    if (!container) return false;
+    const btns = Array.from(container.querySelectorAll('button'));
+    const btn = btns.find(b => b.textContent.trim() === t);
+    if (!btn) return false;
+    btn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, [containerSelector, text]);
+}
+
+async function tapTreeGroupHeadline(page, label) {
+  // The headline row's onTap fires from the TEXT child (children[1]), same convention as a leaf tap
+  // — arrow (children[0]) only expands.
+  return page.evaluate((lbl) => {
+    const row = document.querySelector('.find-tree-row[data-find-parent="' + lbl + '"]');
+    if (!row) return false;
+    const text = row.children[1];
+    if (!text) return false;
+    text.dispatchEvent(new PointerEvent('pointerup', { bubbles: false }));
+    return true;
+  }, label);
+}
+
+function markersOfColor(page, hex) {
+  return page.evaluate((h) => {
+    const out = [];
+    if (window.APP && window.APP.scene) {
+      window.APP.scene.traverse((o) => {
+        if (o.material && o.material.color && ('#' + o.material.color.getHexString()) === h) out.push(o.type);
+      });
+    }
+    return out;
+  }, hex);
+}
+
+function doorMarkerCount(page) {
+  return page.evaluate(() => {
+    let n = 0;
+    if (window.APP && window.APP.scene) {
+      window.APP.scene.traverse((o) => { if (o.userData && o.userData._doorMarker) n++; });
+    }
+    return n;
+  });
+}
+
+async function pathRoomOptions(page) {
+  return page.evaluate(() => {
+    const sel = document.getElementById('find-path-from');
+    if (!sel) return [];
+    return Array.from(sel.options).map(o => o.value).filter(v => v);
+  });
+}
+
+async function trySetPathAndFind(page, fromGuid, toGuid) {
+  return page.evaluate(([f, t]) => {
+    const selFrom = document.getElementById('find-path-from');
+    const selTo = document.getElementById('find-path-to');
+    if (!selFrom || !selTo) return false;
+    selFrom.value = f; selFrom.dispatchEvent(new Event('change', { bubbles: true }));
+    selTo.value = t; selTo.dispatchEvent(new Event('change', { bubbles: true }));
+    const wrap = selTo.closest('div').parentElement;
+    const btn = wrap ? Array.from(wrap.querySelectorAll('button')).find(b => b.textContent.trim().length > 0) : null;
+    if (!btn) return false;
+    btn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  }, [fromGuid, toGuid]);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => { cons.push(m.text()); });
+
+  // Part 1 needs a building with a real "Hall / Corridor" Type-tree group — Duplex (used for Part 2's
+  // path check) is too small to have one (its rooms don't hallway-backbone-classify as corridors).
+  // HHS_Office_Federated is the building the corridor-category work was proven against originally
+  // (ROOM_LENS_VISUAL_HIGHLIGHT_SPEC.md), and it's already an LFS-tracked fixture in this repo.
+  S('── witness_find_close_no_leak Part 1 (HHS_Office_Federated) ──');
+  await page.goto('http://127.0.0.1:' + server.address().port +
+    '/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db',
+    { waitUntil: 'networkidle' });
+  const ready = await waitReady(page);
+  verdict(ready, 'real model loaded + ready (HHS_Office_Federated)');
+  if (!ready) {
+    S('\n❌ ABORT — model never became ready');
+    fs.writeFileSync(path.join(__dirname, 'witness_find_close_no_leak_2026-07-26.log'), log.join('\n') + '\n');
+    await browser.close(); server.close(); process.exit(1);
+  }
+
+  await page.waitForFunction(() => window._mainPillActions && window._mainPillActions.length > 0, { timeout: 15000 }).catch(() => {});
+  await page.click('#mobile-trigger', { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(300);
+
+  // ── Part 1: category reveal (Hall/Corridor) doors must not survive close ──
+  verdict(await tap(page, 'pill-navigate'), 'Navigate rail pill tapped');
+  verdict(await tap(page, 'drawer-row-find'), 'Find drawer row tapped');
+  await page.waitForTimeout(500);
+  verdict((await cycleAxisTo(page, 'room')) === 'room', 'Room axis reachable');
+  verdict(await clickButtonByText(page, '#find-tree', 'Type'), 'Type sub-toggle clicked');
+  await page.waitForTimeout(400);
+  const hasCorridorGroup = await page.evaluate(() =>
+    !!document.querySelector('.find-tree-row[data-find-parent="Hall / Corridor"]'));
+  verdict(hasCorridorGroup, 'a "Hall / Corridor" group row exists in Type mode');
+  if (hasCorridorGroup) {
+    cons.length = 0;
+    verdict(await tapTreeGroupHeadline(page, 'Hall / Corridor'), 'Hall / Corridor headline tapped (fires _revealCategoryGroup)');
+    await page.waitForTimeout(600);
+    const revealLine = cons.find(l => l.indexOf('[RP-TA] §CATEGORY_REVEAL on') === 0);
+    S('     [console] ' + (revealLine || '(none)'));
+    const beforeClose = await doorMarkerCount(page);
+    S('     [info] door markers BEFORE close: ' + beforeClose);
+    verdict(beforeClose >= 1, 'category reveal produced at least one door marker before close');
+
+    // §find-close is bound via elClose.onclick (a native 'click' handler, not 'pointerup' like the
+    // rail/drawer pills above) — a synthetic pointerup wouldn't fire it. page.click() dispatches the
+    // real mouse event sequence, same as an actual user click.
+    await page.click('#find-close');
+    verdict(true, 'Find panel closed (#find-close, real close button)');
+    await page.waitForTimeout(400);
+    const afterClose = await doorMarkerCount(page);
+    S('     [info] door markers AFTER close: ' + afterClose);
+    verdict(afterClose === 0, 'zero door markers remain after closing Find — category-reveal leak is fixed');
+  }
+
+  // ── Part 2: Path sub-mode line/markers must not survive close (Duplex — small/fast, real
+  // corridor-connected rooms, same building the room-select-door witness already uses) ──
+  S('── witness_find_close_no_leak Part 2 (Duplex) ──');
+  await page.goto('http://127.0.0.1:' + server.address().port +
+    '/viewer/viewer.html?db=buildings/Duplex_extracted.db',
+    { waitUntil: 'networkidle' });
+  const ready2 = await waitReady(page);
+  verdict(ready2, 'real model loaded + ready (Duplex)');
+  if (!ready2) {
+    S('\n❌ ABORT — Duplex never became ready');
+    fs.writeFileSync(path.join(__dirname, 'witness_find_close_no_leak_2026-07-26.log'), log.join('\n') + '\n');
+    await page.close(); await ctx.close(); await browser.close(); server.close(); process.exit(1);
+  }
+  await page.waitForFunction(() => window._mainPillActions && window._mainPillActions.length > 0, { timeout: 15000 }).catch(() => {});
+  await page.click('#mobile-trigger', { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(300);
+  verdict(await tap(page, 'pill-navigate'), 'Navigate rail pill tapped (reopen)');
+  verdict(await tap(page, 'drawer-row-find'), 'Find drawer row tapped (reopen)');
+  await page.waitForTimeout(500);
+  verdict((await cycleAxisTo(page, 'room')) === 'room', 'Room axis reachable (2nd open)');
+  verdict(await clickButtonByText(page, '#find-tree', 'Path'), 'Path sub-toggle clicked');
+  await page.waitForTimeout(400);
+  const opts = await pathRoomOptions(page);
+  S('     [info] path room options: ' + JSON.stringify(opts));
+  let pathDrawn = false;
+  for (let i = 0; i < opts.length - 1 && !pathDrawn; i++) {
+    await trySetPathAndFind(page, opts[i], opts[i + 1]);
+    await page.waitForTimeout(500);
+    const orangeNow = markersOfColor(page, '#ff9100');
+    const found = (await orangeNow).length > 0;
+    if (found) { pathDrawn = true; S('     [info] path drawn using pair (' + i + ',' + (i + 1) + ')'); }
+  }
+  verdict(pathDrawn, 'an orange (0xff9100) path line/marker appeared in the scene for some room pair');
+  if (pathDrawn) {
+    await page.click('#find-close');
+    verdict(true, 'Find panel closed again (#find-close)');
+    await page.waitForTimeout(400);
+    const orangeAfter = await markersOfColor(page, '#ff9100');
+    S('     [info] orange path meshes AFTER close: ' + orangeAfter.length);
+    verdict(orangeAfter.length === 0, 'zero orange path meshes remain after closing Find — Path leak is fixed');
+  }
+
+  await page.close(); await ctx.close();
+  await browser.close();
+  server.close();
+
+  S('\n' + (fails === 0 ? '✅ ALL PASS' : '❌ ' + fails + ' FAILED'));
+  fs.writeFileSync(path.join(__dirname, 'witness_find_close_no_leak_2026-07-26.log'), log.join('\n') + '\n');
+  process.exit(fails === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- **Recovers an orphaned commit**: PR #1016 auto-merged right after its first commit was pushed; the second commit (Find-panel close-leak fix — category-reveal doors + Path highlight surviving `closeFindPanel()`) was pushed 8 minutes later and never reached `main`. Cherry-picked here onto a fresh branch off current `origin/main`.
- **New fix**: `_revealCategoryGroup` (tapping a Type-tree headline like "Hall / Corridor") only brightened shells already in `_roomBoxes`. A corridor bucket made entirely of `§CORRIDOR-ROOM-BACKPROP` synthetic `CORRIDOR_ROOM::*` guids (real, door+wall-verified hallways with no `spatial_structure` row) never had a shell there to begin with — confirmed by the user's own live console capture on Hospital: `rooms=0 doors=59`. Now draws a fresh shell for each unmatched corridor guid via the same `_corridorRoomBBox()` helper `_roomSelect`'s single-room path already used, tagged for clean disposal on toggle-off (never leaks a phantom box).

## Test plan
- [x] `node -c viewer/navigate_find.js` — syntax clean
- [x] `viewer/tests/witness_find_close_no_leak_2026-07-26.js` (recovered fix) — HHS_Office_Federated + Duplex, both leak checks — ALL PASS
- [x] `viewer/tests/witness_corridor_reveal_shell_2026-07-26.js` (new fix) — Hospital, the user's own fixture: `rooms=0→10, addedShells=10, doors=59` (doors unchanged), every added shell `#0277bd` @ opacity 0.55, zero leak on toggle-off — ALL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)