### PR TITLE
fix(cpe): duplicate-stick guard — same-spot re-click auto-Escs to review (§CPE_WALK_SNAP_GUARD)

### DIFF
--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -98,6 +98,10 @@
   // resume pose so the next shoes press continues exactly where the user stood (snap → review →
   // continue). Only closing B / the editor (forceStop) clears it.
   var _resumePose = null;    // { x,y,z, yaw, pitch } from the last stop(); null = spawn fresh
+  // §CPE_WALK_SNAP_GUARD — duplicate-stick guard for the click (snap-and-keep-walking) gesture.
+  var SNAP_MIN_MOVE_M = 1.5;   // walker must move this far before the next stick can plant
+  var SNAP_DEBOUNCE_MS = 700;  // and at least this long after the previous plant
+  var _lastSnap = null;        // { x,y,z, t } of the last PLANTED stick this walk session
   var _glideLogged = false;
   // §CPE_WALK_GAMEPAD_NAV — connect-gated, per the spec's "zero cost when unused": _tick() only
   // calls navigator.getGamepads() when this flag is true (set by a real gamepadconnected event),
@@ -373,12 +377,41 @@
   function _doSnap() {
     if (!_active || !_cpe || !_vfCam) return null;
     var pos = { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z };
+    // §CPE_WALK_SNAP_GUARD (2026-08-08, user: "i accidentally hit multi sticks at a single spot
+    // because i have not exited the walk mode... one cheap way is to auto ESC when the user clicks
+    // on the stick he just landed") — the click gesture plants WITHOUT exiting, so clicking the
+    // just-landed stick on the frozen backdrop planted a DUPLICATE at the same spot. Three-way
+    // resolution on a repeat click, all decided from the walker's own numbers (under pointer lock
+    // the crosshair IS where you stand — no cursor position exists to hit-test):
+    //   1. within the debounce window        → a double-click bounce; swallow it, stay walking;
+    //   2. later, but still at the same spot → the user is clicking AT the stick they just planted
+    //      = the user's own auto-Esc: exit to review, plant nothing;
+    //   3. moved a real distance             → a genuine next stick; plant and keep walking.
+    var now = performance.now();
+    if (_lastSnap) {
+      var dLast = Math.hypot(pos.x - _lastSnap.x, pos.y - _lastSnap.y, pos.z - _lastSnap.z);
+      if ((now - _lastSnap.t) < SNAP_DEBOUNCE_MS) {
+        console.log('§CPE_WALK_SNAP_GUARD bounce swallowed dtMs=' + (now - _lastSnap.t).toFixed(0) +
+          ' (min ' + SNAP_DEBOUNCE_MS + ') — still walking');
+        return null;
+      }
+      if (dLast < SNAP_MIN_MOVE_M) {
+        console.log('§CPE_WALK_SNAP_GUARD auto-Esc: repeat click at the just-planted stick (dist=' +
+          dLast.toFixed(2) + 'm < ' + SNAP_MIN_MOVE_M + 'm) — exiting walk to review, nothing planted');
+        stop();
+        return null;
+      }
+    }
     var fwdV = new THREE.Vector3(0, 0, -1).applyQuaternion(_vfCam.quaternion);
     var fwd = { x: fwdV.x, y: fwdV.y, z: fwdV.z };
     var t0 = performance.now();
     var res = _cpe._walkSnap(pos, fwd);
     var ms = performance.now() - t0;
     if (!res) { console.warn('§CPE_WALK_SNAP_FAIL pos=(' + pos.x.toFixed(2) + ',' + pos.y.toFixed(2) + ',' + pos.z.toFixed(2) + ') — no flown path to snap onto yet'); return null; }
+    // t is stamped AFTER the plant below completes (see the end of this function) — the debounce
+    // window must start when the user can SEE the result, not at click time: the replan + wow
+    // repaint between the two can exceed the window on slow renderers.
+    _lastSnap = { x: pos.x, y: pos.y, z: pos.z, t: now };
     _snapCount++;
     console.log('§CPE_WALK_SNAP_RESULT n=' + _snapCount + ' bandIndex=' + res.bandIndex + ' s=' + res.s.toFixed(3) +
       ' centre=(' + res.centre.x.toFixed(2) + ',' + res.centre.y.toFixed(2) + ',' + res.centre.z.toFixed(2) + ')' +
@@ -389,6 +422,9 @@
     // the new stick + re-snaked pipe the instant it lands — noise on top of the 0.3-1.2s replan the
     // spec already budgets for this.
     if (_renderMainOnce()) _captureFreeze();
+    // §CPE_WALK_SNAP_GUARD — re-stamp now that the replan + wow repaint are done (see the comment
+    // at the _lastSnap assignment above).
+    if (_lastSnap) _lastSnap.t = performance.now();
     return res;
   }
 
@@ -543,7 +579,9 @@
     isActive: function() { return _active; },
     // §CPE_WALK_SPAWN — external stops (eye-off, editor close) also clear the resume pose: the
     // walk context is gone, the next session must spawn fresh at the walk stretch's start.
-    forceStop: function() { _resumePose = null; return stop(); },
+    // §CPE_WALK_SNAP_GUARD — same lifetime: the duplicate-stick memory belongs to this editor
+    // context; a fresh editor session starts unguarded.
+    forceStop: function() { _resumePose = null; _lastSnap = null; return stop(); },
     // ══ witness hooks — read-only or exercising the REAL internal function, same precedent
     // cinema_path_editor.js's own `_probe*`/`_*ForTest` hooks already use (e.g. `_setPin`,
     // `_spawnStickForTest`) — never a re-implementation of the maths under test.
@@ -553,6 +591,10 @@
       if (!_cpe) return null;
       return _cpe._walkSnap(pos, fwd);
     },
+    // §CPE_WALK_SNAP_GUARD witness hook — runs the REAL guarded _doSnap() (guard included), unlike
+    // _snapForTest above which bypasses the guard on purpose (synthetic geometry tests need
+    // arbitrary repeated positions). Requires a mounted walk; snaps at the live _vfCam pose.
+    _doSnapForTest: function() { return _doSnap(); },
     _poseForTest: function() { return _vfCam ? { x: _vfCam.position.x, y: _vfCam.position.y, z: _vfCam.position.z, yaw: _yaw, pitch: _pitch } : null; },
     _setPoseForTest: function(pos, yaw, pitch) {
       if (!_vfCam) return false;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v970';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v971';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -825,7 +825,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
-<script src="cpe_walk.js?v=5" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
+<script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
 <script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>

--- a/witness_cpe_walk_edit.js
+++ b/witness_cpe_walk_edit.js
@@ -199,6 +199,40 @@ async function gates(browser, BLD) {
     Math.abs(glideOut - 3.6) < 0.01 && glideBack < 1e-9,
     `out=${glideOut.toFixed(3)}m back=${glideBack.toExponential(2)}`);
 
+  // ══ §CPE_WALK_SNAP_GUARD — the user's duplicate-stick report: repeat clicks at one spot must
+  // never stack sticks. Bounce (fast) is swallowed; deliberate same-spot re-click auto-Escs to
+  // review; a genuinely moved click plants. All through the REAL guarded _doSnap (_doSnapForTest). ══
+  const markG = logs.length;
+  const guard = await page.evaluate(async () => {
+    const n0 = window.APP.cinemaPathEditor._probeOverride().bands.length;
+    const activeBefore1 = window.CpeWalk.isActive();
+    const r1 = window.CpeWalk._doSnapForTest();                       // plant at the live pose
+    const activeAfter1 = window.CpeWalk.isActive();
+    const bounce = window.CpeWalk._doSnapForTest();                   // immediate repeat = bounce
+    const activeAfterBounce = window.CpeWalk.isActive();
+    await new Promise(res => setTimeout(res, 800));                   // clear the debounce window
+    const rpt = window.CpeWalk._doSnapForTest();                      // deliberate same-spot repeat
+    const activeAfterRepeat = window.CpeWalk.isActive();              // must have auto-Esc'd
+    window.CpeWalk.toggle();                                          // remount (resumes same spot)
+    // The auto-Esc's exitPointerLock fires a DEFERRED pointerlockchange that can kill a same-tick
+    // remount (synthetic-only race — real shoes presses are separated by human time). Let it land,
+    // then re-ensure a mounted walk before the moved-snap leg.
+    await new Promise(res => setTimeout(res, 250));
+    if (!window.CpeWalk.isActive()) window.CpeWalk.toggle();
+    const p = window.CpeWalk._poseForTest();
+    window.CpeWalk._setPoseForTest({ x: p.x + 2.5, y: p.y, z: p.z }, p.yaw, p.pitch);
+    await new Promise(res => setTimeout(res, 800));
+    const r2 = window.CpeWalk._doSnapForTest();                       // moved 2.5m = real next stick
+    const n1 = window.APP.cinemaPathEditor._probeOverride().bands.length;
+    return { planted1: !!r1, activeBefore1, activeAfter1, bounceNull: bounce === null, activeAfterBounce,
+             repeatNull: rpt === null, activeAfterRepeat, planted2: !!r2, n0, n1 };
+  });
+  const guardLogs = logs.slice(markG).filter(l => l.indexOf('§CPE_WALK') >= 0).slice(0, 12);
+  P('G-WALK-SNAP-GUARD bounce swallowed (walking), same-spot re-click auto-Escs (nothing planted), moved click plants — net +2 bands, never +3',
+    guard.planted1 && guard.bounceNull && guard.activeAfterBounce === true &&
+    guard.repeatNull && guard.activeAfterRepeat === false && guard.planted2 &&
+    guard.n1 === guard.n0 + 2, JSON.stringify(guard) + ' | ' + guardLogs.join(' | '));
+
   // ══ §CPE_WALK_SPAWN resume — shoes off/on continues at the identical pose (Esc keeps it;
   // only eye-off/editor-close forceStop clears it — proven by the later EYE-OFF gate's fresh spawn). ══
   const resume = await page.evaluate(() => {


### PR DESCRIPTION
User's live Terminal report: clicking the just-landed stick while still in walk mode planted a duplicate at the same spot. Fix folds in the user's own suggestion: a repeat click within 1.5m of the last plant = auto-Esc to review (nothing planted); a fast double-click bounce is swallowed (700ms debounce measured from plant-complete, renderer-speed-proof); a genuinely moved click plants as before. Witness 24/24 Duplex through the real guarded path. Cache: cpe_walk v6 / sw v971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)