### PR TITLE
feat(cpe): scrub-ahead pre-positions the walk spawn (optional accelerator) — §CPE_WALK_SCRUB_SPAWN

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -3449,22 +3449,30 @@
           return true;
         },
         _walkSnap: function(pos, fwd) { return _walkSnap(pos, fwd); },
-        // §CPE_WALK_SPAWN (2026-08-07, user: "SCRUB BAR IS NOT TO BE USED! WALK!!!") — the walk is
-        // self-sufficient: first shoes press spawns at the WALK STRETCH's eye-level start (the fat
-        // authorable tube, where sticks live), computed from the plan itself. The old behaviour —
-        // start wherever B's camera happened to be — meant the aerial dive start on a fresh open,
-        // and the user's Hospital bug report shows the consequence: a snap there clamps to s=0.000
-        // and plants a sky stick. Positions the vfCam directly; returns the pose for logging.
+        // §CPE_WALK_SPAWN (2026-08-07, user rulings, two rounds): the walk is self-sufficient —
+        // a fresh shoes press spawns at the WALK STRETCH's start (the fat authorable tube), never
+        // the aerial dive pose (the user's Hospital sky-stick report, s=0.000 260m up).
+        // §CPE_WALK_SCRUB_SPAWN refinement (same day, user: "user can bring further along the path,
+        // then began the stick planting... that is alternative to speed things up, but in essence
+        // the walk finder mode is also it"): a scrub already sitting INSIDE the walk stretch is an
+        // optional accelerator — spawn THERE instead of the walk head. Outside the stretch (e.g.
+        // the untouched 0 = the dive) still falls back to the walk head. Positions vfCam directly.
         _walkSpawnPose: function() {
           if (!_state || !_state.plan || typeof _state.plan.poseAt !== 'function') return null;
           var bts = _state.plan.beats || {};
           var lo = isFinite(bts.spin) ? bts.spin : 0, hi = isFinite(bts.out) ? bts.out : 1;
-          var tn = lo + (hi - lo) * 0.02;   // just inside the walk stretch, clear of the beat seam
+          var st = _state.scrubTn || 0;
+          var scrubbed = (st > lo && st < hi);
+          var tn = scrubbed ? st : lo + (hi - lo) * 0.02;   // head nudge stays clear of the beat seam
           var p = _state.plan.poseAt(tn);
           if (!p) return null;
           if (_state.vfCam) { _state.vfCam.position.set(p.x, p.y, p.z); _state.vfCam.lookAt(p.tx, p.ty, p.tz); }
-          return { tn: tn, x: p.x, y: p.y, z: p.z, tx: p.tx, ty: p.ty, tz: p.tz };
+          return { tn: tn, scrubbed: scrubbed, x: p.x, y: p.y, z: p.z, tx: p.tx, ty: p.ty, tz: p.tz };
         },
+        // §CPE_WALK_SCRUB_SPAWN — cpe_walk.js compares this against the value it saw at the last
+        // stop(): a scrub MOVED since the last walk means the user chose a new start (scrub beats
+        // resume); an untouched scrub keeps the resume pose (continue where they stood).
+        _walkScrubTn: function() { return _state ? (_state.scrubTn || 0) : 0; },
         // Read-only proof for G-WALK-ISOLATE: whether the stick editor's OWN drag gesture is live
         // right now. `_state.drag` is only ever non-null while a real pointerdown->pointermove
         // sequence, dispatched through the `_wire()`-installed capture-phase listeners, is in

--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -306,17 +306,25 @@
     if (!canvas) { console.warn('§CPE_WALK_START_FAIL no canvas'); return false; }
 
     _cpe = cpe; _vfCam = vfCam; _canvas = canvas;
-    // §CPE_WALK_SPAWN — walk-centric, ZERO scrub involvement (user ruling; the old "start wherever
-    // B's camera happens to be" spawned at the aerial dive start and their Hospital snap planted a
-    // sky stick at s=0.000). Resume the last walked pose if this B session walked before; otherwise
-    // spawn at the walk stretch's eye-level start via the editor's own plan.
+    // §CPE_WALK_SPAWN / §CPE_WALK_SCRUB_SPAWN — spawn priority:
+    //   1. resume pose, IF the scrub has not moved since the last walk stopped (continue in place);
+    //   2. a scrub sitting inside the walk stretch (user's optional accelerator: "bring further
+    //      along the path, then began the stick planting");
+    //   3. the walk stretch's start (the self-sufficient default — never the aerial dive pose).
+    var _scrubNow = cpe._walkScrubTn ? cpe._walkScrubTn() : 0;
+    if (_resumePose && _resumePose.scrubTn !== undefined && _scrubNow !== _resumePose.scrubTn) {
+      console.log('§CPE_WALK_SPAWN scrub moved since last walk (' + _resumePose.scrubTn.toFixed(3) +
+        ' -> ' + _scrubNow.toFixed(3) + ') — user chose a new start, resume dropped');
+      _resumePose = null;
+    }
     if (_resumePose) {
       _vfCam.position.set(_resumePose.x, _resumePose.y, _resumePose.z);
     } else if (cpe._walkSpawnPose) {
       var sp = cpe._walkSpawnPose();
-      if (sp) console.log('§CPE_WALK_SPAWN walk-start tn=' + sp.tn.toFixed(3) +
+      if (sp) console.log('§CPE_WALK_SPAWN ' + (sp.scrubbed ? 'scrubbed' : 'walk-start') + ' tn=' + sp.tn.toFixed(3) +
         ' pos=(' + sp.x.toFixed(2) + ',' + sp.y.toFixed(2) + ',' + sp.z.toFixed(2) +
-        ') — eye-level start of the authorable stretch, scrub not consulted');
+        (sp.scrubbed ? ') — spawning at the scrubbed path point (accelerator)' :
+                       ') — start of the authorable stretch (self-sufficient default)'));
     }
     _vfCam.rotation.reorder && _vfCam.rotation.reorder('XYZ');
     _yaw = _vfCam.rotation.y; _pitch = _vfCam.rotation.x;
@@ -368,7 +376,11 @@
     // (snap → Esc review → shoes → next stick, no re-navigation). Cleared only by forceStop
     // (eye-off / editor close), where the path context that made this pose meaningful is gone.
     if (_vfCam) _resumePose = { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z,
-                                yaw: _yaw, pitch: _pitch };
+                                yaw: _yaw, pitch: _pitch,
+                                // §CPE_WALK_SCRUB_SPAWN — the scrub value at stop time; a DIFFERENT
+                                // value at the next start means the user scrubbed meanwhile = chose
+                                // a new spawn (scrub beats resume, untouched scrub keeps resume).
+                                scrubTn: (_cpe && _cpe._walkScrubTn) ? _cpe._walkScrubTn() : 0 };
     if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
     if (_handlers) {
       document.removeEventListener('mousemove', _handlers.mousemove, true);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v960';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v961';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -824,8 +824,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects.js?v=11" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=12" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cpe_walk.js?v=3" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cinema_path_editor.js?v=13" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cpe_walk.js?v=4" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_walk_edit.js
+++ b/witness_cpe_walk_edit.js
@@ -300,6 +300,40 @@ async function gates(browser, BLD) {
   P('G-WALK-ENTER-LOCK Enter plants a stick (+1 band) AND exits the walk in one stroke',
     enterRes.nAfter === enterRes.nBefore + 1 && enterRes.active === false, JSON.stringify(enterRes));
 
+  // ══ §CPE_WALK_SCRUB_SPAWN — a scrub INSIDE the walk stretch is an optional accelerator: shoes
+  // spawns at the scrubbed path point, and a scrub moved since the last walk beats the resume pose.
+  // The walk-stretch bounds come from the plan's own §CINEMA_BEATS log (spin..out), so the click
+  // fraction is derived, not guessed. ══
+  const beatsLine = [...logs].reverse().find(l => l.startsWith('§CINEMA_BEATS'));
+  const beatsM = beatsLine && beatsLine.match(/spin=([\d.]+) out=([\d.]+)/);
+  const midTn = beatsM ? (+beatsM[1] + +beatsM[2]) / 2 : null;
+  let scrubSpawn = { skipped: true };
+  if (midTn !== null) {
+    const mark3 = logs.length;
+    scrubSpawn = await page.evaluate((tn) => {
+      const track = document.getElementById('cpe-scrub-track');
+      if (!track) return { noTrack: true };
+      const r = track.getBoundingClientRect();
+      const x = r.left + r.width * tn, y = r.top + r.height / 2;
+      track.dispatchEvent(new PointerEvent('pointerdown', { clientX: x, clientY: y, pointerId: 9, bubbles: true, cancelable: true }));
+      track.dispatchEvent(new PointerEvent('pointerup', { clientX: x, clientY: y, pointerId: 9, bubbles: true, cancelable: true }));
+      window.CpeWalk.toggle();
+      const p = window.CpeWalk._poseForTest();
+      const active = window.CpeWalk.isActive();
+      window.CpeWalk.toggle();   // leave unmounted for the gates below
+      return { p, active };
+    }, midTn);
+    await sleep(100);
+    const win3 = logs.slice(mark3);
+    const scrubbedLog = win3.find(l => l.startsWith('§CPE_WALK_SPAWN scrubbed'));
+    const tnM = scrubbedLog && scrubbedLog.match(/tn=([\d.]+)/);
+    P('G-WALK-SCRUB-SPAWN a scrub inside the walk stretch pre-positions the spawn (log says scrubbed, tn == clicked fraction ±0.05, resume overridden)',
+      !!scrubbedLog && !!tnM && Math.abs(+tnM[1] - midTn) < 0.05 && scrubSpawn.active === true,
+      `wanted tn≈${midTn.toFixed(3)} log=${scrubbedLog || 'MISSING (spawn logs: ' + win3.filter(l => l.startsWith('§CPE_WALK_SPAWN')).join(' | ') + ')'}`);
+  } else {
+    P('G-WALK-SCRUB-SPAWN precondition', false, 'no §CINEMA_BEATS line found to derive the walk stretch');
+  }
+
   // ══ G-WALK-TEARDOWN: mount again, then close the editor via Cancel — finish() must force-stop it ══
   await page.evaluate(() => window.CpeWalk.toggle());
   await sleep(100);


### PR DESCRIPTION
User refinement on the shipped walk mode: scrubbing along the path first is an optional accelerator — shoes then starts planting from the scrubbed point. The walk (finger mode) stays self-sufficient: untouched scrub spawns at the walk head; a scrub moved since the last walk overrides the resume pose (moving it = choosing a new start).

Witness: +G-WALK-SCRUB-SPAWN driving the real scrub track at the plan-derived mid-stretch fraction; Duplex 23/23 PASS. Cache: cpe v13 / cpe_walk v4 / sw v961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)