### PR TITLE
feat(ifc): preflight script reports unique-shape vs placed-instance counts

### DIFF
--- a/IFC/ifc_preflight_stats.sh
+++ b/IFC/ifc_preflight_stats.sh
@@ -76,6 +76,16 @@ grep -oE '=IFC[A-Z0-9]+\(' "$f" | tr -d '=(' | awk '
     print "GEOM_IFCFACE=" typeCount["IFCFACE"]+0;
     print "GEOM_IFCCARTESIANPOINT=" typeCount["IFCCARTESIANPOINT"]+0;
     print "GEOM_IFCFACETEDBREP=" typeCount["IFCFACETEDBREP"]+0;
+    # Instancing: IFCREPRESENTATIONMAP defines a shape ONCE; IFCMAPPEDITEM is a placed instance of
+    # it (like a block insert). UNIQUE_SHAPE_DEFS is the real "how many distinct meshes" number —
+    # ELEMENT_COUNT (placed elements) can be far higher than this when a catalog part repeats.
+    # NOT every element goes through a mapped item — IFCEXTRUDEDAREASOLID direct/parametric solids
+    # (walls, slabs, straight runs) are unique per placement and never show up in this reuse count.
+    umap = typeCount["IFCREPRESENTATIONMAP"]+0; mitem = typeCount["IFCMAPPEDITEM"]+0;
+    print "UNIQUE_SHAPE_DEFS(IFCREPRESENTATIONMAP)=" umap;
+    print "INSTANCED_PLACEMENTS(IFCMAPPEDITEM)=" mitem;
+    if (umap > 0) printf "AVG_REUSE_PER_SHAPE=%.1f\n", mitem/umap;
+    print "DIRECT_PARAMETRIC_SOLIDS(IFCEXTRUDEDAREASOLID, not instanced)=" typeCount["IFCEXTRUDEDAREASOLID"]+0;
     print "OTHER_NON_PRODUCT_ENTITIES=" otherCount+0;
     print "DISTINCT_TYPES=" length(typeCount);
   }


### PR DESCRIPTION
## Summary
`IFC/ifc_preflight_stats.sh` now also reports `UNIQUE_SHAPE_DEFS` (IFCREPRESENTATIONMAP),
`INSTANCED_PLACEMENTS` (IFCMAPPEDITEM), `AVG_REUSE_PER_SHAPE`, and
`DIRECT_PARAMETRIC_SOLIDS` (IFCEXTRUDEDAREASOLID, never instanced) — free from the existing
single-pass tally, no extra scan. Answers "how many unique meshes vs placed elements" for a
raw .ifc without a real parse.

Follow-up on bim-ootb#1076, prompted by a live Q&A in `prompts/IFC_LARGE_PRIVATE_STRESS_TEST.md`
(bim-compiler) about whether 37.7M (raw STEP entity count) vs 66,214 (placed elements) vs unique
mesh count were being conflated.

## Test plan
- [x] Re-ran against OVERALL.ifc: UNIQUE_SHAPE_DEFS=6524, INSTANCED_PLACEMENTS=71355, AVG_REUSE_PER_SHAPE=10.9