### PR TITLE
revert(precision-cam): Auto-Pivot default-off — real usage showed drift + broke Reset

### DIFF
--- a/viewer/precision_cam.js
+++ b/viewer/precision_cam.js
@@ -256,24 +256,6 @@
     if (_fine) document.getElementById('prec-fine-btn').style.background = '#1a6b8a';
     if (_pivot) _pivotPaint();
 
-    // §PIVOT_DEFAULT_ON (2026-07-27): Auto-Pivot active out of the box — gamer-style
-    // continuous navigation, no manual Q press needed to escape a stale/stuck target.
-    // A().controls doesn't exist yet at DOMContentLoaded (setupScene creates it later,
-    // async) — poll briefly, then call pivotOn() exactly as if the user had pressed Q.
-    // Still toggleable off afterward via Q / the panel / drawer chip, unchanged.
-    var _pivotDefaultTries = 0;
-    var _pivotDefaultTimer = setInterval(function() {
-      _pivotDefaultTries++;
-      if (A() && A().controls) {
-        clearInterval(_pivotDefaultTimer);
-        pivotOn();
-        console.log('§pivot default-on tries=' + _pivotDefaultTries);
-      } else if (_pivotDefaultTries > 100) {  // ~10s — give up quietly, Q still works manually
-        clearInterval(_pivotDefaultTimer);
-        console.log('§pivot default-on timeout — controls never became ready');
-      }
-    }, 100);
-
     // S265: Precision Camera button — Lucide focus icon, matches overflow grid style
     var toolbar = document.querySelector('#search-body > div');
     if (!toolbar) return;


### PR DESCRIPTION
## Summary
Reverts the always-on half of #1033 based on a real session's §-tagged console log (not a screenshot): Auto-Pivot worked exactly as coded (fired automatically, `§pivot ON tries=1`, recentered on every drag — `§pivot recenter ... hit=mesh`), but that surfaced two real problems:

1. **Feels like drift, not smooth nav** — recentering the orbit target on every single drag-end, un-opted-in, reads as the view moving on its own during ordinary navigation.
2. **Silently breaks Reset (`A` key)** — `resetCamOrbit` wiring is untouched and correct, but `resetOrbit()` only moves `controls.target` (no camera motion), so its effect is invisible until the next drag/zoom. With Pivot always listening, that next drag-end immediately overwrites the target Reset just set, before the user ever sees Reset take effect.

**Keeping** the other half of #1033 — Fine wins over auto-recenter (`_onEnd` checks `_pivot && !_fine`) — independently correct regardless of Pivot's default state.

## Test plan
- [x] `node -c viewer/precision_cam.js` — syntax OK
- [x] Diff confirmed to remove only the default-on poll block, nothing else
- [ ] Manual: confirm Auto-Pivot starts OFF on load, `Q` still toggles it on, `A` (Reset) has its normal effect again

🤖 Generated with [Claude Code](https://claude.com/claude-code)