### PR TITLE
chore(sw): bump CACHE_VERSION v871→v872 for PR #1068

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v871';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v872';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- `viewer/sw.js` precaches `viewer.html`/`config.js`/`streaming.js` cache-first — freshness is guaranteed only by a `CACHE_VERSION` bump on deploy, per this file's own doctrine (`isNetworkFirst()`).
- #1068 (Blank Viewer card) changed exactly those three files but never bumped the version.
- Result, observed live by the user: an already-installed client kept serving the pre-fix `config.js`, so the Blank Viewer card resolved via the stale §S283 `pwa_last_db` resume path and opened the last-viewed building (Hospital) instead of a blank scene.
- One-line fix: `v871` → `v872`.

## Test plan
- [x] `node --check viewer/sw.js`
- [ ] User reload after merge — expect the SW to purge/refresh the old cache and the Blank Viewer card to actually open blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)