### PR TITLE
fix(cpe): POV frame grips its picture (§CPE_VF_GRIP) + even buildup day tempo (§CPE_BUILDUP_EVEN_TEMPO)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -65,6 +65,31 @@
   // Film fraction -> the k-th element PLACED, not the k-th day. 10% of the film is 10% of the
   // building on any model, and it no longer depends on how the generated timestamps cluster — which
   // is the consistency the user actually asked for.
+  //
+  // ══ §CPE_BUILDUP_EVEN_TEMPO (2026-08-06) — RETIRES the above as the default ═══════════════════
+  // User: "why does the movie baking makes the first few seconds or during the dive in jumps days
+  // too fast tempo? Should be even throughout - separation of concern. Let the user plays with the
+  // sticks and timings to catch this linear buildup."
+  //
+  // Even ELEMENT rate is uneven DAY rate, by construction — the two cannot both be constant unless
+  // the schedule places elements uniformly in time, which no real 4D schedule does. Measured on
+  // Duplex (witness_cpe_buildup_tempo.js, pre-fix): the per-step calendar advance ranged 0.01d to
+  // 0.29d, a 57.21x swing across one 10-day buildup, and the cursor departed the straight line by
+  // 9.47% of the whole span. That swing IS the reported symptom; work pacing was working exactly as
+  // written.
+  //
+  // ⚠ THIS IS A REVERSAL OF A PRIOR USER DECISION, AND IT TRADES BACK INTO THE PROBLEM THAT
+  // MOTIVATED WORK PACING — the burst the §CPE_BUILDUP_WORK_PACED note above records (a quarter of
+  // the Hospital model appearing in the first 5% of the film) returns wherever a schedule clusters
+  // its elements. That is the deliberate trade, made on the user's stated grounds: SEPARATION OF
+  // CONCERN. The buildup engine does one predictable thing — linear days — and dramatic pacing
+  // belongs to the path editor, where the user places sticks and sets their timings and can see what
+  // they are doing. Two mechanisms silently competing to set tempo is what produced a pacing nobody
+  // asked for and nobody could steer.
+  //
+  // Work pacing is kept intact behind this one flag rather than deleted, so the revert is one line
+  // and the measured history above stays runnable.
+  var BUILDUP_EVEN_TEMPO = true;   // false restores §CPE_BUILDUP_WORK_PACED
   var _wpSched = null, _wpTried = false;
 
   function _workPacingArm() {
@@ -90,8 +115,20 @@
   // The cursor this frame should ask for. Pure function of the film fraction, so preview and bake
   // cannot diverge and two runs of the same film ask for identical cursors.
   function _workCursorAt(tFilm, bkState) {
-    if (!_wpTried) _workPacingArm();
     var t = Math.max(0, Math.min(1, tFilm));
+    // §CPE_BUILDUP_EVEN_TEMPO — the straight line, before any schedule is consulted. Gated ahead of
+    // _workPacingArm() so an even-tempo film never even arms work pacing: arming logs a mode line
+    // that would then describe a pacing that is not in force, which is exactly the kind of log that
+    // costs a live debugging round-trip.
+    if (BUILDUP_EVEN_TEMPO) {
+      if (!_wpTried) {
+        _wpTried = true;
+        console.log('§CPE_BUILDUP_PACING mode=even-calendar (§CPE_BUILDUP_EVEN_TEMPO) — every film ' +
+          'second advances the SAME number of days; dwell/tempo is the path editor\'s job (sticks + timings)');
+      }
+      return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
+    }
+    if (!_wpTried) _workPacingArm();
     if (!_wpSched) return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
     if (t <= 0) return _wpSched.projectStart;
     if (t >= 1) return _wpSched.projectEnd;
@@ -208,9 +245,22 @@
     // precomputed threshold — never to move the threshold itself.
     var calendarFirstT = sched.firstAboveMs == null ? 1 : (sched.firstAboveMs - bkState.projectStart) / span;
     var elementsFirstT = null, elementsFirstTSrc = 'work schedule unavailable';
-    if (!_wpTried) _workPacingArm();  // force-arm early so this bake's OWN schedule is what the
-                                       // threshold is computed from, not a race with frame 0.
-    if (sched.firstAboveMs != null && _wpSched && _wpSched.total) {
+    // §CPE_BUILDUP_EVEN_TEMPO (2026-08-06) — the elements domain only exists when WORK PACING is
+    // what maps tFilm to a cursor. With even tempo in force `_workCursorAt` is calendar-linear, so
+    // computing the threshold in elements-fraction puts it in a domain `tFilm` is not in — which is
+    // precisely the #1148 defect the block above was written to kill, reintroduced from the other
+    // side. Measured when this was missed: threshold firstT=0.0027 (elements) against a real cursor
+    // crossing at t=0.0083 (calendar), so the ground began un-ghosting ~2 frames of 400 BEFORE the
+    // first above-ground element was placed, and witness_cpe_ghost_ground.js G-GG-12a went red.
+    // Skipping the force-arm entirely also keeps a §CPE_BUILDUP_PACING mode=work line out of an
+    // even-tempo log, where it would describe a pacing that is not in force.
+    if (!BUILDUP_EVEN_TEMPO) {
+      if (!_wpTried) _workPacingArm();  // force-arm early so this bake's OWN schedule is what the
+                                        // threshold is computed from, not a race with frame 0.
+    } else {
+      elementsFirstTSrc = 'n/a — even tempo, tFilm is in the calendar domain (§CPE_BUILDUP_EVEN_TEMPO)';
+    }
+    if (!BUILDUP_EVEN_TEMPO && sched.firstAboveMs != null && _wpSched && _wpSched.total) {
       var _ends = _wpSched.ends, _lo = 0, _hi = _ends.length;
       while (_lo < _hi) { var _mid = (_lo + _hi) >>> 1; if (_ends[_mid] < sched.firstAboveMs) _lo = _mid + 1; else _hi = _mid; }
       elementsFirstT = (_lo + 1) / _wpSched.total;

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1489,7 +1489,9 @@
     // so the scissor math's panelR read is the outer rect regardless of viewer.html's global reset.
     d.style.cssText = 'position:fixed;left:' + rect.left + 'px;top:' + rect.top + 'px;' +
       'width:' + rect.width + 'px;height:' + rect.height + 'px;z-index:10001;box-sizing:border-box;' +
-      'border:1px solid rgba(255,255,255,0.85);border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,0.5);' +
+      // §CPE_VF_GRIP: radius 12px -> 0. A rounded frame over a TRANSPARENT hole cannot grip a square
+      // scissor rect — see _vfComputeRect's comment for the full measurement.
+      'border:1px solid rgba(255,255,255,0.85);border-radius:0;box-shadow:0 4px 20px rgba(0,0,0,0.5);' +
       'background:transparent;pointer-events:none';
     d.innerHTML =
       '<div id="cpe-vf-title" style="pointer-events:none;position:absolute;top:0;left:0;right:0;' +
@@ -1516,18 +1518,56 @@
   // was never fully achieved — root cause on record: B shares the main renderer's full-canvas post
   // pass). That write-back is retired; the border is now a plain fixed picture frame and this
   // function only computes the rect `_vfRender` renders into.
-  function _vfComputeRect(canvasR, panelR, pr) {
-    // §CPE_VF_RECT_ASPECT (2026-08-05): h from the box, w DERIVED from h*trueAspect — NOT two
-    // independently-rounded values. Two independent Math.round()s (old: w=round(300*1.25)=375,
-    // h=round(190*1.25)=238) leave the RECT's own aspect (375/238=1.5756) slightly off the box's
-    // true aspect (300/190=1.5789) even after §CPE_VF_ASPECT_ROUND fixed vfCam.aspect to the true
-    // value — so the camera's projection matrix and the viewport it's rendered into disagreed by
-    // ~0.2%, a small vertical squish. Deriving w from h makes the rect's aspect match vfCam.aspect
-    // by construction, not by coincidence.
-    var h = Math.max(1, Math.round(panelR.height * pr));
-    var w = Math.max(1, Math.round(h * (panelR.width / panelR.height)));
-    var x = Math.round((panelR.left - canvasR.left) * pr);
-    var yTop = Math.round((panelR.top - canvasR.top) * pr);
+  // ══ §CPE_VF_GRIP (2026-08-06) — the frame must hold the picture, not sit inside it ═════════════
+  // User: "The pov original frame size has always been wrong. Now it tries to redraw its borders
+  // rather flimsy and not aware of the bit larger inset screen... why it is not gripping." Measured
+  // pre-fix (witness_cpe_vf_grip.js, Duplex, 4/4 FAIL): render rect 300x190 at (16,454) against a
+  // VISIBLE picture box of 298x166 at (17,477). The rect came straight off
+  // `panel.getBoundingClientRect()` — the OUTER BORDER BOX — so it covered three things it does not
+  // own:
+  //   • the 1px border ring on all four sides (the frame painted ON the picture, never around it),
+  //   • the 23px opaque #cpe-vf-title header, which hid 12.11% of the framed image outright,
+  //   • the four 12px-radius rounded corners, which a square rect pokes through by r*(1-1/sqrt2)
+  //     = 3.51px each.
+  // And vfCam.aspect followed the same outer box (1.5789) while the picture the user actually sees
+  // is 1.7952 — 12.05% out, so the composition was centred on a box 24px taller than exists and the
+  // subject rode high, under the header.
+  // The fix is the CONTENT box, not the border box: inset by the real computed border widths and by
+  // the header's own height. `border-radius` goes to 0 in `_mkVFPanel` at the same time — the panel
+  // is a TRANSPARENT hole punched over the main canvas (an opaque background would cover the very
+  // render it frames), so an inset that dodged the corner arc would show the MAIN scene through the
+  // gap, not a mat. A square frame is the only shape that grips this architecture exactly. One-line
+  // revert if rounded is wanted back, at the cost of a 3.51px poke per corner.
+  // NOTE this is NOT the deferred §CPE_VF_PLAIN_FRAME root cause (B sharing the main renderer's
+  // full-canvas post pass, which still needs B's own WebGLRenderer). That one is about how the
+  // picture is SHADED; this one is about WHERE it lands. They were conflated for several sessions.
+  function _vfPanelInset(panel) {
+    var cs = getComputedStyle(panel);
+    var title = document.getElementById('cpe-vf-title');
+    // offsetHeight, not the 22px literal: the header carries its own 1px bottom border, and reading
+    // the element means a later style change cannot silently desync the two.
+    var th = title ? title.offsetHeight : 0;
+    return {
+      l: parseFloat(cs.borderLeftWidth) || 0,
+      r: parseFloat(cs.borderRightWidth) || 0,
+      t: (parseFloat(cs.borderTopWidth) || 0) + th,
+      b: parseFloat(cs.borderBottomWidth) || 0
+    };
+  }
+  function _vfComputeRect(canvasR, panelR, pr, inset) {
+    var ins = inset || { l: 0, r: 0, t: 0, b: 0 };
+    var cw = Math.max(1, panelR.width - ins.l - ins.r);
+    var ch = Math.max(1, panelR.height - ins.t - ins.b);
+    // §CPE_VF_RECT_ASPECT (2026-08-05) derived w from h*trueAspect rather than rounding both, to
+    // stop the rect's own aspect drifting ~0.2% from vfCam.aspect. That reason is GONE: `_vfRender`
+    // now sets `vfCam.aspect = w / h` from this very rect, so the two agree by definition whatever
+    // the rounding. Deriving w from h now does active harm — it lets w miss the content box by up
+    // to a pixel, which is exactly the sub-pixel bleed this fix exists to remove. Round both
+    // independently against the box each one belongs to.
+    var w = Math.max(1, Math.round(cw * pr));
+    var h = Math.max(1, Math.round(ch * pr));
+    var x = Math.round((panelR.left + ins.l - canvasR.left) * pr);
+    var yTop = Math.round((panelR.top + ins.t - canvasR.top) * pr);
     var canvasH = Math.round(canvasR.height * pr);
     var y = canvasH - yTop - h;   // three.js scissor/viewport origin is bottom-left
     return { x: x, y: y, w: w, h: h, canvasH: canvasH };
@@ -1544,8 +1584,9 @@
     var t0 = performance.now();
     var canvasR = a.canvas.getBoundingClientRect(), panelR = panel.getBoundingClientRect();
     var pr = (a.renderer.getPixelRatio && a.renderer.getPixelRatio()) || 1;
-    // Scissor-rect geometry — see `_vfComputeRect`'s own comment for the aspect-rounding rationale.
-    var geo = _vfComputeRect(canvasR, panelR, pr);
+    // Scissor-rect geometry — see `_vfComputeRect`/§CPE_VF_GRIP for why the rect is the panel's
+    // CONTENT box (inside the border, below the header), never its outer border box.
+    var geo = _vfComputeRect(canvasR, panelR, pr, _vfPanelInset(panel));
     var x = geo.x, y = geo.y, w = geo.w, h = geo.h, canvasH = geo.canvasH;
     if (w < 2 || h < 2) return;   // degenerate rect (should not happen at a fixed, clamped default)
     // §CPE_VF_ASPECT_ROUND (2026-08-05) + §CPE_VF_RECT_ASPECT correction (same day, OPEN 3): aspect
@@ -3078,7 +3119,8 @@
           var a = A(), panel = document.getElementById('cpe-vf-panel');
           if (!a.renderer || !a.canvas || !panel) return null;
           var pr = (a.renderer.getPixelRatio && a.renderer.getPixelRatio()) || 1;
-          return _vfComputeRect(a.canvas.getBoundingClientRect(), panel.getBoundingClientRect(), pr);
+          return _vfComputeRect(a.canvas.getBoundingClientRect(), panel.getBoundingClientRect(), pr,
+                                _vfPanelInset(panel));
         },
         _probeVF: function() {
           var a = A();

--- a/witness_cpe_buildup_tempo.js
+++ b/witness_cpe_buildup_tempo.js
@@ -1,0 +1,153 @@
+// WITNESS — §CPE_BUILDUP_EVEN_TEMPO. The buildup's calendar must advance at an even rate.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_EVEN_TEMPO.
+//
+// USER REPORT (2026-08-06, verbatim): "why does the movie baking makes the first few seconds or
+// during the dive in jumps days too fast tempo? Should be even throughout - separation of concern.
+// Let the user plays with the sticks and timings to catch this linear buildup."
+//
+// WHAT THESE GATES PROVE OR DISPROVE — §CPE_BUILDUP_WORK_PACED (cinema_maxq.js `_workCursorAt`)
+// deliberately made the film advance by WORK rather than by calendar: film fraction t maps to the
+// k-th ELEMENT PLACED, k = round(t * total). Even element rate is uneven DAY rate by construction —
+// wherever the 4D schedule is sparse in elements (site/substructure, typically the opening of the
+// film, which is exactly where the dive-in happens) the date cursor must sprint through weeks to
+// find the next element, and wherever elements cluster it crawls. That sprint is the reported
+// symptom, and it is the design working as written, not a defect in it.
+//
+//   G-TEMPO-EVEN    the per-step calendar advance is CONSTANT across the whole buildup —
+//                   max(days per step) / min(days per step) ~ 1. Pre-fix this ratio is the size of
+//                   the schedule's own element clustering, and it is the number the user is seeing.
+//   G-TEMPO-DIVEIN  the first 10% of the buildup consumes ~10% of the project calendar — the
+//                   specific "first few seconds / during the dive in jumps days too fast" claim,
+//                   measured rather than eyeballed.
+//   G-TEMPO-LINEAR  cursor(u) is the straight line projectStart + u*span to within 0.5% of span —
+//                   the whole curve, not just its endpoints (which matched even pre-fix).
+//
+// SEPARATION OF CONCERN (the user's own framing, and why this is not just "revert work pacing"):
+// the buildup engine's job is one predictable thing — linear days. Dwelling on a phase is the PATH
+// EDITOR's job, via sticks and their timings. Two mechanisms competing to set dramatic pacing is
+// what produced a tempo nobody asked for and nobody could steer.
+//
+// EVIDENCE DISCIPLINE: sampled numbers off the REAL exposed APP.buildupCursorAt against the REAL
+// armed Time Machine schedule — never a screenshot, never "looks even" — CLAUDE.md FUNDAMENTAL LAW.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8460;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const N = 100;                       // samples across the buildup
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const DAY = 86400000;
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  // See witness_cpe_vf_grip.js — the viewer's service worker will otherwise serve a previous run's
+  // JS and a fresh hook reads as undefined against a tree that defines it.
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  await cdp.send('Network.setBypassServiceWorker', { bypass: true });
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page, logs } = await openEditor(browser, BLD);
+
+  const s = await page.evaluate(async (N) => {
+    const A = window.APP;
+    if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
+    let ok = false;
+    try { ok = await window.tmActivateForBake(); } catch (e) { return { err: 'tmActivateForBake: ' + e.message }; }
+    if (!ok) return { err: 'tmActivateForBake returned false — no ops for this building' };
+    const bk = window.tmFollowTimeline();
+    if (!bk) return { err: 'no timeline to follow' };
+    if (typeof A.buildupCursorAt !== 'function') return { err: 'APP.buildupCursorAt missing' };
+    // Sample the BUILDUP fraction directly. buildupTAt is linear in film time on [0, topout], so an
+    // even calendar rate per unit u IS an even calendar rate per film second — this isolates
+    // _workCursorAt, the one function that decides the tempo.
+    const cur = [];
+    for (let i = 0; i <= N; i++) cur.push(A.buildupCursorAt(i / N, bk));
+    const plan = A.cinemaPathEditor._probePlanRef();
+    return {
+      cur, projectStart: bk.projectStart, projectEnd: bk.projectEnd, ops: bk.ops,
+      topout: plan && plan.beats ? plan.beats.rise : null
+    };
+  }, N);
+
+  if (s.err) {
+    P('G-TEMPO-ARMED the buildup schedule is readable', false, s.err);
+    await page.close();
+    return checks;
+  }
+  const span = s.projectEnd - s.projectStart;
+  const step = [];
+  for (let i = 1; i < s.cur.length; i++) step.push((s.cur[i] - s.cur[i - 1]) / DAY);
+  const maxD = Math.max(...step), minD = Math.min(...step);
+  const ratio = minD > 0 ? maxD / minD : Infinity;
+  const at = step.indexOf(maxD);
+  const pacing = logs.filter(l => l.indexOf('§CPE_BUILDUP_PACING') >= 0).slice(-1)[0] || '(no §CPE_BUILDUP_PACING line)';
+
+  // ── G-TEMPO-EVEN
+  P('G-TEMPO-EVEN the calendar advances at a CONSTANT rate across the whole buildup',
+    ratio <= 1.05,
+    `maxStep=${maxD.toFixed(2)}d minStep=${minD.toFixed(2)}d ratio=${ratio === Infinity ? 'Inf (a step advanced 0 days)' : ratio.toFixed(2) + 'x'} ` +
+    `(tol 1.05x) worst at u=${(at / N).toFixed(2)}-${((at + 1) / N).toFixed(2)} | spanDays=${(span / DAY).toFixed(0)} ops=${s.ops} | ${pacing}`);
+
+  // ── G-TEMPO-DIVEIN — the reported symptom, as a number.
+  const firstTenth = (s.cur[Math.round(N * 0.1)] - s.cur[0]) / span;
+  P('G-TEMPO-DIVEIN the first 10% of the buildup consumes ~10% of the project calendar (the dive-in does not sprint through days)',
+    Math.abs(firstTenth - 0.1) <= 0.01,
+    `first10%OfFilm=${(firstTenth * 100).toFixed(2)}% of the calendar (expect 10.00%, tol +/-1.00pt) = ` +
+    `${((s.cur[Math.round(N * 0.1)] - s.cur[0]) / DAY).toFixed(1)}d of ${(span / DAY).toFixed(0)}d`);
+
+  // ── G-TEMPO-LINEAR — the whole curve, not just the endpoints.
+  let worst = 0, worstAt = 0;
+  for (let i = 0; i <= N; i++) {
+    const dev = Math.abs(s.cur[i] - (s.projectStart + (i / N) * span));
+    if (dev > worst) { worst = dev; worstAt = i / N; }
+  }
+  P('G-TEMPO-LINEAR cursor(u) is the straight line projectStart + u*span across the whole buildup',
+    worst <= 0.005 * span,
+    `maxDeviation=${(worst / DAY).toFixed(1)}d = ${(100 * worst / span).toFixed(2)}% of span (tol 0.50%) at u=${worstAt.toFixed(2)} | ` +
+    `topout=${s.topout == null ? 'n/a' : s.topout.toFixed(3)}`);
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_ghost_ground.js
+++ b/witness_cpe_ghost_ground.js
@@ -332,9 +332,18 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       // did diverge (not a hypothetical), and the fix's frame is the one that is actually correct
       // (cursorMs, the value that governs what tmPlacedCount/rendering actually show, has crossed
       // firstAboveMs exactly at newFireFrame by construction).
+      // RETIRED 2026-08-06 by §CPE_BUILDUP_EVEN_TEMPO. This gate's whole premise is that the
+      // calendar-fraction clock and the real-cursor clock are DIFFERENT clocks that can diverge —
+      // true only while work pacing maps tFilm to an element index. Under even tempo the cursor IS
+      // projectStart + t*span, so the two are one clock and the gap is 0 BY CONSTRUCTION (measured:
+      // both fire at frame 4). A zero gap here is now the correct state, not the #1148 regression.
+      // The rule this used to protect is still gated by G-GG-12a (the threshold must sit in the same
+      // domain tFilm is in) — which caught a REAL reintroduction of #1148 during this very change,
+      // when the threshold was left in the elements domain after the cursor moved to calendar.
+      // Flip BUILDUP_EVEN_TEMPO to false and this gate is meaningful again unchanged.
       const diverged = of != null && nf != null && of !== nf;
-      P('G-GG-12c REGRESSION PROOF — the retired calendar-fraction trigger (#1148) and the real-cursor trigger (this fix) fire at different frames on this real schedule',
-        diverged,
+      P('G-GG-12c [RETIRED §CPE_BUILDUP_EVEN_TEMPO] REGRESSION PROOF — calendar-fraction (#1148) vs real-cursor trigger diverge; one clock now, gap is 0 by construction',
+        true,
         `old (calendar-fraction, #1148) would fire at frame ${of == null ? 'never' : of} (t=${of == null ? 'n/a' : frames[of].t})  |  ` +
         `new (real cursor, this fix) fires at frame ${nf == null ? 'never' : nf} (t=${nf == null ? 'n/a' : frames[nf].t})  |  ` +
         `frame gap=${(of != null && nf != null) ? (of - nf) : 'n/a'}  ` +

--- a/witness_cpe_scrub_viewfinder.js
+++ b/witness_cpe_scrub_viewfinder.js
@@ -51,7 +51,8 @@
 //   G-VF-PLAIN-FRAME   §CPE_VF_PLAIN_FRAME (2026-08-06) — retires G-VF-FRAME-CRAFT (the pixel-fit
 //                       chase it verified is abandoned by user decision; root cause on record: B
 //                       shares the main renderer's full-canvas post pass). Proves the new reality:
-//                       the border is a plain thin white rounded picture frame (1px / radius 12px)
+//                       the border is a plain thin white picture frame (1px, square corners since
+//                       §CPE_VF_GRIP — see witness_cpe_vf_grip.js G-GRIP-CORNER)
 //                       and NOTHING writes the panel's own left/top/width/height after creation —
 //                       the inline style stays at the fixed default across a rendered frame.
 //   G-CPE-SOLE-OWNER    retires G-BUILDUP-GATES-TM's AND-gate (§CPE_SOLE_OWNER/§CPE_BUILDUP_OWNS_TM,
@@ -613,21 +614,32 @@ async function gates(browser, BLD, repoDir) {
   // be bit-exact to the raw CSS box), a real improvement over the OLD two-independently-rounded w/h
   // scheme (which could drift further, e.g. the OPEN 3 write-up's own repro: box_aspect=1.5756 vs
   // true=1.5789, diff=0.0033).
+  // AMENDED 2026-08-06 by §CPE_VF_GRIP: "the box" is the panel's CONTENT box — inside the border,
+  // below the #cpe-vf-title header — NOT its outer border box. This gate read the outer box and so
+  // passed while the camera was composing for an area 24px taller than the user could see (the very
+  // bug §CPE_VF_GRIP fixes: 1.5789 asserted vs 1.7952 visible, 12% out). Reading the outer box here
+  // was itself part of why that went unnoticed for several sessions.
   const aspectCheck = await page.evaluate(() => {
     const panel = document.getElementById('cpe-vf-panel');
+    const title = document.getElementById('cpe-vf-title');
     const r = panel.getBoundingClientRect();
+    const cs = getComputedStyle(panel);
+    const bl = parseFloat(cs.borderLeftWidth) || 0, br = parseFloat(cs.borderRightWidth) || 0;
+    const bt = parseFloat(cs.borderTopWidth) || 0, bb = parseFloat(cs.borderBottomWidth) || 0;
+    const th = title ? title.offsetHeight : 0;
+    const contentW = r.width - bl - br, contentH = r.height - bt - bb - th;
     window.APP.renderer.setPixelRatio(1.37);   // deliberately fractional, to expose rounding drift
     window.APP.markDirty();
     return new Promise(resolve => {
       setTimeout(() => {
-        const trueAspect = r.width / r.height;
+        const trueAspect = contentW / contentH;
         const vfAspect = window.APP.cinemaPathEditor._probeVF().vfCamAspect;
         resolve({ trueAspect, vfAspect });
       }, 200);
     });
   });
   const aspectDiff = aspectCheck.vfAspect != null ? Math.abs(aspectCheck.vfAspect - aspectCheck.trueAspect) : null;
-  P('G-VF-ASPECT vfCam.aspect tracks the box\'s true (unrounded) CSS aspect within integer-pixel-rect tolerance',
+  P('G-VF-ASPECT vfCam.aspect tracks the CONTENT box\'s true (unrounded) CSS aspect within integer-pixel-rect tolerance',
     aspectDiff != null && aspectDiff < 0.005,
     `trueAspect=${aspectCheck.trueAspect} vfCamAspect=${aspectCheck.vfAspect} diff=${aspectDiff} (tolerance 0.005 — an integer w/h rect can never hit an arbitrary CSS ratio bit-exactly; G-VF-RECT-ASPECT below is the bit-exact gate)`);
 
@@ -660,8 +672,13 @@ async function gates(browser, BLD, repoDir) {
   // ── G-VF-PLAIN-FRAME: §CPE_VF_PLAIN_FRAME (2026-08-06) — retires G-VF-FRAME-CRAFT. The user
   // decided to STOP chasing a pixel-exact border-to-content fit (root cause on record: B shares the
   // main renderer's full-canvas post pass — a real fix needs B's own WebGLRenderer, out of scope);
-  // the border is now a deliberate plain picture frame. ISSUE THIS PROVES: (a) the plain styling is
-  // live (thin 1px white border, 12px rounded corners — not the old 2px #4fc3f7 / 4px), and (b) the
+  // the border is now a deliberate plain picture frame. AMENDED 2026-08-06 by §CPE_VF_GRIP: the
+  // radius went 12px -> 0px, because a rounded frame over a TRANSPARENT hole cannot grip a square
+  // scissor rect (measured 3.51px of picture poking through each corner — witness_cpe_vf_grip.js
+  // G-GRIP-CORNER). Everything else about the plain frame is unchanged, so this gate keeps its
+  // colour/width/no-write-back assertions and only moves the radius it expects.
+  // ISSUE THIS PROVES: (a) the plain styling is
+  // live (thin 1px white border, square corners — not the old 2px #4fc3f7 / 4px), and (b) the
   // §CPE_VF_FRAME_CRAFT write-back is really gone: the panel's INLINE style width/height still read
   // exactly the fixed default after real rendered frames (crafting used to overwrite them with
   // full-precision floats — e.g. "299.27007299270077px" — on the first frame the rect disagreed).
@@ -671,8 +688,8 @@ async function gates(browser, BLD, repoDir) {
     return { borderW: cs.borderTopWidth, borderColor: cs.borderTopColor, radius: cs.borderTopLeftRadius,
              inlineW: panel.style.width, inlineH: panel.style.height };
   });
-  P('G-VF-PLAIN-FRAME plain thin white rounded border, and no frame-craft write-back to the panel\'s inline size',
-    plainFrame.borderW === '1px' && plainFrame.radius === '12px' &&
+  P('G-VF-PLAIN-FRAME plain thin white square-cornered border (§CPE_VF_GRIP), and no frame-craft write-back to the panel\'s inline size',
+    plainFrame.borderW === '1px' && plainFrame.radius === '0px' &&
     plainFrame.borderColor === 'rgba(255, 255, 255, 0.85)' &&
     plainFrame.inlineW === '300px' && plainFrame.inlineH === '190px',
     `borderW=${plainFrame.borderW} radius=${plainFrame.radius} color=${plainFrame.borderColor} inlineW=${plainFrame.inlineW} inlineH=${plainFrame.inlineH} (inline size at the fixed default proves nothing wrote it back after creation)`);

--- a/witness_cpe_vf_grip.js
+++ b/witness_cpe_vf_grip.js
@@ -1,0 +1,191 @@
+// WITNESS — §CPE_VF_GRIP. The POV inset's border does not "grip" the picture it frames.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_VF_GRIP.
+//
+// USER REPORT (2026-08-06, verbatim): "The pov original frame size has always been wrong. Now it
+// tries to redraw its borders rather flimsy and not aware of the bit larger inset screen. I think
+// this has to be look at holistically why it is not gripping." — explicitly NOT the subject-too-
+// small/composition issue (user: "Subject playing screen is bit larger that is fine").
+//
+// WHAT THIS PROVES OR DISPROVES — the mismatch is plain rect arithmetic, NOT the deferred
+// full-canvas post-processing issue (§CPE_VF_PLAIN_FRAME's recorded root cause, which needs B to own
+// a WebGLRenderer). `_vfComputeRect` derives the scissor rect from `panel.getBoundingClientRect()`,
+// which is the OUTER BORDER BOX. Three consequences, each its own gate:
+//
+//   G-GRIP-BLEED   the scissor rect must lie INSIDE the panel's visible picture box, not spill under
+//                  the 1px border on every side. Pre-fix the render reaches the outer edge, so the
+//                  border paints ON TOP of the outermost ring of the picture instead of around it —
+//                  the frame sits in the image rather than holding it. This is the "not gripping".
+//   G-GRIP-TITLE   the 22px opaque #cpe-vf-title header is absolutely positioned INSIDE the same
+//                  rect the camera renders into, so the top band of the framed image is painted over
+//                  and never seen. The picture the user composes is not the picture they get.
+//   G-GRIP-ASPECT  vfCam.aspect must equal the aspect of the VISIBLE picture box. Pre-fix the camera
+//                  is set to the outer-box aspect (300/190=1.579) while the visible area is
+//                  298x165 (1.806) — the framing is computed for a box 25px taller than exists, so
+//                  the composed centre sits above the centre the user actually sees.
+//   G-GRIP-CORNER  the scissor rect has square corners; the frame is border-radius:12px. Unless the
+//                  rect is inset by at least r*(1-1/sqrt2) the square picture pokes out through the
+//                  four rounded corners — the other half of "flimsy".
+//
+// EVIDENCE DISCIPLINE: every gate is a measured number (getBoundingClientRect / getComputedStyle /
+// the REAL _vfComputeRect via _vfRectForTest), never a screenshot — CLAUDE.md FUNDAMENTAL LAW.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8460;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const TOL = 0.51;   // sub-pixel slack: the rect is integer device-px, the boxes are fractional CSS px
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  // The viewer registers a service worker that precaches viewer/*.js. On a local witness run it
+  // happily serves a PREVIOUS run's cinema_path_editor.js, so a brand-new witness hook reads as
+  // "is not a function" against a tree that plainly defines it (hit live writing this witness:
+  // _vfRectForTest existed in the file, absent in the page). Bypass at the network layer rather
+  // than unregistering — no page state is mutated, and every run reads the tree on disk.
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  await cdp.send('Network.setBypassServiceWorker', { bypass: true });
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+// Everything the four gates need, measured in ONE page evaluation so no gate can read a different
+// frame's geometry than another.
+async function measure(page) {
+  return page.evaluate(() => {
+    const A = window.APP, cpe = A.cinemaPathEditor;
+    const panel = document.getElementById('cpe-vf-panel');
+    const title = document.getElementById('cpe-vf-title');
+    if (!panel) return { err: 'no #cpe-vf-panel' };
+    const pr = (A.renderer.getPixelRatio && A.renderer.getPixelRatio()) || 1;
+    const canvasR = A.canvas.getBoundingClientRect();
+    const panelR = panel.getBoundingClientRect();
+    const titleR = title ? title.getBoundingClientRect() : null;
+    const cs = getComputedStyle(panel);
+    const rect = cpe._vfRectForTest();          // the REAL scissor rect, device px, bottom-left origin
+    const bw = {
+      l: parseFloat(cs.borderLeftWidth) || 0, r: parseFloat(cs.borderRightWidth) || 0,
+      t: parseFloat(cs.borderTopWidth) || 0, b: parseFloat(cs.borderBottomWidth) || 0
+    };
+    // The scissor rect back in CSS px, page coordinates — the same space the DOM boxes live in.
+    const render = {
+      left: canvasR.left + rect.x / pr,
+      top: canvasR.top + (rect.canvasH - rect.y - rect.h) / pr,
+      width: rect.w / pr,
+      height: rect.h / pr
+    };
+    render.right = render.left + render.width;
+    render.bottom = render.top + render.height;
+    // The box the user can actually SEE the picture in: inside the border, below the header.
+    const visible = {
+      left: panelR.left + bw.l,
+      right: panelR.right - bw.r,
+      top: titleR ? titleR.bottom : panelR.top + bw.t,
+      bottom: panelR.bottom - bw.b
+    };
+    visible.width = visible.right - visible.left;
+    visible.height = visible.bottom - visible.top;
+    return {
+      pr, panelR: { left: panelR.left, top: panelR.top, width: panelR.width, height: panelR.height },
+      titleH: titleR ? titleR.height : 0, bw, radius: parseFloat(cs.borderTopLeftRadius) || 0,
+      rect, render, visible,
+      vfCamAspect: cpe._probeVF().vfCamAspect
+    };
+  });
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page } = await openEditor(browser, BLD);
+
+  // B's panel only exists while the eye is on (§CPE_SCRUB_EYE_GATED) — turn it on before measuring.
+  const vfOn = await page.evaluate(() => window.APP.cinemaPathEditor._vfToggle());
+  await sleep(600);
+  const m = await measure(page);
+  if (m.err) {
+    P('G-GRIP-MEASURABLE B\'s panel and scissor rect are readable', false, `vfOn=${vfOn} err=${m.err}`);
+    await page.close();
+    return checks;
+  }
+  const f = n => n.toFixed(2);
+
+  // ── G-GRIP-BLEED — the picture must sit inside the frame, not under it.
+  const over = {
+    l: m.visible.left - m.render.left,        // >0 = render spills left of the visible box
+    r: m.render.right - m.visible.right,
+    t: m.visible.top - m.render.top,
+    b: m.render.bottom - m.visible.bottom
+  };
+  const worst = Math.max(over.l, over.r, over.t, over.b);
+  P('G-GRIP-BLEED the scissor rect lies INSIDE the visible picture box — the border frames the picture, it does not paint over it',
+    worst <= TOL,
+    `overflow px  left=${f(over.l)} right=${f(over.r)} top=${f(over.t)} bottom=${f(over.b)}  worst=${f(worst)} (tol ${TOL}) | ` +
+    `render ${f(m.render.left)},${f(m.render.top)} ${f(m.render.width)}x${f(m.render.height)} vs ` +
+    `visible ${f(m.visible.left)},${f(m.visible.top)} ${f(m.visible.width)}x${f(m.visible.height)} | ` +
+    `panel ${f(m.panelR.width)}x${f(m.panelR.height)} border ${m.bw.t}px pr=${m.pr}`);
+
+  // ── G-GRIP-TITLE — nothing the camera frames may be hidden behind the header.
+  const hidden = Math.max(0, m.visible.top - m.render.top);
+  P('G-GRIP-TITLE no part of the framed image is painted over by the opaque #cpe-vf-title header',
+    hidden <= TOL,
+    `hiddenPx=${f(hidden)} of ${f(m.render.height)} (${f(100 * hidden / m.render.height)}% of the frame) | ` +
+    `titleH=${f(m.titleH)} renderTop=${f(m.render.top)} visibleTop=${f(m.visible.top)}`);
+
+  // ── G-GRIP-ASPECT — the camera must be composing for the box that is actually seen.
+  const visAspect = m.visible.width / m.visible.height;
+  const err = Math.abs(m.vfCamAspect - visAspect) / visAspect;
+  P('G-GRIP-ASPECT vfCam.aspect matches the VISIBLE picture box\'s aspect, not the outer border box\'s',
+    err <= 0.005,
+    `vfCam.aspect=${m.vfCamAspect.toFixed(4)} visibleAspect=${visAspect.toFixed(4)} err=${(err * 100).toFixed(2)}% (tol 0.5%) | ` +
+    `outerAspect=${(m.panelR.width / m.panelR.height).toFixed(4)} rectAspect=${(m.rect.w / m.rect.h).toFixed(4)}`);
+
+  // ── G-GRIP-CORNER — a square picture inside a rounded frame pokes out unless it is inset enough.
+  const needInset = m.radius * (1 - 1 / Math.SQRT2);
+  const gotInset = Math.min(over.l < 0 ? -over.l : 0, over.t < 0 ? -over.t : 0,
+                            over.r < 0 ? -over.r : 0, over.b < 0 ? -over.b : 0);
+  P('G-GRIP-CORNER the square scissor rect is inset enough not to poke through the rounded corners',
+    gotInset + TOL >= needInset,
+    `radius=${f(m.radius)}px needInset=${f(needInset)}px gotInset=${f(gotInset)}px ` +
+    `(max radial poke pre-fix = ${f(Math.max(0, needInset - gotInset))}px per corner)`);
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();

--- a/witness_cpe_work_pacing.js
+++ b/witness_cpe_work_pacing.js
@@ -1,6 +1,18 @@
 // WITNESS — §CPE_BUILDUP_WORK_PACED: the film must advance by WORK, not by calendar.
 // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_WORK_PACED.
 //
+// ⚠ PARTLY RETIRED 2026-08-06 by §CPE_BUILDUP_EVEN_TEMPO (user: "why does the movie baking makes the
+// first few seconds or during the dive in jumps days too fast tempo? Should be even throughout -
+// separation of concern. Let the user plays with the sticks and timings to catch this linear
+// buildup"). Work pacing is OFF by default — `BUILDUP_EVEN_TEMPO` in cinema_maxq.js — so the four
+// gates that asserted its CONTRACT (G-WP-1/2/7/8) now assert the opposite of live behaviour and are
+// retired IN PLACE below, each with the number it last measured, rather than deleted: the decision
+// they encode was real, was the user's, and was reversed on the record. The replacement contract is
+// witness_cpe_buildup_tempo.js (G-TEMPO-EVEN/DIVEIN/LINEAR).
+// The five gates that are ORTHOGONAL to which pacing is in force — monotonicity, determinism,
+// degrade-not-disable, preview==bake, full placement — stay LIVE and still gate the film. Flip
+// BUILDUP_EVEN_TEMPO to false and the retired four go green again unchanged.
+//
 // THE DEFECT THIS PROVES OR DISPROVES (user, after two Hospital buildup bakes: "but construction
 // came on too fast.. is the path and TM consistent?" -> "as long it is consistent as i find this
 // seems to be at random"):
@@ -189,13 +201,19 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       const calDev = res.calendar.map(c => Math.abs(c.placedFrac - c.t));
       const worstWork = Math.max(...workDev), worstCal = Math.max(...calDev);
 
-      P('G-WP-1 k% of the film is k% of the building',
-        worstWork <= TOL,
+      // RETIRED (§CPE_BUILDUP_EVEN_TEMPO) — "k% of the film is k% of the building" IS work pacing;
+      // asserting it would re-assert the behaviour the user asked to be removed. Last measured
+      // live: worst deviation 5.48pp against a 3pp tolerance, i.e. the calendar-paced reality.
+      P('G-WP-1 [RETIRED §CPE_BUILDUP_EVEN_TEMPO] k% of the film is k% of the building — work pacing is off by default; witness_cpe_buildup_tempo.js gates the live contract',
+        true,
         res.work.map((w, i) => `t=${w.t}→placed ${(w.placedFrac * 100).toFixed(1)}%`).join('  ') +
         `   worst deviation ${(worstWork * 100).toFixed(2)}pp (tol ${TOL * 100}pp)`);
 
-      P('G-WP-2 calendar pacing is measurably worse on this model (the RED this replaces)',
-        worstCal > worstWork,
+      // RETIRED with G-WP-1 — this was its RED control (calendar must be worse than work-paced).
+      // With even tempo in force both branches ARE calendar, so the two deviations are now equal by
+      // construction (5.48pp vs 5.48pp measured), which is the correct new state, not a failure.
+      P('G-WP-2 [RETIRED §CPE_BUILDUP_EVEN_TEMPO] calendar pacing is measurably worse on this model (the RED G-WP-1 replaced)',
+        true,
         res.calendar.map(c => `t=${c.t}→placed ${(c.placedFrac * 100).toFixed(1)}%`).join('  ') +
         `   worst ${(worstCal * 100).toFixed(2)}pp vs work-paced ${(worstWork * 100).toFixed(2)}pp`);
 
@@ -215,8 +233,11 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
 
       const line = logs.filter(l => /§CPE_BUILDUP_PACING/.test(l)).slice(-1)[0] || '';
       const sch = logs.filter(l => /§CPE_WORK_SCHEDULE/.test(l)).slice(-1)[0] || '';
-      P('G-WP-7 the log states the pacing mode and how front-loaded the model is',
-        /mode=work/.test(line) && /workInFirst10%OfCalendar/.test(sch),
+      // AMENDED, not retired: the log must still NAME the pacing in force — that requirement never
+      // depended on WHICH pacing it is. Now expects mode=even-calendar (§CPE_BUILDUP_EVEN_TEMPO);
+      // mode=work is still accepted so this gate keeps working with BUILDUP_EVEN_TEMPO flipped off.
+      P('G-WP-7 the log states the pacing mode in force',
+        /mode=even-calendar|mode=work/.test(line),
         `${line || 'no §CPE_BUILDUP_PACING'}\n        ${sch || 'no §CPE_WORK_SCHEDULE'}`);
 
       // G-WP-8/9 — real per-frame FILM reveal rate (2026-08-03 "fast start, slow middle" report).
@@ -224,8 +245,13 @@ const FRACS = [0.10, 0.25, 0.50, 0.75];
       // that it is frame-perfect — a model with real duration ties will always have some jitter.
       const RATE_TOL = 0.25;
       const cpLine = res.checkpoints.map(c => `t=${c.t}→${c.placed} (${c.ratePerFrame}/frame)`).join('  ');
-      P('G-WP-8 the per-frame reveal rate stays even across the pre-topout film (no burst/plateau)',
-        res.maxRateDeviationFrac <= RATE_TOL,
+      // RETIRED (§CPE_BUILDUP_EVEN_TEMPO) — an even ELEMENT-per-frame rate and an even DAY-per-frame
+      // rate cannot both hold unless the schedule spreads elements uniformly in time. The user chose
+      // even DAYS. So elements now arrive as the real schedule delivers them (last measured: 81.0%
+      // worst deviation against a 25% tolerance), and dwelling on a busy phase is the path editor's
+      // job via sticks + timings. The evenness that IS still gated: witness_cpe_buildup_tempo.js.
+      P('G-WP-8 [RETIRED §CPE_BUILDUP_EVEN_TEMPO] the per-frame ELEMENT reveal rate stays even — superseded by even CALENDAR rate',
+        true,
         `topoutU=${res.topoutU.toFixed(3)} meanRate=${res.meanRatePerFrame}/frame ` +
         `worstDeviation=${(res.maxRateDeviationFrac * 100).toFixed(1)}% (tol ${RATE_TOL * 100}%)\n        ` +
         `checkpoints: ${cpLine}\n        ` +


### PR DESCRIPTION
Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md`, 2026-08-06 pickup session.

## §CPE_VF_GRIP — the POV frame did not hold its picture

User: *"The pov original frame size has always been wrong. Now it tries to redraw its borders rather flimsy and not aware of the bit larger inset screen. I think this has to be look at holistically why it is not gripping."*

`_vfComputeRect` derived the scissor rect from `panel.getBoundingClientRect()` — the **outer border box**. So the render covered three things it does not own: the 1px border ring (frame painted *on* the picture, not around it), the 22px opaque `#cpe-vf-title` header (**23px = 12.11% of the framed image, painted over and never seen**), and it poked **3.51px** through each `border-radius:12px` corner. `vfCam.aspect` followed the same outer box (**1.5789**) while the visible picture is **1.7952** — **12.05% out**, composing for a box 24px taller than exists.

⚠ This is **not** the deferred §CPE_VF_PLAIN_FRAME root cause (B sharing the main renderer's full-canvas post pass, needing its own `WebGLRenderer`). That one is how the picture is **shaded**; this is **where it lands**. The two were conflated for several sessions. The WebGLRenderer work remains deferred and untouched.

**Fix:** `_vfPanelInset()` reads real computed border widths + the header's `offsetHeight`; `_vfComputeRect` computes the **content box**; radius 12px → 0 (the panel is a transparent hole punched over the main canvas — an inset dodging the corner arc would show the *main scene* through the gap, not a mat, so square is the only shape that grips exactly; one-line revert if rounded is wanted back).

| | pre-fix | post-fix |
|---|---|---|
| bleed (l/r/t/b px) | 1.00 / 1.00 / **23.00** / 1.00 | **0.00 / 0.00 / 0.00 / 0.00** |
| hidden by header | 23.00px = **12.11%** | 0.00px |
| vfCam vs visible aspect | 1.5789 vs 1.7952 (**12.05% out**) | err **0.00%** |
| corner poke | 3.51px | 0.00px |

`witness_cpe_vf_grip.js` (**new**) 0/4 → **4/4**. `witness_cpe_scrub_viewfinder.js` **33/33** — `G-VF-ASPECT` had been reading the *outer* box and so sat green through the entire 12% error; it now reads the content box.

## §CPE_BUILDUP_EVEN_TEMPO — the days sprint during the dive-in

User: *"why does the movie baking makes the first few seconds or during the dive in jumps days too fast tempo? Should be even throughout - separation of concern. Let the user plays with the sticks and timings to catch this linear buildup."*

**Why:** §CPE_BUILDUP_WORK_PACED working exactly as written — film fraction maps to the k-th **element placed**, and an even element rate is an uneven **day** rate by construction. Measured on Duplex: per-step calendar advance **0.01d → 0.29d, a 57.21× swing**, cursor **9.47%** off the straight line.

**Fix:** `BUILDUP_EVEN_TEMPO = true`; `_workCursorAt` returns `projectStart + t*span`. Work pacing kept intact behind the flag, not deleted.

⚠ **Reverses a prior user decision and trades back into the burst work pacing was added to fix** — made deliberately on the user's stated grounds: the buildup engine does one predictable thing (linear days), dramatic pacing belongs to the path editor's sticks and timings.

`witness_cpe_buildup_tempo.js` (**new**) 1/3 → **3/3** — ratio **1.00×**, first 10% of film = **10.00%** of calendar, deviation **0.00%**.

## A regression this change introduced — caught, and fixed at the source

Leaving `_ghostGroundArm`'s threshold in the **elements** domain while the cursor moved to **calendar** reintroduced #1148 from the other direction: `firstT=0.0027` against a real crossing at `t=0.0083`, so the ground began un-ghosting ~2 frames of 400 *before* the first above-ground element was placed. `witness_cpe_ghost_ground.js` went 15/15 → 13/15. **Confirmed a genuine regression by re-running against stashed pre-fix code (baseline 15/15), not assumed.** Fixed by gating the elements branch on the flag → back to **15/15**, `cursorConfirms` **0 → 1**.

## Superseded gates retired in place

Never deleted, never silently flipped — each keeps the number it last measured, because the decision it encodes was real, was the user's, and was reversed on the record. `G-WP-1/2/8` and `G-GG-12c` (premises that hold only under work pacing) retired; `G-WP-7` amended to accept either mode; `G-WP-3/4/5/6/9` and `G-GG-12a` stay **live** — orthogonal to which pacing is in force, and `G-GG-12a` is what caught the regression above. `witness_cpe_work_pacing.js` **9/9**.

## Not verified

`witness_cpe_buildup_schedule.js` cannot run locally — its first building `TerminalHi4D` is a 74-byte LFS pointer, so it times out at page load. Pre-existing environment limitation, **not** a regression from this change; no gate in it executed. Every witness above ran on Duplex for the same reason — no LFS blobs pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoQuFDehHBzRUjo3TrVczk