### PR TITLE
fix(4d): scope PHASE_OVERLAP_SUPPORT_GUARD wall-carrier check (3rd of 4 duplicate support-check copies)

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4002,9 +4002,17 @@
       // carries (the support DAG's own topological potential, established by §STAGGER_SUPPORT_ORDER
       // above), so every true carrier of T has already been visited — and any correction already
       // applied to it — by the time T is processed.
+      // §XRAY_WALL_SCOPE (found 2026-08-04, live in a real Hospital session — user report: proxy/
+      // misc elements chronologically before columns, "2 trucks came on first! Then walls!"): this
+      // predicate was even more permissive than the two sibling copies already fixed this session
+      // (schedule_gate.js auditFloating(), time_machine.js _buildXraySupportCache) — ANY wall was a
+      // candidate carrier for ANY element, no promoted-roof-slab restriction at all. A wall is only
+      // ever a real candidate carrier for a slab itself promoted to the roof role (seq>4) — same
+      // §4D_ROOF_LOAD_PATH M3 restriction, applied here for the third time this session. Structure
+      // (seq<=4) stays an unconditional carrier candidate for everything — only the wall branch is
+      // now gated on the TARGET being a promoted slab.
       var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
       var _ogEPS = 0.05, _ogGAP = 0.5;
-      var _ogIsCarrier = function (e) { return e.seq <= 4 || e.cls.indexOf('IfcWall') === 0; };
       var _ogCells = function (e) {
         var out = [];
         for (var cx = Math.floor(e.x0 / _ogCELL); cx <= Math.floor(e.x1 / _ogCELL); cx++)
@@ -4012,18 +4020,29 @@
         return out;
       };
       var _ogXY = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
-      var _ogGrid = {};
-      _allScheduled.forEach(function (e) { if (_ogIsCarrier(e)) _ogCells(e).forEach(function (c) { (_ogGrid[c] = _ogGrid[c] || []).push(e); }); });
+      var _ogStructGrid = {}, _ogWallGrid = {};
+      _allScheduled.forEach(function (e) {
+        if (e.seq <= 4) _ogCells(e).forEach(function (c) { (_ogStructGrid[c] = _ogStructGrid[c] || []).push(e); });
+        else if (e.cls.indexOf('IfcWall') === 0) _ogCells(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
+      });
       _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
       var _ogPushed = 0;
       _allScheduled.forEach(function (T) {
+        var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
         var cells = _ogCells(T), seen = {}, lastEnd = 0;
         for (var ci = 0; ci < cells.length; ci++) {
-          var arr = _ogGrid[cells[ci]]; if (!arr) continue;
-          for (var si = 0; si < arr.length; si++) {
+          var arr = _ogStructGrid[cells[ci]];
+          if (arr) for (var si = 0; si < arr.length; si++) {
             var S = arr[si];
             if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
             if (S.bz < T.bz - _ogEPS && Math.abs(S.tz - T.bz) <= _ogGAP && _ogXY(S, T) && S.e > lastEnd) lastEnd = S.e;
+          }
+          if (!promotedSlab) continue;
+          arr = _ogWallGrid[cells[ci]];
+          if (arr) for (var wi = 0; wi < arr.length; wi++) {
+            var W = arr[wi];
+            if (W.guid === T.guid || seen[W.guid]) continue; seen[W.guid] = 1;
+            if (W.bz < T.bz - _ogEPS && Math.abs(W.tz - T.bz) <= _ogGAP && _ogXY(W, T) && W.e > lastEnd) lastEnd = W.e;
           }
         }
         if (lastEnd && T.s < lastEnd) {


### PR DESCRIPTION
## What
A third independent copy of "wall as false physical support" (same class of bug fixed twice already: `auditFloating` M3, this session's `_buildXraySupportCache` fix). `_ogIsCarrier` in `time_machine.js`'s `PHASE_OVERLAP_SUPPORT_GUARD` treated ANY wall as a candidate support for ANY element — no promoted-roof-slab restriction. Live symptom on Hospital: proxy/misc elements chronologically before columns.

## Measured (Node script vs real Hospital data, not a guess)
- Old predicate: 1,049 elements pushed later citing a wall as support — **1,047 were false positives**.
- New predicate (wall only counts when the target is a promoted roof slab): **0 pushed, 0 false positives**.

## Root cause, named for the record
At least 4 independent copies of "what counts as physical support" exist in this codebase (`schedule_gate.js auditFloating`, `time_machine.js _buildXraySupportCache`, this `PHASE_OVERLAP_SUPPORT_GUARD`, and `boq_charts.html`'s fully separate scheduler) — they drifted apart because none share code. This closes the third. The fourth (`boq_charts.html`, the "4" button) is still open.

## Verified
- `node --check` clean
- `witness_support_invariant_all_buildings.js` 18/18
- `witness_zone_cpm.js` 11/11
- `witness_zstack_xray_staging.js` (Hospital) — real=0, green=0, synthetic positive-control fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141qDMu7p22poyXrrHYjrHf