### PR TITLE
fix(dlod-nav): §26 _boxIndex null-deref race on rapid o/o toggle

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -1659,6 +1659,20 @@
     var idx = _boxIndex, ridx = _realIndex;
     var guids = idx ? Object.keys(idx) : [];
     var i = 0;
+    // §26 fix (2026-08-08): finish() must run AT MOST ONCE per _restoreAllNow() invocation. Before
+    // this flag, step()'s own already-scheduled requestAnimationFrame(step) continuation (queued
+    // during THIS call's first synchronous step() below, before any external caller forces an
+    // early finish via the module-level _restoreFlush) was never cancelled — a rapid OFF→ON toggle
+    // makes _tick() call _restoreFlush() (=finish, closure-local, still the CURRENT invocation's)
+    // to force-complete the drain early so the fresh re-engage can rebuild _boxIndex. That leftover
+    // rAF-scheduled step() then fires on a LATER frame regardless, sees i already at guids.length,
+    // and calls finish() A SECOND TIME — re-disposing (via onDone=_disposeBoxes) whatever _boxIndex
+    // is CURRENTLY live (the fresh one from the re-engage), which the main tick's _evalChunk then
+    // reads as null on its very next call. Reproduced live: `witness_boxindex_race.js` — unfixed,
+    // rapid o/o on LTU_AHouse throws `Cannot read properties of null (reading '<guid>')` from
+    // _evalChunk, exactly matching the field stack trace; fixed, zero crash across repeated runs,
+    // __dlodNavAudit() mismatch=0 afterward (structurally correct, not just crash-silenced).
+    var _done = false;
     function runTo(end) {
       for (; i < end; i++) {
         var guid = guids[i], e = idx[guid];
@@ -1671,6 +1685,8 @@
       }
     }
     function finish() {
+      if (_done) return; // stale leftover step() firing after an external flush already finished this
+      _done = true;
       runTo(guids.length); // no-op if step() already finished the loop
       _restoreFlush = null;
       // Belt-and-braces: if a filter turned on while we were engaged, reassert it after restore
@@ -1681,6 +1697,7 @@
       if (onDone) onDone();
     }
     function step() {
+      if (_done) return; // this invocation was already force-finished elsewhere — stop rescheduling
       runTo(Math.min(i + EVAL_CHUNK, guids.length));
       if (i < guids.length) requestAnimationFrame(step);
       else finish();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v971';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v972';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -930,7 +930,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="time_machine.js?v=67" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="dlod_nav.js?v=1" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
+<script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=12" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>


### PR DESCRIPTION
## Summary
- `FLY_TOUR_DLOD_SCALE.md` §26/§27 — user priority directive, chase to zero.
- `_restoreAllNow()`'s chunked restore drain schedules its own `requestAnimationFrame(step)` continuation, untracked by the module's `_rafId`. A rapid OFF→ON toggle force-completes that drain early (`_restoreFlush()`) so the re-engage can rebuild `_boxIndex`, but the drain's stale leftover `step()` still fires later, sees the loop already done, and calls `finish()` a second time — disposing whatever `_boxIndex` is *currently* live. `_evalChunk` then reads it as null on its next call: `Cannot read properties of null (reading '<guid>')`, matching the field crash exactly.
- Fix: `finish()`/`step()` are now idempotent per `_restoreAllNow()` invocation via a closure-local `_done` flag.

## Test plan
- [x] Live-witnessed on real GPU (RTX 4060 passthrough, headless Chrome, LTU_AHouse 122,330 elements)
- [x] Unfixed build reproduces the exact crash signature on rapid `o`/`o` toggle
- [x] Fixed build: zero crashes across repeated runs (2-press and 3-press patterns)
- [x] `__dlodNavAudit()` mismatch=0 after the toggle sequence — structurally correct, not just crash-silenced
- [x] `node --check viewer/dlod_nav.js` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)