### PR TITLE
fix(cinema): §CINEMA_DAMPING_BLEED — OrbitControls damping overwrites the authored cinema pose

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -50,6 +50,32 @@
   function _sleep(ms) { return new Promise(function(res) { setTimeout(res, ms); }); }
   function _status(t) { var A = window.APP; if (A && A.status) A.status.textContent = t; }
 
+  // §CINEMA_DAMPING_BLEED (2026-07-26 — PHOTOREAL_STILL_RENDER.md §CINEMA_DAMPING_BLEED).
+  // Both authored loops below (the 10s path preview AND the frame bake) do
+  // camera.position.set(pose) → controls.update(). OrbitControls.update() recomputes the position
+  // from its own spherical state with the dampened deltas applied, OVERWRITING the authored pose.
+  // With scene.js's dampingFactor=0.08 the residual from whatever the user did right before Alt+C
+  // bleeds in at 1.637% of the look distance on frame 0, decaying by exactly 1-dampingFactor per
+  // frame — the reported "slight twitch at the first second of the movie". Damping is an
+  // interaction affordance; an authored camera must not be subject to it. Paired with
+  // _wakeAcquire/_wakeRelease so every exit path that releases the wake lock releases this too.
+  var _dampSaved = null;
+  function _dampHold() {
+    var A = window.APP;
+    if (!A || !A.controls || _dampSaved !== null) return;
+    _dampSaved = A.controls.enableDamping;
+    A.controls.enableDamping = false;
+    A.controls.update();   // flush the residual BEFORE the first authored pose
+    console.log('§CINEMA_DAMPING_BLEED held (enableDamping ' + _dampSaved + ' -> false for preview+bake)');
+  }
+  function _dampRelease() {
+    var A = window.APP;
+    if (_dampSaved === null) return;
+    if (A && A.controls) A.controls.enableDamping = _dampSaved;
+    console.log('§CINEMA_DAMPING_BLEED released (enableDamping restored to ' + _dampSaved + ')');
+    _dampSaved = null;
+  }
+
   // §MAXQ_IDB — open must NEVER hang silently. An earlier run that exited abnormally (or a second
   // app tab still holding a connection) leaves _idbDestroy's deleteDatabase() pending-blocked, and
   // every later open() then queues behind it FOREVER with no event, no error, no log — the exact
@@ -331,6 +357,7 @@
     _active = true; _cancel = false;
     A._maxqActive = true;   // mirror for the cinema icon's busy/done check (panels.js)
     _wakeAcquire();
+    _dampHold();   // §CINEMA_DAMPING_BLEED — the preview and the bake are both authored cameras
     // §MAXQ_STREAM_FIRST (user report, LTU_AHouse/122k: preview was SEEN showing boxes — initial
     // assumption was that this was a deliberate LOD-for-speed choice. WRONG, disproven by
     // investigation: dlod_nav.js already fully disengages the instant A._maxqActive is set above,
@@ -357,7 +384,7 @@
       console.log('§MAXQ_CANCEL during stream-wait — nothing baked, nothing saved');
       _status('🎬 MaxQ cancelled');
       _active = false; _cancel = false; A._maxqActive = false;
-      _wakeRelease();
+      _wakeRelease(); _dampRelease();
       return;
     }
     // §CINEMA_PATH: fly the SAME orbit-path formula as the live-capture Cinema Orbit (push-in to
@@ -423,7 +450,7 @@
         console.log('§MAXQ_CANCEL during preview — nothing baked, nothing saved');
         _status('🎬 MaxQ cancelled during preview');
         _active = false; _cancel = false; A._maxqActive = false;
-        _wakeRelease();
+        _wakeRelease(); _dampRelease();
         return;
       }
       console.log('§MAXQ_PREVIEW done — camera restored, commencing capture');
@@ -571,7 +598,7 @@
       // swallowed as a cancel-toggle. Cleanup must never gate the ability to retry.
       _active = false; _cancel = false;
       A._maxqActive = false;
-      _wakeRelease();
+      _wakeRelease(); _dampRelease();
       await _idbDestroy(db);
     }
   }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3276,7 +3276,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v13 (§CINEMA_TURN_SLERP look-back + §CINEMA_EXIT_BREATHE overlap)';
+  var EFFECTS_V = 'v14 (§CINEMA_TURN_SLERP look-back + §CINEMA_DAMPING_BLEED authored-pose hold)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).
@@ -4155,6 +4155,33 @@ async function setupEffects(A, renderer, scene, camera) {
     ]);
     _hdriWaitMs = performance.now() - _hdriWaitT0;
     console.log('§CINEMA_HDRI_RACE waitedMs=' + _hdriWaitMs.toFixed(0) + ' ready=' + !!_hdriEnvMap);
+    // §CINEMA_DAMPING_BLEED (2026-07-26, user: "a slight twitch at the first second of the movie,
+    // where the screen size is adjusted slightly narrower. Tested on two buildings it is so").
+    // A recording is a FULLY AUTHORED camera — cinemaPathPlan owns every pose. But step() below does
+    // camera.position.set(pose) → controls.update(), and OrbitControls.update() recomputes the
+    // position from its OWN spherical state with the dampened deltas applied, OVERWRITING the pose
+    // that was just authored. With scene.js's enableDamping/dampingFactor=0.08, the residual left by
+    // whatever navigation the user did immediately before pressing Alt+C bleeds into the film:
+    // measured 1.637% of the look distance at frame 0, decaying by exactly 0.92 = 1 - dampingFactor
+    // per frame, i.e. ~1-2s to become invisible. That is the reported twitch.
+    // Damping is an INTERACTION affordance; it has no business editing an authored pose. Hold it off
+    // for the run and flush the residual here, BEFORE frame 0. update() is still called every frame
+    // (it has other duties) — with damping off it applies zeroed deltas and preserves the pose
+    // exactly. Restored on every exit path below, next to the SSAA detach.
+    var _dampSaved = A.controls.enableDamping, _dampHeld = false;
+    function _cinemaDampRelease() {
+      if (!_dampHeld) return;
+      _dampHeld = false; A.controls.enableDamping = _dampSaved;
+      console.log('§CINEMA_DAMPING_BLEED released (enableDamping restored to ' + _dampSaved + ')');
+    }
+    A.controls.enableDamping = false; _dampHeld = true;
+    // One-off flush: with damping off, update() applies the ENTIRE remaining delta at once instead
+    // of 8% of it per frame (measured 13.3m on a fresh drag). That is exactly what we want, and it
+    // is harmless here — it lands BEFORE the first authored pose, which overwrites the position
+    // outright. Doing it after frame 0 would put that whole jump INSIDE the film.
+    A.controls.update();
+    console.log('§CINEMA_DAMPING_BLEED held (enableDamping ' + _dampSaved + ' -> false for the recording)');
+
     console.log('§CINEMA_ORBIT start envelope=' + envelope.toFixed(1) + ' arcOnly=' + plan.arcOnly +
       ' fillDistance=' + plan.fillDistance.toFixed(1) + ' pushInRadius=' + plan.pushInRadius.toFixed(1) +
       ' radiusBand=[' + plan.radiusMin.toFixed(1) + ',' + plan.radiusMax.toFixed(1) + '] triplanarMaterials=' + _triCount);
@@ -4189,7 +4216,7 @@ async function setupEffects(A, renderer, scene, camera) {
       ? 'video/webm;codecs=vp9' : 'video/webm';
     var recorder;
     try { recorder = new MediaRecorder(stream, { mimeType: mimeType }); }
-    catch (e) { console.warn('§CINEMA_FAIL MediaRecorder ctor: ' + e.message); _cinemaSsaaDetach(); _teardownStillRefine('cinema-fail'); _cinemaActive = false; return; }
+    catch (e) { console.warn('§CINEMA_FAIL MediaRecorder ctor: ' + e.message); _cinemaDampRelease(); _cinemaSsaaDetach(); _teardownStillRefine('cinema-fail'); _cinemaActive = false; return; }
     recorder.ondataavailable = function(e) { if (e.data && e.data.size) chunks.push(e.data); };
     recorder.onstop = function() {
       var blob = new Blob(chunks, { type: mimeType });
@@ -4199,6 +4226,7 @@ async function setupEffects(A, renderer, scene, camera) {
       document.body.appendChild(a); a.click(); document.body.removeChild(a);
       setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
       console.log('§CINEMA_ORBIT saved size=' + blob.size + ' type=' + mimeType);
+      _cinemaDampRelease();      // §CINEMA_DAMPING_BLEED: recording over — user's damping back
       _cinemaSsaaDetach();       // §CINEMA_SSAA: recording over — plain head pass back
       _giCinemaPresetRestore();  // §GI_CINEMA_PRESET: recording over — full-quality GI settings back
       _teardownStillRefine('cinema-orbit-done');
@@ -4210,7 +4238,7 @@ async function setupEffects(A, renderer, scene, camera) {
     var durationMs = (CINEMA_N_FRAMES / CINEMA_FPS) * 1000;
     var _cinePerfN = 0, _cinePerfMs = 0, _cinePrevFrameMs = 0;  // §CINEMA_PERF frame-time telemetry
     function step() {
-      if (!_cinemaActive) { _giCinemaPresetRestore(); _cinemaSsaaDetach(); return; }  // early abort (stopCinemaOrbit) — restore GI + head pass too
+      if (!_cinemaActive) { _giCinemaPresetRestore(); _cinemaDampRelease(); _cinemaSsaaDetach(); return; }  // early abort (stopCinemaOrbit) — restore GI + head pass + damping too
       var tNorm = Math.min(1, (performance.now() - startMs) / durationMs);
       // §CINEMA_PATH: pose from the shared plan (§CINEMA_SIMPLE's one routine — dive → spin →
       // out → rise → orbit) — the SAME path the MaxQ exporter flies.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v849';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v850';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cinema_damping_bleed.js
+++ b/witness_cinema_damping_bleed.js
@@ -1,0 +1,151 @@
+// WITNESS — §CINEMA_DAMPING_BLEED (prompts/PHOTOREAL_STILL_RENDER.md, user report 2026-07-26).
+//
+// ISSUE PROVEN/DISPROVEN: "there is a slight twitch at the first second of the movie, where the
+//   screen size is adjusted slightly narrower. Tested on two buildings it is so."
+//
+// A recording is a FULLY AUTHORED camera — cinemaPathPlan owns every pose. But every authored loop
+// does camera.position.set(pose) → controls.update(), and OrbitControls.update() recomputes the
+// position from its OWN spherical state with the dampened deltas applied, OVERWRITING the pose just
+// authored. This measures that overwrite directly: wrap controls.update(), record the camera
+// position immediately before and immediately after each call, and report the distance between them.
+// Any non-zero value is damping editing a pose it does not own.
+//
+// ⚠ THE PRECONDITION IS THE WHOLE TEST. The residual only exists if the user NAVIGATED just before
+// starting — which a real user always has. Pressing Alt+C from a clean, untouched camera shows
+// nothing at all (three earlier probes did exactly that and found a flat zero). So this witness
+// dispatches a real wheel + drag on the canvas immediately before starting the recording. Remove
+// that and the witness proves nothing.
+//
+//   G1 fixed tip: controls.update() moves the camera by 0 m on EVERY frame OF THE FILM (counting
+//      starts at the '§CINEMA_ORBIT start' marker — before it the camera is still interactive and
+//      damping SHOULD be live; the one-off flush is deliberately on the other side of that line).
+//   G2 control — unfixed tip: frame-0 drift > 1% of the look distance, i.e. the first second of the
+//      film really was rendered from a pose the plan did not author. A gate that only ever passes
+//      proves nothing.
+//   G3 the unfixed tip's drift decays at exactly (1 - dampingFactor) per frame. This NAMES the
+//      mechanism — it is the damping residual and not some other drift.
+//
+// Run: node witness_cinema_damping_bleed.js [--baseline /path/to/unfixed/worktree]
+
+const http = require('http'), fs = require('fs'), path = require('path');
+let puppeteer;
+try { puppeteer = require('puppeteer'); }
+catch (e) { puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer'); }
+
+const DB = 'buildings/Duplex_extracted.db';
+const DAMPING_FACTOR = 0.08;   // scene.js — the constant this whole defect is made of
+const MIME = { '.html':'text/html','.js':'application/javascript','.css':'text/css','.json':'application/json',
+  '.wasm':'application/wasm','.db':'application/octet-stream','.sql':'application/sql','.jpg':'image/jpeg',
+  '.png':'image/png','.hdr':'application/octet-stream','.svg':'image/svg+xml','.ico':'image/x-icon' };
+
+function serve(root) {
+  return new Promise(res => {
+    const s = http.createServer((q, r) => {
+      let p = path.join(root, decodeURIComponent(q.url.split('?')[0]));
+      fs.stat(p, (e, st) => {
+        if (e) { r.writeHead(404); return r.end(); }
+        if (st.isDirectory()) p = path.join(p, 'index.html');
+        r.writeHead(200, { 'Content-Type': MIME[path.extname(p).toLowerCase()] || 'application/octet-stream', 'Accept-Ranges': 'bytes' });
+        fs.createReadStream(p).pipe(r);
+      });
+    });
+    s.listen(0, '127.0.0.1', () => res({ s, port: s.address().port }));
+  });
+}
+
+async function sample(root, label, secs) {
+  const { s, port } = await serve(root);
+  const b = await puppeteer.launch({ headless: 'new', handleSIGINT: false, defaultViewport: null,
+    args: ['--use-gl=angle','--use-angle=gl','--ignore-gpu-blocklist','--enable-gpu','--no-sandbox','--window-size=1280,800'] });
+  const pg = (await b.pages())[0];
+  const logs = []; pg.on('console', m => logs.push(m.text()));
+  const remote = []; pg.on('response', r => { if (/oraclecloud|objectstorage/.test(r.url())) remote.push(r.url()); });
+  await pg.goto(`http://127.0.0.1:${port}/viewer/viewer.html?db=${encodeURIComponent(DB)}`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await pg.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls, { timeout: 180000 });
+  await new Promise(r => setTimeout(r, 9000));
+
+  // THE PRECONDITION: navigate, exactly as a user does before reaching for Alt+C.
+  await pg.evaluate(() => {
+    const c = window.APP.renderer.domElement, R = c.getBoundingClientRect();
+    const cx = R.left + R.width / 2, cy = R.top + R.height / 2;
+    c.dispatchEvent(new WheelEvent('wheel', { deltaY: -240, clientX: cx, clientY: cy, bubbles: true }));
+    c.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, button: 0, clientX: cx, clientY: cy, bubbles: true }));
+    for (let i = 1; i <= 8; i++)
+      c.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: cx + i * 7, clientY: cy + i * 3, bubbles: true }));
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, button: 0, bubbles: true }));
+  });
+
+  await pg.evaluate(() => {
+    const A = window.APP;
+    window.__d = []; window.__n = 0; window.__cine = false;
+    // Count ONLY the film. '§CINEMA_ORBIT start' is the run's marker and both tips emit it; on the
+    // fixed tip the one-off damping flush happens just BEFORE it, so it is correctly excluded —
+    // that flush lands before the first authored pose and is overwritten by it.
+    const _log = console.log.bind(console);
+    console.log = function () {
+      if (arguments[0] && String(arguments[0]).indexOf('§CINEMA_ORBIT start') === 0) window.__cine = true;
+      return _log.apply(null, arguments);
+    };
+    const orig = A.controls.update.bind(A.controls);
+    A.controls.update = function () {
+      const p = A.camera.position, before = { x: p.x, y: p.y, z: p.z };
+      const r = orig();
+      if (window.__cine) {
+        const drift = Math.hypot(p.x - before.x, p.y - before.y, p.z - before.z);
+        const dist = Math.hypot(p.x - A.controls.target.x, p.y - A.controls.target.y, p.z - A.controls.target.z);
+        window.__d.push({ n: window.__n++, drift: drift, pct: 100 * drift / (dist || 1) });
+      }
+      return r;
+    };
+    A.startCinemaOrbit();
+  });
+  await new Promise(r => setTimeout(r, secs * 1000));
+  let d = []; try { d = await pg.evaluate(() => window.__d); } catch (e) {}
+  await b.close(); s.close();
+  return { label, root, d, ociHits: remote.length,
+           held: logs.some(l => l.indexOf('§CINEMA_DAMPING_BLEED held') === 0) };
+}
+
+(async () => {
+  const bi = process.argv.indexOf('--baseline');
+  const baseline = bi > 0 ? process.argv[bi + 1] : '/tmp/wt-damp-base';
+  const runs = [await sample(baseline, 'BEFORE (unfixed)', 30), await sample(__dirname, 'AFTER  (fixed)', 30)];
+
+  console.log('\n================= §CINEMA_DAMPING_BLEED WITNESS =================');
+  for (const r of runs) {
+    const nz = r.d.filter(x => x.drift > 1e-9);
+    console.log('\n--- ' + r.label + '  (' + r.root + ')');
+    console.log('  update() calls during the film   : ' + r.d.length);
+    console.log('  calls that MOVED the camera      : ' + nz.length);
+    console.log('  §CINEMA_DAMPING_BLEED held       : ' + r.held);
+    console.log('  off-localhost object-storage     : ' + r.ociHits);
+    if (r.d.length) {
+      console.log('  drift, first 8 frames (% of look distance):');
+      console.log('    ' + r.d.slice(0, 8).map(x => x.pct.toFixed(3) + '%').join('  '));
+      console.log('  max drift anywhere in the film   : ' + Math.max(...r.d.map(x => x.drift)).toFixed(6) + ' m');
+    }
+  }
+  const before = runs[0], after = runs[1];
+  // Decay ratio across the pure-decay stretch (skip frames 0-1: the rotate residual and the zoom
+  // scale residual are still both unwinding there).
+  let ratios = [];
+  for (let i = 3; i < Math.min(14, before.d.length); i++)
+    if (before.d[i - 1].pct > 1e-6) ratios.push(before.d[i].pct / before.d[i - 1].pct);
+  const meanRatio = ratios.length ? ratios.reduce((a, b) => a + b, 0) / ratios.length : NaN;
+
+  console.log('\n--- GATES');
+  const g = [];
+  const afterMax = after.d.length ? Math.max(...after.d.map(x => x.drift)) : Infinity;
+  g.push(['G1 fixed: controls.update() never moves the authored pose (max drift = 0)',
+          after.d.length > 0 && afterMax < 1e-9 && after.held, afterMax.toFixed(9) + ' m over ' + after.d.length + ' calls']);
+  g.push(['G2 control: unfixed tip drifts > 1% of look distance on frame 0',
+          before.d.length > 0 && before.d[0].pct > 1.0, (before.d.length ? before.d[0].pct.toFixed(3) : '0') + '%']);
+  g.push(['G3 control: that drift decays at exactly 1 - dampingFactor (' + (1 - DAMPING_FACTOR).toFixed(2) + '), naming the mechanism',
+          Math.abs(meanRatio - (1 - DAMPING_FACTOR)) < 0.01, 'measured ' + (isNaN(meanRatio) ? 'n/a' : meanRatio.toFixed(4))]);
+  let pass = 0;
+  for (const [n, ok, v] of g) { console.log('  ' + (ok ? 'PASS' : 'FAIL') + '  ' + n + '  [' + v + ']'); if (ok) pass++; }
+  console.log('\n  ' + pass + '/' + g.length + ' gates green');
+  console.log('=================================================================');
+  process.exit(pass === g.length ? 0 : 1);
+})().catch(e => { console.error('WITNESS CRASH ' + (e && e.stack || e)); process.exit(1); });


### PR DESCRIPTION
## The report
> "there is a slight twitch at the first second of the movie, where the screen size is adjusted slightly narrower. Tested on two buildings it is so."

## It is not a resize — ruled out by measurement, not by reading code
- `window.innerWidth`, canvas backing/client size, `camera.aspect`, `camera.fov`, `devicePixelRatio`, composer render-target size, sampled **every animation frame** across the MaxQ 10 s preview, a full MaxQ bake, and a full live-capture recording, at **dpr 1 and 2** → **zero changes to any of them, ever**.
- A decoded recording: `1280×713`, coded `1280×713`, SAR 1:1, constant on every frame.
- The reporter's own three films: dimensions constant within each file (1852×960 / 1854×962).

## What the films actually show
Frames extracted and analysed numerically (best-fit uniform zoom about the centre; re-fit with each frame contrast-normalised so a lighting step can't masquerade as a scale change):

| | push-in/frame before | the event | after |
|---|---|---|---|
| Hospital | +0.4 → +1.0 % | **f4→5 stalls to +0.0 %, f5→6 breaks** (residual 0.907 vs ~0.16) | steady **+2.6 %** |
| TerminalMerged | +0.2 → +1.0 % | **f9→10 reverses to −0.4 %** (residual 0.184 vs 0.062) | steady **+1.4→1.6 %** |

Brightness resets to its own frame-0 value at the same instant (Terminal 27.7 → **25.7** = exactly frame 0). Signature: **the first frames advance too slowly, then the film catches up.**

## Root cause — proven by its decay constant
`scene.js` sets `enableDamping = true`, `dampingFactor = 0.08`. Every authored loop does `camera.position.set(pose)` → `controls.target.set(...)` → **`controls.update()`**, and `OrbitControls.update()` recomputes the position from its *own* spherical state with the dampened deltas applied — **overwriting the pose the plan just authored**.

Wrapping `update()` during a real recording, with a wheel+drag dispatched first (the realistic precondition), measuring "pose as set" vs "pose after update()", as a fraction of the camera→target distance:

```
frame 0: 1.637%   frame 4: 1.175%   frame 8: 0.846%   frame 12: 0.608%
frame 1: 1.497%   frame 5: 1.076%   frame 9: 0.776%   frame 16: 0.436%
```

**Ratio between consecutive frames = 0.92 = 1 − dampingFactor.** That's the fingerprint — it is the damping residual and nothing else. ~1.6 % at frame 0, needing 1–2 s to decay below visibility: exactly "the first second of the movie", and exactly the magnitude of the framing error measured in the films.

It never reproduced in the first probes because those pressed Alt+C from a **clean, untouched camera** — no residual to bleed. A real user always navigates first.

## Fix
Damping is an *interaction* affordance; an authored camera must not be subject to it. Hold `enableDamping` off for the run, flush the residual **before frame 0**, restore on every exit path. `update()` is still called each frame (it has other duties) — with damping off it applies zeroed deltas and preserves the authored position exactly. Applied to all three authored loops: the live capture (`effects.js`), and the MaxQ preview + bake (`cinema_maxq.js`).

## Witness — `witness_cinema_damping_bleed.js`, 3/3
```
PASS  G1 fixed: controls.update() never moves the authored pose  [0.000000000 m over 2519 calls]
PASS  G2 control: unfixed tip drifts > 1% of look distance on frame 0  [1.387%]
PASS  G3 control: that drift decays at exactly 1 - dampingFactor (0.92)  [measured 0.9200]
```
The witness dispatches a real wheel+drag before starting — **without that precondition it proves nothing**, and that's called out at the top of the file. G2/G3 run against the unfixed tip so the gate is shown to discriminate.

## Recorded, not fixed here
The mp4 path grabs frames at `w×h` but configures H.264 at `(w & ~1, h & ~1)` and draws 1:1 — an odd-height canvas **silently loses one pixel row**. Constant across frames, invisible, but real.

Full spec: `bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §CINEMA_DAMPING_BLEED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)