### PR TITLE
feat(cpe): §CPE_WALK_EDIT_V1 — POV walk-mode input device for the CPE stick editor

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -339,6 +339,65 @@
     _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
     return true;
   }
+  // ══ §CPE_WALK_EDIT_V1 (prompts/CPE_POV_WALK_PATHING.md) — the ONE new maths piece the walk
+  // feature needs: a stick whose CENTRE is the walked pose (not a curve sample) but whose ordering
+  // in the chain and seed TANGENT still come from the curve, exactly as §CPE_STICK's own
+  // `_spawnStick` does. Called by cpe_walk.js through the narrow surface below (`_walkSnap` on the
+  // public API) — this function is the only place cpe_walk.js reaches into `_state`/bands/plan.
+  function _walkSnap(pos, fwd) {
+    var a = A();
+    if (!_state || !_state.flowRaw || !_state.flowFrac || !_state.flowRaw.length) return null;
+    if (typeof a.cinemaSeedStick !== 'function') return null;
+    // Insertion fraction `s` in the SAME space _bandArcS reads (flowRaw/flowFrac) so ordering
+    // against the existing bands (each measured in that same space) is apples-to-apples.
+    var pts = _state.flowRaw, frac = _state.flowFrac, best = 0, bd = Infinity;
+    for (var i = 0; i < pts.length; i++) {
+      var dx = pts[i].x - pos.x, dy = pts[i].y - pos.y, dz = pts[i].z - pos.z;
+      var d = dx * dx + dy * dy + dz * dz;
+      if (d < bd) { bd = d; best = i; }
+    }
+    var s = frac[best];
+    var len = _state.bands.length ? _state.bands[0].len : 2;
+    var nb = a.cinemaSeedStick(pts, best, len);   // tangent direction from the curve at the nearest sample
+    if (!nb) return null;
+    nb.c = { x: pos.x, y: pos.y, z: pos.z };      // OVERRIDE centre: the walked pose, not the curve sample
+    nb._s = s; nb._stick = true;
+    // Facing = the existing pin data path (§CPE_AIM_PIN) — raycast the walked forward ray against
+    // real building meshes, same pattern `_tryPinClick` already uses (A.raycaster, scene meshes
+    // minus ground and CPE's own overlay `_state.objs`, so a walked-along stretch of the film tube
+    // itself can never be "the wall you were looking at"). Fallback = 10m out along the facing when
+    // nothing is hit — named in the spec, not invented here.
+    var look = null;
+    if (a.raycaster && a.scene && fwd) {
+      try {
+        a.raycaster.set(new THREE.Vector3(pos.x, pos.y, pos.z), new THREE.Vector3(fwd.x, fwd.y, fwd.z).normalize());
+        var meshes = [];
+        a.scene.traverse(function(o) { if (o.isMesh && o.visible && o !== a.ground && _state.objs.indexOf(o) === -1) meshes.push(o); });
+        var hits = a.raycaster.intersectObjects(meshes, false);
+        if (hits.length) look = { x: hits[0].point.x, y: hits[0].point.y, z: hits[0].point.z };
+      } catch (e) { console.warn('§CPE_WALK_SNAP_RAYCAST_FAIL ' + e.message); }
+    }
+    if (!look && fwd) look = { x: pos.x + fwd.x * 10, y: pos.y + fwd.y * 10, z: pos.z + fwd.z * 10 };
+    if (look) nb.lookAt = look;
+    // Ordering — identical rule to _spawnStick: after the last band whose own arc position precedes it.
+    var at = _state.bands.length - 1;
+    for (var k = 1; k < _state.bands.length; k++) {
+      var bs = _bandArcS(k);
+      if (bs != null && bs > s) { at = k; break; }
+    }
+    at = Math.max(1, Math.min(_state.bands.length - 1, at));
+    _undoPush('walk snap at ' + Math.round(s * 100) + '%');
+    _state.bands.splice(at, 0, nb);
+    _state.staged = false;
+    console.log('§CPE_WALK_SNAP pos=(' + pos.x.toFixed(2) + ',' + pos.y.toFixed(2) + ',' + pos.z.toFixed(2) + ')' +
+      ' s=' + s.toFixed(3) + ' index=' + at + '/' + _state.bands.length +
+      ' lookAt=' + (look ? '(' + look.x.toFixed(2) + ',' + look.y.toFixed(2) + ',' + look.z.toFixed(2) + ')' : 'none') +
+      ' — §CPE_STICK insertion maths, centre = walked pose not curve sample');
+    _markPreviewStale();
+    _refreshFlow(); _replanFilm();
+    _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+    return { bandIndex: at, s: s, centre: nb.c, lookAt: look, replanMs: _state.replanMs };
+  }
   function _removeStick(bi) {
     if (bi <= 0 || bi >= _state.bands.length - 1) return false;   // settle and stop are not removable
     _undoPush('remove ' + _labelOf(bi));
@@ -747,7 +806,13 @@
         // swaps it in place, never rebuilding the button.
         '<button id="cpe-vf-toggle" title="turn on the POV viewfinder (B) — shows the exact camera pose the rehearsal is at" ' +
           'style="flex:none;padding:3px 8px;font-size:13px;line-height:1;background:#2a2e34;color:#888;' +
-          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer;display:flex;align-items:center">' + _eyeIconSvg(false) + '</button></div>' +
+          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer;display:flex;align-items:center">' + _eyeIconSvg(false) + '</button>' +
+        // §CPE_WALK_EDIT_V1 (prompts/CPE_POV_WALK_PATHING.md) — walk B in POV with mouse+WASD, press
+        // Enter/click to snap a stick where you are looking. All behaviour lives in viewer/cpe_walk.js;
+        // this button only starts/stops it (same icon-only-button convention as the eye toggle).
+        '<button id="cpe-walk-toggle" title="walk the POV (B) with mouse-look + WASD; click or Enter snaps a stick where you are looking and facing" ' +
+          'style="flex:none;padding:3px 8px;font-size:11px;line-height:1;background:#2a2e34;color:#888;' +
+          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer">walk</button></div>' +
       '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
       '<div id="cpe-rows" style="padding:4px 0"></div>' +
       // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path controls, one strip.
@@ -1819,6 +1884,19 @@
     // plain <button> the way it excludes INPUT/close/export elements.
     btn.addEventListener('pointerdown', function(ev) { ev.stopPropagation(); });
     btn.addEventListener('click', function(ev) { ev.stopPropagation(); _toggleViewfinder(btn); });
+  }
+  // §CPE_WALK_EDIT_V1 — the walk-mode button only calls into cpe_walk.js (window.CpeWalk); all
+  // mount/unmount/pointer-lock/freeze/snap logic lives there. Same pointerdown-stopPropagation
+  // guard as _wireViewfinderToggle, same reason (the panel drag strip would otherwise claim the click).
+  function _wireWalkToggle() {
+    var btn = document.getElementById('cpe-walk-toggle');
+    if (!btn) return;
+    btn.addEventListener('pointerdown', function(ev) { ev.stopPropagation(); });
+    btn.addEventListener('click', function(ev) {
+      ev.stopPropagation();
+      if (window.CpeWalk && typeof window.CpeWalk.toggle === 'function') window.CpeWalk.toggle();
+      else console.warn('§CPE_WALK_MODULE_MISSING cpe_walk.js did not load — walk button is a no-op');
+    });
   }
 
   // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path strip.
@@ -2949,6 +3027,8 @@
       _state.scrubTn = 0;
       // §CPE_VIEWFINDER: the eye-icon toggle button lives in the panel's title row (_buildPanel).
       _wireViewfinderToggle();
+      // §CPE_WALK_EDIT_V1: the walk-mode toggle button, same title row.
+      _wireWalkToggle();
       // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted
       // console ever shows the bake's §CINEMA_PIVOT disagreeing with the editor's, this line says
       // which camera the editor was planning from.
@@ -3092,6 +3172,13 @@
       _renderPlans();
 
       function finish(action) {
+        // §CPE_WALK_EDIT_V1 teardown hook — walk-mode's pointer-lock listeners, its own rAF loop,
+        // the freeze overlay and the Time Machine lock must not outlive the editor (same "must not
+        // outlive" rule _vfTeardown/_scrubPanelTeardown already follow below). forceStop() is a no-op
+        // if walk mode was never entered or is already off.
+        if (window.CpeWalk && typeof window.CpeWalk.isActive === 'function' && window.CpeWalk.isActive()) {
+          window.CpeWalk.forceStop();
+        }
         var ov = (action === 'ok' || action === 'save') ? _buildOverride() : null;
         var edited = ov ? _isEdited() : false;
         _stopPulse(); _release('close'); _unwire(); _clearScene();
@@ -3323,7 +3410,35 @@
           if (!_state || !_state.flowRaw || !_state.flowFrac) return false;
           var idx = Math.max(0, Math.min(_state.flowFrac.length - 1, Math.round(_state.flowFrac.length * frac)));
           return _spawnStick({ i: idx, s: _state.flowFrac[idx] });
-        }
+        },
+        // ══ §CPE_WALK_EDIT_V1 witness hooks — the narrow read/write surface prompts/
+        // CPE_POV_WALK_PATHING.md hands to cpe_walk.js. `_walkMount`/`_walkUnmount` are the
+        // `_wire()`/`_unwire()` calls at walk mount/unmount named in the spec; `_walkSnap` is the
+        // band-insertion write surface (the one new maths piece, implemented above as `_walkSnap`).
+        _walkMount: function() {
+          if (!_state) return null;
+          _stopPulse();
+          _unwire();
+          console.log('§CPE_WALK_MOUNT stick-editor handlers off (_unwire), pulse stopped');
+          return true;
+        },
+        _walkUnmount: function() {
+          if (!_state) return null;
+          var a = A();
+          _wire();
+          _redrawScene(); _renderRows(); _renderClock(); _renderWhole(); _syncButtons();
+          if (a.markDirty) a.markDirty();
+          console.log('§CPE_WALK_UNMOUNT stick-editor handlers restored (_wire)');
+          return true;
+        },
+        _walkSnap: function(pos, fwd) { return _walkSnap(pos, fwd); },
+        // Read-only proof for G-WALK-ISOLATE: whether the stick editor's OWN drag gesture is live
+        // right now. `_state.drag` is only ever non-null while a real pointerdown->pointermove
+        // sequence, dispatched through the `_wire()`-installed capture-phase listeners, is in
+        // progress — so a witness can dispatch a synthetic pointerdown at a known handle and read
+        // this to prove the listeners are (or are not) actually attached, not merely assume it from
+        // the mount/unmount call having run. Mutates nothing itself.
+        _probeDrag: function() { return _state ? !!_state.drag : null; }
       };
       clearInterval(_attach);
     }

--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -1,0 +1,365 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// cpe_walk.js — §CPE_WALK_EDIT_V1 (prompts/CPE_POV_WALK_PATHING.md).
+//
+// 🔒 LOCKED VISION (user 2026-08-07, "the perfect rehash"): POV walk is an INPUT DEVICE for the
+// existing stick edit, not a new authoring model. Walk in B (the CPE viewfinder), press snap, a
+// stick lands at the walked pose facing where you were looking, and the EXISTING re-plan
+// (_replanFilm -> cinemaPathPlan) re-snakes the path exactly as a drag-release does today. There is
+// no second path truth here and no continuous pose recording — that idea ("the walk becomes the
+// path") was explicitly RETIRED by the same user ruling; see the spec file's own §SUPERSEDED note.
+//
+// This file is the ONLY new code for the feature (spec's "Handed to the implementation session as
+// fact"). cinema_path_editor.js was touched at exactly four named seams — see that file's own
+// §CPE_WALK_EDIT_V1 comments for each: (1) the `cpe-walk-toggle` button in `_buildPanel()`'s title
+// row + `_wireWalkToggle()`, (2) `_walkMount`/`_walkUnmount` on the public `cinemaPathEditor`
+// object, which are the ONLY callers of the private `_wire()`/`_unwire()` functions this feature
+// needed, (3) `_walkSnap()` — the one new maths piece (band insertion at a walked pose, ordering +
+// tangent from the curve, `lookAt` from a forward raycast — reuses §CPE_STICK's insertion rule and
+// §CPE_AIM_PIN's `lookAt` storage verbatim), (4) one guard line at the top of `finish()` so walk
+// mode cannot outlive the editor. effects.js / time_machine.js / schedule_*.js / main.js: zero edits.
+//
+// ══ §CPE_WALK_CANVAS_FREEZE — how "render only B while walking" is achieved with ZERO main.js
+// edits ══════════════════════════════════════════════════════════════════════════════════════════
+// main.js's animate() loop renders the MAIN view and the B scissor pass TOGETHER, gated by the SAME
+// `_needsRender` flag (main.js:903/907/912 mobile, :922/925/927 desktop — read, not edited) — there
+// is no existing lever to run one without the other from outside that file. So this module never
+// calls `A.markDirty()` during continuous walking: main.js's own §IDLE-PARK self-parks (0 frames)
+// the instant nothing keeps it awake, and this module drives B ITSELF, directly, in its own private
+// rAF loop, by calling `A._cpeViewfinderRender()` — the exact hook main.js would have called, just
+// invoked from here instead. The main view genuinely renders zero frames while walking; the only
+// reason the user does not see it go stale is the freeze overlay below.
+//
+// The freeze overlay is a 2D `<canvas>` snapshot of the WebGL canvas, positioned exactly over it,
+// with a hole `clearRect` cut where B's own rect lives (so B's live, scissored pixels keep showing
+// through — B is not part of the overlay, it is a hole IN it). Three.js's default
+// `preserveDrawingBuffer:false` means the capture MUST happen in the same synchronous task as the
+// render that produced it (no rAF hop, no await in between) — `_renderMainOnce()` and
+// `_recaptureFreeze()` are always called back-to-back, never separated by a yield.
+//
+// ══ §CPE_WALK_TM_LOCK — same zero-edit constraint applied to time_machine.js ═══════════════════
+// time_machine.js exposes no public pause/resume function (checked: only tmGetState/tmSetCursor/
+// tmActivateForBake/tm*Order*/tm*Schedule* are on `window`). Its own play/pause buttons
+// (#tm-fwd-btn/#tm-rev-btn) are real DOM elements wired to `startPlayback(dir)`, which TOGGLES
+// (call it twice with the same dir and it stops) — and `.tm-active` is the CSS class the SAME file
+// already applies to whichever button is currently driving playback. So "pause TM" here means
+// dispatching a real `pointerup` at whichever button already carries `.tm-active` — the exact
+// gesture a user's own click would produce, through time_machine.js's own existing listener, not a
+// re-implementation of its playback state machine. Resume is the identical dispatch, once, at
+// unmount. `pointer-events:none` on the panel additionally blocks the user from starting a NEW
+// scrub/play mid-walk (spec: "disables/backgrounds its panel").
+(function() {
+  'use strict';
+
+  function A() { return window.APP; }
+
+  var WALK_SPEED_MPS = 6;          // fly-speed in metres/sec — reasonable interior walking pace
+  var MOUSE_SENSITIVITY = 0.002;   // identical constant to navigate_controls.js:45 (copied pattern)
+  var LOOK_RAY_FALLBACK_M = 10;    // §CPE_WALK_EDIT_V1 spec's own fallback when the forward ray hits nothing
+  var LOG_EVERY_N_FRAMES = 30;     // ~0.5s at 60fps — enough numeric truth without flooding the console
+  var MAX_DT = 0.1;                // clamp a long stall (tab switch) so one frame cannot teleport the walker
+
+  var _active = false;
+  var _cpe = null;          // window.APP.cinemaPathEditor, cached at mount
+  var _vfCam = null;
+  var _canvas = null;
+  var _keys = { w: false, a: false, s: false, d: false };
+  var _yaw = 0, _pitch = 0;
+  var _rafId = 0;
+  var _lastT = 0;
+  var _frame = 0;
+  var _snapCount = 0;
+  var _pointerLocked = false;
+  var _freezeEl = null;
+  var _tm = null;            // { panel, prevPointerEvents, lockedBtn } or null if TM was not touched
+  var _handlers = null;      // DOM listeners installed at mount, removed at unmount
+
+  // ══════════════════ §CPE_WALK_CANVAS_FREEZE — capture / recapture ══════════════════
+  function _renderMainOnce() {
+    var a = A();
+    if (!a.renderer || !a.scene || !a.camera) return false;
+    // Same 3-way branch main.js's own animate() already uses (main.js:905-907/923-925, read not
+    // edited) so a direct call here matches whatever the normal loop would have drawn.
+    if (a._giComposer && a._giComposerActive) a._giComposer.render();
+    else if (a._composer && a._composerEnabled) a._composer.render();
+    else a.renderer.render(a.scene, a.camera);
+    return true;
+  }
+  function _vfPanelHoleRect(canvasRect) {
+    var panel = document.getElementById('cpe-vf-panel');
+    if (!panel) return null;
+    var pr = panel.getBoundingClientRect();
+    return { x: pr.left - canvasRect.left, y: pr.top - canvasRect.top, w: pr.width, h: pr.height };
+  }
+  // Builds (mount) or repaints (snap) the frozen backdrop. MUST be called immediately after
+  // `_renderMainOnce()` in the same synchronous task — see the file-header comment on
+  // `preserveDrawingBuffer:false`.
+  function _captureFreeze() {
+    var a = A(), canvas = a.canvas;
+    if (!canvas) return null;
+    var rect = canvas.getBoundingClientRect();
+    if (!_freezeEl) {
+      _freezeEl = document.createElement('canvas');
+      _freezeEl.id = 'cpe-walk-freeze';
+      // Below both CPE panels (#cpe-panel z-index 10000, #cpe-vf-panel 10001 — cinema_path_editor.js,
+      // read not edited) and above the plain (non-positioned) WebGL canvas, which stacks at the base
+      // regardless of z-index since it has none of its own (viewer.html:18 `#canvas{...}` no z-index).
+      _freezeEl.style.cssText = 'position:fixed;z-index:9990;pointer-events:none';
+      document.body.appendChild(_freezeEl);
+    }
+    _freezeEl.style.left = rect.left + 'px';
+    _freezeEl.style.top = rect.top + 'px';
+    _freezeEl.style.width = rect.width + 'px';
+    _freezeEl.style.height = rect.height + 'px';
+    _freezeEl.width = Math.max(1, Math.round(rect.width));
+    _freezeEl.height = Math.max(1, Math.round(rect.height));
+    var ctx = _freezeEl.getContext('2d');
+    try { ctx.drawImage(canvas, 0, 0, _freezeEl.width, _freezeEl.height); }
+    catch (e) { console.warn('§CPE_WALK_FREEZE_CAPTURE_FAIL ' + e.message); return _freezeEl; }
+    var hole = _vfPanelHoleRect(rect);
+    if (hole) ctx.clearRect(hole.x, hole.y, hole.w, hole.h);
+    console.log('§CPE_WALK_FREEZE_CAPTURE w=' + _freezeEl.width + ' h=' + _freezeEl.height +
+      ' hole=' + (hole ? JSON.stringify({ x: Math.round(hole.x), y: Math.round(hole.y), w: Math.round(hole.w), h: Math.round(hole.h) }) : 'none'));
+    return _freezeEl;
+  }
+  function _dropFreeze() {
+    if (_freezeEl && _freezeEl.parentNode) _freezeEl.parentNode.removeChild(_freezeEl);
+    _freezeEl = null;
+  }
+
+  // ══════════════════ §CPE_WALK_TM_LOCK ══════════════════
+  function _tmLock() {
+    var panel = document.getElementById('time-machine-panel');
+    if (!panel) { console.log('§CPE_WALK_TM_LOCK no TM panel — nothing to lock'); return null; }
+    var fwd = document.getElementById('tm-fwd-btn'), rev = document.getElementById('tm-rev-btn');
+    var playingBtn = (fwd && fwd.classList.contains('tm-active')) ? fwd
+                    : (rev && rev.classList.contains('tm-active')) ? rev : null;
+    var rec = { panel: panel, prevPointerEvents: panel.style.pointerEvents || '', lockedBtn: playingBtn };
+    if (playingBtn) {
+      // Same gesture the button's own listener already handles (time_machine.js:2902-2908, read not
+      // edited) — startPlayback(dir) toggles OFF when called twice with the same dir.
+      playingBtn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true }));
+    }
+    panel.style.pointerEvents = 'none';
+    console.log('§CPE_WALK_TM_LOCK paused=' + (playingBtn ? playingBtn.id : 'none') +
+      ' panel pointer-events=none');
+    return rec;
+  }
+  function _tmUnlock(rec) {
+    if (!rec) return;
+    rec.panel.style.pointerEvents = rec.prevPointerEvents;
+    if (rec.lockedBtn) rec.lockedBtn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true }));
+    console.log('§CPE_WALK_TM_LOCK restored resumed=' + (rec.lockedBtn ? rec.lockedBtn.id : 'none') +
+      ' panel pointer-events="' + rec.prevPointerEvents + '"');
+  }
+
+  // ══════════════════ pointer-lock mouse-look + WASD — pattern copied from
+  // navigate_controls.js:28-56 (canvas.requestPointerLock, mousemove yaw/pitch with clamp,
+  // pointerlockchange flag), adapted to drive `_vfCam` instead of the main nav camera. ══════════
+  function _onMouseMove(e) {
+    if (!_active || !_pointerLocked) return;
+    _yaw -= e.movementX * MOUSE_SENSITIVITY;
+    _pitch -= e.movementY * MOUSE_SENSITIVITY;
+    _pitch = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, _pitch));
+    _vfCam.rotation.set(_pitch, _yaw, 0);
+  }
+  function _onLockChange() {
+    _pointerLocked = (document.pointerLockElement === _canvas);
+    if (_active && !_pointerLocked) {
+      // Lock lost outside our own stop() (Escape, alt-tab, OS focus change) — treat it as the exit
+      // gesture, same as the spec's own "user may stop walk" framing.
+      console.log('§CPE_WALK_LOCK_LOST exiting walk mode');
+      stop();
+    }
+  }
+  function _onKeyDown(e) {
+    if (!_active) return;
+    var k = (e.key || '').toLowerCase();
+    if (k === 'w' || k === 'a' || k === 's' || k === 'd') { _keys[k] = true; e.preventDefault(); e.stopPropagation(); return; }
+    if (k === 'enter') { e.preventDefault(); e.stopPropagation(); _doSnap(); return; }
+    if (k === 'escape') { e.preventDefault(); e.stopPropagation(); stop(); return; }
+  }
+  function _onKeyUp(e) {
+    if (!_active) return;
+    var k = (e.key || '').toLowerCase();
+    if (k === 'w' || k === 'a' || k === 's' || k === 'd') { _keys[k] = false; e.preventDefault(); e.stopPropagation(); }
+  }
+  function _onMouseDown(e) {
+    if (!_active || !_pointerLocked || e.button !== 0) return;
+    e.preventDefault(); e.stopPropagation();
+    _doSnap();
+  }
+  function _onCanvasClick() {
+    if (_active && !document.pointerLockElement) _canvas.requestPointerLock();
+  }
+
+  // ══════════════════ the per-frame walk loop — see §CPE_WALK_CANVAS_FREEZE header comment for
+  // why this NEVER calls A.markDirty() ══════════════════
+  function _tick(tNow) {
+    if (!_active) return;
+    _rafId = requestAnimationFrame(_tick);
+    var dt = _lastT ? Math.min(MAX_DT, (tNow - _lastT) / 1000) : 0;
+    _lastT = tNow;
+    var right = new THREE.Vector3(1, 0, 0).applyQuaternion(_vfCam.quaternion);
+    var fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(_vfCam.quaternion);
+    var move = new THREE.Vector3();
+    if (_keys.w) move.add(fwd);
+    if (_keys.s) move.sub(fwd);
+    if (_keys.d) move.add(right);
+    if (_keys.a) move.sub(right);
+    if (move.lengthSq() > 0 && dt > 0) {
+      move.normalize().multiplyScalar(WALK_SPEED_MPS * dt);
+      _vfCam.position.add(move);
+    }
+    _vfCam.updateMatrixWorld(true);
+    var a = A();
+    if (a._cpeViewfinderRender) a._cpeViewfinderRender();   // B only — see header comment
+    _frame++;
+    if (_frame % LOG_EVERY_N_FRAMES === 0) {
+      console.log('§CPE_WALK_POSE frame=' + _frame +
+        ' pos=(' + _vfCam.position.x.toFixed(2) + ',' + _vfCam.position.y.toFixed(2) + ',' + _vfCam.position.z.toFixed(2) + ')' +
+        ' yaw=' + (_yaw * 180 / Math.PI).toFixed(1) + 'deg pitch=' + (_pitch * 180 / Math.PI).toFixed(1) + 'deg');
+    }
+  }
+
+  // ══════════════════ snap action — the one new maths piece lives in cinema_path_editor.js's
+  // `_walkSnap`; this only gathers the walked pose and hands it over. ══════════════════
+  function _doSnap() {
+    if (!_active || !_cpe || !_vfCam) return null;
+    var pos = { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z };
+    var fwdV = new THREE.Vector3(0, 0, -1).applyQuaternion(_vfCam.quaternion);
+    var fwd = { x: fwdV.x, y: fwdV.y, z: fwdV.z };
+    var t0 = performance.now();
+    var res = _cpe._walkSnap(pos, fwd);
+    var ms = performance.now() - t0;
+    if (!res) { console.warn('§CPE_WALK_SNAP_FAIL pos=(' + pos.x.toFixed(2) + ',' + pos.y.toFixed(2) + ',' + pos.z.toFixed(2) + ') — no flown path to snap onto yet'); return null; }
+    _snapCount++;
+    console.log('§CPE_WALK_SNAP_RESULT n=' + _snapCount + ' bandIndex=' + res.bandIndex + ' s=' + res.s.toFixed(3) +
+      ' centre=(' + res.centre.x.toFixed(2) + ',' + res.centre.y.toFixed(2) + ',' + res.centre.z.toFixed(2) + ')' +
+      ' lookAt=' + (res.lookAt ? '(' + res.lookAt.x.toFixed(2) + ',' + res.lookAt.y.toFixed(2) + ',' + res.lookAt.z.toFixed(2) + ')' : 'none') +
+      ' replanMs=' + (res.replanMs != null ? res.replanMs.toFixed(0) : '?') + ' snapCallMs=' + ms.toFixed(1));
+    // §CPE_WALK_SNAP_WOW — replan already ran inside _walkSnap (via _replanFilm/_redrawScene). One
+    // extra main repaint + re-capture, in the SAME task as that render, so the frozen backdrop shows
+    // the new stick + re-snaked pipe the instant it lands — noise on top of the 0.3-1.2s replan the
+    // spec already budgets for this.
+    if (_renderMainOnce()) _captureFreeze();
+    return res;
+  }
+
+  // ══════════════════ mount / unmount ══════════════════
+  function start() {
+    if (_active) return true;
+    var cpe = A() && A().cinemaPathEditor;
+    if (!cpe) { console.warn('§CPE_WALK_START_FAIL cinemaPathEditor not open'); return false; }
+    var vf = cpe._probeVF ? cpe._probeVF() : null;
+    if (!vf) { console.warn('§CPE_WALK_START_FAIL editor has no open path to walk'); return false; }
+    if (!vf.on) { cpe._vfToggle(); }   // §CPE_WALK_EDIT_V1 spec: "B must be on"
+    var vfCam = cpe.activePOVCamera();
+    if (!vfCam) { console.warn('§CPE_WALK_START_FAIL viewfinder camera unavailable after turning B on'); return false; }
+    var canvas = A().canvas;
+    if (!canvas) { console.warn('§CPE_WALK_START_FAIL no canvas'); return false; }
+
+    _cpe = cpe; _vfCam = vfCam; _canvas = canvas;
+    // Start facing where B already faces (whatever pose the eye/scrub last set), not a hard reset —
+    // continuing the walk from what the user was already looking at.
+    _vfCam.rotation.reorder && _vfCam.rotation.reorder('XYZ');
+    _yaw = _vfCam.rotation.y; _pitch = _vfCam.rotation.x;
+    _keys = { w: false, a: false, s: false, d: false };
+    _frame = 0; _snapCount = 0; _lastT = 0;
+
+    // Seam 2 — the ONLY caller of _wire()/_unwire() this feature needed.
+    cpe._walkMount();
+
+    _tm = _tmLock();
+
+    if (!_renderMainOnce()) console.warn('§CPE_WALK_FREEZE_SKIP renderer unavailable, walking without a frozen backdrop');
+    _captureFreeze();
+
+    _handlers = {
+      mousemove: _onMouseMove, lockchange: _onLockChange, keydown: _onKeyDown, keyup: _onKeyUp,
+      mousedown: _onMouseDown, click: _onCanvasClick
+    };
+    document.addEventListener('mousemove', _handlers.mousemove, true);
+    document.addEventListener('pointerlockchange', _handlers.lockchange, true);
+    window.addEventListener('keydown', _handlers.keydown, true);
+    window.addEventListener('keyup', _handlers.keyup, true);
+    canvas.addEventListener('mousedown', _handlers.mousedown, true);
+    canvas.addEventListener('click', _handlers.click, true);
+
+    _active = true;
+    _syncButton();
+    canvas.requestPointerLock();   // synchronous within this click's call stack — a real user gesture
+    _rafId = requestAnimationFrame(_tick);
+    console.log('§CPE_WALK_MOUNT_DONE pos=(' + _vfCam.position.x.toFixed(2) + ',' + _vfCam.position.y.toFixed(2) +
+      ',' + _vfCam.position.z.toFixed(2) + ') yaw=' + (_yaw * 180 / Math.PI).toFixed(1) +
+      'deg pitch=' + (_pitch * 180 / Math.PI).toFixed(1) + 'deg — WASD + mouse-look live, main view frozen, B renders alone');
+    return true;
+  }
+
+  function stop() {
+    if (!_active) return true;
+    _active = false;
+    if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
+    if (_handlers) {
+      document.removeEventListener('mousemove', _handlers.mousemove, true);
+      document.removeEventListener('pointerlockchange', _handlers.lockchange, true);
+      window.removeEventListener('keydown', _handlers.keydown, true);
+      window.removeEventListener('keyup', _handlers.keyup, true);
+      if (_canvas) {
+        _canvas.removeEventListener('mousedown', _handlers.mousedown, true);
+        _canvas.removeEventListener('click', _handlers.click, true);
+      }
+      _handlers = null;
+    }
+    if (document.pointerLockElement === _canvas && document.exitPointerLock) document.exitPointerLock();
+    _dropFreeze();
+    _tmUnlock(_tm); _tm = null;
+    // Seam 2's other half — restores the stick editor's own listeners.
+    if (_cpe && _cpe._walkUnmount) _cpe._walkUnmount();
+    console.log('§CPE_WALK_UNMOUNT_DONE snaps=' + _snapCount + ' frames=' + _frame +
+      ' — freeze dropped, TM restored, stick editor re-wired, one markDirty repaint queued');
+    _cpe = null; _vfCam = null; _canvas = null;
+    _syncButton();
+    return true;
+  }
+
+  function _syncButton() {
+    var btn = document.getElementById('cpe-walk-toggle');
+    if (!btn) return;
+    btn.style.color = _active ? '#4fc3f7' : '#888';
+    btn.style.borderColor = _active ? '#4fc3f7' : '#4a4f57';
+    btn.textContent = _active ? 'walking…' : 'walk';
+  }
+
+  function toggle() { return _active ? stop() : start(); }
+
+  window.CpeWalk = {
+    toggle: toggle,
+    isActive: function() { return _active; },
+    forceStop: stop,
+    // ══ witness hooks — read-only or exercising the REAL internal function, same precedent
+    // cinema_path_editor.js's own `_probe*`/`_*ForTest` hooks already use (e.g. `_setPin`,
+    // `_spawnStickForTest`) — never a re-implementation of the maths under test.
+    _snapForTest: function(pos, fwd) {
+      // Drives the exact code path `_doSnap()` uses, but with a SYNTHETIC pose/facing instead of
+      // reading `_vfCam` — deterministic, no live pointer-lock/rAF session required.
+      if (!_cpe) return null;
+      return _cpe._walkSnap(pos, fwd);
+    },
+    _poseForTest: function() { return _vfCam ? { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z, yaw: _yaw, pitch: _pitch } : null; },
+    _setPoseForTest: function(pos, yaw, pitch) {
+      if (!_vfCam) return false;
+      _vfCam.position.set(pos.x, pos.y, pos.z);
+      _yaw = yaw; _pitch = pitch;
+      _vfCam.rotation.set(pitch, yaw, 0);
+      _vfCam.updateMatrixWorld(true);
+      return true;
+    },
+    _tmLockState: function() { return _tm ? { locked: true, lockedBtn: _tm.lockedBtn ? _tm.lockedBtn.id : null, prevPointerEvents: _tm.prevPointerEvents } : { locked: false }; },
+    _freezeElId: function() { return _freezeEl ? _freezeEl.id : null; }
+  };
+  console.log('§CPE_WALK_MODULE_LOADED');
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v956';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v957';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -115,6 +115,7 @@ const PRECACHE_ASSETS = [
   'effects.js',
   'cinema_maxq.js',
   'cinema_path_editor.js',
+  'cpe_walk.js',
   'lib/mp4_mux.js',   // §MAXQ_MP4 — hand-rolled mp4 muxer; missing => MaxQ silently falls back to webm
   'input_registry.js',
   'scene.js',

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v957';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v958';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -825,6 +825,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=10" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cpe_walk.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_walk_edit.js
+++ b/witness_cpe_walk_edit.js
@@ -1,0 +1,241 @@
+// WITNESS — §CPE_WALK_EDIT_V1 (prompts/CPE_POV_WALK_PATHING.md).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-WALK-ISOLATE-1  before walk mode, a real pointerdown at a handle's own screen position IS
+//                      claimed by the stick editor (_state.drag becomes non-null) — sanity precondition.
+//   G-WALK-ISOLATE-2  once walk mode is mounted (_unwire), the SAME gesture at the SAME pixel is
+//                      NOT claimed (_state.drag stays null) — the isolation the spec's §CPE_WALK_SEAM
+//                      claims ("structurally CANNOT run ... off the DOM"), proven by dispatch, not read.
+//   G-WALK-ISOLATE-3  after unmount (_wire), the same gesture IS claimed again — handlers restored.
+//   G-WALK-SNAP-1     a synthetic snap at a KNOWN pos/facing, chosen far enough from the building that
+//                      the forward raycast is guaranteed to miss every mesh, produces a band whose
+//                      CENTRE is bit-identical to the walked pos and whose lookAt is bit-identical to
+//                      the spec's own fallback formula (pos + facing*10m) — computed independently in
+//                      this file, not read back from the module under test.
+//   G-WALK-SNAP-2     the snap actually inserted a band (`_stick:true`, bands.length +1) and ran the
+//                      real replan pipeline (replanMs present) — reuses §CPE_STICK/§CPE_AIM_PIN
+//                      machinery, not a stub.
+//   G-WALK-TMLOCK     mount dispatches a real pointerup at whichever TM button carries `.tm-active`
+//                      and sets the TM panel's pointer-events to none; unmount dispatches the same
+//                      pointerup again and restores the panel's prior pointer-events value exactly.
+//   G-WALK-TEARDOWN   closing the CPE editor (finish()) while walk mode is still mounted force-stops
+//                      it — CpeWalk.isActive() is false afterward, no dangling session.
+//   G-WALK-LOG        every claim above also has its own §-tagged console line (FUNDAMENTAL LAW:
+//                      numeric truth, not "it returned true").
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8512;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.CpeWalk && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+async function dispatchPointerDownUp(page, x, y) {
+  return page.evaluate((x, y) => {
+    const canvas = window.APP.canvas;
+    const r = canvas.getBoundingClientRect();
+    const down = new PointerEvent('pointerdown', { clientX: x, clientY: y, button: 0, bubbles: true, cancelable: true });
+    canvas.dispatchEvent(down);
+    const dragAfterDown = window.APP.cinemaPathEditor._probeDrag();
+    const up = new PointerEvent('pointerup', { clientX: x, clientY: y, button: 0, bubbles: true, cancelable: true });
+    window.dispatchEvent(up);
+    return dragAfterDown;
+  }, x, y);
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page, logs } = await openEditor(browser, BLD);
+
+  // ── setup: a handle to grab, and the current path/bands to plan against ──
+  const setup = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const handles = cpe._probeHandles();
+    const h = handles && handles.find(h => h.px != null && h.py != null);
+    const ov = cpe._probeOverride();
+    const vf = cpe._probeVF();
+    return h && ov && vf ? { hx: h.px, hy: h.py, hb: h.b, nBands: ov.bands.length, mainPose: vf.mainPose } : null;
+  });
+  if (!setup) {
+    P('G-WALK-0 a grabbable handle + open path is available (precondition)', false, 'freshly-opened editor had no on-screen handle — inconclusive');
+    await page.close();
+    return checks;
+  }
+
+  // ══ G-WALK-ISOLATE-1: pre-walk, the gesture IS claimed ══
+  const claimedBefore = await dispatchPointerDownUp(page, setup.hx, setup.hy);
+  P('G-WALK-ISOLATE-1 pre-walk pointerdown at a handle is claimed by the stick editor (_state.drag set)',
+    claimedBefore === true, `_probeDrag()=${claimedBefore}`);
+
+  // ══ mount walk mode ══
+  const mark1 = logs.length;
+  const mounted = await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(150);
+  const win1 = logs.slice(mark1);
+  const activeAfterMount = await page.evaluate(() => window.CpeWalk.isActive());
+  P('G-WALK-MOUNT toggle() mounted (isActive true) and logged §CPE_WALK_MOUNT/_DONE',
+    mounted === true && activeAfterMount === true &&
+    win1.some(l => l.startsWith('§CPE_WALK_MOUNT ')) && win1.some(l => l.startsWith('§CPE_WALK_MOUNT_DONE')),
+    `toggle()=${mounted} isActive=${activeAfterMount} logged=[${win1.filter(l => l.startsWith('§CPE_WALK')).join(' | ')}]`);
+
+  // ══ G-WALK-FREEZE: the overlay exists, sized to the canvas, while mounted ══
+  const freezeInfo = await page.evaluate(() => {
+    const el = document.getElementById('cpe-walk-freeze');
+    const canvas = window.APP.canvas;
+    const cr = canvas.getBoundingClientRect();
+    return el ? { id: el.id, w: el.width, h: el.height, canvasW: Math.round(cr.width), canvasH: Math.round(cr.height) } : null;
+  });
+  P('G-WALK-FREEZE overlay canvas exists while mounted, sized to the WebGL canvas (main view is covered)',
+    !!freezeInfo && freezeInfo.w === freezeInfo.canvasW && freezeInfo.h === freezeInfo.canvasH,
+    `freeze=${JSON.stringify(freezeInfo)} logged=[${win1.filter(l => l.startsWith('§CPE_WALK_FREEZE')).join(' | ')}]`);
+
+  // ══ G-WALK-ISOLATE-2: mounted, the SAME gesture is NOT claimed ══
+  const claimedDuring = await dispatchPointerDownUp(page, setup.hx, setup.hy);
+  P('G-WALK-ISOLATE-2 mounted: the SAME pointerdown/up is NOT claimed (_unwire actually removed the listeners)',
+    claimedDuring === false || claimedDuring === null, `_probeDrag()=${claimedDuring}`);
+
+  // ══ G-WALK-SNAP-1/2: synthetic snap far from the building — guaranteed raycast miss ══
+  const snapPos = { x: setup.mainPose.x + 500, y: setup.mainPose.y + 500, z: setup.mainPose.z };
+  const snapFwd = { x: 1, y: 0, z: 0 };
+  const mark2 = logs.length;
+  const snapRes = await page.evaluate((pos, fwd) => window.CpeWalk._snapForTest(pos, fwd), snapPos, snapFwd);
+  await sleep(50);
+  const win2 = logs.slice(mark2);
+  const ovAfterSnap = await page.evaluate(() => window.APP.cinemaPathEditor._probeOverride());
+
+  const wantLookAt = { x: snapPos.x + snapFwd.x * 10, y: snapPos.y + snapFwd.y * 10, z: snapPos.z + snapFwd.z * 10 };
+  const centreOk = !!snapRes && snapRes.centre.x === snapPos.x && snapRes.centre.y === snapPos.y && snapRes.centre.z === snapPos.z;
+  const lookAtOk = !!snapRes && snapRes.lookAt &&
+    Math.abs(snapRes.lookAt.x - wantLookAt.x) < 1e-9 && Math.abs(snapRes.lookAt.y - wantLookAt.y) < 1e-9 && Math.abs(snapRes.lookAt.z - wantLookAt.z) < 1e-9;
+  P('G-WALK-SNAP-1a band centre is bit-identical to the walked position (not a curve sample)',
+    centreOk, `centre=${snapRes ? JSON.stringify(snapRes.centre) : 'null'} want=${JSON.stringify(snapPos)}`);
+  P('G-WALK-SNAP-1b lookAt matches the spec\'s own fallback formula pos+facing*10m (raycast guaranteed to miss, 500m out)',
+    lookAtOk, `lookAt=${snapRes ? JSON.stringify(snapRes.lookAt) : 'null'} want=${JSON.stringify(wantLookAt)}`);
+  const sOk = !!snapRes && typeof snapRes.s === 'number' && snapRes.s >= 0 && snapRes.s <= 1;
+  P('G-WALK-SNAP-1c insertion fraction s is a valid [0,1] arc-fraction', sOk, `s=${snapRes ? snapRes.s : 'null'}`);
+  const bandOk = !!ovAfterSnap && ovAfterSnap.bands.length === setup.nBands + 1 &&
+    ovAfterSnap.bands[snapRes.bandIndex] && ovAfterSnap.bands[snapRes.bandIndex]._stick === true;
+  P('G-WALK-SNAP-2a a real band was inserted (_stick:true, bands.length +1) — reuses §CPE_STICK, not a stub',
+    bandOk, `nBandsBefore=${setup.nBands} nBandsAfter=${ovAfterSnap ? ovAfterSnap.bands.length : 'null'} bandIndex=${snapRes ? snapRes.bandIndex : 'null'} _stick=${ovAfterSnap && snapRes ? ovAfterSnap.bands[snapRes.bandIndex]._stick : 'null'}`);
+  P('G-WALK-SNAP-2b the real replan pipeline ran (replanMs present, §CPE_WALK_SNAP logged)',
+    !!snapRes && typeof snapRes.replanMs === 'number' && win2.some(l => l.startsWith('§CPE_WALK_SNAP pos=')),
+    `replanMs=${snapRes ? snapRes.replanMs : 'null'} logged=${win2.filter(l => l.startsWith('§CPE_WALK_SNAP')).join(' | ')}`);
+
+  // Reset to a known unmounted baseline (still mounted from the earlier snap test).
+  await page.evaluate(() => { if (window.CpeWalk.isActive()) window.CpeWalk.toggle(); });
+  await sleep(100);
+
+  // ══ G-WALK-TMLOCK — stub panel/button so this gate proves OUR dispatch+lock code, independent
+  // of whether real Time Machine happens to be activated in this session (out of scope: we do not
+  // edit time_machine.js, so its own playback state machine is not what this gate is about). ══
+  await page.evaluate(() => {
+    let panel = document.getElementById('time-machine-panel');
+    if (panel) panel.remove();
+    panel = document.createElement('div');
+    panel.id = 'time-machine-panel';
+    panel.style.pointerEvents = 'auto';
+    const fwd = document.createElement('button');
+    fwd.id = 'tm-fwd-btn';
+    fwd.classList.add('tm-active');
+    let ups = 0;
+    fwd.addEventListener('pointerup', () => { ups++; });
+    panel.appendChild(fwd);
+    document.body.appendChild(panel);
+    window.__tmUps = () => ups;
+    return true;
+  });
+  await page.evaluate(() => window.CpeWalk.toggle());   // fresh mount, observes the stub panel
+  await sleep(150);
+  const tmLockState = await page.evaluate(() => ({
+    lockState: window.CpeWalk._tmLockState(),
+    pointerEvents: document.getElementById('time-machine-panel').style.pointerEvents,
+    ups: window.__tmUps()
+  }));
+  P('G-WALK-TMLOCK-1 mount dispatched a real pointerup at the .tm-active button and locked the panel',
+    tmLockState.lockState.locked === true && tmLockState.lockState.lockedBtn === 'tm-fwd-btn' &&
+    tmLockState.pointerEvents === 'none' && tmLockState.ups === 1,
+    `state=${JSON.stringify(tmLockState.lockState)} pointerEvents=${tmLockState.pointerEvents} ups=${tmLockState.ups}`);
+
+  const beforeUnmountUps = tmLockState.ups;
+  await page.evaluate(() => window.CpeWalk.toggle());   // unmount
+  await sleep(150);
+  const tmAfterUnmount = await page.evaluate(() => ({
+    pointerEvents: document.getElementById('time-machine-panel').style.pointerEvents,
+    ups: window.__tmUps()
+  }));
+  P('G-WALK-TMLOCK-2 unmount dispatched the resume pointerup again and restored pointer-events to its prior value',
+    tmAfterUnmount.ups === beforeUnmountUps + 1 && tmAfterUnmount.pointerEvents === 'auto',
+    `ups ${beforeUnmountUps}->${tmAfterUnmount.ups} pointerEvents=${tmAfterUnmount.pointerEvents}`);
+
+  // ══ G-WALK-ISOLATE-3: after unmount, the ORIGINAL stick-editor gesture works again ══
+  const claimedAfter = await dispatchPointerDownUp(page, setup.hx, setup.hy);
+  P('G-WALK-ISOLATE-3 post-unmount: the pointerdown/up gesture is claimed again (_wire restored the listeners)',
+    claimedAfter === true, `_probeDrag()=${claimedAfter}`);
+  const freezeGoneAfterUnmount = await page.evaluate(() => document.getElementById('cpe-walk-freeze'));
+  P('G-WALK-FREEZE-DROP the overlay is removed from the DOM after unmount',
+    freezeGoneAfterUnmount === null, `element=${freezeGoneAfterUnmount}`);
+
+  // ══ G-WALK-TEARDOWN: mount again, then close the editor via Cancel — finish() must force-stop it ══
+  await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(100);
+  const activeBeforeClose = await page.evaluate(() => window.CpeWalk.isActive());
+  await page.evaluate(() => document.getElementById('cpe-cancel').click());
+  await sleep(200);
+  const activeAfterClose = await page.evaluate(() => window.CpeWalk.isActive());
+  P('G-WALK-TEARDOWN closing the editor (Cancel -> finish()) force-stops an active walk session',
+    activeBeforeClose === true && activeAfterClose === false,
+    `activeBeforeClose=${activeBeforeClose} activeAfterClose=${activeAfterClose}`);
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    try {
+      const checks = await gates(browser, BLD);
+      checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+      summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    } catch (e) {
+      // Witness-harness infra failure (puppeteer/browser flakiness), not a product gate — do not let
+      // it kill the rest of the run or masquerade as a code FAIL.
+      console.log(`  INFRA-ERROR ${BLD}: ${e.message}`);
+      allPass = false;
+      summary.push({ BLD, pass: false, n: 0, t: 0, infra: true });
+    }
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Implements `prompts/CPE_POV_WALK_PATHING.md` §CPE_WALK_EDIT_V1: walk B (the CPE viewfinder) with pointer-lock mouse-look + WASD, press Enter/click to snap a stick at the walked pose facing where you were looking. Reuses the existing §CPE_STICK insertion and §CPE_AIM_PIN `lookAt` machinery verbatim — no second path truth, no continuous pose recording (that idea was explicitly retired by the same user ruling the spec documents).
- All new code in `viewer/cpe_walk.js`. `cinema_path_editor.js` touched only at the four named seams: the walk-toggle button in `_buildPanel()`, `_walkMount()`/`_walkUnmount()` (the only callers of the private `_wire()`/`_unwire()`), `_walkSnap()` (the one new maths piece), and one teardown guard at the top of `finish()`. Zero edits to `effects.js`, `time_machine.js`, `schedule_*.js`, `main.js`.
- §CPE_WALK_CANVAS_FREEZE ("render only B while walking") and §CPE_WALK_TM_LOCK are both achieved without touching `main.js`/`time_machine.js` — see the file-header comment in `cpe_walk.js` for the exact mechanism.

## Test plan
- [x] `node --check` on all touched/new files
- [x] `witness_cpe_walk_edit.js` — 14 gates × 2 buildings (Duplex, SampleHouse) = 28/28 PASS, run against a local `python3 -m http.server` (whitebox §-log assertions, real dispatched DOM events, no screenshots)
- [x] Verified no `§CPE_SEAM_CONTINUOUS seamGapDeg` landmine surfaced in either run

🤖 Generated with [Claude Code](https://claude.com/claude-code)