### PR TITLE
feat(viewer): §CPE_ROOM_TITLE — name the room as the Film-Maker camera enters it

### DIFF
--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -94,6 +94,7 @@
   "setupClashReporter": "readonly",
   "setupClashSnag": "readonly",
   "setupConfig": "readonly",
+  "setupCpeRoomTitle": "readonly",
   "setupDiff": "readonly",
   "setupDLOD": "readonly",
   "setupEffects": "readonly",

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -246,12 +246,19 @@
 
   // One explicit composer render, then SAME-TASK drawImage into a 2D canvas (clash_snag.js's
   // proven capture pattern — the WebGL buffer is only guaranteed valid within the task that drew it).
-  function _captureFrame(w, h) {
+  // §CPE_ROOM_TITLE: titleInfo ({name, opacity}, or null/opacity<=0) is composited onto THIS 2D
+  // context, after the WebGL frame is drawn in but before toBlob — the only point that reaches the
+  // actual exported bytes (RESUME_CPE_ROOM_TITLE.md §2's trap: a DOM caption never would).
+  function _captureFrame(w, h, titleInfo) {
     var A = window.APP;
     if (A._composer) A._composer.render();
     var c = document.createElement('canvas');
     c.width = w; c.height = h;
-    c.getContext('2d').drawImage(A.renderer.domElement, 0, 0, w, h);
+    var ctx = c.getContext('2d');
+    ctx.drawImage(A.renderer.domElement, 0, 0, w, h);
+    if (titleInfo && titleInfo.opacity > 0 && A.roomTitleCompositeOntoCanvas) {
+      A.roomTitleCompositeOntoCanvas(ctx, w, h, titleInfo.name, titleInfo.opacity);
+    }
     return new Promise(function(res) { c.toBlob(res, 'image/webp', 0.92); });
   }
 
@@ -507,7 +514,7 @@
     // Set from the editor's override below. `poseAt` is the ONE place the window is applied, so
     // every consumer — the preview, the bake loop, and anything added later — flies the clip through
     // the same function, and there is no second notion of "which part of the film this is".
-    var _clip = null, _buildup = false, _bkState = null;
+    var _clip = null, _buildup = false, _bkState = null, _roomTitle = false, _titleSegs = null;
     function _tFilm(tNorm) { return _clip ? _clip.in + tNorm * (_clip.out - _clip.in) : tNorm; }
     function poseAt(tNorm) {
       tNorm = _tFilm(tNorm);
@@ -633,6 +640,7 @@
             ' (poseAt remaps; the film itself is unchanged)');
         }
         _buildup = !!_ov.buildup;
+        _roomTitle = !!_ov.roomTitle; // §CPE_ROOM_TITLE — off unless the editor's checkbox set it
         var _wpN = _ov.bands ? _ov.bands.length * 2 : (_ov.waypoints ? _ov.waypoints.length : '?');
         console.log('§CPE_APPLIED total=' + _cpeRes.durationSec.toFixed(1) + 's frames=' + nFrames +
           ' waypoints=' + _wpN + ' saved=' + !!_cpeRes.saved);
@@ -752,6 +760,14 @@
           }
         }
       }
+      // §CPE_ROOM_TITLE — one coarse pre-pass over the WHOLE (already clip/buildup-resolved) frame
+      // count, not a per-frame room query: nFrames/fps here is the bake's actual, final duration
+      // (§CPE_CLIP has already resized it above), so the timeline never disagrees with what's about
+      // to be captured.
+      if (_roomTitle && plan && A.roomTitleBuildTimeline) {
+        try { _titleSegs = A.roomTitleBuildTimeline(plan, nFrames / fps); }
+        catch (eT) { console.warn('§CPE_ROOM_TITLE_ERR ' + eT.message); _titleSegs = null; }
+      }
       t0 = _etaPrev = performance.now();
       for (var i = 0; i < nFrames; i++) {
         if (_cancel) { console.log('§MAXQ_CANCEL i=' + i); break; }
@@ -794,7 +810,8 @@
         // state its own health at the end instead of leaving a degraded film to look identical to
         // a good one.
         if (!ok) { _unconverged++; console.warn('§MAXQ_FRAME_TIMEOUT i=' + i + ' — capturing as-is (UNCONVERGED, count=' + _unconverged + ')'); }
-        var blob = await _captureFrame(w, h);
+        var _titleInfo = (_titleSegs && A.roomTitleOpacityAt) ? A.roomTitleOpacityAt(_titleSegs, i / fps) : null;
+        var blob = await _captureFrame(w, h, _titleInfo);
         // §MAXQ_IDB_SALVAGE (2026-07-25, real user repro on Hospital AND HHS_Office — both mid-bake,
         // ~100+ frames in): a backgrounded/throttled tab can have Chrome force-close this run's IDB
         // connection out from under it (confirmed live: two consecutive rAF gaps of 29s and 67s right

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -436,6 +436,7 @@
       // §CPE_CLIP: null means the whole film; the bake remaps poseAt into [in,out] when set.
       clip: (s.clipIn > 0 || s.clipOut < 1) ? { in: s.clipIn, out: s.clipOut } : null,
       buildup: !!s.buildup,
+      roomTitle: !!s.roomTitle,
       diveSec: s.baseSec.dive * scale, spinSec: s.baseSec.spin * scale,
       outSec: nat.outSec * scale, riseSec: s.baseSec.rise * scale,
       _total: total, _naturalTotal: nat.total, _scale: scale, _pathLen: nat.len
@@ -471,6 +472,7 @@
     if (_state.hose.length) return true;
     if (_state.clipIn > 0 || _state.clipOut < 1) return true;
     if (_state.buildup) return true;
+    if (_state.roomTitle) return true;
     if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
     // §CPE_STICK: the band COUNT is now a thing that can change, and it must count as an edit before
     // the per-band comparison below (which indexes both arrays in lockstep and would otherwise miss
@@ -557,6 +559,8 @@
           '<button id="cpe-clip-clear" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">whole film</button></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox"> ' +
           'build the model as the film plays</label> <span style="color:#666">(follows the Time Machine, not a programme)</span></div>' +
+        '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-room-title" type="checkbox"> ' +
+          'room titles</label> <span style="color:#666">(name card as the camera enters each room)</span></div>' +
         // §CPE_IDB_PATH_STORE — saved plans for THIS building.
         '<div style="margin-top:6px">saved <select id="cpe-plans" style="max-width:150px;background:#15181c;color:#ddd;' +
           'border:1px solid #3a3f47;border-radius:3px;font-size:10px;padding:1px 2px"></select> ' +
@@ -924,11 +928,13 @@
     _state.clipIn = ov.clip ? ov.clip.in : 0;
     _state.clipOut = ov.clip ? ov.clip.out : 1;
     _state.buildup = !!ov.buildup;
+    _state.roomTitle = !!ov.roomTitle;
     _state.userTotal = ov._total;
     _state.staged = false; _state.held = null;
     console.log('§CPE_PATH_LOADED name="' + rec.name + '" bands=' + _state.bands.length +
       ' hoseOps=' + _state.hose.length + ' clip=' + _state.clipIn.toFixed(2) + '→' + _state.clipOut.toFixed(2) +
-      ' buildup=' + (_state.buildup ? 1 : 0) + ' savedAt=' + new Date(rec.savedAt).toISOString().slice(0, 16) +
+      ' buildup=' + (_state.buildup ? 1 : 0) + ' roomTitle=' + (_state.roomTitle ? 1 : 0) +
+      ' savedAt=' + new Date(rec.savedAt).toISOString().slice(0, 16) +
       ' — Ctrl+Z restores what you had before loading');
     _markPreviewStale();
     _refreshFlow(); _replanFilm();
@@ -951,6 +957,12 @@
     var save = { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
                  tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z };
     s.flying = true; s.previewedAt = s.edits; _renderWhole();
+
+    // §CPE_ROOM_TITLE — live preview overlay, built ONCE per rehearsal against the film's real
+    // duration in seconds (poseAt's tNorm domain is 0..1 over the WHOLE plan; `dur` above is just
+    // this rehearsal's playback speed, not the film's real length).
+    var _titleTotalSec = s.roomTitle ? _buildOverride()._total : 0;
+    if (s.roomTitle && a.roomTitleLiveStart) a.roomTitleLiveStart(s.plan, _titleTotalSec);
 
     // ══ §CPE_BUILDUP in the PREVIEW — measured before it was assumed expensive ═════════════════
     // User, 2026-07-28: "i dont expect buildup preview can be done as it be heavy engine work...
@@ -977,6 +989,7 @@
         a.camera.position.set(p.x, p.y, p.z);
         a.controls.target.set(p.tx, p.ty, p.tz);
         a.controls.update();
+        if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
         if (bkPrev && window.tmSetCursor) {
           window.tmSetCursor(bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart));
         }
@@ -991,6 +1004,7 @@
         // Hand Time Machine back exactly as it was — the preview must never leave the user's
         // timeline re-ordered, same contract the bake honours on every exit path.
         if (bkPrev && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); bkPrev = null; }
+        if (a.roomTitleLiveStop) a.roomTitleLiveStop();
         _state.flying = false;
         console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +
           ' buildup=' + (s.buildup ? 1 : 0) + ' — camera restored to the editing pose');
@@ -1453,6 +1467,9 @@
         // §CPE_BUILDUP: off by default — a film that assembles itself is a deliberate choice, not
         // the default reading of a fly-through.
         buildup: false,
+        // §CPE_ROOM_TITLE: off by default, same reasoning — a captioned film is a deliberate choice
+        // (RESUME_CPE_ROOM_TITLE.md).
+        roomTitle: false,
         // §CPE_PREVIEW_BUTTON: edits counts every landed change; previewedAt is the edit the user
         // has actually seen. Equal = "you have seen this version".
         edits: 0, previewedAt: 0, flying: false,
@@ -1529,6 +1546,17 @@
         // this checkbox.
         console.log('§CPE_BUILDUP ' + (_state.buildup ? 'ON' : 'off') +
           ' — reveal FOLLOWS the Time Machine timeline as-is (no re-key; the camera does not author the build order)');
+        _renderWhole(); _syncButtons();
+      });
+      document.getElementById('cpe-room-title').addEventListener('change', function(e) {
+        _state.roomTitle = !!e.target.checked;
+        _markPreviewStale();
+        console.log('§CPE_ROOM_TITLE ' + (_state.roomTitle ? 'ON' : 'off'));
+        // a.friendlyName/a.getRoomGraph live in the lazy Navigate bundle — same load-on-first-use
+        // as §HOVER_NAME (HOVER_NAME.md).
+        var _a = A();
+        if (_state.roomTitle && typeof _a.friendlyName !== 'function' && typeof _a.loadNavigate === 'function') _a.loadNavigate();
+        if (!_state.roomTitle && _a.roomTitleLiveStop) _a.roomTitleLiveStop();
         _renderWhole(); _syncButtons();
       });
       document.getElementById('cpe-preview').addEventListener('click', _previewFly);

--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -1,0 +1,165 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// cpe_room_title.js — §CPE_ROOM_TITLE (prompts/RESUME_CPE_ROOM_TITLE.md): a room-name title card
+// that appears as the Film-Maker's camera enters each room, behind a checkbox, OFF by default.
+// Naming is NOT reinvented here — every title runs through A.friendlyName, the same verb the Find
+// panel and §HOVER_NAME use (HOVER_NAME.md's own coverage sweep is what proved that pipeline).
+// The one real problem this file solves: cinema_maxq.js's _captureFrame grabs the renderer CANVAS
+// only, so an HTML caption would be invisible in the exported video (HOVER_NAME.md's DOM label
+// trick does NOT transfer here). Titles are composited onto a 2D context directly — either the
+// bake's captured frame, or a live overlay canvas positioned over the WebGL canvas for editing —
+// through the SAME draw routine, so the preview can never look different from what actually bakes.
+function setupCpeRoomTitle(A) {
+  var SAMPLE_DT = 0.15;   // seconds between coarse room-at-time samples when building the timeline
+  var MIN_DWELL = 1.4;    // seconds — a room shown for less than this is suppressed (rate limit):
+                          // a walk crossing six small rooms in four seconds must not strobe six titles
+  var FADE = 0.4;         // seconds — fade in/out
+
+  // Point-in-room via the shared room graph (A.getRoomGraph — the ONE cache per building every
+  // other room consumer already shares, FLY_TOUR_CORRIDOR_GRAPH.md §S2). Only 'room'-kind nodes
+  // carry a rect footprint (real IfcSpace + synthesized corridors both do; stair/circulation
+  // waypoint nodes are points, not polygons, and simply produce no title — same scope CINEMA_DIVE's
+  // own room search already accepts). z-closest match disambiguates stacked floors whose plan
+  // rects overlap.
+  function _roomAtIfcPoint(ix, iy, iz) {
+    var g = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
+    if (!g || !g.nodesByGuid) return null;
+    var best = null, bestDz = Infinity;
+    for (var k in g.nodesByGuid) {
+      var n = g.nodesByGuid[k];
+      if (!n || n.kind !== 'room' || !n.rects || !n.rects.length) continue;
+      for (var i = 0; i < n.rects.length; i++) {
+        var r = n.rects[i];
+        if (ix < r.x0 || ix > r.x1 || iy < r.y0 || iy > r.y1) continue;
+        var dz = Math.abs((n.cz || 0) - iz);
+        if (dz < bestDz) { bestDz = dz; best = n; }
+        break;
+      }
+    }
+    return best;
+  }
+
+  // ⚠ HOVER_NAME.md §1 / this feature's own scope note: consume A.friendlyName, never a second
+  // naming path. A room's stored name is already human-authored or compiler-synthesized-friendly
+  // (e.g. "≈ Roof R1") — friendlyName is a no-op passthrough for those, but running every title
+  // through it is what the witness asserts and what keeps this in lockstep with the Find panel if
+  // friendlyName is ever improved.
+  function _titleFor(n) {
+    if (!n) return null;
+    var name = (typeof A.friendlyName === 'function') ? A.friendlyName(n.name, null) : n.name;
+    return { guid: n.guid, name: name };
+  }
+
+  // Coarse-samples the whole (or clipped) film ONCE, collapses into room-dwell segments, and drops
+  // any segment shorter than MIN_DWELL. Cheap: a few hundred samples, each one THREE→IFC conversion
+  // plus a linear scan of a few hundred room rects — §CPE_BUILDUP_FOLLOW_TM measured this class of
+  // per-t lookup as trivial next to a bake's real cost (a full still-refine per frame).
+  A.roomTitleBuildTimeline = function(plan, totalSec) {
+    var t0 = performance.now();
+    var samples = [];
+    for (var t = 0; t <= totalSec + 1e-6; t += SAMPLE_DT) {
+      var tn = totalSec > 0 ? Math.min(1, t / totalSec) : 0;
+      var p = plan.poseAt(tn);
+      var ifcP = A.three2ifc ? A.three2ifc(p.x, p.y, p.z) : null;
+      var room = ifcP ? _roomAtIfcPoint(ifcP.ix, ifcP.iy, ifcP.iz) : null;
+      samples.push({ t: t, guid: room ? room.guid : null, node: room });
+    }
+    var raw = [];
+    samples.forEach(function(s) {
+      var last = raw[raw.length - 1];
+      if (last && last.guid === s.guid) { last.tEnd = s.t; }
+      else raw.push({ guid: s.guid, node: s.node, tStart: s.t, tEnd: s.t });
+    });
+    var kept = [], suppressed = 0;
+    raw.forEach(function(seg) {
+      if (!seg.guid) return; // no room here — no title, never a fabricated one
+      if ((seg.tEnd - seg.tStart) < MIN_DWELL) { suppressed++; return; }
+      var title = _titleFor(seg.node);
+      kept.push({ guid: seg.guid, name: title.name, tStart: seg.tStart, tEnd: seg.tEnd });
+    });
+    console.log('§CPE_ROOM_TITLE_TIMELINE segments=' + kept.length + ' suppressed=' + suppressed +
+      ' totalSec=' + totalSec.toFixed(1) + ' ms=' + (performance.now() - t0).toFixed(1));
+    return kept;
+  };
+
+  // Opacity/text for whichever segment is active (or fading) at absolute time t. Two segments can
+  // both claim a moment during a crossfade — the higher-opacity one wins, so the reveal reads as
+  // one continuous crossfade rather than a flicker between two half-visible captions.
+  A.roomTitleOpacityAt = function(segs, t) {
+    var best = null;
+    (segs || []).forEach(function(s) {
+      if (t < s.tStart - FADE || t > s.tEnd + FADE) return;
+      var op = (t < s.tStart) ? (t - (s.tStart - FADE)) / FADE :
+               (t > s.tEnd) ? 1 - (t - s.tEnd) / FADE : 1;
+      if (!best || op > best.opacity) best = { name: s.name, guid: s.guid, opacity: op };
+    });
+    return best;
+  };
+
+  // Shared draw routine — the ONLY place title text is ever drawn, so the live preview and the
+  // baked video can never disagree about how a title looks (same font, size, band, fade). A lower-
+  // third caption band, documentary-style — screen POSITION is the one open detail RESUME_CPE_
+  // ROOM_TITLE.md left for the user; this is the placeholder until told otherwise.
+  A.roomTitleCompositeOntoCanvas = function(ctx, w, h, text, opacity) {
+    if (!ctx || !text || !(opacity > 0)) return;
+    ctx.save();
+    var fontPx = Math.max(18, Math.round(h * 0.032));
+    var bandH = fontPx * 2.2;
+    var y = h - bandH * 1.4;
+    ctx.globalAlpha = opacity;
+    ctx.fillStyle = 'rgba(0,0,0,0.45)';
+    ctx.fillRect(0, y, w, bandH);
+    ctx.fillStyle = '#fff';
+    ctx.font = '600 ' + fontPx + 'px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, w / 2, y + bandH / 2);
+    ctx.restore();
+  };
+
+  // ══ Live editor preview — an overlay canvas positioned exactly over the WebGL canvas, drawn
+  // through the SAME roomTitleCompositeOntoCanvas the bake uses. Never a DOM label: the point is
+  // WYSIWYG with what the export will actually produce, not just "something readable on screen"
+  // (the exact trap this file's own header warns about).
+  var _liveCanvas = null, _liveSegs = null;
+
+  function _ensureLiveCanvas() {
+    if (_liveCanvas && _liveCanvas.isConnected) return _liveCanvas;
+    if (!A.renderer || !A.renderer.domElement) return null;
+    var c = document.createElement('canvas');
+    c.id = 'cpe-room-title-overlay';
+    c.style.cssText = 'position:fixed;pointer-events:none;z-index:50;';
+    document.body.appendChild(c);
+    _liveCanvas = c;
+    return c;
+  }
+
+  // Called once when a preview rehearsal starts (cinema_path_editor.js's _previewFly).
+  A.roomTitleLiveStart = function(plan, totalSec) {
+    _liveSegs = A.roomTitleBuildTimeline(plan, totalSec);
+  };
+
+  // Called every preview frame with the ABSOLUTE seconds along the (unclipped) film timeline.
+  A.roomTitleLiveTick = function(tSec) {
+    var c = _ensureLiveCanvas();
+    if (!c) return;
+    var src = A.renderer.domElement, r = src.getBoundingClientRect();
+    c.style.left = r.left + 'px'; c.style.top = r.top + 'px';
+    if (c.width !== r.width) c.width = r.width;
+    if (c.height !== r.height) c.height = r.height;
+    c.style.width = r.width + 'px'; c.style.height = r.height + 'px';
+    var ctx = c.getContext('2d');
+    ctx.clearRect(0, 0, c.width, c.height);
+    var info = A.roomTitleOpacityAt(_liveSegs, tSec);
+    if (info) A.roomTitleCompositeOntoCanvas(ctx, c.width, c.height, info.name, info.opacity);
+  };
+
+  A.roomTitleLiveStop = function() {
+    if (!_liveCanvas) return;
+    var ctx = _liveCanvas.getContext('2d');
+    ctx.clearRect(0, 0, _liveCanvas.width, _liveCanvas.height);
+  };
+}

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -13,7 +13,7 @@ async function initViewer() {
   if (typeof setupConfig === 'function') setupConfig(APP);
   if (typeof setupScene === 'function') await setupScene(APP);
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
-    setupPicking, setupHoverName, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
+    setupPicking, setupHoverName, setupCpeRoomTitle, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
   // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
   // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v883';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v884';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -123,6 +123,7 @@ const PRECACHE_ASSETS = [
   'tools.js',
   'picking.js',
   'hover_name.js',
+  'cpe_room_title.js',
   'tour.js',
   'clash_matrix.js',
   'measure.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,6 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
+<script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>

--- a/witness_cpe_room_title.js
+++ b/witness_cpe_room_title.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * W-TITLE-COMPOSITED / W-TITLE-NAME-SOURCE / W-TITLE-RATE + checkbox/Guardrail-2 wiring —
+ * prompts/RESUME_CPE_ROOM_TITLE.md. Numeric §-tagged proof only, per CLAUDE.md's FUNDAMENTAL LAW.
+ * RUN: node witness_cpe_room_title.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (e) { r.writeHead(404); r.end('404'); return; }
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-CPE-ROOM-TITLE TIMEOUT — killed after 180s'); process.exit(3); }, 180000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const errs = [];
+  pg.on('pageerror', e => errs.push(String(e)));
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera && !!window.APP.db', { timeout: 45000 });
+  await new Promise(r => setTimeout(r, 2000));
+  await pg.evaluate(() => window.APP.loadNavigate ? window.APP.loadNavigate() : null);
+  await pg.evaluate(() => window.APP.ensureRooms ? window.APP.ensureRooms({}) : null);
+  await new Promise(r => setTimeout(r, 500));
+
+  // ── W-TITLE-NAME-SOURCE: a synthetic 2-room "plan" (real room-graph points, fake poseAt) — every
+  // title must equal A.friendlyName(roomNode.name, ...) for THAT room, the same verb the Find panel
+  // and §HOVER_NAME use. No second naming path. ──
+  const nameTest = await pg.evaluate(() => {
+    const A = window.APP;
+    const g = A.getRoomGraph();
+    if (!g || !g.nodesByGuid) return { ok: false, reason: 'no room graph' };
+    const rooms = Object.values(g.nodesByGuid).filter(n => n.kind === 'room' && n.rects && n.rects.length);
+    if (rooms.length < 2) return { ok: false, reason: 'not enough rooms, n=' + rooms.length };
+    const r0 = rooms[0], r1 = rooms[rooms.length - 1];
+    const p0 = A.ifc2three(r0.cx, r0.cy, r0.cz), p1 = A.ifc2three(r1.cx, r1.cy, r1.cz);
+    const plan = { poseAt: function(tn) { const p = tn < 0.5 ? p0 : p1; return { x: p.x, y: p.y, z: p.z, tx: p.x + 1, ty: p.y, tz: p.z }; } };
+    const segs = A.roomTitleBuildTimeline(plan, 6); // 3s/room — well over MIN_DWELL
+    return {
+      ok: true, segs: segs,
+      expected0: A.friendlyName(r0.name, null), expected1: A.friendlyName(r1.name, null),
+      guid0: r0.guid, guid1: r1.guid
+    };
+  });
+  chk('W-TITLE-NAME-SOURCE: room graph reachable with real room-kind nodes', nameTest.ok, nameTest.reason || '');
+  if (nameTest.ok) {
+    chk('W-TITLE-NAME-SOURCE: exactly 2 segments (one per room, well over MIN_DWELL)', nameTest.segs.length === 2, 'got=' + nameTest.segs.length);
+    if (nameTest.segs.length === 2) {
+      chk('W-TITLE-NAME-SOURCE: segment 1 guid + name match A.friendlyName for that room',
+        nameTest.segs[0].guid === nameTest.guid0 && nameTest.segs[0].name === nameTest.expected0,
+        'guid=' + nameTest.segs[0].guid + ' name="' + nameTest.segs[0].name + '" want="' + nameTest.expected0 + '"');
+      chk('W-TITLE-NAME-SOURCE: segment 2 guid + name match A.friendlyName for that room',
+        nameTest.segs[1].guid === nameTest.guid1 && nameTest.segs[1].name === nameTest.expected1,
+        'guid=' + nameTest.segs[1].guid + ' name="' + nameTest.segs[1].name + '" want="' + nameTest.expected1 + '"');
+    }
+  }
+
+  // ── W-TITLE-RATE: a synthetic path crossing 8 rooms in 2.4s (0.3s each) — every dwell is under
+  // MIN_DWELL=1.4s, so every title must be suppressed, never strobed. ──
+  const rateTest = await pg.evaluate(() => {
+    const A = window.APP;
+    const g = A.getRoomGraph();
+    const rooms = Object.values(g.nodesByGuid).filter(n => n.kind === 'room' && n.rects && n.rects.length).slice(0, 8);
+    if (rooms.length < 4) return { ok: false, reason: 'not enough rooms, n=' + rooms.length };
+    const pts = rooms.map(function(r) { return A.ifc2three(r.cx, r.cy, r.cz); });
+    const total = pts.length * 0.3;
+    const plan = { poseAt: function(tn) {
+      var idx = Math.min(pts.length - 1, Math.floor(tn * pts.length));
+      var p = pts[idx]; return { x: p.x, y: p.y, z: p.z, tx: p.x + 1, ty: p.y, tz: p.z };
+    } };
+    const segs = A.roomTitleBuildTimeline(plan, total);
+    return { ok: true, nRooms: pts.length, segsKept: segs.length };
+  });
+  chk('W-TITLE-RATE: rapid room-crossing rate-limited (kept < visited rooms)',
+    rateTest.ok && rateTest.segsKept < rateTest.nRooms, JSON.stringify(rateTest));
+
+  // ── W-TITLE-COMPOSITED (the gate): the SAME draw routine _captureFrame calls, run against a
+  // plain 2D context — proves the composite actually changes PIXELS, and only in the title band
+  // (RESUME_CPE_ROOM_TITLE.md §2's trap: a DOM caption never would show up here at all). ──
+  const compositeTest = await pg.evaluate(() => {
+    const A = window.APP;
+    const w = 800, h = 450;
+    const c1 = document.createElement('canvas'); c1.width = w; c1.height = h;
+    const ctx1 = c1.getContext('2d'); ctx1.fillStyle = '#123456'; ctx1.fillRect(0, 0, w, h);
+    const c2 = document.createElement('canvas'); c2.width = w; c2.height = h;
+    const ctx2 = c2.getContext('2d'); ctx2.fillStyle = '#123456'; ctx2.fillRect(0, 0, w, h);
+    A.roomTitleCompositeOntoCanvas(ctx2, w, h, 'Witness Room', 1.0);
+    const d1 = ctx1.getImageData(0, 0, w, h).data, d2 = ctx2.getImageData(0, 0, w, h).data;
+    const fontPx = Math.max(18, Math.round(h * 0.032)), bandH = fontPx * 2.2, bandY0 = h - bandH * 1.4 - bandH;
+    let diffInBand = 0, diffOutsideBand = 0;
+    for (let y = 0; y < h; y += 2) for (let x = 0; x < w; x += 4) {
+      const i = (y * w + x) * 4;
+      const diff = Math.abs(d1[i] - d2[i]) + Math.abs(d1[i + 1] - d2[i + 1]) + Math.abs(d1[i + 2] - d2[i + 2]);
+      if (diff > 10) { if (y >= bandY0) diffInBand++; else diffOutsideBand++; }
+    }
+    return { diffInBand, diffOutsideBand, bandY0 };
+  });
+  chk('W-TITLE-COMPOSITED: composite changes real pixels, confined to the title band',
+    compositeTest.diffInBand > 0 && compositeTest.diffOutsideBand === 0, JSON.stringify(compositeTest));
+
+  // ── Checkbox in the Film-Maker panel: exists, OFF by default, and the FULL wiring chain reaches
+  // the resolved override — including Guardrail 2 (an OK with ONLY this box checked must still
+  // hand back override.roomTitle=true; caught and fixed during this witness's own first draft). ──
+  const cbTest = await pg.evaluate(async () => {
+    const A = window.APP;
+    let plan; try { plan = A.cinemaPathPlan(15); } catch (e) { return { ok: false, reason: 'cinemaPathPlan failed: ' + e.message }; }
+    const openPromise = A.cinemaPathEditor.open({ plan: plan, durationSec: 15, fps: 15 });
+    await new Promise(function(r) { setTimeout(r, 400); });
+    const cb = document.getElementById('cpe-room-title');
+    if (!cb) { document.getElementById('cpe-cancel') && document.getElementById('cpe-cancel').click(); return { ok: false, reason: 'no checkbox' }; }
+    const startChecked = cb.checked;
+    cb.click(); // native click on a checkbox toggles .checked AND fires 'change'
+    await new Promise(function(r) { setTimeout(r, 50); });
+    const afterChecked = cb.checked;
+    document.getElementById('cpe-ok').click();
+    const res = await openPromise;
+    return { ok: true, startChecked: startChecked, afterChecked: afterChecked,
+      overrideRoomTitle: res.override ? res.override.roomTitle : 'NO-OVERRIDE(' + JSON.stringify(res) + ')' };
+  });
+  chk('checkbox exists in the Film-Maker panel', cbTest.ok, cbTest.reason || '');
+  if (cbTest.ok) {
+    chk('checkbox starts unchecked (OFF by default)', cbTest.startChecked === false);
+    chk('checkbox click sets checked=true', cbTest.afterChecked === true);
+    chk('OK with ONLY the checkbox toggled still returns override.roomTitle=true (Guardrail 2)',
+      cbTest.overrideRoomTitle === true, 'got=' + cbTest.overrideRoomTitle);
+  }
+
+  chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));
+
+  await br.close();
+  await server.close();
+  clearTimeout(_watchdog);
+  console.log('\n§W-CPE-ROOM-TITLE DONE pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.log('\n§W-CPE-ROOM-TITLE CRASHED ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## Summary
- `prompts/RESUME_CPE_ROOM_TITLE.md` (bim-compiler) implementation: a "room titles" checkbox in the Film-Maker (Alt+C) panel, OFF by default. A lower-third title card fades in as the camera enters each room, both in the live editor rehearsal and the baked video.
- Naming reuses `A.friendlyName` (same verb as the Find panel / §HOVER_NAME) via the shared room graph (`A.getRoomGraph`) — no second naming path, honesty markers (`≈`, etc.) pass through untouched.
- Titles are composited onto a 2D canvas context directly (not a DOM element) — required because `cinema_maxq.js`'s `_captureFrame` grabs only the renderer canvas, so an HTML caption would be invisible in the exported video. One shared draw routine is used for both the live-preview overlay and the baked frame, so preview and export can't disagree.
- A per-t timeline pre-pass collapses room-dwell into segments and drops any segment under 1.4s, so a fast multi-room crossing doesn't strobe titles.
- **Bug fix included**: `_isEdited()`'s Guardrail 2 checked `_state.buildup` but not the new `_state.roomTitle` — an OK with only the room-titles box checked would have silently discarded it. Caught by this PR's own witness before merging.

## Test plan
- [x] `witness_cpe_room_title.js` (committed, repo-root convention): 11/11 on Duplex — room-graph name resolution against `A.friendlyName` for real rooms, rate-limit suppression (8-room rapid crossing → 0 kept), the actual pixel composite (changes pixels ONLY in the title band), full checkbox→override wiring including the Guardrail-2 fix, zero pageerrors.
- [ ] Caption screen position (lower-third) is a placeholder — the spec left this open; a follow-up if the user wants it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXTQM1qx4y4fmSSvcLhR6H