### PR TITLE
fix(4d): §CLASS_UNMATCHED_FALLBACK follow-up — widen witness to 7 fixtures, close 2 more

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -103,7 +103,7 @@ var LABOR_RATES = {
   },
   ELECTRICIAN: {
     rate_per_day: 175, crew_size: 2, max_crews: 2, trade: 'Electrician (Skilled)',
-    productivity: {IfcCableCarrier:30,IfcCableCarrierSegment:30,IfcLightFixture:20,IfcOutlet:25,IfcElectricAppliance:15,IfcFlowController:10,IfcSwitchingDevice:10,IfcAlarm:25,IfcController:10,IfcDistributionControlElement:10}
+    productivity: {IfcCableCarrier:30,IfcCableCarrierSegment:30,IfcLightFixture:20,IfcOutlet:25,IfcElectricAppliance:15,IfcFlowController:10,IfcSwitchingDevice:10,IfcAlarm:25,IfcController:10,IfcDistributionControlElement:10,IfcActuator:10,IfcSensor:10,IfcFlowInstrument:10,IfcProtectiveDeviceTrippingUnit:10,IfcUnitaryControlElement:10}
   },
   STEEL_ERECTOR: {
     rate_per_day: 195, crew_size: 4, max_crews: 3, trade: 'Steel Erector (Skilled)',
@@ -192,6 +192,11 @@ var SEQUENCE_RULES = {
   IfcAlarm:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   IfcController:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   IfcDistributionControlElement:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcActuator:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcSensor:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcFlowInstrument:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcProtectiveDeviceTrippingUnit:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
+  IfcUnitaryControlElement:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   // Architecture
   IfcWall:{phase:'Architecture',sequence:5,resource:'MASON'},
   IfcWallStandardCase:{phase:'Architecture',sequence:5,resource:'MASON'},

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -167,6 +167,31 @@
       "sequence": 9,
       "resource": "ELECTRICIAN"
     },
+    "IfcActuator": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
+    "IfcSensor": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
+    "IfcFlowInstrument": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
+    "IfcProtectiveDeviceTrippingUnit": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
+    "IfcUnitaryControlElement": {
+      "phase": "MEP Final",
+      "sequence": 9,
+      "resource": "ELECTRICIAN"
+    },
     "IfcWall": {
       "phase": "Architecture",
       "sequence": 5,


### PR DESCRIPTION
## Summary
- PR #1186 only ran `witness_class_fallback_blackbox.js` against its default 4-fixture list. Widened to all 7 real buildings (`+Clinic,JKR,HHS_Office_Federated`) and found 2 more real silent-fallback classes: `IfcSensorType`/`IfcFlowInstrumentType` (HHS_Office_Federated, 1 each).
- Both are Type objects for undocumented siblings of `IfcController`/`IfcAlarm`/`IfcDistributionControlElement`. Added the remaining IFC4 `IfcDistributionControlElement` subtypes with no rule yet: `IfcActuator`, `IfcSensor`, `IfcFlowInstrument`, `IfcProtectiveDeviceTrippingUnit`, `IfcUnitaryControlElement` — same MEP Final/ELECTRICIAN as their classified siblings. `matchRule`'s substring match covers the `...Type` variants for free.

## Test plan
- [x] `witness_class_fallback_blackbox.js` against all 7 real fixtures (273,081 elements): G-A 2→0
- [x] bar_identity 6/6, palette 7/7, row_order 9/9, coherence 7/7, constraints 18/18
- [x] zone_cpm 11/11, zone_cpm_duplex 9/9, tm_duration_sync 8/8, support_invariant_all 18/18, gap1 7/7
- [x] boq_charts_real_schedule 91/91
- [ ] Live browser — not run this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)