### PR TITLE
feat(cpe): §CPE_WALK_WEBXR_VR stopgap — WebXR feature-detect + lifecycle, controller/pose stubbed

### DIFF
--- a/smoke_xr_load.js
+++ b/smoke_xr_load.js
@@ -1,0 +1,52 @@
+// Lightweight browser load-check (NOT the numeric proof — that's witness_cpe_xr_stub.js).
+// Confirms: cpe_xr.js?v=1 loads with no console/page errors in a REAL browser, window.CpeXr
+// carries the documented surface, and the Enter VR button (#cpe-xr-toggle) STAYS HIDDEN because
+// this headless browser reports no navigator.xr support — the correct, expected result here.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8531;
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errors.push(e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Duplex_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => !!window.CpeXr, { timeout: 60000 });
+
+  const check = await page.evaluate(() => ({
+    hasIsSupported: typeof window.CpeXr.isSupported === 'function',
+    hasEnter: typeof window.CpeXr.enter === 'function',
+    hasTick: typeof window.CpeXr._xrTick === 'function',
+    hasControllerMap: typeof window.CpeXr._xrControllerMap === 'function',
+    hasWorldPose: typeof window.CpeXr._xrReadWorldPose === 'function',
+  }));
+  const scriptTagOk = await page.evaluate(() =>
+    !!Array.from(document.scripts).find(s => s.src.indexOf('cpe_xr.js?v=1') !== -1));
+  const moduleLoaded = logs.some(l => l.indexOf('§CPE_XR_MODULE_LOADED') === 0);
+
+  // navigator.xr in this headless swiftshader browser: real Chrome build, but no XR runtime — so
+  // isSupported() must resolve false (the honest, expected result — NOT a mocked true).
+  const supportResult = await page.evaluate(() => window.CpeXr.isSupported());
+
+  // Open the CPE panel + B viewfinder so #cpe-xr-toggle actually gets built (same panel the walk
+  // button lives on), then confirm it stays hidden.
+  await page.evaluate(() => { window.APP && window.APP.markDirty && window.APP.markDirty(); });
+  const btnState = await page.evaluate(() => {
+    var btn = document.getElementById('cpe-xr-toggle');
+    return btn ? { found: true, display: getComputedStyle(btn).display } : { found: false, display: null };
+  });
+
+  console.log('§SMOKE_RESULT ' + JSON.stringify({ check, scriptTagOk, moduleLoaded, supportResult, btnState, errors, pageerrorCount: errors.length }));
+  await browser.close();
+  const surfaceOk = check.hasIsSupported && check.hasEnter && check.hasTick && check.hasControllerMap && check.hasWorldPose;
+  // btnState.found is allowed to be false here (panel never opened in this smoke pass — that's a
+  // separate manual/UI concern) but IF found, it must be hidden since supportResult is false.
+  const btnOk = !btnState.found || btnState.display === 'none';
+  const ok = surfaceOk && scriptTagOk && moduleLoaded && supportResult === false && btnOk && errors.length === 0;
+  console.log(ok ? 'SMOKE PASS' : 'SMOKE FAIL');
+  process.exit(ok ? 0 : 1);
+})();

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1677,7 +1677,13 @@
           '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
             '<path d="M4 16v-2.38C4 11.5 2.97 10.5 3 8c.03-2.72 1.49-6 4.5-6C9.37 2 10 3.8 10 5.5c0 3.11-2 5.66-2 8.68V16a2 2 0 1 1-4 0Z"/>' +
             '<path d="M20 20v-2.38c0-2.12 1.03-3.12 1-5.62-.03-2.72-1.49-6-4.5-6C14.63 6 14 7.8 14 9.5c0 3.11 2 5.66 2 8.68V20a2 2 0 1 0 4 0Z"/>' +
-            '<path d="M16 17h4"/><path d="M4 13h4"/></svg></button></div>';
+            '<path d="M16 17h4"/><path d="M4 13h4"/></svg></button>' +
+        // §CPE_WALK_WEBXR_VR — stopgap flag-plant (prompts/CPE_WALK_WEBXR_VR.md), analogous to the
+        // walk-toggle button just above. Starts hidden; _wireXrToggle() below shows it only if
+        // window.CpeXr.isSupported() resolves true (no headset in dev — stays hidden here).
+        '<button id="cpe-xr-toggle" title="enter VR (WebXR headset)" ' +
+          'style="display:none;pointer-events:auto;flex:none;padding:1px 4px;line-height:1;background:transparent;color:#888;' +
+          'border:1px solid #4a4f57;border-radius:3px;cursor:pointer;font:600 9px system-ui,sans-serif;margin-left:4px">VR</button></div>';
     document.body.appendChild(d);
     // §CPE_VF_STACK owns final geometry (see _vfLayoutStack) and bottom-anchors B + the fused bar
     // as ONE object, so B's own independent viewport clamp is retired here too. Clamping each panel
@@ -1863,6 +1869,7 @@
       // §CPE_WALK_SHOES_BTN: the walk button was just built with B's panel — wire it here, every
       // time the eye re-opens (the old panel and its listeners were removed on the last eye-off).
       _wireWalkToggle();
+      _wireXrToggle();
       if (a.markDirty) a.markDirty();
       console.log('§CPE_VF on — one renderer, scissor sub-viewport, camera pose from the same plan.poseAt() the main view samples; display-only, no drop interaction — timeline panel shown alongside it (§CPE_VF_EYE_DRIVES_SCRUB)');
     } else {
@@ -1914,6 +1921,16 @@
       if (window.CpeWalk && typeof window.CpeWalk.toggle === 'function') window.CpeWalk.toggle();
       else console.warn('§CPE_WALK_MODULE_MISSING cpe_walk.js did not load — walk button is a no-op');
     });
+  }
+  // §CPE_WALK_WEBXR_VR — analogous to _wireWalkToggle above; all WebXR session logic lives in
+  // cpe_xr.js (window.CpeXr). Button starts hidden (see markup) and is shown only if isSupported()
+  // resolves true — this environment has no headset, so it stays hidden.
+  function _wireXrToggle() {
+    var btn = document.getElementById('cpe-xr-toggle');
+    if (!btn || !window.CpeXr) return;
+    window.CpeXr.isSupported().then(function(ok) { if (ok) btn.style.display = ''; });
+    btn.addEventListener('pointerdown', function(ev) { ev.stopPropagation(); });
+    btn.addEventListener('click', function(ev) { ev.stopPropagation(); window.CpeXr.enter(); });
   }
 
   // ══ §CPE_HOSE / §CPE_CLIP / §CPE_BUILDUP — the whole-path strip.

--- a/viewer/cpe_xr.js
+++ b/viewer/cpe_xr.js
@@ -1,0 +1,100 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// cpe_xr.js — §CPE_WALK_WEBXR_VR (prompts/CPE_WALK_WEBXR_VR.md). STOPGAP FLAG-PLANT, not a
+// finished feature (spec's own "Intent" section) — no headset/gamepad has been tested against.
+// Feature detection + session lifecycle are real and wired. Controller locomotion and the
+// rig-vs-camera pose read are INTENTIONAL stubs (spec §VERIFY 1 and 3) — guessing them would land
+// VR snaps silently at the wrong place, worse than an honest gap. No headset in this environment,
+// so session lifecycle (sessionstart/sessionend/_xrTick) is verified by code review + load/syntax
+// checks only, not a live session.
+(function() {
+  'use strict';
+
+  function A() { return window.APP; }
+
+  function isSupported() {
+    if (!navigator.xr || typeof navigator.xr.isSessionSupported !== 'function') return Promise.resolve(false);
+    return navigator.xr.isSessionSupported('immersive-vr').catch(function() { return false; });
+  }
+
+  var _session = null;
+
+  // Real per-frame render call — same renderer/scene/camera main.js's idle-park loop uses (spec's
+  // "render-loop conflict: non-issue" finding). With renderer.xr.enabled=true, Three.js swaps in
+  // the tracked XR camera internally; the passed camera is the reference object (standard WebXR
+  // boilerplate pattern), matching cpe_walk.js's own _renderMainOnce() precedent of calling render
+  // directly from an independent rAF-equivalent loop.
+  function _xrTick(timestamp, frame) {
+    var a = A();
+    if (!a || !a.renderer || !a.scene || !a.camera) return;
+    a.renderer.render(a.scene, a.camera);
+  }
+
+  function _onSessionEnd() {
+    var a = A();
+    if (a && a.renderer) {
+      a.renderer.setAnimationLoop(null);
+      a.renderer.xr.enabled = false;
+    }
+    _session = null;
+    console.log('§CPE_XR_SESSION_END');
+    // Hand back to main.js's idle-park loop. APP.markDirty() (main.js:693) is the real public
+    // entry point — sets _needsRender and calls the internal _startLoop() — same call cpe_walk.js's
+    // own stop() relies on to resume main-view rendering after an independent render loop ends.
+    if (a && a.markDirty) a.markDirty();
+  }
+
+  // Requires a real trusted user gesture — navigator.xr.requestSession() rejects on a synthetic
+  // click, same constraint pointer-lock already hits in cpe_walk.js. Only call from a real click.
+  function enter() {
+    var a = A();
+    if (!a || !a.renderer || !navigator.xr) return;
+    navigator.xr.requestSession('immersive-vr').then(function(session) {
+      _session = session;
+      session.addEventListener('end', _onSessionEnd);
+      a.renderer.xr.enabled = true;
+      a.renderer.xr.setSession(session).then(function() {
+        a.renderer.setAnimationLoop(_xrTick);
+        console.log('§CPE_XR_SESSION_START');
+      });
+    }, function(err) {
+      console.warn('§CPE_XR_REQUEST_FAIL ' + (err && err.message));
+    });
+  }
+
+  // ══ STUBS below — each blocks on an open §VERIFY question in the spec that needs a real
+  // headset/controller to answer. Do not fill in with a guess. ══
+
+  var _stubWarned = false;
+  // Same {axes,buttons}-in shape as cpe_walk.js's _gamepadMap(pad, dt) — XRInputSource.gamepad is
+  // Gamepad-shaped, so this COULD reuse it directly, except xr-standard mapping's axis order is not
+  // confirmed to match the "standard" mapping _gamepadMap assumes (spec §VERIFY 1). No real
+  // controller here to check, so: no-op, honestly.
+  function _xrControllerMap(inputSource, dt) {
+    if (!_stubWarned) {
+      console.warn('§CPE_XR_CONTROLLER_STUB not yet mapped — no locomotion from VR controllers yet, headset pose tracking works, controller input does not');
+      _stubWarned = true;
+    }
+    return { moveRight: 0, moveFwd: 0, yawDelta: 0, pitchDelta: 0, snap: false, stop: false };
+  }
+
+  // Spec §VERIFY 3: does WebXR move the camera directly, or a parent "rig" Object3D it's tracked
+  // under? Reading the wrong one silently lands a snap at the wrong world position — the sharpest
+  // risk this spec names. Returns null; called from nowhere until a real session answers this.
+  function _xrReadWorldPose() {
+    return null;
+  }
+
+  window.CpeXr = {
+    isSupported: isSupported,
+    enter: enter,
+    isActive: function() { return !!_session; },
+    _xrTick: _xrTick,
+    _xrControllerMap: _xrControllerMap,
+    _xrReadWorldPose: _xrReadWorldPose
+  };
+  console.log('§CPE_XR_MODULE_LOADED');
+})();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v967';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v968';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -116,6 +116,7 @@ const PRECACHE_ASSETS = [
   'cinema_maxq.js',
   'cinema_path_editor.js',
   'cpe_walk.js',
+  'cpe_xr.js',
   'lib/mp4_mux.js',   // §MAXQ_MP4 — hand-rolled mp4 muxer; missing => MaxQ silently falls back to webm
   'input_registry.js',
   'scene.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -826,6 +826,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=13" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=5" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>

--- a/witness_cpe_xr_stub.js
+++ b/witness_cpe_xr_stub.js
@@ -1,0 +1,92 @@
+// WITNESS — §CPE_WALK_WEBXR_VR (prompts/CPE_WALK_WEBXR_VR.md). This is a STOPGAP flag-plant, not a
+// finished feature — see that file's own "Intent" section. There is no headset in this
+// environment and navigator.xr session state cannot be faked from plain JS (same constraint the
+// gamepad witness documents for navigator.getGamepads()), so this witness proves only what CAN be
+// proven without hardware: feature-detection resolves cleanly, and the two intentional stub
+// functions (_xrControllerMap, _xrReadWorldPose) return exactly what the spec's stub boundary
+// requires. Session lifecycle (sessionstart/sessionend/_xrTick) is NOT witnessed here — it needs a
+// real or emulated XR session, out of scope for this pass (see report).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-XR-LOAD         cpe_xr.js loads cleanly and exposes the documented window.CpeXr surface.
+//   G-XR-UNSUPPORTED  isSupported() resolves false (without throwing) when navigator.xr is absent
+//                     — the expected, correct result in this environment (no headset).
+//   G-XR-SUPPORTED    isSupported() resolves true when a fake navigator.xr.isSessionSupported
+//                     resolves true — proves the function actually forwards the real API's answer
+//                     rather than being hardcoded false.
+//   G-XR-CONTROLLER-STUB  _xrControllerMap() returns the documented zero/false-shaped no-op object
+//                     (not a guessed mapping) and logs §CPE_XR_CONTROLLER_STUB exactly ONCE across
+//                     repeated calls (per-session warn-once, not a per-frame log flood).
+//   G-XR-WORLDPOSE-STUB   _xrReadWorldPose() returns exactly null — confirms it is NOT wired to a
+//                     guessed rig/camera object (spec §VERIFY 3's sharpest-named risk).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC_PATH = path.join(__dirname, 'viewer', 'cpe_xr.js');
+const src = fs.readFileSync(SRC_PATH, 'utf8');
+
+function makeSandbox(xrStub) {
+  const logs = [];
+  const sandbox = {
+    window: {},
+    navigator: { xr: xrStub },
+    console: { log: function(s) { logs.push(String(s)); }, warn: function(s) { logs.push('WARN ' + s); } },
+    Promise: Promise,
+  };
+  sandbox.window = sandbox;   // cpe_xr.js reads bare `window` — self-reference, same pattern as the gamepad witness
+  sandbox.window.APP = {};    // A() returns window.APP; not exercised by the stub gates below
+  vm.createContext(sandbox);
+  vm.runInContext(src, sandbox, { filename: SRC_PATH });
+  return { CpeXr: sandbox.window.CpeXr, logs };
+}
+
+const checks = [];
+const P = (n, ok, d) => checks.push({ n, ok, d });
+
+(async () => {
+  // G-XR-LOAD + G-XR-UNSUPPORTED — navigator.xr absent entirely (typical non-VR browser)
+  const noXr = makeSandbox(undefined);
+  P('G-XR-LOAD module loaded, exposes documented window.CpeXr surface',
+    !!noXr.CpeXr && typeof noXr.CpeXr.isSupported === 'function' && typeof noXr.CpeXr.enter === 'function' &&
+    typeof noXr.CpeXr._xrTick === 'function' && typeof noXr.CpeXr._xrControllerMap === 'function' &&
+    typeof noXr.CpeXr._xrReadWorldPose === 'function' &&
+    noXr.logs.some(l => l.indexOf('§CPE_XR_MODULE_LOADED') === 0),
+    `CpeXr=${!!noXr.CpeXr} logs=[${noXr.logs.join(' | ')}]`);
+
+  let unsupportedResolved, unsupportedThrew = false;
+  try { unsupportedResolved = await noXr.CpeXr.isSupported(); } catch (e) { unsupportedThrew = true; }
+  P('G-XR-UNSUPPORTED isSupported() resolves false (no throw) when navigator.xr is absent — expected in this environment',
+    unsupportedResolved === false && !unsupportedThrew,
+    `resolved=${unsupportedResolved} threw=${unsupportedThrew}`);
+
+  // G-XR-SUPPORTED — fake navigator.xr.isSessionSupported resolving true, proves isSupported()
+  // forwards the real answer rather than being hardcoded.
+  const fakeXr = { isSessionSupported: function(mode) { return Promise.resolve(mode === 'immersive-vr'); } };
+  const withXr = makeSandbox(fakeXr);
+  const supportedResolved = await withXr.CpeXr.isSupported();
+  P('G-XR-SUPPORTED isSupported() resolves true when a fake navigator.xr reports immersive-vr supported',
+    supportedResolved === true, `resolved=${supportedResolved}`);
+
+  // G-XR-CONTROLLER-STUB
+  const s1 = withXr.CpeXr._xrControllerMap({}, 0.016);
+  const s2 = withXr.CpeXr._xrControllerMap({}, 0.016);   // second call — warn must NOT repeat
+  const warnCount = withXr.logs.filter(l => l.indexOf('§CPE_XR_CONTROLLER_STUB') !== -1).length;
+  const zeroShaped = s1.moveRight === 0 && s1.moveFwd === 0 && s1.yawDelta === 0 && s1.pitchDelta === 0 &&
+    s1.snap === false && s1.stop === false;
+  P('G-XR-CONTROLLER-STUB _xrControllerMap returns zero/false-shaped no-op, warns exactly once across 2 calls',
+    zeroShaped && JSON.stringify(s1) === JSON.stringify(s2) && warnCount === 1,
+    `s1=${JSON.stringify(s1)} s2=${JSON.stringify(s2)} warnCount=${warnCount}`);
+
+  // G-XR-WORLDPOSE-STUB
+  const pose = withXr.CpeXr._xrReadWorldPose();
+  P('G-XR-WORLDPOSE-STUB _xrReadWorldPose() returns exactly null (not wired to a guessed rig/camera object)',
+    pose === null, `pose=${JSON.stringify(pose)}`);
+
+  console.log(`\n${'='.repeat(78)}\n§CPE_WALK_WEBXR_VR stub witness — no headset in this environment, session lifecycle NOT covered here\n${'='.repeat(78)}`);
+  let allPass = true;
+  checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+  console.log(`\n${allPass ? checks.length + '/' + checks.length + ' PASS — WITNESS PASS' : 'WITNESS FAIL'}`);
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
Follow-on to §CPE_WALK_GAMEPAD_NAV (#1251), scoped narrowly per `prompts/CPE_WALK_WEBXR_VR.md`'s
own "Intent — stopgap flag-plant" section: this is a minimal, honest stub, not a finished feature.
No headset was available to test against.

**Real** (`viewer/cpe_xr.js`, new file, 100 lines):
- `window.CpeXr.isSupported()` — `navigator.xr.isSessionSupported('immersive-vr')`.
- `enter()` — `navigator.xr.requestSession('immersive-vr')` from a real trusted click only.
- Session lifecycle: `sessionstart` → `renderer.xr.enabled=true` + `setSession` + `setAnimationLoop(_xrTick)`; `end` → `setAnimationLoop(null)` + `renderer.xr.enabled=false` + `APP.markDirty()` (the real public hand-back into main.js's idle-park loop, same call `cpe_walk.js`'s own `stop()` uses).
- `_xrTick()` calls `renderer.render(scene, camera)` directly — same precedent as `cpe_walk.js`'s `_renderMainOnce()`.
- Enter VR button (`#cpe-xr-toggle`) next to the walk-mode toggle in the B viewfinder header — hidden until `isSupported()` resolves true.

**Stubbed on purpose** (spec `§VERIFY` items 1 and 3 — both need real hardware, guessing would be silently wrong):
- `_xrControllerMap(inputSource, dt)` — same `{axes,buttons}` shape as `cpe_walk.js`'s `_gamepadMap`, but xr-standard axis order is unconfirmed against it. Returns an all-zero/false no-op, warns once.
- `_xrReadWorldPose()` — returns `null`, called from nowhere. Rig-vs-camera ambiguity is the sharpest named risk (wrong guess = silently wrong VR-snap position).

`sw.js`: `cpe_xr.js` added to precache, `CACHE_VERSION` v967→v968.

## Test plan
- [x] `witness_cpe_xr_stub.js` — 5/5 PASS (module surface, `isSupported()` true/false paths, controller-stub shape + warn-once, world-pose stub returns exactly `null`).
- [x] `smoke_xr_load.js` (puppeteer, real Chrome) — script loads, zero console/page errors, `isSupported()` resolves `false` in this headless env (expected, no headset), `§CPE_XR_MODULE_LOADED` logged.
- [x] `node --check` clean on all touched/new files.
- [ ] Session lifecycle (`sessionstart`/`sessionend`/`_xrTick`) — **NOT** exercised against a real or emulated XR session. No headset/WebXR emulator available in this environment. This is an honest, expected gap, not a finished/tested claim — flagged for the next session with real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4X8krLrmSjGCFt5hJgQK1