### PR TITLE
fix(4d+cinema): materializeDefault exclusion + §DLOD_VF_CAMGUARD — orphaned by #1198's squash-merge race

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -2775,6 +2775,13 @@
     if (window.APP) {
       window.APP.cinemaPathEditor = {
         open: open, version: CPE_V,
+        // §DLOD_VF_CAMGUARD (2026-08-05, cross-session finding — see 4D_SCHEDULE_PERFECTION.md and
+        // this file's own SESSION HANDOFF): time_machine.js's buildup-visibility DLOD gate was
+        // hardcoded to the main camera even while the POV panel scrubs `vfCam` independently. This
+        // is the clean read surface for that fix — returns the live POV camera object ONLY while
+        // the viewfinder is actually on, else null, so a caller elsewhere never needs to know about
+        // `_state` at all.
+        activePOVCamera: function() { return (_state && _state.vfOn && _state.vfCam) ? _state.vfCam : null; },
         // §CPE_STICK_HOLD — the teaching default, exposed so the witness asserts against the
         // constant the seeding actually uses rather than a copy of the number (G-SH-7).
         holdDefaultSec: CPE_HOLD_DEFAULT_SEC,

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -455,7 +455,13 @@
     // Read the raw material: every element + its class + name (name feeds matchNameOverride) +
     // storey (§PHASE_OVERLAP_BAND below — real band count for the overlap fix).
     var elems = [];
-    var er = db.exec('SELECT guid, ifc_class, COALESCE(element_name,\'\'), COALESCE(storey,\'\') FROM elements_meta');
+    // §CLASS_UNMATCHED_FALLBACK follow-up (2026-08-05, named in 4D_SCHEDULE_PERFECTION.md): the
+    // _buildScheduleElements/materializeZones path already excludes IfcOpeningElement (ghost/position-
+    // only, never real work) and IfcSpace (spatial zone, not physical work) — this query was the one
+    // materialize path that still read every row unfiltered. Same exclusion, same two classes, so a
+    // blank-model default schedule can't invent labor for a room volume or a doorway either.
+    var er = db.exec("SELECT guid, ifc_class, COALESCE(element_name,''), COALESCE(storey,'') FROM elements_meta " +
+      "WHERE ifc_class != 'IfcOpeningElement' AND ifc_class != 'IfcSpace'");
     if (er.length && er[0].values.length) {
       er[0].values.forEach(function (r) { elems.push({ guid: r[0], cls: r[1], name: r[2], storey: r[3] }); });
     }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v952';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v953';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_dlod_vf_camguard.js
+++ b/viewer/tests/witness_dlod_vf_camguard.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// witness_dlod_vf_camguard.js — §DLOD_VF_CAMGUARD (2026-08-05). Cross-session finding, root-caused
+// independently in both 4D_SCHEDULE_PERFECTION.md (this session) and CINEMA_PATH_EDITOR.md's own
+// SESSION HANDOFF (concurrent cinema session): Time Machine's buildup-visibility DLOD gate
+// (_dlodInView) was hardcoded to the MAIN camera even while CPE's POV panel scrubs its own `vfCam`
+// independently. Proves the extracted `_dlodResolveCamera(app)` picks the POV camera while CPE's
+// viewfinder is genuinely on, and falls back to the main camera in every other case (viewfinder
+// off, CPE module not loaded at all, or loaded with no cinemaPathEditor exposed) — sliced by
+// balanced braces from the real shipped function, never reimplemented.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const sliced = sliceFn(tmSrc, '_dlodResolveCamera');
+
+function run(windowObj) {
+  const sandbox = { console: console, window: windowObj };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nglobalThis.__resolve = _dlodResolveCamera;', sandbox);
+  return sandbox.__resolve;
+}
+
+const mainCam = { position: { x: 0, y: 0, z: 0 }, tag: 'main' };
+const povCam = { position: { x: 9, y: 9, z: 9 }, tag: 'pov' };
+const app = { camera: mainCam };
+
+// ── Case 1: no window.APP at all (module loaded outside a browser / CPE not loaded) — main camera ──
+{
+  const resolve = run({});
+  const r = resolve(app);
+  assert(r === mainCam, 'no window.APP: falls back to the main camera');
+}
+
+// ── Case 2: window.APP exists but no cinemaPathEditor (CPE module never opened) — main camera ──
+{
+  const resolve = run({ APP: {} });
+  const r = resolve(app);
+  assert(r === mainCam, 'no cinemaPathEditor on window.APP: falls back to the main camera');
+}
+
+// ── Case 3: cinemaPathEditor exists, viewfinder OFF (activePOVCamera returns null) — main camera ──
+{
+  const resolve = run({ APP: { cinemaPathEditor: { activePOVCamera: function () { return null; } } } });
+  const r = resolve(app);
+  assert(r === mainCam, 'viewfinder off (activePOVCamera returns null): falls back to the main camera');
+}
+
+// ── Case 4: viewfinder ON — the REAL bug case. Must return the POV camera, not main. ──
+{
+  const resolve = run({ APP: { cinemaPathEditor: { activePOVCamera: function () { return povCam; } } } });
+  const r = resolve(app);
+  assert(r === povCam, 'viewfinder on: resolves to the POV camera, not the parked main camera');
+  assert(r !== mainCam, 'RED CONTROL: without this fix, resolve(app) === mainCam always — proves the branch is live');
+}
+
+console.log('\n§DLOD_VF_CAMGUARD SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_materialize_default_exclusion.js
+++ b/viewer/tests/witness_materialize_default_exclusion.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// witness_materialize_default_exclusion.js — §CLASS_UNMATCHED_FALLBACK follow-up (2026-08-05,
+// named in 4D_SCHEDULE_PERFECTION.md by bim-ootb PR #1186). materializeDefault's elements_meta read
+// carried ZERO class exclusion while the materializeZones/_buildScheduleElements path already
+// excluded IfcOpeningElement (ghost/position-only) and IfcSpace (spatial zone, not physical work).
+// Proves the fix on the real fixture, not a synthetic one: Duplex_extracted.db carries 50 real
+// IfcOpeningElement rows and 21 real IfcSpace rows.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  const dbPath = path.join(require('os').homedir(), 'bim-ootb', 'buildings', 'Duplex_extracted.db');
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const rawCounts = db.exec("SELECT ifc_class, COUNT(*) FROM elements_meta WHERE ifc_class IN ('IfcOpeningElement','IfcSpace') GROUP BY ifc_class")[0].values;
+  const openings = (rawCounts.find(function (r) { return r[0] === 'IfcOpeningElement'; }) || [null, 0])[1];
+  const spaces = (rawCounts.find(function (r) { return r[0] === 'IfcSpace'; }) || [null, 0])[1];
+  console.log('§FIXTURE Duplex IfcOpeningElement=' + openings + ' IfcSpace=' + spaces);
+  assert(openings > 0 && spaces > 0, 'RED-CONTROL: fixture actually carries both excludable classes, or this test proves nothing');
+
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const res = ScheduleAuthor.materializeDefault(db, SEQUENCE_RULES, { start: '2026-01-01', laborRates: {}, blank: false });
+  assert(res && res.scheduleId && res.assignmentCount > 0, 'materializeDefault succeeds on the real fixture — assignmentCount=' + (res && res.assignmentCount));
+
+  const assignedGuids = db.exec('SELECT guid FROM task_elements')[0].values.map(function (r) { return r[0]; });
+  const assignedSet = {}; assignedGuids.forEach(function (g) { assignedSet[g] = true; });
+
+  const badGuids = db.exec("SELECT guid FROM elements_meta WHERE ifc_class IN ('IfcOpeningElement','IfcSpace')")[0].values.map(function (r) { return r[0]; });
+  const leaked = badGuids.filter(function (g) { return assignedSet[g]; });
+  assert(leaked.length === 0, 'zero IfcOpeningElement/IfcSpace guids were assigned a task — leaked=' + leaked.length);
+
+  const totalElems = db.exec('SELECT COUNT(*) FROM elements_meta')[0].values[0][0];
+  const expectedEligible = totalElems - openings - spaces;
+  assert(assignedGuids.length === expectedEligible,
+    'assignment count matches elements_meta minus both excluded classes exactly — assigned=' + assignedGuids.length + ' expected=' + expectedEligible);
+
+  db.close();
+  console.log('\n§W-MATDEFAULT-EXCL SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -573,6 +573,21 @@
     return _dlodProxyOn && _isLargeBuilding && !app.streaming;
   }
 
+  // §DLOD_VF_CAMGUARD (2026-08-05, cross-session finding — independently root-caused in both
+  // 4D_SCHEDULE_PERFECTION.md and CINEMA_PATH_EDITOR.md's own SESSION HANDOFF). The buildup-
+  // visibility gate used to be hardcoded to the main camera always, even while CPE's POV panel
+  // scrubs its own `vfCam` independently (main camera stays parked during a scrub) — so the POV
+  // inset could show buildup-hidden geometry gated by the WRONG camera's frustum. Pulled out as its
+  // own pure function (same precedent as `_retimeSpan`'s own header: kept self-contained so a
+  // witness can slice the real decision out of `renderAtTime` instead of re-implementing it).
+  // Returns the POV camera while CPE's viewfinder is genuinely on, else the main camera — never
+  // guesses, reads CPE's own exposed `activePOVCamera()` accessor.
+  function _dlodResolveCamera(app) {
+    var povCam = (typeof window !== 'undefined' && window.APP && window.APP.cinemaPathEditor &&
+      window.APP.cinemaPathEditor.activePOVCamera) ? window.APP.cinemaPathEditor.activePOVCamera() : null;
+    return povCam || app.camera;
+  }
+
   // In-view = the S261 LOD0/LOD2 boundary: close AND actually in the camera's frustum. Fails open
   // (treats as in-view/real) for an unknown guid rather than risk hiding something real by mistake.
   function _dlodInView(g) {
@@ -1285,8 +1300,10 @@
       _dlodBuildBoxes(app);
       if (_dlodBoxIndex && app.camera) {
         if (!_dlodFrustum) { _dlodFrustum = new THREE.Frustum(); _dlodPSM = new THREE.Matrix4(); _dlodSphere = new THREE.Sphere(); }
-        _dlodCamPos = app.camera.position;
-        _dlodPSM.multiplyMatrices(app.camera.projectionMatrix, app.camera.matrixWorldInverse);
+        // §DLOD_VF_CAMGUARD — gate against whichever camera the user is actually looking through.
+        var _dlodActiveCam = _dlodResolveCamera(app);
+        _dlodCamPos = _dlodActiveCam.position;
+        _dlodPSM.multiplyMatrices(_dlodActiveCam.projectionMatrix, _dlodActiveCam.matrixWorldInverse);
         _dlodFrustum.setFromProjectionMatrix(_dlodPSM);
       } else {
         _dlodOn = false; // box build failed (deps/query) — fall back to legacy behavior this tick


### PR DESCRIPTION
## Summary
Two commits that were pushed to `feat/gantt-edit-foundation` after PR #1198's auto-merge had
already triggered on an earlier head — same squash-merge race this project's CLAUDE.md documents
(auto-merge fires on whatever head is green at the moment, a later push to the same branch doesn't
retroactively get folded in). Verified via `git merge-base --is-ancestor <sha> origin/main` before
opening this: neither commit was reachable from `main`. Recovered per the documented procedure —
fresh branch off current `origin/main`, cherry-pick forward, re-run witnesses, new PR (not a
re-push to the stale branch).

1. **`materializeDefault` IfcOpeningElement/IfcSpace exclusion** — named as a real gap in #1186's
   own write-up: the blank-model default schedule path read `elements_meta` with zero class
   exclusion, so it could assign labor to a room volume or a doorway opening. Same two-class
   filter as the already-fixed `_buildScheduleElements`/`materializeZones` path.
2. **§DLOD_VF_CAMGUARD** — cross-session finding, independently root-caused in both
   `4D_SCHEDULE_PERFECTION.md` and `CINEMA_PATH_EDITOR.md`. Time Machine's buildup-visibility gate
   was hardcoded to the main camera even while CPE's POV panel scrubs its own `vfCam`
   independently, so the POV inset could show buildup-hidden geometry gated by the wrong camera.
   Extracted the camera choice into `_dlodResolveCamera(app)` and added a minimal read-only
   accessor on CPE's own exposed API (`window.APP.cinemaPathEditor.activePOVCamera()`) — falls
   back to the main camera in every case except "viewfinder genuinely on."

`sw.js` CACHE_VERSION carried forward to v953 (both `time_machine.js` and `cinema_path_editor.js`
are precached).

## Test plan
- [x] `node --check` on all 4 touched files
- [x] `witness_materialize_default_exclusion.js` 4/4 (new) — real Duplex fixture, 50 real
      IfcOpeningElement + 21 real IfcSpace rows, RED CONTROL confirms the fixture exercises it
- [x] `witness_dlod_vf_camguard.js` 5/5 (new) — slices the real `_dlodResolveCamera`, all 3
      fallback cases + the POV-on case + a RED CONTROL
- [x] Regression on the just-merged #1198 surface: `witness_gantt_edit_lock` 5/5,
      `witness_gantt_native_generate` 5/5, `witness_gantt_bar_identity` 6/6,
      `witness_gap1_task_sequences` 7/7, `witness_phase_duration` 5/5 — all re-run on this branch
      (built on current `origin/main`, i.e. post-#1198), all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01UCZQfqMncP9QapmvjQZbD8