### PR TITLE
feat(4d): §GANTT_AUTHOR_ENTRY native — Generate button calls the engine directly, no side panel

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v949';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v950';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v948';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v949';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_native_generate.js
+++ b/viewer/tests/witness_gantt_native_generate.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// witness_gantt_native_generate.js — §GANTT_AUTHOR_ENTRY native (2026-08-05). Proves the drawer's
+// "Generate 4D schedule" button now calls the real engine directly instead of reopening the old
+// ScheduleAuthorUI side panel, AND proves the captured-schedule guard actually prevents a synthetic
+// schedule from being generated on top of a real imported (Bonsai/Revit/IFC-native) one. Sliced by
+// balanced braces from the real shipped function — same convention as commitGanttDrag/
+// undoLastGanttEdit's witnesses, never reimplemented.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+const sliced = sliceFn(tmSrc, 'generateGanttSchedule');
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDING = process.argv[2] || 'Duplex';
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const dbPath = path.join(BLD_DIR, BUILDING + '_extracted.db');
+  if (!fs.existsSync(dbPath)) { console.log('§SKIP ' + BUILDING + ' fixture missing'); return; }
+  const rules = loadRules();
+
+  // ── Scenario A: no schedule exists yet — native generate must actually create one ──
+  {
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    var toggleCalled = 0, tipMsgs = [];
+    const sandbox = {
+      console: console, JSON: JSON, Date: Date, Math: Math, setTimeout: setTimeout,
+      window: { ScheduleAuthor: ScheduleAuthor, ScheduleGate: ScheduleGate,
+        SEQUENCE_RULES: rules.SEQUENCE_RULES, LABOR_RATES: rules.LABOR_RATES, RATES: rules.RATES,
+        ScheduleAuthorUI: { toggle: function () { toggleCalled++; } },
+        tmRefoldSchedule: function () { /* no-op in this headless harness — refresh path proven elsewhere */ } },
+      A: function () { return { db: db }; },
+      document: { getElementById: function () { return { textContent: '', style: {} }; } },
+      invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {}, _cursor: 0
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nglobalThis.__gen = generateGanttSchedule;', sandbox);
+    sandbox.__gen();
+
+    const tr = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED'");
+    const taskCount = tr.length ? tr[0].values[0][0] : 0;
+    assert(taskCount > 0, 'Scenario A (' + BUILDING + ', no schedule yet): native generate created real SCH_AUTHORED tasks — count=' + taskCount);
+    assert(toggleCalled === 0, 'Scenario A: the old ScheduleAuthorUI panel was NEVER opened — this is the native path, not a redirect');
+    db.close();
+  }
+
+  // ── Scenario B: a captured (imported) schedule already exists — must NOT be clobbered ──
+  {
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    // A real schedule under a non-SCH_AUTHORED id — the SAME real materializeZones call (real
+    // columns, real write path), just a different scheduleId, standing in for a real Bonsai/Revit
+    // import the same way activeSchedule() actually distinguishes one: schedule_id !== 'SCH_AUTHORED'.
+    const seed = ScheduleAuthor.materializeZones(db, rules.SEQUENCE_RULES,
+      { scheduleId: 'IMPORTED_1', start: '2026-01-01', laborRates: rules.LABOR_RATES, rates: rules.RATES, scheduleGate: ScheduleGate });
+    if (!seed.ok) { console.log('§SKIP Scenario B — seed schedule failed: ' + JSON.stringify(seed)); db.close(); return; }
+
+    var toggleCalled = 0;
+    const sandbox = {
+      console: console, JSON: JSON, Date: Date, Math: Math, setTimeout: setTimeout,
+      window: { ScheduleAuthor: ScheduleAuthor, ScheduleGate: ScheduleGate,
+        SEQUENCE_RULES: rules.SEQUENCE_RULES, LABOR_RATES: rules.LABOR_RATES, RATES: rules.RATES,
+        ScheduleAuthorUI: { toggle: function () { toggleCalled++; } },
+        tmRefoldSchedule: function () {} },
+      A: function () { return { db: db }; },
+      document: { getElementById: function () { return { textContent: '', style: {} }; } },
+      invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {}, _cursor: 0
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nglobalThis.__gen = generateGanttSchedule;', sandbox);
+    sandbox.__gen();
+
+    const tr = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='SCH_AUTHORED'");
+    const authoredCount = tr.length ? tr[0].values[0][0] : 0;
+    assert(authoredCount === 0, 'Scenario B (captured schedule exists): materializeZones was NOT run — no SCH_AUTHORED tasks were created — count=' + authoredCount);
+    assert(toggleCalled === 1, 'Scenario B: the old panel WAS opened exactly once — the one legitimate remaining fallback, for editing the real imported schedule');
+    const importedStillThere = db.exec("SELECT COUNT(*) FROM tasks WHERE schedule_id='IMPORTED_1'")[0].values[0][0];
+    const expected = seed.zoneCount + 1;   // + TASK_ROOT
+    assert(importedStillThere === expected, 'Scenario B: the real imported schedule is completely untouched — expected=' + expected + ' actual=' + importedStillThere);
+    db.close();
+  }
+
+  console.log('\n§W-NATIVE-GEN SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§NATIVE_GEN_ERROR', e); process.exit(1); });

--- a/viewer/tests/witness_gantt_og_grid_perf.js
+++ b/viewer/tests/witness_gantt_og_grid_perf.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// witness_gantt_og_grid_perf.js — §OG_GRID_Z_BAND (2026-08-05). Proves two things about
+// §PHASE_OVERLAP_SUPPORT_GUARD's cell-bucket pass (time_machine.js, "var _ogCELL" block):
+//   1. CORRECTNESS: the Z-banded grid produces the EXACT same push decisions as a brute-force
+//      O(n^2) reference with no grid at all — the Z-banding only prunes which cells get SCANNED,
+//      the inner predicate is byte-identical, so this proves the pruning drops nothing real.
+//   2. PERFORMANCE: a ceiling on Terminal (the worst real fixture — small footprint, 22 stacked
+//      storeys) so a future change can't silently reintroduce the multi-second block this fixed.
+//      Measured pre-fix: 4636ms. Post-fix: ~2840ms. Ceiling set well above measured noise, tight
+//      enough to catch a real regression back toward the old XY-only behavior.
+// Sliced by raw text span (flat sequential statements, not a named function — brace-balance
+// checked before running), same "never reimplement the block under test" convention this repo
+// already uses for matchRule/commitGanttDrag/undoLastGanttEdit.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const startMark = 'var _ogCELL = ';
+const endMark = "if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +\n        ' elements later than their §PHASE_OVERLAP_BAND window to stay after their real structural support');";
+const si = tmSrc.indexOf(startMark);
+if (si < 0) throw new Error('start mark not found — has the block been renamed/moved?');
+const ei = tmSrc.indexOf(endMark, si);
+if (ei < 0) throw new Error('end mark not found — has the block been renamed/moved?');
+const block = tmSrc.slice(si, ei + endMark.length);
+let depth = 0;
+for (const ch of block) { if (ch === '{') depth++; else if (ch === '}') depth--; }
+assert(depth === 0, 'sliced block is brace-balanced (a self-contained statement sequence, not a truncated fragment)');
+
+function loadRules() {
+  var txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  var start = txt.indexOf('var RATES = {');
+  var defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  var end = txt.indexOf('};', defIdx) + 2;
+  var slice = txt.slice(start, end);
+  return (new Function(slice + '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT };'))();
+}
+
+function realScheduledFrom(rows, matchRule, rules) {
+  return rows.map(function (row, i) {
+    const cls = row[1], cx = row[2], cy = row[3], cz = row[4], bx = row[5], by = row[6], bz = row[7];
+    const rule = matchRule(cls, rules.SEQUENCE_RULES, rules.SEQUENCE_DEFAULT);
+    const t0 = i * 60000;
+    return { guid: row[0], s: t0, e: t0 + 60000, cls: cls, seq: rule.sequence,
+      bz: cz - bz / 2, tz: cz + bz / 2, x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2 };
+  });
+}
+
+// Brute-force O(n^2) reference — the SAME predicate AND the same in-place-mutate-as-you-go
+// semantics as the shipped block (a carrier's own bz is always below what it carries, so
+// processing in ascending bz order means a candidate's .e may already reflect ITS OWN push
+// applied earlier in this same pass — that cascading is load-bearing, not incidental, so an
+// honest reference has to replicate it). The only real difference from the shipped code is HOW
+// candidates are found: no grid at all, scan every other element every time. Deliberately
+// independent code (not sliced) so a bug shared by both implementations would not hide here.
+function bruteForcePush(elements) {
+  const EPS = 0.05, GAP = 0.5;
+  const xy = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
+  const work = elements.map(function (e) { return { guid: e.guid, s: e.s, e: e.e, cls: e.cls, seq: e.seq, bz: e.bz, tz: e.tz, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1 }; });
+  work.sort(function (a, b) { return a.bz - b.bz; });
+  const pushed = {};
+  work.forEach(function (T) {
+    const promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
+    let lastEnd = 0;
+    for (let i = 0; i < work.length; i++) {
+      const S = work[i]; if (S.guid === T.guid) continue;
+      if (S.seq <= 4 && S.bz < T.bz - EPS && Math.abs(S.tz - T.bz) <= GAP && xy(S, T) && S.e > lastEnd) lastEnd = S.e;
+      if (promotedSlab && S.cls.indexOf('IfcWall') === 0 && S.bz < T.bz - EPS && Math.abs(S.tz - T.bz) <= GAP && xy(S, T) && S.e > lastEnd) lastEnd = S.e;
+    }
+    if (lastEnd && T.s < lastEnd) {
+      const dur = Math.max(60000, T.e - T.s);
+      T.s = lastEnd + 1; T.e = T.s + dur;
+      pushed[T.guid] = true;
+    } else {
+      pushed[T.guid] = false;
+    }
+  });
+  return pushed;
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const rules = loadRules();
+  const matchRule = ScheduleAuthor.matchRule;
+
+  // ── CORRECTNESS — small fixture, O(n^2) reference is cheap enough to be honest ──
+  const smallPath = path.join(BLD_DIR, 'Duplex_extracted.db');
+  if (fs.existsSync(smallPath)) {
+    const db = new SQL.Database(fs.readFileSync(smallPath));
+    const r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(t.center_x,0), COALESCE(t.center_y,0), COALESCE(t.center_z,0), " +
+      "COALESCE(t.bbox_x,0), COALESCE(t.bbox_y,0), COALESCE(t.bbox_z,0) FROM elements_meta m " +
+      "LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    db.close();
+    const _allScheduled = realScheduledFrom(r[0].values, matchRule, rules);
+    const refPushed = bruteForcePush(_allScheduled);
+    const origS = {};
+    _allScheduled.forEach(function (e) { origS[e.guid] = e.s; });   // capture BEFORE the block mutates in place (objects are shared by reference, not deep-cloned by .slice())
+
+    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, console: console, Math: Math };
+    vm.createContext(sandbox);
+    vm.runInContext(block, sandbox);
+    const realPushedIds = {};
+    sandbox._allScheduled.forEach(function (T) { if (T.s !== origS[T.guid]) realPushedIds[T.guid] = T.s; });
+    // Compare by "was this guid identified as needing a push at all" — refPushed has a nonzero
+    // lastEnd whenever the brute force found a real carrier constraint above baseMs.
+    let mismatches = 0;
+    for (const guid in refPushed) {
+      const realSaysPush = !!realPushedIds[guid];
+      if (refPushed[guid] !== realSaysPush) mismatches++;
+    }
+    assert(mismatches === 0, 'Duplex: grid-based push decisions match the O(n^2) brute-force reference exactly — mismatches=' + mismatches + '/' + Object.keys(refPushed).length);
+  } else {
+    console.log('§SKIP correctness check — Duplex fixture missing');
+  }
+
+  // ── PERFORMANCE — Terminal, the real reported-hang fixture ──
+  const bigPath = path.join(BLD_DIR, 'Terminal_extracted.db');
+  if (fs.existsSync(bigPath)) {
+    const db = new SQL.Database(fs.readFileSync(bigPath));
+    const r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(t.center_x,0), COALESCE(t.center_y,0), COALESCE(t.center_z,0), " +
+      "COALESCE(t.bbox_x,0), COALESCE(t.bbox_y,0), COALESCE(t.bbox_z,0) FROM elements_meta m " +
+      "LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    db.close();
+    const _allScheduled = realScheduledFrom(r[0].values, matchRule, rules);
+    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, console: console, Math: Math };
+    vm.createContext(sandbox);
+    const t0 = process.hrtime.bigint();
+    vm.runInContext(block, sandbox);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    console.log('§OG_GRID_PERF Terminal n=' + _allScheduled.length + ' ms=' + ms.toFixed(1) + ' pushed=' + sandbox._ogPushed);
+    assert(ms < 3500, 'Terminal (the real reported-hang fixture, 48,428 elements) completes under 3500ms — measured=' + ms.toFixed(1) + 'ms (pre-fix was 4636ms)');
+  } else {
+    console.log('§SKIP performance check — Terminal fixture missing');
+  }
+
+  console.log('\n§W-OG-GRID SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(function (e) { console.error('§OG_GRID_ERROR', e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5079,6 +5079,57 @@
     say('Baseline set — ' + res.taskCount + ' tasks');
   }
 
+  // §GANTT_AUTHOR_ENTRY (native) — the drawer's "Generate 4D schedule" button used to just call
+  // ScheduleAuthorUI.toggle(), reopening the old side panel — a hidden dependency, not the "native
+  // to the drawer" generation this was supposed to be (4D_SCHEDULE_PERFECTION.md, user ruling
+  // 2026-08-05). Calls the real engine verb directly, same as the panel's own generateDraft() zone-
+  // detail path (schedule_author_ui.js), not a reimplementation of it.
+  function generateGanttSchedule() {
+    var app = A();
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    var tip = document.getElementById('tm-gantt-tip');
+    function say(msg) {
+      if (!tip) return;
+      tip.textContent = msg; tip.style.display = 'block';
+      setTimeout(function () { tip.style.display = 'none'; }, 3200);
+    }
+    if (!app || !app.db || !SA || !SA.materializeZones) {
+      console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=ScheduleAuthor_not_loaded');
+      say('Not available'); return;
+    }
+    // Never clobber a REAL imported (Bonsai/Revit/IFC-native) schedule with a synthetic one — the
+    // SAME guard schedule_author_ui.js's generateDraft() already applies before it materializes
+    // anything. The drawer doesn't offer fine-grained editing for a captured schedule's own
+    // structure yet, so THIS is the one legitimate remaining reason to fall back to that panel —
+    // not a general re-opening of it.
+    var act = SA.activeSchedule ? SA.activeSchedule(app.db) : null;
+    if (act && act.captured) {
+      console.log('§GANTT_AUTHOR_ENTRY captured=' + act.id + ' — opening the schedule author panel to edit it in place, not regenerating');
+      say('Imported schedule "' + act.name + '" — opening its editor');
+      if (window.ScheduleAuthorUI) window.ScheduleAuthorUI.toggle();
+      else console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=ScheduleAuthorUI_not_loaded_for_captured_schedule');
+      return;
+    }
+    var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
+    var res = SA.materializeZones(app.db, SR, { start: '2026-01-01', laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
+    if (!res.ok) {
+      console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
+      res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: '2026-01-01', laborRates: LR, blank: false }) : { ok: false };
+    }
+    if (!res.ok) {
+      console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=' + (res.reason || 'materialize_failed'));
+      say('Could not generate a schedule'); return;
+    }
+    console.log('§GANTT_AUTHOR_ENTRY native generate zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') +
+      ' phases=' + (res.phases ? res.phases.length : 'n/a'));
+    say('Schedule generated — refreshing…');
+    // Reuse the SAME refresh path applyTo4D() already uses for this exact situation (a fresh/edited
+    // schedule needs the drawer's overlay re-run) — real, already-working machinery, not a second
+    // lighter-weight refresh path whose correctness would need its own separate proof.
+    if (typeof window.tmRefoldSchedule === 'function') window.tmRefoldSchedule();
+    else { invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor); }
+  }
+
   function wireGanttDrag() {
     var cv = document.getElementById('tm-gantt-canvas');
     if (!cv || cv._dragWired) return;
@@ -5269,10 +5320,7 @@
         ab._wired = true;
         ab.addEventListener('pointerup', function (e) {
           e.stopPropagation();
-          console.log('§GANTT_AUTHOR_ENTRY opening the schedule author from the drawer');
-          if (window.ScheduleAuthorUI) window.ScheduleAuthorUI.toggle();
-          else if (typeof window.openScheduleAuthorWizard === 'function') window.openScheduleAuthorWizard();
-          else console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=ScheduleAuthorUI_not_loaded');
+          generateGanttSchedule();
         });
       }
     })();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4130,23 +4130,40 @@
       // now gated on the TARGET being a promoted slab.
       var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
       var _ogEPS = 0.05, _ogGAP = 0.5;
-      var _ogCells = function (e) {
+      // §OG_GRID_Z_BAND (2026-08-05, measured not guessed — 4D_SCHEDULE_PERFECTION.md §Open Decisions
+      // named this block "NOT yet measured, prime suspect"). The grid used to bucket by XY only, so
+      // a small-footprint TALL building stacks every floor's structural elements into the SAME cell —
+      // measured 4636ms on Terminal's 48,428 elements (22 stacked storeys, small footprint, worst
+      // cell 379 members) vs 1695ms on Hospital's 63,415 (more elements, but a bigger footprint means
+      // less Z-stacking per cell) — element COUNT alone doesn't predict the cost, per-cell Z-density
+      // does. Bucketing Z too prunes each query to the target's own real vertical neighborhood — the
+      // ONLY z-range `S.bz<T.bz-EPS && |S.tz-T.bz|<=GAP` can ever match — with the identical predicate
+      // inside the loop unchanged, so results are provably identical, only the scan is smaller.
+      var _ogCellsFor = function (x0, x1, y0, y1, z0, z1) {
         var out = [];
-        for (var cx = Math.floor(e.x0 / _ogCELL); cx <= Math.floor(e.x1 / _ogCELL); cx++)
-          for (var cy = Math.floor(e.y0 / _ogCELL); cy <= Math.floor(e.y1 / _ogCELL); cy++) out.push(cx + '|' + cy);
+        for (var cx = Math.floor(x0 / _ogCELL); cx <= Math.floor(x1 / _ogCELL); cx++)
+          for (var cy = Math.floor(y0 / _ogCELL); cy <= Math.floor(y1 / _ogCELL); cy++)
+            for (var cz = Math.floor(z0 / _ogCELL); cz <= Math.floor(z1 / _ogCELL); cz++)
+              out.push(cx + '|' + cy + '|' + cz);
         return out;
       };
+      // Build-time: bucket a candidate under its OWN full vertical extent, so it registers in every
+      // z-cell it actually occupies (a tall candidate can span more than one).
+      var _ogCellsBuild = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz, e.tz); };
+      // Query-time: only a target's real z-neighborhood [T.bz-GAP, T.bz+GAP] can ever satisfy the
+      // |S.tz-T.bz|<=GAP predicate — querying anything wider would waste the pruning this exists for.
+      var _ogCellsQuery = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz - _ogGAP, e.bz + _ogGAP); };
       var _ogXY = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
       var _ogStructGrid = {}, _ogWallGrid = {};
       _allScheduled.forEach(function (e) {
-        if (e.seq <= 4) _ogCells(e).forEach(function (c) { (_ogStructGrid[c] = _ogStructGrid[c] || []).push(e); });
-        else if (e.cls.indexOf('IfcWall') === 0) _ogCells(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
+        if (e.seq <= 4) _ogCellsBuild(e).forEach(function (c) { (_ogStructGrid[c] = _ogStructGrid[c] || []).push(e); });
+        else if (e.cls.indexOf('IfcWall') === 0) _ogCellsBuild(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
       });
       _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
       var _ogPushed = 0;
       _allScheduled.forEach(function (T) {
         var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
-        var cells = _ogCells(T), seen = {}, lastEnd = 0;
+        var cells = _ogCellsQuery(T), seen = {}, lastEnd = 0;
         for (var ci = 0; ci < cells.length; ci++) {
           var arr = _ogStructGrid[cells[ci]];
           if (arr) for (var si = 0; si < arr.length; si++) {


### PR DESCRIPTION
## Summary
- User: "Hiding the Generate 4D schedule which hangs is not following my request to get it removed... we be doing it natively in the gantt chart panel." The drawer's "Generate 4D schedule" button called `window.ScheduleAuthorUI.toggle()` — reopening the OLD side panel every time, a hidden dependency the earlier removal never actually cut.
- `generateGanttSchedule()` now calls `ScheduleAuthor.materializeZones()` directly — the same real engine verb the panel's own `generateDraft()` uses, not a reimplementation.
- One case deliberately still falls back to the old panel: a real imported (Bonsai/Revit/IFC-native) schedule already active — replicates `generateDraft()`'s own captured-schedule guard so a native path can't silently create a competing schedule alongside a real one.

## Test plan
- [x] `witness_gantt_native_generate.js` (new, sliced by balanced braces): Scenario A (no schedule yet, native generate works, old panel never opens) + Scenario B (real captured schedule seeded via the real engine, native path refuses, old panel opens exactly once, imported schedule provably untouched) — 5/5 on Duplex and Terminal
- [x] Full regression clean: bar_identity 6/6, palette 7/7, row_order 9/9, coherence 7/7, constraints 18/18, zone_cpm 11/11, zone_cpm_duplex 9/9, tm_duration_sync 8/8, support_invariant_all 18/18, gap1 7/7, boq_charts_real_schedule 91/91, gantt_edit_undo 9/9, gantt_baseline 11/11, og_grid_perf 3/3
- [x] Bumps sw.js CACHE_VERSION v949→v950 in this same PR
- [ ] Live browser — not run this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)