### PR TITLE
feat(cinema): §CINEMA_PATH_EDITOR — waypoint editor in the Alt+C gap

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -455,6 +455,48 @@
       }
       console.log('§MAXQ_PREVIEW done — camera restored, commencing capture');
     }
+    // ══ §CINEMA_PATH_EDITOR (prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL item 12): the
+    // waypoint editor opens HERE — after the preview has shown the path and put the camera back.
+    //
+    // Item 20, a real defect this placement exposes and must fix: `A._maxqActive`, the wake lock and
+    // the damping hold are all claimed at the TOP of start(), before the plan and preview. In
+    // particular `A._maxqActive` makes dlod_nav.js:307 report 'cinema' and fully disengage DLOD. A
+    // user editing for five minutes would otherwise hold a screen wake lock and run Terminal/Hospital
+    // at full detail with no LOD the entire time. So all three are released for the duration of the
+    // editor and re-claimed on OK. Gated by G11 — proven released, not merely described as released.
+    if (A.cinemaPathEditor && plan && plan.waypoints && opts.editor !== false) {
+      A._maxqActive = false;
+      _wakeRelease(); _dampRelease();
+      console.log('§CPE_LOCKS released for editing (maxqActive=false, wake+damping released)');
+      _status('🎬 Edit the path, then OK to record');
+      var _cpeRes = null;
+      try {
+        _cpeRes = await A.cinemaPathEditor.open({ plan: plan, durationSec: nFrames / fps, fps: fps });
+      } catch (eE) { console.warn('§CPE_FAIL ' + eE.message + ' — proceeding with the derived path'); }
+      A._maxqActive = true;
+      _wakeAcquire(); _dampHold();
+      console.log('§CPE_LOCKS re-claimed for the bake (maxqActive=true)');
+      if (_cpeRes && _cpeRes.action === 'cancel') {
+        console.log('§MAXQ_CANCEL from path editor — nothing baked, nothing saved');
+        _status('🎬 Cancelled');
+        _active = false; _cancel = false; A._maxqActive = false;
+        _wakeRelease(); _dampRelease();
+        return;
+      }
+      if (_cpeRes && _cpeRes.override) {
+        // Constant speed means an edited path generally changes the total, so the frame count is
+        // re-derived from it (item 11 — this is the render cost the editor surfaced).
+        nFrames = Math.max(1, Math.round(_cpeRes.durationSec * fps));
+        plan = A.cinemaPathPlan(nFrames / fps, _cpeRes.override);
+        console.log('§CPE_APPLIED total=' + _cpeRes.durationSec.toFixed(1) + 's frames=' + nFrames +
+          ' waypoints=' + _cpeRes.override.waypoints.length + ' saved=' + !!_cpeRes.saved);
+      } else {
+        // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
+        // literally the same object, so the film is byte-identical to one recorded without the
+        // editor existing. The default cost of this feature is one click and nothing else.
+        console.log('§CPE_APPLIED none — derived plan unchanged (guardrail 2: OK is a no-op)');
+      }
+    }
     var db = null;
     var framesDone = 0;
     var _idbLost = false;

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1,0 +1,540 @@
+// §CINEMA_PATH_EDITOR — the simplest fastest tour maker.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL (settled with the user
+// 2026-07-26). Opens AFTER the Alt+C 10s preview, with the camera already back at its initial pose.
+//
+// The whole model in four lines, because everything else here follows from them:
+//   1. Waypoints are the ONLY authored data — position + camera height. Nothing else is stored.
+//   2. Camera angle is NEVER authored. It is LOS toward the next waypoint. That is why the table
+//      carries one extra final row: the stopping waypoint exists to give the last leg something to
+//      look at, and dragging waypoint n+1 IS how you change waypoint n's camera angle.
+//   3. Waypoints are CONTROL points, not corners — effects.js `_cinemaRoundCorners` cuts inside
+//      every corner, bounded by measured clearance, so a sharp corner cannot occur.
+//   4. Constant speed: path length sets the clock. The total is then editable and scales the whole
+//      film uniformly.
+(function() {
+  'use strict';
+  var CPE_V = 'v1 (§CINEMA_PATH_EDITOR_MODEL — LOS aim, clearance-bounded corners, constant speed)';
+  console.log('§CPE_LOADED ' + CPE_V);
+
+  // Held-point verbs mirror the viewer's own navigation verbs (user: "isn't that intuitive?").
+  // drag = horizontal (x,z) · ctrl+drag = vertical (camera height) · wheel = still scene zoom.
+  var DRAG_VERT_M_PER_PX = 0.02;   // ctrl+drag pixels → metres of height
+  var MARKER_R = 0.35;             // metres; hit radius is scaled up separately for easy grabbing
+  var GRAB_PX = 18;                // screen-space grab tolerance around a marker
+
+  var _A = null, _state = null;
+
+  function A() { return window.APP; }
+
+  // ── §SELECT-PULSE reuse (navigate_find.js:2160-2227): generation counter + rAF + markDirty, and
+  // depthTest:false/renderOrder so the marker SHINES THROUGH WALLS. That last property is
+  // load-bearing, not decoration — when the editor opens the camera is outside the building, so a
+  // depth-tested marker sitting in a room would simply not be visible at all.
+  function _mkMarker(p, color) {
+    var a = A();
+    var geo = new THREE.SphereGeometry(MARKER_R, 12, 10);
+    var mat = new THREE.MeshBasicMaterial({ color: color, transparent: true, opacity: 0.9,
+                                            depthTest: false, depthWrite: false });
+    var m = new THREE.Mesh(geo, mat);
+    m.position.set(p.x, p.y, p.z);
+    m.renderOrder = 1003;
+    m.userData._cpeMarker = true;
+    a.scene.add(m);
+    return m;
+  }
+
+  function _mkLine(points, color, width) {
+    var a = A();
+    var geo = new THREE.BufferGeometry();
+    var arr = new Float32Array(points.length * 3);
+    for (var i = 0; i < points.length; i++) { arr[i * 3] = points[i].x; arr[i * 3 + 1] = points[i].y; arr[i * 3 + 2] = points[i].z; }
+    geo.setAttribute('position', new THREE.BufferAttribute(arr, 3));
+    var mat = new THREE.LineBasicMaterial({ color: color, transparent: true, opacity: 0.95, depthTest: false });
+    var l = new THREE.Line(geo, mat);
+    l.renderOrder = 1002;
+    l.userData._cpeMarker = true;
+    a.scene.add(l);
+    return l;
+  }
+
+  function _clearScene() {
+    var a = A();
+    if (!_state) return;
+    (_state.objs || []).forEach(function(o) {
+      if (o.parent) o.parent.remove(o);
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) o.material.dispose();
+    });
+    _state.objs = [];
+    _state.markers = [];
+    if (a && a.markDirty) a.markDirty();
+  }
+
+  // ── The flown curve, drawn from the SAME function the plan flies (effects.js
+  // `_cinemaRoundCorners`). Drawing it any other way would make the picture a second, drifting
+  // implementation of the path — the exact thing the prime rule forbids.
+  function _redrawScene() {
+    var a = A();
+    _clearScene();
+    if (!a.scene || typeof THREE === 'undefined') return;
+    var wp = _state.wp;
+    var flown = (typeof a.cinemaRoundCorners === 'function') ? a.cinemaRoundCorners(wp) : wp;
+    _state.objs.push(_mkLine(flown, 0x4fc3f7, 2));
+    for (var i = 0; i < wp.length; i++) {
+      var held = (i === _state.held);
+      var sel = (i === _state.sel);
+      var m = _mkMarker(wp[i], held ? 0xffcc00 : sel ? 0xffffff : 0x4fc3f7);
+      m.userData._cpeIndex = i;
+      _state.objs.push(m);
+      _state.markers.push(m);
+    }
+    if (a.markDirty) a.markDirty();
+  }
+
+  function _pulse(idx) {
+    var a = A();
+    if (!_state || !_state.markers[idx]) return;
+    var m = _state.markers[idx];
+    var myPulse = ++_state.pulseId;
+    var t = 0;
+    (function frame() {
+      if (!_state || myPulse !== _state.pulseId || !m.parent) return;
+      t += 0.06; if (t > 1) t = 1;
+      var e = 1 - Math.pow(1 - t, 3);
+      var k = 1 - e;
+      m.scale.setScalar(1 + k * 1.8);
+      m.material.opacity = 0.9 - k * 0.3;
+      if (a.markDirty) a.markDirty();
+      if (t < 1) requestAnimationFrame(frame);
+      else { m.scale.setScalar(1); m.material.opacity = 0.9; if (a.markDirty) a.markDirty(); }
+    })();
+  }
+
+  // ── Frame a waypoint: back the camera up so the point is genuinely in view and grabbable
+  // (§CINEMA_PATH_EDITOR_MODEL item 13). Distance comes from MEASURED clearance where available —
+  // in a tight room you must be close or the walls fill the frame; in a hall you want to be back
+  // far enough to see the neighbouring legs.
+  function _frameWaypoint(idx) {
+    var a = A();
+    var p = _state.wp[idx];
+    var clear = 6;
+    try { var f = a.cinemaFan ? a.cinemaFan({ x: p.x, y: p.y, z: p.z }, 8) : null; if (f && isFinite(f.min)) clear = f.min; } catch (e) {}
+    var dist = Math.max(5, Math.min(30, clear * 2.5));
+    var dir = new THREE.Vector3();
+    a.camera.getWorldDirection(dir);
+    if (!isFinite(dir.x) || (!dir.x && !dir.z)) dir.set(0, 0, 1);
+    var to = { x: p.x - dir.x * dist, y: p.y - dir.y * dist + dist * 0.35, z: p.z - dir.z * dist };
+    var from = { x: a.camera.position.x, y: a.camera.position.y, z: a.camera.position.z };
+    var tFrom = { x: a.controls.target.x, y: a.controls.target.y, z: a.controls.target.z };
+    var gen = ++_state.flyId, t0 = performance.now(), DUR = 420;
+    (function step() {
+      if (!_state || gen !== _state.flyId) return;
+      var u = Math.min(1, (performance.now() - t0) / DUR);
+      var e = 1 - Math.pow(1 - u, 3);
+      a.camera.position.set(from.x + (to.x - from.x) * e, from.y + (to.y - from.y) * e, from.z + (to.z - from.z) * e);
+      a.controls.target.set(tFrom.x + (p.x - tFrom.x) * e, tFrom.y + (p.y - tFrom.y) * e, tFrom.z + (p.z - tFrom.z) * e);
+      a.controls.update();
+      if (a.markDirty) a.markDirty();
+      if (u < 1) requestAnimationFrame(step);
+    })();
+  }
+
+  // ══ Timing — §CINEMA_PATH_EDITOR_MODEL items 9-11. Constant speed: the metres-per-second implied
+  // by the ORIGINAL derived path at its original out-beat duration. Not a guessed m/s constant —
+  // it is read off the plan the building itself produced, so every building keeps its own pace.
+  function _naturalDuration() {
+    var s = _state;
+    var len = _flownLength(_state.wp);
+    var outSec = len / s.speed;
+    return { len: len, outSec: outSec, total: s.baseTotal - s.baseOutSec + outSec };
+  }
+
+  function _flownLength(wp) {
+    var a = A();
+    var pts = (typeof a.cinemaRoundCorners === 'function') ? a.cinemaRoundCorners(wp) : wp;
+    var L = 0;
+    for (var i = 1; i < pts.length; i++)
+      L += Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y, pts[i].z - pts[i - 1].z);
+    return L || 1;
+  }
+
+  // The override object handed back to A.cinemaPathPlan. `scale` is the uniform speed-up/slow-down
+  // the user asks for by keying a different total (item 10) — it multiplies EVERY beat, so the film
+  // keeps its proportions and only its pace changes.
+  function _buildOverride() {
+    var s = _state, nat = _naturalDuration();
+    var total = s.userTotal != null ? s.userTotal : nat.total;
+    var scale = total / Math.max(0.001, nat.total);
+    return {
+      waypoints: s.wp.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+      diveSec: s.baseSec.dive * scale,
+      spinSec: s.baseSec.spin * scale,
+      outSec: nat.outSec * scale,
+      riseSec: s.baseSec.rise * scale,
+      _total: total, _naturalTotal: nat.total, _scale: scale, _pathLen: nat.len
+    };
+  }
+
+  // ── LOS aim, item 2: the look direction at waypoint n is toward waypoint n+1. Shown in the table
+  // read-only, because it is derived — there is nothing here for the user to set.
+  function _aimOf(i) {
+    var wp = _state.wp;
+    if (i >= wp.length - 1) return null;
+    var dx = wp[i + 1].x - wp[i].x, dy = wp[i + 1].y - wp[i].y, dz = wp[i + 1].z - wp[i].z;
+    var h = Math.hypot(dx, dz);
+    return { yaw: Math.atan2(dz, dx) * 180 / Math.PI, pitch: Math.atan2(dy, h || 1e-6) * 180 / Math.PI };
+  }
+
+  // ══════════════════ panel ══════════════════
+  function _buildPanel() {
+    var d = document.createElement('div');
+    d.id = 'cpe-panel';
+    d.style.cssText = 'position:fixed;top:60px;right:12px;width:396px;max-height:calc(100vh - 96px);' +
+      'overflow:auto;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:8px;' +
+      'z-index:10000;font-family:system-ui,sans-serif;color:#ddd;box-shadow:0 8px 32px rgba(0,0,0,0.6)';
+    d.innerHTML =
+      '<div style="padding:10px 12px;border-bottom:1px solid #3a3f47;font-size:13px;font-weight:600;color:#4fc3f7">' +
+        'Cinema path <span style="font-weight:400;color:#888;font-size:11px">— edit before recording</span></div>' +
+      '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
+      '<div id="cpe-rows" style="padding:4px 0"></div>' +
+      '<div style="padding:8px 12px;border-top:1px solid #3a3f47;font-size:11px" id="cpe-clock"></div>' +
+      '<div style="padding:10px 12px;border-top:1px solid #3a3f47;display:flex;gap:8px;justify-content:flex-end">' +
+        '<button id="cpe-cancel" style="padding:6px 12px;font-size:12px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:4px;cursor:pointer">Cancel</button>' +
+        '<button id="cpe-save" style="padding:6px 12px;font-size:12px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:4px;cursor:pointer">Save this path</button>' +
+        '<button id="cpe-ok" style="padding:6px 14px;font-size:12px;background:#4fc3f7;color:#0b0d10;border:none;border-radius:4px;font-weight:600;cursor:pointer">OK</button>' +
+      '</div>';
+    document.body.appendChild(d);
+    return d;
+  }
+
+  function _num(v) { return (Math.round(v * 100) / 100).toFixed(2); }
+
+  function _renderRows() {
+    var box = document.getElementById('cpe-rows');
+    if (!box) return;
+    box.innerHTML = '';
+    var wp = _state.wp;
+    for (var i = 0; i < wp.length; i++) {
+      (function(i) {
+        var last = (i === wp.length - 1);
+        var aim = _aimOf(i);
+        var row = document.createElement('div');
+        var isSel = (i === _state.sel), isHeld = (i === _state.held);
+        row.style.cssText = 'padding:5px 12px;font-size:11px;display:flex;align-items:center;gap:5px;cursor:pointer;' +
+          'border-left:3px solid ' + (isHeld ? '#ffcc00' : isSel ? '#4fc3f7' : 'transparent') + ';' +
+          (isSel || isHeld ? 'background:rgba(79,195,247,0.10);' : '');
+        var lbl = document.createElement('span');
+        lbl.style.cssText = 'width:64px;color:' + (last ? '#ffb74d' : '#888') + ';flex:none';
+        // The final row is the STOPPING waypoint (item 2) — labelled so its purpose is obvious
+        // rather than looking like a stray extra point.
+        lbl.textContent = last ? 'stop' : (i === 0 ? 'settle' : 'wp' + i);
+        lbl.title = last ? 'the stopping waypoint — it exists to give the last leg its look direction' : '';
+        row.appendChild(lbl);
+        ['x', 'z', 'y'].forEach(function(ax) {
+          var inp = document.createElement('input');
+          inp.type = 'number'; inp.step = '0.1';
+          inp.value = _num(wp[i][ax]);
+          inp.title = ax === 'y' ? 'camera height' : ax;
+          inp.style.cssText = 'width:62px;background:#15181c;border:1px solid #3a3f47;color:' +
+            (ax === 'y' ? '#8bc34a' : '#ddd') + ';border-radius:3px;padding:2px 4px;font-size:11px;font-family:monospace';
+          // Two-way binding (item 19): keying a number moves the canvas immediately.
+          inp.addEventListener('change', function() {
+            var v = parseFloat(inp.value);
+            if (!isFinite(v)) { inp.value = _num(wp[i][ax]); return; }
+            wp[i][ax] = v;
+            console.log('§CPE_KEY i=' + i + ' ' + ax + '=' + v.toFixed(2));
+            _redrawScene(); _renderClock();
+          });
+          inp.addEventListener('click', function(ev) { ev.stopPropagation(); });
+          row.appendChild(inp);
+        });
+        var aimEl = document.createElement('span');
+        aimEl.style.cssText = 'flex:1;text-align:right;color:#666;font-size:10px;font-family:monospace';
+        // Derived, never editable — moving the NEXT point is how this changes (item 3).
+        aimEl.textContent = aim ? (Math.round(aim.yaw) + '° / ' + Math.round(aim.pitch) + '°') : '—';
+        aimEl.title = aim ? 'LOS aim toward the next waypoint (derived — drag the next point to change it)'
+                          : 'stopping waypoint: nothing after it to look at';
+        row.appendChild(aimEl);
+        row.addEventListener('click', function() { _select(i, true); });
+        box.appendChild(row);
+      })(i);
+    }
+  }
+
+  function _renderClock() {
+    var el = document.getElementById('cpe-clock');
+    if (!el) return;
+    var s = _state, nat = _naturalDuration();
+    var total = s.userTotal != null ? s.userTotal : nat.total;
+    var fps = s.fps || 15;
+    el.innerHTML = '';
+    var line1 = document.createElement('div');
+    line1.style.cssText = 'display:flex;align-items:center;gap:6px;margin-bottom:4px';
+    line1.innerHTML = '<span style="color:#888">total</span>';
+    var inp = document.createElement('input');
+    inp.type = 'number'; inp.step = '1'; inp.min = '4';
+    inp.value = (Math.round(total * 10) / 10);
+    inp.style.cssText = 'width:64px;background:#15181c;border:1px solid #3a3f47;color:#4fc3f7;border-radius:3px;padding:2px 4px;font-size:11px;font-family:monospace';
+    inp.title = 'total seconds — changing this speeds up or slows down the WHOLE clip uniformly';
+    inp.addEventListener('change', function() {
+      var v = parseFloat(inp.value);
+      if (!isFinite(v) || v < 1) { inp.value = (Math.round(total * 10) / 10); return; }
+      _state.userTotal = v;
+      console.log('§CPE_TOTAL set=' + v.toFixed(1) + 's natural=' + nat.total.toFixed(1) + 's scale=' + (v / nat.total).toFixed(3));
+      _renderClock();
+    });
+    line1.appendChild(inp);
+    var sfx = document.createElement('span');
+    sfx.style.cssText = 'color:#888';
+    // Item 11 — the render cost behind that field, surfaced rather than hidden.
+    sfx.innerHTML = 's &nbsp;·&nbsp; <span style="color:#666">' + Math.round(total * fps) + ' frames to bake</span>';
+    line1.appendChild(sfx);
+    el.appendChild(line1);
+    var line2 = document.createElement('div');
+    line2.style.cssText = 'color:#666;font-size:10px;font-family:monospace';
+    var dTot = total - s.baseTotal;
+    line2.textContent = 'path ' + nat.len.toFixed(1) + 'm · ' + s.speed.toFixed(2) + ' m/s · natural ' +
+      nat.total.toFixed(1) + 's' + (Math.abs(dTot) > 0.05 ? '  (' + (dTot > 0 ? '+' : '') + dTot.toFixed(1) + 's vs original)' : '');
+    el.appendChild(line2);
+  }
+
+  function _renderHint() {
+    var el = document.getElementById('cpe-hint');
+    if (!el) return;
+    // Item 17: a frozen canvas with no explanation reads as a hang, so the held state is always
+    // spelled out in words as well as colour.
+    el.innerHTML = _state.held != null
+      ? '<b style="color:#ffcc00">Holding ' + (_state.held === _state.wp.length - 1 ? 'stop' : _state.held === 0 ? 'settle' : 'wp' + _state.held) +
+        '</b> — drag to move, ctrl+drag for height, wheel still zooms. <b>Double-click empty space to release.</b>'
+      : 'Click a row or a point to hold it. Camera angle is always toward the next point, so move a point to aim the one before it.';
+  }
+
+  function _select(i, frame) {
+    _state.sel = i;
+    _state.held = i;
+    if (A().controls) A().controls.enabled = false;   // item 13 — same pattern as grid_drag.js
+    console.log('§CPE_HOLD i=' + i + ' controls.enabled=false');
+    _redrawScene(); _renderRows(); _renderHint();
+    _pulse(i);
+    if (frame) _frameWaypoint(i);
+  }
+
+  function _release(why) {
+    if (_state.held == null) return;
+    var was = _state.held;
+    _state.held = null;
+    if (A().controls) A().controls.enabled = true;
+    console.log('§CPE_RELEASE i=' + was + ' why=' + why + ' controls.enabled=true');
+    _redrawScene(); _renderRows(); _renderHint();
+  }
+
+  // ══════════════════ canvas interaction ══════════════════
+  function _screenOf(p) {
+    var a = A();
+    var v = new THREE.Vector3(p.x, p.y, p.z).project(a.camera);
+    var r = a.canvas.getBoundingClientRect();
+    return { x: r.left + (v.x + 1) / 2 * r.width, y: r.top + (1 - v.y) / 2 * r.height, behind: v.z > 1 };
+  }
+
+  function _hitTest(ev) {
+    // Screen-space proximity rather than a mesh raycast: the markers draw with depthTest:false so
+    // they are clickable through walls, and a depth-sorted raycast would disagree with what the
+    // user can actually see.
+    var best = -1, bestD = GRAB_PX;
+    for (var i = 0; i < _state.wp.length; i++) {
+      var s = _screenOf(_state.wp[i]);
+      if (s.behind) continue;
+      var d = Math.hypot(ev.clientX - s.x, ev.clientY - s.y);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    return best;
+  }
+
+  // Horizontal drag: intersect the pointer ray with the horizontal plane through the point's own
+  // height, so the point tracks the cursor exactly instead of sliding at a camera-dependent rate.
+  function _planePoint(ev, height) {
+    var a = A();
+    var r = a.canvas.getBoundingClientRect();
+    var ndc = new THREE.Vector2(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    var rc = new THREE.Raycaster();
+    rc.setFromCamera(ndc, a.camera);
+    var dir = rc.ray.direction, org = rc.ray.origin;
+    if (Math.abs(dir.y) < 1e-5) return null;
+    var t = (height - org.y) / dir.y;
+    if (t <= 0) return null;
+    return { x: org.x + dir.x * t, z: org.z + dir.z * t };
+  }
+
+  function _wire() {
+    var a = A(), c = a.canvas;
+    var h = {};
+
+    h.down = function(ev) {
+      if (!_state) return;
+      var i = _hitTest(ev);
+      if (i >= 0) {
+        ev.preventDefault(); ev.stopPropagation();
+        _select(i, false);
+        _state.drag = { i: i, ctrl: !!ev.ctrlKey, y0: ev.clientY, h0: _state.wp[i].y };
+        return;
+      }
+      // Item 16: while a point is held, a stray click must not run element picking and select the
+      // wall behind the waypoint.
+      if (_state.held != null) { ev.preventDefault(); ev.stopPropagation(); }
+    };
+
+    h.move = function(ev) {
+      if (!_state || !_state.drag) return;
+      ev.preventDefault(); ev.stopPropagation();
+      var d = _state.drag, w = _state.wp[d.i];
+      if (d.ctrl || ev.ctrlKey) {
+        // ctrl+drag → camera height (item 14). Up on screen = up in the world.
+        w.y = d.h0 + (d.y0 - ev.clientY) * DRAG_VERT_M_PER_PX;
+      } else {
+        var p = _planePoint(ev, w.y);
+        if (p) { w.x = p.x; w.z = p.z; }
+      }
+      _redrawScene(); _renderRows(); _renderClock();
+    };
+
+    h.up = function(ev) {
+      if (!_state || !_state.drag) return;
+      var d = _state.drag, w = _state.wp[d.i];
+      _state.drag = null;
+      console.log('§CPE_DRAG i=' + d.i + ' axis=' + (d.ctrl ? 'height' : 'xz') +
+        ' → (' + w.x.toFixed(2) + ',' + w.y.toFixed(2) + ',' + w.z.toFixed(2) + ')');
+      _renderClock();
+    };
+
+    // Item 15 — double-click empty canvas releases. Single click was rejected by the user as too
+    // easy to trigger and lose the point.
+    h.dbl = function(ev) {
+      if (!_state) return;
+      if (_hitTest(ev) >= 0) return;
+      ev.preventDefault(); ev.stopPropagation();
+      _release('dblclick');
+    };
+
+    // Touch has no dblclick — same 350ms double-tap window picking.js:174 already uses for measure
+    // mode, reused rather than reinvented.
+    h.touchTap = function(ev) {
+      if (!_state) return;
+      var t = ev.changedTouches && ev.changedTouches[0];
+      if (!t) return;
+      var fake = { clientX: t.clientX, clientY: t.clientY };
+      if (_hitTest(fake) >= 0) return;
+      var now = Date.now();
+      if (_state.lastTap && (now - _state.lastTap) < 350) { _state.lastTap = 0; _release('double-tap'); }
+      else _state.lastTap = now;
+    };
+
+    c.addEventListener('pointerdown', h.down, true);
+    window.addEventListener('pointermove', h.move, true);
+    window.addEventListener('pointerup', h.up, true);
+    c.addEventListener('dblclick', h.dbl, true);
+    c.addEventListener('touchend', h.touchTap, true);
+    _state.handlers = h;
+  }
+
+  function _unwire() {
+    var a = A(), c = a.canvas, h = _state.handlers;
+    if (!h) return;
+    c.removeEventListener('pointerdown', h.down, true);
+    window.removeEventListener('pointermove', h.move, true);
+    window.removeEventListener('pointerup', h.up, true);
+    c.removeEventListener('dblclick', h.dbl, true);
+    c.removeEventListener('touchend', h.touchTap, true);
+  }
+
+  // ══════════════════ public API ══════════════════
+  // open({plan, durationSec, fps}) → Promise<{action:'ok'|'cancel', override, durationSec}>
+  function open(ctx) {
+    var a = A();
+    return new Promise(function(resolve) {
+      var plan = ctx.plan;
+      if (!plan || !plan.waypoints || plan.waypoints.length < 2) {
+        console.warn('§CPE_SKIP plan has no waypoints — nothing to edit, proceeding unchanged');
+        return resolve({ action: 'ok', override: null, durationSec: ctx.durationSec });
+      }
+      _state = {
+        wp: plan.waypoints.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+        sel: null, held: null, drag: null, objs: [], markers: [], pulseId: 0, flyId: 0,
+        baseSec: { dive: plan.sec.dive, spin: plan.sec.spin, out: plan.sec.out, rise: plan.sec.rise },
+        baseOutSec: plan.sec.out,
+        baseTotal: ctx.durationSec,
+        baseLen: plan.pathLen,
+        // Constant speed, read off the building's OWN derived plan — never a guessed m/s.
+        speed: plan.pathLen / Math.max(0.001, plan.sec.out),
+        userTotal: null,
+        fps: ctx.fps || 15,
+        camSave: { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
+                   tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z },
+        controlsWere: a.controls ? a.controls.enabled : true
+      };
+      console.log('§CPE_OPEN waypoints=' + _state.wp.length + ' pathLen=' + plan.pathLen.toFixed(1) +
+        'm outSec=' + plan.sec.out.toFixed(1) + ' speed=' + _state.speed.toFixed(2) + 'm/s total=' +
+        ctx.durationSec.toFixed(1) + 's');
+
+      var panel = _buildPanel();
+      _state.panel = panel;
+      _redrawScene(); _renderRows(); _renderClock(); _renderHint();
+      _wire();
+
+      function finish(action) {
+        var ov = (action === 'ok' || action === 'save') ? _buildOverride() : null;
+        var edited = ov ? _edited(ov) : false;
+        _release('close');
+        _unwire();
+        _clearScene();
+        if (panel.parentNode) panel.parentNode.removeChild(panel);
+        if (a.controls) a.controls.enabled = _state.controlsWere;
+        // Always hand the camera back exactly as the editor found it — the bake starts from the
+        // same pose whether or not anything was edited.
+        a.camera.position.set(_state.camSave.px, _state.camSave.py, _state.camSave.pz);
+        a.controls.target.set(_state.camSave.tx, _state.camSave.ty, _state.camSave.tz);
+        a.controls.update();
+        if (a.markDirty) a.markDirty();
+        var total = ov ? ov._total : _state.baseTotal;
+        console.log('§CPE_CLOSE action=' + action + ' edited=' + edited + ' total=' + total.toFixed(1) + 's');
+        _state = null;
+        // Guardrail 2: an untouched OK hands back NO override at all, so the bake re-uses the
+        // derived plan verbatim. "One click costs nothing" is enforced here, not merely intended.
+        resolve({ action: action === 'cancel' ? 'cancel' : 'ok',
+                  override: edited ? ov : null,
+                  saved: action === 'save',
+                  durationSec: edited ? total : ctx.durationSec });
+      }
+
+      // "Edited" means the authored path actually differs from what the plan derived. Floating
+      // point round-trips through the number inputs must not count as an edit.
+      function _edited(ov) {
+        if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
+        var base = plan.waypoints;
+        if (ov.waypoints.length !== base.length) return true;
+        for (var i = 0; i < base.length; i++) {
+          if (Math.abs(ov.waypoints[i].x - base[i].x) > 1e-6) return true;
+          if (Math.abs(ov.waypoints[i].y - base[i].y) > 1e-6) return true;
+          if (Math.abs(ov.waypoints[i].z - base[i].z) > 1e-6) return true;
+        }
+        return false;
+      }
+
+      document.getElementById('cpe-ok').addEventListener('click', function() { finish('ok'); });
+      document.getElementById('cpe-cancel').addEventListener('click', function() { finish('cancel'); });
+      document.getElementById('cpe-save').addEventListener('click', function() {
+        // Explicit persistence (guardrail 5): stage into the in-memory DB; the user's normal Ctrl+S
+        // carries it to the file, exactly as staffage does. Never auto-persist on adjust.
+        var ov = _buildOverride();
+        if (typeof a.stageCinemaPath === 'function') a.stageCinemaPath(ov);
+        finish('save');
+      });
+    });
+  }
+
+  var _attach = setInterval(function() {
+    if (window.APP) {
+      window.APP.cinemaPathEditor = { open: open, version: CPE_V };
+      clearInterval(_attach);
+    }
+  }, 500);
+})();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3304,6 +3304,65 @@ async function setupEffects(A, renderer, scene, camera) {
   var CINEMA_FAN_FAR = 60;      // metres; no hit inside this = open in that bearing
   var CINEMA_FAN_NUDGE_MAX = 3; // metres the settle point may slide toward the open side
   var CINEMA_ENCLOSED_THRESHOLD = 0.6; // BVH fan fraction that counts as "genuinely enclosed"
+
+  // ══ §CINEMA_PATH_EDITOR — authored path state + corner rounding. Spec:
+  // prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL (settled with the user 2026-07-26).
+  // _cpeWp is the ONE piece of authored state the plan reads. Null = nothing authored = the plan
+  // behaves EXACTLY as it did before this feature existed, which is what makes guardrail 2 ("OK
+  // without an edit must be byte-identical to today") true by construction rather than by test.
+  var _cpeWp = null;
+  var CINEMA_CORNER_ARC_SEGS = 8;    // sample points per rounded corner
+  var CINEMA_CORNER_LEG_FRAC = 0.4;  // a corner may never eat more than 40% of either adjoining leg
+  // Corner rounding, clearance-bounded (§CINEMA_PATH_EDITOR_MODEL items 5-7). Straight runs pass
+  // through verbatim; every interior corner is replaced by a quadratic Bézier that leaves the
+  // incoming leg `r` before the waypoint and rejoins the outgoing leg `r` after it, with the
+  // waypoint itself as the control point. A quadratic Bézier's furthest excursion from its control
+  // point is at u=0.5 and equals 0.25·r·|b̂−â| ≤ r/2 — so the flown curve can never stray more than
+  // HALF the measured clearance from the point the user placed. That bound is the G8 claim, and it
+  // is why `r` may be taken straight from _cinemaFan.min with no safety fudge factor invented on top.
+  function _cinemaRoundCorners(wp) {
+    if (!wp || wp.length < 3) return (wp || []).slice();
+    var out = [{ x: wp[0].x, y: wp[0].y, z: wp[0].z }], rounded = 0, rMin = 1e9, rMax = 0;
+    for (var i = 1; i < wp.length - 1; i++) {
+      var p0 = wp[i - 1], p1 = wp[i], p2 = wp[i + 1];
+      var ax = p1.x - p0.x, ay = p1.y - p0.y, az = p1.z - p0.z;
+      var bx = p2.x - p1.x, by = p2.y - p1.y, bz = p2.z - p1.z;
+      var aL = Math.hypot(ax, ay, az), bL = Math.hypot(bx, by, bz);
+      if (aL < 1e-4 || bL < 1e-4) { out.push({ x: p1.x, y: p1.y, z: p1.z }); continue; }
+      // A waypoint the path runs straight through is not a corner — leave it alone rather than
+      // spend a BVH fan on it.
+      var dot = (ax * bx + ay * by + az * bz) / (aL * bL);
+      var turnDeg = Math.acos(Math.max(-1, Math.min(1, dot))) * 180 / Math.PI;
+      if (turnDeg < 3) { out.push({ x: p1.x, y: p1.y, z: p1.z }); continue; }
+      // MEASURED clearance at this corner. Fallback is CINEMA_FAN_NUDGE_MAX — an existing constant
+      // that already means "how far the camera may slide about inside a room" — not a new number.
+      var clear = CINEMA_FAN_NUDGE_MAX;
+      try {
+        var fanC = _cinemaFan({ x: p1.x, y: p1.y, z: p1.z }, 8);
+        if (fanC && isFinite(fanC.min)) clear = fanC.min;
+      } catch (eC) { /* no BVH yet → the existing nudge budget stands in */ }
+      var r = Math.min(clear, aL * CINEMA_CORNER_LEG_FRAC, bL * CINEMA_CORNER_LEG_FRAC);
+      if (!(r > 0.01)) { out.push({ x: p1.x, y: p1.y, z: p1.z }); continue; }
+      rounded++; rMin = Math.min(rMin, r); rMax = Math.max(rMax, r);
+      var pA = { x: p1.x - ax / aL * r, y: p1.y - ay / aL * r, z: p1.z - az / aL * r };
+      var pB = { x: p1.x + bx / bL * r, y: p1.y + by / bL * r, z: p1.z + bz / bL * r };
+      out.push(pA);
+      for (var s = 1; s < CINEMA_CORNER_ARC_SEGS; s++) {
+        var u = s / CINEMA_CORNER_ARC_SEGS, iu = 1 - u;
+        out.push({ x: iu * iu * pA.x + 2 * iu * u * p1.x + u * u * pB.x,
+                   y: iu * iu * pA.y + 2 * iu * u * p1.y + u * u * pB.y,
+                   z: iu * iu * pA.z + 2 * iu * u * p1.z + u * u * pB.z });
+      }
+      out.push(pB);
+    }
+    var last = wp[wp.length - 1];
+    out.push({ x: last.x, y: last.y, z: last.z });
+    console.log('§CINEMA_CORNERS control=' + wp.length + ' flown=' + out.length + ' rounded=' + rounded +
+      ' rMin=' + (rounded ? rMin.toFixed(2) : 'n/a') + ' rMax=' + (rounded ? rMax.toFixed(2) : 'n/a') +
+      ' maxDeviation=' + (rounded ? (rMax / 2).toFixed(2) : '0.00') + 'm (bound=clearance/2)');
+    return out;
+  }
+  A.cinemaRoundCorners = _cinemaRoundCorners;   // witness G7/G8 read this directly
   // Exit cost = dist × (1 − FACE_GAIN·facingDot) × perimFactor. facingDot=+1 (door dead ahead) →
   // (1-GAIN)×dist; facingDot=−1 (door behind you) → (1+GAIN)×dist. This asymmetry is the entire
   // "myriad of paths" mechanism: two poses at the SAME spot facing different ways can pick DIFFERENT
@@ -3757,24 +3816,88 @@ async function setupEffects(A, renderer, scene, camera) {
                       y: chosenExit.p.y + CINEMA_EYE_M,
                       z: chosenExit.p.z + odz * Math.max(8, envelope * 0.15) };
     outWp.push(exitOuter);
+    // ══ §CINEMA_PATH_EDITOR (prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL item 1):
+    // AUTHORED waypoints replace the derived walk-out wholesale. Waypoints are the ONLY authored
+    // data in this whole feature — position plus camera height, nothing else. The camera ANGLE is
+    // never authored (item 2): it stays LOS toward the next waypoint, which is exactly what _outPos
+    // and the existing §CINEMA_TURN_SLERP already derive. That is WHY this feature cannot weaken
+    // §CINEMA_TURN_SLERP's witness (item 4) — it changes that law's inputs, never the law.
+    var cpeOrbitScale = 1, cpeOrbitDY = 0;
+    if (_cpeWp && _cpeWp.length >= 2) {
+      // ══ The LAST waypoint is the orbit's control point, and it acts ELASTICALLY (user, 2026-07-26:
+      // "that curve remains static, it is just its waypoint that gets adjusted... it is elastic,
+      // relative to its original orbit"). The orbit KEEPS ITS SHAPE — ellipse, Sun-glint swoop, flat
+      // hold, decelerating ending, all formula-driven and all already witnessed. The stop row only
+      // stretches it: a RATIO on radius and an OFFSET on height, both measured against the derived
+      // orbit rather than replacing it.
+      // Relative, not absolute, on purpose: a stored path is re-applied later against a plan that
+      // may have been derived from a different start pose (hence a different fillDistance). A ratio
+      // still means "a bit wider than this building's natural orbit" then; an absolute radius in
+      // metres would not.
+      // The third lever needs no code at all: `exitAz` below is measured off exitOuter, and it is
+      // what decides where the Sun crossing falls in the loop — whether the film catches the
+      // reflection early and then rises, or rises into it at the end. Reassigning exitOuter is
+      // enough for the stop row to re-shape the orbit's whole mood through existing code.
+      var derivedOuter = exitOuter;
+      var derivedR = Math.hypot(derivedOuter.x - pivot.x, derivedOuter.z - pivot.z);
+      outWp = _cpeWp.map(function(w) { return { x: w.x, y: w.y, z: w.z }; });
+      outRoute = 'authored';
+      exitOuter = outWp[outWp.length - 1];
+      // ── Two things downstream still pointed at the DERIVED route and had to be re-aimed at the
+      // authored one. Both were caught by witness numbers, not by reading the code:
+      //
+      // (a) `settle` — Beats 1-2 (dive, spin) fly to `settle`, which came from the §CINEMA_SPACE
+      //     pick, while Beat 3 starts from outWp[0]. Authoring row 0 without this moved only the
+      //     walk, so the camera teleported at the beat seam. G3 measured it exactly: a 1.5m
+      //     height edit produced dy over the walk-out of [0.000, 1.508] — the 0.000 IS the seam.
+      //     Mutated in place because the beat closures captured this object.
+      // (b) `odx/odz` — the outward push direction past the doorway. Beat 3's gaze falls back to it
+      //     whenever the look-ahead point collapses onto the position (the last half-metre of the
+      //     walk, line ~4146), and Beat 4 assumes "(odx,odz) IS the direction Beat 3 ends on". With
+      //     an authored path that was still the derived exit's bearing, so the gaze SNAPPED onto it
+      //     at the end of the walk: G7 measured 115.2 deg in a single frame — six times worse than
+      //     the 19.8 deg/frame whip this feature set out to retire.
+      settle.x = outWp[0].x; settle.y = outWp[0].y; settle.z = outWp[0].z;
+      var lastLeg = outWp[outWp.length - 1], prevLeg = outWp[outWp.length - 2];
+      var lgx = lastLeg.x - prevLeg.x, lgz = lastLeg.z - prevLeg.z;
+      var lgL = Math.hypot(lgx, lgz);
+      if (lgL > 1e-4) { odx = lgx / lgL; odz = lgz / lgL; }
+      var authoredR = Math.hypot(exitOuter.x - pivot.x, exitOuter.z - pivot.z);
+      if (derivedR > 0.01) cpeOrbitScale = authoredR / derivedR;
+      cpeOrbitDY = exitOuter.y - derivedOuter.y;
+      console.log('§CINEMA_PATH_EDIT authored waypoints=' + outWp.length + ' (derived route replaced)' +
+        ' orbitScale=' + cpeOrbitScale.toFixed(3) + ' orbitDY=' + cpeOrbitDY.toFixed(2) + 'm');
+    }
+    // ══ §CINEMA_PATH_EDITOR_MODEL items 5-7: the waypoints are CONTROL points, not corners. The
+    // flown curve CUTS INSIDE every corner (user: "yes cut inside"), so a sharp corner is not a
+    // state this path can reach — user: "that means there are no 'sharp' corners." The cut is
+    // bounded by MEASURED clearance at each waypoint (_cinemaFan.min, this project's single source
+    // for "how much open space is here", already trusted by §CINEMA_SPACE), never by a guessed
+    // fillet constant: tight room → tight curve, open hall → wide graceful arc.
+    // This retires the ungated "D2 walk-out corner whip" (19.8°/frame) the user reported as "about
+    // 2 jerks, fast jump at least a frame" — tolerable while the route was derived-and-tame, trivial
+    // to hit once waypoints are user-draggable. Gated by G7 (°/frame cap) and G8 (deviation ≤ the
+    // measured clearance). `outWp` stays the authored control points (the editor's table and the
+    // LOS derivation both read it); `flowWp` is what is actually flown.
+    var flowWp = _cinemaRoundCorners(outWp);
     var segLen = [0];
-    for (var wi = 1; wi < outWp.length; wi++)
-      segLen.push(segLen[wi - 1] + Math.hypot(outWp[wi].x - outWp[wi - 1].x,
-                                              outWp[wi].y - outWp[wi - 1].y,
-                                              outWp[wi].z - outWp[wi - 1].z));
+    for (var wi = 1; wi < flowWp.length; wi++)
+      segLen.push(segLen[wi - 1] + Math.hypot(flowWp[wi].x - flowWp[wi - 1].x,
+                                              flowWp[wi].y - flowWp[wi - 1].y,
+                                              flowWp[wi].z - flowWp[wi - 1].z));
     var totalLen = segLen[segLen.length - 1] || 1;
     function _outPos(f) {
       var want = Math.max(0, Math.min(1, f)) * totalLen;
-      for (var i2 = 1; i2 < outWp.length; i2++) {
-        if (want <= segLen[i2] || i2 === outWp.length - 1) {
+      for (var i2 = 1; i2 < flowWp.length; i2++) {
+        if (want <= segLen[i2] || i2 === flowWp.length - 1) {
           var seg = (segLen[i2] - segLen[i2 - 1]) || 1;
           var lf = Math.max(0, Math.min(1, (want - segLen[i2 - 1]) / seg));
-          return { x: outWp[i2 - 1].x + (outWp[i2].x - outWp[i2 - 1].x) * lf,
-                   y: outWp[i2 - 1].y + (outWp[i2].y - outWp[i2 - 1].y) * lf,
-                   z: outWp[i2 - 1].z + (outWp[i2].z - outWp[i2 - 1].z) * lf };
+          return { x: flowWp[i2 - 1].x + (flowWp[i2].x - flowWp[i2 - 1].x) * lf,
+                   y: flowWp[i2 - 1].y + (flowWp[i2].y - flowWp[i2 - 1].y) * lf,
+                   z: flowWp[i2 - 1].z + (flowWp[i2].z - flowWp[i2 - 1].z) * lf };
         }
       }
-      return outWp[outWp.length - 1];
+      return flowWp[flowWp.length - 1];
     }
     // The spin's destination bearing: the FIRST leg of the route out, so the spin ends looking
     // exactly where the walk begins (no seam between the two beats).
@@ -3816,7 +3939,18 @@ async function setupEffects(A, renderer, scene, camera) {
     var sunAz = A.sun ? Math.atan2(A.sun.position.z - pivot.z, A.sun.position.x - pivot.x) : exitAz + Math.PI;
     var lookdownTilt = Math.max(tiltMin, Math.min(tiltMax, CINEMA_LOOKDOWN_DEG * Math.PI / 180));
     var flatTiltRad = THREE.MathUtils.degToRad(CINEMA_FLAT_TILT_DEG);
-    var orbitRadius = Math.max(radiusMin, Math.min(radiusMax, fillDistance));
+    // §CINEMA_PATH_EDITOR: the stop row stretches the orbit elastically. The radius band still
+    // clamps the result — that band is what keeps the building framed at all (too close clips, too
+    // far is a speck), so a stretch is honoured WITHIN it, never in place of it. Both the requested
+    // and the granted value are logged, so a clamp is visible in the log instead of silently
+    // swallowing what the user dragged.
+    var orbitRadiusWant = fillDistance * cpeOrbitScale;
+    var orbitRadius = Math.max(radiusMin, Math.min(radiusMax, orbitRadiusWant));
+    if (cpeOrbitScale !== 1 || cpeOrbitDY !== 0)
+      console.log('§CINEMA_ORBIT_ELASTIC scale=' + cpeOrbitScale.toFixed(3) +
+        ' requested=' + orbitRadiusWant.toFixed(1) + ' granted=' + orbitRadius.toFixed(1) +
+        ' band=[' + radiusMin.toFixed(1) + ',' + radiusMax.toFixed(1) + ']' +
+        ' clamped=' + (Math.abs(orbitRadius - orbitRadiusWant) > 0.05) + ' dY=' + cpeOrbitDY.toFixed(2) + 'm');
 
     // ══ Beat boundaries, in normalized time. Fixed SECONDS, so a longer film gets a longer orbit,
     // never a longer dive (§CINEMA_SIMPLE: the dive is time-boxed at 4s and must not be clamped).
@@ -3953,7 +4087,11 @@ async function setupEffects(A, renderer, scene, camera) {
         radius *= 1 + (CINEMA_PULLBACK_SCALE - 1) * pb;
       }
       var hr = radius * Math.cos(tilt);
-      return { x: pivot.x + hr * Math.cos(az), y: pivot.y + radius * Math.sin(tilt),
+      // cpeOrbitDY: the elastic height offset from the authored stop row (§CINEMA_PATH_EDITOR).
+      // Additive on the whole loop, so the orbit rides higher or lower while keeping every shape
+      // rule above — tilt easing, flat ending, pull-back — exactly as derived. Zero when nothing is
+      // authored, so this line is a no-op on the default path.
+      return { x: pivot.x + hr * Math.cos(az), y: pivot.y + radius * Math.sin(tilt) + cpeOrbitDY,
                z: pivot.z + hr * Math.sin(az), tx: pivot.x, ty: pivot.y, tz: pivot.z };
     }
     var orbitStart = _orbitPose(0);
@@ -4069,9 +4207,94 @@ async function setupEffects(A, renderer, scene, camera) {
              pushInRadius: pushInRadius, radiusMin: radiusMin, radiusMax: radiusMax,
              pivot: pivot, pivotSrc: pivotSrc, settle: settle, exit: chosenExit,
              beats: { dive: tD, spin: tS, out: tO, rise: tR },
+             // §CINEMA_PATH_EDITOR: the editor's table renders `waypoints` (authored control points,
+             // NOT the rounded flown polyline) and re-times off `pathLen`. `sec` echoes the beat
+             // seconds actually in force for this plan so the editor never has to guess them back
+             // out of the normalized beat fractions.
+             waypoints: outWp.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+             flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
+             sec: { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC },
+             eyeM: CINEMA_EYE_M, lookdownDeg: CINEMA_LOOKDOWN_DEG, durationSec: durationSec,
              indoor: true, poseAt: poseAt };
   }
-  A.cinemaPathPlan = _cinemaPathPlan;   // shared with cinema_maxq.js — see §CINEMA_PATH above
+  // ══ §CINEMA_PATH_EDITOR — the override seam. Deliberately a THIN WRAPPER rather than edits inside
+  // _cinemaPathPlan: the plan function is 600+ lines and its §CINEMA_SPACE block is another session's
+  // working set (see the spec's DO-NOT-REMOVE header), so this feature touches it as little as
+  // possible. The overridable inputs are module-level `var`s in this same IIFE, so they can be set,
+  // the untouched plan called, and restored in `finally`.
+  // Guardrail 2 falls out for free: with no override this calls _cinemaPathPlan(durationSec) with
+  // every global at its original value — the same function with the same inputs, so "OK without an
+  // edit is byte-identical to today" is a property of the code, not a hope pinned on a test.
+  var _CPE_KEYS = [['diveSec', 'CINEMA_DIVE_SEC'], ['spinSec', 'CINEMA_SPIN_SEC'],
+                   ['outSec', 'CINEMA_OUT_SEC'], ['riseSec', 'CINEMA_RISE_SEC'],
+                   ['eyeM', 'CINEMA_EYE_M'], ['lookdownDeg', 'CINEMA_LOOKDOWN_DEG']];
+  function _cpeSet(name, v) {
+    if (name === 'CINEMA_DIVE_SEC') CINEMA_DIVE_SEC = v;
+    else if (name === 'CINEMA_SPIN_SEC') CINEMA_SPIN_SEC = v;
+    else if (name === 'CINEMA_OUT_SEC') CINEMA_OUT_SEC = v;
+    else if (name === 'CINEMA_RISE_SEC') CINEMA_RISE_SEC = v;
+    else if (name === 'CINEMA_EYE_M') CINEMA_EYE_M = v;
+    else if (name === 'CINEMA_LOOKDOWN_DEG') CINEMA_LOOKDOWN_DEG = v;
+  }
+  function _cpeGet(name) {
+    return name === 'CINEMA_DIVE_SEC' ? CINEMA_DIVE_SEC : name === 'CINEMA_SPIN_SEC' ? CINEMA_SPIN_SEC :
+           name === 'CINEMA_OUT_SEC' ? CINEMA_OUT_SEC : name === 'CINEMA_RISE_SEC' ? CINEMA_RISE_SEC :
+           name === 'CINEMA_EYE_M' ? CINEMA_EYE_M : CINEMA_LOOKDOWN_DEG;
+  }
+  // ── §CINEMA_PATH_EDITOR persistence, read side. Restored LAZILY at first plan rather than at load:
+  // the plan is the only consumer, so there is no window in which a stored path could be missed, and
+  // it needs no hook in the load path at all. (This is deliberately NOT the staffage bug the spec
+  // lists — staffage restores on first Alt+P, which is a *user action* and therefore genuinely too
+  // late; a plan-time restore happens before the first thing that could observe it.)
+  var _cpeLoaded = false;
+  function _cpeLoadFromDb() {
+    if (_cpeLoaded) return;
+    _cpeLoaded = true;
+    try {
+      if (!A.dbQuery) return;
+      var has = A.dbQuery("SELECT name FROM sqlite_master WHERE type='table' AND name='cinema_path'");
+      if (!has || !has.length) { console.log('§CINEMA_PATH_RESTORE none (no cinema_path table) — derived path'); return; }
+      var rows = A.dbQuery("SELECT seq,ifc_x,ifc_y,ifc_z,total_sec,dive_sec,spin_sec,out_sec,rise_sec FROM cinema_path ORDER BY seq");
+      if (!rows || rows.length < 2) { console.log('§CINEMA_PATH_RESTORE none (0 rows) — derived path'); return; }
+      var wp = rows.map(function(r) {
+        var p = A.ifc2three(r[1], r[2], r[3]);
+        return { x: p.x, y: p.y, z: p.z };
+      });
+      A._cinemaPathEdit = { waypoints: wp, diveSec: rows[0][5], spinSec: rows[0][6],
+                            outSec: rows[0][7], riseSec: rows[0][8], _total: rows[0][4] };
+      console.log('§CINEMA_PATH_RESTORE rows=' + wp.length + ' total=' + rows[0][4].toFixed(1) + 's — authored path in force');
+    } catch (e) { console.warn('§CINEMA_PATH_RESTORE_FAIL ' + e.message); }
+  }
+  // Staged by the editor's "Save this path"; read by scene.js `_writeCinemaPathTable` at export.
+  A.stageCinemaPath = function(ov) {
+    A._cinemaPathEdit = ov;
+    console.log('§CINEMA_PATH_STAGE waypoints=' + (ov && ov.waypoints ? ov.waypoints.length : 0) +
+      ' total=' + (ov && ov._total ? ov._total.toFixed(1) : '?') + 's (Ctrl+S writes it to the file)');
+  };
+  A._getCinemaPathEdit = function() { return A._cinemaPathEdit || null; };
+  A.clearCinemaPath = function() { A._cinemaPathEdit = null; console.log('§CINEMA_PATH_CLEAR authored path dropped'); };
+
+  A.cinemaPathPlan = function(durationSec, ov) {
+    // `undefined` means "use whatever is stored/staged"; an explicit null means "derived, ignore any
+    // stored edit" — the G5 control path needs that distinction to be expressible.
+    if (ov === undefined) { _cpeLoadFromDb(); ov = A._cinemaPathEdit || null; }
+    if (!ov) return _cinemaPathPlan(durationSec);
+    var saved = [], i;
+    for (i = 0; i < _CPE_KEYS.length; i++) {
+      var k = _CPE_KEYS[i][0], g = _CPE_KEYS[i][1];
+      saved.push(_cpeGet(g));
+      if (ov[k] != null && isFinite(ov[k])) _cpeSet(g, ov[k]);
+    }
+    var savedWp = _cpeWp;
+    if (ov.waypoints && ov.waypoints.length >= 2) _cpeWp = ov.waypoints;
+    try {
+      return _cinemaPathPlan(durationSec);
+    } finally {
+      for (i = 0; i < _CPE_KEYS.length; i++) _cpeSet(_CPE_KEYS[i][1], saved[i]);
+      _cpeWp = savedWp;
+    }
+  };
+  A.cinemaPathPlanDerived = _cinemaPathPlan;   // unwrapped, for G1's byte-identity comparison
   // §INTERIOR_PACING (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-25): exposes the SAME BVH raycast fan
   // §CINEMA_SPACE already trusts as "the ONLY where-is-open-space source" (see the file-header
   // comment above _cinemaFanMeshes) to tour.js's flight-pacing — real measured clearance-to-

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -433,6 +433,13 @@ async function setupScene(A) {
   A.ifc2three = function(ix, iy, iz) {
     return { x: ix - A.modelOffset.x, y: iz - A.modelOffset.z, z: -(iy - A.modelOffset.y) };
   };
+  // Exact inverse. Anything PERSISTED must be stored in IFC space, never three.js space:
+  // A.modelOffset is established at load time, so a three.js coordinate written into a .db is only
+  // meaningful to the session that wrote it. This is why staffage_instances stores ifc_* columns,
+  // and §CINEMA_PATH_EDITOR's cinema_path table follows it.
+  A.three2ifc = function(x, y, z) {
+    return { ix: x + A.modelOffset.x, iy: -z + A.modelOffset.y, iz: y + A.modelOffset.z };
+  };
 
   // IndexedDB cache
   A.CACHE_DB_NAME = 'bim_ootb_cache';
@@ -586,11 +593,36 @@ async function setupScene(A) {
       console.log('§STAFFAGE_SAVE rows=' + rows.length);
     } catch (e) { console.warn('§STAFFAGE_SAVE_FAIL ' + e.message); }
   }
+  // §CINEMA_PATH_EDITOR (prompts/CINEMA_PATH_EDITOR.md, guardrail 5 + §CINEMA_PATH_EDITOR_MODEL):
+  // an edited cinema path is AUTHORED data, so under the prime rule it must be STORED, never
+  // re-guessed. Mirrors staffage_instances exactly — same explicit-action model: "Save this path"
+  // stages the edit into memory, the user's normal Ctrl+S is what writes it to the file. Adjusting
+  // and proceeding stays ephemeral, so a user experimenting with waypoints can walk away without
+  // having changed the building.
+  // Positions only, plus the beat seconds — camera ANGLE is never stored because it is never
+  // authored (it is LOS to the next waypoint, re-derived on load).
+  function _writeCinemaPathTable(db) {
+    var ov = (A._getCinemaPathEdit && A._getCinemaPathEdit()) || null;
+    if (!ov || !ov.waypoints || ov.waypoints.length < 2) return;
+    try {
+      db.run("DROP TABLE IF EXISTS cinema_path");
+      db.run("CREATE TABLE cinema_path (seq INTEGER, ifc_x REAL, ifc_y REAL, ifc_z REAL, " +
+             "total_sec REAL, dive_sec REAL, spin_sec REAL, out_sec REAL, rise_sec REAL)");
+      var stmt = db.prepare("INSERT INTO cinema_path VALUES (?,?,?,?,?,?,?,?,?)");
+      ov.waypoints.forEach(function(w, i) {
+        var p = A.three2ifc(w.x, w.y, w.z);
+        stmt.run([i, p.ix, p.iy, p.iz, ov._total, ov.diveSec, ov.spinSec, ov.outSec, ov.riseSec]);
+      });
+      stmt.free();
+      console.log('§CINEMA_PATH_SAVE rows=' + ov.waypoints.length + ' total=' + ov._total.toFixed(1) + 's');
+    } catch (e) { console.warn('§CINEMA_PATH_SAVE_FAIL ' + e.message); }
+  }
   A._exportBuildingDb = function() {
     if (!A.db) return null;
     if (!A.libDb || A.libDb === A.db) {
       console.log('§SAVE_EXPORT monolith (A.db holds geometry)');
       _writeStaffageTable(A.db);
+      _writeCinemaPathTable(A.db);
       return A.db.export();
     }
     // Split → build a monolith: clone meta, copy every geometry table not already present.
@@ -616,6 +648,7 @@ async function setupScene(A) {
     });
     console.log('§SAVE_FOLD split→monolith geoTablesCopied=' + copied + ' rows=' + rows);
     _writeStaffageTable(mono);
+    _writeCinemaPathTable(mono);
     var bytes = mono.export();
     mono.close();
     return bytes;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v851';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v852';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -113,6 +113,7 @@ const PRECACHE_ASSETS = [
   'loader.js',
   'effects.js',
   'cinema_maxq.js',
+  'cinema_path_editor.js',
   'lib/mp4_mux.js',   // §MAXQ_MP4 — hand-rolled mp4 muxer; missing => MaxQ silently falls back to webm
   'input_registry.js',
   'scene.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,6 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
+<script src="cinema_path_editor.js?v=1" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cinema_path_editor.js
+++ b/witness_cinema_path_editor.js
@@ -1,0 +1,301 @@
+// WITNESS — §CINEMA_PATH_EDITOR.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL.
+//
+// ISSUE EACH GATE PROVES OR DISPROVES — every one of these is a way the feature could be silently
+// broken while still "working" on screen:
+//   G1  OK-without-edit is a no-op. If false, the feature costs every user a changed film for
+//       nothing. Proven by SAMPLED POSES being bit-for-bit equal, not by "looks the same".
+//   G2  a waypoint edit changes the sampled path AT that waypoint and not elsewhere.
+//   G3  a camera-height edit moves eye height by exactly the amount asked, on the affected beat.
+//   G5  control: with no cinema_path table the plan is the derived one.
+//   G7  no sharp corners: peak angular rate on a deliberately sharp authored corner stays under the
+//       cap. This is the user's "about 2 jerks" made into a NUMBER (today: 19.8 deg/frame, ungated).
+//   G8  the flown curve never strays further from an authored waypoint than the MEASURED clearance
+//       there. Proves the corner cut is bounded by real space, not a guessed fillet constant.
+//   G9  constant speed + uniform scale: a longer path costs proportionally more time at unchanged
+//       m/s; setting a total re-times every beat by one common factor.
+//   G10 LOS: the aim at each waypoint points at the NEXT waypoint, and moving waypoint n+1 changes
+//       waypoint n's aim — the claim that makes "no authored angles" workable at all.
+//   G12 elastic orbit: the stop row stretches the orbit by a RATIO against the derived orbit, and
+//       the radius band still clamps.
+//
+// G4/G4b (persistence round-trip) and G11 (lock release) live in witness_cinema_path_persist.js —
+// they need a save/reopen cycle and the real Alt+C entry, not just the plan API.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const DEG_PER_FRAME_CAP = parseFloat(process.env.CAP || '12');   // G7 cap, stated up front
+const FPS = 15;
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls && window.APP.cinemaPathPlan,
+      { timeout: 90000 });
+    await new Promise(r => setTimeout(r, 9000));
+    await page.waitForFunction(() => {
+      const A = window.APP;
+      try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+
+    const res = await page.evaluate(async (capDeg, fps) => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+
+      const DUR = 24;
+      const N = 400;
+      const sample = (plan) => {
+        const out = [];
+        for (let i = 0; i <= N; i++) out.push(plan.poseAt(i / N));
+        return out;
+      };
+      const maxDiff = (a, b) => {
+        let m = 0;
+        for (let i = 0; i < a.length; i++)
+          m = Math.max(m, Math.abs(a[i].x - b[i].x), Math.abs(a[i].y - b[i].y), Math.abs(a[i].z - b[i].z),
+                          Math.abs(a[i].tx - b[i].tx), Math.abs(a[i].ty - b[i].ty), Math.abs(a[i].tz - b[i].tz));
+        return m;
+      };
+
+      const out = {};
+
+      // ── G5 control: no authored path staged → derived plan.
+      A._cinemaPathEdit = null;
+      const planA = A.cinemaPathPlan(DUR);
+      const planB = A.cinemaPathPlan(DUR);
+      out.g5 = { authored: !!planA.authored, route: planA.route, wp: planA.waypoints.length,
+                 deterministic: maxDiff(sample(planA), sample(planB)) };
+
+      // ── G1: OK-without-edit. The editor hands back NO override when nothing changed, so the bake
+      // re-uses this very plan object. Prove the wrapper with an explicit null override is
+      // identical to the unwrapped derived function.
+      const derived = A.cinemaPathPlanDerived(DUR);
+      out.g1 = { maxPoseDiff: maxDiff(sample(planA), sample(derived)) };
+
+      // ── G10 LOS: aim at each waypoint points at the next one.
+      const wp0 = planA.waypoints.map(w => ({ x: w.x, y: w.y, z: w.z }));
+      const beats = planA.beats;
+      // sample t at the moment the path is nearest waypoint i, then compare the look vector
+      // (target - position) bearing to the bearing toward waypoint i+1.
+      const bearingAt = (t) => {
+        const p = planA.poseAt(t);
+        return Math.atan2(p.tz - p.z, p.tx - p.x) * 180 / Math.PI;
+      };
+      const wpBearing = (i) => Math.atan2(wp0[i + 1].z - wp0[i].z, wp0[i + 1].x - wp0[i].x) * 180 / Math.PI;
+      const angDiff = (a, b) => { let d = Math.abs(a - b) % 360; return d > 180 ? 360 - d : d; };
+      // nearest-t search over the walk-out beat only
+      const losErrs = [];
+      for (let i = 1; i < wp0.length - 1; i++) {
+        let bestT = null, bestD = 1e18;
+        for (let s = 0; s <= 200; s++) {
+          const t = beats.spin + (beats.out - beats.spin) * (s / 200);
+          const p = planA.poseAt(t);
+          const d = Math.hypot(p.x - wp0[i].x, p.z - wp0[i].z);
+          if (d < bestD) { bestD = d; bestT = t; }
+        }
+        losErrs.push({ i, distToWp: bestD, aimErrDeg: angDiff(bearingAt(bestT), wpBearing(i)) });
+      }
+      out.g10 = { perWaypoint: losErrs };
+
+      // ── G2/G3: move waypoint 1 sideways by +5m and up by +1m; sample and compare.
+      if (wp0.length >= 3) {
+        const moved = wp0.map(w => ({ ...w }));
+        moved[1] = { x: wp0[1].x + 5, y: wp0[1].y + 1, z: wp0[1].z };
+        const planM = A.cinemaPathPlan(DUR, { waypoints: moved });
+        const sA = sample(planA), sM = sample(planM);
+        // where in normalized time does the difference live?
+        let firstDiffT = null, lastDiffT = null, maxD = 0;
+        for (let i = 0; i <= N; i++) {
+          const d = Math.hypot(sA[i].x - sM[i].x, sA[i].y - sM[i].y, sA[i].z - sM[i].z);
+          if (d > 0.01) { if (firstDiffT === null) firstDiffT = i / N; lastDiffT = i / N; }
+          maxD = Math.max(maxD, d);
+        }
+        out.g2 = { firstDiffT, lastDiffT, maxD, diveBeatEnd: beats.dive, outBeatEnd: beats.out,
+                   diveUntouched: firstDiffT === null ? true : firstDiffT >= beats.dive * 0.98 };
+
+        // ── G3: eye height. Measured TWICE on purpose.
+        // (a) isolated: a STRAIGHT 2-point path has no corners, so no clearance is measured and the
+        //     arc-length parameterization cannot shift. Height must then move by exactly 1.5m —
+        //     this is the gate on the mechanism itself.
+        // (b) in situ: on a path WITH corners the same edit lands within a few cm rather than
+        //     exactly, because raising the path makes the corner fans hit different geometry, so the
+        //     rounding radius (and with it the arc-length parameterization) legitimately differs.
+        //     Reported as a number rather than hidden inside a loose tolerance on (a).
+        const dyOver = (planBase, planEdit) => {
+          let mn = 1e9, mx = -1e9;
+          for (let s = 0; s <= 100; s++) {
+            const t = beats.spin + (beats.out - beats.spin) * (s / 100);
+            const dy = planEdit.poseAt(t).y - planBase.poseAt(t).y;
+            mn = Math.min(mn, dy); mx = Math.max(mx, dy);
+          }
+          return { mn, mx };
+        };
+        const straight = [{ x: wp0[0].x, y: wp0[0].y, z: wp0[0].z },
+                          { x: wp0[0].x + 20, y: wp0[0].y, z: wp0[0].z }];
+        const straightUp = straight.map(w => ({ x: w.x, y: w.y + 1.5, z: w.z }));
+        const pS = A.cinemaPathPlan(DUR, { waypoints: straight });
+        const pSU = A.cinemaPathPlan(DUR, { waypoints: straightUp });
+        const iso = dyOver(pS, pSU);
+
+        const raised = wp0.map(w => ({ x: w.x, y: w.y + 1.5, z: w.z }));
+        const planR = A.cinemaPathPlan(DUR, { waypoints: raised });
+        const situ = dyOver(planA, planR);
+        out.g3 = { asked: 1.5, isoMin: iso.mn, isoMax: iso.mx, situMin: situ.mn, situMax: situ.mx };
+      }
+
+      // ── G7/G8: a deliberately SHARP authored corner — a hard right-angle dog-leg.
+      {
+        const s0 = planA.waypoints[0];
+        const sharp = [
+          { x: s0.x, y: s0.y, z: s0.z },
+          { x: s0.x + 12, y: s0.y, z: s0.z },
+          { x: s0.x + 12, y: s0.y, z: s0.z + 12 },     // 90 deg
+          { x: s0.x + 24, y: s0.y, z: s0.z + 12 },     // 90 deg back
+        ];
+        const planS = A.cinemaPathPlan(DUR, { waypoints: sharp });
+        // G7 — peak angular rate of the LOOK direction, per rendered frame.
+        const nF = Math.round(24 * fps);
+        let peak = 0, peakT = 0, prev = null;
+        for (let f = 0; f <= nF; f++) {
+          const t = f / nF;
+          if (t < beats.spin || t > beats.out) { prev = null; continue; }
+          const p = planS.poseAt(t);
+          const b = Math.atan2(p.tz - p.z, p.tx - p.x) * 180 / Math.PI;
+          if (prev !== null) {
+            let d = Math.abs(b - prev) % 360; if (d > 180) d = 360 - d;
+            if (d > peak) { peak = d; peakT = t; }
+          }
+          prev = b;
+        }
+        out.g7 = { peakDegPerFrame: peak, atT: peakT, cap: capDeg, fps };
+
+        // G8 — max deviation of the FLOWN curve from each authored waypoint, vs measured clearance.
+        const flown = A.cinemaRoundCorners(sharp);
+        const dev = [];
+        for (let i = 1; i < sharp.length - 1; i++) {
+          let best = 1e18;
+          for (const p of flown) best = Math.min(best, Math.hypot(p.x - sharp[i].x, p.y - sharp[i].y, p.z - sharp[i].z));
+          let clear = null;
+          try { const f = A.cinemaFan({ x: sharp[i].x, y: sharp[i].y, z: sharp[i].z }, 8); clear = f && isFinite(f.min) ? f.min : null; } catch (e) {}
+          dev.push({ i, deviation: best, clearance: clear });
+        }
+        out.g8 = { perCorner: dev };
+
+        // G9 — constant speed. Double a leg, expect the natural out-time to rise proportionally.
+        const lenOf = (wps) => {
+          const pts = A.cinemaRoundCorners(wps);
+          let L = 0;
+          for (let i = 1; i < pts.length; i++) L += Math.hypot(pts[i].x - pts[i-1].x, pts[i].y - pts[i-1].y, pts[i].z - pts[i-1].z);
+          return L;
+        };
+        const longer = sharp.map(w => ({ ...w }));
+        longer[3] = { x: s0.x + 36, y: s0.y, z: s0.z + 12 };   // last leg 12m -> 24m
+        const L1 = lenOf(sharp), L2 = lenOf(longer);
+        const speed = planA.pathLen / planA.sec.out;
+        out.g9 = { L1, L2, speed, outSec1: L1 / speed, outSec2: L2 / speed,
+                   ratioLen: L2 / L1, ratioTime: (L2 / speed) / (L1 / speed) };
+
+        // G12 — elastic orbit: push the stop row 1.5x further from the pivot, expect the logged
+        // scale to match and the granted radius to be the band-clamped product.
+        const piv = planA.pivot;
+        const last = sharp[sharp.length - 1];
+        const dx = last.x - piv.x, dz = last.z - piv.z;
+        const stretched = sharp.map(w => ({ ...w }));
+        stretched[3] = { x: piv.x + dx * 1.5, y: last.y + 4, z: piv.z + dz * 1.5 };
+        const planE = A.cinemaPathPlan(DUR, { waypoints: stretched });
+        // orbit height offset shows up at the very end of the film
+        out.g12 = { baseEndY: planS.poseAt(1).y, elasticEndY: planE.poseAt(1).y,
+                    radiusMin: planA.radiusMin, radiusMax: planA.radiusMax, fillDistance: planA.fillDistance };
+      }
+
+      A._cinemaPathEdit = null;
+      return out;
+    }, DEG_PER_FRAME_CAP, FPS);
+
+    const checks = [];
+    const P = (name, ok, detail) => { checks.push({ name, ok, detail }); if (!ok) allPass = false; };
+
+    console.log('  §CINEMA_CORNERS lines seen:');
+    logs.filter(l => l.startsWith('§CINEMA_CORNERS')).slice(-4).forEach(l => console.log('    ' + l));
+    logs.filter(l => l.startsWith('§CINEMA_ORBIT_ELASTIC') || l.startsWith('§CINEMA_PATH_EDIT')).slice(-4).forEach(l => console.log('    ' + l));
+
+    P('G5 control: no authored path → derived route',
+      res.g5.authored === false && res.g5.deterministic < 1e-9,
+      `authored=${res.g5.authored} route=${res.g5.route} wp=${res.g5.wp} replanDiff=${res.g5.deterministic.toExponential(2)}`);
+
+    P('G1 OK-without-edit is byte-identical',
+      res.g1.maxPoseDiff === 0,
+      `maxPoseDiff=${res.g1.maxPoseDiff}`);
+
+    if (res.g10) {
+      const worst = Math.max(...res.g10.perWaypoint.map(w => w.aimErrDeg), 0);
+      P('G10 LOS aim points at the next waypoint (<=25 deg through smoothing)',
+        res.g10.perWaypoint.length === 0 || worst <= 25,
+        res.g10.perWaypoint.map(w => `wp${w.i}: aimErr=${w.aimErrDeg.toFixed(1)}deg d=${w.distToWp.toFixed(2)}m`).join(' | ') || 'no interior waypoints');
+    }
+
+    if (res.g2) {
+      P('G2 waypoint edit changes the path, and not the dive before it',
+        res.g2.maxD > 0.5 && res.g2.diveUntouched,
+        `maxDelta=${res.g2.maxD.toFixed(2)}m firstDiffT=${res.g2.firstDiffT} diveEnds=${res.g2.diveBeatEnd.toFixed(3)}`);
+    }
+    if (res.g3) {
+      const isoErr = Math.max(Math.abs(res.g3.isoMin - 1.5), Math.abs(res.g3.isoMax - 1.5));
+      const situErr = Math.max(Math.abs(res.g3.situMin - 1.5), Math.abs(res.g3.situMax - 1.5));
+      P('G3 camera height moves by exactly what was asked (straight path, no rounding)',
+        isoErr < 0.001,
+        `asked=1.5m got=[${res.g3.isoMin.toFixed(4)},${res.g3.isoMax.toFixed(4)}] err=${isoErr.toExponential(2)}m`);
+      // Not a gate — a reported second-order term. Raising a cornered path makes the corner fans hit
+      // different geometry, so the rounding radius and the arc-length parameterization legitimately
+      // shift. Printed so the size of that effect is on record instead of being assumed negligible.
+      console.log(`  INFO  G3 in-situ (path with corners): got=[${res.g3.situMin.toFixed(3)},${res.g3.situMax.toFixed(3)}] ` +
+        `spread=${situErr.toFixed(4)}m — re-planning term, not a height error`);
+    }
+
+    P(`G7 no sharp corners: peak <= ${DEG_PER_FRAME_CAP} deg/frame on a 90-deg dog-leg`,
+      res.g7.peakDegPerFrame <= DEG_PER_FRAME_CAP,
+      `peak=${res.g7.peakDegPerFrame.toFixed(1)} deg/frame at t=${res.g7.atT.toFixed(3)} (fps=${res.g7.fps})`);
+
+    const g8bad = res.g8.perCorner.filter(c => c.clearance != null && c.deviation > c.clearance);
+    P('G8 curve deviation <= measured clearance at every corner',
+      g8bad.length === 0,
+      res.g8.perCorner.map(c => `corner${c.i}: dev=${c.deviation.toFixed(2)}m clear=${c.clearance == null ? 'n/a' : c.clearance.toFixed(2) + 'm'}`).join(' | '));
+
+    P('G9 constant speed: time ratio == length ratio',
+      Math.abs(res.g9.ratioTime - res.g9.ratioLen) < 1e-9,
+      `len ${res.g9.L1.toFixed(1)}→${res.g9.L2.toFixed(1)}m (x${res.g9.ratioLen.toFixed(3)}) time ${res.g9.outSec1.toFixed(2)}→${res.g9.outSec2.toFixed(2)}s at ${res.g9.speed.toFixed(2)}m/s`);
+
+    P('G12 elastic orbit: stop row raises the orbit height',
+      Math.abs(res.g12.elasticEndY - res.g12.baseEndY) > 0.5,
+      `endY ${res.g12.baseEndY.toFixed(2)} → ${res.g12.elasticEndY.toFixed(2)} band=[${res.g12.radiusMin.toFixed(1)},${res.g12.radiusMax.toFixed(1)}] fill=${res.g12.fillDistance.toFixed(1)}`);
+
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.name}\n          ${c.detail}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), checks });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.checks.filter(c => c.ok).length}/${s.checks.length})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cinema_path_persist.js
+++ b/witness_cinema_path_persist.js
@@ -1,0 +1,205 @@
+// WITNESS — §CINEMA_PATH_EDITOR persistence + lock release.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL, guardrail 5, item 20.
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G4  round-trip: edit → "Save this path" → _exportBuildingDb() → _openDbBytes() → the SAME edited
+//       path is in force. Proven by SAMPLED POSES, never by the table merely existing — a table full
+//       of rows nothing reads would pass a weaker test and ship a dead feature.
+//   G4b ephemerality: edit → proceed WITHOUT saving → export/reopen → the plan is the unedited
+//       derived one. If this fails, experimenting with waypoints silently mutates the building,
+//       which is exactly what the explicit-save rule exists to prevent.
+//   G11 lock release: while the editor is open, A._maxqActive is false (so dlod_nav.js does not
+//       report 'cinema' and disengage DLOD) and the wake lock is released; both re-claimed on OK.
+//       Proves defect (20) is fixed rather than merely described.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BLD = process.env.BLD || 'Duplex';
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  const url = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.cinemaPathPlan && window.APP._exportBuildingDb,
+    { timeout: 90000 });
+  await new Promise(r => setTimeout(r, 9000));
+  await page.waitForFunction(() => {
+    const A = window.APP;
+    try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+
+  console.log(`\n${'='.repeat(78)}\n${BLD} — persistence + locks\n${'='.repeat(78)}`);
+
+  const checks = [];
+  const P = (name, ok, detail) => { checks.push({ name, ok, detail }); console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}\n          ${detail}`); };
+
+  // ══ G4 / G4b ══
+  const res = await page.evaluate(async () => {
+    const A = window.APP;
+    if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+    if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+    const DUR = 24, N = 200;
+    const sample = (p) => { const o = []; for (let i = 0; i <= N; i++) { const q = p.poseAt(i / N); o.push([q.x, q.y, q.z]); } return o; };
+    const maxDiff = (a, b) => { let m = 0; for (let i = 0; i < a.length; i++) for (let k = 0; k < 3; k++) m = Math.max(m, Math.abs(a[i][k] - b[i][k])); return m; };
+
+    A._cinemaPathEdit = null;
+    const derived = A.cinemaPathPlan(DUR);
+    const derivedSample = sample(derived);
+    const wp = derived.waypoints.map(w => ({ x: w.x, y: w.y, z: w.z }));
+
+    // A clearly visible edit: shove waypoint 1 sideways 6m and raise the whole path 1m.
+    const edited = wp.map((w, i) => ({ x: w.x + (i === 1 ? 6 : 0), y: w.y + 1, z: w.z }));
+    const ov = { waypoints: edited, diveSec: derived.sec.dive, spinSec: derived.sec.spin,
+                 outSec: derived.sec.out, riseSec: derived.sec.rise, _total: DUR };
+    const editedSample = sample(A.cinemaPathPlan(DUR, ov));
+
+    // ── G4b FIRST: adjust but do NOT save, then export. The table must not appear.
+    A._cinemaPathEdit = null;
+    const bytesNoSave = A._exportBuildingDb();
+    const hasTableNoSave = (() => {
+      try {
+        const Database = A.db.constructor;
+        const d = new Database(bytesNoSave);
+        const r = d.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='cinema_path'");
+        const n = r.length ? r[0].values.length : 0;
+        d.close();
+        return n > 0;
+      } catch (e) { return 'ERR:' + e.message; }
+    })();
+
+    // ── G4: stage via the same call the editor's "Save this path" button makes, then export.
+    A.stageCinemaPath(ov);
+    const bytesSaved = A._exportBuildingDb();
+    let savedRows = -1;
+    try {
+      const Database = A.db.constructor;
+      const d = new Database(bytesSaved);
+      const r = d.exec("SELECT COUNT(*) FROM cinema_path");
+      savedRows = r.length ? r[0].values[0][0] : 0;
+      d.close();
+    } catch (e) { savedRows = 'ERR:' + e.message; }
+
+    return { derivedSample, editedSample, hasTableNoSave, savedRows,
+             editedDelta: maxDiff(derivedSample, editedSample),
+             bytesSaved: Array.from(bytesSaved.slice(0, 0)), // not transferred; reopened in-page below
+             wpCount: wp.length };
+  });
+
+  P('G4b ephemeral: adjusting without saving writes NO cinema_path table',
+    res.hasTableNoSave === false,
+    `cinema_path present after export-without-save = ${res.hasTableNoSave}`);
+
+  P('G4 pre-check: the edit actually changes the flown path',
+    res.editedDelta > 0.5,
+    `maxPoseDelta derived→edited = ${res.editedDelta.toFixed(2)}m over ${res.wpCount} waypoints`);
+
+  P('G4 stage+export writes the table',
+    res.savedRows === res.wpCount,
+    `cinema_path rows=${res.savedRows} (expected ${res.wpCount})`);
+
+  // ── The real G4. _openDbBytes caches the bytes and NAVIGATES (scene.js:696), so the round-trip
+  // runs through a genuine page reload — the actual user path, not a same-page re-parse. Sample the
+  // authored path first, hand it out to Node, reload, and compare after.
+  const before = await page.evaluate(() => {
+    const A = window.APP;
+    const DUR = 24, N = 200;
+    const o = [];
+    const p = A.cinemaPathPlan(DUR);      // authored, still staged in memory
+    for (let i = 0; i <= N; i++) { const q = p.poseAt(i / N); o.push([q.x, q.y, q.z]); }
+    return o;
+  });
+
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 }),
+    page.evaluate(async () => {
+      const A = window.APP;
+      const bytes = A._exportBuildingDb();
+      A._cinemaPathEdit = null;           // nothing may survive in memory — it must come from the file
+      await A._openDbBytes('roundtrip.db', bytes);
+    }),
+  ]);
+
+  await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.cinemaPathPlan, { timeout: 90000 });
+  await new Promise(r => setTimeout(r, 9000));
+  await page.waitForFunction(() => {
+    const A = window.APP;
+    try { const r = A.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r.length && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+
+  const round = await page.evaluate(async (before) => {
+    const A = window.APP;
+    if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+    if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+    const DUR = 24, N = 200;
+    const p = A.cinemaPathPlan(DUR);      // first plan on the reopened DB → lazy restore fires here
+    let m = 0;
+    for (let i = 0; i <= N; i++) {
+      const q = p.poseAt(i / N);
+      m = Math.max(m, Math.abs(q.x - before[i][0]), Math.abs(q.y - before[i][1]), Math.abs(q.z - before[i][2]));
+    }
+    return { restored: !!A._cinemaPathEdit,
+             wpRestored: A._cinemaPathEdit ? A._cinemaPathEdit.waypoints.length : 0,
+             authored: !!p.authored, poseDiff: m };
+  }, before);
+
+  P('G4 round-trip: reopened DB flies the SAME edited path (sampled poses, not table presence)',
+    round.restored && round.authored && round.poseDiff < 0.05,
+    `restored=${round.restored} authored=${round.authored} waypoints=${round.wpRestored} maxPoseDiff before→after reload = ${round.poseDiff.toFixed(4)}m`);
+
+  const restoreLine = logs.filter(l => l.startsWith('§CINEMA_PATH_RESTORE')).pop();
+  const saveLine = logs.filter(l => l.startsWith('§CINEMA_PATH_SAVE')).pop();
+  console.log('  LOG   ' + (saveLine || 'no §CINEMA_PATH_SAVE line'));
+  console.log('  LOG   ' + (restoreLine || 'no §CINEMA_PATH_RESTORE line'));
+
+  // ══ G11 — lock release around the editor. Drive the REAL Alt+C entry with the preview skipped,
+  // and stub the editor so we can observe the state WHILE it is open.
+  const locks = await page.evaluate(async () => {
+    const A = window.APP;
+    A._cinemaPathEdit = null;
+    const seen = {};
+    const realOpen = A.cinemaPathEditor ? A.cinemaPathEditor.open : null;
+    if (!realOpen) return { skipped: 'cinemaPathEditor not loaded' };
+    A.cinemaPathEditor.open = function(ctx) {
+      // Observed from INSIDE the open editor — the whole point of item 20.
+      seen.duringMaxqActive = A._maxqActive;
+      seen.duringWaypoints = ctx.plan.waypoints.length;
+      return Promise.resolve({ action: 'cancel', override: null, durationSec: ctx.durationSec });
+    };
+    seen.beforeMaxqActive = A._maxqActive;
+    await A.startMaxQualityOrbit({ preview: false, frames: 30, fps: 15 });
+    seen.afterMaxqActive = A._maxqActive;
+    A.cinemaPathEditor.open = realOpen;
+    return seen;
+  });
+
+  if (locks.skipped) {
+    P('G11 lock release around the editor', false, locks.skipped);
+  } else {
+    P('G11 DLOD is NOT held disengaged while the editor is open',
+      locks.duringMaxqActive === false,
+      `_maxqActive before=${locks.beforeMaxqActive} during=${locks.duringMaxqActive} after=${locks.afterMaxqActive} (waypoints seen by editor=${locks.duringWaypoints})`);
+    const lockLines = logs.filter(l => l.startsWith('§CPE_LOCKS'));
+    P('G11 locks released and re-claimed, both logged',
+      lockLines.length >= 2,
+      lockLines.join(' | ') || 'no §CPE_LOCKS lines');
+    P('G11 Cancel from the editor bakes nothing',
+      logs.some(l => l.indexOf('§MAXQ_CANCEL from path editor') >= 0),
+      logs.filter(l => l.startsWith('§MAXQ_CANCEL')).pop() || 'no cancel line');
+  }
+
+  await browser.close();
+  const allPass = checks.every(c => c.ok);
+  console.log(`\n${allPass ? 'WITNESS PASS' : 'WITNESS FAIL'}  (${checks.filter(c => c.ok).length}/${checks.length})`);
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Alt+C's cinema plan now exposes an editable waypoint table (side panel) instead of only replaying the derived path — drag to move, ctrl+drag for height, double-click to release.
- `A.cinemaPathPlan` is a thin override wrapper around the existing 600-line plan body; no-edit path is byte-identical by construction (measured maxPoseDiff=0).
- `_cinemaRoundCorners()` rounds waypoint corners within measured clearance, retiring the previously-ungated D2 corner whip (19.8 → 7.5 deg/frame, cap 12).
- Fixes two silent defects found by the new witnesses: `settle` now follows waypoint 0 (was teleporting the camera at the beat seam on a height edit), and `odx/odz` no longer snaps to the stale derived-exit bearing (was a 115° single-frame jerk on an edited path — worse than the bug this feature removes).
- `cinema_path` table round-trips through `_exportBuildingDb`, same pattern as `staffage_instances`.

## Test plan
- [x] `witness_cinema_path_editor.js` 9/9 on Duplex + Terminal
- [x] `witness_cinema_path_persist.js` 7/7 (save round-trip survives a real page reload)
- [x] Existing cinema witnesses verified byte-identical branch vs origin/main (5 of 6 are already red on main, unrelated to this branch; `witness_cinema_damping_bleed` times out on main and could not be compared either way)
- [ ] Drag/ctrl+drag/double-click DOM interaction not yet driven by hand in a real browser — plan API and lock-release logic verified via stub, but real pointer events are untested

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)