### PR TITLE
fix(cinema): §CPE_REOPEN_NODE — the added node survives OK, and an unselected stick is dark blue

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -23,7 +23,12 @@
   // rather than a drag (a hose bend). 4px is standard click slop; at Hospital's 0.192 m/px that is
   // 0.77m, comfortably below any intentional bend and comfortably above hand tremor.
   var CLICK_SLOP_PX = 4;
-  var CPE_V = 'v16 (§CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  // §CPE_REOPEN_NODE — the colour a user-dropped node is drawn in when it is NOT selected. Dark
+  // enough to separate from the seeder's light blue (0x4fc3f7) and the white bar/mid at a glance,
+  // and already this file's contrast colour on a light scene (see _contrastColour below).
+  var CPE_STICK_BLUE = 0x1565c0;
+  var CPE_STICK_TEXT = '#64b5f6';   // the same hue, readable as text on the dark panel
+  var CPE_V = 'v17 (§CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the added node survives; provenance travels in the override instead of being guessed from the index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; §CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -367,15 +372,22 @@
       // Hit-testing reads these same drawn positions, so what you grab is what you see.
       var e = [_drawn(e0[0]), _drawn(e0[1])];
       var heldBand = _state.held && _state.held.b === i;
-      _state.objs.push(_mkLine([e[0], e[1]], heldBand ? 0xff8c00 : 0xffffff, 1.0));
+      // §CPE_REOPEN_NODE (user: "the new nodes has to be darker blue when not selected to stand
+      // out"): a band the USER dropped used to be drawn pixel-identically to one the seeder
+      // produced — same white bar, same white mid, same light-blue ends — so the only way to find
+      // your own node again was to remember where you put it. An unheld stick now draws its bar and
+      // all three handles in CPE_STICK_BLUE. Radii are untouched, so mid-vs-end still reads by size,
+      // and held-orange still wins over everything (selection must stay the loudest state).
+      var isStick = !!b._stick;
+      _state.objs.push(_mkLine([e[0], e[1]], heldBand ? 0xff8c00 : isStick ? CPE_STICK_BLUE : 0xffffff, 1.0));
       var zones = [{ p: e[0], z: 'a' }, { p: _drawn(b.c), z: 'mid' }, { p: e[1], z: 'b' }];
       for (var k = 0; k < zones.length; k++) {
         var isHeld = heldBand && _state.held.z === zones[k].z;
         var isMid = zones[k].z === 'mid';
-        var o = _mkSphere(zones[k].p, isHeld ? 0xff8c00 : isMid ? 0xffffff : 0x4fc3f7,
-                          isHeld ? 1.2 : isMid ? 0.9 : 0.75, isHeld ? 1.0 : 0.8);
+        var col = isHeld ? 0xff8c00 : isStick ? CPE_STICK_BLUE : isMid ? 0xffffff : 0x4fc3f7;
+        var o = _mkSphere(zones[k].p, col, isHeld ? 1.2 : isMid ? 0.9 : 0.75, isHeld ? 1.0 : 0.8);
         _state.objs.push(o);
-        _state.handles.push({ b: i, z: zones[k].z, p: zones[k].p, mesh: o });
+        _state.handles.push({ b: i, z: zones[k].z, p: zones[k].p, mesh: o, stick: isStick, col: col });
       }
     }
     if (a.markDirty) a.markDirty();
@@ -423,8 +435,13 @@
     var total = s.userTotal != null ? s.userTotal : nat.total;
     var scale = total / Math.max(0.001, nat.total);
     return {
+      // §CPE_REOPEN_NODE: `_stick`/`_s` travel WITH the band. They used to be dropped here, so both
+      // readers (_pathsApply, open()'s clone) had to GUESS provenance from position — "every middle
+      // band is a stick" — which was survivable while the only per-stick affordance was the × button
+      // and is not survivable now that colour depends on it (a dark-blue seeded band is a lie).
       bands: s.bands.map(function(b) {
-        return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
+        return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
+                 _stick: !!b._stick, _s: b._s };
       }),
       // §CPE_HOSE: the ops ride the same override the plan, Save and the bake already consume — a
       // deep copy, same treatment as the bands, so nothing downstream can write back into the holder
@@ -506,11 +523,18 @@
     if (i === 0) return 'settle';
     if (i === _state.bands.length - 1) return 'stop';
     var b = _state.bands[i];
+    // §CPE_REOPEN_NODE: only a band the USER dropped is called a stick. §CPE_STICK's blanket "every
+    // middle is a stick" was true when the count was 3 and a stick was the only way to get a fourth,
+    // but it renamed the DERIVED exit-door anchor too — so a list with one added node read
+    // `settle | stick @ 15% | stick | stop` and the user's own node was one of two identical words.
+    // Provenance is carried now (see _buildOverride), so the label can tell the truth.
+    if (!b._stick) return ROW_LABEL[1];
     return 'stick' + (b._s != null ? ' @ ' + Math.round(b._s * 100) + '%' : '');
   }
   function _helpOf(i) {
     if (i === 0) return ROW_HELP[0];
     if (i === _state.bands.length - 1) return ROW_HELP[2];
+    if (!_state.bands[i]._stick) return ROW_HELP[1];
     return 'a stick you added — drag its middle to move it, an end to twist the curve through it';
   }
   var ROW_LABEL = ['settle', 'exit door', 'stop'];
@@ -709,12 +733,16 @@
         var b = _state.bands[i];
         var sel = _state.held && _state.held.b === i;
         var row = document.createElement('div');
+        // §CPE_REOPEN_NODE: the list carries the SAME cue as the pipe — a node you dropped is blue
+        // in both places, so "which row is my node" and "which bar is my node" are one question.
+        var stickRow = !!b._stick && i > 0 && i < _state.bands.length - 1;
         row.style.cssText = 'padding:5px 12px;font-size:11px;cursor:pointer;' +
-          'border-left:3px solid ' + (sel ? '#ff8c00' : 'transparent') + ';' + (sel ? 'background:rgba(255,140,0,0.09);' : '');
+          'border-left:3px solid ' + (sel ? '#ff8c00' : stickRow ? '#1565c0' : 'transparent') + ';' +
+          (sel ? 'background:rgba(255,140,0,0.09);' : stickRow ? 'background:rgba(21,101,192,0.10);' : '');
         var head = document.createElement('div');
         head.style.cssText = 'display:flex;align-items:center;gap:5px';
         var lbl = document.createElement('span');
-        lbl.style.cssText = 'width:62px;color:#888;flex:none';
+        lbl.style.cssText = 'width:62px;color:' + (stickRow ? CPE_STICK_TEXT : '#888') + ';flex:none';
         lbl.textContent = _labelOf(i);
         lbl.title = _helpOf(i);
         head.appendChild(lbl);
@@ -928,8 +956,10 @@
     if (!ov || !ov.bands || ov.bands.length < 2) { console.warn('§CPE_PATH_LOAD_FAIL empty or malformed record'); return false; }
     _undoPush('load "' + rec.name + '"');
     _state.bands = ov.bands.map(function(b, i) {
+      // §CPE_REOPEN_NODE: prefer the STORED flag; the index rule is the fallback for records saved
+      // before _buildOverride carried it, so an old plan keeps its × affordance.
       return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
-               _stick: i > 0 && i < ov.bands.length - 1, _s: b._s };
+               _stick: b._stick != null ? !!b._stick : (i > 0 && i < ov.bands.length - 1), _s: b._s };
     });
     _state.hose = (ov.hose || []).map(function(o) {
       return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
@@ -1456,9 +1486,13 @@
       var clone = function(bs) {
         return bs.map(function(b, i) {
           var o = { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
-          // Re-flag the middles so a re-opened stick keeps its × remove affordance, exactly as
-          // _pathsApply does when loading a stored plan.
-          if (authored && i > 0 && i < bs.length - 1) o._stick = true;
+          // §CPE_REOPEN_NODE: the plan now carries provenance (OK stages the override, _buildOverride
+          // keeps `_stick`/`_s`), so read it. The index rule stays as the fallback for a plan that
+          // predates that — same reciprocal treatment as _pathsApply.
+          if (authored) {
+            o._stick = b._stick != null ? !!b._stick : (i > 0 && i < bs.length - 1);
+            o._s = b._s;
+          }
           return o;
         });
       };
@@ -1621,6 +1655,21 @@
         a.controls.update();
         if (a.markDirty) a.markDirty();
         console.log('§CPE_CLOSE action=' + action + ' edited=' + edited + ' total=' + total.toFixed(1) + 's');
+        // §CPE_REOPEN_NODE (user: "i can hardly pick out the extra node without been listed") — an
+        // edited OK STAGES the path, so the next Alt+C re-opens what was authored instead of
+        // re-seeding the derived three. Before this line the override was handed to the bake
+        // (cinema_maxq.js:624) and then dropped: the next open planned with no override at all
+        // (:494 -> effects.js:6466 -> A._cinemaPathEdit === null -> plan.bands === null), `authored`
+        // was false, and the user's stick was GONE — the list was not hiding it, it no longer
+        // existed. Guardrail 2 is why this is gated on `edited`: an untouched OK must stage nothing
+        // and stay byte-identical. Cancel stages nothing. In-memory only — the cinema_path TABLE is
+        // still written solely by Ctrl+S Save Building.
+        if (edited && action === 'ok' && typeof a.stageCinemaPath === 'function') {
+          a.stageCinemaPath(ov);
+          console.log('§CPE_OK_STAGED bands=' + ov.bands.length +
+            ' sticks=' + ov.bands.filter(function(b) { return b._stick; }).length +
+            ' — the next Alt+C re-opens THIS path (src=authored), not the derived seed');
+        }
         _state = null;
         // Guardrail 2: an untouched OK hands back NO override, so the bake re-uses the derived plan
         // object verbatim. "One click costs nothing" is enforced here, not merely intended.
@@ -1673,6 +1722,20 @@
           var i = Math.max(0, Math.min(pts.length - 1, Math.round((frac || 0.5) * (pts.length - 1))));
           var s = _screenOf(pts[i]);
           return s.behind ? null : { x: Math.round(s.x), y: Math.round(s.y), i: i };
+        },
+        // §CPE_REOPEN_NODE's G-RN-4. Colour is geometry state, not a look — so it is asserted off the
+        // REAL handle meshes the scene is drawing (CLAUDE.md FUNDAMENTAL LAW: numbers, never a
+        // screenshot). Read-only, mutates nothing, same precedent as _probePipe.
+        _probeHandles: function() {
+          if (!_state) return null;
+          return _state.handles.map(function(h) {
+            var s = _screenOf(h.p);
+            return { b: h.b, z: h.z, stick: !!h.stick,
+                     x: h.p.x, y: h.p.y, z3: h.p.z,
+                     hex: '0x' + (h.mesh && h.mesh.material ? h.mesh.material.color.getHex() : h.col)
+                            .toString(16).padStart(6, '0'),
+                     px: s.behind ? null : Math.round(s.x), py: s.behind ? null : Math.round(s.y) };
+          });
         }
       };
       clearInterval(_attach);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -6339,8 +6339,14 @@ async function setupEffects(A, renderer, scene, camera) {
              // seconds actually in force for this plan so the editor never has to guess them back
              // out of the normalized beat fractions.
              waypoints: outWp.map(function(w) { return { x: w.x, y: w.y, z: w.z }; }),
+             // §CPE_REOPEN_NODE: `_stick`/`_s` ride along. The plan is what the editor RE-OPENS from
+             // (cinema_path_editor.js:1454), so dropping them here made a re-opened path fall back to
+             // "every middle band is a stick" — which mislabels seeded bands and, now that colour
+             // follows provenance, would paint them as nodes the user never added. Measured RED by
+             // witness_cpe_reopen_node.js G-RN-3 with only the editor side of this fix in place.
              bands: _cpeBands ? _cpeBands.map(function(b) {
-               return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len };
+               return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
+                        _stick: b._stick, _s: b._s };
              }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
              sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, rise: _useSec.rise },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v889';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v890';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_click_slop.js
+++ b/witness_cpe_click_slop.js
@@ -49,15 +49,48 @@ async function openEditor(browser, BLD) {
 // A blind canvas sweep is a lottery on a small building — a 42px grid missed Duplex's walk entirely
 // (measured 2026-07-29). Ask the editor for the pixel of a point along the walk instead, then CONFIRM
 // with its own hit test, so the gesture below is known to land on the pipe before anything is claimed.
+// ⚠ HARNESS ROT, found 2026-07-31 by §CPE_REOPEN_NODE's witness and confirmed identically RED on
+// origin/main (1/4 there and here) — this was NEVER a product regression. Two things had drifted:
+//   (a) the editor opens at the pre-dive orbit pose, from which Duplex's whole 15m walk projects
+//       into a ~30px smear, and
+//   (b) every pixel of that smear is inside a band handle's GRAB_PX=18 radius, so `h.down` resolves
+//       the gesture to a HANDLE (a rotate/translate) and never reaches the pipe at all — no stick,
+//       no hose, and the witness read that as "the product does not spawn sticks".
+// Fixed by looking closer first (free: §CPE_PREVIEW_DIVERGENCE pins every re-plan to the pose the
+// editor OPENED at, so moving the camera cannot change the film) and by requiring the chosen pixel
+// to clear every handle. Measured after: 4/4.
+const HANDLE_CLEAR_PX = 26;
+
+async function lookCloser(page) {
+  await page.evaluate(() => {
+    const A = window.APP, hs = A.cinemaPathEditor._probeHandles ? A.cinemaPathEditor._probeHandles() : null;
+    if (!hs || !hs.length) return;
+    const mid = hs[Math.floor(hs.length / 2)];
+    A.controls.target.set(mid.x, mid.y, mid.z3);
+    A.camera.position.set(mid.x + 7, mid.y + 6, mid.z3 + 7);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+  });
+  await sleep(700);
+}
+
 async function findPipePixel(page) {
   const tried = [];
-  for (let f = 0.10; f <= 0.90; f += 0.02) {
-    const spot = await page.evaluate((f) => {
+  await lookCloser(page);
+  for (let f = 0.02; f <= 0.98; f += 0.01) {
+    const spot = await page.evaluate((f, clear) => {
       const cpe = window.APP.cinemaPathEditor;
       if (!cpe || !cpe._pipePixel || !cpe._probePipe) return { why: 'no hook' };
       const p = cpe._pipePixel(f);
       if (!p) return { why: 'behind camera' };
       if (!cpe._probePipe(p.x, p.y)) return { why: 'hit test missed its own point' };
+      if (cpe._probeHandles) {
+        let near = 1e9;
+        (cpe._probeHandles() || []).forEach(function(h) {
+          if (h.px != null) near = Math.min(near, Math.hypot(h.px - p.x, h.py - p.y));
+        });
+        if (near < clear) return { why: 'handle ' + near.toFixed(0) + 'px (a handle wins the grab)' };
+      }
       // ⚠ The hit test is pure maths and does not know about occlusion. The CPE panel is a DOM
       // element floating over the canvas, so a pixel that is mathematically on the pipe can still
       // deliver its pointerdown to the panel — measured 2026-07-29: every gesture at the walk's
@@ -70,7 +103,7 @@ async function findPipePixel(page) {
         return { why: 'topmost is <' + (el ? el.tagName + (el.id ? '#' + el.id : '') : 'null') + '>, not APP.canvas' };
       }
       return { px: p.x, py: p.y, frac: f };
-    }, f);
+    }, f, HANDLE_CLEAR_PX);
     if (spot && spot.px !== undefined) return spot;
     if (spot && spot.why) tried.push(f.toFixed(2) + ':' + spot.why);
   }
@@ -136,9 +169,13 @@ async function gates(browser, BLD) {
     `§CPE_STICK added=${count(win, /§CPE_STICK added/)}`);
 
   // ── G-CS-4: a 0px press still spawns, and pushes no dead undo step ──────────────────────────
+  // Re-find the pixel: G-CS-2 just BENT the pipe 20px away from `spot`, so re-using it presses on
+  // empty space and the gate reads as a product failure (measured 2026-07-31, the last RED of the
+  // four). The pipe moving is the thing G-CS-2 proves — the coordinate has to move with it.
+  const spot4 = await findPipePixel(page) || spot;
   const n4 = await bandCount(page);
   mark = logs.length;
-  await gesture(page, spot.px, spot.py, 0);
+  await gesture(page, spot4.px, spot4.py, 0);
   win = logs.slice(mark);
   const n5 = await bandCount(page);
   P('G-CS-4 a 0px press spawns the stick too (the original gesture still works)',

--- a/witness_cpe_reopen_node.js
+++ b/witness_cpe_reopen_node.js
@@ -1,0 +1,257 @@
+// WITNESS — §CPE_REOPEN_NODE: the node you added survives OK, and you can SEE which node is yours.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_REOPEN_NODE.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, 2026-07-31: "i can hardly pick out the extra node
+// without been listed" / "the new nodes has to be darker blue when not selected to stand out"):
+// `finish('ok')` handed the override to the bake (cinema_maxq.js:624) and staged NOTHING. The next
+// Alt+C planned with no override (cinema_maxq.js:494 -> effects.js:6466 -> A._cinemaPathEdit null ->
+// plan.bands null), so cinema_path_editor.js:1454 `authored` was false and the editor RE-SEEDED the
+// derived three. The added stick was not hidden from the list — it no longer existed. And while it
+// did exist it was drawn identically to a seeded band (white bar, white mid, 0x4fc3f7 ends), so it
+// could not be picked out of the pipe either.
+//
+//   G-RN-1  RED on origin/main. Spawn a stick (rows N -> N+1), OK, re-open Alt+C: the panel lists
+//           N+1 rows and the log says `§CPE_OPEN src=authored bands=N+1`. Today: `src=seeded bands=3`.
+//   G-RN-2  Guardrail 2 intact: OK with NO edit stages nothing (`A._getCinemaPathEdit()` stays null)
+//           and the next open is still `src=seeded`. An untouched OK must not silently pin a path.
+//   G-RN-3  Provenance is CARRIED, not guessed from the index: after the re-open, exactly ONE row
+//           has a × and it is the row the stick was dropped at — not every middle row.
+//   G-RN-4  Colour by provenance, read off the REAL handle meshes (CLAUDE.md FUNDAMENTAL LAW —
+//           numbers, never a screenshot): every unheld handle of the stick is 0x1565c0, seeded bands
+//           keep 0xffffff mid / 0x4fc3f7 ends, and grabbing the stick turns its held handle 0xff8c00.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8437;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const count = (logs, re) => logs.filter(l => re.test(l)).length;
+const last = (logs, re) => { const h = logs.filter(l => re.test(l)); return h.length ? h[h.length - 1] : ''; };
+
+async function newPage(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  return { page, logs };
+}
+
+// The REAL entry: Alt+C's own code path with the editor armed. Retried, because a bake left running
+// from a previous OK makes start() a cancel request instead (cinema_maxq.js:420) — the retry both
+// waits it out and is what accelerates it.
+async function openEditor(page, tries = 8) {
+  for (let t = 0; t < tries; t++) {
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, frames: 4, editor: true }); });
+    try {
+      await page.waitForSelector('#cpe-ok', { timeout: 20000 });
+      await sleep(800);
+      return true;
+    } catch (e) { await sleep(2500); }
+  }
+  return false;
+}
+
+// GRAB_PX is 18: a handle wins the pointerdown over the pipe, so a pixel that is on the pipe AND
+// within 18px of a band handle is a rotate/translate gesture, not a click. Measured, not assumed —
+// the first run of this witness picked frac 0.10, landed on band 0's end handle, and reported
+// "rows 3 -> 3" as a product failure that was really a harness failure.
+const HANDLE_CLEAR_PX = 26;
+
+// The editor opens at the pre-dive orbit pose, from which Duplex's whole 15m walk projects into a
+// ~30px smear — every pixel of it inside a band handle's 18px grab radius, so there is no pixel at
+// which a click could ever reach the pipe (measured: nearest handle 0-3px across the first half of
+// the walk). Looking closer is explicitly free: §CPE_PREVIEW_DIVERGENCE pins every re-plan to the
+// pose the editor OPENED at, so moving the camera to see cannot change the film. This is the
+// witness getting its eye close enough to click, not a product setting.
+async function lookCloser(page) {
+  const ok = await page.evaluate(() => {
+    const A = window.APP, hs = A.cinemaPathEditor._probeHandles();
+    if (!hs || !hs.length) return false;
+    const mid = hs[Math.floor(hs.length / 2)];
+    A.controls.target.set(mid.x, mid.y, mid.z3);
+    A.camera.position.set(mid.x + 7, mid.y + 6, mid.z3 + 7);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+    return true;
+  });
+  await sleep(700);
+  return ok;
+}
+
+async function findPipePixel(page) {
+  const diag = [];
+  for (let f = 0.02; f <= 0.98; f += 0.01) {
+    const spot = await page.evaluate((f, clear) => {
+      const cpe = window.APP.cinemaPathEditor;
+      if (!cpe || !cpe._pipePixel || !cpe._probePipe) return null;
+      const p = cpe._pipePixel(f);
+      if (!p || !cpe._probePipe(p.x, p.y)) return null;
+      const hs = cpe._probeHandles() || [];
+      let near = 1e9;
+      for (const h of hs) {
+        if (h.px == null) continue;
+        near = Math.min(near, Math.hypot(h.px - p.x, h.py - p.y));
+      }
+      if (near < clear) return { why: 'handle ' + near.toFixed(0) + 'px' };
+      // The panel floats over the canvas: a pixel that is mathematically on the pipe can still
+      // deliver its pointerdown to the panel (measured 2026-07-29, §CPE_CLICK_SLOP).
+      if (document.elementFromPoint(p.x, p.y) !== window.APP.canvas) return null;
+      return { px: p.x, py: p.y, frac: f };
+    }, f, HANDLE_CLEAR_PX);
+    if (spot && spot.px !== undefined) return spot;
+    if (spot && spot.why) diag.push(f.toFixed(2) + ':' + spot.why);
+  }
+  console.log('        no usable pipe pixel — ' + diag.slice(0, 10).join(', ') + (diag.length ? '' : '(nothing hit the pipe at all)'));
+  return null;
+}
+
+// §CPE_CLICK_SLOP: a 2px grab is a CLICK, and a click on the pipe spawns a stick.
+async function clickPipe(page, px, py) {
+  await page.mouse.move(px, py);
+  await page.mouse.down();
+  await page.mouse.move(px + 2, py);
+  await sleep(60);
+  await page.mouse.up();
+  await sleep(900);
+}
+
+const rows = page => page.evaluate(() => {
+  const out = [];
+  document.querySelectorAll('#cpe-rows > div').forEach((d, i) => {
+    const btns = Array.from(d.querySelectorAll('button')).map(b => b.textContent.trim());
+    const lbl = d.querySelector('span');
+    out.push({ i, label: lbl ? lbl.textContent : '', removable: btns.indexOf('×') >= 0,
+               border: d.style.borderLeftColor, labelColor: lbl ? lbl.style.color : '' });
+  });
+  return out;
+});
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+  // ══ session 1: spawn a stick, look at it, OK ═══════════════════════════════════════════════
+  const { page, logs } = await newPage(browser, BLD);
+  if (!await openEditor(page)) { P('G-RN-0 the editor opens', false, 'no #cpe-ok — INCONCLUSIVE'); await page.close(); return checks; }
+  await lookCloser(page);
+  const spot = await findPipePixel(page);
+  if (!spot) { P('G-RN-0 the fat pipe is reachable on screen', false, 'no usable pipe pixel — INCONCLUSIVE'); await page.close(); return checks; }
+
+  const r0 = await rows(page);
+  let mark = logs.length;
+  await clickPipe(page, spot.px, spot.py);
+  const r1 = await rows(page);
+  const stickAt = r1.findIndex(r => r.removable);
+  P('G-RN-1a a click on the pipe spawns exactly one stick, listed immediately',
+    r1.length === r0.length + 1 && count(logs.slice(mark), /§CPE_STICK added/) === 1,
+    `rows ${r0.length} -> ${r1.length}   stick at row ${stickAt}   label="${r1[stickAt] ? r1[stickAt].label : '-'}"`);
+
+  // ── G-RN-4: colour off the real meshes, before anything is grabbed ─────────────────────────
+  const h1 = await page.evaluate(() => window.APP.cinemaPathEditor._probeHandles());
+  const sIdx = stickAt;
+  const mine = h1.filter(h => h.b === sIdx);
+  const others = h1.filter(h => h.b !== sIdx);
+  const okStick = mine.length === 3 && mine.every(h => h.hex === '0x1565c0' && h.stick);
+  const okOther = others.every(h => !h.stick && (h.z === 'mid' ? h.hex === '0xffffff' : h.hex === '0x4fc3f7'));
+  P('G-RN-4a an unselected stick is dark blue; seeded bands keep their colours',
+    okStick && okOther,
+    `stick handles=[${mine.map(h => h.z + ':' + h.hex).join(' ')}]   ` +
+    `seeded=[${others.map(h => h.z + ':' + h.hex).join(' ')}]`);
+
+  // grab the stick's middle handle — held-orange must still win over the new blue
+  const mid = mine.find(h => h.z === 'mid');
+  let heldHex = 'n/a', okHeld = false;
+  if (mid && mid.px != null) {
+    await page.mouse.move(mid.px, mid.py);
+    await page.mouse.down();
+    await sleep(500);
+    const h2 = await page.evaluate(() => window.APP.cinemaPathEditor._probeHandles());
+    const held = h2.filter(h => h.b === sIdx && h.z === 'mid')[0];
+    heldHex = held ? held.hex : 'missing';
+    okHeld = !!held && held.hex === '0xff8c00';
+    await page.mouse.up();
+    await sleep(600);
+  }
+  P('G-RN-4b grabbing the stick still turns it held-orange (selection stays the loudest state)',
+    okHeld, `held mid handle = ${heldHex} (want 0xff8c00)`);
+
+  // ── OK, then re-open through the real Alt+C entry ──────────────────────────────────────────
+  mark = logs.length;
+  await page.click('#cpe-ok');
+  await sleep(2500);
+  const staged = await page.evaluate(() => {
+    const ov = window.APP._getCinemaPathEdit ? window.APP._getCinemaPathEdit() : null;
+    return ov && ov.bands ? { bands: ov.bands.length, sticks: ov.bands.filter(b => b._stick).length } : null;
+  });
+  P('G-RN-1b an edited OK stages the path (the seam the whole defect turned on)',
+    !!staged && staged.bands === r1.length && staged.sticks === 1,
+    `A._cinemaPathEdit = ${staged ? `bands=${staged.bands} sticks=${staged.sticks}` : 'null'}   ` +
+    `${last(logs.slice(mark), /§CPE_OK_STAGED/) || 'no §CPE_OK_STAGED'}`);
+
+  mark = logs.length;
+  const reopened = await openEditor(page);
+  const r2 = reopened ? await rows(page) : [];
+  const openLine = last(logs.slice(mark), /§CPE_OPEN /);
+  P('G-RN-1 the added node is STILL THERE on re-open, and it is in the list',
+    reopened && r2.length === r1.length && /src=authored/.test(openLine),
+    `rows ${r1.length} -> ${r2.length}   ${openLine || 'no §CPE_OPEN line'}`);
+  P('G-RN-3 provenance is carried, not guessed: exactly ONE removable row, at the same index',
+    r2.filter(r => r.removable).length === 1 && r2.findIndex(r => r.removable) === stickAt,
+    `removable rows=[${r2.map((r, i) => r.removable ? i : null).filter(v => v !== null).join(',')}]   ` +
+    `want [${stickAt}]   labels=[${r2.map(r => r.label).join(' | ')}]`);
+  P('G-RN-3c only the node the USER dropped is called a stick — the derived middle keeps its own name',
+    r2.filter(r => /^stick/.test(r.label)).length === 1 && r2.some(r => r.label === 'exit door'),
+    `labels=[${r2.map(r => r.label).join(' | ')}]   want exactly one "stick …"`);
+  const blueRow = r2[stickAt];
+  P('G-RN-3b the list carries the same blue cue as the pipe',
+    !!blueRow && /rgb\(21, *101, *192\)/.test(blueRow.border || ''),
+    `row ${stickAt} border=${blueRow ? blueRow.border : '-'} label=${blueRow ? blueRow.labelColor : '-'}`);
+  await page.close();
+
+  // ══ session 2: G-RN-2 — an untouched OK must stage nothing ════════════════════════════════
+  const s2 = await newPage(browser, BLD);
+  if (!await openEditor(s2.page)) {
+    P('G-RN-2 untouched OK stages nothing', false, 'editor did not open — INCONCLUSIVE');
+  } else {
+    let m2 = s2.logs.length;
+    await s2.page.click('#cpe-ok');
+    await sleep(2500);
+    const st2 = await s2.page.evaluate(() => (window.APP._getCinemaPathEdit ? window.APP._getCinemaPathEdit() : 'no hook'));
+    const re2 = await openEditor(s2.page);
+    const line2 = last(s2.logs.slice(m2), /§CPE_OPEN /);
+    P('G-RN-2 Guardrail 2: an untouched OK stages nothing and the next open is still derived',
+      st2 === null && re2 && /src=seeded/.test(line2) && count(s2.logs.slice(m2), /§CPE_OK_STAGED/) === 0,
+      `_cinemaPathEdit=${JSON.stringify(st2)}   ${line2 || 'no §CPE_OPEN'}   ` +
+      `§CPE_OK_STAGED=${count(s2.logs.slice(m2), /§CPE_OK_STAGED/)}`);
+  }
+  await s2.page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+  }
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
fix(cinema): §CPE_REOPEN_NODE — the added node survives OK, and an unselected stick is dark blue

User, 2026-07-31: "the new nodes has to be darker blue when not selected to stand out, but if the
listing has the new node, it be easier to spot" / "i can hardly pick out the extra node without
been listed".

ROOT CAUSE of the listing half — and it is NOT the dropdown-Open path the last four sessions were
chasing for a §CPE_PATH_LOADED log that was never going to exist (that line only fires in
_pathsApply, the `saved ▾ open` button; the user's "opening" is Alt+C again):

  cinema_path_editor.js:1637  stageCinemaPath() is called from `Save this path` ONLY
  cinema_path_editor.js:1631  OK -> finish('ok') resolves the override and stages NOTHING
  cinema_maxq.js:624          that override bakes THIS film, then is dropped
  cinema_maxq.js:494          the next Alt+C plans with no ov at all
  effects.js:6466             ov undefined -> A._cinemaPathEdit -> null
  effects.js:6342             plan.bands = null
  cinema_path_editor.js:1454  authored=false -> _cinemaSeedBands -> back to the derived 3

So the stick was not missing from the list — it no longer existed, and the evidence was in every
log already pasted: `§CPE_OPEN src=seeded bands=3`.

Fixes:
- an EDITED OK stages the override (Guardrail 2 intact: an untouched OK stages nothing; Cancel
  stages nothing; in-memory only, the cinema_path table is still Ctrl+S's job). New §CPE_OK_STAGED.
- provenance travels instead of being guessed: _buildOverride carries `_stick`/`_s`, effects.js's
  plan echo carries them, and _pathsApply/open() read the stored flag with the old index rule as
  the fallback for records saved before this.
- an unselected stick draws its bar and all three handles in 0x1565c0; held-orange still wins.
  Its row gets the matching blue border/label tint, and only a node the USER dropped is called a
  "stick" — the derived middle is "exit door" again (a list used to read
  `settle | stick @ 15% | stick | stop`).

WITNESSED — witness_cpe_reopen_node.js, Duplex 9/9 (`PORT=8437 node witness_cpe_reopen_node.js`).
RED on origin/main with the read-only probe hook alone: 3/9, `rows 4 -> 3`,
`§CPE_OPEN src=seeded bands=3`, `_cinemaPathEdit=null`. Colour asserted off the real handle
meshes via a new read-only _probeHandles(), never a screenshot.

Regressions: witness_cinema_path_editor.js 7/9 — IDENTICAL on origin/main (G7/G10 pre-existing,
§CPE_AIM_DEPTH lane); G1 OK-without-edit byte-identity maxPoseDiff=0 both sides.

Also repairs witness_cpe_click_slop.js, which was 1/4 on origin/main too (harness rot, never a
product regression): the editor opens at the orbit pose where Duplex's whole walk projects into a
~30px smear entirely inside the handles' GRAB_PX=18 radius, so every gesture resolved to a handle
drag; and G-CS-4 re-used a pixel that G-CS-2 had just bent the pipe away from. Now 4/4.

Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_REOPEN_NODE.
viewer sw CACHE_VERSION v889 -> v890 (precached viewer/ files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)