### PR TITLE
fix(cpe): the grab zone is the DRAWN handle, not a fixed 18px (§CPE_GRAB_WYSIWYG)

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -2461,13 +2461,49 @@
   }
   // Screen-space proximity, not a mesh raycast: the handles draw with depthTest:false so they are
   // clickable through walls, and a depth-sorted raycast would disagree with what is actually visible.
+  //
+  // ══ §CPE_GRAB_WYSIWYG (2026-08-06) — the grab zone is the DRAWN sphere, never smaller than
+  // GRAB_PX. Implementing CINEMA_PATH_EDITOR.md's own §CPE_STICK_ANCHOR doctrine ("what you grab is
+  // what you see") — Witness: witness_cpe_stick_after_preview.js.
+  //
+  // THE DEFECT: GRAB_PX alone is a FIXED 18px around the handle's CENTRE, while the sphere itself
+  // renders HANDLE_R x drawScale METRES — a screen size that grows as the camera closes in. At real
+  // editing range (user's own §PICK d=11.89 proves ~12m; measured 57.7 px/m there) a HELD handle
+  // paints 21px of radius, 37px at the selection pulse's 1.8x peak — so MOST of the visible blob
+  // was a dead zone. A click landing 19-37px off-centre — ON the sphere the user sees — returned
+  // no handle, fell through h.down unclaimed, and the viewer's model picker consumed the gesture
+  // (§PICK/§BATCHED_PICK/§FOCUS_ELEM stealing the drag; §CPE_AIM_PIN used to swallow these near
+  // misses until #1228 disabled it, which is what made the fall-through visible). The sequence
+  // "drag works, preview, drag falls to the picker" is this: the FIRST grab is on an unheld
+  // 15.6px blob (≈ inside GRAB_PX), the drag leaves the band HELD+pulsing (up to 2.4x bigger on
+  // screen, same 18px zone), and the next grab attempt — after the rehearsal, in the user's
+  // workflow — aims at blob pixels that were never grabbable. Far away nothing changes: the
+  // projected radius shrinks below 18px and GRAB_PX stays the floor.
+  function _handleGrabPx(h) {
+    var a = A(), r = a.canvas.getBoundingClientRect();
+    var D = Math.hypot(h.p.x - a.camera.position.x, h.p.y - a.camera.position.y, h.p.z - a.camera.position.z);
+    if (!(D > 1e-3)) return GRAB_PX;
+    var pxPerM = r.height / (2 * D * Math.tan(a.camera.fov * Math.PI / 360));
+    // The mesh's own geometry radius IS the drawn radius (HANDLE_R x the draw scale _redrawScene
+    // chose — held/mid/end differ), read back rather than re-derived so draw and grab cannot drift.
+    var geoR = (h.mesh && h.mesh.geometry && h.mesh.geometry.parameters &&
+                isFinite(h.mesh.geometry.parameters.radius)) ? h.mesh.geometry.parameters.radius : HANDLE_R;
+    // The held handle BREATHES (mesh.scale 1..1.8 at PULSE_HZ, see _pulse). The user aims at the
+    // breathing blob as a whole, so its OUTER envelope is the honest target — and a constant, so
+    // the zone never depends on which pulse phase a pointerdown happens to sample.
+    var held = _state.held && _state.held.b === h.b && _state.held.z === h.z;
+    return Math.max(GRAB_PX, geoR * (held ? 1.8 : 1) * pxPerM + 2);
+  }
   function _hitTest(ev) {
-    var best = null, bestD = GRAB_PX;
+    // Nearness is scored relative to each handle's OWN grab radius (score < 1 = inside it), so a
+    // big near blob cannot shadow a small far one that the cursor is actually inside.
+    var best = null, bestScore = 1;
     for (var i = 0; i < _state.handles.length; i++) {
       var h = _state.handles[i], s = _screenOf(h.p);
       if (s.behind) continue;
       var d = Math.hypot(ev.clientX - s.x, ev.clientY - s.y);
-      if (d < bestD) { bestD = d; best = h; }
+      var score = d / _handleGrabPx(h);
+      if (score < bestScore) { bestScore = score; best = h; }
     }
     return best;
   }

--- a/witness_cpe_stick_after_preview.js
+++ b/witness_cpe_stick_after_preview.js
@@ -1,0 +1,167 @@
+// WITNESS — §CPE_GRAB_WYSIWYG: after a real preview, a click ON the drawn handle still grabs it.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_STICK_ANCHOR ("what you grab is what you
+// see") — dispatched 2026-08-06 as "stick drag dead after preview, click falls through to the
+// model picker".
+//
+// THE DEFECT (user, big building, 2026-08-06): before a preview, a canvas click on a band handle
+// logs `§CPE_DRAG_SCALE grab band=0 zone=mid`; after `§CPE_PREVIEW done ... buildup=1` the SAME
+// gesture on the SAME handle logs `§PICK hits=71 ...` + `§BATCHED_PICK ...` + `§FOCUS_ELEM` — the
+// viewer's model picker consumed it, no §CPE line at all. Root cause measured, not guessed:
+// `_hitTest`'s tolerance was a FIXED `GRAB_PX` (18px) around the handle CENTRE while the drawn
+// sphere is HANDLE_R x drawScale METRES — at the user's real editing range (their own §PICK
+// d=11.89 proves ~12m; 57.7 px/m there) a HELD handle renders 21px of radius, 37px at the
+// selection pulse's 1.8x peak, so MOST of the visible blob was a dead zone. The first drag of a
+// session grabs an UNHELD 15.6px blob (fits inside 18px) and leaves the band HELD+pulsing; the
+// next grab — after the rehearsal, in the user's edit→preview→edit loop — aims at blob pixels
+// that were never grabbable and falls through to the picker.
+//
+//   G-SAP-0  (sanity, both worlds) centre-click on the unheld handle grabs — proves the wiring
+//            and this harness, and puts the band in the HELD state the defect needs.
+//   G-SAP-1  (THE gate) after a REAL preview (`#cpe-preview` click → §CPE_PREVIEW done), a tap
+//            landing ON the drawn held blob but outside the legacy 18px zone produces
+//            `§CPE_DRAG_SCALE grab`. FAILS on unfixed main (no §CPE line), PASSES with
+//            §CPE_GRAB_WYSIWYG.
+//   G-SAP-2  the same tap must be CLAIMED from the picker: `§PICK_GUARD blocked` must appear for
+//            it (CPE stopPropagation'd the pointerdown, so picking.js never saw it) and no
+//            `§PICK hits=` may fire in that window. FAILS on unfixed main — this is literally the
+//            user's console shape.
+//   G-SAP-3  far-pose behaviour unchanged: at the handle's projected radius << 18px, the grab
+//            tolerance the fix computes stays exactly GRAB_PX (asserted via the same maths on the
+//            live camera state), so nothing loosens for normal outside-the-building editing.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8491;
+const BLD = process.env.BLD || 'Duplex';
+const GRAB_PX = 18, HELD_SCALE = 1.2, PULSE_MAX = 1.8, HANDLE_R = 0.30;
+const CAM_DIST = 12;   // the user's own close-in editing range (§PICK d=11.89 in their log)
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const checks = [];
+  let allPass = true;
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
+
+  const page = await browser.newPage();
+  // Service-worker landmine: without the bypass this witness can run a PREVIOUS build's JS.
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  await cdp.send('Network.setBypassServiceWorker', { bypass: true });
+  await page.setViewport({ width: 1280, height: 800 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit
+    && window.APP._composer, { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1 }); });
+  await page.waitForSelector('#cpe-rows', { timeout: 120000 });
+  await sleep(800);
+
+  // ── G-SAP-3 first, from the UNTOUCHED far open pose: the projected blob is tiny, the effective
+  //    zone must still be exactly GRAB_PX (the floor). Same formula the fix uses, on live state.
+  const far = await page.evaluate((HANDLE_R) => {
+    const A = window.APP, hs = A.cinemaPathEditor._probeHandles();
+    const m = hs.find(h => h.b === 0 && h.z === 'mid');
+    const D = Math.hypot(m.x - A.camera.position.x, m.y - A.camera.position.y, m.z3 - A.camera.position.z);
+    const r = A.canvas.getBoundingClientRect();
+    const pxPerM = r.height / (2 * D * Math.tan(A.camera.fov * Math.PI / 360));
+    return { D, blobPx: HANDLE_R * 0.9 * pxPerM };
+  }, HANDLE_R);
+  P('G-SAP-3 far pose: projected blob << 18px, so the zone stays the GRAB_PX floor (nothing loosens)',
+    far.blobPx < GRAB_PX,
+    `open pose D=${far.D.toFixed(1)}m, unheld blob radius ${far.blobPx.toFixed(1)}px vs GRAB_PX=${GRAB_PX} ` +
+    `-> max(GRAB_PX, blob) == GRAB_PX`);
+
+  // ── Move the camera to the user's real editing range: 12m from band 0's mid handle.
+  await page.evaluate((CAM_DIST) => {
+    const A = window.APP, hs = A.cinemaPathEditor._probeHandles();
+    const m = hs.find(h => h.b === 0 && h.z === 'mid');
+    const p = new THREE.Vector3(m.x, m.y, m.z3);
+    const dir = new THREE.Vector3().subVectors(A.camera.position, p).normalize();
+    A.camera.position.copy(p.clone().add(dir.multiplyScalar(CAM_DIST)));
+    A.controls.target.copy(p);
+    A.controls.update();
+    if (A.markDirty) A.markDirty();
+  }, CAM_DIST);
+  await sleep(600);
+
+  const probe = () => page.evaluate(() => {
+    const A = window.APP, hs = A.cinemaPathEditor._probeHandles();
+    const m = hs.find(h => h.b === 0 && h.z === 'mid');
+    const D = Math.hypot(m.x - A.camera.position.x, m.y - A.camera.position.y, m.z3 - A.camera.position.z);
+    const r = A.canvas.getBoundingClientRect();
+    return { px: m.px, py: m.py, D, pxPerM: r.height / (2 * D * Math.tan(A.camera.fov * Math.PI / 360)) };
+  });
+
+  // A TAP (2px of travel — under picking.js's own 5px tap-vs-drag test, so an unclaimed tap PICKS,
+  // exactly the user's gesture), through the browser's real input pipeline.
+  async function tap(x, y) {
+    const n0 = logs.length;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 2, y + 1);
+    await page.mouse.up();
+    await sleep(400);
+    return logs.slice(n0);
+  }
+
+  // ── G-SAP-0: centre tap on the UNHELD handle — grabs, and leaves band 0 HELD (pulse on).
+  let m = await probe();
+  let seg = await tap(m.px, m.py);
+  P('G-SAP-0 sanity: centre tap on the unheld handle grabs (and holds band 0)',
+    seg.some(l => /§CPE_DRAG_SCALE grab band=0/.test(l)),
+    `tap at centre (${m.px},${m.py}) D=${m.D.toFixed(1)}m -> ` +
+    (seg.find(l => /§CPE_DRAG_SCALE grab/.test(l)) || 'NO GRAB LINE').slice(0, 90));
+
+  // ── The REAL preview, via the real button, to §CPE_PREVIEW done.
+  const nPrev = logs.length;
+  await page.evaluate(() => document.getElementById('cpe-preview').click());
+  const t0 = Date.now();
+  while (Date.now() - t0 < 90000) {
+    if (logs.slice(nPrev).some(l => /§CPE_PREVIEW done/.test(l))) break;
+    await sleep(500);
+  }
+  const prevDone = logs.slice(nPrev).find(l => /§CPE_PREVIEW done/.test(l));
+  P('PRECOND a real preview ran to completion', !!prevDone, prevDone || 'NO §CPE_PREVIEW done within 90s');
+  await sleep(800);
+
+  // ── G-SAP-1/2: tap ON the drawn held blob, outside the legacy 18px zone.
+  m = await probe();
+  const heldBlobPx = HANDLE_R * HELD_SCALE * PULSE_MAX * m.pxPerM;   // the breathing blob's outer envelope
+  const offset = Math.round(Math.min(heldBlobPx - 4, GRAB_PX + 10)); // on the blob, past the old zone
+  P('PRECOND the drawn held blob extends past the legacy zone (the gesture is ON the visible sphere)',
+    heldBlobPx > offset && offset > GRAB_PX,
+    `held blob radius ${heldBlobPx.toFixed(1)}px (pulse peak) at D=${m.D.toFixed(1)}m ` +
+    `(${m.pxPerM.toFixed(1)} px/m), tap offset ${offset}px, legacy GRAB_PX=${GRAB_PX}`);
+
+  seg = await tap(m.px + offset, m.py);
+  const grabbed = seg.some(l => /§CPE_DRAG_SCALE grab band=0/.test(l));
+  const picked = seg.some(l => /§PICK hits=|§BATCHED_PICK/.test(l));
+  const guarded = seg.some(l => /§PICK_GUARD blocked/.test(l));
+  P('G-SAP-1 after the preview, a tap ON the drawn handle still grabs it',
+    grabbed,
+    `tap at (${m.px + offset},${m.py}) — ${offset}px off-centre, on the blob -> ` +
+    (seg.find(l => /§CPE_DRAG_SCALE grab/.test(l)) || 'NO GRAB LINE — gesture fell through').slice(0, 90));
+  P('G-SAP-2 that tap is CLAIMED from the model picker (guard blocked, no §PICK)',
+    guarded && !picked,
+    `§PICK_GUARD blocked=${guarded} §PICK/§BATCHED_PICK fired=${picked}` +
+    (picked ? ' — the picker consumed the gesture, the user\'s exact console shape' : ''));
+
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+  console.log(`${checks.filter(c => c.ok).length}/${checks.length} gates`);
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md` §CPE_GRAB_WYSIWYG.

User, repeatedly: *"i lost grip of the stick again"* / *"if i am to grip it after preview"*.

## The preview was sequencing, NOT the mechanism — disproven, not assumed

Earlier sessions (and I) read "after preview" as the trigger from log correlation. It is not. An identical 25px-off-centre miss reproduces **before and after** a preview, and 7 preview/scrub/pause/viewfinder scenarios plus an authored-reopen run all left `_wire`/`_unwire`, `_state.handles`, the bands, the camera and the canvas fully intact.

## Root cause: you could not grab the handle you were looking at

`_hitTest` accepted a click only within a **fixed `GRAB_PX=18px` of the handle's centre**, while the sphere **draws** at `HANDLE_R=0.30m × drawScale` in *world metres* — a screen size that grows as the camera closes in. At real editing range (the user's own `§PICK d=11.89` proves ~12m; 57.7 px/m there):

| handle state | drawn radius | grabbable |
|---|---|---|
| unheld mid | 15.6px | 18px — just inside |
| **held** | 21px | 18px |
| **held, at pulse peak** | **37px** | 18px |

Most of the visible blob was a dead zone. A click 19–37px off-centre — *on the sphere the user can see* — returned no handle, `h.down` never claimed the gesture, and the viewer's model picker consumed it: `§PICK` / `§BATCHED_PICK` / `§FOCUS_ELEM`, exactly the user's console shape. #1228 disabling the `§CPE_AIM_PIN` near-miss catcher did not cause this — it removed what had been swallowing the near-misses, which is why it became *visible* then.

The "works, then stops after a preview" sequence: the **first** grab lands on the small **unheld** blob (≈ inside 18px) and works; that drag leaves the band **held + pulsing** (up to 2.4× bigger on screen, same 18px zone); the next attempt aims at pixels that were never grabbable.

## Fix (+38/−2)

`_handleGrabPx(h)` — per-handle tolerance `max(GRAB_PX, drawnRadius × pxPerM + 2)`, with the drawn radius **read back from the mesh's own geometry** so drawing and grabbing cannot drift apart, × 1.8 for the pulse envelope when held (a constant, so the zone never depends on which pulse phase a `pointerdown` happens to sample). `_hitTest` now scores `distance / ownGrabPx` (< 1 = inside) so a big near blob cannot shadow a small far one.

**Nothing loosens for normal editing:** far from the model the projected radius falls below 18px and `GRAB_PX` remains the floor.

## Witness

`witness_cpe_stick_after_preview.js` — Duplex, real preview via `#cpe-preview`, real pointer taps, service worker bypassed, `§`-log/state assertions only (no screenshots).

- **unmodified `origin/main`: 4/6 FAIL (exit 1)** — `G-SAP-1 NO GRAB LINE — gesture fell through`; `G-SAP-2 §PICK_GUARD blocked=false, §PICK/§BATCHED_PICK fired=true`
- **with fix: 6/6 PASS (exit 0)** — the same 28px-off-centre tap on a 37.4px blob grabs (`§CPE_DRAG_SCALE grab band=0 zone=mid`), `§PICK_GUARD blocked`, no `§PICK`. `G-SAP-3` confirms the far-pose zone is still exactly 18px.

No regressions: `witness_cpe_drag.js` 4/4, `witness_cpe_click_slop.js` 6/6.

## Side-finding — NOT fixed here, needs its own change

`#cpe-preview` is wired as `addEventListener('click', _previewFly)` (`:3019`), so the MouseEvent lands in the `povOnly` parameter — truthy. **The main Preview button has flown B only since #1197**, never moving or restoring the main camera, while the done-log still prints "camera restored to the editing pose". Confirmed live: `§CPE_PREVIEW click … povOnly=1` from the button in every run. #1197's comment claims "#cpe-preview's own wiring calls this with no argument — unaffected", which is not what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoQuFDehHBzRUjo3TrVczk