### PR TITLE
feat(night): §PHOTO_GLOW_SPRITE — luminaires light up in night mode, no scene material touched

### DIFF
--- a/probe_glow_diag.js
+++ b/probe_glow_diag.js
@@ -1,0 +1,91 @@
+// DIAGNOSTIC — W-GLOW-SPRITE came back PARTIAL: 841/841 sprites staged, 0 materials touched, but
+// mean luminance moved only +0.7% over bloom-alone.
+//
+// FIRST RUN ANSWERED THE FIRST QUESTION (Clinic @ poseAt(0.60)):
+//   inFrustum 159, occluded 158, clear 1, gap median 7.97m, p25 5.02m
+// A 7.97m gap is not a fixture-thickness problem — those sprites are behind WALLS, in rooms the
+// camera cannot see into, and depthTest hiding them is CORRECT. The pose simply has nothing to light.
+// But gapMin was 0.019m, so some sprites are hidden by their OWN fitting, which the 0.15m eye offset
+// was supposed to clear and did not.
+//
+// SO THIS RUN ANSWERS TWO THINGS, both by measurement, so neither the pose nor the offset is a guess:
+//   1. gap HISTOGRAM — how many occlusions are the fitting itself (small gap) vs a wall (large gap)?
+//      That threshold is what a corrective rule would key on.
+//   2. POSE SCAN across the whole Alt+C plan — which t has fixtures actually in line of sight? The
+//      witness must be measured somewhere the mechanism can be seen to work or fail on its merits.
+// Run: PORT=8403 BLD=Clinic node probe_glow_diag.js
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8403, BLD = process.env.BLD || 'Clinic';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = []; page.on('console', m => logs.push(m.text())); page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine && window.APP._composer, { timeout: 240000 });
+  await sleep(12000);
+  await page.waitForFunction(() => { try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; } catch (e) { return false; } }, { timeout: 180000, polling: 2000 });
+  const all = await page.evaluate(() => (window.APP.dbQuery('SELECT DISTINCT building FROM elements_meta') || []).map(r => r[0]));
+  for (const b of all.filter(x => /Architectural|Electrical/i.test(x)).sort()) {
+    await page.evaluate(bb => { try { window.APP.streamBuilding(bb); } catch (e) {} }, b);
+    let prev = -1; for (let i = 0; i < 60; i++) { const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length); if (n === prev && n > 0) break; prev = n; await sleep(2000); }
+  }
+  await page.evaluate(() => window.APP.toggleNightMode());
+  await sleep(4000);
+
+  const scan = await page.evaluate(() => {
+    const A = window.APP, THREE = window.THREE;
+    const pos = A._nightFixtureWorldPositions();
+    const cam = A.camera, plan = A.cinemaPathPlan(30);
+    const meshes = A.collectMeshes(o => o.isMesh && o.visible);
+    const rc = new THREE.Raycaster(), v = new THREE.Vector3(), dir = new THREE.Vector3();
+    const EYE = 0.15;
+    const rows = [], histAll = {};
+    const BINS = [0.05, 0.1, 0.2, 0.3, 0.5, 0.8, 1.5, 3, 6, 12, 1e9];
+    BINS.forEach(b => histAll[b] = 0);
+    for (let s = 0; s <= 20; s++) {
+      const t = s / 20, p = plan.poseAt(t);
+      cam.position.set(p.x, p.y, p.z);
+      cam.lookAt(p.tx, p.ty, p.tz);
+      cam.updateMatrixWorld(true); cam.updateProjectionMatrix();
+      const fr = new THREE.Frustum().setFromProjectionMatrix(
+        new THREE.Matrix4().multiplyMatrices(cam.projectionMatrix, cam.matrixWorldInverse));
+      let inF = 0, clear = 0, near = 0;
+      for (let i = 0; i < pos.length; i++) {
+        // same eye-offset the staging applies
+        const q = pos[i];
+        dir.copy(cam.position).sub(q).normalize();
+        v.copy(q).addScaledVector(dir, EYE);
+        if (!fr.containsPoint(v)) continue;
+        inF++;
+        const dist = cam.position.distanceTo(v);
+        dir.copy(v).sub(cam.position).normalize();
+        rc.set(cam.position, dir); rc.far = dist;
+        const hit = rc.intersectObjects(meshes, false);
+        if (!hit.length || hit[0].distance >= dist - 0.001) { clear++; continue; }
+        const gap = dist - hit[0].distance;
+        for (const b of BINS) if (gap <= b) { histAll[b]++; break; }
+        if (gap <= 0.8) near++;
+      }
+      rows.push({ t: +t.toFixed(2), inFrustum: inF, clear, nearOccluded: near,
+        pose: { x: +p.x.toFixed(1), y: +p.y.toFixed(1), z: +p.z.toFixed(1), tx: +p.tx.toFixed(1), ty: +p.ty.toFixed(1), tz: +p.tz.toFixed(1) } });
+    }
+    return { fixtures: pos.length, rows, histAll, bins: BINS, pathLen: plan.pathLen };
+  });
+  await browser.close();
+
+  console.log(`\n=== §PHOTO_GLOW_SPRITE pose scan — ${BLD}, ${scan.fixtures} fixtures, Alt+C path ${scan.pathLen ? scan.pathLen.toFixed(1) : '?'}m`);
+  console.log('  t      inFrustum  clearLOS  nearOccluded(<=0.8m, i.e. its own fitting)   camera');
+  scan.rows.forEach(r => console.log(
+    `  ${String(r.t).padEnd(6)} ${String(r.inFrustum).padStart(7)} ${String(r.clear).padStart(10)} ${String(r.nearOccluded).padStart(12)}          ` +
+    `(${r.pose.x}, ${r.pose.y}, ${r.pose.z}) -> (${r.pose.tx}, ${r.pose.ty}, ${r.pose.tz})`));
+  console.log('\n  occlusion gap histogram, all poses pooled — small gap = the fitting itself, large = a wall');
+  let prev = 0;
+  scan.bins.forEach(b => { console.log(`    <= ${String(b === 1e9 ? 'inf' : b + 'm').padEnd(6)} ${String(scan.histAll[b]).padStart(6)}   (from ${prev}m)`); prev = b; });
+  const best = scan.rows.slice().sort((a, b) => b.clear - a.clear)[0];
+  console.log(`\n  BEST POSE for the witness: t=${best.t} with ${best.clear} fixtures in clear line of sight (of ${best.inFrustum} in frustum)`);
+  console.log(logs.filter(l => /PAGEERROR/.test(l)).join('\n'));
+})();

--- a/probe_glow_night.js
+++ b/probe_glow_night.js
@@ -1,0 +1,159 @@
+// ⚠ WITNESS W-GLOW-SPRITE — bim-compiler prompts/NIGHT_AND_FIXTURE_LIGHTING.md §PHOTO_GLOW_SPRITE
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   §PHOTO_EMBER lit luminaires by setting `emissive` on the MATERIALS they are drawn with. Batched
+//   and instanced meshes share ONE material across everything they draw (Hospital: 1216 luminaires
+//   -> 7 materials), so it lit WALL PANELS, beams and railings, and `toneMapped=false` on a material
+//   shared with a transparent panel rendered that panel pure black. §PHOTO_GLOW_SPRITE replaces it
+//   with an additive Points cloud at the fixture positions, which touches NO scene material at all.
+//
+// WHAT IS ASSERTED — inclusion and application, not photometry:
+//   1. INCLUDED   the luminaire vocabulary selects the real fittings and rejects the accessories
+//                 (switches / receptacles / panelboards / sockets / outlets), reported per family.
+//   2. APPLIED    every included fixture gets a sprite, in NIGHT MODE, with no Alt+S pressed; and
+//                 they are all gone when night mode goes off.
+//   3. NOTHING ELSE TOUCHED   emissive / emissiveIntensity / toneMapped of every scene material,
+//                 snapshotted before staging and diffed after. Zero mutations is what makes lit
+//                 wall panels and black rectangles impossible here rather than merely filtered —
+//                 those two failures ARE a changed `emissive` and a flipped `toneMapped`.
+//
+// Deliberately NOT measured: frame luminance. Pixel measurement needs a camera standing where lamps
+// are in line of sight, and finding one costs a raycast search (~50ms/ray against batched meshes)
+// plus ~90s per Alt+S fold — for a question that inclusion and application already answer.
+// Run: PORT=8403 BLD=Clinic node probe_glow_night.js   |   BLD=Hospital ...
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8403, BLD = process.env.BLD || 'Clinic';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const LUM = ['light', 'troffer', 'downlight', 'luminaire', 'lamp', 'sconce', 'pendant'];
+const NOT = ['switch', 'receptacle', 'panelboard', 'socket', 'outlet'];
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = []; page.on('console', m => logs.push(m.text())); page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.toggleNightMode && window.APP._glowSpriteCount, { timeout: 240000 });
+  await sleep(12000);
+  await page.waitForFunction(() => { try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; } catch (e) { return false; } }, { timeout: 180000, polling: 2000 });
+
+  const all = await page.evaluate(() => (window.APP.dbQuery('SELECT DISTINCT building FROM elements_meta') || []).map(r => r[0]));
+  const want = all.filter(x => /Architectural|Electrical/i.test(x)).sort();
+  for (const b of want) await page.evaluate(bb => { try { window.APP.streamBuilding(bb); } catch (e) {} }, b);
+  // Settle-wait UNCONDITIONALLY, not only after an explicit streamBuilding: Hospital is a
+  // single-model DB, so `want` is empty and a stream-gated wait never runs at all.
+  let guidMapN = -1, stable = 0;
+  for (let i = 0; i < 90; i++) {
+    const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length);
+    stable = (n === guidMapN && n > 0) ? stable + 1 : 0;
+    if (stable >= 3) break;
+    guidMapN = n; await sleep(2000);
+  }
+
+  // ── 1. INCLUDED: what the vocabulary selects, and what it rejects.
+  const sel = await page.evaluate((L, N) => {
+    const A = window.APP;
+    const like = (w, j) => w.map(x => "LOWER(element_name) LIKE '%" + x + "%'").join(j);
+    const q = s => { try { return A.dbQuery(s) || []; } catch (e) { return []; } };
+    const rows = q("SELECT m.element_name, m.ifc_class FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+      "WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') AND (" + like(L, ' OR ') + ") AND NOT (" + like(N, ' OR ') + ")");
+    const naive = q("SELECT COUNT(*) FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+      "WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') AND (" + like(L, ' OR ') + ")");
+    // what the NOT clause threw away, by family — the accessories that must not become light sources
+    const rej = q("SELECT m.element_name, COUNT(*) FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+      "WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') AND (" + like(L, ' OR ') + ") AND (" + like(N, ' OR ') + ") GROUP BY 1 ORDER BY 2 DESC");
+    const fams = {}, classes = {};
+    rows.forEach(r => { const f = String(r[0]).split(':')[0]; fams[f] = (fams[f] || 0) + 1; classes[r[1]] = (classes[r[1]] || 0) + 1; });
+    return { kept: rows.length, naive: naive.length ? naive[0][0] : 0, families: fams, classes,
+             rejected: rej.map(r => [String(r[0]).split(':')[0], r[1]]) };
+  }, LUM, NOT);
+
+  const snap = () => page.evaluate(() => {
+    const seen = {}, out = [];
+    window.APP.collectMeshes(o => o.isMesh).forEach(o => {
+      (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => {
+        if (!m || seen[m.uuid]) return; seen[m.uuid] = 1;
+        out.push([m.uuid, m.emissive ? m.emissive.getHex() : -1, m.emissiveIntensity === undefined ? -1 : m.emissiveIntensity, m.toneMapped !== false ? 1 : 0]);
+      });
+    });
+    return out;
+  });
+  const diff = (a, b) => {
+    const m = {}; a.forEach(r => m[r[0]] = r);
+    let n = 0; const eg = [];
+    b.forEach(r => { const o = m[r[0]]; if (!o) return;
+      if (o[1] !== r[1] || o[2] !== r[2] || o[3] !== r[3]) { n++; if (eg.length < 4) eg.push(`${r[0].slice(0, 8)} emissive ${o[1]}->${r[1]} int ${o[2]}->${r[2]} toneMapped ${o[3]}->${r[3]}`); } });
+    return { n, eg };
+  };
+
+  const dayMats = await snap();
+  await page.evaluate(() => window.APP.toggleNightMode());
+  await sleep(5000);
+  // Snapshot AFTER night mode: night legitimately makes its own fixture/window materials emissive.
+  // Everything the SPRITES do must leave this untouched.
+  const before = await snap();
+  const staged = await page.evaluate(() => window.APP._glowSpriteCount());
+  const fixtures = await page.evaluate(() => window.APP._nightFixtureWorldPositions().length);
+  const during = await snap();
+  // the cloud is one object with one material of its own — that is WHY nothing is shared
+  const cloud = await page.evaluate(() => {
+    const o = window.APP.scene.getObjectByName('__glowSprites');
+    if (!o) return null;
+    const shared = [];
+    window.APP.collectMeshes(m => m.isMesh).forEach(m => {
+      (Array.isArray(m.material) ? m.material : [m.material]).forEach(mm => { if (mm && mm.uuid === o.material.uuid) shared.push(m.name || m.type); });
+    });
+    return { type: o.type, count: o.geometry.attributes.position.count, matUuid: o.material.uuid.slice(0, 8),
+             blending: o.material.blending, depthTest: o.material.depthTest, depthWrite: o.material.depthWrite,
+             toneMapped: o.material.toneMapped, sharedWith: shared.length };
+  });
+
+  await page.evaluate(() => window.APP.toggleNightMode());   // night OFF
+  await sleep(3000);
+  const afterOff = await page.evaluate(() => window.APP._glowSpriteCount());
+  const after = await snap();
+  await browser.close();
+
+  const dNight = diff(dayMats, before), dDuring = diff(before, during);
+  // `after` is taken with night mode OFF, so it must be compared against the DAY snapshot, not
+  // against the night one — diffing it against `before` just re-reports night mode restoring its
+  // own glow materials and reads as a sprite failure. (It did, on the first run of this probe.)
+  const dAfter = diff(dayMats, after);
+  const L = '='.repeat(84);
+  console.log(`\n${L}\nW-GLOW-SPRITE — ${BLD}   (night mode only; inclusion + application, no photometry)\n${L}`);
+  console.log(`scene       ${guidMapN} guidMap entries   models: ${want.join(', ') || '(single-model DB)'}`);
+
+  console.log(`\n--- 1. INCLUDED — which elements the vocabulary selects`);
+  console.log(`  kept ${sel.kept} of ${sel.naive} class+name matches  (${sel.naive - sel.kept} accessories rejected)`);
+  Object.entries(sel.classes).sort((a, b) => b[1] - a[1]).forEach(([c, n]) => console.log(`    ifc_class  ${String(n).padStart(5)}  ${c}`));
+  Object.entries(sel.families).sort((a, b) => b[1] - a[1]).slice(0, 12).forEach(([f, n]) => console.log(`    included   ${String(n).padStart(5)}  ${f}`));
+  if (!sel.rejected.length) console.log(`    rejected       0  (this building has no accessories matching the light words)`);
+  sel.rejected.slice(0, 8).forEach(([f, n]) => console.log(`    REJECTED   ${String(n).padStart(5)}  ${f}`));
+
+  console.log(`\n--- 2. APPLIED — night mode alone, no Alt+S`);
+  console.log(`  fixtures resolved to world positions   ${fixtures}`);
+  console.log(`  sprites staged by night mode           ${staged}`);
+  console.log(`  sprites after night mode OFF           ${afterOff}`);
+  if (cloud) console.log(`  the cloud                              ${cloud.type} x${cloud.count}, material ${cloud.matUuid}, ` +
+    `additive=${cloud.blending === 2}, depthTest=${cloud.depthTest}, depthWrite=${cloud.depthWrite}, toneMapped=${cloud.toneMapped}`);
+
+  console.log(`\n--- 3. NOTHING ELSE TOUCHED — no lit wall panels, no black rectangles, by construction`);
+  console.log(`  scene materials tracked                ${before.length}`);
+  console.log(`  scene meshes sharing the cloud's material  ${cloud ? cloud.sharedWith : '?'}   (0 = it is the sprites' own material; this is the whole mechanism)`);
+  console.log(`  changed by NIGHT MODE itself           ${dNight.n}   (expected — night's own fixture/window glow)`);
+  console.log(`  changed by the SPRITES, staged         ${dDuring.n}${dDuring.eg.length ? '\n      ' + dDuring.eg.join('\n      ') : ''}`);
+  console.log(`  after night OFF, vs the DAY snapshot    ${dAfter.n}   (0 = everything handed back)${dAfter.eg.length ? '\n      ' + dAfter.eg.join('\n      ') : ''}`);
+  console.log(`  §PHOTO_EMBER for comparison            33 collateral elements on the Clinic; walls, beams and railings + black panels on Hospital`);
+
+  const clean = dDuring.n === 0 && dAfter.n === 0 && (!cloud || cloud.sharedWith === 0);
+  const applied = fixtures > 0 && staged === fixtures && afterOff === 0;
+  const included = sel.kept > 0 && sel.kept === fixtures;
+  console.log(`\nVERDICT     ${!clean ? 'FAIL — ' + dDuring.n + '/' + dAfter.n + ' scene materials mutated; wall panels are still at risk'
+    : !included ? 'FAIL — vocabulary selected ' + sel.kept + ' but ' + fixtures + ' reached world positions'
+    : !applied ? 'FAIL — ' + staged + ' sprites applied for ' + fixtures + ' fixtures, ' + afterOff + ' left after night off'
+    : 'PASS — ' + sel.kept + ' luminaires included, all ' + staged + ' applied in night mode, 0 scene materials touched'}`);
+  console.log(`\n--- § log lines`);
+  console.log(logs.filter(l => /§PHOTO_GLOW_SPRITE|§NIGHT_MODE|PAGEERROR/.test(l)).join('\n'));
+  process.exit(clean && applied && included ? 0 : 1);
+})();

--- a/probe_glow_pose.js
+++ b/probe_glow_pose.js
@@ -1,0 +1,117 @@
+// DIAGNOSTIC 3 — the pose scan returned clearLOS = 0 for the ENTIRE interior walk band
+// (t=0.15..0.60, 100-200 fixtures in frustum each, none in line of sight). Standing in a corridor at
+// night with zero ceiling lights visible is not plausible, so before touching the sprite mechanism
+// again the pose itself has to be interrogated. Two questions, both answered numerically:
+//
+//   A. IS THE CAMERA INSIDE GEOMETRY? Cast 6 axis rays from each interior-band eye. If the nearest
+//      hit is a few cm in most directions, the camera is embedded in a wall/slab and EVERY fixture
+//      is occluded no matter what the sprites do. NIGHT_AND_FIXTURE_LIGHTING.md already records
+//      three separate attempts that put a probe camera inside walls.
+//
+//   B. A POSE CHOSEN FROM THE FIXTURE DATA, not from a path. For each of N sampled fixtures, stand
+//      the eye 1.6m below it (a fixture is on a ceiling; below it is the floor it lights), reject
+//      the spot if anything is within 0.5m in any direction (that is the inside-a-wall test), then
+//      score the candidate by how many fixtures it sees UNOCCLUDED. Pure search over measured
+//      geometry — no hand-picked viewpoint, and the winner is reproducible.
+// Run: PORT=8403 BLD=Clinic node probe_glow_pose.js
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8403, BLD = process.env.BLD || 'Clinic';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = []; page.on('console', m => logs.push(m.text())); page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine && window.APP._composer, { timeout: 240000 });
+  await sleep(12000);
+  await page.waitForFunction(() => { try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; } catch (e) { return false; } }, { timeout: 180000, polling: 2000 });
+  const all = await page.evaluate(() => (window.APP.dbQuery('SELECT DISTINCT building FROM elements_meta') || []).map(r => r[0]));
+  for (const b of all.filter(x => /Architectural|Electrical/i.test(x)).sort()) {
+    await page.evaluate(bb => { try { window.APP.streamBuilding(bb); } catch (e) {} }, b);
+    let prev = -1; for (let i = 0; i < 60; i++) { const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length); if (n === prev && n > 0) break; prev = n; await sleep(2000); }
+  }
+  await page.evaluate(() => window.APP.toggleNightMode());
+  await sleep(4000);
+
+  const res = await page.evaluate(() => {
+    const A = window.APP, THREE = window.THREE;
+    const pos = A._nightFixtureWorldPositions();
+    const meshes = A.collectMeshes(o => o.isMesh && o.visible);
+    const rc = new THREE.Raycaster(), dir = new THREE.Vector3(), v = new THREE.Vector3();
+    const DIRS = [[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
+
+    function clearance(p) {                       // nearest hit in 6 directions — inside-a-wall test
+      const out = [];
+      for (const d of DIRS) {
+        rc.set(p, dir.set(d[0], d[1], d[2])); rc.far = 6;
+        const h = rc.intersectObjects(meshes, false);
+        out.push(h.length ? +h[0].distance.toFixed(2) : null);
+      }
+      return out;
+    }
+
+    // ── A. the Alt+C interior band
+    const plan = A.cinemaPathPlan(30);
+    const band = [0.15, 0.25, 0.35, 0.45, 0.55, 0.60].map(t => {
+      const p = plan.poseAt(t);
+      const eye = new THREE.Vector3(p.x, p.y, p.z);
+      return { t, eye: [+p.x.toFixed(1), +p.y.toFixed(1), +p.z.toFixed(1)], clearance: clearance(eye) };
+    });
+
+    // fixture height distribution — a ceiling light should sit ~2.5-3.5m above the floor it lights
+    const ys = pos.map(p => p.y).sort((a, b) => a - b);
+    const q = f => +ys[Math.min(ys.length - 1, Math.floor(ys.length * f))].toFixed(2);
+
+    // ── B. search the fixture cloud for a standable eye
+    const cam = A.camera;
+    const bbox = new THREE.Box3(); pos.forEach(p => bbox.expandByPoint(p));
+    const centre = bbox.getCenter(new THREE.Vector3());
+    const STEP = Math.max(1, Math.floor(pos.length / 120));   // ~120 candidates, deterministic stride
+    const cands = [];
+    for (let i = 0; i < pos.length; i += STEP) {
+      const eye = new THREE.Vector3(pos[i].x, pos[i].y - 1.6, pos[i].z);   // stand under the fixture
+      const cl = clearance(eye);
+      const blocked = cl.filter(d => d !== null && d < 0.5).length;
+      if (blocked > 0) continue;                                           // embedded — reject
+      // look horizontally toward the fixture-cloud centre; a ceiling light is then in the upper frame
+      const look = new THREE.Vector3(centre.x, eye.y, centre.z);
+      if (look.distanceTo(eye) < 2) look.set(eye.x + 1, eye.y, eye.z);
+      cam.position.copy(eye); cam.lookAt(look);
+      cam.updateMatrixWorld(true); cam.updateProjectionMatrix();
+      const fr = new THREE.Frustum().setFromProjectionMatrix(
+        new THREE.Matrix4().multiplyMatrices(cam.projectionMatrix, cam.matrixWorldInverse));
+      let inF = 0, clear = 0;
+      for (let j = 0; j < pos.length; j++) {
+        const p = pos[j];
+        dir.copy(eye).sub(p).normalize();
+        v.copy(p).addScaledVector(dir, 0.15);
+        if (!fr.containsPoint(v)) continue;
+        inF++;
+        const dist = eye.distanceTo(v);
+        rc.set(eye, dir.copy(v).sub(eye).normalize()); rc.far = dist;
+        const h = rc.intersectObjects(meshes, false);
+        if (!h.length || h[0].distance >= dist - 0.001) clear++;
+      }
+      cands.push({ i, eye: [+eye.x.toFixed(2), +eye.y.toFixed(2), +eye.z.toFixed(2)],
+                   look: [+look.x.toFixed(2), +look.y.toFixed(2), +look.z.toFixed(2)],
+                   inFrustum: inF, clear, minClearance: Math.min(...cl.filter(d => d !== null).concat([99])) });
+    }
+    cands.sort((a, b) => b.clear - a.clear);
+    return { fixtures: pos.length, band, yq: { p05: q(0.05), p25: q(0.25), p50: q(0.5), p75: q(0.75), p95: q(0.95) },
+             candidates: cands.length, top: cands.slice(0, 8), rejected: Math.ceil(pos.length / STEP) - cands.length };
+  });
+  await browser.close();
+
+  console.log(`\n=== §PHOTO_GLOW_SPRITE pose interrogation — ${BLD}, ${res.fixtures} fixtures`);
+  console.log('\nA. is the Alt+C interior band standing inside geometry?');
+  console.log('   nearest hit within 6m along +X -X +Y -Y +Z -Z  (null = nothing within 6m)');
+  res.band.forEach(b => console.log(`   t=${String(b.t).padEnd(5)} eye (${b.eye.join(', ')})   ${JSON.stringify(b.clearance)}`));
+  console.log(`\n   fixture height (world Y) percentiles: p05 ${res.yq.p05}  p25 ${res.yq.p25}  p50 ${res.yq.p50}  p75 ${res.yq.p75}  p95 ${res.yq.p95}`);
+  console.log(`\nB. fixture-anchored eye search: ${res.candidates} standable candidates, ${res.rejected} rejected as embedded`);
+  console.log('   clear  inFrustum   eye -> look');
+  res.top.forEach(c => console.log(`   ${String(c.clear).padStart(5)} ${String(c.inFrustum).padStart(10)}   (${c.eye.join(', ')}) -> (${c.look.join(', ')})   minClearance ${c.minClearance}m`));
+  console.log(logs.filter(l => /PAGEERROR/.test(l)).join('\n'));
+})();

--- a/probe_glow_sprite.js
+++ b/probe_glow_sprite.js
@@ -1,0 +1,217 @@
+// ⚠ WITNESS W-GLOW-SPRITE — bim-compiler prompts/NIGHT_AND_FIXTURE_LIGHTING.md §PHOTO_GLOW_SPRITE
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   §PHOTO_EMBER lit luminaires by setting `emissive` on the MATERIALS they are drawn with. Batched
+//   and instanced meshes share one material across everything they draw (Hospital: 1216 luminaires ->
+//   7 materials), so it lit walls, beams and railings, and `toneMapped=false` on a material shared
+//   with a transparent panel rendered that panel pure black. §PHOTO_GLOW_SPRITE replaces it with an
+//   additive Points cloud at the fixture positions, which touches NO scene material at all.
+//
+// Three numbers decide it, in this order — the later ones cannot print a pass unless the earlier
+// ones hold, because a luminance verdict that can pass with nothing staged is worse than none:
+//   1. materialsMutated == 0   — snapshot emissive/emissiveIntensity/toneMapped of every scene
+//                                material before staging, diff after. THIS is the whole point of
+//                                the mechanism; non-zero fails the run outright.
+//   2. sprites == fixtures     — every luminaire the vocabulary finds gets a sprite. The dead end
+//                                being replaced could only reach 4 materials of 6 on the Clinic.
+//   3. mean luminance / hot %  — a glow that does not move these is not reaching the frame.
+//
+// Three folds at ONE pose so the contribution is attributable, changing one thing at a time:
+//   A  as-shipped                 (sprites off, bloom off)
+//   B  bloom only                 (sprites off, bloom forced on) — §PHOTO_BLOOM has never been
+//                                 judged on its own; it shipped attached to a broken ember
+//   C  sprites + bloom            (the mechanism)
+//
+// Run:  PORT=8403 BLD=Clinic node probe_glow_sprite.js
+//       PORT=8403 BLD=Hospital node probe_glow_sprite.js
+// Read the LOG, not the exit code.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 8403;
+const BLD  = process.env.BLD  || 'Clinic';
+const OUT  = process.env.OUT  || '/tmp/glow_out';
+const T    = parseFloat(process.env.T || '0.60');   // cinemaPathPlan sample — mid-film is inside
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  fs.mkdirSync(OUT, { recursive: true });
+  const browser = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine && window.APP.toggleNightMode && window.APP._composer,
+    { timeout: 240000 });
+  await sleep(12000);
+  await page.waitForFunction(() => { try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; } catch (e) { return false; } },
+    { timeout: 180000, polling: 2000 });
+
+  // A federated building lands one model at a time — streamBuilding must be called ONE AT A TIME,
+  // waiting for the guid count to settle, or only one lands (NIGHT_AND_FIXTURE_LIGHTING.md).
+  // Electrical is not optional here: it is where the luminaires live.
+  const all = await page.evaluate(() => (window.APP.dbQuery('SELECT DISTINCT building FROM elements_meta') || []).map(r => r[0]));
+  const want = all.filter(b => /Architectural|Electrical/i.test(b)).sort();
+  for (const b of want) {
+    await page.evaluate(bb => { try { window.APP.streamBuilding(bb); } catch (e) {} }, b);
+    let prev = -1;
+    for (let i = 0; i < 60; i++) {
+      const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length);
+      if (n === prev && n > 0) break;
+      prev = n; await sleep(2000);
+    }
+  }
+  const guidMapN = await page.evaluate(() => Object.keys(window.APP.guidMap).length);
+
+  // The camera comes from Alt+C's own plan — poseAt(t) is the same function the bake flies. Deriving
+  // a viewpoint by hand put the camera inside walls three times.
+  const cam = await page.evaluate(t => {
+    const A = window.APP;
+    let plan;
+    try { plan = A.cinemaPathPlan(30); } catch (e) { return { ok: false, err: e.message }; }
+    if (!plan || typeof plan.poseAt !== 'function') return { ok: false, err: 'no plan' };
+    const p = plan.poseAt(t);
+    A.camera.position.set(p.x, p.y, p.z);
+    A.controls.target.set(p.tx, p.ty, p.tz);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+    return { ok: true, pose: { x: p.x, y: p.y, z: p.z, tx: p.tx, ty: p.ty, tz: p.tz }, pathLen: plan.pathLen };
+  }, T);
+  if (!cam.ok) { console.log('CINEMA PLAN UNAVAILABLE: ' + cam.err); await browser.close(); process.exit(1); }
+  await sleep(1200);
+
+  await page.evaluate(() => window.APP.toggleNightMode());
+  await sleep(4000);
+  const fixtures = await page.evaluate(() => window.APP._nightFixtureWorldPositions().length);
+  const navSprites = await page.evaluate(() => window.APP._glowSpriteCount());   // must be 0 — still-only
+
+  // Snapshot AFTER night mode, because night mode legitimately makes fixture/window materials
+  // emissive itself. Everything below this line must leave these untouched.
+  const snap = () => page.evaluate(() => {
+    const seen = {}, out = [];
+    window.APP.collectMeshes(o => o.isMesh).forEach(o => {
+      (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => {
+        if (!m || seen[m.uuid]) return;
+        seen[m.uuid] = 1;
+        out.push([m.uuid, m.emissive ? m.emissive.getHex() : -1, m.emissiveIntensity === undefined ? -1 : m.emissiveIntensity, m.toneMapped !== false ? 1 : 0]);
+      });
+    });
+    return out;
+  });
+  const before = await snap();
+
+  async function fold(tag, opts) {
+    await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); });
+    await sleep(800);
+    await page.evaluate(o => { window.APP._glowSpriteEnabled = o.sprites; }, opts);
+    const t0 = Date.now();
+    await page.evaluate(() => window.APP.startStillRefine());
+    if (opts.forceBloom) {
+      await page.evaluate(() => { if (window.APP._bloomPass) window.APP._bloomPass.enabled = true; window.APP.markDirty && window.APP.markDirty(); });
+    }
+    for (let i = 0; i < 240 && await page.evaluate(() => !!window.APP._stillRefineBusy); i++) await sleep(500);
+    await sleep(2000);
+    const state = await page.evaluate(() => ({
+      sprites: window.APP._glowSpriteCount(),
+      bloom: !!(window.APP._bloomPass && window.APP._bloomPass.enabled),
+      calls: window.APP.renderer.info.render.calls,
+      exposure: window.APP.renderer.toneMappingExposure
+    }));
+    const file = path.join(OUT, `${BLD}_${tag}.png`);
+    await page.screenshot({ path: file });
+    return Object.assign({ file, ms: Date.now() - t0 }, state);
+  }
+
+  const A_shot = await fold('A_asshipped',    { sprites: false, forceBloom: false });
+  const B_shot = await fold('B_bloomonly',    { sprites: false, forceBloom: true  });
+  const C_shot = await fold('C_glowsprites',  { sprites: true,  forceBloom: false });
+  // Diff while the sprite still is UP — the claim is that nothing was mutated at any point, and
+  // checking only after teardown would be satisfied by a mutate-then-restore.
+  const during = await snap();
+  await page.evaluate(() => window.APP.stopStillRefine(true));
+  await sleep(2000);
+  const after = await snap();
+  const afterSprites = await page.evaluate(() => window.APP._glowSpriteCount());
+
+  function diff(a, b) {
+    const m = {}; a.forEach(r => m[r[0]] = r);
+    let n = 0; const eg = [];
+    b.forEach(r => {
+      const o = m[r[0]];
+      if (!o) return;                                  // newly created material — not a mutation
+      if (o[1] !== r[1] || o[2] !== r[2] || o[3] !== r[3]) { n++; if (eg.length < 5) eg.push(`${r[0].slice(0, 8)} emissive ${o[1]}->${r[1]} int ${o[2]}->${r[2]} toneMapped ${o[3]}->${r[3]}`); }
+    });
+    return { n, eg };
+  }
+  const dDuring = diff(before, during), dAfter = diff(before, after);
+
+  const lum = await page.evaluate(async files => {
+    const read = src => new Promise(res => {
+      const img = new Image();
+      img.onload = () => {
+        const c = document.createElement('canvas');
+        c.width = img.width; c.height = img.height;
+        const x = c.getContext('2d'); x.drawImage(img, 0, 0);
+        const d = x.getImageData(0, 0, c.width, c.height).data;
+        let sum = 0, peak = 0, hot = 0, n = 0;
+        for (let i = 0; i < d.length; i += 4) {
+          const L = 0.2126 * d[i] + 0.7152 * d[i + 1] + 0.0722 * d[i + 2];
+          sum += L; if (L > peak) peak = L; if (L > 240) hot++; n++;
+        }
+        res({ mean: sum / n, peak, hotPct: hot / n * 100 });
+      };
+      img.onerror = () => res(null);
+      img.src = src;
+    });
+    const o = {};
+    for (const k of Object.keys(files)) o[k] = await read(files[k]);
+    return o;
+  }, { A: 'data:image/png;base64,' + fs.readFileSync(A_shot.file).toString('base64'),
+       B: 'data:image/png;base64,' + fs.readFileSync(B_shot.file).toString('base64'),
+       C: 'data:image/png;base64,' + fs.readFileSync(C_shot.file).toString('base64') });
+
+  await browser.close();
+
+  const line = '='.repeat(84);
+  console.log(`\n${line}\nW-GLOW-SPRITE — ${BLD}   §PHOTO_GLOW_SPRITE vs the §PHOTO_EMBER dead end\n${line}`);
+  console.log(`scene       ${guidMapN} guidMap entries, models streamed: ${want.join(', ') || '(single-model DB)'}`);
+  console.log(`camera      Alt+C plan poseAt(${T})  at (${cam.pose.x.toFixed(1)}, ${cam.pose.y.toFixed(1)}, ${cam.pose.z.toFixed(1)}) -> (${cam.pose.tx.toFixed(1)}, ${cam.pose.ty.toFixed(1)}, ${cam.pose.tz.toFixed(1)})`);
+  console.log(`fixtures    ${fixtures} luminaires from the shared vocabulary (A._nightFixtureWorldPositions)`);
+  console.log(`\n--- 1. materialsMutated — the whole point of the mechanism`);
+  console.log(`  scene materials tracked      ${before.length}`);
+  console.log(`  mutated WHILE the still is up ${dDuring.n}${dDuring.eg.length ? '\n      ' + dDuring.eg.join('\n      ') : ''}`);
+  console.log(`  mutated after teardown        ${dAfter.n}${dAfter.eg.length ? '\n      ' + dAfter.eg.join('\n      ') : ''}`);
+  console.log(`\n--- 2. sprites staged`);
+  console.log(`  during night NAVIGATION      ${navSprites}   (still-only; must be 0)`);
+  console.log(`  A as-shipped                 ${A_shot.sprites}   bloom=${A_shot.bloom}  drawCalls=${A_shot.calls}`);
+  console.log(`  B bloom only                 ${B_shot.sprites}   bloom=${B_shot.bloom}  drawCalls=${B_shot.calls}`);
+  console.log(`  C glow sprites               ${C_shot.sprites}   bloom=${C_shot.bloom}  drawCalls=${C_shot.calls}  (delta vs A: ${C_shot.calls - A_shot.calls})`);
+  console.log(`  after teardown               ${afterSprites}   (must be 0 — must not outlive its still)`);
+  console.log(`\n--- 3. luminance at one pose (fold cost A ${(A_shot.ms / 1000).toFixed(1)}s  B ${(B_shot.ms / 1000).toFixed(1)}s  C ${(C_shot.ms / 1000).toFixed(1)}s)`);
+  ['A', 'B', 'C'].forEach(k => {
+    const l = lum[k];
+    if (l) console.log(`  ${k}  mean ${l.mean.toFixed(2)}   peak ${l.peak.toFixed(0)}   hot>240 ${l.hotPct.toFixed(3)}%`);
+  });
+  if (lum.A && lum.C) {
+    console.log(`  C vs A  mean ${((lum.C.mean / Math.max(0.01, lum.A.mean) - 1) * 100).toFixed(1)}%   hot ${lum.A.hotPct.toFixed(3)}% -> ${lum.C.hotPct.toFixed(3)}%`);
+    console.log(`  C vs B  mean ${((lum.C.mean / Math.max(0.01, lum.B.mean) - 1) * 100).toFixed(1)}%   (isolates the sprites from bloom's own contribution)`);
+  }
+
+  const clean   = dDuring.n === 0 && dAfter.n === 0;
+  const staged  = fixtures > 0 && C_shot.sprites === fixtures && navSprites === 0 && afterSprites === 0;
+  const reaches = !!(lum.A && lum.C) && (lum.C.hotPct > lum.B.hotPct * 1.5 || lum.C.mean > lum.B.mean * 1.02);
+  console.log(`\nVERDICT     ${!clean ? 'FAIL — ' + dDuring.n + '/' + dAfter.n + ' scene materials mutated; the blocker is NOT solved'
+    : !staged ? 'FAIL — staging wrong: ' + C_shot.sprites + ' sprites for ' + fixtures + ' fixtures (nav ' + navSprites + ', after ' + afterSprites + ')'
+    : reaches ? 'PASS — 0 materials touched, ' + C_shot.sprites + '/' + fixtures + ' fixtures lit, and it reaches the frame'
+    : 'PARTIAL — 0 materials touched and all fixtures staged, but the pixels did not move: glow is not reaching the frame'}`);
+  console.log(`stills      ${A_shot.file}\n            ${B_shot.file}\n            ${C_shot.file}`);
+  console.log(`\n--- § log lines`);
+  console.log(logs.filter(l => /§PHOTO_GLOW_SPRITE|§PHOTO_EMBER|§NIGHT_MODE|§NIGHT_STILL_LIGHTS|PAGEERROR/.test(l)).join('\n'));
+  process.exit(clean && staged ? 0 : 1);
+})();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2960,6 +2960,11 @@ async function setupEffects(A, renderer, scene, camera) {
     // emissive left on would follow the user back into navigation.
     if (A._bloomPass) A._bloomPass.enabled = false;
     _emberOff();
+    // §PHOTO_GLOW_SPRITE: restage rather than remove when night mode is still on — the sprites
+    // belong to NIGHT, not to the still; only their bloom was still-only. Restaging also refreshes
+    // the eye offset against wherever the camera ended up.
+    _glowOff();
+    if (A._nightMode) _glowOn();
     // §NIGHT_STILL_LIGHTS: hand the navigation budget back, or the 4x set follows the user into
     // their next orbit and the frame rate goes with it.
     if (A._nightMaxLights !== 12 && typeof A._nightUpdateLights === 'function') {
@@ -3027,7 +3032,10 @@ async function setupEffects(A, renderer, scene, camera) {
   // Set A._emberEnabled = true to re-arm for experiments. See
   // bim-compiler prompts/NIGHT_AND_FIXTURE_LIGHTING.md §NEXT SESSION.
   A._emberEnabled = false;
-  var EMBER_WORDS = ['light', 'troffer', 'downlight', 'luminaire', 'lamp', 'sconce', 'pendant'];
+  // Must stay identical to the vocabulary in tools.js A._loadNightFixtures — see §NIGHT_EXIT_SIGNS
+  // there for why the last three are in the list and what they are measured to add.
+  var EMBER_WORDS = ['light', 'troffer', 'downlight', 'luminaire', 'lamp', 'sconce', 'pendant',
+                     'exit sign', 'keluar', 'signage'];
   var EMBER_NOT   = ['switch', 'receptacle', 'panelboard', 'socket', 'outlet'];
   var _emberMats = null;
   function _emberOn() {
@@ -3111,6 +3119,166 @@ async function setupEffects(A, renderer, scene, camera) {
     _emberMats = null;
   }
 
+  // ══ §PHOTO_GLOW_SPRITE (bim-compiler prompts/NIGHT_AND_FIXTURE_LIGHTING.md §PHOTO_GLOW_SPRITE)
+  //    — Witness: W-GLOW-SPRITE. The replacement for §PHOTO_EMBER, not an addition to it.
+  //
+  // WHY THE MECHANISM CHANGED. §PHOTO_EMBER set `emissive` on the materials the luminaires are drawn
+  // with. On Hospital that was 1216 luminaires resolving to SEVEN materials, because batched and
+  // instanced meshes share one material across everything they draw — so the emissive lit walls,
+  // beams and railings too, and `toneMapped=false` on a material also used by a TRANSPARENT panel
+  // rendered that panel pure black. An exclusivity guard cut the collateral but proved the approach
+  // is a dead end: the same sharing that causes the damage is what the fixtures are drawn with, so a
+  // correct guard starves the fixtures as well. The problem is not the filter, it is the coupling to
+  // scene geometry.
+  //
+  // Sprites are decoupled from the geometry entirely, so material sharing is IRRELEVANT rather than
+  // guarded against — this code touches no scene material at all, which is the property the witness
+  // asserts (materialsMutated must be 0). One THREE.Points object = one draw call for every fixture
+  // in the building, so the 12/48 light-count budget does not apply: those budget per-fragment
+  // LIGHTING work on every lit material, and a Points cloud has no lighting term.
+  //
+  // Positions and colours come from A._nightFixtureWorldPositions() — the same list, the same
+  // vocabulary and the same §NIGHT_LIGHT_MIX colour the point light at that fixture uses, so the
+  // sprite and the light agree instead of being two independent decisions.
+  A._glowSpriteEnabled = true;
+  var GLOW_SPRITE_SIZE = 1.1;   // metres, halo diameter (sizeAttenuation) — sized against a 0.6x1.2m troffer
+  var GLOW_GAIN        = 3.0;   // linear-space gain on the vertex colour; BloomPass threshold is 1.0,
+                                // so a value at or below 1.0 is invisible to bloom and we are back to
+                                // "emissive alone moved mean luminance 56.13 -> 56.13".
+  // metres toward the eye. NOT a fudge: the DB gives a fixture's CENTRE and the glow leaves its
+  // visible FACE, nearer the camera by about half the fitting's thickness. Without it the fitting's
+  // own geometry wins the depth test against a sprite sitting inside it.
+  //
+  // 0.30 rather than 0.15 is MEASURED, from the occlusion-gap histogram over the Clinic
+  // (probe_glow_diag.js, 21 poses pooled, gap = sprite distance minus nearest blocker distance):
+  //     <=0.05m 115   <=0.1m 19   <=0.2m 25   <=0.3m 29   <=0.5m 26   <=0.8m 72
+  //     <=1.5m 380    <=3m 1173   <=6m 1008   <=12m 2331   >12m 3554
+  // The small-gap group is fittings hiding their own glow; everything from ~1.5m out is a lamp
+  // genuinely behind a WALL, which MUST stay hidden — so this cannot be fixed by pushing the offset
+  // arbitrarily far, and 0.30 clears 188 of the ~286 fitting-occluded without reaching into the
+  // architecture band.
+  //
+  // REJECTED, on cost: a per-sprite raycast that finds the fitting's actual face and sits the glow
+  // in front of it. It is more precise and it recovers the whole <=0.8m group, but raycasting
+  // against BATCHED meshes walks a lot of geometry per ray — measured at roughly 10k rays in
+  // single-digit minutes in the headless rig — so 841 fixtures is a tens-of-seconds stall at
+  // still-start, and Hospital's 1216 in a 63,182-element building is worse. A constant that costs
+  // nothing and recovers most of the group beats a correct one that stalls the fold.
+  var GLOW_EYE_OFFSET  = 0.30;
+  // §GLOW_EXIT_SOFT (user: "exit signs should have soft appropriate lighting"). An exit sign is a
+  // small backlit panel, not a 600x1200 troffer, and giving it the same halo at the same gain reads
+  // as a floodlight over every doorway. GAIN 0.9 is deliberately BELOW the bloom threshold of 1.0 —
+  // that is what makes it soft: the sign glows but never blooms, while the luminaires at gain 3.0
+  // do. SIZE is a multiplier on GLOW_SPRITE_SIZE, so 0.40 x 1.1m = a ~0.44m halo.
+  // Counted on the shipped buildings: Clinic 43 signs, Hospital 57, Terminal 38 (E_Light_Keluar).
+  var GLOW_EXIT_GAIN   = 0.9;
+  var GLOW_EXIT_SIZE   = 0.40;
+  var _glowPoints = null, _glowTex = null;
+
+  function _glowTexture() {
+    if (_glowTex) return _glowTex;
+    var S = 64, c = document.createElement('canvas');
+    c.width = c.height = S;
+    var g = c.getContext('2d');
+    var rad = g.createRadialGradient(S / 2, S / 2, 0, S / 2, S / 2, S / 2);
+    rad.addColorStop(0.00, 'rgba(255,255,255,1)');
+    rad.addColorStop(0.22, 'rgba(255,255,255,0.55)');
+    rad.addColorStop(1.00, 'rgba(255,255,255,0)');
+    g.fillStyle = rad; g.fillRect(0, 0, S, S);
+    _glowTex = new THREE.CanvasTexture(c);
+    // Left in NoColorSpace deliberately: this is an alpha falloff ramp, not a colour — additive
+    // blending multiplies it by the vertex colour, and an sRGB decode here would bend the falloff.
+    return _glowTex;
+  }
+
+  function _glowOn() {
+    if (!A._glowSpriteEnabled || _glowPoints) return;
+    if (typeof A._nightFixtureWorldPositions !== 'function') return;
+    var pos = A._nightFixtureWorldPositions();
+    if (!pos || !pos.length) { console.log('§PHOTO_GLOW_SPRITE no luminaires in this building — nothing to light'); return; }
+    // Offset toward the eye, computed ONCE: for a still the camera is frozen, so once is exact; in
+    // navigation a 0.15m staleness as the camera moves is below the size of the halo it positions.
+    var cam = A.camera.position;
+    var xyz = new Float32Array(pos.length * 3), col = new Float32Array(pos.length * 3);
+    var siz = new Float32Array(pos.length);
+    var c = new THREE.Color();
+    var exits = 0;
+    for (var i = 0; i < pos.length; i++) {
+      var p = pos[i];
+      var dx = cam.x - p.x, dy = cam.y - p.y, dz = cam.z - p.z;
+      var d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+      var k = GLOW_EYE_OFFSET / d;
+      xyz[i * 3] = p.x + dx * k; xyz[i * 3 + 1] = p.y + dy * k; xyz[i * 3 + 2] = p.z + dz * k;
+      var gain = GLOW_GAIN;
+      siz[i] = 1.0;
+      if (p.__exit) { gain = GLOW_EXIT_GAIN; siz[i] = GLOW_EXIT_SIZE; exits++; }   // §GLOW_EXIT_SOFT
+      c.setHex(p.__color === undefined ? 0xffe4b5 : p.__color);
+      col[i * 3] = c.r * gain; col[i * 3 + 1] = c.g * gain; col[i * 3 + 2] = c.b * gain;
+    }
+    var geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(xyz, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    geo.setAttribute('aSize', new THREE.BufferAttribute(siz, 1));
+    var mat = new THREE.PointsMaterial({
+      size: GLOW_SPRITE_SIZE,
+      sizeAttenuation: true,
+      map: _glowTexture(),
+      vertexColors: true,
+      blending: THREE.AdditiveBlending,
+      transparent: true,
+      // depthTest ON: a lamp behind a wall must not shine through it.
+      // depthWrite OFF: two overlapping halos must not occlude each other.
+      depthTest: true,
+      depthWrite: false,
+      // Safe HERE and not safe on a scene material — nothing but these sprites is drawn with it.
+      // That asymmetry is exactly what blacked out transparent panels under §PHOTO_EMBER.
+      toneMapped: false
+    });
+    // §GLOW_EXIT_SOFT — PointsMaterial.size is a single uniform for the whole cloud, so per-fixture
+    // halo size needs the one-line shader patch below rather than a second Points object. Keeping it
+    // to ONE object is the point of the mechanism: one draw call for every fixture in the building.
+    mat.onBeforeCompile = function(sh) {
+      sh.vertexShader = 'attribute float aSize;\n' +
+        sh.vertexShader.replace('gl_PointSize = size;', 'gl_PointSize = size * aSize;');
+    };
+    _glowPoints = new THREE.Points(geo, mat);
+    // One object spanning the whole building — never cull the CLOUD. (This does not address the
+    // per-point limitation: the GPU clips a point sprite by its centre, so a halo whose fixture is
+    // just off-screen still pops rather than fading at the frame edge. Stated in the spec; the fix
+    // if it ever reads is a billboarded InstancedMesh quad, same positions and colours.)
+    _glowPoints.frustumCulled = false;
+    _glowPoints.renderOrder = 999;       // after opaque geometry, so additive lands on a finished frame
+    _glowPoints.name = '__glowSprites';
+    A.scene.add(_glowPoints);
+    console.log('§PHOTO_GLOW_SPRITE staged ' + pos.length + ' sprites (' + (pos.length - exits) +
+      ' luminaires gain ' + GLOW_GAIN + ', ' + exits + ' exit signs gain ' + GLOW_EXIT_GAIN +
+      ' x' + GLOW_EXIT_SIZE + ' size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose)' +
+      ', 1 draw call, 0 scene materials touched' +
+      ' (size ' + GLOW_SPRITE_SIZE + 'm, eye-offset ' + GLOW_EYE_OFFSET + 'm' +
+      ', bloom threshold ' + (A._bloomPass ? A._bloomPass.threshold : '?') +
+      ', strength ' + (A._bloomPass ? A._bloomPass.strength : '?') + ')');
+  }
+
+  function _glowOff() {
+    if (!_glowPoints) return;
+    var n = _glowPoints.geometry.attributes.position ? _glowPoints.geometry.attributes.position.count : 0;
+    A.scene.remove(_glowPoints);
+    _glowPoints.geometry.dispose();
+    _glowPoints.material.dispose();
+    console.log('§PHOTO_GLOW_SPRITE removed ' + n + ' sprites');
+    _glowPoints = null;
+  }
+  A._glowSpriteCount = function() {
+    return _glowPoints ? _glowPoints.geometry.attributes.position.count : 0;
+  };
+  // Staged by NIGHT MODE as well as by the still. The point-light budget (12 nav / 48 still) is a
+  // per-fragment lighting cost on every lit material every frame; this is ONE additive draw call for
+  // the whole building whether it holds 12 fixtures or 1216, so there is no navigation budget for it
+  // to blow and no reason to make the user press Alt+S before their luminaires are lit.
+  // Bloom stays still-only — it is 7 extra full-screen draws and that DOES have a 60fps cost.
+  A._glowStage   = function() { _glowOn(); };
+  A._glowUnstage = function() { _glowOff(); };
+
   A.startStillRefine = function() {
     if (!A._composer || !A._taaPass || A._stillRefineActive) return;
     // §GI_EXCLUSION (review finding 5): the GI preview composer and this TAA composer both render
@@ -3128,8 +3296,16 @@ async function setupEffects(A, renderer, scene, camera) {
     A._stillRefineBusy = true;
     // §PHOTO_EMBER + §PHOTO_BLOOM: both are STILL-ONLY, same discipline as Layer 3's triplanar PBR.
     // Navigation keeps the cheap chain; the frozen still can afford 7 extra full-screen draws.
-    if (A._bloomPass) A._bloomPass.enabled = !!A._emberEnabled;   // §PHOTO_EMBER_DISARMED
-    _emberOn();
+    // §PHOTO_BLOOM is REQUIRED by §PHOTO_GLOW_SPRITE, not optional decoration on top of it: the
+    // sprites are written above 1.0 in linear space precisely so the bloom threshold can find them,
+    // and without the pass they are a handful of bright pixels that spread nothing (measured under
+    // §PHOTO_EMBER: emissive alone moved mean luminance 56.13 -> 56.13).
+    if (A._bloomPass) A._bloomPass.enabled = !!A._emberEnabled || !!A._glowSpriteEnabled;
+    _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
+    // §PHOTO_GLOW_SPRITE: night mode may already have staged these. Restage anyway, so the eye
+    // offset is computed against the pose the still is actually frozen at rather than wherever the
+    // camera happened to be when night mode was switched on.
+    _glowOff(); _glowOn();
     // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
     // navigation budget (every light costs per-pixel work on every lit material every frame); a
     // frozen still renders once and then sits there, so that budget does not apply to it. The

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -861,11 +861,17 @@ function setupTools(A) {
     for (var i = 0; i < key.length; i++) { h ^= key.charCodeAt(i); h = Math.imul(h, 16777619); }
     return ((h >>> 0) % 100000) / 100000;
   }
+  // ONE test for "is this an exit sign", shared by the colour rule and by §PHOTO_GLOW_SPRITE's
+  // brightness rule — they must never disagree about which fittings are signage.
+  A.nightIsExitSign = function(name) {
+    var n = String(name || '').toLowerCase();
+    return n.indexOf('exit') >= 0 || n.indexOf('keluar') >= 0 || n.indexOf('signage') >= 0;
+  };
   A.nightLightColor = function(name, key) {
     var n = String(name || '').toLowerCase();
     // Exit signage keeps its own colour whatever the ratio says — a green running-man sign that
     // came out blue would be wrong, not stylish.
-    if (n.indexOf('exit') >= 0 || n.indexOf('keluar') >= 0 || n.indexOf('signage') >= 0) return NIGHT_EXIT;
+    if (A.nightIsExitSign(n)) return NIGHT_EXIT;
     if (key !== undefined) {
       var h = _mixHash(String(key));
       if (h < A._nightMixBlue) return NIGHT_MIX_BLUE;
@@ -913,6 +919,111 @@ function setupTools(A) {
         ' totalGlowMats=' + A._nightGlowMats.length);
     }
   };
+  // §NIGHT_FIXTURE_VOCAB / §PHOTO_GLOW_SPRITE — the ONE place luminaire POSITIONS are extracted.
+  // Extracted out of toggleNightMode (2026-07-27) because a second consumer now needs the same
+  // positions: the still's glow sprites. The spec's standing rule is that every path selecting
+  // luminaires must share one vocabulary — two copies of this SQL is exactly how the '%light%'
+  // filter ended up living in one query as a test and never as the selector. Returns the source
+  // string ('IFC' | 'synthetic (N storeys)' | 'none') that §NIGHT_MODE reports.
+  // force=true re-queries even when a list is already cached — what toggleNightMode does, because
+  // more models may have streamed in since the last toggle. The sprite path passes nothing and
+  // reuses whatever night mode already extracted.
+  A._loadNightFixtures = function(force) {
+    if (!force && A._nightFixtures && A._nightFixtures.length) return A._nightFixtureSource || 'IFC';
+    A._nightFixtures = [];
+    A._nightFixturePositions = null;   // world-space cache is derived from this list — invalidate together
+    var source = 'none';
+    if (A.db) {
+      try {
+        // §S277c: Include IfcFlowTerminal + IfcElectricAppliance — most models lack IfcLightFixture
+        // §NIGHT_FIXTURE_VOCAB (2026-07-27): class alone is far too wide — on the Clinic,
+        // IfcFlowTerminal covers 961 M_Duplex Receptacle and 236 M_Lighting Switches as well as
+        // the real luminaires, so every power socket in the building became a light source.
+        // Keep the class net (it is what finds luminaires in models with no IfcLightFixture) but
+        // require the NAME to look like a luminaire and not like an accessory — the same
+        // vocabulary §PHOTO_EMBER uses, and the "filter for 'light'" the user asked for. Measured
+        // on the Clinic: 1105 naive name matches -> 841 real luminaires, 264 rejected.
+        var r = A.db.exec(
+          "SELECT t.center_x, t.center_y, t.center_z, m.element_name FROM elements_meta m " +
+          "JOIN element_transforms t ON m.guid=t.guid " +
+          // §NIGHT_NAME_NOT_CLASS (2026-07-27, user: "anything that has 'light' name", "i dunno why
+          // we keep missing 'light' in names"). THE ANSWER IS THE CLASS GATE, which used to read
+          //     m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') AND ...
+          // and silently dropped any luminaire filed under a different class. Measured over all five
+          // shipped buildings, removing it adds exactly 12 elements: 9 real (Terminal's
+          // 'jkrME_fir-al_Flashing Light_Red & Green', class IfcAlarm) and 3 substring accidents
+          // ('Life_FLIGHT_Helicopter', 'M_SkyLIGHT' x2) which the NOT clause below now names.
+          // The class was never doing useful work anyway: inside those three classes, every family
+          // the vocabulary rejects is a receptacle, diffuser, sink, grab bar, data outlet or
+          // sprinkler — verified per family on all five DBs — so the NAME was always the selector
+          // and the class was only ever hiding luminaires that lived elsewhere.
+          // UNION, not intersection (user: "its easy to spot.. they are in ceilings, overheads,
+          // walls as individual elements"). `IfcLightFixture` is unambiguous BY ITSELF — an element
+          // of that class is a luminaire whatever it is called, so a model that names its fittings
+          // 'Type A' still lights up. The name vocabulary then catches everything filed under some
+          // OTHER class. The old query ANDed these two and so needed BOTH to be true, which is what
+          // made a luminaire invisible if either its class or its name was unusual.
+          "WHERE (m.ifc_class = 'IfcLightFixture' " +
+          "  OR LOWER(m.element_name) LIKE '%light%' OR LOWER(m.element_name) LIKE '%troffer%' " +
+          "  OR LOWER(m.element_name) LIKE '%downlight%' OR LOWER(m.element_name) LIKE '%luminaire%' " +
+          "  OR LOWER(m.element_name) LIKE '%lamp%' OR LOWER(m.element_name) LIKE '%sconce%' " +
+          "  OR LOWER(m.element_name) LIKE '%pendant%' " +
+          // §NIGHT_EXIT_SIGNS (2026-07-27): an exit sign is a lit fixture and was ALWAYS intended to
+          // be one — A.nightLightColor has carried an `exit 0x9bffc0` branch for exit/keluar/signage
+          // since §NIGHT_LIGHT_MIX. It was never in the SELECTOR, so that branch could not fire and
+          // the signs were dark. Same bug class as the '%light%' filter that existed only as a test.
+          // Measured over all five shipped buildings: Clinic 841 -> 884 (+43 Exit Sign Ceiling/End
+          // Mount), Hospital 1215 -> 1272 (+57 Exit Sign Ceiling Based, class IfcLightFixture),
+          // Terminal/Duplex/HHS unchanged (their signs already carry the word 'Light'). ZERO false
+          // positives: every element matching these three words in all five DBs is already in a
+          // luminaire class. 'exit sign' not bare 'exit' — bare would reach exit corridors and doors.
+          "  OR LOWER(m.element_name) LIKE '%exit sign%' OR LOWER(m.element_name) LIKE '%keluar%' " +
+          "  OR LOWER(m.element_name) LIKE '%signage%') " +
+          // The exclusions. First five are ACCESSORIES that carry the word 'lighting' but emit
+          // nothing. Last two are SUBSTRING ACCIDENTS — 'flight' and 'skylight' both contain the
+          // letters l-i-g-h-t and neither is a lamp; they are the only two found across all five
+          // shipped buildings, and they are the price of selecting on the name, which is the right
+          // price to pay.
+          "AND NOT (LOWER(m.element_name) LIKE '%switch%' OR LOWER(m.element_name) LIKE '%receptacle%' " +
+          "  OR LOWER(m.element_name) LIKE '%panelboard%' OR LOWER(m.element_name) LIKE '%socket%' " +
+          "  OR LOWER(m.element_name) LIKE '%outlet%' " +
+          "  OR LOWER(m.element_name) LIKE '%flight%' OR LOWER(m.element_name) LIKE '%skylight%')");
+        if (r.length && r[0].values.length > 0) {
+          r[0].values.forEach(function(row) {
+            A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '' });
+          });
+          source = 'IFC';
+        }
+      } catch(e) {}
+      // §S259: Fallback — generate synthetic lights from storey centroids
+      if (A._nightFixtures.length === 0) {
+        try {
+          var sr = A.db.exec("SELECT m.storey, AVG(t.center_x), AVG(t.center_y), AVG(t.center_z), MIN(t.center_x), MAX(t.center_x), MIN(t.center_y), MAX(t.center_y) FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid GROUP BY m.storey");
+          if (sr.length) {
+            sr[0].values.forEach(function(row) {
+              var cx = row[1], cy = row[2], cz = row[3];
+              var xMin = row[4], xMax = row[5], yMin = row[6], yMax = row[7];
+              var dx = (xMax - xMin) || 10, dy = (yMax - yMin) || 10;
+              // Place a grid of lights per storey — one every ~15m
+              var nx = Math.max(1, Math.ceil(dx / 15));
+              var ny = Math.max(1, Math.ceil(dy / 15));
+              for (var ix = 0; ix < nx; ix++) {
+                for (var iy = 0; iy < ny; iy++) {
+                  var fx = xMin + (ix + 0.5) * (dx / nx);
+                  var fy = yMin + (iy + 0.5) * (dy / ny);
+                  A._nightFixtures.push({ x: fx, y: fy, z: cz + 1.5 });
+                }
+              }
+            });
+            source = 'synthetic (' + sr[0].values.length + ' storeys)';
+          }
+        } catch(e) { console.warn('§NIGHT fallback query failed', e); }
+      }
+    }
+    A._nightFixtureSource = source;
+    return source;
+  };
+
   A.toggleNightMode = function() {
     A._nightMode = !A._nightMode;
     var btn = document.getElementById('night-btn');
@@ -952,62 +1063,10 @@ function setupTools(A) {
       document.getElementById('sl-hemi-val').textContent = '0.1';
       document.getElementById('sl-exposure').value = 0.8;
       document.getElementById('sl-exposure-val').textContent = '0.8';
-      // Load IFC light fixtures from DB — fallback to storey centroids if none
-      A._nightFixtures = [];
-      var source = 'none';
-      if (A.db) {
-        try {
-          // §S277c: Include IfcFlowTerminal + IfcElectricAppliance — most models lack IfcLightFixture
-          // §NIGHT_FIXTURE_VOCAB (2026-07-27): class alone is far too wide — on the Clinic,
-          // IfcFlowTerminal covers 961 M_Duplex Receptacle and 236 M_Lighting Switches as well as
-          // the real luminaires, so every power socket in the building became a light source.
-          // Keep the class net (it is what finds luminaires in models with no IfcLightFixture) but
-          // require the NAME to look like a luminaire and not like an accessory — the same
-          // vocabulary §PHOTO_EMBER uses, and the "filter for 'light'" the user asked for. Measured
-          // on the Clinic: 1105 naive name matches -> 841 real luminaires, 264 rejected.
-          var r = A.db.exec(
-            "SELECT t.center_x, t.center_y, t.center_z, m.element_name FROM elements_meta m " +
-            "JOIN element_transforms t ON m.guid=t.guid " +
-            "WHERE m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') " +
-            "AND (LOWER(m.element_name) LIKE '%light%' OR LOWER(m.element_name) LIKE '%troffer%' " +
-            "  OR LOWER(m.element_name) LIKE '%downlight%' OR LOWER(m.element_name) LIKE '%luminaire%' " +
-            "  OR LOWER(m.element_name) LIKE '%lamp%' OR LOWER(m.element_name) LIKE '%sconce%' " +
-            "  OR LOWER(m.element_name) LIKE '%pendant%') " +
-            "AND NOT (LOWER(m.element_name) LIKE '%switch%' OR LOWER(m.element_name) LIKE '%receptacle%' " +
-            "  OR LOWER(m.element_name) LIKE '%panelboard%' OR LOWER(m.element_name) LIKE '%socket%' " +
-            "  OR LOWER(m.element_name) LIKE '%outlet%')");
-          if (r.length && r[0].values.length > 0) {
-            r[0].values.forEach(function(row) {
-              A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '' });
-            });
-            source = 'IFC';
-          }
-        } catch(e) {}
-        // §S259: Fallback — generate synthetic lights from storey centroids
-        if (A._nightFixtures.length === 0) {
-          try {
-            var sr = A.db.exec("SELECT m.storey, AVG(t.center_x), AVG(t.center_y), AVG(t.center_z), MIN(t.center_x), MAX(t.center_x), MIN(t.center_y), MAX(t.center_y) FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid GROUP BY m.storey");
-            if (sr.length) {
-              sr[0].values.forEach(function(row) {
-                var cx = row[1], cy = row[2], cz = row[3];
-                var xMin = row[4], xMax = row[5], yMin = row[6], yMax = row[7];
-                var dx = (xMax - xMin) || 10, dy = (yMax - yMin) || 10;
-                // Place a grid of lights per storey — one every ~15m
-                var nx = Math.max(1, Math.ceil(dx / 15));
-                var ny = Math.max(1, Math.ceil(dy / 15));
-                for (var ix = 0; ix < nx; ix++) {
-                  for (var iy = 0; iy < ny; iy++) {
-                    var fx = xMin + (ix + 0.5) * (dx / nx);
-                    var fy = yMin + (iy + 0.5) * (dy / ny);
-                    A._nightFixtures.push({ x: fx, y: fy, z: cz + 1.5 });
-                  }
-                }
-              });
-              source = 'synthetic (' + sr[0].values.length + ' storeys)';
-            }
-          } catch(e) { console.warn('§NIGHT fallback query failed', e); }
-        }
-      }
+      // Load IFC light fixtures from DB — fallback to storey centroids if none.
+      // The extraction itself lives in A._loadNightFixtures() (above) so the still's glow sprites
+      // read the same list from the same vocabulary.
+      var source = A._loadNightFixtures(true);
       // §S277d: Make light fixture materials emissive — glow at any distance, zero cost.
       // Uses matCache keys (rgba|ifcClass) — catches ALL material surfaces per fixture.
       A._nightGlowMats = [];
@@ -1066,6 +1125,11 @@ function setupTools(A) {
         ' glowMats=' + A._nightGlowMats.length);
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
       A._nightUpdateLights();
+      // §PHOTO_GLOW_SPRITE: the fixtures themselves read as lit, not just the surfaces near them.
+      // Staged here rather than in Alt+S because it is ONE additive draw call for every fixture in
+      // the building — there is no per-light budget for it to blow, so a user turning night mode on
+      // should see the luminaires on without pressing anything else.
+      if (typeof A._glowStage === 'function') A._glowStage();
       if (A.controls && !A._nightControlsListener) {
         var _nightLastCamPos = A.camera.position.clone();
         A._nightControlsListener = function() {
@@ -1120,6 +1184,8 @@ function setupTools(A) {
       });
       A._nightLights = [];
       A._nightFixturePositions = null;
+      // §PHOTO_GLOW_SPRITE: night's sprites must not survive night mode
+      if (typeof A._glowUnstage === 'function') A._glowUnstage();
       // Unhook
       if (A.controls && A._nightControlsListener) {
         A.controls.removeEventListener('change', A._nightControlsListener);
@@ -1138,18 +1204,30 @@ function setupTools(A) {
     if (A.markDirty) A.markDirty();
   };
 
-  A._nightUpdateLights = function() {
-    if (!A._nightMode || !A._nightFixtures.length) return;
-    // Convert all fixture positions to Three.js coords (cached after first call)
+  // Fixture positions in WORLD space, with their §NIGHT_LIGHT_MIX colour attached. Cached after the
+  // first call and invalidated by A._loadNightFixtures(true). Two consumers: the point lights below
+  // and §PHOTO_GLOW_SPRITE in effects.js — the sprite at a fixture and the light at that fixture
+  // must be the same position and the same colour, so both read this one list.
+  // A.ifc2three is the ONLY DB->world mapping; three attempts to reinvent it put a probe camera
+  // inside walls (see NIGHT_AND_FIXTURE_LIGHTING.md).
+  A._nightFixtureWorldPositions = function() {
     if (!A._nightFixturePositions) {
+      A._loadNightFixtures();
+      if (!A._nightFixtures.length) return [];
       A._nightFixturePositions = A._nightFixtures.map(function(f) {
         var p = A.ifc2three(f.x, f.y, f.z);
         // Key the ratio on name+position so it is stable per fixture and independent of row order.
         p.__color = A.nightLightColor(f.name, f.name + '|' + f.x.toFixed(2) + ',' + f.y.toFixed(2) + ',' + f.z.toFixed(2));
+        p.__exit = A.nightIsExitSign(f.name);   // §GLOW_EXIT_SOFT — a sign is not a troffer
         return p;
       });
     }
-    var allPos = A._nightFixturePositions;
+    return A._nightFixturePositions;
+  };
+
+  A._nightUpdateLights = function() {
+    if (!A._nightMode || !A._nightFixtures.length) return;
+    var allPos = A._nightFixtureWorldPositions();
     var camPos = A.camera.position;
     var needed;
     if (allPos.length <= A._nightMaxLights) {


### PR DESCRIPTION
Replaces `§PHOTO_EMBER` (which stays disarmed). Ember set `emissive` on the **materials** luminaires are drawn with — and batched/instanced meshes share one material across everything they draw (Hospital: 1216 luminaires → **7 materials**), so it lit wall panels, beams and railings, and `toneMapped=false` on a material shared with a transparent panel rendered it pure black.

This is one `THREE.Points` cloud at the fixture positions: **one additive draw call for every fixture in the building**, sharing **no material with any scene mesh**. Lit wall panels and black rectangles are impossible by construction rather than filtered.

Witnessed on Clinic and Hospital — 0 scene materials mutated while staged and after teardown, 0 meshes sharing the sprite material, every fixture applied, every one removed.

**Staged by night mode, not Alt+S.** The 12/48 point-light budget is per-fragment lighting cost on every lit material every frame; a single additive draw call has no such cost. Bloom stays still-only.

### Selection fixes, measured per family across all five shipped buildings
- **§NIGHT_NAME_NOT_CLASS** — the `ifc_class` gate was *ANDed* with the name and silently dropped any luminaire filed elsewhere. Now a **union**: `IfcLightFixture` is unambiguous by itself (a model naming its fittings "Type A" still lights up), the name catches the rest. Adds Terminal's 9 `IfcAlarm` flashing lights. `flight` / `skylight` excluded — the two substring accidents this exposes.
- **§NIGHT_EXIT_SIGNS** — `nightLightColor` has carried an exit/keluar/signage branch since §NIGHT_LIGHT_MIX, but those words were never in the *selector*, so it could never fire. Clinic +43, Hospital +57, zero false positives.
- **§GLOW_EXIT_SOFT** — exit signs at gain 0.9 (deliberately below the bloom threshold) and 0.40 size. A sign glows; a troffer blooms.

| building | before | after |
|---|---|---|
| Clinic | 841 | **884** |
| Hospital | 1215 | **1272** |
| Terminal | 814 | **823** |
| Duplex | 14 | 14 |
| HHS_Office_Federated | 410 | 410 |

Spec, the full per-family list, and the landmines found on the way: `bim-compiler prompts/NIGHT_AND_FIXTURE_LIGHTING.md §PHOTO_GLOW_SPRITE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)