### PR TITLE
fix(cinema): §CPE_WALK_BUDGET_NOISE_BLIND — the walk's SECONDS now obey the noise law

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5729,6 +5729,44 @@ async function setupEffects(A, renderer, scene, camera) {
       var c0 = _dvC[lo], c1 = _dvC[hi], f = (c1 - c0 > 1e-12) ? (u - c0) / (c1 - c0) : 0;
       return (lo + Math.max(0, Math.min(1, f))) / _DV_N;
     }
+    // §CPE_WALK_BUDGET_NOISE_BLIND (2026-08-01, user: "it shuld be controlled by that noise-speed
+    // ratio we setup before to govern thruout"). The walk's SECONDS must see the same content-change
+    // signal §CPE_NOISE_LAW already computes for the walk's FRAME SPACING (_evenTurnBuild below) —
+    // not a new probe, the SAME central-difference-of-density measurement _densityAt/_noiseRadius
+    // already give the dive, just evaluated here because _natSec (next block) needs the scalar
+    // before it exists anywhere else.
+    //
+    // ⚠ Cannot call _beat3Pose(e) directly for this, despite it being the primitive named in the
+    // correction — MEASURED by reading, not in the debugger: _beat3Pose reads _openU and _handDir,
+    // and both are assigned INSIDE the block this IIFE runs before (_natSec needs _useSec.out, which
+    // needs _natSec.out, which is what this scalar feeds). Calling it early would run its gaze blend
+    // against two undefined values. It is not needed anyway: _cinemaGazeBlend returns x/y/z UNCHANGED
+    // from the position it was given (see its `return { x: px, y: py, z: pz, ... }`), so
+    // _beat3Pose(e).x/y/z is byte-identical to _outPos(e).x/y/z for every e — _outPos alone gives the
+    // same positions this probe needs, and it has no such dependency (defined at L5005, before any of
+    // this). Radius uses `totalLen` (the walk's own travel, already computed) rather than the 240-
+    // sample arc length _evenTurnBuild measures later — the same choice the dive already makes
+    // (_diveNoiseBuild above uses ITS OWN straight-line travel, not a beat-later refinement of it).
+    var _wnkN = 32, _walkBusy = 0;
+    (function _walkNoiseBuild() {
+      var q, nz = [], nzC = [], nzMax = 0, rad = _noiseRadius(totalLen);
+      for (q = 0; q <= _wnkN; q++) nz.push(_densityAt(_outPos(q / _wnkN), rad));
+      for (q = 0; q <= _wnkN; q++) {
+        var lo = nz[Math.max(0, q - 1)], hi = nz[Math.min(_wnkN, q + 1)];
+        nzC.push(Math.abs(hi - lo));
+        if (nzC[q] > nzMax) nzMax = nzC[q];
+      }
+      if (nzMax > 0) {
+        var sum = 0;
+        for (q = 0; q < nzC.length; q++) sum += nzC[q];
+        _walkBusy = (sum / nzC.length) / nzMax;
+      }
+      console.log('§CPE_NOISE_LAW beat=walk-budget src=bbox probes=' + (_wnkN + 1) +
+        ' radius=' + rad.toFixed(1) + 'm elems=' + _densPoints().length +
+        ' meanBusy=' + _walkBusy.toFixed(3) + ' maxChange=' + nzMax +
+        ' swing=' + CINEMA_PACE_SWING +
+        ' — the walk SECONDS below are bought by this number, the same signal that already spaces its frames');
+    })();
     // ⚠ §CPE_SEAM_CONTINUOUS — DO NOT add a pitch term to _spinDeg. It was tried this session and
     // reverted: pricing the walk's opening pitch into the spin makes the spin's DURATION depend on
     // the authored path, which shifts every beat fraction before it and breaks G2's "an edit
@@ -5745,20 +5783,40 @@ async function setupEffects(A, renderer, scene, camera) {
     // every beat fraction before it and breaks G2's "an edit changes nothing before it".
     var _openDir = { x: (_wkA0.x - _wkP0.x) / _wkL, y: _wkDy / _wkL, z: (_wkA0.z - _wkP0.z) / _wkL };
     var _spinDeg = Math.min(180, Math.abs(dYaw) * 180 / Math.PI);
+    var _walkTurnDegVal = _walkTurnDeg();
     var _natSec = {
       // §CPE_NOISE_LAW, second half — the same ratio that spaces the frames also BUYS the seconds
       // ("where sudden diff is adverse noise impact and introduce frames to smoothen", the user's
-      // rule, already applied to the walk in `out` below via _walkTurnDeg). A dive that ends deep
-      // inside a busy building buys up to PACE_SWING times the seconds of one that drops into an
-      // empty yard; redistribution alone could never do this, because with the frame count fixed
-      // the mean speed is fixed whatever the parameterization does.
+      // rule). A dive that ends deep inside a busy building buys up to PACE_SWING times the seconds
+      // of one that drops into an empty yard; redistribution alone could never do this, because with
+      // the frame count fixed the mean speed is fixed whatever the parameterization does.
+      // §CPE_WALK_BUDGET_NOISE_BLIND CORRECTION (2026-08-01) — this used to say the walk already got
+      // this treatment "via _walkTurnDeg". It did not: _walkTurnDeg prices GEOMETRY (degrees turned),
+      // not CONTENT (rate of change), so two equal-length equal-turning walks through empty and dense
+      // areas billed identically. `out` below now carries the same `* (1 + (SWING-1)*busy)` factor
+      // the dive uses, with busy = _walkBusy from _walkNoiseBuild above.
       dive:  Math.max(CINEMA_DIVE_MIN_SEC, _diveEff / CINEMA_DIVE_MPS * (1 + (CINEMA_PACE_SWING - 1) * _diveBusy)),
       spin:  Math.max(CINEMA_SPIN_MIN_SEC, _spinDeg / CINEMA_TURN_DPS),
-      out:   totalLen / CINEMA_WALK_MPS + _walkTurnDeg() / (CINEMA_TURN_DPS / 3),
+      // §CPE_WALK_BUDGET_NOISE_BLIND — same shape as the dive above, one law every beat. The `/3`
+      // that used to inflate the turn charge as a stand-in for busyness is GONE: a degree now costs
+      // CINEMA_TURN_DPS, exactly as the comment above _walkTurnDeg already claims, and busyness
+      // (measured, not assumed) does the job the `/3` was faking.
+      out:   (totalLen / CINEMA_WALK_MPS + _walkTurnDegVal / CINEMA_TURN_DPS) *
+             (1 + (CINEMA_PACE_SWING - 1) * _walkBusy),
       rise:  Math.max(0.5, _pullDist / CINEMA_PULLBACK_MPS),
       orbit: 360 / CINEMA_TURN_DPS
     };
     var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.rise + _natSec.orbit;
+    // Whitebox proof for §CPE_WALK_BUDGET_NOISE_BLIND — every term the formula reads, printed
+    // together so a witness can recompute `out` from this line alone and compare against
+    // _natSec.out, rather than trusting the arithmetic happened as claimed.
+    console.log('§CPE_WALK_BUDGET_NOISE_BLIND totalLen=' + totalLen.toFixed(2) + 'm walkMps=' + CINEMA_WALK_MPS +
+      ' turnDeg=' + _walkTurnDegVal.toFixed(1) + ' turnDps=' + CINEMA_TURN_DPS +
+      ' travelSec=' + (totalLen / CINEMA_WALK_MPS).toFixed(3) + ' turnSec=' + (_walkTurnDegVal / CINEMA_TURN_DPS).toFixed(3) +
+      ' rawSec=' + (totalLen / CINEMA_WALK_MPS + _walkTurnDegVal / CINEMA_TURN_DPS).toFixed(3) +
+      ' busy=' + _walkBusy.toFixed(3) + ' swing=' + CINEMA_PACE_SWING +
+      ' busyMult=' + (1 + (CINEMA_PACE_SWING - 1) * _walkBusy).toFixed(4) +
+      ' outSec=' + _natSec.out.toFixed(3));
     // An explicit override (the editor's "set the total") scales the whole film uniformly; the SHAPE
     // is geometric either way, so the beat fractions are derived-seconds over the natural total and
     // do not depend on durationSec at all. That is what makes "key 20s and everything speeds up

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v903';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v904';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cinema_path_editor.js
+++ b/witness_cinema_path_editor.js
@@ -151,10 +151,10 @@ const FPS = 15;
         //     exactly, because raising the path makes the corner fans hit different geometry, so the
         //     rounding radius (and with it the arc-length parameterization) legitimately differs.
         //     Reported as a number rather than hidden inside a loose tolerance on (a).
-        const dyOver = (planBase, planEdit) => {
+        const dyOver = (planBase, planEdit, win) => {
           let mn = 1e9, mx = -1e9;
           for (let s = 0; s <= 100; s++) {
-            const t = beats.spin + (beats.out - beats.spin) * (s / 100);
+            const t = win.spin + (win.out - win.spin) * (s / 100);
             const dy = planEdit.poseAt(t).y - planBase.poseAt(t).y;
             mn = Math.min(mn, dy); mx = Math.max(mx, dy);
           }
@@ -165,11 +165,28 @@ const FPS = 15;
         const straightUp = straight.map(w => ({ x: w.x, y: w.y + 1.5, z: w.z }));
         const pS = A.cinemaPathPlan(DUR, { waypoints: straight });
         const pSU = A.cinemaPathPlan(DUR, { waypoints: straightUp });
-        const iso = dyOver(pS, pSU);
+        // §CPE_WALK_BUDGET_NOISE_BLIND follow-up (2026-08-01): the isolated case used to sample pS/pSU
+        // (a SYNTHETIC straight 20m leg) at `beats` — planA's window, i.e. the REAL building path's
+        // beat fractions. That was always a mismatch (pS has a totally different totalLen/turnDeg from
+        // planA, so its own beat fractions land at a different tNorm), but it stayed hidden while the
+        // walk's seconds were priced by geometry alone, because the two paths' `out`-beat boundaries
+        // happened to sit close together. Once the walk's seconds started depending on CONTENT (this
+        // fix's own change, _walkBusy from §CPE_NOISE_LAW), planA's `out` boundary and pS's own moved
+        // apart — MEASURED on Terminal: planA.beats.out=0.5607 vs pS.beats.out=0.5406, so the sample at
+        // the window's far edge landed ~9% into pS's OWN rise beat, where the override is not held
+        // (dy fell to 0.57 there). Sampling pS/pSU at pS's OWN beat window instead gives dy===1.5 at
+        // every one of 101 samples, on BOTH this branch and unmodified origin/main, for BOTH buildings —
+        // proving the eye-height override itself never regressed; only the instrument's window did.
+        // A 2% inset off each end of that window avoids a second, unrelated artifact: the beat3->rise
+        // handoff is a literal knife-edge in poseAt() (dy steps 1.50000->1.50308 in the very next sample
+        // AT the exact boundary, reproduced on unmodified origin/main too — pre-existing, not this fix).
+        const ownWin = pS.beats, ownSpan = ownWin.out - ownWin.spin;
+        const isoWin = { spin: ownWin.spin + ownSpan * 0.02, out: ownWin.out - ownSpan * 0.02 };
+        const iso = dyOver(pS, pSU, isoWin);
 
         const raised = wp0.map(w => ({ x: w.x, y: w.y + 1.5, z: w.z }));
         const planR = A.cinemaPathPlan(DUR, { waypoints: raised });
-        const situ = dyOver(planA, planR);
+        const situ = dyOver(planA, planR, beats);
         out.g3 = { asked: 1.5, isoMin: iso.mn, isoMax: iso.mx, situMin: situ.mn, situMax: situ.mx };
       }
 

--- a/witness_cpe_walk_budget.js
+++ b/witness_cpe_walk_budget.js
@@ -1,0 +1,289 @@
+// WITNESS — §CPE_WALK_BUDGET_NOISE_BLIND: the walk's SECONDS must obey the noise law like every
+// other beat.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_WALK_BUDGET_NOISE_BLIND + its CORRECTION
+// (the last section of the file — Defect 1 as first written is WRONG, build against the correction).
+//
+// THE DEFECT: `effects.js` used to charge the walk's seconds as
+//   totalLen / CINEMA_WALK_MPS + _walkTurnDeg() / (CINEMA_TURN_DPS / 3)
+// — raw metres plus raw degrees at a 3x-inflated rate. `_walkTurnDeg()` prices GEOMETRY (how far the
+// path turns); the user's settled law (2026-07-27, "100% rate of change") prices CONTENT (how fast
+// the scene changes). Two paths that turn the same amount through an empty yard and a dense
+// plantroom billed IDENTICALLY. The fix gives the walk the same shape the dive already has:
+//   (totalLen / CINEMA_WALK_MPS + _walkTurnDeg() / CINEMA_TURN_DPS) * (1 + (PACE_SWING-1) * busy)
+// with `busy` measured by the same _densityAt/_noiseRadius central-difference probe §CPE_NOISE_LAW
+// already runs for the walk's frame SPACING (_evenTurnBuild), and the `/3` tax gone because honest
+// busy now does the job it was faking.
+//
+//   G-WB-1  formula honesty: the §CPE_WALK_BUDGET_NOISE_BLIND log line's own reported terms
+//           recompute `outSec` exactly, AND the rate charged per degree is CINEMA_TURN_DPS (45),
+//           not the old 15 (Defect 2). RED on origin/main: no such log line exists at all — the old
+//           code never surfaces turnDeg/busy as first-class numbers, only the flat totals.
+//   G-WB-2  THE gate that matters: two paths of EQUAL length and EQUAL total turning (built as one
+//           path translated bodily into empty space — translation cannot change either quantity)
+//           through DIFFERENT content-change score must get DIFFERENT walk seconds. RED on
+//           origin/main: translation doesn't change pathLen or turnDeg there either, and the old
+//           formula reads nothing else, so the two plans' walk seconds are identical.
+//   G-WB-3  bounded by the one dial: busy in force is a value the reported logs place in [0,1], so
+//           the resulting multiplier never exceeds CINEMA_PACE_SWING (1.6, read from the log, not
+//           hardcoded) on any of the 4 plans this file builds. No second dial appears in any line.
+//   G-WB-4  a degree of turning costs the same in the walk as in the spin — the claim
+//           effects.js:5150-5153 already makes in prose, checked against the spin's own logged rate.
+//   G-WB-5  constant speed with busy HELD FLAT (both paths measured busy=0): two straight walks of
+//           different length still get seconds exactly proportional to length. The full-noise
+//           version of this claim (busy free to vary) is witness_cinema_path_editor.js's G9, run as
+//           a regression alongside this file, not re-litigated here.
+//   G-WB-6  the §CPE_HOSE_LENGTH_BLIND invariant: the plan is internally self-consistent
+//           (naturalTotal == sum of its own sec.* fields) and DETERMINISTIC (replanning the same
+//           override twice gives byte-identical pathLen/naturalTotal) — re-costing the walk did not
+//           reintroduce a display-vs-bake divergence or any nondeterminism from the new density read.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8450;
+const BUILDINGS = (process.env.BLDS || 'Hospital,Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.dbQuery,
+      { timeout: 300000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 300000, polling: 3000 });
+
+    const DUR = 24;
+    const res = await page.evaluate(async (DUR) => {
+      const A = window.APP;
+      const out = { err: null };
+      try {
+        if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+        if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+
+        // A real anchor point near the building, from the derived plan — not invented.
+        const planD = A.cinemaPathPlan(DUR);
+        const s0 = planD.waypoints[0];
+        out.envelope = planD.envelope;
+
+        // ── G-WB-1/G-WB-4 subject: a dogleg near the building (2 real 90deg corners), and the
+        // same shape extended by two more legs (2 more corners) — the "add waypoints, path grows,
+        // does the clock explode" scenario the user actually reported.
+        const base = [
+          { x: s0.x,      y: s0.y, z: s0.z },
+          { x: s0.x + 10, y: s0.y, z: s0.z },
+          { x: s0.x + 10, y: s0.y, z: s0.z + 10 },
+          { x: s0.x + 20, y: s0.y, z: s0.z + 10 },
+        ];
+        const extended = base.concat([
+          { x: s0.x + 20, y: s0.y, z: s0.z + 20 },
+          { x: s0.x + 30, y: s0.y, z: s0.z + 20 },
+        ]);
+        const planBase = A.cinemaPathPlan(DUR, { waypoints: base });
+        const planExt = A.cinemaPathPlan(DUR, { waypoints: extended });
+        out.base = { pathLen: planBase.pathLen, outSec: planBase.naturalSec.out };
+        out.ext = { pathLen: planExt.pathLen, outSec: planExt.naturalSec.out };
+
+        // ── G-WB-2 subject: a STRAIGHT 2-point leg near the building, and the SAME leg bodily
+        // TRANSLATED 3000m away. Deliberately NOT the cornered `base` dogleg above: corner rounding
+        // (_cinemaRoundCorners) cuts each corner by a radius bounded by MEASURED fan clearance AT
+        // THAT LOCATION, so a cornered path's FLOWN length legitimately shifts when translated
+        // somewhere with different nearby geometry (confirmed empirically: the dogleg's flowed
+        // length differed by ~3% between near-building and 3000m-out on Duplex) — witness_cinema_
+        // path_editor.js's G3 documents the same effect for a raised path. A straight leg has no
+        // corner to round, so translation preserves totalLen and turnDeg (=0 for both) EXACTLY,
+        // isolating the one thing this gate is actually testing: does busy alone move the seconds.
+        const OFFSET = 3000;
+        const busyWp = [{ x: s0.x, y: s0.y, z: s0.z }, { x: s0.x + 20, y: s0.y, z: s0.z }];
+        const emptyWp = busyWp.map(w => ({ x: w.x + OFFSET, y: w.y, z: w.z }));
+        const planBusy = A.cinemaPathPlan(DUR, { waypoints: busyWp });
+        const planEmpty = A.cinemaPathPlan(DUR, { waypoints: emptyWp });
+        out.busy = { pathLen: planBusy.pathLen, outSec: planBusy.naturalSec.out };
+        out.empty = { pathLen: planEmpty.pathLen, outSec: planEmpty.naturalSec.out };
+
+        // ── G-WB-5 subject: two STRAIGHT walks (no turning at all) at different lengths, both far
+        // from anything (busy pinned at 0 by construction, same offset trick).
+        const shortStraight = [{ x: s0.x + OFFSET, y: s0.y, z: s0.z }, { x: s0.x + OFFSET + 10, y: s0.y, z: s0.z }];
+        const longStraight  = [{ x: s0.x + OFFSET, y: s0.y, z: s0.z }, { x: s0.x + OFFSET + 30, y: s0.y, z: s0.z }];
+        const planShort = A.cinemaPathPlan(DUR, { waypoints: shortStraight });
+        const planLong = A.cinemaPathPlan(DUR, { waypoints: longStraight });
+        out.short = { pathLen: planShort.pathLen, outSec: planShort.naturalSec.out };
+        out.long = { pathLen: planLong.pathLen, outSec: planLong.naturalSec.out };
+
+        // ── G-WB-6 subject: internal self-consistency + determinism of planBusy, replanned twice.
+        const planBusy2 = A.cinemaPathPlan(DUR, { waypoints: busyWp });
+        out.selfConsistent = {
+          natSum: planBusy.naturalSec.dive + planBusy.naturalSec.spin + planBusy.naturalSec.out +
+                  planBusy.naturalSec.rise + planBusy.naturalSec.orbit,
+          natTotal: planBusy.naturalTotal,
+        };
+        out.deterministic = {
+          pathLenDiff: Math.abs(planBusy.pathLen - planBusy2.pathLen),
+          totalDiff: Math.abs(planBusy.naturalTotal - planBusy2.naturalTotal),
+          outSecDiff: Math.abs(planBusy.naturalSec.out - planBusy2.naturalSec.out),
+        };
+      } catch (e) { out.err = e.message + ' | ' + (e.stack || '').split('\n').slice(0, 3).join(' / '); }
+      return out;
+    }, DUR);
+
+    const checks = [];
+    const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+    if (res.err) {
+      P('G-WB-1..6 the plan API runs on real authored waypoints', false, res.err);
+      console.log(`\n  ${BLD}: 0/1`); allPass = false; await page.close(); continue;
+    }
+
+    // §CPE_WALK_BUDGET_NOISE_BLIND lines, in call order: [derived(unused for parsing), base, ext,
+    // busy, empty, short, long, busy2]. Filter, then index by call position.
+    const wbLines = logs.filter(l => l.startsWith('§CPE_WALK_BUDGET_NOISE_BLIND'));
+    const parseWB = (line) => {
+      if (!line) return null;
+      const g = (re) => { const m = re.exec(line); return m ? +m[1] : null; };
+      return {
+        totalLen: g(/totalLen=([\d.]+)/), walkMps: g(/walkMps=([\d.]+)/),
+        turnDeg: g(/turnDeg=([\d.]+)/), turnDps: g(/turnDps=([\d.]+)/),
+        travelSec: g(/travelSec=([\d.]+)/), turnSec: g(/turnSec=([\d.]+)/),
+        rawSec: g(/rawSec=([\d.]+)/), busy: g(/busy=([\d.]+)/), swing: g(/swing=([\d.]+)/),
+        busyMult: g(/busyMult=([\d.]+)/), outSec: g(/outSec=([\d.]+)/),
+      };
+    };
+    // 7 authored plans were built above (base, ext, busy, empty, short, long, busy2) — the derived
+    // plan `planD` at the top does NOT go through the authored-waypoint path with a fresh totalLen
+    // in the same shape (it does, in fact — every call to _cinemaPathPlan logs this line), so there
+    // are 8 lines total; the last 7, in order, are the ones this test built explicitly.
+    const wb = wbLines.slice(-7).map(parseWB);
+    const [wbBase, wbExt, wbBusy, wbEmpty, wbShort, wbLong, wbBusy2] = wb;
+
+    // ── G-WB-1 ─────────────────────────────────────────────────────────────────────────────────
+    if (!wbBase || !wbExt) {
+      P('G-WB-1 formula honesty: §CPE_WALK_BUDGET_NOISE_BLIND is emitted and self-consistent',
+        false,
+        `no §CPE_WALK_BUDGET_NOISE_BLIND line found (${wbLines.length} matched of 7 expected) — ` +
+        `old code has no busy term to log. Raw plan numbers: base pathLen=${res.base.pathLen.toFixed(2)}m ` +
+        `outSec=${res.base.outSec.toFixed(3)}s | ext pathLen=${res.ext.pathLen.toFixed(2)}m ` +
+        `outSec=${res.ext.outSec.toFixed(3)}s | lenRatio=${(res.ext.pathLen/res.base.pathLen).toFixed(3)} ` +
+        `secRatio=${(res.ext.outSec/res.base.outSec).toFixed(3)}`);
+    } else {
+      const recompute = (wb) => (wb.travelSec + wb.turnSec) * wb.busyMult;
+      const err1 = Math.abs(recompute(wbBase) - wbBase.outSec);
+      const err2 = Math.abs(recompute(wbExt) - wbExt.outSec);
+      // Tolerance reflects the LOG LINE's own printed precision (travelSec/turnSec at 3 decimals,
+      // busyMult at 4) propagated through one multiply, not numerical slop in the formula itself —
+      // the source values inside effects.js are full double precision; only what this test can SEE
+      // is rounded.
+      const TOL = 2e-3;
+      const rateOK = wbBase.turnDps === 45 && wbExt.turnDps === 45;
+      P('G-WB-1 formula honesty: outSec == (travelSec+turnSec)*busyMult (within log-print precision), and a degree costs turnDps=45 (not the old 15)',
+        err1 < TOL && err2 < TOL && rateOK,
+        `base: turnDeg=${wbBase.turnDeg} turnDps=${wbBase.turnDps} travelSec=${wbBase.travelSec} turnSec=${wbBase.turnSec} ` +
+        `busy=${wbBase.busy} busyMult=${wbBase.busyMult} outSec=${wbBase.outSec} (recompute err=${err1.toExponential(2)}) | ` +
+        `ext: turnDeg=${wbExt.turnDeg} turnDps=${wbExt.turnDps} travelSec=${wbExt.travelSec} turnSec=${wbExt.turnSec} ` +
+        `busy=${wbExt.busy} busyMult=${wbExt.busyMult} outSec=${wbExt.outSec} (recompute err=${err2.toExponential(2)}) | ` +
+        `lenRatio=${(res.ext.pathLen/res.base.pathLen).toFixed(3)} secRatio=${(res.ext.outSec/res.base.outSec).toFixed(3)} ` +
+        `turnRatio=${(wbExt.turnDeg/wbBase.turnDeg).toFixed(3)}`);
+    }
+
+    // ── G-WB-2 (the gate that matters) ────────────────────────────────────────────────────────
+    if (!wbBusy || !wbEmpty) {
+      P('G-WB-2 equal length + equal turn, different content-change -> different walk seconds',
+        false,
+        `no §CPE_WALK_BUDGET_NOISE_BLIND line for busy/empty plans — old code cannot report busy. ` +
+        `Raw: busy pathLen=${res.busy.pathLen.toFixed(2)}m outSec=${res.busy.outSec.toFixed(3)}s | ` +
+        `empty(+${3000}m) pathLen=${res.empty.pathLen.toFixed(2)}m outSec=${res.empty.outSec.toFixed(3)}s | ` +
+        `lenDiff=${Math.abs(res.busy.pathLen-res.empty.pathLen).toExponential(2)}m ` +
+        `outSecDiff=${Math.abs(res.busy.outSec-res.empty.outSec).toExponential(2)}s (RED: ~0, identical)`);
+    } else {
+      const lenEq = Math.abs(wbBusy.totalLen - wbEmpty.totalLen) < 1e-6;
+      const turnEq = Math.abs(wbBusy.turnDeg - wbEmpty.turnDeg) < 1e-6;
+      const busyDiffers = (wbBusy.busy - wbEmpty.busy) > 0.02;
+      const secDiffers = Math.abs(wbBusy.outSec - wbEmpty.outSec) / wbBase.outSec > 0.001 || wbBusy.outSec !== wbEmpty.outSec;
+      P('G-WB-2 equal length + equal turn (proven by translation), different busy -> different walk seconds',
+        lenEq && turnEq && busyDiffers && secDiffers,
+        `totalLen: busy=${wbBusy.totalLen} empty=${wbEmpty.totalLen} (equal=${lenEq}) | ` +
+        `turnDeg: busy=${wbBusy.turnDeg} empty=${wbEmpty.turnDeg} (equal=${turnEq}) | ` +
+        `busy: near-building=${wbBusy.busy} vs 3000m-out=${wbEmpty.busy} (differs=${busyDiffers}) | ` +
+        `outSec: ${wbBusy.outSec}s vs ${wbEmpty.outSec}s (differs=${secDiffers})`);
+    }
+
+    // ── G-WB-3 ─────────────────────────────────────────────────────────────────────────────────
+    {
+      const all = [wbBase, wbExt, wbBusy, wbEmpty, wbShort, wbLong].filter(Boolean);
+      const swingVals = new Set(all.map(w => w.swing));
+      const oneDial = swingVals.size <= 1 && (swingVals.size === 0 || [...swingVals][0] === 1.6);
+      const busyBounded = all.every(w => w.busy >= -1e-9 && w.busy <= 1 + 1e-9);
+      const multBounded = all.every(w => w.busyMult >= 1 - 1e-9 && w.busyMult <= (all[0] ? all[0].swing : 1.6) + 1e-6);
+      P('G-WB-3 bounded by the ONE dial: busy in [0,1], busyMult in [1,swing], swing constant across every plan',
+        all.length > 0 && oneDial && busyBounded && multBounded,
+        all.length === 0 ? 'no lines to check'
+          : `swing values seen=${[...swingVals]} | busy=[${all.map(w=>w.busy).join(',')}] | ` +
+            `busyMult=[${all.map(w=>w.busyMult).join(',')}]`);
+    }
+
+    // ── G-WB-4 ─────────────────────────────────────────────────────────────────────────────────
+    {
+      const pacingLine = logs.filter(l => l.startsWith('§CINEMA_PACING')).slice(-1)[0] || '';
+      const mSpin = /spin raw \d+deg capped \d+deg @(\d+)deg\/s/.exec(pacingLine);
+      const spinRate = mSpin ? +mSpin[1] : null;
+      const walkRate = wbBase ? wbBase.turnDps : null;
+      P('G-WB-4 a degree of turning costs the same in the walk as in the spin (effects.js:5150-5153\'s own claim)',
+        spinRate != null && walkRate != null && spinRate === walkRate,
+        `spin rate=${spinRate}deg/s (from §CINEMA_PACING) walk rate=${walkRate}deg/s (from §CPE_WALK_BUDGET_NOISE_BLIND)`);
+    }
+
+    // ── G-WB-5 ─────────────────────────────────────────────────────────────────────────────────
+    if (!wbShort || !wbLong) {
+      P('G-WB-5 constant speed with busy held flat: two straight walks, seconds proportional to length',
+        false, 'no §CPE_WALK_BUDGET_NOISE_BLIND line for short/long straight plans');
+    } else {
+      const bothFlat = wbShort.busy === 0 && wbLong.busy === 0;
+      const lenRatio = res.long.pathLen / res.short.pathLen;
+      const secRatio = res.long.outSec / res.short.outSec;
+      const ratioErr = Math.abs(lenRatio - secRatio);
+      P('G-WB-5 constant speed with busy held flat: seconds/length ratio == length ratio (no turning, no busy)',
+        bothFlat && ratioErr < 1e-6,
+        `busy short=${wbShort.busy} long=${wbLong.busy} (flat=${bothFlat}) | ` +
+        `pathLen ${res.short.pathLen.toFixed(2)}->${res.long.pathLen.toFixed(2)}m (x${lenRatio.toFixed(4)}) ` +
+        `outSec ${res.short.outSec.toFixed(3)}->${res.long.outSec.toFixed(3)}s (x${secRatio.toFixed(4)}) ` +
+        `err=${ratioErr.toExponential(2)} — full-noise (busy varying) version of this claim is ` +
+        `witness_cinema_path_editor.js G9, run as a regression alongside this file`);
+    }
+
+    // ── G-WB-6 ─────────────────────────────────────────────────────────────────────────────────
+    {
+      const sc = res.selfConsistent, det = res.deterministic;
+      const consistent = Math.abs(sc.natSum - sc.natTotal) < 1e-9;
+      const deterministic = det.pathLenDiff === 0 && det.totalDiff === 0 && det.outSecDiff === 0;
+      P('G-WB-6 §CPE_HOSE_LENGTH_BLIND invariant holds: plan is internally self-consistent and deterministic',
+        consistent && deterministic,
+        `naturalTotal=${sc.natTotal.toFixed(6)} sum(sec.*)=${sc.natSum.toFixed(6)} diff=${Math.abs(sc.natSum-sc.natTotal).toExponential(2)} | ` +
+        `replan-twice diff: pathLen=${det.pathLenDiff.toExponential(2)} naturalTotal=${det.totalDiff.toExponential(2)} outSec=${det.outSecDiff.toExponential(2)}`);
+    }
+
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n  ${BLD}: ${pass}/${checks.length}`);
+    summary.push({ BLD, pass, total: checks.length });
+    if (pass !== checks.length || !checks.length) allPass = false;
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass === s.total ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.pass}/${s.total})`));
+  console.log(allPass ? '\nALL GREEN' : '\nRED');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User: *"when at extra node length, it seems to slow down too much"* → *"it shuld be controlled by that noise-speed ratio we setup before to govern thruout"*. They were right, and their own LTU log proved it: path +16.9%, walk seconds +30.9%, **turn charge alone +108%** (2.33s → 4.86s).

## The defect, corrected mid-spec
My first diagnosis said the walk budget had no noise term. `effects.js:5751` disproves that — the comment states the rule is *"already applied to the walk in `out` below via \_walkTurnDeg"*. The turn charge IS the intended noise term; it just **measures the wrong quantity**. It sums DIRECTION change, while the user's settled law (2026-07-27, "100% rate of change") prices CONTENT change. A corner in an empty yard was billed identically to one inside a dense plantroom. Meanwhile the content signal already existed one beat away (`effects.js:6272-6284`) but fed a cost normalised to 1 — so it redistributed frames and bought zero seconds, while its own log line claimed *"a corner whose CONTENT is not changing stays cheap"*.

Also settled: the turn was charged at `CINEMA_TURN_DPS / 3` = 15°/s while the comment directly above `_walkTurnDeg` asserts "no new constant — rotation is charged at CINEMA_TURN_DPS" = 45°/s. Three times the price, undocumented. The `/3` is gone because its job — standing in for busyness — is now done by measured busyness.

## WITNESSED — witness_cpe_walk_budget.js, Hospital 6/6 + Duplex 6/6
- **G-WB-2, the gate that matters**, built honestly: a straight 20 m leg beside the building vs the identical leg translated 3000 m into empty space (translation preserves length and turning exactly). RED: both `outSec=8.696s`, byte-identical. GREEN: `20.334s vs 16.054s`.
- **G-WB-4**: walk turn rate 45°/s, equal to the spin's — the claim the code already made in prose.
- **G-WB-5**: with busyness flat, `pathLen x3.0000 → outSec x3.0000 err=0` — constant speed (§CINEMA_PATH_EDITOR_MODEL rule 9) survives.
- **G-WB-3**: `swing=1.6` only, `busyMult ∈ [1, 1.2666]` — bounded by the one dial, no second knob.

## ⚠ A pre-existing gate was CORRECTED, and the proof it was not lowered
`witness_cinema_path_editor.js` G3 (Terminal) was already failing at 8.85e-3 m; this change took it to 9.26e-1 m. Investigated rather than waved through as "already red": G3's isolated case sampled a SYNTHETIC straight leg (`pS`) at **planA's** beat window — a mismatch that always existed but stayed hidden while the two paths' `out` boundaries happened to sit close (Terminal: planA 0.5607 vs pS 0.5406). Pricing the walk by content moved them apart, so the far sample fell into pS's own rise beat where the override isn't held.

Fixed the INSTRUMENT: `dyOver()` now takes its window as a parameter and iso passes `pS.beats`. **Tolerance (<0.001) and the 1.5 m ask untouched.** Verified independently by the dispatching session: the corrected gate reads `got=[1.5000,1.5000] err=0.00e+0` on **both buildings with BOTH this branch and unmodified origin/main** — exactly 1.5, not "just inside tolerance". So the eye-height override never regressed, and this also clears a pre-existing red.

Known instrument-side constant: a 2% inset off each end of that window, to avoid a knife-edge at the beat3→rise handoff (`dy` steps 1.50000→1.50308 in one sample AT the boundary, reproduced on unmodified origin/main — pre-existing, unrelated).

## Regressions (dispatching session re-ran all of these)
walk_budget 6/6+6/6 · room_title gaze 8/8 · room_title lead 10/10 · cinema_bands Duplex 5/6 + Terminal 6/6 (B7 pre-existing, identical on origin/main).

Note: `_beat3Pose` could not be reused for the busy probe — it reads `_openU`/`_handDir`, assigned only after `_natSec` (the sequencing trap the spec warned of). `_outPos` used instead, documented at the code rather than silently substituted.

viewer sw v903 → v904.
Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_WALK_BUDGET_NOISE_BLIND + its CORRECTION section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)