### PR TITLE
fix(cpe): separate B's viewfinder from main-canvas perf/DLOD state — 3 real bugs

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1549,7 +1549,13 @@
     // untouched default pose, and the v1-only one-shot could have logged an entirely different
     // instant than the one in the reported screenshot.
     if (w < 2 || h < 2) return;   // panel dragged fully off-canvas — nothing to draw
-    _state.vfCam.aspect = w / h;
+    // §CPE_VF_ASPECT_ROUND (2026-08-05): aspect from the TRUE CSS box (panelR, unrounded), not from
+    // w/h — those are two INDEPENDENTLY Math.round()-ed backing-buffer pixel counts, so their ratio
+    // drifts off the real box aspect (e.g. panelR 300x190 at pr=1.25 -> w=375, h=Math.round(237.5)=238,
+    // aspect 1.5756 vs true 1.5789 — a real, provable distortion, worse at fractional pr). Small on
+    // its own, but stacked with §CPE_VF_DPR_GUARD's pr no longer flip-flopping mid-drag, this keeps
+    // the frustum matching the box exactly instead of drifting by a different amount per pr value.
+    _state.vfCam.aspect = panelR.width / panelR.height;
     _state.vfCam.updateProjectionMatrix();
     // §CPE_VF_ALIGN_DIAG / _V2 diagnostics moved to AFTER the aspect fix-up above (a real bug in
     // the diagnostic itself, caught by re-running it: logging vfCam.aspect BEFORE this line reads
@@ -2146,7 +2152,18 @@
     // wiring §CPE_SCRUB_VF_LIVE already established, no second path.
     if (!same && _state.bands[bi] && _state.bands[bi]._stick) {
       var bearTn = _bandTNorm(bi);
-      if (bearTn != null) _scrubTo(bearTn);
+      if (bearTn != null) {
+        // §CPE_SCRUB_BEARING_FLY_PAUSE (2026-08-05) — a real click landed here fine (this branch
+        // ran, _scrubTo did move vfCam) but a REHEARSAL IN PROGRESS overwrote it within one rAF
+        // frame: _previewFly's step() applies plan.poseAt(elapsedTimeFraction) to vfCam every
+        // frame regardless of _state.scrubTn, so a click-driven pose lasted <16ms before the
+        // flight's own tick silently replaced it — invisible to the user, no error, exactly
+        // "clicking a stick does not move B's inset" while playing. Pause the rehearsal at the
+        // click, same as the transport's own pause button (line ~1696) — the bearing then sticks
+        // where the user actually clicked, instead of racing the flight's own clock.
+        if (_state.flying && !_state.flyPaused && _state._flyPauseAt) _state._flyPauseAt();
+        _scrubTo(bearTn);
+      }
     }
     _redrawScene(); _renderRows(); _renderHint(); _syncButtons();
     _pulse();
@@ -3011,6 +3028,7 @@
             on: !!_state.vfOn,
             hookInstalled: a._cpeViewfinderRender === _vfRender,
             camPose: _state.vfCam ? { x: _state.vfCam.position.x, y: _state.vfCam.position.y, z: _state.vfCam.position.z } : null,
+            vfCamAspect: _state.vfCam ? _state.vfCam.aspect : null,
             mainPose: { x: a.camera.position.x, y: a.camera.position.y, z: a.camera.position.z },
             // §CPE_SCRUB correction ground truth: the main canvas's ORBIT TARGET, not just its
             // position — a scrub-caused main-camera move could show up as a target drift alone

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -710,7 +710,15 @@ async function initViewer() {
     // made the re-arm branch dead code and let Stage 2 fire mid-gesture (the ghosting report).
     if ((APP._stillRefineActive || APP._photoAutoStageOn) && typeof APP.softStopStillRefine === 'function') APP.softStopStillRefine();
     _startLoop(); // §IDLE-PARK: drag begins → revive the loop if parked
-    if (!_orbiting && APP.streamedCount > 5000) {
+    // §CPE_VF_DPR_GUARD (2026-08-05): skip the perf-DPR drop while the cinema path editor's POV
+    // inset (B) is open. B's own scissor render (cinema_path_editor.js _vfRender) reads
+    // renderer.getPixelRatio() fresh every frame, so a mid-drag pr flip between _fullDPR and
+    // _orbitDPR — invisible on the main view (browser upscales the whole canvas uniformly) —
+    // shows up as B's small inset box visibly resizing/rescaling frame to frame (§CPE_VF_RENDER_TRACE
+    // logged x/y/w/h changing while panelR stayed fixed). This LOD trick exists purely for main-canvas
+    // orbit smoothness on large buildings; B is a tiny sub-render, not worth degrading, and coupling
+    // it to a main-canvas-only heuristic is exactly the entanglement the user flagged — separate them.
+    if (!_orbiting && APP.streamedCount > 5000 && !APP._cpeViewfinderRender) {
       _orbiting = true;
       APP.renderer.setPixelRatio(_orbitDPR);
     }

--- a/viewer/tests/witness_dlod_vf_camguard.js
+++ b/viewer/tests/witness_dlod_vf_camguard.js
@@ -118,5 +118,22 @@ const app = { camera: mainCam };
   assert(callSiteRe.test(tmSrc), 'renderAtTime\'s _dlodCamMoved edge-detector calls _giHoldCamSig(app, _dlodActiveCam), not _giHoldCamSig(app) alone');
 }
 
+// ── Case 8: §DLOD_VF_MATRIX_STALE (2026-08-05, follow-on) — static: renderAtTime must force
+// _dlodActiveCam.updateMatrixWorld() BEFORE reading matrixWorldInverse for the frustum. renderAtTime
+// runs off Time Machine's OWN setTimeout ticker, never synchronized with the rAF loop that normally
+// refreshes a camera's matrix via renderer.render() — app.camera gets refreshed every rAF frame
+// regardless, but vfCam ONLY via cinema_path_editor.js's _vfRender(), itself gated behind the same
+// rAF loop. Without the explicit update, a POV rehearsal can build the DLOD frustum from a stale
+// vfCam pose one or more _applyVFPose() moves behind — user-reported as the inset "ends up looking
+// at nothing" mid-rehearsal.
+{
+  const psmIdx = tmSrc.indexOf('_dlodPSM.multiplyMatrices(_dlodActiveCam.projectionMatrix');
+  const resolveIdx = tmSrc.indexOf('var _dlodActiveCam = _dlodResolveCamera(app);');
+  const updateIdx = tmSrc.indexOf('_dlodActiveCam.updateMatrixWorld();');
+  assert(resolveIdx > 0 && updateIdx > resolveIdx && psmIdx > updateIdx,
+    '_dlodActiveCam.updateMatrixWorld() is called after resolving the camera and before the PSM/frustum build ' +
+    `(resolveIdx=${resolveIdx} updateIdx=${updateIdx} psmIdx=${psmIdx})`);
+}
+
 console.log('\n§DLOD_VF_CAMGUARD SUMMARY pass=' + pass + ' fail=' + fail);
 process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1312,6 +1312,20 @@
         if (!_dlodFrustum) { _dlodFrustum = new THREE.Frustum(); _dlodPSM = new THREE.Matrix4(); _dlodSphere = new THREE.Sphere(); }
         // §DLOD_VF_CAMGUARD — gate against whichever camera the user is actually looking through.
         var _dlodActiveCam = _dlodResolveCamera(app);
+        // §DLOD_VF_MATRIX_STALE (2026-08-05) — this function runs off Time Machine's OWN setTimeout
+        // ticker (_playTimer, see playTick), never synchronized with the rAF-driven animate() loop.
+        // app.camera's matrixWorld/matrixWorldInverse get refreshed every rAF frame because
+        // renderer.render(scene, app.camera) runs there unconditionally. vfCam's ONLY gets refreshed
+        // by cinema_path_editor.js's own _vfRender(), itself gated behind the SAME rAF loop's
+        // needsRender check — so on a POV-only rehearsal, whichever of these two independent timers
+        // (TM's setTimeout vs. rAF) happens to fire first in a given moment can read vfCam's matrix
+        // BEFORE this tick's _applyVFPose() move has actually reached it, i.e. the frustum below is
+        // built from the WRONG pose. updateMatrixWorld() recomputes both matrixWorld and
+        // matrixWorldInverse from whatever position/quaternion _applyVFPose already set — cheap
+        // (single camera, not a scene traverse) and makes this tick's frustum correct regardless of
+        // which timer got here first. This is exactly the vfCam-goes-blank mechanism named in the
+        // prior session's handoff ("vfCam ends up looking at nothing").
+        _dlodActiveCam.updateMatrixWorld();
         _dlodCamPos = _dlodActiveCam.position;
         _dlodPSM.multiplyMatrices(_dlodActiveCam.projectionMatrix, _dlodActiveCam.matrixWorldInverse);
         _dlodFrustum.setFromProjectionMatrix(_dlodPSM);
@@ -1360,7 +1374,7 @@
     if (_incrOK) _incrStats.delta++; else _incrStats.full++;
     _lastShadowOn = _shadowNow;
 
-    var _perfT0 = performance.now(), _perfObjs = 0, _perfSkipped = 0;
+    var _perfT0 = performance.now(), _perfObjs = 0, _perfSkipped = 0, _perfHideForProxy = 0;
     app.scene.traverse(function(obj) {
       _perfObjs++;
       if (!obj.userData) return;
@@ -1374,6 +1388,7 @@
         // §DLOD_TM landmine-5 guard (double-draw): hideForProxy can only be true for placed-only
         // elements — isFrontier already excludes it, so real-mesh and box visibility stay disjoint.
         var hideForProxy = _dlodOn && isPlaced && !isFrontier && !isRecent && !_dlodInView(g);
+        if (hideForProxy) _perfHideForProxy++;
         var showReal = (isRecent || isPlaced) && !hideForProxy;
 
         // Visibility + highlighting
@@ -1588,6 +1603,19 @@
     // on the throttled log. Read via window.__tmTrav in a probe.
     window.__tmTrav = { ms: +_travMs.toFixed(1), objs: _perfObjs, skipped: _perfSkipped,
                         mode: _incrOK ? 'delta' : 'full' };
+    // §DLOD_VF_VISCOUNT (2026-08-05) — every tick while DLOD is engaged AND a POV camera (not main)
+    // is the active gate, per the prior session's ask: "add a log of visible-element-count from
+    // vfCam's perspective... at the moment _vfRender()'s box goes visually blank". Not throttled
+    // like §PERF_TRAVERSE — only fires while B is on, so volume is bounded by rehearsal length, not
+    // general use. hideForProxy climbing toward objs (few/no real meshes left near the camera) at
+    // the SAME tick the user reports "blank" would confirm the DLOD-culling theory directly; staying
+    // low would point elsewhere (e.g. scissor/viewport, see §CPE_VF_RENDER_TRACE).
+    if (_dlodOn && _dlodActiveCam !== app.camera) {
+      window.__tmDlodVf = { hideForProxy: _perfHideForProxy, objs: _perfObjs,
+        camPos: { x: +_dlodCamPos.x.toFixed(2), y: +_dlodCamPos.y.toFixed(2), z: +_dlodCamPos.z.toFixed(2) } };
+      console.log('§DLOD_VF_VISCOUNT hideForProxy=' + _perfHideForProxy + ' objs=' + _perfObjs +
+        ' camPos=' + JSON.stringify(window.__tmDlodVf.camPos));
+    }
     _incrPrimed = true;   // a full pass has now established slot state for every mesh
     // §GROUP_SPARK: emit AFTER the traverse — capping and per-group random selection need the
     // whole candidate set, which spawn-as-you-find (the reverted #866 shape) cannot provide.

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -340,6 +340,42 @@ async function gates(browser, BLD, repoDir) {
     dPovPos < 1e-9 && dPovTgt < 1e-9,
     `mainPosDelta=${dPovPos.toExponential(2)}m mainTargetDelta=${dPovTgt.toExponential(2)}m`);
 
+  // ── G-SCRUB-BEARING-FLY-PAUSE: §CPE_SCRUB_BEARING_FLY_PAUSE (2026-08-05) — the flight from
+  // G-SCRUB-PLAY-POVONLY above is STILL ACTIVELY PLAYING at this point (resumed, not re-paused).
+  // Clicking a stick while flying used to be silently overwritten within one rAF frame: _hold's
+  // _scrubTo(bearTn) moved vfCam once, but _previewFly's own step() applies plan.poseAt(elapsed-
+  // time-fraction) to vfCam EVERY frame regardless of _state.scrubTn, so the click-driven pose
+  // never survived to the next paint — reproduces the user's "clicking a stick does not move B's
+  // inset" report exactly, and explains why the earlier G-SCRUB-BEARING gate (flight NOT running)
+  // passed while the same code failed live. Fix: selecting a stick now pauses an in-progress flight
+  // (same _flyPauseAt hook the transport's own pause button uses), so the bearing sticks.
+  const flyBearing = stickCount ? await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const beforeFly = cpe._flyState();
+    const target = cpe._probeScrub().sticks[0];
+    cpe._holdForTest(target.i, 'lo');   // different zone than G-SCRUB-BEARING's 'mid' -> !same, re-fires
+    const afterHold = cpe._flyState();
+    return { beforeFly, afterHold, targetTn: target.tNorm, p: cpe._probePoseAt(target.tNorm) };
+  }) : null;
+  await sleep(400);   // real wait — if the click didn't actually pause it, step() would move vfCam again
+  const flyBearingAfterWait = flyBearing ? await page.evaluate(() => window.APP.cinemaPathEditor._probeVF().camPose) : null;
+  let flyBearOk = false, flyBearDetail = 'no sticks on this building — inconclusive';
+  if (flyBearing) {
+    const dVfBear = (flyBearingAfterWait && flyBearing.p)
+      ? Math.hypot(flyBearingAfterWait.x - flyBearing.p.x, flyBearingAfterWait.y - flyBearing.p.y, flyBearingAfterWait.z - flyBearing.p.z) : null;
+    flyBearOk = flyBearing.beforeFly.flying && !flyBearing.beforeFly.paused &&
+      flyBearing.afterHold.flying && flyBearing.afterHold.paused &&
+      dVfBear != null && dVfBear < 1e-6;
+    flyBearDetail = `wasFlying=${flyBearing.beforeFly.flying} wasPaused=${flyBearing.beforeFly.paused} ` +
+      `pausedByClick=${flyBearing.afterHold.paused} vfCamDeltaAfter400msWait=${dVfBear == null ? 'n/a' : dVfBear.toExponential(2) + 'm'} (must stay ~0 — step() must not overwrite it)`;
+  }
+  P('G-SCRUB-BEARING-FLY-PAUSE clicking a stick DURING an active flight pauses it and the bearing survives (not overwritten next frame)',
+    flyBearOk, flyBearDetail);
+  // Clean up: the click above paused the flight (that's the fix under test) — resume it so the
+  // G-VF-2b/G-PERF-1a gates below, which wait for this SAME flight to reach its natural
+  // §CPE_PREVIEW done completion, still see it finish rather than time out.
+  await page.evaluate(() => { const cpe = window.APP.cinemaPathEditor; if (cpe._flyState().paused) cpe._flyResume(); });
+
   // Poll for a non-empty readout the same way the original gate did (post-resume).
   let vf2 = null;
   const vfT0 = Date.now();
@@ -382,6 +418,53 @@ async function gates(browser, BLD, repoDir) {
   const bakeClean = !maxqSrc.includes('_cpeViewfinderRender');
   P('G-PERF-1b static: cinema_maxq.js (the MaxQ bake loop) has zero references to the viewfinder render hook',
     bakeClean, `occurrences=${(maxqSrc.match(/_cpeViewfinderRender/g) || []).length}`);
+
+  // ── G-VF-DPR-GUARD: §CPE_VF_DPR_GUARD (2026-08-05) — the orbit-drag perf-DPR drop (§S260b, only
+  // engages once APP.streamedCount>5000) must NOT fire while B is open, since it flips
+  // renderer.getPixelRatio() mid-drag with B's own panel position unchanged — exactly the
+  // frame-to-frame scale churn §CPE_VF_RENDER_TRACE caught live ("much nearer not fully inside").
+  // Probe with a pr value (9.99) neither _fullDPR nor _orbitDPR can ever naturally equal, so the
+  // assertion doesn't depend on this headless page's real devicePixelRatio.
+  const dprGuard = await page.evaluate(() => {
+    const savedCount = window.APP.streamedCount;
+    window.APP.streamedCount = 6000;
+    window.APP.renderer.setPixelRatio(9.99);
+    window.APP.controls.dispatchEvent({ type: 'start' });
+    const duringVfOn = window.APP.renderer.getPixelRatio();
+    window.APP.controls.dispatchEvent({ type: 'end' });
+    window.APP.cinemaPathEditor._vfToggle();   // B off
+    window.APP.renderer.setPixelRatio(9.99);
+    window.APP.controls.dispatchEvent({ type: 'start' });
+    const duringVfOff = window.APP.renderer.getPixelRatio();
+    window.APP.controls.dispatchEvent({ type: 'end' });
+    window.APP.cinemaPathEditor._vfToggle();   // B back on — restore state for any later gate
+    window.APP.streamedCount = savedCount;
+    return { duringVfOn, duringVfOff };
+  });
+  P('G-VF-DPR-GUARD B open skips the orbit-drag DPR drop (pr unchanged); B closed still applies it',
+    dprGuard.duringVfOn === 9.99 && dprGuard.duringVfOff !== 9.99,
+    `duringVfOn(pr)=${dprGuard.duringVfOn} (expect unchanged=9.99) duringVfOff(pr)=${dprGuard.duringVfOff} (expect changed, proves the guard — not devicePixelRatio coincidence — is what held it at 9.99 above)`);
+
+  // ── G-VF-ASPECT: §CPE_VF_ASPECT_ROUND (2026-08-05) — vfCam.aspect must come from the TRUE CSS
+  // panelR.width/height, not from two independently-rounded backing-buffer pixel counts (w/h),
+  // whose ratio drifts off the real box aspect at fractional pixel ratios.
+  const aspectCheck = await page.evaluate(() => {
+    const panel = document.getElementById('cpe-vf-panel');
+    const r = panel.getBoundingClientRect();
+    window.APP.renderer.setPixelRatio(1.37);   // deliberately fractional, to expose rounding drift
+    window.APP.markDirty();
+    return new Promise(resolve => {
+      setTimeout(() => {
+        const trueAspect = r.width / r.height;
+        const vfAspect = window.APP.cinemaPathEditor._probeVF().vfCamAspect;
+        resolve({ trueAspect, vfAspect });
+      }, 200);
+    });
+  });
+  const aspectDiff = aspectCheck.vfAspect != null ? Math.abs(aspectCheck.vfAspect - aspectCheck.trueAspect) : null;
+  P('G-VF-ASPECT vfCam.aspect matches the box\'s true (unrounded) CSS aspect, even at a fractional pixel ratio',
+    aspectDiff != null && aspectDiff < 1e-6,
+    `trueAspect=${aspectCheck.trueAspect} vfCamAspect=${aspectCheck.vfAspect} diff=${aspectDiff}`);
 
   // ── G-SCRUB-CLOSE-TEARDOWN: closing the editor (Cancel) removes the scrub panel ─────────────────
   await page.evaluate(() => document.getElementById('cpe-cancel').click());


### PR DESCRIPTION
## Summary
Continuation of prompts/CINEMA_PATH_EDITOR.md's 2026-08-05 session handoff — the three open, evidence-backed bugs from the live Hospital repro, all root-caused by code reading + witness (no screenshots/guessing per project rule).

- **§CPE_VF_DPR_GUARD** — main.js's orbit-drag perf-DPR drop (`streamedCount>5000`) flipped `renderer.getPixelRatio()` mid-drag while B's panel stayed put, causing B's scissor box to visibly rescale frame-to-frame ("much nearer not fully inside"). B is now excluded from that main-canvas-only heuristic. Also fixed a small real aspect-rounding drift (§CPE_VF_ASPECT_ROUND) — `vfCam.aspect` now comes from the true unrounded CSS box instead of two independently-rounded pixel counts.
- **§DLOD_VF_MATRIX_STALE** — Time Machine's `renderAtTime()` runs off its own `setTimeout` ticker, never synced to the rAF loop that normally refreshes a camera's `matrixWorld`. vfCam only got refreshed via `_vfRender()`, gated behind that same rAF loop — so a POV rehearsal could build the DLOD visibility frustum from a stale vfCam pose ("preview does not play but becomes blank"). Now forces `updateMatrixWorld()` on the resolved camera before the frustum build. Added `§DLOD_VF_VISCOUNT` diagnostic logging for any future live repro.
- **§CPE_SCRUB_BEARING_FLY_PAUSE** — clicking a stick during an active rehearsal moved vfCam once via `_scrubTo`, but `_previewFly`'s own `step()` overwrote it within ~16ms with the flight's own elapsed-time pose — invisible to the user ("clicking a stick does not move B's inset"). Selecting a stick now pauses an in-progress flight first, same hook the transport's pause button already uses.

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` — 22/22 green (HHS_Office_Federated), incl. 3 new gates (G-VF-DPR-GUARD, G-VF-ASPECT, G-SCRUB-BEARING-FLY-PAUSE)
- [x] `viewer/tests/witness_dlod_vf_camguard.js` — 10/10 green, incl. new static ordering gate for the `updateMatrixWorld()` fix
- [x] `witness_incr_shadow_equiv.js` — 0 mismatch across 19 cursors (HHS_Office_Federated), confirms zero behavioural change off the DLOD path

🤖 Generated with [Claude Code](https://claude.com/claude-code)