### PR TITLE
feat(cpe): §CPE_ROOM_TITLE_COLLECTIVE — one composed caption + live [phase], sw v920

### DIFF
--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -355,6 +355,38 @@ function setupCpeRoomTitle(A) {
   A.roomTitleSightProbe = function(ox, oy, oz, dx, dy, dz) {
     return _sightRoomsAt(ox, oy, oz, dx, dy, dz).map(function(n) { return n.guid; });
   };
+  // The single-line grammar — "Storey · Containment · Rooms a, b" — extracted verbatim from the
+  // gap composer so §CPE_ROOM_TITLE_COLLECTIVE's dwell labels use the SAME rules: storey only if
+  // unanimous, containment only if unanimous, sighted rooms deduped of the storey prefix, first
+  // five named and the rest counted, the building alone as the last resort.
+  function _lineFrom(stSame, stU, ctSame, ctNode, ctU, sightMap, bldName) {
+    var parts = [], keyParts = [], srcCat = null;
+    var dedupe = function(nm, stName) {
+      return stName && nm.indexOf(stName + ' ') >= 0 ? nm.replace(stName + ' ', '') : nm;
+    };
+    if (stSame && stU) { parts.push(stU); keyParts.push('s:' + stU); srcCat = 'storey'; }
+    if (ctSame && ctU) {
+      parts.push(dedupe(_titleFor(ctNode).name, stSame ? stU : null));
+      keyParts.push('c:' + ctU); srcCat = 'containment';
+      delete sightMap[ctU];
+    }
+    var sightNames = [];
+    for (var gk in sightMap) {
+      sightNames.push(dedupe(_titleFor(sightMap[gk]).name, stSame ? stU : null));
+      keyParts.push('r:' + gk);
+    }
+    if (sightNames.length) {
+      // single-line cap: a pull-back can sweep a dozen rooms into one window — name the
+      // first five and COUNT the rest, so the line stays readable and nothing is hidden.
+      var shown = sightNames.length > 5
+        ? sightNames.slice(0, 5).join(', ') + ' +' + (sightNames.length - 5) + ' more'
+        : sightNames.join(', ');
+      parts.push(shown);
+      if (srcCat !== 'containment') srcCat = 'sight';
+    }
+    if (!parts.length && bldName) { parts.push(bldName); keyParts.push('b'); srcCat = 'building'; }
+    return { parts: parts, keyParts: keyParts, srcCat: srcCat };
+  }
 
   // Coarse-samples the whole (or clipped) film ONCE, collapses into room-dwell segments, and drops
   // any segment shorter than MIN_DWELL. Cheap: a few hundred samples, each one THREE→IFC conversion
@@ -524,32 +556,11 @@ function setupCpeRoomTitle(A) {
             lastKey = key;
           }
           var t1w = (i >= ss.length) ? gap[1] : ss[i - 1].t;
-          // compose the window's single line
-          var parts = [], keyParts = [], srcCat = null;
-          var dedupe = function(nm, stName) {
-            return stName && nm.indexOf(stName + ' ') >= 0 ? nm.replace(stName + ' ', '') : nm;
-          };
-          if (stSame && stU) { parts.push(stU); keyParts.push('s:' + stU); srcCat = 'storey'; }
-          if (ctSame && ctU) {
-            parts.push(dedupe(_titleFor(ctNode).name, stSame ? stU : null));
-            keyParts.push('c:' + ctU); srcCat = 'containment';
-            delete sightMap[ctU];
-          }
-          var sightNames = [];
-          for (var gk in sightMap) {
-            sightNames.push(dedupe(_titleFor(sightMap[gk]).name, stSame ? stU : null));
-            keyParts.push('r:' + gk);
-          }
-          if (sightNames.length) {
-            // single-line cap: a pull-back can sweep a dozen rooms into one window — name the
-            // first five and COUNT the rest, so the line stays readable and nothing is hidden.
-            var shown = sightNames.length > 5
-              ? sightNames.slice(0, 5).join(', ') + ' +' + (sightNames.length - 5) + ' more'
-              : sightNames.join(', ');
-            parts.push(shown);
-            if (srcCat !== 'containment') srcCat = 'sight';
-          }
-          if (!parts.length && bldName) { parts.push(bldName); keyParts.push('b'); srcCat = 'building'; }
+          // compose the window's single line — ONE composer, two callers (§CPE_ROOM_TITLE_COLLECTIVE:
+          // the room-dwell rename pass below builds its label through THIS same function, so the
+          // gap fill and the dwell captions can never disagree about the grammar).
+          var C = _lineFrom(stSame, stU, ctSame, ctNode, ctU, sightMap, bldName);
+          var parts = C.parts, keyParts = C.keyParts, srcCat = C.srcCat;
           if (parts.length && (t1w - t0w) >= MIN_HOLD) {
             var name = parts.join(' · ');
             if (prevSeg && prevSeg.name === name) { prevSeg.tEnd = t1w; gSec += t1w - t0w; byCat[srcCat] += t1w - t0w; }
@@ -579,6 +590,50 @@ function setupCpeRoomTitle(A) {
         ' ms=' + (performance.now() - gT0).toFixed(1) +
         ' — anything within range of path or sight is pointed out (user ruling 2026-08-02)');
     } catch (eG) { console.warn('§CPE_ROOM_TITLE_GROUP failed (room captions unaffected): ' + eG.message); }
+    // ══ §CPE_ROOM_TITLE_COLLECTIVE (user, 2026-08-02: "grouped together in single label… it is
+    // caption optics"; format confirmed verbatim "Storey - 1 Corridor Hall Rooms 2,3 [MEP Rough
+    // in]"): every caption window — not just the gap fills — carries the composed line, through
+    // the SAME _lineFrom grammar. The dwell timeline (dwell floor, 3s-or-skip, lead, hold,
+    // hysteresis — all settled, all witnessed) is UNTOUCHED: this pass writes ONLY `label`;
+    // guid/name/times stay exactly what those rules produced, so their witnesses still gate the
+    // same facts. The draw reads label || name — a failure here degrades to the bare room name,
+    // never to silence. The [phase] bracket is NOT composed here: day↔t is nonlinear twice over
+    // (work pacing + topout), so plan time cannot know it — see roomTitleFinalText.
+    try {
+      var lT0 = performance.now(), labelled = 0, dwellN = 0;
+      var bldNm = A.activeBuilding || A.currentBuilding || '';
+      held.forEach(function(seg) {
+        if (seg.group) return;                     // gap fills are already composed lines
+        dwellN++;
+        var ss = samples.filter(function(s) {
+          return s.t >= seg.tStart - 1e-9 && s.t <= seg.tEnd + 1e-9 && s.ix != null;
+        });
+        if (!ss.length) return;
+        var stU = null, ctU = null, ctNode = null, stSame = true, ctSame = true, sightMap = {};
+        // the captioned room itself leads its own collective line — seeded FIRST so the 5-name
+        // cap can never fold the room this window exists for into "+N more" (the composition
+        // diffuses pinpointing, but the dwell room is the one item the window is ABOUT)
+        for (var lj = 0; lj < ss.length; lj++) {
+          if (ss[lj].guid === seg.guid && ss[lj].node) { sightMap[seg.guid] = ss[lj].node; break; }
+        }
+        for (var li = 0; li < ss.length; li++) {
+          var s = ss[li];
+          var st = _storeyAt(s.iz);
+          var ct = _roomAtIfcPoint(s.ix, s.iy, s.iz);
+          if (li === 0) { stU = st; ctU = ct ? ct.guid : null; ctNode = ct; }
+          else {
+            if (st !== stU) stSame = false;
+            if ((ct ? ct.guid : null) !== ctU) ctSame = false;
+          }
+          (s.sight || []).forEach(function(n) { if (!sightMap[n.guid]) sightMap[n.guid] = n; });
+        }
+        var C = _lineFrom(stSame, stU, ctSame, ctNode, ctU, sightMap, bldNm);
+        if (C.parts.length) { seg.label = C.parts.join(' · '); labelled++; }
+      });
+      console.log('§CPE_ROOM_TITLE_COLLECTIVE labelled=' + labelled + '/' + dwellN +
+        ' dwell captions composed via the group grammar (label only — name/guid/times untouched)' +
+        ' ms=' + (performance.now() - lT0).toFixed(1));
+    } catch (eC) { console.warn('§CPE_ROOM_TITLE_COLLECTIVE failed (bare names shown): ' + eC.message); }
     return held;
   };
 
@@ -680,7 +735,9 @@ function setupCpeRoomTitle(A) {
       if (t < s.tStart - FADE || t > s.tEnd + FADE) return;
       var op = (t < s.tStart) ? (t - (s.tStart - FADE)) / FADE :
                (t > s.tEnd) ? 1 - (t - s.tEnd) / FADE : 1;
-      if (!best || op > best.opacity) best = { name: s.name, guid: s.guid, opacity: op };
+      // §CPE_ROOM_TITLE_COLLECTIVE: the composed label is what the film shows; the bare room
+      // name survives on the segment for the timing/identity witnesses and as the degrade path.
+      if (!best || op > best.opacity) best = { name: s.label || s.name, guid: s.guid, opacity: op };
     });
     return best;
   };
@@ -689,8 +746,27 @@ function setupCpeRoomTitle(A) {
   // baked video can never disagree about how a title looks (same font, size, band, fade). A lower-
   // third caption band, documentary-style — screen POSITION is the one open detail RESUME_CPE_
   // ROOM_TITLE.md left for the user; this is the placeholder until told otherwise.
+  // §CPE_ROOM_TITLE_COLLECTIVE, the [phase] half: the trailing bracket names the collective being
+  // BUILT — the live Time Machine frontier phase, the same per-frame state the bake already drives
+  // (§SFX_PLAY src=tm phase=… is this exact value). Resolved at DRAW time, never at plan time:
+  // day↔t is nonlinear twice over (work pacing + topout), so a plan-time guess would lie. No
+  // frontier in force (no buildup, or construction complete) → no bracket, never a guessed one.
+  // Pure and exposed so the witness gates THIS function, not a re-implementation.
+  var _lastPhaseLogged = null;
+  A.roomTitleFinalText = function(text) {
+    var p = A.tmFrontierPhase;
+    if (p && text) {
+      if (_lastPhaseLogged !== p) {
+        console.log('§CPE_ROOM_TITLE_PHASE phase="' + p + '" — appended to captions (live TM frontier)');
+        _lastPhaseLogged = p;
+      }
+      return text + ' [' + p + ']';
+    }
+    return text;
+  };
   A.roomTitleCompositeOntoCanvas = function(ctx, w, h, text, opacity) {
     if (!ctx || !text || !(opacity > 0)) return;
+    text = A.roomTitleFinalText(text);
     ctx.save();
     var fontPx = Math.max(18, Math.round(h * 0.032));
     var bandH = fontPx * 2.2;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v919';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v920';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1126,7 +1126,7 @@
     var frontier = {};  // guid → {t: 0-1 progress, isSteel: bool}
     var recent = {};    // guid → fade 0-1 (1 = just finished)
     var arrival = {};   // guid → true (just appeared this tick — white flash)
-    var _sfxPhases = null; // §SFX: phase set at the frontier this tick (built only when sfx.js present)
+    var _sfxPhases = null; // phase set at the frontier this tick (§SFX voice + §CPE_ROOM_TITLE_COLLECTIVE bracket)
     var lingerMs = tickMs() * 3; // linger for 3 ticks after completion
     var _isMobileTM = !!(window._isMobile || window._isMobileTM);
 
@@ -1151,9 +1151,11 @@
         frontier[guid] = { t: progress, isSteel: isSteel };
         // Arrival = first 15% of install time (white flash)
         if (progress < 0.15) arrival[guid] = true;
-        // §SFX seam (sfx.js): collect the construction phase(s) at the frontier. No-op
-        // when sfx.js absent or audio OFF — sfx decides whether/what to play (SoC).
-        if (window.__sfxTM && p.phase) { if (!_sfxPhases) _sfxPhases = {}; _sfxPhases[p.phase] = (_sfxPhases[p.phase] || 0) + 1; }
+        // §SFX seam (sfx.js) + §CPE_ROOM_TITLE_COLLECTIVE (cpe_room_title.js): collect the
+        // construction phase(s) at the frontier. Two consumers now — the sfx voice AND the
+        // caption's [phase] bracket — so the collection no longer gates on __sfxTM; each
+        // consumer still decides for itself what to do with it (SoC).
+        if (p.phase) { if (!_sfxPhases) _sfxPhases = {}; _sfxPhases[p.phase] = (_sfxPhases[p.phase] || 0) + 1; }
       }
     }
 
@@ -1828,9 +1830,14 @@
 
     // §SFX seam (sfx.js): report frontier phases + a representative world centroid (→ stereo
     // pan) + progress/activity (→ the cinematic bed's two dials). No-op when audio off/absent.
+    // most-active phase first (by element count) — stable dominant, not alphabetical flicker
+    var _sfxArr = _sfxPhases ? Object.keys(_sfxPhases).sort(function (a, b) { return _sfxPhases[b] - _sfxPhases[a]; }) : [];
+    // §CPE_ROOM_TITLE_COLLECTIVE: the dominant frontier phase, refreshed EVERY tick — null the
+    // moment the frontier empties (construction complete), so the caption bracket can never
+    // outlive the work it names. cpe_room_title.js reads this at draw time.
+    var _appPh = (typeof A === 'function') ? A() : null;
+    if (_appPh) _appPh.tmFrontierPhase = _sfxArr[0] || null;
     if (window.__sfxTM) {
-      // most-active phase first (by element count) — stable dominant, not alphabetical flicker
-      var _sfxArr = _sfxPhases ? Object.keys(_sfxPhases).sort(function (a, b) { return _sfxPhases[b] - _sfxPhases[a]; }) : [];
       var _sfxCen = null;
       if (_frontierPositions.length) {
         var _sx = 0, _sy = 0, _sz = 0;

--- a/witness_cpe_room_title_collective.js
+++ b/witness_cpe_room_title_collective.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// WITNESS — §CPE_ROOM_TITLE_COLLECTIVE: ONE composed caption everywhere + live [phase].
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_COLLECTIVE (2026-08-02).
+//
+// THE ISSUE IT PROVES OR DISPROVES (user, 2026-08-02): "grouped together in single label… it is
+// caption optics" — the film mixed two caption formats (bare room names during dwells, composed
+// lines only in the gaps), and no caption ever named the collective being BUILT. Format confirmed
+// verbatim: "Storey - 1 Corridor Hall Rooms 2,3 [MEP Rough in]".
+//
+//   G-RTC-1  every dwell caption is composed: the §CPE_ROOM_TITLE_COLLECTIVE pass labels 100% of
+//            dwell segments through the SAME grammar the gap fill uses. RED before the fix: zero
+//            dwell segments carry a label — the two-format optics.
+//   G-RTC-2  the captioned room appears in its OWN collective line (a label that dropped the room
+//            it captions would be worse optics, not better).
+//   G-RTC-3  optics only — name/guid/times untouched: bare `name` survives on every dwell segment
+//            (degrade path + what the settled timing witnesses gate), and two builds of the same
+//            plan agree byte-for-byte on (guid,tStart,tEnd,name) — the pass is deterministic and
+//            writes ONLY `label`.
+//   G-RTC-4  the film shows the label: roomTitleOpacityAt inside a dwell window returns the
+//            composed label, not the bare name.
+//   G-RTC-5  [phase] resolves at DRAW time from the live TM frontier: with a phase in force the
+//            compositor paints exactly "text [phase]"; with none it paints bare text. Driven
+//            through the REAL roomTitleCompositeOntoCanvas via a capturing ctx stub — not a
+//            re-implementation. RED before the fix: no bracket ever.
+// RUN: node witness_cpe_room_title_collective.js
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const FALLBACK_ROOT = '/home/red1/bim-ootb';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream', '.json': 'application/json', '.css': 'text/css', '.jpg': 'image/jpeg', '.png': 'image/png' };
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    const send = (b) => { r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b); };
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (!e) return send(b);
+      fs.readFile(path.join(FALLBACK_ROOT, p), (e2, b2) => {
+        if (e2) { r.writeHead(404); r.end('404'); return; }
+        send(b2);
+      });
+    });
+  });
+}
+const BLD = process.env.BLD || 'Hospital';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const _watchdog = setTimeout(() => { console.log('\n§W-RTC TIMEOUT — killed after 420s'); process.exit(3); }, 420000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${port}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.roomTitleBuildTimeline && window.APP.dbQuery,
+    { timeout: 300000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 300000, polling: 3000 });
+
+  const res = await page.evaluate(async () => {
+    const A = window.APP, out = { err: null };
+    try {
+      if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
+      if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
+      const DUR = 147.9;                              // the user's own film length
+      const plan = A.cinemaPathPlan(DUR);
+      const segs = A.roomTitleBuildTimeline(plan, DUR);
+      const rooms = segs.filter(s => !s.group), groups = segs.filter(s => s.group);
+      out.nRooms = rooms.length; out.nGroups = groups.length;
+      // G-RTC-1: every dwell caption composed
+      out.labelled = rooms.filter(s => typeof s.label === 'string' && s.label.length > 0).length;
+      out.sample = rooms.slice(0, 5).map(s => ({ name: s.name, label: s.label }));
+      // G-RTC-2: own room in its own line — the bare title, or its storey-deduped tail, must
+      // appear in the label (the grammar strips a unanimous storey prefix from room names).
+      out.ownRoomMissing = [];
+      for (const s of rooms) {
+        if (!s.label) continue;
+        // Mirror the grammar's own dedupe: a unanimous storey (the label's FIRST part) is
+        // stripped from inside room names — "⚠ Level 1 R11" renders as "⚠ R11" under "Level 1".
+        const first = s.label.split(' · ')[0];
+        const dedup = s.name.replace(first + ' ', '');
+        if (s.label.indexOf(s.name) < 0 && s.label.indexOf(dedup) < 0)
+          out.ownRoomMissing.push({ name: s.name, label: s.label });
+      }
+      // G-RTC-3: bare names survive; deterministic double build agrees on identity+times+name
+      out.nameHasDot = rooms.filter(s => s.name.indexOf(' · ') >= 0).length;
+      const key = list => JSON.stringify(list.map(s => [s.guid, +s.tStart.toFixed(4), +s.tEnd.toFixed(4), s.name]));
+      const segs2 = A.roomTitleBuildTimeline(plan, DUR);
+      out.deterministic = key(segs.filter(s => !s.group)) === key(segs2.filter(s => !s.group));
+      // G-RTC-4: the film shows the label
+      out.opacityShowsLabel = null;
+      const withLabel = rooms.find(s => s.label && s.label !== s.name);
+      if (withLabel) {
+        const info = A.roomTitleOpacityAt(segs, (withLabel.tStart + withLabel.tEnd) / 2);
+        out.opacityShowsLabel = !!info && info.name === withLabel.label;
+        out.opacitySample = info && info.name;
+      }
+      // G-RTC-5: [phase] at draw time, through the REAL compositor via a capturing ctx stub
+      const painted = [];
+      const stub = { save() {}, restore() {}, fillRect() {}, fillText(t) { painted.push(t); },
+                     set globalAlpha(v) {}, set fillStyle(v) {}, set font(v) {},
+                     set textAlign(v) {}, set textBaseline(v) {} };
+      const prevPhase = A.tmFrontierPhase;
+      A.tmFrontierPhase = 'MEP Rough in';
+      A.roomTitleCompositeOntoCanvas(stub, 1852, 960, 'Level 1 · Corridor · Rooms 2, 3', 1);
+      A.tmFrontierPhase = null;
+      A.roomTitleCompositeOntoCanvas(stub, 1852, 960, 'Level 1 · Corridor · Rooms 2, 3', 1);
+      A.tmFrontierPhase = prevPhase == null ? null : prevPhase;
+      out.painted = painted;
+      out.pure = [A.roomTitleFinalText && A.roomTitleFinalText('X') === 'X'];
+    } catch (e) { out.err = String(e && e.message) + '\n' + String(e && e.stack).slice(0, 400); }
+    return out;
+  });
+
+  let all = true;
+  const P = (name, ok, detail) => { all = all && ok; console.log(`${ok ? '✅' : '❌'} ${name}  ${detail}`); };
+  if (res.err) { console.log('❌ setup: ' + res.err); await browser.close(); server.close(); process.exit(1); }
+
+  P('G-RTC-1 every dwell caption is composed (RED before fix: 0 labelled)',
+    res.nRooms > 0 && res.labelled === res.nRooms,
+    `${res.labelled}/${res.nRooms} labelled; sample: ${JSON.stringify(res.sample.slice(0, 2))}`);
+  P('G-RTC-2 the captioned room appears in its own collective line',
+    res.ownRoomMissing.length === 0,
+    `${res.ownRoomMissing.length} missing` + (res.ownRoomMissing.length ? ' ' + JSON.stringify(res.ownRoomMissing.slice(0, 2)) : ''));
+  P('G-RTC-3 optics only: bare names survive, double build byte-identical on (guid,times,name)',
+    res.nameHasDot === 0 && res.deterministic === true,
+    `namesComposed=${res.nameHasDot} (must be 0) deterministic=${res.deterministic}`);
+  P('G-RTC-4 the film shows the composed label (roomTitleOpacityAt returns label)',
+    res.opacityShowsLabel === true,
+    `mid-window text: ${JSON.stringify(res.opacitySample)}`);
+  P('G-RTC-5 [phase] resolves at draw: bracket exactly when a TM frontier phase is in force',
+    res.painted.length === 2 &&
+    res.painted[0] === 'Level 1 · Corridor · Rooms 2, 3 [MEP Rough in]' &&
+    res.painted[1] === 'Level 1 · Corridor · Rooms 2, 3',
+    JSON.stringify(res.painted));
+  const cl = logs.find(l => l.includes('§CPE_ROOM_TITLE_COLLECTIVE'));
+  console.log('  instrument: ' + (cl || 'NO §CPE_ROOM_TITLE_COLLECTIVE LINE'));
+  all = all && !!cl;
+
+  await browser.close(); server.close(); clearTimeout(_watchdog);
+  console.log(all ? '\n§W-RTC all green' : '\n§W-RTC FAIL');
+  process.exit(all ? 0 : 1);
+})();


### PR DESCRIPTION
User, 2026-08-02: "grouped together in single label… it is caption optics", format confirmed verbatim **"Storey - 1 Corridor Hall Rooms 2,3 [MEP Rough in]"** — a *composition* of label types in one line, diffusing single-item pinpointing.

- **One grammar everywhere:** dwell captions now compose through the SAME `_lineFrom` grammar the §CPE_ROOM_TITLE_GROUP gap fill uses (one composer, two callers). Captioned room seeded first — never folded into "+N more".
- **Optics only:** the pass writes `.label`; guid/name/times untouched (settled timing rules + their witnesses unaffected); draw reads `label || name`.
- **`[phase]` at draw time:** live TM frontier phase (`A.tmFrontierPhase`, refreshed per tick, null once construction completes) — the same value `§SFX_PLAY src=tm phase=…` already proves per frame. Plan time cannot know it (day↔t nonlinear twice over: work pacing + topout).
- sw v920.

Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md §CPE_ROOM_TITLE_COLLECTIVE`.
Witnesses: `witness_cpe_room_title_collective.js` **G-RTC-1..5 all green** (20/20 dwell captions composed; double-build byte-identical on guid/times/name; bracket exactly when a phase is in force, driven through the real compositor via ctx stub). Regressions: `witness_cpe_room_title_group.js` **5/5**, `witness_cpe_room_title_multi.js` **4/4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)