### PR TITLE
fix(night): §GLOW_EMIT_DOWN — recessed troffers and downlights were lit inside the ceiling

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3205,10 +3205,20 @@ async function setupEffects(A, renderer, scene, camera) {
     var exits = 0;
     for (var i = 0; i < pos.length; i++) {
       var p = pos[i];
-      var dx = cam.x - p.x, dy = cam.y - p.y, dz = cam.z - p.z;
+      // §GLOW_EMIT_DOWN — drop to the EMITTING FACE first, then nudge toward the eye.
+      // The nudge alone was the bug the user caught: "M_Troffer Light not lighted... M_Downlight
+      // not lighted", while pendants, sconces, surface-mounted and exit signs all lit fine. Those
+      // all HANG BELOW the ceiling; troffers, downlights and plain-recessed are RECESSED FLUSH INTO
+      // it. A toward-the-eye offset is nearly HORIZONTAL for any fixture more than a few metres
+      // down a corridor, so it slid a recessed sprite sideways and left it buried in the slab —
+      // correctly depth-culled, invisible, and only for the recessed families. The one direction
+      // that escapes a recessed fitting is DOWN, which is also the direction it emits.
+      // p.__drop is half the fitting's real bbox height plus clearance (see tools.js).
+      var py = p.y - (p.__drop || 0.12);
+      var dx = cam.x - p.x, dy = cam.y - py, dz = cam.z - p.z;
       var d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
       var k = GLOW_EYE_OFFSET / d;
-      xyz[i * 3] = p.x + dx * k; xyz[i * 3 + 1] = p.y + dy * k; xyz[i * 3 + 2] = p.z + dz * k;
+      xyz[i * 3] = p.x + dx * k; xyz[i * 3 + 1] = py + dy * k; xyz[i * 3 + 2] = p.z + dz * k;
       var gain = GLOW_GAIN;
       siz[i] = 1.0;
       if (p.__exit) { gain = GLOW_EXIT_GAIN; siz[i] = GLOW_EXIT_SIZE; exits++; }   // §GLOW_EXIT_SOFT

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -944,7 +944,7 @@ function setupTools(A) {
         // vocabulary §PHOTO_EMBER uses, and the "filter for 'light'" the user asked for. Measured
         // on the Clinic: 1105 naive name matches -> 841 real luminaires, 264 rejected.
         var r = A.db.exec(
-          "SELECT t.center_x, t.center_y, t.center_z, m.element_name FROM elements_meta m " +
+          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z FROM elements_meta m " +
           "JOIN element_transforms t ON m.guid=t.guid " +
           // §NIGHT_NAME_NOT_CLASS (2026-07-27, user: "anything that has 'light' name", "i dunno why
           // we keep missing 'light' in names"). THE ANSWER IS THE CLASS GATE, which used to read
@@ -990,7 +990,7 @@ function setupTools(A) {
           "  OR LOWER(m.element_name) LIKE '%flight%' OR LOWER(m.element_name) LIKE '%skylight%')");
         if (r.length && r[0].values.length > 0) {
           r[0].values.forEach(function(row) {
-            A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '' });
+            A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0 });
           });
           source = 'IFC';
         }
@@ -1219,6 +1219,13 @@ function setupTools(A) {
         // Key the ratio on name+position so it is stable per fixture and independent of row order.
         p.__color = A.nightLightColor(f.name, f.name + '|' + f.x.toFixed(2) + ',' + f.y.toFixed(2) + ',' + f.z.toFixed(2));
         p.__exit = A.nightIsExitSign(f.name);   // §GLOW_EXIT_SOFT — a sign is not a troffer
+        // §GLOW_EMIT_DOWN — how far BELOW the stored centre the fitting actually emits. The DB gives
+        // a bounding-box centre; a RECESSED fitting's centre is level with (or above) the ceiling
+        // face, and a suspended one's centre is up in its drop rod. Half the bbox height plus a
+        // clearance puts the glow on the emitting face in both cases. Measured half-heights:
+        // troffer 0.07m, downlight 0.10m, plain recessed 0.075m, pendant-linear 0.77m (Clinic) —
+        // the pendant number is the drop rod, and dropping by it lands the glow on the lamp.
+        p.__drop = (f.h || 0) / 2 + 0.12;
         return p;
       });
     }


### PR DESCRIPTION
User, watching the fittings marked last session: **"M_Troffer Light not lighted.. M_Downlight not lighted"** — while pendants, sconces, surface-mounted and exit signs all lit correctly.

**That split is the diagnosis.** Every family that worked *hangs below* the ceiling. Every family that failed is *recessed flush into* it.

`§PHOTO_GLOW_SPRITE` placed each sprite by nudging the stored bbox centre **toward the eye** — and for any fixture more than a few metres down a corridor that direction is nearly **horizontal**, so a recessed sprite slid sideways and stayed buried in the ceiling slab: correctly depth-culled, and invisible. Nothing was missing from the selection — the Clinic already had 443 troffers and 147 downlights staged. They were being drawn *inside the ceiling*.

The only direction that escapes a recessed fitting is **down**, which is also the direction it emits. Each sprite now drops to the emitting face first — half the fitting's real `bbox_z` plus 0.12 m clearance, **read from the DB, not a constant** — and only then takes the toward-eye nudge.

| family | drop applied |
|---|---|
| M_Troffer Light (Parabolic Rect/Square) | 0.19 m |
| M_Downlight - Recessed Can | 0.22 m |
| M_Plain Recessed Lighting Fixture | 0.195 m |
| Exit Sign (ceiling/end mount) | 0.23 – 0.29 m |
| M_Pendant Light - Linear | 0.889 m |

The pendant figure is its **drop rod**, which the bbox centre sits in the middle of — so this also lands those glows on the lamp instead of halfway up the suspension. Second defect, same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)