### PR TITLE
feat(4d): §TM_RULER_SHIFT — day ruler drag shifts whole project start/finish, native generate defaults to today

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -990,6 +990,33 @@
     return { ok: true, start: newStart, finish: finish, days: days };
   }
 
+  // §TM_RULER_SHIFT (2026-08-05, user ruling: dragging the Gantt drawer's day ruler adjusts the
+  // whole project's start/finish, "updated of course along with any other edit"). Translate EVERY
+  // task in the schedule — leaf AND summary alike — by a constant number of days. Deliberately no
+  // constraint checking, unlike moveTaskCascade/resizeTask: a uniform shift preserves every
+  // task_sequences edge and every task's relative position to every other task by construction, so
+  // there is nothing for C1/C2 to clamp or cascade. duration is untouched (start and finish move by
+  // the identical amount).
+  function shiftSchedule(db, scheduleId, deltaDays) {
+    var r = db.exec('SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id=?', [scheduleId]);
+    if (!r.length || !r[0].values.length) {
+      console.log('§SE_SHIFT_FAIL schedule=' + scheduleId + ' reason=no_tasks');
+      return { ok: false, reason: 'no_tasks' };
+    }
+    var upd = db.prepare('UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE task_id=?');
+    var moved = [];
+    db.run('BEGIN');
+    r[0].values.forEach(function (row) {
+      var taskId = row[0], newStart = _addDays(row[1], deltaDays), newFinish = _addDays(row[2], deltaDays);
+      upd.run([newStart, newFinish, taskId]);
+      moved.push({ id: taskId, start: newStart, finish: newFinish });
+    });
+    upd.free();
+    db.run('COMMIT');
+    console.log('§SE_SHIFT schedule=' + scheduleId + ' deltaDays=' + deltaDays + ' tasks=' + moved.length);
+    return { ok: true, moved: moved, deltaDays: deltaDays };
+  }
+
   // ── §GANTT_EDIT C1/C2 — constraint-aware move (prompts/4D_SCHEDULE_PERFECTION.md §GANTT_EDIT) ──
   // moveTask() above deliberately writes dates and nothing else ("CPM invalidation is the caller's
   // concern"). That is the right primitive but the WRONG thing to put under a user's finger: a drag
@@ -1495,6 +1522,7 @@
     computeCpm: computeCpm,
     moveTask: moveTask,
     moveTaskCascade: moveTaskCascade,   // §GANTT_EDIT C1/C2 — the constraint-aware move
+    shiftSchedule: shiftSchedule,       // §TM_RULER_SHIFT — uniform whole-project date shift
     resizeTask: resizeTask,             // §GANTT_EDIT E2 — edge-pull, duration changes
     setBaseline: setBaseline,           // ⚑ Set Baseline — schedule variance snapshot, single baseline
     getBaselineVariance: getBaselineVariance,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v954';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v955';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_ruler_shift_lock.js
+++ b/viewer/tests/witness_gantt_ruler_shift_lock.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// witness_gantt_ruler_shift_lock.js — §TM_RULER_SHIFT UI gate (2026-08-05). Proves the ruler-drag
+// entry point respects the SAME edit lock as bar drag/resize/link (this is the biggest possible
+// edit, not a reason to exempt it), and that the pixel-to-days conversion matches the qualified
+// axis math used everywhere else in the drawer. Slices the real wireGanttRulerShift by balanced
+// braces, never reimplements the gate or the day math.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const sliced = sliceFn(tmSrc, 'wireGanttRulerShift');
+
+function fakeElement(clientWidth) {
+  const handlers = {};
+  return {
+    _shiftWired: false,
+    addEventListener: function (type, fn) { handlers[type] = fn; },
+    setPointerCapture: function () {}, releasePointerCapture: function () {},
+    clientWidth: clientWidth, style: {}, _handlers: handlers
+  };
+}
+function ev(clientX) { return { clientX: clientX, preventDefault: function () {}, stopPropagation: function () {} }; }
+
+function makeSandbox(editable) {
+  const ruler = fakeElement(660);   // 660 - 60 gutter = 600px bar width
+  const tip = fakeElement(0);
+  let shiftCalls = [];
+  const sandbox = {
+    console: console, Math: Math, setTimeout: setTimeout,
+    document: { getElementById: function (id) { return id === 'tm-gantt-ruler' ? ruler : (id === 'tm-gantt-tip' ? tip : null); } },
+    _ganttEditable: editable,
+    _ganttAxisStart: 0, _ganttAxisEnd: 30 * 86400000,   // 30-day project -> 20px/day over a 600px bar area
+    shiftGanttSchedule: function (d) { shiftCalls.push(d); }
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced, sandbox);
+  sandbox.wireGanttRulerShift();
+  return { sandbox: sandbox, ruler: ruler, getShiftCalls: function () { return shiftCalls; } };
+}
+
+// ── Case 1: locked — a full drag gesture must never reach shiftGanttSchedule ──
+{
+  const h = makeSandbox(false);
+  h.ruler._handlers.pointerdown(ev(100));
+  h.ruler._handlers.pointermove(ev(300));   // would-be a large rightward drag
+  h.ruler._handlers.pointerup(ev(300));
+  assert(h.getShiftCalls().length === 0, 'locked: a full ruler drag gesture never calls shiftGanttSchedule');
+}
+
+// ── Case 2: unlocked — a real drag calls shiftGanttSchedule with the correct day delta ──
+{
+  const h = makeSandbox(true);
+  h.ruler._handlers.pointerdown(ev(100));
+  h.ruler._handlers.pointermove(ev(140));   // +40px at 20px/day (600px bar / 30 days) = +2 days
+  h.ruler._handlers.pointerup(ev(140));
+  const calls = h.getShiftCalls();
+  assert(calls.length === 1 && calls[0] === 2, 'unlocked: +40px drag on a 30-day/600px axis calls shiftGanttSchedule(2) — got ' + JSON.stringify(calls));
+}
+
+// ── Case 3: unlocked but no actual movement (a click) — must NOT call shiftGanttSchedule ──
+{
+  const h = makeSandbox(true);
+  h.ruler._handlers.pointerdown(ev(100));
+  h.ruler._handlers.pointerup(ev(100));
+  assert(h.getShiftCalls().length === 0, 'unlocked click (zero delta) never calls shiftGanttSchedule — a click is not a drag');
+}
+
+// ── RED CONTROL: unlocked + a real drag with pointerdown skipped must not call shift either
+// (pointermove alone, no drag in progress) — proves the gate isn't just "editable=true always calls" ──
+{
+  const h = makeSandbox(true);
+  h.ruler._handlers.pointermove(ev(999));
+  h.ruler._handlers.pointerup(ev(999));
+  assert(h.getShiftCalls().length === 0, 'RED CONTROL: pointermove/up with no pointerdown never calls shiftGanttSchedule');
+}
+
+console.log('\n§GANTT_RULER_SHIFT_LOCK SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_shift_schedule.js
+++ b/viewer/tests/witness_shift_schedule.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// witness_shift_schedule.js — §TM_RULER_SHIFT engine verb (2026-08-05). Proves ScheduleAuthor.
+// shiftSchedule translates EVERY task (leaf and summary alike) by a constant number of days while
+// preserving every task's relative position to every other task exactly — the property that makes
+// C1/C2 constraint checking unnecessary for this verb (a uniform shift can never create or resolve
+// a task_sequences violation). Real fixture, real materialized schedule, not synthetic rows.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function day(s) { return Math.round(Date.parse(s + 'T00:00:00Z') / 86400000); }
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  const dbPath = path.join(require('os').homedir(), 'bim-ootb', 'buildings', 'Duplex_extracted.db');
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const opts = { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate };
+  const mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES, opts);
+  if (!mres.ok) { console.log('§SHIFT_SKIP materializeZones failed: ' + JSON.stringify(mres)); return; }
+  const schedId = mres.scheduleId;
+
+  function readAll() {
+    const r = db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration, is_summary FROM tasks WHERE schedule_id=?', [schedId]);
+    const out = {};
+    r[0].values.forEach(function (row) { out[row[0]] = { start: row[1], finish: row[2], duration: row[3], isSummary: row[4] }; });
+    return out;
+  }
+
+  const before = readAll();
+  const taskIds = Object.keys(before);
+  assert(taskIds.length > 1, 'RED-CONTROL: the real schedule has more than one task, or a uniform-shift claim is untestable');
+  const summaryCount = taskIds.filter(function (id) { return before[id].isSummary; }).length;
+  assert(summaryCount > 0, 'RED-CONTROL: at least one summary/root row exists, so "leaf AND summary alike" is actually exercised');
+
+  const DELTA = 17;
+  const res = ScheduleAuthor.shiftSchedule(db, schedId, DELTA);
+  assert(res.ok, 'shiftSchedule succeeds on a real materialized schedule');
+  assert(res.moved.length === taskIds.length, 'moved count equals every task in the schedule — moved=' + res.moved.length + ' total=' + taskIds.length);
+
+  const after = readAll();
+  let allShiftedByDelta = true, allDurationsUnchanged = true, allRelativeOffsetsPreserved = true;
+  taskIds.forEach(function (id) {
+    const b = before[id], a = after[id];
+    if (day(a.start) - day(b.start) !== DELTA) allShiftedByDelta = false;
+    if (day(a.finish) - day(b.finish) !== DELTA) allShiftedByDelta = false;
+    if (a.duration !== b.duration) allDurationsUnchanged = false;
+  });
+  assert(allShiftedByDelta, 'every task (leaf + summary) start AND finish moved by exactly +' + DELTA + 'd, none skipped');
+  assert(allDurationsUnchanged, 'duration is untouched on every task — start and finish moved by the identical amount');
+
+  // RELATIVE spacing between any two tasks must be byte-identical before/after — this is the
+  // property that makes the verb safe with zero C1/C2 constraint checking.
+  const pairSample = taskIds.slice(0, Math.min(20, taskIds.length));
+  for (let i = 0; i < pairSample.length && allRelativeOffsetsPreserved; i++) {
+    for (let j = i + 1; j < pairSample.length; j++) {
+      const beforeGap = day(before[pairSample[j]].start) - day(before[pairSample[i]].start);
+      const afterGap = day(after[pairSample[j]].start) - day(after[pairSample[i]].start);
+      if (beforeGap !== afterGap) { allRelativeOffsetsPreserved = false; break; }
+    }
+  }
+  assert(allRelativeOffsetsPreserved, 'every pair of tasks keeps its exact relative start-date gap (uniform translation, no relative drift)');
+
+  // RED CONTROL: a zero-delta shift must still succeed and be a true no-op (not silently skipped).
+  const noop = ScheduleAuthor.shiftSchedule(db, schedId, 0);
+  const afterNoop = readAll();
+  const noopIdentical = taskIds.every(function (id) { return afterNoop[id].start === after[id].start && afterNoop[id].finish === after[id].finish; });
+  assert(noop.ok && noopIdentical, 'RED CONTROL: a deltaDays=0 shift succeeds and changes nothing (true no-op, not a silent skip)');
+
+  db.close();
+  console.log('\n§SHIFT_SCHEDULE SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2724,7 +2724,8 @@
             '<button id="tm-gantt-editlock" style="font-size:10px;padding:1px 6px" ' +
             'title="Locked: drag/resize/link disabled, timeline still scrubs live. Click to unlock editing.">' +
             '&#x1F512; Locked</button><span id="tm-gantt-lockmsg" style="flex:1"></span></div>' +
-          '<canvas id="tm-gantt-ruler" style="width:100%;height:18px;display:block"></canvas>' +
+          '<canvas id="tm-gantt-ruler" style="width:100%;height:18px;display:block;cursor:ew-resize" ' +
+            'title="Drag to shift the whole project\'s start/finish (Editing must be unlocked)"></canvas>' +
         '</div>' +
         '<div style="position:relative">' +
           '<canvas id="tm-gantt-canvas" style="width:100%;cursor:pointer"></canvas>' +
@@ -4888,6 +4889,55 @@
     grip.addEventListener('pointercancel', end);
   }
 
+  // §TM_RULER_SHIFT UI — drag the day ruler to move the whole project's start/finish (user ruling
+  // 2026-08-05). Same lock gate as bar drag/resize/link (this is the biggest possible edit, not a
+  // reason to exempt it from the lock). Uses the SAME axis math as ganttHit's dayPx so a drag of N
+  // pixels always means the same N days everywhere in the drawer, ruler included.
+  function wireGanttRulerShift() {
+    var rc = document.getElementById('tm-gantt-ruler');
+    if (!rc || rc._shiftWired) return;
+    rc._shiftWired = true;
+    var startX = 0, dragDays = 0, dragging = false;
+    rc.addEventListener('pointerdown', function (e) {
+      if (!_ganttEditable) {
+        console.log('§TM_RULER_SHIFT_REJECT reason=locked');
+        var t0 = document.getElementById('tm-gantt-tip');
+        if (t0) {
+          t0.textContent = 'Locked — click 🔒 Locked to enable editing';
+          t0.style.display = 'block';
+          setTimeout(function () { t0.style.display = 'none'; }, 2200);
+        }
+        return;
+      }
+      dragging = true; startX = e.clientX; dragDays = 0;
+      try { rc.setPointerCapture(e.pointerId); } catch (err) {}
+      e.preventDefault(); e.stopPropagation();
+    });
+    rc.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var range = Math.max(1, _ganttAxisEnd - _ganttAxisStart);
+      var barW = Math.max(1, rc.clientWidth - 60);   // 60 = the storey-label gutter, same as ganttHit/drawGanttMini
+      var dayPx = barW / (range / 86400000);
+      dragDays = Math.round((e.clientX - startX) / Math.max(0.001, dayPx));
+      var tip = document.getElementById('tm-gantt-tip');
+      if (tip) {
+        tip.textContent = 'Shift whole schedule ' + (dragDays >= 0 ? '+' : '') + dragDays + 'd';
+        tip.style.left = '4px'; tip.style.top = '20px'; tip.style.display = 'block';
+      }
+      e.preventDefault(); e.stopPropagation();
+    });
+    function end(e) {
+      if (!dragging) return;
+      dragging = false;
+      try { rc.releasePointerCapture(e.pointerId); } catch (err) {}
+      var tip = document.getElementById('tm-gantt-tip');
+      if (tip) tip.style.display = 'none';
+      if (dragDays) shiftGanttSchedule(dragDays);
+    }
+    rc.addEventListener('pointerup', end);
+    rc.addEventListener('pointercancel', end);
+  }
+
   // §GANTT_RESIZE (E6) — drag the grip to make the drawer taller than the CSS 220px cap. Inline
   // max-height wins over the .tm-drawer-bottom.open rule, so the class keeps owning open/close and
   // this only owns the height. Reuses the same pointer-capture idiom as makeDraggable.
@@ -5098,6 +5148,59 @@
     renderAtTime(_cursor);
   }
 
+  // §TM_RULER_SHIFT — drag the day ruler to move the WHOLE project's start/finish. Same shape as
+  // commitGanttDrag (snapshot every leaf task's before-state + every touched guid's before-state
+  // into the SAME _lastEdit single-level undo, call the real engine verb, retimeTaskElements to
+  // resync playback), just against SA.shiftSchedule instead of moveTaskCascade/resizeTask and
+  // against EVERY task instead of one cascade. mode:'shift' in _lastEdit is cosmetic (log/tip text
+  // only) — undoLastGanttEdit's restore loop doesn't branch on it, so no other change was needed
+  // there at all.
+  function shiftGanttSchedule(deltaDays) {
+    var app = A();
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    if (!app || !app.db || !SA || !SA.shiftSchedule) {
+      console.log('§TM_RULER_SHIFT_REJECT reason=ScheduleAuthor_not_loaded');
+      return;
+    }
+    if (!deltaDays) return;   // a click, not a drag — nothing to shift
+    var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
+
+    var tasksBefore = {};
+    try {
+      var tb = app.db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id=?', [schedId]);
+      if (tb.length) tb[0].values.forEach(function (row) {
+        tasksBefore[row[0]] = { start: row[1], finish: row[2], duration: row[3] };
+      });
+    } catch (e) {}
+
+    var res = SA.shiftSchedule(app.db, schedId, deltaDays);
+    if (!res || !res.ok) {
+      console.log('§TM_RULER_SHIFT_REJECT reason=' + ((res && res.reason) || 'unknown'));
+      return;
+    }
+
+    var barsByTask = {};
+    for (var i = 0; i < _ganttTasks.length; i++) if (_ganttTasks[i].taskId) barsByTask[_ganttTasks[i].taskId] = _ganttTasks[i];
+    var opsBefore = {};
+    var _opByGuidForUndo = {};
+    for (var oi2 = 0; oi2 < _ops.length; oi2++) if (_ops[oi2].output_guid) _opByGuidForUndo[_ops[oi2].output_guid] = _ops[oi2];
+    res.moved.forEach(function (m) {
+      var bar2 = barsByTask[m.id]; if (!bar2 || !bar2.guids) return;
+      bar2.guids.forEach(function (g) {
+        var op = _opByGuidForUndo[g];
+        if (op) opsBefore[g] = { start_ts: op.start_ts, end_ts: op.end_ts, parameters: JSON.stringify(op.parameters) };
+      });
+    });
+
+    retimeTaskElements(app.db, barsByTask, res.moved);
+    _lastEdit = { schedId: schedId, taskId: '(whole schedule)', mode: 'shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
+    console.log('§TM_RULER_SHIFT_COMMIT schedule=' + schedId + ' deltaDays=' + deltaDays + ' tasks=' + res.moved.length);
+    invalidateGanttModel();
+    computeDays();
+    drawGanttMini();
+    renderAtTime(_cursor);
+  }
+
   // §GANTT_EDIT_UNDO — reverse the single most recent commitGanttDrag edit. Restores both halves
   // that edit changed: the task dates (moveTaskCascade/resizeTask's write to `tasks`) and the
   // element ops (retimeTaskElements's write to `kernel_ops`) — same two tables, same shape, run
@@ -5205,11 +5308,16 @@
       console.log('§GANTT_AUTHOR_ENTRY captured=' + act.id + ' — leaving it as imported, not regenerating');
       return;
     }
+    // §TM_RULER_SHIFT (2026-08-05, user ruling): "defaulted to today if the JSON is silent" — the
+    // native auto-generate path has no imported schedule to take a start date from, so it starts
+    // TODAY (real wall-clock date), not a hardcoded placeholder. Once materialized the user can drag
+    // the ruler to shift the whole project to a different start, same as any other edit.
+    var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
-    var res = SA.materializeZones(app.db, SR, { start: '2026-01-01', laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
-      res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: '2026-01-01', laborRates: LR, blank: false }) : { ok: false };
+      res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false }) : { ok: false };
     }
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=' + (res.reason || 'materialize_failed'));
@@ -5421,6 +5529,7 @@
     buildGanttTasks();
     if (!_ganttTasks.length) return;
     wireGanttResize();
+    wireGanttRulerShift();
     // §GANTT_EDIT_LOCK: wire the lock toggle once, and auto-materialize a schedule the first time
     // this drawer has nothing editable to show (replaces the old §GANTT_AUTHOR_ENTRY button — no
     // click required, no side panel involved). One attempt per activate() (_ganttAutoGenAttempted),


### PR DESCRIPTION
## Summary
Orphaned by #1201's squash-merge race (same pattern as #1198/#1199 earlier today) — verified via
`git merge-base --is-ancestor` before opening this, recovered by cherry-pick onto a fresh branch
off current `origin/main`, all witnesses re-run against the real merged state.

- **`ScheduleAuthor.shiftSchedule(db, scheduleId, deltaDays)`** — translates every task (leaf and
  summary alike) by a constant number of days. No C1/C2 constraint checking needed: a uniform
  shift preserves every relative task position by construction.
- **Day ruler is now draggable** — previously non-interactive UI, wired to shift the whole project
  via the same qualified-axis pixel-to-days math the bars already use. Gated behind the same
  Editing lock as bar drag/resize/link. Reuses the existing single-level Undo unchanged (its
  restore loop is already generic over any tasksBefore/opsBefore set).
- **`generateGanttSchedule()` now defaults to today**, not a hardcoded `2026-01-01`.

## Test plan
- [x] `node --check` on all touched files
- [x] `witness_shift_schedule.js` (new) 8/8 — real fixture, uniform shift, relative-gap
      preservation, RED CONTROLs
- [x] `witness_gantt_ruler_shift_lock.js` (new) 4/4 — locked/unlocked gate, correct day-delta math,
      click-is-not-a-drag, RED CONTROL
- [x] Regression: `witness_gantt_edit_lock` 5/5, `witness_tm_panel_resize` 5/5 (confirms #1201
      carried forward correctly), `witness_gantt_bar_identity` 6/6

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01UCZQfqMncP9QapmvjQZbD8