### PR TITLE
fix(4d): applyDates() third contiguous-cursor site was reverting the phase overlap

### DIFF
--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -179,20 +179,35 @@
   }
 
   // ── Authoring writes (each = an in-place edit of the IFC-native tables) ────────
+  // §PHASE_OVERLAP_BAND (GANTT_ACCURACY.md): this was a THIRD independent "lay phases out from a
+  // start date" implementation — materializeDefault and scheduleContiguous (schedule_author.js) both
+  // got the real-band overlap fix, this UI-only re-apply path did not, so hitting "Apply" in the
+  // wizard silently reverted an overlapping schedule back to strictly-contiguous (measured live:
+  // Terminal's real 229-day materialized schedule read back as span=407d — the plain Σ of the 5
+  // phase durations — after Apply). Same fix, same reasoning: a phase starts once the leading trade
+  // clears ONE real band (elements_meta.storey via task_elements), not the whole building.
+  function _bandCount(d, tid) {
+    var r = d.exec("SELECT DISTINCT COALESCE(m.storey,'') FROM task_elements te " +
+      "JOIN elements_meta m ON m.guid=te.guid WHERE te.task_id=?", [tid]);
+    var n = (r.length && r[0].values.length) ? r[0].values.length : 1;
+    return Math.max(1, n);
+  }
   function applyDates() {
     var d = db(); if (!d || !_state) return;
-    var cursor = 0, start = _state.start || '2026-01-01';
+    var cursor = 0, totalDays = 0, start = _state.start || '2026-01-01';
     _state.order.forEach(function (tid) {
       var dur = _state.dur[tid] || 30;
       var s = addDays(start, cursor), f = addDays(start, cursor + dur);
       d.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
         [s, f, 'P' + dur + 'D', tid]);
-      cursor += dur;
+      totalDays = Math.max(totalDays, cursor + dur);
+      var lag = Math.max(1, Math.ceil(dur / _bandCount(d, tid)));
+      cursor += lag;
     });
     // root span
     d.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
-      [start, addDays(start, cursor), _state.schedId]);
-    console.log('§AUTHOR_UI_DATES start=' + start + ' span=' + cursor + 'd phases=' + _state.order.length);
+      [start, addDays(start, totalDays), _state.schedId]);
+    console.log('§AUTHOR_UI_DATES start=' + start + ' span=' + totalDays + 'd phases=' + _state.order.length);
   }
 
   function renamePhase(tid, name) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v933';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v934';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -931,7 +931,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="dlod_nav.js?v=1" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=11" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_author_ui.js?v=8" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
+<script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>
 <script src="sfx.js?v=1" onerror="console.warn('§LOAD_FAIL sfx.js — audio feedback disabled')"></script>
 <!-- HR_BIM_Asset spatial lenses (prompts/RESUME_HR_BIM_ASSET.md §RESUME NEXT#2). ADDITIVE peer module: the
@@ -1019,7 +1019,7 @@ if(new URLSearchParams(location.search).get('embedded')!=='true'){
 </script>
 <script>
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js?v=536')
+  navigator.serviceWorker.register('sw.js?v=537')
     .then(function(r){console.log('§SW_REG scope='+r.scope)})
     .catch(function(e){console.warn('§SW_REG_FAIL',e)});
   // §BUILD_VERSION_STAMP: log the ACTIVE (controlling) service worker's CACHE_VERSION at page


### PR DESCRIPTION
## Summary
Live-caught right after PR #1154 shipped: user reported Terminal's opening still bunched, and the console log showed `§AUTHOR_UI_DATES span=407d` and `§TIME_MACHINE ON — 408 days` — not the 229 days `materializeDefault` actually computed. `schedule_author_ui.js`'s `applyDates()` (fired on the wizard's "Apply" step) is a third, independent contiguous-cursor implementation that `§PHASE_OVERLAP_BAND` (#1154) never touched — it read back each phase's correct duration but re-advanced the cursor by the FULL duration, discarding the overlap.

Same fix as the other two sites: real band count per phase (`task_elements` → `elements_meta.storey`), lag = duration/bands.

## Test plan
- [x] Headless: reproduced the exact live bug (naive sum = 407d) and confirmed the fix restores 229d, against real `Terminal_extracted.db`
- [x] `node -c` syntax check
- [x] sw.js CACHE_VERSION + precache version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)