### PR TITLE
fix(cinema): §CPE_GHOST_GROUND never armed in a real bake — visibility guard, and a witness that hid it

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -43,7 +43,13 @@
   function _ghostGroundArm(bkState) {
     var A = window.APP;
     _ggSched = null;
-    if (!A || !A.ground || !A.ground.material || !A.ground.visible) return false;
+    // ⚠ NO `A.ground.visible` GUARD. The ground plane is turned on by photoreal STAGING, which runs
+    // per frame INSIDE the capture loop (§PHOTO_STAGING on -> §GROUND_MAP key=paved) and off again
+    // after each frame. Arming happens once, BEFORE that loop, when the plane is still hidden — so a
+    // visibility check here skipped the whole feature on every real bake (user, 2026-07-31: no
+    // §GHOST_GROUND_SCHEDULE line and no `groundOpacity=` in §CPE_BUILDUP anywhere in their log).
+    // Setting opacity on a hidden plane costs nothing and is correct the moment staging shows it.
+    if (!A || !A.ground || !A.ground.material) return false;
     if (!bkState || typeof window.tmGroundSchedule !== 'function') return false;
     var z = A.groundIfcZ;
     if (!isFinite(z)) { console.log('§GHOST_GROUND skip reason=no groundIfcZ (tools.js §GROUND_Y never ran)'); return false; }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v895';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v896';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -56,10 +56,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     const res = await page.evaluate(async () => {
       const A = window.APP;
       const out = { steps: [] };
-      // The ground plane is normally hidden until Shadow/photoreal staging turns it on; the feature
-      // is explicitly a no-op while it is invisible, so make it visible exactly as staging does.
+      // ⚠ DO NOT make the ground visible before arming. This witness used to do exactly that, and
+      // it is why 8/8 green shipped a feature that never armed in a real bake: photoreal staging
+      // turns the plane on INSIDE the per-frame loop, so at arm time it is always hidden. Arming
+      // against a state the browser never has is the harness lying, not the product passing.
       if (!A.ground) return { err: 'no ground plane' };
-      A.ground.visible = true;
+      A.ground.visible = false;
       out.groundIfcZ = A.groundIfcZ;
       if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
       let ok = false;
@@ -81,7 +83,9 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       // RED reference: what the ground reads at an early cursor with the feature NOT armed.
       out.unarmedEarlyOpacity = m.opacity;
 
+      out.groundVisibleAtArm = A.ground.visible;   // false, exactly as a real bake has it
       out.armed = A.ghostGroundArm(bk);
+      A.ground.visible = true;                     // staging turns it on once the frame loop starts
       const TOTAL = 100;   // a 100 s film, so 1 film-fraction unit == 100 s
       // Sample densely across the whole film; that is the only way to see whether the return to
       // opaque is a ramp or a cut.
@@ -178,6 +182,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
       const trig = logs.filter(l => /§GHOST_GROUND_SCHEDULE /.test(l)).slice(-1)[0] || '';
       const armed = logs.filter(l => /§GHOST_GROUND armed/.test(l)).slice(-1)[0] || '';
+      P('G-GG-9 it arms while the ground is still HIDDEN — the state every real bake arms in',
+        res.groundVisibleAtArm === false && res.armed === true,
+        `ground.visible at arm = ${res.groundVisibleAtArm}, armed = ${res.armed}  ` +
+        `(a visibility guard here silently disabled the feature on every real bake — the witness had ` +
+        `been setting visible=true first, which is a regime the browser never enters at that moment)`);
+
       P('G-GG-7 the log states the trigger and the arming, so a quiet no-op is visible',
         !!trig && !!armed,
         `${trig || 'no §GHOST_GROUND_SCHEDULE'}\n        ${armed || 'no §GHOST_GROUND armed'}`);


### PR DESCRIPTION
User tested live: **the feature did nothing.** No `§GHOST_GROUND_SCHEDULE`, no `§GHOST_GROUND armed`, and `§CPE_BUILDUP frame=0/1137` carried no `groundOpacity=` through a whole Hospital bake.

**Cause, one condition:** `_ghostGroundArm` bailed on `!A.ground.visible`. The ground plane is turned on by photoreal **staging**, which runs per frame *inside* the capture loop and off again after each frame. Arming happens once, *before* that loop, with the plane still hidden — so the guard skipped the feature on every real bake.

**⚠ The witness was complicit, and that's the more important half.** It set `A.ground.visible = true` before arming — a state the browser never has at that moment — so 9 gates went green on a feature that could not fire. Textbook harness-regime gap. The witness now arms with the ground hidden the way a bake does, and new **G-GG-9** asserts exactly that (`ground.visible at arm = false, armed = true`) — RED on the build just tested.

Duplex **9/9** with the corrected setup. sw v895→v896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)