### PR TITLE
feat(cpe): §CPE_MAXQ_STATUS_DAY_LABEL — MaxQ bake HUD shows live Day # and room label

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -294,6 +294,23 @@
   function _sleep(ms) { return new Promise(function(res) { setTimeout(res, ms); }); }
   function _status(t) { var A = window.APP; if (A && A.status) A.status.textContent = t; }
 
+  // §CPE_MAXQ_STATUS_DAY_LABEL (CINEMA_PATH_EDITOR.md) — Day # and current room label, appended
+  // to the same per-frame status line §CPE_STICK_APPROACH already writes to. Pure and exposed on
+  // APP below (same treatment as `A.dayCounterAt`/`A.roomTitleOpacityAt` themselves) so the
+  // witness can gate this exact composition without spinning up a live bake — `dayInfo`/
+  // `titleInfo` are exactly the objects the per-frame loop already computed for the canvas-
+  // compositing path (_captureFrame), this function only formats them into the two extra
+  // status-line segments. Nothing is recomputed: `dayInfo` null means the day-counter is off for
+  // this bake (§CPE_DAY_COUNTER, `_dayPos === 'off'`); `titleInfo`/`titleInfo.name` null/empty
+  // means §CPE_ROOM_TITLE is off or the walk is between rooms (no active caption) — both segments
+  // are omitted entirely rather than ever printing "Day null/null" or empty quotes.
+  function _maxqStatusDayRoomSegs(dayInfo, titleInfo) {
+    var dayTxt = (dayInfo && dayInfo.day != null && dayInfo.totalDays != null)
+      ? ', Day ' + dayInfo.day + '/' + dayInfo.totalDays : '';
+    var roomTxt = (titleInfo && titleInfo.name) ? ', "' + titleInfo.name + '"' : '';
+    return { dayTxt: dayTxt, roomTxt: roomTxt };
+  }
+
   // §CINEMA_DAMPING_BLEED (2026-07-26 — PHOTOREAL_STILL_RENDER.md §CINEMA_DAMPING_BLEED).
   // Both authored loops below (the 10s path preview AND the frame bake) do
   // camera.position.set(pose) → controls.update(). OrbitControls.update() recomputes the position
@@ -1138,8 +1155,13 @@
         // (falls back to the pre-feature text) when the path has no user-dropped sticks or the walk
         // is already past the last one.
         var _stickTxt = _stickNow ? ', approaching Stick ' + _stickNow.index + '/' + _stickNow.count : '';
+        // §CPE_MAXQ_STATUS_DAY_LABEL — Day # and current room label, same per-frame cadence as the
+        // stick-approach text above. `_dayInfo`/`_titleInfo` are already computed earlier THIS
+        // frame for the canvas-compositing path (_captureFrame, above) — this reads the SAME
+        // values through the pure, witnessed formatter, nothing is recomputed here.
+        var _segs = _maxqStatusDayRoomSegs(_dayInfo, _titleInfo);
         _status('🎬 MaxQ frame ' + (i + 1) + '/' + nFrames + ' — ' + Math.round(_el / 1000) + 's, ~' +
-          _etaTxt + _stickTxt + ' (Alt+C / cinema icon cancels + saves partial)');
+          _etaTxt + _segs.dayTxt + _segs.roomTxt + _stickTxt + ' (Alt+C / cinema icon cancels + saves partial)');
         if (_etaNow - _logPrev >= MAXQ_LOG_MS || i === 0 || i === nFrames - 1) {
           _logPrev = _etaNow;
           console.log('§MAXQ_FRAME i=' + i + '/' + nFrames + ' elapsedMs=' + Math.round(_el) +
@@ -1245,6 +1267,9 @@
       window.APP.ghostGroundArm = _ghostGroundArm;
       window.APP.ghostGroundAt = _ghostGroundAt;
       window.APP.ghostGroundRestore = _ghostGroundRestore;
+      // §CPE_MAXQ_STATUS_DAY_LABEL — exposed for the witness (gates the pure formatter directly,
+      // same precedent as the other pure functions on this line, instead of sitting through a bake).
+      window.APP.maxqStatusDayRoomSegs = _maxqStatusDayRoomSegs;
       clearInterval(_attach);
     }
   }, 500);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v925';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v926';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_maxq_status_day_label.js
+++ b/witness_cpe_maxq_status_day_label.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * §CPE_MAXQ_STATUS_DAY_LABEL witness — prompts/CINEMA_PATH_EDITOR.md §CPE_MAXQ_STATUS_DAY_LABEL.
+ *
+ * THE FEATURE: cinema_maxq.js's per-frame bake status line (the same site §CPE_STICK_APPROACH's
+ * "approaching Stick k/N" clause lives on) now also carries the current Day # and room label —
+ * "Day 42/214" and "Level 2 R3" — read from `_dayInfo`/`_titleInfo`, the SAME objects the loop
+ * already computes every frame for the canvas-compositing path (_captureFrame). Nothing new is
+ * computed; `window.APP.maxqStatusDayRoomSegs(dayInfo, titleInfo)` is the pure formatter the loop
+ * calls, exposed for direct gating (same precedent as `A.dayCounterAt`/`A.roomTitleOpacityAt`
+ * themselves — pure functions tested without sitting through a live bake).
+ *
+ * THE ISSUES THIS PROVES OR DISPROVES (a test that names neither is not a test):
+ *  G-DRL-1  Day # on: at a few checkpoints (day 1, mid-span, last day) the segment reads exactly
+ *           ", Day <day>/<totalDays>" off the SAME dayInfo the day-counter itself would draw —
+ *           no re-derivation, no off-by-one.
+ *  G-DRL-2  Day # off: dayInfo === null (the day-counter disabled for this bake, `_dayPos ===
+ *           'off'`) produces an EMPTY day segment — never "Day null/null" or "Day undefined/...".
+ *  G-DRL-3  Room label present: titleInfo.name set produces exactly ', "<name>"' — quoted, comma-
+ *           led, matching the spec's own worked example.
+ *  G-DRL-4  Room label absent (§CPE_ROOM_TITLE off, or titleInfo itself null): empty segment.
+ *  G-DRL-5  Room label gap: titleInfo is a real (non-null) object but between rooms it carries no
+ *           name (opacity fade with no active caption) — still an empty segment, not blank quotes
+ *           (`', ""'`). This is the "gap" case named in the task: a present-but-empty titleInfo
+ *           must be told apart from an absent one, and both must produce nothing.
+ *  G-DRL-6  A short multi-frame sequence (day counter on throughout, room label on/gap/on/off)
+ *           mirrors the per-frame loop's actual cadence — proving the segments track frame-to-
+ *           frame instead of only working in isolation, exactly the "updates across frames
+ *           including a gap" the task asks for.
+ *  G-DRL-7  Composition order: when both segments are present, Day comes before the room label in
+ *           the assembled string (the spec's own example: "Day 42/214, "Level 2 R3", approaching
+ *           Stick 4/9") — proven by building the exact status line the bake loop builds and
+ *           checking substring order, not just presence.
+ * RUN: node witness_cpe_maxq_status_day_label.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+// A fresh worktree has no buildings/*.db (gitignored — DB CHANGES = MIGRATION SCRIPT, binaries
+// never enter git). Serve code from the WORKTREE (the code under test), DB assets from the
+// primary checkout. Deliberately NOT a symlink into the worktree (feedback_never_symlink_into_repo_worktree).
+const FALLBACK_ROOT = '/home/red1/bim-ootb';
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    const send = (b) => { r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); r.end(b); };
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (!e) return send(b);
+      const alt = p.replace(/^\/viewer\//, '/');
+      fs.readFile(path.join(FALLBACK_ROOT, p), (e2, b2) => {
+        if (!e2) return send(b2);
+        fs.readFile(path.join(FALLBACK_ROOT, alt), (e3, b3) => { if (e3) { r.writeHead(404); r.end('404'); return; } send(b3); });
+      });
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-MAXQ-DRL TIMEOUT — killed after 90s'); process.exit(3); }, 90000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  pg.on('console', m => { const t = m.text(); if (t.indexOf('§CPE_MAXQ_STATUS_DAY_LABEL') === 0) console.log('   log: ' + t); });
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera', { timeout: 45000 });
+  // ⚠ main.js runs its module list AFTER setupScene resolves — APP.camera existing does not mean
+  // cinema_maxq.js's deferred _attach interval has fired yet (feedback_verify_checker_before_code_under_test).
+  await pg.waitForFunction('typeof window.APP.maxqStatusDayRoomSegs === "function"', { timeout: 30000 }).catch(() => {});
+
+  const armed = await pg.evaluate(() => typeof window.APP.maxqStatusDayRoomSegs === 'function');
+  chk('T0 module loaded (maxqStatusDayRoomSegs exposed on APP)', armed);
+  if (!armed) { clearTimeout(_watchdog); await br.close(); server.close(); console.log('\n§W-MAXQ-DRL 0/... module absent'); process.exit(1); }
+
+  const r = await pg.evaluate(() => {
+    const A = window.APP;
+    const out = {};
+
+    // ── G-DRL-1: Day # on, at a few checkpoints, off the SAME dayInfo shape A.dayCounterAt returns.
+    out.dayStart = A.maxqStatusDayRoomSegs({ day: 1, totalDays: 214 }, null);
+    out.dayMid   = A.maxqStatusDayRoomSegs({ day: 42, totalDays: 214 }, null);
+    out.dayLast  = A.maxqStatusDayRoomSegs({ day: 214, totalDays: 214 }, null);
+
+    // ── G-DRL-2: Day # off — dayInfo is null (the real value the loop carries when _dayPos==='off'
+    // or there is no buildup span).
+    out.dayOff = A.maxqStatusDayRoomSegs(null, null);
+
+    // ── G-DRL-3: room label present — the shape A.roomTitleOpacityAt actually returns: {name, guid, opacity}.
+    out.roomPresent = A.maxqStatusDayRoomSegs(null, { name: 'Level 2 R3', guid: 'g1', opacity: 1 });
+
+    // ── G-DRL-4: room label absent — titleInfo itself is null (§CPE_ROOM_TITLE off, or roomTitleOpacityAt
+    // found no segment covering this frame at all).
+    out.roomAbsentNull = A.maxqStatusDayRoomSegs(null, null);
+
+    // ── G-DRL-5: the GAP case — titleInfo is a real, non-null object (as it would be mid-crossfade)
+    // but carries no name. Must still produce nothing, never ', ""'.
+    out.roomGapEmptyName = A.maxqStatusDayRoomSegs(null, { name: '', guid: null, opacity: 0 });
+    out.roomGapNullName  = A.maxqStatusDayRoomSegs(null, { name: null, guid: null, opacity: 0 });
+
+    // ── G-DRL-6: a short multi-frame sequence, day-counter ON throughout, room label
+    // on -> gap -> on(different room) -> off(§CPE_ROOM_TITLE disabled entirely), mirroring the
+    // loop's real per-frame cadence.
+    const frames = [
+      { day: { day: 10, totalDays: 214 }, title: { name: 'Level 1 Kitchen', opacity: 1 } },
+      { day: { day: 11, totalDays: 214 }, title: null },                                    // gap: between rooms
+      { day: { day: 12, totalDays: 214 }, title: { name: 'Level 1 Hallway', opacity: 0.6 } },
+      { day: { day: 13, totalDays: 214 }, title: null },                                    // §CPE_ROOM_TITLE off / gap again
+    ];
+    out.sequence = frames.map(f => A.maxqStatusDayRoomSegs(f.day, f.title));
+
+    // ── G-DRL-7: composition order — build the EXACT status line shape the bake loop assembles
+    // (frame/eta segment + dayTxt + roomTxt + stickTxt + trailing paren), both present.
+    const segs = A.maxqStatusDayRoomSegs({ day: 42, totalDays: 214 }, { name: 'Level 2 R3', opacity: 1 });
+    const stickTxt = ', approaching Stick 4/9';
+    out.composedLine = '🎬 MaxQ frame 342/576 — 210s, ~45s left' + segs.dayTxt + segs.roomTxt + stickTxt +
+      ' (Alt+C / cinema icon cancels + saves partial)';
+
+    console.log('§CPE_MAXQ_STATUS_DAY_LABEL composed="' + out.composedLine + '"');
+    return out;
+  });
+
+  // ── G-DRL-1 ──────────────────────────────────────────────────────────────────────────────────
+  chk('G-DRL-1a Day 1/214 (project start)', r.dayStart.dayTxt === ', Day 1/214', JSON.stringify(r.dayStart));
+  chk('G-DRL-1b Day 42/214 (mid-span)', r.dayMid.dayTxt === ', Day 42/214', JSON.stringify(r.dayMid));
+  chk('G-DRL-1c Day 214/214 (last day, no totalDays+1 off-by-one)', r.dayLast.dayTxt === ', Day 214/214', JSON.stringify(r.dayLast));
+
+  // ── G-DRL-2 ──────────────────────────────────────────────────────────────────────────────────
+  chk('G-DRL-2 day-counter off (dayInfo=null) omits the Day segment entirely (never "Day null/null")',
+    r.dayOff.dayTxt === '', JSON.stringify(r.dayOff));
+
+  // ── G-DRL-3 ──────────────────────────────────────────────────────────────────────────────────
+  chk('G-DRL-3 room label present reads exactly \', "Level 2 R3"\'',
+    r.roomPresent.roomTxt === ', "Level 2 R3"', JSON.stringify(r.roomPresent));
+
+  // ── G-DRL-4 ──────────────────────────────────────────────────────────────────────────────────
+  chk('G-DRL-4 room label absent (titleInfo=null) omits the segment entirely',
+    r.roomAbsentNull.roomTxt === '', JSON.stringify(r.roomAbsentNull));
+
+  // ── G-DRL-5 ──────────────────────────────────────────────────────────────────────────────────
+  chk('G-DRL-5a gap with empty name omits the segment (never \', ""\')',
+    r.roomGapEmptyName.roomTxt === '', JSON.stringify(r.roomGapEmptyName));
+  chk('G-DRL-5b gap with null name omits the segment', r.roomGapNullName.roomTxt === '', JSON.stringify(r.roomGapNullName));
+
+  // ── G-DRL-6 ──────────────────────────────────────────────────────────────────────────────────
+  const seq = r.sequence;
+  const seqOK =
+    seq[0].dayTxt === ', Day 10/214' && seq[0].roomTxt === ', "Level 1 Kitchen"' &&
+    seq[1].dayTxt === ', Day 11/214' && seq[1].roomTxt === '' &&                     // the gap frame
+    seq[2].dayTxt === ', Day 12/214' && seq[2].roomTxt === ', "Level 1 Hallway"' &&  // recovers on the next room
+    seq[3].dayTxt === ', Day 13/214' && seq[3].roomTxt === '';                       // stays empty, not stale
+  chk('G-DRL-6 4-frame sequence tracks day+room per frame, gap frames omit the room segment (not stale/blank)',
+    seqOK, JSON.stringify(seq));
+
+  // ── G-DRL-7 ──────────────────────────────────────────────────────────────────────────────────
+  const line = r.composedLine;
+  const dayIdx = line.indexOf('Day 42/214'), roomIdx = line.indexOf('"Level 2 R3"'), stickIdx = line.indexOf('approaching Stick 4/9');
+  chk('G-DRL-7 composed line carries Day, then room label, then stick-approach, in that order',
+    dayIdx > -1 && roomIdx > dayIdx && stickIdx > roomIdx, line);
+
+  clearTimeout(_watchdog);
+  await br.close(); server.close();
+  console.log('\n§W-MAXQ-DRL ' + pass + '/' + (pass + fail) + (fail ? ' — FAIL' : ' — all green'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { clearTimeout(_watchdog); console.error('§W-MAXQ-DRL ERROR ' + e.message); process.exit(2); });


### PR DESCRIPTION
## Summary
- Extends the §CPE_STICK_APPROACH bake status line (PR #1143) with two more live values while a MaxQ bake is running: current **Day #** and current **room label**.
- Reads the SAME per-frame objects already computed for canvas compositing (`_dayInfo`/`_titleInfo` in `viewer/cinema_maxq.js`'s per-frame loop) — nothing is recomputed. New pure formatter `window.APP.maxqStatusDayRoomSegs(dayInfo, titleInfo)` composes the two extra segments, exposed the same way `dayCounterAt`/`roomTitleOpacityAt` already are so it can be witnessed directly without a live bake.
- Day segment omitted entirely when the day-counter is off (`dayInfo` null). Room segment omitted entirely between rooms / when §CPE_ROOM_TITLE is off (`titleInfo` null or `titleInfo.name` falsy) — never "Day null/null" or blank quotes.
- Export/compositing path (`_captureFrame`, `roomTitleCompositeOntoCanvas`, `dayCounterCompositeOntoCanvas`) untouched — this is status-bar text only.
- `sw.js` `CACHE_VERSION` bumped v925 → v926.

Before: `🎬 MaxQ frame 342/576 — 210s, ~45s left, approaching Stick 4/9 (Alt+C / cinema icon cancels + saves partial)`
After: `🎬 MaxQ frame 342/576 — 210s, ~45s left, Day 42/214, "Level 2 R3", approaching Stick 4/9 (Alt+C / cinema icon cancels + saves partial)`

## Test plan
- [x] New witness `witness_cpe_maxq_status_day_label.js`: 11/11 GREEN (RED confirmed pre-fix — module absent).
- [x] Regression: `witness_cpe_stick_approach.js` 7/7 GREEN
- [x] Regression: `witness_cpe_day_counter.js` 17/17 GREEN
- [x] Regression: `witness_cpe_room_title_collective.js` all green
- [x] `node -c` syntax check on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLyi4DXiz3PUCHegrGg8ES