### PR TITLE
feat(viewer): §HOVER_NAME — hover the model, see friendly name + room

### DIFF
--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -102,6 +102,7 @@
   "setupGhostGlass": "readonly",
   "setupGridOverlay": "readonly",
   "setupHelpers": "readonly",
+  "setupHoverName": "readonly",
   "setupImport": "readonly",
   "setupIssues": "readonly",
   "setupMeasure": "readonly",

--- a/viewer/hover_name.js
+++ b/viewer/hover_name.js
@@ -1,0 +1,173 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// hover_name.js — §HOVER_NAME (prompts/Viewer/HOVER_NAME.md): a "hover name" checkbox in the
+// Find panel + the `'` shortcut. With it on, hovering the model shows the friendly name (and
+// containing room) of whatever is under the cursor — zero clicks. Click still SELECTS, untouched.
+function setupHoverName(A) {
+  var _on = false;
+  var _raf = 0;
+  var _mouseX = 0, _mouseY = 0, _haveMouse = false;
+  var _lastGuid; // undefined = never resolved; null = last hover hit nothing
+  var _label = null;
+  var _rc = null;
+  var _meshes = null, _meshT = 0;
+  var _MESH_REFRESH_MS = 1000; // scene is mostly static between streams — same cache window as §SFX-RAYBLAST
+
+  function _ensureLabel() {
+    if (_label) return _label;
+    _label = document.createElement('div');
+    _label.id = 'hover-name-label';
+    _label.style.cssText = 'position:fixed;z-index:9000;pointer-events:none;display:none;' +
+      'background:rgba(20,20,24,0.88);color:#fff;padding:5px 10px;border-radius:6px;' +
+      'font:12px/1.35 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;' +
+      'box-shadow:0 2px 8px rgba(0,0,0,0.4);white-space:nowrap;';
+    document.body.appendChild(_label);
+    return _label;
+  }
+
+  function _hideLabel() {
+    if (_label) _label.style.display = 'none';
+    _lastGuid = undefined;
+  }
+
+  function _positionLabel() {
+    if (!_label) return;
+    _label.style.left = (_mouseX + 14) + 'px';
+    _label.style.top = (_mouseY + 16) + 'px';
+  }
+
+  // Mirrors picking.js's guid-resolution chain (BatchedMesh → InstancedMesh → merged-mesh raycast
+  // tag → guidMap/userData), read-only against the SAME shared indices picking.js populates.
+  // Deliberately NOT a refactor of the click path — hover runs every frame while armed, so it
+  // must never touch click-select state (A._lastPickGuid, A._pickIsolated, the info panel, …).
+  function _guidForHit(hit) {
+    var o = hit.object;
+    if (o.isBatchedMesh && hit.batchId !== undefined && A._batchMeta && A._batchMeta[o.id]) {
+      var bm = A._batchMeta[o.id];
+      for (var i = 0; i < bm.length; i++) { if (bm[i].slotId === hit.batchId) return bm[i].guid; }
+    }
+    if (o.isInstancedMesh && hit.instanceId !== undefined && A._instanceMeta && A._instanceMeta[o.id]) {
+      var im = A._instanceMeta[o.id][hit.instanceId];
+      if (im) return im.guid;
+    }
+    if (o.userData && o.userData.isMerged && hit._mergedGuid) return hit._mergedGuid;
+    if (A.guidMap && A.guidMap[o.id]) return A.guidMap[o.id];
+    if (o.userData && o.userData.guid) return o.userData.guid;
+    return null;
+  }
+
+  function _resolveMeshes() {
+    var now = performance.now();
+    if (_meshes && now - _meshT < _MESH_REFRESH_MS) return _meshes;
+    _meshes = A.collectMeshes(function(o) {
+      if (!(o.isMesh || o.isInstancedMesh || o.isBatchedMesh) || !o.visible) return false;
+      if (o.userData && (o.userData.isBboxPlaceholder || o.userData._isOutline)) return false;
+      return true;
+    });
+    _meshT = now;
+    return _meshes;
+  }
+
+  function _name(elementName, ifcClass) {
+    // A.friendlyName is defined in the lazy Navigate bundle — same verb the Find panel and
+    // navigate_engine.js use (HOVER_NAME.md: "use this verb, do not invent a second naming path").
+    // Fall back to the raw fields only in the brief window before that bundle has loaded.
+    if (typeof A.friendlyName === 'function') return A.friendlyName(elementName, ifcClass);
+    return elementName || ifcClass || '?';
+  }
+
+  function _roomLabelFor(guid) {
+    try {
+      var rel = A.dbQuery('SELECT space_guid FROM rel_contained_in_space WHERE element_guid = ? LIMIT 1', [guid]);
+      if (!rel.length || !rel[0][0]) return null;
+      var rows = A.dbQuery('SELECT element_name, ifc_class FROM elements_meta WHERE guid = ?', [rel[0][0]]);
+      if (!rows.length) return null;
+      return _name(rows[0][0], rows[0][1]);
+    } catch (e) { return null; }
+  }
+
+  // Event-driven, not a perpetual loop: a raycast only runs when the mouse actually moves, and at
+  // most once per animation frame no matter how many pointermove events land in that frame
+  // (HOVER_NAME.md's trap — "raycast per pointermove is not free at 63k elements"). A continuous
+  // 60fps rAF loop that re-raycasts even while the mouse sits still would burn the same budget for
+  // nothing — the earlier draft did exactly that.
+  function _tick() {
+    _raf = 0;
+    if (!_on) return;
+    if (!_haveMouse || !A.camera || typeof THREE === 'undefined') { _hideLabel(); return; }
+    var t0 = performance.now();
+    if (!_rc) _rc = new THREE.Raycaster();
+    var nx = (_mouseX / window.innerWidth) * 2 - 1;
+    var ny = -(_mouseY / window.innerHeight) * 2 + 1;
+    _rc.setFromCamera({ x: nx, y: ny }, A.camera);
+    var meshes = _resolveMeshes();
+    var hits = meshes.length ? _rc.intersectObjects(meshes, false) : [];
+    var guid = null;
+    for (var i = 0; i < hits.length; i++) {
+      if (hits[i].object.material && hits[i].object.material.opacity < 0.3) continue;
+      guid = _guidForHit(hits[i]);
+      if (guid) break;
+    }
+    _positionLabel();
+    if (guid === _lastGuid) return; // same target as last frame — cursor-follow position already updated above
+    _lastGuid = guid;
+    if (!guid) { _hideLabel(); return; }
+    var rows;
+    try { rows = A.dbQuery('SELECT element_name, ifc_class FROM elements_meta WHERE guid = ?', [guid]); }
+    catch (e) { rows = []; }
+    if (!rows.length) { _hideLabel(); return; }
+    var name = _name(rows[0][0], rows[0][1]);
+    var room = _roomLabelFor(guid);
+    var lbl = _ensureLabel();
+    lbl.innerHTML = '<div>' + String(name).replace(/</g, '&lt;') + '</div>' +
+      (room ? '<div style="opacity:0.65;font-size:10px;margin-top:2px">' + String(room).replace(/</g, '&lt;') + '</div>' : '');
+    lbl.style.display = 'block';
+    _positionLabel();
+    // §IDLE_GATE parks the rAF chain when nothing moves — force one frame so the label isn't
+    // stranded on a still scene (same trap §CPE_HOVER_SCRUB names for the Cinema hover).
+    if (A.markDirty) A.markDirty();
+    console.log('§HOVER_NAME guid=' + guid.substring(0, 12) + ' name="' + name + '" ifc=' +
+      (rows[0][1] || '') + ' room="' + (room || '') + '" ms=' + (performance.now() - t0).toFixed(1));
+  }
+
+  function _onMove(e) {
+    if (e.pointerType && e.pointerType !== 'mouse') return; // hover is a mouse concept — no touch
+    _mouseX = e.clientX; _mouseY = e.clientY; _haveMouse = true;
+    if (_on && !_raf) _raf = requestAnimationFrame(_tick);
+  }
+  function _onLeave() { _haveMouse = false; _hideLabel(); }
+
+  function _syncCheckbox() {
+    var cb = document.getElementById('find-hover-name-cb');
+    if (cb) cb.checked = _on;
+  }
+
+  // src: 'key' | 'checkbox' | 'api'. force: explicit boolean, or omit to flip.
+  A.toggleHoverName = function(src, force) {
+    if (window._isMobile) return; // HOVER_NAME.md: no hover on touch — checkbox hidden there too
+    var next = (force !== undefined) ? !!force : !_on;
+    if (next === _on) { _syncCheckbox(); return; }
+    _on = next;
+    _syncCheckbox();
+    console.log('§HOVER_NAME toggle=' + (_on ? 'on' : 'off') + ' src=' + (src || 'api'));
+    if (_on) {
+      if (typeof A.friendlyName !== 'function' && typeof A.loadNavigate === 'function') A.loadNavigate();
+      if (!_raf) _raf = requestAnimationFrame(_tick);
+    } else {
+      _hideLabel();
+      if (_raf) { cancelAnimationFrame(_raf); _raf = 0; }
+    }
+  };
+
+  A.canvas.addEventListener('pointermove', _onMove);
+  A.canvas.addEventListener('pointerleave', _onLeave);
+
+  // Test-only accessor (same convention as sfx.js's window.__sfx) — witness_hover_name.js reads
+  // the ACTUAL resolved guid rather than guessing one, since dense BIM scenes overlap in depth
+  // (a wall in front of the MEP behind it) and a screen position's nearest hit is legitimately
+  // not whichever element a witness expected to be there.
+  A._hoverNameState = function() { return { on: _on, guid: _lastGuid || null }; };
+}

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -13,7 +13,7 @@ async function initViewer() {
   if (typeof setupConfig === 'function') setupConfig(APP);
   if (typeof setupScene === 'function') await setupScene(APP);
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
-    setupPicking, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
+    setupPicking, setupHoverName, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
   // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
   // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -175,6 +175,14 @@
       '  <input type="text" id="find-name" data-trl-placeholder="ui_find_placeholder" placeholder="' + _t('ui_find_placeholder', 'Count doors, Total cost…') + '">',
       '</div>',
       '<div id="find-chips"></div>',
+      // §HOVER_NAME (HOVER_NAME.md): hidden on touch — no hover on mobile, don't ship a
+      // control that silently does nothing there.
+      '<div id="find-hover-row" style="display:' + (window._isMobile ? 'none' : 'flex') +
+        ';align-items:center;gap:6px;padding:4px 10px;border-bottom:1px solid rgba(255,255,255,0.06);font-size:11px;color:#ccc">',
+      '  <input type="checkbox" id="find-hover-name-cb" style="cursor:pointer;margin:0">',
+      '  <label for="find-hover-name-cb" style="cursor:pointer;user-select:none">' +
+        _t('ui_hover_name', 'Hover name') + ' <span style="opacity:0.5">(&#39;)</span></label>',
+      '</div>',
       // Hidden selects — still used for data binding
       '<select id="find-type" style="display:none"><option value="">' + _t('ui_find_all_types', 'All types') + '</option></select>',
       '<select id="find-storey" style="display:none"><option value="">' + _t('ui_all_storeys', 'All Storeys') + '</option></select>',
@@ -247,6 +255,13 @@
     var _lastSelSet = null, _lastSelLabel = '';               // current selection, for the ERP push
     var elClose = document.getElementById('find-close');
     var elChips = document.getElementById('find-chips');
+    // §HOVER_NAME: checkbox and the ' key drive ONE state — checkbox side of that contract.
+    var elHoverCb = document.getElementById('find-hover-name-cb');
+    if (elHoverCb) {
+      elHoverCb.addEventListener('change', function() {
+        if (A.toggleHoverName) A.toggleHoverName('checkbox', elHoverCb.checked);
+      });
+    }
     var elMicBtn = document.getElementById('find-mic-btn');
     var elSelected = document.getElementById('find-selected');
     // §RevitParity A1: isolate controls

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1375,6 +1375,10 @@ async function setupScene(A) {
       else if (A.status) A.status.textContent = 'UNDER CONSTRUCTION';
     },
     '/':  function() { if (A.quickShare) A.quickShare(); },
+    // §HOVER_NAME (HOVER_NAME.md): verified free against this table 2026-07-29. Checkbox lives in
+    // the Find panel; A.toggleHoverName exists from load (hover_name.js) regardless of whether the
+    // panel was ever opened, so the key works standalone — same lazy-load-then-act shape as 'f'.
+    "'": function() { if (A.toggleHoverName) A.toggleHoverName('key'); },
     '.':  function() { // §S281 P2: ⋯ toggle — prefer the live mobile pill, fall back to legacy overflow
       if (typeof window.toggleMobilePill === 'function') window.toggleMobilePill();
       else if (typeof window.toggleOverflow === 'function') window.toggleOverflow();
@@ -1529,6 +1533,9 @@ async function setupScene(A) {
       // §PHOTO_POPULATE (2026-07-17): Alt+P adds fabricated staffage (people + trees) for the
       // presentation shot — its own toggle, separate from Alt+S's clean extract-only still.
       all.push({ seq: 'ALT+P', name: 'Populate (people + trees)', icon: '', action: function() { if (typeof A.togglePopulate === 'function') A.togglePopulate(); }, children: null });
+      // §HOVER_NAME: same keyboard-only pattern — lives as a Find-panel checkbox, not a pill.
+      // Dead key on some international layouts (US-Intl, ES, PT, FR-CA) — fails harmlessly there.
+      if (!window._isMobile) all.push({ seq: "'", name: 'Hover Name', icon: '', action: function() { if (A.toggleHoverName) A.toggleHoverName('key'); }, children: null });
       var matches = all.filter(function(e) {
         return e.name.toLowerCase().indexOf(f) >= 0 || e.seq.toLowerCase().indexOf(f) >= 0;
       });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v882';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v883';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -122,6 +122,7 @@ const PRECACHE_ASSETS = [
   'panels.js',
   'tools.js',
   'picking.js',
+  'hover_name.js',
   'tour.js',
   'clash_matrix.js',
   'measure.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -839,6 +839,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
+<script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>

--- a/witness_hover_name.js
+++ b/witness_hover_name.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * W-HOVER-NAME / W-HOVER-COST / W-HOVER-COVERAGE / click-not-suppressed / toggle-symmetry —
+ * prompts/Viewer/HOVER_NAME.md. Numeric §-tagged proof only, per CLAUDE.md's FUNDAMENTAL LAW —
+ * no screenshots, no eyeballing.
+ * RUN: node witness_hover_name.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.css': 'text/css',
+  '.db': 'application/octet-stream', '.data': 'application/octet-stream' };
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (e) { r.writeHead(404); r.end('404'); return; }
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' });
+      r.end(b);
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+// Hard watchdog — this host has been observed under heavy load from unrelated concurrent
+// sessions (load avg 15+), which can stall a Puppeteer CDP round-trip indefinitely (evaluate()
+// has no built-in timeout). Never let a hang masquerade as "still running" — force an exit with a
+// loud, unambiguous signal instead.
+const _watchdog = setTimeout(() => {
+  console.log('\n§W-HOVER-NAME TIMEOUT — killed after 280s, host likely under heavy contention');
+  process.exit(3);
+}, 280000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const hoverLogs = [];
+  const errs = [];
+  pg.on('pageerror', e => errs.push(String(e)));
+  pg.on('console', msg => {
+    const t = msg.text();
+    if (t.indexOf('§HOVER_NAME') === 0) hoverLogs.push(t);
+  });
+  const BLD = process.env.HOVER_WITNESS_BLD || 'Duplex_extracted.db';
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/${BLD}`;
+  console.log('  building=' + BLD);
+  await pg.goto(url, { waitUntil: 'load', timeout: 90000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera && !!window.APP.db && !!window.APP.toggleHoverName', { timeout: 90000 });
+  await new Promise(r => setTimeout(r, 3000)); // let streaming settle so meshes are actually there
+
+  // Force the Navigate bundle loaded (A.friendlyName lives there) so we're testing the steady
+  // state, not the brief pre-load fallback.
+  await pg.evaluate(() => window.APP.loadNavigate ? window.APP.loadNavigate() : null);
+  await new Promise(r => setTimeout(r, 500));
+
+  const meshCount = await pg.evaluate(() => window.APP.collectMeshes(o => o.isMesh || o.isInstancedMesh || o.isBatchedMesh).length);
+  console.log('  scene meshCount=' + meshCount);
+
+  // Pick N real elements with a known screen position (project their DB centre through the
+  // camera) — NOT synthetic guids, real rows from element_transforms/elements_meta.
+  const N = 18; // trimmed from 50 — host under heavy unrelated load, keep the run fast and reliable
+  const targets = await pg.evaluate((n) => {
+    const A = window.APP;
+    const rows = A.dbQuery(
+      `SELECT t.guid, t.center_x, t.center_y, t.center_z, m.element_name, m.ifc_class
+       FROM element_transforms t JOIN elements_meta m ON m.guid = t.guid
+       WHERE t.center_x IS NOT NULL ORDER BY RANDOM() LIMIT ?`, [n]);
+    const out = [];
+    rows.forEach(r => {
+      const [guid, ix, iy, iz, name, cls] = r;
+      const c = A.ifc2three(ix, iy, iz);
+      const v = new THREE.Vector3(c.x, c.y, c.z).project(A.camera);
+      if (v.z < -1 || v.z > 1) return; // behind camera / outside clip
+      const sx = (v.x * 0.5 + 0.5) * window.innerWidth;
+      const sy = (-v.y * 0.5 + 0.5) * window.innerHeight;
+      if (sx < 0 || sx > window.innerWidth || sy < 0 || sy > window.innerHeight) return;
+      out.push({ guid, name, cls, sx, sy, friendly: A.friendlyName(name, cls) });
+    });
+    return out;
+  }, N);
+  console.log('  on-screen candidate targets=' + targets.length + '/' + N);
+
+  // ── Turn hover-name ON via the checkbox path (Find panel), verify the key stays in sync ──
+  await pg.evaluate(() => { if (window.APP.openFindPanel) window.APP.openFindPanel(''); });
+  await new Promise(r => setTimeout(r, 300));
+  const cbBefore = await pg.evaluate(() => {
+    const cb = document.getElementById('find-hover-name-cb');
+    return cb ? { exists: true, checked: cb.checked, visible: cb.offsetParent !== null } : { exists: false };
+  });
+  chk('checkbox exists in Find panel', cbBefore.exists);
+  chk('checkbox starts unchecked (default OFF per HOVER_NAME.md)', cbBefore.checked === false);
+
+  await pg.evaluate(() => document.getElementById('find-hover-name-cb').click());
+  await new Promise(r => setTimeout(r, 100));
+  const onState1 = await pg.evaluate(() => document.getElementById('find-hover-name-cb').checked);
+  chk('checkbox click → checked=true', onState1 === true);
+
+  // Press the ' key → must toggle back OFF and the checkbox must follow (ONE state, HOVER_NAME.md).
+  await pg.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: "'", bubbles: true })));
+  await new Promise(r => setTimeout(r, 100));
+  const afterKey = await pg.evaluate(() => document.getElementById('find-hover-name-cb').checked);
+  chk("' key toggles OFF and checkbox follows (checkbox and key drive ONE state)", afterKey === false);
+
+  // Turn back on via the key for the rest of the sweep.
+  await pg.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: "'", bubbles: true })));
+  await new Promise(r => setTimeout(r, 100));
+  const onState2 = await pg.evaluate(() => document.getElementById('find-hover-name-cb').checked);
+  chk("' key toggles ON and checkbox follows", onState2 === true);
+
+  // ── W-HOVER-NAME (gate) + W-HOVER-COST + W-HOVER-COVERAGE: sweep real screen positions ──
+  // NOTE: a target's DB-centre screen projection is NOT necessarily what the ray hits — dense BIM
+  // scenes overlap in depth (a wall in front of the MEP behind it), so the nearest surface at that
+  // pixel is legitimately a DIFFERENT, occluding element (same WYSIWYG rule picking.js applies).
+  // The gate therefore checks the ACTUAL resolved element (via A._hoverNameState(), the same
+  // test-only accessor sfx.js's window.__sfx precedent uses) against A.friendlyName for THAT
+  // element — not against the pre-chosen target, which HOVER_NAME.md's own gate text calls for:
+  // "the string shown equals A.friendlyName(...) for that element".
+  const canvasBox = await pg.evaluate(() => { const r = window.APP.canvas.getBoundingClientRect(); return { x: r.x, y: r.y }; });
+  let gateOk = 0, gateChecked = 0, coverageNamed = 0, coverageRaw = 0, roomHits = 0;
+  let lastHoverGuid = null, lastHoverPos = null;
+  for (const t of targets) {
+    const cx = canvasBox.x + t.sx, cy = canvasBox.y + t.sy;
+    await pg.mouse.move(cx - 5, cy - 5, { steps: 1 });
+    await pg.mouse.move(cx, cy, { steps: 1 });
+    await new Promise(r => setTimeout(r, 60)); // >= one rAF + settle
+    const result = await pg.evaluate(() => {
+      const A = window.APP;
+      const el = document.getElementById('hover-name-label');
+      const st = A._hoverNameState();
+      let dbName = null, dbCls = null;
+      if (st.guid) {
+        const rows = A.dbQuery('SELECT element_name, ifc_class FROM elements_meta WHERE guid = ?', [st.guid]);
+        if (rows.length) { dbName = rows[0][0]; dbCls = rows[0][1]; }
+      }
+      return {
+        display: el ? el.style.display : null,
+        html: el ? el.innerHTML : null,
+        guid: st.guid,
+        expectedFriendly: st.guid ? A.friendlyName(dbName, dbCls) : null,
+        rawName: dbName
+      };
+    });
+    if (result.display === 'block' && result.guid) {
+      gateChecked++;
+      const nameShown = result.html.replace(/<[^>]+>/g, '|').split('|')[1] || '';
+      if (nameShown === result.expectedFriendly) gateOk++;
+      if (result.expectedFriendly === result.rawName) coverageRaw++; else coverageNamed++;
+      if (/opacity:0\.65/.test(result.html)) roomHits++;
+      lastHoverGuid = result.guid; lastHoverPos = { cx, cy };
+    }
+  }
+  chk('W-HOVER-NAME: label text matches A.friendlyName(...) for the ACTUAL resolved element',
+    gateChecked > 0 && gateOk === gateChecked, 'checked=' + gateChecked + ' matched=' + gateOk);
+
+  // Cost — mean/max ms from the §HOVER_NAME transition logs gathered during the sweep above.
+  const costs = hoverLogs.map(l => { const m = /ms=([0-9.]+)/.exec(l); return m ? parseFloat(m[1]) : null; }).filter(v => v != null);
+  const mean = costs.length ? costs.reduce((a, b) => a + b, 0) / costs.length : null;
+  const max = costs.length ? Math.max(...costs) : null;
+  chk('W-HOVER-COST: samples captured', costs.length > 0, 'n=' + costs.length);
+  console.log('  §HOVER_NAME cost mean=' + (mean != null ? mean.toFixed(2) : '?') + 'ms max=' + (max != null ? max.toFixed(2) : '?') + 'ms over n=' + costs.length + ' at meshCount=' + meshCount);
+  chk('W-HOVER-COST: mean pick cost < 16ms (one frame budget at 60fps)', mean != null && mean < 16, 'mean=' + (mean || 0).toFixed(2) + 'ms');
+
+  console.log('  W-HOVER-COVERAGE: named=' + coverageNamed + ' raw-passthrough=' + coverageRaw +
+    ' room-subtitle-shown=' + roomHits + ' / resolved=' + gateChecked);
+
+  // ── Click still SELECTS while hover is ON — the trap HOVER_NAME.md names explicitly ──
+  // Click at the SAME pixel hover just verified (lastHoverGuid/lastHoverPos from the sweep above)
+  // — that proves click and hover AGREE on which element is under the cursor (no "two truths, one
+  // screen" desync) AND that hover does not consume/suppress the click.
+  chk('sweep produced at least one verified hover position to click-test', !!lastHoverPos);
+  if (lastHoverPos) {
+    await pg.mouse.move(lastHoverPos.cx, lastHoverPos.cy);
+    await new Promise(r => setTimeout(r, 60));
+    await pg.mouse.down(); await pg.mouse.up();
+    await new Promise(r => setTimeout(r, 200));
+    const pickState = await pg.evaluate(() => ({
+      lastPickGuid: window.APP._lastPickGuid,
+      infoVisible: document.getElementById('info-panel') && document.getElementById('info-panel').style.display === 'block'
+    }));
+    chk('click while hover-name ON selects the SAME element hover showed (no interference)',
+      pickState.lastPickGuid === lastHoverGuid, 'got=' + pickState.lastPickGuid + ' want=' + lastHoverGuid);
+    chk('click while hover-name ON still opens the info panel', pickState.infoVisible === true);
+  }
+
+  chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));
+
+  await br.close();
+  await server.close();
+  clearTimeout(_watchdog);
+  console.log('\n§W-HOVER-NAME DONE pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.log('\n§W-HOVER-NAME CRASHED ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## Summary
- `prompts/Viewer/HOVER_NAME.md` (bim-compiler) implementation: a "hover name" checkbox in the Find panel + the `'` shortcut key (one state, both drive it). Hovering shows the friendly name (via `A.friendlyName`, the same verb the Find panel uses — no second naming path) and containing room (via `rel_contained_in_space`) of whatever's under the cursor, zero clicks. Click still selects, untouched.
- Raycast is event-driven and rAF-coalesced (fires on pointermove, at most once per frame) — not a perpetual 60fps loop, per the spec's frame-budget trap.
- `sw.js` CACHE_VERSION v882→v883 (new precached file, per project DB/asset-change convention).

## Test plan
- [x] `witness_hover_name.js` (committed, repo-root convention): 12/12 on Duplex — gate (label text matches `A.friendlyName` for the ACTUAL resolved element — dense BIM scenes occlude in depth so a naive pre-picked target isn't reliable), cost (mean 1.14ms), checkbox↔key toggle symmetry, click-not-suppressed while hover is on, zero pageerrors.
- [x] Hospital-scale (63k elements) cost independently confirmed: mean=8.52ms / max=20.50ms pick cost, under the 16ms one-frame budget.
- [ ] A full clean witness run at Hospital scale is currently blocked by this dev host's pre-existing ~148s `A.loadNavigate()` cost against a 63k-element DB (confirmed via a hover-untouched control run that stalls identically) — unrelated to this feature, not something this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXTQM1qx4y4fmSSvcLhR6H