### PR TITLE
fix(seams): F2 IDB cache version drift — 4D/5D re-download + ERP persist loss

### DIFF
--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -130,12 +130,28 @@
       var myTip = _lastSealedTip(db).hash;
       var buf = db.export().buffer;
       return new Promise(function(resolve) {
-        var req = indexedDB.open('bim_ootb_cache', 1);
-        req.onupgradeneeded = function() { req.result.createObjectStore('dbs'); };
-        req.onerror = function() { console.warn('§KRN_PERSIST_ERR open failed'); resolve(); };
-        req.onsuccess = function() {
+        // §KRN_PERSIST_FIX (F2, SEAM_IDENTITY_AUDIT.md) — mirrors viewer/kernel_ops.js's proven fix.
+        // The old hardcoded indexedDB.open('bim_ootb_cache', 1) drifted BELOW scene.js's v2 opener →
+        // every open fired onerror (VersionError), onsuccess never ran, and the ERP op-log was
+        // silently never persisted ("survive refresh" was dead). Route through the app's SINGLE
+        // opener (version 2, guards the store) when present; else an unversioned open (whatever
+        // version is actually stored — never throws VersionError) for a standalone ERP page.
+        var openP = (typeof window !== 'undefined' && window.APP && APP.openCacheDB)
+          ? APP.openCacheDB()
+          : new Promise(function(res) {
+              var rq = indexedDB.open('bim_ootb_cache');   // no version → current
+              rq.onupgradeneeded = function() {
+                var d = rq.result;
+                if (!d.objectStoreNames.contains('dbs')) d.createObjectStore('dbs');
+              };
+              rq.onsuccess = function() { res(rq.result); };
+              rq.onerror = function() { console.warn('§KRN_PERSIST_ERR open failed'); res(null); };
+            });
+        openP.then(function(idb) {
+          if (!idb) { resolve(); return; }
           try {
-            var store = req.result.transaction('dbs', 'readwrite').objectStore('dbs');
+            if (!idb.objectStoreNames.contains('dbs')) { console.warn('§KRN_PERSIST_ERR no dbs store'); resolve(); return; }
+            var store = idb.transaction('dbs', 'readwrite').objectStore('dbs');
             var tipKey = dbUrl + '::tip';
             var getReq = store.get(tipKey);
             var writeAndDone = function() {
@@ -155,7 +171,7 @@
             };
             getReq.onerror = function() { writeAndDone(); };   // fail-open (no worse than today)
           } catch(e) { console.warn('§KRN_PERSIST_ERR', e); resolve(); }
-        };
+        }).catch(function(e) { console.warn('§KRN_PERSIST_ERR open ' + (e && e.message)); resolve(); });
       });
     }).catch(function(e) { console.warn('§KRN_SEAL_ERR', e); });
   }

--- a/tests/witness_idb_cache_version_drift.js
+++ b/tests/witness_idb_cache_version_drift.js
@@ -1,0 +1,63 @@
+// WITNESS: F2 (prompts/SEAM_IDENTITY_AUDIT.md) — "four modules still open the shared cache DB at
+// hardcoded version 1 (canonical is 2)". Proves the exact failure mechanism numerically (no browser,
+// no screenshot): once the shared bim_ootb_cache IndexedDB is at v2 (scene.js's canonical opener,
+// which is how it looks in any real profile after the Viewer has been opened once), a hardcoded
+// open(name, 1) throws VersionError forever — this is what made boq_charts.html's 4D/5D charts
+// always miss the offline cache (full network re-download every open) and erp/kernel_ops.js's
+// _idbPersist silently drop every ERP edit (never survives a refresh).
+//
+// Issue proved: OLD code (open(name, 1) after DB is at v2) → VersionError → cacheDb resolves null.
+// Issue disproved for the fix: NEW code (open(name) — no version) → succeeds, reads back what v2 wrote.
+require('fake-indexeddb/auto');
+
+function log(s) { console.log(s); }
+
+async function openAtVersion(name, version) {
+  return new Promise((resolve) => {
+    const req = version == null ? indexedDB.open(name) : indexedDB.open(name, version);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains('dbs')) req.result.createObjectStore('dbs');
+    };
+    req.onsuccess = () => resolve({ ok: true, db: req.result });
+    req.onerror = () => resolve({ ok: false, err: req.error && req.error.name });
+  });
+}
+
+(async () => {
+  const DB = 'bim_ootb_cache_witness';
+
+  // Step 1: simulate scene.js's canonical opener — bumps the shared DB to v2, writes a value.
+  const v2 = await openAtVersion(DB, 2);
+  log('§W1 scene.js-style open(name,2): ok=' + v2.ok + ' version=' + v2.db.version);
+  await new Promise((resolve) => {
+    const tx = v2.db.transaction('dbs', 'readwrite');
+    tx.objectStore('dbs').put(new ArrayBuffer(8), 'buildings/Hospital_extracted.db');
+    tx.oncomplete = resolve;
+  });
+  v2.db.close();
+
+  // Step 2: OLD boq_charts.html / erp/kernel_ops.js behaviour — hardcoded open(name, 1).
+  const oldOpen = await openAtVersion(DB, 1);
+  const oldBroken = oldOpen.ok === false && oldOpen.err === 'VersionError';
+  log('§W2 OLD hardcoded open(name,1): ok=' + oldOpen.ok + ' err=' + oldOpen.err +
+      '  → matches-reported-bug=' + oldBroken);
+
+  // Step 3: NEW fixed behaviour — open(name) with no version, as applied in this commit.
+  const newOpen = await openAtVersion(DB, null);
+  let readBack = null;
+  if (newOpen.ok) {
+    readBack = await new Promise((resolve) => {
+      const tx = newOpen.db.transaction('dbs', 'readonly');
+      const req = tx.objectStore('dbs').get('buildings/Hospital_extracted.db');
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => resolve(null);
+    });
+  }
+  log('§W3 NEW versionless open(name): ok=' + newOpen.ok +
+      ' readBackCachedEntry=' + (readBack !== null) +
+      '  → offline-cache-hit-restored=' + (newOpen.ok && readBack !== null));
+
+  const pass = oldBroken && newOpen.ok && readBack !== null;
+  log('§WITNESS_RESULT F2_idb_version_drift ' + (pass ? 'PASS' : 'FAIL'));
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/boq_charts.html
+++ b/viewer/boq_charts.html
@@ -722,8 +722,12 @@ function audit4DSchedule(scheduleData, db, qtoData) {
 async function peekDbCache(url) {
   try {
     const cacheDb = await new Promise(resolve => {
-      const req = indexedDB.open('bim_ootb_cache', 1);
-      req.onupgradeneeded = () => req.result.createObjectStore('dbs');
+      // §KRN_PERSIST_FIX (F2, SEAM_IDENTITY_AUDIT.md): no version arg → opens at whatever version
+      // is actually stored (scene.js's canonical opener is v2+). A hardcoded v1 here throws
+      // VersionError forever once scene.js has run in the profile, so this always fell through to
+      // resolve(null) and forced a full network re-download of the building on every 4D/5D open.
+      const req = indexedDB.open('bim_ootb_cache');
+      req.onupgradeneeded = () => { if (!req.result.objectStoreNames.contains('dbs')) req.result.createObjectStore('dbs'); };
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => resolve(null);
     });
@@ -742,8 +746,9 @@ async function peekDbCache(url) {
 async function fetchDbBuffer(url) {
   const _tFetch = performance.now();
   const cacheDb = await new Promise(resolve => {
-    const req = indexedDB.open('bim_ootb_cache', 1);
-    req.onupgradeneeded = () => req.result.createObjectStore('dbs');
+    // §KRN_PERSIST_FIX (F2, SEAM_IDENTITY_AUDIT.md) — same fix as peekDbCache() above.
+    const req = indexedDB.open('bim_ootb_cache');
+    req.onupgradeneeded = () => { if (!req.result.objectStoreNames.contains('dbs')) req.result.createObjectStore('dbs'); };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => resolve(null);
   });


### PR DESCRIPTION
## Summary
- `boq_charts.html` and `erp/kernel_ops.js` hardcoded `indexedDB.open('bim_ootb_cache', 1)` while `scene.js`'s canonical opener runs at v2 — once a profile's cache DB is at v2, these throw `VersionError` forever.
- Symptom 1: 4D/5D charts' offline-read path silently fell through to a full network re-download of the building on every open.
- Symptom 2: ERP's debounced IDB persist silently dropped every edit — nothing survived a refresh.
- Documented as F2 in `prompts/SEAM_IDENTITY_AUDIT.md` (pass-1, list-only, never fixed until now).

## Fix
- `boq_charts.html`: drop the hardcoded version (opens at whatever version is actually stored — the same idiom already used elsewhere in the codebase).
- `erp/kernel_ops.js`: mirror `viewer/kernel_ops.js`'s proven fix — route through `APP.openCacheDB()` when present, else a versionless fallback open.

## Test plan
- [x] `node -c erp/kernel_ops.js` — syntax OK
- [x] Inline scripts in `boq_charts.html` parse OK
- [x] `tests/witness_idb_cache_version_drift.js` — deterministic witness (fake-indexeddb, no browser): reproduces `VersionError` on the old hardcoded `open(name, 1)` after the DB is at v2, and proves the new versionless open succeeds and reads back the cached entry. `PASS`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>