### PR TITLE
§CPE_CLICK_SLOP — a click on the pipe spawns a stick again (no pixel threshold existed)

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -19,7 +19,11 @@
   // Missed for §CPE_DRAG_TELEPORT (#1035): the cache-bust and sw CACHE_VERSION were bumped but this
   // string was not, so v5 named both the with- and without-fix builds and a user asking "am I on the
   // right version?" could not be answered from their own log. That is the whole job of this line.
-  var CPE_V = 'v15 (§CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  // §CPE_CLICK_SLOP — how far the pointer may travel and still count as a CLICK on the pipe (a stick),
+  // rather than a drag (a hose bend). 4px is standard click slop; at Hospital's 0.192 m/px that is
+  // 0.77m, comfortably below any intentional bend and comfortably above hand tremor.
+  var CLICK_SLOP_PX = 4;
+  var CPE_V = 'v16 (§CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -1268,6 +1272,17 @@
         // §CPE_HOSE: one op per gesture, mutated live — not one op per pointermove, which would
         // stack hundreds of ops for a single drag and make the stored path grow with the gesture
         // rather than with the edit.
+        // §CPE_CLICK_SLOP (prompts/CINEMA_PATH_EDITOR.md; user 2026-07-29: "when i made a new node in
+        // the pipe, it does not show up in the alt-c panel list"). §CPE_STICK's rule is one grab split
+        // by what the hand does — let go without moving and you get a stick. h.up implements that
+        // correctly (`if (!d.op) _spawnStick`), but this branch used to create the op on the FIRST
+        // pointermove of ANY size, so the stick branch was unreachable in practice: a physical click
+        // emits 1-2px of movement almost every time. The `mag < 1e-4` cancel in h.up does not catch it
+        // either — at Hospital's 0.192 m/px one pixel is 0.19m, four orders of magnitude above it — so
+        // the click landed as a real recorded hose pull. Confirmed in the user's console: five
+        // §CPE_HOSE grab/landed pairs, zero §CPE_STICK, bands=3 unchanged throughout.
+        // Below the slop the grab stays a CANDIDATE CLICK: no op, no deform, no undo entry.
+        if (!d.snapped && Math.hypot(ev.clientX - d.sx0, ev.clientY - d.sy0) < CLICK_SLOP_PX) return;
         var dwh = _dragDelta(ev, d);
         d.lx = ev.clientX; d.ly = ev.clientY;
         if (!d.snapped) {
@@ -1599,6 +1614,30 @@
   }
 
   var _attach = setInterval(function() {
-    if (window.APP) { window.APP.cinemaPathEditor = { open: open, version: CPE_V }; clearInterval(_attach); }
+    // `_probePipe` is a READ-ONLY whitebox hook for witnesses (§CPE_CLICK_SLOP's W-CLICK-STICK): it
+    // answers "does this screen pixel land on the fat walk pipe?" using the editor's OWN hit test, so
+    // a witness never guesses a coordinate or asserts against a re-implementation. Same precedent as
+    // effects.js's `A.cinemaPathPlanDerived`. It mutates nothing and is not part of the UI.
+    if (window.APP) {
+      window.APP.cinemaPathEditor = {
+        open: open, version: CPE_V,
+        _probePipe: function(clientX, clientY) {
+          if (!_state) return null;
+          var h = _hitTestPath({ clientX: clientX, clientY: clientY });
+          return h ? { s: h.s, i: h.i } : null;
+        },
+        // The screen pixel of a point at `frac` along the WALK, through the editor's own projection.
+        // A witness sweeping the canvas for the pipe is a lottery on a small building (measured: a
+        // 42px grid missed Duplex's walk entirely); this hands it the answer the hit test would give.
+        _pipePixel: function(frac) {
+          if (!_state || !_state.flowHosed || _state.flowHosed.length < 2) return null;
+          var pts = _state.flowHosed;
+          var i = Math.max(0, Math.min(pts.length - 1, Math.round((frac || 0.5) * (pts.length - 1))));
+          var s = _screenOf(pts[i]);
+          return s.behind ? null : { x: Math.round(s.x), y: Math.round(s.y), i: i };
+        }
+      };
+      clearInterval(_attach);
+    }
   }, 500);
 })();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v880';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v881';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_click_slop.js
+++ b/witness_cpe_click_slop.js
@@ -1,0 +1,171 @@
+// WITNESS — §CPE_CLICK_SLOP: a click on the fat pipe spawns a stick; a drag bends it.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_CLICK_SLOP.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, 2026-07-29: "when i made a new node in the pipe, it does
+// not show up in the alt-c panel list"):
+// h.up implements §CPE_STICK's one-grab-split correctly — `if (!d.op) _spawnStick(d.hit)` — but h.move
+// used to create d.op on the FIRST pointermove of ANY size. A physical click emits 1-2px of movement
+// almost every time, so d.op was truthy by pointerup and the stick branch was unreachable. The
+// `mag < 1e-4` cancel does not catch it either: at 0.192 m/px one pixel is 0.19m.
+//
+//   G-CS-1  a 2px grab on the pipe spawns exactly ONE stick — §CPE_STICK added, bands N -> N+1, a new
+//           row in #cpe-rows, and NO §CPE_HOSE landed. 2px is the jitter a real click carries, which
+//           is precisely what made the old build take the wrong branch. RED on the old build.
+//   G-CS-2  a 20px grab bends the pipe and spawns NOTHING — one §CPE_HOSE landed, bands unchanged.
+//           Proves the slop did not turn small intentional bends into stray nodes.
+//   G-CS-3  §CPE_UNDO survives: after the 2px click, Ctrl+Z returns the band count to N.
+//   G-CS-4  a 0px press leaves NO undo entry AND still spawns the stick (G-DRAG-1's property: a press
+//           that never moved must not push a dead undo step).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8433;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+// Find a screen pixel that actually lands on the fat walk pipe, by asking the editor's own hit test
+// through a real pointer sweep — never a guessed coordinate. Returns null if the pipe is off-screen.
+// A blind canvas sweep is a lottery on a small building — a 42px grid missed Duplex's walk entirely
+// (measured 2026-07-29). Ask the editor for the pixel of a point along the walk instead, then CONFIRM
+// with its own hit test, so the gesture below is known to land on the pipe before anything is claimed.
+async function findPipePixel(page) {
+  const tried = [];
+  for (let f = 0.10; f <= 0.90; f += 0.02) {
+    const spot = await page.evaluate((f) => {
+      const cpe = window.APP.cinemaPathEditor;
+      if (!cpe || !cpe._pipePixel || !cpe._probePipe) return { why: 'no hook' };
+      const p = cpe._pipePixel(f);
+      if (!p) return { why: 'behind camera' };
+      if (!cpe._probePipe(p.x, p.y)) return { why: 'hit test missed its own point' };
+      // ⚠ The hit test is pure maths and does not know about occlusion. The CPE panel is a DOM
+      // element floating over the canvas, so a pixel that is mathematically on the pipe can still
+      // deliver its pointerdown to the panel — measured 2026-07-29: every gesture at the walk's
+      // midpoint produced NO §CPE_HOSE and NO §CPE_STICK, because the panel was on top of it.
+      // It must be APP.canvas specifically — that is what the editor binds pointerdown to
+      // (`c.addEventListener('pointerdown', h.down, true)` with `c = A().canvas`). Any other canvas
+      // on top would swallow the gesture and the witness would report a product failure that isn't.
+      const el = document.elementFromPoint(p.x, p.y);
+      if (el !== window.APP.canvas) {
+        return { why: 'topmost is <' + (el ? el.tagName + (el.id ? '#' + el.id : '') : 'null') + '>, not APP.canvas' };
+      }
+      return { px: p.x, py: p.y, frac: f };
+    }, f);
+    if (spot && spot.px !== undefined) return spot;
+    if (spot && spot.why) tried.push(f.toFixed(2) + ':' + spot.why);
+  }
+  console.log('        no usable pipe pixel — ' + tried.slice(0, 6).join(', '));
+  return null;
+}
+
+const count = (logs, re) => logs.filter(l => re.test(l)).length;
+
+async function gesture(page, px, py, dx) {
+  await page.mouse.move(px, py);
+  await page.mouse.down();
+  if (dx > 0) {
+    // Deliberately stepped, like a real hand — a single jump could skip the slop crossing entirely.
+    for (let i = 1; i <= 4; i++) { await page.mouse.move(px + (dx * i) / 4, py); await sleep(40); }
+  }
+  await sleep(60);
+  await page.mouse.up();
+  await sleep(900);
+}
+
+const bandCount = page => page.evaluate(() => document.querySelectorAll('#cpe-rows > div').length);
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page, logs } = await openEditor(browser, BLD);
+
+  const spot = await findPipePixel(page);
+  if (!spot) {
+    P('G-CS-0 the fat pipe is reachable on screen', false,
+      'no pixel in the sweep hit the walk pipe — INCONCLUSIVE, not a product verdict');
+    await page.close();
+    return checks;
+  }
+
+  // ── G-CS-1: 2px == a click ──────────────────────────────────────────────────────────────────
+  const n0 = await bandCount(page);
+  let mark = logs.length;
+  await gesture(page, spot.px, spot.py, 2);
+  let win = logs.slice(mark);
+  const n1 = await bandCount(page);
+  P('G-CS-1 a 2px grab on the pipe spawns exactly ONE stick, immediately in the list',
+    n1 === n0 + 1 && count(win, /§CPE_STICK added/) === 1 && count(win, /§CPE_HOSE landed/) === 0,
+    `rows ${n0} -> ${n1}   §CPE_STICK added=${count(win, /§CPE_STICK added/)}   ` +
+    `§CPE_HOSE landed=${count(win, /§CPE_HOSE landed/)}`);
+
+  // ── G-CS-3: undo puts it back ───────────────────────────────────────────────────────────────
+  await page.keyboard.down('Control'); await page.keyboard.press('KeyZ'); await page.keyboard.up('Control');
+  await sleep(900);
+  const n2 = await bandCount(page);
+  P('G-CS-3 Ctrl+Z removes the clicked stick (§CPE_UNDO intact)',
+    n2 === n0, `rows after undo ${n2}, expected ${n0}`);
+
+  // ── G-CS-2: 20px == a bend, and nothing is spawned ──────────────────────────────────────────
+  mark = logs.length;
+  await gesture(page, spot.px, spot.py, 20);
+  win = logs.slice(mark);
+  const n3 = await bandCount(page);
+  P('G-CS-2 a 20px grab bends the pipe and spawns NOTHING',
+    n3 === n2 && count(win, /§CPE_HOSE landed/) === 1 && count(win, /§CPE_STICK added/) === 0,
+    `rows ${n2} -> ${n3}   §CPE_HOSE landed=${count(win, /§CPE_HOSE landed/)}   ` +
+    `§CPE_STICK added=${count(win, /§CPE_STICK added/)}`);
+
+  // ── G-CS-4: a 0px press still spawns, and pushes no dead undo step ──────────────────────────
+  const n4 = await bandCount(page);
+  mark = logs.length;
+  await gesture(page, spot.px, spot.py, 0);
+  win = logs.slice(mark);
+  const n5 = await bandCount(page);
+  P('G-CS-4 a 0px press spawns the stick too (the original gesture still works)',
+    n5 === n4 + 1 && count(win, /§CPE_STICK added/) === 1,
+    `rows ${n4} -> ${n5}   §CPE_STICK added=${count(win, /§CPE_STICK added/)}`);
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
> *"when i made a new node in the pipe, it does not show up in the alt-c panel list as first time using. I know it can appear after refresh. But immediate as before is important helpful."*

## The defect
`h.up` already implemented §CPE_STICK's one-grab-split correctly — `if (!d.op) _spawnStick(d.hit)` — but `h.move` created `d.op` on the **first `pointermove` of any size**, so the stick branch was unreachable in practice: a physical click emits 1–2 px of movement almost every time. The `mag < 1e-4` cancel below it doesn't catch that either — at Hospital's `0.192 m/px` one pixel is **0.19 m**, four orders of magnitude above the threshold — so the click landed as a real, recorded hose pull.

**Confirmed from the user's own console before touching anything:** five `§CPE_HOSE grab`/`landed` pairs (smallest `disp=1.84m`), **zero `§CPE_STICK`**, and `§CINEMA_BANDS bands=3 waypoints=6` unchanged from the first plan to the last. No node was ever created — the panel list was telling the truth.

The *"it can appear after refresh"* half was **§CPE_REOPEN_DOUBLE**, fixed earlier the same day (#1081): re-open used to re-seed 2N bands from `plan.waypoints`, so a bend eventually surfaced as extra rows. That accidental route is gone by design and must not be restored — making the *click* work is the fix actually asked for.

## The fix
`CLICK_SLOP_PX = 4` (standard click slop; 0.77 m at that rate, well below any intentional bend). Below it the grab stays a candidate click: no op, no deform, and no `_undoPush` — which stays on the crossing so a click cannot leave an undo step that does nothing (G-DRAG-1's property). No modifier key, and not applied to the band-handle path, which has no click action.

Also adds two **read-only** whitebox hooks used only by witnesses, mutating nothing: `_probePipe(x,y)` and `_pipePixel(frac)`, so a witness asks the editor's own hit test where the pipe is instead of guessing a coordinate (a blind 42 px canvas sweep missed Duplex's walk entirely).

## ⚠ The witness is included and does NOT pass — for an instrument reason, stated plainly
`witness_cpe_click_slop.js` never gets a gesture through. `page.mouse` produces **no `§CPE_HOSE grab` at that pixel at all** — not even on a 20 px drag, which needs none of this change and behaved the same before it. `_pipePixel` + `_probePipe` + `elementFromPoint` all agree the point is on the walk with `APP.canvas` topmost, so the panel-occlusion hypothesis was measured **wrong**. The open question is whether CDP-synthesised input reaches a capture-phase `pointerdown` on that element in this app's event stack.

**The RED is not evidence about the slop**, and G-CS-3 passes only because its assertion is trivially true when nothing spawned. Landing *any* pipe gesture must be proven against the old build before any gate in that file is trusted. Recorded in the spec so it is not re-derived.

Follows #1082, which squash-merged while this was being written — rebased onto fresh `origin/main` rather than re-using the merged branch.

CPE v16, sw v881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)