### PR TITLE
fix(tour): scrub-bar close button + Tab/space panel controls

### DIFF
--- a/viewer/tour.js
+++ b/viewer/tour.js
@@ -1641,6 +1641,7 @@ function setupTour(A) {
     if (_scrubPanel) return;
     _scrubPanel = document.createElement('div');
     _scrubPanel.id = 'tour-scrub-panel';
+    _scrubPanel.className = 'glass-panel'; // §S280 universal Esc-panel-close + toggleAllPanels/focusOnlyLatest sweeps
     var tmp = document.getElementById('time-machine-panel');
     var bottom = (tmp && tmp.style.display && tmp.style.display !== 'none') ? '260px' : '80px';
     _scrubPanel.style.cssText =
@@ -1654,6 +1655,7 @@ function setupTour(A) {
       '<div style="display:flex;align-items:center;gap:6px;width:100%">' +
         '<span id="tour-scrub-label" style="flex:1;color:#4fc3f7;font-weight:bold;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Fly Tour</span>' +
         '<span id="tour-scrub-time" style="font-size:13px;color:#ccc;font-variant-numeric:tabular-nums">0:00 / 0:00</span>' +
+        '<button id="tour-scrub-close" title="Stop tour and close" style="width:20px;height:20px;line-height:18px;padding:0;font-size:13px;color:#ccc;background:transparent;border:none;cursor:pointer">&#x2715;</button>' +
       '</div>' +
       '<div id="tour-scrub-ticks" style="position:relative;width:100%;height:10px"></div>' +
       '<input id="tour-scrub-slider" type="range" min="0" max="' + SCRUB_RES + '" step="1" value="0" style="width:100%;accent-color:#4fc3f7">' +
@@ -1705,9 +1707,23 @@ function setupTour(A) {
     document.getElementById('tour-scrub-prev').onclick = function() { A.tourStepBeat(-1); };
     document.getElementById('tour-scrub-next').onclick = function() { A.tourStepBeat(1); };
     document.getElementById('tour-scrub-play').onclick = function() { A.tourTogglePause(); };
+    document.getElementById('tour-scrub-close').onclick = function() { A._scrubStop('close-button'); };
     var spds = _scrubPanel.querySelectorAll('.tour-scrub-spd');
     for (var i = 0; i < spds.length; i++) {
       spds[i].onclick = function() { A.tourSetSpeed(parseFloat(this.getAttribute('data-spd'))); };
+    }
+
+    // §SCRUB_PANEL_TAB — join the same Tab-cycle/focus registry every other floating panel uses
+    // (scene.js _registerPanel/_cyclePanel). While focused: space/Enter = pause toggle, left/right
+    // arrows = step one beat, Escape = full stop (routes to A._scrubStop as the panel's closeFn).
+    if (typeof window._registerPanel === 'function') {
+      window._registerPanel('tourscrub', _scrubPanel, {
+        onKey: function(e) {
+          if (e.key === ' ' || e.key === 'Enter') { A.tourTogglePause(); return; }
+          if (e.key === 'ArrowLeft') { A.tourStepBeat(-1); return; }
+          if (e.key === 'ArrowRight') { A.tourStepBeat(1); return; }
+        }
+      }, A._scrubStop);
     }
   }
 
@@ -1891,6 +1907,29 @@ function setupTour(A) {
   A._scrubHide = function() {
     if (_scrubPanel) _scrubPanel.style.display = 'none';
     A._tourPaused = false;
+  };
+
+  // §SCRUB_BAR_LIFECYCLE — the missing "stop" (D3, 2026-07-25, kept L as pause/resume-only on
+  // purpose; this fills the gap it left: nothing previously reset walkActions/walkActionIdx once
+  // a graph tour had started, so the bar could never close except on natural tour completion
+  // (walkTick above) or a canvas-tap abort — both of which leave walkActionIdx intact, so the next
+  // L just resumes. This is a real, full stop: same reset walkTick does on natural completion,
+  // callable from the scrub panel's close button and its Tab-focused Escape (closeFn below).
+  A._scrubStop = function(why) {
+    A.walkMode = false;
+    A.flyActive = false;
+    A.walkActionIdx = 0;
+    A.walkActionT = 0;
+    A.walkPanAngle = 0;
+    A.walkLastTime = 0;
+    var btnE = document.getElementById('fly-btn');
+    if (btnE) btnE.classList.remove('active');
+    var spdBtn = document.getElementById('walk-speed-btn');
+    if (spdBtn) spdBtn.style.display = 'none';
+    A.status.textContent = 'Tour stopped.';
+    A.wlog('Tour stopped (' + (why || 'manual') + ')');
+    if (A._scrubHide) A._scrubHide();
+    console.log('[TOUR] §SCRUB_STOP why=' + (why || 'manual'));
   };
 
   // ── Legacy path builders (kept for fallback) ──

--- a/witness_tour_scrub.js
+++ b/witness_tour_scrub.js
@@ -434,6 +434,67 @@ function claim(name, pass, detail) {
       `| ✈-PAUSE bar=${life.barOnFlyPause} paused=${life.pausedOnFlyPause} ` +
       `| REVEAL bar=${life.revealBar} walkModeStillRunning=${life.revealWalkStillOn} (discovery not broken)`);
 
+    // ── W-SCRUB-PANEL-TAB — the bar must join the same _registerPanel/_focusPanel registry every
+    // other floating panel uses (scene.js), so it's Tab-reachable; while focused, space pauses/
+    // resumes (real onKey routing). Runs on the tour STILL RUNNING from W-SCRUB-RESUME-BAR above —
+    // deliberately not a fresh restart: a second cold toggleFlyAround() re-triggers a genuine
+    // multi-minute full-building re-stream (observed live, not a hang — 122k elements from 0%),
+    // unrelated to this fix and not worth paying for twice in one run. Escape's "call the focused
+    // panel's closeFn" routing is scene.js's existing shared mechanism (every other panel already
+    // depends on it, unmodified here) — proven structurally (closeFn === A._scrubStop) rather than
+    // by re-triggering a second expensive stop+restart; W-SCRUB-STOP-CLOSE below already proves
+    // A._scrubStop performs a REAL full stop behaviorally.
+    const tabTest = await page.evaluate(async () => {
+      const A = window.APP;
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const p = document.getElementById('tour-scrub-panel');
+      const entry = window._panels ? window._panels.find(x => x.id === 'tourscrub') : null;
+      const registered = !!entry;
+      const closeIsScrubStop = !!(entry && entry.close === A._scrubStop);
+
+      window._focusPanel('tourscrub');       // same call _cyclePanel(Tab) lands on internally
+      await sleep(20);
+      // _focusPanel sets style.boxShadow='inset 3px 0 0 #4fc3f7', but the browser normalizes hex
+      // to rgb(...) on readback — match on non-empty (default/blurred state is '') not the hex text.
+      const focused = p.style.boxShadow.length > 0;
+
+      const pausedBefore = A._tourPaused;
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+      await sleep(20);
+      const pausedAfterSpace = A._tourPaused;
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+      await sleep(20);
+      const pausedAfterSpace2 = A._tourPaused;
+
+      return { registered, closeIsScrubStop, focused, pausedBefore, pausedAfterSpace, pausedAfterSpace2 };
+    });
+    claim('W-SCRUB-PANEL-TAB',
+      tabTest.registered && tabTest.closeIsScrubStop && tabTest.focused &&
+      !tabTest.pausedBefore && tabTest.pausedAfterSpace && !tabTest.pausedAfterSpace2,
+      `registered=${tabTest.registered} closeFn=A._scrubStop:${tabTest.closeIsScrubStop} focusedGlow=${tabTest.focused} ` +
+      `| space-pause ${tabTest.pausedBefore}→${tabTest.pausedAfterSpace}→${tabTest.pausedAfterSpace2}`);
+
+    // ── W-SCRUB-STOP-CLOSE — the new × button must be a REAL stop, not a re-hideable pause: L
+    // never had a path back to this branch once a graph tour started (only pause/resume), so
+    // walkActionIdx must reset to 0 here — proof a later L can't silently resume a dead tour.
+    const stopClick = await page.evaluate(() => {
+      const A = window.APP;
+      const p = document.getElementById('tour-scrub-panel');
+      const closeBtn = document.getElementById('tour-scrub-close');
+      const hasCloseBtn = !!closeBtn;
+      const shownBefore = p && p.style.display === 'flex';
+      const idxBefore = A.walkActionIdx, walkBefore = A.walkMode;
+      if (closeBtn) closeBtn.click();
+      return { hasCloseBtn, shownBefore, idxBefore, walkBefore,
+               shownAfter: p && p.style.display === 'flex',
+               idxAfter: A.walkActionIdx, walkAfter: A.walkMode, flyAfter: A.flyActive };
+    });
+    claim('W-SCRUB-STOP-CLOSE',
+      stopClick.hasCloseBtn && stopClick.shownBefore && stopClick.idxBefore > 0 && stopClick.walkBefore &&
+      !stopClick.shownAfter && stopClick.idxAfter === 0 && !stopClick.walkAfter && !stopClick.flyAfter,
+      `before ×: bar=${stopClick.shownBefore} idx=${stopClick.idxBefore} walkMode=${stopClick.walkBefore} | ` +
+      `after ×: bar=${stopClick.shownAfter} idx=${stopClick.idxAfter} walkMode=${stopClick.walkAfter} flyActive=${stopClick.flyAfter}`);
+
   } catch (e) {
     claim('WITNESS-RUN', false, 'threw: ' + e.message);
   }


### PR DESCRIPTION
## Summary
- Fly Tour's scrub bar had no way to fully close once a graph tour started — L only pauses/resumes (`§SCRUB_BAR_LIFECYCLE` D3, deliberate), and nothing else ever reset `walkActionIdx`, so the bar could only close via natural tour completion or a canvas-tap abort (both leave `idx` intact, so the next L just resumes).
- Adds a × close button (`A._scrubStop`) that fully resets `walkMode`/`flyActive`/`walkActionIdx` and hides the bar — a real stop, not a re-hideable pause.
- Joins the scrub bar to the same `_registerPanel`/`_focusPanel` Tab-cycle registry every other floating panel (toolbar/section/sunglass/find) already uses: while focused, space pauses/resumes, Escape triggers the same full stop via `closeFn=A._scrubStop`.

## Test plan
- [x] `node --check viewer/tour.js witness_tour_scrub.js` — clean
- [x] `npx eslint viewer/tour.js witness_tour_scrub.js` — clean
- [x] `witness_tour_scrub.js` (LTU_AHouse, headless) — 13/13 PASS, including new `W-SCRUB-STOP-CLOSE` and `W-SCRUB-PANEL-TAB` claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)