### PR TITLE
fix(room-graph): detour legalization vetoes waypoints already used earlier in the same path

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -1422,6 +1422,12 @@
         if (mid && mid.length) {
           var laterAnchors = {};
           for (var k = i + 2; k < path.length; k++) laterAnchors[path[k]] = 1;
+          // §DETOUR-NO-BACKTRACK (2026-08-04): the forward-only check above misses a waypoint an
+          // EARLIER chord's own detour already spliced into `out` this same pass — that guid never
+          // appears in the original `path` array, only in `out`, so it slipped through. Widening the
+          // same veto-candidate set to also cover everything already placed reuses the existing
+          // chainLen-guarded "only replace if not longer" acceptance below unchanged — no new logic.
+          for (var eo = 0; eo < out.length; eo++) laterAnchors[out[eo]] = 1;
           var revisits = mid.filter(function (g) { return laterAnchors[g]; });
           if (revisits.length) {
             var veto = {};


### PR DESCRIPTION
## Summary
- \`_legalizePath\`'s existing no-revisit guard only checked a new detour against anchors still *ahead* in the path — never against waypoints an *earlier* chord's own detour already placed into the output this same pass.
- Widens the same veto-candidate set already feeding the existing chainLen-guarded accept/reject logic to also include everything already emitted — reuses the existing mechanism, no new logic.
- Found via a live witness on Hospital's real `L1 -> L4` room-to-room route: the path walked `doorwp A -> doorwp B -> junction -> doorwp B again -> doorwp A again` before diverging.

## Test plan
- [x] Re-witnessed the same 5 real room-to-room paths (Hospital x3, LTU_AHouse x2) — 4/5 identical, target case now correctly attempts a no-revisit alternative and honestly rejects it (8.7m longer, existing length-guard keeps the shorter route)
- [x] Fleet-wide connectivity (`witness_full_connectivity.js`: Clinic/HHS/Duplex) — byte-identical output before/after
- [x] Direct `fullConnectivity()` check on Hospital/LTU — byte-identical before/after
- [ ] Open question, not blocking: should the length-guard ever prefer a no-revisit route even when longer? Left as-is (existing design), flagged for a separate discussion if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJbNvbyKUPz5CNkoW1ohb5