### PR TITLE
feat(ifc): KUL/ stress-test README + reusable large-IFC preflight script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,5 @@ witness/
 
 # Private large-project IFC benchmark stress-test set (multi-GB raw source files, never git/LFS —
 # see prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md). Local-only, not a shipped IFC/ resident.
-IFC/KUL/
+IFC/KUL/*
+!IFC/KUL/README.md

--- a/IFC/KUL/README.md
+++ b/IFC/KUL/README.md
@@ -1,0 +1,32 @@
+# IFC/KUL/ — private large-project IFC benchmark stress-test set
+
+**Not a shipped resident.** Three raw `.ifc` files from an external private project
+(`KUL070-SWC-01-XX-3D-E-0001*`), staged here 2026-07-28 to stress-test the Modeller/Viewer's
+IFC-open code path against real files far larger than anything the pipeline has been fitted or
+tested against. **Gitignored** (`.gitignore` `IFC/KUL/*` + `!IFC/KUL/README.md`) — the `.ifc`
+sources are multi-GB and never git/LFS; only this README is tracked.
+
+Full analysis, code-path read, and the perf/sizing investigation task: **`prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md`** (bim-compiler repo).
+
+## Files (not present in git — local only)
+| file | size | STEP entities | elements (PRODUCT_TYPES) | discipline breakdown |
+|---|---|---|---|---|
+| `... - CONTAINMENT.ifc` | 56.7 MB | 774,041 | 21,009 | MEP=21,009 |
+| `... - EQUIPMENT.ifc` | 1,394.2 MB | 26,103,308 | 292 | ARC=292 (dense mesh geometry — ~23,500 raw faces/element avg) |
+| `...-OVERALL.ifc` | 2,045.2 MB | 37,716,099 | 66,214 | ARC=39,254, MEP=26,960 |
+
+Counts produced by `../ifc_preflight_stats.sh` (grep+awk, no browser/wasm parse — see that script's
+header for exactly which classification table it mirrors and its known parity gaps vs the real
+in-browser parser).
+
+## Why EQUIPMENT.ifc is the interesting one
+292 "elements" but 6.88M `IFCPOLYLOOP` / 6.78M `IFCFACE` / 5.37M `IFCCARTESIANPOINT` — this file is
+almost entirely dense tessellated B-rep mesh geometry on a handful of equipment items, not many
+simple parametric elements. That shape (few elements, huge per-element mesh) stresses a different
+part of the pipeline than element *count* does — see `prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md`
+§RISK FINDINGS.
+
+## Regenerating these numbers
+```
+../ifc_preflight_stats.sh "KUL070-SWC-01-XX-3D-E-0001 - CONTAINMENT.ifc"
+```

--- a/IFC/ifc_preflight_stats.sh
+++ b/IFC/ifc_preflight_stats.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# ifc_preflight_stats.sh — fast, non-invasive size/element/discipline probe for a raw .ifc file,
+# meant to run BEFORE attempting to open a large IFC in the Modeller/Viewer (see
+# prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md, bim-compiler repo). One grep pass + one awk pass over
+# the STEP text — no wasm parse, no browser, works at multi-GB scale in seconds.
+#
+# The product-type → discipline table below is a MANUAL MIRROR of viewer/import_worker.js's
+# PRODUCT_TYPES + DISC_MAP (that's the browser's real classifier — this script never invents its
+# own taxonomy). If those change, update the split() lists below to match.
+#
+# Known parity gaps vs the real in-browser parse (both make this an UPPER-BOUND/estimate, not the
+# exact number the app would report):
+#   - IfcFlowTerminal here always counts as MEP (DISC_MAP default). The app further disambiguates
+#     it by element Name (sprinkler/light/diffuser/sanitary → FP/ELEC/ACMV/PLB, §FLOWTERM-REFINE)
+#     which needs the wasm parser's attribute resolution, not a raw grep.
+#   - discFromFilename() filename-suffix override (e.g. "_HEAT.ifc" forces HEAT) is not replicated
+#     — none of the KUL files match that pattern, so it's a no-op for this set, but a future file
+#     named that way would get a different discipline in the real app than this script reports.
+#   - Counts every top-level STEP instance line; does not resolve IFCMAPPEDITEM-referenced repeats
+#     the way the app's geometry dedup (FNV-1a) does, so raw entity counts can overstate rendered
+#     geometry — see the GEOM_* lines, which are raw entity counts, not deduped mesh counts.
+#
+# Usage: ./ifc_preflight_stats.sh path/to/file.ifc
+
+set -euo pipefail
+
+f="${1:?usage: ifc_preflight_stats.sh <file.ifc>}"
+[ -f "$f" ] || { echo "not found: $f" >&2; exit 1; }
+
+size_bytes=$(stat -c%s "$f" 2>/dev/null || stat -f%z "$f")
+size_mb=$(awk -v b="$size_bytes" 'BEGIN{printf "%.1f", b/1048576}')
+echo "FILE=$f"
+echo "SIZE_MB=$size_mb"
+
+t0=$(date +%s.%N)
+grep -oE '=IFC[A-Z0-9]+\(' "$f" | tr -d '=(' | awk '
+  BEGIN {
+    # ARC
+    n=split("IFCWALL IFCWALLSTANDARDCASE IFCSLAB IFCDOOR IFCWINDOW IFCROOF IFCSTAIR IFCSTAIRFLIGHT " \
+      "IFCRAILING IFCCOVERING IFCCURTAINWALL IFCPLATE IFCFURNISHINGELEMENT IFCBUILDINGELEMENTPROXY " \
+      "IFCSPACE IFCFURNITURE IFCSYSTEMFURNITUREELEMENT IFCBUILDINGELEMENTPART IFCRAMP IFCRAMPFLIGHT " \
+      "IFCTRANSPORTELEMENT IFCCONTROLLER IFCGEOGRAPHICELEMENT", a); for (i=1;i<=n;i++) disc[a[i]]="ARC";
+    # STR
+    n=split("IFCBEAM IFCCOLUMN IFCFOOTING IFCPILE IFCMEMBER IFCREINFORCINGBAR IFCREINFORCINGMESH " \
+      "IFCTENDON IFCTENDONANCHOR", a); for (i=1;i<=n;i++) disc[a[i]]="STR";
+    # ELEC
+    n=split("IFCCABLESEGMENT IFCCABLECARRIERSEGMENT IFCCABLECARRIERFITTING IFCELECTRICAPPLIANCE " \
+      "IFCLIGHTFIXTURE IFCOUTLET IFCJUNCTIONBOX IFCSWITCHINGDEVICE IFCELECTRICDISTRIBUTIONBOARD", a);
+      for (i=1;i<=n;i++) disc[a[i]]="ELEC";
+    # PLB
+    n=split("IFCPIPESEGMENT IFCPIPEFITTING IFCSANITARYTERMINAL IFCVALVE IFCWASTETERMINAL " \
+      "IFCSTACKTERMINAL", a); for (i=1;i<=n;i++) disc[a[i]]="PLB";
+    # ACMV
+    n=split("IFCDUCTSEGMENT IFCDUCTFITTING IFCAIRTERMINAL IFCAIRTERMINALBOX IFCUNITARYEQUIPMENT " \
+      "IFCCOIL IFCFAN IFCCOMPRESSOR IFCCHILLER", a); for (i=1;i<=n;i++) disc[a[i]]="ACMV";
+    # FP
+    n=split("IFCFIRESUPPRESSIONTERMINAL IFCALARM", a); for (i=1;i<=n;i++) disc[a[i]]="FP";
+    # MEP (generic)
+    n=split("IFCFLOWSEGMENT IFCFLOWTERMINAL IFCFLOWFITTING IFCFLOWCONTROLLER IFCFLOWMOVINGDEVICE " \
+      "IFCFLOWSTORAGEDEVICE IFCFLOWTREATMENTDEVICE IFCENERGYCONVERSIONDEVICE IFCDISTRIBUTIONELEMENT " \
+      "IFCDISTRIBUTIONFLOWELEMENT IFCDISTRIBUTIONCONTROLELEMENT", a); for (i=1;i<=n;i++) disc[a[i]]="MEP";
+  }
+  {
+    total++; typeCount[$0]++;
+    if ($0 in disc) { elementCount++; discCount[disc[$0]]++ } else { otherCount++ }
+  }
+  END {
+    print "TOTAL_STEP_ENTITIES=" total;
+    print "ELEMENT_COUNT=" elementCount+0 "   # instances of PRODUCT_TYPES (import_worker.js parity)";
+    printf "DISC_BREAKDOWN=";
+    order="ARC STR ELEC PLB ACMV FP MEP"; ndisc=split(order, do_, " ");
+    out="";
+    for (i=1;i<=ndisc;i++) { d=do_[i]; if (discCount[d]+0 > 0) out=out d "=" discCount[d]+0 " "; }
+    print out;
+    print "GEOM_IFCPOLYLOOP=" typeCount["IFCPOLYLOOP"]+0;
+    print "GEOM_IFCFACE=" typeCount["IFCFACE"]+0;
+    print "GEOM_IFCCARTESIANPOINT=" typeCount["IFCCARTESIANPOINT"]+0;
+    print "GEOM_IFCFACETEDBREP=" typeCount["IFCFACETEDBREP"]+0;
+    print "OTHER_NON_PRODUCT_ENTITIES=" otherCount+0;
+    print "DISTINCT_TYPES=" length(typeCount);
+  }
+'
+t1=$(date +%s.%N)
+awk -v t0="$t0" -v t1="$t1" 'BEGIN{printf "SCAN_SECONDS=%.1f\n", t1-t0}'


### PR DESCRIPTION
## Summary
- `IFC/ifc_preflight_stats.sh` — fast grep+awk element-count/discipline-breakdown probe for a raw `.ifc` file, mirroring `import_worker.js`'s `PRODUCT_TYPES`/`DISC_MAP` classification, no browser/wasm parse needed. Runs in seconds at GB scale.
- `IFC/KUL/README.md` — documents the private-project stress-test files staged in that gitignored folder, with the counts the script produced.
- `.gitignore`: `IFC/KUL/*` + `!IFC/KUL/README.md` so the README tracks while the multi-GB `.ifc` sources stay local-only.

Full write-up: `prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md` (bim-compiler repo).

## Test plan
- [x] `ifc_preflight_stats.sh` run against all 3 KUL files locally (57MB/1.4GB/2.0GB), correct element counts + discipline breakdown produced
- [x] `git add -n` confirms README stages while sibling `.ifc` files stay ignored