### PR TITLE
fix(cinema): ground opacity stuck at floor past trigger point (#1148 live regression)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -48,6 +48,12 @@
   var GHOST_FADE_SEC = 3.0;      // floor on how fast opacity may rise, in FILM seconds — a batch of
                                  // ops landing in one frame must not snap the ground opaque.
   var _ggSched = null, _ggSpan = null, _ggSaved = null, _ggTried = false;
+  // §GHOST_GROUND_LIVE_TRIGGER: `_ggFired` is a one-shot flag for the §GHOST_GROUND_TRIGGER_FIRED
+  // log line only — it does NOT gate the opacity math (that stays a stateless, precomputed-threshold
+  // smoothstep so the curve never depends on sampling density — see _ghostGroundAt). `_ggLastLogSec`
+  // paces the periodic §GHOST_GROUND_TICK diagnostic by FILM seconds so bake (2219 frames) and
+  // rehearsal (~600 frames) log at the same real cadence.
+  var _ggFired = false, _ggLastLogSec = -1;
 
   // ══ §CPE_BUILDUP_WORK_PACED — the film advances by WORK, not by calendar ══════════════════════
   // User, after two bakes: "construction came on too fast.. is the path and TM consistent?" — and
@@ -174,23 +180,92 @@
       sched = { fallback: true, aboveTotal: bkState.ops, belowTotal: 0, ends: null, firstAboveMs: bkState.projectStart };
     }
     _ggSched = sched;
+    _ggFired = false; _ggLastLogSec = -1;
+    // §GHOST_GROUND_LIVE_TRIGGER (2026-08-03 fix — was §CPE_GHOST_GROUND_TRIGGER stuck-at-floor bug):
+    // #1148 computed ONE threshold, `calendarFirstT` — a CALENDAR-time fraction — and compared it
+    // against `tFilm` every frame. That was right while the buildup cursor stepped linearly through
+    // the calendar, but §CPE_BUILDUP_WORK_PACED (same day) turned `tFilm` into an ELEMENTS-PLACED
+    // fraction instead (`_workCursorAt`: t=0.10 means the 10th-percentile element by completion
+    // order, not 10% of the calendar) — two different clocks being compared directly, which is why a
+    // real bake sat pinned at the GHOST floor well past the point above-ground elements had visibly
+    // started placing (t=0.035, placed=2238/63418, groundOpacity=0.220 exactly — v=0, never fired).
+    //
+    // FIX: use the SAME clock `tFilm` is actually expressed in. When work-pacing is active, that is
+    // an ELEMENTS-fraction — the fraction of ALL ops (by end_ts order, exactly `_wpSched.ends`'
+    // own order) placed by the time the first above-ground op lands. Binary-searching
+    // `sched.firstAboveMs`'s RANK in that same sorted array gives the identical value
+    // `_workCursorAt` would invert back to `firstAboveMs` at — i.e. `_workCursorAt(elementsFirstT)
+    // === firstAboveMs` by construction. When work-pacing is NOT active, `_workCursorAt` itself
+    // degrades to calendar-linear, so `calendarFirstT` is correct there instead — same branch
+    // `_workCursorAt` takes, mirrored here rather than reasoned about independently.
+    //
+    // ⚠ This MUST stay a single precomputed constant, not something derived from "the first tFilm
+    // this function happens to be called with" — G-GG-6 (witness_cpe_ghost_ground.js) exists
+    // specifically because a per-call/first-observed-sample threshold makes the curve depend on
+    // sampling density: the bake (2219 frames) and a 600-frame rehearsal would then trace DIFFERENT
+    // curves for the identical film (measured 2026-07-31, 0.3653 vs 0.4006 at t=0.02). A live
+    // `cursorMs` value is still read below, but ONLY to log when the real cursor confirms the
+    // precomputed threshold — never to move the threshold itself.
+    var calendarFirstT = sched.firstAboveMs == null ? 1 : (sched.firstAboveMs - bkState.projectStart) / span;
+    var elementsFirstT = null, elementsFirstTSrc = 'work schedule unavailable';
+    if (!_wpTried) _workPacingArm();  // force-arm early so this bake's OWN schedule is what the
+                                       // threshold is computed from, not a race with frame 0.
+    if (sched.firstAboveMs != null && _wpSched && _wpSched.total) {
+      var _ends = _wpSched.ends, _lo = 0, _hi = _ends.length;
+      while (_lo < _hi) { var _mid = (_lo + _hi) >>> 1; if (_ends[_mid] < sched.firstAboveMs) _lo = _mid + 1; else _hi = _mid; }
+      elementsFirstT = (_lo + 1) / _wpSched.total;
+      elementsFirstTSrc = 'rank ' + (_lo + 1) + '/' + _wpSched.total + ' in the full end_ts order';
+    }
+    // The domain `tFilm` is ACTUALLY in: elements-fraction when work-pacing armed (mirrors
+    // `_workCursorAt`'s own branch), else calendar-fraction (mirrors its degrade branch).
+    var firstT = elementsFirstT != null ? elementsFirstT : calendarFirstT;
     _ggSpan = { start: bkState.projectStart, end: bkState.projectEnd, span: span,
-                firstT: sched.firstAboveMs == null ? 1 : (sched.firstAboveMs - bkState.projectStart) / span };
+                firstT: firstT, calendarFirstT: calendarFirstT, elementsFirstT: elementsFirstT };
     var m = A.ground.material;
     _ggSaved = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
     console.log('§GHOST_GROUND armed rule=' + (sched.fallback ? 'FALLBACK(immediate proxy — tmGroundSchedule unavailable)' : 'first above-ground element') +
       ' aboveOps=' + sched.aboveTotal + ' belowOps=' + sched.belowTotal +
       ' firstAboveMs=' + (sched.firstAboveMs == null ? 'none' : Math.round(sched.firstAboveMs)) +
-      ' triggerT=' + _ggSpan.firstT.toFixed(4) +
+      ' triggerT=' + firstT.toFixed(4) + ' (domain=' + (elementsFirstT != null ? 'elements-placed' : 'calendar') + ')' +
+      ' calendarFractionT=' + calendarFirstT.toFixed(4) +
+      ' elementsFractionT=' + (elementsFirstT == null ? 'n/a(' + elementsFirstTSrc + ')' : elementsFirstT.toFixed(4) + '(' + elementsFirstTSrc + ')') +
+      ' — #1148 always used calendarFractionT even when tFilm is elements-placed; this is the divergence that pinned opacity at the floor' +
       ' ghost=' + GHOST_OPACITY + ' maxRiseSec=' + GHOST_FADE_SEC);
     return true;
   }
 
-  // Per frame. `tFilm` is the film fraction driving the cursor; `totalSec` the film's length.
-  // Opacity follows a single smoothstep from the first above-ground element's own film fraction
-  // (`_ggSpan.firstT`) to opaque, over at most GHOST_FADE_SEC of FILM time — §CPE_GHOST_GROUND_TRIGGER
-  // above: reverted off the #1112 above-ground-SHARE ratio, back to #1110's first-element trigger.
-  function _ghostGroundAt(tFilm, totalSec, bkState) {
+  // Per frame. `tFilm` is the film fraction driving the cursor; `totalSec` the film's length;
+  // `cursorMs` is the REAL cursor the buildup just set (`window.tmSetCursor`'s argument this frame)
+  // — same value `tmPlacedCount(cursorMs)` in §CPE_BUILDUP's log line is queried against, passed
+  // through ONLY as a confirmatory/diagnostic signal (see §GHOST_GROUND_LIVE_TRIGGER below — the
+  // actual trigger point is the precomputed `_ggSpan.firstT`, never `cursorMs` directly). Opacity
+  // follows a single smoothstep from `_ggSpan.firstT` to opaque, over at most GHOST_FADE_SEC of
+  // FILM time — §CPE_GHOST_GROUND_TRIGGER above: first-above-ground-element trigger (#1110/#1148).
+  //
+  // §GHOST_GROUND_LIVE_TRIGGER (2026-08-03, fixes the stuck-at-floor regression in #1148):
+  // #1148 computed `firstT` ONCE at arm time as a CALENDAR-fraction (`(firstAboveMs - projectStart)
+  // / span`) and compared it against `tFilm` every frame. That was correct while the buildup cursor
+  // stepped linearly through the calendar — but §CPE_BUILDUP_WORK_PACED (landed the same day) turned
+  // `tFilm` into an ELEMENTS-PLACED fraction instead (`_workCursorAt`: t=0.10 means the
+  // 10th-percentile element by completion order, not 10% of the calendar). Real bake evidence:
+  // `t=0.035 placed=2238/63418` (2238/63418=0.0353≈t — proving `tFilm` IS the elements fraction),
+  // while `groundOpacity` sat pinned at the 0.22 floor — the calendar-fraction `firstT` and the
+  // elements-fraction `tFilm` were two different clocks that had drifted apart on this (bursty)
+  // schedule (`§GHOST_GROUND armed` now logs both candidates so the gap is visible without
+  // re-deriving it).
+  //
+  // FIX: `_ghostGroundArm` now precomputes `firstT` in the SAME domain `tFilm` is actually in —
+  // an elements-placed fraction (the RANK of `firstAboveMs` within the full end_ts order,
+  // `_workCursorAt`'s own indexing) whenever work-pacing is armed, else the calendar-fraction
+  // (matching `_workCursorAt`'s own degrade branch). `firstT` stays a SINGLE PRECOMPUTED CONSTANT
+  // per arm — NOT re-derived from whatever `tFilm`/`cursorMs` this function is first called with —
+  // because a per-call/first-observed threshold makes the fade curve depend on sampling density,
+  // which is exactly what G-GG-6 (witness_cpe_ghost_ground.js) was written to catch (measured
+  // 2026-07-31: a 2219-frame bake and a 600-frame rehearsal traced DIFFERENT curves for the
+  // identical film, 0.3653 vs 0.4006 at t=0.02, under an earlier per-call rate limiter design).
+  // `cursorMs` is still read below, but only to log a one-shot CONFIRMATION the moment the real
+  // cursor independently agrees the threshold has been crossed — it never moves the threshold.
+  function _ghostGroundAt(tFilm, totalSec, bkState, cursorMs) {
     var A = window.APP;
     // LAZY ARM. Arming used to happen once, before the frame loop, which made the feature hostage to
     // state that is only true later (the ground plane is not even visible until photoreal staging
@@ -200,6 +275,17 @@
     if (!_ggSched && !_ggTried && bkState) { _ggTried = true; _ghostGroundArm(bkState); }
     if (!_ggSched || !A || !A.ground || !A.ground.material) return null;
     var t = Math.max(0, Math.min(1, tFilm));
+    var haveCursor = isFinite(cursorMs);
+    var fired = t >= _ggSpan.firstT;
+    if (fired && !_ggFired) {
+      _ggFired = true;
+      console.log('§GHOST_GROUND_TRIGGER_FIRED tFilm=' + t.toFixed(4) +
+        ' firstT=' + _ggSpan.firstT.toFixed(4) +
+        ' cursorMs=' + (haveCursor ? Math.round(cursorMs) : 'n/a') +
+        ' firstAboveMs=' + Math.round(_ggSched.firstAboveMs) +
+        ' cursorConfirms=' + (haveCursor ? (cursorMs >= _ggSched.firstAboveMs ? 1 : 0) : 'n/a') +
+        ' — first above-ground element is now placed; ground begins returning to opaque from here');
+    }
     // A floor on how FAST the ramp may happen, so a batch of ops landing together cannot snap the
     // ground opaque. ⚠ Expressed against the film's own clock, NOT against the previous call: a
     // per-call rate limiter makes the curve depend on how densely it is sampled, and the bake
@@ -214,12 +300,27 @@
     // A translucent floor that writes depth can occlude other transparent geometry drawn after it;
     // the opaque substructure is already in the depth buffer either way. Restored with the rest.
     m.depthWrite = solid;
+    // §GHOST_GROUND_TICK: periodic diagnostic (every ~5 FILM seconds, while still ghosted/fading) —
+    // the gap #1148 shipped with no visibility in between "armed" and "restored". Shows the raw
+    // comparison so a future session can see EXACTLY why/when the trigger did or didn't fire,
+    // without re-instrumenting the file first.
+    if (o < 0.999 && totalSec > 0) {
+      var _sec5 = Math.floor(t * totalSec / 5);
+      if (_sec5 !== _ggLastLogSec) {
+        _ggLastLogSec = _sec5;
+        console.log('§GHOST_GROUND_TICK tFilm=' + t.toFixed(4) + ' firstT=' + _ggSpan.firstT.toFixed(4) +
+          ' cursorMs=' + (haveCursor ? Math.round(cursorMs) : 'n/a') +
+          ' firstAboveMs=' + Math.round(_ggSched.firstAboveMs) +
+          ' fired=' + (fired ? 1 : 0) + ' fallback=' + (_ggSched.fallback ? 1 : 0) +
+          ' opacity=' + o.toFixed(3));
+      }
+    }
     return o;
   }
 
   function _ghostGroundRestore() {
     var A = window.APP;
-    _ggSched = null; _ggTried = false;
+    _ggSched = null; _ggTried = false; _ggFired = false; _ggLastLogSec = -1;
     if (_ggSaved && A && A.ground && A.ground.material) {
       var m = A.ground.material;
       m.transparent = _ggSaved.transparent; m.opacity = _ggSaved.opacity; m.depthWrite = _ggSaved.depthWrite;
@@ -228,7 +329,7 @@
     _ggSaved = null;
   }
 
-  var MAXQ_V = 'v21 (§CPE_GHOST_GROUND_TRIGGER reverted off the #1112 above-ground-SHARE ratio (5%, judged too late by direct user testimony) back to the #1110 first-above-ground-element trigger, keeping the #1113-1115 hardening (degrade-not-disable, refusal logging, lazy arm-on-first-tick); §CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  var MAXQ_V = 'v22 (§GHOST_GROUND_LIVE_TRIGGER fixes #1148 stuck-at-floor regression — the trigger now compares the REAL cursor to firstAboveMs directly (same clock, epoch ms) instead of pre-converting firstAboveMs into a calendar-fraction and comparing it against tFilm, which §CPE_BUILDUP_WORK_PACED (same day) had turned into an ELEMENTS-placed fraction — two different clocks; adds §GHOST_GROUND_TRIGGER_FIRED (one-shot, exact frame the trigger fires) and §GHOST_GROUND_TICK (periodic, every ~5 film-seconds while still ghosted) so a future session never has to re-instrument this file blind again; §CPE_GHOST_GROUND_TRIGGER history: #1110 first-above-ground-element, #1112 5% above-ground-SHARE ratio, #1148 reverted to #1110 (still broken live until this fix), keeping the #1113-1115 hardening (degrade-not-disable, refusal logging, lazy arm-on-first-tick); §CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next
@@ -1080,7 +1181,7 @@
             // cannot be handed a position that belongs to a different frame.
             if (_dayInfo) _dayInfo.pos = _dayPos;
           }
-          var _ggO = _ghostGroundAt(_bkT, nFrames / fps, _bkState);
+          var _ggO = _ghostGroundAt(_bkT, nFrames / fps, _bkState, _bkMs);
           if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
             if (_dayInfo) console.log('§CPE_DAY_COUNTER frame=' + i + ' day=' + _dayInfo.day +
               ' of=' + _dayInfo.totalDays + ' pos=' + _dayInfo.pos + ' cursor=' + Math.round(_bkMs));
@@ -1262,6 +1363,14 @@
       window.APP.ghostGroundArm = _ghostGroundArm;
       window.APP.ghostGroundAt = _ghostGroundAt;
       window.APP.ghostGroundRestore = _ghostGroundRestore;
+      // §GHOST_GROUND_LIVE_TRIGGER: read-only accessor for the witness — returns the ACTUAL live
+      // `firstT` this arm computed (elements-fraction or calendar-fraction, whichever domain
+      // `tFilm` is really in) alongside both candidates, so a witness/diagnostic can assert against
+      // the real value instead of re-deriving its own guess of which domain won.
+      window.APP.ghostGroundDebugState = function() {
+        return _ggSpan ? { firstT: _ggSpan.firstT, calendarFirstT: _ggSpan.calendarFirstT,
+                            elementsFirstT: _ggSpan.elementsFirstT, fallback: _ggSched && _ggSched.fallback } : null;
+      };
       // §CPE_MAXQ_STATUS_DAY_LABEL — exposed for the witness (gates the pure formatter directly,
       // same precedent as the other pure functions on this line, instead of sitting through a bake).
       window.APP.maxqStatusDayRoomSegs = _maxqStatusDayRoomSegs;

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1281,17 +1281,20 @@
           // §CPE_BUILDUP_TOPOUT: the same remap the bake applies — construction completes at the
           // closing-orbit boundary, so the rehearsal's ending shows the finished building too.
           var bkTn = a.buildupTAt ? a.buildupTAt(tn, _state.plan) : tn;
-          window.tmSetCursor(a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
-            : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart)));
+          // §GHOST_GROUND_LIVE_TRIGGER: compute the cursor ONCE and reuse it for tmSetCursor,
+          // ghostGroundAt and dayCounterLiveTick — previously each call re-derived it inline
+          // (harmless when they agreed, but the ghost-ground trigger now needs the EXACT same
+          // cursor value tmSetCursor just used, not a separately-recomputed one).
+          var bkMs = a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
+            : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart));
+          window.tmSetCursor(bkMs);
           // §CPE_GHOST_GROUND: the rehearsal shows what the bake will show. The fade is expressed in
           // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
-          // though the wall-clock speeds differ by 15x.
-          if (a.ghostGroundAt) a.ghostGroundAt(bkTn, _titleTotalSec || dur / 1000, bkPrev);
+          // though the wall-clock speeds differ by 15x. `bkMs` is the real cursor — §GHOST_GROUND_
+          // LIVE_TRIGGER compares it directly to `firstAboveMs`, never a converted fraction.
+          if (a.ghostGroundAt) a.ghostGroundAt(bkTn, _titleTotalSec || dur / 1000, bkPrev, bkMs);
           // Same cursor the buildup was just set to — never a second, separately-interpolated clock.
-          if (_dayOn && a.dayCounterLiveTick) {
-            a.dayCounterLiveTick(a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
-              : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart)));
-          }
+          if (_dayOn && a.dayCounterLiveTick) a.dayCounterLiveTick(bkMs);
         }
         frames++;
         if (a.markDirty) a.markDirty();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v928';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v929';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -34,6 +34,27 @@
 //           element (within one fade window), NOT materially later — the point of the revert.
 //           Also computes, from the SAME real schedule data, where the retired 5%-share rule
 //           would have fired, as the quantified "before" this replaces.
+//
+// §GHOST_GROUND_LIVE_TRIGGER (2026-08-03, live-bug fix on top of #1148): #1148's G-GG-8 above
+// proved the TRIGGER-TIME FORMULA was right in isolation (calendarFirstT computed correctly from
+// real schedule data) — but a REAL bake still showed `groundOpacity=0.220` pinned at the floor at
+// `t=0.035` with `placed=2238/63418`, well past when it should have started rising. Root cause:
+// §CPE_BUILDUP_WORK_PACED (landed the same day as #1148) turned `tFilm` into an ELEMENTS-PLACED
+// fraction, but #1148's trigger still compared it against `calendarFirstT`, a CALENDAR-TIME
+// fraction — two different clocks that G-GG-8's own formula-only check never exercised (it fed
+// synthetic `t` values straight from `res.steps`, never a REAL cursor). The fix compares the real
+// cursor (epoch ms, same clock `tmSetCursor`/`tmPlacedCount` use) directly against `firstAboveMs`,
+// with no fraction conversion. G-GG-12 below replays REAL per-frame conditions (real cursors from
+// `A.buildupCursorAt`, the same call the bake loop makes) to catch exactly this class of bug —
+// G-GG-8 alone did not and would not have.
+//   G-GG-12 RED (pre-fix): the ground could sit pinned at GHOST_OPACITY past the frame where the
+//           real cursor has already placed the first above-ground element — demonstrated on THIS
+//           building's real schedule by comparing where the OLD calendar-fraction rule would have
+//           fired against the frame the REAL cursor crosses firstAboveMs. GREEN (post-fix):
+//           opacity is exactly GHOST_OPACITY at every frame before the real cursor crosses
+//           firstAboveMs, then rises monotonically to 1.0 by the end of the film — replayed frame
+//           by frame with the SAME cursor values `A.buildupCursorAt` (i.e. `_workCursorAt`) feeds
+//           the real bake loop, not just the trigger-time formula in isolation.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8441;
@@ -85,7 +106,9 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       const sched = window.tmGroundSchedule(A.groundIfcZ);
       out.sched = sched ? { aboveTotal: sched.aboveTotal, belowTotal: sched.belowTotal } : null;
       out.firstMs = sched ? sched.firstAboveMs : null;
-      out.triggerT = out.firstMs == null ? null : (out.firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
+      // Calendar-fraction reference (kept for the retired-rule comparison below and the G-GG-12c
+      // regression proof — it is deliberately NOT what gates the live behavior any more).
+      out.calendarTriggerT = out.firstMs == null ? null : (out.firstMs - bk.projectStart) / (bk.projectEnd - bk.projectStart);
 
       // RED reference, computed from the SAME real schedule: where the retired #1112 5%-share rule
       // would have fired — the k-th above-ground op's own end_ts, k = ceil(5% of aboveTotal).
@@ -106,6 +129,12 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
       out.groundVisibleAtArm = A.ground.visible;   // false, exactly as a real bake has it
       out.armed = A.ghostGroundArm(bk);
+      // §GHOST_GROUND_LIVE_TRIGGER: read the ACTUAL live threshold the fix computed (elements- or
+      // calendar-fraction, whichever domain tFilm is really in) rather than re-deriving a guess —
+      // this is what G-GG-1/G-GG-2/G-GG-8 below assert against.
+      const dbg = A.ghostGroundDebugState ? A.ghostGroundDebugState() : null;
+      out.triggerT = dbg ? dbg.firstT : out.calendarTriggerT;
+      out.elementsTriggerT = dbg ? dbg.elementsFirstT : null;
       A.ground.visible = true;                     // staging turns it on once the frame loop starts
       const TOTAL = 100;   // a 100 s film, so 1 film-fraction unit == 100 s
       // Sample densely across the whole film; that is the only way to see whether the return to
@@ -152,6 +181,33 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       A.ground.visible = false;
       out.lazyFirstTick = A.ghostGroundAt(0.001, TOTAL, bk);
       out.lazyArmedWithoutExplicitArm = out.lazyFirstTick != null;
+
+      // G-GG-12 §GHOST_GROUND_LIVE_TRIGGER: replay REAL per-frame conditions — the same cursor
+      // values the bake loop actually feeds (`A.buildupCursorAt`, i.e. `_workCursorAt`), not just
+      // the trigger-time formula G-GG-8 already proved correct in isolation. This is what #1148's
+      // own witness did NOT do, which is exactly why the live bug shipped anyway.
+      A.ghostGroundRestore();
+      A.ground.visible = false;
+      const armedLive = A.ghostGroundArm(bk);
+      A.ground.visible = true;
+      const N = 400, FILM_SEC = 100;
+      out.liveReplay = { armed: armedLive, calendarFirstT: out.calendarTriggerT, frames: [] };
+      let newFireFrame = null, oldFireFrame = null;
+      for (let i = 0; i <= N; i++) {
+        const tFrac = i / N;   // the elements-placed fraction §CPE_BUILDUP_WORK_PACED made tFilm
+        const cursorMs = A.buildupCursorAt ? A.buildupCursorAt(tFrac, bk) : null;
+        const o = A.ghostGroundAt(tFrac, FILM_SEC, bk, cursorMs);
+        // "new" = ground truth: the frame the REAL cursor actually crosses firstAboveMs (what the
+        // fixed code's precomputed elements-fraction threshold is designed to match).
+        if (newFireFrame == null && sched && cursorMs != null && cursorMs >= sched.firstAboveMs) newFireFrame = i;
+        // "old" = the retired #1148 behavior: comparing the elements-fraction tFrac directly
+        // against the CALENDAR-fraction threshold — the exact bug, reconstructed from raw data,
+        // not by calling any removed code path.
+        if (oldFireFrame == null && out.calendarTriggerT != null && tFrac >= out.calendarTriggerT) oldFireFrame = i;
+        out.liveReplay.frames.push({ i, t: +tFrac.toFixed(4), cursorMs: cursorMs == null ? null : Math.round(cursorMs), o: o == null ? null : +o.toFixed(4) });
+      }
+      out.liveReplay.newFireFrame = newFireFrame;   // the FIX: fires when the real cursor crosses firstAboveMs
+      out.liveReplay.oldFireFrame = oldFireFrame;   // the BUG: #1148 fired when elements-fraction crossed calendarFirstT
 
       A.ghostGroundRestore();
       out.after = { transparent: m.transparent, opacity: m.opacity, depthWrite: m.depthWrite };
@@ -248,6 +304,47 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       P('G-GG-7 the log states the trigger and the arming, so a quiet no-op is visible',
         !!trig && !!armed,
         `${trig || 'no §GHOST_GROUND_SCHEDULE'}\n        ${armed || 'no §GHOST_GROUND armed'}`);
+
+      // G-GG-12: real per-frame replay with the REAL cursor (§GHOST_GROUND_LIVE_TRIGGER fix).
+      const lr = res.liveReplay || {};
+      const frames = lr.frames || [];
+      const nf = lr.newFireFrame, of = lr.oldFireFrame;
+      const preFireFloor = nf == null ? [] : frames.slice(0, nf);
+      const allFloorBeforeFire = preFireFloor.every(f => f.o != null && Math.abs(f.o - 0.22) < 1e-6);
+      let postFireMonotone = true;
+      for (let i = 1; i < frames.length; i++) {
+        if (frames[i].o != null && frames[i - 1].o != null && frames[i].o < frames[i - 1].o - 1e-9) postFireMonotone = false;
+      }
+      const endsOpaque = frames.length && frames[frames.length - 1].o === 1;
+      P('G-GG-12a opacity is pinned at GHOST_OPACITY on every real-cursor frame before the cursor crosses firstAboveMs',
+        lr.armed === true && nf != null && allFloorBeforeFire,
+        `armed=${lr.armed}  fires at replay frame ${nf}/${frames.length ? frames.length - 1 : '?'}  (t=${nf == null ? 'n/a' : frames[nf].t}, ` +
+        `cursorMs=${nf == null ? 'n/a' : frames[nf].cursorMs}, firstAboveMs=${res.firstMs})  ` +
+        `${preFireFloor.length} frames before it, all pinned at 0.22: ${allFloorBeforeFire}`);
+
+      P('G-GG-12b once fired, opacity is monotone non-decreasing and reaches fully opaque by end of film',
+        postFireMonotone && endsOpaque,
+        `monotone=${postFireMonotone}  endOpacity=${frames.length ? frames[frames.length - 1].o : 'n/a'}  ` +
+        `ramp sample near fire: [${frames.slice(Math.max(0, (nf || 0) - 1), (nf || 0) + 5).map(f => f.o).join(' ')}]`);
+
+      // The regression proof: on THIS real building's real schedule, the OLD calendar-fraction
+      // rule and the NEW real-cursor rule fire at DIFFERENT replay frames — the two clocks really
+      // did diverge (not a hypothetical), and the fix's frame is the one that is actually correct
+      // (cursorMs, the value that governs what tmPlacedCount/rendering actually show, has crossed
+      // firstAboveMs exactly at newFireFrame by construction).
+      const diverged = of != null && nf != null && of !== nf;
+      P('G-GG-12c REGRESSION PROOF — the retired calendar-fraction trigger (#1148) and the real-cursor trigger (this fix) fire at different frames on this real schedule',
+        diverged,
+        `old (calendar-fraction, #1148) would fire at frame ${of == null ? 'never' : of} (t=${of == null ? 'n/a' : frames[of].t})  |  ` +
+        `new (real cursor, this fix) fires at frame ${nf == null ? 'never' : nf} (t=${nf == null ? 'n/a' : frames[nf].t})  |  ` +
+        `frame gap=${(of != null && nf != null) ? (of - nf) : 'n/a'}  ` +
+        `(a positive gap means #1148 stayed ghosted LONGER than correct — matching the user's real observation of opacity stuck at the 0.22 floor well past when above-ground elements were visibly placed)`);
+
+      const fired = logs.filter(l => /§GHOST_GROUND_TRIGGER_FIRED/.test(l)).slice(-1)[0] || '';
+      const tick = logs.filter(l => /§GHOST_GROUND_TICK/.test(l)).slice(-1)[0] || '';
+      P('G-GG-13 new diagnostic logging — one-shot TRIGGER_FIRED and periodic TICK lines are present',
+        !!fired && !!tick,
+        `${fired || 'no §GHOST_GROUND_TRIGGER_FIRED'}\n        ${tick || 'no §GHOST_GROUND_TICK'}`);
     }
 
     const pass = checks.filter(c => c.ok).length;


### PR DESCRIPTION
## Summary
- PR #1148 (§CPE_GHOST_GROUND_TRIGGER) reverted the ground-ghost trigger to fire at the first above-ground element, and its own formula-only witness (G-GG-8) measured that correctly in isolation. A real bake still showed `groundOpacity=0.220` pinned exactly at the GHOST floor at `t=0.035` with `placed=2238/63418` — well past when it should have started rising.
- **Root cause**: the trigger compared `tFilm` against `firstAboveMs` converted into a CALENDAR-time fraction. `§CPE_BUILDUP_WORK_PACED` (landed the same day as #1148) turned `tFilm` into an ELEMENTS-PLACED fraction instead — two different clocks compared directly, drifted apart on this bursty real schedule.
- **Fix**: `_ghostGroundArm` now precomputes the trigger threshold in the domain `tFilm` is actually in — the RANK of `firstAboveMs` within the full end_ts order (mirroring `_workCursorAt`'s own indexing) when work-pacing is armed, else the calendar-fraction (mirroring `_workCursorAt`'s own degrade branch). Stays a single precomputed constant per arm so the fade curve remains sampling-density-independent (the property G-GG-6 already guards — an earlier "live-latch on first observed call" version of this fix broke that gate, caught before commit).
- Adds two new diagnostic log lines that did not exist before: `§GHOST_GROUND_TRIGGER_FIRED` (one-shot, exact frame the trigger fires, cross-checked against the real cursor) and `§GHOST_GROUND_TICK` (periodic, every ~5 film-seconds while still ghosted/fading) — closing the "armed → (silence) → restored" gap that made this bug take this long to pin down.
- `sw.js` `CACHE_VERSION` v928 → v929 (no new precached files).

## Real per-frame evidence (Hospital, from the extended witness's live replay)
```
armed rule=first above-ground element aboveOps=62450 belowOps=965 firstAboveMs=1654644218000
  triggerT=0.0074 (domain=elements-placed) calendarFractionT=0.0218 elementsFractionT=0.0074(rank 468/63415)
  — #1148 always used calendarFractionT even when tFilm is elements-placed; this is the divergence that pinned opacity at the floor
G-GG-12c REGRESSION PROOF: old (calendar-fraction, #1148) would fire at frame 9 (t=0.0225) | new (real cursor, this fix) fires at frame 3 (t=0.0075) | frame gap=6
```

## Test plan
- [x] `node --check` on all 4 touched files
- [x] `witness_cpe_ghost_ground.js` extended with G-GG-12a/b/c (real per-frame replay with the actual cursor `A.buildupCursorAt` feeds, not just the trigger-time formula) + G-GG-13 (new log lines present) — **30/30 gates green** on Duplex (15/15) and Hospital (15/15), including all pre-existing #1148 gates (G-GG-1..11)
- [x] `witness_cpe_buildup_topout.js` regression-checked — 4/4 green, unaffected
- [x] Root-caused and fixed via real bake evidence (`§CPE_BUILDUP frame=60/1820 t=0.035 ... groundOpacity=0.220`), not speculation

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RLyi4DXiz3PUCHegrGg8ES