### PR TITLE
fix(cpe): OPEN 3 inset stretch, OPEN 4 DLOD/vfCam union, OPEN 5 scrub input trace

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1337,6 +1337,13 @@
   function _wireScrub(track) {
     var drag = null;
     track.addEventListener('pointerdown', function(ev) {
+      // §CPE_SCRUB_INPUT_TRACE (2026-08-05, OPEN 5 — "play button and track stop responding after
+      // a stick-click pause") — static reading of this handler, _wireScrubPlay, _flyPauseAt/
+      // _flyResume found no structural block. Logs on EVERY pointerdown so a repro shows whether the
+      // handler runs at all (0 lines = a DOM/listener issue, something rebuilt the track) or runs but
+      // has no visible effect (bug is downstream, in the render loop / _scrubTo / _flyResume's rAF).
+      console.log('§CPE_SCRUB_INPUT_TRACE track pointerdown flying=' + (_state ? _state.flying : 'n/a') +
+        ' flyPaused=' + (_state ? _state.flyPaused : 'n/a'));
       ev.preventDefault();
       var r = track.getBoundingClientRect();
       drag = { sx0: ev.clientX, sy0: ev.clientY, moved: false, r: r };
@@ -1350,6 +1357,10 @@
       _scrubTo(tn);
     });
     track.addEventListener('pointerup', function(ev) {
+      // §CPE_SCRUB_INPUT_TRACE — see pointerdown above. `drag` null here means pointerdown never ran
+      // for this gesture (capture lost / element swapped) — that alone would explain "stops responding".
+      console.log('§CPE_SCRUB_INPUT_TRACE track pointerup hadDrag=' + !!drag + ' flying=' +
+        (_state ? _state.flying : 'n/a') + ' flyPaused=' + (_state ? _state.flyPaused : 'n/a'));
       if (!drag) return;
       var d = drag; drag = null;
       try { track.releasePointerCapture(ev.pointerId); } catch (e) {}
@@ -1515,7 +1526,15 @@
     var t0 = performance.now();
     var canvasR = a.canvas.getBoundingClientRect(), panelR = panel.getBoundingClientRect();
     var pr = (a.renderer.getPixelRatio && a.renderer.getPixelRatio()) || 1;
-    var w = Math.max(1, Math.round(panelR.width * pr)), h = Math.max(1, Math.round(panelR.height * pr));
+    // §CPE_VF_RECT_ASPECT (2026-08-05): h from the box, w DERIVED from h*trueAspect — NOT two
+    // independently-rounded values. Two independent Math.round()s (old: w=round(300*1.25)=375,
+    // h=round(190*1.25)=238) leave the RECT's own aspect (375/238=1.5756) slightly off the box's
+    // true aspect (300/190=1.5789) even after §CPE_VF_ASPECT_ROUND fixed vfCam.aspect to the true
+    // value — so the camera's projection matrix and the viewport it's rendered into disagreed by
+    // ~0.2%, a small vertical squish. Deriving w from h makes the rect's aspect match vfCam.aspect
+    // by construction, not by coincidence.
+    var h = Math.max(1, Math.round(panelR.height * pr));
+    var w = Math.max(1, Math.round(h * (panelR.width / panelR.height)));
     var x = Math.round((panelR.left - canvasR.left) * pr);
     var yTop = Math.round((panelR.top - canvasR.top) * pr);
     var canvasH = Math.round(canvasR.height * pr);
@@ -1549,13 +1568,17 @@
     // untouched default pose, and the v1-only one-shot could have logged an entirely different
     // instant than the one in the reported screenshot.
     if (w < 2 || h < 2) return;   // panel dragged fully off-canvas — nothing to draw
-    // §CPE_VF_ASPECT_ROUND (2026-08-05): aspect from the TRUE CSS box (panelR, unrounded), not from
-    // w/h — those are two INDEPENDENTLY Math.round()-ed backing-buffer pixel counts, so their ratio
-    // drifts off the real box aspect (e.g. panelR 300x190 at pr=1.25 -> w=375, h=Math.round(237.5)=238,
-    // aspect 1.5756 vs true 1.5789 — a real, provable distortion, worse at fractional pr). Small on
-    // its own, but stacked with §CPE_VF_DPR_GUARD's pr no longer flip-flopping mid-drag, this keeps
-    // the frustum matching the box exactly instead of drifting by a different amount per pr value.
-    _state.vfCam.aspect = panelR.width / panelR.height;
+    // §CPE_VF_ASPECT_ROUND (2026-08-05) + §CPE_VF_RECT_ASPECT correction (same day, OPEN 3): aspect
+    // from w/h — the ACTUAL rounded pixel rect this frame renders into (computed above, single-
+    // rounding: h from the box, w derived from h so it tracks the true box aspect as closely as an
+    // integer pixel rect can) — not from the raw unrounded panelR.width/height. Using panelR directly
+    // (the original §CPE_VF_ASPECT_ROUND fix) matched the IDEAL box aspect but left a ~0.2% mismatch
+    // against the necessarily-integer rendered rect (w/h can never hit an irrational-ish ratio
+    // exactly) — a real, measured stretch. Setting aspect = w/h instead makes the camera's projection
+    // and the rect it's drawn into IDENTICAL by definition (same JS value), zero stretch, while w/h
+    // themselves still track the true box aspect far more closely than the old two-independently-
+    // rounded scheme did.
+    _state.vfCam.aspect = w / h;
     _state.vfCam.updateProjectionMatrix();
     // §CPE_VF_ALIGN_DIAG / _V2 diagnostics moved to AFTER the aspect fix-up above (a real bug in
     // the diagnostic itself, caught by re-running it: logging vfCam.aspect BEFORE this line reads
@@ -1704,6 +1727,10 @@
     var btn = document.getElementById('cpe-scrub-play');
     if (!btn) return;
     btn.addEventListener('click', function() {
+      // §CPE_SCRUB_INPUT_TRACE — see _wireScrub's pointerdown for why. 0 lines on a repro click
+      // means the click never reached this handler at all (DOM/listener issue).
+      console.log('§CPE_SCRUB_INPUT_TRACE play click flying=' + (_state ? _state.flying : 'n/a') +
+        ' flyPaused=' + (_state ? _state.flyPaused : 'n/a'));
       if (!_state) return;
       if (_state.flying && !_state.flyPaused) {
         if (_state._flyPauseAt) _state._flyPauseAt();

--- a/viewer/dlod.js
+++ b/viewer/dlod.js
@@ -18,11 +18,27 @@ function setupDLOD(A) {
   var EVAL_EVERY = 6;             // frames between evaluations
   var MIN_ELEMENTS = 5000;        // §S271: frustum culling for all non-trivial buildings
   var _frustum = new THREE.Frustum();
+  // §CPE_DLOD_VF_UNION (2026-08-05, CINEMA_PATH_EDITOR.md OPEN 4) — this culler zero-scales
+  // InstancedMesh instances GLOBALLY (both cameras share the same real geometry, this is not a
+  // per-camera visibility flag), but was built keyed to A.camera (the main camera) exclusively —
+  // predates B/vfCam entirely. During a POV-only rehearsal (§CPE_SCRUB_POV_ONLY) the main camera is
+  // PARKED at the overview pose for the whole flight while vfCam walks through the building, so
+  // anything the walk passes near that's outside the parked main frustum gets zeroed here — invisible
+  // to B's render too, looking exactly like "buildup not reflected in POV" even though Time Machine's
+  // own visibility flags are correct (confirmed separately, see time_machine.js §DLOD_VF_CAMGUARD).
+  // Fix: while B is on, an instance is only hidden if it's outside BOTH frustums (union), not just
+  // the main camera's — same `activePOVCamera()` accessor time_machine.js's own §DLOD_VF_CAMGUARD
+  // already established, no new coupling.
+  var _frustumVF = new THREE.Frustum();
+  var _projScreenMatrixVF = new THREE.Matrix4();
   var _projScreenMatrix = new THREE.Matrix4();
   var _sphere = new THREE.Sphere();
   var _zeroScale = new THREE.Matrix4().makeScale(0, 0, 0);
   var _lastCamX = 0, _lastCamY = 0, _lastCamZ = 0;  // §S260b: skip tick when camera idle
   var _lastTargX = 0, _lastTargY = 0, _lastTargZ = 0;
+  var _lastVfX = 0, _lastVfY = 0, _lastVfZ = 0;  // §CPE_DLOD_VF_UNION: vfCam's own idle check —
+  // main camera can be PARKED (POV-only rehearsal) while vfCam alone is moving; without this the
+  // §S260b skip above would never re-evaluate at all during that flight.
   // §DLOD_TICK whitebox (2026-07-23): testing whether this always-on, UNCHUNKED per-slot culler
   // (full instancedMatrix re-upload on any flip — see §S274 comment below) is the source of
   // bbox-mode's fly > orbit lag reported after nav-DLOD (dlod_nav.js, separate module) was ruled
@@ -113,15 +129,23 @@ function setupDLOD(A) {
     A._dlodFrame++;
     if (A._dlodFrame % EVAL_EVERY !== 0) return;
 
-    // §S260b: Skip when camera hasn't moved
+    // §CPE_DLOD_VF_UNION: resolve B's POV camera the SAME way time_machine.js's own
+    // §DLOD_VF_CAMGUARD already does — no new coupling, just reused.
+    var _cpe = A.cinemaPathEditor;
+    var vfCam = (_cpe && _cpe.activePOVCamera) ? _cpe.activePOVCamera() : null;
+
+    // §S260b: Skip when NEITHER camera has moved (vfCam included — see _lastVfX above).
     var cp = A.camera.position, ct = A.controls ? A.controls.target : cp;
-    if (Math.abs(cp.x - _lastCamX) < 0.01 && Math.abs(cp.y - _lastCamY) < 0.01 &&
+    var vfp = vfCam ? vfCam.position : null;
+    var camIdle = Math.abs(cp.x - _lastCamX) < 0.01 && Math.abs(cp.y - _lastCamY) < 0.01 &&
         Math.abs(cp.z - _lastCamZ) < 0.01 && Math.abs(ct.x - _lastTargX) < 0.01 &&
-        Math.abs(ct.y - _lastTargY) < 0.01 && Math.abs(ct.z - _lastTargZ) < 0.01) {
-      return;
-    }
+        Math.abs(ct.y - _lastTargY) < 0.01 && Math.abs(ct.z - _lastTargZ) < 0.01;
+    var vfIdle = !vfp || (Math.abs(vfp.x - _lastVfX) < 0.01 && Math.abs(vfp.y - _lastVfY) < 0.01 &&
+        Math.abs(vfp.z - _lastVfZ) < 0.01);
+    if (camIdle && vfIdle) return;
     _lastCamX = cp.x; _lastCamY = cp.y; _lastCamZ = cp.z;
     _lastTargX = ct.x; _lastTargY = ct.y; _lastTargZ = ct.z;
+    if (vfp) { _lastVfX = vfp.x; _lastVfY = vfp.y; _lastVfZ = vfp.z; }
 
     _buildRefs();
     var t0 = performance.now();
@@ -129,6 +153,11 @@ function setupDLOD(A) {
     A.camera.updateMatrixWorld();
     _projScreenMatrix.multiplyMatrices(A.camera.projectionMatrix, A.camera.matrixWorldInverse);
     _frustum.setFromProjectionMatrix(_projScreenMatrix);
+    if (vfCam) {
+      vfCam.updateMatrixWorld();
+      _projScreenMatrixVF.multiplyMatrices(vfCam.projectionMatrix, vfCam.matrixWorldInverse);
+      _frustumVF.setFromProjectionMatrix(_projScreenMatrixVF);
+    }
 
     var imVis = 0, imHid = 0, skipCount = 0;
     var hiddenDiscs = A.hiddenDiscs;
@@ -161,7 +190,10 @@ function setupDLOD(A) {
         _sphere.center.set(m._wx, m._wy, m._wz);
         _sphere.radius = m._radius;
 
-        if (!_frustum.intersectsSphere(_sphere)) {
+        // §CPE_DLOD_VF_UNION: hidden only if outside BOTH the main camera's frustum AND (when B is
+        // on) vfCam's — an instance visible to either camera must survive, since this culling is
+        // global (zero-scale), not per-camera.
+        if (!_frustum.intersectsSphere(_sphere) && (!vfCam || !_frustumVF.intersectsSphere(_sphere))) {
           if (!m._dlodHid) {
             obj.setMatrixAt(m.instanceIndex, _zeroScale);
             m._dlodHid = true;
@@ -207,7 +239,8 @@ function setupDLOD(A) {
     if (_now - _tickLastLogT >= 2000) {
       console.log('§DLOD_TICK n=' + _tickN + ' ms_mean=' + (_tickMs / _tickN).toFixed(2) +
         ' ms_max=' + _tms.toFixed(2) + ' flips_mean=' + (_tickFlips / _tickN).toFixed(1) +
-        ' fly=' + (A.flyActive ? 1 : 0));
+        ' fly=' + (A.flyActive ? 1 : 0) +
+        ' vfCamActive=' + (vfCam ? 1 : 0) + ' imHid=' + imHid + ' imVis=' + imVis);
       _tickN = 0; _tickMs = 0; _tickFlips = 0; _tickLastLogT = _now;
     }
 

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -463,9 +463,12 @@ async function gates(browser, BLD, repoDir) {
     dprGuard.duringVfOn === 9.99 && dprGuard.duringVfOff !== 9.99,
     `duringVfOn(pr)=${dprGuard.duringVfOn} (expect unchanged=9.99) duringVfOff(pr)=${dprGuard.duringVfOff} (expect changed, proves the guard — not devicePixelRatio coincidence — is what held it at 9.99 above)`);
 
-  // ── G-VF-ASPECT: §CPE_VF_ASPECT_ROUND (2026-08-05) — vfCam.aspect must come from the TRUE CSS
-  // panelR.width/height, not from two independently-rounded backing-buffer pixel counts (w/h),
-  // whose ratio drifts off the real box aspect at fractional pixel ratios.
+  // ── G-VF-ASPECT: §CPE_VF_ASPECT_ROUND (2026-08-05) + §CPE_VF_RECT_ASPECT correction (OPEN 3,
+  // same day) — vfCam.aspect tracks the true CSS box aspect CLOSELY (within the rounding tolerance
+  // an integer-pixel viewport rect can achieve — see G-VF-RECT-ASPECT below for why it can no longer
+  // be bit-exact to the raw CSS box), a real improvement over the OLD two-independently-rounded w/h
+  // scheme (which could drift further, e.g. the OPEN 3 write-up's own repro: box_aspect=1.5756 vs
+  // true=1.5789, diff=0.0033).
   const aspectCheck = await page.evaluate(() => {
     const panel = document.getElementById('cpe-vf-panel');
     const r = panel.getBoundingClientRect();
@@ -480,9 +483,35 @@ async function gates(browser, BLD, repoDir) {
     });
   });
   const aspectDiff = aspectCheck.vfAspect != null ? Math.abs(aspectCheck.vfAspect - aspectCheck.trueAspect) : null;
-  P('G-VF-ASPECT vfCam.aspect matches the box\'s true (unrounded) CSS aspect, even at a fractional pixel ratio',
-    aspectDiff != null && aspectDiff < 1e-6,
-    `trueAspect=${aspectCheck.trueAspect} vfCamAspect=${aspectCheck.vfAspect} diff=${aspectDiff}`);
+  P('G-VF-ASPECT vfCam.aspect tracks the box\'s true (unrounded) CSS aspect within integer-pixel-rect tolerance',
+    aspectDiff != null && aspectDiff < 0.005,
+    `trueAspect=${aspectCheck.trueAspect} vfCamAspect=${aspectCheck.vfAspect} diff=${aspectDiff} (tolerance 0.005 — an integer w/h rect can never hit an arbitrary CSS ratio bit-exactly; G-VF-RECT-ASPECT below is the bit-exact gate)`);
+
+  // ── G-VF-RECT-ASPECT: §CPE_VF_RECT_ASPECT (2026-08-05, OPEN 3) — the ACTUAL viewport/scissor
+  // rectangle _vfRender() passes to setViewport/setScissor must have the EXACT SAME aspect as
+  // vfCam.aspect — not "close", bit-identical, since a real user-visible STRETCH is any non-zero gap
+  // between what the camera projects and what pixel rect it's drawn into. §CPE_VF_ASPECT_ROUND
+  // (PR #1209) set vfCam.aspect from the raw unrounded CSS box, which fixed the camera's OWN
+  // accuracy but left it disagreeing with the still-independently-rounded w/h rect (measured: box_
+  // aspect=1.5756 vs vfCam_aspect=1.5789, diff=0.0033 — a real stretch). Fixed by deriving
+  // vfCam.aspect = w/h (the SAME rounded rect this frame renders into, computed via a single
+  // rounding pass — h from the box, w derived from h — so it still tracks the true box far more
+  // closely than the old two-independent-roundings), making the two values identical by definition.
+  await page.evaluate(() => { window.APP.renderer.setPixelRatio(1.37); window.APP.markDirty(); });
+  await sleep(300);
+  const traceLine = logs.filter(l => l.includes('§CPE_VF_RENDER_TRACE')).pop();
+  const vfAspectNow = (await page.evaluate(() => window.APP.cinemaPathEditor._probeVF())).vfCamAspect;
+  let rectAspectDiff = null, rectW = null, rectH = null;
+  if (traceLine) {
+    const mw = traceLine.match(/\bw=(-?\d+(?:\.\d+)?)/), mh = traceLine.match(/\bh=(-?\d+(?:\.\d+)?)/);
+    if (mw && mh) {
+      rectW = parseFloat(mw[1]); rectH = parseFloat(mh[1]);
+      rectAspectDiff = Math.abs((rectW / rectH) - vfAspectNow);
+    }
+  }
+  P('G-VF-RECT-ASPECT the scissor/viewport rect\'s own aspect is bit-identical to vfCam.aspect — zero stretch',
+    rectAspectDiff != null && rectAspectDiff < 1e-9,
+    `rectW=${rectW} rectH=${rectH} rectAspect=${rectW != null ? (rectW / rectH).toFixed(6) : 'n/a'} vfCamAspect=${vfAspectNow} diff=${rectAspectDiff}`);
 
   // ── G-SCRUB-CLOSE-TEARDOWN: closing the editor (Cancel) removes the scrub panel ─────────────────
   await page.evaluate(() => document.getElementById('cpe-cancel').click());


### PR DESCRIPTION
## Summary
Follow-on to PR #1211's 5-item handoff (bim-compiler `prompts/CINEMA_PATH_EDITOR.md`, SESSION 2026-08-05 LIVE-TEST FOLLOW-ON). Closes 3 of the 4 remaining open items.

- **OPEN 3** — the POV inset's scissor/viewport rect (w/h) was independently double-rounded, drifting ~0.2% off `vfCam.aspect` (a real stretch). Fixed: derive `w` from `h` (single rounding), set `vfCam.aspect = w/h` so camera projection and rendered rect are identical by construction.
- **OPEN 4** — `viewer/dlod.js`'s per-instance frustum culler was keyed exclusively to the main camera, predating B/vfCam. During a POV-only rehearsal the main camera parks while vfCam walks the building — geometry outside the parked frustum could get culled invisible to B too ("buildup not reflected in POV"). Fixed: union the main + vfCam frustums via the same `activePOVCamera()` accessor `time_machine.js`'s own DLOD fix already established. Added `vfCamActive`/`imHid`/`imVis` to the throttled `§DLOD_TICK` log.
- **OPEN 5** — added `§CPE_SCRUB_INPUT_TRACE` logging to the scrub track's pointerdown/pointerup and the play button's click handler. Static reading found no structural block for "track/play stop responding after a stick-click pause" — this gives the next live repro real evidence.
- **OPEN 2** (buildup-checkbox → scrub-panel coupling) intentionally NOT touched — needs a user answer on which of two readings is meant before implementing.

## Test plan
- [x] `node -c` syntax check on both edited files
- [x] `npx eslint viewer/cinema_path_editor.js viewer/dlod.js` — clean
- [x] `witness_cpe_scrub_viewfinder.js` (HHS_Office_Federated, live puppeteer) — 23/23 green, including 2 new gates for OPEN 3 (G-VF-ASPECT relaxed tolerance + new bit-exact G-VF-RECT-ASPECT)
- [x] `witness_dlod_vf_camguard.js` (different DLOD subsystem, unaffected) — 10/10 green
- [~] OPEN 4's union fix reviewed correct by code inspection and confirmed wired live (`vfCamActive=1` appears when B is on); a synthetic instance-level A/B test was attempted but the harness's own EVAL_EVERY/idle-check timing made results ambiguous — real confirmation needs the user's live repro with the new `§DLOD_TICK` log line
- [ ] OPEN 5's freeze itself not yet reproduced — needs the user to repro with this build and paste the `§CPE_SCRUB_INPUT_TRACE` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)