### PR TITLE
feat(4d): §TM_PANEL_RESIZE — Time Machine drawer width is draggable, auto-expands on Editing

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v953';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v954';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_tm_panel_resize.js
+++ b/viewer/tests/witness_tm_panel_resize.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// witness_tm_panel_resize.js — §TM_PANEL_RESIZE (2026-08-05). Proves the new drawer-width resize
+// grip does the right pixel math given `_panel` is horizontally CENTERED (left:50%,
+// translateX(-50%)) — dragging the right edge by dx must grow width by 2*dx for the visible edge to
+// actually track the cursor 1:1, and the result must clamp to [PANEL_W_MIN, min(92vw, 900)]. Slices
+// the real wirePanelResize by balanced braces, never reimplements the drag math.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const varsMatch = tmSrc.match(/var PANEL_W_DEFAULT = \d+, PANEL_W_EDIT = \d+, PANEL_W_MIN = \d+;/);
+if (!varsMatch) throw new Error('PANEL_W_* constants not found');
+const sliced = varsMatch[0] + '\n' + sliceFn(tmSrc, 'wirePanelResize');
+
+function fakeElement(rectWidth) {
+  const handlers = {};
+  return {
+    _wired: false, classList: { add: function () {}, remove: function () {} },
+    addEventListener: function (type, fn) { handlers[type] = fn; },
+    setPointerCapture: function () {}, releasePointerCapture: function () {},
+    getBoundingClientRect: function () { return { width: rectWidth }; },
+    style: {}, _handlers: handlers
+  };
+}
+
+function makeSandbox(startWidth, innerWidth) {
+  const grip = fakeElement(0);
+  const panel = fakeElement(startWidth);
+  let loggedWidth = null;
+  const sandbox = {
+    console: { log: function (msg) { const m = /width=(\d+)px/.exec(msg); if (m) loggedWidth = parseInt(m[1], 10); } },
+    Math: Math, window: { innerWidth: innerWidth },
+    document: { getElementById: function (id) { return id === 'tm-panel-resize-grip' ? grip : null; } },
+    _panel: panel, _panelW: 0
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced, sandbox);
+  sandbox.wirePanelResize();
+  return { sandbox: sandbox, grip: grip, panel: panel, getLoggedWidth: function () { return loggedWidth; } };
+}
+
+function ev(clientX) { return { clientX: clientX, preventDefault: function () {}, stopPropagation: function () {} }; }
+
+// ── Case 1: dragging the right edge by +40px must grow width by 80px (2x, centered-panel math) ──
+{
+  const h = makeSandbox(376, 1600);
+  h.grip._handlers.pointerdown(ev(500));
+  h.grip._handlers.pointermove(ev(540));
+  assert(h.panel.style.width === '456px', '2x symmetric growth: +40px drag -> width 376+80=456px, got ' + h.panel.style.width);
+  h.grip._handlers.pointerup(ev(540));
+  assert(h.getLoggedWidth() === 456, '§TM_PANEL_RESIZE log reports the same final width');
+}
+
+// ── Case 2: dragging left (shrink) clamps at PANEL_W_MIN (320), never goes negative/smaller ──
+{
+  const h = makeSandbox(376, 1600);
+  h.grip._handlers.pointerdown(ev(500));
+  h.grip._handlers.pointermove(ev(0));   // huge leftward drag
+  assert(h.panel.style.width === '320px', 'clamps to PANEL_W_MIN=320px on a huge shrink drag, got ' + h.panel.style.width);
+}
+
+// ── Case 3: on a narrow viewport, the ceiling is 92vw, not the hardcoded 900px ──
+{
+  const h = makeSandbox(376, 500);   // 92% of 500 = 460, well under 900
+  h.grip._handlers.pointerdown(ev(0));
+  h.grip._handlers.pointermove(ev(1000));  // huge rightward drag
+  assert(h.panel.style.width === '460px', 'clamps to 92vw=460px on a narrow viewport (not the 900px ceiling), got ' + h.panel.style.width);
+}
+
+// ── Case 4: no drag in progress — pointermove before pointerdown must not touch the panel ──
+{
+  const h = makeSandbox(376, 1600);
+  h.grip._handlers.pointermove(ev(999));
+  assert(h.panel.style.width === undefined, 'RED CONTROL: pointermove with no active drag never sets width');
+}
+
+console.log('\n§TM_PANEL_RESIZE SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2749,12 +2749,23 @@
         '<div style="font-size:11px;color:#4fc3f7;font-weight:bold;margin:8px 0 4px">S-Curve</div>' +
         '<canvas id="tm-dash-scurve" width="200" height="60" style="width:100%;height:60px"></canvas>' +
         '<div id="tm-dash-daycnt" style="font-size:10px;color:#999;margin-top:2px;text-align:center"></div>' +
-      '</div>';
+      '</div>' +
+      // §TM_PANEL_RESIZE (2026-08-05, user ruling: "panel borders supposed to be draggable so we
+      // can see more"). The whole drawer was hardcoded 376px with a resize handle for the internal
+      // Gantt box's HEIGHT (tm-gantt-grip) but nothing for the drawer's own WIDTH — exactly what the
+      // screenshot showed: the props panel overlapping the storey labels and ruler with nowhere to
+      // grow into. `_panel` is centered via left:50%/translateX(-50%), so a single edge handle grows
+      // the box symmetrically for free — no left-edge math needed.
+      '<div id="tm-panel-resize-grip" title="Drag to resize the drawer" style="position:absolute;' +
+        'top:0;right:-3px;bottom:0;width:8px;cursor:ew-resize;z-index:6"></div>';
     document.body.appendChild(_panel);
+    wirePanelResize();
 
     var style = document.createElement('style');
     style.textContent =
       '#time-machine-panel{transition:width 200ms ease-out}' +
+      '#time-machine-panel.tm-panel-resizing{transition:none}' +
+      '#tm-panel-resize-grip:hover,#tm-panel-resize-grip.tm-gripping{background:rgba(79,195,247,0.35)}' +
       '#time-machine-panel button{background:rgba(255,255,255,0.1);color:#e0e0e0;border:1px solid rgba(79,195,247,0.3);' +
       'border-radius:4px;padding:4px 4px;cursor:pointer;font-size:10px}' +
       '#time-machine-panel button:hover{background:rgba(79,195,247,0.2)}' +
@@ -4838,6 +4849,45 @@
     return R;
   }
 
+  // §TM_PANEL_RESIZE — drag tm-panel-resize-grip to widen the WHOLE drawer past its 376px default.
+  // _panel is centered (left:50%/translateX(-50%)), so dragging the right edge by dx pixels must
+  // grow width by 2*dx for the edge to actually track the cursor 1:1 (the invisible left edge moves
+  // -dx to keep centered) — see wirePanelResize's pointermove for the derivation.
+  var _panelW = 0;            // 0 = follow the stylesheet default (376px); set once the user drags
+  var _panelWPreEdit = null;  // width to restore to when Editing turns back off (auto-expand undo)
+  var PANEL_W_DEFAULT = 376, PANEL_W_EDIT = 560, PANEL_W_MIN = 320;
+
+  function wirePanelResize() {
+    var grip = document.getElementById('tm-panel-resize-grip');
+    if (!grip || !_panel || grip._wired) return;
+    grip._wired = true;
+    var startX = 0, startW = 0, dragging = false;
+    grip.addEventListener('pointerdown', function (e) {
+      dragging = true; startX = e.clientX; startW = _panel.getBoundingClientRect().width;
+      _panel.classList.add('tm-panel-resizing');
+      grip.classList.add('tm-gripping');
+      grip.setPointerCapture(e.pointerId); e.preventDefault(); e.stopPropagation();
+    });
+    grip.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var maxW = Math.min(Math.round(window.innerWidth * 0.92), 900);
+      var w = Math.max(PANEL_W_MIN, Math.min(maxW, Math.round(startW + 2 * (e.clientX - startX))));
+      _panelW = w;
+      _panel.style.width = w + 'px';
+      e.preventDefault(); e.stopPropagation();
+    });
+    function end(e) {
+      if (!dragging) return;
+      dragging = false;
+      _panel.classList.remove('tm-panel-resizing');
+      grip.classList.remove('tm-gripping');
+      try { grip.releasePointerCapture(e.pointerId); } catch (err) {}
+      console.log('§TM_PANEL_RESIZE width=' + _panelW + 'px');
+    }
+    grip.addEventListener('pointerup', end);
+    grip.addEventListener('pointercancel', end);
+  }
+
   // §GANTT_RESIZE (E6) — drag the grip to make the drawer taller than the CSS 220px cap. Inline
   // max-height wins over the .tm-drawer-bottom.open rule, so the class keeps owning open/close and
   // this only owns the height. Reuses the same pointer-capture idiom as makeDraggable.
@@ -5389,6 +5439,20 @@
             ? 'Editing: drag to move/resize, drag onto another bar to link, double-click for typed edit. Click to lock.'
             : 'Locked: drag/resize/link disabled, timeline still scrubs live. Click to unlock editing.';
           console.log('§GANTT_EDIT_LOCK editable=' + _ganttEditable);
+          // §TM_PANEL_RESIZE auto-expand (user ruling 2026-08-05): editing needs elbow room (the
+          // props panel alone is ~330px wide) — widen automatically rather than making the user find
+          // the new resize grip every time. Only expands if narrower than the edit width already (a
+          // user who manually widened past it keeps their own choice); restores to whatever width was
+          // active the moment editing turned on, so a manual resize DURING editing is not fought.
+          if (_panel) {
+            var curW = _panel.getBoundingClientRect().width;
+            if (_ganttEditable) {
+              _panelWPreEdit = curW;
+              if (curW < PANEL_W_EDIT) { _panelW = PANEL_W_EDIT; _panel.style.width = PANEL_W_EDIT + 'px'; }
+            } else if (_panelWPreEdit != null) {
+              _panelW = _panelWPreEdit; _panel.style.width = _panelWPreEdit + 'px'; _panelWPreEdit = null;
+            }
+          }
         });
       }
       var lockMsg = document.getElementById('tm-gantt-lockmsg');


### PR DESCRIPTION
## Summary
- The drawer had a resize grip for the internal Gantt box's HEIGHT only; the drawer's own WIDTH
  was hardcoded at 376px. A live screenshot showed the cost: the typed-props panel overlapping
  the storey labels and day ruler with nowhere to grow.
- New `tm-panel-resize-grip` on the drawer's right edge. The panel is horizontally centered, so
  one edge handle grows the box symmetrically (2x drag-distance math, derived and tested).
  Clamped to `[320px, min(92vw, 900px)]`.
- Auto-expands to 560px the instant the Editing lock toggles on (only if narrower already),
  restores the exact pre-edit width on lock — elbow room without hunting for the grip.

## Test plan
- [x] `node --check`
- [x] `witness_tm_panel_resize.js` (new) 5/5 — 2x centered-drag math, both clamps, RED CONTROL
- [x] Regression: `witness_gantt_edit_lock` 5/5, `witness_gantt_native_generate` 5/5,
      `witness_gantt_bar_identity` 6/6

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01UCZQfqMncP9QapmvjQZbD8