### PR TITLE
feat(4d): §GANTT_GROUP_MOVE — MS-Word-style marquee-select drags a bar cluster together

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -990,30 +990,52 @@
     return { ok: true, start: newStart, finish: finish, days: days };
   }
 
-  // §TM_RULER_SHIFT (2026-08-05, user ruling: dragging the Gantt drawer's day ruler adjusts the
-  // whole project's start/finish, "updated of course along with any other edit"). Translate EVERY
-  // task in the schedule — leaf AND summary alike — by a constant number of days. Deliberately no
-  // constraint checking, unlike moveTaskCascade/resizeTask: a uniform shift preserves every
-  // task_sequences edge and every task's relative position to every other task by construction, so
-  // there is nothing for C1/C2 to clamp or cascade. duration is untouched (start and finish move by
-  // the identical amount).
-  function shiftSchedule(db, scheduleId, deltaDays) {
-    var r = db.exec('SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id=?', [scheduleId]);
-    if (!r.length || !r[0].values.length) {
-      console.log('§SE_SHIFT_FAIL schedule=' + scheduleId + ' reason=no_tasks');
-      return { ok: false, reason: 'no_tasks' };
-    }
+  // Shared core: translate an explicit list of task rows by a constant number of days. No
+  // constraint checking — a uniform translation of a fixed row set can never create or resolve a
+  // task_sequences violation, by construction. duration is untouched.
+  function _shiftRows(db, rows, deltaDays) {
     var upd = db.prepare('UPDATE tasks SET schedule_start=?, schedule_finish=? WHERE task_id=?');
     var moved = [];
     db.run('BEGIN');
-    r[0].values.forEach(function (row) {
+    rows.forEach(function (row) {
       var taskId = row[0], newStart = _addDays(row[1], deltaDays), newFinish = _addDays(row[2], deltaDays);
       upd.run([newStart, newFinish, taskId]);
       moved.push({ id: taskId, start: newStart, finish: newFinish });
     });
     upd.free();
     db.run('COMMIT');
+    return moved;
+  }
+
+  // §TM_RULER_SHIFT (2026-08-05, user ruling: dragging the Gantt drawer's day ruler adjusts the
+  // whole project's start/finish, "updated of course along with any other edit"). Translate EVERY
+  // task in the schedule — leaf AND summary alike.
+  function shiftSchedule(db, scheduleId, deltaDays) {
+    var r = db.exec('SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id=?', [scheduleId]);
+    if (!r.length || !r[0].values.length) {
+      console.log('§SE_SHIFT_FAIL schedule=' + scheduleId + ' reason=no_tasks');
+      return { ok: false, reason: 'no_tasks' };
+    }
+    var moved = _shiftRows(db, r[0].values, deltaDays);
     console.log('§SE_SHIFT schedule=' + scheduleId + ' deltaDays=' + deltaDays + ' tasks=' + moved.length);
+    return { ok: true, moved: moved, deltaDays: deltaDays };
+  }
+
+  // §GANTT_GROUP_MOVE (2026-08-05, user ruling: marquee-select a cluster of bars, MS-Word-style —
+  // "when dragging a bar, it drags along its group"). Same uniform-translate primitive as
+  // shiftSchedule, scoped to an explicit task_id list (the marquee selection) instead of a whole
+  // schedule. The selection itself is ephemeral UI state, never persisted — only the resulting date
+  // change is a real edit.
+  function shiftTasks(db, taskIds, deltaDays) {
+    if (!taskIds || !taskIds.length) return { ok: false, reason: 'no_tasks' };
+    var placeholders = taskIds.map(function () { return '?'; }).join(',');
+    var r = db.exec('SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE task_id IN (' + placeholders + ')', taskIds);
+    if (!r.length || !r[0].values.length) {
+      console.log('§SE_GROUP_SHIFT_FAIL reason=no_matching_tasks');
+      return { ok: false, reason: 'no_tasks' };
+    }
+    var moved = _shiftRows(db, r[0].values, deltaDays);
+    console.log('§SE_GROUP_SHIFT tasks=' + moved.length + ' deltaDays=' + deltaDays);
     return { ok: true, moved: moved, deltaDays: deltaDays };
   }
 
@@ -1523,6 +1545,7 @@
     moveTask: moveTask,
     moveTaskCascade: moveTaskCascade,   // §GANTT_EDIT C1/C2 — the constraint-aware move
     shiftSchedule: shiftSchedule,       // §TM_RULER_SHIFT — uniform whole-project date shift
+    shiftTasks: shiftTasks,             // §GANTT_GROUP_MOVE — uniform date shift over an explicit task_id list
     resizeTask: resizeTask,             // §GANTT_EDIT E2 — edge-pull, duration changes
     setBaseline: setBaseline,           // ⚑ Set Baseline — schedule variance snapshot, single baseline
     getBaselineVariance: getBaselineVariance,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v955';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v956';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_bars_in_rect.js
+++ b/viewer/tests/witness_gantt_bars_in_rect.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// witness_gantt_bars_in_rect.js — §GANTT_GROUP_MOVE marquee geometry (2026-08-05). Proves
+// barsInRect uses the EXACT same bar geometry as findBarAtClick (marginL=60, rowH=14) — a marquee
+// that misses a bar findBarAtClick would hit is a real bug, not a UI nuance. Slices the real
+// barsInRect by balanced braces.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const sliced = sliceFn(tmSrc, 'barsInRect');
+
+// A 30-day axis over a 600px bar area (+60px gutter = 660px canvas) -> 20px/day.
+// Row height 14 (barH=12 + gapH=2), rows start at y = i*14 + 2.
+const _ganttTasks = [
+  { taskId: 'A', startTs: 0,              endTs: 5 * 86400000  },  // row 0: x=[60,160],  y=[2,14]
+  { taskId: 'B', startTs: 10 * 86400000,  endTs: 15 * 86400000 },  // row 1: x=[260,360], y=[16,28]
+  { taskId: 'C', startTs: 20 * 86400000,  endTs: 25 * 86400000 },  // row 2: x=[460,560], y=[30,42]
+  { taskId: null, startTs: 0, endTs: 5 * 86400000 },               // row 3: un-authored, must NEVER be selectable
+];
+
+function makeSandbox() {
+  const sandbox = { Math: Math, _ganttTasks: _ganttTasks, _ganttAxisStart: 0, _ganttAxisEnd: 30 * 86400000 };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced, sandbox);
+  return sandbox;
+}
+
+// ── Case 1: a marquee over rows 0-1 only selects A and B, not C ──
+{
+  const sb = makeSandbox();
+  const hit = sb.barsInRect(660, 50, 0, 400, 29);
+  const ids = hit.map(function (t) { return t.taskId; }).sort();
+  assert(JSON.stringify(ids) === JSON.stringify(['A', 'B']), 'marquee over rows 0-1 selects exactly [A,B], got ' + JSON.stringify(ids));
+}
+
+// ── Case 2: a marquee that only grazes A's right edge still counts it (any overlap, not full containment) ──
+{
+  const sb = makeSandbox();
+  const hit = sb.barsInRect(660, 150, 0, 200, 14);
+  const ids = hit.map(function (t) { return t.taskId; });
+  assert(ids.indexOf('A') !== -1, 'a marquee that only grazes a bar\'s edge still selects it (overlap, not full containment)');
+}
+
+// ── Case 3: a marquee entirely inside the label gutter (x < 60) selects nothing ──
+{
+  const sb = makeSandbox();
+  const hit = sb.barsInRect(660, 0, 0, 55, 100);
+  assert(hit.length === 0, 'a marquee entirely inside the storey-label gutter selects zero bars');
+}
+
+// ── Case 4: reversed drag direction (bottom-right to top-left) must give the identical result ──
+{
+  const sb = makeSandbox();
+  const forward = sb.barsInRect(660, 50, 0, 400, 29).map(function (t) { return t.taskId; }).sort();
+  const reversed = sb.barsInRect(660, 400, 29, 50, 0).map(function (t) { return t.taskId; }).sort();
+  assert(JSON.stringify(forward) === JSON.stringify(reversed), 'drag direction does not matter — same rect, same selection, got fwd=' + JSON.stringify(forward) + ' rev=' + JSON.stringify(reversed));
+}
+
+// ── RED CONTROL: a bar with no task_id (un-authored) is NEVER selectable, even dead-center in the marquee ──
+{
+  const sb = makeSandbox();
+  const hit = sb.barsInRect(660, 50, 40, 200, 45);
+  assert(hit.length === 0, 'RED CONTROL: an un-authored bar (taskId=null) directly inside the marquee is never selected');
+}
+
+console.log('\n§GANTT_BARS_IN_RECT SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_gantt_edit_lock.js
+++ b/viewer/tests/witness_gantt_edit_lock.js
@@ -45,9 +45,14 @@ function makeSandbox() {
   let openGanttPropsCalls = 0;
   const fakeBar = { taskId: 'T1', storey: 'Level 1', phase: 'Superstructure' };
   const sandbox = {
-    console: console, Math: Math, setTimeout: setTimeout,
+    console: console, Math: Math, Object: Object, setTimeout: setTimeout,
     document: { getElementById: function (id) { return id === 'tm-gantt-canvas' ? canvas : (id === 'tm-gantt-tip' ? tip : null); } },
     _active: true, _ganttTasks: [fakeBar], _ganttEditable: false, _drag: null, _dragConsumed: false,
+    // §GANTT_GROUP_MOVE additions to wireGanttDrag — not this witness's concern (that's
+    // witness_gantt_group_move.js), just enough state for the sliced function to run without
+    // throwing on a reference it now makes.
+    _ganttSelected: {}, _marquee: null, _groupDrag: null,
+    barsInRect: function () { return []; }, commitGanttGroupShift: function () {},
     ganttHit: function () { return { bar: fakeBar, mode: 'move', dayPx: 10 }; },
     openGanttProps: function () { openGanttPropsCalls++; },
     linkGanttBars: function () {}, commitGanttDrag: function () {}

--- a/viewer/tests/witness_gantt_group_move.js
+++ b/viewer/tests/witness_gantt_group_move.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// witness_gantt_group_move.js — §GANTT_GROUP_MOVE gesture state machine (2026-08-05). Proves the
+// marquee-select / group-drag routing inside wireGanttDrag: empty-space drag starts a marquee
+// (gated by the lock, same as everything else), a near-zero marquee clears the selection
+// (click-away = ungroup, no separate verb), a real marquee populates _ganttSelected via the real
+// barsInRect, dragging a SELECTED bar calls commitGanttGroupShift (not commitGanttDrag) with every
+// selected task_id, and dragging an UNselected bar clears the group and falls through to the
+// normal single-bar commitGanttDrag. Slices the real wireGanttDrag + barsInRect by balanced
+// braces — hit-test geometry itself is separately proven in witness_gantt_bars_in_rect.js, so
+// ganttHit is stubbed here to a deterministic lookup rather than re-driving real pixel math.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const sliced = sliceFn(tmSrc, 'barsInRect') + '\n' + sliceFn(tmSrc, 'wireGanttDrag');
+
+function fakeElement(rectOverrides) {
+  const handlers = {};
+  return {
+    _dragWired: false, clientWidth: 660,
+    addEventListener: function (type, fn) { handlers[type] = fn; },
+    setPointerCapture: function () {}, releasePointerCapture: function () {},
+    getBoundingClientRect: function () { return Object.assign({ left: 0, top: 0, width: 660 }, rectOverrides || {}); },
+    style: {}, _handlers: handlers
+  };
+}
+function ev(clientX, clientY, target) { return { clientX: clientX, clientY: clientY || 0, target: target, offsetX: 0, offsetY: 0, preventDefault: function () {}, stopPropagation: function () {} }; }
+
+// Same geometry as witness_gantt_bars_in_rect.js: 30-day axis, 20px/day, rows 14px tall.
+const BAR_A = { taskId: 'A', storey: 's', phase: 'p', startTs: 0, endTs: 5 * 86400000 };
+const BAR_B = { taskId: 'B', storey: 's', phase: 'p', startTs: 10 * 86400000, endTs: 15 * 86400000 };
+const BAR_C = { taskId: 'C', storey: 's', phase: 'p', startTs: 20 * 86400000, endTs: 25 * 86400000 };
+
+function makeSandbox(editable) {
+  const cv = fakeElement({});
+  const tip = fakeElement({});
+  const marquee = fakeElement({});
+  const calls = { groupShift: [], singleDrag: [], link: [] };
+  // Deterministic hit lookup: clientX buckets, matching each bar's OWN row/x-range from the
+  // barsInRect witness — this is a TEST INPUT stub, not a re-implementation of ganttHit's geometry.
+  const HITMAP = { 100: { bar: BAR_A, mode: 'move', dayPx: 20 }, 300: { bar: BAR_B, mode: 'move', dayPx: 20 }, 500: { bar: BAR_C, mode: 'move', dayPx: 20 } };
+  const sandbox = {
+    console: console, Math: Math, Object: Object, setTimeout: setTimeout,
+    document: { getElementById: function (id) { return id === 'tm-gantt-canvas' ? cv : (id === 'tm-gantt-tip' ? tip : (id === 'tm-gantt-marquee' ? marquee : null)); } },
+    _active: true, _ganttTasks: [BAR_A, BAR_B, BAR_C], _ganttAxisStart: 0, _ganttAxisEnd: 30 * 86400000,
+    _ganttEditable: editable, _ganttSelected: {}, _marquee: null, _groupDrag: null, _drag: null, _dragConsumed: false,
+    ganttHit: function (e) { return HITMAP[e.clientX] || null; },
+    drawGanttMini: function () {},
+    commitGanttGroupShift: function (taskIds, days) { calls.groupShift.push({ taskIds: taskIds.slice().sort(), days: days }); },
+    commitGanttDrag: function (bar, mode, days) { calls.singleDrag.push({ id: bar.taskId, mode: mode, days: days }); },
+    linkGanttBars: function (a, b) { calls.link.push({ a: a.taskId, b: b.taskId }); }
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced, sandbox);
+  sandbox.wireGanttDrag();
+  return { sandbox: sandbox, cv: cv, calls: calls };
+}
+
+// ── Case 1: locked — empty-space drag never starts a marquee ──
+{
+  const h = makeSandbox(false);
+  h.cv._handlers.pointerdown(ev(1000, 1, h.cv));   // no HITMAP entry at x=1000 -> empty space
+  assert(h.sandbox._marquee === null, 'locked: pointerdown on empty canvas never starts a marquee');
+}
+
+// ── Case 2: unlocked — a real marquee drag over A and B populates _ganttSelected via the real barsInRect ──
+{
+  const h = makeSandbox(true);
+  h.cv._handlers.pointerdown(ev(1000, 0, h.cv));
+  assert(h.sandbox._marquee !== null, 'unlocked: pointerdown on empty canvas starts a marquee');
+  h.cv._handlers.pointermove(ev(1000, 400, h.cv));   // sweep down toward x=400,y=29 covering rows 0-1 (A,B)
+  // pointermove sets _marquee.x1/y1 off e.clientX/e.clientY directly (canvas-local, rect.left/top=0)
+  h.sandbox._marquee.x0 = 50; h.sandbox._marquee.y0 = 0; h.sandbox._marquee.x1 = 400; h.sandbox._marquee.y1 = 29;
+  h.cv._handlers.pointerup(ev(400, 29, h.cv));
+  const selected = Object.keys(h.sandbox._ganttSelected).sort();
+  assert(JSON.stringify(selected) === '["A","B"]', 'a marquee over rows 0-1 selects exactly [A,B] via the real barsInRect, got ' + JSON.stringify(selected));
+}
+
+// ── Case 3: click-away (near-zero marquee) clears an existing selection ──
+{
+  const h = makeSandbox(true);
+  h.sandbox._ganttSelected = { A: true, B: true };
+  h.cv._handlers.pointerdown(ev(1000, 0, h.cv));
+  h.cv._handlers.pointerup(ev(1000, 0, h.cv));   // zero movement -> a click, not a drag
+  assert(Object.keys(h.sandbox._ganttSelected).length === 0, 'a near-zero marquee (click-away) clears the existing selection');
+}
+
+// ── Case 4: dragging a SELECTED bar moves the whole group via commitGanttGroupShift, not a single drag ──
+{
+  const h = makeSandbox(true);
+  h.sandbox._ganttSelected = { A: true, B: true };
+  h.cv._handlers.pointerdown(ev(100, 0, h.cv));    // bar A, which IS in the selection
+  h.cv._handlers.pointermove(ev(140, 0, h.cv));    // +40px / 20px-per-day = +2 days
+  h.cv._handlers.pointerup(ev(140, 0, h.cv));
+  assert(h.calls.singleDrag.length === 0, 'dragging a selected bar never calls the single-bar commitGanttDrag');
+  assert(h.calls.groupShift.length === 1 && h.calls.groupShift[0].days === 2 &&
+    JSON.stringify(h.calls.groupShift[0].taskIds) === '["A","B"]',
+    'dragging a selected bar calls commitGanttGroupShift(["A","B"], 2) — got ' + JSON.stringify(h.calls.groupShift));
+}
+
+// ── Case 5: dragging a bar NOT in the selection clears the group and does a normal single drag ──
+{
+  const h = makeSandbox(true);
+  h.sandbox._ganttSelected = { A: true, B: true };
+  h.cv._handlers.pointerdown(ev(500, 0, h.cv));    // bar C, NOT in the selection
+  h.cv._handlers.pointermove(ev(540, 0, h.cv));
+  h.cv._handlers.pointerup(ev(540, 0, h.cv));
+  assert(Object.keys(h.sandbox._ganttSelected).length === 0, 'dragging an unselected bar clears the group selection');
+  assert(h.calls.groupShift.length === 0, 'dragging an unselected bar never calls commitGanttGroupShift');
+  assert(h.calls.singleDrag.length === 1 && h.calls.singleDrag[0].id === 'C',
+    'dragging an unselected bar falls through to the normal single-bar commitGanttDrag on that bar');
+}
+
+console.log('\n§GANTT_GROUP_MOVE SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_shift_tasks.js
+++ b/viewer/tests/witness_shift_tasks.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// witness_shift_tasks.js — §GANTT_GROUP_MOVE engine verb (2026-08-05). Proves ScheduleAuthor.
+// shiftTasks translates ONLY the given task_id subset by a constant number of days, and — the
+// property that actually matters for a marquee-selected group — every task NOT in the list stays
+// byte-identical. Real fixture, real materialized schedule.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function day(s) { return Math.round(Date.parse(s + 'T00:00:00Z') / 86400000); }
+
+initSqlJs({ locateFile: function (f) { return path.join(SQLJS_DIST, f); } }).then(function (SQL) {
+  const dbPath = path.join(require('os').homedir(), 'bim-ootb', 'buildings', 'Duplex_extracted.db');
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const opts = { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate };
+  const mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES, opts);
+  if (!mres.ok) { console.log('§SKIP materializeZones failed: ' + JSON.stringify(mres)); return; }
+  const schedId = mres.scheduleId;
+
+  function readAll() {
+    const r = db.exec('SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_id=?', [schedId]);
+    const out = {};
+    r[0].values.forEach(function (row) { out[row[0]] = { start: row[1], finish: row[2] }; });
+    return out;
+  }
+
+  const before = readAll();
+  const allIds = Object.keys(before);
+  assert(allIds.length >= 4, 'RED-CONTROL: the real schedule has at least 4 tasks — a subset-vs-rest test needs both groups non-trivial');
+  const selected = allIds.slice(0, Math.floor(allIds.length / 2));
+  const untouched = allIds.slice(Math.floor(allIds.length / 2));
+  assert(untouched.length > 0, 'RED-CONTROL: a real "untouched" group actually exists to check');
+
+  const DELTA = 9;
+  const res = ScheduleAuthor.shiftTasks(db, selected, DELTA);
+  assert(res.ok, 'shiftTasks succeeds on a real subset');
+  assert(res.moved.length === selected.length, 'moved count equals exactly the requested subset — moved=' + res.moved.length + ' requested=' + selected.length);
+
+  const after = readAll();
+  const selectedShifted = selected.every(function (id) {
+    return day(after[id].start) - day(before[id].start) === DELTA && day(after[id].finish) - day(before[id].finish) === DELTA;
+  });
+  assert(selectedShifted, 'every SELECTED task moved by exactly +' + DELTA + 'd');
+
+  const restUntouched = untouched.every(function (id) { return after[id].start === before[id].start && after[id].finish === before[id].finish; });
+  assert(restUntouched, 'every NON-selected task is byte-identical before/after — the whole point of a scoped group move');
+
+  // RED CONTROL: an id list containing a bogus, non-existent task_id must not blow up and must
+  // still move the real ones — proves the verb is robust against a stale selection.
+  const withBogus = selected.slice(0, 2).concat(['TASK_DOES_NOT_EXIST']);
+  const res2 = ScheduleAuthor.shiftTasks(db, withBogus, 3);
+  assert(res2.ok && res2.moved.length === 2, 'RED CONTROL: a bogus task_id in the selection is silently ignored, real ones still move — moved=' + (res2.moved || []).length);
+
+  db.close();
+  console.log('\n§SHIFT_TASKS SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+});

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2730,6 +2730,8 @@
         '<div style="position:relative">' +
           '<canvas id="tm-gantt-canvas" style="width:100%;cursor:pointer"></canvas>' +
           '<div id="tm-gantt-hair" style="position:absolute;top:0;width:2px;height:100%;background:#ff8c00;pointer-events:none;z-index:1;display:none"></div>' +
+          '<div id="tm-gantt-marquee" style="position:absolute;border:1px dashed #4fc3f7;' +
+            'background:rgba(79,195,247,0.12);pointer-events:none;z-index:1;display:none"></div>' +
           '<div id="tm-gantt-tip" style="position:absolute;top:4px;left:0;background:rgba(20,20,40,0.92);color:#ff8c00;font-size:10px;padding:3px 8px;border-radius:3px;border:1px solid rgba(255,140,0,0.3);pointer-events:none;z-index:2;display:none;white-space:nowrap;max-width:280px;overflow:hidden;text-overflow:ellipsis"></div>' +
         '</div>' +
       '</div>' +
@@ -4992,6 +4994,17 @@
   var _ganttEditable = false;
   var _ganttAutoGenAttempted = false;  // reset per activate() — one auto-generate attempt per open
 
+  // §GANTT_GROUP_MOVE (user ruling 2026-08-05): marquee-select a cluster of bars (MS-Word-style —
+  // drag from EMPTY canvas space, sweep into the bars you want), then dragging any SELECTED bar
+  // moves the whole group together (same uniform-shift primitive as §TM_RULER_SHIFT, scoped to the
+  // selection instead of the whole project). Ephemeral, never persisted — same convention as
+  // selecting files in a file manager: it exists between "marquee" and "click away," nothing more.
+  // Click any empty canvas space (a marquee drag that ends up ~zero-size) clears it — same gesture
+  // starts a NEW marquee and dissolves the OLD selection in one motion, no separate "ungroup" verb.
+  var _ganttSelected = {};   // taskId -> true
+  var _marquee = null;       // { x0, y0, x1, y1 } in canvas-local px while a marquee drag is live
+  var _groupDrag = null;     // { taskIds, x0, y0, dayPx, days, moved } while dragging a selected bar
+
   // §GANTT_EDIT_UNDO — single-level (not a stack): a drag can cascade N successors with no way back
   // except regenerating the whole schedule (real gap, this session's own edit UI made it possible).
   // Scope is deliberately narrow: only commitGanttDrag (E1/E2 move/resize) sets this, not link/unlink
@@ -5201,6 +5214,57 @@
     renderAtTime(_cursor);
   }
 
+  // §GANTT_GROUP_MOVE — same shape as shiftGanttSchedule, scoped to an explicit marquee-selected
+  // task_id list instead of the whole schedule. Reuses the SAME _lastEdit single-level undo — its
+  // restore loop doesn't care whether tasksBefore/opsBefore covers a cascade, the whole schedule,
+  // or a selection, it just restores whatever's in there.
+  function commitGanttGroupShift(taskIds, deltaDays) {
+    var app = A();
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    if (!app || !app.db || !SA || !SA.shiftTasks) {
+      console.log('§GANTT_GROUP_SHIFT_REJECT reason=ScheduleAuthor_not_loaded');
+      return;
+    }
+    if (!deltaDays || !taskIds || !taskIds.length) return;
+    var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
+
+    var tasksBefore = {};
+    try {
+      var placeholders = taskIds.map(function () { return '?'; }).join(',');
+      var tb = app.db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE task_id IN (' + placeholders + ')', taskIds);
+      if (tb.length) tb[0].values.forEach(function (row) {
+        tasksBefore[row[0]] = { start: row[1], finish: row[2], duration: row[3] };
+      });
+    } catch (e) {}
+
+    var res = SA.shiftTasks(app.db, taskIds, deltaDays);
+    if (!res || !res.ok) {
+      console.log('§GANTT_GROUP_SHIFT_REJECT reason=' + ((res && res.reason) || 'unknown'));
+      return;
+    }
+
+    var barsByTask = {};
+    for (var i = 0; i < _ganttTasks.length; i++) if (_ganttTasks[i].taskId) barsByTask[_ganttTasks[i].taskId] = _ganttTasks[i];
+    var opsBefore = {};
+    var _opByGuidForUndo = {};
+    for (var oi3 = 0; oi3 < _ops.length; oi3++) if (_ops[oi3].output_guid) _opByGuidForUndo[_ops[oi3].output_guid] = _ops[oi3];
+    res.moved.forEach(function (m) {
+      var bar3 = barsByTask[m.id]; if (!bar3 || !bar3.guids) return;
+      bar3.guids.forEach(function (g) {
+        var op = _opByGuidForUndo[g];
+        if (op) opsBefore[g] = { start_ts: op.start_ts, end_ts: op.end_ts, parameters: JSON.stringify(op.parameters) };
+      });
+    });
+
+    retimeTaskElements(app.db, barsByTask, res.moved);
+    _lastEdit = { schedId: schedId, taskId: '(' + taskIds.length + ' selected)', mode: 'group-shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
+    console.log('§GANTT_GROUP_SHIFT_COMMIT tasks=' + res.moved.length + ' deltaDays=' + deltaDays);
+    invalidateGanttModel();
+    computeDays();
+    drawGanttMini();
+    renderAtTime(_cursor);
+  }
+
   // §GANTT_EDIT_UNDO — reverse the single most recent commitGanttDrag edit. Restores both halves
   // that edit changed: the task dates (moveTaskCascade/resizeTask's write to `tasks`) and the
   // element ops (retimeTaskElements's write to `kernel_ops`) — same two tables, same shape, run
@@ -5340,7 +5404,16 @@
     cv.addEventListener('pointerdown', function (e) {
       if (!_active || !_ganttTasks.length) return;
       var hit = ganttHit(e);
-      if (!hit) return;
+      if (!hit) {
+        // §GANTT_GROUP_MOVE — empty canvas starts a marquee-select (MS-Word-style: drag from empty
+        // space, sweep into the bars you want). Same lock gate as everything else — selecting is
+        // UI-only, but its only purpose here is to enable a group move, which IS an edit.
+        if (!_ganttEditable) return;
+        var mrect = e.target.getBoundingClientRect();
+        _marquee = { x0: e.clientX - mrect.left, y0: e.clientY - mrect.top, x1: e.clientX - mrect.left, y1: e.clientY - mrect.top };
+        try { cv.setPointerCapture(e.pointerId); } catch (err) {}
+        return;
+      }
       // §GANTT_DRAG_REJECT at the point of refusal. This used to be a bare `return`: a user dragging
       // a non-editable bar got NO feedback and NO log line, and the browser wiring test could not
       // tell "handler never fired" apart from "handler correctly refused". Silence is not a refusal.
@@ -5369,10 +5442,46 @@
         }
         return;
       }
+      // §GANTT_GROUP_MOVE — dragging a bar that's part of the current multi-selection moves the
+      // WHOLE group together. Dragging a bar OUTSIDE the current selection clears it first (same
+      // convention as every other selection UI: clicking an unselected object deselects the group).
+      if (_ganttSelected[hit.bar.taskId] && Object.keys(_ganttSelected).length > 1) {
+        _groupDrag = { taskIds: Object.keys(_ganttSelected), x0: e.clientX, y0: e.clientY, dayPx: hit.dayPx, days: 0, moved: false };
+        try { cv.setPointerCapture(e.pointerId); } catch (err) {}
+        return;
+      }
+      if (Object.keys(_ganttSelected).length) { _ganttSelected = {}; drawGanttMini(); }
       _drag = { bar: hit.bar, mode: hit.mode, x0: e.clientX, y0: e.clientY, dayPx: hit.dayPx, days: 0, moved: false };
       try { cv.setPointerCapture(e.pointerId); } catch (err) {}
     });
     cv.addEventListener('pointermove', function (e) {
+      if (_marquee) {
+        var mrect2 = e.target.getBoundingClientRect();
+        _marquee.x1 = e.clientX - mrect2.left; _marquee.y1 = e.clientY - mrect2.top;
+        var mel = document.getElementById('tm-gantt-marquee');
+        if (mel) {
+          var lo = Math.min(_marquee.x0, _marquee.x1), hi = Math.max(_marquee.x0, _marquee.x1);
+          var top = Math.min(_marquee.y0, _marquee.y1), bot = Math.max(_marquee.y0, _marquee.y1);
+          mel.style.left = lo + 'px'; mel.style.top = top + 'px';
+          mel.style.width = (hi - lo) + 'px'; mel.style.height = (bot - top) + 'px';
+          mel.style.display = 'block';
+        }
+        e.preventDefault();
+        return;
+      }
+      if (_groupDrag) {
+        var days2 = Math.round((e.clientX - _groupDrag.x0) / Math.max(0.001, _groupDrag.dayPx));
+        if (days2 !== _groupDrag.days) { _groupDrag.days = days2; _groupDrag.moved = _groupDrag.moved || days2 !== 0; }
+        var tip2 = document.getElementById('tm-gantt-tip');
+        if (tip2 && _groupDrag.moved) {
+          tip2.textContent = 'Move ' + _groupDrag.taskIds.length + ' bars  ' + (days2 >= 0 ? '+' : '') + days2 + 'd';
+          tip2.style.left = Math.max(0, Math.min(e.offsetX + 8, e.target.clientWidth - 200)) + 'px';
+          tip2.style.top = Math.max(2, e.offsetY - 22) + 'px';
+          tip2.style.display = 'block';
+        }
+        e.preventDefault();
+        return;
+      }
       if (!_drag) { cv.style.cursor = (function () { var h = ganttHit(e); return h && h.bar.taskId ? (h.mode === 'move' ? 'grab' : 'ew-resize') : 'pointer'; })(); return; }
       var days = Math.round((e.clientX - _drag.x0) / Math.max(0.001, _drag.dayPx));
       if (days !== _drag.days) { _drag.days = days; _drag.moved = _drag.moved || days !== 0; }
@@ -5387,6 +5496,38 @@
       e.preventDefault();
     });
     function endDrag(e) {
+      if (_marquee) {
+        var m = _marquee; _marquee = null;
+        try { cv.releasePointerCapture(e.pointerId); } catch (err) {}
+        var mel2 = document.getElementById('tm-gantt-marquee');
+        if (mel2) mel2.style.display = 'none';
+        // A near-zero marquee is a CLICK, not a drag — click-away-to-deselect, the same gesture
+        // that starts a new marquee also dissolves the old selection (no separate "ungroup" verb).
+        if (Math.abs(m.x1 - m.x0) + Math.abs(m.y1 - m.y0) < 4) {
+          if (Object.keys(_ganttSelected).length) {
+            _ganttSelected = {};
+            console.log('§GANTT_GROUP_SELECT count=0 (cleared)');
+            drawGanttMini();
+          }
+          return;
+        }
+        var hitBars = barsInRect(cv.clientWidth, m.x0, m.y0, m.x1, m.y1);
+        _ganttSelected = {};
+        hitBars.forEach(function (t) { _ganttSelected[t.taskId] = true; });
+        console.log('§GANTT_GROUP_SELECT count=' + hitBars.length);
+        drawGanttMini();
+        return;
+      }
+      if (_groupDrag) {
+        var gd = _groupDrag; _groupDrag = null;
+        try { cv.releasePointerCapture(e.pointerId); } catch (err) {}
+        var tip3 = document.getElementById('tm-gantt-tip');
+        if (tip3) tip3.style.display = 'none';
+        if (!gd.moved || !gd.days) return;   // a click, not a drag
+        _dragConsumed = true;
+        commitGanttGroupShift(gd.taskIds, gd.days);
+        return;
+      }
       if (!_drag) return;
       var d = _drag; _drag = null;
       try { cv.releasePointerCapture(e.pointerId); } catch (err) {}
@@ -5659,6 +5800,17 @@
         ctx.strokeRect(x, y, w, barH);
       }
 
+      // §GANTT_GROUP_MOVE — marquee-selected bars get a bright cyan frame, same idea as the
+      // captured-schedule yellow frame above (a different concern, so a different colour, drawn
+      // last so it always reads on top). Selection is ephemeral UI state (_ganttSelected), not
+      // persisted — this is the only place it's visible.
+      if (task.taskId && _ganttSelected[task.taskId]) {
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = '#4fc3f7';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x - 1, y - 1, w + 2, barH + 2);
+      }
+
       // Label: explicit phase short-code (§GANTT_PALETTE). substring(0,3) used to yield "Sub" vs
       // "Sup" — one character apart at 9px, colliding on the very pair the colours also collided on.
       if (w > 40) {
@@ -5754,6 +5906,28 @@
       if (x >= bx && x <= bx + bw && y >= by && y <= by + barH) return task;
     }
     return null;
+  }
+
+  // §GANTT_GROUP_MOVE — every task whose drawn rect intersects the given canvas-local marquee
+  // rectangle. SAME geometry as findBarAtClick (marginL=60, rowH=14) — a marquee that misses a bar
+  // findBarAtClick would also miss is a bug, not a feature, so this deliberately shares the exact
+  // constants rather than a second copy of them. Only bars with a real taskId are selectable — an
+  // un-authored bar has nothing to shift.
+  function barsInRect(cW, rx0, ry0, rx1, ry1) {
+    var barH = 12, gapH = 2, rowH = barH + gapH;
+    var range = Math.max(1, _ganttAxisEnd - _ganttAxisStart);
+    var marginL = 60;
+    var barW = cW - marginL;
+    var lo = Math.min(rx0, rx1), hi = Math.max(rx0, rx1), top = Math.min(ry0, ry1), bot = Math.max(ry0, ry1);
+    var out = [];
+    for (var i = 0; i < _ganttTasks.length; i++) {
+      var task = _ganttTasks[i]; if (!task.taskId) continue;
+      var bx = marginL + (task.startTs - _ganttAxisStart) / range * barW;
+      var bw = (task.endTs - task.startTs) / range * barW; if (bw < 2) bw = 2;
+      var by = i * rowH + 2;
+      if (bx <= hi && bx + bw >= lo && by <= bot && by + barH >= top) out.push(task);
+    }
+    return out;
   }
 
   // ── RES_ICONS (reused from boq_charts) ──
@@ -6170,6 +6344,7 @@
     if (_active) return;
     _lastEdit = null;   // §GANTT_EDIT_UNDO — a stale snapshot from a prior building must never apply here
     _ganttAutoGenAttempted = false;   // §GANTT_EDIT_LOCK — allow one fresh auto-generate attempt
+    _ganttSelected = {}; _marquee = null; _groupDrag = null;   // §GANTT_GROUP_MOVE — stale selection from a prior building must never apply here
     // §MERGED_GUID: TM mutates elements individually (setMatrixAt/setVisibleAt per slot), which a
     // merged buffer cannot do — so TM re-streams unmerged. Two corrections to the old trigger:
     //   (1) condition is _mergeActive (are merged meshes ACTUALLY in the scene), not _isMobile.


### PR DESCRIPTION
## Summary
Orphaned by #1202's squash-merge race (same pattern as #1198/#1199/#1201 earlier today) —
verified via \`git merge-base --is-ancestor\` before opening this, recovered by cherry-pick onto
a fresh branch off current \`origin/main\`, all witnesses re-run against the real merged state.

- **\`ScheduleAuthor.shiftTasks(db, taskIds, deltaDays)\`** — same uniform-translate primitive as
  \`shiftSchedule\` (#1202), refactored to share a \`_shiftRows\` core, scoped to an explicit
  task_id list instead of a whole schedule.
- **Marquee-select**: dragging from empty canvas space (MS-Word convention) selects a bar
  cluster, gated behind the Editing lock. Dragging any selected bar moves the whole group
  together; dragging an unselected bar clears the group and falls back to a normal single drag.
  Click-away (near-zero marquee) clears the selection — same gesture starts a new one and
  dissolves the old, no separate ungroup verb. Selection is ephemeral, never persisted.
- Link stays on its existing gesture (drag-bar-onto-bar) — user's own conclusion after discussion
  was that mechanism doesn't need changing.

## Test plan
- [x] \`node --check\` on all touched files
- [x] \`witness_shift_tasks.js\` (new) 7/7 — subset shift, untouched-rest invariant, RED CONTROL
- [x] \`witness_gantt_bars_in_rect.js\` (new) 5/5 — marquee geometry matches findBarAtClick exactly
- [x] \`witness_gantt_group_move.js\` (new) 9/9 — full gesture routing sliced from the real
      wireGanttDrag
- [x] Regression: \`witness_gantt_edit_lock\` 5/5 (updated for new sandbox globals),
      \`witness_gantt_ruler_shift_lock\` 4/4, \`witness_tm_panel_resize\` 5/5,
      \`witness_gantt_bar_identity\` 6/6

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01UCZQfqMncP9QapmvjQZbD8