### PR TITLE
feat(cpe): §CPE_WALK_SHOES_BTN — walk toggle on B's frame header (shoes icon) + eye-off guard + hallway witness promotion

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -807,12 +807,11 @@
         '<button id="cpe-vf-toggle" title="turn on the POV viewfinder (B) — shows the exact camera pose the rehearsal is at" ' +
           'style="flex:none;padding:3px 8px;font-size:13px;line-height:1;background:#2a2e34;color:#888;' +
           'border:1px solid #4a4f57;border-radius:4px;cursor:pointer;display:flex;align-items:center">' + _eyeIconSvg(false) + '</button>' +
-        // §CPE_WALK_EDIT_V1 (prompts/CPE_POV_WALK_PATHING.md) — walk B in POV with mouse+WASD, press
-        // Enter/click to snap a stick where you are looking. All behaviour lives in viewer/cpe_walk.js;
-        // this button only starts/stops it (same icon-only-button convention as the eye toggle).
-        '<button id="cpe-walk-toggle" title="walk the POV (B) with mouse-look + WASD; click or Enter snaps a stick where you are looking and facing" ' +
-          'style="flex:none;padding:3px 8px;font-size:11px;line-height:1;background:#2a2e34;color:#888;' +
-          'border:1px solid #4a4f57;border-radius:4px;cursor:pointer">walk</button></div>' +
+        // §CPE_WALK_SHOES_BTN (2026-08-07, user: "The Walk button (shoes icon preferred) should be
+        // at the POV frame") — the walk toggle moved OUT of this title row onto B's own frame header
+        // (_buildVFPanel), extending §CPE_SOLE_OWNER: the POV frame owns its walk, the eye owns the
+        // frame. See _wireWalkToggle, wired in _toggleViewfinder's ON branch now.
+        '</div>' +
       '<div id="cpe-hint" style="padding:6px 12px;font-size:10px;color:#888;border-bottom:1px solid #2a2e34;line-height:1.5"></div>' +
       '<div id="cpe-rows" style="padding:4px 0"></div>' +
       // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path controls, one strip.
@@ -1667,7 +1666,18 @@
         'height:22px;background:rgba(20,22,26,0.85);color:#4fc3f7;font:600 10px system-ui,sans-serif;' +
         'padding:2px 6px;display:flex;align-items:center;justify-content:space-between;' +
         'border-bottom:1px solid #4fc3f7;user-select:none">' +
-        '<span>POV <span id="cpe-vf-clock" style="color:#888;font-family:monospace;font-weight:400"></span></span></div>';
+        '<span>POV <span id="cpe-vf-clock" style="color:#888;font-family:monospace;font-weight:400"></span></span>' +
+        // §CPE_WALK_SHOES_BTN (2026-08-07, user ruling): the walk toggle lives ON B's frame header —
+        // shoes (Lucide footprints, pulled verbatim like panels.js §CINEMA_ROW_ICONS; inline SVG so
+        // stroke:currentColor follows the active-color swap in cpe_walk.js _syncButton). The header
+        // and panel are pointer-events:none by design — the button opts itself back in.
+        '<button id="cpe-walk-toggle" title="walk this POV: mouse-look + WASD; click or Enter snaps a stick where you stand and face (Esc or click again to stop)" ' +
+          'style="pointer-events:auto;flex:none;width:18px;height:18px;padding:1px;line-height:0;background:transparent;color:#888;' +
+          'border:1px solid #4a4f57;border-radius:3px;cursor:pointer;display:flex;align-items:center;justify-content:center">' +
+          '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+            '<path d="M4 16v-2.38C4 11.5 2.97 10.5 3 8c.03-2.72 1.49-6 4.5-6C9.37 2 10 3.8 10 5.5c0 3.11-2 5.66-2 8.68V16a2 2 0 1 1-4 0Z"/>' +
+            '<path d="M20 20v-2.38c0-2.12 1.03-3.12 1-5.62-.03-2.72-1.49-6-4.5-6C14.63 6 14 7.8 14 9.5c0 3.11 2 5.66 2 8.68V20a2 2 0 1 0 4 0Z"/>' +
+            '<path d="M16 17h4"/><path d="M4 13h4"/></svg></button></div>';
     document.body.appendChild(d);
     // §CPE_VF_STACK owns final geometry (see _vfLayoutStack) and bottom-anchors B + the fused bar
     // as ONE object, so B's own independent viewport clamp is retired here too. Clamping each panel
@@ -1850,9 +1860,16 @@
       // §CPE_VF_STACK — AFTER both panels exist and the bar has real content (its height is
       // content-driven and must be measured, not assumed), lay the fused stack out as one object.
       _vfLayoutStack();
+      // §CPE_WALK_SHOES_BTN: the walk button was just built with B's panel — wire it here, every
+      // time the eye re-opens (the old panel and its listeners were removed on the last eye-off).
+      _wireWalkToggle();
       if (a.markDirty) a.markDirty();
       console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; display-only, no drop interaction — timeline panel shown alongside it (§CPE_VF_EYE_DRIVES_SCRUB)');
     } else {
+      // §CPE_WALK_SHOES_BTN + §CPE_SOLE_OWNER: the walk session is B's tenant — closing B (its
+      // owner) force-stops an active walk BEFORE the panel (and the walk button on it) is removed,
+      // so freeze/TM/pointer-lock/stick-editor listeners are all restored, never orphaned.
+      if (window.CpeWalk && window.CpeWalk.isActive && window.CpeWalk.isActive()) window.CpeWalk.forceStop();
       var panel = document.getElementById('cpe-vf-panel');
       if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
       if (a._cpeViewfinderRender === _vfRender) delete a._cpeViewfinderRender;
@@ -3026,9 +3043,9 @@
       // (already null-guards on a missing track).
       _state.scrubTn = 0;
       // §CPE_VIEWFINDER: the eye-icon toggle button lives in the panel's title row (_buildPanel).
+      // §CPE_WALK_SHOES_BTN: the walk button lives on B's frame header now — built and wired in
+      // _toggleViewfinder's ON branch, not here (B does not exist yet at open()).
       _wireViewfinderToggle();
-      // §CPE_WALK_EDIT_V1: the walk-mode toggle button, same title row.
-      _wireWalkToggle();
       // §CPE_PREVIEW_DIVERGENCE: state the basis every re-plan below is pinned to, once. If a pasted
       // console ever shows the bake's §CINEMA_PIVOT disagreeing with the editor's, this line says
       // which camera the editor was planning from.

--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -329,9 +329,13 @@
   function _syncButton() {
     var btn = document.getElementById('cpe-walk-toggle');
     if (!btn) return;
+    // §CPE_WALK_SHOES_BTN: the button is the Lucide footprints SVG on B's frame header now
+    // (stroke:currentColor) — active state is the color swap alone; never write textContent here,
+    // that would erase the icon markup.
     btn.style.color = _active ? '#4fc3f7' : '#888';
     btn.style.borderColor = _active ? '#4fc3f7' : '#4a4f57';
-    btn.textContent = _active ? 'walking…' : 'walk';
+    btn.title = _active ? 'walking — Esc or click to stop; Enter/click on the scene snaps a stick'
+                        : 'walk this POV: mouse-look + WASD; click or Enter snaps a stick where you stand and face (Esc or click again to stop)';
   }
 
   function toggle() { return _active ? stop() : start(); }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v958';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v959';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,8 +824,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=11" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=10" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cpe_walk.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cinema_path_editor.js?v=11" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cpe_walk.js?v=2" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_walk_edit.js
+++ b/witness_cpe_walk_edit.js
@@ -88,6 +88,13 @@ async function gates(browser, BLD) {
   P('G-WALK-ISOLATE-1 pre-walk pointerdown at a handle is claimed by the stick editor (_state.drag set)',
     claimedBefore === true, `_probeDrag()=${claimedBefore}`);
 
+  // ══ G-WALK-BTN-ABSENT (§CPE_WALK_SHOES_BTN): with the eye OFF there is no B frame, and the walk
+  // button lives ON B's frame header now — so it must NOT exist yet (it used to sit in the CPE
+  // panel's title row; this gate proves the move, not just the addition). ══
+  const btnPre = await page.evaluate(() => !!document.getElementById('cpe-walk-toggle'));
+  P('G-WALK-BTN-ABSENT eye off => no B frame => no walk button anywhere (button moved off the CPE title row)',
+    btnPre === false, `#cpe-walk-toggle exists=${btnPre}`);
+
   // ══ mount walk mode ══
   const mark1 = logs.length;
   const mounted = await page.evaluate(() => window.CpeWalk.toggle());
@@ -109,6 +116,16 @@ async function gates(browser, BLD) {
   P('G-WALK-FREEZE overlay canvas exists while mounted, sized to the WebGL canvas (main view is covered)',
     !!freezeInfo && freezeInfo.w === freezeInfo.canvasW && freezeInfo.h === freezeInfo.canvasH,
     `freeze=${JSON.stringify(freezeInfo)} logged=[${win1.filter(l => l.startsWith('§CPE_WALK_FREEZE')).join(' | ')}]`);
+
+  // ══ G-WALK-BTN-B (§CPE_WALK_SHOES_BTN): mounting auto-opened B, and the walk button (shoes icon)
+  // must exist ON B's frame header — inside #cpe-vf-panel, carrying the footprints SVG. ══
+  const btnB = await page.evaluate(() => {
+    const btn = document.getElementById('cpe-walk-toggle');
+    const panel = document.getElementById('cpe-vf-panel');
+    return { exists: !!btn, inPanel: !!(btn && panel && panel.contains(btn)), hasSvg: !!(btn && btn.querySelector('svg path')) };
+  });
+  P('G-WALK-BTN-B walk button exists on B\'s frame header (inside #cpe-vf-panel, shoes SVG present)',
+    btnB.exists && btnB.inPanel && btnB.hasSvg, JSON.stringify(btnB));
 
   // ══ G-WALK-ISOLATE-2: mounted, the SAME gesture is NOT claimed ══
   const claimedDuring = await dispatchPointerDownUp(page, setup.hx, setup.hy);
@@ -142,9 +159,20 @@ async function gates(browser, BLD) {
     !!snapRes && typeof snapRes.replanMs === 'number' && win2.some(l => l.startsWith('§CPE_WALK_SNAP pos=')),
     `replanMs=${snapRes ? snapRes.replanMs : 'null'} logged=${win2.filter(l => l.startsWith('§CPE_WALK_SNAP')).join(' | ')}`);
 
-  // Reset to a known unmounted baseline (still mounted from the earlier snap test).
-  await page.evaluate(() => { if (window.CpeWalk.isActive()) window.CpeWalk.toggle(); });
+  // ══ G-WALK-EYE-OFF-STOP (§CPE_WALK_SHOES_BTN / §CPE_SOLE_OWNER): closing B (the eye, walk's
+  // owner surface) while a walk is active must force-stop the walk — freeze dropped, no orphaned
+  // session. This doubles as the reset to the unmounted baseline the gates below assume. ══
+  const eyeOff = await page.evaluate(() => {
+    const activeBefore = window.CpeWalk.isActive();
+    window.APP.cinemaPathEditor._vfToggle();   // eye OFF (same call cpe_walk's own start() uses for ON)
+    return { activeBefore, activeAfter: window.CpeWalk.isActive(),
+             freezeGone: !document.getElementById('cpe-walk-freeze'),
+             btnGone: !document.getElementById('cpe-walk-toggle') };
+  });
   await sleep(100);
+  P('G-WALK-EYE-OFF-STOP closing B (eye off) force-stops an active walk (session, freeze and button all gone)',
+    eyeOff.activeBefore === true && eyeOff.activeAfter === false && eyeOff.freezeGone && eyeOff.btnGone,
+    JSON.stringify(eyeOff));
 
   // ══ G-WALK-TMLOCK — stub panel/button so this gate proves OUR dispatch+lock code, independent
   // of whether real Time Machine happens to be activated in this session (out of scope: we do not

--- a/witness_cpe_walk_hallway.js
+++ b/witness_cpe_walk_hallway.js
@@ -1,0 +1,198 @@
+// WITNESS — §CPE_WALK_EDIT_V1 hallway walk on real mid-size buildings (HHS_Office_Federated, Clinic).
+// Follow-on named in prompts/CPE_POV_WALK_PATHING.md coverage caveat: prove the walk-snap mechanics
+// inside a REAL hallway, extracted from the building DB (not invented), on buildings beyond the two
+// small residential ones the shipped witness covered. Promoted from the one-off scratchpad run
+// 2026-08-07 (HHS 8/8, Clinic 8/8, Hospital 8/8) so the coverage is repeatable, per watchdog ask.
+//
+// PRECONDITIONS: serve the repo root (python3 -m http.server $PORT) from a checkout/worktree.
+// Building DBs: HHS_Office_Federated_extracted.db is git-tracked; Clinic/Hospital are OCI-distributed
+// binaries — place them in buildings/ (copy or symlink from a full checkout), or rely on the viewer's
+// own §DB_404_OCI_RETRY fallback (fetches from OCI over the network when the local file is missing).
+// Hospital-class needs the full 600s editor-open budget below (63k elems under swiftshader).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-HALL-EXTRACT   a real hallway run exists and is EXTRACTED from the DB: two doors on one storey,
+//                    aligned (cross-axis offset < 1.5m) and >8m apart. No coordinates are invented.
+//   G-HALL-SNAP-POS  walking that line and snapping at u=0.25/0.5/0.75 produces bands whose centres
+//                    are bit-identical to the walked poses (same guarantee as G-WALK-SNAP-1a, now
+//                    in-building instead of 500m outside).
+//   G-HALL-MONO      the three insertion fractions s are strictly increasing in walk order — the
+//                    projection onto the path orders multiple snaps correctly (the shipped witness
+//                    only ever snapped ONCE per run; ordering was never proven).
+//   G-HALL-FACE-WALL the mid-hallway snap faces PERPENDICULAR at a near wall: its lookAt must be a
+//                    real raycast HIT (distance != the 10m fallback, and < 10m) — proves in-building
+//                    facing capture hits real meshes; the shipped witness only proved the MISS path.
+//   G-HALL-FACE-AXIS the along-hallway snaps report hit-or-fallback with distance (informational
+//                    gate: PASSes either way but the distance is logged — long sightline down a
+//                    hallway may legitimately miss within raycast range).
+//   G-HALL-REPLAN    every snap ran the real replan; ms recorded per building (budget: < 5000ms).
+//   G-HALL-SEAM      §CPE_SEAM_CONTINUOUS must NOT report a seam gap during these replans (the known
+//                    pin-replan landmine — if it fires here, that is a real surfaced regression).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8513;
+const BUILDINGS = (process.env.BLDS || 'HHS_Office_Federated,Clinic').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser, BLD, logs) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.CpeWalk && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  // 600s: Hospital-class (63k elems) under swiftshader needs far longer than small buildings to
+  // stream + compile + plan before the editor panel exists.
+  await page.waitForSelector('#cpe-ok', { timeout: 600000 });
+  await sleep(800);
+  return page;
+}
+
+async function gates(browser, BLD, logs) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const page = await openEditor(browser, BLD, logs);
+
+  // ── G-HALL-EXTRACT: the hallway run, straight out of the DB ──
+  const hall = await page.evaluate(() => {
+    const rows = window.APP.dbQuery(
+      "SELECT m.storey, t.center_x, t.center_y, t.center_z FROM elements_meta m " +
+      "JOIN element_transforms t ON m.guid = t.guid WHERE m.ifc_class LIKE 'IfcDoor%'");
+    const byStorey = {};
+    rows.forEach(r => { (byStorey[r[0]] = byStorey[r[0]] || []).push({ x: r[1], y: r[2], z: r[3] }); });
+    let best = null;
+    Object.keys(byStorey).forEach(st => {
+      const ds = byStorey[st];
+      for (let i = 0; i < ds.length; i++) for (let j = i + 1; j < ds.length; j++) {
+        const dx = Math.abs(ds[i].x - ds[j].x), dy = Math.abs(ds[i].y - ds[j].y);
+        const long = Math.max(dx, dy), short = Math.min(dx, dy);
+        if (short < 1.5 && long > 8 && (!best || long > best.long))
+          best = { long, short, storey: st, a: ds[i], b: ds[j] };
+      }
+    });
+    if (!best) return null;
+    // three.js-space endpoints at eye height (+0.6 above door centre ≈ 1.7m above floor)
+    const A3 = window.APP.ifc2three(best.a.x, best.a.y, best.a.z + 0.6);
+    const B3 = window.APP.ifc2three(best.b.x, best.b.y, best.b.z + 0.6);
+    return { storey: best.storey, long: best.long, short: best.short,
+             a: { x: A3.x, y: A3.y, z: A3.z }, b: { x: B3.x, y: B3.y, z: B3.z } };
+  });
+  P('G-HALL-EXTRACT hallway run extracted from DB (two aligned doors, one storey, >8m apart)',
+    !!hall, hall ? `storey="${hall.storey}" run=${hall.long.toFixed(2)}m crossOffset=${hall.short.toFixed(2)}m` : 'no aligned door pair found');
+  if (!hall) { await page.close(); return checks; }
+
+  // ── mount walk mode ──
+  const mounted = await page.evaluate(() => { const r = window.CpeWalk.toggle(); return r && window.CpeWalk.isActive(); });
+  P('G-HALL-MOUNT walk mode mounted on this building', mounted === true, `isActive=${mounted}`);
+
+  // walk direction (three space) + a horizontal perpendicular
+  const dir = { x: hall.b.x - hall.a.x, y: hall.b.y - hall.a.y, z: hall.b.z - hall.a.z };
+  const len = Math.hypot(dir.x, dir.y, dir.z);
+  const fwd = { x: dir.x / len, y: dir.y / len, z: dir.z / len };
+  const perp = { x: -fwd.z, y: 0, z: fwd.x };  // cross(up, fwd) — horizontal, toward a side wall
+  const at = u => ({ x: hall.a.x + dir.x * u, y: hall.a.y + dir.y * u, z: hall.a.z + dir.z * u });
+
+  const snaps = [];
+  for (const [u, f, tag] of [[0.25, fwd, 'axis'], [0.5, perp, 'wall'], [0.75, fwd, 'axis']]) {
+    const pos = at(u);
+    const mark = logs.length;
+    const res = await page.evaluate((p, fv) => window.CpeWalk._snapForTest(p, fv), pos, f);
+    await sleep(60);
+    const seam = logs.slice(mark).filter(l => l.indexOf('§CPE_SEAM_CONTINUOUS') >= 0);
+    snaps.push({ u, tag, pos, fwd: f, res, seam });
+  }
+
+  // ── G-HALL-SNAP-POS ──
+  const posOk = snaps.every(s => s.res && s.res.centre.x === s.pos.x && s.res.centre.y === s.pos.y && s.res.centre.z === s.pos.z);
+  P('G-HALL-SNAP-POS all three band centres bit-identical to the walked hallway poses',
+    posOk, snaps.map(s => `u=${s.u} centre=(${s.res ? [s.res.centre.x.toFixed(2), s.res.centre.y.toFixed(2), s.res.centre.z.toFixed(2)] : 'null'})`).join('  '));
+
+  // ── G-HALL-MONO — strictly monotonic in ONE consistent direction. The film's own walk stretch
+  // may traverse the hallway in either direction (Clinic's runs opposite to the door-pair order);
+  // ordering must follow the PATH's direction deterministically, which is monotonic either way.
+  const ss = snaps.map(s => s.res ? s.res.s : NaN);
+  const monoOk = ss.every(v => typeof v === 'number' && !isNaN(v)) &&
+    ((ss[0] < ss[1] && ss[1] < ss[2]) || (ss[0] > ss[1] && ss[1] > ss[2]));
+  P('G-HALL-MONO insertion fractions strictly monotonic in walk order (path-direction-consistent multi-snap ordering)',
+    monoOk, `s=[${ss.map(v => (typeof v === 'number' ? v.toFixed(4) : 'NaN')).join(', ')}] dir=${ss[0] < ss[2] ? 'with-path' : 'against-path'}`);
+
+  // ── G-HALL-FACE-WALL: perpendicular snap must be a REAL raycast hit — any distance. The issue
+  // proved is hit-vs-fallback (fallback is exactly 10.000m by construction), NOT corridor width:
+  // Hospital's mid-run perpendicular legitimately crosses into a larger space and hits at 18.5m.
+  const wall = snaps[1];
+  const wallDist = wall.res && wall.res.lookAt ?
+    Math.hypot(wall.res.lookAt.x - wall.pos.x, wall.res.lookAt.y - wall.pos.y, wall.res.lookAt.z - wall.pos.z) : null;
+  P('G-HALL-FACE-WALL mid-hallway perpendicular facing raycast-HITS a real mesh (dist != the exact-10m fallback)',
+    wallDist !== null && Math.abs(wallDist - 10) > 1e-6,
+    `lookAt dist=${wallDist === null ? 'null' : wallDist.toFixed(3)}m (fallback would be exactly 10.000)`);
+
+  // ── G-HALL-FACE-AXIS (informational: hit or fallback, distance recorded) ──
+  const axisD = [snaps[0], snaps[2]].map(s => s.res && s.res.lookAt ?
+    Math.hypot(s.res.lookAt.x - s.pos.x, s.res.lookAt.y - s.pos.y, s.res.lookAt.z - s.pos.z) : null);
+  P('G-HALL-FACE-AXIS along-hallway facings resolved (hit or 10m fallback — distance recorded)',
+    axisD.every(d => d !== null),
+    axisD.map((d, i) => `axisSnap${i} dist=${d === null ? 'null' : d.toFixed(3)}m ${d !== null && Math.abs(d - 10) <= 1e-6 ? '(fallback)' : '(HIT)'}`).join('  '));
+
+  // ── G-HALL-REPLAN ──
+  const replanOk = snaps.every(s => s.res && typeof s.res.replanMs === 'number' && s.res.replanMs < 5000);
+  P('G-HALL-REPLAN every snap ran the real replan within budget (<5000ms)',
+    replanOk, `replanMs=[${snaps.map(s => s.res ? s.res.replanMs.toFixed(0) : 'null').join(', ')}]`);
+
+  // ── G-HALL-SEAM — parse the actual metric. The §CPE_SEAM_CONTINUOUS family also prints routine
+  // informational lines (openDeg/handoffYawDeg) on every replan; the landmine is seamGapDeg=57-93
+  // where ~0 is required. Gate on the parsed values, not on the tag's presence.
+  const seamLines = snaps.flatMap(s => s.seam);
+  const gaps = seamLines.map(l => { const m = l.match(/seamGapDeg=([\d.]+)/); return m ? parseFloat(m[1]) : null; })
+    .filter(v => v !== null);
+  P('G-HALL-SEAM every seamGapDeg reported during pin-bearing hallway replans is ~0 (<5°, landmine silent)',
+    gaps.length > 0 && gaps.every(g => g < 5),
+    `seamGapDeg=[${gaps.map(g => g.toFixed(3)).join(', ')}] from ${seamLines.length} §CPE_SEAM_CONTINUOUS lines`);
+
+  // unmount + close cleanly
+  await page.evaluate(() => { if (window.CpeWalk.isActive()) window.CpeWalk.toggle(); });
+  await page.evaluate(() => document.getElementById('cpe-cancel').click());
+  await sleep(200);
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const logs = [];
+    try {
+      const checks = await gates(browser, BLD, logs);
+      checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+      summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+    } catch (e) {
+      console.log(`  INFRA-ERROR ${BLD}: ${e.message}`);
+      // Say WHERE the viewer got stuck: dump the §-relevant console tail, not just "selector failed".
+      const tail = logs.filter(l => l.indexOf('§') >= 0 || /error/i.test(l)).slice(-25);
+      console.log(`  --- page console tail (${logs.length} lines total, last ${tail.length} §/error lines) ---`);
+      tail.forEach(l => console.log('  | ' + l.slice(0, 200)));
+      allPass = false;
+      summary.push({ BLD, pass: false, n: 0, t: 0, infra: true });
+    }
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
User ruling 2026-08-07 (prompts/CPE_POV_WALK_PATHING.md §CPE_WALK_SHOES_BTN): "The Walk button (shoes icon preferred) should be at the POV frame." Pointer-lock interaction unchanged (option A, advisor-confirmed).

- Walk toggle moved off the CPE panel title row onto B's frame header as a Lucide footprints icon (inline SVG, stroke:currentColor so the existing active-color swap keeps working). §CPE_SOLE_OWNER extended: the POV frame owns its walk.
- Eye-off while walking force-stops the walk before the panel is removed — freeze dropped, TM restored, stick editor re-wired.
- Witness: 3 new gates (BTN-ABSENT pre-eye, BTN-B on-frame with SVG, EYE-OFF-STOP), Duplex 17/17 PASS.
- Promotes witness_cpe_walk_hallway.js (HHS 8/8 · Clinic 8/8 · Hospital 8/8 one-off runs) so hallway/large-building coverage is repeatable — watchdog ask.
- Cache: viewer.html ?v bumps, sw CACHE_VERSION v959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)