### PR TITLE
fix(modeller): Walk-ALL tooltip + proxy-mode toast + §SEL-TINT-REFOLD

### DIFF
--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -280,6 +280,12 @@
       const st = d.stats ? ' regen[rebuilt=' + d.stats.rebuilt + ' hits=' + d.stats.hits + ' tess=' + d.stats.tess + ' tessHits=' + d.stats.tessHits + ']' : '';
       console.log(TAG + ' chain ops=' + ops.length + ' solids=' + meshes.length + ' tris=' + totalTris + ' ms=' + Math.round(ms) + ' inScene=' + !!g + st);
       if (window.A && typeof A.requestRender === 'function') A.requestRender();
+      // §SEL-TINT-REFOLD (MODELLER_MASTER.md row 16 — Witness: W-E2E-SEL-TINT-REFOLD): every authoritative
+      // re-fold lands HERE with its rebuilt meshes already in the group — announce it so selection paint
+      // (modeller.html _paintSel) can re-apply the emissive tint to the NEW mesh objects (same featureIds).
+      // Needed because bonsai_oplog.scrubTo (history slider undo/redo, x-ray restore, Connect timeline)
+      // deliberately never _emit()s — the existing bonsai:oplog → _paintSel hook cannot fire on those paths.
+      try { window.dispatchEvent(new CustomEvent('bonsai:refold', { detail: { solids: meshes.length } })); } catch (e) { }
       return { solids: meshes.length, triangleCount: totalTris, meshes };
     },
 

--- a/modeller/bonsai_outliner.js
+++ b/modeller/bonsai_outliner.js
@@ -599,7 +599,9 @@
         const active = window.Bonsai._selId === n.id;      // adjacency-lens degree badge below reads this
         const pad = 16 + depth * 14;
         // W-UX-4: a DISCIPLINE node (n.disc) is a WALKER entry point — render a ▶ walk affordance + carry data-disc.
-        const walkGlyph = n.disc ? ' <span class="bn-walk" title="Walk this discipline" style="color:#4fc3f7">▶</span>' : '';
+        // MODELLER_MASTER.md row 17: the synthetic disc:'__ALL__' row (modeller.html §DISCWALK-ALL) walks EVERY
+        // discipline — its tooltip must say so; ordinary disc rows keep the singular.
+        const walkGlyph = n.disc ? ' <span class="bn-walk" title="' + (n.disc === '__ALL__' ? 'Walk ALL disciplines' : 'Walk this discipline') + '" style="color:#4fc3f7">▶</span>' : '';
         // W-UX-6: adjacency lens — a NEIGHBOUR of the selected element gets a per-EDGE-TYPE badge (⇄ abuts ·
         // ⌂ fills · ⧉ aggregates) + amber tint; the selected element shows its per-kind degree + its element↔
         // datum relations (⊥ anchored · ↕ spans). All read the derived map (window.swXEdges), never a baked table.

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -1054,6 +1054,13 @@ function _paintSel() {                                    // emissive: primary b
 }
 // a re-fold rebuilds meshes (new geometry uuids) — re-sync outlines onto the fresh meshes
 window.addEventListener('bonsai:oplog', () => { try { _paintSel(); } catch (e) { } });
+// §SEL-TINT-REFOLD (MODELLER_MASTER.md row 16 — Witness: W-E2E-SEL-TINT-REFOLD): the hook above never fires
+// on a scrubTo re-fold (history slider undo/redo, x-ray restore, Connect timeline) because scrubTo
+// deliberately never _emit()s — so the rebuilt mesh of a STILL-selected featureId came back with emissive
+// 000000 while _selSet still held it. foldChainToScene now announces 'bonsai:refold' after the rebuilt
+// meshes land; repaint through _paintSel — the ONE existing tinting path, membership re-resolved by
+// featureId (meshes are NEW objects after a re-fold). Idempotent + cheap on the paths bonsai:oplog covers.
+window.addEventListener('bonsai:refold', () => { try { if (selectedIds.size) console.log('§SEL-TINT-REFOLD repaint n=' + selectedIds.size); _paintSel(); } catch (e) { } });
 // ── §ZOOM-SEL (MODELLER_ZOOM_TO_SELECTION.md — Witness: W-E2E-ZOOMSEL): port of the Viewer Find panel's
 // zoom-to-frame mechanism (viewer/navigate_find.js _lerpCam/_fitDistForBox/_zoomToBoxFill — the frustum-fit
 // variant, not the naive maxDim*factor one). Fires automatically on every real selection change via
@@ -1358,6 +1365,11 @@ function _applyShadowFlags() {
 }
 window.Bonsai.setShadows = (v) => { _shadowMode = (v === 'auto') ? 'auto' : !!v; return _applyShadowFlags(); };
 window.addEventListener('bonsai:oplog', () => { try { _applyShadowFlags(); } catch (e) { } });
+// §SEL-TINT-REFOLD sibling (same root cause, found by W-E2E-CUT C6's pixel oracle, 2026-07-30): a scrubTo
+// re-fold (history slider, x-ray restore, Connect timeline) rebuilds every mesh with castShadow/receiveShadow
+// FALSE and never fires bonsai:oplog — so the scene renders subtly unshadowed until the next commit. Re-apply
+// at the same 'bonsai:refold' choke point the selection repaint uses (event from foldChainToScene).
+window.addEventListener('bonsai:refold', () => { try { _applyShadowFlags(); } catch (e) { } });
 // ── Outliner→scene camera fly-to (2026-07-02, RESUME §3): click an Outliner row → besides the existing
 // select/highlight (window.Bonsai.select → setActive), smoothly orbit the camera in CLOSER, framed on that
 // element's own bbox centre — mirrors viewer/measure.js's _flyToClash/_animFly easing pattern (ease-in-out
@@ -3855,6 +3867,11 @@ function _flashSettleDisc(disc) {
     var sceneTotal = (window.Bonsai.group && window.Bonsai.group()) ? window.Bonsai.group().children.length : 0;
     var proxyMode = sceneTotal > window.DW_ALL_PROXY_THRESHOLD;
     if (proxyMode) {
+      // MODELLER_MASTER.md row 18: the batch-hold downgrade was §-log-only — surface it to the USER once per
+      // walk run via the existing toast (W-BONSAI-TOAST). Guarded by the run-scoped flag discWalkAll resets,
+      // so a run that only ENTERS proxyMode mid-walk (the scene grows as each disc commits) still says it
+      // exactly once. Geometry is identical either way; only the reveal animation is simplified.
+      if (!window.__dwProxyToasted) { window.__dwProxyToasted = true; if (window.toast) toast('Large scene — reveal animation simplified; final geometry unchanged', 'ok'); }
       var HOLD = 150;   // batch hold+settle only — no per-instance stagger above the threshold
       setTimeout(function () {
         idx.forEach(function (e) { e.im.setColorAt(e.i, e.base); });
@@ -3901,6 +3918,11 @@ window.discWalkAll = async function (ctx) {
   var sceneTotal = (window.Bonsai.group && window.Bonsai.group()) ? window.Bonsai.group().children.length : 0;
   var proxyMode = sceneTotal > window.DW_ALL_PROXY_THRESHOLD;
   console.log('§DISCWALK-ALL start disciplines=[' + ds.join(',') + '] n=' + ds.length + ' sceneElements=' + sceneTotal + ' threshold=' + window.DW_ALL_PROXY_THRESHOLD + ' proxyMode=' + proxyMode);
+  // MODELLER_MASTER.md row 18: reset the once-per-run proxy toast flag; if the RUN already starts in
+  // proxyMode, say it up front (the per-disc flash branch in _flashSettleDisc covers a mid-run entry).
+  // The §DISCWALK-ALL log line above stays unchanged.
+  window.__dwProxyToasted = false;
+  if (proxyMode) { window.__dwProxyToasted = true; if (window.toast) toast('Large scene — reveal animation simplified; final geometry unchanged', 'ok'); }
   setStat('Walk ALL — x-ray on, walking ' + ds.length + ' disciplines…');
   var xr = await xrayReveal(true);
   console.log('§DISCWALK-ALL xray-on glass=' + xr.glass + ' glow=' + xr.glow + ' t=' + (Date.now() - t0) + 'ms');

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v38';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v39';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/e2e_harness.js
+++ b/modeller/tests/e2e_harness.js
@@ -134,11 +134,46 @@ async function runE2E(NAME, body, opts) {
             return null;
           }
           , bboxScreen(fid) { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid); if (!m) return null; const b = new window.THREE.Box3().setFromObject(m); if (!isFinite(b.min.x)) return null; let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity; for (let i = 0; i < 8; i++) { const x = (i & 1) ? b.max.x : b.min.x, y = (i & 2) ? b.max.y : b.min.y, z = (i & 4) ? b.max.z : b.min.z; const p = this.proj(x, y, z); if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0]; if (p[1] < minY) minY = p[1]; if (p[1] > maxY) maxY = p[1]; } return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }; }
+          // Anti-flake (2026-07-30, found chasing W-E2E-CUT/W-E2E-SEL-TINT-REFOLD pick()=null runs): clicking a
+          // candidate's projected BBOX CENTRE is a lottery — a low wall's centre is routinely occluded by an
+          // upper-storey mesh, so whether the click lands depends on sub-pixel camera state that varies run to
+          // run. Return a VERIFIED click point instead: sample the mesh's own triangle centroids, project each,
+          // and keep the first whose raycast FIRST HIT (same raycast the app's pick uses) is this very mesh.
+          // Deterministic given the camera; null = genuinely not visible from here (caller skips the candidate).
+          , clickPointFor(fid) {
+            const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid); if (!m) return null;
+            const cam = window.A.camera, rc = new window.THREE.Raycaster();
+            const meshes = g.children.filter(o => o.isMesh);
+            const cv = window.A.renderer.domElement, r = cv.getBoundingClientRect();
+            m.updateMatrixWorld();
+            const pos = m.geometry.attributes.position, idx = m.geometry.index;
+            const triN = idx ? idx.count / 3 : pos.count / 3;
+            const samples = Math.min(triN, 60), p = new window.THREE.Vector3();
+            for (let s = 0; s < samples; s++) {
+              const ti = Math.floor(s * triN / samples);
+              const a = idx ? idx.getX(ti * 3) : ti * 3, b = idx ? idx.getX(ti * 3 + 1) : ti * 3 + 1, c = idx ? idx.getX(ti * 3 + 2) : ti * 3 + 2;
+              p.set((pos.getX(a) + pos.getX(b) + pos.getX(c)) / 3, (pos.getY(a) + pos.getY(b) + pos.getY(c)) / 3, (pos.getZ(a) + pos.getZ(b) + pos.getZ(c)) / 3).applyMatrix4(m.matrixWorld);
+              const sp = this.proj(p.x, p.y, p.z);
+              if (sp[0] < r.left + 8 || sp[0] > r.right - 8 || sp[1] < r.top + 8 || sp[1] > r.bottom - 8 || sp[2] > 1) continue;
+              rc.setFromCamera(new window.THREE.Vector2(((sp[0] - r.left) / r.width) * 2 - 1, -(((sp[1] - r.top) / r.height) * 2 - 1)), cam);
+              const hits = rc.intersectObjects(meshes, false);
+              if (hits.length && hits[0].object === m) return [sp[0], sp[1]];
+            }
+            return null;
+          }
         }; return true;
       });
     },
     proj(x, y, z) { return pg.evaluate((a, b, c) => window.__e2e.proj(a, b, c), x, y, z); },
     centre(fid) { return pg.evaluate(f => window.__e2e.centre(f), fid); },
+    // real mouse click ON the mesh with this featureId, at a raycast-verified point (anti-flake — see
+    // __e2e.clickPointFor); falls back to the projected bbox centre if no verified point is visible.
+    async clickOn(fid) {
+      let pt = await pg.evaluate(f => window.__e2e.clickPointFor(f), fid);
+      if (!pt) { const c = await this.centre(fid); if (!c) return false; pt = await this.proj(c[0], c[1], c[2]); }
+      await pg.mouse.click(pt[0], pt[1]); await sleep(250);
+      return true;
+    },
     pixsum() { return pg.evaluate(() => window.__e2e.pixsum()); },
     async bboxScreen(fid) { return pg.evaluate(f => window.__e2e.bboxScreen(f), fid); },
     // §F2-FRAMING: fly the camera to a real element close-up (spec G4 "element close-up") — use BEFORE
@@ -195,9 +230,25 @@ async function runE2E(NAME, body, opts) {
     // require the click to have selected THAT candidate (the old code returned whatever got selected).
     async pick(opts) {
       opts = opts || {};
-      let cands = await pg.evaluate(() => window.__e2e.candidates());
+      const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
+      // opts.cuttable (W-E2E-CUT / W-E2E-SEL-TINT-REFOLD subject guard, 2026-07-30): keep only candidates the
+      // PRODUCTION cut gate itself accepts — a rotated/non-box ARC insert is HONESTLY refused by bCut
+      // (Bonsai._insertCutBox returns null), so a cut witness that picks one measures the refusal path, not
+      // the cut. Duplex's biggest wallish candidates are now rotated (openings-inherit-host-rotation data),
+      // which is exactly how witness_e2e_cut went red with no cut regression. Eligibility is asked OF the
+      // production gate (reused, not re-implemented); a non-GEOM_INSERT solid is worker-cuttable natively.
+      const filterCuttable = async (list) => {
+        if (!opts.cuttable) return list;
+        const ok = await pg.evaluate(fids => {
+          const ops = window.Bonsai.oplog._geomOps(); const byId = new Map(ops.map(o => [o.id, o]));
+          const out = {};
+          fids.forEach(f => { const op = byId.get(f); if (!op) { out[f] = false; return; } if (op.op_type !== 'GEOM_INSERT') { out[f] = true; return; } let b = null; try { b = window.Bonsai._insertCutBox(op); } catch (e) { } out[f] = !!(b && b.c1); });
+          return out;
+        }, list.map(c => c.fid));
+        return list.filter(c => ok[c.fid]);
+      };
+      let cands = await filterCuttable(await pg.evaluate(() => window.__e2e.candidates()));
       if (opts.prefer === 'wall') {
-        const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
         cands = cands.filter(wallish).concat(cands.filter(c => !wallish(c)));
       }
       // §ZOOM-SEL: every selection now auto-flies the camera (modeller.html zoomToSelection). A real user
@@ -205,9 +256,14 @@ async function runE2E(NAME, body, opts) {
       // otherwise every coordinate a witness computes right after pick() is stale mid-flight. On a wrong-fid
       // hit the fly also moved the camera, so the remaining precomputed candidate coords are stale too:
       // refetch them and restart the scan.
-      const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
       for (let attempt = 0; attempt < 2; attempt++) {
-        for (const c of cands) { await pg.mouse.move(c.sx, c.sy); await sleep(40); await pg.mouse.click(c.sx, c.sy); await sleep(120);
+        for (const c of cands) {
+          // Anti-flake: click a raycast-VERIFIED point on the candidate itself (see __e2e.clickPointFor),
+          // not its bbox centre — a centre occluded by an upper storey made pick() return null run-to-run.
+          const pt = await pg.evaluate(f => window.__e2e.clickPointFor(f), c.fid);
+          if (!pt && opts.prefer) continue;   // candidate genuinely not visible from this camera → next
+          const cx = pt ? pt[0] : c.sx, cy = pt ? pt[1] : c.sy;
+          await pg.mouse.move(cx, cy); await sleep(40); await pg.mouse.click(cx, cy); await sleep(120);
           const sel = await pg.evaluate(() => Array.from(window.Bonsai._selSet || []));
           if (sel.length === 1 && (!opts.prefer || sel[0] === c.fid)) { await this.flySettle(); return { fid: sel[0], centre: await this.centre(sel[0]) }; }
           if (sel.length) {
@@ -220,7 +276,7 @@ async function runE2E(NAME, body, opts) {
             const fit = await pg.$('#b-fit'); if (fit) { await fit.click(); await sleep(600); }
           }
         }
-        cands = await pg.evaluate(() => window.__e2e.candidates());
+        cands = await filterCuttable(await pg.evaluate(() => window.__e2e.candidates()));
         if (opts.prefer === 'wall') cands = cands.filter(wallish).concat(cands.filter(c => !wallish(c)));
       }
       return null;

--- a/modeller/tests/witness_e2e_cut.js
+++ b/modeller/tests/witness_e2e_cut.js
@@ -23,7 +23,11 @@ const { runE2E } = require('./e2e_harness');
 runE2E('W-E2E-CUT', async (t) => {
   await t.open('Duplex');
   await t.shot('01-open');
-  const sel = await t.pick({ prefer: 'wall' });   // §F2-FRAMING: the guide caption says "the wall" — don't grab the biggest slab
+  // §F2-FRAMING: the guide caption says "the wall" — don't grab the biggest slab. cuttable (2026-07-30):
+  // Duplex's front-ranked wallish candidates are now ROTATED inserts (openings-inherit-host-rotation data);
+  // bCut honestly refuses those ("cut needs a box-shaped wall"), so the subject must be one the production
+  // gate (Bonsai._insertCutBox) accepts — otherwise this witness measures the refusal path, not the cut.
+  const sel = await t.pick({ prefer: 'wall', cuttable: true });
   t.assert('C1 SELECT (real click selects element)', !!sel, 'fid=' + (sel && sel.fid));
   if (!sel) return;
   await t.frameElement(sel.fid, 0.42);            // §F2-FRAMING: real close-up BEFORE any pixsum baseline (camera then stays fixed)
@@ -40,15 +44,17 @@ runE2E('W-E2E-CUT', async (t) => {
   t.assert('C4 VISIBLE (framebuffer changed)', pix0 !== pix1, 'pix ' + pix0 + '→' + pix1);
   await t.undoToCursor(before.cur);
   const undo = await t.oplog();
-  // §SEL-TINT-REFOLD (found by this witness's wall subject, PROBE-CUT-FULL): an authoritative re-fold
-  // (the cut, the undo) rebuilds the selected mesh WITHOUT its selection emissive (2b5a8c → 000000) even
-  // though the selection logically persists — so a raw pix compare here would measure lost selection TINT,
-  // not geometry. C6's claim is GEOMETRY reversibility: re-select the same wall with a real click (the tint
-  // re-applies deterministically), THEN compare frames. The tint-loss itself is a separate app-level UX nit,
-  // documented in the resume card — this witness proved the wall's tris/colour/centre restore exactly.
+  // C6 re-select, MEASURED PRECISION (2026-07-30, §SEL-TINT-REFOLD fix session): the old comment here blamed
+  // lost selection TINT — wrong attribution. bCut.onclick ends in an explicit highlight(null) (deselect by
+  // design), so pix0's selection visuals (emissive + §V5 outline) are legitimately absent post-undo; the
+  // re-click restores SELECTION STATE, and the tint on the rebuilt mesh is now guaranteed by §SEL-TINT-REFOLD
+  // (foldChainToScene → 'bonsai:refold' → _paintSel; Witness: W-E2E-SEL-TINT-REFOLD). What HAD broken C6
+  // since §ZOOM-SEL landed: the re-click auto-flies the camera, so the frames could never match again.
+  // Settle the fly, then re-frame with the SAME deterministic frameElement(fid, 0.42) that produced pix0's
+  // camera (same bbox, same view dir = ZOOM_ISO_DIR after either fly) — identical camera, honest compare.
   {
-    const wp = await t.proj(sel.centre[0], sel.centre[1], sel.centre[2]);
-    await t.pg.mouse.click(wp[0], wp[1]); await t.sleep(250);
+    await t.clickOn(sel.fid); await t.flySettle();
+    await t.frameElement(sel.fid, 0.42);
   }
   const pix2 = await t.pixsum();
   await t.shot('04-undone');

--- a/modeller/tests/witness_e2e_sel_tint_refold.js
+++ b/modeller/tests/witness_e2e_sel_tint_refold.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-SEL-TINT-REFOLD scope (read this block first; read the log after every run)
+ * ISSUE UNDER TEST (§SEL-TINT-REFOLD — MODELLER_MASTER.md OPEN row 16, first documented as an unfixed UX
+ * nit in witness_e2e_cut.js C6): an AUTHORITATIVE RE-FOLD rebuilds every mesh FRESH, and the rebuilt mesh
+ * for a STILL-SELECTED featureId comes back WITHOUT its selection emissive (2b5a8c → 000000) even though
+ * window.Bonsai._selSet still logically holds it.
+ *
+ * MEASURED PRECISION (2026-07-30, this witness's own RED runs): the cut path itself is NOT a repro today —
+ * bCut.onclick ends in an explicit `highlight(null)` (deselect by design, predates the nit note), so after
+ * a cut the set is EMPTY and 000000 is correct. The genuine repro is every re-fold that does NOT `_emit()`
+ * — bonsai_oplog.scrubTo (the real #hist-slider = undo/redo scrub, x-ray restore, Connect timeline) — where
+ * nothing clears the selection and nothing repaints it either (the bonsai:oplog → _paintSel hook never
+ * fires because scrubTo deliberately never emits).
+ *
+ * PROOF PROTOCOL: RED first on unmodified main (proving it catches the bug), then GREEN with the fix
+ * (foldChainToScene announces 'bonsai:refold' after the rebuilt meshes land → modeller.html re-runs
+ * _paintSel, the ONE existing tinting path, membership re-resolved by featureId).
+ *
+ * CLAIMS (all maths off the live scene graph + _selSet — no screenshots as evidence):
+ *   T1 SELECT-TINT       — a real click selects a cut-eligible wall, primary emissive 0x2b5a8c.
+ *   T2 CUT+RESELECT-TINT — cut commits (authoritative re-fold; cut deselects by design), a real re-click
+ *                          re-selects the SAME featureId on its REBUILT mesh (new uuid) and tints it.
+ *   T3 TINT-AFTER-UNDO   — undo via the real #hist-slider (scrubTo re-fold, the no-_emit path) with the
+ *                          selection LIVE: _selSet still holds the fid, the again-rebuilt mesh (new uuid)
+ *                          must carry 2b5a8c. THE BUG: it comes back 000000.
+ *   T4 TINT-AFTER-REDO   — slider forward to the post-cut cursor (same no-_emit re-fold, other direction):
+ *                          membership persisted, rebuilt mesh must carry 2b5a8c.
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+runE2E('W-E2E-SEL-TINT-REFOLD', async (t) => {
+  const probe = (fid) => t.pg.evaluate(f => {
+    const g = window.Bonsai.group();
+    const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+    return {
+      uuid: m ? m.uuid : null,
+      emissive: (m && m.material && m.material.emissive) ? m.material.emissive.getHexString() : null,
+      inSel: !!(window.Bonsai._selSet && window.Bonsai._selSet.has(f)),
+      selN: window.Bonsai._selSet ? window.Bonsai._selSet.size : 0
+    };
+  }, fid);
+  const reclick = async (fid) => {   // real mouse re-click on the mesh (raycast-verified point, production select path)
+    const ok = await t.clickOn(fid); await t.flySettle();
+    return ok;
+  };
+
+  await t.open('Duplex');
+  // subject must be cut-ELIGIBLE (see e2e_harness pick opts.cuttable). pick() marches real clicks and can
+  // exhaust its 2 passes on headless-swiftshader timing flake — re-Fit and retry up to 3 times.
+  let sel = null;
+  for (let i = 0; i < 3 && !sel; i++) {
+    sel = await t.pick({ prefer: 'wall', cuttable: true });
+    if (!sel) { const fit = await t.pg.$('#b-fit'); if (fit) { await fit.click(); await t.sleep(600); } }
+  }
+  t.assert('T0 SELECT (real click selects a cut-eligible wall)', !!sel, 'fid=' + (sel && sel.fid));
+  if (!sel) return;
+
+  const p0 = await probe(sel.fid);
+  console.log('  §SEL-TINT stage=selected ' + JSON.stringify(p0));
+  t.assert('T1 SELECT-TINT (primary emissive 2b5a8c on select)', p0.inSel && p0.emissive === '2b5a8c', 'emissive=' + p0.emissive + ' inSel=' + p0.inSel);
+
+  const before = await t.oplog();
+  await t.clickSel('#b-cut'); await t.sleep(900);
+  const after = await t.oplog(); const last = await t.lastOp();
+  t.assert('T2a CUT-COMMIT (one GEOM_CUT parented to the selection)', after.len === before.len + 1 && last && last.op_type === 'GEOM_CUT' && last.parameters && last.parameters.parent === sel.fid, 'len ' + before.len + '→' + after.len + ' op=' + (last && last.op_type));
+
+  // cut DESELECTS by design (bCut.onclick → highlight(null)) — re-select the same wall with a real click,
+  // exactly the flow a user takes before scrubbing history with the element still selected.
+  await reclick(sel.fid);
+  const p1 = await probe(sel.fid);
+  console.log('  §SEL-TINT stage=post-cut-reselect ' + JSON.stringify(p1) + ' (pre-cut uuid=' + p0.uuid + ')');
+  t.assert('T2 CUT+RESELECT-TINT (rebuilt mesh — new uuid — selected + tinted)', p1.uuid !== null && p1.uuid !== p0.uuid && p1.inSel && p1.emissive === '2b5a8c', 'uuid ' + p0.uuid + '→' + p1.uuid + ' inSel=' + p1.inSel + ' emissive=' + p1.emissive);
+
+  // THE ISSUE: slider undo → scrubToShared → oplog.scrubTo → foldChainToScene, and scrubTo NEVER _emit()s —
+  // nothing deselects, nothing repaints. Selection must survive the re-fold WITH its tint.
+  await t.undoToCursor(before.cur);
+  const undo = await t.oplog();
+  t.assert('T3a UNDO (slider restored the pre-cut cursor)', undo.cur === before.cur, 'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ')');
+  const p2 = await probe(sel.fid);
+  console.log('  §SEL-TINT stage=post-undo ' + JSON.stringify(p2) + ' (post-cut uuid=' + p1.uuid + ')');
+  t.assert('T3 TINT-AFTER-UNDO (scrub re-fold keeps membership AND repaints emissive)', p2.uuid !== null && p2.uuid !== p1.uuid && p2.inSel && p2.emissive === '2b5a8c', 'uuid ' + p1.uuid + '→' + p2.uuid + ' inSel=' + p2.inSel + ' emissive=' + p2.emissive + ' (want 2b5a8c)');
+
+  // scrub FORWARD (redo direction) — same no-_emit re-fold, opposite direction.
+  await t.undoToCursor(after.cur);
+  const redo = await t.oplog();
+  t.assert('T4a REDO (slider restored the post-cut cursor)', redo.cur === after.cur, 'cursor ' + undo.cur + '→' + redo.cur + ' (want ' + after.cur + ')');
+  const p3 = await probe(sel.fid);
+  console.log('  §SEL-TINT stage=post-redo ' + JSON.stringify(p3) + ' (post-undo uuid=' + p2.uuid + ')');
+  t.assert('T4 TINT-AFTER-REDO (forward scrub re-fold keeps membership AND repaints emissive)', p3.uuid !== null && p3.uuid !== p2.uuid && p3.inSel && p3.emissive === '2b5a8c', 'uuid ' + p2.uuid + '→' + p3.uuid + ' inSel=' + p3.inSel + ' emissive=' + p3.emissive + ' (want 2b5a8c)');
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_walk_all_disciplines.js
+++ b/modeller/tests/witness_e2e_walk_all_disciplines.js
@@ -20,6 +20,14 @@
  *   A6 COMMITTED         — op-log grew by the total placed count, signed + verifyChain OK.
  *   A7 VISIBLE           — the framebuffer changed after the walk (readPixels checksum differs).
  *   A8 NO-ERROR          — zero pageerror across the whole sequence.
+ *   A9 TOOLTIP           — (MODELLER_MASTER.md row 17) the synthetic __ALL__ row's ▶ affordance reads
+ *                          "Walk ALL disciplines" (plural/accurate); an ordinary disc row keeps the
+ *                          singular "Walk this discipline".
+ *   A10 NO-PROXY-TOAST   — (row 18 negative control) Duplex (253 el.) < threshold (50000) ⇒ NO
+ *                          "reveal animation simplified" toast may fire on the normal path.
+ *   B3 PROXY-TOAST-ONCE  — (row 18) with the threshold lowered so proxyMode fires, the downgrade is
+ *                          surfaced to the USER exactly ONCE per walk-all run (§TOAST line), not per
+ *                          discipline (Duplex roster = 4 discs → 4 BATCH flashes, still 1 toast).
  *
  * PERF-GUARD NOTE (§4 of the walk-all spec): this witness runs on Duplex (253 scene elements), far below
  * window.DW_ALL_PROXY_THRESHOLD (50000) — the guard's proxyMode branch does NOT fire here by construction.
@@ -44,6 +52,9 @@ async function openDuplex(pg) {
   await pg.click('#b-open'); await sleep(200);
   await pg.click('#m-open-panel .mo-row[data-key="Duplex"]');
   await pg.waitForFunction(() => !!window.__dwBuf, { timeout: 30000 }).catch(() => {});
+  // Anti-race (2026-07-30, seen as a spurious A6 red: before.oplogLen read 0): __dwBuf lands BEFORE the
+  // arcseed commitSeedGroup (196 ops + verifyChain) finishes — wait for the seed to actually be in the log.
+  await pg.waitForFunction(() => window.Bonsai && window.Bonsai.oplog && window.Bonsai.oplog.length > 0, { timeout: 30000 }).catch(() => {});
   await sleep(2000);
 }
 
@@ -57,8 +68,18 @@ async function openDuplex(pg) {
   {
     const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850, deviceScaleFactor: 2 });
     const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+    const proxyToasts = []; pg.on('console', m => { const t = m.text(); if (/^§TOAST/.test(t) && t.indexOf('reveal animation simplified') >= 0) proxyToasts.push(t); });
     const shot = (label) => pg.screenshot({ path: path.join(SHOTS, 'W-E2E-WALK-ALL-' + label + '.png') }).catch(() => {});
     await openDuplex(pg);
+
+    // A9 (MODELLER_MASTER.md row 17): read the REAL rendered title attributes off the production DOM.
+    const titles = await pg.evaluate(() => {
+      const allEl = document.querySelector('[data-bnode="dw-all"] .bn-walk');
+      const discEl = Array.from(document.querySelectorAll('.bn-walk')).find(el => { const row = el.closest('[data-bnode]'); return row && row.getAttribute('data-bnode') !== 'dw-all'; });
+      return { all: allEl ? allEl.getAttribute('title') : null, disc: discEl ? discEl.getAttribute('title') : null };
+    });
+    console.log('  §TOOLTIP ' + JSON.stringify(titles));
+    chk('A9 TOOLTIP (__ALL__ row plural, disc row singular)', titles.all === 'Walk ALL disciplines' && titles.disc === 'Walk this discipline', JSON.stringify(titles));
 
     const roster = await pg.evaluate(() => window.DiscWalker.disciplines());
     const before = await pg.evaluate(() => {
@@ -135,6 +156,7 @@ async function openDuplex(pg) {
     chk('A6 COMMITTED (op-log grew by placedTotal, chain OK)', after.oplogLen === before.oplogLen + placedTotal && chain === true, 'oplog ' + before.oplogLen + '→' + after.oplogLen + ' (+' + placedTotal + ') chain=' + chain);
     chk('A7 VISIBLE (framebuffer changed)', before.pix !== after.pix, 'pix ' + before.pix + '→' + after.pix);
     chk('A8 NO-ERROR', errs.length === 0, errs.slice(0, 2).join(' | '));
+    chk('A10 NO-PROXY-TOAST (row 18 negative control: below threshold ⇒ silent)', proxyToasts.length === 0, 'proxyToasts=' + proxyToasts.length);
 
     await pg.close();
   }
@@ -143,14 +165,17 @@ async function openDuplex(pg) {
   {
     const pg = await br.newPage(); await pg.setViewport({ width: 1200, height: 850, deviceScaleFactor: 2 });
     const errs = []; pg.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+    const proxyToasts = []; pg.on('console', m => { const t = m.text(); if (/^§TOAST/.test(t) && t.indexOf('reveal animation simplified') >= 0) proxyToasts.push(t); });
     await openDuplex(pg);
     await pg.evaluate(() => { window.DW_ALL_PROXY_THRESHOLD = 10; });   // Duplex has 253 scene elements > 10 → guard fires
     await pg.click('[data-bnode="dw-all"]');
     const done = await pg.waitForFunction(() => window.__dwAllDone === true, { timeout: 60000, polling: 250 }).then(() => true).catch(() => false);
     const result = await pg.evaluate(() => window.__dwAllResult);
     console.log('  §GUARD-RUN done=' + done + ' ' + JSON.stringify(result));
+    console.log('  §PROXY-TOASTS n=' + proxyToasts.length + ' ' + JSON.stringify(proxyToasts));
     chk('B1 PROXY-MODE FIRES when scene > threshold', done && result && result.proxyMode === true, 'proxyMode=' + (result && result.proxyMode));
     chk('B2 NO-ERROR in guard path', errs.length === 0, errs.slice(0, 2).join(' | '));
+    chk('B3 PROXY-TOAST-ONCE (row 18: downgrade surfaced to the user exactly once per run)', proxyToasts.length === 1, 'toasts=' + proxyToasts.length + ' (want 1; per-disc would be ' + ((result && result.walked && result.walked.length) || '?') + ')');
     await pg.close();
   }
 


### PR DESCRIPTION
MODELLER_MASTER.md §OPEN LIST rows 16/17/18 (LOD400 §START HERE OPEN 3/4/5). All three witnessed; §SEL-TINT-REFOLD proven RED-first on unmodified main.

## Row 17 — Walk-ALL tooltip
`bonsai_outliner.js`: the synthetic `__ALL__` row rendered `title="Walk this discipline"` → now "Walk ALL disciplines"; ordinary disc rows keep the singular. **W-E2E-WALK-ALL A9** reads the real rendered `title` attributes off the production DOM.

## Row 18 — proxy-mode downgrade surfaced to the user
`modeller.html` §DISCWALK-ALL: the batch-hold reveal downgrade was console-only. Now `toast('Large scene — reveal animation simplified; final geometry unchanged', 'ok')` exactly ONCE per walk run (run-scoped flag: set at run start when the run already opens in proxyMode, or by `_flashSettleDisc`'s BATCH branch on mid-run entry). §-log line unchanged. **W-E2E-WALK-ALL B3** (1 toast where per-disc would be 4) + **A10** negative control (below threshold ⇒ zero toasts).

## Row 16 — §SEL-TINT-REFOLD
A `scrubTo` re-fold (history slider undo/redo, x-ray restore, Connect timeline) rebuilds every mesh fresh and deliberately never `_emit()`s — so the `bonsai:oplog → _paintSel` hook can't fire and a still-selected mesh came back `emissive 000000` while `_selSet` held it. Fix at the single choke point: `foldChainToScene` announces **`bonsai:refold`** after rebuilt meshes land; `modeller.html` repaints via the existing `_paintSel` (membership re-resolved by featureId — no second tinting path) and re-applies `_applyShadowFlags` (same root cause, found by W-E2E-CUT C6's pixel oracle: scrub-rebuilt meshes also lost their shadow flags).

**W-E2E-SEL-TINT-REFOLD (new)** — RED first on unmodified main: `T3/T4 inSel=true emissive=000000 (want 2b5a8c)`; GREEN 9/9 with the fix. Measured precision in the witness header: `bCut` deselects by design (`highlight(null)`), so the cut path is not a repro — the no-`_emit` scrub paths are.

## Witness/harness repairs (each a diagnosed pre-existing red on unmodified main)
- `e2e_harness pick()` `opts.cuttable`: Duplex's front-ranked wallish candidates are now rotated inserts that bCut honestly refuses — eligibility asked of the production gate itself (`Bonsai._insertCutBox`).
- `e2e_harness clickPointFor()/clickOn()`: raycast-verified click points replace the bbox-centre occlusion lottery (`pick()` returned null run-to-run).
- `witness_e2e_cut` C6: re-click restores SELECTION STATE (old comment misattributed to tint); §ZOOM-SEL's auto-fly had broken the frame compare — settle + deterministic re-frame. Now pixel-EXACT: `pix0 == postUndo == 5826476`, **7/7**.
- `witness_e2e_walk_all_disciplines` openDuplex: wait for the arcseed to be IN the op-log (spurious A6 red). **13/13**.

## Regression
- W-E2E-OL-GROUPSELECT **8/8**.
- Known pre-existing red, untouched + verified identical on unmodified main: `witness_e2e_delete` D4.

## Deploy
`sw.js` CACHE_VERSION **v38 → v39** in this same commit (all touched runtime files are precached by basename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQXpiFZiXd5CTpCyEyZNjZ