### PR TITLE
fix(modeller): bump service-worker cache v37→v38 so the geo fix reaches a returning browser

### DIFF
--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v37';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v38';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
The geo fix (#1090) landed and the new `str_walker_outliner.js` **is** on the network. But that file is listed in the Modeller service worker's `PRECACHE_ASSETS` and `CACHE_VERSION` stayed at `v37`.

So any browser that had opened the Modeller before kept serving its **own cached copy of the old script** — still fetching the LFS-pointer `mesh.db`, still drawing bounding boxes. The fix was invisible to exactly the people who had used the page before.

`v38` purges the old cache on activate and a returning browser picks up the new script.

Standing rule in this repo: bump `CACHE_VERSION` in the same change as any precached file edit. It was missed on #1090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZX1USuzGMn9Z88cJXAaWq