### PR TITLE
chore(cinema): §CPE_LOADED must identify the build — CPE_V v5 → v6

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -15,7 +15,11 @@
 //      and discards them.
 (function() {
   'use strict';
-  var CPE_V = 'v5 (§CPE_PREVIEW_DIVERGENCE — plan pinned to the open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG — panel moves by its header)';
+  // ⚠ BUMP THIS ON EVERY BEHAVIOUR CHANGE — it is how a pasted console answers "which build is this?".
+  // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
+  // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
+  // right version?" could not be answered from their own log. That is the whole job of this line.
+  var CPE_V = 'v6 (§CPE_DRAG_TELEPORT drag=delta; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v858';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v859';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=6" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>


### PR DESCRIPTION
User: *"am i on right v?"* — and their own console could not answer it.

§CPE_DRAG_TELEPORT (#1035) bumped `cinema_path_editor.js?v=` and `sw` `CACHE_VERSION` but **not** the `CPE_V` fingerprint, so `v5` named both the with-fix and without-fix builds. Identifying the build from a pasted console is the entire job of that line, and the file's own header says to bump it on every behaviour change.

`v6` now names the drag fix explicitly, so `§CPE_LOADED` answers the question on its own.

`sw` CACHE_VERSION v858→v859; `cinema_path_editor.js?v=5`→`v=6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)