### PR TITLE
fix(cpe): §CPE_BUILDUP_DEFAULT_ON — build-as-it-plays defaults ON, sw v925

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -634,7 +634,7 @@
           '<button id="cpe-mark-in" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">mark in</button> ' +
           '<button id="cpe-mark-out" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">mark out</button> ' +
           '<button id="cpe-clip-clear" style="padding:1px 6px;font-size:10px;background:#2a2e34;color:#888;border:1px solid #4a4f57;border-radius:3px;cursor:pointer">whole film</button></div>' +
-        '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox"> ' +
+        '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox" checked> ' +
           'build the model as the film plays</label> <span style="color:#666">(follows the Time Machine, not a programme)</span></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-room-title" type="checkbox"> ' +
           'room titles</label> <span style="color:#666">(name card as the camera enters each room)</span></div>' +
@@ -1796,9 +1796,12 @@
         hose: [], reach: 0.15, flowRaw: null, flowFrac: null, flowHosed: null,
         // §CPE_CLIP: the whole film until marked.
         clipIn: 0, clipOut: 1,
-        // §CPE_BUILDUP: off by default — a film that assembles itself is a deliberate choice, not
-        // the default reading of a fly-through.
-        buildup: false,
+        // §CPE_BUILDUP_DEFAULT_ON (2026-08-02, user ruling — reverses the original "off by
+        // default" call below): ON by default — build-as-it-plays is the expected reading now,
+        // not a deliberate opt-in. A fresh session's checkbox and _state must agree (HTML
+        // `checked` attribute at the render site above) or the panel would show checked while
+        // the first bake silently ran unbuilt.
+        buildup: true,
         // §CPE_ROOM_TITLE: off by default, same reasoning — a captioned film is a deliberate choice
         // (RESUME_CPE_ROOM_TITLE.md).
         roomTitle: false,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v924';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v925';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_buildup_default_on.js
+++ b/witness_cpe_buildup_default_on.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// § CPE_BUILDUP_DEFAULT_ON — witness: a fresh Cinema Path Editor session must open with the
+// "build the model as the film plays" checkbox CHECKED and _state.buildup seeded true, not the
+// old opt-in default. Static source-assertion (deterministic, no browser needed for this claim):
+// both the checkbox's rendered HTML and the _state initializer must agree, or the panel would
+// show checked while the underlying state (and therefore the first bake) stayed unbuilt.
+const fs = require('fs');
+const path = require('path');
+const SRC = fs.readFileSync(path.join(__dirname, 'viewer/cinema_path_editor.js'), 'utf8');
+
+let pass = true;
+function P(name, ok, detail) {
+  console.log('§CPE_BUILDUP_DEFAULT ' + name + ' = ' + (ok ? 'PASS' : 'FAIL') + (detail ? ' — ' + detail : ''));
+  if (!ok) pass = false;
+}
+
+// G-BD-1: the checkbox markup carries the `checked` attribute.
+const checkboxMatch = SRC.match(/<input id="cpe-buildup" type="checkbox"([^>]*)>/);
+P('G-BD-1 checkbox has checked attribute',
+  !!checkboxMatch && /\bchecked\b/.test(checkboxMatch[1]),
+  checkboxMatch ? ('found tag: <input id="cpe-buildup" type="checkbox"' + checkboxMatch[1] + '>') : 'checkbox markup not found');
+
+// G-BD-2: the fresh-session _state initializer seeds buildup: true, not false.
+const stateInitMatch = SRC.match(/_state\s*=\s*\{[\s\S]*?\bbuildup:\s*(true|false)\s*,/);
+P('G-BD-2 _state initializer seeds buildup:true',
+  !!stateInitMatch && stateInitMatch[1] === 'true',
+  stateInitMatch ? ('found: buildup: ' + stateInitMatch[1]) : '_state initializer buildup field not found');
+
+// G-BD-3: restoring an EXISTING saved plan still honours whatever that plan actually saved
+// (ov.buildup) rather than being forced true — this default only governs a FRESH session.
+const restoreMatch = SRC.match(/_state\.buildup\s*=\s*!!ov\.buildup;/);
+P('G-BD-3 saved-plan restore still reads the plan\'s own value (not forced)',
+  !!restoreMatch, restoreMatch ? 'found: _state.buildup = !!ov.buildup;' : 'restore assignment not found — check it was not accidentally changed');
+
+console.log('§CPE_BUILDUP_DEFAULT_VERDICT ' + (pass ? 'PASS' : 'FAIL'));
+process.exit(pass ? 0 : 1);


### PR DESCRIPTION
User ruling: build-as-it-plays should be the default reading of a fresh Cinema Path Editor session, not opt-in. Reverses the original §CPE_BUILDUP "off by default" decision (`_state.buildup: false` → `true`, checkbox gets `checked`).

Saved-plan restore (`_state.buildup = !!ov.buildup`) is untouched — this only changes what a *fresh* session starts with.

Witness `witness_cpe_buildup_default_on.js`: RED (2/3 fail on pre-fix) → GREEN (3/3). Regression-checked: stagger-support-order, x-ray-staging, room-title-collective all green.

sw.js v924→v925.