### PR TITLE
fix(cinema): §CPE_GHOST_GROUND_TRIGGER — revert to first-above-ground-element, not 5% share

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -28,13 +28,23 @@
   // Deliberately NOT "switch the ground off", which the user floated first and flagged the risk of
   // themselves: that takes §PHOTO_SHADOW's casters and the sense of a site with it, and the
   // foundation floats in blackness.
+  //
+  // §CPE_GHOST_GROUND_TRIGGER history (read before changing this threshold again):
+  //   #1110 fired at the first at-or-above-ground element (MIN(end_ts) over above-ground ops) —
+  //   measured t=0.0162 on Hospital, 2.4s of a 147.9s film.
+  //   #1112 judged that too early ("over before the camera lands") and replaced it with a RATIO
+  //   against the model's own above-ground total (opaque at 5% of above-ground work placed,
+  //   t=0.050 on Hospital) — a deliberate, reasoned widening, not a bug.
+  //   2026-08-03: the user watched real bakes and said, twice, directly, that even 5% is "quite
+  //   further on" — they want the ground solid essentially the MOMENT the first slab(s) appear,
+  //   not materially later. This reverts the TRIGGER to #1110's first-above-ground-element rule
+  //   (still computed from tmGroundSchedule's `firstAboveMs`, so the §1113-1115 hardening below —
+  //   degrade-not-disable, refusal logging, lazy arm-on-first-tick, arm-while-hidden — is untouched).
+  //   NOTE FOR THE USER: #1112's "too early to be legible" concern was real and measured, not
+  //   invented — reverting does trade back into that risk (a 2.4s-of-148s window is brief). This
+  //   revert is implemented as directly asked, not silently split-the-difference; flagging the
+  //   historical concern here rather than deciding it unilaterally.
   var GHOST_OPACITY = 0.22;      // survey-drawing translucency; low enough to read what is under it
-  // §CPE_GHOST_GROUND_RATIO — the ground is fully opaque once this SHARE of the building's own
-  // above-ground work is placed. A fraction, never a count: 5% of a 62,450-element hospital and 5%
-  // of a 961-element house are both "the building is unmistakably out of the ground now". This is
-  // the ONLY presentation constant in the rule — the trigger, the totals and the ordering all come
-  // from the model.
-  var GHOST_REVEAL_FRAC = 0.05;
   var GHOST_FADE_SEC = 3.0;      // floor on how fast opacity may rise, in FILM seconds — a batch of
                                  // ops landing in one frame must not snap the ground opaque.
   var _ggSched = null, _ggSpan = null, _ggSaved = null, _ggTried = false;
@@ -156,9 +166,10 @@
       // about that building. Self-disabling, not a special case anyone has to configure.
       if (!sched.belowTotal) { console.log('§GHOST_GROUND skip reason=this model has no below-ground elements (nothing to reveal)'); return false; }
     } else {
-      // Coarse proxy: the share of ALL placement, not just above-ground. Less faithful (it cannot
-      // tell a pile cap from a parapet) but it moves in the same direction at the same time, and it
-      // is strictly better than the feature vanishing.
+      // Coarse proxy: without tmGroundSchedule we cannot tell a pile cap from a parapet, so we
+      // cannot locate a precise "first above-ground element" moment either. Arm as if that moment
+      // is essentially the start of the buildup (firstT ~ 0 below) — strictly better than the
+      // feature vanishing, and consistent with the precise rule's own intent (fire immediately).
       if (!bkState.ops) { console.log('§GHOST_GROUND skip reason=fallback needs an op count and bkState.ops is ' + bkState.ops); return false; }
       sched = { fallback: true, aboveTotal: bkState.ops, belowTotal: 0, ends: null, firstAboveMs: bkState.projectStart };
     }
@@ -167,26 +178,18 @@
                 firstT: sched.firstAboveMs == null ? 1 : (sched.firstAboveMs - bkState.projectStart) / span };
     var m = A.ground.material;
     _ggSaved = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
-    console.log('§GHOST_GROUND armed rule=' + (sched.fallback ? 'FALLBACK(all-placement proxy — tmGroundSchedule unavailable)' : 'above-ground share') +
+    console.log('§GHOST_GROUND armed rule=' + (sched.fallback ? 'FALLBACK(immediate proxy — tmGroundSchedule unavailable)' : 'first above-ground element') +
       ' aboveOps=' + sched.aboveTotal + ' belowOps=' + sched.belowTotal +
-      ' revealFrac=' + GHOST_REVEAL_FRAC + ' (opaque once ' + Math.ceil(sched.aboveTotal * GHOST_REVEAL_FRAC) +
-      ' above-ground elements are placed) ghost=' + GHOST_OPACITY + ' maxRiseSec=' + GHOST_FADE_SEC);
+      ' firstAboveMs=' + (sched.firstAboveMs == null ? 'none' : Math.round(sched.firstAboveMs)) +
+      ' triggerT=' + _ggSpan.firstT.toFixed(4) +
+      ' ghost=' + GHOST_OPACITY + ' maxRiseSec=' + GHOST_FADE_SEC);
     return true;
   }
 
-  // How many above-ground ops have COMPLETED by this cursor. Binary search on the sorted end_ts —
-  // the same `end_ts <= cursor` definition tmPlacedCount uses, so the ghost and the visible model
-  // can never disagree about what is built.
-  function _ggPlacedAbove(ms) {
-    if (_ggSched.fallback) return window.tmPlacedCount(ms);
-    var e = _ggSched.ends, lo = 0, hi = e.length;
-    while (lo < hi) { var mid = (lo + hi) >> 1; if (e[mid] <= ms) lo = mid + 1; else hi = mid; }
-    return lo;
-  }
-
   // Per frame. `tFilm` is the film fraction driving the cursor; `totalSec` the film's length.
-  // Opacity follows the SHARE of above-ground work placed — the ground solidifies as the building
-  // rises — with a rate limit so a batch of ops cannot turn the ramp into a cut.
+  // Opacity follows a single smoothstep from the first above-ground element's own film fraction
+  // (`_ggSpan.firstT`) to opaque, over at most GHOST_FADE_SEC of FILM time — §CPE_GHOST_GROUND_TRIGGER
+  // above: reverted off the #1112 above-ground-SHARE ratio, back to #1110's first-element trigger.
   function _ghostGroundAt(tFilm, totalSec, bkState) {
     var A = window.APP;
     // LAZY ARM. Arming used to happen once, before the frame loop, which made the feature hostage to
@@ -197,22 +200,14 @@
     if (!_ggSched && !_ggTried && bkState) { _ggTried = true; _ghostGroundArm(bkState); }
     if (!_ggSched || !A || !A.ground || !A.ground.material) return null;
     var t = Math.max(0, Math.min(1, tFilm));
-    var ms = _ggSpan.start + t * _ggSpan.span;
-    // 1. What the BUILDING says: the share of its own above-ground work that is placed.
-    var frac = _ggPlacedAbove(ms) / _ggSched.aboveTotal;
-    var u = Math.max(0, Math.min(1, frac / GHOST_REVEAL_FRAC));
-    var byWork = GHOST_OPACITY + (1 - GHOST_OPACITY) * (u * u * (3 - 2 * u));
-    // 2. A floor on how FAST that may happen, so a batch of ops landing together cannot snap the
-    //    ground opaque. ⚠ Expressed against the film's own clock, NOT against the previous call:
-    //    a per-call rate limiter makes the curve depend on how densely it is sampled, and the bake
-    //    (2219 frames) and the rehearsal (~600) then trace different curves for the same film.
-    //    Measured 2026-07-31 — G-GG-6 caught exactly that, 0.3653 vs 0.4006 at t=0.02.
+    // A floor on how FAST the ramp may happen, so a batch of ops landing together cannot snap the
+    // ground opaque. ⚠ Expressed against the film's own clock, NOT against the previous call: a
+    // per-call rate limiter makes the curve depend on how densely it is sampled, and the bake
+    // (2219 frames) and the rehearsal (~600) then trace different curves for the same film.
+    // Measured 2026-07-31 — G-GG-6 caught exactly that, 0.3653 vs 0.4006 at t=0.02.
     var fadeFrac = (totalSec > 0) ? Math.min(0.5, GHOST_FADE_SEC / totalSec) : 0.05;
     var v = Math.max(0, Math.min(1, (t - _ggSpan.firstT) / Math.max(1e-6, fadeFrac)));
-    var byTime = GHOST_OPACITY + (1 - GHOST_OPACITY) * (v * v * (3 - 2 * v));
-    // Both curves are monotone functions of t alone, so their min is too — and the result is a pure
-    // function of the film fraction: identical in the preview and the bake, at any frame count.
-    var o = Math.min(byWork, byTime);
+    var o = GHOST_OPACITY + (1 - GHOST_OPACITY) * (v * v * (3 - 2 * v));   // smoothstep, no cut
     var m = A.ground.material, solid = o > 0.999;
     m.opacity = o;
     m.transparent = !solid;
@@ -233,7 +228,7 @@
     _ggSaved = null;
   }
 
-  var MAXQ_V = 'v20 (§CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_GHOST_GROUND_RATIO the ground solidifies as the SHARE of above-ground work rises — generic to any building, self-disabling where there is no substructure; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v21 (§CPE_GHOST_GROUND_TRIGGER reverted off the #1112 above-ground-SHARE ratio (5%, judged too late by direct user testimony) back to the #1110 first-above-ground-element trigger, keeping the #1113-1115 hardening (degrade-not-disable, refusal logging, lazy arm-on-first-tick); §CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v927';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v928';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -23,6 +23,17 @@
 //           before arming. A ghosted ground left behind follows the user into normal navigation.
 //   G-GG-6  preview and bake agree — the same film fraction yields the same opacity whichever
 //           call site drives it, because the fade is expressed in film fraction, not wall time.
+//
+// §CPE_GHOST_GROUND_TRIGGER (2026-08-03): #1112 replaced the first-element trigger above with a
+// RATIO against the model's own above-ground total (opaque at 5% of above-ground work placed),
+// reasoning the first-element trigger was too brief to be legible. The user then watched real
+// bakes and said, twice, directly, that even 5% is "quite further on" than they want — this
+// reverts the TRIGGER to first-above-ground-element while keeping every #1113-1115 hardening
+// (degrade-not-disable, refusal logging, lazy arm-on-first-tick, arm-while-hidden) intact.
+//   G-GG-8  RED-vs-GREEN: the ground reaches opaque essentially AT the first above-ground
+//           element (within one fade window), NOT materially later — the point of the revert.
+//           Also computes, from the SAME real schedule data, where the retired 5%-share rule
+//           would have fired, as the quantified "before" this replaces.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8441;
@@ -75,6 +86,16 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       out.sched = sched ? { aboveTotal: sched.aboveTotal, belowTotal: sched.belowTotal } : null;
       out.firstMs = sched ? sched.firstAboveMs : null;
       out.triggerT = out.firstMs == null ? null : (out.firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
+
+      // RED reference, computed from the SAME real schedule: where the retired #1112 5%-share rule
+      // would have fired — the k-th above-ground op's own end_ts, k = ceil(5% of aboveTotal).
+      if (sched && sched.ends && sched.ends.length) {
+        const k = Math.max(1, Math.ceil(sched.aboveTotal * 0.05));
+        const oldMs = sched.ends[Math.min(k, sched.ends.length) - 1];
+        out.oldRuleK = k;
+        out.oldRuleMs = oldMs;
+        out.oldRuleT = (oldMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
+      }
 
       const m = A.ground.material;
       const before = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
@@ -190,14 +211,21 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         agree,
         res.previewSamples.map(s => `t=${s.t} bake=${s.bake} preview=${s.preview}`).join('   '));
 
-      // §CPE_GHOST_GROUND_RATIO: the point of replacing the first-element trigger. On Hospital that
-      // trigger fired at t=0.0162 (2.4s of a 147.9s film) — the ghost was over before the camera
-      // landed. The ratio rule must hold the ground open materially longer than that.
-      P('G-GG-8 the ghost outlasts the first above-ground element (the ratio rule, not a trigger)',
-        res.opaqueAt != null && res.opaqueAt > res.triggerT * 2,
+      // §CPE_GHOST_GROUND_TRIGGER (2026-08-03 revert): the ground must go opaque essentially AT the
+      // first above-ground element — within one GHOST_FADE_SEC fade window of it, not materially
+      // later. fadeFrac = min(0.5, 3s / 100s film) = 0.03; allow slack for the 1/200 sample grid.
+      const fadeFrac = 0.03, tol = fadeFrac + 0.015;
+      const gap = res.opaqueAt == null ? null : res.opaqueAt - res.triggerT;
+      P('G-GG-8 GREEN — opaque essentially AT first above-ground element, not materially later (the point of the revert)',
+        gap != null && gap > 0 && gap <= tol,
         `first above-ground element at t=${res.triggerT.toFixed(4)}; ground reaches opaque at ` +
-        `t=${res.opaqueAt == null ? 'never' : res.opaqueAt.toFixed(4)}  ` +
-        `(above=${res.sched.aboveTotal} below=${res.sched.belowTotal}, opaque once 5% of above-ground work is placed)`);
+        `t=${res.opaqueAt == null ? 'never' : res.opaqueAt.toFixed(4)}  gap=${gap == null ? 'n/a' : gap.toFixed(4)} ` +
+        `(tolerance=${tol.toFixed(4)}, above=${res.sched.aboveTotal} below=${res.sched.belowTotal})  |  ` +
+        `RED reference (retired #1112 5%-share rule, same real schedule): would have fired at ` +
+        `t=${res.oldRuleT == null ? 'n/a' : res.oldRuleT.toFixed(4)} (k=${res.oldRuleK}th above-ground element) — ` +
+        `gap this revert closes = ${res.oldRuleT == null ? 'n/a' : (res.oldRuleT - res.triggerT).toFixed(4)} film-fraction ` +
+        `(${res.oldRuleMs == null ? '' : Math.round(res.oldRuleMs - res.firstMs) + 'ms, '}` +
+        `${res.oldRuleK ? (res.oldRuleK - 1) + ' extra above-ground elements waited on' : ''})`);
 
       P('G-GG-10 a stale time_machine.js DEGRADES to the coarse rule instead of disabling the feature',
         res.fallbackArmed === true && res.fallbackOpacityEarly != null && res.fallbackOpacityEarly < 0.3 &&


### PR DESCRIPTION
## Summary
- The ground plane during a buildup bake (Alt+M) was staying x-ray/ghosted well past the first above-ground slab — user reported this twice, directly, from watching real Hospital bakes.
- Traced to #1112 (`§CPE_GHOST_GROUND_RATIO`), which deliberately widened the original #1110 first-element trigger to a 5% above-ground-work share, reasoning the first-element trigger was too brief to read. That was a real, measured design call — not a bug.
- The user has now overridden that with direct testimony from real bakes: even 5% is "quite further on" than wanted. This reverts the **trigger** (not the shared opacity mechanics) back to #1110's first-above-ground-element rule, keeping all #1113-1115 hardening (degrade-not-disable fallback, refusal logging, lazy arm-on-first-tick, arm-while-hidden).
- `effects.js`'s Alt+S still-photo shadow system is untouched — different lane, not touched.

## Real numbers (witness_cpe_ghost_ground.js, real Hospital + Duplex schedule data)
- **Hospital**: first above-ground element at t=0.0227 → ground opaque at t=0.0550 (gap 0.032, one fade window). The retired 5%-rule would have fired at t=0.0648 — the **3,123rd** above-ground element, 3,122 elements later than the new trigger.
- **Duplex**: first above-ground element at t=0.0083 → ground opaque at t=0.0400 (gap 0.032). The retired 5%-rule would have fired at t=0.1315 — the 50th element, 49 later.

## Test plan
- [x] `witness_cpe_ghost_ground.js` — Duplex 11/11, Hospital 11/11 (extended G-GG-8 to assert opaque-essentially-at-trigger AND to compute the retired-rule comparison from the same real schedule data)
- [x] `witness_cpe_buildup_topout.js` — 4/4, unaffected (buildup pacing/topout untouched)
- [x] `witness_cpe_ok_bake.js` K3 — confirmed pre-existing flake, fails identically on unmodified origin/main (unrelated to this change, not in scope)
- [x] sw.js CACHE_VERSION bumped v927 → v928 (cinema_maxq.js is precached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLyi4DXiz3PUCHegrGg8ES