### PR TITLE
fix(cinema): §CPE_STICK_HOLD default moves to the LAST band (the exit), not the middle

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -33,8 +33,8 @@
   // you drag and the handles you grab — and reads at a glance on a 63K-element scene.
   var CPE_STICK_RED = 0xe53935;
   var CPE_STICK_TEXT = '#64b5f6';   // the same hue, readable as text on the dark panel
-  // §CPE_STICK_HOLD — the user's own number ("putting hold at 1 sec"), applied to the LAST stick of a
-  // freshly seeded path so the beat teaches itself. Every other stick defaults to 0.
+  // §CPE_STICK_HOLD — the user's own number ("putting hold at 1 sec"), applied to the LAST band (the
+  // EXIT) of a freshly seeded path so the beat teaches itself. Every other band defaults to 0.
   var CPE_HOLD_DEFAULT_SEC = 1.0;
   var CPE_V = 'v19 (§CPE_HOSE_LENGTH_BLIND the clock costs the HOSED curve — a hose pull used to buy speed instead of time (user record: 107.55m costed, 173.53m flown); §CPE_STICK_RED_BAR an unselected stick is a RED bar with BLUE dots, not an all-blue smudge; §CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the added node survives; provenance travels in the override instead of being guessed from the index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; §CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
@@ -1581,8 +1581,13 @@
           // Only on a FRESHLY SEEDED path: an authored one carries whatever the user actually set,
           // including a deliberate 0, and re-imposing the default would overwrite their edit every
           // time they re-opened the panel.
+          // ⚠ CORRECTED 2026-08-01 (user): the default goes on the LAST band — the EXIT — not on
+          // `length-2`. The first cut read "last stick" as the last SPAWNED band (index length-2,
+          // since the stop row is not a spawned stick) and put the 1s in the MIDDLE of the walk.
+          // The user's intent is the end of the walk, where the camera pauses before the pull-back:
+          // "u placed that 1 sec in the middle instead of the last ie exit."
           o.hold = authored ? +(b.hold || 0)
-                            : ((bs.length >= 3 && i === bs.length - 2) ? CPE_HOLD_DEFAULT_SEC : 0);
+                            : ((bs.length >= 2 && i === bs.length - 1) ? CPE_HOLD_DEFAULT_SEC : 0);
           return o;
         });
       };
@@ -1805,7 +1810,7 @@
         // checkable without driving the panel UI.
         _seedHolds: function(n) {
           var o = [];
-          for (var i = 0; i < n; i++) o.push((n >= 3 && i === n - 2) ? CPE_HOLD_DEFAULT_SEC : 0);
+          for (var i = 0; i < n; i++) o.push((n >= 2 && i === n - 1) ? CPE_HOLD_DEFAULT_SEC : 0);
           return o;
         },
         _probePipe: function(clientX, clientY) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v909';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v910';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_stick_hold.js
+++ b/witness_cpe_stick_hold.js
@@ -306,11 +306,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         return { dflt: E.holdDefaultSec, three: E._seedHolds(3), five: E._seedHolds(5), two: E._seedHolds(2) };
       } catch (e) { return null; }
     });
+    // CORRECTED 2026-08-01 (user): the hold belongs on the LAST band — the EXIT — not on length-2.
     const seedOK = !!seed && seed.dflt === 1.0 &&
-      JSON.stringify(seed.three) === JSON.stringify([0, 1, 0]) &&
-      JSON.stringify(seed.five) === JSON.stringify([0, 0, 0, 1, 0]) &&
-      JSON.stringify(seed.two) === JSON.stringify([0, 0]);
-    P('G-SH-7 the LAST stick of a freshly seeded path defaults to 1.0s, every other band to 0',
+      JSON.stringify(seed.three) === JSON.stringify([0, 0, 1]) &&
+      JSON.stringify(seed.five) === JSON.stringify([0, 0, 0, 0, 1]) &&
+      JSON.stringify(seed.two) === JSON.stringify([0, 1]);
+    P('G-SH-7 the LAST band (the EXIT) of a freshly seeded path defaults to 1.0s, every other band to 0',
       seedOK,
       seed === null ? 'editor exposes no hold seeding — the default does not exist (RED on main)'
                     : `default=${seed.dflt}s; seeding 3 bands → [${seed.three}], 5 → [${seed.five}], ` +


### PR DESCRIPTION
> *"u placed that 1 sec in the middle instead of the last ie exit. I corrected that."*

The first cut read *"last stick"* as the last **spawned** band (`length-2` — the stop row is not a spawned stick), which put the 1 s **mid-walk**. The intent is the **exit**: the last band, where the camera pauses before the pull-back. Now `i === bs.length - 1`.

**`witness_cpe_stick_hold.js`: 8/8 Hospital, 8/8 Duplex.**
```
G-SH-7  default=1s; seeding 3 bands → [0,0,1], 5 → [0,0,0,0,1], 2 → [0,1]
```

`sw.js` v909 → v910.

## Also in this PR: two spec corrections, no code

**The blind-fan hypothesis I published is WRONG and is retracted here.** I claimed `_cinemaFanMeshes()` does not collect `BatchedMesh`. It already does:
```js
(o.isMesh || o.isInstancedMesh || o.isBatchedMesh) && o.visible && … && !_isGhostGeometry(o)
```
The clue was in the user's URL: **`&ghost=1`**, with `§SHELL_GHOST_AUTO meshCacheKeys=20609`. Leading cause is now `!_isGhostGeometry(o)` excluding the whole building in ghost mode — which is how the user opens the viewer. Not fixed here: the hypothesis has been wrong once already, and the check is one log line (`§CINEMA_FAN_MESHES n=… ghost=… dlod=…`) with and without `&ghost=1`.

**Orbit over-rotation narrowed, fix deliberately not attempted.** Position is fine — the lap is exactly one turn and Beat 4 is radial. The excess is the **gaze**: Beat 4 turns onto the pivot bearing (~180°) and then Beat 5 adds a full 360°. Fifth instance of the §CPE_SPIN_WHIP family. ⚠ Shortening the lap would break *"the last spin is all a straight circle"*; the real answer is Beat 4 approaching the orbit **tangentially**. Measurement named in the spec.

Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md` §CORRECTIONS 2026-08-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)