### PR TITLE
fix(cpe): scrub panel eye-gating, playhead tick fix, POV frame diagnostic

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -167,6 +167,7 @@
   // frame theory (§IDLE_GATE self-parks the render loop; nothing in the drag path calls markDirty()
   // except a repositioning save()) without needing to guess from a screenshot.
   var _lastVfRenderRect = null, _lastVfRenderT = null;
+  var _lastFrameDiagT = null;   // §CPE_VF_FRAME_DIAG throttle — see _vfRender
   // §CPE_SCRUB_STANDALONE (2026-08-04) — where the user last dragged the standalone scrub panel,
   // same session-only scope as `_panelPos`/`_vfRect` above.
   var _scrubRect = null;
@@ -1619,6 +1620,50 @@
         ' freshPose_pos=' + (freshP ? JSON.stringify({x:+freshP.x.toFixed(3), y:+freshP.y.toFixed(3), z:+freshP.z.toFixed(3)}) : 'n/a') +
         ' scrubTn=' + _state.scrubTn);
     }
+    // §CPE_VF_FRAME_DIAG (2026-08-06, Issue 2 — "working, but not well framed") — position, fov and
+    // aspect are ALL already proven correct above and by G-VF-1/G-VF-ASPECT/G-VF-RECT-ASPECT (pose
+    // bit-identical to the main camera's, fov a hardcoded constant — 60, `scene.js:139` — copied
+    // once at vfCam creation and NEVER reassigned afterward so it cannot drift, rect aspect
+    // bit-identical to vfCam.aspect by construction). So none of those numbers can be the cause of a
+    // composition/zoom complaint. This logs the one thing that COULD be: how close the nearest real
+    // surface is along vfCam's own look direction, and what fraction of the box's height a 1m
+    // reference object at that distance would fill. A wide 60° FOV pointed at a DISTANT subject
+    // reads as "small/not well framed" with zero coordinate error anywhere — this is the honest way
+    // to tell "genuinely too wide/zoomed-out" from "actually fine, only looked off in a screenshot."
+    // Throttled to ~500ms (tn changes every frame during playback; a handful of samples across a
+    // real scrub/rehearsal is enough to characterize composition without flooding the console).
+    var _fdNow = performance.now();
+    if (typeof a.collectMeshes === 'function' && (_lastFrameDiagT == null || _fdNow - _lastFrameDiagT >= 500)) {
+      _lastFrameDiagT = _fdNow;
+      // §CPE_VF_FRAME_DIAG safety: mirrors effects.js's own `_cinemaFan` raycast pattern exactly —
+      // `A.collectMeshes(...)` (a curated, safe-to-raycast list — NOT raw a.scene.children, which
+      // includes helper/staffage/sprite objects some of this app's custom BatchedMesh/BVH raycast
+      // overrides cannot handle and will throw on) plus a try/catch, since `_cinemaFan` ITSELF
+      // wraps every `intersectObjects` call the same way — this is not a new pattern, just reused.
+      // A raw a.scene.children raycast (the first version of this diagnostic) threw
+      // "Cannot read properties of null (reading 'matrixWorld')" and — because it ran BEFORE the
+      // real a.renderer.render() call below — would have silently killed B's actual render on every
+      // frame it hit. Diagnostic code must never be able to break the feature it's diagnosing.
+      try {
+        var _fdMeshes = a.collectMeshes(function(o) {
+          return (o.isMesh || o.isInstancedMesh || o.isBatchedMesh) && o.visible && !o.isSprite;
+        });
+        var _fdDir = new THREE.Vector3();
+        _state.vfCam.getWorldDirection(_fdDir);
+        var _fdRay = new THREE.Raycaster(_state.vfCam.position, _fdDir, 0.01, 200);
+        _fdRay.firstHitOnly = true;
+        var _fdHits = _fdMeshes.length ? _fdRay.intersectObjects(_fdMeshes, true) : [];
+        var _fdDist = _fdHits.length ? _fdHits[0].distance : null;
+        var _fdFrac = _fdDist ? (1 / (2 * _fdDist * Math.tan(_state.vfCam.fov * Math.PI / 360))) : null;
+        console.log('§CPE_VF_FRAME_DIAG scrubTn=' + _state.scrubTn +
+          ' nearestSurfaceDist=' + (_fdDist != null ? _fdDist.toFixed(2) + 'm' : 'none-within-200m') +
+          ' fov=' + _state.vfCam.fov +
+          ' refObj1mVerticalFrameFraction=' + (_fdFrac != null ? _fdFrac.toFixed(3) : 'n/a') +
+          ' — low fraction = subject reads small/distant in the box even with zero coordinate error');
+      } catch (_fdErr) {
+        console.log('§CPE_VF_FRAME_DIAG_ERR ' + _fdErr.message);
+      }
+    }
     a.renderer.setScissorTest(true);
     a.renderer.setViewport(x, y, w, h);
     a.renderer.setScissor(x, y, w, h);
@@ -2080,6 +2125,14 @@
         // _applyCameraPose above. Was inlined here; extracted so scrubbing and B share it exactly.
         // §CPE_SCRUB_POV_ONLY: povOnly skips the main camera entirely, applying to B alone.
         if (povOnly) { _applyVFPose(tn); } else { _applyCameraPose(tn); }
+        // §CPE_SCRUB_PLAYHEAD_TICK (2026-08-06) — mirrors _scrubTo's own `_state.scrubTn = tn;
+        // _renderScrub();` pair exactly. Without this the camera pose advances correctly every
+        // frame but the playhead (`#cpe-scrub-head`, driven by `_state.scrubTn`) never does — the
+        // same "second state update never wired into the real tick" shape §CPE_SCRUB_BEARING_
+        // FLY_PAUSE hit: the pose write and the UI-state write are two separate lines, and this one
+        // was missing from step() even though _scrubTo (the drag path) always had both.
+        _state.scrubTn = tn;
+        _renderScrub();
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
         if (bkPrev && window.tmSetCursor) {
           // §CPE_BUILDUP_WORK_PACED: the rehearsal asks for the SAME cursor the bake will ask for at
@@ -2753,14 +2806,18 @@
         'm speed=' + _state.speed.toFixed(2) + 'm/s total=' + ctx.durationSec.toFixed(1) + 's');
 
       var panel = _buildPanel();
-      // §CPE_SCRUB_STANDALONE — built unconditionally alongside #cpe-panel, independent of B's
-      // toggle (resolves the OPEN QUESTION the #1177 fix left open). _renderScrub() itself is
-      // already invoked from every mutation path via _redrawScene() (see that function's own
-      // §CPE_SCRUB comment) — nothing extra to wire for refresh, only initial build.
+      // §CPE_SCRUB_EYE_GATED (2026-08-06, retires §CPE_SCRUB_STANDALONE's "built unconditionally"
+      // behaviour) — user, this session: "Been minimalist, user is asked to just bake on the fly.
+      // The eye is only for path edit... Scrubber is new, is only to be ON under the Eye toggle."
+      // §CPE_SCRUB_STANDALONE (2026-08-05) deliberately decoupled the bar from B's toggle for a
+      // DIFFERENT reason (making B's own render display-only, no drop/raycast interaction on the
+      // bar) — but its side effect was that the panel appeared immediately on Alt+C, before the eye
+      // is ever touched, confirmed live. `vfOn` starts false (2 lines above), so simply do NOT build
+      // the bar here — `_toggleViewfinder`'s ON branch (§CPE_VF_EYE_DRIVES_SCRUB /
+      // §CPE_BUILDUP_GATES_TM) already builds it, guarded, the first time the eye turns on; nothing
+      // else to wire here. _renderScrub() stays safe to call from every mutation path regardless
+      // (already null-guards on a missing track).
       _state.scrubTn = 0;
-      _buildScrubPanel();
-      _wireScrub(document.getElementById('cpe-scrub-track'));
-      _wireScrubPlay();
       // §CPE_VIEWFINDER: the eye-icon toggle button lives in the panel's title row (_buildPanel).
       _wireViewfinderToggle();
       // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -1,25 +1,33 @@
 // WITNESS — §CPE_SCRUB / §CPE_VIEWFINDER (Parts A and B).
 // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md Part A §CPE_SCRUB, Part B §CPE_VIEWFINDER.
 //
-// REWRITTEN 2026-08-05 — the scrub bar became its own standalone panel (§CPE_SCRUB_STANDALONE),
-// independent of B's toggle, and a scrub drag now legitimately drives B's inset camera again
-// (§CPE_SCRUB_VF_LIVE — the mid-fix cut from the #1177 session, restored). The v23-era gates that
-// asserted the OPPOSITE of both (bar gated to B; B's camera never moves on scrub) are GONE, replaced
-// below — see CPE_V's v24 entry in cinema_path_editor.js for the full change list this witness
-// re-verifies. The one invariant that has NEVER changed across any of these revisions — the MAIN
-// canvas camera/controls must stay byte-identical across any scrub, drag or click — is still the
-// single most important gate here (G-SCRUB-NOCAM), unmodified in spirit from the original #1177 fix.
+// REWRITTEN 2026-08-06 — §CPE_SCRUB_EYE_GATED retires §CPE_SCRUB_STANDALONE's "exists unconditionally
+// at open" behaviour: the scrub/timeline panel now only exists while B's eye is on (user: "Scrubber
+// is new, is only to be ON under the Eye toggle"). This ripples through the whole suite — every gate
+// that reads `#cpe-scrub-*` now needs B toggled on FIRST, so "toggle B on" moved to the TOP of the
+// run instead of happening midway. The v23-era gates that asserted the OPPOSITE of §CPE_SCRUB_VF_LIVE
+// (bar gated to B; B's camera never moves on scrub) are GONE, replaced below — see CPE_V's v24 entry
+// in cinema_path_editor.js for the full change list this witness re-verifies. The one invariant that
+// has NEVER changed across any of these revisions — the MAIN canvas camera/controls must stay
+// byte-identical across any scrub, drag or click — is still the single most important gate here
+// (G-SCRUB-NOCAM), unmodified in spirit from the original #1177 fix.
 //
 // ISSUE EACH GATE PROVES OR DISPROVES:
-//   G-SCRUB-STANDALONE  the scrub panel exists in the DOM as soon as the editor opens, BEFORE B is
-//                       ever toggled on — proves the panel is independent of B, not nested/gated.
+//   G-SCRUB-EYE-GATED   the scrub/timeline panel does NOT exist at editor-open (before the eye is
+//                       ever toggled), and DOES appear once the eye toggles on (§CPE_SCRUB_EYE_GATED,
+//                       2026-08-06) — retires G-SCRUB-STANDALONE, which asserted the opposite.
 //   G-SCRUB-PANEL-LOG   the scrub panel logs its own creation (was completely silent before) —
 //                       left-anchored, no viewport-bottom overflow, clear of #cpe-panel.
 //   G-VF-PANEL-CLEAR    B's panel logs its own creation (also previously silent) — left-anchored,
 //                       NOT the old right-anchor-into-#cpe-panel's-column bug, z-index above it.
 //   G-SCRUB-NOCAM       the main camera's position AND orbit target are byte-identical before/after
-//                       a scrub drag (B off) — the regression gate, unchanged in spirit since #1177.
+//                       a scrub drag — the regression gate, unchanged in spirit since #1177 (now run
+//                       with B on, the only way a scrub can happen at all post-§CPE_SCRUB_EYE_GATED).
 //   G-SCRUB-VISUAL      a scrub drag still updates the playhead and the "mm:ss / mm:ss" readout text.
+//   G-SCRUB-PLAYHEAD-TICK  the SAME playhead also advances during _previewFly() PLAYBACK, not just a
+//                       manual drag (§CPE_SCRUB_PLAYHEAD_TICK, 2026-08-06) — step() previously moved
+//                       the camera every frame but never wrote `_state.scrubTn`/called `_renderScrub`,
+//                       so the blue progress line never moved even though play/pause/resume worked.
 //   G-SCRUB-VF-LIVE     with B ON, a scrub drag drives B's inset camera (vfCam) to plan.poseAt(tn) —
 //                       while the main camera stays untouched in the SAME drag. Proves the restored
 //                       §CPE_SCRUB_VF_LIVE feature without reopening the #1177 regression.
@@ -43,6 +51,11 @@
 //                       (§CPE_BUILDUP_GATES_TM) — cycling the eye while buildup is off must NOT
 //                       resurrect it, the actual bug this gate exists to catch.
 //   G-SCRUB-CLOSE-TEARDOWN  closing the editor (Cancel) removes the scrub panel too.
+//   G-VF-FRAME-DIAG  (informational, not pass/fail) §CPE_VF_FRAME_DIAG diagnostic for the "not well
+//                       framed" composition/zoom complaint — logs real nearest-surface-distance and
+//                       frame-fill-fraction numbers across a rehearsal; see CINEMA_PATH_EDITOR.md's
+//                       session writeup for the honest diagnosis (position/fov/aspect all proven
+//                       correct elsewhere in this suite; composition genuinely varies by beat).
 //   G-VF-1     B's camera pose at tn matches the main camera's exact pose at that instant DURING A
 //              REAL REHEARSAL — one pose source, both fed by the same _applyCameraPose call.
 //              Unaffected by any of this session's changes — same mechanism as before.
@@ -84,15 +97,34 @@ async function gates(browser, BLD, repoDir) {
   const P = (n, ok, d) => checks.push({ n, ok, d });
   const { page, logs } = await openEditor(browser, BLD);
 
-  // ── G-SCRUB-STANDALONE: the panel exists BEFORE B is ever toggled on ────────────────────────────
-  const standalone = await page.evaluate(() => ({
+  // ── G-SCRUB-EYE-GATED: §CPE_SCRUB_EYE_GATED (2026-08-06) — retires G-SCRUB-STANDALONE, which
+  // asserted the OPPOSITE (panel exists unconditionally at open, independent of B). User, this
+  // session: "Been minimalist, user is asked to just bake on the fly. The eye is only for path
+  // edit... Scrubber is new, is only to be ON under the Eye toggle." Confirmed live before this fix:
+  // the panel appeared immediately on Alt+C, before the eye was ever touched — §CPE_SCRUB_STANDALONE
+  // (2026-08-05) deliberately decoupled the bar from B's toggle, but for a DIFFERENT reason (making
+  // B's own render display-only), and that decoupling had this unintended side effect.
+  const atOpen = await page.evaluate(() => ({
     track: !!document.getElementById('cpe-scrub-track'),
     panel: !!document.getElementById('cpe-scrub-panel'),
     vfOn: window.APP.cinemaPathEditor._probeVF().on
   }));
-  P('G-SCRUB-STANDALONE the scrub panel exists at editor-open, independent of B',
-    standalone.track && standalone.panel && standalone.vfOn === false,
-    `trackPresent=${standalone.track} panelPresent=${standalone.panel} vfOnAtOpen=${standalone.vfOn}`);
+  P('G-SCRUB-EYE-GATED the scrub/timeline panel does NOT exist at editor-open, before the eye is ever toggled',
+    !atOpen.track && !atOpen.panel && atOpen.vfOn === false,
+    `trackPresent=${atOpen.track} panelPresent=${atOpen.panel} vfOnAtOpen=${atOpen.vfOn}`);
+
+  // ── toggle B on — moved to the TOP of the suite (was previously after G-SCRUB-NOCAM/VISUAL): now
+  // that the scrub panel only exists while the eye is on (§CPE_SCRUB_EYE_GATED above), every gate
+  // below needs the panel/track present in the DOM, so B goes on once, here, for the rest of the run.
+  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(300);
+  const afterEyeOn = await page.evaluate(() => ({
+    track: !!document.getElementById('cpe-scrub-track'),
+    panel: !!document.getElementById('cpe-scrub-panel')
+  }));
+  P('G-SCRUB-EYE-GATED toggling the eye ON builds the scrub/timeline panel',
+    vfOnState === true && afterEyeOn.track && afterEyeOn.panel,
+    `vfOnState=${vfOnState} trackPresent=${afterEyeOn.track} panelPresent=${afterEyeOn.panel}`);
 
   // ── G-SCRUB-PANEL-LOG: the scrub panel logs its own creation (was completely silent before —
   // no console evidence existed for a "scrubber is missing" report). Real numbers, not a screenshot:
@@ -110,7 +142,27 @@ async function gates(browser, BLD, repoDir) {
   P('G-SCRUB-PANEL-LOG scrub panel logs its own creation: left-anchored, no viewport overflow, clear of #cpe-panel',
     scrubLogOk, scrubLogDetail);
 
-  // ── G-SCRUB-NOCAM: the regression gate — no MAIN camera move during a scrub drag, B still off ───
+  // ── G-VF-PANEL-CLEAR: B's default position was NEVER actually fixed by the earlier "clear of
+  // #cpe-panel" commit (only the scrub panel's was, despite that commit's own message claiming
+  // both) — confirmed by direct code read, fixed in this same edit. B's own creation log (also
+  // previously silent) now proves it live: left-anchored (not the old canvasWidth-derived right
+  // anchor), z-index above #cpe-panel's, no overlap.
+  const vfCreated = logs.find(l => l.startsWith('§CPE_VF_PANEL_CREATED'));
+  let vfLogOk = false, vfLogDetail = 'no §CPE_VF_PANEL_CREATED line seen';
+  if (vfCreated) {
+    const m = /left=(-?\d+).*zIndex=(\d+).*cpePanel=(\S+)/.exec(vfCreated);
+    if (m) {
+      const left = +m[1], zIndex = +m[2], cpePanel = m[3];
+      vfLogOk = left < 100 && zIndex >= 10001 && cpePanel !== 'OVERLAP';
+      vfLogDetail = `left=${left} zIndex=${zIndex} cpePanel=${cpePanel}`;
+    }
+  }
+  P('G-VF-PANEL-CLEAR B\'s panel logs its own creation: left-anchored (not the old right-anchor bug), z-index above #cpe-panel, clear of it',
+    vfLogOk, vfLogDetail);
+
+  // ── G-SCRUB-NOCAM: the regression gate — no MAIN camera move during a scrub (B is ON — since
+  // §CPE_SCRUB_EYE_GATED, the bar cannot exist at all with B off, so a scrub with B off is no longer
+  // a real-world path; the invariant is tested here, the only way a user can actually scrub now) ───
   const before1 = await page.evaluate(() => {
     const A = window.APP;
     return {
@@ -131,35 +183,13 @@ async function gates(browser, BLD, repoDir) {
   });
   const dMainPos1 = Math.hypot(after1.mainPos.x - before1.mainPos.x, after1.mainPos.y - before1.mainPos.y, after1.mainPos.z - before1.mainPos.z);
   const dMainTgt1 = Math.hypot(after1.mainTgt.x - before1.mainTgt.x, after1.mainTgt.y - before1.mainTgt.y, after1.mainTgt.z - before1.mainTgt.z);
-  P('G-SCRUB-NOCAM the main camera (position AND target) is byte-identical before/after a scrub drag (B off)',
+  P('G-SCRUB-NOCAM the main camera (position AND target) is byte-identical before/after a scrub drag',
     dMainPos1 < 1e-9 && dMainTgt1 < 1e-9,
     `mainPosDelta=${dMainPos1.toExponential(2)}m mainTargetDelta=${dMainTgt1.toExponential(2)}m ` +
     `scrubResult.x=${scrubResult ? scrubResult.x.toFixed(2) : 'null'} (poseAt(0.42) IS sampled and returned — just never written to the main camera)`);
   P('G-SCRUB-VISUAL the playhead/readout DID change (mm:ss / mm:ss, not the old %)',
     before1.scrubLabel !== after1.scrubLabel,
     `before="${before1.scrubLabel}" after="${after1.scrubLabel}"`);
-
-  // ── toggle B on — shared setup for G-SCRUB-VF-LIVE, G-EYE-DRIVES-SCRUB, G-VF-1, G-VF-2, G-PERF-1 ──
-  const vfOnState = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
-  await sleep(300);
-
-  // ── G-VF-PANEL-CLEAR: B's default position was NEVER actually fixed by the earlier "clear of
-  // #cpe-panel" commit (only the scrub panel's was, despite that commit's own message claiming
-  // both) — confirmed by direct code read, fixed in this same edit. B's own creation log (also
-  // previously silent) now proves it live: left-anchored (not the old canvasWidth-derived right
-  // anchor), z-index above #cpe-panel's, no overlap.
-  const vfCreated = logs.find(l => l.startsWith('§CPE_VF_PANEL_CREATED'));
-  let vfLogOk = false, vfLogDetail = 'no §CPE_VF_PANEL_CREATED line seen';
-  if (vfCreated) {
-    const m = /left=(-?\d+).*zIndex=(\d+).*cpePanel=(\S+)/.exec(vfCreated);
-    if (m) {
-      const left = +m[1], zIndex = +m[2], cpePanel = m[3];
-      vfLogOk = left < 100 && zIndex >= 10001 && cpePanel !== 'OVERLAP';
-      vfLogDetail = `left=${left} zIndex=${zIndex} cpePanel=${cpePanel}`;
-    }
-  }
-  P('G-VF-PANEL-CLEAR B\'s panel logs its own creation: left-anchored (not the old right-anchor bug), z-index above #cpe-panel, clear of it',
-    vfLogOk, vfLogDetail);
 
   // ── G-SCRUB-VF-LIVE: with B on, scrub drives B's camera to plan.poseAt(tn); main stays untouched ─
   const before2 = await page.evaluate(() => {
@@ -348,6 +378,28 @@ async function gates(browser, BLD, repoDir) {
   P('G-SCRUB-PLAY resume continues the flight (still flying, no longer paused)',
     resumedOk && resumedState && resumedState.flying && !resumedState.paused,
     `resumeOk=${resumedOk} flying=${resumedState ? resumedState.flying : 'n/a'} paused=${resumedState ? resumedState.paused : 'n/a'}`);
+
+  // ── G-SCRUB-PLAYHEAD-TICK: §CPE_SCRUB_PLAYHEAD_TICK (2026-08-06, Issue 3) — the flight resumed
+  // above is STILL ACTIVELY PLAYING; sample the playhead (`_state.scrubTn`, what drives
+  // `#cpe-scrub-head`'s CSS left%) and poll for a strict increase over a real wait. Before this fix,
+  // step() moved the CAMERA every frame via `_applyVFPose(tn)`/`_applyCameraPose(tn)` but never wrote
+  // `tn` back to `_state.scrubTn` nor called `_renderScrub()` — play/pause/resume worked (proven
+  // above) while the visual progress indicator stayed frozen the whole flight, exactly the user's
+  // report. Polls rather than a single fixed gap: this exact point in the suite is deep into an
+  // already-heavy run (SwiftShader software rendering under cumulative load from every gate above),
+  // and a live isolated repro of this identical pause/resume sequence measured msPerFrame=662.7 —
+  // a single frame can genuinely take longer than a short fixed sleep here, which is an environment
+  // artifact, not a claim about the fix; polling up to 5s absorbs that without weakening what's
+  // actually being proven (the value must still strictly increase from its own first reading).
+  const tickA = await page.evaluate(() => window.APP.cinemaPathEditor._probeScrub().scrubTn);
+  let tickB = tickA, tickT0 = Date.now();
+  while (Date.now() - tickT0 < 5000) {
+    await sleep(200);
+    tickB = await page.evaluate(() => window.APP.cinemaPathEditor._probeScrub().scrubTn);
+    if (tickB > tickA) break;
+  }
+  P('G-SCRUB-PLAYHEAD-TICK the playhead (scrubTn) advances during ACTIVE playback, not just on a manual drag',
+    tickB > tickA, `scrubTn_t0=${tickA.toFixed(4)} scrubTn_later=${tickB.toFixed(4)} delta=${(tickB - tickA).toFixed(4)} waitedMs=${Date.now() - tickT0}`);
 
   // ── G-SCRUB-PLAY-POVONLY: the main camera stayed byte-identical across the whole button-driven ──
   // flight above (start, mid-flight pause, resume) — proves _previewFly(true) never touches it,
@@ -576,6 +628,16 @@ async function gates(browser, BLD, repoDir) {
     `scrubStillGoneAfterEyeCycle=${gate.step2.scrubStillGone} vfOnAfterCycle=${gate.step2.vf.on}`);
   P('G-BUILDUP-GATES-TM re-checking buildup (eye already on) restores the timeline panel',
     gate.step3.scrubBack, `scrubTrackPresent=${gate.step3.scrubBack}`);
+
+  // ── G-VF-FRAME-DIAG: informational only (Issue 2, "not well framed") — summarize every
+  // §CPE_VF_FRAME_DIAG line logged during this whole run (scrubbing + the real rehearsal above
+  // already sampled several tn values). Not pass/fail: position/fov/aspect are ALREADY proven
+  // correct by G-VF-1/G-VF-ASPECT/G-VF-RECT-ASPECT, so there is no known-correct "frame fraction" to
+  // assert against yet — this just puts the real numbers on record for the doc/next live repro.
+  const frameDiagLines = logs.filter(l => l.startsWith('§CPE_VF_FRAME_DIAG'));
+  P('G-VF-FRAME-DIAG (informational) composition samples logged across the run, zero crashes',
+    !logs.some(l => l.startsWith('§CPE_VF_FRAME_DIAG_ERR')),
+    `samples=${frameDiagLines.length} ` + frameDiagLines.map(l => l.replace('§CPE_VF_FRAME_DIAG ', '')).join(' | '));
 
   // ── G-SCRUB-CLOSE-TEARDOWN: closing the editor (Cancel) removes the scrub panel ─────────────────
   await page.evaluate(() => document.getElementById('cpe-cancel').click());


### PR DESCRIPTION
## Summary
Three issues in the Cinema Path Editor (Alt+C), off fresh `origin/main` (PR #1211/#1212/#1213 all already merged).

- **Issue 1 (§CPE_SCRUB_EYE_GATED)** — the scrub/timeline panel appeared immediately on Alt+C, before the eye (B/POV) was ever toggled. User: "Scrubber is new, is only to be ON under the Eye toggle." Fixed by removing the unconditional initial build; the panel now only exists while the eye is on (and, per the prior session's AND-gate, buildup is also checked).
- **Issue 2 (§CPE_VF_FRAME_DIAG, diagnosed not guess-fixed)** — "not well framed" investigated end to end. Position/FOV/aspect are all proven correct (bit-identical pose, hardcoded 60° FOV that can never drift, bit-identical rect/camera aspect) — no coordinate bug found. Added a live diagnostic (reusing effects.js's own established safe raycast pattern) logging nearest-surface-distance and frame-fill-fraction. Real samples show composition genuinely varies by beat (30-46% frame height on interior walk-throughs vs under 3% on wide establishing shots) — not a uniform defect. Honestly reported as diagnosed, not fixed.
- **Issue 3 (§CPE_SCRUB_PLAYHEAD_TICK)** — the blue progress line never moved during playback even though play/pause/resume worked. `step()` moved the camera every frame but never wrote the result back to `_state.scrubTn` nor called `_renderScrub()` — same bug shape as the earlier `§CPE_SCRUB_BEARING_FLY_PAUSE` fix. Fixed by mirroring `_scrubTo`'s own write pair inside the tick.

## Test plan
- [x] `node -c` syntax check
- [x] `npx eslint` — clean
- [x] `witness_cpe_scrub_viewfinder.js` (HHS_Office_Federated, live puppeteer) — 30/30 green, stable across repeated runs. `G-SCRUB-STANDALONE` retired (asserted the opposite of Issue 1's fix) → replaced by `G-SCRUB-EYE-GATED`; new `G-SCRUB-PLAYHEAD-TICK` and informational `G-VF-FRAME-DIAG`
- [x] `witness_dlod_vf_camguard.js` (different subsystem, unaffected) — 10/10 green
- [x] My own new frame-diagnostic was caught throwing on a raw scene-graph raycast during testing (would have silently broken B's real render every frame) — fixed by reusing the codebase's own established safe raycast pattern before shipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)