### PR TITLE
fix(cpe): OPEN 2 AND-gate + OPEN 3 real root cause (drag never woke render loop)

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1466,6 +1466,18 @@
     document.body.appendChild(d);
     d._dragStrip = 22;
     if (a && typeof a._makeDraggable === 'function') a._makeDraggable(d);
+    // §CPE_VF_DRAG_MARKDIRTY (2026-08-05) — the ACTUAL root cause behind "dragging repositions
+    // correctly, but releasing snaps it back" / "inset not fitting the box, bigger a bit and off"
+    // (OPEN 3): neither `_makeDraggable`'s shared drag handler nor the resize handle's own
+    // pointermove below ever call `markDirty()`. On an idle/parked render loop (§IDLE-PARK, main.js)
+    // — the common case while just dragging a UI panel with no camera motion — `_vfRender()` only
+    // runs INSIDE that loop's render-gated block, so it never re-fires mid-drag: the CSS border
+    // moves live under the cursor while the scissor-rendered CONTENT stays frozen at the pre-drag
+    // rect, catching up only whenever something UNRELATED happens to wake the loop. Fixed by waking
+    // it explicitly on every drag/resize move (both bubble through this parent — `#cpe-vf-title`
+    // drives `_makeDraggable`'s drag, `#cpe-vf-resize` drives the corner resize below — neither
+    // stops propagation on pointermove), gated to `e.buttons` so a mere hover never wastes a frame.
+    d.addEventListener('pointermove', function(e) { if (e.buttons && a.markDirty) a.markDirty(); });
     _clampPanelToViewport(d, !_vfRect);
     // §CPE_VF_PANEL_LOG (2026-08-05) — B's panel had ZERO creation/drag logging (unlike #cpe-panel's
     // own §CPE_PANEL_DRAGGABLE/§CPE_PANEL_MOVED pair), so the console during a live repro carried no

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1648,7 +1648,10 @@
       // §CPE_VF_EYE_DRIVES_SCRUB (2026-08-05, user: "closing eye to act on it similar to opening
       // eye") — the eye toggle is the ONE control for both now, same button, no second widget.
       // Opening the eye brings the timeline back if a prior close removed it.
-      if (!document.getElementById('cpe-scrub-panel')) {
+      // §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2, user: "when buildup is unchecked it should not
+      // remain because it was called by buildup") — the timeline panel needs BOTH the eye ON AND
+      // buildup checked, an AND-gate, not eye-alone. Don't resurrect it here if buildup is off.
+      if (_state.buildup && !document.getElementById('cpe-scrub-panel')) {
         _buildScrubPanel();
         _wireScrub(document.getElementById('cpe-scrub-track'));
         _wireScrubPlay();
@@ -2810,6 +2813,19 @@
         // this checkbox.
         console.log('§CPE_BUILDUP ' + (_state.buildup ? 'ON' : 'off') +
           ' — reveal FOLLOWS the Time Machine timeline as-is (no re-key; the camera does not author the build order)');
+        // §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2, user: "when buildup is unchecked it should not
+        // remain because it was called by buildup" / "it follows the Eye ... buildUp told u also")
+        // — the timeline panel needs BOTH the eye ON AND buildup checked (AND-gate, see the mirror
+        // of this in _toggleViewfinder's ON branch). Unchecking buildup tears it down regardless of
+        // the eye; re-checking it only rebuilds if the eye is ALSO already on.
+        if (!_state.buildup) {
+          _scrubPanelTeardown();
+        } else if (_state.vfOn && !document.getElementById('cpe-scrub-panel')) {
+          _buildScrubPanel();
+          _wireScrub(document.getElementById('cpe-scrub-track'));
+          _wireScrubPlay();
+          _renderScrub();
+        }
         _renderWhole(); _syncButtons();
       });
       document.getElementById('cpe-room-title').addEventListener('change', function(e) {

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -37,6 +37,8 @@
 //   G-SCRUB-PLAY-POVONLY  the SAME button-driven flight leaves the main camera byte-identical
 //                       throughout (start/pause/resume) — §CPE_SCRUB_POV_ONLY: the scrub-play
 //                       button now calls _previewFly(true), driving B alone, never the main canvas.
+//   G-VF-DRAG-WAKES-RENDER  dragging/resizing B's panel calls markDirty() on every move, not just on
+//                       release (§CPE_VF_DRAG_MARKDIRTY) — the real staleness cause behind OPEN 3.
 //   G-BUILDUP-GATES-TM  the timeline panel needs BOTH the eye ON and buildup checked
 //                       (§CPE_BUILDUP_GATES_TM) — cycling the eye while buildup is off must NOT
 //                       resurrect it, the actual bug this gate exists to catch.
@@ -515,6 +517,33 @@ async function gates(browser, BLD, repoDir) {
   P('G-VF-RECT-ASPECT the scissor/viewport rect\'s own aspect is bit-identical to vfCam.aspect — zero stretch',
     rectAspectDiff != null && rectAspectDiff < 1e-9,
     `rectW=${rectW} rectH=${rectH} rectAspect=${rectW != null ? (rectW / rectH).toFixed(6) : 'n/a'} vfCamAspect=${vfAspectNow} diff=${rectAspectDiff}`);
+
+  // ── G-VF-DRAG-WAKES-RENDER: §CPE_VF_DRAG_MARKDIRTY (2026-08-05, OPEN 3 root cause) — dragging or
+  // resizing B's panel must call markDirty() on EVERY move, not just on release. Before this fix,
+  // neither _makeDraggable's shared drag handler nor the resize handle's pointermove ever woke the
+  // (self-parking, §IDLE-PARK) render loop — on a static scene the CSS border moved live under the
+  // cursor while _vfRender()'s scissor rect stayed frozen at the pre-drag position/size the whole
+  // drag, only catching up whenever something UNRELATED happened to wake the loop. This is the
+  // structural cause behind "dragging repositions correctly but releasing snaps it back" / "inset
+  // not fitting the box, bigger a bit and off" — a staleness bug, not a coordinate-math bug.
+  const dragWake = await page.evaluate(async () => {
+    const A = window.APP;
+    let calls = 0;
+    const orig = A.markDirty;
+    A.markDirty = function() { calls++; return orig.apply(A, arguments); };
+    const title = document.getElementById('cpe-vf-title');
+    const r0 = title.getBoundingClientRect();
+    const sx = r0.left + 20, sy = r0.top + 10;
+    const fire = (type, x, y, buttons) => title.dispatchEvent(new PointerEvent(type, { bubbles: true, clientX: x, clientY: y, buttons, pointerId: 1 }));
+    fire('pointerdown', sx, sy, 1);
+    await new Promise(r => setTimeout(r, 20));
+    for (let i = 1; i <= 5; i++) { fire('pointermove', sx + i * 15, sy + i * 5, 1); await new Promise(r => setTimeout(r, 20)); }
+    fire('pointerup', sx + 75, sy + 25, 0);
+    A.markDirty = orig;
+    return { calls };
+  });
+  P('G-VF-DRAG-WAKES-RENDER dragging B\'s panel calls markDirty() on every move (not just on release)',
+    dragWake.calls >= 5, `markDirtyCallsDuring5Moves=${dragWake.calls}`);
 
   // ── G-BUILDUP-GATES-TM: §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2) — the timeline panel needs
   // BOTH the eye ON and buildup checked (an AND-gate, user: "it follows the Eye" AND "buildUp told u

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -37,6 +37,9 @@
 //   G-SCRUB-PLAY-POVONLY  the SAME button-driven flight leaves the main camera byte-identical
 //                       throughout (start/pause/resume) — §CPE_SCRUB_POV_ONLY: the scrub-play
 //                       button now calls _previewFly(true), driving B alone, never the main canvas.
+//   G-BUILDUP-GATES-TM  the timeline panel needs BOTH the eye ON and buildup checked
+//                       (§CPE_BUILDUP_GATES_TM) — cycling the eye while buildup is off must NOT
+//                       resurrect it, the actual bug this gate exists to catch.
 //   G-SCRUB-CLOSE-TEARDOWN  closing the editor (Cancel) removes the scrub panel too.
 //   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant DURING A
 //              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call.
@@ -512,6 +515,38 @@ async function gates(browser, BLD, repoDir) {
   P('G-VF-RECT-ASPECT the scissor/viewport rect\'s own aspect is bit-identical to vfCam.aspect — zero stretch',
     rectAspectDiff != null && rectAspectDiff < 1e-9,
     `rectW=${rectW} rectH=${rectH} rectAspect=${rectW != null ? (rectW / rectH).toFixed(6) : 'n/a'} vfCamAspect=${vfAspectNow} diff=${rectAspectDiff}`);
+
+  // ── G-BUILDUP-GATES-TM: §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2) — the timeline panel needs
+  // BOTH the eye ON and buildup checked (an AND-gate, user: "it follows the Eye" AND "buildUp told u
+  // also, when it is unchecked it should not remain because it was called by buildup"). B's eye is
+  // ON at this point (earlier gates left it on). B's own panel/hookInstalled state must be untouched
+  // by any of this — only the TIMELINE panel is gated by buildup, never B itself.
+  const gate = await page.evaluate(() => {
+    const cb = document.getElementById('cpe-buildup');
+    const vfBefore = window.APP.cinemaPathEditor._probeVF();
+    // 1) Uncheck buildup (eye still ON) — timeline must go away.
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    const step1 = { scrubGone: !document.getElementById('cpe-scrub-panel'), vf: window.APP.cinemaPathEditor._probeVF() };
+    // 2) Toggle the eye OFF then back ON while buildup is STILL unchecked — timeline must NOT
+    // reappear (this is the actual bug the AND-gate exists to prevent: eye-alone used to resurrect it).
+    window.APP.cinemaPathEditor._vfToggle();   // eye off
+    window.APP.cinemaPathEditor._vfToggle();   // eye back on
+    const step2 = { scrubStillGone: !document.getElementById('cpe-scrub-panel'), vf: window.APP.cinemaPathEditor._probeVF() };
+    // 3) Re-check buildup (eye is on from step 2) — timeline must come back.
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    const step3 = { scrubBack: !!document.getElementById('cpe-scrub-track') };
+    return { vfBefore, step1, step2, step3 };
+  });
+  P('G-BUILDUP-GATES-TM unchecking buildup hides the timeline panel, B itself untouched',
+    gate.step1.scrubGone && gate.step1.vf.on === gate.vfBefore.on && gate.step1.vf.hookInstalled === gate.vfBefore.hookInstalled,
+    `scrubGoneOnUncheck=${gate.step1.scrubGone} vfOnUnchanged=${gate.step1.vf.on === gate.vfBefore.on} vfHookUnchanged=${gate.step1.vf.hookInstalled === gate.vfBefore.hookInstalled}`);
+  P('G-BUILDUP-GATES-TM cycling the eye while buildup is OFF does NOT resurrect the timeline (the actual AND-gate)',
+    gate.step2.scrubStillGone && gate.step2.vf.on === true,
+    `scrubStillGoneAfterEyeCycle=${gate.step2.scrubStillGone} vfOnAfterCycle=${gate.step2.vf.on}`);
+  P('G-BUILDUP-GATES-TM re-checking buildup (eye already on) restores the timeline panel',
+    gate.step3.scrubBack, `scrubTrackPresent=${gate.step3.scrubBack}`);
 
   // ── G-SCRUB-CLOSE-TEARDOWN: closing the editor (Cancel) removes the scrub panel ─────────────────
   await page.evaluate(() => document.getElementById('cpe-cancel').click());


### PR DESCRIPTION
## Summary
Follow-on to PR #1212 (already merged/squashed while this work was in flight — these two commits were cherry-picked onto fresh `origin/main` to avoid the squash-orphan trap).

- **OPEN 2** — the timeline/scrub panel now needs BOTH B's eye ON and `#cpe-buildup` checked (an AND-gate). Corrects two wrong attempts earlier the same session (buildup-alone, then buildup-as-fully-independent) — direct user correction: it follows the eye, AND unchecking buildup must not let it remain since it was "called by buildup." The actual bug this closes: cycling the eye while buildup is off used to resurrect the panel.
- **OPEN 3 (real root cause)** — traced further after the user asked whether the scissor/viewport pattern itself was suspect. It isn't (it's the standard three.js technique for a shared-context PIP view). The actual bug: neither B's drag handler nor its resize handle ever called `markDirty()`, so on the self-parking render loop, a drag/resize with no other camera motion left `_vfRender()`'s scissor rect frozen at the pre-drag position while the CSS border moved live — exactly "dragging repositions correctly but releasing snaps it back."

## Test plan
- [x] `node -c` syntax check
- [x] `npx eslint` — clean
- [x] `witness_cpe_scrub_viewfinder.js` (HHS_Office_Federated, live puppeteer) — 27/27 green, including new `G-BUILDUP-GATES-TM` (3 gates, the actual eye+buildup interaction) and `G-VF-DRAG-WAKES-RENDER` (proves markDirty fires on every drag move, not just release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)