### PR TITLE
fix(4d): §GANTT_RETIME_RESYNC — gantt edits no longer black out the canvas

### DIFF
--- a/tests/witness_gantt_retime_resync.js
+++ b/tests/witness_gantt_retime_resync.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/* ⚠ WITNESS — proves/disproves §GANTT_RETIME_RESYNC (4D_SCHEDULE_PERFECTION.md, 2026-08-07, user
+ * report: "foundation piling nor others does not seem to come onto canvas anymore, though i dragged
+ * to certain bars passing" — witnessed in the user's console as §PERF_TRAVERSE cand=0 on every scrub
+ * after §GANTT_RETIME): the retime paths moved op timestamps but never rebuilt the §PERF_INCR event
+ * index, re-sorted _ops, or rebuilt the §XRAY solidify cache — so the incremental reveal skipped
+ * meshes straight across their new transitions.
+ *
+ * PASS iff after driving the REAL ruler-shift commit path (__tmGanttShift(-93)):
+ *   - §GANTT_RETIME fired with rows>0 (ops actually moved)
+ *   - §PERF_INCR_INDEX fired AGAIN after the shift (event index rebuilt on the new times)
+ *   - §XRAY_EDGES fired AGAIN after the shift (solidify cache rebuilt)
+ *   - functional: tmPlacedCount at 30% of the NEW project span is >0 (reveal not blacked out)
+ */
+const { chromium } = require('/home/red1/bim-ootb/tests/node_modules/playwright-core');
+const URL = process.env.WITNESS_URL ||
+  'http://localhost:8484/viewer/viewer.html?db=https://objectstorage.ap-kulai-2.oraclecloud.com/n/ax3cp6tzwuy2/b/bim-ootb/o/buildings/Hospital_extracted.db&ghost=1';
+(async () => {
+  const browser = await chromium.launch({ executablePath: '/usr/bin/google-chrome', headless: true,
+    args: ['--no-sandbox', '--disable-gpu'] });
+  const page = await (await browser.newContext()).newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text();
+    if (/§GANTT_RETIME|§PERF_INCR_INDEX|§XRAY_EDGES|§TM_RULER_SHIFT|§SE_SHIFT/.test(t)) {
+      lines.push(t); console.log('[console]', t.slice(0, 160)); } });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.db && window.toggleTimeMachine, null, { timeout: 180000 });
+  await page.evaluate(() => window.toggleTimeMachine());
+  await page.waitForFunction(() => { try { return window.tmGetState && window.tmGetState().active; } catch (e) { return false; } }, null, { timeout: 300000 });
+  await page.evaluate(() => document.getElementById('tm-gantt').dispatchEvent(new PointerEvent('pointerup', { bubbles: true })));
+  await page.waitForTimeout(4000);
+  const before = lines.length;                          // everything up to here is activation noise
+  await page.evaluate(() => window.__tmGanttShift(-93));
+  await page.waitForTimeout(4000);
+  const after = lines.slice(before);
+  const placed = await page.evaluate(() => {
+    const st = window.tmGetState();
+    const t = st.projectStart + (st.projectEnd - st.projectStart) * 0.3;
+    window.tmSetCursor(t);
+    return window.tmPlacedCount(t);
+  });
+  const n = re => after.filter(l => re.test(l)).length;
+  const retime = after.find(l => /§GANTT_RETIME/.test(l)) || '';
+  const rows = +(retime.match(/rows=(\d+)/) || [0, 0])[1];
+  const idxRebuilt = n(/§PERF_INCR_INDEX/), xrayRebuilt = n(/§XRAY_EDGES/);
+  console.log(`§RETIME_RESYNC_CHECK rows=${rows} perfIndexRebuilds=${idxRebuilt} xrayRebuilds=${xrayRebuilt} placedAt30pct=${placed}`);
+  const pass = rows > 0 && idxRebuilt >= 1 && xrayRebuilt >= 1 && placed > 0;
+  console.log(pass ? 'PASS — retime resyncs the event index + xray cache; reveal alive after an edit'
+                   : 'FAIL — a stale derived structure survived the retime (the canvas blackout)');
+  await browser.close();
+  process.exit(pass ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5260,6 +5260,20 @@
     return rows;
   }
 
+  // §GANTT_RETIME_RESYNC (2026-08-07, 4D_SCHEDULE_PERFECTION.md §4D_LAYER_TRUTH follow-on — user
+  // report: "foundation piling nor others does not come onto canvas anymore, though i dragged to
+  // certain bars passing", witnessed as §PERF_TRAVERSE cand=0 on every scrub after §GANTT_RETIME):
+  // retimeTaskElements moves the ops' timestamps, but THREE derived structures kept the old times —
+  // (1) the §PERF_INCR event index (_evMesh), so the incremental reveal skipped meshes straight
+  // across their new transitions (the blackout); (2) _ops' sort order (consumers binary-search it);
+  // (3) the §XRAY solidify cache (stale carrier ends). One resync, called by every retime commit
+  // path (drag, ruler shift, group shift, undo) — same drop-pattern deactivate() already uses.
+  function _tmResyncAfterRetime() {
+    _ops.sort(function (a, b) { return a.start_ts - b.start_ts; });
+    _evMesh = null; _evSig = ''; _incrPrimed = false;   // §PERF_INCR: force full rebuild next tick
+    _tmRebuildXrayCache();
+  }
+
   // Commit a finished gesture: engine verb → clamp/cascade result → re-time elements → redraw.
   function commitGanttDrag(bar, mode, deltaDays) {
     var app = A();
@@ -5334,6 +5348,7 @@
     _lastEdit = { schedId: schedId, taskId: bar.taskId, mode: mode, tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§GANTT_DRAG_COMMIT task=' + bar.taskId + ' mode=' + mode + ' deltaDays=' + deltaDays +
       ' start=' + res.start + ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
+    _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -5387,6 +5402,7 @@
     retimeTaskElements(app.db, barsByTask, res.moved);
     _lastEdit = { schedId: schedId, taskId: '(whole schedule)', mode: 'shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§TM_RULER_SHIFT_COMMIT schedule=' + schedId + ' deltaDays=' + deltaDays + ' tasks=' + res.moved.length);
+    _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -5438,6 +5454,7 @@
     retimeTaskElements(app.db, barsByTask, res.moved);
     _lastEdit = { schedId: schedId, taskId: '(' + taskIds.length + ' selected)', mode: 'group-shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§GANTT_GROUP_SHIFT_COMMIT tasks=' + res.moved.length + ' deltaDays=' + deltaDays);
+    _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -5491,6 +5508,7 @@
     console.log('§GANTT_EDIT_UNDO task=' + edit.taskId + ' mode=' + edit.mode +
       ' tasksRestored=' + tRestored + ' opsRestored=' + oRestored);
     say('Undone: ' + edit.mode + ' ' + edit.taskId);
+    _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6873,6 +6891,9 @@
     return wasActive;
   }
   window.tmRefoldSchedule = refoldSchedule;
+  // §GANTT_RETIME_RESYNC witness hook (double-underscore debug convention, read-only intent):
+  // lets witness_gantt_retime_resync.js drive the REAL ruler-shift commit path headlessly.
+  window.__tmGanttShift = shiftGanttSchedule;
 
   // §S2 (TM_4D5D_VARIANCE_LANE) — juncture jump: land the cursor at the START of a named phase's window so the
   // scene is rendered PARTIALLY-BUILT at that moment (the IFC cost panel's "View at this moment"). The phase


### PR DESCRIPTION
User-witnessed: after §GANTT_RETIME every §PERF_TRAVERSE showed cand=0 — the
incremental reveal skipped meshes straight across their moved transitions
('foundation piling does not come onto canvas anymore'). One
_tmResyncAfterRetime() (re-sort _ops, drop event index, rebuild xray cache)
called by all four retime commit paths (drag, ruler shift, group shift, undo).

Witness: tests/witness_gantt_retime_resync.js — drives the REAL ruler-shift
path (-93d) on Hospital: rows=63182 retimed, §PERF_INCR_INDEX + §XRAY_EDGES
both rebuilt after the shift, tmPlacedCount at 30% of the new span = 22766.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5rYmahmKaQbUsS5rfSset
