### PR TITLE
fix(4d): phase calendar width is workload-proportional, not flat phaseDays

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -43,6 +43,21 @@
     return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
   }
 
+  // _installSecs — REPLICATES time_machine.js getInstallSecs EXACTLY (same 28800s/day, same 120s
+  // no-data default, same longest-substring productivity match), parameterized instead of reading
+  // window globals so it is node-testable. `rule` is the phase rule already resolved for this
+  // element (matchNameOverride/matchRule) — not re-derived, to keep the classification a single pass.
+  function _installSecs(cls, rule, laborRates) {
+    var resource = rule && rule.resource;
+    if (!resource || !laborRates[resource]) return 120;
+    var labor = laborRates[resource], bestPk = null, bestLen = 0;
+    for (var pk in labor.productivity) {
+      if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
+    }
+    var prod = bestPk ? labor.productivity[bestPk] : 0;
+    return prod > 0 ? Math.round(28800 / prod) : 120;
+  }
+
   // YYYY-MM-DD a given number of whole days after a base date string. Pure UTC arithmetic so
   // it is deterministic regardless of host timezone (no Date.now / locale dependence).
   function _addDays(baseStr, days) {
@@ -109,6 +124,11 @@
                                 // the TM until dated → _cap skips NULL-dated tasks).
     rules = rules || (global.SEQUENCE_RULES) || {};
     var nameOverrides = opts.nameOverrides || (global.SEQUENCE_NAME_OVERRIDES) || [];
+    // §PHASE_DURATION: labor rates for workload-proportional phase width (see below). Falls back to
+    // {} when unavailable (blank-model bootstrap, older tests) — every element then gets the SAME
+    // 120s default weight, which degrades gracefully to plain element-count proportionality, never
+    // to the old flat-phaseDays-per-phase behaviour.
+    var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
 
     // Ensure the IFC-native 4D tables exist (mirror import_db_builder.js DDL exactly).
     db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
@@ -145,9 +165,15 @@
       if (ov) nameOverridden++;
       var rule = ov || matchRule(e.cls, rules, dflt);
       var p = phases[rule.phase];
-      if (!p) { p = phases[rule.phase] = { name: rule.phase, seq: rule.sequence, guids: [] }; }
+      if (!p) { p = phases[rule.phase] = { name: rule.phase, seq: rule.sequence, guids: [], resourceSecs: {} }; }
       if (rule.sequence < p.seq) p.seq = rule.sequence;   // phase ordered by its earliest rule
       p.guids.push(e.guid);
+      // Bucket by resource (trade), not summed flat — see the width computation below: different
+      // trades within a phase run in PARALLEL (this file's own "true parallel trades" principle,
+      // §Current Problems item 3 / resourceCursor in time_machine.js), so a phase's duration is set
+      // by its slowest trade, not the sum of all trades' work.
+      var resKey = rule.resource || '__NONE__';
+      p.resourceSecs[resKey] = (p.resourceSecs[resKey] || 0) + _installSecs(e.cls, rule, laborRates);
     });
     if (nameOverridden) console.log('§NAME_OVERRIDE ' + nameOverridden + ' elements reclassified by name (' +
       nameOverrides.map(function (o) { return o.id; }).join(',') + ') — see rates/sequence_rules.json NAME_OVERRIDES');
@@ -156,14 +182,42 @@
     var ordered = Object.keys(phases).map(function (k) { return phases[k]; });
     ordered.sort(function (a, b) { return (a.seq - b.seq) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0); });
 
+    // §PHASE_DURATION (GANTT_ACCURACY.md "RESUME 2026-08-04+"): each phase's calendar-window width
+    // is workload-proportional, NOT the old flat `phaseDays` constant — that made Superstructure's
+    // 72.4%-of-building bucket occupy the SAME width as Finishes' smallest bucket, so the building
+    // looked visually complete within the first hours of a 4D film (workInFirst10%=51.7%, measured).
+    // Per-trade labor-seconds (Σ getInstallSecs, already-extracted LABOR_RATES productivity) is
+    // divided by that trade's `max_crews` (also already-extracted, not invented — how many
+    // independent crews of a trade work the site simultaneously) to get realistic elapsed days, and
+    // a phase's duration is the SLOWEST trade (max, not sum) — trades within a phase already run in
+    // parallel per this file's own principle, so the bottleneck trade sets the phase's real length.
+    // User-confirmed 2026-08-04: max_crews applied, bottleneck (not summed) — plain Σ-seconds/1-crew
+    // gave Terminal a 10.2y total (Superstructure alone 2,922d); this gives ~3.5y, Superstructure
+    // ~968d (still ~75% of the project, correctly dominant, but no longer absurd).
+    var totalDays = 0;
+    ordered.forEach(function (p) {
+      var maxTradeDays = 0, laborSecsTotal = 0;
+      for (var resKey in p.resourceSecs) {
+        var secs = p.resourceSecs[resKey];
+        laborSecsTotal += secs;
+        var maxCrews = (laborRates[resKey] && laborRates[resKey].max_crews) || 1;
+        var tradeDays = secs / (28800 * maxCrews);
+        if (tradeDays > maxTradeDays) maxTradeDays = tradeDays;
+      }
+      p.widthDays = Math.max(1, Math.ceil(maxTradeDays));
+      p.laborSecs = laborSecsTotal;   // kept for the log line only
+      totalDays += p.widthDays;
+      console.log('§PHASE_DURATION phase=' + p.name + ' elements=' + p.guids.length +
+        ' laborSecs=' + p.laborSecs + ' trades=' + Object.keys(p.resourceSecs).length + ' days=' + p.widthDays);
+    });
+
     db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start]);
 
     // ROOT summary task (is_summary=1 → excluded from _cap leaf window; spans the whole project).
     // In blank mode dates are NULL (the user originates them via scheduleDefault/the wizard).
     var rootId = 'TASK_ROOT';
-    var totalDays = Math.max(phaseDays, ordered.length * phaseDays);
     var rootStart = blank ? null : start;
-    var rootFinish = blank ? null : _addDays(start, ordered.length * phaseDays);
+    var rootFinish = blank ? null : _addDays(start, totalDays);
     db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
       [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, rootStart, rootFinish, blank ? null : 'P' + totalDays + 'D', null, 'PLANNED']);
 
@@ -172,14 +226,14 @@
     var outPhases = [], cursor = 0, assignN = 0;
     ordered.forEach(function (p) {
       var tid = 'TASK_' + _slug(p.name);
-      var s = blank ? null : _addDays(start, cursor * phaseDays);
-      var f = blank ? null : _addDays(start, (cursor + 1) * phaseDays);
-      cursor++;
+      var s = blank ? null : _addDays(start, cursor);
+      var f = blank ? null : _addDays(start, cursor + p.widthDays);
+      cursor += p.widthDays;
       // Leaf, is_summary=0. Dated → _cap.win picks it up; blank/undated → _cap skips it (the user
       // originates the dates, then it appears in the timeline). Assignments are made either way.
-      stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, blank ? null : 'P' + phaseDays + 'D', null, 'PLANNED']);
+      stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, blank ? null : 'P' + p.widthDays + 'D', null, 'PLANNED']);
       p.guids.forEach(function (g) { stmtTe.run([tid, g]); assignN++; });
-      outPhases.push({ taskId: tid, name: p.name, sequence: p.seq, start: s, finish: f, count: p.guids.length });
+      outPhases.push({ taskId: tid, name: p.name, sequence: p.seq, start: s, finish: f, count: p.guids.length, durationDays: p.widthDays });
     });
     stmtTk.free();
     stmtTe.free();
@@ -188,8 +242,8 @@
 
     console.log('§AUTHOR_MATERIALIZE schedule=' + schedId + ' mode=' + (blank ? 'blank' : 'dated') +
       ' phases=' + outPhases.length + ' leafTasks=' + outPhases.length +
-      ' assignments=' + assignN + ' elements=' + elems.length);
-    return { scheduleId: schedId, rootId: rootId, phases: outPhases, taskCount: outPhases.length, assignmentCount: assignN, blank: blank };
+      ' assignments=' + assignN + ' elements=' + elems.length + ' totalDays=' + totalDays);
+    return { scheduleId: schedId, rootId: rootId, phases: outPhases, taskCount: outPhases.length, assignmentCount: assignN, blank: blank, totalDays: totalDays };
   }
 
   // assignElement(db, guid, taskId) — the CRAFT verb. Re-home one element to a different phase task.
@@ -247,17 +301,50 @@
     scheduleId = scheduleId || 'SCH_AUTHORED';
     opts = opts || {};
     var start = opts.start || '2026-01-01';
-    var phaseDays = opts.phaseDays || 30;
+    var phaseDays = opts.phaseDays || 30;   // still the floor/no-data fallback width (see below)
+    var rules = opts.rules || (global.SEQUENCE_RULES) || {};
+    var dflt = opts.defaultRule || (global.SEQUENCE_DEFAULT) || { phase: 'Architecture', sequence: 6, resource: null };
+    var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
     var lr = db.exec("SELECT task_id FROM tasks WHERE schedule_id='" + scheduleId +
       "' AND (is_summary IS NULL OR is_summary=0) ORDER BY rowid");
     var ids = (lr.length && lr[0].values.length) ? lr[0].values.map(function (r) { return r[0]; }) : [];
+
+    // §PHASE_DURATION — same bug, same fix as materializeDefault (GANTT_ACCURACY.md "RESUME
+    // 2026-08-04+"): a blank-materialized schedule reaches this function with dates not yet
+    // assigned, so `phaseDays` was the ONLY width ever used here too. Re-derive each task's
+    // workload from task_elements/elements_meta (materializeDefault's own phase objects aren't
+    // persisted) and apply the identical bottleneck-trade, max_crews-adjusted width. A task with
+    // no resolvable elements/labor data falls back to opts.phaseDays (matches materializeDefault's
+    // own no-laborRates degrade-to-count behaviour when there's nothing to weight by).
+    var widthDays = {};
+    ids.forEach(function (tid) {
+      var er = db.exec("SELECT m.ifc_class FROM task_elements te JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id=?", [tid]);
+      var resourceSecs = {};
+      if (er.length && er[0].values.length) {
+        er[0].values.forEach(function (row) {
+          var cls = row[0];
+          var rule = matchRule(cls, rules, dflt);
+          var resKey = rule.resource || '__NONE__';
+          resourceSecs[resKey] = (resourceSecs[resKey] || 0) + _installSecs(cls, rule, laborRates);
+        });
+      }
+      var maxTradeDays = 0;
+      for (var resKey2 in resourceSecs) {
+        var maxCrews = (laborRates[resKey2] && laborRates[resKey2].max_crews) || 1;
+        var d = resourceSecs[resKey2] / (28800 * maxCrews);
+        if (d > maxTradeDays) maxTradeDays = d;
+      }
+      widthDays[tid] = maxTradeDays > 0 ? Math.max(1, Math.ceil(maxTradeDays)) : phaseDays;
+    });
+
     var cursor = 0;
     db.run('BEGIN TRANSACTION');   // §SE-5a — same per-statement-overhead fix as materializeDefault
     ids.forEach(function (tid) {
-      var s = _addDays(start, cursor), f = _addDays(start, cursor + phaseDays);
+      var w = widthDays[tid];
+      var s = _addDays(start, cursor), f = _addDays(start, cursor + w);
       db.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
-        [s, f, 'P' + phaseDays + 'D', tid]);
-      cursor += phaseDays;
+        [s, f, 'P' + w + 'D', tid]);
+      cursor += w;
     });
     db.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
       [start, _addDays(start, cursor), scheduleId]);

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -12,6 +12,7 @@
   function A() { return global.APP || global.A; }
   function db() { var a = A(); return a && a.db; }
   function rules() { return global.SEQUENCE_RULES || {}; }
+  function laborRates() { return global.LABOR_RATES || {}; }
   var SA = function () { return global.ScheduleAuthor; };
 
   // §SE-6: the wizard edits APP.db directly (shares it with the whole viewer) — but kernel_ops.js's
@@ -230,7 +231,7 @@
     }
     var blankEl = document.getElementById('sa-blank');
     var blank = !!(blankEl && blankEl.checked);
-    var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', phaseDays: 30, blank: blank });
+    var res = SA().materializeDefault(d, rules(), { start: '2026-01-01', laborRates: laborRates(), blank: blank });
     _state = { schedId: res.scheduleId, start: '2026-01-01', order: [], name: {}, dur: {}, count: {} };
     refreshState();
     console.log('§AUTHOR_UI_DRAFT mode=' + (blank ? 'blank' : 'dated') + ' phases=' + res.phases.length + ' assignments=' + res.assignmentCount);
@@ -243,7 +244,7 @@
   // The user's deliberate "originate the dates" act (blank mode) — lay phases out from the start date.
   function scheduleNow() {
     var d = db(); if (!d || !SA() || !_state) return;
-    SA().scheduleContiguous(d, _state.schedId, { start: _state.start || '2026-01-01', phaseDays: 30 });
+    SA().scheduleContiguous(d, _state.schedId, { start: _state.start || '2026-01-01', laborRates: global.LABOR_RATES });
     refreshState(); render();
     status('Scheduled — phases now carry dates and appear in the timeline.');
     _syncWhatIf();   // dates just originated → mirror into C_ProjectPhase for the What-if panel

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -187,9 +187,9 @@
 </section>
 <script src="https://cdn.jsdelivr.net/npm/rtree-sql.js@1.7.0/dist/sql-wasm.js"></script>
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
-<script src="schedule_author.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=11" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_editor_ui.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -500,7 +500,7 @@
     }
     status('Materializing default schedule — please wait…');
     setTimeout(function () {
-      var res = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+      var res = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', laborRates: global.LABOR_RATES });
       schedId = res.scheduleId;
       collapsed = {}; critSet = {};
       renderWbs(); renderDeps(); renderGantt(); fillAddForm();
@@ -650,7 +650,7 @@
         status('Materializing default schedule for ' + url.split('/').pop() + ' — please wait…');
         return new Promise(function (resolve) {
           setTimeout(function () {
-            var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', phaseDays: 30 });
+            var resM = SA().materializeDefault(db, global.SEQUENCE_RULES, { start: '2026-01-01', laborRates: global.LABOR_RATES });
             schedId = 'SCH_AUTHORED';
             status('Seeded default schedule (' + resM.phases.length + ' phases) — ' + url.split('/').pop());
             persist();   // §SE-6 — the freshly-seeded schedule is itself an edit worth saving

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v929';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v930';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -929,9 +929,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=64" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=1" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
-<script src="schedule_author.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_author_ui.js?v=7" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author_ui.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- HR_BIM_Asset spatial lenses (prompts/RESUME_HR_BIM_ASSET.md §RESUME NEXT#2). ADDITIVE peer module: the
@@ -1019,7 +1019,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=532')
+  navigator.serviceWorker.register('sw.js?v=533')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
   // §BUILD_VERSION_STAMP: log the ACTIVE (controlling) service worker's CACHE_VERSION at page

--- a/witness_phase_duration.js
+++ b/witness_phase_duration.js
@@ -1,0 +1,114 @@
+// witness_phase_duration.js — GANTT_ACCURACY.md "RESUME 2026-08-04+" phase-duration fix.
+//
+// ISSUE PROVED: schedule_author.js materializeDefault() gave every phase the SAME fixed-width
+// calendar slot (phaseDays:30) regardless of population — Terminal's Superstructure (72.4% of all
+// 48,428 elements) occupied the same window as Finishes (0.5%), so the building looked visually
+// "done" (Architecture-looking mass complete) within the first hours of playback
+// (workInFirst10%OfCalendar=51.7%, measured 2026-08-03). This witness proves the fix makes phase
+// window WIDTH workload-proportional (Σ labor-seconds via the already-extracted LABOR_RATES
+// productivity table), and reports the real numbers on real Terminal_extracted.db — not invented.
+//
+// Non-invent: real Terminal_extracted.db (48,428 elements); SEQUENCE_RULES/LABOR_RATES/
+// SEQUENCE_DEFAULT extracted verbatim from rates.js; materializeDefault is the real shipped function.
+
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, 'viewer');
+var DB_PATH = '/home/red1/bim-compiler/deploy/buildings/Terminal_extracted.db';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-PHASEDUR PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-PHASEDUR FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+// Extract SEQUENCE_RULES / SEQUENCE_DEFAULT / LABOR_RATES verbatim from rates.js (same technique
+// as erp/tests/author_4d_witness.js loadRules(), widened to also pull LABOR_RATES).
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var LABOR_RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  // eslint-disable-next-line no-new-func
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES };'))();
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  var rulesPack = loadRules();
+  var RULES = rulesPack.SEQUENCE_RULES, DEFAULT = rulesPack.SEQUENCE_DEFAULT, LABOR = rulesPack.LABOR_RATES;
+  console.log('§W-PHASEDUR RULES-LOADED keys=' + Object.keys(RULES).length + ' labor=' + Object.keys(LABOR).length);
+
+  var dbBytes = fs.readFileSync(DB_PATH);
+  var db = new SQL.Database(new Uint8Array(dbBytes));
+  var nElems = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+  check('real-db-loaded', nElems === 48428, 'elements=' + nElems);
+
+  // ── OLD behaviour, for comparison: flat phaseDays=30, no laborRates ── (fresh db — TASK_ROOT's
+  // id is not scoped by schedule_id, so re-materializing a DIFFERENT scheduleId on the SAME db
+  // collides; real callers only ever use one scheduleId at a time, this is a witness-only artifact)
+  var dbOld = new SQL.Database(new Uint8Array(dbBytes));
+  var resOld = ScheduleAuthor.materializeDefault(dbOld, RULES, { start: '2026-01-01', phaseDays: 30, scheduleId: 'SCH_OLD_FLAT' });
+  // laborRates omitted here on purpose but the fix ALWAYS computes width from laborSecs now, so
+  // "old" behaviour (flat 30d/phase) no longer exists as a code path — this call instead shows the
+  // element-count-only degraded mode (laborRates={} → every element weighted 120s equally →
+  // width ∝ pure element count, the documented no-data fallback).
+  var oldTotal = resOld.totalDays;
+  console.log('§W-PHASEDUR OLD(no-laborRates, count-proportional) totalDays=' + oldTotal);
+  resOld.phases.forEach(function (p) {
+    console.log('  ' + p.name + ' count=' + p.count + ' days=' + p.durationDays +
+      ' pctOfTotal=' + (100 * p.durationDays / oldTotal).toFixed(1) + '%');
+  });
+
+  // ── NEW behaviour: real LABOR_RATES productivity → labor-day-weighted width ──
+  var resNew = ScheduleAuthor.materializeDefault(db, RULES, { start: '2026-01-01', laborRates: LABOR, scheduleId: 'SCH_AUTHORED' });
+  var newTotal = resNew.totalDays;
+  console.log('§W-PHASEDUR NEW(laborRates) totalDays=' + newTotal);
+  resNew.phases.forEach(function (p) {
+    console.log('  ' + p.name + ' count=' + p.count + ' days=' + p.durationDays +
+      ' pctOfTotal=' + (100 * p.durationDays / newTotal).toFixed(1) + '%');
+  });
+
+  // G1: Superstructure (72.4% of elements) no longer gets the SAME width as Finishes (0.5%).
+  var supNew = resNew.phases.filter(function (p) { return p.name === 'Superstructure'; })[0];
+  var finNew = resNew.phases.filter(function (p) { return p.name === 'Finishes'; })[0];
+  check('G1-superstructure-wider-than-finishes', supNew.durationDays > finNew.durationDays,
+    'Superstructure=' + supNew.durationDays + 'd Finishes=' + finNew.durationDays + 'd');
+
+  // G2: width tracks labor, not just headcount — Architecture's SHARE of the total calendar nearly
+  // DOUBLES under labor+max_crews weighting vs the pure element-count fallback (its mix of
+  // CARPENTER/MASON/ROOFER/proxy work is slower-per-unit than its 2.6%-of-elements headcount alone
+  // would suggest). Superstructure's own share is a poor probe here — it happens to land within
+  // 0.1pp of its count-proportional share by coincidence of this specific building's numbers, even
+  // though its ABSOLUTE days (144 → 968, G1) changed by 6.7x.
+  var archOld = resOld.phases.filter(function (p) { return p.name === 'Architecture'; })[0];
+  var archNew = resNew.phases.filter(function (p) { return p.name === 'Architecture'; })[0];
+  var archNewPct = 100 * archNew.durationDays / newTotal;
+  var archOldPct = 100 * archOld.durationDays / oldTotal;
+  check('G2-labor-weighting-changes-share-vs-pure-count', Math.abs(archNewPct - archOldPct) > 0.5,
+    'countProportional=' + archOldPct.toFixed(1) + '% laborProportional=' + archNewPct.toFixed(1) + '%');
+
+  // G3: no phase collapses to 0 days (every populated phase gets a real window).
+  var anyZero = resNew.phases.some(function (p) { return p.durationDays < 1; });
+  check('G3-no-zero-width-phase', !anyZero);
+
+  // G4: the fix is DERIVED from real productivity+max_crews data, not a hardcoded ratio —
+  // reproducible by hand from the shipped rates.js numbers alone. Superstructure's bottleneck
+  // trade is STEEL_ERECTOR (33,324 IfcPlate@12/day + 432 IfcBeam@8/day + 158 IfcColumn@6/day +
+  // 442 IfcMember@10/day), max_crews=3, vs CONCRETE_GANG's much smaller 705 IfcSlab@35/day — the
+  // phase's widthDays must equal ceil(STEEL_ERECTOR secs / (28800*3)), not their sum.
+  var steelSecs = 33324 * Math.round(28800 / 12) + 432 * Math.round(28800 / 8) +
+    158 * Math.round(28800 / 6) + 442 * Math.round(28800 / 10);
+  var expectSteelDays = Math.ceil(steelSecs / (28800 * 3));
+  check('G4-matches-hand-computed-bottleneck-trade', supNew.durationDays === expectSteelDays,
+    'handComputed(STEEL_ERECTOR/3 crews)=' + expectSteelDays + 'd supTotal=' + supNew.durationDays + 'd');
+
+  console.log('§W-PHASEDUR SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§W-PHASEDUR ERROR', e); process.exit(1); });


### PR DESCRIPTION
## Summary
- `schedule_author.js`'s `materializeDefault()` gave every phase the SAME fixed 30-day slot regardless of population — Terminal's Superstructure (72.4% of 48,428 elements) got the same window as Finishes (0.5%), so a 4D bake looked visually complete within the first hours (`workInFirst10%OfCalendar=51.7%`, diagnosed 2026-08-03 — see bim-compiler `prompts/GANTT_ACCURACY.md` "RESUME 2026-08-04+").
- Phase width is now workload-proportional: Σ per-trade labor-seconds (already-extracted `LABOR_RATES` productivity) ÷ that trade's `max_crews` (also already-extracted, previously unused), taking the slowest trade as the phase duration (trades within a phase already run in parallel).
- Pure serial Σ-seconds/1-crew was tried first — gives Terminal a 10.2y total (Superstructure alone 2,922d), rejected as unrealistic. max_crews + bottleneck-trade gives ~3.5y total, Superstructure ~968d (still ~75% of the project, correctly dominant, no longer absurd).
- Same flat-`phaseDays` bug found and fixed in `scheduleContiguous()` (the blank-model "originate the dates" flow) — missed by the original investigation.

## Test plan
- [x] `node witness_phase_duration.js` — 5/5 green on real `Terminal_extracted.db`, hand-computed bottleneck-trade day count matches exactly (968d)
- [x] Full existing author/schedule witness suite re-run, all green (`author_4d_witness`, `author_blank_start_witness`, `schedule_cpm_witness`, `author_wizard_wiring`, `schedule_move_witness`, `author_captured_witness`, `schedule_editor_witness`, `author_5d_cost_witness`, `schedule_sync_witness`, `test_facade_stagger_order`)
- [ ] User bakes a live 4D movie against this branch to confirm the visual pacing improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)