### PR TITLE
feat(cpe): §CPE_PANEL_STATE — saved paths carry the panel context they were recorded under, sw v922

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1069,6 +1069,30 @@
         .sort(function(x, y) { return (y.savedAt || 0) - (x.savedAt || 0); });
     });
   }
+  // ══ §CPE_PANEL_STATE — the save carries the PANEL CONTEXT the path was recorded under, so a
+  // reopened plan restores the full session, not just the geometry. Three captured facts:
+  //   • checkboxes — every checkbox the CPE panel has (#cpe-buildup → _state.buildup,
+  //     #cpe-room-title → _state.roomTitle; the panel's full checkbox census, panels.js has none),
+  //     plus the #cpe-day-counter corner select (§CPE_DAY_COUNTER_POS) — name → value.
+  //   • total time — the Time Machine's project span, from its own public accessor
+  //     window.tmGetState() (time_machine.js): projectEnd − projectStart, stored as tmSpanMs with
+  //     both endpoints kept for provenance. There is NO setter for the span (it is derived from the
+  //     op-log), so on restore it is a drift check, never a write.
+  //   • day-counter position — the live cursor (`_cursor` inside time_machine.js, read via
+  //     tmGetState().cursor): "what day the counter currently shows."
+  function _capturePanelState(ov) {
+    var tm = null;
+    try { tm = (typeof window.tmGetState === 'function') ? window.tmGetState() : null; } catch (e) {}
+    return {
+      checkboxes: { buildup: !!ov.buildup, roomTitle: !!ov.roomTitle },
+      dayCounter: ov.dayCounter || 'tr',
+      tmActive: tm ? !!tm.active : false,
+      tmCursor: tm ? tm.cursor : null,
+      tmProjectStart: tm ? tm.projectStart : null,
+      tmProjectEnd: tm ? tm.projectEnd : null,
+      tmSpanMs: tm ? (tm.projectEnd - tm.projectStart) : null
+    };
+  }
   function _pathsSave(name) {
     var ov = _buildOverride(), bld = _bldKey();
     var rec = {
@@ -1079,14 +1103,21 @@
       meta: { bands: ov.bands.length, hoseOps: ov.hose.length,
               clip: ov.clip ? [ov.clip.in, ov.clip.out] : null, buildup: !!ov.buildup,
               totalSec: ov._total, pathLen: ov._pathLen, cpe: CPE_V.split(' ')[0] },
-      override: ov
+      override: ov,
+      panelState: _capturePanelState(ov)
     };
     return _pathsTx('readwrite', function(st) { return st.put(rec); }).then(function() {
+      var ps = rec.panelState;
       console.log('§CPE_PATH_SAVED name="' + name + '" building=' + bld +
         ' bands=' + rec.meta.bands + ' hoseOps=' + rec.meta.hoseOps +
         ' clip=' + (rec.meta.clip ? rec.meta.clip[0].toFixed(2) + '→' + rec.meta.clip[1].toFixed(2) : 'whole') +
         ' buildup=' + (rec.meta.buildup ? 1 : 0) + ' total=' + rec.meta.totalSec.toFixed(1) + 's' +
         ' — IndexedDB working store; cinema_path TABLE written separately so it travels with the .db');
+      console.log('§CPE_PANEL_STATE saved buildup=' + (ps.checkboxes.buildup ? 1 : 0) +
+        ' roomTitle=' + (ps.checkboxes.roomTitle ? 1 : 0) + ' dayCounter=' + ps.dayCounter +
+        ' tmActive=' + (ps.tmActive ? 1 : 0) +
+        ' tmCursor=' + (ps.tmCursor != null ? ps.tmCursor : 'n/a') +
+        ' tmSpanMs=' + (ps.tmSpanMs != null ? ps.tmSpanMs : 'n/a'));
       return rec;
     });
   }
@@ -1094,6 +1125,51 @@
     return _pathsTx('readwrite', function(st) { return st.delete(key); }).then(function() {
       console.log('§CPE_PATH_DELETED key="' + key + '"');
     });
+  }
+  // §CPE_PANEL_STATE restore — drive the panel's own controls through their OWN change handlers
+  // (the same mechanism a user's click uses: panels.js:552 is the dispatchEvent precedent), never a
+  // bare DOM mutation the rest of the app cannot see. The dayEl seeding at wiring time already did
+  // this for the select; the sibling checkboxes never got it — this closes that gap.
+  function _syncPanelControls() {
+    [['cpe-buildup', !!_state.buildup], ['cpe-room-title', !!_state.roomTitle]].forEach(function(p) {
+      var el = document.getElementById(p[0]);
+      if (el && el.checked !== p[1]) { el.checked = p[1]; el.dispatchEvent(new Event('change')); }
+    });
+    var dayEl = document.getElementById('cpe-day-counter'), want = _state.dayCounter || 'tr';
+    if (dayEl && dayEl.value !== want) { dayEl.value = want; dayEl.dispatchEvent(new Event('change')); }
+  }
+  function _applyPanelState(ps) {
+    if (!ps) {
+      // Old record, saved before panelState existed — skip, exactly today's behaviour, never throw.
+      console.log('§CPE_PANEL_STATE none on record (pre-panelState save) — panel-state restore skipped');
+      return;
+    }
+    if (ps.checkboxes) {
+      _state.buildup = !!ps.checkboxes.buildup;
+      _state.roomTitle = !!ps.checkboxes.roomTitle;
+    }
+    if (ps.dayCounter) _state.dayCounter = ps.dayCounter;
+    _syncPanelControls();
+    // Day-counter position (= Time Machine cursor): restored through the ONE public cursor setter,
+    // window.tmSetCursor (time_machine.js — "renderAtTime() is internal by design; this is the ONE
+    // public cursor setter"). The span has no setter (derived from the op-log), so a saved-vs-now
+    // mismatch is REPORTED, not written.
+    var cursorNote = 'skipped';
+    if (ps.tmCursor != null && typeof window.tmGetState === 'function' && typeof window.tmSetCursor === 'function') {
+      var tm = window.tmGetState();
+      if (tm.active) {
+        var span = tm.projectEnd - tm.projectStart;
+        if (ps.tmSpanMs != null && Math.abs(span - ps.tmSpanMs) > 1)
+          console.warn('§CPE_PANEL_STATE span drift saved=' + ps.tmSpanMs + 'ms now=' + span +
+            'ms — the schedule changed since this plan was saved');
+        cursorNote = window.tmSetCursor(ps.tmCursor) ? 'restored ms=' + ps.tmCursor : 'setter-refused';
+      } else {
+        cursorNote = ps.tmActive ? 'tm-inactive-now (activate Time Machine to see the saved day)' : 'tm-was-inactive';
+      }
+    }
+    console.log('§CPE_PANEL_STATE restored buildup=' + (_state.buildup ? 1 : 0) +
+      ' roomTitle=' + (_state.roomTitle ? 1 : 0) + ' dayCounter=' + (_state.dayCounter || 'tr') +
+      ' tmCursor=' + cursorNote + ' tmSpanMs=' + (ps.tmSpanMs != null ? ps.tmSpanMs : 'n/a'));
   }
   // Loading REPLACES the authored state, and only when asked — never on open. The spec left that as
   // an open question; the user's own words answer it: *"open to look back saved hose plans"*. Looking
@@ -1120,6 +1196,9 @@
     _state.dayCounter = ov.dayCounter || 'tr';   // older saved plans predate the choice — top right
     _state.userTotal = ov._total;
     _state.held = null;
+    // §CPE_PANEL_STATE — restore the panel context the plan was recorded under (or skip loudly for
+    // records that predate it). Runs BEFORE staging so the staged override reflects the final state.
+    _applyPanelState(rec.panelState);
     // §CPE_PATH_NOT_PORTABLE fix, part 1 (prompts/CINEMA_PATH_EDITOR.md): opening a named plan used
     // to leave `_state.staged = false` and never call `A.stageCinemaPath` — so after any reload,
     // `A._cinemaPathEdit` stayed null and Ctrl+S's `_writeCinemaPathTable` guard returned silently,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v921';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v922';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_path_portable.js
+++ b/witness_cpe_path_portable.js
@@ -28,6 +28,21 @@
 //           reports a restored path AND the next plan build logs §CINEMA_BEATS route=authored.
 //   G-PP-5  no regression: a save with nothing authored still produces a valid DB (openable, correct
 //           element count) and does NOT create an empty cinema_path table.
+//
+// §CPE_PANEL_STATE gates (added 2026-08-02) — THE ISSUE: "Save this path" persisted only the
+// path/override; the PANEL CONTEXT it was recorded under (checkbox states, Time Machine total span,
+// the day the counter currently shows) was dropped, so reopening a saved plan did not restore the
+// session. RED on pre-fix code proves the drop; GREEN proves restore matches save byte-for-byte.
+//   G-PS-1  the saved IndexedDB record carries `panelState` — checkboxes {buildup, roomTitle}
+//           (the CPE panel's full checkbox census), dayCounter corner, tmCursor / tmSpanMs from
+//           window.tmGetState(). RED: rec.panelState === undefined — the context is dropped at save.
+//   G-PS-2  after reload + open, the PANEL CONTROLS show the saved context (#cpe-buildup.checked,
+//           #cpe-room-title.checked, #cpe-day-counter.value). RED: _state is restored from the
+//           override but the DOM controls are not re-seeded — the panel lies about the plan.
+//   G-PS-3  the day-counter position is restored: with TM active, tmGetState().cursor equals the
+//           saved cursor (restored via the ONE public setter window.tmSetCursor). RED: cursor is
+//           never touched on open — the counter shows whatever day the session happened to be at.
+//   G-PS-4  byte-for-byte: every restored value equals the saved record's panelState exactly.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8461;
@@ -135,6 +150,7 @@ async function clickPipe(page, px, py) {
   console.log(`\n${'='.repeat(78)}\n${BLD} — §CPE_PATH_NOT_PORTABLE\n${'='.repeat(78)}`);
 
   let authoredOv = null, authoredIfc = null;   // stashed at authoring time, read back in later phases
+  let savedTmTruth = null, savedRec = null;    // §CPE_PANEL_STATE ground truth captured at save time
 
   const page = await browser.newPage();
   await page.setViewport({ width: 1200, height: 700 });
@@ -185,11 +201,52 @@ async function clickPipe(page, px, py) {
           });
         }, afterEdit);
 
+        // ── §CPE_PANEL_STATE setup: put the panel into a NON-DEFAULT context before saving, so a
+        // dropped context is distinguishable from a default one. Real controls, real change events.
+        await page.click('#cpe-buildup');       // buildup ON  (default off)
+        await page.click('#cpe-room-title');    // room titles ON (default off)
+        await page.select('#cpe-day-counter', 'bl');  // corner bottom-left (default tr)
+        await sleep(600);
+        // Time Machine context: activate (derived timeline) and park the cursor mid-project —
+        // a value no default lands on — through the same public setter the app itself uses.
+        savedTmTruth = await page.evaluate(async () => {
+          if (typeof window.tmActivateForBake !== 'function' || typeof window.tmGetState !== 'function') return null;
+          const ok = await window.tmActivateForBake();
+          if (!ok) return null;
+          const tm0 = window.tmGetState();
+          const target = tm0.projectStart + Math.round((tm0.projectEnd - tm0.projectStart) * 0.37);
+          window.tmSetCursor(target);
+          const tm = window.tmGetState();
+          return { target, cursor: tm.cursor, projectStart: tm.projectStart, projectEnd: tm.projectEnd,
+                   spanMs: tm.projectEnd - tm.projectStart };
+        });
+        P('SETUP Time Machine context established (active, cursor parked mid-project)',
+          !!savedTmTruth && Math.abs(savedTmTruth.cursor - savedTmTruth.target) < 2,
+          savedTmTruth ? `cursor=${savedTmTruth.cursor} target=${savedTmTruth.target} spanMs=${savedTmTruth.spanMs}` : 'tmActivateForBake unavailable or no ops');
+
         let mark = logs.length;
         await page.click('#cpe-save');
         await sleep(1200);
         const savedLine = logs.slice(mark).filter(l => l.startsWith('§CPE_PATH_SAVED')).pop();
         P('SETUP plan named and saved to IndexedDB', !!savedLine, savedLine || 'no §CPE_PATH_SAVED line');
+
+        // ── G-PS-1: the record itself carries panelState (read straight from IndexedDB) ──
+        savedRec = await page.evaluate((name) => new Promise((res, rej) => {
+          const rq = indexedDB.open('bim_ootb_cinema_paths', 1);
+          rq.onsuccess = () => {
+            const db = rq.result, g = db.transaction('paths', 'readonly').objectStore('paths').getAll();
+            g.onsuccess = () => { db.close(); res((g.result || []).filter(r => r.name === name).pop() || null); };
+            g.onerror = () => { db.close(); rej(g.error); };
+          };
+          rq.onerror = () => rej(rq.error);
+        }), PLAN_NAME);
+        const ps = savedRec && savedRec.panelState;
+        P('G-PS-1 the saved record carries panelState (checkboxes + dayCounter + tmCursor/tmSpanMs) ' +
+          '(THE drop: pre-fix, rec.panelState is undefined — the recording context never reaches the store)',
+          !!ps && ps.checkboxes && ps.checkboxes.buildup === true && ps.checkboxes.roomTitle === true &&
+          ps.dayCounter === 'bl' && savedTmTruth && ps.tmCursor === savedTmTruth.cursor &&
+          ps.tmSpanMs === savedTmTruth.spanMs,
+          ps ? `panelState=${JSON.stringify(ps)}` : `rec keys=${savedRec ? Object.keys(savedRec).join(',') : 'no record'} — panelState MISSING`);
 
         // Close via CANCEL, not OK — an untouched-vs-edited OK has its OWN pre-existing staging path
         // (finish() -> stageCinemaPath on an edited OK); using it here would mask exactly the bug
@@ -225,12 +282,61 @@ async function clickPipe(page, px, py) {
     P('SETUP the saved plan is listed after reload (IndexedDB persisted across it)', optIdx >= 0, `option index=${optIdx}`);
     if (optIdx < 0) { inconclusive = true; }
     else {
+      // §CPE_PANEL_STATE: re-activate TM BEFORE opening the plan — the cursor restore goes through
+      // tmSetCursor and (by design) only writes when TM is active; the witness must be in the state
+      // a buildup user actually is in. The reload wiped _active/_cursor — that is the RED condition.
+      const tmReady = await page.evaluate(async () =>
+        (typeof window.tmActivateForBake === 'function') ? await window.tmActivateForBake() : false);
+      P('SETUP Time Machine re-activated after reload (cursor at whatever the activation left, NOT the saved day)',
+        tmReady === true, `tmActivateForBake=${tmReady}`);
       await page.select('#cpe-plans', String(optIdx));
       let mark = logs.length;
       await page.click('#cpe-plan-open');
       await sleep(800);
       const loadedLine = logs.slice(mark).filter(l => l.startsWith('§CPE_PATH_LOADED')).pop();
       P('SETUP the plan opened successfully from IndexedDB', !!loadedLine, loadedLine || 'no §CPE_PATH_LOADED line');
+
+      // ── §CPE_PANEL_STATE after the reload: does the reopened plan restore the recording context? ──
+      const psLine = logs.slice(mark).filter(l => l.startsWith('§CPE_PANEL_STATE')).pop();
+      const domState = await page.evaluate(() => ({
+        buildup: !!document.getElementById('cpe-buildup').checked,
+        roomTitle: !!document.getElementById('cpe-room-title').checked,
+        dayCounter: document.getElementById('cpe-day-counter').value,
+        tm: (typeof window.tmGetState === 'function') ? window.tmGetState() : null,
+      }));
+      P('G-PS-2 the PANEL CONTROLS show the saved context after reload+open ' +
+        '(THE drop: pre-fix, _state is set from the override but the checkboxes/select are never re-seeded)',
+        domState.buildup === true && domState.roomTitle === true && domState.dayCounter === 'bl',
+        `#cpe-buildup=${domState.buildup} #cpe-room-title=${domState.roomTitle} #cpe-day-counter=${domState.dayCounter}` +
+        `  LOG: ${psLine || 'no §CPE_PANEL_STATE line'}`);
+      P('G-PS-3 the day-counter position (TM cursor) is restored through window.tmSetCursor ' +
+        '(THE drop: pre-fix, opening a plan never touches the cursor)',
+        !!savedTmTruth && !!domState.tm && domState.tm.active === true &&
+        Math.abs(domState.tm.cursor - savedTmTruth.cursor) < 2,
+        savedTmTruth && domState.tm
+          ? `cursor now=${domState.tm.cursor} saved=${savedTmTruth.cursor} diff=${Math.abs(domState.tm.cursor - savedTmTruth.cursor)}ms tmActive=${domState.tm.active}`
+          : 'no TM state to compare');
+      const psSaved = savedRec && savedRec.panelState;
+      // Byte-for-byte on every RESTORABLE value (checkboxes, corner, cursor — the values the feature
+      // writes back). The span has NO setter (derived from the op-log — a reload re-derives it, and
+      // TM's derived synthesis is not ms-identical across loads), so the CONTRACT there is a drift
+      // check: equal spans stay silent, unequal spans are reported by the §CPE_PANEL_STATE span-drift
+      // warn — never silently absorbed.
+      const spanNow = domState.tm ? (domState.tm.projectEnd - domState.tm.projectStart) : null;
+      const spanEqual = !!psSaved && spanNow != null && Math.abs(spanNow - psSaved.tmSpanMs) <= 1;
+      const driftLine = logs.slice(mark).filter(l => l.indexOf('§CPE_PANEL_STATE span drift') >= 0).pop();
+      P('G-PS-4 byte-for-byte: every restored value equals the saved panelState exactly; the ' +
+        'non-settable span either matches or its drift is REPORTED, never silent',
+        !!psSaved && domState.buildup === psSaved.checkboxes.buildup &&
+        domState.roomTitle === psSaved.checkboxes.roomTitle &&
+        domState.dayCounter === psSaved.dayCounter &&
+        !!domState.tm && domState.tm.cursor === psSaved.tmCursor &&
+        (spanEqual || !!driftLine),
+        psSaved && domState.tm
+          ? `saved={buildup:${psSaved.checkboxes.buildup},roomTitle:${psSaved.checkboxes.roomTitle},day:${psSaved.dayCounter},cursor:${psSaved.tmCursor},span:${psSaved.tmSpanMs}} ` +
+            `restored={buildup:${domState.buildup},roomTitle:${domState.roomTitle},day:${domState.dayCounter},cursor:${domState.tm.cursor},span:${spanNow}}` +
+            `  spanEqual=${spanEqual} DRIFT: ${driftLine || 'none logged'}`
+          : `saved panelState=${JSON.stringify(psSaved)} — nothing to compare byte-for-byte`);
 
       // ── G-PP-1a: is the just-opened plan actually staged for Ctrl+S? ──
       stagedAfterOpen = await page.evaluate(() => {


### PR DESCRIPTION
## What

"Save this path" (Cinema Path Editor, IndexedDB `bim_ootb_cinema_paths`) now captures the panel context the path was recorded under, and opening a saved plan restores it.

**panelState sub-object on each record:**
- `checkboxes.buildup` / `checkboxes.roomTitle` — the CPE panel's two checkboxes (`#cpe-buildup` → `_state.buildup`, `#cpe-room-title` → `_state.roomTitle`); panels.js has zero checkboxes, so this is the whole census
- `dayCounter` — the `#cpe-day-counter` corner select (§CPE_DAY_COUNTER_POS)
- `tmCursor` — the day the counter currently shows (`tmGetState().cursor` = time_machine.js `_cursor`)
- `tmProjectStart`/`tmProjectEnd`/`tmSpanMs` — total project time (`_projectEnd − _projectStart`); no setter exists (derived from the op-log), so restore REPORTS drift (§CPE_PANEL_STATE span drift warn), never writes

**Restore path (_pathsApply):** through the app's own setters — checkbox/select `change` handlers via dispatchEvent (panels.js:552 precedent) and `window.tmSetCursor` (the ONE public cursor setter). Records without `panelState` skip loudly, exactly the old behavior.

**Portable `cinema_path` table (scene.js `_writeCinemaPathTable`) deliberately NOT extended** — it stores only band geometry + timing scalars today (no hose/clip/buildup either); panelState there is a schema evolution with version-skew rules, out of scope this pass.

## Witness

`witness_cpe_path_portable.js` extended with G-PS-1..4 (each names the issue it proves):
- RED on pre-fix code: **16/20** — `rec keys=key,building,name,savedAt,meta,override — panelState MISSING`; `#cpe-buildup=false #cpe-room-title=false #cpe-day-counter=tr`; cursor `diff=1521847006ms`
- GREEN after fix: **20/20** — `§CPE_PANEL_STATE restored buildup=1 roomTitle=1 dayCounter=bl tmCursor=restored ms=1784160999545`, cursor `diff=0ms`

Regressions green: `witness_stagger_support_order.js` (G-SSO-1..4 PASS), `witness_zstack_xray_staging.js` (G-XRAY-1..4 PASS), `witness_cpe_room_title_collective.js` (§W-RTC all green).

sw.js CACHE_VERSION v921 → v922 (cinema_path_editor.js is precached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)