### PR TITLE
feat(4d): §EXACT_LOOKUP_BLINDSPOT P1 — export classify() from schedule_author.js

### DIFF
--- a/viewer/boq_charts.html
+++ b/viewer/boq_charts.html
@@ -1805,12 +1805,14 @@ function renderCharts() {
     var resKey = '';
     if (t.ifcClasses && t.ifcClasses.length) {
       for (const cls of t.ifcClasses) {
-        var sr = SEQUENCE_RULES[cls];
+        // §EXACT_LOOKUP_BLINDSPOT P2 — was a raw SEQUENCE_RULES[cls] dict lookup, missing tier
+        // 2 (schema-hierarchy inheritance) and tier 3's §CLASS_UNMATCHED visibility entirely.
+        var sr = window.ScheduleAuthor.classify(cls, window.IFC_SCHEMA_HIERARCHY);
         if (sr && sr.resource) { resKey = sr.resource; break; }
       }
     }
     if (!resKey && t.ifcClass) {
-      var sr2 = SEQUENCE_RULES[t.ifcClass];
+      var sr2 = window.ScheduleAuthor.classify(t.ifcClass, window.IFC_SCHEMA_HIERARCHY);
       if (sr2) resKey = sr2.resource;
     }
     if (!resKey) resKey = 'LABORER';

--- a/viewer/boq_charts.html
+++ b/viewer/boq_charts.html
@@ -474,7 +474,12 @@ function generateSchedule(activities, startDateStr) {
   const grouped = {};  // phase|||storey -> [act, ...]
   const phaseSets = {};
   for (const act of activities) {
-    const rules = SEQUENCE_RULES[act.cls] || DEFAULT_RULE;
+    // §EXACT_LOOKUP_BLINDSPOT P4 — was a raw SEQUENCE_RULES[act.cls] exact-key lookup, missing tier
+    // 1 substring matches and tier 2 schema-hierarchy inheritance. DEFAULT_RULE was already the same
+    // generic fallback classify()'s tier 3 returns, so no genuine-vs-generic distinction to preserve
+    // here (unlike buildScheduleFromOps below, whose discipline SET must stay untouched by a truly
+    // unclassified class the way it is today).
+    const rules = window.ScheduleAuthor.classify(act.cls, window.IFC_SCHEMA_HIERARCHY);
     const phase = rules.phase;
     const storey = act.storey || 'Unknown';
     const key = `${phase}|||${storey}`;
@@ -882,6 +887,21 @@ async function _tryScheduleRelay(timeoutMs) {
 function buildScheduleFromOps(ops) {
   const PHASE_ORDER = phaseOrder();   // §BOQ4D B0 — third hardcoded stale copy, now derived
 
+  // §EXACT_LOOKUP_BLINDSPOT P4 — was a raw SEQUENCE_RULES[op.cls] exact-key lookup below. Routes
+  // through the real matchRule tier 1->2->3; genuine tier 3 (no own/substring match, no classified
+  // ancestor) returns null, NOT the generic default — so a truly unclassified class still doesn't
+  // contribute a spurious discipline to g.disciplines, exactly like today when SEQUENCE_RULES[cls]
+  // is undefined (op.phase itself is unaffected either way — it's read from the persisted kernel_op,
+  // never derived from this lookup).
+  function classifyOp(cls) {
+    var warned = null, orig = console.warn;
+    console.warn = function (m) { warned = m; orig(m); };
+    var rule = window.ScheduleAuthor.classify(cls, window.IFC_SCHEMA_HIERARCHY);
+    console.warn = orig;
+    var isTier3 = warned && warned.indexOf('§CLASS_UNMATCHED_INHERITED') !== 0 && warned.indexOf('§CLASS_UNMATCHED') === 0;
+    return isTier3 ? null : rule;
+  }
+
   // Group ops by phase+storey (same grouping as generateSchedule)
   var groups = {};  // "phase|||storey" → { ops[], minTs, maxTs, ... }
   for (var i = 0; i < ops.length; i++) {
@@ -904,8 +924,8 @@ function buildScheduleFromOps(ops) {
     if (op.guid) g.guids.push(op.guid);
     if (op.cls) g.classes.add(op.cls);
     if (op.resource) g.resources.add(op.resource);
-    // Derive discipline from SEQUENCE_RULES
-    var rule = SEQUENCE_RULES[op.cls];
+    // Derive discipline from the real classify() tier 1->2->3 result
+    var rule = classifyOp(op.cls);
     if (rule && rule.resource) {
       // §BOQ4D — one shared mapping (schedule_read_4d.js), so an authored task and a kernel_ops
       // task never disagree about what discipline the same resource belongs to.

--- a/viewer/export_5d.js
+++ b/viewer/export_5d.js
@@ -229,15 +229,32 @@ async function save5D() {
   const wpHeaders = [_TRL.h_item, _TRL.h_description, _TRL.h_quantity, _TRL.h_uom, _TRL.h_mat_rate+' ('+CUR+')', _TRL.h_material+' ('+CUR+')', _TRL.h_labour+' ('+CUR+')', _TRL.h_equipment+' ('+CUR+')', _TRL.h_total+' ('+CUR+')', _TRL.h_total+' ('+CUR2+')'];
   const wpColWidths = [{ width: 8 },{ width: 35 },{ width: 10 },{ width: 6 },{ width: 18 },{ width: 16 },{ width: 14 },{ width: 14 },{ width: 16 },{ width: 14 }];
 
-  // Build set of all matched classes to find "OTHER"
-  const matchedClasses = new Set();
-  for (const wp of WORK_PACKAGES) wp.classes.forEach(c => matchedClasses.add(c));
+  // §EXACT_LOOKUP_BLINDSPOT P3 — was a hand-maintained classes:[...] membership array per package (a
+  // 4th classification system, not keyed off SEQUENCE_RULES at all). Groups by the real classify()
+  // tier 1->2->3 result instead: WORK_PACKAGES now carries `phase` (SEQUENCE_RULES' own field, added
+  // to every rate template's work_packages JSON, positionally verified identical to the classes-based
+  // grouping it replaces). Genuinely unclassified (tier 3) rows still go to their own OTHER package —
+  // NOT classify()'s 'Architecture' default — same distinction proj_fold.js's P2 fix preserves.
+  const _p3Hier = (typeof window !== 'undefined' && window.IFC_SCHEMA_HIERARCHY) || {};
+  const _wpByPhase = {};
+  for (const wp of WORK_PACKAGES) _wpByPhase[wp.phase] = wp;
+  const rowsByWpId = {};
+  const otherRows = [];
+  for (const r of qtoData) {
+    let warned = null;
+    const origWarn = console.warn;
+    console.warn = function (m) { warned = m; origWarn(m); };
+    const rule = window.ScheduleAuthor.classify(r.cls, _p3Hier);
+    console.warn = origWarn;
+    const isTier3 = warned && warned.indexOf('§CLASS_UNMATCHED_INHERITED') !== 0 && warned.indexOf('§CLASS_UNMATCHED') === 0;
+    const wp = !isTier3 && _wpByPhase[rule.phase];
+    if (wp) { (rowsByWpId[wp.id] || (rowsByWpId[wp.id] = [])).push(r); }
+    else { otherRows.push(r); }
+  }
 
-  // Check if we need a PACKAGE 6: OTHER
-  const otherRows = qtoData.filter(r => !matchedClasses.has(r.cls));
   const allWPs = [...WORK_PACKAGES];
   if (otherRows.length > 0) {
-    allWPs.push({ id: 'PACKAGE 6', name: 'OTHER', color: '7F8C8D', classes: null });
+    allWPs.push({ id: 'PACKAGE 7', name: 'OTHER', color: '7F8C8D' });
   }
 
   const wsWP = wb.addWorksheet('Work Packages');
@@ -247,9 +264,7 @@ async function save5D() {
   let wpGrandMat = 0, wpGrandLab = 0, wpGrandEq = 0;
 
   for (const wp of allWPs) {
-    const wpData = wp.classes
-      ? qtoData.filter(r => wp.classes.includes(r.cls))
-      : otherRows;
+    const wpData = wp.phase ? (rowsByWpId[wp.id] || []) : otherRows;
     if (wpData.length === 0) continue;
 
     wsWP.addRow([]);

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1932,6 +1932,7 @@
         if (!db) { _pushReject('ERP db unavailable for push'); console.log('[RP-C] §PROJ_PUSH_DEFER no ERP db'); return; }
         var opts = {
           seqRules: window.SEQUENCE_RULES || {}, laborRates: window.LABOR_RATES || {},
+          hierarchy: window.IFC_SCHEMA_HIERARCHY || {},
           packCurrencyISO: _cur(), now: (function () { try { return new Date().toISOString().replace('T', ' ').slice(0, 19); } catch (e) { return '2026-01-01 00:00:00'; } })()
         };
         var r = window.ProjFold.foldProjectOrder(db, building, priced.rows, opts);

--- a/viewer/proj_fold.js
+++ b/viewer/proj_fold.js
@@ -17,6 +17,11 @@
     ? require('../erp/bigdecimal.js')
     : (global.BigDecimal);
   var HALF_UP = BD.RoundingMode.HALF_UP;
+  // §EXACT_LOOKUP_BLINDSPOT P2 — resolved LAZILY (called only inside foldProjectOrder, never at
+  // module-load time): viewer.html loads proj_fold.js (:868) BEFORE schedule_author.js (:932), so
+  // capturing global.ScheduleAuthor at top-level `var` time would freeze it at undefined forever.
+  var SA_NODE = (typeof module !== 'undefined' && module.exports) ? require('./schedule_author.js') : null;
+  function _SA() { return SA_NODE || global.ScheduleAuthor; }
 
   // BIM-folded rows live in a high PK band so they never collide with seed / real iDempiere IDs.
   var BIM_BASE = 990000;
@@ -107,6 +112,26 @@
   function foldProjectOrder(db, building, priced, opts) {
     opts = opts || {};
     var SR = opts.seqRules || {}, LR = opts.laborRates || {};
+    var HIER = opts.hierarchy || (typeof window !== 'undefined' ? window.IFC_SCHEMA_HIERARCHY : null) || {};
+    // §EXACT_LOOKUP_BLINDSPOT P2 — was a raw SR[cls] dict lookup, missing tier 2 (schema-hierarchy
+    // inheritance) and tier 3's §CLASS_UNMATCHED visibility. classify() always returns a rule object
+    // (tier 1/2/3), never undefined, so callers below no longer need `|| {}`.
+    // Tier 3 (genuinely unclassified — no own-name match, no classified ancestor) is remapped back
+    // to phase='Unsequenced' here, NOT classify()'s own 'Architecture' default: time_machine.js:4376
+    // and poc_dashboard_variance.js:31 both filter `WHERE Name<>'Unsequenced'` on this exact table to
+    // keep un-grounded costs out of the phase dashboard total — collapsing tier 3 into 'Architecture'
+    // would silently fold those costs into a real phase's committed amount. Tier 1/2 (the actual P2
+    // fix) pass through unchanged; only the pre-existing "truly unclassified" bucket is preserved.
+    function classifyCls(c) {
+      var warned = null, orig = console.warn;
+      console.warn = function (m) { warned = m; orig(m); };
+      var rule = _SA().classify(c, HIER, SR);
+      console.warn = orig;
+      if (warned && warned.indexOf('§CLASS_UNMATCHED_INHERITED') !== 0 && warned.indexOf('§CLASS_UNMATCHED') === 0) {
+        return { phase: 'Unsequenced', sequence: rule.sequence, resource: rule.resource };
+      }
+      return rule;
+    }
     var CL = opts.clientId != null ? opts.clientId : 11;
     var OG = opts.orgId != null ? opts.orgId : 11;
     var U = opts.user != null ? opts.user : 100;
@@ -147,7 +172,7 @@
     // group priced rows by 4D phase (sequence_rules), seqno = the canonical phase sequence
     var phases = {};   // phaseName → { seqno, resources:{res:[rows]}, rows:[] }
     priced.forEach(function (r) {
-      var sr = SR[r.cls] || {};
+      var sr = classifyCls(r.cls);
       var ph = sr.phase || 'Unsequenced';
       var res = sr.resource || 'GENERAL';
       var p = phases[ph] || (phases[ph] = { seqno: (phaseSeq[ph] != null ? phaseSeq[ph] : (sr.sequence != null ? sr.sequence : 99)), resources: {}, rows: [] });
@@ -169,7 +194,7 @@
       // duration
       var days = 0;
       P.rows.forEach(function (r) {
-        var lr = LR[(SR[r.cls] || {}).resource];
+        var lr = LR[classifyCls(r.cls).resource];
         var prod = lr && lr.productivity && lr.productivity[r.cls];
         days += prod ? Math.ceil(r.count / prod) : Math.max(1, Math.ceil(r.count / 20));
       });
@@ -212,7 +237,7 @@
       var lineNo = 10;
       Object.keys(byCls).forEach(function (cls) {
         var rows = byCls[cls];
-        var unit = rows[0].unit, rate = rows[0].rate, disc = rows[0].disc, res = (SR[cls] || {}).resource || 'GENERAL';
+        var unit = rows[0].unit, rate = rows[0].rate, disc = rows[0].disc, res = classifyCls(cls).resource || 'GENERAL';
         var qty = 0, amt = BD.ZERO, cnt = 0;
         rows.forEach(function (r) {
           qty += r.qty; cnt += r.count;

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -244,7 +244,15 @@ var SEQUENCE_NAME_OVERRIDES = [
 ];
 
 // Helper: get phase for an IFC class
+// §EXACT_LOOKUP_BLINDSPOT P3 — was a raw SEQUENCE_RULES[ifcClass] exact-key lookup (missed tier 1
+// substring matches like IfcDoorType, and tier 2 schema-hierarchy inheritance like IfcTank). Routes
+// through the real classify() when it's loaded (schedule_author.js); the raw lookup stays as a
+// fallback for the rare page that never loads schedule_author.js at all, same 3-tier-never-fires
+// degrade-safe convention the rest of this lane already uses.
 function getPhase(ifcClass) {
+  if (typeof window !== 'undefined' && window.ScheduleAuthor) {
+    return window.ScheduleAuthor.classify(ifcClass, window.IFC_SCHEMA_HIERARCHY).phase;
+  }
   var r = SEQUENCE_RULES[ifcClass];
   return r ? r.phase : SEQUENCE_DEFAULT.phase;
 }
@@ -262,21 +270,24 @@ function getProductivity(ifcClass) {
 }
 
 // ============================================================================
-// WORK PACKAGES — IFC class → construction phase mapping
+// WORK PACKAGES — construction phase grouping, for export_5d.js's Work Package sheets
+// §EXACT_LOOKUP_BLINDSPOT P3 §PROPOSED FIX: this used to carry its own hand-maintained
+// `classes: [...]` membership array per package — a 4th, fully separate hardcoded classification,
+// not even keyed off SEQUENCE_RULES, matched by .includes() (so e.g. IfcDoorType, IfcFooting's own
+// Type variant, or any of the ~950 real IFC classes never named here, all silently fell to
+// "PACKAGE 6: OTHER" regardless of what SEQUENCE_RULES actually says about them). `phase` below is
+// SEQUENCE_RULES' own field — the SAME 6 values every real entry uses (confirmed exhaustively:
+// Substructure/Superstructure/MEP Rough-in/Architecture/Finishes/MEP Final, nothing else) — so
+// export_5d.js derives membership from the real classify() tier 1->2->3 result instead of a 5th
+// place that could drift from it.
 // ============================================================================
 var WORK_PACKAGES = [
-  { id: 'PACKAGE 1', name: 'SUBSTRUCTURE', color: '8E44AD',
-    classes: ['IfcFooting','IfcPile','IfcReinforcingBar'] },
-  { id: 'PACKAGE 2', name: 'SUPERSTRUCTURE', color: '2980B9',
-    classes: ['IfcColumn','IfcBeam','IfcSlab','IfcPlate','IfcMember'] },
-  { id: 'PACKAGE 3', name: 'MEP ROUGH-IN', color: 'D35400',
-    classes: ['IfcDuct','IfcDuctSegment','IfcDuctFitting','IfcPipe','IfcPipeSegment','IfcPipeFitting','IfcCableCarrier','IfcCableCarrierSegment','IfcFlowSegment','IfcFlowFitting','IfcFlowController','IfcFlowMovingDevice','IfcFlowStorageDevice','IfcFlowTreatmentDevice','IfcEnergyConversionDevice','IfcDistributionElement','IfcValve'] },
-  { id: 'PACKAGE 4', name: 'ARCHITECTURE', color: 'ED7D31',
-    classes: ['IfcWall','IfcWallStandardCase','IfcCurtainWall','IfcDoor','IfcWindow','IfcStair','IfcStairFlight','IfcRailing','IfcRoof','IfcRamp','IfcRampFlight'] },
-  { id: 'PACKAGE 5', name: 'FINISHES', color: '27AE60',
-    classes: ['IfcCovering','IfcFurniture','IfcFurnishingElement'] },
-  { id: 'PACKAGE 6', name: 'MEP FINAL FIX', color: 'C0392B',
-    classes: ['IfcFlowTerminal','IfcLightFixture','IfcOutlet','IfcElectricAppliance','IfcFireSuppressionTerminal','IfcAirTerminal','IfcAlarm','IfcController'] },
+  { id: 'PACKAGE 1', name: 'SUBSTRUCTURE', color: '8E44AD', phase: 'Substructure' },
+  { id: 'PACKAGE 2', name: 'SUPERSTRUCTURE', color: '2980B9', phase: 'Superstructure' },
+  { id: 'PACKAGE 3', name: 'MEP ROUGH-IN', color: 'D35400', phase: 'MEP Rough-in' },
+  { id: 'PACKAGE 4', name: 'ARCHITECTURE', color: 'ED7D31', phase: 'Architecture' },
+  { id: 'PACKAGE 5', name: 'FINISHES', color: '27AE60', phase: 'Finishes' },
+  { id: 'PACKAGE 6', name: 'MEP FINAL FIX', color: 'C0392B', phase: 'MEP Final' },
 ];
 
 // ============================================================================

--- a/viewer/rates/aramco2024_sa.json
+++ b/viewer/rates/aramco2024_sa.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/asaqs2024_za.json
+++ b/viewer/rates/asaqs2024_za.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/bki2024_de.json
+++ b/viewer/rates/bki2024_de.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "UNTERBAU",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "ROHBAU",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "HAUSTECHNIK ROHINSTALLATION",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITEKTUR",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "AUSBAU",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "HAUSTECHNIK ENDMONTAGE",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/cidb2024_my.json
+++ b/viewer/rates/cidb2024_my.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/cype2024_es.json
+++ b/viewer/rates/cype2024_es.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "CIMENTACION",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "ESTRUCTURA",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "INSTALACIONES FASE 1",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "CERRAMIENTOS Y ACABADOS",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "ACABADOS",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "INSTALACIONES FASE 2",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/dpt2024_th.json
+++ b/viewer/rates/dpt2024_th.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/gb50500_cn.json
+++ b/viewer/rates/gb50500_cn.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "基础工程",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "主体结构",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "机电粗装",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "建筑工程",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "装饰装修",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "机电精装",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/jbci2024_jp.json
+++ b/viewer/rates/jbci2024_jp.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "基礎工事",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "躯体工事",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "設備粗工事",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "建築工事",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "仕上工事",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "設備仕上工事",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/kict2024_kr.json
+++ b/viewer/rates/kict2024_kr.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/pwd2024_bd.json
+++ b/viewer/rates/pwd2024_bd.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/rawlinsons2024_au.json
+++ b/viewer/rates/rawlinsons2024_au.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/rsmeans2024_us.json
+++ b/viewer/rates/rsmeans2024_us.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/sinapi2024_br.json
+++ b/viewer/rates/sinapi2024_br.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/sni2024_id.json
+++ b/viewer/rates/sni2024_id.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "SUBSTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "SUPERSTRUCTURE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "MEP ROUGH-IN",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "ARCHITECTURE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINISHES",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "MEP FINAL FIX",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/rates/untec2024_fr.json
+++ b/viewer/rates/untec2024_fr.json
@@ -731,6 +731,7 @@
       "id": "PACKAGE 1",
       "name": "INFRASTRUCTURE",
       "color": "8E44AD",
+      "phase": "Substructure",
       "classes": [
         "IfcFooting",
         "IfcPile",
@@ -741,6 +742,7 @@
       "id": "PACKAGE 2",
       "name": "GROS OEUVRE",
       "color": "2980B9",
+      "phase": "Superstructure",
       "classes": [
         "IfcColumn",
         "IfcBeam",
@@ -753,6 +755,7 @@
       "id": "PACKAGE 3",
       "name": "CVC GROS OEUVRE",
       "color": "D35400",
+      "phase": "MEP Rough-in",
       "classes": [
         "IfcDuct",
         "IfcDuctSegment",
@@ -777,6 +780,7 @@
       "id": "PACKAGE 4",
       "name": "SECOND OEUVRE",
       "color": "ED7D31",
+      "phase": "Architecture",
       "classes": [
         "IfcWall",
         "IfcWallStandardCase",
@@ -795,6 +799,7 @@
       "id": "PACKAGE 5",
       "name": "FINITIONS",
       "color": "27AE60",
+      "phase": "Finishes",
       "classes": [
         "IfcCovering",
         "IfcFurniture",
@@ -805,6 +810,7 @@
       "id": "PACKAGE 6",
       "name": "CVC FINITION",
       "color": "C0392B",
+      "phase": "MEP Final",
       "classes": [
         "IfcFlowTerminal",
         "IfcLightFixture",

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -70,6 +70,22 @@
     return dflt;   // tier 3 — generic default
   }
 
+  // classify — thin convenience wrapper around matchRule for the exact-lookup consumers named in
+  // CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §PROPOSED FIX: callers that used to do a raw
+  // `SEQUENCE_RULES[cls]` dictionary lookup (bypassing tier 1's substring match, tier 2's schema-
+  // hierarchy walk, and tier 3's `§CLASS_UNMATCHED` visibility entirely) call this instead. Real
+  // browser call sites only ever need `classify(cls)` or `classify(cls, hierarchy)` — rules/dflt
+  // default from the same window globals matchRule's own callers already default from (rates.js).
+  // `rules`/`dflt` are accepted as trailing overrides so a Node witness can drive this against real
+  // fixture data without a window global to read (module-scope `global` here is `this`, not
+  // `globalThis` — see witness_schema_exhaustive_classify.js).
+  function classify(cls, hierarchy, rules, dflt) {
+    rules = rules || global.SEQUENCE_RULES || {};
+    dflt = dflt || global.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+    hierarchy = hierarchy || global.IFC_SCHEMA_HIERARCHY || {};
+    return matchRule(cls, rules, dflt, hierarchy);
+  }
+
   // matchNameOverride — REPLICATES time_machine.js matchNameOverride EXACTLY. §4D_FACADE_ORDER:
   // ifc_class alone cannot tell curtain-wall glazing/framing (IfcPlate/IfcMember) from genuinely
   // structural plates/members. Checked BEFORE matchRule, never replacing it — see rates/sequence_rules.json.
@@ -1508,6 +1524,7 @@
 
   var API = {
     matchRule: matchRule,
+    classify: classify,
     matchNameOverride: matchNameOverride,
     // §TM_DURATION_SYNC — exported so time_machine.js's playback-clock duration engine
     // (getInstallSecs, viewer/time_machine.js ~3478) can call the SAME fragmentation-aware

--- a/viewer/schedule_read_4d.js
+++ b/viewer/schedule_read_4d.js
@@ -94,9 +94,27 @@
     var laborRates = opts.laborRates || global.LABOR_RATES || {};
     var equipAlloc = opts.equipmentAllocation || global.EQUIPMENT_ALLOCATION || {};
     var equipRates = opts.equipmentRates || global.EQUIPMENT_RATES || {};
+    var hierarchy = opts.hierarchy || global.IFC_SCHEMA_HIERARCHY || {};
+    var dflt = opts.defaultRule || global.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
     var order = phaseOrder(rules);
     var knownPhase = {};
     order.forEach(function (p) { knownPhase[p] = true; });
+
+    // §EXACT_LOOKUP_BLINDSPOT P4 — was a raw rules[cls] exact-key lookup below (missed tier 1
+    // substring matches like IfcDoorType, tier 2 schema-hierarchy inheritance like IfcTank). Routes
+    // through the real matchRule tier 1->2->3; genuine tier 3 (no own/substring match, no classified
+    // ancestor) returns null here, NOT the generic default — so callers below keep today's exact
+    // "skip, don't count toward this tally" behavior for truly unclassified classes, the same
+    // distinction P2 preserved for proj_fold.js's 'Unsequenced' bucket and P3 for export_5d.js's
+    // OTHER package.
+    function classifyCls(cls) {
+      var warned = null, orig = console.warn;
+      console.warn = function (m) { warned = m; orig(m); };
+      var rule = SA.classify(cls, hierarchy, rules, dflt);
+      console.warn = orig;
+      var isTier3 = warned && warned.indexOf('§CLASS_UNMATCHED_INHERITED') !== 0 && warned.indexOf('§CLASS_UNMATCHED') === 0;
+      return isTier3 ? null : rule;
+    }
 
     // ---- leaf tasks of the active schedule (summaries are WBS containers, not work) -------------
     var trows = execRows(db,
@@ -137,7 +155,7 @@
       if (!cls) { noMeta++; }
       else {
         t.classes[cls] = (t.classes[cls] || 0) + 1;
-        var rule = rules[cls];
+        var rule = classifyCls(cls);
         if (rule) {
           if (rule.resource) t.resources[rule.resource] = 1;
           t.disciplines[discOfResource(rule.resource)] = 1;
@@ -183,7 +201,7 @@
       }
       var maj = null, best = 0;
       for (var cls in t.classes) {
-        var rule = rules[cls]; if (!rule || !rule.phase) continue;
+        var rule = classifyCls(cls); if (!rule || !rule.phase) continue;
         if (t.classes[cls] > best) { best = t.classes[cls]; maj = rule.phase; }
       }
       if (maj) { fromElements++; return { phase: maj, storey: majority(t.storeys) || 'Unknown' }; }

--- a/viewer/tests/witness_exact_lookup_p2.js
+++ b/viewer/tests/witness_exact_lookup_p2.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p2.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P2: wire the two
+// higher-priority live consumers (boq_charts.html:1808/1813 crew chart, proj_fold.js ERP push) through
+// ScheduleAuthor.classify() instead of a raw SEQUENCE_RULES[cls]/SR[cls] dict lookup.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: a raw dict lookup misses BOTH tier 1's substring match (a
+// Type-suffixed class like IfcDoorType never had its own SEQUENCE_RULES key, only 'IfcDoor' does) AND
+// tier 2's schema-hierarchy inheritance (a class like IfcTank has no entry of its own OR any
+// substring match, only its real ancestor IfcFlowStorageDevice does). Both used to silently fall to
+// proj_fold.js's local 'Unsequenced'/'GENERAL' bucket and boq_charts.html's 'LABORER' default — not
+// wrong exactly, just needlessly generic when a real classification was one substring/one hierarchy
+// hop away. This witness proves: (a) proj_fold.js's REAL foldProjectOrder (required verbatim, not
+// reimplemented) now resolves both cases correctly when given `hierarchy`, (b) genuinely unclassified
+// classes (true tier 3) still land in 'Unsequenced' — NOT 'Architecture' — preserving the exact
+// dashboard contract time_machine.js:4376 / poc_dashboard_variance.js:31 depend on
+// (`WHERE Name<>'Unsequenced'`), (c) omitting `hierarchy` entirely (existing callers like
+// bake_gw_hospital_seed.js) degrades to the identical pre-fix 'Unsequenced' outcome — never a
+// regression for callers that haven't been updated to pass it yet.
+//
+// Run: node witness_exact_lookup_p2.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+const ProjFold = require(path.join(__dirname, '..', 'proj_fold.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+// Three real cases, ground-truthed directly against sequence_rules.json / ifc_schema_hierarchy.json:
+//   IfcTank        — no own entry, no substring match; ancestor IfcFlowStorageDevice IS classified
+//                    (MEP Rough-in / PLUMBER) — tier 2, the schema-hierarchy gap.
+//   IfcDoorType    — no own entry; but 'IfcDoorType'.indexOf('IfcDoor')>=0 — tier 1, the substring gap
+//                    a raw exact-key dict lookup can never see (Architecture / CARPENTER, from IfcDoor).
+//   IfcActor       — no own entry, ancestor chain [IfcObject, IfcObjectDefinition, IfcRoot] has no
+//                    classified member either — genuinely tier 3, must stay 'Unsequenced'.
+const PRICED = [
+  { disc: 'MEP', cls: 'IfcTank', storey: 'L1', unit: 'EA', qty: 1, rate: 1000, cost: 1000, count: 1 },
+  { disc: 'Architecture', cls: 'IfcDoorType', storey: 'L1', unit: 'EA', qty: 2, rate: 500, cost: 1000, count: 2 },
+  { disc: 'Unknown', cls: 'IfcActor', storey: 'L1', unit: 'EA', qty: 1, rate: 100, cost: 100, count: 1 }
+];
+
+(async function () {
+  const SQL = await initSqlJs();
+  const seedBytes = fs.readFileSync(path.join(__dirname, '..', '..', 'erp', 'ad_seed.db'));
+
+  function phasesOf(db, building) {
+    const projId = (db.exec("SELECT C_Project_ID FROM C_Project WHERE Value=?", [building])[0] || { values: [] }).values[0];
+    if (!projId) return { names: [], tasks: [] };
+    const pid = projId[0];
+    const ph = db.exec("SELECT Name FROM C_ProjectPhase WHERE C_Project_ID=" + pid);
+    const names = ph.length ? ph[0].values.map(r => r[0]) : [];
+    const tk = db.exec("SELECT t.Name FROM C_ProjectTask t JOIN C_ProjectPhase p ON p.C_ProjectPhase_ID=t.C_ProjectPhase_ID WHERE p.C_Project_ID=" + pid);
+    const tasks = tk.length ? tk[0].values.map(r => r[0]) : [];
+    return { names, tasks, pid };
+  }
+
+  // ── WITH hierarchy — the actual P2 fix ──
+  const edb1 = new SQL.Database(seedBytes);
+  const opts1 = { seqRules: SEQUENCE_RULES, laborRates: {}, hierarchy: HIERARCHY, packCurrencyISO: 'MYR', now: '2026-08-05 00:00:00' };
+  ProjFold.foldProjectOrder(edb1, 'ExactLookupP2Test', PRICED, opts1);
+  const r1 = phasesOf(edb1, 'ExactLookupP2Test');
+  console.log('§P2_WITH_HIERARCHY phases=' + r1.names.join(',') + ' tasks=' + r1.tasks.join(','));
+
+  assert(r1.names.indexOf('MEP Rough-in') >= 0, 'G-K IfcTank (tier 2, via IfcFlowStorageDevice) resolves to phase "MEP Rough-in", not Unsequenced');
+  assert(r1.tasks.indexOf('PLUMBER') >= 0, 'G-K IfcTank resolves resource PLUMBER (inherited), not GENERAL');
+  assert(r1.names.indexOf('Architecture') >= 0, 'G-L IfcDoorType (tier 1 substring, no own key) resolves to phase "Architecture" via IfcDoor');
+  assert(r1.tasks.indexOf('CARPENTER') >= 0, 'G-L IfcDoorType resolves resource CARPENTER (via IfcDoor), not GENERAL');
+  assert(r1.names.indexOf('Unsequenced') >= 0, 'G-M IfcActor (genuine tier 3 — no own match, no classified ancestor) still lands in Unsequenced');
+
+  // ── the dashboard contract this preserves: time_machine.js:4376 / poc_dashboard_variance.js:31
+  // both filter `WHERE Name<>'Unsequenced'` — confirm that query still excludes exactly the right row
+  // and nothing else, on the SAME data this witness just folded.
+  const filtered = edb1.exec("SELECT Name FROM C_ProjectPhase WHERE C_Project_ID=" + r1.pid + " AND Name<>'Unsequenced'")[0].values.map(r => r[0]);
+  assert(filtered.indexOf('Unsequenced') === -1 && filtered.indexOf('MEP Rough-in') >= 0 && filtered.indexOf('Architecture') >= 0,
+    'G-N dashboard filter (Name<>\'Unsequenced\') still excludes the true-unclassified bucket, keeps the real phases');
+
+  // ── WITHOUT hierarchy — existing callers (e.g. bake_gw_hospital_seed.js) that haven't been updated
+  // to pass it yet must degrade to the IDENTICAL pre-fix outcome: IfcTank has no own/substring match
+  // either, so with no hierarchy to walk it falls to tier 3 → 'Unsequenced', same as raw SR['IfcTank']
+  // being undefined always did. Not a regression for any caller this session didn't touch.
+  const edb2 = new SQL.Database(seedBytes);
+  const opts2 = { seqRules: SEQUENCE_RULES, laborRates: {}, packCurrencyISO: 'MYR', now: '2026-08-05 00:00:00' }; // no hierarchy
+  ProjFold.foldProjectOrder(edb2, 'ExactLookupP2NoHier', PRICED, opts2);
+  const r2 = phasesOf(edb2, 'ExactLookupP2NoHier');
+  console.log('§P2_NO_HIERARCHY phases=' + r2.names.join(','));
+  assert(r2.names.indexOf('Unsequenced') >= 0, 'G-O without hierarchy, IfcTank still falls to Unsequenced (tier 2 simply never fires — degrade-safe)');
+  assert(r2.names.indexOf('Architecture') >= 0, 'G-O without hierarchy, IfcDoorType STILL resolves via tier 1 substring (unaffected by hierarchy presence)');
+
+  console.log('\n§EXACT_LOOKUP_P2_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error(e); process.exit(2); });

--- a/viewer/tests/witness_exact_lookup_p2_boqchart.js
+++ b/viewer/tests/witness_exact_lookup_p2_boqchart.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p2_boqchart.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P2, the
+// OTHER higher-priority consumer: boq_charts.html:1808/1813's resource/crew-count chart. proj_fold.js
+// (witness_exact_lookup_p2.js) is a real Node-requirable module; this one is inline <script> in an
+// .html file, so it can't be required directly. Slicing the LITERAL shipped block between two fixed
+// marker comments and running it in a vm sandbox — same "extract, never reimplement" discipline
+// witness_class_fallback_blackbox.js already uses for time_machine.js's inline closures — so this
+// witness proves the actual shipped lines, not a paraphrase of them.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: same as proj_fold.js's — a raw SEQUENCE_RULES[cls] dict lookup
+// misses tier 1 substring matches (IfcDoorType) and tier 2 hierarchy inheritance (IfcTank), silently
+// defaulting the chart's crew-count to 'LABORER' for both.
+//
+// Run: node witness_exact_lookup_p2_boqchart.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+// classify(cls, hierarchy)'s 2-arg form (the exact shape the shipped boq_charts.html code below
+// calls) reads rules/dflt off schedule_author.js's own module-scope `global` (bound to `self||this`
+// at require time) — in the real browser that's `window`, populated by rates.js BEFORE
+// schedule_author.js loads (viewer.html:62 then :67). Replicating that here, not working around it:
+// set Node's `global.self` with the real rules/hierarchy BEFORE requiring the module, so classify()'s
+// internal default sees the same data window.SEQUENCE_RULES would hold in a real page load.
+global.self = { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, IFC_SCHEMA_HIERARCHY: HIERARCHY };
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+// ── slice the literal shipped block, verbatim, between its own comment markers ──
+const SRC_PATH = path.join(__dirname, '..', 'boq_charts.html');
+const src = fs.readFileSync(SRC_PATH, 'utf8');
+const startMarker = '// Aggregate resources across all tasks';
+const endMarker = "const resBox = el('div','chart-box full');";
+const si = src.indexOf(startMarker);
+const ei = src.indexOf(endMarker, si);
+if (si < 0 || ei < 0) { console.log('  FAIL G-SLICE could not locate the shipped block markers in boq_charts.html'); process.exit(1); }
+const block = src.slice(si, ei);
+if (!/window\.ScheduleAuthor\.classify/.test(block)) {
+  console.log('  FAIL G-SLICE sliced block does not contain the expected classify() call — markers drifted from the real code');
+  process.exit(1);
+}
+
+// ── run it, verbatim, in a sandbox exposing exactly what the real page would: window.ScheduleAuthor
+// (real, required) + window.IFC_SCHEMA_HIERARCHY (real, loaded from the real JSON) + a synthetic
+// scheduleData covering the same three ground-truthed cases as witness_exact_lookup_p2.js ──
+const scheduleData = [
+  { ifcClasses: ['IfcTank'], qty: 1 },      // tier 2 — via IfcFlowStorageDevice → PLUMBER
+  { ifcClasses: ['IfcDoorType'], qty: 1 },  // tier 1 substring — via IfcDoor → CARPENTER
+  { ifcClasses: ['IfcActor'], qty: 1 }      // genuine tier 3 — no match at all → LABORER default
+];
+const sandbox = {
+  window: { ScheduleAuthor: ScheduleAuthor, IFC_SCHEMA_HIERARCHY: HIERARCHY },
+  scheduleData: scheduleData,
+  EQUIPMENT_ALLOCATION: {},   // not under test here — real crew-chart concern only
+  console: console,
+  resCounts: undefined, maxResCrew: undefined, machineSet: undefined
+};
+vm.createContext(sandbox);
+// `const`/`let` in the sliced block don't become own-properties of the vm context the way `var`
+// would — appending a capture line in the SAME script (same lexical scope) reads them back without
+// altering the sliced logic itself.
+vm.runInContext(block + '\nthis.__captured = { resCounts: resCounts, maxResCrew: maxResCrew };', sandbox);
+sandbox.resCounts = sandbox.__captured.resCounts;
+sandbox.maxResCrew = sandbox.__captured.maxResCrew;
+
+console.log('§P2_BOQCHART_RESCOUNTS ' + JSON.stringify(sandbox.resCounts));
+assert(sandbox.resCounts.PLUMBER === 1, 'G-P IfcTank (tier 2) contributes to PLUMBER crew count in the real sliced block, not LABORER');
+assert(sandbox.resCounts.CARPENTER === 1, 'G-Q IfcDoorType (tier 1 substring) contributes to CARPENTER crew count, not LABORER');
+assert(sandbox.resCounts.LABORER === 1, 'G-R IfcActor (genuine tier 3) still defaults to LABORER — this bucket is unaffected, by design');
+
+console.log('\n§EXACT_LOOKUP_P2_BOQCHART_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_exact_lookup_p3_getphase.js
+++ b/viewer/tests/witness_exact_lookup_p3_getphase.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p3_getphase.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P3:
+// rates.js's getPhase(ifcClass) — consumed by variation_order.js:133/154/176 (S222 Variation Order
+// Excel export, a real financial/contractual document) — was a raw SEQUENCE_RULES[ifcClass] exact-key
+// lookup. Fixing getPhase() itself (rather than variation_order.js's 3 call sites) closes the gap for
+// all 3 in one place, since they only ever call the shared helper.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: same tier 1 substring / tier 2 inheritance gap as P2 — an
+// IfcDoorType or IfcTank in an ADDED/REMOVED/CHANGED variation row used to silently get the generic
+// default phase, mispricing the FIDIC Clause 12 impact bucket it's grouped under. Slices the LITERAL
+// shipped getPhase() (via vm, not reimplemented) and drives it against ground-truthed cases.
+//
+// Run: node witness_exact_lookup_p3_getphase.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+global.self = { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, IFC_SCHEMA_HIERARCHY: HIERARCHY };
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+// ── slice the literal shipped getPhase() out of rates.js ──
+const src = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+const startMarker = 'function getPhase(ifcClass) {';
+const si = src.indexOf(startMarker);
+if (si < 0) { console.log('  FAIL G-SLICE could not locate getPhase() in rates.js'); process.exit(1); }
+const ei = src.indexOf('\n}', si) + 2;
+const block = src.slice(si, ei);
+if (!/window\.ScheduleAuthor\.classify/.test(block)) {
+  console.log('  FAIL G-SLICE sliced getPhase() does not contain the expected classify() call — marker drifted from the real code');
+  process.exit(1);
+}
+
+const sandbox = { window: { ScheduleAuthor: ScheduleAuthor, IFC_SCHEMA_HIERARCHY: HIERARCHY }, SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, console: console };
+vm.createContext(sandbox);
+vm.runInContext(block, sandbox);
+
+assert(sandbox.getPhase('IfcFooting') === 'Substructure', 'G-Y IfcFooting (tier 1 explicit) resolves Substructure');
+assert(sandbox.getPhase('IfcTank') === 'MEP Rough-in', 'G-Z IfcTank (tier 2, via IfcFlowStorageDevice) resolves MEP Rough-in, not the generic default');
+assert(sandbox.getPhase('IfcDoorType') === 'Architecture', 'G-AA IfcDoorType (tier 1 substring, via IfcDoor) resolves Architecture, not the generic default');
+assert(sandbox.getPhase('IfcActor') === 'Architecture', 'G-AB IfcActor (genuine tier 3) resolves the generic default (Architecture) — getPhase has no Unsequenced/OTHER concept of its own, unchanged from before');
+
+console.log('\n§EXACT_LOOKUP_P3_GETPHASE_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_exact_lookup_p3_workpackages.js
+++ b/viewer/tests/witness_exact_lookup_p3_workpackages.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p3_workpackages.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P3:
+// WORK_PACKAGES used to carry its own hand-maintained `classes: [...]` membership array per package —
+// a 4th, fully separate hardcoded classification, not even keyed off SEQUENCE_RULES. Verified
+// (session transcript) that every one of the 15 non-empty rate templates' work_packages arrays carry
+// BYTE-IDENTICAL `classes` groupings to rates.js's own default, in the SAME PACKAGE 1..6 order — so a
+// positional `phase` field (SEQUENCE_RULES' own field) was added to rates.js AND all 15 template
+// JSONs, and export_5d.js now derives Work Package membership from the real classify() tier 1->2->3
+// result instead of `.classes.includes()`.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: same class of gap as P2 — IfcDoorType (tier 1 substring, only
+// 'IfcFooting'/'IfcDoor'/etc. were literal keys) and IfcTank (tier 2, only its ancestor
+// IfcFlowStorageDevice was ever in a classes:[...] list) both used to fall silently into the "OTHER"
+// catch-all, indistinguishable from a genuinely unclassified class like IfcActor. This slices the
+// LITERAL shipped export_5d.js block (via vm, not reimplemented) and proves all three now resolve to
+// their real package, while IfcActor (genuine tier 3) still lands in OTHER — not silently merged into
+// a real package the way P2 found for proj_fold.js's 'Unsequenced' bucket.
+//
+// Run: node witness_exact_lookup_p3_workpackages.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+// classify()'s 2-arg form reads schedule_author.js's own module-scope `global` (bound at require
+// time) — replicate what rates.js/schedule_author.js loading in a real page provides (same technique
+// as witness_exact_lookup_p2_boqchart.js).
+global.self = { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, IFC_SCHEMA_HIERARCHY: HIERARCHY };
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+// ── the REAL WORK_PACKAGES — required verbatim by extracting the var declaration out of rates.js's
+// own source text (rates.js is a plain script, not require()-able: it references DOM/window at load
+// time). Sliced between its own fixed markers, same discipline as the export_5d.js slice below. ──
+const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+const wpStart = ratesSrc.indexOf('var WORK_PACKAGES = [');
+const wpEnd = ratesSrc.indexOf('];', wpStart) + 2;
+if (wpStart < 0) { console.log('  FAIL G-SLICE could not locate WORK_PACKAGES in rates.js'); process.exit(1); }
+const WORK_PACKAGES = vm.runInNewContext(ratesSrc.slice(wpStart, wpEnd) + '\nWORK_PACKAGES;');
+assert(WORK_PACKAGES.length === 6 && WORK_PACKAGES.every(wp => !!wp.phase), 'G-S rates.js WORK_PACKAGES has 6 entries, every one carries `phase` (classes:[...] retired)');
+
+// ── slice the literal shipped classification block from export_5d.js ──
+const srcPath = path.join(__dirname, '..', 'export_5d.js');
+const src = fs.readFileSync(srcPath, 'utf8');
+const startMarker = '// §EXACT_LOOKUP_BLINDSPOT P3';
+const endMarker = "const wsWP = wb.addWorksheet('Work Packages');";
+const si = src.indexOf(startMarker);
+const ei = src.indexOf(endMarker, si);
+if (si < 0 || ei < 0) { console.log('  FAIL G-SLICE could not locate the shipped block markers in export_5d.js'); process.exit(1); }
+const block = src.slice(si, ei);
+if (!/window\.ScheduleAuthor\.classify/.test(block)) {
+  console.log('  FAIL G-SLICE sliced block does not contain the expected classify() call — markers drifted from the real code');
+  process.exit(1);
+}
+
+const qtoData = [
+  { cls: 'IfcFooting', desc: 'Footing', qty: 1, matTotal: 100, laborCost: 50, equipCost: 0 },   // tier 1 explicit -> PACKAGE 1 Substructure
+  { cls: 'IfcTank', desc: 'Water Tank', qty: 1, matTotal: 200, laborCost: 80, equipCost: 0 },    // tier 2 via IfcFlowStorageDevice -> PACKAGE 3 MEP Rough-in
+  { cls: 'IfcDoorType', desc: 'Door Type', qty: 2, matTotal: 300, laborCost: 60, equipCost: 0 }, // tier 1 substring via IfcDoor -> PACKAGE 4 Architecture
+  { cls: 'IfcActor', desc: 'Unclassified', qty: 1, matTotal: 10, laborCost: 5, equipCost: 0 }    // genuine tier 3 -> OTHER
+];
+
+const sandbox = {
+  window: { ScheduleAuthor: ScheduleAuthor, IFC_SCHEMA_HIERARCHY: HIERARCHY },
+  WORK_PACKAGES: WORK_PACKAGES,
+  qtoData: qtoData,
+  console: console
+};
+vm.createContext(sandbox);
+vm.runInContext(block + '\nthis.__captured = { rowsByWpId: rowsByWpId, otherRows: otherRows, allWPs: allWPs };', sandbox);
+const { rowsByWpId, otherRows, allWPs } = sandbox.__captured;
+
+console.log('§P3_WORKPACKAGES rowsByWpId=' + JSON.stringify(Object.keys(rowsByWpId).reduce((a, k) => (a[k] = rowsByWpId[k].map(r => r.cls), a), {}))
+  + ' other=' + otherRows.map(r => r.cls).join(','));
+
+assert((rowsByWpId['PACKAGE 1'] || []).some(r => r.cls === 'IfcFooting'), 'G-T IfcFooting (tier 1 explicit) lands in PACKAGE 1 SUBSTRUCTURE');
+assert((rowsByWpId['PACKAGE 3'] || []).some(r => r.cls === 'IfcTank'), 'G-U IfcTank (tier 2, via IfcFlowStorageDevice) lands in PACKAGE 3 MEP ROUGH-IN, not OTHER');
+assert((rowsByWpId['PACKAGE 4'] || []).some(r => r.cls === 'IfcDoorType'), 'G-V IfcDoorType (tier 1 substring, via IfcDoor) lands in PACKAGE 4 ARCHITECTURE, not OTHER');
+assert(otherRows.some(r => r.cls === 'IfcActor'), 'G-W IfcActor (genuine tier 3) still lands in OTHER, not silently merged into a real package');
+const otherWp = allWPs.find(wp => wp.name === 'OTHER');
+assert(!!otherWp && otherWp.id === 'PACKAGE 7', 'G-X the dynamically-added OTHER package is PACKAGE 7, not a duplicate PACKAGE 6 (pre-existing id collision with MEP FINAL FIX, fixed)');
+assert(allWPs.some(wp => wp.id === 'PACKAGE 6' && wp.name === 'MEP FINAL FIX'), 'G-X PACKAGE 6 stays MEP FINAL FIX, unaffected by the OTHER id fix');
+
+console.log('\n§EXACT_LOOKUP_P3_WORKPACKAGES_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_exact_lookup_p4_boqchart.js
+++ b/viewer/tests/witness_exact_lookup_p4_boqchart.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p4_boqchart.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P4, the
+// last two consumers: boq_charts.html:477 (generateSchedule, the no-authored-schedule FALLBACK
+// generator) and :908 (buildScheduleFromOps, the kernel_ops live-mirror path). Both were confirmed by
+// BOQ4D as intentionally-preserved fallback-only paths — lower priority than P2's live consumers, but
+// the same raw SEQUENCE_RULES[cls] exact-key gap applies. Slices the LITERAL shipped blocks (via vm,
+// not reimplemented), same discipline as every other witness in this lane.
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   generateSchedule (:477) — IfcTank/IfcDoorType used to silently fall to DEFAULT_RULE (Architecture,
+//     generic) instead of their real tier 2/tier 1 classification, misgrouping the fallback chart's
+//     phase|||storey buckets.
+//   buildScheduleFromOps (:908) — same gap, but ALSO must preserve today's exact behavior for a
+//     genuinely tier-3 class (skip — do not add a spurious discipline to g.disciplines), the same
+//     distinction P2/P3/P4's schedule_read_4d.js fix all preserve elsewhere in this lane.
+//
+// Run: node witness_exact_lookup_p4_boqchart.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+global.self = { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, IFC_SCHEMA_HIERARCHY: HIERARCHY };
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleRead4D = require(path.join(__dirname, '..', 'schedule_read_4d.js'));
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'boq_charts.html'), 'utf8');
+
+// ── generateSchedule's classification loop (:477 area) ──
+{
+  const startMarker = '  // Group activities by phase -> storey';
+  const endMarker = '\n  // Sort storeys per phase';
+  const si = src.indexOf(startMarker);
+  const ei = src.indexOf(endMarker, si);
+  if (si < 0 || ei < 0) { console.log('  FAIL G-SLICE could not locate generateSchedule\'s classification loop'); process.exit(1); }
+  const block = src.slice(si, ei);
+  if (!/window\.ScheduleAuthor\.classify/.test(block)) { console.log('  FAIL G-SLICE generateSchedule slice missing classify() — marker drifted'); process.exit(1); }
+
+  const activities = [
+    { cls: 'IfcTank', storey: 'L1' },      // tier 2 -> MEP Rough-in
+    { cls: 'IfcDoorType', storey: 'L1' },  // tier 1 substring -> Architecture
+    { cls: 'IfcActor', storey: 'L1' }      // genuine tier 3 -> Architecture (SAME as DEFAULT_RULE always was — no distinction needed here)
+  ];
+  const sandbox = { window: { ScheduleAuthor: ScheduleAuthor, IFC_SCHEMA_HIERARCHY: HIERARCHY }, activities: activities, console: console };
+  vm.createContext(sandbox);
+  vm.runInContext(block + '\nthis.__captured = { grouped: grouped, phaseSets: Object.keys(phaseSets) };', sandbox);
+  const grouped = sandbox.__captured.grouped;
+  console.log('§P4_GENERATESCHEDULE groups=' + Object.keys(grouped).join(' | '));
+  assert(!!grouped['MEP Rough-in|||L1'] && grouped['MEP Rough-in|||L1'].some(a => a.cls === 'IfcTank'),
+    'G-AF generateSchedule: IfcTank (tier 2) groups into MEP Rough-in|||L1, not the generic default bucket');
+  assert(!!grouped['Architecture|||L1'] && grouped['Architecture|||L1'].some(a => a.cls === 'IfcDoorType'),
+    'G-AG generateSchedule: IfcDoorType (tier 1 substring, via IfcDoor) groups into Architecture|||L1');
+}
+
+// ── buildScheduleFromOps's classification block (:908 area) ──
+{
+  const startMarker = '// §EXACT_LOOKUP_BLINDSPOT P4 — was a raw SEQUENCE_RULES[op.cls]';
+  const endMarker = '\n  // Find project start from ops';
+  const si = src.indexOf(startMarker);
+  const ei = src.indexOf(endMarker, si);
+  if (si < 0 || ei < 0) { console.log('  FAIL G-SLICE could not locate buildScheduleFromOps\'s classification block'); process.exit(1); }
+  const block = src.slice(si, ei);
+  if (!/window\.ScheduleAuthor\.classify/.test(block)) { console.log('  FAIL G-SLICE buildScheduleFromOps slice missing classify() — marker drifted'); process.exit(1); }
+
+  // 3x IfcActor (genuine tier 3) outnumbers the 2 real-classified ops, same discriminating shape as
+  // the schedule_read_4d.js witness: if tier 3 wrongly contributed a discipline, it would still show
+  // up (Set, not count-weighted) — the decisive check is that ONLY MEP/ARC (from the 2 real classes)
+  // appear, nothing extra, and specifically that a tier-3-only group carries NO disciplines at all.
+  const ops = [
+    { op_type: 'ELEMENT_PLACE', phase: 'MEP Rough-in', storey: 'L1', cls: 'IfcTank', start_ts: 0, end_ts: 1, guid: 'g1' },
+    { op_type: 'ELEMENT_PLACE', phase: 'MEP Rough-in', storey: 'L1', cls: 'IfcDoorType', start_ts: 0, end_ts: 1, guid: 'g2' },
+    { op_type: 'ELEMENT_PLACE', phase: 'Unsequenced', storey: 'L2', cls: 'IfcActor', start_ts: 0, end_ts: 1, guid: 'g3' }
+  ];
+  const sandbox = {
+    window: { ScheduleAuthor: ScheduleAuthor, IFC_SCHEMA_HIERARCHY: HIERARCHY, ScheduleRead4D: ScheduleRead4D },
+    ops: ops, console: console,
+    phaseOrder: function () { return ['Substructure', 'Superstructure', 'Architecture', 'MEP Rough-in', 'MEP Final', 'Finishes']; }
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(block + '\nthis.__captured = { groups: groups };', sandbox);
+  const groups = sandbox.__captured.groups;
+  const mepGroup = groups['MEP Rough-in|||L1'];
+  const unclassifiedGroup = groups['Unsequenced|||L2'];
+  console.log('§P4_BUILDSCHEDULEFROMOPS mepDisciplines=' + JSON.stringify([...(mepGroup ? mepGroup.disciplines : [])])
+    + ' unclassifiedDisciplines=' + JSON.stringify([...(unclassifiedGroup ? unclassifiedGroup.disciplines : [])]));
+  assert(!!mepGroup && mepGroup.disciplines.has('MEP'), 'G-AH buildScheduleFromOps: IfcTank (tier 2, via IfcFlowStorageDevice/PLUMBER) contributes MEP discipline — was silently absent before');
+  assert(!!mepGroup && mepGroup.disciplines.has('ARC'), 'G-AI buildScheduleFromOps: IfcDoorType (tier 1 substring, via IfcDoor/CARPENTER) contributes ARC discipline — was silently absent before');
+  assert(!!unclassifiedGroup && unclassifiedGroup.disciplines.size === 0, 'G-AJ buildScheduleFromOps: IfcActor (genuine tier 3) contributes NO discipline — stays excluded, same as today\'s undefined-lookup skip');
+}
+
+console.log('\n§EXACT_LOOKUP_P4_BOQCHART_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_exact_lookup_p4_scheduleread.js
+++ b/viewer/tests/witness_exact_lookup_p4_scheduleread.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// witness_exact_lookup_p4_scheduleread.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P4:
+// schedule_read_4d.js's readTasks() had two raw `rules[cls]` exact-key lookups (resource/discipline
+// tally per task, majority-phase fallback when a task's name doesn't parse to a known phase) —
+// missing tier 1 substring matches and tier 2 schema-hierarchy inheritance, same gap class as P2/P3.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: (a) IfcTank (tier 2) and IfcDoorType (tier 1 substring) used to
+// contribute NOTHING to a task's resource/discipline tally or its majority-phase vote — now they do.
+// (b) a genuinely tier-3 class must NOT start winning the majority-phase vote just because classify()
+// gives it a real (if generic) phase — it must stay excluded, exactly like today's `!rule` skip, or a
+// handful of truly-unclassified elements could hijack a task's phase away from its real majority.
+//
+// Drives the REAL readTasks() (required verbatim from schedule_read_4d.js) against a real sql.js db
+// shaped exactly like the tables it queries.
+//
+// Run: node witness_exact_lookup_p4_scheduleread.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+const ScheduleRead4D = require(path.join(__dirname, '..', 'schedule_read_4d.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+(async function () {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run(`
+    CREATE TABLE schedules (schedule_id TEXT, name TEXT);
+    CREATE TABLE tasks (task_id TEXT, schedule_id TEXT, name TEXT, schedule_start TEXT, schedule_finish TEXT,
+      resource TEXT, total_float INT, is_critical INT, is_summary INT);
+    CREATE TABLE task_elements (task_id TEXT, guid TEXT);
+    CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT, storey TEXT);
+    CREATE TABLE task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days INT);
+  `);
+  db.run("INSERT INTO schedules VALUES ('SCH1','Test Schedule')");
+  // name has no ' — ' separator -> forces the majority-phase-of-elements fallback path (identify()),
+  // exercising the SAME classifyCls() the resource/discipline tally uses.
+  db.run("INSERT INTO tasks VALUES ('T1','SCH1','Misc Task','2026-01-01','2026-01-05',NULL,0,0,0)");
+  // 3x IfcActor (genuine tier 3) deliberately outnumbers the 2 real-classified elements — if tier 3
+  // were wrongly allowed into the majority vote with classify()'s generic 'Architecture' default, it
+  // would WIN on count alone (3 > 1) and hijack the task's phase away from its real classification.
+  const elements = [
+    ['g1', 'IfcTank'], ['g2', 'IfcDoorType'],
+    ['g3', 'IfcActor'], ['g4', 'IfcActor'], ['g5', 'IfcActor']
+  ];
+  elements.forEach(function (e) {
+    db.run("INSERT INTO task_elements VALUES ('T1',?)", [e[0]]);
+    db.run("INSERT INTO elements_meta VALUES (?,?,'L1')", [e[0], e[1]]);
+  });
+
+  const opts = { rules: SEQUENCE_RULES, defaultRule: SEQUENCE_DEFAULT, hierarchy: HIERARCHY, scheduleAuthor: ScheduleAuthor };
+  const out = ScheduleRead4D.readTasks(db, opts);
+  if (!out || !out.length) { console.log('  FAIL readTasks() returned nothing — cannot verify'); process.exit(1); }
+  const t = out[0];
+  console.log('§P4_SCHEDULEREAD phase=' + t.phase + ' resource=' + t.resource + ' discipline=' + t.discipline);
+
+  assert(t.resource.split(',').indexOf('PLUMBER') >= 0, 'G-AC IfcTank (tier 2, via IfcFlowStorageDevice) now contributes PLUMBER to the resource tally — was silently absent before');
+  assert(t.resource.split(',').indexOf('CARPENTER') >= 0, 'G-AD IfcDoorType (tier 1 substring, via IfcDoor) now contributes CARPENTER to the resource tally — was silently absent before');
+  assert(t.phase === 'MEP Rough-in', 'G-AE genuine tier 3 (IfcActor x3) does NOT win the majority-phase vote despite outnumbering the real classes 3-to-1 — phase correctly stays MEP Rough-in (from IfcTank)');
+
+  console.log('\n§EXACT_LOOKUP_P4_SCHEDULEREAD_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error(e); process.exit(2); });

--- a/viewer/tests/witness_schema_exhaustive_classify.js
+++ b/viewer/tests/witness_schema_exhaustive_classify.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// witness_schema_exhaustive_classify.js — CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md §BUILD PLAN P1:
+// "export classify() from schedule_author.js, witnessed against the existing
+// witness_schema_exhaustive_fallback.js's 1006-class sweep (same tiers, same numbers, just via the
+// new export instead of the internal closure)."
+//
+// THE ISSUE THIS PROVES OR DISPROVES: classify() is a NEW code path (a second call site into
+// matchRule, not matchRule itself) — nothing guarantees it reaches tier 1/2/3 the same way matchRule's
+// direct callers do until it's driven across the SAME exhaustive class list and diffed against the
+// SAME expected tier a real caller would see. A classify() that silently dropped `hierarchy` or
+// defaulted `rules`/`dflt` wrong would regress every consumer P2/P3 route through it, invisibly,
+// because none of those consumers have their own per-class coverage.
+//
+// FAILS on:
+//   G-H: classify(cls, ...) returns a DIFFERENT rule object than matchRule(cls, ...) for the same
+//        class — classify must be a pure pass-through, not a reimplementation.
+//   G-I: the tier distribution (132/53/821, pinned from witness_schema_exhaustive_fallback.js's own
+//        run) drifts — would mean either witness or the rules/hierarchy data changed underneath this
+//        one without both being updated together.
+//
+// Run: node witness_schema_exhaustive_classify.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const RULES_PATH = path.join(__dirname, '..', 'rates', 'sequence_rules.json');
+const rulesJson = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+const SEQUENCE_DEFAULT = rulesJson.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
+
+const HIERARCHY_PATH = path.join(__dirname, '..', 'rates', 'ifc_schema_hierarchy.json');
+const hierarchyJson = JSON.parse(fs.readFileSync(HIERARCHY_PATH, 'utf8'));
+const HIERARCHY = {};
+for (const cls in hierarchyJson) { if (cls !== '_meta') HIERARCHY[cls] = hierarchyJson[cls]; }
+
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+if (!ScheduleAuthor.classify) { console.log('  FAIL G-EXPORT ScheduleAuthor.classify is exported'); process.exit(1); }
+
+const classNames = Object.keys(HIERARCHY).sort();
+let tier1 = 0, tier2 = 0, tier3 = 0, mismatches = 0;
+
+classNames.forEach(function (cls) {
+  let mrWarn = null, clWarn = null;
+  const origWarn = console.warn;
+
+  console.warn = function (msg) { mrWarn = msg; };
+  const mrRule = ScheduleAuthor.matchRule(cls, SEQUENCE_RULES, SEQUENCE_DEFAULT, HIERARCHY);
+
+  console.warn = function (msg) { clWarn = msg; };
+  const clRule = ScheduleAuthor.classify(cls, HIERARCHY, SEQUENCE_RULES, SEQUENCE_DEFAULT);
+
+  console.warn = origWarn;
+
+  if (clRule !== mrRule || clWarn !== mrWarn) {
+    mismatches++;
+    console.log('  MISMATCH cls=' + cls + ' matchRule.warn=' + mrWarn + ' classify.warn=' + clWarn);
+  }
+
+  if (mrWarn === null) tier1++;
+  else if (mrWarn.indexOf('§CLASS_UNMATCHED_INHERITED') === 0) tier2++;
+  else tier3++;
+});
+
+console.log('\n=== classify() vs matchRule() across ' + classNames.length + ' real IFC classes ===');
+console.log('  tier 1 (explicit)  : ' + tier1);
+console.log('  tier 2 (inherited) : ' + tier2);
+console.log('  tier 3 (generic)   : ' + tier3);
+
+assert(mismatches === 0, 'G-H classify() returns the identical rule+warn as matchRule() for every class — mismatches=' + mismatches);
+assert(tier1 === 132, 'G-I tier 1 count pinned to witness_schema_exhaustive_fallback.js baseline (132), got ' + tier1);
+assert(tier2 === 53, 'G-I tier 2 count pinned to witness_schema_exhaustive_fallback.js baseline (53), got ' + tier2);
+assert(tier3 === 821, 'G-I tier 3 count pinned to witness_schema_exhaustive_fallback.js baseline (821), got ' + tier3);
+
+// classify(cls) with no hierarchy arg at all — real call sites that only pass `cls` (P2's
+// boq_charts.html chart, proj_fold.js) must still resolve tier 1 correctly; tier 2 simply never
+// fires (identical to an omitted-hierarchy matchRule call), never silently throws on missing arg.
+const noHierRule = ScheduleAuthor.classify('IfcWall', undefined, SEQUENCE_RULES, SEQUENCE_DEFAULT);
+assert(!!noHierRule && noHierRule.phase != null, 'G-J classify(cls) with no hierarchy arg still resolves tier 1 for a real explicit class (IfcWall)');
+
+console.log('\n§SCHEMA_EXHAUSTIVE_CLASSIFY_SUMMARY pass=' + pass + ' fail=' + fail
+  + ' tier1=' + tier1 + ' tier2=' + tier2 + ' tier3=' + tier3);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
`CLASSIFICATION_EXACT_LOOKUP_BLINDSPOT.md` — full build plan (P1–P4), CLOSED. Stacked on #1191 (base branch), which this depends on — `classify()` wraps `matchRule`'s tier 1→2→3 (explicit / schema-hierarchy-inherited / generic-default) logic that #1191 introduces.

**P1**: `classify(cls, hierarchy, rules, dflt)` added to `viewer/schedule_author.js`, exported as `ScheduleAuthor.classify` — pure pass-through to `matchRule`.

**P2**: `boq_charts.html:1808/1813` (crew chart) and `proj_fold.js` (BIM→Project ERP push, all 3 internal sites) wired through `classify()`. Preserves the existing `'Unsequenced'` phase bucket for genuinely-unclassified classes so the `Name<>'Unsequenced'` dashboard filter (`time_machine.js:4376`, `poc_dashboard_variance.js:31`) keeps working.

**P3**: `rates.js getPhase()` (shared helper behind `variation_order.js`'s 3 call sites) now routes through `classify()`. `WORK_PACKAGES` resolved as **derive, not retire** — verified all 15 rate templates' `classes:[...]` arrays were byte-identical to the default in the same PACKAGE order, then added a positional `phase` field to all 16 files; `export_5d.js` now groups by the real `classify()` result. Fixed a pre-existing `PACKAGE 6` id collision along the way (OTHER → `PACKAGE 7`).

**P4** (this update, the final two — lower priority by BOQ4D's own ruling, fallback-only/secondary paths):
- `schedule_read_4d.js`'s `readTasks()` — 2 sites (per-task resource/discipline tally, majority-phase-of-elements fallback). Both route through a local `classifyCls()` that returns `null` on a genuine tier-3 hit (not the generic default), preserving today's exact "skip, don't count" behavior for truly unclassified classes — same distinction P2/P3 preserved elsewhere.
- `boq_charts.html generateSchedule()` (:477, the no-authored-schedule fallback generator) — straight substitution, no tier-3 distinction needed since `DEFAULT_RULE` was already the same generic fallback `classify()` produces.
- `boq_charts.html buildScheduleFromOps()` (:908, kernel_ops live-mirror path) — same tier-3-preserving pattern, so a truly unclassified class doesn't add a spurious discipline to a phase|storey group's discipline set.

## Verification
- `witness_schema_exhaustive_classify.js` 5/5, `witness_exact_lookup_p2.js` 8/8, `witness_exact_lookup_p2_boqchart.js` 3/3, `witness_exact_lookup_p3_workpackages.js` 7/7, `witness_exact_lookup_p3_getphase.js` 4/4, `witness_exact_lookup_p4_scheduleread.js` 3/3, `witness_exact_lookup_p4_boqchart.js` 5/5 — all against real code paths (real `foldProjectOrder`/`readTasks` on real sql.js fixtures, or the literal shipped inline-HTML/JS blocks sliced verbatim via `vm`, never reimplemented).
- Zero regression: `witness_schema_exhaustive_fallback.js` (6/6), `bake_gw_hospital_seed.js` (7/7, PlannedAmt golden unchanged), `witness_whatif_authored_sync.js` (9/9), and the root-level `witness_boq_charts_real_schedule.js` (91/91, Hospital+Terminal real fixtures, 48000+ elements).

## Test plan
- [x] Headless witness proof (project standing discipline)
- [x] P2: wire `boq_charts.html:1808/1813` + `proj_fold.js` through `classify()`
- [x] P3: `variation_order.js` (via `getPhase()`) + `WORK_PACKAGES` derivation
- [x] P4: `schedule_read_4d.js` + `boq_charts.html`'s remaining fallback-only sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NV5fUSEBaZddgKsAUANDM7