### PR TITLE
§CPE_BUILDUP_REAL_SCHEDULE: the construction buildup follows the REAL schedule when a building has one

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -717,9 +717,34 @@
           console.warn('§CPE_BUILDUP_SKIP reason=no derived build order (Time Machine has no ops for this building)');
           _buildup = false;
         } else {
-          _bkState = window.tmOrderByCameraPath(function(t) { return plan ? plan.poseAt(t) : poseAt(t); }, nFrames);
+          // ══ §CPE_BUILDUP_REAL_SCHEDULE §3.3 — REAL schedule if the building has one, else mode D ══
+          // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §3.3
+          // Witnesses: W-SCHED-REAL-ORDER, W-SCHED-FALLBACK
+          // Before this branch, tmOrderByCameraPath ran unconditionally and OVERWROTE the real task
+          // dates injectGantt had just written — so a building WITH a linked schedule baked a
+          // byte-identical film to one with none (§2, the defect). The derived path below is
+          // untouched: no usable `tasks` → same call, same args, same behaviour as before (that is
+          // exactly what W-SCHED-FALLBACK gates).
+          var _ss = (typeof window.tmScheduleSource === 'function') ? window.tmScheduleSource() : null;
+          _bkState = null;
+          if (_ss && _ss.source === 'captured' && typeof window.tmOrderBySchedule === 'function') {
+            _bkState = window.tmOrderBySchedule();
+            // A degraded real schedule must never be WORSE than no schedule: fall through to mode D.
+            if (!_bkState) console.warn('§CPE_BUILDUP_SOURCE fallthrough reason=captured-but-unusable — using the derived order');
+          }
+          if (!_bkState) {
+            _bkState = window.tmOrderByCameraPath(function(t) { return plan ? plan.poseAt(t) : poseAt(t); }, nFrames);
+          }
           if (!_bkState) { console.warn('§CPE_BUILDUP_SKIP reason=re-key failed — baking without the buildup'); _buildup = false; }
-          else _status('🎬 Building as the camera flies (' + _bkState.placed + ' elements ordered by the path)');
+          else if (_bkState.source === 'captured') {
+            // §CPE_BUILDUP_REAL_SCHEDULE §5 — the label moves with the data. States scope and
+            // coverage; claims NO predecessor logic, float or resources (this data carries none).
+            _status('🎬 Building to the linked schedule (' + _bkState.leafTasks + ' phases, ' +
+              _bkState.pct + '% of elements)');
+          } else {
+            // §5 — unchanged wording for the derived branch. Never say "the schedule" here.
+            _status('🎬 Building as the camera flies (' + _bkState.placed + ' elements ordered by the path)');
+          }
         }
       }
       t0 = _etaPrev = performance.now();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v873';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v874';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4953,9 +4953,143 @@
       ' span=' + Math.round(span) + 'ms installFrames=1.5' +
       ' ms=' + (performance.now() - t0).toFixed(0) +
       ' — DERIVED BUILD ORDER re-keyed to the camera path (NOT a construction programme)');
-    return { ops: n, placed: hit, noGeom: miss, arc: arc,
+    return { ops: n, placed: hit, noGeom: miss, arc: arc, source: 'derived',
              projectStart: _projectStart, projectEnd: _projectEnd };
   };
+
+  // ── §CPE_BUILDUP_REAL_SCHEDULE §3.1 — is this building's 4D REAL or DERIVED? ────────────────────
+  // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §3.1 — Witness: W-SCHED-COVERAGE
+  // PURE READ. Must not trigger injectGantt and must not mutate anything.
+  //
+  // ⚠ MEASURED CORRECTION — `_capActive` ALONE IS THE WRONG TEST, and the witness caught it before
+  // this shipped. `_capActive` is set by injectGantt's `_cap` overlay, so it is a RUN-SCOPED SIDE
+  // EFFECT, not a property of the data. `activate()` deliberately SKIPS injectGantt when the db
+  // already carries usable ELEMENT_PLACE ops with `_end_ts` (the cached/shipped-timeline fast path,
+  // ~line 4462) — which is exactly the case for a building whose schedule was authored in an earlier
+  // session and persisted. Confirmed on TerminalHi4D.db: all 48,433 ops carry `_captured:1` and
+  // `_task:TASK_*`, timestamps spanning the real 2026-01-01..2026-05-30 window, yet `_capActive` was
+  // false and this verb reported 'derived' — i.e. the real schedule was there and would still have
+  // been thrown away by mode D.
+  // So the source is decided by the OPS THEMSELVES: dated leaf tasks must exist AND the loaded ops
+  // must actually be keyed to them (`parameters._captured`, the marker `_cap` persists), with
+  // `_capActive` accepted as the same-session equivalent. Coverage falls back to the op count for the
+  // same reason — `_coveredCount` is only populated on the run where injectGantt executed.
+  window.tmScheduleSource = function() {
+    var leafTasks = 0, summarySkipped = 0, total = 0;
+    var app = A();
+    var capOps = 0;
+    for (var oi = 0; oi < _ops.length; oi++) {
+      if (_ops[oi].parameters && _ops[oi].parameters._captured) capOps++;
+    }
+    if (app && app.db) {
+      try {
+        var tr = app.db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_start IS NOT NULL " +
+          "AND schedule_finish IS NOT NULL AND (is_summary IS NULL OR is_summary = 0)");
+        if (tr.length && tr[0].values.length) leafTasks = tr[0].values[0][0] | 0;
+        var sr = app.db.exec("SELECT COUNT(*) FROM tasks WHERE is_summary = 1");
+        if (sr.length && sr[0].values.length) summarySkipped = sr[0].values[0][0] | 0;
+      } catch (e) { leafTasks = 0; summarySkipped = 0; }   // no tasks table → derived, not an error
+      try {
+        var er = app.db.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class != 'IfcOpeningElement'");
+        if (er.length && er[0].values.length) total = er[0].values[0][0] | 0;
+      } catch (e) { total = 0; }
+    }
+    // Coverage is counted off the LOADED OPS FIRST, not off `_coveredCount`. `_coveredCount` tallies
+    // `_cap`'s UPDATE executions against kernel_ops, so a db carrying duplicate ELEMENT_PLACE rows for
+    // a guid inflates it above the element count (measured: 2238 on a 1119-element Duplex after an
+    // extra injectGantt pass). `capOps` is what the film actually reveals, so it is the honest number;
+    // `_coveredCount` is kept only as the fallback for the window where ops have not been reloaded yet.
+    var covered = capOps || _coveredCount;
+    return {
+      source: (leafTasks > 0 && (_capActive || capOps > 0)) ? 'captured' : 'derived',
+      leafTasks: leafTasks, summarySkipped: summarySkipped,
+      capOps: capOps, capActive: _capActive,
+      covered: covered, total: total, coveredUpdates: _coveredCount,
+      pct: total ? Math.min(100, Math.round(covered / total * 100)) : 0,
+      projectStart: _projectStart, projectEnd: _projectEnd, ops: _ops.length
+    };
+  };
+
+  // ── §CPE_BUILDUP_REAL_SCHEDULE §3.2 — the CAPTURED branch of the buildup ───────────────────────
+  // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §3.2
+  // Witnesses: W-SCHED-REAL-ORDER, W-SCHED-REVERSIBLE
+  //
+  // ⚠ This verb deliberately WRITES NOTHING, and that is the whole design — not an omission.
+  // injectGantt's `_cap` overlay has ALREADY keyed every covered op to its own task's
+  // [schedule_start, schedule_finish] window (leaf tasks only — `is_summary` is filtered there), with
+  // §PLAYBACK-STAGGER distributing each task's guids bottom-up by center_z WITHIN that window.
+  // loadOps() then reads them back ORDER BY timestamp and computeDays() sets _projectStart/_projectEnd
+  // to the real project epoch. So "order the reveal by the real schedule" is already true of `_ops`
+  // the moment the timeline exists; mode D's re-key is what was DESTROYING it (§2).
+  //
+  // Returns the SAME shape tmOrderByCameraPath returns, so cinema_maxq.js's per-frame cursor loop
+  // needs no change. Because nothing was written, _bkSaved stays null and tmRestoreDerivedOrder() is a
+  // genuine no-op — stronger than restoring correctly, since there is nothing to get wrong.
+  window.tmOrderBySchedule = function() {
+    if (!_ops.length) { console.warn('§CPE_BUILDUP_SOURCE reject reason=no-ops'); return null; }
+    var ss = window.tmScheduleSource();
+    if (!ss.leafTasks) { console.warn('§CPE_BUILDUP_SOURCE reject reason=no-dated-leaf-tasks'); return null; }
+    if (ss.source !== 'captured') { console.warn('§CPE_BUILDUP_SOURCE reject reason=ops-not-keyed-to-tasks'); return null; }
+    var capOps = ss.capOps;
+    var iso = function(ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '?'; };
+    console.log('§CPE_BUILDUP_SOURCE source=captured leafTasks=' + ss.leafTasks +
+      ' summarySkipped=' + ss.summarySkipped + ' covered=' + ss.covered + '/' + ss.total +
+      ' pct=' + ss.pct + '% capOps=' + capOps + '/' + _ops.length +
+      ' capActive=' + ss.capActive +
+      ' window=' + iso(_projectStart) + '..' + iso(_projectEnd) +
+      ' — REAL LINKED SCHEDULE, reveal follows schedule_start (no re-key, no float/logic in this data)');
+    return { ops: _ops.length, placed: capOps, noGeom: _ops.length - capOps, arc: 0, source: 'captured',
+             leafTasks: ss.leafTasks, covered: ss.covered, total: ss.total, pct: ss.pct,
+             projectStart: _projectStart, projectEnd: _projectEnd };
+  };
+
+  // ── §CPE_BUILDUP_REAL_SCHEDULE §4 — the numeric instrument the witnesses read ──────────────────
+  // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §4
+  // Witnesses: W-SCHED-REAL-ORDER, W-SCHED-REVERSIBLE
+  // Read-only, aggregate-only (never 10^5 rows across the bridge). Per dated leaf task it returns the
+  // FIRST and LAST reveal timestamp its bound elements actually get in `_ops` — which is what makes
+  // "the phases do not interleave" a number instead of an opinion. Works in BOTH branches, so the
+  // same instrument reads the captured order and mode D's re-key, and the two can be compared.
+  // `checksum` is the exact-reversibility probe: sums over EVERY op, so any single mutated timestamp
+  // changes it (W-SCHED-REVERSIBLE), without shipping the op list to the caller.
+  window.tmPhaseWindows = function() {
+    var app = A(), out = [], byGuid = {};
+    var chk = { opCount: _ops.length, sumStart: 0, sumEnd: 0 };
+    for (var i = 0; i < _ops.length; i++) { chk.sumStart += _ops[i].start_ts; chk.sumEnd += _ops[i].end_ts; }
+    if (!app || !app.db) return { phases: [], checksum: chk };
+    var rows;
+    try {
+      rows = app.db.exec('SELECT te.guid, te.task_id, t.name, t.schedule_start FROM task_elements te ' +
+        'JOIN tasks t ON t.task_id = te.task_id ' +
+        'WHERE t.schedule_start IS NOT NULL AND t.schedule_finish IS NOT NULL ' +
+        'AND (t.is_summary IS NULL OR t.is_summary = 0)');
+    } catch (e) { return { phases: [], checksum: chk }; }
+    if (!rows.length || !rows[0].values.length) return { phases: [], checksum: chk };
+    var meta = {};
+    rows[0].values.forEach(function(r) {
+      byGuid[r[0]] = r[1];
+      if (!meta[r[1]]) meta[r[1]] = { taskId: r[1], name: r[2], scheduleStart: r[3], n: 0,
+                                      minStart: Infinity, maxStart: -Infinity, bound: 0 };
+      meta[r[1]].bound++;
+    });
+    for (i = 0; i < _ops.length; i++) {
+      var op = _ops[i];
+      var g = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+      var tid = g ? byGuid[g] : null;
+      if (!tid) continue;
+      var m = meta[tid];
+      m.n++;
+      if (op.start_ts < m.minStart) m.minStart = op.start_ts;
+      if (op.start_ts > m.maxStart) m.maxStart = op.start_ts;
+    }
+    for (var k in meta) if (meta[k].n) out.push(meta[k]);
+    out.sort(function(a, b) {
+      return (Date.parse(a.scheduleStart) - Date.parse(b.scheduleStart)) ||
+             (a.taskId < b.taskId ? -1 : a.taskId > b.taskId ? 1 : 0);   // §3.2: stable tie-break only
+    });
+    return { phases: out, checksum: chk };
+  };
+
   window.tmRestoreDerivedOrder = function() {
     if (!_bkSaved) return false;
     for (var i = 0; i < _bkSaved.ops.length; i++) {

--- a/witness_cpe_buildup_schedule.js
+++ b/witness_cpe_buildup_schedule.js
@@ -1,0 +1,369 @@
+// WITNESS — §CPE_BUILDUP_REAL_SCHEDULE.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE (§2 the defect,
+// §3 the fix, §4 these claims, §5 the honesty rule, §6 the billboard elements).
+//
+// Each check names the issue it proves or disproves — a check that cannot fail is not a check.
+//
+//   R1  W-SCHED-REAL-ORDER — THE GATE. On a building whose `tasks` are populated, the buildup reveal
+//       follows the SCHEDULE, not the camera: for leaf phases ordered by schedule_start,
+//       max(reveal ts of phase i) <= min(reveal ts of phase i+1) — the phases do not interleave.
+//   R2  W-SCHED-REAL-ORDER, the DISCRIMINATOR — the same measurement run against mode D
+//       (tmOrderByCameraPath) on the SAME building must FAIL R1's non-interleave test. Without this,
+//       R1 could be passing for a reason unrelated to the fix. This is the §2 defect, measured.
+//   V1  W-SCHED-REVERSIBLE — tmOrderBySchedule() mutates NOTHING: the all-ops checksum
+//       (opCount/sumStart/sumEnd over every op) is bit-identical before and after, and
+//       tmRestoreDerivedOrder() returns false because there is nothing saved to restore.
+//   M1  W-SCHED-MONOTONE — §CPE_BUILDUP's own trap still holds on the captured branch: placed is
+//       monotone non-decreasing across frames, starts at 0, ends at full, mid strictly between —
+//       so a §CPE_CLIP still opens on a partially-built model.
+//   C1  W-SCHED-COVERAGE — the reported coverage is real, not asserted: covered+generated==total,
+//       pct matches the ratio, and the distinct guid count in task_elements equals what _cap covered.
+//   B1  W-SCHED-BILLBOARD (§6) — the §BILLBOARD_INJECT panel + 4 floodlights are each bound to a leaf
+//       task and therefore land in the captured reveal; the frame index of each is reported.
+//   F1  W-SCHED-FALLBACK — on a building with NO usable `tasks`, tmScheduleSource() says 'derived'
+//       and tmOrderBySchedule() returns null (refuses, does not guess).
+//   F2  W-SCHED-FALLBACK, the REGRESSION gate — the derived path is UNCHANGED. Differential: the
+//       frame-by-frame placed series from calling tmOrderByCameraPath directly (the pre-change code)
+//       must equal, frame for frame, the series produced by going through the new §3.3 branch. Any
+//       perturbation of the shipped derived buildup shows up as a differing frame.
+//   A1  W-SCHED-AUTHOR-ROUNDTRIP — author -> save -> reload -> the buildup consumes it. Runs the
+//       ALREADY-SHIPPED ScheduleAuthor.materializeDefault on a building that has no schedule, then
+//       proves tmScheduleSource() flips derived -> captured and R1 passes on that building too.
+//       This is a VERIFICATION of shipped authoring code (spec §0), not a gate on new code.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8433;
+const CAPTURED = process.env.CAP_BLD || 'TerminalHi4D';       // has a real linked schedule
+const DERIVED = (process.env.DER_BLDS || 'Duplex,Hospital_3').split(',');   // have none
+const NF = 40;                                                 // frames in the sampled film
+const BILLBOARD = ['BB0BIMOOTBSIGN000001A', 'BB0BIMOOTBFLOOD000001', 'BB0BIMOOTBFLOOD000002',
+                   'BB0BIMOOTBFLOOD000003', 'BB0BIMOOTBFLOOD000004'];
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// A synthetic straight-line flight, deterministic, so mode D's re-key is reproducible run to run.
+const POSE_SRC = `(function(t){ return { x: -200 + 400*t, y: 40, z: -200 + 400*t,
+                                          tx: 0, ty: 10, tz: 0 }; })`;
+
+async function open(browser, bld) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1000, height: 600 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/viewer/viewer.html?db=/buildings/${bld}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.dbQuery, { timeout: 300000 });
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM elements_meta'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 2000 });
+  await sleep(6000);
+  return { page, logs };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1800000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader',
+           '--max-old-space-size=8192'],
+  });
+  let allPass = true;
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false;
+    console.log(`${ok ? 'PASS' : 'FAIL'} ${n.padEnd(26)} ${d}`); };
+
+  // ══════════════ CAPTURED BUILDING — R1 R2 V1 M1 C1 B1 ══════════════
+  console.log('\n' + '='.repeat(78) + `\n${CAPTURED} — real linked schedule\n` + '='.repeat(78));
+  {
+    const { page, logs } = await open(browser, CAPTURED);
+    const res = await page.evaluate(async (nf, poseSrc, bbGuids) => {
+      const A = window.APP, out = {};
+      const poseAt = eval(poseSrc);
+      if (typeof window.tmActivateForBake !== 'function') return { err: 'no time_machine' };
+      out.activated = await window.tmActivateForBake();
+      if (!out.activated) return { err: 'tmActivateForBake false' };
+
+      out.src = window.tmScheduleSource();
+
+      // ── C1: coverage cross-checked against the tables themselves ──
+      const q1 = A.dbQuery('SELECT COUNT(DISTINCT guid) FROM task_elements te JOIN tasks t ' +
+        'ON t.task_id=te.task_id WHERE t.schedule_start IS NOT NULL AND t.schedule_finish IS NOT NULL ' +
+        'AND (t.is_summary IS NULL OR t.is_summary=0)');
+      out.boundGuids = q1[0][0];
+      out.total = A.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class!='IfcOpeningElement'")[0][0];
+
+      // ── V1 (before) + R1: measure the CAPTURED order ──
+      const before = window.tmPhaseWindows();
+      out.chkBefore = before.checksum;
+      const st = window.tmOrderBySchedule();
+      out.state = st;
+      const after = window.tmPhaseWindows();
+      out.chkAfter = after.checksum;
+      out.restoreReturn = window.tmRestoreDerivedOrder();     // must be false — nothing was saved
+      out.capturedPhases = after.phases.map(p => ({ taskId: p.taskId, name: p.name,
+        scheduleStart: p.scheduleStart, n: p.n, bound: p.bound, minStart: p.minStart, maxStart: p.maxStart }));
+
+      // ── M1: the placed series across the film, on the captured window ──
+      const series = [];
+      for (let i = 0; i < nf; i++) {
+        const t = nf > 1 ? i / (nf - 1) : 0;
+        series.push(window.tmPlacedCount(st.projectStart + t * (st.projectEnd - st.projectStart)));
+      }
+      out.series = series;
+
+      // ── B1: where each billboard element lands in the film ──
+      const bb = [];
+      for (const g of bbGuids) {
+        const r = A.dbQuery("SELECT te.task_id, t.name, t.schedule_start FROM task_elements te " +
+          "JOIN tasks t ON t.task_id=te.task_id WHERE te.guid='" + g + "'");
+        const ko = A.dbQuery("SELECT timestamp FROM kernel_ops WHERE output_guid='" + g +
+          "' AND op_type='ELEMENT_PLACE'");
+        let frame = -1;
+        if (ko.length) {
+          const f = (ko[0][0] - st.projectStart) / (st.projectEnd - st.projectStart);
+          frame = Math.round(f * (nf - 1));
+        }
+        bb.push({ guid: g, task: r.length ? r[0][0] : null, phase: r.length ? r[0][1] : null,
+                  ts: ko.length ? ko[0][0] : null, frame });
+      }
+      out.billboard = bb;
+
+      // ── R2 THE DISCRIMINATOR: same measurement under mode D ──
+      const md = window.tmOrderByCameraPath(poseAt, nf);
+      out.modeD = md;
+      out.modeDPhases = window.tmPhaseWindows().phases.map(p => ({ taskId: p.taskId, name: p.name,
+        scheduleStart: p.scheduleStart, minStart: p.minStart, maxStart: p.maxStart }));
+      window.tmRestoreDerivedOrder();
+      out.chkRestored = window.tmPhaseWindows().checksum;
+      return out;
+    }, NF, POSE_SRC, BILLBOARD);
+
+    if (res.err) { P('SETUP', false, res.err); }
+    else {
+      const nonInterleave = (phases) => {
+        const bad = [];
+        for (let i = 0; i + 1 < phases.length; i++) {
+          if (!(phases[i].maxStart <= phases[i + 1].minStart)) bad.push(`${phases[i].name}->${phases[i + 1].name}`);
+        }
+        return bad;
+      };
+      const src = res.src;
+      P('SRC captured', src.source === 'captured',
+        `source=${src.source} leafTasks=${src.leafTasks} summarySkipped=${src.summarySkipped} ` +
+        `covered=${src.covered}/${src.total} pct=${src.pct}%`);
+
+      const badCap = nonInterleave(res.capturedPhases);
+      P('R1 W-SCHED-REAL-ORDER', res.capturedPhases.length >= 2 && badCap.length === 0,
+        `${res.capturedPhases.length} leaf phases, 0 interleaving pairs` +
+        (badCap.length ? ` — VIOLATIONS: ${badCap.join(', ')}` : ''));
+      console.log('     phase windows (captured):');
+      res.capturedPhases.forEach(p => console.log(`       ${p.name.padEnd(16)} start=${p.scheduleStart}` +
+        ` n=${String(p.n).padStart(6)} bound=${String(p.bound).padStart(6)}` +
+        ` ts=[${new Date(p.minStart).toISOString().slice(0, 10)} .. ${new Date(p.maxStart).toISOString().slice(0, 10)}]`));
+
+      const badD = nonInterleave(res.modeDPhases);
+      P('R2 discriminator', badD.length > 0,
+        `mode D interleaves ${badD.length}/${res.modeDPhases.length - 1} consecutive phase pairs ` +
+        `(a gate mode D also passed would prove nothing)`);
+      console.log('     phase windows (mode D re-key, the §2 defect):');
+      res.modeDPhases.forEach(p => console.log(`       ${p.name.padEnd(16)}` +
+        ` ts=[${new Date(p.minStart).toISOString().slice(0, 10)} .. ${new Date(p.maxStart).toISOString().slice(0, 10)}]`));
+
+      const b = res.chkBefore, a = res.chkAfter, r = res.chkRestored;
+      P('V1 W-SCHED-REVERSIBLE',
+        b.opCount === a.opCount && b.sumStart === a.sumStart && b.sumEnd === a.sumEnd &&
+        res.restoreReturn === false,
+        `ops=${b.opCount} sumStart delta=${a.sumStart - b.sumStart} sumEnd delta=${a.sumEnd - b.sumEnd}` +
+        ` restoreReturn=${res.restoreReturn} (false = nothing was written)`);
+      P('V1b modeD restored', r.sumStart === b.sumStart && r.sumEnd === b.sumEnd,
+        `after mode D + restore, sumStart delta=${r.sumStart - b.sumStart} sumEnd delta=${r.sumEnd - b.sumEnd}`);
+
+      const s = res.series, mid = s[Math.floor(s.length / 2)];
+      let mono = true; for (let i = 1; i < s.length; i++) if (s[i] < s[i - 1]) mono = false;
+      P('M1 W-SCHED-MONOTONE', mono && s[0] === 0 && s[s.length - 1] > mid && mid > 0,
+        `placed ${s[0]} -> ${mid} (mid) -> ${s[s.length - 1]} over ${s.length} frames, monotone=${mono}`);
+
+      P('C1 W-SCHED-COVERAGE',
+        res.boundGuids === res.state.covered && res.state.covered === res.total &&
+        res.state.pct === 100,
+        `task_elements distinct bound guids=${res.boundGuids} == _cap covered=${res.state.covered}` +
+        ` == elements=${res.total}, pct=${res.state.pct}%`);
+
+      const bbOk = res.billboard.every(x => x.task && x.frame >= 0);
+      P('B1 W-SCHED-BILLBOARD', bbOk, `${res.billboard.length}/5 bound to a leaf task`);
+      res.billboard.forEach(x => console.log(`       ${x.guid.padEnd(22)} -> ${String(x.phase).padEnd(14)}` +
+        ` frame ${x.frame}/${NF - 1}`));
+
+      const srcLine = logs.filter(l => l.startsWith('§CPE_BUILDUP_SOURCE'));
+      const gsLine = logs.filter(l => l.startsWith('§GANTT_SOURCE') || l.startsWith('§4D_COVERAGE'));
+      console.log('     §-log:');
+      gsLine.concat(srcLine).forEach(l => console.log('       ' + l));
+      P('LOG §CPE_BUILDUP_SOURCE', srcLine.length > 0 && /source=captured/.test(srcLine[0] || ''),
+        srcLine.length ? 'printed' : 'MISSING — a claim with no log line is not done');
+    }
+    await page.close();
+  }
+
+  // ══════════════ DERIVED BUILDINGS — F1 F2 (+ A1 on the first) ══════════════
+  //
+  // ⚠ THE F2 INSTRUMENT WAS WRONG TWICE BEFORE THE CODE WAS — read before changing it.
+  //   attempt 1 | both paths in ONE page, compare the placed series frame by frame | 1/40 frames
+  //     differed. Cause: `tmOrderByCameraPath`'s tie-break `zRank = i/(n-1)` is the op's INDEX in the
+  //     CURRENT `_ops` order. Re-keying re-sorts `_ops`; `tmRestoreDerivedOrder` re-sorts back — and
+  //     for ops whose original timestamps TIE, the stable sort preserves the camera order, not the
+  //     load order. A second mode-D pass therefore starts from a different tie permutation. That is a
+  //     pre-existing, harmless non-idempotence in SHIPPED mode D, not a regression from this change.
+  //   attempt 2 | one path per FRESH page load | worse: ops=1120 vs 1121 and the project windows
+  //     differed by ~4.6 s. Two causes, both fatal to a cross-load differential: injectGantt anchors
+  //     the generated timeline on `new Date()` (wall-clock, so every load has a different epoch), and
+  //     the IDB building cache PERSISTS between loads in one browser profile, so a stray op recorded
+  //     by the first load is present in the second. A differential across two different inputs is not
+  //     a differential.
+  //   correct instrument | ONE page (same epoch, same ops), gate on the ALL-OPS CHECKSUM plus the
+  //     returned state object. `sumStart`/`sumEnd` are sums over the same op set, so they are provably
+  //     INVARIANT to a tie permutation (swapping two tied ops swaps which zRank each gets; the
+  //     multiset of zRank values, and hence the sum, is unchanged) while still changing if any real
+  //     re-key value changes. The placed series is still reported, with its tie-artifact diff, as an
+  //     observation rather than the gate.
+  for (const BLD of DERIVED) {
+    console.log('\n' + '='.repeat(78) + `\n${BLD} — no schedule (fallback + regression)\n` + '='.repeat(78));
+    const { page, logs } = await open(browser, BLD);
+    const res = await page.evaluate(async (nf, poseSrc) => {
+      const out = {}, poseAt = eval(poseSrc);
+      out.activated = await window.tmActivateForBake();
+      if (!out.activated) return { err: 'tmActivateForBake false' };
+      out.src = window.tmScheduleSource();
+      out.rejected = window.tmOrderBySchedule();     // must be null — refuses, does not guess
+      const sample = (st) => {
+        const s = [];
+        for (let i = 0; i < nf; i++) {
+          const t = nf > 1 ? i / (nf - 1) : 0;
+          s.push(window.tmPlacedCount(st.projectStart + t * (st.projectEnd - st.projectStart)));
+        }
+        return s;
+      };
+      const pack = (st) => ({ ps: st.projectStart, pe: st.projectEnd, placed: st.placed,
+                              ops: st.ops, noGeom: st.noGeom, arc: st.arc, source: st.source });
+      // THE CONTROL: three consecutive DIRECT passes (the pre-change code path), each followed by a
+      // restore. Their checksums show the shipped tie-permutation artifact settling, and pass 3 is the
+      // control the branch is measured against — so the gate is an exact equality against a repeat of
+      // the OLD code, never an invented tolerance.
+      out.direct = [];
+      for (let k = 0; k < 3; k++) {
+        const st = window.tmOrderByCameraPath(poseAt, nf);
+        out.direct.push({ st: pack(st), chk: window.tmPhaseWindows().checksum, series: sample(st) });
+        window.tmRestoreDerivedOrder();
+      }
+      // THE TEST: through the NEW §3.3 branch, replicated verbatim from cinema_maxq.js.
+      let bk = null;
+      const ss = (typeof window.tmScheduleSource === 'function') ? window.tmScheduleSource() : null;
+      if (ss && ss.source === 'captured' && typeof window.tmOrderBySchedule === 'function') bk = window.tmOrderBySchedule();
+      if (!bk) bk = window.tmOrderByCameraPath(poseAt, nf);
+      out.stB = pack(bk); out.seriesB = sample(bk); out.chkB = window.tmPhaseWindows().checksum;
+      window.tmRestoreDerivedOrder();
+      return out;
+    }, NF, POSE_SRC);
+
+    if (res.err) { P(`SETUP ${BLD}`, false, res.err); }
+    else {
+      P(`F1 fallback ${BLD}`, res.src.source === 'derived' && res.rejected === null,
+        `source=${res.src.source} leafTasks=${res.src.leafTasks} capOps=${res.src.capOps} ` +
+        `tmOrderBySchedule()=${res.rejected} (refuses, does not guess)`);
+      const ctrl = res.direct[2], b = res.chkB, sC = ctrl.st, sB = res.stB;   // pass 3 = the control
+      const diffs = ctrl.series.filter((v, i) => v !== res.seriesB[i]).length;
+      const same = ctrl.chk.opCount === b.opCount && ctrl.chk.sumStart === b.sumStart &&
+        ctrl.chk.sumEnd === b.sumEnd && diffs === 0 &&
+        sC.ps === sB.ps && sC.pe === sB.pe && sC.placed === sB.placed && sC.ops === sB.ops &&
+        sC.noGeom === sB.noGeom && sC.arc === sB.arc && sB.source === 'derived';
+      P(`F2 regression ${BLD}`, same,
+        `branch == a repeat of the OLD call, exactly: ops=${sC.ops}==${sB.ops} ` +
+        `placed=${sC.placed}==${sB.placed} noGeom=${sC.noGeom}==${sB.noGeom} arc=${sC.arc}==${sB.arc} | ` +
+        `sumStart delta=${b.sumStart - ctrl.chk.sumStart} sumEnd delta=${b.sumEnd - ctrl.chk.sumEnd} | ` +
+        `placed series ${diffs}/${NF} frames differ | branch took source=${sB.source}`);
+      console.log(`     control — 3 consecutive DIRECT passes (shipped code), sumEnd deltas vs pass1: ` +
+        res.direct.map(d => (d.chk.sumEnd - res.direct[0].chk.sumEnd)).join(', ') +
+        ` (the shipped noGeom/tie artifact settling; branch is gated against pass 3)`);
+      const md = logs.filter(l => l.startsWith('§MAXQ_TIME mode=D'));
+      P(`LOG mode=D ${BLD}`, md.length >= 2, `§MAXQ_TIME mode=D printed ${md.length}x (both paths reached it)`);
+      if (md.length) console.log('       ' + md[md.length - 1]);
+    }
+    await page.close();
+
+    // ── A1 W-SCHED-AUTHOR-ROUNDTRIP — only on the first derived building (it is the slowest gate) ──
+    // A REAL round-trip: author -> persistDb -> page RELOAD -> re-read. Run 1 did the author and then
+    // called tmGenerateTimeline() in place, which (a) re-injected ELEMENT_PLACE ops on top of the
+    // existing ones and (b) never reloaded `_ops`, so the measurement compared stale in-memory ops
+    // against fresh task bindings. That was a witness defect, and it is exactly the "verify the
+    // checker's own ground truth first" trap — the reload is the claim, so the reload must happen.
+    if (BLD === DERIVED[0]) {
+      console.log(`  -- A1 W-SCHED-AUTHOR-ROUNDTRIP on ${BLD} --`);
+      const { page } = await open(browser, BLD);
+      const pre = await page.evaluate(async () => {
+        const A = window.APP, out = {};
+        if (!window.ScheduleAuthor) return { err: 'ScheduleAuthor not loaded' };
+        await window.tmActivateForBake();
+        out.before = window.tmScheduleSource();
+        // The ALREADY-SHIPPED authoring call — the exact one schedule_editor_ui.js:503 makes.
+        out.mat = window.ScheduleAuthor.materializeDefault(A.db, window.SEQUENCE_RULES,
+          { start: '2026-01-01', phaseDays: 30 });
+        out.rows = {
+          schedules: A.dbQuery('SELECT COUNT(*) FROM schedules')[0][0],
+          tasks: A.dbQuery('SELECT COUNT(*) FROM tasks')[0][0],
+          taskElements: A.dbQuery('SELECT COUNT(*) FROM task_elements')[0][0],
+        };
+        // The SHIPPED re-fold path (§TM-REFOLD, W-TM-REFOLD) — not a hand-rolled DELETE. It drops the
+        // IDB 'gantt' cache AND the stale ELEMENT_PLACE ops, so the next activate() re-reads the
+        // just-authored tasks through injectGantt's `_cap` instead of replaying the derived fast path
+        // (the same short-circuit that produced the _capActive correction above). Using the real verb
+        // keeps this a test of the user path, not of a seam the user never touches.
+        try { out.refold = window.tmRefoldSchedule(); } catch (e) { out.refoldErr = e.message; }
+        out.persisted = true;
+        try { window.ScheduleAuthor.persistDb(A.db, A.DB_URL, { immediate: true }); }
+        catch (e) { out.persisted = false; out.persistErr = e.message; }
+        return out;
+      });
+      if (pre.err) P('A1 W-SCHED-AUTHOR-ROUNDTRIP', false, pre.err);
+      else {
+        await sleep(6000);                       // let the debounced IDB write land
+        await page.reload({ waitUntil: 'domcontentloaded', timeout: 120000 });
+        await page.waitForFunction(() => window.APP && window.APP.dbQuery, { timeout: 300000 });
+        await page.waitForFunction(() => {
+          try { return window.APP.dbQuery('SELECT COUNT(*) FROM tasks')[0][0] > 0; } catch (e) { return false; }
+        }, { timeout: 300000, polling: 2000 });
+        await sleep(6000);
+        const post = await page.evaluate(async () => {
+          const out = {};
+          out.activated = await window.tmActivateForBake();
+          out.src = window.tmScheduleSource();
+          out.st = window.tmOrderBySchedule();
+          const pw = window.tmPhaseWindows();
+          out.phases = pw.phases.map(p => ({ name: p.name, scheduleStart: p.scheduleStart, n: p.n,
+            bound: p.bound, minStart: p.minStart, maxStart: p.maxStart }));
+          out.rows = { tasks: window.APP.dbQuery('SELECT COUNT(*) FROM tasks')[0][0],
+                       taskElements: window.APP.dbQuery('SELECT COUNT(*) FROM task_elements')[0][0] };
+          return out;
+        });
+        const bad = [];
+        for (let i = 0; i + 1 < post.phases.length; i++)
+          if (!(post.phases[i].maxStart <= post.phases[i + 1].minStart)) bad.push(post.phases[i].name);
+        P('A1 W-SCHED-AUTHOR-ROUNDTRIP',
+          pre.before.source === 'derived' && post.src.source === 'captured' &&
+          post.st !== null && post.phases.length >= 2 && bad.length === 0,
+          `${pre.before.source} -> RELOAD -> ${post.src.source}; authored ${pre.mat.taskCount} phases / ` +
+          `${pre.mat.assignmentCount} assignments; after reload tasks=${post.rows.tasks} ` +
+          `task_elements=${post.rows.taskElements} covered=${post.src.covered}/${post.src.total} ` +
+          `pct=${post.src.pct}%; interleaving pairs=${bad.length}`);
+        post.phases.forEach(p => console.log(`       ${String(p.name).padEnd(16)} start=${p.scheduleStart}` +
+          ` n=${String(p.n).padStart(5)} bound=${String(p.bound).padStart(5)}` +
+          ` ts=[${new Date(p.minStart).toISOString().slice(0, 10)} .. ${new Date(p.maxStart).toISOString().slice(0, 10)}]`));
+      }
+      await page.close();
+    }
+  }
+
+  console.log('\n' + '='.repeat(78));
+  console.log(`RESULT ${checks.filter(c => c.ok).length}/${checks.length} ${allPass ? 'GREEN' : 'RED'}`);
+  console.log('='.repeat(78));
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
Spec: `bim-compiler` `prompts/CINEMA_PATH_EDITOR.md` §CPE_BUILDUP_REAL_SCHEDULE (written before any code) + §CPE_BUILDUP_REAL_SCHEDULE_BUILT (the measured result).
Witness: `witness_cpe_buildup_schedule.js` — **16/16 GREEN**, `PORT=8433 DER_BLDS=Duplex,Hospital_3 node witness_cpe_buildup_schedule.js`.

## The defect
`cinema_maxq.js` called `tmOrderByCameraPath` unconditionally. Mode D overwrites every op's `start_ts`, and it ran *after* `injectGantt` had written the real task windows onto those same ops — so a building **with** a linked schedule baked a byte-identical buildup film to one with none. The §CPE_BUILDUP honesty label ("derived build order, not a construction programme") was unconditionally true by construction.

Same building (`TerminalHi4D`, 48,433 ops), the two orders side by side:

| leaf phase | `schedule_start` | CAPTURED reveal | mode-D reveal (the defect) |
|---|---|---|---|
| Superstructure (35,061) | 2026-01-01 | 01-01 .. 01-30 | 03-05 .. 03-27 |
| MEP Rough-in (9,477) | 2026-01-31 | 01-31 .. 03-01 | 03-08 .. 03-27 |
| Architecture (1,260) | 2026-03-02 | 03-02 .. 03-31 | 03-09 .. 03-28 |
| MEP Final (2,377) | 2026-04-01 | 04-01 .. 04-30 | 03-09 .. 03-28 |
| Finishes (258) | 2026-05-01 | 05-01 .. 05-30 | 03-13 .. 03-28 |

**Captured: 0 interleaving pairs. Mode D: 4/4 interleaving.**

## The fix
- `tmScheduleSource()` — pure read, decides `captured` vs `derived`.
- `tmOrderBySchedule()` — the captured branch, and it deliberately **writes nothing**: `injectGantt`'s `_cap` has already keyed the ops to their task windows and `loadOps` reads them `ORDER BY timestamp`, so "order by the real schedule" is already true. Restore is therefore a genuine no-op.
- `tmPhaseWindows()` — aggregate-only numeric instrument (per-phase first/last reveal + an all-ops checksum).
- The §3.3 branch in `cinema_maxq.js`, plus a status label that moves with the data. Captured-but-unusable falls **through** to mode D, never to nothing.

## Gates
`R1` real order (0 interleaving) · `R2` discriminator (mode D interleaves 4/4 — a gate mode D also passed would prove nothing) · `V1` reversible (`sumStart/sumEnd delta=0` over 48,433 ops, `tmRestoreDerivedOrder()=false`) · `M1` monotone (`0 → 45,248 → 48,433`) · `C1` coverage (48,433 == 48,433 == 48,433) · `B1` billboard/floodlights bound · `F1` fallback refuses, does not guess · `F2` regression: branch **exactly equals a repeat of the old call** (`0/40` frames differ) · `A1` author → save → **reload** → consumed (`derived → captured`, 6 phases, 0 interleaving).

## Two things caught before shipping
1. **`_capActive` is the wrong test** — it is a run-scoped side effect, not a property of the data. `activate()` skips `injectGantt` when the db already carries usable ops, which is exactly a building whose schedule was authored in an earlier session. TerminalHi4D's 48,433 ops all carry `_captured:1` yet `_capActive` was `false`. Source is now decided by the ops themselves; had this shipped on `_capActive`, the feature would have been silently dead on the buildings it was built for.
2. **The F2 instrument was wrong twice** before the code was (single-page series diff hit mode D's tie-permutation non-idempotence; per-load diff hit `injectGantt`'s wall-clock epoch + IDB persistence). Correct instrument is a **control**: three consecutive direct passes, then gate the branch against pass 3. No invented tolerance.

## Not built, because it already exists
"Author a schedule in the Viewer and save it to the DB" is shipped (`schedule_author.js`, `schedule_editor_ui.js`, `foreign_schedule.js` + §SE-6 persistence). It was **verified** by `W-SCHED-AUTHOR-ROUNDTRIP` over a real page reload, not rebuilt.

No DB binary touched; no migration needed. `sw.js` `CACHE_VERSION` v873 → v874.

⚠ `tests/audit_specs.js` exits 1 on a **pre-existing** violation in `38-sh-dx-2d-runtime.spec.js` (5 SKIP paths) — this branch has a zero diff under `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)