### PR TITLE
feat(4d): §GANTT_LOCK_INTEGRITY — lock-back verifies physical integrity, refuses on breach

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -232,8 +232,16 @@
           // each other, an unsatisfiable cycle for the repair loop; an embedding slab still tops me)
           // …and a pool member never hangs from what it sits BELOW of (S resting on el is not el's
           // carrier — the reverse below edge already orders the pair; same rule as geoGate's).
+          // …and a WALL never hangs from a promoted slab IT BEARS (wallGate's own relation, reversed:
+          // the slab waits for the wall whose top reaches its base — measured livelock on Duplex,
+          // §DEQ_REPAIR 16 sweeps/379 shifts, seq-5 upper walls vs the load-path roof at bz 6.00).
+          // A fan/duct in the same geometric relation keeps its hang: it is not wall-pool material,
+          // and class-scoped carrier pools are this module's established, measured practice
+          // (§4D_ROOF_LOAD_PATH attempt-1: class-blind widening = 3421 false positives).
           if (S.base_z >= el.top_z - GAP && S.base_z <= el.top_z + GAP && S.top_z > el.top_z + EPS &&
               !(elPool && el.base_z < S.base_z - EPS) &&
+              !(S.promoted && el.cls && el.cls.indexOf('IfcWall') === 0 &&
+                el.base_z < S.base_z - EPS && el.top_z >= S.base_z - GAP) &&
               S.end > g && overlap(S, el)) g = S.end; } }
       return g;
     }
@@ -313,7 +321,8 @@
       // is acyclic for any real geometry; §SUPPORT_CYCLE below reports whatever remains, never hides it.
       for (nc = 0; nc < cands.length; nc++) { si = cands[nc]; S = elements[si];
         if (edgeBelow(S, E) || (!isPoolE && edgeContained(S, E)) ||
-            (hangs[t] && edgeCarrier(S, E) && !(isPoolE && E.base_z < S.base_z - EPS))) {
+            (hangs[t] && edgeCarrier(S, E) && !(isPoolE && E.base_z < S.base_z - EPS) &&
+             !(isPromotedSlab(S) && E.cls && E.cls.indexOf('IfcWall') === 0 && edgeBearing(E, S)))) {
           (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; } }
       if (isPromotedSlab(E)) {                                       // wallGate's relation
         _gen++;
@@ -478,7 +487,10 @@
   // roof case §SUPPORT_CHECK was blind to by construction. The hang check is scoped exactly like the
   // scheduler's hangGate (no bearing-below only), which is what keeps attempt-1's mutual-wait false
   // positives out: a beam bearing on its columns is never audited against the slab resting on it.
-  function auditFloating(elements, sched, classFilter) {
+  // collectGuids (optional, §GANTT_LOCK_INTEGRITY): an array to receive the offending GUIDs so a
+  // caller can NAME what floats (the lock-back "Integrity Breach" flag), not just count it. The
+  // count return is unchanged for every existing caller.
+  function auditFloating(elements, sched, classFilter, collectGuids) {
     var structGrid = {}, wallGrid = {}, i, c, cs, k, arr, S;
     for (i = 0; i < elements.length; i++) { var e = elements[i];
       if (e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4)) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (structGrid[cs[c]] = structGrid[cs[c]] || []).push(e); }
@@ -499,14 +511,18 @@
         // §GEOMETRIC_SUPPORT_ORDER: a pool member (promoted slab) never hangs from what it sits
         // BELOW of — mirrors the scheduler's hangGate pool rule, so audit and scheduler agree
         var tPool = T.cls === 'IfcSlab' && T.seq > 4;
+        var tWall = T.cls.indexOf('IfcWall') === 0;
         var seenH = {};
         for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
           for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenH[S.guid] || S.guid === T.guid) continue; seenH[S.guid] = 1;
             if (S.base_z >= T.top_z - GAP && S.base_z <= T.top_z + GAP && S.top_z > T.top_z + EPS &&
-                !(tPool && T.base_z < S.base_z - EPS) && overlap(S, T)) {
+                !(tPool && T.base_z < S.base_z - EPS) &&
+                !(tWall && S.cls === 'IfcSlab' && S.seq > 4 &&
+                  T.base_z < S.base_z - EPS && T.top_z >= S.base_z - GAP) &&
+                overlap(S, T)) {
               var eh = sched[S.guid].end; if (eh > se) se = eh; } } }
       }
-      if (se > 0 && sched[T.guid].start < se - 1) v++;
+      if (se > 0 && sched[T.guid].start < se - 1) { v++; if (collectGuids) collectGuids.push(T.guid); }
     }
     return v;
   }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v957';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v958';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -91,7 +91,10 @@ const BUILDING = process.argv[2] || 'Duplex';
     window: { ScheduleAuthor: ScheduleAuthor, performance: null },
     A: function () { return { db: db }; },
     document: { getElementById: function () { return null; } },
-    invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {}
+    invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {},
+    // §GANTT_RETIME_RESYNC (PR #1240) added this call to every retime commit path; a cache/index
+    // rebuild is a no-op here (the witness asserts on the DB rows, not the render caches)
+    _tmResyncAfterRetime: function () {}
   };
   vm.createContext(sandbox);
   vm.runInContext(sliced + '\nglobalThis.__ops = _ops = loadOps(); ' +

--- a/viewer/tests/witness_gantt_lock_integrity.js
+++ b/viewer/tests/witness_gantt_lock_integrity.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// witness_gantt_lock_integrity.js — §GANTT_LOCK_INTEGRITY (2026-08-07, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md). Proves the 🔓→🔒 lock-back transition VERIFIES physical
+// integrity of the edited schedule and REFUSES to lock while anything floats — a user must Undo
+// (or fix by further edits) before locking completes. Today locking just flips a flag: whatever
+// the user dragged is accepted as-is, no re-check — a drag that strands an element mid-air locks
+// in silently, precisely the "drag hides a real defect" failure the C-band constraint rules exist
+// to prevent.
+//
+// Names the issues it tests:
+//   G-LI-1  auditFloating names offenders: optional collector arg fills the offending GUIDs
+//           (count return unchanged for every existing caller). RED on main: arg ignored.
+//   G-LI-2  verifyGanttIntegrity() (sliced from the SHIPPED time_machine.js, never reimplemented —
+//           repo convention, witness_gantt_edit_undo.js): on a REAL building (Duplex) with a REAL
+//           computeSchedule-derived op set — clean state verifies ok; a simulated bad drag (element
+//           moved to start before its support finishes) is caught with the offender named; restoring
+//           the edit (what ↺ Undo does) verifies clean again. RED on main: function absent.
+//   G-LI-3  lock-gate wiring (static source, same convention as witness_tm_panel_resize_h): the
+//           lock handler verifies on the Editing→Locked transition ONLY (unlock never gated),
+//           REFUSES the flip on breach (stays editable), shows an "Integrity Breach" message
+//           naming the Undo path, logs §GANTT_LOCK_BREACH / §GANTT_LOCK_VERIFY. RED on main.
+//   G-LI-4  cost (spec open-question 3): auditFloating over Hospital-scale (63,415 elements) —
+//           measured, printed, sane (<10s); the handler paints "Verifying…" before running.
+//
+// Read the §LI log lines, not exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { execSync } = require('child_process');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+/* ── G-LI-1: auditFloating collector names the offender ────────────────────────────────────── */
+// slab bears wall; wall scheduled to START before the slab it stands on FINISHES = 1 floating.
+const synEls = [
+  { guid: 'SLAB', cls: 'IfcSlab', seq: 4, storey: 'L1', x0: 0, x1: 10, y0: 0, y1: 10, base_z: 0, top_z: 0.3 },
+  { guid: 'WALL', cls: 'IfcWallStandardCase', seq: 6, storey: 'L1', x0: 0, x1: 10, y0: 0, y1: 0.2, base_z: 0.3, top_z: 3 },
+];
+const synSched = { SLAB: { start: 0, end: 1000000 }, WALL: { start: 100, end: 2000000 } };
+const got = [];
+const synN = ScheduleGate.auditFloating(synEls, synSched, null, got);
+assert(synN === 1, 'G-LI-1a count unchanged: floating=' + synN + ' (wall starts at 100, its slab ends at 1000000)');
+assert(got.length === 1 && got[0] === 'WALL', 'G-LI-1b collector names the offender: got=[' + got.join(',') + '] (RED on main: arg ignored, empty)');
+
+/* ── G-LI-3: lock-gate wiring, static source ───────────────────────────────────────────────── */
+(function () {
+  let handler = '';
+  const anchor = tmSrc.indexOf("lockBtn.addEventListener('pointerup'");
+  if (anchor >= 0) {
+    let depth = 0, i = tmSrc.indexOf('{', anchor), start = i, seenOpen = false;
+    for (; i < tmSrc.length; i++) {
+      if (tmSrc[i] === '{') { depth++; seenOpen = true; }
+      else if (tmSrc[i] === '}') { depth--; if (seenOpen && depth === 0) { handler = tmSrc.slice(start, i + 1); break; } }
+    }
+  }
+  assert(handler.length > 0, 'G-LI-3a lock handler found');
+  assert(handler.indexOf('verifyGanttIntegrity') >= 0, 'G-LI-3b handler calls verifyGanttIntegrity (RED on main: no verification at all)');
+  assert(handler.indexOf('Integrity Breach') >= 0, 'G-LI-3c breach message shown ("Integrity Breach")');
+  assert(/Undo/.test(handler), 'G-LI-3d breach message names the Undo path');
+  assert(handler.indexOf('§GANTT_LOCK_BREACH') >= 0, 'G-LI-3e refusal is logged (§GANTT_LOCK_BREACH), silence is not a refusal');
+  assert(handler.indexOf('§GANTT_LOCK_VERIFY') >= 0, 'G-LI-3f clean lock is logged (§GANTT_LOCK_VERIFY, with ms)');
+  assert(handler.indexOf('Verifying') >= 0, 'G-LI-3g paints a "Verifying…" state before the audit (cost honesty, spec Q3)');
+  // the refusal path must RETURN before _ganttEditable is flipped false — i.e. inside the handler,
+  // the breach branch keeps editing on. Structural: '_ganttEditable = false' appears only AFTER the
+  // verify call in source order, and a `return` sits between the breach log and it.
+  const vIdx = handler.indexOf('verifyGanttIntegrity');
+  const lockOff = handler.indexOf('_ganttEditable = false');
+  assert(lockOff > vIdx, 'G-LI-3h lock (editable=false) only after verification in the Editing→Locked branch');
+  const breachIdx = handler.indexOf('§GANTT_LOCK_BREACH');
+  const retIdx = handler.indexOf('return', breachIdx);
+  assert(breachIdx >= 0 && retIdx > breachIdx && (lockOff < 0 || retIdx < lockOff),
+    'G-LI-3i breach branch returns (refuses) before the flag ever flips');
+  // unlock direction (Locked→Editing) is NEVER gated — verify must be inside the _ganttEditable
+  // (currently-editing) branch only.
+  assert(/if\s*\(\s*_ganttEditable\s*\)[\s\S]*verifyGanttIntegrity/.test(handler),
+    'G-LI-3j verification scoped to the Editing→Locked transition only (unlock never gated, spec Q2)');
+})();
+
+/* ── G-LI-2: verify core, sliced + driven on real Duplex ───────────────────────────────────── */
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+
+(async () => {
+  let sliced;
+  try {
+    sliced = ['_buildXrayElements', 'verifyGanttIntegrity'].map(n => sliceFn(tmSrc, n)).join('\n');
+  } catch (e) {
+    assert(false, 'G-LI-2 slice failed (RED on main: ' + e.message + ')');
+    finish();
+    return;
+  }
+  const dbPath = path.join(BLD_DIR, 'Duplex_extracted.db');
+  if (!fs.existsSync(dbPath)) { console.log('§LI_SKIP Duplex fixture missing at ' + dbPath); finish(); return; }
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+
+  const sandbox = {
+    console: console,
+    performance: { now: () => Date.now() },
+    ScheduleGate: ScheduleGate,
+    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || [] },
+    A: function () { return { db: db }; },
+    _ops: [],
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nthis.__verify = verifyGanttIntegrity; this.__bxe = _buildXrayElements;', sandbox);
+
+  // Seed _ops from the REAL scheduler on the REAL geometry — the clean, engine-produced state.
+  const els = sandbox.__bxe();
+  assert(els && els.length > 500, 'G-LI-2a _buildXrayElements yields real geometry (n=' + (els ? els.length : 0) + ')');
+  const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+  geoEls.forEach(e => { e.resource = e.cls; e.installSecs = 120; });
+  const sched = ScheduleGate.computeSchedule(geoEls, 0, 1);
+  sandbox._ops = geoEls.map(e => ({ timestamp: sched[e.guid].start, end_ts: sched[e.guid].end, output_guid: e.guid, input_guids: [e.guid] }));
+
+  const clean = sandbox.__verify();
+  assert(clean && clean.ok === true && clean.floating === 0,
+    'G-LI-2b clean engine schedule verifies ok (floating=' + (clean && clean.floating) + '/' + (clean && clean.total) + ' ms=' + (clean && clean.ms) + ')');
+
+  // Simulate the bad drag: take a floating-capable element (has a real bearing support that ends
+  // late) and move its op to start at time 0 — before its support finishes. Find one empirically:
+  // latest-starting gated elements first, stop at the first whose early-move breaks the audit.
+  const byLate = sandbox._ops.slice().sort((a, b) => b.timestamp - a.timestamp);
+  let brokeGuid = null, saved = null, breach = null;
+  for (let i = 0; i < Math.min(byLate.length, 200); i++) {
+    const op = byLate[i];
+    saved = { op: op, t: op.timestamp, e: op.end_ts };
+    const dur = op.end_ts - op.timestamp;
+    op.timestamp = 0; op.end_ts = dur;
+    breach = sandbox.__verify();
+    if (!breach.ok) { brokeGuid = op.output_guid; break; }
+    op.timestamp = saved.t; op.end_ts = saved.e; saved = null;
+  }
+  assert(brokeGuid !== null, 'G-LI-2c a real bad drag is constructible on Duplex (moved ' + brokeGuid + ' to t=0)');
+  assert(breach && breach.ok === false && breach.floating > 0,
+    'G-LI-2d breach detected on lock-back verify (floating=' + (breach && breach.floating) + ')');
+  assert(breach && breach.guids && breach.guids.indexOf(brokeGuid) >= 0,
+    'G-LI-2e breach NAMES the dragged element (guids sample=[' + (breach ? breach.guids.slice(0, 3).join(',') : '') + '])');
+
+  // Undo (restore the exact pre-edit values, what undoLastGanttEdit does) → verifies clean again.
+  if (saved) { saved.op.timestamp = saved.t; saved.op.end_ts = saved.e; }
+  const after = sandbox.__verify();
+  assert(after.ok === true && after.floating === 0, 'G-LI-2f after Undo the lock verifies ok again (floating=' + after.floating + ')');
+  db.close();
+
+  /* ── G-LI-4: audit cost at Hospital scale (spec open-question 3, measured not guessed) ────── */
+  const HOSP = '/home/red1/bim-compiler/deploy/buildings/Hospital_extracted.db';
+  if (fs.existsSync(HOSP)) {
+    const SR = rulesJson.SEQUENCE_RULES, SDEF = rulesJson.SEQUENCE_DEFAULT || { sequence: 6 };
+    const matchRule = c => { let b = null, l = 0; for (const k in SR) if (c.indexOf(k) >= 0 && k.length > l) { b = k; l = k.length; } return b ? SR[b] : SDEF; };
+    const csv = execSync(
+      `sqlite3 -noheader -csv "${HOSP}" "SELECT m.guid,m.ifc_class,COALESCE(t.center_x,0),COALESCE(t.center_y,0),` +
+      `COALESCE(t.center_z,0),COALESCE(t.bbox_x,0),COALESCE(t.bbox_y,0),COALESCE(t.bbox_z,0),COALESCE(m.storey,'_UNKNOWN') ` +
+      `FROM elements_meta m LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class!='IfcOpeningElement';"`,
+      { maxBuffer: 1 << 28 }).toString().trim().split('\n');
+    const hEls = csv.map(line => {
+      const a = line.split(','); if (a.length < 8) return null;
+      const cls = a[1], cx = +a[2], cy = +a[3], cz = +a[4], bx = +a[5], by = +a[6], bz = +a[7], r = matchRule(cls);
+      return { guid: a[0], cls, seq: r.sequence, resource: r.resource || cls, storey: (a[8] || '_UNKNOWN').replace(/"/g, ''),
+               installSecs: 120, x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2, base_z: cz - bz / 2, top_z: cz + bz / 2 };
+    }).filter(Boolean);
+    const hSched = ScheduleGate.computeSchedule(hEls, 0, 1);
+    const at0 = Date.now();
+    const hFloat = ScheduleGate.auditFloating(hEls, hSched, null, []);
+    const atMs = Date.now() - at0;
+    console.log('§LI_COST auditFloating n=' + hEls.length + ' ms=' + atMs + ' floating=' + hFloat);
+    assert(atMs < 10000, 'G-LI-4 Hospital-scale lock-back audit measured: ' + atMs + 'ms for ' + hEls.length + ' elements (<10s sanity bar)');
+  } else console.log('§LI_SKIP Hospital fixture missing — G-LI-4 cost not measured');
+
+  finish();
+})();
+
+function finish() {
+  console.log('§GANTT_LOCK_INTEGRITY pass=' + pass + ' fail=' + fail);
+  if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+  console.log('PASS — lock-back verifies physical integrity, refuses on breach, names offenders, clears after Undo');
+}

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3600,6 +3600,43 @@
     console.log('§XRAY_CACHE_BUILD total_ms=' + (performance.now() - _xt0).toFixed(1));
   }
 
+  // §GANTT_LOCK_INTEGRITY (2026-08-07, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) — the
+  // lock-back verification core. Pure READ: rebuilds geometry via _buildXrayElements() (works on
+  // the §GANTT_CACHE_HIT path too) and audits the CURRENT op times — the post-edit truth, whatever
+  // the user dragged — with ScheduleGate.auditFloating, ALL classes, no filter (the §DEQ_V1 bar).
+  // The check IS auditFloating: when §GEOMETRIC_SUPPORT_ORDER-class upgrades land in the gate
+  // module, this hook strengthens automatically, no separate integration.
+  // Returns { ok, floating, total, guids, ms, skipped? }. A state with nothing auditable (no
+  // geometry / gate not loaded) verifies ok WITH the skip named — logged by the caller, never a
+  // silent false pass.
+  function verifyGanttIntegrity() {
+    var t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    function ms() { return Math.round(((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - t0); }
+    if (typeof ScheduleGate === 'undefined' || !ScheduleGate.auditFloating)
+      return { ok: true, skipped: 'no_schedule_gate', floating: 0, total: 0, guids: [], ms: ms() };
+    var els = _buildXrayElements();
+    if (!els || !els.length) return { ok: true, skipped: 'no_geometry', floating: 0, total: 0, guids: [], ms: ms() };
+    var sched = {};
+    for (var i = 0; i < _ops.length; i++) {
+      var o = _ops[i];
+      var g = o.output_guid || (o.input_guids && o.input_guids.length && o.input_guids[0]);
+      if (g) sched[g] = { start: o.timestamp, end: o.end_ts || o.timestamp };
+    }
+    // audit only elements that are scheduled AND have real geometry — §4D_NOGEO parked elements
+    // (zero bbox at origin) can neither bear nor hang and sit at project end by design
+    var audited = [];
+    for (var j = 0; j < els.length; j++) {
+      var e = els[j];
+      if (!sched[e.guid]) continue;
+      if (e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z) continue;
+      audited.push(e);
+    }
+    if (!audited.length) return { ok: true, skipped: 'no_scheduled_geometry', floating: 0, total: 0, guids: [], ms: ms() };
+    var guids = [];
+    var n = ScheduleGate.auditFloating(audited, sched, null, guids);
+    return { ok: n === 0, floating: n, total: audited.length, guids: guids, ms: ms() };
+  }
+
   // ══════════════════════════════════════════════════════════════════
   // Z-DRIVEN CONSTRUCTION SCHEDULE
   // ══════════════════════════════════════════════════════════════════
@@ -5901,26 +5938,57 @@
         lockBtn._wired = true;
         lockBtn.addEventListener('pointerup', function (e) {
           e.stopPropagation();
-          _ganttEditable = !_ganttEditable;
-          lockBtn.innerHTML = _ganttEditable ? '&#x1F513; Editing' : '&#x1F512; Locked';
-          lockBtn.title = _ganttEditable
-            ? 'Editing: drag to move/resize, drag onto another bar to link, double-click for typed edit. Click to lock.'
-            : 'Locked: drag/resize/link disabled, timeline still scrubs live. Click to unlock editing.';
-          console.log('§GANTT_EDIT_LOCK editable=' + _ganttEditable);
-          // §TM_PANEL_RESIZE auto-expand (user ruling 2026-08-05): editing needs elbow room (the
-          // props panel alone is ~330px wide) — widen automatically rather than making the user find
-          // the new resize grip every time. Only expands if narrower than the edit width already (a
-          // user who manually widened past it keeps their own choice); restores to whatever width was
-          // active the moment editing turned on, so a manual resize DURING editing is not fought.
-          if (_panel) {
-            var curW = _panel.getBoundingClientRect().width;
-            if (_ganttEditable) {
-              _panelWPreEdit = curW;
-              if (curW < PANEL_W_EDIT) { _panelW = PANEL_W_EDIT; _panel.style.width = PANEL_W_EDIT + 'px'; }
-            } else if (_panelWPreEdit != null) {
-              _panelW = _panelWPreEdit; _panel.style.width = _panelWPreEdit + 'px'; _panelWPreEdit = null;
+          function applyLockUi() {
+            lockBtn.innerHTML = _ganttEditable ? '&#x1F513; Editing' : '&#x1F512; Locked';
+            lockBtn.title = _ganttEditable
+              ? 'Editing: drag to move/resize, drag onto another bar to link, double-click for typed edit. Click to lock.'
+              : 'Locked: drag/resize/link disabled, timeline still scrubs live. Click to unlock editing.';
+            console.log('§GANTT_EDIT_LOCK editable=' + _ganttEditable);
+            // §TM_PANEL_RESIZE auto-expand (user ruling 2026-08-05): editing needs elbow room (the
+            // props panel alone is ~330px wide) — widen automatically rather than making the user find
+            // the new resize grip every time. Only expands if narrower than the edit width already (a
+            // user who manually widened past it keeps their own choice); restores to whatever width was
+            // active the moment editing turned on, so a manual resize DURING editing is not fought.
+            if (_panel) {
+              var curW = _panel.getBoundingClientRect().width;
+              if (_ganttEditable) {
+                _panelWPreEdit = curW;
+                if (curW < PANEL_W_EDIT) { _panelW = PANEL_W_EDIT; _panel.style.width = PANEL_W_EDIT + 'px'; }
+              } else if (_panelWPreEdit != null) {
+                _panelW = _panelWPreEdit; _panel.style.width = _panelWPreEdit + 'px'; _panelWPreEdit = null;
+              }
             }
           }
+          if (_ganttEditable) {
+            // §GANTT_LOCK_INTEGRITY: 🔓→🔒 verifies the EDITED schedule still holds physical
+            // integrity before the lock is accepted. Breach ⇒ the lock is REFUSED (stays Editing),
+            // the flag names the floaters, and ↺ Undo (or further corrective edits) is the way out —
+            // the gate is stateless, every lock attempt re-audits, so undo depth vs breach depth
+            // (spec open-question 1) needs no edit-history tracing. Only THIS transition is gated
+            // (spec Q2); unlock below never verifies.
+            var lm = document.getElementById('tm-gantt-lockmsg');
+            if (lm) { lm.textContent = 'Verifying integrity…'; lm.style.color = ''; }
+            setTimeout(function () {   // let the "Verifying…" state paint before the audit runs (spec Q3)
+              var v = verifyGanttIntegrity();
+              if (!v.ok) {
+                console.log('§GANTT_LOCK_BREACH floating=' + v.floating + '/' + v.total + ' ms=' + v.ms +
+                  ' sample=[' + v.guids.slice(0, 5).join(',') + '] (lock refused — Undo or fix, then lock again)');
+                if (lm) {
+                  lm.textContent = '⚠ Integrity Breach: ' + v.floating + ' floating — press ↺ Undo edit (or fix), then lock again';
+                  lm.style.color = '#f66';
+                }
+                return;   // REFUSED — _ganttEditable stays true, nothing hidden
+              }
+              console.log('§GANTT_LOCK_VERIFY ok floating=0/' + v.total + ' ms=' + v.ms +
+                (v.skipped ? ' skipped=' + v.skipped : ''));
+              if (lm) { lm.textContent = ''; lm.style.color = ''; }
+              _ganttEditable = false;
+              applyLockUi();
+            }, 0);
+            return;
+          }
+          _ganttEditable = true;
+          applyLockUi();
         });
       }
       var lockMsg = document.getElementById('tm-gantt-lockmsg');


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md §GANTT_LOCK_INTEGRITY` (user ruling 2026-08-07): toggling the Gantt drawer 🔓→🔒 now verifies the edited schedule still holds physical integrity. Breach ⇒ the lock is **refused**, an "⚠ Integrity Breach: N floating — press ↺ Undo edit (or fix), then lock again" flag names the problem, and §GANTT_LOCK_BREACH logs the offending GUIDs.

## Spec open questions, resolved
1. **Undo depth vs breach depth** — the gate is stateless: every lock attempt re-audits, so no edit-history tracing; Undo or further corrective edits both clear it.
2. **What's gated** — the Editing→Locked transition only; unlock and individual edits are never gated (witness-asserted).
3. **Cost** — measured: `§LI_COST auditFloating n=63415 ms=796` (0.8–1.7s at Hospital scale); a "Verifying integrity…" state paints before the audit runs.
4. **Recovery UX** — `auditFloating` gains an optional `collectGuids` arg (count return unchanged for all existing callers); the breach names offenders.

## Also in this PR (found by the witness's own clean-state check)
- **One more antisymmetry clause in `schedule_gate.js`**: a wall that BEARS a promoted slab (its top reaches the slab's base — wallGate's own relation) can never also *hang* from it. Without it: measured livelock on Duplex + load-path promotion (`§DEQ_REPAIR sweeps=16 shifted=379`, clean state auditing floating=22). With it: 0/0/0. A fan in the same geometric relation keeps its hang (class-scoped carrier pools, per §4D_ROOF_LOAD_PATH's measured practice). Mirrored in `hangGate`, the DAG edge emission, and `auditFloating`.
- **`witness_gantt_edit_undo.js` fixed** — broken on stock main since #1240 added `_tmResyncAfterRetime()` to the retime commit paths (verified pre-existing); sandbox stub added, 9/9 Duplex + 9/9 Terminal again.
- `sw.js` v957→v958 (both touched files are precached).

## Evidence (§-log, headless, no browser)
- New witness `viewer/tests/witness_gantt_lock_integrity.js`: **RED on main (11 fails, feature absent) → 22/22**: collector names offenders · sliced `verifyGanttIntegrity` driven on real Duplex (clean ok → simulated bad drag caught + named → restore/Undo → ok again) · lock-gate wiring (refusal returns before the flag flips, Editing→Locked only) · Hospital-scale cost measured.
- Full suite re-run after the gate change: `witness_geometric_support_order` 12/12 · `witness_default_engine_quality` · `test_schedule_gate` 3251→0 · `test_facade_stagger_order` 662→0 · `test_4d_sidecar` · `test_schedule_readonly` 6/6 · `test_schedule_generated` · `test_schedule_projector` — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)