### PR TITLE
fix(cinema): §CINEMA_PATH_EDITOR — no-hit fan is UNKNOWN not 60m, plus orange held-state feedback

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -486,10 +486,17 @@
       if (_cpeRes && _cpeRes.override) {
         // Constant speed means an edited path generally changes the total, so the frame count is
         // re-derived from it (item 11 — this is the render cost the editor surfaced).
+        var _framesWas = nFrames;
         nFrames = Math.max(1, Math.round(_cpeRes.durationSec * fps));
         plan = A.cinemaPathPlan(nFrames / fps, _cpeRes.override);
         console.log('§CPE_APPLIED total=' + _cpeRes.durationSec.toFixed(1) + 's frames=' + nFrames +
           ' waypoints=' + _cpeRes.override.waypoints.length + ' saved=' + !!_cpeRes.saved);
+        // §MAXQ_START was printed before the editor opened, so its frame count is now stale — a
+        // pasted console must not disagree with what actually gets baked (observed live: START said
+        // 360, the bake ran 489).
+        if (nFrames !== _framesWas)
+          console.log('§MAXQ_START_REVISED frames=' + _framesWas + '→' + nFrames +
+            ' (path edited; §MAXQ_START above is superseded)');
       } else {
         // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
         // literally the same object, so the film is byte-identical to one recorded without the

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -30,10 +30,11 @@
   // depthTest:false/renderOrder so the marker SHINES THROUGH WALLS. That last property is
   // load-bearing, not decoration — when the editor opens the camera is outside the building, so a
   // depth-tested marker sitting in a room would simply not be visible at all.
-  function _mkMarker(p, color) {
+  function _mkMarker(p, color, scale, opacity) {
     var a = A();
-    var geo = new THREE.SphereGeometry(MARKER_R, 12, 10);
-    var mat = new THREE.MeshBasicMaterial({ color: color, transparent: true, opacity: 0.9,
+    var geo = new THREE.SphereGeometry(MARKER_R * (scale == null ? 1 : scale), 12, 10);
+    var mat = new THREE.MeshBasicMaterial({ color: color, transparent: true,
+                                            opacity: (opacity == null ? 0.9 : opacity),
                                             depthTest: false, depthWrite: false });
     var m = new THREE.Mesh(geo, mat);
     m.position.set(p.x, p.y, p.z);
@@ -82,8 +83,10 @@
     _state.objs.push(_mkLine(flown, 0x4fc3f7, 2));
     for (var i = 0; i < wp.length; i++) {
       var held = (i === _state.held);
-      var sel = (i === _state.sel);
-      var m = _mkMarker(wp[i], held ? 0xffcc00 : sel ? 0xffffff : 0x4fc3f7);
+      // Blue = a waypoint you have not picked up; ORANGE and breathing = the one you are holding.
+      // The blue ones stay clearly visible (they ARE the rest of the path, not decoration) but read
+      // as secondary, so at a glance it is obvious which single point your drag will move.
+      var m = _mkMarker(wp[i], held ? 0xff8c00 : 0x4fc3f7, held ? 1 : 0.7, held ? 0.95 : 0.75);
       m.userData._cpeIndex = i;
       _state.objs.push(m);
       _state.markers.push(m);
@@ -91,23 +94,39 @@
     if (a.markDirty) a.markDirty();
   }
 
+  // CONTINUOUS pulse while a point is held, not a one-shot settle (user, 2026-07-27: "status
+  // feedback, the buttons should pulse louder perhaps some orange"). A held point freezes the
+  // canvas, so its marker has to stay visibly alive the whole time it is held — a pulse that
+  // finishes after 300ms leaves a frozen scene with a static dot, which is exactly the state that
+  // reads as a hang.
+  // Throttled to PULSE_HZ: every frame would markDirty() continuously and stop the renderer's idle
+  // parking for as long as a point is held — on Hospital that is 63k elements re-rendering at full
+  // rate while the user types in a text box. 12Hz still reads as a smooth breath.
+  var PULSE_HZ = 12;
   function _pulse(idx) {
     var a = A();
     if (!_state || !_state.markers[idx]) return;
     var m = _state.markers[idx];
     var myPulse = ++_state.pulseId;
-    var t = 0;
+    var t0 = performance.now(), lastPaint = 0;
     (function frame() {
       if (!_state || myPulse !== _state.pulseId || !m.parent) return;
-      t += 0.06; if (t > 1) t = 1;
-      var e = 1 - Math.pow(1 - t, 3);
-      var k = 1 - e;
-      m.scale.setScalar(1 + k * 1.8);
-      m.material.opacity = 0.9 - k * 0.3;
-      if (a.markDirty) a.markDirty();
-      if (t < 1) requestAnimationFrame(frame);
-      else { m.scale.setScalar(1); m.material.opacity = 0.9; if (a.markDirty) a.markDirty(); }
+      var now = performance.now();
+      if (now - lastPaint >= 1000 / PULSE_HZ) {
+        lastPaint = now;
+        var phase = ((now - t0) % 900) / 900;              // 0.9s breath
+        var k = 0.5 - 0.5 * Math.cos(phase * Math.PI * 2); // smooth 0→1→0
+        m.scale.setScalar(1 + k * 0.9);
+        m.material.opacity = 0.65 + k * 0.35;
+        if (a.markDirty) a.markDirty();
+      }
+      requestAnimationFrame(frame);
     })();
+  }
+  function _stopPulse() {
+    if (!_state) return;
+    _state.pulseId++;
+    if (A().markDirty) A().markDirty();
   }
 
   // ── Frame a waypoint: back the camera up so the point is genuinely in view and grabbable
@@ -192,12 +211,25 @@
     d.style.cssText = 'position:fixed;top:60px;right:12px;width:396px;max-height:calc(100vh - 96px);' +
       'overflow:auto;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:8px;' +
       'z-index:10000;font-family:system-ui,sans-serif;color:#ddd;box-shadow:0 8px 32px rgba(0,0,0,0.6)';
+    // Orange breathing glow, same language as the held marker in the canvas — one visual idea for
+    // "this is live / this wants your attention", not two unrelated ones.
+    if (!document.getElementById('cpe-style')) {
+      var st = document.createElement('style');
+      st.id = 'cpe-style';
+      st.textContent =
+        '@keyframes cpe-breathe{0%,100%{box-shadow:0 0 4px rgba(255,140,0,0.35)}50%{box-shadow:0 0 16px rgba(255,140,0,0.95)}}' +
+        '.cpe-live{animation:cpe-breathe 1.2s ease-in-out infinite}' +
+        '#cpe-panel button{transition:background .15s,color .15s,border-color .15s}' +
+        '#cpe-panel button:disabled{opacity:.45;cursor:default}';
+      document.head.appendChild(st);
+    }
     d.innerHTML =
       '<div style="padding:10px 12px;border-bottom:1px solid #3a3f47;font-size:13px;font-weight:600;color:#4fc3f7">' +
         'Cinema path <span style="font-weight:400;color:#888;font-size:11px">— edit before recording</span></div>' +
       '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
       '<div id="cpe-rows" style="padding:4px 0"></div>' +
       '<div style="padding:8px 12px;border-top:1px solid #3a3f47;font-size:11px" id="cpe-clock"></div>' +
+      '<div id="cpe-state" style="padding:0 12px 6px;font-size:10px;color:#666"></div>' +
       '<div style="padding:10px 12px;border-top:1px solid #3a3f47;display:flex;gap:8px;justify-content:flex-end">' +
         '<button id="cpe-cancel" style="padding:6px 12px;font-size:12px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:4px;cursor:pointer">Cancel</button>' +
         '<button id="cpe-save" style="padding:6px 12px;font-size:12px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:4px;cursor:pointer">Save this path</button>' +
@@ -243,7 +275,8 @@
             if (!isFinite(v)) { inp.value = _num(wp[i][ax]); return; }
             wp[i][ax] = v;
             console.log('§CPE_KEY i=' + i + ' ' + ax + '=' + v.toFixed(2));
-            _redrawScene(); _renderClock();
+            _state.staged = false;   // the staged path no longer matches what is on screen
+            _redrawScene(); _renderClock(); _syncButtons();
           });
           inp.addEventListener('click', function(ev) { ev.stopPropagation(); });
           row.appendChild(inp);
@@ -281,7 +314,8 @@
       if (!isFinite(v) || v < 1) { inp.value = (Math.round(total * 10) / 10); return; }
       _state.userTotal = v;
       console.log('§CPE_TOTAL set=' + v.toFixed(1) + 's natural=' + nat.total.toFixed(1) + 's scale=' + (v / nat.total).toFixed(3));
-      _renderClock();
+      _state.staged = false;
+      _renderClock(); _syncButtons();
     });
     line1.appendChild(inp);
     var sfx = document.createElement('span');
@@ -310,11 +344,14 @@
   }
 
   function _select(i, frame) {
+    var was = _state.held;
     _state.sel = i;
     _state.held = i;
     if (A().controls) A().controls.enabled = false;   // item 13 — same pattern as grid_drag.js
-    console.log('§CPE_HOLD i=' + i + ' controls.enabled=false');
-    _redrawScene(); _renderRows(); _renderHint();
+    // Only log a CHANGE of hold. Re-clicking the same row is common and logged it every time
+    // (observed 4-5 identical lines in a row, live Hospital 2026-07-27).
+    if (was !== i) console.log('§CPE_HOLD i=' + i + ' controls.enabled=false');
+    _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
     _pulse(i);
     if (frame) _frameWaypoint(i);
   }
@@ -323,9 +360,53 @@
     if (_state.held == null) return;
     var was = _state.held;
     _state.held = null;
+    _stopPulse();
     if (A().controls) A().controls.enabled = true;
     console.log('§CPE_RELEASE i=' + was + ' why=' + why + ' controls.enabled=true');
-    _redrawScene(); _renderRows(); _renderHint();
+    _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
+  }
+
+  // ══ Button status feedback (user, 2026-07-27: "status feedback, the buttons should pulse louder
+  // perhaps some orange"). The buttons carry the answer to "what happens if I stop now?":
+  //   nothing edited → OK is the plain default, Save is disabled (there is nothing to save)
+  //   edited        → OK turns ORANGE and breathes (a different film is queued), Save lights up
+  //   saved         → Save goes quiet and says so, because the edit is now staged
+  // Same orange, same breath as the held marker in the canvas — one idea, two places.
+  function _syncButtons() {
+    var ok = document.getElementById('cpe-ok'),
+        save = document.getElementById('cpe-save'),
+        note = document.getElementById('cpe-state');
+    if (!ok || !save) return;
+    var edited = _isEdited();
+    ok.classList.toggle('cpe-live', edited);
+    ok.style.background = edited ? '#ff8c00' : '#4fc3f7';
+    ok.textContent = edited ? 'OK — record this' : 'OK';
+    save.disabled = !edited || _state.staged;
+    save.classList.toggle('cpe-live', edited && !_state.staged);
+    save.style.borderColor = (edited && !_state.staged) ? '#ff8c00' : '#4a4f57';
+    save.style.color = (edited && !_state.staged) ? '#ffb74d' : '#ddd';
+    save.textContent = _state.staged ? 'Path saved' : 'Save this path';
+    if (note) {
+      var nat = _naturalDuration();
+      var total = _state.userTotal != null ? _state.userTotal : nat.total;
+      note.style.color = edited ? '#ffb74d' : '#666';
+      note.textContent = _state.staged
+        ? 'Saved — Ctrl+S writes it into the building file.'
+        : edited
+          ? 'Edited — ' + total.toFixed(1) + 's film queued. Not saved to the building.'
+          : 'Unedited — OK records exactly the film the preview just showed.';
+    }
+  }
+
+  function _isEdited() {
+    if (!_state || !_state.origWp) return false;
+    if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
+    var b = _state.origWp;
+    if (_state.wp.length !== b.length) return true;
+    for (var i = 0; i < b.length; i++)
+      if (Math.abs(_state.wp[i].x - b[i].x) > 1e-6 || Math.abs(_state.wp[i].y - b[i].y) > 1e-6 ||
+          Math.abs(_state.wp[i].z - b[i].z) > 1e-6) return true;
+    return false;
   }
 
   // ══════════════════ canvas interaction ══════════════════
@@ -394,7 +475,8 @@
         var p = _planePoint(ev, w.y);
         if (p) { w.x = p.x; w.z = p.z; }
       }
-      _redrawScene(); _renderRows(); _renderClock();
+      _state.staged = false;
+      _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
     };
 
     h.up = function(ev) {
@@ -458,6 +540,10 @@
       }
       _state = {
         wp: plan.waypoints.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+        // Pristine copy — "edited" is measured against what the plan derived, so a value typed and
+        // typed back does not count as an edit and guardrail 2 still holds.
+        origWp: plan.waypoints.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+        staged: false,
         sel: null, held: null, drag: null, objs: [], markers: [], pulseId: 0, flyId: 0,
         baseSec: { dive: plan.sec.dive, spin: plan.sec.spin, out: plan.sec.out, rise: plan.sec.rise },
         baseOutSec: plan.sec.out,
@@ -477,12 +563,13 @@
 
       var panel = _buildPanel();
       _state.panel = panel;
-      _redrawScene(); _renderRows(); _renderClock(); _renderHint();
+      _redrawScene(); _renderRows(); _renderClock(); _renderHint(); _syncButtons();
       _wire();
 
       function finish(action) {
         var ov = (action === 'ok' || action === 'save') ? _buildOverride() : null;
-        var edited = ov ? _edited(ov) : false;
+        var edited = ov ? _isEdited() : false;
+        _stopPulse();
         _release('close');
         _unwire();
         _clearScene();
@@ -505,20 +592,6 @@
                   durationSec: edited ? total : ctx.durationSec });
       }
 
-      // "Edited" means the authored path actually differs from what the plan derived. Floating
-      // point round-trips through the number inputs must not count as an edit.
-      function _edited(ov) {
-        if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
-        var base = plan.waypoints;
-        if (ov.waypoints.length !== base.length) return true;
-        for (var i = 0; i < base.length; i++) {
-          if (Math.abs(ov.waypoints[i].x - base[i].x) > 1e-6) return true;
-          if (Math.abs(ov.waypoints[i].y - base[i].y) > 1e-6) return true;
-          if (Math.abs(ov.waypoints[i].z - base[i].z) > 1e-6) return true;
-        }
-        return false;
-      }
-
       document.getElementById('cpe-ok').addEventListener('click', function() { finish('ok'); });
       document.getElementById('cpe-cancel').addEventListener('click', function() { finish('cancel'); });
       document.getElementById('cpe-save').addEventListener('click', function() {
@@ -526,7 +599,10 @@
         // carries it to the file, exactly as staffage does. Never auto-persist on adjust.
         var ov = _buildOverride();
         if (typeof a.stageCinemaPath === 'function') a.stageCinemaPath(ov);
-        finish('save');
+        // Staging is not closing: the user said "save this path", not "record it now". Keep the
+        // editor open so they can carry on adjusting, and let the buttons say what happened.
+        _state.staged = true;
+        _syncButtons();
       });
     });
   }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3322,7 +3322,7 @@ async function setupEffects(A, renderer, scene, camera) {
   // is why `r` may be taken straight from _cinemaFan.min with no safety fudge factor invented on top.
   function _cinemaRoundCorners(wp) {
     if (!wp || wp.length < 3) return (wp || []).slice();
-    var out = [{ x: wp[0].x, y: wp[0].y, z: wp[0].z }], rounded = 0, rMin = 1e9, rMax = 0;
+    var out = [{ x: wp[0].x, y: wp[0].y, z: wp[0].z }], rounded = 0, rMin = 1e9, rMax = 0, unmeasured = 0;
     for (var i = 1; i < wp.length - 1; i++) {
       var p0 = wp[i - 1], p1 = wp[i], p2 = wp[i + 1];
       var ax = p1.x - p0.x, ay = p1.y - p0.y, az = p1.z - p0.z;
@@ -3336,11 +3336,23 @@ async function setupEffects(A, renderer, scene, camera) {
       if (turnDeg < 3) { out.push({ x: p1.x, y: p1.y, z: p1.z }); continue; }
       // MEASURED clearance at this corner. Fallback is CINEMA_FAN_NUDGE_MAX — an existing constant
       // that already means "how far the camera may slide about inside a room" — not a new number.
-      var clear = CINEMA_FAN_NUDGE_MAX;
+      //
+      // ⚠ NO-HIT IS NOT A MEASUREMENT (live Hospital log, 2026-07-27). `_cinemaFan` returns
+      // CINEMA_FAN_FAR for a ray that hits nothing, so a fan that hits nothing AT ALL reports
+      // min=60.0 — which reads as "60 metres of clearance" but actually means "unknown, the BVH saw
+      // no geometry here." Taking it at face value let the rounding radius fall through to the
+      // 40%-of-leg cap and cut 7.50m inside a point the user had placed by hand, while G8 passed
+      // vacuously by comparing that cut against the same fictional 60m. Treat a full no-hit fan as
+      // UNKNOWN and fall back to the same conservative nudge budget as an outright fan failure.
+      var clear = CINEMA_FAN_NUDGE_MAX, clearSrc = 'no-bvh';
       try {
         var fanC = _cinemaFan({ x: p1.x, y: p1.y, z: p1.z }, 8);
-        if (fanC && isFinite(fanC.min)) clear = fanC.min;
+        if (fanC && isFinite(fanC.min)) {
+          if (fanC.min >= CINEMA_FAN_FAR - 0.01) { clearSrc = 'unknown(no-hit)'; }
+          else { clear = fanC.min; clearSrc = 'measured'; }
+        }
       } catch (eC) { /* no BVH yet → the existing nudge budget stands in */ }
+      if (clearSrc !== 'measured') unmeasured++;
       var r = Math.min(clear, aL * CINEMA_CORNER_LEG_FRAC, bL * CINEMA_CORNER_LEG_FRAC);
       if (!(r > 0.01)) { out.push({ x: p1.x, y: p1.y, z: p1.z }); continue; }
       rounded++; rMin = Math.min(rMin, r); rMax = Math.max(rMax, r);
@@ -3357,11 +3369,22 @@ async function setupEffects(A, renderer, scene, camera) {
     }
     var last = wp[wp.length - 1];
     out.push({ x: last.x, y: last.y, z: last.z });
-    console.log('§CINEMA_CORNERS control=' + wp.length + ' flown=' + out.length + ' rounded=' + rounded +
-      ' rMin=' + (rounded ? rMin.toFixed(2) : 'n/a') + ' rMax=' + (rounded ? rMax.toFixed(2) : 'n/a') +
-      ' maxDeviation=' + (rounded ? (rMax / 2).toFixed(2) : '0.00') + 'm (bound=clearance/2)');
+    // Throttled: a live drag re-plans on every pointermove, and an unthrottled line here flooded a
+    // real user's console with dozens of identical rows per second (observed Hospital, 2026-07-27).
+    // Log only when the shape actually changes, plus at most once a second.
+    var sig = wp.length + '|' + out.length + '|' + rounded + '|' + rMax.toFixed(2) + '|' + unmeasured;
+    var nowMs = (typeof performance !== 'undefined') ? performance.now() : 0;
+    if (sig !== _cornersLastSig || nowMs - _cornersLastMs > 1000) {
+      _cornersLastSig = sig; _cornersLastMs = nowMs;
+      console.log('§CINEMA_CORNERS control=' + wp.length + ' flown=' + out.length + ' rounded=' + rounded +
+        ' rMin=' + (rounded ? rMin.toFixed(2) : 'n/a') + ' rMax=' + (rounded ? rMax.toFixed(2) : 'n/a') +
+        ' maxDeviation=' + (rounded ? (rMax / 2).toFixed(2) : '0.00') + 'm' +
+        ' unmeasuredCorners=' + unmeasured + '/' + rounded +
+        (unmeasured ? ' (fan saw no geometry — radius capped at the ' + CINEMA_FAN_NUDGE_MAX + 'm nudge budget, NOT treated as ' + CINEMA_FAN_FAR + 'm of space)' : ' (bound=measured clearance/2)'));
+    }
     return out;
   }
+  var _cornersLastSig = '', _cornersLastMs = 0;
   A.cinemaRoundCorners = _cinemaRoundCorners;   // witness G7/G8 read this directly
   // Exit cost = dist × (1 − FACE_GAIN·facingDot) × perimFactor. facingDot=+1 (door dead ahead) →
   // (1-GAIN)×dist; facingDot=−1 (door behind you) → (1+GAIN)×dist. This asymmetry is the entire

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v852';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v853';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cinema_path_editor.js
+++ b/witness_cinema_path_editor.js
@@ -194,9 +194,16 @@ const FPS = 15;
         for (let i = 1; i < sharp.length - 1; i++) {
           let best = 1e18;
           for (const p of flown) best = Math.min(best, Math.hypot(p.x - sharp[i].x, p.y - sharp[i].y, p.z - sharp[i].z));
-          let clear = null;
-          try { const f = A.cinemaFan({ x: sharp[i].x, y: sharp[i].y, z: sharp[i].z }, 8); clear = f && isFinite(f.min) ? f.min : null; } catch (e) {}
-          dev.push({ i, deviation: best, clearance: clear });
+          // A fan that hits NOTHING returns CINEMA_FAN_FAR (60) — that is "unknown", not "60m of
+          // space". Comparing the cut against it is how this gate passed vacuously on Terminal
+          // before the live Hospital log exposed it. Report it as unknown and assert the
+          // conservative cap instead.
+          let clear = null, noHit = false;
+          try {
+            const f = A.cinemaFan({ x: sharp[i].x, y: sharp[i].y, z: sharp[i].z }, 8);
+            if (f && isFinite(f.min)) { if (f.min >= 59.99) noHit = true; else clear = f.min; }
+          } catch (e) {}
+          dev.push({ i, deviation: best, clearance: clear, noHit });
         }
         out.g8 = { perCorner: dev };
 
@@ -275,10 +282,16 @@ const FPS = 15;
       res.g7.peakDegPerFrame <= DEG_PER_FRAME_CAP,
       `peak=${res.g7.peakDegPerFrame.toFixed(1)} deg/frame at t=${res.g7.atT.toFixed(3)} (fps=${res.g7.fps})`);
 
-    const g8bad = res.g8.perCorner.filter(c => c.clearance != null && c.deviation > c.clearance);
-    P('G8 curve deviation <= measured clearance at every corner',
+    // Two ways to fail, no way to pass vacuously: where clearance was really measured the cut must
+    // fit inside it; where the fan saw nothing the cut must obey the conservative 3m nudge cap.
+    const NUDGE_CAP = 3;
+    const g8bad = res.g8.perCorner.filter(c => c.noHit ? (c.deviation > NUDGE_CAP / 2 + 1e-6)
+                                                       : (c.clearance != null && c.deviation > c.clearance));
+    P('G8 deviation <= measured clearance, or <= the conservative cap where clearance is unknown',
       g8bad.length === 0,
-      res.g8.perCorner.map(c => `corner${c.i}: dev=${c.deviation.toFixed(2)}m clear=${c.clearance == null ? 'n/a' : c.clearance.toFixed(2) + 'm'}`).join(' | '));
+      res.g8.perCorner.map(c => `corner${c.i}: dev=${c.deviation.toFixed(2)}m ` +
+        (c.noHit ? `clear=UNKNOWN(no-hit) cap=${(NUDGE_CAP / 2).toFixed(2)}m`
+                 : `clear=${c.clearance == null ? 'n/a' : c.clearance.toFixed(2) + 'm'}`)).join(' | '));
 
     P('G9 constant speed: time ratio == length ratio',
       Math.abs(res.g9.ratioTime - res.g9.ratioLen) < 1e-9,


### PR DESCRIPTION
## Summary
Cherry-pick of `b0db992` from `feat/cinema-path-editor` onto fresh `main` — that branch was already squash-merged once (#1023), so reusing it for this follow-up collided with its own squash history (add/add + content conflicts on every file it touches, purely a git-identity artifact, not real overlap — verified the diff here is byte-identical to the original commit's diff).

- Fixes a real defect the user's live Hospital test exposed: `_cinemaFan` returns the 60m sentinel for a ray that hits nothing, which the corner-rounding code was reading as an actual clearance measurement — cutting 7.5m inside a hand-placed waypoint while G8 passed vacuously against that same fictional number. No-hit is now UNKNOWN, capped at the existing 3m nudge budget, and the log names `unmeasuredCorners=n/m`. Terminal was in this state on 2/2 corners too (radius 4.80→3.00m, deviation 2.40→1.50m after the fix).
- Log-flooding fix: `§CINEMA_CORNERS` was firing every pointermove, now once per shape change or per second.
- Feedback pass: held waypoint is now orange and breathes at 12Hz (throttled so it doesn't defeat renderer idle-parking) instead of settling in 300ms; OK/Save buttons carry edit state; a status line answers "what happens if I stop now?".

## Test plan
- [x] `witness_cinema_path_editor.js` 9/9 on Duplex + Terminal (re-run after fix)
- [x] `witness_cinema_path_persist.js` 7/7
- [ ] ctrl+drag height, total-seconds field, Save → Ctrl+S → reopen — not yet driven by hand, named as next in the spec

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_LIVE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)