### PR TITLE
fix(maxq): hidden-tab pause + §PHOTO_EMBER/§PHOTO_BLOOM + night-mode luminaire fixes

### DIFF
--- a/probe_allout.js
+++ b/probe_allout.js
@@ -1,0 +1,36 @@
+// PROBE — §PHOTO_EMBER + §PHOTO_BLOOM through the REAL Alt+S path (A.startStillRefine), not by
+// poking materials from outside. Same Alt+C pose, before and after, measured.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs=require('fs'), path=require('path');
+const PORT=process.env.PORT||8403, OUT='/tmp/ember_out';
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+(async()=>{
+  fs.mkdirSync(OUT,{recursive:true});
+  const b=await puppeteer.launch({headless:'new',protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p=await b.newPage(); await p.setViewport({width:1280,height:720});
+  const logs=[]; p.on('console',m=>logs.push(m.text())); p.on('pageerror',e=>logs.push('PAGEERROR '+e.message));
+  await p.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Clinic_extracted.db`,{waitUntil:'domcontentloaded',timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.startStillRefine&&window.APP._composer,{timeout:180000});
+  await sleep(12000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const want=await p.evaluate(()=>(window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(x=>/Architectural|Electrical/i.test(x)).sort());
+  for(const bb of want){ await p.evaluate(x=>{try{window.APP.streamBuilding(x);}catch(e){}},bb);
+    let prev=-1; for(let i=0;i<60;i++){const n=await p.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+  const pose=await p.evaluate(()=>{const q=window.APP.cinemaPathPlan(30).poseAt(0.60);return{x:q.x,y:q.y,z:q.z,tx:q.tx,ty:q.ty,tz:q.tz};});
+  await p.evaluate(q=>{const A=window.APP;A.camera.position.set(q.x,q.y,q.z);A.controls.target.set(q.tx,q.ty,q.tz);A.controls.update();A.markDirty&&A.markDirty();},pose);
+  const exposure=await p.evaluate(()=>window.APP.renderer.toneMappingExposure);
+  await sleep(2500);
+  const navShot=path.join(OUT,'allout_1_nav.png'); await p.screenshot({path:navShot});
+  await p.evaluate(()=>window.APP.startStillRefine());
+  for(let i=0;i<200 && await p.evaluate(()=>!!window.APP._stillRefineBusy);i++) await sleep(500);
+  await sleep(2500);
+  const stillShot=path.join(OUT,'allout_2_still_ember_bloom.png'); await p.screenshot({path:stillShot});
+  const bloomOn=await p.evaluate(()=>!!(window.APP._bloomPass&&window.APP._bloomPass.enabled));
+  await p.evaluate(()=>window.APP.stopStillRefine(true)); await sleep(2000);
+  const afterShot=path.join(OUT,'allout_3_after_restore.png'); await p.screenshot({path:afterShot});
+  await b.close();
+  console.log('exposure', exposure, '| bloom enabled during still:', bloomOn);
+  console.log(logs.filter(l=>/PHOTO_EMBER|PHOTO_BLOOM|LOAD_FAIL|PAGEERROR|BloomPass/.test(l)).join('\n')||'(no §PHOTO_EMBER lines)');
+  console.log('stills:\n  '+navShot+'\n  '+stillShot+'\n  '+afterShot);
+})();

--- a/probe_disc.js
+++ b/probe_disc.js
@@ -1,0 +1,27 @@
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+(async () => {
+  const b = await puppeteer.launch({ headless:'new', protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p = await b.newPage();
+  const logs=[]; p.on('console',m=>logs.push(m.text()));
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db', {waitUntil:'domcontentloaded', timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.startStillRefine, {timeout:180000});
+  await sleep(20000);
+  const out = await p.evaluate(() => {
+    const A=window.APP;
+    const guids=Object.values(A.guidMap);
+    const uniq=[...new Set(guids)];
+    // what disciplines / classes are actually in the scene?
+    const q = (sql)=>{try{return A.dbQuery(sql)||[];}catch(e){return [['ERR '+e.message]];}};
+    const inList = uniq.slice(0,4000).map(g=>"'"+g+"'").join(',');
+    const disc = q("SELECT discipline, COUNT(*) FROM elements_meta WHERE guid IN ("+inList+") GROUP BY discipline ORDER BY 2 DESC");
+    const allDisc = q("SELECT discipline, COUNT(*) FROM elements_meta GROUP BY discipline ORDER BY 2 DESC");
+    return { guidMapUnique: uniq.length, inSceneByDiscipline: disc, wholeBuildingByDiscipline: allDisc,
+             streamedCount: A.streamedCount, hasInstances: !!A._instanceMeta };
+  });
+  console.log(JSON.stringify(out,null,1));
+  console.log('--- streaming/discipline log lines ---');
+  console.log(logs.filter(l=>/STREAM|DISCIPLINE|§CONTRACT|ELEC|budget|LOD/i.test(l)).slice(0,14).join('\n'));
+  await b.close();
+})();

--- a/probe_ember_bright.js
+++ b/probe_ember_bright.js
@@ -1,0 +1,71 @@
+// PROBE — §PHOTO_EMBER part 2: is "too dark drab" the EXPOSURE, the emissive, or both?
+// User: "Can we get light to emit from those fixtures. Scene still too dark drab."
+//
+// Three renders at ONE Alt+C pose, changing one thing at a time, so the answer is attributable:
+//   A  as-shipped                     (toneMappingExposure 0.45)
+//   B  exposure raised to 1.0         (nothing else touched)
+//   C  exposure 1.0 + luminaires emissive
+// scene.js:103 ships 0.45 against three.js's default of 1.0, so A vs B tests the cheapest possible
+// explanation before anything is built. B vs C tests whether emission adds anything once the frame
+// is correctly exposed — the previous probe measured it as invisible at 0.45.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs = require('fs'); const path = require('path');
+const PORT = process.env.PORT || 8403, OUT = '/tmp/ember_out';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const LUM = ['light','troffer','downlight','luminaire','lamp','sconce','pendant'];
+const NOT = ['switch','receptacle','panelboard','socket','outlet'];
+
+(async () => {
+  fs.mkdirSync(OUT, { recursive: true });
+  const browser = await puppeteer.launch({ headless:'new', protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  page.on('pageerror', e => console.log('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Clinic_extracted.db`, {waitUntil:'domcontentloaded', timeout:60000});
+  await page.waitForFunction(()=>window.APP&&window.APP.startStillRefine&&window.APP._composer,{timeout:180000});
+  await sleep(12000);
+  await page.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+
+  const want = await page.evaluate(()=> (window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(b=>/Architectural|Electrical/i.test(b)).sort());
+  for (const b of want) {
+    await page.evaluate(bb=>{try{window.APP.streamBuilding(bb);}catch(e){}}, b);
+    let prev=-1; for(let i=0;i<60;i++){const n=await page.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+
+  const pose = await page.evaluate(()=>{ const p=window.APP.cinemaPathPlan(30).poseAt(0.60); return {x:p.x,y:p.y,z:p.z,tx:p.tx,ty:p.ty,tz:p.tz}; });
+  await page.evaluate(p=>{const A=window.APP;A.camera.position.set(p.x,p.y,p.z);A.controls.target.set(p.tx,p.ty,p.tz);A.controls.update();A.markDirty&&A.markDirty();}, pose);
+  const shipped = await page.evaluate(()=>window.APP.renderer.toneMappingExposure);
+
+  async function shoot(tag){
+    await page.evaluate(()=>{ if(window.APP._stillRefineActive) window.APP.stopStillRefine(true); });
+    await sleep(600);
+    await page.evaluate(()=>window.APP.startStillRefine());
+    for(let i=0;i<120 && await page.evaluate(()=>!!window.APP._stillRefineBusy);i++) await sleep(500);
+    await sleep(1500);
+    const f=path.join(OUT,`bright_${tag}.png`); await page.screenshot({path:f}); return f;
+  }
+  const files={};
+  files.A = await shoot('A_shipped_exp' + String(shipped).replace('.',''));
+
+  await page.evaluate(()=>{ window.APP.renderer.toneMappingExposure = 1.0; window.APP.markDirty&&window.APP.markDirty(); });
+  files.B = await shoot('B_exposure10');
+
+  const lit = await page.evaluate((L,N)=>{
+    const A=window.APP;
+    const like=(w,j)=>w.map(x=>"lower(element_name) LIKE '%"+x+"%'").join(j);
+    const rows=A.dbQuery("SELECT guid FROM elements_meta WHERE ("+like(L,' OR ')+") AND NOT ("+like(N,' OR ')+")")||[];
+    const want=new Set(rows.map(r=>r[0])), ids=new Set();
+    Object.keys(A.guidMap).forEach(k=>{ if(want.has(A.guidMap[k])) ids.add(parseInt(String(k).split('_')[0],10)); });
+    const seen=new Set(); let mats=0;
+    A.collectMeshes(o=>o.isMesh).forEach(o=>{ if(!ids.has(o.id))return;
+      (Array.isArray(o.material)?o.material:[o.material]).forEach(m=>{ if(!m||!m.emissive||seen.has(m.uuid))return; seen.add(m.uuid); mats++;
+        m.emissive.setHex(0xfff2d0); m.emissiveIntensity=3.0; m.toneMapped=false; m.needsUpdate=true; }); });
+    return { fixtures: rows.length, materials: mats };
+  }, LUM, NOT);
+  files.C = await shoot('C_exposure10_emissive');
+
+  await browser.close();
+  console.log(`\nshipped toneMappingExposure = ${shipped}   (three.js default is 1.0)`);
+  console.log(`emissive applied to ${lit.materials} materials covering ${lit.fixtures} luminaires\n`);
+  Object.entries(files).forEach(([k,v])=>console.log(`  ${k}  ${v}`));
+})();

--- a/probe_ember_clinic.js
+++ b/probe_ember_clinic.js
@@ -1,0 +1,294 @@
+// PROBE — §PHOTO_EMBER glow-only, Clinic main hallway. Spec: PHOTOREAL_STILL_RENDER.md §PHOTO_EMBER.
+//
+// User ruling: "glow only first, use the Clinic hallway, then have a the later version to compare."
+// So this renders the SAME camera in the SAME room twice, through the real Alt+S fold, and hands back
+// two stills plus the numbers — baseline and glow — so the comparison is a comparison and not a memory
+// of what the last render looked like.
+//
+// A SANDBOX, deliberately: nothing here edits the viewer. It reaches in at runtime exactly the way
+// ghostglass.js already does (cache emissive/emissiveIntensity per material, set, restore), so if the
+// look is not worth it, there is nothing to revert.
+//
+// WHY THE STILLS ARE NOT THE ONLY OUTPUT: this project's rule is that code and maths are the truth,
+// never "does it look right". For a LIGHTING change the image genuinely is the deliverable — but it is
+// reported next to numbers that can be argued with: how many fixtures were matched (and that switches
+// were NOT), mean and peak luminance of each render, and what the fold cost. A glow that does not move
+// the luminance numbers is decoration that is not reaching the frame.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 8403;
+const BLD = process.env.BLD || 'Clinic';
+const ROOM = process.env.ROOM || '≈ Second Floor R22';   // 21.8 x 6.8m, 67 luminaires — see the spec
+const OUT = process.env.OUT || '/tmp/ember_out';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// The luminaire vocabulary, and the exclusions that matter more than the vocabulary does. The Clinic
+// has 236 "M_Lighting Switches", 28 "M_Lighting and Appliance Panelboard" and 961 "M_Duplex
+// Receptacle" — every one of which a naive '%light%' would set glowing.
+const LUM_WORDS = ['light', 'troffer', 'downlight', 'luminaire', 'lamp', 'sconce', 'pendant'];
+const NOT_WORDS = ['switch', 'receptacle', 'panelboard', 'socket', 'outlet'];
+
+(async () => {
+  fs.mkdirSync(OUT, { recursive: true });
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine && window.APP._composer,
+    { timeout: 180000 });
+  await sleep(12000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 120000, polling: 2000 });
+
+  // ── 0. Federated models. The Clinic is FIVE separate `building` values and the streamer loads the
+  //       one nearest the camera — the first cut of this probe sat at the opening camera for 20s, got
+  //       Clinic_HVAC_IFC2x3 only, and concluded there were no luminaires in the scene. The user's own
+  //       baked film shows the downlights and sphere sconces plainly, which is the better evidence:
+  //       Electrical DOES stream in a real session as the camera moves. So ask for it explicitly
+  //       rather than hoping proximity brings it, and take Architectural too — glow with no walls or
+  //       ceiling to sit in is not a hallway shot.
+  const streamed = await page.evaluate(async () => {
+    const A = window.APP;
+    const want = (A.dbQuery("SELECT DISTINCT building FROM elements_meta") || []).map(r => r[0])
+      .filter(b => /Architectural|Electrical/i.test(b))
+      .sort();   // Architectural FIRST — the room has to exist before the lights in it mean anything
+    window.__emberWant = want;
+    return want;
+  });
+  // ONE AT A TIME. Firing streamBuilding for both models in the same tick only ever landed one of
+  // them (guidMap came back 5822 = HVAC + Electrical, with Architectural missing entirely, so the
+  // render had fixtures floating in the dark with no walls or floor). Request, wait for the count to
+  // settle, then request the next.
+  for (const b of streamed) {
+    await page.evaluate(bb => { try { window.APP.streamBuilding(bb); } catch (e) {} }, b);
+    let prev = -1;
+    for (let i = 0; i < 60; i++) {
+      const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length);
+      if (n === prev && n > 0) break;
+      prev = n; await sleep(2000);
+    }
+  }
+  const rendered = await page.evaluate(() => [...(window.APP.buildingsRendered || [])]);
+
+  // ── 1. The room, and the luminaires inside it — selected from the DB, by position, because
+  //       rel_contained_in_space carries no ELEC rows at all.
+  const room = await page.evaluate((ROOM) => {
+    const r = window.APP.dbQuery(
+      "SELECT guid, name, center_x, center_y, center_z, size_x, size_y, size_z FROM spatial_structure WHERE name = '" +
+      ROOM.replace(/'/g, "''") + "'");
+    if (!r || !r.length) return null;
+    const q = r[0];
+    return { guid: q[0], name: q[1], cx: q[2], cy: q[3], cz: q[4], sx: q[5], sy: q[6], sz: q[7] };
+  }, ROOM);
+  if (!room) { console.log('ROOM NOT FOUND: ' + ROOM); await browser.close(); process.exit(1); }
+
+  const sel = await page.evaluate((room, LUM, NOT) => {
+    const like = (col, words, join) => words.map(w => "lower(" + col + ") LIKE '%" + w + "%'").join(join);
+    const sql =
+      "SELECT e.guid, e.element_name, e.material_rgba FROM elements_meta e " +
+      "JOIN element_transforms t ON t.guid = e.guid WHERE (" + like('e.element_name', LUM, ' OR ') + ") " +
+      "AND NOT (" + like('e.element_name', NOT, ' OR ') + ") " +
+      "";
+    // NO room filter. The user's framing is "implant ANY lighting fixture as source of light", and a
+    // room box actively hurts: the wall sconces they can see in the hallway sit outside the compiled
+    // space's bbox, so filtering by room dropped exactly the fixtures they asked about. Emissive costs
+    // nothing per fixture, so scoping it to a room buys nothing and loses the sconces.
+    const rows = window.APP.dbQuery(sql) || [];
+    // The exclusions are ASSERTED, not assumed: count what a naive match would have swept in.
+    const naive = (window.APP.dbQuery(
+      "SELECT COUNT(*) FROM elements_meta e JOIN element_transforms t ON t.guid=e.guid WHERE (" +
+      like('e.element_name', LUM, ' OR ') + ") " +
+      "AND t.center_x BETWEEN " + (room.cx - room.sx / 2) + " AND " + (room.cx + room.sx / 2) + " " +
+      "AND t.center_y BETWEEN " + (room.cy - room.sy / 2) + " AND " + (room.cy + room.sy / 2) + " " +
+      "AND ABS(t.center_z - " + room.cz + ") < 4") || [[0]])[0][0];
+    // TWO sets, and conflating them put the camera inside a wall: everything gets LIT (emissive is
+    // free per fixture and the sconces live outside the compiled room's box), but the CAMERA is
+    // placed from the hallway's fixtures alone — otherwise the centroid is the whole building.
+    const roomRows = window.APP.dbQuery(sql +
+      " AND t.center_x BETWEEN " + (room.cx - room.sx / 2) + " AND " + (room.cx + room.sx / 2) +
+      " AND t.center_y BETWEEN " + (room.cy - room.sy / 2) + " AND " + (room.cy + room.sy / 2) +
+      " AND ABS(t.center_z - " + room.cz + ") < 4") || [];
+    const fams = {};
+    rows.forEach(r => { const f = String(r[1]).split(':')[0]; fams[f] = (fams[f] || 0) + 1; });
+    return { guids: rows.map(r => r[0]), roomGuids: roomRows.map(r => r[0]), families: fams, naive: naive };
+  }, room, LUM_WORDS, NOT_WORDS);
+
+  // ── 2. The camera comes from Alt+C. Deriving a viewpoint by hand failed three times (bbox centroid
+  //       and fixture-anchor both landed inside walls, and the fixture anchor resolved to the world
+  //       origin because instance-matrix extraction is wrong for batched meshes). None of that needs
+  //       solving here: cinemaPathPlan already walks this building at eye level through its corridors,
+  //       and poseAt(t) is the same function the bake flies. Sample its walk band and stand there.
+  const cam = await page.evaluate(async () => {
+    const A = window.APP;
+    let plan = null;
+    try { plan = A.cinemaPathPlan(30); } catch (e) { return { ok: false, err: e.message }; }
+    if (!plan || typeof plan.poseAt !== 'function') return { ok: false, err: 'no plan' };
+    // The walk sits between the dive/spin and the rise/orbit; mid-film is inside the building.
+    const ts = [0.40, 0.50, 0.60];
+    const poses = ts.map(t => { const p = plan.poseAt(t); return { t: t, x: p.x, y: p.y, z: p.z, tx: p.tx, ty: p.ty, tz: p.tz }; });
+    return { ok: true, poses: poses, sec: plan.sec, pathLen: plan.pathLen };
+  });
+  if (!cam.ok) { console.log('CINEMA PLAN UNAVAILABLE: ' + cam.err); await browser.close(); process.exit(1); }
+  async function stand(pose) {
+    await page.evaluate(p => {
+      const A = window.APP;
+      A.camera.position.set(p.x, p.y, p.z);
+      A.controls.target.set(p.tx, p.ty, p.tz);
+      A.controls.update();
+      if (A.markDirty) A.markDirty();
+    }, pose);
+    await sleep(800);
+  }
+
+  // ── 3. How many of those GUIDs are actually meshes in the scene? A glow applied to nothing looks
+  //       exactly like a glow that is too subtle, so this number has to be reported either way.
+  // guidMap is keyed meshId -> guid for standalone meshes and meshId_slot -> guid for instanced and
+  // batched ones. Reading it the other way round (guidMap[o.id] and hoping) found nothing at all: the
+  // Clinic's fixtures are instanced, so their key carries a slot suffix. Invert the map instead.
+  const matched = await page.evaluate(guids => {
+    const A = window.APP, want = new Set(guids);
+    const ids = new Set();
+    Object.keys(A.guidMap).forEach(k => {
+      if (want.has(A.guidMap[k])) ids.add(parseInt(String(k).split('_')[0], 10));
+    });
+    return { meshIds: [...ids], hits: Object.keys(A.guidMap).filter(k => want.has(A.guidMap[k])).length };
+  }, sel.guids);
+
+  // One Alt+S fold, then a capture. Same routine both times so the only difference is the emissive.
+  async function foldAndShoot(tag) {
+    const t0 = Date.now();
+    await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); });
+    await sleep(600);
+    await page.evaluate(() => window.APP.startStillRefine());
+    for (let i = 0; i < 120 && await page.evaluate(() => !!window.APP._stillRefineBusy); i++) await sleep(500);
+    await sleep(1500);
+    const file = path.join(OUT, `${BLD}_${tag}.png`);
+    await page.screenshot({ path: file });
+    return { file, ms: Date.now() - t0 };
+  }
+
+  const shots = [];
+  for (const pose of cam.poses) {
+    await stand(pose);
+    shots.push({ t: pose.t, base: await foldAndShoot('t' + Math.round(pose.t * 100) + '_1_baseline'), pose: pose });
+  }
+  const base = shots[0].base;
+
+  // ── 4. The glow. Emissive only — no lights, no composer change. Cached exactly the way
+  //       ghostglass.js caches it, so this is reversible and so a second run cannot double-apply.
+  const applied = await page.evaluate((guids) => {
+    const A = window.APP, want = new Set(guids);
+    // Which mesh objects hold these guids? Instanced and batched meshes key as meshId_slot.
+    const ids = new Set();
+    Object.keys(A.guidMap).forEach(k => {
+      if (want.has(A.guidMap[k])) ids.add(parseInt(String(k).split('_')[0], 10));
+    });
+    // An instanced/batched mesh shares ONE material across every element in it, so emissive cannot be
+    // per-instance — every element drawn by that material lights up together. For luminaires that is
+    // acceptable and is in fact what was asked for ("implant any lighting fixture as source of
+    // light"). What is NOT acceptable is doing it silently: count the elements that share these
+    // materials but are NOT luminaires, because that is the collateral, and report it.
+    const objs = [];
+    A.collectMeshes(o => o.isMesh).forEach(o => { if (ids.has(o.id)) objs.push(o); });
+    const collateral = new Set();
+    objs.forEach(o => {
+      Object.keys(A.guidMap).forEach(k => {
+        if (parseInt(String(k).split('_')[0], 10) === o.id && !want.has(A.guidMap[k])) collateral.add(A.guidMap[k]);
+      });
+    });
+    const seen = new Set();
+    let mats = 0;
+    objs.forEach(o => {
+      (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => {
+        if (!m || !m.emissive || seen.has(m.uuid)) return;
+        seen.add(m.uuid); mats++;
+        m.userData = m.userData || {};
+        m.userData._emberSave = { e: m.emissive.getHex(), i: m.emissiveIntensity || 0, tm: m.toneMapped !== false };
+        // Warm white. STATED, not measured: the Clinic's family names carry no wattage and no cw/ww
+        // tag (unlike Terminal's "2 X 28W ... cw"), so a per-kind default is the honest fallback and
+        // it is declared here rather than tuned silently. toneMapped=false is what makes an emissive
+        // surface read as a SOURCE rather than as pale paint, given there is no bloom pass in the chain.
+        m.emissive.setHex(0xfff2d0);
+        m.emissiveIntensity = 3.0;
+        m.toneMapped = false;
+        m.needsUpdate = true;
+      });
+    });
+    return { meshes: objs.length, materials: mats, meshIds: [...ids].length, collateral: collateral.size };
+  }, sel.guids);
+
+  for (const sh of shots) { await stand(sh.pose); sh.glow = await foldAndShoot('t' + Math.round(sh.t * 100) + '_2_glow'); }
+  const glow = shots[0].glow;
+
+  // ── 5. Numbers, so the comparison is arguable. Mean and peak luminance of each PNG, computed from
+  //       the pixels — a glow that does not move these is not reaching the frame.
+  const lum = await page.evaluate(async (files) => {
+    const read = src => new Promise(res => {
+      const img = new Image();
+      img.onload = () => {
+        const c = document.createElement('canvas');
+        c.width = img.width; c.height = img.height;
+        const x = c.getContext('2d'); x.drawImage(img, 0, 0);
+        const d = x.getImageData(0, 0, c.width, c.height).data;
+        let sum = 0, peak = 0, hot = 0, n = 0;
+        for (let i = 0; i < d.length; i += 4) {
+          const L = 0.2126 * d[i] + 0.7152 * d[i + 1] + 0.0722 * d[i + 2];
+          sum += L; if (L > peak) peak = L; if (L > 240) hot++; n++;
+        }
+        res({ mean: sum / n, peak: peak, hotPct: hot / n * 100 });
+      };
+      img.onerror = () => res(null);
+      img.src = src;
+    });
+    return { a: await read(files[0]), b: await read(files[1]) };
+  }, [ 'data:image/png;base64,' + fs.readFileSync(base.file).toString('base64'),
+       'data:image/png;base64,' + fs.readFileSync(glow.file).toString('base64') ]);
+
+  console.log(`\n${'='.repeat(78)}\n§PHOTO_EMBER sandbox — ${BLD}  "${room.name}"\n${'='.repeat(78)}`);
+  console.log(`camera      from Alt+C's own plan (pathLen ${cam.pathLen ? cam.pathLen.toFixed(1) : '?'}m) — poseAt() sampled mid-film, the same function the bake flies`);
+  cam.poses.forEach(p => console.log(`              t=${p.t.toFixed(2)}  at (${p.x.toFixed(1)}, ${p.y.toFixed(1)}, ${p.z.toFixed(1)})  looking to (${p.tx.toFixed(1)}, ${p.ty.toFixed(1)}, ${p.tz.toFixed(1)})`));
+  console.log(`luminaires  ${sel.guids.length} lit building-wide, ${sel.roomGuids.length} of them in the demo room (camera placed from those)`);
+  const naiveAll = await page.evaluate(() => (window.APP.dbQuery(
+    "SELECT COUNT(*) FROM elements_meta WHERE lower(element_name) LIKE '%light%'") || [[0]])[0][0]);
+  console.log(`exclusions  a bare '%light%' over the building matches ${naiveAll}; the vocabulary keeps ${sel.guids.length}` +
+              ` — ${naiveAll - sel.guids.length} switches/panelboards rejected`);
+  Object.entries(sel.families).sort((a, b) => b[1] - a[1]).forEach(([f, c]) => console.log(`              ${String(c).padStart(4)}  ${f}`));
+  console.log(`scene       requested: ${streamed.join(', ')}  |  RENDERED: ${rendered.join(', ')}  |  guidMap ${await page.evaluate(() => Object.keys(window.APP.guidMap).length)} entries`);
+  console.log(`meshes      ${matched.hits} guidMap hits across ${matched.meshIds.length} mesh objects  ->  ${applied.meshes} lit, ${applied.materials} materials`);
+  console.log(`collateral  ${applied.collateral} NON-luminaire elements share those materials and will also glow` +
+              (applied.collateral ? '  <-- instanced/batched meshes cannot do per-instance emissive' : ''));
+  console.log(`\nfold cost   baseline ${(base.ms / 1000).toFixed(1)}s   glow ${(glow.ms / 1000).toFixed(1)}s   ` +
+              `delta ${((glow.ms - base.ms) / 1000).toFixed(1)}s  (emissive is a material property — expect ~0)`);
+  if (lum.a && lum.b) {
+    console.log(`\nluminance   mean ${lum.a.mean.toFixed(1)} -> ${lum.b.mean.toFixed(1)}  (${((lum.b.mean / Math.max(0.01, lum.a.mean) - 1) * 100).toFixed(1)}%)`);
+    console.log(`            peak ${lum.a.peak.toFixed(0)} -> ${lum.b.peak.toFixed(0)}`);
+    console.log(`            pixels >240 ("hot", i.e. reading as a source): ${lum.a.hotPct.toFixed(3)}% -> ${lum.b.hotPct.toFixed(3)}%`);
+    // The first cut of this probe printed "the glow IS reaching the frame" while ZERO meshes had been
+    // lit — it was reading fold-to-fold TAA noise. A verdict that can pass with nothing applied is
+    // worse than no verdict, so the applied count gates it before any pixel is consulted.
+    const reaching = applied.materials > 0 &&
+                     (lum.b.hotPct > lum.a.hotPct * 1.5 || lum.b.mean > lum.a.mean * 1.02);
+    console.log(`\nVERDICT     ${applied.materials === 0
+      ? 'NOTHING WAS LIT — 0 materials touched. Any pixel difference below is fold noise, not glow.'
+      : reaching ? 'the glow IS reaching the frame'
+                 : 'applied to ' + applied.materials + ' materials but NOT moving the frame — intensity or occlusion, not taste'}`);
+  }
+  console.log('\nstills');
+  shots.forEach(sh => console.log(`   t=${sh.t.toFixed(2)}  ${sh.base.file}\n           ${sh.glow.file}`));
+  const errs = logs.filter(l => /PAGEERROR|Uncaught/.test(l));
+  if (errs.length) console.log(`\npage errors ${errs.slice(0, 3).join('\n            ')}`);
+
+  await browser.close();
+})();

--- a/probe_guid2.js
+++ b/probe_guid2.js
@@ -1,0 +1,36 @@
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+(async () => {
+  const b = await puppeteer.launch({ headless:'new', protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p = await b.newPage();
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db', {waitUntil:'domcontentloaded', timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.startStillRefine, {timeout:180000});
+  await sleep(16000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const out = await p.evaluate(() => {
+    const A=window.APP;
+    // invert guidMap: guid -> [meshId or meshId_slot]
+    const inv={}; Object.keys(A.guidMap).forEach(k=>{ const g=A.guidMap[k]; (inv[g]=inv[g]||[]).push(k); });
+    const lum = A.dbQuery("SELECT e.guid, e.element_name FROM elements_meta e WHERE e.discipline='ELEC' AND (lower(e.element_name) LIKE '%troffer%' OR lower(e.element_name) LIKE '%downlight%' OR lower(e.element_name) LIKE '%pendant%' OR lower(e.element_name) LIKE '%sconce%')")||[];
+    const inScene = lum.filter(r=>inv[r[0]]);
+    // what object types hold them?
+    const byId={}; A.collectMeshes(o=>o.isMesh||o.isInstancedMesh||o.isBatchedMesh).forEach(o=>byId[o.id]=o);
+    const kinds={}; const matIds=new Set();
+    inScene.slice(0,400).forEach(r=>{
+      inv[r[0]].forEach(k=>{
+        const id=parseInt(String(k).split('_')[0],10); const o=byId[id];
+        if(!o){kinds['(mesh-not-in-scene)']=(kinds['(mesh-not-in-scene)']||0)+1;return;}
+        const t=o.isBatchedMesh?'BatchedMesh':o.isInstancedMesh?'InstancedMesh':'Mesh';
+        kinds[t]=(kinds[t]||0)+1;
+        const ms=Array.isArray(o.material)?o.material:[o.material];
+        ms.forEach(m=>{ if(m) matIds.add(m.uuid+'|'+(m.name||'')+'|hasEmissive='+!!m.emissive); });
+      });
+    });
+    return { totalLuminairesDB: lum.length, inScene: inScene.length, kinds,
+             distinctMaterials: matIds.size, matSample:[...matIds].slice(0,6),
+             totalMeshObjs: A.collectMeshes(o=>o.isMesh).length };
+  });
+  console.log(JSON.stringify(out,null,1));
+  await b.close();
+})();

--- a/probe_guid_axes.js
+++ b/probe_guid_axes.js
@@ -1,0 +1,38 @@
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+(async () => {
+  const b = await puppeteer.launch({ headless:'new', protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p = await b.newPage();
+  p.on('pageerror', e => console.log('PAGEERROR', e.message));
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db', {waitUntil:'domcontentloaded', timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.startStillRefine, {timeout:180000});
+  await sleep(14000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const out = await p.evaluate(() => {
+    const A = window.APP;
+    const meshes = A.collectMeshes(o=>o.isMesh);
+    const sample = [];
+    for (let i=0;i<meshes.length && sample.length<5;i++){
+      const o=meshes[i];
+      const g=(A.guidMap&&A.guidMap[o.id])||(o.userData&&o.userData.guid);
+      if(g) sample.push({g:String(g), name:o.name||'', type:o.type, isInst:!!o.isInstancedMesh, count:o.count||1});
+    }
+    // a real luminaire guid from the DB
+    const rows = A.dbQuery("SELECT e.guid, e.element_name, t.center_x, t.center_y, t.center_z FROM elements_meta e JOIN element_transforms t ON t.guid=e.guid WHERE lower(e.element_name) LIKE '%troffer%' LIMIT 3")||[];
+    // does that guid appear anywhere in the scene?
+    const found = rows.map(r=>{
+      const want=r[0];
+      let hit=null;
+      A.collectMeshes(o=>o.isMesh).forEach(o=>{
+        const g=(A.guidMap&&A.guidMap[o.id])||(o.userData&&o.userData.guid);
+        if(g && String(g).indexOf(want)===0){ if(!hit){ const w=new o.position.constructor(); o.getWorldPosition(w); hit={sceneGuid:String(g), wx:w.x, wy:w.y, wz:w.z, inst:!!o.isInstancedMesh}; } }
+      });
+      return { dbGuid:want, name:r[1], dbx:r[2], dby:r[3], dbz:r[4], hit:hit };
+    });
+    return { meshCount: meshes.length, guidMapSize: A.guidMap?Object.keys(A.guidMap).length:0, sample, found,
+             hasFindMeshByGuid: typeof A.findMeshByGuid };
+  });
+  console.log(JSON.stringify(out,null,1));
+  await b.close();
+})();

--- a/probe_hallway.js
+++ b/probe_hallway.js
@@ -1,0 +1,65 @@
+// The Clinic main hallway, lit. Camera placed with the app's OWN coordinate transform
+// (A.ifc2three) instead of a guessed axis mapping — three earlier attempts put the camera outside
+// the building or inside a wall precisely because that transform was being reinvented.
+const puppeteer=require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs=require('fs'),path=require('path');
+const sleep=ms=>new Promise(r=>setTimeout(r,ms)); const OUT='/tmp/ember_out';
+const ROOM=process.env.ROOM||'≈ Second Floor R22';
+(async()=>{
+  const b=await puppeteer.launch({headless:'new',protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p=await b.newPage(); await p.setViewport({width:1280,height:720});
+  const logs=[]; p.on('console',m=>logs.push(m.text())); p.on('pageerror',e=>logs.push('PAGEERROR '+e.message));
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db',{waitUntil:'domcontentloaded',timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.toggleNightMode&&window.APP.startStillRefine&&window.APP.ifc2three,{timeout:180000});
+  await sleep(12000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const want=await p.evaluate(()=>(window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(x=>/Architectural|Electrical/i.test(x)).sort());
+  for(const bb of want){ await p.evaluate(x=>{try{window.APP.streamBuilding(x);}catch(e){}},bb);
+    let prev=-1; for(let i=0;i<60;i++){const n=await p.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+
+  const cam=await p.evaluate((ROOM)=>{
+    const A=window.APP;
+    const rr=A.dbQuery("SELECT center_x,center_y,center_z,size_x,size_y FROM spatial_structure WHERE name='"+ROOM.replace(/'/g,"''")+"'");
+    if(!rr||!rr.length) return {ok:false,err:'room not found'};
+    const R={cx:rr[0][0],cy:rr[0][1],cz:rr[0][2],sx:rr[0][3],sy:rr[0][4]};
+    const rows=A.dbQuery(
+      "SELECT t.center_x,t.center_y,t.center_z FROM elements_meta e JOIN element_transforms t ON t.guid=e.guid "+
+      "WHERE (lower(e.element_name) LIKE '%troffer%' OR lower(e.element_name) LIKE '%downlight%' OR lower(e.element_name) LIKE '%light%') "+
+      "AND NOT (lower(e.element_name) LIKE '%switch%' OR lower(e.element_name) LIKE '%receptacle%' OR lower(e.element_name) LIKE '%panelboard%') "+
+      "AND t.center_x BETWEEN "+(R.cx-R.sx/2)+" AND "+(R.cx+R.sx/2)+
+      " AND t.center_y BETWEEN "+(R.cy-R.sy/2)+" AND "+(R.cy+R.sy/2)+
+      " AND ABS(t.center_z-"+R.cz+")<4")||[];
+    if(rows.length<2) return {ok:false,err:'only '+rows.length+' fixtures'};
+    // THE APP'S OWN TRANSFORM. tools.js uses exactly this to place its night lights, so it is the
+    // one mapping guaranteed to agree with where the geometry actually is.
+    const P=rows.map(r=>A.ifc2three(r[0],r[1],r[2]));
+    const mn={x:Math.min(...P.map(q=>q.x)),y:Math.min(...P.map(q=>q.y)),z:Math.min(...P.map(q=>q.z))};
+    const mx={x:Math.max(...P.map(q=>q.x)),y:Math.max(...P.map(q=>q.y)),z:Math.max(...P.map(q=>q.z))};
+    const alongX=(mx.x-mn.x)>=(mx.z-mn.z);
+    const key=alongX?'x':'z';
+    const sorted=P.slice().sort((a,b)=>a[key]-b[key]);
+    const near=sorted[Math.floor(sorted.length*0.10)], far=sorted[Math.floor(sorted.length*0.90)];
+    const eye=mn.y-1.5;                       // ceiling fixtures -> standing height
+    A.camera.position.set(near.x,eye,near.z);
+    A.controls.target.set(far.x,eye,far.z);
+    A.controls.update(); A.markDirty&&A.markDirty();
+    return {ok:true,n:P.length,along:key,eye:+eye.toFixed(2),
+            from:{x:+near.x.toFixed(1),z:+near.z.toFixed(1)},to:{x:+far.x.toFixed(1),z:+far.z.toFixed(1)},
+            ceiling:+mn.y.toFixed(2), span:{x:+(mx.x-mn.x).toFixed(1),z:+(mx.z-mn.z).toFixed(1)}};
+  },ROOM);
+  if(!cam.ok){ console.log('FAILED: '+cam.err); await b.close(); return; }
+  await sleep(2000);
+  await p.screenshot({path:path.join(OUT,'hall_1_day_nav.png')});
+  await p.evaluate(()=>window.APP.toggleNightMode()); await sleep(4000);
+  await p.screenshot({path:path.join(OUT,'hall_2_night_nav.png')});
+  await p.evaluate(()=>window.APP.startStillRefine());
+  for(let i=0;i<200 && await p.evaluate(()=>!!window.APP._stillRefineBusy);i++) await sleep(500);
+  await sleep(2500);
+  await p.screenshot({path:path.join(OUT,'hall_3_night_still.png')});
+  const lights=await p.evaluate(()=>window.APP._nightLights.length);
+  await b.close();
+  console.log(JSON.stringify(cam));
+  console.log('lights during still:',lights);
+  console.log(logs.filter(l=>/§PHOTO_EMBER|§NIGHT_STILL_LIGHTS|§NIGHT_MODE/.test(l)).join('\n'));
+})();

--- a/probe_night.js
+++ b/probe_night.js
@@ -1,0 +1,24 @@
+// Does the night-mode gate fix actually identify the Clinic's luminaires now?
+const puppeteer=require('/home/red1/bim-compiler/node_modules/puppeteer');
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+(async()=>{
+  const b=await puppeteer.launch({headless:'new',protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p=await b.newPage(); const logs=[];
+  p.on('console',m=>logs.push(m.text())); p.on('pageerror',e=>logs.push('PAGEERROR '+e.message));
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db',{waitUntil:'domcontentloaded',timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.toggleNightMode,{timeout:180000});
+  await sleep(12000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const want=await p.evaluate(()=>(window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(x=>/Architectural|Electrical/i.test(x)).sort());
+  for(const bb of want){ await p.evaluate(x=>{try{window.APP.streamBuilding(x);}catch(e){}},bb);
+    let prev=-1; for(let i=0;i<60;i++){const n=await p.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+  await p.evaluate(()=>window.APP.toggleNightMode());
+  await sleep(4000);
+  const st=await p.evaluate(()=>({fixtures:(window.APP._nightFixtures||[]).length,
+    lights:(window.APP._nightLights||[]).length, glowClasses:window.APP._nightGlowClasses,
+    glowMats:(window.APP._nightGlowMats||[]).length, exposure:window.APP.renderer.toneMappingExposure}));
+  console.log(JSON.stringify(st,null,1));
+  console.log(logs.filter(l=>/§NIGHT/.test(l)).slice(0,6).join('\n'));
+  await b.close();
+})();

--- a/probe_night_still.js
+++ b/probe_night_still.js
@@ -1,0 +1,32 @@
+// Night mode + Alt+S: do we get 4x lights, and does the frame actually get brighter?
+const puppeteer=require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs=require('fs'),path=require('path');
+const sleep=ms=>new Promise(r=>setTimeout(r,ms)); const OUT='/tmp/ember_out';
+(async()=>{
+  const b=await puppeteer.launch({headless:'new',protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p=await b.newPage(); await p.setViewport({width:1280,height:720});
+  const logs=[]; p.on('console',m=>logs.push(m.text())); p.on('pageerror',e=>logs.push('PAGEERROR '+e.message));
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db',{waitUntil:'domcontentloaded',timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.toggleNightMode&&window.APP.startStillRefine,{timeout:180000});
+  await sleep(12000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const want=await p.evaluate(()=>(window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(x=>/Architectural|Electrical/i.test(x)).sort());
+  for(const bb of want){ await p.evaluate(x=>{try{window.APP.streamBuilding(x);}catch(e){}},bb);
+    let prev=-1; for(let i=0;i<60;i++){const n=await p.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+  const pose=await p.evaluate(()=>{const q=window.APP.cinemaPathPlan(30).poseAt(0.60);return{x:q.x,y:q.y,z:q.z,tx:q.tx,ty:q.ty,tz:q.tz};});
+  await p.evaluate(q=>{const A=window.APP;A.camera.position.set(q.x,q.y,q.z);A.controls.target.set(q.tx,q.ty,q.tz);A.controls.update();A.markDirty&&A.markDirty();},pose);
+  await p.evaluate(()=>window.APP.toggleNightMode()); await sleep(4000);
+  const navLights=await p.evaluate(()=>window.APP._nightLights.length);
+  await p.screenshot({path:path.join(OUT,'night_1_nav.png')});
+  await p.evaluate(()=>window.APP.startStillRefine());
+  for(let i=0;i<200 && await p.evaluate(()=>!!window.APP._stillRefineBusy);i++) await sleep(500);
+  await sleep(2500);
+  const stillLights=await p.evaluate(()=>window.APP._nightLights.length);
+  await p.screenshot({path:path.join(OUT,'night_2_still.png')});
+  await p.evaluate(()=>window.APP.stopStillRefine(true)); await sleep(2500);
+  const backLights=await p.evaluate(()=>window.APP._nightLights.length);
+  await b.close();
+  console.log(`lights: nav=${navLights}  still=${stillLights}  restored=${backLights}`);
+  console.log(logs.filter(l=>/§NIGHT_STILL_LIGHTS|§PHOTO_EMBER|§NIGHT_MODE/.test(l)).join('\n'));
+})();

--- a/probe_troffer.js
+++ b/probe_troffer.js
@@ -1,0 +1,43 @@
+// Which luminaire FAMILIES actually receive an emissive material, and which silently do not.
+// User: "In dark rooms these are not lighted 'M_Troffer Light - Parabolic Rectangular'"
+const puppeteer=require('/home/red1/bim-compiler/node_modules/puppeteer');
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+(async()=>{
+  const b=await puppeteer.launch({headless:'new',protocolTimeout:900000,
+    args:['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader']});
+  const p=await b.newPage();
+  await p.goto('http://localhost:8403/viewer/viewer.html?db=/buildings/Clinic_extracted.db',{waitUntil:'domcontentloaded',timeout:60000});
+  await p.waitForFunction(()=>window.APP&&window.APP.startStillRefine,{timeout:180000});
+  await sleep(12000);
+  await p.waitForFunction(()=>{try{const r=window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms');return r&&r[0][0]>0;}catch(e){return false;}},{timeout:120000,polling:2000});
+  const want=await p.evaluate(()=>(window.APP.dbQuery("SELECT DISTINCT building FROM elements_meta")||[]).map(r=>r[0]).filter(x=>/Architectural|Electrical/i.test(x)).sort());
+  for(const bb of want){ await p.evaluate(x=>{try{window.APP.streamBuilding(x);}catch(e){}},bb);
+    let prev=-1; for(let i=0;i<60;i++){const n=await p.evaluate(()=>Object.keys(window.APP.guidMap).length); if(n===prev&&n>0)break; prev=n; await sleep(2000);} }
+  const out=await p.evaluate(()=>{
+    const A=window.APP;
+    const rows=A.dbQuery("SELECT guid, element_name FROM elements_meta WHERE (lower(element_name) LIKE '%light%' OR lower(element_name) LIKE '%troffer%' OR lower(element_name) LIKE '%downlight%' OR lower(element_name) LIKE '%sconce%' OR lower(element_name) LIKE '%pendant%' OR lower(element_name) LIKE '%lamp%' OR lower(element_name) LIKE '%luminaire%') AND NOT (lower(element_name) LIKE '%switch%' OR lower(element_name) LIKE '%receptacle%' OR lower(element_name) LIKE '%panelboard%' OR lower(element_name) LIKE '%socket%' OR lower(element_name) LIKE '%outlet%')")||[];
+    const famOf=n=>String(n).split(':')[0];
+    const g2f={}; rows.forEach(r=>g2f[r[0]]=famOf(r[1]));
+    const byId={}; A.collectMeshes(o=>o.isMesh).forEach(o=>byId[o.id]=o);
+    const stat={};
+    rows.forEach(r=>{ const f=g2f[r[0]]; stat[f]=stat[f]||{db:0,mapped:0,meshFound:0,withEmissive:0,matTypes:{}}; stat[f].db++; });
+    Object.keys(A.guidMap).forEach(k=>{
+      const g=A.guidMap[k]; const f=g2f[g]; if(!f) return;
+      stat[f].mapped++;
+      const o=byId[parseInt(String(k).split('_')[0],10)];
+      if(!o) return;
+      stat[f].meshFound++;
+      (Array.isArray(o.material)?o.material:[o.material]).forEach(m=>{
+        if(!m) return;
+        stat[f].matTypes[m.type]=(stat[f].matTypes[m.type]||0)+1;
+        if(m.emissive) stat[f].withEmissive++;
+      });
+    });
+    return stat;
+  });
+  console.log('family                                        db  guidMapped  meshFound  hasEmissive   material types');
+  Object.entries(out).sort((a,b)=>b[1].db-a[1].db).forEach(([f,s])=>{
+    console.log(`${f.slice(0,44).padEnd(44)} ${String(s.db).padStart(4)} ${String(s.mapped).padStart(10)} ${String(s.meshFound).padStart(10)} ${String(s.withEmissive).padStart(12)}   ${Object.keys(s.matTypes).join(',')||'-'}`);
+  });
+  await b.close();
+})();

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v11 (§CPE_OK_CRASH — edited paths reach the bake again)';
+  var MAXQ_V = 'v13 (§MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -46,7 +46,28 @@
     _wakeLock = null;
   }
 
-  function _raf2() { return new Promise(function(res) { requestAnimationFrame(function() { requestAnimationFrame(res); }); }); }
+  // §MAXQ_HIDDEN_PAUSE — THE chokepoint, found by probing the browser rather than reasoning about
+  // it. requestAnimationFrame does not merely slow down in a hidden tab, it STOPS: a probe counted
+  // rAF ticks frozen at exactly 167 for a full 6s of hiding, resuming only on reveal. So every
+  // `await _raf2()` in the bake blocks indefinitely while hidden — the loop parks HERE, before any
+  // frame-boundary or fold-timeout check can run, which is why the first cut of this fix logged
+  // hiddenPauses=0 after being hidden for 20 real seconds. Waiting for visibility FIRST is what
+  // makes the pause observable; the rAF-vs-timeout race then covers the case where the tab hides
+  // between the check and the callback, so a lost frame cannot wedge a multi-minute bake.
+  function _raf2(why) {
+    return (async function() {
+      for (;;) {
+        if (_isHidden()) await _awaitVisible(why || 'render tick');
+        var got = await new Promise(function(r) {
+          var settled = false;
+          var fin = function(v) { if (!settled) { settled = true; r(v); } };
+          requestAnimationFrame(function() { requestAnimationFrame(function() { fin(true); }); });
+          setTimeout(function() { fin(false); }, 1500);
+        });
+        if (got) return;
+      }
+    })();
+  }
   function _sleep(ms) { return new Promise(function(res) { setTimeout(res, ms); }); }
   function _status(t) { var A = window.APP; if (A && A.status) A.status.textContent = t; }
 
@@ -156,16 +177,71 @@
   }
   function _restoreRandom() { if (window.__maxqOrigRandom) Math.random = window.__maxqOrigRandom; }
 
-  function _waitFoldDone(timeoutMs) {
-    var A = window.APP;
+  // ══ §MAXQ_HIDDEN_PAUSE (PHOTOREAL_STILL_RENDER.md §MAXQ_HIDDEN_PAUSE, 2026-07-27).
+  //
+  // A backgrounded tab does not merely slow the bake down — it RUINS it, silently. Chrome throttles
+  // rAF to a near-stop when hidden, so the per-frame TAA fold + §PHOTO_AO never converge,
+  // _waitFoldDone's wall-clock timeout expires, and §MAXQ_FRAME_TIMEOUT saves a frame that never
+  // finished. Consecutive such captures come out near-duplicates, so the delivered MP4 ends in a
+  // stretch of visually dead video. It does not throw, it does not stop, and the file plays fine:
+  // the user lost a 45s Hospital film to this and only knew because they remembered the tab was
+  // unfocused — a measurement pass looking for defects had already mis-attributed it to pacing.
+  //
+  // NOT re-plumbed onto timers, and the reason is physical rather than stylistic: a hidden tab does
+  // not reliably composite WebGL at all, so a timer-driven fold would accumulate nothing either. It
+  // would fail identically while looking fixed. A converged frame cannot be rendered in a
+  // backgrounded tab, so the only honest behaviour is to refuse to pretend.
+  var _hiddenMsTotal = 0, _hiddenPauses = 0, _unconverged = 0;
+  function _isHidden() { return typeof document !== 'undefined' && document.visibilityState === 'hidden'; }
+  // Resolves as soon as the tab is visible. `why` is logged so a pasted console shows WHERE the bake
+  // was parked, not merely that it was slow.
+  function _awaitVisible(why) {
+    if (!_isHidden()) return Promise.resolve(0);
     return new Promise(function(res) {
       var t0 = performance.now();
-      (function poll() {
-        if (!A._stillRefineBusy) return res(true);
-        if (performance.now() - t0 > timeoutMs) return res(false);
-        setTimeout(poll, 100);
-      })();
+      _hiddenPauses++;
+      console.log('§MAXQ_HIDDEN_PAUSE at ' + why + ' — tab is hidden; the bake is PARKED, not ' +
+        'degrading. A hidden tab cannot converge a frame, so advancing here would save unconverged ' +
+        'frames and silently ruin the film. Bring the tab back to resume.');
+      _status('⏸ Paused — bring this tab back to the front to continue the bake');
+      // Two things can notice the reveal — the visibilitychange listener and the poll below — and
+      // without this guard BOTH run, so the hidden time is added twice. Measured: one 20516ms pause
+      // reported totalHiddenMs=40908. A health line that overstates is as useless as one that lies.
+      var settled = false;
+      var done = function() {
+        if (_isHidden() || settled) return;
+        settled = true;
+        document.removeEventListener('visibilitychange', done);
+        var ms = performance.now() - t0;
+        _hiddenMsTotal += ms;
+        console.log('§MAXQ_HIDDEN_RESUME at ' + why + ' hiddenMs=' + Math.round(ms) +
+          ' totalHiddenMs=' + Math.round(_hiddenMsTotal) + ' pauses=' + _hiddenPauses);
+        res(ms);
+      };
+      document.addEventListener('visibilitychange', done);
+      // Belt and braces: visibilitychange is the signal, but a poll means a missed event cannot
+      // wedge a multi-minute bake forever.
+      (function poll() { if (_isHidden()) return setTimeout(poll, 250); done(); })();
     });
+  }
+  // The fold's budget must be measured in VISIBLE time, AND the wait must itself park when the tab
+  // goes hidden. Parking only at the frame boundary is not enough and the witness proved it: a
+  // 20s hide landed entirely inside ONE frame's cook (swiftshader frames are slow), so the loop
+  // never reached the boundary check, nothing was logged, and the run reported hiddenPauses=0 while
+  // having been hidden for 20 seconds. A pause that does not announce itself is the same silent
+  // failure this whole section exists to kill — so the wait reports through the same bookkeeping.
+  async function _waitFoldDone(timeoutMs, why) {
+    var A = window.APP;
+    var spentVisible = 0, last = performance.now();
+    for (;;) {
+      if (_isHidden()) { await _awaitVisible(why); last = performance.now(); }
+      if (!A._stillRefineBusy) return true;
+      if (spentVisible > timeoutMs) return false;
+      await _sleep(100);
+      var now = performance.now();
+      spentVisible += now - last;
+      last = now;
+    }
   }
 
   // One explicit composer render, then SAME-TASK drawImage into a 2D canvas (clash_snag.js's
@@ -355,6 +431,9 @@
     }
     var nFrames = opts.frames || MAXQ_N_FRAMES, fps = opts.fps || MAXQ_FPS;
     _active = true; _cancel = false;
+    // §MAXQ_HIDDEN_PAUSE / §MAXQ_QUALITY counters are per-RUN, not per-session — a second bake must
+    // not inherit the first one's pauses or its unconverged count and report someone else's health.
+    _hiddenMsTotal = 0; _hiddenPauses = 0; _unconverged = 0;
     A._maxqActive = true;   // mirror for the cinema icon's busy/done check (panels.js)
     _wakeAcquire();
     _dampHold();   // §CINEMA_DAMPING_BLEED — the preview and the bake are both authored cameras
@@ -585,7 +664,7 @@
       // than later ones (whole-building tint shift — measured 21.6dB vs 24.3dB PSNR in the PoC).
       _status('🎬 MaxQ warming up…');
       A.startStillRefine();
-      await _waitFoldDone(30000);
+      await _waitFoldDone(30000, 'warm-up fold');
       // §CINEMA_HDRI_RACE (2026-07-24, user-reported live via their own pasted console log —
       // "flicker or snapping... before Alt-S fully applied"): _waitFoldDone above only tracks the
       // TAA/AO accumulate fold's own busy flag. A.startStillRefine() ALSO kicks off the HDRI envMap
@@ -614,7 +693,10 @@
         // same treatment as the IDB-connection-lost path below.
         if (A._webglContextLost) { _glLost = true; console.log('§MAXQ_GL_LOST i=' + i + ' salvaging ' + framesDone + ' already-captured frames'); break; }
         if (A._stillRefineActive) A.stopStillRefine(true);
-        await _raf2();
+        // §MAXQ_HIDDEN_PAUSE: park BEFORE the cook, not after. Waiting here means the frame is
+        // begun with the tab already visible, so the fold has a real rAF loop to converge on.
+        await _awaitVisible('frame ' + i + '/' + nFrames);
+        await _raf2('frame ' + i + ' settle');
         await _sleep(SETTLE_MS);
         _freezeRandom();
         var pose = poseAt(nFrames > 1 ? i / (nFrames - 1) : 0);  // tNorm hits 1.0 on the last frame so the pull-back completes
@@ -622,10 +704,14 @@
         A.controls.target.set(pose.tx, pose.ty, pose.tz);
         A.controls.update();
         A.startStillRefine();
-        var ok = await _waitFoldDone(30000);
-        await _raf2();
+        var ok = await _waitFoldDone(30000, 'cook of frame ' + i + '/' + nFrames);
+        await _raf2('frame ' + i + ' capture');
         _restoreRandom();
-        if (!ok) console.warn('§MAXQ_FRAME_TIMEOUT i=' + i + ' — capturing as-is');
+        // A timeout can now only mean a genuinely slow frame, since hidden time no longer counts
+        // against the budget. Counted rather than merely warned: the total is what lets the run
+        // state its own health at the end instead of leaving a degraded film to look identical to
+        // a good one.
+        if (!ok) { _unconverged++; console.warn('§MAXQ_FRAME_TIMEOUT i=' + i + ' — capturing as-is (UNCONVERGED, count=' + _unconverged + ')'); }
         var blob = await _captureFrame(w, h);
         // §MAXQ_IDB_SALVAGE (2026-07-25, real user repro on Hospital AND HHS_Office — both mid-bake,
         // ~100+ frames in): a backgrounded/throttled tab can have Chrome force-close this run's IDB
@@ -681,6 +767,17 @@
       }
       if (A._stillRefineActive) A.stopStillRefine(true);
       _restoreRandom();
+      // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
+      // The defect this exists for is a film that looks complete and plays fine while its last
+      // seconds are visually dead. A degraded bake must never finish quietly: `unconverged` is the
+      // load-bearing number, because it counts frames captured before the fold finished — exactly
+      // the frames that come out as near-duplicates and read as the film stalling. With
+      // §MAXQ_HIDDEN_PAUSE in place a hidden tab should contribute ZERO of them, so a non-zero
+      // count now means genuinely slow frames and nothing else.
+      console.log('§MAXQ_QUALITY frames=' + framesDone + ' unconverged=' + _unconverged +
+        (_unconverged ? ' ⚠ THOSE FRAMES DID NOT FINISH — expect dead-looking video where they land' : ' (every frame converged)') +
+        ' hiddenPauses=' + _hiddenPauses + ' totalHiddenMs=' + Math.round(_hiddenMsTotal) +
+        (_hiddenPauses ? ' — the bake PARKED while the tab was hidden rather than degrading; the wall clock is longer, the film is not worse' : ''));
       // §MAXQ_PARTIAL: cancel SAVES what's cooked so far (user Q 2026-07-19 — losing minutes of
       // cook must never be the default). Threshold: at least 1s of footage (fps frames) on a
       // cancelled run — below that there's nothing worth stitching.

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -23,13 +23,14 @@ async function setupEffects(A, renderer, scene, camera) {
 
   try {
     // §S277c: Parallel import — all 6 addons load concurrently, not sequentially
-    var [_ecMod, _rpMod, _taaMod, _ssaoMod, _outMod, _opMod] = await Promise.all([
+    var [_ecMod, _rpMod, _taaMod, _ssaoMod, _outMod, _opMod, _blMod] = await Promise.all([
       import('./lib/EffectComposer.js'),
       import('./lib/RenderPass.js'),
       import('./lib/TAARenderPass.js'),
       import('./lib/SSAOPass.js'),
       import('./lib/OutlinePass.js'),
-      import('./lib/OutputPass.js')
+      import('./lib/OutputPass.js'),
+      import('./lib/BloomPass.js')
     ]);
 
     var _composer = new _ecMod.EffectComposer(renderer);
@@ -64,11 +65,24 @@ async function setupEffects(A, renderer, scene, camera) {
     _outlinePass.enabled = false;  // enabled on demand by pick/clash
     _composer.addPass(_outlinePass);
 
-    // Pass 4: Output — tone mapping + color space
+    // Pass 4: §PHOTO_BLOOM — BEFORE OutputPass, so it runs in linear HDR where an emissive material
+    // with toneMapped=false genuinely exceeds 1.0 and the threshold means something. After tone
+    // mapping everything is clamped into 0-1 and there is nothing left to find.
+    //
+    // OFF during navigation, ON only for the Alt+S still (see startStillRefine). Same discipline as
+    // Layer 3's triplanar PBR: a bake can afford a few ms a frame, a 60fps orbit cannot, and this
+    // renders 7 extra full-screen draws (bright + 3 levels x 2 blur directions) plus a composite.
+    var _bloomPass = new _blMod.BloomPass(window.innerWidth, window.innerHeight,
+      { strength: 0.9, threshold: 1.0, knee: 0.6 });
+    _bloomPass.enabled = false;
+    _composer.addPass(_bloomPass);
+
+    // Pass 5: Output — tone mapping + color space
     var _outputPass = new _opMod.OutputPass();
     _composer.addPass(_outputPass);
 
     A._composer = _composer;
+    A._bloomPass = _bloomPass;
     A._ssaoPass = _ssaoPass;
     A._outlinePass = _outlinePass;
     A._renderPass = _renderPass;
@@ -2931,6 +2945,18 @@ async function setupEffects(A, renderer, scene, camera) {
     if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
     if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
     _stopStillAOPhase(reason);  // §PHOTO_AO: disable the still-only AO pass on ANY exit path
+    // §PHOTO_EMBER / §PHOTO_BLOOM: same rule, and this is the ONLY place they are turned off —
+    // every cancel, interaction and cinema handoff funnels through here, so a glowing building can
+    // never outlive its still. Restoring the materials matters more than disabling the pass: an
+    // emissive left on would follow the user back into navigation.
+    if (A._bloomPass) A._bloomPass.enabled = false;
+    _emberOff();
+    // §NIGHT_STILL_LIGHTS: hand the navigation budget back, or the 4x set follows the user into
+    // their next orbit and the frame rate goes with it.
+    if (A._nightMaxLights !== 12 && typeof A._nightUpdateLights === 'function') {
+      A._nightMaxLights = 12;
+      if (A._nightLights && A._nightLights.length) A._nightUpdateLights();
+    }
     // §PHOTO_SSGI: same rule — a fold-engaged SSGI must not outlive the still (a pre-existing
     // Alt+J preview survives, only dropped back to nav-quality knobs; see effects_gi_poc.js).
     if (typeof A.stopStillSSGIPhase === 'function') A.stopStillSSGIPhase(reason);
@@ -2961,6 +2987,74 @@ async function setupEffects(A, renderer, scene, camera) {
                                                         // sparkle visibility is camera-position-dependent
                                                         // and the natural step() loop stops re-evaluating
                                                         // it once still-refine freezes.
+
+  // ══ §PHOTO_EMBER (PHOTOREAL_STILL_RENDER.md) — the luminaires light up for the still.
+  //
+  // User, 2026-07-27: "Can we get light to emit from those fixtures. Scene still too dark drab."
+  // Measured first, and the measurement is why this is emissive+bloom TOGETHER rather than emissive
+  // alone: at one Alt+C pose, glow-only moved mean luminance 56.13 -> 56.13, i.e. not at all. A
+  // luminaire is a handful of pixels and nothing spreads its energy, so raising emissiveIntensity
+  // only makes the same few pixels whiter. Bloom is what turns a bright pixel into a lamp.
+  //
+  // DETECTION is a vocabulary over element_name, NOT the IFC class, and NOT a bare '%light%':
+  //   - class is inconsistent across buildings — Terminal/Hospital use IfcLightFixture, the Clinic
+  //     uses IfcFlowTerminal, so keying on the class finds ZERO luminaires in the Clinic.
+  //   - '%light%' also matches 236 "M_Lighting Switches" and 28 "M_Lighting and Appliance
+  //     Panelboard" in that same building. Measured: 1105 naive matches vs 841 real luminaires.
+  // Save/restore mirrors ghostglass.js, which already does exactly this per material.
+  //
+  // Instanced/batched meshes share one material across every element drawn by them, so emissive
+  // cannot be per-instance — measured collateral on the Clinic is 33 non-luminaire elements out of
+  // 8408. Reported rather than hidden; it is a footnote, not a defect to discover later.
+  var EMBER_WORDS = ['light', 'troffer', 'downlight', 'luminaire', 'lamp', 'sconce', 'pendant'];
+  var EMBER_NOT   = ['switch', 'receptacle', 'panelboard', 'socket', 'outlet'];
+  var _emberMats = null;
+  function _emberOn() {
+    if (_emberMats || typeof A.dbQuery !== 'function') return;
+    var like = function(w, j) { return w.map(function(x) { return "lower(element_name) LIKE '%" + x + "%'"; }).join(j); };
+    var rows;
+    try {
+      rows = A.dbQuery("SELECT guid FROM elements_meta WHERE (" + like(EMBER_WORDS, ' OR ') +
+                       ") AND NOT (" + like(EMBER_NOT, ' OR ') + ")") || [];
+    } catch (e) { console.warn('§PHOTO_EMBER query failed: ' + e.message); return; }
+    if (!rows.length) { console.log('§PHOTO_EMBER no luminaires in this building — nothing to light'); return; }
+    var want = Object.create(null);
+    for (var i = 0; i < rows.length; i++) want[rows[i][0]] = 1;
+    var ids = Object.create(null), hits = 0;
+    for (var k in A.guidMap) if (want[A.guidMap[k]]) { ids[parseInt(String(k).split('_')[0], 10)] = 1; hits++; }
+    _emberMats = [];
+    var seen = Object.create(null), meshes = 0;
+    A.collectMeshes(function(o) { return o.isMesh; }).forEach(function(o) {
+      if (!ids[o.id]) return;
+      meshes++;
+      (Array.isArray(o.material) ? o.material : [o.material]).forEach(function(m) {
+        if (!m || !m.emissive || seen[m.uuid]) return;
+        seen[m.uuid] = 1;
+        _emberMats.push({ m: m, e: m.emissive.getHex(), i: m.emissiveIntensity || 0, tm: m.toneMapped !== false });
+        // Warm white, STATED not measured. Terminal's family names carry wattage and colour temp
+        // ("2 X 28W ... cw"); the Clinic's carry neither, so a per-kind default is the honest
+        // fallback and it is declared here rather than tuned silently per building.
+        // toneMapped=false is what pushes the surface above 1.0 in linear space so the bloom
+        // threshold can find it at all.
+        m.emissive.setHex(0xfff2d0);
+        m.emissiveIntensity = 3.0;
+        m.toneMapped = false;
+        m.needsUpdate = true;
+      });
+    });
+    console.log('§PHOTO_EMBER lit ' + rows.length + ' luminaires -> ' + hits + ' guidMap hits, ' +
+      meshes + ' meshes, ' + _emberMats.length + ' materials (bloom threshold ' +
+      (A._bloomPass ? A._bloomPass.threshold : '?') + ', strength ' + (A._bloomPass ? A._bloomPass.strength : '?') + ')');
+  }
+  function _emberOff() {
+    if (!_emberMats) return;
+    _emberMats.forEach(function(r) {
+      r.m.emissive.setHex(r.e); r.m.emissiveIntensity = r.i; r.m.toneMapped = r.tm; r.m.needsUpdate = true;
+    });
+    console.log('§PHOTO_EMBER restored ' + _emberMats.length + ' materials');
+    _emberMats = null;
+  }
+
   A.startStillRefine = function() {
     if (!A._composer || !A._taaPass || A._stillRefineActive) return;
     // §GI_EXCLUSION (review finding 5): the GI preview composer and this TAA composer both render
@@ -2976,6 +3070,20 @@ async function setupEffects(A, renderer, scene, camera) {
     // in _teardownStillRefine (every cancel/interaction/cinema-handoff exit), so it can never get
     // stuck true.
     A._stillRefineBusy = true;
+    // §PHOTO_EMBER + §PHOTO_BLOOM: both are STILL-ONLY, same discipline as Layer 3's triplanar PBR.
+    // Navigation keeps the cheap chain; the frozen still can afford 7 extra full-screen draws.
+    if (A._bloomPass) A._bloomPass.enabled = true;
+    _emberOn();
+    // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
+    // navigation budget (every light costs per-pixel work on every lit material every frame); a
+    // frozen still renders once and then sits there, so that budget does not apply to it. The
+    // user's report is that the night lights "have been weak" — part of that is simply that a
+    // 841-fixture building was being lit by 12 of them.
+    if (A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
+      A._nightMaxLights = A._nightMaxLightsStill;
+      A._nightUpdateLights();
+      console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length + ' lights for the still');
+    }
     A._composerEnabled = true;   // teardown RECOMPUTES from SSAO/Outline state (§GI_HANDOFF_GHOST_FIX) — no save needed
     A._taaPass.accumulate = true;
     A._taaPass.accumulateIndex = -1;

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2962,6 +2962,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // their next orbit and the frame rate goes with it.
     if (A._nightMaxLights !== 12 && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = 12;
+      A._nightNearFadeFloor = 0.3;
       if (A._nightLights && A._nightLights.length) A._nightUpdateLights();
     }
     // §PHOTO_SSGI: same rule — a fold-engaged SSGI must not outlive the still (a pre-existing
@@ -3088,8 +3089,10 @@ async function setupEffects(A, renderer, scene, camera) {
     // 841-fixture building was being lit by 12 of them.
     if (A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = A._nightMaxLightsStill;
+      A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
       A._nightUpdateLights();
-      console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length + ' lights for the still');
+      console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length +
+        ' lights, near-fade floor ' + A._nightNearFadeFloorStill + ' (was 0.3) for the still');
     }
     A._composerEnabled = true;   // teardown RECOMPUTES from SSAO/Outline state (§GI_HANDOFF_GHOST_FIX) — no save needed
     A._taaPass.accumulate = true;

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2104,6 +2104,13 @@ async function setupEffects(A, renderer, scene, camera) {
   var PHOTO_HEMI_SKY_COLOR = 0x6a5a7a;  // dusky violet-warm sky half of the hemi light
   var PHOTO_SUN_INTENSITY_SCALE = 0.7;  // dimmer than full daylight — evening, not noon
   var PHOTO_EXPOSURE_SCALE = 0.85;      // slightly underexposed overall — "materials in little light"
+  // §PHOTO_EXPOSURE_LIFT (2026-07-27, user: "Scene still too dark drab"). The still was rendering at
+  // 0.45 x 0.85 = 0.3825 — about a stop and a half under three.js's default, which is most of why
+  // interiors read as drab and why emissive luminaires had so little to show. Lifted here rather
+  // than at the renderer default because that default is the DAY NAVIGATION value and the user
+  // recalls overexposure from raising it. 2.2x lands the still at ~0.85, bright enough to read
+  // without blowing out the sky, and it touches nothing outside the photoshoot.
+  var PHOTO_EXPOSURE_LIFT = 2.2;
   // §PHOTO_SUN_REFLECTION (user ask, continued session — "get the Sun reflection beautiful
   // realistic surface material impact correct firsts"): three things were found reading the
   // existing sun/sky code rather than adding a new one:
@@ -2663,7 +2670,7 @@ async function setupEffects(A, renderer, scene, camera) {
         A.ambient.color.setHex(PHOTO_AMBIENT_COLOR);
         A.hemi.intensity = A._nightSaved.hemiI * PHOTO_HEMI_INTENSITY_SCALE;
         A.hemi.color.setHex(PHOTO_HEMI_SKY_COLOR);
-        A.renderer.toneMappingExposure = A._nightSaved.exposure * PHOTO_EXPOSURE_SCALE;
+        A.renderer.toneMappingExposure = A._nightSaved.exposure * PHOTO_EXPOSURE_SCALE * PHOTO_EXPOSURE_LIFT;
       }
     }
     // §PHOTO_FOG_ORDER_FIX (2026-07-16, RESUME BRIEF ADDENDUM item 2 — "sky/ground darkness, one

--- a/viewer/lib/BloomPass.js
+++ b/viewer/lib/BloomPass.js
@@ -1,0 +1,163 @@
+// §PHOTO_BLOOM — a compact bloom pass, written rather than imported.
+// Spec: bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §PHOTO_EMBER.
+//
+// WHY THIS FILE EXISTS AT ALL: three.js ships UnrealBloomPass, but it is not vendored here and this
+// app must work OFFLINE — pulling it from a CDN at runtime is not an option (the whole product is a
+// static site users open with no network). The pmndrs `postprocessing` bundle already vendored for
+// N8AO does contain BloomEffect, but it belongs to a DIFFERENT composer implementation and cannot be
+// added to three's native EffectComposer that viewer/effects.js uses. So: bright-pass, separable
+// blur, additive composite, built from the Pass/FullScreenQuad primitives already in this folder.
+//
+// WHAT IT IS FOR: measured 2026-07-27, emissive luminaires were INVISIBLE in the render — mean
+// luminance 56.13 -> 56.13 with the glow on, because a luminaire is a handful of pixels and nothing
+// spreads its energy. Raising emissiveIntensity cannot fix that; it makes the same few pixels
+// whiter. Bloom is what turns a bright pixel into a lamp, which is why glow and bloom are one
+// feature and not two increments.
+//
+// Placed BEFORE OutputPass in the chain so it works in linear HDR, where emissive materials with
+// toneMapped=false genuinely exceed 1.0 and the threshold means something.
+const { ShaderMaterial, UniformsUtils, WebGLRenderTarget, Vector2, HalfFloatType, LinearFilter, ClampToEdgeWrapping } = window.THREE;
+import { Pass, FullScreenQuad } from './Pass.js';
+
+// Everything above `threshold` is kept, smoothly, and scaled by how far above it sits. `knee` softens
+// the cutoff so a surface hovering at the threshold does not pop in and out between frames — with TAA
+// accumulating 16 samples a hard cutoff shimmers.
+const BrightShader = {
+  uniforms: { tDiffuse: { value: null }, threshold: { value: 1.0 }, knee: { value: 0.6 } },
+  vertexShader: `varying vec2 vUv; void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+  fragmentShader: `
+    uniform sampler2D tDiffuse; uniform float threshold; uniform float knee; varying vec2 vUv;
+    void main(){
+      vec4 c = texture2D(tDiffuse, vUv);
+      float l = dot(c.rgb, vec3(0.2126, 0.7152, 0.0722));
+      float soft = clamp((l - threshold + knee) / max(0.0001, 2.0 * knee), 0.0, 1.0);
+      float w = max(l - threshold, 0.0) * soft;
+      gl_FragColor = vec4(c.rgb * (l > 0.0001 ? w / l : 0.0), 1.0);
+    }`
+};
+
+// Separable 9-tap gaussian. Two passes (H then V) per level; running it over several progressively
+// smaller targets is what gives a wide, soft falloff without a large kernel.
+const BlurShader = {
+  uniforms: { tDiffuse: { value: null }, direction: { value: new Vector2(1, 0) }, texelSize: { value: new Vector2() } },
+  vertexShader: `varying vec2 vUv; void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+  fragmentShader: `
+    uniform sampler2D tDiffuse; uniform vec2 direction; uniform vec2 texelSize; varying vec2 vUv;
+    void main(){
+      vec2 d = direction * texelSize;
+      vec4 s = texture2D(tDiffuse, vUv) * 0.227027;
+      s += (texture2D(tDiffuse, vUv + d * 1.3846) + texture2D(tDiffuse, vUv - d * 1.3846)) * 0.316216;
+      s += (texture2D(tDiffuse, vUv + d * 3.2308) + texture2D(tDiffuse, vUv - d * 3.2308)) * 0.070270;
+      gl_FragColor = vec4(s.rgb, 1.0);
+    }`
+};
+
+const CompositeShader = {
+  uniforms: { tDiffuse: { value: null }, tBloom0: { value: null }, tBloom1: { value: null },
+              tBloom2: { value: null }, strength: { value: 1.0 } },
+  vertexShader: `varying vec2 vUv; void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+  fragmentShader: `
+    uniform sampler2D tDiffuse; uniform sampler2D tBloom0; uniform sampler2D tBloom1;
+    uniform sampler2D tBloom2; uniform float strength; varying vec2 vUv;
+    void main(){
+      vec3 base = texture2D(tDiffuse, vUv).rgb;
+      // Coarser levels weigh less, so the halo falls off instead of forming a flat disc.
+      vec3 b = texture2D(tBloom0, vUv).rgb * 1.0
+             + texture2D(tBloom1, vUv).rgb * 0.6
+             + texture2D(tBloom2, vUv).rgb * 0.35;
+      gl_FragColor = vec4(base + b * strength, texture2D(tDiffuse, vUv).a);
+    }`
+};
+
+const LEVELS = 3;
+
+class BloomPass extends Pass {
+  constructor(width, height, opts) {
+    super();
+    opts = opts || {};
+    this.strength = opts.strength !== undefined ? opts.strength : 0.9;
+    this.threshold = opts.threshold !== undefined ? opts.threshold : 1.0;
+    this.knee = opts.knee !== undefined ? opts.knee : 0.6;
+    this.needsSwap = true;
+
+    // HalfFloat because the whole point is values ABOVE 1.0; an 8-bit target would clip the very
+    // pixels this pass exists to find, and the threshold would then be meaningless.
+    const rtOpts = { type: HalfFloatType, minFilter: LinearFilter, magFilter: LinearFilter,
+                     wrapS: ClampToEdgeWrapping, wrapT: ClampToEdgeWrapping, depthBuffer: false, stencilBuffer: false };
+    this._rtBright = new WebGLRenderTarget(Math.max(1, width >> 1), Math.max(1, height >> 1), rtOpts);
+    this._levels = [];
+    for (let i = 0; i < LEVELS; i++) {
+      const w = Math.max(1, width >> (i + 1)), h = Math.max(1, height >> (i + 1));
+      this._levels.push({
+        a: new WebGLRenderTarget(w, h, rtOpts),
+        b: new WebGLRenderTarget(w, h, rtOpts),
+        size: new Vector2(1 / w, 1 / h)
+      });
+    }
+    this._bright = new ShaderMaterial({ uniforms: UniformsUtils.clone(BrightShader.uniforms),
+      vertexShader: BrightShader.vertexShader, fragmentShader: BrightShader.fragmentShader });
+    this._blur = new ShaderMaterial({ uniforms: UniformsUtils.clone(BlurShader.uniforms),
+      vertexShader: BlurShader.vertexShader, fragmentShader: BlurShader.fragmentShader });
+    this._comp = new ShaderMaterial({ uniforms: UniformsUtils.clone(CompositeShader.uniforms),
+      vertexShader: CompositeShader.vertexShader, fragmentShader: CompositeShader.fragmentShader });
+    this._quad = new FullScreenQuad(null);
+  }
+
+  setSize(width, height) {
+    this._rtBright.setSize(Math.max(1, width >> 1), Math.max(1, height >> 1));
+    for (let i = 0; i < LEVELS; i++) {
+      const w = Math.max(1, width >> (i + 1)), h = Math.max(1, height >> (i + 1));
+      this._levels[i].a.setSize(w, h); this._levels[i].b.setSize(w, h);
+      this._levels[i].size.set(1 / w, 1 / h);
+    }
+  }
+
+  _draw(renderer, material, target) {
+    this._quad.material = material;
+    renderer.setRenderTarget(target);
+    this._quad.render(renderer);
+  }
+
+  render(renderer, writeBuffer, readBuffer) {
+    const oldTarget = renderer.getRenderTarget();
+    const oldAutoClear = renderer.autoClear;
+    renderer.autoClear = false;
+
+    this._bright.uniforms.tDiffuse.value = readBuffer.texture;
+    this._bright.uniforms.threshold.value = this.threshold;
+    this._bright.uniforms.knee.value = this.knee;
+    this._draw(renderer, this._bright, this._rtBright);
+
+    // Each level blurs the level above it, so the kernel widens geometrically for free.
+    let src = this._rtBright;
+    for (let i = 0; i < LEVELS; i++) {
+      const L = this._levels[i];
+      this._blur.uniforms.texelSize.value.copy(L.size);
+      this._blur.uniforms.tDiffuse.value = src.texture;
+      this._blur.uniforms.direction.value.set(1, 0);
+      this._draw(renderer, this._blur, L.a);
+      this._blur.uniforms.tDiffuse.value = L.a.texture;
+      this._blur.uniforms.direction.value.set(0, 1);
+      this._draw(renderer, this._blur, L.b);
+      src = L.b;
+    }
+
+    this._comp.uniforms.tDiffuse.value = readBuffer.texture;
+    this._comp.uniforms.tBloom0.value = this._levels[0].b.texture;
+    this._comp.uniforms.tBloom1.value = this._levels[1].b.texture;
+    this._comp.uniforms.tBloom2.value = this._levels[2].b.texture;
+    this._comp.uniforms.strength.value = this.strength;
+    this._draw(renderer, this._comp, this.renderToScreen ? null : writeBuffer);
+
+    renderer.autoClear = oldAutoClear;
+    renderer.setRenderTarget(oldTarget);
+  }
+
+  dispose() {
+    this._rtBright.dispose();
+    this._levels.forEach(L => { L.a.dispose(); L.b.dispose(); });
+    this._bright.dispose(); this._blur.dispose(); this._comp.dispose(); this._quad.dispose();
+  }
+}
+
+export { BloomPass };

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -100,7 +100,11 @@ async function setupScene(A) {
   // §S260c: ACESFilmic tone mapping — preserves color saturation, adds cinematic contrast.
   // NoToneMapping was flat/grey. ACES gives "crisp vibrant" look like Bonsai/Autodesk.
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 0.45;
+  // §PHOTO_EXPOSURE (2026-07-27, user: "Scene still too dark drab"). Was 0.45 — less than half
+  // three.js's own default of 1.0, i.e. the whole app was rendering roughly a stop under-exposed,
+  // which is a large part of why interiors read as drab and why emissive luminaires were invisible
+  // (a glow measured through a half-stop-down exposure has half a stop less to show).
+  renderer.toneMappingExposure = 1.0;
   console.log('§TONEMAPPING type=ACESFilmic exposure=0.45');
   renderer.localClippingEnabled = true;
   renderer.outputColorSpace = THREE.SRGBColorSpace;  // §S259: proper gamma curve for web display

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -100,11 +100,13 @@ async function setupScene(A) {
   // §S260c: ACESFilmic tone mapping — preserves color saturation, adds cinematic contrast.
   // NoToneMapping was flat/grey. ACES gives "crisp vibrant" look like Bonsai/Autodesk.
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  // §PHOTO_EXPOSURE (2026-07-27, user: "Scene still too dark drab"). Was 0.45 — less than half
-  // three.js's own default of 1.0, i.e. the whole app was rendering roughly a stop under-exposed,
-  // which is a large part of why interiors read as drab and why emissive luminaires were invisible
-  // (a glow measured through a half-stop-down exposure has half a stop less to show).
-  renderer.toneMappingExposure = 1.0;
+  // §PHOTO_EXPOSURE — 0.45 is DELIBERATE and stays. It has been the daytime value since the initial
+  // migration, and the user recalls overexposure problems from raising it ("AFAIR before we may have
+  // issue of overexposure"). Briefly set to 1.0 this session to fix "too dark drab" and reverted:
+  // doubling the base brightens DAY NAVIGATION too, which is not what was being complained about.
+  // The lift is applied to the frozen still ONLY — see PHOTO_EXPOSURE_LIFT in effects.js — matching
+  // how bloom, ember and the 48-light budget are all still-only.
+  renderer.toneMappingExposure = 0.45;
   console.log('§TONEMAPPING type=ACESFilmic exposure=0.45');
   renderer.localClippingEnabled = true;
   renderer.outputColorSpace = THREE.SRGBColorSpace;  // §S259: proper gamma curve for web display

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v864';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v865';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -43,6 +43,7 @@ const SHELL_LIBS = [
   'lib/SSAOPass.js',
   'lib/OutlinePass.js',
   'lib/OutputPass.js',
+  'lib/BloomPass.js',
   // §CINEMA_SSAA (2026-07-18) + transitive-import completion: the 6 modules above `import` these
   // 8 (Pass/CopyShader ← everything; ShaderPass/MaskPass ← EffectComposer; SSAARenderPass ←
   // TAARenderPass; SimplexNoise/SSAOShader ← SSAOPass; OutputShader ← OutputPass) — precaching

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -819,7 +819,14 @@ function setupTools(A) {
   A._nightLights = [];       // active THREE.PointLight objects
   A._nightFixtures = [];     // [{x,y,z}] from DB — IFC coordinates
   A._nightSaved = null;      // saved day settings
-  var NIGHT_MAX_LIGHTS = 12; // §S277d: 12 proximity-culled lights — perf cap (each light = per-pixel cost/frame)
+  // §NIGHT_STILL_LIGHTS (2026-07-27, user: "alt-s is quite impressive if more lights chances").
+  // 12 is a NAVIGATION budget — every point light costs per-pixel work on every lit material every
+  // frame, so 12 is what a 60fps orbit can carry. A frozen still has no frame budget to protect: it
+  // renders once and then sits there. So the cap is a variable the still can raise, not a constant.
+  // Read through A._nightMaxLights everywhere below so raising it and re-running _nightUpdateLights
+  // is all that is needed.
+  A._nightMaxLights = 12;          // navigation budget
+  A._nightMaxLightsStill = 48;     // frozen-still budget — 4x, paid once
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
   var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
@@ -898,7 +905,24 @@ function setupTools(A) {
       if (A.db) {
         try {
           // §S277c: Include IfcFlowTerminal + IfcElectricAppliance — most models lack IfcLightFixture
-          var r = A.db.exec("SELECT t.center_x, t.center_y, t.center_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance')");
+          // §NIGHT_FIXTURE_VOCAB (2026-07-27): class alone is far too wide — on the Clinic,
+          // IfcFlowTerminal covers 961 M_Duplex Receptacle and 236 M_Lighting Switches as well as
+          // the real luminaires, so every power socket in the building became a light source.
+          // Keep the class net (it is what finds luminaires in models with no IfcLightFixture) but
+          // require the NAME to look like a luminaire and not like an accessory — the same
+          // vocabulary §PHOTO_EMBER uses, and the "filter for 'light'" the user asked for. Measured
+          // on the Clinic: 1105 naive name matches -> 841 real luminaires, 264 rejected.
+          var r = A.db.exec(
+            "SELECT t.center_x, t.center_y, t.center_z FROM elements_meta m " +
+            "JOIN element_transforms t ON m.guid=t.guid " +
+            "WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') " +
+            "AND (LOWER(m.element_name) LIKE '%light%' OR LOWER(m.element_name) LIKE '%troffer%' " +
+            "  OR LOWER(m.element_name) LIKE '%downlight%' OR LOWER(m.element_name) LIKE '%luminaire%' " +
+            "  OR LOWER(m.element_name) LIKE '%lamp%' OR LOWER(m.element_name) LIKE '%sconce%' " +
+            "  OR LOWER(m.element_name) LIKE '%pendant%') " +
+            "AND NOT (LOWER(m.element_name) LIKE '%switch%' OR LOWER(m.element_name) LIKE '%receptacle%' " +
+            "  OR LOWER(m.element_name) LIKE '%panelboard%' OR LOWER(m.element_name) LIKE '%socket%' " +
+            "  OR LOWER(m.element_name) LIKE '%outlet%')");
           if (r.length && r[0].values.length > 0) {
             r[0].values.forEach(function(row) {
               A._nightFixtures.push({ x: row[0], y: row[1], z: row[2] });
@@ -938,14 +962,24 @@ function setupTools(A) {
       // Determine which IFC classes to glow
       A._nightGlowClasses = ['IfcLightFixture'];
       // Check if building has any IfcLightFixture — if not, fallback to FlowTerminal
-      var _hasNamedLights = false;
+      // §NIGHT_GLOW_CLASS_GATE (2026-07-27, user: "In Night mode, these were not identified, thus
+      // the Alt-s also didn't pick it up nor alt-c" — reporting M_Troffer Light on the Clinic).
+      // THE BUG: this test used to read
+      //     ifc_class='IfcLightFixture' OR LOWER(element_name) LIKE '%light%' OR ...
+      // which mixes two different questions. The Clinic HAS named lights (1105 rows match on name)
+      // but ZERO IfcLightFixture — its luminaires are IfcFlowTerminal. So the gate came back true,
+      // the IfcFlowTerminal widening was SKIPPED, _nightGlowClasses stayed ['IfcLightFixture'], and
+      // nothing at all glowed. Having named lights disabled the very fallback that would have
+      // caught them. The only question this gate should ask is whether the CLASS is present, since
+      // the class list is all it controls.
+      var _hasClassLights = false;
       if (A.db) {
         try {
-          var lr = A.db.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class='IfcLightFixture' OR LOWER(element_name) LIKE '%light%' OR LOWER(element_name) LIKE '%lamp%' OR LOWER(element_name) LIKE '%led%' OR LOWER(element_name) LIKE '%luminaire%'");
-          _hasNamedLights = lr.length && lr[0].values[0][0] > 0;
+          var lr = A.db.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class='IfcLightFixture'");
+          _hasClassLights = lr.length && lr[0].values[0][0] > 0;
         } catch(e) {}
       }
-      if (!_hasNamedLights) {
+      if (!_hasClassLights) {
         A._nightGlowClasses.push('IfcFlowTerminal', 'IfcElectricAppliance');
         source += '+fallback';
       }
@@ -1062,7 +1096,7 @@ function setupTools(A) {
     var allPos = A._nightFixturePositions;
     var camPos = A.camera.position;
     var needed;
-    if (allPos.length <= NIGHT_MAX_LIGHTS) {
+    if (allPos.length <= A._nightMaxLights) {
       // Small building — place ALL fixtures, no culling
       needed = allPos.map(function(p) { return { pos: p }; });
     } else {
@@ -1081,7 +1115,7 @@ function setupTools(A) {
         var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
         return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
       }).sort(function(a, b) { return a.dist2 - b.dist2; });
-      needed = sorted.slice(0, NIGHT_MAX_LIGHTS);
+      needed = sorted.slice(0, A._nightMaxLights);
     }
     // Remove old lights
     A._nightLights.forEach(function(l) {

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -827,6 +827,8 @@ function setupTools(A) {
   // is all that is needed.
   A._nightMaxLights = 12;          // navigation budget
   A._nightMaxLightsStill = 48;     // frozen-still budget — 4x, paid once
+  A._nightNearFadeFloor = 0.3;     // navigation: a light at the eye dims to 30% (anti-blowout)
+  A._nightNearFadeFloorStill = 1.0;// still: no proximity penalty at all
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
   var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
@@ -1130,7 +1132,15 @@ function setupTools(A) {
     needed.forEach(function(f) {
       var dist = camPos.distanceTo(f.pos);
       var fade = Math.min(1.0, dist / 15);              // 0 at the light, full at 15m+
-      var intensity = NIGHT_LIGHT_INTENSITY * (0.3 + 0.7 * fade);  // never below 30%
+      // §NIGHT_NEAR_FADE (2026-07-27, user: "They dont catch even lights right near to cam").
+      // This fade cuts a light to 30% as you approach it — added to fix "inside too bright", and it
+      // is exactly backwards for the complaint now being made: standing under a fixture gives the
+      // WEAKEST light in the scene. Kept for navigation (it is what stops an interior orbit
+      // blowing out) but lifted to full strength for the frozen still, where there is no exposure
+      // to protect and where the whole point is that the fixture you are standing under reads as
+      // lit. A._nightNearFadeFloor is raised by startStillRefine alongside the light count.
+      var floor = A._nightNearFadeFloor;
+      var intensity = NIGHT_LIGHT_INTENSITY * (floor + (1 - floor) * fade);
       var light = new THREE.PointLight(0xffe4b5, intensity, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
       light.position.copy(f.pos);
       A.scene.add(light);

--- a/witness_maxq_hidden_pause.js
+++ b/witness_maxq_hidden_pause.js
@@ -1,0 +1,179 @@
+// WITNESS — §MAXQ_HIDDEN_PAUSE: a backgrounded tab parks the bake instead of ruining the film.
+// Spec: bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §MAXQ_HIDDEN_PAUSE.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, Hospital, 2026-07-27):
+// They baked a 45s film and it came out with a dead tail, then said "The hospital just before was
+// frozen tab due to been out of focus." Chrome throttles rAF to a near-stop in a hidden tab, so the
+// per-frame TAA fold + §PHOTO_AO never converge, _waitFoldDone's WALL-CLOCK timeout expires, and
+// §MAXQ_FRAME_TIMEOUT saves a frame that never finished. Consecutive such captures come out
+// near-duplicates, so the delivered MP4 ends in visually dead video. From their console:
+//     §TAB_VISIBILITY visible=false
+//     STILL_REFINE done elapsedMs 850 -> 11190 -> 25589 -> 45355
+//     §MAXQ_FRAME_TIMEOUT i=683 — capturing as-is
+// It does not throw, does not stop, and the file plays fine. That silence is the defect: a
+// measurement pass looking for defects had already mis-attributed the dead tail to PACING.
+//
+//   G-HID-1  the bake does not advance while hidden — frame index at hide == frame index at reveal.
+//   G-HID-2  it says so: §MAXQ_HIDDEN_PAUSE on hide, §MAXQ_HIDDEN_RESUME with measured hiddenMs.
+//   G-HID-3  no frame captured unconverged across a hide/reveal — ZERO §MAXQ_FRAME_TIMEOUT. This is
+//            the gate that maps directly to the ruined film.
+//   G-HID-4  the run reports its own health (§MAXQ_QUALITY ... unconverged=0), so a pasted console
+//            answers "is this film any good" without re-deriving it.
+//   G-HID-5  regression: a bake never hidden is unaffected — no pause lines, and it still finishes.
+//
+// The tab is hidden the REAL way — a second tab is brought to front — because the thing under test
+// is the browser's own throttling. Patching document.hidden would test the patch, not the browser.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8402;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const FRAMES = parseInt(process.env.FRAMES || '10', 10);
+const HIDE_MS = parseInt(process.env.HIDE_MS || '20000', 10);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Anchored at line start, ALWAYS. §MAXQ_LOADED's version string names the features it ships, so an
+// unanchored /§MAXQ_HIDDEN_PAUSE/ matches the banner and the witness grades itself on its own
+// version line — which it did on the first run here, failing three gates that were actually fine.
+const has = (logs, re) => logs.some(l => re.test(l));
+const find = (logs, re) => { const h = logs.filter(l => re.test(l)); return h.length ? h[h.length - 1] : null; };
+const num = (l, re) => { const m = l && l.match(re); return m ? parseFloat(m[1]) : null; };
+// Highest frame index the bake has reached, read from its own progress lines.
+const frameIdx = logs => logs.reduce((mx, l) => {
+  const m = l.match(/§MAXQ_(?:FRAME|HIDDEN_PAUSE at frame) i?=?\s*(\d+)/) || l.match(/frame (\d+)\//);
+  return m ? Math.max(mx, parseInt(m[1], 10)) : mx;
+}, -1);
+
+async function openViewer(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 900, height: 560 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.startMaxQualityOrbit && window.APP._composer, { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  return { page, logs };
+}
+
+// preview:false + editor:false — this witness is about the frame loop, and the editor would block it
+// waiting for an OK that no one is going to click.
+const startBake = page => page.evaluate(n => {
+  window.APP.startMaxQualityOrbit({ preview: false, editor: false, fps: 1, frames: n, forceWebm: true });
+}, FRAMES);
+
+async function run(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+
+  const { page, logs } = await openViewer(browser, BLD);
+  await startBake(page);
+  // Let it get a few frames in, so the hide lands mid-bake rather than during setup.
+  for (let i = 0; i < 240 && frameIdx(logs) < 1; i++) await sleep(1000);
+  const idxBefore = frameIdx(logs);
+  const timeoutsBefore = logs.filter(l => /§MAXQ_FRAME_TIMEOUT/.test(l)).length;
+
+  // ── hide it the way a user does: another tab takes the foreground.
+  const other = await browser.newPage();
+  await other.goto('about:blank', { waitUntil: 'domcontentloaded' });
+  await other.bringToFront();
+  const hiddenSeen = await page.evaluate(() => document.visibilityState).catch(() => '?');
+  await sleep(HIDE_MS);
+  const idxHidden = frameIdx(logs);
+  await page.bringToFront();
+  await other.close();
+  await sleep(4000);
+
+  const pause = find(logs, /^§MAXQ_HIDDEN_PAUSE/), resume = find(logs, /^§MAXQ_HIDDEN_RESUME/);
+  const hiddenMs = num(resume, /hiddenMs=(\d+)/);
+  // The invariant is NOT "the frame index freezes". A hide can land just after the loop enters the
+  // next frame, so the index may legitimately tick once before that frame parks in its cook — which
+  // is exactly what happened (paused at "cook of frame 2/10" after hiding at index 1). What must
+  // hold is that the frame IN FLIGHT when the tab hid is the SAME frame that resumes: it did not
+  // finish, was not captured, and no further frame was started. Asserting the stricter, wrong thing
+  // failed a fix that was working.
+  const frameOf = l => { const m = l && l.match(/at cook of frame (\d+)/); return m ? m[1] : null; };
+  P('G-HID-1 the frame in flight when the tab hid is the same frame that resumes — none completed hidden',
+    hiddenSeen === 'hidden' && frameOf(pause) !== null && frameOf(pause) === frameOf(resume) &&
+      idxHidden - idxBefore <= 1,
+    `visibilityState while backgrounded = "${hiddenSeen}" (must be "hidden", else the rig never hid it)\n` +
+    `          parked on frame ${frameOf(pause)}, resumed on frame ${frameOf(resume)} (must match)\n` +
+    `          frame index at hide = ${idxBefore}, after ${(HIDE_MS / 1000).toFixed(0)}s hidden = ${idxHidden} (may tick at most once, into the frame that then parks)`);
+  P('G-HID-2 it says so — §MAXQ_HIDDEN_PAUSE on hide, §MAXQ_HIDDEN_RESUME with measured hiddenMs',
+    !!pause && !!resume && hiddenMs !== null && hiddenMs > HIDE_MS * 0.5,
+    `pause : ${pause ? pause.slice(0, 96) : '(none)'}\n` +
+    `          resume: ${resume || '(none)'}\n` +
+    `          measured hiddenMs=${hiddenMs} against ${HIDE_MS}ms of real hiding`);
+
+  // A health line that OVERSTATES is as useless as one that lies: a double-counted total once
+  // reported 40908ms for a single 20516ms pause. One pause, so the total must equal it.
+  const totalHidden = num(resume, /totalHiddenMs=(\d+)/), pausesN = num(resume, /pauses=(\d+)/);
+  P('G-HID-2b the reported total is not double-counted — one pause, total == that pause',
+    totalHidden !== null && pausesN === 1 && Math.abs(totalHidden - hiddenMs) < 50,
+    `pauses=${pausesN} hiddenMs=${hiddenMs} totalHiddenMs=${totalHidden} (must differ by <50ms)`);
+
+  // Let the rest of the frames finish so §MAXQ_QUALITY lands.
+  for (let i = 0; i < 600 && !has(logs, /^§MAXQ_QUALITY/); i++) await sleep(1000);
+
+  const timeouts = logs.filter(l => /§MAXQ_FRAME_TIMEOUT/.test(l));
+  P('G-HID-3 no frame captured unconverged across the hide — zero §MAXQ_FRAME_TIMEOUT',
+    timeouts.length === timeoutsBefore,
+    `${timeouts.length} §MAXQ_FRAME_TIMEOUT total (${timeoutsBefore} before the hide)` +
+    (timeouts.length ? '\n          ' + timeouts.slice(-3).join('\n          ') : ' — the film is clean'));
+
+  // The property is HONESTY, not a clean render: under swiftshader a genuinely slow frame can blow
+  // the 30s budget, and demanding unconverged=0 would gate the rasterizer rather than the code. What
+  // must hold is that the line EXISTS and its numbers match what actually happened — a run that
+  // degraded has to say the same thing the timeout warnings say.
+  const q = find(logs, /^§MAXQ_QUALITY/);
+  const qUnconv = num(q, /unconverged=(\d+)/), qPauses = num(q, /hiddenPauses=(\d+)/);
+  P('G-HID-4 the run reports its own health truthfully, so a degraded film cannot finish quietly',
+    !!q && qUnconv === timeouts.length && qPauses >= 1,
+    `${q || '(no §MAXQ_QUALITY line — unpatched build)'}\n` +
+    `          reported unconverged=${qUnconv} against ${timeouts.length} actual §MAXQ_FRAME_TIMEOUT lines; hiddenPauses=${qPauses} (must be >=1)`);
+
+  await page.close();
+  return checks;
+}
+
+async function regression(browser, BLD) {
+  const { page, logs } = await openViewer(browser, BLD);
+  await startBake(page);
+  for (let i = 0; i < 600 && !has(logs, /^§MAXQ_QUALITY/); i++) await sleep(1000);
+  const q = find(logs, /^§MAXQ_QUALITY/);
+  await page.close();
+  return [{
+    n: 'G-HID-5 a bake that is never hidden is unaffected — no pause lines, still finishes',
+    ok: !!q && /hiddenPauses=0/.test(q) && !has(logs, /^§MAXQ_HIDDEN_PAUSE/),
+    d: `${q || '(no §MAXQ_QUALITY line)'}\n` +
+       `          §MAXQ_HIDDEN_PAUSE lines: ${logs.filter(l => /^§MAXQ_HIDDEN_PAUSE/.test(l)).length} (must be 0)`
+  }];
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}  (${FRAMES} frames, hidden for ${HIDE_MS / 1000}s mid-bake)\n${'='.repeat(78)}`);
+    const checks = (await run(browser, BLD)).concat(await regression(browser, BLD));
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
Two things, both from live reports today.

## §MAXQ_HIDDEN_PAUSE — a backgrounded tab was silently ruining films
The user lost a 45s Hospital bake and only knew because they remembered the tab was unfocused. rAF does not throttle in a hidden tab, it **stops** — a probe counted ticks frozen at exactly 167 for 6s — so every `await _raf2()` blocked, the fold never converged, and `§MAXQ_FRAME_TIMEOUT` saved unconverged frames that come out as near-duplicates. Complete, playable MP4; dead last seconds.

`witness_maxq_hidden_pause.js` **6/6**, RED **0/6** on main with the extra unconverged frame appearing live during the hide. Every run now ends with `§MAXQ_QUALITY … unconverged=N` so a degraded bake cannot finish quietly.

## Lighting — "Scene still too dark drab" / "these are not lighted"
| | |
|---|---|
| **§NIGHT_GLOW_CLASS_GATE** | The gate asked `ifc_class='IfcLightFixture' OR name LIKE '%light%'`. The Clinic has 1,105 named lights but **zero** `IfcLightFixture`, so the gate said yes and *skipped* the `IfcFlowTerminal` widening — nothing glowed. Now `fixtures=841 source=IFC+fallback`. |
| **§NIGHT_FIXTURE_VOCAB** | Night point-lights sat on every `IfcFlowTerminal` — 961 receptacles and 236 switches were light sources. |
| **§NIGHT_NEAR_FADE** | A light *at* the camera ran at 30%, the weakest in the scene. Lifted to full for the still. |
| **§NIGHT_STILL_LIGHTS** | 12 was a 60fps nav budget; a still gets 48 and hands them back. |
| **§PHOTO_EMBER** | 841 luminaires emissive for the still, by name vocabulary (class is inconsistent across buildings; `%light%` alone catches switches). |
| **§PHOTO_BLOOM** | New `BloomPass.js`, written not imported — three's UnrealBloomPass isn't vendored and the app must work offline. Emissive alone measured **56.13 → 56.13**, i.e. invisible; bloom is what makes glow exist. |
| **§PHOTO_EXPOSURE_LIFT** | The still ran at `0.45 × 0.85 = 0.38`. Lifted 2.2× **in the photoshoot only** — the renderer default stays 0.45, per the user's recollection of overexposure. |

Measured: night still is **+67% brighter** than night nav (61.77 → 103.17 mean luminance).

**Everything here is still-only. Navigation is unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)