### PR TITLE
fix(cpe): §CPE_SCRUB no longer moves the main canvas camera — regression fix

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -329,7 +329,22 @@
     _ggSaved = null;
   }
 
-  var MAXQ_V = 'v22 (§GHOST_GROUND_LIVE_TRIGGER fixes #1148 stuck-at-floor regression — the trigger now compares the REAL cursor to firstAboveMs directly (same clock, epoch ms) instead of pre-converting firstAboveMs into a calendar-fraction and comparing it against tFilm, which §CPE_BUILDUP_WORK_PACED (same day) had turned into an ELEMENTS-placed fraction — two different clocks; adds §GHOST_GROUND_TRIGGER_FIRED (one-shot, exact frame the trigger fires) and §GHOST_GROUND_TICK (periodic, every ~5 film-seconds while still ghosted) so a future session never has to re-instrument this file blind again; §CPE_GHOST_GROUND_TRIGGER history: #1110 first-above-ground-element, #1112 5% above-ground-SHARE ratio, #1148 reverted to #1110 (still broken live until this fix), keeping the #1113-1115 hardening (degrade-not-disable, refusal logging, lazy arm-on-first-tick); §CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; §CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; §CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; §CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; §CPE_CLIP in/out window remaps poseAt + scales frames; §MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; §MAXQ_QUALITY health line)';
+  // Reorganized 2026-08-04 into one clause per line for readability — no §TAG dropped, content
+  // byte-verified against the pre-reorg single-line blob before this landed. Version NOT bumped:
+  // this is a formatting-only change, zero behaviour touched (cinema_maxq.js's bake loop is
+  // deliberately untouched by the whole §CPE_SCRUB/§CPE_VIEWFINDER/§CPE_AIM_PIN lane — see those
+  // features' own witness gates that grep this file for zero references to their hooks).
+  var MAXQ_V = 'v22 (' +
+    '§GHOST_GROUND_LIVE_TRIGGER fixes #1148 stuck-at-floor regression — the trigger now compares the REAL cursor to firstAboveMs directly (same clock, epoch ms) instead of pre-converting firstAboveMs into a calendar-fraction and comparing it against tFilm, which §CPE_BUILDUP_WORK_PACED (same day) had turned into an ELEMENTS-placed fraction — two different clocks; ' +
+    'adds §GHOST_GROUND_TRIGGER_FIRED (one-shot, exact frame the trigger fires) and §GHOST_GROUND_TICK (periodic, every ~5 film-seconds while still ghosted) so a future session never has to re-instrument this file blind again; ' +
+    '§CPE_GHOST_GROUND_TRIGGER history: #1110 first-above-ground-element, #1112 5% above-ground-SHARE ratio, #1148 reverted to #1110 (still broken live until this fix), keeping the #1113-1115 hardening (degrade-not-disable, refusal logging, lazy arm-on-first-tick); ' +
+    '§CPE_BUILDUP_WORK_PACED the film advances by ELEMENTS PLACED, not by calendar days — 10% of the film is 10% of the building on any model; ' +
+    '§CPE_BUILDUP_FOLLOW_TM — the buildup PLAYS the Time Machine timeline, it does not author one; ' +
+    '§CPE_PREVIEW_AFTER_RETIRED — OK records, no rehearsal either side of the editor; ' +
+    '§CPE_PREVIEW_REDUNDANT pre-editor rehearsal removed; ' +
+    '§CPE_CLIP in/out window remaps poseAt + scales frames; ' +
+    '§MAXQ_HIDDEN_PAUSE — a hidden tab parks the bake instead of ruining it; ' +
+    '§MAXQ_QUALITY health line)';
   console.log('§MAXQ_LOADED ' + MAXQ_V);
   var MAXQ_N_FRAMES = 360, MAXQ_FPS = 15;  // 24s clip (360/15) — opts-overridable
   var SETTLE_MS = 250;   // teardown→restage settle. Flicker fix, PoC-proven: without it the next

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -51,14 +51,71 @@
   var VF_MIN_W = 160, VF_MIN_H = 100;           // px — floor a resize cannot cross
   var VF_MARGIN = 16;                            // px from the viewport edge for the first-open position
   var VF_RESIZE_HANDLE_PX = 16;                  // px — the corner grab square's hit size
-  var CPE_V = 'v22 (§CPE_VIEWFINDER eye icon now swaps open/slashed with vfOn, reading panels.js ICONS.' +
-    'eyeOpen/eyeOff — not ICONS.eye, which is actually scan-eye; §CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look ' +
-    'direction there (rotation only, never position); the pin wins outright inside its own band\'s Voronoi ' +
-    'zone of the walk (by band-centre arc-fraction), LOS/§CPE_AIM_DENSITY resume immediately in neighbouring ' +
-    'bands with no bleed; §CPE_SCRUB timeline scrub bar with stick tick-marks, drag drives plan.poseAt through the ' +
-    'same camera-move code _previewFly() uses per frame; §CPE_VIEWFINDER a synced second-camera POV sub-panel, ' +
-    'one renderer via setScissorTest, eye-icon toggle OFF by default, scoped to rehearsal only, never wired ' +
-    'into the MaxQ bake loop; §CPE_HOSE_LENGTH_BLIND the clock costs the HOSED curve — a hose pull used to buy speed instead of time (user record: 107.55m costed, 173.53m flown); §CPE_STICK_RED_BAR an unselected stick is a RED bar with BLUE dots, not an all-blue smudge; §CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the added node survives; provenance travels in the override instead of being guessed from the index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; §CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; §CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; §CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; §CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer doubles; §CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; §CPE_HOSE_REANCHOR pulls re-project by world anchor; §CPE_IDB_PATH_STORE named plans save/open/delete; §CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the authorable stretch; §CPE_PREVIEW drives the buildup; §CPE_HOSE whole-path arc-length falloff drag; §CPE_CLIP in/out markers; §CPE_BUILDUP checkbox; §CPE_PREVIEW_BUTTON with stale marker; §CPE_AIM_DENSITY in effects.js; §CPE_DRAG_LAND_FIRST no re-plan during a drag; §CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; §CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; §CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); §CPE_WALK 2.3m/s; §CPE_PREVIEW_DIVERGENCE plan pinned to open pose; §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
+  // ══════════════════════════════════════════════════════════════════════════════════════════════
+  // CPE_V — the pasted-console-answers-"which build is this?" string (comment at file top explains
+  // why this exists and must be bumped on every behaviour change). Reorganized 2026-08-04 into one
+  // clause per line, NEWEST FIRST, purely for human readability — every §TAG below is preserved
+  // verbatim from the pre-reorg blob, nothing dropped. A NEW SESSION: read the newest few lines
+  // here for a fast fix on current behaviour, then `prompts/CINEMA_PATH_EDITOR.md`'s own DONE
+  // blocks (search `§CPE_SCRUB`, `§CPE_VIEWFINDER`, `§CPE_AIM_PIN`) for the full history/reasoning —
+  // this string is a manifest, not a substitute for the spec doc.
+  // ══════════════════════════════════════════════════════════════════════════════════════════════
+  var CPE_V = 'v23 (' +
+    // ── 2026-08-04, same day, three changes in sequence — read together ──
+    '§CPE_SCRUB_MAIN_CAM_REGRESSION FIXED: scrubbing the timeline used to move the MAIN canvas ' +
+      'camera (a.camera/a.controls) — wrong, caught live by the user in their own browser. Scrubbing ' +
+      'is now VISUAL-ONLY (playhead + "timeline NN.N%" readout) and touches NO camera at all, main ' +
+      'or B\'s inset — an in-between fix that routed scrub into B\'s camera only was written and then ' +
+      'reverted before landing, simplified further at the user\'s own request; ' +
+    '§CPE_SCRUB_BAR_GATED the scrub bar\'s existence is now gated to B (built/torn down inside ' +
+      '_toggleViewfinder, alongside the vf panel) instead of always present from editor-open — ' +
+      'PROVISIONAL, not settled architecture: the bar\'s permanent home (standalone widget vs docked ' +
+      'under B) is an OPEN QUESTION left for a future session, since it needs to carry more later ' +
+      '(pin-drop, Find/Clash drag) per the user\'s own words — see the spec doc\'s DONE block; ' +
+    '§CPE_VIEWFINDER_EYE_ICON the #cpe-vf-toggle icon now swaps open/slashed with vfOn, reading ' +
+      'panels.js ICONS.eyeOpen/eyeOff — NOT ICONS.eye, which is actually Lucide\'s "scan-eye", a ' +
+      'different shape repurposed elsewhere for an unrelated Role View toggle; ' +
+    // ── 2026-08-04, Part C ──
+    '§CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look direction ' +
+      'there (rotation only, never position); the pin wins outright inside its own band\'s Voronoi ' +
+      'zone of the walk (by band-centre arc-fraction), LOS/§CPE_AIM_DENSITY resume immediately in ' +
+      'neighbouring bands with no bleed; ' +
+    // ── 2026-08-04, Parts A/B (original ship — the scrub-driving claim below is HISTORICAL, see ' +
+    //    the FIXED entry at the top of this string for what changed) ──
+    '§CPE_SCRUB timeline scrub bar with stick tick-marks (original ship note — since corrected: see ' +
+      '§CPE_SCRUB_MAIN_CAM_REGRESSION above, scrub no longer drives any camera-move code); ' +
+    '§CPE_VIEWFINDER a synced second-camera POV sub-panel, one renderer via setScissorTest, ' +
+      'eye-icon toggle OFF by default, scoped to rehearsal only, never wired into the MaxQ bake loop; ' +
+    // ── 2026-07-31 and earlier — unchanged, kept verbatim ──
+    '§CPE_HOSE_LENGTH_BLIND the clock costs the HOSED curve — a hose pull used to buy speed instead ' +
+      'of time (user record: 107.55m costed, 173.53m flown); ' +
+    '§CPE_STICK_RED_BAR an unselected stick is a RED bar with BLUE dots, not an all-blue smudge; ' +
+    '§CPE_REOPEN_NODE an edited OK STAGES the path so the next Alt+C re-opens it authored — the ' +
+      'added node survives; provenance travels in the override instead of being guessed from the ' +
+      'index; an unselected stick draws dark blue in the pipe and blue-tinted in the list; ' +
+    '§CPE_CLICK_SLOP a 4px click on the pipe spawns a stick again, no threshold existed; ' +
+    '§CPE_BUILDUP_FOLLOW_TM the reveal follows the Time Machine as-is, no camera-path re-key; ' +
+    '§CPE_PREVIEW_AFTER_RETIRED OK records without a rehearsal; ' +
+    '§CPE_REOPEN_DOUBLE re-open ADOPTS the authored bands instead of re-seeding them, N no longer ' +
+      'doubles; ' +
+    '§CPE_STICK_ANCHOR author raw + draw through the hose so a bar stays on the line; ' +
+    '§CPE_HOSE_REANCHOR pulls re-project by world anchor; ' +
+    '§CPE_IDB_PATH_STORE named plans save/open/delete; ' +
+    '§CPE_STICK click the pipe to spawn a band, N bands not 3, removable; walk drawn fat = the ' +
+      'authorable stretch; ' +
+    '§CPE_PREVIEW drives the buildup; ' +
+    '§CPE_HOSE whole-path arc-length falloff drag; ' +
+    '§CPE_CLIP in/out markers; ' +
+    '§CPE_BUILDUP checkbox; ' +
+    '§CPE_PREVIEW_BUTTON with stale marker; ' +
+    '§CPE_AIM_DENSITY in effects.js; ' +
+    '§CPE_DRAG_LAND_FIRST no re-plan during a drag; ' +
+    '§CPE_DRAG_SCALE building-derived m/px, camera distance no longer gears the drag; ' +
+    '§CPE_UNDO Ctrl+Z/Ctrl+Shift+Z + history-line event; ' +
+    '§CPE_DRAG_TELEPORT delta (reach cap removed, G-DRAG-3); ' +
+    '§CPE_WALK 2.3m/s; ' +
+    '§CPE_PREVIEW_DIVERGENCE plan pinned to open pose; ' +
+    '§CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG)';
   console.log('§CPE_LOADED ' + CPE_V);
 
   var HANDLE_R = 0.30;             // metres
@@ -1107,6 +1164,9 @@
     return { i: best, s: frac[best], p: { x: pts[best].x, y: pts[best].y, z: pts[best].z } };
   }
 
+  // Called from `_toggleViewfinder`'s ON branch only (2026-08-04 provisional simplification — see
+  // that function's own comment and this file's DONE block: the scrub bar's permanent place is an
+  // OPEN QUESTION for a future session, not settled by nesting it under B here).
   function _buildScrub(panel) {
     var wrap = document.createElement('div');
     wrap.id = 'cpe-scrub-wrap';
@@ -1168,19 +1228,20 @@
     if (lbl) lbl.textContent = (tnP * 100).toFixed(1) + '%';
   }
 
-  // Manual single step of the SAME per-frame update `_previewFly()`'s step() runs — see
-  // _applyCameraPose above. Called once per pointermove, never a rAF loop of its own (spec point 2:
-  // "scrubbing is a manual single step of that existing function, never a second pose path").
+  // §CPE_SCRUB — simplified 2026-08-04 (caught live in the browser, then simplified further by the
+  // user rather than perfected in place): scrubbing is VISUAL-ONLY. It moves NO camera, main or B's
+  // inset — only the playhead position and the "timeline NN.N%" readout update. An in-between fix
+  // that routed scrub into B's camera only was written and then reverted before landing: the user
+  // asked for the simpler cut now, and left "scrub drives B's camera" as deliberately DEFERRED
+  // future work — see this file's own DONE block in the spec doc — not something to rebuild here.
+  // `plan.poseAt` is still sampled — read-only, informational, useful to a witness or a future
+  // session — but nothing in this function writes to any camera.
   function _scrubTo(tn) {
-    if (!_state || !_state.plan) return null;
+    if (!_state) return null;
     tn = Math.max(0, Math.min(1, tn));
     _state.scrubTn = tn;
-    var p = _applyCameraPose(tn);
-    // Scrubbing never touches Time Machine (no buildup cursor tick outside a rehearsal), so there is
-    // no "this frame's cursor is not final yet" race here — safe to read straight back.
-    if (_state.vfOn) _vfUpdateReadout();
     _renderScrub();
-    return p;
+    return (_state.plan && typeof _state.plan.poseAt === 'function') ? _state.plan.poseAt(tn) : null;
   }
 
   function _wireScrub(track) {
@@ -1369,14 +1430,31 @@
       var p = _state.plan ? _state.plan.poseAt(_state.scrubTn || 0) : null;
       if (p) { _state.vfCam.position.set(p.x, p.y, p.z); _state.vfCam.lookAt(p.tx, p.ty, p.tz); }
       if (a.markDirty) a.markDirty();
-      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples');
+      // §CPE_SCRUB (2026-08-04 provisional simplification, NOT settled — see this file's DONE block
+      // in the spec doc): the scrub bar is built here, alongside B, rather than existing on its own
+      // at editor-open time. The user's own words on this NOT being final: "that timeline was
+      // supposed to be standalone widget panel... independent because it is supposed to do more
+      // next ie pin point drop, Find / Clash drop... let's have the next prompts/# session figure
+      // that out — as now just get the canvas part to be its true self." Shipped this way only to
+      // get the main-canvas regression fixed today; a future session may need to un-nest this.
+      var cpePanel = document.getElementById('cpe-panel');
+      if (cpePanel && !document.getElementById('cpe-scrub-track')) {
+        _buildScrub(cpePanel);
+        var scrubTrack = document.getElementById('cpe-scrub-track');
+        if (scrubTrack) _wireScrub(scrubTrack);
+        _renderScrub();
+      }
+      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; scrub bar shown (provisional: nested under B, see DONE block)');
     } else {
       var panel = document.getElementById('cpe-vf-panel');
       if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
       if (a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
       if (btn) { btn.style.color = '#888'; btn.style.borderColor = '#4a4f57'; }
+      // The scrub bar goes with B — see the ON branch's comment on why this pairing is provisional.
+      var scrubWrap = document.getElementById('cpe-scrub-wrap');
+      if (scrubWrap && scrubWrap.parentNode) scrubWrap.parentNode.removeChild(scrubWrap);
       if (a.markDirty) a.markDirty();
-      console.log('§CPE_VF off — panel removed, render hook cleared, zero per-frame cost');
+      console.log('§CPE_VF off — panel removed, render hook cleared, scrub bar removed, zero per-frame cost');
     }
   }
   function _vfTeardown() {
@@ -1384,6 +1462,8 @@
     var panel = document.getElementById('cpe-vf-panel');
     if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
     if (a && a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
+    // The scrub bar is a child of #cpe-panel (removed by finish() itself right after this call), so
+    // no separate removal is needed here — listed for the reader, not left implicit.
   }
   function _wireViewfinderToggle() {
     var btn = document.getElementById('cpe-vf-toggle');
@@ -1620,17 +1700,19 @@
     return true;
   }
 
-  // ══ §CPE_SCRUB / §CPE_VIEWFINDER — THE ONE PLACE A POSE IS APPLIED TO THE LIVE CAMERA ══════════
-  // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PREVIEW_DIVERGENCE doctrine, restated for
-  // this build — "cannot become a second notion of the path". `_previewFly()`'s per-frame step used
-  // to inline `plan.poseAt(tn)` -> camera.position/controls.target -> controls.update() -> markDirty
-  // directly inside its rAF closure, which meant the ONLY way to move the live camera along the
-  // plan was to run a full rehearsal. §CPE_SCRUB needs the identical four lines for a manual
-  // single-step drag, and §CPE_VIEWFINDER needs the SAME `tn` fed to a second camera in the same
-  // call — so both now go through this one function instead of a second, parallel implementation.
-  // Extracted verbatim: nothing about what it does to `a.camera`/`a.controls` changed, only that
-  // it is now callable from three places (rehearsal step, scrub drag, and — via the return value —
-  // the witness) instead of being buried in one.
+  // ══ §CPE_VIEWFINDER — THE ONE PLACE A POSE IS APPLIED TO THE LIVE MAIN CAMERA ══════════════════
+  // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PREVIEW_DIVERGENCE doctrine — "cannot
+  // become a second notion of the path". Used by `_previewFly()`'s rehearsal step() ONLY.
+  //
+  // §CPE_SCRUB correction (2026-08-04, caught live by the user in their own browser, NOT the same
+  // claude-in-chrome instability seen elsewhere this session — a genuine behavioural defect, then
+  // simplified further rather than fixed in place): this function used to ALSO be called by the
+  // scrub-bar drag handler, which meant dragging the Part A timeline moved the MAIN canvas — wrong,
+  // per the user: "the main canvas... supposed to remain as was where user still does traditional
+  // editing dragging the pipe etc." The scrub-driving call was removed outright (see `_scrubTo`,
+  // now visual-only) rather than rerouted to drive `_state.vfCam` instead — "scrub drives B's
+  // camera" is DEFERRED, explicitly left for a future session (see this file's own DONE block in
+  // the spec doc), not rebuilt here.
   function _applyCameraPose(tn) {
     var a = A();
     if (!_state || !_state.plan || typeof _state.plan.poseAt !== 'function') return null;
@@ -1640,18 +1722,16 @@
     a.controls.update();
     // §CPE_VIEWFINDER point 2: "B's camera pose is set from the SAME plan.poseAt(tn) the main
     // rehearsal camera uses at that instant" — literally the same sample just taken above, not a
-    // second poseAt call. Runs whether this frame came from a rehearsal step or a scrub drag, which
-    // is what keeps B in sync with BOTH (spec: "the scrub playhead and the B viewfinder camera must
-    // sample this SAME function").
+    // second poseAt call. B tracking the main camera 1:1 while `_previewFly()` flies it is exactly
+    // the "exact POV" ask; this path is unaffected by the 2026-08-04 scrub correction.
     if (_state.vfOn && _state.vfCam) {
       _state.vfCam.position.set(p.x, p.y, p.z);
       _state.vfCam.lookAt(p.tx, p.ty, p.tz);
       // §CPE_VIEWFINDER point 4: the readout is NOT refreshed here. Inside a rehearsal step, this
       // function runs BEFORE that frame's `window.tmSetCursor` call (see step() below) — reading the
       // clock here would show LAST frame's cursor for one frame every frame, a small but real
-      // staleness the "no second clock" doctrine exists to catch. Callers refresh it themselves once
-      // they know the frame's cursor is final: step() calls it AFTER its own tmSetCursor block,
-      // _scrubTo calls it right here since scrubbing never touches Time Machine at all.
+      // staleness the "no second clock" doctrine exists to catch. step() refreshes it AFTER its own
+      // tmSetCursor block instead.
     }
     if (a.markDirty) a.markDirty();
     return p;
@@ -2357,12 +2437,11 @@
         'm speed=' + _state.speed.toFixed(2) + 'm/s total=' + ctx.durationSec.toFixed(1) + 's');
 
       var panel = _buildPanel();
-      // §CPE_SCRUB: built right after the panel, before the first _redrawScene() call below — the
-      // scrub track must exist for _renderScrub() (called from inside _redrawScene) to find it.
+      // §CPE_SCRUB (2026-08-04 provisional simplification — see this file's DONE block in the spec
+      // doc for why, and that it is NOT settled architecture): the scrub bar is built/torn down
+      // alongside B, inside _toggleViewfinder — not unconditionally here. `scrubTn` still gets a
+      // default so _renderScrub (a no-op until the track exists) has something sane to read later.
       _state.scrubTn = 0;
-      _buildScrub(panel);
-      var scrubTrack = document.getElementById('cpe-scrub-track');
-      if (scrubTrack) _wireScrub(scrubTrack);
       // §CPE_VIEWFINDER: the eye-icon toggle button lives in the panel's title row (_buildPanel).
       _wireViewfinderToggle();
       // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted
@@ -2628,10 +2707,19 @@
                      hex: '0x' + r.mesh.material.color.getHex().toString(16).padStart(6, '0') };
           });
         },
-        // ══ §CPE_SCRUB witness hooks — G-SCRUB-1/2. Read-only where possible; `_scrubTo` drives the
-        // real camera exactly as a drag would (it IS the drag handler's own function), so a witness
-        // exercises the product path rather than asserting against a re-implementation.
+        // ══ §CPE_SCRUB witness hooks. Read-only where possible; `_scrubTo` IS the real drag
+        // handler's own function (a witness exercises the product path, not a re-implementation) —
+        // simplified 2026-08-04 (caught live in the browser, then simplified further rather than
+        // fixed in place — see `_scrubTo`'s own comment): it is VISUAL-ONLY now, touching no camera
+        // at all, main or B's. `_probeVF().mainPose`/`mainTarget` below is the ground truth for
+        // proving the main camera stays untouched across a scrub drag.
         _scrubTo: function(tn) { return _scrubTo(tn); },
+        // G-VF-1's witness hook: the real rehearsal-only pose function `_previewFly()`'s step() uses
+        // — the ONE remaining caller of `_applyCameraPose` after the 2026-08-04 scrub correction.
+        // Exposed the same way `_scrubTo` is (the real internal function, not a re-implementation),
+        // so G-VF-1 can prove B tracks the main camera during a REHEARSAL-style pose application
+        // without needing to run and wait out a full real Preview flight.
+        _applyCameraPoseForTest: function(tn) { return _applyCameraPose(tn); },
         _scrubHitAt: function(tn) { return _tnormToStickHit(tn); },
         _bandTNorm: function(bi) { return _state ? _bandTNorm(bi) : null; },
         // Ground truth for G-SCRUB-1/G-VF-1 — the SAME `_state.plan.poseAt` every render (tube,
@@ -2660,6 +2748,10 @@
             hookInstalled: a._cpeViewfinderRender === _vfRender,
             camPose: _state.vfCam ? { x: _state.vfCam.position.x, y: _state.vfCam.position.y, z: _state.vfCam.position.z } : null,
             mainPose: { x: a.camera.position.x, y: a.camera.position.y, z: a.camera.position.z },
+            // §CPE_SCRUB correction ground truth: the main canvas's ORBIT TARGET, not just its
+            // position — a scrub-caused main-camera move could show up as a target drift alone
+            // (e.g. controls.update() re-deriving something) even with position untouched.
+            mainTarget: { x: a.controls.target.x, y: a.controls.target.y, z: a.controls.target.z },
             rect: r ? { left: r.left, top: r.top, width: r.width, height: r.height } : null,
             tmCursorReadout: document.getElementById('cpe-vf-clock') ? document.getElementById('cpe-vf-clock').textContent : null
           };

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4541,8 +4541,19 @@ async function setupEffects(A, renderer, scene, camera) {
     return a * Math.max(0, Math.min(1, t)) + (1 - a) * _cinemaSmoothstep(t);
   }
   // §EFFECTS_LOADED — effects.js's build fingerprint, so a pasted console can answer "is this
-  // live?" by itself. Bump on EVERY behaviour change in this file.
-  var EFFECTS_V = 'v18 (§CPE_PACE_SWING_SOFTEN CINEMA_PACE_SWING 1.6->1.45, direct user tuning request; §CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; §CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; §STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
+  // live?" by itself. Bump on EVERY behaviour change in this file. Reorganized to one clause per
+  // line 2026-08-04 for readability (no §TAG dropped) — also CAUGHT UP a real gap found while doing
+  // that: §CPE_AIM_PIN (Part C) added real behaviour here (`_buildPinZones`/`_pinLookAtAt` inside
+  // `_beat3Pose`) but this string was never bumped for it, breaking the file's own "bump on EVERY
+  // behaviour change" rule for one release. Fixed now, not left for a future session to rediscover.
+  var EFFECTS_V = 'v19 (' +
+    '§CPE_AIM_PIN a pinned band\'s Voronoi zone of the walk overrides LOS/§CPE_AIM_DENSITY outright ' +
+      '(_buildPinZones/_pinLookAtAt inside _beat3Pose) — was live in v18\'s shipped code, this ' +
+      'string just never said so; ' +
+    '§CPE_PACE_SWING_SOFTEN CINEMA_PACE_SWING 1.6->1.45, direct user tuning request; ' +
+    '§CINEMA_LOOKAHEAD_ARC no-threshold look-ahead; ' +
+    '§CPE_EVEN_TURN cost-parameterized walk + §CPE_SEAM_CONTINUOUS Beat2→3 opening blend; ' +
+    '§STAFFAGE_OUTSIDE_VARIETY + §STAFFAGE_FLOOR_PHANTOM)';
   console.log('§EFFECTS_LOADED ' + EFFECTS_V);
 
   // Inverse of scene.js's A.ifc2three (IFC X=east,Y=north,Z=up → three X=east,Y=up,Z=south).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v941';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v942';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -1,15 +1,32 @@
 // WITNESS — §CPE_SCRUB / §CPE_VIEWFINDER (Parts A and B).
 // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part A §CPE_SCRUB, Part B §CPE_VIEWFINDER.
 //
+// §CPE_SCRUB gates REWRITTEN 2026-08-04 — a real regression, caught live by the user in their own
+// browser: scrubbing the timeline used to move the MAIN canvas camera (`A.camera`/`A.controls`),
+// which is wrong — the main canvas is the user's traditional editing view and must stay exactly
+// where they left it, always. The fix was then simplified further, past "route scrub into B's
+// camera instead": scrubbing is now VISUAL-ONLY (playhead + tNorm readout), touching NO camera at
+// all, and the scrub bar itself only exists while B is open (a provisional pairing, not settled
+// architecture — see the spec doc's DONE block). The OLD G-SCRUB-1 (scrub reproduces poseAt on the
+// LIVE camera) asserted exactly the behaviour that was the bug — it is GONE, replaced below.
+//
 // ISSUE EACH GATE PROVES OR DISPROVES:
-//   G-SCRUB-1  dragging the playhead to tNorm=X reproduces the exact pose _previewFly() would show
-//              at that instant — no second pose pipeline. Proven by comparing what _scrubTo(X) left
-//              on the LIVE camera against a direct, independent plan.poseAt(X) read.
-//   G-SCRUB-2  clicking empty bar at tNorm=X spawns a band at the same world point the pipe's own
-//              arc-length placement (plan.poseAt(X)) gives for X. A REAL pointer click on the DOM
-//              track, not a synthetic call — exercises the actual click-vs-drag slop split too.
-//   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant — one pose
-//              source, both fed by the same _applyCameraPose call.
+//   G-SCRUB-GATED  the scrub bar does not exist in the DOM while B is off (fresh editor open), and
+//                  does exist once B is toggled on — the bar's existence is gated to B, not a
+//                  permanent fixture (2026-08-04 provisional simplification).
+//   G-SCRUB-VISUAL a scrub drag still updates the playhead position and the "timeline NN.N%"
+//                  readout text — the feature has a real effect, it just isn't a camera move.
+//   G-SCRUB-NOCAM  THE regression gate: the main camera's position AND orbit target, and B's inset
+//                  camera's position, are all byte-identical before and after a scrub drag. Proves
+//                  the bug (scrub moving the main canvas) cannot recur silently.
+//   G-SCRUB-SPAWN  clicking the (now B-gated) bar at tNorm=X still spawns a band at the same world
+//                  point the pipe's own arc-length placement (plan.poseAt(X)) gives for X — a REAL
+//                  pointer click on the DOM track, exercising the actual click-vs-drag slop split.
+//   G-SCRUB-TEARDOWN  toggling B back off removes the scrub bar from the DOM too.
+//   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant DURING A
+//              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call. This
+//              path is unaffected by the scrub fix (`_previewFly()` still legitimately flies the
+//              main camera; B still legitimately tracks it 1:1 while that happens).
 //   G-VF-2     B's Time Machine readout is a READ of the cursor step() already set that frame, never
 //              a second tmSetCursor call — proven both statically (source has tmGetState, not
 //              tmSetCursor, inside the vf functions) and live (readout agrees with tmGetState() at
@@ -51,25 +68,52 @@ async function gates(browser, BLD, repoDir) {
   const P = (n, ok, d) => checks.push({ n, ok, d });
   const { page, logs } = await openEditor(browser, BLD);
 
-  // ── G-SCRUB-1 ──────────────────────────────────────────────────────────────────────────────────
-  const scrub1 = await page.evaluate(() => {
-    const cpe = window.APP.cinemaPathEditor;
-    const A = window.APP;
-    const tn = 0.42;
-    const ground = cpe._probePoseAt(tn);            // direct, independent poseAt(tn) read
-    const applied = cpe._scrubTo(tn);                // the real drag-handler function
-    const cam = { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z };
-    const tgt = { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z };
-    return { ground, applied, cam, tgt };
-  });
-  const dCam = Math.hypot(scrub1.ground.x - scrub1.cam.x, scrub1.ground.y - scrub1.cam.y, scrub1.ground.z - scrub1.cam.z);
-  const dTgt = Math.hypot(scrub1.ground.tx - scrub1.tgt.x, scrub1.ground.ty - scrub1.tgt.y, scrub1.ground.tz - scrub1.tgt.z);
-  P('G-SCRUB-1 scrubbing to tn=0.42 leaves the live camera at plan.poseAt(0.42), position AND target',
-    dCam < 1e-6 && dTgt < 1e-6,
-    `camDelta=${dCam.toExponential(2)}m targetDelta=${dTgt.toExponential(2)}m ` +
-    `(ground pos=(${scrub1.ground.x.toFixed(2)},${scrub1.ground.y.toFixed(2)},${scrub1.ground.z.toFixed(2)}))`);
+  // ── G-SCRUB-GATED: the bar does not exist before B is toggled on ────────────────────────────────
+  const beforeVF = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
+  P('G-SCRUB-GATED the scrub bar does not exist in the DOM while B is off',
+    beforeVF === false, `trackPresent=${beforeVF}`);
 
-  // ── G-SCRUB-2: a REAL pointer click on the scrub track, inside the walk window ────────────────
+  // ── toggle B on — shared setup for every gate below (bar existence, no-cam, spawn, and G-VF-1) ──
+  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(300);
+  const afterVF = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
+  P('G-SCRUB-GATED the scrub bar DOES exist once B is toggled on',
+    vfOnState === true && afterVF === true, `vfOn=${vfOnState} trackPresent=${afterVF}`);
+
+  // ── G-SCRUB-NOCAM: THE regression gate — no camera moves during a scrub drag ────────────────────
+  const before = await page.evaluate(() => {
+    const A = window.APP, cpe = window.APP.cinemaPathEditor;
+    const vf = cpe._probeVF();
+    return {
+      mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+      mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z },
+      vfPos: vf.camPose, scrubLabel: document.getElementById('cpe-scrub-tn').textContent
+    };
+  });
+  const scrubResult = await page.evaluate(() => window.APP.cinemaPathEditor._scrubTo(0.42));
+  await sleep(50);
+  const after = await page.evaluate(() => {
+    const A = window.APP, cpe = window.APP.cinemaPathEditor;
+    const vf = cpe._probeVF();
+    return {
+      mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+      mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z },
+      vfPos: vf.camPose, scrubLabel: document.getElementById('cpe-scrub-tn').textContent
+    };
+  });
+  const dMainPos = Math.hypot(after.mainPos.x - before.mainPos.x, after.mainPos.y - before.mainPos.y, after.mainPos.z - before.mainPos.z);
+  const dMainTgt = Math.hypot(after.mainTgt.x - before.mainTgt.x, after.mainTgt.y - before.mainTgt.y, after.mainTgt.z - before.mainTgt.z);
+  const dVfPos = (before.vfPos && after.vfPos)
+    ? Math.hypot(after.vfPos.x - before.vfPos.x, after.vfPos.y - before.vfPos.y, after.vfPos.z - before.vfPos.z) : null;
+  P('G-SCRUB-NOCAM the main camera (position AND target) and B\'s inset camera are byte-identical before/after a scrub drag',
+    dMainPos < 1e-9 && dMainTgt < 1e-9 && (dVfPos == null || dVfPos < 1e-9),
+    `mainPosDelta=${dMainPos.toExponential(2)}m mainTargetDelta=${dMainTgt.toExponential(2)}m vfPosDelta=${dVfPos == null ? 'n/a' : dVfPos.toExponential(2) + 'm'} ` +
+    `scrubResult.x=${scrubResult ? scrubResult.x.toFixed(2) : 'null'} (poseAt(0.42) IS sampled and returned — just never written to any camera)`);
+  P('G-SCRUB-VISUAL the playhead/readout DID change (the feature still has a real, visible effect)',
+    before.scrubLabel !== after.scrubLabel,
+    `before="${before.scrubLabel}" after="${after.scrubLabel}"`);
+
+  // ── G-SCRUB-SPAWN: a REAL pointer click on the (B-gated) scrub track, inside the walk window ────
   const setup2 = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
     const win = cpe._probeScrub().walkWindow;
@@ -89,35 +133,36 @@ async function gates(browser, BLD, repoDir) {
     await sleep(30);
     await page.mouse.up();          // a 0px press == a click, same doctrine as §CPE_CLICK_SLOP
     await sleep(700);
-    const after = await page.evaluate(() => {
+    const afterSpawn = await page.evaluate(() => {
       const cpe = window.APP.cinemaPathEditor;
       const n = document.querySelectorAll('#cpe-rows > div[data-cpe-row="band"]').length;
       // Find the newly-added stick's drawn centre via the bars/handles probe (mid handle, z==='mid').
       const handles = cpe._probeHandles() || [];
       return { n, handles };
     });
-    const stickHandle = after.handles.filter(h => h.z === 'mid' && h.stick).pop();
+    const stickHandle = afterSpawn.handles.filter(h => h.z === 'mid' && h.stick).pop();
     const dSpawn = stickHandle
       ? Math.hypot(stickHandle.x - setup2.ground.x, stickHandle.y - setup2.ground.y, stickHandle.z3 - setup2.ground.z)
       : null;
     // Seeding resolution is bounded by the flow polyline's own sample density, not by the film's
     // FILM_SAMPLES — a few tens of cm is the real bound, measured below rather than asserted blind.
-    g2ok = after.n === setup2.nBefore + 1 && stickHandle != null && dSpawn != null && dSpawn < 2.0;
-    g2detail = `rows ${setup2.nBefore}->${after.n} spawnDist=${dSpawn == null ? 'n/a' : dSpawn.toFixed(3) + 'm'} ` +
+    g2ok = afterSpawn.n === setup2.nBefore + 1 && stickHandle != null && dSpawn != null && dSpawn < 2.0;
+    g2detail = `rows ${setup2.nBefore}->${afterSpawn.n} spawnDist=${dSpawn == null ? 'n/a' : dSpawn.toFixed(3) + 'm'} ` +
       `(clicked tn=${setup2.tn.toFixed(3)}, target=(${setup2.ground.x.toFixed(2)},${setup2.ground.y.toFixed(2)},${setup2.ground.z.toFixed(2)}))`;
   }
-  P('G-SCRUB-2 a click on the shaded bar spawns a stick at the pipe\'s own placement for that tNorm', g2ok, g2detail);
+  P('G-SCRUB-SPAWN a click on the shaded bar spawns a stick at the pipe\'s own placement for that tNorm', g2ok, g2detail);
 
-  // ── G-VF-1 ─────────────────────────────────────────────────────────────────────────────────────
-  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
-  await sleep(300);
+  // ── G-VF-1 (B already on from the shared setup above): rehearsal-style pose application only —
+  // NOT `_scrubTo` (that no longer touches any camera, per the 2026-08-04 correction/simplification
+  // above). `_applyCameraPoseForTest` calls the real `_applyCameraPose`, the one function
+  // `_previewFly()`'s step() still legitimately uses to fly the main camera and sync B to it.
   const vf1 = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
-    cpe._scrubTo(0.65);
+    cpe._applyCameraPoseForTest(0.65);
     return cpe._probeVF();
   });
   const dVF = vf1.camPose ? Math.hypot(vf1.camPose.x - vf1.mainPose.x, vf1.camPose.y - vf1.mainPose.y, vf1.camPose.z - vf1.mainPose.z) : null;
-  P('G-VF-1 B\'s camera pose at tn=0.65 matches the main camera exactly (same plan.poseAt sample)',
+  P('G-VF-1 B\'s camera pose at tn=0.65 matches the main camera exactly (same plan.poseAt sample, rehearsal-style application)',
     vfOnState === true && dVF != null && dVF < 1e-6,
     `vfOn=${vfOnState} hookInstalled=${vf1.hookInstalled} delta=${dVF == null ? 'n/a' : dVF.toExponential(2)}m ` +
     `rect=${vf1.rect ? JSON.stringify(vf1.rect) : 'null'}`);
@@ -198,11 +243,16 @@ async function gates(browser, BLD, repoDir) {
   const off = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
     const on = cpe._vfToggle();
-    return { on: on, panelGone: !document.getElementById('cpe-vf-panel'), hookGone: !window.APP._cpeViewfinderRender };
+    return {
+      on: on, panelGone: !document.getElementById('cpe-vf-panel'), hookGone: !window.APP._cpeViewfinderRender,
+      scrubGone: !document.getElementById('cpe-scrub-track')
+    };
   });
   P('G-VF-off toggling off removes the DOM panel and clears the render hook (zero cost when off)',
     off.on === false && off.panelGone && off.hookGone,
     `vfOn=${off.on} panelGone=${off.panelGone} hookGone=${off.hookGone}`);
+  P('G-SCRUB-TEARDOWN toggling B off also removes the scrub bar (its existence is gated to B)',
+    off.scrubGone, `trackGoneAfterVfOff=${off.scrubGone}`);
 
   await page.close();
   return checks;


### PR DESCRIPTION
## Summary
Real bug, caught live by the user in their own browser: scrubbing the Part A timeline was moving the MAIN viewport camera (`A.camera`/`A.controls`). Wrong — the main canvas is the user's traditional editing view and must stay exactly where they left it at all times, including during and after a scrub drag. B is "an aid only."

**Fix**: scrubbing is now VISUAL-ONLY. It touches no camera at all, main or B's inset — only the playhead and "timeline NN.N%" readout move. `plan.poseAt(tn)` is still sampled (informational) but never written to any camera. `_previewFly()`'s own step() (the pre-existing "Preview" button) is completely unaffected — it still legitimately flies the main camera and restores it on completion.

**Provisional**: the scrub bar's existence is now gated to B being open (built/torn down alongside the vf panel). This is NOT settled architecture — the bar's permanent home (standalone widget vs docked under B) is left as an open question for a future session, since it needs to carry more later (pin-drop, Find/Clash drag). Recorded in the spec doc's handoff section.

**Also**: consolidated the bloated single-line version-banner comments (`CPE_V`, `EFFECTS_V`, `MAXQ_V`) into one-clause-per-line for readability — every `§TAG` preserved, `MAXQ_V`'s reconstructed content verified byte-identical against the pre-reorg original (pure format change, zero behaviour touched in `cinema_maxq.js`, consistent with this lane's standing "never touch the bake loop" boundary). Along the way, fixed a real pre-existing gap: `EFFECTS_V` had never been bumped for `§CPE_AIM_PIN`'s real behaviour change in `_beat3Pose` — fixed now (v18→v19).

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` rewritten — the old G-SCRUB-1 asserted exactly the buggy behaviour and is gone. New gates: G-SCRUB-GATED, G-SCRUB-NOCAM (the regression gate — main camera position+target AND B's vfCam byte-identical before/after a scrub drag), G-SCRUB-VISUAL, G-SCRUB-SPAWN, G-SCRUB-TEARDOWN. **12/12 green on both Duplex and Terminal** (was 8/8 before this rewrite).
- [x] `witness_cpe_aim_pin.js` re-run clean — 7/7 both buildings.
- [x] Broader `witness_cpe_*`/`witness_cinema_path_editor.js` suite re-run — pre-existing baseline failures (G10/G7) confirmed unchanged.
- [x] Live-verified via real pointer-drag sequences in a genuine browser session: with B closed, the bar doesn't exist and `_scrubTo` leaves the main camera byte-identical; with B open, a real mouse drag on the track leaves BOTH the main camera and B's vfCam byte-identical while the readout genuinely updates (0.0% → 70.0%).
- [x] `sw.js` `CACHE_VERSION` bumped (v941 → v942).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThtkvHdEX4jKQVS92cBqxf