### PR TITLE
fix(room-graph): log the silent no-alternative revisit fallback

### DIFF
--- a/common/room_graph.js
+++ b/common/room_graph.js
@@ -1491,6 +1491,17 @@
             } else if (alt && alt.length) {
               _log('§PATH_LEGAL_DETOUR_REVISIT_KEPT storey=' + a.storey + ' the only revisit-free detour is ' +
                 'longer (' + chainLen(mid).toFixed(1) + 'm -> ' + chainLen(alt).toFixed(1) + 'm) — keeping the shorter line');
+            } else {
+              // §PATH_LEGAL_DETOUR_REVISIT_FORCED (2026-08-05, real gap caught in review): the two
+              // branches above only fire when a revisit-free ALTERNATIVE exists (chosen either
+              // because it's shorter, or kept-anyway because it's longer). When no such alternative
+              // exists at all (`alt` null/empty — the revisit is the ONLY legal route), neither branch
+              // fired and the revisit was kept with ZERO log line — indistinguishable in the log from
+              // a clean detour with no revisit at all. Detecting the revisit was already correct; this
+              // just makes the "kept because it's the only option" case as visible as the "kept
+              // because shorter" case above, per this project's no-silent-fallback Log Mandate.
+              _log('§PATH_LEGAL_DETOUR_REVISIT_FORCED storey=' + a.storey + ' no revisit-free detour exists ' +
+                'at all (' + revisits.length + ' unavoidable waypoint(s): ' + revisits.join(',') + ') — keeping the only route');
             }
           }
         }


### PR DESCRIPTION
## Summary
- `_legalizePath`'s revisit-guard logs two of its three outcomes (found a shorter revisit-free alternative → `§DETOUR_NOREVISIT`; kept a longer one anyway → `§DETOUR_REVISIT_KEPT`). The third — no revisit-free alternative exists at all — fell through silently, indistinguishable in the log from a clean detour.
- Adds `§PATH_LEGAL_DETOUR_REVISIT_FORCED` for that case. Log-only change: the new branch is a single `_log()` call, no state or control-flow change, so the computed route is provably unchanged.

## Test plan
- [x] Code inspection: new branch only calls `_log()`, touches nothing else.
- [x] Spot-check on a real LTU_AHouse pair that hits this branch (`RM_VÅNING_1_1 -> RM_VÅNING_2_27`) — path/doors/distance byte-identical before vs after.
- [x] Fleet-wide occurrence count (not a theoretical case): 437 real hits — 318 LTU_AHouse, 119 Clinic, 0 elsewhere.

Companion PR: #1200 (unrelated fix, different branch, found in the same review session).