### PR TITLE
perf(4d): time the write loop behind the reported Apply-to-4D freeze

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4055,6 +4055,10 @@
       if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +
         ' elements later than their §PHASE_OVERLAP_BAND window to stay after their real structural support');
 
+      // §WRITE_LOOP_TIMING (2026-08-04) — a user report of the browser tab freezing traced to
+      // console output stopping right at this point, on a 63,415-element building. No fix here —
+      // just precise measurement, so the NEXT report says a real number instead of "it stopped".
+      var _wlT0 = performance.now();
       _allScheduled.forEach(function (item) {
         item.params._end_ts = item.e;
         item.params._captured = 1;
@@ -4062,6 +4066,7 @@
         _upd.run([item.s, JSON.stringify(item.params), item.guid]);
       });
       _upd.free();
+      console.log('§WRITE_LOOP_TIMING rows=' + _allScheduled.length + ' ms=' + (performance.now() - _wlT0).toFixed(1));
       db.run('COMMIT');
       _capActive = true;
       _coveredCount = _covered;


### PR DESCRIPTION
## What
Pure timing instrumentation around the write loop right after `PHASE_OVERLAP_SUPPORT_GUARD` — no logic change. User reported the browser tab freezing during "Apply to 4D" on Hospital (63,415 elements); the live console log cut off immediately after the guard's log line, right before this loop.

Confirmed `kernel_ops.output_guid` IS indexed (`idx_kernel_ops_guid`) — ruling out an O(n²) table-scan as the cause. Likely just raw per-row cost at 63k scale, but I can't measure it precisely without a browser. This logs the real millisecond number next time it runs.

Traced the loop itself to PR #1154 (2026-08-03, `d35366a`) — predates this session, not something introduced by today's fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141qDMu7p22poyXrrHYjrHf