### PR TITLE
feat(4d): ⚑ Set Baseline — schedule variance, replaces the dead Copy New button

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1137,6 +1137,55 @@
     return moveTaskCascade(db, scheduleId, taskId, _dayStr(s), opts);
   }
 
+  // setBaseline(db, scheduleId) — §GANTT_EDIT_UNDO's transport-row sibling, ⚑ Set Baseline
+  // (4D_SCHEDULE_PERFECTION.md "the transport row's two buttons"). P6 baseline = a frozen snapshot
+  // of every task's dates, taken at a deliberate moment, compared against the live (possibly
+  // since-edited) schedule — SCHEDULE variance, a different axis from §TM-VARIANCE's existing
+  // C_Project PlannedAmt/CommittedAmt COST variance, which this does not touch.
+  // Single baseline (not P6's multi-baseline numbering) — MVP scope, matches the definition the
+  // user confirmed 2026-08-05: re-running this OVERWRITES the prior baseline, it does not version it.
+  // Snapshots EVERY task row for the schedule (including summaries) so project-level rollup variance
+  // is available too, not just leaf tasks.
+  function setBaseline(db, scheduleId) {
+    db.run('CREATE TABLE IF NOT EXISTS task_baseline (task_id TEXT PRIMARY KEY, schedule_id TEXT, ' +
+      'baseline_start TEXT, baseline_finish TEXT, baseline_duration TEXT, set_at TEXT)');
+    var tr = db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id=?', [scheduleId]);
+    if (!tr.length || !tr[0].values.length) { console.log('§GANTT_SET_BASELINE_FAIL reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+    var setAt = new Date().toISOString();
+    db.run('BEGIN');
+    db.run('DELETE FROM task_baseline WHERE schedule_id=?', [scheduleId]);
+    var st = db.prepare('INSERT INTO task_baseline VALUES (?,?,?,?,?,?)');
+    tr[0].values.forEach(function (row) { st.run([row[0], scheduleId, row[1], row[2], row[3], setAt]); });
+    st.free();
+    db.run('COMMIT');
+    console.log('§GANTT_SET_BASELINE schedule=' + scheduleId + ' tasks=' + tr[0].values.length + ' setAt=' + setAt);
+    return { ok: true, taskCount: tr[0].values.length, setAt: setAt };
+  }
+
+  // getBaselineVariance(db, scheduleId) — reads BOTH tables, computes nothing that isn't a direct
+  // date subtraction of two already-real, already-persisted values. varianceDays > 0 = the task now
+  // finishes LATER than its baseline (slip); < 0 = earlier. `projectVarianceDays` is TASK_ROOT's own
+  // row if present (its schedule_finish is already the whole project's real end, same convention
+  // moveTaskCascade/materializeZones use elsewhere in this file — never re-derived by scanning leaves).
+  function getBaselineVariance(db, scheduleId) {
+    var br;
+    try { br = db.exec('SELECT task_id, baseline_start, baseline_finish FROM task_baseline WHERE schedule_id=?', [scheduleId]); }
+    catch (e) { return { ok: false, reason: 'no_baseline' }; }
+    if (!br.length || !br[0].values.length) return { ok: false, reason: 'no_baseline' };
+    var baseline = {};
+    br[0].values.forEach(function (row) { baseline[row[0]] = { start: row[1], finish: row[2] }; });
+    var tr = db.exec('SELECT task_id, name, schedule_start, schedule_finish, is_summary FROM tasks WHERE schedule_id=?', [scheduleId]);
+    var tasks = [], projectVarianceDays = null;
+    (tr.length ? tr[0].values : []).forEach(function (row) {
+      var tid = row[0], b = baseline[tid]; if (!b) return;   // a task added after baseline was set — no variance to report
+      var varianceDays = _dayNum(row[3]) - _dayNum(b.finish);
+      tasks.push({ taskId: tid, name: row[1], baselineStart: b.start, baselineFinish: b.finish,
+        currentStart: row[2], currentFinish: row[3], varianceDays: varianceDays });
+      if (tid === 'TASK_ROOT') projectVarianceDays = varianceDays;
+    });
+    return { ok: true, tasks: tasks, projectVarianceDays: projectVarianceDays };
+  }
+
   // computeCpm(db, scheduleId, opts) — write early/late dates, float, is_critical onto the leaf tasks.
   // fixedDates opt (§ZONE_CPM_COHERENCE): computeCpm's forward pass normally DERIVES each task's
   // early start from the graph (max over predecessors' EF+lag) — correct when the dates themselves
@@ -1441,6 +1490,8 @@
     moveTask: moveTask,
     moveTaskCascade: moveTaskCascade,   // §GANTT_EDIT C1/C2 — the constraint-aware move
     resizeTask: resizeTask,             // §GANTT_EDIT E2 — edge-pull, duration changes
+    setBaseline: setBaseline,           // ⚑ Set Baseline — schedule variance snapshot, single baseline
+    getBaselineVariance: getBaselineVariance,
     addTask: addTask,
     reparentTask: reparentTask,
     breakdownByAttribute: breakdownByAttribute,
@@ -1451,5 +1502,5 @@
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
   else global.ScheduleAuthor = API;
 
-  console.log('§SCHEDULE_AUTHOR_LOADED v7');
+  console.log('§SCHEDULE_AUTHOR_LOADED v8');
 })(typeof self !== 'undefined' ? self : this);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v947';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v948';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_baseline.js
+++ b/viewer/tests/witness_gantt_baseline.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// witness_gantt_baseline.js — ⚑ Set Baseline (2026-08-05). Proves ScheduleAuthor.setBaseline /
+// getBaselineVariance against a REAL authored schedule + a REAL drag (moveTaskCascade), on real
+// building fixtures. Both verbs are exported and node-testable directly — no slicing needed, unlike
+// the DOM-coupled UI functions witness_gantt_edit_undo.js had to slice.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDING = process.argv[2] || 'Terminal';
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const dbPath = path.join(BLD_DIR, BUILDING + '_extracted.db');
+  if (!fs.existsSync(dbPath)) { console.log('§BASELINE_SKIP ' + BUILDING + ' fixture missing'); return; }
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES, { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate });
+  if (!mres.ok) { console.log('§BASELINE_SKIP materializeZones failed: ' + JSON.stringify(mres)); db.close(); return; }
+  const schedId = 'SCH_AUTHORED';
+
+  // RED CONTROL: no baseline set yet -> honest refusal, not a fabricated empty-success.
+  const preRes = ScheduleAuthor.getBaselineVariance(db, schedId);
+  assert(preRes.ok === false && preRes.reason === 'no_baseline', 'RED-CONTROL getBaselineVariance before any setBaseline call refuses honestly');
+
+  const setRes = ScheduleAuthor.setBaseline(db, schedId);
+  assert(setRes.ok === true && setRes.taskCount > 0, 'setBaseline captures every task row — taskCount=' + (setRes && setRes.taskCount));
+
+  const v0 = ScheduleAuthor.getBaselineVariance(db, schedId);
+  assert(v0.ok === true, 'getBaselineVariance succeeds once a baseline exists');
+  const nonZeroAtStart = v0.tasks.filter(function (t) { return t.varianceDays !== 0; });
+  assert(nonZeroAtStart.length === 0,
+    'immediately after baseline, every task shows 0 variance (baseline == current) — nonZero=' + nonZeroAtStart.length);
+  assert(v0.tasks.length === setRes.taskCount, 'getBaselineVariance covers exactly the tasks setBaseline captured');
+
+  // Real drag — same engine verb commitGanttDrag uses, real cascade, on a task with a real successor.
+  const seqR = db.exec('SELECT predecessor_id FROM task_sequences GROUP BY predecessor_id HAVING COUNT(*) >= 1');
+  const dragTaskId = (seqR.length ? seqR[0].values[0][0] : null) ||
+    db.exec("SELECT task_id FROM tasks WHERE schedule_id='SCH_AUTHORED' AND (is_summary IS NULL OR is_summary=0) LIMIT 1")[0].values[0][0];
+  const curR = db.exec('SELECT schedule_start FROM tasks WHERE task_id=?', [dragTaskId]);
+  const newStart = new Date(Date.parse(curR[0].values[0][0] + 'T00:00:00Z') + 20 * 86400000).toISOString().slice(0, 10);
+  const moveRes = ScheduleAuthor.moveTaskCascade(db, schedId, dragTaskId, newStart, {});
+  assert(moveRes.ok === true, 'the real drag itself succeeds — dragTask=' + dragTaskId + ' cascaded=' + (moveRes && moveRes.cascaded));
+  const movedIds = (moveRes.moved || []).map(function (m) { return m.id; });
+
+  const v1 = ScheduleAuthor.getBaselineVariance(db, schedId);
+  const nonZeroAfter = v1.tasks.filter(function (t) { return t.varianceDays !== 0; }).map(function (t) { return t.taskId; });
+  const wrongZero = movedIds.filter(function (id) { return nonZeroAfter.indexOf(id) < 0; });
+  const wrongNonZero = nonZeroAfter.filter(function (id) { return movedIds.indexOf(id) < 0; });
+  console.log('§BASELINE ' + BUILDING + ' dragTask=' + dragTaskId + ' cascaded=' + moveRes.cascaded +
+    ' movedByDrag=' + movedIds.length + ' nonZeroVariance=' + nonZeroAfter.length);
+  assert(wrongZero.length === 0, 'every task the drag actually moved shows non-zero variance — missing=' + JSON.stringify(wrongZero));
+  assert(wrongNonZero.length === 0, 'no task OUTSIDE the drag shows spurious variance — spurious=' + JSON.stringify(wrongNonZero));
+
+  // Re-baseline (idempotent overwrite, single baseline — not P6's multi-baseline numbering).
+  const setRes2 = ScheduleAuthor.setBaseline(db, schedId);
+  assert(setRes2.taskCount === setRes.taskCount, 're-baselining does not change the task count (overwrite, not accumulation)');
+  const rowCountR = db.exec('SELECT COUNT(*) FROM task_baseline WHERE schedule_id=?', [schedId]);
+  assert(rowCountR[0].values[0][0] === setRes.taskCount, 'task_baseline row count still equals taskCount after re-baseline — no duplicate rows');
+  const v2 = ScheduleAuthor.getBaselineVariance(db, schedId);
+  const nonZeroAfterRebaseline = v2.tasks.filter(function (t) { return t.varianceDays !== 0; });
+  assert(nonZeroAfterRebaseline.length === 0,
+    'after re-baselining, every task shows 0 variance again (new baseline == current) — nonZero=' + nonZeroAfterRebaseline.length);
+
+  db.close();
+  console.log('\n§W-BASELINE SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§BASELINE_ERROR', e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2669,7 +2669,7 @@
         '<button id="tm-fwd-btn" style="width:30px;font-size:14px" title="Build">&#x25B6;</button>' +
         '<button id="tm-end-btn" style="width:30px;font-size:14px" title="Jump to end">&#x25B6;&#x25B6;</button>' +
         '<button id="tm-undo" style="flex:1;font-size:9px" title="Undo the last Gantt drag/resize">&#x21BA; Undo edit</button>' +
-        '<button id="tm-new" style="flex:1;font-size:9px">Copy New</button>' +
+        '<button id="tm-baseline" style="flex:1;font-size:9px" title="Snapshot current dates as the baseline for schedule variance">&#x2691; Set Baseline</button>' +
       '</div>' +
       '<div id="tm-gantt-box" class="tm-drawer-bottom">' +
         // §GANTT_PALETTE 2026-08-04: phase legend strip removed — the hover tooltip already reports
@@ -2800,8 +2800,8 @@
     document.getElementById('tm-undo').addEventListener('pointerup', function(e) {
       e.stopPropagation(); undoLastGanttEdit();
     });
-    document.getElementById('tm-new').addEventListener('pointerup', function(e) {
-      e.stopPropagation(); copyGuids(true);
+    document.getElementById('tm-baseline').addEventListener('pointerup', function(e) {
+      e.stopPropagation(); setGanttBaseline();
     });
     document.getElementById('tm-sun').addEventListener('pointerup', function(e) {
       e.stopPropagation();
@@ -5035,6 +5035,31 @@
     computeDays();
     drawGanttMini();
     renderAtTime(_cursor);
+  }
+
+  // ⚑ Set Baseline — replaces the dead Copy New slot. Definition user-confirmed 2026-08-05
+  // (4D_SCHEDULE_PERFECTION.md "the transport row's two buttons"): a deliberate snapshot of the
+  // schedule's own dates, a DIFFERENT axis from §TM-VARIANCE's existing ERP cost variance. Manual
+  // button today because MOB's auto-trigger-at-ERP-push (M2) doesn't exist yet — once it does, the
+  // SAME ScheduleAuthor.setBaseline verb gets called there too; this button does not become obsolete,
+  // it becomes the "re-baseline for an approved change order" case named in the spec.
+  function setGanttBaseline() {
+    var app = A();
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    var tip = document.getElementById('tm-gantt-tip');
+    function say(msg) {
+      if (!tip) return;
+      tip.textContent = msg; tip.style.display = 'block';
+      setTimeout(function () { tip.style.display = 'none'; }, 2600);
+    }
+    if (!app || !app.db || !SA || !SA.setBaseline) {
+      console.log('§GANTT_SET_BASELINE_REJECT reason=ScheduleAuthor_not_loaded');
+      say('Not available'); return;
+    }
+    var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
+    var res = SA.setBaseline(app.db, schedId);
+    if (!res.ok) { say('No schedule to baseline yet — generate a 4D schedule first'); return; }
+    say('Baseline set — ' + res.taskCount + ' tasks');
   }
 
   function wireGanttDrag() {


### PR DESCRIPTION
## Summary
- Second half of the transport-row pair (↺ Undo edit shipped in #1188). Definition user-confirmed: P6 baseline is a frozen snapshot of the schedule's own dates, compared against the live schedule — SCHEDULE variance, a different axis from `§TM-VARIANCE`'s existing ERP COST variance (untouched).
- `ScheduleAuthor.setBaseline(db, scheduleId)` — snapshots every task row into a new `task_baseline` table. Single baseline, re-running overwrites (MVP scope, not P6 multi-baseline numbering).
- `ScheduleAuthor.getBaselineVariance(db, scheduleId)` — real `varianceDays` per task (direct date subtraction, nothing invented), honest refusal when no baseline set.
- Manual button today since MOB's auto-trigger-at-ERP-push (M2) isn't built; same verb gets called there later — this button becomes "re-baseline for a change order," not obsolete.
- Bumps `sw.js` `CACHE_VERSION` v947→v948 in the same PR (touches precached files again) — applying the #1189 lesson proactively this time.

## Test plan
- [x] `witness_gantt_baseline.js` (new): real authored schedule + real drag on Terminal (20-task cascade) 11/11, Duplex (10-task cascade) 11/11 — RED control, exact scope match, re-baseline is a true overwrite
- [x] bar_identity 6/6, palette 7/7, row_order 9/9, coherence 7/7, constraints 18/18
- [x] zone_cpm 11/11, zone_cpm_duplex 9/9, tm_duration_sync 8/8, support_invariant_all 18/18, gap1 7/7
- [x] boq_charts_real_schedule 91/91, gantt_edit_undo 9/9, class_fallback (7 fixtures) 11/11
- [ ] Live browser — not run this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)