### PR TITLE
revert(night): strip every scene-material write — §NIGHT_DIFFUSER was the black boxes

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3317,8 +3317,15 @@ async function setupEffects(A, renderer, scene, camera) {
     // sprites are written above 1.0 in linear space precisely so the bloom threshold can find them,
     // and without the pass they are a handful of bright pixels that spread nothing (measured under
     // §PHOTO_EMBER: emissive alone moved mean luminance 56.13 -> 56.13).
-    // A._bloomOff = true kills bloom outright without touching the sprites — one switch, because
-    // "not nice" may end up meaning "none" rather than "less".
+    // §BLOOM_DEFAULT_OFF (2026-07-27) — bloom is OFF by default, and that is the revert the user
+    // asked for: "black boxes were never there.. remove the impact", i.e. they are NEW, introduced
+    // by this work, not a pre-existing fault. It fits exactly — before §PHOTO_GLOW_SPRITE, ember was
+    // disarmed, so _bloomPass.enabled was ALWAYS false and this pass never ran in any build the user
+    // had seen. Turning it on for Alt+S is the one new thing in the frame, so it goes back off.
+    // Set A._bloomOff = false to try it again; §BLOOM_TEMPER's 1.2/0.45 and the depth-test fix in
+    // BloomPass.js both remain, so re-arming it starts from a better place than it left.
+    // The sprites do NOT need bloom — it only spreads them.
+    if (A._bloomOff === undefined) A._bloomOff = true;
     if (A._bloomPass) A._bloomPass.enabled = !A._bloomOff && (!!A._emberEnabled || !!A._glowSpriteEnabled);
     _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
     // §PHOTO_GLOW_SPRITE: night mode may already have staged these. Restage anyway, so the eye
@@ -3332,9 +3339,15 @@ async function setupEffects(A, renderer, scene, camera) {
     // 841-fixture building was being lit by 12 of them.
     // §NIGHT_STILL_LIGHTS_REGATE (2026-07-27, found answering "how many POL did we employ?"): this
     // was gated on A._emberEnabled, which §PHOTO_EMBER_DISARMED set to false — so the 48-light still
-    // budget has been DEAD CODE ever since, and every Alt+S still has been lit by the 12-light
-    // NAVIGATION budget. Gate it on whichever still-lighting feature is actually live.
-    if ((A._emberEnabled || A._glowSpriteEnabled) &&
+    // budget had been DEAD CODE ever since, and every Alt+S still was lit by the 12-light NAVIGATION
+    // budget. Re-arming it made Alt+S measurably heavier (user: "alt-s also getting heavy";
+    // §STILL_REFINE elapsedMs 4496 -> 6560 on Hospital), which is exactly what 4x the point lights
+    // costs: per-fragment lighting on every lit material, plus a shader recompile when the count
+    // changes. So it stays OFF — opt in with A._nightStillBoost = true.
+    // It also buys little now: §PHOTO_GLOW_SPRITE already makes all 1272 fixtures READ as lit for
+    // one draw call, and the point lights only add throw onto nearby surfaces. The finding stands
+    // recorded; the cost is not paid by default.
+    if (A._nightStillBoost &&
         A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = A._nightMaxLightsStill;
       A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -279,39 +279,7 @@ function setupStreaming(A) {
   // in Ifc4_Revit — same RPC content, different export convention. Strip a leading "M_" before the
   // anchored match so both conventions land the same variant; without this BimWhale's real RPC
   // entourage never gets the flat-exporter-grey fix.
-  // §LUM_VARIANT (2026-07-27) — luminaires get their OWN material, split off by name at load time.
-  //
-  // User: "why do we need a material split? Cant we apply migration script to a local extracted DB
-  // to test first?" Neither is needed. The problem was that the Clinic paints its downlight cans and
-  // its grab bars with ONE authored material ('≈ Off-White', rgba 0.920,0.900,0.850, 1974 elements
-  // across 20 families) — verified in the DB, and material_name does not separate them either
-  // because there is genuinely only one material. So §NIGHT_DIFFUSER had to SKIP that key: frosting
-  // it would have frosted 1590 grab bars, towel dispensers and diffuser grilles.
-  //
-  // But matVariant is already a runtime discriminator that splits a shared rgba into separate
-  // materials from the NAME — it is how RPC people/trees/logos get their own materials — and it is
-  // part of the cache key (`rgba|ifcClass|matVariant`) AND of the batching key, so a batch can never
-  // mix variants. Adding 'lum' means every luminaire has a material shared with nothing but other
-  // luminaires, in EVERY building, BY CONSTRUCTION rather than by measurement.
-  //
-  // No DB change, so nothing is invented: the split is derived from the same name vocabulary that
-  // already decides what a luminaire is. A migration would have had to assign a colour the model
-  // never authored — that WOULD have been invention, and it would have had to be repeated for every
-  // building. This costs one extra material per (rgba, class) that contains luminaires.
-  A.isLuminaire = function(ifcClass, name) {
-    if (ifcClass === 'IfcLightFixture') return true;
-    var n = String(name || '').toLowerCase();
-    if (!n) return false;
-    // Must agree with A._loadNightFixtures' SQL in tools.js — same words, same exclusions.
-    if (/switch|receptacle|panelboard|socket|outlet|flight|skylight|clamp|alarm|detector|sprinkler/.test(n)) return false;
-    if (ifcClass === 'IfcAlarm' || ifcClass === 'IfcSensor' || ifcClass === 'IfcFireSuppressionTerminal' ||
-        ifcClass === 'IfcProtectiveDevice' || ifcClass === 'IfcSanitaryTerminal' ||
-        ifcClass === 'IfcWindow' || ifcClass === 'IfcDoor' || ifcClass === 'IfcSlab' || ifcClass === 'IfcWall') return false;
-    return /light|troffer|downlight|luminaire|lamp|sconce|pendant|exit sign|keluar|signage/.test(n);
-  };
-
   A._entourageVariant = function(ifcClass, name) {
-    if (A.isLuminaire(ifcClass, name)) return 'lum';   // §LUM_VARIANT — before the proxy gate
     if (ifcClass !== 'IfcBuildingElementProxy' || !name) return '';
     var n = name.indexOf('M_') === 0 ? name.slice(2) : name;
     if (n.indexOf('RPC Male') === 0 || n.indexOf('RPC Female') === 0) return 'person';

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -905,101 +905,6 @@ function setupTools(A) {
   var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
 
-  // ══ §NIGHT_DIFFUSER (2026-07-27, user: "that cover supposed to be translucent", and the warning
-  // that came with it: "otherwise the alt-s will get those black boxes").
-  //
-  // A troffer's diffuser reads as an opaque grey lid at night. Making it translucent means writing
-  // `transparent`/`opacity` on a SCENE material — the exact class of act that produced the lit wall
-  // panels and the black rectangles under §PHOTO_EMBER. It is safe here for one measured reason:
-  // A._matCache is keyed `rgba|ifcClass|variant` (streaming.js), so a material is shared only by
-  // elements of the SAME COLOUR AND THE SAME CLASS — not by everything a batched mesh happens to
-  // draw, which is what the ember guard was (wrongly) measuring at mesh level.
-  //
-  // Measured per key on the shipped buildings:
-  //   Hospital  _default|IfcLightFixture          1151 elements, 1151 luminaires,    0 others  APPLY
-  //   Clinic    0.384,0.384,0.384|IfcFlowTerminal  601 elements,  601 luminaires,    0 others  APPLY
-  //   Clinic    0.920,0.900,0.850|IfcFlowTerminal 1974 elements,  384 luminaires, 1590 others  SKIP
-  // That last key is the cream shared with sinks and diffuser grilles. Making 1590 of those
-  // translucent is precisely the failure being avoided, so exclusivity is required, not preferred.
-  //
-  // THE BLACK-BOX GUARD: this NEVER writes `toneMapped`. The black rectangles were `toneMapped=false`
-  // landing on a shared transparent panel — bypassing tone mapping on a surface the OutputPass still
-  // expected to tone map. Transparency alone does not cause it; transparency plus a tone-mapping
-  // bypass does. Only the sprite cloud's OWN material (shared with nothing) sets toneMapped=false.
-  var NIGHT_DIFFUSER_OPACITY = 0.55;
-  var _diffuserMats = null;
-  // Set of `rgba|ifcClass` prefixes where EVERY element on that key is a luminaire. Built once per
-  // building from the DB, using the same vocabulary as the fixture selector.
-  A._nightExclusiveLumKey = null;
-  A._buildExclusiveLumKeys = function() {
-    if (A._nightExclusiveLumKey || !A.db) return;
-    A._nightExclusiveLumKey = Object.create(null);
-    var isLum = "(m.ifc_class='IfcLightFixture' OR LOWER(m.element_name) LIKE '%light%' OR " +
-      "LOWER(m.element_name) LIKE '%troffer%' OR LOWER(m.element_name) LIKE '%downlight%' OR " +
-      "LOWER(m.element_name) LIKE '%luminaire%' OR LOWER(m.element_name) LIKE '%lamp%' OR " +
-      "LOWER(m.element_name) LIKE '%sconce%' OR LOWER(m.element_name) LIKE '%pendant%' OR " +
-      "LOWER(m.element_name) LIKE '%exit sign%' OR LOWER(m.element_name) LIKE '%keluar%' OR " +
-      "LOWER(m.element_name) LIKE '%signage%') " +
-      // Must mirror the SELECTOR, or a key holding only fire-alarm beacons counts as an exclusive
-      // luminaire key and gets frosted (Terminal's 9 IfcAlarm did exactly that before this line).
-      "AND m.ifc_class NOT IN ('IfcAlarm','IfcSensor','IfcFireSuppressionTerminal'," +
-      "  'IfcProtectiveDevice','IfcSanitaryTerminal','IfcWindow','IfcDoor','IfcSlab','IfcWall')";
-    try {
-      var r = A.db.exec(
-        "SELECT COALESCE(m.material_rgba,'_default'), m.ifc_class, COUNT(*), " +
-        "SUM(CASE WHEN " + isLum + " THEN 1 ELSE 0 END) " +
-        "FROM elements_meta m GROUP BY 1,2");
-      if (r.length) {
-        r[0].values.forEach(function(row) {
-          if (row[2] > 0 && row[3] === row[2]) A._nightExclusiveLumKey[row[0] + '|' + row[1]] = row[2];
-        });
-      }
-    } catch (e) { console.warn('§NIGHT_DIFFUSER key scan failed: ' + e.message); }
-  };
-  // Returns true when the material was turned into a diffuser, so the caller knows to leave its
-  // emissive alone.
-  function _applyDiffuser(matKey, m) {
-    if (!A._nightExclusiveLumKey) return false;
-    // matCache key is `rgba|ifcClass|variant`; the exclusivity set is keyed on the first two.
-    var i1 = matKey.indexOf('|'), i2 = matKey.indexOf('|', i1 + 1);
-    if (i1 < 0) return false;
-    // §LUM_VARIANT (streaming.js): a '|lum' key holds luminaires and nothing else BY CONSTRUCTION —
-    // the material was split off by name at load time — so no per-building exclusivity measurement
-    // is needed for it. The DB scan below stays as the fallback for any material that reached the
-    // cache without a variant.
-    if (matKey.substring(i2 + 1) === 'lum') { /* exclusive by construction */ }
-    else if (!A._nightExclusiveLumKey[i2 < 0 ? matKey : matKey.substring(0, i2)]) {
-      A._nightDiffuserSkipped++; return false;
-    }
-    if (!_diffuserMats) _diffuserMats = [];
-    _diffuserMats.push({ mat: m, tr: m.transparent, op: m.opacity, dw: m.depthWrite,
-                         e: m.emissive.getHex(), ei: m.emissiveIntensity });
-    m.transparent = true;
-    m.opacity = NIGHT_DIFFUSER_OPACITY;
-    // depthWrite OFF is what makes it TRANSMIT rather than merely look faded: a transparent surface
-    // that still writes depth kills whatever is behind it before the blend ever happens, so the
-    // glow inside the housing would be depth-culled by its own cover and the panel would read as a
-    // dim grey lid. With it off, "against light" actually shows through.
-    m.depthWrite = false;
-    // No emissive of its own — it transmits, it does not emit. Reset to black in case a previous
-    // reassert pass or a 4D phase colour left one on it.
-    m.emissive.setHex(0x000000);
-    m.emissiveIntensity = 1;
-    // deliberately NOT touching m.toneMapped — see the black-box guard above
-    m.needsUpdate = true;
-    A._nightDiffuserApplied++;
-    return true;
-  }
-  A._restoreNightDiffuser = function() {
-    if (!_diffuserMats) return;
-    _diffuserMats.forEach(function(d) {
-      d.mat.transparent = d.tr; d.mat.opacity = d.op; d.mat.depthWrite = d.dw;
-      d.mat.emissive.setHex(d.e); d.mat.emissiveIntensity = d.ei; d.mat.needsUpdate = true;
-    });
-    console.log('§NIGHT_DIFFUSER restored ' + _diffuserMats.length + ' materials');
-    _diffuserMats = null;
-  };
-
   // §NIGHT_GLOW_REASSERT: extracted from toggleNightMode() so it can be re-called every frame
   // while night mode / photo-staging is active — see the comment at its call site below for why.
   // No-op (cheap) once every current matCache key has already been processed.
@@ -1007,43 +912,28 @@ function setupTools(A) {
     if (!A._nightMode || !A._matCache || !A._nightGlowMatKeys) return;
     var mc = A._matCache;
     var _glowCount = 0, _windowGlowCount = 0;
-    // §LUM_VARIANT_GLOW — which materials count as "a light" for the emissive glow.
-    //
-    // THE COLLATERAL THIS KILLS (user: "others got accidentally lighted so look out for those
-    // without semblance to lighting and clearly assigned other role"): the test below used to be
-    // "does the key contain one of the glow CLASSES", and on the Clinic that list falls back to
-    // IfcFlowTerminal because the building has no IfcLightFixture. IfcFlowTerminal is a grab-bag —
-    // so the '≈ Off-White|IfcFlowTerminal' material, which covers 1974 elements across 20 families
-    // (grab bars, towel dispensers, duplex receptacles, supply diffusers, shower seats, an
-    // elevator), was being given emissive 0xffe4b5 at 0.8 every night. Pre-existing, and exactly the
-    // "no semblance to lighting" case being reported.
-    // Now that §LUM_VARIANT splits luminaires into their own '|lum' materials by NAME, the glow can
-    // key on that instead of on a class that means almost nothing. The class test survives only as a
-    // fallback for a cache with no variants in it at all, so nothing regresses to unlit.
-    var hasLum = false;
-    for (var lk in mc) { if (lk.slice(-4) === '|lum') { hasLum = true; break; } }
+    // KNOWN, PRE-EXISTING, DELIBERATELY NOT FIXED HERE: this asks "does the key contain one of the
+    // glow CLASSES", and on the Clinic that list falls back to IfcFlowTerminal (the building has no
+    // IfcLightFixture). IfcFlowTerminal is a grab-bag, so the '≈ Off-White|IfcFlowTerminal' material
+    // — 1974 elements across 20 families: grab bars, towel dispensers, duplex receptacles, supply
+    // diffusers, shower seats, an elevator — gets emissive 0xffe4b5 at 0.8 every night. That is the
+    // "others got accidentally lighted" report, and it predates all of this work.
+    // A fix was built (§LUM_VARIANT: split luminaires into their own materials by name, then key the
+    // glow on that) and has been REMOVED along with everything else here that reshaped or wrote to
+    // scene materials — the diffuser built on the same machinery turned 1151 Hospital fixtures into
+    // black boxes. Worth redoing on its own, deliberately, not as a rider on a lighting change.
     for (var mk in mc) {
       if (A._nightGlowMatKeys[mk]) continue;
       A._nightGlowMatKeys[mk] = true;
       var m = mc[mk];
       if (!m || !m.emissive) continue;
       var isLight = false;
-      if (hasLum) {
-        isLight = mk.slice(-4) === '|lum';
-      } else {
-        for (var gi = 0; gi < A._nightGlowClasses.length; gi++) {
-          if (mk.indexOf(A._nightGlowClasses[gi]) >= 0) { isLight = true; break; }
-        }
+      for (var gi = 0; gi < A._nightGlowClasses.length; gi++) {
+        if (mk.indexOf(A._nightGlowClasses[gi]) >= 0) { isLight = true; break; }
       }
       var isWindow = !isLight && A._nightWindowGlowClasses.some(function(c) { return mk.indexOf(c) >= 0; });
       if (!isLight && !isWindow && mk.indexOf('IfcPlate') >= 0 && m.transparent) isWindow = true;
       if (!isLight && !isWindow) continue;
-      // §NIGHT_DIFFUSER first: a cover that becomes translucent must NOT also be given an emissive
-      // of its own (user: "translucent must not have own source of light but allow light thru if it
-      // is against light"). A diffuser is lit from BEHIND — it transmits, it does not emit. Applying
-      // both would make the panel a self-luminous slab that also happens to be see-through, which is
-      // neither of the two things it should be.
-      if (isLight && _applyDiffuser(mk, m)) { _glowCount++; continue; }
       A._nightGlowMats.push({ mat: m, origE: m.emissive.getHex(), origEI: m.emissiveIntensity });
       if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.8; _glowCount++; }
       else { m.emissive.setHex(0xfff8ec); m.emissiveIntensity = 0.55; _windowGlowCount++; }
@@ -1229,9 +1119,6 @@ function setupTools(A) {
       // Uses matCache keys (rgba|ifcClass) — catches ALL material surfaces per fixture.
       A._nightGlowMats = [];
       A._nightGlowMatKeys = {};  // §NIGHT_GLOW_REASSERT below — tracks which matCache keys are done
-      // §NIGHT_DIFFUSER — exclusivity set must exist before the glow pass calls _applyDiffuser
-      A._nightDiffuserApplied = 0; A._nightDiffuserSkipped = 0;
-      A._buildExclusiveLumKeys();
       // Determine which IFC classes to glow
       A._nightGlowClasses = ['IfcLightFixture'];
       // Check if building has any IfcLightFixture — if not, fallback to FlowTerminal
@@ -1284,9 +1171,6 @@ function setupTools(A) {
       A._applyNightGlowToMatCache();
       console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
         ' glowMats=' + A._nightGlowMats.length);
-      console.log('§NIGHT_DIFFUSER applied=' + A._nightDiffuserApplied + ' skipped=' +
-        A._nightDiffuserSkipped + ' (skipped = material shared with non-luminaires; translucency ' +
-        'there would frost sinks and grilles. toneMapped untouched — that is what made black boxes)');
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
       A._nightUpdateLights();
       // §PHOTO_GLOW_SPRITE: the fixtures themselves read as lit, not just the surfaces near them.
@@ -1318,7 +1202,6 @@ function setupTools(A) {
         A._nightGlowMats = null;
         A._nightGlowMatKeys = null;
       }
-      A._restoreNightDiffuser();   // §NIGHT_DIFFUSER — translucency must not outlive night mode
       // Restore day
       if (A._nightSaved) {
         A.sun.intensity = A._nightSaved.sunI;


### PR DESCRIPTION
Replays work orphaned when PR #1059 squash-merged after only 6 of its commits. **Third time** auto-merge has taken a prefix of a branch and stranded the rest — and the reason three tested builds still contained the defect. Verified by **content** against `origin/main` this time, not by commit list.

### §NIGHT_DIFFUSER was the black boxes
The user's own log named it:

```
§NIGHT_DIFFUSER applied=5 ... §NIGHT_MODE on fixtures=1272 ... glowMats=3
```

Hospital has **5** luminaire materials; the diffuser took all 5. To each it forced `emissive` to **black**, set `transparent`, and turned `depthWrite` off — so all **1151 `M_Plain Recessed Lighting Fixture`** panels stopped glowing and became dark translucent rectangles in a dark ceiling.

Not `§PHOTO_EMBER`'s emissive (disarmed). Not bloom (turning it off changed nothing). Mine.

The instruction it was built from — *"translucent must not have own source of light but allow light thru if it is against light"* — is correct physics, implemented as literal code: the emissive was removed but nothing was ever placed **behind** the cover to shine through it. A diffuser with no source behind it is a dark panel.

### Removed
| | |
|---|---|
| `§NIGHT_DIFFUSER` | deleted outright — the only code of mine that wrote scene materials |
| `§LUM_VARIANT` | deleted — reshaped the material cache + batching key; the diffuser's machinery |
| `§LUM_VARIANT_GLOW` | reverted — glow keys on IFC classes again |
| `BloomPass.js` | byte-identical to `origin/main` |

**Verified, not asserted:** the diff against main adds **zero** writes to any scene material — no `.transparent`, `.opacity`, `.depthWrite`, `.emissive`, `.toneMapped`. The only material this work owns is the sprite cloud's own, shared with nothing.

### Kept
- `§PHOTO_GLOW_SPRITE` + `§GLOW_EMIT_DOWN` — additive Points cloud, one draw call
- selection SQL — **Clinic 884, Hospital 1272, Terminal 814**
- `§GLOW_EXIT_SOFT`, `§NIGHT_MIX_WHITE` (20/20/60), bloom off, 48-light boost off

### Left broken on purpose (pre-existing)
Night glow keys on glow *classes*; the Clinic falls back to `IfcFlowTerminal`, so its `≈ Off-White` material — 1974 elements incl. grab bars and receptacles — still gets emissive at night. `§LUM_VARIANT` fixed it and was pulled with the rest. Noted at the code site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)