### PR TITLE
fix(cpe): B panel position/z-index, scrub panel overflow, both silent-before

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -158,6 +158,15 @@
   // `_vfRender()` calls a single rehearsal makes; reset by `_vfPerfReset()` at the top of each
   // `_previewFly()` run.
   var _vfPerf = { n: 0, sum: 0, max: 0 };
+  // §CPE_VF_RENDER_TRACE (2026-08-05) — user-reported: clicking INSIDE B's box (passes through, its
+  // background is pointer-events:none — confirmed by the user's own log showing [RP-TB] §FOCUS_ELEM_
+  // CLEAR firing on that click, i.e. the main scene received it) makes misaligned content "jump into
+  // correctly", then it reverts on release. Logged on CHANGE only (not every frame — would flood) so
+  // the next live paste shows the exact timeline of every real scissor-rect recompute, each tagged
+  // with ms-since-last-call — a large gap right before a "jump" would confirm the idle-park/stale-
+  // frame theory (§IDLE_GATE self-parks the render loop; nothing in the drag path calls markDirty()
+  // except a repositioning save()) without needing to guess from a screenshot.
+  var _lastVfRenderRect = null, _lastVfRenderT = null;
   // §CPE_SCRUB_STANDALONE (2026-08-04) — where the user last dragged the standalone scrub panel,
   // same session-only scope as `_panelPos`/`_vfRect` above.
   var _scrubRect = null;
@@ -1222,9 +1231,26 @@
     document.body.appendChild(d);
     d._dragStrip = 26;
     if (a && typeof a._makeDraggable === 'function') a._makeDraggable(d);
+    _clampPanelToViewport(d, !_scrubRect);
+    // §CPE_SCRUB_PANEL_LOG (2026-08-05) — this panel had ZERO creation/drag logging at all (silent
+    // build, silent save()), so a "scrubber is missing" report had no console evidence to confirm
+    // even DOM existence, let alone position — mirrors #cpe-panel's own §CPE_PANEL_DRAGGABLE/
+    // §CPE_PANEL_MOVED log shape. `bottomOverflowPx` catches the panel's default vertical anchor
+    // (computed off B's default top, off-viewport-bottom by construction if B's own H/margins ever
+    // change) running past window.innerHeight — would read as "gone" without ever logging why.
+    // §CPE_PANEL_CLAMP measures+corrects this above; the log now reports the CLAMPED rect.
+    var _cr0 = d.getBoundingClientRect();
+    console.log('§CPE_SCRUB_PANEL_CREATED left=' + Math.round(_cr0.left) + ' top=' + Math.round(_cr0.top) +
+      ' w=' + Math.round(_cr0.width) + ' h=' + Math.round(_cr0.height) +
+      ' zIndex=' + getComputedStyle(d).zIndex + ' viewport=' + window.innerWidth + 'x' + window.innerHeight +
+      ' bottomOverflowPx=' + Math.max(0, Math.round(_cr0.bottom - window.innerHeight)) +
+      ' cpePanel=' + _overlapWithCpePanel(_cr0) + (_scrubRect ? ' (restored)' : ' (default)'));
     var save = function() {
       var r = d.getBoundingClientRect();
       _scrubRect = { left: Math.round(r.left), top: Math.round(r.top) };
+      console.log('§CPE_SCRUB_PANEL_MOVED left=' + _scrubRect.left + ' top=' + _scrubRect.top +
+        ' bottomOverflowPx=' + Math.max(0, Math.round(r.bottom - window.innerHeight)) +
+        ' cpePanel=' + _overlapWithCpePanel(r) + ' (remembered for this session)');
     };
     d.addEventListener('pointerup', save);
     return d;
@@ -1371,17 +1397,50 @@
     try { if (typeof window.tmGetState === 'function') { var tm = window.tmGetState(); if (tm && tm.active) ms = tm.cursor; } } catch (e) {}
     el.textContent = ms != null ? new Date(ms).toISOString().slice(0, 10) : '';
   }
+  // §CPE_PANEL_CLEAR_VF (2026-08-05, follow-on to the scrub panel's own §CPE_PANEL_CLEAR fix) —
+  // B's default was NEVER actually moved off the right-anchored formula the scrub panel's fix
+  // replaced; a4c24da/PR#1195 only touched _buildScrubPanel's default despite its own commit
+  // message claiming both. Confirmed by direct code read, not a screenshot: this function's old
+  // default was `canvasWidth - VF_DEFAULT_W - VF_MARGIN` (right edge) at z-index:9998 — BELOW
+  // #cpe-panel's z-index:10000 (top:60,right:12,width:412) — so B could land inside that same
+  // right-hand column AND render behind it. Left-anchored now, matching the scrub panel's own
+  // fix exactly, z-index raised to 10001 (same as the scrub panel, above #cpe-panel).
+  function _overlapWithCpePanel(r) {
+    var cp = document.getElementById('cpe-panel');
+    if (!cp) return 'n/a (#cpe-panel not open)';
+    var c = cp.getBoundingClientRect();
+    var ox = Math.max(0, Math.min(r.left + r.width, c.left + c.width) - Math.max(r.left, c.left));
+    var oy = Math.max(0, Math.min(r.top + r.height, c.top + c.height) - Math.max(r.top, c.top));
+    return (ox > 0 && oy > 0) ? ('OVERLAP ' + Math.round(ox) + 'x' + Math.round(oy) + 'px') : 'clear';
+  }
+  // §CPE_PANEL_CLAMP (2026-08-05) — the scrub panel's default top was computed from B's DEFAULT_H
+  // constant plus a fixed gap, assuming a fixed total panel height that was never actually measured
+  // against the real rendered height (font metrics, border, padding) — confirmed 17px past the
+  // viewport bottom by witness_dlod... no, witness_cpe_scrub_viewfinder.js's own new G-SCRUB-PANEL-LOG
+  // gate (bottomOverflowPx=17). Rather than hand-tune the estimate again (same class of bug), measure
+  // the REAL rect after append and clamp against the actual viewport — robust to content changes.
+  // ONLY clamps the default-position path — a user's own explicit drag (_vfRect/_scrubRect already
+  // set) is left alone even if it now overflows (e.g. after a window resize), matching this
+  // codebase's existing "remembered position" convention elsewhere.
+  function _clampPanelToViewport(d, isDefaultPos) {
+    if (!isDefaultPos) return;
+    var r = d.getBoundingClientRect();
+    var overflowBottom = r.bottom - (window.innerHeight - VF_MARGIN);
+    if (overflowBottom > 0) d.style.top = (r.top - overflowBottom) + 'px';
+    var overflowRight = r.right - (window.innerWidth - VF_MARGIN);
+    if (overflowRight > 0) d.style.left = (r.left - overflowRight) + 'px';
+  }
   function _buildVFPanel() {
     var a = A();
     var rect = _vfRect || {
-      left: Math.max(VF_MARGIN, (a.canvas ? a.canvas.clientWidth : window.innerWidth) - VF_DEFAULT_W - VF_MARGIN),
+      left: VF_MARGIN,
       top: (a.canvas ? a.canvas.clientHeight : window.innerHeight) - VF_DEFAULT_H - VF_MARGIN - 40,
       width: VF_DEFAULT_W, height: VF_DEFAULT_H
     };
     var d = document.createElement('div');
     d.id = 'cpe-vf-panel';
     d.style.cssText = 'position:fixed;left:' + rect.left + 'px;top:' + rect.top + 'px;' +
-      'width:' + rect.width + 'px;height:' + rect.height + 'px;z-index:9998;' +
+      'width:' + rect.width + 'px;height:' + rect.height + 'px;z-index:10001;' +
       'border:2px solid #4fc3f7;border-radius:4px;box-shadow:0 4px 20px rgba(0,0,0,0.5);' +
       'background:transparent;pointer-events:none';
     d.innerHTML =
@@ -1396,9 +1455,24 @@
     document.body.appendChild(d);
     d._dragStrip = 22;
     if (a && typeof a._makeDraggable === 'function') a._makeDraggable(d);
+    _clampPanelToViewport(d, !_vfRect);
+    // §CPE_VF_PANEL_LOG (2026-08-05) — B's panel had ZERO creation/drag logging (unlike #cpe-panel's
+    // own §CPE_PANEL_DRAGGABLE/§CPE_PANEL_MOVED pair), so the console during a live repro carried no
+    // evidence at all for either the wrong-default-position bug this same edit fixes, or a reported
+    // "snaps back after drag release" symptom. Mirrors #cpe-panel's exact log shape, plus the
+    // overlap-with-#cpe-panel check computed directly rather than guessed from screenshots.
+    // §CPE_PANEL_CLAMP measures+corrects this above; the log now reports the CLAMPED rect.
+    var _cr0 = d.getBoundingClientRect();
+    console.log('§CPE_VF_PANEL_CREATED left=' + Math.round(_cr0.left) + ' top=' + Math.round(_cr0.top) +
+      ' w=' + Math.round(_cr0.width) + ' h=' + Math.round(_cr0.height) +
+      ' zIndex=' + getComputedStyle(d).zIndex + ' cpePanel=' + _overlapWithCpePanel(_cr0) +
+      (_vfRect ? ' (restored)' : ' (default)'));
     var save = function() {
       var r = d.getBoundingClientRect();
       _vfRect = { left: Math.round(r.left), top: Math.round(r.top), width: Math.round(r.width), height: Math.round(r.height) };
+      console.log('§CPE_VF_PANEL_MOVED left=' + _vfRect.left + ' top=' + _vfRect.top +
+        ' w=' + _vfRect.width + ' h=' + _vfRect.height + ' cpePanel=' + _overlapWithCpePanel(r) +
+        ' (remembered for this session)');
       // §CPE_VF_ALIGN_DIAG_V2: re-arm the one-shot diagnostic so the NEXT _vfRender() frame logs
       // fresh numbers for this new drag/resize pose — a misalignment report is more likely to
       // follow a reposition than the untouched default.
@@ -1446,6 +1520,17 @@
     var yTop = Math.round((panelR.top - canvasR.top) * pr);
     var canvasH = Math.round(canvasR.height * pr);
     var y = canvasH - yTop - h;   // three.js scissor/viewport origin is bottom-left
+    // §CPE_VF_RENDER_TRACE — see the var declaration's comment for why. Fires on ANY change to the
+    // computed scissor rect, every call (not gated by _vfDiagLogged's one-shot).
+    var _t0trace = performance.now();
+    if (!_lastVfRenderRect || _lastVfRenderRect.x !== x || _lastVfRenderRect.y !== y ||
+        _lastVfRenderRect.w !== w || _lastVfRenderRect.h !== h) {
+      var _gapMs = _lastVfRenderT == null ? -1 : Math.round(_t0trace - _lastVfRenderT);
+      console.log('§CPE_VF_RENDER_TRACE x=' + x + ' y=' + y + ' w=' + w + ' h=' + h +
+        ' panelR={' + Math.round(panelR.left) + ',' + Math.round(panelR.top) + '} gapSinceLastCallMs=' + _gapMs);
+      _lastVfRenderRect = { x: x, y: y, w: w, h: h };
+    }
+    _lastVfRenderT = _t0trace;
     // §CPE_VF_ALIGN_DIAG (2026-08-05, user-reported: rendered content sits right of the panel
     // border) — one-shot per toggle-on, not every frame. Prints every number the scissor math
     // depends on PLUS the renderer's actual backing-buffer size (ground truth — canvasR.width*pr

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -13,6 +13,10 @@
 // ISSUE EACH GATE PROVES OR DISPROVES:
 //   G-SCRUB-STANDALONE  the scrub panel exists in the DOM as soon as the editor opens, BEFORE B is
 //                       ever toggled on — proves the panel is independent of B, not nested/gated.
+//   G-SCRUB-PANEL-LOG   the scrub panel logs its own creation (was completely silent before) —
+//                       left-anchored, no viewport-bottom overflow, clear of #cpe-panel.
+//   G-VF-PANEL-CLEAR    B's panel logs its own creation (also previously silent) — left-anchored,
+//                       NOT the old right-anchor-into-#cpe-panel's-column bug, z-index above it.
 //   G-SCRUB-NOCAM       the main camera's position AND orbit target are byte-identical before/after
 //                       a scrub drag (B off) — the regression gate, unchanged in spirit since #1177.
 //   G-SCRUB-VISUAL      a scrub drag still updates the playhead and the "mm:ss / mm:ss" readout text.
@@ -83,6 +87,22 @@ async function gates(browser, BLD, repoDir) {
     standalone.track && standalone.panel && standalone.vfOn === false,
     `trackPresent=${standalone.track} panelPresent=${standalone.panel} vfOnAtOpen=${standalone.vfOn}`);
 
+  // ── G-SCRUB-PANEL-LOG: the scrub panel logs its own creation (was completely silent before —
+  // no console evidence existed for a "scrubber is missing" report). Real numbers, not a screenshot:
+  // left-anchored (not off past the viewport bottom), clear of #cpe-panel.
+  const scrubCreated = logs.find(l => l.startsWith('§CPE_SCRUB_PANEL_CREATED'));
+  let scrubLogOk = false, scrubLogDetail = 'no §CPE_SCRUB_PANEL_CREATED line seen';
+  if (scrubCreated) {
+    const m = /left=(-?\d+).*bottomOverflowPx=(\d+).*cpePanel=(\S+)/.exec(scrubCreated);
+    if (m) {
+      const left = +m[1], overflow = +m[2], cpePanel = m[3];
+      scrubLogOk = left < 100 && overflow === 0 && cpePanel !== 'OVERLAP';
+      scrubLogDetail = `left=${left} bottomOverflowPx=${overflow} cpePanel=${cpePanel}`;
+    }
+  }
+  P('G-SCRUB-PANEL-LOG scrub panel logs its own creation: left-anchored, no viewport overflow, clear of #cpe-panel',
+    scrubLogOk, scrubLogDetail);
+
   // ── G-SCRUB-NOCAM: the regression gate — no MAIN camera move during a scrub drag, B still off ───
   const before1 = await page.evaluate(() => {
     const A = window.APP;
@@ -115,6 +135,24 @@ async function gates(browser, BLD, repoDir) {
   // ── toggle B on — shared setup for G-SCRUB-VF-LIVE, G-SCRUB-PERSISTS, G-VF-1, G-VF-2, G-PERF-1 ──
   const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
   await sleep(300);
+
+  // ── G-VF-PANEL-CLEAR: B's default position was NEVER actually fixed by the earlier "clear of
+  // #cpe-panel" commit (only the scrub panel's was, despite that commit's own message claiming
+  // both) — confirmed by direct code read, fixed in this same edit. B's own creation log (also
+  // previously silent) now proves it live: left-anchored (not the old canvasWidth-derived right
+  // anchor), z-index above #cpe-panel's, no overlap.
+  const vfCreated = logs.find(l => l.startsWith('§CPE_VF_PANEL_CREATED'));
+  let vfLogOk = false, vfLogDetail = 'no §CPE_VF_PANEL_CREATED line seen';
+  if (vfCreated) {
+    const m = /left=(-?\d+).*zIndex=(\d+).*cpePanel=(\S+)/.exec(vfCreated);
+    if (m) {
+      const left = +m[1], zIndex = +m[2], cpePanel = m[3];
+      vfLogOk = left < 100 && zIndex >= 10001 && cpePanel !== 'OVERLAP';
+      vfLogDetail = `left=${left} zIndex=${zIndex} cpePanel=${cpePanel}`;
+    }
+  }
+  P('G-VF-PANEL-CLEAR B\'s panel logs its own creation: left-anchored (not the old right-anchor bug), z-index above #cpe-panel, clear of it',
+    vfLogOk, vfLogDetail);
 
   // ── G-SCRUB-VF-LIVE: with B on, scrub drives B's camera to plan.poseAt(tn); main stays untouched ─
   const before2 = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
Three concrete bugs, found by direct code read + witness-verified, not screenshot guessing (user pushback this session, correctly — abandoned live-browser DOM probing after repeated Puppeteer timeouts on the large Hospital building, went to static code analysis + witness assertions instead).

1. **B's (POV panel) default position/z-index were never actually fixed.** The earlier "clear of #cpe-panel" work (PR #1195) only touched the scrub panel's default despite its own commit message claiming both. `_buildVFPanel`'s default was still right-anchored (`canvasWidth - VF_DEFAULT_W - MARGIN`, same column as `#cpe-panel`) at `z-index:9998` — below `#cpe-panel`'s 10000. Fixed: left-anchored, z-index 10001.

2. **Scrub panel's default vertical position overflowed the viewport bottom by 17px** — confirmed by a new witness gate, not eyeballed. Added `_clampPanelToViewport()`: measures the real rect after append and corrects against the actual viewport, only on the default-position path (an explicit user drag is left alone).

3. **Both panels had zero creation/drag-release logging** — unlike `#cpe-panel`'s own `§CPE_PANEL_DRAGGABLE`/`§CPE_PANEL_MOVED` pair, so a live console paste mid-session had no evidence for either bug above, or for a separately reported "content snaps back after drag release" symptom. Added matching logs for both panels.

Also added `§CPE_VF_RENDER_TRACE`: change-triggered logging of `_vfRender`'s computed scissor rect with ms-since-last-call, targeting a live report that clicking inside B's box (passes through to the main scene — confirmed by `[RP-TB] §FOCUS_ELEM_CLEAR` firing in the user's own pasted log) makes misaligned content "jump into correctly" then revert on release. Working theory: the render loop self-parks (`§IDLE_GATE`) and nothing in the drag path calls `markDirty()` except a repositioning `save()` — needs the next live repro with this trace to confirm.

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` extended with `G-SCRUB-PANEL-LOG` and `G-VF-PANEL-CLEAR` (assert on real console log lines) — 19/19 green (HHS_Office_Federated)
- [x] `bottomOverflowPx` 17 → 0, confirmed by the gate itself

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>