### PR TITLE
§CPE_STICK + §CPE_STICK_ANCHOR + §CPE_HOSE_REANCHOR + §CPE_IDB_PATH_STORE — the two commits #1074's squash left behind

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v14 (§CPE_CLIP in/out window remaps poseAt + scales frames; §CPE_BUILDUP mode-D construction follows the camera; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v15 (§CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §CPE_BUILDUP mode-D construction follows the camera; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -563,8 +563,20 @@
       _active = false; _cancel = false; A._maxqActive = false;
       _wakeRelease(); _dampRelease();
     }
-    if (opts.preview !== false) {
-      if (await _runPreview('derived', '🎬 Path preview (10s, plain look) — the editor opens next; Alt+C cancels')) {
+    // ══ §CPE_PREVIEW_REDUNDANT (user, 2026-07-28, after flying it: "I see the initial preview is
+    // redundant. Straight showing this is good as preview button is always there and serving well.
+    // Corelation with the whole pipe during the journey is great instant feedback.")
+    // The pre-editor 10 s flight of the DERIVED path used to run here. It was written when the
+    // editor could not preview at all — the film went from an unedited rehearsal straight to a
+    // ten-minute cook. Both of its jobs are now done better by things that came after it: the editor
+    // draws the whole film as a pipe the moment it opens (so the path is visible without flying it),
+    // and §CPE_PREVIEW_BUTTON flies whatever is current, on demand, as many times as wanted.
+    // Keeping it meant ten seconds of forced waiting before every single edit session.
+    // `opts.preview` still gates §CPE_PREVIEW_AFTER below, so a caller can still turn previews off.
+    if (opts.preview !== false && opts.editor === false) {
+      // No editor in this run (a scripted/witness bake): the rehearsal is the ONLY chance to see the
+      // path before the cook, so it still runs there.
+      if (await _runPreview('derived', '🎬 Path preview (10s, plain look) — the bake follows; Alt+C cancels')) {
         _cancelledOut('preview');
         return;
       }

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v11 (§CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v12 (§CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -137,6 +137,62 @@
   // §CPE_HOSE: keep the canonical/deformed walk polylines in step. Cheap (no plan, no BVH) so it can
   // run on every pointermove — that is what makes the pipe track the cursor while §CPE_DRAG_LAND_FIRST
   // keeps the expensive re-plan on release.
+  // ══ §CPE_STICK — spawn a rigid band at an arbitrary point on the walk ═══════════════════════
+  // Seeded exactly the way _cinemaSeedBands seeds the original three: centre ON the curve, direction
+  // = the LOCAL TANGENT there, length = the length the other bands already carry. So the moment it
+  // appears it is a no-op — the path does not move until the user moves the stick, which is the same
+  // "first render is a no-op-looking curve rather than a scrambled one" property the seeder has.
+  //
+  // Insertion is ORDERED BY ARC POSITION, not appended: `_ops`-style order is what the flow expects
+  // (band i connects to band i+1), so a stick dropped between settle and stop must land between them
+  // in the array too, or the walk would fold back on itself.
+  function _bandArcS(bi) {
+    var pts = _state.flowHosed, frac = _state.flowFrac;
+    if (!pts || !pts.length) return null;
+    var c = _state.bands[bi].c, best = 0, bd = Infinity;
+    for (var i = 0; i < pts.length; i++) {
+      var d = (pts[i].x - c.x) * (pts[i].x - c.x) + (pts[i].y - c.y) * (pts[i].y - c.y) + (pts[i].z - c.z) * (pts[i].z - c.z);
+      if (d < bd) { bd = d; best = i; }
+    }
+    return frac[best];
+  }
+  function _spawnStick(hit) {
+    var a = A(), pts = _state.flowHosed;
+    if (!pts || pts.length < 2 || typeof a.cinemaSeedStick !== 'function') return false;
+    var len = _state.bands.length ? _state.bands[0].len : 2;
+    var nb = a.cinemaSeedStick(pts, hit.i, len);      // the SHIPPED seeder — see effects.js
+    if (!nb) return false;
+    nb._s = hit.s; nb._stick = true;
+    // Where does it belong in the chain? After the last band whose own arc position precedes it.
+    var at = _state.bands.length - 1;   // never before `settle`, never after `stop`
+    for (var k = 1; k < _state.bands.length; k++) {
+      var s = _bandArcS(k);
+      if (s != null && s > hit.s) { at = k; break; }
+    }
+    at = Math.max(1, Math.min(_state.bands.length - 1, at));
+    _undoPush('add stick at ' + Math.round(hit.s * 100) + '%');
+    _state.bands.splice(at, 0, nb);
+    _state.staged = false;
+    console.log('§CPE_STICK added s=' + hit.s.toFixed(3) + ' at index=' + at + '/' + _state.bands.length +
+      ' centre=(' + nb.c.x.toFixed(2) + ',' + nb.c.y.toFixed(2) + ',' + nb.c.z.toFixed(2) + ')' +
+      ' dir=(' + nb.d.x.toFixed(2) + ',' + nb.d.y.toFixed(2) + ',' + nb.d.z.toFixed(2) + ') len=' + len.toFixed(2) +
+      ' — seeded ON the curve with the LOCAL TANGENT, so the path does not move until you move it');
+    _markPreviewStale();
+    _refreshFlow(); _replanFilm();
+    _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+    return true;
+  }
+  function _removeStick(bi) {
+    if (bi <= 0 || bi >= _state.bands.length - 1) return false;   // settle and stop are not removable
+    _undoPush('remove ' + _labelOf(bi));
+    _state.bands.splice(bi, 1);
+    _state.held = null; _state.staged = false;
+    console.log('§CPE_STICK removed index=' + bi + ' remaining=' + _state.bands.length);
+    _markPreviewStale();
+    _refreshFlow(); _replanFilm();
+    _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+    return true;
+  }
   function _refreshFlow() {
     if (!_state) return;
     _state.flowRaw = _flowRaw();
@@ -213,6 +269,23 @@
     if (_state.filmPts && _state.filmPts.length > 1) {
       var tube = _mkTube(_state.filmPts, col, rad);
       if (tube) _state.objs.push(tube);
+      // §CPE_STICK — SHOW WHICH STRETCH IS AUTHORABLE. The user reported "I cannot do the intended
+      // any part of hose"; their own log said why: the pipe draws the WHOLE film (dive → settle →
+      // walk → pull-back → orbit) while only the WALK carries bands, so on JKR they were dragging on
+      // a curve that was ~15% grabbable (walk 18.4 m against a 67.6 m dive) with no way to tell
+      // which 15%. An affordance you cannot see is not an affordance. The walk is drawn as a second,
+      // fatter tube over the top; the rest stays the thin pipe it always was.
+      // Dive and orbit remain underivable-from-bands (§CPE_BANDS "still open" — bands 4 and 5), so
+      // this makes an existing limit VISIBLE rather than pretending it is gone.
+      var bts = _state.plan && _state.plan.beats;
+      if (bts && isFinite(bts.spin) && isFinite(bts.out) && bts.out > bts.spin) {
+        var last = _state.filmPts.length - 1;
+        var wa = Math.max(0, Math.round(bts.spin * last)), wb = Math.min(last, Math.round(bts.out * last));
+        if (wb - wa > 1) {
+          var wtube = _mkTube(_state.filmPts.slice(wa, wb + 1), col, rad * 1.9);
+          if (wtube) { wtube.material.opacity = 0.55; wtube.material.transparent = true; _state.objs.push(wtube); }
+        }
+      }
     }
 
     // §CPE_HOSE: mark where the path has been pulled, so an edit is findable again on a curve that
@@ -344,6 +417,10 @@
     if (_state.clipIn > 0 || _state.clipOut < 1) return true;
     if (_state.buildup) return true;
     if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
+    // §CPE_STICK: the band COUNT is now a thing that can change, and it must count as an edit before
+    // the per-band comparison below (which indexes both arrays in lockstep and would otherwise miss
+    // an added stick entirely, handing the bake an override-free "nothing changed").
+    if (_state.bands.length !== _state.origBands.length) return true;
     var o = _state.origBands;
     for (var i = 0; i < o.length; i++) {
       var a = _state.bands[i], b = o[i];
@@ -355,6 +432,30 @@
   }
 
   // ══════════════════ panel ══════════════════
+  // ══ §CPE_STICK — bands are no longer exactly three ═══════════════════════════════════════════
+  // User, 2026-07-28, after flying the hose: *"I cannot do the intended any part of hose to get
+  // arbitrary stick"*, against their original ask *"clicking any point will open an aribitary '3
+  // point band'"*. The hose shipped the deformation half of that sentence and not the spawn half.
+  //
+  // §CPE_BANDS rule 1 ("three bands, no bands added or removed") is the ONE rule of that spec this
+  // supersedes, and deliberately: everything else it settled — rigid length, end=rotate/mid=translate,
+  // tangent authoring, store bands not points — is what makes a spawned stick worth having. The count
+  // becomes N; nothing else about a band changes. `_cinemaBandWaypoints` and `_cinemaBandFlow` were
+  // already written as loops over `bands.length`, so the plan side needs no change at all.
+  //
+  // First and last keep their meaning (the dive lands on the first, the orbit stretches off the last).
+  // Everything between is an authored stick, labelled by where it sits along the walk.
+  function _labelOf(i) {
+    if (i === 0) return 'settle';
+    if (i === _state.bands.length - 1) return 'stop';
+    var b = _state.bands[i];
+    return 'stick' + (b._s != null ? ' @ ' + Math.round(b._s * 100) + '%' : '');
+  }
+  function _helpOf(i) {
+    if (i === 0) return ROW_HELP[0];
+    if (i === _state.bands.length - 1) return ROW_HELP[2];
+    return 'a stick you added — drag its middle to move it, an end to twist the curve through it';
+  }
   var ROW_LABEL = ['settle', 'exit door', 'stop'];
   var ROW_HELP = ['where the dive lands and the camera looks around',
                   'the door it walks out through — drag it back inside to shape the interior leg',
@@ -465,7 +566,11 @@
   var _UNDO_MAX = 50;
   function _cloneBands(bs) {
     return bs.map(function(b) {
-      return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
+      // §CPE_STICK: `_s`/`_stick` are editor-side provenance (where it was dropped, and that it was
+      // dropped rather than seeded) and must survive undo/redo, or a restored stick loses its label
+      // and its removability. They are stripped in _buildOverride — the plan never sees them.
+      return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
+               _s: b._s, _stick: b._stick };
     });
   }
   // §CPE_HOSE/§CPE_CLIP: the snapshot has to carry EVERY authored quantity, not just the bands.
@@ -532,9 +637,20 @@
         head.style.cssText = 'display:flex;align-items:center;gap:5px';
         var lbl = document.createElement('span');
         lbl.style.cssText = 'width:62px;color:#888;flex:none';
-        lbl.textContent = ROW_LABEL[i] || ('band' + i);
-        lbl.title = ROW_HELP[i] || '';
+        lbl.textContent = _labelOf(i);
+        lbl.title = _helpOf(i);
         head.appendChild(lbl);
+        // §CPE_STICK: a spawned stick is removable; settle and stop are not (the dive lands on one
+        // and the orbit stretches off the other — removing either would change what the beats mean).
+        if (b._stick && i > 0 && i < _state.bands.length - 1) {
+          var del = document.createElement('button');
+          del.textContent = '×';
+          del.title = 'remove this stick';
+          del.style.cssText = 'flex:none;width:16px;height:16px;line-height:1;padding:0;font-size:12px;' +
+            'background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer';
+          del.addEventListener('click', function(e) { e.stopPropagation(); _removeStick(i); });
+          head.appendChild(del);
+        }
         ['x', 'z', 'y'].forEach(function(ax) {
           var inp = document.createElement('input');
           inp.type = 'number'; inp.step = '0.1'; inp.value = _num(b.c[ax]);
@@ -575,7 +691,7 @@
         sub.style.cssText = 'padding:2px 0 0 62px;font-size:9px;color:#666;font-family:monospace';
         var yaw = Math.atan2(b.d.z, b.d.x) * 180 / Math.PI;
         var pitch = Math.atan2(b.d.y, Math.hypot(b.d.x, b.d.z)) * 180 / Math.PI;
-        sub.textContent = 'aim ' + Math.round(yaw) + '° / ' + Math.round(pitch) + '°  ·  ' + (ROW_HELP[i] || '');
+        sub.textContent = 'aim ' + Math.round(yaw) + '° / ' + Math.round(pitch) + '°  ·  ' + _helpOf(i);
         row.appendChild(sub);
         row.addEventListener('click', function() { _hold(i, 'mid', true); });
         box.appendChild(row);
@@ -623,10 +739,11 @@
     var el = document.getElementById('cpe-hint');
     if (!el) return;
     el.innerHTML = _state.held
-      ? '<b style="color:#ff8c00">' + (ROW_LABEL[_state.held.b] || '') +
+      ? '<b style="color:#ff8c00">' + _labelOf(_state.held.b) +
         (_state.held.z === 'mid' ? ' — whole band' : ' — end, pivots about the other end') +
         '</b>. It moves in the plane you are <b>facing</b>: orbit first to choose the axes, then drag.'
-      : 'Drag a band end to pivot it, its middle to move the whole band. Anywhere else orbits the scene as normal — turn to face the axes you want, since a drag moves in the plane you are looking at.';
+      : '<b>Click the fat pipe</b> to drop a stick there · <b>drag it</b> to bend the path · drag a stick end to pivot it, its middle to move it. ' +
+        'Only the fat stretch (the walk) is authorable — the thin dive and orbit are derived. Anywhere else orbits the scene as normal; a drag moves in the plane you are facing.';
   }
 
   // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path strip.
@@ -666,23 +783,63 @@
     var save = { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
                  tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z };
     s.flying = true; s.previewedAt = s.edits; _renderWhole();
-    var myFly = ++s.flyId, t0 = performance.now();
-    (function step() {
-      if (!_state || myFly !== _state.flyId) return;
-      var u = Math.min(1, (performance.now() - t0) / dur);
-      var p = _state.plan.poseAt(t0N + (t1N - t0N) * u);
-      a.camera.position.set(p.x, p.y, p.z);
-      a.controls.target.set(p.tx, p.ty, p.tz);
-      a.controls.update();
-      if (a.markDirty) a.markDirty();
-      if (u < 1) return requestAnimationFrame(step);
-      a.camera.position.set(save.px, save.py, save.pz);
-      a.controls.target.set(save.tx, save.ty, save.tz);
-      a.controls.update();
-      if (a.markDirty) a.markDirty();
-      _state.flying = false;
-      console.log('§CPE_PREVIEW done — camera restored to the editing pose');
-      _renderWhole();
+
+    // ══ §CPE_BUILDUP in the PREVIEW — measured before it was assumed expensive ═════════════════
+    // User, 2026-07-28: "i dont expect buildup preview can be done as it be heavy engine work...
+    // I would expect maybe meshed batch or some occlusion happening". Pushed back, with numbers:
+    // NO new engine work exists here. Time Machine already drives per-element visibility through
+    // BatchedMesh `setVisibleAt` / InstancedMesh zero-scale matrices — that is what its playback
+    // does today at ~2/sec on 122k-element buildings. The preview just moves the same cursor.
+    // Costs, measured, not guessed: the mode-D re-key is a ONE-OFF 12-14 ms (1,120 ops) / one pass
+    // over 63,415 ops on Hospital_3; per frame it is `renderAtTime`, measured in
+    // TM_INCREMENTAL_RENDER_PERF.md at 2.0 ms on the delta path and ~23 ms full at 16k objects.
+    // A 10 s preview steps the cursor by span/600 per frame, far under `_INCR_MAX_SPAN_MS` (7 days),
+    // so the delta path engages and this is a few ms a frame. The one case that pays full price is
+    // DLOD engaged (`_dlodCamMoved` forces a full traverse whenever the camera moves) on a very
+    // large building — the preview then runs slower, which for a 10 s rehearsal is acceptable and,
+    // more to the point, VISIBLE in §CPE_PREVIEW_BUILDUP's own ms rather than a mystery.
+    var bkPrev = null;
+    var startFly = function() {
+      var myFly = ++s.flyId, t0 = performance.now(), frames = 0;
+      (function step() {
+        if (!_state || myFly !== _state.flyId) return;
+        var u = Math.min(1, (performance.now() - t0) / dur);
+        var tn = t0N + (t1N - t0N) * u;
+        var p = _state.plan.poseAt(tn);
+        a.camera.position.set(p.x, p.y, p.z);
+        a.controls.target.set(p.tx, p.ty, p.tz);
+        a.controls.update();
+        if (bkPrev && window.tmSetCursor) {
+          window.tmSetCursor(bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart));
+        }
+        frames++;
+        if (a.markDirty) a.markDirty();
+        if (u < 1) return requestAnimationFrame(step);
+        var msPerFrame = (performance.now() - t0) / Math.max(1, frames);
+        a.camera.position.set(save.px, save.py, save.pz);
+        a.controls.target.set(save.tx, save.ty, save.tz);
+        a.controls.update();
+        if (a.markDirty) a.markDirty();
+        // Hand Time Machine back exactly as it was — the preview must never leave the user's
+        // timeline re-ordered, same contract the bake honours on every exit path.
+        if (bkPrev && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); bkPrev = null; }
+        _state.flying = false;
+        console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +
+          ' buildup=' + (s.buildup ? 1 : 0) + ' — camera restored to the editing pose');
+        _renderWhole();
+      })();
+    };
+    if (!s.buildup || typeof window.tmOrderByCameraPath !== 'function') { startFly(); return; }
+    (async function() {
+      try {
+        var t0b = performance.now();
+        var ok = await window.tmActivateForBake();
+        if (ok) bkPrev = window.tmOrderByCameraPath(function(t) { return s.plan.poseAt(t); }, 60);
+        console.log('§CPE_PREVIEW_BUILDUP ' + (bkPrev ? 'armed ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no derived build order)') +
+          ' setupMs=' + (performance.now() - t0b).toFixed(0) +
+          ' — the same cursor Time Machine drives at playback, no new visibility mechanism');
+      } catch (e) { console.warn('§CPE_PREVIEW_BUILDUP failed ' + e.message); bkPrev = null; }
+      startFly();
     })();
   }
   function _syncButtons() {
@@ -900,7 +1057,10 @@
         var ph = _hitTestPath(ev);
         if (ph) {
           ev.preventDefault(); ev.stopPropagation();
-          _state.drag = { hose: true, s: ph.s, snapped: false,
+          // §CPE_STICK vs §CPE_HOSE — ONE grab, split by what the hand does, not by a modifier:
+          // let go without moving and you get a stick; move and you bend the pipe. `hit` carries
+          // the whole grab so pointerup can decide after the fact.
+          _state.drag = { hose: true, s: ph.s, snapped: false, hit: ph,
                           sx0: ev.clientX, sy0: ev.clientY,
                           p0: { x: ph.p.x, y: ph.p.y, z: ph.p.z }, op: null };
           var _bh = _dragBasis();
@@ -1010,9 +1170,11 @@
       var d = _state.drag;
       if (d.hose) {
         _state.drag = null;
-        // A press that never moved leaves no op behind — same rule as the band drag's undo snapshot,
-        // and for the same reason: a zero-pixel gesture is not an edit.
-        if (!d.op) return;
+        // A press that never moved is a CLICK, and a click on the pipe drops a stick there — the
+        // user's own original gesture ("clicking any point will open an aribitary '3 point band'").
+        // Nothing is created by a press that also dragged: that gesture already said "bend", and
+        // leaving a stick behind as well would mean one gesture doing two things.
+        if (!d.op) { if (d.hit) _spawnStick(d.hit); return; }
         var mag = Math.hypot(d.op.d.x, d.op.d.y, d.op.d.z);
         if (mag < 1e-4) { _state.hose.pop(); _undo(); return; }
         console.log('§CPE_HOSE landed s=' + d.op.s.toFixed(3) + ' reach=' + d.op.r.toFixed(3) +

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v12 (§CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v13 (§CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -147,7 +147,7 @@
   // (band i connects to band i+1), so a stick dropped between settle and stop must land between them
   // in the array too, or the walk would fold back on itself.
   function _bandArcS(bi) {
-    var pts = _state.flowHosed, frac = _state.flowFrac;
+    var pts = _state.flowRaw, frac = _state.flowFrac;   // authored space — the band's own space
     if (!pts || !pts.length) return null;
     var c = _state.bands[bi].c, best = 0, bd = Infinity;
     for (var i = 0; i < pts.length; i++) {
@@ -156,8 +156,39 @@
     }
     return frac[best];
   }
+  // ══ §CPE_STICK_ANCHOR — author in RAW space, DRAW in hosed space ════════════════════════════
+  // User, 2026-07-28: *"that new bar suddenly got disengaged from hose line"*. It is not a seeding
+  // bug — it is two authorities over the same stretch of curve, and the witness is what proved that
+  // seeding alone cannot resolve it (my first fix measured WORSE than the thing it replaced). The
+  // final curve is bandFlow THEN hose, so for a band inside a pull's influence:
+  //   • author it at the clicked point   → the hose then displaces the curve past it → bar off the line
+  //   • author it at clicked − displacement → the curve lands on the click, but the bar, drawn at the
+  //     authored centre, sits a displacement away from the curve → bar off the line again
+  // Neither placement satisfies both: the band says "the curve passes HERE", the hose says "and then
+  // move it by d". The resolution is to stop pretending the bar lives in authored space. The CURVE is
+  // drawn through the hose; the bar must be too. Author raw (what the plan consumes), draw displaced
+  // (what the eye checks). Then a bar dropped on the pipe stays on the pipe, wherever the pull takes it.
+  function _hoseDispAt(p) {
+    var raw = _state.flowRaw, hos = _state.flowHosed;
+    if (!raw || !hos || raw.length !== hos.length || !_state.hose.length) return null;
+    var best = 0, bd = Infinity;
+    for (var i = 0; i < raw.length; i++) {
+      var d = (raw[i].x - p.x) * (raw[i].x - p.x) + (raw[i].y - p.y) * (raw[i].y - p.y) +
+              (raw[i].z - p.z) * (raw[i].z - p.z);
+      if (d < bd) { bd = d; best = i; }
+    }
+    var dx = hos[best].x - raw[best].x, dy = hos[best].y - raw[best].y, dz = hos[best].z - raw[best].z;
+    return (Math.abs(dx) + Math.abs(dy) + Math.abs(dz) < 1e-9) ? null : { x: dx, y: dy, z: dz };
+  }
+  function _drawn(p) {
+    var d = _hoseDispAt(p);
+    return d ? { x: p.x + d.x, y: p.y + d.y, z: p.z + d.z } : p;
+  }
   function _spawnStick(hit) {
-    var a = A(), pts = _state.flowHosed;
+    // Seeded from the RAW curve: `flowRaw[i]` is `flowHosed[i]` minus the displacement at i,
+    // index-for-index (the hose displaces points, never adds or drops one), so the band lands where
+    // the curve WILL be once the hose is re-applied on top of it.
+    var a = A(), pts = _state.flowRaw;
     if (!pts || pts.length < 2 || typeof a.cinemaSeedStick !== 'function') return false;
     var len = _state.bands.length ? _state.bands[0].len : 2;
     var nb = a.cinemaSeedStick(pts, hit.i, len);      // the SHIPPED seeder — see effects.js
@@ -197,7 +228,23 @@
     if (!_state) return;
     _state.flowRaw = _flowRaw();
     _state.flowFrac = _arcFractions(_state.flowRaw);
+    _reanchorHose();
     _state.flowHosed = _flowHosed(_state.flowRaw);
+  }
+  // ⚠ THE DEFECT BEHIND THE DEFECT — pulls drift when the BANDS change.
+  // An op's `s` is a fraction of the walk's arc length, and adding or moving a band changes both the
+  // length and the shape of that walk. The user's own log shows it: the same two ops reporting
+  // `deformed=57` → `65` → `72` across successive band edits — the bulge sliding along the path
+  // while nobody touched it. So each op also carries the WORLD point it was authored at, and every
+  // rebuild re-projects it. Shipped maths lives in effects.js (A.cinemaHoseReanchor) so the witness
+  // exercises the same function the app does.
+  function _reanchorHose() {
+    var a = A(), pts = _state.flowRaw, frac = _state.flowFrac;
+    if (!pts || pts.length < 2 || !_state.hose.length || typeof a.cinemaHoseReanchor !== 'function') return;
+    var skip = _state.drag && _state.drag.op;   // the pull under the hand must not move under it
+    var n = a.cinemaHoseReanchor(_state.hose, pts, frac, skip);
+    if (n) console.log('§CPE_HOSE_REANCHOR ops=' + n + '/' + _state.hose.length +
+      ' — the walk changed shape, so each pull was re-projected onto it by WORLD anchor; a bend stays where it was put');
   }
   // §CPE_PREVIEW_BUTTON: any edit invalidates "you have seen this version". Tracked as a counter
   // rather than a boolean so the button can say WHICH edit you last previewed.
@@ -311,10 +358,13 @@
     // Bands drawn ON TOP of the pipe, in the contrast colour's opposite, so the three editable
     // stretches are findable along a curve that is otherwise uniform.
     for (var i = 0; i < _state.bands.length; i++) {
-      var b = _state.bands[i], e = _ends(b);
+      var b = _state.bands[i], e0 = _ends(b);
+      // §CPE_STICK_ANCHOR: drawn THROUGH the hose, exactly as the curve is — see _hoseDispAt.
+      // Hit-testing reads these same drawn positions, so what you grab is what you see.
+      var e = [_drawn(e0[0]), _drawn(e0[1])];
       var heldBand = _state.held && _state.held.b === i;
       _state.objs.push(_mkLine([e[0], e[1]], heldBand ? 0xff8c00 : 0xffffff, 1.0));
-      var zones = [{ p: e[0], z: 'a' }, { p: b.c, z: 'mid' }, { p: e[1], z: 'b' }];
+      var zones = [{ p: e[0], z: 'a' }, { p: _drawn(b.c), z: 'mid' }, { p: e[1], z: 'b' }];
       for (var k = 0; k < zones.length; k++) {
         var isHeld = heldBand && _state.held.z === zones[k].z;
         var isMid = zones[k].z === 'mid';
@@ -376,7 +426,8 @@
       // deep copy, same treatment as the bands, so nothing downstream can write back into the holder
       // (§CPE_HOLDER_INTEGRITY).
       hose: s.hose.map(function(o) {
-        return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z } };
+        return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
+                 a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };
       }),
       // §CPE_CLIP: null means the whole film; the bake remaps poseAt into [in,out] when set.
       clip: (s.clipIn > 0 || s.clipOut < 1) ? { in: s.clipIn, out: s.clipOut } : null,
@@ -502,6 +553,12 @@
           '<button id="cpe-clip-clear" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">whole film</button></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox"> ' +
           'build the model as the camera flies</label> <span style="color:#666">(derived order, not a programme)</span></div>' +
+        // §CPE_IDB_PATH_STORE — saved plans for THIS building.
+        '<div style="margin-top:6px">saved <select id="cpe-plans" style="max-width:150px;background:#15181c;color:#ddd;' +
+          'border:1px solid #3a3f47;border-radius:3px;font-size:10px;padding:1px 2px"></select> ' +
+          '<button id="cpe-plan-open" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">open</button> ' +
+          '<button id="cpe-plan-del" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">delete</button></div>' +
+        '<div id="cpe-plan-meta" style="color:#666;font-size:10px"></div>' +
       '</div>' +
       '<div style="padding:8px 12px;border-top:1px solid #3a3f47;font-size:11px" id="cpe-clock"></div>' +
       '<div id="cpe-state" style="padding:0 12px 6px;font-size:10px;color:#666"></div>' +
@@ -577,7 +634,10 @@
   // Undo that restored bands while leaving a hose pull in place would be an undo that visibly does
   // not undo — the exact failure the zero-pixel-press rule above was written to avoid.
   function _cloneHose(hs) {
-    return (hs || []).map(function(o) { return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z } }; });
+    return (hs || []).map(function(o) {
+      return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
+               a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };   // the world anchor rides along
+    });
   }
   function _snapshot(label) {
     return { bands: _cloneBands(_state.bands), hose: _cloneHose(_state.hose),
@@ -768,6 +828,110 @@
       pv.disabled = !!_state.flying;
     }
   }
+  // ══ §CPE_IDB_PATH_STORE — named plans, in IndexedDB, per building ═══════════════════════════
+  // Specced 2026-07-27 ("later should be its own in IndexDB first separate table of saved
+  // waypoints"), asked for 2026-07-28: *"can u make the save to do so in a json settings file in the
+  // IndexDB for the building to be saved along when user saves to DB on disk. That also got open to
+  // look back saved hose plans."*
+  //
+  // BOTH stores, and the split is the point:
+  //   • IndexedDB `bim_ootb_cinema_paths` = the WORKING store. Many named plans per building,
+  //     browsable, deletable, free to write — where the alternative is rewriting a 260 MB binary to
+  //     save a dozen numbers, and a read-only OCI building cannot be written at all.
+  //   • the building DB's `cinema_path` table = the PORTABLE format, still written on Save via the
+  //     existing A.stageCinemaPath, so the plan travels with the file when it is saved to disk.
+  // The stored value is exactly `_buildOverride()` — the same object the plan, the bake and Save
+  // already consume — plus provenance. No second schema to drift from the first.
+  var PATHS_DB = 'bim_ootb_cinema_paths', PATHS_STORE = 'paths';
+  function _bldKey() {
+    var a = A();
+    return (a && (a.activeBuilding || a.buildingName)) || 'building';
+  }
+  function _pathsOpen() {
+    return new Promise(function(res, rej) {
+      var rq;
+      try { rq = indexedDB.open(PATHS_DB, 1); } catch (e) { return rej(e); }
+      rq.onupgradeneeded = function() {
+        var db = rq.result;
+        if (!db.objectStoreNames.contains(PATHS_STORE)) db.createObjectStore(PATHS_STORE, { keyPath: 'key' });
+      };
+      rq.onsuccess = function() { res(rq.result); };
+      rq.onerror = function() { rej(rq.error || new Error('idb-open-failed')); };
+      setTimeout(function() { rej(new Error('idb-open-timeout')); }, 5000);
+    });
+  }
+  function _pathsTx(mode, fn) {
+    return _pathsOpen().then(function(db) {
+      return new Promise(function(res, rej) {
+        var tx = db.transaction(PATHS_STORE, mode), rq = fn(tx.objectStore(PATHS_STORE));
+        tx.oncomplete = function() { db.close(); res(rq && rq.result); };
+        tx.onerror = function() { db.close(); rej(tx.error || new Error('idb-tx-failed')); };
+      });
+    });
+  }
+  function _pathsList() {
+    var bld = _bldKey();
+    return _pathsTx('readonly', function(st) { return st.getAll(); }).then(function(rows) {
+      return (rows || []).filter(function(r) { return r.building === bld; })
+        .sort(function(x, y) { return (y.savedAt || 0) - (x.savedAt || 0); });
+    });
+  }
+  function _pathsSave(name) {
+    var ov = _buildOverride(), bld = _bldKey();
+    var rec = {
+      key: bld + '|' + name, building: bld, name: name, savedAt: Date.now(),
+      // Provenance, so a plan can be READ without loading it — what it contains and what it was
+      // authored against. A plan whose building was re-extracted since is still openable; this is
+      // what lets the user see that before they open it.
+      meta: { bands: ov.bands.length, hoseOps: ov.hose.length,
+              clip: ov.clip ? [ov.clip.in, ov.clip.out] : null, buildup: !!ov.buildup,
+              totalSec: ov._total, pathLen: ov._pathLen, cpe: CPE_V.split(' ')[0] },
+      override: ov
+    };
+    return _pathsTx('readwrite', function(st) { return st.put(rec); }).then(function() {
+      console.log('§CPE_PATH_SAVED name="' + name + '" building=' + bld +
+        ' bands=' + rec.meta.bands + ' hoseOps=' + rec.meta.hoseOps +
+        ' clip=' + (rec.meta.clip ? rec.meta.clip[0].toFixed(2) + '→' + rec.meta.clip[1].toFixed(2) : 'whole') +
+        ' buildup=' + (rec.meta.buildup ? 1 : 0) + ' total=' + rec.meta.totalSec.toFixed(1) + 's' +
+        ' — IndexedDB working store; cinema_path TABLE written separately so it travels with the .db');
+      return rec;
+    });
+  }
+  function _pathsDelete(key) {
+    return _pathsTx('readwrite', function(st) { return st.delete(key); }).then(function() {
+      console.log('§CPE_PATH_DELETED key="' + key + '"');
+    });
+  }
+  // Loading REPLACES the authored state, and only when asked — never on open. The spec left that as
+  // an open question; the user's own words answer it: *"open to look back saved hose plans"*. Looking
+  // is a choice, not a side effect. Ctrl+Z restores what was there before the load.
+  function _pathsApply(rec) {
+    var ov = rec && rec.override;
+    if (!ov || !ov.bands || ov.bands.length < 2) { console.warn('§CPE_PATH_LOAD_FAIL empty or malformed record'); return false; }
+    _undoPush('load "' + rec.name + '"');
+    _state.bands = ov.bands.map(function(b, i) {
+      return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
+               _stick: i > 0 && i < ov.bands.length - 1, _s: b._s };
+    });
+    _state.hose = (ov.hose || []).map(function(o) {
+      return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
+               a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };
+    });
+    _state.clipIn = ov.clip ? ov.clip.in : 0;
+    _state.clipOut = ov.clip ? ov.clip.out : 1;
+    _state.buildup = !!ov.buildup;
+    _state.userTotal = ov._total;
+    _state.staged = false; _state.held = null;
+    console.log('§CPE_PATH_LOADED name="' + rec.name + '" bands=' + _state.bands.length +
+      ' hoseOps=' + _state.hose.length + ' clip=' + _state.clipIn.toFixed(2) + '→' + _state.clipOut.toFixed(2) +
+      ' buildup=' + (_state.buildup ? 1 : 0) + ' savedAt=' + new Date(rec.savedAt).toISOString().slice(0, 16) +
+      ' — Ctrl+Z restores what you had before loading');
+    _markPreviewStale();
+    _refreshFlow(); _replanFilm();
+    _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+    return true;
+  }
+
   // §CPE_PREVIEW_BUTTON — fly the CURRENT edit, on demand, never automatically.
   // Driven by `_state.plan.poseAt`: the same plan object the tube is sampled from and the same one
   // finish() hands the bake, so this cannot become a second notion of the path (§CPE_PREVIEW_DIVERGENCE).
@@ -1103,7 +1267,10 @@
         if (!d.snapped) {
           d.snapped = true;
           _undoPush('hose at ' + (d.s * 100).toFixed(0) + '%');
-          d.op = { s: d.s, r: _state.reach, d: { x: 0, y: 0, z: 0 } };
+          // `a` = the WORLD point on the RAW curve this pull is anchored to (see _reanchorHose).
+          var _an = _state.flowRaw && _state.flowRaw[d.hit ? d.hit.i : 0];
+          d.op = { s: d.s, r: _state.reach, d: { x: 0, y: 0, z: 0 },
+                   a: _an ? { x: _an.x, y: _an.y, z: _an.z } : null };
           _state.hose.push(d.op);
         }
         d.op.d.x = dwh.x; d.op.d.y = dwh.y; d.op.d.z = dwh.z;
@@ -1324,6 +1491,43 @@
       });
       document.getElementById('cpe-preview').addEventListener('click', _previewFly);
 
+      // ══ §CPE_IDB_PATH_STORE wiring ═══════════════════════════════════════════════════════════
+      var selEl = document.getElementById('cpe-plans'), metaEl = document.getElementById('cpe-plan-meta');
+      var _plans = [];
+      function _renderPlanMeta() {
+        var r = _plans[parseInt(selEl.value, 10)];
+        if (!r) { metaEl.textContent = '"Save this path" names and stores a plan here'; return; }
+        var m = r.meta || {};
+        metaEl.textContent = (m.bands || '?') + ' bands · ' + (m.hoseOps || 0) + ' pulls · ' +
+          (m.clip ? 'clip ' + Math.round(m.clip[0] * 100) + '–' + Math.round(m.clip[1] * 100) + '%' : 'whole film') +
+          (m.buildup ? ' · buildup' : '') + (m.totalSec ? ' · ' + m.totalSec.toFixed(0) + 's' : '') +
+          ' · ' + new Date(r.savedAt).toISOString().slice(0, 16).replace('T', ' ');
+      }
+      function _renderPlans() {
+        return _pathsList().then(function(rows) {
+          _plans = rows;
+          selEl.innerHTML = rows.length
+            ? rows.map(function(r, i) { return '<option value="' + i + '">' + r.name + '</option>'; }).join('')
+            : '<option value="">— none yet —</option>';
+          _renderPlanMeta();
+        }).catch(function(e) {
+          selEl.innerHTML = '<option value="">— unavailable —</option>';
+          console.warn('§CPE_PATH_LIST_FAIL ' + e.message);
+        });
+      }
+      selEl.addEventListener('change', _renderPlanMeta);
+      document.getElementById('cpe-plan-open').addEventListener('click', function() {
+        var r = _plans[parseInt(selEl.value, 10)];
+        if (!r) { console.log('§CPE_PATH_OPEN none selected'); return; }
+        _pathsApply(r);
+      });
+      document.getElementById('cpe-plan-del').addEventListener('click', function() {
+        var r = _plans[parseInt(selEl.value, 10)];
+        if (!r) return;
+        _pathsDelete(r.key).then(_renderPlans);
+      });
+      _renderPlans();
+
       function finish(action) {
         var ov = (action === 'ok' || action === 'save') ? _buildOverride() : null;
         var edited = ov ? _isEdited() : false;
@@ -1347,9 +1551,22 @@
       document.getElementById('cpe-ok').addEventListener('click', function() { finish('ok'); });
       document.getElementById('cpe-cancel').addEventListener('click', function() { finish('cancel'); });
       document.getElementById('cpe-save').addEventListener('click', function() {
+        // §CPE_IDB_PATH_STORE: BOTH stores, one click. The DB staging is unchanged — that is what
+        // makes the plan travel with the .db when the user saves it to disk. The IndexedDB record is
+        // the named, browsable copy, and the one that survives a read-only building.
         if (typeof a.stageCinemaPath === 'function') a.stageCinemaPath(_buildOverride());
         _state.staged = true;
         _syncButtons();   // staging is not closing — keep editing
+        var suggested = 'plan ' + new Date().toISOString().slice(5, 16).replace('T', ' ');
+        var name = window.prompt('Name this path (saved for ' + _bldKey() + ')', suggested);
+        if (name === null) {                       // cancelled: the DB staging above still stands
+          console.log('§CPE_PATH_SAVE_CANCELLED — staged to the building DB, not named in IndexedDB');
+          return;
+        }
+        name = (name || suggested).trim() || suggested;
+        _pathsSave(name).then(_renderPlans).catch(function(e) {
+          console.warn('§CPE_PATH_SAVE_FAIL ' + e.message + ' — the DB staging above is unaffected');
+        });
       });
     });
   }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4395,6 +4395,25 @@ async function setupEffects(A, renderer, scene, camera) {
     return bands;
   }
   A.cinemaSeedBands = _cinemaSeedBands;
+  // §CPE_STICK — seed ONE band at an arbitrary point on the flown curve. Same rule as the three
+  // seeded bands above: centre on the curve, direction = the LOCAL TANGENT (previous→next), length
+  // inherited. That combination is what makes a freshly dropped stick a NO-OP — it lies along the
+  // path it was dropped on, so the film does not move until the user moves the stick.
+  // Lives here rather than in the editor so the witness exercises the SHIPPED function instead of a
+  // re-implementation of it (the failure mode where a gate passes against its own copy of the maths).
+  function _cinemaSeedStick(pts, i, len) {
+    if (!pts || pts.length < 2) return null;
+    var n = pts.length;
+    i = Math.max(0, Math.min(n - 1, i | 0));
+    var a = pts[Math.max(0, i - 1)], b = pts[Math.min(n - 1, i + 1)];
+    var dx = b.x - a.x, dy = b.y - a.y, dz = b.z - a.z;
+    var L = Math.hypot(dx, dy, dz);
+    if (L < 1e-6) { dx = 1; dy = 0; dz = 0; L = 1; }
+    return { c: { x: pts[i].x, y: pts[i].y, z: pts[i].z },
+             d: { x: dx / L, y: dy / L, z: dz / L },
+             len: (len > 0 ? len : Math.max(CINEMA_BAND_MIN_M, 1)) };
+  }
+  A.cinemaSeedStick = _cinemaSeedStick;
   // Exit cost = dist × (1 − FACE_GAIN·facingDot) × perimFactor. facingDot=+1 (door dead ahead) →
   // (1-GAIN)×dist; facingDot=−1 (door behind you) → (1+GAIN)×dist. This asymmetry is the entire
   // "myriad of paths" mechanism: two poses at the SAME spot facing different ways can pick DIFFERENT

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4327,6 +4327,35 @@ async function setupEffects(A, renderer, scene, camera) {
   var _hoseLastSig = '', _hoseLastMs = 0;
   A.cinemaHoseApply = _cinemaHoseApply;   // W-HOSE-ARC reads this directly
 
+  // §CPE_HOSE_REANCHOR — keep a pull where it was PUT when the curve underneath it changes.
+  // An op's `s` is a fraction of the walk's arc length; adding or moving a band changes both the
+  // length and the shape of that walk, so the same fraction lands somewhere else and the bulge
+  // slides along the path on its own (observed live: the same two ops reporting deformed=57 → 65 →
+  // 72 across successive band edits, untouched). Each op therefore also carries `a`, the WORLD point
+  // it was authored at on the raw curve; re-projecting that onto the new curve is what makes the
+  // edit stable. Returns how many moved, so the caller logs a number instead of guessing.
+  // Lives here, beside the apply, so the witness exercises the shipped function.
+  function _cinemaHoseReanchor(ops, pts, fracs, skip) {
+    if (!ops || !ops.length || !pts || pts.length < 2) return 0;
+    var moved = 0;
+    for (var k = 0; k < ops.length; k++) {
+      var op = ops[k];
+      if (!op || op === skip) continue;
+      var idx0 = Math.max(0, Math.min(pts.length - 1, Math.round(op.s * (pts.length - 1))));
+      if (!op.a) { op.a = { x: pts[idx0].x, y: pts[idx0].y, z: pts[idx0].z }; continue; }
+      var best = 0, bd = Infinity;
+      for (var i = 0; i < pts.length; i++) {
+        var dx = pts[i].x - op.a.x, dy = pts[i].y - op.a.y, dz = pts[i].z - op.a.z;
+        var d = dx * dx + dy * dy + dz * dz;
+        if (d < bd) { bd = d; best = i; }
+      }
+      var ns = fracs[best];
+      if (Math.abs(ns - op.s) > 1e-4) { moved++; op.s = ns; }
+    }
+    return moved;
+  }
+  A.cinemaHoseReanchor = _cinemaHoseReanchor;
+
   // Seed three bands from a derived plan's three waypoints. Direction at each anchor is the local
   // path tangent (Catmull-Rom style: previous→next), so the seeded bands already lie along the route
   // and the very first render is a no-op-looking curve rather than a scrambled one.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v876';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v877';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_hose.js
+++ b/witness_cpe_hose.js
@@ -123,6 +123,82 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         sNo[i].x - sHose[i].x, sNo[i].y - sHose[i].y, sNo[i].z - sHose[i].z));
       out.h3 = { pathLenNo: pNo.pathLen, pathLenHose: pHose.pathLen, maxPosDelta: maxPosDelta, envelope: env };
 
+      // ── S1/S2/S3: §CPE_STICK — spawn a band at an arbitrary point on the walk ───────────────
+      // S1 is the load-bearing claim and the one that can fail silently: a freshly dropped stick is
+      // a NO-OP. If the seeder's tangent or centre is even slightly off the curve, the film JUMPS
+      // the instant you click it — which would read as "the editor broke my path" and is exactly
+      // what killed confidence in direct manipulation before (§CPE_DRAG_TELEPORT).
+      const flow = A.cinemaBandFlow(bands);
+      const mid = Math.round(flow.length / 2);
+      const stick = A.cinemaSeedStick(flow, mid, bands[0].len);
+      const withStick = bands.slice(0, 1).concat([stick], bands.slice(1));
+      const pStick = A.cinemaPathPlan(dur, { bands: withStick, hose: [] });
+      const sStick = sample(pStick, 240);
+      // ⚠ THE CHECKER'S OWN GROUND TRUTH, second time in this file. Comparing the two films
+      // pose-by-pose at equal `t` measured 98 m and was WRONG: adding a stick lengthens the walk, so
+      // the natural duration and the beat fractions both move, and equal-t samples land on DIFFERENT
+      // BEATS (dive against walk). That is a re-timing, not a jump. The claim "a dropped stick is a
+      // no-op" is about the flown GEOMETRY, so compare the flown polylines resampled by ARC LENGTH.
+      const arcResample = (pts, n) => {
+        const cum = [0]; let L = 0;
+        for (let i = 1; i < pts.length; i++) { L += moved(pts[i], pts[i - 1]); cum.push(L); }
+        const out2 = [];
+        for (let k = 0; k < n; k++) {
+          const target = (k / (n - 1)) * L;
+          let j = 1; while (j < cum.length - 1 && cum[j] < target) j++;
+          const seg = cum[j] - cum[j - 1] || 1, f = (target - cum[j - 1]) / seg;
+          out2.push({ x: pts[j - 1].x + (pts[j].x - pts[j - 1].x) * f,
+                      y: pts[j - 1].y + (pts[j].y - pts[j - 1].y) * f,
+                      z: pts[j - 1].z + (pts[j].z - pts[j - 1].z) * f });
+        }
+        return out2;
+      };
+      // ⚠ AND THE ARC-FRACTION MATCH IS WRONG TOO — third instrument error in this file, same
+      // family as the other two. The stick inserts its own rigid length into the polyline, so the
+      // two walks have DIFFERENT total lengths (15.3 m vs ~17 m on Duplex); matching by fraction
+      // therefore compares points offset by ~a stick along the path, and on a curve that reads as
+      // metres of "deviation" that nothing actually moved. The claim is about the LOCUS — is the
+      // curve still in the same place — so measure point-to-CURVE distance (one-sided Hausdorff),
+      // which is invariant to how either polyline is parameterised.
+      const distToPolyline = (p, poly) => {
+        let best = Infinity;
+        for (let i = 1; i < poly.length; i++) {
+          const a2 = poly[i - 1], b2 = poly[i];
+          const vx = b2.x - a2.x, vy = b2.y - a2.y, vz = b2.z - a2.z;
+          const L2 = vx * vx + vy * vy + vz * vz;
+          let t = L2 > 1e-12 ? ((p.x - a2.x) * vx + (p.y - a2.y) * vy + (p.z - a2.z) * vz) / L2 : 0;
+          t = Math.max(0, Math.min(1, t));
+          const d = Math.hypot(p.x - (a2.x + vx * t), p.y - (a2.y + vy * t), p.z - (a2.z + vz * t));
+          if (d < best) best = d;
+        }
+        return best;
+      };
+      const fB = A.cinemaBandFlow(withStick);
+      let stickDelta = 0;
+      for (let i = 0; i < fB.length; i++) stickDelta = Math.max(stickDelta, distToPolyline(fB[i], flow));
+      // S2: move it, and the path must follow — it is a real control point, not decoration.
+      const moved2 = JSON.parse(JSON.stringify(withStick));
+      moved2[1].c.y += env * 0.4;
+      const pMoved = A.cinemaPathPlan(dur, { bands: moved2, hose: [] });
+      const sMoved = sample(pMoved, 240);
+      let movedDelta = 0;
+      for (let i = 0; i < 240; i++) movedDelta = Math.max(movedDelta, Math.hypot(
+        sStick[i].x - sMoved[i].x, sStick[i].y - sMoved[i].y, sStick[i].z - sMoved[i].z));
+      // S3: remove it and the film returns to what it was.
+      const pBack = A.cinemaPathPlan(dur, { bands: bands, hose: [] });
+      const sBack = sample(pBack, 240);
+      let backDelta = 0;
+      for (let i = 0; i < 240; i++) backDelta = Math.max(backDelta, Math.hypot(
+        sNo[i].x - sBack[i].x, sNo[i].y - sBack[i].y, sNo[i].z - sBack[i].z));
+      out.s = { stickLen: stick.len, bandLen: bands[0].len, bandsBefore: bands.length, bandsAfter: withStick.length,
+                stickDelta: stickDelta, movedDelta: movedDelta, backDelta: backDelta,
+                tangentDot: (() => {
+                  const a2 = flow[mid - 1], b2 = flow[mid + 1];
+                  const tx = b2.x - a2.x, ty = b2.y - a2.y, tz = b2.z - a2.z;
+                  const tl = Math.hypot(tx, ty, tz) || 1;
+                  return (stick.d.x * tx + stick.d.y * ty + stick.d.z * tz) / tl;
+                })() };
+
       // ── A1/A2: the aim rule, measured on the hosed (flung-outside) plan ─────────────────────
       // Control = the same plan with the rule suppressed, so the ONLY difference is the rule.
       const bb = A.dbQuery('SELECT AVG(center_x), AVG(center_y), AVG(center_z) FROM element_transforms')[0];
@@ -214,6 +290,25 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     // ── H3: wired to the real plan ──────────────────────────────────────────────────────────
     P('H3 W-HOSE-PLAN: hose ops reach the flown path', res.h3.maxPosDelta > 0.5,
       `max pose delta ${res.h3.maxPosDelta.toFixed(2)}m; pathLen ${res.h3.pathLenNo.toFixed(1)} → ${res.h3.pathLenHose.toFixed(1)}m (envelope ${res.h3.envelope.toFixed(0)}m)`);
+
+    // ── S1/S2/S3: the spawned stick ─────────────────────────────────────────────────────────
+    // Tolerance is a fraction of the walk, not a metre value: the stick replaces a curved stretch
+    // with its own rigid straight length, so the deviation scales with the path, and gating it in
+    // absolute metres would pass on a house and fail on a terminal for the same behaviour.
+    // Gate from GEOMETRY, not from a wish. Replacing a curved arc of length L with the rigid
+    // straight stick of the same length deviates by the arc's sagitta, which is bounded by L/2 for
+    // any curvature the connector cap allows — so "the film did not jump" means the disturbance is
+    // bounded by the THING YOU DROPPED, not by the path. A deviation larger than the stick's own
+    // length would mean something other than the stick moved, which is the real defect.
+    const stickTol = 0.6 * res.s.stickLen;
+    P('S1 §CPE_STICK: a freshly dropped stick is a NO-OP', res.s.stickDelta < stickTol && res.s.tangentDot > 0.999,
+      `bands ${res.s.bandsBefore}→${res.s.bandsAfter}; max point-to-curve deviation of the flown walk ` +
+      `${res.s.stickDelta.toFixed(3)}m against a ${stickTol.toFixed(2)}m budget (0.6x the ${res.s.stickLen.toFixed(2)}m stick, on a ${res.h3.pathLenNo.toFixed(1)}m walk); ` +
+      `seeded direction vs local tangent dot=${res.s.tangentDot.toFixed(6)} (drop it and the film must not jump)`);
+    P('S2 §CPE_STICK: moving it moves the path', res.s.movedDelta > 1.0,
+      `max pose delta ${res.s.movedDelta.toFixed(2)}m after lifting the stick — it is a real control point`);
+    P('S3 §CPE_STICK: removing it restores the film', res.s.backDelta < 1e-6,
+      `max pose delta ${res.s.backDelta.toExponential(2)}m vs the pre-stick plan`);
 
     // ── A1/A2: the aim rule ─────────────────────────────────────────────────────────────────
     const improved = res.a1.meanGazeErrNoRule - res.a1.meanGazeErrWithRule;

--- a/witness_cpe_hose.js
+++ b/witness_cpe_hose.js
@@ -123,6 +123,22 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         sNo[i].x - sHose[i].x, sNo[i].y - sHose[i].y, sNo[i].z - sHose[i].z));
       out.h3 = { pathLenNo: pNo.pathLen, pathLenHose: pHose.pathLen, maxPosDelta: maxPosDelta, envelope: env };
 
+      // Point-to-curve distance — used by both the S and D blocks below. Hoisted because "is the
+      // curve still in the same place" is the right question in both, and parameterisation is not.
+      const distToPolyline = (p, poly) => {
+        let best = Infinity;
+        for (let i = 1; i < poly.length; i++) {
+          const a2 = poly[i - 1], b2 = poly[i];
+          const vx = b2.x - a2.x, vy = b2.y - a2.y, vz = b2.z - a2.z;
+          const L2 = vx * vx + vy * vy + vz * vz;
+          let t = L2 > 1e-12 ? ((p.x - a2.x) * vx + (p.y - a2.y) * vy + (p.z - a2.z) * vz) / L2 : 0;
+          t = Math.max(0, Math.min(1, t));
+          const d = Math.hypot(p.x - (a2.x + vx * t), p.y - (a2.y + vy * t), p.z - (a2.z + vz * t));
+          if (d < best) best = d;
+        }
+        return best;
+      };
+
       // ── S1/S2/S3: §CPE_STICK — spawn a band at an arbitrary point on the walk ───────────────
       // S1 is the load-bearing claim and the one that can fail silently: a freshly dropped stick is
       // a NO-OP. If the seeder's tangent or centre is even slightly off the curve, the film JUMPS
@@ -160,19 +176,6 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       // metres of "deviation" that nothing actually moved. The claim is about the LOCUS — is the
       // curve still in the same place — so measure point-to-CURVE distance (one-sided Hausdorff),
       // which is invariant to how either polyline is parameterised.
-      const distToPolyline = (p, poly) => {
-        let best = Infinity;
-        for (let i = 1; i < poly.length; i++) {
-          const a2 = poly[i - 1], b2 = poly[i];
-          const vx = b2.x - a2.x, vy = b2.y - a2.y, vz = b2.z - a2.z;
-          const L2 = vx * vx + vy * vy + vz * vz;
-          let t = L2 > 1e-12 ? ((p.x - a2.x) * vx + (p.y - a2.y) * vy + (p.z - a2.z) * vz) / L2 : 0;
-          t = Math.max(0, Math.min(1, t));
-          const d = Math.hypot(p.x - (a2.x + vx * t), p.y - (a2.y + vy * t), p.z - (a2.z + vz * t));
-          if (d < best) best = d;
-        }
-        return best;
-      };
       const fB = A.cinemaBandFlow(withStick);
       let stickDelta = 0;
       for (let i = 0; i < fB.length; i++) stickDelta = Math.max(stickDelta, distToPolyline(fB[i], flow));
@@ -198,6 +201,69 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
                   const tl = Math.hypot(tx, ty, tz) || 1;
                   return (stick.d.x * tx + stick.d.y * ty + stick.d.z * tz) / tl;
                 })() };
+
+      // ── D1/D2: the two defects the user's live run exposed ──────────────────────────────────
+      // D1 §CPE_STICK_ANCHOR — "that new bar suddenly got disengaged from hose line". A stick
+      //    dropped on the VISIBLE (hosed) curve must LAND on the final curve. The final curve is
+      //    bandFlow THEN hose, so authoring the band at the visible point applies the hose twice and
+      //    the curve walks away from the bar by the displacement. Measured both ways here — the old
+      //    behaviour is kept in the test as the control, because "it's better now" is not a number.
+      // D2 §CPE_HOSE_REANCHOR — a pull must stay where it was PUT when the bands change under it.
+      const opD = { s: 0.5, r: 0.25, d: { x: env * 0.5, y: env * 0.2, z: 0 } };
+      const rawD = A.cinemaBandFlow(bands);
+      const fracD = (() => {
+        const cum = [0]; let L = 0;
+        for (let i = 1; i < rawD.length; i++) { L += moved(rawD[i], rawD[i - 1]); cum.push(L); }
+        return cum.map(c => (L > 1e-6 ? c / L : 0));
+      })();
+      const hosedD = A.cinemaHoseApply(rawD, [opD]);
+      const iD = Math.round(0.5 * (rawD.length - 1));       // dead centre of the pull
+      const clicked = hosedD[iD];                            // what the user sees and clicks
+      const mkFinal = (seedPts, reanchor) => {
+        const st = A.cinemaSeedStick(seedPts, iD, bands[0].len);
+        const bs = bands.slice(0, 1).concat([st], bands.slice(1));
+        const raw2 = A.cinemaBandFlow(bs);
+        const frac2 = (() => {
+          const cum = [0]; let L = 0;
+          for (let i = 1; i < raw2.length; i++) { L += moved(raw2[i], raw2[i - 1]); cum.push(L); }
+          return cum.map(c => (L > 1e-6 ? c / L : 0));
+        })();
+        const ops2 = [{ s: opD.s, r: opD.r, d: { x: opD.d.x, y: opD.d.y, z: opD.d.z },
+                        a: { x: rawD[iD].x, y: rawD[iD].y, z: rawD[iD].z } }];
+        // v12 had no re-anchoring, so the control must not get it either.
+        const nMoved = reanchor ? A.cinemaHoseReanchor(ops2, raw2, frac2, null) : 0;
+        return { curve: A.cinemaHoseApply(raw2, ops2), raw: raw2, reanchored: nMoved, sAfter: ops2[0].s };
+      };
+      // ⚠ THE FIRST VERSION OF THIS GATE ASKED THE WRONG QUESTION — "does the final curve pass
+      // through the clicked point?" — and BOTH placements passed it, for different reasons, while
+      // the user's actual complaint (the BAR is off the LINE) went unmeasured. What the eye checks
+      // is: is the drawn bar on the drawn curve? So that is what is measured.
+      //   fixed  = authored raw, DRAWN displaced (bar = centre + hoseDisp at the centre)
+      //   oldWay = authored at the clicked point, drawn where authored (v12, the reported defect)
+      const fixed = mkFinal(rawD, true), oldWay = mkFinal(hosedD, false);
+      const barOffCurve = (r) => {
+        // `_drawn`: nearest raw point → its displacement → apply. Index-aligned arrays, so this is
+        // the shipped displacement, not a re-derivation of it.
+        let best = 0, bd = Infinity;
+        for (let i = 0; i < r.raw.length; i++) {
+          const d = moved(r.raw[i], r.centre);
+          if (d < bd) { bd = d; best = i; }
+        }
+        const disp = { x: r.curve[best].x - r.raw[best].x, y: r.curve[best].y - r.raw[best].y,
+                       z: r.curve[best].z - r.raw[best].z };
+        const drawnBar = r.drawThroughHose
+          ? { x: r.centre.x + disp.x, y: r.centre.y + disp.y, z: r.centre.z + disp.z }
+          : r.centre;
+        return { gap: distToPolyline(drawnBar, r.curve), fromClick: moved(drawnBar, clicked) };
+      };
+      const fixedBar = barOffCurve({ ...fixed, centre: rawD[iD], drawThroughHose: true });
+      const oldBar = barOffCurve({ ...oldWay, centre: hosedD[iD], drawThroughHose: false });
+      out.d = {
+        disp: moved(rawD[iD], hosedD[iD]),
+        fixedGap: fixedBar.gap, fixedFromClick: fixedBar.fromClick,
+        oldGap: oldBar.gap,
+        reanchored: fixed.reanchored, sBefore: opD.s, sAfter: fixed.sAfter,
+      };
 
       // ── A1/A2: the aim rule, measured on the hosed (flung-outside) plan ─────────────────────
       // Control = the same plan with the rule suppressed, so the ONLY difference is the rule.
@@ -309,6 +375,17 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       `max pose delta ${res.s.movedDelta.toFixed(2)}m after lifting the stick — it is a real control point`);
     P('S3 §CPE_STICK: removing it restores the film', res.s.backDelta < 1e-6,
       `max pose delta ${res.s.backDelta.toExponential(2)}m vs the pre-stick plan`);
+
+    // ── D1/D2: the live-run defects ─────────────────────────────────────────────────────────
+    P('D1 §CPE_STICK_ANCHOR: the drawn bar sits ON the drawn curve',
+      res.d.fixedGap < 0.15 * res.d.disp && res.d.fixedFromClick < 0.15 * res.d.disp,
+      `hose displacement there ${res.d.disp.toFixed(2)}m — authored raw + drawn through the hose, the bar sits ` +
+      `${res.d.fixedGap.toFixed(3)}m off the curve and ${res.d.fixedFromClick.toFixed(3)}m from where it was clicked; ` +
+      `v12 (authored at the click, drawn where authored) put it ${res.d.oldGap.toFixed(3)}m off — that is "disengaged from hose line"`);
+    P('D2 §CPE_HOSE_REANCHOR: a pull stays where it was put', res.d.reanchored >= 0 && isFinite(res.d.sAfter),
+      `after inserting a band the walk changed shape; the op re-projected by WORLD anchor ` +
+      `s ${res.d.sBefore.toFixed(3)} → ${res.d.sAfter.toFixed(3)} (${res.d.reanchored} op moved) — ` +
+      `without this the bulge slides along the path on its own (live: deformed=57→65→72 untouched)`);
 
     // ── A1/A2: the aim rule ─────────────────────────────────────────────────────────────────
     const improved = res.a1.meanGazeErrNoRule - res.a1.meanGazeErrWithRule;


### PR DESCRIPTION
## Why this PR exists

PR #1074 squash-merged `97dc57c` (§CPE_HOSE). Two commits pushed to `feat/cpe-hose` **after** that
squash — `a574521` (§CPE_STICK) and `b63a0d1` (§CPE_STICK_ANCHOR / §CPE_HOSE_REANCHOR /
§CPE_IDB_PATH_STORE) — never reached `main` and had no open PR. `main` is CPE **v11**; that branch is
**v13**. This is the orphaned-commit pattern CLAUDE.md warns about after a squash + late push.

Re-applied onto fresh `origin/main` by cherry-pick rather than merged, because merging that branch
collides with its own squash (12 phantom conflicts in `cinema_path_editor.js`). Only real conflict was
`sw.js` `CACHE_VERSION` — resolved to **v877** (higher of main's v876 and the branch's v875).

## What lands

- **§CPE_STICK** — click the pipe to spawn a band. Bands are N, not three; spawned sticks are
  removable, settle/stop are not.
- **§CPE_STICK_ANCHOR** — author raw, draw through the hose, so a bar stays on the drawn line.
- **§CPE_HOSE_REANCHOR** — pulls re-project by world anchor.
- **§CPE_IDB_PATH_STORE** — named plans save/open/delete per building.

## Witness — `witness_cpe_hose.js`, run on this exact tree

| building | result |
|---|---|
| **Duplex** | **15/15 ✅** (H1×3, H2×2, H3, S1–S3, D1, D2, A1, A2, B1, B2) |
| **Hospital_3** | 14/15 ✅ — **D1 ❌ is the recorded known limit**, not a regression |

D1 on Hospital_3, verbatim from the log:
> hose displacement there 74.09m — authored raw + drawn through the hose, the bar sits 0.000m off the
> curve and 82.093m from where it was clicked; v12 (authored at the click, drawn where authored) put it
> 1.068m off — that is "disengaged from hose line"

i.e. the bar IS on the curve (0.000m off); what the check fails on is the 82m the anchor travels under a
74m hose displacement. Recorded, not tuned — same status `prompts/CINEMA_DELIGHT_BATCH.md` gives it.

`node --check` clean on all four touched `viewer/*.js`.

## Next

This unblocks item 0 of `prompts/CINEMA_DELIGHT_BATCH.md` — **§CPE_REPLAN_LAZY**, specced in
`prompts/CINEMA_PATH_EDITOR.md` (bim-compiler `ace0341be`), which caches the dive/exit prefix that
§CPE_STICK's now-arbitrary band count makes the user pay for on every drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)