### PR TITLE
fix(4d): §CLASS_UNMATCHED_FALLBACK — 3 real classes were silently defaulting

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -103,7 +103,7 @@ var LABOR_RATES = {
   },
   ELECTRICIAN: {
     rate_per_day: 175, crew_size: 2, max_crews: 2, trade: 'Electrician (Skilled)',
-    productivity: {IfcCableCarrier:30,IfcCableCarrierSegment:30,IfcLightFixture:20,IfcOutlet:25,IfcElectricAppliance:15,IfcFlowController:10,IfcAlarm:25,IfcController:10}
+    productivity: {IfcCableCarrier:30,IfcCableCarrierSegment:30,IfcLightFixture:20,IfcOutlet:25,IfcElectricAppliance:15,IfcFlowController:10,IfcSwitchingDevice:10,IfcAlarm:25,IfcController:10,IfcDistributionControlElement:10}
   },
   STEEL_ERECTOR: {
     rate_per_day: 195, crew_size: 4, max_crews: 3, trade: 'Steel Erector (Skilled)',
@@ -179,6 +179,7 @@ var SEQUENCE_RULES = {
   IfcFlowSegment:{phase:'MEP Rough-in',sequence:7,resource:'PLUMBER'},
   IfcFlowFitting:{phase:'MEP Rough-in',sequence:7,resource:'PLUMBER'},
   IfcFlowController:{phase:'MEP Rough-in',sequence:7,resource:'ELECTRICIAN'},
+  IfcSwitchingDevice:{phase:'MEP Rough-in',sequence:7,resource:'ELECTRICIAN'},
   IfcFlowMovingDevice:{phase:'MEP Rough-in',sequence:7,resource:'HVAC_TECH'},
   IfcFlowStorageDevice:{phase:'MEP Rough-in',sequence:7,resource:'PLUMBER'},
   IfcFlowTreatmentDevice:{phase:'MEP Rough-in',sequence:7,resource:'PLUMBER'},
@@ -190,10 +191,12 @@ var SEQUENCE_RULES = {
   IfcAirTerminal:{phase:'MEP Final',sequence:9,resource:'HVAC_TECH'},
   IfcAlarm:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   IfcController:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcDistributionControlElement:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   // Architecture
   IfcWall:{phase:'Architecture',sequence:5,resource:'MASON'},
   IfcWallStandardCase:{phase:'Architecture',sequence:5,resource:'MASON'},
   IfcOpeningElement:{phase:'Architecture',sequence:5,resource:'MASON'},
+  IfcSpace:{phase:'Architecture',sequence:5,resource:null},
   IfcBuildingElementPart:{phase:'Architecture',sequence:5,resource:'MASON'},
   IfcDoor:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
   IfcWindow:{phase:'Architecture',sequence:6,resource:'CARPENTER'},

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -107,6 +107,11 @@
       "sequence": 7,
       "resource": "ELECTRICIAN"
     },
+    "IfcSwitchingDevice": {
+      "phase": "MEP Rough-in",
+      "sequence": 7,
+      "resource": "ELECTRICIAN"
+    },
     "IfcFlowMovingDevice": {
       "phase": "MEP Rough-in",
       "sequence": 7,
@@ -157,6 +162,11 @@
       "sequence": 9,
       "resource": "ELECTRICIAN"
     },
+    "IfcDistributionControlElement": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
     "IfcWall": {
       "phase": "Architecture",
       "sequence": 5,
@@ -171,6 +181,11 @@
       "phase": "Architecture",
       "sequence": 5,
       "resource": "MASON"
+    },
+    "IfcSpace": {
+      "phase": "Architecture",
+      "sequence": 5,
+      "resource": null
     },
     "IfcBuildingElementPart": {
       "phase": "Architecture",

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -22,6 +22,11 @@
     for (var key in rules) {
       if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
     }
+    // §CLASS_UNMATCHED_FALLBACK (2026-08-04): a class with no SEQUENCE_RULES key at all used to
+    // land on `dflt` silently — found live on real Hospital data (861 IfcDistributionControlElement,
+    // 113 IfcSwitchingDevice). Loud, not silent: whoever imports a new IFC set with a genuinely
+    // unclassified class sees it in the log instead of it vanishing into the generic default.
+    if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + dflt.phase);
     return bestKey ? rules[bestKey] : dflt;
   }
 
@@ -257,11 +262,14 @@
     // 4.5% of elements on a real building (JKR: 425/9410). Silent: doesn't break DAG/support-order
     // (openings rarely collide with anything), just inflates phase/zone element+crew-time counts and
     // breaks the "movie-coherent, can never tell a different story" guarantee those functions claim.
+    // §CLASS_UNMATCHED_FALLBACK (found 2026-08-04, witness_class_fallback_blackbox.js): IfcSpace is a
+    // spatial-zone entity, not a physical installable element — same non-physical category as
+    // IfcOpeningElement, excluded the same way (never invented labor for a room volume).
     var r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.element_name,''), COALESCE(m.storey,'_UNKNOWN'), " +
       "COALESCE(t.center_x,0), COALESCE(t.center_y,0), COALESCE(t.center_z,0), " +
       "COALESCE(t.bbox_x,0), COALESCE(t.bbox_y,0), COALESCE(t.bbox_z,0) " +
       "FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid " +
-      "WHERE m.ifc_class != 'IfcOpeningElement'");
+      "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
     if (!r.length || !r[0].values.length) return [];
 
     var storeyZs = {};

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3297,6 +3297,8 @@
       for (var key in SR) {
         if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
       }
+      // §CLASS_UNMATCHED_FALLBACK (2026-08-04) — see schedule_author.js's matchRule for the finding.
+      if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + SD.phase);
       return bestKey ? SR[bestKey] : SD;
     }
     var r;
@@ -3308,7 +3310,7 @@
         'COALESCE(t.bbox_x, 0) as bx, COALESCE(t.bbox_y, 0) as by ' +
         'FROM elements_meta m ' +
         'LEFT JOIN element_transforms t ON t.guid = m.guid ' +
-        "WHERE m.ifc_class != 'IfcOpeningElement'"
+        "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'"
       );
     } catch (e) { return null; }
     if (!r.length || !r[0].values.length) return null;
@@ -3575,6 +3577,8 @@
       for (var key in SR) {
         if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
       }
+      // §CLASS_UNMATCHED_FALLBACK (2026-08-04) — see schedule_author.js's matchRule for the finding.
+      if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + SD.phase);
       return bestKey ? SR[bestKey] : SD;
     }
     // §TM_DURATION_SYNC (viewer/schedule_author.js commit d35366a §LABOR_QUANTITY_WEIGHT): this used
@@ -3633,7 +3637,7 @@
         'COALESCE(t.bbox_x, 0) as bx, COALESCE(t.bbox_y, 0) as by ' +
         'FROM elements_meta m ' +
         'LEFT JOIN element_transforms t ON t.guid = m.guid ' +
-        "WHERE m.ifc_class != 'IfcOpeningElement' " +
+        "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace' " +
         'ORDER BY cz, COALESCE(t.center_x, 0), COALESCE(t.center_y, 0)'
       );
     } catch(e) { console.log('§GANTT table error: ' + e.message); return false; }
@@ -6371,7 +6375,7 @@
         if (sr.length && sr[0].values.length) summarySkipped = sr[0].values[0][0] | 0;
       } catch (e) { leafTasks = 0; summarySkipped = 0; }   // no tasks table → derived, not an error
       try {
-        var er = app.db.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class != 'IfcOpeningElement'");
+        var er = app.db.exec("SELECT COUNT(*) FROM elements_meta WHERE ifc_class != 'IfcOpeningElement' AND ifc_class != 'IfcSpace'");
         if (er.length && er[0].values.length) total = er[0].values[0][0] | 0;
       } catch (e) { total = 0; }
     }


### PR DESCRIPTION
## Summary
- `witness_class_fallback_blackbox.js` (PR #1185) found `IfcDistributionControlElement` (861 elements) and `IfcSwitchingDevice` (113, both Hospital) silently landing on `matchRule`'s generic Architecture/seq6/no-resource default across all 3 copies — no explicit `SEQUENCE_RULES` entry existed.
- Both classified via real IFC4 hierarchy, not guessed: `IfcDistributionControlElement` mirrors its already-classified siblings `IfcController`/`IfcAlarm` (MEP Final/ELECTRICIAN); `IfcSwitchingDevice` mirrors its IFC4 parent `IfcFlowController` (MEP Rough-in/ELECTRICIAN).
- `IfcSpace` (21, Duplex) is a spatial zone, not a physical element — same non-physical category as `IfcOpeningElement`, given the identical treatment: an explicit rule entry (classified, not silently defaulted) + exclusion from the same 4 schedule-building queries that already exclude `IfcOpeningElement`.
- Added a loud `§CLASS_UNMATCHED` `console.warn` at the fallback point in all 3 `matchRule` copies, so a future genuinely-unclassified class (a different IFC set) is visible in the log instead of silently vanishing into the default.

Implements `prompts/4D_SCHEDULE_PERFECTION.md` §CLASS_UNMATCHED_FALLBACK PRELIM NOTE.

## Test plan
- [x] `witness_class_fallback_blackbox.js`: G-A hits 3→0, G-B/C/D unchanged pass
- [x] `witness_gantt_bar_identity.js` 6/6
- [x] `witness_gantt_palette.js` 7/7
- [x] `witness_gantt_row_order.js` 9/9
- [x] `witness_gantt_edit_coherence.js` 7/7
- [x] `witness_gantt_edit_constraints.js` 18/18
- [x] `witness_zone_cpm.js` 11/11
- [x] `witness_zone_cpm_duplex.js` 9/9
- [x] `witness_tm_duration_sync.js` 8/8
- [x] `witness_support_invariant_all_buildings.js` 18/18
- [x] `witness_gap1_task_sequences.js` 7/7
- [x] `witness_boq_charts_real_schedule.js` 91/91
- [ ] Live browser — not run this session (headless-only, per session directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)