### PR TITLE
fix(viewer): §CACHE_KEY — stop re-downloading a building that's already in IndexedDB

### DIFF
--- a/viewer/db_resolve.js
+++ b/viewer/db_resolve.js
@@ -21,6 +21,25 @@
 //   R6 absolute non-OCI .../buildings/X → prodBase+buildings/X  (heal a stale absolute GH-Pages link too)
 // NON-INVENT: only the filename (url.split('/').pop()) is reused; no path is fabricated.
 // Read the §-log after every run (Universal Protocol Log Mandate).
+//
+// # ⚠ DO NOT REMOVE — SPEC (W-DB-CACHE-KEY) — prompts/HISTORY_PERSIST_RECALL.md §VERIFY-FIRST ITEM 1
+// SCOPE: one pure decision — given a building-asset URL, return the CANONICAL IndexedDB cache key.
+// WHY:   scene.js cachedFetch() stored/looked up the blob under the raw url STRING, and the two ways
+//        a user reaches the same building build two different strings for the same bytes:
+//          landing/hub  (index.html:489)          → '<prodBase>buildings/Hospital_extracted.db'
+//          ERP red pill (erp/idempiere.html:4716) → '../buildings/Hospital_extracted.db'
+//        So opening from the landing cached 251MB under the OCI key, and the Zoom-Across red pill then
+//        MISSED, 404'd, retried OCI, and re-downloaded the whole 251MB — every single time, forever,
+//        writing a SECOND copy under the relative key. One building, two entries, 502MB.
+// RULES (each is a test case in tests/witness_db_cache_key.js):
+//   K1 import:// url                  → verbatim   (IDB-only identity; never rewritten)
+//   K2 production buildings/<file>    → 'buildings/<file>'  (folds ../buildings, buildings, /buildings,
+//                                                            and <prodBase>buildings onto ONE key)
+//   K3 /deploy/ or /modeller/ path    → verbatim   (dev bench serves deploy/dev/buildings/Terminal…
+//                                                   AND deploy/buildings/Hospital… — same filenames,
+//                                                   DIFFERENT bytes. Folding those = wrong geometry.)
+//   K4 anything else                  → verbatim   (../erp/ad_seed.db, non-buildings/ assets)
+// NON-INVENT: the key is built from the url's own filename; no path is fabricated, nothing is guessed.
 (function () {
   'use strict';
 
@@ -39,7 +58,23 @@
     return prodBase + 'buildings/' + file;
   }
 
-  var DbResolve = { ociRetryUrl: ociRetryUrl };
+  // cacheKey(url, prodBase) → string   (W-DB-CACHE-KEY — never null; a key is always returned)
+  function cacheKey(url, prodBase) {
+    if (!url || typeof url !== 'string') return url;
+    if (url.indexOf('import://') === 0) return url;                  // K1
+    // K3 — dev/authoring trees keep their full path: deploy/dev/buildings/Terminal_extracted.db and
+    // deploy/buildings/Terminal_extracted.db are different bytes behind the same filename.
+    if (/\/deploy\/|\/modeller\//.test(url)) return url;             // K3
+    // K2 — the shipped production set, however it was addressed. Strip the query/hash first so a
+    // cache-busted '?v=' link folds onto the same key as the plain one.
+    var bare = url.split('#')[0].split('?')[0];
+    if (!/(^|\/)buildings\//.test(bare)) return url;                 // K4
+    var file = bare.split('/').pop();
+    if (!file) return url;                                           // K4 — 'buildings/' with no file
+    return 'buildings/' + file;                                      // K2
+  }
+
+  var DbResolve = { ociRetryUrl: ociRetryUrl, cacheKey: cacheKey };
   if (typeof window !== 'undefined') window.DbResolve = DbResolve;
   if (typeof module !== 'undefined' && module.exports) module.exports = DbResolve;
 })();

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -481,6 +481,21 @@ async function setupScene(A) {
     }).catch(function() {});
   }
 
+  // §PERSIST (W-DB-CACHE-KEY F2 — prompts/HISTORY_PERSIST_RECALL.md §VERIFY-FIRST ITEM 1): ask ONCE per
+  // load for durable storage. Until this, persist() was only ever called from the PWA-install overlay
+  // (_ensureBuildingCached), so a normal viewer session ran on best-effort storage — the browser is then
+  // free to silently evict the whole origin's IndexedDB, and a 251MB building blob is the first thing it
+  // drops. Nothing in the log said so; you just saw §CACHE_MISS_READ and a fresh 251MB download next time.
+  // Cheap, idempotent (already-granted resolves true without a prompt), and never blocks the boot.
+  if (navigator.storage && navigator.storage.persisted && navigator.storage.persist) {
+    navigator.storage.persisted().then(function(already) {
+      if (already) { console.log('[S203] §PERSIST already=true'); return; }
+      return navigator.storage.persist().then(function(granted) {
+        console.log('[S203] §PERSIST granted=' + granted + (granted ? '' : ' — cache is best-effort, browser may evict'));
+      });
+    }).catch(function() {});
+  }
+
   // §IDB_VERSION_FALLBACK (2026-07-18): a browser profile whose bim_ootb_cache is ALREADY at a
   // version higher than 2 (another tab/build that bumped it further, dev/test residue — IndexedDB
   // versions only ever increase, never reopen at a LOWER version) makes the explicit
@@ -544,14 +559,18 @@ async function setupScene(A) {
 
   // §S260b: LRU eviction — keep max 80 entries (~25 buildings × 3 files). Evict oldest on write.
   A._MAX_CACHE_ENTRIES = 80;
-  A._evictOldest = async function(cacheDb) {
+  // §CACHE_EVICT_LRU_FORCE (W-DB-CACHE-KEY F3): `forceN` drops the N oldest entries even when the
+  // count is under the cap — the quota-abort path calls it that way. It used to .clear() the WHOLE
+  // store instead, so one over-quota write threw away every other building that was fitting fine.
+  A._evictOldest = async function(cacheDb, forceN) {
     try {
       var tx = cacheDb.transaction('timestamps', 'readonly');
       var store = tx.objectStore('timestamps');
       var allKeys = await new Promise(function(r) {
         var req = store.getAllKeys(); req.onsuccess = function() { r(req.result || []); }; req.onerror = function() { r([]); };
       });
-      if (allKeys.length < A._MAX_CACHE_ENTRIES) return;
+      if (!forceN && allKeys.length < A._MAX_CACHE_ENTRIES) return 0;
+      if (forceN && !allKeys.length) return 0;
       // Get all timestamps, sort by oldest
       var entries = [];
       var tx2 = cacheDb.transaction('timestamps', 'readonly');
@@ -563,31 +582,47 @@ async function setupScene(A) {
         entries.push({ key: allKeys[i], ts: ts });
       }
       entries.sort(function(a, b) { return a.ts - b.ts; });
-      // Remove oldest until we're under limit
-      var toRemove = entries.slice(0, entries.length - A._MAX_CACHE_ENTRIES + 1);
+      // Remove oldest until we're under limit (or the forced count, for the quota-abort retry).
+      var toRemove = forceN ? entries.slice(0, Math.min(forceN, entries.length))
+                            : entries.slice(0, entries.length - A._MAX_CACHE_ENTRIES + 1);
       if (toRemove.length > 0) {
-        var tx3 = cacheDb.transaction([A.CACHE_STORE, 'timestamps'], 'readwrite');
-        for (var j = 0; j < toRemove.length; j++) {
-          tx3.objectStore(A.CACHE_STORE).delete(toRemove[j].key);
-          tx3.objectStore('timestamps').delete(toRemove[j].key);
-        }
-        console.log('[S203] §CACHE_EVICT_LRU removed=' + toRemove.length + ' keys=' + toRemove.map(function(e){return e.key.split('/').pop();}).join(','));
+        await new Promise(function(done) {
+          var tx3 = cacheDb.transaction([A.CACHE_STORE, 'timestamps'], 'readwrite');
+          for (var j = 0; j < toRemove.length; j++) {
+            tx3.objectStore(A.CACHE_STORE).delete(toRemove[j].key);
+            tx3.objectStore('timestamps').delete(toRemove[j].key);
+          }
+          tx3.oncomplete = done; tx3.onerror = done; tx3.onabort = done;
+        });
+        console.log('[S203] §CACHE_EVICT_LRU removed=' + toRemove.length + ' forced=' + (forceN ? 'yes' : 'no') +
+          ' keys=' + toRemove.map(function(e){return String(e.key).split('/').pop();}).join(','));
       }
-    } catch(e) { /* eviction is best-effort */ }
+      return toRemove.length;
+    } catch(e) { /* eviction is best-effort */ return 0; }
   };
 
   // §S260b: Check if URL is in cache (returns buffer or null, no network)
+  // §CACHE_KEY (W-DB-CACHE-KEY): must use the SAME canonical key as cachedFetch, and must fall back to
+  // the legacy raw-url key for profiles cached before the fix. Missing this here re-opened the exact
+  // §OFFLINE-GATEWAY-LEAK that streaming.js:2051 warns about: streaming's diagnostic size check calls
+  // _checkCache(A.DB_URL) and, on a miss, fires a HEAD at the network for a building already in IDB —
+  // visible in the field as `§DB_SIZE_CHECK size=0MB src=network` on a cached building.
   A._checkCache = async function(url) {
     try {
       const cacheDb = await A.openCacheDB();
       if (!cacheDb) return null;
-      const cached = await new Promise((resolve) => {
-        const tx = cacheDb.transaction(A.CACHE_STORE, 'readonly');
-        const req = tx.objectStore(A.CACHE_STORE).get(url);
-        req.onsuccess = () => resolve(req.result || null);
-        req.onerror = () => resolve(null);
-      });
-      return cached;
+      const key = (window.DbResolve && window.DbResolve.cacheKey) ? window.DbResolve.cacheKey(url, A.PROD_BASE) : url;
+      const get = function(k) {
+        return new Promise((resolve) => {
+          const tx = cacheDb.transaction(A.CACHE_STORE, 'readonly');
+          const req = tx.objectStore(A.CACHE_STORE).get(k);
+          req.onsuccess = () => resolve(req.result || null);
+          req.onerror = () => resolve(null);
+        });
+      };
+      const cached = await get(key);
+      if (cached) return cached;
+      return (key !== url) ? await get(url) : null;   // legacy raw-url entry, pre-fix profiles
     } catch(e) { return null; }
   };
 
@@ -748,12 +783,19 @@ async function setupScene(A) {
   };
 
   A.cachedFetch = async function(url) {
+    // §CACHE_KEY (W-DB-CACHE-KEY — prompts/HISTORY_PERSIST_RECALL.md §VERIFY-FIRST ITEM 1): look the
+    // blob up under the CANONICAL key, not the raw url. The landing opens a building with the absolute
+    // OCI url and the ERP red pill opens the SAME building with '../buildings/<file>' — keyed raw, the
+    // second one missed and re-downloaded 251MB every time. db_resolve.cacheKey folds the production
+    // buildings/ set onto one key and leaves dev/deploy paths verbatim. Network still uses the real url.
+    const key = (window.DbResolve && window.DbResolve.cacheKey) ? window.DbResolve.cacheKey(url, A.PROD_BASE) : url;
+    if (key !== url) console.log(`[S203] §CACHE_KEY url=${url.split('/').pop()} key=${key}`);
     const cacheDb = await A.openCacheDB();
     if (cacheDb) {
       try {
         const cached = await new Promise((resolve, reject) => {
           const tx = cacheDb.transaction(A.CACHE_STORE, 'readonly');
-          const req = tx.objectStore(A.CACHE_STORE).get(url);
+          const req = tx.objectStore(A.CACHE_STORE).get(key);
           req.onsuccess = () => resolve(req.result);
           req.onerror = () => resolve(null);
         });
@@ -761,13 +803,43 @@ async function setupScene(A) {
           // §PERF: log a cache hit ONCE per url, not on every call. A per-tick caller (e.g. the
           // dashboard's ad_seed.db read) turned this into 25.8MB-labelled console spam every tick.
           A._cacheHitLogged = A._cacheHitLogged || {};
-          if (!A._cacheHitLogged[url]) {
-            A._cacheHitLogged[url] = 1;
+          if (!A._cacheHitLogged[key]) {
+            A._cacheHitLogged[key] = 1;
             console.log(`[S203] §CACHE_HIT ${url.split('/').pop()} size=${(cached.byteLength/1024/1024).toFixed(1)}MB`);
           }
           // Update LRU timestamp on hit
-          try { var tx2 = cacheDb.transaction('timestamps', 'readwrite'); tx2.objectStore('timestamps').put(Date.now(), url); } catch(e2) {}
+          try { var tx2 = cacheDb.transaction('timestamps', 'readwrite'); tx2.objectStore('timestamps').put(Date.now(), key); } catch(e2) {}
           return cached;
+        }
+        // §CACHE_KEY_LEGACY (W-DB-CACHE-KEY): profiles that cached BEFORE this fix hold the blob under
+        // the raw url. Adopt it in place rather than making every existing user pay one more 251MB
+        // download for the privilege of the fix. Re-key is best-effort; if it fails the legacy entry
+        // is still found next load.
+        if (key !== url) {
+          var legacy = await new Promise(function(resolve) {
+            try {
+              var txL = cacheDb.transaction(A.CACHE_STORE, 'readonly');
+              var reqL = txL.objectStore(A.CACHE_STORE).get(url);
+              reqL.onsuccess = function() { resolve(reqL.result); };
+              reqL.onerror = function() { resolve(null); };
+            } catch(e3) { resolve(null); }
+          });
+          if (legacy) {
+            console.log(`[S203] §CACHE_KEY_LEGACY_HIT url=${url.split('/').pop()} size=${(legacy.byteLength/1024/1024).toFixed(1)}MB → re-keying to ${key} (no re-download)`);
+            try {
+              await new Promise(function(resolve) {
+                var txR = cacheDb.transaction([A.CACHE_STORE, 'timestamps'], 'readwrite');
+                txR.objectStore(A.CACHE_STORE).put(legacy, key);
+                txR.objectStore('timestamps').put(Date.now(), key);
+                txR.objectStore(A.CACHE_STORE).delete(url);
+                txR.objectStore('timestamps').delete(url);
+                txR.oncomplete = function() { console.log(`[S203] §CACHE_KEY_REKEY_OK key=${key}`); resolve(); };
+                txR.onerror = function() { resolve(); };
+                txR.onabort = function() { console.warn(`[S203] §CACHE_KEY_REKEY_SKIP key=${key} — legacy entry left in place`); resolve(); };
+              });
+            } catch(e4) {}
+            return legacy;
+          }
         }
         console.log(`[S203] §CACHE_MISS_READ url=${url.split('/').pop()} — not in IDB, will fetch`);
       } catch(e) { console.log(`[S203] §CACHE_READ_ERR ${e.message}`); }
@@ -827,36 +899,36 @@ async function setupScene(A) {
       try {
         // §S260b: LRU evict before write to keep under max entries
         await A._evictOldest(cacheDb);
-        await new Promise(function(resolve) {
-          var _writeOk = false;
-          const tx = cacheDb.transaction([A.CACHE_STORE, 'timestamps'], 'readwrite');
-          tx.objectStore('timestamps').put(Date.now(), url);
-          const req = tx.objectStore(A.CACHE_STORE).put(buf, url);
-          req.onsuccess = function() { _writeOk = true; console.log(`[S203] §CACHE_WRITE_OK url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB`); };
-          req.onerror = function(e) {
-            // §S260b: Quota exceeded — let tx abort so onabort evicts+retries
-            console.warn(`[S203] §CACHE_WRITE_ERR url=${url.split('/').pop()} err=${req.error}`);
-          };
-          tx.oncomplete = function() {
-            if (!_writeOk) console.warn('[S203] §CACHE_TX_COMPLETE_BUT_NO_WRITE — data NOT persisted');
-            resolve();
-          };
-          tx.onabort = function() {
-            // Evict all entries then retry write
-            console.log(`[S203] §CACHE_EVICT clearing all cached DBs for space`);
-            var tx2 = cacheDb.transaction(A.CACHE_STORE, 'readwrite');
-            tx2.objectStore(A.CACHE_STORE).clear();
-            tx2.oncomplete = function() {
-              var tx3 = cacheDb.transaction(A.CACHE_STORE, 'readwrite');
-              var req3 = tx3.objectStore(A.CACHE_STORE).put(buf, url);
-              req3.onsuccess = function() { console.log(`[S203] §CACHE_EVICT_WRITE_OK url=${url.split('/').pop()}`); };
-              req3.onerror = function() { console.warn(`[S203] §CACHE_EVICT_WRITE_FAIL — quota too small`); };
-              tx3.oncomplete = resolve;
-              tx3.onerror = function() { resolve(); };
+        // One write attempt under `key`; resolves true on success, false if the tx aborted (quota).
+        var _attemptWrite = function() {
+          return new Promise(function(resolve) {
+            var _writeOk = false;
+            const tx = cacheDb.transaction([A.CACHE_STORE, 'timestamps'], 'readwrite');
+            tx.objectStore('timestamps').put(Date.now(), key);
+            const req = tx.objectStore(A.CACHE_STORE).put(buf, key);
+            req.onsuccess = function() { _writeOk = true; console.log(`[S203] §CACHE_WRITE_OK url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB`); };
+            req.onerror = function() {
+              // §S260b: Quota exceeded — let the tx abort so the caller evicts LRU and retries.
+              console.warn(`[S203] §CACHE_WRITE_ERR url=${url.split('/').pop()} err=${req.error}`);
             };
-            tx2.onerror = function() { resolve(); };
-          };
-        });
+            tx.oncomplete = function() {
+              if (!_writeOk) console.warn('[S203] §CACHE_TX_COMPLETE_BUT_NO_WRITE — data NOT persisted');
+              resolve(_writeOk);
+            };
+            tx.onabort = function() { resolve(false); };
+          });
+        };
+        // §CACHE_EVICT_LRU_RETRY (F3): on a quota abort, drop the OLDEST entries and try again —
+        // bounded. The old code .clear()'d the entire store, so one oversized write wiped every
+        // other cached building and turned the next open of ANY of them into a fresh download.
+        var _ok = await _attemptWrite();
+        for (var _try = 0; !_ok && _try < 4; _try++) {
+          var _dropped = await A._evictOldest(cacheDb, 4);
+          if (!_dropped) break;                       // nothing left to give up — stop, don't spin
+          console.log(`[S203] §CACHE_EVICT_LRU_RETRY attempt=${_try + 1} dropped=${_dropped}`);
+          _ok = await _attemptWrite();
+        }
+        if (!_ok) console.warn(`[S203] §CACHE_EVICT_WRITE_FAIL url=${url.split('/').pop()} — quota too small even after LRU eviction`);
       } catch(e) { console.log(`[S203] §CACHE_WRITE_ERR ${e.message}`); }
     }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v883';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v884';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/poc_db_cache_key_live.js
+++ b/viewer/tests/poc_db_cache_key_live.js
@@ -1,0 +1,110 @@
+// ⚠ DO NOT REMOVE — Scope guard — W-DB-CACHE-KEY (live half)
+// Scope: real-browser §-witness for the reported bug — "the ERP red pill re-fetches the same building
+//   that is already in IndexedDB". Spec: prompts/HISTORY_PERSIST_RECALL.md §VERIFY-FIRST ITEM 1.
+//   Against the REAL viewer.html + the REAL scene.js cachedFetch + a REAL building
+//   (HHS_Office_Federated_extracted.db, 75MB, the largest checked in) — no mock, no stub.
+//   ISSUE PROVED: the landing opens a building with one url form ('<prodBase>buildings/X') and the ERP
+//   red pill opens the SAME building with another ('../buildings/X'). Keyed on the raw url, load #2
+//   MISSED and re-downloaded the whole file. Both loads here run in ONE browser context so IndexedDB
+//   carries over exactly as it does for a real user opening a second tab.
+//   ASSERTS:
+//     - load #1 (form A) → §CACHE_MISS_READ then §CACHE_WRITE_OK (cold, as expected)
+//     - load #2 (form B, SAME bytes, different url string) → §CACHE_HIT, and §CACHE_KEY shows both
+//       forms folding onto 'buildings/<file>'
+//     - load #2 issues ZERO network requests for the .db — the number that IS the bug (0, not 75MB)
+//     - 0 pageerrors on both loads
+//   §-log first — READ viewer/tests/poc_db_cache_key_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node viewer/tests/poc_db_cache_key_live.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DBFILE = 'HHS_Office_Federated_extracted.db';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.bin': 'application/octet-stream', '.png': 'image/png',
+  '.css': 'text/css', '.wasm': 'application/wasm', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  S('§CACHEKEY_LIVE server=http://localhost:' + PORT + ' db=' + DBFILE);
+
+  const browser = await chromium.launch();
+  // ONE context for both loads — IndexedDB persists across page.goto exactly like a real second tab.
+  const ctx = await browser.newContext();
+
+  // The two url forms a real user actually produces. Both resolve to the same file on this server:
+  //   A = the landing/hub form (index.html:489 builds an absolute base + 'buildings/<file>')
+  //   B = the ERP red-pill form (erp/idempiere.html:4716 builds '../buildings/<file>')
+  const FORMS = [
+    { id: 'A-landing', db: 'http://localhost:' + PORT + '/buildings/' + DBFILE },
+    { id: 'B-redpill', db: '../buildings/' + DBFILE }
+  ];
+
+  const runs = [];
+  for (const form of FORMS) {
+    const page = await ctx.newPage();
+    const lines = [], errs = [];
+    let dbRequests = 0;
+    page.on('console', m => lines.push(m.text()));
+    page.on('pageerror', e => errs.push(e.message));
+    page.on('request', r => { if (r.url().split('?')[0].endsWith(DBFILE)) dbRequests++; });
+
+    const url = 'http://localhost:' + PORT + '/viewer/viewer.html?db=' + encodeURIComponent(form.db) + '&bld=HHS_Office_Federated';
+    S('\n§CACHEKEY_LIVE load ' + form.id + ' → ?db=' + form.db);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 });
+    // Wait for the cache decision to be logged (hit or miss), then let the write settle.
+    await page.waitForFunction(() => true, null, { timeout: 1000 }).catch(() => {});
+    const deadline = Date.now() + 90000;
+    while (Date.now() < deadline) {
+      if (lines.some(l => /§CACHE_HIT|§CACHE_WRITE_OK|§CACHE_KEY_LEGACY_HIT|§CACHE_SKIP|§CACHE_EVICT_WRITE_FAIL/.test(l))) break;
+      await new Promise(r => setTimeout(r, 500));
+    }
+    await new Promise(r => setTimeout(r, 2000));
+
+    const cacheLines = lines.filter(l => /§CACHE_|§PERSIST|§DB_SIZE_CHECK/.test(l));
+    cacheLines.forEach(l => S('   | ' + l));
+    runs.push({ id: form.id, lines, errs, dbRequests, cacheLines });
+    verdict(errs.length === 0, form.id + ' 0 pageerrors', errs.length ? errs[0] : '');
+    await page.close();
+  }
+
+  const [a, b] = runs;
+  S('\n§CACHEKEY_LIVE VERDICT');
+  // Load #1 — cold, as expected. If this is already a hit the test proved nothing.
+  verdict(a.lines.some(l => /§CACHE_MISS_READ/.test(l) && l.includes(DBFILE)),
+    'load A (landing form) is COLD (§CACHE_MISS_READ)');
+  verdict(a.lines.some(l => /§CACHE_WRITE_OK/.test(l)), 'load A wrote the blob (§CACHE_WRITE_OK)');
+  verdict(a.dbRequests > 0, 'load A downloaded the .db', 'requests=' + a.dbRequests);
+
+  // Load #2 — THE BUG. Different url string, same building. Must hit, must not touch the network.
+  const bHit = b.lines.some(l => /§CACHE_HIT/.test(l) && l.includes(DBFILE)) ||
+               b.lines.some(l => /§CACHE_KEY_LEGACY_HIT/.test(l) && l.includes(DBFILE));
+  verdict(bHit, 'load B (red-pill form) HIT the cache written by load A',
+    bHit ? '' : 'this is the reported bug: a second url form re-downloads the whole building');
+  verdict(b.dbRequests === 0, 'load B made ZERO network requests for the .db',
+    'requests=' + b.dbRequests + ' (was the full re-download before the fix)');
+  verdict(!b.lines.some(l => /§CACHE_MISS_READ/.test(l) && l.includes(DBFILE)),
+    'load B logged no §CACHE_MISS_READ for the building');
+  const keyLine = b.lines.find(l => /§CACHE_KEY /.test(l) && l.includes(DBFILE));
+  verdict(!!keyLine && /key=buildings\//.test(keyLine || ''),
+    'load B folded onto the canonical key', keyLine || 'no §CACHE_KEY line');
+
+  S('\n§CACHEKEY_LIVE-SUMMARY fails=' + fails);
+  fs.writeFileSync(path.join(__dirname, 'poc_db_cache_key_live.log'), log.join('\n') + '\n');
+  await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(e => { console.error('§CACHEKEY_LIVE FATAL ' + e.message); server.close(); process.exit(1); });

--- a/viewer/tests/witness_db_cache_key.js
+++ b/viewer/tests/witness_db_cache_key.js
@@ -1,0 +1,67 @@
+// # ⚠ DO NOT REMOVE — W-DB-CACHE-KEY
+// ISSUE PROVED: the SAME building reached by two different routes was cached under two different
+//   IndexedDB keys, so the ERP red-pill Zoom-Across re-downloaded 251MB of Hospital that the landing
+//   had already cached. The landing builds '<prodBase>buildings/Hospital_extracted.db'
+//   (index.html:489); the red pill builds '../buildings/Hospital_extracted.db'
+//   (erp/idempiere.html:4716). scene.js cachedFetch keyed the blob on that raw string.
+//   Spec: prompts/HISTORY_PERSIST_RECALL.md §VERIFY-FIRST ITEM 1.
+// THIS TEST FAILS ON THE OLD CODE — the old key was the url itself, so K2-fold-* could never match.
+// METHOD: drive the REAL pure decision db_resolve.cacheKey (require'd verbatim, no copy) across the
+//   four spec rules K1–K4 + the exact url pair from the bug report. Whitebox §-log; no browser needed.
+// Run: node viewer/tests/witness_db_cache_key.js   → exit 0 = GREEN. Read the §-log, not the exit code.
+const path = require('path');
+const { cacheKey } = require(path.join(__dirname, '..', 'db_resolve.js'));
+
+const PROD = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/';
+const BLD = PROD + 'buildings/';
+
+const cases = [
+  // K2 — every production form of the same building asset folds onto ONE key.
+  { id: 'K2-redpill',  url: '../buildings/Hospital_extracted.db',        want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-landing',  url: BLD + 'Hospital_extracted.db',              want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-bare',     url: 'buildings/Hospital_extracted.db',          want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-rooted',   url: '/bim-ootb/buildings/Hospital_extracted.db', want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-ghpages',  url: 'https://red1oon.github.io/bim-ootb/buildings/Hospital_extracted.db', want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-cachebust', url: '../buildings/Hospital_extracted.db?v=12', want: 'buildings/Hospital_extracted.db' },
+  { id: 'K2-positions', url: '../buildings/Hospital_positions.bin',     want: 'buildings/Hospital_positions.bin' },
+  // K3 — dev/authoring trees keep their FULL path. deploy/dev/buildings/Terminal_extracted.db and
+  // deploy/buildings/Terminal_extracted.db are different bytes behind the same filename
+  // (viewer/dlod_bench.html:29,33) — folding them would serve wrong geometry on a dev machine.
+  { id: 'K3-devbench', url: '/bim-compiler/deploy/dev/buildings/Terminal_extracted.db', want: '/bim-compiler/deploy/dev/buildings/Terminal_extracted.db' },
+  { id: 'K3-prodbench', url: '/bim-compiler/deploy/buildings/Terminal_extracted.db',    want: '/bim-compiler/deploy/buildings/Terminal_extracted.db' },
+  { id: 'K3-modeller', url: '/modeller/Duplex_extracted.db',            want: '/modeller/Duplex_extracted.db' },
+  // K1 — import:// is an IDB-only identity, never rewritten.
+  { id: 'K1-import',   url: 'import://myhouse/myhouse_extracted.db',    want: 'import://myhouse/myhouse_extracted.db' },
+  // K4 — anything that isn't a buildings/ asset is left exactly as it was.
+  { id: 'K4-adseed',   url: '../erp/ad_seed.db',                        want: '../erp/ad_seed.db' },
+  { id: 'K4-lib',      url: 'mep_rw.db',                                want: 'mep_rw.db' },
+  { id: 'K4-nearmiss', url: '../buildingsX/foo.db',                     want: '../buildingsX/foo.db' }, // 'buildings' must be a path segment
+];
+
+let pass = 0, fail = 0;
+for (const c of cases) {
+  const got = cacheKey(c.url, PROD);
+  const ok = got === c.want;
+  ok ? pass++ : fail++;
+  console.log(`§CACHEKEY ${ok ? 'PASS' : 'FAIL'} ${c.id}  in=${c.url}  → ${got}` +
+              (ok ? '' : `  EXPECTED ${c.want}`));
+}
+
+// THE REGRESSION — this single assertion IS the reported bug. Two routes, one building, one key.
+const kRedPill = cacheKey('../buildings/Hospital_extracted.db', PROD);
+const kLanding = cacheKey(BLD + 'Hospital_extracted.db', PROD);
+const folded = kRedPill === kLanding;
+folded ? pass++ : fail++;
+console.log(`§CACHEKEY ${folded ? 'PASS' : 'FAIL'} BUG-red-pill-vs-landing  redpill=${kRedPill}  landing=${kLanding}` +
+            (folded ? '  → one key, no re-download' : '  → STILL TWO KEYS: the 251MB re-download is back'));
+
+// And the guard that must NOT fold — dev vs prod bench, same filename, different bytes.
+const kDev = cacheKey('/bim-compiler/deploy/dev/buildings/Terminal_extracted.db', PROD);
+const kPrd = cacheKey('/bim-compiler/deploy/buildings/Terminal_extracted.db', PROD);
+const kept = kDev !== kPrd;
+kept ? pass++ : fail++;
+console.log(`§CACHEKEY ${kept ? 'PASS' : 'FAIL'} GUARD-dev-vs-prod-bench  dev=${kDev}  prod=${kPrd}` +
+            (kept ? '  → kept apart' : '  → COLLIDED: dev bench would serve prod geometry'));
+
+console.log(`§CACHEKEY-SUMMARY ${pass}/${pass + fail} pass`);
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -820,7 +820,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="lib/httpvfs.js?v=1" onerror="console.warn('§LOAD_FAIL httpvfs.js — range-request streaming disabled')"></script>
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
-<script src="db_resolve.js?v=1" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
+<script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
 <script src="effects.js?v=7" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
@@ -831,7 +831,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=53" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=54" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=58" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>


### PR DESCRIPTION
## The bug (user report)

The ERP red-pill **Zoom-Across** opens the Viewer and re-downloads the **whole building** — 251MB of Hospital — even though it is already sitting in IndexedDB. From the reporting session's log:

```
§CACHE_MISS_READ url=Hospital_extracted.db — not in IDB, will fetch
§DB_404_OCI_RETRY status=404 → https://objectstorage…/buildings/Hospital_extracted.db
§CACHE_WRITE_OK url=Hospital_extracted.db size=251.1MB
```

## Root cause — one key per URL string, and there are two URL strings

`scene.js` `cachedFetch()` stored and looked the blob up under the **raw `url` argument**. The two ways a user reaches the same building build different strings for identical bytes:

| entry point | code | `db=` param |
|---|---|---|
| Landing / hub card | `index.html:489` | `<prodBase>buildings/Hospital_extracted.db` |
| ERP red pill | `erp/idempiere.html:4716` | `../buildings/Hospital_extracted.db` |

Open from the landing → cached under the OCI key. Red-pill across → looks up the relative key → **MISS** → 404 on GH-Pages → OCI retry → 251MB down the wire → written back under a *second* key. One building, two entries, 502MB, and the red pill missed forever.

Not eviction. Not LFS. A key mismatch — deterministic and reproducible.

## The fix

**F1 — canonical cache key.** New pure decision `DbResolve.cacheKey(url, prodBase)` (rules K1–K4, same house style as the existing `ociRetryUrl`). Every production form of `buildings/<file>` folds onto one key; `/deploy/` and `/modeller/` paths stay verbatim — the dev bench serves `deploy/dev/buildings/Terminal_extracted.db` **and** `deploy/buildings/Terminal_extracted.db`, same filename, different bytes, and folding those would serve wrong geometry. Used by `cachedFetch` **and** `_checkCache`; the network fetch still uses the real url, so the 404→OCI self-heal is untouched. Pre-fix profiles have their legacy raw-url entry **adopted and re-keyed in place** (`§CACHE_KEY_LEGACY_HIT`) — nobody pays one more download for the fix itself.

**F2 — `§PERSIST`.** `navigator.storage.persist()` is now requested on every load, not only from the PWA-install overlay (`_ensureBuildingCached`). A normal session ran on best-effort storage, so the browser was free to silently evict the whole origin — a 251MB blob is the first thing to go, and nothing in the log said so.

**F3 — quota abort evicts LRU, never `.clear()`.** One over-quota write used to throw away *every* cached building. Now it drops the oldest entries and retries, bounded.

**Bonus:** closes the `§OFFLINE-GATEWAY-LEAK` that `streaming.js:2051` warns about in a comment. `_checkCache` kept the raw key, so the diagnostic size probe fired a HEAD at the network for an already-cached building — visible in the field as `§DB_SIZE_CHECK size=0MB src=network`.

## Witnesses — real building, `§`-log first

`viewer/tests/witness_db_cache_key.js` — pure, headless, **16/16**. Fails on the old code; the decisive assertion *is* the bug:

```
§CACHEKEY PASS BUG-red-pill-vs-landing  redpill=buildings/Hospital_extracted.db  landing=buildings/Hospital_extracted.db  → one key, no re-download
§CACHEKEY PASS GUARD-dev-vs-prod-bench  → kept apart
```

`viewer/tests/poc_db_cache_key_live.js` — real browser, real `HHS_Office_Federated_extracted.db` (72.1MB), one context, two url forms, **7/7, 0 pageerrors**:

```
load A (landing form)  §CACHE_MISS_READ → §CACHE_WRITE_OK 72.1MB   db requests=2
load B (red-pill form) §CACHE_KEY key=buildings/HHS_Office_Federated_extracted.db
                       §CACHE_HIT 72.1MB                            db requests=0
§DB_SIZE_CHECK src=network (A) → src=cache (B)
```

Load B making **zero** network requests for the .db is the whole deliverable.

**Regressions:** `W-DB-404-OCI-RETRY` 12/12 green · `tests/audit_script_tags.js` 140/140 exit 0 · `sw.js` `CACHE_VERSION` v883→v884, `scene.js?v=54`, `db_resolve.js?v=2`.
`tests/audit_specs.js` reports one violation (`38-sh-dx-2d-runtime.spec.js`, 5 SKIP paths) that is **pre-existing on `main`** and unrelated to this change — verified against the baseline checkout, unchanged by this PR.

## Not fixed here

The user also reported Hospital showing **missing walls on one side** in the same re-fetching tab. Hypothesis (unproven) is that the re-download raced the geometry stream. Verify after this lands: if a clean `§CACHE_HIT` open renders the walls it was the re-fetch; if they are still absent from a fully-cached load it is an extraction gap in `Hospital_extracted.db` and needs its own lane. Recorded in the spec file.

Spec: `bim-compiler prompts/HISTORY_PERSIST_RECALL.md` §VERIFY-FIRST ITEM 1 (this PR answers that open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157mVHKeGT2MFDM3Jgjgsyo