### PR TITLE
fix(4d): §GANTT_CACHE_VERSION 4 → 5 — the roof fix could not reach an already-cached browser

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v905';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v906';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4375,7 +4375,15 @@
   // prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md Item 2. v4 (2026-07-18): §STOREY-Z
   // no-storey-element reassignment (PR #869) — Item 6. Missed on first landing (user hit exactly
   // this "hard reset didn't fix it" symptom); this bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 4;
+  // v5 (2026-08-01): §4D_ROOF_LOAD_PATH (PR #1120) changed BOTH things this comment names — the
+  // slab sequence rule (role now derived from the load path, not the storey name) and
+  // schedule_gate.js's gating logic (walls became candidate supports for promoted roof slabs).
+  // Missed on first landing for the SECOND time in this file's history, and the user hit the exact
+  // symptom the v4 note above already describes in those words: "I still see the roof of the helipad
+  // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
+  // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
+  // IndexedDB, not the HTTP cache. This bump is that fix's second half.
+  var _GANTT_CACHE_VERSION = 5;
 
   function _cacheKey(prefix) {
     var app = A();


### PR DESCRIPTION
User, after PR #1120 shipped: "I still see the roof of the helipad huts going first before the walls"
— after a hard reset. They were right, and the cause is one line this file already warned about.

`_GANTT_CACHE_VERSION` gates the `gantt:v<N>:<building>` IndexedDB key. Its own comment says to bump
it "whenever schedule-GENERATION logic changes in a way that would make an already-cached schedule
wrong (rate/productivity tables, SEQUENCE RULES, SCHEDULE_GATE.JS GATING LOGIC)" and warns that
"a logic fix alone does NOT reach a browser that already generated+cached a schedule under the old
(buggy) logic; only a version bump does".

§4D_ROOF_LOAD_PATH changed BOTH named things — the slab sequence rule (role derived from load path,
not storey name) and schedule_gate.js's gating (walls became candidate supports for promoted roof
slabs) — and the bump was missed. So §GANTT_CACHE_HIT kept serving the pre-fix ordering forever, and
a hard reset cannot help: the entry is in IndexedDB, not the HTTP cache.

⚠ This is the SECOND time this exact trap has fired in this file. The v4 note already records it
verbatim: "Missed on first landing (user hit exactly this 'hard reset didn't fix it' symptom); this
bump is that fix's second half." The warning was written, and the fix shipped without it anyway —
including through my own review of the diff. The v5 note now says so.

Verified: witness_4d_roof_load_path.js 9/9 with the bump in place (the new key is a clean miss, so
the schedule regenerates under the fixed ordering).

Workaround for anyone already holding a stale entry and not yet on v906: the 4D panel's Regenerate
issues §CACHE_DEL for that one key. Do NOT clear site data — that also destroys saved cinema paths
in IndexedDB (§CPE_IDB_PATH_STORE).

viewer sw v905 → v906.
Spec: bim-compiler prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)