### PR TITLE
fix(4d): §GANTT_SINGLE_LOAD — cold Time Machine open no longer runs injectGantt twice

### DIFF
--- a/tests/witness_gantt_single_load.js
+++ b/tests/witness_gantt_single_load.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/* ⚠ WITNESS — proves/disproves §GANTT_DOUBLE_LOAD (4D_SCHEDULE_PERFECTION.md, 2026-08-07): "clicking
+ * the Gantt/TM icon on a cold open runs injectGantt() TWICE — pass 1 placeholder-dated + task_id-less,
+ * auto-materialize discards it via tmRefoldSchedule(), pass 2 refolds the whole chain."
+ *
+ * §-log capture only (headless, fresh profile = true cold open: no SW, no IDB gantt cache, no
+ * authored schedule row). PASS iff, for ONE TM activation:
+ *   - §GANTT_PREMATERIALIZE fires (the fix: schedule materialized before first injectGantt)
+ *   - the expensive chain runs ONCE: §SUPPORT_CHECK ×1, §GANTT injected ×1, §XRAY_EDGES ×1
+ *   - the double-load signature is ABSENT: §GANTT_AUTO_GENERATE ×0, §TM_REFOLD ×0
+ *   - bars are editable on first draw: §GANTT_BAR_IDENTITY editable>0 (ops carry real task_ids)
+ *
+ * URL: set WITNESS_URL, else localhost:8484 (a server rooted at the repo/worktree under test).
+ */
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const URL = process.env.WITNESS_URL ||
+  'http://localhost:8484/viewer/viewer.html?db=https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/buildings/Hospital_extracted.db&ghost=1';
+(async () => {
+  const browser = await chromium.launch({ executablePath: '/usr/bin/google-chrome', headless: true,
+    args: ['--no-sandbox', '--disable-gpu'] });
+  const page = await (await browser.newContext()).newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text();
+    if (/§GANTT_PREMATERIALIZE|§SUPPORT_CHECK|§GANTT injected|§XRAY_EDGES|§GANTT_AUTO_GENERATE|§TM_REFOLD|§GANTT_BAR_IDENTITY|§TIME_MACHINE (ON|OFF)/.test(t)) {
+      lines.push(t); console.log('[console]', t); } });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.db && window.toggleTimeMachine, null, { timeout: 180000 });
+  await page.evaluate(() => window.toggleTimeMachine());
+  await page.waitForFunction(() => { try { return window.tmGetState && window.tmGetState().active; } catch (e) { return false; } }, null, { timeout: 300000 });
+  // The user's second step: press the Gantt chart icon (opens the drawer → drawGanttMini → the
+  // §GANTT_EDIT_LOCK auto-generate branch that used to fire the refold double-load).
+  await page.evaluate(() => document.getElementById('tm-gantt').dispatchEvent(new PointerEvent('pointerup', { bubbles: true })));
+  await page.waitForTimeout(8000);   // window in which the OLD code fired auto-generate + refold
+  const n = re => lines.filter(l => re.test(l)).length;
+  const pre = n(/§GANTT_PREMATERIALIZE native schedule written/);
+  const support = n(/§SUPPORT_CHECK/), injected = n(/§GANTT injected/), xray = n(/§XRAY_EDGES/);
+  const autogen = n(/§GANTT_AUTO_GENERATE/), refold = n(/§TM_REFOLD/);
+  const barLine = lines.find(l => /§GANTT_BAR_IDENTITY.*editable=/.test(l)) || '';
+  const editable = +(barLine.match(/editable=(\d+)/) || [0, 0])[1];
+  console.log(`§GANTT_SINGLE_LOAD_CHECK prematerialize=${pre} support=${support} injected=${injected} xray=${xray} autogen=${autogen} refold=${refold} editableBars=${editable}`);
+  const pass = pre === 1 && support === 1 && injected === 1 && xray === 1 && autogen === 0 && refold === 0 && editable > 0;
+  console.log(pass ? 'PASS — cold TM open is single-pass: schedule materialized first, no auto-generate refold, bars editable'
+                   : 'FAIL — double-load signature still present (or bars not editable), see counts');
+  await browser.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5455,6 +5455,27 @@
   // called automatically by drawGanttMini when the drawer has nothing editable to show, no button,
   // no side panel involved at all any more. Calls the real engine verb directly, same as the panel's
   // own generateDraft() zone-detail path (schedule_author_ui.js), not a reimplementation of it.
+  // §GANTT_SINGLE_LOAD (2026-08-07, 4D_SCHEDULE_PERFECTION.md §GANTT_DOUBLE_LOAD) — the materialize
+  // core, callable BEFORE activation: no UI tip, no refold. Returns true iff a fresh native schedule
+  // was written. Scoped to the truly-cold case only (NO schedule row at all) — an existing schedule,
+  // authored or captured, is left for injectGantt to absorb as-is; generateGanttSchedule() below keeps
+  // its own wider semantics (regenerates over a non-captured schedule) for the drawer's auto-gen
+  // fallback. Same materializeZones call/opts as generateGanttSchedule — keep them in sync.
+  function _materializeNativeSchedule(app) {
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    if (!app || !app.db || !SA || !SA.materializeZones) return false;
+    var act = SA.activeSchedule ? SA.activeSchedule(app.db) : null;
+    if (act) return false;                       // schedule exists — injectGantt absorbs it, one pass
+    var todayStart = new Date().toISOString().slice(0, 10);
+    var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
+    if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false });
+    console.log('§GANTT_PREMATERIALIZE ' + (res.ok
+      ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
+      : 'failed reason=' + (res.reason || 'unknown') + ' — legacy auto-generate fallback will handle it'));
+    return !!res.ok;
+  }
+
   function generateGanttSchedule() {
     var app = A();
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
@@ -6542,6 +6563,14 @@
       if (!_placeOps.length) {
         if (st) st.textContent = 'Setting up 4D construction timeline...';
         viewerStatus('Time Machine: generating construction schedule...');
+        // §GANTT_SINGLE_LOAD (4D_SCHEDULE_PERFECTION.md §GANTT_DOUBLE_LOAD): a cold open used to run
+        // injectGantt TWICE — pass 1 with no schedule (placeholder dates, task_id-less ops), then
+        // drawGanttMini's §GANTT_EDIT_LOCK auto-materialize called tmRefoldSchedule(), which threw
+        // pass 1 away (deactivate + cacheDel + re-activate) and ran the ENTIRE chain again. Now the
+        // native schedule is materialized FIRST, so the single injectGantt run absorbs it, bars carry
+        // real task_ids, and the auto-generate branch never fires. refoldSchedule() itself is
+        // untouched — its external-edit caller (4D_SCHED_EDIT in main.js) still needs the round-trip.
+        _materializeNativeSchedule(app);
         if (!injectGantt()) {
           if (st) st.textContent = 'No elements found in database';
           viewerStatus('Time Machine: no elements found');
@@ -6563,7 +6592,7 @@
       console.warn('§GANTT_CACHE_ERR ' + e.message);
       // Fallback: compute without cache
       _ops = loadOps(); _ganttDirty = true;
-      if (!_ops.length) { injectGantt(); _ops = loadOps(); _ganttDirty = true; }
+      if (!_ops.length) { _materializeNativeSchedule(A()); injectGantt(); _ops = loadOps(); _ganttDirty = true; }  // §GANTT_SINGLE_LOAD, same as the main path
       if (_ops.length) { _finishActivate(app); resolve(true); }
       else resolve(false);
     });


### PR DESCRIPTION
Fixes 4D_SCHEDULE_PERFECTION.md §GANTT_DOUBLE_LOAD (user-reported: double load on init and on Gantt icon press).

Cold open used to run the full injectGantt chain twice: pass 1 with placeholder dates and no task_ids, then the drawer's auto-materialize discarded it via tmRefoldSchedule() and re-ran everything. Now the native schedule is materialized first, so one pass absorbs it — bars editable immediately, project starts today.

Witness: tests/witness_gantt_single_load.js — §GANTT_PREMATERIALIZE=1, expensive chain ×1, §GANTT_AUTO_GENERATE=0, §TM_REFOLD=0, editable=35/35 on Hospital (63,415 elements), including the Gantt-icon press step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5rYmahmKaQbUsS5rfSset