### PR TITLE
fix(4d): real-cause fix for Terminal's schedule skew — quantity weighting + phase overlap, film hack removed

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -81,41 +81,10 @@
       return false;
     }
     _wpSched = sch;
-    var phaseMode = sch.phases && sch.phases.length > 1;
-    console.log('§CPE_BUILDUP_PACING mode=' + (phaseMode ? 'even-phase' : 'work') + ' ops=' + sch.total +
-      (phaseMode ? ' phases=' + sch.phases.length + ' — each phase gets an EQUAL film segment, work-paced within it'
-                 : ' — t=0.10 now means 10% of the ELEMENTS placed, not 10% of the days elapsed') +
+    console.log('§CPE_BUILDUP_PACING mode=work ops=' + sch.total +
+      ' — t=0.10 now means 10% of the ELEMENTS placed, not 10% of the days elapsed' +
       ' (this model puts ' + (sch.workInFirstTenthOfCalendar * 100).toFixed(1) + '% of its work in the first 10% of its calendar)');
     return true;
-  }
-
-  // §CPE_PHASE_STAGGER (2026-08-04): a visually homogeneous phase (Terminal's Superstructure is
-  // 72.4% one thing — 33,324 near-identical "Metal Deck" IfcPlate) reads as monotonous tiling when
-  // played in total isolation for its own equal segment, even though §CPE_EVEN_PHASE_PACING already
-  // gives it a fair (not dominant) share of the film. Real construction overlaps trades too (this
-  // file's own "true parallel trades" principle) — so phase i's window is allowed to START
-  // STAGGER_OVERLAP/N EARLY, borrowed from phase i-1's tail, while its END stays at its nominal
-  // boundary (unchanged share of the film, just entered from an earlier point). `_phaseWindow` is
-  // the SINGLE SOURCE for this window shape — `_workCursorAt` and `_ghostGroundArm`'s inverse
-  // lookup both call it, so they cannot drift into the two-different-clocks bug class that shipped
-  // twice already this file (§GHOST_GROUND_LIVE_TRIGGER, then its 2026-08-04 recurrence when
-  // §CPE_EVEN_PHASE_PACING first landed).
-  var STAGGER_OVERLAP = 0.20;
-
-  function _phaseWindow(i, N) {
-    return { lo: Math.max(0, i - STAGGER_OVERLAP) / N, hi: (i + 1) / N };
-  }
-
-  // One phase's own monotonic cursor contribution at film-fraction t, or null before its window
-  // opens. Monotonic non-decreasing in t by construction (linear ramp into a sorted-array lookup,
-  // saturating at the phase's own max) — this is what makes `max` over every phase's contribution
-  // (below) monotonic too, with no boundary special-casing required.
-  function _phaseCursorAt(t, ph, win) {
-    if (!ph.total || t < win.lo) return null;
-    var localT = win.hi > win.lo ? Math.min(1, (t - win.lo) / (win.hi - win.lo)) : 1;
-    var k = Math.round(localT * ph.total);
-    if (k < 1) return null;
-    return ph.ends[Math.min(ph.total, k) - 1];
   }
 
   // The cursor this frame should ask for. Pure function of the film fraction, so preview and bake
@@ -126,24 +95,7 @@
     if (!_wpSched) return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
     if (t <= 0) return _wpSched.projectStart;
     if (t >= 1) return _wpSched.projectEnd;
-    // §CPE_EVEN_PHASE_PACING: split the film into one EQUAL segment per phase (in the phase's own
-    // schedule order), and work-pace (k-th completion) WITHIN that phase's own segment. A
-    // population-dominant phase no longer eats the film in proportion to its element count — it
-    // gets the same screen time as every other phase, same as this file's within-phase pacing
-    // already gives every ELEMENT an even share of its own phase's time. §CPE_PHASE_STAGGER above
-    // widens each phase's window on its LEADING edge only, so cursor(t) = max over every phase's
-    // own (individually monotonic) contribution — the max of monotonic functions is monotonic.
-    var phases = _wpSched.phases;
-    if (phases && phases.length) {
-      var N = phases.length, best = -Infinity;
-      for (var i = 0; i < N; i++) {
-        var val = _phaseCursorAt(t, phases[i], _phaseWindow(i, N));
-        if (val != null && val > best) best = val;
-      }
-      return best > -Infinity ? best : _wpSched.projectStart;
-    }
-    // Fallback (no phase grouping available — e.g. every op landed in one phase): the original
-    // global k-th completion. `ends` is sorted, so this is the instant at which exactly k ops are done.
+    // k-th completion. `ends` is sorted, so this is the instant at which exactly k ops are done.
     var k = Math.round(t * _wpSched.total);
     if (k < 1) return _wpSched.projectStart;
     if (k >= _wpSched.total) return _wpSched.projectEnd;
@@ -258,38 +210,11 @@
     var elementsFirstT = null, elementsFirstTSrc = 'work schedule unavailable';
     if (!_wpTried) _workPacingArm();  // force-arm early so this bake's OWN schedule is what the
                                        // threshold is computed from, not a race with frame 0.
-    // §CPE_EVEN_PHASE_PACING / §CPE_PHASE_STAGGER (2026-08-04): `tFilm` maps through `_phaseWindow`
-    // now, not a flat global-rank fraction or even N equal un-overlapping segments — inverting
-    // `_workCursorAt`'s mapping via a rank in the flat `_wpSched.ends` array (the ORIGINAL fix
-    // below) reproduces the exact §GHOST_GROUND_LIVE_TRIGGER bug class: a precomputed threshold
-    // computed in a domain `_workCursorAt` no longer uses. Find which phase `firstAboveMs` belongs
-    // to and its rank WITHIN that phase, then invert via THAT SAME phase's `_phaseWindow(i, N)` —
-    // the identical window `_workCursorAt`/`_phaseCursorAt` use — guaranteeing
-    // `_workCursorAt(firstT) === firstAboveMs` again, by construction. Only phase j itself (the one
-    // containing firstAboveMs) can produce that exact value: an earlier phase i<j saturates below
-    // it (its whole calendar range precedes phase j's), and a later phase i>j cannot produce a
-    // value AS SMALL as firstAboveMs (its own smallest end_ts is already >= phase j's largest) — so
-    // the single-phase inversion is exact, the overlap window doesn't need to be searched globally.
     if (sched.firstAboveMs != null && _wpSched && _wpSched.total) {
-      if (_wpSched.phases && _wpSched.phases.length) {
-        var _phs = _wpSched.phases, _Nph = _phs.length, _segFound = -1, _rankFound = -1;
-        for (var _pi = 0; _pi < _Nph; _pi++) {
-          var _pends = _phs[_pi].ends, _plo = 0, _phi = _pends.length;
-          while (_plo < _phi) { var _pmid = (_plo + _phi) >>> 1; if (_pends[_pmid] < sched.firstAboveMs) _plo = _pmid + 1; else _phi = _pmid; }
-          if (_plo < _pends.length) { _segFound = _pi; _rankFound = _plo; break; }
-        }
-        if (_segFound < 0) { _segFound = _Nph - 1; _rankFound = _phs[_Nph - 1].total - 1; }   // past the last op
-        var _win = _phaseWindow(_segFound, _Nph);
-        var _localT = (_rankFound + 1) / _phs[_segFound].total;
-        elementsFirstT = _win.lo + _localT * (_win.hi - _win.lo);
-        elementsFirstTSrc = 'phase ' + _phs[_segFound].name + ' rank ' + (_rankFound + 1) + '/' + _phs[_segFound].total +
-          ' (segment ' + (_segFound + 1) + '/' + _Nph + ', window ' + _win.lo.toFixed(4) + '-' + _win.hi.toFixed(4) + ')';
-      } else {
-        var _ends = _wpSched.ends, _lo = 0, _hi = _ends.length;
-        while (_lo < _hi) { var _mid = (_lo + _hi) >>> 1; if (_ends[_mid] < sched.firstAboveMs) _lo = _mid + 1; else _hi = _mid; }
-        elementsFirstT = (_lo + 1) / _wpSched.total;
-        elementsFirstTSrc = 'rank ' + (_lo + 1) + '/' + _wpSched.total + ' in the full end_ts order';
-      }
+      var _ends = _wpSched.ends, _lo = 0, _hi = _ends.length;
+      while (_lo < _hi) { var _mid = (_lo + _hi) >>> 1; if (_ends[_mid] < sched.firstAboveMs) _lo = _mid + 1; else _hi = _mid; }
+      elementsFirstT = (_lo + 1) / _wpSched.total;
+      elementsFirstTSrc = 'rank ' + (_lo + 1) + '/' + _wpSched.total + ' in the full end_ts order';
     }
     // The domain `tFilm` is ACTUALLY in: elements-fraction when work-pacing armed (mirrors
     // `_workCursorAt`'s own branch), else calendar-fraction (mirrors its degrade branch).
@@ -1435,9 +1360,6 @@
       window.APP.buildupTAt = _buildupTAt;
       window.APP.buildupTopoutU = _buildupTopoutU;
       window.APP.buildupPacingReset = _workPacingReset;
-      // §CPE_PHASE_STAGGER: exposed so a witness gates the REAL constant, not a hand-copied guess
-      // that can drift from the shipped value.
-      window.APP.buildupStaggerOverlap = STAGGER_OVERLAP;
       window.APP.ghostGroundArm = _ghostGroundArm;
       window.APP.ghostGroundAt = _ghostGroundAt;
       window.APP.ghostGroundRestore = _ghostGroundRestore;

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -47,7 +47,10 @@
   // no-data default, same longest-substring productivity match), parameterized instead of reading
   // window globals so it is node-testable. `rule` is the phase rule already resolved for this
   // element (matchNameOverride/matchRule) — not re-derived, to keep the classification a single pass.
-  function _installSecs(cls, rule, laborRates) {
+  // `realQty` (optional) — §LABOR_QUANTITY_WEIGHT below: when a class is geometrically
+  // over-fragmented, the caller passes this element's REAL bbox area instead of leaving it null,
+  // and the same per-unit rate (28800/prod) is charged per m² instead of once per element.
+  function _installSecs(cls, rule, laborRates, realQty) {
     var resource = rule && rule.resource;
     if (!resource || !laborRates[resource]) return 120;
     var labor = laborRates[resource], bestPk = null, bestLen = 0;
@@ -55,7 +58,71 @@
       if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
     }
     var prod = bestPk ? labor.productivity[bestPk] : 0;
-    return prod > 0 ? Math.round(28800 / prod) : 120;
+    if (prod <= 0) return 120;
+    var secsPerUnit = 28800 / prod;
+    return Math.round(realQty != null ? secsPerUnit * realQty : secsPerUnit);
+  }
+
+  // _classFragmentation(db, rates) — §LABOR_QUANTITY_WEIGHT (GANTT_ACCURACY.md "RESUME 2026-08-04,
+  // root cause found"): 33,324 Terminal "Metal Deck" IfcPlate fragments average 0.074 m² each —
+  // smaller than a floor tile — so charging LABOR_RATES.STEEL_ERECTOR.productivity.IfcPlate=12/day
+  // once PER FRAGMENT (33,324 "elements") inflated Superstructure to 968 days. The formula itself
+  // was never wrong; its INPUT (element count as a proxy for real installable quantity) was wrong
+  // for this one over-fragmented class.
+  //
+  // The fix is NOT "always use RATES[cls].unit='M2' as area" — measured on Terminal, every OTHER
+  // M2-priced class already has a normal, real-panel-sized average (IfcSlab 22.7 m², IfcWall 40.6
+  // m², IfcCovering 65.6 m², IfcRoof 91.4 m²) — their per-element counts already ARE real
+  // installable units, and area-weighting them anyway would invent a NEW regression with zero
+  // evidence behind it (measured: IfcWall would jump from ~14 days to 563 days). So this is a
+  // DATA-DRIVEN per-class test, not a per-unit-type blanket rule: an M2-priced class is
+  // fragmented only when its OWN measured average bbox area is smaller than a floor tile
+  // (FRAGMENT_M2_FLOOR) — the same yardstick this file's own investigation already used in
+  // prose ("0.074 m² is smaller than a floor tile"), now the actual test. Any building where some
+  // OTHER M2 class is the fragmented one (curtain-wall glazing, brick coursing) is caught the same
+  // way, generically — nothing here names "Metal Deck" or "IfcPlate".
+  //
+  // Non-invented: uses RATES[cls].unit (already shipped, rates.js) to find candidate classes, and
+  // the EXACT analysis_sidecar.js compute5D dominant-face-area SQL expression (already shipped) to
+  // measure them. No conversion factor, no assumed "real plate size" — the measured average IS the
+  // test, and the real per-element area IS the weight.
+  var FRAGMENT_M2_FLOOR = 1.0;   // m² — "smaller than a floor tile"
+  var _AREA_EXPR = "MAX(t.bbox_x,t.bbox_y,t.bbox_z) * CASE " +
+    "WHEN t.bbox_x>=t.bbox_y AND t.bbox_x>=t.bbox_z THEN MAX(t.bbox_y,t.bbox_z) " +
+    "WHEN t.bbox_y>=t.bbox_x AND t.bbox_y>=t.bbox_z THEN MAX(t.bbox_x,t.bbox_z) " +
+    "ELSE MAX(t.bbox_x,t.bbox_y) END";
+  function _classFragmentation(db, qsRates) {
+    var out = { fragmented: {}, area: {} };
+    qsRates = qsRates || {};
+    var m2Classes = [];
+    for (var cls in qsRates) if (qsRates[cls] && qsRates[cls].unit === 'M2') m2Classes.push(cls);
+    if (!m2Classes.length) return out;
+    var q = function (list) { return list.map(function (c) { return "'" + c.replace(/'/g, "''") + "'"; }).join(','); };
+    var r;
+    try {
+      r = db.exec("SELECT m.ifc_class, COUNT(*), SUM(" + _AREA_EXPR + ") FROM elements_meta m " +
+        "JOIN element_transforms t ON m.guid=t.guid WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 " +
+        "AND m.ifc_class IN (" + q(m2Classes) + ") GROUP BY m.ifc_class");
+    } catch (e) { return out; }   // no element_transforms table (e.g. a stripped test DB) — degrade to count-based
+    var fragClasses = [];
+    if (r.length && r[0].values.length) {
+      r[0].values.forEach(function (row) {
+        var cls = row[0], cnt = row[1], total = row[2] || 0;
+        var avg = cnt > 0 ? total / cnt : 0;
+        if (avg > 0 && avg < FRAGMENT_M2_FLOOR) { out.fragmented[cls] = { avg: avg, total: total, count: cnt }; fragClasses.push(cls); }
+      });
+    }
+    if (!fragClasses.length) return out;
+    var ar = db.exec("SELECT m.guid, " + _AREA_EXPR + " FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+      "WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 AND m.ifc_class IN (" + q(fragClasses) + ")");
+    if (ar.length && ar[0].values.length) ar[0].values.forEach(function (row) { out.area[row[0]] = row[1] || 0; });
+    fragClasses.forEach(function (cls) {
+      var f = out.fragmented[cls];
+      console.log('§LABOR_QUANTITY_WEIGHT class=' + cls + ' count=' + f.count + ' avgArea=' + f.avg.toFixed(4) +
+        'm2 (<' + FRAGMENT_M2_FLOOR + 'm2 floor) totalRealArea=' + f.total.toFixed(1) +
+        'm2 — real AREA used as labor quantity, not element count');
+    });
+    return out;
   }
 
   // YYYY-MM-DD a given number of whole days after a base date string. Pure UTC arithmetic so
@@ -129,11 +196,17 @@
     // 120s default weight, which degrades gracefully to plain element-count proportionality, never
     // to the old flat-phaseDays-per-phase behaviour.
     var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
+    // §LABOR_QUANTITY_WEIGHT: RATES (rates.js, the QS/BOQ cost table — separate from LABOR_RATES)
+    // gives each class's real physical measure via `unit`. Used ONLY to detect and re-weight
+    // classes whose geometry is over-fragmented relative to real installable units — see
+    // _classFragmentation's header for why this cannot be a blanket per-unit-type rule.
+    var qsRates = opts.rates || (global.RATES) || {};
 
     // Ensure the IFC-native 4D tables exist (mirror import_db_builder.js DDL exactly).
     db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
     _ensureWideTasks(db);   // migrate any legacy-thin tasks table → the widened DDL `_cap` reads
     db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+    var _frag = _classFragmentation(db, qsRates);
 
     // §SE-5a: one transaction around the whole rebuild (delete + insert). Without this, sql.js pays
     // per-statement implicit-commit overhead on EVERY row — for a large building (tens of thousands of
@@ -150,11 +223,12 @@
     db.run("DELETE FROM tasks WHERE schedule_id='" + schedId + "'");
     db.run("DELETE FROM schedules WHERE schedule_id='" + schedId + "'");
 
-    // Read the raw material: every element + its class + name (name feeds matchNameOverride).
+    // Read the raw material: every element + its class + name (name feeds matchNameOverride) +
+    // storey (§PHASE_OVERLAP_BAND below — real band count for the overlap fix).
     var elems = [];
-    var er = db.exec('SELECT guid, ifc_class, COALESCE(element_name,\'\') FROM elements_meta');
+    var er = db.exec('SELECT guid, ifc_class, COALESCE(element_name,\'\'), COALESCE(storey,\'\') FROM elements_meta');
     if (er.length && er[0].values.length) {
-      er[0].values.forEach(function (r) { elems.push({ guid: r[0], cls: r[1], name: r[2] }); });
+      er[0].values.forEach(function (r) { elems.push({ guid: r[0], cls: r[1], name: r[2], storey: r[3] }); });
     }
 
     // Group into phases via the SAME rule the read-path uses.
@@ -165,15 +239,17 @@
       if (ov) nameOverridden++;
       var rule = ov || matchRule(e.cls, rules, dflt);
       var p = phases[rule.phase];
-      if (!p) { p = phases[rule.phase] = { name: rule.phase, seq: rule.sequence, guids: [], resourceSecs: {} }; }
+      if (!p) { p = phases[rule.phase] = { name: rule.phase, seq: rule.sequence, guids: [], resourceSecs: {}, storeys: {} }; }
       if (rule.sequence < p.seq) p.seq = rule.sequence;   // phase ordered by its earliest rule
       p.guids.push(e.guid);
+      p.storeys[e.storey] = true;   // §PHASE_OVERLAP_BAND below — real storey count, not invented
       // Bucket by resource (trade), not summed flat — see the width computation below: different
       // trades within a phase run in PARALLEL (this file's own "true parallel trades" principle,
       // §Current Problems item 3 / resourceCursor in time_machine.js), so a phase's duration is set
       // by its slowest trade, not the sum of all trades' work.
       var resKey = rule.resource || '__NONE__';
-      p.resourceSecs[resKey] = (p.resourceSecs[resKey] || 0) + _installSecs(e.cls, rule, laborRates);
+      var realQty = (_frag.fragmented[e.cls] && _frag.area[e.guid] != null) ? _frag.area[e.guid] : null;
+      p.resourceSecs[resKey] = (p.resourceSecs[resKey] || 0) + _installSecs(e.cls, rule, laborRates, realQty);
     });
     if (nameOverridden) console.log('§NAME_OVERRIDE ' + nameOverridden + ' elements reclassified by name (' +
       nameOverrides.map(function (o) { return o.id; }).join(',') + ') — see rates/sequence_rules.json NAME_OVERRIDES');
@@ -194,7 +270,21 @@
     // User-confirmed 2026-08-04: max_crews applied, bottleneck (not summed) — plain Σ-seconds/1-crew
     // gave Terminal a 10.2y total (Superstructure alone 2,922d); this gives ~3.5y, Superstructure
     // ~968d (still ~75% of the project, correctly dominant, but no longer absurd).
-    var totalDays = 0;
+    // §PHASE_OVERLAP_BAND (GANTT_ACCURACY.md "GENERIC RULE" item 3, conventional construction
+    // scheduling — Line of Balance / flowline): `materializeDefault` used to place phase i+1 only
+    // after phase i was 100% done PROJECT-WIDE (plain Σ cursor below), so a phase that legitimately
+    // dominates the workload (e.g. Superstructure) pushed every later phase's start out to nearly
+    // the project's end — measured on Terminal pre-fix: Architecture started at day 1,189 of 1,264
+    // (94%). Real construction does not wait for a trade to leave the WHOLE building before the
+    // next trade starts — it follows the leading trade band-by-band (floor-by-floor), starting once
+    // the leading trade has cleared ONE band, same as any flowline/repetitive-work schedule.
+    //
+    // `p.storeys` (built above from `elements_meta.storey`, real extracted data, no name-matching)
+    // gives each phase's real band count. lagDays = the time to clear ONE band (widthDays/numBands)
+    // — not an invented overlap fraction (contrast §CPE_PHASE_STAGGER's fixed 20%, a FILM-layer
+    // hack, now removed). A phase touching only 1 band (numBands=1, e.g. a single-storey building)
+    // degrades to the old fully-contiguous behaviour automatically — no special-casing needed.
+    var totalDays = 0, _cursor = 0;
     ordered.forEach(function (p) {
       var maxTradeDays = 0, laborSecsTotal = 0;
       for (var resKey in p.resourceSecs) {
@@ -206,9 +296,16 @@
       }
       p.widthDays = Math.max(1, Math.ceil(maxTradeDays));
       p.laborSecs = laborSecsTotal;   // kept for the log line only
-      totalDays += p.widthDays;
+      var numBands = Math.max(1, Object.keys(p.storeys).length);
+      p.lagDays = Math.max(1, Math.ceil(p.widthDays / numBands));
+      p.startCursor = _cursor;
+      _cursor += p.lagDays;
+      totalDays = Math.max(totalDays, p.startCursor + p.widthDays);
       console.log('§PHASE_DURATION phase=' + p.name + ' elements=' + p.guids.length +
         ' laborSecs=' + p.laborSecs + ' trades=' + Object.keys(p.resourceSecs).length + ' days=' + p.widthDays);
+      console.log('§PHASE_OVERLAP_BAND phase=' + p.name + ' bands=' + numBands +
+        ' lagDays=' + p.lagDays + ' startsAtDay=' + p.startCursor +
+        ' (overlaps ' + Math.max(0, p.widthDays - p.lagDays) + 'd of the PREVIOUS phase\'s tail)');
     });
 
     db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start]);
@@ -223,12 +320,11 @@
 
     var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
     var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
-    var outPhases = [], cursor = 0, assignN = 0;
+    var outPhases = [], assignN = 0;
     ordered.forEach(function (p) {
       var tid = 'TASK_' + _slug(p.name);
-      var s = blank ? null : _addDays(start, cursor);
-      var f = blank ? null : _addDays(start, cursor + p.widthDays);
-      cursor += p.widthDays;
+      var s = blank ? null : _addDays(start, p.startCursor);
+      var f = blank ? null : _addDays(start, p.startCursor + p.widthDays);
       // Leaf, is_summary=0. Dated → _cap.win picks it up; blank/undated → _cap skips it (the user
       // originates the dates, then it appears in the timeline). Assignments are made either way.
       stmtTk.run([tid, schedId, rootId, p.name, 'CONSTRUCTION', 0, s, f, blank ? null : 'P' + p.widthDays + 'D', null, 'PLANNED']);
@@ -305,9 +401,11 @@
     var rules = opts.rules || (global.SEQUENCE_RULES) || {};
     var dflt = opts.defaultRule || (global.SEQUENCE_DEFAULT) || { phase: 'Architecture', sequence: 6, resource: null };
     var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
+    var qsRates = opts.rates || (global.RATES) || {};   // §LABOR_QUANTITY_WEIGHT — see materializeDefault
     var lr = db.exec("SELECT task_id FROM tasks WHERE schedule_id='" + scheduleId +
       "' AND (is_summary IS NULL OR is_summary=0) ORDER BY rowid");
     var ids = (lr.length && lr[0].values.length) ? lr[0].values.map(function (r) { return r[0]; }) : [];
+    var _frag = _classFragmentation(db, qsRates);
 
     // §PHASE_DURATION — same bug, same fix as materializeDefault (GANTT_ACCURACY.md "RESUME
     // 2026-08-04+"): a blank-materialized schedule reaches this function with dates not yet
@@ -316,16 +414,20 @@
     // persisted) and apply the identical bottleneck-trade, max_crews-adjusted width. A task with
     // no resolvable elements/labor data falls back to opts.phaseDays (matches materializeDefault's
     // own no-laborRates degrade-to-count behaviour when there's nothing to weight by).
-    var widthDays = {};
+    // §PHASE_OVERLAP_BAND — same fix, same reasoning as materializeDefault (see its header comment):
+    // real storey count per task (from elements_meta.storey) instead of a project-wide contiguous cursor.
+    var widthDays = {}, bandCount = {};
     ids.forEach(function (tid) {
-      var er = db.exec("SELECT m.ifc_class FROM task_elements te JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id=?", [tid]);
-      var resourceSecs = {};
+      var er = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.storey,'') FROM task_elements te JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id=?", [tid]);
+      var resourceSecs = {}, storeys = {};
       if (er.length && er[0].values.length) {
         er[0].values.forEach(function (row) {
-          var cls = row[0];
+          var guid = row[0], cls = row[1], storey = row[2];
           var rule = matchRule(cls, rules, dflt);
           var resKey = rule.resource || '__NONE__';
-          resourceSecs[resKey] = (resourceSecs[resKey] || 0) + _installSecs(cls, rule, laborRates);
+          var realQty = (_frag.fragmented[cls] && _frag.area[guid] != null) ? _frag.area[guid] : null;
+          resourceSecs[resKey] = (resourceSecs[resKey] || 0) + _installSecs(cls, rule, laborRates, realQty);
+          storeys[storey] = true;
         });
       }
       var maxTradeDays = 0;
@@ -335,22 +437,26 @@
         if (d > maxTradeDays) maxTradeDays = d;
       }
       widthDays[tid] = maxTradeDays > 0 ? Math.max(1, Math.ceil(maxTradeDays)) : phaseDays;
+      bandCount[tid] = Math.max(1, Object.keys(storeys).length);
     });
 
-    var cursor = 0;
+    var cursor = 0, totalDays = 0;
     db.run('BEGIN TRANSACTION');   // §SE-5a — same per-statement-overhead fix as materializeDefault
     ids.forEach(function (tid) {
       var w = widthDays[tid];
+      var lag = Math.max(1, Math.ceil(w / bandCount[tid]));
       var s = _addDays(start, cursor), f = _addDays(start, cursor + w);
       db.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
         [s, f, 'P' + w + 'D', tid]);
-      cursor += w;
+      console.log('§PHASE_OVERLAP_BAND task=' + tid + ' bands=' + bandCount[tid] + ' lagDays=' + lag + ' startsAtDay=' + cursor);
+      totalDays = Math.max(totalDays, cursor + w);
+      cursor += lag;
     });
     db.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
-      [start, _addDays(start, cursor), scheduleId]);
+      [start, _addDays(start, totalDays), scheduleId]);
     db.run('COMMIT');
-    console.log('§AUTHOR_SCHEDULE schedule=' + scheduleId + ' phases=' + ids.length + ' from=' + start + ' span=' + cursor + 'd');
-    return { scheduled: ids.length, start: start, span: cursor };
+    console.log('§AUTHOR_SCHEDULE schedule=' + scheduleId + ' phases=' + ids.length + ' from=' + start + ' span=' + totalDays + 'd');
+    return { scheduled: ids.length, start: start, span: totalDays };
   }
 
   // foldCost(db, scheduleId, RATES, ratesDefault, currency) — §AUTHOR-1 step ④ (5D).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v932';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v933';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3895,6 +3895,17 @@
       db.run('BEGIN');
       var _upd = db.prepare("UPDATE kernel_ops SET timestamp = ?, parameters = ? " +
         "WHERE op_type = 'ELEMENT_PLACE' AND output_guid = ?");
+      // §PHASE_OVERLAP_SUPPORT_GUARD (GANTT_ACCURACY.md §PHASE_OVERLAP_BAND): schedule_author.js's
+      // task windows can now OVERLAP (a later phase starts once the leading trade clears ONE band,
+      // not the whole building — see materializeDefault). The per-task stagger below still only
+      // orders elements WITHIN their own task; it has no way to know a DIFFERENT (now-overlapping)
+      // task's elements. Measured before shipping: this creates real cross-task support violations
+      // (Terminal 447, Hospital 1,929 — e.g. a beam scheduled before the wall it bears on, because
+      // Architecture's window now starts inside Superstructure's tail). Collect every element's
+      // provisional (s_i, e_i) here instead of writing immediately, then run ONE global correction
+      // pass below — same "push after, never re-key" mechanism §4D_HOST_BEFORE_HOSTED already uses,
+      // just applied across tasks instead of within one.
+      var _allScheduled = [];
       for (var _tid in _byTask) {
         var w = _cap.win[_tid];
         var _bucket = _byTask[_tid];
@@ -3943,13 +3954,60 @@
           if (e_i <= s_i) e_i = s_i + 60000;   // never zero/negative duration
           var p; try { p = JSON.parse(item.params); } catch (e) { p = {}; }
           p.phase = w.name;                         // real task name → shows in mini-Gantt
-          p._end_ts = e_i;
-          p._captured = 1;                          // visual distinction + coverage flag
-          p._task = _tid;
-          _upd.run([s_i, JSON.stringify(p), item.guid]);
+          _allScheduled.push({ guid: item.guid, s: s_i, e: e_i, params: p, task: _tid,
+            bz: item.bz, tz: item.tz, x0: item.x0, x1: item.x1, y0: item.y0, y1: item.y1,
+            cls: item.cls, seq: item.seq });
           _covered++;
         });
       }
+
+      // §PHASE_OVERLAP_SUPPORT_GUARD global pass (see header above). isCarrier/CELL/EPS/GAP are the
+      // SAME role-blind support predicate this file already uses for the generative path
+      // (audit_support_roleblind.js / §SUPPORT_CHECK above) — not a new definition. Processing in
+      // ascending base_z order is safe in ONE pass: a carrier's base_z is always below what it
+      // carries (the support DAG's own topological potential, established by §STAGGER_SUPPORT_ORDER
+      // above), so every true carrier of T has already been visited — and any correction already
+      // applied to it — by the time T is processed.
+      var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
+      var _ogEPS = 0.05, _ogGAP = 0.5;
+      var _ogIsCarrier = function (e) { return e.seq <= 4 || e.cls.indexOf('IfcWall') === 0; };
+      var _ogCells = function (e) {
+        var out = [];
+        for (var cx = Math.floor(e.x0 / _ogCELL); cx <= Math.floor(e.x1 / _ogCELL); cx++)
+          for (var cy = Math.floor(e.y0 / _ogCELL); cy <= Math.floor(e.y1 / _ogCELL); cy++) out.push(cx + '|' + cy);
+        return out;
+      };
+      var _ogXY = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
+      var _ogGrid = {};
+      _allScheduled.forEach(function (e) { if (_ogIsCarrier(e)) _ogCells(e).forEach(function (c) { (_ogGrid[c] = _ogGrid[c] || []).push(e); }); });
+      _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
+      var _ogPushed = 0;
+      _allScheduled.forEach(function (T) {
+        var cells = _ogCells(T), seen = {}, lastEnd = 0;
+        for (var ci = 0; ci < cells.length; ci++) {
+          var arr = _ogGrid[cells[ci]]; if (!arr) continue;
+          for (var si = 0; si < arr.length; si++) {
+            var S = arr[si];
+            if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
+            if (S.bz < T.bz - _ogEPS && Math.abs(S.tz - T.bz) <= _ogGAP && _ogXY(S, T) && S.e > lastEnd) lastEnd = S.e;
+          }
+        }
+        if (lastEnd && T.s < lastEnd) {
+          var dur = Math.max(60000, T.e - T.s);
+          T.s = lastEnd + 1;
+          T.e = T.s + dur;
+          _ogPushed++;
+        }
+      });
+      if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +
+        ' elements later than their §PHASE_OVERLAP_BAND window to stay after their real structural support');
+
+      _allScheduled.forEach(function (item) {
+        item.params._end_ts = item.e;
+        item.params._captured = 1;
+        item.params._task = item.task;
+        _upd.run([item.s, JSON.stringify(item.params), item.guid]);
+      });
       _upd.free();
       db.run('COMMIT');
       _capActive = true;
@@ -5825,46 +5883,6 @@
       ' span=' + Math.round(_projectStart) + '..' + Math.round(_projectEnd) +
       ' workInFirst10%OfCalendar=' + (out.workInFirstTenthOfCalendar * 100).toFixed(1) + '%' +
       ' (10.0% would be evenly spread — anything above it is the burst calendar pacing shows)');
-
-    // §CPE_EVEN_PHASE_PACING (GANTT_ACCURACY.md, 2026-08-04): global element-rank pacing makes
-    // "10% of the film is 10% of the building" TRUE, but a population-dominant phase (Terminal's
-    // Superstructure, 72.4% of 48,428 elements) still eats 72.4% of the FILM, leaving the smaller
-    // phases (Architecture 2.6%, Finishes 0.5%) a blink of screen time regardless of how their
-    // CALENDAR duration is set (§PHASE_DURATION only fixes calendar dates, not film pacing — the
-    // work-paced cursor never reads them). Each op already carries its own phase name
-    // (`parameters.phase`, set by the §PLAYBACK-STAGGER overlay) — group by it, in the phase's own
-    // schedule order (earliest `start_ts` first, i.e. the same order §PHASE_DURATION laid the
-    // phases out in), so the film can give each phase an EQUAL segment of screen time while still
-    // work-pacing (element-rank) WITHIN each phase — the within-phase evenness that made
-    // §CPE_BUILDUP_WORK_PACED necessary in the first place is untouched.
-    var byPhase = {}, order = [];
-    for (i = 0; i < _ops.length; i++) {
-      var ph = (_ops[i].parameters || {}).phase || 'Architecture';
-      var bucket = byPhase[ph];
-      if (!bucket) { bucket = byPhase[ph] = { name: ph, endsArr: [], minStart: Infinity }; order.push(bucket); }
-      bucket.endsArr.push(_ops[i].end_ts);
-      if (_ops[i].start_ts < bucket.minStart) bucket.minStart = _ops[i].start_ts;
-    }
-    order.sort(function(a, b) { return a.minStart - b.minStart; });
-    // Monotonic clamp: real (captured) schedules can have phases that overlap in calendar time.
-    // A running max keeps phase-to-phase cursor values non-decreasing across the whole film, the
-    // same guarantee a single globally-sorted `ends` array gives by construction — without it, a
-    // reveal could jump backward in calendar time at a phase boundary and un-place elements
-    // (renderAtTime's placed test is `end_ts <= cursor`, evaluated fresh every frame).
-    var running = -Infinity;
-    order.forEach(function(p) {
-      p.endsArr.sort(function(a, b) { return a - b; });
-      for (var j = 0; j < p.endsArr.length; j++) {
-        if (p.endsArr[j] < running) p.endsArr[j] = running;
-        running = p.endsArr[j];
-      }
-      p.ends = new Float64Array(p.endsArr);
-      p.total = p.ends.length;
-      delete p.endsArr;
-    });
-    out.phases = order;
-    console.log('§CPE_PHASE_PACING phases=' + order.length + ' ' +
-      order.map(function(p) { return p.name + '=' + p.total; }).join(' '));
     return out;
   };
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -825,7 +825,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=10" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cinema_maxq.js?v=3" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
@@ -927,9 +927,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=65" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=66" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=1" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
-<script src="schedule_author.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=11" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
@@ -1019,7 +1019,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=535')
+  navigator.serviceWorker.register('sw.js?v=536')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
   // §BUILD_VERSION_STAMP: log the ACTIVE (controlling) service worker's CACHE_VERSION at page

--- a/witness_cpe_work_pacing.js
+++ b/witness_cpe_work_pacing.js
@@ -1,40 +1,35 @@
-// WITNESS — §CPE_BUILDUP_WORK_PACED / §CPE_EVEN_PHASE_PACING: the film must advance by WORK, and
-// (2026-08-04) give every PHASE an equal share of screen time, not just every element an even
-// share of its own phase.
-// Spec: bim-compiler prompts/GANTT_ACCURACY.md §PHASE_DURATION follow-on, §CPE_EVEN_PHASE_PACING.
+// WITNESS — §CPE_BUILDUP_WORK_PACED: the film must advance by WORK, not by calendar.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_WORK_PACED.
 //
-// THE ORIGINAL DEFECT (kept, still proven below — G-WP-3..G-WP-6, G-WP-9):
-// The buildup used to step the cursor linearly in DAYS — `projectStart + t*span` — while the
-// derived 4D order clusters thousands of elements at nearby timestamps. Their own logs, same film
-// fraction: run A t=0.054 placed=210/63,421 (0.3%); run B t=0.053 placed=15,485/63,416 (24%).
-// §CPE_BUILDUP_WORK_PACED fixed that by pacing on ELEMENT RANK instead of calendar date.
+// THE DEFECT THIS PROVES OR DISPROVES (user, after two Hospital buildup bakes: "but construction
+// came on too fast.. is the path and TM consistent?" -> "as long it is consistent as i find this
+// seems to be at random"):
+// The buildup stepped the cursor linearly in DAYS — `projectStart + t*span` — while the derived 4D
+// order clusters thousands of elements at nearby timestamps. Their own logs, same film fraction:
+//     run A  t=0.054  placed=210/63,421      (0.3% of the building)
+//     run B  t=0.053  placed=15,485/63,416    (24% of the building)
+// Same path, same moment, two completely different films.
 //
-// THE DEFECT THAT SURVIVED THE FIRST FIX (2026-08-04, this file's rewrite): element-rank pacing
-// makes "10% of the film is 10% of the building" true GLOBALLY, but a population-dominant phase
-// (Terminal's Superstructure, 72.4% of 48,428 elements) still eats 72.4% of the FILM — Architecture
-// (2.6%) and Finishes (0.5%) got a couple of seconds, or less, regardless of calendar duration
-// (§PHASE_DURATION only fixes dates; the work-paced cursor never reads them). The user: "we need a
-// 2 min movie to be even or sensible."
-//
-//   G-WP-1  PHASE-LOCAL evenness: within a phase's own film segment, that phase's own placed
-//           fraction tracks the LOCAL film fraction (the original claim, now scoped per phase).
-//   G-WP-1b EQUAL SCREEN TIME PER PHASE: at each phase boundary t=i/N, the phase before it is
-//           fully placed and the phase after it has barely started — segments are exactly 1/N of
-//           the film each, not weighted by element count.
-//   G-WP-2  RED control: under the OLD pure-global-rank scheme (still recoverable from the flat
-//           `ends` array `tmWorkSchedule` still returns), the dominant phase's screen-time share
-//           equals its ELEMENT share (i.e. ~72% on Terminal) — proving the old scheme is what NEW
-//           equal-share fixes, not a strawman.
+//   G-WP-1  the claim: at t = 0.1/0.25/0.5/0.75 the PLACED FRACTION equals t within tolerance.
+//           "10% of the film is 10% of the building", measured against the real op schedule.
+//   G-WP-2  RED on calendar pacing. The same fractions paced by DATE deviate far more — without
+//           this, G-WP-1 could pass on a model that happens to be evenly spread anyway.
 //   G-WP-3  the cursor is monotone non-decreasing across the film. A building does not un-build.
-//   G-WP-4  DETERMINISM — two independent arms produce byte-identical cursors for identical fractions.
+//   G-WP-4  DETERMINISM — the user's "seems to be at random" answered with a number: two independent
+//           arms produce byte-identical cursors for identical fractions.
 //   G-WP-5  degrade, don't disable: with tmWorkSchedule hidden the way a stale cache would, pacing
 //           falls back to calendar and says so in the log — the film still bakes.
 //   G-WP-6  preview and bake ask for the same cursor at the same film fraction.
-//   G-WP-7  the log states the pacing mode (even-phase when >1 phase) and phase count.
-//   G-WP-8  per-frame reveal rate stays even WITHIN each phase's own frame range (no burst/plateau
-//           inside a phase — segment-local, since phase-to-phase rate now deliberately differs:
-//           a small phase spreads few elements over the SAME screen time as a huge one).
-//   G-WP-9  construction is fully placed and stays flat through the post-topout dwell.
+//   G-WP-8  2026-08-03 — user report on a REAL Hospital bake: "the buildup reveal starts too FAST,
+//           then the MIDDLE is relatively SLOW." G-WP-1 only proves index-fraction == film-fraction;
+//           it says nothing about FRAME-BY-FRAME evenness, which is what a viewer actually sees.
+//           Replays the real bake's per-frame pipeline (buildupTAt + buildupCursorAt, nFrames=1905 —
+//           the user's own log) and asserts the elements/frame rate has no burst/plateau, plus logs
+//           the end_ts tie-cluster structure (a big tied group would cause exactly that pattern even
+//           with an even element-index rate). See prompts/CINEMA_PATH_EDITOR.md 2026-08-03 for the
+//           real numbers this produced on Hospital and the conclusion (camera-beat-speed illusion,
+//           not a pacing defect — the measured rate came back flat, ~36.2 elements/frame, <0.5% jitter).
+//   G-WP-9  the post-topout dwell (§CPE_BUILDUP_TOPOUT) stays flat, not still climbing.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 
 const PORT = process.env.PORT || 8442;
@@ -68,19 +63,6 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
 
     const res = await page.evaluate(async (FRACS) => {
       const A = window.APP;
-      // Real flow parity: the user's Terminal report logged `§AUTHOR_MATERIALIZE schedule=
-      // SCH_AUTHORED` — i.e. schedule_editor_ui.js's doGenerate() had already run before the bake,
-      // so §PHASE_DURATION's workload-proportional widths were live. Without this call,
-      // tmActivateForBake() falls through to injectGantt's OWN separate, un-fixed generative
-      // fallback (no `tasks` rows to overlay), which is a DIFFERENT code path this fix never
-      // touched — silently testing the wrong thing.
-      if (window.ScheduleAuthor && A && A.db) {
-        try {
-          const r = window.ScheduleAuthor.materializeDefault(A.db, window.SEQUENCE_RULES,
-            { start: '2026-01-01', laborRates: window.LABOR_RATES });
-          console.log('§WITNESS_MATERIALIZE phases=' + r.phases.length + ' assignments=' + r.assignmentCount);
-        } catch (e) { console.warn('§WITNESS_MATERIALIZE_FAIL ' + e.message); }
-      }
       if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
       let ok = false;
       try { ok = await window.tmActivateForBake(); } catch (e) { return { err: 'tmActivateForBake: ' + e.message }; }
@@ -90,90 +72,18 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       const total = bk.ops;
       const out = { total, span: { s: bk.projectStart, e: bk.projectEnd } };
 
+      // ── work pacing: the cursor asked for, and the work actually placed there ────────────────
       A.buildupPacingReset();
-      const sch = window.tmWorkSchedule();
-      const phases = (sch && sch.phases) || [];
-      out.phaseNames = phases.map(p => p.name);
-      out.phaseCounts = phases.map(p => p.total);
-      const N = phases.length;
+      out.work = FRACS.map(t => {
+        const ms = A.buildupCursorAt(t, bk);
+        return { t, ms, placedFrac: window.tmPlacedCount(ms) / total };
+      });
 
-      // helper: count of a phase's own ends <= ms (phase-LOCAL placed count)
-      function localPlaced(ph, ms) {
-        let n = 0;
-        for (let i = 0; i < ph.ends.length; i++) { if (ph.ends[i] <= ms) n++; else break; }
-        return n;
-      }
-
-      // §CPE_PHASE_STAGGER: phase i's REAL window is [max(0,i-OVERLAP)/N, (i+1)/N) — read the real
-      // constant off APP rather than hand-copying it, so this witness cannot silently drift from
-      // the shipped value.
-      const OVERLAP = (typeof A.buildupStaggerOverlap === 'number') ? A.buildupStaggerOverlap : 0;
-      const phaseWindow = i => ({ lo: Math.max(0, i - OVERLAP) / N, hi: (i + 1) / N });
-      out.overlap = OVERLAP;
-
-      // ── G-WP-1: phase-local evenness — within phase i's OWN window, local placed frac ≈ local t
-      out.g1 = [];
-      if (N > 0) {
-        for (let i = 0; i < N; i++) {
-          const ph = phases[i], win = phaseWindow(i);
-          [0.25, 0.5, 0.75].forEach(localT => {
-            const tFilm = win.lo + localT * (win.hi - win.lo);
-            const ms = A.buildupCursorAt(tFilm, bk);
-            const frac = ph.total ? localPlaced(ph, ms) / ph.total : 1;
-            out.g1.push({ phase: ph.name, localT, localPlacedFrac: frac, dev: Math.abs(frac - localT) });
-          });
-        }
-      }
-
-      // ── G-WP-1b: at each NOMINAL boundary t=i/N, the PREVIOUS phase is still fully done (its own
-      // window's `hi` is unchanged) and the phase STARTING there is at the overlap-derived expected
-      // fraction — no longer 0%, that IS the stagger (a homogeneous phase isn't watched in total
-      // isolation; the next phase visibly peeks in during its tail).
-      out.g1b = [];
-      if (N > 1) {
-        for (let i = 1; i < N; i++) {
-          const t = i / N;
-          const ms = A.buildupCursorAt(t, bk);
-          const prevPh = phases[i - 1], curPh = phases[i];
-          const prevFrac = prevPh.total ? localPlaced(prevPh, ms) / prevPh.total : 1;
-          const curFrac = curPh.total ? localPlaced(curPh, ms) / curPh.total : 0;
-          const curWin = phaseWindow(i);
-          const expectedCurFrac = curWin.hi > curWin.lo ? Math.min(1, (t - curWin.lo) / (curWin.hi - curWin.lo)) : 1;
-          out.g1b.push({ boundary: i, t, prevPhase: prevPh.name, prevFrac, curPhase: curPh.name, curFrac, expectedCurFrac });
-        }
-      }
-
-      // ── G-WP-2 control: OLD pure-global-rank scheme — dominant phase's screen share == element share
-      out.g2 = null;
-      if (N > 1 && sch.ends && sch.ends.length) {
-        // reproduce the OLD _workCursorAt formula directly from the flat globally-sorted ends array
-        function oldCursorAt(t) {
-          if (t <= 0) return sch.projectStart;
-          if (t >= 1) return sch.projectEnd;
-          const k = Math.round(t * sch.total);
-          if (k < 1) return sch.projectStart;
-          if (k >= sch.total) return sch.projectEnd;
-          return sch.ends[k - 1];
-        }
-        // biggest phase by element count
-        let big = phases[0];
-        phases.forEach(p => { if (p.total > big.total) big = p; });
-        // how much of the [0,1] film-fraction axis (old scheme) does `big` occupy, sampled densely
-        const S = 500;
-        let inBig = 0;
-        for (let i = 0; i <= S; i++) {
-          const t = i / S;
-          const ms = oldCursorAt(t);
-          if (localPlaced(big, ms) > 0 && localPlaced(big, ms) < big.total) inBig++;
-          else if (localPlaced(big, ms) >= big.total && i > 0) {
-            // count only up to first frame the phase completes — approximate share via placed-frac test below
-          }
-        }
-        // Simpler, exact measure: old scheme's screen share of `big` == its element share, by construction
-        // (that IS the defect) — assert element share is far from 1/N, proving the phases are unequal
-        // under raw count and therefore under the old scheme too.
-        out.g2 = { biggest: big.name, elementShare: big.total / total, equalShare: 1 / N };
-      }
+      // ── G-WP-2 control: the SAME fractions paced by calendar, the way it used to be ──────────
+      out.calendar = FRACS.map(t => {
+        const ms = bk.projectStart + t * (bk.projectEnd - bk.projectStart);
+        return { t, ms, placedFrac: window.tmPlacedCount(ms) / total };
+      });
 
       // ── G-WP-3 monotone across a dense sweep ────────────────────────────────────────────────
       let prev = -Infinity, mono = true;
@@ -185,8 +95,6 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       out.monotone = mono;
 
       // ── G-WP-4 determinism: a second, independent arm must reproduce the cursors exactly ────
-      A.buildupPacingReset();
-      out.work = FRACS.map(t => ({ t, ms: A.buildupCursorAt(t, bk) }));
       A.buildupPacingReset();
       out.secondArm = FRACS.map(t => A.buildupCursorAt(t, bk));
       out.deterministic = out.secondArm.every((ms, i) => ms === out.work[i].ms);
@@ -207,8 +115,20 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       out.bakeCursors = FRACS.map(t => A.buildupCursorAt(t, bk));
       out.previewMatchesBake = out.previewCursors.every((ms, i) => ms === out.bakeCursors[i]);
 
-      // ── G-WP-8/9 — per-frame reveal, now checked PHASE-LOCAL (segment-to-segment rate is
-      // SUPPOSED to differ — that is the point of even-phase pacing) ───────────────────────────
+      // ── G-WP-8/9 (2026-08-03) — user bug report on a real Hospital bake: "buildup reveal starts
+      // too FAST, then the MIDDLE is relatively SLOW." §CPE_BUILDUP_WORK_PACED already proved the
+      // ELEMENT-INDEX fraction tracks the film fraction (G-WP-1 above) — but that says nothing about
+      // whether the RENDER actually reveals elements at an even rate FRAME BY FRAME, which is what a
+      // viewer sees. Two separate ways this could still be uneven even with G-WP-1 green:
+      //   (a) end_ts TIES — tmPlacedCount() counts `end_ts <= cursor`, so if many ops share one
+      //       timestamp, the reveal would burst (all of a tied group appears in one frame) then
+      //       plateau (no visible change for the rest of that tied index range) even though the
+      //       INDEX advances evenly every frame.
+      //   (b) §CPE_BUILDUP_TOPOUT's remap (t -> t/topoutU) is linear in FILM FRACTION, which this
+      //       code simulates using the actual real-bake per-frame pipeline (buildupTAt then
+      //       buildupCursorAt), not just the FRACS checkpoints G-WP-1 used.
+      // This replays the exact per-frame sequence cinema_maxq.js's bake loop runs (same two calls,
+      // same nFrames a real Hospital bake used — frame=0/1905 in the user's own log).
       const nFrames = 1905;
       const topout = A.buildupTopoutU(null);
       A.buildupPacingReset();
@@ -220,44 +140,43 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
         trace.push(window.tmPlacedCount(ms));
       }
       out.topoutU = topout.u;
-      out.finalPlaced = trace[nFrames - 1];
-      out.postTopoutFlat = trace.slice(Math.min(nFrames - 1, Math.round(topout.u * (nFrames - 1)) + 1))
-        .every(p => p === out.finalPlaced);
-
-      // segment-local rate evenness: for each phase's own frame range, block-rate deviation
-      out.g8 = [];
-      if (N > 0) {
-        // Measured over the MIDDLE HALF of each phase's nominal segment, not its full span — the
-        // leading ~OVERLAP fraction is the deliberate ramp blending in the PREVIOUS phase's tail,
-        // and the trailing ~OVERLAP fraction is where the NEXT phase's own ramp starts contributing
-        // to the global trace — both are intended smoothing, not a steady-state rate, so including
-        // either would flag the intended blend as a defect. The core between them is where a single
-        // phase's own characteristic rate is actually isolated.
-        const topoutFrame = Math.min(nFrames - 1, Math.round(topout.u * (nFrames - 1)) + 1);
-        for (let i = 0; i < N; i++) {
-          const f0 = Math.round(((i + 0.25) / N) * topoutFrame), f1 = Math.min(topoutFrame, Math.round(((i + 0.75) / N) * topoutFrame));
-          const span = f1 - f0;
-          // A phase with few elements over its segment cannot produce a meaningful per-block rate —
-          // any block sees 0 or 1 placement and "deviation" is pure integer quantization, not a
-          // burst/plateau. Same population floor as G-WP-1's tolerance below.
-          if (span < 10 || phases[i].total < 50) {
-            out.g8.push({ phase: phases[i].name, skipped: true,
-              reason: span < 10 ? 'segment too short to rate (' + span + ' frames)' : 'too few elements to rate (' + phases[i].total + ')' });
-            continue;
-          }
-          const block = Math.max(3, Math.round(span / 10));
-          const rates = [];
-          for (let f = f0 + block; f <= f1; f += block) rates.push((trace[f] - trace[f - block]) / block);
-          const mean = rates.length ? rates.reduce((s, x) => s + x, 0) / rates.length : 0;
-          const worst = rates.length && mean > 0 ? Math.max(...rates.map(r => Math.abs(r - mean))) / mean : 0;
-          out.g8.push({ phase: phases[i].name, frames: span, meanRate: +mean.toFixed(3), worstDevFrac: +worst.toFixed(3) });
-        }
+      // end_ts tie-cluster structure — the (a) mechanism above, checked directly against real data.
+      const sch = window.tmWorkSchedule();
+      let groups = 0, maxGroup = 1, run = 1;
+      for (let i = 1; i < sch.ends.length; i++) {
+        if (sch.ends[i] === sch.ends[i - 1]) { run++; } else { groups++; if (run > maxGroup) maxGroup = run; run = 1; }
       }
+      groups++;
+      out.tieGroups = groups; out.tieGroupMax = maxGroup;
+      // Windowed rate (elements per BLOCK of frames), over the pre-topout span only (post-topout is
+      // SUPPOSED to be flat — that is the dwell §CPE_BUILDUP_TOPOUT deliberately introduces). A block
+      // rather than a raw 1-frame diff: on a small building (e.g. Duplex, ~1100 ops/1905 frames) most
+      // single frames place 0 or 1 element, so a per-frame diff is dominated by integer-count
+      // quantization noise that has nothing to do with pacing evenness — the same reason a human
+      // doesn't perceive "fast/slow" frame-to-frame, only over a stretch of the film. Block size
+      // scales with total ops so it always spans a real number of elements (min 5 frames).
+      const topoutFrame = Math.min(nFrames - 1, Math.round(topout.u * (nFrames - 1)) + 1);
+      const block = Math.max(5, Math.round(topoutFrame / Math.max(20, Math.min(100, Math.round(total / 50)))));
+      const rates = [];
+      for (let f = block; f <= topoutFrame; f += block) rates.push((trace[f] - trace[f - block]) / block);
+      const meanRate = rates.length ? rates.reduce((s, x) => s + x, 0) / rates.length : 0;
+      out.rateBlockFrames = block;
+      // Coarse checkpoints for a human-readable summary (start/quarter/half/three-quarter of the FILM).
+      out.checkpoints = [0.10, 0.25, 0.50, 0.75].map(cp => {
+        const f = Math.round(cp * (nFrames - 1));
+        const w = 20; // local rate window, frames
+        const f0 = Math.max(0, f - w), f1 = Math.min(topoutFrame, f + w);
+        return { t: cp, placed: trace[f], ratePerFrame: +((trace[f1] - trace[f0]) / (f1 - f0)).toFixed(2) };
+      });
+      out.meanRatePerFrame = +meanRate.toFixed(2);
+      out.maxRateDeviationFrac = rates.length ?
+        Math.max(...rates.map(r => Math.abs(r - meanRate))) / meanRate : 0;
+      out.postTopoutFlat = trace.slice(topoutFrame).every(p => p === trace[topoutFrame]);
+      out.finalPlaced = trace[nFrames - 1];
 
       try { window.tmRestoreDerivedOrder(); } catch (e) {}
       return out;
     }, FRACS);
-    res.pacingLine = logs.filter(l => /§CPE_BUILDUP_PACING/.test(l)).slice(-1)[0] || '';
 
     const checks = [];
     const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`  ${ok ? '✅' : '❌'} ${n}\n        ${d}`); };
@@ -265,42 +184,20 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
     if (res.err) {
       P('G-WP-0 the building has a buildup timeline', false, res.err + ' — INCONCLUSIVE, not a product verdict');
     } else {
-      const N = res.phaseNames.length;
-      console.log(`  phases: ${res.phaseNames.map((n, i) => n + '=' + res.phaseCounts[i]).join(', ')}`);
+      const TOL = 0.03;   // 3 percentage points; the k-th completion can share a timestamp with others
+      const workDev = res.work.map(w => Math.abs(w.placedFrac - w.t));
+      const calDev = res.calendar.map(c => Math.abs(c.placedFrac - c.t));
+      const worstWork = Math.max(...workDev), worstCal = Math.max(...calDev);
 
-      // Tolerance floors at the phase's OWN bucket granularity (1/total) — a 7-element phase can
-      // only land on 1/7 ≈ 14.3% steps, so a flat 5pp bar would fail on pure integer rounding, not
-      // a real defect. Same reasoning as the original file's per-model TOL, made per-phase here
-      // since phase populations now vary hugely within one building (Terminal: 258..35,061).
-      const countOf = {}; res.phaseNames.forEach((n, i) => { countOf[n] = res.phaseCounts[i]; });
-      const tolOf = name => Math.max(0.05, 1.5 / Math.max(1, countOf[name] || 1));
-      const over1 = res.g1.filter(x => x.dev > tolOf(x.phase));
-      P('G-WP-1 within each phase, LOCAL placed fraction tracks LOCAL film fraction',
-        over1.length === 0,
-        res.g1.map(x => `${x.phase}@${x.localT}→${(x.localPlacedFrac * 100).toFixed(1)}%(tol${(tolOf(x.phase) * 100).toFixed(1)}pp)`).join('  ') +
-        (over1.length ? `   OVER TOL: ${over1.map(x => x.phase + '@' + x.localT + ' dev=' + (x.dev * 100).toFixed(2) + 'pp').join(', ')}` : '   all within tolerance'));
+      P('G-WP-1 k% of the film is k% of the building',
+        worstWork <= TOL,
+        res.work.map((w, i) => `t=${w.t}→placed ${(w.placedFrac * 100).toFixed(1)}%`).join('  ') +
+        `   worst deviation ${(worstWork * 100).toFixed(2)}pp (tol ${TOL * 100}pp)`);
 
-      const b1bOk = N <= 1 || res.g1b.every(b => b.prevFrac >= 0.98);
-      P('G-WP-1b every phase\'s OWN share ends exactly at its nominal boundary (equal share preserved)',
-        b1bOk,
-        res.g1b.map(b => `t=${b.t.toFixed(2)}  ${b.prevPhase} finishes at ${(b.prevFrac * 100).toFixed(1)}%`).join('  ') +
-        `  overlap=${res.overlap}`);
-
-      // §CPE_PHASE_STAGGER: the NEXT phase should be VISIBLY started (not 0%) at the boundary,
-      // tracking the overlap-derived expected fraction — proving the peek is real, not a no-op.
-      const tolStagger = name => Math.max(0.05, 1.5 / Math.max(1, countOf[name] || 1));
-      const over1c = res.g1b.filter(b => Math.abs(b.curFrac - b.expectedCurFrac) > tolStagger(b.curPhase));
-      P('G-WP-1c the stagger overlap is real: next phase already partway in at the boundary, matching the expected overlap fraction',
-        res.overlap === 0 ? true : over1c.length === 0,
-        res.g1b.map(b => `${b.curPhase}@boundary→${(b.curFrac * 100).toFixed(1)}% (expected ${(b.expectedCurFrac * 100).toFixed(1)}%)`).join('  '));
-
-      if (res.g2) {
-        P('G-WP-2 RED control: the dominant phase\'s ELEMENT share is far from equal — the old global-rank scheme would have given it that same share of the FILM (the defect this fix replaces)',
-          Math.abs(res.g2.elementShare - res.g2.equalShare) > 0.15,
-          `${res.g2.biggest} elementShare=${(res.g2.elementShare * 100).toFixed(1)}% vs equalShare=${(res.g2.equalShare * 100).toFixed(1)}% (N=${N} phases)`);
-      } else {
-        P('G-WP-2 RED control', N <= 1, 'single-phase model — no dominant-phase defect possible, skip is correct');
-      }
+      P('G-WP-2 calendar pacing is measurably worse on this model (the RED this replaces)',
+        worstCal > worstWork,
+        res.calendar.map(c => `t=${c.t}→placed ${(c.placedFrac * 100).toFixed(1)}%`).join('  ') +
+        `   worst ${(worstCal * 100).toFixed(2)}pp vs work-paced ${(worstWork * 100).toFixed(2)}pp`);
 
       P('G-WP-3 the cursor never goes backward', res.monotone === true,
         `201 samples across the film, monotone=${res.monotone}`);
@@ -316,15 +213,24 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       P('G-WP-6 preview and bake ask for the same cursor', res.previewMatchesBake === true,
         `preview=[${res.previewCursors.join(',')}] bake=[${res.bakeCursors.join(',')}]`);
 
-      P('G-WP-7 the log states the pacing mode and phase count',
-        N <= 1 ? /mode=work/.test(res.pacingLine) : (/mode=even-phase/.test(res.pacingLine) && res.pacingLine.includes('phases=' + N)),
-        res.pacingLine || 'no §CPE_BUILDUP_PACING line');
+      const line = logs.filter(l => /§CPE_BUILDUP_PACING/.test(l)).slice(-1)[0] || '';
+      const sch = logs.filter(l => /§CPE_WORK_SCHEDULE/.test(l)).slice(-1)[0] || '';
+      P('G-WP-7 the log states the pacing mode and how front-loaded the model is',
+        /mode=work/.test(line) && /workInFirst10%OfCalendar/.test(sch),
+        `${line || 'no §CPE_BUILDUP_PACING'}\n        ${sch || 'no §CPE_WORK_SCHEDULE'}`);
 
-      const RATE_TOL = 0.35;   // segment-local, looser than the old global check — small phases have few ops
-      const g8bad = res.g8.filter(x => !x.skipped && x.worstDevFrac > RATE_TOL);
-      P('G-WP-8 reveal rate stays even WITHIN each phase\'s own segment (rate MAY differ phase-to-phase — that is the design)',
-        g8bad.length === 0,
-        res.g8.map(x => x.skipped ? `${x.phase}: ${x.reason}` : `${x.phase}: ${x.frames}f meanRate=${x.meanRate}/f worstDev=${(x.worstDevFrac * 100).toFixed(0)}%`).join('  '));
+      // G-WP-8/9 — real per-frame FILM reveal rate (2026-08-03 "fast start, slow middle" report).
+      // Tolerance is loose (25%) on purpose: this proves the reveal isn't BURSTY/PLATEAUING, not
+      // that it is frame-perfect — a model with real duration ties will always have some jitter.
+      const RATE_TOL = 0.25;
+      const cpLine = res.checkpoints.map(c => `t=${c.t}→${c.placed} (${c.ratePerFrame}/frame)`).join('  ');
+      P('G-WP-8 the per-frame reveal rate stays even across the pre-topout film (no burst/plateau)',
+        res.maxRateDeviationFrac <= RATE_TOL,
+        `topoutU=${res.topoutU.toFixed(3)} meanRate=${res.meanRatePerFrame}/frame ` +
+        `worstDeviation=${(res.maxRateDeviationFrac * 100).toFixed(1)}% (tol ${RATE_TOL * 100}%)\n        ` +
+        `checkpoints: ${cpLine}\n        ` +
+        `end_ts tie clusters: ${res.tieGroups} distinct timestamps / ${res.total} ops, largest tied group=${res.tieGroupMax} ` +
+        `(a large group here would explain a burst/plateau reveal even with an even element-index rate)`);
 
       P('G-WP-9 construction is fully placed and stays flat through the post-topout dwell',
         res.postTopoutFlat === true && res.finalPlaced === res.total,


### PR DESCRIPTION
## Summary
- Removed the film-layer stagger hack (§CPE_EVEN_PHASE_PACING/§CPE_PHASE_STAGGER, PR #1153) — user ruling: it was re-authoring pacing the schedule data didn't say, wrong layer. Film now plays the real schedule (plain element-rank pacing) again.
- §LABOR_QUANTITY_WEIGHT: real cause of Terminal's 968-day Superstructure — 33,324 Metal Deck fragments (avg 0.074m², measured) were charged labor per fragment. Only classes measurably below 1m² avg get area-weighted (via `RATES[cls].unit` + the existing `analysis_sidecar.js` bbox formula); every other class (Slab/Wall/Covering/Roof, all normal sizes) is untouched — no blanket rule, no invented conversion factor.
- §PHASE_OVERLAP_BAND: conventional Line-of-Balance flowline scheduling — a phase starts once the leading trade clears one real band (storey), not the whole building. A global cross-task support-guard pass (same push-after mechanism as §4D_HOST_BEFORE_HOSTED) keeps this from placing anything before its real structural support.

## Results (real Terminal_extracted.db / Hospital_extracted.db)
| | Terminal | Hospital |
|---|---|---|
| Total project days | 1264 → 229 | 1064 → 799 |
| Superstructure days | 968 → 111 | 116 (unchanged, not fragmented) |
| Architecture starts at | day 1189 (94%) → day 27 (12%) | day 902 (85%) → day 152 (19%) |
| Cross-task support violations | n/a (was impossible pre-overlap) | 447→0 (Terminal), 1929→0 (Hospital) |

Duplex: byte-identical §PHASE_DURATION output pre/post (zero regression), 40→36 total days from the overlap fix alone.

## Test plan
- [x] Headless verification against real Terminal/Hospital/Duplex DBs (sql.js, no browser) — numbers above
- [x] Cross-task support-violation audit (verbatim role-blind predicate from `audit_support_roleblind.js`) — 0/0 on both buildings after the guard pass
- [x] `witness_cpe_work_pacing.js` 9/9 green, both buildings (film pacing reverted correctly)
- [x] `witness_stagger_support_order.js` unaffected (different code path — generative ScheduleGate fallback, not touched)
- [x] Browser smoke test (Terminal, headless Chrome) — no console/page errors from the change
- [x] sw.js CACHE_VERSION + precache versions bumped (cinema_maxq.js, time_machine.js, schedule_author.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)