### PR TITLE
feat(precision-cam): Auto-Pivot active by default, Fine wins over auto-recenter

### DIFF
--- a/viewer/precision_cam.js
+++ b/viewer/precision_cam.js
@@ -151,7 +151,10 @@
     if (!A() || !A().controls) return;
     _pivot = true;
     window._autoPivot = true;  // exposed for Help-row isActive highlight
-    _onEnd = function() { if (_pivot) recenterPivot(); };
+    // §PIVOT_FINE_WINS: Fine is a deliberate user act (visible top-centre icon) for slowly
+    // closing in on one specific point — Auto-Pivot yanking the target elsewhere on every
+    // drag-end would fight that. Fine wins: pause auto-recenter while Fine is active.
+    _onEnd = function() { if (_pivot && !_fine) recenterPivot(); };
     A().controls.addEventListener('end', _onEnd);
     _pivotPaint();
     if (_pivotInd) _pivotInd.style.display = 'flex';  // top-centre orbit-icon notice
@@ -252,6 +255,24 @@
     // If fine is active, reflect in panel button
     if (_fine) document.getElementById('prec-fine-btn').style.background = '#1a6b8a';
     if (_pivot) _pivotPaint();
+
+    // §PIVOT_DEFAULT_ON (2026-07-27): Auto-Pivot active out of the box — gamer-style
+    // continuous navigation, no manual Q press needed to escape a stale/stuck target.
+    // A().controls doesn't exist yet at DOMContentLoaded (setupScene creates it later,
+    // async) — poll briefly, then call pivotOn() exactly as if the user had pressed Q.
+    // Still toggleable off afterward via Q / the panel / drawer chip, unchanged.
+    var _pivotDefaultTries = 0;
+    var _pivotDefaultTimer = setInterval(function() {
+      _pivotDefaultTries++;
+      if (A() && A().controls) {
+        clearInterval(_pivotDefaultTimer);
+        pivotOn();
+        console.log('§pivot default-on tries=' + _pivotDefaultTries);
+      } else if (_pivotDefaultTries > 100) {  // ~10s — give up quietly, Q still works manually
+        clearInterval(_pivotDefaultTimer);
+        console.log('§pivot default-on timeout — controls never became ready');
+      }
+    }, 100);
 
     // S265: Precision Camera button — Lucide focus icon, matches overflow grid style
     var toolbar = document.querySelector('#search-body > div');


### PR DESCRIPTION
## Summary
- Auto-Pivot (re-anchor orbit target on drag-end) was opt-in via `Q`. Flips it on by default — the always-on behavior was already accepted 2026-06-04 (user: "pivot centre can be always on... that is ok too"), just never defaulted — giving continuous navigation without needing to know/press `Q` to escape a stuck/stale target.
- `init()` polls for `A().controls` (created later, inside async `setupScene`, not ready yet at `DOMContentLoaded`) every 100ms up to ~10s, then calls the existing `pivotOn()` — same function `Q` already calls. Self-clearing either branch, zero steady-state cost once resolved.
- **Fine wins over auto-recenter**: Fine is a deliberate act (visible top-centre icon) for slowly closing in on one point; auto-recentering on every drag-end while Fine is on would fight that. `_onEnd` now checks `_pivot && !_fine`.
- `Q` / panel button / drawer chip still toggle it off exactly as before — no UI removed.

## Test plan
- [x] `node -c viewer/precision_cam.js` — syntax OK
- [x] Reasoned through the control-flow directly (bounded poll, self-clearing timer either branch, inherits already-shipped `pivotOn()`/`recenterPivot()` correctness, safe no-mesh-yet fallback reuses the existing Reset-style "10m ahead" path) — no browser run needed for this kind of bounded lifecycle change
- [ ] Manual: load a building, confirm Auto-Pivot's top-centre orbit icon appears without pressing Q; toggle Fine on and confirm the target stops recentering on drag-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)