### PR TITLE
fix(cinema): §CPE_DRAG_TELEPORT — mid-band drag moves by the gesture, not to the cursor ray

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -584,7 +584,19 @@
       if (!p) return;
       if (d.z === 'mid') {
         // Middle = the whole length moving as one.
-        b.c.x = p.x; b.c.y = p.y; b.c.z = p.z;
+        // §CPE_DRAG_TELEPORT (user, Hospital, 2026-07-27: "went off to a spot user didnt put.
+        // Draging it back, still flew back"). This USED to assign the projected cursor point
+        // absolutely — `b.c = p` — so the band's new centre became whatever the grab ray happened
+        // to meet, not the centre plus the gesture. Any depth error in the grab point `p0` therefore
+        // became a PERMANENT offset, and every later drag re-anchored its plane at the already-wrong
+        // depth — which is exactly "dragging it back still flew back". Measured in their log: band 1
+        // centre y=+39.24 against floorY=-15.47 (~55m above the floor), pathLen 32.3m -> 161.7m.
+        // DELTA, not absolute: `c0` was already captured on pointerdown for this and was never read
+        // — the intent was here all along. A zero-pixel drag is now a zero-metre move by
+        // construction, and any p0 depth error cancels out of (p - p0) instead of accumulating.
+        b.c.x = d.c0.x + (p.x - d.p0.x);
+        b.c.y = d.c0.y + (p.y - d.p0.y);
+        b.c.z = d.c0.z + (p.z - d.p0.z);
       } else {
         // End = pivot about the far end. Length is invariant, so this is pure rotation.
         _rotateAbout(b, d.z === 'b', p);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v857';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v858';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>


### PR DESCRIPTION
User, Hospital: *"the drag of the waypoint seems to misbehave went off to a spot user didnt put. Draging it back, still flew back."*

## Root cause — and `c0` proves the intent
`h.move` for `zone='mid'` assigned the projected cursor point **absolutely** (`b.c = p`), so the band's new centre became wherever the grab ray met the view plane — **not** the old centre plus the gesture. `_state.drag.c0` (the centre at pointerdown) is captured on the line above and **never read anywhere in the file**. The delta form was intended and never wired.

Both halves of the report fall out of that:
1. Any depth error in the grab point `p0` becomes an immediate **teleport**.
2. The next drag re-anchors its plane at the already-wrong depth, so **"dragging it back" moves it wrong again** — the error compounds instead of cancelling.

## Measured in their log
```
§CPE_DRAG band=1 zone=mid centre=(-14.26, 39.24,-33.54)   floorY=-15.47, settle y=-13.8
§CPE_DRAG band=1 zone=mid centre=(-15.04, 41.65,-25.45)   <- the "drag it back" attempt, still up there
pathLen 32.3m -> 40.3 -> 52.0 -> 161.7m      walk 24.9s -> 124.4s
```
`y=+39` against a floor at `-15.5` is **~55m above the floor**. The 5× path length is why their film ballooned to 148s.

## Fix
`b.c = c0 + (p - p0)`. A zero-pixel drag is now a zero-metre move *by construction*, and any `p0` depth error cancels out of the difference instead of accumulating. End-drags (`_rotateAbout`) are absolute by nature — rotate the band to aim at the cursor — and are correct as they stand; only the translate branch was wrong.

## ⚠ Not yet witnessed — stated plainly
The gates are specced but not written:
- **G-DRAG-1** zero-pixel drag ⇒ centre unchanged to 1e-9 (the invariant the absolute form breaks)
- **G-DRAG-2** known pixel delta ⇒ exact in-plane world delta, and **zero along the view normal**
- **G-DRAG-3** drag out and back to the same pixel ⇒ returns to start within 1e-6 — literally the user's report

Re-applied off fresh `origin/main`: the first push of this fix was orphaned by the squash-merge of #1032, the exact hazard `CLAUDE.md` documents.

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_DRAG_TELEPORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)