### PR TITLE
fix(night+bloom): §BLOOM_BLACK_BOXES, §NIGHT_DIFFUSER, §LUM_VARIANT, §NIGHT_ROLE_EXCLUDE

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -72,8 +72,15 @@ async function setupEffects(A, renderer, scene, camera) {
     // OFF during navigation, ON only for the Alt+S still (see startStillRefine). Same discipline as
     // Layer 3's triplanar PBR: a bake can afford a few ms a frame, a 60fps orbit cannot, and this
     // renders 7 extra full-screen draws (bright + 3 levels x 2 blur directions) plus a composite.
+    // §BLOOM_TEMPER (2026-07-27, user: "bloom also overshot its not nice"). It was strength 0.9 at
+    // threshold 1.0, and §PHOTO_GLOW_SPRITE writes its sprites at gain 3.0 — three times over the
+    // threshold, then amplified nearly 1:1. Everything that qualified bloomed hard, and on Hospital
+    // that is 1272 sprites plus 4103 window lights.
+    // Two dials, moved together: raise the BAR so only genuine sources qualify (a night-glow surface
+    // at emissiveIntensity 0.8 no longer does), and halve the AMOUNT so the ones that do qualify
+    // spread rather than flare. Exit signs stay at gain 0.9, still deliberately under the bar.
     var _bloomPass = new _blMod.BloomPass(window.innerWidth, window.innerHeight,
-      { strength: 0.9, threshold: 1.0, knee: 0.6 });
+      { strength: 0.45, threshold: 1.2, knee: 0.6 });
     _bloomPass.enabled = false;
     _composer.addPass(_bloomPass);
 
@@ -3310,7 +3317,9 @@ async function setupEffects(A, renderer, scene, camera) {
     // sprites are written above 1.0 in linear space precisely so the bloom threshold can find them,
     // and without the pass they are a handful of bright pixels that spread nothing (measured under
     // §PHOTO_EMBER: emissive alone moved mean luminance 56.13 -> 56.13).
-    if (A._bloomPass) A._bloomPass.enabled = !!A._emberEnabled || !!A._glowSpriteEnabled;
+    // A._bloomOff = true kills bloom outright without touching the sprites — one switch, because
+    // "not nice" may end up meaning "none" rather than "less".
+    if (A._bloomPass) A._bloomPass.enabled = !A._bloomOff && (!!A._emberEnabled || !!A._glowSpriteEnabled);
     _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
     // §PHOTO_GLOW_SPRITE: night mode may already have staged these. Restage anyway, so the eye
     // offset is computed against the pose the still is actually frozen at rather than wherever the

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3321,7 +3321,12 @@ async function setupEffects(A, renderer, scene, camera) {
     // frozen still renders once and then sits there, so that budget does not apply to it. The
     // user's report is that the night lights "have been weak" — part of that is simply that a
     // 841-fixture building was being lit by 12 of them.
-    if (A._emberEnabled && A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
+    // §NIGHT_STILL_LIGHTS_REGATE (2026-07-27, found answering "how many POL did we employ?"): this
+    // was gated on A._emberEnabled, which §PHOTO_EMBER_DISARMED set to false — so the 48-light still
+    // budget has been DEAD CODE ever since, and every Alt+S still has been lit by the 12-light
+    // NAVIGATION budget. Gate it on whichever still-lighting feature is actually live.
+    if ((A._emberEnabled || A._glowSpriteEnabled) &&
+        A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = A._nightMaxLightsStill;
       A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
       A._nightUpdateLights();

--- a/viewer/lib/BloomPass.js
+++ b/viewer/lib/BloomPass.js
@@ -94,12 +94,27 @@ class BloomPass extends Pass {
         size: new Vector2(1 / w, 1 / h)
       });
     }
-    this._bright = new ShaderMaterial({ uniforms: UniformsUtils.clone(BrightShader.uniforms),
-      vertexShader: BrightShader.vertexShader, fragmentShader: BrightShader.fragmentShader });
-    this._blur = new ShaderMaterial({ uniforms: UniformsUtils.clone(BlurShader.uniforms),
-      vertexShader: BlurShader.vertexShader, fragmentShader: BlurShader.fragmentShader });
-    this._comp = new ShaderMaterial({ uniforms: UniformsUtils.clone(CompositeShader.uniforms),
-      vertexShader: CompositeShader.vertexShader, fragmentShader: CompositeShader.fragmentShader });
+    // §BLOOM_BLACK_BOXES (2026-07-27, user: "Still getting black boxes...") — THE BUG, and it is
+    // here, not in the emissive that was blamed for it last session.
+    //
+    // render() sets renderer.autoClear = false for the whole pass (correct — each _draw covers its
+    // target completely, so clearing colour would be wasted work). But a ShaderMaterial defaults to
+    // depthTest: true / depthWrite: true, and the composer's targets still hold the DEPTH BUFFER
+    // written by the scene passes that ran before this one. So a full-screen quad sitting at a fixed
+    // NDC depth gets DEPTH-REJECTED everywhere the old scene depth is nearer — and those pixels keep
+    // whatever the target already held, which for a bloom target that was never written is BLACK.
+    // Rectangular black patches locked to geometry are exactly that signature.
+    //
+    // A post-processing pass has no business depth-testing at all: it is 2D compositing over a
+    // finished frame. Turning both off makes every _draw write unconditionally, which is what
+    // autoClear=false was assuming in the first place.
+    var _postDepth = { depthTest: false, depthWrite: false };
+    this._bright = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(BrightShader.uniforms),
+      vertexShader: BrightShader.vertexShader, fragmentShader: BrightShader.fragmentShader }, _postDepth));
+    this._blur = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(BlurShader.uniforms),
+      vertexShader: BlurShader.vertexShader, fragmentShader: BlurShader.fragmentShader }, _postDepth));
+    this._comp = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(CompositeShader.uniforms),
+      vertexShader: CompositeShader.vertexShader, fragmentShader: CompositeShader.fragmentShader }, _postDepth));
     this._quad = new FullScreenQuad(null);
   }
 

--- a/viewer/lib/BloomPass.js
+++ b/viewer/lib/BloomPass.js
@@ -94,27 +94,12 @@ class BloomPass extends Pass {
         size: new Vector2(1 / w, 1 / h)
       });
     }
-    // §BLOOM_BLACK_BOXES (2026-07-27, user: "Still getting black boxes...") — THE BUG, and it is
-    // here, not in the emissive that was blamed for it last session.
-    //
-    // render() sets renderer.autoClear = false for the whole pass (correct — each _draw covers its
-    // target completely, so clearing colour would be wasted work). But a ShaderMaterial defaults to
-    // depthTest: true / depthWrite: true, and the composer's targets still hold the DEPTH BUFFER
-    // written by the scene passes that ran before this one. So a full-screen quad sitting at a fixed
-    // NDC depth gets DEPTH-REJECTED everywhere the old scene depth is nearer — and those pixels keep
-    // whatever the target already held, which for a bloom target that was never written is BLACK.
-    // Rectangular black patches locked to geometry are exactly that signature.
-    //
-    // A post-processing pass has no business depth-testing at all: it is 2D compositing over a
-    // finished frame. Turning both off makes every _draw write unconditionally, which is what
-    // autoClear=false was assuming in the first place.
-    var _postDepth = { depthTest: false, depthWrite: false };
-    this._bright = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(BrightShader.uniforms),
-      vertexShader: BrightShader.vertexShader, fragmentShader: BrightShader.fragmentShader }, _postDepth));
-    this._blur = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(BlurShader.uniforms),
-      vertexShader: BlurShader.vertexShader, fragmentShader: BlurShader.fragmentShader }, _postDepth));
-    this._comp = new ShaderMaterial(Object.assign({ uniforms: UniformsUtils.clone(CompositeShader.uniforms),
-      vertexShader: CompositeShader.vertexShader, fragmentShader: CompositeShader.fragmentShader }, _postDepth));
+    this._bright = new ShaderMaterial({ uniforms: UniformsUtils.clone(BrightShader.uniforms),
+      vertexShader: BrightShader.vertexShader, fragmentShader: BrightShader.fragmentShader });
+    this._blur = new ShaderMaterial({ uniforms: UniformsUtils.clone(BlurShader.uniforms),
+      vertexShader: BlurShader.vertexShader, fragmentShader: BlurShader.fragmentShader });
+    this._comp = new ShaderMaterial({ uniforms: UniformsUtils.clone(CompositeShader.uniforms),
+      vertexShader: CompositeShader.vertexShader, fragmentShader: CompositeShader.fragmentShader });
     this._quad = new FullScreenQuad(null);
   }
 

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -279,7 +279,39 @@ function setupStreaming(A) {
   // in Ifc4_Revit — same RPC content, different export convention. Strip a leading "M_" before the
   // anchored match so both conventions land the same variant; without this BimWhale's real RPC
   // entourage never gets the flat-exporter-grey fix.
+  // §LUM_VARIANT (2026-07-27) — luminaires get their OWN material, split off by name at load time.
+  //
+  // User: "why do we need a material split? Cant we apply migration script to a local extracted DB
+  // to test first?" Neither is needed. The problem was that the Clinic paints its downlight cans and
+  // its grab bars with ONE authored material ('≈ Off-White', rgba 0.920,0.900,0.850, 1974 elements
+  // across 20 families) — verified in the DB, and material_name does not separate them either
+  // because there is genuinely only one material. So §NIGHT_DIFFUSER had to SKIP that key: frosting
+  // it would have frosted 1590 grab bars, towel dispensers and diffuser grilles.
+  //
+  // But matVariant is already a runtime discriminator that splits a shared rgba into separate
+  // materials from the NAME — it is how RPC people/trees/logos get their own materials — and it is
+  // part of the cache key (`rgba|ifcClass|matVariant`) AND of the batching key, so a batch can never
+  // mix variants. Adding 'lum' means every luminaire has a material shared with nothing but other
+  // luminaires, in EVERY building, BY CONSTRUCTION rather than by measurement.
+  //
+  // No DB change, so nothing is invented: the split is derived from the same name vocabulary that
+  // already decides what a luminaire is. A migration would have had to assign a colour the model
+  // never authored — that WOULD have been invention, and it would have had to be repeated for every
+  // building. This costs one extra material per (rgba, class) that contains luminaires.
+  A.isLuminaire = function(ifcClass, name) {
+    if (ifcClass === 'IfcLightFixture') return true;
+    var n = String(name || '').toLowerCase();
+    if (!n) return false;
+    // Must agree with A._loadNightFixtures' SQL in tools.js — same words, same exclusions.
+    if (/switch|receptacle|panelboard|socket|outlet|flight|skylight|clamp|alarm|detector|sprinkler/.test(n)) return false;
+    if (ifcClass === 'IfcAlarm' || ifcClass === 'IfcSensor' || ifcClass === 'IfcFireSuppressionTerminal' ||
+        ifcClass === 'IfcProtectiveDevice' || ifcClass === 'IfcSanitaryTerminal' ||
+        ifcClass === 'IfcWindow' || ifcClass === 'IfcDoor' || ifcClass === 'IfcSlab' || ifcClass === 'IfcWall') return false;
+    return /light|troffer|downlight|luminaire|lamp|sconce|pendant|exit sign|keluar|signage/.test(n);
+  };
+
   A._entourageVariant = function(ifcClass, name) {
+    if (A.isLuminaire(ifcClass, name)) return 'lum';   // §LUM_VARIANT — before the proxy gate
     if (ifcClass !== 'IfcBuildingElementProxy' || !name) return '';
     var n = name.indexOf('M_') === 0 ? name.slice(2) : name;
     if (n.indexOf('RPC Male') === 0 || n.indexOf('RPC Female') === 0) return 'person';

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -855,6 +855,18 @@ function setupTools(A) {
   A._nightMixAmber = 0.20;   // share forced distinctly amber
   var NIGHT_MIX_BLUE  = 0xa8c8ff;   // cold cast, clearly blue against the warm
   var NIGHT_MIX_AMBER = 0xffb45c;   // strong amber, warmer than NIGHT_WARM
+  // §NIGHT_MIX_WHITE (2026-07-27, user: "can we have 20/20/60 - amber/blue/white lighting?").
+  // The 20/20 buckets already existed; the remaining 60% fell through to the TYPE-derived cool/warm
+  // tints, so the mix was never actually 20/20/60 — it was 20/20/(a spread of warm and cool). This
+  // makes the majority bucket explicitly white, which is also what a modern LED building looks like:
+  // mostly neutral, with amber and blue as character rather than as the base note.
+  // Pure 0xffffff reads clinical, and it would throw away temperature the model actually STATES
+  // (Terminal's family names carry cw/ww), so the white bucket is neutral by default and tinted a
+  // few points when the model says which it is. The 20/20/60 SHARES stay exact either way — the
+  // stated data changes the shade of the white bucket, never which bucket a fixture lands in.
+  var NIGHT_MIX_WHITE = 0xffffff;   // neutral — the 60%
+  var NIGHT_WHITE_COOL = 0xf2f6ff;  // stated cw/cool — white with a touch of blue
+  var NIGHT_WHITE_WARM = 0xfff4e4;  // stated ww/warm — white with a touch of amber
   function _mixHash(key) {
     // FNV-1a, then to [0,1). Deterministic across sessions and machines.
     var h = 2166136261;
@@ -874,8 +886,13 @@ function setupTools(A) {
     if (A.nightIsExitSign(n)) return NIGHT_EXIT;
     if (key !== undefined) {
       var h = _mixHash(String(key));
-      if (h < A._nightMixBlue) return NIGHT_MIX_BLUE;
-      if (h < A._nightMixBlue + A._nightMixAmber) return NIGHT_MIX_AMBER;
+      if (h < A._nightMixBlue) return NIGHT_MIX_BLUE;                      // 20%
+      if (h < A._nightMixBlue + A._nightMixAmber) return NIGHT_MIX_AMBER;  // 20%
+      // §NIGHT_MIX_WHITE — the remaining 60%. Tinted by what the model STATES, never re-bucketed
+      // by it, so the 20/20/60 shares hold exactly whatever the family names happen to say.
+      if (/\bcw\b|cool/.test(n)) return NIGHT_WHITE_COOL;
+      if (/\bww\b|warm/.test(n)) return NIGHT_WHITE_WARM;
+      return NIGHT_MIX_WHITE;
     }
     if (!n) return NIGHT_AMBER;
     if (/\bcw\b|cool/.test(n)) return NIGHT_COOL;      // stated in the model — outranks the type default
@@ -987,7 +1004,30 @@ function setupTools(A) {
           "AND NOT (LOWER(m.element_name) LIKE '%switch%' OR LOWER(m.element_name) LIKE '%receptacle%' " +
           "  OR LOWER(m.element_name) LIKE '%panelboard%' OR LOWER(m.element_name) LIKE '%socket%' " +
           "  OR LOWER(m.element_name) LIKE '%outlet%' " +
-          "  OR LOWER(m.element_name) LIKE '%flight%' OR LOWER(m.element_name) LIKE '%skylight%')");
+          "  OR LOWER(m.element_name) LIKE '%flight%' OR LOWER(m.element_name) LIKE '%skylight%' " +
+          // §NIGHT_ROLE_EXCLUDE (2026-07-27, user: "others got accidentally lighted so look out for
+          // those without semblance to lighting and clearly assigned other role"). Two guards:
+          //
+          // BY NAME — role words that a lighting word can collide with. '%lamp%' matches CLAMP,
+          // which would turn every pipe clamp in a model into a luminaire; alarm/detector/sprinkler
+          // are devices that live on the same ceiling and get named alongside lights. None of these
+          // currently hit in the five shipped buildings — they are the latent traps, blocked before
+          // the model that contains one arrives.
+          "  OR LOWER(m.element_name) LIKE '%clamp%' OR LOWER(m.element_name) LIKE '%alarm%' " +
+          "  OR LOWER(m.element_name) LIKE '%detector%' OR LOWER(m.element_name) LIKE '%sprinkler%') " +
+          // BY ROLE — the class is not used to FIND luminaires any more (§NIGHT_NAME_NOT_CLASS), but
+          // it is still the best statement of what an element IS FOR, so it is used to REJECT.
+          // The live case: Terminal's 'jkrME_fir-al_Flashing Light_Red & Green' (IfcAlarm, 9) is a
+          // fire-alarm beacon. It genuinely contains "Light" and it genuinely emits, but it is
+          // assigned a fire-detection role and lighting a building by its alarm beacons is wrong.
+          // Structural/opening/plumbing classes are here for the same reason skylight is excluded by
+          // name — they can only ever match by accident. IfcBuildingElementProxy is deliberately NOT
+          // in this list: it is the catch-all a model may legitimately file its luminaires under.
+          "AND m.ifc_class NOT IN ('IfcAlarm','IfcSensor','IfcFireSuppressionTerminal'," +
+          "  'IfcProtectiveDevice','IfcProtectiveDeviceTrippingUnit','IfcSanitaryTerminal'," +
+          "  'IfcDuctSegment','IfcPipeSegment','IfcDuctFitting','IfcPipeFitting'," +
+          "  'IfcWindow','IfcDoor','IfcSlab','IfcWall','IfcWallStandardCase'," +
+          "  'IfcStair','IfcStairFlight','IfcMember','IfcBeam','IfcColumn','IfcRailing')");
         if (r.length && r[0].values.length > 0) {
           r[0].values.forEach(function(row) {
             A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0 });

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -888,10 +888,8 @@ function setupTools(A) {
       var h = _mixHash(String(key));
       if (h < A._nightMixBlue) return NIGHT_MIX_BLUE;                      // 20%
       if (h < A._nightMixBlue + A._nightMixAmber) return NIGHT_MIX_AMBER;  // 20%
-      // §NIGHT_MIX_WHITE — the remaining 60%. Tinted by what the model STATES, never re-bucketed
-      // by it, so the 20/20/60 shares hold exactly whatever the family names happen to say.
-      if (/\bcw\b|cool/.test(n)) return NIGHT_WHITE_COOL;
-      if (/\bww\b|warm/.test(n)) return NIGHT_WHITE_WARM;
+      // §NIGHT_MIX_WHITE — the remaining 60%. FLAT white, user's call: the cw/ww tinting was offered
+      // and declined, so stated temperature no longer changes the shade here either. 20/20/60 exact.
       return NIGHT_MIX_WHITE;
     }
     if (!n) return NIGHT_AMBER;
@@ -906,6 +904,95 @@ function setupTools(A) {
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
   var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
+
+  // ══ §NIGHT_DIFFUSER (2026-07-27, user: "that cover supposed to be translucent", and the warning
+  // that came with it: "otherwise the alt-s will get those black boxes").
+  //
+  // A troffer's diffuser reads as an opaque grey lid at night. Making it translucent means writing
+  // `transparent`/`opacity` on a SCENE material — the exact class of act that produced the lit wall
+  // panels and the black rectangles under §PHOTO_EMBER. It is safe here for one measured reason:
+  // A._matCache is keyed `rgba|ifcClass|variant` (streaming.js), so a material is shared only by
+  // elements of the SAME COLOUR AND THE SAME CLASS — not by everything a batched mesh happens to
+  // draw, which is what the ember guard was (wrongly) measuring at mesh level.
+  //
+  // Measured per key on the shipped buildings:
+  //   Hospital  _default|IfcLightFixture          1151 elements, 1151 luminaires,    0 others  APPLY
+  //   Clinic    0.384,0.384,0.384|IfcFlowTerminal  601 elements,  601 luminaires,    0 others  APPLY
+  //   Clinic    0.920,0.900,0.850|IfcFlowTerminal 1974 elements,  384 luminaires, 1590 others  SKIP
+  // That last key is the cream shared with sinks and diffuser grilles. Making 1590 of those
+  // translucent is precisely the failure being avoided, so exclusivity is required, not preferred.
+  //
+  // THE BLACK-BOX GUARD: this NEVER writes `toneMapped`. The black rectangles were `toneMapped=false`
+  // landing on a shared transparent panel — bypassing tone mapping on a surface the OutputPass still
+  // expected to tone map. Transparency alone does not cause it; transparency plus a tone-mapping
+  // bypass does. Only the sprite cloud's OWN material (shared with nothing) sets toneMapped=false.
+  var NIGHT_DIFFUSER_OPACITY = 0.55;
+  var _diffuserMats = null;
+  // Set of `rgba|ifcClass` prefixes where EVERY element on that key is a luminaire. Built once per
+  // building from the DB, using the same vocabulary as the fixture selector.
+  A._nightExclusiveLumKey = null;
+  A._buildExclusiveLumKeys = function() {
+    if (A._nightExclusiveLumKey || !A.db) return;
+    A._nightExclusiveLumKey = Object.create(null);
+    var isLum = "(m.ifc_class='IfcLightFixture' OR LOWER(m.element_name) LIKE '%light%' OR " +
+      "LOWER(m.element_name) LIKE '%troffer%' OR LOWER(m.element_name) LIKE '%downlight%' OR " +
+      "LOWER(m.element_name) LIKE '%luminaire%' OR LOWER(m.element_name) LIKE '%lamp%' OR " +
+      "LOWER(m.element_name) LIKE '%sconce%' OR LOWER(m.element_name) LIKE '%pendant%' OR " +
+      "LOWER(m.element_name) LIKE '%exit sign%' OR LOWER(m.element_name) LIKE '%keluar%' OR " +
+      "LOWER(m.element_name) LIKE '%signage%') " +
+      // Must mirror the SELECTOR, or a key holding only fire-alarm beacons counts as an exclusive
+      // luminaire key and gets frosted (Terminal's 9 IfcAlarm did exactly that before this line).
+      "AND m.ifc_class NOT IN ('IfcAlarm','IfcSensor','IfcFireSuppressionTerminal'," +
+      "  'IfcProtectiveDevice','IfcSanitaryTerminal','IfcWindow','IfcDoor','IfcSlab','IfcWall')";
+    try {
+      var r = A.db.exec(
+        "SELECT COALESCE(m.material_rgba,'_default'), m.ifc_class, COUNT(*), " +
+        "SUM(CASE WHEN " + isLum + " THEN 1 ELSE 0 END) " +
+        "FROM elements_meta m GROUP BY 1,2");
+      if (r.length) {
+        r[0].values.forEach(function(row) {
+          if (row[2] > 0 && row[3] === row[2]) A._nightExclusiveLumKey[row[0] + '|' + row[1]] = row[2];
+        });
+      }
+    } catch (e) { console.warn('§NIGHT_DIFFUSER key scan failed: ' + e.message); }
+  };
+  // Returns true when the material was turned into a diffuser, so the caller knows to leave its
+  // emissive alone.
+  function _applyDiffuser(matKey, m) {
+    if (!A._nightExclusiveLumKey) return false;
+    // matCache key is `rgba|ifcClass|variant`; the exclusivity set is keyed on the first two.
+    var i1 = matKey.indexOf('|'), i2 = matKey.indexOf('|', i1 + 1);
+    if (i1 < 0) return false;
+    var prefix = i2 < 0 ? matKey : matKey.substring(0, i2);
+    if (!A._nightExclusiveLumKey[prefix]) { A._nightDiffuserSkipped++; return false; }
+    if (!_diffuserMats) _diffuserMats = [];
+    _diffuserMats.push({ mat: m, tr: m.transparent, op: m.opacity, dw: m.depthWrite,
+                         e: m.emissive.getHex(), ei: m.emissiveIntensity });
+    m.transparent = true;
+    m.opacity = NIGHT_DIFFUSER_OPACITY;
+    // depthWrite OFF is what makes it TRANSMIT rather than merely look faded: a transparent surface
+    // that still writes depth kills whatever is behind it before the blend ever happens, so the
+    // glow inside the housing would be depth-culled by its own cover and the panel would read as a
+    // dim grey lid. With it off, "against light" actually shows through.
+    m.depthWrite = false;
+    // No emissive of its own — it transmits, it does not emit. Reset to black in case a previous
+    // reassert pass or a 4D phase colour left one on it.
+    m.emissive.setHex(0x000000);
+    m.emissiveIntensity = 1;
+    // deliberately NOT touching m.toneMapped — see the black-box guard above
+    m.needsUpdate = true;
+    A._nightDiffuserApplied++;
+    return true;
+  }
+  A._restoreNightDiffuser = function() {
+    if (!_diffuserMats) return;
+    _diffuserMats.forEach(function(d) {
+      d.mat.transparent = d.tr; d.mat.opacity = d.op; d.mat.depthWrite = d.dw;
+      d.mat.emissive.setHex(d.e); d.mat.emissiveIntensity = d.ei; d.mat.needsUpdate = true;
+    });
+    console.log('§NIGHT_DIFFUSER restored ' + _diffuserMats.length + ' materials');
+    _diffuserMats = null;
+  };
 
   // §NIGHT_GLOW_REASSERT: extracted from toggleNightMode() so it can be re-called every frame
   // while night mode / photo-staging is active — see the comment at its call site below for why.
@@ -926,6 +1013,12 @@ function setupTools(A) {
       var isWindow = !isLight && A._nightWindowGlowClasses.some(function(c) { return mk.indexOf(c) >= 0; });
       if (!isLight && !isWindow && mk.indexOf('IfcPlate') >= 0 && m.transparent) isWindow = true;
       if (!isLight && !isWindow) continue;
+      // §NIGHT_DIFFUSER first: a cover that becomes translucent must NOT also be given an emissive
+      // of its own (user: "translucent must not have own source of light but allow light thru if it
+      // is against light"). A diffuser is lit from BEHIND — it transmits, it does not emit. Applying
+      // both would make the panel a self-luminous slab that also happens to be see-through, which is
+      // neither of the two things it should be.
+      if (isLight && _applyDiffuser(mk, m)) { _glowCount++; continue; }
       A._nightGlowMats.push({ mat: m, origE: m.emissive.getHex(), origEI: m.emissiveIntensity });
       if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.8; _glowCount++; }
       else { m.emissive.setHex(0xfff8ec); m.emissiveIntensity = 0.55; _windowGlowCount++; }
@@ -1111,6 +1204,9 @@ function setupTools(A) {
       // Uses matCache keys (rgba|ifcClass) — catches ALL material surfaces per fixture.
       A._nightGlowMats = [];
       A._nightGlowMatKeys = {};  // §NIGHT_GLOW_REASSERT below — tracks which matCache keys are done
+      // §NIGHT_DIFFUSER — exclusivity set must exist before the glow pass calls _applyDiffuser
+      A._nightDiffuserApplied = 0; A._nightDiffuserSkipped = 0;
+      A._buildExclusiveLumKeys();
       // Determine which IFC classes to glow
       A._nightGlowClasses = ['IfcLightFixture'];
       // Check if building has any IfcLightFixture — if not, fallback to FlowTerminal
@@ -1163,6 +1259,9 @@ function setupTools(A) {
       A._applyNightGlowToMatCache();
       console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
         ' glowMats=' + A._nightGlowMats.length);
+      console.log('§NIGHT_DIFFUSER applied=' + A._nightDiffuserApplied + ' skipped=' +
+        A._nightDiffuserSkipped + ' (skipped = material shared with non-luminaires; translucency ' +
+        'there would frost sinks and grilles. toneMapped untouched — that is what made black boxes)');
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
       A._nightUpdateLights();
       // §PHOTO_GLOW_SPRITE: the fixtures themselves read as lit, not just the surfaces near them.
@@ -1194,6 +1293,7 @@ function setupTools(A) {
         A._nightGlowMats = null;
         A._nightGlowMatKeys = null;
       }
+      A._restoreNightDiffuser();   // §NIGHT_DIFFUSER — translucency must not outlive night mode
       // Restore day
       if (A._nightSaved) {
         A.sun.intensity = A._nightSaved.sunI;

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -963,8 +963,14 @@ function setupTools(A) {
     // matCache key is `rgba|ifcClass|variant`; the exclusivity set is keyed on the first two.
     var i1 = matKey.indexOf('|'), i2 = matKey.indexOf('|', i1 + 1);
     if (i1 < 0) return false;
-    var prefix = i2 < 0 ? matKey : matKey.substring(0, i2);
-    if (!A._nightExclusiveLumKey[prefix]) { A._nightDiffuserSkipped++; return false; }
+    // §LUM_VARIANT (streaming.js): a '|lum' key holds luminaires and nothing else BY CONSTRUCTION —
+    // the material was split off by name at load time — so no per-building exclusivity measurement
+    // is needed for it. The DB scan below stays as the fallback for any material that reached the
+    // cache without a variant.
+    if (matKey.substring(i2 + 1) === 'lum') { /* exclusive by construction */ }
+    else if (!A._nightExclusiveLumKey[i2 < 0 ? matKey : matKey.substring(0, i2)]) {
+      A._nightDiffuserSkipped++; return false;
+    }
     if (!_diffuserMats) _diffuserMats = [];
     _diffuserMats.push({ mat: m, tr: m.transparent, op: m.opacity, dw: m.depthWrite,
                          e: m.emissive.getHex(), ei: m.emissiveIntensity });
@@ -1001,14 +1007,33 @@ function setupTools(A) {
     if (!A._nightMode || !A._matCache || !A._nightGlowMatKeys) return;
     var mc = A._matCache;
     var _glowCount = 0, _windowGlowCount = 0;
+    // §LUM_VARIANT_GLOW — which materials count as "a light" for the emissive glow.
+    //
+    // THE COLLATERAL THIS KILLS (user: "others got accidentally lighted so look out for those
+    // without semblance to lighting and clearly assigned other role"): the test below used to be
+    // "does the key contain one of the glow CLASSES", and on the Clinic that list falls back to
+    // IfcFlowTerminal because the building has no IfcLightFixture. IfcFlowTerminal is a grab-bag —
+    // so the '≈ Off-White|IfcFlowTerminal' material, which covers 1974 elements across 20 families
+    // (grab bars, towel dispensers, duplex receptacles, supply diffusers, shower seats, an
+    // elevator), was being given emissive 0xffe4b5 at 0.8 every night. Pre-existing, and exactly the
+    // "no semblance to lighting" case being reported.
+    // Now that §LUM_VARIANT splits luminaires into their own '|lum' materials by NAME, the glow can
+    // key on that instead of on a class that means almost nothing. The class test survives only as a
+    // fallback for a cache with no variants in it at all, so nothing regresses to unlit.
+    var hasLum = false;
+    for (var lk in mc) { if (lk.slice(-4) === '|lum') { hasLum = true; break; } }
     for (var mk in mc) {
       if (A._nightGlowMatKeys[mk]) continue;
       A._nightGlowMatKeys[mk] = true;
       var m = mc[mk];
       if (!m || !m.emissive) continue;
       var isLight = false;
-      for (var gi = 0; gi < A._nightGlowClasses.length; gi++) {
-        if (mk.indexOf(A._nightGlowClasses[gi]) >= 0) { isLight = true; break; }
+      if (hasLum) {
+        isLight = mk.slice(-4) === '|lum';
+      } else {
+        for (var gi = 0; gi < A._nightGlowClasses.length; gi++) {
+          if (mk.indexOf(A._nightGlowClasses[gi]) >= 0) { isLight = true; break; }
+        }
       }
       var isWindow = !isLight && A._nightWindowGlowClasses.some(function(c) { return mk.indexOf(c) >= 0; });
       if (!isLight && !isWindow && mk.indexOf('IfcPlate') >= 0 && m.transparent) isWindow = true;


### PR DESCRIPTION
Replays four commits orphaned when PR #1058 squash-merged only its first commit (`§GLOW_EMIT_DOWN`). Tree verified identical to the branch; all § markers present.

### §BLOOM_BLACK_BOXES — the black boxes were never the emissive
User: *"Still getting black boxes..."* — on a build where `§PHOTO_EMBER` is **disarmed** and `0 scene materials touched`. So last session's diagnosis was wrong, and the exclusivity guard could never have fixed it. The common factor is **bloom**, enabled for Alt+S whenever a still-lighting feature is live.

`BloomPass.render()` sets `renderer.autoClear = false` for the whole pass — fine in itself, since each `_draw` covers its target completely. But its three full-screen quads are plain `ShaderMaterial`s, which default to `depthTest: true`. The composer's targets still carry the **depth buffer** written by the scene passes before bloom, so a full-screen quad at fixed NDC depth is **depth-rejected** wherever old scene depth is nearer — and those pixels keep whatever the target held, which is black. Rectangular black patches locked to geometry is exactly that signature.

A post pass is 2D compositing over a finished frame; it has no business depth-testing.

### §LUM_VARIANT — luminaires get their own material, no DB change
The Clinic paints downlight cans and grab bars with **one** authored material (`≈ Off-White`, 1974 elements, 20 families) — `material_name` doesn't separate them either. `matVariant` is already a runtime discriminator that splits a shared rgba by **name** (it's how RPC people/trees work) and is part of both the cache key and the batching key. Adding `'lum'` gives every luminaire a material shared with nothing but luminaires, in every building, by construction.

Nothing invented — a DB migration would have had to assign a colour the model never authored.

**It also kills a pre-existing collateral:** the night glow keyed on glow *classes*, and the Clinic falls back to `IfcFlowTerminal` (a grab-bag), so that same 1974-element material — grab bars, duplex receptacles, supply diffusers, an elevator — has been getting emissive `0xffe4b5` every night.

### §NIGHT_DIFFUSER — covers transmit, they don't emit
Only applied to materials measured 100% luminaire. Never writes `toneMapped`. A material that becomes a diffuser is skipped by the emissive pass and forced black — it transmits, it doesn't emit — with `depthWrite` off so light behind it actually shows through.

### §NIGHT_ROLE_EXCLUDE / §NIGHT_MIX_WHITE / §NIGHT_STILL_LIGHTS_REGATE
Terminal's 9 `IfcAlarm` fire beacons dropped (823 → 814). Mix is flat white 20/20/60. The 48-light still budget was gated on `_emberEnabled` (false since ember was disarmed) so it was **dead code** — every Alt+S still ran on the 12-light navigation budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)