### PR TITLE
feat(cinema): §CPE_BUILDUP_WORK_PACED — the film advances by elements placed, not calendar days

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -39,6 +39,55 @@
                                  // ops landing in one frame must not snap the ground opaque.
   var _ggSched = null, _ggSpan = null, _ggSaved = null, _ggTried = false;
 
+  // ══ §CPE_BUILDUP_WORK_PACED — the film advances by WORK, not by calendar ══════════════════════
+  // User, after two bakes: "construction came on too fast.. is the path and TM consistent?" — and
+  // their logs said no: 210/63,421 placed at t=0.054 in one run, 15,485/63,416 at t=0.053 in another.
+  // The cursor was stepping linearly in DAYS while the derived 4D order dumps thousands of elements
+  // at nearby timestamps, so a quarter of the model appeared in the first 5% of the film and the
+  // rest of the film had little left to raise.
+  //
+  // Film fraction -> the k-th element PLACED, not the k-th day. 10% of the film is 10% of the
+  // building on any model, and it no longer depends on how the generated timestamps cluster — which
+  // is the consistency the user actually asked for.
+  var _wpSched = null, _wpTried = false;
+
+  function _workPacingArm() {
+    _wpTried = true; _wpSched = null;
+    if (typeof window.tmWorkSchedule !== 'function') {
+      // DEGRADE, DON'T DISABLE — the §CPE_GHOST_GROUND lesson, applied up front. A stale cached
+      // time_machine.js must cost pacing quality, never the film.
+      console.log('§CPE_BUILDUP_PACING mode=calendar reason=tmWorkSchedule unavailable (older time_machine.js) — film advances by DAYS, work may arrive in bursts');
+      return false;
+    }
+    var sch = window.tmWorkSchedule();
+    if (!sch || !sch.total || !(sch.projectEnd > sch.projectStart)) {
+      console.log('§CPE_BUILDUP_PACING mode=calendar reason=no usable work schedule');
+      return false;
+    }
+    _wpSched = sch;
+    console.log('§CPE_BUILDUP_PACING mode=work ops=' + sch.total +
+      ' — t=0.10 now means 10% of the ELEMENTS placed, not 10% of the days elapsed' +
+      ' (this model puts ' + (sch.workInFirstTenthOfCalendar * 100).toFixed(1) + '% of its work in the first 10% of its calendar)');
+    return true;
+  }
+
+  // The cursor this frame should ask for. Pure function of the film fraction, so preview and bake
+  // cannot diverge and two runs of the same film ask for identical cursors.
+  function _workCursorAt(tFilm, bkState) {
+    if (!_wpTried) _workPacingArm();
+    var t = Math.max(0, Math.min(1, tFilm));
+    if (!_wpSched) return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
+    if (t <= 0) return _wpSched.projectStart;
+    if (t >= 1) return _wpSched.projectEnd;
+    // k-th completion. `ends` is sorted, so this is the instant at which exactly k ops are done.
+    var k = Math.round(t * _wpSched.total);
+    if (k < 1) return _wpSched.projectStart;
+    if (k >= _wpSched.total) return _wpSched.projectEnd;
+    return _wpSched.ends[k - 1];
+  }
+
+  function _workPacingReset() { _wpSched = null; _wpTried = false; }
+
   // Called ONCE per preview/bake, after the buildup timeline is in force. Returns true when armed.
   function _ghostGroundArm(bkState) {
     var A = window.APP;
@@ -158,7 +207,7 @@
     _ggSaved = null;
   }
 
-  var MAXQ_V = 'v19 (§CPE_GHOST_GROUND_RATIO the ground solidifies as the SHARE of above-ground work rises — generic to any building, self-disabling where there is no substructure; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v20 (§CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_GHOST_GROUND_RATIO the ground solidifies as the SHARE of above-ground work rises — generic to any building, self-disabling where there is no substructure; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -944,7 +993,10 @@
         // parameter, so a clip samples the middle of the buildup rather than restarting it.
         if (_buildup && _bkState) {
           var _bkT = _tFilm(_tn);
-          var _bkMs = _bkState.projectStart + _bkT * (_bkState.projectEnd - _bkState.projectStart);
+          // §CPE_BUILDUP_WORK_PACED: was `projectStart + t*span` — linear in DAYS. Now linear in
+          // ELEMENTS, so the building rises at an even rate regardless of how the derived 4D order
+          // clusters its timestamps.
+          var _bkMs = _workCursorAt(_bkT, _bkState);
           window.tmSetCursor(_bkMs);
           // §CPE_GHOST_GROUND: same film fraction the cursor rides, so the ghost cannot drift out of
           // step with what is actually placed.
@@ -1030,6 +1082,7 @@
       // §CPE_GHOST_GROUND: same contract, same exit — a ghosted ground left behind would follow the
       // user into normal navigation for the rest of the session.
       try { _ghostGroundRestore(); } catch (eGG) {}
+      _workPacingReset();
       // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
       // The defect this exists for is a film that looks complete and plays fine while its last
       // seconds are visually dead. A degraded bake must never finish quietly: `unconverged` is the
@@ -1080,6 +1133,7 @@
       // bake would look like a corrupted schedule to the next person who opens the timeline.
       try { if (_bkState && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); _bkState = null; } } catch (e3) {}
       try { _ghostGroundRestore(); } catch (e4) {}
+      try { _workPacingReset(); } catch (e5) {}
       // Recoverability FIRST: clearing the store can itself block for seconds behind the very
       // zombie connection that failed this run, and until these flags reset the next Alt+C is
       // swallowed as a cancel-toggle. Cleanup must never gate the ability to retry.
@@ -1104,6 +1158,10 @@
       window.APP.cancelMaxQualityOrbit = cancel;
       // §CPE_GHOST_GROUND: exported so cinema_path_editor's REHEARSAL drives the identical curve —
       // one implementation, two call sites (the §CPE_ROOM_TITLE precedent).
+      // §CPE_BUILDUP_WORK_PACED: the rehearsal must ask for the same cursor as the bake, or the
+      // preview shows a different construction rate from the film it is previewing.
+      window.APP.buildupCursorAt = _workCursorAt;
+      window.APP.buildupPacingReset = _workPacingReset;
       window.APP.ghostGroundArm = _ghostGroundArm;
       window.APP.ghostGroundAt = _ghostGroundAt;
       window.APP.ghostGroundRestore = _ghostGroundRestore;

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1051,7 +1051,11 @@
         a.controls.update();
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
         if (bkPrev && window.tmSetCursor) {
-          window.tmSetCursor(bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart));
+          // §CPE_BUILDUP_WORK_PACED: the rehearsal asks for the SAME cursor the bake will ask for at
+          // this film fraction — paced by elements placed, not by days elapsed. Falls back to the
+          // old linear-calendar expression if cinema_maxq is an older cached copy.
+          window.tmSetCursor(a.buildupCursorAt ? a.buildupCursorAt(tn, bkPrev)
+            : (bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart)));
           // §CPE_GHOST_GROUND: the rehearsal shows what the bake will show. The fade is expressed in
           // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
           // though the wall-clock speeds differ by 15x.
@@ -1071,6 +1075,7 @@
         // §CPE_GHOST_GROUND: same exit contract as the Time Machine restore above — the rehearsal
         // must not leave the ground see-through for the editing session that follows it.
         if (a.ghostGroundRestore) a.ghostGroundRestore();
+        if (a.buildupPacingReset) a.buildupPacingReset();
         if (a.roomTitleLiveStop) a.roomTitleLiveStop();
         _state.flying = false;
         console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v898';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v899';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5314,6 +5314,33 @@
     return out;
   };
 
+  // §CPE_BUILDUP_WORK_PACED (CINEMA_PATH_EDITOR.md) — the sorted completion times of every op, so a
+  // film can advance by WORK instead of by CALENDAR. Measured on the user's own Hospital bakes: at
+  // the same film fraction one run had 210/63,421 elements placed and another 15,485/63,416, because
+  // the derived 4D order clusters thousands of elements at nearby timestamps and the film was
+  // stepping the cursor linearly in days. Stepping it linearly in ELEMENTS makes "10% of the film"
+  // mean "10% of the building" on any model.
+  //
+  // One pass, called ONCE per bake/preview — never per frame. Read-only: nothing here re-keys or
+  // reorders the op log (§CPE_BUILDUP_FOLLOW_TM — the film plays the timeline, it does not author one).
+  window.tmWorkSchedule = function() {
+    if (!_ops.length) return null;
+    var ends = new Float64Array(_ops.length), i;
+    for (i = 0; i < _ops.length; i++) ends[i] = _ops[i].end_ts;
+    ends.sort();
+    var out = { ends: ends, total: ends.length, projectStart: _projectStart, projectEnd: _projectEnd };
+    // How front-loaded IS this model? The share of work completed in the first 10% of the calendar —
+    // 0.10 would mean evenly spread, and anything far above it is exactly the burst the user saw.
+    var tenPct = _projectStart + 0.10 * (_projectEnd - _projectStart), n10 = 0;
+    for (i = 0; i < ends.length; i++) { if (ends[i] > tenPct) break; n10++; }
+    out.workInFirstTenthOfCalendar = ends.length ? n10 / ends.length : 0;
+    console.log('§CPE_WORK_SCHEDULE ops=' + out.total +
+      ' span=' + Math.round(_projectStart) + '..' + Math.round(_projectEnd) +
+      ' workInFirst10%OfCalendar=' + (out.workInFirstTenthOfCalendar * 100).toFixed(1) + '%' +
+      ' (10.0% would be evenly spread — anything above it is the burst calendar pacing shows)');
+    return out;
+  };
+
   // §PHASE_LENS exposure: let other modules (Find panel Phase axis) lazily
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. Returns its boolean (count>0 / false); callers cache.

--- a/witness_cpe_work_pacing.js
+++ b/witness_cpe_work_pacing.js
@@ -1,0 +1,163 @@
+// WITNESS — §CPE_BUILDUP_WORK_PACED: the film must advance by WORK, not by calendar.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_WORK_PACED.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, after two Hospital buildup bakes: "but construction
+// came on too fast.. is the path and TM consistent?" -> "as long it is consistent as i find this
+// seems to be at random"):
+// The buildup stepped the cursor linearly in DAYS — `projectStart + t*span` — while the derived 4D
+// order clusters thousands of elements at nearby timestamps. Their own logs, same film fraction:
+//     run A  t=0.054  placed=210/63,421      (0.3% of the building)
+//     run B  t=0.053  placed=15,485/63,416    (24% of the building)
+// Same path, same moment, two completely different films.
+//
+//   G-WP-1  the claim: at t = 0.1/0.25/0.5/0.75 the PLACED FRACTION equals t within tolerance.
+//           "10% of the film is 10% of the building", measured against the real op schedule.
+//   G-WP-2  RED on calendar pacing. The same fractions paced by DATE deviate far more — without
+//           this, G-WP-1 could pass on a model that happens to be evenly spread anyway.
+//   G-WP-3  the cursor is monotone non-decreasing across the film. A building does not un-build.
+//   G-WP-4  DETERMINISM — the user's "seems to be at random" answered with a number: two independent
+//           arms produce byte-identical cursors for identical fractions.
+//   G-WP-5  degrade, don't disable: with tmWorkSchedule hidden the way a stale cache would, pacing
+//           falls back to calendar and says so in the log — the film still bakes.
+//   G-WP-6  preview and bake ask for the same cursor at the same film fraction.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8442;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const FRACS = [0.10, 0.25, 0.50, 0.75];
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1800000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.buildupCursorAt && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const res = await page.evaluate(async (FRACS) => {
+      const A = window.APP;
+      if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
+      let ok = false;
+      try { ok = await window.tmActivateForBake(); } catch (e) { return { err: 'tmActivateForBake: ' + e.message }; }
+      if (!ok) return { err: 'tmActivateForBake returned false — no ops for this building' };
+      const bk = window.tmFollowTimeline();
+      if (!bk) return { err: 'no timeline to follow' };
+      const total = bk.ops;
+      const out = { total, span: { s: bk.projectStart, e: bk.projectEnd } };
+
+      // ── work pacing: the cursor asked for, and the work actually placed there ────────────────
+      A.buildupPacingReset();
+      out.work = FRACS.map(t => {
+        const ms = A.buildupCursorAt(t, bk);
+        return { t, ms, placedFrac: window.tmPlacedCount(ms) / total };
+      });
+
+      // ── G-WP-2 control: the SAME fractions paced by calendar, the way it used to be ──────────
+      out.calendar = FRACS.map(t => {
+        const ms = bk.projectStart + t * (bk.projectEnd - bk.projectStart);
+        return { t, ms, placedFrac: window.tmPlacedCount(ms) / total };
+      });
+
+      // ── G-WP-3 monotone across a dense sweep ────────────────────────────────────────────────
+      let prev = -Infinity, mono = true;
+      for (let i = 0; i <= 200; i++) {
+        const ms = A.buildupCursorAt(i / 200, bk);
+        if (ms < prev - 1e-6) mono = false;
+        prev = ms;
+      }
+      out.monotone = mono;
+
+      // ── G-WP-4 determinism: a second, independent arm must reproduce the cursors exactly ────
+      A.buildupPacingReset();
+      out.secondArm = FRACS.map(t => A.buildupCursorAt(t, bk));
+      out.deterministic = out.secondArm.every((ms, i) => ms === out.work[i].ms);
+
+      // ── G-WP-5 degrade: hide the API the way a stale cached time_machine.js would ────────────
+      A.buildupPacingReset();
+      const real = window.tmWorkSchedule;
+      window.tmWorkSchedule = undefined;
+      out.fallback = FRACS.map(t => A.buildupCursorAt(t, bk));
+      out.fallbackIsCalendar = out.fallback.every((ms, i) =>
+        Math.abs(ms - (bk.projectStart + FRACS[i] * (bk.projectEnd - bk.projectStart))) < 1);
+      window.tmWorkSchedule = real;
+
+      // ── G-WP-6 preview/bake parity: same function, same args, same answer ────────────────────
+      A.buildupPacingReset();
+      out.previewCursors = FRACS.map(t => A.buildupCursorAt(t, bk));
+      A.buildupPacingReset();
+      out.bakeCursors = FRACS.map(t => A.buildupCursorAt(t, bk));
+      out.previewMatchesBake = out.previewCursors.every((ms, i) => ms === out.bakeCursors[i]);
+
+      try { window.tmRestoreDerivedOrder(); } catch (e) {}
+      return out;
+    }, FRACS);
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+    if (res.err) {
+      P('G-WP-0 the building has a buildup timeline', false, res.err + ' — INCONCLUSIVE, not a product verdict');
+    } else {
+      const TOL = 0.03;   // 3 percentage points; the k-th completion can share a timestamp with others
+      const workDev = res.work.map(w => Math.abs(w.placedFrac - w.t));
+      const calDev = res.calendar.map(c => Math.abs(c.placedFrac - c.t));
+      const worstWork = Math.max(...workDev), worstCal = Math.max(...calDev);
+
+      P('G-WP-1 k% of the film is k% of the building',
+        worstWork <= TOL,
+        res.work.map((w, i) => `t=${w.t}→placed ${(w.placedFrac * 100).toFixed(1)}%`).join('  ') +
+        `   worst deviation ${(worstWork * 100).toFixed(2)}pp (tol ${TOL * 100}pp)`);
+
+      P('G-WP-2 calendar pacing is measurably worse on this model (the RED this replaces)',
+        worstCal > worstWork,
+        res.calendar.map(c => `t=${c.t}→placed ${(c.placedFrac * 100).toFixed(1)}%`).join('  ') +
+        `   worst ${(worstCal * 100).toFixed(2)}pp vs work-paced ${(worstWork * 100).toFixed(2)}pp`);
+
+      P('G-WP-3 the cursor never goes backward', res.monotone === true,
+        `201 samples across the film, monotone=${res.monotone}`);
+
+      P('G-WP-4 deterministic — the same fraction gives the SAME cursor on a fresh arm',
+        res.deterministic === true,
+        `arm1=[${res.work.map(w => w.ms).join(',')}]  arm2=[${res.secondArm.join(',')}]  identical=${res.deterministic}`);
+
+      P('G-WP-5 a stale time_machine.js degrades to calendar pacing instead of breaking the film',
+        res.fallbackIsCalendar === true,
+        `with tmWorkSchedule hidden, cursors match the linear-calendar expression exactly: ${res.fallbackIsCalendar}`);
+
+      P('G-WP-6 preview and bake ask for the same cursor', res.previewMatchesBake === true,
+        `preview=[${res.previewCursors.join(',')}] bake=[${res.bakeCursors.join(',')}]`);
+
+      const line = logs.filter(l => /§CPE_BUILDUP_PACING/.test(l)).slice(-1)[0] || '';
+      const sch = logs.filter(l => /§CPE_WORK_SCHEDULE/.test(l)).slice(-1)[0] || '';
+      P('G-WP-7 the log states the pacing mode and how front-loaded the model is',
+        /mode=work/.test(line) && /workInFirst10%OfCalendar/.test(sch),
+        `${line || 'no §CPE_BUILDUP_PACING'}\n        ${sch || 'no §CPE_WORK_SCHEDULE'}`);
+    }
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User, after two buildup bakes: *"construction came on too fast.. is the path and TM consistent?"* → *"as long it is consistent as i find this seems to be at random"*.

Their logs said it plainly — **same film fraction, two runs:**

| run | film t | placed |
|---|---|---|
| A | 0.054 | **210** / 63,421 (0.3%) |
| B | 0.053 | **15,485** / 63,416 (24%) |

**Root cause, one line:** the buildup stepped the cursor linearly in *days* (`projectStart + t*span`) while the derived 4D order clusters thousands of elements at nearby timestamps. Hospital puts **15.5%** of its work in the first 10% of its calendar; Duplex 14.0%. §CPE_GHOST_GROUND's collapsed reveal window was a downstream symptom of this, not a bug in its own rule.

Film fraction now maps to the **k-th element placed**: `k = round(t × totalOps)`, cursor = `sortedEnds[k-1]`.

**Measured, both ends of the size range:**

| model | work-paced worst deviation | calendar-paced worst |
|---|---|---|
| Hospital (63,415 ops) | **0.00 pp** | 11.29 pp |
| Duplex (1,119 ops) | **0.07 pp** | 12.13 pp |

"10% of the film is 10% of the building" is now literally true on both.

⚠ **Not a re-key.** Only which cursor a *frame* asks for changed — op order and timestamps untouched, `tmRestoreDerivedOrder` still returns the user's timeline exactly as it was.

⚠ **The §CPE_GHOST_GROUND lesson applied up front:** the schedule lives in `time_machine.js`, the pacing in `cinema_maxq.js`, so a stale cached copy of either **degrades** to calendar pacing with a named `§CPE_BUILDUP_PACING` line — it can never silently break the film.

**Witnessed:** `witness_cpe_work_pacing.js` Duplex **7/7** and Hospital **7/7**. G-WP-2 is the RED control; **G-WP-4 answers "seems at random" with a number** — two independent arms produce byte-identical cursors. Regression: ghost-ground 11/11.

MAXQ v19→v20, sw v898→v899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)