### PR TITLE
§CPE_PREVIEW_AFTER_RETIRED + §CPE_BUILDUP_FOLLOW_TM — OK records without a rehearsal; the film plays the Time Machine instead of re-keying it

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v15 (§CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §CPE_BUILDUP mode-D construction follows the camera; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v16 (§CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §CPE_BUILDUP mode-D construction follows the camera; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -642,28 +642,25 @@
         if (nFrames !== _framesWas)
           console.log('§MAXQ_START_REVISED frames=' + _framesWas + '→' + nFrames +
             ' (path edited; §MAXQ_START above is superseded)');
-        // ══ §CPE_PREVIEW_AFTER (CINEMA_PATH_EDITOR.md ask 5) — the preview you get AFTER you edit.
-        // Until now the only 10s rehearsal ran BEFORE the editor opened, so it showed the DERIVED
-        // path — the one film you already knew you did not want, which is why you opened the editor.
-        // The film you actually authored went straight to a ten-minute bake unseen. Confirmed absent
-        // in the user's own console: §CPE_CLOSE -> §CPE_APPLIED -> §MAXQ_FRAME i=0, with no second
-        // §MAXQ_PREVIEW between them.
+        // ══ §CPE_PREVIEW_AFTER_RETIRED (prompts/CINEMA_PATH_EDITOR.md, user 2026-07-29: "when OK, do
+        // not run preview again as there is already a Preview button") — the 10 s flight of the EDITED
+        // path used to run HERE, between §CPE_APPLIED and frame 0.
         //
-        // It runs ONLY when the path was really edited. An untouched OK re-uses the plan object
-        // computed before the editor opened (guardrail 2, see the else branch), so a second preview
-        // there would be ten seconds spent proving nothing changed — and "the default cost of this
-        // feature is one click and nothing else" is a promise this must not quietly break.
+        // It was written for a build where the editor could not preview at all: the film you authored
+        // went straight to a ten-minute bake unseen, so a forced rehearsal was the only way to catch a
+        // bad edit. §CPE_PREVIEW_BUTTON closed that gap directly and better — it flies the CURRENT edit
+        // on demand, any number of times, and its stale marker ('Preview ●') answers "have I seen THIS
+        // version?" without guessing. What was left here was ten forced seconds proving something the
+        // user had already chosen when to see. This is the same cut §CPE_PREVIEW_REDUNDANT made above
+        // for the PRE-editor rehearsal, on the same reasoning, applied to the other end.
         //
-        // `plan` was reassigned three lines up, and poseAt() resolves `plan` at call time, so this
-        // flies the EDITED plan through the identical function the bake steps frame by frame. Not
-        // a re-implementation of the path: the same one, which is the whole point.
-        if (opts.preview !== false) {
-          if (await _runPreview('edited', '🎬 Preview of YOUR edit (10s) — the ' + nFrames +
-                                          '-frame bake follows; Alt+C cancels')) {
-            _cancelledOut('the edited-path preview');
-            return;
-          }
-        }
+        // The trade, stated rather than glossed: the replacement is opt-in, so a user who never presses
+        // Preview now bakes unseen. That is the user's ruling, consistent with how they ruled on the
+        // pre-editor preview.
+        //
+        // `_runPreview` STAYS — the `opts.editor === false` branch above (scripted/witness bakes: no
+        // panel, therefore no Preview button) is the one caller that still needs a rehearsal, and
+        // `opts.preview` keeps its meaning for it.
       } else {
         // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
         // literally the same object, so the film is byte-identical to one recorded without the

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,7 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v16 (§CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §CPE_BUILDUP mode-D construction follows the camera; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v17 (§CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -726,33 +726,29 @@
           console.warn('§CPE_BUILDUP_SKIP reason=no derived build order (Time Machine has no ops for this building)');
           _buildup = false;
         } else {
-          // ══ §CPE_BUILDUP_REAL_SCHEDULE §3.3 — REAL schedule if the building has one, else mode D ══
-          // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §3.3
-          // Witnesses: W-SCHED-REAL-ORDER, W-SCHED-FALLBACK
-          // Before this branch, tmOrderByCameraPath ran unconditionally and OVERWROTE the real task
-          // dates injectGantt had just written — so a building WITH a linked schedule baked a
-          // byte-identical film to one with none (§2, the defect). The derived path below is
-          // untouched: no usable `tasks` → same call, same args, same behaviour as before (that is
-          // exactly what W-SCHED-FALLBACK gates).
-          var _ss = (typeof window.tmScheduleSource === 'function') ? window.tmScheduleSource() : null;
-          _bkState = null;
-          if (_ss && _ss.source === 'captured' && typeof window.tmOrderBySchedule === 'function') {
-            _bkState = window.tmOrderBySchedule();
-            // A degraded real schedule must never be WORSE than no schedule: fall through to mode D.
-            if (!_bkState) console.warn('§CPE_BUILDUP_SOURCE fallthrough reason=captured-but-unusable — using the derived order');
-          }
-          if (!_bkState) {
-            _bkState = window.tmOrderByCameraPath(function(t) { return plan ? plan.poseAt(t) : poseAt(t); }, nFrames);
-          }
-          if (!_bkState) { console.warn('§CPE_BUILDUP_SKIP reason=re-key failed — baking without the buildup'); _buildup = false; }
+          // ══ §CPE_BUILDUP_FOLLOW_TM — the film PLAYS the Time Machine, it does not author an order ══
+          // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_SOURCE_BLIND
+          // User, 2026-07-29: "do not bake anything for TM.. it is user's own plan" /
+          // "this practices good separation of tasks" / "so buildup it gives as it is basis".
+          //
+          // What this replaces: mode D (tmOrderByCameraPath) re-keyed every op to camera-path
+          // proximity. §CPE_BUILDUP_REAL_SCHEDULE had already stopped it eating a CAPTURED schedule,
+          // but a GENERATED timeline — schedule_gate's geometry-gated bottom-up order, which is what
+          // the TM drawer is showing — was still discarded. Reported live on Hospital (63,439 ops, 36
+          // mini-Gantt bars, zero rows in `tasks`): proximity to a 73.6m walk through a building of
+          // boundingR=91.4 reveals every storey at once, which is the "flattens too much too early"
+          // the user saw. One verb now decides for BOTH callers, so the Preview and the bake can no
+          // longer disagree about what they are showing.
+          _bkState = (typeof window.tmFollowTimeline === 'function') ? window.tmFollowTimeline() : null;
+          if (!_bkState) { console.warn('§CPE_BUILDUP_SKIP reason=no timeline to follow — baking without the buildup'); _buildup = false; }
           else if (_bkState.source === 'captured') {
             // §CPE_BUILDUP_REAL_SCHEDULE §5 — the label moves with the data. States scope and
             // coverage; claims NO predecessor logic, float or resources (this data carries none).
             _status('🎬 Building to the linked schedule (' + _bkState.leafTasks + ' phases, ' +
               _bkState.pct + '% of elements)');
           } else {
-            // §5 — unchanged wording for the derived branch. Never say "the schedule" here.
-            _status('🎬 Building as the camera flies (' + _bkState.placed + ' elements ordered by the path)');
+            // §5 tier 2 — a real, model-derived 4D. Never "the schedule", never "a programme".
+            _status('🎬 Building to this model\'s 4D timeline (' + _bkState.placed + ' elements, as the Time Machine has it)');
           }
         }
       }

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,7 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v14 (§CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  var CPE_V = 'v15 (§CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -552,7 +552,7 @@
           '<button id="cpe-mark-out" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">mark out</button> ' +
           '<button id="cpe-clip-clear" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">whole film</button></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox"> ' +
-          'build the model as the camera flies</label> <span style="color:#666">(derived order, not a programme)</span></div>' +
+          'build the model as the film plays</label> <span style="color:#666">(follows the Time Machine, not a programme)</span></div>' +
         // §CPE_IDB_PATH_STORE — saved plans for THIS building.
         '<div style="margin-top:6px">saved <select id="cpe-plans" style="max-width:150px;background:#15181c;color:#ddd;' +
           'border:1px solid #3a3f47;border-radius:3px;font-size:10px;padding:1px 2px"></select> ' +
@@ -993,13 +993,19 @@
         _renderWhole();
       })();
     };
-    if (!s.buildup || typeof window.tmOrderByCameraPath !== 'function') { startFly(); return; }
+    // §CPE_BUILDUP_FOLLOW_TM — this used to call tmOrderByCameraPath UNCONDITIONALLY, with no
+    // tmScheduleSource() consultation at all: the whole source-selection branch existed only in
+    // cinema_maxq.js, so on a captured-schedule building the rehearsal showed one build order and the
+    // film recorded another. Both callers now go through the single verb, so preview and bake cannot
+    // disagree — and neither of them re-keys anything.
+    if (!s.buildup || typeof window.tmFollowTimeline !== 'function') { startFly(); return; }
     (async function() {
       try {
         var t0b = performance.now();
         var ok = await window.tmActivateForBake();
-        if (ok) bkPrev = window.tmOrderByCameraPath(function(t) { return s.plan.poseAt(t); }, 60);
-        console.log('§CPE_PREVIEW_BUILDUP ' + (bkPrev ? 'armed ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no derived build order)') +
+        if (ok) bkPrev = window.tmFollowTimeline();
+        console.log('§CPE_PREVIEW_BUILDUP ' + (bkPrev ? 'armed mode=' + (bkPrev.source === 'captured' ? 'S' : 'T') +
+            ' ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no timeline to follow)') +
           ' setupMs=' + (performance.now() - t0b).toFixed(0) +
           ' — the same cursor Time Machine drives at playback, no new visibility mechanism');
       } catch (e) { console.warn('§CPE_PREVIEW_BUILDUP failed ' + e.message); bkPrev = null; }
@@ -1502,8 +1508,12 @@
       document.getElementById('cpe-buildup').addEventListener('change', function(e) {
         _state.buildup = !!e.target.checked;
         _markPreviewStale();
+        // §CPE_BUILDUP_FOLLOW_TM — the reveal is the Time Machine's own timeline, unmodified. The
+        // mode (S = linked schedule, T = this model's derived 4D) is decided and logged by
+        // tmFollowTimeline() at preview/bake time, because it is a property of the DATA, not of
+        // this checkbox.
         console.log('§CPE_BUILDUP ' + (_state.buildup ? 'ON' : 'off') +
-          ' — reveal follows the camera path (derived build order, NOT a construction programme)');
+          ' — reveal FOLLOWS the Time Machine timeline as-is (no re-key; the camera does not author the build order)');
         _renderWhole(); _syncButtons();
       });
       document.getElementById('cpe-preview').addEventListener('click', _previewFly);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v879';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v880';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v878';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v879';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5067,6 +5067,65 @@
              projectStart: _projectStart, projectEnd: _projectEnd };
   };
 
+  // ── §CPE_BUILDUP_FOLLOW_TM — the film PLAYS the Time Machine; it does not author a build order ──
+  // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_SOURCE_BLIND
+  // User, 2026-07-29: "do not bake anything for TM.. as i said, it is user's own plan" /
+  // "this practices good separation of tasks" — Time Machine owns the build order, Alt+C owns the
+  // camera. The film is a camera over a timeline someone else authored, and nothing about pressing
+  // Alt+C may change WHEN anything is built.
+  //
+  // This is the ONE verb both callers (the bake in cinema_maxq.js and the Preview in
+  // cinema_path_editor.js) now use, which is also the fix for those two having chosen the buildup
+  // source by different rules — the preview called tmOrderByCameraPath unconditionally while the bake
+  // consulted tmScheduleSource(), so on a captured-schedule building the rehearsal and the film could
+  // disagree about what they were showing.
+  //
+  // Like tmOrderBySchedule (which it delegates to for the captured case) it WRITES NOTHING: `_ops`
+  // are already in timeline order the moment the timeline exists — loadOps() reads them ORDER BY
+  // timestamp and computeDays() sets the real project epoch. So "follow the Time Machine" needs no
+  // pass at all, which is why _bkSaved stays null and tmRestoreDerivedOrder() is a genuine no-op.
+  //
+  // mode S = a captured/linked schedule keyed to dated leaf tasks.
+  // mode T = this model's own derived 4D timeline (schedule_gate's geometry-gated, bottom-up order —
+  //          real work, but NOT a construction programme; the wording tiers in §5 still apply).
+  // There is deliberately no mode D here. tmOrderByCameraPath still exists and is still correct at
+  // what it does, but re-keying a timeline to camera proximity is exactly the interference this verb
+  // was written to remove.
+  window.tmFollowTimeline = function() {
+    if (!_ops.length) { console.warn('§CPE_BUILDUP_SOURCE reject reason=no-ops'); return null; }
+    var ss = window.tmScheduleSource();
+    if (ss.source === 'captured' && typeof window.tmOrderBySchedule === 'function') {
+      var cap = window.tmOrderBySchedule();
+      if (cap) return cap;
+      // A degraded captured schedule falls through to the timeline as loaded — still the user's
+      // plan, never a re-key.
+      console.warn('§CPE_BUILDUP_SOURCE fallthrough reason=captured-but-unusable — following the timeline as loaded');
+    }
+    // Count what the reveal can actually show, the same way mode D counted `placed`: an op with no
+    // geometry still holds its place in the order, it just has nothing to appear.
+    var app = A(), placed = 0, noGeom = 0;
+    try {
+      var have = {};
+      var rows = app.dbQuery('SELECT guid FROM element_transforms');
+      for (var r = 0; r < rows.length; r++) have[rows[r][0]] = 1;
+      for (var i = 0; i < _ops.length; i++) {
+        var op = _ops[i];
+        var guid = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+        if (guid && have[guid]) placed++; else noGeom++;
+      }
+    } catch (e) { placed = _ops.length; noGeom = 0; }   // counting failed → do not block the film
+    var iso = function(ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '?'; };
+    console.log('§CPE_BUILDUP_SOURCE mode=T reason=generated-timeline ops=' + _ops.length +
+      ' placed=' + placed + ' noGeom=' + noGeom +
+      ' leafTasks=' + ss.leafTasks + ' capOps=' + ss.capOps + '/' + _ops.length +
+      ' capActive=' + ss.capActive +
+      ' window=' + iso(_projectStart) + '..' + iso(_projectEnd) +
+      ' — the reveal FOLLOWS this model\'s own 4D timeline, unmodified (no re-key; not a construction programme)');
+    return { ops: _ops.length, placed: placed, noGeom: noGeom, arc: 0, source: 'timeline',
+             leafTasks: ss.leafTasks, covered: ss.covered, total: ss.total, pct: ss.pct,
+             projectStart: _projectStart, projectEnd: _projectEnd };
+  };
+
   // ── §CPE_BUILDUP_REAL_SCHEDULE §4 — the numeric instrument the witnesses read ──────────────────
   // Implementing prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REAL_SCHEDULE §4
   // Witnesses: W-SCHED-REAL-ORDER, W-SCHED-REVERSIBLE

--- a/witness_cpe_preview_after.js
+++ b/witness_cpe_preview_after.js
@@ -1,25 +1,39 @@
-// WITNESS — §CPE_PREVIEW_AFTER: you get to see the film you edited, before it bakes.
-// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md ask 5.
+// WITNESS — §CPE_PREVIEW_AFTER_RETIRED: OK records. It does not preview first.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PREVIEW_AFTER_RETIRED.
 //
-// THE DEFECT THIS PROVES OR DISPROVES (user's own console, 2026-07-27, and their ask):
-// The 10s rehearsal ran ONCE, BEFORE the editor opened — so it showed the DERIVED path, the one film
-// you already knew you did not want, which is why you opened the editor at all. The film you then
-// authored went straight into a ten-minute bake completely unseen. Their log shows the gap exactly:
-//     §CPE_CLOSE -> §CPE_APPLIED -> §MAXQ_FRAME i=0        (no second §MAXQ_PREVIEW anywhere)
+// ⚠ RE-AIMED 2026-07-29. This file used to prove the OPPOSITE — that a second 10s rehearsal ran
+// after OK (§CPE_PREVIEW_AFTER). The user removed that feature: "when OK, do not run preview again
+// as there is already a Preview button." A witness left asserting a deleted feature is worse than no
+// witness, so the gates are re-pointed rather than deleted, and each still names its property.
 //
-//   G-PA-1  a second preview exists, and it is in the right place — §MAXQ_PREVIEW phase=edited
-//           strictly AFTER §CPE_APPLIED and strictly BEFORE the first §MAXQ_FRAME. RED on
-//           origin/main by construction: there is only one preview there.
-//   G-PA-2  it flies the EDITED film, not a re-run of the derived one. Both previews are sampled
-//           from the LIVE camera at matched tNorm; after a real edit the two streams must separate.
-//           A second preview that merely replayed the old path would pass G-PA-1 and fail here.
-//   G-PA-3  it flies the same poseAt the BAKE does. The bake's first frame is poseAt(0); the edited
-//           preview's first sample is poseAt(0) of whatever plan it flew. Same plan => same point.
-//           This is the §CPE_PREVIEW_DIVERGENCE property, re-asserted for the new preview.
-//   G-PA-4  guardrail 2 is intact: an UNTOUCHED OK gets exactly ONE preview. The promise is "the
-//           default cost of this feature is one click and nothing else" — a second 10s rehearsal
-//           proving nothing changed would break it, so this gate fails if the preview is
-//           unconditional rather than edit-only.
+// THE DEFECT THIS PROVES OR DISPROVES:
+// Cutting the post-OK rehearsal must remove the WAIT and nothing else. The failure mode that would
+// look identical from the outside is a cut that also loses the EDIT — a bake that quietly reverts to
+// the derived plan prints no edited preview either, and would pass a naive "no preview" check. So
+// G-PA-2/3 assert the authored path still reaches the flown film, numerically.
+//
+//   G-PA-1  no rehearsal runs between §CPE_APPLIED and the first §MAXQ_FRAME after an EDITED OK —
+//           and none anywhere in an editor run (§CPE_PREVIEW_REDUNDANT already removed the
+//           pre-editor one). RED on a build that still has §CPE_PREVIEW_AFTER by construction.
+//   G-PA-2  the edit still reaches the flown path. Measured on the PLANS, not on a camera: the
+//           derived plan and the plan built from the override OK actually handed the bake are
+//           sampled at matched tNorm and must separate after a 12m band edit. This is the gate that
+//           catches "the removal ate the edit", which G-PA-1 alone cannot see.
+//   G-PA-3  §CPE_PREVIEW_DIVERGENCE survives: the bake's first frame is the EDITED plan's poseAt(0).
+//           The bake is now the only flight, so this reads the live camera at frame 0 and compares
+//           it against poseAt(0) recomputed under the pinned §CPE_CAM_BASIS pose.
+//
+// ⚠ TWO INSTRUMENT CORRECTIONS, both measured while re-aiming, both worth keeping in mind before
+// trusting any future gate here (each one first read as a product failure and was not):
+//   1. A._getCinemaPathEdit() is NULL after a plain OK — stageCinemaPath() is wired to "Save this
+//      path" only. Reading the staged copy measures the SAVE path, not the OK path. Tap open()'s
+//      resolve instead (below).
+//   2. The plan reads A.camera/A.controls DIRECTLY and the editor PINS that basis at open. Re-planning
+//      with the live mid-bake camera gave 33.80m of disagreement at poseAt(0) — the witness had moved
+//      the goalposts, not the code. Restore §CPE_CAM_BASIS before any comparison plan.
+//   G-PA-4  an UNTOUCHED OK runs ZERO previews and re-uses the plan object (§CPE_APPLIED none).
+//           ⚠ Previously asserted exactly ONE (phase=derived) — already stale when re-aimed, since
+//           §CPE_PREVIEW_REDUNDANT deleted that pre-editor rehearsal the day before.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8402;
@@ -93,6 +107,21 @@ async function run(browser, BLD, edit) {
   const samples = [];
   const stopSampling = startSampling(page, samples);
 
+  // Tap the editor's RESOLVE, not A._cinemaPathEdit. Measured 2026-07-29: _getCinemaPathEdit()
+  // returns null after a plain OK, because A.stageCinemaPath() is wired to "Save this path" ONLY —
+  // OK hands its override straight to cinema_maxq.js and never stages it. A gate that read the
+  // staged copy was therefore measuring the SAVE path while claiming to measure the OK path.
+  // Wrapping open() keeps the product untouched and captures exactly what OK handed the bake.
+  await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor, orig = cpe.open.bind(cpe);
+    cpe.open = async function(a) {
+      const r = await orig(a);
+      window.__W_OV = (r && r.override) || null;
+      window.__W_DUR = r && r.durationSec;
+      return r;
+    };
+  });
+
   // fps:1 keeps the bake cheap — this witness only needs its first frames, not a finished film.
   await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: true, fps: 1 }); });
   await page.waitForSelector('#cpe-ok', { timeout: 300000 });
@@ -120,67 +149,110 @@ async function run(browser, BLD, edit) {
   await sleep(1500);
 
   stopSampling();
+
+  // The numeric half of this witness. With the rehearsal gone there is no second flight to sample, so
+  // the "did the edit survive?" property is read off the PLANS: the derived plan and the plan built
+  // from the staged override (A._getCinemaPathEdit(), the same object the plan wrapper re-applies),
+  // sampled through the bake's own poseAt. Same function the bake steps frame by frame — not a
+  // re-implementation. Only meaningful on the edited run; the untouched run has no override.
+  let planCmp = null;
+  if (edit) {
+    const total = (logs.find(l => /§CPE_APPLIED total=/.test(l.text)) || { text: '' })
+      .text.match(/total=([\d.]+)s/);
+    const durSec = total ? parseFloat(total[1]) : 30;
+    // §CPE_PREVIEW_DIVERGENCE is load-bearing for this comparison: _cinemaPathPlan reads
+    // A.camera.position / A.controls.target DIRECTLY, and the editor PINS that basis to the pose it
+    // opened with. Re-planning here with the live camera (mid-bake, parked on frame 0's pose) plans a
+    // different dive and pivot entirely — measured 33.80m of disagreement at poseAt(0), which read as
+    // a product failure and was the witness moving the goalposts. Restore the pinned basis, which the
+    // editor already prints, so the plan computed here is the plan the bake is flying.
+    const cb = (logs.find(l => /§CPE_CAM_BASIS/.test(l.text)) || { text: '' }).text
+      .match(/cam=\(([-\d.]+),([-\d.]+),([-\d.]+)\) target=\(([-\d.]+),([-\d.]+),([-\d.]+)\)/);
+    const basis = cb ? { px: +cb[1], py: +cb[2], pz: +cb[3], tx: +cb[4], ty: +cb[5], tz: +cb[6] } : null;
+    try {
+      planCmp = await page.evaluate((dur, N, b) => {
+        const A = window.APP;
+        const ov = window.__W_OV || null;
+        if (!ov) return { err: 'the editor resolved no override — OK returned override:null' };
+        if (!b) return { err: 'no §CPE_CAM_BASIS line — cannot reproduce the plan basis' };
+        A.camera.position.set(b.px, b.py, b.pz);
+        A.controls.target.set(b.tx, b.ty, b.tz);
+        A.controls.update();
+        const d = A.cinemaPathPlan(dur, null);   // explicit null = derived, no db load
+        const e = A.cinemaPathPlan(dur, ov);
+        if (!d || !d.poseAt || !e || !e.poseAt) return { err: 'a plan came back without poseAt' };
+        const D = [], E = [];
+        for (let i = 0; i < N; i++) { const t = i / (N - 1); D.push(d.poseAt(t)); E.push(e.poseAt(t)); }
+        const dst = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+        const len = s => s.slice(1).reduce((a, p, i) => a + dst(p, s[i]), 0);
+        let maxSep = 0;
+        for (let i = 0; i < N; i++) maxSep = Math.max(maxSep, dst(D[i], E[i]));
+        const p0 = E[0];
+        return { maxSep: maxSep, dLen: len(D), eLen: len(E), n: N,
+                 pose0: { x: p0.x, y: p0.y, z: p0.z } };
+      }, durSec, 200, basis);
+    } catch (e) { planCmp = { err: 'page.evaluate failed: ' + e.message }; }
+  }
+
   try { await page.evaluate(() => { window.APP.cancelMaxQualityOrbit && window.APP.cancelMaxQualityOrbit(); }); } catch (e) {}
   await sleep(300);
   await page.close();
-  return { logs, samples };
+  return { logs, samples, planCmp };
 }
 
 async function gates(browser, BLD) {
   const checks = [];
   const P = (n, ok, d) => checks.push({ n, ok, d });
 
-  const { logs, samples } = await run(browser, BLD, true);
+  const { logs, samples, planCmp } = await run(browser, BLD, true);
 
   const iApplied = idx(logs, /§CPE_APPLIED total=/);
   const iFrame0  = idx(logs, /§MAXQ_FRAME i=/);
   const previews = logs.filter(isPreviewStart);
-  const iEdited  = idx(logs, /§MAXQ_PREVIEW start phase=edited/);
 
-  P('G-PA-1 a second preview runs, after §CPE_APPLIED and before the first baked frame',
-    iEdited > 0 && iApplied > 0 && iEdited > iApplied && (iFrame0 < 0 || iEdited < iFrame0),
-    `previews=${previews.length} [${previews.map(phaseOf).join(', ')}]  ` +
-    `§CPE_APPLIED@${iApplied}  §MAXQ_PREVIEW(edited)@${iEdited}  §MAXQ_FRAME i=0@${iFrame0}`);
+  // The window the deleted rehearsal used to occupy. Nothing may fly in it, and — because
+  // §CPE_PREVIEW_REDUNDANT already removed the pre-editor one — nothing may fly before it either.
+  const inWindow = previews.filter(p => {
+    const i = logs.indexOf(p);
+    return iApplied > 0 && i > iApplied && (iFrame0 < 0 || i < iFrame0);
+  });
+  P('G-PA-1 OK records without a rehearsal — no §MAXQ_PREVIEW between §CPE_APPLIED and frame 0',
+    iApplied > 0 && inWindow.length === 0 && previews.length === 0,
+    `previews in whole run=${previews.length} [${previews.map(phaseOf).join(', ')}], ` +
+    `in the OK→bake window=${inWindow.length}  ` +
+    `§CPE_APPLIED@${iApplied}  §MAXQ_FRAME i=0@${iFrame0}`);
 
-  // Cut the two preview windows out of the sample stream using the phase log lines as boundaries.
-  const at = re => { const h = logs.find(l => re.test(l.text)); return h ? h.t : null; };
-  const dStart = at(/§MAXQ_PREVIEW start/), dEnd = at(/§MAXQ_PREVIEW done/);
-  const eStart = at(/§MAXQ_PREVIEW start phase=edited/),  eEnd = at(/§MAXQ_PREVIEW done phase=edited/);
-  const D = dStart && dEnd ? resample(between(samples, dStart, dEnd), 20) : null;
-  const E = eStart && eEnd ? resample(between(samples, eStart, eEnd), 20) : null;
+  // G-PA-2 — the property G-PA-1 alone cannot see: a bake that quietly reverted to the derived plan
+  // ALSO prints no preview. Measured on the plans themselves (real object state, per the FUNDAMENTAL
+  // LAW), not on a camera: derived poseAt(t) vs staged-override poseAt(t) at matched tNorm.
+  P('G-PA-2 the edit still reaches the flown path (derived vs authored plans separate)',
+    planCmp !== null && !planCmp.err && planCmp.maxSep > 1.0,
+    planCmp === null || planCmp.err
+      ? `could not compare plans: ${planCmp ? planCmp.err : 'no override staged — A._getCinemaPathEdit() returned null'}`
+      : `derived pathLen ${planCmp.dLen.toFixed(1)}m, authored pathLen ${planCmp.eLen.toFixed(1)}m, ` +
+        `max separation over ${planCmp.n} matched tNorm = ${planCmp.maxSep.toFixed(2)}m ` +
+        `(must be > 1.0m after a 12m band edit)`);
 
-  let maxSep = null, dLen = null, eLen = null;
-  if (D && E) {
-    maxSep = Math.max(...D.map((d, i) => dist(d, E[i])));
-    const pathLen = s => s.slice(1).reduce((a, p, i) => a + dist(p, s[i]), 0);
-    dLen = pathLen(D); eLen = pathLen(E);
-  }
-  P('G-PA-2 the second preview flies the EDITED film, not a replay of the derived one',
-    maxSep !== null && maxSep > 1.0 && eLen > 1.0,
-    `derived preview ${D ? D.length : 0} samples, travelled ${dLen === null ? 'n/a' : dLen.toFixed(1) + 'm'}\n` +
-    `          edited  preview ${E ? E.length : 0} samples, travelled ${eLen === null ? 'n/a' : eLen.toFixed(1) + 'm'}\n` +
-    `          max separation at matched tNorm = ${maxSep === null ? 'n/a' : maxSep.toFixed(2) + 'm'} (must be > 1.0m after a 12m band edit)`);
-
-  // The bake's first frame is poseAt(0). The edited preview's first sample is poseAt(0) of whatever
-  // plan IT flew. Same number => one plan, which is the §CPE_PREVIEW_DIVERGENCE property.
+  // §CPE_PREVIEW_DIVERGENCE, re-asserted against the only flight left: the bake's first frame must be
+  // the EDITED plan's poseAt(0), computed from the same staged override the plan wrapper re-applies.
   const tFrame0 = iFrame0 >= 0 ? logs[iFrame0].t : null;
-  const bakeFirst = tFrame0 ? between(samples, eEnd || 0, tFrame0 + 1200)[0] : null;
-  const editFirst = E ? E[0] : null;
+  const bakeFirst = tFrame0 ? between(samples, tFrame0 - 400, tFrame0 + 1200)[0] : null;
+  const editFirst = planCmp && !planCmp.err ? planCmp.pose0 : null;
   const gap = bakeFirst && editFirst ? dist(bakeFirst, editFirst) : null;
   // If the bake never reached frame 0 inside the wait, say so — an unobserved bake is not evidence
   // either way, and reporting it as a failed comparison would be a false accusation against the code.
-  P('G-PA-3 the edited preview and the bake fly the same plan (poseAt(0) agrees)' +
+  P('G-PA-3 the bake flies the EDITED plan (frame 0 == authored poseAt(0))' +
     (tFrame0 === null ? ' — INCONCLUSIVE, no bake frame observed' : ''),
     tFrame0 === null ? false : (gap !== null && gap < 2.0),
-    `edited preview started at (${editFirst ? [editFirst.x, editFirst.y, editFirst.z].map(v => v.toFixed(1)).join(',') : 'n/a'}), ` +
+    `authored poseAt(0) = (${editFirst ? [editFirst.x, editFirst.y, editFirst.z].map(v => v.toFixed(1)).join(',') : 'n/a'}), ` +
     `bake's first frame at (${bakeFirst ? [bakeFirst.x, bakeFirst.y, bakeFirst.z].map(v => v.toFixed(1)).join(',') : 'n/a'}) ` +
     `— ${gap === null ? 'n/a' : gap.toFixed(2) + 'm apart'}`);
 
-  // Guardrail 2: OK with no edit must not cost a second 10 seconds.
+  // Guardrail 2: OK with no edit costs one click and nothing else — now literally zero rehearsals.
   const r2 = await run(browser, BLD, false);
   const prev2 = r2.logs.filter(isPreviewStart);
-  P('G-PA-4 an untouched OK still gets exactly ONE preview (guardrail 2: one click, nothing else)',
-    prev2.length === 1 && phaseOf(prev2[0]) === 'derived',
+  P('G-PA-4 an untouched OK runs ZERO previews (guardrail 2: one click, nothing else)',
+    prev2.length === 0 && r2.logs.some(l => /§CPE_APPLIED none/.test(l.text)),
     `${prev2.length} preview(s): [${prev2.map(phaseOf).join(', ')}]  ` +
     `— ${r2.logs.some(l => /§CPE_APPLIED none/.test(l.text)) ? '§CPE_APPLIED none (plan object re-used)' : 'no §CPE_APPLIED none line'}`);
 


### PR DESCRIPTION
Two user-reported items from 2026-07-29, spec'd in `bim-compiler` `prompts/CINEMA_PATH_EDITOR.md`.

## 1. §CPE_PREVIEW_AFTER_RETIRED — OK records, it does not preview first
> *"also when OK, do not run preview again as there is already a Preview button"*

The second half of a cut already made once. §CPE_PREVIEW_REDUNDANT removed the **pre**-editor 10 s rehearsal on 2026-07-28; the **post-OK** one survived only because it predates §CPE_PREVIEW_BUTTON — its own comment says it existed because *"the film you actually authored went straight to a ten-minute bake unseen"*, which the button closed directly, with a stale marker that answers "have I seen THIS version?".

`_runPreview` stays: the `opts.editor === false` path (scripted/witness bakes — no panel, so no button) still needs it. The trade is stated in the comment rather than glossed: the replacement is opt-in, so a user who never presses Preview now bakes unseen.

**`witness_cpe_preview_after.js` is RE-AIMED in the same commit** rather than left green-by-neglect asserting a deleted feature. **4/4 on Duplex:**

| gate | claim | measured |
|---|---|---|
| G-PA-1 | no rehearsal in the OK→bake window | 0 previews in the whole run |
| G-PA-2 | the edit still reaches the flown path | derived 402.5 m vs authored 423.2 m, max separation **93.84 m** over 200 matched tNorm |
| G-PA-3 | bake frame 0 == authored `poseAt(0)` | **0.00 m apart** |
| G-PA-4 | untouched OK runs ZERO previews | 0, with `§CPE_APPLIED none` |

G-PA-2 is the gate that matters: a cut that also ate the EDIT would print no preview either, and would pass a naive "no preview ran" check.

Two **instrument** corrections, both first read as product failures and were not: `A._getCinemaPathEdit()` is null after a plain OK (`stageCinemaPath` is wired to *Save this path* only, so the old approach measured the SAVE path), and the plan reads `A.camera`/`A.controls` directly under a basis the editor **pins** at open — re-planning with the live mid-bake camera gave 33.80 m of false disagreement until `§CPE_CAM_BASIS` was restored first. G-PA-4 was also already stale before this PR: it asserted one derived preview that §CPE_PREVIEW_REDUNDANT had deleted the day before.

## 2. §CPE_BUILDUP_FOLLOW_TM — the film PLAYS the Time Machine, it does not author a build order
> *"Hospital has a proper schedule, but when done in alt-c it takes a bad one that flattens too much too early"* → *"do not bake anything for TM.. it is user's own plan"* → *"this practices good separation of tasks"* → *"so buildup it gives as it is basis"*

**Time Machine owns the build order; Alt+C owns the camera.**

`tmOrderByCameraPath` re-keyed every op to camera-path proximity. §CPE_BUILDUP_REAL_SCHEDULE had already stopped that eating a **captured** schedule, but a **generated** timeline — `schedule_gate`'s geometry-gated bottom-up order, which is exactly what the TM drawer displays — was still discarded. On the user's Hospital run: 63,439 ops, 36 mini-Gantt bars, and **zero rows in `tasks`** (its schema also predates the IFC one — `start_date`/`finish_date`, no `is_summary` — so the §3.1 probe throws and the catch reports it as "no schedule"). Proximity to a 73.6 m walk through a building of `boundingR=91.4` reveals every storey at once: the *"flattens too much too early"*.

**Fix: one verb, `tmFollowTimeline()`, used by both callers.** It writes nothing — `_ops` are already in timeline order the moment the timeline exists. Mode **S** = captured/linked schedule (delegates to `tmOrderBySchedule`), mode **T** = this model's own derived 4D. No mode D in the film path any more; `tmOrderByCameraPath` is left unchanged and uncalled.

Two more defects close with it:
- **`cinema_path_editor.js` called `tmOrderByCameraPath` unconditionally**, with no source consultation at all — the selection branch existed only in `cinema_maxq.js` — so on a captured-schedule building the Preview and the bake could show *different* build orders. One verb makes that impossible rather than merely unlikely.
- **Nothing logged the choice**, which is why this needed a DB dig instead of a console read. `§CPE_BUILDUP_SOURCE` now prints unconditionally with `mode=S|T`, reason, `leafTasks`, `capOps`, `placed` and the project window; `§CPE_PREVIEW_BUILDUP` prints the mode it armed.

Wording follows the data per §5's tiers — mode S *"Building to the linked schedule"*, mode T *"Building to this model's 4D timeline (as the Time Machine has it)"*; never "the schedule", never "a programme". Checkbox is now *"build the model as the film plays (follows the Time Machine, not a programme)"*.

CPE v15, MAXQ v17, sw v880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)