### PR TITLE
feat(4d): 4D Schedule Diff — grade imported P6/MSP against our real-quantity estimate

### DIFF
--- a/erp/tests/schedule_diff_witness.js
+++ b/erp/tests/schedule_diff_witness.js
@@ -1,0 +1,127 @@
+// schedule_diff_witness.js — proves §4D_SCHEDULE_DIFF (viewer/schedule_diff.js) on the REAL Hospital
+// model: matches the synthetic-but-grounded GW-Hospital P6 programme (tests/gen_foreign_schedule.js —
+// real WBS/IFC-class vocabulary, real Hospital element counts drive the binding sidecar) against OUR
+// own materializeDefault labor-rate x real-quantity estimate for the SAME building, and reports the
+// variance — exactly the feature the user asked for ("our 4D schedule diff and show them their
+// variance - ie correcting theirs!" — CPM_FLOAT_GAP.md).
+//
+// ⚠ No real (non-synthetic) P6/MSP export was obtained for this session (prompts/XER_REAL_FIXTURE_PROOF.md
+// stays ⛔ BLOCKED — two of the three public-sample leads returned HTTP 521/500 when checked). This
+// witness therefore runs against the SAME synthetic Hospital_GW_Programme fixture the rest of the
+// foreign_schedule.js suite already treats as its demo/coverage fixture (real building, real element
+// counts, synthetic activity DURATIONS/DATES only) — see gen_foreign_schedule.js header. Real-file
+// calibration of the phase-matching vocabulary remains open, named here rather than silently dropped.
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, '..', '..', 'viewer');
+var FIX = path.join(__dirname, '..', '..', 'tests', 'fixtures');
+var HOSPITAL_DB = '/home/red1/bim-ootb/buildings/Hospital_meta.db';
+
+var FS_ = require(path.join(VIEWER, 'foreign_schedule.js'));
+var SA = require(path.join(VIEWER, 'schedule_author.js'));
+var DIFF = require(path.join(VIEWER, 'schedule_diff.js'));
+global.ScheduleAuthor = SA;   // schedule_diff.js's SA() reads global.ScheduleAuthor (globalThis fallback)
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-DIFF PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-DIFF FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+function read(f) { return fs.readFileSync(path.join(VIEWER, f), 'utf8'); }
+// rates.js is a browser global-assigning script (no module.exports) — eval its rule/rate blocks the
+// same way the other witnesses in this suite already do (foreign_compose_witness.js loadRates()).
+function loadRates() {
+  var t = read('rates.js');
+  function block(m, endTok) { var s = t.indexOf(m); return t.slice(s, t.indexOf(endTok, s) + endTok.length); }
+  var src = block('var RATES = {', '};') + '\n' +
+    block('var LABOR_RATES = {', '};') + '\n' +
+    block('var SEQUENCE_RULES = {', '};') + '\n' +
+    block('var SEQUENCE_DEFAULT', ';') + '\n' +
+    block('var SEQUENCE_NAME_OVERRIDES = [', '];');
+  return (new Function(src + '\n return {RATES:RATES, LABOR_RATES:LABOR_RATES, ' +
+    'SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES};'))();
+}
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } });
+  if (!fs.existsSync(HOSPITAL_DB)) { console.log('§W-DIFF SKIP Hospital DB absent: ' + HOSPITAL_DB); process.exit(0); }
+  var HOSP = new Uint8Array(fs.readFileSync(HOSPITAL_DB));
+  var R = loadRates();
+  global.SEQUENCE_RULES = R.SEQUENCE_RULES; global.LABOR_RATES = R.LABOR_RATES;
+  global.SEQUENCE_DEFAULT = R.SEQUENCE_DEFAULT; global.SEQUENCE_NAME_OVERRIDES = R.SEQUENCE_NAME_OVERRIDES;
+  global.RATES = R.RATES;
+
+  // ── §W-DIFF-BASIC: XER path, unmatched activities honestly reported, not silently dropped ─────────
+  var db1 = new SQL.Database(HOSP);
+  var xerText = fs.readFileSync(path.join(FIX, 'Hospital_GW_Programme.xer'), 'utf8');
+  var det1 = FS_.parseForeign(xerText, 'Hospital_GW_Programme.xer');
+  check('parsed-xer', det1.format === 'XER' && det1.parsed.activities.length === 14, 'activities=' + det1.parsed.activities.length);
+  var data1 = FS_.toScheduleData(det1.parsed, { scheduleId: 'GW-HOSP-XER' });
+  var res1 = DIFF.computeScheduleDiff(db1, data1, { shadowScheduleId: 'SCH_DIFF_XER' });
+  check('diff-ran-no-error', !res1.error, JSON.stringify(res1.error || 'ok'));
+  check('diff-coverage-reported', res1.summary.theirActivities === 14,
+    'theirActivities=' + res1.summary.theirActivities + ' matched=' + res1.summary.matchedActivities +
+    ' unmatched=' + res1.summary.unmatchedActivities);
+  check('diff-matched-most-activities', res1.summary.matchedActivities >= 10,
+    'matched=' + res1.summary.matchedActivities + '/14 (coarse name/WBS matcher, real vocabulary — see §4D_DIFF_MATCH log above)');
+  check('diff-produced-phase-rows', res1.phases.length >= 3, 'matchedPhases=' + res1.phases.length);
+  // every row must trace to REAL numbers: ourDays from materializeDefault (>0, real labor math),
+  // theirDays from the file's own start/finish window (>0, real dates) — never invented.
+  var allReal = res1.phases.every(function (r) { return r.ourDays > 0 && r.theirDays >= 0 && r.flag && r.flagMsg; });
+  check('diff-rows-trace-to-real-numbers', allReal, JSON.stringify(res1.phases.map(function (r) {
+    return { phase: r.phase, ours: r.ourDays, theirs: r.theirDays, flag: r.flag };
+  })));
+
+  // ── §W-DIFF-XML-EQ: PMXML of the SAME plan produces the SAME diff verdicts as XER (format-agnostic) ──
+  var db2 = new SQL.Database(HOSP);
+  var pmxmlText = fs.readFileSync(path.join(FIX, 'Hospital_GW_Programme.xml'), 'utf8');
+  var det2 = FS_.parseForeign(pmxmlText, 'Hospital_GW_Programme.xml');
+  var data2 = FS_.toScheduleData(det2.parsed, { scheduleId: 'GW-HOSP-XML' });
+  var res2 = DIFF.computeScheduleDiff(db2, data2, { shadowScheduleId: 'SCH_DIFF_XML' });
+  var flags1 = res1.phases.map(function (r) { return r.phase + '=' + r.flag; }).sort().join(',');
+  var flags2 = res2.phases.map(function (r) { return r.phase + '=' + r.flag; }).sort().join(',');
+  check('diff-format-agnostic-xer-vs-pmxml', flags1 === flags2 && res1.phases.length === res2.phases.length,
+    'xer[' + flags1 + '] vs pmxml[' + flags2 + ']');
+
+  // ── §W-DIFF-MSPDI: MS Project reader path too (all 3 foreign_schedule.js formats covered) ─────────
+  var db3 = new SQL.Database(HOSP);
+  var mspText = fs.readFileSync(path.join(FIX, 'Hospital_GW_MSProject.xml'), 'utf8');
+  var det3 = FS_.parseForeign(mspText, 'Hospital_GW_MSProject.xml');
+  check('parsed-mspdi', det3.format === 'MSPDI', 'format=' + det3.format);
+  var data3 = FS_.toScheduleData(det3.parsed, { scheduleId: 'GW-HOSP-MSP' });
+  var res3 = DIFF.computeScheduleDiff(db3, data3, { shadowScheduleId: 'SCH_DIFF_MSP' });
+  check('diff-mspdi-ran', !res3.error && res3.phases.length >= 3, 'matchedPhases=' + (res3.phases && res3.phases.length));
+
+  // ── §W-DIFF-SENSITIVITY: an activity list artificially compressed to 20% of real duration must be
+  // flagged 'optimistic' (proves the flag logic actually fires, not just always 'realistic') ─────────
+  var db4 = new SQL.Database(HOSP);
+  var compressed = JSON.parse(JSON.stringify(data1));
+  compressed.tasks.forEach(function (t) {
+    if (t.isSummary || !t.scheduleStart || !t.scheduleFinish) return;
+    // shrink every activity's window to start..start+1 (near-zero duration) — an absurdly optimistic plan
+    t.scheduleFinish = t.scheduleStart;
+  });
+  var res4 = DIFF.computeScheduleDiff(db4, compressed, { shadowScheduleId: 'SCH_DIFF_COMPRESSED' });
+  var anyOptimistic = res4.phases.some(function (r) { return r.flag === 'optimistic'; });
+  check('diff-flags-optimistic-plan', anyOptimistic, JSON.stringify(res4.phases.map(function (r) { return r.phase + '=' + r.flag; })));
+
+  // ── §W-DIFF-SENSITIVITY-SLOW: an activity list artificially stretched 10x must flag 'slow' ─────────
+  var db5 = new SQL.Database(HOSP);
+  var stretched = JSON.parse(JSON.stringify(data1));
+  stretched.tasks.forEach(function (t) {
+    if (t.isSummary || !t.scheduleStart || !t.scheduleFinish) return;
+    var s = Date.parse(t.scheduleStart + 'T00:00:00Z'), f = Date.parse(t.scheduleFinish + 'T00:00:00Z');
+    var stretchedF = new Date(s + (f - s) * 10).toISOString().slice(0, 10);
+    t.scheduleFinish = stretchedF;
+  });
+  var res5 = DIFF.computeScheduleDiff(db5, stretched, { shadowScheduleId: 'SCH_DIFF_STRETCHED' });
+  var anySlow = res5.phases.some(function (r) { return r.flag === 'slow'; });
+  check('diff-flags-slow-plan', anySlow, JSON.stringify(res5.phases.map(function (r) { return r.phase + '=' + r.flag; })));
+
+  console.log('\n§W-DIFF SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§W-DIFF ERROR', e); process.exit(1); });

--- a/viewer/schedule_diff.js
+++ b/viewer/schedule_diff.js
@@ -1,0 +1,283 @@
+// schedule_diff.js — §4D_SCHEDULE_DIFF (CPM_FLOAT_GAP.md, user's own words: "our 4D schedule diff and
+// show them their variance - ie correcting theirs!"). Grades an imported P6/MSP schedule against the
+// SAME real-quantity/labor-productivity model materializeDefault already uses to generate a schedule
+// from geometry alone — surfaces where a human planner's activity durations are unrealistic (too fast
+// for the real quantity + crew-count math, or unusually slow) versus what THIS building's own extracted
+// elements/rates say is physically achievable.
+//
+// NOT the "bind P6 to model elements for animation" feature (that's foreign_schedule.js's separate,
+// still-open task_elements binding gap — CPM_FLOAT_GAP.md Gap 2). This is COARSE phase/trade-level
+// matching only — an imported activity is matched to one of OUR phase buckets (Substructure/
+// Superstructure/MEP Rough-in/Architecture/MEP Final/Finishes), never to an individual model element.
+//
+// NON-INVENT: "our" duration comes straight from ScheduleAuthor.materializeDefault's already-proven
+// labor-rate x real-quantity / max_crews math (same function Terminal_extracted.db's 111d Superstructure
+// / 221d MEP Rough-in numbers come from — CPM_FLOAT_GAP.md). "their" duration comes straight from the
+// imported file's own activity start/finish dates (real elapsed calendar days — sidesteps the P6
+// working-calendar-vs-our-calendar-day unit mismatch CPM_FLOAT_GAP.md's real-XER witness already named,
+// by comparing DATE WINDOWS, not summed hour-derived durations). The flag thresholds below are a coarse,
+// clearly-logged classification rule (same class of transparent constant as materializeDefault's own
+// FRAGMENT_M2_FLOOR), not an invented duration number.
+//
+// Matching reuses schedule_author.js's matchRule (unmodified, literal call) over a keyword dictionary
+// DERIVED (not invented) from three already-real sources: (1) the phase names SEQUENCE_RULES itself
+// uses, (2) SEQUENCE_RULES' own IfcClass keys humanized into words ("IfcDuctSegment" -> "duct segment"),
+// (3) LABOR_RATES' own trade descriptions ("Steel Erector (Skilled)" -> "steel erector"). rates.js's
+// existing SEQUENCE_NAME_OVERRIDES regex list is reused as-is (its `classes` gate is skipped — a P6
+// activity carries no ifc_class to gate on, but the pattern/phase pair is the SAME curated rule). A
+// small set of well-known, real construction-industry terms (first fix/second fix, rough-in, envelope —
+// standard trade vocabulary, not fabricated data values) rounds out the phase-classification vocabulary;
+// per this project's own scope note (Prime Rule = data, not presentation), a text-classification
+// heuristic is presentation-layer, not an invented number — every DURATION/QUANTITY compared downstream
+// still traces to real extracted/rate data only.
+//
+// Pure, DOM-free, node-testable (mirrors schedule_author.js's own module shape).
+
+(function (global) {
+  'use strict';
+
+  // Node's top-level `this` (this IIFE's `global` param when neither `self` nor a real global scope
+  // is present) is `module.exports`, NOT the process-wide `global` object — same gap schedule_sync.js
+  // already hit and fixed (its own SA() helper). Mirror that fallback for every global lookup here.
+  function G(name) { return global[name] || (typeof globalThis !== 'undefined' ? globalThis[name] : undefined); }
+  var SA = function () { return G('ScheduleAuthor'); };
+
+  // ── phase-classification keyword dictionary (derived, not invented — see header) ─────────────────
+  var STOP_WORDS = { 'case': 1, 'type': 1, 'part': 1, 'unit': 1, 'with': 1, 'from': 1, 'into': 1,
+    'device': 1, 'skilled': 1, 'mixed': 1, 'laborers': 1, 'laborer': 1, 'general': 1 };
+
+  function _humanize(cls) {
+    return String(cls).replace(/^Ifc/, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+  }
+
+  // Real, standard construction-industry trade vocabulary (see header §NON-INVENT) mapped onto the
+  // phase names THIS project's own SEQUENCE_RULES already uses — added only when that phase name is
+  // actually present in the caller's rules (never invents a phase that doesn't exist here).
+  var _SYNONYMS = {
+    'Substructure': ['substructure', 'foundation', 'foundations', 'footing', 'footings', 'piling', 'piles', 'excavation'],
+    'Superstructure': ['superstructure', 'structural frame', 'structural framing', 'structural steel', 'steel erection', 'concrete frame'],
+    'MEP Rough-in': ['mep rough-in', 'mep first fix', 'first fix', 'rough-in', 'roughin', 'containment'],
+    'Architecture': ['building envelope', 'envelope', 'fenestration', 'cladding', 'blockwork', 'masonry', 'waterproofing'],
+    'MEP Final': ['mep final', 'second fix', 'final fix', 'trim-out', 'fit-off', 'mep commissioning', 'testing and commissioning'],
+    'Finishes': ['finishes', 'fit-out', 'fitout', 'flooring', 'painting', 'joinery'],
+  };
+
+  // buildMatcher(rules, laborRates, nameOverrides) — index built ONCE per computeScheduleDiff call.
+  function buildMatcher(rules, laborRates, nameOverrides) {
+    rules = rules || {};
+    laborRates = laborRates || {};
+    nameOverrides = nameOverrides || [];
+    var phaseSet = {};
+    for (var k in rules) phaseSet[rules[k].phase] = true;
+
+    var dict = {}, source = {};
+    function addKey(key, phase, why) {
+      key = String(key || '').trim().toLowerCase();
+      if (!key || dict[key]) return;   // first writer wins (deterministic insertion order)
+      dict[key] = { phase: phase };
+      source[key] = why;
+    }
+
+    // (1) exact phase names — the strongest, most specific signal, naturally long so matchRule's
+    // longest-key-wins already prioritizes these over a single generic word.
+    Object.keys(phaseSet).forEach(function (p) { addKey(p, p, 'exact_phase'); });
+
+    // (2) IfcClass keys humanized into words/phrases.
+    for (var cls in rules) {
+      var phase = rules[cls].phase;
+      var humanized = _humanize(cls);
+      addKey(humanized, phase, 'class:' + cls);
+      humanized.split(' ').forEach(function (w) {
+        if (w.length >= 4 && !STOP_WORDS[w]) addKey(w, phase, 'class:' + cls);
+      });
+    }
+
+    // (3) LABOR_RATES trade descriptions -> majority phase among the classes assigned that resource.
+    var resourcePhaseCounts = {};
+    for (var c2 in rules) {
+      var r = rules[c2].resource;
+      if (!r) continue;
+      resourcePhaseCounts[r] = resourcePhaseCounts[r] || {};
+      resourcePhaseCounts[r][rules[c2].phase] = (resourcePhaseCounts[r][rules[c2].phase] || 0) + 1;
+    }
+    for (var resKey in laborRates) {
+      var counts = resourcePhaseCounts[resKey];
+      if (!counts) continue;
+      var bestPhase = null, bestN = 0;
+      for (var ph in counts) if (counts[ph] > bestN) { bestN = counts[ph]; bestPhase = ph; }
+      if (!bestPhase) continue;
+      var tradeLabel = String(laborRates[resKey].trade || '').replace(/\([^)]*\)/g, '').replace(/\+.*/, '').trim().toLowerCase();
+      if (!tradeLabel) continue;
+      addKey(tradeLabel, bestPhase, 'trade:' + resKey);
+      tradeLabel.split(' ').forEach(function (w) {
+        if (w.length >= 4 && !STOP_WORDS[w]) addKey(w, bestPhase, 'trade:' + resKey);
+      });
+    }
+
+    // (4) real construction-industry synonyms, only for phases that actually exist in `rules`.
+    Object.keys(_SYNONYMS).forEach(function (p) {
+      if (!phaseSet[p]) return;
+      _SYNONYMS[p].forEach(function (kw) { addKey(kw, p, 'synonym'); });
+    });
+
+    return { dict: dict, source: source, nameOverrides: nameOverrides };
+  }
+
+  // matchActivityToPhase(text, matcher) — text = activity name (+ its WBS ancestor names, joined).
+  // Returns {phase, tier, key} or null (unmatched — reported, never silently dropped).
+  function matchActivityToPhase(text, matcher) {
+    if (!text) return null;
+    var lower = String(text).toLowerCase();
+    // pass 1 — reuse rates.js's own curated SEQUENCE_NAME_OVERRIDES regex list AS-IS (the `classes`
+    // gate is skipped: a P6 activity carries no ifc_class to gate against — same list, same pattern).
+    var ov = matcher.nameOverrides || [];
+    for (var i = 0; i < ov.length; i++) {
+      var o = ov[i];
+      if (!o._re) { try { o._re = new RegExp(o.pattern, o.flags || 'i'); } catch (e) { o._re = null; } }
+      if (o._re && o._re.test(text)) return { phase: o.phase, tier: 'name_override', key: o.id };
+    }
+    // pass 2 — SA().matchRule, called UNMODIFIED (literal reuse, not reimplemented) against the
+    // derived keyword dictionary. Sentinel dflt lets us tell "matched the default" from "no match".
+    var matchRule = SA() && SA().matchRule;
+    if (!matchRule) return null;
+    var NOMATCH = { __nomatch: true };
+    var res = matchRule(lower, matcher.dict, NOMATCH);
+    if (res.__nomatch) return null;
+    // recover which key actually hit (matchRule doesn't return it) by re-running its own longest-match rule.
+    var bestKey = null, bestLen = 0;
+    for (var key in matcher.dict) {
+      if (lower.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
+    }
+    return { phase: res.phase, tier: matcher.source[bestKey] || 'keyword', key: bestKey };
+  }
+
+  // ── date helpers (elapsed CALENDAR days between two YYYY-MM-DD dates — real, not derived-from-hours) ─
+  function _daysSpan(startStr, finishStr) {
+    if (!startStr || !finishStr) return null;
+    var s = Date.parse(startStr + 'T00:00:00Z'), f = Date.parse(finishStr + 'T00:00:00Z');
+    if (isNaN(s) || isNaN(f)) return null;
+    return Math.max(0, Math.round((f - s) / 86400000));
+  }
+
+  // normalize an imported schedule into a flat leaf-activity array, from EITHER a live-adopted db
+  // schedule_id OR a not-yet-adopted ForeignSchedule.toScheduleData() result — same shape either way.
+  function _readForeignTasks(db, foreignData, importedScheduleId) {
+    var wbsName = {}, out = [];
+    if (foreignData) {
+      foreignData.tasks.forEach(function (t) { if (t.isSummary) wbsName[t.id] = t.name; });
+      foreignData.tasks.forEach(function (t) {
+        if (t.isSummary) return;
+        var parentName = t.wbsParent && wbsName[t.wbsParent] ? wbsName[t.wbsParent] : '';
+        out.push({ id: t.id, name: t.name, text: (parentName ? parentName + ' ' : '') + t.name,
+          start: t.scheduleStart, finish: t.scheduleFinish });
+      });
+      return out;
+    }
+    if (db && importedScheduleId) {
+      var r = db.exec('SELECT task_id, wbs_parent, name, is_summary, schedule_start, schedule_finish FROM tasks WHERE schedule_id=?', [importedScheduleId]);
+      if (!r.length || !r[0].values.length) return out;
+      r[0].values.forEach(function (row) { if (row[3] === 1) wbsName[row[0]] = row[2]; });
+      r[0].values.forEach(function (row) {
+        if (row[3] === 1) return;
+        var parentName = row[1] && wbsName[row[1]] ? wbsName[row[1]] : '';
+        out.push({ id: row[0], name: row[2], text: (parentName ? parentName + ' ' : '') + row[2],
+          start: row[4], finish: row[5] });
+      });
+    }
+    return out;
+  }
+
+  // computeScheduleDiff(db, foreignData, opts) — the main entry point.
+  //   db: sql.js Database with elements_meta (drives OUR estimate — real building, no invention).
+  //   foreignData: ForeignSchedule.toScheduleData() output, OR null if opts.importedScheduleId names an
+  //                already-adopted schedule_id inside `db` instead.
+  //   opts: { importedScheduleId, start, rules, laborRates, nameOverrides, rates, defaultRule,
+  //           shadowScheduleId, optimisticRatio(0.8), slowRatio(1.2) }
+  function computeScheduleDiff(db, foreignData, opts) {
+    opts = opts || {};
+    if (!db) return { error: 'no_db' };
+    var rules = opts.rules || G('SEQUENCE_RULES') || {};
+    var laborRates = opts.laborRates || G('LABOR_RATES') || {};
+    var nameOverrides = opts.nameOverrides || G('SEQUENCE_NAME_OVERRIDES') || [];
+    var qsRates = opts.rates || G('RATES') || {};
+    var dflt = opts.defaultRule || G('SEQUENCE_DEFAULT') || { phase: 'Architecture', sequence: 6, resource: null };
+    var optimisticRatio = opts.optimisticRatio || 0.8;   // theirs <=80% of ours -> flagged optimistic
+    var slowRatio = opts.slowRatio || 1.2;                // theirs >=120% of ours -> flagged slow
+
+    if (!SA() || !SA().materializeDefault) return { error: 'no_engine' };
+
+    // ── OUR estimate: the EXACT already-proven per-phase labor-rate x real-quantity / max_crews math
+    // materializeDefault computes for a from-scratch generated schedule. Written to a throwaway
+    // schedule_id (never SCH_AUTHORED, never the imported schedule) so this diff is non-destructive —
+    // same idempotent-shadow-schedule convention this file's own rebuild-on-every-call already uses.
+    var shadowId = opts.shadowScheduleId || 'SCH_DIFF_SHADOW';
+    var ours = SA().materializeDefault(db, rules, {
+      scheduleId: shadowId, start: opts.start || '2026-01-01',
+      defaultRule: dflt, laborRates: laborRates, rates: qsRates, nameOverrides: nameOverrides,
+    });
+    var ourPhases = {};
+    ours.phases.forEach(function (p) { ourPhases[p.name] = p; });
+
+    // ── THEIR activities, matched to OUR phase buckets.
+    var theirTasks = _readForeignTasks(db, foreignData, opts.importedScheduleId);
+    var matcher = buildMatcher(rules, laborRates, nameOverrides);
+    var byPhase = {};   // phaseName -> { minStart, maxFinish, activities:[] }
+    var unmatched = [];
+    theirTasks.forEach(function (t) {
+      var m = matchActivityToPhase(t.text, matcher);
+      if (!m) { unmatched.push({ id: t.id, name: t.name }); console.log('§4D_DIFF_UNMATCHED activity=' + t.id + ' name="' + t.name + '"'); return; }
+      var b = byPhase[m.phase] || (byPhase[m.phase] = { minStart: null, maxFinish: null, activities: [] });
+      b.activities.push({ id: t.id, name: t.name, tier: m.tier, key: m.key, start: t.start, finish: t.finish });
+      if (t.start && (!b.minStart || t.start < b.minStart)) b.minStart = t.start;
+      if (t.finish && (!b.maxFinish || t.finish > b.maxFinish)) b.maxFinish = t.finish;
+      console.log('§4D_DIFF_MATCH activity=' + t.id + ' name="' + t.name + '" -> phase=' + m.phase + ' tier=' + m.tier + ' key=' + m.key);
+    });
+
+    // ── diff rows: every phase where BOTH sides have data.
+    var rows = [], ourOnly = [];
+    ours.phases.forEach(function (p) {
+      var b = byPhase[p.name];
+      if (!b || !b.activities.length) { ourOnly.push(p.name); return; }
+      var theirDays = _daysSpan(b.minStart, b.maxFinish);
+      if (theirDays == null) { ourOnly.push(p.name); return; }   // matched activities but no usable dates
+      var ourDays = p.durationDays;
+      var deltaDays = theirDays - ourDays;
+      var deltaPct = ourDays > 0 ? Math.round((deltaDays / ourDays) * 1000) / 10 : null;
+      var ratio = ourDays > 0 ? theirDays / ourDays : null;
+      var flag = 'realistic';
+      var flagMsg = 'within ' + Math.round((1 - optimisticRatio) * 100) + '% band of the achievable estimate';
+      if (ratio != null && ratio <= optimisticRatio) {
+        flag = 'optimistic';
+        var factor = theirDays > 0 ? (ourDays / theirDays).toFixed(1) + 'x' : 'zero-duration (no time budgeted at all)';
+        flagMsg = 'flagged optimistic — ' + factor + (theirDays > 0 ? ' faster than' : ' vs') + ' the real quantity + crew-count minimum';
+      } else if (ratio != null && ratio >= slowRatio) {
+        flag = 'slow';
+        flagMsg = 'flagged slow — ' + (theirDays / ourDays).toFixed(1) + 'x longer than necessary given the real quantity + crew count';
+      }
+      var row = { phase: p.name, ourDays: ourDays, ourElements: p.count, theirDays: theirDays,
+        theirStart: b.minStart, theirFinish: b.maxFinish, theirActivities: b.activities.length,
+        deltaDays: deltaDays, deltaPct: deltaPct, flag: flag, flagMsg: flagMsg };
+      rows.push(row);
+      console.log('§4D_DIFF phase=' + p.name + ' ours=' + ourDays + 'd theirs=' + theirDays + 'd delta=' +
+        deltaDays + 'd (' + deltaPct + '%) flag=' + flag + ' — ' + flagMsg);
+    });
+
+    var summary = {
+      ourPhases: ours.phases.length, matchedPhases: rows.length, ourOnlyPhases: ourOnly.length,
+      theirActivities: theirTasks.length, matchedActivities: theirTasks.length - unmatched.length,
+      unmatchedActivities: unmatched.length,
+    };
+    console.log('§4D_DIFF_COVERAGE ourPhases=' + summary.ourPhases + ' matchedPhases=' + summary.matchedPhases +
+      ' ourOnlyPhases=' + summary.ourOnlyPhases + ' theirActivities=' + summary.theirActivities +
+      ' matchedActivities=' + summary.matchedActivities + ' unmatchedActivities=' + summary.unmatchedActivities);
+
+    return { ourScheduleId: shadowId, phases: rows, ourOnlyPhases: ourOnly, unmatchedActivities: unmatched, summary: summary };
+  }
+
+  var API = { computeScheduleDiff: computeScheduleDiff, matchActivityToPhase: matchActivityToPhase, buildMatcher: buildMatcher };
+  if (typeof window !== 'undefined') window.ScheduleDiff = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else global.ScheduleDiff = API;
+
+  console.log('§SCHEDULE_DIFF_LOADED v1');
+})(typeof self !== 'undefined' ? self : this);

--- a/viewer/schedule_editor.html
+++ b/viewer/schedule_editor.html
@@ -68,6 +68,9 @@
   #se-cpm-btn { background: #243042; border-color: #34465e; color: #cdd7e4; cursor: pointer; }
   #se-cpm-btn:hover { background: #2c3a50; }
   #se-cpm-out { font-size: 11px; color: #9fb0c6; }
+  #se-diff-btn { background: #243042; border: 1px solid #34465e; color: #cdd7e4; cursor: pointer; margin-left: 6px; }
+  #se-diff-btn:hover { background: #2c3a50; }
+  #se-diff-out { font-size: 11px; color: #9fb0c6; padding: 4px 0 2px; line-height: 1.6; }
   .se-dep-row.se-dep-crit .se-dep-pred, .se-dep-row.se-dep-crit .se-dep-succ { color: #f0a6b1; font-weight: 600; }
   /* Gantt timeline */
   .gantt-pane { height: calc(58vh - 96px); overflow: auto; padding: 10px 12px; }
@@ -157,6 +160,7 @@
     <span class="se-ribbon-label">Compute</span>
     <button id="se-cpm-btn" title="Critical-path forward/backward pass over the dependency graph">▶ CPM</button>
     <span id="se-cpm-out"></span>
+    <button id="se-diff-btn" title="4D Schedule Diff — grade an IMPORTED P6/MS Project schedule's per-phase durations against this building's own real-quantity + labor-rate estimate (import a P6/MSP file first via ⤓ P6)">⚖ Diff vs Model</button>
   </div>
   <div class="se-ribbon-group">
     <span class="se-ribbon-label">Zoom</span>
@@ -166,6 +170,7 @@
   </div>
 </div>
 <div id="se-status">Initialising…</div>
+<div id="se-diff-out"></div>
 <main>
   <section class="pane left">
     <h2>Work Breakdown (WBS)</h2>
@@ -193,7 +198,8 @@
 <script src="rates.js?v=4" onerror="console.warn('§LOAD_FAIL rates.js')"></script>
 <script src="schedule_author.js?v=12" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="foreign_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL foreign_schedule.js')"></script>
+<script src="schedule_diff.js?v=1" onerror="console.warn('§LOAD_FAIL schedule_diff.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
-<script src="schedule_editor_ui.js?v=10" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
+<script src="schedule_editor_ui.js?v=11" onerror="console.warn('§LOAD_FAIL schedule_editor_ui.js')"></script>
 </body>
 </html>

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -452,6 +452,38 @@
     persist();
   }
 
+  // ── §4D_SCHEDULE_DIFF: grade an IMPORTED P6/MSP schedule against OUR own real-quantity/labor-rate
+  // estimate for THIS building (CPM_FLOAT_GAP.md — user's own words: "our 4D schedule diff and show
+  // them their variance - ie correcting theirs!"). Only meaningful on a CAPTURED (imported) schedule —
+  // diffing our own generated estimate against itself is a no-op, same guard doGenerate already uses.
+  function onDiffVsModel() {
+    var DFx = global.ScheduleDiff;
+    var out = $('se-diff-out');
+    if (!DFx) { status('⚠ schedule_diff.js not loaded'); return; }
+    if (!db || !schedId) { status('⚠ no schedule loaded'); return; }
+    var act = SA().activeSchedule(db);
+    if (!act || !act.captured) {
+      status('⚖ Diff vs Model compares an IMPORTED P6/MSP schedule against our real-quantity estimate — import one first (⤓ P6).');
+      return;
+    }
+    if (out) out.textContent = 'computing…';
+    setTimeout(function () {
+      var res = DFx.computeScheduleDiff(db, null, { importedScheduleId: schedId, start: '2026-01-01' });
+      if (res.error) { if (out) out.textContent = '⚠ ' + res.error; return; }
+      var lines = res.phases.map(function (r) {
+        var icon = r.flag === 'optimistic' ? '⚡' : r.flag === 'slow' ? '🐢' : '✓';
+        return icon + ' ' + r.phase + ': theirs ' + r.theirDays + 'd vs ours ' + r.ourDays + 'd (' +
+          (r.deltaPct > 0 ? '+' : '') + r.deltaPct + '%) — ' + r.flagMsg;
+      });
+      if (res.unmatchedActivities.length) lines.push(res.unmatchedActivities.length + ' activity(ies) unmatched — see console §4D_DIFF_UNMATCHED');
+      if (out) out.textContent = lines.join('   ');
+      status('4D Schedule Diff: ' + res.summary.matchedPhases + '/' + res.summary.ourPhases + ' phases compared, ' +
+        res.summary.matchedActivities + '/' + res.summary.theirActivities + ' activities matched.');
+      console.log('§SE_DIFF schedule=' + schedId + ' matchedPhases=' + res.summary.matchedPhases +
+        ' matchedActivities=' + res.summary.matchedActivities + ' unmatched=' + res.summary.unmatchedActivities);
+    }, 30);
+  }
+
   // §SE-6: debounced write-back to the SAME IndexedDB cache slot the building was loaded from — the
   // gap that made every schedule edit vanish on tab close (see schedule_author.js persistDb doc).
   // Called from BOTH mutation choke points below (refreshFold covers WBS/dep/date/reparent edits;
@@ -721,6 +753,7 @@
         renderWbs(); renderDeps(); renderGantt();
         var addBtn = $('se-add-btn'); if (addBtn) addBtn.onclick = onAdd;
         var cpmBtn = $('se-cpm-btn'); if (cpmBtn) cpmBtn.onclick = onComputeCpm;
+        var diffBtn = $('se-diff-btn'); if (diffBtn) diffBtn.onclick = onDiffVsModel;
         var genBtn = $('se-generate-btn'); if (genBtn) genBtn.onclick = doGenerate;
         var expBtn = $('se-export-msp-btn'); if (expBtn) expBtn.onclick = exportMSProject;
         var expPmxmlBtn = $('se-export-pmxml-btn'); if (expPmxmlBtn) expPmxmlBtn.onclick = exportPMXML;
@@ -746,7 +779,7 @@
       .catch(function (e) { status('⚠ ' + e.message); console.error('§SE_UI ERROR', e); });
   }
 
-  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm, setZoom: setZoom, exportMSProject: exportMSProject, exportPMXML: exportPMXML, exportXER: exportXER };
+  global.ScheduleEditor = { init: init, renderWbs: renderWbs, renderDeps: renderDeps, renderGantt: renderGantt, computeCpm: onComputeCpm, diffVsModel: onDiffVsModel, setZoom: setZoom, exportMSProject: exportMSProject, exportPMXML: exportPMXML, exportXER: exportXER };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })(typeof window !== 'undefined' ? window : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v936';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v937';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -196,6 +196,7 @@ const PRECACHE_ASSETS = [
   'schedule_author.js',
   'schedule_author_ui.js',
   'foreign_schedule.js',
+  'schedule_diff.js',
   'schedule_sync.js',
   'schedule_editor.html',
   'schedule_editor_ui.js',


### PR DESCRIPTION
## Summary
- New engine `viewer/schedule_diff.js`: matches an imported Primavera P6 / MS Project schedule's activities to our `SEQUENCE_RULES` phase buckets (Substructure/Superstructure/MEP Rough-in/Architecture/MEP Final/Finishes) via coarse name/WBS-code text matching, then compares their real elapsed-calendar-day duration per phase against `materializeDefault`'s already-proven labor-rate × real-quantity / max_crews estimate for the SAME building — flagging phases `optimistic`/`slow`/`realistic`.
- This is the feature from the user's own words: *"our 4D schedule diff and show them their variance - ie correcting theirs!"* (`prompts/CPM_FLOAT_GAP.md`). Coarse phase-level matching only — **not** the separate, still-open element-binding gap (Gap 2).
- Matching reuses `schedule_author.js`'s `matchRule` verbatim (not reimplemented) over a keyword dictionary derived from real `SEQUENCE_RULES`/`LABOR_RATES` data plus `rates.js`'s existing `SEQUENCE_NAME_OVERRIDES`, plus a small set of real construction-industry terms (first fix/second fix/rough-in/envelope) — see the file header for full non-invent rationale.
- Minimal UI hook: a "⚖ Diff vs Model" button in `schedule_editor.html`'s Compute ribbon (active only on an imported/captured schedule), printing a per-phase report line — same `status()`/`se-*-out` convention as the existing ▶ CPM button. POC-track: engine + proof is the deliverable, not a polished report UI.
- `sw.js`: `schedule_diff.js` added to `PRECACHE_ASSETS`, `CACHE_VERSION` bumped v936→v937.

## Real-fixture search (per prompts/XER_REAL_FIXTURE_PROOF.md)
No real (non-synthetic) P6/MSP export was obtained this session — checked 2 of 3 public-sample leads (pmproguide.com, project.pm), both returned HTTP 521/500. `prompts/XER_REAL_FIXTURE_PROOF.md` stays `⛔ BLOCKED`, unchanged. The witness below runs against the existing synthetic-but-grounded `Hospital_GW_Programme` fixture (`tests/gen_foreign_schedule.js` — real WBS/IFC-class vocabulary and real Hospital element counts, synthetic activity durations/dates only). Real-file calibration of the phase-matching vocabulary remains open.

## Test plan
- [x] `node -c` on every changed JS file
- [x] New witness `erp/tests/schedule_diff_witness.js` — **W-DIFF 11/11 pass** on the REAL `Hospital_meta.db` (63,415 elements):
  - XER/PMXML/MSPDI readers all produce identical diff verdicts (format-agnostic)
  - Coverage fully reported: 14/14 activities matched, 0 unmatched
  - Real finding surfaced: our labor-derived **MEP Rough-in estimate is 755 real days vs the demo plan's 55 days (flagged 13.7x optimistic)** on this building's actual element/rate data
  - Sensitivity checks confirm the flag logic actually fires both directions (artificially compressed → `optimistic`, artificially stretched 10x → `slow`)
- [x] Verified non-regressive against a concurrent same-day merge (`#1160`, zone-level CPM) — clean merge, no conflicts, re-ran witness green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)