### PR TITLE
fix(4d): §4D_ROOF_LOAD_PATH — a slab's role comes from its load path, not its storey name

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -133,18 +133,45 @@
   // Independent audit: count elements that start before a TRUE support finishes — structural,
   // XY-overlapping, rising from below (base < base-ε), topping within GAP of the target base.
   // 0 ⇒ nothing floats over its physical support. Works for any class (beams, furniture, MEP…).
+  // §4D_ROOF_LOAD_PATH M3 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH): the support
+  // grid used to be built ONLY from seq<=4 (structure) elements — the SAME trade-number assumption
+  // the scheduler's PASS A/B split makes. A wall (seq 6) can never be a support in that grid, so a
+  // roof slab carried by walls read as floating=0 (nothing to compare against) even while the real
+  // schedule built it before the walls under it — the audit shared the defect's own blind spot
+  // instead of catching it. Fix, MEASURED through two iterations:
+  //   attempt 1 | grid = EVERY element (any class a support for any class) | Hospital floating
+  //     0 -> 3421/10979, almost all "IfcBeam floats over IfcWallStandardCase" (1056), "IfcBeam
+  //     floats over IfcMember" (191) etc — seq<=4 PASS-A structure held to falsely "float" over
+  //     unrelated seq>4 PASS-B trades that finish much later in the crew-capped schedule for reasons
+  //     that have nothing to do with this defect. Walls do not structurally carry beams/members/
+  //     furniture in this DB.
+  //   attempt 2 | grid = structure PLUS walls, offered to every audited IfcSlab | Hospital floating
+  //     0 -> 24/10979 — better, but ALL 24 were ORDINARY (non-promoted, still seq 4) floor slabs
+  //     comparing themselves against a wall from a DIFFERENT storey that happens to sit geometrically
+  //     underneath. An un-promoted floor slab is PASS-A structure; it was never gated on any wall in
+  //     the real schedule (PASS A finishes long before PASS B's crew-capped walls even start), so
+  //     auditing it against a wall manufactures a violation the scheduler itself never claimed to
+  //     avoid.
+  //   correct scope | walls are only EVER a real candidate support for a slab M1 itself promoted to
+  //     seq 8 (roof role) — that is the one case where the real scheduler also moved the slab into
+  //     PASS B and made it wait on walls (§4D_ROOF_LOAD_PATH M2). An ordinary seq<=4 slab keeps its
+  //     original structure-only pool, unchanged from the proven pre-fix behaviour.
   function auditFloating(elements, sched, classFilter) {
-    var grid = {}, i, c, cs, k, arr, S;
+    var structGrid = {}, wallGrid = {}, i, c, cs, k, arr, S;
     for (i = 0; i < elements.length; i++) { var e = elements[i];
-      if (e.seq <= 4) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(e); } }
+      if (e.seq <= 4) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (structGrid[cs[c]] = structGrid[cs[c]] || []).push(e); }
+      else if (e.cls.indexOf('IfcWall') === 0) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (wallGrid[cs[c]] = wallGrid[cs[c]] || []).push(e); } }
     var v = 0;
     for (i = 0; i < elements.length; i++) { var T = elements[i];
       if (classFilter && !classFilter(T)) continue;
       var se = 0, seen = {}; cs = cellsOf(T);
-      for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
-        for (k = 0; k < arr.length; k++) { S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
-          if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
-            var en = sched[S.guid].end; if (en > se) se = en; } } }
+      var pools = (T.cls === 'IfcSlab' && T.seq > 4) ? [structGrid, wallGrid] : [structGrid];
+      for (var p = 0; p < pools.length; p++) {
+        for (c = 0; c < cs.length; c++) { arr = pools[p][cs[c]]; if (!arr) continue;
+          for (k = 0; k < arr.length; k++) { S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+            if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
+              var en = sched[S.guid].end; if (en > se) se = en; } } }
+      }
       if (se > 0 && sched[T.guid].start < se - 1) v++;
     }
     return v;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v902';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v903';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3282,7 +3282,7 @@
     }
 
     // ── Build elements with storey-aware overrides ──
-    var roofOverrides = 0, nameOverrides = 0;
+    var nameOverrides = 0;
     var elements = r[0].values.map(function(row) {
       var cls = row[1], elName = row[2] || '', rawStorey = row[3] || '_UNKNOWN', cz = row[5] || 0, bz = row[6] || 0;
       var cx = row[7] || 0, cy = row[8] || 0, bx = row[9] || 0, by = row[10] || 0;
@@ -3291,12 +3291,6 @@
       if (ov) nameOverrides++;
       var rule = ov || matchRule(cls);
       var seq = rule.sequence, phase = rule.phase;
-
-      // §A.1 Storey-aware override: slabs on "Roof" storey → Architecture/Roof seq 8
-      if (/roof/i.test(storey) && cls === 'IfcSlab' && seq < 8) {
-        seq = 8; phase = 'Architecture';
-        roofOverrides++;
-      }
 
       return {
         guid: row[0], cls: cls, name: elName, storey: storey,
@@ -3309,9 +3303,52 @@
       };
     });
     if (unknownReassigned) console.log('§GANTT_STOREY_Z reassigned=' + unknownReassigned + ' no-storey elements to nearest real storey by median Z');
-    if (roofOverrides) console.log('§GANTT_OVERRIDE ' + roofOverrides + ' roof slabs overridden to seq=8');
     if (nameOverrides) console.log('§NAME_OVERRIDE ' + nameOverrides + ' elements reclassified by name (' +
       NO.map(function(o){ return o.id; }).join(',') + ') — see rates/sequence_rules.json NAME_OVERRIDES');
+
+    // §4D_ROOF_LOAD_PATH M1 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH) — a slab's
+    // ROLE is a load-path fact, not a storey-name label. SUPERSEDES the deleted `/roof/i` override
+    // above: measured 2026-08-01, that regex fired ZERO times on Hospital ("Level 1..7A"/"Unknown")
+    // and LTU_AHouse ("TAKPLAN", Swedish) — the two roof slabs it was meant to catch have storey
+    // "Unknown". For each IfcSlab, take the IfcWall*/IfcWallStandardCase whose XY footprint overlaps
+    // it ("those walls"). Two checks from the SAME paragraph of the spec, both epsilon-free:
+    //   (a) the slab's base_z is above the average midheight of those walls — the walls are BELOW
+    //       and physically carry it.
+    //   (b) NONE of those walls stand ON it (no overlapping wall has base_z >= the slab's own
+    //       top_z) — this is the spec's own stated definition of "the floor case" ("floor slab:
+    //       walls stand ON it ... otherwise it stays a floor slab"), and it is NOT redundant with
+    //       (a): measured on this exact DB, (a) alone is true for nearly every capped-wall slab in
+    //       the building (35 slabs -> 23 "promoted"), including known mid-building intermediate
+    //       floors (base_z 176.81, between Level 2 and Level 3, 5 more levels above) — a slab that
+    //       caps the walls below it satisfies (a) whether or not it ALSO carries walls above, so (a)
+    //       alone cannot tell "top of the load path" from "one more floor in the middle of it". (b)
+    //       is the missing half of the spec's own description and brings Hospital down to the 2
+    //       true roof slabs + a handful of isolated panels with no wall directly overlapping the
+    //       next level up (open corridor/atrium bays) — reported, not silently forced to exactly 2.
+    // Promoted -> roof role -> seq 8, phase 'Architecture'. Otherwise stays whatever seq matchRule
+    // gave it (the floor case). No new numeric constant either way — both checks compare the slab
+    // against its own extracted geometry and the walls' own extracted geometry.
+    var loadPathWalls = elements.filter(function(e) { return e.cls.indexOf('IfcWall') === 0; });
+    var loadPathOverrides = 0;
+    elements.forEach(function(el) {
+      if (el.cls !== 'IfcSlab') return;
+      var carriers = loadPathWalls.filter(function(w) {
+        return el.x0 <= w.x1 && el.x1 >= w.x0 && el.y0 <= w.y1 && el.y1 >= w.y0;
+      });
+      if (!carriers.length) return;
+      var midSum = 0, hasWallAbove = false;
+      for (var ci = 0; ci < carriers.length; ci++) {
+        midSum += (carriers[ci].base_z + carriers[ci].top_z) / 2;
+        if (carriers[ci].base_z >= el.top_z) hasWallAbove = true;
+      }
+      var wallMidheight = midSum / carriers.length;
+      if (el.base_z > wallMidheight && !hasWallAbove) {
+        el.seq = 8; el.phase = 'Architecture';
+        loadPathOverrides++;
+      }
+    });
+    if (loadPathOverrides) console.log('§GANTT_OVERRIDE ' + loadPathOverrides +
+      ' slabs promoted to roof role (seq=8) by load path — base_z above the average midheight of their XY-overlapping walls');
 
     // §S260e: Sort by actual Z (quantized to 3m bands) → seq → fine Z
     // Real construction: lower Z builds first regardless of storey name.
@@ -3406,6 +3443,10 @@
     var _auditN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (_audit(elements[_bi])) _auditN++;
     var _float = ScheduleGate.auditFloating(elements, _sched, _audit);
     console.log('§SUPPORT_CHECK floating=' + _float + '/' + _auditN + ' (struct+furniture+walls over their XY support) gated=' + elements.length + ' (0=solved)');
+    // §4D_ROOF_LOAD_PATH witness hook (2026-08-01) — same double-underscore debug convention as
+    // __tmTrav/__forceFull/__tmStep above: read-only, lets witness_4d_roof_load_path.js compare the
+    // OLD (seq<=4-only) and NEW (M3) audit definitions against the SAME elements+schedule.
+    window.__tmScheduleDebug = { elements: elements, sched: _sched, audit: _audit };
 
     // §S260c BUG5: Log first 20 ops to verify bottom-up storey ordering
     var _first20 = [];

--- a/witness_4d_roof_load_path.js
+++ b/witness_4d_roof_load_path.js
@@ -1,0 +1,298 @@
+// WITNESS — §4D_ROOF_LOAD_PATH: a slab's ROLE is a load-path fact, not a storey-name label.
+// Spec: bim-compiler prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, watching a Hospital buildup: "how do we solve the 2
+// top boxes next to helicopter in Hospital getting their roofs first before the walls?"):
+// Hospital band 67 (z 201..204): two roof slabs sit ON TOP of eight walls, all inside one 3m
+// Z-band, so the bottom-up sort falls through to trade order — IfcSlab seq 4 beats IfcWall* seq 6.
+// Roofs scheduled before the walls that carry them.
+//
+// THE FIX, three rules (M1/M2/M3, see the spec for the full reasoning):
+//   M1 — a slab's role is derived from its load path (is it carried by walls below it, with
+//        nothing standing on it), never from a storey name. Deletes the old `/roof/i` premise,
+//        which fired ZERO times on Hospital ("Level 1..7A"/"Unknown") and LTU_AHouse ("TAKPLAN").
+//   M2 — verified NOT needed as a separate change: M1's reseq to 8 alone moves the slab into PASS
+//        B, where the per-phase trade gate makes it wait for the walls (seq 6) in the same phase.
+//   M3 — the "independent" audit shared the scheduler's blind spot (support grid = seq<=4 only,
+//        so a wall could never be found carrying anything). Rebuilt to find a support by GEOMETRY.
+//
+// MEASURED DURING THIS BUILD (reported honestly, not hidden): M1's literal spec formula (average
+// midheight of ALL XY-overlapping walls, no other condition) promotes 23/35 Hospital slabs,
+// including known mid-building intermediate floors — the average-only test does not actually
+// discriminate "top of the load path" from "one more floor in the middle of it" (a slab capping
+// walls below it satisfies that formula whether or not it ALSO carries walls above). Fixed by
+// adding the spec's OWN second clause from the same paragraph ("floor slab: walls stand ON it ...
+// otherwise it stays a floor slab") as an explicit condition: promoted only if ALSO no wall stands
+// on it. Brings Hospital to 10 promoted (2 true roof slabs + isolated panels with no wall directly
+// overlapping the next level, e.g. over an open corridor). Similarly M3's first widening (grid =
+// every element) took Hospital's §SUPPORT_CHECK from 0 to 3421/10979 floating — PASS-A structure
+// (built chronologically early) falsely "floating" over unrelated PASS-B walls (built later, crew-
+// capped) with no real support relationship. Rescoped: walls are only ever a candidate support for
+// a slab M1 itself promoted (seq>4) — ordinary floor slabs keep their original structure-only pool.
+// Both refinements are documented in time_machine.js/schedule_gate.js at the point of the code.
+//
+//   G-RLP-1  RED on unmodified main: Hospital band 67, both known roof slabs start before all
+//            eight walls that carry them finish. GREEN after: both start at/after the last wall.
+//   G-RLP-2  the role is DERIVED, not named: with every storey string blanked, the same two slabs
+//            are still classified as roofs (2/2). A name test scores 0 here.
+//   G-RLP-3  a FLOOR slab (walls stand ON it) is NOT promoted, on a real floor/wall pair from the
+//            same DB — the fix cannot pass by promoting everything.
+//   G-RLP-4  §GANTT_OVERRIDE reports the load-path promotion count; the old `/roof/i` wording
+//            ("roof slabs overridden to seq=8") is gone from the log — a stale build can't hide.
+//   G-RLP-5  M3's rebuilt audit, called directly (the real ScheduleGate.auditFloating) on the two
+//            known slabs + eight walls using REAL extracted geometry: fed the OLD (pre-fix,
+//            measured) timestamps it reports floating=2 (falsifies); fed the NEW (fixed) timestamps
+//            it reports 0. The OLD (pre-M3) audit definition, reproduced for comparison, reports 0
+//            on BOTH — proving the improvement is the audit, not the schedule.
+//   G-RLP-6  no regression: total ops placed == total elements (monotone, nothing dropped) on
+//            Hospital AND LTU_AHouse, and the real §SUPPORT_CHECK is 0/0 on both — the class of
+//            defect this audit exists to catch is gone, not just hidden again.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8450;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// The user's own case — Hospital band 67 (z 201..204), extracted 2026-08-01 via sqlite3 directly
+// against buildings/Hospital_extracted.db (elements_meta JOIN element_transforms). Real GUIDs, real
+// geometry — nothing invented.
+const ROOF_SLABS = ['3eq15PZlbCi8$6xdfFtxpB', '3Vxmv9vT1DBOVGP9f4HeYO'];
+const WALLS = ['3Vxmv9vT1DBOVGP9X4HeDg', '3Vxmv9vT1DBOVGP9X4HeH8', '3eq15PZlbCi8$6xdXFtxz5',
+  '3eq15PZlbCi8$6xdXFtxz4', '3eq15PZlbCi8$6xdXFtxz6', '3eq15PZlbCi8$6xdXFtxz7',
+  '3Vxmv9vT1DBOVGP9X4HeDp', '3Vxmv9vT1DBOVGP9X4HeGE'];
+// A genuine intermediate floor slab from the SAME DB (base_z 176.81, between Level 2 and Level 3,
+// five more levels above it) — walls stand ON it (level above) as well as under it. G-RLP-3's
+// "the fix cannot pass by promoting everything" control.
+const FLOOR_SLAB = '1OV06Y3c5D8vODNyxVnSVI';
+
+// RED baseline, measured 2026-08-01 on unmodified origin/main (git stash), same GUIDs, same DB,
+// logged to scratchpad/probe_g1_baseline.log — reproduced here as the gate's "before" numbers so
+// the claim is checkable without re-running against a stashed tree every time.
+const RED_BASELINE = {
+  slabStart: 1658885760000, slabEnd: 1658886720000, slabPhase: 'Superstructure',
+  wallEndMax: 1682822359000,
+};
+
+async function open(browser, bld) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${bld}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.dbQuery, { timeout: 300000 });
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM elements_meta'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 2000 });
+  await sleep(6000);
+  return { page, logs };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const checks = [];
+  let allPass = true;
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false;
+    console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+  console.log('='.repeat(78) + '\nHospital — G-RLP-1..5\n' + '='.repeat(78));
+  const { page, logs } = await open(browser, 'Hospital');
+
+  const res = await page.evaluate(async (roofSlabs, walls, floorSlabGuid) => {
+    const A = window.APP;
+    const out = {};
+    await window.tmActivateForBake();
+
+    function fetchOps(guids) {
+      return guids.map(g => {
+        const r = A.dbQuery("SELECT timestamp, parameters FROM kernel_ops WHERE output_guid='" + g +
+          "' AND op_type='ELEMENT_PLACE'");
+        if (!r.length) return { guid: g, missing: true };
+        const p = JSON.parse(r[0][1]);
+        return { guid: g, start: r[0][0], end: p._end_ts, phase: p.phase, storey: p.storey };
+      });
+    }
+    out.slabsFixed = fetchOps(roofSlabs);
+    out.wallsFixed = fetchOps(walls);
+    out.floorSlabFixed = fetchOps([floorSlabGuid])[0];
+
+    // ── G-RLP-4: the §GANTT_OVERRIDE log line ──
+    out.total = A.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class!='IfcOpeningElement'")[0][0];
+    out.placed = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+
+    // ── G-RLP-5: real extracted geometry for the 10 known elements, for a direct
+    // ScheduleGate.auditFloating call (both the current and the pre-M3 definition) ──
+    function fetchGeom(guids, cls, seq) {
+      return guids.map(g => {
+        const r = A.dbQuery('SELECT t.center_x,t.bbox_x,t.center_y,t.bbox_y,t.center_z,t.bbox_z ' +
+          "FROM element_transforms t WHERE t.guid='" + g + "'");
+        const [cx, bx, cy, by, cz, bz] = r[0];
+        return { guid: g, cls: cls, seq: seq, storey: 'Level 7', resource: cls === 'IfcSlab' ? 'CONCRETE_GANG' : 'MASON',
+          x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2, base_z: cz - bz / 2, top_z: cz + bz / 2 };
+      });
+    }
+    out.geomSlabs = fetchGeom(roofSlabs, 'IfcSlab', 8);   // seq=8: what M1 actually assigns
+    out.geomWalls = fetchGeom(walls, 'IfcWallStandardCase', 6);
+
+    // ── G-RLP-2: blank every storey string, refold, re-check the same 2 slabs ──
+    A.db.run("UPDATE elements_meta SET storey=''");
+    const before = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+    window.tmRefoldSchedule();
+    let waited = 0;
+    while (waited < 120000) {
+      await new Promise(r => setTimeout(r, 1000)); waited += 1000;
+      const n = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+      if (n >= before) break;
+    }
+    out.slabsBlanked = fetchOps(roofSlabs);
+    out.waitedMsForRefold = waited;
+
+    return out;
+  }, ROOF_SLABS, WALLS, FLOOR_SLAB);
+
+  // ── G-RLP-1 ──
+  const fixedSlabStarts = res.slabsFixed.map(s => s.start);
+  const fixedWallEnds = res.wallsFixed.map(w => w.end);
+  const minSlabStartFixed = Math.min(...fixedSlabStarts);
+  const maxWallEndFixed = Math.max(...fixedWallEnds);
+  const redViolated = RED_BASELINE.slabStart < RED_BASELINE.wallEndMax;
+  const greenOk = minSlabStartFixed >= maxWallEndFixed;
+  P('G-RLP-1 RED->GREEN: roof slabs no longer start before the walls that carry them finish',
+    redViolated && greenOk,
+    `RED (unmodified main, measured 2026-08-01): slab start=${RED_BASELINE.slabStart} ` +
+    `(${new Date(RED_BASELINE.slabStart).toISOString().slice(0,10)}, phase=${RED_BASELINE.slabPhase}) ` +
+    `< wall maxEnd=${RED_BASELINE.wallEndMax} (${new Date(RED_BASELINE.wallEndMax).toISOString().slice(0,10)}) ` +
+    `— VIOLATED (slabs built ~277 days before their own walls). ` +
+    `GREEN (this fix): slab minStart=${minSlabStartFixed} (${new Date(minSlabStartFixed).toISOString().slice(0,10)}, ` +
+    `phase=${res.slabsFixed[0].phase}) >= wall maxEnd=${maxWallEndFixed} (${new Date(maxWallEndFixed).toISOString().slice(0,10)}) — HOLDS`);
+
+  // ── G-RLP-2 ──
+  const blankedPromoted = res.slabsBlanked.every(s => s.phase === 'Architecture');
+  P('G-RLP-2 role is DERIVED not named: blanked storeys, same 2 slabs still classified as roof (2/2)',
+    blankedPromoted,
+    `waited ${res.waitedMsForRefold}ms for refold; ` +
+    res.slabsBlanked.map(s => `${s.guid.slice(0,8)}.. phase=${s.phase} storey="${s.storey}"`).join(', '));
+
+  // ── G-RLP-3 ──
+  const floorNotPromoted = res.floorSlabFixed && res.floorSlabFixed.phase !== 'Architecture';
+  P('G-RLP-3 a real floor slab (walls stand ON it, 5 more levels above) is NOT promoted',
+    floorNotPromoted,
+    `guid=${FLOOR_SLAB} base_z=176.81 (between Level 2/Level 3) phase=${res.floorSlabFixed && res.floorSlabFixed.phase} ` +
+    `(promotion would be phase=Architecture) — fix does not promote everything`);
+
+  // ── G-RLP-4 ──
+  const overrideLine = logs.filter(l => l.startsWith('§GANTT_OVERRIDE')).slice(-1)[0] || '';
+  const oldWordingPresent = logs.some(l => /roof slabs overridden to seq=8/.test(l));
+  P('G-RLP-4 §GANTT_OVERRIDE reports load-path promotions; old /roof\\/i wording is gone',
+    /load path/.test(overrideLine) && !oldWordingPresent,
+    `log: "${overrideLine}" | old wording present=${oldWordingPresent} (must be false)`);
+
+  // ── G-RLP-5: direct ScheduleGate.auditFloating call, OLD vs NEW definition, OLD vs NEW timestamps.
+  // Real wall timestamps come from res.wallsFixed (identical in both RED and GREEN runs — confirmed
+  // 2026-08-01: walls are seq6 in both, unaffected by M1, same crew-cap schedule either way). ──
+  const g5res = await page.evaluate((geomSlabs, geomWalls, wallSched, redSlabStart, redSlabEnd) => {
+    const SG = window.ScheduleGate;
+    const elements = geomSlabs.concat(geomWalls);
+    const REDsched = {}, GREENsched = {};
+    geomSlabs.forEach(s => {
+      REDsched[s.guid] = { start: redSlabStart, end: redSlabEnd };       // pre-fix measured
+    });
+    geomWalls.forEach(w => {
+      const ws = wallSched[w.guid];
+      REDsched[w.guid] = { start: ws.start, end: ws.end };
+    });
+    // GREEN: slabs scheduled properly via the real fixed schedule (from res.slabsFixed, passed in
+    // as part of geomSlabs' companion below) — simplest: run the REAL computeSchedule on this
+    // 10-element subset with seq=8 slabs, generous crew caps so this isolated subset doesn't queue.
+    GREENsched.computed = SG.computeSchedule(elements, 1600000000000, 1, { CONCRETE_GANG: 8, MASON: 8 });
+    elements.forEach(e => { GREENsched[e.guid] = GREENsched.computed[e.guid]; });
+
+    const isSlab = e => e.cls === 'IfcSlab';
+    const newAuditRED = SG.auditFloating(elements, REDsched, isSlab);
+    const newAuditGREEN = SG.auditFloating(elements, GREENsched, isSlab);
+
+    // OLD (pre-M3) definition reproduced for comparison: support grid = seq<=4 only (walls, seq 6,
+    // are NEVER in it — this is the exact shipped behaviour before this fix).
+    function oldAuditFloating(elements, sched, classFilter) {
+      const CELL = 4, EPS = 0.05, GAP = 0.5;
+      function cellsOf(e) { const o = []; for (let i=Math.floor(e.x0/CELL); i<=Math.floor(e.x1/CELL); i++)
+        for (let j=Math.floor(e.y0/CELL); j<=Math.floor(e.y1/CELL); j++) o.push(i+','+j); return o; }
+      function overlap(a,b){ return a.x0<=b.x1 && a.x1>=b.x0 && a.y0<=b.y1 && a.y1>=b.y0; }
+      const grid = {};
+      elements.forEach(e => { if (e.seq <= 4) cellsOf(e).forEach(c => (grid[c]=grid[c]||[]).push(e)); });
+      let v = 0;
+      elements.forEach(T => {
+        if (classFilter && !classFilter(T)) return;
+        let se = 0, seen = {};
+        cellsOf(T).forEach(c => (grid[c]||[]).forEach(S => {
+          if (seen[S.guid] || S.guid === T.guid) return; seen[S.guid] = 1;
+          if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
+            const en = sched[S.guid].end; if (en > se) se = en;
+          }
+        }));
+        if (se > 0 && sched[T.guid].start < se - 1) v++;
+      });
+      return v;
+    }
+    const oldAuditRED = oldAuditFloating(elements, REDsched, isSlab);
+    const oldAuditGREEN = oldAuditFloating(elements, GREENsched, isSlab);
+
+    return { newAuditRED, newAuditGREEN, oldAuditRED, oldAuditGREEN };
+  }, res.geomSlabs, res.geomWalls,
+     Object.fromEntries(res.wallsFixed.map(w => [w.guid, { start: w.start, end: w.end }])),
+     RED_BASELINE.slabStart, RED_BASELINE.slabEnd);
+
+  P('G-RLP-5a NEW (M3) audit, fed the RED (pre-fix) timestamps, falsifies: floating=2/2',
+    g5res.newAuditRED === 2,
+    `ScheduleGate.auditFloating on the 2 slabs + 8 walls, real geometry, RED timestamps: ${g5res.newAuditRED}`);
+  P('G-RLP-5b NEW (M3) audit, fed the GREEN (fixed) schedule, reports 0',
+    g5res.newAuditGREEN === 0,
+    `same call, schedule computed via the real ScheduleGate.computeSchedule on this subset: ${g5res.newAuditGREEN}`);
+  P('G-RLP-5c OLD (pre-M3) audit definition reads 0 on BOTH — proves the earlier bug was the audit, not just the schedule',
+    g5res.oldAuditRED === 0 && g5res.oldAuditGREEN === 0,
+    `old (seq<=4-only grid, walls never visible) audit: RED=${g5res.oldAuditRED} GREEN=${g5res.oldAuditGREEN} ` +
+    `(an audit that reads 0 both times is not a gate — this is exactly why M3 was needed)`);
+
+  const supportLineHosp = logs.filter(l => l.startsWith('§SUPPORT_CHECK')).slice(-1)[0] || '';
+  console.log('     §SUPPORT_CHECK (Hospital, full building, real pipeline): ' + supportLineHosp);
+  const hospFloatingMatch = /floating=(\d+)\/(\d+)/.exec(supportLineHosp);
+  const hospFloating = hospFloatingMatch ? +hospFloatingMatch[1] : -1;
+  const hospTotalOk = res.total === res.placed;
+
+  await page.close();
+
+  // ══════════════ LTU_AHouse — G-RLP-6 second building ══════════════
+  console.log('\n' + '='.repeat(78) + '\nLTU_AHouse — G-RLP-6 regression\n' + '='.repeat(78));
+  const { page: page2, logs: logs2 } = await open(browser, 'LTU_AHouse');
+  const res2 = await page2.evaluate(async () => {
+    await window.tmActivateForBake();
+    const A = window.APP;
+    return {
+      total: A.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class!='IfcOpeningElement'")[0][0],
+      placed: A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0],
+    };
+  });
+  const supportLineLtu = logs2.filter(l => l.startsWith('§SUPPORT_CHECK')).slice(-1)[0] || '';
+  console.log('     §SUPPORT_CHECK (LTU_AHouse, full building, real pipeline): ' + supportLineLtu);
+  const ltuFloatingMatch = /floating=(\d+)\/(\d+)/.exec(supportLineLtu);
+  const ltuFloating = ltuFloatingMatch ? +ltuFloatingMatch[1] : -1;
+  const ltuTotalOk = res2.total === res2.placed;
+  await page2.close();
+
+  P('G-RLP-6 no regression: total ops == total elements on both buildings (nothing dropped, monotone)',
+    hospTotalOk && ltuTotalOk,
+    `Hospital placed=${res.placed}/${res.total} | LTU_AHouse placed=${res2.placed}/${res2.total}`);
+  P('G-RLP-6 §SUPPORT_CHECK is 0 on both real buildings under the rebuilt (M3) audit',
+    hospFloating === 0 && ltuFloating === 0,
+    `Hospital: ${supportLineHosp || 'MISSING'} | LTU_AHouse: ${supportLineLtu || 'MISSING'}`);
+
+  await browser.close();
+  console.log('\n' + '='.repeat(78));
+  console.log(`RESULT ${checks.filter(c => c.ok).length}/${checks.length} ${allPass ? 'ALL GREEN' : 'RED'}`);
+  console.log('='.repeat(78));
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
M1 (time_machine.js): a slab is promoted to roof role (seq=8, Architecture)
only when it is both above the average midheight of its XY-overlapping
walls AND has no wall standing on it — the spec's average-only formula
alone does not discriminate a roof from a mid-building floor (measured:
23/35 Hospital slabs "promoted" using midheight alone); the "nothing
stands on it" clause from the same spec paragraph fixes that, landing on
10 (2 known roof slabs + isolated open-bay panels). Deletes the old
/roof/i storey-name override, which fired zero times on Hospital
("Level N"/"Unknown") and LTU_AHouse ("TAKPLAN").

M3 (schedule_gate.js): auditFloating's support grid used to be seq<=4
only, so a wall could never be found carrying anything — the audit
shared the scheduler's own blind spot and read 0 floating on a building
whose roofs demonstrably float. Widened, but scoped to walls-as-support
ONLY for slabs M1 itself promoted (an unscoped widening manufactured
3421 then 24 false positives on Hospital, measured and documented at
the point of the code).

M2 needed no separate change: M1's reseq to 8 alone moves a promoted
slab into PASS B, where the per-phase trade gate makes it wait for the
walls in the same phase.

Witness: witness_4d_roof_load_path.js, G-RLP-1..6, all green. RED
confirmed on unmodified main (slab scheduled ~277 days before its own
walls); GREEN after. §SUPPORT_CHECK floating=0/10979 (Hospital) and
0/7824 (LTU_AHouse), no regression in placed-element counts.

sw.js CACHE_VERSION v902 -> v903 (time_machine.js/schedule_gate.js are
precached assets).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UFGeaRFs1jiJy3u1kf54jq

## Verified independently by the dispatching session
Re-ran every gate rather than trusting the build report: §4D_ROOF_LOAD_PATH 9/9, room_title gaze 8/8 / lead 10/10 / hold 8/8, tests/test_schedule_gate.js PASS. Hospital 63415/63415 and LTU_AHouse 122330/122330 placed, `§SUPPORT_CHECK floating=0` on both.

RED: the user's two helipad boxes started 2022-07-27 (phase Superstructure) while the walls carrying them finished 2023-04-30 — **277 days before their own walls**. GREEN: they start 2023-10-19 as Architecture, after those walls.

## ⚠ Two limits recorded, not glossed
1. **M3's blind spot is NARROWED, not removed.** The rebuilt audit still keys on trade number (`T.seq > 4`) with one extra branch, rather than finding supports by geometry as the spec asked. G-RLP-5 feeds `seq=8` in BOTH its RED and GREEN arms, so it proves "given a slab M1 promoted, the audit can now falsify a bad schedule" — it does NOT prove the audit would catch a roof M1 failed to promote. The two widening attempts that were tried and rejected are documented in-code with their measured false-positive counts (3421, then 24), so this is a reasoned compromise, not an oversight.
2. **Parapets.** Condition (b) excludes any slab with an XY-overlapping wall standing on it. A roof with a parapet wall is ordinary construction and would be excluded, silently returning to the old behaviour for that roof. On Hospital, (a) alone promoted 23 and (b) reduced it to 10 — the 13 blocked include genuine intermediate floors (correct) and would include any parapeted roof (incorrect). Not exercised by this building; named so it is not rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)