### PR TITLE
fix(4d): §GANTT_OPS_BOOKKEEPING_LEAK — BUILDING_OPEN was polluting the real project timeline

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v943';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v944';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -110,24 +110,39 @@
     } catch(e) { return []; }
   }
 
+  // §GANTT_OPS_BOOKKEEPING_LEAK (2026-08-04): _ops (loadOps()) intentionally carries EVERY kernel_ops
+  // row, not just construction ops — copyGuids(false) and other consumers legitimately want the full
+  // mixed history (picks, GRID_*, etc.), so the fix does NOT belong in loadOps()'s query. But a
+  // bookkeeping op like BUILDING_OPEN (streaming.js, commitOp with no ts -> Date.now(), real
+  // wall-clock, no storey/phase, no real output_guid) has no business defining the PROJECT'S OWN
+  // timeline bounds — traced live as the "_UNKNOWN/Architecture outlier" behind §GANTT_AXIS_OUTLIER
+  // (#1175, which qualified the DISPLAY axis but left _projectStart/_projectEnd — the real playback
+  // bounds scrubbing/renderAtTime use — still polluted, unmeasured until now). Scoped to exactly the
+  // two places that build the construction TIMELINE from _ops: this function's bounds, and
+  // buildGanttTasks()'s bar grouping.
+  function _placeOps() { return _ops.filter(function (o) { return o.op_type === 'ELEMENT_PLACE'; }); }
+
   function computeDays() {
+    var cOps = _placeOps();
     var seen = {};
-    _ops.forEach(function(op) {
+    cOps.forEach(function(op) {
       var d = new Date(op.start_ts);
       var key = d.getFullYear() + '-' + (d.getMonth()+1) + '-' + d.getDate();
       if (!seen[key]) seen[key] = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
     });
     _days = Object.values(seen).sort(function(a,b){ return a - b; });
-    if (_ops.length) {
+    if (cOps.length) {
       // projectStart = 1ms BEFORE first op so ⏪ = truly empty (no frontier)
-      _projectStart = _ops[0].start_ts - 1;
-      _projectEnd = Math.max.apply(null, _ops.map(function(o){ return o.end_ts; }));
+      _projectStart = cOps[0].start_ts - 1;
+      _projectEnd = Math.max.apply(null, cOps.map(function(o){ return o.end_ts; }));
     }
     // §GANTT_AXIS_OUTLIER — qualified DISPLAY axis. Same 2nd-98th percentile trim §GANTT_MINI_TRIM
     // already uses per-bar (buildGanttTasks), applied here to the GLOBAL population of end_ts that
     // would otherwise define the whole chart's axis. n>20 real percentiles, else true min/max — same
-    // threshold, never a new invented one.
-    var ends = _ops.map(function (o) { return o.end_ts; }).sort(function (a, b) { return a - b; });
+    // threshold, never a new invented one. Kept as real, independent defense against genuinely
+    // mistagged construction data even now that cOps excludes bookkeeping ops (§GANTT_MINI_TRIM's own
+    // proven case — a handful of real elements DO carry a real-but-wrong storey tag).
+    var ends = cOps.map(function (o) { return o.end_ts; }).sort(function (a, b) { return a - b; });
     var n = ends.length;
     _ganttAxisStart = _projectStart;   // starts are not the observed problem; leave unqualified
     if (n > 20) {
@@ -4578,6 +4593,10 @@
     var _idN = 0, _noIdN = 0;
     for (var i = 0; i < _ops.length; i++) {
       var op = _ops[i];
+      // §GANTT_OPS_BOOKKEEPING_LEAK: a non-construction op (BUILDING_OPEN, ELEMENT_PICK, GRID_*, ...)
+      // is not a task and must not become a bar — see computeDays()'s own header comment for the
+      // traced mechanism. _ops itself stays the full mixed history for other consumers (copyGuids).
+      if (op.op_type !== 'ELEMENT_PLACE') continue;
       var p = op.parameters || {};
       var storey = p.storey || '_UNKNOWN';
       var phase = p.phase || 'Architecture';

--- a/witness_gantt_ops_blackbox.js
+++ b/witness_gantt_ops_blackbox.js
@@ -1,0 +1,106 @@
+// witness_gantt_ops_blackbox.js — headless, no browser. The "black box output log" requested
+// 2026-08-04: dump the deterministic Gantt op population in build order (first pile knocked, last
+// thing built) so a session can READ what the chart will draw instead of screenshotting it.
+//
+// Regression guard for §GANTT_OPS_BOOKKEEPING_LEAK, found by reading source (not guessed), chain:
+//   1. streaming.js:812   commitOp(db,'BUILDING_OPEN',{name,count},[])  — no ts passed
+//   2. kernel_ops.js:83   commitOp defaults stamp = Date.now() when ts is omitted — REAL wall-clock,
+//      not a simulated construction date
+//   3. time_machine.js loadOps() intentionally has NO op_type filter (copyGuids(false) legitimately
+//      wants the full mixed kernel_ops history — picks, GRID_*, etc. — so the fix does not belong
+//      in the query)
+//   4. Pre-fix, computeDays()/buildGanttTasks() consumed that full mixed _ops directly: a missing
+//      storey/phase defaulted to '_UNKNOWN'/'Architecture' (the exact bucket the live session traced
+//      as "the one outlier bar" behind §GANTT_AXIS_OUTLIER, PR #1175), and Math.max over ALL ops'
+//      end_ts let BUILDING_OPEN's real-wall-clock timestamp define _projectEnd — the REAL playback
+//      bounds (scrubbing, "every element must eventually build"), not just the display axis #1175
+//      qualified.
+//
+// This witness slices `_placeOps`+`computeDays` OUT OF THE SHIPPED FILE (same idiom as
+// tests/test_tm_broadcast.js) and runs the REAL function against a synthetic op population — not a
+// re-implementation. G-3/G-4 below fail if the filter is ever removed from computeDays().
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const src = fs.readFileSync(path.join(__dirname, 'viewer', 'time_machine.js'), 'utf8');
+const a = src.indexOf('function _placeOps()');
+const b = src.indexOf('\n  }', src.indexOf('function computeDays()')) + 4;
+if (a < 0 || b < a) { console.log('§BLACKBOX FAIL: could not locate _placeOps/computeDays span'); process.exit(1); }
+const logic = src.slice(a, b);
+
+const DAY = 86400000, base = Date.parse('2023-09-20T00:00:00Z');
+// Real construction ops — same shape loadOps() returns for op_type='ELEMENT_PLACE' rows.
+const realOps = [];
+for (let i = 0; i < 40; i++) {
+  const s = base + i * 8 * DAY;
+  realOps.push({ op_type: 'ELEMENT_PLACE', output_guid: 'G' + i, start_ts: s, end_ts: s + 8 * DAY,
+    parameters: { storey: 'Level ' + (1 + (i % 5)), phase: 'Superstructure' } });
+}
+const realProjectEnd = Math.max.apply(null, realOps.map(o => o.end_ts));
+
+// The exact shape streaming.js:812's commitOp('BUILDING_OPEN', {name,count}, []) produces once
+// loadOps() reads it back: no storey/phase, real wall-clock timestamp (here fixed, not Date.now(),
+// so the witness stays reproducible — same class of value, chosen far past any building's
+// simulated window, same as the live symptom).
+const bookkeepingOp = { op_type: 'BUILDING_OPEN', output_guid: null,
+  start_ts: Date.parse('2026-08-04T05:00:00Z'), end_ts: Date.parse('2026-08-04T05:01:00Z'),
+  parameters: {} };
+
+function mkSandbox(ops) {
+  const s = { _ops: ops, _days: [], _projectStart: 0, _projectEnd: 0, _ganttAxisStart: 0, _ganttAxisEnd: 0,
+    Object: Object, Math: Math, Date: Date };
+  vm.runInNewContext(logic + '\n; globalThis.__placeOps=_placeOps; globalThis.__computeDays=computeDays; ' +
+    'globalThis.__get=function(){return {ps:_projectStart,pe:_projectEnd,as:_ganttAxisStart,ae:_ganttAxisEnd,days:_days.length};};', s);
+  return s;
+}
+
+// ── G-1: bounds are correct with construction-only ops (baseline, no pollution) ──
+const sbClean = mkSandbox(realOps.slice());
+sbClean.__computeDays();
+const clean = sbClean.__get();
+assert(clean.pe === realProjectEnd, 'G-1 clean _projectEnd equals the real construction max end_ts');
+
+// ── G-2/G-3: bounds are UNCHANGED by a bookkeeping op mixed in — THE regression gate ──
+const pollutedList = realOps.slice(); pollutedList.push(bookkeepingOp);
+pollutedList.sort((x, y) => x.start_ts - y.start_ts);
+const sbPolluted = mkSandbox(pollutedList);
+sbPolluted.__computeDays();
+const polluted = sbPolluted.__get();
+assert(polluted.pe === realProjectEnd,
+  'G-2 _projectEnd (REAL playback bounds) ignores BUILDING_OPEN — was ' +
+  (polluted.pe === bookkeepingOp.end_ts ? 'WRONGLY equal to the bookkeeping op\'s wall-clock end' : 'correct') +
+  ` (real=${new Date(realProjectEnd).toISOString().slice(0,10)} got=${new Date(polluted.pe).toISOString().slice(0,10)})`);
+assert(polluted.ae <= realProjectEnd,
+  'G-3 _ganttAxisEnd (DISPLAY axis) also ignores it — axis=' + new Date(polluted.ae).toISOString().slice(0,10));
+assert(polluted.days === clean.days,
+  'G-4 _days (DAY-mode slider granularity) unaffected by the bookkeeping op — days=' + polluted.days);
+
+// ── G-5: _placeOps itself is the actual filter mechanism, not a side effect ──
+const filtered = sbPolluted.__placeOps();
+assert(filtered.length === realOps.length && filtered.every(o => o.op_type === 'ELEMENT_PLACE'),
+  'G-5 _placeOps() returns exactly the ELEMENT_PLACE subset — n=' + filtered.length);
+
+// ── G-6 static: loadOps() itself still has NO op_type filter — the fix must stay scoped to
+// computeDays/buildGanttTasks, not the query (copyGuids(false) legitimately needs the full history).
+const loadOpsSrc = src.slice(src.indexOf('function loadOps()'), src.indexOf('function computeDays()'));
+assert(/FROM kernel_ops WHERE undone = 0 ORDER BY timestamp/.test(loadOpsSrc),
+  'G-6 loadOps() query stays unfiltered — copyGuids(false) still sees the full op history');
+
+// ── G-7 static: buildGanttTasks() carries the same guard (not sliced — needs buildTaskIndex/app.db) ──
+const bgtSrc = src.slice(src.indexOf('function buildGanttTasks()'), src.indexOf('function buildGanttTasks()') + 800);
+assert(/op\.op_type !== 'ELEMENT_PLACE'/.test(bgtSrc),
+  'G-7 buildGanttTasks() skips non-ELEMENT_PLACE ops before grouping into bars');
+
+console.log('\n--- black-box build order (polluted population, as loadOps() actually returns it) ---');
+pollutedList.forEach((o, i) => {
+  const flag = o.op_type !== 'ELEMENT_PLACE' ? '  <-- NOT A CONSTRUCTION OP' : '';
+  console.log(`  #${i + 1} ${o.op_type} guid=${o.output_guid || '(none)'} ` +
+    `storey=${(o.parameters||{}).storey || '_UNKNOWN'} start=${new Date(o.start_ts).toISOString().slice(0,10)}${flag}`);
+});
+
+console.log(`\n§BLACKBOX SUMMARY pass=${pass} fail=${fail}`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
Root cause of the §GANTT_AXIS_OUTLIER symptom (#1175), traced by source read: `streaming.js` commits `BUILDING_OPEN` with no `ts` → `kernel_ops.js` defaults it to `Date.now()` (real wall-clock, not a simulated construction date). `loadOps()` has no `op_type` filter — the one exception in `time_machine.js` where every other `kernel_ops` read filters `op_type='ELEMENT_PLACE'` — so it rides into `_ops`. `buildGanttTasks()` then defaulted its missing `storey`/`phase` to `'_UNKNOWN'`/`'Architecture'`, exactly the bucket the live session traced as "the one outlier bar."

#1175 qualified the DISPLAY axis so the chart no longer stretches to cover it, but `_projectStart`/`_projectEnd` — the real playback bounds scrubbing/`renderAtTime` use — stayed polluted, unmeasured until now. Confirmed headlessly: real span 416d, polluted span 20669d, ending on today's real date.

Fix is scoped to exactly the two functions that build the construction timeline from `_ops` (`computeDays`, `buildGanttTasks`) via a new `_placeOps()` filter — **not** `loadOps()` itself, since `copyGuids(false)` legitimately wants the full mixed `kernel_ops` history for its "copy all" mode.

- `witness_gantt_ops_blackbox.js` slices the real shipped `_placeOps`/`computeDays` out of the file and proves it both ways: fails outright against pre-fix `main`, passes 7/7 against this fix.
- Full existing Gantt witness suite re-run unchanged, still green (145/145) — none of those fixtures ever commit a `BUILDING_OPEN` op, so this was invisible to headless testing until traced from source.
- `sw.js` CACHE_VERSION v943 → v944.

## Test plan
- [x] `witness_gantt_ops_blackbox.js` — 7/7, RED against pre-fix main, GREEN against this fix
- [x] Full Gantt witness suite (bar identity, edit coherence/constraints, row order, palette, duration sync, gap1, BOQ4D) — 145/145 unchanged
- [ ] Not yet exercised live in a real browser (same open item as #1175 — this was found by source reading + headless reproduction, not a live session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)