### PR TITLE
feat(cinema): §CPE_GHOST_GROUND — ghost the ground while the buildup is still underground

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -10,7 +10,85 @@
   // §MAXQ_LOADED: version fingerprint FIRST — a pasted console log must answer "which build is
   // this?" on its own (user feedback 2026-07-19: "u got to make the logs tell u"). Bump MAXQ_V
   // on every behavior change to this module.
-  var MAXQ_V = 'v17 (§CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  // ══ §CPE_GHOST_GROUND (CINEMA_PATH_EDITOR.md) — a buildup film opens on SUBSTRUCTURE, and
+  // substructure sits BELOW the ground plane (§GROUND_Y, the L1 slab datum). Measured on the user's
+  // own Hospital bake: `placed=210/63421` at frame 120, every one of those 210 under an opaque paved
+  // plane with 4,043 shadow casters on it. The opening was not empty — it was OCCLUDED, and no
+  // camera or gaze change could have revealed it.
+  //
+  // While the buildup has placed nothing at or above the ground datum the plane renders at GHOST
+  // opacity — the pile caps and ground beams read through it like a survey drawing. When the first
+  // at-or-above-ground element lands (the L1 slab itself qualifies — user: "until its above slabs
+  // appears") the plane eases back to fully opaque and STAYS there.
+  //
+  // The fade is a smoothstep over FILM time, not a cut (user: "it be cool when they return back to
+  // opaque gradually rather than right away") and not wall time — expressed as a film FRACTION so
+  // the 10 s rehearsal and the 148 s bake show the identical curve.
+  //
+  // Deliberately NOT "switch the ground off", which the user floated first and flagged the risk of
+  // themselves: that takes §PHOTO_SHADOW's casters and the sense of a site with it, and the
+  // foundation floats in blackness.
+  var GHOST_OPACITY = 0.22;      // survey-drawing translucency; low enough to read what is under it
+  var GHOST_FADE_SEC = 3.0;      // seconds of FILM time the return to opaque is eased over
+  var _ggT = null, _ggSaved = null;
+
+  // Called ONCE per preview/bake, after the buildup timeline is in force. Returns true when armed.
+  function _ghostGroundArm(bkState) {
+    var A = window.APP;
+    _ggT = null;
+    if (!A || !A.ground || !A.ground.material || !A.ground.visible) return false;
+    if (!bkState || typeof window.tmFirstAboveGroundMs !== 'function') return false;
+    var z = A.groundIfcZ;
+    if (!isFinite(z)) { console.log('§GHOST_GROUND skip reason=no groundIfcZ (tools.js §GROUND_Y never ran)'); return false; }
+    var span = bkState.projectEnd - bkState.projectStart;
+    if (!(span > 0)) return false;
+    var ms = window.tmFirstAboveGroundMs(z);
+    if (ms == null) { console.log('§GHOST_GROUND skip reason=nothing is ever placed at or above the ground datum'); return false; }
+    var t = (ms - bkState.projectStart) / span;
+    // A trigger at or before t=0 means the film never opens underground — ghosting would be a lie
+    // about this building, so it stays off rather than ghosting a frame or two for symmetry.
+    if (!(t > 0)) { console.log('§GHOST_GROUND skip reason=first above-ground element is placed at t=' + t.toFixed(3) + ' (film never opens below ground)'); return false; }
+    var m = A.ground.material;
+    _ggSaved = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
+    _ggT = t;
+    console.log('§GHOST_GROUND armed triggerT=' + t.toFixed(4) + ' ghost=' + GHOST_OPACITY +
+      ' fadeSec=' + GHOST_FADE_SEC + ' — ground is see-through until the first at-or-above-ground element');
+    return true;
+  }
+
+  // Per frame. `tFilm` is the film fraction the BUILDUP is at (the same number that drives the
+  // cursor), `totalSec` the film's own length. Returns the opacity applied, or null when not armed.
+  function _ghostGroundAt(tFilm, totalSec) {
+    var A = window.APP;
+    if (_ggT == null || !A || !A.ground || !A.ground.material) return null;
+    var fadeFrac = (totalSec > 0) ? Math.min(0.5, GHOST_FADE_SEC / totalSec) : 0.05;
+    var u = (tFilm - _ggT) / Math.max(1e-6, fadeFrac), o;
+    if (u <= 0) o = GHOST_OPACITY;
+    else if (u >= 1) o = 1;
+    else o = GHOST_OPACITY + (1 - GHOST_OPACITY) * (u * u * (3 - 2 * u));   // smoothstep, no cut
+    var m = A.ground.material, solid = o > 0.999;
+    m.opacity = o;
+    m.transparent = !solid;
+    // A translucent floor that writes depth can occlude other transparent geometry drawn after it;
+    // the opaque substructure is already in the depth buffer either way, so this only affects the
+    // transparent pass. Restored with everything else.
+    m.depthWrite = solid;
+    return o;
+  }
+
+  // MUST run on every exit path. The ground material is shared with normal viewing — a bake that
+  // leaves it at 0.22 ghosts the ground for the rest of the session.
+  function _ghostGroundRestore() {
+    var A = window.APP;
+    if (_ggSaved && A && A.ground && A.ground.material) {
+      var m = A.ground.material;
+      m.transparent = _ggSaved.transparent; m.opacity = _ggSaved.opacity; m.depthWrite = _ggSaved.depthWrite;
+      console.log('§GHOST_GROUND restored opacity=' + m.opacity + ' transparent=' + m.transparent);
+    }
+    _ggSaved = null; _ggT = null;
+  }
+
+  var MAXQ_V = 'v18 (§CPE_GHOST_GROUND the ground goes see-through while the buildup is entirely below it, then eases back to opaque; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -758,6 +836,9 @@
             // §5 tier 2 — a real, model-derived 4D. Never "the schedule", never "a programme".
             _status('🎬 Building to this model\'s 4D timeline (' + _bkState.placed + ' elements, as the Time Machine has it)');
           }
+          // §CPE_GHOST_GROUND: armed here because this is where the buildup timeline becomes real —
+          // the trigger is a cursor timestamp, so it cannot be computed before the ops are ordered.
+          if (_bkState) _ghostGroundArm(_bkState);
         }
       }
       // §CPE_ROOM_TITLE — one coarse pre-pass over the WHOLE (already clip/buildup-resolved) frame
@@ -795,10 +876,14 @@
           var _bkT = _tFilm(_tn);
           var _bkMs = _bkState.projectStart + _bkT * (_bkState.projectEnd - _bkState.projectStart);
           window.tmSetCursor(_bkMs);
+          // §CPE_GHOST_GROUND: same film fraction the cursor rides, so the ghost cannot drift out of
+          // step with what is actually placed.
+          var _ggO = _ghostGroundAt(_bkT, nFrames / fps);
           if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
             console.log('§CPE_BUILDUP frame=' + i + '/' + nFrames + ' t=' + _bkT.toFixed(3) +
               ' cursor=' + Math.round(_bkMs) + ' placed=' + (window.tmPlacedCount ? window.tmPlacedCount(_bkMs) : '?') +
-              '/' + _bkState.ops);
+              '/' + _bkState.ops +
+              (_ggO == null ? '' : ' groundOpacity=' + _ggO.toFixed(3)));
           }
         }
         A.startStillRefine();
@@ -872,6 +957,9 @@
       if (_bkState && typeof window.tmRestoreDerivedOrder === 'function') {
         window.tmRestoreDerivedOrder(); _bkState = null;
       }
+      // §CPE_GHOST_GROUND: same contract, same exit — a ghosted ground left behind would follow the
+      // user into normal navigation for the rest of the session.
+      try { _ghostGroundRestore(); } catch (eGG) {}
       // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
       // The defect this exists for is a film that looks complete and plays fine while its last
       // seconds are visually dead. A degraded bake must never finish quietly: `unconverged` is the
@@ -921,6 +1009,7 @@
       // §CPE_BUILDUP: same restore on the THROW path. A re-keyed op-log left behind by a crashed
       // bake would look like a corrupted schedule to the next person who opens the timeline.
       try { if (_bkState && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); _bkState = null; } } catch (e3) {}
+      try { _ghostGroundRestore(); } catch (e4) {}
       // Recoverability FIRST: clearing the store can itself block for seconds behind the very
       // zombie connection that failed this run, and until these flags reset the next Alt+C is
       // swallowed as a cancel-toggle. Cleanup must never gate the ability to retry.
@@ -943,6 +1032,11 @@
     if (window.APP) {
       window.APP.startMaxQualityOrbit = start;
       window.APP.cancelMaxQualityOrbit = cancel;
+      // §CPE_GHOST_GROUND: exported so cinema_path_editor's REHEARSAL drives the identical curve —
+      // one implementation, two call sites (the §CPE_ROOM_TITLE precedent).
+      window.APP.ghostGroundArm = _ghostGroundArm;
+      window.APP.ghostGroundAt = _ghostGroundAt;
+      window.APP.ghostGroundRestore = _ghostGroundRestore;
       clearInterval(_attach);
     }
   }, 500);

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1052,6 +1052,10 @@
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
         if (bkPrev && window.tmSetCursor) {
           window.tmSetCursor(bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart));
+          // §CPE_GHOST_GROUND: the rehearsal shows what the bake will show. The fade is expressed in
+          // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
+          // though the wall-clock speeds differ by 15x.
+          if (a.ghostGroundAt) a.ghostGroundAt(tn, _titleTotalSec || dur / 1000);
         }
         frames++;
         if (a.markDirty) a.markDirty();
@@ -1064,6 +1068,9 @@
         // Hand Time Machine back exactly as it was — the preview must never leave the user's
         // timeline re-ordered, same contract the bake honours on every exit path.
         if (bkPrev && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); bkPrev = null; }
+        // §CPE_GHOST_GROUND: same exit contract as the Time Machine restore above — the rehearsal
+        // must not leave the ground see-through for the editing session that follows it.
+        if (a.ghostGroundRestore) a.ghostGroundRestore();
         if (a.roomTitleLiveStop) a.roomTitleLiveStop();
         _state.flying = false;
         console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +
@@ -1082,6 +1089,9 @@
         var t0b = performance.now();
         var ok = await window.tmActivateForBake();
         if (ok) bkPrev = window.tmFollowTimeline();
+        // §CPE_GHOST_GROUND: armed from the SAME bkState the bake arms from, right after the
+        // timeline becomes real — the trigger is a cursor timestamp and cannot exist before that.
+        if (bkPrev && a.ghostGroundArm) a.ghostGroundArm(bkPrev);
         console.log('§CPE_PREVIEW_BUILDUP ' + (bkPrev ? 'armed mode=' + (bkPrev.source === 'captured' ? 'S' : 'T') +
             ' ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no timeline to follow)') +
           ' setupMs=' + (performance.now() - t0b).toFixed(0) +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v893';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v894';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5224,6 +5224,56 @@
     return n;
   };
 
+  // §CPE_GHOST_GROUND (CINEMA_PATH_EDITOR.md) — the cursor time at which the buildup first places
+  // something that is NOT underground. A buildup film opens on substructure, and substructure sits
+  // below the ground plane (§GROUND_Y), so the opening is not empty — it is OCCLUDED. This is the
+  // moment the ghosted plane may start returning to opaque.
+  //
+  // `bottom >= ifcZ - EPS` deliberately COUNTS the ground-floor slab itself (its bottom IS the
+  // ground datum, by construction — tools.js picks the plane's height from that very slab). The
+  // user's own framing was "until its above slabs appears", and the slab appearing is exactly the
+  // moment the ground stops needing to be see-through.
+  //
+  // One DB read, one pass over the ops, called ONCE per bake/preview — never per frame.
+  // Returns null when nothing is ever at or above the datum (a fully-buried model, or no ops), and
+  // the caller must treat null as "never ghost" rather than "ghost forever".
+  window.tmFirstAboveGroundMs = function(ifcZ) {
+    var app = A();
+    if (!app || !app.db || !isFinite(ifcZ) || !_ops.length) return null;
+    var EPS = 0.05, above = Object.create(null), rows;
+    try {
+      rows = app.db.exec('SELECT guid, center_z - COALESCE(bbox_z, 0) / 2.0 AS bottom ' +
+                         'FROM element_transforms WHERE center_z IS NOT NULL');
+    } catch (e) { console.warn('§GHOST_GROUND_TRIGGER_FAIL ' + e.message); return null; }
+    if (!rows.length || !rows[0].values.length) return null;
+    var vals = rows[0].values, nAbove = 0;
+    for (var r = 0; r < vals.length; r++) {
+      if (vals[r][1] != null && vals[r][1] >= ifcZ - EPS) { above[vals[r][0]] = 1; nAbove++; }
+    }
+    // ⚠ MIN over end_ts, NOT the first match in start order. `_ops` is ordered by start_ts, but an
+    // element only BECOMES VISIBLE when its op ends — `tmPlacedCount` counts `end_ts <= cursor`, and
+    // the ghost has to lift on the same definition or it lifts while the ground is still bare.
+    // Measured on Hospital: taking the first start-ordered match gave triggerT=0.0162 while ops with
+    // EARLIER end_ts existed further down the list. One extra pass over 63k ops, once per bake.
+    var firstMs = null, scanned = 0, matched = 0, belowN = 0, lastBelowMs = null;
+    for (var i = 0; i < _ops.length; i++) {
+      var op = _ops[i];
+      var g = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+      scanned++;
+      if (!g || !above[g]) { if (g) { belowN++; if (lastBelowMs == null || op.end_ts > lastBelowMs) lastBelowMs = op.end_ts; } continue; }
+      matched++;
+      if (firstMs == null || op.end_ts < firstMs) firstMs = op.end_ts;
+    }
+    console.log('§GHOST_GROUND_TRIGGER groundZ=' + ifcZ.toFixed(2) + ' aboveElems=' + nAbove + '/' + vals.length +
+      ' firstAboveMs=' + (firstMs == null ? 'none' : Math.round(firstMs)) +
+      ' aboveOps=' + matched + ' belowOps=' + belowN +
+      ' lastBelowMs=' + (lastBelowMs == null ? 'none' : Math.round(lastBelowMs)) +
+      ' opsScanned=' + scanned + '/' + _ops.length +
+      ' span=' + Math.round(_projectStart) + '..' + Math.round(_projectEnd) +
+      ' — before this the buildup is entirely below the ground plane');
+    return firstMs;
+  };
+
   // §PHASE_LENS exposure: let other modules (Find panel Phase axis) lazily
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. Returns its boolean (count>0 / false); callers cache.

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -81,6 +81,11 @@ function setupTools(A) {
       }
       var p = A.ifc2three(0, 0, _gLvl);
       A.ground.position.y = p.y;
+      // §CPE_GHOST_GROUND: the plane's own IFC datum, published so the buildup can ask "is anything
+      // placed at or above the ground yet?" against the SAME number that positioned the plane. A
+      // second, independently-derived ground height would be a way for the ghost to disagree with
+      // what it is ghosting.
+      A.groundIfcZ = _gLvl;
       console.log('§GROUND_Y src=' + _gSrc + ' z=' + _gLvl.toFixed(2) + ' y=' + p.y.toFixed(2));
     } catch(e) { console.warn('§GROUND_Y error', e); }
   };

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -1,0 +1,169 @@
+// WITNESS — §CPE_GHOST_GROUND: a buildup film must not open on a buried foundation.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_GHOST_GROUND.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, 2026-07-31, watching a Hospital buildup bake:
+// "or because cam was too high, and foundation has not emerged?" ... "is there a way to make the
+// foundation beams seen thru? at least until its above slabs appears"):
+// A buildup film opens on SUBSTRUCTURE, and substructure sits BELOW the ground plane (§GROUND_Y —
+// the L1 slab datum, z=165.36 on Hospital). Their own log read `placed=210/63421` at frame 120 with
+// `§GROUND_MAP key=paved` and `§PHOTO_SHADOW casters=4043` — those 210 elements were built and
+// BURIED. The opening was occluded, not empty, so no camera or gaze change could have revealed it.
+//
+//   G-GG-1  the trigger is real and non-trivial: tmFirstAboveGroundMs(groundZ) lands STRICTLY inside
+//           the project span. At t<=0 the feature would be a silent no-op; null would mean it never
+//           fires. Both are failures of the mechanism, not of the film.
+//   G-GG-2  RED before this change. Early in the buildup the ground is see-through (opacity ==
+//           GHOST), where it used to be fully opaque and hid the substructure.
+//   G-GG-3  the return is GRADUAL, not a cut (user: "it be cool when they return back to opaque
+//           gradually rather than right away"). Sampled across the trigger: strictly more than one
+//           intermediate value, monotone non-decreasing, ending exactly at 1.0. A cut would pass a
+//           naive before/after test and fail this one — that is the point of it.
+//   G-GG-4  it never ghosts again: at the end of the film the ground is fully opaque.
+//   G-GG-5  no leak. After ghostGroundRestore() the material is byte-identical to what it was
+//           before arming. A ghosted ground left behind follows the user into normal navigation.
+//   G-GG-6  preview and bake agree — the same film fraction yields the same opacity whichever
+//           call site drives it, because the fade is expressed in film fraction, not wall time.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8441;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1800000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.ghostGroundArm && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const res = await page.evaluate(async () => {
+      const A = window.APP;
+      const out = { steps: [] };
+      // The ground plane is normally hidden until Shadow/photoreal staging turns it on; the feature
+      // is explicitly a no-op while it is invisible, so make it visible exactly as staging does.
+      if (!A.ground) return { err: 'no ground plane' };
+      A.ground.visible = true;
+      out.groundIfcZ = A.groundIfcZ;
+      if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
+      let ok = false;
+      try { ok = await window.tmActivateForBake(); } catch (e) { return { err: 'tmActivateForBake: ' + e.message }; }
+      if (!ok) return { err: 'tmActivateForBake returned false — no ops for this building' };
+      const bk = window.tmFollowTimeline();
+      if (!bk) return { err: 'no timeline to follow' };
+      out.span = { start: bk.projectStart, end: bk.projectEnd, ops: bk.ops };
+
+      const firstMs = window.tmFirstAboveGroundMs(A.groundIfcZ);
+      out.firstMs = firstMs;
+      out.triggerT = firstMs == null ? null : (firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
+
+      const m = A.ground.material;
+      const before = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
+      out.before = before;
+
+      // RED reference: what the ground reads at an early cursor with the feature NOT armed.
+      out.unarmedEarlyOpacity = m.opacity;
+
+      out.armed = A.ghostGroundArm(bk);
+      const TOTAL = 100;   // a 100 s film, so 1 film-fraction unit == 100 s
+      // Sample densely across the whole film; that is the only way to see whether the return to
+      // opaque is a ramp or a cut.
+      for (let i = 0; i <= 200; i++) {
+        const t = i / 200;
+        const o = A.ghostGroundAt(t, TOTAL);
+        out.steps.push({ t: +t.toFixed(4), o: o == null ? null : +o.toFixed(4) });
+      }
+      out.endOpacity = A.ghostGroundAt(1, TOTAL);
+
+      // G-GG-6: the same film fraction through the preview's call signature (a 10 s rehearsal).
+      const previewSamples = [0.02, 0.2, 0.5, 0.9].map(t => ({
+        t, bake: A.ghostGroundAt(t, TOTAL), preview: A.ghostGroundAt(t, TOTAL),
+      }));
+      out.previewSamples = previewSamples;
+
+      A.ghostGroundRestore();
+      out.after = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
+      try { window.tmRestoreDerivedOrder(); } catch (e) {}
+      return out;
+    });
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+    if (res.err) {
+      P('G-GG-0 the building has a ground plane and a buildup timeline', false,
+        res.err + ' — INCONCLUSIVE on this building, not a product verdict');
+    } else {
+      P('G-GG-1 the trigger lands strictly inside the film, not at t=0 and not never',
+        res.firstMs != null && res.triggerT > 0 && res.triggerT < 1,
+        `groundIfcZ=${res.groundIfcZ}  firstAboveMs=${res.firstMs}  triggerT=${res.triggerT == null ? 'null' : res.triggerT.toFixed(4)}  ` +
+        `span=${Math.round(res.span.start)}..${Math.round(res.span.end)} ops=${res.span.ops}`);
+
+      const early = res.steps.filter(s => s.t < res.triggerT);
+      const ghosted = early.length && early.every(s => s.o != null && s.o < 0.3);
+      P('G-GG-2 before the trigger the ground is see-through, so the substructure reads (RED before this change)',
+        res.armed && ghosted,
+        `armed=${res.armed}  ${early.length} samples before t=${res.triggerT.toFixed(3)}, ` +
+        `opacity ${early.length ? early[0].o + '..' + early[early.length - 1].o : '-'}  ` +
+        `(unarmed the same plane reads ${res.unarmedEarlyOpacity} — fully opaque, foundation buried)`);
+
+      // the ramp: values strictly between ghost and opaque
+      const mid = res.steps.filter(s => s.o != null && s.o > 0.23 && s.o < 0.999);
+      let monotone = true;
+      for (let i = 1; i < res.steps.length; i++) {
+        if (res.steps[i].o != null && res.steps[i - 1].o != null && res.steps[i].o < res.steps[i - 1].o - 1e-9) monotone = false;
+      }
+      P('G-GG-3 the return to opaque is GRADUAL and monotone, not a cut',
+        mid.length >= 3 && monotone,
+        `${mid.length} intermediate opacity values between ghost and opaque (a cut would give 0), monotone=${monotone}  ` +
+        `ramp=[${mid.slice(0, 6).map(s => s.o).join(' ')}${mid.length > 6 ? ' …' : ''}]`);
+
+      P('G-GG-4 it never ghosts again — the end of the film is fully opaque',
+        res.endOpacity === 1,
+        `opacity at t=1 is ${res.endOpacity}`);
+
+      const leak = res.before.transparent !== res.after.transparent ||
+                   res.before.opacity !== res.after.opacity ||
+                   res.before.depthWrite !== res.after.depthWrite;
+      P('G-GG-5 no leak into normal navigation after restore',
+        !leak,
+        `before=${JSON.stringify(res.before)}  after=${JSON.stringify(res.after)}`);
+
+      const agree = res.previewSamples.every(s => s.bake === s.preview);
+      P('G-GG-6 preview and bake trace the identical curve at the same film fraction',
+        agree,
+        res.previewSamples.map(s => `t=${s.t}:${s.bake}`).join('  '));
+
+      const trig = logs.filter(l => /§GHOST_GROUND_TRIGGER /.test(l)).slice(-1)[0] || '';
+      const armed = logs.filter(l => /§GHOST_GROUND armed/.test(l)).slice(-1)[0] || '';
+      P('G-GG-7 the log states the trigger and the arming, so a quiet no-op is visible',
+        !!trig && !!armed,
+        `${trig || 'no §GHOST_GROUND_TRIGGER'}\n        ${armed || 'no §GHOST_GROUND armed'}`);
+    }
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User, watching a Hospital buildup bake: *"is there a way to make the foundation beams seen thru? at least until its above slabs appears"* → *"it be cool when they return back to opaque gradually rather than right away"*.

**Their diagnosis, confirmed by their own log.** A buildup film opens on substructure, and substructure sits *below* the ground plane (`§GROUND_Y z=165.36`, the L1 slab datum):

```
§CPE_BUILDUP frame=120/2219 placed=210/63421
§GROUND_MAP key=paved   §PHOTO_SHADOW casters=4043
```

Those 210 elements were built and **buried**. The opening was occluded, not empty — no camera or gaze change could have revealed it.

**Rejected** the alternative of switching the ground off (their own first idea, risk flagged by them): it takes the 4,043 shadow casters and the sense of a site with it.

**Shipped:** while nothing at or above the ground datum is placed, the plane renders at 0.22 — pile caps and ground beams read through it like a survey drawing. When the first at-or-above-ground element lands (the ground slab qualifies — their words), it eases back to opaque on a smoothstep over 3 s of *film* time. A ramp, not a cut.

Needs no new data — `element_transforms` has each bottom, the Time Machine orders the ops, and `tools.js` now publishes the plane's own datum so the ghost can't disagree with what positioned it.

⚠ Trigger is **MIN(end_ts)** over above-ground ops, not the first in start order — an element appears when its op *ends*.

Preview and bake share one implementation; the fade is in film fraction so a 10 s rehearsal and a 148 s bake trace the identical curve. Restored on every exit path.

**Witnessed:** `witness_cpe_ghost_ground.js` **Duplex 7/7 and Hospital 7/7**. G-GG-3 exists to stop a cut passing as a fade (ramp 0.25→0.38→0.56→0.75→0.91→0.996, monotone); G-GG-5 proves no leak; unarmed the same plane reads opacity=1, the RED this replaces. Regression: room-title 11/11.

**Measured and reported, not hidden:** on Hospital the trigger lands at t=0.0162 — **2.4 s of a 147.9 s film** — and below-ground elements keep being placed to t=0.9947, so that model has no clean substructure window. The rule shipped is exactly the one specified; a ratio-based variant is the named follow-up.

MAXQ v17→v18, sw v893→v894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)