### PR TITLE
feat(viewer): add Blank Viewer card to the Buildings/IFC hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,6 +482,12 @@ var BUILDINGS={
   'Schependomlaan':{db:'Schependomlaan_extracted.db'},'SampleCastle':{db:'SampleCastle_extracted.db'},
   'Molio':{db:'Molio_extracted.db'},'BimWhale_Advanced':{db:'BimWhale_Advanced_extracted.db'}
 };
+// Implementing prompts/Viewer/BLANK_VIEWER_LANDING_CARD.md §3 (bim-ootb port) — Witness: manual, see §STATUS
+function openBlankViewer(){
+  sfxPress(); L('§BLANK_VIEWER_OPEN → viewer/viewer.html?blank=1');
+  try { if(window.WholeHistory && WholeHistory.record){ WholeHistory.record({ page:'viewer', label:'Blank', kind:'nav' }); } } catch(e){}
+  var win=window.open('viewer/viewer.html?blank=1&ghost=1','bim_blank'); if(!win){ location.href='viewer/viewer.html?blank=1&ghost=1'; }
+}
 function openHub(){ document.getElementById('hub').classList.add('active'); buildHubBody(); _refreshCachedIndicator(); L('§HUB opened (Buildings/IFC)'); }
 function closeHub(){ document.getElementById('hub').classList.remove('active'); }
 function openBuilding(name){
@@ -546,6 +552,9 @@ async function buildHubBody(){
       '<div style="display:none;margin:8px auto 0;max-width:400px;height:4px;background:#222;border-radius:2px;overflow:hidden">'+
         '<div id="import-progress-bar" style="height:100%;width:0%;background:#0277bd;border-radius:2px;transition:width .3s"></div></div>'+
     '</div>'+
+    '<div class="hub-sect"><div class="hub-grid"><div class="hub-card" style="border:1px dashed rgba(79,195,247,.4)" onclick="openBlankViewer()">'+
+      '<div class="nm" style="color:#4fc3f7">&#10133; Blank Viewer</div>'+
+      '<div class="mt">Open your own .db file</div></div></div></div>'+
     '<div id="hub-status" style="text-align:center;color:#667;font-size:12px;padding:20px">loading building manifest&hellip;</div>';
   if(typeof wireImportZone==='function') wireImportZone(); else L('§HUB import_own.js not loaded');
   try {

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -19,11 +19,14 @@ function setupConfig(A) {
   // OCI prod base for building DBs (matches index.html _prodBase). cachedFetch retries a failing
   // relative buildings/<file> against this base so a stale relative db url self-heals (W-DB-404-OCI-RETRY).
   A.PROD_BASE = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/';
-  // §S283: If no ?db= param, try last building from localStorage (PWA resume), then default
+  // Implementing prompts/Viewer/BLANK_VIEWER_LANDING_CARD.md §1 (bim-ootb port) — Witness: manual, see §STATUS
+  A.BLANK_MODE = _params.get('blank') === '1';
+  // §S283: If no ?db= param, try last building from localStorage (PWA resume), then default.
+  // Blank mode skips BOTH — a truly empty scene, not a PWA-resumed or sample building.
   var _lastDb = null;
   try { _lastDb = localStorage.getItem('pwa_last_db'); } catch(e) {}
-  A.DB_URL = _params.get('db') || _lastDb || (_base ? _base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db');
-  if (_lastDb && !_params.get('db')) console.log('§PWA_RESUME db=' + _lastDb);
+  A.DB_URL = A.BLANK_MODE ? '' : (_params.get('db') || _lastDb || (_base ? _base + 'Duplex_extracted.db' : 'buildings/Duplex_extracted.db'));
+  if (_lastDb && !_params.get('db') && !A.BLANK_MODE) console.log('§PWA_RESUME db=' + _lastDb);
   A.CITY_URL = _params.get('city') || null;
   A.BLD_BASE = _params.get('bldbase') || '';
 

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1671,6 +1671,16 @@ function setupStreaming(A) {
     const SQL = await initSqlJs(sqlOpts);
     A._SQL = SQL; // Cache for reuse (diff DB, import) — avoids re-downloading WASM
 
+    // Implementing prompts/Viewer/BLANK_VIEWER_LANDING_CARD.md §1 (bim-ootb port) — Witness: manual, see §STATUS
+    // Blank mode with nothing opened: fetch(A.DB_URL) below would resolve '' to the page's own HTML and
+    // fail confusingly. A.openModelDb() (Ctrl+O / Open Building pill) navigates to viewer.html?db=import://…
+    // once a file is picked — a fresh page load, so no re-entry guard is needed here.
+    if (A.BLANK_MODE && !A.DB_URL) {
+      A.status.textContent = 'Blank scene — press Ctrl+O (Open Building) to load a .db file';
+      console.log('§BLANK_MODE active=1 waiting_for_open=1');
+      return;
+    }
+
     if (A.CITY_URL) {
       // S250 §6: On mobile, defer city_index.db auto-load to save memory
       if (A._isMobile) {


### PR DESCRIPTION
## Summary
- The Buildings/IFC hub had no way to reach a truly blank viewer scene — `config.js`'s `A.DB_URL` always fell back to `Duplex_extracted.db` (or the §S283 `pwa_last_db` PWA-resume) when no `?db=` was given.
- Adds a dashed "➕ Blank Viewer" card to the hub, opening `viewer/viewer.html?blank=1`.
- `streaming.js` `A.init()` now short-circuits on `A.BLANK_MODE && !A.DB_URL` before the fetch, instead of resolving `''` to the page's own HTML.
- No new open-file UI needed — the existing Ctrl+O / "Open Building" pill (`A.openModelDb`, native file picker, shipped per `OPEN_BUTTON_IFC_BCF_MERGE.md`) already does the job once the scene is blank.
- Ported from a bim-compiler counterpart (`prompts/Viewer/BLANK_VIEWER_LANDING_CARD.md`) where the equivalent viewer had no Open control yet, so that port also added a local file-picker/drag-drop.

## Test plan
- [x] `node --check` on `viewer/config.js` + `viewer/streaming.js`
- [x] Inline `<script>` blocks in `index.html` parse (`new Function(...)`)
- [x] Served the real repo topology locally (python http.server) and curl-verified: hub card wiring present, `viewer/viewer.html?blank=1` returns 200, both edited JS files serve with the blank-mode guard
- [ ] Live click-through (not done this session — static/whitebox only, matches this repo's testing convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)