### PR TITLE
feat(cinema): §CPE_ROOM_TITLE_GAZE — caption the room the camera is LOOKING INTO (1 → 15 on Hospital)

### DIFF
--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -102,6 +102,97 @@ function setupCpeRoomTitle(A) {
     return best;
   }
 
+  // §CPE_ROOM_TITLE_GAZE (user ruling 2026-08-01, on the measured §CPE_ROOM_TITLE_FLYOVER_BLIND —
+  // "Label what the camera looks at"): a caption names the room the camera is LOOKING INTO, not the
+  // one it is standing in. A 147.9s Hospital flyover produced ONE caption under containment, because
+  // 31% of its samples were over a room's footprint but a full storey above its datum — the camera
+  // is simply never inside anything.
+  //
+  // Ray vs. room AABB, exact, no marching. A step size would be an invented constant that either
+  // skips through small rooms or costs hundreds of steps a sample; the slab test needs none and is
+  // the same O(rooms) per sample the point test already pays. The room's box is the one it already
+  // has: `rects` for x/y, and the SAME storey band `_roomAtIfcPoint` uses for z — reused, never
+  // relaxed, so a ray passing 20 m above a room still misses it and §CPE_ROOM_TITLE_HEIGHT_BLIND
+  // (PR #1108) stays closed. Nearest positive hit wins.
+  var _gazeMissedAll = 0;
+  function _roomAlongGaze(ox, oy, oz, dx, dy, dz) {
+    var g = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
+    if (!g || !g.nodesByGuid) return null;
+    var L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (!(L > 1e-9)) return null;
+    dx /= L; dy /= L; dz /= L;
+    var pitch = _storeyPitch(g), band = pitch > 0 ? pitch : Infinity;
+    var best = null, bestT = Infinity, bestDz = Infinity;
+    for (var k in g.nodesByGuid) {
+      var n = g.nodesByGuid[k];
+      if (!n || n.kind !== 'room' || !n.rects || !n.rects.length) continue;
+      // An infinite band (single-storey building, no pitch derivable) makes the z slab a no-op —
+      // the same disabling _roomAtIfcPoint already does rather than guess a height.
+      var z0 = (n.cz || 0) - band, z1 = (n.cz || 0) + band;
+      for (var i = 0; i < n.rects.length; i++) {
+        var r = n.rects[i];
+        var tN = -Infinity, tF = Infinity, s;
+        // x slab
+        if (Math.abs(dx) < 1e-12) { if (ox < r.x0 || ox > r.x1) continue; }
+        else {
+          var ax = (r.x0 - ox) / dx, bx = (r.x1 - ox) / dx;
+          if (ax > bx) { s = ax; ax = bx; bx = s; }
+          if (ax > tN) tN = ax; if (bx < tF) tF = bx;
+        }
+        // y slab
+        if (Math.abs(dy) < 1e-12) { if (oy < r.y0 || oy > r.y1) continue; }
+        else {
+          var ay = (r.y0 - oy) / dy, by = (r.y1 - oy) / dy;
+          if (ay > by) { s = ay; ay = by; by = s; }
+          if (ay > tN) tN = ay; if (by < tF) tF = by;
+        }
+        // z slab — the storey band, identical to the point test's
+        if (isFinite(band)) {
+          if (Math.abs(dz) < 1e-12) { if (oz < z0 || oz > z1) continue; }
+          else {
+            var az = (z0 - oz) / dz, bz = (z1 - oz) / dz;
+            if (az > bz) { s = az; az = bz; bz = s; }
+            if (az > tN) tN = az; if (bz < tF) tF = bz;
+          }
+        }
+        if (tF < 0 || tN > tF) continue;          // behind the camera, or no overlap
+        var tHit = tN < 0 ? 0 : tN;               // inside the box already -> hit at the camera
+        // ⚠ Ties are NOT hash order. Stacked storeys share x/y, so a camera standing inside one room
+        // is inside several room BOXES at once and every one of them hits at t=0 — whichever the
+        // `for..in` reached first would win, and witness_cpe_room_title.js caught exactly that
+        // (segment 2 came back as "≈ Level 1 R2" instead of the room the camera was in). The point
+        // test has always broken this tie by NEAREST STOREY DATUM; the ray must do the same, or the
+        // gaze rule silently loses §CPE_ROOM_TITLE's floor disambiguation.
+        var dzHit = Math.abs((n.cz || 0) - (oz + dz * tHit));
+        if (tHit < bestT - 1e-6 || (Math.abs(tHit - bestT) <= 1e-6 && dzHit < bestDz)) {
+          bestT = tHit; bestDz = dzHit; best = n;
+        }
+        break;
+      }
+    }
+    if (!best) _gazeMissedAll++;
+    _lastGazeT = best ? bestT : null;
+    return best;
+  }
+  var _lastGazeT = null;
+
+  // Exposed so witness_cpe_room_title_gaze.js gates THIS ray, not a re-implementation of it, and can
+  // recompute the hit point itself to prove the captioned room really contains it (G-GZ-2).
+  // The rule this REPLACES, exposed so G-GZ-1's baseline is the real previous behaviour rather than a
+  // number copied out of an old log or re-implemented in the gate.
+  A.roomTitleContainProbe = function(ix, iy, iz) {
+    var n = _roomAtIfcPoint(ix, iy, iz);
+    return n ? { guid: n.guid, name: _titleFor(n).name } : null;
+  };
+
+  A.roomTitleGazeProbe = function(ox, oy, oz, dx, dy, dz) {
+    var n = _roomAlongGaze(ox, oy, oz, dx, dy, dz);
+    if (!n) return null;
+    var g = A.getRoomGraph(), pitch = _storeyPitch(g);
+    return { guid: n.guid, name: _titleFor(n).name, t: _lastGazeT, cz: n.cz,
+             band: pitch > 0 ? pitch : null, rects: n.rects };
+  };
+
   // ⚠ HOVER_NAME.md §1 / this feature's own scope note: consume A.friendlyName, never a second
   // naming path. A room's stored name is already human-authored or compiler-synthesized-friendly
   // (e.g. "≈ Roof R1") — friendlyName is a no-op passthrough for those, but running every title
@@ -119,13 +210,27 @@ function setupCpeRoomTitle(A) {
   // per-t lookup as trivial next to a bake's real cost (a full still-refine per frame).
   A.roomTitleBuildTimeline = function(plan, totalSec) {
     var t0 = performance.now();
-    _rejectedByHeight = 0;
-    var samples = [];
+    _rejectedByHeight = 0; _gazeMissedAll = 0;
+    var samples = [], rule = 'gaze', noTarget = 0;
     for (var t = 0; t <= totalSec + 1e-6; t += SAMPLE_DT) {
       var tn = totalSec > 0 ? Math.min(1, t / totalSec) : 0;
       var p = plan.poseAt(tn);
       var ifcP = A.three2ifc ? A.three2ifc(p.x, p.y, p.z) : null;
-      var room = ifcP ? _roomAtIfcPoint(ifcP.ix, ifcP.iy, ifcP.iz) : null;
+      var room = null;
+      // §CPE_ROOM_TITLE_GAZE: the room the LOOK DIRECTION enters. `poseAt` already carries the look
+      // target beside the position, so the gaze needs no new machinery — and because the ray starts
+      // AT the camera, a camera standing inside a room still resolves to that room (nearest hit,
+      // t=0). Walk films therefore do not regress; only the flyover case changes.
+      // DEGRADE, DON'T DISABLE: a plan whose poseAt returns no target (an older cached effects.js)
+      // falls back to the containment test and the log says so, rather than captioning nothing.
+      if (ifcP && p.tx != null) {
+        var ifcT = A.three2ifc(p.tx, p.ty, p.tz);
+        if (ifcT) room = _roomAlongGaze(ifcP.ix, ifcP.iy, ifcP.iz,
+                                        ifcT.ix - ifcP.ix, ifcT.iy - ifcP.iy, ifcT.iz - ifcP.iz);
+      } else if (ifcP) {
+        noTarget++; rule = 'containment(no poseAt target)';
+        room = _roomAtIfcPoint(ifcP.ix, ifcP.iy, ifcP.iz);
+      }
       samples.push({ t: t, guid: room ? room.guid : null, node: room });
     }
     var raw = [];
@@ -165,8 +270,9 @@ function setupCpeRoomTitle(A) {
     var led = 0;
     for (var h = 0; h < held.length; h++) if (held[h].entry > held[h].tStart + 1e-9) led++;
 
-    console.log('§CPE_ROOM_TITLE_TIMELINE segments=' + held.length + '/' + kept.length +
+    console.log('§CPE_ROOM_TITLE_TIMELINE rule=' + rule + ' segments=' + held.length + '/' + kept.length +
       ' suppressed=' + suppressed +
+      ' gazeMissedAll=' + _gazeMissedAll + '/' + samples.length +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +
       ' lead=' + led + '/' + held.length + '@' + LEAD + 's' +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v901';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v902';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_room_title_gaze.js
+++ b/witness_cpe_room_title_gaze.js
@@ -1,0 +1,207 @@
+// WITNESS — §CPE_ROOM_TITLE_GAZE: caption the room the camera is LOOKING INTO.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_GAZE.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (§CPE_ROOM_TITLE_FLYOVER_BLIND, measured 2026-08-01 from the
+// user's own preview log on a 147.9s Hospital buildup film):
+//   §CPE_ROOM_TITLE_TIMELINE segments=1/1 suppressed=2 rejectedByHeight=306 storeyPitch=5.0m
+// 987 samples, 306 of them (31%) over a room's FOOTPRINT but a full storey above its datum, and ONE
+// caption in a 148-second film. Containment answers "which room am I in"; a wide flyover is never in
+// one. User ruling: "Label what the camera looks at" — as the rule, not as a fallback.
+//
+//   G-GZ-1  RED on the real thing: the same plan yields more captions by gaze than by containment.
+//   G-GZ-2  truthfulness: the hit point is recomputed here and must lie inside the captioned room's
+//           own AABB. Never a fabricated name.
+//   G-GZ-3  the storey band still bites — a ray passing above a room does not caption it (#1108).
+//   G-GZ-4  nearest-hit, not any-hit.
+//   G-GZ-5  a camera INSIDE a room still captions that room — walk films do not regress.
+//   G-GZ-6  the orbit beat is MEASURED, not assumed: how many captions, and does one hold the lap.
+//   G-GZ-7  cost stays the same order as the point test (the slab test's budget claim, checked).
+//   G-GZ-8  the log names the rule in force, so a stale cache cannot silently serve containment.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8443;
+const BUILDINGS = (process.env.BLDS || 'Hospital').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.roomTitleGazeProbe && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const res = await page.evaluate(async () => {
+      const A = window.APP;
+      const out = {};
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+
+      const g = A.getRoomGraph();
+      const rooms = Object.values(g.nodesByGuid).filter(n => n.kind === 'room' && n.rects && n.rects.length);
+      out.nRooms = rooms.length;
+
+      // The film the user actually ran: 147.9s.
+      const DUR = 147.9;
+      let segs = [];
+      try {
+        const plan = A.cinemaPathPlan(DUR);
+        out.hasTarget = plan.poseAt(0.5).tx != null;
+        segs = A.roomTitleBuildTimeline(plan, DUR) || [];
+        // G-GZ-1's baseline: the SAME plan, same sampling, resolved by containment — computed here
+        // rather than quoted from a log, so the comparison is like-for-like.
+        let contain = 0, lastGuid = null;
+        for (let t = 0; t <= DUR + 1e-6; t += 0.15) {
+          const p = plan.poseAt(Math.min(1, t / DUR));
+          const q = A.three2ifc(p.x, p.y, p.z);
+          const n = q ? A.roomTitleContainProbe(q.ix, q.iy, q.iz) : null;
+          const gid = n ? n.guid : null;
+          if (gid && gid !== lastGuid) contain++;
+          lastGuid = gid;
+        }
+        out.containRuns = contain;
+        // G-GZ-2: re-probe along the film and verify each hit geometrically.
+        const bad = [];
+        let probes = 0, hits = 0;
+        for (let t = 0; t <= DUR + 1e-6; t += 1.5) {
+          const p = plan.poseAt(Math.min(1, t / DUR));
+          const o = A.three2ifc(p.x, p.y, p.z), tg = A.three2ifc(p.tx, p.ty, p.tz);
+          if (!o || !tg) continue;
+          probes++;
+          const h = A.roomTitleGazeProbe(o.ix, o.iy, o.iz, tg.ix - o.ix, tg.iy - o.iy, tg.iz - o.iz);
+          if (!h) continue;
+          hits++;
+          const L = Math.hypot(tg.ix - o.ix, tg.iy - o.iy, tg.iz - o.iz) || 1;
+          const hx = o.ix + (tg.ix - o.ix) / L * h.t;
+          const hy = o.iy + (tg.iy - o.iy) / L * h.t;
+          const hz = o.iz + (tg.iz - o.iz) / L * h.t;
+          const E = 1e-6;
+          const inRect = h.rects.some(r => hx >= r.x0 - E && hx <= r.x1 + E && hy >= r.y0 - E && hy <= r.y1 + E);
+          const inBand = h.band == null || Math.abs(hz - h.cz) <= h.band + E;
+          if (!inRect || !inBand) bad.push({ t: +t.toFixed(1), name: h.name, inRect, inBand,
+                                             hit: [+hx.toFixed(2), +hy.toFixed(2), +hz.toFixed(2)],
+                                             cz: h.cz, band: h.band });
+        }
+        out.probes = probes; out.hits = hits; out.badHits = bad.slice(0, 5); out.nBad = bad.length;
+
+        // G-GZ-6: the orbit beat, measured. beats.rise is where the orbit starts.
+        const rise = plan.beats ? plan.beats.rise : null;
+        out.orbitFrom = rise;
+        if (rise != null) {
+          const orbitNames = new Set();
+          for (let tn = rise; tn <= 1.0 + 1e-9; tn += 0.01) {
+            const p = plan.poseAt(Math.min(1, tn));
+            const o = A.three2ifc(p.x, p.y, p.z), tg = A.three2ifc(p.tx, p.ty, p.tz);
+            if (!o || !tg) continue;
+            const h = A.roomTitleGazeProbe(o.ix, o.iy, o.iz, tg.ix - o.ix, tg.iy - o.iy, tg.iz - o.iz);
+            orbitNames.add(h ? h.name : '(none)');
+          }
+          out.orbitNames = [...orbitNames];
+        }
+      } catch (e) { out.err = e.message + ' | ' + (e.stack || '').split('\n')[1]; }
+      out.segs = segs.map(s => ({ name: s.name, tStart: +s.tStart.toFixed(2), tEnd: +s.tEnd.toFixed(2) }));
+
+      // G-GZ-3 / G-GZ-4 / G-GZ-5: synthetic rays against a REAL room, so the geometry rules are
+      // exercised at exact offsets instead of hoping the film produces them.
+      const r0 = rooms[0];
+      const zs = [...new Set(rooms.map(n => Math.round(n.cz * 10) / 10))].sort((a, b) => a - b);
+      const gaps = []; for (let i = 1; i < zs.length; i++) { const d = zs[i] - zs[i - 1]; if (d > 0.5) gaps.push(d); }
+      gaps.sort((a, b) => a - b);
+      const pitch = gaps.length ? gaps[Math.floor(gaps.length / 2)] : 0;
+      out.pitch = pitch;
+      const c = { x: (r0.rects[0].x0 + r0.rects[0].x1) / 2, y: (r0.rects[0].y0 + r0.rects[0].y1) / 2, z: r0.cz };
+      const span = Math.max(r0.rects[0].x1 - r0.rects[0].x0, 10);
+      // level ray from outside, straight at the room's centre
+      out.level = A.roomTitleGazeProbe(c.x - span * 5, c.y, c.z, 1, 0, 0);
+      // G-GZ-3, CORRECTED 2026-08-01. The first version asserted "a ray 4 pitches higher must hit
+      // NOTHING" and went red against correct code: this is a 5-storey hospital, so a horizontal ray
+      // 20 m up simply enters Level 4's rooms instead — a true hit, not a fabricated one. The premise
+      // was wrong, not the ray. What #1108 actually forbids is naming a room you merely pass OVER, so
+      // that is what is asserted now, in two parts:
+      //   (a) the lifted ray must not still name the room it is flying above, and
+      //   (b) a ray above EVERY room's band must miss entirely — proving the z slab is enforced at
+      //       all, rather than the storey below happening to catch it.
+      out.high = A.roomTitleGazeProbe(c.x - span * 5, c.y, c.z + pitch * 4, 1, 0, 0);
+      const maxCz = Math.max(...rooms.map(n => n.cz || 0));
+      out.aboveAll = A.roomTitleGazeProbe(c.x - span * 5, c.y, maxCz + pitch * 3, 1, 0, 0);
+      out.maxCz = maxCz;
+      // camera standing INSIDE the room, looking anywhere (G-GZ-5)
+      out.inside = A.roomTitleGazeProbe(c.x, c.y, c.z, 1, 0, 0);
+      out.r0name = A.friendlyName(r0.name, null);
+      return out;
+    });
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+    if (res.err) {
+      P('G-GZ-1..8 the gaze pre-pass runs on a real plan', false, res.err);
+      console.log(`\n  ${BLD}: 0/1`); allPass = false; await page.close(); continue;
+    }
+
+    const line = logs.filter(l => /§CPE_ROOM_TITLE_TIMELINE/.test(l)).slice(-1)[0] || '';
+    const mSeg = /segments=(\d+)\//.exec(line);
+    const nSeg = mSeg ? +mSeg[1] : res.segs.length;
+
+    P('G-GZ-1 the gaze rule produces MORE captions than containment on the same 147.9s plan (RED: 1)',
+      nSeg > 1,
+      `gaze -> ${nSeg} captions [${res.segs.map(s => `${s.name} ${s.tStart}→${s.tEnd}`).join(' | ')}]` +
+      `  (containment room-runs over the same samples: ${res.containRuns})`);
+
+    P('G-GZ-2 every gaze hit lies inside the captioned room\'s own AABB — recomputed here, not trusted',
+      res.nBad === 0,
+      `${res.hits}/${res.probes} probes hit a room; ${res.nBad} bad` +
+      (res.nBad ? `  ${JSON.stringify(res.badHits)}` : ''));
+
+    P('G-GZ-3 the storey band still bites: a ray never names a room it flies OVER, and misses above them all',
+      !!res.level && (!res.high || res.high.guid !== res.level.guid) && !res.aboveAll,
+      `pitch=${res.pitch}m | level ray -> ${res.level ? res.level.name : 'MISS'} | ` +
+      `+${(res.pitch * 4).toFixed(1)}m -> ${res.high ? res.high.name : 'MISS'} ` +
+      `(must not be the room below it) | above every storey (z=${(res.maxCz + res.pitch * 3).toFixed(1)}) -> ` +
+      `${res.aboveAll ? res.aboveAll.name + ' (WRONG)' : 'MISS'}`);
+
+    P('G-GZ-5 a camera standing INSIDE a room still captions that room — walk films do not regress',
+      !!res.inside && res.inside.name === res.r0name && res.inside.t < 1e-6,
+      `inside ${res.r0name} -> ${res.inside ? `${res.inside.name} at t=${res.inside.t}` : 'MISS'}`);
+
+    P('G-GZ-4 nearest-hit: the level ray from outside resolves at a positive t, at the near face',
+      !!res.level && res.level.t > 0, `t=${res.level ? res.level.t.toFixed(2) : 'n/a'}m along the ray`);
+
+    P('G-GZ-6 the orbit beat is MEASURED (this gate reports, it does not judge)',
+      res.orbitFrom != null,
+      `orbit from tn=${res.orbitFrom} — distinct captions across the lap: ` +
+      `${res.orbitNames ? res.orbitNames.length : '?'} ${JSON.stringify(res.orbitNames || [])}`);
+
+    const mMs = /ms=([\d.]+)/.exec(line);
+    P('G-GZ-7 cost stays the same order as the point test (34ms on 987 samples before this change)',
+      mMs && +mMs[1] < 340, `§CPE_ROOM_TITLE_TIMELINE ms=${mMs ? mMs[1] : '?'} for ${res.nRooms} rooms`);
+
+    P('G-GZ-8 the log names the rule in force',
+      /rule=gaze/.test(line), line || 'no §CPE_ROOM_TITLE_TIMELINE line');
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User ruling, on the measured §CPE_ROOM_TITLE_FLYOVER_BLIND: "Label what the camera looks at" — as the
rule, not as a fallback.

THE DEFECT, from their own preview log on a 147.9s Hospital buildup film:
  §CPE_ROOM_TITLE_TIMELINE segments=1/1 suppressed=2 rejectedByHeight=306 storeyPitch=5.0m
987 samples; 306 of them (31%) sat over a room's FOOTPRINT but a full storey above its datum. ONE
caption in a 148-second film. Containment answers "which room am I in", and a wide flyover is never
in one. Neither the lead nor the hold was at fault — that same line reads lead=1/1@2s.

The gaze ray starts AT the camera, so a camera inside a room still resolves to that room (nearest hit,
t=0) and walk films do not change. Only the flyover case diverges — which is the case with one caption.

Ray vs. room AABB, exact, no marching: a step size would be an invented constant that either skips
through small rooms or costs hundreds of steps a sample. The room's box is the one it already has —
`rects` for x/y, and the SAME storey band the point test uses for z. REUSED, NEVER RELAXED: a ray
passing 20 m above a room still misses it, so PR #1108's bug stays closed. `poseAt` already carries
the look target beside the position, so no new aim machinery is added (and deliberately NOT
§CPE_AIM_DEPTH's `subject` — closure-local, walk-beat only, a density centroid rather than a point on
the model).

WITNESSED — witness_cpe_room_title_gaze.js, Hospital 8/8:
  G-GZ-1  the same 147.9s plan: 1 caption -> 15, against a containment baseline computed in the same
          run rather than quoted from an old log
  G-GZ-2  76/76 gaze hits re-derived in the gate and proven inside the captioned room's own AABB
  G-GZ-3  a ray never names a room it flies OVER, and misses entirely above every storey
  G-GZ-5  a camera inside a room still captions that room, at t=0
  G-GZ-6  the orbit lap MEASURED, not assumed: 11 distinct rooms across it, so it sweeps rather than
          holding one name — the 3s-slot rule is what thins it, and it already exists
  G-GZ-7  cost 34ms -> 108ms on 987 samples/224 rooms; same order, as the slab-test claim predicted
Regressions GREEN: room_title 11/11, lead 10/10, hold 8/8, height 5/5, timing 3/3.

⚠ TWO THINGS THE GATES CAUGHT THAT I HAD WRONG:
- G-GZ-3's first version asserted "a ray 4 pitches higher must hit NOTHING" and went red against
  correct code — this is a 5-storey hospital, so a horizontal ray 20 m up simply enters Level 4's
  rooms instead. A true hit, not a fabricated one. The gate's premise was wrong, not the ray; it now
  asserts what #1108 actually forbids (never name a room you pass OVER) plus a miss above every storey.
- Ties at t=0 were resolved by `for..in` order. Stacked storeys share x/y, so a camera inside one room
  is inside several room BOXES at once and all hit at t=0. witness_cpe_room_title.js caught it
  (segment 2 came back "≈ Level 1 R2" instead of the room the camera was in). The point test has
  always broken this tie by nearest storey datum; the ray now does the same.

⚠ THE PROMISE CHANGES, and the UI wording should follow: a caption now means "the room being looked
into", not "the room you are in". Not changed here because no wording was specified.

viewer sw v901 -> v902.
Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_GAZE.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)