### PR TITLE
feat(photoreal): §BILLBOARD_SOURCE + §BILLBOARD_FIT + §BILLBOARD_ALWAYS

### DIFF
--- a/probe_billboard.js
+++ b/probe_billboard.js
@@ -23,6 +23,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
              lamps: q("SELECT COUNT(*) FROM elements_meta WHERE element_name LIKE 'BIM_OOTB_Floodlight%'"),
              fin:   q("SELECT finish, COUNT(*) FROM render_finishes GROUP BY 1") };
   });
+  // §BILLBOARD_ALWAYS gate: the art must exist BEFORE Alt+S is ever pressed. Measured first,
+  // because that was the live defect — the panel rendered as a black slab in normal navigation.
+  const preStill = await page.evaluate(() => { let n = 0; window.APP.scene.traverse(o => {
+    if (o.isMesh && o.geometry && o.geometry.type === 'PlaneGeometry' && o.material && o.material.isMeshBasicMaterial) n++; }); return n; });
   await page.evaluate(() => window.APP.startStillRefine());
   // Wait for the CONDITION, never a fixed sleep: the art quad's texture arrives after up to four
   // sequential image probes (404, 404, then the hit), and a timed guess measured a null map and
@@ -51,6 +55,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
   P(db.lamps[0] && db.lamps[0][0]===4, `corner floodlights in DB: ${db.lamps[0]?db.lamps[0][0]:0} (expect 4)`);
   P(db.fin.length>0, `render_finishes: ${db.fin.map(r=>r[0]+'='+r[1]).join(', ')}`);
   console.log('\n─ 2. ART QUAD built from those rows');
+  P(preStill === 1, `§BILLBOARD_ALWAYS: art quad exists BEFORE any Alt+S (found ${preStill}, must be 1)`);
   P(!!art.found, `art quad exists (count=${art.count}, must be 1)`);
   if (art.found) {
     P(Math.abs(art.found.w-db.panel[0][2])<0.01 && Math.abs(art.found.h-db.panel[0][3])<0.01, `sized from the DB row: ${art.found.w}m x ${art.found.h}m`);

--- a/probe_billboard.js
+++ b/probe_billboard.js
@@ -24,7 +24,17 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
              fin:   q("SELECT finish, COUNT(*) FROM render_finishes GROUP BY 1") };
   });
   await page.evaluate(() => window.APP.startStillRefine());
-  await sleep(12000);
+  // Wait for the CONDITION, never a fixed sleep: the art quad's texture arrives after up to four
+  // sequential image probes (404, 404, then the hit), and a timed guess measured a null map and
+  // reported a working feature as broken. Second occurrence of this exact race in this suite —
+  // the ground witness needed the same fix for _applyGroundTexture's async load.
+  await page.waitForFunction(() => {
+    let ok = false;
+    window.APP.scene.traverse(o => { if (o.isMesh && o.geometry && o.geometry.type === 'PlaneGeometry'
+      && o.material && o.material.isMeshBasicMaterial && o.material.map) ok = true; });
+    return ok;
+  }, { timeout: 120000, polling: 500 }).catch(() => {});
+  await sleep(2000);
   const art = await page.evaluate(() => {
     let found = null, count = 0, shared = 0;
     const mats = [];
@@ -48,9 +58,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     P(art.found.hasMap, `texture bound (fallback notice or billboard.png)`);
     P(art.shared===1, `material shared with ${art.shared} mesh — the invariant (must be 1: itself)`);
   }
-  console.log('\n─ 3. FALLBACK (no billboard.png present)');
-  const fb = logs.filter(l=>/§BILLBOARD_ART/.test(l));
-  P(fb.some(l=>/fallback notice drawn/.test(l)), `notice fallback fired, not a silent blank panel`);
+  console.log('\n─ 3. IMAGE PICKUP + ASPECT FIT');
+  const fb = logs.filter(l=>/§BILLBOARD_(ART|FIT)/.test(l));
+  const got = fb.find(l=>/§BILLBOARD_ART image=/.test(l));
+  P(!!got, `real image picked up by convention (not the fallback): ${got ? got.split('image=')[1] : 'NONE — fell back'}`);
+  const fit = fb.find(l=>/§BILLBOARD_FIT/.test(l));
+  P(!!fit && /mode=cover/.test(fit), `artwork COVER-fitted (crop to fill), never stretched: ${fit ? fit.replace('§BILLBOARD_FIT ','') : 'no fit line'}`);
   console.log('\n─ § lines'); fb.forEach(l=>console.log('   '+l));
   const errs = logs.filter(l=>/PAGEERROR/.test(l)); if (errs.length){ console.log('\n─ errors'); errs.slice(0,3).forEach(l=>console.log('   '+l)); }
   await b.close();

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2163,6 +2163,16 @@ async function setupEffects(A, renderer, scene, camera) {
     console.log('§BILLBOARD_ART fallback notice drawn (' + W + 'x' + H + ') — no billboard.png found');
     return tex;
   }
+  // §BILLBOARD_ALWAYS (2026-07-28, user live: "its blank black.. ah i see it, alt-s!!") — the art
+  // quad was only ever built from _showPhotoProps(true), so outside Alt+S the panel rendered as its
+  // own near-black hoarding body with no face on it, and it looked broken rather than unlit. A sign
+  // is a sign all the time; it should not need a photoshoot to have a face. Built once when the
+  // model has finished streaming, and _showPhotoProps's call is now just a harmless re-assert
+  // (the function is idempotent — it returns immediately if the mesh exists).
+  A._billboardAutoBuild = function() {
+    if (!A.db || !A.scene) return;
+    try { A._buildBillboardArt(); } catch (e) { console.warn('§BILLBOARD_ART auto-build failed: ' + e.message); }
+  };
   A._buildBillboardArt = function() {
     if (_billboardMesh || !A.db || !A.ifc2three) return;
     var rows;
@@ -2246,7 +2256,7 @@ async function setupEffects(A, renderer, scene, camera) {
       _buildPhotoProps();
     }
     if (show) _updateFacadeFacingLights();
-    if (show) A._buildBillboardArt();   // §BILLBOARD_ART — idempotent, builds once
+    if (show) A._buildBillboardArt();   // §BILLBOARD_ART — idempotent; also built outside staging, see §BILLBOARD_ALWAYS
     _photoUplights.forEach(function(l) { l.visible = show; });
     if (_photoSkyline) _photoSkyline.visible = show;
     if (_photoSkylineLights) _photoSkylineLights.visible = show;

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2180,23 +2180,63 @@ async function setupEffects(A, renderer, scene, camera) {
     var mat = new THREE.MeshBasicMaterial({ toneMapped: true, side: THREE.DoubleSide });
     // MeshBasic, not Standard: a sign face reads as self-lit, so it stays legible at dusk without
     // depending on whether the corner floodlights are inside the night light budget this frame.
+    // §BILLBOARD_SOURCE — candidates tried in order, first hit wins, then stop. Derived from the
+    // DB's own filename rather than hardcoded: "Terminal_Hi.db" -> first token "Terminal" ->
+    // TerminalBillboard.jpg. So either `billboard.<ext>` or `<Building>Billboard.<ext>` beside the
+    // .db is found without a code change. A._billboardImage overrides everything (console-testable:
+    //   APP._setBillboardImage('whatever.jpg')  — swaps the map on the live mesh, no reload).
     var dir = (A.DB_URL || '').replace(/[^/]*$/, '');
-    var url = dir + 'billboard.png';
-    new THREE.TextureLoader().load(url,
-      function(tex) {
-        if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
-        mat.map = tex; mat.needsUpdate = true;
-        console.log('§BILLBOARD_ART image=' + url);
-      },
-      undefined,
-      function() { mat.map = _billboardFallbackTexture(wy, hz); mat.needsUpdate = true; });
+    var stem = ((A.DB_URL || '').replace(/^.*\//, '').replace(/\.db$/i, '').split('_')[0]) || 'building';
+    var cands = A._billboardImage ? [A._billboardImage.indexOf('/') >= 0 ? A._billboardImage : dir + A._billboardImage]
+      : [dir + 'billboard.png', dir + 'billboard.jpg', dir + stem + 'Billboard.jpg', dir + stem + 'Billboard.png'];
+    // §BILLBOARD_FIT — the artwork almost never matches the hoarding's aspect (the first real test
+    // image was 945x960 = 0.98 against a 2.00 panel, which stretches to twice its width if mapped
+    // raw). COVER-fit: scale by the LARGER ratio so the artwork fills the whole hoarding and the
+    // overflow is cropped evenly from both edges — user's call ("the script simply crop any pic
+    // landed"), and it is the right one for a billboard: a real hoarding is never letterboxed.
+    // Aspect is always preserved; only the overflow is lost, never the proportions.
+    A._billboardFit = function(img, wm, hm) {
+      var W = 1024, H = Math.max(1, Math.round(W * (hm / wm)));
+      var c = document.createElement('canvas'); c.width = W; c.height = H;
+      var g = c.getContext('2d');
+      g.fillStyle = '#0d1017'; g.fillRect(0, 0, W, H);
+      var s = Math.max(W / img.width, H / img.height);   // COVER: fill the board, crop the overflow
+      var dw = img.width * s, dh = img.height * s;
+      g.drawImage(img, (W - dw) / 2, (H - dh) / 2, dw, dh);
+      var tex = new THREE.CanvasTexture(c);
+      if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+      console.log('§BILLBOARD_FIT src=' + img.width + 'x' + img.height + ' (aspect ' + (img.width / img.height).toFixed(2) +
+        ') -> panel ' + W + 'x' + H + ' (aspect ' + (wm / hm).toFixed(2) + ') mode=cover scale=' + s.toFixed(3) + ' cropped=' + (((img.width*s - W)/s).toFixed(0)) + 'x' + (((img.height*s - H)/s).toFixed(0)) + 'px');
+      return tex;
+    };
+    function _tryLoad(list, n) {
+      if (n >= list.length) { mat.map = _billboardFallbackTexture(wy, hz); mat.needsUpdate = true; return; }
+      var im = new Image();
+      im.crossOrigin = 'anonymous';
+      im.onload = function() { mat.map = A._billboardFit(im, wy, hz); mat.needsUpdate = true;
+        console.log('§BILLBOARD_ART image=' + list[n]); if (A.markDirty) A.markDirty(); };
+      im.onerror = function() { _tryLoad(list, n + 1); };
+      im.src = list[n];
+    }
+    _tryLoad(cands, 0);
+    // Live swap for iteration — no reload, no rebuild of the quad.
+    A._setBillboardImage = function(u) {
+      if (!_billboardMesh) { console.log('§BILLBOARD_ART no mesh yet — press Alt+S once'); return; }
+      var full = (u.indexOf('/') >= 0) ? u : dir + u;
+      var im = new Image(); im.crossOrigin = 'anonymous';
+      im.onload = function() { _billboardMesh.material.map = A._billboardFit(im, wy, hz);
+        _billboardMesh.material.needsUpdate = true; console.log('§BILLBOARD_ART swapped image=' + full);
+        if (A.markDirty) A.markDirty(); };
+      im.onerror = function() { console.warn('§BILLBOARD_ART load failed ' + full); };
+      im.src = full;
+    };
     _billboardMesh = new THREE.Mesh(geo, mat);
     _billboardMesh.position.set(p.x, p.y, p.z);
     _billboardMesh.rotation.y = Math.PI / 2;   // PlaneGeometry normal +Z -> +X, matching the facade
     _billboardMesh.renderOrder = 1;
     A.scene.add(_billboardMesh);
     console.log('§BILLBOARD_ART built ' + wy.toFixed(1) + 'm x ' + hz.toFixed(1) + 'm at ifc(' +
-      cx.toFixed(2) + ',' + cy.toFixed(2) + ',' + cz.toFixed(2) + ') source=' + url + ' drawCalls=1');
+      cx.toFixed(2) + ',' + cy.toFixed(2) + ',' + cz.toFixed(2) + ') candidates=' + cands.length + ' drawCalls=1');
     if (A.markDirty) A.markDirty();
   };
 

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -1334,6 +1334,9 @@ function setupStreaming(A) {
     // §TM_STREAM_RESWEEP: newly-flushed geometry defaults to visible — if Time Machine is
     // active, sweep it against the current cursor (no-op when TM isn't active).
     if (window.tmResweep) window.tmResweep();
+    // §BILLBOARD_ALWAYS: the model is fully streamed here, so any billboard element in the DB can
+    // now be read and given its face. Idempotent and a no-op for buildings that have no billboard.
+    if (A._billboardAutoBuild) A._billboardAutoBuild();
   };
 
   // §S261: Bbox-only BatchedMesh flush — ONE flush, all elements start as bbox cubes.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v870';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v871';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v869';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v870';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=6" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=7" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -834,7 +834,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=52" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=56" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=57" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
Replaces #1067, which went DIRTY: #1066 squash-merged `feat/billboard-art`, and continuing to push to that same branch collided with the squash — the exact trap this repo's own notes warn about. Re-cut from fresh `origin/main`, same commit cherry-picked, plus one more fix.

**§BILLBOARD_SOURCE** — image found by convention beside the DB: `billboard.png`, `billboard.jpg`, `<Stem>Billboard.jpg`, `<Stem>Billboard.png` (Stem from the DB filename, `Terminal_Hi.db` → `Terminal`). `APP._setBillboardImage(url)` hot-swaps on the live mesh.

**§BILLBOARD_FIT** — cover, not contain. Test image is 945×960 (aspect 0.98) on a 2.00 panel; raw mapping stretches it to twice its width. Cover fills the hoarding, crops overflow evenly, logs the exact crop: `mode=cover scale=1.084 cropped=0x488px`.

**§BILLBOARD_ALWAYS** — user found the real defect live: *"its blank black.. ah i see it, alt-s!!"*. The art quad was only built from `_showPhotoProps(true)`, so in normal navigation the panel was its own near-black hoarding body with no face — it read as broken. Now built when streaming completes (`streaming.js`, after §CONTRACT_CHECK), with the staging call left as an idempotent re-assert.

**W-BILLBOARD-ART 10/10**, including a new gate asserting the art exists *before* any Alt+S. Also fixed a witness race: it slept a fixed 12 s and measured a null map, reporting a working feature as broken — the texture arrives after up to four sequential image probes. Waits on the condition now, same fix the ground witness needed.

`sw.js v869→v871`, `effects.js?v=7`, `streaming.js?v=57`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)