### PR TITLE
fix(cpe): §CPE_VIEWFINDER eye toggle shows open/closed state

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -51,7 +51,8 @@
   var VF_MIN_W = 160, VF_MIN_H = 100;           // px — floor a resize cannot cross
   var VF_MARGIN = 16;                            // px from the viewport edge for the first-open position
   var VF_RESIZE_HANDLE_PX = 16;                  // px — the corner grab square's hit size
-  var CPE_V = 'v21 (§CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look ' +
+  var CPE_V = 'v22 (§CPE_VIEWFINDER eye icon now swaps open/slashed with vfOn, reading panels.js ICONS.' +
+    'eyeOpen/eyeOff — not ICONS.eye, which is actually scan-eye; §CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look ' +
     'direction there (rotation only, never position); the pin wins outright inside its own band\'s Voronoi ' +
     'zone of the walk (by band-centre arc-fraction), LOS/§CPE_AIM_DENSITY resume immediately in neighbouring ' +
     'bands with no bleed; §CPE_SCRUB timeline scrub bar with stick tick-marks, drag drives plan.poseAt through the ' +
@@ -655,9 +656,11 @@
         // §CPE_VIEWFINDER launcher (spec Part B point 7, user 2026-08-04 correction: eye icon, not
         // binoculars) — icon-only, OFF by default, so it does not clutter the header. Matches the
         // action-row button convention (~L664-667) at a smaller icon-only footprint.
-        '<button id="cpe-vf-toggle" title="toggle the POV viewfinder (B) — shows the exact camera pose the rehearsal is at" ' +
+        // OFF by default (spec) — the slashed eye is the correct starting icon; _toggleViewfinder
+        // swaps it in place, never rebuilding the button.
+        '<button id="cpe-vf-toggle" title="turn on the POV viewfinder (B) — shows the exact camera pose the rehearsal is at" ' +
           'style="flex:none;padding:3px 8px;font-size:13px;line-height:1;background:#2a2e34;color:#888;' +
-          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer">👁️</button></div>' +
+          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer;display:flex;align-items:center">' + _eyeIconSvg(false) + '</button></div>' +
       '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
       '<div id="cpe-rows" style="padding:4px 0"></div>' +
       // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path controls, one strip.
@@ -1333,10 +1336,29 @@
     var ms = performance.now() - t0;
     _vfPerf.n++; _vfPerf.sum += ms; if (ms > _vfPerf.max) _vfPerf.max = ms;
   }
+  // §CPE_VIEWFINDER on/off icon — open eye = ON/visible, slashed eye = OFF/hidden (user, 2026-08-04:
+  // "find another eye icon that is closed eye to reflect it is OFF"). Reads `panels.js`'s shared
+  // `ICONS` registry (`eyeOpen`/`eyeOff`, added alongside this fix — NOT `ICONS.eye`, which is
+  // actually Lucide's "scan-eye", a different shape, repurposed there for an unrelated Role View
+  // toggle). `ICONS` is a plain top-level `var` in panels.js, so it is a real global by the time this
+  // runs (the editor only opens on Alt+C, long after every script has loaded) — same cross-file
+  // reliance `A.icon()`'s own callers already have, not a new pattern.
+  function _eyeIconSvg(on) {
+    var ic = (typeof ICONS !== 'undefined') && ICONS[on ? 'eyeOpen' : 'eyeOff'];
+    if (!ic) return on ? '👁️' : '🚫';   // ICONS not loaded (§LOAD_FAIL panels.js) — degrade, don't break
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + ic.svg + '</svg>';
+  }
   function _toggleViewfinder(btn) {
     if (!_state) return;
     _state.vfOn = !_state.vfOn;
     var a = A();
+    if (btn) {
+      btn.innerHTML = _eyeIconSvg(_state.vfOn);
+      btn.title = _state.vfOn
+        ? 'turn off the POV viewfinder (B) — shows the exact camera pose the rehearsal is at'
+        : 'turn on the POV viewfinder (B) — shows the exact camera pose the rehearsal is at';
+    }
     if (_state.vfOn) {
       _vfEnsureCam();
       _buildVFPanel();

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -20,6 +20,13 @@ var ICONS = {
   // the Role/Profession view-filter toggle (id:'roleFilter' in _actions). trl/desc updated so a
   // stale X-Ray tooltip can't leak if A.icon('eye',...) is ever called directly.
   eye:       { svg: '<path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><circle cx="12" cy="12" r="1"/><path d="M18.944 12.33a1 1 0 0 0 0-.66 7.5 7.5 0 0 0-13.888 0 1 1 0 0 0 0 .66 7.5 7.5 0 0 0 13.888 0"/>', trl: null, key: 'r', desc: 'Role View' },
+  // §CPE_VIEWFINDER on/off pair (2026-08-04, user: "find another eye icon that is closed eye to
+  // reflect it is OFF") — NOT `eye` above, which is actually Lucide's "scan-eye" (repurposed for
+  // Role View, a different shape). Verified against the real Lucide source (raw.githubusercontent.
+  // com/lucide-icons/lucide/main/icons/) rather than approximated from memory. Open eye = ON/visible,
+  // slashed eye = OFF/hidden — used by cinema_path_editor.js's #cpe-vf-toggle.
+  eyeOpen:   { svg: '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>', trl: null, key: null, desc: 'Viewfinder On' },
+  eyeOff:    { svg: '<path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/><path d="m2 2 20 20"/>', trl: null, key: null, desc: 'Viewfinder Off' },
   clipboard: { svg: '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/>', trl: 'ui_tt_issues', key: 'I', desc: 'Issues' },
   triangle:  { svg: '<path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/>', trl: 'ui_tt_clash', key: null, desc: 'Clash Matrix' },
   plane:     { svg: '<path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z"/>', trl: 'ui_tt_fly', key: 'L', desc: 'Fly Tour' },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v940';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v941';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- Small UI polish on Part B (§CPE_VIEWFINDER). User: "it be nice if we can find another eye icon that is closed eye to reflect it is OFF."
- `#cpe-vf-toggle` used to show a static 👁️ emoji regardless of state. Now swaps between a real Lucide open-eye SVG (ON/visible) and a slashed-eye SVG (OFF/hidden, the default) in place.
- Added `panels.js` `ICONS.eyeOpen`/`ICONS.eyeOff` — verified against the real Lucide source, not reused from the existing `ICONS.eye` entry (which turns out to be Lucide's "scan-eye", a different shape, repurposed there for an unrelated Role View toggle).
- Title text also updates ("turn on"/"turn off the POV viewfinder").

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` re-run clean — 8/8 both buildings.
- [x] `witness_cpe_aim_pin.js` re-run clean — 7/7 both buildings.
- [x] Live-verified via a real Puppeteer session: toggling `window.APP.cinemaPathEditor._vfToggle()` twice produces slashed-eye → open-eye → slashed-eye (byte-identical to initial render), title and accent color changing in lockstep.
- [x] `sw.js` `CACHE_VERSION` bumped (v940 → v941).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThtkvHdEX4jKQVS92cBqxf