### PR TITLE
fix(4d): §4D_LAYER_TRUTH — task-window layer preserves schedule-layer truth (staged 284→0)

### DIFF
--- a/tests/witness_4d_layer_truth.js
+++ b/tests/witness_4d_layer_truth.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/* ⚠ WITNESS — proves/disproves §4D_LAYER_TRUTH (4D_SCHEDULE_PERFECTION.md, 2026-08-07, user report:
+ * "walls coming up before the foundation slabs all around... the 2 trucks still came out on day 1"):
+ * the task-window playback layer DISCARDED the schedule layer's element times (even index-stagger)
+ * and geometry-less elements (no transform row → z=0) dragged zone windows to day 0.
+ *
+ * Witnessed pre-fix numbers, from the user's own console (Hospital, cold open):
+ *   §XRAY_EDGES staged=284/63415 on the task-window pass  (generative pass: staged=0)
+ *   §GANTT band 0 z=[0.0,0.0] 233 elements: Architecture:233   (the day-0 wall population)
+ *
+ * PASS iff on a cold Hospital open (fresh profile, single-load path):
+ *   - §XRAY_EDGES staged=0  (support carrier never finishes after its element's reveal)
+ *   - §4D_NOGEO parked>0    (geometry-less elements parked at project end, not day 0)
+ *   - §SUPPORT_CHECK floating=0 (engine invariant intact)
+ *   - §GANTT_OPS_FIRST20 has no Wall and no undefined entry (day-1 ops are substructure)
+ */
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const URL = process.env.WITNESS_URL ||
+  'http://localhost:8484/viewer/viewer.html?db=https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/buildings/Hospital_extracted.db&ghost=1';
+(async () => {
+  const browser = await chromium.launch({ executablePath: '/usr/bin/google-chrome', headless: true,
+    args: ['--no-sandbox', '--disable-gpu'] });
+  const page = await (await browser.newContext()).newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text();
+    if (/§XRAY_EDGES|§4D_NOGEO|§SUPPORT_CHECK|§GANTT_OPS_FIRST20|§GANTT_PREMATERIALIZE|§TM_REFOLD|§GANTT band 0 /.test(t)) {
+      lines.push(t); console.log('[console]', t.slice(0, 220)); } });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.db && window.toggleTimeMachine, null, { timeout: 180000 });
+  await page.evaluate(() => window.toggleTimeMachine());
+  await page.waitForFunction(() => { try { return window.tmGetState && window.tmGetState().active; } catch (e) { return false; } }, null, { timeout: 300000 });
+  await page.evaluate(() => document.getElementById('tm-gantt').dispatchEvent(new PointerEvent('pointerup', { bubbles: true })));
+  await page.waitForTimeout(8000);
+  const grab = re => { const l = lines.find(x => re.test(x)) || ''; return l; };
+  const staged = +(grab(/§XRAY_EDGES/).match(/staged=(\d+)/) || [0, -1])[1];
+  const parked = +(grab(/§4D_NOGEO/).match(/parked=(\d+)/) || [0, 0])[1];
+  const floating = +(grab(/§SUPPORT_CHECK/).match(/floating=(\d+)/) || [0, -1])[1];
+  const first20 = grab(/§GANTT_OPS_FIRST20/);
+  const first20Clean = first20 !== '' && !/Wall|undefined/.test(first20.replace('§GANTT_OPS_FIRST20', ''));
+  const refolds = lines.filter(l => /§TM_REFOLD/.test(l)).length;
+  console.log(`§4D_LAYER_TRUTH_CHECK staged=${staged} (was 284) noGeoParked=${parked} floating=${floating} first20Clean=${first20Clean} refolds=${refolds}`);
+  const pass = staged === 0 && parked > 0 && floating === 0 && first20Clean && refolds === 0;
+  console.log(pass ? 'PASS — schedule-layer truth survives the task-window layer; no day-0 geometry-less pollution'
+                   : 'FAIL — see counts (staged>0 = window layer still re-times against the schedule layer)');
+  await browser.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -313,9 +313,14 @@
         base_z: cz - bz / 2, top_z: cz + bz / 2,
         x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,
         seq: rule.sequence, phase: rule.phase, resource: rule.resource || '_DEFAULT',
-        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio)
+        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio),
+        // §4D_NOGEO (2026-08-07, mirrors time_machine.js's own pool — this function's header says
+        // "REPLICATES ... EXACTLY"): no transform row → COALESCE parks it at origin/zero-bbox. At
+        // z=0 it has no support, schedules at day 0, and its zone's MIN start follows it there —
+        // that day-0 zone window is what spread walls from day 1 in the live movie.
+        noGeo: (bx === 0 && by === 0 && bz === 0 && cx === 0 && cy === 0 && cz === 0)
       };
-    });
+    }).filter(function (e) { return !e.noGeo; });
   }
 
   // materializeZones(db, rules, opts) — CPM_FLOAT_GAP.md Gap 1 (element-level, rolled up): the

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3829,7 +3829,13 @@
         x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,  // §gate: XY footprint for the support gate
         seq: seq, phase: phase,
         resource: rule.resource || '_DEFAULT',
-        installSecs: getInstallSecs(cls, rule, row[0], bx, by, bz)
+        installSecs: getInstallSecs(cls, rule, row[0], bx, by, bz),
+        // §4D_NOGEO (2026-08-07, 4D_SCHEDULE_PERFECTION.md §4D_LAYER_TRUTH): no transform row —
+        // COALESCE lands it at origin with a zero bbox. It cannot bear, hang, or be witnessed, and
+        // at z=0 (metres below the building) geoGate finds nothing under it, so it scheduled at
+        // day 0 AND dragged its whole zone's start there (user-witnessed: "walls before the
+        // foundations" — 233 such elements on Hospital, §GANTT band 0 z=[0.0,0.0] Architecture:233).
+        noGeo: (bx === 0 && by === 0 && bz === 0 && cx === 0 && cy === 0 && cz === 0)
       };
     });
     if (unknownReassigned) console.log('§GANTT_STOREY_Z reassigned=' + unknownReassigned + ' no-storey elements to nearest real storey by median Z');
@@ -3993,16 +3999,24 @@
     // schedule_gate.js's own MAX_CREWS_DEFAULT for any resource without an explicit value.
     var _maxCrews = {};
     for (var _mcRes in LR) if (LR[_mcRes].max_crews) _maxCrews[_mcRes] = LR[_mcRes].max_crews;
+    // §4D_NOGEO: geometry-less elements are EXCLUDED from the support-gated schedule (they poison
+    // it at day 0) and parked at the project end below — present in the movie's totals, never in
+    // its physics.
+    var _geoElements = elements.filter(function (el) { return !el.noGeo; });
+    var _noGeoN = elements.length - _geoElements.length;
     var _sched = (typeof ScheduleGate !== 'undefined' && ScheduleGate.computeSchedule)
-      ? ScheduleGate.computeSchedule(elements, baseMs, scaleFactor, _maxCrews) : null;
+      ? ScheduleGate.computeSchedule(_geoElements, baseMs, scaleFactor, _maxCrews) : null;
     if (!_sched) { console.warn('§SUPPORT_CHECK ScheduleGate.js not loaded — generated 4D aborted'); return false; }
+    var _schedEnd = baseMs;
+    for (var _sg in _sched) if (_sched[_sg].end > _schedEnd) _schedEnd = _sched[_sg].end;
+    if (_noGeoN) console.log('§4D_NOGEO parked=' + _noGeoN + ' at project end (no transform/zero bbox — cannot bear, hang, or be witnessed)');
 
     // §S280h: ONE transaction + prepared statement (batched INSERTs — avoids the multi-second freeze).
     db.run('BEGIN');
     var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
     var _projEnd = baseMs;
     elements.forEach(function(el) {
-      var s = _sched[el.guid] || { start: baseMs, end: baseMs + 60000 };
+      var s = _sched[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park, was baseMs (day 0)
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
            resource:el.resource, _end_ts:s.end}),
@@ -4021,8 +4035,8 @@
     // §DEQ_V1 (2026-08-07, 4D_SCHEDULE_PERFECTION.md §DEQ_V1_IMPL #5): filter is ALL classes now —
     // the old hand-picked list (Beam/Member/Slab/'Furni'/'Wall') silently excluded every MEP/flow
     // class, so this line printed floating=0 while fans hung mid-air unaudited.
-    var _auditN = elements.length;
-    var _float = ScheduleGate.auditFloating(elements, _sched, null);
+    var _auditN = _geoElements.length;
+    var _float = ScheduleGate.auditFloating(_geoElements, _sched, null);
     console.log('§SUPPORT_CHECK floating=' + _float + '/' + _auditN + ' (ALL classes, bearing-below + hang-carrier) gated=' + elements.length + ' (0=solved)');
 
     // §4D_WALLS_BEFORE_ROOF M6 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) — stop
@@ -4139,14 +4153,18 @@
       var _elByGuid = {};
       elements.forEach(function(el) { _elByGuid[el.guid] = el; });
       var _byTask = {};
-      var _allOps = db.exec("SELECT output_guid, parameters FROM kernel_ops WHERE op_type='ELEMENT_PLACE'");
+      var _allOps = db.exec("SELECT output_guid, parameters, timestamp FROM kernel_ops WHERE op_type='ELEMENT_PLACE'");
       if (_allOps.length && _allOps[0].values.length) {
         _allOps[0].values.forEach(function(row) {
           var g = row[0], tid = _cap.guidTask[g];
           if (!tid) return;                         // uncovered → keep generative timing
           if (!_byTask[tid]) _byTask[tid] = [];
           var _el = _elByGuid[g];
-          _byTask[tid].push({ guid: g, params: row[1],
+          // §4D_LAYER_TRUTH (2026-08-07): the element's GENERATIVE (computeSchedule) start/end —
+          // the schedule layer's proven truth (floating=0) — rides into the task bucket so the
+          // window mapping below can PRESERVE it instead of discarding it.
+          var _lsEnd = 0; try { _lsEnd = (JSON.parse(row[1]) || {})._end_ts || 0; } catch (e) {}
+          _byTask[tid].push({ guid: g, params: row[1], ls: row[2] || 0, le: _lsEnd || ((row[2] || 0) + 60000),
             cz: _el ? _el.cz : 0, seq: _el ? _el.seq : 999,
             bz: _el ? _el.base_z : 0, tz: _el ? _el.top_z : 0,
             x0: _el ? _el.x0 : 0, x1: _el ? _el.x1 : 0,
@@ -4182,7 +4200,12 @@
         // S.base_z < T.base_z - EPS — audit_support_roleblind.js's own predicate), so a base_z walk
         // cannot place anything before its support. seq then cz break ties WITHIN a bearing level,
         // keeping §4D_FACADE_ORDER's trade discipline for same-level elements.
-        _bucket.sort(function(a, b) { return (a.bz - b.bz) || (a.seq - b.seq) || (a.cz - b.cz); });
+        // §4D_LAYER_TRUTH (2026-08-07, supersedes bz-primary here): order INSIDE a task = the
+        // generative schedule's own order (ls = computeSchedule start). base_z ordering was the
+        // best available proxy before the §DEQ_V1 engine — but it is provably wrong for hanging
+        // elements (a fan's base_z is BELOW its roof carrier's), while ls already encodes
+        // bearing-below + hang-carrier + the repair loop. bz/seq/cz stay as tiebreakers only.
+        _bucket.sort(function(a, b) { return (a.ls - b.ls) || (a.bz - b.bz) || (a.seq - b.seq) || (a.cz - b.cz); });
         // §4D_HOST_BEFORE_HOSTED (same spec file): float-noise near-ties defeat the seq tiebreak —
         // 101/5,924 host pairs on Hospital have the wall base 0–0.043m ABOVE its hosted glazing's
         // base (< EPS), so the panel sorts first. Constraint AFTER the sort, never a replacement:
@@ -4196,7 +4219,9 @@
           for (i = 0; i < items.length; i++) {
             var H = items[i]; if (!H.hostable) continue;
             var last = -1;
-            for (j = i + 1; j < items.length && items[j].bz <= H.bz + HEPS; j++) {
+            // §4D_LAYER_TRUTH: scan bound follows the new ls-primary sort — host/hosted pairs are
+            // near-tied in ls (same supports), so a 1-day ls window covers what the bz window did.
+            for (j = i + 1; j < items.length && items[j].ls <= H.ls + 86400000; j++) {
               var W = items[j];
               if (W.cls.indexOf('IfcWall') === 0 &&
                   H.x0 <= W.x1 && H.x1 >= W.x0 && H.y0 <= W.y1 && H.y1 >= W.y0 &&
@@ -4211,10 +4236,24 @@
             console.log('§STAGGER_HOST movedAfterHost=' + moved + ' (task bucket n=' + items.length + ')');
           }
         })(_bucket);
+        // §4D_LAYER_TRUTH (2026-08-07, replaces the even index-stagger): the even spread kept only
+        // the bucket's ORDER and re-timed elements uniformly across the window — measured on the
+        // user's own Hospital console: §XRAY_EDGES staged=284/63415 on this path vs staged=0 on the
+        // generative path, i.e. the window layer re-introduced 284 support violations the schedule
+        // layer had already solved. Map each element's generative [ls,le] AFFINELY into the task's
+        // own [w.s,w.e] instead: an untouched window (windows come from the SAME schedule's zone
+        // rollup) reproduces the generative times in shape, and a user-dragged window rescales them
+        // without reordering. Monotone by construction (bucket is ls-sorted).
         var _n = _bucket.length, _span = Math.max(1, w.e - w.s);
+        var _lsMin = Infinity, _leMax = -Infinity;
+        _bucket.forEach(function(item) {
+          if (item.ls < _lsMin) _lsMin = item.ls;
+          if (item.le > _leMax) _leMax = item.le;
+        });
+        var _lsSpan = Math.max(1, _leMax - _lsMin);
         _bucket.forEach(function(item, i) {
-          var s_i = w.s + Math.floor((i / _n) * _span);
-          var e_i = (i + 1 < _n) ? (w.s + Math.floor(((i + 1) / _n) * _span)) : w.e;
+          var s_i = w.s + Math.floor(((item.ls - _lsMin) / _lsSpan) * _span);
+          var e_i = w.s + Math.floor(((item.le - _lsMin) / _lsSpan) * _span);
           if (e_i <= s_i) e_i = s_i + 60000;   // never zero/negative duration
           var p; try { p = JSON.parse(item.params); } catch (e) { p = {}; }
           p.phase = w.name;                         // real task name → shows in mini-Gantt
@@ -4273,34 +4312,66 @@
         else if (e.cls.indexOf('IfcWall') === 0) _ogCellsBuild(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
       });
       _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
-      var _ogPushed = 0;
-      _allScheduled.forEach(function (T) {
-        var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
-        var cells = _ogCellsQuery(T), seen = {}, lastEnd = 0;
-        for (var ci = 0; ci < cells.length; ci++) {
-          var arr = _ogStructGrid[cells[ci]];
-          if (arr) for (var si = 0; si < arr.length; si++) {
-            var S = arr[si];
-            if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
-            if (S.bz < T.bz - _ogEPS && Math.abs(S.tz - T.bz) <= _ogGAP && _ogXY(S, T) && S.e > lastEnd) lastEnd = S.e;
+      // §4D_LAYER_TRUTH (2026-08-07): the single ascending-bz pass was measured leaving 25 staged
+      // violations (witness_4d_layer_truth.js, Hospital) for the SAME two reasons §DEQ_REPAIR exists
+      // in schedule_gate.js: (a) pushing a carrier later never re-checks dependents already visited
+      // (bz order guarantees carriers-first only for bearing-below, and a push can still ripple
+      // forward), and (b) the predicate was hang-blind — a fan's carrier (roof above) has HIGHER bz,
+      // so ordering can't help it at all. Same fix as the engine layer: bearing-below OR (no bearing)
+      // hang-carrier, swept to fixpoint (≤16, monotone pushes, acyclic relation).
+      // Hang lookup queries the target's TOP z-neighborhood (carrier underside within ±GAP of T.tz,
+      // carrier top strictly above T.tz — the same antisymmetric predicate as schedule_gate.js).
+      var _ogCellsQueryTop = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.tz - _ogGAP, e.tz + _ogGAP); };
+      var _ogPushed = 0, _ogSweeps = 0;
+      for (; _ogSweeps < 16; _ogSweeps++) {
+        var _ogMoved = 0;
+        _allScheduled.forEach(function (T) {
+          var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
+          var cells = _ogCellsQuery(T), seen = {}, lastEnd = 0, hasBearing = false;
+          for (var ci = 0; ci < cells.length; ci++) {
+            var arr = _ogStructGrid[cells[ci]];
+            if (arr) for (var si = 0; si < arr.length; si++) {
+              var S = arr[si];
+              if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
+              // §4D_LAYER_TRUTH: predicate ALIGNED with auditFloating()/_buildXraySupportCache —
+              // carrier top REACHES my base (>= T.bz-GAP, unbounded above: a tall column a beam
+              // frames into tops far above the beam's base). The old ±GAP band was narrower than
+              // the audits and left exactly the 25 staged elements those audits could still see.
+              if (S.bz < T.bz - _ogEPS && S.tz >= T.bz - _ogGAP && _ogXY(S, T)) {
+                hasBearing = true; if (S.e > lastEnd) lastEnd = S.e; }
+            }
+            if (!promotedSlab) continue;
+            arr = _ogWallGrid[cells[ci]];
+            if (arr) for (var wi = 0; wi < arr.length; wi++) {
+              var W = arr[wi];
+              if (W.guid === T.guid || seen[W.guid]) continue; seen[W.guid] = 1;
+              if (W.bz < T.bz - _ogEPS && W.tz >= T.bz - _ogGAP && _ogXY(W, T)) {
+                hasBearing = true; if (W.e > lastEnd) lastEnd = W.e; }
+            }
           }
-          if (!promotedSlab) continue;
-          arr = _ogWallGrid[cells[ci]];
-          if (arr) for (var wi = 0; wi < arr.length; wi++) {
-            var W = arr[wi];
-            if (W.guid === T.guid || seen[W.guid]) continue; seen[W.guid] = 1;
-            if (W.bz < T.bz - _ogEPS && Math.abs(W.tz - T.bz) <= _ogGAP && _ogXY(W, T) && W.e > lastEnd) lastEnd = W.e;
+          if (!hasBearing && T.seq > 4) {          // hangs — gate on the carrier above instead
+            var hcells = _ogCellsQueryTop(T), hseen = {};
+            for (var hi = 0; hi < hcells.length; hi++) {
+              var harr = _ogStructGrid[hcells[hi]];
+              if (harr) for (var hj = 0; hj < harr.length; hj++) {
+                var H = harr[hj];
+                if (H.guid === T.guid || hseen[H.guid]) continue; hseen[H.guid] = 1;
+                if (H.bz >= T.tz - _ogGAP && H.bz <= T.tz + _ogGAP && H.tz > T.tz + _ogEPS &&
+                    _ogXY(H, T) && H.e > lastEnd) lastEnd = H.e;
+              }
+            }
           }
-        }
-        if (lastEnd && T.s < lastEnd) {
-          var dur = Math.max(60000, T.e - T.s);
-          T.s = lastEnd + 1;
-          T.e = T.s + dur;
-          _ogPushed++;
-        }
-      });
+          if (lastEnd && T.s < lastEnd) {
+            var dur = Math.max(60000, T.e - T.s);
+            T.s = lastEnd + 1;
+            T.e = T.s + dur;
+            _ogPushed++; _ogMoved++;
+          }
+        });
+        if (!_ogMoved) break;
+      }
       if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +
-        ' elements later than their §PHASE_OVERLAP_BAND window to stay after their real structural support');
+        ' (sweeps=' + _ogSweeps + ', bearing+hang) elements later than their §PHASE_OVERLAP_BAND window to stay after their real support');
 
       // §WRITE_LOOP_TIMING (2026-08-04) — a user report of the browser tab freezing traced to
       // console output stopping right at this point, on a 63,415-element building. No fix here —


### PR DESCRIPTION
User-witnessed on Hospital: §XRAY_EDGES staged=284/63415 on the task-window pass
vs 0 on the generative pass, and §GANTT band 0 z=[0,0] 233 Architecture elements
scheduling at day 0 (walls spreading from day 1; geometry-less elements at
origin dragged their zone windows there).

Three-layer fix:
- §4D_NOGEO: elements with no transform row are excluded from the support-gated
  schedule and from zone rollup (both extractors), parked at project end.
- Task-window overlay maps each element's generative [start,end] AFFINELY into
  its task window (ls-primary order) instead of even index-stagger — the window
  layer can no longer re-time against the schedule layer.
- §PHASE_OVERLAP_SUPPORT_GUARD: fixpoint sweep (≤16), bearing-below OR
  hang-carrier, predicate aligned with auditFloating/_buildXraySupportCache
  (carrier top REACHES the base, unbounded above — the ±GAP band left exactly
  25 staged).

Witness: tests/witness_4d_layer_truth.js — staged 284→0, noGeo parked=233,
floating=0, first-day ops clean of walls/undefined. Full suite + single-load
witness PASS.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5rYmahmKaQbUsS5rfSset
