### PR TITLE
fix(cinema): §CPE_PREVIEW_AFTER + P4 rotation gate + §CPE_DRAG_TRACK

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -437,9 +437,16 @@
     // "the user sees what its next 10 mins of rendering will be up to". Plain nav look, no Alt+S
     // staging/folds (path rehearsal, not a quality preview — per user, "the fast preview the
     // scene wont be in Alt-S mode"). Alt+C during the preview cancels the whole run for free.
-    if (opts.preview !== false) {
-      console.log('§MAXQ_PREVIEW start 10s real-time mock of the exact path (plain look, no Alt+S)');
-      _status('🎬 Path preview (10s, plain look) — the bake follows; Alt+C cancels');
+    // ONE implementation, two call sites (§CPE_PREVIEW_AFTER below is the second). It reads `poseAt`,
+    // which reads `plan` from this scope at CALL time — so whichever plan is current when it runs is
+    // the plan it flies. That is not incidental: it is what makes the after-edit preview show the
+    // EDITED film through the very same function the bake will step frame by frame, rather than a
+    // second, parallel notion of the path that could drift from it (§CPE_PREVIEW_DIVERGENCE, again).
+    // Returns true if the user cancelled during it.
+    async function _runPreview(phase, status) {
+      console.log('§MAXQ_PREVIEW start phase=' + phase +
+        ' 10s real-time mock of the exact path (plain look, no Alt+S)');
+      _status(status);
       var camSave = { px: A.camera.position.x, py: A.camera.position.y, pz: A.camera.position.z,
                       qx: A.controls.target.x, qy: A.controls.target.y, qz: A.controls.target.z };
       var pv0 = performance.now(), PREV_MS = 10000;
@@ -460,14 +467,21 @@
       A.controls.target.set(camSave.qx, camSave.qy, camSave.qz);
       A.controls.update();
       if (A.markDirty) A.markDirty();
-      if (_cancel) {
-        console.log('§MAXQ_CANCEL during preview — nothing baked, nothing saved');
-        _status('🎬 MaxQ cancelled during preview');
-        _active = false; _cancel = false; A._maxqActive = false;
-        _wakeRelease(); _dampRelease();
+      if (_cancel) return true;
+      console.log('§MAXQ_PREVIEW done phase=' + phase + ' — camera restored');
+      return false;
+    }
+    function _cancelledOut(where) {
+      console.log('§MAXQ_CANCEL during ' + where + ' — nothing baked, nothing saved');
+      _status('🎬 MaxQ cancelled during ' + where);
+      _active = false; _cancel = false; A._maxqActive = false;
+      _wakeRelease(); _dampRelease();
+    }
+    if (opts.preview !== false) {
+      if (await _runPreview('derived', '🎬 Path preview (10s, plain look) — the editor opens next; Alt+C cancels')) {
+        _cancelledOut('preview');
         return;
       }
-      console.log('§MAXQ_PREVIEW done — camera restored, commencing capture');
     }
     // ══ §CINEMA_PATH_EDITOR (prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL item 12): the
     // waypoint editor opens HERE — after the preview has shown the path and put the camera back.
@@ -518,6 +532,28 @@
         if (nFrames !== _framesWas)
           console.log('§MAXQ_START_REVISED frames=' + _framesWas + '→' + nFrames +
             ' (path edited; §MAXQ_START above is superseded)');
+        // ══ §CPE_PREVIEW_AFTER (CINEMA_PATH_EDITOR.md ask 5) — the preview you get AFTER you edit.
+        // Until now the only 10s rehearsal ran BEFORE the editor opened, so it showed the DERIVED
+        // path — the one film you already knew you did not want, which is why you opened the editor.
+        // The film you actually authored went straight to a ten-minute bake unseen. Confirmed absent
+        // in the user's own console: §CPE_CLOSE -> §CPE_APPLIED -> §MAXQ_FRAME i=0, with no second
+        // §MAXQ_PREVIEW between them.
+        //
+        // It runs ONLY when the path was really edited. An untouched OK re-uses the plan object
+        // computed before the editor opened (guardrail 2, see the else branch), so a second preview
+        // there would be ten seconds spent proving nothing changed — and "the default cost of this
+        // feature is one click and nothing else" is a promise this must not quietly break.
+        //
+        // `plan` was reassigned three lines up, and poseAt() resolves `plan` at call time, so this
+        // flies the EDITED plan through the identical function the bake steps frame by frame. Not
+        // a re-implementation of the path: the same one, which is the whole point.
+        if (opts.preview !== false) {
+          if (await _runPreview('edited', '🎬 Preview of YOUR edit (10s) — the ' + nFrames +
+                                          '-frame bake follows; Alt+C cancels')) {
+            _cancelledOut('the edited-path preview');
+            return;
+          }
+        }
       } else {
         // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
         // literally the same object, so the film is byte-identical to one recorded without the

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -647,6 +647,64 @@
              z: B.right.z * dx + B.up.z * dy };
   }
 
+  // ══ §CPE_DRAG_TRACK — the lag, measured in the app, on every real gesture.
+  //
+  // §CPE_DRAG_SCALE gears the drag to the BUILDING (envelope/canvasHeight), not to the handle's
+  // distance from the camera. A constant rate equals the perspective rate at exactly one depth, so
+  // everywhere else the handle cannot land under the cursor. Measured by witness_cpe_drag_track.js
+  // on 2026-07-27: Duplex 0.071 m/px in force against 0.151 needed at the handle's 91m depth (the
+  // band landed 102px behind a 194px gesture), Terminal 0.097 against 0.219 at 132m (108px behind).
+  // Consistently 0.44-0.47x.
+  //
+  // USER RULING, 2026-07-27, shown those numbers — this is NOT a defect and must not be gated:
+  //   "I think it is fine.. the slight jump is no longer exagerated, it is in small measures so the
+  //    user able to hold and see it coming back quicker than before. I see the effect is the path
+  //    only follows after releasing the wypt which may still jump but in small leap which is more of
+  //    a feature as user need not drag further on fear of losing to big jump."
+  // The under-gearing IS the safety margin: half-speed means an overshoot is small and recoverable,
+  // which is the whole reason §CPE_DRAG_TELEPORT's big leaps were frightening in the first place.
+  //
+  // So this is a LOG, not a gate. It exists because a rate that drifts from ~0.45x — toward 1.0x
+  // (the leaps come back) or toward 0 (the drag stops responding) — is the shape of the next
+  // regression, and nothing else in the console would show it. Derived from the gesture's own
+  // pixels and the camera frustum, independent of how _dragBasis computed the rate, so it can
+  // contradict that code rather than merely echo it.
+  function _logDragTrack(d, b, len0) {
+    if (d.lx == null) return;                      // a press that never moved: nothing to measure
+    var a = A(), r = a.canvas.getBoundingClientRect();
+    var pix = Math.hypot(d.lx - d.sx0, d.ly - d.sy0);
+    if (pix < 1) return;
+    // How far the thing actually travelled. For 'mid' that is the centre; for an end drag the band
+    // rotates about its far end, so the moved end is centre +/- half the (rigid) length along dir.
+    var s = d.z === 'b' ? 1 : d.z === 'a' ? -1 : 0;
+    var now = { x: b.c.x + b.d.x * b.len / 2 * s, y: b.c.y + b.d.y * b.len / 2 * s, z: b.c.z + b.d.z * b.len / 2 * s };
+    var world = Math.hypot(now.x - d.p0.x, now.y - d.p0.y, now.z - d.p0.z);
+    // The rate that WOULD have kept the handle under the cursor: one pixel subtends
+    // 2*D*tan(fov/2)/H metres at the grabbed handle's depth D.
+    var D = Math.hypot(d.p0.x - a.camera.position.x, d.p0.y - a.camera.position.y, d.p0.z - a.camera.position.z);
+    var need = 2 * D * Math.tan(a.camera.fov * Math.PI / 180 / 2) / Math.max(1, r.height);
+    var got = world / pix;
+    var ratio = need > 0 ? got / need : 0;
+    // ── THE LEVER. User, 2026-07-27, describing what they actually feel: "Its like a lever effect.
+    // Move small length, it exagerates bigger but not jump as the path has not react yet until
+    // release." That is NOT the cursor->band gearing above (which is under-geared, 0.45x) — it is
+    // the SECOND stage: band -> re-derived path. A metre of band moves the walk by more than a
+    // metre, because the plan re-routes the whole leg around it. The two stages point opposite
+    // ways, which is precisely why the gesture feels safe and the result still feels big, and why
+    // measuring only one of them explains neither. Lever = metres of path per metre of band.
+    var lever = (len0 != null && _state.plan && world > 0.01)
+      ? (_state.plan.pathLen - len0) / world : null;
+    console.log('§CPE_DRAG_TRACK zone=' + d.z + ' gesture=' + pix.toFixed(0) + 'px moved=' + world.toFixed(2) +
+      'm rate=' + got.toFixed(4) + ' m/px vs cursor-lock ' + need.toFixed(4) + ' m/px at depth ' +
+      D.toFixed(0) + 'm — ratio=' + ratio.toFixed(2) + 'x' +
+      (d.z === 'mid' ? ' lag=' + (pix * (1 - ratio)).toFixed(0) + 'px' : ' (end drag: rigid length, rotation not translation)') +
+      ' — UNDER-GEARED BY DESIGN (user ruling 2026-07-27: small leaps are the feature). Watch for drift toward 1.00x.' +
+      ' | LEVER pathLen ' + (len0 == null ? '?' : len0.toFixed(1)) + 'm -> ' +
+      (_state.plan ? _state.plan.pathLen.toFixed(1) : '?') + 'm = ' +
+      (lever == null ? 'n/a' : (lever >= 0 ? '+' : '') + lever.toFixed(2) + 'm of path per metre of band') +
+      ' (the exaggeration; it lands ONCE, after release, never during the gesture)');
+  }
+
   function _wire() {
     var a = A(), c = a.canvas, h = {};
     h.down = function(ev) {
@@ -678,6 +736,7 @@
       var d = _state.drag, b = _state.bands[d.b];
       var dw = _dragDelta(ev, d);          // §CPE_DRAG_SCALE: pixels x a building-derived rate
       var p = { x: d.p0.x + dw.x, y: d.p0.y + dw.y, z: d.p0.z + dw.z };
+      d.lx = ev.clientX; d.ly = ev.clientY;   // §CPE_DRAG_TRACK reads the gesture's own last pixel
       // First real movement of this gesture = the edit is now happening; snapshot the pre-drag
       // state exactly once, before anything below mutates it.
       if (!d.snapped) { d.snapped = true; _undoPush('drag band ' + d.b + ' (' + d.z + ')'); }
@@ -733,7 +792,10 @@
       console.log('§CPE_DRAG landed band=' + d.b + ' zone=' + d.z + ' plane=view (re-plan runs NOW, once)' +
         ' centre=(' + b.c.x.toFixed(2) + ',' + b.c.y.toFixed(2) + ',' + b.c.z.toFixed(2) + ')' +
         ' dir=(' + b.d.x.toFixed(2) + ',' + b.d.y.toFixed(2) + ',' + b.d.z.toFixed(2) + ') len=' + b.len.toFixed(2));
-      _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
+      var _len0 = _state.plan ? _state.plan.pathLen : null;   // the path as it stood when you let go
+      _replanFilm();
+      _logDragTrack(d, b, _len0);
+      _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
     };
     // §CPE_UNDO: Ctrl+Z / Ctrl+Shift+Z (and Ctrl+Y) while the editor is OPEN. Same bindings
     // grid_drag.js already uses, and like it this listener is added on open and removed on close, so

--- a/witness_cpe_drag_track.js
+++ b/witness_cpe_drag_track.js
@@ -1,0 +1,222 @@
+// WITNESS — §CPE_DRAG_TRACK: does the handle stay under the cursor?
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_DRAG_SCALE / §CPE_DRAG_TRACK.
+//
+// THE ISSUE THIS PROVES OR DISPROVES (user, live on origin/main AFTER the merge, 2026-07-27):
+//   "i checked the last session solving the jumping waypoints, it is much better, as it delays the
+//    path but the wpts still jumpy but its more intuitive to handle"
+// §CPE_DRAG_LAND_FIRST landed ("it delays the path") and §CPE_BASIS_HALF_PIN landed, yet the drag
+// still does not feel exact. Both of those removed a re-plan running under the gesture; NEITHER
+// touched the pixels->metres mapping. §CPE_DRAG_SCALE replaced the old perspective mapping
+// (ray x plane-through-the-handle, world-m/px = handle depth / focal length) with a building-derived
+// constant:
+//       m/px = envelope / canvasHeightPx
+// That bought identical gearing across buildings, which is what it was asked for. But a constant
+// rate equals the perspective rate at exactly ONE depth. At any other depth the handle CANNOT stay
+// under the cursor — it lags or races — and cinema_path_editor.js's own §CPE_DRAG_REACH note states
+// the invariant it must not break: "Direct manipulation has ONE invariant: the thing you grabbed
+// stays under the cursor."
+//
+// So this witness measures the two properties against each other, in numbers, and does NOT assume
+// which one should win — that is the user's call and needs the numbers first:
+//
+//   G-TRACK-1  CURSOR LOCK — REPORT, NOT A GATE. Drag a band's middle by a known pixel delta, then
+//              re-project the band's landed centre to screen. Residual px = |projected - cursor|.
+//              Measured 2026-07-27: Duplex 102px behind a 194px gesture, Terminal 108px — 0.44-0.47x
+//              on both. Shown those numbers the user RULED it is not a defect:
+//                "I think it is fine.. the slight jump is no longer exagerated, it is in small
+//                 measures so the user able to hold and see it coming back quicker than before. I see
+//                 the effect is the path only follows after releasing the wypt which may still jump
+//                 but in small leap which is more of a feature as user need not drag further on fear
+//                 of losing to big jump."
+//              So this asserts only that the ratio stays in the band that ruling describes: drift to
+//              1.00x means §CPE_DRAG_TELEPORT's frightening leaps are back, drift to 0 means the drag
+//              has died. The app logs the same quantity live as §CPE_DRAG_TRACK, derived
+//              independently (gesture pixels + camera frustum), so the two can disagree.
+//   G-TRACK-2  OUT-AND-BACK. Drag out, drag back to the same pixel. The centre must return EXACTLY
+//              (the pure-delta invariant §CPE_DRAG_TELEPORT established). Independent of G-TRACK-1:
+//              a wrong-but-linear rate still returns exactly.
+//   G-TRACK-3  LANDING JUMP. The centre §CPE_DRAG logs on release (before _replanFilm) vs the centre
+//              the rows show after it. Any difference means the re-plan wrote back into the authored
+//              bands — the "jump after you let go" §CPE_HOLDER_INTEGRITY says cannot happen.
+//   G-TRACK-4  GEARING CONSISTENCY. m/px as a fraction of the building envelope, across buildings.
+//              Equal = what §CPE_DRAG_SCALE bought. Reported for the trade, not gated.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const BAND = parseInt(process.env.BAND || '1', 10);   // 1 = the walk band (the one the user drags)
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const num = (l, re) => { const m = l && l.match(re); return m ? parseFloat(m[1]) : null; };
+const last = (logs, re) => { const h = logs.filter(l => re.test(l)); return h.length ? h[h.length - 1] : null; };
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(500);
+  return { page, logs };
+}
+
+// The rows are the editor's own read-out of the authored band centres — [x, z, y, len].
+const readBand = (page, i) => page.evaluate(b => {
+  const ins = document.querySelectorAll('#cpe-rows > div')[b].querySelectorAll('input');
+  return { x: parseFloat(ins[0].value), z: parseFloat(ins[1].value), y: parseFloat(ins[2].value),
+           len: parseFloat(ins[3].value) };
+}, i);
+
+// Where a world point lands on screen, using the viewer's own camera and canvas rect — the same
+// projection cinema_path_editor.js's _screenOf uses to decide what the cursor grabbed.
+const screenOf = (page, p) => page.evaluate(pt => {
+  const A = window.APP, V3 = A.camera.position.constructor;
+  const v = new V3(pt.x, pt.y, pt.z).project(A.camera);
+  const r = A.canvas.getBoundingClientRect();
+  return { x: r.left + (v.x + 1) / 2 * r.width, y: r.top + (1 - v.y) / 2 * r.height,
+           behind: v.z > 1, depth: Math.hypot(pt.x - A.camera.position.x, pt.y - A.camera.position.y,
+                                              pt.z - A.camera.position.z) };
+}, p);
+
+// A real gesture on the canvas: pointerdown on the handle, N intermediate moves, pointerup. Driven
+// through the page's own event path (the listeners are on canvas/window, capture phase), so this is
+// the user's path, not a call into a private function.
+async function drag(page, from, steps) {
+  await page.evaluate(p => {
+    const c = window.APP.canvas;
+    c.dispatchEvent(new PointerEvent('pointerdown', { clientX: p.x, clientY: p.y, bubbles: true, cancelable: true }));
+  }, from);
+  await sleep(60);
+  for (const s of steps) {
+    await page.evaluate(p => {
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: p.x, clientY: p.y, bubbles: true, cancelable: true }));
+    }, s);
+    await sleep(30);
+  }
+  await page.evaluate(() => {
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true }));
+  });
+  await sleep(900);      // the ONE re-plan §CPE_DRAG_LAND_FIRST defers to here
+}
+
+// A straight gesture from `from` to `to`, in `n` steps — how a hand actually moves, not one teleport.
+const lerpSteps = (from, to, n) => Array.from({ length: n }, (_, i) => ({
+  x: from.x + (to.x - from.x) * (i + 1) / n,
+  y: from.y + (to.y - from.y) * (i + 1) / n,
+}));
+
+async function run(browser, BLD) {
+  const { page, logs } = await openEditor(browser, BLD);
+  const checks = [];
+  const R = {};
+
+  const c0 = await readBand(page, BAND);
+  const s0 = await screenOf(page, c0);
+  R.depth = s0.depth;
+
+  // ── G-TRACK-1: drag the middle by a known pixel delta, then see where the handle ended up.
+  const PIX = { dx: 160, dy: -110 };
+  const target = { x: s0.x + PIX.dx, y: s0.y + PIX.dy };
+  await drag(page, { x: s0.x, y: s0.y }, lerpSteps({ x: s0.x, y: s0.y }, target, 8));
+
+  const c1 = await readBand(page, BAND);
+  const landed = await screenOf(page, c1);
+  R.residualPx = Math.hypot(landed.x - target.x, landed.y - target.y);
+  R.pixLen = Math.hypot(PIX.dx, PIX.dy);
+  R.worldLen = Math.hypot(c1.x - c0.x, c1.y - c0.y, c1.z - c0.z);
+  R.mpp = R.worldLen / R.pixLen;
+
+  const grab = last(logs, /§CPE_DRAG_SCALE grab/);
+  R.env = num(grab, /envelope ([\d.]+)m/);
+  R.rateLogged = num(grab, /rate=([\d.]+) m\/px/);
+  // What the perspective mapping would have given: the rate that keeps the handle under the cursor.
+  // m/px at depth D for a vertical FOV f over H pixels = 2·D·tan(f/2) / H.
+  R.mppPerspective = await page.evaluate(d => {
+    const A = window.APP, r = A.canvas.getBoundingClientRect();
+    return 2 * d * Math.tan(A.camera.fov * Math.PI / 180 / 2) / r.height;
+  }, s0.depth);
+
+  // G-TRACK-1 is a REPORT, not a gate — see the ruling in the header. What it watches for is DRIFT:
+  // back toward 1.00x means the big leaps have returned, toward 0 means the drag has stopped
+  // responding. Both ends are bounded generously; the middle is where the user asked it to sit.
+  R.ratio = R.rateLogged / R.mppPerspective;
+  checks.push({ n: 'G-TRACK-1 the drag stays under-geared, in the band the user ruled for (report)',
+    ok: R.ratio > 0.20 && R.ratio < 0.85,
+    d: `gesture ${R.pixLen.toFixed(0)}px -> ${R.worldLen.toFixed(2)}m at ${R.mpp.toFixed(4)} m/px\n` +
+       `          handle landed ${R.residualPx.toFixed(1)}px from the cursor ` +
+       `(${(R.residualPx / R.pixLen * 100).toFixed(0)}% of the gesture) — the small, recoverable leap, by design\n` +
+       `          rate in force ${R.rateLogged} m/px (envelope ${R.env}m / 700px) vs ` +
+       `${R.mppPerspective.toFixed(4)} m/px needed at this handle's depth ${s0.depth.toFixed(0)}m ` +
+       `— ratio ${R.ratio.toFixed(2)}x (must stay in 0.20-0.85; 1.00x = the big leaps are back)\n` +
+       `          in-app: ${last(logs, /§CPE_DRAG_TRACK/) || '(no §CPE_DRAG_TRACK line — unpatched build)'}` });
+
+  // ── G-TRACK-3: what the release logged vs what the rows show after the re-plan ran.
+  const landedLog = last(logs, /§CPE_DRAG landed/);
+  const lc = landedLog && landedLog.match(/centre=\(([-\d.]+),([-\d.]+),([-\d.]+)\)/);
+  R.jump = lc ? Math.hypot(parseFloat(lc[1]) - c1.x, parseFloat(lc[2]) - c1.y, parseFloat(lc[3]) - c1.z) : null;
+  checks.push({ n: 'G-TRACK-3 the re-plan on release does not move the band you just placed',
+    ok: R.jump !== null && R.jump < 0.005,
+    d: `on release §CPE_DRAG logged centre=(${lc ? lc.slice(1, 4).join(',') : 'n/a'}), ` +
+       `after the re-plan the rows read (${c1.x},${c1.y},${c1.z}) — moved ${R.jump === null ? 'n/a' : R.jump.toFixed(4) + 'm'}` });
+
+  // ── G-TRACK-2: out and back to the very same pixel must return the band exactly.
+  const s1 = await screenOf(page, c1);
+  const away = { x: s1.x - 130, y: s1.y + 90 };
+  await drag(page, { x: s1.x, y: s1.y },
+    lerpSteps({ x: s1.x, y: s1.y }, away, 6).concat(lerpSteps(away, { x: s1.x, y: s1.y }, 6)));
+  const c2 = await readBand(page, BAND);
+  R.residue = Math.hypot(c2.x - c1.x, c2.y - c1.y, c2.z - c1.z);
+  checks.push({ n: 'G-TRACK-2 out-and-back to the same pixel leaves no residue',
+    ok: R.residue < 0.01,
+    d: `before (${c1.x},${c1.y},${c1.z}) -> after (${c2.x},${c2.y},${c2.z}) = ${R.residue.toFixed(4)}m residue`});
+
+  await page.close();
+  return { checks, R };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    // Hospital blocks the JS thread far longer than puppeteer's 180s default while it plans, and a
+    // blown protocolTimeout aborts the run mid-gate — which reads as a product failure and is not one.
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [], rates = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}  (band ${BAND})\n${'='.repeat(78)}`);
+    const { checks, R } = await run(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    rates.push({ BLD, R });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+
+  // G-TRACK-4 is a REPORT, not a gate: it is the thing the current mapping bought, stated next to
+  // what G-TRACK-1 says it cost, so the trade can be decided on numbers.
+  console.log(`\n${'='.repeat(78)}\nG-TRACK-4 gearing across buildings (report, not a gate)`);
+  rates.forEach(({ BLD, R }) => console.log(
+    `  ${BLD.padEnd(10)} envelope ${String(R.env).padStart(6)}m  rate ${R.rateLogged} m/px  ` +
+    `= ${(R.rateLogged / R.env * 700 * 100).toFixed(1)}% of envelope per screen-height  ` +
+    `| perspective rate here ${R.mppPerspective.toFixed(4)} m/px (depth ${R.depth.toFixed(0)}m)  ` +
+    `| cursor residual ${R.residualPx.toFixed(1)}px`));
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_preview_after.js
+++ b/witness_cpe_preview_after.js
@@ -1,0 +1,211 @@
+// WITNESS — §CPE_PREVIEW_AFTER: you get to see the film you edited, before it bakes.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md ask 5.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user's own console, 2026-07-27, and their ask):
+// The 10s rehearsal ran ONCE, BEFORE the editor opened — so it showed the DERIVED path, the one film
+// you already knew you did not want, which is why you opened the editor at all. The film you then
+// authored went straight into a ten-minute bake completely unseen. Their log shows the gap exactly:
+//     §CPE_CLOSE -> §CPE_APPLIED -> §MAXQ_FRAME i=0        (no second §MAXQ_PREVIEW anywhere)
+//
+//   G-PA-1  a second preview exists, and it is in the right place — §MAXQ_PREVIEW phase=edited
+//           strictly AFTER §CPE_APPLIED and strictly BEFORE the first §MAXQ_FRAME. RED on
+//           origin/main by construction: there is only one preview there.
+//   G-PA-2  it flies the EDITED film, not a re-run of the derived one. Both previews are sampled
+//           from the LIVE camera at matched tNorm; after a real edit the two streams must separate.
+//           A second preview that merely replayed the old path would pass G-PA-1 and fail here.
+//   G-PA-3  it flies the same poseAt the BAKE does. The bake's first frame is poseAt(0); the edited
+//           preview's first sample is poseAt(0) of whatever plan it flew. Same plan => same point.
+//           This is the §CPE_PREVIEW_DIVERGENCE property, re-asserted for the new preview.
+//   G-PA-4  guardrail 2 is intact: an UNTOUCHED OK gets exactly ONE preview. The promise is "the
+//           default cost of this feature is one click and nothing else" — a second 10s rehearsal
+//           proving nothing changed would break it, so this gate fails if the preview is
+//           unconditional rather than edit-only.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const idx = (logs, re) => logs.findIndex(l => re.test(l.text));
+// A build predating §CPE_PREVIEW_AFTER logs '§MAXQ_PREVIEW start 10s ...' with no phase= at all.
+// Read that as the derived phase rather than as "no preview": the RED must name the property that
+// is genuinely missing (there is no EDITED preview) and must not also fail gates the old build
+// actually satisfies — guardrail 2 was already intact there, and a gate that lies about which
+// property broke is worse than no gate.
+const phaseOf = l => { const m = l.text.match(/phase=(\w+)/); return m ? m[1] : 'derived'; };
+const isPreviewStart = l => /§MAXQ_PREVIEW start/.test(l.text);
+
+async function openViewer(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push({ t: Date.now(), text: m.text() }));
+  page.on('pageerror', e => logs.push({ t: Date.now(), text: 'PAGEERROR ' + e.message }));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  return { page, logs };
+}
+
+// The live camera, in Node time, so samples and console lines share one clock and the phases can be
+// cut apart afterwards. This is the real object state the FUNDAMENTAL LAW asks for — position read
+// off the camera itself, never a picture of it.
+function startSampling(page, out) {
+  let stop = false;
+  (async () => {
+    while (!stop) {
+      try {
+        const p = await page.evaluate(() => {
+          const c = window.APP.camera, t = window.APP.controls.target;
+          return { x: c.position.x, y: c.position.y, z: c.position.z, tx: t.x, ty: t.y, tz: t.z };
+        });
+        out.push({ t: Date.now(), p });
+      } catch (e) { /* page busy inside a blocking plan — skip this tick */ }
+      await sleep(110);
+    }
+  })();
+  return () => { stop = true; };
+}
+
+const between = (samples, t0, t1) => samples.filter(s => s.t >= t0 && s.t <= t1).map(s => s.p);
+// Resample a pose stream onto n evenly spaced points so two runs of unequal sample count compare.
+function resample(stream, n) {
+  if (stream.length < 2) return null;
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const u = i / (n - 1) * (stream.length - 1);
+    const a = stream[Math.floor(u)], b = stream[Math.min(stream.length - 1, Math.ceil(u))], f = u - Math.floor(u);
+    out.push({ x: a.x + (b.x - a.x) * f, y: a.y + (b.y - a.y) * f, z: a.z + (b.z - a.z) * f });
+  }
+  return out;
+}
+const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+
+// One full run: open the editor, optionally edit, OK, and watch what happens next.
+async function run(browser, BLD, edit) {
+  const { page, logs } = await openViewer(browser, BLD);
+  const samples = [];
+  const stopSampling = startSampling(page, samples);
+
+  // fps:1 keeps the bake cheap — this witness only needs its first frames, not a finished film.
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: true, fps: 1 }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(500);
+
+  if (edit) {
+    // A big, unmistakable edit on the walk band: +12m of x. Small nudges can leave the re-derived
+    // film close enough to the original that G-PA-2 could not tell a real preview from a replay.
+    await page.evaluate(() => {
+      const xIn = document.querySelectorAll('#cpe-rows > div')[1].querySelectorAll('input')[0];
+      xIn.value = (parseFloat(xIn.value) + 12).toFixed(2);
+      xIn.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await sleep(1200);
+  }
+
+  await page.evaluate(() => document.getElementById('cpe-ok').click());
+  await page.waitForFunction(() => !document.getElementById('cpe-ok'), { timeout: 60000 });
+  // Long enough for a whole 10s preview plus the first bake frames to land.
+  await page.waitForFunction(() => true, { timeout: 5000 }).catch(() => {});
+  // Terminal-sized buildings take well past 60s to stage and converge their first frame under
+  // swiftshader; a short wait made G-PA-3 report a product failure when the bake simply had not
+  // reached frame 0 yet (observed 2026-07-27, Terminal, iFrame0=-1).
+  for (let i = 0; i < 300 && idx(logs, /§MAXQ_FRAME i=/) < 0; i++) await sleep(1000);
+  await sleep(1500);
+
+  stopSampling();
+  try { await page.evaluate(() => { window.APP.cancelMaxQualityOrbit && window.APP.cancelMaxQualityOrbit(); }); } catch (e) {}
+  await sleep(300);
+  await page.close();
+  return { logs, samples };
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+
+  const { logs, samples } = await run(browser, BLD, true);
+
+  const iApplied = idx(logs, /§CPE_APPLIED total=/);
+  const iFrame0  = idx(logs, /§MAXQ_FRAME i=/);
+  const previews = logs.filter(isPreviewStart);
+  const iEdited  = idx(logs, /§MAXQ_PREVIEW start phase=edited/);
+
+  P('G-PA-1 a second preview runs, after §CPE_APPLIED and before the first baked frame',
+    iEdited > 0 && iApplied > 0 && iEdited > iApplied && (iFrame0 < 0 || iEdited < iFrame0),
+    `previews=${previews.length} [${previews.map(phaseOf).join(', ')}]  ` +
+    `§CPE_APPLIED@${iApplied}  §MAXQ_PREVIEW(edited)@${iEdited}  §MAXQ_FRAME i=0@${iFrame0}`);
+
+  // Cut the two preview windows out of the sample stream using the phase log lines as boundaries.
+  const at = re => { const h = logs.find(l => re.test(l.text)); return h ? h.t : null; };
+  const dStart = at(/§MAXQ_PREVIEW start/), dEnd = at(/§MAXQ_PREVIEW done/);
+  const eStart = at(/§MAXQ_PREVIEW start phase=edited/),  eEnd = at(/§MAXQ_PREVIEW done phase=edited/);
+  const D = dStart && dEnd ? resample(between(samples, dStart, dEnd), 20) : null;
+  const E = eStart && eEnd ? resample(between(samples, eStart, eEnd), 20) : null;
+
+  let maxSep = null, dLen = null, eLen = null;
+  if (D && E) {
+    maxSep = Math.max(...D.map((d, i) => dist(d, E[i])));
+    const pathLen = s => s.slice(1).reduce((a, p, i) => a + dist(p, s[i]), 0);
+    dLen = pathLen(D); eLen = pathLen(E);
+  }
+  P('G-PA-2 the second preview flies the EDITED film, not a replay of the derived one',
+    maxSep !== null && maxSep > 1.0 && eLen > 1.0,
+    `derived preview ${D ? D.length : 0} samples, travelled ${dLen === null ? 'n/a' : dLen.toFixed(1) + 'm'}\n` +
+    `          edited  preview ${E ? E.length : 0} samples, travelled ${eLen === null ? 'n/a' : eLen.toFixed(1) + 'm'}\n` +
+    `          max separation at matched tNorm = ${maxSep === null ? 'n/a' : maxSep.toFixed(2) + 'm'} (must be > 1.0m after a 12m band edit)`);
+
+  // The bake's first frame is poseAt(0). The edited preview's first sample is poseAt(0) of whatever
+  // plan IT flew. Same number => one plan, which is the §CPE_PREVIEW_DIVERGENCE property.
+  const tFrame0 = iFrame0 >= 0 ? logs[iFrame0].t : null;
+  const bakeFirst = tFrame0 ? between(samples, eEnd || 0, tFrame0 + 1200)[0] : null;
+  const editFirst = E ? E[0] : null;
+  const gap = bakeFirst && editFirst ? dist(bakeFirst, editFirst) : null;
+  // If the bake never reached frame 0 inside the wait, say so — an unobserved bake is not evidence
+  // either way, and reporting it as a failed comparison would be a false accusation against the code.
+  P('G-PA-3 the edited preview and the bake fly the same plan (poseAt(0) agrees)' +
+    (tFrame0 === null ? ' — INCONCLUSIVE, no bake frame observed' : ''),
+    tFrame0 === null ? false : (gap !== null && gap < 2.0),
+    `edited preview started at (${editFirst ? [editFirst.x, editFirst.y, editFirst.z].map(v => v.toFixed(1)).join(',') : 'n/a'}), ` +
+    `bake's first frame at (${bakeFirst ? [bakeFirst.x, bakeFirst.y, bakeFirst.z].map(v => v.toFixed(1)).join(',') : 'n/a'}) ` +
+    `— ${gap === null ? 'n/a' : gap.toFixed(2) + 'm apart'}`);
+
+  // Guardrail 2: OK with no edit must not cost a second 10 seconds.
+  const r2 = await run(browser, BLD, false);
+  const prev2 = r2.logs.filter(isPreviewStart);
+  P('G-PA-4 an untouched OK still gets exactly ONE preview (guardrail 2: one click, nothing else)',
+    prev2.length === 1 && phaseOf(prev2[0]) === 'derived',
+    `${prev2.length} preview(s): [${prev2.map(phaseOf).join(', ')}]  ` +
+    `— ${r2.logs.some(l => /§CPE_APPLIED none/.test(l.text)) ? '§CPE_APPLIED none (plan object re-used)' : 'no §CPE_APPLIED none line'}`);
+
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_preview_divergence.js
+++ b/witness_cpe_preview_divergence.js
@@ -18,6 +18,19 @@
 //      not at all on the bands, so it isolates the camera basis from the edit itself.
 //   P3 no-move regression — a session where the camera never moves must be unaffected (the basis
 //      then IS the live camera). Same three numbers, editor vs bake, on an untouched camera.
+//
+// §CPE_BASIS_HALF_PIN — P4, THE ROTATION GATE (2026-07-27). P1-P3 were 3/3 both BEFORE and AFTER
+// the half-pin fix, so they could not see it: they only ever DOLLY the camera, and the half pin
+// pinned POSITION and TARGET correctly. What it never pinned was the camera's ROTATION, and
+// yaw0/pitch0 come from A.camera.getWorldDirection(). A dolly along the view axis leaves the
+// rotation alone, so the blind spot is exactly "the user ORBITED while the editor was open" — the
+// gesture they actually make. Measured in their Hospital log, one session, one edit:
+//     editing: yaw0=-88.9 pitch0=-16.9  exit facingDot=+0.456  spin  -35.3 deg
+//     baking : yaw0=+91.5 pitch0=-81.0  exit facingDot=-0.450  spin +504.3 deg class=behind(full-lap)
+// A different exit door and a full extra lap.
+//   P4 orbit (not dolly) mid-edit, then compare the editor's LAST plan with the BAKE's on the four
+//      quantities the rotation actually drives: yaw0, pitch0, the chosen exit GUID, finalSpinDeg.
+//      RED without the `c.lookAt(basis)` half of the pin, GREEN with it.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8402;
@@ -27,6 +40,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 const pivotOf = l => { const m = l && l.match(/src=(\S+) pivot=\(([^)]*)\)/); return m ? m[1] + ' @' + m[2] : null; };
 const diveOf  = l => { const m = l && l.match(/diveDist=([\d.]+)m/); return m ? m[1] : null; };
 const spinOf  = l => { const m = l && l.match(/finalSpinDeg=([\d.-]+)/); return m ? m[1] : null; };
+// P4's four: the quantities a ROTATION drives and a dolly does not.
+const yawOf   = l => { const m = l && l.match(/yaw0=(-?[\d.]+)°/);   return m ? m[1] : null; };
+const pitchOf = l => { const m = l && l.match(/pitch0=(-?[\d.]+)°/); return m ? m[1] : null; };
+const exitOf  = l => { const m = l && l.match(/§CINEMA_EXIT chosen=(\S+)/); return m ? m[1] : null; };
 const last = (logs, re) => { const h = logs.filter(l => re.test(l)); return h.length ? h[h.length - 1] : null; };
 
 async function openViewer(browser, BLD) {
@@ -48,13 +65,18 @@ async function openViewer(browser, BLD) {
   return { page, logs };
 }
 
-// One editor session. `dolly` true → move the camera hard toward the target mid-edit, which is what
-// orbiting/zooming in to inspect a band does, and what flipped the user's plausibility test.
-async function session(browser, BLD, dolly) {
+// One editor session. `move` is the gesture made mid-edit:
+//   'dolly'  → drive the camera hard toward the target (zooming in to inspect a band). Changes
+//              POSITION only — what P1/P2/P3 exercise, and what the half pin already covered.
+//   'orbit'  → swing the camera around the target and re-aim it, i.e. a real orbit drag. Changes
+//              the camera's ROTATION, which is what P4 exists to catch.
+//   'none'   → the camera is never touched (P3's regression control).
+async function session(browser, BLD, move) {
   const { page, logs } = await openViewer(browser, BLD);
   // BLOCK body: a concise arrow would return the bake promise and evaluate() would await the cook.
   await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
-  await page.waitForSelector('#cpe-ok', { timeout: 120000 });
+  // Hospital's first plan (room graph + raycast fan) does not finish inside 120s under swiftshader.
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
   await sleep(500);
 
   const pivotsAtOpen = logs.filter(l => /§CINEMA_PIVOT/.test(l)).length;
@@ -70,18 +92,41 @@ async function session(browser, BLD, dolly) {
   await sleep(500);
 
   let camMoved = null;
-  if (dolly) {
+  if (move === 'dolly') {
     camMoved = await page.evaluate(() => {
       const A = window.APP, c = A.camera, t = A.controls.target;
       const before = Math.hypot(c.position.x - t.x, c.position.y - t.y, c.position.z - t.z);
-      // 75% of the way to the target — a big, unambiguous "I orbited in to look at this band".
+      // 75% of the way to the target — a big, unambiguous "I zoomed in to look at this band".
       c.position.set(c.position.x + (t.x - c.position.x) * 0.75,
                      c.position.y + (t.y - c.position.y) * 0.75,
                      c.position.z + (t.z - c.position.z) * 0.75);
       A.controls.update();
       const after = Math.hypot(c.position.x - t.x, c.position.y - t.y, c.position.z - t.z);
-      return { before: before.toFixed(1), after: after.toFixed(1) };
+      return { what: 'dollied', before: before.toFixed(1) + 'm', after: after.toFixed(1) + 'm from target' };
     });
+  } else if (move === 'orbit') {
+    camMoved = await page.evaluate(() => {
+      const A = window.APP, c = A.camera, t = A.controls.target;
+      const deg = d => (d * 180 / Math.PI).toFixed(1);
+      // Reuse the camera's own vector class rather than reaching for a global THREE, which the
+      // viewer does not necessarily expose on window.
+      const V3 = c.position.constructor;
+      const d0 = c.getWorldDirection(new V3());
+      const before = deg(Math.atan2(d0.z, d0.x)) + '°/' + deg(Math.asin(Math.max(-1, Math.min(1, d0.y)))) + '°';
+      // A 140° azimuth swing plus a big elevation change, about the orbit target — exactly what
+      // dragging with the left mouse button does. Distance to target is preserved.
+      const dx = c.position.x - t.x, dy = c.position.y - t.y, dz = c.position.z - t.z;
+      const a = 140 * Math.PI / 180;
+      const nx = dx * Math.cos(a) - dz * Math.sin(a);
+      const nz = dx * Math.sin(a) + dz * Math.cos(a);
+      c.position.set(t.x + nx, t.y + dy * 0.25, t.z + nz);
+      A.controls.update();      // OrbitControls re-aims the camera at the target — the ROTATION changes
+      const d1 = c.getWorldDirection(new V3());
+      const after = deg(Math.atan2(d1.z, d1.x)) + '°/' + deg(Math.asin(Math.max(-1, Math.min(1, d1.y)))) + '°';
+      return { what: 'orbited', before: 'yaw/pitch ' + before, after: after };
+    });
+  }
+  if (camMoved) {
     await sleep(200);
     await keyY(1.0);            // re-plan WITH the moved camera
     await sleep(500);
@@ -90,6 +135,7 @@ async function session(browser, BLD, dolly) {
   const editPivot = last(logs, /§CINEMA_PIVOT/);
   const editDive  = last(logs, /§CINEMA_DIVE /);
   const editSpin  = last(logs, /§CINEMA_SPIN /);
+  const editExit  = last(logs, /§CINEMA_EXIT chosen=/);
   const pivotsWhileEditing = logs.filter(l => /§CINEMA_PIVOT/.test(l)).slice(pivotsAtOpen - 1);
 
   await page.evaluate(() => document.getElementById('cpe-ok').click());
@@ -100,16 +146,21 @@ async function session(browser, BLD, dolly) {
   const bakePivot = last(afterClose, /§CINEMA_PIVOT/);
   const bakeDive  = last(afterClose, /§CINEMA_DIVE /);
   const bakeSpin  = last(afterClose, /§CINEMA_SPIN /);
+  const bakeExit  = last(afterClose, /§CINEMA_EXIT chosen=/);
 
   try { await page.evaluate(() => { window.APP.startMaxQualityOrbit(); }); } catch (e) {}
   await sleep(400);
   await page.close();
-  return { logs, camMoved, editPivot, editDive, editSpin, bakePivot, bakeDive, bakeSpin, pivotsWhileEditing };
+  return { logs, camMoved, editPivot, editDive, editSpin, editExit,
+           bakePivot, bakeDive, bakeSpin, bakeExit, pivotsWhileEditing };
 }
 
 (async () => {
   const browser = await puppeteer.launch({
     headless: 'new',
+    // Hospital blocks the JS thread far longer than puppeteer's 180s default while it plans, and a
+    // blown protocolTimeout aborts the run mid-gate — which reads as a product failure and is not one.
+    protocolTimeout: 900000,
     args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
   });
   let allPass = true;
@@ -120,7 +171,7 @@ async function session(browser, BLD, dolly) {
     const checks = [];
     const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
 
-    const r = await session(browser, BLD, true);
+    const r = await session(browser, BLD, 'dolly');
 
     const same = (a, b, f) => f(a) !== null && f(a) === f(b);
     const p1 = same(r.editPivot, r.bakePivot, pivotOf) &&
@@ -128,7 +179,7 @@ async function session(browser, BLD, dolly) {
                same(r.editSpin, r.bakeSpin, spinOf);
     P('P1 the last EDITED plan and the BAKED plan agree on pivot, diveDist and spin',
       p1,
-      `camera dollied ${r.camMoved ? r.camMoved.before + 'm -> ' + r.camMoved.after + 'm from target' : '(not moved)'} mid-edit\n` +
+      `camera ${r.camMoved ? r.camMoved.what + ' ' + r.camMoved.before + ' -> ' + r.camMoved.after : '(not moved)'} mid-edit\n` +
       `          editor: pivot=${pivotOf(r.editPivot)} dive=${diveOf(r.editDive)}m spin=${spinOf(r.editSpin)}deg\n` +
       `          bake:   pivot=${pivotOf(r.bakePivot)} dive=${diveOf(r.bakeDive)}m spin=${spinOf(r.bakeSpin)}deg`);
 
@@ -139,12 +190,26 @@ async function session(browser, BLD, dolly) {
       `          ${uniq.join('\n          ')}\n` +
       `          ${last(r.logs, /§CPE_CAM_BASIS/) || '(no §CPE_CAM_BASIS line — unpatched build)'}`);
 
-    const r2 = await session(browser, BLD, false);
+    const r2 = await session(browser, BLD, 'none');
     P('P3 no-move regression: an untouched camera still agrees editor-vs-bake',
       same(r2.editPivot, r2.bakePivot, pivotOf) && same(r2.editDive, r2.bakeDive, diveOf) &&
         same(r2.editSpin, r2.bakeSpin, spinOf),
       `editor: pivot=${pivotOf(r2.editPivot)} dive=${diveOf(r2.editDive)}m spin=${spinOf(r2.editSpin)}deg\n` +
       `          bake:   pivot=${pivotOf(r2.bakePivot)} dive=${diveOf(r2.bakeDive)}m spin=${spinOf(r2.bakeSpin)}deg`);
+
+    // P4 — the rotation gate. Same comparison, but the mid-edit gesture is an ORBIT, and the four
+    // quantities compared are the ones a rotation drives. P1's three (pivot/dive/spin) are blind to
+    // it because the half pin already held position and target.
+    const r4 = await session(browser, BLD, 'orbit');
+    const fmt4 = (dv, ex, sp) =>
+      `yaw0=${yawOf(dv)}° pitch0=${pitchOf(dv)}° exit=${exitOf(ex)} spin=${spinOf(sp)}deg`;
+    const p4 = same(r4.editDive, r4.bakeDive, yawOf) && same(r4.editDive, r4.bakeDive, pitchOf) &&
+               same(r4.editExit, r4.bakeExit, exitOf) && same(r4.editSpin, r4.bakeSpin, spinOf);
+    P('P4 ORBITING mid-edit does not change the film (yaw0, pitch0, exit GUID, finalSpinDeg agree)',
+      p4,
+      `camera ${r4.camMoved ? r4.camMoved.what + ' ' + r4.camMoved.before + ' -> ' + r4.camMoved.after : '(not moved)'} mid-edit\n` +
+      `          editor: ${fmt4(r4.editDive, r4.editExit, r4.editSpin)}\n` +
+      `          bake:   ${fmt4(r4.bakeDive, r4.bakeExit, r4.bakeSpin)}`);
 
     checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
     summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });


### PR DESCRIPTION
Three things, all witnessed, all from the user's live reports today.

## §CPE_PREVIEW_AFTER — a preview of the film you actually edited (their one remaining ask)
The 10s rehearsal ran once, **before** the editor opened, so it showed the derived path — the film you already knew you didn't want. What you authored went straight to a ten-minute bake unseen. One preview implementation, two call sites; the second reads the same `poseAt` the bake steps, so it cannot drift from what gets rendered. Runs only when the path was really edited, so an untouched OK still costs one click and nothing else.

`witness_cpe_preview_after.js` — Duplex 4/4, RED on `main` (1/4, and it fails only on the property that is genuinely missing).

## P4 — the rotation gate §CPE_BASIS_HALF_PIN never had
P1–P3 were 3/3 both before *and* after that fix because they only ever **dolly** the camera, and the half pin already held position and target. It never held **rotation**, which is where `yaw0`/`pitch0` come from. P4 **orbits** mid-edit instead.

| build | result |
|---|---|
| half-pin | **FAIL 3/4** — editor `yaw0=5.0 spin=-500.6`, bake `yaw0=-135.0 spin=0.0`, different exit door |
| fixed | **PASS 4/4** — identical on all four |

The RED signature reproduces the user's live Hospital report exactly: a different exit and a full extra lap.

## §CPE_DRAG_TRACK — the lever, measured
Their report: "much better ... but the wpts still jumpy", then "Its like a lever effect. Move small length, it exagerates bigger". Two stages pull opposite ways, and measuring either alone explains neither:

- cursor → band: **0.47×** (Duplex), 0.44× (Terminal) — under-geared
- band → path: **+1.98 m of path per metre of band** — the lever

Ruled by the user as a feature, not a defect (small leaps are recoverable; the canvas overlay makes XY-plane dragging hard, so amplification saves gesture). So it **logs, it does not gate** — derived in-app from the gesture's pixels and the camera frustum, independent of `_dragBasis`, so it can contradict that code rather than echo it. The witness check is demoted to a drift report (0.20–0.85×; 1.00× means the frightening leaps are back).

Also confirms §CPE_DRAG_LAND_FIRST is clean — out-and-back residue `0.0000 m`, re-plan moves the placed band `0.0000 m` — which is what they felt as "the wypt jerk is gone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)