### PR TITLE
fix(cpe): scrub/POV panels default clear of #cpe-panel

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1189,14 +1189,20 @@
   function _buildScrubPanel() {
     var a = A();
     var vfDefaultTop = (a.canvas ? a.canvas.clientHeight : window.innerHeight) - VF_DEFAULT_H - VF_MARGIN - 40;
+    // §CPE_PANEL_CLEAR (2026-08-05, user: "place those new panels away from present alt-c panel
+    // so not hidden by each other") — #cpe-panel defaults to top:60,RIGHT:12,width:412 (near
+    // full-height, right-anchored). B's old default (canvasWidth-VF_DEFAULT_W-MARGIN) landed
+    // inside that same right-hand column. Anchored to the LEFT edge instead — clear of it.
     var rect = _scrubRect || {
-      left: Math.max(VF_MARGIN, (a.canvas ? a.canvas.clientWidth : window.innerWidth) - SCRUB_PANEL_W - VF_MARGIN),
+      left: VF_MARGIN,
       top: vfDefaultTop + VF_DEFAULT_H + SCRUB_PANEL_GAP
     };
     var d = document.createElement('div');
     d.id = 'cpe-scrub-panel';
+    // z-index above #cpe-panel's 10000 (user: "the scrub timeline should be above all as it got
+    // tucked in bottom right") — was 9997, the most-buried of the three CPE panels.
     d.style.cssText = 'position:fixed;left:' + rect.left + 'px;top:' + rect.top + 'px;width:' + SCRUB_PANEL_W + 'px;' +
-      'z-index:9997;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:6px;' +
+      'z-index:10001;background:rgba(20,22,26,0.96);border:1px solid #3a3f47;border-radius:6px;' +
       'box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:system-ui,sans-serif';
     d.innerHTML =
       '<div id="cpe-scrub-title" title="drag to move the timeline" style="padding:4px 8px;cursor:move;' +


### PR DESCRIPTION
## Summary
- Recovers commit a4c24da, orphaned on `fix/cpe-vf-followup` by the same squash-merge race that hit PR #1184/#1192 — rebuilt clean off fresh origin/main.
- B (viewfinder) and the scrub panel now default-anchor to the LEFT edge instead of the right, since `#cpe-panel` defaults to `top:60,right:12,width:412` and both panels' old right-anchored defaults landed in that same column, overlapping and hidden behind it (z-index 10000 beat 9998/9997).
- Scrub panel z-index raised 9997 → 10001 (above `#cpe-panel`) — user: "the scrub timeline should be above all as it got tucked in bottom right."

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` 16/16 green against HHS_Office_Federated (localhost:8460)
- [x] Clean cherry-pick onto fresh origin/main, no conflicts

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>