### PR TITLE
fix(cinema): §CPE_PREVIEW_DIVERGENCE — the film you edit is the film that bakes

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -15,7 +15,7 @@
 //      and discards them.
 (function() {
   'use strict';
-  var CPE_V = 'v4 (§CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG — panel moves by its header)';
+  var CPE_V = 'v5 (§CPE_PREVIEW_DIVERGENCE — plan pinned to the open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG — panel moves by its header)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -133,8 +133,18 @@
   function _replanFilm() {
     var a = A(), t0 = performance.now();
     var ov = _buildOverride();
+    // §CPE_PREVIEW_DIVERGENCE: plan from the camera pose the editor OPENED with — the pose the bake
+    // will plan from, because finish() restores exactly this before resolving. Without it the film
+    // silently re-derived from wherever the user had orbited to, so (a) the baked film differed from
+    // the edited one and (b) merely LOOKING at the path from another angle changed it.
+    // Attached to a COPY, never to the override itself: _buildOverride() is also what "Save this
+    // path" stages and what finish() hands the bake, and a camera basis is session state — pinning a
+    // stored path to one session's camera is exactly the bug this fixes, inverted.
+    var povr = {}; for (var k in ov) povr[k] = ov[k];
+    var cs = _state.camSave;
+    if (cs) povr._camBasis = { px: cs.px, py: cs.py, pz: cs.pz, tx: cs.tx, ty: cs.ty, tz: cs.tz };
     var plan = null;
-    try { plan = a.cinemaPathPlan(ov._total, ov); } catch (e) { console.warn('§CPE_REPLAN_FAIL ' + e.message); }
+    try { plan = a.cinemaPathPlan(ov._total, povr); } catch (e) { console.warn('§CPE_REPLAN_FAIL ' + e.message); }
     if (!plan) return;
     var pts = [];
     for (var i = 0; i <= FILM_SAMPLES; i++) {
@@ -634,6 +644,13 @@
         'm speed=' + _state.speed.toFixed(2) + 'm/s total=' + ctx.durationSec.toFixed(1) + 's');
 
       var panel = _buildPanel();
+      // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted
+      // console ever shows the bake's §CINEMA_PIVOT disagreeing with the editor's, this line says
+      // which camera the editor was planning from.
+      console.log('§CPE_CAM_BASIS cam=(' + _state.camSave.px.toFixed(1) + ',' + _state.camSave.py.toFixed(1) +
+        ',' + _state.camSave.pz.toFixed(1) + ') target=(' + _state.camSave.tx.toFixed(1) + ',' +
+        _state.camSave.ty.toFixed(1) + ',' + _state.camSave.tz.toFixed(1) + ')' +
+        ' — every re-plan uses THIS pose, not the live camera, so orbiting to look cannot change the film');
       _replanFilm();
       _redrawScene(); _renderRows(); _renderClock(); _renderHint(); _syncButtons();
       _wire();
@@ -644,12 +661,12 @@
         _stopPulse(); _release('close'); _unwire(); _clearScene();
         if (_state._replanTimer) { clearTimeout(_state._replanTimer); _state._replanTimer = null; }
         if (panel.parentNode) panel.parentNode.removeChild(panel);
+        var total = ov ? ov._total : _state.baseTotal;
         if (a.controls) a.controls.enabled = _state.controlsWere;
         a.camera.position.set(_state.camSave.px, _state.camSave.py, _state.camSave.pz);
         a.controls.target.set(_state.camSave.tx, _state.camSave.ty, _state.camSave.tz);
         a.controls.update();
         if (a.markDirty) a.markDirty();
-        var total = ov ? ov._total : _state.baseTotal;
         console.log('§CPE_CLOSE action=' + action + ' edited=' + edited + ' total=' + total.toFixed(1) + 's');
         _state = null;
         // Guardrail 2: an untouched OK hands back NO override, so the bake re-uses the derived plan

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4566,11 +4566,38 @@ async function setupEffects(A, renderer, scene, camera) {
   A._getCinemaPathEdit = function() { return A._cinemaPathEdit || null; };
   A.clearCinemaPath = function() { A._cinemaPathEdit = null; console.log('§CINEMA_PATH_CLEAR authored path dropped'); };
 
+  // ══ §CPE_PREVIEW_DIVERGENCE (CINEMA_PATH_EDITOR.md) — the plan reads A.camera.position and
+  // A.controls.target directly, so it silently depends on WHERE THE USER IS LOOKING FROM at the
+  // moment it is called. Measured live (user, Hospital, 2026-07-27): while editing, the orbited-in
+  // camera gave targetOffCam=16.7 — under envelope*0.25=36.9, so §CINEMA_PIVOT stayed
+  // `arc-bbox-centre` (dive 14.2m, spin 0.0deg). On OK the editor restores the camera it captured at
+  // open, targetOffCam became 54.0 — over the threshold, so the SAME building planned
+  // `controls-target(plausible)` at the origin: dive 77.2m, spin 118.1deg, facingDot 0.980 -> -0.471.
+  // The user previewed a film with no spin and baked one that turns 118 degrees at the start.
+  // FIX: an explicit camera basis. Same "set, call the untouched plan, restore in finally" pattern
+  // the beat-second overrides above already use — the plan function itself stays untouched.
+  // Nothing here moves the camera as far as any renderer is concerned: the swap and the restore
+  // happen inside one synchronous call with no frame in between.
+  function _withCamBasis(basis, fn) {
+    if (!basis) return fn();
+    var c = A.camera, t = A.controls.target;
+    var sp = { x: c.position.x, y: c.position.y, z: c.position.z };
+    var st = { x: t.x, y: t.y, z: t.z };
+    c.position.set(basis.px, basis.py, basis.pz);
+    t.set(basis.tx, basis.ty, basis.tz);
+    try { return fn(); }
+    finally { c.position.set(sp.x, sp.y, sp.z); t.set(st.x, st.y, st.z); }
+  }
+
   A.cinemaPathPlan = function(durationSec, ov) {
     // `undefined` means "use whatever is stored/staged"; an explicit null means "derived, ignore any
     // stored edit" — the G5 control path needs that distinction to be expressible.
     if (ov === undefined) { _cpeLoadFromDb(); ov = A._cinemaPathEdit || null; }
     if (!ov) return _cinemaPathPlan(durationSec);
+    if (ov._camBasis) return _withCamBasis(ov._camBasis, function() {
+      var o = {}; for (var q in ov) if (q !== '_camBasis') o[q] = ov[q];
+      return A.cinemaPathPlan(durationSec, o);
+    });
     var saved = [], i, savedSecOv = _cpeSecOverride;
     _cpeSecOverride = ['diveSec', 'spinSec', 'outSec', 'riseSec']
       .some(function(k) { return ov[k] != null && isFinite(ov[k]); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v856';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v857';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=3" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_preview_divergence.js
+++ b/witness_cpe_preview_divergence.js
@@ -1,0 +1,158 @@
+// WITNESS — §CPE_PREVIEW_DIVERGENCE: the film you edit is the film that bakes.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PREVIEW_DIVERGENCE.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (measured live by the user, Hospital, 2026-07-27):
+// _cinemaPathPlan reads A.camera.position / A.controls.target directly, so the plan silently depends
+// on where the user happens to be LOOKING FROM. While editing (orbited in) their log showed
+// targetOffCam=16.7 — under envelope*0.25=36.9 — so §CINEMA_PIVOT stayed `arc-bbox-centre`:
+// diveDist=14.2m, spin 0.0deg. On OK the editor restores the pose it captured at open, targetOffCam
+// became 54.0, the threshold flipped, and the SAME building planned `controls-target(plausible)`:
+// diveDist=77.2m, spin 118.1deg. They previewed a film with no spin and baked one that turns 118deg.
+//
+//   P1 the report — the LAST plan the editor showed and the plan the bake uses must agree on
+//      §CINEMA_PIVOT src, pivot coords, diveDist and finalSpinDeg. RED on origin/main by
+//      construction: this witness dollies the camera in mid-edit, exactly as orbiting does.
+//   P2 the invariant that makes P1 true — merely LOOKING from somewhere else must not change the
+//      film. Every §CINEMA_PIVOT emitted while the editor is open must be identical, before and
+//      after a large camera move. Pivot is used because it depends ONLY on camera/target/bbox and
+//      not at all on the bands, so it isolates the camera basis from the edit itself.
+//   P3 no-move regression — a session where the camera never moves must be unaffected (the basis
+//      then IS the live camera). Same three numbers, editor vs bake, on an untouched camera.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const pivotOf = l => { const m = l && l.match(/src=(\S+) pivot=\(([^)]*)\)/); return m ? m[1] + ' @' + m[2] : null; };
+const diveOf  = l => { const m = l && l.match(/diveDist=([\d.]+)m/); return m ? m[1] : null; };
+const spinOf  = l => { const m = l && l.match(/finalSpinDeg=([\d.-]+)/); return m ? m[1] : null; };
+const last = (logs, re) => { const h = logs.filter(l => re.test(l)); return h.length ? h[h.length - 1] : null; };
+
+async function openViewer(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  return { page, logs };
+}
+
+// One editor session. `dolly` true → move the camera hard toward the target mid-edit, which is what
+// orbiting/zooming in to inspect a band does, and what flipped the user's plausibility test.
+async function session(browser, BLD, dolly) {
+  const { page, logs } = await openViewer(browser, BLD);
+  // BLOCK body: a concise arrow would return the bake promise and evaluate() would await the cook.
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 120000 });
+  await sleep(500);
+
+  const pivotsAtOpen = logs.filter(l => /§CINEMA_PIVOT/.test(l)).length;
+
+  // A real edit, so a re-plan definitely happens (keyed y — the same state a drag mutates).
+  const keyY = (d) => page.evaluate(dd => {
+    const yIn = document.querySelectorAll('#cpe-rows > div')[0].querySelectorAll('input')[2];
+    yIn.value = (parseFloat(yIn.value) + dd).toFixed(2);
+    yIn.dispatchEvent(new Event('change', { bubbles: true }));
+  }, d);
+
+  await keyY(1.0);
+  await sleep(500);
+
+  let camMoved = null;
+  if (dolly) {
+    camMoved = await page.evaluate(() => {
+      const A = window.APP, c = A.camera, t = A.controls.target;
+      const before = Math.hypot(c.position.x - t.x, c.position.y - t.y, c.position.z - t.z);
+      // 75% of the way to the target — a big, unambiguous "I orbited in to look at this band".
+      c.position.set(c.position.x + (t.x - c.position.x) * 0.75,
+                     c.position.y + (t.y - c.position.y) * 0.75,
+                     c.position.z + (t.z - c.position.z) * 0.75);
+      A.controls.update();
+      const after = Math.hypot(c.position.x - t.x, c.position.y - t.y, c.position.z - t.z);
+      return { before: before.toFixed(1), after: after.toFixed(1) };
+    });
+    await sleep(200);
+    await keyY(1.0);            // re-plan WITH the moved camera
+    await sleep(500);
+  }
+
+  const editPivot = last(logs, /§CINEMA_PIVOT/);
+  const editDive  = last(logs, /§CINEMA_DIVE /);
+  const editSpin  = last(logs, /§CINEMA_SPIN /);
+  const pivotsWhileEditing = logs.filter(l => /§CINEMA_PIVOT/.test(l)).slice(pivotsAtOpen - 1);
+
+  await page.evaluate(() => document.getElementById('cpe-ok').click());
+  await page.waitForFunction(() => !document.getElementById('cpe-ok'), { timeout: 30000 });
+  // The bake's plan is the one printed AFTER the editor closed.
+  const closeIdx = logs.findIndex(l => /§CPE_CLOSE/.test(l));
+  const afterClose = logs.slice(closeIdx + 1);
+  const bakePivot = last(afterClose, /§CINEMA_PIVOT/);
+  const bakeDive  = last(afterClose, /§CINEMA_DIVE /);
+  const bakeSpin  = last(afterClose, /§CINEMA_SPIN /);
+
+  try { await page.evaluate(() => { window.APP.startMaxQualityOrbit(); }); } catch (e) {}
+  await sleep(400);
+  await page.close();
+  return { logs, camMoved, editPivot, editDive, editSpin, bakePivot, bakeDive, bakeSpin, pivotsWhileEditing };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const r = await session(browser, BLD, true);
+
+    const same = (a, b, f) => f(a) !== null && f(a) === f(b);
+    const p1 = same(r.editPivot, r.bakePivot, pivotOf) &&
+               same(r.editDive, r.bakeDive, diveOf) &&
+               same(r.editSpin, r.bakeSpin, spinOf);
+    P('P1 the last EDITED plan and the BAKED plan agree on pivot, diveDist and spin',
+      p1,
+      `camera dollied ${r.camMoved ? r.camMoved.before + 'm -> ' + r.camMoved.after + 'm from target' : '(not moved)'} mid-edit\n` +
+      `          editor: pivot=${pivotOf(r.editPivot)} dive=${diveOf(r.editDive)}m spin=${spinOf(r.editSpin)}deg\n` +
+      `          bake:   pivot=${pivotOf(r.bakePivot)} dive=${diveOf(r.bakeDive)}m spin=${spinOf(r.bakeSpin)}deg`);
+
+    const uniq = [...new Set(r.pivotsWhileEditing.map(pivotOf))];
+    P('P2 looking from somewhere else does not change the film (every editing pivot identical)',
+      uniq.length === 1,
+      `${r.pivotsWhileEditing.length} re-plans while the editor was open, ${uniq.length} distinct pivot(s):\n` +
+      `          ${uniq.join('\n          ')}\n` +
+      `          ${last(r.logs, /§CPE_CAM_BASIS/) || '(no §CPE_CAM_BASIS line — unpatched build)'}`);
+
+    const r2 = await session(browser, BLD, false);
+    P('P3 no-move regression: an untouched camera still agrees editor-vs-bake',
+      same(r2.editPivot, r2.bakePivot, pivotOf) && same(r2.editDive, r2.bakeDive, diveOf) &&
+        same(r2.editSpin, r2.bakeSpin, spinOf),
+      `editor: pivot=${pivotOf(r2.editPivot)} dive=${diveOf(r2.editDive)}m spin=${spinOf(r2.editSpin)}deg\n` +
+      `          bake:   pivot=${pivotOf(r2.bakePivot)} dive=${diveOf(r2.bakeDive)}m spin=${spinOf(r2.bakeSpin)}deg`);
+
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User, Hospital: *"still noticed a sharp jerk"*. Their console showed the plan built when the editor closes is **not** the plan they were editing against:

| | while editing | after OK, the plan that BAKES |
|---|---|---|
| `§CINEMA_PIVOT src` | `arc-bbox-centre` | `controls-target(plausible)` at the origin |
| `diveDist` | 14.2m | **77.2m** |
| `finalSpinDeg` | 0.0 (`already-facing`) | **118.1** |
| `facingDot` | 0.980 | **-0.471** |

They previewed a film with no spin and baked one that turns 118° at the start. It reproduces across both of their runs.

## Root cause, and why it is broader than it first looked
`_cinemaPathPlan` reads `A.camera.position` / `A.controls.target` directly, so the plan silently depends on where the user is **looking from**. Editing orbited-in gave `targetOffCam=16.7` (under `envelope*0.25=36.9`); `finish()` restores the pose captured at open (`54.0`) and the plausibility branch flips.

**But the witness found the branch flip is only one symptom.** On Duplex the pivot `src` matched in both plans and the film still diverged:
```
RED (origin/main), Duplex — camera dollied 93.3m -> 23.3m from target mid-edit
  FAIL P1  editor: pivot=controls-target @0,0,0  dive=21.7m  spin=0.0deg
           bake:   pivot=controls-target @0,0,0  dive=91.3m  spin=0.0deg    <- 4.2x
  PASS P3  untouched camera: editor and bake agree exactly (91.3m both)
```
`diveDist` is measured from the live camera to the settle point, so **any** camera movement while the editor is open rewrites the opening beat. P3 passing RED is the proof of mechanism.

## Fix
An explicit `_camBasis` on the `A.cinemaPathPlan` wrapper: every editor re-plan is pinned to the pose captured at editor **open** — the pose the bake plans from, since `finish()` restores it before resolving. Same *set inputs → call the untouched `_cinemaPathPlan` → restore in `finally`* pattern the beat-second overrides already use; the 600-line plan function is not touched. The basis rides a **copy** of the override, never the override itself — `_buildOverride()` is also what "Save this path" stages, and pinning a stored path to one session's camera would be this bug inverted.

**Second property, arguably the bigger one:** looking at the path from another angle can no longer change the path. §CPE_SCREEN_PLANE *tells* the user to orbit before dragging, so the old behaviour meant the documented gesture silently rewrote the film.

## witness_cpe_preview_divergence.js — 3/3 Duplex, 3/3 Terminal
```
Duplex    editor dive=91.3m  spin=0.0deg  == bake dive=91.3m  spin=0.0deg   (dollied 93.3->23.3m)
Terminal  editor dive=143.7m spin=57.9deg == bake dive=143.7m spin=57.9deg  (dollied 119.9->30.0m)
P2  3 re-plans across a large camera move -> 1 distinct pivot, both buildings
P3  no-move regression clean, both buildings
```

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PREVIEW_DIVERGENCE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)