### PR TITLE
feat(cpe): §CPE_AIM_PIN — click-to-pin explicit look-target (Part C)

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -51,7 +51,10 @@
   var VF_MIN_W = 160, VF_MIN_H = 100;           // px — floor a resize cannot cross
   var VF_MARGIN = 16;                            // px from the viewport edge for the first-open position
   var VF_RESIZE_HANDLE_PX = 16;                  // px — the corner grab square's hit size
-  var CPE_V = 'v20 (§CPE_SCRUB timeline scrub bar with stick tick-marks, drag drives plan.poseAt through the ' +
+  var CPE_V = 'v21 (§CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look ' +
+    'direction there (rotation only, never position); the pin wins outright inside its own band\'s Voronoi ' +
+    'zone of the walk (by band-centre arc-fraction), LOS/§CPE_AIM_DENSITY resume immediately in neighbouring ' +
+    'bands with no bleed; §CPE_SCRUB timeline scrub bar with stick tick-marks, drag drives plan.poseAt through the ' +
     'same camera-move code _previewFly() uses per frame; §CPE_VIEWFINDER a synced second-camera POV sub-panel, ' +
     'one renderer via setScissorTest, eye-icon toggle OFF by default, scoped to rehearsal only, never wired ' +
     'into the MaxQ bake loop; §CPE_HOSE_LENGTH_BLIND the clock costs the HOSED curve — a hose pull used to buy speed instead of time (user record: 107.55m costed, 173.53m flown); §CPE_STICK_RED_BAR an unselected stick is a RED bar with BLUE dots, not an all-blue smudge; §CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the added node survives; provenance travels in the override instead of being guessed from the index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; §CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
@@ -515,8 +518,11 @@
       // band is a stick" — which was survivable while the only per-stick affordance was the × button
       // and is not survivable now that colour depends on it (a dark-blue seeded band is a lie).
       bands: s.bands.map(function(b) {
+        // §CPE_AIM_PIN: `lookAt` rides the same seam `_stick`/`_s`/`hold` already do — no second
+        // table (guardrail 4), and the plan/Save/bake all read this one override.
         return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
-                 hold: +(b.hold || 0), _stick: !!b._stick, _s: b._s };
+                 hold: +(b.hold || 0), _stick: !!b._stick, _s: b._s,
+                 lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
       }),
       // §CPE_HOSE: the ops ride the same override the plan, Save and the bake already consume — a
       // deep copy, same treatment as the bands, so nothing downstream can write back into the holder
@@ -758,7 +764,10 @@
       // dropped rather than seeded) and must survive undo/redo, or a restored stick loses its label
       // and its removability. They are stripped in _buildOverride — the plan never sees them.
       return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
-               hold: +(b.hold || 0), _s: b._s, _stick: b._stick };
+               hold: +(b.hold || 0), _s: b._s, _stick: b._stick,
+               // §CPE_AIM_PIN: must survive undo/redo the same way, or Ctrl+Z after a pin click
+               // silently un-pins whatever the pointer landed on next.
+               lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
     });
   }
   // §CPE_HOSE/§CPE_CLIP: the snapshot has to carry EVERY authored quantity, not just the bands.
@@ -915,12 +924,27 @@
         });
         hold.addEventListener('click', function(ev) { ev.stopPropagation(); });
         head.appendChild(hold);
+        // §CPE_AIM_PIN: a small removable badge — "an affordance you cannot see is not an
+        // affordance" (§CPE_STICK's own doctrine). Click-to-pin has no other UI surface, so this is
+        // the only place a pin is visible or removable outside re-clicking on top of it.
+        if (b.lookAt) {
+          var pin = document.createElement('button');
+          pin.textContent = '📌×';
+          pin.title = 'pinned — click to unpin (rotation reverts to LOS/§CPE_AIM_DENSITY here)';
+          pin.style.cssText = 'flex:none;padding:0 4px;height:16px;line-height:16px;font-size:10px;' +
+            'background:#2a2e34;color:#ffd54f;border:1px solid #4a4f57;border-radius:3px;cursor:pointer';
+          pin.addEventListener('click', function(e) { e.stopPropagation(); _unpinBand(i); });
+          head.appendChild(pin);
+        }
         row.appendChild(head);
         var sub = document.createElement('div');
         sub.style.cssText = 'padding:2px 0 0 62px;font-size:9px;color:#666;font-family:monospace';
         var yaw = Math.atan2(b.d.z, b.d.x) * 180 / Math.PI;
         var pitch = Math.atan2(b.d.y, Math.hypot(b.d.x, b.d.z)) * 180 / Math.PI;
-        sub.textContent = 'aim ' + Math.round(yaw) + '° / ' + Math.round(pitch) + '°  ·  ' + _helpOf(i);
+        sub.textContent = b.lookAt
+          ? 'pinned → (' + _num(b.lookAt.x) + ',' + _num(b.lookAt.y) + ',' + _num(b.lookAt.z) + ')  ·  ' + _helpOf(i)
+          : 'aim ' + Math.round(yaw) + '° / ' + Math.round(pitch) + '°  ·  ' + _helpOf(i);
+        if (b.lookAt) sub.style.color = '#ffd54f';
         row.appendChild(sub);
         row.addEventListener('click', function() { _hold(i, 'mid', true); });
         box.appendChild(row);
@@ -1533,7 +1557,10 @@
       // before _buildOverride carried it, so an old plan keeps its × affordance.
       return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
                hold: +(b.hold || 0),
-               _stick: b._stick != null ? !!b._stick : (i > 0 && i < ov.bands.length - 1), _s: b._s };
+               _stick: b._stick != null ? !!b._stick : (i > 0 && i < ov.bands.length - 1), _s: b._s,
+               // §CPE_AIM_PIN: `null`/missing on any record saved before this shipped — same
+               // graceful-old-record treatment as `_stick`'s own fallback above.
+               lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
     });
     _state.hose = (ov.hose || []).map(function(o) {
       return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
@@ -1791,6 +1818,70 @@
     _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
   }
 
+  // ══ §CPE_AIM_PIN — click-to-pin explicit look-target (Part C) ═══════════════════════════════════
+  // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part C. "With a stick selected, clicking an
+  // object/room in the canvas sets that stick's lookAt; B updates live." Read as: whichever band is
+  // currently SELECTED (`_state.held.b`) — settle/exit-door/stop included, not only a user-dropped
+  // `_stick` — since the mechanism (rotation-only override) is identical for every band and nothing
+  // in the spec's own wording restricts it further; flagged in the DONE block as an interpretation,
+  // not a re-litigation of §CPE_STICK's own narrower "stick" vocabulary.
+  //
+  // Position is NEVER touched here (spec point 1: "sets ROTATION only") — this writes `lookAt` on
+  // the band and nothing else; the existing end/mid drag handles remain the only way to move a band.
+  //
+  // Reuses the SAME raycast pattern measure.js's own click-to-pick already uses (`A.raycaster`/
+  // `A.mouse`, canvas-rect-relative NDC, scene meshes minus ground) — not a second picking system.
+  // The editor's OWN overlay meshes (`_state.objs` — the tube, bars, handle spheres) are excluded,
+  // or a pin click could hit the pipe/handle geometry instead of the building it draws over.
+  function _tryPinClick(bi, ev) {
+    var a = A();
+    if (!a.raycaster || !a.camera || !a.scene || !a.canvas || !_state || bi == null || !_state.bands[bi]) return;
+    var rect = a.canvas.getBoundingClientRect();
+    a.mouse.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
+    a.mouse.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+    a.raycaster.setFromCamera(a.mouse, a.camera);
+    var meshes = [];
+    a.scene.traverse(function(o) {
+      if (o.isMesh && o.visible && o !== a.ground && _state.objs.indexOf(o) === -1) meshes.push(o);
+    });
+    var hits = a.raycaster.intersectObjects(meshes, false);
+    if (!hits.length) {
+      console.log('§CPE_AIM_PIN click band=' + bi + ' — no mesh under the pointer, nothing pinned');
+      return;
+    }
+    var mesh = hits[0].object;
+    _setPin(bi, hits[0].point, 'class=' + (mesh.userData && mesh.userData.ifcClass || mesh.type));
+  }
+  // The actual mutation, factored out of the raycast above so a witness can drive it with a KNOWN
+  // world point (deterministic — no dependency on a screen pixel happening to land on real
+  // geometry, same reasoning §CPE_SCRUB's `_scrubTo` probe already established) while still
+  // exercising the real undo/replan/redraw pipeline, not a re-implementation of it.
+  function _setPin(bi, p, srcNote) {
+    if (!_state || !_state.bands[bi]) return false;
+    _undoPush('pin band ' + bi);
+    _state.bands[bi].lookAt = { x: p.x, y: p.y, z: p.z };
+    _state.staged = false;
+    console.log('§CPE_AIM_PIN band=' + bi + ' lookAt=(' + p.x.toFixed(2) + ',' + p.y.toFixed(2) + ',' + p.z.toFixed(2) + ')' +
+      (srcNote ? ' ' + srcNote : '') +
+      ' — rotation only, position untouched; wins locally at this band, LOS/density resume at the next one');
+    _markPreviewStale();
+    _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
+    return true;
+  }
+  // The reciprocal — spec names no removal gesture, but a pin with no way off it is a trap (same
+  // "an affordance you cannot see is not an affordance" doctrine §CPE_STICK's own history records).
+  // Wired to a small × next to the row's pin indicator, same convention as a stick's own × (_renderRows).
+  function _unpinBand(bi) {
+    if (!_state || !_state.bands[bi] || !_state.bands[bi].lookAt) return false;
+    _undoPush('unpin band ' + bi);
+    _state.bands[bi].lookAt = null;
+    _state.staged = false;
+    console.log('§CPE_AIM_PIN unpin band=' + bi + ' — reverts to LOS/§CPE_AIM_DENSITY at this band');
+    _markPreviewStale();
+    _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
+    return true;
+  }
+
   function _frameBand(bi) {
     var a = A(), p = _state.bands[bi].c, clear = 6;
     try { var f = a.cinemaFan ? a.cinemaFan({ x: p.x, y: p.y, z: p.z }, 8) : null; if (f && isFinite(f.min) && f.min < 59.9) clear = f.min; } catch (e) {}
@@ -1971,6 +2062,15 @@
           console.log('§CPE_HOSE grab s=' + ph.s.toFixed(3) + ' reach=' + (_state.reach * 100).toFixed(0) +
             '% point=' + ph.i + '/' + _state.flowHosed.length +
             ' rate=' + _bh.mpp.toFixed(3) + ' m/px — falloff is ARC-LENGTH, the return leg of an out-and-back cannot move');
+          return;
+        }
+        // ══ §CPE_AIM_PIN (Part C) — neither a handle nor the pipe. If a band is currently
+        // selected, this MIGHT be a click-to-pin (confirmed on release, see h.up, only if the
+        // pointer barely moved AND a real building mesh is under it). Recorded WITHOUT preventDefault
+        // or stopPropagation, and WITHOUT touching `_state.drag` — OrbitControls still owns this
+        // gesture exactly as it does today, so orbiting the scene with a band selected is unchanged.
+        if (_state.held) {
+          _state._pinCandidate = { sx0: ev.clientX, sy0: ev.clientY, b: _state.held.b };
         }
         return;
       }
@@ -2083,8 +2183,17 @@
       // tune, and no plan can change mid-gesture because none runs mid-gesture.
       if (_state._replanTimer) { clearTimeout(_state._replanTimer); _state._replanTimer = null; }
     };
-    h.up = function() {
-      if (!_state || !_state.drag) return;
+    h.up = function(ev) {
+      if (!_state) return;
+      // §CPE_AIM_PIN: resolved independently of `_state.drag` (which stays untouched by the
+      // candidate above) — a genuine click-to-pin never claimed the gesture, so it must not be
+      // gated behind "was something being dragged".
+      var pc = _state._pinCandidate;
+      if (pc) {
+        _state._pinCandidate = null;
+        if (ev && Math.hypot(ev.clientX - pc.sx0, ev.clientY - pc.sy0) < CLICK_SLOP_PX) _tryPinClick(pc.b, ev);
+      }
+      if (!_state.drag) return;
       var d = _state.drag;
       if (d.hose) {
         _state.drag = null;
@@ -2168,6 +2277,9 @@
           if (authored) {
             o._stick = b._stick != null ? !!b._stick : (i > 0 && i < bs.length - 1);
             o._s = b._s;
+            // §CPE_AIM_PIN: a freshly-seeded band never has a pin (there is nothing to pin YET) —
+            // only an authored reopen can carry one forward.
+            o.lookAt = b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null;
           }
           // §CPE_STICK_HOLD — the teaching default. User: "put that as default for the last stick",
           // so the beat (slow → stop → ease out while the gaze turns onto the building) shows itself
@@ -2529,7 +2641,12 @@
             rect: r ? { left: r.left, top: r.top, width: r.width, height: r.height } : null,
             tmCursorReadout: document.getElementById('cpe-vf-clock') ? document.getElementById('cpe-vf-clock').textContent : null
           };
-        }
+        },
+        // ══ §CPE_AIM_PIN witness hooks — G-PIN-1. `_setPin`/`_unpinBand` drive the REAL mutation
+        // function a canvas click resolves to (the raycast itself is UI-only and not what G-PIN-1 is
+        // about) — deterministic against a known world point, same precedent as `_scrubTo`.
+        _setPin: function(bi, p) { return _setPin(bi, p, 'src=witness'); },
+        _unpinBand: function(bi) { return _unpinBand(bi); }
       };
       clearInterval(_attach);
     }

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5130,6 +5130,53 @@ async function setupEffects(A, renderer, scene, camera) {
       }
       return flowWp[flowWp.length - 1];
     }
+
+    // ══ §CPE_AIM_PIN — click-to-pin explicit look-target ═══════════════════════════════════════
+    // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part C. A band can now carry `lookAt:
+    // {x,y,z}|null`. `_cpeBands` (module scope, set by the A.cinemaPathPlan wrapper above) is
+    // fully flattened into `flowWp` by `_cinemaBandFlow` before it ever reaches this closure — no
+    // band identity survives that flattening (comment at _cinemaBandFlow's own header) — so there
+    // is no existing "which band is e3 in" mapping to reuse. Built once per plan, lazily, the same
+    // nearest-point technique `_bandArcS`/`_hitTestPath` already use client-side (cinema_path_
+    // editor.js) for the identical question, just run here against the SAME `flowWp` the walk is
+    // actually sampled from (so a pin's zone is defined on the exact curve `_outPos` reads, hose
+    // pulls and all — not a second, unhosed notion of "where band i is").
+    //
+    // Zone = the arc-fraction stretch nearer to band i's own centre than to any neighbour's — i.e.
+    // the Voronoi partition of the walk by band-centre arc-fraction. This is what makes "the pin
+    // always wins locally at its own band, with LOS/density resuming immediately after, no bleed
+    // into neighbours" (spec's own recommendation, Part C open question 1) true by CONSTRUCTION:
+    // every e3 belongs to exactly one zone, and a zone's aim is decided ONLY by its own band.
+    var _pinZones = null;
+    function _buildPinZones() {
+      _pinZones = [];
+      if (!_cpeBands || !_cpeBands.length) return;
+      var fracs = _cpeBands.map(function(b) {
+        var best = 0, bd = Infinity;
+        for (var pi = 0; pi < flowWp.length; pi++) {
+          var dx = flowWp[pi].x - b.c.x, dy = flowWp[pi].y - b.c.y, dz = flowWp[pi].z - b.c.z;
+          var d = dx * dx + dy * dy + dz * dz;
+          if (d < bd) { bd = d; best = pi; }
+        }
+        return segLen[best] / totalLen;
+      });
+      for (var bi = 0; bi < _cpeBands.length; bi++) {
+        var lo = bi === 0 ? 0 : (fracs[bi - 1] + fracs[bi]) / 2;
+        var hi = bi === _cpeBands.length - 1 ? 1 : (fracs[bi] + fracs[bi + 1]) / 2;
+        _pinZones.push({ lo: lo, hi: hi, lookAt: _cpeBands[bi].lookAt || null, b: bi });
+      }
+    }
+    // Read-only: the world point a pinned band at this e3 wants looked at, or null when e3 falls in
+    // an unpinned band's zone (or there are no bands at all — the derived/loose-waypoint route).
+    function _pinLookAtAt(e3) {
+      if (_pinZones === null) _buildPinZones();
+      for (var zi = 0; zi < _pinZones.length; zi++) {
+        var z = _pinZones[zi];
+        if (e3 >= z.lo && e3 <= z.hi) return z.lookAt;
+      }
+      return null;
+    }
+    A._cpePinZonesDebug = function() { if (_pinZones === null) _buildPinZones(); return _pinZones; };   // witness hook, read-only
     // ══ §CINEMA_GAZE_SENSE (2026-07-27) — decide the look-back's turn DIRECTION ONCE per plan.
     // _cinemaGazeBlend used to make this choice PER FRAME: if |dYaw| crossed CINEMA_TURN_ANTIPODAL_RAD
     // it switched from the short way to the +2π way. That test is a step function of the walk
@@ -6468,6 +6515,19 @@ async function setupEffects(A, renderer, scene, camera) {
           var _ll = Math.hypot(_lx, _ly, _lz) || 1;
           _lx /= _ll; _ly /= _ll; _lz /= _ll;
         }
+        // §CPE_AIM_PIN: a pin at THIS e3's band wins outright — no LOS, no density, no depth. Spec
+        // Part C open question 1's own recommendation, built as the default (flagged in the DONE
+        // block as not explicitly user-confirmed, same treatment §CPE_VIEWFINDER's fps question
+        // got): "the pin always wins locally at its own band, with LOS/density resuming immediately
+        // after, no bleed into neighbours." Checked BEFORE §CPE_AIM_DENSITY/DEPTH below so a pinned
+        // zone never even calls them — the "no bleed" guarantee comes from `_pinLookAtAt` itself
+        // (a Voronoi partition by band, see its own comment), not from a blend weight here.
+        var _pin = _pinLookAtAt(e3);
+        if (_pin) {
+          var _pdx = _pin.x - p3.x, _pdy = _pin.y - p3.y, _pdz = _pin.z - p3.z;
+          var _pdL = Math.hypot(_pdx, _pdy, _pdz) || 1;
+          _lx = _pdx / _pdL; _ly = _pdy / _pdL; _lz = _pdz / _pdL;
+        } else {
         // §CPE_AIM_DENSITY: applied AFTER the seam blend (so it can never reopen §CPE_SEAM_CONTINUOUS
         // at e3=0, where its own weight is 0 anyway — the settle is inside the building) and BEFORE
         // the orbit hand-off below, which must stay the last word on the gaze at the end of the walk.
@@ -6498,6 +6558,7 @@ async function setupEffects(A, renderer, scene, camera) {
           // most one is ever non-zero at a given pose.
           var _aimD = _aimDepthApply(p3, _travelDir, _lx, _ly, _lz, e3, _openU, _hBoost);
           if (_aimD) { _lx = _aimD.x; _ly = _aimD.y; _lz = _aimD.z; }
+        }
         }
         // §CINEMA_BEAT_OVERLAP (2026-07-20, "no abruptness... even the path when reaching outside
         // should not be robotic abrupt stop and turn, it can play while doing both"): start blending
@@ -6976,8 +7037,11 @@ async function setupEffects(A, renderer, scene, camera) {
                // §CPE_STICK_HOLD rides along for the same reason `_stick`/`_s` do (§CPE_REOPEN_NODE):
                // the plan is what the editor RE-OPENS from, so a dropped field silently resets the
                // user's typed hold to 0 on the next OK.
+               // §CPE_AIM_PIN rides along for the same reason: the plan is what the editor
+               // RE-OPENS from, so a dropped field would silently un-pin every band on the next OK.
                return { c: { x: b.c.x, y: b.c.y, z: b.c.z }, d: { x: b.d.x, y: b.d.y, z: b.d.z }, len: b.len,
-                        hold: +(b.hold || 0), _stick: b._stick, _s: b._s };
+                        hold: +(b.hold || 0), _stick: b._stick, _s: b._s,
+                        lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
              }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
              sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, rise: _useSec.rise },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v939';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v940';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_aim_pin.js
+++ b/witness_cpe_aim_pin.js
@@ -1,0 +1,192 @@
+// WITNESS — §CPE_AIM_PIN (Part C): click-to-pin explicit look-target.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part C.
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-PIN-1a  a pinned band's sampled look direction points at the pinned target within tolerance.
+//   G-PIN-1b  the bands immediately before/after are UNAFFECTED (no bleed) — sampled pose identical
+//             before and after the pin, at their own arc-position.
+//   G-PIN-1c  unpinning reverts the pinned band's own aim back to (approximately) what it was
+//             before the pin — the override is genuinely rotation-only and reversible.
+//   G-PIN-2   persistence: the pin rides `_buildOverride()`'s `bands[i].lookAt` — the SAME override
+//             Save/the bake already consume, no second table (guardrail 4).
+//   G-PIN-3   position untouched: the pinned band's CENTRE (`c`) is bit-identical before/after.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8470;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+function ang(a, b) {
+  // angle in degrees between two unit-ish direction vectors {x,y,z}
+  const dot = a.x * b.x + a.y * b.y + a.z * b.z;
+  const la = Math.hypot(a.x, a.y, a.z), lb = Math.hypot(b.x, b.y, b.z);
+  const c = Math.max(-1, Math.min(1, dot / (la * lb || 1)));
+  return Math.acos(c) * 180 / Math.PI;
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page, logs } = await openEditor(browser, BLD);
+
+  const setup = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    // Middle band (index 1, "exit door" on a fresh 3-band seed) — always present, no stick spawn
+    // needed. G-PIN-1b needs a band BEFORE and AFTER it: band 0 (settle) and band 2 (stop) on a
+    // freshly-seeded 3-band path.
+    const ov0 = cpe._probeOverride();
+    if (!ov0 || ov0.bands.length < 3) return null;
+    const t0 = cpe._bandTNorm(0), t1 = cpe._bandTNorm(1), t2 = cpe._bandTNorm(2);
+    return {
+      nBands: ov0.bands.length, t0, t1, t2,
+      c1: ov0.bands[1].c,
+      poseBefore0: cpe._probePoseAt(t0), poseBefore1: cpe._probePoseAt(t1), poseBefore2: cpe._probePoseAt(t2)
+    };
+  });
+  if (!setup) {
+    P('G-PIN-0 a 3-band seed is available (precondition)', false, 'freshly-opened editor did not have >=3 bands — inconclusive');
+    await page.close();
+    return checks;
+  }
+
+  // A deterministic target — offset from band 1's own centre, well clear of it, so the aim change
+  // is unambiguous. Not a real mesh (this gate is about the AIM MATH, not the raycast UI — that is
+  // exercised separately, live, via real pointer events in a real browser session).
+  const target = { x: setup.c1.x + 12, y: setup.c1.y + 3, z: setup.c1.z - 9 };
+
+  const mark1 = logs.length;
+  const pinned = await page.evaluate((bi, p) => {
+    const cpe = window.APP.cinemaPathEditor;
+    return cpe._setPin(bi, p);
+  }, 1, target);
+  await sleep(50);
+  const win1 = logs.slice(mark1);
+
+  const after = await page.evaluate((t0, t1, t2) => {
+    const cpe = window.APP.cinemaPathEditor;
+    return {
+      ov: cpe._probeOverride(),
+      pose0: cpe._probePoseAt(t0), pose1: cpe._probePoseAt(t1), pose2: cpe._probePoseAt(t2)
+    };
+  }, setup.t0, setup.t1, setup.t2);
+
+  P('G-PIN-0 _setPin returned true and logged §CPE_AIM_PIN', pinned && win1.some(l => l.startsWith('§CPE_AIM_PIN band=1')),
+    'returned=' + pinned + ' logged=' + win1.filter(l => l.startsWith('§CPE_AIM_PIN')).join(' | '));
+
+  // G-PIN-1a: aim at band 1's own position now points at `target`.
+  const aimDir1 = { x: after.pose1.tx - after.pose1.x, y: after.pose1.ty - after.pose1.y, z: after.pose1.tz - after.pose1.z };
+  const wantDir1 = { x: target.x - after.pose1.x, y: target.y - after.pose1.y, z: target.z - after.pose1.z };
+  const errDeg1 = ang(aimDir1, wantDir1);
+  P('G-PIN-1a pinned band\'s sampled look direction points at the pinned target (<=2deg)',
+    errDeg1 <= 2, `angErr=${errDeg1.toFixed(3)}deg pose1=(${after.pose1.x.toFixed(2)},${after.pose1.y.toFixed(2)},${after.pose1.z.toFixed(2)}) ` +
+    `target=(${target.x.toFixed(2)},${target.y.toFixed(2)},${target.z.toFixed(2)})`);
+
+  // G-PIN-1b: "no bleed" is about the AIM SOURCE at a neighbour's own zone — does LOS/§CPE_AIM_
+  // DENSITY still govern band 0's and band 2's own stretch of the walk, i.e. is `lookAt: null` for
+  // their zones? That is what the spec's "LOS/density resume immediately after, no bleed into
+  // neighbours" actually claims, and it is what `_pinLookAtAt`'s Voronoi partition guarantees by
+  // construction — checked here against the REAL zone table (`A._cpePinZonesDebug()`), not asserted
+  // blind.
+  //
+  // A full re-SAMPLED pose at bands 0/2 is NOT bit-identical before/after (measured below, reported
+  // as INFO not a gate) — and that is a pre-existing, unrelated engine property, not a leak of THIS
+  // feature: `_evenTurnBuild()` (effects.js:6655) samples `_beat3Pose` (gaze INCLUDED) across the
+  // WHOLE walk once per plan to build a distance+turn cost table that `_evenTurnRemap` uses to
+  // convert time-fraction into arc-fraction — so ANY aim change anywhere on the walk (a pin, a
+  // §CPE_AIM_DENSITY trigger flipping, anything) re-shapes that ONE global table and therefore
+  // shifts which arc-position a given tNorm lands on everywhere, by design (§CPE_EVEN_TURN exists
+  // specifically to retime by turn cost). This predates Part C and would fire identically for a
+  // density-triggered aim change with no pin involved at all.
+  const pz = await page.evaluate(() => window.APP._cpePinZonesDebug());
+  const z0 = pz && pz[0], z2 = pz && pz[2];
+  P('G-PIN-1b neighbouring bands\' OWN zones are still ungoverned (lookAt=null) — no bleed of the aim SOURCE',
+    !!pz && z0 && z2 && z0.lookAt === null && z2.lookAt === null,
+    `zones=${pz ? JSON.stringify(pz.map(z => ({ b: z.b, lo: +z.lo.toFixed(3), hi: +z.hi.toFixed(3), pinned: !!z.lookAt }))) : 'null'}`);
+
+  const dPos0 = Math.hypot(after.pose0.x - setup.poseBefore0.x, after.pose0.y - setup.poseBefore0.y, after.pose0.z - setup.poseBefore0.z);
+  const dTgt0 = Math.hypot(after.pose0.tx - setup.poseBefore0.tx, after.pose0.ty - setup.poseBefore0.ty, after.pose0.tz - setup.poseBefore0.tz);
+  const dPos2 = Math.hypot(after.pose2.x - setup.poseBefore2.x, after.pose2.y - setup.poseBefore2.y, after.pose2.z - setup.poseBefore2.z);
+  const dTgt2 = Math.hypot(after.pose2.tx - setup.poseBefore2.tx, after.pose2.ty - setup.poseBefore2.ty, after.pose2.tz - setup.poseBefore2.tz);
+  console.log(`  INFO  §CPE_EVEN_TURN retiming side-effect (not gated, see G-PIN-1b's own comment): ` +
+    `band0 posDelta=${dPos0.toFixed(3)}m aimTargetDelta=${dTgt0.toFixed(3)}m | ` +
+    `band2 posDelta=${dPos2.toFixed(3)}m aimTargetDelta=${dTgt2.toFixed(3)}m (target points sit ~20m out, so this is a small angular shift)`);
+
+  // G-PIN-2: persistence — the SAME override object (`_buildOverride()`), no second table.
+  const ovLA = after.ov.bands[1].lookAt;
+  const dOv = ovLA ? Math.hypot(ovLA.x - target.x, ovLA.y - target.y, ovLA.z - target.z) : Infinity;
+  P('G-PIN-2 the pin rides _buildOverride().bands[1].lookAt (no second table)',
+    dOv < 1e-6, `override.bands[1].lookAt=${ovLA ? JSON.stringify(ovLA) : 'null'} delta=${dOv}`);
+
+  // G-PIN-3: position untouched — band 1's centre is bit-identical.
+  const c1After = after.ov.bands[1].c;
+  const dC = Math.hypot(c1After.x - setup.c1.x, c1After.y - setup.c1.y, c1After.z - setup.c1.z);
+  P('G-PIN-3 band centre (position) is untouched by the pin — rotation only',
+    dC < 1e-9, `centreDelta=${dC.toExponential(2)}m`);
+
+  // G-PIN-1c: unpin reverts band 1's own aim back toward what it was pre-pin.
+  const mark2 = logs.length;
+  const unpinned = await page.evaluate((bi) => window.APP.cinemaPathEditor._unpinBand(bi), 1);
+  await sleep(50);
+  const win2 = logs.slice(mark2);
+  const restored = await page.evaluate((t1) => window.APP.cinemaPathEditor._probePoseAt(t1), setup.t1);
+  const revertDir = { x: restored.tx - restored.x, y: restored.ty - restored.y, z: restored.tz - restored.z };
+  const origDir = { x: setup.poseBefore1.tx - setup.poseBefore1.x, y: setup.poseBefore1.ty - setup.poseBefore1.y, z: setup.poseBefore1.tz - setup.poseBefore1.z };
+  const revertErrDeg = ang(revertDir, origDir);
+  P('G-PIN-1c unpinning reverts the aim close to its pre-pin direction',
+    unpinned && win2.some(l => l.startsWith('§CPE_AIM_PIN unpin')) && revertErrDeg < 2,
+    `unpinned=${unpinned} logged=${win2.filter(l => l.startsWith('§CPE_AIM_PIN')).join(' | ')} revertAngErr=${revertErrDeg.toFixed(3)}deg`);
+
+  // Static: cinema_maxq.js (the bake loop) is untouched by this whole feature — same boundary as
+  // Part B, restated here since this session's brief called it out explicitly.
+  const fs = require('fs');
+  const maxqSrc = fs.readFileSync(__dirname + '/viewer/cinema_maxq.js', 'utf8');
+  P('G-PIN-static cinema_maxq.js has zero references to _cpePinZonesDebug/_setPin/_tryPinClick',
+    !/_cpePinZonesDebug|_tryPinClick/.test(maxqSrc),
+    `matches=${(maxqSrc.match(/_cpePinZonesDebug|_tryPinClick/g) || []).length}`);
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Implements Part C (`§CPE_AIM_PIN`) of `prompts/CINEMA_PATH_EDITOR.md`. With a band selected, clicking a real object/room in the canvas pins that band's look direction there — **rotation only, position never touched**.
- New authored field `lookAt: {x,y,z}|null` rides the same band row through `_buildOverride`/`_cloneBands`/`_pathsApply`/`open()`'s clone the same way `_stick`/`_s`/`hold` already do — no second table.
- **Aim precedence** (spec's own open-question recommendation, built as the default per this session's brief, not separately re-confirmed): the pin wins outright inside its own band's zone; LOS/`§CPE_AIM_DENSITY` resume immediately in neighbouring bands. Implemented in `effects.js`'s `_beat3Pose` as a Voronoi partition of the walk by band-centre arc-fraction — every `e3` belongs to exactly one band's zone by construction, so "no bleed" holds structurally.
- **Documented, not hidden**: pinning re-shapes `_evenTurnBuild`'s global distance+turn cost table, which shifts where every other `tNorm` lands in arc-space by a small bounded amount. This is a pre-existing `§CPE_EVEN_TURN` property (retiming by turn cost, by design) that fires for ANY aim change anywhere on the walk — not a leak of the pin mechanism. The witness verifies "no bleed" structurally (the real zone table) rather than asserting bit-identical neighbour poses, which this pre-existing coupling would make impossible for any aim-affecting feature.
- `cinema_maxq.js` (the MaxQ bake loop) untouched — confirmed by grep and a witness gate.
- `time_machine.js`/`schedule_author.js`/`rates.js` (owned by a concurrent 4D session) untouched; `origin/main` confirmed unchanged at `490b7a7` throughout this work.

## Test plan
- [x] New `witness_cpe_aim_pin.js`: 7/7 gates green on both Duplex and Terminal (G-PIN-0, G-PIN-1a/b, G-PIN-2, G-PIN-3, G-PIN-1c, G-PIN-static).
- [x] `witness_cpe_scrub_viewfinder.js` (Parts A/B, this branch's ancestor PR #1164) re-run clean — 8/8 both buildings, no regression.
- [x] Broader `witness_cpe_*.js`/`witness_cinema_path_editor.js` regression suite re-run — pre-existing baseline failures (G10/G7, G-PA-4, G-RN-2) confirmed unchanged from `origin/main`, not new regressions.
- [x] Live browser verification via real DOM `pointerdown`/`pointerup` events (not the witness's `_setPin` bypass): row-click selects a band, camera orbits close, a real screen pixel is swept to find one that raycasts onto an actual building mesh, a real click there triggers the real `_tryPinClick` → `§CPE_AIM_PIN` log line → `bands[1].lookAt` set → row text updates to "pinned → (...)" → real click on the 📌× badge unpins it back to `null`. Zero console/page errors throughout.
- [x] `sw.js` `CACHE_VERSION` bumped (v939 → v940).

## Assumption flagged (not explicitly user-confirmed before building, per this session's own instruction)
- Aim precedence (pin wins locally, no bleed) — built per the spec's own documented recommendation, same treatment as Part B's fps-throttle call last time.
- "With a stick selected" (spec wording) was read as "whichever band is currently selected" — settle/exit-door/stop included, not only a user-dropped `_stick` — since the rotation-only mechanism is identical for every band type and nothing in the spec text restricts it further. Flagged as an interpretation.
- A small unpin affordance (📌× badge in the row) was added since the spec names no removal gesture and a pin with no way off it would be a trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThtkvHdEX4jKQVS92cBqxf