### PR TITLE
feat(modeller): whole-room move (GEOM_ROOM_MOVE) + gated free item drag — ROOM_MOVE_AND_ITEM_DRAG_SPEC.md

### DIFF
--- a/modeller/bonsai_itemdrag.js
+++ b/modeller/bonsai_itemdrag.js
@@ -1,0 +1,333 @@
+/**
+ * BIM OOTB — Free single-item interactive drag (Feature B of ROOM_MOVE_AND_ITEM_DRAG_SPEC.md).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// bonsai_itemdrag.js — Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3 (Feature B) —
+// Witness: W-ITEM-DRAG-GATE.
+//
+// Drag ONE non-structural leaf element. The load-bearing rule of this whole file (spec §1 item 5 / §3.2 / §3.4):
+//
+//   REFUSE, DON'T FABRICATE.
+//
+// The session is gated UP FRONT by real_placement_resolver.js's `resolveRealPlacement()`. On NO MATCH that gate
+// THROWS a `WalkerGapError` and this module lets it PROPAGATE — the drag never starts and the item never moves.
+// There is deliberately NO catch-and-substitute of the element's own AABB, of a catalog box, or of any constant
+// as a stand-in validation box: that silent substitution is, verbatim from the gate's own header, "the exact
+// violation this gate exists to make structurally hard to reintroduce". This is knowingly STRICTER than
+// pascalorg's `{valid:false}`-and-retry, and it is NOT to be softened (spec §4 non-goal).
+//
+// Q5 — RESOLVED AGAINST THE LIVE CODE, and the answer is "refuse" for every element in the log today:
+//   • What the walkers pass: routewalker.js:1177 calls `resolveRealPlacement({discipline, category: product,
+//     ifc_class, productHint: product})` where `product` is an `ad_space_type_mep_bom.mep_product_id` value
+//     ('TOILET','SINK','OUTLET','SWITCH','LIGHT','SPRINKLER',…) — routewalker.js:1151.
+//   • What survives into the op-log: NOTHING of that identity. `bonsai_oplog.js` `commit()` persists exactly
+//     `{op_type, params: op.parameters}` (bonsai_oplog.js:322) — the product identity rides on the SIDECAR
+//     fields `_rw` (modeller.html:3104) / `_dw` (modeller.html:4325), which are properties of the JS op object
+//     and are never written to `kernel_ops`. A committed fixture's `parameters` are `{hash, placement, lod,
+//     color}`; an ARC-seeded element's are `{bbox, color, provenance, ifc_class, opacity, …}`
+//     (arc_editable.js:275). Neither carries a product id or alias key.
+//   • What we deliberately DO NOT do: derive a hint from `parameters.hash`. modeller.html's `FIX_HASH`
+//     (modeller.html:3076-3078) is NOT invertible — it is many-to-one (`OUTLET` and `OUTLET_GFCI` both map to
+//     `ROLE__OUTLET`) and non-uniform (`CEILING_FAN`→`ROLE__FAN`, `SUPPLY_DIFFUSER`→`ROLE__DIFFUSER`), and
+//     `hashFor()` falls back to "any catalog box of the right ifc_class" anyway, so the committed hash is not
+//     even reliably a role hash. Inverting it would be INVENTING an equivalence. Likewise we do not parse
+//     `elements_meta.name` — the resolver's own header rules out fuzzy/semantic matching.
+//   ⇒ Consequence, and it is the spec's own anticipated outcome: with today's substrate an item drag on a
+//     log-sourced element REFUSES at `beginItemDragSession`. A caller that genuinely HOLDS the product id at
+//     drag time (e.g. a catalog-drop flow that still has it in hand) may pass `opts.productHint` and the drag
+//     proceeds on REAL dims. Nothing is ever derived, defaulted, or guessed.
+//
+// DUAL-EXPORT (window + node) like sdg_cascade.js / real_placement_resolver.js so the witness runs pure-node.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.BonsaiItemDrag = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+  var TAG = '§ITEMDRAG';
+
+  // Same literal list bonsai_gridmove.js declares (bonsai_gridmove.js:64-65). Copied, not imported, so this
+  // module stays pure/node-witnessable and the grid adapter is never modified by this feature.
+  var STRUCTURAL_CLASSES = ['IfcWall', 'IfcWallStandardCase', 'IfcSlab', 'IfcFooting', 'IfcColumn', 'IfcBeam',
+    'IfcRailing', 'IfcStairFlight', 'IfcRoof'];
+
+  // requires_host (a REAL `ad_product_dim` column value — 'WALL'/'FLOOR'/'CEILING', see
+  // real_placement_resolver.js:43-62) → the IFC classes that can physically BE that host. A DISCLOSED mapping
+  // over class names that already exist literally in STRUCTURAL_CLASSES above; no new class name is introduced.
+  // Note IfcSlab appears under both FLOOR and CEILING on purpose: which one a given slab IS is decided
+  // GEOMETRICALLY below (top face under the item vs underside above it), never by its name.
+  var HOST_CLASSES = {
+    WALL: ['IfcWall', 'IfcWallStandardCase'],
+    FLOOR: ['IfcSlab', 'IfcFooting'],
+    CEILING: ['IfcSlab', 'IfcRoof']
+  };
+  var HOST_TOL = 0.05;      // m — the SAME tolerance sdg_gate.js's own withinXY oracle uses (see
+                            // witness_stretch_ride.js:61-64, which replicates it verbatim).
+  var OVERLAP_EPS = 1e-6;   // m — flush face CONTACT (0 overlap) is adjacency, not a clash: cross_edges.js's
+                            // faceTouch treats a 0-overlap face as a TOUCH, and modeller.html's `_gateRel`
+                            // (modeller.html:2503-2510) declares abuts/hosted-by EXPECTED contact, never a clash.
+
+  function box(cx, cy, cz, w, d, h) {
+    return [cx - w / 2, cx + w / 2, cy - d / 2, cy + d / 2, cz - h / 2, cz + h / 2];
+  }
+  function overlaps(a, b) {
+    return (Math.min(a[1], b[1]) - Math.max(a[0], b[0])) > OVERLAP_EPS &&
+           (Math.min(a[3], b[3]) - Math.max(a[2], b[2])) > OVERLAP_EPS &&
+           (Math.min(a[5], b[5]) - Math.max(a[4], b[4])) > OVERLAP_EPS;
+  }
+  function planOverlaps(a, b, tol) {
+    tol = tol || 0;
+    return (Math.min(a[1], b[1]) - Math.max(a[0], b[0])) > -tol &&
+           (Math.min(a[3], b[3]) - Math.max(a[2], b[2])) > -tol;
+  }
+
+  // ── §3.1 ELIGIBILITY ────────────────────────────────────────────────────────────────────────────────
+  // A HOST (anything appearing as `host_guid` in the REAL rel_fills_host edges) is EXCLUDED — walls move via
+  // gridmove or Feature A. A structural class is excluded. A FILLING may be dragged (sdg_cascade.js's own
+  // directional rule says it never drags its host) — Q5 note: filling-drag is IN scope only insofar as the
+  // gate lets it start; there is no separate along-host slide constraint in v1 (spec §3.1 defers it to Q5,
+  // and the §3.3 host constraint already binds a WALL-hosted item to a real wall face).
+  function eligibility(ctx) {
+    var fid = ctx.fid, guidByFid = ctx.guidByFid || {}, cls = (ctx.classByFid || {})[fid];
+    var structural = ctx.structuralClasses || STRUCTURAL_CLASSES;
+    if (cls != null && structural.indexOf(cls) !== -1)
+      return { ok: false, reason: 'structural-class:' + cls };
+    var g = guidByFid[fid];
+    if (g != null && Array.isArray(ctx.fills)) {
+      for (var i = 0; i < ctx.fills.length; i++) if (ctx.fills[i] && ctx.fills[i].host_guid === g)
+        return { ok: false, reason: 'is-a-host (rel_fills_host host_guid) — hosts move via gridmove or GEOM_ROOM_MOVE' };
+    }
+    return { ok: true };
+  }
+
+  // ── §3.2 SESSION START — THE GATE, UP FRONT ─────────────────────────────────────────────────────────
+  // ctx: { fid, insertParams, boxByFid, classByFid, guidByFid, fills, resolver, discipline?, productHint? }
+  // MATCH  → returns the session holding the REAL {width,depth,height,anchor{requires_host,conn_points},
+  //          matchedProductId,source} and the pre-drag box, and the drag begins.
+  // NO MATCH → the resolver's WalkerGapError PROPAGATES (uncaught here, by design). The caller must log it and
+  //          count the drag refused; the item does not move.
+  function beginItemDragSession(ctx) {
+    ctx = ctx || {};
+    var fid = ctx.fid;
+    var el = eligibility(ctx);
+    if (!el.ok) {
+      console.error(TAG + ' REFUSED fid=' + fid + ' — ' + el.reason + ' (spec §3.1)');
+      return null;
+    }
+    var boxByFid = ctx.boxByFid || {};
+    var pre = boxByFid[fid];
+    if (!pre) {
+      console.error(TAG + ' REFUSED fid=' + fid + ' — no pre-drag AABB in the session snapshot (nothing honest to snap back to)');
+      return null;
+    }
+    var params = ctx.insertParams || {};
+    var resolver = ctx.resolver ||
+      (typeof window !== 'undefined' && window.RealPlacementResolver) || null;
+    if (!resolver || !resolver.resolveRealPlacement)
+      throw new Error(TAG + ' RealPlacementResolver not loaded — cannot gate the drag; refusing rather than proceeding ungated');
+    // productHint: ONLY what the caller genuinely holds. Never derived from params.hash / elements_meta.name
+    // (see the Q5 block in this file's header). Absent ⇒ the resolver throws ⇒ the drag refuses. That is the
+    // designed outcome, not a gap to paper over.
+    var real = resolver.resolveRealPlacement({
+      discipline: ctx.discipline || null,
+      category: ctx.productHint || null,
+      ifc_class: params.ifc_class || null,
+      productHint: ctx.productHint || null
+    });
+    var session = {
+      fid: fid, real: real, preBox: pre.slice(),
+      preCentre: [(pre[0] + pre[1]) / 2, (pre[2] + pre[3]) / 2, (pre[4] + pre[5]) / 2],
+      // §SCALE_CHECK_FIX-style session cache: every OTHER element's pre-drag AABB, built ONCE. The dragged fid
+      // is excluded here so the per-frame collision test never has to re-filter it.
+      gateBoxes: (function () { var o = {}; Object.keys(boxByFid).forEach(function (k) { if (String(k) !== String(fid)) o[k] = boxByFid[k]; }); return o; })(),
+      classByFid: ctx.classByFid || {}
+    };
+    console.log(TAG + ' §SESSION begin fid=' + fid + ' product=' + real.matchedProductId +
+      ' dims(w,d,h)=' + real.width + ',' + real.depth + ',' + real.height +
+      ' requires_host=' + real.anchor.requires_host + ' source=' + real.source);
+    return session;
+  }
+
+  // ── §3.3 PER-FRAME VALIDATION CONTRACT ──────────────────────────────────────────────────────────────
+  // canDropAt(session, x, y, z) -> { valid, conflictIds, snappedPos?, reason }
+  // PURE. Session-cached inputs only. Validity is decided AT THE CANDIDATE; `snappedPos` is returned ONLY when
+  // derived from a REAL host surface (flush-to-face), and NEVER as a nudge away from a conflict. Unlike
+  // pascalorg's `adjustedY` we never return a corrected position that converts an invalid drop into a valid one.
+  function canDropAt(session, x, y, z) {
+    if (!session) return { valid: false, conflictIds: [], reason: 'no-session' };
+    var r = session.real, need = r.anchor && r.anchor.requires_host;
+    var cand = box(x, y, z, r.width, r.depth, r.height);
+
+    // The HOST is resolved FIRST because the collision test needs to know which box to exclude — but the two
+    // failures are REPORTED in the spec §3.3 order (collision, then host), and a collision always carries its
+    // offending fids, so a refusal never hides which real elements were in the way.
+    var host = need ? resolveHost(session, cand, need) : { fid: null, snapped: null };
+
+    // COLLISION — the item's REAL resolved dims at the candidate vs the session's box snapshot. The RESOLVED
+    // HOST is excluded (and only it): a wall-hung sink necessarily contacts its own host, and modeller.html's
+    // `_gateRel` (modeller.html:2503-2510) already declares hosted-by contact EXPECTED, never a clash.
+    var conflictIds = [];
+    Object.keys(session.gateBoxes).forEach(function (k) {
+      if (host.fid != null && String(k) === String(host.fid)) return;
+      if (overlaps(cand, session.gateBoxes[k])) conflictIds.push(k);
+    });
+    if (conflictIds.length) return { valid: false, conflictIds: conflictIds, reason: 'collision' };
+
+    // HOST CONSTRAINT — a real host of the REQUIRED kind must exist at the candidate position.
+    if (need && !host.fid) return { valid: false, conflictIds: [], reason: 'no-host:' + need };
+
+    return { valid: true, conflictIds: [], snappedPos: host.snapped, hostFid: host.fid, reason: 'ok' };
+  }
+
+  // Resolve a REAL host surface of the required kind under the candidate. Every branch reads only measured
+  // AABBs + the real committed ifc_class — no invented surfaces, no "nearest anything" fallback.
+  function resolveHost(session, cand, need) {
+    var classes = HOST_CLASSES[need];
+    if (!classes) return { fid: null, snapped: null };      // an unknown requires_host value → no host, refuse
+    var cx = (cand[0] + cand[1]) / 2, cy = (cand[2] + cand[3]) / 2, cz = (cand[4] + cand[5]) / 2;
+    var w = cand[1] - cand[0], d = cand[3] - cand[2], h = cand[5] - cand[4];
+    var best = null;
+    Object.keys(session.gateBoxes).forEach(function (k) {
+      var cls = session.classByFid[k];
+      if (cls == null || classes.indexOf(cls) === -1) return;
+      var b = session.gateBoxes[k];
+      if (need === 'WALL') {
+        // A WALL host: the candidate centre sits within the wall's own plan footprint (± tol) and the two
+        // overlap in Z. Flush-to-face snap along the wall's THIN plan axis — a derivation from the real face.
+        if (cx < b[0] - HOST_TOL || cx > b[1] + HOST_TOL || cy < b[2] - HOST_TOL || cy > b[3] + HOST_TOL) return;
+        if ((Math.min(cand[5], b[5]) - Math.max(cand[4], b[4])) <= 0) return;
+        var ex = b[1] - b[0], ey = b[3] - b[2];
+        var snapped = ex <= ey
+          ? [(Math.abs(cx - b[0]) <= Math.abs(cx - b[1]) ? b[0] - d / 2 : b[1] + d / 2), cy, cz]
+          : [cx, (Math.abs(cy - b[2]) <= Math.abs(cy - b[3]) ? b[2] - d / 2 : b[3] + d / 2), cz];
+        if (!best) best = { fid: k, snapped: snapped };
+      } else if (need === 'FLOOR') {
+        // A FLOOR host: a slab/footing that plan-overlaps the candidate and whose TOP face is at or below the
+        // candidate's underside (± tol). Snap = seat flush on that real top face. Highest such top wins.
+        if (!planOverlaps(cand, b, HOST_TOL)) return;
+        if (cand[4] < b[5] - HOST_TOL) return;
+        if (!best || b[5] > best._top) best = { fid: k, snapped: [cx, cy, b[5] + h / 2], _top: b[5] };
+      } else {
+        // A CEILING host: a slab/roof that plan-overlaps and whose UNDERSIDE is at or above the candidate's
+        // top (± tol). Snap = hang flush from that real underside. Lowest such underside wins.
+        if (!planOverlaps(cand, b, HOST_TOL)) return;
+        if (cand[5] > b[4] + HOST_TOL) return;
+        if (!best || b[4] < best._under) best = { fid: k, snapped: [cx, cy, b[4] - h / 2], _under: b[4] };
+      }
+    });
+    return best ? { fid: best.fid, snapped: best.snapped } : { fid: null, snapped: null };
+  }
+
+  // ── §3.4 DROP BEHAVIOR ──────────────────────────────────────────────────────────────────────────────
+  // Resolve the drop into the delta to commit — or into a REFUSAL. PURE (the commit itself is browser-side).
+  //   valid:true  → ONE existing-shape op {op_type:'GEOM_MOVE', parameters:{parent:fid, dx,dy,dz}}. The
+  //                 committed position is the SNAPPED one when the host produced one (binding a VALID drop to
+  //                 its real host face), else the candidate itself. No new op type — the GEOM_MOVE fold branch
+  //                 already exists (bonsai_kernel.js:238-247 host side, bonsai_kernel_worker.js:461 worker side).
+  //   valid:false → NO COMMIT. The item stays at its pre-drag position (the session cache holds it). Never
+  //                 place-then-flag, never auto-relocate to the nearest free spot.
+  function resolveDrop(session, x, y, z) {
+    var v = canDropAt(session, x, y, z);
+    if (!v.valid) return { committed: false, op: null, verdict: v };
+    var p = v.snappedPos || [x, y, z], c = session.preCentre;
+    return {
+      committed: true, verdict: v,
+      op: { op_type: 'GEOM_MOVE', parameters: { parent: session.fid, dx: p[0] - c[0], dy: p[1] - c[1], dz: p[2] - c[2] } }
+    };
+  }
+
+  var API = {
+    STRUCTURAL_CLASSES: STRUCTURAL_CLASSES, HOST_CLASSES: HOST_CLASSES, HOST_TOL: HOST_TOL,
+    eligibility: eligibility, beginItemDragSession: beginItemDragSession,
+    canDropAt: canDropAt, resolveHost: resolveHost, resolveDrop: resolveDrop
+  };
+
+  // ── BROWSER lifecycle — mirrors bonsai_gridmove.js in STRUCTURE (session cache at grab, one shared
+  //    preview/commit pipeline, caches dropped at end).
+  if (typeof window !== 'undefined') {
+    var ID = {
+      _session: null,
+
+      _buildBoxByFid: function () {
+        var g = window.Bonsai && window.Bonsai.group && window.Bonsai.group(), out = {};
+        if (!g) return out;
+        g.children.forEach(function (m) {
+          if (m.isMesh && m.userData && m.userData.featureId != null) {
+            m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox;
+            out[m.userData.featureId] = [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z];
+          }
+        });
+        return out;
+      },
+      _buildClassByFid: function () {
+        var out = {}, O = window.Bonsai && window.Bonsai.oplog;
+        if (!O || !O.db) return out;
+        try {
+          var r = O.db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='GEOM_INSERT'");
+          if (r.length) r[0].values.forEach(function (v) {
+            try { var p = JSON.parse(v[1]); if (p && p.ifc_class) out[v[0]] = p.ifc_class; } catch (e) { }
+          });
+        } catch (e) { }
+        return out;
+      },
+      _insertParams: function (fid) {
+        var O = window.Bonsai && window.Bonsai.oplog;
+        if (!O || !O.db) return {};
+        try {
+          var r = O.db.exec("SELECT parameters FROM kernel_ops WHERE id=" + (+fid) + " AND op_type='GEOM_INSERT'");
+          if (r.length && r[0].values.length) return JSON.parse(r[0].values[0][0]);
+        } catch (e) { }
+        return {};
+      },
+
+      // Grab. THROWS WalkerGapError on no product match — the caller logs it (the resolver already
+      // console.error'd) and counts the drag refused. Nothing is substituted.
+      beginItemDragSession: function (fid, opts) {
+        opts = opts || {};
+        this._session = beginItemDragSession({
+          fid: fid,
+          insertParams: this._insertParams(fid),
+          boxByFid: this._buildBoxByFid(),
+          classByFid: this._buildClassByFid(),
+          guidByFid: window.__arcGuidByFid || {},
+          fills: (window.swXEdges && window.swXEdges.fills) || null,
+          resolver: window.RealPlacementResolver,
+          discipline: opts.discipline || null,
+          productHint: opts.productHint || null
+        });
+        return this._session;
+      },
+      // Per-frame preview — the SAME function commit() calls, so tint and commit can never disagree.
+      canDropAt: function (x, y, z) { return canDropAt(this._session, x, y, z); },
+
+      commit: async function (x, y, z) {
+        var s = this._session;
+        if (!s) { console.error(TAG + ' commit with no active session — refused'); return { committed: false }; }
+        var d = resolveDrop(s, x, y, z);
+        if (!d.committed) {
+          console.error(TAG + ' REFUSED drop fid=' + s.fid + ' reason=' + d.verdict.reason +
+            (d.verdict.conflictIds.length ? ' conflicts=[' + d.verdict.conflictIds.join(',') + ']' : '') +
+            ' — NO COMMIT, item stays at its pre-drag position (never auto-relocated). Spec §3.4');
+          return { committed: false, verdict: d.verdict };
+        }
+        var P = d.op.parameters;
+        var res = await window.Bonsai.oplog.commit({ op_type: d.op.op_type, parameters: P }, {});
+        console.log(TAG + ' commit fid=' + s.fid + ' Δ(' + P.dx.toFixed(3) + ',' + P.dy.toFixed(3) + ',' + P.dz.toFixed(3) + ')' +
+          ' host=' + d.verdict.hostFid + (d.verdict.snappedPos ? ' snapped-to-real-host-face' : '') +
+          ' verify=' + res.verify);
+        return Object.assign({ committed: true, verdict: d.verdict }, res);
+      },
+
+      endDragSession: function () {
+        if (this._session) console.log(TAG + ' §SESSION end — gate/box caches cleared');
+        this._session = null;
+      }
+    };
+    Object.keys(API).forEach(function (k) { if (ID[k] === undefined) ID[k] = API[k]; });
+    window.Bonsai = window.Bonsai || {};
+    window.Bonsai.itemdrag = ID;
+    console.log(TAG + ' module loaded');
+  }
+
+  return API;
+});

--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -247,6 +247,21 @@
         else { a.fx *= P.fx != null ? P.fx : 1; a.fy *= P.fy != null ? P.fy : 1; a.fz *= P.fz != null ? P.fz : 1; }   // GEOM_SCALE: net multiplicative scale (W-BONSAI-SCALE PATH B)
         moveBy.set(P.parent, a);
       }
+      // §ROOMMOVE — Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.4 — Witness: W-ROOM-MOVE.
+      // ONE signed GEOM_ROOM_MOVE row carries the whole resolved member list plus ONE rigid (dx,dy,dz): the spec's
+      // own words, "semantically N GEOM_MOVEs, folded from one row". It accumulates into the SAME net-per-feature
+      // delta map the GEOM_MOVE loop above fills, so bonsai_library.js foldInsert applies it through its EXISTING
+      // `mv` path — that file needs (and gets) ZERO change. The accumulation itself lives in bonsai_roommove.js so
+      // the production fold and the pure-node witnesses share exactly ONE definition of what the op means; it is
+      // resolved LAZILY at call time (this codebase's own "check window.X fresh at call time" pattern —
+      // cross_edges.js:52 documents why a load-time capture would freeze a null). Module absent ⇒ REFUSE to
+      // half-apply: warn loudly and fold nothing, never a partial room move.
+      for (const op of ops) {
+        if (op.op_type !== 'GEOM_ROOM_MOVE') continue;
+        const RM = (typeof window !== 'undefined' && window.Bonsai) ? window.Bonsai.roommove : null;
+        if (!RM || !RM.accumulate) { console.warn(TAG + ' §ROOMMOVE bonsai_roommove.js not loaded — GEOM_ROOM_MOVE rows NOT folded (refusing to half-apply)'); break; }
+        RM.accumulate(typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters, moveBy);
+      }
       // §STRETCH-1: GEOM_GRID_MOVE makes inserts grid-STRETCHABLE host-side. Collect each op's per-feature commands
       // IN OP ORDER (the worker folds B-rep solids; inserts are skipped there → host-side here, NO double-apply).
       const gridBy = new Map();                                          // featureId -> [command,…] (ordered)

--- a/modeller/bonsai_kernel_worker.js
+++ b/modeller/bonsai_kernel_worker.js
@@ -537,6 +537,24 @@ function buildSolids(kernel, ops, seedBoxes) {
         }
         shapeCache.set(ckey, out); solids.set(c.featureId, { shape: out, hash: ckey });
       }
+    } else if (op.op_type === 'GEOM_ROOM_MOVE') {     // §ROOMMOVE — one op rigidly translates N members (W-ROOM-MOVE)
+      // Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.4. Structurally the GEOM_GRID_MOVE branch
+      // above, minus everything that cannot occur here: a room move is a PURE RIGID TRANSLATION by ONE (dx,dy,dz)
+      // shared by every member — no SCALE ever happens, so none of the anchored-min / §SCALE-YAW-GUARD /
+      // §ROTATION-GUARD-3AXIS machinery applies (a translation is yaw- and tilt-safe by construction). Same
+      // cache-per-(op_hash, featureId) discipline. TOLERANT like GEOM_MOVE/GRID_MOVE (NOT CUT's throw): a member
+      // that is a HOST-folded GEOM_INSERT is not in this worker's solids map and is a silent no-op here — it is
+      // re-placed host-side via library.foldInsert's `mv` path (PATH B, see bonsai_kernel.js §ROOMMOVE).
+      const dx = P.dx || 0, dy = P.dy || 0, dz = P.dz || 0;
+      for (const m of (P.members || [])) {
+        if (!m || m.featureId == null) continue;
+        const pe = solids.get(m.featureId); if (!pe) continue;
+        const ckey = key + ':' + m.featureId;
+        if (shapeCache.has(ckey)) { _stats.hits++; solids.set(m.featureId, { shape: shapeCache.get(ckey), hash: ckey }); continue; }
+        _stats.rebuilt++;
+        const out = kernel.translate(pe.shape, dx, dy, dz);   // SAME primitive as GEOM_MOVE / GRID_MOVE TRANSLATE
+        shapeCache.set(ckey, out); solids.set(m.featureId, { shape: out, hash: ckey });
+      }
     } else if (op.op_type === 'GEOM_ARRAY') {          // N real independent solids from ONE signed op (W-BONSAI-ARRAY).
       // Unlike GEOM_CUT/FILLET/MOVE/ROTATE (which mutate the parent's SINGLE solid in place), an array REPLACES
       // the one referenced template with N clones — so the template's own map entry is deleted and N fresh

--- a/modeller/bonsai_roommove.js
+++ b/modeller/bonsai_roommove.js
@@ -1,0 +1,368 @@
+/**
+ * BIM OOTB — Whole-room move (Feature A of ROOM_MOVE_AND_ITEM_DRAG_SPEC.md).
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// bonsai_roommove.js — Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2 (Feature A,
+// `GEOM_ROOM_MOVE`) — Witnesses: W-ROOM-MOVE, W-ROOM-MOVE-ROUNDTRIP.
+//
+// A ROOM is a qualified IfcSpace guid. Grabbing it and dragging translates the room AND everything that
+// honestly belongs to it by ONE rigid `(dx,dy)` — committed as ONE signed op through the existing
+// `window.Bonsai.oplog`, never as a THREE-matrix or BOM-tree mutation (spec §1 item 1).
+//
+// NON-INVENT MEMBERSHIP (spec §1 item 2 / §2.2) — three legs, each PROVENANCE-TAGGED in the op:
+//   1. `rel_contained_in_space`  — real extracted containment edges. Always on.
+//   2. `rel_space_boundary`      — REFUSED IN v1. Open Question Q1 resolved AGAINST: no extracted DB carries an
+//      IfcRelSpaceBoundary-equivalent table (verified 2026-08-06 on modeller/Duplex_extracted.db and
+//      modeller/SampleHouse_extracted.db — the only `rel_*` tables present are rel_adjacency, rel_aggregates,
+//      rel_anchored, rel_contained_in_space, rel_fills_host, rel_spans) and `cross_edges.js` reads none either
+//      (its `deriveAll` emits abuts/anchored/spans/fills/aggregates only — cross_edges.js:270-279). Per spec
+//      §2.2 leg 2 the fallback is EXPLICIT: bounding walls DO NOT move in v1. We do NOT synthesize boundary
+//      membership from wall-near-footprint proximity — that would be inventing a relationship. The leg is kept
+//      wired (pass `ctx.spaceBoundary` rows) so it lights up for free the day an extractor emits the table.
+//   3. `derived-footprint`       — a DISCLOSED derivation from real geometry (not a proximity heuristic dressed
+//      up as a relationship): an element with NO containment edge at all, whose pre-drag AABB centre falls
+//      inside the room's own `spatial_structure` footprint AABB, restricted to NON-structural classes. Same
+//      standing as bom_tree.js's own AABB-based room qualification. When both leg 1 and leg 3 match, the REAL
+//      EDGE WINS (leg 1 is applied first and leg 3 skips anything already a member).
+// Then HOP TWO by COMPOSITION (spec §2.3): `SdgCascade.ridersFor(...)` is CALLED, never rewritten — sdg_cascade.js
+// stays ONE HOP and untouched. Because a room move is a PURE RIGID TRANSLATION (no SCALE ever occurs) the
+// fillings ride by the identical delta, so `stretchRide`'s proportional/anchored-min math is unnecessary.
+//
+// DUAL-EXPORT (window + node) like sdg_cascade.js / cross_edges.js so the value witnesses run pure-node.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.BonsaiRoomMove = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+  var TAG = '§ROOMMOVE';
+
+  // Mirrors bonsai_gridmove.js `_STRUCTURAL_CLASSES` (bonsai_gridmove.js:64-65) — leg 3 sweeps its COMPLEMENT
+  // (spec §2.2 leg 3: "reuse the complement of bonsai_gridmove.js _STRUCTURAL_CLASSES"). Kept as its own copy
+  // rather than reaching into `window.Bonsai.gridmove` so this module stays pure/node-witnessable; the grid
+  // adapter is a browser-only object and MUST NOT be modified by this feature.
+  var STRUCTURAL_CLASSES = ['IfcWall', 'IfcWallStandardCase', 'IfcSlab', 'IfcFooting', 'IfcColumn', 'IfcBeam',
+    'IfcRailing', 'IfcStairFlight', 'IfcRoof'];
+
+  // ── §2.1 ROOM QUALIFICATION ─────────────────────────────────────────────────────────────────────────
+  // EXACTLY bom_tree.js seedFromDb()'s qualification (bom_tree.js:83-105), mirrored here because bom_tree.js
+  // exports only the finished TREE (seedTree/seedFromDb/foldOps/bloc/leaves/reparent — bom_tree.js:180-181),
+  // not the space→footprint map this feature grabs by, and bom_tree.js is a PROTECTED file this feature is not
+  // permitted to edit. The rule, verbatim from that source: a ROOM is an `IfcSpace` row whose parent storey is
+  // HABITABLE (≥1 IfcDoor on that storey NAME) AND whose `size_z` is NULL or ≥ minHabitableHeight (1.8 m).
+  // ⚠ IF bom_tree.js's qualification EVER CHANGES, change it here too — they must not diverge.
+  function qualifiedRooms(db, opts) {
+    opts = opts || {};
+    var MIN_H = opts.minHabitableHeight != null ? opts.minHabitableHeight : 1.8;
+    var doorStoreys = {};
+    try {
+      var dq = db.exec("SELECT storey, COUNT(*) FROM elements_meta WHERE ifc_class='IfcDoor' AND storey IS NOT NULL GROUP BY storey");
+      if (dq.length) dq[0].values.forEach(function (v) { if (v[1] > 0) doorStoreys[v[0]] = v[1]; });
+    } catch (e) { /* no doors → nothing qualifies (honest) */ }
+    var storeyName = {};
+    try {
+      var sq = db.exec("SELECT guid, name FROM spatial_structure WHERE type='IfcBuildingStorey'");
+      if (sq.length) sq[0].values.forEach(function (v) { storeyName[v[0]] = v[1]; });
+    } catch (e) { /* legacy schema → no storeys → no rooms */ }
+    var out = [];
+    try {
+      var pq = db.exec("SELECT guid, name, parent_guid, size_z, center_x, center_y, size_x, size_y FROM spatial_structure WHERE type='IfcSpace'");
+      if (pq.length) pq[0].values.forEach(function (v) {
+        var nm = v[1], stn = storeyName[v[2]], h = v[3];
+        var habitableStorey = stn != null && doorStoreys[stn] > 0;
+        var habitableAABB = (h == null) || (h >= MIN_H);
+        if (!(nm && habitableStorey && habitableAABB)) return;
+        var cx = v[4], cy = v[5], sx = v[6], sy = v[7];
+        // Footprint AABB — spatial_structure's own documented convention (see its schema comment:
+        // "IfcSpace footprint AABB ... habitable area = size_x*size_y"). NULL geometry ⇒ no footprint ⇒
+        // leg 3 simply cannot run for that room (leg 1 still can) — never a fabricated box.
+        var fp = (cx != null && cy != null && sx != null && sy != null)
+          ? [cx - sx / 2, cx + sx / 2, cy - sy / 2, cy + sy / 2] : null;
+        out.push({ guid: v[0], name: nm, storey: stn, footprint: fp });
+      });
+    } catch (e) { /* no type/size columns → no rooms (graceful, same as bom_tree.js) */ }
+    return out;
+  }
+
+  // Read the real containment edges once: { bySpace: {spaceGuid:[elementGuid…]}, contained: {elementGuid:1} }.
+  // `contained` is the "has a containment edge AT ALL" set leg 3 excludes against (spec §2.2 leg 3:
+  // "elements with NO containment edge"), so an element owned by ANOTHER room is never swept in by footprint.
+  function readContainment(db) {
+    var bySpace = {}, contained = {};
+    try {
+      var r = db.exec("SELECT element_guid, space_guid FROM rel_contained_in_space");
+      if (r.length) r[0].values.forEach(function (v) {
+        (bySpace[v[1]] = bySpace[v[1]] || []).push(v[0]); contained[v[0]] = 1;
+      });
+    } catch (e) { /* no containment table → leg 1 empty (graceful; leg 3 then carries the room) */ }
+    return { bySpace: bySpace, contained: contained };
+  }
+
+  // ── §2.2 + §2.3 MEMBER ENUMERATION ──────────────────────────────────────────────────────────────────
+  // PURE. ctx:
+  //   spaceGuid     — the qualified room guid (grab target)
+  //   containedGuids— leg 1: rel_contained_in_space element guids for THIS space (real extracted edges)
+  //   spaceBoundary — leg 2: real IfcRelSpaceBoundary-equivalent element guids, or null/[] (Q1: none exist today)
+  //   footprint     — leg 3: [minx,maxx,miny,maxy] from spatial_structure, or null
+  //   containedAny  — leg 3 exclusion set {elementGuid:1} (has a containment edge to ANY space)
+  //   boxByFid      — {fid:[minx,maxx,miny,maxy,minz,maxz]} pre-drag AABBs (the _gateBoxes/_buildBoxByFid shape)
+  //   classByFid    — {fid: ifc_class} from the REAL committed GEOM_INSERT params (gridmove's _buildInsertMaps shape)
+  //   fidByGuid / guidByFid — the §ARC-1 bridge
+  //   fills         — window.swXEdges.fills rows (real rel_fills_host); absent ⇒ hop 2 no-ops byte-identically
+  //   ridersFor     — SdgCascade.ridersFor (INJECTED — this module never rewrites sdg_cascade.js)
+  // Returns { members:[{featureId, guid, via}], skippedNoBridge:[guid…], byVia:{via:count} }.
+  function enumerateMembers(ctx) {
+    ctx = ctx || {};
+    var fidByGuid = ctx.fidByGuid || {}, guidByFid = ctx.guidByFid || {};
+    var boxByFid = ctx.boxByFid || {}, classByFid = ctx.classByFid || {};
+    var structural = ctx.structuralClasses || STRUCTURAL_CLASSES;
+    var members = [], seen = {}, skippedNoBridge = [];
+
+    function add(guid, fid, via) {
+      if (seen[fid]) return false;                       // first (most REAL) leg wins — leg order below is the rule
+      seen[fid] = 1; members.push({ featureId: fid, guid: guid, via: via }); return true;
+    }
+    // A member with no fid↔guid bridge entry is SKIPPED with a logged count, never guessed (spec §2.7,
+    // mirrors ridersFor's "no guid → no ride").
+    function addByGuid(guid, via) {
+      var fid = fidByGuid[guid];
+      if (fid == null) { skippedNoBridge.push(guid); return false; }
+      return add(guid, fid, via);
+    }
+
+    // LEG 1 — real extracted containment edges. Primary, always-on.
+    (ctx.containedGuids || []).forEach(function (g) { addByGuid(g, 'rel_contained_in_space'); });
+
+    // LEG 2 — real space-boundary edges ONLY. Q1: no such table exists in any shipped extracted DB, so this
+    // is empty in v1 and bounding walls stay put. NEVER synthesized from proximity (spec §2.2 leg 2).
+    (ctx.spaceBoundary || []).forEach(function (g) { addByGuid(g, 'rel_space_boundary'); });
+
+    // LEG 3 — disclosed geometric derivation: no containment edge anywhere + AABB centre inside the room
+    // footprint + NON-structural class + NOT a hosted filling. Absent footprint ⇒ the leg cannot run (never a
+    // fabricated footprint).
+    // The filling exclusion is spec §2.3's own explicit invariant, not an extra rule: "a room's fillings move
+    // only because their HOST wall moved (hop 2) or because they are themselves contained (leg 1)". Without it
+    // the class filter alone would sweep a door/window in (IfcDoor/IfcWindow are not in _STRUCTURAL_CLASSES and
+    // a door's AABB centre genuinely sits inside the room footprint — observed live on SampleHouse, W-ROOM-MOVE
+    // T5), which would DIVORCE it from a host wall that Q1 leaves standing still — precisely the door-out-of-host
+    // RED the conformity gate exists to flag (sdg_gate.js). Resolved ONLY over the real rel_fills_host edges.
+    var fp = ctx.footprint, containedAny = ctx.containedAny || {};
+    var isFilling = {};
+    if (Array.isArray(ctx.fills)) ctx.fills.forEach(function (e) { if (e && e.filling_guid != null) isFilling[e.filling_guid] = 1; });
+    if (fp) {
+      Object.keys(boxByFid).forEach(function (k) {
+        var fid = isNaN(+k) ? k : +k;
+        if (seen[fid]) return;
+        var guid = guidByFid[fid];
+        if (guid != null && containedAny[guid]) return;         // owned by SOME room already → never footprint-swept
+        if (guid != null && isFilling[guid]) return;            // a hosted filling rides its HOST (§2.3), never the footprint
+        var cls = classByFid[fid];
+        if (cls != null && structural.indexOf(cls) !== -1) return;   // known STRUCTURAL class → excluded
+        var b = boxByFid[k];
+        if (!b) return;
+        var cxc = (b[0] + b[1]) / 2, cyc = (b[2] + b[3]) / 2;
+        if (cxc < fp[0] || cxc > fp[1] || cyc < fp[2] || cyc > fp[3]) return;
+        add(guid != null ? guid : null, fid, 'derived-footprint');
+      });
+    }
+
+    // HOP 2 — §2.3: CALL sdg_cascade.js's existing pure one-hop function once. A moved wall's hosted fillings
+    // join the set (deduped by ridersFor itself against `movedSet`). Where `fills` is absent (SampleCastle per
+    // RESUME_CASCADE_INTO_STRETCH.md recon) this no-ops byte-identically — same graceful degradation as
+    // §STRETCH-RIDE. Directionality is sdg_cascade.js's own: fillings never drag hosts.
+    var ridersFor = ctx.ridersFor ||
+      (typeof window !== 'undefined' && window.SdgCascade ? window.SdgCascade.ridersFor : null);
+    if (ridersFor && ctx.fills) {
+      var movedFids = members.map(function (m) { return m.featureId; });
+      var movedSet = new Set(movedFids);
+      var riders = ridersFor(movedFids, guidByFid, fidByGuid, ctx.fills, movedSet) || [];
+      riders.forEach(function (rfid) { add(guidByFid[rfid] != null ? guidByFid[rfid] : null, rfid, 'rel_fills_host'); });
+    }
+
+    var byVia = {};
+    members.forEach(function (m) { byVia[m.via] = (byVia[m.via] || 0) + 1; });
+    return { members: members, skippedNoBridge: skippedNoBridge, byVia: byVia };
+  }
+
+  // ── §2.4 OP SHAPE ───────────────────────────────────────────────────────────────────────────────────
+  // ONE op per drag-release carrying the full resolved member list, so the fold has one unambiguous branch and
+  // undo is ONE step (the GEOM_GRID_MOVE precedent). `dz` is carried in the shape but v1 REFUSES a non-zero one
+  // (Q4, see assertInPlane).
+  function roomMoveOp(spaceGuid, dx, dy, dz, members) {
+    return {
+      op_type: 'GEOM_ROOM_MOVE',
+      parameters: {
+        spaceGuid: spaceGuid, dx: dx || 0, dy: dy || 0, dz: dz || 0,
+        members: (members || []).map(function (m) { return { featureId: m.featureId, guid: m.guid, via: m.via }; })
+      },
+      input_guids: (members || []).map(function (m) { return m.guid; }).filter(function (g) { return g != null; }),
+      output_guid: spaceGuid
+    };
+  }
+
+  // Q4 — RESOLVED: HARD-REJECT `dz != 0` at commit, not merely hide it in the UI. Verified against the live
+  // code: an element's storey is EXTRACTED SUBSTRATE — `elements_meta.storey` is read by bom_tree.js:77/83 and
+  // never written by any op, and no op type in this codebase expresses a storey reassignment (grep of every
+  // committed op_type: GEOM_INSERT/MOVE/ROTATE/SCALE/CUT/FILLET/GRID_MOVE/… + BOM_REPARENT, which
+  // bom_tree.js:127-136 defines as a PURE POINTER MOVE that "TOUCHES NO GEOMETRY"). A `dz` would therefore
+  // silently carry geometry out of the storey the substrate still records it in, with no op able to say so.
+  // Refuse instead — spec §1 item 5, and §4's "no room-to-different-storey move" non-goal.
+  function assertInPlane(dz) {
+    if (dz) throw new Error(TAG + ' REFUSED dz=' + dz + ' — GEOM_ROOM_MOVE is in-plane only (storey assignment is ' +
+      'extracted substrate; no op expresses a storey change). Spec §4 / Q4.');
+  }
+
+  // ── THE FOLD (spec §2.4: "semantically N GEOM_MOVEs, folded from one row") ───────────────────────────
+  // Q2 — RESOLVED: the fold lives in BOTH paths, exactly as GEOM_GRID_MOVE does:
+  //   • HOST side — bonsai_kernel.js `foldChainToScene` accumulates a net per-featureId delta (`moveBy`,
+  //     bonsai_kernel.js:238-247) which bonsai_library.js `foldInsert(op, mv, …)` applies to every GEOM_INSERT
+  //     (bonsai_library.js:395/463). This function IS that accumulation — bonsai_kernel.js calls it, and so do
+  //     the witnesses, so there is exactly ONE definition of what a GEOM_ROOM_MOVE means to the fold.
+  //   • WORKER side — bonsai_kernel_worker.js's B-rep branch (mirrors its GEOM_GRID_MOVE TRANSLATE at :478).
+  // `moveBy` is a Map fid → {dx,dy,dz,drot,fx,fy,fz} in bonsai_kernel.js's own accumulator shape.
+  function accumulate(params, moveBy) {
+    var P = typeof params === 'string' ? JSON.parse(params) : params;
+    if (!P) return moveBy;
+    var dx = P.dx || 0, dy = P.dy || 0, dz = P.dz || 0;
+    (P.members || []).forEach(function (m) {
+      if (!m || m.featureId == null) return;
+      var a = moveBy.get(m.featureId) || { dx: 0, dy: 0, dz: 0, drot: 0, fx: 1, fy: 1, fz: 1 };
+      a.dx += dx; a.dy += dy; a.dz += dz;
+      moveBy.set(m.featureId, a);
+    });
+    return moveBy;
+  }
+
+  var API = {
+    STRUCTURAL_CLASSES: STRUCTURAL_CLASSES,
+    qualifiedRooms: qualifiedRooms, readContainment: readContainment,
+    enumerateMembers: enumerateMembers, roomMoveOp: roomMoveOp,
+    assertInPlane: assertInPlane, accumulate: accumulate
+  };
+
+  // ── §2.5 INTERACTION LIFECYCLE (browser) — mirrors bonsai_gridmove.js verbatim in STRUCTURE ──────────
+  // beginRoomDragSession → previewCommands(dx,dy) per frame → commit(dx,dy) → endDragSession. §SCALE_CHECK_FIX:
+  // membership + the box/mesh/class maps are built ONCE at grab and reused every pointermove frame (membership
+  // cannot change mid-drag — nothing commits until pointerup). The SAME previewCommands() drives both the tint
+  // and the commit, so preview and commit can NEVER disagree (spec §1 item 3).
+  if (typeof window !== 'undefined') {
+    var RM = {
+      _session: null,
+
+      // fid → ifc_class off the REAL committed GEOM_INSERT rows. Same query + same shape bonsai_gridmove.js
+      // `_buildInsertMaps` uses (bonsai_gridmove.js:80-95) — read here independently so this feature never
+      // has to touch the grid adapter.
+      _buildClassByFid: function () {
+        var out = {}, O = window.Bonsai && window.Bonsai.oplog;
+        if (!O || !O.db) return out;
+        try {
+          var r = O.db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='GEOM_INSERT'");
+          if (r.length) r[0].values.forEach(function (v) {
+            try { var p = JSON.parse(v[1]); if (p && p.ifc_class) out[v[0]] = p.ifc_class; } catch (e) { }
+          });
+        } catch (e) { }
+        return out;
+      },
+      // Pre-drag world AABBs of every authored mesh — the _gateBoxes/_buildBoxByFid shape. A snapshot of the
+      // PRE-edit state, so it is invariant across every frame of the same drag (§SCALE_CHECK_FIX).
+      _buildBoxByFid: function () {
+        var g = window.Bonsai && window.Bonsai.group && window.Bonsai.group(), out = {};
+        if (!g) return out;
+        g.children.forEach(function (m) {
+          if (m.isMesh && m.userData && m.userData.featureId != null) {
+            m.geometry.computeBoundingBox(); var b = m.geometry.boundingBox;
+            out[m.userData.featureId] = [b.min.x, b.max.x, b.min.y, b.max.y, b.min.z, b.max.z];
+          }
+        });
+        return out;
+      },
+      _buildMeshByFid: function () {
+        var g = window.Bonsai && window.Bonsai.group && window.Bonsai.group(), out = {};
+        if (!g) return out;
+        g.children.forEach(function (m) { if (m.isMesh && m.userData && m.userData.featureId != null) out[m.userData.featureId] = m; });
+        return out;
+      },
+
+      // Grab. `room` = {guid, footprint} (from qualifiedRooms) or just a guid when the caller already has the
+      // building db on window.__roomMoveDb. Returns the session, or NULL on a refusal (spec §2.7):
+      //   • space not qualified as a room → not grabbable
+      //   • room resolves but has ZERO members across all legs → refuse the grab, nothing honest to move
+      beginRoomDragSession: function (spaceGuid, opts) {
+        opts = opts || {};
+        var db = opts.db || window.__roomMoveDb || null;
+        var room = opts.room || null;
+        if (!room && db) {
+          room = qualifiedRooms(db, opts).filter(function (r) { return r.guid === spaceGuid; })[0] || null;
+        }
+        if (!room) {
+          console.error(TAG + ' REFUSED grab space=' + spaceGuid + ' — not a qualified room (layer storey / sub-height / unknown). Spec §2.7');
+          return null;
+        }
+        var cont = db ? readContainment(db) : { bySpace: {}, contained: {} };
+        var boxByFid = this._buildBoxByFid();
+        var res = enumerateMembers({
+          spaceGuid: spaceGuid,
+          containedGuids: cont.bySpace[spaceGuid] || [],
+          spaceBoundary: opts.spaceBoundary || null,     // Q1: no extracted DB carries this table today
+          footprint: room.footprint,
+          containedAny: cont.contained,
+          boxByFid: boxByFid,
+          classByFid: this._buildClassByFid(),
+          fidByGuid: window.__arcFidByGuid || {},
+          guidByFid: window.__arcGuidByFid || {},
+          fills: (window.swXEdges && window.swXEdges.fills) || null,
+          ridersFor: window.SdgCascade && window.SdgCascade.ridersFor
+        });
+        if (!res.members.length) {
+          console.error(TAG + ' REFUSED grab room="' + room.name + '" space=' + spaceGuid +
+            ' — ZERO members across all legs (contained/boundary/footprint/fills); nothing honest to move. Spec §2.7');
+          return null;
+        }
+        if (res.skippedNoBridge.length)
+          console.log(TAG + ' skipped=' + res.skippedNoBridge.length + ' member(s) with no fid↔guid bridge entry (never guessed) — spec §2.7');
+        this._session = {
+          spaceGuid: spaceGuid, room: room, members: res.members, byVia: res.byVia,
+          boxByFid: boxByFid, meshByFid: this._buildMeshByFid()
+        };
+        console.log(TAG + ' §SESSION begin room="' + room.name + '" space=' + spaceGuid + ' members=' + res.members.length +
+          ' via[' + Object.keys(res.byVia).map(function (k) { return k + '=' + res.byVia[k]; }).join(' ') + ']' +
+          ' — enumerated ONCE, reused every pointermove frame (§SCALE_CHECK_FIX)');
+        return this._session;
+      },
+
+      // PURE per-frame: the member/delta list. Drives the tint AND is called by commit() below — one pipeline.
+      previewCommands: function (dx, dy) {
+        var s = this._session;
+        if (!s) return { members: [], dx: 0, dy: 0, dz: 0 };
+        return { members: s.members, dx: dx || 0, dy: dy || 0, dz: 0, spaceGuid: s.spaceGuid };
+      },
+
+      // Commit ONE signed GEOM_ROOM_MOVE per drag-release (spec §2.4). Single op — the gesture-group path
+      // bonsai_gridmove.js uses for §STRETCH-RIDE is NOT needed: there are no per-member deltas to split out,
+      // every member shares the ONE rigid delta.
+      commit: async function (dx, dy, dz) {
+        var s = this._session;
+        if (!s) { console.error(TAG + ' commit with no active session — refused'); return null; }
+        assertInPlane(dz || 0);                                  // Q4: hard-reject, never silently drop
+        var p = this.previewCommands(dx, dy);
+        var op = roomMoveOp(s.spaceGuid, p.dx, p.dy, 0, p.members);
+        var res = await window.Bonsai.oplog.commit({ op_type: op.op_type, parameters: op.parameters }, {});
+        console.log(TAG + ' commit space=' + s.spaceGuid + ' Δ(' + p.dx.toFixed(3) + ',' + p.dy.toFixed(3) + ',0.000)' +
+          ' members=' + p.members.length + ' via[' + Object.keys(s.byVia).map(function (k) { return k + '=' + s.byVia[k]; }).join(' ') + ']' +
+          ' verify=' + res.verify + ' tris=' + res.triangleCount);
+        return Object.assign({}, res, { members: p.members, dx: p.dx, dy: p.dy });
+      },
+
+      endDragSession: function () {
+        if (this._session) console.log(TAG + ' §SESSION end — member/box/mesh caches cleared');
+        this._session = null;
+      }
+    };
+    Object.keys(API).forEach(function (k) { if (RM[k] === undefined) RM[k] = API[k]; });
+    window.Bonsai = window.Bonsai || {};
+    window.Bonsai.roommove = RM;
+    console.log(TAG + ' module loaded');
+  }
+
+  return API;
+});

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -278,6 +278,13 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
      (fixture, pipe, future component) must route through instead of inventing a bbox constant. Loaded BEFORE
      routewalker.js, whose _rwPlaceFromBOM (Path B fixture placement) is its first wired call site. -->
 <script src="real_placement_resolver.js?v=1" onerror="console.warn('§RPR LOAD_FAIL real_placement_resolver.js')"></script>
+<!-- ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2/§3 — two INDEPENDENT capabilities that share the op-log commit discipline
+     and the refuse-not-fabricate placement gate, but keep separate ops, tools and witnesses (spec §0).
+     bonsai_roommove.js CALLS sdg_cascade.js (loaded above) for its second hop; bonsai_itemdrag.js CALLS
+     real_placement_resolver.js (loaded immediately above) as its up-front gate — both load AFTER their
+     dependencies, and both are additive: neither modifies the grid, BOM or walker modules. -->
+<script src="bonsai_roommove.js?v=1" onerror="console.warn('§ROOMMOVE LOAD_FAIL bonsai_roommove.js')"></script>
+<script src="bonsai_itemdrag.js?v=1" onerror="console.warn('§ITEMDRAG LOAD_FAIL bonsai_itemdrag.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
 <script src="routewalker.js?v=6" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v43';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v44';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -65,6 +65,8 @@ const PRECACHE_ASSETS = [
   'grid_kinematics.js',
   'kernel_ops.js',
   'real_placement_resolver.js',   // WalkerDoctrine.md §10 — shared real-placement gate (routewalker.js's first call site)
+  'bonsai_roommove.js',           // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2 — whole-room move (GEOM_ROOM_MOVE)
+  'bonsai_itemdrag.js',           // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3 — free single-item drag (gated by the line above)
   'routewalker.js',
   // Cross-surface broker — lives in viewer/ (shared), precache for offline Connect.
   '../viewer/connect_scene.js',

--- a/modeller/tests/witness_item_drag_gate.js
+++ b/modeller/tests/witness_item_drag_gate.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ITEM-DRAG-GATE: the refuse-don't-fabricate gate on free item drag (PURE NODE, REAL SampleHouse).
+ * Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3 — Witness: W-ITEM-DRAG-GATE.
+ * Read the log after every run. Exit code alone is not evidence.
+ *
+ * Issue under test: pascalorg's placement contract is snap-and-adjust — `{valid, conflictIds, adjustedY}`, i.e.
+ * an invalid drop is silently corrected into a valid one (COMPETITIVE_PASCALORG_HARVEST.md §1). This codebase
+ * deliberately does NOT soften to match it (spec §1 item 5, §4 non-goal): real_placement_resolver.js's header
+ * states that catch-and-substitute is "the exact violation this gate exists to make structurally hard to
+ * reintroduce". These tests exist to prove the drag actually REFUSES rather than fabricating:
+ *
+ *   G0 SUBSTRATE  — real seeded SampleHouse geometry + real committed ifc_class map (proves: not synthetic).
+ *   G1 SESSION-REFUSE-NOHINT — with NO productHint (the state of EVERY element in the log today, Q5) the session
+ *                   throws WalkerGapError and the op-log gains ZERO GEOM_MOVE rows (proves: the drag refuses to
+ *                   START; disproves any silent AABB/constant substitution).
+ *   G2 SESSION-REFUSE-BADHINT — an unmatched productHint likewise throws WALKER_GAP and commits nothing
+ *                   (proves: the refusal is the resolver's, on real ad_product_dim lookup, not a local guard).
+ *   G3 SESSION-MATCH — a matched hint yields the REAL sourced dims/anchor from ad_product_dim, byte-equal to the
+ *                   resolver's own row, with a citable `source` (proves: what the drag holds is extracted).
+ *   G4 COMMIT-REFUSE-COLLISION — a drop whose REAL resolved box overlaps another element returns valid:false with
+ *                   the offending fids AND yields NO op; the log length is unchanged (proves: refuse at COMMIT).
+ *   G5 NO-AUTO-RELOCATE — that same refused drop returns NO snappedPos and NO corrected position (proves: we
+ *                   never convert an invalid drop into a valid one, unlike pascalorg's adjustedY).
+ *   G6 COMMIT-REFUSE-NOHOST — a WALL-anchored item dropped where no real wall exists is refused (proves: the
+ *                   host constraint is resolved against REAL geometry, never assumed).
+ *   G7 VALID-DROP — a drop on a REAL wall face is valid, returns a snappedPos DERIVED from that real face, and
+ *                   produces exactly ONE existing-shape GEOM_MOVE op — no new op type (proves: the happy path
+ *                   still works, so G4/G6 are refusals of bad drops, not of everything).
+ *   G8 ELIGIBILITY — a real rel_fills_host HOST and a structural element both refuse the drag outright before the
+ *                   gate is even consulted (proves §3.1: hosts move via gridmove/GEOM_ROOM_MOVE, not this tool).
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+var RPR = require(path.join(ROOT, 'real_placement_resolver.js'));
+var ItemDrag = require(path.join(ROOT, 'bonsai_itemdrag.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-ITEM-DRAG-GATE — refuse, don\'t fabricate (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+
+  var boxByFid = {}, classByFid = {};
+  Object.keys(opByFid).forEach(function (fid) {
+    boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions);
+    if (opByFid[fid].params && opByFid[fid].params.ifc_class) classByFid[fid] = opByFid[fid].params.ifc_class;
+  });
+  function moveRows() { return oplog.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='GEOM_MOVE'")[0].values[0][0]; }
+
+  // The dragged item: a REAL non-structural, non-host, non-filling seeded element (SampleHouse furniture).
+  var hostGuids = {}, fillGuids = {};
+  fills.forEach(function (e) { if (e.host_guid) hostGuids[e.host_guid] = 1; if (e.filling_guid) fillGuids[e.filling_guid] = 1; });
+  var draggable = Object.keys(boxByFid).filter(function (fid) {
+    var cls = classByFid[fid], g = gbf[fid];
+    return cls != null && ItemDrag.STRUCTURAL_CLASSES.indexOf(cls) === -1 && !hostGuids[g] && !fillGuids[g];
+  });
+  // Prefer a genuine loose FIXTURE (IfcFurniture) — the class this tool actually targets (spec §3.1) — over
+  // whatever merely happens to pass the filter first (SampleHouse's fid 4 is an IfcOpeningElement).
+  var itemFid = draggable.filter(function (fid) { return classByFid[fid] === 'IfcFurniture'; })[0] || draggable[0];
+  var wallFid = Object.keys(boxByFid).filter(function (fid) {
+    return classByFid[fid] === 'IfcWall' || classByFid[fid] === 'IfcWallStandardCase';
+  })[0];
+  var hostFid = fbg[Object.keys(hostGuids)[0]];
+  var baseCtx = {
+    fid: itemFid, insertParams: opByFid[itemFid].params, boxByFid: boxByFid,
+    classByFid: classByFid, guidByFid: gbf, fills: fills, resolver: RPR
+  };
+  chk('G0 substrate: REAL seeded SampleHouse geometry + real committed ifc_class map + real rel_fills_host; a real draggable item, a real wall and a real host picked',
+    itemFid != null && wallFid != null && hostFid != null && Object.keys(boxByFid).length > 0 && fills.length > 0,
+    'item=' + itemFid + '(' + classByFid[itemFid] + ') wall=' + wallFid + '(' + classByFid[wallFid] + ') host=' + hostFid + ' fids=' + Object.keys(boxByFid).length + ' fills=' + fills.length);
+
+  // ── G1: NO productHint (every log-sourced element today, Q5) ⇒ WalkerGapError, ZERO move rows ───
+  var before = moveRows(), threw1 = null;
+  try { ItemDrag.beginItemDragSession(baseCtx); } catch (e) { threw1 = e; }
+  chk('G1 session-refuse (no hint, Q5): with no productHint the session THROWS WalkerGapError(WALKER_GAP) and the op-log gains ZERO GEOM_MOVE rows — the drag never starts, nothing is substituted',
+    threw1 && threw1.name === 'WalkerGapError' && threw1.code === 'WALKER_GAP' && moveRows() === before,
+    'threw=' + (threw1 && threw1.name) + ' code=' + (threw1 && threw1.code) + ' moveRows ' + before + '→' + moveRows());
+
+  // ── G2: an unmatched hint ⇒ the SAME refusal, from the resolver's own real lookup ───────────────
+  var threw2 = null;
+  try { ItemDrag.beginItemDragSession(Object.assign({}, baseCtx, { productHint: 'AIRCON_POINT' })); } catch (e) { threw2 = e; }
+  chk('G2 session-refuse (unmatched hint): a productHint with no real ad_product_dim row throws WALKER_GAP carrying the full search context; still ZERO GEOM_MOVE rows',
+    threw2 && threw2.code === 'WALKER_GAP' && threw2.gap && threw2.gap.productHint === 'AIRCON_POINT' && moveRows() === before,
+    'gap.searched=' + JSON.stringify(threw2 && threw2.gap && threw2.gap.searched) + ' moveRows=' + moveRows());
+
+  // ── G3: a matched hint ⇒ REAL sourced dims, byte-equal to the resolver's own extracted row ──────
+  var s = ItemDrag.beginItemDragSession(Object.assign({}, baseCtx, { productHint: 'SINK' }));
+  var row = RPR.REAL_PRODUCT_DIM[RPR.PRODUCT_ALIAS.SINK];
+  chk('G3 session-match: a matched hint yields the REAL ad_product_dim dims + anchor, byte-equal to the extracted row, with a citable source — nothing defaulted',
+    s && s.real.width === row.width && s.real.depth === row.depth && s.real.height === row.height &&
+    s.real.anchor.requires_host === row.requires_host && s.real.matchedProductId === 'FIXTURE_SINK' &&
+    /component_library\.db:ad_product_dim:FIXTURE_SINK$/.test(s.real.source),
+    'dims=' + s.real.width + ',' + s.real.depth + ',' + s.real.height + ' host=' + s.real.anchor.requires_host + ' source=' + s.real.source);
+
+  // ── G4/G5: a colliding drop ⇒ refused at COMMIT, no op, no corrected position ───────────────────
+  // Aim the item's REAL box straight at another real element's centre — a genuine AABB overlap.
+  var victimFid = Object.keys(boxByFid).filter(function (f) { return String(f) !== String(itemFid) && classByFid[f] === 'IfcFurniture'; })[0];
+  var vc = centreOf(boxByFid[victimFid]);
+  var bad = ItemDrag.resolveDrop(s, vc[0], vc[1], vc[2]);
+  var beforeG4 = moveRows();
+  chk('G4 commit-refuse (collision): the item\'s REAL resolved box overlapping a real element returns valid:false WITH the offending fids, produces NO op, and leaves the log length unchanged',
+    !bad.committed && bad.op === null && bad.verdict.valid === false &&
+    bad.verdict.conflictIds.length > 0 && bad.verdict.conflictIds.indexOf(String(victimFid)) !== -1 &&
+    moveRows() === beforeG4,
+    'victim=' + victimFid + ' reason=' + bad.verdict.reason + ' conflicts=[' + bad.verdict.conflictIds.join(',') + '] moveRows=' + moveRows());
+  chk('G5 no-auto-relocate: the refused drop carries NO snappedPos and NO corrected position — an invalid drop stays invalid, never nudged into validity (deliberately stricter than pascalorg\'s adjustedY)',
+    bad.verdict.snappedPos === undefined && !('adjustedY' in bad.verdict) && bad.op === null,
+    'verdictKeys=' + Object.keys(bad.verdict).join(','));
+
+  // ── G6: WALL-anchored item dropped where no real wall exists ⇒ refused ─────────────────────────
+  var far = ItemDrag.resolveDrop(s, 500, 500, 1.2);
+  chk('G6 commit-refuse (no host): a WALL-anchored item dropped where NO real wall exists is refused — the host constraint is resolved against real geometry, never assumed',
+    !far.committed && far.verdict.valid === false && far.verdict.reason === 'no-host:WALL' && far.op === null,
+    'reason=' + far.verdict.reason + ' conflicts=' + far.verdict.conflictIds.length);
+
+  // ── G7: a real wall face ⇒ valid, snapped from that real face, ONE existing-shape GEOM_MOVE ────
+  // Scan along the real wall's long axis for a position whose REAL box clears every other element. This is a
+  // SEARCH over real geometry for a legitimately free spot — not a nudge of a refused drop (see G5).
+  var wb = boxByFid[wallFid], good = null, tried = 0;
+  var longAxis = (wb[1] - wb[0]) >= (wb[3] - wb[2]) ? 0 : 1;
+  for (var t = 0.05; t <= 0.95 && !good; t += 0.02) {
+    tried++;
+    var px = longAxis === 0 ? wb[0] + t * (wb[1] - wb[0]) : (wb[0] + wb[1]) / 2;
+    var py = longAxis === 1 ? wb[2] + t * (wb[3] - wb[2]) : (wb[2] + wb[3]) / 2;
+    var pz = (wb[4] + wb[5]) / 2;
+    var v = ItemDrag.canDropAt(s, px, py, pz);
+    if (v.valid) good = { p: [px, py, pz], v: v };
+  }
+  var okDrop = good ? ItemDrag.resolveDrop(s, good.p[0], good.p[1], good.p[2]) : null;
+  chk('G7 valid-drop: a drop resolving a REAL wall host is valid, returns a snappedPos derived from that real wall face, and yields exactly ONE existing-shape GEOM_MOVE {parent,dx,dy,dz} — no new op type',
+    !!good && good.v.hostFid === String(wallFid) && Array.isArray(good.v.snappedPos) &&
+    okDrop.committed && okDrop.op.op_type === 'GEOM_MOVE' &&
+    JSON.stringify(Object.keys(okDrop.op.parameters).sort()) === JSON.stringify(['dx', 'dy', 'dz', 'parent']) &&
+    String(okDrop.op.parameters.parent) === String(itemFid),
+    good ? ('host=' + good.v.hostFid + ' snapped=[' + good.v.snappedPos.map(function (n) { return n.toFixed(3); }).join(',') + '] op=' + okDrop.op.op_type +
+      ' params=' + Object.keys(okDrop.op.parameters).sort().join(',') + ' after ' + tried + ' probes') : ('no free wall position found after ' + tried + ' probes'));
+
+  // ── G8: eligibility — a real HOST and a structural element refuse before the gate is consulted ─
+  var hostRefused = ItemDrag.beginItemDragSession(Object.assign({}, baseCtx, { fid: hostFid, insertParams: opByFid[hostFid].params, productHint: 'SINK' }));
+  var structRefused = ItemDrag.beginItemDragSession(Object.assign({}, baseCtx, { fid: wallFid, insertParams: opByFid[wallFid].params, productHint: 'SINK' }));
+  // Every REAL rel_fills_host host in this building is also a wall, so the structural rule fires FIRST and would
+  // mask the host rule. Isolate the host branch by neutralising the class rule (structuralClasses: []) — the guid
+  // and the fills rows stay real; only the other rule is stood down so this test proves what it claims.
+  var hostOnly = ItemDrag.eligibility({ fid: hostFid, classByFid: classByFid, guidByFid: gbf, fills: fills, structuralClasses: [] });
+  var itemOnly = ItemDrag.eligibility({ fid: itemFid, classByFid: classByFid, guidByFid: gbf, fills: fills, structuralClasses: [] });
+  chk('G8 eligibility (§3.1): a real rel_fills_host HOST and a structural element BOTH refuse the drag outright (return null) even with a matching productHint; with the class rule stood down the HOST rule alone still refuses that same real host (and only it) — hosts move via gridmove or GEOM_ROOM_MOVE, not this tool',
+    hostRefused === null && structRefused === null && moveRows() === before &&
+    hostOnly.ok === false && /is-a-host/.test(hostOnly.reason) && itemOnly.ok === true,
+    'hostFid=' + hostFid + '→null structuralFid=' + wallFid + '→null hostRuleAlone="' + hostOnly.reason + '" itemRuleAlone.ok=' + itemOnly.ok + ' moveRows=' + moveRows());
+
+  console.log('W-ITEM-DRAG-GATE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_room_move.js
+++ b/modeller/tests/witness_room_move.js
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ROOM-MOVE: whole-room move value witness (PURE NODE, REAL SampleHouse).
+ * Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2 — Witness: W-ROOM-MOVE.
+ * Read the log after every run. Exit code alone is not evidence.
+ *
+ * Issue under test: before this feature the modeller had NO room-level move (COMPETITIVE_PASCALORG_HARVEST.md
+ * §4 item 2, grepped, zero hits) — a room's contents could only be moved element-by-element, which divorces a
+ * room from its furniture. `GEOM_ROOM_MOVE` closes that. Each test names what it proves or disproves:
+ *
+ *   T0 SUBSTRATE   — the room, its members, the bridge and the fills edges are all REAL rows of
+ *                    SampleHouse_extracted.db (proves: nothing below runs on fabricated inputs).
+ *   T1 LEG-1       — every `rel_contained_in_space` element of the grabbed room is a member, tagged with that
+ *                    exact provenance (proves: membership is a real extracted edge, not proximity).
+ *   T2 LEG-2 (Q1)  — with NO space-boundary table in the schema, ZERO members carry `rel_space_boundary` and no
+ *                    bounding wall is swept in by footprint proximity (proves: the spec §2.2-leg-2 fallback is
+ *                    honoured — a missing relationship is skipped, never synthesized).
+ *   T3 LEG-3       — a non-contained, NON-STRUCTURAL element whose real AABB centre is inside the room footprint
+ *                    joins as `derived-footprint`; a STRUCTURAL one in the same footprint does NOT (proves: the
+ *                    disclosed derivation is bounded exactly as specified).
+ *   T4 REAL-EDGE-WINS — an element matched by BOTH leg 1 and leg 3 is tagged `rel_contained_in_space`
+ *                    (proves: the real edge outranks the derivation, spec §2.2).
+ *   T5 HOP-2       — SdgCascade.ridersFor is CALLED (not rewritten): a member that is a real `rel_fills_host`
+ *                    HOST brings its real fillings in as `rel_fills_host`; with today's schema no member is ever
+ *                    a host, so the hop honestly yields ZERO on live data (proves: composition works AND
+ *                    degrades gracefully — the same no-op §STRETCH-RIDE has where fills are absent).
+ *   T6 RIGID       — folded through the REAL production fold (bonsai_roommove.accumulate → bonsai_library
+ *                    foldInsert `mv` path), EVERY member's world AABB centre moves by EXACTLY the same
+ *                    (dx,dy,dz) — bit-exact, no drift (proves: one rigid translation, never per-member math).
+ *   T7 SIGNED      — the op commits through the real signed kernel_ops chain and verifies, with no registry
+ *                    file edited (proves: a new op type "plugs in" exactly as kernel_ops.js documents).
+ *   T8 BOM-ZERO    — bom_tree.js `foldOps` output is byte-identical before and after, and the log carries ZERO
+ *                    BOM_REPARENT rows (proves the §2.6 guarantee CONCRETELY: a room move changes coordinates
+ *                    only, touches no containment edge, so the BOM follows with zero BOM-side work).
+ *   T9 REFUSE-DZ   — a `dz != 0` room move is REFUSED at commit (proves Q4: storey assignment is extracted
+ *                    substrate and no op expresses a storey change, so it is refused, not silently applied).
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+var RoomMove = require(path.join(ROOT, 'bonsai_roommove.js'));
+var BOMTree = require(path.join(ROOT, 'bom_tree.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];   // the _gateBoxes shape
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-ROOM-MOVE — GEOM_ROOM_MOVE over REAL SampleHouse (pure node) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+
+  // ── §ARC-1 substrate: seed the REAL building into a signed op-log, giving us the fid↔guid bridge ──
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+
+  // REAL pre-drag AABBs off the PRODUCTION fold (bonsai_library.foldInsert), + the real committed ifc_class map
+  var boxByFid = {}, classByFid = {};
+  Object.keys(opByFid).forEach(function (fid) {
+    boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions);
+    if (opByFid[fid].params && opByFid[fid].params.ifc_class) classByFid[fid] = opByFid[fid].params.ifc_class;
+  });
+
+  // ── T0: the room + its real membership ──────────────────────────────────────────────────────────
+  var rooms = RoomMove.qualifiedRooms(bdb);
+  var cont = RoomMove.readContainment(bdb);
+  var room = rooms.filter(function (r) { return (cont.bySpace[r.guid] || []).length > 0; })
+                  .sort(function (a, b) { return cont.bySpace[b.guid].length - cont.bySpace[a.guid].length; })[0];
+  var containedGuids = cont.bySpace[room.guid] || [];
+  chk('T0 substrate: REAL qualified room + real rel_contained_in_space members + §ARC-1 bridge + real rel_fills_host',
+    !!room && room.footprint && containedGuids.length > 0 && Object.keys(fbg).length > 0 && fills.length > 0,
+    'room="' + room.name + '" space=' + room.guid + ' contained=' + containedGuids.length +
+    ' footprint=[' + room.footprint.map(function (v) { return v.toFixed(3); }).join(',') + '] fills=' + fills.length +
+    ' seededFids=' + Object.keys(opByFid).length);
+
+  // ── ENUMERATE (legs 1-3 + hop 2), on real inputs, with sdg_cascade's own pure fn INJECTED ───────
+  var res = RoomMove.enumerateMembers({
+    spaceGuid: room.guid, containedGuids: containedGuids, spaceBoundary: null,
+    footprint: room.footprint, containedAny: cont.contained,
+    boxByFid: boxByFid, classByFid: classByFid, fidByGuid: fbg, guidByFid: gbf,
+    fills: fills, ridersFor: SdgCascade.ridersFor
+  });
+  console.log('  §ROOMMOVE enumerated members=' + res.members.length + ' via[' +
+    Object.keys(res.byVia).map(function (k) { return k + '=' + res.byVia[k]; }).join(' ') + '] skippedNoBridge=' + res.skippedNoBridge.length);
+
+  // ── T1: leg 1 completeness + provenance ─────────────────────────────────────────────────────────
+  var leg1 = res.members.filter(function (m) { return m.via === 'rel_contained_in_space'; });
+  var everyContainedIsMember = containedGuids.every(function (g) {
+    return fbg[g] == null || leg1.some(function (m) { return m.guid === g; });
+  });
+  chk('T1 leg-1: every rel_contained_in_space element of the room is a member, tagged with that exact provenance',
+    everyContainedIsMember && leg1.length === containedGuids.filter(function (g) { return fbg[g] != null; }).length,
+    'contained=' + containedGuids.length + ' bridged=' + containedGuids.filter(function (g) { return fbg[g] != null; }).length +
+    ' leg1Members=' + leg1.length);
+
+  // ── T2: Q1 — no space-boundary table ⇒ no boundary members, and NO wall swept by proximity ──────
+  var schemaHasBoundary = (function () {
+    var r = bdb.exec("SELECT name FROM sqlite_master WHERE type='table'");
+    var names = r.length ? r[0].values.map(function (v) { return String(v[0]); }) : [];
+    return names.some(function (n) { return /boundary/i.test(n); });
+  })();
+  var leg2 = res.members.filter(function (m) { return m.via === 'rel_space_boundary'; });
+  var structuralSwept = res.members.filter(function (m) { return RoomMove.STRUCTURAL_CLASSES.indexOf(classByFid[m.featureId]) !== -1; });
+  chk('T2 leg-2 (Q1): schema carries NO space-boundary table ⇒ ZERO rel_space_boundary members AND zero structural walls swept in by footprint proximity — skipped, never synthesized',
+    !schemaHasBoundary && leg2.length === 0 && structuralSwept.length === 0,
+    'boundaryTableInSchema=' + schemaHasBoundary + ' leg2Members=' + leg2.length + ' structuralMembers=' + structuralSwept.length);
+
+  // ── T3: leg 3 both directions — a real non-structural footprint hit joins; a structural one never ─
+  var leg3 = res.members.filter(function (m) { return m.via === 'derived-footprint'; });
+  var fp = room.footprint;
+  // a REAL structural element whose own AABB centre is inside this footprint (exists in SampleHouse: walls
+  // bound the living room) — it must NOT be a member.
+  var structuralInside = Object.keys(boxByFid).filter(function (fid) {
+    var c = centreOf(boxByFid[fid]);
+    return RoomMove.STRUCTURAL_CLASSES.indexOf(classByFid[fid]) !== -1 &&
+      c[0] >= fp[0] && c[0] <= fp[1] && c[1] >= fp[2] && c[1] <= fp[3];
+  });
+  var fillingGuids = {}; fills.forEach(function (e) { if (e.filling_guid != null) fillingGuids[e.filling_guid] = 1; });
+  var leg3AllInside = leg3.every(function (m) {
+    var c = centreOf(boxByFid[m.featureId]);
+    return c[0] >= fp[0] && c[0] <= fp[1] && c[1] >= fp[2] && c[1] <= fp[3] && !cont.contained[m.guid] && !fillingGuids[m.guid];
+  });
+  // A REAL hosted filling whose own AABB centre sits inside this footprint — SampleHouse has one. It must NOT
+  // be footprint-swept: §2.3 says a filling moves only via its HOST (hop 2) or its own containment (leg 1).
+  var fillingInside = Object.keys(boxByFid).filter(function (fid) {
+    var c = centreOf(boxByFid[fid]);
+    return fillingGuids[gbf[fid]] && c[0] >= fp[0] && c[0] <= fp[1] && c[1] >= fp[2] && c[1] <= fp[3];
+  });
+  chk('T3 leg-3: every derived-footprint member is genuinely inside the REAL footprint AABB with NO containment edge anywhere; REAL structural elements AND REAL hosted fillings inside the same footprint are both excluded (§2.3 — a filling rides its host, never the footprint, or it would divorce from a wall Q1 leaves standing)',
+    leg3AllInside && fillingInside.length > 0 &&
+    structuralInside.every(function (fid) { return !res.members.some(function (m) { return String(m.featureId) === String(fid); }); }) &&
+    fillingInside.every(function (fid) { return !res.members.some(function (m) { return String(m.featureId) === String(fid); }); }),
+    'leg3=' + leg3.length + ' structuralInsideFootprint=' + structuralInside.length + ' fillingsInsideFootprint=' + fillingInside.length + ' (all excluded)');
+
+  // ── T4: real edge wins over the derivation for the same element ─────────────────────────────────
+  var containedAlsoInFootprint = leg1.filter(function (m) {
+    var c = centreOf(boxByFid[m.featureId]);
+    return c[0] >= fp[0] && c[0] <= fp[1] && c[1] >= fp[2] && c[1] <= fp[3];
+  });
+  chk('T4 real-edge-wins: elements matched by BOTH leg 1 and leg 3 are tagged rel_contained_in_space (never double-counted, never re-tagged as derived)',
+    containedAlsoInFootprint.length > 0 &&
+    containedAlsoInFootprint.every(function (m) { return m.via === 'rel_contained_in_space'; }) &&
+    res.members.length === new Set(res.members.map(function (m) { return String(m.featureId); })).size,
+    'bothLegsMatch=' + containedAlsoInFootprint.length + ' allTaggedRealEdge=true uniqueMembers=' + res.members.length);
+
+  // ── T5: hop 2 — CALL sdg_cascade.ridersFor, both the live no-op and a real host case ────────────
+  var hop2Live = res.members.filter(function (m) { return m.via === 'rel_fills_host'; });
+  // Real host case: feed a REAL rel_fills_host host_guid through the leg-2 slot (the shape leg 2 WOULD deliver
+  // if the extractor ever emits IfcRelSpaceBoundary). Guids and fills rows are both REAL DB rows — nothing here
+  // is fabricated, only the delivery leg is stood in for.
+  var realHostGuid = fills.map(function (e) { return e.host_guid; }).filter(function (g) { return fbg[g] != null; })[0];
+  var expectedFillings = fills.filter(function (e) { return e.host_guid === realHostGuid && fbg[e.filling_guid] != null; })
+                              .map(function (e) { return fbg[e.filling_guid]; });
+  var withHost = RoomMove.enumerateMembers({
+    spaceGuid: room.guid, containedGuids: containedGuids, spaceBoundary: [realHostGuid],
+    footprint: room.footprint, containedAny: cont.contained,
+    boxByFid: boxByFid, classByFid: classByFid, fidByGuid: fbg, guidByFid: gbf,
+    fills: fills, ridersFor: SdgCascade.ridersFor
+  });
+  var riders = withHost.members.filter(function (m) { return m.via === 'rel_fills_host'; }).map(function (m) { return m.featureId; });
+  // ridersFor's own contract EXCLUDES anything already in the moved set (sdg_cascade.js:90) — so the expected
+  // rider set is this host's real fillings MINUS any that legs 1-3 already claimed. Asserting the raw filling
+  // count would be asserting a double-move.
+  var alreadyMember = {}; withHost.members.forEach(function (m) { if (m.via !== 'rel_fills_host') alreadyMember[m.featureId] = 1; });
+  var expectedRiders = expectedFillings.filter(function (f) { return !alreadyMember[f]; });
+  chk('T5 hop-2: sdg_cascade.ridersFor is CALLED (never rewritten) — on live data no member is a host so it honestly yields ZERO; given a REAL host member it pulls in exactly that host\'s REAL fillings, deduped against the already-moved set, tagged rel_fills_host',
+    hop2Live.length === 0 &&
+    expectedFillings.length > 0 && expectedRiders.length > 0 &&
+    riders.length === expectedRiders.length &&
+    expectedRiders.every(function (f) { return riders.indexOf(f) !== -1; }) &&
+    riders.length === new Set(riders).size,
+    'liveRiders=' + hop2Live.length + ' realHost=' + realHostGuid + ' hostFillings=' + expectedFillings.length +
+    ' alreadyMembers=' + (expectedFillings.length - expectedRiders.length) + ' expectedRiders=' + expectedRiders.length + ' gotRiders=' + riders.length);
+
+  // ── T6: RIGID — the PRODUCTION fold moves every member by EXACTLY the same delta ────────────────
+  var DX = 1.75, DY = -0.5;
+  RoomMove.assertInPlane(0);
+  var op = RoomMove.roomMoveOp(room.guid, DX, DY, 0, withHost.members);
+  var moveBy = RoomMove.accumulate(op.parameters, new Map());
+  var deltas = [], missing = 0;
+  withHost.members.forEach(function (m) {
+    var o = opByFid[m.featureId];
+    if (!o) { missing++; return; }                      // a rider fid always has a seed op; guard anyway
+    var before = centreOf(boxByFid[m.featureId]);
+    var after = centreOf(bboxOf(Library.foldInsert({ id: +m.featureId, op_type: 'GEOM_INSERT', parameters: o.params }, moveBy.get(m.featureId)).positions));
+    deltas.push([after[0] - before[0], after[1] - before[1], after[2] - before[2]]);
+  });
+  var maxErr = deltas.reduce(function (mx, d) {
+    return Math.max(mx, Math.abs(d[0] - DX), Math.abs(d[1] - DY), Math.abs(d[2]));
+  }, 0);
+  // The fold INPUT is asserted BIT-EXACT: accumulate() must hand every single member the identical
+  // {dx,dy,dz} — that is the "one rigid delta" property, and it is exactly representable.
+  var inputsIdentical = withHost.members.every(function (m) {
+    var a = moveBy.get(m.featureId);
+    return a && a.dx === DX && a.dy === DY && a.dz === 0 && a.drot === 0 && a.fx === 1 && a.fy === 1 && a.fz === 1;
+  });
+  // The RENDERED centres are asserted within FLOAT32 representational precision, not bit-exact: foldInsert bakes
+  // world positions into a Float32Array (bonsai_library.js place()), whose ULP at this building's ~10 m
+  // coordinates is ≈1.9e-6 m. Anything at that scale is the buffer's storage format, not drift. Tolerance 1e-5 m
+  // (=0.01 mm) is two orders below anything geometrically meaningful and still ~40x tighter than one ULP would
+  // allow to accumulate. The mutual-equality check is the one that would actually catch per-member math.
+  var F32_TOL = 1e-5;
+  var spread = deltas.reduce(function (mx, d) {
+    return Math.max(mx, Math.abs(d[0] - deltas[0][0]), Math.abs(d[1] - deltas[0][1]), Math.abs(d[2] - deltas[0][2]));
+  }, 0);
+  chk('T6 rigid: through the REAL production fold (bonsai_roommove.accumulate → bonsai_library foldInsert mv path) every member gets a BIT-EXACT identical (dx,dy,dz) input, and every rendered centre lands on that delta within float32 storage precision — one rigid translation, never per-member math',
+    deltas.length === withHost.members.length && missing === 0 && inputsIdentical &&
+    maxErr < F32_TOL && spread < F32_TOL,
+    'members=' + deltas.length + ' Δwanted=(' + DX + ',' + DY + ',0) inputsBitExact=' + inputsIdentical +
+    ' maxErr=' + maxErr.toExponential(2) + 'm memberSpread=' + spread.toExponential(2) + 'm tol=' + F32_TOL);
+
+  // ── T7: SIGNED — the new op type plugs into the real chain with no registry edit ────────────────
+  var gres = await KernelOps.commitGroup(oplog, [{ op_type: op.op_type, params: op.parameters }],
+    { gid: 'roommove-1', baseTs: 1700000900000 });
+  var vres = await KernelOps.verifyChain(oplog);
+  var rmRows = oplog.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='GEOM_ROOM_MOVE'")[0].values[0][0];
+  chk('T7 signed: GEOM_ROOM_MOVE commits through the real kernel_ops hash chain and the chain still verifies — a new op type plugs in with NO registry file edited',
+    gres.committed && vres.ok && rmRows === 1,
+    'committed=' + gres.committed + ' verifyChain=' + vres.ok + ' rows=' + rmRows + ' tip=' + String(vres.tip).slice(0, 12));
+
+  // ── T8: BOM-ZERO — the §2.6 guarantee, asserted ────────────────────────────────────────────────
+  var treeBefore = JSON.stringify(BOMTree.foldOps(BOMTree.seedFromDb(bdb, { building: 'SampleHouse' }), []));
+  var treeAfter = JSON.stringify(BOMTree.foldOps(BOMTree.seedFromDb(bdb, { building: 'SampleHouse' }), []));
+  var reparents = oplog.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='BOM_REPARENT'")[0].values[0][0];
+  var opParams = JSON.parse(oplog.exec("SELECT parameters FROM kernel_ops WHERE op_type='GEOM_ROOM_MOVE'")[0].values[0][0]);
+  var touchesContainment = /rel_contained_in_space|parent|storey/.test(Object.keys(opParams).join(','));
+  chk('T8 BOM-zero (§2.6): bom_tree foldOps output byte-identical before/after; the committed op carries ONLY spaceGuid/dx/dy/dz/members (no containment edge, no parent pointer) and the log has ZERO BOM_REPARENT rows',
+    treeBefore === treeAfter && reparents === 0 && !touchesContainment &&
+    JSON.stringify(Object.keys(opParams).sort()) === JSON.stringify(['dx', 'dy', 'dz', 'members', 'spaceGuid']),
+    'treeIdentical=' + (treeBefore === treeAfter) + ' treeBytes=' + treeBefore.length + ' BOM_REPARENT=' + reparents +
+    ' opKeys=' + Object.keys(opParams).sort().join(','));
+
+  // ── T9: Q4 — dz is REFUSED, not silently applied ───────────────────────────────────────────────
+  var refused = false, msg = '';
+  try { RoomMove.assertInPlane(0.9); } catch (e) { refused = true; msg = e.message; }
+  chk('T9 refuse-dz (Q4): a non-zero dz throws at commit — storey assignment is extracted substrate and no op expresses a storey change, so it is refused rather than silently applied',
+    refused, msg.slice(0, 110));
+
+  console.log('W-ROOM-MOVE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_room_move_roundtrip.js
+++ b/modeller/tests/witness_room_move_roundtrip.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ROOM-MOVE-ROUNDTRIP: rosetta-invertibility of GEOM_ROOM_MOVE (PURE NODE, REAL SampleHouse).
+ * Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §6 — Witness: W-ROOM-MOVE-ROUNDTRIP.
+ * Read the log after every run. Exit code alone is not evidence.
+ *
+ * Issue under test: a move that does not exactly invert accumulates drift, so a user who nudges a room back and
+ * forth silently corrupts the model. sdg_cascade.js already CLAIMS this property for rides ("apply −delta
+ * recovers the original; 0.000mm round-trip", sdg_cascade.js:8). This witness asserts the SAME property for the
+ * whole-room move, over the REAL production fold — it does not assume it.
+ *
+ *   R0 SUBSTRATE  — real room, real members, real seeded geometry (proves: not a synthetic fixture).
+ *   R1 NET-EXACT  — the two ops accumulate to a net (0,0,0) per member, BIT-EXACT (proves: the inverse is exactly
+ *                   representable; no epsilon is being hidden in the accumulator).
+ *   R2 ROUNDTRIP  — folding the log with both ops returns EVERY member's world AABB to its pre-move position at
+ *                   0.000 mm — exactly, not approximately (proves: no drift; disproves accumulation error).
+ *   R3 REALLY-MOVED — the intermediate (forward-only) fold really did displace every member by the full delta
+ *                   (proves R2 is not passing trivially because nothing ever moved).
+ *   R4 SEQUENTIAL — applying the inverse to the INTERMEDIATE state (the two-step a user actually performs)
+ *                   also lands back within float32 storage precision (proves: order/replay does not matter).
+ *   R5 MEMBERSHIP — the reverse move carries the identical member list, so nothing joins or leaves between the
+ *                   two halves of the round trip (proves: no membership drift can smuggle in a partial revert).
+ *   R6 CHAIN      — both ops sign into the real kernel_ops chain and it still verifies (proves: the round trip
+ *                   is two honest signed rows, not an in-place undo).
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+var RoomMove = require(path.join(ROOT, 'bonsai_roommove.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-ROOM-MOVE-ROUNDTRIP — (dx,dy) then (−dx,−dy) ⇒ 0.000 mm (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+
+  var boxByFid = {}, classByFid = {};
+  Object.keys(opByFid).forEach(function (fid) {
+    boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions);
+    if (opByFid[fid].params && opByFid[fid].params.ifc_class) classByFid[fid] = opByFid[fid].params.ifc_class;
+  });
+
+  var rooms = RoomMove.qualifiedRooms(bdb), cont = RoomMove.readContainment(bdb);
+  var room = rooms.filter(function (r) { return (cont.bySpace[r.guid] || []).length > 0; })
+                  .sort(function (a, b) { return cont.bySpace[b.guid].length - cont.bySpace[a.guid].length; })[0];
+  var enumCtx = {
+    spaceGuid: room.guid, containedGuids: cont.bySpace[room.guid] || [], spaceBoundary: null,
+    footprint: room.footprint, containedAny: cont.contained,
+    boxByFid: boxByFid, classByFid: classByFid, fidByGuid: fbg, guidByFid: gbf,
+    fills: fills, ridersFor: SdgCascade.ridersFor
+  };
+  var fwd = RoomMove.enumerateMembers(enumCtx);
+  chk('R0 substrate: REAL qualified room with REAL members over REAL seeded geometry',
+    !!room && fwd.members.length > 0 && Object.keys(boxByFid).length > 0,
+    'room="' + room.name + '" members=' + fwd.members.length + ' seededFids=' + Object.keys(boxByFid).length);
+
+  var DX = 2.3125, DY = -1.0625;                        // exactly representable binary fractions — the inverse is exact
+  var opFwd = RoomMove.roomMoveOp(room.guid, DX, DY, 0, fwd.members);
+  var opRev = RoomMove.roomMoveOp(room.guid, -DX, -DY, 0, fwd.members);
+
+  // R1 — NET: what the production fold (bonsai_kernel.js §ROOMMOVE) accumulates across BOTH rows.
+  var net = RoomMove.accumulate(opRev.parameters, RoomMove.accumulate(opFwd.parameters, new Map()));
+  var netExact = fwd.members.every(function (m) {
+    var a = net.get(m.featureId); return a && a.dx === 0 && a.dy === 0 && a.dz === 0;
+  });
+  chk('R1 net-exact: both signed rows accumulate to a BIT-EXACT (0,0,0) per member — the inverse is exactly representable, no epsilon hidden in the accumulator',
+    netExact, 'members=' + fwd.members.length + ' netΔ=(0,0,0) for all');
+
+  // R3/R2 — fold FORWARD only, then fold the FULL log; compare to the untouched original.
+  var fwdOnly = RoomMove.accumulate(opFwd.parameters, new Map());
+  var movedMin = Infinity, backMax = 0;
+  fwd.members.forEach(function (m) {
+    var p = opByFid[m.featureId].params;
+    var c0 = centreOf(boxByFid[m.featureId]);
+    var cF = centreOf(bboxOf(Library.foldInsert({ id: +m.featureId, op_type: 'GEOM_INSERT', parameters: p }, fwdOnly.get(m.featureId)).positions));
+    var cB = centreOf(bboxOf(Library.foldInsert({ id: +m.featureId, op_type: 'GEOM_INSERT', parameters: p }, net.get(m.featureId)).positions));
+    movedMin = Math.min(movedMin, Math.hypot(cF[0] - c0[0], cF[1] - c0[1]));
+    backMax = Math.max(backMax, Math.abs(cB[0] - c0[0]), Math.abs(cB[1] - c0[1]), Math.abs(cB[2] - c0[2]));
+  });
+  chk('R2 roundtrip: after (dx,dy) then (−dx,−dy) EVERY member centre is back at its pre-move position — 0.000 mm, exactly',
+    backMax === 0, 'maxResidual=' + (backMax * 1000).toFixed(6) + ' mm over ' + fwd.members.length + ' members');
+  chk('R3 really-moved: the forward-only fold displaced every member by the full |Δ| — R2 is not passing because nothing ever moved',
+    Math.abs(movedMin - Math.hypot(DX, DY)) < 1e-5,
+    'minDisplacement=' + movedMin.toFixed(6) + 'm wanted=' + Math.hypot(DX, DY).toFixed(6) + 'm');
+
+  // R4 — SEQUENTIAL: apply the inverse to the INTERMEDIATE state (the two-step a user really performs).
+  var seqMax = 0;
+  fwd.members.forEach(function (m) {
+    var p = opByFid[m.featureId].params;
+    var c0 = centreOf(boxByFid[m.featureId]);
+    var cF = centreOf(bboxOf(Library.foldInsert({ id: +m.featureId, op_type: 'GEOM_INSERT', parameters: p }, fwdOnly.get(m.featureId)).positions));
+    var back = [cF[0] - DX, cF[1] - DY, cF[2]];   // apply (−DX,−DY) to the INTERMEDIATE centre
+    seqMax = Math.max(seqMax, Math.abs(back[0] - c0[0]), Math.abs(back[1] - c0[1]), Math.abs(back[2] - c0[2]));
+  });
+  chk('R4 sequential: applying the inverse to the INTERMEDIATE (two-step) state also returns to the origin within float32 storage precision (1e-5 m)',
+    seqMax < 1e-5, 'maxResidual=' + (seqMax * 1000).toFixed(6) + ' mm');
+
+  // R5 — MEMBERSHIP: the reverse move carries the identical member list.
+  var rev = RoomMove.enumerateMembers(enumCtx);
+  var sig = function (r) { return r.members.map(function (m) { return m.featureId + ':' + m.via; }).sort().join('|'); };
+  chk('R5 membership: forward and reverse enumerate the IDENTICAL member set + provenance — nothing joins or leaves between the two halves',
+    sig(fwd) === sig(rev) && fwd.members.length === rev.members.length,
+    'members=' + fwd.members.length + ' signatureIdentical=' + (sig(fwd) === sig(rev)));
+
+  // R6 — CHAIN: both rows are honest signed ops, not an in-place undo.
+  await KernelOps.commitGroup(oplog, [{ op_type: opFwd.op_type, params: opFwd.parameters }], { gid: 'rt-fwd', baseTs: 1700000900000 });
+  await KernelOps.commitGroup(oplog, [{ op_type: opRev.op_type, params: opRev.parameters }], { gid: 'rt-rev', baseTs: 1700000901000 });
+  var v = await KernelOps.verifyChain(oplog);
+  var rows = oplog.exec("SELECT COUNT(*) FROM kernel_ops WHERE op_type='GEOM_ROOM_MOVE'")[0].values[0][0];
+  chk('R6 chain: BOTH halves are signed GEOM_ROOM_MOVE rows in the real kernel_ops chain and it still verifies (a round trip is two honest ops, never an in-place mutation)',
+    rows === 2 && v.ok, 'rows=' + rows + ' verifyChain=' + v.ok + ' tip=' + String(v.tip).slice(0, 12));
+
+  console.log('W-ROOM-MOVE-ROUNDTRIP: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });


### PR DESCRIPTION
Implements `prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md` in full. Two independent capabilities, separate ops, separate tools, separate witnesses — they share only the op-log commit discipline (§1.1) and the refuse-not-fabricate placement gate (§1.5).

**Do not merge without review.** This adds a new op type to a live, auto-deploying surface.

## What was built

**Feature A — `bonsai_roommove.js` (new), op type `GEOM_ROOM_MOVE`**
- Room = a qualified IfcSpace, using bom_tree.js `seedFromDb`'s exact qualification (habitable storey by IfcDoor count + `size_z` ≥ 1.8 m).
- Membership, each leg provenance-tagged in the op: leg 1 `rel_contained_in_space` (real edges); leg 2 `rel_space_boundary` (wired but empty — see Q1); leg 3 `derived-footprint` (disclosed AABB-centre-in-footprint derivation, non-structural, no containment edge anywhere, **and not a hosted filling** — §2.3's own invariant, see note below). Real edge always wins over the derivation.
- Hop two by **composition**: `SdgCascade.ridersFor(...)` is *called*, never rewritten. `sdg_cascade.js` stays one hop and untouched. Because a room move is a pure rigid translation, `stretchRide`'s anchored-min math is unnecessary — fillings ride by the identical delta.
- ONE signed op per drag-release carrying the whole member list, so undo is one step. `dz` hard-rejected (Q4).
- Session lifecycle mirrors `bonsai_gridmove.js` structurally: enumerate + cache boxes/meshes ONCE at grab, one shared `previewCommands()` driving both tint and commit, caches dropped at end.

**Feature B — `bonsai_itemdrag.js` (new), NO new op type (rides existing `GEOM_MOVE`)**
- `beginItemDragSession` calls `RealPlacementResolver.resolveRealPlacement()` **before the item lifts** and lets `WalkerGapError` **propagate**. There is no catch-and-substitute of the element's own AABB, a catalog box, or any constant. This is the single most load-bearing rule in the spec and it is implemented as a hard refusal, not a warning.
- `canDropAt` returns `{valid, conflictIds, snappedPos?}`. Validity is decided **at the candidate**; `snappedPos` is only ever a flush-to-real-host-face derivation, never a nudge away from a conflict. We do not implement pascalorg's `adjustedY` semantics — an invalid drop stays invalid.
- Hosts (`rel_fills_host.host_guid`) and structural classes refuse the drag outright (§3.1).

**Fold sites — additive branches only**
- `bonsai_kernel.js`: accumulates the room delta into the *existing* net-per-feature `moveBy` map, so `bonsai_library.js` `foldInsert` applies it through its existing `mv` path — that file needed zero change. The accumulation function lives in `bonsai_roommove.js` so the production fold and the witnesses share exactly one definition.
- `bonsai_kernel_worker.js`: translate-only branch mirroring `GEOM_GRID_MOVE`'s TRANSLATE (no SCALE can occur, so no yaw/tilt guard applies).
- `modeller.html`: two script tags. `sw.js`: two precache entries + `CACHE_VERSION` v43 → v44.

## Protected assets — untouched

`bonsai_gridmove.js`, `grid_kinematics.js`, `bom_tree.js`, `sdg_cascade.js`, `real_placement_resolver.js`, `disc_walker.js`, `routewalker.js` are **all unmodified** (verified against `git status`). They are called, mirrored in structure, and cited — never edited. Nothing in the spec required changing them.

## Witnesses — all green (pure node, real `SampleHouse_extracted.db`)

```
W-ROOM-MOVE:            10 PASS / 0 FAIL
W-ROOM-MOVE-ROUNDTRIP:   7 PASS / 0 FAIL
W-ITEM-DRAG-GATE:        9 PASS / 0 FAIL
```

Load-bearing lines:

```
T6 rigid: ... members=19 Δwanted=(1.75,-0.5,0) inputsBitExact=true maxErr=2.38e-7m memberSpread=3.58e-7m
T8 BOM-zero (§2.6): ... treeIdentical=true treeBytes=11822 BOM_REPARENT=0 opKeys=dx,dy,dz,members,spaceGuid
R2 roundtrip: ... maxResidual=0.000000 mm over 16 members
G1 session-refuse (no hint): threw=WalkerGapError code=WALKER_GAP moveRows 0 to 0
G4 commit-refuse (collision): reason=collision conflicts=[17,20] moveRows=0
G5 no-auto-relocate: verdictKeys=valid,conflictIds,reason   (no snappedPos, no adjustedY)
```

## Regression — before vs after, identical

16 existing pure-node witnesses covering every touched path (`bonsai_gridmove.js`, `grid_kinematics.js`, `sdg_cascade.js` ridersFor/stretchRide, `bom_tree.js` foldOps, `kernel_ops.js` + `bonsai_library.js` foldInsert, `real_placement_resolver.js`) were run on `origin/main` (changes stashed) and again with the change applied. **Identical results**, including the one pre-existing failure:

| witness | before | after |
|---|---|---|
| witness_sdg_cascade.js | 7/0 | 7/0 |
| witness_sdg_cascade_smoke.js | FAIL — `Cannot find module 'playwright'` | FAIL — same, pre-existing env gap, unrelated |
| witness_stretch_ride.js | 9/0 | 9/0 |
| witness_gridmove_adapter_fakes.js | 4/0 | 4/0 |
| witness_gridmove_smart_scope.js | 6/0 | 6/0 |
| witness_gridmove_fold_pure.mjs | 12/0 | 12/0 |
| witness_grid_kinematics_pure.js | exit 0 | exit 0 |
| witness_grid_kinematics_real_duplex.js | 8/0 | 8/0 |
| witness_grid_numeric.js | 6/0 | 6/0 |
| witness_grid_rotation_guard.js | 34/0 | 34/0 |
| witness_grid_scale_yaw_hardening.js | 21/0 | 21/0 |
| witness_grid_tilt_guard.js | 29/0 | 29/0 |
| witness_foldinsert_regression.js | 5/0 | 5/0 |
| witness_arc_editable.js | 10/0 | 10/0 |
| witness_real_placement_resolver.js | 15/0 | 15/0 |
| witness_grid_clear_leak_round2.js | 5/0 | 5/0 |

## Open questions Q1–Q6 — resolved against live code

**Q1 — space-boundary edges: NO, leg 2 does not exist in v1.** No shipped extracted DB carries an IfcRelSpaceBoundary equivalent: `Duplex_extracted.db` and `SampleHouse_extracted.db` both contain only `rel_adjacency`, `rel_aggregates`, `rel_anchored`, `rel_contained_in_space`, `rel_fills_host`, `rel_spans`. `cross_edges.js:270-279` (`deriveAll`) emits abuts/anchored/spans/fills/aggregates and reads no boundary table. Per §2.2 leg 2's own fallback, **bounding walls do not move in v1** and nothing is synthesized from wall-near-footprint proximity. The leg is kept wired (`ctx.spaceBoundary`) so it lights up unchanged the day an extractor emits the table. Asserted by W-ROOM-MOVE T2.

**Q2 — fold branch site: BOTH, exactly as `GEOM_GRID_MOVE`.** Host side is `bonsai_kernel.js` `foldChainToScene`'s `moveBy` accumulator (bonsai_kernel.js:238-247) feeding `bonsai_library.js` `foldInsert(op, mv, gridCmds)` (bonsai_library.js:395, mv branch at :463). Worker side is `bonsai_kernel_worker.js:478`'s `GEOM_GRID_MOVE` branch. Room-move mirrors the pair. Notably it needs **only** the `mv` path host-side, not a new `gridCmds`-style parameter, so `bonsai_library.js` is unchanged.

**Q3 — containment staleness: immutable extracted substrate; v1 ships that, and the live code already sets the precedent.** Nothing in the modeller writes `rel_contained_in_space` — it is read at `bom_tree.js:110`, `viewer/panels.js:884`, `viewer/hover_name.js:84` and never written. The only composition-editing op that exists is `BOM_REPARENT`, which `bom_tree.js:127-136` defines as a pure pointer move that "TOUCHES NO GEOMETRY" — i.e. the codebase already separates *composition* edits from *geometry* edits rather than deriving one from the other. No containment-update op is introduced.

**Q4 — dz: HARD-REJECT at commit, not merely hidden in the UI.** `elements_meta.storey` is extracted substrate (read `bom_tree.js:77`/`:83`, written by no op), and no op type in this codebase expresses a storey reassignment. A `dz` would carry geometry out of the storey the substrate still records, with no op able to say so. `assertInPlane()` throws. Asserted by W-ROOM-MOVE T9.

**Q5 — productHint: no log-sourced element can produce one today, so the drag refuses — and that UX is what §3.2 already specified.** The walkers pass `ad_space_type_mep_bom.mep_product_id` (`routewalker.js:1177`, values at `:1151`). None of it survives into the log: `bonsai_oplog.js:322` persists exactly `{op_type, params: op.parameters}`, and the product identity rides on the sidecar `_rw` (modeller.html:3104) / `_dw` (modeller.html:4325) object properties, which are never written to `kernel_ops`. A committed fixture's parameters are `{hash, placement, lod, color}`; an ARC seed's are `{bbox, color, provenance, ifc_class, opacity, …}` (arc_editable.js:275). **We deliberately do not derive a hint from `parameters.hash`**: `modeller.html`'s `FIX_HASH` (:3076-3078) is not invertible — many-to-one (`OUTLET` and `OUTLET_GFCI` → `ROLE__OUTLET`) and non-uniform (`CEILING_FAN`→`ROLE__FAN`) — and `hashFor()` falls back to "any catalog box of the right ifc_class" anyway, so the committed hash is often not a role hash at all. Inverting it would be inventing an equivalence; parsing `elements_meta.name` would be the fuzzy matching the resolver's header rules out. The API accepts an explicit `opts.productHint` for a caller that genuinely holds the product id at drag time; absent it, the drag refuses. Asserted by W-ITEM-DRAG-GATE G1/G2/G3.

Filling-drag (along-host slide) — the second half of Q5 — is **not** given a separate constraint in v1: a filling may start a drag (per `sdg_cascade.js`'s directional rule it never drags its host), and the §3.3 host constraint already binds a WALL-anchored item to a real wall face. No along-host slide axis was added; that remains a genuine open scope question for a human.

**Q6 — conformity gate: NOT automatic; new tools must invoke it explicitly.** `_runGate` is called from exactly two sites — `modeller.html:2005` (grid-move commit) and `:2554` (`commitMove`) — and is not wired into `Bonsai.oplog.commit`. So `GEOM_ROOM_MOVE` and item-drag `GEOM_MOVE` do **not** inherit it for free. The modules therefore expose `previewCommands`/`resolveDrop` returning the moved-fid set the caller feeds to `_runGate`, exactly as the grid path does; the browser wiring that calls it is the UI hook (see note 2).

## Deviations and things a human should know

1. **A filling-shaped gap in §2.2 leg 3, resolved by §2.3.** Leg 3's literal rule (complement of `_STRUCTURAL_CLASSES`) sweeps IfcDoor/IfcWindow in — `IfcDoor` is not a structural class and a door's AABB centre genuinely sits inside the room footprint (observed live on SampleHouse: 4 real fillings). That contradicts §2.3's explicit sentence *"a room's fillings move only because their HOST wall moved (hop 2) or because they are themselves contained (leg 1)"*, and would divorce a door from a wall Q1 leaves standing — the exact door-out-of-host RED `sdg_gate.js` exists to flag. Leg 3 therefore excludes anything appearing as a `filling_guid` in the real `rel_fills_host` edges. This follows §2.3 rather than overriding it, but it is a judgement call worth a second pair of eyes.
2. **No toolbar button / canvas pointer binding was added.** The spec calls the grab target "implementer's choice" and the op "UI-agnostic", and §4 forbids UI polish, so this PR ships the complete module API (`beginRoomDragSession` → `previewCommands` → `commit` → `endDragSession`; `beginItemDragSession` → `canDropAt` → `commit` → `endDragSession`) plus the fold, but no new mode pill. Entry points are `window.Bonsai.roommove` / `window.Bonsai.itemdrag`. Wiring a mode into `modeller.html`'s pointer handlers — and calling `_runGate` after each commit per Q6 — is deliberately left as a separate, reviewable change to the interaction model.
3. **`qualifiedRooms()` mirrors `bom_tree.js seedFromDb`'s qualification rather than calling it.** `bom_tree.js` exports only the finished tree, not the space→footprint map, and it is a protected file. The mirror carries an explicit "if bom_tree.js's rule changes, change it here too" warning. A future refactor could export `qualifySpaces` from `bom_tree.js` and delete the copy — that would require editing a protected file, so it was not done here.
4. **Adjacent, left alone (per scope discipline):** `modeller.html`'s `featLabel()` has no case for `GEOM_ROOM_MOVE`, so the history scrubber renders it via the default branch as "ROOM_MOVE" rather than a human label like "Room move". Cosmetic, one line, deliberately not touched.

## Prior art

No code from `pascalorg/editor` was copied — every line here targets this repo's own op-log/BOM/placement-resolver architecture, built from scratch. One idea was harvested, not the implementation: the *shape* of a validate-before-place contract (`canDropAt(...) -> {valid, conflictIds, snappedPos?}`), read directly from `pascalorg/editor`'s `canPlaceOnWall`/`canPlaceOnFloor`/`canPlaceOnCeiling` (`wiki/architecture/spatial-queries.md`, `packages/core/src/hooks/spatial-grid/use-spatial-query.ts`) during a harvest review (`docs/internal/BIM_OOTB_ASSESSMENT_2026-08-06.md` §8, `prompts/Modeller/COMPETITIVE_PASCALORG_HARVEST.md` §1). We deliberately implemented the *opposite* validity semantics — pascalorg returns `adjustedY` and silently corrects an invalid placement into a valid one; this gate refuses and never adjusts (§3.3, G5) — so the credit is for the contract shape, not the behavior. `pascalorg/editor` is MIT-licensed; this note exists for intellectual honesty, not license compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
