### PR TITLE
fix(cpe): walk spawns at the walk stretch, trackpad glide, Enter/Space plant+release — Hospital sky-stick bug

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -3449,6 +3449,22 @@
           return true;
         },
         _walkSnap: function(pos, fwd) { return _walkSnap(pos, fwd); },
+        // §CPE_WALK_SPAWN (2026-08-07, user: "SCRUB BAR IS NOT TO BE USED! WALK!!!") — the walk is
+        // self-sufficient: first shoes press spawns at the WALK STRETCH's eye-level start (the fat
+        // authorable tube, where sticks live), computed from the plan itself. The old behaviour —
+        // start wherever B's camera happened to be — meant the aerial dive start on a fresh open,
+        // and the user's Hospital bug report shows the consequence: a snap there clamps to s=0.000
+        // and plants a sky stick. Positions the vfCam directly; returns the pose for logging.
+        _walkSpawnPose: function() {
+          if (!_state || !_state.plan || typeof _state.plan.poseAt !== 'function') return null;
+          var bts = _state.plan.beats || {};
+          var lo = isFinite(bts.spin) ? bts.spin : 0, hi = isFinite(bts.out) ? bts.out : 1;
+          var tn = lo + (hi - lo) * 0.02;   // just inside the walk stretch, clear of the beat seam
+          var p = _state.plan.poseAt(tn);
+          if (!p) return null;
+          if (_state.vfCam) { _state.vfCam.position.set(p.x, p.y, p.z); _state.vfCam.lookAt(p.tx, p.ty, p.tz); }
+          return { tn: tn, x: p.x, y: p.y, z: p.z, tx: p.tx, ty: p.ty, tz: p.tz };
+        },
         // Read-only proof for G-WALK-ISOLATE: whether the stick editor's OWN drag gesture is live
         // right now. `_state.drag` is only ever non-null while a real pointerdown->pointermove
         // sequence, dispatched through the `_wire()`-installed capture-phase listeners, is in

--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -61,6 +61,12 @@
   var LOOK_RAY_FALLBACK_M = 10;    // §CPE_WALK_EDIT_V1 spec's own fallback when the forward ray hits nothing
   var LOG_EVERY_N_FRAMES = 30;     // ~0.5s at 60fps — enough numeric truth without flooding the console
   var MAX_DT = 0.1;                // clamp a long stall (tab switch) so one frame cannot teleport the walker
+  // §CPE_WALK_GLIDE (2026-08-07, user on Hospital: "only able to turn cam but not zoom in (via pinch
+  // out)") — wheel / trackpad-pinch is locomotion: pinch-out / wheel-up glides forward along the
+  // facing, Shift multiplies. Trackpad pinch arrives as ctrl+wheel — same handler, preventDefault
+  // stops the browser's page-zoom.
+  var WHEEL_GLIDE_M = 1.2;         // metres per wheel notch
+  var WHEEL_SPRINT_X = 4;          // Shift multiplier
 
   var _active = false;
   var _cpe = null;          // window.APP.cinemaPathEditor, cached at mount
@@ -76,6 +82,13 @@
   var _freezeEl = null;
   var _tm = null;            // { panel, prevPointerEvents, lockedBtn } or null if TM was not touched
   var _handlers = null;      // DOM listeners installed at mount, removed at unmount
+  // §CPE_WALK_SPAWN (2026-08-07, user: "SCRUB BAR IS NOT TO BE USED! WALK!!!" — after their Hospital
+  // bug report proved a shoes press at the aerial pose plants a sky stick at s=0.000): the walk is
+  // self-sufficient. First shoes press spawns at the WALK STRETCH's eye-level start; Esc keeps this
+  // resume pose so the next shoes press continues exactly where the user stood (snap → review →
+  // continue). Only closing B / the editor (forceStop) clears it.
+  var _resumePose = null;    // { x,y,z, yaw, pitch } from the last stop(); null = spawn fresh
+  var _glideLogged = false;
 
   // ══════════════════ §CPE_WALK_CANVAS_FREEZE — capture / recapture ══════════════════
   function _renderMainOnce() {
@@ -179,7 +192,19 @@
     if (!_active) return;
     var k = (e.key || '').toLowerCase();
     if (k === 'w' || k === 'a' || k === 's' || k === 'd') { _keys[k] = true; e.preventDefault(); e.stopPropagation(); return; }
-    if (k === 'enter') { e.preventDefault(); e.stopPropagation(); _doSnap(); return; }
+    // §CPE_WALK_ENTER_LOCK (2026-08-07, user: "besides ESC, perhaps Enter can be used to lock -
+    // plant stick and set cam pov"): Enter = snap the stick (facing becomes its lookAt pin) AND
+    // exit to review, one stroke. stop() runs after the snap so the resume pose IS the snapped
+    // spot — the next shoes press continues exactly there. Click (mousedown while locked) stays
+    // the snap-and-keep-walking gesture.
+    // Spacebar is Enter's twin (user: "for finger dexterity") — same one-stroke plant+release.
+    if (k === 'enter' || k === ' ') {
+      e.preventDefault(); e.stopPropagation();
+      var r = _doSnap();
+      if (r) console.log('§CPE_WALK_ENTER_LOCK stick planted + walk released for review (resume pose kept) key=' + (k === ' ' ? 'space' : 'enter'));
+      stop();
+      return;
+    }
     if (k === 'escape') { e.preventDefault(); e.stopPropagation(); stop(); return; }
   }
   function _onKeyUp(e) {
@@ -194,6 +219,24 @@
   }
   function _onCanvasClick() {
     if (_active && !document.pointerLockElement) _canvas.requestPointerLock();
+  }
+  // §CPE_WALK_GLIDE — trackpad-first locomotion (user: "it is all mousepad movement... pivot, zoom
+  // in/out"): two-finger scroll and pinch (which browsers deliver as ctrl+wheel) glide the walker
+  // along the facing. Pinch-out / scroll-up (deltaY<0) = forward, Shift = ×WHEEL_SPRINT_X.
+  // preventDefault matters twice: ctrl+wheel would otherwise page-zoom, plain wheel would scroll.
+  function _onWheel(e) {
+    if (!_active || !_vfCam) return;
+    e.preventDefault(); e.stopPropagation();
+    var fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(_vfCam.quaternion);
+    var notches = -e.deltaY / 100;   // wheel notch ≈ 100; trackpads deliver finer-grained deltas
+    var step = notches * WHEEL_GLIDE_M * (e.shiftKey ? WHEEL_SPRINT_X : 1);
+    if (!step) return;
+    _vfCam.position.addScaledVector(fwd, step);
+    if (!_glideLogged) {
+      _glideLogged = true;
+      console.log('§CPE_WALK_GLIDE first glide step=' + step.toFixed(2) + 'm ctrl=' + !!e.ctrlKey +
+        ' (pinch/scroll drives forward-back along facing; ' + WHEEL_GLIDE_M + 'm/notch, Shift ×' + WHEEL_SPRINT_X + ')');
+    }
   }
 
   // ══════════════════ the per-frame walk loop — see §CPE_WALK_CANVAS_FREEZE header comment for
@@ -263,10 +306,27 @@
     if (!canvas) { console.warn('§CPE_WALK_START_FAIL no canvas'); return false; }
 
     _cpe = cpe; _vfCam = vfCam; _canvas = canvas;
-    // Start facing where B already faces (whatever pose the eye/scrub last set), not a hard reset —
-    // continuing the walk from what the user was already looking at.
+    // §CPE_WALK_SPAWN — walk-centric, ZERO scrub involvement (user ruling; the old "start wherever
+    // B's camera happens to be" spawned at the aerial dive start and their Hospital snap planted a
+    // sky stick at s=0.000). Resume the last walked pose if this B session walked before; otherwise
+    // spawn at the walk stretch's eye-level start via the editor's own plan.
+    if (_resumePose) {
+      _vfCam.position.set(_resumePose.x, _resumePose.y, _resumePose.z);
+    } else if (cpe._walkSpawnPose) {
+      var sp = cpe._walkSpawnPose();
+      if (sp) console.log('§CPE_WALK_SPAWN walk-start tn=' + sp.tn.toFixed(3) +
+        ' pos=(' + sp.x.toFixed(2) + ',' + sp.y.toFixed(2) + ',' + sp.z.toFixed(2) +
+        ') — eye-level start of the authorable stretch, scrub not consulted');
+    }
     _vfCam.rotation.reorder && _vfCam.rotation.reorder('XYZ');
     _yaw = _vfCam.rotation.y; _pitch = _vfCam.rotation.x;
+    if (_resumePose) {
+      _yaw = _resumePose.yaw; _pitch = _resumePose.pitch;
+      _vfCam.rotation.set(_pitch, _yaw, 0);
+      console.log('§CPE_WALK_SPAWN resume pos=(' + _resumePose.x.toFixed(2) + ',' + _resumePose.y.toFixed(2) +
+        ',' + _resumePose.z.toFixed(2) + ') yaw=' + (_yaw * 180 / Math.PI).toFixed(1) +
+        'deg pitch=' + (_pitch * 180 / Math.PI).toFixed(1) + 'deg — continuing where the last walk stopped');
+    }
     _keys = { w: false, a: false, s: false, d: false };
     _frame = 0; _snapCount = 0; _lastT = 0;
 
@@ -280,7 +340,7 @@
 
     _handlers = {
       mousemove: _onMouseMove, lockchange: _onLockChange, keydown: _onKeyDown, keyup: _onKeyUp,
-      mousedown: _onMouseDown, click: _onCanvasClick
+      mousedown: _onMouseDown, click: _onCanvasClick, wheel: _onWheel
     };
     document.addEventListener('mousemove', _handlers.mousemove, true);
     document.addEventListener('pointerlockchange', _handlers.lockchange, true);
@@ -288,6 +348,8 @@
     window.addEventListener('keyup', _handlers.keyup, true);
     canvas.addEventListener('mousedown', _handlers.mousedown, true);
     canvas.addEventListener('click', _handlers.click, true);
+    // §CPE_WALK_GLIDE — passive:false so preventDefault can stop ctrl+wheel page-zoom (trackpad pinch)
+    window.addEventListener('wheel', _handlers.wheel, { capture: true, passive: false });
 
     _active = true;
     _syncButton();
@@ -302,6 +364,11 @@
   function stop() {
     if (!_active) return true;
     _active = false;
+    // §CPE_WALK_SPAWN — remember where the walk stopped so the next shoes press CONTINUES here
+    // (snap → Esc review → shoes → next stick, no re-navigation). Cleared only by forceStop
+    // (eye-off / editor close), where the path context that made this pose meaningful is gone.
+    if (_vfCam) _resumePose = { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z,
+                                yaw: _yaw, pitch: _pitch };
     if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
     if (_handlers) {
       document.removeEventListener('mousemove', _handlers.mousemove, true);
@@ -312,6 +379,7 @@
         _canvas.removeEventListener('mousedown', _handlers.mousedown, true);
         _canvas.removeEventListener('click', _handlers.click, true);
       }
+      window.removeEventListener('wheel', _handlers.wheel, { capture: true });
       _handlers = null;
     }
     if (document.pointerLockElement === _canvas && document.exitPointerLock) document.exitPointerLock();
@@ -343,7 +411,9 @@
   window.CpeWalk = {
     toggle: toggle,
     isActive: function() { return _active; },
-    forceStop: stop,
+    // §CPE_WALK_SPAWN — external stops (eye-off, editor close) also clear the resume pose: the
+    // walk context is gone, the next session must spawn fresh at the walk stretch's start.
+    forceStop: function() { _resumePose = null; return stop(); },
     // ══ witness hooks — read-only or exercising the REAL internal function, same precedent
     // cinema_path_editor.js's own `_probe*`/`_*ForTest` hooks already use (e.g. `_setPin`,
     // `_spawnStickForTest`) — never a re-implementation of the maths under test.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v959';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v960';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,8 +824,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=11" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=11" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cpe_walk.js?v=2" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cinema_path_editor.js?v=12" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cpe_walk.js?v=3" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_walk_edit.js
+++ b/witness_cpe_walk_edit.js
@@ -132,9 +132,33 @@ async function gates(browser, BLD) {
   P('G-WALK-ISOLATE-2 mounted: the SAME pointerdown/up is NOT claimed (_unwire actually removed the listeners)',
     claimedDuring === false || claimedDuring === null, `_probeDrag()=${claimedDuring}`);
 
+  // ══ §CPE_WALK_SPAWN gates FIRST — they must read the PRISTINE plan (the sky-snap below re-snakes
+  // the path and would shift every arc-fraction) ══
+  const spawnLog = win1.find(l => l.startsWith('§CPE_WALK_SPAWN walk-start'));
+  const spawnM = spawnLog && spawnLog.match(/pos=\((-?[\d.]+),(-?[\d.]+),(-?[\d.]+)\)/);
+  const poseNow = await page.evaluate(() => window.CpeWalk._poseForTest());
+  P('G-WALK-SPAWN first mount logged a walk-start spawn whose pose IS the live vfCam pose (not the aerial seed)',
+    !!spawnM && !!poseNow && Math.abs(poseNow.x - +spawnM[1]) < 0.01 &&
+    Math.abs(poseNow.y - +spawnM[2]) < 0.01 && Math.abs(poseNow.z - +spawnM[3]) < 0.01,
+    `log=${spawnLog || 'MISSING'} live=(${poseNow ? [poseNow.x.toFixed(2), poseNow.y.toFixed(2), poseNow.z.toFixed(2)] : 'null'})`);
+  const spawnSnap = await page.evaluate(() => {
+    const p = window.CpeWalk._poseForTest();
+    const n0 = window.APP.cinemaPathEditor._probeOverride().bands.length;
+    const r = window.CpeWalk._snapForTest({ x: p.x, y: p.y, z: p.z }, { x: 0, y: 0, z: -1 });
+    return { p, n0, r, n1: window.APP.cinemaPathEditor._probeOverride().bands.length };
+  });
+  // s≈0 is CORRECT here — the spawn IS the walk head. The Hospital regression was s=0.000 with a
+  // 260m-away AERIAL centre; the spawn move kills the aerial pose itself, and centre==pose (at the
+  // logged eye-level walk start, proven above) is what distinguishes the two.
+  P('G-WALK-SPAWN-SNAP a snap at the spawn pose lands ON the walk head (s in [0,0.6], centre==spawn pose, +1 band)',
+    !!spawnSnap.r && spawnSnap.r.s >= 0 && spawnSnap.r.s < 0.6 && spawnSnap.n1 === spawnSnap.n0 + 1 &&
+    spawnSnap.r.centre.x === spawnSnap.p.x && spawnSnap.r.centre.y === spawnSnap.p.y && spawnSnap.r.centre.z === spawnSnap.p.z,
+    `s=${spawnSnap.r ? spawnSnap.r.s.toFixed(4) : 'null'} bands ${spawnSnap.n0}->${spawnSnap.n1}`);
+
   // ══ G-WALK-SNAP-1/2: synthetic snap far from the building — guaranteed raycast miss ══
   const snapPos = { x: setup.mainPose.x + 500, y: setup.mainPose.y + 500, z: setup.mainPose.z };
   const snapFwd = { x: 1, y: 0, z: 0 };
+  const nBeforeSky = await page.evaluate(() => window.APP.cinemaPathEditor._probeOverride().bands.length);
   const mark2 = logs.length;
   const snapRes = await page.evaluate((pos, fwd) => window.CpeWalk._snapForTest(pos, fwd), snapPos, snapFwd);
   await sleep(50);
@@ -151,17 +175,55 @@ async function gates(browser, BLD) {
     lookAtOk, `lookAt=${snapRes ? JSON.stringify(snapRes.lookAt) : 'null'} want=${JSON.stringify(wantLookAt)}`);
   const sOk = !!snapRes && typeof snapRes.s === 'number' && snapRes.s >= 0 && snapRes.s <= 1;
   P('G-WALK-SNAP-1c insertion fraction s is a valid [0,1] arc-fraction', sOk, `s=${snapRes ? snapRes.s : 'null'}`);
-  const bandOk = !!ovAfterSnap && ovAfterSnap.bands.length === setup.nBands + 1 &&
+  const bandOk = !!ovAfterSnap && ovAfterSnap.bands.length === nBeforeSky + 1 &&
     ovAfterSnap.bands[snapRes.bandIndex] && ovAfterSnap.bands[snapRes.bandIndex]._stick === true;
   P('G-WALK-SNAP-2a a real band was inserted (_stick:true, bands.length +1) — reuses §CPE_STICK, not a stub',
-    bandOk, `nBandsBefore=${setup.nBands} nBandsAfter=${ovAfterSnap ? ovAfterSnap.bands.length : 'null'} bandIndex=${snapRes ? snapRes.bandIndex : 'null'} _stick=${ovAfterSnap && snapRes ? ovAfterSnap.bands[snapRes.bandIndex]._stick : 'null'}`);
+    bandOk, `nBandsBefore=${nBeforeSky} nBandsAfter=${ovAfterSnap ? ovAfterSnap.bands.length : 'null'} bandIndex=${snapRes ? snapRes.bandIndex : 'null'} _stick=${ovAfterSnap && snapRes ? ovAfterSnap.bands[snapRes.bandIndex]._stick : 'null'}`);
   P('G-WALK-SNAP-2b the real replan pipeline ran (replanMs present, §CPE_WALK_SNAP logged)',
     !!snapRes && typeof snapRes.replanMs === 'number' && win2.some(l => l.startsWith('§CPE_WALK_SNAP pos=')),
     `replanMs=${snapRes ? snapRes.replanMs : 'null'} logged=${win2.filter(l => l.startsWith('§CPE_WALK_SNAP')).join(' | ')}`);
 
+  // ══ §CPE_WALK_GLIDE — wheel/pinch is locomotion: 3 notches out = 3×1.2m along the facing,
+  // 3 notches back returns to the exact start (reversibility proves the along-facing line). ══
+  const glide = await page.evaluate(() => {
+    const p0 = window.CpeWalk._poseForTest();
+    for (let i = 0; i < 3; i++) window.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, bubbles: true, cancelable: true }));
+    const p1 = window.CpeWalk._poseForTest();
+    for (let i = 0; i < 3; i++) window.dispatchEvent(new WheelEvent('wheel', { deltaY: 100, bubbles: true, cancelable: true }));
+    const p2 = window.CpeWalk._poseForTest();
+    return { p0, p1, p2 };
+  });
+  const glideOut = Math.hypot(glide.p1.x - glide.p0.x, glide.p1.y - glide.p0.y, glide.p1.z - glide.p0.z);
+  const glideBack = Math.hypot(glide.p2.x - glide.p0.x, glide.p2.y - glide.p0.y, glide.p2.z - glide.p0.z);
+  P('G-WALK-GLIDE 3 wheel notches glide 3.60m along the facing; 3 reverse notches return bit-exactly',
+    Math.abs(glideOut - 3.6) < 0.01 && glideBack < 1e-9,
+    `out=${glideOut.toFixed(3)}m back=${glideBack.toExponential(2)}`);
+
+  // ══ §CPE_WALK_SPAWN resume — shoes off/on continues at the identical pose (Esc keeps it;
+  // only eye-off/editor-close forceStop clears it — proven by the later EYE-OFF gate's fresh spawn). ══
+  const resume = await page.evaluate(() => {
+    const before = window.CpeWalk._poseForTest();
+    window.CpeWalk.toggle();
+    const stopped = !window.CpeWalk.isActive();
+    window.CpeWalk.toggle();
+    const after = window.CpeWalk._poseForTest();
+    return { before, stopped, after, active: window.CpeWalk.isActive() };
+  });
+  const resumeOk = resume.stopped && resume.active &&
+    resume.before.x === resume.after.x && resume.before.y === resume.after.y && resume.before.z === resume.after.z &&
+    resume.before.yaw === resume.after.yaw && resume.before.pitch === resume.after.pitch;
+  P('G-WALK-RESUME shoes off/on resumes at the bit-identical pose+facing (no respawn mid-session)',
+    resumeOk, JSON.stringify(resume));
+
   // ══ G-WALK-EYE-OFF-STOP (§CPE_WALK_SHOES_BTN / §CPE_SOLE_OWNER): closing B (the eye, walk's
   // owner surface) while a walk is active must force-stop the walk — freeze dropped, no orphaned
   // session. This doubles as the reset to the unmounted baseline the gates below assume. ══
+  // Precondition: the RESUME gate's same-tick stop/start can be trailed by a deferred
+  // pointerlockchange that auto-stops the walk (a race only a synthetic same-tick toggle hits —
+  // real shoes clicks are separated by human time). Let it land, then ensure a mounted walk.
+  await sleep(200);
+  await page.evaluate(() => { if (!window.CpeWalk.isActive()) window.CpeWalk.toggle(); });
+  await sleep(100);
   const eyeOff = await page.evaluate(() => {
     const activeBefore = window.CpeWalk.isActive();
     window.APP.cinemaPathEditor._vfToggle();   // eye OFF (same call cpe_walk's own start() uses for ON)
@@ -223,6 +285,20 @@ async function gates(browser, BLD) {
   const freezeGoneAfterUnmount = await page.evaluate(() => document.getElementById('cpe-walk-freeze'));
   P('G-WALK-FREEZE-DROP the overlay is removed from the DOM after unmount',
     freezeGoneAfterUnmount === null, `element=${freezeGoneAfterUnmount}`);
+
+  // ══ §CPE_WALK_ENTER_LOCK — Enter plants the stick AND exits to review in ONE stroke (user ask);
+  // click remains snap-and-keep-walking. ══
+  await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(100);
+  const enterRes = await page.evaluate(() => {
+    const nBefore = window.APP.cinemaPathEditor._probeOverride().bands.length;
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    return { nBefore, nAfter: window.APP.cinemaPathEditor._probeOverride().bands.length,
+             active: window.CpeWalk.isActive() };
+  });
+  await sleep(100);
+  P('G-WALK-ENTER-LOCK Enter plants a stick (+1 band) AND exits the walk in one stroke',
+    enterRes.nAfter === enterRes.nBefore + 1 && enterRes.active === false, JSON.stringify(enterRes));
 
   // ══ G-WALK-TEARDOWN: mount again, then close the editor via Cancel — finish() must force-stop it ══
   await page.evaluate(() => window.CpeWalk.toggle());


### PR DESCRIPTION
User's live Hospital report: shoes press at the aerial pose → snap planted a sky stick (s=0.000, centre=(141,69,212)); pinch did nothing; walk read as \"orbit around a static pos only\".

- §CPE_WALK_SPAWN — walk is self-sufficient (no scrub involvement, user ruling): first shoes press spawns at the walk stretch's eye-level start via a new narrow read surface (`_walkSpawnPose`); shoes off/on resumes bit-identically; eye-off/editor-close clears the resume.
- §CPE_WALK_GLIDE — trackpad-first locomotion: two-finger scroll / pinch (ctrl+wheel) glides along the facing, 1.2m/notch, Shift ×4, preventDefault kills page-zoom.
- §CPE_WALK_ENTER_LOCK — Enter/Space = plant stick with facing pin AND release to canvas review in one stroke (replan runs at the plant, backdrop refreshes); click = snap-and-keep-walking.
- Witness 22/22 on Duplex (5 new gates; spawn gates read the pristine plan; eye-off race precondition documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)