### PR TITLE
§CPE_REOPEN_DOUBLE — the band count doubled on every re-open of an authored path

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v13 (§CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v14 (§CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -1397,9 +1397,25 @@
         console.warn('§CPE_SKIP no waypoints to seed bands from — proceeding unchanged');
         return resolve({ action: 'ok', override: null, durationSec: ctx.durationSec });
       }
-      var seeded = a.cinemaSeedBands(plan.waypoints, plan.pathLen);
+      // §CPE_REOPEN_DOUBLE (CINEMA_PATH_EDITOR.md — user: "it seems to dupe more bars upon alt-c
+      // cancel and resume"). ADOPT the authored bands when the plan was built from them; only SEED
+      // when there are none. The two functions have reciprocal fan-out — _cinemaSeedBands emits one
+      // band per waypoint, _cinemaBandWaypoints emits two waypoints per band — so re-seeding an
+      // authored plan's waypoints DOUBLED the count on every open (N → 2N → 4N), and any save taken
+      // after a re-open stored a band list the user never authored. Cancel was never implicated: it
+      // is the staged override (A._cinemaPathEdit) that feeds the doubled plan back in.
+      // A derived plan carries `bands: null`, so the first open of an unauthored building still runs
+      // the seeder and is byte-identical to before.
+      var authored = !!(plan.bands && plan.bands.length >= 2);
+      var seeded = authored ? plan.bands : a.cinemaSeedBands(plan.waypoints, plan.pathLen);
       var clone = function(bs) {
-        return bs.map(function(b) { return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len }; });
+        return bs.map(function(b, i) {
+          var o = { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
+          // Re-flag the middles so a re-opened stick keeps its × remove affordance, exactly as
+          // _pathsApply does when loading a stored plan.
+          if (authored && i > 0 && i < bs.length - 1) o._stick = true;
+          return o;
+        });
       };
       _state = {
         bands: clone(seeded), origBands: clone(seeded), staged: false, undo: [], redo: [],
@@ -1424,7 +1440,8 @@
                    tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z },
         controlsWere: a.controls ? a.controls.enabled : true
       };
-      console.log('§CPE_OPEN bands=' + _state.bands.length + ' waypoints=' + (_state.bands.length * 2) +
+      console.log('§CPE_OPEN src=' + (authored ? 'authored' : 'seeded') +
+        ' bands=' + _state.bands.length + ' waypoints=' + (_state.bands.length * 2) +
         ' bandLen=' + _state.bands[0].len.toFixed(2) + 'm pathLen=' + plan.pathLen.toFixed(1) +
         'm speed=' + _state.speed.toFixed(2) + 'm/s total=' + ctx.durationSec.toFixed(1) + 's');
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v877';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v878';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_hose.js
+++ b/witness_cpe_hose.js
@@ -202,6 +202,32 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
                   return (stick.d.x * tx + stick.d.y * ty + stick.d.z * tz) / tl;
                 })() };
 
+      // ── R1/R2: §CPE_REOPEN_DOUBLE — re-opening an authored path must not multiply the bands ──
+      // The user's report: "it seems to dupe more bars upon alt-c cancel and resume". The mechanism
+      // is reciprocal fan-out — cinemaSeedBands emits ONE band per waypoint, cinemaBandWaypoints
+      // emits TWO waypoints per band — so re-seeding an authored plan's waypoints doubles the count
+      // on every open. R1 measures the doubling directly so the fix is proven against a NUMBER, not
+      // against the absence of a complaint; R2 checks the adoption source is the authored bands
+      // themselves, not a re-derivation that merely happens to have the right length.
+      const pAuth = A.cinemaPathPlan(dur, { bands: withStick, hose: [] });
+      const reSeed = A.cinemaSeedBands(pAuth.waypoints, pAuth.pathLen);
+      let adoptMax = Infinity;
+      if (pAuth.bands && pAuth.bands.length === withStick.length) {
+        adoptMax = 0;
+        for (let i = 0; i < withStick.length; i++) {
+          const a3 = pAuth.bands[i], b3 = withStick[i];
+          adoptMax = Math.max(adoptMax,
+            Math.hypot(a3.c.x - b3.c.x, a3.c.y - b3.c.y, a3.c.z - b3.c.z),
+            Math.hypot(a3.d.x - b3.d.x, a3.d.y - b3.d.y, a3.d.z - b3.d.z),
+            Math.abs(a3.len - b3.len));
+        }
+      }
+      out.r = { authoredN: withStick.length,
+                planBandsN: pAuth.bands ? pAuth.bands.length : 0,
+                reSeedN: reSeed ? reSeed.length : 0,
+                adoptMax: adoptMax,
+                waypoints: pAuth.waypoints.length };
+
       // ── D1/D2: the two defects the user's live run exposed ──────────────────────────────────
       // D1 §CPE_STICK_ANCHOR — "that new bar suddenly got disengaged from hose line". A stick
       //    dropped on the VISIBLE (hosed) curve must LAND on the final curve. The final curve is
@@ -389,6 +415,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
     // ── A1/A2: the aim rule ─────────────────────────────────────────────────────────────────
     const improved = res.a1.meanGazeErrNoRule - res.a1.meanGazeErrWithRule;
+    P('R1 §CPE_REOPEN_DOUBLE: adopting the plan bands does not multiply them',
+      res.r.planBandsN === res.r.authoredN && res.r.reSeedN === 2 * res.r.authoredN,
+      `authored ${res.r.authoredN} bands -> plan carries ${res.r.planBandsN} (adopted, correct); re-seeding the SAME plan's ${res.r.waypoints} waypoints gives ${res.r.reSeedN} — that doubling IS the bug, measured`);
+    P('R2 §CPE_REOPEN_DOUBLE: the adopted bands ARE the authored ones',
+      res.r.adoptMax < 1e-6,
+      `max centre/direction/length deviation ${res.r.adoptMax.toExponential(2)} over ${res.r.authoredN} bands (tol 1e-6) — adoption, not re-derivation`);
     P('A1 §CPE_AIM_DENSITY: gaze turns toward the mass', improved > 0.5,
       `mean angle to building centroid ${res.a1.meanGazeErrNoRule.toFixed(1)}° without the rule → ` +
       `${res.a1.meanGazeErrWithRule.toFixed(1)}° with it (improvement ${improved.toFixed(1)}°, ${res.a1.frames} frames)`);


### PR DESCRIPTION
User report: *"it seems to dupe more bars upon alt-c cancel and resume, so when i reopen saved path it
gave me back my last count."*

## The mechanism — reciprocal fan-out, composed in a loop

- `_cinemaSeedBands(wp)` emits **one band per waypoint**.
- `_cinemaBandWaypoints(bands)` emits **two waypoints per band** (hence `§CPE_OPEN waypoints = bands*2`).

`open()` re-seeded from `plan.waypoints` **unconditionally** — including when the plan was itself built
FROM authored bands. So N → 2N → 4N, once per open, forever. **Every save taken after a re-open stored a
band list the user never authored**, which is why this outranked the perf work queued behind it.

Cancel was never implicated: `finish('cancel')` correctly returns `override: null`. What feeds the
doubled plan back in is the staged `A._cinemaPathEdit` from an earlier *Save this path* / OK.

## The fix — adoption, not arithmetic

`_cinemaPathPlan` already returns `bands: _cpeBands ? …map(c,d,len) : null` — the authored bands,
verbatim — and `open()` ignored it. Now it adopts them when present and seeds only when there are none.
Middles are re-flagged `_stick` so a re-opened stick keeps its `×`, exactly as `_pathsApply` does.
A derived plan carries `bands: null`, so the first open of an unauthored building still seeds and is
byte-identical to before. `§CPE_OPEN` gains `src=authored|seeded`.

## Witness — `witness_cpe_hose.js`, Duplex **17/17 ✅**

R1 is written to measure **the defect**, not its absence:
> authored 4 bands -> plan carries 4 (adopted, correct); re-seeding the SAME plan's 8 waypoints gives 8
> — that doubling IS the bug, measured

> R2: max centre/direction/length deviation **0.00e+0** over 4 bands (tol 1e-6) — adoption, not re-derivation

H1×3, H2×2, H3, S1–S3, D1, D2, A1, A2, B1, B2 all green alongside.

CPE **v14**, sw **v878**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)