### PR TITLE
fix(photoreal): skyline silhouette buildings now cast shadows (§PHOTO_SKYLINE_SHADOW_FRUSTUM)

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -307,6 +307,17 @@ async function setupEffects(A, renderer, scene, camera) {
   }
   var _photoFacadeLights = [];  // [{mid:{x,z}(three), normalThree:{x,z}, up:PointLight, down:PointLight}]
   var PHOTO_FACADE_UP_BASE = 9, PHOTO_FACADE_DOWN_BASE = 7;
+  // §PHOTO_SKYLINE_SHADOW_FRUSTUM: shared with _enablePhotoShadows()'s frustum sizing below (search
+  // the same name there) so the two can never drift apart again the way they did at introduction —
+  // both the skyline ring's placement radius AND the shadow-camera frustum need the SAME multiplier
+  // applied to the SAME envelope; before this fix each recomputed its own value independently, and
+  // the frustum one never got the 2.2x term at all (see the DONE record in
+  // prompts/PHOTOREAL_STILL_RENDER.md for the measured before/after numbers and the regression check).
+  var PHOTO_SKYLINE_RADIUS_MULT = 2.2;
+  // Half of the skyline box's widest possible footprint (bw = 18 + Math.random()*32, max 50, half
+  // 25) plus a small margin, so a box isn't clipped right at its own edge when its CENTER sits just
+  // inside the frustum bound.
+  var PHOTO_SKYLINE_BOX_MARGIN = 30;
   // §FACADE_WARM_COOL — the two illuminants this scene already declares (PHOTO_SUN_COLOR warm,
   // PHOTO_HEMI_SKY_COLOR cool dusk sky). Warm pair unchanged from what shipped; cool pair chosen
   // LUMINANCE-MATCHED to it (0.728 vs 0.714, 0.825 vs 0.837 — within 2%) so the split is purely
@@ -653,7 +664,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // (envelope*4) put these so far out they subtended almost no visible angle from a normal
     // camera position, reading as tiny specks. Pulled closer + bigger + more of them.
     var envelope = Math.max(w, d, 50);
-    var radius = envelope * 2.2;
+    var radius = envelope * PHOTO_SKYLINE_RADIUS_MULT;
     var group = new THREE.Group();
     var winPos = [], winCol = [];
     var N = 40;
@@ -2622,6 +2633,24 @@ async function setupEffects(A, renderer, scene, camera) {
     var _bc = Object.values(A.buildingCentres || {})[0];
     if (_bc && _bc.envelope) _env = Math.ceil(_bc.envelope);
     _env = Math.max(_env, 50);
+    // §PHOTO_SKYLINE_SHADOW_FRUSTUM (bug: "the silhouette buildings in distance cannot cast shadows
+    // well" — confirmed via real measured numbers, not assumption: HHS_Office_Federated envelope=
+    // 68.17m gave a frustum half-width of 69m, but the skyline ring (built in _buildPhotoProps,
+    // radius = envelope * PHOTO_SKYLINE_RADIUS_MULT) sits at ~150m — all 36/36 skyline boxes fell
+    // entirely outside [-_env,_env] on X and/or Z, so they were clipped from the shadow depth pass
+    // before any render, regardless of castShadow. This has been true since the photo-shadow
+    // feature's OWN introduction (PR #806, 2026-07-16) — the same commit that set the skyline ring
+    // to its current radius multiplier never accounted for it here; not a later drift-apart
+    // regression. Recomputed from the SAME real bbox query _buildPhotoProps() itself uses (not read
+    // off the built skyline group, which may not exist yet — _enablePhotoShadows() runs BEFORE
+    // _buildPhotoProps()/_showPhotoProps(true) in _applyPhotoStaging's call order below, so a
+    // group-based read would miss the very first Alt+S press for a building).
+    var _skyBbox = _buildingBBoxIfc();
+    if (_skyBbox) {
+      var _skyEnvelope = Math.max(_skyBbox.xMax - _skyBbox.xMin, _skyBbox.yMax - _skyBbox.yMin, 50);
+      var _skyRadius = _skyEnvelope * PHOTO_SKYLINE_RADIUS_MULT;
+      _env = Math.max(_env, Math.ceil(_skyRadius + PHOTO_SKYLINE_BOX_MARGIN));
+    }
     // NOTE: computed AFTER A.updateSky() has already positioned A.sun at the dusk direction (see
     // call order in _applyPhotoStaging below) — using the ORIGINAL toggleShadow() order (frustum
     // math before the sun is repositioned) would size this frustum for the wrong sun distance.
@@ -2645,7 +2674,8 @@ async function setupEffects(A, renderer, scene, camera) {
       for (; _si < end; _si++) { var o = _shadowList[_si]; if (o.visible) { o.castShadow = true; o.receiveShadow = true; } }
       A.renderer.shadowMap.needsUpdate = true;
       if (_si < _shadowList.length) setTimeout(_chunk, 0);
-      else console.log('§PHOTO_SHADOW enabled casters=' + _shadowList.length + ' sunDist=' + _sunDist.toFixed(0) + ' env=' + _env);
+      else console.log('§PHOTO_SHADOW enabled casters=' + _shadowList.length + ' sunDist=' + _sunDist.toFixed(0) +
+        ' env=' + _env + ' texelPerM=' + (A.sun.shadow.mapSize.width / (2 * _env)).toFixed(1));
     })();
   }
   function _disablePhotoShadows() {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v922';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v923';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_photo_skyline_shadow_frustum.js
+++ b/witness_photo_skyline_shadow_frustum.js
@@ -1,0 +1,93 @@
+// WITNESS — §PHOTO_SKYLINE_SHADOW_FRUSTUM (2026-08-02)
+// ISSUE IT PROVES/DISPROVES: user report "the silhouette buildings in distance cannot cast
+// shadows well now" — the distant skyline ring (_buildPhotoProps, effects.js, radius = envelope *
+// PHOTO_SKYLINE_RADIUS_MULT) sat OUTSIDE the shadow-camera's orthographic frustum
+// (_enablePhotoShadows, _env sized to the main building's envelope only, 1x) — the ring was
+// clipped from the shadow depth pass entirely, before any render, regardless of castShadow being
+// set correctly elsewhere. Confirmed via real measured numbers before fixing (not assumption):
+// HHS_Office_Federated envelope=68.17m → pre-fix frustum half-width=69m, skyline boxes at
+// 139.5-160.4m from center — 36/36 outside. This has been true since the photo-shadow feature's
+// OWN introduction (PR #806, 2026-07-16) — the same commit that set the skyline radius multiplier
+// never sized this frustum to match; not a later drift-apart regression.
+//
+// This witness reads the REAL THREE.js shadow-camera frustum (A.sun.shadow.camera.left/right, the
+// same object the renderer's shadow pass actually uses) and the REAL skyline box world positions
+// (A._getPhotoSkyline().children) live from the running app — never asks the code whether it
+// thinks it worked. PASS bar: every skyline box's position falls within [-_env,_env] on both X and
+// Z (relative to the shadow camera's look-at target), zero page errors.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8461;
+const BLD = process.env.BLD || 'HHS_Office_Federated';
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    protocolTimeout: 300000,
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  console.log(`\n${'='.repeat(78)}\n§PHOTO_SKYLINE_SHADOW_FRUSTUM witness — ${BLD}\n${'='.repeat(78)}`);
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls &&
+    typeof window.APP.toggleStillRefine === 'function', { timeout: 90000 });
+  // Must wait for the DB to be actually loaded (buildingCentres.envelope populated) before
+  // triggering Alt+S — an early trigger falls back to the unrelated _env=300 default, which is
+  // not the production condition this bug was reported under.
+  await page.waitForFunction(() => {
+    const bc = window.APP.buildingCentres && Object.values(window.APP.buildingCentres)[0];
+    return bc && bc.envelope > 0 && window.APP.dbQuery;
+  }, { timeout: 120000, polling: 500 });
+  await page.waitForFunction(() => window.APP.streaming === false, { timeout: 60000, polling: 500 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 1500));
+
+  await page.evaluate(() => { window.APP.toggleStillRefine(); });
+  await new Promise(r => setTimeout(r, 3000));
+
+  const nums = await page.evaluate(() => {
+    const A = window.APP;
+    const bc = Object.values(A.buildingCentres || {})[0];
+    const envelope = bc ? bc.envelope : null;
+    const _env = A.sun && A.sun.shadow ? A.sun.shadow.camera.right : null;
+    const mapSize = A.sun && A.sun.shadow ? A.sun.shadow.mapSize.width : null;
+    const skyline = A._getPhotoSkyline ? A._getPhotoSkyline() : null;
+    const ctr = A.controls ? A.controls.target : { x: 0, y: 0, z: 0 };
+    const boxResults = [];
+    if (skyline) {
+      skyline.children.forEach(function(b) {
+        const dx = b.position.x - ctr.x, dz = b.position.z - ctr.z;
+        const insideX = Math.abs(dx) <= _env, insideZ = Math.abs(dz) <= _env;
+        boxResults.push({ dx: +dx.toFixed(1), dz: +dz.toFixed(1), inside: insideX && insideZ });
+      });
+    }
+    return { envelope, _env, mapSize, skylineBoxCount: skyline ? skyline.children.length : 0, boxResults };
+  });
+
+  const outside = nums.boxResults.filter(b => !b.inside);
+  const texelPerM = nums._env ? (nums.mapSize / (2 * nums._env)).toFixed(1) : null;
+  console.log('--- measured ---');
+  console.log('envelope=' + nums.envelope + ' frustum_env(half-width)=' + nums._env +
+    ' skylineBoxCount=' + nums.skylineBoxCount + ' outside=' + outside.length + ' texelPerM=' + texelPerM);
+  if (outside.length) console.log('outside sample: ' + JSON.stringify(outside.slice(0, 5)));
+
+  const relevant = logs.filter(l => l.includes('§PHOTO_SHADOW') || l.includes('§PHOTO_ADDONS'));
+  console.log('\n--- relevant log lines ---');
+  relevant.forEach(l => console.log(l));
+
+  const pageErrors = logs.filter(l => l.startsWith('PAGEERROR'));
+  console.log('§WITNESS pageErrors=' + pageErrors.length);
+  if (pageErrors.length) pageErrors.forEach(l => console.log(l));
+
+  await browser.close();
+
+  const pass = nums.skylineBoxCount > 0 && outside.length === 0 && pageErrors.length === 0;
+  console.log('\n' + (pass ? 'PASS' : 'FAIL') + ' — §PHOTO_SKYLINE_SHADOW_FRUSTUM: ' +
+    (outside.length === 0
+      ? 'all ' + nums.skylineBoxCount + ' skyline boxes fall inside the shadow-camera frustum (env=' + nums._env + '), zero pageerrors.'
+      : outside.length + '/' + nums.skylineBoxCount + ' skyline boxes fall OUTSIDE the frustum — they cannot cast shadows.'));
+  process.exit(pass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Bug report: "the silhouette buildings in distance cannot cast shadows well now" — confirmed via real measured numbers, not assumption: the shadow-camera frustum (`_enablePhotoShadows`, `effects.js`) was sized to the main building's envelope only (1x), while the skyline ring (`_buildPhotoProps`) sits at `envelope * 2.2` — the ring fell entirely outside the frustum bounds and was clipped from the shadow depth pass before any render.
- Not a later drift-apart regression: both values were introduced in the SAME commit (PR #806, 2026-07-16) and never coordinated from the start.
- Fix: new shared `PHOTO_SKYLINE_RADIUS_MULT` constant used by both the skyline placement and the frustum sizing, recomputed from the same real bbox query `_buildPhotoProps()` itself uses (not read off the skyline group, since `_enablePhotoShadows()` runs BEFORE `_buildPhotoProps()` on the very first Alt+S press for a building).
- `sw.js` `CACHE_VERSION` v922 → v923 (effects.js is precached).

## Measured (HHS_Office_Federated)
| | before | after |
|---|---|---|
| envelope | 68.17m | 68.17m |
| frustum half-width (`_env`) | 69m | 180m |
| skyline boxes outside frustum | 36/36 | 0/36 |
| shadow texel density on main building | 14.8 texels/m | 5.7 texels/m (2.6x coarser, ~17.5cm/texel — accepted, no `mapSize` change needed) |

## Test plan
- [x] `witness_photo_skyline_shadow_frustum.js` — RED (pre-fix, via `git stash`) 36/36 boxes outside → FAIL; GREEN (post-fix) 0/36 outside → PASS
- [x] `witness_photo_shadow_skip.js` regression — PASS (reassert skip-gate mechanics unaffected)
- [x] `witness_photo_shadow_finalcapture.js` — times out under this headless-SwiftShader environment identically on baseline (confirmed via stash A/B) — pre-existing environment slowness, not caused by this change
- [x] `node -c viewer/effects.js`, `node -c viewer/sw.js` syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLyi4DXiz3PUCHegrGg8ES