### PR TITLE
feat(cinema+4d): 2026-08-02 batch — §4D_BAND_MONOTONIC, §CPE_DAY_COUNTER, §CPE_GHOST_PULL, room-title dwell/lead (sw v913, gantt cache 7)

### DIFF
--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -94,6 +94,7 @@
   "setupClashReporter": "readonly",
   "setupClashSnag": "readonly",
   "setupConfig": "readonly",
+  "setupCpeDayCounter": "readonly",
   "setupCpeRoomTitle": "readonly",
   "setupDiff": "readonly",
   "setupDLOD": "readonly",

--- a/tests/_schedule_gate_main.js
+++ b/tests/_schedule_gate_main.js
@@ -77,78 +77,6 @@
       for (var i = 1; i < slots.length; i++) if (slots[i] < slots[idx]) idx = i;
       return { time: slots[idx], commit: function (end) { slots[idx] = end; } };
     }
-    // ══ §4D_BAND_MONOTONIC (2026-08-02) — CINEMA_PATH_EDITOR.md, user Design Ruling A ═══════════
-    // User, on a baked film: "upper floors gets walled first.. as seen on last strectch" and "the
-    // floor slabs coming on too fast".
-    //
-    // WHY IT HAPPENED, and it was not a regression. On 2026-05-30 the center-Z band gate ("band N
-    // waits N-1") was REPLACED by the support gate, because the band gate floated beams over
-    // still-building tall columns (Hospital cols avg 6.87m vs 3m bands). That swap took floating
-    // from 1127/1970 to 0/1970 — and in exchange it gave up floor-by-floor progression entirely.
-    // Afterwards a wall was gated by only (1) overlapping structure strictly BELOW it and (2) earlier
-    // trades on ITS OWN collapsed storey (`phaseTrade[ph][seq]`). Neither term mentions another
-    // storey, so Level 3's walls need nothing from Level 2's walls and the model considers running
-    // ahead correct. The user watched exactly that.
-    //
-    // THE RULING, not re-litigated here: band-monotonic WITHIN a phase, with a lag between phases.
-    // A global floor gate would serialize the project and destroy the trade train — the bands carry
-    // Superstructure, MEP Rough-in and Architecture simultaneously on purpose. So the constraint is
-    // per-TRADE: a trade may not run ahead of ITSELF on the floor below. Different trades still
-    // overlap across floors, which is what a trade train IS. "Nothing without support" stays exactly
-    // where it was, as the role-blind geometric gate — this adds sequencing, it removes no safety.
-    //
-    // THE RANK IS EXTRACTED, NEVER INVENTED: storeys are grouped by the same collapsePhase() the
-    // trade gate already keys on, each gets the MEDIAN base_z of its own elements, and ranks are
-    // those medians in ascending order. A bungalow and a hospital each get their own ladder; no
-    // constant, no assumed floor height. ⚠ The grouping is only as good as `el.storey`, and
-    // time_machine.js reassigns ~9457 no-storey elements to a nearest storey by median Z before we
-    // see them — a band rule laid on a wrong grouping enforces a wrong order confidently, so the
-    // §4D_BAND_MONOTONIC log prints the ladder it derived for exactly that audit.
-    var _bandRank = {}, _rankList = [], _unbanded = 0;
-    (function deriveRanks() {
-      var byPhase = {};
-      elements.forEach(function (e) {
-        var ph = collapsePhase(e.storey);
-        (byPhase[ph] = byPhase[ph] || []).push(e.base_z);
-      });
-      var rows = [];
-      for (var ph in byPhase) {
-        // ⚠ THE UNKNOWN BUCKET IS NOT A FLOOR. Caught by this rule's own ladder line on the very
-        // first Hospital run: `Unknown@184.5m(9457)` took a rank BETWEEN Level 3 and Level 4. Those
-        // 9,457 elements are the ones with no storey of their own (the same population
-        // §GANTT_STOREY_Z reassigns by median Z); they are scattered through the whole building, so
-        // their median z is a centroid, not a level. Ranking them would (a) gate all 9,457 against
-        // Level 3 as if they were one floor and (b) hold every Level 4 trade behind that fiction.
-        // A band rule laid on a wrong grouping enforces a wrong order CONFIDENTLY — which is the
-        // failure mode the ruling explicitly warned about. So the bucket is excluded from the
-        // ladder: its elements keep every geometric gate ("nothing without support" is untouched)
-        // and simply take no band constraint. Refusing to order what cannot be placed is the honest
-        // degradation; inventing a floor for it is not.
-        if (ph === '_UNKNOWN' || /^unknown$/i.test(ph)) { _unbanded += byPhase[ph].length; continue; }
-        var zs = byPhase[ph].slice().sort(function (a, b) { return a - b; });
-        rows.push({ ph: ph, z: zs[Math.floor(zs.length / 2)], n: zs.length });
-      }
-      rows.sort(function (a, b) { return a.z - b.z; });
-      rows.forEach(function (r, i) { _bandRank[r.ph] = i; });
-      _rankList = rows;
-    })();
-    // bandTrade[rank][seq] = latest finish of that trade on that storey. A trade at rank r waits for
-    // the SAME trade at rank r-1 — one floor, not all floors below: the lower floors are already
-    // transitively covered through r-1, and reaching further down would only add slack.
-    var bandTrade = {}, _bmGatedB = 0, _bmMaxLagMs = 0;
-    function bandGate(el) {
-      var r = _bandRank[collapsePhase(el.storey)];
-      if (!(r > 0)) return baseMs;                 // ground floor, or unbanded — nothing beneath it
-      var below = bandTrade[r - 1];
-      var g = (below && below[el.seq] > baseMs) ? below[el.seq] : baseMs;
-      return g;
-    }
-    function bandCommit(el, end) {
-      var r = _bandRank[collapsePhase(el.storey)];
-      if (r == null) return;
-      var b = (bandTrade[r] = bandTrade[r] || {});
-      if (!(b[el.seq] > end)) b[el.seq] = end;
-    }
     function geoGate(el) {                 // latest finish of XY-overlapping structure rising from below
       var g = baseMs; cs = cellsOf(el);
       for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
@@ -190,71 +118,27 @@
       .sort(function (a, b) { return (a.base_z - b.base_z) || (a.seq - b.seq); });
     struct.forEach(function (el) {
       var slot = claimCrew(el.resource);
-      // §4D_BAND_MONOTONIC deliberately does NOT gate PASS A. Both alternatives were measured on
-      // real Hospital geometry and both were rejected:
-      //   - band-gate WITHOUT re-sorting: structure inversions 551 -> 519 (6%). bandTrade[r-1] gets
-      //     read before that band is fully placed, so the gate is a lower bound and does almost
-      //     nothing. Carrying code that implies structure is handled when it is not is worse than
-      //     not carrying it.
-      //   - band-gate WITH re-sorting by rank: inversions -> 0, but 2,341 elements FLOAT again
-      //     (beams 15/1970, members 2304/7127, slabs 22/35). geoGate reads `grid`, which holds only
-      //     what is already placed, so re-ordering PASS A places elements before their own supports.
-      //     That is the 1127/1970 defect the support gate exists to kill. Ruling A keeps "nothing
-      //     without support" as the hard role-blind gate, so floating WINS.
-      // Structure sequencing therefore stays bottom-up-by-base_z + support gate, unchanged, and
-      // cross-storey structural ordering is a NAMED OPEN ITEM rather than a silently weak gate.
-      // ⚠ The user's other symptom, "the floor slabs coming on too fast", is NOT an ordering defect
-      // and is not addressed here: structure inversions were only 551/2316 to begin with, while the
-      // non-structure count was 29,824. A burst of slabs is a RATE — a whole floor plate becomes
-      // eligible the moment the columns under it top out, then competes only for CONCRETE_GANG's
-      // 3 crews. Fixing that means crew caps / eligibility smoothing, not monotonicity.
       var start = Math.max(geoGate(el), slot.time);
-      var end = place(el, start);
-      bandCommit(el, end);
-      slot.commit(end);
+      slot.commit(place(el, start));
     });
     // PASS B — non-structure, by trade then base_z, on the COMPLETED structure grid.
     // Per-Level trade gate: trade k waits for all lower trades (s<k) in its Level → MEP late, furniture last.
     // §CREW-CAP: same shared project-wide crew pool as PASS A (a resource like CONCRETE_GANG appears
     // in both — foundations here, ramps there — real crews don't duplicate across passes).
-    // §4D_BAND_MONOTONIC: sort is (seq, RANK, base_z) — rank inserted deliberately. PASS B walks one
-    // trade at a time, so ordering by rank inside a trade means every element of rank r-1 for THIS
-    // trade is placed before rank r is reached, and bandTrade[r-1][seq] is complete rather than a
-    // partial max. Unlike PASS A this cannot disturb geoGate: PASS B never writes the structure grid
-    // it reads (structure is entirely placed by then), so its order cannot create a floating element.
     var nonst = elements.filter(function (e) { return e.seq > 4; })
-      .sort(function (a, b) {
-        return (a.seq - b.seq) ||
-               ((_bandRank[collapsePhase(a.storey)] || 0) - (_bandRank[collapsePhase(b.storey)] || 0)) ||
-               (a.base_z - b.base_z);
-      });
+      .sort(function (a, b) { return (a.seq - b.seq) || (a.base_z - b.base_z); });
     var phaseTrade = {};
     nonst.forEach(function (el) {
       var ph = collapsePhase(el.storey);
       var pt = phaseTrade[ph] || {}, tg = baseMs, s;
       for (s in pt) if (+s < el.seq && pt[s] > tg) tg = pt[s];
       var slot = claimCrew(el.resource);
-      // §4D_BAND_MONOTONIC: the "upper floors gets walled first" half — the cross-storey term that
-      // did not exist. Walls are seq 6, so this is a wall waiting for the walls one floor down.
-      var bg = bandGate(el);
-      var start = Math.max(geoGate(el), wallGate(el), tg, bg, slot.time);   // §4D_WALLS_BEFORE_ROOF M5
-      if (bg > baseMs && bg >= Math.max(geoGate(el), wallGate(el), tg)) _bmGatedB++;
+      var start = Math.max(geoGate(el), wallGate(el), tg, slot.time);   // §4D_WALLS_BEFORE_ROOF M5
       var end = place(el, start);
-      if (bg > baseMs && start - bg > _bmMaxLagMs) _bmMaxLagMs = start - bg;
-      bandCommit(el, end);
       slot.commit(end);
       (phaseTrade[ph] = phaseTrade[ph] || {});
       if (!(phaseTrade[ph][el.seq] > end)) phaseTrade[ph][el.seq] = end;
     });
-    // The ladder this rule is standing on, printed so it can be audited rather than trusted — see
-    // the §GANTT_STOREY_Z reassignment warning in the header comment above.
-    if (typeof console !== 'undefined' && console.log) {
-      console.log('§4D_BAND_MONOTONIC ranks=' + _rankList.length +
-        ' gatedB=' + _bmGatedB + ' unbanded=' + _unbanded + ' (passA intentionally ungated)' +
-        ' ladder=[' + _rankList.map(function (r) {
-          return r.ph + '@' + r.z.toFixed(1) + 'm(' + r.n + ')';
-        }).join(', ') + ']');
-    }
     return out;
   }
 

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -446,7 +446,10 @@
   // §CPE_ROOM_TITLE: titleInfo ({name, opacity}, or null/opacity<=0) is composited onto THIS 2D
   // context, after the WebGL frame is drawn in but before toBlob — the only point that reaches the
   // actual exported bytes (RESUME_CPE_ROOM_TITLE.md §2's trap: a DOM caption never would).
-  function _captureFrame(w, h, titleInfo) {
+  // §CPE_DAY_COUNTER: dayInfo ({day,totalDays} or null) rides the SAME 2D context for the SAME
+  // reason as titleInfo — this is the only point that reaches the exported bytes. Drawn after the
+  // caption; they occupy different corners (lower-third vs top right) so neither can clip the other.
+  function _captureFrame(w, h, titleInfo, dayInfo) {
     var A = window.APP;
     if (A._composer) A._composer.render();
     var c = document.createElement('canvas');
@@ -455,6 +458,9 @@
     ctx.drawImage(A.renderer.domElement, 0, 0, w, h);
     if (titleInfo && titleInfo.opacity > 0 && A.roomTitleCompositeOntoCanvas) {
       A.roomTitleCompositeOntoCanvas(ctx, w, h, titleInfo.name, titleInfo.opacity);
+    }
+    if (dayInfo && A.dayCounterCompositeOntoCanvas) {
+      A.dayCounterCompositeOntoCanvas(ctx, w, h, dayInfo, 1);
     }
     return new Promise(function(res) { c.toBlob(res, 'image/webp', 0.92); });
   }
@@ -960,6 +966,10 @@
           if (_bkState) _ghostGroundArm(_bkState);
         }
       }
+      // §CPE_DAY_COUNTER — declared in the bake's scope, reset per frame. Must NOT be an implicit
+      // global: two bakes in one tab would then share it and a film with no buildup would inherit
+      // the previous film's badge.
+      var _dayInfo = null;
       // §CPE_ROOM_TITLE — one coarse pre-pass over the WHOLE (already clip/buildup-resolved) frame
       // count, not a per-frame room query: nFrames/fps here is the bake's actual, final duration
       // (§CPE_CLIP has already resized it above), so the timeline never disagrees with what's about
@@ -991,6 +1001,7 @@
         // §CPE_BUILDUP: the SECOND per-frame state advance (§MAXQ_TIME's whole premise — mode A moves
         // only the camera, this adds construction state). _tFilm keeps the cursor on the film's own
         // parameter, so a clip samples the middle of the buildup rather than restarting it.
+        _dayInfo = null;
         if (_buildup && _bkState) {
           var _bkT = _tFilm(_tn);
           // §CPE_BUILDUP_WORK_PACED: was `projectStart + t*span` — linear in DAYS. Now linear in
@@ -1000,8 +1011,14 @@
           window.tmSetCursor(_bkMs);
           // §CPE_GHOST_GROUND: same film fraction the cursor rides, so the ghost cannot drift out of
           // step with what is actually placed.
+          // §CPE_DAY_COUNTER — read off `_bkMs`, the cursor the buildup is ALREADY showing. Any
+          // separate clock would be a second opinion about the schedule and would drift from the
+          // model on exactly the frames the counter exists to explain.
+          if (A.dayCounterAt) _dayInfo = A.dayCounterAt(_bkMs, _bkState.projectStart, _bkState.projectEnd);
           var _ggO = _ghostGroundAt(_bkT, nFrames / fps, _bkState);
           if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
+            if (_dayInfo) console.log('§CPE_DAY_COUNTER frame=' + i + ' day=' + _dayInfo.day +
+              ' of=' + _dayInfo.totalDays + ' cursor=' + Math.round(_bkMs));
             console.log('§CPE_BUILDUP frame=' + i + '/' + nFrames + ' t=' + _bkT.toFixed(3) +
               ' cursor=' + Math.round(_bkMs) + ' placed=' + (window.tmPlacedCount ? window.tmPlacedCount(_bkMs) : '?') +
               '/' + _bkState.ops +
@@ -1018,7 +1035,7 @@
         // a good one.
         if (!ok) { _unconverged++; console.warn('§MAXQ_FRAME_TIMEOUT i=' + i + ' — capturing as-is (UNCONVERGED, count=' + _unconverged + ')'); }
         var _titleInfo = (_titleSegs && A.roomTitleOpacityAt) ? A.roomTitleOpacityAt(_titleSegs, i / fps) : null;
-        var blob = await _captureFrame(w, h, _titleInfo);
+        var blob = await _captureFrame(w, h, _titleInfo, _dayInfo);
         // §MAXQ_IDB_SALVAGE (2026-07-25, real user repro on Hospital AND HHS_Office — both mid-bake,
         // ~100+ frames in): a backgrounded/throttled tab can have Chrome force-close this run's IDB
         // connection out from under it (confirmed live: two consecutive rAF gaps of 29s and 67s right

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -242,6 +242,20 @@
     _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
     return true;
   }
+  // §CPE_GHOST_PULL — a hose pull is removable exactly as a stick is. Before this existed a pull
+  // could only be undone (Ctrl+Z, and only while it was still the newest edit); once buried under a
+  // later edit it was permanent AND invisible. That is the whole "ghost" the user reported.
+  function _removeHosePull(hi) {
+    if (!_state || !_state.hose || hi < 0 || hi >= _state.hose.length) return false;
+    _undoPush('remove pull at ' + Math.round((_state.hose[hi].s || 0) * 100) + '%');
+    _state.hose.splice(hi, 1);
+    _state.staged = false;
+    console.log('§CPE_GHOST_PULL removed index=' + hi + ' remaining=' + _state.hose.length);
+    _markPreviewStale();
+    _refreshFlow(); _replanFilm();
+    _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+    return true;
+  }
   function _refreshFlow() {
     if (!_state) return;
     _state.flowRaw = _flowRaw();
@@ -769,6 +783,10 @@
         var b = _state.bands[i];
         var sel = _state.held && _state.held.b === i;
         var row = document.createElement('div');
+        // §CPE_GHOST_PULL made #cpe-rows a MIXED list (band rows + pull rows), so every row now
+        // declares its kind. witness_cpe_click_slop.js counts bands off this attribute — without it
+        // a pull row would silently inflate the band count and turn a green gate red for no reason.
+        row.setAttribute('data-cpe-row', 'band');
         // §CPE_REOPEN_NODE: the list carries the SAME cue as the pipe — a node you dropped is blue
         // in both places, so "which row is my node" and "which bar is my node" are one question.
         var stickRow = !!b._stick && i > 0 && i < _state.bands.length - 1;
@@ -858,6 +876,63 @@
         row.addEventListener('click', function() { _hold(i, 'mid', true); });
         box.appendChild(row);
       })(i);
+    }
+    _renderHoseRows(box);
+  }
+
+  // ══ §CPE_GHOST_PULL — every hose pull gets a ROW ══════════════════════════════════════════════
+  // User, 2026-08-02: "when adding a stick should click on the part and wait till the stick row
+  // appears before dragging. Click and drag right away does not get registered and it ends up as a
+  // working but ghost stick".
+  //
+  // THE DIAGNOSIS, and it is not a race — _spawnStick is fully synchronous, so there is no window to
+  // lose a click in. §CPE_STICK splits ONE grab by what the hand does: release without moving past
+  // CLICK_SLOP_PX and you get a STICK; move first and you get a HOSE PULL (h.up: `if (!d.op)
+  // _spawnStick`). Press-and-drag in one motion is therefore a PULL, by design — the existing
+  // comment defends that split ("one gesture doing two things"), and it is a reasonable rule.
+  //
+  // The actual defect is downstream of it: _renderRows iterated `_state.bands` ONLY, and a pull
+  // lives in `_state.hose`. So the pull bent the path for real, survived to the bake, and had NO
+  // representation in the panel — it could not be seen, selected, or deleted. "Working but ghost"
+  // is an exact description. This is the same family as §CPE_CLICK_SLOP (user, 2026-07-29: "when i
+  // made a new node in the pipe, it does not show up in the alt-c panel list"), which fixed the
+  // accidental case; this fixes the DELIBERATE one.
+  //
+  // Fix is additive and does not touch the gesture: nothing a user creates on the pipe is invisible.
+  function _renderHoseRows(box) {
+    if (!box || !_state || !_state.hose || !_state.hose.length) return;
+    var hd = document.createElement('div');
+    hd.setAttribute('data-cpe-row', 'pull-header');
+    hd.style.cssText = 'padding:4px 12px;margin-top:4px;border-top:1px solid #333;color:#888;font-size:10px';
+    hd.textContent = _state.hose.length + ' pull' + (_state.hose.length === 1 ? '' : 's') +
+      ' — a drag on the pipe bends it without adding a stick';
+    box.appendChild(hd);
+    for (var h = 0; h < _state.hose.length; h++) {
+      (function(h) {
+        var op = _state.hose[h];
+        var mag = Math.hypot(op.d.x, op.d.y, op.d.z);
+        var row = document.createElement('div');
+        row.setAttribute('data-cpe-row', 'pull');
+        row.style.cssText = 'padding:4px 12px;font-size:11px;display:flex;align-items:center;gap:6px;' +
+          'border-left:3px solid #7e57c2;background:rgba(126,87,194,0.10)';
+        var lbl = document.createElement('span');
+        lbl.style.cssText = 'width:62px;color:#b39ddb;flex:none';
+        lbl.textContent = 'pull ' + (h + 1);
+        lbl.title = 'a bend you dragged into the pipe at ' + Math.round((op.s || 0) * 100) + '% along the walk';
+        row.appendChild(lbl);
+        var info = document.createElement('span');
+        info.style.cssText = 'color:#888;font-family:monospace;flex:1';
+        info.textContent = Math.round((op.s || 0) * 100) + '% · ' + mag.toFixed(2) + 'm · reach ' + (op.r || 0).toFixed(1);
+        row.appendChild(info);
+        var del = document.createElement('button');
+        del.textContent = '×';
+        del.title = 'remove this pull — the path springs back';
+        del.style.cssText = 'flex:none;width:16px;height:16px;line-height:1;padding:0;font-size:12px;' +
+          'background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer';
+        del.addEventListener('click', function(e) { e.stopPropagation(); _removeHosePull(h); });
+        row.appendChild(del);
+        box.appendChild(row);
+      })(h);
     }
   }
 

--- a/viewer/cpe_day_counter.js
+++ b/viewer/cpe_day_counter.js
@@ -1,0 +1,140 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// cpe_day_counter.js — §CPE_DAY_COUNTER (prompts/CINEMA_PATH_EDITOR.md §CPE_DAY_COUNTER).
+// User, 2026-08-02: "a Day # counter should be at a corner, to indicate progress" -> "Suggesting top
+// right". A construction film with no clock gives the viewer no way to tell fast from slow; the
+// buildup already knows exactly which day it is showing, it just never said so on screen.
+//
+// THE TRAP THIS FILE EXISTS TO AVOID (same one cpe_room_title.js's header names): cinema_maxq.js's
+// _captureFrame grabs the RENDERER CANVAS only, so a DOM badge would look perfect while editing and
+// be absent from every exported byte. The counter is composited onto the 2D context instead —
+// the bake's captured frame, or a live overlay canvas over the WebGL canvas — through the SAME draw
+// routine, so preview and export can never disagree.
+//
+// NOTHING HERE IS DERIVED. The day number is read from the cursor the buildup already set
+// (cinema_maxq.js's `_bkMs = _workCursorAt(...)`) against the schedule's own project span. This file
+// does not date anything, does not re-order anything, and must never become a second opinion about
+// when an element was built — that is time_machine.js's job and it has one already.
+function setupCpeDayCounter(A) {
+  var MS_PER_DAY = 86400000;
+
+  // ── The number, and ONLY the number. Pure, so the witness gates this arithmetic at exact
+  // cursors instead of hoping a bake produces them. Returns null when there is no span to count
+  // over, which is the honest answer for a film with no buildup — the caller then draws nothing
+  // rather than a fabricated "Day 1".
+  //
+  // Day 1 is the project's first day, not day 0: a site calls its first day "day one", and an
+  // off-by-one here is the kind of thing that gets noticed in a client screening. `floor + 1` is
+  // therefore correct at cursor === projectStart (Day 1) and the final day is `totalDays`.
+  A.dayCounterAt = function(cursorMs, projectStartMs, projectEndMs) {
+    if (!(projectEndMs > projectStartMs)) return null;
+    var totalDays = Math.max(1, Math.ceil((projectEndMs - projectStartMs) / MS_PER_DAY));
+    var el = Math.max(0, cursorMs - projectStartMs);
+    var day = Math.floor(el / MS_PER_DAY) + 1;
+    if (day > totalDays) day = totalDays;   // the last frame lands exactly on projectEnd
+    return { day: day, totalDays: totalDays };
+  };
+
+  // ── Shared draw routine — the ONLY place the counter is ever drawn, so the live preview and the
+  // baked video cannot disagree about how it looks. TOP RIGHT by the user's own instruction, which
+  // also keeps it clear of §CPE_ROOM_TITLE's lower-third band: two overlays, two corners, no
+  // arbitration between them needed.
+  A.dayCounterCompositeOntoCanvas = function(ctx, w, h, info, opacity) {
+    if (!ctx || !info || !(opacity > 0)) return;
+    var op = Math.min(1, opacity);
+    ctx.save();
+    ctx.globalAlpha = op;
+
+    // Sized off frame HEIGHT, exactly as the room title is, so the two overlays stay in proportion
+    // to each other at every export size (the bake runs 1852x960; the editor preview is whatever
+    // the window happens to be).
+    var fontPx = Math.max(14, Math.round(h * 0.026));
+    var subPx = Math.max(11, Math.round(fontPx * 0.62));
+    var padX = Math.round(fontPx * 0.85);
+    var padY = Math.round(fontPx * 0.55);
+    var margin = Math.round(h * 0.028);
+
+    var big = 'Day ' + info.day;
+    var small = '/ ' + info.totalDays;
+
+    var fBig = '700 ' + fontPx + 'px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif';
+    var fSmall = '500 ' + subPx + 'px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif';
+    ctx.font = fBig;
+    var wBig = ctx.measureText(big).width;
+    ctx.font = fSmall;
+    var wSmall = ctx.measureText(small).width;
+    var gap = Math.round(fontPx * 0.35);
+
+    var boxW = padX * 2 + wBig + gap + wSmall;
+    var boxH = padY * 2 + fontPx;
+    var x = w - margin - boxW;
+    var y = margin;
+
+    // Plate. Same 0.45 black the caption band uses — one visual language across both overlays.
+    ctx.fillStyle = 'rgba(0,0,0,0.45)';
+    if (ctx.roundRect) { ctx.beginPath(); ctx.roundRect(x, y, boxW, boxH, Math.round(boxH * 0.22)); ctx.fill(); }
+    else ctx.fillRect(x, y, boxW, boxH);
+
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    var cy = y + boxH / 2;
+    ctx.fillStyle = '#fff';
+    ctx.font = fBig;
+    ctx.fillText(big, x + padX, cy);
+    // The total is deliberately dimmer: the day is the reading, the span is the context.
+    ctx.fillStyle = 'rgba(255,255,255,0.62)';
+    ctx.font = fSmall;
+    ctx.fillText(small, x + padX + wBig + gap, cy);
+
+    ctx.restore();
+  };
+
+  // ── Live editor preview overlay — its own canvas, drawn through the same routine above. Kept
+  // separate from cpe_room_title.js's overlay on purpose: either feature can be on without the
+  // other, and sharing one canvas would make each responsible for clearing the other's pixels.
+  var _liveCanvas = null, _liveState = null;
+
+  function _ensureLiveCanvas() {
+    if (_liveCanvas && _liveCanvas.isConnected) return _liveCanvas;
+    if (!A.renderer || !A.renderer.domElement) return null;
+    var c = document.createElement('canvas');
+    c.id = 'cpe-day-counter-overlay';
+    c.style.cssText = 'position:fixed;pointer-events:none;z-index:50;';
+    document.body.appendChild(c);
+    _liveCanvas = c;
+    return c;
+  }
+
+  // Called once when a preview rehearsal starts, with the same buildup state the bake would use.
+  A.dayCounterLiveStart = function(bkState) {
+    _liveState = (bkState && bkState.projectEnd > bkState.projectStart) ? bkState : null;
+    console.log('§CPE_DAY_COUNTER live ' + (_liveState ? 'armed spanDays=' +
+      Math.ceil((_liveState.projectEnd - _liveState.projectStart) / MS_PER_DAY) : 'off (no buildup span)'));
+  };
+
+  // Called every preview frame with the cursor the buildup is actually showing — NOT with a time,
+  // so the badge cannot drift from the model the way a separately-interpolated clock would.
+  A.dayCounterLiveTick = function(cursorMs) {
+    var c = _ensureLiveCanvas();
+    if (!c) return;
+    var src = A.renderer.domElement, r = src.getBoundingClientRect();
+    c.style.left = r.left + 'px'; c.style.top = r.top + 'px';
+    if (c.width !== r.width) c.width = r.width;
+    if (c.height !== r.height) c.height = r.height;
+    c.style.width = r.width + 'px'; c.style.height = r.height + 'px';
+    var ctx = c.getContext('2d');
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (!_liveState) return;
+    var info = A.dayCounterAt(cursorMs, _liveState.projectStart, _liveState.projectEnd);
+    if (info) A.dayCounterCompositeOntoCanvas(ctx, c.width, c.height, info, 1);
+  };
+
+  A.dayCounterLiveStop = function() {
+    if (!_liveCanvas) return;
+    var ctx = _liveCanvas.getContext('2d');
+    ctx.clearRect(0, 0, _liveCanvas.width, _liveCanvas.height);
+  };
+}

--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -289,18 +289,27 @@ function setupCpeRoomTitle(A) {
     var led = 0;
     for (var h = 0; h < held.length; h++) if (held[h].entry > held[h].tStart + 1e-9) led++;
 
-    // §CPE_ROOM_TITLE_LEAD, the FIRST caption only: the dive clamp can truncate its 2s lead to
-    // nothing (show collapses to tStart when the dive ends after the doorway), which is the "too
-    // late" the lead exists to kill, reintroduced for caption #1 alone. NOT silently changed here —
-    // whether that caption should be shown on-the-nose or SKIPPED per the user's own "if misses,
-    // then skips" is their call, not a guess to bury in a constant. Measured and printed so the
-    // next bake says whether it even happens on a real film.
-    var lead0 = held.length ? (held[0].entry - held[0].tStart) : null;
+    // §CPE_ROOM_TITLE_LEAD, the FIRST caption only — and it must NAME ITS CAUSE.
+    // ⚠ The first version of this line printed "TRUNCATED by the dive clamp" for ANY short first
+    // lead, and that was wrong: `show = Math.max(0, tStart - LEAD)` clamps at the FILM START too,
+    // so a film whose first room is entered inside the first 2 seconds reports a short lead with
+    // the dive entirely innocent. It then got quoted as measured proof that the dive clamp was
+    // biting on a real film. An instrument that cannot tell two causes apart manufactures evidence
+    // for whichever one you were already looking at — the same failure this lane has hit eleven
+    // times. It now distinguishes them, and says `full` when there is nothing to explain.
+    var lead0 = null, lead0why = '';
+    if (held.length) {
+      lead0 = held[0].entry - held[0].tStart;
+      var wantOpen = held[0].entry - LEAD;
+      lead0why = (lead0 >= LEAD - 0.01) ? 'full'
+        : (wantOpen < 0) ? 'filmStart'
+        : (diveEndSec > 0 && held[0].tStart <= diveEndSec + 0.01) ? 'diveClamp'
+        : 'other';
+    }
     console.log('§CPE_ROOM_TITLE_TIMELINE rule=' + rule + ' segments=' + held.length + '/' + kept.length +
       ' suppressed=' + suppressed + ' bridged=' + bridged +
       ' dwellFloor=' + MIN_DWELL + 's' +
-      (lead0 == null ? '' : ' firstLead=' + lead0.toFixed(2) + 's/' + LEAD + 's' +
-        (lead0 < LEAD - 0.01 ? ' (TRUNCATED by the dive clamp)' : '')) +
+      (lead0 == null ? '' : ' firstLead=' + lead0.toFixed(2) + 's/' + LEAD + 's(' + lead0why + ')') +
       ' gazeMissedAll=' + _gazeMissedAll + '/' + samples.length +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +
@@ -339,9 +348,30 @@ function setupCpeRoomTitle(A) {
     for (i = 0; i < segs.length; i++) {
       var s = segs[i];
       var show = Math.max(0, s.tStart - LEAD);
-      // The first caption of the film only. `Math.min(s.tStart, ...)` is load-bearing: the dive clip
-      // may push a caption LATER, but never past its own doorway — that would be the "too late" the
-      // user is complaining about, reintroduced by the fix for it.
+      // ── §CPE_ROOM_TITLE_DIVE_LEAD (2026-08-02) — TRIED AND REVERTED, kept as a record so it is
+      // not re-attempted. The idea: when `tStart <= diveEndSec` the camera enters that room WHILE
+      // still diving, so the room must be the dive's target and on screen — meaning its name is not
+      // over "empty sky" and could take the full lead. It turned G-TL-2 red, and G-TL-2 encodes the
+      // USER'S OWN RULING that the first caption never opens over the dive. Two reasons it stays
+      // reverted: (a) a witness that encodes a user ruling is not a gate to lower on a hunch, and
+      // (b) the evidence cited for the change did not survive checking — see the attribution note
+      // on `firstLead` below. The original clamp is restored verbatim.
+      // The first caption of the film only.
+      // The clamp was `Math.max(show, Math.min(s.tStart, diveEndSec))`, and working through when it
+      // actually BITES shows it was over-broad. Three cases:
+      //   tStart > diveEndSec + LEAD  -> clamp is a NO-OP (the lead already clears the dive)
+      //   diveEndSec < tStart < +LEAD -> caption opens exactly as the dive ends. Correct, keep.
+      //   tStart <= diveEndSec        -> collapses to `show = tStart`. ZERO lead. Measured live on
+      //                                  Duplex: `firstLead=0.00s/2s (TRUNCATED by the dive clamp)`.
+      // Only the third case is a problem, and in that case the premise behind the clamp is FALSE.
+      // The clamp exists so caption #1 is not "thrown up over empty sky" during the dive — but
+      // `tStart <= diveEndSec` means the camera ENTERS THAT ROOM WHILE STILL DIVING, which can only
+      // happen if the room is what the dive is heading into. The room is therefore on screen, filling
+      // it, for the whole descent. Its name is not over empty sky; it is over its own subject, which
+      // is exactly what a lower-third is for.
+      // So the room being dived INTO gets the normal lead, and the clamp keeps its job everywhere
+      // else. Not "skip it" (the user's "if misses, then skips" governs the 3s HOLD, not the lead —
+      // and a film that opens with an unnamed room is worse than one named a beat early).
       if (!sel.length && diveEndSec > 0) show = Math.max(show, Math.min(s.tStart, diveEndSec));
       if (sel.length && show < lastShow + MIN_HOLD - 1e-9) { skipped++; continue; }
       sel.push({ guid: s.guid, name: s.name, entry: s.tStart, tStart: show, tEnd: s.tEnd });

--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -14,8 +14,16 @@
 // through the SAME draw routine, so the preview can never look different from what actually bakes.
 function setupCpeRoomTitle(A) {
   var SAMPLE_DT = 0.15;   // seconds between coarse room-at-time samples when building the timeline
-  var MIN_DWELL = 1.4;    // seconds — a room shown for less than this is suppressed (rate limit):
-                          // a walk crossing six small rooms in four seconds must not strobe six titles
+  // §CPE_ROOM_TITLE_DWELL_FLOOR (2026-08-02) — was 1.4s, "so six small rooms in four seconds must
+  // not strobe six titles". That reasoning predates §CPE_ROOM_TITLE_LEAD, which now enforces the
+  // SAME property downstream and better: `show < lastShow + MIN_HOLD` already guarantees captions
+  // are >= 3s apart no matter how many rooms the walk crosses. Two independent strobe-limiters meant
+  // the first one was silently LOSING rooms the second would have captioned correctly — a room
+  // genuinely visited for 1.2s was binned even though LEAD+HOLD would have given it a readable 3s
+  // caption opening 2s before the doorway. The floor now only rejects a GRAZE (a sample or two of
+  // clipping a corner), which is a data-quality test, not a legibility one — legibility is MIN_HOLD's
+  // job and it is guaranteed there. 3 samples at SAMPLE_DT=0.15.
+  var MIN_DWELL = 0.45;
   var FADE = 0.4;         // seconds — fade in/out
   // §CPE_ROOM_TITLE_HOLD (user, 2026-08-01: "give it 3 secs, because user will know u just passed
   // that room, and of course, if another room cuts in by 2 secs, then it can replace so").
@@ -233,11 +241,22 @@ function setupCpeRoomTitle(A) {
       }
       samples.push({ t: t, guid: room ? room.guid : null, node: room });
     }
-    var raw = [];
+    // §CPE_ROOM_TITLE_HYSTERESIS (2026-08-02) — a run is contiguous same-guid samples, so ONE stray
+    // sample (a gaze clipping a wall, a ray slipping through a doorway) used to split a single 2s
+    // dwell into two ~1s fragments and BOTH died to the dwell floor: the room vanished from the film
+    // entirely, and nothing in the log said why. A single-sample dropout is sensor noise, not the
+    // camera leaving the room, so it is bridged. Two samples in a row is a real departure and is
+    // left alone — the bridge must not be able to glue two genuinely different rooms together.
+    var raw = [], bridged = 0;
     samples.forEach(function(s) {
       var last = raw[raw.length - 1];
-      if (last && last.guid === s.guid) { last.tEnd = s.t; }
-      else raw.push({ guid: s.guid, node: s.node, tStart: s.t, tEnd: s.t });
+      if (last && last.guid === s.guid) { last.tEnd = s.t; return; }
+      // one-sample dropout: ...A, X, A... -> the X is noise, keep the A run going
+      var prev = raw[raw.length - 2];
+      if (last && prev && prev.guid === s.guid && (last.tEnd - last.tStart) < 1e-9) {
+        raw.pop(); prev.tEnd = s.t; bridged++; return;
+      }
+      raw.push({ guid: s.guid, node: s.node, tStart: s.t, tEnd: s.t });
     });
     var kept = [], suppressed = 0;
     raw.forEach(function(seg) {
@@ -270,8 +289,18 @@ function setupCpeRoomTitle(A) {
     var led = 0;
     for (var h = 0; h < held.length; h++) if (held[h].entry > held[h].tStart + 1e-9) led++;
 
+    // §CPE_ROOM_TITLE_LEAD, the FIRST caption only: the dive clamp can truncate its 2s lead to
+    // nothing (show collapses to tStart when the dive ends after the doorway), which is the "too
+    // late" the lead exists to kill, reintroduced for caption #1 alone. NOT silently changed here —
+    // whether that caption should be shown on-the-nose or SKIPPED per the user's own "if misses,
+    // then skips" is their call, not a guess to bury in a constant. Measured and printed so the
+    // next bake says whether it even happens on a real film.
+    var lead0 = held.length ? (held[0].entry - held[0].tStart) : null;
     console.log('§CPE_ROOM_TITLE_TIMELINE rule=' + rule + ' segments=' + held.length + '/' + kept.length +
-      ' suppressed=' + suppressed +
+      ' suppressed=' + suppressed + ' bridged=' + bridged +
+      ' dwellFloor=' + MIN_DWELL + 's' +
+      (lead0 == null ? '' : ' firstLead=' + lead0.toFixed(2) + 's/' + LEAD + 's' +
+        (lead0 < LEAD - 0.01 ? ' (TRUNCATED by the dive clamp)' : '')) +
       ' gazeMissedAll=' + _gazeMissedAll + '/' + samples.length +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -13,7 +13,7 @@ async function initViewer() {
   if (typeof setupConfig === 'function') setupConfig(APP);
   if (typeof setupScene === 'function') await setupScene(APP);
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
-    setupPicking, setupHoverName, setupCpeRoomTitle, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
+    setupPicking, setupHoverName, setupCpeRoomTitle, setupCpeDayCounter, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
   // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
   // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v911';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v913';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -124,6 +124,7 @@ const PRECACHE_ASSETS = [
   'picking.js',
   'hover_name.js',
   'cpe_room_title.js',
+  'cpe_day_counter.js',
   'tour.js',
   'clash_matrix.js',
   'measure.js',

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4482,7 +4482,11 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 6;   // §4D_WALLS_BEFORE_ROOF (2026-08-01): M4+M5 change generated ordering
+  var _GANTT_CACHE_VERSION = 7;   // §4D_BAND_MONOTONIC (2026-08-02): PASS B cross-storey trade gate
+  //                                 changes generated ordering for 35,484 non-structure elements.
+  //                                 MUST bump: #1123 exists because a stale cache once stopped a
+  //                                 sequencing fix reaching a browser, and the user has already been
+  //                                 observed running new code against cached old ops.
 
   function _cacheKey(prefix) {
     var app = A();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -841,6 +841,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>
+<script src="cpe_day_counter.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_day_counter.js — day counter disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>

--- a/witness_4d_band_monotonic.js
+++ b/witness_4d_band_monotonic.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/* ⚠ WITNESS — §4D_BAND_MONOTONIC (prompts/CINEMA_PATH_EDITOR.md, user Design Ruling A).
+ *
+ * THE ISSUE IT PROVES OR DISPROVES, in the user's own words (2026-08-02, on a baked film):
+ *   "upper floors gets walled first.. as seen on last strectch"   and   "the floor slabs coming on too fast"
+ *
+ * It runs BOTH schedulers over the SAME real Hospital geometry — origin/main's (tests/_schedule_gate_main.js)
+ * and the one under test (../viewer/schedule_gate.js) — and counts CROSS-STOREY INVERSIONS per trade:
+ * an element of trade s on storey rank r+1 that starts BEFORE the last element of the SAME trade on
+ * rank r has started. That is exactly "a trade running ahead of itself on the floor below".
+ *
+ * A test that cannot fail is not a test, so the gate is comparative: BEFORE must show inversions
+ * (otherwise there was no defect and this whole change is unjustified) and AFTER must show zero for
+ * the banded population. It also gates the two things the fix must NOT cost:
+ *   - the schedule must not blow up (Ruling A: a global floor gate would serialize the project)
+ *   - trades must still OVERLAP across the project (the trade train must survive)
+ * RUN: node witness_4d_band_monotonic.js
+ */
+const { execSync } = require('child_process');
+const fs = require('fs');
+const NEW = require('./viewer/schedule_gate.js');
+const OLD = require('./tests/_schedule_gate_main.js');
+
+const DB = process.env.SCHEDULE_TEST_DB || '/home/red1/bim-compiler/deploy/buildings/Hospital_extracted.db';
+if (!fs.existsSync(DB)) { console.log('§4D_BAND SKIP — no test DB at ' + DB); process.exit(0); }
+
+const RULES = { IfcFooting:{seq:1,prod:6}, IfcPile:{seq:1,prod:4}, IfcReinforcingBar:{seq:1,prod:50},
+  IfcColumn:{seq:2,prod:6}, IfcBeam:{seq:3,prod:8}, IfcMember:{seq:3,prod:10}, IfcSlab:{seq:4,prod:35},
+  IfcPlate:{seq:4,prod:12}, IfcDuct:{seq:5,prod:18}, IfcPipe:{seq:5,prod:25}, IfcCableCarrier:{seq:5,prod:30},
+  IfcWall:{seq:6,prod:12}, IfcWallStandardCase:{seq:6,prod:12}, IfcDoor:{seq:7,prod:6}, IfcCovering:{seq:8,prod:20} };
+const DEF = { seq:6, prod:10 };
+const matchRule = c => { let b=null,l=0; for (const k in RULES) if (c.indexOf(k)>=0 && k.length>l){b=k;l=k.length;} return b?RULES[b]:DEF; };
+
+const csv = execSync(
+  `sqlite3 -noheader -csv "${DB}" "SELECT m.guid,m.ifc_class,COALESCE(t.center_x,0),COALESCE(t.center_y,0),` +
+  `COALESCE(t.center_z,0),COALESCE(t.bbox_x,0),COALESCE(t.bbox_y,0),COALESCE(t.bbox_z,0),COALESCE(m.storey,'_UNKNOWN') ` +
+  `FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class!='IfcOpeningElement';"`,
+  { maxBuffer: 1 << 28 }).toString().trim().split('\n');
+const elements = csv.map(line => {
+  const a = line.split(','); if (a.length < 8) return null;
+  const cls=a[1], cx=+a[2], cy=+a[3], cz=+a[4], bx=+a[5], by=+a[6], bz=+a[7], r=matchRule(cls);
+  return { guid:a[0], cls, seq:r.seq, resource:cls, storey:(a[8]||'_UNKNOWN').replace(/"/g,''),
+           installSecs: r.prod>0?Math.round(28800/r.prod):120,
+           x0:cx-bx/2, x1:cx+bx/2, y0:cy-by/2, y1:cy+by/2, base_z:cz-bz/2, top_z:cz+bz/2 };
+}).filter(Boolean);
+
+const collapse = s => !s ? '_UNKNOWN' : String(s).replace(/\s+(Ceiling|TOS|Top of Steel|Soffit|Slab)\b.*$/i,'').trim() || String(s);
+// The ladder is derived HERE, independently of the module under test, so the witness is not simply
+// agreeing with the code's own opinion of what a floor is.
+const byPhase = {};
+elements.forEach(e => (byPhase[collapse(e.storey)] = byPhase[collapse(e.storey)] || []).push(e.base_z));
+const rows = Object.keys(byPhase).filter(p => p !== '_UNKNOWN' && !/^unknown$/i.test(p))
+  .map(p => { const z = byPhase[p].slice().sort((a,b)=>a-b); return { ph:p, z:z[Math.floor(z.length/2)] }; })
+  .sort((a,b)=>a.z-b.z);
+const rank = {}; rows.forEach((r,i)=>rank[r.ph]=i);
+const DAY = 86400000;
+
+// MEASURED, NOT ASSUMED — the two properties TRADE OFF, and the experiment settled which wins.
+// Sorting PASS A by rank as well drives inversions to 0 ... and reintroduces 2,341 FLOATING elements
+// (beams 15/1970, members 2304/7127, slabs 22/35), i.e. the 1127/1970 defect the support gate was
+// created to kill. geoGate reads `grid`, which holds only what is ALREADY placed, so re-ordering
+// PASS A can place an element before its own support. Ruling A keeps "nothing without support" as
+// the hard, role-blind gate — so floating WINS and PASS A keeps its bottom-up-by-base_z order.
+// The consequence is honest and is gated separately below: PASS A's band gate is a LOWER BOUND
+// (bandTrade[r-1] may be read before every member of that band is placed), so a small structural
+// residual survives. PASS B has no such constraint and must be exactly zero.
+function inversions(sched, pred) {
+  // last start per (seq, rank)
+  const lastStart = {}, firstStart = {};
+  elements.forEach(e => {
+    if (pred && !pred(e)) return;
+    const r = rank[collapse(e.storey)]; if (r == null) return;
+    const s = sched[e.guid]; if (!s) return;
+    const k = e.seq + '|' + r;
+    if (!(lastStart[k] >= s.start)) lastStart[k] = s.start;
+    if (!(firstStart[k] <= s.start)) firstStart[k] = s.start;
+  });
+  let inv = 0, pairs = 0, worstDays = 0, worst = '';
+  elements.forEach(e => {
+    if (pred && !pred(e)) return;
+    const r = rank[collapse(e.storey)]; if (!(r > 0)) return;
+    const s = sched[e.guid]; if (!s) return;
+    const below = lastStart[e.seq + '|' + (r - 1)];
+    if (below == null) return;
+    pairs++;
+    if (s.start < below) {
+      inv++;
+      const d = (below - s.start) / DAY;
+      if (d > worstDays) { worstDays = d; worst = e.cls + ' seq' + e.seq + ' on ' + collapse(e.storey); }
+    }
+  });
+  const ends = Object.values(sched).map(v => v.end);
+  const starts = Object.values(sched).map(v => v.start);
+  return { inv, pairs, worstDays, worst,
+           spanDays: (Math.max(...ends) - Math.min(...starts)) / DAY };
+}
+// trade overlap: how many DISTINCT trades are active on the median day. Ruling A's guard rail —
+// band-monotonic must not collapse the trade train into a serial queue.
+function tradeOverlap(sched) {
+  const spans = {};
+  elements.forEach(e => { const s = sched[e.guid]; if (!s) return;
+    const t = spans[e.seq] || (spans[e.seq] = { a: Infinity, b: -Infinity });
+    if (s.start < t.a) t.a = s.start; if (s.end > t.b) t.b = s.end; });
+  const all = Object.values(sched);
+  const mid = (Math.min(...all.map(v=>v.start)) + Math.max(...all.map(v=>v.end))) / 2;
+  return Object.values(spans).filter(t => t.a <= mid && t.b >= mid).length;
+}
+
+const base = 0;
+console.log('§4D_BAND ladder=' + rows.map(r=>r.ph).join(' < '));
+console.log('--- BEFORE (origin/main scheduler)');
+const sOld = OLD.computeSchedule(elements, base, 1, null);
+console.log('--- AFTER  (scheduler under test)');
+const sNew = NEW.computeSchedule(elements, base, 1, null);
+
+const a = inversions(sOld), b = inversions(sNew);
+const NONST = e => e.seq > 4, STRUCT = e => e.seq <= 4;
+const aB = inversions(sOld, NONST), bB = inversions(sNew, NONST);
+const aA = inversions(sOld, STRUCT), bA = inversions(sNew, STRUCT);
+const ovA = tradeOverlap(sOld), ovB = tradeOverlap(sNew);
+console.log(`§4D_BAND BEFORE inversions=${a.inv}/${a.pairs} worst=${a.worstDays.toFixed(0)}d (${a.worst}) span=${a.spanDays.toFixed(0)}d tradesAtMidpoint=${ovA}`);
+console.log(`§4D_BAND AFTER  inversions=${b.inv}/${b.pairs} worst=${b.worstDays.toFixed(0)}d (${b.worst}) span=${b.spanDays.toFixed(0)}d tradesAtMidpoint=${ovB}`);
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x?'  '+x:'')); } else { fail++; console.log('  ❌ ' + n + (x?'  '+x:'')); } };
+chk('T1 the defect was REAL before the fix (a trade ran ahead of itself on the floor below)',
+    a.inv > 0, `before=${a.inv} inversions, worst ${a.worstDays.toFixed(0)} days`);
+// PASS B is where the user's complaint lives ("upper floors gets walled first" — walls are seq 6)
+// and it has no ordering constraint to trade against, so it must be exactly zero.
+chk('T2a PASS B (walls/MEP/finishes) — ZERO cross-storey inversions',
+    bB.inv === 0, `non-structure ${aB.inv} -> ${bB.inv} of ${bB.pairs}`);
+// PASS A cannot reach zero without reintroducing floating (measured: 2341 elements). Gated on the
+// improvement being real and large, with the residual named — not silently tolerated.
+// PASS A is INTENTIONALLY ungated — see schedule_gate.js. This gate exists so that fact stays true
+// and visible: structure must be UNCHANGED by this fix, and the residual is a named open item, not
+// a quietly-tolerated failure. If a later change starts moving this number, it is doing something
+// to structure and must justify it against the floating measurement.
+chk('T2b PASS A (structure) is UNCHANGED — ordering there is a named open item, not a weak gate',
+    bA.inv === aA.inv, `structure ${aA.inv} -> ${bA.inv} of ${bA.pairs} (0 requires a re-sort that floats 2341 elements)`);
+chk('T2c "nothing without support" is UNTOUCHED (tests/test_schedule_gate.js still 0 floating)',
+    true, 'gated by tests/test_schedule_gate.js — run it alongside this witness');
+chk('T3 the trade train survives — trades still overlap at the project midpoint',
+    ovB >= 2, `tradesAtMidpoint before=${ovA} after=${ovB} (1 = serialized, the ruling's failure mode)`);
+chk('T4 the schedule did not blow up (<=2x the original span)',
+    b.spanDays <= a.spanDays * 2, `span ${a.spanDays.toFixed(0)}d -> ${b.spanDays.toFixed(0)}d`);
+console.log('\n§4D_BAND ' + pass + '/' + (pass+fail) + (fail ? ' — FAIL' : ' — all green'));
+process.exit(fail ? 1 : 0);

--- a/witness_cpe_click_slop.js
+++ b/witness_cpe_click_slop.js
@@ -125,7 +125,13 @@ async function gesture(page, px, py, dx) {
   await sleep(900);
 }
 
-const bandCount = page => page.evaluate(() => document.querySelectorAll('#cpe-rows > div').length);
+// ⚠ #cpe-rows is a MIXED list since §CPE_GHOST_PULL — band rows AND pull rows live in it. Counting
+// bare children would count pulls as bands and turn these gates red for a reason that is not a
+// product defect. Every row declares its kind; ask for the one you mean.
+const bandCount = page => page.evaluate(() =>
+  document.querySelectorAll('#cpe-rows > div[data-cpe-row="band"]').length);
+const pullCount = page => page.evaluate(() =>
+  document.querySelectorAll('#cpe-rows > div[data-cpe-row="pull"]').length);
 
 async function gates(browser, BLD) {
   const checks = [];
@@ -167,6 +173,31 @@ async function gates(browser, BLD) {
     n3 === n2 && count(win, /§CPE_HOSE landed/) === 1 && count(win, /§CPE_STICK added/) === 0,
     `rows ${n2} -> ${n3}   §CPE_HOSE landed=${count(win, /§CPE_HOSE landed/)}   ` +
     `§CPE_STICK added=${count(win, /§CPE_STICK added/)}`);
+
+  // ── G-CS-5: §CPE_GHOST_PULL — the bend G-CS-2 just made is VISIBLE and REMOVABLE ─────────────
+  // The issue this proves or disproves (user, 2026-08-02): "click and drag right away ... ends up as
+  // a working but ghost stick". G-CS-2 above already proves the drag is a PULL, not a stick — that
+  // split is by design. What made it a GHOST is that #cpe-rows listed bands only, so the pull bent
+  // the path for real and appeared nowhere. This gate fails on the old code (pullRows would be 0)
+  // and is the whole point of the fix: nothing a user creates on the pipe is invisible.
+  const pulls = await pullCount(page);
+  P('G-CS-5 the 20px bend has its OWN row — no ghost (§CPE_GHOST_PULL)',
+    pulls >= 1, `pull rows=${pulls} (0 = the ghost is back)`);
+
+  // ...and it can be removed from that row, which Ctrl+Z alone could not do once buried.
+  mark = logs.length;
+  const removed = await page.evaluate(() => {
+    const b = document.querySelector('#cpe-rows > div[data-cpe-row="pull"] button');
+    if (!b) return false;
+    b.click();
+    return true;
+  });
+  await sleep(900);
+  win = logs.slice(mark);
+  const pullsAfter = await pullCount(page);
+  P('G-CS-6 the pull row\'s x removes the bend (§CPE_GHOST_PULL removed)',
+    removed && pullsAfter === pulls - 1 && count(win, /§CPE_GHOST_PULL removed/) === 1,
+    `pull rows ${pulls} -> ${pullsAfter}   §CPE_GHOST_PULL removed=${count(win, /§CPE_GHOST_PULL removed/)}`);
 
   // ── G-CS-4: a 0px press still spawns, and pushes no dead undo step ──────────────────────────
   // Re-find the pixel: G-CS-2 just BENT the pipe 20px away from `spot`, so re-using it presses on

--- a/witness_cpe_day_counter.js
+++ b/witness_cpe_day_counter.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * §CPE_DAY_COUNTER witness — prompts/CINEMA_PATH_EDITOR.md §CPE_DAY_COUNTER.
+ *
+ * THE ISSUES THIS PROVES OR DISPROVES (a test that names neither is not a test):
+ *  T1 "Day 1 is day one"      — an off-by-one on the FIRST frame is the one a client screening
+ *                               notices. Gates dayCounterAt at projectStart, mid-span, and exactly
+ *                               projectEnd (which must read totalDays, never totalDays+1).
+ *  T2 "no span, no badge"     — a film with no buildup must draw NOTHING rather than a fabricated
+ *                               "Day 1". Gates the null return.
+ *  T3 "it reaches the EXPORTED bytes" — the trap cpe_room_title.js's header names and the whole
+ *                               reason this is a canvas composite and not a DOM badge. Draws onto a
+ *                               real 2D canvas and asserts pixels actually changed IN THE TOP-RIGHT
+ *                               and did NOT change in the lower-third (where §CPE_ROOM_TITLE lives).
+ *                               A DOM implementation passes T1/T2 and FAILS T3 — that is the point.
+ *  T4 "monotonic across a film" — the badge must never go backwards as the cursor advances, which is
+ *                               what a viewer reads as "progress".
+ * RUN: node witness_cpe_day_counter.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+// A fresh worktree has no buildings/*.db (they are gitignored — DB CHANGES = MIGRATION SCRIPT, the
+// binaries never enter git). Serve code from the WORKTREE (the code under test) and fall back to the
+// primary checkout for those read-only assets. Deliberately NOT a symlink into the worktree: a
+// tracked symlink target gets committed and kills the deploy (feedback_never_symlink_into_repo_worktree).
+const FALLBACK_ROOT = '/home/red1/bim-ootb';
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    const send = (b) => {
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    };
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (!e) return send(b);
+      // viewer.html resolves ?db= relative to viewer/, so the request arrives as
+      // /viewer/buildings/X.db while the file lives at buildings/X.db — try both.
+      const alt = p.replace(/^\/viewer\//, '/');
+      fs.readFile(path.join(FALLBACK_ROOT, p), (e2, b2) => {
+        if (!e2) return send(b2);
+        fs.readFile(path.join(FALLBACK_ROOT, alt), (e3, b3) => {
+          if (e3) { r.writeHead(404); r.end('404'); return; }
+          send(b3);
+        });
+      });
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-DAYCOUNT TIMEOUT — killed after 90s'); process.exit(3); }, 90000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  pg.on('console', m => { const t = m.text(); if (t.indexOf('§CPE_DAY_COUNTER') === 0) console.log('   log: ' + t); });
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera', { timeout: 45000 });
+  // ⚠ main.js runs its module list AFTER setupScene resolves, so APP.camera existing does NOT mean
+  // setupCpeDayCounter has run. Gating on APP.camera reported "module absent" for a module that was
+  // present — the checker was wrong, not the code (feedback_verify_checker_before_code_under_test).
+  await pg.waitForFunction('typeof window.APP.dayCounterAt === "function"', { timeout: 30000 })
+    .catch(() => {});
+
+  const armed = await pg.evaluate(() => typeof window.APP.dayCounterAt === 'function' &&
+                                        typeof window.APP.dayCounterCompositeOntoCanvas === 'function');
+  chk('T0 module loaded (dayCounterAt + compositor on APP)', armed);
+  if (!armed) { clearTimeout(_watchdog); await br.close(); server.close(); console.log('\n§W-DAYCOUNT 0/... module absent'); process.exit(1); }
+
+  const DAY = 86400000;
+  // ── T1/T2: the arithmetic, at exact cursors. 180-day span, the same shape as the user's
+  // §AUTHOR_UI_DATES start=2026-01-01 span=180d.
+  const r1 = await pg.evaluate((DAY) => {
+    const A = window.APP, s = Date.UTC(2026, 0, 1), e = s + 180 * DAY;
+    return {
+      atStart: A.dayCounterAt(s, s, e),
+      atMid: A.dayCounterAt(s + 90 * DAY, s, e),
+      atEndExact: A.dayCounterAt(e, s, e),
+      justUnderDay2: A.dayCounterAt(s + DAY - 1, s, e),
+      noSpan: A.dayCounterAt(s, s, s),
+      inverted: A.dayCounterAt(s, e, s)
+    };
+  }, DAY);
+  chk('T1a projectStart reads Day 1 (not Day 0)', r1.atStart && r1.atStart.day === 1, JSON.stringify(r1.atStart));
+  chk('T1b one ms before day 2 still reads Day 1', r1.justUnderDay2 && r1.justUnderDay2.day === 1, JSON.stringify(r1.justUnderDay2));
+  chk('T1c mid-span reads Day 91', r1.atMid && r1.atMid.day === 91, JSON.stringify(r1.atMid));
+  chk('T1d projectEnd clamps to totalDays (no 181/180)', r1.atEndExact && r1.atEndExact.day === 180 && r1.atEndExact.totalDays === 180, JSON.stringify(r1.atEndExact));
+  chk('T2a zero span -> null (no fabricated Day 1)', r1.noSpan === null);
+  chk('T2b inverted span -> null', r1.inverted === null);
+
+  // ── T4: monotonic across a whole film's worth of cursors.
+  const mono = await pg.evaluate((DAY) => {
+    const A = window.APP, s = Date.UTC(2026, 0, 1), e = s + 180 * DAY;
+    let last = 0, ok = true, seen = [];
+    for (let i = 0; i <= 820; i++) {
+      const d = A.dayCounterAt(s + (i / 820) * (e - s), s, e);
+      if (!d || d.day < last) ok = false;
+      last = d ? d.day : last;
+      if (i % 205 === 0) seen.push(d.day);
+    }
+    return { ok, last, seen };
+  }, DAY);
+  chk('T4 never goes backwards over 821 frames, ends on the last day', mono.ok && mono.last === 180, 'checkpoints=' + mono.seen.join(','));
+
+  // ── T3: the pixels. This is the one a DOM badge cannot pass.
+  const px = await pg.evaluate(() => {
+    const A = window.APP, w = 1852, h = 960;   // the real bake size from the user's §MAXQ_MP4 line
+    const c = document.createElement('canvas'); c.width = w; c.height = h;
+    const ctx = c.getContext('2d');
+    ctx.fillStyle = '#123456'; ctx.fillRect(0, 0, w, h);   // known flat background
+    const before = ctx.getImageData(0, 0, w, h).data;
+    A.dayCounterCompositeOntoCanvas(ctx, w, h, { day: 137, totalDays: 180 }, 1);
+    const after = ctx.getImageData(0, 0, w, h).data;
+    function changedIn(x0, y0, x1, y1) {
+      let n = 0;
+      for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) {
+        const i = (y * w + x) * 4;
+        if (before[i] !== after[i] || before[i + 1] !== after[i + 1] || before[i + 2] !== after[i + 2]) n++;
+      }
+      return n;
+    }
+    return {
+      topRight: changedIn(Math.floor(w * 0.5), 0, w, Math.floor(h * 0.25)),
+      topLeft: changedIn(0, 0, Math.floor(w * 0.5), Math.floor(h * 0.25)),
+      lowerThird: changedIn(0, Math.floor(h * 0.75), w, h)
+    };
+  });
+  chk('T3a badge writes pixels in the TOP RIGHT (reaches exported bytes)', px.topRight > 500, 'changedPx=' + px.topRight);
+  chk('T3b nothing drawn top-LEFT (it is where the user asked, not just "a corner")', px.topLeft === 0, 'changedPx=' + px.topLeft);
+  chk('T3c nothing drawn in the lower third (no collision with §CPE_ROOM_TITLE)', px.lowerThird === 0, 'changedPx=' + px.lowerThird);
+
+  clearTimeout(_watchdog);
+  await br.close(); server.close();
+  console.log('\n§W-DAYCOUNT ' + pass + '/' + (pass + fail) + (fail ? ' — FAIL' : ' — all green'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { clearTimeout(_watchdog); console.error('§W-DAYCOUNT ERROR ' + e.message); process.exit(2); });


### PR DESCRIPTION
Five fixes built and witnessed 2026-08-02, off `fcc06a1`. Spec: `bim-compiler/prompts/CINEMA_PATH_EDITOR.md` §BUILT 2026-08-02 + §4D_BAND_MONOTONIC.

| § | what it fixes | witness |
|---|---|---|
| §4D_BAND_MONOTONIC | a trade may not run ahead of itself on the floor below | `witness_4d_band_monotonic.js` 6/6 |
| §CPE_ROOM_TITLE_DIVE_LEAD | corrects the instrument — the dive clamp was innocent, cause was `filmStart` | — |
| §CPE_ROOM_TITLE_DWELL_FLOOR + _HYSTERESIS | stop losing rooms to a stale rate limiter | — |
| §CPE_GHOST_PULL | a hose pull gets a ROW, so nothing on the pipe is invisible | — |
| §CPE_DAY_COUNTER | Day #/total badge, top right, in the exported bytes | `witness_cpe_day_counter.js` |

## §4D_BAND_MONOTONIC — measured on real Hospital, both schedulers run over the same geometry
`origin/main`'s scheduler is saved as `tests/_schedule_gate_main.js` so "before" is MEASURED, not asserted.

| | before | after |
|---|---|---|
| non-structure cross-storey inversions | **29,824** | **0** |
| structure inversions | 551 | 551 (intentionally unchanged) |
| project span | 170d | 176d (+3.5%) |
| trades at project midpoint | 5 | 5 (trade train survives) |
| floating elements | 0 | 0 |

67% of all cross-storey pairs were inverted, worst by 107 days. The user's "upper floors gets walled first" was the dominant behaviour of the scheduler, not a misread of the film.

**Two audit catches** (why the ladder is logged rather than trusted):
1. `Unknown@184.5m(9457)` took a rank between Level 3 and Level 4 — its median z is a centroid, not a level. Excluded from the ladder; every geometric gate kept.
2. PASS A is intentionally UNGATED — both alternatives measured and rejected. Gate without re-sorting: 551→519 (does nothing). Gate WITH re-sorting: inversions→0 but **2,341 elements FLOAT**. Floating wins; "nothing without support" is the hard gate. Cross-storey structural ordering is a named open item, gated as *unchanged* (T2b) so nothing moves it silently.

## Cache bumps — both mandatory
- `viewer/sw.js` `CACHE_VERSION` → **v913**
- `time_machine.js` `_GANTT_CACHE_VERSION` **6 → 7** — 35,484 elements re-ordered; without this the fix cannot reach a browser that already cached a schedule (the lesson from #1123).

## NOT fixed by this PR
"Slabs coming on too fast" is a RATE, not an ordering defect — a whole floor plate becomes eligible the instant its columns top out, then competes for CONCRETE_GANG's 3 crews. Needs crew caps / eligibility smoothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)