### PR TITLE
fix(4D): populate hardcoded SEQUENCE_NAME_OVERRIDES (viewer.html never fetches the JSON)

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -217,9 +217,23 @@ var SEQUENCE_RULES = {
 };
 var SEQUENCE_DEFAULT = {phase:'Architecture',sequence:6,resource:null};
 // §4D_FACADE_ORDER: name-based reclass ahead of the class lookup above — ifc_class alone cannot
-// tell curtain-wall glazing/framing (IfcPlate/IfcMember) from genuinely structural plates/members.
-// Empty in-file default; populated from rates/sequence_rules.json NAME_OVERRIDES by loadSequenceRules().
-var SEQUENCE_NAME_OVERRIDES = [];
+// tell curtain-wall glazing/framing (IfcPlate/IfcMember) from genuinely structural plates/members
+// (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR/LTU_AHouse structural steel/timber, which must
+// stay at their structural seq). This is the IN-FILE SYNC DEFAULT — viewer.html does NOT call
+// initRateTemplate()/loadSequenceRules() (only mep_report.html/boq_charts.html do), so this hardcoded
+// copy, not the JSON, is what actually runs in the main viewer/Time Machine/Author wizard. Keep it in
+// sync with rates/sequence_rules.json's NAME_OVERRIDES (same convention as SEQUENCE_RULES above).
+var SEQUENCE_NAME_OVERRIDES = [
+  {
+    id: 'glazed_curtainwall_facade',
+    classes: ['IfcPlate', 'IfcMember'],
+    pattern: 'glaz|glass|verglas|vitrage|vidrio|curtain|mullion',
+    flags: 'i',
+    phase: 'Architecture',
+    sequence: 7,
+    resource: 'CARPENTER'
+  }
+];
 
 // Helper: get phase for an IFC class
 function getPhase(ifcClass) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v886';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v887';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
Follow-up to #1098. That PR's fix was inert for the actual viewer — `viewer.html` never calls `initRateTemplate()`/`loadSequenceRules()` (only `mep_report.html`/`boq_charts.html` do), so `rates/sequence_rules.json`'s `NAME_OVERRIDES` was never fetched and `window.SEQUENCE_NAME_OVERRIDES` stayed at `rates.js`'s empty hardcoded default. Confirmed live: a full cache-clear + hard reload of the Hospital viewer still showed zero `§NAME_OVERRIDE` log lines and zero `§RATES_JSON` log lines at all.

Fix: hardcode the same override directly in `rates.js`, matching the existing convention that `SEQUENCE_RULES`/`SEQUENCE_DEFAULT`/`LABOR_RATES` are all hardcoded in-file defaults the JSON only optionally overrides once (if ever) fetched.

## Test plan
- [x] Node vm sandbox with `window` as the context's true global object (matching how a classic non-module `<script>` behaves) — `window.SEQUENCE_NAME_OVERRIDES` now resolves to the override object; was `undefined` before this fix.
- [ ] Live: hard-reload Hospital, click Regenerate in the Author wizard, confirm `§NAME_OVERRIDE 9333 elements reclassified...` appears in console and glazed panels no longer erect before walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)