### PR TITLE
§CPE_CLICK_SLOP is WITNESSED 4/4 — the three RED runs were the instrument, not the code

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v881';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v882';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
`witness_cpe_click_slop.js` shipped RED in #1083 with an honest *"the harness cannot land a gesture"* note. It can now, and the fix passes:

```
G-CS-1  2px grab  -> rows 3->4, §CPE_STICK added=1, §CPE_HOSE landed=0
G-CS-2  20px grab -> §CPE_HOSE landed=1, bands unchanged
G-CS-3  Ctrl+Z    -> back to 3 (§CPE_UNDO intact)
G-CS-4  0px press -> rows 3->4 (the original gesture still works)
```

## The root cause of the RED — a real property, not just a test bug
`h.down` checks `_hitTest` (band handles) **before** `_hitTestPath` (the pipe), so a pixel inside a handle's grab radius is a **band drag** and can never be a stick, however exactly it sits on the tube. The witness was choosing such a pixel every time.

`_probePipe` now returns `{pipe, band}` instead of just the pipe hit, and the picker rejects any pixel with a band under it. Three earlier hypotheses — blind sweep too coarse, CPE panel occlusion, CDP input not reaching a capture-phase `pointerdown` — were each measured and each only moved the picker closer without being the cause. All three are recorded in the file so they are not re-tried.

Also switches the gesture from `page.mouse` to real `PointerEvent` objects dispatched at the elements the editor actually binds (`APP.canvas` for down, `window` for move/up). Kept because it removes CDP input synthesis from the loop entirely — it is the browser's own event class, not a mock.

The stale *"harness cannot land a gesture"* note in the spec is superseded by this run.

sw v882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)