### PR TITLE
fix(room-graph): bridge isolated door-pair islands to circulation spine

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -820,36 +820,68 @@
     var _legalCtx = { rasters: rasters, roomRectsByStorey: roomRectsByStorey,
                       corridorRectsByStorey: corridorRectsByStorey, doorRectsByStorey: doorRectsByStorey,
                       stairRectsByStorey: stairRectsByStorey };
-    var _degSoFar = {};
+    // §SPINE-BRIDGE-CLUSTER (2026-08-05, OCCUPANT_PATHFINDER.md — real LTU_AHouse field report):
+    // the old test skipped any room with SOME degree, on the assumption that any edge at all means
+    // "already reachable". False for a room-PAIR island: R1's only edge is its door to R2, and
+    // neither reaches circulation — the pair is a 2-node component with zero outward edges, but
+    // neither node is individually zero-degree so the old per-node check never even tried them
+    // (measured: LTU_AHouse VÅNING 4 stranded 8 of 12 rooms this way). Union-find the E1 (room-room
+    // door) edges into components and bridge by COMPONENT: a component needs an attempt only if
+    // NONE of its members already has a non-E1 edge (i.e. none reaches spine/circ/doorwp-to-spine).
+    // This subsumes the old zero-degree case (a size-1 component with no outward edge) — same
+    // legality test, same nearest-first/first-legal-wins rule, just ranking candidates across every
+    // member of the component instead of one room's own centre.
+    var _ufParent = {};
+    order.forEach(function (lg) { if (nodes[lg].kind === 'room') _ufParent[lg] = lg; });
+    function _ufFind(x) { while (_ufParent[x] !== x) { x = _ufParent[x]; } return x; }
+    function _ufUnion(a, b) { var ra = _ufFind(a), rb = _ufFind(b); if (ra !== rb) _ufParent[ra] = rb; }
+    var hasOutward = {};
     edges.forEach(function (e) {
-      _degSoFar[e.a] = (_degSoFar[e.a] || 0) + 1;
-      _degSoFar[e.b] = (_degSoFar[e.b] || 0) + 1;
+      if (e.kind === 'E1') {
+        if (_ufParent[e.a] !== undefined && _ufParent[e.b] !== undefined) _ufUnion(e.a, e.b);
+      } else {
+        hasOutward[e.a] = true; hasOutward[e.b] = true;
+      }
     });
+    var components = {};
     order.forEach(function (lg) {
-      var g = nodes[lg];
-      if (g.kind !== 'room' || _degSoFar[lg]) return;
-      var pts = spineByStorey[g.storey];
+      if (nodes[lg].kind !== 'room') return;
+      var root = _ufFind(lg);
+      (components[root] = components[root] || []).push(lg);
+    });
+    Object.keys(components).forEach(function (root) {
+      var members = components[root];
+      if (members.some(function (m) { return hasOutward[m]; })) return; // component already reaches circulation
+      var storey = nodes[members[0]].storey;
+      var pts = spineByStorey[storey];
       if (!pts || !pts.length) return;
       // rect distance ranks candidates (a long room's centre can be far from a corridor its EDGE
       // touches); the LEGALITY test uses centre->spine, which is the segment a router actually draws.
-      var ranked = pts.map(function (p) {
-        var d;
-        if (g.rects && g.rects.length) {
-          d = Infinity;
-          for (var ri = 0; ri < g.rects.length; ri++) {
-            var rc = g.rects[ri];
-            var ddx = Math.max(0, Math.max(rc.x0 - p.cx, p.cx - rc.x1));
-            var ddy = Math.max(0, Math.max(rc.y0 - p.cy, p.cy - rc.y1));
-            var dd = Math.hypot(ddx, ddy);
-            if (dd < d) d = dd;
+      // Ranked across EVERY member of the component, not just one room's centre — any member
+      // reaching the spine reconnects the whole component via its own internal E1 edges.
+      var ranked = [];
+      members.forEach(function (mlg) {
+        var mg = nodes[mlg];
+        pts.forEach(function (p) {
+          var d;
+          if (mg.rects && mg.rects.length) {
+            d = Infinity;
+            for (var ri = 0; ri < mg.rects.length; ri++) {
+              var rc = mg.rects[ri];
+              var ddx = Math.max(0, Math.max(rc.x0 - p.cx, p.cx - rc.x1));
+              var ddy = Math.max(0, Math.max(rc.y0 - p.cy, p.cy - rc.y1));
+              var dd = Math.hypot(ddx, ddy);
+              if (dd < d) d = dd;
+            }
+          } else {
+            d = Math.hypot(p.cx - mg.cx, p.cy - mg.cy);
           }
-        } else {
-          d = Math.hypot(p.cx - g.cx, p.cy - g.cy);
-        }
-        return { p: p, d: d };
-      }).sort(function (a, b) { return a.d - b.d; });
+          ranked.push({ g: mg, p: p, d: d });
+        });
+      });
+      ranked.sort(function (a, b) { return a.d - b.d; });
       for (var k = 0; k < ranked.length; k++) {
-        var sp = ranked[k].p;
+        var g = ranked[k].g, sp = ranked[k].p;
         // §BRIDGE-ROUTED-LEGAL (2026-07-25, review correction to §BRIDGE-WALL-LEGAL above):
         // _chordIllegalCount samples a STRAIGHT segment — that is a visibility test, not a
         // connectivity test. A person leaving a 9.7x34.1m atrium walks through the opening and
@@ -865,11 +897,11 @@
         // The edge WEIGHT is the routed length, never the straight distance — an edge that claims
         // a shorter walk than the only real way there is the same class of lie as an invented
         // passage. Nothing else changes: candidates are still tried nearest-first, the first
-        // ACCEPTED one wins, and a room with no route stays deg-0 on purpose (logged as REJECT).
+        // ACCEPTED one wins, and a component with no route stays disconnected ON PURPOSE (REJECT).
         // _buildPolyline re-derives the same A* interior points at render time, so the drawn route
         // follows the floor without this block having to store geometry on the edge.
-        var hop = _astarHop(_legalCtx, { storey: g.storey, cx: g.cx, cy: g.cy },
-                                       { storey: g.storey, cx: sp.cx, cy: sp.cy });
+        var hop = _astarHop(_legalCtx, { storey: storey, cx: g.cx, cy: g.cy },
+                                       { storey: storey, cx: sp.cx, cy: sp.cy });
         if (hop === null) continue; // A* searched the walkable evidence and found no on-floor route
         var w = Math.hypot(sp.cx - g.cx, sp.cy - g.cy), routedVia = 'straight';
         if (hop.length) {
@@ -878,16 +910,19 @@
           w = L + Math.hypot(sp.cx - px, sp.cy - py);
           routedVia = 'routed(' + hop.length + ' turns)';
         }
-        edges.push({ a: lg, b: sp.guid, doorGuid: null, doorName: 'Opening onto corridor',
-                     storey: g.storey, kind: 'E6', w: w, wpA: sp.guid });
+        edges.push({ a: g.guid, b: sp.guid, doorGuid: null, doorName: 'Opening onto corridor',
+                     storey: storey, kind: 'E6', w: w, wpA: sp.guid });
         roomBridges++;
-        log('§ROOM_SPINE_BRIDGE room="' + (g.name || lg) + '" storey=' + g.storey +
+        log('§ROOM_SPINE_BRIDGE' + (members.length > 1 ? '_CLUSTER' : '') + ' room="' + (g.name || g.guid) + '" storey=' + storey +
+            (members.length > 1 ? ' clusterSize=' + members.length + ' clusterMembers=' + members.join(',') : '') +
             ' spine=' + sp.guid + ' gap=' + ranked[k].d.toFixed(2) + 'm walk=' + w.toFixed(2) + 'm via=' + routedVia);
         return;
       }
       bridgeRejected++;
-      log('§ROOM_SPINE_BRIDGE_REJECT room="' + (g.name || lg) + '" storey=' + g.storey +
-          ' candidates=' + ranked.length + ' nearest=' + ranked[0].d.toFixed(2) + 'm — no walkable route (straight or A*)');
+      log('§ROOM_SPINE_BRIDGE_REJECT' + (members.length > 1 ? '_CLUSTER' : '') + ' storey=' + storey +
+          (members.length > 1 ? ' clusterSize=' + members.length + ' clusterMembers=' + members.join(',')
+                               : ' room="' + (nodes[members[0]].name || members[0]) + '"') +
+          ' candidates=' + ranked.length + ' nearest=' + (ranked.length ? ranked[0].d.toFixed(2) : '?') + 'm — no walkable route (straight or A*)');
     });
     if (roomBridges || bridgeRejected)
       log('§ROOM_SPINE_BRIDGE bridged=' + roomBridges + ' rejected=' + bridgeRejected);

--- a/poc_spine_bridge_cluster.js
+++ b/poc_spine_bridge_cluster.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — POC GATE, calculation-only, no engine edit
+ * SCOPE: OCCUPANT_PATHFINDER.md §SPINE-BRIDGE-CLUSTER POC gate. Measures, per fleet building/storey,
+ * how many connected components of E1 (door) edges have ZERO members touching spine/circ (E2/E6/E7)
+ * — i.e. how many rooms today's `_degSoFar[lg]` guard skips because they have SOME degree, just not
+ * to circulation. Uses only room_graph.js's own exported buildGraph()/edges — no engine change.
+ * RUN: node poc_spine_bridge_cluster.js   (run from the repo root; needs buildings/*.db present)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const RG = require(path.join(__dirname, 'common', 'room_graph.js'));
+
+const BLD = path.join(__dirname, 'buildings');
+const PATCH = path.join(BLD, 'patches');
+const FLEET = [
+  // Hospital/Clinic/Terminal ship meta/extracted SPLIT locally (extracted.db lacks
+  // spatial_structure) — use the meta.db + its patch, same pairing the detour-backtrack
+  // witness used (RESUME_ROOMPATH_DETOUR_BACKTRACK.md §1). LTU/JKR/HHS/TermRooms are unsplit
+  // extracted.db with spatial_structure already present.
+  ['Hospital_meta.db', 'Hospital_meta.db.sql'],
+  ['Clinic_meta.db', null],
+  ['Terminal_meta.db', 'Terminal_meta.db.sql'],
+  ['LTU_AHouse_extracted.db', null],
+  ['JKR_extracted.db', 'JKR_extracted.db.sql'],
+  ['HHS_Office_Federated_extracted.db', 'HHS_Office_Federated_extracted.db.sql'],
+  ['TermRooms_extracted.db', null],
+  // Duplex: no meta.db split present locally, extracted.db lacks spatial_structure — skipped
+  // honestly rather than faked; not evidence of zero isolated components for this building.
+];
+
+function unionFind(n) {
+  const parent = Array.from({ length: n }, (_, i) => i);
+  function find(x) { while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; }
+  function union(a, b) { a = find(a); b = find(b); if (a !== b) parent[a] = b; }
+  return { find, union };
+}
+
+let grandTotalIsolatedComponents = 0, grandTotalIsolatedRooms = 0;
+
+for (const [dbFile, patchFile] of FLEET) {
+  const src = path.join(BLD, dbFile);
+  if (!fs.existsSync(src)) { console.log('§SKIP ' + dbFile + ' (not present locally)'); continue; }
+  const tmp = '/tmp/_poc_sbc_' + Math.random().toString(36).slice(2) + '.db';
+  fs.copyFileSync(src, tmp);
+  const db = new Database(tmp);
+  if (patchFile) {
+    const p = path.join(PATCH, patchFile);
+    if (fs.existsSync(p)) db.exec(fs.readFileSync(p, 'utf8'));
+  }
+  const dbQuery = (q) => db.prepare(q).raw(true).all();
+  const logs = [];
+  const g = RG.buildGraph(dbQuery, { log: (m) => logs.push(m) });
+
+  const rooms = g.nodes.filter(n => n.kind === 'room');
+  const guidToIdx = {}; rooms.forEach((r, i) => guidToIdx[r.guid] = i);
+  const uf = unionFind(rooms.length);
+
+  const touchesSpine = {}; // room guid -> true if it has an E2/E6/E7 edge
+  g.edges.forEach(e => {
+    if (e.kind === 'E1' && guidToIdx[e.a] !== undefined && guidToIdx[e.b] !== undefined) {
+      uf.union(guidToIdx[e.a], guidToIdx[e.b]);
+    }
+    if (e.kind === 'E2' || e.kind === 'E6' || e.kind === 'E7') {
+      if (guidToIdx[e.a] !== undefined) touchesSpine[e.a] = true;
+      if (guidToIdx[e.b] !== undefined) touchesSpine[e.b] = true;
+    }
+  });
+
+  const compMembers = {};
+  rooms.forEach((r, i) => { const root = uf.find(i); (compMembers[root] = compMembers[root] || []).push(r); });
+
+  let isolatedComponents = 0, isolatedRooms = 0;
+  const detail = [];
+  Object.values(compMembers).forEach(members => {
+    if (members.length < 2) return; // size-1 orphans are already handled by today's per-node bridge attempt
+    const anyTouches = members.some(m => touchesSpine[m.guid]);
+    if (!anyTouches) {
+      isolatedComponents++;
+      isolatedRooms += members.length;
+      detail.push('storey=' + members[0].storey + ' size=' + members.length + ' rooms=' + members.map(m => m.name).join(',') + ' guids=' + members.map(m => m.guid).join(','));
+    }
+  });
+
+  console.log('§POC_SBC ' + dbFile + ' rooms=' + rooms.length + ' isolatedComponents(size>=2, zero spine touch)=' + isolatedComponents + ' isolatedRooms=' + isolatedRooms);
+  detail.forEach(d => console.log('  ' + d));
+
+  grandTotalIsolatedComponents += isolatedComponents;
+  grandTotalIsolatedRooms += isolatedRooms;
+  fs.unlinkSync(tmp);
+}
+
+console.log('§POC_SBC_TOTAL isolatedComponents=' + grandTotalIsolatedComponents + ' isolatedRooms=' + grandTotalIsolatedRooms);

--- a/witness_spine_bridge_cluster_regression.js
+++ b/witness_spine_bridge_cluster_regression.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — real acceptance test for OCCUPANT_PATHFINDER.md §SPINE-BRIDGE-CLUSTER
+ * Classifies every room-pair diff between origin/main and this branch's room_graph.js into:
+ *   SAME          - both null, or both found and byte-identical (stops/doors/distance)
+ *   NEWLY_FOUND   - was null, now found (expected result of this fix)
+ *   LOST          - was found, now null (real regression — must be zero)
+ *   CHANGED       - both found but stops/doors/distance differ (real regression — must be zero)
+ * RUN: node witness_spine_bridge_cluster_regression.js   (run from the repo root; needs
+ * buildings/*.db present, and better-sqlite3 available — see ../bim-compiler/node_modules)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'better-sqlite3'));
+const { execSync } = require('child_process');
+
+const RG = require(path.join(__dirname, 'common', 'room_graph.js'));
+const BEFORE_SRC = execSync('git show origin/main:common/room_graph.js', { cwd: __dirname }).toString();
+const beforePath = path.join(__dirname, 'common', '_room_graph_before_' + process.pid + '.js');
+fs.writeFileSync(beforePath, BEFORE_SRC);
+const RGbefore = require(beforePath);
+process.on('exit', () => { try { fs.unlinkSync(beforePath); } catch (e) {} });
+
+const BLD = path.join(__dirname, 'buildings');
+const PATCH = path.join(BLD, 'patches');
+const FLEET = [
+  ['Hospital_meta.db', 'Hospital_meta.db.sql'],
+  ['Clinic_meta.db', null],
+  ['Terminal_meta.db', 'Terminal_meta.db.sql'],
+  ['LTU_AHouse_extracted.db', null],
+  ['JKR_extracted.db', 'JKR_extracted.db.sql'],
+  ['HHS_Office_Federated_extracted.db', 'HHS_Office_Federated_extracted.db.sql'],
+  ['TermRooms_extracted.db', null],
+];
+
+function load(dbFile) {
+  const tmp = '/tmp/_sbc_reg_' + Math.random().toString(36).slice(2) + '.db';
+  fs.copyFileSync(path.join(BLD, dbFile), tmp);
+  return { db: new Database(tmp), tmp };
+}
+function stops(r, gg) {
+  return JSON.stringify(r.path.filter(x => { const k = (gg.nodesByGuid[x] || {}).kind; return k === 'room' || k === 'exit'; }));
+}
+
+let grandSame = 0, grandNew = 0, grandLost = 0, grandChanged = 0;
+for (const [dbFile, patchFile] of FLEET) {
+  if (!fs.existsSync(path.join(BLD, dbFile))) { console.log('§SKIP ' + dbFile); continue; }
+  const { db, tmp } = load(dbFile);
+  if (patchFile) {
+    const p = path.join(PATCH, patchFile);
+    if (fs.existsSync(p)) db.exec(fs.readFileSync(p, 'utf8'));
+  }
+  const dbQuery = (q) => db.prepare(q).raw(true).all();
+  const gAfter = RG.buildGraph(dbQuery, { log: () => {} });
+  const gBefore = RGbefore.buildGraph(dbQuery, { log: () => {} });
+  const rooms = gAfter.nodes.filter(n => n.kind === 'room');
+
+  let same = 0, neu = 0, lost = 0, changed = 0;
+  const changedDetail = [], lostDetail = [], newDetail = [];
+  const realLog = console.log; console.log = () => {}; // room_graph.js's own _log() writes to
+  // console.log unconditionally (not gated by buildGraph's opts.log) — silence it for the O(n^2)
+  // shortestPath sweep, restored right after.
+  for (let i = 0; i < rooms.length; i++) for (let j = i + 1; j < rooms.length; j++) {
+    const rN = RG.shortestPath(gAfter, rooms[i].guid, rooms[j].guid);
+    const rO = RGbefore.shortestPath(gBefore, rooms[i].guid, rooms[j].guid);
+    if (rN === null && rO === null) { same++; continue; }
+    if (rN === null && rO !== null) { lost++; if (lostDetail.length < 5) lostDetail.push(rooms[i].guid + '>' + rooms[j].guid); continue; }
+    if (rN !== null && rO === null) { neu++; if (newDetail.length < 5) newDetail.push(rooms[i].guid + '>' + rooms[j].guid); continue; }
+    const ident = stops(rN, gAfter) === stops(rO, gBefore) &&
+      JSON.stringify(rN.doors) === JSON.stringify(rO.doors) &&
+      Math.abs(rN.distance - rO.distance) < 1e-6;
+    if (ident) same++; else { changed++; if (changedDetail.length < 5) changedDetail.push(rooms[i].guid + '>' + rooms[j].guid + ' dN=' + rN.distance.toFixed(1) + ' dO=' + rO.distance.toFixed(1)); }
+  }
+  console.log = realLog;
+  console.log('§SBC_REGRESSION ' + dbFile + ' rooms=' + rooms.length + ' same=' + same + ' newlyFound=' + neu + ' lost=' + lost + ' changed=' + changed);
+  if (newDetail.length) console.log('  newlyFound sample: ' + newDetail.join(' | '));
+  if (lostDetail.length) console.log('  ❌ LOST sample: ' + lostDetail.join(' | '));
+  if (changedDetail.length) console.log('  ❌ CHANGED sample: ' + changedDetail.join(' | '));
+  grandSame += same; grandNew += neu; grandLost += lost; grandChanged += changed;
+  db.close(); fs.unlinkSync(tmp);
+}
+console.log('§SBC_REGRESSION_TOTAL same=' + grandSame + ' newlyFound=' + grandNew + ' lost=' + grandLost + ' changed=' + grandChanged);
+console.log(grandLost === 0 && grandChanged === 0 ? '✅ PASS — zero lost, zero changed (only new connectivity added)' : '❌ FAIL — real regression present');


### PR DESCRIPTION
## Summary
- `§ROOM-SPINE-BRIDGE` only attempted a bridge for zero-degree rooms — a room with a door to exactly one sibling and nothing else was treated as "already connected" and skipped, even when the whole pair has no route to the corridor.
- Fix: union-find the E1 (room-room door) edges into connected components, bridge by component instead of by single-node degree. Same legality test (`_astarHop`), same nearest-first/first-legal-wins rule, additive only — subsumes the old zero-degree case rather than adding a parallel path.
- Found via `LTU_AHouse` `RM_VÅNING_1_1 -> RM_VÅNING_4_1` returning `NO_PATH` (room-pathing witness session). Root cause traced to the eligibility check, not the detour legalizer.

## Test plan
- [x] POC gate (`poc_spine_bridge_cluster.js`, calculation-only, no engine edit): 7 of 9 fleet buildings checkable locally — **6 isolated door-pair components / 12 rooms, all on `LTU_AHouse`, zero elsewhere** (Hospital/Clinic/Terminal/JKR/HHS/TermRooms). Confirms this is a general graph-topology gap, not LTU-specific data.
- [x] Acceptance test: `LTU_AHouse_meta.db` `RM_VÅNING_1_1 -> RM_VÅNING_4_1` now returns a real path (19 stops, 211.1m, 5 doors), previously `null`. The one pair with no legal route within reach (`RM_VÅNING_4_10/_11`, nearest spine candidate 67.35m) still honestly rejects.
- [x] Fleet regression (`witness_spine_bridge_cluster_regression.js`, classifies same/newlyFound/lost/changed rather than a binary diff): **89,627 existing room pairs across all 7 loadable buildings — 0 lost, 0 changed. 3,500 newly connected, all on LTU_AHouse.**
- [ ] Spec + full results recorded in `bim-compiler` (`prompts/Modeller/DISC_Walker/OCCUPANT_PATHFINDER.md §SPINE-BRIDGE-CLUSTER`), not part of this repo's diff.

Spec-first per project doctrine — full writeup lives in the `bim-compiler` repo (separate repo, this PR is engine-only).