### PR TITLE
fix(modeller): row 33 — withdraw the partial layer ship; §LAYER-GATE refuses the trimmed party walls loudly

### DIFF
--- a/modeller/str_walker_outliner.js
+++ b/modeller/str_walker_outliner.js
@@ -49,7 +49,7 @@
   var GEO_BASE = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/modeller/';
   var RESIDENTS = [
     { key: 'SampleHouse',   label: 'SampleHouse · wall-bearing',        db: 'SampleHouse_ARC.db', v: 1, geoDb: 'SampleHouse_geo.db',    geoV: 3, geoBase: GEO_BASE },
-    { key: 'Duplex',        label: 'Duplex · wall-bearing',             db: 'Duplex_ARC.db',      v: 2, geoDb: 'Duplex_geo.db',         geoV: 4, geoBase: GEO_BASE },   // geoV 4: §LOD400-LAYERS layered slabs + component_geometry_layers (gen_layered_geo_db.py)
+    { key: 'Duplex',        label: 'Duplex · wall-bearing',             db: 'Duplex_ARC.db',      v: 2, geoDb: 'Duplex_geo.db',         geoV: 5, geoBase: GEO_BASE },   // geoV 5: row 33 — the 2 clip-trimmed party walls revert to envelopes (no layer rows) so §LAYER-GATE refuses them loudly; an empty slab is a refusal, not a row
     { key: 'SampleCastle',  label: 'SampleCastle · column-framed',      db: 'SampleCastle_ARC.db',v: 1, geoDb: 'SampleCastle_geo.db',   geoV: 3, geoBase: GEO_BASE },
     { key: 'HHS',           label: 'HHS Office · column-framed',        db: 'HHS_ARC.db',         v: 1, geoDb: 'HHS_geo.db',            geoV: 3, geoBase: GEO_BASE },
     { key: 'Clinic',        label: 'Clinic · column-framed',            db: 'Clinic_ARC.db',      v: 1, geoDb: 'Clinic_geo.db',         geoV: 3, geoBase: GEO_BASE },

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v41';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v42';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_e2e_layers_residents.js
+++ b/modeller/tests/witness_e2e_layers_residents.js
@@ -1,37 +1,42 @@
 #!/usr/bin/env node
 /**
  * W-E2E-LAYERS-RESIDENTS — §LOD400-LAYERS reaches the live Modeller residents + §LAYER-GATE refusal
- * (bim-compiler RESUME_MODELLER_LOD400_REAL_GEOMETRY.md §LOD400-ENVELOPE, Modeller half).
+ * (bim-compiler RESUME_MODELLER_LOD400_REAL_GEOMETRY.md §LOD400-ENVELOPE, Modeller half; updated for
+ * ROW 33, 2026-07-31: an empty layer slab is a REFUSAL, not a row).
  *
- * ISSUE UNDER TEST: the Duplex party wall `2O2Fr$t4X7Zf8NOew3FNbT` is authored as 7 material layers
- * (Plasterboard 16 / Stud 41 / CMU 193 / Air 50 / CMU 193 / Stud 41 / Plasterboard 16 mm) but the
- * resident geo store shipped ONE 14-triangle envelope box presented as its real geometry — the exact
- * fallback the doctrine forbids. The fix ships (a) layer tables into Duplex_ARC.db via the
- * patches/Duplex_ARC.db.sql self-heal loader, (b) a rebuilt Duplex_geo.db whose multi-layer buffers
- * are per-layer slab compilations indexed by `component_geometry_layers`, and (c) a seed-time gate
- * (arc_editable.js §LAYER-GATE) that REFUSES any authored-multi-layer element still resolving an
- * envelope-only mesh.
+ * ISSUE UNDER TEST: the Duplex party walls are authored as 7 material layers (Plasterboard 16 /
+ * Stud 41 / CMU 193 / Air 50 / CMU 193 / Stud 41 / Plasterboard 16 mm). Two of the four
+ * (`2O2Fr$t4X7Zf8NOew3FNbT`, `2O2Fr$t4X7Zf8NOew3FKRi`) are trimmed in the SOURCE by an authored
+ * IfcPolygonalBoundedHalfSpace at the layer-4/5 boundary (Revit unit-demising — the neighbour-side
+ * stud+plasterboard belong to the neighbour wall's body; ZERO openings involved, measured
+ * 2026-07-30). The first ship compiled those two as 5 slabs + 2 face_count=0 index rows — a partial
+ * ship whose witness sums were blind by construction (Watchdog, MODELLER_MASTER row 33). Under the
+ * row-33 directive the partial ship is withdrawn: the two trimmed walls revert to their original
+ * envelope buffers with NO layer rows, and the armed §LAYER-GATE refuses them LOUDLY on seed — the
+ * "honestly RED" end-state on the surface the user sees. The layered proof moves to the full-span
+ * party wall `2O2Fr$t4X7Zf8NOew3FKRH` (7 real slabs, every row face_count>0).
  *
  * Exercises the REAL user path: the shipped Duplex_ARC.db bytes + the shipped patch SQL (same text
  * _applyPendingPatch feeds sql.js) + the geo file (live object-storage URL by default — the same
  * bytes a browser fetches; DUPLEX_GEO=<path> overrides for pre-upload local runs).
  *
  * Checks (each names what it proves):
- *   L1 party-slabs     — party wall hash resolves 124 tris (pre-fix envelope: 14 — a box cannot carry 5 slabs)
- *   L2 layer-index     — exactly 7 component_geometry_layers rows; SUM(thickness_m) == 0.550 m authored total
- *   L3 slab-extents    — per-slab thin-axis extents 16/41/193/50/193 mm (±1.5mm) + exactly 2 honest empty
- *                        rows (L5/L6 authored outside this element's own body — §LAYER-PARTIAL, never invented)
- *   L4 full-coverage   — the layer rows tile the whole buffer (Σ face_count == total tris): no un-indexed
- *                        envelope residue hiding behind the hash
- *   L5 all-resolve     — buildSeedOps(patched ARC, geo): 196 seeded ops (measured origin/main baseline,
- *                        unchanged), hardfail=0, layerRefused=0, gate ARMED (multiLayer=80,
- *                        layeredHashes=71), AND all 215 element_instances resolve (155/155 distinct
- *                        hashes present in the rebuilt geo) — the fix empties nothing
- *   L6 refusal-fires   — FALSIFICATION: delete the party hash's layer rows from a COPY → the SAME seed
- *                        refuses the party-wall guid with a §LAYER-ENVELOPE-REFUSE console.error and
- *                        drops exactly that op (proves the gate is live, not decorative)
- *   L7 unarmed-safe    — UNPATCHED ARC bytes + the same geo db: gate stays DISARMED, 196 ops, 0 refusals
- *                        (a resident whose layer tables never shipped — SampleCastle today — is untouched)
+ *   L1 trimmed-envelope — trimmed wall's hash resolves its ORIGINAL 14-tri envelope again with ZERO
+ *                         layer rows (partial-ship 124-tri buffer + 7 rows is GONE)
+ *   L2 layer-index      — full-span exemplar resolves exactly 7 rows; SUM(thickness_m) == 0.550 m
+ *   L3 slab-extents     — exemplar per-slab thin-axis extents 16/41/193/50/193/41/16 mm (±1.5mm),
+ *                         ALL SEVEN real — no empty rows
+ *   L4 full-coverage    — exemplar rows tile its whole buffer; AND store-wide 0 rows with
+ *                         face_count<=0 (row 33: an empty slab is a refusal, not a row)
+ *   L5 refusal-live     — buildSeedOps(patched ARC, geo): the 2 trimmed walls are REFUSED BY NAME
+ *                         with 2 loud §LAYER-ENVELOPE-REFUSE console.error lines; ops 196→194;
+ *                         hardfail=0; gate ARMED (multiLayer=80, layeredHashes=69); all 215
+ *                         instances / 155 hashes still resolve — nothing else lost
+ *   L6 refusal-fires    — FALSIFICATION: delete the EXEMPLAR's layer rows from a COPY → the SAME
+ *                         seed refuses it too (layerRefused=3, ops=193) — the gate is live per-hash,
+ *                         not hardcoded to the two known walls
+ *   L7 unarmed-safe     — UNPATCHED ARC bytes + the same geo db: gate stays DISARMED, 196 ops,
+ *                         0 refusals (a resident whose layer tables never shipped is untouched)
  */
 'use strict';
 var fs = require('fs'), path = require('path'), https = require('https');
@@ -47,9 +52,10 @@ var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
 
 var ARC_PATH = path.join(ROOT, 'Duplex_ARC.db');
 var PATCH_PATH = path.join(ROOT, 'patches', 'Duplex_ARC.db.sql');
-var GEO_URL = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/modeller/Duplex_geo.db?v=4';
-var PARTY_GUID = '2O2Fr$t4X7Zf8NOew3FNbT';
-var PARTY_GUID2 = '2O2Fr$t4X7Zf8NOew3FKRi';   // the sibling demising wall — same authored layer set
+var GEO_URL = 'https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/modeller/Duplex_geo.db?v=5';
+var TRIMMED_GUID = '2O2Fr$t4X7Zf8NOew3FNbT';   // clip-trimmed demising wall — refused (row 33)
+var TRIMMED_GUID2 = '2O2Fr$t4X7Zf8NOew3FKRi';  // its sibling — same authored set, same trim, refused
+var EXEMPLAR_GUID = '2O2Fr$t4X7Zf8NOew3FKRH';  // full-span 7-layer party wall — the layered proof
 
 var pass = 0, fail = 0;
 function chk(name, cond, extra) {
@@ -75,7 +81,7 @@ function fetchGeo() {
 
 initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
   return fetchGeo().then(function (geoBuf) {
-    console.log('═══ W-E2E-LAYERS-RESIDENTS — §LOD400-LAYERS layered walls reach the residents + §LAYER-GATE ═══');
+    console.log('═══ W-E2E-LAYERS-RESIDENTS — layered walls + §LAYER-GATE, row-33 refusal posture ═══');
     // §PRIME LESSON (GEO-SERVED): a 200 is not evidence — assert the bytes ARE a SQLite db
     var magic = geoBuf.slice(0, 16).toString('utf8');
     chk('L0 geo-bytes-real', magic.indexOf('SQLite format 3') === 0,
@@ -89,26 +95,33 @@ initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
     adb.run(patchSql);
     var gdb = new SQL.Database(new Uint8Array(geoBuf));
 
-    var hash = adb.exec("SELECT geometry_hash FROM element_instances WHERE guid='" + PARTY_GUID + "'")[0].values[0][0];
-    var g = gdb.exec("SELECT length(faces)/12, length(vertices)/12 FROM component_geometries WHERE geometry_hash='" + hash + "'");
-    var tris = g.length ? g[0].values[0][0] : -1;
-    chk('L1 party-slabs', tris === 124, 'hash=' + hash + ' tris=' + tris + ' (pre-fix envelope: 14)');
+    // L1: the trimmed wall is an ENVELOPE again — its partial layered ship is withdrawn
+    var tHash = adb.exec("SELECT geometry_hash FROM element_instances WHERE guid='" + TRIMMED_GUID + "'")[0].values[0][0];
+    var g = gdb.exec("SELECT length(faces)/12 FROM component_geometries WHERE geometry_hash='" + tHash + "'");
+    var tTris = g.length ? g[0].values[0][0] : -1;
+    var tRowsQ = gdb.exec("SELECT count(*) FROM component_geometry_layers WHERE geometry_hash='" + tHash + "'");
+    var tRows = tRowsQ.length ? tRowsQ[0].values[0][0] : -1;
+    chk('L1 trimmed-envelope', tTris === 14 && tRows === 0,
+      'hash=' + tHash + ' tris=' + tTris + ' (original envelope; partial ship was 124) layerRows=' + tRows);
 
+    // L2: the full-span exemplar carries the real 7-slab compile
+    var hash = adb.exec("SELECT geometry_hash FROM element_instances WHERE guid='" + EXEMPLAR_GUID + "'")[0].values[0][0];
     var rows = gdb.exec("SELECT layer_seq, material_name, thickness_m, face_start, face_count FROM component_geometry_layers WHERE geometry_hash='" + hash + "' ORDER BY layer_seq");
     var rv = rows.length ? rows[0].values : [];
     var sum = rv.reduce(function (a, r) { return a + r[2]; }, 0);
     chk('L2 layer-index', rv.length === 7 && Math.abs(sum - 0.550) < 1e-9,
-      'rows=' + rv.length + ' Σthickness=' + sum.toFixed(3) + 'm (authored total 0.550)');
+      'exemplar hash=' + hash + ' rows=' + rv.length + ' Σthickness=' + sum.toFixed(3) + 'm (authored total 0.550)');
 
-    // per-slab thin-axis extents from the actual buffer — the geometry, not just the index
-    var vb = gdb.exec("SELECT vertices, faces FROM component_geometries WHERE geometry_hash='" + hash + "'")[0].values[0];
+    // L3: per-slab thin-axis extents from the actual buffer — all SEVEN slabs real
+    var vb = gdb.exec("SELECT vertices, faces, length(faces)/12 FROM component_geometries WHERE geometry_hash='" + hash + "'")[0].values[0];
     var verts = new Float32Array(vb[0].buffer, vb[0].byteOffset, vb[0].byteLength / 4);
     var faces = new Uint32Array(vb[1].buffer, vb[1].byteOffset, vb[1].byteLength / 4);
-    var expect = [16, 41, 193, 50, 193];   // mm, the 5 in-body slabs; L5/L6 authored-outside-body ⇒ empty
+    var tris = vb[2];
+    var expect = [16, 41, 193, 50, 193, 41, 16];   // mm — the full authored set, no empties allowed
     var extOk = true, emptyN = 0, got = [];
     rv.forEach(function (r) {
       var fs0 = r[3], fc = r[4];
-      if (fc === 0) { emptyN++; return; }
+      if (!fc) { emptyN++; return; }
       var mn = [Infinity, Infinity, Infinity], mx = [-Infinity, -Infinity, -Infinity];
       for (var i = fs0 * 3; i < (fs0 + fc) * 3; i++) {
         var vi = faces[i] * 3;
@@ -121,50 +134,56 @@ initSqlJs({ wasmBinary: wasmBinary }).then(function (SQL) {
       got.push(thin.toFixed(1));
       if (Math.abs(thin - expect[got.length - 1]) > 1.5) extOk = false;
     });
-    chk('L3 slab-extents', extOk && got.length === 5 && emptyN === 2,
-      'thin-extents [' + got.join(',') + ']mm vs authored [' + expect.join(',') + '] + ' + emptyN + ' honest empty rows');
+    chk('L3 slab-extents', extOk && got.length === 7 && emptyN === 0,
+      'thin-extents [' + got.join(',') + ']mm vs authored [' + expect.join(',') + '], empty rows=' + emptyN);
 
+    // L4: exemplar tiles its buffer + ROW 33 store-wide: no face_count<=0 row anywhere
     var totalFc = rv.reduce(function (a, r) { return a + r[4]; }, 0);
-    chk('L4 full-coverage', totalFc === tris, 'Σface_count=' + totalFc + ' == buffer tris=' + tris + ' (no envelope residue)');
+    var nEmptyAll = gdb.exec("SELECT count(*) FROM component_geometry_layers WHERE face_count<=0 OR face_count IS NULL")[0].values[0][0];
+    chk('L4 full-coverage', totalFc === tris && nEmptyAll === 0,
+      'Σface_count=' + totalFc + ' == exemplar tris=' + tris + '; store-wide empty rows=' + nEmptyAll +
+      ' (an empty slab is a refusal, not a row)');
 
-    // capture §LAYER-ENVELOPE-REFUSE console.error lines (the loud path is part of the contract)
+    // L5: the armed gate refuses BOTH trimmed walls loudly on the real seed path
     var errs = [];
     var origErr = console.error;
     console.error = function (m) { errs.push(String(m)); origErr.apply(console, arguments); };
-
     var built = ArcEditable.buildSeedOps(adb, gdb);
     console.error = origErr;
-    // instance-level resolution over the WHOLE building (215 instances / 155 distinct hashes),
-    // independent of the ARC-discipline seed subset (196 ops — measured origin/main baseline)
+    var refused = built.skipped.filter(function (s) { return s.reason === 'envelope-no-layers'; })
+      .map(function (s) { return s.guid; });
+    var loud = errs.filter(function (m) { return m.indexOf('§LAYER-ENVELOPE-REFUSE') >= 0; });
     var nInst = adb.exec("SELECT count(*) FROM element_instances WHERE geometry_hash IS NOT NULL")[0].values[0][0];
     var hashList = adb.exec("SELECT DISTINCT geometry_hash FROM element_instances WHERE geometry_hash IS NOT NULL")[0]
       .values.map(function (v) { return "'" + v[0] + "'"; });
     var nHave = gdb.exec("SELECT count(DISTINCT geometry_hash) FROM component_geometries WHERE geometry_hash IN (" +
       hashList.join(',') + ")")[0].values[0][0];
-    chk('L5 all-resolve',
-      built.ops.length === 196 && built.hardfail === 0 && built.layerRefused === 0 && built.skipped.length === 0 &&
-      !!built.layerGate && built.layerGate.multiLayer === 80 && built.layerGate.layeredHashes === 71 &&
+    chk('L5 refusal-live',
+      built.layerRefused === 2 && refused.indexOf(TRIMMED_GUID) >= 0 && refused.indexOf(TRIMMED_GUID2) >= 0 &&
+      loud.length === 2 && built.ops.length === 194 && built.hardfail === 0 &&
+      !!built.layerGate && built.layerGate.multiLayer === 80 && built.layerGate.layeredHashes === 69 &&
       nInst === 215 && nHave === hashList.length && hashList.length === 155,
-      'ops=' + built.ops.length + ' hardfail=' + built.hardfail + ' layerRefused=' + built.layerRefused +
-      ' gate=' + JSON.stringify(built.layerGate) + ' instances=' + nInst + ' hashesResolved=' + nHave + '/' + hashList.length);
+      'layerRefused=' + built.layerRefused + ' guids=' + JSON.stringify(refused) +
+      ' console.error lines=' + loud.length + ' ops=' + built.ops.length + ' (was 196 pre-row-33)' +
+      ' gate=' + JSON.stringify(built.layerGate) + ' instances=' + nInst +
+      ' hashesResolved=' + nHave + '/' + hashList.length);
 
-    // L6 FALSIFICATION: strip ONE hash's layer rows from a COPY — the gate must fire for its guids
+    // L6 FALSIFICATION: strip the EXEMPLAR's rows from a COPY — the gate must fire for it too
     var gdb2 = new SQL.Database(new Uint8Array(geoBuf));
     gdb2.run("DELETE FROM component_geometry_layers WHERE geometry_hash='" + hash + "'");
     errs = [];
     console.error = function (m) { errs.push(String(m)); origErr.apply(console, arguments); };
     var built2 = ArcEditable.buildSeedOps(adb, gdb2);
     console.error = origErr;
-    var refusedGuids = built2.skipped.filter(function (s) { return s.reason === 'envelope-no-layers'; })
+    var refused2 = built2.skipped.filter(function (s) { return s.reason === 'envelope-no-layers'; })
       .map(function (s) { return s.guid; });
-    var loud = errs.filter(function (m) { return m.indexOf('§LAYER-ENVELOPE-REFUSE') >= 0; });
+    var loud2 = errs.filter(function (m) { return m.indexOf('§LAYER-ENVELOPE-REFUSE') >= 0; });
     chk('L6 refusal-fires',
-      built2.layerRefused === 1 && refusedGuids.indexOf(PARTY_GUID) >= 0 &&
-      loud.length === 1 && built2.ops.length === 196 - 1,
-      'layerRefused=' + built2.layerRefused + ' guids=' + JSON.stringify(refusedGuids) +
-      ' console.error lines=' + loud.length + ' ops=' + built2.ops.length +
-      ' (sibling ' + PARTY_GUID2 + ' keeps its OWN hash+rows, still rendered: ' +
-      (refusedGuids.indexOf(PARTY_GUID2) < 0) + ')');
+      built2.layerRefused === 3 && refused2.indexOf(EXEMPLAR_GUID) >= 0 &&
+      loud2.length === 3 && built2.ops.length === 193,
+      'layerRefused=' + built2.layerRefused + ' guids=' + JSON.stringify(refused2) +
+      ' console.error lines=' + loud2.length + ' ops=' + built2.ops.length +
+      ' (gate live per-hash, not hardcoded to the trimmed pair)');
 
     // L7 unarmed: the UNPATCHED shipped bytes (no rel_material_layer_set) — zero new code paths
     var adb0 = new SQL.Database(new Uint8Array(rawArc));

--- a/modeller/tests/witness_glass_parity_e2e.js
+++ b/modeller/tests/witness_glass_parity_e2e.js
@@ -5,6 +5,11 @@ const { runE2E } = require('./e2e_harness');
 (async () => {
   await runE2E('W-GLASS-PARITY', async (t) => {
     await t.open('Duplex');
+    // t.open resolves on __dwBuf + a fixed settle; the ARC seed (patch → OCI geo fetch → fold) can
+    // land later on a cold edge cache. Wait on the REAL condition — seeded meshes present — bounded.
+    await t.pg.waitForFunction(
+      () => window.Bonsai && window.Bonsai.group() && window.Bonsai.group().children.some(o => o.isMesh),
+      { timeout: 30000 });
     const info = await t.pg.evaluate(() => {
       var out = { windows: [], total: 0 };
       var g = window.Bonsai.group();


### PR DESCRIPTION
Modeller half of MODELLER_MASTER.md row 33 (bim-compiler PR #60 is the extractor half).

Root cause measured: the two 5-slab party walls carry ZERO openings; an authored `IfcPolygonalBoundedHalfSpace` clip at the layer-4/5 boundary trims the neighbour-side stud+plasterboard (Revit unit-demising) — the material is genuinely absent, so the partial ship is withdrawn and the walls go honestly RED.

- `Duplex_geo.db` rebuilt + re-uploaded to OCI (byte-verified): trimmed hashes revert to original envelopes, 14 empty-carrying index rows deleted → 215 rows / 69 layered hashes / zero `face_count<=0`
- geoV 4→5, sw v41→v42
- `witness_e2e_layers_residents.js` **8/8 against the LIVE geo URL**, RED-first (pre-fix bytes: 4/8); exemplar = full-span `…FKRH` (7 real slabs); both trimmed walls refused BY NAME, 2 loud `§LAYER-ENVELOPE-REFUSE`, ops 196→194, 215/215 instances still resolve
- `witness_glass_parity_e2e.js` latent sampling race fixed (wait on real seeded-meshes condition) — 4/4
- Regressions: W-ARC-EDITABLE 10/10 · W-E2E-VOID-ANCHOR 19/19 · anchor sweep green through HHS (later untouched residents cut by runner timeout) · headless real-user open: 194 meshes, gate armed refused=2, hardfail 0/194

🤖 Generated with [Claude Code](https://claude.com/claude-code)