### PR TITLE
fix(cpe): §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE — group sight list by storey, not window unanimity

### DIFF
--- a/viewer/cpe_room_title.js
+++ b/viewer/cpe_room_title.js
@@ -355,9 +355,34 @@ function setupCpeRoomTitle(A) {
   A.roomTitleSightProbe = function(ox, oy, oz, dx, dy, dz) {
     return _sightRoomsAt(ox, oy, oz, dx, dy, dz).map(function(n) { return n.guid; });
   };
+  // §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE (fix, 2026-08-02): a sighted room's OWN name already carries
+  // its storey as a literal prefix (room names are per-storey, e.g. "Level 4 R1") — that is what
+  // the sight-list dedupe below strips. The window's storey UNANIMITY (stSame/stU) is a separate,
+  // stricter test — the CAMERA'S own position resolved consistently across every sample in the
+  // window — and can read false (a window straddling a storey-band edge, one ambiguous sample)
+  // even when every SIGHTED ROOM in it is unambiguously the same level by its own name. Gating the
+  // per-room strip on stSame meant that whenever stSame was false the composed line fell back to
+  // raw, unstripped names and repeated the level prefix once per room — a real regression measured
+  // on the same Hospital film this lane's own witnesses already drive (#1136/#1138 build-session
+  // log): "Level 4 Hall/Corridor 2, Level 4 Hall/Corridor 1, Level 4 R1, Level 4 R4" instead of one
+  // shared "Level 4" heading the list. G-RTG-6/G-RTC-6 assert the fix: a storey prefix appears at
+  // most once per composed line.
+  // Finds which ladder rung (if any) a name's OWN prefix names — extracted against the same ladder
+  // _storeyLadderForGroups already builds (never invented), independent of the window's stSame.
+  // indexOf(...) >= 0, not startsWith: room names carry a leading confidence marker ("≈ Level 4
+  // R1", "⚠ Level 4 R1" — the same friendlyName-produced glyphs _titleFor passes through), same
+  // permissive match the pre-existing `dedupe` above already used for the stSame-unanimous case.
+  function _storeyPrefixOf(nm) {
+    var lad = _storeyLadderForGroups();
+    for (var i = 0; i < lad.length; i++) {
+      if (nm.indexOf(lad[i].name + ' ') >= 0) return lad[i].name;
+    }
+    return null;
+  }
   // The single-line grammar — "Storey · Containment · Rooms a, b" — extracted verbatim from the
   // gap composer so §CPE_ROOM_TITLE_COLLECTIVE's dwell labels use the SAME rules: storey only if
-  // unanimous, containment only if unanimous, sighted rooms deduped of the storey prefix, first
+  // unanimous, containment only if unanimous, sighted rooms deduped of the storey prefix (grouped
+  // by that prefix, not gated on window unanimity — §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE above), first
   // five named and the rest counted, the building alone as the last resort.
   function _lineFrom(stSame, stU, ctSame, ctNode, ctU, sightMap, bldName) {
     var parts = [], keyParts = [], srcCat = null;
@@ -370,17 +395,41 @@ function setupCpeRoomTitle(A) {
       keyParts.push('c:' + ctU); srcCat = 'containment';
       delete sightMap[ctU];
     }
-    var sightNames = [];
+    var sightEntries = [];
     for (var gk in sightMap) {
-      sightNames.push(dedupe(_titleFor(sightMap[gk]).name, stSame ? stU : null));
+      sightEntries.push({ guid: gk, raw: _titleFor(sightMap[gk]).name });
       keyParts.push('r:' + gk);
     }
-    if (sightNames.length) {
+    if (sightEntries.length) {
       // single-line cap: a pull-back can sweep a dozen rooms into one window — name the
       // first five and COUNT the rest, so the line stays readable and nothing is hidden.
-      var shown = sightNames.length > 5
-        ? sightNames.slice(0, 5).join(', ') + ' +' + (sightNames.length - 5) + ' more'
-        : sightNames.join(', ');
+      // Grouping (below) applies AFTER the cap, over exactly the rooms that will be shown.
+      var overflow = sightEntries.length > 5 ? sightEntries.length - 5 : 0;
+      var shownEntries = overflow ? sightEntries.slice(0, 5) : sightEntries;
+      // Group the shown rooms by their OWN storey prefix — computed per room, not assumed from the
+      // window's stSame/stU. A room whose own prefix MATCHES the already-announced top storey (or
+      // has no ladder-matching prefix at all) needs no header of its own: it goes in the shared
+      // LOOSE bucket (bare name only — either already covered by the top announcement, or nothing
+      // to announce, never a guessed one). A room whose own prefix DIFFERS from the top announcement
+      // (including when there is no top announcement at all, stSame false) is grouped with every
+      // other shown room sharing that SAME prefix under one header, stated once — this is what
+      // stops "Level 4 A, Level 4 B, Level 4 C" from repeating: A/B/C land in one "Level 4" group.
+      var LOOSE = ' loose';
+      var groupOrder = [], groups = {};
+      shownEntries.forEach(function(e) {
+        var ownPfx = _storeyPrefixOf(e.raw);
+        var covered = !!(stSame && stU && ownPfx === stU);
+        var header = covered ? null : ownPfx;   // null: covered by top announcement, or no prefix at all
+        var bare = dedupe(e.raw, covered ? stU : ownPfx);
+        var key = header || LOOSE;
+        if (!groups[key]) { groups[key] = { header: header, names: [] }; groupOrder.push(key); }
+        groups[key].names.push(bare);
+      });
+      var sightNames = groupOrder.map(function(key) {
+        var grp = groups[key];
+        return grp.header ? grp.header + ' ' + grp.names.join(', ') : grp.names.join(', ');
+      });
+      var shown = sightNames.join(', ') + (overflow ? ' +' + overflow + ' more' : '');
       parts.push(shown);
       if (srcCat !== 'containment') srcCat = 'sight';
     }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v922';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v923';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_room_title_collective.js
+++ b/witness_cpe_room_title_collective.js
@@ -22,6 +22,19 @@
 //            compositor paints exactly "text [phase]"; with none it paints bare text. Driven
 //            through the REAL roomTitleCompositeOntoCanvas via a capturing ctx stub — not a
 //            re-implementation. RED before the fix: no bracket ever.
+//   G-RTC-6  §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE (fix, 2026-08-02): same invariant as
+//            witness_cpe_room_title_group.js's G-RTG-6, applied to dwell-caption `.label`s (the
+//            SAME _lineFrom grammar composes both) — a shared storey prefix is named ONCE per
+//            composed line, never repeated per room.
+//   G-RTC-7  THE BAKE PATH, NOT INFERRED: cinema_maxq.js's frame loop is a SEPARATE compositing
+//            call site from the live-display caller (`_captureFrame` at cinema_maxq.js:478-491
+//            calls `A.roomTitleOpacityAt(_titleSegs, i/fps)` at :1082, then passes `.name`
+//            UNMODIFIED into `A.roomTitleCompositeOntoCanvas` at :486 — the exact function this
+//            witness already drives for G-RTC-5). Reproduces that EXACT call chain — same two
+//            functions, same argument shapes — across every segment (dwell AND gap-fill) of the
+//            real 147.9s Hospital film and asserts the text actually painted onto the captured-
+//            frame canvas carries no repeated storey prefix. Proves the bake's EXPORTED bytes, not
+//            just the segment builder.
 // RUN: node witness_cpe_room_title_collective.js
 'use strict';
 const http = require('http'), fs = require('fs'), path = require('path');
@@ -82,17 +95,29 @@ const _watchdog = setTimeout(() => { console.log('\n§W-RTC TIMEOUT — killed a
       // G-RTC-1: every dwell caption composed
       out.labelled = rooms.filter(s => typeof s.label === 'string' && s.label.length > 0).length;
       out.sample = rooms.slice(0, 5).map(s => ({ name: s.name, label: s.label }));
-      // G-RTC-2: own room in its own line — the bare title, or its storey-deduped tail, must
-      // appear in the label (the grammar strips a unanimous storey prefix from room names).
+      // Storey ladder, fetched once — used by G-RTC-2 (own-room presence, mirroring the grammar's
+      // per-room dedupe) and G-RTC-6 (level-consolidate invariant) below.
+      const ladder = A.dbQuery(
+        "SELECT m.storey, AVG(COALESCE(t.center_z,0)) FROM elements_meta m " +
+        "JOIN element_transforms t ON t.guid=m.guid " +
+        "WHERE m.storey IS NOT NULL AND m.storey NOT IN ('','_UNKNOWN','Unknown') GROUP BY m.storey")
+        .map(r => ({ name: String(r[0]), z: +r[1] }));
+      // G-RTC-2: own room in its own line — the bare title, with ANY ladder-matching storey
+      // prefix it carries stripped, must appear in the label. §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE
+      // groups the sight list by each room's OWN embedded prefix (not only the window's announced
+      // top storey — a mixed-storey sight or an unannounced window still strips per-room), so the
+      // check mirrors THAT: try stripping every ladder name the room's own raw text contains,
+      // not just the label's first ' · ' segment.
       out.ownRoomMissing = [];
       for (const s of rooms) {
         if (!s.label) continue;
-        // Mirror the grammar's own dedupe: a unanimous storey (the label's FIRST part) is
-        // stripped from inside room names — "⚠ Level 1 R11" renders as "⚠ R11" under "Level 1".
-        const first = s.label.split(' · ')[0];
-        const dedup = s.name.replace(first + ' ', '');
-        if (s.label.indexOf(s.name) < 0 && s.label.indexOf(dedup) < 0)
-          out.ownRoomMissing.push({ name: s.name, label: s.label });
+        if (s.label.indexOf(s.name) >= 0) continue;
+        let found = false;
+        for (const L of ladder) {
+          const dedup = s.name.replace(L.name + ' ', '');
+          if (dedup !== s.name && s.label.indexOf(dedup) >= 0) { found = true; break; }
+        }
+        if (!found) out.ownRoomMissing.push({ name: s.name, label: s.label });
       }
       // G-RTC-3: bare names survive; deterministic double build agrees on identity+times+name
       out.nameHasDot = rooms.filter(s => s.name.indexOf(' · ') >= 0).length;
@@ -120,6 +145,49 @@ const _watchdog = setTimeout(() => { console.log('\n§W-RTC TIMEOUT — killed a
       A.tmFrontierPhase = prevPhase == null ? null : prevPhase;
       out.painted = painted;
       out.pure = [A.roomTitleFinalText && A.roomTitleFinalText('X') === 'X'];
+      // G-RTC-6: no ladder storey prefix repeats inside one dwell-caption label (ladder fetched above).
+      const repeats = [];
+      for (const s of rooms) {
+        if (!s.label) continue;
+        for (const L of ladder) {
+          const token = L.name + ' ';
+          let count = 0, idx = -1;
+          while ((idx = s.label.indexOf(token, idx + 1)) !== -1) count++;
+          if (count > 1) repeats.push({ label: s.label, storey: L.name, count });
+        }
+      }
+      out.levelRepeats = repeats;
+      // G-RTC-7: THE BAKE PATH — reproduce cinema_maxq.js's exact frame-loop chain (`_captureFrame`
+      // :478-491, driven from :1082/:486) rather than inferring it shares the live path. `segs`
+      // here IS what `_titleSegs = A.roomTitleBuildTimeline(plan, nFrames/fps)` (:1015) holds —
+      // both dwell AND gap-fill segments, unfiltered, same as the bake samples per-frame. For every
+      // segment's midpoint, call `A.roomTitleOpacityAt(segs, t)` (the SAME function+args as :1082)
+      // and feed `.name` into the SAME `A.roomTitleCompositeOntoCanvas` (:486) via a capturing
+      // stub — the exact two-call chain that reaches the exported frame bytes.
+      const bakeStub = { save() {}, restore() {}, fillRect() {}, fillText(t) { bakePainted.push(t); },
+                         set globalAlpha(v) {}, set fillStyle(v) {}, set font(v) {},
+                         set textAlign(v) {}, set textBaseline(v) {} };
+      var bakePainted = [];
+      const bakeRepeats = [];
+      for (const s of segs) {
+        const mid = (s.tStart + s.tEnd) / 2;
+        const info = A.roomTitleOpacityAt(segs, mid);          // exact call cinema_maxq.js:1082 makes
+        if (!info || !(info.opacity > 0)) continue;
+        const before = bakePainted.length;
+        A.roomTitleCompositeOntoCanvas(bakeStub, 1852, 960, info.name, info.opacity); // exact call :486 makes
+        for (let bi = before; bi < bakePainted.length; bi++) {
+          const txt = bakePainted[bi];
+          for (const L of ladder) {
+            const token = L.name + ' ';
+            let count = 0, idx = -1;
+            while ((idx = txt.indexOf(token, idx + 1)) !== -1) count++;
+            if (count > 1) bakeRepeats.push({ segGuid: s.guid, painted: txt, storey: L.name, count });
+          }
+        }
+      }
+      out.bakeFramesChecked = segs.length;
+      out.bakePaintedSample = bakePainted.slice(0, 3);
+      out.bakeLevelRepeats = bakeRepeats;
     } catch (e) { out.err = String(e && e.message) + '\n' + String(e && e.stack).slice(0, 400); }
     return out;
   });
@@ -145,6 +213,16 @@ const _watchdog = setTimeout(() => { console.log('\n§W-RTC TIMEOUT — killed a
     res.painted[0] === 'Level 1 · Corridor · Rooms 2, 3 [MEP Rough in]' &&
     res.painted[1] === 'Level 1 · Corridor · Rooms 2, 3',
     JSON.stringify(res.painted));
+  P('G-RTC-6 a shared storey prefix is named ONCE per dwell-caption label, never repeated per room',
+    res.levelRepeats.length === 0,
+    `${res.levelRepeats.length} repeats` +
+    (res.levelRepeats.length ? ' ' + JSON.stringify(res.levelRepeats.slice(0, 4)) : ''));
+  P('G-RTC-7 THE BAKE PATH: cinema_maxq.js\'s exact roomTitleOpacityAt->roomTitleCompositeOntoCanvas ' +
+    'chain paints no repeated storey prefix onto the captured-frame canvas',
+    res.bakeLevelRepeats.length === 0,
+    `${res.bakeFramesChecked} segments driven through the bake chain, ${res.bakeLevelRepeats.length} repeats; ` +
+    `sample painted: ${JSON.stringify(res.bakePaintedSample)}` +
+    (res.bakeLevelRepeats.length ? ' ' + JSON.stringify(res.bakeLevelRepeats.slice(0, 4)) : ''));
   const cl = logs.find(l => l.includes('§CPE_ROOM_TITLE_COLLECTIVE'));
   console.log('  instrument: ' + (cl || 'NO §CPE_ROOM_TITLE_COLLECTIVE LINE'));
   all = all && !!cl;

--- a/witness_cpe_room_title_group.js
+++ b/witness_cpe_room_title_group.js
@@ -16,6 +16,15 @@
 //            containment key resolves to the room the camera is inside.
 //   G-RTG-4  TEMPERED: every group segment holds ≥ MIN_HOLD (3s) — no fast flashing.
 //   G-RTG-5  single line, and the instrument reports (§CPE_ROOM_TITLE_GROUP line with coverage).
+//   G-RTG-6  §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE (fix, 2026-08-02): a shared storey prefix must be
+//            named ONCE in a composed line, never repeated per room. Real defect measured on this
+//            same Hospital film (#1136/#1138 build session witness log): a window whose sighted
+//            rooms all read "Level 4 ..." rendered "Level 4 Hall/Corridor 2, Level 4 Hall/Corridor
+//            1, Level 4 R1, Level 4 R4" — the prefix repeated four times — because the per-room
+//            dedupe only fired when the WINDOW's camera-position storey test (stSame) was
+//            unanimous, a stricter and independent test from "do the sighted rooms themselves
+//            share a level". For every ladder storey name, its "<name> " substring must occur at
+//            most once in any composed line.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8443;
@@ -115,6 +124,17 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         }
       }
       out.honesty = { checked, bad: bad.slice(0, 4), nBad: bad.length };
+      // G-RTG-6: no ladder storey prefix repeats inside one composed line.
+      const repeats = [];
+      for (const g of groups) {
+        for (const L of ladder) {
+          const token = L.name + ' ';
+          let count = 0, idx = -1;
+          while ((idx = g.name.indexOf(token, idx + 1)) !== -1) count++;
+          if (count > 1) repeats.push({ name: g.name, storey: L.name, count });
+        }
+      }
+      out.levelRepeats = repeats;
     } catch (e) { out.err = String(e && e.message); }
     return out;
   });
@@ -142,6 +162,10 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     res.multiline === 0 && !!glog,
     `multiline=${res.multiline}; sample: ${JSON.stringify(res.sampleNames.slice(0, 3))}; ` +
     (glog ? glog.slice(0, 160) : 'NO §CPE_ROOM_TITLE_GROUP line'));
+  P('G-RTG-6 a shared storey prefix is named ONCE per composed line, never repeated per room',
+    res.levelRepeats.length === 0,
+    `${res.levelRepeats.length} repeats` +
+    (res.levelRepeats.length ? ' ' + JSON.stringify(res.levelRepeats.slice(0, 4)) : ''));
 
   console.log(all ? 'ALL GATES PASS' : 'GATES FAILED');
   await browser.close();


### PR DESCRIPTION
## Summary
- Real Hospital-bake evidence (via the same `A.roomTitleBuildTimeline`/`roomTitleOpacityAt` functions #1136/#1138 already witness): multi-room captions on one storey were NOT consolidating the shared level prefix — e.g. `"Level 4 Hall/Corridor 2, Level 4 Hall/Corridor 1, Level 4 R1, Level 4 R4"` instead of one shared `"Level 4"` heading the list.
- Root cause: `_lineFrom`'s sight-list dedupe (`viewer/cpe_room_title.js`) only stripped a room's own embedded storey prefix when the *window's* camera-position storey test (`stSame`/`stU`) was unanimous — a stricter, separate test from "do the sighted rooms themselves share a level." Whenever `stSame` was false, nothing stripped and the prefix repeated once per room.
- Fix: group the sight list by each room's OWN storey prefix (extracted from the same ladder `_storeyLadderForGroups` already builds), independent of `stSame`. Applies identically to the gap-fill composer and the §CPE_ROOM_TITLE_COLLECTIVE dwell-caption composer (both call the same `_lineFrom`), and to the bake path (`cinema_maxq.js`'s `_captureFrame` calls the exact same `roomTitleOpacityAt`→`roomTitleCompositeOntoCanvas` chain — verified end-to-end, not inferred).

## Witnesses (RED before, GREEN after, real Hospital data)
- `witness_cpe_room_title_group.js` **G-RTG-6** (new): no ladder storey prefix repeats in a composed gap-fill line. RED: 3 repeats (counts 4/2/2). GREEN: 0 repeats. G-RTG-1/2/4/5 stay green; G-RTG-3/coverage numbers show pre-existing run-to-run bake-timing flakiness confirmed present on unmodified `main` too under current machine load (unrelated to this fix — the invariant under test, G-RTG-6, is 6/6 green across repeated runs).
- `witness_cpe_room_title_collective.js` **G-RTC-6** (new): same invariant for dwell-caption `.label`. RED: 15 repeats. GREEN: 0 repeats.
- `witness_cpe_room_title_collective.js` **G-RTC-7** (new): drives the *exact* bake-path chain (`roomTitleOpacityAt`→`roomTitleCompositeOntoCanvas`, the same two calls `cinema_maxq.js`'s `_captureFrame` makes) across every segment of the real film and asserts the painted canvas text has no repeated prefix. RED: 18 repeats. GREEN: 0 repeats.
- Regressions green: G-RTC-1..5, `witness_cpe_room_title_multi.js`, `witness_cpe_room_title_height.js`, `witness_cpe_room_title_lead.js`, `witness_cpe_room_title_hold.js`.
- Day-counter default-visibility question (raised alongside this bug): confirmed via code (`cinema_path_editor.js:1722-1726`, `cinema_maxq.js:1042/1056-1066`) + the existing `witness_cpe_day_counter.js` (17/17 green, T3 proves it reaches exported canvas bytes) that the day counter already defaults to VISIBLE (top-right) the instant the `#cpe-buildup` checkbox is on — no code change needed there. No feature-behavior change made for that item; recorded as a separate open note in the spec file.

## sw.js
`CACHE_VERSION` v922 → v923.

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md` §CPE_ROOM_TITLE_LEVEL_CONSOLIDATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)