### PR TITLE
feat(4d): CPM Gap 1 — task_sequences edges + Gantt dependency arrows

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -323,6 +323,7 @@
     var outPhases = [], assignN = 0;
     ordered.forEach(function (p) {
       var tid = 'TASK_' + _slug(p.name);
+      p.taskId = tid;   // CPM_FLOAT_GAP.md Gap 1 — kept on p so the task_sequences pass below can use it
       var s = blank ? null : _addDays(start, p.startCursor);
       var f = blank ? null : _addDays(start, p.startCursor + p.widthDays);
       // Leaf, is_summary=0. Dated → _cap.win picks it up; blank/undated → _cap skips it (the user
@@ -333,6 +334,26 @@
     });
     stmtTk.free();
     stmtTe.free();
+
+    // CPM_FLOAT_GAP.md Gap 1 (phase-level) — §PHASE_OVERLAP_BAND already computed the real
+    // leading-trade/follow-on-trade relationship between consecutive phases (p.lagDays = days for
+    // the leading phase to clear one band before the next phase can start behind it) but only ever
+    // wrote it into schedule_start/schedule_finish, never into task_sequences — so computeCpm was
+    // blind to a generated (no-plan) schedule: zero predecessor/successor rows, every phase trivially
+    // ES=0, float meaningless. This exposes the SAME already-derived number as an explicit
+    // CPM-solvable SS edge — not a new/invented relationship, just the one already computed above,
+    // made readable by computeCpm/listDependencies/the Gantt dependency view.
+    db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+    db.run("DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)", [schedId, schedId]);
+    var stmtSeq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    var seqN = 0;
+    for (var i = 1; i < ordered.length; i++) {
+      var pred = ordered[i - 1], succ = ordered[i];
+      stmtSeq.run([pred.taskId, succ.taskId, 'SS', pred.lagDays]);
+      seqN++;
+    }
+    stmtSeq.free();
+    if (seqN) console.log('§AUTHOR_SEQUENCES schedule=' + schedId + ' edges=' + seqN + ' (SS, lag=leading-phase band-clear days)');
 
     db.run('COMMIT');   // §SE-5a — single commit for the whole rebuild
 
@@ -440,11 +461,12 @@
       bandCount[tid] = Math.max(1, Object.keys(storeys).length);
     });
 
-    var cursor = 0, totalDays = 0;
+    var cursor = 0, totalDays = 0, lagByTid = {};
     db.run('BEGIN TRANSACTION');   // §SE-5a — same per-statement-overhead fix as materializeDefault
     ids.forEach(function (tid) {
       var w = widthDays[tid];
       var lag = Math.max(1, Math.ceil(w / bandCount[tid]));
+      lagByTid[tid] = lag;
       var s = _addDays(start, cursor), f = _addDays(start, cursor + w);
       db.run("UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?",
         [s, f, 'P' + w + 'D', tid]);
@@ -454,6 +476,22 @@
     });
     db.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
       [start, _addDays(start, totalDays), scheduleId]);
+
+    // CPM_FLOAT_GAP.md Gap 1 (phase-level) — same edge-exposure as materializeDefault (see its
+    // comment above the identical block): this function re-dates a previously-blank schedule, so it
+    // must (re)write the SAME SS edges here too, using the just-recomputed per-task lag — otherwise a
+    // schedule authored blank-then-dated would keep the STALE edges (or none) from before dating.
+    db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+    db.run("DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)", [scheduleId, scheduleId]);
+    var stmtSeq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    var seqN = 0;
+    for (var i = 1; i < ids.length; i++) {
+      stmtSeq.run([ids[i - 1], ids[i], 'SS', lagByTid[ids[i - 1]]]);
+      seqN++;
+    }
+    stmtSeq.free();
+    if (seqN) console.log('§AUTHOR_SEQUENCES schedule=' + scheduleId + ' edges=' + seqN + ' (SS, lag=leading-phase band-clear days)');
+
     db.run('COMMIT');
     console.log('§AUTHOR_SCHEDULE schedule=' + scheduleId + ' phases=' + ids.length + ' from=' + start + ' span=' + totalDays + 'd');
     return { scheduled: ids.length, start: start, span: totalDays };
@@ -759,11 +797,19 @@
       t.es = Math.max(0, es); t.ef = t.es + t.dur;
     });
     var PF = 0; ids.forEach(function (id) { PF = Math.max(PF, T[id].ef); });
-    // BACKWARD: LF/LS in reverse topo order.
+    // BACKWARD: LF/LS in reverse topo order. A task's late finish can never legitimately exceed the
+    // project's own finish PF — that IS the definition of "project finish." The un-clamped succs-loop
+    // result can overshoot PF for a task whose only successor edge is SS/SF (constrains the
+    // SUCCESSOR's START, never THIS task's finish) — e.g. a §PHASE_OVERLAP_BAND-style SS chain where
+    // an early, long-duration phase (its EF ends up defining PF itself) is followed by a short-lag
+    // successor: nothing in the graph consumes that predecessor's FINISH, so the naive backward pass
+    // (mirroring only its successor's late START) can compute an LF hundreds of days past PF — a
+    // provably-impossible float that silently zeroed the critical path on any SS-only chain (this
+    // was never exercised before task_sequences carried real SS edges — CPM_FLOAT_GAP.md Gap 1).
     for (var i = topo.length - 1; i >= 0; i--) {
       var t = T[topo[i]];
       if (!t.succs.length) t.lf = PF;
-      else { var lf = Infinity; t.succs.forEach(function (e) { lf = Math.min(lf, _bwdLF(T[e.succ], e.lag, e.type, t.dur)); }); t.lf = lf; }
+      else { var lf = Infinity; t.succs.forEach(function (e) { lf = Math.min(lf, _bwdLF(T[e.succ], e.lag, e.type, t.dur)); }); t.lf = Math.min(lf, PF); }
       t.ls = t.lf - t.dur;
     }
     // float + critical + free float + write-back

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -194,7 +194,7 @@
   }
   function applyDates() {
     var d = db(); if (!d || !_state) return;
-    var cursor = 0, totalDays = 0, start = _state.start || '2026-01-01';
+    var cursor = 0, totalDays = 0, start = _state.start || '2026-01-01', lagByTid = {};
     _state.order.forEach(function (tid) {
       var dur = _state.dur[tid] || 30;
       var s = addDays(start, cursor), f = addDays(start, cursor + dur);
@@ -202,11 +202,28 @@
         [s, f, 'P' + dur + 'D', tid]);
       totalDays = Math.max(totalDays, cursor + dur);
       var lag = Math.max(1, Math.ceil(dur / _bandCount(d, tid)));
+      lagByTid[tid] = lag;
       cursor += lag;
     });
     // root span
     d.run("UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE schedule_id=? AND is_summary=1",
       [start, addDays(start, totalDays), _state.schedId]);
+
+    // CPM_FLOAT_GAP.md Gap 1 (phase-level) — same fix, same reasoning as the "THIRD independent
+    // lay-out implementation" note above: materializeDefault and scheduleContiguous both now write
+    // task_sequences SS edges from this exact lag; this UI-only re-apply path must too, or hitting
+    // "Apply" would silently leave stale/absent edges the same way it used to silently revert dates.
+    d.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+    d.run("DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)", [_state.schedId, _state.schedId]);
+    var stmtSeq = d.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    var seqN = 0;
+    for (var i = 1; i < _state.order.length; i++) {
+      stmtSeq.run([_state.order[i - 1], _state.order[i], 'SS', lagByTid[_state.order[i - 1]]]);
+      seqN++;
+    }
+    stmtSeq.free();
+    if (seqN) console.log('§AUTHOR_UI_SEQUENCES edges=' + seqN + ' (SS, lag=leading-phase band-clear days)');
+
     console.log('§AUTHOR_UI_DATES start=' + start + ' span=' + totalDays + 'd phases=' + _state.order.length);
   }
 

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -102,6 +102,10 @@
   /* §SE-5b today marker — vertical line across the whole Gantt body */
   .g-today-line { position: absolute; top: -16px; bottom: 0; width: 1px; background: #4fc3f7;
                   z-index: 1; opacity: .6; pointer-events: none; }
+  /* §SE-5c dependency-arrow overlay (traditional Gantt connector lines) */
+  .g-deps-svg { overflow: visible; }
+  .g-dep-line { stroke: #6f89ac; stroke-width: 1.4; opacity: .8; }
+  .g-dep-line.crit { stroke: #d2475c; stroke-width: 1.8; opacity: .95; }
   .g-today-line::before { content: 'today'; position: absolute; top: -14px; left: 3px; font-size: 9px;
                            color: #4fc3f7; opacity: 1; }
   /* dependency rows */

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -274,12 +274,17 @@
       host.appendChild(todayLine);
     }
 
-    leaves.forEach(function (n) {
+    // geometry per task, filled in below — the dependency-arrow overlay draws from this afterward
+    // (needs every bar's final on-screen position, so it has to run after the row loop, not during it).
+    var AXIS_H = 16, ROW_H = 26;   // must match .g-axis/.g-row in schedule_editor.html
+    var geom = {};
+    leaves.forEach(function (n, idx) {
       var dur = daysBetween(n.start, n.finish);
       var off = daysBetween(min, n.start);
       var row = el('div', 'g-row');
       row.appendChild(el('div', 'g-label', n.name));
       var track = el('div', 'g-track');
+      var yCenter = AXIS_H + idx * ROW_H + ROW_H / 2;
       // §SE-5b milestone — a 0-day task (start===finish) renders as a diamond, not a bar.
       if (dur === 0) {
         var ms = el('div', 'g-milestone' + (n.critical ? ' crit' : ''));
@@ -287,10 +292,12 @@
         ms.dataset.task = n.id;
         ms.title = n.name + '  ' + n.start + ' (milestone)';
         track.appendChild(ms);
+        geom[n.id] = { x: labelW + off * pxPerDay, xEnd: labelW + off * pxPerDay, y: yCenter };
       } else {
         var bar = el('div', 'g-bar' + (n.critical ? ' crit' : ''), dur + 'd');
-        bar.style.left = (off * pxPerDay) + 'px';
-        bar.style.width = Math.max(8, dur * pxPerDay) + 'px';
+        var barX = off * pxPerDay, barW = Math.max(8, dur * pxPerDay);
+        bar.style.left = barX + 'px';
+        bar.style.width = barW + 'px';
         bar.dataset.task = n.id;
         bar.title = n.name + '  ' + n.start + ' → ' + n.finish + (n.totalFloat != null ? '  (float ' + n.totalFloat + 'd)' : '');
         _wireBarDrag(bar, n, off, pxPerDay);
@@ -299,10 +306,59 @@
         _wireLinkDrag(handle, n);
         bar.appendChild(handle);
         track.appendChild(bar);
+        geom[n.id] = { x: labelW + barX, xEnd: labelW + barX + barW, y: yCenter };
       }
       row.appendChild(track);
       host.appendChild(row);
     });
+
+    // §SE-5c dependency arrows — traditional Gantt connector lines between linked bars, the visual
+    // counterpart to the text-only §SE list (renderDeps' predName→succName rows). Drawn from
+    // task_sequences via the SAME read SA().listDependencies already uses, honouring FS/SS/FF/SF
+    // (endpoint = start or finish per type, matching schedule_author.js SEQ_TYPES/computeCpm — not
+    // always drawn finish→start). An SVG overlay sits on top of the rows (host is position:relative);
+    // z-index keeps it above bars for visibility but pointer-events:none so drag/click still hit bars.
+    var deps = SA().listDependencies ? SA().listDependencies(db, schedId) : [];
+    var drawable = deps.filter(function (dep) { return geom[dep.predId] && geom[dep.succId]; });
+    if (drawable.length) {
+      var svgH = AXIS_H + leaves.length * ROW_H;
+      var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'g-deps-svg');
+      svg.setAttribute('width', labelW + chartW);
+      svg.setAttribute('height', svgH);
+      svg.style.position = 'absolute'; svg.style.left = '0'; svg.style.top = '0';
+      svg.style.pointerEvents = 'none'; svg.style.zIndex = '2';
+      var defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+      [['g-arrowhead', '#6f89ac'], ['g-arrowhead-crit', '#d2475c']].forEach(function (m) {
+        var marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+        marker.setAttribute('id', m[0]);
+        marker.setAttribute('viewBox', '0 0 8 8'); marker.setAttribute('refX', '7'); marker.setAttribute('refY', '4');
+        marker.setAttribute('markerWidth', '7'); marker.setAttribute('markerHeight', '7'); marker.setAttribute('orient', 'auto-start-reverse');
+        var tri = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        tri.setAttribute('d', 'M0,0 L8,4 L0,8 z'); tri.setAttribute('fill', m[1]);
+        marker.appendChild(tri); defs.appendChild(marker);
+      });
+      svg.appendChild(defs);
+      drawable.forEach(function (dep) {
+        var pg = geom[dep.predId], sg = geom[dep.succId];
+        var crit = critSet[dep.predId] && critSet[dep.succId];
+        // endpoint per link type — SS/FF/SF connect at START, not always predecessor's finish.
+        var x1 = (dep.type === 'SS' || dep.type === 'SF') ? pg.x : pg.xEnd;
+        var x2 = (dep.type === 'FF' || dep.type === 'SF') ? sg.xEnd : sg.x;
+        var y1 = pg.y, y2 = sg.y;
+        var midX = x1 + Math.max(6, (x2 - x1) / 2 * (x2 >= x1 ? 1 : -1));
+        var d3 = 'M ' + x1 + ' ' + y1 + ' L ' + midX + ' ' + y1 + ' L ' + midX + ' ' + y2 + ' L ' + x2 + ' ' + y2;
+        var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', d3);
+        path.setAttribute('class', 'g-dep-line' + (crit ? ' crit' : ''));
+        path.setAttribute('fill', 'none');
+        path.setAttribute('marker-end', 'url(#' + (crit ? 'g-arrowhead-crit' : 'g-arrowhead') + ')');
+        path.setAttribute('title', dep.predName + ' → ' + dep.succName + ' (' + dep.type + (dep.lag ? ', lag ' + dep.lag + 'd' : '') + ')');
+        svg.appendChild(path);
+      });
+      host.appendChild(svg);
+      console.log('§SE_GANTT_ARROWS drawn=' + drawable.length + '/' + deps.length + ' (skipped=' + (deps.length - drawable.length) + ' undated/off-chart endpoints)');
+    }
     console.log('§SE_GANTT bars=' + leaves.length + ' span=' + min + '..' + max + ' days=' + totalDays + ' zoom=' + _zoom);
   }
 

--- a/witness_gap1_task_sequences.js
+++ b/witness_gap1_task_sequences.js
@@ -1,0 +1,61 @@
+// witness_gap1_task_sequences.js — CPM_FLOAT_GAP.md Gap 1 (phase-level).
+// Proves materializeDefault now emits task_sequences SS edges from the already-computed
+// §PHASE_OVERLAP_BAND lag, and that computeCpm is no longer blind to a generated (no-plan)
+// schedule: real predecessor/successor edges → real ES/EF/LS/LF/float/is_critical, not the
+// trivial all-ES=0 result a zero-edge graph gives Kahn's sort.
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, 'viewer');
+var DB_PATH = '/home/red1/bim-compiler/deploy/dev/buildings/Terminal_extracted.db';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-GAP1 PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-GAP1 FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  var rules = loadRules();
+  var db = new SQL.Database(fs.readFileSync(DB_PATH));
+  var res = ScheduleAuthor.materializeDefault(db, rules.SEQUENCE_RULES, {
+    start: '2026-01-01', laborRates: rules.LABOR_RATES, rates: rules.RATES
+  });
+  check('materialize-produced-5-phases', res.phases.length === 5, 'phases=' + res.phases.length);
+
+  var seq = db.exec('SELECT predecessor_id, successor_id, sequence_type, lag_days FROM task_sequences');
+  var edgeCount = (seq.length && seq[0].values.length) ? seq[0].values.length : 0;
+  check('task_sequences-has-N-1-edges', edgeCount === res.phases.length - 1, 'edges=' + edgeCount + ' expected=' + (res.phases.length - 1));
+
+  var deps = ScheduleAuthor.listDependencies(db, res.scheduleId);
+  check('listDependencies-sees-them', deps.length === edgeCount, 'listDependencies=' + deps.length);
+  deps.forEach(function (d) { console.log('§W-GAP1 EDGE ' + d.predName + ' -> ' + d.succName + ' (' + d.type + ', lag=' + d.lag + 'd)'); });
+
+  var cpm = ScheduleAuthor.computeCpm(db, res.scheduleId, { start: '2026-01-01' });
+  check('cpm-no-error', !cpm.error, JSON.stringify(cpm.error || null));
+  var nonZeroES = (cpm.tasks || []).filter(function (t) { return t.es > 0; }).length;
+  check('cpm-not-trivial-all-ES-zero', nonZeroES > 0, 'tasksWithES>0=' + nonZeroES + '/' + (cpm.tasks || []).length);
+  (cpm.tasks || []).forEach(function (t) { console.log('§W-GAP1 TASK ' + t.id + ' es=' + t.es + ' ef=' + t.ef + ' ls=' + t.ls + ' lf=' + t.lf + ' totalFloat=' + t.totalFloat + ' crit=' + t.critical); });
+  check('cpm-reports-a-critical-path', (cpm.criticalIds || []).length > 0, 'critical=' + (cpm.criticalIds || []).length);
+  console.log('§W-GAP1 CPM projectDuration=' + cpm.projectDuration + ' critical=' + (cpm.criticalIds || []).length + '/' + (cpm.tasks || []).length);
+
+  // Re-run materializeDefault (idempotent rebuild) — edges must not duplicate/accumulate.
+  ScheduleAuthor.materializeDefault(db, rules.SEQUENCE_RULES, { start: '2026-01-01', laborRates: rules.LABOR_RATES, rates: rules.RATES });
+  var seq2 = db.exec('SELECT COUNT(*) FROM task_sequences');
+  check('idempotent-rebuild-no-duplicate-edges', seq2[0].values[0][0] === edgeCount, 'after-rebuild=' + seq2[0].values[0][0]);
+
+  console.log('§W-GAP1 SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});


### PR DESCRIPTION
## Summary
- `materializeDefault`/`scheduleContiguous`/`applyDates` now emit real `task_sequences` SS edges from the already-computed §PHASE_OVERLAP_BAND lag, so `computeCpm` is no longer blind to a GENERATED (no-plan) schedule — CPM_FLOAT_GAP.md Gap 1 (phase-level).
- Fixed a real backward-pass bug in `computeCpm`, exposed for the first time by SS-only edges: late-finish was unclamped, so a predecessor with only an SS successor could compute an LF past the project's own finish — impossible, and silently zeroed the critical path.
- `schedule_editor_ui.js` `renderGantt` now draws real SVG dependency-arrow connectors between bars (FS/SS/FF/SF-aware endpoints, red for critical links) — previously text-only.

## Test plan
- [x] `node -c` all 4 changed JS files
- [x] New `witness_gap1_task_sequences.js` — 7/7 pass (edge emission, idempotent rebuild, real non-trivial critical path on Terminal)
- [x] `erp/tests/schedule_cpm_witness.js` — 10/10 (unchanged FS-diamond + generated-SH tests still pass)
- [x] `erp/tests/real_xer_witness.js` — 12/12, critical(52)==P6 driving_path_flag(52) unchanged
- [x] `erp/tests/foreign_adopt_witness.js` — 28/28
- [x] `erp/tests/foreign_compose_witness.js` — 16/16