### PR TITLE
feat(cinema): §CPE_ROOM_TITLE_HOLD — a caption stays up 3s, unless the next room takes over

### DIFF
--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -17,6 +17,14 @@ function setupCpeRoomTitle(A) {
   var MIN_DWELL = 1.4;    // seconds — a room shown for less than this is suppressed (rate limit):
                           // a walk crossing six small rooms in four seconds must not strobe six titles
   var FADE = 0.4;         // seconds — fade in/out
+  // §CPE_ROOM_TITLE_HOLD (user, 2026-08-01: "give it 3 secs, because user will know u just passed
+  // that room, and of course, if another room cuts in by 2 secs, then it can replace so").
+  // A caption used to vanish the instant the camera left the room, so a 1.5s crossing produced a
+  // 1.5s label — measured on their own Hospital film: four of six labels were under 2 seconds and
+  // they could not read them. The label now stays up for at least MIN_HOLD, which is what makes it
+  // legible; it is CUT SHORT only by the next room's caption, because the newer room is what the
+  // viewer is actually in.
+  var MIN_HOLD = 3.0;     // seconds — floor on how long a caption stays readable
 
   // Point-in-room via the shared room graph (A.getRoomGraph — the ONE cache per building every
   // other room consumer already shares, FLY_TOUR_CORRIDOR_GRAPH.md §S2). Only 'room'-kind nodes
@@ -131,11 +139,38 @@ function setupCpeRoomTitle(A) {
     // `suppressed` = rooms crossed too fast (MIN_DWELL), high `rejectedByHeight` = the camera spent
     // its time above the building, `storeyPitch=0.0` = single-storey, height test disabled.
     var g0 = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
+    // §CPE_ROOM_TITLE_HOLD: extend each caption to MIN_HOLD, clipped by the NEXT caption's start.
+    // Exposed (below) so the witness gates this exact function rather than a re-implementation.
+    var held = A.roomTitleApplyHold(kept, totalSec);
+    var extended = 0;
+    for (var h = 0; h < kept.length; h++) if (held[h].tEnd > kept[h].tEnd + 1e-9) extended++;
+
     console.log('§CPE_ROOM_TITLE_TIMELINE segments=' + kept.length + ' suppressed=' + suppressed +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +
+      ' held=' + extended + '/' + kept.length + '@' + MIN_HOLD + 's' +
       ' totalSec=' + totalSec.toFixed(1) + ' ms=' + (performance.now() - t0).toFixed(1));
-    return kept;
+    return held;
+  };
+
+  // §CPE_ROOM_TITLE_HOLD — pure, and deliberately separate from the sampling above so it can be
+  // gated on synthetic segment lists with exact durations. Two rules, both the user's own words:
+  //   "give it 3 secs"                        -> every caption lasts at least MIN_HOLD
+  //   "if another room cuts in ... it replace" -> unless the next caption starts first, which wins
+  // A caption is never shortened below what it earned, and never runs past the film.
+  A.roomTitleApplyHold = function(segs, totalSec) {
+    if (!segs || !segs.length) return segs || [];
+    var out = [], i;
+    for (i = 0; i < segs.length; i++) {
+      var s0 = segs[i];
+      var want = s0.tStart + MIN_HOLD;
+      var cap = (i + 1 < segs.length) ? segs[i + 1].tStart : (isFinite(totalSec) ? totalSec : want);
+      var end = Math.max(s0.tEnd, want);
+      if (end > cap) end = cap;
+      if (end < s0.tEnd) end = s0.tEnd;   // never shorten what the camera actually dwelt
+      out.push({ guid: s0.guid, name: s0.name, tStart: s0.tStart, tEnd: end });
+    }
+    return out;
   };
 
   // Opacity/text for whichever segment is active (or fading) at absolute time t. Two segments can

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v899';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v900';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_room_title_hold.js
+++ b/witness_cpe_room_title_hold.js
@@ -1,0 +1,145 @@
+// WITNESS — §CPE_ROOM_TITLE_HOLD: a caption must stay up long enough to read.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_HOLD.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, 2026-08-01: "give it 3 secs, because user will know u
+// just passed that room, and of course, if another room cuts in by 2 secs, then it can replace so"
+// — after twice reporting labels flashing past unread):
+// A caption ended the instant the camera left the room, so a 1.5s crossing produced a 1.5s label.
+// Measured on their own Hospital film: FOUR of six labels were under 2 seconds
+// (2.6 / 1.5 / 1.8 / 1.8 / 1.5 / 4.7).
+//
+// Gated on `A.roomTitleApplyHold` — the SAME function the timeline builder calls, fed synthetic
+// segment lists so each rule is exercised at an exact duration rather than hoping a camera path
+// happens to produce one. Plus a real-path invariant check on a live timeline.
+//
+//   G-TH-1  RED before this change: a short caption is extended to the 3s floor.
+//   G-TH-2  a caption that already earned MORE than 3s is left alone — the hold is a floor, not a cap.
+//   G-TH-3  the user's replacement rule: a next room starting at 2s CUTS the hold at 2s, so the
+//           newer room wins. Without this the hold would overlap the room you are actually in.
+//   G-TH-4  a caption is never SHORTENED below the dwell the camera actually earned, even when the
+//           next room starts early — that would be the hold making things worse than before.
+//   G-TH-5  the last caption's hold never runs past the end of the film.
+//   G-TH-6  ordering/monotonicity survives: starts unchanged, ends non-decreasing, no segment ends
+//           before it starts.
+//   G-TH-7  on a REAL timeline every segment satisfies the invariant (>=3s, or clipped by the next
+//           start, or clipped by the film end) — the synthetic gates cannot drift from the product.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8443;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const HOLD = 3.0;
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.roomTitleApplyHold && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const res = await page.evaluate(async () => {
+      const A = window.APP;
+      const seg = (name, a, b) => ({ guid: name, name, tStart: a, tEnd: b });
+      const out = {};
+
+      // G-TH-1/2/5: a short one, a long one, and the last one near the film end.
+      out.solo = A.roomTitleApplyHold([seg('short', 10, 11.5)], 100);
+      out.longEnough = A.roomTitleApplyHold([seg('long', 10, 18)], 100);
+      out.atFilmEnd = A.roomTitleApplyHold([seg('tail', 98.5, 99)], 100);
+
+      // G-TH-3: the user's own case — next room cuts in at 2s.
+      out.replaced = A.roomTitleApplyHold([seg('a', 10, 11.5), seg('b', 12, 13.5)], 100);
+
+      // G-TH-4: next room starts BEFORE this one's earned end (overlapping samples).
+      out.noShorten = A.roomTitleApplyHold([seg('a', 10, 14), seg('b', 12, 13)], 100);
+
+      // G-TH-7: the real thing — build a timeline from the real plan and check the invariant.
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      const DUR = 60;
+      let real = [];
+      try {
+        const plan = A.cinemaPathPlan(DUR);
+        real = A.roomTitleBuildTimeline(plan, DUR) || [];
+      } catch (e) { out.realErr = e.message; }
+      out.real = real.map(s => ({ name: s.name, tStart: +s.tStart.toFixed(2), tEnd: +s.tEnd.toFixed(2) }));
+      out.realTotal = DUR;
+      return out;
+    });
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+    const dur = s => +(s.tEnd - s.tStart).toFixed(3);
+
+    P('G-TH-1 a 1.5s caption is held to 3s (RED before this change — it stayed 1.5s)',
+      dur(res.solo[0]) === HOLD,
+      `10.0→11.5 (1.5s)  becomes  ${res.solo[0].tStart}→${res.solo[0].tEnd} (${dur(res.solo[0])}s)`);
+
+    P('G-TH-2 a caption that earned 8s is left alone — the hold is a floor, not a cap',
+      dur(res.longEnough[0]) === 8,
+      `10.0→18.0 (8s) stays ${res.longEnough[0].tStart}→${res.longEnough[0].tEnd} (${dur(res.longEnough[0])}s)`);
+
+    P('G-TH-3 the replacement rule: a room cutting in at 2s truncates the hold at 2s',
+      res.replaced[0].tEnd === 12 && dur(res.replaced[1]) === HOLD,
+      `first 10.0→${res.replaced[0].tEnd} (cut by the next room's start at 12.0), ` +
+      `second ${res.replaced[1].tStart}→${res.replaced[1].tEnd} (${dur(res.replaced[1])}s)`);
+
+    P('G-TH-4 a caption is never shortened below the dwell the camera actually earned',
+      res.noShorten[0].tEnd === 14,
+      `earned 10.0→14.0; next room starts at 12.0; kept ${res.noShorten[0].tStart}→${res.noShorten[0].tEnd}`);
+
+    P('G-TH-5 the last caption never runs past the end of the film',
+      res.atFilmEnd[0].tEnd === 100,
+      `98.5→99.0 in a 100s film becomes ${res.atFilmEnd[0].tStart}→${res.atFilmEnd[0].tEnd}`);
+
+    const ordered = res.replaced.every((s, i, arr) => s.tEnd >= s.tStart && (i === 0 || s.tStart >= arr[i - 1].tStart));
+    P('G-TH-6 ordering survives: no segment ends before it starts, starts stay ordered',
+      ordered, `segments=${JSON.stringify(res.replaced)}`);
+
+    if (res.realErr || !res.real.length) {
+      P('G-TH-7 real timeline invariant', false,
+        (res.realErr || 'the real plan produced no captions on this building') + ' — INCONCLUSIVE, not a product verdict');
+    } else {
+      const bad = res.real.filter((s, i, arr) => {
+        const held = s.tEnd - s.tStart;
+        if (held >= HOLD - 1e-6) return false;                       // met the floor
+        const cap = (i + 1 < arr.length) ? arr[i + 1].tStart : res.realTotal;
+        return Math.abs(s.tEnd - cap) > 1e-6;                        // or was legitimately clipped
+      });
+      P('G-TH-7 on a REAL timeline every caption is >=3s, or clipped by the next one / the film end',
+        bad.length === 0,
+        `${res.real.length} captions: ` + res.real.map(s => `${s.name} ${s.tStart}→${s.tEnd}`).join('  |  ') +
+        (bad.length ? `   VIOLATIONS: ${JSON.stringify(bad)}` : ''));
+    }
+
+    const line = logs.filter(l => /§CPE_ROOM_TITLE_TIMELINE/.test(l)).slice(-1)[0] || '';
+    P('G-TH-8 the log reports how many captions were extended',
+      /held=\d+\/\d+@3s/.test(line), line || 'no §CPE_ROOM_TITLE_TIMELINE line');
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User, after twice reporting labels flashing past unread: *"give it 3 secs, because user will know u just passed that room, and of course, if another room cuts in by 2 secs, then it can replace so."*

A caption ended the instant the camera left the room — a 1.5 s crossing gave a 1.5 s label. On their own Hospital film **four of six were under two seconds** (2.6 / 1.5 / 1.8 / 1.8 / 1.5 / 4.7).

Two rules, both theirs:
- **"give it 3 secs"** → every caption lasts at least 3.0 s
- **"if another room cuts in … it replace"** → unless the next caption starts first, which wins

The hold is a **floor, never a cap** (an 8 s dwell stays 8 s), never shortens what the camera earned, and the last caption is clipped at the film end.

**Witnessed:** `witness_cpe_room_title_hold.js` Duplex **8/8** — G-TH-1 is the RED (1.5 s → 3.0 s), G-TH-3 proves the replacement rule, G-TH-4 proves the hold can't make things worse, G-TH-7 checks the invariant on a real timeline. Regressions green: room_title 11/11, timing 3/3, height 5/5.

**Not changed, stated rather than smuggled:** `MIN_DWELL` still drops rooms crossed in under 1.4 s *before* the hold applies. Lowering it would add captions rather than lengthen them — separate decision.

sw v899→v900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)