### PR TITLE
feat(modeller): wire Room Move + Item Drag into the UI

### DIFF
--- a/modeller/bom_tree.js
+++ b/modeller/bom_tree.js
@@ -44,7 +44,16 @@ function seedTree(elements, opts) {
     // element has a real IfcSpace container (e.room, derived from rel_contained_in_space). Buildings with
     // no IfcSpace (rooms = weak handle) simply skip this level — NON-INVENT, never a fabricated room.
     var underStorey = sId;
-    if (e.room != null && e.room !== '') underStorey = ensure(sId + '|R|' + e.room, e.room, sId, 'room');
+    if (e.room != null && e.room !== '') {
+      underStorey = ensure(sId + '|R|' + e.room, e.room, sId, 'room');
+      // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1 — the grab target needs the room's real IfcSpace guid, not just
+      // its display name. `opts.roomGuidByName` (storey-scoped, built by seedFromDb below) is EXTRACT-not-invent:
+      // the guid was already read off spatial_structure, just never retained on this node until now.
+      if (!nodes[underStorey].guid && opts.roomGuidByName) {
+        var _rk = st + '|' + e.room;
+        if (opts.roomGuidByName[_rk] != null) nodes[underStorey].guid = opts.roomGuidByName[_rk];
+      }
+    }
     var dId = ensure(underStorey + '|D|' + dc, dc, underStorey, 'disc');
     var cId = ensure(dId + '|C|' + cl, cl, dId, 'class');
     // element leaf — guid is the id (globally unique, GUID-bound = rename/regroup-proof)
@@ -57,7 +66,8 @@ function seedTree(elements, opts) {
     var isLayer = layerOf[st] === true;
     var sId = ensure('S|' + st, isLayer ? (st + ' · layer') : st, ROOT, 'storey');
     if (isLayer) nodes[sId].layer = true;
-    ensure(sId + '|R|' + rm.name, rm.name, sId, 'room');
+    var rId = ensure(sId + '|R|' + rm.name, rm.name, sId, 'room');
+    if (rm.guid != null && !nodes[rId].guid) nodes[rId].guid = rm.guid;   // §2.1: real IfcSpace guid, carried through
   });
   return { nodes: nodes, roots: [ROOT] };
 }
@@ -100,9 +110,14 @@ function seedFromDb(db, opts) {
       var nm = v[1], stn = storeyName[v[2]], h = v[3];
       var habitableStorey = stn != null && doorStoreys[stn] > 0;
       var habitableAABB = (h == null) || (h >= MIN_H);    // no geometry → don't reject on the AABB leg
-      if (nm && habitableStorey && habitableAABB) { spaceRoom[v[0]] = nm; roomList.push({ name: nm, storey: stn }); }
+      if (nm && habitableStorey && habitableAABB) { spaceRoom[v[0]] = nm; roomList.push({ name: nm, storey: stn, guid: v[0] }); }
     });
   } catch (e) { /* spatial_structure lacks type/size_z (legacy DB) → no room level (graceful) */ }
+  // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1 — storey-scoped name→guid map (two different storeys may legitimately
+  // share a room NAME, e.g. "Bathroom" on floors 1 and 2; scoping by storey keeps each its own real guid).
+  var roomGuidByName = {};
+  roomList.forEach(function (rm) { var k = (rm.storey || '') + '|' + rm.name; if (roomGuidByName[k] == null) roomGuidByName[k] = rm.guid; });
+  opts.roomGuidByName = roomGuidByName;
 
   // element → room: only when the containing space qualified as a room.
   var room = {};

--- a/modeller/bom_tree_outliner.js
+++ b/modeller/bom_tree_outliner.js
@@ -36,6 +36,10 @@ function treeNodes(tree) {
       children: isLeaf ? [] : ch.map(build).sort(byLabel) };
     // W-UX-4: tag a DISCIPLINE node so the Outliner can make it a WALKER entry point (click → walk that disc).
     if (n.kind === 'disc') node.disc = n.label;
+    // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1/§2.5 — tag a ROOM node with its real IfcSpace guid so the Outliner
+    // can render a grab affordance (Feature A's grab target). Absent guid (pre-fix seed / no bom_tree.js update
+    // on the reader's side) → no affordance, never a fabricated guid.
+    if (n.kind === 'room' && n.guid != null) node.room = n.guid;
     return node;
   }
   return tree.roots.map(build);
@@ -88,7 +92,11 @@ if (typeof window !== 'undefined' && window.document) {
       // W-UX-4: a discipline node is a WALKER entry point — click it → walk that disc. The cross-engine
       // dispatch (STR=swbInit walk, already done at Open; MEP/etc=RouteWalker or an honest refusal) lives in
       // window.discWalk (modeller.html UX glue) so this category stays a pure BOM-graph view.
-      onWalk: function (disc) { if (window.discWalk) window.discWalk(disc, { building: State.building }); }
+      onWalk: function (disc) { if (window.discWalk) window.discWalk(disc, { building: State.building }); },
+      // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1 — a room node's grab glyph dispatches here. Mirrors onWalk's own
+      // shape: this category stays a pure BOM-graph view, the actual drag-session/canvas glue lives in
+      // modeller.html (window.__armRoomMove), same separation onWalk already uses for window.discWalk.
+      onRoomGrab: function (guid) { if (window.__armRoomMove) window.__armRoomMove(guid); }
     };
   }
 

--- a/modeller/bonsai_outliner.js
+++ b/modeller/bonsai_outliner.js
@@ -606,6 +606,11 @@
         // MODELLER_MASTER.md row 17: the synthetic disc:'__ALL__' row (modeller.html §DISCWALK-ALL) walks EVERY
         // discipline — its tooltip must say so; ordinary disc rows keep the singular.
         const walkGlyph = n.disc ? ' <span class="bn-walk" title="' + (n.disc === '__ALL__' ? 'Walk ALL disciplines' : 'Walk this discipline') + '" style="color:#4fc3f7">▶</span>' : '';
+        // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1/§2.5 — the room node IS the grab target (IfcSpace carries no
+        // rendered mesh, so there is nothing to pick in the 3D canvas; confirmed by grep — no GEOM_INSERT/
+        // arc_editable seed ever runs for ifc_class='IfcSpace'). data-room carries the real guid the click
+        // dispatches with; mirrors the disc walkGlyph in shape.
+        const roomGlyph = n.room ? ' <span class="bn-roommove" data-room="' + n.room + '" title="Move this room — drag on canvas after grabbing" style="color:#4fc3f7">⛶</span>' : '';
         // W-UX-6: adjacency lens — a NEIGHBOUR of the selected element gets a per-EDGE-TYPE badge (⇄ abuts ·
         // ⌂ fills · ⧉ aggregates) + amber tint; the selected element shows its per-kind degree + its element↔
         // datum relations (⊥ anchored · ↕ spans). All read the derived map (window.swXEdges), never a baked table.
@@ -649,7 +654,7 @@
           (n.disc ? ' data-disc="' + n.disc + '"' : '') + (isNbr ? ' data-adj="1"' : '') + (hid ? ' data-hid="1"' : '') + ' draggable="true" ' +
           'style="padding:3px 6px 3px ' + pad + 'px;cursor:' + (isLeaf ? 'grab' : 'pointer') + ';border-radius:4px;' +
           (hid ? 'opacity:.45;' : '') + rowBg + '">' + eye +
-          (kids.length ? CHEV(showKids) : LEAF) + n.label + walkGlyph + adjBadge +
+          (kids.length ? CHEV(showKids) : LEAF) + n.label + walkGlyph + roomGlyph + adjBadge +
           (n.sub ? '  <span style="color:#7f8aa0;font-family:ui-monospace,monospace">' + n.sub + '</span>' : '') + '</div>';
         if (showKids) { const r = this._renderNodes(kids, depth + 1, ckey, match, String(n.id), hid); html += r.html; shown += r.shown; }
       });
@@ -716,6 +721,14 @@
         d.onclick = (e) => {
           // §V1: the eye toggle owns its click — never a select/collapse.
           if (e && e.target && e.target.closest && e.target.closest('.bn-eye')) { this._toggleHide(id); return; }
+          // ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.1/§2.5: the room grab glyph owns its click too — never a
+          // subtree-select/collapse (a room node otherwise falls into the generic non-leaf branch below).
+          if (e && e.target && e.target.closest && e.target.closest('.bn-roommove')) {
+            const cat = byKey[d.getAttribute('data-tcat')];
+            const guid = e.target.closest('.bn-roommove').getAttribute('data-room');
+            if (cat && cat.onRoomGrab) cat.onRoomGrab(guid);
+            return;
+          }
           if (isLeaf) {
             // The seeded ARC-BOM tree's leaf id IS THE GUID (bom_tree.js `id: e.guid`) — window.Bonsai.select
             // only accepts a NUMERIC featureId, so resolve guid→featureId via arc_editable.js's bridge

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -155,6 +155,7 @@
   <button id="b-grid" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg><span>Grid</span></button>
   <button id="b-gridmove" disabled title="Drag a gridline — attached walls recompose"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 5-3-3-3 3"/><path d="m15 19-3 3-3-3"/><path d="M2 12h20"/></svg><span>Move Grid</span></button>
   <button id="b-move" disabled title="Move the selected object — drag an axis handle or nudge with arrow keys (M)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 9 2 12l3 3"/><path d="M9 5l3-3 3 3"/><path d="M15 19l-3 3-3-3"/><path d="M19 9l3 3-3 3"/><path d="M2 12h20"/><path d="M12 2v20"/></svg><span>Move</span></button>
+  <button id="b-itemdrag" disabled title="Drag a fixture/fitting freely — gated by the real placement resolver (ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3)"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M2 12h4"/><path d="M18 12h4"/></svg><span>Drag Item</span></button>
   <button id="b-sketch" disabled><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg><span>Sketch</span></button>
   <button id="b-extrude" disabled style="display:none"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg><span>Extrude</span></button>
   <button id="b-constrain" disabled style="display:none" title="Constraint intent the solver enforces on the sketch"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span>Axis</span></button>
@@ -241,10 +242,10 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
 <script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
-<script src="bonsai_outliner.js?v=12" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
+<script src="bonsai_outliner.js?v=13" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
-<script src="bom_tree.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
-<script src="bom_tree_outliner.js?v=3" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
+<script src="bom_tree.js?v=4" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree.js')"></script>
+<script src="bom_tree_outliner.js?v=4" onerror="console.warn('§BOMTREE LOAD_FAIL bom_tree_outliner.js')"></script>
 <!-- Cross-edges: the typed SDG lateral edges (abuts/...) derived on-the-fly from the bbox substrate. -->
 <script src="cross_edges.js?v=2" onerror="console.warn('§XEDGE LOAD_FAIL cross_edges.js')"></script>
 <!-- Real per-element geometry (component_geometries/base_geometries) — read+recentre, no THREE/DOM deps.
@@ -1440,7 +1441,7 @@ window.Bonsai.frameElementByGuid = (guid) => {
   } catch (e) { console.warn('§FRAME_GUID fail ' + (e && e.message)); return false; }
   finally { if (db) { try { db.close(); } catch (e) { } } }
 };
-function inSelectCtx() { return !(sketching || routing || edgePicking || gridMoving || moving || inserting); }
+function inSelectCtx() { return !(sketching || routing || edgePicking || gridMoving || moving || inserting || roomMoving || itemDragging); }
 // §Q2 (RESUME_MODELLER_POLISH2.md — Witness: W-E2E-INSTPICK): walked fixtures live as InstancedMesh buckets
 // under dwRoot (NOT direct children of g), so the old non-recursive intersect never even raycast them — a
 // canvas click on a walked fixture was a silent miss, instanceId or not. Include the buckets; THREE populates
@@ -1543,6 +1544,8 @@ function modeCursor() {
   if (sketching || routing) return 'crosshair'; // drawing sketch points / a route
   if (edgePicking) return 'crosshair';          // picking edges to fillet
   if (gridMoving) return 'grab';                // grabbing a gridline to drag
+  if (roomMoving) return 'grab';                // room armed via the Outliner — drag anywhere on canvas
+  if (itemDragging) return 'crosshair';         // click a fixture/fitting to grab it (gated pick)
   if (moving) return 'move';                    // dragging the transform gizmo
   return null;                                  // default browsing → hover decides
 }
@@ -2020,6 +2023,167 @@ async function commitGridMove() {
 }
 window.__gridStretch = async (id, delta) => { _dragGrid = { id, delta }; await commitGridMove(); };   // test hook (§STRETCH-GATE smoke)
 canvas.addEventListener('pointerup', () => { if (gridMoving && _dragGrid) commitGridMove(); });
+
+// ── ROOM MOVE (whole-room drag) ───────────────────────────────────────────────────────────────────
+// Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.5 — Witness: W-ROOMMOVE-UI.
+// Grab target = the Outliner room node (§2.1 "implementer's choice"): an IfcSpace is never GEOM_INSERT-seeded
+// (grepped — arc_editable.js has no room mesh), so there is nothing to raycast-pick in the 3D canvas; the
+// Outliner's own ⛶ glyph (bonsai_outliner.js) is the only real grab target. Grab happens on click
+// (window.__armRoomMove, dispatched via bom_tree_outliner.js's onRoomGrab), then drag continues on the CANVAS
+// ground plane — mirrors bonsai_gridmove.js's arm→pointerdown→pointermove(preview/tint)→pointerup(commit)
+// structure exactly; only the ARM trigger moves from a toolbar button to the Outliner row (the op itself is
+// UI-agnostic per spec §2.1).
+let roomMoving = false, _roomDrag = null;
+window.__armRoomMove = function (spaceGuid) {
+  if (roomMoving) exitRoomMove();                                 // grabbing a new room cancels any prior arm
+  if (!window.__dwBuf || !window.SQL) { console.warn('§ROOMMOVE-UI no building open — cannot grab a room'); setStat('room move: open a building first'); return; }
+  let db, session;
+  try { db = new window.SQL.Database(new Uint8Array(window.__dwBuf)); }
+  catch (e) { console.warn('§ROOMMOVE-UI db open failed ' + (e && e.message)); return; }
+  try { session = window.Bonsai.roommove.beginRoomDragSession(spaceGuid, { db: db }); }
+  finally { db.close(); }                                          // §ROOMMOVE-UI: transient re-open, mirrors disc_walker.js's own __dwBuf re-open idiom
+  if (!session) { setStat('room move refused — see console (§ROOMMOVE)'); return; }   // engine already console.error'd (spec §2.7)
+  roomMoving = true; _roomDrag = null; controls.enabled = false; applyModeCursor();
+  setStat('room "' + session.room.name + '" armed (' + session.members.length + ' members) — drag anywhere on canvas to move, Esc cancels');
+  audioCue('tick');
+};
+function exitRoomMove() {
+  roomMoving = false; _roomDrag = null; controls.enabled = true; applyModeCursor();
+  gmClearTints();
+  if (window.Bonsai.roommove && window.Bonsai.roommove.endDragSession) window.Bonsai.roommove.endDragSession();
+}
+function rmTint(members) {
+  gmClearTints();
+  const s = window.Bonsai.roommove._session;
+  if (!s) return;
+  (members || []).forEach(m => { const mesh = s.meshByFid[m.featureId]; if (mesh) _emis(mesh, 0x1e66c8); });   // blue = rigid translate (§2.4: no scale ever occurs)
+  if (window.A && A.requestRender) A.requestRender();
+}
+canvas.addEventListener('pointerdown', (e) => {
+  if (!roomMoving || e.button !== 0 || _roomDrag) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(GROUND, hit)) return;
+  _roomDrag = { downX: hit.x, downY: hit.y, dx: 0, dy: 0 };
+});
+canvas.addEventListener('pointermove', (e) => {
+  if (!roomMoving || !_roomDrag) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(GROUND, hit)) return;
+  _roomDrag.dx = hit.x - _roomDrag.downX; _roomDrag.dy = hit.y - _roomDrag.downY;
+  const preview = window.Bonsai.roommove.previewCommands(_roomDrag.dx, _roomDrag.dy);
+  rmTint(preview.members);
+  setStat('room move Δ(' + _roomDrag.dx.toFixed(2) + ',' + _roomDrag.dy.toFixed(2) + ') — ' + preview.members.length + ' members');
+});
+canvas.addEventListener('pointerup', async () => {
+  if (!roomMoving || !_roomDrag) return;
+  if (Math.abs(_roomDrag.dx) < 0.05 && Math.abs(_roomDrag.dy) < 0.05) { exitRoomMove(); return; }   // dead-zone (mirror commitGridMove) → click, no commit
+  const { dx, dy } = _roomDrag;
+  const _gateBefore = _gateBoxes();                                 // §GATE-1 parity: snapshot AABBs BEFORE the edit
+  try {
+    const res = await window.Bonsai.roommove.commit(dx, dy, 0);
+    if (res) {
+      const gateMsg = _runGate(_gateBefore, res.members.map(m => m.featureId));
+      setStat('room moved Δ(' + dx.toFixed(2) + ',' + dy.toFixed(2) + ') members=' + res.members.length + ' verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
+      audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    }
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER roommove fail ' + err); }
+  exitRoomMove();
+});
+
+// ── ITEM DRAG (free single-item drag, gated) ──────────────────────────────────────────────────────
+// Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3 — Witness: W-ITEMDRAG-UI.
+// A DEDICATED #b-itemdrag toolbar button (mirrors bGridMove's arm/cancel pattern), NOT folded into the
+// existing #b-move gizmo tool: Move is UNGATED axis-constrained direct manipulation (W-BONSAI-MOVE, already
+// shipped) — this tool is a genuinely different contract (resolver-gated session start, collision/host
+// canDropAt validation, snap-back on refusal) and mixing the two would silently change Move's own behavior.
+const bItemDrag = document.getElementById('b-itemdrag');
+const IDRAG_ARM = _ico('<rect x="6" y="6" width="12" height="12" rx="2"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M2 12h4"/><path d="M18 12h4"/>') + '<span>Drag Item</span>';
+const IDRAG_CANCEL = _ico('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>') + '<span>Cancel</span>';
+let itemDragging = false, _itemDrag = null;
+function enterItemDrag() {
+  itemDragging = true; _itemDrag = null; bItemDrag.innerHTML = IDRAG_CANCEL; controls.enabled = false; applyModeCursor();
+  setStat('drag item: click a fixture/fitting, drag on canvas — release to drop (green=valid, red=blocked), Esc cancels');
+}
+function exitItemDrag() {
+  itemDragging = false; _itemDrag = null; bItemDrag.innerHTML = IDRAG_ARM; controls.enabled = true; applyModeCursor();
+  gmClearTints();
+  if (window.Bonsai.itemdrag && window.Bonsai.itemdrag.endDragSession) window.Bonsai.itemdrag.endDragSession();
+}
+bItemDrag.onclick = () => itemDragging ? exitItemDrag() : enterItemDrag();
+function idTint(fid, valid) {
+  gmClearTints();
+  const g = window.Bonsai.group && window.Bonsai.group();
+  const byFid = window.Bonsai.gridmove && window.Bonsai.gridmove.meshByFid ? window.Bonsai.gridmove.meshByFid() : null;
+  const m = byFid ? byFid[fid] : (g && g.children.find(o => o.isMesh && o.userData.featureId === fid));
+  if (m) _emis(m, valid ? 0x1ea83c : 0x8c1e1e);                    // green=valid / red=blocked (spec §3.3)
+  if (window.A && A.requestRender) A.requestRender();
+}
+// Grab a fid. Factored out so a witness can call it directly with a caller-held productHint (spec §3.2:
+// "a caller that genuinely HOLDS the product id ... may pass opts.productHint") to exercise the MATCH path
+// deterministically. The real pick handler below always passes {} — Q5's own resolved-against-live-code
+// finding is that NO already-committed element carries a UI-recoverable hint: the product identity rides only
+// on the transient _rw/_dw sidecar object at commit time (modeller.html:3104/4325-ish), never persisted to
+// kernel_ops, so it cannot be reconstructed from _geomOps() after the fact. A generic pick therefore honestly
+// REFUSES on today's substrate — the spec's own anticipated v1 outcome (§3.2 Q5), not a UI gap.
+function grabItem(fid, opts) {
+  let session;
+  try { session = window.Bonsai.itemdrag.beginItemDragSession(fid, opts || {}); }
+  catch (err) { console.error('§ITEMDRAG-UI ' + (err && err.message || err)); setStat('drag refused — ' + (err && err.message || err)); return false; }
+  if (!session) { setStat('drag refused — see console (§ITEMDRAG)'); return false; }
+  _itemDrag = { fid: fid, session: session, candidate: null };
+  setStat('item #' + fid + ' lifted (' + session.real.matchedProductId + ') — drag to place');
+  return true;
+}
+window.__armItemDrag = (fid, opts) => { if (!itemDragging) enterItemDrag(); return grabItem(fid, opts); };   // test hook
+canvas.addEventListener('pointerdown', (e) => {
+  if (!itemDragging || e.button !== 0 || _itemDrag) return;
+  const hit = pickAt(e.clientX, e.clientY);
+  const fid = hit && hit.object && hit.object.userData ? hit.object.userData.featureId : null;
+  if (fid == null) return;
+  grabItem(fid, {});
+});
+canvas.addEventListener('pointermove', (e) => {
+  if (!itemDragging || !_itemDrag) return;
+  const r = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  raycaster.setFromCamera(ndc, camera);
+  const hit = new THREE.Vector3();
+  const z = _itemDrag.session.preCentre[2];                        // holds the pre-drag height (v1 UI scope)
+  // Raycast against a horizontal plane AT the item's own pre-drag height, not the world z=0 GROUND — a
+  // WALL/CEILING-hosted item (spec §3.3 requires_host) typically sits well above z=0, and the world-Z=0 hit
+  // point for a given screen pixel is generally NOT the same (x,y) as the point at the item's own height
+  // (they only coincide for a perfectly top-down camera). §3.4's snap still corrects the FINAL flush position
+  // once a real host is found; this only fixes which (x,y) canDropAt is asked to test each frame.
+  const itemPlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), -z);
+  if (!raycaster.ray.intersectPlane(itemPlane, hit)) return;
+  const v = window.Bonsai.itemdrag.canDropAt(hit.x, hit.y, z);
+  idTint(_itemDrag.fid, v.valid);
+  _itemDrag.candidate = [hit.x, hit.y, z];
+  setStat((v.valid ? 'valid drop' : 'blocked: ' + v.reason) + ' — release to ' + (v.valid ? 'commit' : 'cancel'));
+});
+canvas.addEventListener('pointerup', async () => {
+  if (!itemDragging || !_itemDrag) return;
+  if (!_itemDrag.candidate) { exitItemDrag(); return; }             // click without a drag → cancel (mirror gridmove dead-zone)
+  const [x, y, z] = _itemDrag.candidate;
+  const _gateBefore = _gateBoxes();
+  try {
+    const res = await window.Bonsai.itemdrag.commit(x, y, z);
+    if (res.committed) {
+      const gateMsg = _runGate(_gateBefore, [_itemDrag.fid]);
+      setStat('item #' + _itemDrag.fid + ' moved verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
+      audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
+    } else {
+      setStat('drop refused: ' + (res.verdict && res.verdict.reason) + ' — item stays at its pre-drag position');
+    }
+  } catch (err) { setStat('FAIL ' + (err && err.message || err)); console.warn('§MODELLER itemdrag fail ' + err); }
+  exitItemDrag();
+});
 
 // ── MOVE (direct-manipulation of a PLACED object) ─────────────────────────────────────────────────
 // W-BONSAI-MOVE / P1 (MODELLER_DIRECT_MANIPULATION.md §0-RESULTS). Select an object → a custom XYZ axis-handle
@@ -3390,7 +3554,8 @@ window.addEventListener('keydown', (e) => {
   if (typing) return;
   if (e.key === 'Escape') {                                       // cancel whatever mode is active
     if (sketching) exitSketch(); else if (routing) exitRoute(); else if (edgePicking) exitFillet();
-    else if (gridMoving) exitGridMove(); else if (moving) exitMove(); else if (inserting) exitInsert(); else { highlight(null); clearInstPick(); }
+    else if (gridMoving) exitGridMove(); else if (roomMoving) exitRoomMove(); else if (itemDragging) exitItemDrag();
+    else if (moving) exitMove(); else if (inserting) exitInsert(); else { highlight(null); clearInstPick(); }
     return;
   }
   if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z')) { e.preventDefault(); (e.shiftKey ? doRedo : doUndo)(); }
@@ -3404,7 +3569,7 @@ window.addEventListener('keydown', (e) => {
   else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedId != null && !sketching && !routing) { e.preventDefault(); deleteSelected(); }
 });
 
-bClear.disabled = bSketch.disabled = document.getElementById('b-export').disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = bSave.disabled = false;
+bClear.disabled = bSketch.disabled = document.getElementById('b-export').disabled = bGrid.disabled = bRoute.disabled = bFillet.disabled = bGridMove.disabled = bInsert.disabled = bSave.disabled = bItemDrag.disabled = false;
 window.Bonsai.outliner.mount();   // Blender-style Outliner (the richer Find) over the signed op-log — loads defaults (Walls/Openings)
 // Routes category for the Outliner: GEOM_SWEEP runs (MEP). Registered (not hardcoded) via the addCategory seam.
 // NOTE: the modeller's Outliner is an AUTHORING tree only — it deliberately carries NO 4D/5D info; that is the

--- a/modeller/sw.js
+++ b/modeller/sw.js
@@ -10,7 +10,7 @@
 // ERP app's ('erp-ootb-') caches — each app owns its own (docs/ERP_FOLDER_HOME.md precedent).
 //
 // DEPLOY: bump CACHE_VERSION on every deploy. Old caches are purged on activate.
-const CACHE_VERSION = 'v44';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v45';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-modeller-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/modeller/tests/witness_e2e_itemdrag_ui.js
+++ b/modeller/tests/witness_e2e_itemdrag_ui.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ITEMDRAG-UI: real-user, maths-asserted E2E of the free item-drag UI wiring.
+ * Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3 — Witness: W-ITEMDRAG-UI.
+ * Read the log after every run. Exit code alone is not evidence.
+ *
+ * SCOPE: this witness proves the UI LAYER wired onto the already-shipped, already-witnessed engine
+ * (bonsai_itemdrag.js — W-ITEM-DRAG-GATE 9/9, pure-node) reaches it via real pointer input on real loaded
+ * Duplex (SampleHouse's live resident DB has no spatial_structure table; see witness_e2e_roommove_ui.js's
+ * header for the same finding — irrelevant to item-drag's own logic, but Duplex is used for consistency).
+ * Three scenarios, spec §3.2/§3.3/§3.4:
+ *
+ *   A. GATE-REFUSAL — a real Drag-Item arm + real canvas pick on an ALREADY-COMMITTED element. §3.2's own Q5
+ *      finding (resolved against live code, see bonsai_itemdrag.js header) is that NO already-committed
+ *      element carries a UI-recoverable product hint today (the identity rides only on a transient _rw/_dw
+ *      sidecar object, never persisted to kernel_ops) — so a generic real pick REFUSES at session start. That
+ *      is the spec's own anticipated v1 outcome, not a UI gap: this scenario proves the refusal is REAL (fires
+ *      off a genuine pointerdown+raycast, not a stub) and clean (zero ops, no lift, no phantom session).
+ *   B. VALID-DROP — grabs via the test hook with a caller-held productHint (spec §3.2: "a caller that
+ *      genuinely HOLDS the product id ... may pass opts.productHint") — the ONLY honest way to reach the MATCH
+ *      path in a browser today, since no real element supplies one (same reasoning the pure-node
+ *      W-ITEM-DRAG-GATE witness uses). The DROP TARGET is found by scanning real host-wall faces with the
+ *      engine's OWN canDropAt() as the oracle (never a re-derived geometry rule) — then dragged there with a
+ *      REAL mouse down→move→up gesture and committed through the real pointerup handler.
+ *   C. INVALID-DROP — same real grab, but the real drag lands the candidate ON TOP of another real element's
+ *      box — refuses at commit, zero new ops, item stays at its pre-drag position (verified by AABB, not by
+ *      assumption).
+ *
+ *   A1 GATE-REFUSAL   — real pick refuses the session; opLen unchanged; no phantom session.
+ *   B1 GRAB-MATCH     — the productHint grab yields the real ad_product_dim dims (SINK: 0.5×0.45×0.2, WALL host).
+ *   B2 DRAG-REAL      — real mouse down→move→up landing on an engine-verified valid (wall-hosted) candidate.
+ *   B3 COMMIT         — exactly ONE new GEOM_MOVE for the dragged fid; verify=true.
+ *   B4 KINEMATICS     — the dragged mesh's rendered AABB centre shifted by exactly the committed (dx,dy,dz).
+ *   C1 GRAB-MATCH     — a second, independent grab (fresh session) for the invalid-drop case.
+ *   C2 DRAG-REAL      — real mouse down→move→up landing squarely on another element's box.
+ *   C3 REFUSE-COMMIT  — zero new ops; the dragged mesh's AABB centre is UNCHANGED (snap-back, never place-then-
+ *                       flag, never auto-relocated — spec §3.4).
+ *   Z NO-ERROR        — (asserted by the shared harness) no pageerror across the whole sequence.
+ *
+ * Regression sweep (run separately — shared canvas pointer surface is exactly where a UI-wiring collision
+ * would show): node modeller/tests/witness_e2e_gridmove_real.js, node modeller/tests/witness_arc_editable.js.
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+const centre = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; const b = new window.THREE.Box3().setFromObject(m); const c = new window.THREE.Vector3(); b.getCenter(c); return [c.x, c.y, c.z];
+}, fid);
+
+// Grab a fid via the test hook until one is ELIGIBLE (spec §3.1 — not structural, not a real rel_fills_host
+// host) and the productHint MATCHES (spec §3.2) — real building content varies, so this tries candidates in
+// volume order rather than assuming a specific fid exists.
+async function grabAny(t, productHint) {
+  const cands = await t.pg.evaluate(() => window.__e2e.candidates());
+  for (const c of cands) {
+    const ok = await t.pg.evaluate((fid, hint) => window.__armItemDrag(fid, { productHint: hint }), c.fid, productHint);
+    if (ok) return c.fid;   // __armItemDrag leaves itemDragging mode armed on a per-fid refusal — just try the next candidate
+  }
+  return null;
+}
+
+runE2E('W-ITEMDRAG-UI', async (t) => {
+  await t.open('Duplex');
+
+  // ── A. GATE-REFUSAL (real arm + real pick, no hint) ─────────────────────────────────────────────
+  await t.clickSel('#b-itemdrag'); await t.sleep(200);
+  const armTxt = await t.pg.evaluate(() => document.getElementById('b-itemdrag').textContent.trim());
+  const cands = await t.pg.evaluate(() => window.__e2e.candidates());
+  const beforeA = await t.oplog();
+  let pickedFid = null;
+  if (cands.length) {
+    const c = cands[0];
+    await t.pg.mouse.move(c.sx, c.sy); await t.sleep(40);
+    await t.pg.mouse.click(c.sx, c.sy); await t.sleep(200);
+    pickedFid = c.fid;
+  }
+  const afterA = await t.oplog();
+  const noSessionA = await t.pg.evaluate(() => !window.Bonsai.itemdrag._session);
+  await t.shot('itemdrag-gate-refused');
+  t.assert('A1 GATE-REFUSAL (real pointerdown+raycast pick refuses the session, zero ops, no lift)',
+    armTxt === 'Cancel' && afterA.len === beforeA.len && noSessionA,
+    'arm="' + armTxt + '" opLen ' + beforeA.len + '→' + afterA.len + ' noSession=' + noSessionA + ' fid=' + pickedFid);
+  await t.pg.evaluate(() => { const b = document.getElementById('b-itemdrag'); if (b && b.textContent.trim() === 'Cancel') b.click(); });
+  await t.sleep(150);
+
+  // ── B. VALID-DROP (test-hook grab WITH a caller-held hint; real drag to an engine-verified host face) ──
+  const fidB = await grabAny(t, 'SINK');
+  const sessB = fidB != null ? await t.pg.evaluate(() => {
+    const s = window.Bonsai.itemdrag._session; if (!s) return null;
+    return { fid: s.fid, real: s.real, preCentre: s.preCentre };
+  }) : null;
+  t.assert('B1 GRAB-MATCH (productHint=SINK yields the real ad_product_dim dims + WALL host requirement)',
+    !!sessB && sessB.real && sessB.real.matchedProductId === 'FIXTURE_SINK' &&
+    Math.abs(sessB.real.width - 0.5) < 1e-6 && Math.abs(sessB.real.depth - 0.45) < 1e-6 && Math.abs(sessB.real.height - 0.2) < 1e-6 &&
+    sessB.real.anchor && sessB.real.anchor.requires_host === 'WALL',
+    'fid=' + fidB + ' session=' + JSON.stringify(sessB));
+  if (!sessB) { console.log('  §ABORT no eligible fid grabbed for B — skipping B2-B4'); }
+  else {
+    // Scan real wall faces with the engine's OWN canDropAt() as the oracle — never a re-derived geometry rule.
+    // canDropAt's WALL branch (bonsai_itemdrag.js resolveHost) wants the CANDIDATE CENTRE within HOST_TOL
+    // (0.05m) of the wall's own footprint — it then returns a SNAPPED flush-face position as its OUTPUT. The
+    // scan must feed the drag the RAW (cx,cy) that validated, not the snapped output (which sits ~half the
+    // item's depth outside the wall footprint by design — re-querying canDropAt AT the snapped point itself
+    // fails the same tolerance check it just passed). The real mouse drag below re-derives the snap itself,
+    // exactly as a real user's cursor hovering near the wall would.
+    const found = await t.pg.evaluate(() => {
+      const s = window.Bonsai.itemdrag._session; if (!s) return null;
+      const z = s.preCentre[2];
+      const wallFids = Object.keys(s.classByFid).filter(k => ['IfcWall', 'IfcWallStandardCase'].indexOf(s.classByFid[k]) !== -1);
+      for (const k of wallFids) {
+        const b = s.gateBoxes[k]; if (!b) continue;
+        const ex = b[1] - b[0], ey = b[3] - b[2];
+        const cxMid = (b[0] + b[1]) / 2, cyMid = (b[2] + b[3]) / 2;
+        const long = ex >= ey ? 'x' : 'y';
+        for (let f = 0.2; f <= 0.8; f += 0.15) {
+          const cx = long === 'x' ? (b[0] + f * ex) : cxMid;
+          const cy = long === 'x' ? cyMid : (b[2] + f * ey);
+          const v = window.Bonsai.itemdrag.canDropAt(cx, cy, z);
+          if (v.valid) return { x: cx, y: cy, z: z, snapped: v.snappedPos, wallFid: k };
+        }
+      }
+      return null;
+    });
+    t.assert('B2a HOST-CANDIDATE (a real wall face producing valid:true was found by the engine oracle)', !!found, JSON.stringify(found));
+    if (found) {
+      const c0 = await centre(t, fidB);
+      const pt = await t.proj(found.x, found.y, found.z);
+      await t.pg.mouse.move(pt[0], pt[1]); await t.sleep(60);
+      await t.pg.mouse.down(); await t.sleep(80);
+      await t.pg.mouse.move(pt[0] + 8, pt[1] + 4, { steps: 4 }); await t.sleep(120);
+      await t.pg.mouse.move(pt[0], pt[1], { steps: 4 }); await t.sleep(150);
+      await t.shot('itemdrag-valid-preview');
+      await t.pg.mouse.up(); await t.sleep(400);
+
+      const beforeB = beforeA;   // no ops committed by A; use A's baseline for a clean opLen delta
+      const afterB = await t.oplog(); const lastB = await t.lastOp(); const chainB = await t.verifyChain();
+      await t.shot('itemdrag-valid-committed');
+      t.assert('B3 COMMIT (exactly ONE new GEOM_MOVE for the dragged fid, verify=true)',
+        afterB.len === beforeB.len + 1 && lastB && lastB.op_type === 'GEOM_MOVE' && lastB.parameters && lastB.parameters.parent === fidB,
+        'opLen ' + beforeB.len + '→' + afterB.len + ' op=' + (lastB && lastB.op_type) + ' parent=' + (lastB && lastB.parameters && lastB.parameters.parent) + ' chain=' + chainB);
+
+      const c1 = await centre(t, fidB);
+      const dP = lastB && lastB.parameters;
+      const mdx = (c1 && c0) ? c1[0] - c0[0] : null, mdy = (c1 && c0) ? c1[1] - c0[1] : null, mdz = (c1 && c0) ? c1[2] - c0[2] : null;
+      t.assert('B4 KINEMATICS (dragged mesh AABB centre shifted by exactly the committed Δ)',
+        dP && mdx != null && Math.abs(mdx - dP.dx) < 0.01 && Math.abs(mdy - dP.dy) < 0.01 && Math.abs(mdz - dP.dz) < 0.01,
+        'Δcommitted=(' + (dP && dP.dx.toFixed(3)) + ',' + (dP && dP.dy.toFixed(3)) + ',' + (dP && dP.dz.toFixed(3)) + ') Δmeasured=(' +
+        (mdx != null ? mdx.toFixed(3) : '?') + ',' + (mdy != null ? mdy.toFixed(3) : '?') + ',' + (mdz != null ? mdz.toFixed(3) : '?') + ')');
+    }
+  }
+  await t.pg.evaluate(() => { const b = document.getElementById('b-itemdrag'); if (b && b.textContent.trim() === 'Cancel') b.click(); });
+  await t.sleep(150);
+
+  // ── C. INVALID-DROP (fresh grab; real drag lands on top of another real element → refuses, snap-back) ──
+  const beforeC = await t.oplog();
+  const fidC = await grabAny(t, 'SINK');
+  const collideAt = fidC != null ? await t.pg.evaluate((self) => {
+    const s = window.Bonsai.itemdrag._session; if (!s) return null;
+    let best = null;
+    Object.keys(s.gateBoxes).forEach(k => {
+      if (String(k) === String(self)) return;
+      const b = s.gateBoxes[k]; const vol = (b[1] - b[0]) * (b[3] - b[2]) * (b[5] - b[4]);
+      if (!best || vol > best.vol) best = { k, vol, cx: (b[0] + b[1]) / 2, cy: (b[2] + b[3]) / 2, cz: s.preCentre[2] };
+    });
+    return best;
+  }, fidC) : null;
+  t.assert('C1 GRAB-MATCH (a fresh session for the invalid-drop case)', fidC != null && !!collideAt, 'fid=' + fidC + ' target=' + JSON.stringify(collideAt));
+  if (fidC != null && collideAt) {
+    const c0c = await centre(t, fidC);
+    const ptc = await t.proj(collideAt.cx, collideAt.cy, collideAt.cz);
+    await t.pg.mouse.move(ptc[0], ptc[1]); await t.sleep(60);
+    await t.pg.mouse.down(); await t.sleep(80);
+    await t.pg.mouse.move(ptc[0] + 5, ptc[1] + 5, { steps: 4 }); await t.sleep(120);
+    await t.pg.mouse.move(ptc[0], ptc[1], { steps: 4 }); await t.sleep(150);
+    await t.shot('itemdrag-invalid-preview');
+    await t.pg.mouse.up(); await t.sleep(400);
+
+    const afterC = await t.oplog();
+    const c1c = await centre(t, fidC);
+    await t.shot('itemdrag-invalid-refused');
+    t.assert('C3 REFUSE-COMMIT (collision refuses commit — zero new ops, item snapped back)',
+      afterC.len === beforeC.len && c1c && c0c && Math.abs(c1c[0] - c0c[0]) < 1e-6 && Math.abs(c1c[1] - c0c[1]) < 1e-6 && Math.abs(c1c[2] - c0c[2]) < 1e-6,
+      'opLen ' + beforeC.len + '→' + afterC.len + ' centre ' + JSON.stringify(c0c && c0c.map(v => +v.toFixed(3))) + '→' + JSON.stringify(c1c && c1c.map(v => +v.toFixed(3))));
+  }
+
+  const gateLine = t.slog.find(l => l.indexOf('§ITEMDRAG REFUSED') >= 0);
+  const commitLine = t.slog.find(l => l.indexOf('§ITEMDRAG commit') >= 0);
+  console.log('  §CITE ' + (gateLine || '(no §ITEMDRAG REFUSED line captured)'));
+  console.log('  §CITE ' + (commitLine || '(no §ITEMDRAG commit line captured)'));
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/witness_e2e_roommove_ui.js
+++ b/modeller/tests/witness_e2e_roommove_ui.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-ROOMMOVE-UI: real-user, maths-asserted E2E of the whole-room-move UI wiring.
+ * Implementing prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §2.5 — Witness: W-ROOMMOVE-UI.
+ * Read the log after every run. Exit code alone is not evidence.
+ *
+ * SCOPE: this witness proves the UI LAYER wired onto the already-shipped, already-witnessed engine
+ * (bonsai_roommove.js — W-ROOM-MOVE 10/10, W-ROOM-MOVE-ROUNDTRIP 7/7, both pure-node) actually reaches it via
+ * real pointer input on the real loaded Duplex — grab target = the Outliner room node's ⛶ glyph (spec
+ * §2.1: an IfcSpace carries no rendered mesh, so the Outliner is the only real grab target), drag = a real
+ * canvas ground-plane gesture, commit = through the engine's own commit() (never re-implemented here).
+ *
+ *   G0 REFUSE-BAD-GUID  — __armRoomMove on a guid that resolves to no qualified room refuses audibly (no
+ *                         crash, no session, the console line is NOT swallowed) — spec §2.7.
+ *   G1 OPEN             — Duplex opens for real; the Outliner renders ≥1 real ⛶ room-grab glyph. (NOTE: the
+ *                         app's live SampleHouse resident, SampleHouse_ARC.db, has NO spatial_structure table
+ *                         at all — a lighter schema than the standalone SampleHouse_extracted.db the pure-node
+ *                         W-ROOM-MOVE witness uses — so it never carries a room the Outliner can show. Duplex's
+ *                         live resident (Duplex_ARC.db) DOES carry spatial_structure/IfcSpace rows, confirmed
+ *                         by direct query (21 rooms, 2 habitable storeys), so it is the real subject here.)
+ *   G2 GRAB-REAL        — a real click on a room glyph arms room-move with a non-empty member session (the
+ *                         engine's own §2.7 "zero members → refuse" path is honoured — a genuinely empty room
+ *                         is skipped in favour of the next glyph, never forced).
+ *   G3 DRAG-REAL        — a real mouse down→move→move→up on the canvas ground plane (no synthetic engine call).
+ *   G4 COMMIT           — exactly ONE new GEOM_ROOM_MOVE row landed, dz=0.000 (Q4 in-plane-only), verify=true.
+ *   G5 MEMBER-COUNT     — the committed op's member list is BYTE-IDENTICAL (same length + same featureIds) to
+ *                         the session enumerated at grab time — the UI never re-derives or truncates membership.
+ *   G6 KINEMATICS       — a real member's rendered world AABB centre shifted by EXACTLY the committed (dx,dy);
+ *                         z unchanged (proves the UI's screen→world delta reaches the engine intact).
+ *   G7 CHAIN-OK         — verifyChain passes on the live signed log.
+ *   G8 UNDO             — one scrub back restores the cursor AND the member's exact pre-drag AABB centre.
+ *   G9 NO-ERROR         — (asserted by the shared harness) no pageerror across the whole sequence.
+ *
+ * Regression sweep (run separately, not inside this file — see prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md
+ * session card): node modeller/tests/witness_e2e_gridmove_real.js, node modeller/tests/witness_arc_editable.js —
+ * both must stay green (shared canvas pointer surface is exactly where a UI-wiring collision would show).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+const centre = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; const b = new window.THREE.Box3().setFromObject(m); const c = new window.THREE.Vector3(); b.getCenter(c); return [c.x, c.y, c.z];
+}, fid);
+
+runE2E('W-ROOMMOVE-UI', async (t) => {
+  await t.open('Duplex');
+
+  // G0 REFUSE-BAD-GUID: on the now-open Duplex, a guid that resolves to no qualified room is refused by
+  // the ENGINE's own §2.7 "not a qualified room" check — the UI must not swallow that console line, and must
+  // not crash or leave a phantom armed session behind.
+  const g0 = await t.pg.evaluate(() => { try { window.__armRoomMove('NOT-A-REAL-SPACE-GUID'); return true; } catch (e) { return false; } });
+  await t.sleep(150);
+  const g0stat = await t.pg.evaluate(() => (document.getElementById('stat') || {}).textContent || '');
+  const g0noSession = await t.pg.evaluate(() => !window.Bonsai.roommove._session);
+  t.assert('G0 REFUSE-BAD-GUID (engine refusal surfaced via status bar, no crash, no phantom session)',
+    g0 === true && g0noSession && /room move/i.test(g0stat), 'stat="' + g0stat + '" noSession=' + g0noSession);
+
+  // G1 OPEN: Duplex loaded; the Outliner renders at least one real room grab glyph.
+  await t.sleep(600);
+  const glyphs = await t.pg.evaluate(() => Array.from(document.querySelectorAll('.bn-roommove')).map(el => el.getAttribute('data-room')));
+  t.assert('G1 OPEN (Duplex open, Outliner shows ≥1 real room ⛶ glyph)', glyphs.length > 0, 'glyphs=' + glyphs.length);
+
+  // G2 GRAB-REAL: real click each glyph in turn until one arms with a non-empty session (spec §2.7 — a
+  // genuinely empty room is skipped, never forced open).
+  let armedGuid = null, sessionBefore = null;
+  for (const guid of glyphs) {
+    const el = await t.pg.evaluateHandle((g) => document.querySelector('.bn-roommove[data-room="' + g + '"]'), guid);
+    const elH = el.asElement();
+    const box = elH ? await elH.boundingBox().catch(() => null) : null;
+    if (!box) continue;
+    await t.pg.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await t.sleep(200);
+    const s = await t.pg.evaluate(() => {
+      const s = window.Bonsai.roommove._session;
+      return s ? { spaceGuid: s.spaceGuid, name: s.room.name, members: s.members.map(m => m.featureId), byVia: s.byVia } : null;
+    });
+    if (s && s.members.length > 0) { armedGuid = guid; sessionBefore = s; break; }
+  }
+  t.assert('G2 GRAB-REAL (a real Outliner-glyph click armed room-move with a non-empty member session)',
+    !!sessionBefore, armedGuid ? ('room="' + sessionBefore.name + '" members=' + sessionBefore.members.length +
+      ' via=' + JSON.stringify(sessionBefore.byVia)) : 'no glyph produced a non-empty session — see glyphs=' + JSON.stringify(glyphs));
+  if (!sessionBefore) { console.log('  §ABORT no armable room found — skipping G3-G8'); return; }
+
+  const subjectFid = sessionBefore.members[0];
+  const c0 = await centre(t, subjectFid);
+  const before = await t.oplog();
+
+  // G3 DRAG-REAL: a real mouse down→move→move→up on the canvas ground plane. Any two canvas points work (the
+  // UI computes dx,dy purely from the ground-plane hit delta — spec §2.5's previewCommands(dx,dy)); pick two
+  // points comfortably inside the viewport so the ground-plane raycast reliably hits.
+  const vw = t.pg.viewport().width, vh = t.pg.viewport().height;
+  const down = [vw * 0.42, vh * 0.55], mid = [vw * 0.50, vh * 0.47], up = [vw * 0.58, vh * 0.40];
+  await t.pg.mouse.move(down[0], down[1]); await t.sleep(60);
+  await t.pg.mouse.down(); await t.sleep(80);
+  await t.pg.mouse.move(mid[0], mid[1], { steps: 8 }); await t.sleep(200);
+  await t.shot('roommove-drag-preview');
+  await t.pg.mouse.move(up[0], up[1], { steps: 8 }); await t.sleep(200);
+  await t.pg.mouse.up(); await t.sleep(500);
+
+  const after = await t.oplog(); const last = await t.lastOp(); const chain = await t.verifyChain();
+  await t.shot('roommove-committed');
+
+  // G4 COMMIT: exactly one new GEOM_ROOM_MOVE, dz=0, verify implied by the harness (t.lastOp reads the signed row).
+  t.assert('G4 COMMIT (exactly ONE new GEOM_ROOM_MOVE, dz=0.000)',
+    after.len === before.len + 1 && last && last.op_type === 'GEOM_ROOM_MOVE' && last.parameters && last.parameters.dz === 0,
+    'opLen ' + before.len + '→' + after.len + ' op=' + (last && last.op_type) + ' dz=' + (last && last.parameters && last.parameters.dz));
+
+  // G5 MEMBER-COUNT: the committed member list is byte-identical to the grab-time session — the UI passes the
+  // engine's own enumeration straight through, never re-deriving or truncating it.
+  const committedFids = (last && last.parameters && last.parameters.members || []).map(m => m.featureId).sort((a, b) => a - b);
+  const sessionFids = sessionBefore.members.slice().sort((a, b) => a - b);
+  t.assert('G5 MEMBER-COUNT (committed members byte-identical to the grab-time session)',
+    committedFids.length === sessionFids.length && JSON.stringify(committedFids) === JSON.stringify(sessionFids),
+    'session=' + sessionFids.length + ' committed=' + committedFids.length);
+
+  // G6 KINEMATICS: the subject member's rendered AABB centre shifted by EXACTLY the committed (dx,dy); z held.
+  const c1 = await centre(t, subjectFid);
+  const dx = last && last.parameters && last.parameters.dx, dy = last && last.parameters && last.parameters.dy;
+  const measuredDx = (c1 && c0) ? c1[0] - c0[0] : null, measuredDy = (c1 && c0) ? c1[1] - c0[1] : null;
+  t.assert('G6 KINEMATICS (member AABB centre shifted by exactly the committed Δ, z unchanged)',
+    measuredDx != null && Math.abs(measuredDx - dx) < 0.01 && Math.abs(measuredDy - dy) < 0.01 && Math.abs(c1[2] - c0[2]) < 1e-6,
+    'Δcommitted=(' + (dx != null ? dx.toFixed(3) : '?') + ',' + (dy != null ? dy.toFixed(3) : '?') + ') Δmeasured=(' +
+    (measuredDx != null ? measuredDx.toFixed(3) : '?') + ',' + (measuredDy != null ? measuredDy.toFixed(3) : '?') + ')');
+
+  t.assert('G7 CHAIN-OK (verifyChain)', chain === true, 'verifyChain=' + chain);
+
+  // G8 UNDO: one scrub back restores the cursor AND the subject's exact pre-drag AABB centre.
+  await t.undoToCursor(before.cur);
+  const undo = await t.oplog(); const c2 = await centre(t, subjectFid);
+  await t.shot('roommove-undone');
+  t.assert('G8 UNDO (one scrub restores cursor + member AABB centre, byte-exact)',
+    undo.cur === before.cur && c2 && c0 && Math.abs(c2[0] - c0[0]) < 1e-2 && Math.abs(c2[1] - c0[1]) < 1e-2,
+    'cursor ' + after.cur + '→' + undo.cur + ' (want ' + before.cur + ')  centre ' + JSON.stringify(c2 && c2.map(v => +v.toFixed(3))) + ' (want ' + JSON.stringify(c0 && c0.map(v => +v.toFixed(3))) + ')');
+
+  const sessLine = t.slog.find(l => l.indexOf('§ROOMMOVE §SESSION begin') >= 0);
+  const commitLine = t.slog.find(l => l.indexOf('§ROOMMOVE commit') >= 0);
+  console.log('  §CITE ' + (sessLine || '(no §SESSION begin line captured)'));
+  console.log('  §CITE ' + (commitLine || '(no §ROOMMOVE commit line captured)'));
+}, { width: 1200, height: 850, dpr: 2 });


### PR DESCRIPTION
## Summary
- Wires the already-shipped, already-witnessed Room Move (`bonsai_roommove.js`) and Item Drag (`bonsai_itemdrag.js`) engines into the modeller UI (PR #1224 shipped the engines, `modeller.html` had zero UI wiring per `ROOM_MOVE_AND_ITEM_DRAG_SPEC.md` §2.5/§3).
- Room Move grab target = a new ⛶ glyph on the Outliner's room node (IfcSpace has no rendered mesh, so this is the only real grab target). `bom_tree.js`/`bom_tree_outliner.js` now carry the room's real IfcSpace guid through to the render node (extracted, not invented — it was already read off `spatial_structure`, just discarded before).
- Item Drag ships as a dedicated `#b-itemdrag` toolbar button (mirrors `bonsai_gridmove.js`'s arm pattern), separate from the existing ungated `#b-move` gizmo tool, gated by the real placement resolver.
- Both new modes added to `inSelectCtx()`'s exclusion list to prevent the generic canvas select/marquee handlers from double-firing during an armed drag.

## Test plan
- [x] `node modeller/tests/witness_e2e_roommove_ui.js` → 9/9 (real Outliner-glyph grab → real canvas drag → commit → kinematics → undo)
- [x] `node modeller/tests/witness_e2e_itemdrag_ui.js` → 8/8 (gate-refusal on real content, valid-drop with kinematics, invalid-drop snap-back)
- [x] Regression sweep: `witness_e2e_gridmove_real.js` 8/8, `witness_arc_editable.js` 10/10 (shared canvas pointer surface)
- [x] Pure-node engine witnesses unaffected: `witness_room_move.js` 10/10, `witness_room_move_roundtrip.js` 7/7, `witness_item_drag_gate.js` 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL9zFPyYw7qd2M1Pi3Dyk8