### PR TITLE
fix(witness): G-SH-4 reads its gaze bound from the shipped curve, not a literal 45

### DIFF
--- a/compare_witnesses.sh
+++ b/compare_witnesses.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# §CPE_GAZE_ACQUIRE regression checklist — the SAME 13 witnesses on the branch and on clean
+# origin/main, classified identically. A witness that is already RED on main is NOT evidence about
+# this change; only a green->red transition is.
+printf "%-34s %-10s %-10s %s\n" WITNESS BRANCH MAIN VERDICT
+printf -- "----------------------------------------------------------------------------\n"
+regress=0
+for w in witness_cinema_path_editor witness_cpe_gaze_spin witness_cpe_spin_whip \
+         witness_cpe_even_turn witness_cpe_stick_hold witness_cpe_walk_budget \
+         witness_cinema_orbit_v2 witness_cinema_damping_bleed witness_cinema_flat_ending \
+         witness_cinema_reciprocal witness_cinema_exit_breathe witness_cpe_noise_law \
+         witness_cpe_room_title_gaze; do
+  cls () {   # $1 = logfile -> PASS | RED | INFRA | MISSING
+    [ -f "$1" ] || { echo MISSING; return; }
+    if grep -qE "TimeoutError|ERR_CONNECTION|Cannot read|is not a function|PLAN FAILED|could not discover" "$1"; then echo INFRA; return; fi
+    if grep -qE "VERDICT: FAIL|WITNESS FAIL|— FAIL|^FAIL " "$1"; then echo RED; return; fi
+    echo PASS
+  }
+  b=$(cls "/tmp/wt-gaze/wlogs2/$w.log")
+  m=$(cls "/tmp/wt-base/wlogs2/$w.log")
+  if [ "$b" = "$m" ]; then v="same as main"; else
+    if [ "$m" = "PASS" ] && [ "$b" != "PASS" ]; then v="*** REGRESSION ***"; regress=$((regress+1));
+    else v="differs ($m -> $b)"; fi
+  fi
+  printf "%-34s %-10s %-10s %s\n" "$w" "$b" "$m" "$v"
+done
+printf -- "----------------------------------------------------------------------------\n"
+echo "REGRESSIONS INTRODUCED BY THIS BRANCH: $regress"

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4569,6 +4569,58 @@ async function setupEffects(A, renderer, scene, camera) {
   // §CINEMA_PATH: the ONE shared path plan — flown identically by the live Alt+C capture and by
   // the MaxQ exporter (cinema_maxq.js). Everything derives from the CURRENT camera/sun/building at
   // call time; nothing is hardcoded per building.
+  // ══ §CPE_GAZE_ACQUIRE — the cap ACCELERATES when far off-axis and decays onto the subject ═════
+  // USER, 2026-08-02: "the cam head turning to face density*depth ... Seems a bit slow during this
+  // baking. It be nice if it does so right away gracefully."
+  //
+  // The limiter above was a FLAT cap, so a 90 deg acquisition cost a dead-constant 2.00 s at one
+  // unvarying speed. That is not a slow camera, it is a camera with no acquisition: a real operator
+  // whips onto a subject and DECELERATES onto it. "Right away" and "gracefully" are the two halves
+  // of that, and a single flat number can express neither.
+  //
+  // So the allowance is scaled by the RESIDUAL angle — the further off-axis, the more rate it may
+  // spend; as it converges the multiplier smoothsteps back to exactly 1.0, which is the shipped
+  // behaviour. Peak turn rate is therefore still explicitly bounded (GAZE_ACQUIRE_MAX), still
+  // logged every bake, and a gaze already ON its subject moves exactly as it did before — that
+  // last property matters: it means this cannot add motion to a settled shot.
+  //
+  // ⚠ IT MULTIPLIES OVER CINEMA_TURN_DPS, IT DOES NOT REPLACE IT. That constant also prices the
+  // spin, the orbit lap and the walk's own turn charge (see _useSec, ~line 5932) — raising it would
+  // silently re-time every film ever baked. This is a gaze-only multiplier for exactly that reason.
+  //
+  // 3x = 135 deg/s peak. Chosen against the number that made §CPE_GAZE_CONSTANT_RATE necessary in
+  // the first place: an UNBOUNDED swing measured 29.01 deg/sample at w=0.850 on Hospital and was
+  // judged a whip. At 60 probes/s that is ~1740 deg/s; 135 deg/s is under a thirteenth of it, and
+  // it is the rate a person turns their head to look at something — fast, not violent.
+  // Pure function of the residual, so poseAt stays order-independent and replans stay identical.
+  var GAZE_ACQUIRE_MAX  = 3;                    // peak multiple of the shared CINEMA_TURN_DPS cap
+  var GAZE_ACQUIRE_FULL = 60 * Math.PI / 180;   // residual at/above which the full multiple applies
+  var GAZE_ACQUIRE_DEAD = 2 * Math.PI / 180;    // below this the gaze IS on target — no boost at all
+  function _gazeAcquireCap(residRad, baseMaxAng) {
+    var r = Math.abs(residRad);
+    if (!(r > GAZE_ACQUIRE_DEAD)) return baseMaxAng;
+    var u = Math.min(1, (r - GAZE_ACQUIRE_DEAD) / (GAZE_ACQUIRE_FULL - GAZE_ACQUIRE_DEAD));
+    return baseMaxAng * (1 + (GAZE_ACQUIRE_MAX - 1) * _cinemaSmoothstep(u));
+  }
+  // Exposed for witness_cpe_gaze_acquire.js — the witness drives THIS function, not a copy of the
+  // arithmetic, so a change here cannot pass a test that reimplemented the old curve.
+  A.gazeAcquireCap = _gazeAcquireCap;
+  A.gazeAcquireStep = function (cur, tgt, baseMaxAng) {
+    var d = Math.max(-1, Math.min(1, cur.x * tgt.x + cur.y * tgt.y + cur.z * tgt.z));
+    return _rotToward(cur, tgt, _gazeAcquireCap(Math.acos(d), baseMaxAng));
+  };
+  function _rotToward(a, b, maxAng) {
+    var d = Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z));
+    var ang = Math.acos(d);
+    if (ang <= maxAng || ang < 1e-9) return b;
+    var s = Math.sin(ang);
+    if (Math.abs(s) < 1e-9) return b;             // antipodal/degenerate — no stable arc to walk
+    var t = maxAng / ang, k0 = Math.sin((1 - t) * ang) / s, k1 = Math.sin(t * ang) / s;
+    var x = a.x * k0 + b.x * k1, y = a.y * k0 + b.y * k1, z = a.z * k0 + b.z * k1;
+    var L = Math.hypot(x, y, z) || 1;
+    return { x: x / L, y: y / L, z: z / L };
+  }
+
   function _cinemaPathPlan(durationSec) {
     var _planT0 = (typeof performance !== 'undefined') ? performance.now() : 0;
     var arcBboxRaw = _buildingBBoxArc();
@@ -6708,17 +6760,6 @@ async function setupEffects(A, renderer, scene, camera) {
     // it is safe here because §CPE_AIM_LATCH already made Beat 4 open on Beat 3's real final gaze,
     // so wherever the limiter leaves the gaze, the hand-off follows it. Pure function of w3 — no
     // per-frame state, so poseAt stays order-independent and replans stay byte-identical.
-    function _rotToward(a, b, maxAng) {
-      var d = Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z));
-      var ang = Math.acos(d);
-      if (ang <= maxAng || ang < 1e-9) return b;
-      var s = Math.sin(ang);
-      if (Math.abs(s) < 1e-9) return b;             // antipodal/degenerate — no stable arc to walk
-      var t = maxAng / ang, k0 = Math.sin((1 - t) * ang) / s, k1 = Math.sin(t * ang) / s;
-      var x = a.x * k0 + b.x * k1, y = a.y * k0 + b.y * k1, z = a.z * k0 + b.z * k1;
-      var L = Math.hypot(x, y, z) || 1;
-      return { x: x / L, y: y / L, z: z / L };
-    }
     // The limiter spans Beat 3 AND Beat 4 as ONE continuous stretch of film — [tS, tR]. Limiting
     // only the walk was measured to MOVE the whip rather than remove it: Terminal went 4.1 -> 34.9
     // deg/frame at u=0.645, and `out` there is 0.6442, so the peak had simply relocated into Beat 4,
@@ -6746,12 +6787,16 @@ async function setupEffects(A, renderer, scene, camera) {
       }
       var stepSec = Math.max(1e-6, (tR - tS) * durationSec) / _gazeLimN;
       var maxAng = CINEMA_TURN_DPS * stepSec * Math.PI / 180;
-      var lim = [raw[0]], cur = raw[0], rawPeak = 0, limPeak = 0;
+      var lim = [raw[0]], cur = raw[0], rawPeak = 0, limPeak = 0, acqPeakMult = 1;
       for (i = 1; i <= _gazeLimN; i++) {
         var rp = Math.acos(Math.max(-1, Math.min(1,
           raw[i].x * raw[i - 1].x + raw[i].y * raw[i - 1].y + raw[i].z * raw[i - 1].z))) * 180 / Math.PI;
         if (rp > rawPeak) rawPeak = rp;
-        var nxt = _rotToward(cur, raw[i], maxAng);
+        var _resid = Math.acos(Math.max(-1, Math.min(1,
+          cur.x * raw[i].x + cur.y * raw[i].y + cur.z * raw[i].z)));
+        var _cap = _gazeAcquireCap(_resid, maxAng);
+        if (_cap / maxAng > acqPeakMult) acqPeakMult = _cap / maxAng;
+        var nxt = _rotToward(cur, raw[i], _cap);
         var lp = Math.acos(Math.max(-1, Math.min(1,
           nxt.x * cur.x + nxt.y * cur.y + nxt.z * cur.z))) * 180 / Math.PI;
         if (lp > limPeak) limPeak = lp;
@@ -6763,6 +6808,7 @@ async function setupEffects(A, renderer, scene, camera) {
         ' capDps=' + CINEMA_TURN_DPS + ' capPerProbeDeg=' + (maxAng * 180 / Math.PI).toFixed(3) +
         ' rawPeakDeg=' + rawPeak.toFixed(2) + ' limitedPeakDeg=' + limPeak.toFixed(2) +
         ' rawPeakDps=' + (rawPeak / stepSec).toFixed(1) + ' limitedPeakDps=' + (limPeak / stepSec).toFixed(1) +
+        ' acquirePeakMult=' + acqPeakMult.toFixed(2) + 'x (max ' + GAZE_ACQUIRE_MAX + 'x)' +
         ' — the composed gaze, bounded at the rate the spin and orbit already turn at');
     }
     function _gazeRateAt(w) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v914';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v915';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_gaze_acquire.js
+++ b/witness_cpe_gaze_acquire.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * §CPE_GAZE_ACQUIRE witness — prompts/CINEMA_PATH_EDITOR.md §CPE_GAZE_ACQUIRE.
+ *
+ * THE ISSUE IT PROVES OR DISPROVES (user, 2026-08-02): "the cam head turning to face density*depth
+ * ... Seems a bit slow during this baking. It be nice if it does so right away gracefully".
+ *
+ * The gaze was rate-limited to a FLAT CINEMA_TURN_DPS (45 deg/s), forward-only, so acquiring a
+ * subject 90 deg off-axis cost a dead-constant 2.00 s at one unvarying speed. That is why it reads
+ * as slow rather than smooth: a flat rate has no acquisition at all — no whip on, no settle in.
+ *
+ *  T1 the curve accelerates when far off-axis          — else nothing got faster
+ *  T2 the curve is EXACTLY the base cap when settled   — a settled gaze must not gain new motion
+ *  T3 the curve is monotone in residual angle          — no rate reversal mid-turn
+ *  T4 the peak is BOUNDED                              — §CPE_GAZE_CONSTANT_RATE exists because an
+ *                                                        unbounded swing measured 29.01 deg/sample
+ *                                                        and was judged a whip. Do not reintroduce it.
+ *  T5 RIGHT AWAY  — time-to-acquire a 90 deg subject drops below the flat-rate 2.00 s
+ *  T6 GRACEFULLY  — the turn rate at ARRIVAL is strictly lower than at ONSET. This is the claim a
+ *                   flat-rate implementation fails while still passing T5 by simply turning faster
+ *                   everywhere, which would be a whip and not what the user asked for.
+ *
+ * T5 and T6 drive the REAL limiter (A.gazeAcquireStep, the same function the bake's gaze loop calls)
+ * over a synthetic 90 deg step — not a reimplementation of it — and read the numbers back.
+ * RUN: node witness_cpe_gaze_acquire.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+const FALLBACK_ROOT = '/home/red1/bim-ootb';
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    const send = (b) => {
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    };
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (!e) return send(b);
+      const alt = p.replace(/^\/viewer\//, '/');
+      fs.readFile(path.join(FALLBACK_ROOT, p), (e2, b2) => {
+        if (!e2) return send(b2);
+        fs.readFile(path.join(FALLBACK_ROOT, alt), (e3, b3) => {
+          if (e3) { r.writeHead(404); r.end('404'); return; }
+          send(b3);
+        });
+      });
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-GAZE-ACQ TIMEOUT — killed after 120s'); process.exit(3); }, 120000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera', { timeout: 45000 });
+  await pg.waitForFunction('typeof window.APP.gazeAcquireCap === "function"', { timeout: 30000 })
+    .catch(() => {});
+
+  const armed = await pg.evaluate(() => typeof window.APP.gazeAcquireCap === 'function' &&
+                                        typeof window.APP.gazeAcquireStep === 'function');
+  chk('T0 §CPE_GAZE_ACQUIRE is on APP (gazeAcquireCap + gazeAcquireStep)', armed);
+  if (!armed) {
+    clearTimeout(_watchdog); await br.close(); server.close();
+    console.log('\n§W-GAZE-ACQ 0/6 — the acquisition curve does not exist (RED on origin/main, as intended)');
+    process.exit(1);
+  }
+
+  const D2R = Math.PI / 180, R2D = 180 / Math.PI;
+  const DPS = 45;                       // CINEMA_TURN_DPS — the shared cap this multiplies over
+  const STEP = 1 / 60;                  // one probe's worth of seconds
+  const BASE = DPS * STEP * D2R;        // the flat per-probe allowance (0.75 deg at 60 probes/s)
+
+  // ── T1..T4: the curve itself, sampled directly.
+  const curve = await pg.evaluate((base, d2r) => {
+    const A = window.APP, out = {};
+    [0, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 179].forEach(deg => {
+      out[deg] = A.gazeAcquireCap(deg * d2r, base) / base;   // multiple of the flat cap
+    });
+    return out;
+  }, BASE, D2R);
+  const mult = d => curve[d];
+  chk('T1 far off-axis the gaze ACCELERATES (>=2x the flat cap at 90 deg)',
+    mult(90) >= 2, '90deg=' + mult(90).toFixed(2) + 'x  60deg=' + mult(60).toFixed(2) +
+    'x  120deg=' + mult(120).toFixed(2) + 'x');
+  chk('T2 a SETTLED gaze keeps exactly the flat cap (no new motion where it is already on target)',
+    Math.abs(mult(0) - 1) < 1e-9 && Math.abs(mult(1) - 1) < 1e-9,
+    '0deg=' + mult(0).toFixed(4) + 'x  1deg=' + mult(1).toFixed(4) + 'x  2deg=' + mult(2).toFixed(4) + 'x');
+  const degs = [0, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 179];
+  const mono = degs.every((d, i) => i === 0 || mult(d) >= mult(degs[i - 1]) - 1e-9);
+  chk('T3 monotone in residual angle (no rate reversal mid-turn)', mono,
+    degs.map(d => d + ':' + mult(d).toFixed(2)).join(' '));
+  const peak = Math.max(...degs.map(mult));
+  chk('T4 the peak is BOUNDED (<=3x the shared cap — no return of the 29 deg/sample whip)',
+    peak <= 3 + 1e-9, 'peakMult=' + peak.toFixed(2) + 'x = ' + (peak * DPS).toFixed(0) + ' deg/s');
+
+  // ── T5/T6: drive the REAL limiter over a synthetic 90 deg acquisition and read the profile.
+  const run = await pg.evaluate((base, step, d2r, r2d) => {
+    const A = window.APP;
+    // 90 deg apart in the XZ plane — a plain, checkable geometry, not a scene-dependent one.
+    let cur = { x: 1, y: 0, z: 0 };
+    const tgt = { x: 0, y: 0, z: 1 };
+    const rates = [];
+    let t = 0, acquiredAt = -1;
+    for (let i = 0; i < 2000; i++) {
+      const nxt = A.gazeAcquireStep(cur, tgt, base);
+      const moved = Math.acos(Math.max(-1, Math.min(1, nxt.x * cur.x + nxt.y * cur.y + nxt.z * cur.z))) * r2d;
+      rates.push(moved / step);                                  // deg per second this probe
+      cur = nxt; t += step;
+      const resid = Math.acos(Math.max(-1, Math.min(1, cur.x * tgt.x + cur.y * tgt.y + cur.z * tgt.z))) * r2d;
+      if (acquiredAt < 0 && resid <= 5) acquiredAt = t;
+      if (resid <= 0.05) break;
+    }
+    return { acquiredAt, onset: rates[0], peak: Math.max(...rates),
+             arrival: rates[Math.max(0, rates.length - 1)], n: rates.length,
+             first10: rates.slice(0, 10).map(v => +v.toFixed(1)),
+             last10: rates.slice(-10).map(v => +v.toFixed(1)) };
+  }, BASE, STEP, D2R, R2D);
+
+  const FLAT = 90 / DPS;   // what the shipped flat cap costs for the same 90 deg: 2.00 s
+  chk('T5 RIGHT AWAY — a 90 deg subject is acquired faster than the flat cap\'s ' + FLAT.toFixed(2) + 's',
+    run.acquiredAt > 0 && run.acquiredAt < FLAT,
+    'acquired(resid<=5deg) in ' + run.acquiredAt.toFixed(2) + 's vs flat ' + FLAT.toFixed(2) + 's');
+  chk('T6 GRACEFULLY — the rate at ARRIVAL is strictly lower than at ONSET',
+    run.arrival < run.onset,
+    'onset=' + run.onset.toFixed(1) + 'dps  peak=' + run.peak.toFixed(1) +
+    'dps  arrival=' + run.arrival.toFixed(1) + 'dps');
+  chk('T7 the peak of the REAL run stays inside the bound (measured, not just the curve)',
+    run.peak <= 3 * DPS + 0.5, 'peak=' + run.peak.toFixed(1) + 'dps cap=' + (3 * DPS) + 'dps');
+  console.log('   profile first10 dps: ' + run.first10.join(' '));
+  console.log('   profile  last10 dps: ' + run.last10.join(' '));
+
+  clearTimeout(_watchdog);
+  await br.close(); server.close();
+  console.log('\n§W-GAZE-ACQ ' + pass + '/' + (pass + fail) + (fail ? ' — FAIL' : ' — all green'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { clearTimeout(_watchdog); console.error('§W-GAZE-ACQ ERROR ' + e.message); process.exit(2); });

--- a/witness_cpe_stick_hold.js
+++ b/witness_cpe_stick_hold.js
@@ -249,15 +249,32 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     // 45 deg/s x the sampling interval. 1.25x slack covers the nlerp chord between build probes
     // (512) being read at a finer witness resolution (600). A baseline compare would have accepted
     // whatever main happened to do; this accepts only what the law claims.
+    // ⚠ THE BOUND IS READ FROM THE CODE UNDER TEST, NOT HARDCODED. It used to be a literal 45, and
+    // §CPE_GAZE_ACQUIRE (2026-08-02) legitimately raised the ceiling: the per-probe allowance now
+    // scales with the residual angle, up to GAZE_ACQUIRE_MAX x CINEMA_TURN_DPS, because a flat rate
+    // gave the camera no acquisition at all (user: "seems a bit slow ... it be nice if it does so
+    // right away gracefully"). A literal 45 turned this gate RED on Duplex at a measured 122.4 deg/s
+    // — inside the new law, outside the old constant.
+    // This is deliberately NOT a relaxation to whatever main happens to do. It asks the shipped
+    // curve for its own maximum and holds the film to THAT, so an unbounded whip still fails hard:
+    // the same run measured rawPeakDps 376.7 (Duplex) and 790.8 (Hospital) before limiting, both far
+    // outside 3x. If the curve's ceiling is ever raised without cause, this number moves in the log.
+    const maxMult = await page.evaluate(() => {
+      const A = window.APP;
+      if (typeof A.gazeAcquireCap !== 'function') return 1;   // pre-§CPE_GAZE_ACQUIRE build
+      const base = 1e-3;
+      return A.gazeAcquireCap(Math.PI, base) / base;          // the curve's own stated maximum
+    });
     const sampleSec = res.hold.out / 600;
-    const capDeg = 45 * sampleSec * 1.25;
+    const capDeg = 45 * maxMult * sampleSec * 1.25;
     const stepRatio = s.peakStep / s.meanStep;
     const jerkOK = stepRatio <= 2.4 && s.peakTurn <= capDeg;
     P('G-SH-4 no jerk bought the stop: step inside §CPE_EVEN_TURN\'s 2.4x, gaze no worse than origin/main',
       jerkOK,
       `peak step=${s.peakStep.toExponential(2)}m = ${stepRatio.toFixed(2)}x mean (bound 2.4x); ` +
       `peak gaze=${s.peakTurn.toFixed(3)} deg/sample at w=${s.peakTurnAt.toFixed(3)} ` +
-      `= ${(s.peakTurn/sampleSec).toFixed(1)} deg/s against the ${45} deg/s law ` +
+      `= ${(s.peakTurn/sampleSec).toFixed(1)} deg/s against the ${45 * maxMult} deg/s law ` +
+      `(${45} x ${maxMult}x §CPE_GAZE_ACQUIRE, read from the shipped curve) ` +
       `(cap ${capDeg.toFixed(3)} deg/sample)` +
       `\n        ${(logs.filter(l => l.startsWith('§CPE_GAZE_CONSTANT_RATE')).slice(-1)[0] || 'no §CPE_GAZE_CONSTANT_RATE line').slice(0, 210)}`);
 


### PR DESCRIPTION
**Found by the regression checklist, and it was a real red caused by my own §CPE_GAZE_ACQUIRE (#1131).**

`witness_cpe_stick_hold` **passed on clean `origin/main`** and **failed on the gaze branch** — Duplex 7/8, peak gaze **122.4 °/s**. That is exactly the transition a checklist exists to catch, so it is reported as mine.

## Why it went red
G-SH-4 hardcoded its gaze bound:
```js
const capDeg = 45 * sampleSec * 1.25;   // the flat CINEMA_TURN_DPS law
```
§CPE_GAZE_ACQUIRE legitimately raised the ceiling to `GAZE_ACQUIRE_MAX × CINEMA_TURN_DPS` = 135 °/s, because a flat rate gave the camera no acquisition at all. The measured 122.4 °/s is **inside the new law and outside the old constant**.

## Why this is not "lowering the bar"
The gate now **asks the shipped curve for its own maximum** rather than trusting a literal or a baseline:
```js
const maxMult = await page.evaluate(() => A.gazeAcquireCap(Math.PI, base) / base);
const capDeg  = 45 * maxMult * sampleSec * 1.25;
```
An unbounded whip still fails hard — the same run measured `rawPeakDps` **376.7** (Duplex) and **790.8** (Hospital) before limiting, both far outside 3×. If the curve's ceiling is ever raised without cause, the number moves in the log. Falls back to `1×` on a pre-§CPE_GAZE_ACQUIRE build, so it still gates older checkouts.

The **step/jerk half of G-SH-4 was never in question and is untouched** — 1.57× mean against the 2.4× bound.

## Result
`§CPE_STICK_HOLD WITNESS: Hospital 8/8 | Duplex 8/8 — PASS`

Also adds `compare_witnesses.sh`, the branch-vs-main classifier used for the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)