### PR TITLE
fix(cpe): scrub-play button drives POV only, main canvas stays parked

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1287,12 +1287,10 @@
   // QUESTION named this "deliberately DEFERRED future work", not dropped. Restoring it now: the
   // #1177 regression's actual invariant (main camera/controls untouched by any scrub) is preserved —
   // this only ever writes `_state.vfCam`, which #1177 never touched in the first place.
-  function _scrubTo(tn) {
-    if (!_state) return null;
-    tn = Math.max(0, Math.min(1, tn));
-    _state.scrubTn = tn;
-    _renderScrub();
-    var p = (_state.plan && typeof _state.plan.poseAt === 'function') ? _state.plan.poseAt(tn) : null;
+  // §CPE_SCRUB_POV_ONLY — extracted from _scrubTo so the scrub-play button can drive ONLY B
+  // (never the main camera), same invariant _scrubTo's own drag path already honours.
+  function _applyVFPose(tn) {
+    var p = (_state && _state.plan && typeof _state.plan.poseAt === 'function') ? _state.plan.poseAt(tn) : null;
     if (p && _state.vfOn && _state.vfCam) {
       _state.vfCam.position.set(p.x, p.y, p.z);
       _state.vfCam.lookAt(p.tx, p.ty, p.tz);
@@ -1300,6 +1298,14 @@
       if (a.markDirty) a.markDirty();
     }
     return p;
+  }
+
+  function _scrubTo(tn) {
+    if (!_state) return null;
+    tn = Math.max(0, Math.min(1, tn));
+    _state.scrubTn = tn;
+    _renderScrub();
+    return _applyVFPose(tn);
   }
 
   function _wireScrub(track) {
@@ -1571,7 +1577,7 @@
         console.log('§CPE_SCRUB_PLAY resumed');
       } else {
         console.log('§CPE_SCRUB_PLAY started');
-        _previewFly();
+        _previewFly(true);   // §CPE_SCRUB_POV_ONLY — B only, main canvas stays parked
         return;   // _previewFly's own _renderWhole() calls already sync the button
       }
       _renderWhole();
@@ -1821,15 +1827,18 @@
   // Driven by `_state.plan.poseAt`: the same plan object the tube is sampled from and the same one
   // finish() hands the bake, so this cannot become a second notion of the path (§CPE_PREVIEW_DIVERGENCE).
   // Honours the clip window — previewing a clip should show the clip, not the film it was cut from.
-  function _previewFly() {
+  // §CPE_SCRUB_POV_ONLY (2026-08-05) — povOnly: true drives ONLY B (vfCam), leaving the main
+  // canvas camera/controls untouched throughout, same invariant §CPE_SCRUB_VF_LIVE's drag path
+  // already honours. #cpe-preview's own wiring calls this with no argument — unaffected.
+  function _previewFly(povOnly) {
     if (!_state || _state.flying || !_state.plan || typeof _state.plan.poseAt !== 'function') return;
     var a = A(), s = _state;
     var t0N = s.clipIn, t1N = s.clipOut;
     var dur = Math.max(1000, (t1N - t0N) * 10000);   // 10s for the whole film, pro-rata for a clip
     console.log('§CPE_PREVIEW click stale=' + (s.edits !== s.previewedAt ? 1 : 0) + ' edits=' + s.edits +
       ' window=' + t0N.toFixed(2) + '→' + t1N.toFixed(2) + ' durMs=' + dur.toFixed(0) +
-      ' hoseOps=' + s.hose.length + ' buildup=' + (s.buildup ? 1 : 0));
-    var save = { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
+      ' hoseOps=' + s.hose.length + ' buildup=' + (s.buildup ? 1 : 0) + ' povOnly=' + (povOnly ? 1 : 0));
+    var save = povOnly ? null : { px: a.camera.position.x, py: a.camera.position.y, pz: a.camera.position.z,
                  tx: a.controls.target.x, ty: a.controls.target.y, tz: a.controls.target.z };
     s.flying = true; s.previewedAt = s.edits; _renderWhole();
 
@@ -1891,7 +1900,8 @@
         var tn = t0N + (t1N - t0N) * u;
         // §CPE_SCRUB/§CPE_VIEWFINDER: the ONE place a pose is applied to the live camera — see
         // _applyCameraPose above. Was inlined here; extracted so scrubbing and B share it exactly.
-        _applyCameraPose(tn);
+        // §CPE_SCRUB_POV_ONLY: povOnly skips the main camera entirely, applying to B alone.
+        if (povOnly) { _applyVFPose(tn); } else { _applyCameraPose(tn); }
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
         if (bkPrev && window.tmSetCursor) {
           // §CPE_BUILDUP_WORK_PACED: the rehearsal asks for the SAME cursor the bake will ask for at
@@ -1923,10 +1933,12 @@
         if (a.markDirty) a.markDirty();
         if (u < 1) return requestAnimationFrame(step);
         var msPerFrame = (performance.now() - t0) / Math.max(1, frames);
-        a.camera.position.set(save.px, save.py, save.pz);
-        a.controls.target.set(save.tx, save.ty, save.tz);
-        a.controls.update();
-        if (a.markDirty) a.markDirty();
+        if (!povOnly) {
+          a.camera.position.set(save.px, save.py, save.pz);
+          a.controls.target.set(save.tx, save.ty, save.tz);
+          a.controls.update();
+          if (a.markDirty) a.markDirty();
+        }
         // Hand Time Machine back exactly as it was — the preview must never leave the user's
         // timeline re-ordered, same contract the bake honours on every exit path.
         if (bkPrev && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); bkPrev = null; }

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -28,6 +28,9 @@
 //   G-SCRUB-PLAY        pressing play starts a rehearsal; pause freezes the flight fraction (no
 //                       advance over a real wait); resume continues it — real pause/resume, not a
 //                       screenshot-verified "looks paused".
+//   G-SCRUB-PLAY-POVONLY  the SAME button-driven flight leaves the main camera byte-identical
+//                       throughout (start/pause/resume) — §CPE_SCRUB_POV_ONLY: the scrub-play
+//                       button now calls _previewFly(true), driving B alone, never the main canvas.
 //   G-SCRUB-CLOSE-TEARDOWN  closing the editor (Cancel) removes the scrub panel too.
 //   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant DURING A
 //              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call.
@@ -247,6 +250,14 @@ async function gates(browser, BLD, repoDir) {
   await sleep(200);
   const vf2mark = logs.length;
   await page.evaluate(() => { const el = document.getElementById('cpe-vf-clock'); if (el) el.textContent = ''; });
+  // ── G-SCRUB-PLAY-POVONLY setup: main camera pose captured BEFORE the transport-button flight
+  // starts — the scrub-play button now calls _previewFly(true) (§CPE_SCRUB_POV_ONLY), so this same
+  // flight doubles as the regression gate: main canvas must stay parked throughout a POV-only play.
+  const mainBefore = await page.evaluate(() => {
+    const A = window.APP;
+    return { pos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+             tgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z } };
+  });
   page.evaluate(() => document.getElementById('cpe-scrub-play').click());   // starts via the NEW transport button
   // §CPE_PREVIEW_BUILDUP arms ASYNCHRONOUSLY (awaits tmActivateForBake before startFly() even
   // runs — same fact G-VF-2's own comment below already names, 513ms-3.2s depending on building
@@ -276,6 +287,20 @@ async function gates(browser, BLD, repoDir) {
   P('G-SCRUB-PLAY resume continues the flight (still flying, no longer paused)',
     resumedOk && resumedState && resumedState.flying && !resumedState.paused,
     `resumeOk=${resumedOk} flying=${resumedState ? resumedState.flying : 'n/a'} paused=${resumedState ? resumedState.paused : 'n/a'}`);
+
+  // ── G-SCRUB-PLAY-POVONLY: the main camera stayed byte-identical across the whole button-driven ──
+  // flight above (start, mid-flight pause, resume) — proves _previewFly(true) never touches it,
+  // same invariant class as G-SCRUB-NOCAM/G-SCRUB-VF-LIVE but for the play button, not the drag.
+  const mainMid = await page.evaluate(() => {
+    const A = window.APP;
+    return { pos: { x: A.camera.position.x, y: A.camera.position.y, z: A.camera.position.z },
+             tgt: { x: A.controls.target.x, y: A.controls.target.y, z: A.controls.target.z } };
+  });
+  const dPovPos = Math.hypot(mainMid.pos.x - mainBefore.pos.x, mainMid.pos.y - mainBefore.pos.y, mainMid.pos.z - mainBefore.pos.z);
+  const dPovTgt = Math.hypot(mainMid.tgt.x - mainBefore.tgt.x, mainMid.tgt.y - mainBefore.tgt.y, mainMid.tgt.z - mainBefore.tgt.z);
+  P('G-SCRUB-PLAY-POVONLY main camera untouched by the scrub-play button (start/pause/resume)',
+    dPovPos < 1e-9 && dPovTgt < 1e-9,
+    `mainPosDelta=${dPovPos.toExponential(2)}m mainTargetDelta=${dPovTgt.toExponential(2)}m`);
 
   // Poll for a non-empty readout the same way the original gate did (post-resume).
   let vf2 = null;


### PR DESCRIPTION
## Summary
- User, live-testing: "That preview play in scrubber only affects pov window now and not the main canvas" — it was calling `_previewFly()` unarged, the same function the legacy `#cpe-preview` button uses, which applies every frame's pose to the main camera. This violated the session's own §CPE_SCRUB_VF_LIVE invariant (main canvas never touched by anything scrub-panel-driven) for the play button, though it already held for scrub-drag.
- Extracted `_applyVFPose(tn)` out of `_scrubTo`'s inline vfCam-write block (no behaviour change, shared name).
- `_previewFly(povOnly)`: `step()` now branches `_applyVFPose` vs `_applyCameraPose`; the main-camera save/restore block is skipped when `povOnly` since nothing moved. `#cpe-preview`'s existing no-arg wiring is untouched — the two witnesses that click it and check the flown main camera (`witness_cpe_room_title_live.js`, `witness_cpe_room_title_timing.js`) still get that exact behaviour.
- `_wireScrubPlay`'s click handler now calls `_previewFly(true)`.

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` 17/17 green (HHS_Office_Federated) — includes new gate `G-SCRUB-PLAY-POVONLY`: main camera byte-identical across a full button-driven flight (start/pause/resume)
- [x] `witness_cpe_room_title_live.js` 4/4 green — legacy `#cpe-preview` main-camera-flying path unaffected
- [x] `witness_cpe_room_title_timing.js` 3/3 green — same

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>