### PR TITLE
fix(cpe): POV alignment diagnostic — code-correlated, not screenshot-based

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1399,6 +1399,10 @@
     var save = function() {
       var r = d.getBoundingClientRect();
       _vfRect = { left: Math.round(r.left), top: Math.round(r.top), width: Math.round(r.width), height: Math.round(r.height) };
+      // §CPE_VF_ALIGN_DIAG_V2: re-arm the one-shot diagnostic so the NEXT _vfRender() frame logs
+      // fresh numbers for this new drag/resize pose — a misalignment report is more likely to
+      // follow a reposition than the untouched default.
+      if (_state) _state._vfDiagLogged = false;
     };
     d.addEventListener('pointerup', save);
     // Corner resize — new (spec point 5: "Resize does NOT exist on any panel yet — net-new, small: a
@@ -1447,9 +1451,33 @@
     // depends on PLUS the renderer's actual backing-buffer size (ground truth — canvasR.width*pr
     // is an ASSUMPTION this log can disprove) and the panel's own box-sizing/border, so the next
     // repro gives real numbers instead of a screenshot guess. See CLAUDE.md FUNDAMENTAL LAW.
+    // §CPE_VF_ALIGN_DIAG_V2 (2026-08-05) — the v1 numbers above (still logged) already proved the
+    // scissor rect ITSELF is correctly placed within the real backing buffer (renderer.domElement,
+    // ground truth — not derived), canvas===renderer.domElement (no aliasing), no CSS transform on
+    // the canvas, box-sizing:border-box confirmed. That rules out hypothesis (b) — the BOX is not
+    // misplaced. What's left is hypothesis (a): the CONTENT inside a correctly-placed box is framed
+    // off-center, i.e. vfCam's own orientation state has drifted from what plan.poseAt(tn) intends
+    // or from the main camera's — not a coordinate bug in this function at all. Compares vfCam
+    // against a FRESH poseAt sample and against the main camera at the SAME instant.
+    // Re-armed on every drag/resize `save()` (search _vfDiagLogged in _buildVFPanel), not just
+    // toggle-on — a misalignment report is more likely to follow a user reposition than the
+    // untouched default pose, and the v1-only one-shot could have logged an entirely different
+    // instant than the one in the reported screenshot.
+    if (w < 2 || h < 2) return;   // panel dragged fully off-canvas — nothing to draw
+    _state.vfCam.aspect = w / h;
+    _state.vfCam.updateProjectionMatrix();
+    // §CPE_VF_ALIGN_DIAG / _V2 diagnostics moved to AFTER the aspect fix-up above (a real bug in
+    // the diagnostic itself, caught by re-running it: logging vfCam.aspect BEFORE this line reads
+    // the STALE value from _vfEnsureCam()'s creation-time aspect=1, not what this frame actually
+    // renders with — e.g. one live capture showed vfCam_aspect=1.0000 vs box_aspect=1.5789 purely
+    // from that ordering, not a real per-frame distortion). Logging here reports the exact values
+    // used for THIS frame's renderer.render() call below, not a pre-fixup snapshot.
     if (!_state._vfDiagLogged) {
       _state._vfDiagLogged = true;
       var cs = window.getComputedStyle(panel);
+      var mc = a.camera;
+      var freshP = (_state.plan && typeof _state.plan.poseAt === 'function' && _state.scrubTn != null)
+        ? _state.plan.poseAt(_state.scrubTn) : null;
       console.log('§CPE_VF_ALIGN_DIAG panelR=' + JSON.stringify({left:panelR.left,top:panelR.top,width:panelR.width,height:panelR.height}) +
         ' canvasR=' + JSON.stringify({left:canvasR.left,top:canvasR.top,width:canvasR.width,height:canvasR.height}) +
         ' pr=' + pr + ' computed_x=' + x + ' computed_y=' + y + ' computed_w=' + w + ' computed_h=' + h +
@@ -1457,10 +1485,14 @@
         ' rendererGetSize=' + JSON.stringify((function(){var s=new THREE.Vector2();a.renderer.getSize(s);return {w:s.x,h:s.y};})()) +
         ' boxSizing=' + cs.boxSizing + ' borderWidth=' + cs.borderLeftWidth + '/' + cs.borderTopWidth +
         ' xPlusW=' + (x+w) + ' backingBufferW=' + a.renderer.domElement.width + ' overflowRight=' + ((x+w) - a.renderer.domElement.width));
+      console.log('§CPE_VF_ALIGN_DIAG_V2 vfCam_fov=' + _state.vfCam.fov + ' main_fov=' + mc.fov +
+        ' vfCam_aspect=' + _state.vfCam.aspect.toFixed(4) + ' box_aspect=' + (w / h).toFixed(4) +
+        ' vfCam_up=' + JSON.stringify({x:+_state.vfCam.up.x.toFixed(4), y:+_state.vfCam.up.y.toFixed(4), z:+_state.vfCam.up.z.toFixed(4)}) +
+        ' main_up=' + JSON.stringify({x:+mc.up.x.toFixed(4), y:+mc.up.y.toFixed(4), z:+mc.up.z.toFixed(4)}) +
+        ' vfCam_pos=' + JSON.stringify({x:+_state.vfCam.position.x.toFixed(3), y:+_state.vfCam.position.y.toFixed(3), z:+_state.vfCam.position.z.toFixed(3)}) +
+        ' freshPose_pos=' + (freshP ? JSON.stringify({x:+freshP.x.toFixed(3), y:+freshP.y.toFixed(3), z:+freshP.z.toFixed(3)}) : 'n/a') +
+        ' scrubTn=' + _state.scrubTn);
     }
-    if (w < 2 || h < 2) return;   // panel dragged fully off-canvas — nothing to draw
-    _state.vfCam.aspect = w / h;
-    _state.vfCam.updateProjectionMatrix();
     a.renderer.setScissorTest(true);
     a.renderer.setViewport(x, y, w, h);
     a.renderer.setScissor(x, y, w, h);


### PR DESCRIPTION
## Summary
Investigated the reported "POV content sits right of the box" bug via code correlation, not by asking for a visual read of a screenshot (this project's own CLAUDE.md FUNDAMENTAL LAW: code/maths is the proof).

**Ruled out via code** (all confirmed, not assumed):
- `a.canvas === a.renderer.domElement` — no element aliasing
- No CSS transform/letterbox on the canvas
- `EffectComposer.setSize()` uses the same `window.innerWidth/innerHeight` as `renderer.setSize()` — consistent
- The scissor rect's real backing-buffer ground truth (`renderer.domElement.width`, not derived) matches the computed math — the box itself is provably placed correctly

**Added `§CPE_VF_ALIGN_DIAG_V2`**: compares vfCam's fov/up/aspect/position against a fresh `plan.poseAt()` sample and the main camera's, at the same instant — targets the one remaining hypothesis (content framed off-center inside a correctly-placed box). Re-armed on every drag/resize, not just toggle-on.

**Caught a real bug in the new instrumentation itself while verifying it live**: the diagnostic originally logged `vfCam.aspect` *before* the line that corrects it from camera-creation-time `aspect=1` to the box's real aspect — a live capture showed `vfCam_aspect=1.0000` vs `box_aspect=1.5789` purely from log ordering, not an actual per-frame rendering bug (the fix-up still runs before every real `renderer.render()` call). Moved the log after the fix-up; re-verified live, `vfCam_aspect==box_aspect` now on every capture.

Every layer inspectable from code (scissor rect, backing buffer, camera fov/up/aspect/position vs. pose source) is now provably self-consistent — `vfCam_pos` matches `freshPose_pos` exactly in both a toggle+scrub and a drag+scrub scenario. This closes what static/instrumented analysis alone can determine; the v2 diagnostic is what will show real numbers on the next live repro of the reported bug.

## Test plan
- [x] Standalone Puppeteer check: toggles B, scrubs, drags the panel — confirms the new log fires with sane comparative numbers in both scenarios (not just that it compiles)
- [x] `witness_cpe_scrub_viewfinder.js` 17/17 green (HHS_Office_Federated) — no regression

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>