### PR TITLE
fix(sw): bump CACHE_VERSION + module ?v= — the night fixes were on main but never reached the browser

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v865';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v866';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=2" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=3" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -834,10 +834,10 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=52" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=55" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=56" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=30" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=31" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=29" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>


### PR DESCRIPTION
User: *"alt-s, they still there"* — with a log printing `§NIGHT_DIFFUSER applied=5` and `§BUILD_VERSION v865 (sw-controlled)`, while `origin/main` contains **zero** occurrences of `NIGHT_DIFFUSER`.

The code was already correct. The browser was serving **stale JavaScript**. That is why the last several test rounds kept reproducing a defect that had already been deleted.

**Two cache layers, neither bumped across ~12 commits:**

| | was | now |
|---|---|---|
| `viewer/sw.js` `CACHE_VERSION` | v865 | **v866** |
| `viewer.html` → `tools.js?v=` | 30 | **31** |
| `viewer.html` → `effects.js?v=` | 2 | **3** |
| `viewer.html` → `streaming.js?v=` | 55 | **56** |

`viewer.html` pins its modules by query string, so an edited file keeps its old URL and is served from cache. `PRECACHE_ASSETS` lists these unversioned, so the `CACHE_VERSION` bump covers that side.

`CLAUDE.md` states it plainly — *"every deploy bumps CACHE_VERSION + PRECACHE_ASSETS"* — and there is a `feedback_sw_version` memory for exactly this. I shipped a dozen viewer commits without bumping either, then read the user's logs as evidence about the **code** when they were evidence about the **cache**.

The `§NIGHT_DIFFUSER` diagnosis itself stands — it did create the black boxes — but every *"still there"* after its removal was this.

**Check after deploy:** `§BUILD_VERSION` should read **v866**, and `§NIGHT_DIFFUSER` should be absent from the log entirely. That line's presence or absence is the reliable signal for which build is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)