### PR TITLE
feat(cpe): Day # counter corner is a movie-maker panel option (§CPE_DAY_COUNTER_POS)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -459,8 +459,8 @@
     if (titleInfo && titleInfo.opacity > 0 && A.roomTitleCompositeOntoCanvas) {
       A.roomTitleCompositeOntoCanvas(ctx, w, h, titleInfo.name, titleInfo.opacity);
     }
-    if (dayInfo && A.dayCounterCompositeOntoCanvas) {
-      A.dayCounterCompositeOntoCanvas(ctx, w, h, dayInfo, 1);
+    if (dayInfo && dayInfo.pos !== 'off' && A.dayCounterCompositeOntoCanvas) {
+      A.dayCounterCompositeOntoCanvas(ctx, w, h, dayInfo, 1, dayInfo.pos);
     }
     return new Promise(function(res) { c.toBlob(res, 'image/webp', 0.92); });
   }
@@ -718,6 +718,7 @@
     // every consumer — the preview, the bake loop, and anything added later — flies the clip through
     // the same function, and there is no second notion of "which part of the film this is".
     var _clip = null, _buildup = false, _bkState = null, _roomTitle = false, _titleSegs = null;
+    var _dayPos = 'tr';
     function _tFilm(tNorm) { return _clip ? _clip.in + tNorm * (_clip.out - _clip.in) : tNorm; }
     function poseAt(tNorm) {
       tNorm = _tFilm(tNorm);
@@ -844,6 +845,10 @@
         }
         _buildup = !!_ov.buildup;
         _roomTitle = !!_ov.roomTitle; // §CPE_ROOM_TITLE — off unless the editor's checkbox set it
+        // §CPE_DAY_COUNTER_POS — the editor's corner choice. Absent (an older saved plan, or a bake
+        // that never opened the editor) means TOP RIGHT, which is what shipped, so nothing re-bakes
+        // differently by accident.
+        _dayPos = _ov.dayCounter || 'tr';
         var _wpN = _ov.bands ? _ov.bands.length * 2 : (_ov.waypoints ? _ov.waypoints.length : '?');
         console.log('§CPE_APPLIED total=' + _cpeRes.durationSec.toFixed(1) + 's frames=' + nFrames +
           ' waypoints=' + _wpN + ' saved=' + !!_cpeRes.saved);
@@ -1014,11 +1019,17 @@
           // §CPE_DAY_COUNTER — read off `_bkMs`, the cursor the buildup is ALREADY showing. Any
           // separate clock would be a second opinion about the schedule and would drift from the
           // model on exactly the frames the counter exists to explain.
-          if (A.dayCounterAt) _dayInfo = A.dayCounterAt(_bkMs, _bkState.projectStart, _bkState.projectEnd);
+          if (A.dayCounterAt && _dayPos !== 'off') {
+            _dayInfo = A.dayCounterAt(_bkMs, _bkState.projectStart, _bkState.projectEnd);
+            // The corner rides ON the info object so _captureFrame needs no second parameter and
+            // cannot be handed a position that belongs to a different frame.
+            if (_dayInfo) _dayInfo.pos = _dayPos;
+          }
           var _ggO = _ghostGroundAt(_bkT, nFrames / fps, _bkState);
           if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
             if (_dayInfo) console.log('§CPE_DAY_COUNTER frame=' + i + ' day=' + _dayInfo.day +
-              ' of=' + _dayInfo.totalDays + ' cursor=' + Math.round(_bkMs));
+              ' of=' + _dayInfo.totalDays + ' pos=' + _dayInfo.pos + ' cursor=' + Math.round(_bkMs));
+            else if (_dayPos === 'off' && i === 0) console.log('§CPE_DAY_COUNTER off — the editor set it off for this bake');
             console.log('§CPE_BUILDUP frame=' + i + '/' + nFrames + ' t=' + _bkT.toFixed(3) +
               ' cursor=' + Math.round(_bkMs) + ' placed=' + (window.tmPlacedCount ? window.tmPlacedCount(_bkMs) : '?') +
               '/' + _bkState.ops +

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -500,6 +500,7 @@
       clip: (s.clipIn > 0 || s.clipOut < 1) ? { in: s.clipIn, out: s.clipOut } : null,
       buildup: !!s.buildup,
       roomTitle: !!s.roomTitle,
+      dayCounter: s.dayCounter || 'tr',
       diveSec: s.baseSec.dive * scale, spinSec: s.baseSec.spin * scale,
       // §CPE_STICK_HOLD: the TRAVEL part of the walk scales with the user's total, the authored hold
       // does NOT — a typed "1 s" must stay 1 s whatever the film is re-timed to, or the panel field
@@ -635,6 +636,19 @@
           'build the model as the film plays</label> <span style="color:#666">(follows the Time Machine, not a programme)</span></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-room-title" type="checkbox"> ' +
           'room titles</label> <span style="color:#666">(name card as the camera enters each room)</span></div>' +
+        // §CPE_DAY_COUNTER_POS — user 2026-08-02: "the movie maker panel puts the Day # counter top
+        // right display option". Top right is the DEFAULT so an existing plan re-bakes identically.
+        // Only meaningful with the buildup on (there is no day to show without one), which the hint
+        // says out loud rather than leaving the user to discover by baking.
+        '<div style="margin-top:4px">Day # counter ' +
+          '<select id="cpe-day-counter" style="background:#15181c;color:#ddd;border:1px solid #3a3f47;' +
+            'border-radius:3px;font-size:10px;padding:1px 2px">' +
+            '<option value="tr">top right</option>' +
+            '<option value="tl">top left</option>' +
+            '<option value="br">bottom right</option>' +
+            '<option value="bl">bottom left</option>' +
+            '<option value="off">off</option>' +
+          '</select> <span style="color:#666">(needs the buildup — it counts the days it is showing)</span></div>' +
         // §CPE_IDB_PATH_STORE — saved plans for THIS building.
         '<div style="margin-top:6px">saved <select id="cpe-plans" style="max-width:150px;background:#15181c;color:#ddd;' +
           'border:1px solid #3a3f47;border-radius:3px;font-size:10px;padding:1px 2px"></select> ' +
@@ -1101,6 +1115,7 @@
     _state.clipOut = ov.clip ? ov.clip.out : 1;
     _state.buildup = !!ov.buildup;
     _state.roomTitle = !!ov.roomTitle;
+    _state.dayCounter = ov.dayCounter || 'tr';   // older saved plans predate the choice — top right
     _state.userTotal = ov._total;
     _state.held = null;
     // §CPE_PATH_NOT_PORTABLE fix, part 1 (prompts/CINEMA_PATH_EDITOR.md): opening a named plan used
@@ -1116,6 +1131,7 @@
     console.log('§CPE_PATH_LOADED name="' + rec.name + '" bands=' + _state.bands.length +
       ' hoseOps=' + _state.hose.length + ' clip=' + _state.clipIn.toFixed(2) + '→' + _state.clipOut.toFixed(2) +
       ' buildup=' + (_state.buildup ? 1 : 0) + ' roomTitle=' + (_state.roomTitle ? 1 : 0) +
+      ' dayCounter=' + (_state.dayCounter || 'tr') +
       ' savedAt=' + new Date(rec.savedAt).toISOString().slice(0, 16) +
       ' — re-staged (§CPE_PATH_NOT_PORTABLE): Ctrl+S now writes this path; Ctrl+Z restores what you had before loading');
     _markPreviewStale();
@@ -1145,6 +1161,11 @@
     // this rehearsal's playback speed, not the film's real length).
     var _titleTotalSec = s.roomTitle ? _buildOverride()._total : 0;
     if (s.roomTitle && a.roomTitleLiveStart) a.roomTitleLiveStart(s.plan, _titleTotalSec);
+    // §CPE_DAY_COUNTER_POS — cpe_day_counter.js has carried dayCounterLiveStart/Tick/Stop since it
+    // shipped and NOTHING called them: the counter only ever existed in the exported bytes, so the
+    // user could not see their own choice until a 20-minute bake finished. Wired here so the corner
+    // is checkable in the rehearsal, through the same draw routine the bake uses.
+    var _dayPos = s.dayCounter || 'tr', _dayOn = (_dayPos !== 'off');
 
     // ══ §CPE_BUILDUP in the PREVIEW — measured before it was assumed expensive ═════════════════
     // User, 2026-07-28: "i dont expect buildup preview can be done as it be heavy engine work...
@@ -1182,6 +1203,11 @@
           // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
           // though the wall-clock speeds differ by 15x.
           if (a.ghostGroundAt) a.ghostGroundAt(tn, _titleTotalSec || dur / 1000, bkPrev);
+          // Same cursor the buildup was just set to — never a second, separately-interpolated clock.
+          if (_dayOn && a.dayCounterLiveTick) {
+            a.dayCounterLiveTick(a.buildupCursorAt ? a.buildupCursorAt(tn, bkPrev)
+              : (bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart)));
+          }
         }
         frames++;
         if (a.markDirty) a.markDirty();
@@ -1199,6 +1225,7 @@
         if (a.ghostGroundRestore) a.ghostGroundRestore();
         if (a.buildupPacingReset) a.buildupPacingReset();
         if (a.roomTitleLiveStop) a.roomTitleLiveStop();
+        if (a.dayCounterLiveStop) a.dayCounterLiveStop();
         _state.flying = false;
         console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +
           ' buildup=' + (s.buildup ? 1 : 0) + ' — camera restored to the editing pose');
@@ -1219,6 +1246,9 @@
         // §CPE_GHOST_GROUND: armed from the SAME bkState the bake arms from, right after the
         // timeline becomes real — the trigger is a cursor timestamp and cannot exist before that.
         if (bkPrev && a.ghostGroundArm) a.ghostGroundArm(bkPrev);
+        // §CPE_DAY_COUNTER_POS — armed from the same bkState, for the same reason: the span it
+        // counts over does not exist until the timeline is real.
+        if (bkPrev && _dayOn && a.dayCounterLiveStart) a.dayCounterLiveStart(bkPrev, _dayPos);
         console.log('§CPE_PREVIEW_BUILDUP ' + (bkPrev ? 'armed mode=' + (bkPrev.source === 'captured' ? 'S' : 'T') +
             ' ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no timeline to follow)') +
           ' setupMs=' + (performance.now() - t0b).toFixed(0) +
@@ -1684,6 +1714,7 @@
         // §CPE_ROOM_TITLE: off by default, same reasoning — a captioned film is a deliberate choice
         // (RESUME_CPE_ROOM_TITLE.md).
         roomTitle: false,
+        dayCounter: 'tr',        // §CPE_DAY_COUNTER_POS — the shipped position, unchanged by default
         // §CPE_PREVIEW_BUTTON: edits counts every landed change; previewedAt is the edit the user
         // has actually seen. Equal = "you have seen this version".
         edits: 0, previewedAt: 0, flying: false,
@@ -1771,6 +1802,20 @@
         var _a = A();
         if (_state.roomTitle && typeof _a.friendlyName !== 'function' && typeof _a.loadNavigate === 'function') _a.loadNavigate();
         if (!_state.roomTitle && _a.roomTitleLiveStop) _a.roomTitleLiveStop();
+        _renderWhole(); _syncButtons();
+      });
+      // Seeded from state, not left on the markup's first <option>: a plan re-opened from
+      // §CPE_IDB_PATH_STORE carries its own corner and the control must show it (the sibling
+      // checkboxes do NOT do this — see §CPE_DAY_COUNTER_POS note in prompts/CINEMA_PATH_EDITOR.md).
+      var dayEl = document.getElementById('cpe-day-counter');
+      dayEl.value = _state.dayCounter || 'tr';
+      dayEl.addEventListener('change', function(e) {
+        _state.dayCounter = e.target.value || 'tr';
+        _markPreviewStale();
+        console.log('§CPE_DAY_COUNTER_POS ' + _state.dayCounter +
+          (_state.buildup ? '' : ' — NOTE: buildup is off, so no day is being counted yet'));
+        var _a2 = A();
+        if (_state.dayCounter === 'off' && _a2.dayCounterLiveStop) _a2.dayCounterLiveStop();
         _renderWhole(); _syncButtons();
       });
       document.getElementById('cpe-preview').addEventListener('click', _previewFly);

--- a/viewer/cpe_day_counter.js
+++ b/viewer/cpe_day_counter.js
@@ -39,10 +39,18 @@ function setupCpeDayCounter(A) {
   };
 
   // ── Shared draw routine — the ONLY place the counter is ever drawn, so the live preview and the
-  // baked video cannot disagree about how it looks. TOP RIGHT by the user's own instruction, which
-  // also keeps it clear of §CPE_ROOM_TITLE's lower-third band: two overlays, two corners, no
-  // arbitration between them needed.
-  A.dayCounterCompositeOntoCanvas = function(ctx, w, h, info, opacity) {
+  // baked video cannot disagree about how it looks.
+  //
+  // §CPE_DAY_COUNTER_POS (user, 2026-08-02: "the movie maker panel puts the Day # counter top right
+  // display option"). TOP RIGHT stays the DEFAULT — it is what the user asked for originally and what
+  // already shipped, so an existing plan re-bakes identically. The corner is now a panel choice
+  // because the counter and §CPE_ROOM_TITLE's caption are the only two overlays and a user framing a
+  // particular building may want the clock out of a different corner.
+  // ⚠ The two BOTTOM positions sit in the caption's lower-third band. That is the user's call to
+  // make, not ours to forbid — but it is why top right remains the default rather than a mere
+  // first-in-list accident.
+  var POS = { tr: 1, tl: 1, br: 1, bl: 1 };
+  A.dayCounterCompositeOntoCanvas = function(ctx, w, h, info, opacity, pos) {
     if (!ctx || !info || !(opacity > 0)) return;
     var op = Math.min(1, opacity);
     ctx.save();
@@ -70,8 +78,9 @@ function setupCpeDayCounter(A) {
 
     var boxW = padX * 2 + wBig + gap + wSmall;
     var boxH = padY * 2 + fontPx;
-    var x = w - margin - boxW;
-    var y = margin;
+    var at = (pos && POS[pos]) ? pos : 'tr';
+    var x = (at === 'tl' || at === 'bl') ? margin : w - margin - boxW;
+    var y = (at === 'bl' || at === 'br') ? h - margin - boxH : margin;
 
     // Plate. Same 0.45 black the caption band uses — one visual language across both overlays.
     ctx.fillStyle = 'rgba(0,0,0,0.45)';
@@ -95,7 +104,7 @@ function setupCpeDayCounter(A) {
   // ── Live editor preview overlay — its own canvas, drawn through the same routine above. Kept
   // separate from cpe_room_title.js's overlay on purpose: either feature can be on without the
   // other, and sharing one canvas would make each responsible for clearing the other's pixels.
-  var _liveCanvas = null, _liveState = null;
+  var _liveCanvas = null, _liveState = null, _livePos = 'tr';
 
   function _ensureLiveCanvas() {
     if (_liveCanvas && _liveCanvas.isConnected) return _liveCanvas;
@@ -109,9 +118,10 @@ function setupCpeDayCounter(A) {
   }
 
   // Called once when a preview rehearsal starts, with the same buildup state the bake would use.
-  A.dayCounterLiveStart = function(bkState) {
+  A.dayCounterLiveStart = function(bkState, pos) {
     _liveState = (bkState && bkState.projectEnd > bkState.projectStart) ? bkState : null;
-    console.log('§CPE_DAY_COUNTER live ' + (_liveState ? 'armed spanDays=' +
+    _livePos = (pos && POS[pos]) ? pos : 'tr';
+    console.log('§CPE_DAY_COUNTER live ' + (_liveState ? 'armed pos=' + _livePos + ' spanDays=' +
       Math.ceil((_liveState.projectEnd - _liveState.projectStart) / MS_PER_DAY) : 'off (no buildup span)'));
   };
 
@@ -129,7 +139,7 @@ function setupCpeDayCounter(A) {
     ctx.clearRect(0, 0, c.width, c.height);
     if (!_liveState) return;
     var info = A.dayCounterAt(cursorMs, _liveState.projectStart, _liveState.projectEnd);
-    if (info) A.dayCounterCompositeOntoCanvas(ctx, c.width, c.height, info, 1);
+    if (info) A.dayCounterCompositeOntoCanvas(ctx, c.width, c.height, info, 1, _livePos);
   };
 
   A.dayCounterLiveStop = function() {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v913';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v914';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_day_counter.js
+++ b/witness_cpe_day_counter.js
@@ -127,15 +127,54 @@ const _watchdog = setTimeout(() => { console.log('\n§W-DAYCOUNT TIMEOUT — kil
       }
       return n;
     }
+    // §CPE_DAY_COUNTER_POS — the SAME probe run once per corner. The claim is not "a badge appears"
+    // but "the badge appears in the corner that was ASKED FOR and in no other", which is the only
+    // thing that makes the panel's choice real rather than decorative.
+    function probe(pos) {
+      ctx.fillStyle = '#123456'; ctx.fillRect(0, 0, w, h);
+      const b2 = ctx.getImageData(0, 0, w, h).data;
+      A.dayCounterCompositeOntoCanvas(ctx, w, h, { day: 137, totalDays: 180 }, 1, pos);
+      const a2 = ctx.getImageData(0, 0, w, h).data;
+      const cnt = (x0, y0, x1, y1) => {
+        let n = 0;
+        for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) {
+          const i = (y * w + x) * 4;
+          if (b2[i] !== a2[i] || b2[i + 1] !== a2[i + 1] || b2[i + 2] !== a2[i + 2]) n++;
+        }
+        return n;
+      };
+      const midX = Math.floor(w * 0.5), topY = Math.floor(h * 0.25), botY = Math.floor(h * 0.75);
+      return { tr: cnt(midX, 0, w, topY), tl: cnt(0, 0, midX, topY),
+               br: cnt(midX, botY, w, h), bl: cnt(0, botY, midX, h) };
+    }
     return {
       topRight: changedIn(Math.floor(w * 0.5), 0, w, Math.floor(h * 0.25)),
       topLeft: changedIn(0, 0, Math.floor(w * 0.5), Math.floor(h * 0.25)),
-      lowerThird: changedIn(0, Math.floor(h * 0.75), w, h)
+      lowerThird: changedIn(0, Math.floor(h * 0.75), w, h),
+      corners: { tr: probe('tr'), tl: probe('tl'), br: probe('br'), bl: probe('bl'),
+                 dflt: probe(undefined), junk: probe('nonsense') }
     };
   });
   chk('T3a badge writes pixels in the TOP RIGHT (reaches exported bytes)', px.topRight > 500, 'changedPx=' + px.topRight);
   chk('T3b nothing drawn top-LEFT (it is where the user asked, not just "a corner")', px.topLeft === 0, 'changedPx=' + px.topLeft);
   chk('T3c nothing drawn in the lower third (no collision with §CPE_ROOM_TITLE)', px.lowerThird === 0, 'changedPx=' + px.lowerThird);
+
+  // ── §CPE_DAY_COUNTER_POS (user 2026-08-02: "the movie maker panel puts the Day # counter top right
+  // display option"). Each corner must be EXCLUSIVE: pixels in the requested quadrant, zero in the
+  // other three. A test that only asserted "pixels somewhere" would pass on a counter that ignored
+  // the setting entirely, which is the exact defect worth catching.
+  const C = px.corners, quads = ['tr', 'tl', 'br', 'bl'];
+  quads.forEach(q => {
+    const got = C[q];
+    const others = quads.filter(o => o !== q).map(o => o + '=' + got[o]).join(' ');
+    chk('T4' + q + ' pos="' + q + '" draws ONLY in that corner', got[q] > 500 &&
+      quads.every(o => o === q || got[o] === 0), q + '=' + got[q] + ' others: ' + others);
+  });
+  chk('T4d no position argument still means TOP RIGHT (the shipped default is unchanged)',
+    C.dflt.tr > 500 && C.dflt.tl === 0 && C.dflt.br === 0 && C.dflt.bl === 0,
+    'tr=' + C.dflt.tr + ' tl=' + C.dflt.tl + ' br=' + C.dflt.br + ' bl=' + C.dflt.bl);
+  chk('T4e an UNKNOWN position falls back to top right rather than drawing nothing or throwing',
+    C.junk.tr > 500 && C.junk.tl === 0, 'tr=' + C.junk.tr + ' tl=' + C.junk.tl);
 
   clearTimeout(_watchdog);
   await br.close(); server.close();


### PR DESCRIPTION
User, 2026-08-02: *"the movie maker panel puts the Day # counter top right display option"*.

The Day # counter shipped hardcoded to top right with **no panel control at all**, and its live-preview hooks (`dayCounterLiveStart/Tick/Stop`) had existed since day one with **nothing calling them** — so the counter only ever appeared in the exported bytes, after a ~20 minute bake.

## What changed
- **`cpe_day_counter.js`** — the compositor takes a corner (`tr`/`tl`/`br`/`bl`). Absent or unknown ⇒ **top right**, so every existing saved plan re-bakes byte-identically.
- **`cinema_path_editor.js`** — a corner select in the Whole-path strip (top right first, plus `off`), seeded from state so a re-opened saved plan shows its own corner; carried through the override, restored, and `§`-logged.
- **`cinema_path_editor.js`** — the live preview now arms/ticks/stops the counter off the **same `bkState` and the same cursor the buildup uses**, never a second interpolated clock. The corner is checkable in a 10 s rehearsal.
- **`cinema_maxq.js`** — the corner rides on the `dayInfo` object into `_captureFrame`, the only point that reaches the exported bytes.
- **`sw.js`** `CACHE_VERSION` v913 → **v914** (three precached `viewer/` files changed).

## Witness — `witness_cpe_day_counter.js` 17/17 (was 11/11)
Each corner must be **exclusive**: >500 changed px in the requested quadrant and **exactly 0** in the other three. A test that only asserted "pixels somewhere" would pass on a counter that ignored the setting entirely.

```
✅ T4tr pos="tr" draws ONLY in that corner  tr=9535 others: tl=0 br=0 bl=0
✅ T4tl pos="tl" draws ONLY in that corner  tl=9535 others: tr=0 br=0 bl=0
✅ T4br pos="br" draws ONLY in that corner  br=9535 others: tr=0 tl=0 bl=0
✅ T4bl pos="bl" draws ONLY in that corner  bl=9535 others: tr=0 tl=0 br=0
✅ T4d no position argument still means TOP RIGHT (the shipped default is unchanged)
✅ T4e an UNKNOWN position falls back to top right rather than drawing nothing or throwing
```

## Pre-existing, NOT introduced here (verified on a clean `origin/main` worktree)
- `tests/audit_specs.js` exits 1 — `38-sh-dx-2d-runtime.spec.js` has 5 SKIP paths.
- `witness_cinema_path_editor.js` **G10** ("LOS aim points at the next waypoint ≤25°") fails 8/9 on both Duplex and Terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)