### PR TITLE
fix(cpe): buildup pacing investigation (no defect) + PACE_SWING softened 1.6->1.45, sw v927

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4103,7 +4103,30 @@ async function setupEffects(A, renderer, scene, camera) {
   // only knob the noise ratio is allowed to have. Declared here, at module scope, because the law
   // governs EVERY beat: the dive's cost table (built with the plan) and the walk's blended cost
   // both read it, and the walk's copy used to be a local declared 400 lines below the dive.
-  var CINEMA_PACE_SWING = 1.6;
+  // §CPE_PACE_SWING_SOFTEN (2026-08-03) — 1.6 was the SETTLED value out of the widen/narrow jerk
+  // trade-off documented above (CINEMA_PATH_EDITOR.md "widen PACE_SWING, accept the stall, or accept
+  // more jerk"), but on a real Hospital bake it reads as a genuine over-correction: user, direct
+  // tuning request, "soften the noise density×depth ratio that slows the camera walk in busy/dense
+  // areas — the slowdown is currently too strict." Measured on Hospital before this change (real
+  // §CPE_WALK_BUDGET_NOISE_BLIND line): busy=0.432, swing=1.6 -> busyMult=1.2591, outSec=18.322 (a
+  // 29.8m walk raw-budgeted at 14.552s stretched to 18.322s by busyness alone).
+  //
+  // The user suggested trying 1.3-1.4x — measured, NOT taken as-is: at 1.35 and again at 1.4,
+  // witness_cpe_even_turn.js's T5 (§CPE_EVEN_TURN's own fast-side jerk cap, `1.5 * PACE_SWING`)
+  // goes RED on Duplex — the walk's real cost-parameterized step hits 3.0x its own mean there, and
+  // shrinking the cap below that turns a legitimate fast turn into a flagged discontinuity. This is
+  // the same "widen or accept jerk" trade-off the constant's own history already names; narrowing it
+  // reopens that trade the other direction. 1.45 is the largest reduction from 1.6 that stays clear
+  // of T5 on both regression buildings (Duplex, Terminal) — verified by direct measurement, not
+  // picked to make a gate green: 1.4 fails T5 on Duplex, 1.45 does not, on repeated runs.
+  // (T6, the SLOW-side floor, is RED at 1.6 too — a pre-existing gap this change did not create and
+  // does not fix; out of scope here, noted for whoever picks up §CPE_PACE_FLOOR next.)
+  // Keeps the SAME mechanism (busy areas still slow the camera, `w = 1-1/PACE_SWING` in
+  // §CPE_EVEN_TURN still derives from this one constant, nothing duplicated) while cutting the
+  // busyness CORRECTION (busyMult - 1) by 25%: the same Hospital walk recomputes to
+  // busyMult=1.1943, outSec=17.380s (was busyMult=1.2591, outSec=18.322s — measured before/after,
+  // prompts/CINEMA_PATH_EDITOR.md 2026-08-03).
+  var CINEMA_PACE_SWING = 1.45;
   var CINEMA_TURN_DPS     = 45;    // one rate for BOTH in-place turns: the spin and the orbit lap
   var CINEMA_DIVE_MIN_SEC = 2.5;   // a floor, so a tiny building still gets an arrival rather than a cut
   var CINEMA_SPIN_MIN_SEC = 0.8;
@@ -4509,7 +4532,7 @@ async function setupEffects(A, renderer, scene, camera) {
   }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
   // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v17 (§CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; §CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
+  var EFFECTS_V = 'v18 (§CPE_PACE_SWING_SOFTEN CINEMA_PACE_SWING 1.6->1.45, direct user tuning request; §CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; §CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v926';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v927';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_even_turn.js
+++ b/witness_cpe_even_turn.js
@@ -122,10 +122,11 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       //
       // TWO beats need a different bound, both for stated reasons, neither to make this pass:
       //  - THE WALK is deliberately NOT arc-uniform. §CPE_EVEN_TURN parameterizes it by a blended
-      //    distance+turn cost, so its distance step is bounded by 1/(1-w) = PACE_SWING = 1.6x the
-      //    nominal, and the smoothstep ease multiplies that by 1.5 -> 2.4x. Holding the walk to
-      //    1.5x would gate the FEATURE, not a defect. 2.4x is the same bound the §CPE_EVEN_TURN
-      //    derivation states, so this gate is what checks that derivation against the real film.
+      //    distance+turn cost, so its distance step is bounded by 1/(1-w) = PACE_SWING (mirrored
+      //    below — see §CPE_PACE_SWING_SOFTEN, 1.45 as of 2026-08-03) x the nominal, and the
+      //    smoothstep ease multiplies that by 1.5. Holding the walk to 1.5x would gate the FEATURE,
+      //    not a defect. `1.5 * PACE_SWING` is the same bound the §CPE_EVEN_TURN derivation states,
+      //    so this gate is what checks that derivation against the real film.
       //  - IN-PLACE beats (the spin) barely translate at all: mean steps of 1-3cm make the ratio
       //    pure numerical noise (measured 7.8-13.6x on a 2cm mean). A beat that moves less than a
       //    centimetre per frame on average has no meaningful position bound, so it is reported and
@@ -151,7 +152,9 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
           const mean = steps.reduce((a, s) => a + s.d, 0) / steps.length;
           const top = steps.reduce((a, s) => (s.d > a.d ? s : a), steps[0]);
           const bot = steps.reduce((a, s) => (s.d < a.d ? s : a), steps[0]);
-          const PACE_SWING = 1.6;                       // the user's dial, mirrored from effects.js
+          // §CPE_PACE_SWING_SOFTEN (2026-08-03): mirrored from CINEMA_PACE_SWING in effects.js —
+          // keep in sync, this witness has no way to import the source constant.
+          const PACE_SWING = 1.45;                      // the user's dial, mirrored from effects.js
           const shape = (name === 'walk') ? 1.5 * PACE_SWING : 1.5;
           // The spin is an IN-PLACE turn by definition, not a traverse — it pivots on the settle
           // point. Exempted by name rather than by a magnitude threshold, because a threshold would
@@ -277,7 +280,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     // "2 secs pausing there in movie": does the walk ever crawl so slowly it reads as a stall?
     const wk = H.pos.find(p => p.beat === 'walk');
     const sl = wk && wk.slowest;
-    P(`T6 the walk never crawls below 1/${wk ? wk.swing : 1.6} of what its own ease predicts (PACE_SWING is a RANGE, not just a ceiling)`,
+    P(`T6 the walk never crawls below 1/${wk ? wk.swing : 1.45} of what its own ease predicts (PACE_SWING is a RANGE, not just a ceiling)`,
       // Tolerance is the cost table's resolution, not slack for a bad result: the table has 240
       // segments while the film runs 640-1068 frames, so 3-4 frames interpolate inside one segment
       // and a frame can land a fraction under the segment's own bound. 2% covers that; anything

--- a/witness_cpe_noise_law.js
+++ b/witness_cpe_noise_law.js
@@ -21,7 +21,9 @@ const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8403;
 const BUILDINGS = (process.env.BLDS || 'Duplex,Terminal').split(',');
-const FPS = 15, DUR = 24, PACE_SWING = 1.6;
+// §CPE_PACE_SWING_SOFTEN (2026-08-03): mirrors CINEMA_PACE_SWING in viewer/effects.js — keep in sync,
+// this witness has no way to import the source constant and re-derives its tolerance from this copy.
+const FPS = 15, DUR = 24, PACE_SWING = 1.45;
 // 'a sec or two ... is fine in the film' (user). Two seconds plus a frame of slack.
 const STALL_CEIL = parseFloat(process.env.STALL_CEIL || '3.0');
 const sleep = ms => new Promise(r => setTimeout(r, ms));

--- a/witness_cpe_work_pacing.js
+++ b/witness_cpe_work_pacing.js
@@ -20,6 +20,16 @@
 //   G-WP-5  degrade, don't disable: with tmWorkSchedule hidden the way a stale cache would, pacing
 //           falls back to calendar and says so in the log — the film still bakes.
 //   G-WP-6  preview and bake ask for the same cursor at the same film fraction.
+//   G-WP-8  2026-08-03 — user report on a REAL Hospital bake: "the buildup reveal starts too FAST,
+//           then the MIDDLE is relatively SLOW." G-WP-1 only proves index-fraction == film-fraction;
+//           it says nothing about FRAME-BY-FRAME evenness, which is what a viewer actually sees.
+//           Replays the real bake's per-frame pipeline (buildupTAt + buildupCursorAt, nFrames=1905 —
+//           the user's own log) and asserts the elements/frame rate has no burst/plateau, plus logs
+//           the end_ts tie-cluster structure (a big tied group would cause exactly that pattern even
+//           with an even element-index rate). See prompts/CINEMA_PATH_EDITOR.md 2026-08-03 for the
+//           real numbers this produced on Hospital and the conclusion (camera-beat-speed illusion,
+//           not a pacing defect — the measured rate came back flat, ~36.2 elements/frame, <0.5% jitter).
+//   G-WP-9  the post-topout dwell (§CPE_BUILDUP_TOPOUT) stays flat, not still climbing.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8442;
@@ -105,6 +115,65 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       out.bakeCursors = FRACS.map(t => A.buildupCursorAt(t, bk));
       out.previewMatchesBake = out.previewCursors.every((ms, i) => ms === out.bakeCursors[i]);
 
+      // ── G-WP-8/9 (2026-08-03) — user bug report on a real Hospital bake: "buildup reveal starts
+      // too FAST, then the MIDDLE is relatively SLOW." §CPE_BUILDUP_WORK_PACED already proved the
+      // ELEMENT-INDEX fraction tracks the film fraction (G-WP-1 above) — but that says nothing about
+      // whether the RENDER actually reveals elements at an even rate FRAME BY FRAME, which is what a
+      // viewer sees. Two separate ways this could still be uneven even with G-WP-1 green:
+      //   (a) end_ts TIES — tmPlacedCount() counts `end_ts <= cursor`, so if many ops share one
+      //       timestamp, the reveal would burst (all of a tied group appears in one frame) then
+      //       plateau (no visible change for the rest of that tied index range) even though the
+      //       INDEX advances evenly every frame.
+      //   (b) §CPE_BUILDUP_TOPOUT's remap (t -> t/topoutU) is linear in FILM FRACTION, which this
+      //       code simulates using the actual real-bake per-frame pipeline (buildupTAt then
+      //       buildupCursorAt), not just the FRACS checkpoints G-WP-1 used.
+      // This replays the exact per-frame sequence cinema_maxq.js's bake loop runs (same two calls,
+      // same nFrames a real Hospital bake used — frame=0/1905 in the user's own log).
+      const nFrames = 1905;
+      const topout = A.buildupTopoutU(null);
+      A.buildupPacingReset();
+      const trace = [];
+      for (let f = 0; f < nFrames; f++) {
+        const tFilm = f / (nFrames - 1);
+        const bkT = A.buildupTAt(tFilm, null);
+        const ms = A.buildupCursorAt(bkT, bk);
+        trace.push(window.tmPlacedCount(ms));
+      }
+      out.topoutU = topout.u;
+      // end_ts tie-cluster structure — the (a) mechanism above, checked directly against real data.
+      const sch = window.tmWorkSchedule();
+      let groups = 0, maxGroup = 1, run = 1;
+      for (let i = 1; i < sch.ends.length; i++) {
+        if (sch.ends[i] === sch.ends[i - 1]) { run++; } else { groups++; if (run > maxGroup) maxGroup = run; run = 1; }
+      }
+      groups++;
+      out.tieGroups = groups; out.tieGroupMax = maxGroup;
+      // Windowed rate (elements per BLOCK of frames), over the pre-topout span only (post-topout is
+      // SUPPOSED to be flat — that is the dwell §CPE_BUILDUP_TOPOUT deliberately introduces). A block
+      // rather than a raw 1-frame diff: on a small building (e.g. Duplex, ~1100 ops/1905 frames) most
+      // single frames place 0 or 1 element, so a per-frame diff is dominated by integer-count
+      // quantization noise that has nothing to do with pacing evenness — the same reason a human
+      // doesn't perceive "fast/slow" frame-to-frame, only over a stretch of the film. Block size
+      // scales with total ops so it always spans a real number of elements (min 5 frames).
+      const topoutFrame = Math.min(nFrames - 1, Math.round(topout.u * (nFrames - 1)) + 1);
+      const block = Math.max(5, Math.round(topoutFrame / Math.max(20, Math.min(100, Math.round(total / 50)))));
+      const rates = [];
+      for (let f = block; f <= topoutFrame; f += block) rates.push((trace[f] - trace[f - block]) / block);
+      const meanRate = rates.length ? rates.reduce((s, x) => s + x, 0) / rates.length : 0;
+      out.rateBlockFrames = block;
+      // Coarse checkpoints for a human-readable summary (start/quarter/half/three-quarter of the FILM).
+      out.checkpoints = [0.10, 0.25, 0.50, 0.75].map(cp => {
+        const f = Math.round(cp * (nFrames - 1));
+        const w = 20; // local rate window, frames
+        const f0 = Math.max(0, f - w), f1 = Math.min(topoutFrame, f + w);
+        return { t: cp, placed: trace[f], ratePerFrame: +((trace[f1] - trace[f0]) / (f1 - f0)).toFixed(2) };
+      });
+      out.meanRatePerFrame = +meanRate.toFixed(2);
+      out.maxRateDeviationFrac = rates.length ?
+        Math.max(...rates.map(r => Math.abs(r - meanRate))) / meanRate : 0;
+      out.postTopoutFlat = trace.slice(topoutFrame).every(p => p === trace[topoutFrame]);
+      out.finalPlaced = trace[nFrames - 1];
+
       try { window.tmRestoreDerivedOrder(); } catch (e) {}
       return out;
     }, FRACS);
@@ -149,6 +218,23 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       P('G-WP-7 the log states the pacing mode and how front-loaded the model is',
         /mode=work/.test(line) && /workInFirst10%OfCalendar/.test(sch),
         `${line || 'no §CPE_BUILDUP_PACING'}\n        ${sch || 'no §CPE_WORK_SCHEDULE'}`);
+
+      // G-WP-8/9 — real per-frame FILM reveal rate (2026-08-03 "fast start, slow middle" report).
+      // Tolerance is loose (25%) on purpose: this proves the reveal isn't BURSTY/PLATEAUING, not
+      // that it is frame-perfect — a model with real duration ties will always have some jitter.
+      const RATE_TOL = 0.25;
+      const cpLine = res.checkpoints.map(c => `t=${c.t}→${c.placed} (${c.ratePerFrame}/frame)`).join('  ');
+      P('G-WP-8 the per-frame reveal rate stays even across the pre-topout film (no burst/plateau)',
+        res.maxRateDeviationFrac <= RATE_TOL,
+        `topoutU=${res.topoutU.toFixed(3)} meanRate=${res.meanRatePerFrame}/frame ` +
+        `worstDeviation=${(res.maxRateDeviationFrac * 100).toFixed(1)}% (tol ${RATE_TOL * 100}%)\n        ` +
+        `checkpoints: ${cpLine}\n        ` +
+        `end_ts tie clusters: ${res.tieGroups} distinct timestamps / ${res.total} ops, largest tied group=${res.tieGroupMax} ` +
+        `(a large group here would explain a burst/plateau reveal even with an even element-index rate)`);
+
+      P('G-WP-9 construction is fully placed and stays flat through the post-topout dwell',
+        res.postTopoutFlat === true && res.finalPlaced === res.total,
+        `finalPlaced=${res.finalPlaced}/${res.total} postTopoutFlat=${res.postTopoutFlat}`);
     }
 
     const pass = checks.filter(c => c.ok).length;


### PR DESCRIPTION
## Summary
- **Buildup "fast start, slow middle" investigation**: replayed the real bake's exact per-frame pipeline on Hospital (63,415 ops, nFrames=1905) and measured elements-placed rate at every 20th frame — result is flat, ~36.2 elements/frame, <0.7% worst deviation across the entire pre-topout film. end_ts tie-cluster check (max group size 9, median 1) rules out a burst/plateau mechanism. No cross-contamination from `§CPE_NOISE_LAW` busy-weighting into the buildup index math. **No code change to buildup pacing itself** — it is already even by construction. Extended `witness_cpe_work_pacing.js` (G-WP-8/9) with this real measurement as a permanent regression guard.
- **`CINEMA_PACE_SWING` softened 1.6 → 1.45** (direct user tuning request, independent of the above finding — the walk-speed slowdown in busy/dense areas was "too strict"). The user's suggested 1.3-1.4 range was tested first and measurably breaks `witness_cpe_even_turn.js`'s T5 fast-side jerk cap on Duplex (real walk step hits 3.0x mean against a 2.0x cap); 1.45 is the largest reduction that stays clear of that on both regression buildings. Measured on Hospital: `busyMult` 1.2591→1.1943, `outSec` 18.322→17.380 (25% cut in the busyness correction). Witness mirrors of the constant updated to match (neither witness can import the source value).
- `sw.js` CACHE_VERSION v926→v927 (`effects.js` is precached).

## Root cause read on the original bug report
Most likely the camera beat structure, not the buildup: the dive (short, ~8.7s) and the walk (huge middle stretch, ~117s on the user's real bake) move through the SAME even elements/second placement rate at very different camera speeds — the busy-area walk slowdown this PR softens most likely compounds the "slow middle" perception.

## Known pre-existing gap (not touched here)
`witness_cpe_even_turn.js` T6 (the slow-side stall floor) is already RED at the original PACE_SWING=1.6 baseline on `origin/main` — confirmed by testing before this change. Unrelated to this PR, out of scope, noted for whoever picks up `§CPE_PACE_FLOOR` next.

## Test plan
- [x] `witness_cpe_work_pacing.js` 18/18 (Duplex + Hospital, real DB)
- [x] `witness_cpe_noise_law.js` 10/10 (Duplex + Terminal)
- [x] `witness_cpe_even_turn.js` 8/10 both before and after this change (T6 pre-existing red confirmed unrelated)
- [x] `node -c` syntax check on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLyi4DXiz3PUCHegrGg8ES