### PR TITLE
fix(night): quad rotation + drop-height + light-churn hiccup, brightness tune

### DIFF
--- a/tests/witness_billboard_nameplate.js
+++ b/tests/witness_billboard_nameplate.js
@@ -210,6 +210,11 @@ function makeOverlay(guid) {
   const logs = [];
   const mk = new Function('MESH', 'GUID', 'LOGS', `
     var _billboardNameMesh = MESH, _billboardNameGuid = GUID, _nameVisLast = null;
+    // §GLOW_BUILDUP_GATE (2026-08-07) extended this setter to fan out to other §TM_OVERLAY_SYNC
+    // consumers (glow sprites) via _tmVisListeners — a real closure var declared alongside this
+    // setter in the shipped file, outside FX_SRC's own extracted span (same as _billboardNameMesh
+    // above). Empty here: this witness only exercises the billboard-nameplate half.
+    var _tmVisListeners = [];
     var A = { markDirty: function(){} };
     var console = { log: function(s){ LOGS.push(s); } };
     var window = {};

--- a/tests/witness_glow_buildup_gate.js
+++ b/tests/witness_glow_buildup_gate.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * W-GLOW-BUILDUP-GATE — §GLOW_BUILDUP_GATE (2026-08-07).
+ *
+ * ISSUE THIS TEST EXPOSES: a MaxQ buildup bake (Alt+C, buildup ON) showed every light fixture in
+ * the FINISHED building glowing from Day 1, regardless of how much of the building was actually
+ * built yet — user, verbatim: "all the lights are lighted and not following the buildup schedule".
+ * Root cause: A._loadNightFixtures() (tools.js) reads fixture positions from the final, fully-built
+ * elements_meta/element_transforms snapshot with zero join to the 4D schedule, and §PHOTO_GLOW_SPRITE
+ * (effects.js _glowOn) staged a glow sprite for every one of them unconditionally.
+ *
+ * Fix: thread guid through the fixture query, and gate _glowOn()'s sprite list through the SAME
+ * §TM_OVERLAY_SYNC per-tick predicate Time Machine already hands to the billboard-nameplate overlay
+ * (effects.js A._tmOverlayRegister / window.__tmOverlaySync) — extended into a small fan-out
+ * (A._tmVisSubscribe / A._tmIsVisible) so a second consumer can read it without re-deriving
+ * placed/frontier/recent itself.
+ *
+ * NOT A REIMPLEMENTATION. All three pieces of logic under test — Time Machine's op→state loop, the
+ * §TM_OVERLAY_SYNC fan-out (A._tmOverlayRegister/_tmIsVisible/_tmVisSubscribe), and the glow-sprite
+ * filter line itself — are extracted from the SHIPPED SOURCE TEXT by exact-substring match and run
+ * via new Function(), against REAL fixture guids + REAL kernel_ops timestamps from a real 4D DB.
+ * If any source changes shape, extraction FAILS LOUDLY rather than silently grading a stale copy.
+ *
+ * Run:  node tests/witness_glow_buildup_gate.js 2>&1 | tee /tmp/W_GLOW_GATE.log
+ *       (then READ THE LOG — exit code is not evidence.)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const DB = '/home/red1/Downloads/OPEN SOURCE BIM/TerminalHi4D.db';
+
+let pass = 0, fail = 0;
+function gate(id, claim, ok, detail) {
+  (ok ? pass++ : fail++);
+  console.log((ok ? '✅' : '❌') + ' ' + id + ' — ' + claim + '\n     ' + detail);
+}
+function q(sql) { return execFileSync('sqlite3', ['-noheader', DB, sql], { encoding: 'utf8' }).trim(); }
+function qrows(sql) { const out = q(sql); return out ? out.split('\n').map(l => l.split('|')) : []; }
+
+console.log('§GLOW_GATE_WITNESS start db=' + DB);
+
+const tmSrc = fs.readFileSync(path.join(ROOT, 'viewer/time_machine.js'), 'utf8');
+const fxSrc = fs.readFileSync(path.join(ROOT, 'viewer/effects.js'), 'utf8');
+const toolsSrc = fs.readFileSync(path.join(ROOT, 'viewer/tools.js'), 'utf8');
+
+// ── extract (a) renderAtTime's op→state loop, verbatim (same anchor as witness_billboard_nameplate.js) ──
+const LOOP_HEAD = '    for (var i = 0; i < _ops.length; i++) {\n      var op = _ops[i];\n      if (op.start_ts > cursorMs) break;';
+const li = tmSrc.indexOf(LOOP_HEAD);
+if (li < 0) { console.log('❌ EXTRACT — renderAtTime op loop not found in viewer/time_machine.js (source changed shape)'); process.exit(1); }
+let depth = 0, end = -1;
+for (let i = li; i < tmSrc.length; i++) {
+  if (tmSrc[i] === '{') depth++;
+  else if (tmSrc[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const LOOP_SRC = tmSrc.slice(li, end);
+
+// ── extract (b) the §TM_OVERLAY_SYNC fan-out block, verbatim: _tmVisListeners / _lastTmIsVisible /
+//    A._tmVisSubscribe / A._tmIsVisible / A._tmOverlayRegister (which installs window.__tmOverlaySync) ──
+const FAN_ANCHOR = 'var _tmVisListeners = [];';
+const fai = fxSrc.indexOf(FAN_ANCHOR);
+if (fai < 0) { console.log('❌ EXTRACT — §GLOW_BUILDUP_GATE fan-out block not found in viewer/effects.js'); process.exit(1); }
+const REG_HEAD = 'A._tmOverlayRegister = function() {';
+const rhi = fxSrc.indexOf(REG_HEAD, fai);
+if (rhi < 0) { console.log('❌ EXTRACT — A._tmOverlayRegister not found after fan-out block'); process.exit(1); }
+const rbrace = fxSrc.indexOf('{', rhi);
+depth = 0; end = -1;
+for (let i = rbrace; i < fxSrc.length; i++) {
+  if (fxSrc[i] === '{') depth++;
+  else if (fxSrc[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+// consume the trailing `;` after the assignment, same as the surrounding statement
+while (fxSrc[end] === ';') end++;
+const FANOUT_SRC = fxSrc.slice(fai, end);
+
+// ── extract (c) the glow-sprite filter line itself, verbatim ──
+const FILTER_LINE = 'var pos = allPos.filter(function(p) { return p.__guid == null || A._tmIsVisible(p.__guid); });';
+if (fxSrc.indexOf(FILTER_LINE) < 0) { console.log('❌ EXTRACT — §GLOW_BUILDUP_GATE filter line not found in viewer/effects.js _glowOn()'); process.exit(1); }
+
+console.log('§GLOW_GATE_WITNESS extracted tmLoop=' + LOOP_SRC.length + 'B fanout=' + FANOUT_SRC.length +
+  'B filterLine=' + FILTER_LINE.length + 'B');
+
+// ── G0: the fixture query carries guid through, and the world-position mapper tags __guid ──
+const sqlHasGuid = /SELECT t\.center_x, t\.center_y, t\.center_z, m\.element_name, t\.bbox_z, m\.guid FROM elements_meta/.test(toolsSrc);
+const pushHasGuid = /A\._nightFixtures\.push\(\{ x: row\[0\], y: row\[1\], z: row\[2\], name: row\[3\] \|\| '', h: row\[4\] \|\| 0, guid: row\[5\] \|\| null \}\)/.test(toolsSrc);
+const posHasGuid = /p\.__guid = f\.guid \|\| null;/.test(toolsSrc);
+gate('G0', 'fixture guid is threaded from the SQL row through to the world-space position object',
+  sqlHasGuid && pushHasGuid && posHasGuid,
+  'SELECT includes m.guid=' + sqlHasGuid + '  _nightFixtures row carries guid=' + pushHasGuid +
+  '  world position carries __guid=' + posHasGuid);
+
+// ── real data: every IfcLightFixture in Terminal_Hi that has its own ELEMENT_PLACE op ──
+const fixtureRows = qrows("SELECT m.guid, k.timestamp, json_extract(k.parameters,'$._end_ts') " +
+  "FROM elements_meta m JOIN kernel_ops k ON k.output_guid=m.guid " +
+  "WHERE m.ifc_class='IfcLightFixture' AND k.op_type='ELEMENT_PLACE' ORDER BY k.timestamp");
+if (!fixtureRows.length) { console.log('❌ no IfcLightFixture kernel_ops rows found — DB changed shape'); process.exit(1); }
+const fixtures = fixtureRows.map(r => ({ guid: r[0], start: +r[1], end: +r[2] }));
+const fxStart = Math.min.apply(null, fixtures.map(f => f.start));
+const fxEnd = Math.max.apply(null, fixtures.map(f => f.end));
+const N = fixtures.length;
+console.log('§GLOW_GATE_WITNESS fixtures=' + N + ' installWindow=' + new Date(fxStart).toISOString() +
+  '..' + new Date(fxEnd).toISOString());
+
+// tmState — SAME shape as witness_billboard_nameplate.js, driven off ONLY the fixture ops (a guid's
+// placed/frontier/recent entry depends only on that guid's own op, never on any other guid's op).
+function tickMs() { return 3200000; }
+const _ops = fixtures.map(f => ({ start_ts: f.start, end_ts: f.end, output_guid: f.guid, input_guids: [f.guid], parameters: {} }));
+function tmState(cursorMs) {
+  const placed = {}, frontier = {}, recent = {}, arrival = {};
+  const lingerMs = tickMs() * 3;
+  const run = new Function('_ops', 'cursorMs', 'placed', 'frontier', 'recent', 'arrival', 'lingerMs', 'window', '_sfxPhases',
+    LOOP_SRC + '\n return null;');
+  run(_ops, cursorMs, placed, frontier, recent, arrival, lingerMs, {}, null);
+  return { placed, frontier, recent };
+}
+const PRED = 'return !!placed[g] || !!frontier[g] || recent[g] !== undefined;';
+if (tmSrc.indexOf(PRED) < 0) { console.log('❌ EXTRACT — §TM_OVERLAY_SYNC predicate not found in viewer/time_machine.js'); process.exit(1); }
+const predFn = new Function('placed', 'frontier', 'recent', 'return function(g){ ' + PRED + ' };');
+
+// the SHIPPED fan-out, sandboxed with a real A/window/console
+function makeHarness() {
+  const A = {};
+  const windowObj = {};
+  const logs = [];
+  const consoleObj = { log: s => logs.push(s) };
+  // §TM_OVERLAY_SYNC's setter also reads _billboardNameMesh/_billboardNameGuid — real module-level
+  // vars declared elsewhere in effects.js (the billboard-nameplate feature), outside FANOUT_SRC's own
+  // extracted span. Stub them as absent (no nameplate built in this sandbox) — same as any building
+  // with no config.json/buildingName, where A._tmOverlayRegister() runs from _glowOn() alone.
+  const build = new Function('A', 'window', 'console',
+    'var _billboardNameMesh = null, _billboardNameGuid = null;\n' + FANOUT_SRC + '\nreturn A;');
+  build(A, windowObj, consoleObj);
+  A._tmOverlayRegister();   // installs window.__tmOverlaySync, exactly as _glowOn() now does
+  return { A, window: windowObj, logs };
+}
+// the SHIPPED filter line, executed as-is (not re-derived)
+const runFilter = new Function('allPos', 'A', FILTER_LINE + '\nreturn pos;');
+
+const allPos = fixtures.map(f => ({ __guid: f.guid }));
+
+// ── V1: EARLY buildup — mid-way through the fixtures' own install window ──
+const midCursor = Math.floor((fxStart + fxEnd) / 2);
+const stMid = tmState(midCursor);
+const predMid = predFn(stMid.placed, stMid.frontier, stMid.recent);
+const groundTruthMid = new Set(fixtures.filter(f => predMid(f.guid)).map(f => f.guid));
+
+const hMid = makeHarness();
+hMid.window.__tmOverlaySync(predMid);
+const shippedMid = runFilter(allPos, hMid.A);
+const shippedMidGuids = new Set(shippedMid.map(p => p.__guid));
+const setsEqualMid = shippedMidGuids.size === groundTruthMid.size &&
+  [...groundTruthMid].every(g => shippedMidGuids.has(g));
+gate('V1', 'mid-buildup: the glow filter matches Time Machine\'s own placed/frontier/recent set exactly — partial, not all-or-nothing',
+  setsEqualMid && groundTruthMid.size > 0 && groundTruthMid.size < N,
+  'cursor=' + new Date(midCursor).toISOString() + '  groundTruth=' + groundTruthMid.size + '/' + N +
+  '  shippedFilter=' + shippedMidGuids.size + '/' + N + '  setsEqual=' + setsEqualMid +
+  ' (both must be strictly between 0 and ' + N + ' to prove this is a REAL partial gate, not a stuck 0 or N)');
+
+// ── V2: THE LITERAL REGRESSION — cursor at project/fixture start, before any fixture is placed ──
+const stStart = tmState(fxStart - 1);
+const predStart = predFn(stStart.placed, stStart.frontier, stStart.recent);
+const hStart = makeHarness();
+hStart.window.__tmOverlaySync(predStart);
+const shippedStart = runFilter(allPos, hStart.A);
+gate('V2', '"all the lights are lighted... not following the buildup schedule" — ZERO fixtures glow before the first one is even scheduled to install',
+  shippedStart.length === 0,
+  'cursor=' + new Date(fxStart - 1).toISOString() + ' (1ms before the first fixture op)  glowing=' +
+  shippedStart.length + '/' + N + ' (must be 0 — this is the exact defect reported live)');
+
+// ── V3: full build — every fixture placed ──
+const stEnd = tmState(fxEnd);
+const predEnd = predFn(stEnd.placed, stEnd.frontier, stEnd.recent);
+const hEnd = makeHarness();
+hEnd.window.__tmOverlaySync(predEnd);
+const shippedEnd = runFilter(allPos, hEnd.A);
+gate('V3', 'finished building: every fixture glows once the buildup has actually reached its own install time',
+  shippedEnd.length === N,
+  'cursor=' + new Date(fxEnd).toISOString() + ' (last fixture\'s own end_ts)  glowing=' + shippedEnd.length + '/' + N);
+
+// ── V4: TM OFF must restore full glow — plain Night Mode outside any buildup is UNCHANGED by this fix ──
+const hOff = makeHarness();
+hOff.window.__tmOverlaySync(null);   // §TM_OVERLAY_SYNC's own convention: null = "TM is off, show everything"
+const shippedOff = runFilter(allPos, hOff.A);
+gate('V4', 'Time Machine inactive (plain Night Mode, no buildup bake in progress) — every fixture glows, exactly as before this fix',
+  shippedOff.length === N,
+  'isVisible=null  glowing=' + shippedOff.length + '/' + N + ' (regression guard: this fix must not touch Night Mode outside a buildup)');
+
+console.log('\n§GLOW_GATE_WITNESS done pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3366,15 +3366,16 @@ async function setupEffects(A, renderer, scene, camera) {
     _emberOff();
     // §GLOW_LENS_QUAD: the fitted lens quad is still-only — always tear it down here.
     _glowLensOff();
-    // §PHOTO_GLOW_SPRITE: restage rather than remove when night mode is still on — the sprites
-    // belong to NIGHT, not to the still; only their bloom was still-only. Restaging also refreshes
-    // the eye offset against wherever the camera ended up.
+    // §GLOW_SPRITE_NAV_OFF (2026-08-07): the round sprite no longer restages for nav — live
+    // navigation runs on the real point lights only now (see tools.js toggleNightMode). Still
+    // torn down unconditionally so it can never survive into navigation.
     _glowOff();
-    if (A._nightMode) _glowOn();
-    // §NIGHT_STILL_LIGHTS: hand the navigation budget back, or the 4x set follows the user into
-    // their next orbit and the frame rate goes with it.
-    if (A._nightMaxLights !== 12 && typeof A._nightUpdateLights === 'function') {
-      A._nightMaxLights = 12;
+    // §NIGHT_STILL_LIGHTS: hand the navigation budget back, or the still's raised set follows the
+    // user into their next orbit and the frame rate goes with it. Compares against the CURRENT nav
+    // default (A._nightMaxLightsNav), not a stale literal, so §NIGHT_LIGHT_BUDGET_UP-style tuning
+    // never silently breaks this reset.
+    if (A._nightMaxLights !== A._nightMaxLightsNav && typeof A._nightUpdateLights === 'function') {
+      A._nightMaxLights = A._nightMaxLightsNav;
       A._nightNearFadeFloor = 0.3;
       if (A._nightLights && A._nightLights.length) A._nightUpdateLights();
     }
@@ -3870,10 +3871,9 @@ async function setupEffects(A, renderer, scene, camera) {
     // budget. Re-arming it made Alt+S measurably heavier (user: "alt-s also getting heavy";
     // §STILL_REFINE elapsedMs 4496 -> 6560 on Hospital), which is exactly what 4x the point lights
     // costs: per-fragment lighting on every lit material, plus a shader recompile when the count
-    // changes. So it stays OFF — opt in with A._nightStillBoost = true.
-    // It also buys little now: §PHOTO_GLOW_SPRITE already makes all 1272 fixtures READ as lit for
-    // one draw call, and the point lights only add throw onto nearby surfaces. The finding stands
-    // recorded; the cost is not paid by default.
+    // changes. It shipped OFF by default for that reason.
+    // §NIGHT_LIGHT_BUDGET_UP (2026-08-07): RE-ARMED — user directive explicitly accepts this cost
+    // ("we got speed... throw all in, up to 50 as it is baking"), see tools.js A._nightStillBoost.
     if (A._nightStillBoost &&
         A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = A._nightMaxLightsStill;

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3578,10 +3578,11 @@ async function setupEffects(A, renderer, scene, camera) {
     return _glowTex;
   }
 
-  function _glowOn() {
+  function _glowOn(filterFn) {
     if (!A._glowSpriteEnabled || _glowPoints) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
     var pos = A._nightFixtureWorldPositions();
+    if (filterFn) pos = pos.filter(filterFn);
     if (!pos || !pos.length) { console.log('§PHOTO_GLOW_SPRITE no luminaires in this building — nothing to light'); return; }
     // Offset toward the eye, computed ONCE: for a still the camera is frozen, so once is exact; in
     // navigation a 0.15m staleness as the camera moves is below the size of the halo it positions.
@@ -3697,6 +3698,19 @@ async function setupEffects(A, renderer, scene, camera) {
   function _glowLensOn() {
     if (_glowLensMesh) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
+    // §GLOW_LENS_NO_SYNTH (2026-08-07, user: "misfiring night lights... have to remove those false
+    // lights"). A building with zero real named/classed luminaires falls back to A._loadNightFixtures'
+    // §S259 synthetic grid — fake positions spread every ~15m across the WHOLE storey footprint,
+    // indoors or not (confirmed on LTU_AHouse: 0 real matches, so the scattered rectangles over its
+    // outdoor courtyard were 100% fabricated positions). Sizing/orienting a quad to a position that
+    // corresponds to no real fixture is exactly the kind of invention this project's rules forbid —
+    // skip the lens entirely when the source is synthetic. The round nav sprite is untouched by this
+    // guard (out of the scope the user set — "night fly thru is OK").
+    if (A._nightFixtureSource && A._nightFixtureSource.indexOf('synthetic') === 0) {
+      console.log('§GLOW_LENS_QUAD skipped — fixture source is synthetic (no real luminaires in this ' +
+        'building), a lens would be sized/oriented to a fabricated position');
+      return;
+    }
     var pos = A._nightFixtureWorldPositions();
     if (!pos || !pos.length) return;
     var cam = A.camera.position;
@@ -3785,7 +3799,13 @@ async function setupEffects(A, renderer, scene, camera) {
     // §GLOW_LENS_QUAD (2026-08-07): the still gets the fitted lens quad, not the round nav sprite —
     // "only for the render" (user directive). Night mode may already have staged the round sprite;
     // swap it for the quad rather than stacking both.
-    _glowOff(); _glowLensOn();
+    // §GLOW_LENS_EXIT_FIX: the quad deliberately skips exit signs (§GLOW_EXIT_SOFT — a backlit panel,
+    // not a lens), so a plain swap left them with NO glow at all during the still, a regression from
+    // before this change (found on the Clinic screenshot). Stage the round sprite for the exit-sign
+    // SUBSET only, alongside the quad for everything else, so exits keep their soft glow.
+    _glowOff();
+    _glowOn(function(p) { return p.__exit; });
+    _glowLensOn();
     // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
     // navigation budget (every light costs per-pixel work on every lit material every frame); a
     // frozen still renders once and then sits there, so that budget does not apply to it. The

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3752,22 +3752,8 @@ async function setupEffects(A, renderer, scene, camera) {
   function _glowLensOn() {
     if (_glowLensMesh) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
-    // §GLOW_LENS_NO_SYNTH (2026-08-07, user: "misfiring night lights... have to remove those false
-    // lights"). A building with zero real named/classed luminaires falls back to A._loadNightFixtures'
-    // §S259 synthetic grid — fake positions spread every ~15m across the WHOLE storey footprint,
-    // indoors or not (confirmed on LTU_AHouse: 0 real matches, so the scattered rectangles over its
-    // outdoor courtyard were 100% fabricated positions). Sizing/orienting a quad to a position that
-    // corresponds to no real fixture is exactly the kind of invention this project's rules forbid —
-    // skip the lens entirely when the source is synthetic. The round nav sprite is untouched by this
-    // guard (out of the scope the user set — "night fly thru is OK").
-    if (A._nightFixtureSource && A._nightFixtureSource.indexOf('synthetic') === 0) {
-      console.log('§GLOW_LENS_QUAD skipped — fixture source is synthetic (no real luminaires in this ' +
-        'building), a lens would be sized/oriented to a fabricated position');
-      return;
-    }
     var pos = A._nightFixtureWorldPositions();
     if (!pos || !pos.length) return;
-    var cam = A.camera.position;
     var geo = new THREE.PlaneGeometry(1, 1);
     var mat = new THREE.MeshBasicMaterial({
       color: 0xffffff, transparent: true, blending: THREE.AdditiveBlending,
@@ -3782,15 +3768,23 @@ async function setupEffects(A, renderer, scene, camera) {
     // Plane's default normal is +Z; rotate +90 deg about X so it faces -Y (down, toward the floor —
     // matches §GLOW_EMIT_DOWN, the direction the fixture actually emits and the direction __drop nudges).
     qFace.setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
-    var exits = 0, quads = 0;
+    // §GLOW_LENS_CLEARANCE_FIX (2026-08-07): the round sprite's old GLOW_EYE_OFFSET (0.3m TOWARD
+    // THE CAMERA) is direction-agnostic for a symmetric dot but visibly shifts an ORIENTED
+    // rectangle sideways at any angled view (the Hospital hallway misalignment). A small STRAIGHT
+    // DOWN clearance (same axis __drop already uses) clears the depth test against the fixture's
+    // own geometry without moving X/Z off the real fixture at all, from any angle.
+    var GLOW_LENS_CLEARANCE = 0.03;
+    var exits = 0, quads = 0, skippedTier2 = 0;
     for (var i = 0; i < pos.length; i++) {
       var p = pos[i];
       if (p.__exit) { exits++; continue; }   // §GLOW_EXIT_SOFT stays on the round sprite — see above
-      var py = p.y - (p.__drop || 0.12);
-      var dx = cam.x - p.x, dy = cam.y - py, dz = cam.z - p.z;
-      var d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
-      var k = GLOW_EYE_OFFSET / d;
-      pVec.set(p.x + dx * k, py + dy * k, p.z + dz * k);
+      // §NIGHT_TIER_GATE (2026-08-07, user cascade) — the lens quad only draws for a real named
+      // fixture (p.__guid set) or the explicitly-sanctioned presentation-only ceiling plant
+      // (p.__presentation) — NOT tier 2's "any overhead element in the room" pick, which the user
+      // scoped as light-only ("as source of lite", no quad mentioned for that tier).
+      if (p.__guid == null && !p.__presentation) { skippedTier2++; continue; }
+      var py = p.y - (p.__drop || 0.12) - GLOW_LENS_CLEARANCE;
+      pVec.set(p.x, py, p.z);
       qYaw.setFromEuler(new THREE.Euler(0, p.__rz || 0, 0));
       q.copy(qFace); q.premultiply(qYaw);   // face down, THEN yaw to the fixture's real rotation_z
       var w = p.__bw || GLOW_SPRITE_SIZE, h = p.__bd || GLOW_SPRITE_SIZE;
@@ -3807,7 +3801,8 @@ async function setupEffects(A, renderer, scene, camera) {
     A.scene.add(mesh);
     _glowLensMesh = mesh;
     console.log('§GLOW_LENS_QUAD staged ' + quads + ' lens quads (' + exits +
-      ' exit signs left on the round sprite), 1 draw call, 0 scene materials touched');
+      ' exit signs left on the round sprite, ' + skippedTier2 +
+      ' tier-2 overhead-picks skipped — PL only, no quad), 1 draw call, 0 scene materials touched');
   }
   function _glowLensOff() {
     if (!_glowLensMesh) return;
@@ -3850,11 +3845,14 @@ async function setupEffects(A, renderer, scene, camera) {
     if (A._bloomOff === undefined) A._bloomOff = true;
     if (A._bloomPass) A._bloomPass.enabled = !A._bloomOff && (!!A._emberEnabled || !!A._glowSpriteEnabled);
     _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
-    // §GLOW_ALL_REMOVED (2026-08-07, user: "remove all them, return to PL days... just increase
-    // them" — both the round sprite and the lens quad are OFF, still and nav. Real point lights
-    // only (A._nightLights, budget raised below). _glowOff() kept as a safety no-op in case
-    // anything is somehow still staged from before this change.
+    // §GLOW_STILL_RESTORED (2026-08-07): live nav stays PL-only (round sprite stopped staging
+    // there earlier, §GLOW_SPRITE_NAV_OFF — unchanged). The still gets the lens quad back, fixed
+    // (§GLOW_LENS_CLEARANCE_FIX) + the real point lights it was always getting, now frustum-cased
+    // instead of a flat 50-cap (§NIGHT_STILL_FRUSTUM in tools.js). Exit signs keep the round
+    // soft-glow subset alongside the quad (§GLOW_EXIT_SOFT — a backlit panel is not a lens).
     _glowOff();
+    _glowOn(function(p) { return p.__exit; });
+    _glowLensOn();
     // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
     // navigation budget (every light costs per-pixel work on every lit material every frame); a
     // frozen still renders once and then sits there, so that budget does not apply to it. The

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3850,16 +3850,11 @@ async function setupEffects(A, renderer, scene, camera) {
     if (A._bloomOff === undefined) A._bloomOff = true;
     if (A._bloomPass) A._bloomPass.enabled = !A._bloomOff && (!!A._emberEnabled || !!A._glowSpriteEnabled);
     _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
-    // §GLOW_LENS_QUAD (2026-08-07): the still gets the fitted lens quad, not the round nav sprite —
-    // "only for the render" (user directive). Night mode may already have staged the round sprite;
-    // swap it for the quad rather than stacking both.
-    // §GLOW_LENS_EXIT_FIX: the quad deliberately skips exit signs (§GLOW_EXIT_SOFT — a backlit panel,
-    // not a lens), so a plain swap left them with NO glow at all during the still, a regression from
-    // before this change (found on the Clinic screenshot). Stage the round sprite for the exit-sign
-    // SUBSET only, alongside the quad for everything else, so exits keep their soft glow.
+    // §GLOW_ALL_REMOVED (2026-08-07, user: "remove all them, return to PL days... just increase
+    // them" — both the round sprite and the lens quad are OFF, still and nav. Real point lights
+    // only (A._nightLights, budget raised below). _glowOff() kept as a safety no-op in case
+    // anything is somehow still staged from before this change.
     _glowOff();
-    _glowOn(function(p) { return p.__exit; });
-    _glowLensOn();
     // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
     // navigation budget (every light costs per-pixel work on every lit material every frame); a
     // frozen still renders once and then sits there, so that budget does not apply to it. The

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3763,7 +3763,7 @@ async function setupEffects(A, renderer, scene, camera) {
     mesh.frustumCulled = false;
     mesh.renderOrder = 999;
     mesh.name = '__glowLensQuads';
-    var m4 = new THREE.Matrix4(), q = new THREE.Quaternion(), qFace = new THREE.Quaternion(), qYaw = new THREE.Quaternion();
+    var m4 = new THREE.Matrix4(), q = new THREE.Quaternion(), qFace = new THREE.Quaternion();
     var pVec = new THREE.Vector3(), sVec = new THREE.Vector3(), col = new THREE.Color();
     // Plane's default normal is +Z; rotate +90 deg about X so it faces -Y (down, toward the floor —
     // matches §GLOW_EMIT_DOWN, the direction the fixture actually emits and the direction __drop nudges).
@@ -3785,8 +3785,15 @@ async function setupEffects(A, renderer, scene, camera) {
       if (p.__guid == null && !p.__presentation) { skippedTier2++; continue; }
       var py = p.y - (p.__drop || 0.12) - GLOW_LENS_CLEARANCE;
       pVec.set(p.x, py, p.z);
-      qYaw.setFromEuler(new THREE.Euler(0, p.__rz || 0, 0));
-      q.copy(qFace); q.premultiply(qYaw);   // face down, THEN yaw to the fixture's real rotation_z
+      // §GLOW_LENS_NO_DOUBLE_YAW (2026-08-07, next session, numeric witness not visual — see
+      // NIGHT_AND_FIXTURE_LIGHTING.md §SESSION HANDOFF "second cause" item): bbox_x/bbox_y from
+      // element_transforms are the WORLD-frame AABB, rotation_z ALREADY baked in — proven by
+      // Terminal_extracted.db's EmergencyLight_EL3 rows, same fixture reporting bbox swapped
+      // (0.168x0.419 at rz=+pi/2 vs 0.419x0.168 at rz=pi). The old code treated (bbox_x,bbox_y) as
+      // LOCAL dims and yawed them AGAIN by rotation_z — a no-op at rz=0/pi (why upstairs looked
+      // fine) but a 90 deg swap of the quad's world footprint at rz=+-pi/2 (why downstairs didn't
+      // fit: FitUpstairs.png). No yaw needed — q stays face-down only.
+      q.copy(qFace);
       var w = p.__bw || GLOW_SPRITE_SIZE, h = p.__bd || GLOW_SPRITE_SIZE;
       sVec.set(w, h, 1);
       m4.compose(pVec, q, sVec);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2366,18 +2366,37 @@ async function setupEffects(A, renderer, scene, camera) {
   // it rendered from frame 0 of a buildup. The predicate TM hands over is the SAME placed/frontier/
   // recent state it just applied to the real element, so the overlay cannot drift from it.
   // isVisible === null means TM is off → overlays visible (the sign exists in the finished building).
+  //
+  // §GLOW_BUILDUP_GATE (2026-08-07): a second consumer — §PHOTO_GLOW_SPRITE below — needs this same
+  // per-tick predicate for ~1000 fixture guids, not one billboard guid. window.__tmOverlaySync is a
+  // single global slot (TM calls exactly one function), so this is now a tiny fan-out: the raw
+  // isVisible fn is cached for on-demand reads (A._tmIsVisible) and broadcast to subscribers
+  // (A._tmVisSubscribe) so a buildup bake can withhold a fixture's glow until TM has actually placed
+  // it, without effects.js re-deriving placed/frontier/recent itself.
   var _nameVisLast = null;
+  var _tmVisListeners = [];
+  var _lastTmIsVisible = null;   // latest predicate TM handed over; null when TM isn't driving the scene
+  A._tmVisSubscribe = function(fn) { _tmVisListeners.push(fn); };
+  // Same default as the billboard branch below: no active TM predicate → everything is visible
+  // (Night Mode used outside a buildup bake, or after the buildup has fully completed).
+  A._tmIsVisible = function(guid) { return _lastTmIsVisible ? !!_lastTmIsVisible(guid) : true; };
   A._tmOverlayRegister = function() {
     if (window.__tmOverlaySync) return;   // idempotent
     window.__tmOverlaySync = function(isVisible) {
-      if (!_billboardNameMesh || !_billboardNameGuid) return;
-      var v = isVisible ? !!isVisible(_billboardNameGuid) : true;
-      if (v === _nameVisLast) return;     // log + write on CHANGE only, never per tick
-      _nameVisLast = v;
-      _billboardNameMesh.visible = v;
-      console.log('§BILLBOARD_NAME_VIS guid=' + _billboardNameGuid + ' visible=' + v +
-        ' tmActive=' + !!isVisible);
-      if (A.markDirty) A.markDirty();
+      _lastTmIsVisible = isVisible;
+      if (_billboardNameMesh && _billboardNameGuid) {
+        var v = isVisible ? !!isVisible(_billboardNameGuid) : true;
+        if (v !== _nameVisLast) {     // log + write on CHANGE only, never per tick
+          _nameVisLast = v;
+          _billboardNameMesh.visible = v;
+          console.log('§BILLBOARD_NAME_VIS guid=' + _billboardNameGuid + ' visible=' + v +
+            ' tmActive=' + !!isVisible);
+          if (A.markDirty) A.markDirty();
+        }
+      }
+      for (var _tvi = 0; _tvi < _tmVisListeners.length; _tvi++) {
+        try { _tmVisListeners[_tvi](isVisible); } catch (e) { /* one bad subscriber must not break TM's tick */ }
+      }
     };
     // Read-only probe for the witness: what the overlay currently believes.
     A._billboardNameState = function() {
@@ -3561,6 +3580,7 @@ async function setupEffects(A, renderer, scene, camera) {
   var GLOW_EXIT_GAIN   = 0.9;
   var GLOW_EXIT_SIZE   = 0.40;
   var _glowPoints = null, _glowTex = null;
+  var _glowStagedCount = -1;   // §GLOW_BUILDUP_GATE — fixture count the CURRENT cloud was built with
 
   function _glowTexture() {
     if (_glowTex) return _glowTex;
@@ -3581,9 +3601,25 @@ async function setupEffects(A, renderer, scene, camera) {
   function _glowOn(filterFn) {
     if (!A._glowSpriteEnabled || _glowPoints) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
-    var pos = A._nightFixtureWorldPositions();
+    if (A._tmOverlayRegister) A._tmOverlayRegister();   // idempotent — ensures window.__tmOverlaySync exists even without a billboard nameplate
+    var allPos = A._nightFixtureWorldPositions();
+    if (!allPos || !allPos.length) { console.log('§PHOTO_GLOW_SPRITE no luminaires in this building — nothing to light'); return; }
+    // §GLOW_BUILDUP_GATE (2026-08-07, user: MaxQ buildup bakes showed every fixture lit from
+    // Day 1 — "all the lights are lighted and not following the buildup schedule"). A fixture with
+    // no guid (the synthetic per-storey fallback — no real element to gate against) always glows;
+    // a real fixture only glows once Time Machine has actually placed it. A._tmIsVisible defaults
+    // to true when TM isn't driving the scene at all, so plain Night Mode (no buildup in progress)
+    // is completely unchanged.
+    var pos = allPos.filter(function(p) { return p.__guid == null || A._tmIsVisible(p.__guid); });
+    // §GLOW_LENS_QUAD (this session's own merge) — optional extra filter, e.g. the still stages
+    // ONLY the exit-sign subset here (the quad handles everything else). Applied on TOP of the
+    // buildup gate above, not instead of it.
     if (filterFn) pos = pos.filter(filterFn);
-    if (!pos || !pos.length) { console.log('§PHOTO_GLOW_SPRITE no luminaires in this building — nothing to light'); return; }
+    _glowStagedCount = pos.length;
+    if (!pos.length) {
+      console.log('§PHOTO_GLOW_SPRITE_GATE 0/' + allPos.length + ' fixtures placed yet — nothing to light');
+      return;
+    }
     // Offset toward the eye, computed ONCE: for a still the camera is frozen, so once is exact; in
     // navigation a 0.15m staleness as the camera moves is below the size of the halo it positions.
     var cam = A.camera.position;
@@ -3648,7 +3684,7 @@ async function setupEffects(A, renderer, scene, camera) {
     _glowPoints.renderOrder = 999;       // after opaque geometry, so additive lands on a finished frame
     _glowPoints.name = '__glowSprites';
     A.scene.add(_glowPoints);
-    console.log('§PHOTO_GLOW_SPRITE staged ' + pos.length + ' sprites (' + (pos.length - exits) +
+    console.log('§PHOTO_GLOW_SPRITE staged ' + pos.length + '/' + allPos.length + ' sprites (' + (pos.length - exits) +
       ' luminaires gain ' + GLOW_GAIN + ', ' + exits + ' exit signs gain ' + GLOW_EXIT_GAIN +
       ' x' + GLOW_EXIT_SIZE + ' size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose)' +
       ', 1 draw call, 0 scene materials touched' +
@@ -3676,6 +3712,23 @@ async function setupEffects(A, renderer, scene, camera) {
   // Bloom stays still-only — it is 7 extra full-screen draws and that DOES have a 60fps cost.
   A._glowStage   = function() { _glowOn(); };
   A._glowUnstage = function() { _glowOff(); };
+  // §GLOW_BUILDUP_GATE restage: while sprites are staged during an active TM buildup, the set of
+  // placed fixtures grows tick by tick — rebuild the (small, ≤~1200-point) cloud only when that
+  // count actually changes, not on every tick. isVisible === null (TM inactive) always matches
+  // "everything" and is a no-op restage the first time it's seen after a buildup ends.
+  if (typeof A._tmVisSubscribe === 'function') {
+    A._tmVisSubscribe(function(isVisible) {
+      if (!_glowPoints || !A._nightMode) return;
+      var allPos = A._nightFixtureWorldPositions ? A._nightFixtureWorldPositions() : [];
+      var n = 0;
+      for (var _gi = 0; _gi < allPos.length; _gi++) {
+        if (allPos[_gi].__guid == null || !isVisible || isVisible(allPos[_gi].__guid)) n++;
+      }
+      if (n === _glowStagedCount) return;
+      _glowOff();
+      _glowOn();
+    });
+  }
 
   // ══ §GLOW_LENS_QUAD (NIGHT_AND_FIXTURE_LIGHTING.md §GLOW_LENS_QUAD verdict, 2026-08-07) ══
   // STILL-RENDER ONLY. User directive 2026-08-07: "only for the render, such realism will be a

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3345,6 +3345,8 @@ async function setupEffects(A, renderer, scene, camera) {
     // emissive left on would follow the user back into navigation.
     if (A._bloomPass) A._bloomPass.enabled = false;
     _emberOff();
+    // §GLOW_LENS_QUAD: the fitted lens quad is still-only — always tear it down here.
+    _glowLensOff();
     // §PHOTO_GLOW_SPRITE: restage rather than remove when night mode is still on — the sprites
     // belong to NIGHT, not to the still; only their bloom was still-only. Restaging also refreshes
     // the eye offset against wherever the camera ended up.
@@ -3674,6 +3676,80 @@ async function setupEffects(A, renderer, scene, camera) {
   A._glowStage   = function() { _glowOn(); };
   A._glowUnstage = function() { _glowOff(); };
 
+  // ══ §GLOW_LENS_QUAD (NIGHT_AND_FIXTURE_LIGHTING.md §GLOW_LENS_QUAD verdict, 2026-08-07) ══
+  // STILL-RENDER ONLY. User directive 2026-08-07: "only for the render, such realism will be a
+  // wow. while night fly thru it is OK" — live navigation/night-mode keeps the round
+  // §PHOTO_GLOW_SPRITE halo exactly as it is; this function is never called from there.
+  //
+  // Replaces the round Points sprite (one fixed size, always a circle) with an InstancedMesh of
+  // quads, each sized to ITS OWN fixture's bbox_x x bbox_y and yawed by its own rotation_z, sitting
+  // at the emitting face — a 0.6x1.2m troffer seen from below reads as a 0.6x1.2m rectangle of
+  // light, not a generic dot floating near it. Same position/colour/eye-offset source as the round
+  // sprite (A._nightFixtureWorldPositions) so the two mechanisms never disagree.
+  //
+  // §GLOW_EXIT_SOFT is deliberately NOT ported here — an exit sign is a small backlit panel, not a
+  // lit lens, and stays on the round soft-glow treatment even during the still (skipped below).
+  //
+  // Simplification, stated not hidden: only rotation_z (yaw about vertical) is applied. Fixtures in
+  // the five shipped buildings are ceiling/wall-mounted flat panels — rotation_x/y would matter for
+  // a tilted spotlight, which none of the current luminaire vocabulary matches.
+  var _glowLensMesh = null;
+  function _glowLensOn() {
+    if (_glowLensMesh) return;
+    if (typeof A._nightFixtureWorldPositions !== 'function') return;
+    var pos = A._nightFixtureWorldPositions();
+    if (!pos || !pos.length) return;
+    var cam = A.camera.position;
+    var geo = new THREE.PlaneGeometry(1, 1);
+    var mat = new THREE.MeshBasicMaterial({
+      color: 0xffffff, transparent: true, blending: THREE.AdditiveBlending,
+      depthTest: true, depthWrite: false, toneMapped: false, side: THREE.DoubleSide
+    });
+    var mesh = new THREE.InstancedMesh(geo, mat, pos.length);
+    mesh.frustumCulled = false;
+    mesh.renderOrder = 999;
+    mesh.name = '__glowLensQuads';
+    var m4 = new THREE.Matrix4(), q = new THREE.Quaternion(), qFace = new THREE.Quaternion(), qYaw = new THREE.Quaternion();
+    var pVec = new THREE.Vector3(), sVec = new THREE.Vector3(), col = new THREE.Color();
+    // Plane's default normal is +Z; rotate +90 deg about X so it faces -Y (down, toward the floor —
+    // matches §GLOW_EMIT_DOWN, the direction the fixture actually emits and the direction __drop nudges).
+    qFace.setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
+    var exits = 0, quads = 0;
+    for (var i = 0; i < pos.length; i++) {
+      var p = pos[i];
+      if (p.__exit) { exits++; continue; }   // §GLOW_EXIT_SOFT stays on the round sprite — see above
+      var py = p.y - (p.__drop || 0.12);
+      var dx = cam.x - p.x, dy = cam.y - py, dz = cam.z - p.z;
+      var d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+      var k = GLOW_EYE_OFFSET / d;
+      pVec.set(p.x + dx * k, py + dy * k, p.z + dz * k);
+      qYaw.setFromEuler(new THREE.Euler(0, p.__rz || 0, 0));
+      q.copy(qFace); q.premultiply(qYaw);   // face down, THEN yaw to the fixture's real rotation_z
+      var w = p.__bw || GLOW_SPRITE_SIZE, h = p.__bd || GLOW_SPRITE_SIZE;
+      sVec.set(w, h, 1);
+      m4.compose(pVec, q, sVec);
+      mesh.setMatrixAt(quads, m4);
+      col.setHex(p.__color === undefined ? 0xffe4b5 : p.__color);
+      mesh.setColorAt(quads, col.multiplyScalar(GLOW_GAIN));
+      quads++;
+    }
+    mesh.count = quads;
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+    A.scene.add(mesh);
+    _glowLensMesh = mesh;
+    console.log('§GLOW_LENS_QUAD staged ' + quads + ' lens quads (' + exits +
+      ' exit signs left on the round sprite), 1 draw call, 0 scene materials touched');
+  }
+  function _glowLensOff() {
+    if (!_glowLensMesh) return;
+    A.scene.remove(_glowLensMesh);
+    _glowLensMesh.geometry.dispose();
+    _glowLensMesh.material.dispose();
+    console.log('§GLOW_LENS_QUAD removed');
+    _glowLensMesh = null;
+  }
+
   A.startStillRefine = function() {
     if (!A._composer || !A._taaPass || A._stillRefineActive) return;
     // §GI_EXCLUSION (review finding 5): the GI preview composer and this TAA composer both render
@@ -3706,10 +3782,10 @@ async function setupEffects(A, renderer, scene, camera) {
     if (A._bloomOff === undefined) A._bloomOff = true;
     if (A._bloomPass) A._bloomPass.enabled = !A._bloomOff && (!!A._emberEnabled || !!A._glowSpriteEnabled);
     _emberOn();          // §PHOTO_EMBER_DISARMED — no-op unless deliberately re-armed
-    // §PHOTO_GLOW_SPRITE: night mode may already have staged these. Restage anyway, so the eye
-    // offset is computed against the pose the still is actually frozen at rather than wherever the
-    // camera happened to be when night mode was switched on.
-    _glowOff(); _glowOn();
+    // §GLOW_LENS_QUAD (2026-08-07): the still gets the fitted lens quad, not the round nav sprite —
+    // "only for the render" (user directive). Night mode may already have staged the round sprite;
+    // swap it for the quad rather than stacking both.
+    _glowOff(); _glowLensOn();
     // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
     // navigation budget (every light costs per-pixel work on every lit material every frame); a
     // frozen still renders once and then sits there, so that budget does not apply to it. The

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -397,9 +397,8 @@ function setupStreaming(A) {
       IfcSlab: _TRI_CONCRETE,
       IfcColumn: _TRI_CONCRETE,
       IfcFooting: _TRI_CONCRETE,
-      IfcPile: _TRI_CONCRETE,
       IfcStair: _TRI_CONCRETE,
-      IfcRamp: _TRI_CONCRETE,
+      IfcStairFlight: _TRI_CONCRETE,
       // ── Plaster (STD_MAT: "painted plaster", "plasterboard") ──
       IfcWallStandardCase: _TRI_PLASTER,
       IfcCovering: _TRI_PLASTER,
@@ -408,13 +407,16 @@ function setupStreaming(A) {
       IfcMember: _TRI_METAL,
       IfcPlate: _TRI_METAL,
       IfcRailing: _TRI_METAL,
-      IfcPipe: _TRI_METAL,
       IfcPipeFitting: _TRI_METAL,
       IfcPipeSegment: _TRI_METAL,
-      IfcDuct: _TRI_METAL,
       IfcDuctFitting: _TRI_METAL,
       IfcDuctSegment: _TRI_METAL,
-      IfcCableCarrier: _TRI_METAL
+      IfcCableCarrierSegment: _TRI_METAL,
+      IfcCableCarrierFitting: _TRI_METAL,
+      // ── IFC2x3 generic-MEP convention (Clinic/LTU/HHS export these instead of the above) ──
+      IfcFlowSegment: _TRI_METAL,
+      IfcFlowTerminal: _TRI_METAL,
+      IfcFlowFitting: _TRI_METAL
     };
 
     const key = rgbaStr || '_default';

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v959';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v965';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -855,8 +855,18 @@ function setupTools(A) {
   // renders once and then sits there. So the cap is a variable the still can raise, not a constant.
   // Read through A._nightMaxLights everywhere below so raising it and re-running _nightUpdateLights
   // is all that is needed.
-  A._nightMaxLights = 12;          // navigation budget
-  A._nightMaxLightsStill = 48;     // frozen-still budget — 4x, paid once
+  // §NIGHT_LIGHT_BUDGET_UP (2026-08-07, user: "can we increase them since we got speed? 24 be
+  // good" / "during alt-s throw all in, up to 50 as it is baking") — raised from 12/48. Also
+  // RE-ARMS A._nightStillBoost, which shipped OFF by default (§NIGHT_STILL_LIGHTS below in
+  // effects.js — measured +2064ms on Hospital, judged not worth it at the time). User directive
+  // this session explicitly accepts that cost ("we got speed... without DLOD we can scale with
+  // some more cost") — so the still budget bump below is only real if this is also true.
+  A._nightMaxLightsNav = 24;       // navigation budget — the RESET target (effects.js reads this,
+                                    // not a literal, so tuning this one number can't silently break
+                                    // the still's nav-budget handback)
+  A._nightMaxLights = A._nightMaxLightsNav;  // CURRENT budget — swapped to the still value during Alt+S
+  A._nightMaxLightsStill = 50;     // frozen-still budget — paid once, no 60fps constraint
+  A._nightStillBoost = true;       // re-armed 2026-08-07 — see effects.js §NIGHT_STILL_LIGHTS
   A._nightNearFadeFloor = 0.3;     // navigation: a light at the eye dims to 30% (anti-blowout)
   A._nightNearFadeFloorStill = 1.0;// still: no proximity penalty at all
   // §NIGHT_LIGHT_MIX (2026-07-27, user: "if we can have a mix of amber, and bluish etc").
@@ -1208,11 +1218,11 @@ function setupTools(A) {
         ' glowMats=' + A._nightGlowMats.length);
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
       A._nightUpdateLights();
-      // §PHOTO_GLOW_SPRITE: the fixtures themselves read as lit, not just the surfaces near them.
-      // Staged here rather than in Alt+S because it is ONE additive draw call for every fixture in
-      // the building — there is no per-light budget for it to blow, so a user turning night mode on
-      // should see the luminaires on without pressing anything else.
-      if (typeof A._glowStage === 'function') A._glowStage();
+      // §GLOW_SPRITE_NAV_OFF (2026-08-07, user: "remove the others, no more those flimsy night
+      // lights" — the round decorative sprite, not A._nightLights). Live nav now runs on the real
+      // point lights ONLY (A._nightLights, bumped to 24 below) — no more static round dots. The
+      // sprite mechanism itself stays (still-render exit-sign glow still uses it, see effects.js
+      // startStillRefine), this just stops staging it for navigation.
       if (A.controls && !A._nightControlsListener) {
         var _nightLastCamPos = A.camera.position.clone();
         A._nightControlsListener = function() {

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1002,7 +1002,8 @@ function setupTools(A) {
           // §GLOW_LENS_QUAD (2026-08-07): bbox_x/bbox_y/rotation_z added so the still-render lens
           // quad (effects.js) can size and orient itself to the REAL fixture instead of a generic
           // round halo. Still-only consumer — the live round sprite ignores these three columns.
-          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z, t.bbox_x, t.bbox_y, t.rotation_z FROM elements_meta m " +
+          // m.guid (glow-buildup-gate, merged in) kept alongside for that feature's own consumer.
+          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z, t.bbox_x, t.bbox_y, t.rotation_z, m.guid FROM elements_meta m " +
           "JOIN element_transforms t ON m.guid=t.guid " +
           // §NIGHT_NAME_NOT_CLASS (2026-07-27, user: "anything that has 'light' name", "i dunno why
           // we keep missing 'light' in names"). THE ANSWER IS THE CLASS GATE, which used to read
@@ -1072,7 +1073,7 @@ function setupTools(A) {
         if (r.length && r[0].values.length > 0) {
           r[0].values.forEach(function(row) {
             A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0,
-              bw: row[5] || 0, bd: row[6] || 0, rz: row[7] || 0 });
+              bw: row[5] || 0, bd: row[6] || 0, rz: row[7] || 0, guid: row[8] || null });
           });
           source = 'IFC';
         }
@@ -1310,6 +1311,10 @@ function setupTools(A) {
         p.__drop = (f.h || 0) / 2 + 0.12;
         // §GLOW_LENS_QUAD — real fixture footprint + yaw, still-render lens only (see effects.js).
         p.__bw = f.bw || 0; p.__bd = f.bd || 0; p.__rz = f.rz || 0;
+        // §GLOW_BUILDUP_GATE — null for synthetic per-storey fallback fixtures (no real element to
+        // gate against); real IFC rows carry the guid so a buildup bake can withhold the glow until
+        // Time Machine has actually placed that fixture (see effects.js A._tmIsVisible).
+        p.__guid = f.guid || null;
         return p;
       });
     }

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -942,7 +942,7 @@ function setupTools(A) {
     return NIGHT_AMBER;
   };
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
-  var NIGHT_LIGHT_INTENSITY = 8.0; // §S277d: high intensity — inverse-square decay handles falloff naturally
+  var NIGHT_LIGHT_INTENSITY = 4.5; // §S277d, reduced 8.0->6.5->4.5 2026-08-07 (user: still too bright after first cut)
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
 
   // §NIGHT_GLOW_REASSERT: extracted from toggleNightMode() so it can be re-called every frame
@@ -975,7 +975,7 @@ function setupTools(A) {
       if (!isLight && !isWindow && mk.indexOf('IfcPlate') >= 0 && m.transparent) isWindow = true;
       if (!isLight && !isWindow) continue;
       A._nightGlowMats.push({ mat: m, origE: m.emissive.getHex(), origEI: m.emissiveIntensity });
-      if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.8; _glowCount++; }
+      if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.45; _glowCount++; } // reduced 0.8->0.65->0.45 2026-08-07
       else { m.emissive.setHex(0xfff8ec); m.emissiveIntensity = 0.55; _windowGlowCount++; }
       m.needsUpdate = true;
     }
@@ -1013,8 +1013,12 @@ function setupTools(A) {
           // quad (effects.js) can size and orient itself to the REAL fixture instead of a generic
           // round halo. Still-only consumer — the live round sprite ignores these three columns.
           // m.guid (glow-buildup-gate, merged in) kept alongside for that feature's own consumer.
-          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z, t.bbox_x, t.bbox_y, t.rotation_z, m.guid FROM elements_meta m " +
+          // §GLOW_TRUE_BOTTOM (2026-08-07): i.geometry_hash lets the drop calc below use the
+          // fixture's REAL mesh bounding box instead of assuming center_z sits at the bbox
+          // midpoint — see the drop comment further down for why that assumption was wrong.
+          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z, t.bbox_x, t.bbox_y, t.rotation_z, m.guid, i.geometry_hash FROM elements_meta m " +
           "JOIN element_transforms t ON m.guid=t.guid " +
+          "LEFT JOIN element_instances i ON m.guid=i.guid " +
           // §NIGHT_NAME_NOT_CLASS (2026-07-27, user: "anything that has 'light' name", "i dunno why
           // we keep missing 'light' in names"). THE ANSWER IS THE CLASS GATE, which used to read
           //     m.ifc_class IN ('IfcLightFixture','IfcFlowTerminal','IfcElectricAppliance') AND ...
@@ -1083,7 +1087,7 @@ function setupTools(A) {
         if (r.length && r[0].values.length > 0) {
           r[0].values.forEach(function(row) {
             A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0,
-              bw: row[5] || 0, bd: row[6] || 0, rz: row[7] || 0, guid: row[8] || null });
+              bw: row[5] || 0, bd: row[6] || 0, rz: row[7] || 0, guid: row[8] || null, ghash: row[9] || null });
           });
           source = 'IFC';
         }
@@ -1336,6 +1340,7 @@ function setupTools(A) {
         l.dispose();
       });
       A._nightLights = [];
+      A._nightLightByPos = null;   // stale pos-object keys otherwise survive the next toggle-on
       A._nightFixturePositions = null;
       // §PHOTO_GLOW_SPRITE: night's sprites must not survive night mode
       if (typeof A._glowUnstage === 'function') A._glowUnstage();
@@ -1372,13 +1377,33 @@ function setupTools(A) {
         // Key the ratio on name+position so it is stable per fixture and independent of row order.
         p.__color = A.nightLightColor(f.name, f.name + '|' + f.x.toFixed(2) + ',' + f.y.toFixed(2) + ',' + f.z.toFixed(2));
         p.__exit = A.nightIsExitSign(f.name);   // §GLOW_EXIT_SOFT — a sign is not a troffer
-        // §GLOW_EMIT_DOWN — how far BELOW the stored centre the fitting actually emits. The DB gives
-        // a bounding-box centre; a RECESSED fitting's centre is level with (or above) the ceiling
-        // face, and a suspended one's centre is up in its drop rod. Half the bbox height plus a
-        // clearance puts the glow on the emitting face in both cases. Measured half-heights:
-        // troffer 0.07m, downlight 0.10m, plain recessed 0.075m, pendant-linear 0.77m (Clinic) —
-        // the pendant number is the drop rod, and dropping by it lands the glow on the lamp.
-        p.__drop = (f.h || 0) / 2 + 0.12;
+        // §GLOW_TRUE_BOTTOM (2026-08-07, replaces §GLOW_EMIT_DOWN's half-bbox-height guess — see
+        // NIGHT_AND_FIXTURE_LIGHTING.md §GLOW_TRUE_BOTTOM for the numeric witness). The OLD formula
+        // `bbox_z/2 + 0.12` assumed center_z sits at the bbox MIDPOINT. It doesn't: extractIFCtoDB.py
+        // stores center_z as the IFC PLACEMENT ORIGIN translation, and bbox_z as the full world AABB
+        // height — the two only coincide when a fixture's mesh happens to be symmetric about its own
+        // origin. Measured on Hospital: a recessed troffer (symmetric mesh) was off by 4mm — noise.
+        // A suspended linear pendant (origin at the ceiling attach point, mesh mostly BELOW it) was
+        // off by 196mm — the pendant hangs from the origin, so almost none of its height is above it.
+        // Real fix: read the ACTUAL local bounding box of the fixture's own mesh (already loaded for
+        // rendering, same Y-axis convention as A.blobToGeometry — local Y === IFC Z, no extra math)
+        // instead of guessing from a symmetric assumption. GLOW_LENS_CLEARANCE below is the same
+        // small physical clearance effects.js already uses to clear the fixture's own depth-test —
+        // reused here, not reinvented, for the same reason.
+        var GLOW_LENS_CLEARANCE = 0.03;
+        p.__drop = null;
+        if (f.ghash && A.meshCache && A.meshCache[f.ghash]) {
+          var _geo = A.meshCache[f.ghash];
+          if (!_geo.boundingBox) _geo.computeBoundingBox();
+          if (_geo.boundingBox && isFinite(_geo.boundingBox.min.y)) {
+            p.__drop = -_geo.boundingBox.min.y + GLOW_LENS_CLEARANCE;
+          }
+        }
+        if (p.__drop === null) {
+          // Fallback only — mesh not streamed in yet, or a synthetic/room-fallback fixture with no
+          // geometry_hash. Old heuristic, kept as a documented approximation, not a silent guess.
+          p.__drop = (f.h || 0) / 2 + 0.12;
+        }
         // §GLOW_LENS_QUAD — real fixture footprint + yaw, still-render lens only (see effects.js).
         p.__bw = f.bw || 0; p.__bd = f.bd || 0; p.__rz = f.rz || 0;
         // §GLOW_BUILDUP_GATE — null for synthetic per-storey fallback fixtures (no real element to
@@ -1455,13 +1480,17 @@ function setupTools(A) {
       }
       needed = picked.map(function(p) { return { pos: p }; });
     }
-    // Remove old lights
-    A._nightLights.forEach(function(l) {
-      A.scene.remove(l);
-      if (l.shadow && l.shadow.map) { l.shadow.map.dispose(); l.shadow.map = null; }
-      l.dispose();
-    });
-    A._nightLights = [];
+    // §NIGHT_LIGHT_CHURN_FIX (2026-08-08): this used to dispose EVERY light and rebuild the whole
+    // set from scratch on every call — called on every 5m of camera travel while night mode is on,
+    // so a normal orbit/fly repeatedly churned three.js's per-material light-uniform list (the
+    // exact "shader recompile on light count change" cost this doc's own §RAM section already
+    // named as the expensive part). Root cause of the "hiccups when lighting is on, smooth when
+    // off" report — see §NIGHT_LIGHT_CHURN. Fix: `allPos` entries are stable object references
+    // (memoized by A._nightFixtureWorldPositions), so a Map keyed on that reference tracks which
+    // light belongs to which fixture across calls — reuse the light (just refresh its distance-fade
+    // intensity) when a fixture is still wanted, only dispose/create the delta.
+    if (!A._nightLightByPos) A._nightLightByPos = new Map();
+    var stillWanted = new Set();
     // §S277d: camera-distance fade — lights near the eye (you're inside, next to them) dim to
     // 30%; lights far away (you're outside looking in) stay full strength for façade throw.
     // Fixes "inside too bright" without losing the exterior overhang/doorway spillover.
@@ -1477,11 +1506,25 @@ function setupTools(A) {
       // lit. A._nightNearFadeFloor is raised by startStillRefine alongside the light count.
       var floor = A._nightNearFadeFloor;
       var intensity = NIGHT_LIGHT_INTENSITY * (floor + (1 - floor) * fade);
-      var light = new THREE.PointLight(f.pos.__color || 0xffe4b5, intensity, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
-      light.position.copy(f.pos);
-      A.scene.add(light);
-      A._nightLights.push(light);
+      stillWanted.add(f.pos);
+      var light = A._nightLightByPos.get(f.pos);
+      if (light) {
+        light.intensity = intensity;   // position/colour are fixed per fixture — only fade moves
+      } else {
+        light = new THREE.PointLight(f.pos.__color || 0xffe4b5, intensity, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
+        light.position.copy(f.pos);
+        A.scene.add(light);
+        A._nightLightByPos.set(f.pos, light);
+      }
     });
+    A._nightLightByPos.forEach(function(light, pos) {
+      if (stillWanted.has(pos)) return;
+      A.scene.remove(light);
+      if (light.shadow && light.shadow.map) { light.shadow.map.dispose(); light.shadow.map = null; }
+      light.dispose();
+      A._nightLightByPos.delete(pos);
+    });
+    A._nightLights = Array.from(A._nightLightByPos.values());
     if (A.markDirty) A.markDirty();
   };
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1088,30 +1088,55 @@ function setupTools(A) {
           source = 'IFC';
         }
       } catch(e) {}
-      // §S259: Fallback — generate synthetic lights from storey centroids
-      if (A._nightFixtures.length === 0) {
-        try {
-          var sr = A.db.exec("SELECT m.storey, AVG(t.center_x), AVG(t.center_y), AVG(t.center_z), MIN(t.center_x), MAX(t.center_x), MIN(t.center_y), MAX(t.center_y) FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid GROUP BY m.storey");
-          if (sr.length) {
-            sr[0].values.forEach(function(row) {
-              var cx = row[1], cy = row[2], cz = row[3];
-              var xMin = row[4], xMax = row[5], yMin = row[6], yMax = row[7];
-              var dx = (xMax - xMin) || 10, dy = (yMax - yMin) || 10;
-              // Place a grid of lights per storey — one every ~15m
-              var nx = Math.max(1, Math.ceil(dx / 15));
-              var ny = Math.max(1, Math.ceil(dy / 15));
-              for (var ix = 0; ix < nx; ix++) {
-                for (var iy = 0; iy < ny; iy++) {
-                  var fx = xMin + (ix + 0.5) * (dx / nx);
-                  var fy = yMin + (iy + 0.5) * (dy / ny);
-                  A._nightFixtures.push({ x: fx, y: fy, z: cz + 1.5 });
-                }
-              }
-            });
-            source = 'synthetic (' + sr[0].values.length + ' storeys)';
+      // §NIGHT_ROOM_FALLBACK (2026-08-07, user cascade: "1. fixtures on ceiling 2. any fixtures
+      // 3. just per square empty per PL" — for a ROOM with no real named/classed luminaire above,
+      // don't leave it dark and don't fabricate a position. Uses REAL room-containment data
+      // (rel_contained_in_space, already extracted — 181 real rooms on LTU_AHouse) to pick, per
+      // empty room, the single HIGHEST real element actually inside it — "on the ceiling" if one
+      // exists there (a sprinkler, a diffuser, a beam — whatever the topmost real object is),
+      // otherwise simply the topmost real object present. A REAL element's own position, not a
+      // computed room-centroid average — user preferred a real fixture's position over an invented
+      // one. Tier 3 ("per square empty") turns out to be moot for this data shape: every room that
+      // appears in rel_contained_in_space has >=1 real member by construction of the join, so there
+      // is no room left with zero real elements to fall further back from.
+      try {
+        var litGuids = {};
+        A._nightFixtures.forEach(function(f) { if (f.guid) litGuids[f.guid] = 1; });
+        var rm = A.db.exec(
+          "SELECT r.space_guid, r.element_guid, t.center_x, t.center_y, t.center_z, t.bbox_z " +
+          "FROM rel_contained_in_space r JOIN element_transforms t ON r.element_guid = t.guid"
+        );
+        var byRoom = {};
+        if (rm.length) {
+          rm[0].values.forEach(function(row) {
+            (byRoom[row[0]] = byRoom[row[0]] || []).push(
+              { guid: row[1], x: row[2], y: row[3], z: row[4], bz: row[5] || 0 });
+          });
+        }
+        var roomsLit = 0;
+        for (var room in byRoom) {
+          var members = byRoom[room];
+          if (members.some(function(m) { return litGuids[m.guid]; })) continue;
+          var top = members[0];
+          for (var mi = 1; mi < members.length; mi++) {
+            if (members[mi].z + members[mi].bz / 2 > top.z + top.bz / 2) top = members[mi];
           }
-        } catch(e) { console.warn('§NIGHT fallback query failed', e); }
-      }
+          A._nightFixtures.push({ x: top.x, y: top.y, z: top.z, name: 'room-proxy ' + room,
+            h: top.bz || 0.2, guid: null });
+          roomsLit++;
+        }
+        if (roomsLit) {
+          source = (source === 'IFC' ? 'IFC+room-proxy(' : 'room-proxy(') + roomsLit + ')';
+        }
+      } catch(e) { console.warn('§NIGHT_ROOM_FALLBACK query failed', e); }
+      // §S259_REMOVED (2026-08-07, user: "i want those fake lights removed in the code" — LTU_AHouse
+      // confirmed 0 real luminaires by direct query, and the synthetic grid this used to generate
+      // here (one fake position every ~15m across each storey's WHOLE bounding box, indoors or not)
+      // was exactly what scattered fabricated lights across LTU's outdoor courtyard — both as real
+      // A._nightLights point lights and, before that fix, as still-render lens quads. A position
+      // with no real element behind it is invention, not extraction (project Prime Rule) — a
+      // building with no real named/classed luminaires now simply has none. Night Mode still works
+      // (moonlight ambient), it just has no per-fixture lights to place.
     }
     A._nightFixtureSource = source;
     return source;

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1089,54 +1089,89 @@ function setupTools(A) {
         }
       } catch(e) {}
       // §NIGHT_ROOM_FALLBACK (2026-08-07, user cascade: "1. fixtures on ceiling 2. any fixtures
-      // 3. just per square empty per PL" — for a ROOM with no real named/classed luminaire above,
-      // don't leave it dark and don't fabricate a position. Uses REAL room-containment data
-      // (rel_contained_in_space, already extracted — 181 real rooms on LTU_AHouse) to pick, per
-      // empty room, the single HIGHEST real element actually inside it — "on the ceiling" if one
-      // exists there (a sprinkler, a diffuser, a beam — whatever the topmost real object is),
-      // otherwise simply the topmost real object present. A REAL element's own position, not a
-      // computed room-centroid average — user preferred a real fixture's position over an invented
-      // one. Tier 3 ("per square empty") turns out to be moot for this data shape: every room that
-      // appears in rel_contained_in_space has >=1 real member by construction of the join, so there
-      // is no room left with zero real elements to fall further back from.
+      // 3. just per square empty per PL", refined same session after LTU corridors still read too
+      // dark: "in rooms u can use flow terminal as been the only fixture around"). Uses REAL
+      // room-containment data (rel_contained_in_space, already extracted — 181 real rooms on
+      // LTU_AHouse) — for a ROOM with no real named/classed luminaire:
+      //   a) if the room contains any IfcFlowTerminal (vents/diffusers/sprinklers — a plausible
+      //      ceiling fixture class, and LTU has thousands: 4090 VENT + 1431 PLB), light EVERY ONE
+      //      of them, not just one per room — a long corridor has several spaced along its
+      //      ceiling, and one light for the whole corridor was exactly why it stayed dark at both
+      //      ends. A._nightMaxLights culling (nearest-N to camera) already handles the resulting
+      //      larger candidate pool, same as it does for real luminaires.
+      //   b) otherwise, the single HIGHEST real element in the room (any class) — unchanged from
+      //      before.
+      // Tier 3 ("per square empty") stays moot: every room here has >=1 real member by construction.
       try {
         var litGuids = {};
         A._nightFixtures.forEach(function(f) { if (f.guid) litGuids[f.guid] = 1; });
         var rm = A.db.exec(
-          "SELECT r.space_guid, r.element_guid, t.center_x, t.center_y, t.center_z, t.bbox_z " +
-          "FROM rel_contained_in_space r JOIN element_transforms t ON r.element_guid = t.guid"
+          "SELECT r.space_guid, r.element_guid, t.center_x, t.center_y, t.center_z, t.bbox_z, m.ifc_class " +
+          "FROM rel_contained_in_space r JOIN element_transforms t ON r.element_guid = t.guid " +
+          "JOIN elements_meta m ON r.element_guid = m.guid"
         );
         var byRoom = {};
         if (rm.length) {
           rm[0].values.forEach(function(row) {
             (byRoom[row[0]] = byRoom[row[0]] || []).push(
-              { guid: row[1], x: row[2], y: row[3], z: row[4], bz: row[5] || 0 });
+              { guid: row[1], x: row[2], y: row[3], z: row[4], bz: row[5] || 0, cls: row[6] || '' });
           });
         }
-        var roomsLit = 0;
+        var roomsLit = 0, ftLit = 0;
         for (var room in byRoom) {
           var members = byRoom[room];
           if (members.some(function(m) { return litGuids[m.guid]; })) continue;
-          var top = members[0];
-          for (var mi = 1; mi < members.length; mi++) {
-            if (members[mi].z + members[mi].bz / 2 > top.z + top.bz / 2) top = members[mi];
+          var flowTerms = members.filter(function(m) { return m.cls === 'IfcFlowTerminal'; });
+          if (flowTerms.length) {
+            flowTerms.forEach(function(ft) {
+              A._nightFixtures.push({ x: ft.x, y: ft.y, z: ft.z, name: 'room-flowterm ' + room,
+                h: ft.bz || 0.2, guid: null });
+              ftLit++;
+            });
+          } else {
+            var top = members[0];
+            for (var mi = 1; mi < members.length; mi++) {
+              if (members[mi].z + members[mi].bz / 2 > top.z + top.bz / 2) top = members[mi];
+            }
+            A._nightFixtures.push({ x: top.x, y: top.y, z: top.z, name: 'room-proxy ' + room,
+              h: top.bz || 0.2, guid: null });
           }
-          A._nightFixtures.push({ x: top.x, y: top.y, z: top.z, name: 'room-proxy ' + room,
-            h: top.bz || 0.2, guid: null });
           roomsLit++;
         }
         if (roomsLit) {
-          source = (source === 'IFC' ? 'IFC+room-proxy(' : 'room-proxy(') + roomsLit + ')';
+          source = (source === 'IFC' ? 'IFC+room-fallback(' : 'room-fallback(') +
+            roomsLit + ' rooms, ' + ftLit + ' via flow-terminal)';
         }
       } catch(e) { console.warn('§NIGHT_ROOM_FALLBACK query failed', e); }
-      // §S259_REMOVED (2026-08-07, user: "i want those fake lights removed in the code" — LTU_AHouse
-      // confirmed 0 real luminaires by direct query, and the synthetic grid this used to generate
-      // here (one fake position every ~15m across each storey's WHOLE bounding box, indoors or not)
-      // was exactly what scattered fabricated lights across LTU's outdoor courtyard — both as real
-      // A._nightLights point lights and, before that fix, as still-render lens quads. A position
-      // with no real element behind it is invention, not extraction (project Prime Rule) — a
-      // building with no real named/classed luminaires now simply has none. Night Mode still works
-      // (moonlight ambient), it just has no per-fixture lights to place.
+      // §NIGHT_CEILING_PLANT (2026-08-07, user: "if completely no fixture. then plant a quad and
+      // PL on ceiling. This is not hurting IFC integrity but effect same as having night or sky or
+      // ground mode" — explicitly sanctioned as PRESENTATION layer, same category as the ground
+      // plane / procedural sky, not asserted as real extracted IFC data. Fires only when tiers 1+2
+      // above found LITERALLY NOTHING — no real named luminaire anywhere, no room-containment data
+      // (or a building with rooms but somehow zero elements in any of them, which tier 2 above
+      // already can't produce given rel_contained_in_space's construction). One point per STOREY —
+      // its centroid + near-top Z, not the old removed 15m grid — explicitly tagged
+      // `presentation: true` so it's the ONLY tier besides real named fixtures that also gets a
+      // still-render lens quad (effects.js checks this flag) — tier 2 above stays PL-only, per
+      // user's own tiering ("take any overhead fixture... as source of lite" — light only, no quad).
+      if (A._nightFixtures.length === 0) {
+        try {
+          var sr2 = A.db.exec(
+            "SELECT m.storey, AVG(t.center_x), AVG(t.center_y), MAX(t.center_z + t.bbox_z/2) " +
+            "FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+            "WHERE m.storey IS NOT NULL GROUP BY m.storey"
+          );
+          var storeysLit = 0;
+          if (sr2.length) {
+            sr2[0].values.forEach(function(row) {
+              A._nightFixtures.push({ x: row[1], y: row[2], z: row[3] - 0.3, name: 'ceiling-plant ' + row[0],
+                h: 0.2, guid: null, presentation: true });
+              storeysLit++;
+            });
+          }
+          if (storeysLit) source = 'ceiling-plant(' + storeysLit + ' storeys)';
+        } catch(e) { console.warn('§NIGHT_CEILING_PLANT query failed', e); }
+      }
     }
     A._nightFixtureSource = source;
     return source;
@@ -1350,6 +1385,10 @@ function setupTools(A) {
         // gate against); real IFC rows carry the guid so a buildup bake can withhold the glow until
         // Time Machine has actually placed that fixture (see effects.js A._tmIsVisible).
         p.__guid = f.guid || null;
+        // §NIGHT_CEILING_PLANT — true only for the last-resort synthetic tier; gates the
+        // still-render lens quad IN alongside real named fixtures (guid set), while tier-2's
+        // any-overhead-element pick (guid null, presentation unset) stays PL-only.
+        p.__presentation = !!f.presentation;
         return p;
       });
     }
@@ -1361,7 +1400,20 @@ function setupTools(A) {
     var allPos = A._nightFixtureWorldPositions();
     var camPos = A.camera.position;
     var needed;
-    if (allPos.length <= A._nightMaxLights) {
+    if (A._nightStillBoost) {
+      // §NIGHT_STILL_FRUSTUM (2026-08-07, user: "during Alt-S and movie baking, place quads and
+      // PLs on every noticeable source in the frame") — frustum-cull to what's actually in view
+      // rather than a flat count cap; a still pays this cost once, not every frame. 200 is a
+      // sanity ceiling against a pathological wide aerial shot with hundreds in frame at once —
+      // not a deliberate creative limit.
+      var frustum = new THREE.Frustum();
+      var vpMatrix = new THREE.Matrix4().multiplyMatrices(A.camera.projectionMatrix, A.camera.matrixWorldInverse);
+      frustum.setFromProjectionMatrix(vpMatrix);
+      var inView = allPos.filter(function(p) {
+        return frustum.containsPoint(new THREE.Vector3(p.x, p.y, p.z));
+      });
+      needed = inView.slice(0, 200).map(function(p) { return { pos: p }; });
+    } else if (allPos.length <= A._nightMaxLights) {
       // Small building — place ALL fixtures, no culling
       needed = allPos.map(function(p) { return { pos: p }; });
     } else {
@@ -1380,7 +1432,28 @@ function setupTools(A) {
         var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
         return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
       }).sort(function(a, b) { return a.dist2 - b.dist2; });
-      needed = sorted.slice(0, A._nightMaxLights);
+      // §NIGHT_SPREAD (2026-08-07, user: "not in dense area, if two sources nearby spread out to
+      // cover further line of sight") — greedy nearest-first, but skip a candidate within
+      // NIGHT_SPREAD_MIN_M of one already picked, so the 24-light budget reaches further down a
+      // corridor instead of bunching on one dense cluster right at the camera. If spacing can't
+      // fill the budget (not enough distant candidates), a second pass fills the rest ignoring
+      // spacing — the budget is always fully used, spacing is a preference, not a hard cutoff.
+      var NIGHT_SPREAD_MIN_M = 4;
+      var picked = [];
+      for (var si = 0; si < sorted.length && picked.length < A._nightMaxLights; si++) {
+        var cand = sorted[si].pos;
+        var tooClose = picked.some(function(pk) {
+          var ddx = pk.x - cand.x, ddy = pk.y - cand.y, ddz = pk.z - cand.z;
+          return (ddx * ddx + ddy * ddy + ddz * ddz) < NIGHT_SPREAD_MIN_M * NIGHT_SPREAD_MIN_M;
+        });
+        if (!tooClose) picked.push(cand);
+      }
+      if (picked.length < A._nightMaxLights) {
+        for (var si2 = 0; si2 < sorted.length && picked.length < A._nightMaxLights; si2++) {
+          if (picked.indexOf(sorted[si2].pos) === -1) picked.push(sorted[si2].pos);
+        }
+      }
+      needed = picked.map(function(p) { return { pos: p }; });
     }
     // Remove old lights
     A._nightLights.forEach(function(l) {

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -999,7 +999,10 @@ function setupTools(A) {
         // vocabulary §PHOTO_EMBER uses, and the "filter for 'light'" the user asked for. Measured
         // on the Clinic: 1105 naive name matches -> 841 real luminaires, 264 rejected.
         var r = A.db.exec(
-          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z FROM elements_meta m " +
+          // §GLOW_LENS_QUAD (2026-08-07): bbox_x/bbox_y/rotation_z added so the still-render lens
+          // quad (effects.js) can size and orient itself to the REAL fixture instead of a generic
+          // round halo. Still-only consumer — the live round sprite ignores these three columns.
+          "SELECT t.center_x, t.center_y, t.center_z, m.element_name, t.bbox_z, t.bbox_x, t.bbox_y, t.rotation_z FROM elements_meta m " +
           "JOIN element_transforms t ON m.guid=t.guid " +
           // §NIGHT_NAME_NOT_CLASS (2026-07-27, user: "anything that has 'light' name", "i dunno why
           // we keep missing 'light' in names"). THE ANSWER IS THE CLASS GATE, which used to read
@@ -1068,7 +1071,8 @@ function setupTools(A) {
           "  'IfcStair','IfcStairFlight','IfcMember','IfcBeam','IfcColumn','IfcRailing')");
         if (r.length && r[0].values.length > 0) {
           r[0].values.forEach(function(row) {
-            A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0 });
+            A._nightFixtures.push({ x: row[0], y: row[1], z: row[2], name: row[3] || '', h: row[4] || 0,
+              bw: row[5] || 0, bd: row[6] || 0, rz: row[7] || 0 });
           });
           source = 'IFC';
         }
@@ -1304,6 +1308,8 @@ function setupTools(A) {
         // troffer 0.07m, downlight 0.10m, plain recessed 0.075m, pendant-linear 0.77m (Clinic) —
         // the pendant number is the drop rod, and dropping by it lands the glow on the lamp.
         p.__drop = (f.h || 0) / 2 + 0.12;
+        // §GLOW_LENS_QUAD — real fixture footprint + yaw, still-render lens only (see effects.js).
+        p.__bw = f.bw || 0; p.__bd = f.bd || 0; p.__rz = f.rz || 0;
         return p;
       });
     }

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=11" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=14" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=11" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -838,7 +838,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=32" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=36" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
## Summary
- **§GLOW_LENS_NO_DOUBLE_YAW** — still-render lens quad was applying `rotation_z` as an extra yaw on top of already-world-frame `bbox_x/bbox_y`, double-rotating it. Invisible at 0/π, a 90° footprint swap at ±π/2. Proven against real DB rows (`Terminal_extracted.db`).
- **§GLOW_TRUE_BOTTOM** — night-glow drop height assumed `center_z` sits at the bbox midpoint; it's actually the IFC placement origin. Measured 124-286mm error per fixture type via real mesh vertices (`Hospital_geo.db`). Now reads the fixture's actual mesh bounding box instead of guessing — no schema/migration needed, the geometry hash already ships.
- **§NIGHT_LIGHT_CHURN_FIX** — `_nightUpdateLights()` disposed and rebuilt every `PointLight` from scratch on every ~5m of camera travel while night mode was on, found via a controlled A/B ("smooth when lighting is off"). Now reuses lights in place by stable fixture reference, only the delta is added/removed.
- Brightness tune: `NIGHT_LIGHT_INTENSITY` 8.0→4.5, fixture `emissiveIntensity` 0.8→0.45.

## Test plan
- [x] Syntax-checked (`node --check`) on all touched files
- [x] Numeric witnesses computed directly from real building DB + mesh data (no rendering/screenshots) — see commit message for details
- [ ] Live browser confirmation of `§BUILD_VERSION` + a `§GLOW_LENS_QUAD`/`§NIGHT_MODE` smoke pass (not done this session — offline verification only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F2pgUMpctj58F2hRDSzBdr