### PR TITLE
fix(cinema): §GLOW_LENS_BUILDUP_GATE — lens quad follows the 4D buildup schedule

### DIFF
--- a/tests/witness_glow_buildup_gate.js
+++ b/tests/witness_glow_buildup_gate.js
@@ -187,5 +187,49 @@ gate('V4', 'Time Machine inactive (plain Night Mode, no buildup bake in progress
   shippedOff.length === N,
   'isVisible=null  glowing=' + shippedOff.length + '/' + N + ' (regression guard: this fix must not touch Night Mode outside a buildup)');
 
+// ── §GLOW_LENS_BUILDUP_GATE (2026-08-08) — the SAME defect, found again in the lens-quad path.
+// _glowLensOn() is called every baked frame during an Alt+C buildup movie (cinema_maxq.js:
+// stopStillRefine/startStillRefine cycle each frame — confirmed by grep, not assumed), but it built
+// its InstancedMesh straight from A._nightFixtureWorldPositions() with no Time Machine filter at
+// all, so a buildup bake showed every fixture's lens quad from frame 1 regardless of schedule state
+// — user: "the scene on canvas is flooded with lighting quads", "supposed to appear under 4D
+// schedule after light fixtures are present". Fix ports the identical filter line into _glowLensOn.
+const LENS_ANCHOR = '§GLOW_LENS_BUILDUP_GATE';
+if (fxSrc.indexOf(LENS_ANCHOR) < 0) { console.log('❌ EXTRACT — §GLOW_LENS_BUILDUP_GATE not found in viewer/effects.js _glowLensOn()'); process.exit(1); }
+const LENS_FILTER_LINE = 'pos = pos.filter(function(p) { return p.__guid == null || A._tmIsVisible(p.__guid); });';
+if (fxSrc.indexOf(LENS_FILTER_LINE) < 0) { console.log('❌ EXTRACT — lens-quad filter line not found in viewer/effects.js _glowLensOn()'); process.exit(1); }
+const runLensFilter = new Function('pos', 'A', LENS_FILTER_LINE + '\nreturn pos;');
+
+const hLensMid = makeHarness();
+hLensMid.window.__tmOverlaySync(predMid);
+const shippedLensMid = runLensFilter(allPos.slice(), hLensMid.A);
+const shippedLensMidGuids = new Set(shippedLensMid.map(p => p.__guid));
+const setsEqualLensMid = shippedLensMidGuids.size === groundTruthMid.size &&
+  [...groundTruthMid].every(g => shippedLensMidGuids.has(g));
+gate('V5', 'lens quad, mid-buildup: matches the same placed/frontier/recent set as the round sprite — partial, not all-or-nothing',
+  setsEqualLensMid && groundTruthMid.size > 0 && groundTruthMid.size < N,
+  'shippedFilter=' + shippedLensMidGuids.size + '/' + N + '  setsEqual=' + setsEqualLensMid);
+
+const hLensStart = makeHarness();
+hLensStart.window.__tmOverlaySync(predStart);
+const shippedLensStart = runLensFilter(allPos.slice(), hLensStart.A);
+gate('V6', 'lens quad — THE REPORTED BUG: ZERO quads flood the canvas before the first fixture is even scheduled to install',
+  shippedLensStart.length === 0,
+  'glowing=' + shippedLensStart.length + '/' + N + ' (must be 0 — this is the live "flooded with lighting quads" defect)');
+
+const hLensEnd = makeHarness();
+hLensEnd.window.__tmOverlaySync(predEnd);
+const shippedLensEnd = runLensFilter(allPos.slice(), hLensEnd.A);
+gate('V7', 'lens quad, finished building: every fixture\'s quad renders once the buildup reaches its own install time',
+  shippedLensEnd.length === N,
+  'glowing=' + shippedLensEnd.length + '/' + N);
+
+const hLensOff = makeHarness();
+hLensOff.window.__tmOverlaySync(null);
+const shippedLensOff = runLensFilter(allPos.slice(), hLensOff.A);
+gate('V8', 'lens quad, Time Machine inactive (plain Alt+S still, no buildup) — every quad renders, unchanged by this fix',
+  shippedLensOff.length === N,
+  'glowing=' + shippedLensOff.length + '/' + N + ' (regression guard: Alt+S outside a buildup must be untouched)');
+
 console.log('\n§GLOW_GATE_WITNESS done pass=' + pass + ' fail=' + fail);
 process.exit(fail ? 1 : 0);

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3754,6 +3754,13 @@ async function setupEffects(A, renderer, scene, camera) {
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
     var pos = A._nightFixtureWorldPositions();
     if (!pos || !pos.length) return;
+    // §GLOW_LENS_BUILDUP_GATE (2026-08-08): _glowOn's round sprite already withholds a fixture's
+    // glow until Time Machine has placed it (§GLOW_BUILDUP_GATE above) — this quad path skipped
+    // that filter entirely, so an Alt+C buildup bake (which reaches here every frame via
+    // startStillRefine) staged every fixture's quad from frame 1, ignoring the 4D schedule. Same
+    // predicate, same guid-null passthrough for the synthetic per-storey/tier-3 fallback.
+    pos = pos.filter(function(p) { return p.__guid == null || A._tmIsVisible(p.__guid); });
+    if (!pos.length) { console.log('§GLOW_LENS_QUAD_GATE 0 fixtures placed yet — nothing to light'); return; }
     var geo = new THREE.PlaneGeometry(1, 1);
     var mat = new THREE.MeshBasicMaterial({
       color: 0xffffff, transparent: true, blending: THREE.AdditiveBlending,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v972';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v973';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -821,7 +821,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=14" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=15" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
## Summary
- Alt+C buildup movie bakes flood the canvas with lighting quads for every fixture in the *finished* building, ignoring the 4D schedule — the round glow sprite already has `§GLOW_BUILDUP_GATE` (merged), but the still-render lens quad (`_glowLensOn`, `effects.js`) was added afterward and never got the same gate.
- `cinema_maxq.js` tears down and restarts still-refine every baked frame during a buildup bake, so `_glowLensOn` staged every fixture's quad on every frame regardless of Time Machine's placed/frontier state.
- Fix ports the identical `A._tmIsVisible` filter into `_glowLensOn()`. No extra restage wiring needed — the quad rebuilds fresh every baked frame via the existing teardown/restart cycle.

## Test plan
- [x] `node --check viewer/effects.js viewer/sw.js` — syntax clean
- [x] `node tests/witness_glow_buildup_gate.js` — extended V5-V8 (mirrors the existing round-sprite V1-V4), extracted verbatim from shipped source, run against real `TerminalHi4D.db` kernel_ops (818 real `IfcLightFixture` elements): 0 quads before any fixture is scheduled, exact partial match mid-buildup, full quads once built, unchanged outside a buildup. 8/9 gates pass — the one failure (`G0`) is pre-existing/unrelated: a stale exact-match regex against `tools.js`'s SQL shape from before later unrelated columns (`bbox_x`/`bbox_y`/`rotation_z`/`geometry_hash`) were added; guid-threading itself is proven live by every other gate correctly filtering on real guid data.
- `sw.js` `CACHE_VERSION` v972→v973, `viewer.html` `effects.js?v=14→15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6TpSmLVrQpc6GNjNKWTZ