### PR TITLE
fix(cpe): scrub bar standalone panel + drives POV live + play/pause + selection bearing

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -51,6 +51,11 @@
   var VF_MIN_W = 160, VF_MIN_H = 100;           // px — floor a resize cannot cross
   var VF_MARGIN = 16;                            // px from the viewport edge for the first-open position
   var VF_RESIZE_HANDLE_PX = 16;                  // px — the corner grab square's hit size
+  // §CPE_SCRUB_STANDALONE (2026-08-04) — the scrub bar's own panel, no longer nested under B. Default
+  // width matches B's so the two stack cleanly; default position is directly below B's own default
+  // rect (user: "outside on its own or below the POV") — independent of whether B is actually open.
+  var SCRUB_PANEL_W = VF_DEFAULT_W;              // px
+  var SCRUB_PANEL_GAP = 8;                       // px between B's default rect and the scrub panel
   // ══════════════════════════════════════════════════════════════════════════════════════════════
   // CPE_V — the pasted-console-answers-"which build is this?" string (comment at file top explains
   // why this exists and must be bumped on every behaviour change). Reorganized 2026-08-04 into one
@@ -60,21 +65,38 @@
   // blocks (search `§CPE_SCRUB`, `§CPE_VIEWFINDER`, `§CPE_AIM_PIN`) for the full history/reasoning —
   // this string is a manifest, not a substitute for the spec doc.
   // ══════════════════════════════════════════════════════════════════════════════════════════════
-  var CPE_V = 'v23 (' +
-    // ── 2026-08-04, same day, three changes in sequence — read together ──
-    '§CPE_SCRUB_MAIN_CAM_REGRESSION FIXED: scrubbing the timeline used to move the MAIN canvas ' +
-      'camera (a.camera/a.controls) — wrong, caught live by the user in their own browser. Scrubbing ' +
-      'is now VISUAL-ONLY (playhead + "timeline NN.N%" readout) and touches NO camera at all, main ' +
-      'or B\'s inset — an in-between fix that routed scrub into B\'s camera only was written and then ' +
-      'reverted before landing, simplified further at the user\'s own request; ' +
-    '§CPE_SCRUB_BAR_GATED the scrub bar\'s existence is now gated to B (built/torn down inside ' +
-      '_toggleViewfinder, alongside the vf panel) instead of always present from editor-open — ' +
-      'PROVISIONAL, not settled architecture: the bar\'s permanent home (standalone widget vs docked ' +
-      'under B) is an OPEN QUESTION left for a future session, since it needs to carry more later ' +
-      '(pin-drop, Find/Clash drag) per the user\'s own words — see the spec doc\'s DONE block; ' +
-    '§CPE_VIEWFINDER_EYE_ICON the #cpe-vf-toggle icon now swaps open/slashed with vfOn, reading ' +
-      'panels.js ICONS.eyeOpen/eyeOff — NOT ICONS.eye, which is actually Lucide\'s "scan-eye", a ' +
-      'different shape repurposed elsewhere for an unrelated Role View toggle; ' +
+  var CPE_V = 'v24 (' +
+    // ── 2026-08-05, same day, one connected batch — read together, supersedes the v23 entries below ──
+    '§CPE_SCRUB_STANDALONE the timeline is now its own draggable panel (#cpe-scrub-panel), default ' +
+      'position directly below B\'s default rect — resolves the v23 §CPE_SCRUB_BAR_GATED OPEN ' +
+      'QUESTION ("standalone widget vs docked under B"); built/torn down with the editor itself, ' +
+      'no longer coupled to B\'s toggle; B stays display-only (user: "pov box is purely display for ' +
+      'user bearing" — no drop/raycast interaction on it, this panel is the interactive one); ' +
+    '§CPE_SCRUB_VF_LIVE a scrub drag drives B\'s inset camera (vfCam) again — this is the mid-fix cut ' +
+      'that was written+witnessed then reverted before the v23 #1177 landing; restored now that B is ' +
+      'a stable, separate concern from the main-canvas invariant #1177 actually protects (main camera/ ' +
+      'controls are still NEVER touched by any scrub, drag or click); ' +
+    '§CPE_SCRUB_READONLY the bar no longer spawns or selects sticks on click (retires the old click- ' +
+      'to-spawn path) — sticks show as read-only BLUE tick lines only; editing (add/select/move/ ' +
+      'remove) happens the original way, via the canvas pipe or the row list, never the scrub bar; ' +
+    '§CPE_STICK_TIME_SYNC_F1 the readout is mm:ss / total film length, not a bare percentage; ' +
+    '§CPE_SCRUB_PLAY a play/pause transport button in the scrub panel, reusing _previewFly()\'s own ' +
+      'pose source with new pause/resume support (_state._flyPauseAt/_flyResume) — additive only, ' +
+      'the existing #cpe-preview button in #cpe-panel is untouched; ' +
+    '§CPE_VF_EYE_SPRITES (PR bim-ootb#1179, undocumented here until now) the #cpe-vf-toggle icon uses ' +
+      'real open/shut eyelid PNG sprites (viewer/icons/eye_open.png, eye_closed.png) — NOT the Lucide ' +
+      'slashed-eye pair, which read as "eye with a line through it" rather than an actual shut eyelid; ' +
+      'ICONS.eyeOpen/eyeOff were removed from panels.js as dead code once this landed; ' +
+    // ── 2026-08-04, v23 — HISTORICAL, superseded by the entries above; kept for the reader tracing ' +
+    //    how this evolved, not current behaviour ──
+    '§CPE_SCRUB_MAIN_CAM_REGRESSION (v23) scrubbing the timeline used to move the MAIN canvas ' +
+      'camera (a.camera/a.controls) — wrong, caught live by the user. Scrubbing was made VISUAL-ONLY, ' +
+      'touching no camera at all — since refined by §CPE_SCRUB_VF_LIVE above: B\'s inset camera is ' +
+      'driven again, the main canvas invariant this entry actually protects still holds; ' +
+    '§CPE_SCRUB_BAR_GATED (v23) the scrub bar\'s existence was gated to B — superseded by ' +
+      '§CPE_SCRUB_STANDALONE above; ' +
+    '§CPE_VIEWFINDER_EYE_ICON (v23) the #cpe-vf-toggle icon swapped open/slashed with vfOn, reading ' +
+      'panels.js ICONS.eyeOpen/eyeOff — superseded by §CPE_VF_EYE_SPRITES above; ' +
     // ── 2026-08-04, Part C ──
     '§CPE_AIM_PIN click an object/room in the canvas with a band selected to pin its look direction ' +
       'there (rotation only, never position); the pin wins outright inside its own band\'s Voronoi ' +
@@ -136,6 +158,9 @@
   // `_vfRender()` calls a single rehearsal makes; reset by `_vfPerfReset()` at the top of each
   // `_previewFly()` run.
   var _vfPerf = { n: 0, sum: 0, max: 0 };
+  // §CPE_SCRUB_STANDALONE (2026-08-04) — where the user last dragged the standalone scrub panel,
+  // same session-only scope as `_panelPos`/`_vfRect` above.
+  var _scrubRect = null;
   function A() { return window.APP; }
 
   // ══════════════════ scene objects ══════════════════
@@ -1142,52 +1167,64 @@
     }
     return best / (pts.length - 1);
   }
-  // Inverse of the above (spec point 4: "the inverse of that arc-length lookup"). Given a tNorm on
-  // the scrub bar, find the world point the pipe already draws there (`plan.poseAt(tn)` — one pose
-  // source, never a guessed re-derivation) and match it to the nearest point on the WALK'S OWN
-  // curve, `_state.flowHosed` — index-aligned with `_state.flowRaw` (§CPE_STICK_ANCHOR), which is
-  // what `_spawnStick` needs (`hit.i` indexes `flowRaw`, `hit.s` is that index's arc fraction). Only
-  // the walk is authorable (same rule `_hitTestPath` enforces for a screen click — a tNorm outside
-  // the walk window has no flowRaw point to match at all, so it is refused, not clamped into one).
-  function _tnormToStickHit(tn) {
-    var win = _walkWindow();
-    if (!win || tn < win.spin || tn > win.out) return null;
-    var pts = _state.flowHosed, frac = _state.flowFrac;
-    if (!pts || pts.length < 2) return null;
-    var target = _state.plan.poseAt(tn);
-    var best = 0, bd = Infinity;
-    for (var i = 0; i < pts.length; i++) {
-      var d = (pts[i].x - target.x) * (pts[i].x - target.x) + (pts[i].y - target.y) * (pts[i].y - target.y) +
-              (pts[i].z - target.z) * (pts[i].z - target.z);
-      if (d < bd) { bd = d; best = i; }
-    }
-    return { i: best, s: frac[best], p: { x: pts[best].x, y: pts[best].y, z: pts[best].z } };
+  function _fmtMMSS(sec) {
+    sec = Math.max(0, sec || 0);
+    var m = Math.floor(sec / 60), s = Math.floor(sec % 60);
+    return m + ':' + (s < 10 ? '0' : '') + s;
   }
-
-  // Called from `_toggleViewfinder`'s ON branch only (2026-08-04 provisional simplification — see
-  // that function's own comment and this file's DONE block: the scrub bar's permanent place is an
-  // OPEN QUESTION for a future session, not settled by nesting it under B here).
-  function _buildScrub(panel) {
-    var wrap = document.createElement('div');
-    wrap.id = 'cpe-scrub-wrap';
-    wrap.style.cssText = 'padding:6px 12px 8px;border-top:1px solid #3a3f47';
-    wrap.innerHTML =
-      '<div style="font-size:10px;color:#888;margin-bottom:3px">timeline <span id="cpe-scrub-tn" style="color:#4fc3f7;font-family:monospace"></span> ' +
-        '<span style="color:#666">— drag to scrub, click the shaded stretch to drop a stick</span></div>' +
-      '<div id="cpe-scrub-track" style="position:relative;height:' + SCRUB_H + 'px;background:#15181c;' +
-        'border:1px solid #3a3f47;border-radius:3px;cursor:pointer;user-select:none"></div>';
-    // Inserted right after the hint strip, ahead of the row list — spec point 1: "ADDED alongside
-    // the existing band row-list (not replacing it)".
-    var hint = document.getElementById('cpe-hint');
-    if (hint && hint.nextSibling) panel.insertBefore(wrap, hint.nextSibling);
-    else panel.appendChild(wrap);
-    return wrap;
+  // §CPE_SCRUB_STANDALONE (2026-08-04) — the scrub bar's own panel, no longer nested under B and no
+  // longer touching #cpe-panel at all. Resolves the OPEN QUESTION this file's own DONE block left
+  // ("standalone widget vs docked under B" — user: "that timeline was supposed to be standalone
+  // widget panel... independent"). Built alongside #cpe-panel at editor-open time (see open()), torn
+  // down alongside it in finish() — never gated to B's toggle, so it now exists whenever the editor
+  // is open and B is purely display/bearing (user, 2026-08-04: "pov box is purely display for user
+  // bearing" — no drop/raycast interaction on it; this panel is the interactive one). Default
+  // position sits directly below B's own default rect so the two read as one cluster even though
+  // they are separate panels.
+  function _buildScrubPanel() {
+    var a = A();
+    var vfDefaultTop = (a.canvas ? a.canvas.clientHeight : window.innerHeight) - VF_DEFAULT_H - VF_MARGIN - 40;
+    var rect = _scrubRect || {
+      left: Math.max(VF_MARGIN, (a.canvas ? a.canvas.clientWidth : window.innerWidth) - SCRUB_PANEL_W - VF_MARGIN),
+      top: vfDefaultTop + VF_DEFAULT_H + SCRUB_PANEL_GAP
+    };
+    var d = document.createElement('div');
+    d.id = 'cpe-scrub-panel';
+    d.style.cssText = 'position:fixed;left:' + rect.left + 'px;top:' + rect.top + 'px;width:' + SCRUB_PANEL_W + 'px;' +
+      'z-index:9997;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:6px;' +
+      'box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:system-ui,sans-serif';
+    d.innerHTML =
+      '<div id="cpe-scrub-title" title="drag to move the timeline" style="padding:4px 8px;cursor:move;' +
+        'user-select:none;display:flex;align-items:center;justify-content:space-between;' +
+        'border-bottom:1px solid #3a3f47">' +
+        '<span style="font:600 10px system-ui,sans-serif;color:#4fc3f7">Timeline</span>' +
+        '<span id="cpe-scrub-tn" style="color:#888;font:400 10px monospace"></span></div>' +
+      '<div style="padding:6px 8px 8px;display:flex;align-items:center;gap:6px">' +
+        // §CPE_SCRUB_PLAY (task #8) — play/pause the rehearsal from here, reusing _previewFly's own
+        // pose source. Additive only: the existing #cpe-preview button in #cpe-panel is untouched.
+        '<button id="cpe-scrub-play" title="play the rehearsal from here" style="flex:none;width:22px;height:22px;' +
+          'padding:0;font-size:11px;background:#2a2e34;color:#ddd;border:1px solid #4a4f57;border-radius:4px;' +
+          'cursor:pointer;display:flex;align-items:center;justify-content:center">▶</button>' +
+        '<div id="cpe-scrub-track" style="position:relative;flex:1;height:' + SCRUB_H + 'px;background:#15181c;' +
+          'border:1px solid #3a3f47;border-radius:3px;cursor:pointer;user-select:none"></div>' +
+      '</div>';
+    document.body.appendChild(d);
+    d._dragStrip = 26;
+    if (a && typeof a._makeDraggable === 'function') a._makeDraggable(d);
+    var save = function() {
+      var r = d.getBoundingClientRect();
+      _scrubRect = { left: Math.round(r.left), top: Math.round(r.top) };
+    };
+    d.addEventListener('pointerup', save);
+    return d;
   }
 
   function _renderScrub() {
     var track = document.getElementById('cpe-scrub-track');
     if (!track || !_state) return;
     track.innerHTML = '';
+    // Hoisted once per render (not per-tick/per-drag-frame) — _buildOverride() deep-copies bands/hose.
+    var _filmTotal = _buildOverride()._total;
     // Clip window shading — reuses `s.clipIn`/`s.clipOut` directly (spec point 5), not a new range.
     if (_state.clipIn > 0 || _state.clipOut < 1) {
       var clipEl = document.createElement('div');
@@ -1208,12 +1245,15 @@
       if (!_state.bands[i]._stick) continue;
       var tn = _bandTNorm(i);
       if (tn == null) continue;
+      // Blue lines only (user, 2026-08-04: "let the scrubber shows where the sticks are as blue
+      // lines"). Read-only reflection of selection state set elsewhere (canvas/row) — the bar itself
+      // has no click reaction on a tick, see _wireScrub below.
       var sel = _state.held && _state.held.b === i;
       var tick = document.createElement('div');
-      tick.title = _labelOf(i) + ' — ' + (tn * 100).toFixed(1) + '% of the film';
+      tick.title = _labelOf(i) + ' — ' + _fmtMMSS(tn * _filmTotal) + ' into the film';
       tick.style.cssText = 'position:absolute;top:2px;bottom:2px;width:' + SCRUB_TICK_W + 'px;' +
         'left:calc(' + (tn * 100) + '% - ' + (SCRUB_TICK_W / 2) + 'px);' +
-        'background:' + (sel ? '#ff8c00' : '#' + CPE_STICK_RED.toString(16).padStart(6, '0')) +
+        'background:' + (sel ? '#ff8c00' : '#' + CPE_STICK_BLUE.toString(16).padStart(6, '0')) +
         ';border-radius:1px;pointer-events:none';
       track.appendChild(tick);
     }
@@ -1224,24 +1264,31 @@
     head.style.cssText = 'position:absolute;top:-2px;bottom:-2px;width:2px;left:calc(' + (tnP * 100) + '% - 1px);' +
       'background:#4fc3f7;pointer-events:none;box-shadow:0 0 4px rgba(79,195,247,0.9)';
     track.appendChild(head);
+    // §CPE_STICK_TIME_SYNC F1 (spec Part F1) — mm:ss / total, not a bare %. `_total` is the same
+    // real film duration §CPE_ROOM_TITLE already reads for its own live caption, not a second clock.
     var lbl = document.getElementById('cpe-scrub-tn');
-    if (lbl) lbl.textContent = (tnP * 100).toFixed(1) + '%';
+    if (lbl) lbl.textContent = _fmtMMSS(tnP * _filmTotal) + ' / ' + _fmtMMSS(_filmTotal);
   }
 
-  // §CPE_SCRUB — simplified 2026-08-04 (caught live in the browser, then simplified further by the
-  // user rather than perfected in place): scrubbing is VISUAL-ONLY. It moves NO camera, main or B's
-  // inset — only the playhead position and the "timeline NN.N%" readout update. An in-between fix
-  // that routed scrub into B's camera only was written and then reverted before landing: the user
-  // asked for the simpler cut now, and left "scrub drives B's camera" as deliberately DEFERRED
-  // future work — see this file's own DONE block in the spec doc — not something to rebuild here.
-  // `plan.poseAt` is still sampled — read-only, informational, useful to a witness or a future
-  // session — but nothing in this function writes to any camera.
+  // §CPE_SCRUB_VF_LIVE (restored 2026-08-04) — a scrub drag drives ONLY B's inset camera (`vfCam`),
+  // never the main canvas camera/controls. This is the mid-fix cut that was written, witnessed, then
+  // reverted before #1177 landed in favour of a simpler visual-only cut — the spec doc's own OPEN
+  // QUESTION named this "deliberately DEFERRED future work", not dropped. Restoring it now: the
+  // #1177 regression's actual invariant (main camera/controls untouched by any scrub) is preserved —
+  // this only ever writes `_state.vfCam`, which #1177 never touched in the first place.
   function _scrubTo(tn) {
     if (!_state) return null;
     tn = Math.max(0, Math.min(1, tn));
     _state.scrubTn = tn;
     _renderScrub();
-    return (_state.plan && typeof _state.plan.poseAt === 'function') ? _state.plan.poseAt(tn) : null;
+    var p = (_state.plan && typeof _state.plan.poseAt === 'function') ? _state.plan.poseAt(tn) : null;
+    if (p && _state.vfOn && _state.vfCam) {
+      _state.vfCam.position.set(p.x, p.y, p.z);
+      _state.vfCam.lookAt(p.tx, p.ty, p.tz);
+      var a = A();
+      if (a.markDirty) a.markDirty();
+    }
+    return p;
   }
 
   function _wireScrub(track) {
@@ -1267,17 +1314,13 @@
         console.log('§CPE_SCRUB dragged tn=' + (_state.scrubTn || 0).toFixed(3) + ' — same pose as a normal rehearsal at this instant');
         return;
       }
-      // A press that never crossed the slop is a CLICK — spec point 4, same one-grab-split doctrine
-      // §CPE_CLICK_SLOP already uses on the 3D pipe.
+      // §CPE_SCRUB_READONLY (2026-08-04) — a click (no drag) just scrubs to that point, same as a
+      // drag would. The bar no longer spawns or selects sticks on click (user: "clicking on them
+      // has no reaction, user has to do edits the original way on canvas... or the alt-c panel row
+      // rows"). Retires the old click-to-spawn path (formerly G-SCRUB-SPAWN) — stick creation/
+      // selection/removal happens only via the canvas pipe or the row list, never the scrub bar.
       var tn = (ev.clientX - d.r.left) / Math.max(1, d.r.width);
-      tn = Math.max(0, Math.min(1, tn));
-      var hit = _tnormToStickHit(tn);
-      if (!hit) {
-        console.log('§CPE_SCRUB click tn=' + tn.toFixed(3) + ' — outside the authorable walk window, no stick spawned; scrubbing to it instead');
-        _scrubTo(tn);
-        return;
-      }
-      _spawnStick(hit);
+      _scrubTo(tn);
     });
   }
 
@@ -1424,31 +1467,14 @@
       var p = _state.plan ? _state.plan.poseAt(_state.scrubTn || 0) : null;
       if (p) { _state.vfCam.position.set(p.x, p.y, p.z); _state.vfCam.lookAt(p.tx, p.ty, p.tz); }
       if (a.markDirty) a.markDirty();
-      // §CPE_SCRUB (2026-08-04 provisional simplification, NOT settled — see this file's DONE block
-      // in the spec doc): the scrub bar is built here, alongside B, rather than existing on its own
-      // at editor-open time. The user's own words on this NOT being final: "that timeline was
-      // supposed to be standalone widget panel... independent because it is supposed to do more
-      // next ie pin point drop, Find / Clash drop... let's have the next prompts/# session figure
-      // that out — as now just get the canvas part to be its true self." Shipped this way only to
-      // get the main-canvas regression fixed today; a future session may need to un-nest this.
-      var cpePanel = document.getElementById('cpe-panel');
-      if (cpePanel && !document.getElementById('cpe-scrub-track')) {
-        _buildScrub(cpePanel);
-        var scrubTrack = document.getElementById('cpe-scrub-track');
-        if (scrubTrack) _wireScrub(scrubTrack);
-        _renderScrub();
-      }
-      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; scrub bar shown (provisional: nested under B, see DONE block)');
+      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; display-only, no drop interaction — see §CPE_SCRUB_STANDALONE for the interactive timeline');
     } else {
       var panel = document.getElementById('cpe-vf-panel');
       if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
       if (a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
       if (btn) { btn.style.color = '#888'; btn.style.borderColor = '#4a4f57'; }
-      // The scrub bar goes with B — see the ON branch's comment on why this pairing is provisional.
-      var scrubWrap = document.getElementById('cpe-scrub-wrap');
-      if (scrubWrap && scrubWrap.parentNode) scrubWrap.parentNode.removeChild(scrubWrap);
       if (a.markDirty) a.markDirty();
-      console.log('§CPE_VF off — panel removed, render hook cleared, scrub bar removed, zero per-frame cost');
+      console.log('§CPE_VF off — panel removed, render hook cleared, zero per-frame cost (timeline stays open — see §CPE_SCRUB_STANDALONE)');
     }
   }
   function _vfTeardown() {
@@ -1456,8 +1482,11 @@
     var panel = document.getElementById('cpe-vf-panel');
     if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
     if (a && a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
-    // The scrub bar is a child of #cpe-panel (removed by finish() itself right after this call), so
-    // no separate removal is needed here — listed for the reader, not left implicit.
+  }
+  // §CPE_SCRUB_STANDALONE teardown — mirrors _vfTeardown's shape, called from finish() alongside it.
+  function _scrubPanelTeardown() {
+    var panel = document.getElementById('cpe-scrub-panel');
+    if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
   }
   function _wireViewfinderToggle() {
     var btn = document.getElementById('cpe-vf-toggle');
@@ -1490,6 +1519,36 @@
       pv.title = stale ? 'the path changed since the last preview' : 'you have seen this version';
       pv.disabled = !!_state.flying;
     }
+    // §CPE_SCRUB_PLAY (task #8) — the scrub panel's own transport button, additive to #cpe-preview
+    // above, never replacing it. Reflects the SAME _state.flying/flyPaused this function already
+    // drives #cpe-preview from, no second state.
+    var sp = document.getElementById('cpe-scrub-play');
+    if (sp) {
+      sp.textContent = _state.flying ? (_state.flyPaused ? '▶' : '⏸') : '▶';
+      sp.title = _state.flying ? (_state.flyPaused ? 'resume the rehearsal' : 'pause the rehearsal') : 'play the rehearsal from here';
+    }
+  }
+  // §CPE_SCRUB_PLAY — the play/pause button's click handler. Starting reuses _previewFly() exactly
+  // (same pose source, same buildup/room-title/ghost-ground wiring); pause/resume use the hooks
+  // _previewFly() exposes on _state (_flyPauseAt/_flyResume) while a rehearsal is in flight.
+  function _wireScrubPlay() {
+    var btn = document.getElementById('cpe-scrub-play');
+    if (!btn) return;
+    btn.addEventListener('click', function() {
+      if (!_state) return;
+      if (_state.flying && !_state.flyPaused) {
+        if (_state._flyPauseAt) _state._flyPauseAt();
+        console.log('§CPE_SCRUB_PLAY paused u=' + (_state.flyPausedU || 0).toFixed(3));
+      } else if (_state.flying && _state.flyPaused) {
+        if (_state._flyResume) _state._flyResume();
+        console.log('§CPE_SCRUB_PLAY resumed');
+      } else {
+        console.log('§CPE_SCRUB_PLAY started');
+        _previewFly();
+        return;   // _previewFly's own _renderWhole() calls already sync the button
+      }
+      _renderWhole();
+    });
   }
   // ══ §CPE_IDB_PATH_STORE — named plans, in IndexedDB, per building ═══════════════════════════
   // Specced 2026-07-27 ("later should be its own in IndexDB first separate table of saved
@@ -1776,10 +1835,31 @@
     // §CPE_VIEWFINDER's G-PERF-1: reset the per-rehearsal accumulator so the exit log below reports
     // THIS run's cost, not a running total across preview clicks.
     if (_state.vfOn) _vfPerfReset();
+    s.flyPaused = false;
     var startFly = function() {
       var myFly = ++s.flyId, t0 = performance.now(), frames = 0;
-      (function step() {
+      // §CPE_SCRUB_PLAY (task #8) — pause/resume hooks, same shape as tour.js's own §TOUR_TIMELINE_
+      // SCRUB "pause HOLDS the pose: nothing writes the camera while paused" (tour.js:1527). Pausing
+      // just stops step() from scheduling its next rAF — no cleanup runs, nothing is restored, since
+      // this is not completion. Resuming re-anchors t0 so u continues exactly where it left off.
+      s._flyPauseAt = function() {
+        if (myFly !== s.flyId || s.flyPaused) return;
+        s.flyPausedU = Math.min(1, (performance.now() - t0) / dur);
+        s.flyPaused = true;
+      };
+      s._flyResume = function() {
+        if (myFly !== s.flyId || !s.flyPaused) return;
+        t0 = performance.now() - (s.flyPausedU || 0) * dur;
+        s.flyPaused = false;
+        requestAnimationFrame(step);
+      };
+      // §CPE_SCRUB_PLAY: named-function-expression `step` was only visible to ITSELF (for the
+      // recursive rAF call below), not to `_flyResume` above in the enclosing closure — caught live
+      // by the witness (ReferenceError on the first real pause/resume). Bound to `var step` instead
+      // so both closures resolve the same function.
+      var step = function step() {
         if (!_state || myFly !== _state.flyId) return;
+        if (s.flyPaused) return;   // _flyResume() re-kicks the chain; nothing to do meanwhile
         var u = Math.min(1, (performance.now() - t0) / dur);
         var tn = t0N + (t1N - t0N) * u;
         // §CPE_SCRUB/§CPE_VIEWFINDER: the ONE place a pose is applied to the live camera — see
@@ -1830,6 +1910,8 @@
         if (a.roomTitleLiveStop) a.roomTitleLiveStop();
         if (a.dayCounterLiveStop) a.dayCounterLiveStop();
         _state.flying = false;
+        // §CPE_SCRUB_PLAY: natural completion — clear the pause hooks, this run is over, not paused.
+        s._flyPauseAt = null; s._flyResume = null; s.flyPaused = false;
         console.log('§CPE_PREVIEW done frames=' + frames + ' msPerFrame=' + msPerFrame.toFixed(1) +
           ' buildup=' + (s.buildup ? 1 : 0) + ' — camera restored to the editing pose');
         // §CPE_VIEWFINDER G-PERF-1: measured (not guessed) ms/frame B's OWN scissor render pass
@@ -1837,7 +1919,8 @@
         // (off, or torn down mid-flight), which is itself the "zero cost when off" claim made numeric.
         if (_state.vfOn) _vfPerfLog();
         _renderWhole();
-      })();
+      };
+      step();
     };
     // §CPE_BUILDUP_FOLLOW_TM — this used to call tmOrderByCameraPath UNCONDITIONALLY, with no
     // tmScheduleSource() consultation at all: the whole source-selection branch existed only in
@@ -1900,6 +1983,15 @@
     // disabling controls would disable the way you choose which axes a drag moves in. Dragging and
     // orbiting are told apart by the hit-test on pointerdown, not by a mode.
     if (!same) console.log('§CPE_SELECT band=' + bi + ' zone=' + zone + ' (canvas stays live)');
+    // §CPE_SCRUB_BEARING (2026-08-05, user: "the scrubber and pov correlates which stick the user
+    // selects, they indicate so user gets perfect bearing") — selecting a stick, from EITHER the
+    // canvas (line ~2255) or the row list (line ~1034), moves the playhead (and B's camera, if on)
+    // to that stick's own film position. Reuses _scrubTo verbatim — same pose source, same B-live
+    // wiring §CPE_SCRUB_VF_LIVE already established, no second path.
+    if (!same && _state.bands[bi] && _state.bands[bi]._stick) {
+      var bearTn = _bandTNorm(bi);
+      if (bearTn != null) _scrubTo(bearTn);
+    }
     _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
     _pulse();
     if (frame) _frameBand(bi);
@@ -2417,6 +2509,8 @@
         // §CPE_PREVIEW_BUTTON: edits counts every landed change; previewedAt is the edit the user
         // has actually seen. Equal = "you have seen this version".
         edits: 0, previewedAt: 0, flying: false,
+        // §CPE_SCRUB_PLAY (task #8): pause/resume state for the scrub panel's transport button.
+        flyPaused: false, flyPausedU: 0, _flyPauseAt: null, _flyResume: null,
         userTotal: null, fps: ctx.fps || 15, filmPts: null, plan: plan,
         camSave: { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
                    tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z },
@@ -2431,11 +2525,14 @@
         'm speed=' + _state.speed.toFixed(2) + 'm/s total=' + ctx.durationSec.toFixed(1) + 's');
 
       var panel = _buildPanel();
-      // §CPE_SCRUB (2026-08-04 provisional simplification — see this file's DONE block in the spec
-      // doc for why, and that it is NOT settled architecture): the scrub bar is built/torn down
-      // alongside B, inside _toggleViewfinder — not unconditionally here. `scrubTn` still gets a
-      // default so _renderScrub (a no-op until the track exists) has something sane to read later.
+      // §CPE_SCRUB_STANDALONE — built unconditionally alongside #cpe-panel, independent of B's
+      // toggle (resolves the OPEN QUESTION the #1177 fix left open). _renderScrub() itself is
+      // already invoked from every mutation path via _redrawScene() (see that function's own
+      // §CPE_SCRUB comment) — nothing extra to wire for refresh, only initial build.
       _state.scrubTn = 0;
+      _buildScrubPanel();
+      _wireScrub(document.getElementById('cpe-scrub-track'));
+      _wireScrubPlay();
       // §CPE_VIEWFINDER: the eye-icon toggle button lives in the panel's title row (_buildPanel).
       _wireViewfinderToggle();
       // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted
@@ -2575,6 +2672,9 @@
         // an un-torn-down hook is exactly the "wired into the bake" risk the spec calls out, even
         // though the bake itself never sets or calls this function.
         _vfTeardown();
+        // §CPE_SCRUB_STANDALONE: same lifecycle rule — the timeline panel is independent of B but
+        // must not outlive the editor either.
+        _scrubPanelTeardown();
         if (panel.parentNode) panel.parentNode.removeChild(panel);
         var total = ov ? ov._total : _state.baseTotal;
         if (a.controls) a.controls.enabled = _state.controlsWere;
@@ -2714,8 +2814,11 @@
         // so G-VF-1 can prove B tracks the main camera during a REHEARSAL-style pose application
         // without needing to run and wait out a full real Preview flight.
         _applyCameraPoseForTest: function(tn) { return _applyCameraPose(tn); },
-        _scrubHitAt: function(tn) { return _tnormToStickHit(tn); },
         _bandTNorm: function(bi) { return _state ? _bandTNorm(bi) : null; },
+        // §CPE_SCRUB_PLAY (task #8) witness hooks — real pause/resume, not a re-implementation.
+        _flyPause: function() { return _state && _state._flyPauseAt ? (_state._flyPauseAt(), true) : false; },
+        _flyResume: function() { return _state && _state._flyResume ? (_state._flyResume(), true) : false; },
+        _flyState: function() { return _state ? { flying: _state.flying, paused: _state.flyPaused, u: _state.flyPausedU } : null; },
         // Ground truth for G-SCRUB-1/G-VF-1 — the SAME `_state.plan.poseAt` every render (tube,
         // scrub, B) samples, called directly and read-only (mutates nothing), same precedent as
         // `_probeOverride`/`_probeLengths` above.
@@ -2754,7 +2857,18 @@
         // function a canvas click resolves to (the raycast itself is UI-only and not what G-PIN-1 is
         // about) — deterministic against a known world point, same precedent as `_scrubTo`.
         _setPin: function(bi, p) { return _setPin(bi, p, 'src=witness'); },
-        _unpinBand: function(bi) { return _unpinBand(bi); }
+        _unpinBand: function(bi) { return _unpinBand(bi); },
+        // §CPE_SCRUB_BEARING witness hook — the real selection entry point both the canvas and the
+        // row list already call, not a re-implementation.
+        _holdForTest: function(bi, zone) { return _hold(bi, zone, false); },
+        // Deterministic spawn for buildings whose seeded path has no middle sticks — calls the real
+        // `_spawnStick` mutation with a hit built from the walk's own arc-fraction array, same
+        // precedent as `_setPin` bypassing the UI raycast for a known input.
+        _spawnStickForTest: function(frac) {
+          if (!_state || !_state.flowRaw || !_state.flowFrac) return false;
+          var idx = Math.max(0, Math.min(_state.flowFrac.length - 1, Math.round(_state.flowFrac.length * frac)));
+          return _spawnStick({ i: idx, s: _state.flowFrac[idx] });
+        }
       };
       clearInterval(_attach);
     }

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -1,36 +1,39 @@
 // WITNESS — §CPE_SCRUB / §CPE_VIEWFINDER (Parts A and B).
 // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part A §CPE_SCRUB, Part B §CPE_VIEWFINDER.
 //
-// §CPE_SCRUB gates REWRITTEN 2026-08-04 — a real regression, caught live by the user in their own
-// browser: scrubbing the timeline used to move the MAIN canvas camera (`A.camera`/`A.controls`),
-// which is wrong — the main canvas is the user's traditional editing view and must stay exactly
-// where they left it, always. The fix was then simplified further, past "route scrub into B's
-// camera instead": scrubbing is now VISUAL-ONLY (playhead + tNorm readout), touching NO camera at
-// all, and the scrub bar itself only exists while B is open (a provisional pairing, not settled
-// architecture — see the spec doc's DONE block). The OLD G-SCRUB-1 (scrub reproduces poseAt on the
-// LIVE camera) asserted exactly the behaviour that was the bug — it is GONE, replaced below.
+// REWRITTEN 2026-08-05 — the scrub bar became its own standalone panel (§CPE_SCRUB_STANDALONE),
+// independent of B's toggle, and a scrub drag now legitimately drives B's inset camera again
+// (§CPE_SCRUB_VF_LIVE — the mid-fix cut from the #1177 session, restored). The v23-era gates that
+// asserted the OPPOSITE of both (bar gated to B; B's camera never moves on scrub) are GONE, replaced
+// below — see CPE_V's v24 entry in cinema_path_editor.js for the full change list this witness
+// re-verifies. The one invariant that has NEVER changed across any of these revisions — the MAIN
+// canvas camera/controls must stay byte-identical across any scrub, drag or click — is still the
+// single most important gate here (G-SCRUB-NOCAM), unmodified in spirit from the original #1177 fix.
 //
 // ISSUE EACH GATE PROVES OR DISPROVES:
-//   G-SCRUB-GATED  the scrub bar does not exist in the DOM while B is off (fresh editor open), and
-//                  does exist once B is toggled on — the bar's existence is gated to B, not a
-//                  permanent fixture (2026-08-04 provisional simplification).
-//   G-SCRUB-VISUAL a scrub drag still updates the playhead position and the "timeline NN.N%"
-//                  readout text — the feature has a real effect, it just isn't a camera move.
-//   G-SCRUB-NOCAM  THE regression gate: the main camera's position AND orbit target, and B's inset
-//                  camera's position, are all byte-identical before and after a scrub drag. Proves
-//                  the bug (scrub moving the main canvas) cannot recur silently.
-//   G-SCRUB-SPAWN  clicking the (now B-gated) bar at tNorm=X still spawns a band at the same world
-//                  point the pipe's own arc-length placement (plan.poseAt(X)) gives for X — a REAL
-//                  pointer click on the DOM track, exercising the actual click-vs-drag slop split.
-//   G-SCRUB-TEARDOWN  toggling B back off removes the scrub bar from the DOM too.
+//   G-SCRUB-STANDALONE  the scrub panel exists in the DOM as soon as the editor opens, BEFORE B is
+//                       ever toggled on — proves the panel is independent of B, not nested/gated.
+//   G-SCRUB-NOCAM       the main camera's position AND orbit target are byte-identical before/after
+//                       a scrub drag (B off) — the regression gate, unchanged in spirit since #1177.
+//   G-SCRUB-VISUAL      a scrub drag still updates the playhead and the "mm:ss / mm:ss" readout text.
+//   G-SCRUB-VF-LIVE     with B ON, a scrub drag drives B's inset camera (vfCam) to plan.poseAt(tn) —
+//                       while the main camera stays untouched in the SAME drag. Proves the restored
+//                       §CPE_SCRUB_VF_LIVE feature without reopening the #1177 regression.
+//   G-SCRUB-NOSPAWN     clicking the bar (0px press, same click-vs-drag doctrine as before) does NOT
+//                       spawn a new band — retires the old G-SCRUB-SPAWN gate, which asserted the
+//                       opposite (§CPE_SCRUB_READONLY: creation only via canvas/row list now).
+//   G-SCRUB-TICK-BLUE   a stick's tick mark on the bar renders in CPE_STICK_BLUE, not the old red.
+//   G-SCRUB-PERSISTS    toggling B off does NOT remove the scrub panel (opposite of the old
+//                       gated-to-B behaviour) — it only disappears when the EDITOR closes.
+//   G-SCRUB-PLAY        pressing play starts a rehearsal; pause freezes the flight fraction (no
+//                       advance over a real wait); resume continues it — real pause/resume, not a
+//                       screenshot-verified "looks paused".
+//   G-SCRUB-CLOSE-TEARDOWN  closing the editor (Cancel) removes the scrub panel too.
 //   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant DURING A
-//              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call. This
-//              path is unaffected by the scrub fix (`_previewFly()` still legitimately flies the
-//              main camera; B still legitimately tracks it 1:1 while that happens).
+//              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call.
+//              Unaffected by any of this session's changes — same mechanism as before.
 //   G-VF-2     B's Time Machine readout is a READ of the cursor step() already set that frame, never
-//              a second tmSetCursor call — proven both statically (source has tmGetState, not
-//              tmSetCursor, inside the vf functions) and live (readout agrees with tmGetState() at
-//              the same instant during a real buildup rehearsal).
+//              a second tmSetCursor call — proven both statically and live. Unchanged.
 //   G-PERF-1   measured (not guessed) ms/frame B's own scissor pass adds during rehearsal, plus a
 //              static proof cinema_maxq.js (the MaxQ bake loop) never references the render hook.
 const fs = require('fs');
@@ -39,7 +42,6 @@ const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 const PORT = process.env.PORT || 8460;
 const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
 const sleep = ms => new Promise(r => setTimeout(r, ms));
-const REPO = '/tmp/wt-cpe-rehearsal-studio';   // set per-run below from __dirname
 
 async function openEditor(browser, BLD) {
   const page = await browser.newPage();
@@ -68,52 +70,118 @@ async function gates(browser, BLD, repoDir) {
   const P = (n, ok, d) => checks.push({ n, ok, d });
   const { page, logs } = await openEditor(browser, BLD);
 
-  // ── G-SCRUB-GATED: the bar does not exist before B is toggled on ────────────────────────────────
-  const beforeVF = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
-  P('G-SCRUB-GATED the scrub bar does not exist in the DOM while B is off',
-    beforeVF === false, `trackPresent=${beforeVF}`);
+  // ── G-SCRUB-STANDALONE: the panel exists BEFORE B is ever toggled on ────────────────────────────
+  const standalone = await page.evaluate(() => ({
+    track: !!document.getElementById('cpe-scrub-track'),
+    panel: !!document.getElementById('cpe-scrub-panel'),
+    vfOn: window.APP.cinemaPathEditor._probeVF().on
+  }));
+  P('G-SCRUB-STANDALONE the scrub panel exists at editor-open, independent of B',
+    standalone.track && standalone.panel && standalone.vfOn === false,
+    `trackPresent=${standalone.track} panelPresent=${standalone.panel} vfOnAtOpen=${standalone.vfOn}`);
 
-  // ── toggle B on — shared setup for every gate below (bar existence, no-cam, spawn, and G-VF-1) ──
-  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
-  await sleep(300);
-  const afterVF = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
-  P('G-SCRUB-GATED the scrub bar DOES exist once B is toggled on',
-    vfOnState === true && afterVF === true, `vfOn=${vfOnState} trackPresent=${afterVF}`);
-
-  // ── G-SCRUB-NOCAM: THE regression gate — no camera moves during a scrub drag ────────────────────
-  const before = await page.evaluate(() => {
-    const A = window.APP, cpe = window.APP.cinemaPathEditor;
-    const vf = cpe._probeVF();
+  // ── G-SCRUB-NOCAM: the regression gate — no MAIN camera move during a scrub drag, B still off ───
+  const before1 = await page.evaluate(() => {
+    const A = window.APP;
     return {
       mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
       mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z },
-      vfPos: vf.camPose, scrubLabel: document.getElementById('cpe-scrub-tn').textContent
+      scrubLabel: document.getElementById('cpe-scrub-tn').textContent
     };
   });
   const scrubResult = await page.evaluate(() => window.APP.cinemaPathEditor._scrubTo(0.42));
   await sleep(50);
-  const after = await page.evaluate(() => {
-    const A = window.APP, cpe = window.APP.cinemaPathEditor;
-    const vf = cpe._probeVF();
+  const after1 = await page.evaluate(() => {
+    const A = window.APP;
     return {
       mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
       mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z },
-      vfPos: vf.camPose, scrubLabel: document.getElementById('cpe-scrub-tn').textContent
+      scrubLabel: document.getElementById('cpe-scrub-tn').textContent
     };
   });
-  const dMainPos = Math.hypot(after.mainPos.x - before.mainPos.x, after.mainPos.y - before.mainPos.y, after.mainPos.z - before.mainPos.z);
-  const dMainTgt = Math.hypot(after.mainTgt.x - before.mainTgt.x, after.mainTgt.y - before.mainTgt.y, after.mainTgt.z - before.mainTgt.z);
-  const dVfPos = (before.vfPos && after.vfPos)
-    ? Math.hypot(after.vfPos.x - before.vfPos.x, after.vfPos.y - before.vfPos.y, after.vfPos.z - before.vfPos.z) : null;
-  P('G-SCRUB-NOCAM the main camera (position AND target) and B\'s inset camera are byte-identical before/after a scrub drag',
-    dMainPos < 1e-9 && dMainTgt < 1e-9 && (dVfPos == null || dVfPos < 1e-9),
-    `mainPosDelta=${dMainPos.toExponential(2)}m mainTargetDelta=${dMainTgt.toExponential(2)}m vfPosDelta=${dVfPos == null ? 'n/a' : dVfPos.toExponential(2) + 'm'} ` +
-    `scrubResult.x=${scrubResult ? scrubResult.x.toFixed(2) : 'null'} (poseAt(0.42) IS sampled and returned — just never written to any camera)`);
-  P('G-SCRUB-VISUAL the playhead/readout DID change (the feature still has a real, visible effect)',
-    before.scrubLabel !== after.scrubLabel,
-    `before="${before.scrubLabel}" after="${after.scrubLabel}"`);
+  const dMainPos1 = Math.hypot(after1.mainPos.x - before1.mainPos.x, after1.mainPos.y - before1.mainPos.y, after1.mainPos.z - before1.mainPos.z);
+  const dMainTgt1 = Math.hypot(after1.mainTgt.x - before1.mainTgt.x, after1.mainTgt.y - before1.mainTgt.y, after1.mainTgt.z - before1.mainTgt.z);
+  P('G-SCRUB-NOCAM the main camera (position AND target) is byte-identical before/after a scrub drag (B off)',
+    dMainPos1 < 1e-9 && dMainTgt1 < 1e-9,
+    `mainPosDelta=${dMainPos1.toExponential(2)}m mainTargetDelta=${dMainTgt1.toExponential(2)}m ` +
+    `scrubResult.x=${scrubResult ? scrubResult.x.toFixed(2) : 'null'} (poseAt(0.42) IS sampled and returned — just never written to the main camera)`);
+  P('G-SCRUB-VISUAL the playhead/readout DID change (mm:ss / mm:ss, not the old %)',
+    before1.scrubLabel !== after1.scrubLabel,
+    `before="${before1.scrubLabel}" after="${after1.scrubLabel}"`);
 
-  // ── G-SCRUB-SPAWN: a REAL pointer click on the (B-gated) scrub track, inside the walk window ────
+  // ── toggle B on — shared setup for G-SCRUB-VF-LIVE, G-SCRUB-PERSISTS, G-VF-1, G-VF-2, G-PERF-1 ──
+  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(300);
+
+  // ── G-SCRUB-VF-LIVE: with B on, scrub drives B's camera to plan.poseAt(tn); main stays untouched ─
+  const before2 = await page.evaluate(() => {
+    const A = window.APP;
+    return { mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+             mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z } };
+  });
+  const vfLive = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const p = cpe._scrubTo(0.58);
+    const vf = cpe._probeVF();
+    return { p, vfCam: vf.camPose };
+  });
+  const after2 = await page.evaluate(() => {
+    const A = window.APP;
+    return { mainPos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+             mainTgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z } };
+  });
+  const dMainPos2 = Math.hypot(after2.mainPos.x - before2.mainPos.x, after2.mainPos.y - before2.mainPos.y, after2.mainPos.z - before2.mainPos.z);
+  const dMainTgt2 = Math.hypot(after2.mainTgt.x - before2.mainTgt.x, after2.mainTgt.y - before2.mainTgt.y, after2.mainTgt.z - before2.mainTgt.z);
+  const dVfLive = (vfLive.p && vfLive.vfCam)
+    ? Math.hypot(vfLive.vfCam.x - vfLive.p.x, vfLive.vfCam.y - vfLive.p.y, vfLive.vfCam.z - vfLive.p.z) : null;
+  P('G-SCRUB-VF-LIVE a scrub drag (B on) sets vfCam to plan.poseAt(tn), main camera still untouched',
+    dVfLive != null && dVfLive < 1e-9 && dMainPos2 < 1e-9 && dMainTgt2 < 1e-9,
+    `vfCamDelta=${dVfLive == null ? 'n/a' : dVfLive.toExponential(2) + 'm'} mainPosDelta=${dMainPos2.toExponential(2)}m mainTargetDelta=${dMainTgt2.toExponential(2)}m`);
+
+  // ── Ensure at least one stick exists (some seeded paths have none) via the real _spawnStick ─────
+  // mutation, deterministic input, same precedent as G-PIN's _setPin bypassing the UI raycast. Done
+  // BEFORE either gate below so G-SCRUB-TICK-BLUE observes an UNSELECTED tick (selecting it, which
+  // G-SCRUB-BEARING does next, legitimately turns it orange — that's the correct convention, not a
+  // bug, so the colour check must run first).
+  const stickCount = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    let sticks = cpe._probeScrub().sticks;
+    if (!sticks.length) { cpe._spawnStickForTest(0.5); sticks = cpe._probeScrub().sticks; }
+    return sticks.length;
+  });
+  await sleep(100);
+
+  // ── G-SCRUB-TICK-BLUE: an unselected stick's tick is CPE_STICK_BLUE, not red ────────────────────
+  const tickColor = stickCount ? await page.evaluate(() => {
+    const track = document.getElementById('cpe-scrub-track');
+    const ticks = Array.from(track.children).filter(c => c.title && c.title.indexOf('into the film') >= 0);
+    return ticks.length ? getComputedStyle(ticks[0]).backgroundColor : null;
+  }) : null;
+  // CPE_STICK_BLUE = 0x1565c0 = rgb(21,101,192); the old red was 0xe53935 = rgb(229,57,53).
+  P('G-SCRUB-TICK-BLUE stick tick marks render blue, not the old red',
+    tickColor === 'rgb(21, 101, 192)', `tickColor=${tickColor} stickCount=${stickCount}`);
+
+  // ── G-SCRUB-BEARING: selecting a stick (the row-list path, same fn the canvas click uses) moves ──
+  // the playhead AND B's camera to that stick's own film position — "perfect bearing" per the user.
+  const bearing = stickCount ? await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const target = cpe._probeScrub().sticks[0];
+    cpe._holdForTest(target.i, 'mid');
+    const after = cpe._probeVF();
+    const scrubTn = cpe._probeScrub().scrubTn;
+    return { targetTn: target.tNorm, scrubTn, vfCam: after.camPose, p: cpe._probePoseAt(target.tNorm) };
+  }) : null;
+  let bearOk = false, bearDetail = 'no sticks on this building — inconclusive';
+  if (bearing) {
+    const dPlayhead = Math.abs(bearing.scrubTn - bearing.targetTn);
+    const dVfBear = (bearing.vfCam && bearing.p)
+      ? Math.hypot(bearing.vfCam.x - bearing.p.x, bearing.vfCam.y - bearing.p.y, bearing.vfCam.z - bearing.p.z) : null;
+    bearOk = dPlayhead < 1e-6 && dVfBear != null && dVfBear < 1e-9;
+    bearDetail = `stickTn=${bearing.targetTn.toFixed(4)} playheadTn=${bearing.scrubTn.toFixed(4)} playheadDelta=${dPlayhead.toExponential(2)} vfCamDelta=${dVfBear == null ? 'n/a' : dVfBear.toExponential(2) + 'm'}`;
+  }
+  P('G-SCRUB-BEARING selecting a stick (row list, same fn as canvas) moves the playhead and B\'s camera to it', bearOk, bearDetail);
+
+  // ── G-SCRUB-NOSPAWN: clicking the bar (0px press) does NOT spawn a stick ────────────────────────
   const setup2 = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
     const win = cpe._probeScrub().walkWindow;
@@ -123,39 +191,36 @@ async function gates(browser, BLD, repoDir) {
     const r = track.getBoundingClientRect();
     const px = Math.round(r.left + tn * r.width), py = Math.round(r.top + r.height / 2);
     const nBefore = document.querySelectorAll('#cpe-rows > div[data-cpe-row="band"]').length;
-    const ground = cpe._probePoseAt(tn);
-    return { tn, px, py, nBefore, ground };
+    return { tn, px, py, nBefore };
   });
   let g2ok = false, g2detail = 'walk window unavailable — inconclusive';
   if (setup2) {
+    const before3 = await page.evaluate(() => document.getElementById('cpe-scrub-tn').textContent);
     await page.mouse.move(setup2.px, setup2.py);
     await page.mouse.down();
     await sleep(30);
     await page.mouse.up();          // a 0px press == a click, same doctrine as §CPE_CLICK_SLOP
-    await sleep(700);
-    const afterSpawn = await page.evaluate(() => {
-      const cpe = window.APP.cinemaPathEditor;
-      const n = document.querySelectorAll('#cpe-rows > div[data-cpe-row="band"]').length;
-      // Find the newly-added stick's drawn centre via the bars/handles probe (mid handle, z==='mid').
-      const handles = cpe._probeHandles() || [];
-      return { n, handles };
-    });
-    const stickHandle = afterSpawn.handles.filter(h => h.z === 'mid' && h.stick).pop();
-    const dSpawn = stickHandle
-      ? Math.hypot(stickHandle.x - setup2.ground.x, stickHandle.y - setup2.ground.y, stickHandle.z3 - setup2.ground.z)
-      : null;
-    // Seeding resolution is bounded by the flow polyline's own sample density, not by the film's
-    // FILM_SAMPLES — a few tens of cm is the real bound, measured below rather than asserted blind.
-    g2ok = afterSpawn.n === setup2.nBefore + 1 && stickHandle != null && dSpawn != null && dSpawn < 2.0;
-    g2detail = `rows ${setup2.nBefore}->${afterSpawn.n} spawnDist=${dSpawn == null ? 'n/a' : dSpawn.toFixed(3) + 'm'} ` +
-      `(clicked tn=${setup2.tn.toFixed(3)}, target=(${setup2.ground.x.toFixed(2)},${setup2.ground.y.toFixed(2)},${setup2.ground.z.toFixed(2)}))`;
+    await sleep(300);
+    const after3 = await page.evaluate(() => ({
+      n: document.querySelectorAll('#cpe-rows > div[data-cpe-row="band"]').length,
+      label: document.getElementById('cpe-scrub-tn').textContent
+    }));
+    g2ok = after3.n === setup2.nBefore && after3.label !== before3;
+    g2detail = `rows ${setup2.nBefore}->${after3.n} (unchanged) label "${before3}"->"${after3.label}" (scrubbed instead of spawning)`;
   }
-  P('G-SCRUB-SPAWN a click on the shaded bar spawns a stick at the pipe\'s own placement for that tNorm', g2ok, g2detail);
+  P('G-SCRUB-NOSPAWN a click on the bar scrubs to that point, never spawns a stick', g2ok, g2detail);
 
-  // ── G-VF-1 (B already on from the shared setup above): rehearsal-style pose application only —
-  // NOT `_scrubTo` (that no longer touches any camera, per the 2026-08-04 correction/simplification
-  // above). `_applyCameraPoseForTest` calls the real `_applyCameraPose`, the one function
-  // `_previewFly()`'s step() still legitimately uses to fly the main camera and sync B to it.
+  // ── G-SCRUB-PERSISTS: toggling B off leaves the scrub panel in place ────────────────────────────
+  const offState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(200);
+  const persists = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
+  P('G-SCRUB-PERSISTS toggling B off does NOT remove the scrub panel (only editor-close does)',
+    offState === false && persists === true, `vfOn=${offState} scrubStillPresent=${persists}`);
+  // Toggle B back on — the rest of this run (G-VF-1/2, G-PERF-1) needs it on.
+  await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(200);
+
+  // ── G-VF-1 (B on): rehearsal-style pose application — same mechanism as before, unaffected ──────
   const vf1 = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
     cpe._applyCameraPoseForTest(0.65);
@@ -163,9 +228,8 @@ async function gates(browser, BLD, repoDir) {
   });
   const dVF = vf1.camPose ? Math.hypot(vf1.camPose.x - vf1.mainPose.x, vf1.camPose.y - vf1.mainPose.y, vf1.camPose.z - vf1.mainPose.z) : null;
   P('G-VF-1 B\'s camera pose at tn=0.65 matches the main camera exactly (same plan.poseAt sample, rehearsal-style application)',
-    vfOnState === true && dVF != null && dVF < 1e-6,
-    `vfOn=${vfOnState} hookInstalled=${vf1.hookInstalled} delta=${dVF == null ? 'n/a' : dVF.toExponential(2)}m ` +
-    `rect=${vf1.rect ? JSON.stringify(vf1.rect) : 'null'}`);
+    dVF != null && dVF < 1e-6,
+    `hookInstalled=${vf1.hookInstalled} delta=${dVF == null ? 'n/a' : dVF.toExponential(2)}m rect=${vf1.rect ? JSON.stringify(vf1.rect) : 'null'}`);
 
   // ── G-VF-2: static — the vf functions never call tmSetCursor, only tmGetState ──────────────────
   const src = fs.readFileSync(repoDir + '/viewer/cinema_path_editor.js', 'utf8');
@@ -174,26 +238,35 @@ async function gates(browser, BLD, repoDir) {
   P('G-VF-2a static: the viewfinder block reads tmGetState and never calls tmSetCursor', noSecondClock,
     `vfBlock length=${vfBlock.length} hasGet=${vfBlock.includes('tmGetState')} hasSet=${vfBlock.includes('tmSetCursor')}`);
 
-  // ── G-VF-2 live: run a short real rehearsal with buildup ON and read the readout mid-flight ────
+  // ── G-VF-2 live + G-SCRUB-PLAY: run a real rehearsal with buildup ON, pause it mid-flight, ─────
+  // resume it — one flight covers both the readout-drift gate and the new pause/resume gate.
   await page.evaluate(() => {
     const cb = document.getElementById('cpe-buildup');
     if (cb && !cb.checked) { cb.checked = true; cb.dispatchEvent(new Event('change')); }
   });
   await sleep(200);
   const vf2mark = logs.length;
-  // Clear the readout FIRST — G-VF-1 above already left a stale (pre-rehearsal) value in it, and a
-  // "readout is non-empty" poll needs to mean "the rehearsal wrote a fresh one", not "still showing
-  // last test's leftover".
   await page.evaluate(() => { const el = document.getElementById('cpe-vf-clock'); if (el) el.textContent = ''; });
-  page.evaluate(() => document.getElementById('cpe-preview').click());
-  // §CPE_PREVIEW_BUILDUP arms ASYNCHRONOUSLY (awaits tmActivateForBake before the fly loop even
-  // starts stepping) — measured 513ms on Duplex, 3.2s on the much larger Terminal, whose per-frame
-  // cost also runs ~1.6s/frame on this headless rig (48k ops). A fixed post-arm sleep raced that:
-  // poll for a NON-EMPTY readout instead (bounded 20s), then compare it against tmGetState() in the
-  // SAME evaluate call — by construction (see §CPE_VIEWFINDER's readout-ordering fix) the readout is
-  // only ever written AFTER that frame's own tmSetCursor, so catching it non-empty and reading
-  // tmGetState() immediately after, before the (~1s+) next frame can change it again, is a real
-  // same-instant comparison, not a race window guess.
+  page.evaluate(() => document.getElementById('cpe-scrub-play').click());   // starts via the NEW transport button
+  await sleep(1500);   // let it fly for a bit before pausing
+  const pausedAt = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const ok = cpe._flyPause();
+    return { ok, state: cpe._flyState() };
+  });
+  await sleep(500);   // real wait WHILE paused — the flight fraction must not advance
+  const stillPaused = await page.evaluate(() => window.APP.cinemaPathEditor._flyState());
+  const resumedOk = await page.evaluate(() => window.APP.cinemaPathEditor._flyResume());
+  await sleep(300);
+  const resumedState = await page.evaluate(() => window.APP.cinemaPathEditor._flyState());
+  P('G-SCRUB-PLAY pause freezes the flight fraction (u unchanged over a real wait)',
+    pausedAt.ok && stillPaused && stillPaused.paused && Math.abs(stillPaused.u - pausedAt.state.u) < 1e-6,
+    `pausedU=${pausedAt.state ? pausedAt.state.u.toFixed(4) : 'n/a'} afterWaitU=${stillPaused ? stillPaused.u.toFixed(4) : 'n/a'}`);
+  P('G-SCRUB-PLAY resume continues the flight (still flying, no longer paused)',
+    resumedOk && resumedState && resumedState.flying && !resumedState.paused,
+    `resumeOk=${resumedOk} flying=${resumedState ? resumedState.flying : 'n/a'} paused=${resumedState ? resumedState.paused : 'n/a'}`);
+
+  // Poll for a non-empty readout the same way the original gate did (post-resume).
   let vf2 = null;
   const vfT0 = Date.now();
   while (Date.now() - vfT0 < 20000) {
@@ -206,9 +279,6 @@ async function gates(browser, BLD, repoDir) {
     if (vf2.readout) break;
     await sleep(150);
   }
-  // Wait out the rest of the rehearsal so the next building's page.close() doesn't race a live fly —
-  // polled against the exit log rather than a blind sleep, since arm time (above) already varies
-  // per building and a fixed budget either races a slow one or wastes time on a fast one.
   const doneT0 = Date.now();
   while (Date.now() - doneT0 < 30000 && !logs.slice(vf2mark).some(l => l.startsWith('§CPE_PREVIEW done'))) {
     await sleep(300);
@@ -217,7 +287,7 @@ async function gates(browser, BLD, repoDir) {
   const readoutDay = vf2.readout ? vf2.readout : null;
   const tmDay = vf2.tmMs != null ? new Date(vf2.tmMs).toISOString().slice(0, 10) : null;
   P('G-VF-2b live: B\'s readout equals Time Machine\'s own cursor at the same instant (no drift)',
-    vf2.tmMs == null ? true : readoutDay === tmDay,   // no-buildup-timeline building: both null, vacuously fine
+    vf2.tmMs == null ? true : readoutDay === tmDay,
     `readout="${readoutDay}" tmGetState().cursor day="${tmDay}" tmMs=${vf2.tmMs}`);
 
   // ── G-PERF-1a: measured ms/frame ─────────────────────────────────────────────────────────────
@@ -239,20 +309,15 @@ async function gates(browser, BLD, repoDir) {
   P('G-PERF-1b static: cinema_maxq.js (the MaxQ bake loop) has zero references to the viewfinder render hook',
     bakeClean, `occurrences=${(maxqSrc.match(/_cpeViewfinderRender/g) || []).length}`);
 
-  // ── toggle off, confirm teardown ─────────────────────────────────────────────────────────────
-  const off = await page.evaluate(() => {
-    const cpe = window.APP.cinemaPathEditor;
-    const on = cpe._vfToggle();
-    return {
-      on: on, panelGone: !document.getElementById('cpe-vf-panel'), hookGone: !window.APP._cpeViewfinderRender,
-      scrubGone: !document.getElementById('cpe-scrub-track')
-    };
-  });
-  P('G-VF-off toggling off removes the DOM panel and clears the render hook (zero cost when off)',
-    off.on === false && off.panelGone && off.hookGone,
-    `vfOn=${off.on} panelGone=${off.panelGone} hookGone=${off.hookGone}`);
-  P('G-SCRUB-TEARDOWN toggling B off also removes the scrub bar (its existence is gated to B)',
-    off.scrubGone, `trackGoneAfterVfOff=${off.scrubGone}`);
+  // ── G-SCRUB-CLOSE-TEARDOWN: closing the editor (Cancel) removes the scrub panel ─────────────────
+  await page.evaluate(() => document.getElementById('cpe-cancel').click());
+  await sleep(300);
+  const closed = await page.evaluate(() => ({
+    scrubGone: !document.getElementById('cpe-scrub-panel'),
+    vfGone: !document.getElementById('cpe-vf-panel')
+  }));
+  P('G-SCRUB-CLOSE-TEARDOWN closing the editor removes the scrub panel too', closed.scrubGone,
+    `scrubPanelGone=${closed.scrubGone} vfPanelGone=${closed.vfGone}`);
 
   await page.close();
   return checks;


### PR DESCRIPTION
## Summary
Resolves the #1177 OPEN QUESTION on the scrub bar's own home:
- `#cpe-scrub-panel` — standalone draggable panel, independent of B's toggle, below B's default rect
- §CPE_SCRUB_VF_LIVE — scrub drag drives B's inset camera again (main canvas still never touched)
- §CPE_SCRUB_READONLY — bar no longer spawns/selects sticks; sticks show as read-only blue ticks
- §CPE_STICK_TIME_SYNC F1 — mm:ss / total readout, not a bare %
- §CPE_SCRUB_PLAY — play/pause transport button reusing `_previewFly()`, real pause/resume support (caught and fixed a real closure-scoping bug via the rewritten witness)
- §CPE_SCRUB_BEARING — selecting a stick (canvas or row list) moves the playhead + B's camera to it

Full spec write-up: `bim-compiler` `prompts/CINEMA_PATH_EDITOR.md` (2026-08-05 DONE section).

## Test plan
- [x] `node --check` on both edited files
- [x] `witness_cpe_scrub_viewfinder.js` rewritten — 16/16 green on HHS_Office_Federated
- [x] `witness_cpe_aim_pin.js` — 7/7 clean, no regression
- [x] `witness_cinema_path_editor.js` — 7/9, the 2 red gates (G10/G7) match this file's own documented pre-existing baseline on unmodified `origin/main`, not new regressions