### PR TITLE
fix(cpe): eye toggle now drives the timeline panel too, one control not two

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1622,15 +1622,28 @@
       // ON shows the current pose right away.
       var p = _state.plan ? _state.plan.poseAt(_state.scrubTn || 0) : null;
       if (p) { _state.vfCam.position.set(p.x, p.y, p.z); _state.vfCam.lookAt(p.tx, p.ty, p.tz); }
+      // §CPE_VF_EYE_DRIVES_SCRUB (2026-08-05, user: "closing eye to act on it similar to opening
+      // eye") — the eye toggle is the ONE control for both now, same button, no second widget.
+      // Opening the eye brings the timeline back if a prior close removed it.
+      if (!document.getElementById('cpe-scrub-panel')) {
+        _buildScrubPanel();
+        _wireScrub(document.getElementById('cpe-scrub-track'));
+        _wireScrubPlay();
+        _renderScrub();
+      }
       if (a.markDirty) a.markDirty();
-      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; display-only, no drop interaction — see §CPE_SCRUB_STANDALONE for the interactive timeline');
+      console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; display-only, no drop interaction — timeline panel shown alongside it (§CPE_VF_EYE_DRIVES_SCRUB)');
     } else {
       var panel = document.getElementById('cpe-vf-panel');
       if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
       if (a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
       if (btn) { btn.style.color = '#888'; btn.style.borderColor = '#4a4f57'; }
+      // §CPE_VF_EYE_DRIVES_SCRUB — closing the eye removes the timeline panel too, symmetric with
+      // opening it above. Position is remembered via `_scrubRect` (see _buildScrubPanel's save()),
+      // so re-opening the eye restores it where the user left it, not back at the default.
+      _scrubPanelTeardown();
       if (a.markDirty) a.markDirty();
-      console.log('§CPE_VF off — panel removed, render hook cleared, zero per-frame cost (timeline stays open — see §CPE_SCRUB_STANDALONE)');
+      console.log('§CPE_VF off — panel and timeline removed, render hook cleared, zero per-frame cost (§CPE_VF_EYE_DRIVES_SCRUB)');
     }
   }
   function _vfTeardown() {

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -27,8 +27,10 @@
 //                       spawn a new band — retires the old G-SCRUB-SPAWN gate, which asserted the
 //                       opposite (§CPE_SCRUB_READONLY: creation only via canvas/row list now).
 //   G-SCRUB-TICK-BLUE   a stick's tick mark on the bar renders in CPE_STICK_BLUE, not the old red.
-//   G-SCRUB-PERSISTS    toggling B off does NOT remove the scrub panel (opposite of the old
-//                       gated-to-B behaviour) — it only disappears when the EDITOR closes.
+//   G-EYE-DRIVES-SCRUB  toggling B off REMOVES the scrub panel too, toggling back on restores it at
+//                       its remembered position (§CPE_VF_EYE_DRIVES_SCRUB, 2026-08-05 — direct user
+//                       instruction, one control for both, not a second widget) — retires the older
+//                       G-SCRUB-PERSISTS gate, which asserted the opposite (independent of B).
 //   G-SCRUB-PLAY        pressing play starts a rehearsal; pause freezes the flight fraction (no
 //                       advance over a real wait); resume continues it — real pause/resume, not a
 //                       screenshot-verified "looks paused".
@@ -132,7 +134,7 @@ async function gates(browser, BLD, repoDir) {
     before1.scrubLabel !== after1.scrubLabel,
     `before="${before1.scrubLabel}" after="${after1.scrubLabel}"`);
 
-  // ── toggle B on — shared setup for G-SCRUB-VF-LIVE, G-SCRUB-PERSISTS, G-VF-1, G-VF-2, G-PERF-1 ──
+  // ── toggle B on — shared setup for G-SCRUB-VF-LIVE, G-EYE-DRIVES-SCRUB, G-VF-1, G-VF-2, G-PERF-1 ──
   const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
   await sleep(300);
 
@@ -251,15 +253,31 @@ async function gates(browser, BLD, repoDir) {
   }
   P('G-SCRUB-NOSPAWN a click on the bar scrubs to that point, never spawns a stick', g2ok, g2detail);
 
-  // ── G-SCRUB-PERSISTS: toggling B off leaves the scrub panel in place ────────────────────────────
+  // ── G-EYE-DRIVES-SCRUB: §CPE_VF_EYE_DRIVES_SCRUB (2026-08-05, user: "closing eye to act on it
+  // similar to opening eye" — ONE control for both, not a second widget) — toggling B off now
+  // removes the timeline panel too, and toggling B back on restores it at its remembered position.
+  // Retires the old G-SCRUB-PERSISTS gate, which asserted the OPPOSITE (independent of B's toggle) —
+  // superseded by this direct, explicit user instruction.
+  const rectBefore = await page.evaluate(() => {
+    const r = document.getElementById('cpe-scrub-panel').getBoundingClientRect();
+    return { left: Math.round(r.left), top: Math.round(r.top) };
+  });
   const offState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
   await sleep(200);
-  const persists = await page.evaluate(() => !!document.getElementById('cpe-scrub-track'));
-  P('G-SCRUB-PERSISTS toggling B off does NOT remove the scrub panel (only editor-close does)',
-    offState === false && persists === true, `vfOn=${offState} scrubStillPresent=${persists}`);
-  // Toggle B back on — the rest of this run (G-VF-1/2, G-PERF-1) needs it on.
-  await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  const goneOnOff = await page.evaluate(() => !document.getElementById('cpe-scrub-track'));
+  const onState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
   await sleep(200);
+  const rectAfter = await page.evaluate(() => {
+    const el = document.getElementById('cpe-scrub-panel');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { left: Math.round(r.left), top: Math.round(r.top) };
+  });
+  const backOnOn = rectAfter != null;
+  const samePos = backOnOn && rectAfter.left === rectBefore.left && rectAfter.top === rectBefore.top;
+  P('G-EYE-DRIVES-SCRUB toggling B off removes the timeline panel; toggling B back on restores it at the same spot',
+    offState === false && goneOnOff && onState === true && backOnOn && samePos,
+    `vfOff removed=${goneOnOff} vfOn restored=${backOnOn} samePos=${samePos} before=${JSON.stringify(rectBefore)} after=${JSON.stringify(rectAfter)}`);
 
   // ── G-VF-1 (B on): rehearsal-style pose application — same mechanism as before, unaffected ──────
   const vf1 = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- Reverses a wrong first attempt earlier this session (a separate show/hide button for the timeline panel — user explicitly said that wasn't the ask, reverted, branch deleted).
- Correct fix: `_toggleViewfinder`'s existing ON/OFF branches now also build/tear down `#cpe-scrub-panel`, so B's eye icon is the ONE control for both, symmetric in both directions. Position is remembered across the round trip via the existing `_scrubRect` save hook.

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` — 22/22 green (HHS_Office_Federated). Replaced `G-SCRUB-PERSISTS` (asserted the opposite — independent of B) with `G-EYE-DRIVES-SCRUB`, which asserts: toggling B off removes the timeline panel, toggling back on restores it at the same remembered position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)