### PR TITLE
feat(cinema): §CPE_ROOM_TITLE_LEAD — name the room you are HEADING INTO, 2s early

### DIFF
--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -25,6 +25,14 @@ function setupCpeRoomTitle(A) {
   // legible; it is CUT SHORT only by the next room's caption, because the newer room is what the
   // viewer is actually in.
   var MIN_HOLD = 3.0;     // seconds — floor on how long a caption stays readable
+  // §CPE_ROOM_TITLE_LEAD (user, 2026-08-01: "room labelling ... should not wait to be in the room but
+  // as it is heading towards a room, about 2 secs before will be view point friendly", then "for every
+  // room too... not wait till inside room it can be too late as 3 secs optimum label appearance", then
+  // "even though just left room,.. but when new room appears, it tries to show also up to 3 secs.. and
+  // if misses, then skips"). A caption is a 3-SECOND SLOT THAT OPENS 2s BEFORE THE DOORWAY: the name
+  // arrives as a documentary lower-third does, just before its subject. It is a lead-in — it names the
+  // room being ENTERED, which is why it may never be described as "where the camera is".
+  var LEAD = 2.0;         // seconds — how early a caption appears, ahead of the room it names
 
   // Point-in-room via the shared room graph (A.getRoomGraph — the ONE cache per building every
   // other room consumer already shares, FLY_TOUR_CORRIDOR_GRAPH.md §S2). Only 'room'-kind nodes
@@ -139,16 +147,31 @@ function setupCpeRoomTitle(A) {
     // `suppressed` = rooms crossed too fast (MIN_DWELL), high `rejectedByHeight` = the camera spent
     // its time above the building, `storeyPitch=0.0` = single-storey, height test disabled.
     var g0 = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
-    // §CPE_ROOM_TITLE_HOLD: extend each caption to MIN_HOLD, clipped by the NEXT caption's start.
-    // Exposed (below) so the witness gates this exact function rather than a re-implementation.
-    var held = A.roomTitleApplyHold(kept, totalSec);
-    var extended = 0;
-    for (var h = 0; h < kept.length; h++) if (held[h].tEnd > kept[h].tEnd + 1e-9) extended++;
+    // §CPE_ROOM_TITLE_LEAD: where the dive ends, so the film's FIRST caption is not thrown up over
+    // empty sky. `plan.beats` is the plan's own §CINEMA_BEATS fractions — read, never re-derived.
+    // DEGRADE, DON'T DISABLE (this lane's own lesson from §CPE_GHOST_GROUND): a re-opened authored
+    // path or a stale cached effects.js has no `beats`, and that must cost the dive clip only — the
+    // captions still lead. Silence is what made that bug expensive last time, so it is logged either way.
+    var diveEndSec = 0, diveSrc = 'none(no dive clip)';
+    if (plan && plan.beats && plan.beats.dive > 0) {
+      diveEndSec = plan.beats.dive * totalSec;
+      diveSrc = 'plan.beats';
+    }
+    console.log('§CPE_ROOM_TITLE_DIVE src=' + diveSrc + ' diveEndSec=' + diveEndSec.toFixed(2));
+    // §CPE_ROOM_TITLE_LEAD: open each caption LEAD early, drop the ones that cannot get their full
+    // MIN_HOLD, and let the newer room replace the older. Exposed (below) so the witness gates this
+    // exact function rather than a re-implementation.
+    var held = A.roomTitleApplyLead(kept, totalSec, diveEndSec);
+    var led = 0;
+    for (var h = 0; h < held.length; h++) if (held[h].entry > held[h].tStart + 1e-9) led++;
 
-    console.log('§CPE_ROOM_TITLE_TIMELINE segments=' + kept.length + ' suppressed=' + suppressed +
+    console.log('§CPE_ROOM_TITLE_TIMELINE segments=' + held.length + '/' + kept.length +
+      ' suppressed=' + suppressed +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +
-      ' held=' + extended + '/' + kept.length + '@' + MIN_HOLD + 's' +
+      ' lead=' + led + '/' + held.length + '@' + LEAD + 's' +
+      ' held=' + (held._held || 0) + '/' + held.length + '@' + MIN_HOLD + 's' +
+      ' skipped=' + (held._skipped || 0) + '(<' + MIN_HOLD + 's)' +
       ' totalSec=' + totalSec.toFixed(1) + ' ms=' + (performance.now() - t0).toFixed(1));
     return held;
   };
@@ -158,6 +181,54 @@ function setupCpeRoomTitle(A) {
   //   "give it 3 secs"                        -> every caption lasts at least MIN_HOLD
   //   "if another room cuts in ... it replace" -> unless the next caption starts first, which wins
   // A caption is never shortened below what it earned, and never runs past the film.
+  // §CPE_ROOM_TITLE_LEAD — the arbitration, and the ONLY place caption times are decided. Pure, so
+  // the witness gates it at exact times instead of hoping a camera path produces them. Input is the
+  // room-dwell list (tStart = the sample the camera ENTERED on, tEnd = the sample it LEFT on); output
+  // is the captions actually shown, each carrying `entry` so a caller — and the gate — can still see
+  // the doorway the caption is leading into.
+  //
+  // Four rules, all the user's own words:
+  //   "about 2 secs before"                  -> a caption OPENS at tStart - LEAD
+  //   "clipped to dive end" (their ruling)   -> ...but the film's first caption never opens over the dive
+  //   "tries to show up to 3 secs.. if misses, then skips"
+  //                                          -> a caption that cannot get its full MIN_HOLD is DROPPED,
+  //                                             never shown for less. This is what retires the flash.
+  //   "when new room appears" / "it can replace so"
+  //                                          -> the next caption's APPEARANCE ends this one, even
+  //                                             though the camera may still be inside the old room.
+  // Skipped, never DELAYED: pushing a missed caption later would put the name on screen after the
+  // camera is already through the door — the exact failure the lead exists to kill.
+  A.roomTitleApplyLead = function(segs, totalSec, diveEndSec) {
+    if (!segs || !segs.length) return segs || [];
+    var sel = [], skipped = 0, lastShow = -Infinity, i;
+    for (i = 0; i < segs.length; i++) {
+      var s = segs[i];
+      var show = Math.max(0, s.tStart - LEAD);
+      // The first caption of the film only. `Math.min(s.tStart, ...)` is load-bearing: the dive clip
+      // may push a caption LATER, but never past its own doorway — that would be the "too late" the
+      // user is complaining about, reintroduced by the fix for it.
+      if (!sel.length && diveEndSec > 0) show = Math.max(show, Math.min(s.tStart, diveEndSec));
+      if (sel.length && show < lastShow + MIN_HOLD - 1e-9) { skipped++; continue; }
+      sel.push({ guid: s.guid, name: s.name, entry: s.tStart, tStart: show, tEnd: s.tEnd });
+      lastShow = show;
+    }
+    // Pre-clip the earned dwell at the NEXT caption's appearance, then hand the list to the shipped
+    // hold. That composition is deliberate: `roomTitleApplyHold` keeps its own rule ("never shorten
+    // what the camera actually dwelt") intact and stays gated by its own witness, while the user's
+    // replacement ruling — the newer room wins even mid-dwell — is applied HERE, where it belongs.
+    for (i = 0; i < sel.length - 1; i++) {
+      if (sel[i].tEnd > sel[i + 1].tStart) sel[i].tEnd = sel[i + 1].tStart;
+    }
+    var held = A.roomTitleApplyHold(sel, totalSec), extended = 0;
+    for (i = 0; i < held.length; i++) {
+      held[i].entry = sel[i].entry;
+      if (held[i].tEnd > sel[i].tEnd + 1e-9) extended++;   // the hold did real work on this one
+    }
+    held._skipped = skipped;
+    held._held = extended;
+    return held;
+  };
+
   A.roomTitleApplyHold = function(segs, totalSec) {
     if (!segs || !segs.length) return segs || [];
     var out = [], i;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v900';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v901';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_room_title.js
+++ b/witness_cpe_room_title.js
@@ -52,7 +52,14 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-ROOM-TITLE TIMEOUT �
     const r0 = rooms[0], r1 = rooms[rooms.length - 1];
     const p0 = A.ifc2three(r0.cx, r0.cy, r0.cz), p1 = A.ifc2three(r1.cx, r1.cy, r1.cz);
     const plan = { poseAt: function(tn) { const p = tn < 0.5 ? p0 : p1; return { x: p.x, y: p.y, z: p.z, tx: p.x + 1, ty: p.y, tz: p.z }; } };
-    const segs = A.roomTitleBuildTimeline(plan, 6); // 3s/room — well over MIN_DWELL
+    // 10s/room. FIXTURE CHANGED 2026-08-01 (§CPE_ROOM_TITLE_LEAD), assertion NOT touched — it still
+    // demands exactly 2 segments named through friendlyName, which is the claim this gate exists to
+    // make. The old fixture was 6s (3s/room) and now yields ONE caption, correctly: a caption opens
+    // 2s before its doorway and owns a 3s slot, so two rooms entered 3.0s apart cannot both have one
+    // — the second "misses, then skips", the user's own rule. That is arbitration, not naming, and it
+    // is gated in witness_cpe_room_title_lead.js G-TL-3. Spacing the rooms puts this gate back on its
+    // own subject instead of failing for someone else's reason.
+    const segs = A.roomTitleBuildTimeline(plan, 20); // 10s/room — well over MIN_DWELL and the 3s slot
     return {
       ok: true, segs: segs,
       expected0: A.friendlyName(r0.name, null), expected1: A.friendlyName(r1.name, null),

--- a/witness_cpe_room_title_lead.js
+++ b/witness_cpe_room_title_lead.js
@@ -1,0 +1,204 @@
+// WITNESS — §CPE_ROOM_TITLE_LEAD: name the room you are HEADING INTO, not the one you are in.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_LEAD.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, 2026-08-01, while a bake ran):
+//   "room labelling i got a suggestion is that should not wait to be in the room but as it is
+//    heading towards a room, about 2 secs before will be view point friendly."
+//   "for every room too... not wait till inside room it can be too late as 3 secs optimum label
+//    appearance"
+//   "even though just left room,.. but when new room appears, it tries to show also up to 3 secs..
+//    and if misses, then skips"
+// A caption started at the first sample INSIDE the room's plan rect, so the name arrived after the
+// doorway had already gone past — and §CPE_ROOM_TITLE_HOLD's 3s floor could still be cut short by a
+// fast next room, so a caption could still flash by unread.
+//
+// Gated on `A.roomTitleApplyLead` — the SAME function the timeline builder calls, fed synthetic
+// segment lists so each rule fires at an exact time rather than hoping a camera path produces one,
+// plus a real-timeline invariant sweep so the synthetic gates cannot drift from the product.
+//
+//   G-TL-1  RED before this change: a caption APPEARS 2s before entry, not at entry.
+//   G-TL-2  no negative time, and the film's first caption never opens before the dive ends.
+//   G-TL-3  the skip rule: a room entered too soon after the last caption is DROPPED, not flashed.
+//   G-TL-4  the replacement rule: the previous caption ends exactly when the new one APPEARS.
+//   G-TL-5  the hold is still a floor, not a cap — an 8s dwell is not cut to 3s.
+//   G-TL-6  ordering/monotonicity: starts ordered, no segment ends before it starts.
+//   G-TL-7  on a REAL timeline every caption satisfies all of the above.
+//   G-TL-8  the log says how many captions led, and how many were skipped for want of 3s.
+//   G-TL-9  degrade, not disable: no dive info still leads, and says so.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8443;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const LEAD = 2.0;
+const HOLD = 3.0;
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.roomTitleApplyHold && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const res = await page.evaluate(async () => {
+      const A = window.APP;
+      const seg = (name, a, b) => ({ guid: name, name, tStart: a, tEnd: b });
+      const out = { hasFn: typeof A.roomTitleApplyLead === 'function' };
+      if (!out.hasFn) return out;
+
+      // G-TL-1 / G-TL-5: one caption, well clear of the film start. Compare against what the
+      // SHIPPED path (hold only) produces for the same input — that is the RED.
+      out.today = A.roomTitleApplyHold([seg('kitchen', 10, 11.5)], 100);
+      out.solo = A.roomTitleApplyLead([seg('kitchen', 10, 11.5)], 100, 0);
+      out.longDwell = A.roomTitleApplyLead([seg('hall', 10, 18)], 100, 0);
+
+      // G-TL-2: entry inside the lead window, and a film whose dive ends at 6s.
+      out.atStart = A.roomTitleApplyLead([seg('lobby', 1.0, 4.0)], 100, 0);
+      out.diveClipped = A.roomTitleApplyLead([seg('lobby', 7.0, 10.0)], 100, 6.0);
+      // the dive clip must never push a caption PAST its own doorway: entry before the dive ends.
+      out.diveLate = A.roomTitleApplyLead([seg('lobby', 4.0, 9.0)], 100, 6.0);
+
+      // G-TL-3: second room entered 1.5s after the first — its slot would open at 9.5, inside the
+      // first caption's guaranteed 3s (10 -> 13). It must be SKIPPED, not shown for 1.5s.
+      out.skipped = A.roomTitleApplyLead([seg('a', 12, 13.5), seg('b', 13.5, 16)], 100, 0);
+      // ...and one that DOES fit: entry 5s later, slot opens at 15 > 13.
+      out.fits = A.roomTitleApplyLead([seg('a', 12, 13.5), seg('b', 17, 19)], 100, 0);
+
+      // G-TL-4: the new caption appears while the camera is STILL inside the old room (a long dwell
+      // that runs past the next room's lead-in) — the newer room must take the screen.
+      out.replaced = A.roomTitleApplyLead([seg('a', 10, 20), seg('b', 21, 24)], 100, 0);
+
+      // G-TL-7: the real thing.
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      const DUR = 60;
+      let real = [];
+      try {
+        const plan = A.cinemaPathPlan(DUR);
+        out.planBeats = plan && plan.beats ? plan.beats.dive : null;
+        real = A.roomTitleBuildTimeline(plan, DUR) || [];
+      } catch (e) { out.realErr = e.message; }
+      out.real = real.map(s => ({ name: s.name, tStart: +s.tStart.toFixed(2), tEnd: +s.tEnd.toFixed(2),
+                                 entry: s.entry == null ? null : +s.entry.toFixed(2) }));
+      out.realTotal = DUR;
+      return out;
+    });
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+    const dur = s => +(s.tEnd - s.tStart).toFixed(3);
+    const near = (a, b) => Math.abs(a - b) < 1e-6;
+
+    if (!res.hasFn) {
+      P('G-TL-1..9 A.roomTitleApplyLead exists', false, 'not exported — the feature is not built');
+      console.log(`\n  ${BLD}: 0/1`);
+      allPass = false;
+      await page.close();
+      continue;
+    }
+
+    P('G-TL-1 a caption APPEARS 2s before entry (RED today: the shipped hold starts it at entry)',
+      near(res.solo[0].tStart, 8.0) && near(res.today[0].tStart, 10.0),
+      `entry 10.0 -> shipped caption starts ${res.today[0].tStart} (at the doorway), ` +
+      `led caption starts ${res.solo[0].tStart} and runs to ${res.solo[0].tEnd} (${dur(res.solo[0])}s)`);
+
+    P('G-TL-2 no negative time; the first caption never opens before the dive ends',
+      res.atStart[0].tStart >= 0 && near(res.diveClipped[0].tStart, 6.0) && near(res.diveLate[0].tStart, 4.0),
+      `entry 1.0 with no dive -> starts ${res.atStart[0].tStart} (clamped at 0); ` +
+      `entry 7.0 with a 6.0s dive -> starts ${res.diveClipped[0].tStart} (clipped to the dive end, not 5.0); ` +
+      `entry 4.0 with a 6.0s dive -> starts ${res.diveLate[0].tStart} (its own doorway, never later)`);
+
+    P('G-TL-3 a room entered too soon is SKIPPED, not flashed — every shown caption gets its 3s',
+      res.skipped.length === 1 && dur(res.skipped[0]) >= HOLD - 1e-6 && res.fits.length === 2 &&
+      res.fits.every(s => dur(s) >= HOLD - 1e-6),
+      `rooms at 12.0 and 13.5 (1.5s apart) -> ${res.skipped.length} caption ` +
+      `[${res.skipped.map(s => `${s.name} ${s.tStart}→${s.tEnd}`).join(', ')}]; ` +
+      `rooms at 12.0 and 17.0 -> ${res.fits.length} captions ` +
+      `[${res.fits.map(s => `${s.name} ${s.tStart}→${s.tEnd} (${dur(s)}s)`).join(', ')}]`);
+
+    P('G-TL-4 the previous caption ends exactly when the new one APPEARS — never two at once',
+      res.replaced.length === 2 && near(res.replaced[0].tEnd, res.replaced[1].tStart),
+      `a dwells 10→20, b enters at 21: a shows ${res.replaced[0].tStart}→${res.replaced[0].tEnd}, ` +
+      `b appears ${res.replaced[1].tStart} (a is cut at b's appearance, though the camera was still in a)`);
+
+    P('G-TL-5 the hold is a floor, not a cap — an 8s dwell is not cut to 3s',
+      near(res.longDwell[0].tEnd, 18.0),
+      `dwell 10→18 becomes ${res.longDwell[0].tStart}→${res.longDwell[0].tEnd} (${dur(res.longDwell[0])}s on screen)`);
+
+    const mono = res.fits.every((s, i, arr) => s.tEnd >= s.tStart && (i === 0 || s.tStart >= arr[i - 1].tStart));
+    P('G-TL-6 ordering survives: starts ordered, no caption ends before it starts',
+      mono, `segments=${JSON.stringify(res.fits)}`);
+
+    if (res.realErr || !res.real.length) {
+      P('G-TL-7 real timeline invariant', false,
+        (res.realErr || 'the real plan produced no captions on this building') + ' — INCONCLUSIVE, not a product verdict');
+    } else {
+      const bad = res.real.filter((s, i, arr) => {
+        if (s.tEnd < s.tStart) return true;                                    // inverted
+        if (i > 0 && s.tStart < arr[i - 1].tEnd - 1e-6) return true;           // overlap
+        if (s.entry != null && s.tStart > s.entry + 1e-6) return true;         // shown AFTER the doorway
+        if (s.tEnd - s.tStart >= HOLD - 1e-6) return false;                    // got its 3s
+        return Math.abs(s.tEnd - res.realTotal) > 1e-6;                        // or the film ended
+      });
+      P('G-TL-7 on a REAL timeline every caption leads its doorway, gets 3s (or the film ends), and never overlaps',
+        bad.length === 0,
+        `${res.real.length} captions, planBeats.dive=${res.planBeats}: ` +
+        res.real.map(s => `${s.name} ${s.tStart}→${s.tEnd} (enters ${s.entry})`).join('  |  ') +
+        (bad.length ? `   VIOLATIONS: ${JSON.stringify(bad)}` : ''));
+
+      // ⚠ G-TL-7 alone can pass with the lead NEVER FIRING — measured: on Duplex the only room is
+      // entered at 5.4s and the dive ends at 5.57s, so the clip legitimately pushes the caption to
+      // its own doorway and `lead=0/1`. A gate that green-lights zero lead is the trap this lane
+      // already paid for once (§CPE_GHOST_GROUND armed in a regime the bake never reached). So every
+      // caption must be EXPLAINED: a full 2s lead, or the film start, or the dive clip — nothing else.
+      const diveEnd = res.planBeats != null ? res.planBeats * res.realTotal : 0;
+      const why = res.real.map((s, i) => {
+        if (near(s.tStart, s.entry - LEAD)) return { name: s.name, why: 'led 2.0s' };
+        if (near(s.tStart, 0)) return { name: s.name, why: 'film start' };
+        if (i === 0 && diveEnd > 0 && near(s.tStart, Math.min(s.entry, diveEnd)))
+          return { name: s.name, why: `dive clip (dive ends ${diveEnd.toFixed(2)})` };
+        return { name: s.name, why: 'UNEXPLAINED' };
+      });
+      const unex = why.filter(w => w.why === 'UNEXPLAINED');
+      P('G-TL-7b every caption\'s appearance is a full 2s lead, or explained by the film start / the dive clip',
+        unex.length === 0,
+        why.map(w => `${w.name}: ${w.why}`).join('  |  '));
+    }
+
+    const line = logs.filter(l => /§CPE_ROOM_TITLE_TIMELINE/.test(l)).slice(-1)[0] || '';
+    P('G-TL-8 the log reports the lead and the skips',
+      /lead=\d+\/\d+@2s/.test(line) && /skipped=\d+/.test(line), line || 'no §CPE_ROOM_TITLE_TIMELINE line');
+
+    const degraded = logs.filter(l => /§CPE_ROOM_TITLE_DIVE/.test(l)).slice(-1)[0] || '';
+    P('G-TL-9 degrade, not disable: the dive source is named in the log, and no dive info still leads',
+      /§CPE_ROOM_TITLE_DIVE src=/.test(degraded) && near(res.solo[0].tStart, 8.0),
+      `${degraded || 'no §CPE_ROOM_TITLE_DIVE line'} | with diveEndSec=0 a caption still leads by ` +
+      `${(10 - res.solo[0].tStart).toFixed(1)}s`);
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User, while a bake ran: "room labelling i got a suggestion is that should not wait to be in the room
but as it is heading towards a room, about 2 secs before will be view point friendly." Then, ruling
on the one open question and on arbitration: "for every room too... not wait till inside room it can
be too late as 3 secs optimum label appearance" / "even though just left room,.. but when new room
appears, it tries to show also up to 3 secs.. and if misses, then skips" / first caption: yes, but
clipped to the dive's end.

A caption is now a 3-SECOND SLOT THAT OPENS 2s BEFORE THE DOORWAY, not a report of where the camera
already is. Four rules, all theirs:
  "about 2 secs before"        -> a caption opens at tStart - LEAD (2.0s)
  "clipped to dive end"        -> ...but the film's FIRST caption never opens over the dive, and the
                                  clip may never push it past its own doorway either
  "if misses, then skips"      -> a caption that cannot get its full 3s is DROPPED, never flashed.
                                  This is what retires the flash: MIN_HOLD becomes a real guarantee,
                                  where the shipped hold could still be cut short by a fast next room
  "it can replace so"          -> the next caption's APPEARANCE ends this one, even mid-dwell

Skipped, never DELAYED — pushing a missed caption later would put the name on screen after the camera
is already through the door, the exact failure the lead exists to kill. The hold stays a FLOOR: an 8s
dwell is still an 8s caption. `roomTitleApplyHold` is unchanged and still does the holding, composed
inside the new arbitration, so its own 8/8 gate stays honest rather than being replaced.

WITNESSED — witness_cpe_room_title_lead.js, Duplex 10/10 + Hospital 10/10:
  G-TL-1   entry 10.0 -> shipped caption starts 10.0 (at the doorway), led caption starts 8.0 (the RED)
  G-TL-3   rooms 1.5s apart -> ONE caption, not two flashes; 5s apart -> two, both >= 3s
  G-TL-4   a dwells 10->20, b enters 21: a is cut at 19 when b APPEARS, though the camera is still in a
  G-TL-7b  Hospital's real film: 3 of 4 captions lead the full 2.0s, the 4th explained by the dive clip
Regressions GREEN: room_title 11/11, hold 8/8, height 5/5, timing 3/3.

⚠ TWO THINGS WORTH READING BEFORE THE DIFF:
- G-TL-7 alone passed on Duplex with `lead=0/1` — its only room is entered 5.4s in and the dive ends
  at 5.57s, so nothing led and the gate was green anyway. G-TL-7b was added to make every caption's
  appearance EXPLAIN itself (full lead / film start / dive clip, nothing else). Same trap this lane
  paid for in §CPE_GHOST_GROUND: a gate that passes in a regime the product never reaches.
- witness_cpe_room_title.js's W-TITLE-NAME-SOURCE fixture went 6s -> 20s. The ASSERTION is untouched
  (still exactly 2 segments, still named through friendlyName). Its two rooms were 3.0s apart, which
  under the skip rule correctly yields ONE caption — that is arbitration, gated in G-TL-3, not naming.
  The fixture was corrected, the bar was not lowered.

NOT CHANGED, deliberately: MIN_DWELL (1.4s) still drops rooms crossed faster than that. The skip rule
makes strobing impossible on its own, but the dwell filter still stops a 0.15s clip through a corner
from claiming a 3s slot and starving a real room a second later. Retiring it is the user's call.

NOT NEEDED, and nearly shipped anyway: `plan.beats` already exists (effects.js:6336). The spec called
for adding it and the build added a DUPLICATE key in the same object literal — silently legal, wholly
dead. Caught by baselining a regression against `git show HEAD:`. effects.js is untouched here.

viewer sw v900 -> v901.
Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_LEAD.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)