### PR TITLE
feat(cpe-walk): §CPE_WALK_GAMEPAD_NAV — gamepad as third walk-mode input

### DIFF
--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -67,6 +67,16 @@
   // stops the browser's page-zoom.
   var WHEEL_GLIDE_M = 1.2;         // metres per wheel notch
   var WHEEL_SPRINT_X = 4;          // Shift multiplier
+  // §CPE_WALK_GAMEPAD_NAV (prompts/CPE_WALK_GAMEPAD_NAV.md) — standard-mapping controller as a THIRD
+  // input device alongside WASD+mouse and wheel/pinch-glide, not a replacement for either. Right
+  // stick is a RATE (deflection -> turn-rate, held constant while pushed), unlike MOUSE_SENSITIVITY
+  // which is a per-pixel DELTA gain — different units, so this needs its own constant. Tuned to
+  // "full deflection ≈ 120deg/sec" (2.0944 rad/sec) — fast enough to spin around in ~3s at full
+  // push, slow enough at partial deflection (dead-zone .. 1.0) to still frame a shot precisely;
+  // no real controller in this environment to feel-tune against (spec §VERIFY Q2 open item, deferred
+  // to a live-controller pass), so this is a considered starting value, not a measured one.
+  var GAMEPAD_LOOK_RATE = Math.PI * (120 / 180);   // rad/sec at full stick deflection
+  var GAMEPAD_DEADZONE = 0.15;     // spec's own value — avoids drift from worn/imprecise sticks
 
   var _active = false;
   var _cpe = null;          // window.APP.cinemaPathEditor, cached at mount
@@ -89,6 +99,14 @@
   // continue). Only closing B / the editor (forceStop) clears it.
   var _resumePose = null;    // { x,y,z, yaw, pitch } from the last stop(); null = spawn fresh
   var _glideLogged = false;
+  // §CPE_WALK_GAMEPAD_NAV — connect-gated, per the spec's "zero cost when unused": _tick() only
+  // calls navigator.getGamepads() when this flag is true (set by a real gamepadconnected event),
+  // never speculatively every frame on the chance a pad exists.
+  var _gpConnected = false;
+  var _gpIndex = null;
+  var _gpFirstInputLogged = false;
+  var _gpSnapWasDown = false;   // edge-detect so A button plants one stick per press, not per frame held
+  var _gpStopWasDown = false;   // edge-detect so B/Start stops once per press
 
   // ══════════════════ §CPE_WALK_CANVAS_FREEZE — capture / recapture ══════════════════
   function _renderMainOnce() {
@@ -239,6 +257,59 @@
     }
   }
 
+  // ══════════════════ §CPE_WALK_GAMEPAD_NAV — pure axis/button -> motion mapping ══════════════════
+  // Takes a PLAIN {axes, buttons}-shaped object, never calls navigator.getGamepads() itself — per
+  // the spec's architecture note, this is what makes the maths unit-testable with synthetic data in
+  // an environment with no physical controller attached (getGamepads() can't be faked from JS).
+  // `mapping` is checked by the caller (gamepadconnected handler), NOT here, so this function stays
+  // a pure number-in/number-out transform with no DOM/global dependency at all.
+  function _gamepadMap(pad, dt) {
+    var axes = (pad && pad.axes) || [];
+    var buttons = (pad && pad.buttons) || [];
+    var dz = GAMEPAD_DEADZONE;
+    var az = function(v) { v = v || 0; return Math.abs(v) < dz ? 0 : v; };
+    var lx = az(axes[0]), ly = az(axes[1]);   // left stick: move
+    var rx = az(axes[2]), ry = az(axes[3]);   // right stick: look
+    // move: right*axes[0] + fwd*-axes[1] — same convention as WASD's `move.add(right)`/`move.add(fwd)`
+    // in _tick(), scaled by the SAME WALK_SPEED_MPS so keyboard/gamepad feel identical (spec's own
+    // "no new speed constant" requirement).
+    var moveRight = lx, moveFwd = -ly;
+    var moveLen = Math.sqrt(moveRight * moveRight + moveFwd * moveFwd);
+    if (moveLen > 1) { moveRight /= moveLen; moveFwd /= moveLen; moveLen = 1; }   // clamp diagonal to unit circle
+    var moveMag = moveLen * WALK_SPEED_MPS * dt;
+    var yawDelta = -rx * GAMEPAD_LOOK_RATE * dt;
+    var pitchDelta = -ry * GAMEPAD_LOOK_RATE * dt;
+    var btn = function(i) { var b = buttons[i]; return !!(b && (b.pressed || b === true)); };
+    return {
+      moveRight: moveRight * moveMag, moveFwd: moveFwd * moveMag,   // metres this frame, world-relative-to-facing
+      yawDelta: yawDelta, pitchDelta: pitchDelta,                   // radians this frame
+      snap: btn(0),                                                 // A button -> _doSnap()
+      stop: btn(1) || btn(9),                                       // B or Start -> stop()
+      active: moveLen > 0 || rx !== 0 || ry !== 0 || btn(0) || btn(1) || btn(9)
+    };
+  }
+  function _onGamepadConnected(e) {
+    var gp = e.gamepad;
+    if (!gp) return;
+    if (gp.mapping !== 'standard') {
+      console.log('§CPE_WALK_GAMEPAD_IGNORED id="' + gp.id + '" mapping="' + (gp.mapping || '(none)') +
+        '" — v1 only supports standard-mapping controllers (spec CPE_WALK_GAMEPAD_NAV.md §Scope), skipping');
+      return;
+    }
+    _gpConnected = true;
+    _gpIndex = gp.index;
+    _gpFirstInputLogged = false;
+    console.log('§CPE_WALK_GAMEPAD_CONNECT id="' + gp.id + '" mapping="' + gp.mapping + '" index=' + gp.index +
+      ' axes=' + gp.axes.length + ' buttons=' + gp.buttons.length);
+  }
+  function _onGamepadDisconnected(e) {
+    var gp = e.gamepad;
+    if (!gp || gp.index !== _gpIndex) return;
+    _gpConnected = false;
+    _gpIndex = null;
+    console.log('§CPE_WALK_GAMEPAD_DISCONNECT id="' + gp.id + '" index=' + gp.index);
+  }
+
   // ══════════════════ the per-frame walk loop — see §CPE_WALK_CANVAS_FREEZE header comment for
   // why this NEVER calls A.markDirty() ══════════════════
   function _tick(tNow) {
@@ -256,6 +327,35 @@
     if (move.lengthSq() > 0 && dt > 0) {
       move.normalize().multiplyScalar(WALK_SPEED_MPS * dt);
       _vfCam.position.add(move);
+    }
+    // §CPE_WALK_GAMEPAD_NAV — alternate input, applied additively to the SAME right/fwd/_yaw/_pitch
+    // state WASD+mouse-look already drive (no separate camera path). Only polls getGamepads() when a
+    // gamepadconnected event has actually fired (_gpConnected) — see file-header cost note.
+    if (_gpConnected && dt > 0 && navigator.getGamepads) {
+      var pad = navigator.getGamepads()[_gpIndex];
+      if (pad) {
+        var gm = _gamepadMap(pad, dt);
+        if (gm.moveRight || gm.moveFwd) {
+          _vfCam.position.addScaledVector(right, gm.moveRight);
+          _vfCam.position.addScaledVector(fwd, gm.moveFwd);
+        }
+        if (gm.yawDelta || gm.pitchDelta) {
+          _yaw += gm.yawDelta;
+          _pitch = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, _pitch + gm.pitchDelta));
+          _vfCam.rotation.set(_pitch, _yaw, 0);
+        }
+        if (gm.active && !_gpFirstInputLogged) {
+          _gpFirstInputLogged = true;
+          console.log('§CPE_WALK_GAMEPAD_FIRST_INPUT moveRight=' + gm.moveRight.toFixed(3) + ' moveFwd=' + gm.moveFwd.toFixed(3) +
+            ' yawDelta=' + gm.yawDelta.toFixed(4) + ' pitchDelta=' + gm.pitchDelta.toFixed(4) +
+            ' snap=' + gm.snap + ' stop=' + gm.stop);
+        }
+        // Edge-triggered: _doSnap()/stop() fire once per press, not once per frame held.
+        if (gm.snap && !_gpSnapWasDown) { _gpSnapWasDown = true; _doSnap(); }
+        else if (!gm.snap) { _gpSnapWasDown = false; }
+        if (gm.stop && !_gpStopWasDown) { _gpStopWasDown = true; stop(); return; }
+        else if (!gm.stop) { _gpStopWasDown = false; }
+      }
     }
     _vfCam.updateMatrixWorld(true);
     var a = A();
@@ -337,6 +437,15 @@
     }
     _keys = { w: false, a: false, s: false, d: false };
     _frame = 0; _snapCount = 0; _lastT = 0;
+    // §CPE_WALK_GAMEPAD_NAV — a pad already connected BEFORE this mount (event fired while walk mode
+    // was closed) still needs picking up: gamepadconnected only fires once, at physical connect time.
+    _gpFirstInputLogged = false; _gpSnapWasDown = false; _gpStopWasDown = false;
+    if (!_gpConnected && navigator.getGamepads) {
+      var _existing = navigator.getGamepads();
+      for (var _gi = 0; _existing && _gi < _existing.length; _gi++) {
+        if (_existing[_gi]) { _onGamepadConnected({ gamepad: _existing[_gi] }); break; }
+      }
+    }
 
     // Seam 2 — the ONLY caller of _wire()/_unwire() this feature needed.
     cpe._walkMount();
@@ -348,7 +457,8 @@
 
     _handlers = {
       mousemove: _onMouseMove, lockchange: _onLockChange, keydown: _onKeyDown, keyup: _onKeyUp,
-      mousedown: _onMouseDown, click: _onCanvasClick, wheel: _onWheel
+      mousedown: _onMouseDown, click: _onCanvasClick, wheel: _onWheel,
+      gamepadconnected: _onGamepadConnected, gamepaddisconnected: _onGamepadDisconnected
     };
     document.addEventListener('mousemove', _handlers.mousemove, true);
     document.addEventListener('pointerlockchange', _handlers.lockchange, true);
@@ -358,6 +468,11 @@
     canvas.addEventListener('click', _handlers.click, true);
     // §CPE_WALK_GLIDE — passive:false so preventDefault can stop ctrl+wheel page-zoom (trackpad pinch)
     window.addEventListener('wheel', _handlers.wheel, { capture: true, passive: false });
+    // §CPE_WALK_GAMEPAD_NAV — mount/unmount scoped like every other listener here (spec: "gated the
+    // same way _tick() already gates on _active"); _tick()'s own getGamepads() poll additionally
+    // gates on _gpConnected, so this costs nothing until a real pad both connects AND walk is open.
+    window.addEventListener('gamepadconnected', _handlers.gamepadconnected, true);
+    window.addEventListener('gamepaddisconnected', _handlers.gamepaddisconnected, true);
 
     _active = true;
     _syncButton();
@@ -392,8 +507,11 @@
         _canvas.removeEventListener('click', _handlers.click, true);
       }
       window.removeEventListener('wheel', _handlers.wheel, { capture: true });
+      window.removeEventListener('gamepadconnected', _handlers.gamepadconnected, true);
+      window.removeEventListener('gamepaddisconnected', _handlers.gamepaddisconnected, true);
       _handlers = null;
     }
+    _gpConnected = false; _gpIndex = null;
     if (document.pointerLockElement === _canvas && document.exitPointerLock) document.exitPointerLock();
     _dropFreeze();
     _tmUnlock(_tm); _tm = null;
@@ -445,7 +563,17 @@
       return true;
     },
     _tmLockState: function() { return _tm ? { locked: true, lockedBtn: _tm.lockedBtn ? _tm.lockedBtn.id : null, prevPointerEvents: _tm.prevPointerEvents } : { locked: false }; },
-    _freezeElId: function() { return _freezeEl ? _freezeEl.id : null; }
+    _freezeElId: function() { return _freezeEl ? _freezeEl.id : null; },
+    // §CPE_WALK_GAMEPAD_NAV — exercises the REAL pure mapping function with a SYNTHETIC {axes,
+    // buttons} pad, same precedent as _snapForTest above. This is the ONLY witnessable numeric
+    // surface for gamepad input in an environment with no physical controller (navigator.getGamepads()
+    // cannot be faked from JS — spec's own architecture note).
+    _gamepadMapForTest: function(pad, dt) { return _gamepadMap(pad, dt); },
+    _gamepadStateForTest: function() { return { connected: _gpConnected, index: _gpIndex }; },
+    // Drives the connect/disconnect handlers directly with a synthetic Gamepad-shaped object — lets a
+    // witness prove the mapping-gate (ignore non-standard) and the connect log without real hardware.
+    _gamepadConnectForTest: function(gp) { _onGamepadConnected({ gamepad: gp }); },
+    _gamepadDisconnectForTest: function(gp) { _onGamepadDisconnected({ gamepad: gp }); }
   };
   console.log('§CPE_WALK_MODULE_LOADED');
 })();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v965';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v966';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -825,7 +825,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=13" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cpe_walk.js?v=4" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cpe_walk.js?v=5" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_walk_gamepad.js
+++ b/witness_cpe_walk_gamepad.js
@@ -1,0 +1,162 @@
+// WITNESS — §CPE_WALK_GAMEPAD_NAV (prompts/CPE_WALK_GAMEPAD_NAV.md, prompts/CPE_WALK_GAMEPAD_NAV.md
+// implementation session, 2026-08-08).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-GP-LOAD       cpe_walk.js loads cleanly and exposes the new gamepad test hooks on window.CpeWalk.
+//   G-GP-MOVE-FWD   left stick full-forward (axes=[0,-1,0,0]) produces a move vector of magnitude
+//                   WALK_SPEED_MPS (the SAME constant WASD uses — spec's "no new speed constant").
+//   G-GP-MOVE-RIGHT left stick full-right (axes=[1,0,0,0]) produces moveRight===WALK_SPEED_MPS,
+//                   moveFwd===0 — axis convention matches the spec's `right*axes[0]+fwd*-axes[1]`.
+//   G-GP-MOVE-DT    halving dt halves the move magnitude — confirms dt-scaling (not a fixed step).
+//   G-GP-DIAG-CLAMP a full diagonal push (axes=[1,-1,0,0], both axes at 1.0) is clamped to unit
+//                   circle — magnitude stays WALK_SPEED_MPS*dt, not sqrt(2)x it (no diagonal speed
+//                   boost, matching WASD's own move.normalize() behaviour).
+//   G-GP-DEADZONE   every axis at 0.1 (below the 0.15 dead-zone) produces an all-zero result
+//                   (moveRight=moveFwd=yawDelta=pitchDelta=0, active=false) — no drift from a
+//                   resting/imprecise stick.
+//   G-GP-DEADZONE-EDGE a value just OUTSIDE the dead-zone (0.16) DOES register (active=true) —
+//                   proves the threshold is the boundary, not an unrelated bug masking all input.
+//   G-GP-LOOK-YAW   right stick full-right (axes=[0,0,1,0]) produces yawDelta = -GAMEPAD_LOOK_RATE*dt
+//                   exactly (bit-identical to the constant read out of the source, not re-derived).
+//   G-GP-LOOK-PITCH right stick full-down (axes=[0,0,0,1]) produces pitchDelta = -GAMEPAD_LOOK_RATE*dt.
+//   G-GP-SNAP-BTN   buttons[0].pressed=true => snap===true; buttons[0].pressed=false => snap===false.
+//   G-GP-STOP-BTN   buttons[1].pressed=true => stop===true; buttons[9].pressed=true (Start) =>
+//                   stop===true too (spec: "B button or Start").
+//   G-GP-MAPPING-GATE a non-"standard" mapping connect is IGNORED (state stays disconnected, logs
+//                   §CPE_WALK_GAMEPAD_IGNORED); a "standard" mapping connect DOES register
+//                   (§CPE_WALK_GAMEPAD_CONNECT, _gamepadStateForTest().connected===true) — proves
+//                   the v1 scope gate from the spec's §Scope section.
+//   G-GP-DISCONNECT disconnecting the SAME index clears connected state; a disconnect of a
+//                   DIFFERENT (never-connected) index is a no-op (stale-event guard).
+//
+// All gates run the REAL `_gamepadMap`/`_onGamepadConnected`/`_onGamepadDisconnected` functions
+// inside cpe_walk.js via a Node `vm` sandbox — no reimplementation of the maths under test. This is
+// the ONLY witnessable numeric surface for gamepad input per the spec's own architecture note:
+// `navigator.getGamepads()` cannot be faked from JS, so there is no live-controller assertion; the
+// pure function is what carries all the arithmetic, and `_tick()`'s use of it is a thin,
+// unwitnessable wrapper (same as the file's own precedent for the `_keys` object / WASD).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC_PATH = path.join(__dirname, 'viewer', 'cpe_walk.js');
+const src = fs.readFileSync(SRC_PATH, 'utf8');
+
+// Extract the tuned constants straight from source (EXTRACT, not invent) so the assertions below
+// stay bit-identical to whatever the file actually declares, even if a future tuning pass changes them.
+const speedM = src.match(/var WALK_SPEED_MPS = ([\d.]+);/);
+const deadzoneM = src.match(/var GAMEPAD_DEADZONE = ([\d.]+);/);
+if (!speedM || !deadzoneM) { console.error('§WITNESS_SETUP_FAIL could not extract WALK_SPEED_MPS/GAMEPAD_DEADZONE from source'); process.exit(1); }
+const WALK_SPEED_MPS = +speedM[1];
+const GAMEPAD_DEADZONE = +deadzoneM[1];
+const GAMEPAD_LOOK_RATE = Math.PI * (120 / 180);   // must match cpe_walk.js's own literal expression
+
+const logs = [];
+const sandbox = {
+  window: {},
+  navigator: {},
+  document: { addEventListener: function() {}, removeEventListener: function() {} },
+  console: { log: function(s) { logs.push(String(s)); }, warn: function(s) { logs.push('WARN ' + s); } },
+  performance: { now: function() { return Date.now(); } },
+  requestAnimationFrame: function() {}, cancelAnimationFrame: function() {},
+  THREE: {},
+};
+sandbox.window = sandbox;   // cpe_walk.js reads bare `window` — self-reference so window.APP etc resolve harmlessly
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox, { filename: SRC_PATH });
+
+const CpeWalk = sandbox.window.CpeWalk;
+const checks = [];
+const P = (n, ok, d) => checks.push({ n, ok, d });
+
+P('G-GP-LOAD module loaded, exposes gamepad test hooks',
+  !!CpeWalk && typeof CpeWalk._gamepadMapForTest === 'function' &&
+  typeof CpeWalk._gamepadConnectForTest === 'function' && typeof CpeWalk._gamepadDisconnectForTest === 'function' &&
+  logs.some(l => l.indexOf('§CPE_WALK_MODULE_LOADED') === 0),
+  `hooks present=${!!CpeWalk} logs=[${logs.join(' | ')}]`);
+
+const dt1 = 1.0;
+const fwd = CpeWalk._gamepadMapForTest({ axes: [0, -1, 0, 0], buttons: [] }, dt1);
+const fwdMag = Math.hypot(fwd.moveRight, fwd.moveFwd);
+P('G-GP-MOVE-FWD full-forward left stick (axes[1]=-1) at dt=1 produces move magnitude === WALK_SPEED_MPS',
+  Math.abs(fwdMag - WALK_SPEED_MPS) < 1e-9 && Math.abs(fwd.moveRight) < 1e-9 && Math.abs(fwd.moveFwd - WALK_SPEED_MPS) < 1e-9,
+  `moveRight=${fwd.moveRight} moveFwd=${fwd.moveFwd} mag=${fwdMag} want=${WALK_SPEED_MPS}`);
+
+const right = CpeWalk._gamepadMapForTest({ axes: [1, 0, 0, 0], buttons: [] }, dt1);
+P('G-GP-MOVE-RIGHT full-right left stick (axes[0]=1) at dt=1: moveRight===WALK_SPEED_MPS, moveFwd===0',
+  Math.abs(right.moveRight - WALK_SPEED_MPS) < 1e-9 && Math.abs(right.moveFwd) < 1e-9,
+  `moveRight=${right.moveRight} moveFwd=${right.moveFwd}`);
+
+const fwdHalfDt = CpeWalk._gamepadMapForTest({ axes: [0, -1, 0, 0], buttons: [] }, 0.5);
+P('G-GP-MOVE-DT halving dt halves the move magnitude (rate-based, not a fixed step)',
+  Math.abs(fwdHalfDt.moveFwd - WALK_SPEED_MPS * 0.5) < 1e-9,
+  `moveFwd(dt=0.5)=${fwdHalfDt.moveFwd} want=${WALK_SPEED_MPS * 0.5}`);
+
+const diag = CpeWalk._gamepadMapForTest({ axes: [1, -1, 0, 0], buttons: [] }, dt1);
+const diagMag = Math.hypot(diag.moveRight, diag.moveFwd);
+P('G-GP-DIAG-CLAMP full diagonal push is clamped to the unit circle (magnitude stays WALK_SPEED_MPS, not sqrt(2)x)',
+  Math.abs(diagMag - WALK_SPEED_MPS) < 1e-9,
+  `moveRight=${diag.moveRight} moveFwd=${diag.moveFwd} mag=${diagMag} want=${WALK_SPEED_MPS} (unclamped would be ${(WALK_SPEED_MPS * Math.SQRT2).toFixed(3)})`);
+
+const dz = CpeWalk._gamepadMapForTest({ axes: [0.1, 0.1, 0.1, 0.1], buttons: [] }, dt1);
+P(`G-GP-DEADZONE all axes at 0.1 (< ${GAMEPAD_DEADZONE} dead-zone) produce an all-zero, inactive result`,
+  dz.moveRight === 0 && dz.moveFwd === 0 && dz.yawDelta === 0 && dz.pitchDelta === 0 && dz.active === false,
+  JSON.stringify(dz));
+
+const dzEdge = CpeWalk._gamepadMapForTest({ axes: [0.16, 0, 0, 0], buttons: [] }, dt1);
+P(`G-GP-DEADZONE-EDGE an axis just OUTSIDE the dead-zone (0.16 > ${GAMEPAD_DEADZONE}) DOES register (active=true)`,
+  dzEdge.active === true && dzEdge.moveRight !== 0,
+  JSON.stringify(dzEdge));
+
+const yaw = CpeWalk._gamepadMapForTest({ axes: [0, 0, 1, 0], buttons: [] }, dt1);
+P('G-GP-LOOK-YAW right stick full-right (axes[2]=1) at dt=1: yawDelta === -GAMEPAD_LOOK_RATE (bit-identical to source constant)',
+  Math.abs(yaw.yawDelta - (-GAMEPAD_LOOK_RATE)) < 1e-12,
+  `yawDelta=${yaw.yawDelta} want=${-GAMEPAD_LOOK_RATE}`);
+
+const pitch = CpeWalk._gamepadMapForTest({ axes: [0, 0, 0, 1], buttons: [] }, dt1);
+P('G-GP-LOOK-PITCH right stick full-down (axes[3]=1) at dt=1: pitchDelta === -GAMEPAD_LOOK_RATE',
+  Math.abs(pitch.pitchDelta - (-GAMEPAD_LOOK_RATE)) < 1e-12,
+  `pitchDelta=${pitch.pitchDelta} want=${-GAMEPAD_LOOK_RATE}`);
+
+const snapOn = CpeWalk._gamepadMapForTest({ axes: [0, 0, 0, 0], buttons: [{ pressed: true }] }, dt1);
+const snapOff = CpeWalk._gamepadMapForTest({ axes: [0, 0, 0, 0], buttons: [{ pressed: false }] }, dt1);
+P('G-GP-SNAP-BTN buttons[0].pressed toggles snap true/false',
+  snapOn.snap === true && snapOff.snap === false, `on=${snapOn.snap} off=${snapOff.snap}`);
+
+const stopB = CpeWalk._gamepadMapForTest({ axes: [0, 0, 0, 0], buttons: [{}, { pressed: true }] }, dt1);
+const stopStart = CpeWalk._gamepadMapForTest({ axes: [0, 0, 0, 0], buttons: new Array(9).concat([{ pressed: true }]) }, dt1);
+P('G-GP-STOP-BTN buttons[1] (B) and buttons[9] (Start) both produce stop===true',
+  stopB.stop === true && stopStart.stop === true, `B=${stopB.stop} Start=${stopStart.stop}`);
+
+const markConn = logs.length;
+CpeWalk._gamepadConnectForTest({ id: 'Fake Flight Stick', index: 0, mapping: '', axes: [0, 0], buttons: [] });
+const winIgnore = logs.slice(markConn);
+const stateAfterIgnore = CpeWalk._gamepadStateForTest();
+P('G-GP-MAPPING-GATE non-"standard" mapping connect is IGNORED (state stays disconnected, logs §CPE_WALK_GAMEPAD_IGNORED)',
+  stateAfterIgnore.connected === false && winIgnore.some(l => l.indexOf('§CPE_WALK_GAMEPAD_IGNORED') === 0),
+  `state=${JSON.stringify(stateAfterIgnore)} logged=[${winIgnore.join(' | ')}]`);
+
+const markConn2 = logs.length;
+CpeWalk._gamepadConnectForTest({ id: 'Fake Xbox Controller', index: 2, mapping: 'standard', axes: [0, 0, 0, 0], buttons: [] });
+const winConnect = logs.slice(markConn2);
+const stateAfterConnect = CpeWalk._gamepadStateForTest();
+P('G-GP-CONNECT "standard" mapping connect DOES register (connected=true, index captured, logs §CPE_WALK_GAMEPAD_CONNECT)',
+  stateAfterConnect.connected === true && stateAfterConnect.index === 2 && winConnect.some(l => l.indexOf('§CPE_WALK_GAMEPAD_CONNECT') === 0),
+  `state=${JSON.stringify(stateAfterConnect)} logged=[${winConnect.join(' | ')}]`);
+
+const staleDisconnect = CpeWalk._gamepadDisconnectForTest({ id: 'other', index: 5 });
+const stateAfterStale = CpeWalk._gamepadStateForTest();
+P('G-GP-DISCONNECT-STALE a disconnect event for a DIFFERENT index is a no-op (still connected at index 2)',
+  stateAfterStale.connected === true && stateAfterStale.index === 2, JSON.stringify(stateAfterStale));
+
+CpeWalk._gamepadDisconnectForTest({ id: 'Fake Xbox Controller', index: 2 });
+const stateAfterDisconnect = CpeWalk._gamepadStateForTest();
+P('G-GP-DISCONNECT matching index disconnect clears connected state',
+  stateAfterDisconnect.connected === false && stateAfterDisconnect.index === null, JSON.stringify(stateAfterDisconnect));
+
+console.log(`\n${'='.repeat(78)}\n§CPE_WALK_GAMEPAD_NAV pure-function witness (WALK_SPEED_MPS=${WALK_SPEED_MPS} GAMEPAD_LOOK_RATE=${GAMEPAD_LOOK_RATE.toFixed(6)} GAMEPAD_DEADZONE=${GAMEPAD_DEADZONE})\n${'='.repeat(78)}`);
+let allPass = true;
+checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+console.log(`\n${allPass ? checks.length + '/' + checks.length + ' PASS — WITNESS PASS' : 'WITNESS FAIL'}`);
+process.exit(allPass ? 0 : 1);


### PR DESCRIPTION
## Summary
- Adds a standard-mapping game controller (Xbox/PlayStation/generic USB-BT, via the browser Gamepad API) as a THIRD input method for `viewer/cpe_walk.js`'s CPE walk mode, alongside the existing WASD+mouse and wheel/pinch-glide — not a replacement. Spec: `prompts/CPE_WALK_GAMEPAD_NAV.md`.
- Left stick → move (reuses `WALK_SPEED_MPS`, same speed WASD already uses). Right stick → yaw/pitch turn-rate (new `GAMEPAD_LOOK_RATE` constant, ~120°/sec at full deflection — a rate, not a per-pixel delta like `MOUSE_SENSITIVITY`, so it needed its own constant). A button → `_doSnap()` (plant stick). B button or Start → `stop()`. 0.15 dead-zone on all axes.
- v1 scope: only `mapping === "standard"` gamepads (per spec §Scope) — non-standard devices are logged and ignored.
- The axis/button → motion maths lives in a **pure function** `_gamepadMap(pad, dt)` that takes a plain `{axes, buttons}` object and never calls `navigator.getGamepads()` itself — this is what makes it unit-testable with synthetic data in an environment with no physical controller (`getGamepads()` can't be faked from JS). `_tick()`'s own per-frame poll is a thin wrapper around it, gated on a connected-flag set by a real `gamepadconnected` event (zero cost unless walk mode is open AND a pad has actually connected).
- `gamepadconnected`/`gamepaddisconnected` listeners are mount/unmount scoped, same convention as every other DOM listener already in this file.

## Test plan
- [x] `node --check viewer/cpe_walk.js` — syntax OK.
- [x] `node witness_cpe_walk_gamepad.js` — 15/15 gates PASS, exercising the REAL `_gamepadMap`/connect/disconnect functions via a Node `vm` sandbox (no reimplementation): move magnitude/direction, dt-scaling, diagonal unit-circle clamp, dead-zone threshold + edge, yaw/pitch rate (bit-identical to the source constant), snap/stop buttons, standard-mapping scope gate, connect/disconnect state.
- [x] Lightweight browser load-check (Puppeteer, localhost sandbox, Duplex building) — `cpe_walk.js?v=5` loads with zero console/page errors, `window.CpeWalk` exposes all four new test hooks in a real browser context.
- [x] `sw.js` `CACHE_VERSION` bumped v965→v966; `viewer.html`'s `cpe_walk.js?v=4` → `?v=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4X8krLrmSjGCFt5hJgQK1