### PR TITLE
feat(photoreal): §BILLBOARD_SOURCE + §BILLBOARD_FIT — image by convention, cropped to fill

### DIFF
--- a/probe_billboard.js
+++ b/probe_billboard.js
@@ -1,0 +1,57 @@
+// ⚠ WITNESS W-BILLBOARD-ART — bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §FACADE_SIGNAGE
+// THE ISSUE: the billboard panel is real DB geometry, but component_geometries carries NO UV
+// channel, so a texture map has nothing to sample. §BILLBOARD_ART puts the artwork on its own
+// quad placed FROM THE PANEL'S OWN ROW. Asserts: the DB rows exist and round-trip; the art quad
+// is built once, sized and positioned from those rows, clear of the panel face; it owns its
+// material; and with no billboard.png present the NOTICE fallback is what renders.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8412, DB = process.env.DB || 'Terminal_Hi.db';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+(async () => {
+  const b = await puppeteer.launch({ headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle','--use-angle=swiftshader','--no-sandbox','--enable-unsafe-swiftshader'] });
+  const page = await b.newPage(); await page.setViewport({ width: 1280, height: 720 });
+  const logs = []; page.on('console', m => logs.push(m.text())); page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${DB}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.startStillRefine, { timeout: 240000 });
+  await sleep(10000);
+  await page.waitForFunction(() => { try { return window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms')[0][0] > 0; } catch(e){ return false; } }, { timeout: 180000, polling: 2000 });
+  let n0=-1, st=0; for (let i=0;i<90;i++){ const n=await page.evaluate(()=>Object.keys(window.APP.guidMap).length); st=(n===n0&&n>0)?st+1:0; if(st>=3)break; n0=n; await sleep(2000);}    
+  const db = await page.evaluate(() => {
+    const q = s => { try { return window.APP.dbQuery(s) || []; } catch(e){ return []; } };
+    return { panel: q("SELECT element_name, center_x, bbox_y, bbox_z FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid WHERE m.element_name LIKE 'BIM_OOTB_Billboard%'"),
+             lamps: q("SELECT COUNT(*) FROM elements_meta WHERE element_name LIKE 'BIM_OOTB_Floodlight%'"),
+             fin:   q("SELECT finish, COUNT(*) FROM render_finishes GROUP BY 1") };
+  });
+  await page.evaluate(() => window.APP.startStillRefine());
+  await sleep(12000);
+  const art = await page.evaluate(() => {
+    let found = null, count = 0, shared = 0;
+    const mats = [];
+    window.APP.scene.traverse(o => { if (o.isMesh && o.geometry && o.geometry.type === 'PlaneGeometry' && o.material && o.material.isMeshBasicMaterial) {
+      count++; found = { w: o.geometry.parameters.width, h: o.geometry.parameters.height, x: o.position.x, y: o.position.y, z: o.position.z,
+                         roty: o.rotation.y, hasMap: !!o.material.map, uuid: o.material.uuid }; } });
+    window.APP.scene.traverse(o => { const m = o.material ? (Array.isArray(o.material)?o.material:[o.material]) : []; m.forEach(x => { if (found && x && x.uuid === found.uuid) shared++; }); });
+    return { found, count, shared };
+  });
+  const P=(ok,s)=>console.log((ok?'  PASS  ':'  FAIL  ')+s);
+  console.log(`\n═══ W-BILLBOARD-ART — ${DB} ═══`);
+  console.log('\n─ 1. DB ROWS');
+  P(db.panel.length===1, `panel row: ${db.panel.length ? db.panel[0][0]+' cx='+db.panel[0][1].toFixed(3)+' '+db.panel[0][2]+'x'+db.panel[0][3]+'m' : 'MISSING'}`);
+  P(db.lamps[0] && db.lamps[0][0]===4, `corner floodlights in DB: ${db.lamps[0]?db.lamps[0][0]:0} (expect 4)`);
+  P(db.fin.length>0, `render_finishes: ${db.fin.map(r=>r[0]+'='+r[1]).join(', ')}`);
+  console.log('\n─ 2. ART QUAD built from those rows');
+  P(!!art.found, `art quad exists (count=${art.count}, must be 1)`);
+  if (art.found) {
+    P(Math.abs(art.found.w-db.panel[0][2])<0.01 && Math.abs(art.found.h-db.panel[0][3])<0.01, `sized from the DB row: ${art.found.w}m x ${art.found.h}m`);
+    P(Math.abs(art.found.roty-Math.PI/2)<1e-6, `oriented to the +X facade (rotation.y=${art.found.roty.toFixed(4)})`);
+    P(art.found.hasMap, `texture bound (fallback notice or billboard.png)`);
+    P(art.shared===1, `material shared with ${art.shared} mesh — the invariant (must be 1: itself)`);
+  }
+  console.log('\n─ 3. FALLBACK (no billboard.png present)');
+  const fb = logs.filter(l=>/§BILLBOARD_ART/.test(l));
+  P(fb.some(l=>/fallback notice drawn/.test(l)), `notice fallback fired, not a silent blank panel`);
+  console.log('\n─ § lines'); fb.forEach(l=>console.log('   '+l));
+  const errs = logs.filter(l=>/PAGEERROR/.test(l)); if (errs.length){ console.log('\n─ errors'); errs.slice(0,3).forEach(l=>console.log('   '+l)); }
+  await b.close();
+})();

--- a/probe_billboard.js
+++ b/probe_billboard.js
@@ -24,7 +24,17 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
              fin:   q("SELECT finish, COUNT(*) FROM render_finishes GROUP BY 1") };
   });
   await page.evaluate(() => window.APP.startStillRefine());
-  await sleep(12000);
+  // Wait for the CONDITION, never a fixed sleep: the art quad's texture arrives after up to four
+  // sequential image probes (404, 404, then the hit), and a timed guess measured a null map and
+  // reported a working feature as broken. Second occurrence of this exact race in this suite —
+  // the ground witness needed the same fix for _applyGroundTexture's async load.
+  await page.waitForFunction(() => {
+    let ok = false;
+    window.APP.scene.traverse(o => { if (o.isMesh && o.geometry && o.geometry.type === 'PlaneGeometry'
+      && o.material && o.material.isMeshBasicMaterial && o.material.map) ok = true; });
+    return ok;
+  }, { timeout: 120000, polling: 500 }).catch(() => {});
+  await sleep(2000);
   const art = await page.evaluate(() => {
     let found = null, count = 0, shared = 0;
     const mats = [];
@@ -48,9 +58,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     P(art.found.hasMap, `texture bound (fallback notice or billboard.png)`);
     P(art.shared===1, `material shared with ${art.shared} mesh — the invariant (must be 1: itself)`);
   }
-  console.log('\n─ 3. FALLBACK (no billboard.png present)');
-  const fb = logs.filter(l=>/§BILLBOARD_ART/.test(l));
-  P(fb.some(l=>/fallback notice drawn/.test(l)), `notice fallback fired, not a silent blank panel`);
+  console.log('\n─ 3. IMAGE PICKUP + ASPECT FIT');
+  const fb = logs.filter(l=>/§BILLBOARD_(ART|FIT)/.test(l));
+  const got = fb.find(l=>/§BILLBOARD_ART image=/.test(l));
+  P(!!got, `real image picked up by convention (not the fallback): ${got ? got.split('image=')[1] : 'NONE — fell back'}`);
+  const fit = fb.find(l=>/§BILLBOARD_FIT/.test(l));
+  P(!!fit && /mode=cover/.test(fit), `artwork COVER-fitted (crop to fill), never stretched: ${fit ? fit.replace('§BILLBOARD_FIT ','') : 'no fit line'}`);
   console.log('\n─ § lines'); fb.forEach(l=>console.log('   '+l));
   const errs = logs.filter(l=>/PAGEERROR/.test(l)); if (errs.length){ console.log('\n─ errors'); errs.slice(0,3).forEach(l=>console.log('   '+l)); }
   await b.close();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2119,12 +2119,94 @@ async function setupEffects(A, renderer, scene, camera) {
     if (window.requestIdleCallback) window.requestIdleCallback(run, { timeout: 6000 });
     else setTimeout(run, 4000);
   })();
+  // ══ §BILLBOARD_ART (2026-07-28, user: "make it pick a png image i can place later in the same
+  // DB folder. For now just 'RUANG IKLAN UNTUK DI SEWA'… if no image, it gives that notice.")
+  //
+  // The billboard PANEL is real BIM data — a genuine IfcBuildingElementProxy injected into the DB
+  // (migration/billboards/terminal_billboard.sql), so it is pickable, quantifiable and casts
+  // shadows like any other element. The ARTWORK cannot ride that same mesh: component_geometries
+  // stores vertices + faces ONLY, with no UV channel anywhere in the extraction pipeline (the same
+  // blocker §LAYER 3 had to solve with triplanar), so a texture map has nothing to sample against.
+  // So the art is its own quad, sized and placed FROM THE PANEL'S OWN ROW, sitting a few
+  // millimetres off its display face. One PlaneGeometry, ONE draw call, its own material shared
+  // with nothing — the §PHOTO_GLOW_SPRITE invariant, unbroken.
+  //
+  // IMAGE SOURCE: <folder of A.DB_URL>/billboard.png — drop the file next to the .db and it is
+  // picked up on the next load, no code change. If it is absent or fails to load, the canvas
+  // fallback below draws the notice instead, which is the behaviour the user asked for: an empty
+  // advertising hoarding advertises itself.
+  var BILLBOARD_NOTICE = 'RUANG IKLAN UNTUK DI SEWA';
+  var _billboardMesh = null;
+  function _billboardFallbackTexture(wm, hm) {
+    var W = 1024, H = Math.max(256, Math.round(W * (hm / wm)));
+    var c = document.createElement('canvas'); c.width = W; c.height = H;
+    var g = c.getContext('2d');
+    g.fillStyle = '#0d1017'; g.fillRect(0, 0, W, H);
+    g.strokeStyle = '#e8c34a'; g.lineWidth = Math.round(H * 0.035);
+    g.strokeRect(g.lineWidth, g.lineWidth, W - g.lineWidth * 2, H - g.lineWidth * 2);
+    // Fit the notice to the board rather than guessing a point size — the panel's real aspect
+    // comes from its DB bbox, so this stays correct if the sign is ever resized.
+    var words = BILLBOARD_NOTICE.split(' '), lines = [words.slice(0, 2).join(' '), words.slice(2).join(' ')];
+    var size = Math.round(H * 0.26);
+    g.textAlign = 'center'; g.textBaseline = 'middle'; g.fillStyle = '#f2e6c0';
+    for (var pass = 0; pass < 12; pass++) {
+      g.font = '700 ' + size + 'px system-ui, sans-serif';
+      var widest = Math.max.apply(null, lines.map(function(l) { return g.measureText(l).width; }));
+      if (widest <= W * 0.82) break;
+      size = Math.round(size * 0.9);
+    }
+    for (var i = 0; i < lines.length; i++) {
+      g.fillText(lines[i], W / 2, H / 2 + (i - (lines.length - 1) / 2) * size * 1.15);
+    }
+    var tex = new THREE.CanvasTexture(c);
+    if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+    console.log('§BILLBOARD_ART fallback notice drawn (' + W + 'x' + H + ') — no billboard.png found');
+    return tex;
+  }
+  A._buildBillboardArt = function() {
+    if (_billboardMesh || !A.db || !A.ifc2three) return;
+    var rows;
+    try {
+      rows = A.dbQuery("SELECT t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z " +
+        "FROM elements_meta m JOIN element_transforms t ON t.guid=m.guid " +
+        "WHERE m.element_name LIKE 'BIM_OOTB_Billboard%' LIMIT 1");
+    } catch (e) { return; }
+    if (!rows || !rows.length) return;
+    var r = rows[0], cx = r[0], cy = r[1], cz = r[2], tx = r[3], wy = r[4], hz = r[5];
+    // Display face is +X in IFC (the host wall is on the building's x-max facade); nudge 8mm clear
+    // of it so the art never z-fights the panel it sits on.
+    var p = A.ifc2three(cx + tx / 2 + 0.008, cy, cz);
+    var geo = new THREE.PlaneGeometry(wy, hz);
+    var mat = new THREE.MeshBasicMaterial({ toneMapped: true, side: THREE.DoubleSide });
+    // MeshBasic, not Standard: a sign face reads as self-lit, so it stays legible at dusk without
+    // depending on whether the corner floodlights are inside the night light budget this frame.
+    var dir = (A.DB_URL || '').replace(/[^/]*$/, '');
+    var url = dir + 'billboard.png';
+    new THREE.TextureLoader().load(url,
+      function(tex) {
+        if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+        mat.map = tex; mat.needsUpdate = true;
+        console.log('§BILLBOARD_ART image=' + url);
+      },
+      undefined,
+      function() { mat.map = _billboardFallbackTexture(wy, hz); mat.needsUpdate = true; });
+    _billboardMesh = new THREE.Mesh(geo, mat);
+    _billboardMesh.position.set(p.x, p.y, p.z);
+    _billboardMesh.rotation.y = Math.PI / 2;   // PlaneGeometry normal +Z -> +X, matching the facade
+    _billboardMesh.renderOrder = 1;
+    A.scene.add(_billboardMesh);
+    console.log('§BILLBOARD_ART built ' + wy.toFixed(1) + 'm x ' + hz.toFixed(1) + 'm at ifc(' +
+      cx.toFixed(2) + ',' + cy.toFixed(2) + ',' + cz.toFixed(2) + ') source=' + url + ' drawCalls=1');
+    if (A.markDirty) A.markDirty();
+  };
+
   function _showPhotoProps(show) {
     if (show && (!_photoUplights.length || _photoPropsBuilding !== A.activeBuilding)) {
       _disposePhotoProps();
       _buildPhotoProps();
     }
     if (show) _updateFacadeFacingLights();
+    if (show) A._buildBillboardArt();   // §BILLBOARD_ART — idempotent, builds once
     _photoUplights.forEach(function(l) { l.visible = show; });
     if (_photoSkyline) _photoSkyline.visible = show;
     if (_photoSkylineLights) _photoSkylineLights.visible = show;

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2180,23 +2180,63 @@ async function setupEffects(A, renderer, scene, camera) {
     var mat = new THREE.MeshBasicMaterial({ toneMapped: true, side: THREE.DoubleSide });
     // MeshBasic, not Standard: a sign face reads as self-lit, so it stays legible at dusk without
     // depending on whether the corner floodlights are inside the night light budget this frame.
+    // §BILLBOARD_SOURCE — candidates tried in order, first hit wins, then stop. Derived from the
+    // DB's own filename rather than hardcoded: "Terminal_Hi.db" -> first token "Terminal" ->
+    // TerminalBillboard.jpg. So either `billboard.<ext>` or `<Building>Billboard.<ext>` beside the
+    // .db is found without a code change. A._billboardImage overrides everything (console-testable:
+    //   APP._setBillboardImage('whatever.jpg')  — swaps the map on the live mesh, no reload).
     var dir = (A.DB_URL || '').replace(/[^/]*$/, '');
-    var url = dir + 'billboard.png';
-    new THREE.TextureLoader().load(url,
-      function(tex) {
-        if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
-        mat.map = tex; mat.needsUpdate = true;
-        console.log('§BILLBOARD_ART image=' + url);
-      },
-      undefined,
-      function() { mat.map = _billboardFallbackTexture(wy, hz); mat.needsUpdate = true; });
+    var stem = ((A.DB_URL || '').replace(/^.*\//, '').replace(/\.db$/i, '').split('_')[0]) || 'building';
+    var cands = A._billboardImage ? [A._billboardImage.indexOf('/') >= 0 ? A._billboardImage : dir + A._billboardImage]
+      : [dir + 'billboard.png', dir + 'billboard.jpg', dir + stem + 'Billboard.jpg', dir + stem + 'Billboard.png'];
+    // §BILLBOARD_FIT — the artwork almost never matches the hoarding's aspect (the first real test
+    // image was 945x960 = 0.98 against a 2.00 panel, which stretches to twice its width if mapped
+    // raw). COVER-fit: scale by the LARGER ratio so the artwork fills the whole hoarding and the
+    // overflow is cropped evenly from both edges — user's call ("the script simply crop any pic
+    // landed"), and it is the right one for a billboard: a real hoarding is never letterboxed.
+    // Aspect is always preserved; only the overflow is lost, never the proportions.
+    A._billboardFit = function(img, wm, hm) {
+      var W = 1024, H = Math.max(1, Math.round(W * (hm / wm)));
+      var c = document.createElement('canvas'); c.width = W; c.height = H;
+      var g = c.getContext('2d');
+      g.fillStyle = '#0d1017'; g.fillRect(0, 0, W, H);
+      var s = Math.max(W / img.width, H / img.height);   // COVER: fill the board, crop the overflow
+      var dw = img.width * s, dh = img.height * s;
+      g.drawImage(img, (W - dw) / 2, (H - dh) / 2, dw, dh);
+      var tex = new THREE.CanvasTexture(c);
+      if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+      console.log('§BILLBOARD_FIT src=' + img.width + 'x' + img.height + ' (aspect ' + (img.width / img.height).toFixed(2) +
+        ') -> panel ' + W + 'x' + H + ' (aspect ' + (wm / hm).toFixed(2) + ') mode=cover scale=' + s.toFixed(3) + ' cropped=' + (((img.width*s - W)/s).toFixed(0)) + 'x' + (((img.height*s - H)/s).toFixed(0)) + 'px');
+      return tex;
+    };
+    function _tryLoad(list, n) {
+      if (n >= list.length) { mat.map = _billboardFallbackTexture(wy, hz); mat.needsUpdate = true; return; }
+      var im = new Image();
+      im.crossOrigin = 'anonymous';
+      im.onload = function() { mat.map = A._billboardFit(im, wy, hz); mat.needsUpdate = true;
+        console.log('§BILLBOARD_ART image=' + list[n]); if (A.markDirty) A.markDirty(); };
+      im.onerror = function() { _tryLoad(list, n + 1); };
+      im.src = list[n];
+    }
+    _tryLoad(cands, 0);
+    // Live swap for iteration — no reload, no rebuild of the quad.
+    A._setBillboardImage = function(u) {
+      if (!_billboardMesh) { console.log('§BILLBOARD_ART no mesh yet — press Alt+S once'); return; }
+      var full = (u.indexOf('/') >= 0) ? u : dir + u;
+      var im = new Image(); im.crossOrigin = 'anonymous';
+      im.onload = function() { _billboardMesh.material.map = A._billboardFit(im, wy, hz);
+        _billboardMesh.material.needsUpdate = true; console.log('§BILLBOARD_ART swapped image=' + full);
+        if (A.markDirty) A.markDirty(); };
+      im.onerror = function() { console.warn('§BILLBOARD_ART load failed ' + full); };
+      im.src = full;
+    };
     _billboardMesh = new THREE.Mesh(geo, mat);
     _billboardMesh.position.set(p.x, p.y, p.z);
     _billboardMesh.rotation.y = Math.PI / 2;   // PlaneGeometry normal +Z -> +X, matching the facade
     _billboardMesh.renderOrder = 1;
     A.scene.add(_billboardMesh);
     console.log('§BILLBOARD_ART built ' + wy.toFixed(1) + 'm x ' + hz.toFixed(1) + 'm at ifc(' +
-      cx.toFixed(2) + ',' + cy.toFixed(2) + ',' + cz.toFixed(2) + ') source=' + url + ' drawCalls=1');
+      cx.toFixed(2) + ',' + cy.toFixed(2) + ',' + cz.toFixed(2) + ') candidates=' + cands.length + ' drawCalls=1');
     if (A.markDirty) A.markDirty();
   };
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v868';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v869';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v869';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v870';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=6" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=7" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=5" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=6" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
Follow-up to #1066, same branch. User saved `TerminalBillboard.jpg` beside the DB, then: *"u can crop it / or the script simply crop any pic landed."*

**§BILLBOARD_SOURCE** — candidates in order, first hit wins: `billboard.png`, `billboard.jpg`, `<Stem>Billboard.jpg`, `<Stem>Billboard.png`, where Stem comes from the DB's own filename (`Terminal_Hi.db` → `Terminal`). `APP._setBillboardImage(url)` hot-swaps on the live mesh for iteration.

**§BILLBOARD_FIT** — **cover, not contain.** The real test image is 945×960 (aspect 0.98) on a 2.00 panel; mapped raw it stretches to twice its width. Cover fills the hoarding and crops overflow evenly. Logged exactly: `mode=cover scale=1.084 cropped=0x488px` — so the crop is never a surprise.

**Witness fix worth noting:** the probe slept a fixed 12 s and measured a null map, reporting a working feature as broken. The texture arrives after up to four *sequential* image probes. Now waits on the condition — the same race the ground witness already needed fixing for. W-BILLBOARD-ART **9/9**, real image confirmed picked up.

`sw.js v869→v870`, `effects.js?v=7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)