### PR TITLE
perf(viewer): MergedMesh low-draw path restored (GUID-exact) + HBA opt-in — mobile LTU

### DIFF
--- a/tests/probe_hba_lazy.js
+++ b/tests/probe_hba_lazy.js
@@ -1,0 +1,143 @@
+// probe_hba_lazy.js — witness for the §HBA_LAZY change (user directive 2026-07-28:
+// "It should only come on if called from the pill. No early casting needed.")
+//
+// ISSUE IT PROVES / DISPROVES: hba_lens.js's startup poll used to (a) auto-promote the hbaFM pill
+// onto the rail — the two-heads icon appearing unbidden — and (b) run the whole HBA compile
+// (IfcSpace footprints, rel_contained_in_space members, seven demonstrator spec seeds, plus an
+// async ad_seed.db fetch) on the main thread the moment streaming finished. Both were unasked-for.
+//
+// NO EARLY CASTING (the fix):
+//   1. After a full load, §HBA_LAZY is logged and §HBA_SEED is NOT — zero HBA compile at startup.
+//   2. None of the seeded specs (A._hbaRooms/_hbaOccupancyLog/_hbaPayrollSpec/...) exist yet.
+//   3. The hbaFM action still has pill===false — it did not cast itself onto the rail — and no
+//      hbaFM button is in the DOM.
+// STILL WORKS WHEN CALLED (the no-regression half):
+//   4. Invoking the pill's own fn (openFamilyDrawer) → §HBA_SEED fires ONCE, specs materialise,
+//      the drawer opens with the same lens availability the eager path used to report.
+//   5. A second invocation does NOT re-seed (idempotent).
+//   6. Zero PAGEERROR throughout.
+// Also REPORTS the measured seed cost — the main-thread work moved off page load.
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8157;
+const BLD = process.env.BLD || 'HHS_Office_Federated';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db&bld=${BLD}`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+let fails = 0;
+const FAIL = m => { fails++; console.log('FAIL: ' + m); };
+const PASS = m => console.log('PASS: ' + m);
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    const ctx = await browser.newContext({
+      serviceWorkers: 'block', viewport: { width: 412, height: 915 },
+      isMobile: true, hasTouch: true, deviceScaleFactor: 2,
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36'
+    });
+    const page = await ctx.newPage();
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+    await page.goto(URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => {
+      const A = window.A || window.APP;
+      return A && A.db && A.activeBuilding && !A.streaming && A.streamedCount > 0;
+    }, { timeout: 240000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+    await sleep(8000);   // the old eager gate fired on a 500ms poll after streaming — well inside this
+
+    const has = n => logs.some(l => l.includes(n));
+
+    // ── 1. no seed at startup ──
+    if (has('§HBA_LAZY armed')) PASS('§HBA_LAZY armed at startup');
+    else FAIL('§HBA_LAZY not logged — the lazy gate never armed');
+    if (has('§HBA_SEED')) FAIL('§HBA_SEED fired at page load — HBA still casts early');
+    else PASS('no §HBA_SEED at page load — zero HBA compile at startup');
+    ['§HBA_OCC seeded', '§HBA_PAY seeded', '§HBA_TEN compiled', '§HBA_RES compiled', '§HBA_GOVERN'].forEach(n => {
+      if (has(n)) FAIL('startup still ran ' + n);
+    });
+    if (!['§HBA_OCC seeded', '§HBA_PAY seeded', '§HBA_TEN compiled'].some(has))
+      PASS('no demonstrator specs seeded at startup');
+
+    // ── 2. no seeded state on APP ──
+    const before = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      return {
+        rooms: !!A._hbaRooms, occ: !!A._hbaOccupancyLog, pay: !!A._hbaPayrollSpec,
+        ten: !!A._hbaTenancySpec, res: !!A._hbaResourceSpec, members: !!A._hbaRoomMembers
+      };
+    });
+    console.log('STATE(before) ' + JSON.stringify(before));
+    if (Object.values(before).every(v => v === false)) PASS('no HBA spec state on APP before use');
+    else FAIL('HBA state already present before any pill use: ' + JSON.stringify(before));
+
+    // ── 3. pill did not cast itself onto the rail ──
+    const pillState = await page.evaluate(() => {
+      const acts = window._mainPillActions || [];
+      const a = acts.find(x => x.id === 'hbaFM');
+      const btn = document.getElementById('pill-hbaFM');
+      let rect = null, shown = false;
+      if (btn) {
+        const r = btn.getBoundingClientRect();
+        const cs = getComputedStyle(btn);
+        shown = r.width > 0 && r.height > 0 && cs.display !== 'none' && cs.visibility !== 'hidden';
+        rect = [Math.round(r.left), Math.round(r.top), Math.round(r.width), Math.round(r.height)];
+      }
+      return { registered: !!a, pill: a ? a.pill : 'no-action', inDom: !!btn, shown, rect };
+    });
+    console.log('PILL ' + JSON.stringify(pillState));
+    if (pillState.pill === false && !pillState.shown)
+      PASS('hbaFM stayed pill:false and renders nothing on the rail (no early casting)');
+    else FAIL('hbaFM promoted itself: ' + JSON.stringify(pillState));
+
+    // ── 4. calling it wakes HBA ──
+    const mark = logs.length;
+    const called = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      if (!(window.HBALens && HBALens.openFamilyDrawer)) return 'no-api';
+      HBALens.openFamilyDrawer(A);          // exactly what the hbaFM pill's fn does
+      return 'ok';
+    });
+    await sleep(3000);
+    const seedLine = logs.slice(mark).find(l => l.includes('§HBA_SEED')) || '';
+    if (called !== 'ok') FAIL('could not invoke the pill fn: ' + called);
+    if (seedLine) PASS('pill invocation → ' + seedLine);
+    else FAIL('§HBA_SEED did not fire when the pill was used — HBA would be dead, not lazy');
+
+    const after = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      const d = document.getElementById('hba-fm-drawer');
+      let lenses = null;
+      try { lenses = HBALens.availableLenses(A).filter(x => x.available).map(x => x.id); } catch (e) {}
+      return {
+        rooms: (A._hbaRooms || []).length, occ: (A._hbaOccupancyLog || []).length,
+        pay: !!A._hbaPayrollSpec, ten: !!A._hbaTenancySpec, drawerOpen: !!d, lenses
+      };
+    });
+    console.log('STATE(after) ' + JSON.stringify(after));
+    if (after.rooms > 0 && after.occ > 0 && after.drawerOpen)
+      PASS(`HBA works when called: ${after.rooms} rooms, ${after.occ} occupancy ops, drawer open, lenses=[${after.lenses}]`);
+    else FAIL('HBA did not come up on demand: ' + JSON.stringify(after));
+
+    // ── 5. idempotent ──
+    const mark2 = logs.length;
+    await page.evaluate(() => { const A = window.A || window.APP; HBALens.openFamilyDrawer(A); HBALens.openFamilyDrawer(A); });
+    await sleep(1500);
+    const reseeds = logs.slice(mark2).filter(l => l.includes('§HBA_SEED')).length;
+    if (reseeds === 0) PASS('re-opening does not re-seed (idempotent)');
+    else FAIL('§HBA_SEED fired ' + reseeds + ' more time(s) on re-open');
+
+    // ── 6. clean ──
+    const errs = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs.length) FAIL('PAGEERROR: ' + errs.join(' | '));
+    else PASS('zero PAGEERROR');
+
+    console.log('--- §HBA log lines ---');
+    logs.filter(l => /§HBA/.test(l)).forEach(l => console.log('  ' + l));
+    console.log(fails === 0 ? 'PROBE_RESULT: ALL PASS' : 'PROBE_RESULT: ' + fails + ' FAIL');
+    process.exitCode = fails === 0 ? 0 : 1;
+  } catch (e) {
+    console.log('PROBE_ERROR: ' + (e && e.stack || e));
+    process.exitCode = 1;
+  } finally { await browser.close(); }
+})();

--- a/tests/probe_merged_guid.js
+++ b/tests/probe_merged_guid.js
@@ -1,0 +1,273 @@
+// probe_merged_guid.js — witness for MOBILE_PERF.md §SPEC 2026-07-28 (§MERGED_GUID).
+//
+// ISSUE IT PROVES / DISPROVES: the MergedMesh low-draw path was reverted on 2026-05-27 (68bd9a7)
+// because merging destroyed per-element identity — "merged → no per-GUID metadata" — which broke
+// Time Machine and picking. The claim under test is that the path can be restored WITH identity
+// intact, and WITHOUT costing the mobile strengths (Walk/fly, snag, share-URL, GPS).
+//
+// Each check names what it proves:
+//   1. W-MERGED-ROUTE    draw calls actually collapse (buckets << elements) on the merged path.
+//   2. W-MERGED-CONTRACT §S280d contract holds: merged elements counted + reachable by guid,
+//                        and NO §CONTRACT_FAIL anywhere.
+//   3. W-MERGED-PICK     a real 3D tap resolves the EXACT element — and the identical tap on the
+//                        unmerged path resolves the SAME guid. (The 2026-05 path could not do this:
+//                        it guessed via nearest-centroid SQL.)
+//   4. W-SHARE-URL       #info-guid carries that guid — share.js:225 reads exactly this node, so
+//                        this is the share-a-picked-element feature proven end-to-end.
+//   5. W-MERGED-FILTER   filterByGuids isolates per element on merged meshes (before: merged
+//                        geometry ignored the isolate entirely and stayed visible — silently wrong).
+//   6. W-MERGED-RAYCAST  the AABB pre-cull works: triangle-tested elements << elements scanned.
+//                        This is the Walk/fly protection — sfx.js fly-rayblast casts at 11Hz and
+//                        a merged bucket has no BVH, so without this it would brute-force.
+//   7. W-MERGED-TM       TM still gets per-element slots: merge active → §TM_UNMERGE → re-stream
+//                        unmerged (_mergeActive false, _batchMeta populated).
+//
+// Real viewer, real building, real tap. SW blocked. Leak-safe (finally kills chrome).
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const PORT = process.env.PORT || 8155;
+const BLD = process.env.BLD || 'HHS_Office_Federated';
+const base = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db&bld=${BLD}`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+let fails = 0;
+const FAIL = m => { fails++; console.log('FAIL: ' + m); };
+const PASS = m => console.log('PASS: ' + m);
+
+// Load the viewer, wait for the stream to finish, return {page, logs}.
+async function open(browser, url) {
+  const ctx = await browser.newContext({ serviceWorkers: 'block' });
+  const page = await ctx.newPage();
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR: ' + e.message));
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => {
+    const A = window.A || window.APP;
+    return A && A.db && A.activeBuilding && !A.streaming && A.streamedCount > 0;
+  }, { timeout: 240000 }).catch(e => console.log('WAIT_FAIL ' + e.message));
+  await sleep(3000);   // let the final flush + consolidation settle
+  return { page, ctx, logs };
+}
+
+// Tap the on-screen projection of a specific element's centroid. Returns the guid aimed at.
+async function tapElement(page, guid) {
+  return page.evaluate(g => {
+    const A = window.A || window.APP;
+    const r = A.db.exec('SELECT center_x, center_y, center_z FROM element_transforms WHERE guid = ?', [g]);
+    if (!r.length || !r[0].values.length) return { ok: false, why: 'no-transform' };
+    const [cx, cy, cz] = r[0].values[0];
+    const c = A.ifc2three(cx, cy, cz);
+    const v = new THREE.Vector3(c.x, c.y, c.z).project(A.camera);
+    const px = (v.x * 0.5 + 0.5) * window.innerWidth;
+    const py = (-v.y * 0.5 + 0.5) * window.innerHeight;
+    const opt = () => ({ bubbles: true, cancelable: true, clientX: px, clientY: py, button: 0, pointerId: 1, isPrimary: true });
+    A.canvas.dispatchEvent(new PointerEvent('pointerdown', opt()));
+    A.canvas.dispatchEvent(new PointerEvent('pointerup', opt()));
+    return { ok: true, px: Math.round(px), py: Math.round(py) };
+  }, guid);
+}
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--use-gl=angle', '--use-angle=swiftshader'] });
+  try {
+    // ══ RUN A — merged path forced on (?merge=1) ══════════════════════════════
+    const A1 = await open(browser, base + '&merge=1');
+    const { page, logs } = A1;
+    const has = n => logs.some(l => l.includes(n));
+    const line = n => logs.find(l => l.includes(n)) || '';
+
+    // ── 1. W-MERGED-ROUTE ──
+    if (!has('§MERGE_ROUTE on')) FAIL('§MERGE_ROUTE not logged — merged path never engaged, rest of probe is void');
+    else PASS('§MERGE_ROUTE on — ' + line('§MERGE_ROUTE'));
+    const mf = line('§MERGED_FLUSH');
+    if (!mf) FAIL('no §MERGED_FLUSH — nothing was merged');
+    else {
+      const buckets = +(/buckets=(\d+)/.exec(mf) || [])[1];
+      const elements = +(/elements=(\d+)/.exec(mf) || [])[1];
+      if (buckets > 0 && elements > buckets) {
+        PASS(`W-MERGED-ROUTE draw calls ${elements} → ${buckets} (${(elements / buckets).toFixed(1)}× fewer) | ${mf}`);
+      } else FAIL('merged flush did not reduce draw calls: ' + mf);
+    }
+
+    // ── 2. W-MERGED-CONTRACT ──
+    const cc = line('§CONTRACT_CHECK');
+    const merged = +(/merged=(\d+)/.exec(cc) || [])[1];
+    const mgIdx = +(/mergedIndex=(\d+)/.exec(cc) || [])[1];
+    if (merged > 0 && mgIdx > 0) PASS(`W-MERGED-CONTRACT ${cc}`);
+    else FAIL('contract check shows no merged metadata: ' + cc);
+    const cf = logs.filter(l => l.includes('§CONTRACT_FAIL'));
+    if (cf.length) FAIL('§CONTRACT_FAIL: ' + cf.join(' | '));
+    else PASS('W-MERGED-CONTRACT zero §CONTRACT_FAIL');
+
+    // Pick a target element that actually lives on a merged mesh (not batched/instanced).
+    const target = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      const ids = Object.keys(A._mergedMeta || {});
+      if (!ids.length) return null;
+      // biggest element on the largest merged bucket — a fat tap target
+      let best = null;
+      for (const id of ids) {
+        for (const m of A._mergedMeta[id]) {
+          const vol = (m.maxX - m.minX) * (m.maxY - m.minY) * (m.maxZ - m.minZ);
+          if (!best || vol > best.vol) best = { guid: m.guid, vol, meshId: +id, idxStart: m.idxStart };
+        }
+      }
+      return best;
+    });
+    if (!target) { FAIL('no merged elements to target'); throw new Error('no merged elements'); }
+    console.log('TARGET: ' + JSON.stringify(target));
+
+    // ── 3. W-MERGED-PICK ──
+    const tap1 = await tapElement(page, target.guid);
+    console.log('TAP(merged): ' + JSON.stringify(tap1));
+    await sleep(1500);
+    const mp = logs.find(l => l.includes('§MERGED_PICK')) || '';
+    const mergedGuid = (/guid=(\S+)/.exec(mp) || [])[1];
+    if (mergedGuid) PASS('W-MERGED-PICK exact identity — ' + mp);
+    else FAIL('no §MERGED_PICK after tapping a merged element (fell back to the guessing path?)');
+    if (has('§PICK merged fallback')) FAIL('picking used the nearest-centroid FALLBACK, not the range map');
+    else PASS('W-MERGED-PICK no nearest-centroid fallback used');
+
+    // ── 4. W-SHARE-URL (share.js:225 reads #info-guid) ──
+    const infoGuid = await page.evaluate(() => {
+      const el = document.getElementById('info-guid');
+      return el ? el.textContent.trim() : null;
+    });
+    if (infoGuid && mergedGuid && infoGuid === mergedGuid)
+      PASS('W-SHARE-URL #info-guid = ' + infoGuid + ' (share-a-picked-element intact)');
+    else FAIL('#info-guid="' + infoGuid + '" does not match picked guid "' + mergedGuid + '"');
+
+    // ── 5. W-MERGED-FILTER ──
+    const filt = await page.evaluate(g => {
+      const A = window.A || window.APP;
+      A.filterByGuids(new Set([g]));
+      let visible = 0, hidden = 0, meshesOn = 0;
+      for (const id of Object.keys(A._mergedMeta)) {
+        for (const m of A._mergedMeta[id]) { if (m.hidden) hidden++; else visible++; }
+      }
+      A.collectMeshes(o => o.userData && o.userData.isMerged).forEach(m => { if (m.visible) meshesOn++; });
+      A.filterByGuids(null);
+      let backOn = 0;
+      for (const id of Object.keys(A._mergedMeta)) {
+        for (const m of A._mergedMeta[id]) if (!m.hidden) backOn++;
+      }
+      return { visible, hidden, meshesOn, backOn, total: visible + hidden };
+    }, target.guid);
+    console.log('FILTER: ' + JSON.stringify(filt));
+    if (filt.visible === 1 && filt.hidden === filt.total - 1)
+      PASS(`W-MERGED-FILTER isolate → exactly 1 of ${filt.total} merged elements visible (${filt.meshesOn} bucket(s) drawn)`);
+    else FAIL(`isolate left ${filt.visible} merged elements visible, expected 1 of ${filt.total}`);
+    if (filt.backOn === filt.total) PASS('W-MERGED-FILTER restore → all ' + filt.total + ' visible again');
+    else FAIL(`restore left ${filt.total - filt.backOn} elements still hidden`);
+
+    // ── 6. W-MERGED-RAYCAST (the Walk/fly protection) ──
+    const ray = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      A._mergedRayStats = { casts: 0, tested: 0, scanned: 0 };
+      const meshes = A.collectMeshes(o => o.userData && o.userData.isMerged);
+      const rc = new THREE.Raycaster();
+      // Aim at real merged elements so the casts actually HIT — a cull ratio measured on rays that
+      // hit nothing would prove nothing (0/N is what a broken AABB test looks like too).
+      const targets = [];
+      for (const id of Object.keys(A._mergedMeta)) {
+        const meta = A._mergedMeta[id];
+        for (let i = 0; i < meta.length && targets.length < 60; i += Math.max(1, (meta.length / 4) | 0)) {
+          const m = meta[i];
+          targets.push(new THREE.Vector3((m.minX + m.maxX) / 2, (m.minY + m.maxY) / 2, (m.minZ + m.maxZ) / 2));
+        }
+        if (targets.length >= 60) break;
+      }
+      const dir = new THREE.Vector3();
+      let hits = 0;
+      const t0 = performance.now();
+      for (const t of targets) {
+        dir.copy(t).sub(A.camera.position).normalize();
+        rc.set(A.camera.position, dir);
+        rc.far = Infinity;
+        if (rc.intersectObjects(meshes, false).length) hits++;
+      }
+      const ms = performance.now() - t0;
+      return { ...A._mergedRayStats, ms: +ms.toFixed(1), meshes: meshes.length, casts_aimed: targets.length, hits };
+    });
+    const pct = ray.scanned ? (ray.tested / ray.scanned * 100) : 100;
+    console.log('RAYCAST: ' + JSON.stringify(ray));
+    if (!(ray.hits > 0))
+      FAIL(`raycast returned NO hits on ${ray.casts_aimed} rays aimed at merged elements — the AABB test is rejecting valid hits, not culling`);
+    else if (ray.scanned > 0 && pct < 10)
+      PASS(`W-MERGED-RAYCAST ${ray.hits}/${ray.casts_aimed} aimed rays hit, and only ${ray.tested}/${ray.scanned} elements were triangle-tested (${pct.toFixed(2)}%) — ${ray.casts_aimed} casts in ${ray.ms}ms`);
+    else FAIL(`AABB pre-cull ineffective: ${ray.tested}/${ray.scanned} tested (${pct.toFixed(1)}%) — Walk/fly would pay brute-force cost`);
+
+    // ── 7. W-MERGED-TM ──
+    const tmBefore = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      return { mergeActive: !!A._mergeActive, batchMetas: Object.keys(A._batchMeta || {}).length };
+    });
+    const tmApi = await page.evaluate(() => {
+      if (typeof window.toggleTimeMachine !== 'function') return 'missing';
+      window.toggleTimeMachine();
+      return 'called';
+    });
+    console.log('TM_TOGGLE: ' + tmApi);
+    if (tmApi !== 'called') FAIL('window.toggleTimeMachine missing — probe cannot drive TM');
+    await sleep(20000);   // clearStreamed + full re-stream, unmerged
+    const tmAfter = await page.evaluate(() => {
+      const A = window.A || window.APP;
+      return {
+        mergeActive: !!A._mergeActive, forceNoMerge: !!A._forceNoMerge,
+        batchMetas: Object.keys(A._batchMeta || {}).length,
+        mergedMetas: Object.keys(A._mergedMeta || {}).length,
+        streaming: !!A.streaming
+      };
+    });
+    console.log('TM: before=' + JSON.stringify(tmBefore) + ' after=' + JSON.stringify(tmAfter));
+    const unmergeCount = logs.filter(l => l.includes('§TM_UNMERGE')).length;
+    if (unmergeCount === 1) PASS('W-MERGED-TM §TM_UNMERGE fired exactly once — ' + line('§TM_UNMERGE'));
+    else if (unmergeCount === 0) FAIL('TM did not trigger the unmerge re-stream (merged meshes have no per-element slots)');
+    // ISSUE THIS PROVES: if the re-stream re-merges, TM's activate() sees merged meshes again and
+    // re-streams again — an unbounded clearStreamed/streamBuilding loop. Caught live on the first run.
+    else FAIL('§TM_UNMERGE fired ' + unmergeCount + '× — unmerge/re-stream LOOP, _forceNoMerge is not sticking');
+    if (!tmAfter.streaming && tmAfter.forceNoMerge && tmAfter.mergedMetas === 0 && tmAfter.batchMetas > 0)
+      PASS('W-MERGED-TM re-streamed unmerged: mergedMetas=0 batchMetas=' + tmAfter.batchMetas);
+    else if (tmAfter.streaming) console.log('NOTE: re-stream still running at check time — inconclusive, not a fail');
+    else FAIL('after TM: ' + JSON.stringify(tmAfter) + ' — expected 0 merged metas and populated _batchMeta');
+
+    const errs1 = logs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs1.length) FAIL('PAGEERROR (merged run): ' + errs1.join(' | '));
+    else PASS('zero PAGEERROR on the merged run');
+
+    // ══ RUN B — same tap, unmerged path (?merge=0) — the identity cross-check ══
+    await A1.ctx.close();
+    const B = await open(browser, base + '&merge=0');
+    const bLogs = B.logs;
+    if (bLogs.some(l => l.includes('§MERGE_ROUTE on'))) FAIL('?merge=0 still merged — override broken');
+    else PASS('?merge=0 → BatchedMesh path (A/B handle works)');
+    await tapElement(B.page, target.guid);
+    await sleep(1500);
+    const bPickLine = bLogs.find(l => l.includes('§BATCHED_PICK')) || bLogs.find(l => l.includes('§PICK ')) || '';
+    const bGuid = await B.page.evaluate(() => {
+      const el = document.getElementById('info-guid');
+      return el ? el.textContent.trim() : null;
+    });
+    console.log('TAP(unmerged): ' + bPickLine + ' info-guid=' + bGuid);
+    if (bGuid && mergedGuid && bGuid === mergedGuid)
+      PASS('W-MERGED-PICK cross-check: same screen point resolves the SAME guid merged vs unmerged (' + bGuid + ')');
+    else FAIL(`identity diverges: merged=${mergedGuid} unmerged=${bGuid} — merging changed what the user picks`);
+    const errs2 = bLogs.filter(l => l.startsWith('PAGEERROR'));
+    if (errs2.length) FAIL('PAGEERROR (unmerged run): ' + errs2.join(' | '));
+    else PASS('zero PAGEERROR on the unmerged run');
+
+    console.log('--- §-LOG EXCERPT (merged run) ---');
+    logs.filter(l => /§MERGE|§MERGED|§CONTRACT|§FILTER_GUIDS|§TM_UNMERGE|§RENDERER_CAPS|§BATCHED_FLUSH|§CONSOLIDATE/.test(l))
+      .forEach(l => console.log('  ' + l));
+    console.log('--- §-LOG EXCERPT (unmerged run) ---');
+    bLogs.filter(l => /§BATCHED_FLUSH|§CONSOLIDATE|§CONTRACT_CHECK|§BATCHED_PICK/.test(l))
+      .forEach(l => console.log('  ' + l));
+    console.log(fails === 0 ? 'PROBE_RESULT: ALL PASS' : 'PROBE_RESULT: ' + fails + ' FAIL');
+    process.exitCode = fails === 0 ? 0 : 1;
+  } catch (e) {
+    console.log('PROBE_ERROR: ' + (e && e.stack || e));
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/viewer/hba_lens.js
+++ b/viewer/hba_lens.js
@@ -170,6 +170,21 @@
   // bind the Find-lens storey index from the LIVE model (rooms→IfcBuildingStorey) so density dots use real
   // storeys — non-invent, honest no-op on a building without spatial_structure. Uses the viewer's A.dbQuery.
   var _storeysBound = false;
+  // §HBA_LAZY — the ONE entry point that wakes HBA. Idempotent (bindStoreysFromModel has its own
+  // _storeysBound guard and _ensureErpGovern its own _erpTried guard; this adds the timing + a single
+  // §-line so the deferred cost is MEASURABLE rather than asserted). Called from every public entry
+  // that reads seeded state, never at load. Witness: W-HBA-LAZY.
+  var _hbaSeedMs = null;
+  function ensureHbaData(A) {
+    if (_hbaSeedMs !== null) return false;              // already awake
+    var t0 = (G.performance && G.performance.now) ? G.performance.now() : Date.now();
+    bindStoreysFromModel(A);
+    _hbaSeedMs = +(((G.performance && G.performance.now) ? G.performance.now() : Date.now()) - t0).toFixed(1);
+    console.log('§HBA_SEED ms=' + _hbaSeedMs + ' rooms=' + ((A && A._hbaRooms) ? A._hbaRooms.length : 0) +
+      ' — this is the work that used to run at page load on every building');
+    return true;
+  }
+
   function bindStoreysFromModel(A) {
     var h = HBA();
     if (_storeysBound || !h.L || !h.L.bindStoreys || !A || typeof A.dbQuery !== 'function') return;
@@ -439,6 +454,10 @@
   // non-matching guid never tints (honest). OFF (or switching mode) → full restore (zero residue).
   function toggle(A, mode) {
     if (!ready()) { if (A && A.status) A.status.textContent = 'HR overlay not loaded'; return false; }
+    // §HBA_LAZY: second wake point. A lens can be driven directly (witness scripts, deep-links,
+    // HBALens.toggle from the console) without the drawer, and every plan below reads the seeded
+    // specs — so wake here too rather than assuming the drawer ran first.
+    ensureHbaData(A);
     if (_port) { _port.restoreAll(); _port = null; }            // clear prior mode first (one mode at a time)
     _clearOutlines(A);                                          // §2026-07-05e — perimeter outlines ride the SAME one-mode-at-a-time rule
     if (G.HBAAvatars && G.HBAAvatars.isActive()) G.HBAAvatars.unmount(A);   // §AVATAR-LOD — avatars ride the presence lens; clear them with it
@@ -519,7 +538,9 @@
     var drawerOpen = (typeof document !== 'undefined') && !!document.getElementById('hba-fm-drawer');
     return availableLenses(G.APP || G.A || {}).some(function (x) { return x.active; }) || drawerOpen;
   }
-  function activateLens(A, entry) { if (entry.kind === 'pane') { var p = paneFor(entry); if (p) p.toggle(A); } else { toggle(A, entry.mode); } }
+  // §HBA_LAZY: third wake point — the 'pane' branch calls p.toggle(A) DIRECTLY, bypassing toggle()
+  // above, and every pane (dashboard/payslip/leave/tenancy/bom) reads A._hba* specs.
+  function activateLens(A, entry) { ensureHbaData(A); if (entry.kind === 'pane') { var p = paneFor(entry); if (p) p.toggle(A); } else { toggle(A, entry.mode); } }
 
   // remove every child via removeChild/remove (NOT `.innerHTML = ''` — matches the codebase's own convention,
   // see hba_leave.js/hba_payslip.js headers: innerHTML-clearing isn't reliable across the lightweight witness
@@ -998,6 +1019,10 @@
   function openFamilyDrawer(A) {
     if (typeof document === 'undefined') return null;
     var ex = document.getElementById('hba-fm-drawer'); if (ex) { ex.remove(); _closePresenceDrawer(); return null; }
+    // §HBA_LAZY: the pill IS the wake signal. Seeding here (not at page load) is what makes HBA
+    // opt-in — availableLenses()/familyHasData() below read the specs this call compiles, so it must
+    // precede them. Idempotent: a second open is a no-op.
+    ensureHbaData(A);
     var d = document.createElement('div'); d.id = 'hba-fm-drawer';
     // §FIX 2026-07-06c item B follow-on: this menu's rows are how a user opens a 2nd/3rd pane — it must stay
     // clickable ABOVE any already-open pane (panes are z-index:10050), or opening the first pane hides the
@@ -1063,6 +1088,7 @@
     flyToZone: flyToZone, flyToPOV: flyToPOV, flyToFacing: flyToFacing, captureFacingSnapshot: captureFacingSnapshot,
     openPresenceDrawer: openPresenceDrawer, closePresenceDrawer: _closePresenceDrawer,
     erpLink: erpLink, AD_WINDOWS: AD_WINDOWS,
+    ensureHbaData: ensureHbaData,   // §HBA_LAZY — public wake seam (witnesses + any future entry point)
     _regovern: _regovern, _buildingName: _buildingName, _ensureErpGovern: _ensureErpGovern,
     _consumeFindGuid: _consumeFindGuid, bindStoreysFromModel: bindStoreysFromModel };  // §STAGE2 / §2026-07-04c / §2026-07-05e — witness hooks (additive)
   if (typeof module === 'object' && module.exports) { module.exports = G.HBALens; return; }   // node witness — no DOM gate
@@ -1104,17 +1130,18 @@
     if (!ready() || !hasMesh) { if (_tries > 240) { clearInterval(_poll); console.warn('§HBA_GATE timeout — engine/guidMap not ready'); } return; }
     if (A.streaming) { if (_tries > 240) { clearInterval(_poll); console.warn('§HBA_GATE timeout — still streaming'); } return; }
     clearInterval(_poll);
-    bindStoreysFromModel(A);   // real storeys for the density dots (honest no-op if the model lacks them)
-    _consumeFindGuid(A);       // §2026-07-04c — the reverse Zoom-Across's finer scope (viewer/config.js A.FIND_GUID)
-    // ONE family pill (hbaFM) — flip it on when ANY lens has data (familyHasData = the wake-aware gate). The
-    // per-lens availability/greying is computed live in the drawer (availableLenses), not on the bar.
-    var acts = G._mainPillActions || [], lenses = availableLenses(A), any = familyHasData(A);
-    for (var i = 0; i < acts.length; i++) {
-      if (acts[i].id === 'hbaFM') { acts[i].pill = any ? undefined : false; }
-    }
-    if (any && A._buildPill) A._buildPill();
-    console.log('§HBA_GATE FM=' + (any ? 'on' : 'off') + ' available=['
-      + lenses.filter(function (x) { return x.available; }).map(function (x) { return x.id; }).join(',')
-      + '] (guidMap=' + Object.keys(A.guidMap).length + ')');
+    // §HBA_LAZY (user directive 2026-07-28: "It should only come on if called from the pill. No early
+    // casting needed."). WAS: this tick ran the ENTIRE HBA compile — bindStoreysFromModel() (IfcSpace
+    // footprints, rel_contained_in_space members, the elements_meta aisle-fallback scan, and seven
+    // demonstrator spec seeds) plus the async ad_seed.db fetch in _ensureErpGovern — and then
+    // auto-promoted the hbaFM pill into the rail by flipping acts[i].pill and calling _buildPill().
+    // Two costs, both unasked-for: (1) the pill CAST ITSELF onto the bar on any building with rooms,
+    // (2) all of that DB work landed on the main thread the instant streaming finished — precisely
+    // when a large building is still settling (BVH build, consolidation, bbox ghost).
+    // NOW: nothing runs here. ensureHbaData() does the same work, once, on first real HBA use.
+    // Deep-link (A.FIND_GUID) is an EXPLICIT request, so it still seeds — but only when actually set.
+    if (A.FIND_GUID) { ensureHbaData(A); _consumeFindGuid(A); }
+    console.log('§HBA_LAZY armed — no seed, no pill promotion until the Human-Asset pill is used' +
+      ' (guidMap=' + Object.keys(A.guidMap).length + ', deep_link=' + (A.FIND_GUID ? 'yes' : 'no') + ')');
   }, 500);
 })();

--- a/viewer/helpers.js
+++ b/viewer/helpers.js
@@ -72,6 +72,41 @@ function setupHelpers(A) {
     mesh.visible = anyVisible;
   };
 
+  // ── A.filterMergedMesh(mesh, filterFn) ───────────────────────────────────
+  // §MERGED_GUID (MOBILE_PERF.md §SPEC 2026-07-28 Part 3, item 2). Witness: W-MERGED-FILTER.
+  // ISSUE IT PROVES: a merged mesh has no setVisibleAt, and filterByGuids only ever matched
+  // isMesh-with-userData.guid / isInstancedMesh / isBatchedMesh — so before this, an isolate or
+  // Room Lens left every merged element on screen (silently wrong, not an error).
+  // MECHANISM: hidden elements get their index slice overwritten with a repeated vertex index —
+  // degenerate (zero-area) triangles, discarded at rasterisation. Deliberately NOT index compaction:
+  // compacting would move every later element's idxStart and invalidate the whole range map that
+  // picking and raycasting depend on. Ranges stay pinned; only their CONTENT toggles.
+  // filterFn(meta) → true = visible. meta = A._mergedMeta[mesh.id][i]
+  A.filterMergedMesh = function(mesh, filterFn) {
+    if (!mesh.userData || !mesh.userData.isMerged) return;
+    const meta = A._mergedMeta && A._mergedMeta[mesh.id];
+    if (!meta) return;
+    const geo = mesh.geometry, idxAttr = geo.index;
+    if (!idxAttr) return;
+    const arr = idxAttr.array;
+    // Lazy pristine copy — costs nothing until something actually filters, which on the mobile
+    // path may be never. Kept afterwards: isolate/restore cycles are repeated, not one-shot.
+    let full = geo.userData._fullIndex;
+    if (!full) full = geo.userData._fullIndex = arr.slice();
+    let anyVisible = false, changed = 0;
+    for (let i = 0; i < meta.length; i++) {
+      const m = meta[i], vis = !!filterFn(m);
+      if (vis) anyVisible = true;
+      if (vis === !m.hidden) continue;              // already in the requested state
+      if (vis) arr.set(full.subarray(m.idxStart, m.idxStart + m.idxCount), m.idxStart);
+      else arr.fill(full[m.idxStart], m.idxStart, m.idxStart + m.idxCount);
+      m.hidden = !vis;
+      changed++;
+    }
+    if (changed) idxAttr.needsUpdate = true;
+    mesh.visible = anyVisible;
+  };
+
   // ── A.dbQuery(sql, params) ────────────────────────────────────────────────
   // Safe db.exec wrapper. Returns [] if db not ready or no results.
   // Each item in the returned array is a row-values array (same shape as db.exec rows[0].values).

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -850,7 +850,16 @@ function setupPanels(A) {
     A.collectMeshes(o => o.isBatchedMesh).forEach(mesh => {
       A.filterBatchedMesh(mesh, meta => keep(meta.guid));
     });
-    console.log('[RP-A1] §FILTER_GUIDS ' + (guidSet === null ? 'ALL' : ('isolate=' + guidSet.size)));
+    // §MERGED_GUID: merged meshes are plain isMesh with no userData.guid — they matched NONE of the
+    // three collectors above, so an isolate used to leave them fully visible. Fourth collector, same
+    // keep() predicate, per-element via the index-range map.
+    var _mgVis = 0, _mgMeshes = 0;
+    A.collectMeshes(o => o.userData && o.userData.isMerged).forEach(mesh => {
+      _mgMeshes++;
+      A.filterMergedMesh(mesh, meta => { var k = keep(meta.guid); if (k) _mgVis++; return k; });
+    });
+    console.log('[RP-A1] §FILTER_GUIDS ' + (guidSet === null ? 'ALL' : ('isolate=' + guidSet.size)) +
+      (_mgMeshes ? ' merged_meshes=' + _mgMeshes + ' merged_visible=' + _mgVis : ''));
     A._visibilityGen = (A._visibilityGen|0) + 1;  // §PHOTO_SHADOW_SKIP: shadow-reassert gate needs to see this
     if (A.markDirty) A.markDirty();
   };

--- a/viewer/picking.js
+++ b/viewer/picking.js
@@ -345,7 +345,19 @@ function setupPicking(A) {
       const meta = A._instanceMeta[hit.object.id][hit.instanceId];
       if (meta) guid = meta.guid;
     }
-    // S232: Merged mesh — resolve nearest element by hit-point distance in DB
+    // §MERGED_GUID: Merged mesh — EXACT identity. The custom raycast (streaming.js
+    // _installMergedRaycast) tags each intersection with the guid of the element whose index range
+    // produced the hit, so this is O(1) and cannot pick a neighbour. Witness: W-MERGED-PICK.
+    if (!guid && hit.object.userData.isMerged && hit._mergedGuid) {
+      guid = hit._mergedGuid;
+      var _mr = hit._mergedRange || {};
+      console.log('§MERGED_PICK guid=' + guid + ' idxStart=' + _mr.idxStart +
+        ' storey=' + (_mr.storey || '') + ' disc=' + (_mr.disc || '') + ' class=' + (_mr.ifcClass || ''));
+    }
+    // S232 LEGACY FALLBACK: merged hit with no range tag (merged mesh built before the range map,
+    // or a raycast that bypassed the custom path) — resolve nearest element by hit-point distance
+    // in DB. Approximate by construction: returns the closest CENTROID in the same storey+disc,
+    // which is the wrong element among close-packed neighbours. Kept only as a safety net.
     if (!guid && hit.object.userData.isMerged) {
       // Convert Three.js hit point back to IFC coordinates
       const hp = hit.point;

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -52,7 +52,15 @@ async function setupScene(A) {
     var _dbg = _capGl.getExtension('WEBGL_debug_renderer_info');
     var _gpu = _dbg ? _capGl.getParameter(_dbg.UNMASKED_RENDERER_WEBGL) : 'unknown';
     console.log('§RENDERER_CAPS multi_draw=' + (_md ? 'on (fast batched path)' : 'off (slow — per-draw fallback)') + ' gpu=' + _gpu);
-  } catch(_e) { console.log('§RENDERER_CAPS probe failed: ' + (_e && _e.message)); }
+    // §MERGED_GUID (MOBILE_PERF.md §SPEC 2026-07-28 Part 4): PERSIST the capability — S280c's
+    // `_hasMultiDraw` was computed and thrown away here, which is why the merged low-draw fallback
+    // has been dead since 68bd9a7 (2026-05-27). streaming.js reads this to decide merge routing.
+    // Default TRUE on probe failure = keep the BatchedMesh path (never merge on unknown caps).
+    A._hasMultiDraw = _md;
+  } catch(_e) {
+    A._hasMultiDraw = true;
+    console.log('§RENDERER_CAPS probe failed: ' + (_e && _e.message));
+  }
   // ── Implementing FLY_TOUR_DLOD_SCALE.md §14 (bim-compiler prompts/Viewer/) — GPU capability
   // warning. Witnesses: W-GPU-WARN-FIRSTRUN / -DEGRADED / -RECOVERED / -NONAG.
   // Compares the caps just probed above against the "last known good" signature in localStorage

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -179,6 +179,11 @@ function setupStreaming(A) {
   A._instanceGuids = {}; // guid → {meshId, instanceIndex} for reverse lookup
   A._isMobile = (navigator.maxTouchPoints > 0 && window.screen.width < 1024)
     && !new URLSearchParams(location.search).has('tm');
+  // §MERGED_GUID: `?tm` has always meant "I need per-element slots" — it forced the non-merged path
+  // via _isMobile back when merging was device-gated. Merging is capability-gated now, so carry the
+  // same promise onto the new gate. Set once here and NOT cleared on clearStreamed: TM (which also
+  // sets it) re-streams, and a re-stream that silently re-merged would defeat the whole point.
+  A._forceNoMerge = new URLSearchParams(location.search).has('tm');
   A._bboxPlaceholder = null;
 
   // Per-element wireframe cubes, one InstancedMesh per discipline for disc-based coloring
@@ -965,16 +970,27 @@ function setupStreaming(A) {
   if (!A._batchMeta) A._batchMeta = {};
   if (!A._batchStoreyMap) A._batchStoreyMap = {};
   if (!A._batchDiscMap) A._batchDiscMap = {};
+  // §MERGED_GUID: _mergedMeta[meshId] = [{guid, storey, disc, ifcClass, idxStart, idxCount,
+  //   hidden, minX..maxZ}, ...] — the merged path's slot table. _mergedIndex is the guid→
+  //   {meshId, rangeIdx} reverse lookup (guidMap can't hold it: keyed by mesh.id, one-to-many).
+  if (!A._mergedMeta) A._mergedMeta = {};
+  if (!A._mergedIndex) A._mergedIndex = {};
+  // Raycast accounting — makes the Walk/fly protection MEASURABLE (elements actually triangle-tested
+  // vs elements scanned), so the AABB pre-cull can be proven working instead of assumed.
+  if (!A._mergedRayStats) A._mergedRayStats = { casts: 0, tested: 0, scanned: 0 };
 
   // ── §S280d: Streaming Contract ────────────────────────────────────────────
   // ROUTING RULE (sacred — do NOT change without testing TM, picking, storey/disc filter):
   //   elements.length === 1  → BatchedMesh  → metadata in _batchMeta
   //   elements.length >= 2   → InstancedMesh → metadata in _instanceMeta
-  //   mobile single-instance → MergedMesh    → no per-GUID metadata (merged)
+  //   single-instance, no WEBGL_multi_draw → MergedMesh → metadata in _mergedMeta (§MERGED_GUID,
+  //     2026-07-28: was "no per-GUID metadata"; merged elements now carry full identity via
+  //     index ranges, so picking/filter/TM hold on this path too)
   // CONSUMERS (16 files): time_machine, picking, helpers, walk, dlod, ghostglass,
   //   grid_views, scene, doc_canvas, city, wizard_classify, nlp, tools, main
-  // CONTRACT: every non-merged element must appear in exactly ONE of _batchMeta or
-  //   _instanceMeta, AND have a guidMap entry. Violation = TM/picking/filter breakage.
+  // CONTRACT: every element must appear in exactly ONE of _batchMeta / _instanceMeta /
+  //   _mergedMeta, AND be reachable by guid (guidMap, or _mergedIndex for merged).
+  //   Violation = TM/picking/filter breakage.
 
   // §S280d: Shared metadata registration — used by _flushInstanced AND _flushBboxBatched.
   // Ensures both paths populate the same 4 structures (the contract surface).
@@ -987,6 +1003,71 @@ function setupStreaming(A) {
     if (!A._batchDiscMap[dk]) A._batchDiscMap[dk] = [];
     A._batchDiscMap[dk].push({ mesh: bm, slotId: slotId });
     return { guid: el.guid, storey: el.storey, disc: el.disc, ifcClass: el.ifcClass || '', slotId: slotId, bx: el.bx || 0.3, by: el.by || 0.3, bz: el.bz || 0.3 };
+  };
+
+  // §MERGED_GUID — per-element raycast for merged meshes. Witness: W-MERGED-RAYCAST.
+  // ISSUE IT PROVES: a merged bucket is ONE geometry with no BVH (three-mesh-bvh builds boundsTree
+  // on the shared meshCache source geometries, not on baked merged copies). Plain Mesh.raycast
+  // would brute-force every triangle in the bucket — and sfx.js:445 fly-rayblast casts at 11Hz
+  // during Walk/fly, so that cost would land directly on the mobile navigation path this whole
+  // change is supposed to protect. Two-level instead: ray→element-AABB slab test (a few ns each,
+  // and the AABBs came from the baked vertices so they are exact), then the STOCK Mesh.raycast
+  // restricted by drawRange to just the surviving elements' index slices — stock triangle maths,
+  // stock intersect record (point/face/faceIndex/uv), no hand-rolled geometry.
+  var _mgSphere = null, _mgInvMat = null, _mgRay = null;
+  A._installMergedRaycast = function(mesh) {
+    var _stockRaycast = THREE.Mesh.prototype.raycast;
+    mesh.raycast = function(raycaster, intersects) {
+      var meta = A._mergedMeta[this.id];
+      if (!meta) return _stockRaycast.call(this, raycaster, intersects);
+      var geo = this.geometry, idxAttr = geo.index;
+      if (!idxAttr) return _stockRaycast.call(this, raycaster, intersects);
+
+      // Whole-bucket reject first (stock does this too, but we must do it before the AABB sweep).
+      if (!_mgSphere) { _mgSphere = new THREE.Sphere(); _mgInvMat = new THREE.Matrix4(); _mgRay = new THREE.Ray(); }
+      if (geo.boundingSphere === null) geo.computeBoundingSphere();
+      _mgSphere.copy(geo.boundingSphere).applyMatrix4(this.matrixWorld);
+      if (!raycaster.ray.intersectsSphere(_mgSphere)) return;
+
+      // Ray → this mesh's local space (identity in practice — merged verts are baked world-space —
+      // but never assume it; a parented/offset merged mesh must still pick correctly).
+      _mgInvMat.copy(this.matrixWorld).invert();
+      _mgRay.copy(raycaster.ray).applyMatrix4(_mgInvMat);
+      var ox = _mgRay.origin.x, oy = _mgRay.origin.y, oz = _mgRay.origin.z;
+      var dx = _mgRay.direction.x, dy = _mgRay.direction.y, dz = _mgRay.direction.z;
+      // 1/0 = Infinity would make 0*Infinity = NaN for a ray exactly on a slab plane; a large
+      // finite reciprocal keeps the slab test branch-free and NaN-free.
+      var ix = dx !== 0 ? 1 / dx : 1e30, iy = dy !== 0 ? 1 / dy : 1e30, iz = dz !== 0 ? 1 / dz : 1e30;
+      var near = raycaster.near || 0, far = raycaster.far === undefined ? Infinity : raycaster.far;
+
+      var _prevStart = geo.drawRange.start, _prevCount = geo.drawRange.count;
+      var tested = 0;
+      for (var i = 0; i < meta.length; i++) {
+        var m = meta[i];
+        if (m.hidden) continue;                       // respects filterMergedMesh / Room Lens
+        var t1 = (m.minX - ox) * ix, t2 = (m.maxX - ox) * ix;
+        var tmin = t1 < t2 ? t1 : t2, tmax = t1 < t2 ? t2 : t1;
+        t1 = (m.minY - oy) * iy; t2 = (m.maxY - oy) * iy;
+        var lo = t1 < t2 ? t1 : t2, hi = t1 < t2 ? t2 : t1;
+        if (lo > tmin) tmin = lo;  if (hi < tmax) tmax = hi;
+        t1 = (m.minZ - oz) * iz; t2 = (m.maxZ - oz) * iz;
+        lo = t1 < t2 ? t1 : t2; hi = t1 < t2 ? t2 : t1;
+        if (lo > tmin) tmin = lo;  if (hi < tmax) tmax = hi;
+        if (tmax < 0 || tmin > tmax || tmin > far || tmax < near) continue;
+
+        // Stock triangle intersection, scoped to this element's index slice.
+        geo.setDrawRange(m.idxStart, m.idxCount);
+        var before = intersects.length;
+        _stockRaycast.call(this, raycaster, intersects);
+        for (var k = before; k < intersects.length; k++) {
+          intersects[k]._mergedGuid = m.guid;          // exact identity, O(1) — no faceIndex search
+          intersects[k]._mergedRange = m;
+        }
+        tested++;
+      }
+      geo.setDrawRange(_prevStart, _prevCount);
+      if (A._mergedRayStats) { A._mergedRayStats.casts++; A._mergedRayStats.tested += tested; A._mergedRayStats.scanned += meta.length; }
+    };
   };
 
   A._registerInstanceSlot = function(iMesh, el, instanceIndex) {
@@ -1009,11 +1090,36 @@ function setupStreaming(A) {
     let instancedCount = 0, batchedCount = 0, mergedCount = 0, drawCalls = 0;
     var _prevDrawCalls = 0;
 
-    // ── S232: On mobile, bucket single-instance elements for merge ──
+    // ── S232: bucket single-instance elements for merge (see A._useMerge below) ──
     const mergeBuckets = {};  // key: "storey|disc|rgba" → [{el, geo}, ...]
     // ── S260: On desktop, bucket single-instance elements for BatchedMesh ──
     // §S261: When _useDlodPath, these buckets are passed to _flushBboxBatched instead
     const batchBuckets = {};  // key: "storey|disc|rgba" → [{el, geo}, ...]
+    // §MERGED_GUID (MOBILE_PERF.md §SPEC 2026-07-28) — Witness: W-MERGED-GUID.
+    // WITHOUT WEBGL_multi_draw a BatchedMesh costs ONE DRAW CALL PER SLOT (~13.5K on LTU); merging
+    // the bucket's geometry into one buffer costs one draw per bucket (~200). WITH multi_draw the
+    // BatchedMesh path is already one draw per bucket AND keeps the per-slot APIs, so merging would
+    // only add vertex-baking cost for nothing — hence the gate is the CAPABILITY, not the device.
+    // (68bd9a7's lag was `_useMerge` always-true because `_hasMultiDraw` was never defined; it is
+    // now persisted in scene.js. Default-true on probe failure keeps the safe BatchedMesh path.)
+    // `?merge=1` / `?merge=0` forces the routing either way — the A/B handle for measuring draw
+    // counts on a real device, and how the witness drives the merged path on hardware that has
+    // multi_draw. Parsed once per session, not per flush (this runs every 500-5000 elements).
+    if (A._mergeOverride === undefined) A._mergeOverride = new URLSearchParams(location.search).get('merge');
+    const _mergeOverride = A._mergeOverride;
+    // _forceNoMerge OUTRANKS the override: it is set by TM (and `?tm`) to get per-element slots, and
+    // TM re-streams to obtain them. If `?merge=1` could still win, that re-stream would re-merge,
+    // TM's activate() would see merged meshes again and re-stream again — an infinite unmerge loop
+    // (observed in the probe run before this ordering was fixed, not theorised).
+    const _useMerge = A._forceNoMerge ? false
+                    : _mergeOverride === '1' ? true
+                    : _mergeOverride === '0' ? false
+                    : (A._hasMultiDraw === false);
+    if (_useMerge && !A._mergeLogged) {
+      A._mergeLogged = true;
+      console.log('§MERGE_ROUTE on — multi_draw=' + A._hasMultiDraw + ' mobile=' + A._isMobile +
+        ' override=' + (_mergeOverride === null ? 'none' : _mergeOverride));
+    }
 
     for (const [hash, elements] of Object.entries(A._pendingInstances)) {
       const geo = A.meshCache[hash];
@@ -1044,8 +1150,12 @@ function setupStreaming(A) {
           // bucket + own (Alt+S-gated) material instead of merging into a shared cream BatchedMesh.
           // Positional key.split('|') consumers read parts[0..2] only — 4th field is inert for them.
           const key = (el.storey || '_') + '|' + (el.disc || '_') + '|' + (el.rgba || '_default') + '|' + (el.matVariant || '');
-          if (!batchBuckets[key]) batchBuckets[key] = [];
-          batchBuckets[key].push({ el, geo });
+          // §MERGED_GUID: single target selection — merge bucket or batch bucket, never both.
+          // Applies to §S280e's low-instance elements too: each is baked individually into the
+          // merged buffer with its own index range, so identity survives exactly as for singles.
+          const _target = _useMerge ? mergeBuckets : batchBuckets;
+          if (!_target[key]) _target[key] = [];
+          _target[key].push({ el, geo });
         }
       } else {
         // LOW_INSTANCE_BATCH_MAX+1 or more instances — InstancedMesh (both desktop and mobile)
@@ -1199,11 +1309,14 @@ function setupStreaming(A) {
       _prevDrawCalls = batchedCount;
     }
 
-    // ── S232: Merge single-instance buckets on mobile ──
-    if (A._isMobile) {
+    // ── S232 + §MERGED_GUID: Merge single-instance buckets (no-multi_draw devices) ──
+    if (_useMerge) {
       for (const [key, items] of Object.entries(mergeBuckets)) {
         if (items.length === 0) continue;
         const [storey, disc, rgba] = key.split('|');
+        // §MERGED_GUID: per-element index range map — built inside the existing bake loop below,
+        // so identity costs one array push per element and NO extra geometry pass.
+        const ranges = [];
 
         // Bake transform into vertices and concatenate all geometries in this bucket
         let totalVerts = 0, totalIdx = 0;
@@ -1238,12 +1351,21 @@ function setupStreaming(A) {
           const _nm = new THREE.Matrix3().getNormalMatrix(_m4);
 
           // Bake positions
+          // §MERGED_GUID: accumulate this element's world AABB from the BAKED vertices — exact
+          // under any rotation, and free (we already touch every vertex here). Deliberately NOT
+          // derived from the DB bbox_x/y/z, which is axis-aligned in IFC space and would understate
+          // the world extent of a rotated element.
+          let _eMinX = Infinity, _eMinY = Infinity, _eMinZ = Infinity;
+          let _eMaxX = -Infinity, _eMaxY = -Infinity, _eMaxZ = -Infinity;
           for (let v = 0; v < count; v++) {
             _v.set(srcPos.getX(v), srcPos.getY(v), srcPos.getZ(v));
             _v.applyMatrix4(_m4);
             mergedPos[(vOff + v) * 3] = _v.x;
             mergedPos[(vOff + v) * 3 + 1] = _v.y;
             mergedPos[(vOff + v) * 3 + 2] = _v.z;
+            if (_v.x < _eMinX) _eMinX = _v.x;  if (_v.x > _eMaxX) _eMaxX = _v.x;
+            if (_v.y < _eMinY) _eMinY = _v.y;  if (_v.y > _eMaxY) _eMaxY = _v.y;
+            if (_v.z < _eMinZ) _eMinZ = _v.z;  if (_v.z > _eMaxZ) _eMaxZ = _v.z;
           }
 
           // Bake normals
@@ -1258,6 +1380,7 @@ function setupStreaming(A) {
           }
 
           // Rebase indices
+          const _idxStart = iOff;
           if (srcGeo.index) {
             const srcIdx = srcGeo.index;
             for (let j = 0; j < srcIdx.count; j++) {
@@ -1270,6 +1393,17 @@ function setupStreaming(A) {
             }
             iOff += count;
           }
+          // §MERGED_GUID: the identity record. idxStart/idxCount address this element's slice of
+          // the shared index buffer — the merged equivalent of a BatchedMesh slotId. Everything
+          // downstream (exact picking, per-element hide, promote-on-demand) reads those two numbers;
+          // the AABB pre-culls raycasts so a merged mesh without a BVH stays cheap for Walk/fly ray
+          // probes (sfx.js fly-rayblast, 11Hz) — see mesh.raycast below.
+          ranges.push({
+            guid: el.guid, storey: el.storey, disc: el.disc, ifcClass: el.ifcClass || '',
+            idxStart: _idxStart, idxCount: iOff - _idxStart, hidden: false,
+            bx: el.bx || 0.3, by: el.by || 0.3, bz: el.bz || 0.3,
+            minX: _eMinX, maxX: _eMaxX, minY: _eMinY, maxY: _eMaxY, minZ: _eMinZ, maxZ: _eMaxZ
+          });
           vOff += count;
           vBase += count;
         }
@@ -1285,11 +1419,27 @@ function setupStreaming(A) {
         mesh.userData.disc = disc === '_' ? '' : disc;
         mesh.userData.isMerged = true;
         mesh.userData.mergedCount = items.length;
+        // §MERGED_GUID — CONTRACT REGISTRATION. §S280d's contract says every non-merged element must
+        // live in exactly one of _batchMeta/_instanceMeta with a guidMap entry; merged elements now
+        // satisfy the same shape via _mergedMeta + _mergedIndex, so the "no per-GUID metadata"
+        // exemption is retired. guidMap is NOT written per element (it is keyed by mesh.id, which is
+        // one-to-many here) — _mergedIndex is the reverse lookup instead.
+        A._mergedMeta[mesh.id] = ranges;
+        for (let r = 0; r < ranges.length; r++) {
+          if (ranges[r].guid) A._mergedIndex[ranges[r].guid] = { meshId: mesh.id, rangeIdx: r };
+        }
+        A._mergeActive = true;
+        A._installMergedRaycast(mesh);
         if (!A._storeyVisible(mesh.userData.storey)) mesh.visible = false;
         if (A.hiddenDiscs.size > 0 && A.hiddenDiscs.has(mesh.userData.disc)) mesh.visible = false;
         A.scene.add(mesh);
         mergedCount += items.length;
         drawCalls++;
+      }
+      if (mergedCount > 0) {
+        console.log('§MERGED_FLUSH buckets=' + Object.keys(mergeBuckets).length +
+          ' elements=' + mergedCount + ' draws=' + Object.keys(mergeBuckets).length +
+          ' (BatchedMesh-without-multi_draw would be ' + mergedCount + ')');
       }
     }
 
@@ -1307,19 +1457,29 @@ function setupStreaming(A) {
 
     // §S280d: Contract assertion — verify metadata integrity at final flush
     if (A.streamIdx >= A.streamQueue.length) {
-      var _ca_batch = 0, _ca_inst = 0, _ca_guid = 0, _ca_orphan = 0;
+      var _ca_batch = 0, _ca_inst = 0, _ca_guid = 0, _ca_orphan = 0, _ca_merged = 0, _ca_mgIdx = 0;
       for (var _bmId in A._batchMeta) _ca_batch += A._batchMeta[_bmId].length;
       for (var _imId in A._instanceMeta) _ca_inst += A._instanceMeta[_imId].length;
+      // §MERGED_GUID: merged elements are now a FIRST-CLASS side of the contract — counted here so
+      // "zero metadata" stays a real alarm on the merged path instead of being excused by _isMobile.
+      for (var _mgId in A._mergedMeta) _ca_merged += A._mergedMeta[_mgId].length;
+      _ca_mgIdx = Object.keys(A._mergedIndex).length;
       _ca_guid = Object.keys(A.guidMap).length;
-      var _ca_registered = _ca_batch + _ca_inst;
-      if (!A._isMobile && _ca_registered === 0 && A.streamedCount > 0) {
+      var _ca_registered = _ca_batch + _ca_inst + _ca_merged;
+      if (_ca_registered === 0 && A.streamedCount > 0) {
         console.error('§CONTRACT_FAIL zero metadata entries but streamedCount=' + A.streamedCount +
-          ' — routing broke: no GUIDs in _batchMeta or _instanceMeta. TM/picking will fail.');
+          ' — routing broke: no GUIDs in _batchMeta, _instanceMeta or _mergedMeta. TM/picking will fail.');
       }
-      if (_ca_guid < _ca_registered) {
-        _ca_orphan = _ca_registered - _ca_guid;
-        console.error('§CONTRACT_FAIL guidMap=' + _ca_guid + ' but meta=' + _ca_registered +
+      // guidMap covers the batched+instanced sides; merged identity lives in _mergedIndex instead
+      // (guidMap is keyed by mesh.id, which is one-to-many for a merged bucket).
+      if (_ca_guid < _ca_batch + _ca_inst) {
+        _ca_orphan = (_ca_batch + _ca_inst) - _ca_guid;
+        console.error('§CONTRACT_FAIL guidMap=' + _ca_guid + ' but meta=' + (_ca_batch + _ca_inst) +
           ' — ' + _ca_orphan + ' orphaned GUIDs. Picking will miss elements.');
+      }
+      if (_ca_merged > 0 && _ca_mgIdx === 0) {
+        console.error('§CONTRACT_FAIL merged meta=' + _ca_merged + ' but _mergedIndex is empty' +
+          ' — merged elements unreachable by guid. Lens/isolate will miss them.');
       }
       for (var _ciId in A._instanceMeta) {
         var _ciMeta = A._instanceMeta[_ciId];
@@ -1329,6 +1489,7 @@ function setupStreaming(A) {
         }
       }
       console.log('§CONTRACT_CHECK batch=' + _ca_batch + ' instanced=' + _ca_inst +
+        ' merged=' + _ca_merged + ' mergedIndex=' + _ca_mgIdx +
         ' guidMap=' + _ca_guid + ' streamed=' + A.streamedCount + ' orphans=' + _ca_orphan);
     }
     // §TM_STREAM_RESWEEP: newly-flushed geometry defaults to visible — if Time Machine is
@@ -2168,6 +2329,11 @@ function setupStreaming(A) {
     A._instanceMeta = {};
     A._instanceGuids = {};
     A._matCache = {};
+    // §MERGED_GUID: merged identity dies with the meshes it addressed (index ranges are per-mesh).
+    A._mergedMeta = {};
+    A._mergedIndex = {};
+    A._mergeActive = false;
+    A._mergeLogged = false;
     document.getElementById('s-streamed').textContent = '0';
     document.getElementById('s-building-total').textContent = '0';
     document.getElementById('s-buildings-done').textContent = '0';

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v872';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v873';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4373,11 +4373,23 @@
 
   function activate() {
     if (_active) return;
-    // Mobile merged meshes have no guid — re-stream as individual meshes
+    // §MERGED_GUID: TM mutates elements individually (setMatrixAt/setVisibleAt per slot), which a
+    // merged buffer cannot do — so TM re-streams unmerged. Two corrections to the old trigger:
+    //   (1) condition is _mergeActive (are merged meshes ACTUALLY in the scene), not _isMobile.
+    //       Since 68bd9a7 killed the merge routing, `_isMobile` re-streamed the WHOLE building on
+    //       every mobile TM open for nothing; and with merging now capability-gated rather than
+    //       device-gated, a no-multi_draw DESKTOP has merged meshes too and needs the same unmerge.
+    //   (2) _forceNoMerge makes the re-stream stick — flipping _isMobile no longer disables merging
+    //       (the gate is A._hasMultiDraw), so without this flag the re-stream would just re-merge.
+    // ONE-SHOT: if a re-stream somehow still produced merged meshes, activate normally rather than
+    // re-streaming forever. Belt-and-braces against the loop described above — a spinning
+    // clearStreamed/streamBuilding cycle is a far worse failure than TM opening with merged geometry.
     var app = A();
-    if (app && app._isMobile) {
-      app._isMobile = false;
+    if (app && app._mergeActive && !app._tmUnmergeTried) {
+      app._tmUnmergeTried = true;
+      app._forceNoMerge = true;
       var bld = app.activeBuilding;
+      console.log('§TM_UNMERGE re-streaming ' + (bld || '?') + ' without merge (TM needs per-element slots)');
       app.clearStreamed();
       if (bld) { app.streamBuilding(bld); }
       // Wait for re-stream to finish, then activate

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -831,14 +831,14 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=52" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=53" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
-<script src="helpers.js?v=5" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=57" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
+<script src="streaming.js?v=58" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
-<script src="panels.js?v=42" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
+<script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
-<script src="picking.js?v=29" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
+<script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
@@ -924,7 +924,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=63" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=64" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=1" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
@@ -958,7 +958,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="../hr_bim_asset/ad_attendance.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_attendance.js')"></script>
 <script src="../hr_bim_asset/ad_bom.js?v=1" onerror="console.warn('§LOAD_FAIL hr ad_bom.js')"></script>
 <script src="../hr_bim_asset/iot.js?v=1" onerror="console.warn('§LOAD_FAIL hr iot.js')"></script>
-<script src="hba_lens.js?v=6" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
+<script src="hba_lens.js?v=7" onerror="console.warn('§LOAD_FAIL hba_lens.js')"></script>
 <script src="hba_avatars.js?v=1" onerror="console.warn('§LOAD_FAIL hba_avatars.js')"></script>
 <script src="hba_draggable.js?v=1" onerror="console.warn('§LOAD_FAIL hba_draggable.js')"></script>
 <!-- Mobile card-stack host for the 6 HBA panes (RESUME_HBA_MOBILE_CARD_STACK.md). Loads BETWEEN draggable and


### PR DESCRIPTION
Two mobile-facing changes, both witnessed on a real viewer, plus the same-diff cache bump.

## 1. MergedMesh low-draw path restored, with the GUID contract preserved
The S280c fallback (~200 draws instead of tens of thousands on a device without `WEBGL_multi_draw`) has been **dead code since `68bd9a7` (2026-05-27)**: `_hasMultiDraw` was computed in `scene.js` and thrown away, and the routing that filled `mergeBuckets` was deleted — the merge branch iterated an always-empty object. It was reverted for a real reason: merged geometry had no per-element identity, which broke Time Machine and picking.

Restored **with** identity:
- `scene.js` persists `A._hasMultiDraw`. **The gate is the capability, not the device** — with multi_draw, BatchedMesh is already one draw per bucket and keeps per-slot APIs, so this is inert there.
- `streaming.js` records `{guid, storey, disc, idxStart, idxCount, AABB}` per element inside the existing bake loop → `_mergedMeta` + `_mergedIndex`. AABB comes from the **baked** vertices, so it is exact under rotation.
- `picking.js` resolves the exact guid from the range that produced the hit; the old nearest-centroid SQL guess is demoted to a labelled fallback.
- `helpers.js` `filterMergedMesh()` hides elements via degenerate triangles in their index slice (never compaction — that would invalidate every later `idxStart`); `panels.js` `filterByGuids` gains the fourth collector it was missing, so isolate/Room-Lens no longer leave merged geometry visible.
- `streaming.js` installs a per-element AABB pre-cull on `mesh.raycast` — a merged bucket has no BVH and `sfx.js` fly-rayblast casts at 11Hz during Walk/fly.
- `time_machine.js` triggers the unmerge re-stream on `_mergeActive` (not `_isMobile`, which re-streamed the whole building for nothing on every mobile TM open) and sets `_forceNoMerge`, which **outranks** `?merge=1` — without that ordering the probe hit an unbounded unmerge/re-stream loop.

`?merge=1` / `?merge=0` forces the routing either way — the A/B handle for measuring draw counts on a real device.

## 2. HBA is opt-in — no early casting, no self-promoting pill
User directive: *"It should only come on if called from the pill. No early casting needed."*
`hba_lens.js`'s startup poll used to auto-promote `hbaFM` onto the rail (the two-heads icon appearing unbidden) **and** run the whole HBA compile — IfcSpace footprints, `rel_contained_in_space` members, an `elements_meta` scan, seven demonstrator seeds, plus an async `ad_seed.db` fetch — on the main thread the instant streaming finished, exactly when a large building is still settling. Now the tick logs `§HBA_LAZY` and does nothing; `ensureHbaData()` runs once on first real use (3 wake points, since each is reachable without the others). Deep-links still seed — an explicit request is not an early cast.

## Witnesses (re-run against the merged result, not carried over)
`tests/probe_merged_guid.js` **16/16 PASS**, `tests/probe_hba_lazy.js` **11/11 PASS** — real viewer, real DB, real 3D tap, SW blocked:
- draw calls 420 → 22 (19.1x) on Duplex; 929 merged elements
- same screen point resolves the **same guid** merged vs unmerged
- isolate → exactly 1 of 929 visible; restore → all back
- 60/60 aimed rays hit with 1.38% of elements triangle-tested (the Walk/fly protection)
- `§TM_UNMERGE` exactly once → `mergedMetas=0`, `batchMetas=41`
- no `§HBA_SEED` at load; `§HBA_SEED ms=8.8` on demand; `hbaFM` renders nothing on the rail
- zero PAGEERROR on every run

## Conflict resolutions (both kept BOTH sides)
- `streaming.js`: §S280e's `LOW_INSTANCE_BATCH_MAX=3` kept verbatim; merge/batch target selection applies inside it, so ≤3-instance elements bake individually with their own ranges.
- `panels.js`: upstream's `_visibilityGen` bump kept alongside the new merged collector.

`CACHE_VERSION` v872→v873 + per-script `?v=` busts in the same diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCTQs8TQJc21thzVoT8Rmy