### PR TITLE
feat(cinema): §CPE_GHOST_GROUND_RATIO — the ground solidifies as the building rises

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -29,66 +29,95 @@
   // themselves: that takes §PHOTO_SHADOW's casters and the sense of a site with it, and the
   // foundation floats in blackness.
   var GHOST_OPACITY = 0.22;      // survey-drawing translucency; low enough to read what is under it
-  var GHOST_FADE_SEC = 3.0;      // seconds of FILM time the return to opaque is eased over
-  var _ggT = null, _ggSaved = null;
+  // §CPE_GHOST_GROUND_RATIO — the ground is fully opaque once this SHARE of the building's own
+  // above-ground work is placed. A fraction, never a count: 5% of a 62,450-element hospital and 5%
+  // of a 961-element house are both "the building is unmistakably out of the ground now". This is
+  // the ONLY presentation constant in the rule — the trigger, the totals and the ordering all come
+  // from the model.
+  var GHOST_REVEAL_FRAC = 0.05;
+  var GHOST_FADE_SEC = 3.0;      // floor on how fast opacity may rise, in FILM seconds — a batch of
+                                 // ops landing in one frame must not snap the ground opaque.
+  var _ggSched = null, _ggSpan = null, _ggSaved = null;
 
   // Called ONCE per preview/bake, after the buildup timeline is in force. Returns true when armed.
   function _ghostGroundArm(bkState) {
     var A = window.APP;
-    _ggT = null;
+    _ggSched = null;
     if (!A || !A.ground || !A.ground.material || !A.ground.visible) return false;
-    if (!bkState || typeof window.tmFirstAboveGroundMs !== 'function') return false;
+    if (!bkState || typeof window.tmGroundSchedule !== 'function') return false;
     var z = A.groundIfcZ;
     if (!isFinite(z)) { console.log('§GHOST_GROUND skip reason=no groundIfcZ (tools.js §GROUND_Y never ran)'); return false; }
     var span = bkState.projectEnd - bkState.projectStart;
     if (!(span > 0)) return false;
-    var ms = window.tmFirstAboveGroundMs(z);
-    if (ms == null) { console.log('§GHOST_GROUND skip reason=nothing is ever placed at or above the ground datum'); return false; }
-    var t = (ms - bkState.projectStart) / span;
-    // A trigger at or before t=0 means the film never opens underground — ghosting would be a lie
-    // about this building, so it stays off rather than ghosting a frame or two for symmetry.
-    if (!(t > 0)) { console.log('§GHOST_GROUND skip reason=first above-ground element is placed at t=' + t.toFixed(3) + ' (film never opens below ground)'); return false; }
+    var sched = window.tmGroundSchedule(z);
+    if (!sched || !sched.aboveTotal) { console.log('§GHOST_GROUND skip reason=no above-ground work in this timeline'); return false; }
+    // A model with NOTHING below ground has no substructure to reveal — ghosting it would be a lie
+    // about that building. Self-disabling, not a special case anyone has to configure.
+    if (!sched.belowTotal) { console.log('§GHOST_GROUND skip reason=this model has no below-ground elements (nothing to reveal)'); return false; }
+    _ggSched = sched;
+    _ggSpan = { start: bkState.projectStart, end: bkState.projectEnd, span: span,
+                firstT: sched.firstAboveMs == null ? 1 : (sched.firstAboveMs - bkState.projectStart) / span };
     var m = A.ground.material;
     _ggSaved = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
-    _ggT = t;
-    console.log('§GHOST_GROUND armed triggerT=' + t.toFixed(4) + ' ghost=' + GHOST_OPACITY +
-      ' fadeSec=' + GHOST_FADE_SEC + ' — ground is see-through until the first at-or-above-ground element');
+    console.log('§GHOST_GROUND armed aboveOps=' + sched.aboveTotal + ' belowOps=' + sched.belowTotal +
+      ' revealFrac=' + GHOST_REVEAL_FRAC + ' (opaque once ' + Math.ceil(sched.aboveTotal * GHOST_REVEAL_FRAC) +
+      ' above-ground elements are placed) ghost=' + GHOST_OPACITY + ' maxRiseSec=' + GHOST_FADE_SEC);
     return true;
   }
 
-  // Per frame. `tFilm` is the film fraction the BUILDUP is at (the same number that drives the
-  // cursor), `totalSec` the film's own length. Returns the opacity applied, or null when not armed.
+  // How many above-ground ops have COMPLETED by this cursor. Binary search on the sorted end_ts —
+  // the same `end_ts <= cursor` definition tmPlacedCount uses, so the ghost and the visible model
+  // can never disagree about what is built.
+  function _ggPlacedAbove(ms) {
+    var e = _ggSched.ends, lo = 0, hi = e.length;
+    while (lo < hi) { var mid = (lo + hi) >> 1; if (e[mid] <= ms) lo = mid + 1; else hi = mid; }
+    return lo;
+  }
+
+  // Per frame. `tFilm` is the film fraction driving the cursor; `totalSec` the film's length.
+  // Opacity follows the SHARE of above-ground work placed — the ground solidifies as the building
+  // rises — with a rate limit so a batch of ops cannot turn the ramp into a cut.
   function _ghostGroundAt(tFilm, totalSec) {
     var A = window.APP;
-    if (_ggT == null || !A || !A.ground || !A.ground.material) return null;
+    if (!_ggSched || !A || !A.ground || !A.ground.material) return null;
+    var t = Math.max(0, Math.min(1, tFilm));
+    var ms = _ggSpan.start + t * _ggSpan.span;
+    // 1. What the BUILDING says: the share of its own above-ground work that is placed.
+    var frac = _ggPlacedAbove(ms) / _ggSched.aboveTotal;
+    var u = Math.max(0, Math.min(1, frac / GHOST_REVEAL_FRAC));
+    var byWork = GHOST_OPACITY + (1 - GHOST_OPACITY) * (u * u * (3 - 2 * u));
+    // 2. A floor on how FAST that may happen, so a batch of ops landing together cannot snap the
+    //    ground opaque. ⚠ Expressed against the film's own clock, NOT against the previous call:
+    //    a per-call rate limiter makes the curve depend on how densely it is sampled, and the bake
+    //    (2219 frames) and the rehearsal (~600) then trace different curves for the same film.
+    //    Measured 2026-07-31 — G-GG-6 caught exactly that, 0.3653 vs 0.4006 at t=0.02.
     var fadeFrac = (totalSec > 0) ? Math.min(0.5, GHOST_FADE_SEC / totalSec) : 0.05;
-    var u = (tFilm - _ggT) / Math.max(1e-6, fadeFrac), o;
-    if (u <= 0) o = GHOST_OPACITY;
-    else if (u >= 1) o = 1;
-    else o = GHOST_OPACITY + (1 - GHOST_OPACITY) * (u * u * (3 - 2 * u));   // smoothstep, no cut
+    var v = Math.max(0, Math.min(1, (t - _ggSpan.firstT) / Math.max(1e-6, fadeFrac)));
+    var byTime = GHOST_OPACITY + (1 - GHOST_OPACITY) * (v * v * (3 - 2 * v));
+    // Both curves are monotone functions of t alone, so their min is too — and the result is a pure
+    // function of the film fraction: identical in the preview and the bake, at any frame count.
+    var o = Math.min(byWork, byTime);
     var m = A.ground.material, solid = o > 0.999;
     m.opacity = o;
     m.transparent = !solid;
     // A translucent floor that writes depth can occlude other transparent geometry drawn after it;
-    // the opaque substructure is already in the depth buffer either way, so this only affects the
-    // transparent pass. Restored with everything else.
+    // the opaque substructure is already in the depth buffer either way. Restored with the rest.
     m.depthWrite = solid;
     return o;
   }
 
-  // MUST run on every exit path. The ground material is shared with normal viewing — a bake that
-  // leaves it at 0.22 ghosts the ground for the rest of the session.
   function _ghostGroundRestore() {
     var A = window.APP;
+    _ggSched = null;
     if (_ggSaved && A && A.ground && A.ground.material) {
       var m = A.ground.material;
       m.transparent = _ggSaved.transparent; m.opacity = _ggSaved.opacity; m.depthWrite = _ggSaved.depthWrite;
       console.log('§GHOST_GROUND restored opacity=' + m.opacity + ' transparent=' + m.transparent);
     }
-    _ggSaved = null; _ggT = null;
+    _ggSaved = null;
   }
 
-  var MAXQ_V = 'v18 (§CPE_GHOST_GROUND the ground goes see-through while the buildup is entirely below it, then eases back to opaque; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v19 (§CPE_GHOST_GROUND_RATIO the ground solidifies as the SHARE of above-ground work rises — generic to any building, self-disabling where there is no substructure; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v894';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v895';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5274,6 +5274,46 @@
     return firstMs;
   };
 
+  // §CPE_GHOST_GROUND_RATIO — the SCHEDULE of above-ground placement, not just its first moment.
+  // Measured on Hospital: the first at-or-above-ground element lands at t=0.0162 (2.4s of a 147.9s
+  // film) while below-ground work continues to t=0.9947 — that model has no clean "substructure
+  // window" at all, so a first-element trigger lifts the ghost before the camera has even landed.
+  // The generic answer is a RATIO against the model's own above-ground total: the ground solidifies
+  // as the building rises, on every building, with no per-model tuning.
+  //
+  // Returns sorted end_ts for every above-ground op (binary-searchable per frame — never a rescan),
+  // plus the counts a caller needs to decide whether ghosting applies to this model at all.
+  window.tmGroundSchedule = function(ifcZ) {
+    var app = A();
+    if (!app || !app.db || !isFinite(ifcZ) || !_ops.length) return null;
+    var EPS = 0.05, above = Object.create(null), rows;
+    try {
+      rows = app.db.exec('SELECT guid, center_z - COALESCE(bbox_z, 0) / 2.0 AS bottom ' +
+                         'FROM element_transforms WHERE center_z IS NOT NULL');
+    } catch (e) { console.warn('§GHOST_GROUND_TRIGGER_FAIL ' + e.message); return null; }
+    if (!rows.length || !rows[0].values.length) return null;
+    var vals = rows[0].values, i;
+    for (i = 0; i < vals.length; i++) {
+      if (vals[i][1] != null && vals[i][1] >= ifcZ - EPS) above[vals[i][0]] = 1;
+    }
+    var ends = [], belowN = 0;
+    for (i = 0; i < _ops.length; i++) {
+      var op = _ops[i];
+      var g = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+      if (!g) continue;
+      if (above[g]) ends.push(op.end_ts); else belowN++;
+    }
+    ends.sort(function(a, b) { return a - b; });
+    var out = { ends: ends, aboveTotal: ends.length, belowTotal: belowN,
+                firstAboveMs: ends.length ? ends[0] : null,
+                projectStart: _projectStart, projectEnd: _projectEnd };
+    console.log('§GHOST_GROUND_SCHEDULE groundZ=' + ifcZ.toFixed(2) +
+      ' aboveOps=' + out.aboveTotal + ' belowOps=' + out.belowTotal +
+      ' firstAboveMs=' + (out.firstAboveMs == null ? 'none' : Math.round(out.firstAboveMs)) +
+      ' — opacity follows the SHARE of above-ground work placed, so it scales to any building');
+    return out;
+  };
+
   // §PHASE_LENS exposure: let other modules (Find panel Phase axis) lazily
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. Returns its boolean (count>0 / false); callers cache.

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -69,9 +69,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       if (!bk) return { err: 'no timeline to follow' };
       out.span = { start: bk.projectStart, end: bk.projectEnd, ops: bk.ops };
 
-      const firstMs = window.tmFirstAboveGroundMs(A.groundIfcZ);
-      out.firstMs = firstMs;
-      out.triggerT = firstMs == null ? null : (firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
+      const sched = window.tmGroundSchedule(A.groundIfcZ);
+      out.sched = sched ? { aboveTotal: sched.aboveTotal, belowTotal: sched.belowTotal } : null;
+      out.firstMs = sched ? sched.firstAboveMs : null;
+      out.triggerT = out.firstMs == null ? null : (out.firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
 
       const m = A.ground.material;
       const before = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
@@ -91,11 +92,22 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       }
       out.endOpacity = A.ghostGroundAt(1, TOTAL);
 
-      // G-GG-6: the same film fraction through the preview's call signature (a 10 s rehearsal).
-      const previewSamples = [0.02, 0.2, 0.5, 0.9].map(t => ({
-        t, bake: A.ghostGroundAt(t, TOTAL), preview: A.ghostGroundAt(t, TOTAL),
-      }));
-      out.previewSamples = previewSamples;
+      // G-GG-6: the SAME fractions again through a fresh arming, the way the preview drives it.
+      // ⚠ This must re-arm: the rate limiter carries state forward, so sampling t=0.02 after the
+      // sweep has already reached t=1 returns 1 and the gate would pass for the wrong reason
+      // (caught 2026-07-31 — it did exactly that before this re-arm was added).
+      A.ghostGroundRestore();
+      A.ground.visible = true;
+      A.ghostGroundArm(bk);
+      const fracs = [0.02, 0.05, 0.10, 0.20, 0.50, 0.90];
+      const byT = {};
+      out.steps.forEach(s => { byT[s.t] = s.o; });
+      out.previewSamples = [];
+      for (const t of fracs) {   // ascending, exactly as a rehearsal advances
+        const preview = A.ghostGroundAt(t, TOTAL);
+        // the bake sweep sampled every 1/200, so these fractions land on real samples
+        out.previewSamples.push({ t, bake: byT[+t.toFixed(4)], preview: preview == null ? null : +preview.toFixed(4) });
+      }
 
       A.ghostGroundRestore();
       out.after = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
@@ -115,6 +127,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         `groundIfcZ=${res.groundIfcZ}  firstAboveMs=${res.firstMs}  triggerT=${res.triggerT == null ? 'null' : res.triggerT.toFixed(4)}  ` +
         `span=${Math.round(res.span.start)}..${Math.round(res.span.end)} ops=${res.span.ops}`);
 
+      // where the ratio rule actually reaches opaque — the number that says whether the ghost is
+      // long enough to see, and the whole reason the first-element trigger was replaced.
+      const opaqueAt = (res.steps.find(s => s.o != null && s.o > 0.999) || {}).t;
+      res.opaqueAt = opaqueAt;
       const early = res.steps.filter(s => s.t < res.triggerT);
       const ghosted = early.length && early.every(s => s.o != null && s.o < 0.3);
       P('G-GG-2 before the trigger the ground is see-through, so the substructure reads (RED before this change)',
@@ -145,16 +161,26 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         !leak,
         `before=${JSON.stringify(res.before)}  after=${JSON.stringify(res.after)}`);
 
-      const agree = res.previewSamples.every(s => s.bake === s.preview);
+      const agree = res.previewSamples.length > 0 &&
+        res.previewSamples.every(s => s.bake != null && s.preview != null && Math.abs(s.bake - s.preview) < 1e-6);
       P('G-GG-6 preview and bake trace the identical curve at the same film fraction',
         agree,
-        res.previewSamples.map(s => `t=${s.t}:${s.bake}`).join('  '));
+        res.previewSamples.map(s => `t=${s.t} bake=${s.bake} preview=${s.preview}`).join('   '));
 
-      const trig = logs.filter(l => /§GHOST_GROUND_TRIGGER /.test(l)).slice(-1)[0] || '';
+      // §CPE_GHOST_GROUND_RATIO: the point of replacing the first-element trigger. On Hospital that
+      // trigger fired at t=0.0162 (2.4s of a 147.9s film) — the ghost was over before the camera
+      // landed. The ratio rule must hold the ground open materially longer than that.
+      P('G-GG-8 the ghost outlasts the first above-ground element (the ratio rule, not a trigger)',
+        res.opaqueAt != null && res.opaqueAt > res.triggerT * 2,
+        `first above-ground element at t=${res.triggerT.toFixed(4)}; ground reaches opaque at ` +
+        `t=${res.opaqueAt == null ? 'never' : res.opaqueAt.toFixed(4)}  ` +
+        `(above=${res.sched.aboveTotal} below=${res.sched.belowTotal}, opaque once 5% of above-ground work is placed)`);
+
+      const trig = logs.filter(l => /§GHOST_GROUND_SCHEDULE /.test(l)).slice(-1)[0] || '';
       const armed = logs.filter(l => /§GHOST_GROUND armed/.test(l)).slice(-1)[0] || '';
       P('G-GG-7 the log states the trigger and the arming, so a quiet no-op is visible',
         !!trig && !!armed,
-        `${trig || 'no §GHOST_GROUND_TRIGGER'}\n        ${armed || 'no §GHOST_GROUND armed'}`);
+        `${trig || 'no §GHOST_GROUND_SCHEDULE'}\n        ${armed || 'no §GHOST_GROUND armed'}`);
     }
 
     const pass = checks.filter(c => c.ok).length;


### PR DESCRIPTION
Follow-up to #1110. Its first-element trigger measured at **t=0.0162 on Hospital — 2.4 s of a 147.9 s film**, over before the camera lands, because that model places its ground slab early and keeps placing below-ground work to t=0.9947. No single trigger can find a substructure window that isn't there.

**Now a ratio against the model's own above-ground total:** opacity follows the share of above-ground work placed, smoothstep to opaque at 5%. Generic by construction — 5% of a 62,450-element hospital and 5% of a 961-element house both mean *the building is unmistakably out of the ground* — and **self-disabling**: a model with no below-ground elements is never ghosted, and says so in the log.

Measured: **Hospital opaque at t=0.050** (was 0.0162), **Duplex at t=0.130** (was 0.0083).

⚠ **A defect in my own first cut, caught by a gate rather than shipped.** The rate limiter clamped against the *previous call*, making the curve depend on sampling density — the bake (2219 frames) and the rehearsal (~600) traced different curves for the same film (0.3653 vs 0.4006 at t=0.02). Both terms are now pure functions of film fraction, so their min is too. G-GG-6 itself also had to be fixed to re-arm before sampling; it had begun passing for the wrong reason.

**Witnessed:** Duplex **8/8**, Hospital **8/8**. New G-GG-8 asserts the ghost materially outlasts the first above-ground element.

MAXQ v18→v19, sw v894→v895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)