### PR TITLE
feat(viewer): §SCENE_MERGE — File Open offers "merge into the current scene" instead of navigating the page away

### DIFF
--- a/viewer/import.js
+++ b/viewer/import.js
@@ -377,6 +377,10 @@ function setupImport(A) {
       if (progressBar) { progressBar.style.width = '100%'; progressBar.style.background = '#44cc44'; }
 
       if (A.renderImportCards) A.renderImportCards();
+      // §SCENE_MERGE (prompts/LANDING_MULTIMERGE_SAVEOPEN_RESURRECT.md §SM-7.1 step 5): hand the
+      // produced DB back so the Viewer's Open door can merge it into the LIVE scene. Purely
+      // additive — every pre-existing caller ignores the return value.
+      return { key: key, record: record, buildingName: buildingName, split: !!_recSplit, meta: mergedData.meta };
     } catch (dbErr) {
       console.log('[S220] §MULTI_DB_ERROR ' + dbErr.message);
       if (status) status.textContent = 'DB merge failed: ' + dbErr.message;

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -742,9 +742,252 @@ async function setupScene(A) {
     console.log('§SAVE_DONE mode=download name=' + name + ' bytes=' + bytes.byteLength);
   };
 
-  // ── Open Building → native Open… (FSA / file input). Picks a saved .db, replaces the scene. ──
-  // Mirrors the import monolith path: stash bytes in the cache store, navigate viewer with ?db=import://…
+  // ── §SCENE_MERGE — the merge-or-replace prompt ────────────────────────────────────────────────
+  // Implementing prompts/LANDING_MULTIMERGE_SAVEOPEN_RESURRECT.md §SM-3 / §SM-7 — Witness: W-SCENE-MERGE
+  // PORT of archive/gallery.html:1045 showMergeModal(): same two-button shape, same copy, Enter=merge,
+  // Esc=new. Two forced deltas, both because viewer.html has none of gallery's modal elements:
+  //   (a) the DOM is built once here and reused, and
+  //   (b) gallery's ">1 target → <select>" branch is DROPPED — a Viewer scene has exactly one active
+  //       building, so there is never a target list. NO card / NO list surface (HARD CONSTRAINT).
+  A._showMergeModal = function(fileName, targetName) {
+    return new Promise(function(resolve) {
+      var modal = document.getElementById('merge-modal');
+      if (!modal) {
+        modal = document.createElement('div');
+        modal.id = 'merge-modal';
+        modal.style.cssText = 'position:fixed;inset:0;z-index:100000;display:none;align-items:center;' +
+          'justify-content:center;background:rgba(0,0,0,0.62);font:14px system-ui,sans-serif';
+        modal.innerHTML =
+          '<div style="background:#1b1e24;border:1px solid rgba(255,255,255,0.14);border-radius:10px;' +
+          'padding:22px 24px;max-width:440px;color:#e8e8e8;box-shadow:0 10px 40px rgba(0,0,0,0.6)">' +
+          '<div id="merge-target" style="font-size:15px;line-height:1.45;margin-bottom:6px"></div>' +
+          '<div style="font-size:12px;opacity:0.65;margin-bottom:18px">Merge keeps the current scene and ' +
+          'adds this file alongside it. New replaces the scene with just this file.</div>' +
+          '<div style="display:flex;gap:10px;justify-content:flex-end">' +
+          '<button id="merge-new-btn" style="padding:8px 16px;border-radius:6px;cursor:pointer;' +
+          'background:rgba(255,255,255,0.07);border:1px solid rgba(255,255,255,0.18);color:#ddd">New (Esc)</button>' +
+          '<button id="merge-btn" style="padding:8px 16px;border-radius:6px;cursor:pointer;' +
+          'background:rgba(79,195,247,0.18);border:1px solid rgba(79,195,247,0.5);color:#4fc3f7;' +
+          'font-weight:600">Merge (Enter)</button>' +
+          '</div></div>';
+        document.body.appendChild(modal);
+      }
+      document.getElementById('merge-target').textContent =
+        'Merge "' + fileName + '" into "' + targetName + '"?';
+      modal.style.display = 'flex';
+      console.log('§MERGE_PROMPT file=' + fileName + ' target=' + targetName);
+
+      function cleanup() { modal.style.display = 'none'; document.removeEventListener('keydown', onKey, true); }
+      function done(action) { cleanup(); resolve({ action: action }); }
+      function onKey(e) {
+        if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); done('merge'); }
+        else if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); done('new'); }
+      }
+      document.addEventListener('keydown', onKey, true);
+      document.getElementById('merge-btn').onclick = function() { done('merge'); };
+      document.getElementById('merge-new-btn').onclick = function() { done('new'); };
+    });
+  };
+
+  // Which tables get folded in. meta/transforms/instances are the streaming contract; the rest are
+  // what rooms (rel_contained_in_space, spatial_structure) and 4D (tasks*) read. Folded only when the
+  // table exists on BOTH sides. Dedup is INSERT OR IGNORE — the already-proven rule
+  // (import_db_builder.js:45: same GUID twice collapses).
+  A._MERGE_META_TABLES = ['elements_meta', 'element_transforms', 'element_instances',
+    'rel_contained_in_space', 'spatial_structure', 'tasks', 'task_elements', 'task_sequences',
+    'schedules', 'bom_tree'];
+  A._MERGE_GEO_TABLES = ['component_geometries', 'base_geometries'];
+
+  // ⚠ sql.js `exec` returns ONLY statements that produced rows, so `SELECT * … LIMIT 0` yields `[]`
+  // and NOT a columns list — the first cut of this used that and silently merged nothing
+  // (§MERGE_DONE newBuildings=0 with zero §MERGE_ROWS lines). PRAGMA table_info returns real rows.
+  function _mergeCols(db, table) {
+    try {
+      var r = db.exec('PRAGMA table_info("' + table.replace(/"/g, '') + '")');
+      if (!r || !r.length || !r[0].values.length) return null;
+      return r[0].values.map(function(v) { return v[1]; });
+    } catch (e) { return null; }
+  }
+
+  // §SM-7.0 landmine 3: real DBs disagree on columns (Duplex.component_geometries has `normals`,
+  // Clinic's does not). Insert on the INTERSECTION, driven by the DESTINATION's schema so the
+  // destination schema never changes — which is also what keeps the once-probed, cached
+  // A._libHasNormals (streaming.js:868) honest after a merge.
+  function _mergeTable(src, dst, table) {
+    var sCols = _mergeCols(src, table), dCols = _mergeCols(dst, table);
+    if (!sCols || !dCols) return null;
+    var cols = dCols.filter(function(c) { return sCols.indexOf(c) >= 0; });
+    if (!cols.length) return null;
+    var q = cols.map(function(c) { return '"' + c + '"'; }).join(',');
+    var before = 0, after = 0;
+    try { before = dst.exec('SELECT COUNT(*) FROM "' + table + '"')[0].values[0][0]; } catch (e) {}
+    // Stream row-by-row rather than materialising the whole table first — component_geometries is
+    // ~100MB of BLOBs on Clinic and 311MB-class on KUL070 (§SM-5 memory is the real ceiling).
+    var srcRows = 0, errs = 0;
+    try {
+      var st = src.prepare('SELECT ' + q + ' FROM "' + table + '"');
+      var ins = dst.prepare('INSERT OR IGNORE INTO "' + table + '" (' + q + ') VALUES (' +
+        cols.map(function() { return '?'; }).join(',') + ')');
+      while (st.step()) { srcRows++; try { ins.run(st.get()); } catch (e2) { errs++; } }
+      st.free(); ins.free();
+    } catch (e) { console.warn('§MERGE_READ_FAIL table=' + table + ' ' + e.message); return null; }
+    try { after = dst.exec('SELECT COUNT(*) FROM "' + table + '"')[0].values[0][0]; } catch (e) {}
+    var added = after - before, dup = srcRows - added;
+    console.log('§MERGE_ROWS table=' + table + ' src=' + srcRows + ' before=' + before +
+      ' after=' + after + ' added=' + added + ' dup=' + dup + ' errs=' + errs +
+      ' cols=' + cols.length + '/src' + sCols.length + '/dst' + dCols.length);
+    return { src: srcRows, before: before, after: after, added: added, dup: dup, errs: errs };
+  }
+
+  function _georefPin(db) {
+    if (!db) return null;
+    try {
+      var r = db.exec("SELECT key, value FROM project_metadata WHERE key IN " +
+        "('georef_offset_x','georef_offset_y','georef_offset_z')");
+      if (!r || !r.length) return null;
+      var o = {};
+      r[0].values.forEach(function(v) { o[v[0]] = parseFloat(v[1]); });
+      if (isNaN(o.georef_offset_x) && isNaN(o.georef_offset_y) && isNaN(o.georef_offset_z)) return null;
+      return [o.georef_offset_x || 0, o.georef_offset_y || 0, o.georef_offset_z || 0];
+    } catch (e) { return null; }
+  }
+
+  // Merge an opened .db into the LIVE scene instead of navigating. §SM-7.1.
+  A._mergeDbIntoScene = async function(fileName, bytes) {
+    var t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : 0;
+    var SQL = A._SQL || A.citySQL || A._citySQL;
+    if (!SQL) { console.log('§MERGE_FAIL reason=no_sql_factory'); if (A.status) A.status.textContent = 'Merge failed — sql.js not ready'; return false; }
+    if (!A.db) { console.log('§MERGE_FAIL reason=no_live_db'); return false; }
+    var src;
+    try { src = new SQL.Database(new Uint8Array(bytes)); }
+    catch (e) { console.log('§MERGE_FAIL reason=open_src ' + e.message); return false; }
+
+    var before = Object.keys(A.buildingCentres || {});
+    var srcBlds = [];
+    try {
+      var br = src.exec('SELECT DISTINCT building FROM elements_meta');
+      if (br && br.length) srcBlds = br[0].values.map(function(v) { return v[0]; });
+    } catch (e) {}
+    console.log('§MERGE_START file=' + fileName + ' bytes=' + bytes.byteLength +
+      ' srcBuildings=' + JSON.stringify(srcBlds) + ' sceneBuildings=' + JSON.stringify(before));
+
+    // ── §SM-7.1 step 2: frame rebase. The ALREADY-OPEN building's georef pins the frame; the
+    // incoming DB rebases into it. Same rule as import.js:299-310's sessionGeorefOffset, applied to
+    // a live scene instead of the first file of a drop. A.modelOffset is deliberately NOT touched —
+    // building A's meshes are already placed against it (§SM-7.0 landmine 4).
+    var pin = _georefPin(A.db), inc = _georefPin(src);
+    if (pin && inc) {
+      var dx = inc[0] - pin[0], dy = inc[1] - pin[1], dz = inc[2] - pin[2];
+      if (dx || dy || dz) {
+        try {
+          src.run('UPDATE element_transforms SET center_x = center_x + ?, center_y = center_y + ?, center_z = center_z + ?', [dx, dy, dz]);
+          console.log('§MERGE_GEOREF mode=rebase pin=(' + pin.join(',') + ') inc=(' + inc.join(',') + ') delta=(' + dx + ',' + dy + ',' + dz + ')');
+        } catch (e) { console.log('§MERGE_GEOREF mode=rebase_fail ' + e.message); }
+      } else {
+        console.log('§MERGE_GEOREF mode=same pin=(' + pin.join(',') + ')');
+      }
+    } else {
+      console.log('§MERGE_GEOREF mode=none pin=' + (pin ? '(' + pin.join(',') + ')' : 'absent') +
+        ' inc=' + (inc ? '(' + inc.join(',') + ')' : 'absent') + ' — each DB keeps its own coordinates');
+    }
+
+    // ── §SM-7.1 step 3: fold the tables
+    var stats = {};
+    A._MERGE_META_TABLES.forEach(function(t) { var s = _mergeTable(src, A.db, t); if (s) stats[t] = s; });
+    if (A.libDb) {
+      A._MERGE_GEO_TABLES.forEach(function(t) {
+        var s = _mergeTable(src, A.libDb, t);
+        if (s) stats[t] = s;
+        else if (A.libDb !== A.db) { var s2 = _mergeTable(src, A.db, t); if (s2) stats[t] = s2; }
+      });
+    }
+    console.log('§MERGE_TABLES folded=' + JSON.stringify(Object.keys(stats)) +
+      ' skipped=' + JSON.stringify(A._MERGE_META_TABLES.concat(A._MERGE_GEO_TABLES).filter(function(t){ return !stats[t]; })));
+    if (!stats.elements_meta) {
+      console.error('§MERGE_FAIL reason=elements_meta_not_folded — schema read failed, nothing merged');
+      try { src.close(); } catch (e) {}
+      if (A.status) A.status.textContent = 'Merge failed — could not read ' + fileName;
+      return false;
+    }
+    if (!stats.elements_meta.added) {
+      console.log('§MERGE_WARN elements_meta added=0 — nothing new (all GUIDs already present)');
+    }
+    try { src.close(); } catch (e) {}   // §SM-5 memory: free the source DB immediately
+
+    // ── §SM-7.1 step 5: register in the City shape for API symmetry (one DB now holds both)
+    A.cityBuildingDbs = A.cityBuildingDbs || {};
+    srcBlds.forEach(function(n) { A.cityBuildingDbs[n] = { db: A.db, libDb: A.libDb }; });
+
+    // ── §SM-7.1 step 6: add ONLY the new building names to buildingCentres (same GROUP BY query as
+    // streaming.js:2119). Existing centres are left exactly as they are.
+    var env = null;
+    for (var k0 in A.buildingCentres) { if (A.buildingCentres[k0].envelope) { env = A.buildingCentres[k0].envelope; break; } }
+    var added = [];
+    try {
+      var centres = A.dbQuery('SELECT m.building, COUNT(*), AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
+        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid GROUP BY m.building');
+      for (var ci = 0; ci < centres.length; ci++) {
+        var row = centres[ci];
+        if (A.buildingCentres[row[0]]) { A.buildingCentres[row[0]].count = row[1]; continue; }
+        A.buildingCentres[row[0]] = { ix: row[2], iy: row[3], iz: row[4], count: row[1] };
+        if (env) A.buildingCentres[row[0]].envelope = env;
+        added.push(row[0]);
+      }
+    } catch (e) { console.log('§MERGE_CENTRES_FAIL ' + e.message); }
+    console.log('§MERGE_CENTRES before=' + before.length + ' after=' + Object.keys(A.buildingCentres).length +
+      ' added=' + JSON.stringify(added));
+
+    try {
+      var er = A.dbQuery('SELECT COUNT(*) FROM elements_meta');
+      A.totalElements = er.length ? er[0][0] : A.totalElements;
+      var dr = A.dbQuery('SELECT discipline, COUNT(*) FROM elements_meta GROUP BY discipline');
+      A.discCounts = {};
+      for (var di = 0; di < dr.length; di++) A.discCounts[dr[di][0]] = dr[di][1];
+    } catch (e) {}
+    if (A.updateHUD) A.updateHUD();
+    if (A.populateBuildingList) A.populateBuildingList();
+    if (A._updateFogDensity) A._updateFogDensity();
+
+    var ms = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : 0) - t0;
+    console.log('§MERGE_DONE file=' + fileName + ' newBuildings=' + added.length +
+      ' totalElements=' + A.totalElements + ' ms=' + ms.toFixed(0));
+    if (A.status) A.status.textContent = 'Merged ' + fileName + ' — ' + added.length + ' building(s) added';
+
+    // ── §SM-7.1 step 7: stream the new names sequentially (drained at stream-complete)
+    A._mergePending = (A._mergePending || []).concat(added);
+    A._mergeStreamNext();
+    return true;
+  };
+
+  // Sequential drain, mirroring city.js's _cityStreamNext. Chained from the stream-complete hook in
+  // streaming.js (right beside the existing City drain) — streamBuilding() handles ONE building, and
+  // a real merged package (Clinic = 5 discipline buildings) has N.
+  A._mergeStreamNext = function() {
+    if (!A._mergePending || !A._mergePending.length) return;
+    if (A.streaming) return;                     // re-chained at next stream-complete
+    var next = null;
+    while (A._mergePending.length) {
+      var n = A._mergePending.shift();
+      if (n && !(A.buildingsRendered && A.buildingsRendered.has(n))) { next = n; break; }
+    }
+    if (!next) { console.log('§MERGE_STREAM_DONE queue=empty'); return; }
+    console.log('§MERGE_STREAM bld=' + next + ' remaining=' + A._mergePending.length);
+    A.streamBuilding(next);
+  };
+
+  // ── Open Building → native Open… (FSA / file input). ──
+  // §SCENE_MERGE: a building already open → ASK (merge into this scene / replace). Replace is
+  // today's path, byte-for-byte: stash bytes in the cache store, navigate with ?db=import://…
   A._openDbBytes = async function(fileName, bytes) {
+    var open = Object.keys(A.buildingCentres || {});
+    if (A.db && open.length) {
+      var target = (A.activeBuilding && A.buildingCentres[A.activeBuilding]) ? A.activeBuilding : open[0];
+      var choice = await A._showMergeModal(fileName, target);
+      console.log('§MERGE_CHOICE file=' + fileName + ' target=' + target + ' action=' + choice.action);
+      if (choice.action === 'merge') { await A._mergeDbIntoScene(fileName, bytes); return; }
+    } else {
+      console.log('§MERGE_SKIP reason=no_building_open — replace path');
+    }
     var key = fileName.replace(/\.(db|sqlite)$/i, '') + '.db';
     var dbUrl = 'import://' + key + '/v0';
     var cacheDb = await A.openCacheDB();
@@ -758,26 +1001,52 @@ async function setupScene(A) {
     location.assign('viewer.html?db=' + encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(dbUrl) + '&ghost=1');
   };
 
+  // §SM-7.1 step 5 — source IFC in the SAME door. No new import path: route to the existing
+  // A.importMultiIFC (import.js:267), take the DB it produced, feed it into the same merge/replace
+  // flow. §SM-5 named the ceiling and it is measured, not theoretical: a single ~1GB+ source file
+  // silently imports PARTIAL against the wasm32 4GB budget (IFC_LARGE_PRIVATE_STRESS_TEST §KUL009),
+  // so say so out loud rather than hiding it behind a merge prompt.
+  A._openIfcFiles = async function(files) {
+    if (!A.importMultiIFC) { console.log('§OPEN_IFC_FAIL reason=no_importMultiIFC'); if (A.status) A.status.textContent = 'IFC import unavailable'; return; }
+    var big = [];
+    for (var i = 0; i < files.length; i++) if (files[i].size > 900 * 1048576) big.push(files[i].name + '=' + (files[i].size / 1048576).toFixed(0) + 'MB');
+    if (big.length) {
+      console.warn('§OPEN_IFC_WASM_RISK files=' + big.join(',') + ' — wasm32 4GB ceiling (§KUL009): this may import PARTIAL');
+      if (A.status) A.status.textContent = 'Large IFC (' + big.join(',') + ') — may import partially (4GB wasm limit)';
+    }
+    console.log('§OPEN_IFC files=' + files.length + ' names=' + Array.prototype.map.call(files, function(f){ return f.name; }).join(','));
+    var out = await A.importMultiIFC(files);
+    if (!out || !out.record) { console.log('§OPEN_IFC_FAIL reason=no_record_returned'); return; }
+    var bytes = out.record.extractedDb || out.record.metaDb;
+    if (!bytes) { console.log('§OPEN_IFC_FAIL reason=no_db_bytes split=' + !!out.record.metaDb); return; }
+    console.log('§OPEN_IFC_DB building=' + out.buildingName + ' bytes=' + bytes.byteLength + ' split=' + !!out.split);
+    await A._openDbBytes(out.buildingName + '.db', new Uint8Array(bytes));
+  };
+
   A.openModelDb = async function() {
     // Native Open… (Chromium FSA). Fallback = hidden <input type=file>.
     if (window.showOpenFilePicker) {
       try {
-        var picks = await window.showOpenFilePicker({ multiple: false,
-          types: [{ description: 'Building database', accept: { 'application/x-sqlite3': ['.db', '.sqlite'] } }] });
-        var file = await picks[0].getFile();
-        var buf = await file.arrayBuffer();
-        console.log('§OPEN_PICK mode=fsa name=' + file.name + ' bytes=' + buf.byteLength);
-        await A._openDbBytes(file.name, new Uint8Array(buf));
+        var picks = await window.showOpenFilePicker({ multiple: true,
+          types: [{ description: 'Building database or IFC', accept: { 'application/x-sqlite3': ['.db', '.sqlite'], 'application/x-step': ['.ifc'] } }] });
+        var fsaFiles = [];
+        for (var pi = 0; pi < picks.length; pi++) fsaFiles.push(await picks[pi].getFile());
+        console.log('§OPEN_PICK mode=fsa n=' + fsaFiles.length + ' name=' + fsaFiles[0].name + ' bytes=' + fsaFiles[0].size);
+        if (/\.ifc$/i.test(fsaFiles[0].name)) { await A._openIfcFiles(fsaFiles); return; }
+        var buf = await fsaFiles[0].arrayBuffer();
+        await A._openDbBytes(fsaFiles[0].name, new Uint8Array(buf));
         return;
       } catch (e) { if (e.name === 'AbortError') { console.log('§OPEN_CANCEL user'); return; } /* fall through */ }
     }
-    var input = document.createElement('input'); input.type = 'file'; input.accept = '.db,.sqlite'; input.style.display = 'none';
+    var input = document.createElement('input'); input.type = 'file'; input.accept = '.db,.sqlite,.ifc';
+    input.multiple = true; input.style.display = 'none';
     input.addEventListener('change', async function(){
       if (!input.files.length) return;
-      var file = input.files[0]; var buf = await file.arrayBuffer();
-      console.log('§OPEN_PICK mode=input name=' + file.name + ' bytes=' + buf.byteLength);
-      await A._openDbBytes(file.name, new Uint8Array(buf));
-      document.body.removeChild(input);
+      var file = input.files[0];
+      console.log('§OPEN_PICK mode=input n=' + input.files.length + ' name=' + file.name + ' bytes=' + file.size);
+      if (/\.ifc$/i.test(file.name)) { await A._openIfcFiles(input.files); }
+      else { var buf = await file.arrayBuffer(); await A._openDbBytes(file.name, new Uint8Array(buf)); }
+      if (input.parentNode) document.body.removeChild(input);
     });
     document.body.appendChild(input); input.click();
   };

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -719,6 +719,29 @@ function setupStreaming(A) {
           if (A.CITY_URL && A._cityTagAndBudget) A._cityTagAndBudget(A.activeBuilding);
           // §S285: marquee — stream the next queued building (sequential drain).
           if (A.CITY_URL && A._cityStreamNext) A._cityStreamNext();
+          // §SCENE_MERGE (§SM-7.1 step 7): same sequential drain for buildings folded in by
+          // Open→Merge. A real merged package (Clinic = 5 discipline buildings) has N names and
+          // streamBuilding() handles ONE, so it chains here exactly like City's queue above.
+          if (A._mergePending && A._mergePending.length && A._mergeStreamNext) A._mergeStreamNext();
+          // §MERGE_CONTRACT (W-SCENE-MERGE): §CONTRACT_CHECK is scene-wide and building-blind, so
+          // the merge needs its own per-building split of what is ACTUALLY registered for picking.
+          // guidMap values joined back to elements_meta.building — both sides must be > 0.
+          if (A.cityBuildingDbs && Object.keys(A.buildingCentres || {}).length > 1 && A.db) {
+            try {
+              var _mcOwn = {}, _mcGuids = Object.values(A.guidMap);
+              for (var _mgi in A._mergedIndex) _mcGuids.push(_mgi);
+              var _mcSt = A.db.prepare('SELECT building FROM elements_meta WHERE guid = ?');
+              for (var _mgj = 0; _mgj < _mcGuids.length; _mgj++) {
+                _mcSt.bind([_mcGuids[_mgj]]);
+                if (_mcSt.step()) { var _b = _mcSt.get()[0]; _mcOwn[_b] = (_mcOwn[_b] || 0) + 1; }
+                _mcSt.reset();
+              }
+              _mcSt.free();
+              console.log('§MERGE_CONTRACT buildings=' + Object.keys(_mcOwn).length +
+                ' rendered=' + JSON.stringify(_mcOwn) +
+                ' centres=' + Object.keys(A.buildingCentres).length);
+            } catch (e) { console.warn('§MERGE_CONTRACT_FAIL ' + e.message); }
+          }
         }
         // §S262: Enable DLOD frustum + storey visibility culling (no geometry swap)
         if (A.dlodEnable) {  // §S265: DLOD visibility culling on all devices

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v884';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v885';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_scene_merge_2026-07-30.js
+++ b/viewer/tests/witness_scene_merge_2026-07-30.js
@@ -1,0 +1,342 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// W-SCENE-MERGE — prompts/LANDING_MULTIMERGE_SAVEOPEN_RESURRECT.md §SM-3 / §SM-4 / §SM-7.2
+//
+// THE ISSUE THIS TEST EXPOSES: File Open used to `location.assign()` (scene.js, the old line 758).
+// The page navigated, the scene was destroyed and rebuilt, and that — not memory, not a data limit —
+// is why opening a second file reset the canvas. This witness proves the navigation was REPLACED,
+// not papered over, and that the second building really joins the LIVE scene.
+//
+// Asserted programmatically from § log lines + live object state (no screenshots, per CLAUDE.md
+// FUNDAMENTAL LAW). Test data: Duplex_extracted.db (A, 1119 el, 1 building) then
+// Clinic_extracted.db (B, 16114 el, FIVE discipline buildings — the KUL070 shape).
+//
+// PHASE 1  Open A, Open→Merge B                → no navigation, centres 1→6, arithmetic, both rendered
+// PHASE 2  Open→Merge the SAME B again         → INSERT OR IGNORE dedup: added=0, totals unchanged
+// PHASE 3  Open→Esc (New)                      → today's replace/navigate path still intact
+//
+// §-log first — READ tests/witness_scene_merge_2026-07-30.log before any conclusion.
+// Run:  timeout 900 node viewer/tests/witness_scene_merge_2026-07-30.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+// Duplex/Clinic are gitignored, so they live only in the primary checkout. Serve them as a FALLBACK
+// root — never symlinked into the worktree (feedback_never_symlink_into_repo_worktree).
+const DATA_ROOT = '/home/red1/bim-ootb';
+const CLINIC = path.join(DATA_ROOT, 'buildings', 'Clinic_extracted.db');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const served = {};   // url → resolved physical path (DB-snapshot divergence is a REAL landmine here)
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  const real = (f) => { try { return fs.realpathSync(f); } catch (e) { return f; } };
+  const send = (buf, from) => {
+    try { if (/\.db$/.test(p)) served[p] = from + ' (' + (buf.length / 1048576).toFixed(1) + 'MB)'; } catch (e) {}
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  };
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (!e) return send(buf, real(path.join(ROOT, p)));
+    fs.readFile(path.join(DATA_ROOT, p), (e2, buf2) => {
+      if (e2) { res.writeHead(404); res.end('404 ' + p); return; }
+      send(buf2, real(path.join(DATA_ROOT, p)));
+    });
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+function save() { fs.writeFileSync(path.join(__dirname, 'witness_scene_merge_2026-07-30.log'), log.join('\n') + '\n'); }
+
+async function waitReady(page, secs) {
+  let ready = false;
+  for (let i = 0; i < (secs || 120) && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try {
+      ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap
+        && Object.keys(window.APP.guidMap).length > 0 && window.APP.streaming === false));
+    } catch (e) {}
+  }
+  return ready;
+}
+
+// State read straight out of the running page — the numbers, not a rendering of them.
+function snap(page) {
+  return page.evaluate(() => {
+    const A = window.APP;
+    const q = (sql) => { try { const r = A.db.exec(sql); return r.length ? r[0].values : []; } catch (e) { return []; } };
+    return {
+      href: location.href,
+      epoch: window.__mergeEpoch || null,
+      centres: Object.keys(A.buildingCentres || {}),
+      activeBuilding: A.activeBuilding,
+      rendered: Array.from(A.buildingsRendered || []),
+      guidMap: Object.keys(A.guidMap || {}).length,
+      totalElements: A.totalElements,
+      metaCount: (q('SELECT COUNT(*) FROM elements_meta')[0] || [null])[0],
+      geoCount: (q('SELECT COUNT(*) FROM component_geometries')[0] || [null])[0],
+      perBuilding: q('SELECT building, COUNT(*) FROM elements_meta GROUP BY building'),
+      // does anything list-like/card-like exist? HARD CONSTRAINT check.
+      modalHtml: (document.getElementById('merge-modal') || { innerHTML: '' }).innerHTML.length,
+      modalSelects: document.querySelectorAll('#merge-modal select, #merge-modal .card').length,
+    };
+  });
+}
+
+// Real user path: click the Open pill's own code (A.openModelDb) → hidden <input type=file> →
+// Playwright answers the file chooser → _openDbBytes → merge modal. FSA is removed first so the
+// deterministic input branch is taken (headless Chromium cannot grant FSA user activation).
+async function openFile(page, filePath) {
+  await page.evaluate(() => { try { delete window.showOpenFilePicker; } catch (e) { window.showOpenFilePicker = undefined; } });
+  const [chooser] = await Promise.all([
+    page.waitForEvent('filechooser', { timeout: 30000 }),
+    page.evaluate(() => { window.APP.openModelDb(); }),
+  ]);
+  await chooser.setFiles(filePath);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  const browser = await chromium.launch({ args: ['--js-flags=--max-old-space-size=4096'] });
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+  page.on('pageerror', e => cons.push('PAGEERROR ' + e.message));
+  const grep = (needle) => cons.filter(l => l.indexOf(needle) >= 0);
+
+  S('── W-SCENE-MERGE — witness_scene_merge_2026-07-30 ──');
+  S('   ISSUE: does File Open still navigate the page away (destroying the scene)?');
+
+  // ══ PHASE 1 ══ Open building A, then Open→Merge building B ═══════════════════════════════════
+  S('\n── PHASE 1: Duplex loaded, then Open→Merge Clinic ──');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html?db=buildings/Duplex_extracted.db',
+    { waitUntil: 'networkidle' });
+  const readyA = await waitReady(page, 120);
+  verdict(readyA, 'building A (Duplex) loaded + streaming complete');
+  if (!readyA) {
+    S('   [served] ' + JSON.stringify(served));
+    S('   [console tail] ' + cons.slice(-30).join('\n     '));
+    S('\n❌ ABORT — A never became ready'); save(); await browser.close(); server.close(); process.exit(1);
+  }
+
+  S('     [served] ' + JSON.stringify(served, null, 0));
+  const histBefore = grep('§HIST_SESSION');
+  S('     [console] ' + (histBefore[0] || 'NO §HIST_SESSION LINE'));
+  // Plant an in-page marker. A page navigation wipes it; a merge cannot.
+  await page.evaluate(() => { window.__mergeEpoch = 'E' + Date.now(); });
+  const before = await snap(page);
+  S('     [state] before: centres=' + JSON.stringify(before.centres) + ' meta=' + before.metaCount +
+    ' geo=' + before.geoCount + ' guidMap=' + before.guidMap + ' epoch=' + before.epoch);
+
+  cons.length = 0;
+  await openFile(page, CLINIC);
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  const promptLine = grep('§MERGE_PROMPT')[0];
+  verdict(!!promptLine, 'merge prompt shown instead of navigating', promptLine || 'no §MERGE_PROMPT');
+  const modalTxt = await page.textContent('#merge-target').catch(() => '');
+  verdict(/Merge "Clinic_extracted\.db" into "Ifc2x3_Duplex_Federated"/.test(modalTxt),
+    'prompt names the incoming file and the live target', 'text=' + JSON.stringify(modalTxt));
+  const modalShape = await page.evaluate(() => ({
+    selects: document.querySelectorAll('#merge-modal select').length,
+    cards: document.querySelectorAll('#merge-modal .card, #merge-modal [data-open]').length,
+    buttons: Array.from(document.querySelectorAll('#merge-modal button')).map(b => b.id),
+  }));
+  verdict(modalShape.selects === 0 && modalShape.cards === 0,
+    'HARD CONSTRAINT: no card / no list / no target dropdown in the prompt', JSON.stringify(modalShape));
+
+  await page.click('#merge-btn');
+  // wait for §MERGE_DONE, then for every merged building to finish streaming
+  let mergeDone = null;
+  for (let i = 0; i < 240 && !mergeDone; i++) { await page.waitForTimeout(1000); mergeDone = grep('§MERGE_DONE')[0]; }
+  S('     [console] ' + (grep('§MERGE_START')[0] || 'no §MERGE_START'));
+  S('     [console] ' + (grep('§MERGE_TABLES')[0] || 'no §MERGE_TABLES'));
+  grep('§MERGE_FAIL').concat(grep('§MERGE_READ_FAIL')).forEach(l => S('     [console] ' + l));
+  verdict(!!mergeDone, '§MERGE_DONE emitted', mergeDone || 'never');
+  verdict(!grep('§MERGE_FAIL').length && !grep('§MERGE_READ_FAIL').length,
+    'no §MERGE_FAIL / §MERGE_READ_FAIL', 'fails=' + (grep('§MERGE_FAIL').length + grep('§MERGE_READ_FAIL').length));
+  if (!mergeDone) { S('\n❌ ABORT — merge never completed'); S('   last console: ' + cons.slice(-25).join('\n     ')); save(); await browser.close(); server.close(); process.exit(1); }
+
+  let settled = false;
+  for (let i = 0; i < 420 && !settled; i++) {
+    await page.waitForTimeout(1000);
+    settled = await page.evaluate(() => !!(window.APP && window.APP.streaming === false
+      && (!window.APP._mergePending || window.APP._mergePending.length === 0)
+      && Array.from(window.APP.buildingsRendered || []).length >= 6));
+  }
+  const after = await snap(page);
+  verdict(settled, 'all merged buildings finished streaming', 'rendered=' + JSON.stringify(after.rendered));
+
+  // ── CLAIM 1 (the important one): NO PAGE NAVIGATION ──
+  const histAfter = grep('§HIST_SESSION');
+  const histAll = log.length && histBefore.length ? histBefore.concat(histAfter) : histAfter;
+  verdict(after.epoch === before.epoch && after.epoch !== null,
+    'CLAIM 1a: in-page epoch marker survived → the page was never navigated',
+    'before=' + before.epoch + ' after=' + after.epoch);
+  // The DOCUMENT url (origin+path+search) is what a navigation changes; the #hash is the viewer's own
+  // live "last streamed building / camera" bookmark and is EXPECTED to move — its move to a Clinic
+  // building is itself evidence the merged package streamed into this same document.
+  const doc = (u) => u.split('#')[0];
+  verdict(doc(after.href) === doc(before.href), 'CLAIM 1b: document URL (origin+path+search) unchanged', doc(after.href));
+  verdict(/#bld=Clinic_/.test(after.href), 'CLAIM 1b2: and the live hash now bookmarks a merged Clinic building in the SAME document', after.href.split('#')[1]);
+  verdict(histAfter.length === 0,
+    'CLAIM 1c: §HIST_SESSION did NOT fire a second time (a reload mints a new id)',
+    'post-merge §HIST_SESSION lines=' + histAfter.length + (histAfter[0] ? (' → ' + histAfter[0]) : ''));
+  const sid = await page.evaluate(() => { try { return sessionStorage.getItem('bim.sess.buildings_Duplex_extracted.db'); } catch (e) { return null; } });
+  S('     [state] session id in sessionStorage (still keyed on the ORIGINAL ?db) = ' + sid);
+  verdict(!!sid && (histBefore[0] || '').indexOf('id=' + sid) >= 0,
+    'CLAIM 1d: the live session id is still the one §HIST_SESSION logged at first load', 'sid=' + sid);
+
+  // ── CLAIM 2: centres grew ──
+  const centresLine = grep('§MERGE_CENTRES')[0];
+  S('     [console] ' + centresLine);
+  verdict(after.centres.length > before.centres.length && after.centres.length === 6,
+    'CLAIM 2: A.buildingCentres has 6 keys (1 Duplex + 5 Clinic discipline buildings), not 1',
+    'before=' + before.centres.length + ' after=' + after.centres.length + ' ' + JSON.stringify(after.centres));
+  verdict(after.centres.indexOf(before.centres[0]) >= 0,
+    'CLAIM 2b: building A is still present (merge ADDED, did not replace)', before.centres[0]);
+
+  // ── CLAIM 3: element arithmetic = A + B − shared GUIDs ──
+  const metaRow = grep('§MERGE_ROWS table=elements_meta')[0];
+  S('     [console] ' + metaRow);
+  const m = /src=(\d+) before=(\d+) after=(\d+) added=(\d+) dup=(\d+)/.exec(metaRow || '');
+  if (m) {
+    const src = +m[1], b4 = +m[2], aft = +m[3], added = +m[4], dup = +m[5];
+    verdict(b4 === before.metaCount, 'CLAIM 3a: merge started from A\'s real row count', b4 + ' === ' + before.metaCount);
+    verdict(aft === b4 + src - dup, 'CLAIM 3b: after = A + B − sharedGUIDs', aft + ' === ' + b4 + ' + ' + src + ' − ' + dup);
+    verdict(aft === after.metaCount, 'CLAIM 3c: the live DB agrees', aft + ' === ' + after.metaCount);
+    verdict(added === src, 'CLAIM 3d: Duplex∩Clinic GUID overlap is 0 (verified offline via ATTACH) so all B rows landed', 'added=' + added + ' src=' + src);
+  } else { verdict(false, 'CLAIM 3: §MERGE_ROWS elements_meta parseable', metaRow || 'missing'); }
+  const geoRow = grep('§MERGE_ROWS table=component_geometries')[0];
+  S('     [console] ' + geoRow);
+  const g = /src=(\d+) before=(\d+) after=(\d+) added=(\d+) dup=(\d+) errs=(\d+) cols=(\d+)\/src(\d+)\/dst(\d+)/.exec(geoRow || '');
+  verdict(!!g && +g[5] === 4, 'CLAIM 3e: geometry dedup fired on the 4 hashes the two DBs really share (offline ATTACH of the two served files: 4)', geoRow ? ('dup=' + g[5]) : 'missing');
+  verdict(!!g && +g[6] === 0 && +g[7] === 4 && +g[8] === 4 && +g[9] === 4,
+    'CLAIM 3f: zero insert errors; these two files happen to agree on 4 columns (the real `normals` mismatch is PHASE 1b)',
+    geoRow ? ('inserted=' + g[7] + ' src=' + g[8] + ' dst=' + g[9] + ' errs=' + g[6]) : 'missing');
+  // Every streamable element of BOTH buildings must actually reach the GPU path.
+  const normState = await page.evaluate(() => ({ hasNormals: window.APP._libHasNormals, streamed: window.APP.streamedCount,
+    libCols: (() => { try { return window.APP.libDb.exec('PRAGMA table_info("component_geometries")')[0].values.map(v => v[1]); } catch (e) { return 'ERR'; } })() }));
+  const streamable = await page.evaluate(() => {
+    const r = window.APP.db.exec("SELECT COUNT(*) FROM elements_meta m JOIN element_instances i ON m.guid=i.guid JOIN element_transforms t ON t.guid=m.guid WHERE i.geometry_hash IS NOT NULL AND m.ifc_class != 'IfcOpeningElement'");
+    return r.length ? r[0].values[0][0] : -1;
+  });
+  verdict(normState.streamed === streamable && normState.hasNormals === (normState.libCols.indexOf('normals') >= 0),
+    'CLAIM 3g: every streamable element of BOTH buildings rendered, and the once-cached A._libHasNormals still matches the live libDb schema (merge never changed the destination schema)',
+    'libHasNormals=' + normState.hasNormals + ' libCols=' + JSON.stringify(normState.libCols) +
+    ' streamedCount=' + normState.streamed + ' streamableInMergedDb=' + streamable);
+
+  // ── CLAIM 4: both buildings actually rendered, in ONE contract line ──
+  const mc = grep('§MERGE_CONTRACT');
+  const mcLast = mc[mc.length - 1];
+  S('     [console] ' + mcLast);
+  const cc = grep('§CONTRACT_CHECK');
+  S('     [console] ' + (cc[cc.length - 1] || 'no §CONTRACT_CHECK'));
+  let mcOk = false, mcDetail = 'missing';
+  if (mcLast) {
+    const j = /rendered=(\{.*?\}) centres=/.exec(mcLast);
+    if (j) {
+      try {
+        const own = JSON.parse(j[1]);
+        const dup2 = own['Ifc2x3_Duplex_Federated'] || 0;
+        const clin = Object.keys(own).filter(k => /^Clinic_/.test(k));
+        const clinTot = clin.reduce((s, k) => s + own[k], 0);
+        mcOk = dup2 > 0 && clinTot > 0 && clin.length === 5;
+        mcDetail = 'Duplex=' + dup2 + ' Clinic(' + clin.length + ' buildings)=' + clinTot;
+      } catch (e) { mcDetail = 'unparseable: ' + e.message; }
+    }
+  }
+  verdict(mcOk, 'CLAIM 4: both buildings non-zero in one §MERGE_CONTRACT (guidMap joined back to elements_meta.building)', mcDetail);
+  verdict(!grep('§CONTRACT_FAIL').length, 'CLAIM 4b: no §CONTRACT_FAIL anywhere in the merged scene', 'fails=' + grep('§CONTRACT_FAIL').length);
+  verdict(after.guidMap > before.guidMap, 'CLAIM 4c: guidMap grew (new pickable elements really registered)',
+    before.guidMap + ' → ' + after.guidMap);
+
+  // ── CLAIM 5: georef frame decision was made explicitly, not skipped silently ──
+  const gr = grep('§MERGE_GEOREF')[0];
+  S('     [console] ' + gr);
+  verdict(!!gr, 'CLAIM 5: frame decision logged (neither test DB carries georef_offset_* → mode=none is correct)', gr || 'missing');
+
+  // ══ PHASE 1b ══ the REAL schema mismatch: a 5-column source into a 4-column destination ══════
+  // /home/red1/bim-ootb/buildings/Duplex_extracted.db (14.9MB, 1119 el, component_geometries HAS a
+  // `normals` column) vs the served deploy copy the scene is holding (9.2MB, 1122 el, NO `normals`).
+  // Offline ATTACH: the 14.9MB copy is a strict GUID/hash subset (1119/1119 and 814/814 shared), so
+  // this merge must add nothing AND must not throw — an `INSERT … SELECT *` would.
+  S('\n── PHASE 1b: merge a 5-column-source DB into the 4-column live scene (schema mismatch) ──');
+  cons.length = 0;
+  await openFile(page, path.join(DATA_ROOT, 'buildings', 'Duplex_extracted.db'));
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  await page.click('#merge-btn');
+  let doneMM = null;
+  for (let i = 0; i < 180 && !doneMM; i++) { await page.waitForTimeout(1000); doneMM = grep('§MERGE_DONE')[0]; }
+  verdict(!!doneMM, 'mismatch merge completed', doneMM || 'never');
+  const mmGeo = grep('§MERGE_ROWS table=component_geometries')[0];
+  S('     [console] ' + mmGeo);
+  S('     [console] ' + (grep('§MERGE_ROWS table=elements_meta')[0] || 'missing'));
+  const mm = /src=(\d+) before=(\d+) after=(\d+) added=(\d+) dup=(\d+) errs=(\d+) cols=(\d+)\/src(\d+)\/dst(\d+)/.exec(mmGeo || '');
+  verdict(!!mm && +mm[8] === 5 && +mm[9] === 4 && +mm[7] === 4 && +mm[6] === 0,
+    'CLAIM 8: src has 5 cols (`normals`), dst has 4 — the intersect dropped it and inserted on 4 with ZERO errors (a `SELECT *` merge throws here)',
+    mmGeo ? ('inserted=' + mm[7] + ' src=' + mm[8] + ' dst=' + mm[9] + ' errs=' + mm[6]) : 'missing');
+  verdict(!!mm && +mm[4] === 0 && +mm[5] === 814,
+    'CLAIM 8b: and all 814 geometry rows deduped away (offline ATTACH: 814/814 shared hashes)',
+    mmGeo ? ('added=' + mm[4] + ' dup=' + mm[5]) : 'missing');
+  const afterMM = await snap(page);
+  verdict(afterMM.epoch === before.epoch && afterMM.centres.length === 6,
+    'CLAIM 8c: still the same document, still 6 centres', 'epoch=' + afterMM.epoch + ' centres=' + afterMM.centres.length);
+
+  // ══ PHASE 2 ══ merge the SAME file again → INSERT OR IGNORE dedup ════════════════════════════
+  S('\n── PHASE 2: Open→Merge the SAME Clinic again (proves INSERT OR IGNORE dedup) ──');
+  cons.length = 0;
+  await openFile(page, CLINIC);
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  await page.click('#merge-btn');
+  let done2 = null;
+  for (let i = 0; i < 240 && !done2; i++) { await page.waitForTimeout(1000); done2 = grep('§MERGE_DONE')[0]; }
+  verdict(!!done2, 'second merge completed', done2 || 'never');
+  const dedupRow = grep('§MERGE_ROWS table=elements_meta')[0];
+  S('     [console] ' + dedupRow);
+  const d = /src=(\d+) before=(\d+) after=(\d+) added=(\d+) dup=(\d+)/.exec(dedupRow || '');
+  verdict(!!d && +d[4] === 0 && +d[5] === +d[1],
+    'CLAIM 6: re-merging the same DB adds 0 rows — every GUID collapsed (INSERT OR IGNORE)',
+    dedupRow ? ('added=' + d[4] + ' dup=' + d[5] + ' src=' + d[1]) : 'missing');
+  const after2 = await snap(page);
+  verdict(after2.metaCount === after.metaCount && after2.centres.length === after.centres.length,
+    'CLAIM 6b: totals and centres unchanged by the duplicate merge',
+    'meta ' + after.metaCount + '→' + after2.metaCount + ', centres ' + after.centres.length + '→' + after2.centres.length);
+  verdict(after2.epoch === before.epoch, 'CLAIM 6c: still no navigation after two merges', 'epoch=' + after2.epoch);
+
+  // ══ PHASE 3 ══ Esc = New → today's replace/navigate path unchanged ═══════════════════════════
+  S('\n── PHASE 3: Open→Esc (New) must still take the original replace/navigate path ──');
+  cons.length = 0;
+  await openFile(page, CLINIC);
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  await page.keyboard.press('Escape');
+  let navLine = null;
+  for (let i = 0; i < 90 && !navLine; i++) { await page.waitForTimeout(1000); navLine = grep('§OPEN_DB')[0]; }
+  const choiceNew = grep('§MERGE_CHOICE').find(l => l.indexOf('action=new') >= 0);
+  verdict(!!choiceNew, 'CLAIM 7: Esc resolves the prompt as "new"', choiceNew || 'missing');
+  verdict(!!navLine && navLine.indexOf('→ navigate') >= 0,
+    'CLAIM 7b: falls through to the UNCHANGED cache+navigate replace path', navLine || 'missing');
+  await page.waitForTimeout(4000);
+  const hrefNow = await page.evaluate(() => location.href).catch(() => 'nav-in-flight');
+  const epochNow = await page.evaluate(() => window.__mergeEpoch || null).catch(() => 'unreadable');
+  verdict(/db=import%3A%2F%2FClinic_extracted/.test(hrefNow) || hrefNow === 'nav-in-flight',
+    'CLAIM 7c: the browser really navigated to the import:// URL', hrefNow);
+  verdict(epochNow === null || epochNow === 'unreadable',
+    'CLAIM 7d: and THAT navigation DID wipe the in-page epoch — proving the marker used in CLAIM 1 is a real navigation detector, not a no-op',
+    'epoch after navigate=' + epochNow);
+
+  S('\n── VERDICT ──');
+  S('   ' + (fails === 0 ? '🟢 W-SCENE-MERGE PASS' : '🔴 W-SCENE-MERGE FAIL (' + fails + ' failed assertion(s))'));
+  save();
+  await page.close().catch(() => {}); await ctx.close().catch(() => {}); await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})().catch(async (e) => {
+  S('\n💥 HARNESS ERROR: ' + (e && e.stack ? e.stack : e));
+  save();
+  try { server.close(); } catch (e2) {}
+  process.exit(2);
+});

--- a/viewer/tests/witness_scene_merge_ifc_2026-07-30.js
+++ b/viewer/tests/witness_scene_merge_ifc_2026-07-30.js
@@ -1,0 +1,147 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// W-SCENE-MERGE-IFC — prompts/LANDING_MULTIMERGE_SAVEOPEN_RESURRECT.md §SM-3 step 5 / §SM-7.1
+//
+// THE ISSUE THIS TEST EXPOSES: the Open door used to accept `.db,.sqlite` ONLY, so a source IFC
+// could not be opened — let alone merged — from the Viewer at all. §SM-3 step 5 widens the SAME door
+// to `.ifc` and routes it through the EXISTING A.importMultiIFC (import.js:267), no new import path.
+// A wrong wiring here shows up as either "picker rejects the file" or "IFC parsed but nothing
+// reached the scene".
+//
+// Proves, on the real 2.3MB SampleHouse_ARC.ifc merged into a live Duplex scene:
+//   1. the widened accept list really contains .ifc (read off the live <input>, not the source)
+//   2. the pick routes to importMultiIFC → §OPEN_IFC / §MULTI_IMPORT_DONE / §OPEN_IFC_DB
+//   3. the produced DB reaches the SAME merge path (§MERGE_PROMPT → §MERGE_DONE), no navigation
+//   4. the IFC's building lands in A.buildingCentres and actually streams (§MERGE_CONTRACT > 0)
+//
+// §-log first — READ tests/witness_scene_merge_ifc_2026-07-30.log before any conclusion.
+// Run:  timeout 900 node viewer/tests/witness_scene_merge_ifc_2026-07-30.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DATA_ROOT = '/home/red1/bim-ootb';
+const IFC = path.join(DATA_ROOT, 'IFC', 'SampleHouse_ARC.ifc');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  const send = (buf) => { res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); };
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (!e) return send(buf);
+    fs.readFile(path.join(DATA_ROOT, p), (e2, buf2) => {
+      if (e2) { res.writeHead(404); res.end('404 ' + p); return; }
+      send(buf2);
+    });
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+function save() { fs.writeFileSync(path.join(__dirname, 'witness_scene_merge_ifc_2026-07-30.log'), log.join('\n') + '\n'); }
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  const browser = await chromium.launch({ args: ['--js-flags=--max-old-space-size=4096'] });
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+  page.on('pageerror', e => cons.push('PAGEERROR ' + e.message));
+  const grep = (n) => cons.filter(l => l.indexOf(n) >= 0);
+
+  S('── W-SCENE-MERGE-IFC — source IFC through the SAME Open door ──');
+  S('   ISSUE: the Open door accepted .db/.sqlite only — a source IFC could not be opened at all.');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html?db=buildings/Duplex_extracted.db',
+    { waitUntil: 'networkidle' });
+  let ready = false;
+  for (let i = 0; i < 120 && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try { ready = await page.evaluate(() => !!(window.APP && window.APP.streaming === false && Object.keys(window.APP.guidMap || {}).length > 0)); } catch (e) {}
+  }
+  verdict(ready, 'building A (Duplex) loaded + streaming complete');
+  if (!ready) { S('\n❌ ABORT — A never became ready'); save(); await browser.close(); server.close(); process.exit(1); }
+
+  await page.evaluate(() => { window.__mergeEpoch = 'E' + Date.now(); });
+  const before = await page.evaluate(() => ({ centres: Object.keys(window.APP.buildingCentres), meta: window.APP.totalElements,
+    guidMap: Object.keys(window.APP.guidMap).length, epoch: window.__mergeEpoch, href: location.href.split('#')[0] }));
+  S('     [state] before: centres=' + JSON.stringify(before.centres) + ' totalElements=' + before.meta + ' guidMap=' + before.guidMap);
+
+  cons.length = 0;
+  await page.evaluate(() => { try { delete window.showOpenFilePicker; } catch (e) { window.showOpenFilePicker = undefined; } });
+  const [chooser] = await Promise.all([
+    page.waitForEvent('filechooser', { timeout: 30000 }),
+    page.evaluate(() => { window.APP.openModelDb(); }),
+  ]);
+  // CLAIM 1 — read the widened accept list off the LIVE input element
+  const accept = await page.evaluate(() => {
+    const ins = Array.from(document.querySelectorAll('input[type=file]'));
+    const el = ins[ins.length - 1];
+    return el ? { accept: el.accept, multiple: el.multiple } : null;
+  });
+  verdict(!!accept && /\.ifc/.test(accept.accept), 'CLAIM 1: the live picker accepts .ifc (widened from .db,.sqlite)', JSON.stringify(accept));
+  await chooser.setFiles(IFC);
+
+  // CLAIM 2 — routed to the EXISTING importMultiIFC, not a new import path
+  let ifcDone = null;
+  for (let i = 0; i < 300 && !ifcDone; i++) { await page.waitForTimeout(1000); ifcDone = grep('§OPEN_IFC_DB')[0]; }
+  S('     [console] ' + (grep('§OPEN_IFC')[0] || 'no §OPEN_IFC'));
+  S('     [console] ' + (grep('§MULTI_IMPORT_START')[0] || 'no §MULTI_IMPORT_START'));
+  S('     [console] ' + (grep('§MULTI_IMPORT_DONE')[0] || 'no §MULTI_IMPORT_DONE'));
+  S('     [console] ' + (ifcDone || 'no §OPEN_IFC_DB'));
+  grep('§OPEN_IFC_FAIL').forEach(l => S('     [console] ' + l));
+  verdict(!!grep('§MULTI_IMPORT_DONE')[0], 'CLAIM 2: routed through the existing A.importMultiIFC (import.js:267)', grep('§MULTI_IMPORT_DONE')[0] || 'missing');
+  verdict(!!ifcDone, 'CLAIM 2b: importMultiIFC handed its produced DB back to the Open door', ifcDone || 'missing');
+  if (!ifcDone) { S('\n❌ ABORT — IFC never produced a DB'); S('   tail: ' + cons.slice(-25).join('\n     ')); save(); await browser.close(); server.close(); process.exit(1); }
+
+  // CLAIM 3 — same merge prompt, same merge path, no navigation
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 60000 });
+  const promptLine = grep('§MERGE_PROMPT')[0];
+  verdict(!!promptLine, 'CLAIM 3: the produced DB reaches the SAME merge prompt', promptLine || 'missing');
+  await page.click('#merge-btn');
+  let mergeDone = null;
+  for (let i = 0; i < 240 && !mergeDone; i++) { await page.waitForTimeout(1000); mergeDone = grep('§MERGE_DONE')[0]; }
+  verdict(!!mergeDone, 'CLAIM 3b: §MERGE_DONE for the IFC-derived DB', mergeDone || 'missing');
+  S('     [console] ' + (grep('§MERGE_CENTRES')[0] || 'missing'));
+  S('     [console] ' + (grep('§MERGE_ROWS table=elements_meta')[0] || 'missing'));
+
+  let settled = false;
+  for (let i = 0; i < 300 && !settled; i++) {
+    await page.waitForTimeout(1000);
+    settled = await page.evaluate(() => !!(window.APP.streaming === false && (!window.APP._mergePending || !window.APP._mergePending.length)));
+  }
+  const after = await page.evaluate(() => ({ centres: Object.keys(window.APP.buildingCentres), meta: window.APP.totalElements,
+    guidMap: Object.keys(window.APP.guidMap).length, epoch: window.__mergeEpoch, href: location.href.split('#')[0],
+    rendered: Array.from(window.APP.buildingsRendered) }));
+  verdict(after.epoch === before.epoch && after.href === before.href,
+    'CLAIM 3c: no page navigation — the epoch marker and document URL both survived', 'epoch=' + after.epoch + ' url=' + after.href);
+
+  // CLAIM 4 — the IFC's building is really in the scene
+  const mc = grep('§MERGE_CONTRACT');
+  S('     [console] ' + (mc[mc.length - 1] || 'no §MERGE_CONTRACT'));
+  const newB = after.centres.filter(c => before.centres.indexOf(c) < 0);
+  verdict(newB.length >= 1 && after.centres.length > before.centres.length,
+    'CLAIM 4: the IFC-derived building joined A.buildingCentres', 'added=' + JSON.stringify(newB) +
+    ' centres ' + before.centres.length + '→' + after.centres.length);
+  verdict(newB.every(b => after.rendered.indexOf(b) >= 0) && after.guidMap > before.guidMap,
+    'CLAIM 4b: and it actually streamed (buildingsRendered + guidMap grew)',
+    'rendered=' + JSON.stringify(after.rendered) + ' guidMap ' + before.guidMap + '→' + after.guidMap);
+  verdict(!grep('§CONTRACT_FAIL').length, 'CLAIM 4c: no §CONTRACT_FAIL', 'n=' + grep('§CONTRACT_FAIL').length);
+  const risk = grep('§OPEN_IFC_WASM_RISK');
+  S('     [info] §OPEN_IFC_WASM_RISK lines=' + risk.length + ' (expected 0 for a 2.3MB file; the §KUL009 4GB warning only fires >900MB)');
+
+  S('\n── VERDICT ──');
+  S('   ' + (fails === 0 ? '🟢 W-SCENE-MERGE-IFC PASS' : '🔴 W-SCENE-MERGE-IFC FAIL (' + fails + ')'));
+  save();
+  await page.close().catch(() => {}); await ctx.close().catch(() => {}); await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})().catch((e) => {
+  S('\n💥 HARNESS ERROR: ' + (e && e.stack ? e.stack : e));
+  save();
+  try { server.close(); } catch (e2) {}
+  process.exit(2);
+});

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -831,10 +831,10 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=54" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=55" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=58" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
@@ -880,7 +880,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="import_db_builder.js?v=2"></script>
 <script src="diff.js?v=4"></script>
 <script src="variation_order.js?v=2"></script>
-<script src="import.js?v=3"></script>
+<script src="import.js?v=4"></script>
 <script src="mep_coordination.js?v=1" onerror="console.warn('§LOAD_FAIL mep_coordination.js — MEP coordination disabled')"></script>
 <script src="real_placement_resolver.js?v=1" onerror="console.warn('§RPR LOAD_FAIL real_placement_resolver.js')"></script>
 <script src="routewalker.js?v=3" onerror="console.warn('§LOAD_FAIL routewalker.js — MEP generation disabled')"></script>


### PR DESCRIPTION
Implementing `prompts/LANDING_MULTIMERGE_SAVEOPEN_RESURRECT.md` **§SM-3 / §SM-7** (bim-compiler) — Witness: **W-SCENE-MERGE**

## The bug

`A._openDbBytes` ended in `location.assign('viewer.html?db=import://…')`. **File Open navigated the page** — the scene was destroyed and rebuilt. That, not memory and not a data limit, is why opening a second file reset the canvas.

The driving case is real: KUL070 ships as multiple IFCs and the ARCH/envelope package **arrives later, separately**. Opening it into the loaded MEP model replaced it, so the user had to re-drop every file together.

## What this does

Wiring only. Every mechanism already existed.

- **`A._showMergeModal`** — a **port** of `archive/gallery.html:1045` `showMergeModal()`: same copy, Enter = merge, Esc = new. Two forced deltas: the DOM is built here (viewer.html has none of gallery's five modal elements), and gallery's ">1 target → `<select>`" branch is dropped — a Viewer scene has exactly one active building, so there is never a list. **No card, no list, no dropdown** (the file's HARD CONSTRAINT).
- **`A._mergeDbIntoScene`** — folds the incoming DB's metadata into the **live** `A.db` and its geometry into `A.libDb` with `INSERT OR IGNORE` (the already-proven dedup, `import_db_builder.js:45`), keeps the incoming `building` names, adds **only the new** names to `A.buildingCentres`, then streams them.
- **`A._mergeStreamNext`** — sequential drain chained off the **existing** stream-complete hook, right beside City's `_cityStreamNext`. `streamBuilding()` handles ONE building; a real package has N (Clinic is five discipline buildings).
- **Frame** — the already-open building's `project_metadata.georef_offset_*` pins the frame; the incoming DB rebases into it. That is `import.js:299-310`'s `sessionGeorefOffset` rule applied to a live scene. `A.modelOffset` is deliberately **not** recomputed: building A's meshes are already placed against it.
- **Replace** — byte-for-byte today's cache+navigate path, reached by Esc / New.
- **Open source IFC in the same door** — `accept` widened to `.ifc`, routed to the **existing** `A.importMultiIFC`, which now returns its produced DB (additive; every prior caller ignored the return value), fed into the same merge.

### Why not City mode's `A.db` swap
City mode swaps `A.db` because its `A.db` **is** the city index — one metadata DB already holding every building, with only geometry per-archetype. Swapping `A.db` to B's DB in a single scene would make A un-queryable, and `§CONTRACT_CHECK`, panels, rooms and tour would all lose building A. Folding into one DB is the faithful analogue.

## Two landmines, both hit for real while building this

1. **sql.js `exec` returns only statements that produced ROWS**, so `SELECT * … LIMIT 0` yields `[]` and **not** a column list. The first cut used that for column discovery and silently merged nothing (`§MERGE_DONE newBuildings=0` with zero `§MERGE_ROWS` lines). Now `PRAGMA table_info`, plus a hard `§MERGE_FAIL` if `elements_meta` does not fold — a silent no-op can't recur.
2. **Real DBs disagree on columns.** `Duplex.component_geometries` has a `normals` column; `Clinic`'s does not. Inserts run on the destination∩source intersection, driven by the destination, so the destination schema never changes — which is also what keeps the once-probed, cached `A._libHasNormals` (`streaming.js:868`) honest after a merge.

## Witnesses

**W-SCENE-MERGE** — `viewer/tests/witness_scene_merge_2026-07-30.js`, **24/24 green, exit 0**. Real browser, real DBs, real Open-pill path (`filechooser` → hidden input → `_openDbBytes` → modal → `#merge-btn`). Duplex (A) then Clinic (B):

```
§MERGE_CENTRES before=1 after=6 added=["Clinic_Architectural_IFC2x3","Clinic_Electrical_IFC2x3",
                                       "Clinic_HVAC_IFC2x3","Clinic_Plumbing_IFC2x3","Clinic_Structural_IFC2x3"]
§MERGE_ROWS table=elements_meta        src=16114 before=1122 after=17236 added=16114 dup=0 errs=0 cols=8/src8/dst8
§MERGE_ROWS table=component_geometries src=8461  before=814  after=9271  added=8457  dup=4 errs=0 cols=4/src4/dst4
§MERGE_CONTRACT buildings=6 rendered={"Ifc2x3_Duplex_Federated":1119,"Clinic_Architectural_IFC2x3":2586,
  "Clinic_Electrical_IFC2x3":2118,"Clinic_HVAC_IFC2x3":3704,"Clinic_Plumbing_IFC2x3":6585,"Clinic_Structural_IFC2x3":1078}
§CONTRACT_CHECK batch=10231 instanced=6959 guidMap=17190 streamed=17190 orphans=0
```

- **no page navigation** — the in-page epoch marker and the document URL both survive, and `§HIST_SESSION` never fires a second time (the live `sessionStorage` id is still the one logged at first load). The same marker **is** wiped by the Esc/replace navigation in PHASE 3, which proves the detector is real and not a no-op.
- **arithmetic** — `after = A + B − sharedGUIDs` (17236 = 1122 + 16114 − 0); the 0 overlap and the 4 shared geometry hashes were both verified offline with `ATTACH` against the two served files.
- **dedup** — re-merging the same DB: `added=0 dup=16114`, totals and centres unchanged.
- **schema mismatch** — a 5-column source into the 4-column destination: `inserted=4 src=5 dst=4 errs=0`.
- **replace path intact** — Esc → `§MERGE_CHOICE action=new` → `§OPEN_DB … → navigate` → the browser really lands on the `import://` URL.

**W-SCENE-MERGE-IFC** — `viewer/tests/witness_scene_merge_ifc_2026-07-30.js`, **12/12 green, exit 0**. `SampleHouse_ARC.ifc` into a live Duplex scene: `accept=".db,.sqlite,.ifc"` read off the live `<input>`, `§MULTI_IMPORT_DONE` → `§OPEN_IFC_DB` → `§MERGE_CENTRES before=1 after=2` → `§MERGE_CONTRACT {Duplex:1119, SampleHouse_ARC:58}`, no navigation.

No screenshots anywhere — every claim is a `§` log value or a number read programmatically out of the running page, per the project's FUNDAMENTAL LAW.

## Deploy visibility

`viewer/sw.js` `CACHE_VERSION` v884 → **v885**; `scene.js?v=55`, `streaming.js?v=59`, `import.js?v=4`. Without these the edit is invisible and looks like a code failure (§KUL008_CACHE).

`tests/audit_script_tags.js`, `audit_sw_precache.js`, `audit_spec_paths.js` all exit 0. `audit_specs.js` fails on a **pre-existing** violation in `tests/specs/38-sh-dx-2d-runtime.spec.js` (5 SKIP paths) — byte-identical to `origin/main`, untouched here.

## Deliberately out of scope
Version/variant switching (§SM-5) — a separate feature needing its own decision. N-way memory headroom is named in §SM-5 and still unmeasured for two 300MB-class DBs in one tab; this PR does not promise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CynFYMxZJKiNqgf795CtK
