### PR TITLE
fix(precision-cam): ambient reset re-checks Q/Fine at fire-time

### DIFF
--- a/viewer/precision_cam.js
+++ b/viewer/precision_cam.js
@@ -183,7 +183,7 @@
     _ambientResetCount++;
     clearTimeout(_ambientResetTimer);
     _ambientResetTimer = setTimeout(function() {
-      if (_ambientResetCount >= 3) {
+      if (_ambientResetCount >= 3 && !_pivot && !_fine) {
         resetOrbit();
         console.log('§reset ambient-auto fired count=' + _ambientResetCount);
       }


### PR DESCRIPTION
Q/Fine on stops the ambient auto-reset; Q/Fine off, it resumes on the next 3 moves. One-line fix, fully inside the existing self-contained ambient function.