### PR TITLE
fix(night): mobile 1-PL cap + memory witness logging

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v966';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v967';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -861,9 +861,15 @@ function setupTools(A) {
   // effects.js — measured +2064ms on Hospital, judged not worth it at the time). User directive
   // this session explicitly accepts that cost ("we got speed... without DLOD we can scale with
   // some more cost") — so the still budget bump below is only real if this is also true.
-  A._nightMaxLightsNav = 24;       // navigation budget — the RESET target (effects.js reads this,
-                                    // not a literal, so tuning this one number can't silently break
-                                    // the still's nav-budget handback)
+  // §NIGHT_MOBILE_MIN_PL (2026-08-08, user: mobile hangs, "maybe just one set of PL") — mobile CPUs
+  // pay the same per-light shader-recompile-on-count-change cost as desktop (see §RAM section above)
+  // with far less headroom. One light (following the camera via the existing nearest-fixture
+  // selection in _nightUpdateLights) instead of 24 removes 23/24 of that cost on mobile specifically;
+  // desktop nav is unaffected. A._isMobile is set by setupStreaming, which runs before setupTools
+  // (see main.js _mods order), so it's already valid here.
+  A._nightMaxLightsNav = A._isMobile ? 1 : 24;   // navigation budget — the RESET target (effects.js
+                                    // reads this, not a literal, so tuning this one number can't
+                                    // silently break the still's nav-budget handback)
   A._nightMaxLights = A._nightMaxLightsNav;  // CURRENT budget — swapped to the still value during Alt+S
   A._nightMaxLightsStill = 50;     // frozen-still budget — paid once, no 60fps constraint
   A._nightStillBoost = true;       // re-armed 2026-08-07 — see effects.js §NIGHT_STILL_LIGHTS
@@ -1278,6 +1284,15 @@ function setupTools(A) {
       // so effects.js can re-call it every accumulation/orbit frame (see _reassertPhotoGlow),
       // same discipline. Cheap re-scan: skips any matCache key already processed.
       A._applyNightGlowToMatCache();
+      // §NIGHT_MEM_WITNESS (2026-08-08, user suspects a desktop memory issue across repeated
+      // Night toggles) — real numbers, not a guess-fix: heap (when the browser exposes it) +
+      // every collection this toggle touches, so a repeated on/off/on/off test SHOWS growth (or
+      // its absence) instead of being asserted from code-reading alone.
+      console.log('§NIGHT_MEM_WITNESS heapMB=' +
+        (performance.memory ? (performance.memory.usedJSHeapSize / 1048576).toFixed(1) : 'n/a') +
+        ' matCacheKeys=' + Object.keys(A._matCache || {}).length +
+        ' glowMatKeys=' + Object.keys(A._nightGlowMatKeys || {}).length +
+        ' nightLights=' + (A._nightLightByPos ? A._nightLightByPos.size : 0));
       console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
         ' glowMats=' + A._nightGlowMats.length);
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
@@ -1354,6 +1369,11 @@ function setupTools(A) {
         A.ground.visible = false;
         A._setGroundColor(A._whiteBg ? 0xffffff : 0x222233);
       }
+      console.log('§NIGHT_MEM_WITNESS heapMB=' +
+        (performance.memory ? (performance.memory.usedJSHeapSize / 1048576).toFixed(1) : 'n/a') +
+        ' matCacheKeys=' + Object.keys(A._matCache || {}).length +
+        ' glowMatKeys=' + Object.keys(A._nightGlowMatKeys || {}).length +
+        ' nightLights=' + (A._nightLightByPos ? A._nightLightByPos.size : 0));
       console.log('§NIGHT_MODE off');
       btn.style.background = '#1a1a3e';
       btn.style.color = '#aac';

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -838,7 +838,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=36" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=37" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
## Summary
- Mobile nav point-light budget 24→1 (`A._isMobile`) — mobile pays the same shader-recompile-on-light-count-change cost as desktop with far less headroom, matching the reported mobile hang. Desktop nav budget unchanged.
- Added `§NIGHT_MEM_WITNESS` logging on both Night-mode toggle-on and toggle-off (heap size where exposed + glow-mat/light/matCache counts). Checked the obvious leak candidates by reading the dispose code — all clean — but didn't want to claim "no leak" without a repeated-toggle measurement. This gives the next session real numbers instead of another code-reading guess.

## Test plan
- [x] Syntax-checked (`node --check`)
- [ ] Live: toggle night mode on/off ~10x, read `§NIGHT_MEM_WITNESS` heapMB trend — not done this session (offline verification only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F2pgUMpctj58F2hRDSzBdr