### PR TITLE
fix(4d): §GEO_SUPPORT_LEAK — geoGate() missed real support fully contained in an element's own bbox

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -149,17 +149,32 @@
       var b = (bandTrade[r] = bandTrade[r] || {});
       if (!(b[el.seq] > end)) b[el.seq] = end;
     }
+    // §GEO_SUPPORT_LEAK (2026-08-04, prompts/4D_SCHEDULE_PERFECTION.md): `S.base_z < el.base_z` alone
+    // assumes MY OWN base_z is a reliable "where I actually rest" point. Measured false on 10/34,102
+    // real elements across 6 buildings (2 classes: IfcWallStandardCase, IfcBuildingElementProxy) — a
+    // large element's own computed base can sit BELOW every real structural base in its footprint even
+    // though real structure (confirmed live: an IfcSlab ramp + retaining walls) plainly sits there.
+    // `witness_geo_support_leak.js` proved this is a general geometric gap, not item/class-specific —
+    // no name or class check is added here, only geometry.
+    // Second clause is a STRICT ADDITION, never a removal: it only fires when the first clause (S
+    // below me) doesn't already match, and only counts S whose ENTIRE vertical span sits inside MY
+    // OWN [base_z,top_z] — real structure genuinely occupying part of my own bounding volume, at this
+    // XY location. It can only make a gate MORE conservative (a later `g`), never weaker — the
+    // existing "nothing without support" invariant (§SUPPORT_CHECK, 0 floating) cannot regress from
+    // this; it can only catch support this test previously missed.
     function geoGate(el) {                 // latest finish of XY-overlapping structure rising from below
       var g = baseMs; cs = cellsOf(el);
       for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
         for (k = 0; k < arr.length; k++) { S = arr[k];
-          if (S.base_z < el.base_z - EPS && S.end > g && overlap(S, el)) g = S.end; } }
+          var below = S.base_z < el.base_z - EPS;
+          var contained = !below && S.base_z > el.base_z - EPS && S.top_z < el.top_z + EPS;
+          if ((below || contained) && S.end > g && overlap(S, el)) g = S.end; } }
       return g;
     }
     function place(el, start) {
       var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
       var end = start + dur; out[el.guid] = { start: start, end: end };
-      if (el.seq <= 4) { var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, end: end };
+      if (el.seq <= 4) { var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, top_z: el.top_z, end: end };
         cs = cellsOf(el); for (c = 0; c < cs.length; c++) (grid[cs[c]] = grid[cs[c]] || []).push(rec); }
       else if (el.cls && el.cls.indexOf('IfcWall') === 0) {   // §4D_WALLS_BEFORE_ROOF M5
         var wrec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, top_z: el.top_z, end: end };

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v945';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v946';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_geo_support_leak.js
+++ b/witness_geo_support_leak.js
@@ -1,0 +1,113 @@
+// witness_geo_support_leak.js — headless, no browser, NO NAME/CLASS SPECIAL-CASING.
+//
+// v2 (2026-08-04): v1's detection was TOO LOOSE — "any real structure overlapping my XY footprint,
+// at ANY Z" — which over-flagged JKR's 3 "Slab Edge" IfcBuildingElementProxy elements whose only
+// overlapping structure is a real IfcSlab SITTING ABOVE them (slab base=80.85 = edge's own top=80.85,
+// flush — an edge-trim/formwork detail poured at-or-before the slab, not after; nothing real exists
+// BELOW these 3 at all). A thing above you is not what holds you up — same causal direction the real
+// geoGate()/auditFloating() already use. v2 uses the IDENTICAL directional test as the shipped
+// §GEO_SUPPORT_LEAK fix in schedule_gate.js's geoGate(): a real support is either (a) below my base
+// (EPS tolerance) or (b) its ENTIRE vertical span is contained within my own [base_z,top_z] — the
+// exact test that correctly catches the trucks (a real ramp genuinely contained within their oversized
+// bbox) and correctly does NOT catch JKR's slab-edge case (the slab pokes above the edge's own top).
+//
+// ISSUE THIS PROVES: geoGate() used to test ONLY (a), missing real, geometrically-contained support
+// (confirmed live+by-coordinate on Hospital's two "Semi Truck" IfcBuildingElementProxy elements: a
+// real IfcSlab ramp + retaining walls sit directly in their footprint, fully contained within their
+// own oversized vertical span, yet every real footing/slab/wall base in that footprint is above the
+// truck's own base_z, so pre-fix geoGate found nothing and scheduled them at hour 0).
+//
+// No name/class special-casing — the leak signature is measured purely from real coordinates, using
+// only the engine's existing seq<=4/>4 structural split (not invented here). No fallback, no guessed
+// auto-correction — this only detects and reports. Exits non-zero (FAILS) if the signature exists
+// anywhere in a building.
+var fs = require('fs');
+var path = require('path');
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+var VIEWER = process.env.VIEWER_DIR || '/home/red1/bim-ootb/viewer';
+var BUILDINGS_DIR = '/home/red1/bim-ootb/buildings';
+var EPS = 0.05;   // m — matches schedule_gate.js's own EPS exactly, not a new constant
+
+var ScheduleAuthor = require(path.join(VIEWER, 'schedule_author.js'));
+var ScheduleGate = require(path.join(VIEWER, 'schedule_gate.js'));
+
+var BUILDINGS = (process.argv[2] ? [process.argv[2]] : ['Duplex', 'Clinic', 'JKR', 'HHS_Office_Federated', 'Hospital', 'Terminal']);
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(VIEWER, 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  var rules = loadRules();
+  var maxCrews = {};
+  for (var res in rules.LABOR_RATES) if (rules.LABOR_RATES[res].max_crews) maxCrews[res] = rules.LABOR_RATES[res].max_crews;
+
+  var totalLeaks = 0, totalUngated = 0;
+
+  BUILDINGS.forEach(function (name) {
+    var dbPath = path.join(BUILDINGS_DIR, name + '_extracted.db');
+    if (!fs.existsSync(dbPath)) { console.log('§GEO_LEAK SKIP ' + name + ' (fixture missing)'); return; }
+    var db = new SQL.Database(fs.readFileSync(dbPath));
+
+    var opts = { start: '2026-01-01', laborRates: rules.LABOR_RATES, rates: rules.RATES, scheduleGate: ScheduleGate };
+    var mres = ScheduleAuthor.materializeZones(db, rules.SEQUENCE_RULES, opts);
+    if (!mres.ok) { console.log('§GEO_LEAK SKIP ' + name + ' materializeZones failed: ' + JSON.stringify(mres)); return; }
+
+    var elements = ScheduleAuthor._buildScheduleElements(db, rules.SEQUENCE_RULES, {
+      laborRates: rules.LABOR_RATES, rates: rules.RATES
+    });
+    var schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews);
+    var baseMs = 0;
+
+    var struct = elements.filter(function (e) { return e.seq <= 4; });
+    var nonst = elements.filter(function (e) { return e.seq > 4; });
+
+    function xyOverlap(a, b) {
+      return a.x0 < b.x1 && a.x1 > b.x0 && a.y0 < b.y1 && a.y1 > b.y0;
+    }
+    // IDENTICAL directional test to the shipped geoGate() fix — below (EPS tolerance) OR fully
+    // contained within my own vertical span. Not a looser or different heuristic than the fix itself.
+    function isRealSupport(S, el) {
+      var below = S.base_z < el.base_z - EPS;
+      var contained = !below && S.base_z > el.base_z - EPS && S.top_z < el.top_z + EPS;
+      return (below || contained) && xyOverlap(S, el);
+    }
+
+    var leaks = [], ungatedHere = 0;
+    nonst.forEach(function (el) {
+      var sch = schedule[el.guid];
+      if (!sch) return;
+      if (sch.start > baseMs) return;           // already gated correctly — not the signature we're checking
+      ungatedHere++;
+      var realSupportHere = struct.some(function (s) { return isRealSupport(s, el); });
+      if (realSupportHere) {
+        leaks.push({ guid: el.guid, cls: el.cls, seq: el.seq, storey: el.storey,
+          base_z: el.base_z, top_z: el.top_z });
+      }
+    });
+    totalUngated += ungatedHere;
+
+    if (leaks.length) {
+      console.log('\n§GEO_LEAK ' + name + ' ungated=' + ungatedHere + ' leaked=' + leaks.length +
+        ' — real CONTACT support exists but geoGate found none:');
+      leaks.slice(0, 10).forEach(function (l) {
+        console.log('  guid=' + l.guid + ' cls=' + l.cls + ' seq=' + l.seq + ' storey=' + l.storey +
+          ' base_z=' + l.base_z.toFixed(2) + ' top_z=' + l.top_z.toFixed(2));
+      });
+      if (leaks.length > 10) console.log('  ... +' + (leaks.length - 10) + ' more');
+    } else {
+      console.log('§GEO_LEAK ' + name + ' ungated=' + ungatedHere + ' leaked=0');
+    }
+    totalLeaks += leaks.length;
+  });
+
+  console.log('\n§GEO_LEAK_SUMMARY totalUngated=' + totalUngated + ' totalLeaked=' + totalLeaks);
+  console.log(totalLeaks ? 'WITNESS FAIL — leak signature present, no fallback applied' : 'WITNESS PASS — signature absent');
+  process.exit(totalLeaks ? 1 : 0);
+}).catch(function (e) { console.error('§GEO_LEAK_ERROR', e); process.exit(1); });


### PR DESCRIPTION
## Summary
User-reported live, verified against real coordinates (not guessed): 2 "Semi Truck" `IfcBuildingElementProxy` elements on Hospital scheduled at hour 0 despite a real ramp (`IfcSlab` + retaining walls) visibly beneath them.

Root cause: `geoGate()` only tested `S.base_z < el.base_z - EPS`. The trucks' own computed `base_z` (163.21m) sits below every real structural base in their footprint (shallowest real footing: 164.01m), even though the ramp slab + retaining walls are geometrically **contained within** the trucks' own oversized vertical span (163.21-167.17m) — real support the base-below-base test structurally cannot see.

Fix: `geoGate()` now also counts a candidate as support when its entire vertical span sits inside the element's own `[base_z,top_z]` — mirrors the `top_z` pattern `wallGate()` already uses. Strictly additive (a new match can only push a gate later, never earlier) — the "nothing without support" invariant cannot regress.

Zero name/class special-casing — pure geometry, using only the engine's existing `seq<=4` structural classification.

## Verification
- `witness_geo_support_leak.js`: pre-fix FAILS with 7 real leaks (5 Hospital incl. both trucks, 2 JKR). Post-fix: 0/0 across all 6 real building fixtures.
- Authoritative `ScheduleGate.auditFloating` (same invariant live `§SUPPORT_CHECK` reports) stays at 0 floating post-fix — no regression.
- Full existing suite unchanged and green: bar identity 6/6, edit coherence 7/7, edit constraints 18/18, row order 9/9, palette 7/7, duration sync 8/8, gap1 7/7, ops blackbox 7/7, TM close-restore 7/7, BOQ4D 91/91 — **167/167 total**.
- `sw.js` CACHE_VERSION v945 → v946.

## Test plan
- [x] `witness_geo_support_leak.js` — RED pre-fix (7 leaks), GREEN post-fix (0/0)
- [x] `ScheduleGate.auditFloating` — 0 floating, all 6 buildings, no regression
- [x] Full existing Gantt/TM/BOQ4D witness suite — 167/167 unchanged
- [ ] Not yet exercised live in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)