### PR TITLE
fix(4d): exclude IfcOpeningElement from generated schedule + generalize support-invariant proof

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -193,10 +193,19 @@
     var nameOverrides = opts.nameOverrides || (global.SEQUENCE_NAME_OVERRIDES) || [];
     var _frag = _classFragmentation(db, qsRates);
 
+    // §OPENING_EXCLUDE (found 2026-08-04, 4D_SCHEDULE_PERFECTION.md fool-proofing pass): this query
+    // must match time_machine.js's own live-movie element-building query EXACTLY (this function's own
+    // header says "REPLICATES ... EXACTLY") — that query excludes IfcOpeningElement (time_machine.js
+    // WHERE m.ifc_class != 'IfcOpeningElement', 3x). This one didn't, so materializeDefault/
+    // materializeZones scheduled wall/window VOIDS as if they were physical installable work — up to
+    // 4.5% of elements on a real building (JKR: 425/9410). Silent: doesn't break DAG/support-order
+    // (openings rarely collide with anything), just inflates phase/zone element+crew-time counts and
+    // breaks the "movie-coherent, can never tell a different story" guarantee those functions claim.
     var r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.element_name,''), COALESCE(m.storey,'_UNKNOWN'), " +
       "COALESCE(t.center_x,0), COALESCE(t.center_y,0), COALESCE(t.center_z,0), " +
       "COALESCE(t.bbox_x,0), COALESCE(t.bbox_y,0), COALESCE(t.bbox_z,0) " +
-      "FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid");
+      "FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid " +
+      "WHERE m.ifc_class != 'IfcOpeningElement'");
     if (!r.length || !r[0].values.length) return [];
 
     var storeyZs = {};

--- a/witness_support_invariant_all_buildings.js
+++ b/witness_support_invariant_all_buildings.js
@@ -1,0 +1,76 @@
+// witness_support_invariant_all_buildings.js — "generic killer for any IFC" claim, first principles:
+// nothing appears without support (schedule_gate.js §4D_ROOF_LOAD_PATH / auditFloating header:
+// "0 ⇒ nothing floats over its physical support. Works for any class").
+//
+// This invariant was already proven 0 on Hospital + LTU_AHouse via a full-pipeline Puppeteer bake
+// (witness_4d_roof_load_path.js G-RLP-6). This witness extends the SAME check — same engine call
+// (ScheduleGate.computeSchedule + auditFloating), same SEQUENCE_RULES, zero per-building code — to
+// every large building fixture available, the fast Node path witness_zone_cpm.js already uses
+// (no browser/bake needed for this particular claim: auditFloating only needs geometry + the
+// computed schedule, both available directly from the extracted DB).
+//
+// A generic engine claim can't rest on 2 buildings out of 6 available. Fixtures run here:
+// Terminal, Hospital, Clinic, JKR, HHS_Office_Federated, LTU_AHouse (Duplex excluded — user ruling
+// 2026-08-04: "DX too small for our engine", small/residential buildings are a different regime,
+// see witness_zone_cpm_duplex.js instead).
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, 'viewer');
+var BUILDINGS_DIR = '/home/red1/bim-ootb/buildings';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+var ScheduleGate = require(path.join(VIEWER, 'schedule_gate.js'));
+
+var BUILDINGS = ['Terminal', 'Hospital', 'Clinic', 'JKR', 'HHS_Office_Federated', 'LTU_AHouse'];
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-SUPPORT-ALL PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-SUPPORT-ALL FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  var rules = loadRules();   // ONE rules module, reused verbatim for every building — no per-building tuning
+  var maxCrews = {};
+  for (var res in rules.LABOR_RATES) if (rules.LABOR_RATES[res].max_crews) maxCrews[res] = rules.LABOR_RATES[res].max_crews;
+
+  BUILDINGS.forEach(function (name) {
+    var dbPath = path.join(BUILDINGS_DIR, name + '_extracted.db');
+    if (!fs.existsSync(dbPath)) { check(name + '-fixture-exists', false, dbPath + ' missing'); return; }
+    var db = new SQL.Database(fs.readFileSync(dbPath));
+    var elCount = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+
+    var elements = ScheduleAuthor._buildScheduleElements(db, rules.SEQUENCE_RULES, {
+      laborRates: rules.LABOR_RATES, rates: rules.RATES
+    });
+    check(name + '-elements-extracted', elements.length > 0, 'elements=' + elements.length + '/' + elCount);
+    if (!elements.length) return;
+
+    var schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews);
+    var placed = Object.keys(schedule).length;
+    check(name + '-nothing-dropped', placed === elements.length,
+      'placed=' + placed + ' elements=' + elements.length);
+
+    // THE claim: 0 ⇒ nothing floats over its physical support. No classFilter (null) — audits every
+    // class against every candidate support, exactly as auditFloating's own header describes.
+    var floating = ScheduleGate.auditFloating(elements, schedule, null);
+    check(name + '-nothing-appears-without-support', floating === 0,
+      'floating=' + floating + '/' + elements.length);
+
+    console.log('§W-SUPPORT-ALL ' + name + ' elements=' + elements.length + ' placed=' + placed + ' floating=' + floating);
+  });
+
+  console.log('§W-SUPPORT-ALL SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});

--- a/witness_zone_cpm_duplex.js
+++ b/witness_zone_cpm_duplex.js
@@ -1,0 +1,83 @@
+// witness_zone_cpm_duplex.js — 4D_SCHEDULE_PERFECTION.md gap #2 (multi-building validation).
+// witness_zone_cpm.js proved materializeZones/computeCpm(fixedDates) on Terminal (48,428 elements,
+// 22 real floor-ranks) and Hospital (63,415 elements) — both large. Neither is a SMALL building.
+// Per WalkerDoctrine.md, SH/DX/SC-class buildings are a genuinely different regime. This runs the
+// SAME proof shape against Duplex_extracted.db (1,193 elements, 5 storeys — the standing small-
+// building fixture this project already uses everywhere else) on a SCRATCH COPY (never mutates the
+// shared ~/bim-ootb/buildings/ fixture — CLAUDE.md worktree-hygiene rule).
+// Unlike witness_zone_cpm.js, the zone-count bound here is NOT the large-building 15-200 P6-realistic
+// range — a small building legitimately produces far fewer zones. The real claims under test:
+// zone count is sane (not 1, not the full 1,193-element count), edges form a DAG, and
+// computeCpm(fixedDates:true) still EXACTLY matches the real movie total — the same coherence
+// guarantee, on a structurally different (few-storey, few-element) building.
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = path.join(__dirname, 'viewer');
+var DB_PATH = '/tmp/claude-1000/-home-red1-bim-compiler/6ecb6170-ccda-494f-9a59-8acfc118b0f4/scratchpad/Duplex_extracted_witness.db';
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+var ScheduleGate = require(path.join(VIEWER, 'schedule_gate.js'));
+
+var pass = 0, fail = 0;
+function check(name, cond, detail) {
+  if (cond) { pass++; console.log('§W-ZONE-DX PASS  ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('§W-ZONE-DX FAIL  ' + name + (detail ? '  ' + detail : '')); }
+}
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  var rules = loadRules();
+  var db = new SQL.Database(fs.readFileSync(DB_PATH));
+
+  var elCount = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+  var storeys = db.exec("SELECT DISTINCT storey FROM elements_meta WHERE storey NOT LIKE 'Unknown'")[0].values.map(function (r) { return r[0]; });
+  console.log('§W-ZONE-DX FIXTURE elements=' + elCount + ' storeys=' + storeys.length + ' [' + storeys.join(',') + ']');
+
+  var res = ScheduleAuthor.materializeZones(db, rules.SEQUENCE_RULES, {
+    start: '2026-01-01', laborRates: rules.LABOR_RATES, rates: rules.RATES, scheduleGate: ScheduleGate
+  });
+  check('materializeZones-ok', res.ok === true, JSON.stringify(res));
+  // Small-building bound: sane means more than a single monolithic zone, and nowhere near a
+  // per-element (1,193) blowup — NOT the large-building 15-200 P6-realistic range.
+  check('zone-count-sane-for-small-building', res.zoneCount > 1 && res.zoneCount < elCount,
+    'zones=' + res.zoneCount + ' elements=' + elCount);
+  console.log('§W-ZONE-DX zones=' + res.zoneCount + ' edges=' + res.edgeCount + ' totalDays=' + res.totalDays);
+
+  var zr = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED' AND (is_summary IS NULL OR is_summary=0)");
+  check('tasks-persisted', zr[0].values[0][0] === res.zoneCount, 'persisted=' + zr[0].values[0][0]);
+
+  var er = db.exec('SELECT COUNT(*) FROM task_sequences');
+  check('edges-persisted', er[0].values[0][0] === res.edgeCount, 'persisted=' + er[0].values[0][0]);
+
+  // fixedDates:true must reproduce the real movie's total EXACTLY — same coherence guarantee proven
+  // on Terminal/Hospital, now checked on a structurally different (few-storey) building.
+  var cpm = ScheduleAuthor.computeCpm(db, 'SCH_AUTHORED', { start: '2026-01-01', fixedDates: true });
+  check('cpm-fixed-no-error', !cpm.error, JSON.stringify(cpm.error || null));
+  check('cpm-fixed-matches-real-movie-exactly', cpm.projectDuration === res.totalDays,
+    'cpm(fixedDates)=' + cpm.projectDuration + ' real-movie-totalDays=' + res.totalDays);
+  console.log('§W-ZONE-DX FIXED cpm-projectDuration=' + cpm.projectDuration + ' real-movie-totalDays=' + res.totalDays);
+
+  // DAG check: computeCpm itself bails with error:'cycle' if the topo sort can't consume every
+  // task — reuse that as the DAG proof rather than re-implementing cycle detection here.
+  check('edges-form-a-dag', cpm.error !== 'cycle', 'error=' + (cpm.error || null));
+
+  check('cpm-has-critical-path', (cpm.criticalIds || []).length > 0, 'critical=' + (cpm.criticalIds || []).length);
+
+  var badWindow = 0;
+  var tr = db.exec("SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND (is_summary IS NULL OR is_summary=0)");
+  tr[0].values.forEach(function (row) { if (!row[1] || !row[2] || row[2] < row[1]) badWindow++; });
+  check('all-zones-have-valid-window', badWindow === 0, 'invalid=' + badWindow);
+
+  console.log('§W-ZONE-DX SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});


### PR DESCRIPTION
## Summary
- **Real bug found & fixed**: `schedule_author.js`'s `_buildScheduleElements` claimed to replicate `time_machine.js`'s live-movie element set "EXACTLY" but never applied its `ifc_class != 'IfcOpeningElement'` filter. Wall/window voids were being scheduled as physical installable work — up to 4.5% of a real building's elements (JKR: 425/9410) — inflating generated-schedule durations/crew-time and breaking the "movie-coherent, can never tell a different story" guarantee `materializeZones`/`materializeDefault` claim.
- `witness_support_invariant_all_buildings.js`: extends the "nothing appears without support" proof (previously only Hospital+LTU_AHouse, via a slow full-pipeline Puppeteer bake) to all 6 large building fixtures via the fast Node path already used by `witness_zone_cpm.js`. 18/18 pass, 0 floating across 272k+ elements, one shared ruleset — no per-building tuning.
- `witness_zone_cpm_duplex.js`: validates `materializeZones`/`computeCpm(fixedDates:true)` degrade gracefully on a small building (Duplex, 1,193 elements, 4 storeys) — 9/9 pass.

## Test plan
- [x] `node witness_support_invariant_all_buildings.js` — 18/18 pass, 0 floating on Terminal/Hospital/Clinic/JKR/HHS_Office_Federated/LTU_AHouse
- [x] `node witness_zone_cpm.js` (Terminal, regression) — 11/11 pass, unchanged (Terminal has 0 openings)
- [x] `node witness_zone_cpm_duplex.js` — 9/9 pass
- [x] `node witness_tm_duration_sync.js` — 8/8 pass (unaffected, sanity check)
- [x] `node erp/tests/schedule_diff_witness.js` — 11/11 pass (unaffected, sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141qDMu7p22poyXrrHYjrHf