### PR TITLE
fix(cpe): single-owner toggling — Eye owns B+scrub panel, BuildUp owns Time Machine

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1705,10 +1705,13 @@
       // §CPE_VF_EYE_DRIVES_SCRUB (2026-08-05, user: "closing eye to act on it similar to opening
       // eye") — the eye toggle is the ONE control for both now, same button, no second widget.
       // Opening the eye brings the timeline back if a prior close removed it.
-      // §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2, user: "when buildup is unchecked it should not
-      // remain because it was called by buildup") — the timeline panel needs BOTH the eye ON AND
-      // buildup checked, an AND-gate, not eye-alone. Don't resurrect it here if buildup is off.
-      if (_state.buildup && !document.getElementById('cpe-scrub-panel')) {
+      // §CPE_SOLE_OWNER (2026-08-06, retires §CPE_BUILDUP_GATES_TM's AND-gate — user: "only
+      // respective owner owns its toggling. Eye toggles preview scrubber and POV... no one else
+      // can. BuildUp opens TimeMachine when preview is played and thus must close when BuildUp is
+      // unchecked" — confirmed live: the AND-gate let BuildUp reach into the Eye's widget, closing
+      // the scrub panel instead of TM, and blocked the Eye from re-opening it once buildup was off.
+      // The scrub panel is the Eye's alone now — buildup is never consulted here.
+      if (!document.getElementById('cpe-scrub-panel')) {
         _buildScrubPanel();
         _wireScrub(document.getElementById('cpe-scrub-track'));
         _wireScrubPlay();
@@ -2134,7 +2137,11 @@
         _state.scrubTn = tn;
         _renderScrub();
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
-        if (bkPrev && window.tmSetCursor) {
+        // §CPE_BUILDUP_OWNS_TM: `bkPrev` alone is a snapshot taken once at flight-start — it never
+        // saw a LIVE uncheck of #cpe-buildup mid-flight. Gate on `s.buildup` too so unchecking it
+        // stops feeding the cursor on the very next frame, instead of racing the checkbox handler's
+        // own toggleTimeMachine() close (see the change handler) every ~16ms until the flight ends.
+        if (bkPrev && s.buildup && window.tmSetCursor) {
           // §CPE_BUILDUP_WORK_PACED: the rehearsal asks for the SAME cursor the bake will ask for at
           // this film fraction — paced by elements placed, not by days elapsed. Falls back to the
           // old linear-calendar expression if cinema_maxq is an older cached copy.
@@ -2882,18 +2889,19 @@
         // this checkbox.
         console.log('§CPE_BUILDUP ' + (_state.buildup ? 'ON' : 'off') +
           ' — reveal FOLLOWS the Time Machine timeline as-is (no re-key; the camera does not author the build order)');
-        // §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2, user: "when buildup is unchecked it should not
-        // remain because it was called by buildup" / "it follows the Eye ... buildUp told u also")
-        // — the timeline panel needs BOTH the eye ON AND buildup checked (AND-gate, see the mirror
-        // of this in _toggleViewfinder's ON branch). Unchecking buildup tears it down regardless of
-        // the eye; re-checking it only rebuilds if the eye is ALSO already on.
-        if (!_state.buildup) {
-          _scrubPanelTeardown();
-        } else if (_state.vfOn && !document.getElementById('cpe-scrub-panel')) {
-          _buildScrubPanel();
-          _wireScrub(document.getElementById('cpe-scrub-track'));
-          _wireScrubPlay();
-          _renderScrub();
+        // §CPE_BUILDUP_OWNS_TM (2026-08-06, retires §CPE_BUILDUP_GATES_TM — user: "BuildUp opens
+        // TimeMachine when preview is played and thus must close when BuildUp is unchecked" /
+        // "closing buildUp can consistently just close TM if it is free... because buildup is
+        // coupled with TM construction process, no reason to meddle separately, this is for
+        // convention and user education"). BuildUp's ONLY territory is Time Machine now — the
+        // scrub/timeline panel is the Eye's alone (see _toggleViewfinder, no longer consulted here).
+        // "If it is free" — close it if it's actually on; a Time Machine the user has open for an
+        // unrelated reason and never touched via this checkbox is simply left alone by the `_tmOn`
+        // check below (nothing here forces it on either — that still only happens via a real Play,
+        // through tmActivateForBake in _previewFly, unchanged).
+        if (!_state.buildup && A()._tmOn && typeof window.toggleTimeMachine === 'function') {
+          window.toggleTimeMachine();
+          console.log('§CPE_BUILDUP_OWNS_TM closed Time Machine (was on, buildup just unchecked)');
         }
         _renderWhole(); _syncButtons();
       });

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -47,9 +47,10 @@
 //                       button now calls _previewFly(true), driving B alone, never the main canvas.
 //   G-VF-DRAG-WAKES-RENDER  dragging/resizing B's panel calls markDirty() on every move, not just on
 //                       release (§CPE_VF_DRAG_MARKDIRTY) — the real staleness cause behind OPEN 3.
-//   G-BUILDUP-GATES-TM  the timeline panel needs BOTH the eye ON and buildup checked
-//                       (§CPE_BUILDUP_GATES_TM) — cycling the eye while buildup is off must NOT
-//                       resurrect it, the actual bug this gate exists to catch.
+//   G-CPE-SOLE-OWNER    retires G-BUILDUP-GATES-TM's AND-gate (§CPE_SOLE_OWNER/§CPE_BUILDUP_OWNS_TM,
+//                       2026-08-06) — single owner per widget: Eye alone controls B + the scrub
+//                       panel regardless of buildup state; BuildUp alone controls Time Machine,
+//                       closing it (if on) when unchecked, never touching the scrub panel.
 //   G-SCRUB-CLOSE-TEARDOWN  closing the editor (Cancel) removes the scrub panel too.
 //   G-VF-FRAME-DIAG  (informational, not pass/fail) §CPE_VF_FRAME_DIAG diagnostic for the "not well
 //                       framed" composition/zoom complaint — logs real nearest-surface-distance and
@@ -597,37 +598,58 @@ async function gates(browser, BLD, repoDir) {
   P('G-VF-DRAG-WAKES-RENDER dragging B\'s panel calls markDirty() on every move (not just on release)',
     dragWake.calls >= 5, `markDirtyCallsDuring5Moves=${dragWake.calls}`);
 
-  // ── G-BUILDUP-GATES-TM: §CPE_BUILDUP_GATES_TM (2026-08-05, OPEN 2) — the timeline panel needs
-  // BOTH the eye ON and buildup checked (an AND-gate, user: "it follows the Eye" AND "buildUp told u
-  // also, when it is unchecked it should not remain because it was called by buildup"). B's eye is
-  // ON at this point (earlier gates left it on). B's own panel/hookInstalled state must be untouched
-  // by any of this — only the TIMELINE panel is gated by buildup, never B itself.
-  const gate = await page.evaluate(() => {
+  // ── G-CPE-SOLE-OWNER: §CPE_SOLE_OWNER / §CPE_BUILDUP_OWNS_TM (2026-08-06) — retires
+  // G-BUILDUP-GATES-TM's AND-gate, which let BuildUp reach into the Eye's own widget (the scrub
+  // panel) and blocked the Eye from restoring it once buildup was off — confirmed live by the user
+  // as the actual bug ("closing buildUp... closes the preview scrubber [instead of TM]... Eye icon
+  // no longer controls the preview scrubber... ownership is not tight"). New rule, single owner per
+  // widget: Eye alone owns B + the scrub/timeline panel; BuildUp alone owns Time Machine (close it
+  // if it's on when unchecked — "if it is free", never force it ON independently of a real Play).
+  // Time Machine is ALREADY on at this point in the suite (the G-VF-2/G-SCRUB-PLAY flight above
+  // armed it via tmActivateForBake and nothing has closed it since, by design until now) — this
+  // reuses that real state instead of re-arming a fresh flight.
+  const ownerBefore = await page.evaluate(() => ({
+    tmOn: !!window.APP._tmOn, vf: window.APP.cinemaPathEditor._probeVF(),
+    scrub: !!document.getElementById('cpe-scrub-panel')
+  }));
+  const ownerAfterUncheck = await page.evaluate(() => {
     const cb = document.getElementById('cpe-buildup');
-    const vfBefore = window.APP.cinemaPathEditor._probeVF();
-    // 1) Uncheck buildup (eye still ON) — timeline must go away.
     cb.checked = false;
     cb.dispatchEvent(new Event('change'));
-    const step1 = { scrubGone: !document.getElementById('cpe-scrub-panel'), vf: window.APP.cinemaPathEditor._probeVF() };
-    // 2) Toggle the eye OFF then back ON while buildup is STILL unchecked — timeline must NOT
-    // reappear (this is the actual bug the AND-gate exists to prevent: eye-alone used to resurrect it).
-    window.APP.cinemaPathEditor._vfToggle();   // eye off
-    window.APP.cinemaPathEditor._vfToggle();   // eye back on
-    const step2 = { scrubStillGone: !document.getElementById('cpe-scrub-panel'), vf: window.APP.cinemaPathEditor._probeVF() };
-    // 3) Re-check buildup (eye is on from step 2) — timeline must come back.
+    return { tmOn: !!window.APP._tmOn, vf: window.APP.cinemaPathEditor._probeVF(),
+             scrub: !!document.getElementById('cpe-scrub-panel') };
+  });
+  P('G-CPE-SOLE-OWNER unchecking buildup (TM currently on) closes Time Machine, B/scrub panel untouched',
+    ownerBefore.tmOn === true && ownerAfterUncheck.tmOn === false &&
+    ownerAfterUncheck.vf.on === ownerBefore.vf.on && ownerAfterUncheck.scrub === ownerBefore.scrub,
+    `tmBefore=${ownerBefore.tmOn} tmAfterUncheck=${ownerAfterUncheck.tmOn} vfOnBefore=${ownerBefore.vf.on} vfOnAfter=${ownerAfterUncheck.vf.on} scrubBefore=${ownerBefore.scrub} scrubAfter=${ownerAfterUncheck.scrub}`);
+
+  // Eye cycling while buildup is OFF must still fully control both panels (sole owner, no AND-gate)
+  // — the exact opposite of the retired G-BUILDUP-GATES-TM step2 assertion.
+  const eyeCycle = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    cpe._vfToggle();   // eye off -> both panels must go
+    const off = { vf: !!document.getElementById('cpe-vf-panel'), scrub: !!document.getElementById('cpe-scrub-panel') };
+    cpe._vfToggle();   // eye on -> both panels must return, even though buildup is still unchecked
+    const on = { vf: !!document.getElementById('cpe-vf-panel'), scrub: !!document.getElementById('cpe-scrub-panel'),
+                 buildupChecked: document.getElementById('cpe-buildup').checked };
+    return { off, on };
+  });
+  P('G-CPE-SOLE-OWNER eye alone controls both B and the scrub panel, independent of buildup state',
+    !eyeCycle.off.vf && !eyeCycle.off.scrub && eyeCycle.on.vf && eyeCycle.on.scrub && eyeCycle.on.buildupChecked === false,
+    `offState=${JSON.stringify(eyeCycle.off)} onState=${JSON.stringify(eyeCycle.on)}`);
+
+  // Re-check buildup: TM is left OFF (correct — "opens TimeMachine when preview is PLAYED", not on
+  // checkbox-check alone; only a real Play through tmActivateForBake turns it on).
+  const recheck = await page.evaluate(() => {
+    const cb = document.getElementById('cpe-buildup');
     cb.checked = true;
     cb.dispatchEvent(new Event('change'));
-    const step3 = { scrubBack: !!document.getElementById('cpe-scrub-track') };
-    return { vfBefore, step1, step2, step3 };
+    return { tmOn: !!window.APP._tmOn, scrub: !!document.getElementById('cpe-scrub-panel') };
   });
-  P('G-BUILDUP-GATES-TM unchecking buildup hides the timeline panel, B itself untouched',
-    gate.step1.scrubGone && gate.step1.vf.on === gate.vfBefore.on && gate.step1.vf.hookInstalled === gate.vfBefore.hookInstalled,
-    `scrubGoneOnUncheck=${gate.step1.scrubGone} vfOnUnchanged=${gate.step1.vf.on === gate.vfBefore.on} vfHookUnchanged=${gate.step1.vf.hookInstalled === gate.vfBefore.hookInstalled}`);
-  P('G-BUILDUP-GATES-TM cycling the eye while buildup is OFF does NOT resurrect the timeline (the actual AND-gate)',
-    gate.step2.scrubStillGone && gate.step2.vf.on === true,
-    `scrubStillGoneAfterEyeCycle=${gate.step2.scrubStillGone} vfOnAfterCycle=${gate.step2.vf.on}`);
-  P('G-BUILDUP-GATES-TM re-checking buildup (eye already on) restores the timeline panel',
-    gate.step3.scrubBack, `scrubTrackPresent=${gate.step3.scrubBack}`);
+  P('G-CPE-SOLE-OWNER re-checking buildup does not itself open Time Machine (only a real Play does)',
+    recheck.tmOn === false && recheck.scrub === true,
+    `tmOnAfterRecheck=${recheck.tmOn} scrubStillPresent=${recheck.scrub}`);
 
   // ── G-VF-FRAME-DIAG: informational only (Issue 2, "not well framed") — summarize every
   // §CPE_VF_FRAME_DIAG line logged during this whole run (scrubbing + the real rehearsal above


### PR DESCRIPTION
## Summary
- Eye (B's toggle) now exclusively owns B (POV inset) + the scrub/timeline panel — BuildUp no longer touches either.
- BuildUp now exclusively owns Time Machine — closes it on uncheck if it's on; never opens it by itself (only a real Play does, unchanged).
- `_previewFly`'s live cursor-follow now respects a mid-flight buildup uncheck immediately, instead of racing the checkbox handler's TM-close.

Root cause: the AND-gate shipped in an earlier session (§CPE_BUILDUP_GATES_TM) let BuildUp reach into the Eye's widget and blocked the Eye from restoring it once buildup was off — confirmed live by the user, spec restated directly this session: "only respective owner owns its toggling."

Full write-up: bim-compiler `prompts/CINEMA_PATH_EDITOR.md`, session "SESSION 2026-08-06 (SAME DAY, FOLLOW-ON)".

## Test plan
- [x] `witness_cpe_scrub_viewfinder.js` 30/30 green (Duplex) — `G-BUILDUP-GATES-TM` replaced with `G-CPE-SOLE-OWNER` (3 new gates), all 27 pre-existing gates unaffected
- [x] `npx eslint viewer/cinema_path_editor.js witness_cpe_scrub_viewfinder.js` clean
- [x] Sandbox-reproduced the exact live sequence (eye on → povOnly flight → pause → uncheck buildup) before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)