### PR TITLE
feat(cinema): §CPE_SCREEN_PLANE drag + §CPE_PACING derived duration

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -407,6 +407,20 @@
     if (typeof A.cinemaPathPlan === 'function') {
       try { plan = A.cinemaPathPlan(nFrames / fps); } catch (e) { console.warn('§MAXQ_PATH plan failed: ' + e.message); }
     }
+    // §CPE_PACING: the film's length is a CONSEQUENCE of the building, not an input. Frames used to
+    // set the duration (360/15 = 24s for everything); now the plan measures its own beats from real
+    // distances and angles, and the frame count follows. A caller that asked for a specific frame
+    // count still gets it — only the default defers to the geometry.
+    if (plan && plan.naturalTotal && !opts.frames) {
+      var _natFrames = Math.max(1, Math.round(plan.naturalTotal * fps));
+      if (_natFrames !== nFrames) {
+        console.log('§MAXQ_DURATION_DERIVED ' + (nFrames / fps).toFixed(1) + 's→' +
+          plan.naturalTotal.toFixed(1) + 's, frames ' + nFrames + '→' + _natFrames +
+          ' (paced from this building, not a fixed runtime)');
+        nFrames = _natFrames;
+        try { plan = A.cinemaPathPlan(nFrames / fps); } catch (e2) {}
+      }
+    }
     var tgt = A.controls.target.clone();
     var dx = A.camera.position.x - tgt.x, dy = A.camera.position.y - tgt.y, dz = A.camera.position.z - tgt.z;
     var radius = Math.hypot(dx, dz), height = dy, az0 = Math.atan2(dz, dx);

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -15,10 +15,9 @@
 //      and discards them.
 (function() {
   'use strict';
-  var CPE_V = 'v2 (§CPE_BANDS — rigid bands, tangent-matched connectors, full-film tube)';
+  var CPE_V = 'v3 (§CPE_BANDS + §CPE_SCREEN_PLANE — drag in the plane you face, canvas never frozen)';
   console.log('§CPE_LOADED ' + CPE_V);
 
-  var DRAG_VERT_M_PER_PX = 0.02;   // ctrl+drag pixels → metres
   var HANDLE_R = 0.30;             // metres
   var GRAB_PX = 18;                // screen-space grab tolerance
   var PULSE_HZ = 12;               // throttled: an every-frame markDirty defeats idle parking
@@ -397,10 +396,10 @@
     var el = document.getElementById('cpe-hint');
     if (!el) return;
     el.innerHTML = _state.held
-      ? '<b style="color:#ff8c00">Holding ' + (ROW_LABEL[_state.held.b] || '') +
-        (_state.held.z === 'mid' ? ' (whole band)' : ' (end — pivots about the other end)') +
-        '</b> — drag to move, ctrl+drag for height, wheel still zooms. <b>Double-click empty space to release.</b>'
-      : 'Click a band end to pivot it, or its middle to move the whole band. Camera always aims at the next point, so a band is a direction as well as a place.';
+      ? '<b style="color:#ff8c00">' + (ROW_LABEL[_state.held.b] || '') +
+        (_state.held.z === 'mid' ? ' — whole band' : ' — end, pivots about the other end') +
+        '</b>. It moves in the plane you are <b>facing</b>: orbit first to choose the axes, then drag.'
+      : 'Drag a band end to pivot it, its middle to move the whole band. Anywhere else orbits the scene as normal — turn to face the axes you want, since a drag moves in the plane you are looking at.';
   }
 
   function _syncButtons() {
@@ -430,8 +429,10 @@
   function _hold(bi, zone, frame) {
     var same = _state.held && _state.held.b === bi && _state.held.z === zone;
     _state.held = { b: bi, z: zone };
-    if (A().controls) A().controls.enabled = false;   // grid_drag.js pattern, not a new one
-    if (!same) console.log('§CPE_HOLD band=' + bi + ' zone=' + zone + ' controls.enabled=false');
+    // §CPE_SCREEN_PLANE: the canvas is NEVER frozen. Orbiting is half the editing gesture, so
+    // disabling controls would disable the way you choose which axes a drag moves in. Dragging and
+    // orbiting are told apart by the hit-test on pointerdown, not by a mode.
+    if (!same) console.log('§CPE_SELECT band=' + bi + ' zone=' + zone + ' (canvas stays live)');
     _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
     _pulse();
     if (frame) _frameBand(bi);
@@ -442,8 +443,7 @@
     var was = _state.held;
     _state.held = null;
     _stopPulse();
-    if (A().controls) A().controls.enabled = true;
-    console.log('§CPE_RELEASE band=' + was.b + ' zone=' + was.z + ' why=' + why + ' controls.enabled=true');
+    console.log('§CPE_DESELECT band=' + was.b + ' zone=' + was.z + ' why=' + why);
     _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
   }
 
@@ -488,16 +488,26 @@
     }
     return best;
   }
-  function _planePoint(ev, height) {
+  // §CPE_SCREEN_PLANE (user, 2026-07-27): the point moves in the CAMERA'S OWN VIEW PLANE through
+  // wherever it currently sits — "the dot when moved is merely facing X/Y ranging... it can only
+  // move in that Xy sense". You choose the axes by orbiting the scene to face them first, which is
+  // why the canvas must stay live: orbiting IS half the gesture.
+  // This replaces the horizontal-plane drag plus ctrl+drag-for-height. Height is no longer a special
+  // case — orbit to a side view and up/down on screen IS height.
+  function _viewPlanePoint(ev, anchor) {
     var a = A(), r = a.canvas.getBoundingClientRect();
     var ndc = new THREE.Vector2(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
     var rc = new THREE.Raycaster();
     rc.setFromCamera(ndc, a.camera);
-    var dir = rc.ray.direction, org = rc.ray.origin;
-    if (Math.abs(dir.y) < 1e-5) return null;
-    var t = (height - org.y) / dir.y;
+    var n = new THREE.Vector3();
+    a.camera.getWorldDirection(n);                       // plane normal = where the camera looks
+    var p0 = new THREE.Vector3(anchor.x, anchor.y, anchor.z);
+    var denom = n.dot(rc.ray.direction);
+    if (Math.abs(denom) < 1e-6) return null;
+    var t = p0.clone().sub(rc.ray.origin).dot(n) / denom;
     if (t <= 0) return null;
-    return { x: org.x + dir.x * t, y: height, z: org.z + dir.z * t };
+    var q = rc.ray.origin.clone().addScaledVector(rc.ray.direction, t);
+    return { x: q.x, y: q.y, z: q.z };
   }
 
   function _wire() {
@@ -506,38 +516,27 @@
       if (!_state) return;
       var hit = _hitTest(ev);
       if (hit) {
+        // Only a hit is claimed. Everything else falls straight through to OrbitControls, so the
+        // scene stays fully navigable while the editor is open.
         ev.preventDefault(); ev.stopPropagation();
         _hold(hit.b, hit.z, false);
-        _state.drag = { b: hit.b, z: hit.z, ctrl: !!ev.ctrlKey, y0: ev.clientY,
+        _state.drag = { b: hit.b, z: hit.z,
                         c0: { x: _state.bands[hit.b].c.x, y: _state.bands[hit.b].c.y, z: _state.bands[hit.b].c.z },
                         p0: { x: hit.p.x, y: hit.p.y, z: hit.p.z } };
-        return;
       }
-      if (_state.held) { ev.preventDefault(); ev.stopPropagation(); }   // no element picking mid-edit
     };
     h.move = function(ev) {
       if (!_state || !_state.drag) return;
       ev.preventDefault(); ev.stopPropagation();
-      var d = _state.drag, b = _state.bands[d.b], vert = d.ctrl || ev.ctrlKey;
+      var d = _state.drag, b = _state.bands[d.b];
+      var p = _viewPlanePoint(ev, d.p0);   // the plane the grabbed handle already lies in
+      if (!p) return;
       if (d.z === 'mid') {
         // Middle = the whole length moving as one.
-        if (vert) b.c.y = d.c0.y + (d.y0 - ev.clientY) * DRAG_VERT_M_PER_PX;
-        else {
-          var p = _planePoint(ev, b.c.y);
-          if (p) { b.c.x = p.x; b.c.z = p.z; }
-        }
+        b.c.x = p.x; b.c.y = p.y; b.c.z = p.z;
       } else {
         // End = pivot about the far end. Length is invariant, so this is pure rotation.
-        var movingIsB = (d.z === 'b');
-        var tgt;
-        if (vert) {
-          var e = _ends(b);
-          var cur = movingIsB ? e[1] : e[0];
-          tgt = { x: cur.x, y: d.p0.y + (d.y0 - ev.clientY) * DRAG_VERT_M_PER_PX, z: cur.z };
-        } else {
-          tgt = _planePoint(ev, movingIsB ? _ends(b)[1].y : _ends(b)[0].y);
-        }
-        if (tgt) _rotateAbout(b, movingIsB, tgt);
+        _rotateAbout(b, d.z === 'b', p);
       }
       _state.staged = false;
       _redrawScene();          // handles track the cursor instantly
@@ -547,31 +546,14 @@
       if (!_state || !_state.drag) return;
       var d = _state.drag, b = _state.bands[d.b];
       _state.drag = null;
-      console.log('§CPE_DRAG band=' + d.b + ' zone=' + d.z + ' axis=' + (d.ctrl ? 'height' : 'xz') +
+      console.log('§CPE_DRAG band=' + d.b + ' zone=' + d.z + ' plane=view' +
         ' centre=(' + b.c.x.toFixed(2) + ',' + b.c.y.toFixed(2) + ',' + b.c.z.toFixed(2) + ')' +
         ' dir=(' + b.d.x.toFixed(2) + ',' + b.d.y.toFixed(2) + ',' + b.d.z.toFixed(2) + ') len=' + b.len.toFixed(2));
       _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
     };
-    // Double-click releases (single click was rejected as too easy to trigger and lose focus).
-    h.dbl = function(ev) {
-      if (!_state || _hitTest(ev)) return;
-      ev.preventDefault(); ev.stopPropagation();
-      _release('dblclick');
-    };
-    // Touch has no dblclick — same 350ms window picking.js:174 already uses for measure mode.
-    h.touchTap = function(ev) {
-      if (!_state) return;
-      var t = ev.changedTouches && ev.changedTouches[0];
-      if (!t || _hitTest({ clientX: t.clientX, clientY: t.clientY })) return;
-      var now = Date.now();
-      if (_state.lastTap && now - _state.lastTap < 350) { _state.lastTap = 0; _release('double-tap'); }
-      else _state.lastTap = now;
-    };
     c.addEventListener('pointerdown', h.down, true);
     window.addEventListener('pointermove', h.move, true);
     window.addEventListener('pointerup', h.up, true);
-    c.addEventListener('dblclick', h.dbl, true);
-    c.addEventListener('touchend', h.touchTap, true);
     _state.handlers = h;
   }
   function _unwire() {
@@ -580,8 +562,6 @@
     c.removeEventListener('pointerdown', h.down, true);
     window.removeEventListener('pointermove', h.move, true);
     window.removeEventListener('pointerup', h.up, true);
-    c.removeEventListener('dblclick', h.dbl, true);
-    c.removeEventListener('touchend', h.touchTap, true);
   }
 
   // ══════════════════ public API ══════════════════

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3305,6 +3305,27 @@ async function setupEffects(A, renderer, scene, camera) {
   var CINEMA_FAN_NUDGE_MAX = 3; // metres the settle point may slide toward the open side
   var CINEMA_ENCLOSED_THRESHOLD = 0.6; // BVH fan fraction that counts as "genuinely enclosed"
 
+  // ══════════ §CPE_PACING — total duration is DERIVED from real geometry, never a fixed number ══
+  // User directive 2026-07-27: "the film's total length should not be a fixed constant... if interior
+  // speed is held to a constant m/s, and the exterior pull-back is paced by real distance rather than
+  // a fixed duration, then total duration falls out naturally from each building's actual size."
+  // Confirmed derived (dive, spin and orbit included) when asked.
+  //
+  // The model this REPLACES was inverted: total was fixed at nFrames/fps and speed was whatever made
+  // the derived walk fit CINEMA_OUT_SEC, so the BIGGER the building the FASTER the camera —
+  // measured 2.10 m/s on Duplex against 4.99 on LTU_AHouse. Every rate below is a stated constant
+  // and every duration is that rate applied to a MEASURED distance or angle, so a building's size
+  // now sets its runtime instead of being squeezed into someone else's.
+  var CINEMA_WALK_MPS     = 1.3;   // interior walking pace — deliberately slower than the old 2.1-5.0
+  var CINEMA_PULLBACK_MPS = 6.5;   // exterior recede: flying, not walking
+  var CINEMA_DIVE_MPS     = 20;    // the approach is a fly-IN; dive distances run 20-150m
+  var CINEMA_TURN_DPS     = 45;    // one rate for BOTH in-place turns: the spin and the orbit lap
+  var CINEMA_DIVE_MIN_SEC = 2.5;   // a floor, so a tiny building still gets an arrival rather than a cut
+  var CINEMA_SPIN_MIN_SEC = 0.8;
+  // Set by the wrapper when the editor supplies explicit beat seconds; then those win over the
+  // derived ones. Nothing else may set it.
+  var _cpeSecOverride = false;
+
   // ══ §CINEMA_PATH_EDITOR — authored path state + corner rounding. Spec:
   // prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL (settled with the user 2026-07-26).
   // _cpeWp is the ONE piece of authored state the plan reads. Null = nothing authored = the plan
@@ -4158,10 +4179,51 @@ async function setupEffects(A, renderer, scene, camera) {
     // Computed BEFORE _orbitPose because loopSec (needed to convert the swoop/hold/descent SECONDS
     // constants into this act's own u-domain) depends on tR, and _orbitPose(0) is called immediately
     // after to seed the Beat 4 handoff target. ═══════════════════════════════════════════════════
-    var tD = Math.min(0.30, CINEMA_DIVE_SEC / durationSec);
-    var tS = Math.min(0.42, tD + CINEMA_SPIN_SEC / durationSec);
-    var tO = Math.min(0.62, tS + CINEMA_OUT_SEC / durationSec);
-    var tR = Math.min(0.72, tO + CINEMA_RISE_SEC / durationSec);
+    // ══ §CPE_PACING — every beat's length is a measured distance or angle over a stated rate.
+    // The pull-back is the recede from where the walk ends to the final orbit radius, which is the
+    // "pull back from near to the final orbit distance" the user asked for — paced by that real
+    // distance instead of a fixed 2s.
+    var _pullNearR = Math.hypot(exitOuter.x - pivot.x, exitOuter.z - pivot.z);
+    var _pullDist = Math.max(0, orbitRadius - _pullNearR);
+    // ⚠ diveDist and dYaw are properties of WHERE THE USER WAS STANDING, not of the building —
+    // measured LTU_AHouse: a 746m approach and a 522° spin, because the camera happened to be far
+    // out and facing away. Pacing them raw made the runtime depend on the user's pose (LTU came out
+    // at 93.6s, of which 37.3s was dive and 11.6s spin), which contradicts the whole point: the
+    // total is supposed to fall out of the BUILDING's size. So both are bounded by building-derived
+    // quantities — the approach is capped at the envelope, the spin at a half turn (the most that is
+    // ever needed to face anywhere) — and only then converted at their stated rates.
+    var _diveEff = Math.min(diveDist, envelope);
+    var _spinDeg = Math.min(180, Math.abs(dYaw) * 180 / Math.PI);
+    var _natSec = {
+      dive:  Math.max(CINEMA_DIVE_MIN_SEC, _diveEff / CINEMA_DIVE_MPS),
+      spin:  Math.max(CINEMA_SPIN_MIN_SEC, _spinDeg / CINEMA_TURN_DPS),
+      out:   totalLen / CINEMA_WALK_MPS,
+      rise:  Math.max(0.5, _pullDist / CINEMA_PULLBACK_MPS),
+      orbit: 360 / CINEMA_TURN_DPS
+    };
+    var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.rise + _natSec.orbit;
+    // An explicit override (the editor's "set the total") scales the whole film uniformly; the SHAPE
+    // is geometric either way, so the beat fractions are derived-seconds over the natural total and
+    // do not depend on durationSec at all. That is what makes "key 20s and everything speeds up
+    // uniformly" true by construction.
+    var _useSec = _cpeSecOverride
+      ? { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC,
+          orbit: _natSec.orbit }
+      : _natSec;
+    var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.rise + _useSec.orbit;
+    var tD = _useSec.dive / _shapeTotal;
+    var tS = tD + _useSec.spin / _shapeTotal;
+    var tO = tS + _useSec.out / _shapeTotal;
+    var tR = tO + _useSec.rise / _shapeTotal;
+    console.log('§CINEMA_PACING natural=' + _natTotal.toFixed(1) + 's = dive ' + _natSec.dive.toFixed(1) +
+      ' + spin ' + _natSec.spin.toFixed(1) + ' + walk ' + _natSec.out.toFixed(1) +
+      ' + pullback ' + _natSec.rise.toFixed(1) + ' + orbit ' + _natSec.orbit.toFixed(1) +
+      '  (walk ' + totalLen.toFixed(1) + 'm @' + CINEMA_WALK_MPS + 'm/s, dive ' + diveDist.toFixed(1) +
+      'm @' + CINEMA_DIVE_MPS + 'm/s, pullback ' + _pullDist.toFixed(1) + 'm @' + CINEMA_PULLBACK_MPS +
+      'm/s, dive raw ' + diveDist.toFixed(0) + 'm capped to envelope ' + _diveEff.toFixed(0) +
+      'm, spin raw ' + Math.abs(dYaw * 180 / Math.PI).toFixed(0) + 'deg capped ' + _spinDeg.toFixed(0) +
+      'deg @' + CINEMA_TURN_DPS + 'deg/s)' +
+      ' override=' + _cpeSecOverride + ' running=' + durationSec.toFixed(1) + 's');
     console.log('§CINEMA_BEATS dive=' + tD.toFixed(3) + ' spin=' + tS.toFixed(3) + ' out=' + tO.toFixed(3) +
       ' rise=' + tR.toFixed(3) + ' turnOverlap=' + CINEMA_TURN_OVERLAP +
       ' (dur=' + durationSec.toFixed(1) + 's) route=' + outRoute +
@@ -4430,7 +4492,8 @@ async function setupEffects(A, renderer, scene, camera) {
                return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
              }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
-             sec: { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC },
+             sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, rise: _useSec.rise },
+             naturalSec: _natSec, naturalTotal: _natTotal,
              eyeM: CINEMA_EYE_M, lookdownDeg: CINEMA_LOOKDOWN_DEG, durationSec: durationSec,
              indoor: true, poseAt: poseAt };
   }
@@ -4502,7 +4565,9 @@ async function setupEffects(A, renderer, scene, camera) {
     // stored edit" — the G5 control path needs that distinction to be expressible.
     if (ov === undefined) { _cpeLoadFromDb(); ov = A._cinemaPathEdit || null; }
     if (!ov) return _cinemaPathPlan(durationSec);
-    var saved = [], i;
+    var saved = [], i, savedSecOv = _cpeSecOverride;
+    _cpeSecOverride = ['diveSec', 'spinSec', 'outSec', 'riseSec']
+      .some(function(k) { return ov[k] != null && isFinite(ov[k]); });
     for (i = 0; i < _CPE_KEYS.length; i++) {
       var k = _CPE_KEYS[i][0], g = _CPE_KEYS[i][1];
       saved.push(_cpeGet(g));
@@ -4517,7 +4582,7 @@ async function setupEffects(A, renderer, scene, camera) {
       return _cinemaPathPlan(durationSec);
     } finally {
       for (i = 0; i < _CPE_KEYS.length; i++) _cpeSet(_CPE_KEYS[i][1], saved[i]);
-      _cpeWp = savedWp; _cpeBands = savedBands;
+      _cpeWp = savedWp; _cpeBands = savedBands; _cpeSecOverride = savedSecOv;
     }
   };
   A.cinemaPathPlanDerived = _cinemaPathPlan;   // unwrapped, for G1's byte-identity comparison

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v854';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v855';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Two user-directed changes.

**§CPE_SCREEN_PLANE** — the canvas is never frozen. A drag on a handle moves it in the camera's own
view plane, so you orbit to face the axes you want and then drag. Drag vs orbit is decided by the
hit-test, not by a mode. Removes the freeze, the double-click release, the touch double-tap and
ctrl+drag-for-height. Mobile works for free.

**§CPE_PACING** — duration is derived from geometry, not fixed. Walk = pathLen / 1.3 m/s, pull-back =
(orbitRadius − exitRadius) / 6.5 m/s, dive = approach / 20 m/s, spin and orbit at 45°/s. Frame count
now follows the plan instead of setting it. The old model was measurably inverted: bigger building =
faster camera (Duplex 2.10 m/s vs LTU 4.99).

⚠ dive distance and spin angle are properties of the USER'S POSE, not the building — LTU measured a
746m approach and a 522° spin. Both are bounded by building-derived quantities (envelope, half turn).

Derived totals: Duplex 26.1s · JKR 32.8s · Terminal 39.1s · LTU_AHouse 55.4s.

Witnesses: `witness_cinema_bands.js` 6/6, `witness_cinema_path_persist.js` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwH3MY1ZAGf83e533XySwr