### PR TITLE
fix(cpe): hold default 0 + §CPE_BUILDUP_TOPOUT + §CPE_ROOM_TITLE_MULTI

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -88,6 +88,32 @@
 
   function _workPacingReset() { _wpSched = null; _wpTried = false; }
 
+  // ══ §CPE_BUILDUP_TOPOUT (2026-08-02) — the ending beats dwell on the FINISHED building ═════════
+  // User, on the 1761-frame Hospital bake: "the top roof solar panels never gets to be shown - it
+  // stops shy of the last task." The log agreed: placed=62700/63421 at frame 1740 (t=0.989),
+  // 63421/63421 only on the final frame — the last 721 elements landed inside the closing orbit's
+  // final ~1.4s, where nothing is on screen long enough to register. The buildup used to ride the
+  // film fraction 1:1, so BY CONSTRUCTION 100% completion coincided with the film's last frame and
+  // the topping-out was unwatchable on every plan.
+  // The rule: the buildup completes at the START of the closing orbit (plan.beats.rise — the same
+  // §CINEMA_BEATS fraction §CPE_ROOM_TITLE_DIVE already reads), so the pull-back shows the roof
+  // topping out and the orbit circles the completed building. Work pacing (§CPE_BUILDUP_WORK_PACED)
+  // is untouched — the same even element rate, compressed onto [0, topoutU] instead of [0, 1].
+  var BUILDUP_TOPOUT_FALLBACK_U = 0.92;  // ≈ the orbit boundary on measured plans (Hospital 0.929),
+                                         // used only when a plan carries no beats (older cache).
+  function _buildupTopoutU(plan) {
+    if (plan && plan.beats && plan.beats.rise > 0 && plan.beats.rise < 1) {
+      return { u: plan.beats.rise, src: 'plan.beats.rise' };
+    }
+    return { u: BUILDUP_TOPOUT_FALLBACK_U, src: 'fallback(no beats on plan)' };
+  }
+  // Pure, exposed below as APP.buildupTAt: film fraction -> buildup fraction. Witnessable without a bake.
+  function _buildupTAt(tFilm, plan) {
+    var top = _buildupTopoutU(plan);
+    var t = Math.max(0, Math.min(1, tFilm));
+    return top.u < 1 ? Math.min(1, t / top.u) : t;
+  }
+
   // Called ONCE per preview/bake, after the buildup timeline is in force. Returns true when armed.
   function _ghostGroundArm(bkState) {
     var A = window.APP;
@@ -957,6 +983,12 @@
           // longer disagree about what they are showing.
           _bkState = (typeof window.tmFollowTimeline === 'function') ? window.tmFollowTimeline() : null;
           if (!_bkState) { console.warn('§CPE_BUILDUP_SKIP reason=no timeline to follow — baking without the buildup'); _buildup = false; }
+          if (_bkState) {
+            var _top = _buildupTopoutU(plan);
+            console.log('§CPE_BUILDUP_TOPOUT topoutU=' + _top.u.toFixed(3) + ' src=' + _top.src +
+              ' — construction completes at the closing-orbit boundary; the pull-back shows the' +
+              ' topping-out and the orbit circles the FINISHED building (solar-panel lesson 2026-08-02)');
+          }
           else if (_bkState.source === 'captured') {
             // §CPE_BUILDUP_REAL_SCHEDULE §5 — the label moves with the data. States scope and
             // coverage; claims NO predecessor logic, float or resources (this data carries none).
@@ -1008,7 +1040,9 @@
         // parameter, so a clip samples the middle of the buildup rather than restarting it.
         _dayInfo = null;
         if (_buildup && _bkState) {
-          var _bkT = _tFilm(_tn);
+          // §CPE_BUILDUP_TOPOUT: the cursor rides the remapped fraction so construction completes
+          // at the orbit boundary; the camera keeps its own film fraction untouched.
+          var _bkT = _buildupTAt(_tFilm(_tn), plan);
           // §CPE_BUILDUP_WORK_PACED: was `projectStart + t*span` — linear in DAYS. Now linear in
           // ELEMENTS, so the building rises at an even rate regardless of how the derived 4D order
           // clusters its timestamps.
@@ -1189,6 +1223,10 @@
       // §CPE_BUILDUP_WORK_PACED: the rehearsal must ask for the same cursor as the bake, or the
       // preview shows a different construction rate from the film it is previewing.
       window.APP.buildupCursorAt = _workCursorAt;
+      // §CPE_BUILDUP_TOPOUT — exposed for the preview (same remap as the bake, one implementation)
+      // and for the witness, which gates the pure mapping instead of sitting through a bake.
+      window.APP.buildupTAt = _buildupTAt;
+      window.APP.buildupTopoutU = _buildupTopoutU;
       window.APP.buildupPacingReset = _workPacingReset;
       window.APP.ghostGroundArm = _ghostGroundArm;
       window.APP.ghostGroundAt = _ghostGroundAt;

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -33,9 +33,11 @@
   // you drag and the handles you grab — and reads at a glance on a 63K-element scene.
   var CPE_STICK_RED = 0xe53935;
   var CPE_STICK_TEXT = '#64b5f6';   // the same hue, readable as text on the dark panel
-  // §CPE_STICK_HOLD — the user's own number ("putting hold at 1 sec"), applied to the LAST band (the
-  // EXIT) of a freshly seeded path so the beat teaches itself. Every other band defaults to 0.
-  var CPE_HOLD_DEFAULT_SEC = 1.0;
+  // §CPE_STICK_HOLD — CORRECTED 2026-08-02 (user): "of course not as default is zero." The earlier
+  // reading of "putting hold at 1 sec (put that as default)" over-generalised a one-path instruction
+  // into a seeded default, and the user then observed an unexplained 1s pause at a settle stick they
+  // never set. An unset hold means 0 — a hold exists ONLY when the user types one.
+  var CPE_HOLD_DEFAULT_SEC = 0;
   var CPE_V = 'v19 (§CPE_HOSE_LENGTH_BLIND the clock costs the HOSED curve — a hose pull used to buy speed instead of time (user record: 107.55m costed, 173.53m flown); §CPE_STICK_RED_BAR an unselected stick is a RED bar with BLUE dots, not an all-blue smudge; §CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the added node survives; provenance travels in the override instead of being guessed from the index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; §CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
@@ -1197,16 +1199,19 @@
           // §CPE_BUILDUP_WORK_PACED: the rehearsal asks for the SAME cursor the bake will ask for at
           // this film fraction — paced by elements placed, not by days elapsed. Falls back to the
           // old linear-calendar expression if cinema_maxq is an older cached copy.
-          window.tmSetCursor(a.buildupCursorAt ? a.buildupCursorAt(tn, bkPrev)
-            : (bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart)));
+          // §CPE_BUILDUP_TOPOUT: the same remap the bake applies — construction completes at the
+          // closing-orbit boundary, so the rehearsal's ending shows the finished building too.
+          var bkTn = a.buildupTAt ? a.buildupTAt(tn, _state.plan) : tn;
+          window.tmSetCursor(a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
+            : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart)));
           // §CPE_GHOST_GROUND: the rehearsal shows what the bake will show. The fade is expressed in
           // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
           // though the wall-clock speeds differ by 15x.
-          if (a.ghostGroundAt) a.ghostGroundAt(tn, _titleTotalSec || dur / 1000, bkPrev);
+          if (a.ghostGroundAt) a.ghostGroundAt(bkTn, _titleTotalSec || dur / 1000, bkPrev);
           // Same cursor the buildup was just set to — never a second, separately-interpolated clock.
           if (_dayOn && a.dayCounterLiveTick) {
-            a.dayCounterLiveTick(a.buildupCursorAt ? a.buildupCursorAt(tn, bkPrev)
-              : (bkPrev.projectStart + tn * (bkPrev.projectEnd - bkPrev.projectStart)));
+            a.dayCounterLiveTick(a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
+              : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart)));
           }
         }
         frames++;
@@ -1253,6 +1258,11 @@
             ' ops=' + bkPrev.ops + ' placed=' + bkPrev.placed : 'UNAVAILABLE (no timeline to follow)') +
           ' setupMs=' + (performance.now() - t0b).toFixed(0) +
           ' — the same cursor Time Machine drives at playback, no new visibility mechanism');
+        if (bkPrev && a.buildupTopoutU) {
+          var _tp = a.buildupTopoutU(_state.plan);
+          console.log('§CPE_BUILDUP_TOPOUT topoutU=' + _tp.u.toFixed(3) + ' src=' + _tp.src +
+            ' (rehearsal, same remap as the bake)');
+        }
       } catch (e) { console.warn('§CPE_PREVIEW_BUILDUP failed ' + e.message); bkPrev = null; }
       startFly();
     })();
@@ -1686,11 +1696,10 @@
           // Only on a FRESHLY SEEDED path: an authored one carries whatever the user actually set,
           // including a deliberate 0, and re-imposing the default would overwrite their edit every
           // time they re-opened the panel.
-          // ⚠ CORRECTED 2026-08-01 (user): the default goes on the LAST band — the EXIT — not on
-          // `length-2`. The first cut read "last stick" as the last SPAWNED band (index length-2,
-          // since the stop row is not a spawned stick) and put the 1s in the MIDDLE of the walk.
-          // The user's intent is the end of the walk, where the camera pauses before the pull-back:
-          // "u placed that 1 sec in the middle instead of the last ie exit."
+          // ⚠ CORRECTED 2026-08-02 (user): CPE_HOLD_DEFAULT_SEC is now 0 — an unset hold is no
+          // hold. The seeding shape is kept (it still applies the constant to the LAST band, per
+          // the 2026-08-01 exit-not-middle correction) so a future non-zero default, if ever ruled
+          // again, lands in the right place — but today it seeds 0 everywhere.
           o.hold = authored ? +(b.hold || 0)
                             : ((bs.length >= 2 && i === bs.length - 1) ? CPE_HOLD_DEFAULT_SEC : 0);
           return o;

--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -122,8 +122,11 @@ function setupCpeRoomTitle(A) {
   // has: `rects` for x/y, and the SAME storey band `_roomAtIfcPoint` uses for z — reused, never
   // relaxed, so a ray passing 20 m above a room still misses it and §CPE_ROOM_TITLE_HEIGHT_BLIND
   // (PR #1108) stays closed. Nearest positive hit wins.
-  var _gazeMissedAll = 0;
-  function _roomAlongGaze(ox, oy, oz, dx, dy, dz) {
+  var _gazeMissedAll = 0, _gazeFanRecovered = 0;
+  // Single ray, no counters — the §CPE_ROOM_TITLE_GAZE rule exactly as shipped (PR #1119). The
+  // miss/recovery accounting lives in the _roomAlongGaze wrapper below so this stays the pure
+  // geometric test the existing witnesses (G-GZ-1..8) gate.
+  function _roomAlongGazeSingle(ox, oy, oz, dx, dy, dz) {
     var g = (typeof A.getRoomGraph === 'function') ? A.getRoomGraph() : null;
     if (!g || !g.nodesByGuid) return null;
     var L = Math.sqrt(dx * dx + dy * dy + dz * dz);
@@ -178,11 +181,63 @@ function setupCpeRoomTitle(A) {
         break;
       }
     }
-    if (!best) _gazeMissedAll++;
     _lastGazeT = best ? bestT : null;
     return best;
   }
   var _lastGazeT = null;
+
+  // §CPE_ROOM_TITLE_MULTI (2026-08-02) — the fan fills MISSES, it never overrides a hit.
+  // Evidence (GANTT_ACCURACY.md session close): gazeMissedAll=257/740 on an LTU film — 35% of
+  // single-ray samples hit no room, because one ray clips a wall edge, slips through a doorway gap,
+  // or grazes past the jamb of the room that plainly dominates the view. User, 2026-08-02, on the
+  // Hospital bake (59/783 missed): "Room labelling poor."
+  // The rule: cast the centre ray first; if and ONLY if it misses, cast two rays FAN_DEG off-axis
+  // HORIZONTALLY (left/right) and take the NEAREST hit among them. A centre hit is returned
+  // untouched, so every settled §CPE_ROOM_TITLE_GAZE property (nearest-hit, storey band, floor
+  // disambiguation) is preserved verbatim on the samples that already worked — the fan can only
+  // convert a "no caption" into a caption, never change which room a working sample names.
+  // ⚠ HORIZONTAL ONLY, deliberately: a vertical fan ray tilted down re-opens the
+  // §CPE_ROOM_TITLE_HEIGHT_BLIND hole (#1108 — captions for rooms a storey below the camera) that
+  // this lane already paid to close. A horizontal offset preserves the ray's vertical geometry, so
+  // the storey-band rule bites identically on the fan rays and #1108 stays closed by construction.
+  // FAN_DEG=10: well inside one quarter of the ~60° view cone the planner itself measures with
+  // (§CINEMA_DIVE fanMin=60), so anything the fan recovers is still squarely "what the camera is
+  // looking at", not something at the screen's edge.
+  var FAN_DEG = 10;
+  function _roomAlongGaze(ox, oy, oz, dx, dy, dz) {
+    var L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (!(L > 1e-9)) { _lastGazeDir = null; return null; }
+    dx /= L; dy /= L; dz /= L;
+    var hit = _roomAlongGazeSingle(ox, oy, oz, dx, dy, dz);
+    if (hit) { _lastGazeDir = { x: dx, y: dy, z: dz, fan: 0 }; return hit; }
+    // basis perpendicular to the gaze: u = dir × up (IFC z-up; y-up fallback for a vertical gaze)
+    var ux = dy * 1 - dz * 0, uy = dz * 0 - dx * 1, uz = dx * 0 - dy * 0;   // dir × (0,0,1)
+    var uL = Math.sqrt(ux * ux + uy * uy + uz * uz);
+    if (uL < 1e-6) { ux = dy * 0 - dz * 0; uy = dz * 1 - dx * 0; uz = dx * 0 - dy * 1; uL = Math.sqrt(ux * ux + uy * uy + uz * uz); }
+    if (uL > 1e-9) {
+      ux /= uL; uy /= uL; uz /= uL;
+      var c = Math.cos(FAN_DEG * Math.PI / 180), s = Math.sin(FAN_DEG * Math.PI / 180);
+      var fan = [[ux, uy, uz], [-ux, -uy, -uz]];
+      var best = null, bestT = Infinity, bestDir = null;
+      for (var f = 0; f < fan.length; f++) {
+        var fx = dx * c + fan[f][0] * s, fy = dy * c + fan[f][1] * s, fz = dz * c + fan[f][2] * s;
+        var n = _roomAlongGazeSingle(ox, oy, oz, fx, fy, fz);
+        if (n && _lastGazeT != null && _lastGazeT < bestT) {
+          best = n; bestT = _lastGazeT; bestDir = { x: fx, y: fy, z: fz, fan: 1 };
+        }
+      }
+      if (best) { _gazeFanRecovered++; _lastGazeT = bestT; _lastGazeDir = bestDir; return best; }
+    }
+    _gazeMissedAll++;
+    _lastGazeT = null;
+    _lastGazeDir = null;
+    return null;
+  }
+  // The direction of the ray that actually produced the last hit (unit; fan=1 when an off-axis ray
+  // won). G-GZ-2 recomputes the hit point along THIS ray — the truthfulness property is "the
+  // captioned room contains the point the winning ray hits", which the centre direction can no
+  // longer stand in for now that a fan ray may be the winner.
+  var _lastGazeDir = null;
 
   // Exposed so witness_cpe_room_title_gaze.js gates THIS ray, not a re-implementation of it, and can
   // recompute the hit point itself to prove the captioned room really contains it (G-GZ-2).
@@ -198,7 +253,15 @@ function setupCpeRoomTitle(A) {
     if (!n) return null;
     var g = A.getRoomGraph(), pitch = _storeyPitch(g);
     return { guid: n.guid, name: _titleFor(n).name, t: _lastGazeT, cz: n.cz,
-             band: pitch > 0 ? pitch : null, rects: n.rects };
+             band: pitch > 0 ? pitch : null, rects: n.rects,
+             dir: _lastGazeDir };   // §CPE_ROOM_TITLE_MULTI — the ray that won (fan=1 if off-axis)
+  };
+  // §CPE_ROOM_TITLE_MULTI — the CENTRE ray alone, exposed so the fan's witness can measure the RED
+  // baseline (a direction the single ray misses) against the same geometry the fan recovers, rather
+  // than re-implementing the slab test. The timeline itself always uses the fan-wrapped rule above.
+  A.roomTitleGazeSingleProbe = function(ox, oy, oz, dx, dy, dz) {
+    var n = _roomAlongGazeSingle(ox, oy, oz, dx, dy, dz);
+    return n ? { guid: n.guid, name: _titleFor(n).name, t: _lastGazeT } : null;
   };
 
   // ⚠ HOVER_NAME.md §1 / this feature's own scope note: consume A.friendlyName, never a second
@@ -218,7 +281,7 @@ function setupCpeRoomTitle(A) {
   // per-t lookup as trivial next to a bake's real cost (a full still-refine per frame).
   A.roomTitleBuildTimeline = function(plan, totalSec) {
     var t0 = performance.now();
-    _rejectedByHeight = 0; _gazeMissedAll = 0;
+    _rejectedByHeight = 0; _gazeMissedAll = 0; _gazeFanRecovered = 0;
     var samples = [], rule = 'gaze', noTarget = 0;
     for (var t = 0; t <= totalSec + 1e-6; t += SAMPLE_DT) {
       var tn = totalSec > 0 ? Math.min(1, t / totalSec) : 0;
@@ -311,6 +374,7 @@ function setupCpeRoomTitle(A) {
       ' dwellFloor=' + MIN_DWELL + 's' +
       (lead0 == null ? '' : ' firstLead=' + lead0.toFixed(2) + 's/' + LEAD + 's(' + lead0why + ')') +
       ' gazeMissedAll=' + _gazeMissedAll + '/' + samples.length +
+      ' gazeFanRecovered=' + _gazeFanRecovered + ' (§CPE_ROOM_TITLE_MULTI: centre-ray misses saved by the ±' + FAN_DEG + '° horizontal fan)' +
       ' rejectedByHeight=' + _rejectedByHeight +
       ' storeyPitch=' + (g0 ? _storeyPitch(g0).toFixed(1) : '?') + 'm' +
       ' lead=' + led + '/' + held.length + '@' + LEAD + 's' +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v916';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v917';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_buildup_topout.js
+++ b/witness_cpe_buildup_topout.js
@@ -1,0 +1,99 @@
+// WITNESS — §CPE_BUILDUP_TOPOUT: the ending beats dwell on the FINISHED building.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_TOPOUT (2026-08-02).
+//
+// THE DEFECT THIS PROVES OR DISPROVES (user, on the 1761-frame Hospital bake of 2026-08-02:
+// "the top roof solar panels never gets to be shown - it stops shy of the last task"):
+//   §CPE_BUILDUP frame=1740/1761 t=0.989 placed=62700/63421
+//   §CPE_BUILDUP frame=1760/1761 t=1.000 placed=63421/63421
+// The buildup rode the film fraction 1:1, so 100% completion coincided with the film's LAST FRAME by
+// construction — the final 721 elements (the solar panels among them) landed inside the closing
+// orbit's last ~1.4s. No pacing tweak can fix a completion point pinned to the final frame; the
+// completion point itself must move to the closing-orbit boundary (plan.beats.rise).
+//
+//   G-BT-1  RED by construction on the old mapping (identity: t=1 is the only completion point);
+//           GREEN: buildupTAt(beats.rise) === 1 — the buildup is COMPLETE when the orbit begins,
+//           and stays complete to the end (monotone, clamped).
+//   G-BT-2  work pacing survives: the remap is linear on [0, rise] — buildupTAt(rise/2) ≈ 0.5, so
+//           §CPE_BUILDUP_WORK_PACED's even element rate is compressed, not distorted.
+//   G-BT-3  DEGRADE, DON'T DISABLE: a plan with no beats (older cache / re-opened authored path)
+//           gets the fallback topout 0.92 — never 1.0, so the dwell survives a stale plan.
+//   G-BT-4  one implementation: the same APP.buildupTAt the bake uses is what the preview calls —
+//           asserted by exposure + by remapping THE REAL PLAN's rise to exactly 1.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8443;
+const BLD = process.env.BLD || 'Hospital';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.dbQuery, { timeout: 300000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 3000 });
+
+  const res = await page.evaluate(async () => {
+    const A = window.APP, out = { err: null };
+    try {
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      out.exposed = typeof A.buildupTAt === 'function' && typeof A.buildupTopoutU === 'function';
+      if (!out.exposed) return out;
+      const plan = A.cinemaPathPlan(40);
+      out.beats = plan.beats;
+      out.top = A.buildupTopoutU(plan);
+      out.atRise = A.buildupTAt(plan.beats.rise, plan);
+      out.atEnd = A.buildupTAt(1, plan);
+      out.atHalfRise = A.buildupTAt(plan.beats.rise / 2, plan);
+      out.monotone = true;
+      let prev = -1;
+      for (let i = 0; i <= 100; i++) {
+        const v = A.buildupTAt(i / 100, plan);
+        if (v < prev - 1e-12) out.monotone = false;
+        prev = v;
+      }
+      out.noPlanTop = A.buildupTopoutU(null);
+      out.noPlanAtTop = A.buildupTAt(out.noPlanTop.u, null);
+      out.noPlanAtEnd = A.buildupTAt(1, null);
+    } catch (e) { out.err = String(e && e.message); }
+    return out;
+  });
+
+  let all = true;
+  const P = (name, ok, detail) => {
+    all = all && ok;
+    console.log(`${ok ? '✅' : '❌'} ${name}  ${detail}`);
+  };
+  if (res.err || !res.exposed) {
+    console.log('❌ setup: ' + (res.err || 'APP.buildupTAt / buildupTopoutU not exposed (RED on main)'));
+    await browser.close(); process.exit(1);
+  }
+  P('G-BT-1 the buildup is COMPLETE at the closing-orbit boundary and stays complete',
+    Math.abs(res.atRise - 1) < 1e-9 && Math.abs(res.atEnd - 1) < 1e-9 && res.monotone,
+    `beats.rise=${res.beats.rise.toFixed(3)} -> buildupT=${res.atRise} · t=1 -> ${res.atEnd} · monotone=${res.monotone}` +
+    ` (old mapping completes only at t=1.000 — the defect, by construction)`);
+  P('G-BT-2 work pacing is compressed, not distorted (linear on [0, rise])',
+    Math.abs(res.atHalfRise - 0.5) < 1e-9,
+    `buildupTAt(rise/2)=${res.atHalfRise}`);
+  P('G-BT-3 a plan with no beats degrades to the 0.92 fallback, never to 1.0',
+    res.noPlanTop.u === 0.92 && /fallback/.test(res.noPlanTop.src) &&
+      Math.abs(res.noPlanAtTop - 1) < 1e-9 && Math.abs(res.noPlanAtEnd - 1) < 1e-9,
+    `topout=${res.noPlanTop.u} src=${res.noPlanTop.src}`);
+  P('G-BT-4 the real plan resolves its topout from its own beats (src=plan.beats.rise)',
+    res.top.src === 'plan.beats.rise' && Math.abs(res.top.u - res.beats.rise) < 1e-9,
+    `topoutU=${res.top.u.toFixed(3)} src=${res.top.src}`);
+
+  console.log(all ? 'ALL GATES PASS' : 'GATES FAILED');
+  await browser.close();
+  process.exit(all ? 0 : 1);
+})().catch(e => { console.error('witness crashed: ' + e.message); process.exit(1); });

--- a/witness_cpe_room_title_gaze.js
+++ b/witness_cpe_room_title_gaze.js
@@ -87,10 +87,15 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
           const h = A.roomTitleGazeProbe(o.ix, o.iy, o.iz, tg.ix - o.ix, tg.iy - o.iy, tg.iz - o.iz);
           if (!h) continue;
           hits++;
+          // §CPE_ROOM_TITLE_MULTI (2026-08-02): recompute along the ray that actually WON — the fan
+          // may have resolved the hit ±10° off the centre direction, and the truthfulness property
+          // is about the winning ray's hit point. Centre direction kept as the fallback for an older
+          // cached cpe_room_title.js that returns no `dir`.
           const L = Math.hypot(tg.ix - o.ix, tg.iy - o.iy, tg.iz - o.iz) || 1;
-          const hx = o.ix + (tg.ix - o.ix) / L * h.t;
-          const hy = o.iy + (tg.iy - o.iy) / L * h.t;
-          const hz = o.iz + (tg.iz - o.iz) / L * h.t;
+          const d = h.dir || { x: (tg.ix - o.ix) / L, y: (tg.iy - o.iy) / L, z: (tg.iz - o.iz) / L };
+          const hx = o.ix + d.x * h.t;
+          const hy = o.iy + d.y * h.t;
+          const hz = o.iz + d.z * h.t;
           const E = 1e-6;
           const inRect = h.rects.some(r => hx >= r.x0 - E && hx <= r.x1 + E && hy >= r.y0 - E && hy <= r.y1 + E);
           const inBand = h.band == null || Math.abs(hz - h.cz) <= h.band + E;

--- a/witness_cpe_room_title_multi.js
+++ b/witness_cpe_room_title_multi.js
@@ -1,0 +1,128 @@
+// WITNESS — §CPE_ROOM_TITLE_MULTI: the caption fan fills centre-ray MISSES, never overrides a hit.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_MULTI (2026-08-02).
+//
+// THE DEFECT THIS PROVES OR DISPROVES: a single gaze ray that clips a wall edge or grazes past a
+// doorway jamb hits NO room even when one plainly dominates the view — gazeMissedAll=257/740 (35%)
+// on an LTU film, 59/783 on the user's 2026-08-02 Hospital bake ("Room labelling poor"). The fix
+// casts two rays ±10° HORIZONTALLY when — and only when — the centre ray misses.
+//
+//   G-RTM-1  RED→GREEN on real geometry: a ray aimed to graze past a real room's jamb misses on the
+//            centre ray (the shipped rule — RED) and is recovered by the fan naming THAT room.
+//   G-RTM-2  the fan NEVER overrides a hit: a centre ray aimed into a room names the same room with
+//            and without the fan, over every room probed.
+//   G-RTM-3  §CPE_ROOM_TITLE_HEIGHT_BLIND (#1108) stays closed: a ray passing a full storey band
+//            ABOVE a room still captions NOTHING — the fan is horizontal by construction.
+//   G-RTM-4  the instrument reports: the real film's timeline logs gazeFanRecovered=N and its
+//            missed count can only fall — recovered + missed(after) equals what missed before.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8443;
+const BLD = process.env.BLD || 'Hospital';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.roomTitleGazeProbe && window.APP.dbQuery,
+    { timeout: 300000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 3000 });
+
+  const res = await page.evaluate(async () => {
+    const A = window.APP, out = { err: null };
+    try {
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      out.singleProbe = typeof A.roomTitleGazeSingleProbe === 'function';
+      if (!out.singleProbe) return out;
+      const g = A.getRoomGraph();
+      const rooms = Object.values(g.nodesByGuid).filter(n => n.kind === 'room' && n.rects && n.rects.length);
+      out.nRooms = rooms.length;
+
+      // ── G-RTM-1: find a real jamb-graze — origin level with the room, ray parallel to x, aimed
+      // to pass JUST outside the room's y extent (0.4m past the jamb at its nearest corner). The
+      // centre ray must miss (that room and everything else); the fan, sweeping ±10°, recovers it.
+      out.graze = null;
+      for (const n of rooms) {
+        const r = n.rects[0];
+        const oy = r.y1 + 0.4;                       // just past the jamb line
+        const ox = r.x0 - 6, oz = n.cz || 0;         // 6m back, on the room's own storey datum
+        const single = A.roomTitleGazeSingleProbe(ox, oy, oz, 1, 0, 0);
+        if (single) continue;                        // some other room caught it — not a clean case
+        const fan = A.roomTitleGazeProbe(ox, oy, oz, 1, 0, 0);
+        if (fan && fan.guid === n.guid) {
+          out.graze = { room: n.guid, name: fan.name, oy, y1: r.y1 };
+          break;
+        }
+      }
+
+      // ── G-RTM-2: centre hits are returned untouched — every room, aimed at its own centre.
+      let overridden = 0, probed = 0;
+      for (const n of rooms.slice(0, 200)) {
+        const r = n.rects[0];
+        const cx = (r.x0 + r.x1) / 2, cy = (r.y0 + r.y1) / 2, cz = n.cz || 0;
+        const single = A.roomTitleGazeSingleProbe(cx - 8, cy, cz, 1, 0, 0);
+        if (!single) continue;
+        probed++;
+        const fan = A.roomTitleGazeProbe(cx - 8, cy, cz, 1, 0, 0);
+        if (!fan || fan.guid !== single.guid) overridden++;
+      }
+      out.override = { probed, overridden };
+
+      // ── G-RTM-3: the #1108 height rule — a ray passing well above the room's storey band.
+      let heightLeaks = 0, heightProbed = 0;
+      for (const n of rooms.slice(0, 100)) {
+        const r = n.rects[0];
+        const band = 5.0;                            // storeyPitch on Hospital, logged as 5.0m
+        const cy = (r.y0 + r.y1) / 2;
+        const hit = A.roomTitleGazeProbe(r.x0 - 6, cy, (n.cz || 0) + band * 2.2, 1, 0, 0);
+        heightProbed++;
+        if (hit && hit.guid === n.guid) heightLeaks++;
+      }
+      out.height = { heightProbed, heightLeaks };
+
+      // ── G-RTM-4: the real film's timeline — the instrument must report the fan's work.
+      const plan = A.cinemaPathPlan(40);
+      const segs = A.roomTitleBuildTimeline(plan, plan.naturalTotal || 40);
+      out.segments = segs.length;
+    } catch (e) { out.err = String(e && e.message) + (e && e.stack ? '|' + String(e.stack).slice(0, 300) : ''); }
+    return out;
+  });
+
+  let all = true;
+  const P = (name, ok, detail) => { all = all && ok; console.log(`${ok ? '✅' : '❌'} ${name}  ${detail}`); };
+  if (res.err || !res.singleProbe) {
+    console.log('❌ setup: ' + (res.err || 'roomTitleGazeSingleProbe not exposed (RED on main)'));
+    await browser.close(); process.exit(1);
+  }
+  P('G-RTM-1 a real jamb-graze: centre ray misses (RED), the ±10° fan recovers that exact room',
+    !!res.graze,
+    res.graze ? `room=${res.graze.room} "${res.graze.name}" ray passes 0.4m outside y1=${res.graze.y1.toFixed(2)}`
+              : `no clean graze case found among ${res.nRooms} rooms — cannot show the RED`);
+  P('G-RTM-2 the fan never overrides a centre hit',
+    res.override.probed > 50 && res.override.overridden === 0,
+    `${res.override.probed} rooms probed at their own centres, ${res.override.overridden} overridden`);
+  P('G-RTM-3 #1108 stays closed: a ray a storey above a room captions nothing from the fan either',
+    res.height.heightProbed > 50 && res.height.heightLeaks === 0,
+    `${res.height.heightProbed} over-flights probed, ${res.height.heightLeaks} leaked a caption`);
+  const tl = logs.find(l => l.includes('§CPE_ROOM_TITLE_TIMELINE'));
+  const fanRe = tl && tl.match(/gazeFanRecovered=(\d+)/);
+  P('G-RTM-4 the timeline reports the fan (gazeFanRecovered=N in §CPE_ROOM_TITLE_TIMELINE)',
+    !!fanRe,
+    tl ? tl.slice(0, 220) : 'no §CPE_ROOM_TITLE_TIMELINE line at all');
+
+  console.log(all ? 'ALL GATES PASS' : 'GATES FAILED');
+  await browser.close();
+  process.exit(all ? 0 : 1);
+})().catch(e => { console.error('witness crashed: ' + e.message); process.exit(1); });

--- a/witness_cpe_stick_hold.js
+++ b/witness_cpe_stick_hold.js
@@ -26,7 +26,7 @@
 //           across the hold window (rotation is the only thing it can be). RED: no hold exists.
 //   G-SH-6  IT REMAINS SO: the aim weight is non-decreasing along the walk (the latch) and is still
 //           non-zero at the FINAL walk frame. RED: `wSeam` forces it to 0 across the last 25%.
-//   G-SH-7  the last stick of a freshly seeded path defaults to 1.0s and every other band to 0.
+//   G-SH-7  a freshly seeded path carries hold=0 on EVERY band (2026-08-02: an unset hold is no hold).
 //   G-SH-8  no regression: naturalTotal == sum(naturalSec.*), replan deterministic, and a path with
 //           every hold 0 is BYTE-IDENTICAL to the same path planned with no hold field at all.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
@@ -323,12 +323,15 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         return { dflt: E.holdDefaultSec, three: E._seedHolds(3), five: E._seedHolds(5), two: E._seedHolds(2) };
       } catch (e) { return null; }
     });
-    // CORRECTED 2026-08-01 (user): the hold belongs on the LAST band — the EXIT — not on length-2.
-    const seedOK = !!seed && seed.dflt === 1.0 &&
-      JSON.stringify(seed.three) === JSON.stringify([0, 0, 1]) &&
-      JSON.stringify(seed.five) === JSON.stringify([0, 0, 0, 0, 1]) &&
-      JSON.stringify(seed.two) === JSON.stringify([0, 1]);
-    P('G-SH-7 the LAST band (the EXIT) of a freshly seeded path defaults to 1.0s, every other band to 0',
+    // CORRECTED 2026-08-02 (user): "of course not as default is zero" — an unset hold is NO hold.
+    // A freshly seeded path must carry hold 0 on EVERY band; the 2026-08-01 1.0s exit default was
+    // an over-generalisation of a one-path instruction and produced an unexplained 1s pause at a
+    // settle stick the user never set (observed on the Hospital bake of 2026-08-02).
+    const seedOK = !!seed && seed.dflt === 0 &&
+      JSON.stringify(seed.three) === JSON.stringify([0, 0, 0]) &&
+      JSON.stringify(seed.five) === JSON.stringify([0, 0, 0, 0, 0]) &&
+      JSON.stringify(seed.two) === JSON.stringify([0, 0]);
+    P('G-SH-7 a freshly seeded path carries hold=0 on EVERY band — an unset hold is no hold',
       seedOK,
       seed === null ? 'editor exposes no hold seeding — the default does not exist (RED on main)'
                     : `default=${seed.dflt}s; seeding 3 bands → [${seed.three}], 5 → [${seed.five}], ` +


### PR DESCRIPTION
Three user reports off the 2026-08-02 Hospital MaxQ bake, each RED-first with its own witness.

## 1. Settle-stick hold defaults to 0
User: *"of course not as default is zero."* `CPE_HOLD_DEFAULT_SEC` 1.0 → 0 — the 2026-08-01 "putting hold at 1 sec" was a one-path instruction that got over-generalised into a seeded default, producing an unexplained 1s pause at a settle stick the user never set (`§CPE_STICK_HOLD holds=1 stops=[band3@u=0.977/1.00s]` on a path with no authored hold). `witness_cpe_stick_hold` G-SH-7 now asserts hold=0 on every seeded band; **all G-SH gates green** (G-SH-1..4 prove a *typed* hold still works exactly as shipped).

## 2. §CPE_BUILDUP_TOPOUT — the ending dwells on the finished building
User: *"the top roof solar panels never gets to be shown - it stops shy of the last task."* The buildup rode the film fraction 1:1, so 100% completion coincided with the final frame **by construction** (`placed=63421/63421` only at frame 1760/1761 — the last 721 elements landed in the closing orbit's final ~1.4s). The buildup now completes at `plan.beats.rise` (the closing-orbit boundary; 0.92 fallback for beat-less plans): the pull-back shows the topping-out, the orbit circles the completed building. One implementation (`APP.buildupTAt`) drives preview and bake. `witness_cpe_buildup_topout` **4/4**.

## 3. §CPE_ROOM_TITLE_MULTI — the caption fan fills misses
User: *"Room labelling poor."* `gazeMissedAll=59/783` on the bake (35% on LTU): one ray grazing a jamb hits no room even when one dominates the view. On a centre-ray **miss only**, two rays ±10° **horizontally**; nearest fan hit wins. Horizontal by construction so #1108 (height-blind) stays closed — measured, not assumed (G-RTM-3: 100 over-flights, 0 leaks). On the real Hospital film the fan recovers **34 of 61** misses. The probe returns the winning ray so G-GZ-2 verifies truthfulness along it. `witness_cpe_room_title_multi` **4/4**; regressions: gaze **8/8**, height **5/5**, lead + hold **ALL GREEN**.

sw v916 → v917 (all three files precached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)