### PR TITLE
fix(staffage): §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM — one sprite for everyone, and figures 3.5 m in the air

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -912,6 +912,10 @@ async function setupEffects(A, renderer, scene, camera) {
   // show `§HELPERS_QUERY_ERR no such table: storey_walkable_raster`, so it cannot carry a rule that
   // must hold on every building.
   var _clrRay = new THREE.Raycaster();
+  // §STAFFAGE_FLOOR_PHANTOM tuning. MIN_LIFT: below this a wrong floor pick is not visible as
+  // "in the air", and a coincident-surface ray can self-miss — not worth a false reject. TOL: how
+  // far below the bbox's claimed slab top a real triangle may be and still count as that floor.
+  var _FLOOR_PHANTOM_MIN_LIFT = 0.75, _FLOOR_PHANTOM_TOL = 0.60;
   // Real-geometry meshes only — staffage's own sprites/car meshes must never count as an obstruction
   // (and must never read as a "ceiling"). Collected once per press by the caller, not per candidate.
   function _solidMeshes() {
@@ -1051,7 +1055,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // outside people on the terrain). One slab list, in-memory point-in-footprint test — not a
     // per-figure DB query.
     var _slabs = A.dbQuery("SELECT center_x, center_y, center_z, bbox_x, bbox_y, bbox_z FROM element_transforms t JOIN elements_meta m ON t.guid=m.guid WHERE m.ifc_class IN ('IfcSlab','IfcSlabStandardCase') AND t.bbox_z IS NOT NULL AND t.bbox_z < 1.5 AND t.center_x IS NOT NULL") || [];
-    var _floorSlab = 0, _floorGround = 0;
+    var _floorSlab = 0, _floorGround = 0, _floorPhantom = 0;
     function _floorThreeY(x, y, refZ) {
       var best = null;
       for (var si = 0; si < _slabs.length; si++) {
@@ -1060,7 +1064,34 @@ async function setupEffects(A, renderer, scene, camera) {
           if (best === null || top > best) best = top;
         }
       }
-      if (best !== null) { _floorSlab++; return A.ifc2three(x, y, best).y; }
+      if (best !== null) {
+        var slabY = A.ifc2three(x, y, best).y;
+        // §STAFFAGE_FLOOR_PHANTOM (2026-07-26, user: "some will stand in air outside first floor").
+        // The loop above is a pure AXIS-ALIGNED BBOX test, and this file's own §STAFFAGE_GROUNDSNAP
+        // lesson is that BBOXES LIE: an exterior spot can sit inside an upper slab's bounding
+        // RECTANGLE while being nowhere near its real geometry — the notch of an L-shaped plate, a
+        // courtyard, or just past a facade edge inside the 0.5m tolerance. The spot is then lifted
+        // to that floor's height with nothing under it: a figure standing in mid-air outside the
+        // building. Same defect class, same remedy already trusted elsewhere in this file — ask the
+        // real rendered triangles (BVH raycaster), not the bbox.
+        // Only checked when the lift is big enough to actually read as floating; at ground level a
+        // coincident-surface ray can self-miss and a false reject would be worse than the symptom.
+        var lift = slabY - _staffageGroundY;
+        if (lift > _FLOOR_PHANTOM_MIN_LIFT && typeof _solids !== 'undefined' && _solids && _solids.length) {
+          var p3 = A.ifc2three(x, y, best);
+          _clrRay.set(new THREE.Vector3(p3.x, slabY + 1.0, p3.z), new THREE.Vector3(0, -1, 0));
+          _clrRay.far = 1.0 + _FLOOR_PHANTOM_TOL;
+          var hits = _clrRay.intersectObjects(_solids, false);
+          if (!hits.length) {
+            _floorPhantom++;
+            console.log('§STAFFAGE_FLOOR_PHANTOM bbox slab at y=' + slabY.toFixed(2) + ' (lift=' +
+              lift.toFixed(2) + 'm) has NO real geometry beneath — falling back to groundY=' +
+              _staffageGroundY.toFixed(2));
+            _floorGround++; return _staffageGroundY;
+          }
+        }
+        _floorSlab++; return slabY;
+      }
       _floorGround++; return _staffageGroundY;
     }
     // Place a figure at IFC (x,y), feet on the actual floor slab under it (raised floors respected),
@@ -1225,7 +1256,18 @@ async function setupEffects(A, renderer, scene, camera) {
       // §STAFFAGE_FACADE_FACING (user: "they should be camera facing - facade") — also restrict to
       // facing==='toward' (the face-on shot, reads as looking at the viewer) — the 'away'-facing
       // standing pose is shot from behind and would read as looking away from a facade-facing camera.
-      var outsidePoses = _STAFFAGE_PEOPLE.filter(function(p) { return p.role === 'stand' && p.facing === 'toward'; });
+      // §STAFFAGE_OUTSIDE_VARIETY (2026-07-26, user: "Alt-P made outside standing persons the same,
+      // should be the diff standing sprites" — live log showed 3 placed and all three the SAME male).
+      // The old filter was `role==='stand' && facing==='toward'`, and EXACTLY ONE asset in
+      // _STAFFAGE_PEOPLE satisfies both (person_standing_casual_male: the other 'stand' pose is
+      // 'away'). So outsidePoses.length was 1 and `placedP % length` was always 0 — every exterior
+      // figure on every building was that one cutout. Not intermittent, not a draw-luck artifact.
+      // Widening it does NOT re-litigate §STAFFAGE_FACING, it applies it: that doctrine says route
+      // each pose where its FIXED orientation makes sense, and its own worked example is "the lady
+      // with bags... facing to the building" — an 'away' pose reads as moving toward whatever is
+      // beyond her, which outside a building is the building. 'toward' (facing the camera) also
+      // reads fine outdoors. Only 'sit' is excluded: there is nothing to sit on out here.
+      var outsidePoses = _shuffle(_STAFFAGE_PEOPLE.filter(function(p) { return p.role !== 'sit'; }).slice());
       var doors = A.dbQuery("SELECT et.center_x, et.center_y, et.center_z, et.bbox_z, MAX(COALESCE(et.bbox_x,0), COALESCE(et.bbox_y,0)) FROM element_transforms et JOIN elements_meta em ON et.guid=em.guid WHERE em.ifc_class='IfcDoor' AND et.center_x IS NOT NULL") || [];
       var ext = [];
       for (var di = 0; di < doors.length; di++) {
@@ -1271,6 +1313,7 @@ async function setupEffects(A, renderer, scene, camera) {
       pSrc = gfExt.length ? 'entrance+silhouette' : 'silhouette';
       _shuffle(candSpots);
       var _paxTried = candSpots.length, _rejFBefore = _rejFrustum, _rejOBefore = _rejOcclude, _rejDedup = 0;
+      var _outsideUsed = [];
       for (var si2 = 0; si2 < candSpots.length && thisPressPax < PAX_CAP; si2++) {
         var sp = candSpots[si2], pos3 = A.ifc2three(sp[0], sp[1], sp[2]); pos3.y = _floorThreeY(sp[0], sp[1], sp[2]);
         var inF = _inFrame(pos3);
@@ -1281,9 +1324,11 @@ async function setupEffects(A, renderer, scene, camera) {
         // wings) sits INSIDE another part of the building — frustum+occlusion never noticed.
         if (!_spaceOK(_solids, 'pax', pos3)) continue;
         var pose = outsidePoses[placedP % outsidePoses.length];
+        _outsideUsed.push(pose.file.replace('people/person_', '').replace('.png', ''));
         _placeAt(pose, sp[0], sp[1], sp[2], true);
         placedP++; thisPressPax++;
       }
+      console.log('§STAFFAGE_OUTSIDE_VARIETY pool=' + outsidePoses.length + ' used=[' + _outsideUsed.join(',') + '] distinct=' + (new Set(_outsideUsed)).size);
       console.log('§STAFFAGE_PAX_REJECT tried=' + _paxTried + ' placed=' + thisPressPax + ' rejFrustum=' + (_rejFrustum - _rejFBefore) + ' rejOcclude=' + (_rejOcclude - _rejOBefore) + ' rejDedup=' + _rejDedup);
       if (!thisPressPax) {
         // §STAFFAGE_WIDE_FALLBACK (2026-07-18, user: "the 4/1/2 formula should apply any building"
@@ -1537,7 +1582,7 @@ async function setupEffects(A, renderer, scene, camera) {
     var _fMin = Infinity, _fMax = -Infinity;
     _photoStaffage.children.forEach(function(s) { var dy = (s.position.y + (s.userData.baseOffset || 0)) - _staffageGroundY; if (dy < _fMin) _fMin = dy; if (dy > _fMax) _fMax = dy; });
     if (!_photoStaffage.children.length) { _fMin = 0; _fMax = 0; }
-    console.log('§PHOTO_STAFFAGE thisPress(people=' + placedP + ' trees=' + placedT + ') cumulative(people=' + _photoStaffage.userData.counts.people + ' trees=' + _photoStaffage.userData.counts.trees + ' cars=' + _photoStaffage.userData.counts.cars + ') pSrc=' + pSrc + ' floor=slab:' + _floorSlab + '/ground:' + _floorGround + ' feetVsGroundY=[' + _fMin.toFixed(2) + ',' + _fMax.toFixed(2) + '] groundY=' + _staffageGroundY.toFixed(2) + ' slabs=' + _slabs.length + ' build_ms=' + (performance.now() - _bt0).toFixed(0) + ' (realPeople=' + realPeople + ' realTrees=' + realTrees + ' realCars=' + realCars + ')');
+    console.log('§PHOTO_STAFFAGE thisPress(people=' + placedP + ' trees=' + placedT + ') cumulative(people=' + _photoStaffage.userData.counts.people + ' trees=' + _photoStaffage.userData.counts.trees + ' cars=' + _photoStaffage.userData.counts.cars + ') pSrc=' + pSrc + ' floor=slab:' + _floorSlab + '/ground:' + _floorGround + '/phantom:' + _floorPhantom + ' feetVsGroundY=[' + _fMin.toFixed(2) + ',' + _fMax.toFixed(2) + '] groundY=' + _staffageGroundY.toFixed(2) + ' slabs=' + _slabs.length + ' build_ms=' + (performance.now() - _bt0).toFixed(0) + ' (realPeople=' + realPeople + ' realTrees=' + realTrees + ' realCars=' + realCars + ')');
     // §STAFFAGE_REAL_DEDUP witness (spec S1): how many real entourage positions guarded, how many
     // synthetic candidates they rejected this press.
     console.log('§STAFFAGE_REAL_DEDUP n=' + _realDedup.length + ' rejReal=' + _rejReal);
@@ -3276,7 +3321,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v14 (§CINEMA_TURN_SLERP look-back + §CINEMA_DAMPING_BLEED authored-pose hold)';
+  var EFFECTS_V = 'v15 (§STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v850';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v851';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_staffage_outside.js
+++ b/witness_staffage_outside.js
@@ -1,0 +1,88 @@
+// WITNESS — §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM
+// (prompts/STAFFAGE_WALKABLE_PLACEMENT.md, user report 2026-07-26).
+//
+// ISSUE PROVEN/DISPROVEN:
+//   (1) "Alt-P made outside standing persons the same, should be the diff standing sprites."
+//   (2) "And some will stand in air outside first floor etc."
+//
+// Whitebox per the project rule: drives a REAL Alt+P keypress and reads the §-lines. No screenshots.
+//
+//   G1 the exterior pose pool has more than one asset (the defect was a filter that matched exactly
+//      ONE entry of _STAFFAGE_PEOPLE, so `placedP % pool.length` was always 0).
+//   G2 when >1 exterior figure is placed in a press, they are NOT all the same sprite.
+//   G3 no figure is left standing on a bbox-only "slab" — every press reports phantom rejections
+//      that were CAUGHT (a fallback to groundY), never a silent lift, and the run stays clean.
+//   G4 control: the unfixed tip reports pool=1, i.e. the gate discriminates.
+//
+// Run: node witness_staffage_outside.js [--baseline /path/to/unfixed/worktree]
+const http=require('http'), fs=require('fs'), path=require('path');
+let puppeteer; try{puppeteer=require('puppeteer');}catch(e){puppeteer=require('/home/red1/bim-compiler/node_modules/puppeteer');}
+const DB = process.env.WDB || 'buildings/Duplex_extracted.db';
+const MIME={'.html':'text/html','.js':'application/javascript','.css':'text/css','.json':'application/json','.wasm':'application/wasm','.db':'application/octet-stream','.sql':'application/sql','.jpg':'image/jpeg','.png':'image/png','.hdr':'application/octet-stream','.svg':'image/svg+xml','.ico':'image/x-icon'};
+function serve(root){return new Promise(res=>{const s=http.createServer((q,r)=>{let p=path.join(root,decodeURIComponent(q.url.split('?')[0]));fs.stat(p,(e,st)=>{if(e){r.writeHead(404);return r.end();}if(st.isDirectory())p=path.join(p,'index.html');r.writeHead(200,{'Content-Type':MIME[path.extname(p).toLowerCase()]||'application/octet-stream','Accept-Ranges':'bytes'});fs.createReadStream(p).pipe(r);});});s.listen(0,'127.0.0.1',()=>res({s,port:s.address().port}));});}
+async function run(root,label,presses){
+  const {s,port}=await serve(root);
+  const b=await puppeteer.launch({headless:'new',handleSIGINT:false,defaultViewport:null,
+    args:['--use-gl=angle','--use-angle=gl','--ignore-gpu-blocklist','--enable-gpu','--no-sandbox','--window-size=1280,800']});
+  const pg=(await b.pages())[0]; const logs=[]; pg.on('console',m=>logs.push(m.text()));
+  await pg.goto(`http://127.0.0.1:${port}/viewer/viewer.html?db=${encodeURIComponent(DB)}`,{waitUntil:'domcontentloaded',timeout:120000});
+  await pg.waitForFunction(()=>window.APP&&window.APP.camera,{timeout:180000});
+  await new Promise(r=>setTimeout(r,12000));
+  for(let i=0;i<presses;i++){
+    await pg.keyboard.down('Alt'); await pg.keyboard.press('p'); await pg.keyboard.up('Alt');
+    await new Promise(r=>setTimeout(r,9000));
+  }
+  await b.close(); s.close();
+  return {label,root,logs};
+}
+(async()=>{
+  const bi=process.argv.indexOf('--baseline');
+  const baseline=bi>0?process.argv[bi+1]:null;
+  const runs=[]; if(baseline) runs.push(await run(baseline,'BEFORE (unfixed)',3));
+  runs.push(await run(__dirname,'AFTER  (fixed)',3));
+  console.log('\n========== §STAFFAGE_OUTSIDE_VARIETY / §STAFFAGE_FLOOR_PHANTOM WITNESS ==========');
+  const R={};
+  for(const r of runs){
+    const varie=r.logs.filter(l=>l.startsWith('§STAFFAGE_OUTSIDE_VARIETY'));
+    const summ=r.logs.filter(l=>l.startsWith('§PHOTO_STAFFAGE thisPress'));
+    const phan=r.logs.filter(l=>l.startsWith('§STAFFAGE_FLOOR_PHANTOM'));
+    let pool=null, multi=[], distinctOK=true;
+    for(const l of varie){
+      const m=/pool=(\d+) used=\[([^\]]*)\] distinct=(\d+)/.exec(l); if(!m) continue;
+      pool=Number(m[1]); const used=m[2]?m[2].split(','):[]; const d=Number(m[3]);
+      if(used.length>1){ multi.push(used.length+'->'+d+' distinct'); if(d<2) distinctOK=false; }
+    }
+    R[r.label.slice(0,6).trim()]={pool,multi,distinctOK,phan:phan.length,summ};
+    console.log('\n--- '+r.label);
+    console.log('  exterior pose pool size    : '+(pool===null?'(no exterior press logged)':pool));
+    varie.slice(0,3).forEach(l=>console.log('    '+l));
+    console.log('  §STAFFAGE_FLOOR_PHANTOM catches: '+phan.length);
+    phan.slice(0,3).forEach(l=>console.log('    '+l));
+    summ.slice(0,3).forEach(l=>console.log('    '+l.slice(0,150)));
+  }
+  const A=R['AFTER'], B=R['BEFORE'];
+  let basePool=null;
+  if(baseline){
+    const src=fs.readFileSync(path.join(baseline,'viewer/effects.js'),'utf8');
+    const tbl=/var _STAFFAGE_PEOPLE = \[([\s\S]*?)\];/.exec(src);
+    const usesOldFilter=/outsidePoses = _STAFFAGE_PEOPLE\.filter\(function\(p\) \{ return p\.role === 'stand' && p\.facing === 'toward'; \}\)/.test(src);
+    if(tbl&&usesOldFilter)
+      basePool=tbl[1].split('\n').filter(l=>/role: 'stand'/.test(l)&&/facing: 'toward'/.test(l)).length;
+    console.log('\n  control, read from the unfixed source: usesOldFilter='+usesOldFilter+' -> pool='+basePool);
+  }
+  console.log('\n--- GATES');
+  const g=[];
+  g.push(['G1 exterior pose pool has >1 asset', A.pool!==null&&A.pool>1, 'pool='+A.pool]);
+  g.push(['G2 a multi-figure press is not all the same sprite', A.multi.length===0?true:A.distinctOK,
+          A.multi.length?A.multi.join(' | '):'no multi-figure press in this run (pool gate G1 carries it)']);
+  // G3 must not pass vacuously. With zero phantom slabs on this building there is no evidence
+  // either way, so say so instead of printing a green that proves nothing.
+  if(A.phan>0) g.push(['G3 phantom-slab lifts CAUGHT and fell back to groundY (no silent lift)', true, A.phan+' caught']);
+  else console.log('  ----  G3 NOT EXERCISED on this building: 0 bbox-only slabs encountered, so the');
+  if(A.phan===0) console.log('        phantom path proves nothing here. G1/G2 carry this run.');
+  if(baseline) g.push(['G4 control: unfixed tip pool is exactly 1 (the gate discriminates)',
+                       basePool===1, 'pool='+basePool+' (from source)']);
+  let pass=0; for(const [n,ok,v] of g){console.log('  '+(ok?'PASS':'FAIL')+'  '+n+'  ['+v+']'); if(ok)pass++;}
+  console.log('\n  '+pass+'/'+g.length+' gates green');
+  process.exit(pass===g.length?0:1);
+})().catch(e=>{console.error('WITNESS CRASH '+(e&&e.stack||e));process.exit(1);});


### PR DESCRIPTION
> "Alt-P made outside standing persons the same, should be the diff standing sprites. And some will stand in air outside first floor etc."

Reported on JKR; their log showed `placed=3` and all three the same male.

## Defect 1 — the exterior pose pool contained exactly ONE asset
```js
var outsidePoses = _STAFFAGE_PEOPLE.filter(p => p.role === 'stand' && p.facing === 'toward');
var pose = outsidePoses[placedP % outsidePoses.length];
```
Exactly one entry of `_STAFFAGE_PEOPLE` satisfies **both** predicates — `person_standing_casual_male` (the other `'stand'` pose is `'away'`). So `length === 1`, the modulo was **always 0**, and every exterior figure on every building was that one cutout. Deterministic — it could never have varied.

Widening it **applies** §STAFFAGE_FACING rather than re-litigating it: that doctrine routes each pose to where its fixed orientation makes sense, and its own worked example is *"the lady with bags... facing to the building"* — an `'away'` pose reads as moving toward whatever is beyond her, which outside a building is the building. Only `'sit'` is excluded. **Pool 1 → 4**, shuffled per press so repeat presses differ too.

## Defect 2 — `_floorThreeY` is a pure bbox test, and this file already knows bboxes lie
The floor lookup accepted any slab whose **axis-aligned bounding rectangle** covers the sample point (`|x−cx| ≤ w/2+0.5 && |y−cy| ≤ d/2+0.5`). An exterior candidate on the silhouette ring can sit inside an upper slab's bounding rectangle while being nowhere near its real geometry — an L-notch, a courtyard, or just past a facade edge inside the 0.5 m tolerance — and gets lifted to that floor with **nothing under it**.

Same defect class as §STAFFAGE_GROUNDSNAP and §STAFFAGE_WALK_FLOOR_FIX, which fixed it for the *interior/walk* path; the exterior path still had it. Same remedy, same machinery already trusted in this file: when the chosen slab would lift a figure > 0.75 m above ground, ask the **real rendered triangles** (BVH raycaster) whether anything is actually beneath; if not, fall back to `groundY` and log it. Only above that lift threshold — at ground level a coincident-surface ray can self-miss, and a false reject is worse than the symptom.

## Witness — `witness_staffage_outside.js`, 4/4 on JKR (the reporter's own building)
Drives a real Alt+P keypress and reads the §-lines.

```
PASS  G1 exterior pose pool has >1 asset  [pool=4]
PASS  G2 a multi-figure press is not all the same sprite  [3->3 distinct | 3->3 distinct | 3->3 distinct]
PASS  G3 phantom-slab lifts CAUGHT and fell back to groundY (no silent lift)  [2 caught]
PASS  G4 control: unfixed tip pool is exactly 1 (the gate discriminates)  [pool=1 (from source)]
```

The reported mid-air figures, reproduced and measured:
```
§STAFFAGE_FLOOR_PHANTOM bbox slab at y=-0.40 (lift=3.50m) has NO real geometry beneath — falling back to groundY=-3.90
§STAFFAGE_FLOOR_PHANTOM bbox slab at y=-0.35 (lift=3.55m) has NO real geometry beneath — falling back to groundY=-3.90
```

**3.5 m in the air**, outside the building.

Two witness-design notes: G3 reports **NOT EXERCISED** rather than a green when a building yields no bbox-only slabs (Duplex and Hospital both do) — a gate that passes on zero evidence proves nothing. G4 is derived from the baseline's *source*, because the unfixed tip cannot emit a log that doesn't exist in it.

New per-press fields: `§STAFFAGE_OUTSIDE_VARIETY pool=N used=[...] distinct=N`, and `phantom:N` on `§PHOTO_STAFFAGE`'s `floor=` breakdown.

Full spec: `bim-compiler prompts/STAFFAGE_WALKABLE_PLACEMENT.md §2026-07-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)