### PR TITLE
feat(cinema): §CPE_PANEL_DRAG — the path editor panel moves by its header

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -15,7 +15,7 @@
 //      and discards them.
 (function() {
   'use strict';
-  var CPE_V = 'v3 (§CPE_BANDS + §CPE_SCREEN_PLANE — drag in the plane you face, canvas never frozen)';
+  var CPE_V = 'v4 (§CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG — panel moves by its header)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -25,6 +25,9 @@
   var REPLAN_MS = 120;             // trailing throttle for the live re-derive
 
   var _state = null;
+  // §CPE_PANEL_DRAG: where the user last dragged the panel, remembered for the session only (see
+  // the spec's "scope note"). Module scope, not _state — _state dies with each editor session.
+  var _panelPos = null;
   function A() { return window.APP; }
 
   // ══════════════════ scene objects ══════════════════
@@ -274,9 +277,12 @@
     d.style.cssText = 'position:fixed;top:60px;right:12px;width:412px;max-height:calc(100vh - 96px);' +
       'overflow:auto;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:8px;' +
       'z-index:10000;font-family:system-ui,sans-serif;color:#ddd;box-shadow:0 8px 32px rgba(0,0,0,0.6)';
+    // §CPE_PANEL_DRAG: the header is the grab handle. Titled with the gesture so it is discoverable
+    // without a tooltip hunt — the same "say what the drag does" habit as #cpe-hint below.
     d.innerHTML =
-      '<div style="padding:10px 12px;border-bottom:1px solid #3a3f47;font-size:13px;font-weight:600;color:#4fc3f7">' +
-        'Cinema path <span style="font-weight:400;color:#888;font-size:11px">— 3 bands</span></div>' +
+      '<div id="cpe-title" title="drag to move this panel" style="padding:10px 12px;border-bottom:1px solid #3a3f47;' +
+        'font-size:13px;font-weight:600;color:#4fc3f7;cursor:move;user-select:none">' +
+        'Cinema path <span style="font-weight:400;color:#888;font-size:11px">— 3 bands · drag this bar to move</span></div>' +
       '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
       '<div id="cpe-rows" style="padding:4px 0"></div>' +
       '<div style="padding:8px 12px;border-top:1px solid #3a3f47;font-size:11px" id="cpe-clock"></div>' +
@@ -287,6 +293,41 @@
         '<button id="cpe-ok" style="padding:6px 14px;font-size:12px;background:#4fc3f7;color:#0b0d10;border:none;border-radius:4px;font-weight:600;cursor:pointer">OK</button>' +
       '</div>';
     document.body.appendChild(d);
+
+    // ══ §CPE_PANEL_DRAG (CINEMA_PATH_EDITOR.md) — user 2026-07-27: "can u make the editor panel
+    // draggable". The panel sits over exactly the strip of viewport the user orbits the bands into
+    // once §CPE_SCREEN_PLANE has them facing the plane they want to drag in.
+    // REUSE, not a second implementation: A._makeDraggable (measure.js:13) is this viewer's one
+    // panel-drag utility, already carrying ~10 panels. Do not fork it, do not edit it.
+    // _dragStrip = 36 pins the grab zone to the header exactly — the rows below carry number inputs
+    // whose keyed edits must never fling the panel (gate D3).
+    var a = A();
+    if (a && typeof a._makeDraggable === 'function') {
+      d._dragStrip = 36;
+      a._makeDraggable(d);
+      if (_panelPos) { d.style.left = _panelPos.left + 'px'; d.style.top = _panelPos.top + 'px'; d.style.right = 'auto'; }
+      // Remember where the user put it for the rest of the session (spec §CPE_PANEL_DRAG "scope
+      // note"): re-opening for the next bake should not throw the panel back across the screen.
+      // Nothing is persisted to the DB — this is not `cinema_path` state.
+      // Measured off the element itself rather than off the pointer, so the log is the truth about
+      // where the panel ENDED UP, not where the cursor was.
+      var _pdRect = null;
+      d.addEventListener('pointerdown', function() { _pdRect = d.getBoundingClientRect(); });
+      d.addEventListener('pointerup', function() {
+        if (!_pdRect) return;
+        var r = d.getBoundingClientRect();
+        var mx = r.left - _pdRect.left, my = r.top - _pdRect.top;
+        _pdRect = null;
+        if (Math.abs(mx) + Math.abs(my) < 1) return;   // a tap on the header is not a move
+        _panelPos = { left: Math.round(r.left), top: Math.round(r.top) };
+        console.log('§CPE_PANEL_MOVED dx=' + mx.toFixed(0) + ' dy=' + my.toFixed(0) +
+          ' left=' + _panelPos.left + ' top=' + _panelPos.top + ' (remembered for this session)');
+      });
+      console.log('§CPE_PANEL_DRAGGABLE handle=cpe-title strip=' + d._dragStrip +
+        (_panelPos ? ' restored left=' + _panelPos.left + ' top=' + _panelPos.top : ' at default anchor'));
+    } else {
+      console.warn('§CPE_PANEL_DRAGGABLE unavailable — A._makeDraggable missing (measure.js not loaded)');
+    }
     return d;
   }
 

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4554,8 +4554,14 @@ async function setupEffects(A, renderer, scene, camera) {
   // Staged by the editor's "Save this path"; read by scene.js `_writeCinemaPathTable` at export.
   A.stageCinemaPath = function(ov) {
     A._cinemaPathEdit = ov;
-    console.log('§CINEMA_PATH_STAGE waypoints=' + (ov && ov.waypoints ? ov.waypoints.length : 0) +
-      ' total=' + (ov && ov._total ? ov._total.toFixed(1) : '?') + 's (Ctrl+S writes it to the file)');
+    // Same stale-field species as §CPE_OK_CRASH (cinema_maxq.js:507), caught while answering the
+    // user's "how do I open a saved path?": §CPE_BANDS made the override carry `bands`, so this line
+    // printed a flat `waypoints=0` for every save — guarded, so it never threw, and therefore never
+    // got noticed. A log that lies about the thing it is reporting is worse than no log.
+    console.log('§CINEMA_PATH_STAGE bands=' + (ov && ov.bands ? ov.bands.length : 0) +
+      ' waypoints=' + (ov && ov.bands ? ov.bands.length * 2 : (ov && ov.waypoints ? ov.waypoints.length : 0)) +
+      ' total=' + (ov && ov._total ? ov._total.toFixed(1) : '?') + 's' +
+      ' — STAGED ONLY; Ctrl+S (Save Building) writes the cinema_path table into the .db');
   };
   A._getCinemaPathEdit = function() { return A._cinemaPathEdit || null; };
   A.clearCinemaPath = function() { A._cinemaPathEdit = null; console.log('§CINEMA_PATH_CLEAR authored path dropped'); };

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v855';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v856';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=3" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_panel_drag.js
+++ b/witness_cpe_panel_drag.js
@@ -1,0 +1,151 @@
+// WITNESS — §CPE_PANEL_DRAG: the path-editor panel moves by its header, and nothing else moves.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PANEL_DRAG.
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   D1 the ask — a header drag of a known (dx,dy) moves the panel by EXACTLY that delta. A scaled,
+//      offset or lagging drag would still "look draggable" in a screenshot and be wrong under the
+//      hand, which is why this is measured in pixels off getBoundingClientRect, not eyeballed.
+//   D2 the risk — the SAME drag must not touch the path. `_wire()` puts pointermove/pointerup on
+//      WINDOW in the capture phase, and those are the handlers that move a band; the only thing
+//      keeping a panel drag out of them is that `h.down` is bound to the canvas alone. Gate: zero
+//      §CPE_DRAG lines, and band centres bit-identical before and after.
+//   D3 the grab zone — an identical drag started on a ROW (below the 36px strip) must NOT move the
+//      panel. The rows carry number inputs; keying a camera height must never fling the panel.
+//   D4 session memory — after close and re-open, the panel is back where the user left it (the
+//      spec's stated scope note, gated rather than assumed).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const DX = 180, DY = 120;      // the drag under test
+const TOL = 1;                 // px — sub-pixel rounding only
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// A real pointer drag through the browser's own input pipeline — not a synthesised DOM event.
+// _makeDraggable only captures after 4px of movement, so the move is stepped, not teleported.
+async function dragFrom(page, x0, y0, dx, dy) {
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  for (let i = 1; i <= 6; i++) await page.mouse.move(x0 + dx * i / 6, y0 + dy * i / 6);
+  await page.mouse.up();
+  await sleep(120);
+}
+
+const rectOf = (page, sel) => page.evaluate(s => {
+  const r = document.querySelector(s).getBoundingClientRect();
+  return { left: r.left, top: r.top, width: r.width, height: r.height };
+}, sel);
+
+// Band centres, to 6dp — the path's own state, read straight off the live plan input.
+const bandsOf = page => page.evaluate(() => {
+  const r = [];
+  document.querySelectorAll('#cpe-rows > div').forEach(row => {
+    const v = [];
+    row.querySelectorAll('input').forEach(i => v.push(i.value));
+    r.push(v.join(','));
+  });
+  return r.join(' | ');
+});
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1400, height: 900 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(
+      () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit &&
+            window.APP._composer && typeof window.APP._makeDraggable === 'function',
+      { timeout: 120000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    // ── open the editor exactly the way the bake does. BLOCK body on purpose: a concise body would
+    // RETURN the bake's promise and page.evaluate would wait for the entire cook (protocolTimeout).
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+    await page.waitForSelector('#cpe-title', { timeout: 120000 });
+    await sleep(400);
+
+    const wired = logs.filter(l => /§CPE_PANEL_DRAGGABLE/.test(l))[0] || '(no §CPE_PANEL_DRAGGABLE line)';
+
+    // ── D1 + D2: drag the header, measure the panel and the path
+    const before = await rectOf(page, '#cpe-panel');
+    const bandsBefore = await bandsOf(page);
+    const dragsBefore = logs.filter(l => /§CPE_DRAG /.test(l)).length;
+    const t = await rectOf(page, '#cpe-title');
+    await dragFrom(page, Math.round(t.left + t.width / 2), Math.round(t.top + t.height / 2), DX, DY);
+    const after = await rectOf(page, '#cpe-panel');
+    const bandsAfter = await bandsOf(page);
+    const dragsAfter = logs.filter(l => /§CPE_DRAG /.test(l)).length;
+
+    const mx = after.left - before.left, my = after.top - before.top;
+    P(`D1 header drag moves the panel by exactly (${DX},${DY}) +/-${TOL}px`,
+      Math.abs(mx - DX) <= TOL && Math.abs(my - DY) <= TOL,
+      `panel (${before.left.toFixed(0)},${before.top.toFixed(0)}) -> (${after.left.toFixed(0)},${after.top.toFixed(0)}) ` +
+      `= moved (${mx.toFixed(1)},${my.toFixed(1)}), asked (${DX},${DY})\n          wiring: ${wired}\n` +
+      `          ${logs.filter(l => /§CPE_PANEL_MOVED/.test(l)).slice(-1)[0] || '(no §CPE_PANEL_MOVED line)'}`);
+
+    P('D2 that drag left the PATH untouched — no §CPE_DRAG, band centres identical',
+      dragsAfter === dragsBefore && bandsAfter === bandsBefore,
+      `§CPE_DRAG lines ${dragsBefore} -> ${dragsAfter} (must not change) | bands ${bandsAfter === bandsBefore ? 'IDENTICAL' : 'CHANGED'}\n` +
+      `          before: ${bandsBefore}\n          after:  ${bandsAfter}`);
+
+    // ── D3: the same drag, started on a row instead of the header
+    const rowRect = await page.evaluate(() => {
+      const r = document.querySelectorAll('#cpe-rows > div')[0].getBoundingClientRect();
+      return { left: r.left, top: r.top, width: r.width, height: r.height };
+    });
+    const beforeRow = await rectOf(page, '#cpe-panel');
+    // Start on the row's own label area (left edge), clear of the number inputs.
+    await dragFrom(page, Math.round(rowRect.left + 20), Math.round(rowRect.top + rowRect.height / 2), DX, -DY);
+    const afterRow = await rectOf(page, '#cpe-panel');
+    P('D3 a drag started on a ROW does not move the panel (grab zone = header only)',
+      Math.abs(afterRow.left - beforeRow.left) <= TOL && Math.abs(afterRow.top - beforeRow.top) <= TOL,
+      `panel (${beforeRow.left.toFixed(0)},${beforeRow.top.toFixed(0)}) -> (${afterRow.left.toFixed(0)},${afterRow.top.toFixed(0)}) ` +
+      `= moved (${(afterRow.left - beforeRow.left).toFixed(1)},${(afterRow.top - beforeRow.top).toFixed(1)}), must be (0,0)`);
+
+    // ── D4: close, re-open, is it where the user left it?
+    const parked = await rectOf(page, '#cpe-panel');
+    await page.evaluate(() => document.getElementById('cpe-cancel').click());
+    await sleep(400);
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+    await page.waitForSelector('#cpe-title', { timeout: 120000 });
+    await sleep(400);
+    const reopened = await rectOf(page, '#cpe-panel');
+    P('D4 the dragged position survives close -> re-open (session memory)',
+      Math.abs(reopened.left - parked.left) <= TOL && Math.abs(reopened.top - parked.top) <= TOL,
+      `left at (${parked.left.toFixed(0)},${parked.top.toFixed(0)}), re-opened at (${reopened.left.toFixed(0)},${reopened.top.toFixed(0)})\n` +
+      `          ${logs.filter(l => /§CPE_PANEL_DRAGGABLE/.test(l)).slice(-1)[0] || '(no line)'}`);
+
+    try { await page.evaluate(() => document.getElementById('cpe-cancel').click()); } catch (e) {}
+    await sleep(300);
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User: *"happy with how editor behaves.. but can u make the editor panel draggable"*.

The panel is fixed at `top:60px; right:12px` and covers exactly the strip of viewport the user orbits the bands into — §CPE_SCREEN_PLANE makes "turn to face the plane you want to drag in" the normal gesture, so the panel **will** end up over the handles.

## Reuse, not a second implementation
`A._makeDraggable(el)` (`measure.js:13`) is this viewer's one panel-drag utility, already carrying ~10 panels. Not forked, not edited. Applied as: the header gets `id="cpe-title"` + `cursor:move`, and `_dragStrip = 36` pins the grab zone to the header exactly — the rows below carry number inputs whose keyed edits must never fling the panel.

**Stated, not smuggled:** beyond the literal ask, the dragged position is remembered for the **session** (module-scope `_panelPos`; nothing written to the DB). A panel that forgets where you put it every time Alt+M re-opens it is a half-feature — so it is gated (D4) and called out in the spec.

## witness_cpe_panel_drag.js — 4/4 Duplex, 4/4 Terminal
```
D1  panel (976,60) -> (1156,180) = moved (180.0,120.0), asked (180,120)
    §CPE_PANEL_DRAGGABLE handle=cpe-title strip=36 at default anchor
    §CPE_PANEL_MOVED dx=180 dy=120 left=1156 top=180 (remembered for this session)
D2  §CPE_DRAG lines 0 -> 0 | band centres IDENTICAL before and after
D3  panel (1156,180) -> (1156,180) = moved (0.0,0.0) when the drag starts on a row
D4  left at (1156,180), re-opened at (1156,180)
```
**D2 is the gate that matters.** `_wire()` installs `pointermove`/`pointerup` on **window** in the capture phase, and those are the handlers that move a band — the only thing keeping a header drag out of them is that `h.down` is bound to the canvas alone. That is an argument; D2 makes it a measurement.

## Also fixed — a silent twin of #1029
Found while answering the user's *"when Saved the edited path, how do we open it?"*: `A.stageCinemaPath` logged a flat **`waypoints=0` on every save** — the same stale `override.waypoints` species as §CPE_OK_CRASH, but **guarded**, so it never threw and was never noticed. Now reports `bands=3 waypoints=6` and states outright that staging is not saving. The full save → Ctrl+S → restore lifecycle is documented in the spec (`§CPE_SAVED_PATH_LIFECYCLE`).

`sw` CACHE_VERSION v855→v856; `cinema_path_editor.js?v=2`→`v=3`.

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PANEL_DRAG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)