### PR TITLE
fix(4d): §4D_WALLS_BEFORE_ROOF — #1120 promoted the boxes' roofs and left the roof they stand on

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -63,7 +63,7 @@
   // returns { guid: { start, end } } ms.
   function computeSchedule(elements, baseMs, scaleFactor, maxCrews) {
     baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
-    var grid = {}, out = {}, c, cs, k, arr, S;
+    var grid = {}, wallGrid = {}, out = {}, c, cs, k, arr, S;
     function crewCapFor(resource) {
       if (typeof maxCrews === 'number') return maxCrews;
       if (maxCrews && maxCrews[resource]) return maxCrews[resource];
@@ -89,7 +89,27 @@
       var end = start + dur; out[el.guid] = { start: start, end: end };
       if (el.seq <= 4) { var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, end: end };
         cs = cellsOf(el); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec); }
+      else if (el.cls && el.cls.indexOf('IfcWall') === 0) {   // §4D_WALLS_BEFORE_ROOF M5
+        var wrec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, top_z: el.top_z, end: end };
+        cs = cellsOf(el); for (c = 0; c < cs.length; c++) (wallGrid[cs[c]] = wallGrid[cs[c]] || []).push(wrec); }
       return end;
+    }
+    // §4D_WALLS_BEFORE_ROOF M5 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) — a
+    // roof-role slab (seq>4, promoted by the load-path rule in time_machine.js) must wait for the
+    // walls that CARRY it, by geometry. Before this, a promoted slab's only dependency on walls was
+    // the per-PHASE trade gate below, keyed on collapsePhase(storey) — and MEASURED on Hospital the
+    // roof deck's key is "Level 7" while 12 of its 14 carriers are key "Level 6", so 12 of 14 were
+    // covered by coincidence, not by a rule. This gate is the SAME pool auditFloating already offers
+    // seq>4 slabs (structure + walls), so scheduler and auditor now test the same thing. No new pass
+    // and no cycle: PASS B sorts by (seq, base_z) and walls are seq 6 vs roof slabs seq 8, so every
+    // carrier is already placed when the slab is reached. EPS/GAP are this module's own constants.
+    function wallGate(el) {
+      if (el.cls !== 'IfcSlab' || el.seq <= 4) return baseMs;
+      var g = baseMs; cs = cellsOf(el);
+      for (c = 0; c < cs.length; c++) { arr = wallGrid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) { S = arr[k];
+          if (S.base_z < el.base_z - EPS && S.top_z >= el.base_z - GAP && S.end > g && overlap(S, el)) g = S.end; } }
+      return g;
     }
     // PASS A — structure, bottom-up by base_z (supports scheduled before what rests on them).
     // §CREW-CAP: crew slot is picked PROJECT-WIDE per resource, not per Z-band — lower floors claim
@@ -113,7 +133,7 @@
       var pt = phaseTrade[ph] || {}, tg = baseMs, s;
       for (s in pt) if (+s < el.seq && pt[s] > tg) tg = pt[s];
       var slot = claimCrew(el.resource);
-      var start = Math.max(geoGate(el), tg, slot.time);
+      var start = Math.max(geoGate(el), wallGate(el), tg, slot.time);   // §4D_WALLS_BEFORE_ROOF M5
       var end = place(el, start);
       slot.commit(end);
       (phaseTrade[ph] = phaseTrade[ph] || {});

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v910';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v911';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3330,25 +3330,75 @@
     // against its own extracted geometry and the walls' own extracted geometry.
     var loadPathWalls = elements.filter(function(e) { return e.cls.indexOf('IfcWall') === 0; });
     var loadPathOverrides = 0;
+    // §4D_WALLS_BEFORE_ROOF (2026-08-01) — pass 1 computes the SEED set exactly as #1120 shipped it
+    // (clause a AND clause b), so the shipped count is reproduced unchanged before M4 widens it.
+    var lpSlabs = [], lpSeed = [];
     elements.forEach(function(el) {
       if (el.cls !== 'IfcSlab') return;
       var carriers = loadPathWalls.filter(function(w) {
         return el.x0 <= w.x1 && el.x1 >= w.x0 && el.y0 <= w.y1 && el.y1 >= w.y0;
       });
       if (!carriers.length) return;
-      var midSum = 0, hasWallAbove = false;
+      var midSum = 0, above = [];
       for (var ci = 0; ci < carriers.length; ci++) {
         midSum += (carriers[ci].base_z + carriers[ci].top_z) / 2;
-        if (carriers[ci].base_z >= el.top_z) hasWallAbove = true;
+        if (carriers[ci].base_z >= el.top_z) above.push(carriers[ci]);
       }
       var wallMidheight = midSum / carriers.length;
-      if (el.base_z > wallMidheight && !hasWallAbove) {
+      var clauseA = el.base_z > wallMidheight;
+      lpSlabs.push({ el: el, clauseA: clauseA, above: above });
+      if (clauseA && !above.length) {
         el.seq = 8; el.phase = 'Architecture';
         loadPathOverrides++;
+        lpSeed.push(el);
       }
     });
+
+    // §4D_WALLS_BEFORE_ROOF M4 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) —
+    // user, live on a Hospital MaxQ bake: "The roof before the walls still happening on the roof
+    // top". #1120's clause (b) disqualifies a roof if ANY XY-overlapping wall stands on it. On
+    // Hospital that disqualifies the 2091.5 m² topmost deck (3Csn1z$1v5Q8DXdumWYJUE, base_z 199.66)
+    // because the two helipad boxes — whose OWN roofs #1120 promoted — stand on it. MEASURED on
+    // origin/main: it starts 2022-07-27 as Superstructure while its 14 wall carriers finish
+    // 2023-04-30 — 277 days before its own walls, the identical error #1120 reported fixing for the
+    // boxes. This is #1120's `⚠ LIMIT 2` arriving, and wider than LIMIT 2 predicted: these walls are
+    // 3.05–3.47 m tall and DO carry something, so LIMIT 2's "parapet carries nothing" discriminator
+    // would not have caught it.
+    //   THE RULE: a wall standing on a slab is not "the next storey" if that wall is itself CAPPED
+    //   by a slab already known to be a roof (a helipad box, a plant enclosure, a coped parapet —
+    //   the load path tops out in a roof, it does not continue the building). Capped = a seed roof
+    //   slab XY-overlapping the wall with its base_z between the wall's base_z and top_z + GAP. A
+    //   wall capped by NOTHING does not qualify.
+    //   DEPTH 1, ON THE FROZEN SEED SET, DELIBERATELY. Full recursion was measured and collapses:
+    //   the box walls excuse the 199.66 deck -> the deck excuses 3064w0y0nDv9wdb1cWL_Gu -> Level 6
+    //   promotes -> Level 5 -> Level 4 -> the whole building becomes "roof". Depth-1 terminates.
+    //   MEASURED: Hospital 10 -> 11. The one addition is the user's slab. Level 6 (3 blockers),
+    //   Level 5 (33), Level 4 (514) and #1120's own floor control 1OV06Y3c5D8vODNyxVnSVI (56) all
+    //   stay blocked. A footprint-extent ratio was tried and REJECTED — it does not separate (roof
+    //   0.040 vs intermediate panels 0.024/0.024/0.029/0.044, Level 6 0.170); no threshold exists,
+    //   which is why this is a load-path rule and not an area rule.
+    var LP_GAP = 0.5;  // m — same "tops out at this level" tolerance schedule_gate.js uses (GAP)
+    var m4Promoted = 0;
+    if (lpSeed.length) {
+      lpSlabs.forEach(function(rec) {
+        var el = rec.el;
+        if (el.seq === 8 || !rec.clauseA || !rec.above.length) return;
+        for (var ai = 0; ai < rec.above.length; ai++) {
+          var w = rec.above[ai], capped = false;
+          for (var si = 0; si < lpSeed.length; si++) {
+            var C = lpSeed[si];
+            if (C.x0 <= w.x1 && C.x1 >= w.x0 && C.y0 <= w.y1 && C.y1 >= w.y0 &&
+                C.base_z >= w.base_z && C.base_z <= w.top_z + LP_GAP) { capped = true; break; }
+          }
+          if (!capped) return;             // a wall the building genuinely continues through
+        }
+        el.seq = 8; el.phase = 'Architecture';
+        loadPathOverrides++; m4Promoted++;
+      });
+    }
     if (loadPathOverrides) console.log('§GANTT_OVERRIDE ' + loadPathOverrides +
-      ' slabs promoted to roof role (seq=8) by load path — base_z above the average midheight of their XY-overlapping walls');
+      ' slabs promoted to roof role (seq=8) by load path — base_z above the average midheight of their XY-overlapping walls' +
+      ' (seed=' + lpSeed.length + ' + M4 rooftop-appurtenance=' + m4Promoted + ')');
 
     // §S260e: Sort by actual Z (quantized to 3m bands) → seq → fine Z
     // Real construction: lower Z builds first regardless of storey name.
@@ -3443,6 +3493,55 @@
     var _auditN = 0; for (var _bi = 0; _bi < elements.length; _bi++) if (_audit(elements[_bi])) _auditN++;
     var _float = ScheduleGate.auditFloating(elements, _sched, _audit);
     console.log('§SUPPORT_CHECK floating=' + _float + '/' + _auditN + ' (struct+furniture+walls over their XY support) gated=' + elements.length + ' (0=solved)');
+
+    // §4D_WALLS_BEFORE_ROOF M6 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) — stop
+    // the instrument from lying. §SUPPORT_CHECK above offers its wall pool ONLY to slabs the load-
+    // path rule already promoted (seq>4), so a roof it FAILED to promote reads floating=0 exactly as
+    // if nothing were wrong — that is #1120's `⚠ LIMIT 1`, and it is why "roof before walls" survived
+    // a merge that reported floating=0/10979 on the very run the user was complaining about (24 of
+    // 35 Hospital slabs started ~290 days before the walls carrying them, and the only instrument
+    // said solved). This line is ROLE-BLIND: it counts, for EVERY IfcSlab regardless of seq, whether
+    // it starts before the XY-overlapping walls that carry it finish.
+    //   roofSlabs half  = a GATE. Must be 0. A roof-role slab that starts before its carriers is the
+    //                     defect this section exists to kill.
+    //   otherSlabs half = a MEASUREMENT, NOT a gate. An ordinary intermediate floor legitimately
+    //                     precedes the partitions beneath it in a frame-first concrete schedule —
+    //                     gating on it is #1120's measured-and-rejected "attempt 2" (24 false
+    //                     positives). Printing it is what makes LIMIT 1 auditable instead of hidden.
+    try {
+      var _rgCELL = (ScheduleGate.CELL || 4), _rgEPS = 0.05, _rgGAP = 0.5;
+      var _rgGrid = {}, _rgSlabs = [];
+      for (var _rgi = 0; _rgi < elements.length; _rgi++) {
+        var _e = elements[_rgi];
+        if (_e.cls === 'IfcSlab') { _rgSlabs.push(_e); continue; }
+        if (_e.cls.indexOf('IfcWall') !== 0) continue;
+        for (var _gx = Math.floor(_e.x0 / _rgCELL); _gx <= Math.floor(_e.x1 / _rgCELL); _gx++)
+          for (var _gy = Math.floor(_e.y0 / _rgCELL); _gy <= Math.floor(_e.y1 / _rgCELL); _gy++)
+            (_rgGrid[_gx + ',' + _gy] = _rgGrid[_gx + ',' + _gy] || []).push(_e);
+      }
+      var _rgRoofN = 0, _rgRoofLate = 0, _rgOtherN = 0, _rgOtherLate = 0;
+      _rgSlabs.forEach(function(S) {
+        var sc = _sched[S.guid]; if (!sc) return;
+        var maxEnd = 0, seen = {};
+        for (var gx = Math.floor(S.x0 / _rgCELL); gx <= Math.floor(S.x1 / _rgCELL); gx++)
+          for (var gy = Math.floor(S.y0 / _rgCELL); gy <= Math.floor(S.y1 / _rgCELL); gy++) {
+            var arr = _rgGrid[gx + ',' + gy]; if (!arr) continue;
+            for (var wi = 0; wi < arr.length; wi++) {
+              var W = arr[wi]; if (seen[W.guid]) continue; seen[W.guid] = 1;
+              if (W.base_z < S.base_z - _rgEPS && W.top_z >= S.base_z - _rgGAP &&
+                  S.x0 <= W.x1 && S.x1 >= W.x0 && S.y0 <= W.y1 && S.y1 >= W.y0) {
+                var we = _sched[W.guid]; if (we && we.end > maxEnd) maxEnd = we.end;
+              }
+            }
+          }
+        var late = (maxEnd > 0 && sc.start < maxEnd - 1);
+        if (S.seq > 4) { _rgRoofN++; if (late) _rgRoofLate++; }
+        else { _rgOtherN++; if (late) _rgOtherLate++; }
+      });
+      console.log('§ROOF_GATE roofSlabs=' + _rgRoofN + ' lateVsWallCarriers=' + _rgRoofLate +
+        ' (0=required) | otherSlabs=' + _rgOtherN + ' lateVsWallCarriers=' + _rgOtherLate +
+        ' (frame-first, expected — reported not gated, see GANTT_ACCURACY.md LIMIT 1)');
+    } catch (e) { console.log('§ROOF_GATE error: ' + e.message); }
     // §4D_ROOF_LOAD_PATH witness hook (2026-08-01) — same double-underscore debug convention as
     // __tmTrav/__forceFull/__tmStep above: read-only, lets witness_4d_roof_load_path.js compare the
     // OLD (seq<=4-only) and NEW (M3) audit definitions against the SAME elements+schedule.
@@ -4383,7 +4482,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 5;
+  var _GANTT_CACHE_VERSION = 6;   // §4D_WALLS_BEFORE_ROOF (2026-08-01): M4+M5 change generated ordering
 
   function _cacheKey(prefix) {
     var app = A();

--- a/witness_4d_walls_before_roof.js
+++ b/witness_4d_walls_before_roof.js
@@ -1,0 +1,268 @@
+// WITNESS — §4D_WALLS_BEFORE_ROOF: #1120 promoted the boxes' roofs and left the roof they stand on.
+// Spec: bim-compiler prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF.
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, live, MaxQ buildup bake of Hospital, 2026-08-01):
+//   "The roof before the walls still happening on the roof top"
+// §4D_ROOF_LOAD_PATH (#1120) did NOT fail — the user's own log shows `§GANTT_OVERRIDE 10 slabs
+// promoted to roof role (seq=8) by load path`. What it cannot reach is the slab UNDER the two
+// helipad boxes whose roofs it promoted: clause (b) ("no XY-overlapping wall may stand on it")
+// disqualifies Hospital's 2091.5 m² topmost deck 3Csn1z$1v5Q8DXdumWYJUE (base_z 199.66) because the
+// box walls stand on it. MEASURED on origin/main @9945364 (scratchpad/probe_rooftop_main.log):
+// that deck starts 2022-07-27 as Superstructure while its 14 wall carriers finish 2023-04-30 —
+// 277 days before its own walls, the identical error #1120 reported FIXING for the boxes.
+//
+// THE FIX (M4/M5/M6, see the spec):
+//   M4 — a wall standing on a slab is not "the next storey" if that wall is itself CAPPED by a slab
+//        already known to be a roof. Depth 1 on the frozen #1120 seed set: full recursion cascades
+//        the whole building to "roof" (measured). Hospital 10 -> 11, the one addition is the
+//        user's slab.
+//   M5 — a promoted slab waits for its wall carriers by GEOMETRY. Before this its only wall
+//        dependency was the per-PHASE trade gate, and 12 of this slab's 14 carriers are phase-key
+//        "Level 6" while the slab is "Level 7" — covered by coincidence, not by a rule.
+//   M6 — §ROOF_GATE, a role-blind line, so §SUPPORT_CHECK's floating=0 can no longer be the only
+//        number (#1120's LIMIT 1: the audit's wall pool is offered ONLY to already-promoted slabs,
+//        so a roof it FAILED to promote reads clean — exactly what happened here).
+//
+//   G-WBR-1  RED->GREEN, the user's slab: starts at/after the last of its 14 wall carriers, and is
+//            phase=Architecture. On origin/main it is Superstructure and 277 days early.
+//   G-WBR-2  no cascade: §GANTT_OVERRIDE reports 11 (was 10) and the four named controls (Level 6
+//            191.66, Level 5 186.66, Level 4 181.66, and #1120's own floor control
+//            1OV06Y3c5D8vODNyxVnSVI) are all still NOT promoted.
+//   G-WBR-3  the role is still DERIVED, not named: with every storey string blanked, the same slab
+//            is still promoted. A name test scores 0 here.
+//   G-WBR-4  M5, as a pure-function claim on ScheduleGate.computeSchedule with the trade gate
+//            NEUTRALISED (every carrier given a different storey than the slab): real geometry for
+//            the slab + its 14 carriers; the slab must still start at/after the last carrier. The
+//            pre-M5 gate definition, reproduced inline, fails this on the same input.
+//   G-WBR-5  the instrument no longer hides it: §ROOF_GATE present, roof half = 0 (a gate), other
+//            half reported non-zero (a measurement, not a gate).
+//   G-WBR-6  no regression: placed == total on Hospital AND LTU_AHouse, §SUPPORT_CHECK still 0.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8451;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// The user's slab and its real load path — extracted 2026-08-01 directly from
+// buildings/Hospital_extracted.db (elements_meta JOIN element_transforms). Real GUIDs, real geometry.
+const ROOF_DECK = '3Csn1z$1v5Q8DXdumWYJUE';          // base_z 199.66, top_z 199.81, 2091.5 m²
+const DECK_CARRIERS = ['3064w0y0nDv9wdb1cWL_ja', '3064w0y0nDv9wdb1cWL_ef', '3064w0y0nDv9wdb1cWL_g1',
+  '3064w0y0nDv9wdb1cWL_JV', '0o_QWr67L6KuG2qQA6AhrN', '3klE5WDUzALuFQLQUdamb_',
+  '0tapine8H8Pw$xCCYysqMV', '3064w0y0nDv9wdb1cWL_Gu', '3064w0y0nDv9wdb1cWL_H0',
+  '3Vxmv9vT1DBOVGP9X4HeNy', '3Vxmv9vT1DBOVGP9X4HeLB', '3Vxmv9vT1DBOVGP9X4HeDg',
+  '3Vxmv9vT1DBOVGP9X4HeCY', '3Vxmv9vT1DBOVGP9X4HeCq'];
+// The three walls STANDING ON the deck — the helipad boxes whose own roofs #1120 promoted. These
+// are what clause (b) trips over, and what M4 excuses (each is capped by a seed roof slab).
+const DECK_APPURTENANCE_WALLS = ['3eq15PZlbCi8$6xdXFtxz7', '3Vxmv9vT1DBOVGP9X4HeGE',
+  '3Vxmv9vT1DBOVGP9X4HeDp'];
+// Controls — must stay NOT promoted. Real intermediate floors from the same DB.
+const CONTROLS = {
+  'Level 6 deck (base_z 191.66, 16 walls above, 3 not capped by a roof)': '0e8pm26Tv5vPrj6zU55MQt',
+  'Level 5 deck (base_z 186.66, 54 above, 33 blockers)': '0e8pm26Tv5vPrj6zU55MQv',
+  'Level 4 deck (base_z 181.66, 535 above, 514 blockers)': '0e8pm26Tv5vPrj6zU55MQh',
+  "#1120's own floor control (base_z 176.81, 5 levels above)": '1OV06Y3c5D8vODNyxVnSVI',
+};
+
+async function open(browser, bld) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${bld}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.dbQuery, { timeout: 300000 });
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM elements_meta'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 2000 });
+  await sleep(6000);
+  return { page, logs };
+}
+const D = ms => new Date(ms).toISOString().slice(0, 10);
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const checks = [];
+  let allPass = true;
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false;
+    console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
+
+  console.log('='.repeat(78) + '\nHospital — G-WBR-1..5\n' + '='.repeat(78));
+  const { page, logs } = await open(browser, 'Hospital');
+
+  const res = await page.evaluate(async (deck, carriers, controls, appurt) => {
+    const A = window.APP;
+    const out = {};
+    await window.tmActivateForBake();
+
+    const fetchOps = guids => guids.map(g => {
+      const r = A.dbQuery("SELECT timestamp, parameters FROM kernel_ops WHERE output_guid='" + g +
+        "' AND op_type='ELEMENT_PLACE'");
+      if (!r.length) return { guid: g, missing: true };
+      const p = JSON.parse(r[0][1]);
+      return { guid: g, start: r[0][0], end: p._end_ts, phase: p.phase, storey: p.storey };
+    });
+    const fetchGeom = (guids, cls, seq, storey) => guids.map(g => {
+      const r = A.dbQuery('SELECT center_x,bbox_x,center_y,bbox_y,center_z,bbox_z ' +
+        "FROM element_transforms WHERE guid='" + g + "'");
+      const [cx, bx, cy, by, cz, bz] = r[0];
+      return { guid: g, cls: cls, seq: seq, storey: storey,
+        resource: cls === 'IfcSlab' ? 'CONCRETE_GANG' : 'MASON', installSecs: 120,
+        x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,
+        base_z: cz - bz / 2, top_z: cz + bz / 2 };
+    });
+
+    out.deck = fetchOps([deck])[0];
+    out.carriers = fetchOps(carriers);
+    out.appurt = fetchOps(appurt);
+    out.controls = {};
+    for (const k in controls) out.controls[k] = fetchOps([controls[k]])[0];
+    out.total = A.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class!='IfcOpeningElement'")[0][0];
+    out.placed = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+
+    // ── G-WBR-4: M5 as a pure-function claim, trade gate NEUTRALISED. The slab gets storey
+    // "ROOF_PHASE", every carrier a DIFFERENT storey ("CARRIER_PHASE"), so collapsePhase() puts them
+    // in separate phase buckets and the per-phase trade gate provably cannot cover them. Crew caps
+    // are generous so the isolated subset does not queue. Only a geometric wall gate can hold here.
+    const SG = window.ScheduleGate;
+    const g4slab = fetchGeom([deck], 'IfcSlab', 8, 'ROOF_PHASE');
+    const g4walls = fetchGeom(carriers, 'IfcWallStandardCase', 6, 'CARRIER_PHASE');
+    const g4els = g4slab.concat(g4walls);
+    const BASE = 1600000000000;
+    const s4 = SG.computeSchedule(g4els, BASE, 1, { CONCRETE_GANG: 8, MASON: 8 });
+    out.g4 = {
+      slabStart: s4[deck].start,
+      maxWallEnd: Math.max.apply(null, g4walls.map(w => s4[w.guid].end)),
+      base: BASE,
+    };
+    // The PRE-M5 gate definition, reproduced inline on the same input: the support grid takes only
+    // seq<=4, so a wall can never gate anything. This is exactly what origin/main does.
+    out.g4pre = (function () {
+      const CELL = 4, EPS = 0.05;
+      const cellsOf = e => { const o = []; for (let i = Math.floor(e.x0 / CELL); i <= Math.floor(e.x1 / CELL); i++)
+        for (let j = Math.floor(e.y0 / CELL); j <= Math.floor(e.y1 / CELL); j++) o.push(i + ',' + j); return o; };
+      const ov = (a, b) => a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0;
+      const grid = {}, out2 = {};
+      const place = (el, start) => { const end = start + 120000; out2[el.guid] = { start, end };
+        if (el.seq <= 4) cellsOf(el).forEach(c => (grid[c] = grid[c] || []).push(Object.assign({ end }, el)));
+        return end; };
+      const geoGate = el => { let g = BASE;
+        cellsOf(el).forEach(c => (grid[c] || []).forEach(S => {
+          if (S.base_z < el.base_z - EPS && S.end > g && ov(S, el)) g = S.end; })); return g; };
+      const nonst = g4els.slice().sort((a, b) => (a.seq - b.seq) || (a.base_z - b.base_z));
+      const phaseTrade = {};
+      nonst.forEach(el => {
+        const ph = SG.collapsePhase(el.storey); const pt = phaseTrade[ph] || {}; let tg = BASE;
+        for (const s in pt) if (+s < el.seq && pt[s] > tg) tg = pt[s];
+        const end = place(el, Math.max(geoGate(el), tg));
+        phaseTrade[ph] = phaseTrade[ph] || {};
+        if (!(phaseTrade[ph][el.seq] > end)) phaseTrade[ph][el.seq] = end;
+      });
+      return { slabStart: out2[deck].start, maxWallEnd: Math.max.apply(null, g4walls.map(w => out2[w.guid].end)) };
+    })();
+
+    // ── G-WBR-3: blank every storey string, refold, re-check the same slab ──
+    A.db.run("UPDATE elements_meta SET storey=''");
+    const before = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+    window.tmRefoldSchedule();
+    let waited = 0;
+    while (waited < 120000) {
+      await new Promise(r => setTimeout(r, 1000)); waited += 1000;
+      const n = A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0];
+      if (n >= before) break;
+    }
+    out.deckBlanked = fetchOps([deck])[0];
+    out.waitedMsForRefold = waited;
+    return out;
+  }, ROOF_DECK, DECK_CARRIERS, CONTROLS, DECK_APPURTENANCE_WALLS);
+
+  // ── G-WBR-1 ──
+  const maxCarrierEnd = Math.max(...res.carriers.map(c => c.end));
+  const worstCarrier = res.carriers.find(c => c.end === maxCarrierEnd);
+  const g1 = res.deck.start >= maxCarrierEnd && res.deck.phase === 'Architecture';
+  P('G-WBR-1 the user\'s roof deck no longer starts before the walls that carry it',
+    g1,
+    `deck ${ROOF_DECK} base_z=199.66 (2091.5 m², the building silhouette): start=${D(res.deck.start)} ` +
+    `phase=${res.deck.phase} | 14 wall carriers finish by ${D(maxCarrierEnd)} (last=${worstCarrier.guid}) | ` +
+    `margin=${((res.deck.start - maxCarrierEnd) / 86400000).toFixed(0)}d (>=0 required). ` +
+    `RED on origin/main @9945364, same DB, same GUIDs (scratchpad/probe_rooftop_main.log): ` +
+    `start=2022-07-27 phase=Superstructure vs carriers ending 2023-04-30 = -277d.`);
+
+  // ── G-WBR-2 ──
+  const overrideLine = logs.filter(l => l.startsWith('§GANTT_OVERRIDE')).slice(-1)[0] || '';
+  const nOverride = +((/§GANTT_OVERRIDE (\d+)/.exec(overrideLine) || [])[1] || -1);
+  const ctrlBad = Object.keys(res.controls).filter(k => res.controls[k].phase === 'Architecture');
+  P('G-WBR-2 no cascade: §GANTT_OVERRIDE 10 -> 11, and all 4 intermediate-floor controls stay unpromoted',
+    nOverride === 11 && ctrlBad.length === 0,
+    `§GANTT_OVERRIDE=${nOverride} (11 required: #1120's seed 10 + M4's 1). controls: ` +
+    Object.keys(res.controls).map(k => `${k} -> ${res.controls[k].phase}`).join(' | ') +
+    ` — any 'Architecture' here means the depth-1 rule cascaded. violations=${ctrlBad.length}`);
+
+  // ── G-WBR-3 ──
+  P('G-WBR-3 the role is DERIVED not named: storeys blanked, the same deck is still a roof',
+    res.deckBlanked.phase === 'Architecture',
+    `waited ${res.waitedMsForRefold}ms for refold; deck phase=${res.deckBlanked.phase} ` +
+    `storey=${JSON.stringify(res.deckBlanked.storey)} (a storey-name test scores 0 here)`);
+
+  // ── G-WBR-4 ──
+  const g4ok = res.g4.slabStart >= res.g4.maxWallEnd;
+  const g4preFails = res.g4pre.slabStart < res.g4pre.maxWallEnd;
+  P('G-WBR-4 M5: the wall gate is GEOMETRIC — it holds with the per-phase trade gate neutralised',
+    g4ok && g4preFails,
+    `ScheduleGate.computeSchedule on the real deck + its 14 carriers, slab storey="ROOF_PHASE" vs ` +
+    `carriers "CARRIER_PHASE" (different collapsePhase buckets, so the trade gate CANNOT fire): ` +
+    `slabStart=${res.g4.slabStart - res.g4.base}ms maxWallEnd=${res.g4.maxWallEnd - res.g4.base}ms ` +
+    `-> holds=${g4ok}. PRE-M5 definition (grid=seq<=4 only) on the SAME input: ` +
+    `slabStart=${res.g4pre.slabStart - res.g4.base}ms maxWallEnd=${res.g4pre.maxWallEnd - res.g4.base}ms ` +
+    `-> fails=${g4preFails}. Live, 12 of the 14 carriers are phase-key "Level 6" vs the deck's ` +
+    `"Level 7", so the trade gate never covered them.`);
+
+  // ── G-WBR-5 ──
+  const roofGateLine = logs.filter(l => l.startsWith('§ROOF_GATE')).slice(-1)[0] || '';
+  const rg = /roofSlabs=(\d+) lateVsWallCarriers=(\d+).*otherSlabs=(\d+) lateVsWallCarriers=(\d+)/.exec(roofGateLine);
+  const supportLineHosp = logs.filter(l => l.startsWith('§SUPPORT_CHECK')).slice(-1)[0] || '';
+  P('G-WBR-5 M6: the role-blind §ROOF_GATE exists, its roof half is 0, its other half is reported not hidden',
+    !!rg && +rg[2] === 0 && +rg[4] > 0,
+    `"${roofGateLine || 'MISSING'}" — roof half must be 0 (a gate), other half must be a reported ` +
+    `non-zero (a measurement: ordinary floors legitimately precede their partitions). ` +
+    `Meanwhile §SUPPORT_CHECK reads "${supportLineHosp}" — it read floating=0 on origin/main too, ` +
+    `on the very run the user was complaining about. That is #1120's LIMIT 1, now visible.`);
+
+  const hospFloating = +((/floating=(\d+)/.exec(supportLineHosp) || [])[1] ?? -1);
+  const hospTotalOk = res.total === res.placed;
+  await page.close();
+
+  // ══════════════ LTU_AHouse — G-WBR-6 second building ══════════════
+  console.log('\n' + '='.repeat(78) + '\nLTU_AHouse — G-WBR-6 regression\n' + '='.repeat(78));
+  const { page: page2, logs: logs2 } = await open(browser, 'LTU_AHouse');
+  const res2 = await page2.evaluate(async () => {
+    await window.tmActivateForBake();
+    const A = window.APP;
+    return {
+      total: A.dbQuery("SELECT COUNT(*) FROM elements_meta WHERE ifc_class!='IfcOpeningElement'")[0][0],
+      placed: A.dbQuery("SELECT COUNT(*) FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0][0],
+    };
+  });
+  const supportLineLtu = logs2.filter(l => l.startsWith('§SUPPORT_CHECK')).slice(-1)[0] || '';
+  const roofGateLtu = logs2.filter(l => l.startsWith('§ROOF_GATE')).slice(-1)[0] || '';
+  const ltuFloating = +((/floating=(\d+)/.exec(supportLineLtu) || [])[1] ?? -1);
+  const ltuRoofLate = +((/roofSlabs=\d+ lateVsWallCarriers=(\d+)/.exec(roofGateLtu) || [])[1] ?? -1);
+  await page2.close();
+
+  P('G-WBR-6 no regression: total ops == total elements on both buildings (nothing dropped)',
+    hospTotalOk && res2.total === res2.placed,
+    `Hospital placed=${res.placed}/${res.total} | LTU_AHouse placed=${res2.placed}/${res2.total}`);
+  P('G-WBR-6 §SUPPORT_CHECK still 0 on both, and §ROOF_GATE\'s roof half is 0 on both',
+    hospFloating === 0 && ltuFloating === 0 && ltuRoofLate === 0,
+    `Hospital: ${supportLineHosp || 'MISSING'}\n        LTU_AHouse: ${supportLineLtu || 'MISSING'}` +
+    `\n        LTU_AHouse §ROOF_GATE: ${roofGateLtu || 'MISSING'}`);
+
+  await browser.close();
+  console.log('\n' + '='.repeat(78));
+  console.log(`RESULT ${checks.filter(c => c.ok).length}/${checks.length} ${allPass ? 'ALL GREEN' : 'RED'}`);
+  console.log('='.repeat(78));
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
> **User, live on a Hospital MaxQ buildup bake, 2026-08-01:** *"The roof before the walls still happening on the roof top"*

## §4D_ROOF_LOAD_PATH (#1120) did NOT fail — this is what it could not reach

The user's own log shows `§GANTT_OVERRIDE 10 slabs promoted to roof role (seq=8) by load path`. Ten slabs **were** re-roled. What #1120 structurally cannot promote is the slab **under** the two helipad boxes whose roofs it *did* promote: clause (b) — *"no XY-overlapping wall may have `base_z >= slab.top_z`"* — disqualifies Hospital's **2091.5 m² topmost deck** `3Csn1z$1v5Q8DXdumWYJUE` because the box walls stand on it.

This is #1120's `⚠ LIMIT 2` on record, arriving — and **wider than LIMIT 2 predicted**. LIMIT 2 expected a *parapet* and proposed *"a parapet is a wall whose top is below the tops of the walls it sits among, and which carries nothing"*. That discriminator would **not** have caught these: they are 3.05–3.47 m tall and they **do** carry something (the box roofs).

## The measurement — `origin/main` @ `9945364`, real DB, real `kernel_ops` timestamps

Whole-building probe of all 35 `IfcSlab` against the walls that physically carry them (XY-overlap, `wall.base_z < slab.base_z - 0.05`, `wall.top_z >= slab.base_z - 0.5` — `auditFloating`'s own carrier test):

```
§PROBE_SUMMARY slabs=35 violating=24 promoted(phase=Architecture)=10
               violating_and_promoted=0   violating_and_NOT_promoted=24
```

| the roof top | `3Csn1z$1v5Q8DXdumWYJUE` |
|---|---|
| what it is | the topmost main roof deck, 2091.5 m², the building silhouette |
| storey / z-band | `Level 7` / band 66 |
| base_z / top_z | 199.66 / 199.81 |
| role | **`Superstructure`, seq 4 — NOT promoted** |
| starts | **2022-07-27** |
| its 14 wall carriers finish | **2023-04-30** |
| **error** | **277 days before its own walls** |

**277 days is the identical figure #1120 reported *fixing*.** #1120 measured it on the two box roofs at base_z 202.80/202.83 that sit **on** this deck. Those two now start 2023-10-19. The deck beneath them still started 2022-07-27.

## Which of the three candidate causes is real — measured, not chosen

**CAUSE 1 — the load-path role test misses slabs. REAL, and operative.**
All 24 violating slabs are unpromoted; **0 of the 10 promoted violate**. Promotion is exactly the thing that fixes the ordering, and the roof top does not get it.

**CAUSE 2 — the storey BAND. Not the cause, but a REAL latent hole in the fix.**
`§GANTT_STOREY_Z reassigned=9457` does not misplace the rooftop walls — while the slab is seq 4 it is scheduled in PASS A, where walls are not consulted at all. But it becomes real the moment the slab is promoted: a promoted slab's only wall dependency was the per-**phase** trade gate, and **12 of this deck's 14 carriers are phase-key `Level 6`** while the deck's key is `Level 7`. Promotion alone would have left the wait on those 12 to coincidence.

**CAUSE 3 — the support invariant is wrong. REAL, and why this survived a merge.**
`§SUPPORT_CHECK floating=0/10979 … (0=solved)` **on the very same run** in which 24 of 35 slabs start ~290 days before the walls carrying them. `auditFloating` offers its `wallGrid` only to `T.cls === 'IfcSlab' && T.seq > 4` — only to slabs already promoted. A roof it *failed* to promote reads clean. This is `⚠ LIMIT 1` verbatim, now demonstrated on a real slab.

## The fix

**M4** (`time_machine.js`) — *a wall standing on a slab is not "the next storey" if that wall is itself **capped** by a slab already known to be a roof.* A helipad box, a plant enclosure, a coped parapet: the load path tops out in a roof, it does not continue the building.

**Depth 1, on the frozen #1120 seed set, deliberately.** Full recursion was measured and collapses: the box walls excuse the 199.66 deck → the deck excuses `3064w0y0nDv9wdb1cWL_Gu` → Level 6 promotes → Level 5 → Level 4 → the entire building becomes "roof". Depth-1 terminates. **Hospital 10 → 11**, the single addition is the user's deck:

| slab | base_z | walls above | blockers | verdict |
|---|---|---|---|---|
| `3Csn1z$1v5Q8DXdumWYJUE` | 199.66 | 3 | **0 — all capped by the two box roofs** | **PROMOTED** |
| Level 6 | 191.66 | 16 | 3 | blocked ✓ |
| Level 5 | 186.66 | 54 | 33 | blocked ✓ |
| Level 4 | 181.66 | 535 | 514 | blocked ✓ |
| `1OV06Y3c5D8vODNyxVnSVI` (#1120's control) | 176.81 | 56 | 56 | blocked ✓ |

**Rejected alternative, measured:** a footprint-extent ratio does **not** separate — the roof scores 0.040 while genuine intermediate panels at 176.81 score 0.024 / 0.024 / 0.029 / 0.044 and Level 6 scores 0.170. No threshold exists; that is why M4 is a load-path rule and not an area rule.

**M5** (`schedule_gate.js`) — a roof-role slab waits for its wall carriers by **geometry**, not by phase key. Same pool `auditFloating` already offers `seq>4` slabs, so scheduler and auditor finally test the same thing. No new pass and no cycle: PASS B sorts by `(seq, base_z)` so every seq-6 carrier is placed before the seq-8 slab. No new constant.

**M6** (`time_machine.js`) — `§ROOF_GATE`, **role-blind**, so `floating=0` can no longer be the only number. Roof half is a **gate** (0 required); the other half is a **measurement, not a gate** — an ordinary intermediate floor legitimately precedes the partitions beneath it in a frame-first concrete schedule (gating on it is #1120's measured-and-rejected "attempt 2", 24 false positives). Printing it is what makes LIMIT 1 auditable instead of hidden.

## New `§` lines

```
§GANTT_OVERRIDE 11 slabs promoted to roof role (seq=8) by load path — … (seed=10 + M4 rooftop-appurtenance=1)
§ROOF_GATE roofSlabs=11 lateVsWallCarriers=0 (0=required) | otherSlabs=24 lateVsWallCarriers=23 (frame-first, expected — reported not gated, see GANTT_ACCURACY.md LIMIT 1)
```

## Witness — RED **1/7** on `origin/main` → GREEN **7/7** here

`witness_4d_walls_before_roof.js`, same DBs, same GUIDs, both arms run this session.

| | `origin/main` @9945364 | this branch |
|---|---|---|
| G-WBR-1 the user's deck | ❌ 2022-07-27, `Superstructure`, **−277 d** | ✅ 2023-10-19, `Architecture`, **+173 d** |
| G-WBR-2 no cascade | ❌ `§GANTT_OVERRIDE`=10 | ✅ =11, all 4 floor controls still `Superstructure` |
| G-WBR-3 derived not named | ❌ | ✅ storeys blanked, still a roof |
| G-WBR-4 M5 geometric gate | ❌ slabStart=0 ms < maxWallEnd=240000 ms | ✅ slabStart=240000 ms ≥ maxWallEnd=240000 ms |
| G-WBR-5 M6 instrument | ❌ `§ROOF_GATE` MISSING; `§SUPPORT_CHECK floating=0` was the only number | ✅ roof half 0, other half 23 reported |
| G-WBR-6 regression | ✅ | ✅ |
| **RESULT** | **1/7 RED** | **7/7 ALL GREEN** |

G-WBR-4 is a pure-function claim on `ScheduleGate.computeSchedule` with the per-phase trade gate **neutralised** (slab storey `ROOF_PHASE` vs carriers `CARRIER_PHASE`, different `collapsePhase` buckets) — only a geometric gate can hold it, and the pre-M5 definition reproduced inline on the same input fails.

## Regression — compared against `origin/main`, only NEW failures reported

- `witness_4d_roof_load_path.js` (#1120): **9/9 on main, 9/9 here** — unchanged.
- `tests/test_schedule_gate.js` exit 0 · `tests/test_host_order.js` exit 0 (`§VERDICT GREEN — 0 of 9 witnesses violated`) · `tests/test_facade_stagger_order.js` exit 0 — all identical to main.
- `tests/test_s253_real_db.js` / `test_s253_gantt_sync.js` exit 1 on **both** main and this branch — pre-existing, `MODULE_NOT_FOUND: <repo>/rates.js`. Not a regression, not touched.
- `§SUPPORT_CHECK floating=0` and `placed == total` on **Hospital (63415/63415) and LTU_AHouse** on both.

## Cache / version

- `_GANTT_CACHE_VERSION` **5 → 6** — without it a browser holding a cached gantt never re-generates and the fix cannot reach the user. That is the exact failure #1123 had to ship as its own follow-up for #1120.
- `viewer/sw.js` `CACHE_VERSION` **v910 → v911** (`time_machine.js` and `schedule_gate.js` are both precached).

## Still open, on record

- **`⚠ LIMIT 2` is narrowed, not closed.** A parapet capped by *nothing* still blocks promotion (that is what keeps Level 6 correctly unpromoted here — one of its 3 blockers is a 0.10 m-tall wall capped by nothing). A bare, uncoped parapet ringing a genuine roof would still defeat clause (b). Not exercised by Hospital or LTU_AHouse; `§ROOF_GATE`'s roof half is the line that will show it when a model does.
- **`⚠ LIMIT 1` is now *visible*, not removed.** `§SUPPORT_CHECK` is still role-keyed; `§ROOF_GATE otherSlabs lateVsWallCarriers=23` is the honest number it cannot see. Gating on it remains rejected for the reason #1120 measured.

Spec: `bim-compiler prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF`

🤖 Generated with [Claude Code](https://claude.com/claude-code)