### PR TITLE
fix(4d): computeCpm fixedDates opt — close the zone-graph/movie duration divergence

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -895,6 +895,23 @@
   }
 
   // computeCpm(db, scheduleId, opts) — write early/late dates, float, is_critical onto the leaf tasks.
+  // fixedDates opt (§ZONE_CPM_COHERENCE): computeCpm's forward pass normally DERIVES each task's
+  // early start from the graph (max over predecessors' EF+lag) — correct when the dates themselves
+  // are the thing being solved for (a captured P6 schedule re-solving after an edit, or the
+  // phase-level chain, which is a simple ≤1-parent-per-node list where derivation and the real dates
+  // always agree). It stops being correct once a node can have MULTIPLE real parents, as
+  // materializeZones' zone graph does (a zone can be gated by both its own-phase floor-below AND a
+  // same-floor earlier trade): each incoming edge's lag was computed independently from ONE real
+  // observed pair, so taking the graph max over several independently-derived lags can compound past
+  // what the real, jointly-crew-constrained computation (ScheduleGate.computeSchedule — the same
+  // engine driving the live movie) actually produced. MEASURED on Terminal's 71-zone graph: derived
+  // PF=138d vs the real movie's 93d (+48%, CPM_FLOAT_GAP.md session note, 2026-08-03).
+  // Fix: when opts.fixedDates is set, es/ef come DIRECTLY from the already-real, already-movie-
+  // coherent schedule_start/schedule_finish this task was persisted with — never re-derived through
+  // the graph. The backward pass (LS/LF/float/critical) is UNCHANGED and still runs over real edges,
+  // so float/criticality stay meaningful; only the (previously-compounding) forward derivation is
+  // skipped. Opt-in, not the default — existing callers (phase-level, captured P6) get byte-identical
+  // behavior; only a caller that already trusts its own persisted dates as ground truth sets this.
   function computeCpm(db, scheduleId, opts) {
     opts = opts || {};
     var tr;
@@ -903,11 +920,15 @@
         'WHERE schedule_id=? AND (is_summary IS NULL OR is_summary=0)', [scheduleId]);
     } catch (e) { return { error: 'no_tasks' }; }
     if (!tr.length || !tr[0].values.length) return { error: 'no_tasks', tasks: [], projectDuration: 0, criticalIds: [] };
-    var T = {}, ids = [], minStart = null;
+    var minStart = null;
+    tr[0].values.forEach(function (row) { var s = row[1]; if (s && (!minStart || s < minStart)) minStart = s; });
+    var projStart = opts.start || minStart || '2026-01-01';
+    var T = {}, ids = [];
     tr[0].values.forEach(function (row) {
       var id = row[0], s = row[1], f = row[2];
-      if (s && (!minStart || s < minStart)) minStart = s;
-      T[id] = { id: id, dur: _durDays(row[3], s, f), es: 0, ef: 0, ls: 0, lf: 0, preds: [], succs: [] };
+      var dur = _durDays(row[3], s, f);
+      var fixedEs = opts.fixedDates && s ? _durDays(null, projStart, s) : 0;
+      T[id] = { id: id, dur: dur, es: fixedEs, ef: fixedEs + dur, ls: 0, lf: 0, preds: [], succs: [] };
       ids.push(id);
     });
     // edges among these leaf tasks only
@@ -918,7 +939,8 @@
       var edge = { pred: p, succ: s, type: (row[2] || 'FS').toUpperCase(), lag: (row[3] != null ? row[3] : 0) };
       T[s].preds.push(edge); T[p].succs.push(edge);
     });
-    // Kahn topo sort (DAG guaranteed by the §SE-1 cycle guard; bail defensively if not).
+    // Kahn topo sort (DAG guaranteed by the §SE-1 cycle guard; bail defensively if not) — still run
+    // under fixedDates too: it's the cycle/orphan integrity check, independent of the ES derivation.
     var indeg = {}, queue = [], topo = [];
     ids.forEach(function (id) { indeg[id] = T[id].preds.length; if (indeg[id] === 0) queue.push(id); });
     while (queue.length) {
@@ -929,12 +951,15 @@
       console.log('§SE_CPM_BAIL cycle-or-orphan topo=' + topo.length + ' tasks=' + ids.length);
       return { error: 'cycle', tasks: [], projectDuration: 0, criticalIds: [] };
     }
-    // FORWARD: ES/EF in topo order.
-    topo.forEach(function (id) {
-      var t = T[id], es = 0;
-      t.preds.forEach(function (e) { es = Math.max(es, _fwdES(T[e.pred], e.lag, e.type, t.dur)); });
-      t.es = Math.max(0, es); t.ef = t.es + t.dur;
-    });
+    // FORWARD: ES/EF in topo order — SKIPPED under fixedDates (see header); es/ef already set above
+    // from the real persisted dates.
+    if (!opts.fixedDates) {
+      topo.forEach(function (id) {
+        var t = T[id], es = 0;
+        t.preds.forEach(function (e) { es = Math.max(es, _fwdES(T[e.pred], e.lag, e.type, t.dur)); });
+        t.es = Math.max(0, es); t.ef = t.es + t.dur;
+      });
+    }
     var PF = 0; ids.forEach(function (id) { PF = Math.max(PF, T[id].ef); });
     // BACKWARD: LF/LS in reverse topo order. A task's late finish can never legitimately exceed the
     // project's own finish PF — that IS the definition of "project finish." The un-clamped succs-loop

--- a/witness_zone_cpm.js
+++ b/witness_zone_cpm.js
@@ -53,17 +53,22 @@ initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).the
   check('idempotent-rebuild', zr2[0].values[0][0] === res.zoneCount && er2[0].values[0][0] === res.edgeCount,
     'zones=' + zr2[0].values[0][0] + ' edges=' + er2[0].values[0][0]);
 
-  // Real CPM over the zone graph.
-  var cpm = ScheduleAuthor.computeCpm(db, 'SCH_AUTHORED', { start: '2026-01-01' });
-  check('cpm-no-error', !cpm.error, JSON.stringify(cpm.error || null));
-  // KNOWN, DOCUMENTED divergence (not asserted equal — see CPM_FLOAT_GAP.md session note): CPM's
-  // forward pass idealizes unlimited resources per edge; the real movie (zones' own start/end,
-  // ScheduleGate.computeSchedule) shares a capped crew pool across ALL zones simultaneously. Through
-  // a graph this deep (22 real floor-ranks on Terminal), that idealization compounds and CPM's
-  // implied total can run meaningfully longer than what actually happens — report it, don't hide it.
-  var durationDivergencePct = Math.round(Math.abs(cpm.projectDuration - res.totalDays) / res.totalDays * 100);
-  console.log('§W-ZONE KNOWN-LIMIT cpm-projectDuration=' + cpm.projectDuration + ' real-movie-totalDays=' + res.totalDays +
-    ' divergence=' + durationDivergencePct + '% (CPM forward-pass is resource-unaware; tier-2 derived, not exact — see spec)');
+  // Real CPM over the zone graph — DERIVED forward pass (previous behavior, kept as a live
+  // regression proof of the divergence this fixedDates opt exists to close, not just a historical note).
+  var cpmDerived = ScheduleAuthor.computeCpm(db, 'SCH_AUTHORED', { start: '2026-01-01' });
+  check('cpm-derived-no-error', !cpmDerived.error, JSON.stringify(cpmDerived.error || null));
+  var derivedDivergencePct = Math.round(Math.abs(cpmDerived.projectDuration - res.totalDays) / res.totalDays * 100);
+  console.log('§W-ZONE DERIVED cpm-projectDuration=' + cpmDerived.projectDuration + ' real-movie-totalDays=' + res.totalDays +
+    ' divergence=' + derivedDivergencePct + '% (expected: still diverges — this call does NOT use fixedDates)');
+
+  // fixedDates:true — trusts the zone's real, movie-coherent persisted dates directly (see
+  // computeCpm's header comment). Must reproduce the real movie's total EXACTLY, not approximately.
+  var cpm = ScheduleAuthor.computeCpm(db, 'SCH_AUTHORED', { start: '2026-01-01', fixedDates: true });
+  check('cpm-fixed-no-error', !cpm.error, JSON.stringify(cpm.error || null));
+  check('cpm-fixed-matches-real-movie-exactly', cpm.projectDuration === res.totalDays,
+    'cpm(fixedDates)=' + cpm.projectDuration + ' real-movie-totalDays=' + res.totalDays);
+  console.log('§W-ZONE FIXED cpm-projectDuration=' + cpm.projectDuration + ' real-movie-totalDays=' + res.totalDays +
+    ' (fixedDates:true — should be an EXACT match, coherence restored)');
   check('cpm-has-critical-path', (cpm.criticalIds || []).length > 0, 'critical=' + (cpm.criticalIds || []).length);
   check('cpm-critical-path-plausible-share', (cpm.criticalIds || []).length < res.zoneCount,
     'critical=' + (cpm.criticalIds || []).length + '/' + res.zoneCount);


### PR DESCRIPTION
## Summary
Closes the known limitation documented in PR #1160 / CPM_FLOAT_GAP.md: the zone-level detail schedule's CPM-solved total ran 48% longer (138d) than what the real movie actually produces (93d on Terminal), because a zone with multiple real parents let CPM's forward pass compound independently-derived lag values through a 22-floor-deep chain.

Fix: opt-in `fixedDates` mode on `computeCpm`. Trusts a task's real persisted `schedule_start`/`schedule_finish` directly instead of re-deriving through the graph; backward pass (float/criticality) unchanged. Default false — zero behavior change for existing callers (phase-level, captured P6).

## Test plan
- [x] `witness_zone_cpm.js` — now asserts an EXACT match (93d==93d) with `fixedDates:true`, keeps a live regression proof of the pre-fix divergence so it can't silently return. 11/11 pass.
- [x] `schedule_cpm_witness.js` — 10/10 unchanged
- [x] `real_xer_witness.js` — 12/12 unchanged
- [x] `foreign_adopt_witness.js` — 28/28 unchanged
- [x] `foreign_compose_witness.js` — 16/16 unchanged
- [x] `schedule_diff_witness.js` — 11/11 unchanged
- [x] `test_schedule_gate.js` — 0/3240 floating, unchanged