### PR TITLE
fix(night): brightness round 3, nav 24->30, fix mem-witness logging bug

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v968';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v969';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -867,7 +867,7 @@ function setupTools(A) {
   // selection in _nightUpdateLights) instead of 24 removes 23/24 of that cost on mobile specifically;
   // desktop nav is unaffected. A._isMobile is set by setupStreaming, which runs before setupTools
   // (see main.js _mods order), so it's already valid here.
-  A._nightMaxLightsNav = A._isMobile ? 1 : 24;   // navigation budget — the RESET target (effects.js
+  A._nightMaxLightsNav = A._isMobile ? 1 : 30;   // navigation budget — the RESET target (effects.js
                                     // reads this, not a literal, so tuning this one number can't
                                     // silently break the still's nav-budget handback)
   A._nightMaxLights = A._nightMaxLightsNav;  // CURRENT budget — swapped to the still value during Alt+S
@@ -948,7 +948,7 @@ function setupTools(A) {
     return NIGHT_AMBER;
   };
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
-  var NIGHT_LIGHT_INTENSITY = 4.5; // §S277d, reduced 8.0->6.5->4.5 2026-08-07 (user: still too bright after first cut)
+  var NIGHT_LIGHT_INTENSITY = 2.5; // §S277d, reduced 8.0->6.5->4.5->2.5 2026-08-08 (user: still too bright to make out individual PLs)
   var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
 
   // §NIGHT_GLOW_REASSERT: extracted from toggleNightMode() so it can be re-called every frame
@@ -981,7 +981,7 @@ function setupTools(A) {
       if (!isLight && !isWindow && mk.indexOf('IfcPlate') >= 0 && m.transparent) isWindow = true;
       if (!isLight && !isWindow) continue;
       A._nightGlowMats.push({ mat: m, origE: m.emissive.getHex(), origEI: m.emissiveIntensity });
-      if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.45; _glowCount++; } // reduced 0.8->0.65->0.45 2026-08-07
+      if (isLight) { m.emissive.setHex(0xffe4b5); m.emissiveIntensity = 0.3; _glowCount++; } // reduced 0.8->0.65->0.45->0.3 2026-08-08
       else { m.emissive.setHex(0xfff8ec); m.emissiveIntensity = 0.55; _windowGlowCount++; }
       m.needsUpdate = true;
     }
@@ -1284,19 +1284,18 @@ function setupTools(A) {
       // so effects.js can re-call it every accumulation/orbit frame (see _reassertPhotoGlow),
       // same discipline. Cheap re-scan: skips any matCache key already processed.
       A._applyNightGlowToMatCache();
-      // §NIGHT_MEM_WITNESS (2026-08-08, user suspects a desktop memory issue across repeated
-      // Night toggles) — real numbers, not a guess-fix: heap (when the browser exposes it) +
-      // every collection this toggle touches, so a repeated on/off/on/off test SHOWS growth (or
-      // its absence) instead of being asserted from code-reading alone.
+      console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
+        ' glowMats=' + A._nightGlowMats.length);
+      // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
+      A._nightUpdateLights();
+      // §NIGHT_MEM_WITNESS (2026-08-08, moved AFTER _nightUpdateLights() — placing it before, as
+      // the first version did, made nightLights read 0 on every toggle-on since the light Map
+      // hadn't been populated yet. Real numbers now.
       console.log('§NIGHT_MEM_WITNESS heapMB=' +
         (performance.memory ? (performance.memory.usedJSHeapSize / 1048576).toFixed(1) : 'n/a') +
         ' matCacheKeys=' + Object.keys(A._matCache || {}).length +
         ' glowMatKeys=' + Object.keys(A._nightGlowMatKeys || {}).length +
         ' nightLights=' + (A._nightLightByPos ? A._nightLightByPos.size : 0));
-      console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
-        ' glowMats=' + A._nightGlowMats.length);
-      // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
-      A._nightUpdateLights();
       // §GLOW_SPRITE_NAV_OFF (2026-08-07, user: "remove the others, no more those flimsy night
       // lights" — the round decorative sprite, not A._nightLights). Live nav now runs on the real
       // point lights ONLY (A._nightLights, bumped to 24 below) — no more static round dots. The

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -839,7 +839,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=37" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=38" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
## Summary
- Brightness round 3: `NIGHT_LIGHT_INTENSITY` 4.5→2.5, `emissiveIntensity` 0.45→0.3.
- Nav PL budget (desktop) 24→30 per explicit ask. Alt+S still-refine already shows all in-frustum fixtures regardless of the nav cap — confirmed unchanged, matches "only ALL during Alt-S".
- Fixed a bug in the memory-witness logging added last PR: it read `nightLights` before `_nightUpdateLights()` populated the light map, so it always printed 0. Live data the user pasted (5 on/off cycles) already showed `matCacheKeys` flat at 78 and heap oscillating (not climbing) — no leak found — this fix just makes the light-count field meaningful for future checks.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F2pgUMpctj58F2hRDSzBdr