### PR TITLE
fix(photoreal): §GROUND_ALBEDO + §GROUND_COLOR_ORDER_FIX — the Alt+S evening ground was at 1/3 brightness

### DIFF
--- a/probe_ground_albedo.js
+++ b/probe_ground_albedo.js
@@ -1,0 +1,140 @@
+// ⚠ WITNESS W-GROUND-ALBEDO — bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §GROUND_DARK_RETHINK
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   The Alt+S evening ground is too dark, and the file records it as "cannot be helped" — the 6°
+//   dusk sun gives a horizontal plane sin(6°)=0.105 of a facade's irradiance, and BOTH attempts to
+//   brighten it were reverted for killing the cast shadow ("Shadows? None on the ground", twice).
+//   Those two attempts — a ground emissive add (§PHOTO_GROUND_WHITE_REVERTED) and a hemi/ambient
+//   fill boost (§PHOTO_CONTRAST_DIALBACK) — are both ADDITIVE. §GROUND_ALBEDO is MULTIPLICATIVE.
+//   The claim: a gain on the ground's albedo raises it WITHOUT touching the lit/shadow ratio, so
+//   the shadow survives a lift that additive fill cannot survive.
+//
+// WHAT IS ASSERTED — all four from real object state, no screenshots, no pixel sampling:
+//   1. APPLIED      after Alt+S staging, A.ground.material.color is the gain (not 1.0), the map is
+//                   still bound, and effective albedo = gain x measured texture average.
+//   2. RESTORED     after teardown the gain is handed back to 1.0 — the lift must not follow the
+//                   user into normal navigation (same rule as A._nightMaxLightsStill).
+//   3. RATIO HELD   lit/shadow computed from the REAL staged lights (A.sun/A.ambient/A.hemi
+//                   intensities + the real sun elevation) is IDENTICAL at gain 1.0 and at gain 2.3.
+//   4. CONTROL      the same brightness increase delivered ADDITIVELY (raise ambient until the lit
+//                   ground matches) is computed too — its ratio MUST collapse. A gate that only
+//                   ever passes proves nothing; this is the discriminator, and it is the exact
+//                   mechanism that got the previous two attempts reverted.
+//   5. NOTHING ELSE the color of every other scene material, snapshotted before staging and diffed
+//                   after: only A.ground.material may differ.
+//
+// Run: PORT=8412 BLD=Hospital node probe_ground_albedo.js
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8412, BLD = process.env.BLD || 'Hospital';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const logs = []; page.on('console', m => logs.push(m.text())); page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine && window.APP._setGroundColor, { timeout: 240000 });
+  await sleep(10000);
+  await page.waitForFunction(() => { try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; } catch (e) { return false; } }, { timeout: 180000, polling: 2000 });
+
+  // Settle unconditionally — a single-model DB never triggers a stream-gated wait, and a probe that
+  // measures mid-stream measures a half-built scene (NIGHT_AND_FIXTURE_LIGHTING.md §landmines).
+  let n0 = -1, stable = 0;
+  for (let i = 0; i < 90; i++) {
+    const n = await page.evaluate(() => Object.keys(window.APP.guidMap).length);
+    stable = (n === n0 && n > 0) ? stable + 1 : 0;
+    if (stable >= 3) break;
+    n0 = n; await sleep(2000);
+  }
+
+  const snapBefore = await page.evaluate(() => {
+    const A = window.APP, out = {};
+    A.scene.traverse(o => { const ms = o.material ? (Array.isArray(o.material) ? o.material : [o.material]) : [];
+      ms.forEach(m => { if (m && m.color && m.uuid) out[m.uuid] = [m.color.r, m.color.g, m.color.b]; }); });
+    return { n: Object.keys(out).length, map: out, groundUuid: A.ground && A.ground.material ? A.ground.material.uuid : null };
+  });
+
+  await page.evaluate(() => window.APP.startStillRefine());
+  // The paved texture loads ASYNC (TextureLoader) and _applyGroundTexture's own callback re-runs
+  // _setGroundColor when it lands. A probe that reads before that measures a ground with no map —
+  // which is what the first run of this witness did, and it read as a failure of the gain.
+  await page.waitForFunction(() => window.APP.ground && window.APP.ground.material.map, { timeout: 120000, polling: 500 }).catch(() => {});
+  await sleep(9000);   // staging + a few accumulation frames
+
+  const staged = await page.evaluate(() => {
+    const A = window.APP, g = A.ground.material;
+    // Real staged light state — not constants copied from the source.
+    const sunY = A.sun ? A.sun.position.y : 0;
+    const sunLen = A.sun ? Math.hypot(A.sun.position.x, A.sun.position.y, A.sun.position.z) : 1;
+    const out = {};
+    A.scene.traverse(o => { const ms = o.material ? (Array.isArray(o.material) ? o.material : [o.material]) : [];
+      ms.forEach(m => { if (m && m.color && m.uuid) out[m.uuid] = [m.color.r, m.color.g, m.color.b]; }); });
+    return {
+      gain: A._groundAlbedoGain, photoGain: A._photoGroundAlbedoGain,
+      color: [g.color.r, g.color.g, g.color.b], hasMap: !!g.map,
+      sunI: A.sun ? A.sun.intensity : 0, ambI: A.ambient ? A.ambient.intensity : 0,
+      hemiI: A.hemi ? A.hemi.intensity : 0,
+      sinElev: sunLen ? sunY / sunLen : 0,
+      wetness: A._groundWetnessOverride,
+      after: out, n: Object.keys(out).length
+    };
+  });
+
+  await page.evaluate(() => window.APP.stopStillRefine ? window.APP.stopStillRefine() : window.APP._teardownStillRefine && window.APP._teardownStillRefine());
+  await sleep(3000);
+  const restored = await page.evaluate(() => ({ gain: window.APP._groundAlbedoGain, r: window.APP.ground.material.color.r }));
+
+  // ── The maths. Ground is horizontal: direct term scales with sin(elevation); ambient+hemi are
+  // omnidirectional, so they reach the shadowed ground too (that is precisely why raising them
+  // fills the shadow in). Shadowed ground = indirect only. Lit ground = indirect + direct.
+  const TEX = 0.155;                       // measured linear-avg luminance of paved_1k.jpg
+  const indirect = staged.ambI + staged.hemiI * 0.5;   // hemi delivers ~half its intensity downward
+  const direct   = staged.sunI * Math.max(0, staged.sinElev);
+  const ratio = a => ((a * (indirect + direct)) / (a * indirect));   // albedo cancels — that IS the claim
+  const litAt   = a => a * TEX * (indirect + direct);
+  const shadeAt = a => a * TEX * indirect;
+
+  const r1 = ratio(1.0), rG = ratio(staged.gain);
+  // CONTROL: deliver the SAME lit-ground brightness additively, by raising the indirect term instead.
+  const targetLit = litAt(staged.gain);
+  const indirectNeeded = (targetLit / (1.0 * TEX)) - direct;   // at gain 1.0, solve for indirect
+  const rAdd = (indirectNeeded + direct) / indirectNeeded;
+
+  const changed = Object.keys(staged.after).filter(u => {
+    const b = snapBefore.map[u]; if (!b) return false;
+    const a = staged.after[u];
+    return Math.abs(a[0]-b[0]) > 1e-6 || Math.abs(a[1]-b[1]) > 1e-6 || Math.abs(a[2]-b[2]) > 1e-6;
+  });
+  const changedNonGround = changed.filter(u => u !== snapBefore.groundUuid);
+
+  const P = (ok, s) => console.log((ok ? '  PASS  ' : '  FAIL  ') + s);
+  console.log(`\n═══ W-GROUND-ALBEDO — ${BLD} ═══`);
+  console.log(`  staged lights: sun=${staged.sunI.toFixed(2)} ambient=${staged.ambI.toFixed(2)} hemi=${staged.hemiI.toFixed(2)} sin(elev)=${staged.sinElev.toFixed(4)} wetness=${staged.wetness}`);
+  console.log(`  indirect=${indirect.toFixed(3)}  direct=${direct.toFixed(3)}`);
+  console.log('\n─ 1. APPLIED');
+  P(staged.gain === staged.photoGain && staged.gain > 1, `gain applied at staging: ${staged.gain} (photo constant ${staged.photoGain})`);
+  P(Math.abs(staged.color[0] - staged.gain) < 1e-3, `ground material.color.r = ${staged.color[0].toFixed(3)} (expected ${staged.gain})`);
+  P(staged.hasMap, `map still bound (gain multiplies the texture, does not replace it)`);
+  console.log(`         effective albedo ${TEX.toFixed(3)} -> ${(TEX*staged.gain).toFixed(3)}  (asphalt 0.05-0.12 | dry concrete 0.25-0.40)`);
+  console.log('\n─ 2. RESTORED');
+  P(restored.gain === 1.0, `gain handed back after teardown: ${restored.gain}`);
+  P(Math.abs(restored.r - 1.0) < 1e-3 || restored.r < 1.0, `ground colour back to non-lifted: r=${restored.r.toFixed(3)}`);
+  console.log('\n─ 3. RATIO HELD (the claim)');
+  console.log(`         lit  ${litAt(1).toFixed(4)} -> ${litAt(staged.gain).toFixed(4)}   (x${(litAt(staged.gain)/litAt(1)).toFixed(2)})`);
+  console.log(`         shade ${shadeAt(1).toFixed(4)} -> ${shadeAt(staged.gain).toFixed(4)}   (x${(shadeAt(staged.gain)/shadeAt(1)).toFixed(2)})`);
+  P(Math.abs(rG - r1) < 1e-9, `lit/shadow ratio at gain 1.0 = ${r1.toFixed(4)}, at gain ${staged.gain} = ${rG.toFixed(4)} — unchanged`);
+  console.log('\n─ 4. CONTROL — the same lift delivered ADDITIVELY (what was reverted twice)');
+  console.log(`         to match that lit value with fill light: indirect ${indirect.toFixed(3)} -> ${indirectNeeded.toFixed(3)} (x${(indirectNeeded/indirect).toFixed(2)})`);
+  // Direction, not an invented threshold: ANY additive route to the same lit value must lower the
+  // ratio, and the multiplicative one must not. Magnitude is reported, never gated on a round number.
+  P(rAdd < r1 - 1e-9 && Math.abs(rG - r1) < 1e-9, `additive ${r1.toFixed(4)} -> ${rAdd.toFixed(4)} (loses ${(100*(1-rAdd/r1)).toFixed(1)}% of the shadow contrast) | multiplicative holds at ${rG.toFixed(4)}`);
+  console.log('\n─ 5. NOTHING ELSE TOUCHED');
+  P(changedNonGround.length === 0, `scene materials with a changed colour, excluding the ground: ${changedNonGround.length} (of ${staged.n} tracked)`);
+  console.log('\n─ § lines');
+  logs.filter(l => /§GROUND_|§BUILD_VERSION/.test(l)).forEach(l => console.log("   " + l));
+  const fails = logs.filter(l => /PAGEERROR/.test(l));
+  if (fails.length) { console.log('\n─ page errors'); fails.slice(0, 5).forEach(l => console.log('   ' + l)); }
+  await browser.close();
+})();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2185,6 +2185,17 @@ async function setupEffects(A, renderer, scene, camera) {
   // raw sin(6 deg) ground darkness, not enough to wash out contrast.
   var PHOTO_HEMI_INTENSITY_SCALE = 1.25;
   var PHOTO_AMBIENT_INTENSITY_SCALE = 1.15;
+  // §GROUND_ALBEDO — the multiplicative lever the two paragraphs above never had. Everything they
+  // describe is ADDITIVE (emissive add; hemi/ambient fill), which is exactly why both flattened the
+  // cast shadow; this one scales lit and shadowed ground by the same factor. The claim that the
+  // ground was "ALREADY rendering at maximum brightness… no tint could ever make it brighter" is
+  // wrong: _setGroundColor forces WHITE under a map, and white is the multiplicative identity, not
+  // a ceiling. Full analysis + the 52:1 arithmetic: PHOTOREAL_STILL_RENDER.md §GROUND_DARK_RETHINK.
+  // MEASURED, not assumed: linear-average luminance of viewer/textures/ground/paved_1k.jpg over a
+  // 128x128 downsample, sRGB-decoded — the same method textures/materials/NOTICE.txt already uses
+  // to derive each TRIPLANAR_MAT normFactor (concrete 0.723, plaster 0.742, metal 0.535).
+  var GROUND_TEX_AVG_LUM = 0.155;
+  A._photoGroundAlbedoGain = 2.3;   // 2.3 x 0.155 = 0.36 albedo. Console-tunable for A/B.
   var _photoSunPosSaved = null, _photoSunTargetSaved = null;
   var _photoFlarePrevTone = null, _photoHaloPrevTone = null;
   var _photoEnvBoostedMats = [];
@@ -2593,8 +2604,20 @@ async function setupEffects(A, renderer, scene, camera) {
       // existing 'paved' texture (same real asset Shadow mode already uses — concrete look, per
       // user's own suggestion) with a much brighter warm tint. Fancier grass+paved-rectangle
       // pattern is a separate later experiment, not needed just to fix "too dark."
+      // §GROUND_ALBEDO (2026-07-28, user: "the Alt+S evening ground is too dark… albedo, try it") —
+      // Witness: W-GROUND-ALBEDO. Set BEFORE _applyGroundTexture, because that function calls
+      // _setGroundColor itself (with the remembered solid colour) as soon as the texture lands.
+      // 2.3 x the map's measured 0.155 average puts the ground at ~0.36 albedo — real dry concrete
+      // (0.25-0.40), not the asphalt (0.05-0.12) it renders as today. Live-tunable from the console
+      // for the A/B the user asked for: APP._photoGroundAlbedoGain = 1.0 (default look) / 2.3 / 3.5,
+      // then Alt+S again. See tools.js §GROUND_ALBEDO for why a gain and not more fill light.
+      A._groundAlbedoGain = A._photoGroundAlbedoGain;
       A._applyGroundTexture('paved');
       if (A._setGroundColor) A._setGroundColor(0xd9c39a);  // bright warm sunlit-concrete tone
+      console.log('§GROUND_ALBEDO gain=' + A._groundAlbedoGain.toFixed(2) + ' texAvgLum=' +
+        GROUND_TEX_AVG_LUM.toFixed(3) + ' effAlbedo=' + (GROUND_TEX_AVG_LUM * A._groundAlbedoGain).toFixed(3) +
+        ' color=' + (A.ground.material.color ? A.ground.material.color.r.toFixed(2) : 'n/a') +
+        ' map=' + (A.ground.material.map ? 'paved' : 'none'));
       // §PHOTO_GROUND_WHITE_REVERTED (user reported "Shadows? None on the ground" right after
       // this shipped): a flat emissive add is NOT shadow-map-occluded at all in three.js — it
       // washes out relative contrast between the sun's shadowed and lit ground patches, which is
@@ -2700,6 +2723,22 @@ async function setupEffects(A, renderer, scene, camera) {
       A.scene.fog.color.setHex(0xc9a878);
       A.scene.fog.density = Math.min(A.scene.fog.density, 0.00006);  // lighter haze, not a wall of fog
     }
+    // §GROUND_COLOR_ORDER_FIX (2026-07-28, found by W-GROUND-ALBEDO, not by reading) — the SAME
+    // clobber §PHOTO_FOG_ORDER_FIX above documents, on the SAME call, missed for the ground.
+    // A.toggleNightMode() (line ~2694, called for its amber-glow mechanism) also does
+    // _setGroundColor(0x0a0a15) (tools.js §S277c) as a side effect. The photo ground colour is set
+    // ~78 lines EARLIER, so night's moonlight dim always won: 0x0a0a15's channel sum is 41, under
+    // the 0x60 night-dim threshold, so the ground rendered at 0x555566 = 0.333 instead of the
+    // intended photo-true 1.0. **The evening ground has been rendering at ONE THIRD of the
+    // brightness this file thought it set, since §PHOTO_GROUND_LIT shipped — the 0xd9c39a "bright
+    // warm sunlit-concrete tone" never reached the material at all.**
+    // MEASURED, same run: §GROUND_ALBEDO logged color=2.30 at staging, and the material read 0.333
+    // nine seconds later. Re-asserted HERE, after both clobbering calls, exactly like the fog.
+    if (A.ground && A._setGroundColor) {
+      A._setGroundColor(0xd9c39a);
+      console.log('§GROUND_COLOR_ORDER_FIX reasserted color=' + A.ground.material.color.r.toFixed(2) +
+        ' gain=' + A._groundAlbedoGain.toFixed(2));
+    }
     _showPhotoProps(true);
     console.log('§PHOTO_STAGING on nightWasOn=' + _photoNightWasOn);
   }
@@ -2741,9 +2780,15 @@ async function setupEffects(A, renderer, scene, camera) {
     _photoEnvBoostedMats = [];
     _disablePhotoShadows();
     if (A.ground && A._applyGroundTexture) {
+      // §GROUND_ALBEDO: hand the gain back BEFORE restoring, or the lift follows the user out of
+      // the photoshoot into normal navigation — the same "restore what you borrowed" rule
+      // A._nightMaxLightsStill already has (NIGHT_AND_FIXTURE_LIGHTING.md §constants).
+      A._groundAlbedoGain = 1.0;
       A._applyGroundTexture(_photoGroundPrevKey);  // null → clears map, restores flat color
       if (_photoGroundPrevColor != null && A._setGroundColor) A._setGroundColor(_photoGroundPrevColor);
       A.ground.visible = _photoGroundWasVisible;
+      console.log('§GROUND_ALBEDO restored gain=' + A._groundAlbedoGain.toFixed(2) +
+        ' color=' + (A.ground.material.color ? A.ground.material.color.r.toFixed(2) : 'n/a'));
     }
     if (A.scene && A.scene.fog && _photoFogColorSaved != null) {
       A.scene.fog.color.setHex(_photoFogColorSaved);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v866';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v867';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -116,6 +116,26 @@ function setupTools(A) {
 
   // Set ground flat color, but respect an active photo texture: color MULTIPLIES the map,
   // so keep it white (photo true) and only dim — never blacken — for night-dark targets.
+  //
+  // §GROUND_ALBEDO (bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §GROUND_DARK_RETHINK idea 1,
+  // 2026-07-28) — Witness: W-GROUND-ALBEDO. White here is the multiplicative IDENTITY, not a
+  // ceiling: `diffuseColor = diffuse * map`, `diffuse` is a plain vec3 uniform and THREE.Color is
+  // not clamped to 1, so a value above 1 raises the ground's ALBEDO. That matters because the
+  // ground map's own measured linear-average luminance is 0.155 (paved_1k.jpg = Poly Haven
+  // concrete_floor_01) while every Layer-3 material texture is renormalized to ~1.0 by its
+  // TRIPLANAR_MAT.normFactor — so the ground is ~5.5x darker in albedo than the wall standing on
+  // it, on top of the 9.5x from the 6-degree dusk sun. 0.155 is asphalt; the scene wants a plaza
+  // (real dry concrete is 0.25-0.40).
+  //
+  // WHY A GAIN AND NOT MORE FILL LIGHT — this is the whole point, and both previous attempts got
+  // it backwards. The emissive add (§PHOTO_GROUND_WHITE_REVERTED) and the hemi/ambient boost
+  // (§PHOTO_CONTRAST_DIALBACK, 1.6/1.3 -> 1.25/1.15) are ADDITIVE: they add the same constant to
+  // lit and shadowed pixels, so the shadow's contrast RATIO collapses — that is "Shadows? None on
+  // the ground", reported both times. Albedo is MULTIPLICATIVE: lit and shadowed ground scale by
+  // the SAME factor, so lit/shadow is algebraically unchanged (exactly, pre-tonemap; ACES then
+  // compresses the top end, which softens the high values but never flattens the ratio).
+  // Default 1.0 — navigation and day render byte-identical to before; only the photoshoot lifts it.
+  A._groundAlbedoGain = 1.0;
   A._setGroundColor = function(hex) {
     if (!A.ground) return;
     A._groundSolidColor = hex;   // remember the mode's intended flat color (for 'none')
@@ -123,6 +143,11 @@ function setupTools(A) {
     if (hasMap) {
       var sum = (hex & 0xff) + ((hex >> 8) & 0xff) + ((hex >> 16) & 0xff);
       A.ground.material.color.setHex(sum < 0x60 ? 0x555566 : 0xffffff);  // dim at night, else true
+      // multiplyScalar, never a >1 hex: setHex runs the sRGB->linear transfer, so scaling AFTER it
+      // is unambiguous linear gain. Only lifts the photo-true (white) branch — the night-dim
+      // branch stays dim, since a dark ground at night is deliberate, not the complaint.
+      var g = A._groundAlbedoGain;
+      if (g && g !== 1.0 && sum >= 0x60) A.ground.material.color.multiplyScalar(g);
     } else {
       A.ground.material.color.setHex(hex);
     }

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=3" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=4" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=56" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=31" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=29" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>


### PR DESCRIPTION
User: *"the Alt-S evening scene ground is too dark and previously said cannot be helped. Any ideas?"* → *"albedo u said is easy, try it?"*

Spec: `bim-compiler prompts/PHOTOREAL_STILL_RENDER.md` §GROUND_DARK_RETHINK + §10.
Witness: `probe_ground_albedo.js` — **W-GROUND-ALBEDO, 8/8 on Hospital**.

## §GROUND_COLOR_ORDER_FIX — the real find, caught by the witness, not by reading
`_applyPhotoStaging` sets the photo ground colour ~78 lines **before** `A.toggleNightMode()`, which does `_setGroundColor(0x0a0a15)` as a side effect. Channel sum 41 is under the `0x60` night-dim threshold, so the ground took the dim branch and rendered **`0x555566` = 0.333 instead of photo-true 1.0**.

**The evening ground has been rendering at one third of the intended brightness since §PHOTO_GROUND_LIT shipped — `0xd9c39a` never reached the material at all.** Same clobber, same call, that §PHOTO_FOG_ORDER_FIX already documents for fog; that fix covered sun/ambient/hemi/exposure/fog and never included the ground. Measured in one run: `§GROUND_ALBEDO … color=2.30` at staging, material reading `0.333` nine seconds later.

## §GROUND_ALBEDO — a multiplicative lever, where both previous attempts were additive
`_setGroundColor` forces WHITE under a map, and the code read that as a ceiling (*"no tint could ever make it brighter"*). White is the multiplicative **identity**: `diffuseColor = diffuse * map`, `diffuse` is a plain `vec3`, `THREE.Color` is not clamped to 1.

It matters because `paved_1k.jpg` measures **0.155** linear-average luminance while every Layer-3 material texture is renormalized to ~1.0 by its `normFactor` — the ground is **5.5× darker in albedo than the wall standing on it**. 0.155 is asphalt; ×2.3 puts it at **0.36**, real dry concrete.

The emissive add (§PHOTO_GROUND_WHITE_REVERTED) and the hemi/ambient boost (§PHOTO_CONTRAST_DIALBACK) are both **additive** — they add the same constant to lit and shadowed pixels, which is exactly why both killed the cast shadow. Albedo is **multiplicative**.

## Witness, with its control
| gate | result |
|---|---|
| APPLIED | `color.r = 2.300`, map still bound, albedo 0.155 → **0.356** |
| RESTORED | gain handed back to 1.0 on teardown |
| RATIO HELD | lit/shadow **1.1907 at gain 1.0, 1.1907 at gain 2.3** (lit ×2.30, shade ×2.30) |
| **CONTROL** | same lift delivered additively: **1.1907 → 1.0748, 9.7% of the shadow contrast lost** |
| NOTHING ELSE | **0 of 121** scene materials changed outside the ground |

The control is the discriminator — a gate that only ever passes proves nothing, and this is the exact mechanism behind both reverts. It asserts direction, never a round-number threshold.

## Safety / scope
- Default gain **1.0** — navigation and day render exactly as before.
- Handed back on teardown (same rule as `_nightMaxLightsStill`).
- `APP._photoGroundAlbedoGain` is console-tunable (1.0 / 2.3 / 3.5, then Alt+S) for A/B.
- `sw.js v866→v867` + `viewer.html` `effects.js?v=4`, `tools.js?v=32` — without both, the browser serves cached files and the logs describe the cache, not the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)