### PR TITLE
fix(4d+cinema): §DLOD_VF_CAMGUARD_SIG — camera-moved detector follows resolved DLOD camera

### DIFF
--- a/viewer/tests/witness_dlod_vf_camguard.js
+++ b/viewer/tests/witness_dlod_vf_camguard.js
@@ -7,6 +7,15 @@
 // viewfinder is genuinely on, and falls back to the main camera in every other case (viewfinder
 // off, CPE module not loaded at all, or loaded with no cinemaPathEditor exposed) — sliced by
 // balanced braces from the real shipped function, never reimplemented.
+//
+// §DLOD_VF_CAMGUARD_SIG (2026-08-05, follow-on): the resolver fix above was a real fix but left a
+// gap — _dlodCamMoved (the "did the camera move, force a full DLOD pass" edge-detector) still hard-
+// coded app.camera in _giHoldCamSig, so during a POV-only scrub/play (main parked, §CPE_SCRUB_
+// POV_ONLY) it never saw vfCam moving and could let the incremental-delta path skip re-evaluating
+// visibility for geometry entering/leaving vfCam's own moving frustum — stale buildup in the POV
+// inset. Cases 5-7 prove _giHoldCamSig now takes an explicit camera override (main-camera default
+// unchanged, so the two pre-existing GI hold-converge call sites are untouched) and that the DLOD
+// call site inside renderAtTime passes the SAME resolved camera the frustum was built from.
 'use strict';
 const fs = require('fs');
 const path = require('path');
@@ -67,6 +76,46 @@ const app = { camera: mainCam };
   const r = resolve(app);
   assert(r === povCam, 'viewfinder on: resolves to the POV camera, not the parked main camera');
   assert(r !== mainCam, 'RED CONTROL: without this fix, resolve(app) === mainCam always — proves the branch is live');
+}
+
+// ── Case 5: _giHoldCamSig(app) with NO override — byte-identical to before, reads app.camera ──
+{
+  const sliced = sliceFn(tmSrc, '_giHoldCamSig');
+  const sandbox = { console: console };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nglobalThis.__sig = _giHoldCamSig;', sandbox);
+  const sig = sandbox.__sig;
+  const mc5 = { position: { x: 1, y: 2, z: 3 }, quaternion: { x: 0, y: 0, z: 0, w: 1 } };
+  const mainOnly = { camera: mc5 };
+  const r = sig(mainOnly);
+  const expected = '1.0000,2.0000,3.0000,';
+  assert(typeof r === 'string' && r.indexOf(expected) === 0, 'no override: signature is built from app.camera (GI call sites unaffected) got=' + r);
+}
+
+// ── Case 6: _giHoldCamSig(app, cam) WITH an explicit camera — signature reflects THAT camera, ──
+// not app.camera, and a signature built from vfCam differs from one built from main.
+{
+  const sliced = sliceFn(tmSrc, '_giHoldCamSig');
+  const sandbox = { console: console };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nglobalThis.__sig = _giHoldCamSig;', sandbox);
+  const sig = sandbox.__sig;
+  const mainQ = { x: 0, y: 0, z: 0, w: 1 };
+  const povQ = { x: 0.1, y: 0.2, z: 0.3, w: 0.9 };
+  const mc = { position: { x: 0, y: 0, z: 0 }, quaternion: mainQ };
+  const pc = { position: { x: 9, y: 9, z: 9 }, quaternion: povQ };
+  const app2 = { camera: mc };
+  const sigMain = sig(app2);
+  const sigPov = sig(app2, pc);
+  assert(sigMain !== sigPov, 'explicit cam override: vfCam signature differs from main-camera signature');
+  assert(sigPov.indexOf('9.0000,9.0000,9.0000,') === 0, 'explicit cam override: signature is built from the passed camera, not app.camera got=' + sigPov);
+}
+
+// ── Case 7: static — the renderAtTime call site passes the resolved active camera, not bare app ──
+// (the real bug: main parked + vfCam moving during a POV scrub was invisible to the OLD call).
+{
+  const callSiteRe = /_dlodCamSigNow\s*=\s*_giHoldCamSig\(app,\s*_dlodActiveCam\)/;
+  assert(callSiteRe.test(tmSrc), 'renderAtTime\'s _dlodCamMoved edge-detector calls _giHoldCamSig(app, _dlodActiveCam), not _giHoldCamSig(app) alone');
 }
 
 console.log('\n§DLOD_VF_CAMGUARD SUMMARY pass=' + pass + ' fail=' + fail);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -831,9 +831,19 @@
   // do) — so a drag starting while the 24-frame accumulate is in flight blends N8AO across the
   // moving view, exactly the reported "ghosting when moving the scene." Fix: same pose-signature
   // restart discipline, ported directly — position+quaternion string, checked every frame.
-  function _giHoldCamSig(app) {
-    if (!app || !app.camera) return '';
-    var p = app.camera.position, q = app.camera.quaternion;
+  // §DLOD_VF_CAMGUARD_SIG (2026-08-05) — optional `cam` override, defaulting to app.camera so both
+  // existing GI hold-converge call sites below (main-viewport-only, unaffected) are byte-identical.
+  // The DLOD call site passes the SAME resolved camera _dlodInView's frustum was built from
+  // (_dlodResolveCamera's result — vfCam when POV is active) instead of always app.camera: without
+  // this, _dlodCamMoved never sees vfCam moving during a POV-only scrub/play (main stays parked,
+  // §CPE_SCRUB_POV_ONLY), so the incremental-delta path could skip re-evaluating DLOD visibility
+  // for geometry newly entering/leaving vfCam's OWN moving frustum — stale buildup in the POV inset
+  // that a fresh full pass (triggered by anything else, e.g. a big cursor jump) would silently fix,
+  // masking the gap. Same camera basis end-to-end: resolve → frustum → moved-detection.
+  function _giHoldCamSig(app, cam) {
+    cam = cam || (app && app.camera);
+    if (!cam) return '';
+    var p = cam.position, q = cam.quaternion;
     return p.x.toFixed(4) + ',' + p.y.toFixed(4) + ',' + p.z.toFixed(4) + ',' +
            q.x.toFixed(5) + ',' + q.y.toFixed(5) + ',' + q.z.toFixed(5) + ',' + q.w.toFixed(5);
   }
@@ -1333,7 +1343,10 @@
     // behavioural change (W-DLOD-EQUIV).
     var _dlodCamMoved = false;
     if (_dlodOn) {
-      var _dlodCamSigNow = _giHoldCamSig(app);
+      // §DLOD_VF_CAMGUARD_SIG: same camera _dlodCamPos/frustum were just built from above
+      // (_dlodActiveCam — vfCam when POV is active, main otherwise), not always app.camera — see
+      // that function's own comment for why using the wrong one here goes stale silently.
+      var _dlodCamSigNow = _giHoldCamSig(app, _dlodActiveCam);
       _dlodCamMoved = (_dlodLastCamSig !== null && _dlodLastCamSig !== _dlodCamSigNow);
       _dlodLastCamSig = _dlodCamSigNow;
     } else {


### PR DESCRIPTION
## Summary
Follow-on to PR #1199's `§DLOD_VF_CAMGUARD` (`_dlodResolveCamera` picks `vfCam` while CPE's POV panel is on — already merged, verified live in code). That fix was real but left a gap:

The "did the camera move, force a full DLOD re-evaluation" edge-detector (`_dlodCamMoved`, via `_giHoldCamSig`) still hardcoded `app.camera` regardless of which camera `_dlodInView`'s frustum was actually built from.

During a POV-only scrub/play (main camera stays parked — `§CPE_SCRUB_POV_ONLY`, bim-ootb PR #1197), `_giHoldCamSig(app)` returns the SAME signature every tick because the main camera never moves, so `_dlodCamMoved` stays false for the whole rehearsal even though `vfCam` (the actual DLOD-basis camera) is moving continuously. The incremental-delta path could then skip re-evaluating visibility for geometry entering/leaving vfCam's own moving frustum — stale buildup in the POV inset, invisible until something else (a big cursor jump, a shadow toggle) happened to force a full pass and mask the gap.

- `_giHoldCamSig(app, cam)`: optional camera override, defaults to `app.camera` — the two pre-existing GI hold-converge call sites (main-viewport-only, unrelated feature) are unaffected.
- `renderAtTime`'s `_dlodCamMoved` computation now passes `_dlodActiveCam` (the same resolved camera `_dlodCamPos`/frustum were just built from), not bare `app` — same basis end-to-end: resolve → frustum → moved-detection.

## Test plan
- [x] `witness_dlod_vf_camguard.js` extended with 4 new cases (9/9 total, pure VM slice, no browser) — proves the override works, defaults correctly, and the call site actually wires it up
- [x] `witness_incr_shadow_equiv.js` (W-INCR-EQUIV) against Hospital — 0 mismatch across 19 cursors (11 delta-mode, 8 full-mode) — confirms zero behavioural change on the non-CPE path

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>