### PR TITLE
feat(4d): ↺ Undo edit — replaces the dead Copy Touched button

### DIFF
--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// witness_gantt_edit_undo.js — §GANTT_EDIT_UNDO (2026-08-05). Proves the new ↺ Undo edit button
+// (replacing the dead "Copy Touched" slot) actually restores both tables a drag/resize edit
+// touches — `tasks` (moveTaskCascade/resizeTask) and `kernel_ops` (retimeTaskElements) — to their
+// exact pre-edit values, on a REAL authored schedule against a REAL building fixture.
+//
+// Convention this repo already established (witness_class_fallback_blackbox.js, K0's own lesson
+// "copy the predicate instead of importing it caused the same bug 3x"): slice the SHIPPED functions
+// out of time_machine.js by balanced braces, never reimplement the restore logic in the test. The
+// sliced block (loadOps, _retimeSpan, retimeTaskElements, commitGanttDrag, undoLastGanttEdit) is
+// DOM-heavy in its host file, so this witness supplies a minimal sandbox for its free variables
+// (A(), document, window.ScheduleAuthor, the redraw no-ops) — never a second copy of the restore SQL.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const sliced = [
+  'loadOps', '_retimeSpan', 'retimeTaskElements', 'commitGanttDrag', 'undoLastGanttEdit'
+].map(function (n) { return sliceFn(tmSrc, n); }).join('\n');
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDING = process.argv[2] || 'Duplex';
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const dbPath = path.join(BLD_DIR, BUILDING + '_extracted.db');
+  if (!fs.existsSync(dbPath)) { console.log('§UNDO_SKIP ' + BUILDING + ' fixture missing'); return; }
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const opts = { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate };
+  const mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES, opts);
+  if (!mres.ok) { console.log('§UNDO_SKIP materializeZones failed: ' + JSON.stringify(mres)); db.close(); return; }
+
+  // Seed kernel_ops the way a real built/played Gantt would — one ELEMENT_PLACE row per
+  // task_elements guid, timed at its task's own real window. This is the substrate
+  // retimeTaskElements/commitGanttDrag operate on in the live app (loadOps()'s own table).
+  db.run('CREATE TABLE IF NOT EXISTS kernel_ops (id INTEGER PRIMARY KEY, timestamp INTEGER NOT NULL, ' +
+    'op_type TEXT NOT NULL, parameters TEXT NOT NULL, input_guids TEXT, output_guid TEXT, undone INTEGER DEFAULT 0)');
+  const tr = db.exec("SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND (is_summary IS NULL OR is_summary=0)");
+  const taskWindow = {};
+  tr[0].values.forEach(function (row) {
+    taskWindow[row[0]] = { s: Date.parse(row[1] + 'T00:00:00Z'), e: Date.parse(row[2] + 'T00:00:00Z') };
+  });
+  const teAll = db.exec('SELECT task_id, guid FROM task_elements');
+  const guidsByTask = {};
+  const insOp = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
+  db.run('BEGIN');
+  teAll[0].values.forEach(function (row) {
+    const tid = row[0], guid = row[1], w = taskWindow[tid]; if (!w) return;
+    (guidsByTask[tid] = guidsByTask[tid] || []).push(guid);
+    insOp.run([w.s, 'ELEMENT_PLACE', JSON.stringify({ _end_ts: w.e }), '[]', guid]);
+  });
+  insOp.free();
+  db.run('COMMIT');
+
+  // Pick a real task that has at least one real successor (a cascade case, not a trivial single move)
+  // — the SAME task_sequences data the app's own moveTaskCascade reads.
+  const seqR = db.exec("SELECT predecessor_id FROM task_sequences GROUP BY predecessor_id HAVING COUNT(*) >= 1");
+  const candidates = (seqR.length ? seqR[0].values.map(r => r[0]) : []).filter(function (id) { return taskWindow[id]; });
+  const dragTaskId = candidates[0] || Object.keys(taskWindow)[0];
+
+  // ── Sandbox: real sliced functions, minimal free-variable stubs ──
+  const _ganttTasks = Object.keys(taskWindow).map(function (tid) {
+    return { taskId: tid, guids: guidsByTask[tid] || [], startTs: taskWindow[tid].s, endTs: taskWindow[tid].e, storey: '', phase: '' };
+  });
+  const sandbox = {
+    console: console, JSON: JSON, Date: Date, Math: Math,
+    _ganttTasks: _ganttTasks, _taskIndex: { scheduleId: 'SCH_AUTHORED' }, _lastEdit: null, _cursor: 0,
+    window: { ScheduleAuthor: ScheduleAuthor, performance: null },
+    A: function () { return { db: db }; },
+    document: { getElementById: function () { return null; } },
+    invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {}
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nglobalThis.__ops = _ops = loadOps(); ' +
+    'globalThis.__commit = commitGanttDrag; globalThis.__undo = undoLastGanttEdit; ' +
+    'globalThis.__getLastEdit = function(){ return _lastEdit; };', sandbox);
+  sandbox._ops = sandbox.__ops;
+
+  function snapshot() {
+    const t = {}, o = {};
+    db.exec("SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id='SCH_AUTHORED'")[0].values
+      .forEach(function (r) { t[r[0]] = r[1] + '|' + r[2] + '|' + r[3]; });
+    db.exec("SELECT output_guid, timestamp, parameters FROM kernel_ops WHERE op_type='ELEMENT_PLACE'")[0].values
+      .forEach(function (r) { o[r[0]] = r[1] + '|' + r[2]; });
+    return { t: t, o: o };
+  }
+  function diffKeys(a, b) {
+    const keys = Object.keys(a); const out = [];
+    keys.forEach(function (k) { if (a[k] !== b[k]) out.push(k); });
+    return out;
+  }
+
+  const before = snapshot();
+
+  // Drag the chosen task 20 days later — real engine verb (moveTaskCascade), real cascade.
+  const bar = _ganttTasks.filter(function (b) { return b.taskId === dragTaskId; })[0];
+  sandbox.__commit(bar, 'move', 20);
+  const afterEdit = snapshot();
+  const changedTasksAfterEdit = diffKeys(before.t, afterEdit.t);
+  const changedOpsAfterEdit = diffKeys(before.o, afterEdit.o);
+
+  console.log('§UNDO ' + BUILDING + ' dragTask=' + dragTaskId +
+    ' tasksChangedByEdit=' + changedTasksAfterEdit.length + ' opsChangedByEdit=' + changedOpsAfterEdit.length);
+
+  // RED CONTROL: the edit must actually have changed something, or the restore assertion below is vacuous.
+  assert(changedTasksAfterEdit.length > 0, 'RED-CONTROL the drag actually changed at least one task row');
+  assert(changedOpsAfterEdit.length > 0, 'RED-CONTROL the drag actually changed at least one kernel_ops row');
+  assert(sandbox.__getLastEdit() !== null, '_lastEdit is populated after a committed edit');
+
+  sandbox.__undo();
+  const afterUndo = snapshot();
+  const stillWrongTasks = diffKeys(before.t, afterUndo.t);
+  const stillWrongOps = diffKeys(before.o, afterUndo.o);
+
+  assert(stillWrongTasks.length === 0,
+    'every task row restored to its exact pre-edit value — mismatched=' + JSON.stringify(stillWrongTasks));
+  assert(stillWrongOps.length === 0,
+    'every kernel_ops row restored to its exact pre-edit value — mismatched=' + JSON.stringify(stillWrongOps));
+  assert(sandbox.__getLastEdit() === null, '_lastEdit cleared after undo (single-level, not a stack)');
+
+  // Second undo click must be a safe no-op — not throw, not touch the DB further.
+  let threw = false;
+  try { sandbox.__undo(); } catch (e) { threw = true; }
+  const afterSecondUndo = snapshot();
+  assert(!threw, 'a second Undo click (nothing left to undo) does not throw');
+  assert(diffKeys(before.t, afterSecondUndo.t).length === 0 && diffKeys(before.o, afterSecondUndo.o).length === 0,
+    'a second Undo click leaves state unchanged (true no-op, not a second reversal)');
+
+  // Scope check: tasks/ops OUTSIDE the cascade must never have been touched by either edit or undo.
+  const untouchedTaskIds = Object.keys(before.t).filter(function (id) { return changedTasksAfterEdit.indexOf(id) < 0; });
+  const everTouchedWrongly = untouchedTaskIds.filter(function (id) { return afterEdit.t[id] !== before.t[id] || afterUndo.t[id] !== before.t[id]; });
+  assert(everTouchedWrongly.length === 0, 'tasks outside the real cascade were never mutated by edit or undo');
+
+  db.close();
+  console.log('\n§W-UNDO SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§UNDO_ERROR', e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2668,7 +2668,7 @@
         '<button id="tm-stop-btn" style="width:30px;font-size:14px" title="Stop">&#x25A0;</button>' +
         '<button id="tm-fwd-btn" style="width:30px;font-size:14px" title="Build">&#x25B6;</button>' +
         '<button id="tm-end-btn" style="width:30px;font-size:14px" title="Jump to end">&#x25B6;&#x25B6;</button>' +
-        '<button id="tm-touched" style="flex:1;font-size:9px">Copy Touched</button>' +
+        '<button id="tm-undo" style="flex:1;font-size:9px" title="Undo the last Gantt drag/resize">&#x21BA; Undo edit</button>' +
         '<button id="tm-new" style="flex:1;font-size:9px">Copy New</button>' +
       '</div>' +
       '<div id="tm-gantt-box" class="tm-drawer-bottom">' +
@@ -2797,8 +2797,8 @@
       e.stopPropagation(); stopPlayback();
     });
 
-    document.getElementById('tm-touched').addEventListener('pointerup', function(e) {
-      e.stopPropagation(); copyGuids(false);
+    document.getElementById('tm-undo').addEventListener('pointerup', function(e) {
+      e.stopPropagation(); undoLastGanttEdit();
     });
     document.getElementById('tm-new').addEventListener('pointerup', function(e) {
       e.stopPropagation(); copyGuids(true);
@@ -4828,6 +4828,14 @@
   var _dragConsumed = false;   // set on a committed edit so the seek handler ignores that pointerup
   var EDGE_PX = 5;             // grab zone at each bar end — inside this, a drag resizes, not moves
 
+  // §GANTT_EDIT_UNDO — single-level (not a stack): a drag can cascade N successors with no way back
+  // except regenerating the whole schedule (real gap, this session's own edit UI made it possible).
+  // Scope is deliberately narrow: only commitGanttDrag (E1/E2 move/resize) sets this, not link/unlink
+  // or the property panel — matching exactly the need named in 4D_SCHEDULE_PERFECTION.md, not a
+  // speculative general undo system. { schedId, tasksBefore:{taskId:{start,finish,duration}},
+  // opsBefore:{guid:{start_ts,end_ts,parameters}}, taskId, mode } — cleared on every fresh TM activate().
+  var _lastEdit = null;
+
   // Which bar (and where on it) is under the pointer? Extends findBarAtClick with an edge zone so a
   // single gesture can mean either E1 (move) or E2 (edge-pull), the way P6/MSP behave.
   function ganttHit(e) {
@@ -4911,6 +4919,19 @@
     }
     var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
     var d = function (ms) { return new Date(ms).toISOString().slice(0, 10); };
+
+    // §GANTT_EDIT_UNDO — snapshot BEFORE the engine verb mutates `tasks`. Cascade scope isn't known
+    // until the verb returns, so this captures every leaf task in the active schedule (cheap — a
+    // handful to a few hundred rows), not just the dragged one.
+    var tasksBefore = {};
+    try {
+      var tb = app.db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration ' +
+        'FROM tasks WHERE schedule_id=? AND (is_summary IS NULL OR is_summary=0)', [schedId]);
+      if (tb.length) tb[0].values.forEach(function (row) {
+        tasksBefore[row[0]] = { start: row[1], finish: row[2], duration: row[3] };
+      });
+    } catch (e) {}
+
     var res;
     if (mode === 'move') {
       res = SA.moveTaskCascade(app.db, schedId, bar.taskId, d(bar.startTs + deltaDays * 86400000), {});
@@ -4936,9 +4957,80 @@
     }
     var barsByTask = {};
     for (var i = 0; i < _ganttTasks.length; i++) if (_ganttTasks[i].taskId) barsByTask[_ganttTasks[i].taskId] = _ganttTasks[i];
+
+    // §GANTT_EDIT_UNDO — the element-op "before" state, captured from the in-memory _ops (still the
+    // pre-retime values at this point) for exactly the guids retimeTaskElements is about to touch.
+    // Hash the guid->op lookup ONCE (same shape as retimeTaskElements's own opByGuid below) — a
+    // linear scan per guid here was O(cascadeGuids * totalOps): measured 92s wall-clock on Terminal
+    // (3,519 guids * 48,428 ops) before this fix, unusable for an interactive drag.
+    var opsBefore = {};
+    var _opByGuidForUndo = {};
+    for (var oi2 = 0; oi2 < _ops.length; oi2++) if (_ops[oi2].output_guid) _opByGuidForUndo[_ops[oi2].output_guid] = _ops[oi2];
+    (res.moved || []).forEach(function (m) {
+      var bar2 = barsByTask[m.id]; if (!bar2 || !bar2.guids) return;
+      bar2.guids.forEach(function (g) {
+        var op = _opByGuidForUndo[g];
+        if (op) opsBefore[g] = { start_ts: op.start_ts, end_ts: op.end_ts, parameters: JSON.stringify(op.parameters) };
+      });
+    });
+
     retimeTaskElements(app.db, barsByTask, res.moved || []);
+    _lastEdit = { schedId: schedId, taskId: bar.taskId, mode: mode, tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§GANTT_DRAG_COMMIT task=' + bar.taskId + ' mode=' + mode + ' deltaDays=' + deltaDays +
       ' start=' + res.start + ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
+    invalidateGanttModel();
+    computeDays();
+    drawGanttMini();
+    renderAtTime(_cursor);
+  }
+
+  // §GANTT_EDIT_UNDO — reverse the single most recent commitGanttDrag edit. Restores both halves
+  // that edit changed: the task dates (moveTaskCascade/resizeTask's write to `tasks`) and the
+  // element ops (retimeTaskElements's write to `kernel_ops`) — same two tables, same shape, run
+  // backward. Single-level: clears _lastEdit so a second click is a no-op, not a second undo step.
+  function undoLastGanttEdit() {
+    var app = A();
+    var tip = document.getElementById('tm-gantt-tip');
+    function say(msg) {
+      if (!tip) return;
+      tip.textContent = msg; tip.style.display = 'block';
+      setTimeout(function () { tip.style.display = 'none'; }, 2200);
+    }
+    if (!_lastEdit || !app || !app.db) {
+      console.log('§GANTT_EDIT_UNDO_REJECT reason=nothing_to_undo');
+      say('Nothing to undo');
+      return;
+    }
+    var edit = _lastEdit;
+    _lastEdit = null;   // single-level — commit even if a write below throws, never retry the same edit
+    var db = app.db;
+    db.run('BEGIN');
+    var stT = db.prepare('UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?');
+    var tRestored = 0;
+    for (var tid in edit.tasksBefore) {
+      var t = edit.tasksBefore[tid];
+      stT.run([t.start, t.finish, t.duration, tid]);
+      tRestored++;
+    }
+    stT.free();
+    var stO = db.prepare('UPDATE kernel_ops SET timestamp=?, parameters=? WHERE op_type=\'ELEMENT_PLACE\' AND output_guid=?');
+    var oRestored = 0;
+    // Same O(1)-per-guid hash, same reason as commitGanttDrag's opsBefore capture — a linear scan
+    // per guid here is O(cascadeGuids * totalOps), unusable on a large building's cascade.
+    var _opByGuidForRestore = {};
+    for (var oi3 = 0; oi3 < _ops.length; oi3++) if (_ops[oi3].output_guid) _opByGuidForRestore[_ops[oi3].output_guid] = _ops[oi3];
+    for (var guid in edit.opsBefore) {
+      var o = edit.opsBefore[guid];
+      stO.run([o.start_ts, o.parameters, guid]);
+      var opR = _opByGuidForRestore[guid];
+      if (opR) { opR.start_ts = o.start_ts; opR.end_ts = o.end_ts; opR.parameters = JSON.parse(o.parameters); }
+      oRestored++;
+    }
+    stO.free();
+    db.run('COMMIT');
+    console.log('§GANTT_EDIT_UNDO task=' + edit.taskId + ' mode=' + edit.mode +
+      ' tasksRestored=' + tRestored + ' opsRestored=' + oRestored);
+    say('Undone: ' + edit.mode + ' ' + edit.taskId);
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -5738,6 +5830,7 @@
 
   function activate() {
     if (_active) return;
+    _lastEdit = null;   // §GANTT_EDIT_UNDO — a stale snapshot from a prior building must never apply here
     // §MERGED_GUID: TM mutates elements individually (setMatrixAt/setVisibleAt per slot), which a
     // merged buffer cannot do — so TM re-streams unmerged. Two corrections to the old trigger:
     //   (1) condition is _mergeActive (are merged meshes ACTUALLY in the scene), not _isMobile.


### PR DESCRIPTION
## Summary
- A Gantt drawer drag can cascade N successor tasks with no way back except regenerating the whole schedule (real gap this cycle's own edit UI created).
- Replaces the dead "Copy Touched" debug button (nobody references it — user: "lost touch with them") with **↺ Undo edit**, single-level, scoped to `commitGanttDrag` (E1/E2 move/resize) only. "Copy New" stays as-is — the ⚑ Set Baseline replacement for it is a separate, MOB-dependent decision, not part of this change.
- Snapshots both tables an edit touches (`tasks` + the affected `kernel_ops` rows) before the engine verb runs, restores both exactly on click. Cleared on every fresh `activate()` so a stale cross-building snapshot can never apply.
- Perf bug caught and fixed before shipping: first draft's snapshot capture was O(cascadeGuids × totalOps) — 92s on Terminal. Hashed to O(1), same shape as the existing `retimeTaskElements`'s own lookup — down to 39s (remainder is that function's own pre-existing cost, untouched here).

## Test plan
- [x] `witness_gantt_edit_undo.js` (new) — slices the real shipped functions by balanced braces (no reimplementation), runs against real authored schedules: Duplex (10-task cascade, 898 ops) 9/9, Terminal (20-task cascade, 3,519 ops) 9/9. RED control (edit actually changed something), exact restore, second-click no-op, and out-of-cascade rows proven untouched all verified.
- [x] bar_identity 6/6, palette 7/7, row_order 9/9, coherence 7/7, constraints 18/18
- [x] zone_cpm 11/11, zone_cpm_duplex 9/9, tm_duration_sync 8/8, support_invariant_all 18/18, gap1 7/7
- [x] boq_charts_real_schedule 91/91, class_fallback (all 7 fixtures) 11/11
- [ ] Live browser — not run this session, per session directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)