### PR TITLE
fix(precision-cam): ambient auto uses A (resetOrbit), not Q (recenterPivot)

### DIFF
--- a/viewer/precision_cam.js
+++ b/viewer/precision_cam.js
@@ -15,16 +15,10 @@
   var _slow = { rotateSpeed: 0.15, zoomSpeed: 0.2, panSpeed: 0.15 };
   var _indicator, _panel, _pivotInd;
 
-  // §PIVOT_AMBIENT_AUTO state (declared here so fineOn/resetOrbit/pivotOn below can all
-  // proactively clear it — see _ambientOnEnd further down for what it drives).
-  var _ambientCount = 0, _ambientTimer = null;
-  function _ambientClear() { _ambientCount = 0; clearTimeout(_ambientTimer); }
-
   function fineOn() {
     if (_fine) return;
     if (!A() || !A().controls) return;
     _fine = true;
-    _ambientClear();  // avoid misfire — Fine is deliberate, don't let a queued ambient correct it away
     var c = A().controls;
     c.rotateSpeed = _slow.rotateSpeed;
     c.zoomSpeed = _slow.zoomSpeed;
@@ -57,7 +51,6 @@
   // As if you just started navigating from this spot
   function resetOrbit() {
     if (!A() || !A().controls) return;
-    _ambientClear();  // avoid misfire — don't let a queued ambient correction undo this manual Reset
     var c = A().controls;
     var cam = c.object;
 
@@ -158,7 +151,6 @@
     if (!A() || !A().controls) return;
     _pivot = true;
     window._autoPivot = true;  // exposed for Help-row isActive highlight
-    _ambientClear();  // avoid misfire — Q's own recenter below covers it now, ambient steps aside
     // §PIVOT_FINE_WINS: Fine is a deliberate user act (visible top-centre icon) for slowly
     // closing in on one specific point — Auto-Pivot yanking the target elsewhere on every
     // drag-end would fight that. Fine wins: pause auto-recenter while Fine is active.
@@ -183,34 +175,20 @@
 
   function togglePivot() { _pivot ? pivotOff() : pivotOn(); }
 
-  // §PIVOT_AMBIENT_AUTO (2026-07-27): background pivot correction, active by default —
-  // gives the "continuous navigation, pivot never goes stale" feel without requiring the
-  // user to know about Q. Deliberately a SEPARATE listener from Q's own _onEnd above, not
-  // a change to Q's default state (that was tried in #1033 and reverted in #1034 — firing
-  // on every single drag-end read as the view drifting on its own). Two things make this
-  // one safe where that one wasn't:
-  //   1. Steps aside whenever Q or Fine are active (checked first, and each of pivotOn/
-  //      fineOn/resetOrbit above also proactively clears any pending timer on engage —
-  //      "avoid misfire", no race where a queued ambient correction lands after the user
-  //      just deliberately took over).
-  //   2. Debounced AND count-gated: only fires once the user has actually stopped (no new
-  //      drag/zoom for _AMBIENT_REST_MS), and only if at least _AMBIENT_THRESHOLD drags/
-  //      zooms built up since the last correction — never mid-navigation, never for one
-  //      small nudge. Uses the same raycast-based recenterPivot() Q uses, NOT resetOrbit()
-  //      (resetOrbit is geometry-blind — automating it would reintroduce the "orbiting
-  //      empty space" problem Auto-Pivot was built to fix in the first place).
-  var _AMBIENT_REST_MS = 1500, _AMBIENT_THRESHOLD = 3;
-  function _ambientOnEnd() {
-    if (_pivot || _fine) { _ambientClear(); return; }  // Q/Fine own the recenter instead
-    _ambientCount++;
-    clearTimeout(_ambientTimer);
-    _ambientTimer = setTimeout(function() {
-      if (_ambientCount >= _AMBIENT_THRESHOLD) {
-        recenterPivot();
-        console.log('§pivot ambient-auto fired count=' + _ambientCount);
+  // §RESET_AMBIENT_AUTO: 3 user moves (drag/zoom), then reset A automatically once the
+  // user stops. Self-contained — does not modify fineOn/resetOrbit/pivotOn.
+  var _ambientResetCount = 0, _ambientResetTimer = null;
+  function _ambientResetOnEnd() {
+    if (_pivot || _fine) { _ambientResetCount = 0; clearTimeout(_ambientResetTimer); return; }
+    _ambientResetCount++;
+    clearTimeout(_ambientResetTimer);
+    _ambientResetTimer = setTimeout(function() {
+      if (_ambientResetCount >= 3) {
+        resetOrbit();
+        console.log('§reset ambient-auto fired count=' + _ambientResetCount);
       }
-      _ambientCount = 0;
-    }, _AMBIENT_REST_MS);
+      _ambientResetCount = 0;
+    }, 1500);
   }
 
   // Caps Lock toggles fine mode (desktop)
@@ -294,21 +272,18 @@
     if (_fine) document.getElementById('prec-fine-btn').style.background = '#1a6b8a';
     if (_pivot) _pivotPaint();
 
-    // §PIVOT_AMBIENT_AUTO wiring: A().controls doesn't exist yet at DOMContentLoaded
-    // (setupScene creates it later, async) — poll briefly, then attach the ambient
-    // listener PERMANENTLY (never removed — it self-no-ops via the _pivot||_fine check
-    // inside _ambientOnEnd, so there's nothing to toggle here). Bounded, self-clearing
-    // either branch — zero steady-state cost once resolved.
-    var _ambientWireTries = 0;
-    var _ambientWireTimer = setInterval(function() {
-      _ambientWireTries++;
+    // §RESET_AMBIENT_AUTO wiring: A().controls doesn't exist yet at DOMContentLoaded
+    // (setupScene creates it later, async) — poll briefly, then attach the listener once.
+    var _ambientResetWireTries = 0;
+    var _ambientResetWireTimer = setInterval(function() {
+      _ambientResetWireTries++;
       if (A() && A().controls) {
-        clearInterval(_ambientWireTimer);
-        A().controls.addEventListener('end', _ambientOnEnd);
-        console.log('§pivot ambient-auto wired tries=' + _ambientWireTries);
-      } else if (_ambientWireTries > 100) {  // ~10s — give up quietly
-        clearInterval(_ambientWireTimer);
-        console.log('§pivot ambient-auto wiring timeout — controls never became ready');
+        clearInterval(_ambientResetWireTimer);
+        A().controls.addEventListener('end', _ambientResetOnEnd);
+        console.log('§reset ambient-auto wired tries=' + _ambientResetWireTries);
+      } else if (_ambientResetWireTries > 100) {  // ~10s — give up quietly
+        clearInterval(_ambientResetWireTimer);
+        console.log('§reset ambient-auto wiring timeout — controls never became ready');
       }
     }, 100);
 


### PR DESCRIPTION
Corrects #1039 — the request was to automate A only. This PR calls resetOrbit() instead of recenterPivot(), and removes the _ambientClear() lines #1039 injected into fineOn()/resetOrbit()/pivotOn() (those three are now byte-identical to pre-#1039). Mechanism unchanged: 3 drags/zooms, reset A once the user stops for 1.5s, skipped while Q or Fine are active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)