### PR TITLE
fix(4d): §TM_PANEL_RESIZE_H targets the inner Gantt box, not the outer panel

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4940,39 +4940,43 @@
   }
 
   // §TM_PANEL_RESIZE_H — companion to wirePanelResize() above, same grip/pointer-capture pattern,
-  // mirrored onto the panel's bottom edge. _panel has no height cap of its own (it grows to fit
-  // content, anchored bottom:80px), so growing it means giving it an explicit max-height + scroll
-  // once the user has dragged at least once; until then it stays at its natural intrinsic height.
-  var _panelH = 0;
-  var PANEL_H_MIN = 160;
-
+  // mirrored onto the panel's bottom edge. FIX (2026-08-06, user: "it seems there is an inner frame
+  // for the gantt chart panel... it does not be max" — confirmed live): this used to grow the OUTER
+  // _panel shell only, leaving the actual content (#tm-gantt-box, the Gantt canvas) clipped at its
+  // own separate height cap — so the drag looked like it worked but never uncrammed any content.
+  // Now it drives the SAME #tm-gantt-box / _ganttBoxH that the internal top-strip grip
+  // (wireGanttResize, §GANTT_RESIZE E6) already owns — this is just a second, more discoverable
+  // entry point to that one real resize, not a second independent mechanism. _panel itself has no
+  // height cap of its own (flex column, grows to fit content) so it naturally follows the box taller
+  // — no outer-panel style needed at all, exactly like the top-strip grip already proves works.
   function wirePanelResizeHeight() {
     var grip = document.getElementById('tm-panel-resize-grip-b');
-    if (!grip || !_panel || grip._wired) return;
+    var box = document.getElementById('tm-gantt-box');
+    if (!grip || !box || grip._wired) return;
     grip._wired = true;
     var startY = 0, startH = 0, dragging = false;
     grip.addEventListener('pointerdown', function (e) {
-      dragging = true; startY = e.clientY; startH = _panel.getBoundingClientRect().height;
-      _panel.classList.add('tm-panel-resizing');
+      dragging = true; startY = e.clientY; startH = box.clientHeight;
+      if (_panel) _panel.classList.add('tm-panel-resizing');
       grip.classList.add('tm-gripping');
       grip.setPointerCapture(e.pointerId); e.preventDefault(); e.stopPropagation();
     });
     grip.addEventListener('pointermove', function (e) {
       if (!dragging) return;
-      var maxH = Math.round(window.innerHeight * 0.85);
-      var h = Math.max(PANEL_H_MIN, Math.min(maxH, Math.round(startH + (e.clientY - startY))));
-      _panelH = h;
-      _panel.style.maxHeight = h + 'px';
-      _panel.style.overflowY = 'auto';
+      // Grip sits at the drawer's BOTTOM edge (opposite of tm-gantt-grip's top-edge placement), so
+      // dragging DOWN (positive dy) grows it — same clamp bounds as wireGanttResize for consistency.
+      var h = Math.max(80, Math.min(Math.round(window.innerHeight * 0.75), startH + (e.clientY - startY)));
+      _ganttBoxH = h;
+      box.style.maxHeight = h + 'px';
       e.preventDefault(); e.stopPropagation();
     });
     function end(e) {
       if (!dragging) return;
       dragging = false;
-      _panel.classList.remove('tm-panel-resizing');
+      if (_panel) _panel.classList.remove('tm-panel-resizing');
       grip.classList.remove('tm-gripping');
       try { grip.releasePointerCapture(e.pointerId); } catch (err) {}
-      console.log('§TM_PANEL_RESIZE_H height=' + _panelH + 'px');
+      console.log('§TM_PANEL_RESIZE_H height=' + _ganttBoxH + 'px rows=' + _ganttTasks.length);
     }
     grip.addEventListener('pointerup', end);
     grip.addEventListener('pointercancel', end);

--- a/witness_tm_panel_resize_h.js
+++ b/witness_tm_panel_resize_h.js
@@ -7,6 +7,13 @@
 //   grows the panel in the wrong direction (a resize handle that shrinks when dragged the way a user
 //   expects to grow is worse than none — same class of bug the width grip's own comment warns about).
 //
+//   UPDATED 2026-08-06 — real regression caught live by the user AFTER the above shipped: "it seems
+//   there is an inner frame for the gantt chart panel... it does not be max". The first cut grew the
+//   OUTER _panel shell only; the actual content (#tm-gantt-box) has its own separate height cap and
+//   never grew, so the drag looked like it worked but never uncrammed anything. This witness now
+//   asserts the grip drives #tm-gantt-box / _ganttBoxH — the SAME target the internal top-strip grip
+//   (wireGanttResize) already owns — not the outer panel.
+//
 //   Static-source check, same style as witness_gantt_palette.js: reads the values straight out of
 //   viewer/time_machine.js so it tests what actually ships, not a copy that can drift.
 var fs = require('fs');
@@ -38,22 +45,40 @@ check('G-PRH-6 width-grip-still-wired', /function wirePanelResize\s*\(\)/.test(t
 //     because that one sits ABOVE its content; a bottom-edge handle sits BELOW its content, so the
 //     sign must flip or the drawer would shrink exactly when the user expects it to grow.
 var fnIdx = txt.indexOf('function wirePanelResizeHeight');
-var fnSlice = fnIdx >= 0 ? txt.slice(fnIdx, fnIdx + 1400) : '';
+var fnSlice = fnIdx >= 0 ? txt.slice(fnIdx, fnIdx + 1700) : '';
 check('G-PRH-7 grows-on-downward-drag', /startH \+ \(e\.clientY - startY\)/.test(fnSlice),
   'expected startH + (e.clientY - startY), i.e. dragging down increases height');
 check('G-PRH-8 no-inverted-sign-leftover', !/startY - e\.clientY/.test(fnSlice));
 
 // 4 — clamped, not unbounded (an unclamped drag can push the panel off-screen or to zero height).
-check('G-PRH-9 min-height-clamped', /PANEL_H_MIN/.test(fnSlice) && /Math\.max\(PANEL_H_MIN/.test(fnSlice));
-check('G-PRH-10 max-height-clamped-to-viewport', /window\.innerHeight \* 0\.85/.test(fnSlice));
+//     Same bounds as wireGanttResize's own clamp — deliberately reused, not reinvented.
+check('G-PRH-9 min-height-clamped', /Math\.max\(80,/.test(fnSlice));
+check('G-PRH-10 max-height-clamped-to-viewport', /window\.innerHeight \* 0\.75/.test(fnSlice));
 
 // 5 — a real witness log line ships, same convention as §TM_PANEL_RESIZE's own width log, so the
 //     drag is provable from console output (§ FUNDAMENTAL LAW: log values, not a screenshot).
-check('G-PRH-11 logs-tm-panel-resize-h', /console\.log\('§TM_PANEL_RESIZE_H height=' \+ _panelH \+ 'px'\)/.test(fnSlice));
+check('G-PRH-11 logs-tm-panel-resize-h', /console\.log\('§TM_PANEL_RESIZE_H height=' \+ _ganttBoxH \+/.test(fnSlice));
 
 // 6 — CSS hover/gripping affordance mirrors the existing width grip (visual parity, not a
 //     second-class handle).
 check('G-PRH-12 hover-style-present', txt.indexOf('#tm-panel-resize-grip-b:hover,#tm-panel-resize-grip-b.tm-gripping') >= 0);
+
+// 7 — THE REGRESSION ITSELF: the grip must target #tm-gantt-box / _ganttBoxH (the real content,
+//     same variable wireGanttResize already writes), NOT the outer _panel shell. This is the exact
+//     check that would have caught the shipped bug before it reached the user.
+check('G-PRH-13 targets-inner-gantt-box-not-outer-panel',
+  /var box = document\.getElementById\('tm-gantt-box'\)/.test(fnSlice) &&
+  /_ganttBoxH = h/.test(fnSlice) && /box\.style\.maxHeight = h \+ 'px'/.test(fnSlice));
+check('G-PRH-14 no-outer-panel-maxheight-leftover',
+  !/_panel\.style\.maxHeight/.test(fnSlice) && !/_panel\.style\.overflowY/.test(fnSlice));
+
+// 8 — shares real state with the top-strip grip: both must write the SAME _ganttBoxH variable, and
+//     that value must be the one drawGanttMini/re-render actually applies (time_machine.js's own
+//     `if (_ganttBoxH) box.style.maxHeight = ...` re-apply-on-redraw line), so a resize survives a
+//     data refresh instead of being silently reset.
+check('G-PRH-15 shared-ganttBoxH-with-top-strip-grip',
+  (txt.match(/_ganttBoxH = h/g) || []).length >= 2);
+check('G-PRH-16 reapplied-on-redraw', /if \(_ganttBoxH\) box\.style\.maxHeight = _ganttBoxH \+ 'px'/.test(txt));
 
 console.log('§W-PRH RESULT pass=' + pass + ' fail=' + fail);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
- Fixes a regression in PR #1208: the drawer's bottom-edge resize grip grew the outer `_panel` shell only, leaving the real content (`#tm-gantt-box`, the Gantt canvas) clipped at its own separate height cap — so the drag looked live but never uncrammed any content. Caught live by the user: "there is an inner frame for the gantt chart panel... it does not be max."
- Fix: the grip now drives `#tm-gantt-box`/`_ganttBoxH` directly — the same target the internal top-strip grip (`wireGanttResize`) already owns. Second entry point, not a second mechanism.

## Test plan
- [x] `node --check viewer/time_machine.js`
- [x] `node witness_tm_panel_resize_h.js` — 16/16 (added checks that would have caught the original bug: targets `#tm-gantt-box` not `_panel`, shares `_ganttBoxH` with the top-strip grip, survives redraw re-apply)