### PR TITLE
fix(deploy): bump sw.js CACHE_VERSION v946->v947 — 4D fixes were shipping stale-cached

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v946';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v947';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
PRs #1186/#1187/#1188 all modified `PRECACHE_ASSETS` files (`time_machine.js`, `schedule_author.js`, `rates.js`, `rates/sequence_rules.json`) without bumping `CACHE_VERSION` — violates this project's own standing rule. Any browser with a previously-installed v946 service worker kept serving old cached copies of those files regardless of what GH Pages deployed. Caught live: a user's post-#1188 Hospital TM test log gave no way to confirm which code was actually running.

## Test plan
- [x] `node -c viewer/sw.js`
- [ ] Live browser — bump is mechanical (one string), no logic change to verify beyond syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)