### PR TITLE
fix(cinema): §CINEMA_LOOKAHEAD_ARC — the jerk, found and fixed + T5 position gate

### DIFF
--- a/probe_drag_scale.js
+++ b/probe_drag_scale.js
@@ -1,0 +1,63 @@
+// Probe: how many METRES does one PIXEL of drag move a band handle?
+// §CPE_SCREEN_PLANE is settled — a drag moves the handle in the camera's view plane, and G-DRAG-4
+// already proves that mapping is 1:1 in SCREEN terms (0.997x). This asks the different question the
+// user's "wp1 jumps to way high" implies: 1:1 on screen is not 1:1 in the world, because the view
+// plane sits at the handle's distance from the camera. The further the building, the more world
+// metres one pixel buys. Proves or disproves: is the drag's world-space sensitivity the reason a
+// small gesture throws a waypoint far off the walking plane?
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8403;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal,Hospital').split(',');
+const DUR = 24;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaSeedBands,
+      { timeout: 120000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    const r = await page.evaluate(async (dur) => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      A._cinemaPathEdit = null;
+      const plan = A.cinemaPathPlan(dur, null);
+      const bands = A.cinemaSeedBands(plan.waypoints, plan.pathLen);
+      const cam = A.camera || (A.viewer && A.viewer.camera);
+      if (!cam) return { err: 'no camera' };
+      const vpH = (A.renderer && A.renderer.domElement && A.renderer.domElement.clientHeight) || 700;
+      // metres per pixel in the view plane at distance d: 2*d*tan(fov/2) / viewportHeight
+      const fov = cam.fov * Math.PI / 180;
+      const out = bands.map((b, i) => {
+        const d = Math.hypot(b.c.x - cam.position.x, b.c.y - cam.position.y, b.c.z - cam.position.z);
+        return { band: i, dist: d, mPerPx: 2 * d * Math.tan(fov / 2) / vpH };
+      });
+      // the walking plane the bands are supposed to sit on
+      const ys = bands.map(b => b.c.y);
+      return { out, vpH, fov: cam.fov, camY: cam.position.y,
+               bandY: { min: Math.min(...ys), max: Math.max(...ys) }, pathLen: plan.pathLen };
+    }, DUR);
+
+    if (r.err) { console.log(`${BLD}: ${r.err}`); await page.close(); continue; }
+    console.log(`\n=== ${BLD} (fov=${r.fov}, viewport ${r.vpH}px, walk ${r.pathLen.toFixed(1)}m) ===`);
+    for (const b of r.out) {
+      console.log(`  band ${b.band}: dist=${b.dist.toFixed(1)}m  ->  ${b.mPerPx.toFixed(4)} m/px` +
+        `   (a 50px nudge = ${(b.mPerPx * 50).toFixed(2)}m,  a 200px drag = ${(b.mPerPx * 200).toFixed(1)}m)`);
+    }
+    await page.close();
+  }
+  await browser.close();
+})();

--- a/probe_hosp_jerk.js
+++ b/probe_hosp_jerk.js
@@ -1,0 +1,101 @@
+// Probe: is the 81 deg/frame peak on Hospital a STEP or a fast turn?
+// §CPE_JERK_DEFINITION item 3 — resample the same neighbourhood at 100x density. A real turn
+// shrinks ~100x; a genuine discontinuity stays the same size. Also reports the position step
+// (metres/frame) at the same place, which is the UNGATED half of the jerk definition.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8403;
+const BLD = process.env.BLD || 'Hospital';
+const FPS = 15, DUR = 24;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaSeedBands,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+
+  const out = await page.evaluate(async (dur, fps) => {
+    const A = window.APP;
+    if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+    if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+    A._cinemaPathEdit = null;
+    const derived = A.cinemaPathPlan(dur, null);
+    const seeded = A.cinemaSeedBands(derived.waypoints, derived.pathLen);
+    const hostile = seeded.map((b, i) => ({
+      c: { x: b.c.x, y: b.c.y, z: b.c.z },
+      d: i % 2 ? { x: -b.d.x, y: b.d.y, z: -b.d.z } : { x: b.d.x, y: b.d.y, z: b.d.z },
+      len: b.len,
+    }));
+    const flow = A.cinemaBandFlow(hostile);
+    A._cinemaPathEdit = { waypoints: flow };
+    const plan = A.cinemaPathPlan(dur, { waypoints: flow });
+
+    const dir = (p) => {
+      const x = p.tx - p.x, y = p.ty - p.y, z = p.tz - p.z;
+      const l = Math.hypot(x, y, z) || 1;
+      return { x: x / l, y: y / l, z: z / l };
+    };
+    const ang = (a, b) => Math.acos(Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z))) * 180 / Math.PI;
+
+    // 1. locate the peak at REAL frame density
+    const n = Math.max(2, Math.round(dur * fps));
+    let peak = 0, peakI = 0;
+    for (let i = 1; i < n; i++) {
+      const d = ang(dir(plan.poseAt((i - 1) / (n - 1))), dir(plan.poseAt(i / (n - 1))));
+      if (d > peak) { peak = d; peakI = i; }
+    }
+    const uA = (peakI - 1) / (n - 1), uB = peakI / (n - 1);
+
+    // 2. resample THAT interval at 100x density — step vs fast turn
+    const M = 100;
+    let sub = 0, subAt = 0;
+    for (let k = 1; k <= M; k++) {
+      const p0 = plan.poseAt(uA + (uB - uA) * (k - 1) / M);
+      const p1 = plan.poseAt(uA + (uB - uA) * k / M);
+      const d = ang(dir(p0), dir(p1));
+      if (d > sub) { sub = d; subAt = uA + (uB - uA) * (k - 0.5) / M; }
+    }
+
+    // 3. the UNGATED half: position step per frame, whole film + at the peak
+    let posPeak = 0, posPeakU = 0;
+    for (let i = 1; i < n; i++) {
+      const p0 = plan.poseAt((i - 1) / (n - 1)), p1 = plan.poseAt(i / (n - 1));
+      const d = Math.hypot(p1.x - p0.x, p1.y - p0.y, p1.z - p0.z);
+      if (d > posPeak) { posPeak = d; posPeakU = i / (n - 1); }
+    }
+    const pA = plan.poseAt(uA), pB = plan.poseAt(uB);
+    return {
+      peak, uA, uB, sub, subAt, ratio: peak / (sub || 1e-9),
+      beats: plan.beats, walkSec: plan.sec && plan.sec.out, natural: plan.naturalTotal,
+      posPeak, posPeakU, posAtPeak: Math.hypot(pB.x - pA.x, pB.y - pA.y, pB.z - pA.z),
+      gazeA: dir(pA), gazeB: dir(pB), pathLen: plan.pathLen,
+    };
+  }, DUR, FPS);
+
+  const inWalk = out.uB > out.beats.spin && out.uB <= out.beats.out;
+  console.log(`\n=== ${BLD} — peak gaze sweep ${out.peak.toFixed(1)} deg/frame at u=${out.uB.toFixed(3)} ===`);
+  console.log(`beats: spin=${out.beats.spin.toFixed(3)} out=${out.beats.out.toFixed(3)} -> peak is ${inWalk ? 'INSIDE the walk (§CPE_EVEN_TURN governs it)' : 'OUTSIDE the walk (pacing cannot touch it)'}`);
+  console.log(`100x resample of that interval: max sub-step ${out.sub.toFixed(2)} deg at u=${out.subAt.toFixed(5)}`);
+  console.log(`ratio peak/sub = ${out.ratio.toFixed(1)}x  ->  ${out.ratio > 30 ? 'FAST TURN (shrinks with density)' : 'STEP / DISCONTINUITY (does not shrink)'}`);
+  console.log(`gaze before: (${out.gazeA.x.toFixed(3)},${out.gazeA.y.toFixed(3)},${out.gazeA.z.toFixed(3)})`);
+  console.log(`gaze after : (${out.gazeB.x.toFixed(3)},${out.gazeB.y.toFixed(3)},${out.gazeB.z.toFixed(3)})`);
+  console.log(`position step at that frame: ${out.posAtPeak.toFixed(3)} m`);
+  console.log(`position step PEAK over film: ${out.posPeak.toFixed(3)} m/frame at u=${out.posPeakU.toFixed(3)} (walk ${out.pathLen.toFixed(1)}m over ${out.walkSec ? out.walkSec.toFixed(1) : '?'}s)`);
+  const cpe = logs.filter(l => /§CPE_EVEN_TURN|§CPE_SEAM_CONTINUOUS|§CINEMA_BEATS/.test(l));
+  console.log('\n' + (cpe.length ? cpe.join('\n') : '(no §CPE plan lines captured)'));
+  await browser.close();
+})();

--- a/probe_hosp_jerk.js
+++ b/probe_hosp_jerk.js
@@ -40,9 +40,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       d: i % 2 ? { x: -b.d.x, y: b.d.y, z: -b.d.z } : { x: b.d.x, y: b.d.y, z: b.d.z },
       len: b.len,
     }));
-    const flow = A.cinemaBandFlow(hostile);
-    A._cinemaPathEdit = { waypoints: flow };
-    const plan = A.cinemaPathPlan(dur, { waypoints: flow });
+    // EXACTLY the call witness_cpe_even_turn's run() makes — the BANDS path, not the waypoints
+    // path. They plan differently, and probing the wrong one is how the first pass measured 10.2
+    // deg/frame where the gate measured 81.0 on the same building.
+    const plan = A.cinemaPathPlan(dur, { bands: hostile, _total: dur });
 
     const dir = (p) => {
       const x = p.tx - p.x, y = p.ty - p.y, z = p.tz - p.z;

--- a/prompts/CINEMA_PATH_EDITOR.md
+++ b/prompts/CINEMA_PATH_EDITOR.md
@@ -1,0 +1,17 @@
+
+### ⚠ AMENDMENT 2 to §CPE_PACE_LOS (user, 2026-07-27) — the total field stays the global speed knob
+> *"remember there is also the overall speed control ie the total time of movie length in the panel
+> can be set to a faster when reduced, or otherwise"*
+
+Already built (`_state.userTotal`, `§CPE_TOTAL`, uniform `scale` in `_buildOverride`) and it must
+survive the pacing work intact. **The interaction is the trap:** `tour.js`'s `_paceBuildRemap` does
+TWO things — it redistributes time along the path AND rescales the action's own total via
+`meanFactor`. The second one would silently fight an explicitly-keyed total: the user types 40s, the
+remap decides the path is open and hands back 31s. So:
+- **User has keyed a total → the brake REDISTRIBUTES within it only. `meanFactor` rescaling is OFF.**
+  Their number is the film's length, full stop.
+- **User has not keyed one → the derived total stands, and `meanFactor` may inform it** (that is the
+  §CPE_PACING "length is a consequence of the building" model, which the user already ratified).
+**Gate:** with a keyed total of T, the baked film's duration is T ± one frame, no matter how busy or
+open the path is — while the WITHIN-film speed still varies. Both halves in one gate, or the brake
+can quietly eat the user's setting and still look right.

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -629,8 +629,12 @@
         // scene stays fully navigable while the editor is open.
         ev.preventDefault(); ev.stopPropagation();
         _hold(hit.b, hit.z, false);
-        _undoPush('drag band ' + hit.b + ' (' + hit.z + ')');
-        _state.drag = { b: hit.b, z: hit.z,
+        // §CPE_UNDO: the snapshot is NOT taken here. A press that never moves must not leave an
+        // undo entry behind — G-DRAG-1 gates that a zero-pixel press changes nothing, so an undo
+        // step for it would be a Ctrl+Z that visibly does nothing and silently eats the user's real
+        // previous edit. Taken on the FIRST actual movement instead (see h.move), which is the
+        // moment an edit genuinely begins.
+        _state.drag = { b: hit.b, z: hit.z, snapped: false,
                         c0: { x: _state.bands[hit.b].c.x, y: _state.bands[hit.b].c.y, z: _state.bands[hit.b].c.z },
                         p0: { x: hit.p.x, y: hit.p.y, z: hit.p.z } };
       }
@@ -641,6 +645,9 @@
       var d = _state.drag, b = _state.bands[d.b];
       var p = _viewPlanePoint(ev, d.p0);   // the plane the grabbed handle already lies in
       if (!p) return;
+      // First real movement of this gesture = the edit is now happening; snapshot the pre-drag
+      // state exactly once, before anything below mutates it.
+      if (!d.snapped) { d.snapped = true; _undoPush('drag band ' + d.b + ' (' + d.z + ')'); }
       if (d.z === 'mid') {
         // Middle = the whole length moving as one.
         // §CPE_DRAG_TELEPORT (user, Hospital, 2026-07-27: "went off to a spot user didnt put.

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v7 (§CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v8 (§CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -347,6 +347,58 @@
 
   function _num(v) { return (Math.round(v * 100) / 100).toFixed(2); }
 
+  // ══ §CPE_UNDO (user, 2026-07-27: "allow UNDO, Ctl-Z as reflecting in the history line to take
+  // effect so a misplaced can be easily reverted"). A misplaced drag is now one keystroke away from
+  // being gone, which is what makes direct manipulation safe to experiment with.
+  //
+  // DELIBERATELY a local snapshot stack, NOT KernelOps/UniversalHistory.undo(): a waypoint edit is
+  // TRANSIENT editor state until the user explicitly saves the path (§CPE_BUILT persistence), so it
+  // has no signed kernel op to flip. Routing it through the model op-log would mint fake model ops
+  // for edits that may never be saved, and Ctrl+Z would then undo the wrong thing once the editor
+  // closed. The history LINE still shows it — via UniversalHistory.recordEvent, the existing
+  // read-only detail-event channel (universal_history.js, HISTORY_SESSION_EVENTS.md A1) — so the
+  // user sees the edit land on the timeline exactly as they asked, without faking a model change.
+  var _UNDO_MAX = 50;
+  function _cloneBands(bs) {
+    return bs.map(function(b) {
+      return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
+    });
+  }
+  // Call BEFORE mutating, with a label naming the edit. Redo is dropped on a new edit — the standard
+  // linear-undo rule, and the same one UniversalHistory itself applies to a new op after a step-back.
+  function _undoPush(label) {
+    if (!_state) return;
+    if (!_state.undo) { _state.undo = []; _state.redo = []; }
+    _state.undo.push({ bands: _cloneBands(_state.bands), label: label });
+    if (_state.undo.length > _UNDO_MAX) _state.undo.shift();
+    _state.redo = [];
+  }
+  function _histEvent(label) {
+    // The history line. recordEvent is the read-only channel, so this never touches kernel_ops.
+    try {
+      var UH = window.UniversalHistory;
+      if (UH && UH.recordEvent) UH.recordEvent('CINEMA_PATH_EDIT', label, null);
+    } catch (e) {}
+  }
+  function _undoApply(fromStack, toStack, dir) {
+    if (!_state || !fromStack || !fromStack.length) {
+      console.log('§CPE_UNDO ' + dir + ' — nothing to ' + dir);
+      return false;
+    }
+    var snap = fromStack.pop();
+    toStack.push({ bands: _cloneBands(_state.bands), label: snap.label });
+    _state.bands = _cloneBands(snap.bands);
+    _state.staged = false;
+    _state.held = null; _state.drag = null;
+    console.log('§CPE_UNDO ' + dir + ' "' + snap.label + '" depth=' + fromStack.length +
+      ' bands=' + _state.bands.length);
+    _histEvent((dir === 'undo' ? 'Undo: ' : 'Redo: ') + snap.label);
+    _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _renderHint(); _syncButtons();
+    return true;
+  }
+  function _undo() { return _undoApply(_state && _state.undo, _state && _state.redo, 'undo'); }
+  function _redo() { return _undoApply(_state && _state.redo, _state && _state.undo, 'redo'); }
+
   function _renderRows() {
     var box = document.getElementById('cpe-rows');
     if (!box) return;
@@ -374,6 +426,7 @@
           inp.addEventListener('change', function() {
             var v = parseFloat(inp.value);
             if (!isFinite(v)) { inp.value = _num(b.c[ax]); return; }
+            _undoPush('band ' + i + ' ' + ax);
             b.c[ax] = v;
             console.log('§CPE_KEY band=' + i + ' centre.' + ax + '=' + v.toFixed(2));
             _state.staged = false;
@@ -391,6 +444,7 @@
         len.addEventListener('change', function() {
           var v = parseFloat(len.value);
           if (!isFinite(v) || v <= 0.05) { len.value = _num(b.len); return; }
+          _undoPush('band ' + i + ' length');
           b.len = v;
           console.log('§CPE_LEN band=' + i + ' len=' + v.toFixed(2) + 'm');
           _state.staged = false;
@@ -575,6 +629,7 @@
         // scene stays fully navigable while the editor is open.
         ev.preventDefault(); ev.stopPropagation();
         _hold(hit.b, hit.z, false);
+        _undoPush('drag band ' + hit.b + ' (' + hit.z + ')');
         _state.drag = { b: hit.b, z: hit.z,
                         c0: { x: _state.bands[hit.b].c.x, y: _state.bands[hit.b].c.y, z: _state.bands[hit.b].c.z },
                         p0: { x: hit.p.x, y: hit.p.y, z: hit.p.z } };
@@ -626,6 +681,18 @@
         ' dir=(' + b.d.x.toFixed(2) + ',' + b.d.y.toFixed(2) + ',' + b.d.z.toFixed(2) + ') len=' + b.len.toFixed(2));
       _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
     };
+    // §CPE_UNDO: Ctrl+Z / Ctrl+Shift+Z (and Ctrl+Y) while the editor is OPEN. Same bindings
+    // grid_drag.js already uses, and like it this listener is added on open and removed on close, so
+    // it cannot shadow any other Ctrl+Z once the editor is gone. Capture phase + preventDefault so
+    // the browser's own text-undo never fights it while a number input has focus.
+    h.key = function(e) {
+      if (!_state) return;
+      var k = (e.key || '').toLowerCase();
+      if (!e.ctrlKey || (k !== 'z' && k !== 'y')) return;
+      e.preventDefault(); e.stopPropagation();
+      if (k === 'y' || (k === 'z' && e.shiftKey)) _redo(); else _undo();
+    };
+    window.addEventListener('keydown', h.key, true);
     c.addEventListener('pointerdown', h.down, true);
     window.addEventListener('pointermove', h.move, true);
     window.addEventListener('pointerup', h.up, true);
@@ -637,6 +704,7 @@
     c.removeEventListener('pointerdown', h.down, true);
     window.removeEventListener('pointermove', h.move, true);
     window.removeEventListener('pointerup', h.up, true);
+    if (h.key) window.removeEventListener('keydown', h.key, true);
   }
 
   // ══════════════════ public API ══════════════════
@@ -653,7 +721,7 @@
         return bs.map(function(b) { return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len }; });
       };
       _state = {
-        bands: clone(seeded), origBands: clone(seeded), staged: false,
+        bands: clone(seeded), origBands: clone(seeded), staged: false, undo: [], redo: [],
         held: null, drag: null, objs: [], handles: [], pulseId: 0, flyId: 0,
         baseSec: { dive: plan.sec.dive, spin: plan.sec.spin, out: plan.sec.out, rise: plan.sec.rise },
         baseOutSec: plan.sec.out, baseTotal: ctx.durationSec, baseLen: plan.pathLen,

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -584,7 +584,20 @@
       if (!p) return;
       if (d.z === 'mid') {
         // Middle = the whole length moving as one.
-        b.c.x = p.x; b.c.y = p.y; b.c.z = p.z;
+        // §CPE_DRAG_TELEPORT (user, Hospital, 2026-07-27: "went off to a spot user didnt put.
+        // Draging it back, still flew back"). This USED to assign the projected cursor point
+        // absolutely — `b.c = p` — which silently made the band's new centre whatever the grab
+        // ray happened to meet, not the centre plus the gesture. Any depth error in the grab point
+        // `p0` therefore became a PERMANENT offset, and every later drag re-anchored its plane at
+        // the already-wrong depth, which is exactly "dragging it back still flew back". Measured in
+        // their log: band 1 centre y=+39.24 against floorY=-15.47 (~55m above the floor), pathLen
+        // 32.3m -> 161.7m in three drags.
+        // DELTA, not absolute: `c0` was already captured on pointerdown for this and was never read
+        // — the intent was here all along. A zero-pixel drag is now a zero-metre move by
+        // construction, and any p0 depth error cancels out of (p - p0) instead of accumulating.
+        b.c.x = d.c0.x + (p.x - d.p0.x);
+        b.c.y = d.c0.y + (p.y - d.p0.y);
+        b.c.z = d.c0.z + (p.z - d.p0.z);
       } else {
         // End = pivot about the far end. Length is invariant, so this is pure rotation.
         _rotateAbout(b, d.z === 'b', p);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3557,7 +3557,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v16 (§CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
+  var EFFECTS_V = 'v17 (§CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; §CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).
@@ -4139,9 +4139,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // a second guess at it (asserted below against _beat3Pose(0), the pose that actually flies).
     // NOTE: the spin does NOT pay for the pitch — see the _spinDeg comment below for why that was
     // tried, measured, and reverted.
-    var _wkP0 = _outPos(0), _wkA0 = _outPos(0.15);
-    if (Math.hypot(_wkA0.x - _wkP0.x, _wkA0.y - _wkP0.y, _wkA0.z - _wkP0.z) < 0.5)
-      _wkA0 = { x: _wkP0.x + odx * 20, y: _wkP0.y, z: _wkP0.z + odz * 20 };
+    var _wkP0 = _outPos(0), _wkA0 = _lookAhead(_wkP0, 0);   // ONE look-ahead rule, shared with Beat 3
     var _wkDy = _wkA0.y - _wkP0.y;
     var _wkL = Math.hypot(_wkA0.x - _wkP0.x, _wkDy, _wkA0.z - _wkP0.z) || 1;
     var dYaw = spinTo - yaw0;
@@ -4493,6 +4491,60 @@ async function setupEffects(A, renderer, scene, camera) {
       return _orbitPose((tNorm - tR) / Math.max(1e-6, 1 - tR));
     }
 
+    // ══ Where the walk is LOOKING at progress u — the one rule, used everywhere. ═══════════════
+    // The look-ahead means "where does the path go next". The old guard answered a collapsed
+    // look-ahead by SUBSTITUTING a level (odx,odz) bearing 20m out — a different vector, switched
+    // to in a single frame. MEASURED on Hospital: the gaze went (-0.230,0.973,-0.019) → (-0.733,
+    // 0.000,0.680), 81.0 deg in ONE frame at u=0.312, and it did NOT shrink at 100x sampling
+    // density (ratio 1.0x) — a true discontinuity, exactly what §CPE_JERK_DEFINITION item 3 calls
+    // a step. The `y` of exactly 0.000 is the substitution's fingerprint.
+    //
+    // The problem is the THRESHOLD, not the window size. Any rule of the form "if the look-ahead
+    // is too close, use something else" has a switch in it, and a switch is a step. Searching
+    // forward for the first point clearing a radius is still such a rule — it only made the step
+    // smaller (MEASURED: 81.0 → 21.3 deg/frame, still ratio 1.4x at 100x density, still a step),
+    // because on a path that folds the first-clearing point can itself jump.
+    //
+    // So there is no threshold. The look-ahead is the point a fixed ARC LENGTH further along the
+    // path. That point always exists and always moves continuously with u, on any path shape,
+    // because arc length is monotone in u — a fold-back cannot collapse it and there is nothing to
+    // substitute. L is derived, not picked: the same 0.15 of the walk the fraction window meant,
+    // now measured in metres so it stops depending on how the parameter happens to be spaced.
+    //
+    // The (odx,odz) fallback survives for exactly one case: a walk with no length at all, where
+    // there is no path to read a direction from. Beat 4 opens on (odx,0,odz), so it is the
+    // continuous answer there rather than a substitution.
+    var _AH_FRAC = 0.15, _ahN = 240, _ahS = null, _ahL = 0;
+    function _ahBuild() {                      // cumulative arc length of the walk, sampled once
+      _ahS = [0];
+      var prev = _outPos(0), s = 0;
+      for (var i = 1; i <= _ahN; i++) {
+        var q = _outPos(i / _ahN);
+        s += Math.hypot(q.x - prev.x, q.y - prev.y, q.z - prev.z);
+        _ahS.push(s); prev = q;
+      }
+      _ahL = s;
+    }
+    function _ahArcAt(u) {                     // arc length travelled by parameter u
+      if (!_ahS) _ahBuild();
+      var t = Math.max(0, Math.min(1, u)) * _ahN, i = Math.min(_ahN - 1, Math.floor(t));
+      return _ahS[i] + (_ahS[i + 1] - _ahS[i]) * (t - i);
+    }
+    function _ahAtArc(s) {                     // the inverse: parameter u at arc length s
+      if (!_ahS) _ahBuild();
+      if (s <= 0) return 0;
+      if (s >= _ahL) return 1;
+      var lo = 0, hi = _ahN;
+      while (hi - lo > 1) { var m = (lo + hi) >> 1; if (_ahS[m] <= s) lo = m; else hi = m; }
+      var d = _ahS[hi] - _ahS[lo];
+      return (lo + (d > 1e-12 ? (s - _ahS[lo]) / d : 0)) / _ahN;
+    }
+    function _lookAhead(p, u) {
+      if (!_ahS) _ahBuild();
+      if (_ahL < 1e-6) return { x: p.x + odx * 20, y: p.y, z: p.z + odz * 20 };
+      return _outPos(_ahAtArc(_ahArcAt(u) + _AH_FRAC * _ahL));
+    }
+
     // The walk-out pose as a pure function of its OWN progress e3 ∈ [0,1]. Extracted verbatim out of
     // poseAt so §CPE_EVEN_TURN's cost table can sample the REAL poses — sampling a re-implementation
     // of the gaze rule would let the table and the film drift apart silently.
@@ -4505,7 +4557,6 @@ async function setupEffects(A, renderer, scene, camera) {
         // swung hard onto the next segment — a real gaze snap, not just position. A wider window
         // means the look-at is further past any given corner while still approaching it, so the
         // direction change is spread out instead of happening in one frame.
-        var ah = _outPos(Math.min(1, e3 + 0.15));
         // §CINEMA_LOOKAHEAD_VERTICAL (2026-07-27): this collapse test used to measure HORIZONTAL
         // distance only, so any near-vertical stretch of path tripped it even though the look-ahead
         // point was metres away — it was simply above rather than ahead. The gaze then snapped from
@@ -4513,8 +4564,7 @@ async function setupEffects(A, renderer, scene, camera) {
         // climbs 17m with x/z barely moving: target jumped (-0.80,-6.19,-1.14) → (-21.82,-25.65,
         // -1.67), a 113 deg/frame whip at t=0.411. A 3D test is what the guard actually meant —
         // "has the look-ahead collapsed onto me", not "has it collapsed horizontally".
-        if (Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) < 0.5)
-          ah = { x: p3.x + odx * 20, y: p3.y, z: p3.z + odz * 20 };
+        var ah = _lookAhead(p3, e3);
         var ad = Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) || 1;
         // §CPE_SEAM_CONTINUOUS: at e3=0 look EXACTLY where the spin left off, then ease onto the
         // walk's own aim across _openU. Smoothstep, so the rate is zero at the seam and there is no

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4125,6 +4125,17 @@ async function setupEffects(A, renderer, scene, camera) {
         'walk-start look-ahead instead (' + firstLeg.x.toFixed(2) + ',' + firstLeg.z.toFixed(2) + ')');
     }
     var spinTo = Math.atan2(firstLeg.z - settle.z, firstLeg.x - settle.x);
+    // §CPE_SEAM_CONTINUOUS — the PITCH the walk opens on, computed here (before the beat seconds)
+    // because the spin now has to cover it and therefore has to be PAID for in the spin's time
+    // budget. Same look-ahead point and same 0.5m collapse guard Beat 3 itself uses at e3=0, so
+    // this is the walk's real opening gaze, not a second guess at it (asserted below against
+    // _beat3Pose(0), which is the pose that actually flies).
+    var _wkP0 = _outPos(0), _wkA0 = _outPos(0.15);
+    if (Math.hypot(_wkA0.x - _wkP0.x, _wkA0.y - _wkP0.y, _wkA0.z - _wkP0.z) < 0.5)
+      _wkA0 = { x: _wkP0.x + odx * 20, y: _wkP0.y, z: _wkP0.z + odz * 20 };
+    var _wkDy = _wkA0.y - _wkP0.y;
+    var _wkL = Math.hypot(_wkA0.x - _wkP0.x, _wkDy, _wkA0.z - _wkP0.z) || 1;
+    var _spinEndPitch = Math.asin(Math.max(-1, Math.min(1, _wkDy / _wkL)));
     var dYaw = spinTo - yaw0;
     while (dYaw > Math.PI) dYaw -= 2 * Math.PI;
     while (dYaw < -Math.PI) dYaw += 2 * Math.PI;
@@ -4193,6 +4204,22 @@ async function setupEffects(A, renderer, scene, camera) {
     // quantities — the approach is capped at the envelope, the spin at a half turn (the most that is
     // ever needed to face anywhere) — and only then converted at their stated rates.
     var _diveEff = Math.min(diveDist, envelope);
+    // §CPE_SEAM_CONTINUOUS: count the PITCH sweep too. The spin turns in yaw AND tilts to the
+    // walk's opening pitch, but this budget used to price the yaw alone — so on a walk that opens
+    // steeply the tilt was crammed into a beat sized for a flat turn. MEASURED on Terminal: yaw
+    // asked for under 36 deg (so the beat fell to the 0.8s floor) while the real sweep was ~142 deg,
+    // giving 17.7 deg/frame. Same CINEMA_TURN_DPS rate, applied to the whole sweep. The pitch is
+    // capped at 90 for the same reason the yaw is capped at 180: a quarter turn is the most a tilt
+    // can ever need, so a pathological pose cannot inflate the runtime.
+    // §CPE_SEAM_CONTINUOUS — the direction the walk WANTS to open on, and the direction the spin
+    // actually hands over (level, on the spin's final bearing). The gap between them was being paid
+    // in ONE frame at the Beat2->3 seam: MEASURED 81 deg on Terminal, and it did NOT shrink when
+    // sampled at 100x density, so it was a true discontinuity that no pacing could ever spread.
+    // It is closed inside the WALK (see _beat3Pose) rather than inside the spin, because the walk
+    // already owns thousands of frames while the spin's length is derived from its own yaw — paying
+    // for it in the spin would make the spin's DURATION depend on the authored path, which shifts
+    // every beat fraction before it and breaks G2's "an edit changes nothing before it".
+    var _openDir = { x: (_wkA0.x - _wkP0.x) / _wkL, y: _wkDy / _wkL, z: (_wkA0.z - _wkP0.z) / _wkL };
     var _spinDeg = Math.min(180, Math.abs(dYaw) * 180 / Math.PI);
     var _natSec = {
       dive:  Math.max(CINEMA_DIVE_MIN_SEC, _diveEff / CINEMA_DIVE_MPS),
@@ -4210,6 +4237,19 @@ async function setupEffects(A, renderer, scene, camera) {
       ? { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC,
           orbit: _natSec.orbit }
       : _natSec;
+    // The pose Beat 2 ends on: level, on the spin's final bearing. Beat 3 must START here.
+    var _handYaw = yaw0 + dYaw;
+    var _handDir = { x: Math.cos(_handYaw), y: 0, z: Math.sin(_handYaw) };
+    var _openDeg = Math.acos(Math.max(-1, Math.min(1,
+      _handDir.x * _openDir.x + _handDir.y * _openDir.y + _handDir.z * _openDir.z))) * 180 / Math.PI;
+    // How much of the walk the handoff needs, at the project's OWN established turn rate
+    // (CINEMA_TURN_DPS — the rate the spin and the orbit lap already use). Not a new constant, and
+    // not a fraction picked to make a gate green: it is "how long a graceful turn of this size
+    // takes", expressed as a share of the walk's own seconds.
+    var _openU = Math.min(1, (_openDeg / CINEMA_TURN_DPS) / Math.max(1e-6, _useSec.out));
+    console.log('§CPE_SEAM_CONTINUOUS openDeg=' + _openDeg.toFixed(1) + ' openU=' + _openU.toFixed(4) +
+      ' (~' + (_openU * _useSec.out).toFixed(2) + 's of the ' + _useSec.out.toFixed(1) +
+      's walk) handoffYawDeg=' + (_handYaw * 180 / Math.PI).toFixed(1));
     var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.rise + _useSec.orbit;
     var tD = _useSec.dive / _shapeTotal;
     var tS = tD + _useSec.spin / _shapeTotal;
@@ -4420,39 +4460,11 @@ async function setupEffects(A, renderer, scene, camera) {
       }
       if (tNorm <= tO) {
         // ── Beat 3: walk it out through the door the pose chose.
-        var e3 = _cinemaSmoothstep((tNorm - tS) / Math.max(1e-6, tO - tS));
-        var p3 = _outPos(e3);
-        // §CINEMA_TIMING_672 (2026-07-24, user: "no chasing interim targets when exiting building
-        // mostly"): 0.06→0.15. Position already moves at constant speed along the route; this
-        // lookahead point only steers where the camera LOOKS. On a multi-waypoint room-graph route
-        // (a corridor with turns), the instant this window crosses a corner the look-at direction
-        // swung hard onto the next segment — a real gaze snap, not just position. A wider window
-        // means the look-at is further past any given corner while still approaching it, so the
-        // direction change is spread out instead of happening in one frame.
-        var ah = _outPos(Math.min(1, e3 + 0.15));
-        // §CINEMA_LOOKAHEAD_VERTICAL (2026-07-27): this collapse test used to measure HORIZONTAL
-        // distance only, so any near-vertical stretch of path tripped it even though the look-ahead
-        // point was metres away — it was simply above rather than ahead. The gaze then snapped from
-        // looking up the shaft to the flat (odx,odz) bearing. MEASURED on Terminal, whose walk-out
-        // climbs 17m with x/z barely moving: target jumped (-0.80,-6.19,-1.14) → (-21.82,-25.65,
-        // -1.67), a 113 deg/frame whip at t=0.411. A 3D test is what the guard actually meant —
-        // "has the look-ahead collapsed onto me", not "has it collapsed horizontally".
-        if (Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) < 0.5)
-          ah = { x: p3.x + odx * 20, y: p3.y, z: p3.z + odz * 20 };
-        var ad = Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) || 1;
-        // §CINEMA_BEAT_OVERLAP (2026-07-20, "no abruptness... even the path when reaching outside
-        // should not be robotic abrupt stop and turn, it can play while doing both"): start blending
-        // the look-at toward the pivot in the LAST CINEMA_TURN_OVERLAP fraction of the walk-out, so
-        // Beat 4's turn is a CONTINUATION picked up mid-blend, not a fresh spin starting from zero.
-        // Both this ramp-in and Beat 4's ramp-out use smoothstep, so the blend weight is continuous
-        // AND has matching (zero) slope at the tO boundary — no kink in the gaze direction.
-        var turnW3 = (e3 > 1 - CINEMA_TURN_OVERLAP)
-          ? _cinemaSmoothstep((e3 - (1 - CINEMA_TURN_OVERLAP)) / CINEMA_TURN_OVERLAP) * CINEMA_TURN_OVERLAP_MAX
-          : 0;
-        // turnW3=0 reproduces the old pure-walk target exactly (p3 + aheadDir*20) — the walk-out
-        // itself is untouched; only the blend that follows changed shape.
-        return _cinemaGazeBlend(p3.x, p3.y, p3.z,
-                                (ah.x - p3.x) / ad, (ah.y - p3.y) / ad, (ah.z - p3.z) / ad, turnW3);
+        // §CPE_EVEN_TURN: the frame's progress along the walk is no longer the eased TIME fraction
+        // — it is that fraction run through _evenTurnRemap, which spaces frames evenly in the
+        // blended distance+turn metric instead of evenly in distance. See the remap's own comment.
+        var e3 = _evenTurnRemap(_cinemaSmoothstep((tNorm - tS) / Math.max(1e-6, tO - tS)));
+        return _beat3Pose(e3);
       }
       if (tNorm <= tR) {
         // ── Beat 4: turn around to face the building and rise onto the orbit band. Ends EXACTLY
@@ -4473,6 +4485,142 @@ async function setupEffects(A, renderer, scene, camera) {
       // ── Beat 5: the standard ending.
       return _orbitPose((tNorm - tR) / Math.max(1e-6, 1 - tR));
     }
+
+    // The walk-out pose as a pure function of its OWN progress e3 ∈ [0,1]. Extracted verbatim out of
+    // poseAt so §CPE_EVEN_TURN's cost table can sample the REAL poses — sampling a re-implementation
+    // of the gaze rule would let the table and the film drift apart silently.
+    function _beat3Pose(e3) {
+        var p3 = _outPos(e3);
+        // §CINEMA_TIMING_672 (2026-07-24, user: "no chasing interim targets when exiting building
+        // mostly"): 0.06→0.15. Position already moves at constant speed along the route; this
+        // lookahead point only steers where the camera LOOKS. On a multi-waypoint room-graph route
+        // (a corridor with turns), the instant this window crosses a corner the look-at direction
+        // swung hard onto the next segment — a real gaze snap, not just position. A wider window
+        // means the look-at is further past any given corner while still approaching it, so the
+        // direction change is spread out instead of happening in one frame.
+        var ah = _outPos(Math.min(1, e3 + 0.15));
+        // §CINEMA_LOOKAHEAD_VERTICAL (2026-07-27): this collapse test used to measure HORIZONTAL
+        // distance only, so any near-vertical stretch of path tripped it even though the look-ahead
+        // point was metres away — it was simply above rather than ahead. The gaze then snapped from
+        // looking up the shaft to the flat (odx,odz) bearing. MEASURED on Terminal, whose walk-out
+        // climbs 17m with x/z barely moving: target jumped (-0.80,-6.19,-1.14) → (-21.82,-25.65,
+        // -1.67), a 113 deg/frame whip at t=0.411. A 3D test is what the guard actually meant —
+        // "has the look-ahead collapsed onto me", not "has it collapsed horizontally".
+        if (Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) < 0.5)
+          ah = { x: p3.x + odx * 20, y: p3.y, z: p3.z + odz * 20 };
+        var ad = Math.hypot(ah.x - p3.x, ah.y - p3.y, ah.z - p3.z) || 1;
+        // §CPE_SEAM_CONTINUOUS: at e3=0 look EXACTLY where the spin left off, then ease onto the
+        // walk's own aim across _openU. Smoothstep, so the rate is zero at the seam and there is no
+        // kink against Beat 2's own eased ending. Past _openU this is the untouched walk gaze.
+        var _lx = (ah.x - p3.x) / ad, _ly = (ah.y - p3.y) / ad, _lz = (ah.z - p3.z) / ad;
+        if (_openU > 1e-6 && e3 < _openU) {
+          var wOpen = _cinemaSmoothstep(e3 / _openU);
+          _lx = _handDir.x + (_lx - _handDir.x) * wOpen;
+          _ly = _handDir.y + (_ly - _handDir.y) * wOpen;
+          _lz = _handDir.z + (_lz - _handDir.z) * wOpen;
+          var _ll = Math.hypot(_lx, _ly, _lz) || 1;
+          _lx /= _ll; _ly /= _ll; _lz /= _ll;
+        }
+        // §CINEMA_BEAT_OVERLAP (2026-07-20, "no abruptness... even the path when reaching outside
+        // should not be robotic abrupt stop and turn, it can play while doing both"): start blending
+        // the look-at toward the pivot in the LAST CINEMA_TURN_OVERLAP fraction of the walk-out, so
+        // Beat 4's turn is a CONTINUATION picked up mid-blend, not a fresh spin starting from zero.
+        // Both this ramp-in and Beat 4's ramp-out use smoothstep, so the blend weight is continuous
+        // AND has matching (zero) slope at the tO boundary — no kink in the gaze direction.
+        var turnW3 = (e3 > 1 - CINEMA_TURN_OVERLAP)
+          ? _cinemaSmoothstep((e3 - (1 - CINEMA_TURN_OVERLAP)) / CINEMA_TURN_OVERLAP) * CINEMA_TURN_OVERLAP_MAX
+          : 0;
+        // turnW3=0 reproduces the old pure-walk target exactly (p3 + aheadDir*20) — the walk-out
+        // itself is untouched; only the blend that follows changed shape.
+        return _cinemaGazeBlend(p3.x, p3.y, p3.z, _lx, _ly, _lz, turnW3);
+    }
+
+    // ══ §CPE_EVEN_TURN — the even-out. ═══════════════════════════════════════════════════════════
+    // User, 2026-07-27: "no jerk, no cam pos/pov jump.. but even out".
+    //
+    // What every earlier attempt got wrong: they kept frames evenly spaced in TIME and tried to fix
+    // the corner by MULTIPLYING the speed there. deg/frame = (deg/metre) × (metres/frame), and a
+    // multiplier bounded by the user's own PACE_SWING can only ever divide the peak by 1.6 — the
+    // measured peak was 29.1 deg/frame against a 12 cap, so a 2.4× reduction was needed and no
+    // tuning of a bounded multiplier could reach it. That is why H3 moved 29.1 → 29.4: not a bug,
+    // an arithmetic ceiling. The three dead ends are recorded in prompts/CINEMA_PATH_EDITOR.md.
+    //
+    // The fix is to stop treating pace as a correction and make it the PARAMETERIZATION. Step the
+    // frames at equal increments of a blended cost
+    //
+    //     dc = (1-w)·(ds/S) + w·(dθ/Θ)
+    //
+    // where S is the walk's arc length and Θ its total gaze turn. Because every frame advances the
+    // same Δc = 1/N, each term is bounded on its own by construction:
+    //
+    //     Δθ ≤ Θ/(w·N)         — turn per frame, at most 1/w × the perfectly-even Θ/N
+    //     Δs ≤ S/((1-w)·N)     — distance per frame, at most 1/(1-w) × the nominal speed
+    //
+    // So 1/(1-w) IS the speed range. The user set that range at PACE_SWING = 1.6 ("have a speed
+    // range… don't overdo it"), which fixes w = 1 - 1/1.6 = 0.375 exactly. Nothing here is a tuned
+    // constant: the one dial was already chosen by the user, and the turn bound falls out of it.
+    // Slow-in-the-turn and pick-up-in-the-open are not imposed by a brake — they are what equal
+    // cost stepping DOES, and the brake releases in open space for free because there is no dθ to
+    // pay for there.
+    var CINEMA_PACE_SWING = 1.6;
+    var _etW = 1 - 1 / CINEMA_PACE_SWING;
+    var _etN = 240, _etC = null, _etS = 0, _etT = 0;
+    function _evenTurnBuild() {
+      var ss = [], ts = [], prev = null, prevD = null, s = 0, th = 0;
+      for (var i = 0; i <= _etN; i++) {
+        var e = i / _etN, ps = _beat3Pose(e);
+        var gx = ps.tx - ps.x, gy = ps.ty - ps.y, gz = ps.tz - ps.z;
+        var gl = Math.hypot(gx, gy, gz) || 1; gx /= gl; gy /= gl; gz /= gl;
+        if (prev) {
+          s += Math.hypot(ps.x - prev.x, ps.y - prev.y, ps.z - prev.z);
+          // Angle between successive gaze DIRECTIONS — the full 3D turn, so a pitch whip costs the
+          // same as a yaw whip. Measuring yaw alone would leave §CINEMA_LOOKAHEAD_VERTICAL's class
+          // of jump unpriced.
+          th += Math.acos(Math.max(-1, Math.min(1, gx * prevD.x + gy * prevD.y + gz * prevD.z)));
+        }
+        ss.push(s); ts.push(th);
+        prev = { x: ps.x, y: ps.y, z: ps.z }; prevD = { x: gx, y: gy, z: gz };
+      }
+      _etS = s; _etT = th;
+      // A walk with no turn in it has no turn to even out: fall back to pure arc length, which is
+      // byte-for-byte today's behaviour. Guards ts[i]/Θ against dividing by ~0.
+      var w = (th > 1e-3) ? _etW : 0;
+      var S = s || 1, T = th || 1;
+      var c = [];
+      for (i = 0; i <= _etN; i++) c.push((1 - w) * (ss[i] / S) + w * (ts[i] / T));
+      _etC = c;
+      console.log('§CPE_EVEN_TURN w=' + w.toFixed(3) + ' (PACE_SWING=' + CINEMA_PACE_SWING + ') walkLen=' +
+        s.toFixed(2) + 'm totalTurn=' + (th * 180 / Math.PI).toFixed(1) + 'deg samples=' + (_etN + 1) +
+        ' boundPerFrameTurn=' + (w > 0 ? (th * 180 / Math.PI / w).toFixed(1) + 'deg/N' : 'n/a (straight walk)') +
+        ' speedRange=' + (w > 0 ? (1 / (1 - w)).toFixed(2) + 'x' : '1.00x'));
+    }
+    // Monotone inverse of the cost table: given uniform progress in cost, return the walk fraction.
+    function _evenTurnRemap(u) {
+      if (!_etC) return u;
+      u = Math.max(0, Math.min(1, u));
+      var lo = 0, hi = _etN;
+      while (hi - lo > 1) { var mid = (lo + hi) >> 1; if (_etC[mid] <= u) lo = mid; else hi = mid; }
+      var c0 = _etC[lo], c1 = _etC[hi], f = (c1 - c0 > 1e-12) ? (u - c0) / (c1 - c0) : 0;
+      return (lo + Math.max(0, Math.min(1, f))) / _etN;
+    }
+    // §CPE_SEAM_CONTINUOUS: the pitch Beat 3 opens on, read off the REAL opening pose rather than
+    // re-derived from the waypoints — so the spin lands on the walk's gaze, not on a second guess
+    // at it. Declared here (after _beat3Pose) and read by Beat 2 at frame time.
+    // The spin's landing pitch was computed up at §CINEMA_SPIN_BASELINE so the beat seconds could
+    // pay for it. Assert it against the pose that ACTUALLY flies — if these ever diverge the seam
+    // silently reopens, so the drift is logged rather than assumed to be zero.
+    // Assert the seam is actually closed, on the poses that FLY: the angle between Beat 2's last
+    // gaze and Beat 3's first. Logged rather than assumed — if a future change reopens it, the
+    // number moves off zero here instead of surfacing as a jerk nobody can locate.
+    (function () {
+      var p0 = _beat3Pose(0);
+      var dl = Math.hypot(p0.tx - p0.x, p0.ty - p0.y, p0.tz - p0.z) || 1;
+      var d = (p0.tx - p0.x) / dl * _handDir.x + (p0.ty - p0.y) / dl * _handDir.y + (p0.tz - p0.z) / dl * _handDir.z;
+      console.log('§CPE_SEAM_CONTINUOUS seamGapDeg=' +
+        (Math.acos(Math.max(-1, Math.min(1, d))) * 180 / Math.PI).toFixed(3) +
+        ' (beat2 end -> beat3 start; must be ~0)');
+    })();
+    _evenTurnBuild();
 
     // Plan cost is dominated by the BVH fans + floor raycasts. Measured on this project's headless
     // ANGLE/SwiftShader rig: Duplex ~20-70ms, Terminal/Hospital ~500-750ms — a one-off cost at the

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3557,7 +3557,7 @@ async function setupEffects(A, renderer, scene, camera) {
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v15 (§STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
+  var EFFECTS_V = 'v16 (§CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).
@@ -4133,17 +4133,17 @@ async function setupEffects(A, renderer, scene, camera) {
         'walk-start look-ahead instead (' + firstLeg.x.toFixed(2) + ',' + firstLeg.z.toFixed(2) + ')');
     }
     var spinTo = Math.atan2(firstLeg.z - settle.z, firstLeg.x - settle.x);
-    // §CPE_SEAM_CONTINUOUS — the PITCH the walk opens on, computed here (before the beat seconds)
-    // because the spin now has to cover it and therefore has to be PAID for in the spin's time
-    // budget. Same look-ahead point and same 0.5m collapse guard Beat 3 itself uses at e3=0, so
-    // this is the walk's real opening gaze, not a second guess at it (asserted below against
-    // _beat3Pose(0), which is the pose that actually flies).
+    // §CPE_SEAM_CONTINUOUS — the direction the walk opens on, sampled here (before the beat
+    // seconds) because _openDir/_openDeg below are derived from it. Same look-ahead point and same
+    // 0.5m collapse guard Beat 3 itself uses at e3=0, so this is the walk's real opening gaze, not
+    // a second guess at it (asserted below against _beat3Pose(0), the pose that actually flies).
+    // NOTE: the spin does NOT pay for the pitch — see the _spinDeg comment below for why that was
+    // tried, measured, and reverted.
     var _wkP0 = _outPos(0), _wkA0 = _outPos(0.15);
     if (Math.hypot(_wkA0.x - _wkP0.x, _wkA0.y - _wkP0.y, _wkA0.z - _wkP0.z) < 0.5)
       _wkA0 = { x: _wkP0.x + odx * 20, y: _wkP0.y, z: _wkP0.z + odz * 20 };
     var _wkDy = _wkA0.y - _wkP0.y;
     var _wkL = Math.hypot(_wkA0.x - _wkP0.x, _wkDy, _wkA0.z - _wkP0.z) || 1;
-    var _spinEndPitch = Math.asin(Math.max(-1, Math.min(1, _wkDy / _wkL)));
     var dYaw = spinTo - yaw0;
     while (dYaw > Math.PI) dYaw -= 2 * Math.PI;
     while (dYaw < -Math.PI) dYaw += 2 * Math.PI;
@@ -4212,13 +4212,12 @@ async function setupEffects(A, renderer, scene, camera) {
     // quantities — the approach is capped at the envelope, the spin at a half turn (the most that is
     // ever needed to face anywhere) — and only then converted at their stated rates.
     var _diveEff = Math.min(diveDist, envelope);
-    // §CPE_SEAM_CONTINUOUS: count the PITCH sweep too. The spin turns in yaw AND tilts to the
-    // walk's opening pitch, but this budget used to price the yaw alone — so on a walk that opens
-    // steeply the tilt was crammed into a beat sized for a flat turn. MEASURED on Terminal: yaw
-    // asked for under 36 deg (so the beat fell to the 0.8s floor) while the real sweep was ~142 deg,
-    // giving 17.7 deg/frame. Same CINEMA_TURN_DPS rate, applied to the whole sweep. The pitch is
-    // capped at 90 for the same reason the yaw is capped at 180: a quarter turn is the most a tilt
-    // can ever need, so a pathological pose cannot inflate the runtime.
+    // ⚠ §CPE_SEAM_CONTINUOUS — DO NOT add a pitch term to _spinDeg. It was tried this session and
+    // reverted: pricing the walk's opening pitch into the spin makes the spin's DURATION depend on
+    // the authored path, which shifts every beat fraction before it and breaks G2's "an edit
+    // changes nothing before it". _spinDeg stays yaw-only, and the pitch handoff is paid inside the
+    // WALK instead (see _beat3Pose's opening blend). This comment previously described the reverted
+    // version as if it had shipped — it had not.
     // §CPE_SEAM_CONTINUOUS — the direction the walk WANTS to open on, and the direction the spin
     // actually hands over (level, on the spin's final bearing). The gap between them was being paid
     // in ONE frame at the Beat2->3 seam: MEASURED 81 deg on Terminal, and it did NOT shrink when
@@ -4558,21 +4557,36 @@ async function setupEffects(A, renderer, scene, camera) {
     //
     //     dc = (1-w)·(ds/S) + w·(dθ/Θ)
     //
-    // where S is the walk's arc length and Θ its total gaze turn. Because every frame advances the
-    // same Δc = 1/N, each term is bounded on its own by construction:
+    // where S is the walk's arc length and Θ its total gaze turn. If frames advanced by a constant
+    // Δc, each term would be bounded on its own by construction:
     //
     //     Δθ ≤ Θ/(w·N)         — turn per frame, at most 1/w × the perfectly-even Θ/N
     //     Δs ≤ S/((1-w)·N)     — distance per frame, at most 1/(1-w) × the nominal speed
     //
-    // So 1/(1-w) IS the speed range. The user set that range at PACE_SWING = 1.6 ("have a speed
-    // range… don't overdo it"), which fixes w = 1 - 1/1.6 = 0.375 exactly. Nothing here is a tuned
-    // constant: the one dial was already chosen by the user, and the turn bound falls out of it.
+    // ⚠ Δc IS NOT CONSTANT HERE, and the bounds above are the per-cost-step ones, not what the film
+    // delivers. Beat 3 feeds the remap an EASED time fraction — _evenTurnRemap(_cinemaSmoothstep(t))
+    // — and smoothstep's derivative peaks at 1.5 at its midpoint, so cost advances at up to 1.5/N
+    // per frame and every bound above carries a ×1.5:
+    //
+    //     Δθ ≤ 1.5·Θ/(w·N)     Δs ≤ 1.5·S/((1-w)·N)
+    //
+    // So the DELIVERED speed range is 1.5/(1-w) ≈ 2.4×, not 1/(1-w) = 1.6×: against a nominal
+    // CINEMA_WALK_MPS of 2.3 the walk peaks near 5.5 m/s, and §CPE_WALK's "2.3 m/s pace" is a MEAN,
+    // not the pace. The ease is deliberate (zero rate at both beat seams, so the walk does not start
+    // or stop abruptly) — the ×1.5 is the price of it, and it is stated here rather than left for a
+    // reader to derive from the fact that the two do not agree.
+    //
+    // w itself is still not tuned: PACE_SWING = 1.6 is the user's own dial ("have a speed range…
+    // don't overdo it") and fixes w = 1 - 1/1.6 = 0.375 exactly. What is NOT yet settled is whether
+    // 2.4× is inside what they meant by "don't overdo it" — the gaze half passes comfortably (7.3
+    // measured against a 12 cap) but the POSITION half of §CPE_JERK_DEFINITION is still ungated, and
+    // gating it is what would turn this from an argument into a measurement.
     // Slow-in-the-turn and pick-up-in-the-open are not imposed by a brake — they are what equal
     // cost stepping DOES, and the brake releases in open space for free because there is no dθ to
     // pay for there.
     var CINEMA_PACE_SWING = 1.6;
     var _etW = 1 - 1 / CINEMA_PACE_SWING;
-    var _etN = 240, _etC = null, _etS = 0, _etT = 0;
+    var _etN = 240, _etC = null;
     function _evenTurnBuild() {
       var ss = [], ts = [], prev = null, prevD = null, s = 0, th = 0;
       for (var i = 0; i <= _etN; i++) {
@@ -4589,7 +4603,6 @@ async function setupEffects(A, renderer, scene, camera) {
         ss.push(s); ts.push(th);
         prev = { x: ps.x, y: ps.y, z: ps.z }; prevD = { x: gx, y: gy, z: gz };
       }
-      _etS = s; _etT = th;
       // A walk with no turn in it has no turn to even out: fall back to pure arc length, which is
       // byte-for-byte today's behaviour. Guards ts[i]/Θ against dividing by ~0.
       var w = (th > 1e-3) ? _etW : 0;
@@ -4600,7 +4613,9 @@ async function setupEffects(A, renderer, scene, camera) {
       console.log('§CPE_EVEN_TURN w=' + w.toFixed(3) + ' (PACE_SWING=' + CINEMA_PACE_SWING + ') walkLen=' +
         s.toFixed(2) + 'm totalTurn=' + (th * 180 / Math.PI).toFixed(1) + 'deg samples=' + (_etN + 1) +
         ' boundPerFrameTurn=' + (w > 0 ? (th * 180 / Math.PI / w).toFixed(1) + 'deg/N' : 'n/a (straight walk)') +
-        ' speedRange=' + (w > 0 ? (1 / (1 - w)).toFixed(2) + 'x' : '1.00x'));
+        ' speedRange=' + (w > 0 ? (1 / (1 - w)).toFixed(2) + 'x per cost-step, ' +
+          (1.5 / (1 - w)).toFixed(2) + 'x delivered (x1.5 from the smoothstep ease — see the derivation)'
+          : '1.00x'));
     }
     // Monotone inverse of the cost table: given uniform progress in cost, return the walk fraction.
     function _evenTurnRemap(u) {
@@ -4611,12 +4626,6 @@ async function setupEffects(A, renderer, scene, camera) {
       var c0 = _etC[lo], c1 = _etC[hi], f = (c1 - c0 > 1e-12) ? (u - c0) / (c1 - c0) : 0;
       return (lo + Math.max(0, Math.min(1, f))) / _etN;
     }
-    // §CPE_SEAM_CONTINUOUS: the pitch Beat 3 opens on, read off the REAL opening pose rather than
-    // re-derived from the waypoints — so the spin lands on the walk's gaze, not on a second guess
-    // at it. Declared here (after _beat3Pose) and read by Beat 2 at frame time.
-    // The spin's landing pitch was computed up at §CINEMA_SPIN_BASELINE so the beat seconds could
-    // pay for it. Assert it against the pose that ACTUALLY flies — if these ever diverge the seam
-    // silently reopens, so the drift is logged rather than assumed to be zero.
     // Assert the seam is actually closed, on the poses that FLY: the angle between Beat 2's last
     // gaze and Beat 3's first. Logged rather than assumed — if a future change reopens it, the
     // number moves off zero here instead of surfacing as a jerk nobody can locate.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v863';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v864';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v862';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v863';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v857';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v858';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,7 +824,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=8" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cinema_maxq.js?v=2" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cinema_path_editor.js
+++ b/witness_cinema_path_editor.js
@@ -121,12 +121,23 @@ const FPS = 15;
         const moved = wp0.map(w => ({ ...w }));
         moved[1] = { x: wp0[1].x + 5, y: wp0[1].y + 1, z: wp0[1].z };
         const planM = A.cinemaPathPlan(DUR, { waypoints: moved });
-        const sA = sample(planA), sM = sample(planM);
-        // where in normalized time does the difference live?
+        // Compare the two films at the same ABSOLUTE SECOND, not the same percentage through.
+        // The edited path is longer, and section 9 doctrine ("path length sets the clock") means the
+        // edited film legitimately RUNS LONGER — cinema_maxq.js:414 sets the real bake's frame count
+        // from plan.naturalTotal, so this is the product's actual behaviour, not a theory. Sampling
+        // both at the same normalized t therefore lines up second 3 of a 24s film against second 4
+        // of a 32s one and reports the opening as "changed" when nothing about it moved. Beat
+        // seconds are derived independently of path length (dive from its own distance), so at equal
+        // real time the opening is identical by construction — which is what this now measures.
+        const tA = planA.naturalTotal || DUR, tM = planM.naturalTotal || DUR;
+        const secs = [];
+        for (let i = 0; i <= N; i++) secs.push(i / N * Math.min(tA, tM));
+        const sA = secs.map(sec => planA.poseAt(sec / tA));
+        const sM = secs.map(sec => planM.poseAt(sec / tM));
         let firstDiffT = null, lastDiffT = null, maxD = 0;
         for (let i = 0; i <= N; i++) {
           const d = Math.hypot(sA[i].x - sM[i].x, sA[i].y - sM[i].y, sA[i].z - sM[i].z);
-          if (d > 0.01) { if (firstDiffT === null) firstDiffT = i / N; lastDiffT = i / N; }
+          if (d > 0.01) { if (firstDiffT === null) firstDiffT = secs[i] / tA; lastDiffT = secs[i] / tA; }
           maxD = Math.max(maxD, d);
         }
         out.g2 = { firstDiffT, lastDiffT, maxD, diveBeatEnd: beats.dive, outBeatEnd: beats.out,
@@ -175,9 +186,16 @@ const FPS = 15;
         // G7 — peak angular rate of the LOOK direction, per rendered frame.
         const nF = Math.round(24 * fps);
         let peak = 0, peakT = 0, prev = null;
+        // The walk window must come from THIS plan. It used to read planA.beats — a DIFFERENT
+        // plan, built from a different path, whose walk occupies a different fraction of the film.
+        // So the window was misaligned with planS's own walk and the gate sampled beats the walk's
+        // pacing does not govern (the spin runs on a clock, not on the path). That is why G7 stayed
+        // at 15.7/20.4 to the decimal while every other jerk number moved: the peak it reported was
+        // not in the walk at all. Verify the instrument before the code under test.
+        const sBeats = planS.beats || beats;
         for (let f = 0; f <= nF; f++) {
           const t = f / nF;
-          if (t < beats.spin || t > beats.out) { prev = null; continue; }
+          if (t < sBeats.spin || t > sBeats.out) { prev = null; continue; }
           const p = planS.poseAt(t);
           const b = Math.atan2(p.tz - p.z, p.tx - p.x) * 180 / Math.PI;
           if (prev !== null) {

--- a/witness_cpe_even_turn.js
+++ b/witness_cpe_even_turn.js
@@ -103,6 +103,61 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         return { peak, peakT, peakPitch, total, frames: n, yawPeak, yawPeakT, yawPeakPitch };
       };
 
+      // §CPE_JERK_DEFINITION item 2 — the POSITION half, which the user named FIRST ("pov sudden
+      // position") and which nothing gated until now. T2 above measures only how fast the gaze
+      // sweeps; a camera can hold a perfectly steady aim while TELEPORTING, and that reads as the
+      // worst jerk of all.
+      //
+      // The cap is DERIVED per beat, not invented. Each beat is parameterized by a smoothstep of
+      // its own time fraction, and smoothstep's derivative peaks at exactly 1.5 — so a beat that
+      // moves smoothly along its own path can never exceed 1.5x its OWN mean step. Anything past
+      // that is a discontinuity in that beat, whatever the beat's nominal speed is (dive at 20m/s
+      // and the walk at 2.3m/s are both held to their own mean, so no per-beat constant is needed).
+      // Tolerance 1.1x on top, for the beat-boundary frame that straddles two parameterizations.
+      //
+      // TWO beats need a different bound, both for stated reasons, neither to make this pass:
+      //  - THE WALK is deliberately NOT arc-uniform. §CPE_EVEN_TURN parameterizes it by a blended
+      //    distance+turn cost, so its distance step is bounded by 1/(1-w) = PACE_SWING = 1.6x the
+      //    nominal, and the smoothstep ease multiplies that by 1.5 -> 2.4x. Holding the walk to
+      //    1.5x would gate the FEATURE, not a defect. 2.4x is the same bound the §CPE_EVEN_TURN
+      //    derivation states, so this gate is what checks that derivation against the real film.
+      //  - IN-PLACE beats (the spin) barely translate at all: mean steps of 1-3cm make the ratio
+      //    pure numerical noise (measured 7.8-13.6x on a 2cm mean). A beat that moves less than a
+      //    centimetre per frame on average has no meaningful position bound, so it is reported and
+      //    not gated. The spin's motion is a TURN, and T2 already owns that.
+      const posPeak = (plan) => {
+        const n = Math.max(2, Math.round(dur * fps));
+        const b = plan.beats || {};
+        const bounds = [
+          ['dive', 0, b.dive], ['spin', b.dive, b.spin], ['walk', b.spin, b.out],
+          ['rise', b.out, b.rise], ['orbit', b.rise, 1],
+        ].filter(x => typeof x[1] === 'number' && typeof x[2] === 'number' && x[2] > x[1]);
+        const per = [];
+        for (const [name, u0, u1] of bounds) {
+          const steps = [];
+          for (let i = 1; i < n; i++) {
+            const ua = (i - 1) / (n - 1), ub = i / (n - 1);
+            if (ub <= u0 || ua > u1) continue;
+            const p0 = plan.poseAt(ua), p1 = plan.poseAt(ub);
+            steps.push({ d: Math.hypot(p1.x - p0.x, p1.y - p0.y, p1.z - p0.z), u: ub });
+          }
+          if (steps.length < 3) continue;
+          const mean = steps.reduce((a, s) => a + s.d, 0) / steps.length;
+          const top = steps.reduce((a, s) => (s.d > a.d ? s : a), steps[0]);
+          const PACE_SWING = 1.6;                       // the user's dial, mirrored from effects.js
+          const shape = (name === 'walk') ? 1.5 * PACE_SWING : 1.5;
+          // The spin is an IN-PLACE turn by definition, not a traverse — it pivots on the settle
+          // point. Exempted by name rather than by a magnitude threshold, because a threshold would
+          // just be a picked number that happens to straddle the three buildings (measured means:
+          // Duplex 0.01m, Terminal 0.02m, Hospital 0.03m per frame). Its motion is rotational and
+          // T2 gates it; its position numbers are printed so the exemption stays visible.
+          const inPlace = (name === 'spin');
+          per.push({ beat: name, mean, peak: top.d, at: top.u, inPlace, shape,
+                     cap: shape * 1.1 * mean, ratio: mean > 1e-9 ? top.d / mean : 0 });
+        }
+        return per;
+      };
+
       const run = (bands) => {
         const flow = A.cinemaBandFlow(bands);
         const plan = A.cinemaPathPlan(dur, { bands: bands, _total: dur });
@@ -141,7 +196,8 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
           try { if (Math.hypot(bx, bz) > 1e-4) bowRay = A.cinemaLookDist(at, bx, bz); } catch (e) {}
           bows.push({ i, bow, fanMin, bowRay });
         }
-        return { bows, turn: turnPeak(plan), flown: flow.length, beats: plan.beats || plan.sec || null };
+        return { bows, turn: turnPeak(plan), pos: posPeak(plan), flown: flow.length,
+                 beats: plan.beats || plan.sec || null };
       };
 
       return { hostile: run(hostile), seeded: run(seeded) };
@@ -173,6 +229,18 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       `          yaw-only for reference: ${H.turn.yawPeak.toFixed(1)} at u=${H.turn.yawPeakT.toFixed(3)} ` +
       `where pitch=${H.turn.yawPeakPitch.toFixed(1)}deg — yaw is degenerate above ~80deg pitch, which is ` +
       `why it is reported and not gated\n          beats: ${JSON.stringify(H.beats)}`);
+
+    // T5 — the POSITION half of §CPE_JERK_DEFINITION, the user's own first-named symptom. Proves
+    // or disproves: does any beat move the camera further in one frame than a smooth traverse of
+    // that same beat could? Each beat is held to 1.5x its OWN mean step (smoothstep's peak
+    // derivative) + 10%, so the cap is derived from the beat, never from a picked number.
+    const bad = H.pos.filter(p => !p.inPlace && p.peak > p.cap);
+    P('T5 no beat steps further in one frame than its own shape allows (1.5x mean; the walk 2.4x, being cost-parameterized)',
+      bad.length === 0,
+      H.pos.map(p => `${p.beat}: peak=${p.peak.toFixed(2)}m mean=${p.mean.toFixed(2)}m ` +
+        `(${p.ratio.toFixed(1)}x of ${p.shape.toFixed(1)}x allowed, cap ${p.cap.toFixed(2)}m) at u=${p.at.toFixed(3)}` +
+        (p.inPlace ? '  [in-place beat — reported, not gated]' : '') +
+        (!p.inPlace && p.peak > p.cap ? '  <-- VIOLATION' : '')).join('\n          '));
 
     P('T3 a join whose bow ray ALSO hits nothing still obeys the 3m cap (unknown stays unknown)',
       stuck.every(b => b.bow <= NUDGE_CAP + 0.01),

--- a/witness_cpe_even_turn.js
+++ b/witness_cpe_even_turn.js
@@ -1,0 +1,174 @@
+// WITNESS — §CPE_EVEN_TURN: a hard direction change is curved out, not crammed.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_EVEN_TURN.
+//
+// THE DEFECT (user, Hospital, 2026-07-27: "it has to be even curved out to never have any sharp
+// sudden turns"). Their log: `maxBow=2.13m unmeasuredJoins=2/2` — the clearance fan read NOTHING at
+// both joins, so both fell back to the 3m nudge cap and the k-shrink loop drove the corner tight.
+// §CPE_LIVE's rule is NOT re-litigated here: a fan reporting CINEMA_FAN_FAR is UNKNOWN, never "60m
+// of space". The fix takes a MEASUREMENT instead of reinterpreting the sentinel — one ray along the
+// direction the connector actually bulges.
+//
+//   T1 the rescue — on a hostile layout (bands aimed apart, the shape that produces the user's
+//      report), joins the fan cannot read are probed by the bow ray, and the resulting bow is LARGER
+//      than the 3m cap allowed. Disproves "the cap was already big enough".
+//   T2 the point of it — peak turn rate over the WHOLE film drops, and lands under the B5 cap.
+//      A bigger bow that did not buy a gentler corner would be motion for its own sake.
+//   T3 the doctrine — a join whose bow ray ALSO hits nothing still obeys the 3m cap. Unknown stays
+//      unknown; this must not become a back door to treating the sentinel as space.
+//   T4 no regression — where the fan DID measure, the measured clearance still binds (§CPE_BANDS B4).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const FPS = 15, DUR = 24;
+const CAP_DEG = parseFloat(process.env.CAP || '12');   // same cap witness_cinema_bands B5 uses
+const NUDGE_CAP = 3;
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaBandFlow &&
+      window.APP.cinemaSeedBands, { timeout: 120000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const res = await page.evaluate(async (dur, fps, capDeg) => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      A._cinemaPathEdit = null;
+      const derived = A.cinemaPathPlan(dur, null);
+      const seeded = A.cinemaSeedBands(derived.waypoints, derived.pathLen);
+
+      // HOSTILE layout: bands aimed apart, so each connector must swing hard — the shape behind the
+      // user's report. Same construction witness_cinema_bands B5 uses for its adversarial case.
+      const hostile = seeded.map((b, i) => ({
+        c: { x: b.c.x, y: b.c.y, z: b.c.z },
+        d: i % 2 ? { x: -b.d.x, y: b.d.y, z: -b.d.z } : { x: b.d.x, y: b.d.y, z: b.d.z },
+        len: b.len,
+      }));
+
+      const turnPeak = (plan) => {
+        const n = Math.max(2, Math.round(dur * fps));
+        let peak = 0, peakT = 0, prev = null, total = 0;
+        for (let i = 0; i < n; i++) {
+          const u = i / (n - 1), p = plan.poseAt(u);
+          const yaw = Math.atan2(p.tz - p.z, p.tx - p.x) * 180 / Math.PI;
+          if (prev !== null) {
+            let d = Math.abs(yaw - prev); if (d > 180) d = 360 - d;
+            total += d;
+            if (d > peak) { peak = d; peakT = u; }
+          }
+          prev = yaw;
+        }
+        return { peak, peakT, total, frames: n };
+      };
+
+      const run = (bands) => {
+        const flow = A.cinemaBandFlow(bands);
+        const plan = A.cinemaPathPlan(dur, { bands: bands, _total: dur });
+        // Max excursion of each connector from its chord, recomputed here off the FLOWN polyline so
+        // the gate is not reading the same variable the code under test wrote.
+        const ends = b => { const h = b.len / 2; return [
+          { x: b.c.x - b.d.x * h, y: b.c.y - b.d.y * h, z: b.c.z - b.d.z * h },
+          { x: b.c.x + b.d.x * h, y: b.c.y + b.d.y * h, z: b.c.z + b.d.z * h }]; };
+        const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+        const bows = [];
+        for (let i = 0; i < bands.length - 1; i++) {
+          const e = ends(bands[i]), nx = ends(bands[i + 1]);
+          let iEnd = -1, iNext = -1;
+          for (let k = 0; k < flow.length; k++) {
+            if (dist(flow[k], e[1]) < 1e-9) iEnd = k;
+            if (dist(flow[k], nx[0]) < 1e-9 && iNext < 0 && k > iEnd) iNext = k;
+          }
+          if (iEnd < 0 || iNext < 0) continue;
+          const P0 = flow[iEnd], P1 = flow[iNext];
+          const vx = P1.x - P0.x, vy = P1.y - P0.y, vz = P1.z - P0.z;
+          const s2 = vx * vx + vy * vy + vz * vz || 1;
+          let bow = 0, bx = 0, bz = 0, at = P0;
+          for (let k = iEnd + 1; k < iNext; k++) {
+            const wx = flow[k].x - P0.x, wy = flow[k].y - P0.y, wz = flow[k].z - P0.z;
+            const t = Math.max(0, Math.min(1, (wx * vx + wy * vy + wz * vz) / s2));
+            const ox = wx - vx * t, oy = wy - vy * t, oz = wz - vz * t;
+            const d = Math.hypot(ox, oy, oz);
+            if (d > bow) { bow = d; bx = ox; bz = oz; at = { x: P0.x + vx * t, y: P0.y + vy * t, z: P0.z + vz * t }; }
+          }
+          // Independently re-measure what the code claims to have measured.
+          let fanMin = null, bowRay = null;
+          try {
+            const f = A.cinemaFan({ x: (P0.x + P1.x) / 2, y: (P0.y + P1.y) / 2, z: (P0.z + P1.z) / 2 }, 8);
+            if (f && isFinite(f.min)) fanMin = f.min;
+          } catch (e) {}
+          try { if (Math.hypot(bx, bz) > 1e-4) bowRay = A.cinemaLookDist(at, bx, bz); } catch (e) {}
+          bows.push({ i, bow, fanMin, bowRay });
+        }
+        return { bows, turn: turnPeak(plan), flown: flow.length };
+      };
+
+      return { hostile: run(hostile), seeded: run(seeded) };
+    }, DUR, FPS, CAP_DEG);
+
+    const H = res.hostile;
+    const unread = H.bows.filter(b => b.fanMin === null || b.fanMin >= 59.99);
+    const rescued = unread.filter(b => b.bowRay !== null && b.bowRay < 59.99);
+    const stuck = unread.filter(b => !(b.bowRay !== null && b.bowRay < 59.99));
+
+    P('T1 a join the fan cannot read is probed along its own bow, and bows past the 3m cap',
+      rescued.length === 0 ? unread.length === 0 : rescued.some(b => b.bow > NUDGE_CAP + 0.01),
+      unread.length === 0
+        ? `no unread joins on this building — the fan measured all ${H.bows.length}, nothing to rescue`
+        : rescued.map(b => `join${b.i}: fanMin=${b.fanMin === null ? 'n/a' : b.fanMin.toFixed(2)} ` +
+            `bowRay=${b.bowRay.toFixed(2)}m -> bow=${b.bow.toFixed(2)}m (cap was ${NUDGE_CAP})`).join(' | ') ||
+          `${unread.length} unread join(s), none rescued`);
+
+    P(`T2 peak turn rate over the whole film stays under ${CAP_DEG} deg/frame on a hostile layout`,
+      H.turn.peak <= CAP_DEG,
+      `peak=${H.turn.peak.toFixed(1)} deg/frame at u=${H.turn.peakT.toFixed(3)}, total turn ` +
+      `${H.turn.total.toFixed(0)}deg over ${H.turn.frames} frames (mean ${(H.turn.total / H.turn.frames).toFixed(1)})`);
+
+    P('T3 a join whose bow ray ALSO hits nothing still obeys the 3m cap (unknown stays unknown)',
+      stuck.every(b => b.bow <= NUDGE_CAP + 0.01),
+      stuck.length ? stuck.map(b => `join${b.i}: bowRay=${b.bowRay === null ? 'n/a' : b.bowRay.toFixed(2)} bow=${b.bow.toFixed(2)}m`).join(' | ')
+                   : 'no join was unreadable in both the fan AND the bow ray on this building');
+
+    const meas = res.seeded.bows.filter(b => b.fanMin !== null && b.fanMin < 59.99);
+    P('T4 no regression: where the fan DID measure, the measurement still binds (B4)',
+      meas.every(b => b.bow <= b.fanMin + 0.01),
+      meas.length ? meas.map(b => `conn${b.i}: bow=${b.bow.toFixed(2)}m clear=${b.fanMin.toFixed(2)}m`).join(' | ')
+                  : 'seeded layout had no measured joins on this building');
+
+    console.log(`  INFO  seeded layout peak=${res.seeded.turn.peak.toFixed(1)} deg/frame, flown=${res.seeded.flown} pts`);
+    console.log(`  INFO  ${logs.filter(l => /§CINEMA_BANDS/.test(l)).slice(-1)[0] || '(no §CINEMA_BANDS line)'}`);
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_even_turn.js
+++ b/witness_cpe_even_turn.js
@@ -124,7 +124,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
           try { if (Math.hypot(bx, bz) > 1e-4) bowRay = A.cinemaLookDist(at, bx, bz); } catch (e) {}
           bows.push({ i, bow, fanMin, bowRay });
         }
-        return { bows, turn: turnPeak(plan), flown: flow.length };
+        return { bows, turn: turnPeak(plan), flown: flow.length, beats: plan.beats || plan.sec || null };
       };
 
       return { hostile: run(hostile), seeded: run(seeded) };
@@ -146,7 +146,8 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     P(`T2 peak turn rate over the whole film stays under ${CAP_DEG} deg/frame on a hostile layout`,
       H.turn.peak <= CAP_DEG,
       `peak=${H.turn.peak.toFixed(1)} deg/frame at u=${H.turn.peakT.toFixed(3)}, total turn ` +
-      `${H.turn.total.toFixed(0)}deg over ${H.turn.frames} frames (mean ${(H.turn.total / H.turn.frames).toFixed(1)})`);
+      `${H.turn.total.toFixed(0)}deg over ${H.turn.frames} frames (mean ${(H.turn.total / H.turn.frames).toFixed(1)})\n` +
+      `          beats: ${JSON.stringify(H.beats)}`);
 
     P('T3 a join whose bow ray ALSO hits nothing still obeys the 3m cap (unknown stays unknown)',
       stuck.every(b => b.bow <= NUDGE_CAP + 0.01),

--- a/witness_cpe_even_turn.js
+++ b/witness_cpe_even_turn.js
@@ -8,11 +8,11 @@
 // of space". The fix takes a MEASUREMENT instead of reinterpreting the sentinel — one ray along the
 // direction the connector actually bulges.
 //
-//   T1 the rescue — on a hostile layout (bands aimed apart, the shape that produces the user's
-//      report), joins the fan cannot read are probed by the bow ray, and the resulting bow is LARGER
-//      than the 3m cap allowed. Disproves "the cap was already big enough".
-//   T2 the point of it — peak turn rate over the WHOLE film drops, and lands under the B5 cap.
-//      A bigger bow that did not buy a gentler corner would be motion for its own sake.
+//   T1 RETIRED — the bow-ray rescue hypothesis, disproven by measurement (see the INFO line in the
+//      body). Reported, not gated.
+//   T2 the point of it — peak GAZE SWEEP over the WHOLE film stays under the cap. Measures the angle
+//      the gaze direction turns between frames (what a viewer sees as jerk), NOT yaw: yaw is
+//      degenerate near-vertical and read 46.8 deg/frame on Terminal where the true sweep was 7.2.
 //   T3 the doctrine — a join whose bow ray ALSO hits nothing still obeys the 3m cap. Unknown stays
 //      unknown; this must not become a back door to treating the sentinel as space.
 //   T4 no regression — where the fan DID measure, the measured clearance still binds (§CPE_BANDS B4).
@@ -70,20 +70,37 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         len: b.len,
       }));
 
+      // What "jerk" IS: the angle the gaze DIRECTION sweeps between consecutive frames — the motion
+      // the viewer actually sees. This used to measure YAW instead, and yaw is the wrong instrument:
+      // it is degenerate near-vertical, where a tiny real movement swings it arbitrarily far.
+      // MEASURED on Terminal: yaw read 46.8 deg/frame at u=0.329 while the gaze sat at 87.2 deg of
+      // pitch (horizontal component 0.049) — the true frame-to-frame sweep there was under 7.2 deg.
+      // The 46.8 was an artefact of the instrument, not motion on screen.
+      // This is NOT a weakened gate: the 3D sweep is >= the visible motion in every non-degenerate
+      // case too, and it additionally catches PITCH whips that a yaw-only gate could never see.
+      // Where the camera POINTS is the user's creative control (their call, 2026-07-27); how fast it
+      // is allowed to CHANGE is what this witness owns.
       const turnPeak = (plan) => {
         const n = Math.max(2, Math.round(dur * fps));
-        let peak = 0, peakT = 0, prev = null, total = 0;
+        let peak = 0, peakT = 0, prev = null, total = 0, peakPitch = 0;
+        let yawPeak = 0, yawPeakT = 0, yawPeakPitch = 0, prevYaw = null;
         for (let i = 0; i < n; i++) {
           const u = i / (n - 1), p = plan.poseAt(u);
-          const yaw = Math.atan2(p.tz - p.z, p.tx - p.x) * 180 / Math.PI;
+          const gx = p.tx - p.x, gy = p.ty - p.y, gz = p.tz - p.z;
+          const gl = Math.hypot(gx, gy, gz) || 1;
+          const g = { x: gx / gl, y: gy / gl, z: gz / gl };
+          const pitch = Math.asin(Math.max(-1, Math.min(1, g.y))) * 180 / Math.PI;
+          const yaw = Math.atan2(gz, gx) * 180 / Math.PI;
           if (prev !== null) {
-            let d = Math.abs(yaw - prev); if (d > 180) d = 360 - d;
+            const d = Math.acos(Math.max(-1, Math.min(1, g.x * prev.x + g.y * prev.y + g.z * prev.z))) * 180 / Math.PI;
             total += d;
-            if (d > peak) { peak = d; peakT = u; }
+            if (d > peak) { peak = d; peakT = u; peakPitch = pitch; }
+            let dy = Math.abs(yaw - prevYaw); if (dy > 180) dy = 360 - dy;
+            if (dy > yawPeak) { yawPeak = dy; yawPeakT = u; yawPeakPitch = pitch; }
           }
-          prev = yaw;
+          prev = g; prevYaw = yaw;
         }
-        return { peak, peakT, total, frames: n };
+        return { peak, peakT, peakPitch, total, frames: n, yawPeak, yawPeakT, yawPeakPitch };
       };
 
       const run = (bands) => {
@@ -135,19 +152,27 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     const rescued = unread.filter(b => b.bowRay !== null && b.bowRay < 59.99);
     const stuck = unread.filter(b => !(b.bowRay !== null && b.bowRay < 59.99));
 
-    P('T1 a join the fan cannot read is probed along its own bow, and bows past the 3m cap',
-      rescued.length === 0 ? unread.length === 0 : rescued.some(b => b.bow > NUDGE_CAP + 0.01),
-      unread.length === 0
-        ? `no unread joins on this building — the fan measured all ${H.bows.length}, nothing to rescue`
-        : rescued.map(b => `join${b.i}: fanMin=${b.fanMin === null ? 'n/a' : b.fanMin.toFixed(2)} ` +
-            `bowRay=${b.bowRay.toFixed(2)}m -> bow=${b.bow.toFixed(2)}m (cap was ${NUDGE_CAP})`).join(' | ') ||
-          `${unread.length} unread join(s), none rescued`);
+    // T1 RETIRED 2026-07-27 — reported, no longer gated. It asserted the BOW-RAY RESCUE hypothesis:
+    // that a wider corner was what the jerk needed. Measurement killed that twice over. First the
+    // cap was shown never to bind (Duplex bows 0.26/0.29m against 0.86/0.87m of MEASURED clearance
+    // — k never shrinks, so there was nothing for a rescue to unlock). Then the jerk turned out not
+    // to be a corner-width problem at all: it was frames spaced evenly in DISTANCE (§CPE_EVEN_TURN)
+    // and a discontinuous Beat2→3 seam (§CPE_SEAM_CONTINUOUS), and fixing those two took the hostile
+    // peak to 6.2/7.5 deg/frame with the bows untouched.
+    // Kept as an INFO line, not deleted: the unread-join count is still worth seeing, and T3 below
+    // still GATES the doctrine that matters (an unreadable join must not be treated as open space).
+    console.log(`  INFO  T1 retired (bow-ray rescue — disproven): ${unread.length}/${H.bows.length} join(s) ` +
+      `the fan could not read; ${rescued.length} would have been bow-ray readable. Bows: ` +
+      (H.bows.map(b => `join${b.i}=${b.bow.toFixed(2)}m`).join(' ') || 'none'));
 
-    P(`T2 peak turn rate over the whole film stays under ${CAP_DEG} deg/frame on a hostile layout`,
+    P(`T2 peak gaze sweep over the whole film stays under ${CAP_DEG} deg/frame on a hostile layout`,
       H.turn.peak <= CAP_DEG,
-      `peak=${H.turn.peak.toFixed(1)} deg/frame at u=${H.turn.peakT.toFixed(3)}, total turn ` +
-      `${H.turn.total.toFixed(0)}deg over ${H.turn.frames} frames (mean ${(H.turn.total / H.turn.frames).toFixed(1)})\n` +
-      `          beats: ${JSON.stringify(H.beats)}`);
+      `peak=${H.turn.peak.toFixed(1)} deg/frame at u=${H.turn.peakT.toFixed(3)} (gaze pitch there ` +
+      `${H.turn.peakPitch.toFixed(1)}deg), total sweep ${H.turn.total.toFixed(0)}deg over ${H.turn.frames} ` +
+      `frames (mean ${(H.turn.total / H.turn.frames).toFixed(1)})\n` +
+      `          yaw-only for reference: ${H.turn.yawPeak.toFixed(1)} at u=${H.turn.yawPeakT.toFixed(3)} ` +
+      `where pitch=${H.turn.yawPeakPitch.toFixed(1)}deg — yaw is degenerate above ~80deg pitch, which is ` +
+      `why it is reported and not gated\n          beats: ${JSON.stringify(H.beats)}`);
 
     P('T3 a join whose bow ray ALSO hits nothing still obeys the 3m cap (unknown stays unknown)',
       stuck.every(b => b.bow <= NUDGE_CAP + 0.01),

--- a/witness_cpe_undo.js
+++ b/witness_cpe_undo.js
@@ -16,6 +16,10 @@
 //      user's actual ask ("reflecting in the history line"), not just an internal stack.
 //   U5 a KEYED edit (typing in the panel, not dragging) is undoable too — the panel and the canvas
 //      are the same state per §CINEMA_PATH_EDITOR_MODEL item 19, so undo cannot cover only one.
+//   U6 a press that never MOVES leaves no phantom undo entry. Found by review, not by the user: the
+//      snapshot was originally taken on pointerdown, so a zero-pixel press (which G-DRAG-1 proves
+//      changes nothing) still pushed a step — making the next Ctrl+Z appear to do nothing while
+//      silently consuming the user's real previous edit.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8403;
@@ -104,6 +108,36 @@ async function ctrlZ(page, shift) {
       `centre moved ${dist(cOpen[0], cEmpty[0]).toExponential(2)}m; ` +
       `${logs.filter(l => l.startsWith('PAGEERROR')).length} page error(s); ` +
       `log: ${(logs.filter(l => /§CPE_UNDO/.test(l)).slice(-1)[0] || '(none)')}`);
+
+    // ── U6: a press with NO movement must not leave an undo entry. If it did, the next Ctrl+Z
+    // would visibly do nothing AND silently eat the user's real previous edit.
+    // Sequence: make a real edit, press-without-moving on the handle, then Ctrl+Z once — it must
+    // undo the REAL edit, not a phantom press.
+    const projU6 = await page.evaluate(() => {
+      const A = window.APP, c = A.camera;
+      const row = document.querySelectorAll('#cpe-rows > div')[0].querySelectorAll('input');
+      const p = new THREE.Vector3(parseFloat(row[0].value), parseFloat(row[2].value), parseFloat(row[1].value));
+      const v = p.clone().project(c);
+      const r = A.canvas.getBoundingClientRect();
+      return { sx: r.left + (v.x + 1) / 2 * r.width, sy: r.top + (1 - v.y) / 2 * r.height };
+    });
+    const u6base = await centres();
+    await page.evaluate(() => {
+      const inp = document.querySelectorAll('#cpe-rows > div')[0].querySelectorAll('input')[2];
+      inp.value = String(parseFloat(inp.value) + 3);
+      inp.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await sleep(250);
+    const u6edited = await centres();
+    await page.mouse.move(Math.round(projU6.sx), Math.round(projU6.sy));
+    await page.mouse.down(); await page.mouse.up();
+    await sleep(250);
+    await ctrlZ(page, false);
+    const u6undone = await centres();
+    P('U6 a press with no movement leaves no phantom undo entry',
+      dist(u6base[0], u6edited[0]) > 0.5 && dist(u6base[0], u6undone[0]) < 1e-9,
+      `edit moved ${dist(u6base[0], u6edited[0]).toFixed(2)}m; after a zero-pixel press + ONE Ctrl+Z ` +
+      `the residue is ${dist(u6base[0], u6undone[0]).toExponential(2)}m (a phantom entry would leave the edit in place)`);
 
     // Where band 0 projects on screen.
     const proj = await page.evaluate(() => {

--- a/witness_cpe_undo.js
+++ b/witness_cpe_undo.js
@@ -1,0 +1,178 @@
+// WITNESS — §CPE_UNDO: a misplaced edit is one keystroke away from being gone.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_UNDO.
+//
+// THE ASK (user, 2026-07-27): "allow UNDO, Ctl-Z as reflecting in the history line to take effect
+// so a misplaced can be easily reverted". Direct manipulation is only safe to experiment with if a
+// bad drag costs nothing to reverse — without this, a misplaced band had to be dragged back by
+// hand, which is exactly the gesture §CPE_DRAG_TELEPORT proved is hard to do accurately.
+//
+//   U1 a drag then Ctrl+Z restores the band centre EXACTLY (not approximately — the pre-drag
+//      snapshot, so the residue is 0, unlike dragging back by hand).
+//   U2 Ctrl+Shift+Z redoes it, landing back on the dragged position. Undo that cannot be redone
+//      is a trap of its own.
+//   U3 undo is BOUNDED by real history: with an empty stack Ctrl+Z is a no-op and must not throw,
+//      corrupt the bands, or wind past the state the editor opened in.
+//   U4 the edit reaches the HISTORY LINE — UniversalHistory.recordEvent is called, which is the
+//      user's actual ask ("reflecting in the history line"), not just an internal stack.
+//   U5 a KEYED edit (typing in the panel, not dragging) is undoable too — the panel and the canvas
+//      are the same state per §CINEMA_PATH_EDITOR_MODEL item 19, so undo cannot cover only one.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8403;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function drag(page, x0, y0, x1, y1) {
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  for (let i = 1; i <= 8; i++) await page.mouse.move(x0 + (x1 - x0) * i / 8, y0 + (y1 - y0) * i / 8);
+  await page.mouse.up();
+  await sleep(150);
+}
+// A REAL keystroke through the browser's input pipeline — not a call to an exposed seam, so this
+// proves the binding a user actually presses is the one that works.
+async function ctrlZ(page, shift) {
+  await page.keyboard.down('Control');
+  if (shift) await page.keyboard.down('Shift');
+  await page.keyboard.press('KeyZ');
+  if (shift) await page.keyboard.up('Shift');
+  await page.keyboard.up('Control');
+  await sleep(250);
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 800 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit
+      && window.APP._composer, { timeout: 120000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    // Spy on the history channel BEFORE the editor opens, so U4 observes real calls.
+    await page.evaluate(() => {
+      window.__histSpy = [];
+      const UH = window.UniversalHistory;
+      if (UH && UH.recordEvent) {
+        const orig = UH.recordEvent.bind(UH);
+        UH.recordEvent = function (type, label, ref) {
+          window.__histSpy.push({ type, label });
+          try { return orig(type, label, ref); } catch (e) { return null; }
+        };
+      }
+    });
+
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+    await page.waitForSelector('#cpe-rows', { timeout: 120000 });
+    await sleep(600);
+
+    const centres = () => page.evaluate(() => {
+      const out = [];
+      document.querySelectorAll('#cpe-rows > div').forEach(row => {
+        const i = row.querySelectorAll('input');
+        out.push({ x: parseFloat(i[0].value), z: parseFloat(i[1].value), y: parseFloat(i[2].value) });
+      });
+      return out;
+    });
+    const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+
+    // ── U3 first, while the stack is genuinely empty (order matters: it cannot be tested later).
+    const cOpen = await centres();
+    await ctrlZ(page, false);
+    const cEmpty = await centres();
+    P('U3 Ctrl+Z on an empty stack is a safe no-op (no throw, no drift)',
+      dist(cOpen[0], cEmpty[0]) < 1e-9 && !logs.some(l => l.startsWith('PAGEERROR')),
+      `centre moved ${dist(cOpen[0], cEmpty[0]).toExponential(2)}m; ` +
+      `${logs.filter(l => l.startsWith('PAGEERROR')).length} page error(s); ` +
+      `log: ${(logs.filter(l => /§CPE_UNDO/.test(l)).slice(-1)[0] || '(none)')}`);
+
+    // Where band 0 projects on screen.
+    const proj = await page.evaluate(() => {
+      const A = window.APP, c = A.camera;
+      const row = document.querySelectorAll('#cpe-rows > div')[0].querySelectorAll('input');
+      const p = new THREE.Vector3(parseFloat(row[0].value), parseFloat(row[2].value), parseFloat(row[1].value));
+      const v = p.clone().project(c);
+      const r = A.canvas.getBoundingClientRect();
+      return { sx: r.left + (v.x + 1) / 2 * r.width, sy: r.top + (1 - v.y) / 2 * r.height };
+    });
+
+    // ── U1: drag, then undo.
+    const before = await centres();
+    await drag(page, Math.round(proj.sx), Math.round(proj.sy), Math.round(proj.sx + 90), Math.round(proj.sy + 60));
+    const dragged = await centres();
+    const moved = dist(before[0], dragged[0]);
+    await ctrlZ(page, false);
+    const undone = await centres();
+    const residue = dist(before[0], undone[0]);
+    P('U1 a drag is exactly reverted by Ctrl+Z',
+      moved > 0.5 && residue < 1e-9,
+      `dragged ${moved.toFixed(2)}m, then Ctrl+Z left residue ${residue.toExponential(2)}m ` +
+      `(exact snapshot restore, not a hand-drag back)`);
+
+    // ── U2: redo.
+    await ctrlZ(page, true);
+    const redone = await centres();
+    P('U2 Ctrl+Shift+Z redoes the drag',
+      dist(dragged[0], redone[0]) < 1e-9,
+      `redo landed ${dist(dragged[0], redone[0]).toExponential(2)}m from the dragged position`);
+
+    // ── U5: a KEYED edit is undoable too.
+    const preKey = await centres();
+    const keyed = await page.evaluate(() => {
+      const inp = document.querySelectorAll('#cpe-rows > div')[0].querySelectorAll('input')[0];
+      const v = parseFloat(inp.value) + 7;
+      inp.value = String(v);
+      inp.dispatchEvent(new Event('change', { bubbles: true }));
+      return v;
+    });
+    await sleep(250);
+    const afterKey = await centres();
+    await ctrlZ(page, false);
+    const afterKeyUndo = await centres();
+    P('U5 a keyed panel edit is undoable, same as a drag',
+      Math.abs(afterKey[0].x - keyed) < 1e-6 && dist(preKey[0], afterKeyUndo[0]) < 1e-9,
+      `typed x=${keyed.toFixed(2)} (panel read ${afterKey[0].x.toFixed(2)}), Ctrl+Z residue ` +
+      `${dist(preKey[0], afterKeyUndo[0]).toExponential(2)}m`);
+
+    // ── U4: it reached the history line.
+    const spy = await page.evaluate(() => window.__histSpy || []);
+    const undoEvents = spy.filter(e => e.type === 'CINEMA_PATH_EDIT');
+    P('U4 the edit reaches the history line (UniversalHistory.recordEvent)',
+      undoEvents.length >= 2,
+      `${undoEvents.length} CINEMA_PATH_EDIT event(s): ` +
+      (undoEvents.slice(0, 4).map(e => `"${e.label}"`).join(', ') || 'none') +
+      (spy.length === 0 ? ' — NOTE: UniversalHistory absent or never called' : ''));
+
+    try { await page.evaluate(() => document.getElementById('cpe-cancel').click()); } catch (e) {}
+    console.log(`  INFO  ${logs.filter(l => /§CPE_LOADED/.test(l))[0] || '(no §CPE_LOADED)'}`);
+    logs.filter(l => /§CPE_UNDO/.test(l)).slice(0, 6).forEach(l => console.log(`  INFO  ${l}`));
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
Hospital measured 81.0 deg/frame INSIDE the walk, ratio 1.0x at 100x density = a true step. Cause was the look-ahead collapse guard substituting a level bearing in one frame. Fixed by removing the threshold entirely: the look-ahead is now a fixed ARC LENGTH along the path, continuous on any path shape.

81.0 -> 11.2 deg/frame, ratio 92.9x (a turn, not a step).

Also adds T5, the position half of §CPE_JERK_DEFINITION, which was never gated. Cap derived per beat from smoothstep's 1.5 peak derivative; walk gets 1.5*PACE_SWING=2.4x. Measured walk ratios 2.4/2.3/2.4x confirm the corrected derivation.

witness_cpe_even_turn 4/4 Duplex + Terminal + Hospital. No regression: path_editor 9/9, undo 6/6, ok_bake 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)