### PR TITLE
feat(cinema): §CPE_WALK 2.3m/s base pace + §CPE_DRAG_REACH gesture cap

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v6 (§CPE_DRAG_TELEPORT drag=delta; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v7 (§CPE_DRAG_TELEPORT delta + §CPE_DRAG_REACH cap; §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -598,9 +598,19 @@
         // DELTA, not absolute: `c0` was already captured on pointerdown for this and was never read
         // — the intent was here all along. A zero-pixel drag is now a zero-metre move by
         // construction, and any p0 depth error cancels out of (p - p0) instead of accumulating.
-        b.c.x = d.c0.x + (p.x - d.p0.x);
-        b.c.y = d.c0.y + (p.y - d.p0.y);
-        b.c.z = d.c0.z + (p.z - d.p0.z);
+        // §CPE_DRAG_REACH: 1:1 with the cursor is correct, but the view plane sits at the grab
+        // depth — zoomed out to 46m that is ~0.06 m/px, so a long drag legitimately threw the band
+        // ~46m in one gesture (user, Hospital: centre y -9.58 -> +36.89). Cap the REACH of a single
+        // gesture at the building's own derived walk length: a measured quantity from this building,
+        // not an invented constant. Direction is preserved, so the drag still goes where the cursor
+        // points — it just cannot fling the band outside the film it belongs to.
+        var _dx = p.x - d.p0.x, _dy = p.y - d.p0.y, _dz = p.z - d.p0.z;
+        var _dl = Math.hypot(_dx, _dy, _dz);
+        var _cap = Math.max(2, _state.baseLen || 0);
+        if (_dl > _cap) { var _k = _cap / _dl; _dx *= _k; _dy *= _k; _dz *= _k; }
+        b.c.x = d.c0.x + _dx;
+        b.c.y = d.c0.y + _dy;
+        b.c.z = d.c0.z + _dz;
       } else {
         // End = pivot about the far end. Length is invariant, so this is pure rotation.
         _rotateAbout(b, d.z === 'b', p);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3316,7 +3316,15 @@ async function setupEffects(A, renderer, scene, camera) {
   // measured 2.10 m/s on Duplex against 4.99 on LTU_AHouse. Every rate below is a stated constant
   // and every duration is that rate applied to a MEASURED distance or angle, so a building's size
   // now sets its runtime instead of being squeezed into someone else's.
-  var CINEMA_WALK_MPS     = 1.3;   // interior walking pace — deliberately slower than the old 2.1-5.0
+  // §CPE_PACE_LOS base pace (CINEMA_PATH_EDITOR.md). 1.3 was a literal pedestrian and the user called
+  // the result too slow twice. MEASURED from their own runs: a 92.5m Hospital edit spent 71.2s of a
+  // 99.5s film walking and baked 1015 frames (~26 min of cook at their measured 1.6s/frame). Their
+  // stated expectation is ~15s on Duplex against the 26.1s derived, i.e. ~1.8x faster; 1.3 x 1.8 =
+  // 2.34. Stated rate with the arithmetic shown, per this block's own rule that every rate is a
+  // stated constant applied to a MEASURED distance — not a taste dial.
+  // This is the BASE only. The busyness/noise temperament (§CPE_PACE_LOS, still to build) varies the
+  // pace AROUND it within the user's PACE_SWING range; it does not replace this number.
+  var CINEMA_WALK_MPS     = 2.3;   // interior pace — was 1.3
   var CINEMA_PULLBACK_MPS = 6.5;   // exterior recede: flying, not walking
   var CINEMA_DIVE_MPS     = 20;    // the approach is a fly-IN; dive distances run 20-150m
   var CINEMA_TURN_DPS     = 45;    // one rate for BOTH in-place turns: the spin and the orbit lap

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v859';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v860';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=6" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=7" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>


### PR DESCRIPTION
Two outstanding items, decided and shipped.

## §CPE_WALK — base pace 1.3 → 2.3 m/s
1.3 m/s is a literal pedestrian and the result was called too slow twice. From the user's own runs: a 92.5m Hospital edit spent **71.2s of a 99.5s film walking** and baked **1015 frames (~26 min of cook)**. Expectation is ~15s on Duplex against 26.1s derived ⇒ ~1.8×; `1.3 × 1.8 = 2.34`.

**Verified numerically, both buildings:**
```
Duplex    walk 12.6m / 5.5s  = 2.30 m/s    naturalTotal 26.1s -> 21.9s   (329 frames @15)
Terminal  walk 25.3m / 11.0s = 2.30 m/s    naturalTotal        30.6s    (459 frames @15)
```
This is the **base** only — the busyness temperament varies pace *around* it inside `PACE_SWING`.

## §CPE_DRAG_REACH — the residue the delta fix could not cover
1:1 with the cursor is correct, but the view plane sits at the **grab depth**: zoomed out to `targetOffCam=46.2` that is ~0.06 m/px, so a long drag legitimately threw the band ~46m in one gesture (their log: band 1 centre `y −9.58 → +36.89`). 

Cap the reach of a single gesture at the building's **own derived walk length** (`_state.baseLen`) — a measured quantity from this building, not an invented constant. Direction is preserved, so the drag still follows the cursor; it just cannot fling a band outside the film it belongs to.

`CPE_V` → **v7** so `§CPE_LOADED` names both. sw `CACHE_VERSION` → v860, cache-bust `?v=7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)