### PR TITLE
feat(cpe): §CPE_GAZE_ACQUIRE — the gaze acquires its subject fast and settles onto it

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4569,6 +4569,58 @@ async function setupEffects(A, renderer, scene, camera) {
   // §CINEMA_PATH: the ONE shared path plan — flown identically by the live Alt+C capture and by
   // the MaxQ exporter (cinema_maxq.js). Everything derives from the CURRENT camera/sun/building at
   // call time; nothing is hardcoded per building.
+  // ══ §CPE_GAZE_ACQUIRE — the cap ACCELERATES when far off-axis and decays onto the subject ═════
+  // USER, 2026-08-02: "the cam head turning to face density*depth ... Seems a bit slow during this
+  // baking. It be nice if it does so right away gracefully."
+  //
+  // The limiter above was a FLAT cap, so a 90 deg acquisition cost a dead-constant 2.00 s at one
+  // unvarying speed. That is not a slow camera, it is a camera with no acquisition: a real operator
+  // whips onto a subject and DECELERATES onto it. "Right away" and "gracefully" are the two halves
+  // of that, and a single flat number can express neither.
+  //
+  // So the allowance is scaled by the RESIDUAL angle — the further off-axis, the more rate it may
+  // spend; as it converges the multiplier smoothsteps back to exactly 1.0, which is the shipped
+  // behaviour. Peak turn rate is therefore still explicitly bounded (GAZE_ACQUIRE_MAX), still
+  // logged every bake, and a gaze already ON its subject moves exactly as it did before — that
+  // last property matters: it means this cannot add motion to a settled shot.
+  //
+  // ⚠ IT MULTIPLIES OVER CINEMA_TURN_DPS, IT DOES NOT REPLACE IT. That constant also prices the
+  // spin, the orbit lap and the walk's own turn charge (see _useSec, ~line 5932) — raising it would
+  // silently re-time every film ever baked. This is a gaze-only multiplier for exactly that reason.
+  //
+  // 3x = 135 deg/s peak. Chosen against the number that made §CPE_GAZE_CONSTANT_RATE necessary in
+  // the first place: an UNBOUNDED swing measured 29.01 deg/sample at w=0.850 on Hospital and was
+  // judged a whip. At 60 probes/s that is ~1740 deg/s; 135 deg/s is under a thirteenth of it, and
+  // it is the rate a person turns their head to look at something — fast, not violent.
+  // Pure function of the residual, so poseAt stays order-independent and replans stay identical.
+  var GAZE_ACQUIRE_MAX  = 3;                    // peak multiple of the shared CINEMA_TURN_DPS cap
+  var GAZE_ACQUIRE_FULL = 60 * Math.PI / 180;   // residual at/above which the full multiple applies
+  var GAZE_ACQUIRE_DEAD = 2 * Math.PI / 180;    // below this the gaze IS on target — no boost at all
+  function _gazeAcquireCap(residRad, baseMaxAng) {
+    var r = Math.abs(residRad);
+    if (!(r > GAZE_ACQUIRE_DEAD)) return baseMaxAng;
+    var u = Math.min(1, (r - GAZE_ACQUIRE_DEAD) / (GAZE_ACQUIRE_FULL - GAZE_ACQUIRE_DEAD));
+    return baseMaxAng * (1 + (GAZE_ACQUIRE_MAX - 1) * _cinemaSmoothstep(u));
+  }
+  // Exposed for witness_cpe_gaze_acquire.js — the witness drives THIS function, not a copy of the
+  // arithmetic, so a change here cannot pass a test that reimplemented the old curve.
+  A.gazeAcquireCap = _gazeAcquireCap;
+  A.gazeAcquireStep = function (cur, tgt, baseMaxAng) {
+    var d = Math.max(-1, Math.min(1, cur.x * tgt.x + cur.y * tgt.y + cur.z * tgt.z));
+    return _rotToward(cur, tgt, _gazeAcquireCap(Math.acos(d), baseMaxAng));
+  };
+  function _rotToward(a, b, maxAng) {
+    var d = Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z));
+    var ang = Math.acos(d);
+    if (ang <= maxAng || ang < 1e-9) return b;
+    var s = Math.sin(ang);
+    if (Math.abs(s) < 1e-9) return b;             // antipodal/degenerate — no stable arc to walk
+    var t = maxAng / ang, k0 = Math.sin((1 - t) * ang) / s, k1 = Math.sin(t * ang) / s;
+    var x = a.x * k0 + b.x * k1, y = a.y * k0 + b.y * k1, z = a.z * k0 + b.z * k1;
+    var L = Math.hypot(x, y, z) || 1;
+    return { x: x / L, y: y / L, z: z / L };
+  }
+
   function _cinemaPathPlan(durationSec) {
     var _planT0 = (typeof performance !== 'undefined') ? performance.now() : 0;
     var arcBboxRaw = _buildingBBoxArc();
@@ -6708,17 +6760,6 @@ async function setupEffects(A, renderer, scene, camera) {
     // it is safe here because §CPE_AIM_LATCH already made Beat 4 open on Beat 3's real final gaze,
     // so wherever the limiter leaves the gaze, the hand-off follows it. Pure function of w3 — no
     // per-frame state, so poseAt stays order-independent and replans stay byte-identical.
-    function _rotToward(a, b, maxAng) {
-      var d = Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z));
-      var ang = Math.acos(d);
-      if (ang <= maxAng || ang < 1e-9) return b;
-      var s = Math.sin(ang);
-      if (Math.abs(s) < 1e-9) return b;             // antipodal/degenerate — no stable arc to walk
-      var t = maxAng / ang, k0 = Math.sin((1 - t) * ang) / s, k1 = Math.sin(t * ang) / s;
-      var x = a.x * k0 + b.x * k1, y = a.y * k0 + b.y * k1, z = a.z * k0 + b.z * k1;
-      var L = Math.hypot(x, y, z) || 1;
-      return { x: x / L, y: y / L, z: z / L };
-    }
     // The limiter spans Beat 3 AND Beat 4 as ONE continuous stretch of film — [tS, tR]. Limiting
     // only the walk was measured to MOVE the whip rather than remove it: Terminal went 4.1 -> 34.9
     // deg/frame at u=0.645, and `out` there is 0.6442, so the peak had simply relocated into Beat 4,
@@ -6746,12 +6787,16 @@ async function setupEffects(A, renderer, scene, camera) {
       }
       var stepSec = Math.max(1e-6, (tR - tS) * durationSec) / _gazeLimN;
       var maxAng = CINEMA_TURN_DPS * stepSec * Math.PI / 180;
-      var lim = [raw[0]], cur = raw[0], rawPeak = 0, limPeak = 0;
+      var lim = [raw[0]], cur = raw[0], rawPeak = 0, limPeak = 0, acqPeakMult = 1;
       for (i = 1; i <= _gazeLimN; i++) {
         var rp = Math.acos(Math.max(-1, Math.min(1,
           raw[i].x * raw[i - 1].x + raw[i].y * raw[i - 1].y + raw[i].z * raw[i - 1].z))) * 180 / Math.PI;
         if (rp > rawPeak) rawPeak = rp;
-        var nxt = _rotToward(cur, raw[i], maxAng);
+        var _resid = Math.acos(Math.max(-1, Math.min(1,
+          cur.x * raw[i].x + cur.y * raw[i].y + cur.z * raw[i].z)));
+        var _cap = _gazeAcquireCap(_resid, maxAng);
+        if (_cap / maxAng > acqPeakMult) acqPeakMult = _cap / maxAng;
+        var nxt = _rotToward(cur, raw[i], _cap);
         var lp = Math.acos(Math.max(-1, Math.min(1,
           nxt.x * cur.x + nxt.y * cur.y + nxt.z * cur.z))) * 180 / Math.PI;
         if (lp > limPeak) limPeak = lp;
@@ -6763,6 +6808,7 @@ async function setupEffects(A, renderer, scene, camera) {
         ' capDps=' + CINEMA_TURN_DPS + ' capPerProbeDeg=' + (maxAng * 180 / Math.PI).toFixed(3) +
         ' rawPeakDeg=' + rawPeak.toFixed(2) + ' limitedPeakDeg=' + limPeak.toFixed(2) +
         ' rawPeakDps=' + (rawPeak / stepSec).toFixed(1) + ' limitedPeakDps=' + (limPeak / stepSec).toFixed(1) +
+        ' acquirePeakMult=' + acqPeakMult.toFixed(2) + 'x (max ' + GAZE_ACQUIRE_MAX + 'x)' +
         ' — the composed gaze, bounded at the rate the spin and orbit already turn at');
     }
     function _gazeRateAt(w) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v914';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v915';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_gaze_acquire.js
+++ b/witness_cpe_gaze_acquire.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * §CPE_GAZE_ACQUIRE witness — prompts/CINEMA_PATH_EDITOR.md §CPE_GAZE_ACQUIRE.
+ *
+ * THE ISSUE IT PROVES OR DISPROVES (user, 2026-08-02): "the cam head turning to face density*depth
+ * ... Seems a bit slow during this baking. It be nice if it does so right away gracefully".
+ *
+ * The gaze was rate-limited to a FLAT CINEMA_TURN_DPS (45 deg/s), forward-only, so acquiring a
+ * subject 90 deg off-axis cost a dead-constant 2.00 s at one unvarying speed. That is why it reads
+ * as slow rather than smooth: a flat rate has no acquisition at all — no whip on, no settle in.
+ *
+ *  T1 the curve accelerates when far off-axis          — else nothing got faster
+ *  T2 the curve is EXACTLY the base cap when settled   — a settled gaze must not gain new motion
+ *  T3 the curve is monotone in residual angle          — no rate reversal mid-turn
+ *  T4 the peak is BOUNDED                              — §CPE_GAZE_CONSTANT_RATE exists because an
+ *                                                        unbounded swing measured 29.01 deg/sample
+ *                                                        and was judged a whip. Do not reintroduce it.
+ *  T5 RIGHT AWAY  — time-to-acquire a 90 deg subject drops below the flat-rate 2.00 s
+ *  T6 GRACEFULLY  — the turn rate at ARRIVAL is strictly lower than at ONSET. This is the claim a
+ *                   flat-rate implementation fails while still passing T5 by simply turning faster
+ *                   everywhere, which would be a whip and not what the user asked for.
+ *
+ * T5 and T6 drive the REAL limiter (A.gazeAcquireStep, the same function the bake's gaze loop calls)
+ * over a synthetic 90 deg step — not a reimplementation of it — and read the numbers back.
+ * RUN: node witness_cpe_gaze_acquire.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+const FALLBACK_ROOT = '/home/red1/bim-ootb';
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    const send = (b) => {
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    };
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (!e) return send(b);
+      const alt = p.replace(/^\/viewer\//, '/');
+      fs.readFile(path.join(FALLBACK_ROOT, p), (e2, b2) => {
+        if (!e2) return send(b2);
+        fs.readFile(path.join(FALLBACK_ROOT, alt), (e3, b3) => {
+          if (e3) { r.writeHead(404); r.end('404'); return; }
+          send(b3);
+        });
+      });
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-GAZE-ACQ TIMEOUT — killed after 120s'); process.exit(3); }, 120000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera', { timeout: 45000 });
+  await pg.waitForFunction('typeof window.APP.gazeAcquireCap === "function"', { timeout: 30000 })
+    .catch(() => {});
+
+  const armed = await pg.evaluate(() => typeof window.APP.gazeAcquireCap === 'function' &&
+                                        typeof window.APP.gazeAcquireStep === 'function');
+  chk('T0 §CPE_GAZE_ACQUIRE is on APP (gazeAcquireCap + gazeAcquireStep)', armed);
+  if (!armed) {
+    clearTimeout(_watchdog); await br.close(); server.close();
+    console.log('\n§W-GAZE-ACQ 0/6 — the acquisition curve does not exist (RED on origin/main, as intended)');
+    process.exit(1);
+  }
+
+  const D2R = Math.PI / 180, R2D = 180 / Math.PI;
+  const DPS = 45;                       // CINEMA_TURN_DPS — the shared cap this multiplies over
+  const STEP = 1 / 60;                  // one probe's worth of seconds
+  const BASE = DPS * STEP * D2R;        // the flat per-probe allowance (0.75 deg at 60 probes/s)
+
+  // ── T1..T4: the curve itself, sampled directly.
+  const curve = await pg.evaluate((base, d2r) => {
+    const A = window.APP, out = {};
+    [0, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 179].forEach(deg => {
+      out[deg] = A.gazeAcquireCap(deg * d2r, base) / base;   // multiple of the flat cap
+    });
+    return out;
+  }, BASE, D2R);
+  const mult = d => curve[d];
+  chk('T1 far off-axis the gaze ACCELERATES (>=2x the flat cap at 90 deg)',
+    mult(90) >= 2, '90deg=' + mult(90).toFixed(2) + 'x  60deg=' + mult(60).toFixed(2) +
+    'x  120deg=' + mult(120).toFixed(2) + 'x');
+  chk('T2 a SETTLED gaze keeps exactly the flat cap (no new motion where it is already on target)',
+    Math.abs(mult(0) - 1) < 1e-9 && Math.abs(mult(1) - 1) < 1e-9,
+    '0deg=' + mult(0).toFixed(4) + 'x  1deg=' + mult(1).toFixed(4) + 'x  2deg=' + mult(2).toFixed(4) + 'x');
+  const degs = [0, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 179];
+  const mono = degs.every((d, i) => i === 0 || mult(d) >= mult(degs[i - 1]) - 1e-9);
+  chk('T3 monotone in residual angle (no rate reversal mid-turn)', mono,
+    degs.map(d => d + ':' + mult(d).toFixed(2)).join(' '));
+  const peak = Math.max(...degs.map(mult));
+  chk('T4 the peak is BOUNDED (<=3x the shared cap — no return of the 29 deg/sample whip)',
+    peak <= 3 + 1e-9, 'peakMult=' + peak.toFixed(2) + 'x = ' + (peak * DPS).toFixed(0) + ' deg/s');
+
+  // ── T5/T6: drive the REAL limiter over a synthetic 90 deg acquisition and read the profile.
+  const run = await pg.evaluate((base, step, d2r, r2d) => {
+    const A = window.APP;
+    // 90 deg apart in the XZ plane — a plain, checkable geometry, not a scene-dependent one.
+    let cur = { x: 1, y: 0, z: 0 };
+    const tgt = { x: 0, y: 0, z: 1 };
+    const rates = [];
+    let t = 0, acquiredAt = -1;
+    for (let i = 0; i < 2000; i++) {
+      const nxt = A.gazeAcquireStep(cur, tgt, base);
+      const moved = Math.acos(Math.max(-1, Math.min(1, nxt.x * cur.x + nxt.y * cur.y + nxt.z * cur.z))) * r2d;
+      rates.push(moved / step);                                  // deg per second this probe
+      cur = nxt; t += step;
+      const resid = Math.acos(Math.max(-1, Math.min(1, cur.x * tgt.x + cur.y * tgt.y + cur.z * tgt.z))) * r2d;
+      if (acquiredAt < 0 && resid <= 5) acquiredAt = t;
+      if (resid <= 0.05) break;
+    }
+    return { acquiredAt, onset: rates[0], peak: Math.max(...rates),
+             arrival: rates[Math.max(0, rates.length - 1)], n: rates.length,
+             first10: rates.slice(0, 10).map(v => +v.toFixed(1)),
+             last10: rates.slice(-10).map(v => +v.toFixed(1)) };
+  }, BASE, STEP, D2R, R2D);
+
+  const FLAT = 90 / DPS;   // what the shipped flat cap costs for the same 90 deg: 2.00 s
+  chk('T5 RIGHT AWAY — a 90 deg subject is acquired faster than the flat cap\'s ' + FLAT.toFixed(2) + 's',
+    run.acquiredAt > 0 && run.acquiredAt < FLAT,
+    'acquired(resid<=5deg) in ' + run.acquiredAt.toFixed(2) + 's vs flat ' + FLAT.toFixed(2) + 's');
+  chk('T6 GRACEFULLY — the rate at ARRIVAL is strictly lower than at ONSET',
+    run.arrival < run.onset,
+    'onset=' + run.onset.toFixed(1) + 'dps  peak=' + run.peak.toFixed(1) +
+    'dps  arrival=' + run.arrival.toFixed(1) + 'dps');
+  chk('T7 the peak of the REAL run stays inside the bound (measured, not just the curve)',
+    run.peak <= 3 * DPS + 0.5, 'peak=' + run.peak.toFixed(1) + 'dps cap=' + (3 * DPS) + 'dps');
+  console.log('   profile first10 dps: ' + run.first10.join(' '));
+  console.log('   profile  last10 dps: ' + run.last10.join(' '));
+
+  clearTimeout(_watchdog);
+  await br.close(); server.close();
+  console.log('\n§W-GAZE-ACQ ' + pass + '/' + (pass + fail) + (fail ? ' — FAIL' : ' — all green'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { clearTimeout(_watchdog); console.error('§W-GAZE-ACQ ERROR ' + e.message); process.exit(2); });


### PR DESCRIPTION
User, 2026-08-02: *"the cam head turning to face density*depth ... Seems a bit slow during this baking. It be nice if it does so right away gracefully."*

## The cause, in code
`effects.js` rate-limited the composed gaze to a **flat** `CINEMA_TURN_DPS` (45 °/s), forward-only. A 90° acquisition therefore cost a dead-constant **2.00 s at one unvarying speed**. That is not a slow camera — it is a camera with **no acquisition**: no whip on, no settle in. `_rotToward`'s own header even said the lag was deliberate.

## The change
The per-probe allowance now scales with the **residual angle** — full 3× while far off-axis, smoothstepping back to **exactly 1.0×** as it converges.

- Peak stays **bounded at 135 °/s** and is now logged every bake as `acquirePeakMult`.
- A gaze already **on** its subject (≤2° residual) moves *exactly* as before — this cannot add motion to a settled shot.
- It **multiplies over** `CINEMA_TURN_DPS`, it does not change it: that constant also prices the spin, the orbit lap and the walk's turn budget, so raising it would silently re-time every film ever baked.
- `_rotToward` + the new curve are hoisted to module scope — both pure, and they were trapped inside the per-plan `_cinemaPathPlan` closure where no witness could reach them.

## Witness — `witness_cpe_gaze_acquire.js` 8/8 (RED on `origin/main`: 0/6, curve absent)
```
T5 RIGHT AWAY  90 deg acquired in 0.90s vs the flat cap's 2.00s
T6 GRACEFULLY  onset=135.0dps  peak=135.0dps  arrival=40.9dps
T2 settled     0deg=1.0000x  1deg=1.0000x  2deg=1.0000x
T3 monotone    5:1.02 10:1.10 20:1.46 30:1.95 45:2.67 60:3.00 90:3.00
T4 bounded     peakMult=3.00x = 135 deg/s
   profile first10 dps: 135 135 135 135 135 135 135 135 135 135
   profile  last10 dps: 47.3 46.7 46.2 45.8 45.5 45.2 45.1 45 45 40.9
```
T6 is the claim that separates this from "just turn faster everywhere" — a flat implementation passes T5 and **fails T6**.

## Regression checklist
15 cinema/gaze witnesses run on this branch and the identical set on clean `origin/main` for comparison. **The smoothness gate this change most risks — `witness_cinema_path_editor` G7, "no sharp corners: peak ≤12 deg/frame on a 90-deg dog-leg" — PASSES**, as does `witness_cpe_even_turn` T2 ("peak gaze sweep under 12 deg/frame on a hostile layout"). Full before/after table posted as a comment.

`sw.js` `CACHE_VERSION` v914 → **v915**. `audit_sw_precache` 113/113, `audit_script_tags` 142/142, eslint on `effects.js` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)