### PR TITLE
fix(cinema): §CPE_NOISE_LAW + drag scale/land-first + basis pin

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v8 (§CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v10 (§CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -147,8 +147,22 @@
     var povr = {}; for (var k in ov) povr[k] = ov[k];
     var cs = _state.camSave;
     if (cs) povr._camBasis = { px: cs.px, py: cs.py, pz: cs.pz, tx: cs.tx, ty: cs.ty, tz: cs.tz };
+    // ══ §CPE_HOLDER_INTEGRITY (user, 2026-07-27: "u can persist in a holder, then calc, then apply
+    // back to holder" / "or there is something in the canvas code threejs that mutates?").
+    // _state.bands IS that holder, and _buildOverride already hands the plan a deep COPY of centre,
+    // direction and length — so the calc is separated "but taking its form", as asked. What was
+    // never PROVEN is that nothing writes back through some alias (the drawn handles hold `b.c` by
+    // reference for the mid zone, and the plan chain runs through cinemaSeedBands/cinemaBandFlow/
+    // three.js). So assert it instead of trusting it: snapshot the holder, run the calc, compare.
+    // Costs a 3-band string compare per re-plan and turns "is something mutating?" into a log line.
+    var _holder0 = JSON.stringify(_state.bands);
     var plan = null;
     try { plan = a.cinemaPathPlan(ov._total, povr); } catch (e) { console.warn('§CPE_REPLAN_FAIL ' + e.message); }
+    if (JSON.stringify(_state.bands) !== _holder0) {
+      console.warn('§CPE_HOLDER_MUTATED the calc wrote back into the authored bands — ' +
+        'before=' + _holder0 + ' after=' + JSON.stringify(_state.bands) +
+        ' (the holder must be read-only to the plan; this is a real defect, not a warning to live with)');
+    }
     if (!plan) return;
     var pts = [];
     for (var i = 0; i <= FILM_SAMPLES; i++) {
@@ -597,26 +611,40 @@
     }
     return best;
   }
-  // §CPE_SCREEN_PLANE (user, 2026-07-27): the point moves in the CAMERA'S OWN VIEW PLANE through
-  // wherever it currently sits — "the dot when moved is merely facing X/Y ranging... it can only
-  // move in that Xy sense". You choose the axes by orbiting the scene to face them first, which is
-  // why the canvas must stay live: orbiting IS half the gesture.
-  // This replaces the horizontal-plane drag plus ctrl+drag-for-height. Height is no longer a special
-  // case — orbit to a side view and up/down on screen IS height.
-  function _viewPlanePoint(ev, anchor) {
+  // ══ §CPE_DRAG_SCALE — FIXED AT THE SOURCE (user, 2026-07-27: "the jumping wypt still happening"
+  // → "fix the scale" → "FIX THE SOURCE").
+  //
+  // The source is the projection itself. The old `_viewPlanePoint` intersected the cursor ray with
+  // a plane through the handle, so world-metres-per-pixel was the handle's DISTANCE FROM THE CAMERA
+  // divided by the focal length — measured 0.151 m/px on Duplex (handle 91 m out), 0.227 on
+  // Terminal (138 m) and 0.453 on Hospital (274 m). Same gesture, three different world speeds; on
+  // Hospital a 50 px nudge threw a waypoint 22.7 m, 76% of the whole walk. That is the jump, and no
+  // clamp downstream can fix it because the mapping itself is wrong.
+  //
+  // The fix: the drag rate is a property of the BUILDING, not of where the camera happens to be
+  // standing. One screen height = one building envelope, in the camera's own right/up basis (so
+  // §CPE_SCREEN_PLANE's "it moves in the plane you are facing" is unchanged — only the SCALE is).
+  //     m/px = envelope / canvasHeightPx
+  // Derived, not picked: `envelope` is the plan's own max building dimension, already used for the
+  // orbit radius and the tube thickness. Every building now drags at the same fraction-of-itself
+  // per pixel, and zooming the camera no longer silently changes the gearing.
+  function _dragBasis() {
     var a = A(), r = a.canvas.getBoundingClientRect();
-    var ndc = new THREE.Vector2(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
-    var rc = new THREE.Raycaster();
-    rc.setFromCamera(ndc, a.camera);
-    var n = new THREE.Vector3();
-    a.camera.getWorldDirection(n);                       // plane normal = where the camera looks
-    var p0 = new THREE.Vector3(anchor.x, anchor.y, anchor.z);
-    var denom = n.dot(rc.ray.direction);
-    if (Math.abs(denom) < 1e-6) return null;
-    var t = p0.clone().sub(rc.ray.origin).dot(n) / denom;
-    if (t <= 0) return null;
-    var q = rc.ray.origin.clone().addScaledVector(rc.ray.direction, t);
-    return { x: q.x, y: q.y, z: q.z };
+    var env = (_state && _state.plan && _state.plan.envelope) || 50;
+    var mpp = env / Math.max(1, r.height);
+    var right = new THREE.Vector3(), up = new THREE.Vector3(), fwd = new THREE.Vector3();
+    a.camera.matrixWorld.extractBasis(right, up, fwd);
+    return { mpp: mpp, right: right, up: up, env: env, h: r.height };
+  }
+  // Screen pixels since pointerdown -> a world offset. Pure delta: a zero-pixel drag is a
+  // zero-metre move by construction, and returning the cursor returns the waypoint EXACTLY (the
+  // invariant §CPE_DRAG_TELEPORT established and G-DRAG-3 proved a reach cap destroys).
+  function _dragDelta(ev, d) {
+    var B = _dragBasis();
+    var dx = (ev.clientX - d.sx0) * B.mpp, dy = -(ev.clientY - d.sy0) * B.mpp;
+    return { x: B.right.x * dx + B.up.x * dy,
+             y: B.right.y * dx + B.up.y * dy,
+             z: B.right.z * dx + B.up.z * dy };
   }
 
   function _wire() {
@@ -635,16 +663,21 @@
         // previous edit. Taken on the FIRST actual movement instead (see h.move), which is the
         // moment an edit genuinely begins.
         _state.drag = { b: hit.b, z: hit.z, snapped: false,
+                        sx0: ev.clientX, sy0: ev.clientY,     // §CPE_DRAG_SCALE: the gesture is measured in PIXELS now
                         c0: { x: _state.bands[hit.b].c.x, y: _state.bands[hit.b].c.y, z: _state.bands[hit.b].c.z },
                         p0: { x: hit.p.x, y: hit.p.y, z: hit.p.z } };
+        var _b0 = _dragBasis();
+        console.log('§CPE_DRAG_SCALE grab band=' + hit.b + ' zone=' + hit.z +
+          ' rate=' + _b0.mpp.toFixed(3) + ' m/px (envelope ' + _b0.env.toFixed(0) + 'm / ' +
+          _b0.h.toFixed(0) + 'px) — camera distance no longer sets the gearing');
       }
     };
     h.move = function(ev) {
       if (!_state || !_state.drag) return;
       ev.preventDefault(); ev.stopPropagation();
       var d = _state.drag, b = _state.bands[d.b];
-      var p = _viewPlanePoint(ev, d.p0);   // the plane the grabbed handle already lies in
-      if (!p) return;
+      var dw = _dragDelta(ev, d);          // §CPE_DRAG_SCALE: pixels x a building-derived rate
+      var p = { x: d.p0.x + dw.x, y: d.p0.y + dw.y, z: d.p0.z + dw.z };
       // First real movement of this gesture = the edit is now happening; snapshot the pre-drag
       // state exactly once, before anything below mutates it.
       if (!d.snapped) { d.snapped = true; _undoPush('drag band ' + d.b + ' (' + d.z + ')'); }
@@ -668,22 +701,36 @@
         // residue. Direct manipulation has ONE invariant: the thing you grabbed stays under the
         // cursor. A reach cap cannot hold that invariant by construction. The sensitivity the user
         // felt was the absolute-assignment bug (fixed above), not the 1:1 mapping itself.
-        b.c.x = d.c0.x + (p.x - d.p0.x);
-        b.c.y = d.c0.y + (p.y - d.p0.y);
-        b.c.z = d.c0.z + (p.z - d.p0.z);
+        b.c.x = d.c0.x + dw.x;
+        b.c.y = d.c0.y + dw.y;
+        b.c.z = d.c0.z + dw.z;
       } else {
         // End = pivot about the far end. Length is invariant, so this is pure rotation.
         _rotateAbout(b, d.z === 'b', p);
       }
       _state.staged = false;
       _redrawScene();          // handles track the cursor instantly
-      _scheduleReplan();       // the film curve follows on a trailing throttle
+      // ══ §CPE_DRAG_LAND_FIRST (user, 2026-07-27: "i think it jumps because of the post calcn.
+      // Thus it is to separate the two. Let it land first, persisted." — and their console proves
+      // it). The re-plan used to run on a 120ms trailing throttle DURING the gesture, and it is not
+      // cheap: their log shows §CPE_REPLAN_SLOW ms=1218 firing repeatedly mid-drag. Each one
+      // re-derives the WHOLE plan under the moving cursor — measured in that same log, across one
+      // drag: pitch0 -80.5° -> -5.9°, the chosen exit door changed (Double-Flush -> Curtain Wall),
+      // orbitDY 0.09m -> -20.79m, pathLen 30 -> 64 -> 106 -> 187m. The following pointermove then
+      // resolved against a scene that had moved under it, and the band landed at
+      // centre=(-1.32,63.47,-11.49) — y=63.47 IS the camera's own height (cam=(0.5,63.4,-10.6)).
+      // The waypoint jumped onto the camera.
+      //
+      // Dragging and re-deriving are now SEPARATE: the gesture only moves handles (pure, local,
+      // instant), and the film re-derives ONCE in h.up after the drag has landed. No throttle to
+      // tune, and no plan can change mid-gesture because none runs mid-gesture.
+      if (_state._replanTimer) { clearTimeout(_state._replanTimer); _state._replanTimer = null; }
     };
     h.up = function() {
       if (!_state || !_state.drag) return;
       var d = _state.drag, b = _state.bands[d.b];
       _state.drag = null;
-      console.log('§CPE_DRAG band=' + d.b + ' zone=' + d.z + ' plane=view' +
+      console.log('§CPE_DRAG landed band=' + d.b + ' zone=' + d.z + ' plane=view (re-plan runs NOW, once)' +
         ' centre=(' + b.c.x.toFixed(2) + ',' + b.c.y.toFixed(2) + ',' + b.c.z.toFixed(2) + ')' +
         ' dir=(' + b.d.x.toFixed(2) + ',' + b.d.y.toFixed(2) + ',' + b.d.z.toFixed(2) + ') len=' + b.len.toFixed(2));
       _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4364,10 +4364,18 @@ async function setupEffects(A, renderer, scene, camera) {
     }
     // How many elements are within one fan-horizon of this point. CINEMA_FAN_FAR is reused as the
     // neighbourhood radius rather than inventing a second range constant.
-    function _densityAt(p) {
+    // The radius must be commensurate with how far the BEAT travels. MEASURED: a fixed
+    // CINEMA_FAN_FAR (60m) neighbourhood is constant across a 12-36m walk — the walk's noise series
+    // came out maxChange=0 on BOTH buildings, i.e. the term was inert and Terminal's 2.27s crawl
+    // was untouched. Half the beat's own travel is the natural scale (the neighbourhood turns over
+    // roughly once across the beat), capped at the fan horizon so a 250m dive does not read the
+    // whole site as one blur. Derived from the path, not picked.
+    function _noiseRadius(travel) { return Math.max(3, Math.min(CINEMA_FAN_FAR, travel / 2)); }
+    function _densityAt(p, R) {
       var pts = _densPoints();
       if (!pts.length || typeof A.three2ifc !== 'function') return 0;
-      var q = A.three2ifc(p.x, p.y, p.z), R2 = CINEMA_FAN_FAR * CINEMA_FAN_FAR, n = 0;
+      var rr = R || CINEMA_FAN_FAR;
+      var q = A.three2ifc(p.x, p.y, p.z), R2 = rr * rr, n = 0;
       for (var i = 0; i < pts.length; i++) {
         var dx = pts[i][0] - q.ix, dy = pts[i][1] - q.iy, dz = pts[i][2] - q.iz;
         if (dx * dx + dy * dy + dz * dz < R2) n++;
@@ -4402,6 +4410,7 @@ async function setupEffects(A, renderer, scene, camera) {
     var _DV_N = 64, _dvC = null, _diveBusy = 0;
     (function _diveNoiseBuild() {
       var i, j, dens = [], series = [];
+      var _dvR = _noiseRadius(Math.hypot(settle.x - camPos0.x, settle.y - camPos0.y, settle.z - camPos0.z));
       for (i = 0; i < _DV_N; i++) {
         var e = (i + 0.5) / _DV_N;
         dens.push(_densityAt({ x: camPos0.x + (settle.x - camPos0.x) * e,
@@ -4954,10 +4963,45 @@ async function setupEffects(A, renderer, scene, camera) {
       // WORSE on the metric that matters (Hospital 11.2 → 16.5 → 18.3 deg/frame), because
       // smoothing the noise removes the slowdown exactly at the corner that needed it. Keep the
       // provable bound; buy the headroom with FRAMES instead (§CPE_TURN_BUDGET).
-      var c = [];
-      for (i = 0; i <= _etN; i++) c.push((1 - w) * (ss[i] / S) + w * (ts[i] / T));
+      // §CPE_NOISE_LAW, the walk's share (user, 2026-07-27: "i thnk the stalls are ok, it may mean
+      // a sec or two pause which is fine in the film" ... "but if the noise ratio tempers it a bit
+      // also ok"). The stall is ACCEPTED, so this does not remove it — it TEMPERS it, and it does
+      // so by finishing the law rather than by adding a second mechanism.
+      //
+      // The crawl happens where dθ dominates a cost step: the camera turns hard, cost runs out, and
+      // metres-per-frame collapses. But a hard turn whose CONTENT is not changing is precisely the
+      // "not moving makes a boring show" case — so weight each cost increment by the same bbox rate
+      // of change the dive uses. A corner with little change stays cheap (the film keeps moving);
+      // a corner where the scene really is turning over still pays. 32 density probes, interpolated
+      // across the 240 cost samples — measured at ~15ms on Terminal's 48k rows, against a plan
+      // budget already in the hundreds.
+      var _nk = 32, nz = [], nzMax = 0, q;
+      for (q = 0; q <= _nk; q++) {
+        var pq = _beat3Pose(q / _nk);
+        nz.push(_densityAt({ x: pq.x, y: pq.y, z: pq.z }, _noiseRadius(s)));
+      }
+      var nzC = [];
+      for (q = 0; q <= _nk; q++) {
+        var lo = nz[Math.max(0, q - 1)], hi = nz[Math.min(_nk, q + 1)];
+        nzC.push(Math.abs(hi - lo));
+        if (nzC[q] > nzMax) nzMax = nzC[q];
+      }
+      var noiseAt = function (e) {
+        var x = Math.max(0, Math.min(_nk, e * _nk)), j = Math.min(_nk - 1, Math.floor(x)), f = x - j;
+        return nzMax > 0 ? (nzC[j] * (1 - f) + nzC[j + 1] * f) / nzMax : 0;
+      };
+      var c = [0], acc = 0;
+      for (i = 1; i <= _etN; i++) {
+        var dRaw = (1 - w) * ((ss[i] - ss[i - 1]) / S) + w * ((ts[i] - ts[i - 1]) / T);
+        acc += dRaw * (1 + (CINEMA_PACE_SWING - 1) * noiseAt((i - 0.5) / _etN));
+        c.push(acc);
+      }
+      if (acc > 1e-9) for (i = 0; i <= _etN; i++) c[i] /= acc;
       c = _paceFloor(c, ss, S);
       _etC = c;
+      console.log('§CPE_NOISE_LAW beat=walk src=bbox probes=' + (_nk + 1) +
+        ' maxChange=' + nzMax + ' radius=' + _noiseRadius(s).toFixed(1) + 'm elems=' + _densPoints().length +
+        ' — tempers the turn-driven crawl: a corner whose CONTENT is not changing stays cheap');
       console.log('§CPE_EVEN_TURN blended-cost, PACE_SWING=' + CINEMA_PACE_SWING +
         ' walkLen=' + s.toFixed(2) + 'm totalTurn=' + (th * 180 / Math.PI).toFixed(1) +
         'deg samples=' + (_etN + 1) +

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5135,15 +5135,35 @@ async function setupEffects(A, renderer, scene, camera) {
   // the beat-second overrides above already use — the plan function itself stays untouched.
   // Nothing here moves the camera as far as any renderer is concerned: the swap and the restore
   // happen inside one synchronous call with no frame in between.
+  // §CPE_BASIS_HALF_PIN (user's Hospital console, 2026-07-27 — "drag still jumps"). This pinned the
+  // camera's POSITION and the orbit TARGET but never re-aimed the camera, and yaw0/pitch0 are read
+  // from A.camera.getWorldDirection() — the camera's ROTATION, which this left untouched. So every
+  // editor re-plan ran with the pinned position and whatever rotation the user had orbited to,
+  // while the bake (finish() sets position + target + controls.update(), which DOES re-aim) ran
+  // with the real basis. MEASURED in their log, same session, same edit:
+  //     editing: yaw0=-88.9 pitch0=-16.9  exit facingDot=+0.456  spin -35.3 deg
+  //     baking : yaw0=+91.5 pitch0=-81.0  exit facingDot=-0.450  spin 504.3 deg class=behind(full-lap)
+  // A DIFFERENT exit door and a full extra lap of spin — the film they authored was not the film
+  // that baked, which is the very thing §CPE_PREVIEW_DIVERGENCE was supposed to have closed. It was
+  // only half closed: half a pin is not a pin.
   function _withCamBasis(basis, fn) {
     if (!basis) return fn();
     var c = A.camera, t = A.controls.target;
     var sp = { x: c.position.x, y: c.position.y, z: c.position.z };
     var st = { x: t.x, y: t.y, z: t.z };
+    var sq = c.quaternion.clone();
     c.position.set(basis.px, basis.py, basis.pz);
     t.set(basis.tx, basis.ty, basis.tz);
+    // The half that was missing: re-aim at the pinned target so getWorldDirection() reports the
+    // basis being pinned, not the live orbit. updateMatrixWorld because the plan reads world state
+    // within this same task, before any render tick would have refreshed it.
+    c.lookAt(basis.tx, basis.ty, basis.tz);
+    c.updateMatrixWorld(true);
     try { return fn(); }
-    finally { c.position.set(sp.x, sp.y, sp.z); t.set(st.x, st.y, st.z); }
+    finally {
+      c.position.set(sp.x, sp.y, sp.z); t.set(st.x, st.y, st.z);
+      c.quaternion.copy(sq); c.updateMatrixWorld(true);
+    }
   }
 
   A.cinemaPathPlan = function(durationSec, ov) {

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3342,6 +3342,11 @@ async function setupEffects(A, renderer, scene, camera) {
   var CINEMA_WALK_MPS     = 2.3;   // interior pace — was 1.3
   var CINEMA_PULLBACK_MPS = 6.5;   // exterior recede: flying, not walking
   var CINEMA_DIVE_MPS     = 20;    // the approach is a fly-IN; dive distances run 20-150m
+  // §CPE_NOISE_LAW — the user's ONE pacing dial ("have a speed range… don't overdo it"), and the
+  // only knob the noise ratio is allowed to have. Declared here, at module scope, because the law
+  // governs EVERY beat: the dive's cost table (built with the plan) and the walk's blended cost
+  // both read it, and the walk's copy used to be a local declared 400 lines below the dive.
+  var CINEMA_PACE_SWING = 1.6;
   var CINEMA_TURN_DPS     = 45;    // one rate for BOTH in-place turns: the spin and the orbit lap
   var CINEMA_DIVE_MIN_SEC = 2.5;   // a floor, so a tiny building still gets an arrival rather than a cut
   var CINEMA_SPIN_MIN_SEC = 0.8;
@@ -3618,6 +3623,25 @@ async function setupEffects(A, renderer, scene, camera) {
   var CINEMA_EXIT_FACE_GAIN_RUSHED = 0.1;
   var _cinemaActive = false;
   function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
+  // §CPE_NOISE_LAW — the FLOORED ease. User, live, 2026-07-27: "also noticing last wpt stalling as
+  // the first one ... thus it is not using the noise ratio". They are right, and it is measurable:
+  // a beat's raw speed spans 3.66/0.186 = 20x (witness_cpe_noise_law, Duplex dive) and ALL of that
+  // is smoothstep, whose derivative 6e(1-e) is exactly ZERO at both ends of every beat. The noise
+  // ratio only modulates 1.1-1.5x on top. So the clock governs and the law decorates — the opposite
+  // of the ruling — and the zero at each seam IS the stall the user sees at the first and last
+  // waypoint.
+  //
+  // Fix without throwing away the ease: mix in enough linear rate that the ends never reach zero,
+  // with the mix taken from the user's OWN dial rather than a new number:
+  //     easeF(t) = a·t + (1-a)·smoothstep(t),   a = 1/PACE_SWING
+  // giving easeF'(0) = easeF'(1) = a = 1/1.6 (the slow rail exactly) and easeF'(0.5) = 1.19 (well
+  // inside the fast rail). Ends at 0->0 and 1->1 unchanged, so no beat boundary moves and no path
+  // changes. The ease now spans 1.9x instead of infinity, which leaves the NOISE ratio as the term
+  // that actually shapes the film.
+  function _cinemaEaseFloored(t) {
+    var a = 1 / CINEMA_PACE_SWING;
+    return a * Math.max(0, Math.min(1, t)) + (1 - a) * _cinemaSmoothstep(t);
+  }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
   var EFFECTS_V = 'v17 (§CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; §CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
@@ -4306,6 +4330,133 @@ async function setupEffects(A, renderer, scene, camera) {
       return deg;
     }
     var _diveEff = Math.min(diveDist, envelope);
+    // ══ §CPE_NOISE_LAW (user, 2026-07-27: "the speed of dive to the wp1 is still not using noise
+    // ratio" / "it governs thrughout"). The noise ratio is not a walk feature — it is the film's
+    // one pacing law, and until now Beat 3 was the only beat that obeyed it. Measured before this
+    // change: Hospital's dive/orbit cover 253 m in a 2 s window while its walk covers 1.0 m
+    // (witness_cpe_gaze_spin S3), i.e. the beats OUTSIDE the walk ran on a clock with no noise term
+    // at all.
+    //
+    // Busyness = the fraction of the fan that hits ANYTHING within its own range. Open sky reads 0,
+    // a room reads 1. It is a DENSITY, not the fan MIN that was retired for the courtyard bug, and
+    // it introduces NO new constant: the rays and the range are _cinemaFan's own.
+    //
+    // ⚠ NOT the ray fan. Two measured reasons, both from this session:
+    //   1. The fan is HORIZONTAL only (`_cinemaFan`: dir.set(cos,0,sin)) — a camera 100 m up has
+    //      nothing beside it, so a descent reads as empty however busy the building below is.
+    //   2. It can be BLIND. On Terminal in the headless rig `_cinemaFanMeshes()` returns ZERO
+    //      meshes, so every ray reports the CINEMA_FAN_FAR sentinel and the whole dive measured
+    //      0.000 — and §CINEMA_SPACE fell back to bbox-centre for the same reason. A no-hit is not
+    //      a measurement (§CPE_LIVE's standing rule).
+    // The user's own answer (2026-07-27): "isnt it best to use the bbxes to smell out the frame
+    // rate". `element_transforms` is DB truth, always loaded, deterministic on every machine, and
+    // it cannot go blind. Counted in IFC space so the 48k rows are never converted — one sample
+    // point is converted instead (A.three2ifc).
+    var _densPts = null;
+    function _densPoints() {
+      if (_densPts) return _densPts;
+      _densPts = [];
+      try {
+        var rows = A.dbQuery('SELECT center_x, center_y, center_z FROM element_transforms');
+        for (var i = 0; i < rows.length; i++) _densPts.push(rows[i]);
+      } catch (e) {}
+      return _densPts;
+    }
+    // How many elements are within one fan-horizon of this point. CINEMA_FAN_FAR is reused as the
+    // neighbourhood radius rather than inventing a second range constant.
+    function _densityAt(p) {
+      var pts = _densPoints();
+      if (!pts.length || typeof A.three2ifc !== 'function') return 0;
+      var q = A.three2ifc(p.x, p.y, p.z), R2 = CINEMA_FAN_FAR * CINEMA_FAN_FAR, n = 0;
+      for (var i = 0; i < pts.length; i++) {
+        var dx = pts[i][0] - q.ix, dy = pts[i][1] - q.iy, dz = pts[i][2] - q.iz;
+        if (dx * dx + dy * dy + dz * dz < R2) n++;
+      }
+      return n;
+    }
+    // ⚖ USER RULING 2026-07-27, SETTLED — do not re-derive, do not reintroduce a density term:
+    //   "20% density, 80% noise ie rate of change"  →  then, final: "i would say its 100% rate of
+    //   change of bbxes".
+    // Their reason, verbatim: "because if frame not changing, not matter how dense the animation is
+    // not moving makes a boring show". Density is NOT the signal: a dense corridor the camera
+    // slides along without the view changing is a still, and lingering on it is the boredom, not
+    // the craft. The signal is how fast the bbox neighbourhood CHANGES along the path — so the
+    // brake fires at a roofline, a doorway, a wall crossing, and releases on a static frame however
+    // full it is. Charging cost by it makes metres-per-frame fall exactly where the change is, so
+    // the content crossing the frame per frame comes out EVEN: change is the integrand, even noise
+    // is the invariant.
+    // ⚖ And the saturation question, asked and answered by the user in the same breath: "when
+    // outside building it changes as the building is far off, or it hits the max ... the
+    // surrounding panaroma rate of change is consistent for formula. We are in a range, thus no
+    // worry." Outside, the signal either flattens (nothing entering the neighbourhood) or pins at
+    // the max — and BOTH are harmless because the cost multiplier is bounded by PACE_SWING either
+    // way. So there is deliberately NO outside/inside special case, no panorama branch, and no
+    // clamp beyond the one the range already provides. Do not add one.
+    var NOISE_W_DENSITY = 0, NOISE_W_CHANGE = 1;
+    // The dive is a straight LERP, so its arc and its gaze turn are both uniform in e — the blended
+    // distance+turn cost that paces the walk is the IDENTITY here and can do nothing. Busyness is
+    // the only term that varies along a dive, which is exactly why the user could still see this
+    // beat ignoring the law. Cost per metre = 1 + (SWING-1)·busy, so the emptiest stretch runs at
+    // most PACE_SWING times the speed of the busiest: the same single dial, the same provable
+    // bound, no second knob.
+    var _DV_N = 64, _dvC = null, _diveBusy = 0;
+    (function _diveNoiseBuild() {
+      var i, j, dens = [], series = [];
+      for (i = 0; i < _DV_N; i++) {
+        var e = (i + 0.5) / _DV_N;
+        dens.push(_densityAt({ x: camPos0.x + (settle.x - camPos0.x) * e,
+                               y: camPos0.y + (settle.y - camPos0.y) * e,
+                               z: camPos0.z + (settle.z - camPos0.z) * e }));
+      }
+      // Rate of change = the central difference of the density series. Both channels are
+      // normalised by their OWN maximum, which is what makes this a RATIO (the user's word) rather
+      // than a count with a machine-dependent scale — an empty dive and a dense one both span 0..1.
+      var chg = [], dMax = 0, cMax = 0;
+      for (i = 0; i < _DV_N; i++) {
+        var a = dens[Math.max(0, i - 1)], b = dens[Math.min(_DV_N - 1, i + 1)];
+        chg.push(Math.abs(b - a));
+        if (dens[i] > dMax) dMax = dens[i];
+        if (chg[i] > cMax) cMax = chg[i];
+      }
+      var c = [0], sum = 0, ns = 0, nMax = 0, nMin = 1;
+      for (i = 0; i < _DV_N; i++) {
+        var noise = NOISE_W_DENSITY * (dMax > 0 ? dens[i] / dMax : 0) +
+                    NOISE_W_CHANGE  * (cMax > 0 ? chg[i] / cMax : 0);
+        if (i % 8 === 0 || i === _DV_N - 1) series.push(((i + 0.5) / _DV_N).toFixed(2) + ':' + noise.toFixed(2));
+        ns += noise; if (noise > nMax) nMax = noise; if (noise < nMin) nMin = noise;
+        sum += 1 + (CINEMA_PACE_SWING - 1) * noise;
+        c.push(sum);
+      }
+      if (sum > 1e-9) for (j = 0; j <= _DV_N; j++) c[j] /= sum;
+      _dvC = c; _diveBusy = ns / _DV_N;
+      var bMin = nMin, bMax = nMax;
+      // The delivered speed ratio along the dive, stated as a number rather than claimed: the
+      // emptiest sample runs (1+(SWING-1)·bMax)/(1+(SWING-1)·bMin) times faster than the busiest.
+      // meshes= is the first thing to read when meanBusy is 0.000: MEASURED on Terminal in the
+// headless rig, _cinemaFanMeshes() returns ZERO meshes, so every fan reports the CINEMA_FAN_FAR
+      // sentinel, every §CINEMA_SPACE candidate reads enclosed=0%, and the settle falls back to
+      // bbox-centre. A busyness of 0 then means "the fan is blind", NOT "the scene is empty" —
+      // exactly the §CPE_LIVE rule that a no-hit is not a measurement. The law is inert there by
+      // construction (a flat cost table is the identity remap), which is the correct behaviour, but
+      // it must be visible rather than look like a passing measurement.
+      console.log('§CPE_NOISE_LAW beat=dive src=bbox elems=' + _densPoints().length +
+        ' w=' + NOISE_W_DENSITY + '/' + NOISE_W_CHANGE + ' (density/change)' +
+        ' meanNoise=' + _diveBusy.toFixed(3) +
+        ' busy=' + bMin.toFixed(2) + '..' + bMax.toFixed(2) + ' samples=' + _DV_N +
+        ' swing=' + CINEMA_PACE_SWING +
+        ' deliveredRange=' + ((1 + (CINEMA_PACE_SWING - 1) * bMax) / (1 + (CINEMA_PACE_SWING - 1) * bMin)).toFixed(2) + 'x' +
+        ' series=[' + series.join(' ') + ']' +
+        ' — frames spaced by busyness-weighted distance; the dive seconds below are bought by the same number');
+    })();
+    // Monotone inverse of the dive's cost table — same shape as _evenTurnRemap, one table each.
+    function _diveRemap(u) {
+      if (!_dvC) return u;
+      u = Math.max(0, Math.min(1, u));
+      var lo = 0, hi = _DV_N;
+      while (hi - lo > 1) { var mid = (lo + hi) >> 1; if (_dvC[mid] <= u) lo = mid; else hi = mid; }
+      var c0 = _dvC[lo], c1 = _dvC[hi], f = (c1 - c0 > 1e-12) ? (u - c0) / (c1 - c0) : 0;
+      return (lo + Math.max(0, Math.min(1, f))) / _DV_N;
+    }
     // ⚠ §CPE_SEAM_CONTINUOUS — DO NOT add a pitch term to _spinDeg. It was tried this session and
     // reverted: pricing the walk's opening pitch into the spin makes the spin's DURATION depend on
     // the authored path, which shifts every beat fraction before it and breaks G2's "an edit
@@ -4323,7 +4474,13 @@ async function setupEffects(A, renderer, scene, camera) {
     var _openDir = { x: (_wkA0.x - _wkP0.x) / _wkL, y: _wkDy / _wkL, z: (_wkA0.z - _wkP0.z) / _wkL };
     var _spinDeg = Math.min(180, Math.abs(dYaw) * 180 / Math.PI);
     var _natSec = {
-      dive:  Math.max(CINEMA_DIVE_MIN_SEC, _diveEff / CINEMA_DIVE_MPS),
+      // §CPE_NOISE_LAW, second half — the same ratio that spaces the frames also BUYS the seconds
+      // ("where sudden diff is adverse noise impact and introduce frames to smoothen", the user's
+      // rule, already applied to the walk in `out` below via _walkTurnDeg). A dive that ends deep
+      // inside a busy building buys up to PACE_SWING times the seconds of one that drops into an
+      // empty yard; redistribution alone could never do this, because with the frame count fixed
+      // the mean speed is fixed whatever the parameterization does.
+      dive:  Math.max(CINEMA_DIVE_MIN_SEC, _diveEff / CINEMA_DIVE_MPS * (1 + (CINEMA_PACE_SWING - 1) * _diveBusy)),
       spin:  Math.max(CINEMA_SPIN_MIN_SEC, _spinDeg / CINEMA_TURN_DPS),
       out:   totalLen / CINEMA_WALK_MPS + _walkTurnDeg() / (CINEMA_TURN_DPS / 3),
       rise:  Math.max(0.5, _pullDist / CINEMA_PULLBACK_MPS),
@@ -4543,7 +4700,11 @@ async function setupEffects(A, renderer, scene, camera) {
         // exit is chosen at t=4s by position AND facing, so if the ease were free to re-aim you at
         // the space centre, every film on a building would face the same way here, pick the same
         // door, and the whole feature would collapse to one film per building.
-        var e = _cinemaSmoothstep(tD > 0 ? tNorm / tD : 1);
+        // §CPE_NOISE_LAW: the dive's progress is the eased time fraction run through the busyness
+        // cost table, exactly as Beat 3's is run through _evenTurnRemap. Empty sky is crossed fast,
+        // the arrival into the building slows — without either end of the beat losing its ease, so
+        // the seams stay as smooth as they were.
+        var e = _diveRemap(_cinemaEaseFloored(tD > 0 ? tNorm / tD : 1));
         var px = camPos0.x + (settle.x - camPos0.x) * e;
         var py = camPos0.y + (settle.y - camPos0.y) * e;
         var pz = camPos0.z + (settle.z - camPos0.z) * e;
@@ -4564,7 +4725,7 @@ async function setupEffects(A, renderer, scene, camera) {
         // §CPE_EVEN_TURN: the frame's progress along the walk is no longer the eased TIME fraction
         // — it is that fraction run through _evenTurnRemap, which spaces frames evenly in the
         // blended distance+turn metric instead of evenly in distance. See the remap's own comment.
-        var e3 = _evenTurnRemap(_cinemaSmoothstep((tNorm - tS) / Math.max(1e-6, tO - tS)));
+        var e3 = _evenTurnRemap(_cinemaEaseFloored((tNorm - tS) / Math.max(1e-6, tO - tS)));
         return _beat3Pose(e3);
       }
       if (tNorm <= tR) {
@@ -4572,7 +4733,7 @@ async function setupEffects(A, renderer, scene, camera) {
         // on _orbitPose(0), which is what keeps the handoff continuous (the old Act III handoff
         // did not, and measured a ~10.8m single-frame step at t≈0.80). The look-at picks up from
         // CINEMA_TURN_OVERLAP_MAX (where Beat 3 left it) rather than restarting at 0 — see above.
-        var e4 = _cinemaSmoothstep((tNorm - tO) / Math.max(1e-6, tR - tO));
+        var e4 = _cinemaEaseFloored((tNorm - tO) / Math.max(1e-6, tR - tO));
         var turnW4 = CINEMA_TURN_OVERLAP_MAX + (1 - CINEMA_TURN_OVERLAP_MAX) * _cinemaSmoothstep(e4);
         // (odx,odz) IS the direction Beat 3 ends on — its last route leg is the outward push past
         // the doorway — so e4=0 continues Beat 3's final gaze exactly. At e4=1, turnW4=1 yields the
@@ -4730,7 +4891,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // Slow-in-the-turn and pick-up-in-the-open are not imposed by a brake — they are what equal
     // cost stepping DOES, and the brake releases in open space for free because there is no dθ to
     // pay for there.
-    var CINEMA_PACE_SWING = 1.6;
+    // CINEMA_PACE_SWING now lives at module scope (§CPE_NOISE_LAW) — one dial for every beat.
     var _etW = 1 - 1 / CINEMA_PACE_SWING;
     var _etN = 240, _etC = null;
     // §CPE_PACE_FLOOR — a SEPARATE concern from the cost function, and kept separate.

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -730,12 +730,20 @@ async function initViewer() {
   // §S287b: SINGLE-OWNER render loop. Every (re)start routes through here; the _rafId guard
   // guarantees exactly ONE rAF chain — fixes the S287 focus/pageshow + async-init double-loop
   // (which ran render twice per frame). Witness: §RENDER_LOOP start total= must stay 1.
+  var _idleCycles = 0;   // §LOG_SPAM_THROTTLE — the idle gate's cycle count, logged instead of each cycle
   function _startLoop() {
     if (_rafId) return;                       // already running — never double
     _loopStarts++;
     _needsRender = true;
     _rafId = requestAnimationFrame(animate);
-    console.log('§RENDER_LOOP start total=' + _loopStarts);
+    // §LOG_SPAM_THROTTLE (user, 2026-07-27: "solve the spam too"). This trio — RENDER_LOOP start,
+    // IDLE_GATE park, IDLE_GATE wake — fires once per idle cycle, and the idle gate cycles on every
+    // pointer twitch: their Hospital console ran to `total=189` with hundreds of interleaved
+    // park/wake pairs, burying every §-line that carries information. The COUNT is the signal here,
+    // not each occurrence, so log the first few in full and then only every 25th, carrying the
+    // running total (which is what the §RENDER_LOOP witness asserts on anyway).
+    if (_loopStarts <= 3 || _loopStarts % 25 === 0)
+      console.log('§RENDER_LOOP start total=' + _loopStarts + (_loopStarts > 3 ? ' (throttled: every 25th)' : ''));
   }
   function _ensureLoop() { _tabVisible = true; _startLoop(); }
   document.addEventListener('visibilitychange', function() {
@@ -847,7 +855,13 @@ async function initViewer() {
                  APP.flyActive || _orbiting || _pipelinesCompiling;
     if (!_awake) {
       _rafId = null;
-      if (!_idleLogged) { console.log('§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames)'); _idleLogged = true; }
+      if (!_idleLogged) {
+        _idleCycles = (_idleCycles || 0) + 1;
+        if (_idleCycles <= 3 || _idleCycles % 25 === 0)
+          console.log('§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=' + _idleCycles +
+            (_idleCycles > 3 ? ' (throttled: every 25th)' : ''));
+        _idleLogged = true;
+      }
       return;
     }
     _rafId = requestAnimationFrame(animate);
@@ -897,7 +911,10 @@ async function initViewer() {
         else if (APP._composer && APP._composerEnabled) APP._composer.render();
         else APP.renderer.render(APP.scene, APP.camera);
         _needsRender = false;
-        if (_idleLogged) { console.log('§IDLE_GATE wake'); _idleLogged = false; }
+        if (_idleLogged) {
+          if ((_idleCycles || 0) <= 3 || (_idleCycles || 0) % 25 === 0) console.log('§IDLE_GATE wake cycles=' + (_idleCycles || 0));
+          _idleLogged = false;
+        }
       } else if (!_idleLogged) {
         console.log('§IDLE_GATE park — desktop loop idle, 0 GPU frames (static scene)');
         _idleLogged = true;

--- a/witness_cpe_gaze_spin.js
+++ b/witness_cpe_gaze_spin.js
@@ -1,0 +1,119 @@
+// WITNESS — §CPE_GAZE_SPIN: the gaze follows the path. A revolution in place is a DEFECT.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_GAZE_SPIN (user ruling 2026-07-27:
+// "no reason to if it follows its path, even at wp1, no reason not to follow").
+//
+// WHY A NEW GATE — T2 (witness_cpe_even_turn) measures deg per FRAME and structurally CANNOT see
+// this: a 360 deg revolution spread smoothly over 40 frames is 9 deg/frame and passes. Hospital
+// accumulates ~888 deg of gaze sweep across the film with T2 green. The signature of a spin in
+// place is ACCUMULATED turn >> NET turn over a stretch of path the camera barely moves along.
+//
+//   S1 no window of the film turns the gaze through a revolution it does not keep: over any
+//      WINDOW_SEC stretch, accumulated - |net| must stay under SPIN_DEG. A real corner turns 90 deg
+//      and KEEPS it (accumulated ~= net, waste ~= 0); a spin-in-place turns 360 and keeps 0.
+//   S2 the same, restricted to the WALK beat, where the user saw it (wp1 is inside the walk) —
+//      reported separately so a defect in the orbit/rise cannot mask or be masked by it.
+//   S3 INFO, not gated: the worst window's arc length, so a large waste with a large translation
+//      (a genuine switchback, which IS following the path) is distinguishable from one in place.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8403;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const FPS = 15, DUR = 24;
+const WINDOW_SEC = parseFloat(process.env.WIN || '2.0');   // the stretch a viewer reads as "one move"
+const SPIN_DEG = parseFloat(process.env.SPIN || '120');    // waste this large is a turn the film throws away
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan, { timeout: 180000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 120000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const res = await page.evaluate(async (dur, fps, winSec) => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      A._cinemaPathEdit = null;
+      const plan = A.cinemaPathPlan(dur, null);
+      // The product bakes plan.naturalTotal seconds (cinema_maxq.js:414) — sampling `dur` measures a
+      // film no user sees. Same instrument bug that hid T2/B5 for two sessions.
+      const nSec = plan.naturalTotal || dur;
+      const n = Math.max(4, Math.round(nSec * fps));
+      const beats = plan.beats || {};
+      const g = [], pos = [];
+      for (let i = 0; i < n; i++) {
+        const u = i / (n - 1), p = plan.poseAt(u);
+        const dx = p.tx - p.x, dy = p.ty - p.y, dz = p.tz - p.z;
+        const L = Math.hypot(dx, dy, dz) || 1;
+        g.push({ x: dx / L, y: dy / L, z: dz / L });
+        pos.push({ x: p.x, y: p.y, z: p.z });
+      }
+      const ang = (a, b) => Math.acos(Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z))) * 180 / Math.PI;
+      const beatOf = (u) => (u <= beats.dive ? 'dive' : u <= beats.spin ? 'spin' : u <= beats.out ? 'walk'
+                            : u <= beats.rise ? 'rise' : 'orbit');
+      const wFrames = Math.max(2, Math.round(winSec * fps));
+      // Waste = accumulated - |net|: the turning the film performs and then gives back. A corner
+      // that is kept costs 0 waste however sharp it is, so this gate cannot fire on real cornering.
+      let worst = null, worstWalk = null;
+      for (let i = 0; i + wFrames < n; i++) {
+        let acc = 0, arc = 0;
+        for (let k = i + 1; k <= i + wFrames; k++) {
+          acc += ang(g[k - 1], g[k]);
+          arc += Math.hypot(pos[k].x - pos[k - 1].x, pos[k].y - pos[k - 1].y, pos[k].z - pos[k - 1].z);
+        }
+        const net = ang(g[i], g[i + wFrames]);
+        const rec = { waste: acc - net, acc, net, arc, u0: i / (n - 1), u1: (i + wFrames) / (n - 1),
+                      beat: beatOf((i + wFrames / 2) / (n - 1)) };
+        if (!worst || rec.waste > worst.waste) worst = rec;
+        if (rec.beat === 'walk' && (!worstWalk || rec.waste > worstWalk.waste)) worstWalk = rec;
+      }
+      // Whole-film accumulated sweep, for context against the 888 deg the handover recorded.
+      let totalAcc = 0;
+      for (let i = 1; i < n; i++) totalAcc += ang(g[i - 1], g[i]);
+      return { worst, worstWalk, totalAcc, frames: n, nSec, beats, pathLen: plan.pathLen };
+    }, DUR, FPS, WINDOW_SEC);
+
+    const f = (r) => r ? `waste=${r.waste.toFixed(1)} deg (accumulated ${r.acc.toFixed(1)}, net ${r.net.toFixed(1)}) ` +
+      `over ${WINDOW_SEC}s at u=${r.u0.toFixed(3)}..${r.u1.toFixed(3)} in the ${r.beat}, arc ${r.arc.toFixed(2)}m` : '(none)';
+
+    P(`S1 no ${WINDOW_SEC}s window throws away more than ${SPIN_DEG} deg of gaze turn`,
+      !!res.worst && res.worst.waste < SPIN_DEG, f(res.worst));
+    P(`S2 the WALK beat specifically (where wp1 lives) throws away less than ${SPIN_DEG} deg`,
+      !res.worstWalk || res.worstWalk.waste < SPIN_DEG, f(res.worstWalk));
+    console.log(`  INFO  film ${res.nSec.toFixed(1)}s / ${res.frames} frames, path ${res.pathLen.toFixed(1)}m, ` +
+      `whole-film accumulated gaze sweep ${res.totalAcc.toFixed(0)} deg`);
+    console.log(`  INFO  S3 worst window arc length ${res.worst ? res.worst.arc.toFixed(2) : '?'}m — ` +
+      `near zero means the camera turned without going anywhere (a spin in place); metres mean a real switchback`);
+    console.log(`  INFO  beats ${JSON.stringify(res.beats)}`);
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_noise_law.js
+++ b/witness_cpe_noise_law.js
@@ -1,0 +1,217 @@
+// WITNESS — §CPE_NOISE_LAW: the noise ratio governs the DIVE too, not only the walk.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_NOISE_LAW.
+//
+// THE DEFECT (user, live on Hospital, 2026-07-27): "the speed of dive to the wp1 is still not using
+// noise ratio" ... "it governs thrughout". Measured before the fix (witness_cpe_gaze_spin S3):
+// Hospital's outer beats cover 253 m in a 2 s window while its walk covers 1.0 m — the dive ran on
+// a pure clock with no noise term in it at all.
+//
+//   N1 the slow samples ARE the busy ones: mean dive speed over the busiest third of the dive is
+//      lower than over the emptiest third. This is the whole claim; if it fails the law is not in
+//      the beat, whatever the log says.
+//   N2 the delivered range stays inside the user's one dial: fastest/slowest dive sample <=
+//      PACE_SWING x 1.5 (the smoothstep ease's own peak, the same allowance T5 gives the walk).
+//      "Don't overdo it" is a bound, and a bound is a number or it is nothing.
+//   N3 the remap changed the PACING, not the PATH: the dive still starts at the opening camera
+//      pose and still lands exactly on the settle point. A monotone reparameterization cannot move
+//      either end, so a non-zero residue here means the table is not monotone onto [0,1].
+//   N4 no regression in the plan budget — §CINEMA_PLAN_MS stays in the same class it was in
+//      (reported, and gated only against a 3x blow-out, since the fan sampling is new work).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8403;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const FPS = 15, DUR = 24, PACE_SWING = 1.6;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaFan,
+      { timeout: 180000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 120000, polling: 2000 });
+
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+    const res = await page.evaluate(async (dur, fps) => {
+      const A = window.APP;
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      A._cinemaPathEdit = null;
+      const t0 = performance.now();
+      const plan = A.cinemaPathPlan(dur, null);
+      const planMs = performance.now() - t0;
+      const nSec = plan.naturalTotal || dur;
+      const n = Math.max(4, Math.round(nSec * fps));
+      const tD = plan.beats.dive;
+      // Walk the DIVE frame by frame, at the frame count the product actually bakes, and read the
+      // busyness at each sample with the same fan the law uses.
+      // The SAME signal the law uses — bbox rate of change, not the ray fan. Measuring the law
+      // with a different instrument than the law uses is how the last four "defects" in this lane
+      // turned out to be broken meters.
+      const FAR = 60, R2 = FAR * FAR;
+      const rows = A.dbQuery('SELECT center_x, center_y, center_z FROM element_transforms');
+      const densAt = (p) => {
+        const q = A.three2ifc(p.x, p.y, p.z);
+        let k = 0;
+        for (let i = 0; i < rows.length; i++) {
+          const dx = rows[i][0] - q.ix, dy = rows[i][1] - q.iy, dz = rows[i][2] - q.iz;
+          if (dx * dx + dy * dy + dz * dz < R2) k++;
+        }
+        return k;
+      };
+      // ⚠ The noise signal must be sampled on UNIFORM PATH POSITION, never between consecutive
+      // FRAMES. Measured the wrong way first and it inverted the result (N1 read 0.81x/0.67x
+      // "faster where busier"): a frame-to-frame difference is large wherever the camera is moving
+      // fast, so it measures the pacing it is supposed to be judging. The law samples 64 uniform
+      // points along the dive line; so does this.
+      const p0 = plan.poseAt(0), st = plan.settle;
+      const DL = Math.hypot(st.x - p0.x, st.y - p0.y, st.z - p0.z) || 1;
+      const M = 64, dens = [];
+      for (let i = 0; i < M; i++) {
+        const e = (i + 0.5) / M;
+        dens.push(densAt({ x: p0.x + (st.x - p0.x) * e, y: p0.y + (st.y - p0.y) * e, z: p0.z + (st.z - p0.z) * e }));
+      }
+      let cMax = 0;
+      const chg = dens.map((d, i) => Math.abs(dens[Math.min(M - 1, i + 1)] - dens[Math.max(0, i - 1)]));
+      chg.forEach(c => { if (c > cMax) cMax = c; });
+      const noiseAtE = (e) => {
+        const i = Math.max(0, Math.min(M - 1, Math.round(e * M - 0.5)));
+        return cMax > 0 ? chg[i] / cMax : 0;
+      };
+      const samples = [];
+      let prev = null;
+      for (let i = 0; i < n; i++) {
+        const u = i / (n - 1);
+        if (u > tD) break;
+        const p = plan.poseAt(u);
+        if (prev) {
+          const e = Math.hypot(p.x - p0.x, p.y - p0.y, p.z - p0.z) / DL;
+          samples.push({ u, step: Math.hypot(p.x - prev.x, p.y - prev.y, p.z - prev.z), busy: noiseAtE(e), e });
+        }
+        prev = p;
+      }
+      // N5 — the STALL check the user reported ("last wpt stalling as the first one"). Absolute
+      // metres per frame across the WHOLE film, beat-labelled, with NO ease divided out: the
+      // ease-relative gates above structurally cannot see a stall that the ease itself causes.
+      const bt = plan.beats;
+      const beatOf = (u) => (u <= bt.dive ? 'dive' : u <= bt.spin ? 'spin' : u <= bt.out ? 'walk'
+                            : u <= bt.rise ? 'rise' : 'orbit');
+      const film = [];
+      let pv = null;
+      for (let i = 0; i < n; i++) {
+        const u = i / (n - 1), p = plan.poseAt(u);
+        if (pv) film.push({ u, beat: beatOf(u), step: Math.hypot(p.x - pv.x, p.y - pv.y, p.z - pv.z) });
+        pv = p;
+      }
+      const first = plan.poseAt(0), last = plan.poseAt(tD);
+      return {
+        planMs, nSec, frames: n, tD, samples, film, fps,
+        camNow: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+        settle: plan.settle, first: { x: first.x, y: first.y, z: first.z },
+        last: { x: last.x, y: last.y, z: last.z },
+      };
+    }, DUR, FPS);
+
+    const s0 = res.samples.filter(x => x.step > 0);
+    // ⚠ EVERY comparison below is on the ease-divided residual, never the raw step. Measured the
+    // wrong way twice: the noise peak sits mid-dive, which is exactly where smoothstep's derivative
+    // peaks at 1.5, so raw metres-per-frame reports the EASE and inverted the result (busiest third
+    // read 0.67x "faster"). expected(e) = mean x 6e(1-e) is the ease's own prediction; what is left
+    // after dividing it out is the law.
+    const meanRaw = s0.reduce((a, x) => a + x.step, 0) / (s0.length || 1);
+    const s = s0.map(x => {
+      const et = x.u / res.tD;
+      // The beat is parameterized by the FLOORED ease now (§CPE_NOISE_LAW), so the prediction to
+      // divide out is its derivative, not smoothstep's: easeF'(e) = a + (1-a)*6e(1-e), a=1/SWING.
+      // Left as 6e(1-e) this gate read 0.55x and failed against its own stale model.
+      const A_ = 1 / PACE_SWING;
+      const dEase = A_ + (1 - A_) * 6 * et * (1 - et);
+      return Object.assign({}, x, { et, r: x.step / (meanRaw * dEase) });
+    }).filter(x => x.et > 0.2 && x.et < 0.8 && isFinite(x.r));
+    // Busiest third vs emptiest third, by busyness rank. Thirds rather than a correlation
+    // coefficient because the claim is directional ("busy => slower"), and a rank split says that
+    // in metres per frame instead of in a unitless r.
+    const byBusy = [...s].sort((a, b) => a.busy - b.busy);
+    const k = Math.max(1, Math.floor(byBusy.length / 3));
+    const empt = byBusy.slice(0, k), busy = byBusy.slice(-k);
+    const mean = (arr, f) => arr.reduce((a, x) => a + f(x), 0) / (arr.length || 1);
+    const vEmpty = mean(empt, x => x.r), vBusy = mean(busy, x => x.r);
+    const blind = Math.max(...s.map(x => x.busy), 0) === 0;
+    if (blind) {
+      console.log(`  SKIP  N1 — no noise signal here (bbox change is 0 at every dive sample).`);
+    }
+    if (!blind) P('N1 the dive slows where the bbox neighbourhood is changing fastest',
+      s.length >= 6 && vBusy < vEmpty,
+      `emptiest third ${mean(empt, x => x.busy).toFixed(2)} noise -> ${vEmpty.toFixed(3)}x ease-expected; ` +
+      `busiest third ${mean(busy, x => x.busy).toFixed(2)} noise -> ${vBusy.toFixed(3)}x ` +
+      `(${(vEmpty / (vBusy || 1e-9)).toFixed(2)}x slower where the change is), ${s.length} inner dive frames`);
+
+    // N2 — the same residual, as a BOUND: what is left after the ease must sit inside the one dial.
+    const rHi = Math.max(...s.map(x => x.r)), rLo = Math.min(...s.map(x => x.r));
+    P(`N2 with the ease divided out, the dive's speed stays inside the one dial [1/${PACE_SWING}, ${PACE_SWING}]`,
+      s.length >= 4 && rHi <= PACE_SWING * 1.05 && rLo >= 1 / PACE_SWING / 1.05,
+      `measured/ease-expected spans ${rLo.toFixed(2)}x .. ${rHi.toFixed(2)}x over ${s.length} inner frames ` +
+      `(raw max/min ${Math.max(...s0.map(x => x.step)).toFixed(3)}/${Math.min(...s0.map(x => x.step)).toFixed(3)}, ` +
+      `which is mostly the ease and is NOT the bound)`);
+
+    // N5 — a stall is a run of frames whose speed sits under the beat's own mean/PACE_SWING.
+    // Measured on the MOVING beats only (the spin is in-place by design; T2 owns its rotation).
+    const stalls = [];
+    ['dive', 'walk', 'rise'].forEach(bn => {
+      const f = res.film.filter(x => x.beat === bn);
+      if (f.length < 6) return;
+      const m = f.reduce((a, x) => a + x.step, 0) / f.length, floor = m / PACE_SWING;
+      let run = 0, worst = 0, at = 0;
+      f.forEach(x => { if (x.step < floor) { run++; if (run > worst) { worst = run; at = x.u; } } else run = 0; });
+      stalls.push({ bn, worstFrames: worst, sec: worst / res.fps, at, mean: m, floor });
+    });
+    const worstStall = stalls.reduce((a, x) => (x.sec > a.sec ? x : a), { sec: 0, bn: '-', worstFrames: 0, at: 0 });
+    P('N5 no beat stalls at its seams (no run under beat-mean/PACE_SWING longer than 0.5s)',
+      worstStall.sec <= 0.5,
+      `worst run ${worstStall.worstFrames} frames = ${worstStall.sec.toFixed(2)}s in the ${worstStall.bn} at u=${(worstStall.at || 0).toFixed(3)}; ` +
+      stalls.map(x => `${x.bn}: ${x.sec.toFixed(2)}s under ${x.floor.toFixed(3)}m/frame`).join(', '));
+
+    const d = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+    P('N3 the pacing changed, the path did not (dive still ends exactly on the settle point)',
+      d(res.last, res.settle) < 0.01,
+      `dive end is ${d(res.last, res.settle).toExponential(2)}m from settle; start is ` +
+      `${d(res.first, res.camNow).toFixed(3)}m from the opening camera pose`);
+
+    P('N4 the plan budget did not blow out (fan sampling is new per-plan work)',
+      res.planMs < 3000,
+      `§CINEMA_PLAN_MS ${res.planMs.toFixed(1)}ms — ` +
+      (logs.filter(l => /§CINEMA_PLAN_MS/.test(l)).slice(-1)[0] || '(no log line)'));
+
+    console.log(`  INFO  ${logs.filter(l => /§CPE_NOISE_LAW/.test(l)).slice(-1)[0] || '(no §CPE_NOISE_LAW line)'}`);
+    console.log(`  INFO  film ${res.nSec.toFixed(1)}s / ${res.frames} frames, dive is u<=${res.tD.toFixed(3)}`);
+    checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_noise_law.js
+++ b/witness_cpe_noise_law.js
@@ -22,6 +22,8 @@ const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 const PORT = process.env.PORT || 8403;
 const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
 const FPS = 15, DUR = 24, PACE_SWING = 1.6;
+// 'a sec or two ... is fine in the film' (user). Two seconds plus a frame of slack.
+const STALL_CEIL = parseFloat(process.env.STALL_CEIL || '3.0');
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 (async () => {
@@ -186,10 +188,19 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       stalls.push({ bn, worstFrames: worst, sec: worst / res.fps, at, mean: m, floor });
     });
     const worstStall = stalls.reduce((a, x) => (x.sec > a.sec ? x : a), { sec: 0, bn: '-', worstFrames: 0, at: 0 });
-    P('N5 no beat stalls at its seams (no run under beat-mean/PACE_SWING longer than 0.5s)',
-      worstStall.sec <= 0.5,
-      `worst run ${worstStall.worstFrames} frames = ${worstStall.sec.toFixed(2)}s in the ${worstStall.bn} at u=${(worstStall.at || 0).toFixed(3)}; ` +
-      stalls.map(x => `${x.bn}: ${x.sec.toFixed(2)}s under ${x.floor.toFixed(3)}m/frame`).join(', '));
+    // ⚖ USER RULING 2026-07-27, and the reason this is a REPORT and not a gate: "i thnk the
+    // stalls are ok, it may mean a sec or two pause which is fine in the film" ... "but if the
+    // noise ratio tempers it a bit also ok". A pause is film-making, not a defect, so gating it at
+    // 0.5s was gating the user's own taste. The number is still printed every run — a stall that
+    // grows past a couple of seconds is worth SEEING even though it is not worth failing — and the
+    // ceiling below is deliberately generous, set from their own words rather than from a feel.
+    console.log(`  INFO  N5 stall report (accepted by ruling, not gated below ${STALL_CEIL}s): ` +
+      `worst ${worstStall.worstFrames} frames = ${worstStall.sec.toFixed(2)}s in the ${worstStall.bn} ` +
+      `at u=${(worstStall.at || 0).toFixed(3)}; ` + stalls.map(x => `${x.bn} ${x.sec.toFixed(2)}s`).join(', '));
+    P(`N5 no beat pauses beyond what the user called fine (a sec or two; ceiling ${STALL_CEIL}s)`,
+      worstStall.sec <= STALL_CEIL,
+      `worst pause ${worstStall.sec.toFixed(2)}s in the ${worstStall.bn}` +
+      (worstStall.sec > 0.5 ? ' — a real pause, and an accepted one' : ' — none worth calling a pause'));
 
     const d = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
     P('N3 the pacing changed, the path did not (dive still ends exactly on the settle point)',


### PR DESCRIPTION
Tonight's lane, all witnessed. Details in bim-compiler prompts/CINEMA_PATH_EDITOR.md §START HERE.

- §CPE_NOISE_LAW: dive paced by bbox rate-of-change (user's ruling: 100% rate of change, bboxes not the fan); dive seconds bought by the same number; walk carries the same term; radius = half the beat's travel.
- floored ease (a=1/PACE_SWING) on dive/walk/rise: dive speed spread 20x -> 1.82x, dive stall 0.00s.
- §CPE_DRAG_SCALE fixed at the source: drag rate is building-derived, not camera-distance-geared (0.151->0.063 Duplex, 0.227->0.085 Terminal).
- §CPE_DRAG_LAND_FIRST: no re-plan during a drag (was re-deriving the whole plan every 120ms at ~1.2s each, mid-gesture).
- §CPE_BASIS_HALF_PIN: the basis pin now re-aims the camera; editor and bake were planning from different cameras (504 deg full-lap spin in the bake).
- §CPE_HOLDER_INTEGRITY assert + log-spam throttle.

Gates: witness_cpe_noise_law 5/5+5/5, witness_cpe_drag 4/4+4/4, witness_cpe_preview_divergence 3/3+3/3, witness_cpe_gaze_spin 2/2 on Duplex+Terminal+Hospital, witness_cpe_even_turn T2 4.1 deg/frame (improved).

KNOWN RED, named in the spec not hidden: T5 walk position step 3.0x vs its 2.4x allowance (real, the noise weight multiplies an already-spread cost); T6 stale model + gates a stall the user has accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)