### PR TITLE
fix(cpe): §CPE_WALK_CTRL_DRAG_EXIT — POV walk no longer exits on Ctrl-drag

### DIFF
--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -91,6 +91,7 @@
   var _pointerLocked = false;
   var _freezeEl = null;
   var _tm = null;            // { panel, prevPointerEvents, lockedBtn } or null if TM was not touched
+  var _nav = null;           // prior A.controls.enabled value, or null if OrbitControls was not touched
   var _handlers = null;      // DOM listeners installed at mount, removed at unmount
   // §CPE_WALK_SPAWN (2026-08-07, user: "SCRUB BAR IS NOT TO BE USED! WALK!!!" — after their Hospital
   // bug report proved a shoes press at the aerial pose plants a sky stick at s=0.000): the walk is
@@ -191,6 +192,36 @@
       ' panel pointer-events="' + rec.prevPointerEvents + '"');
   }
 
+  // ══════════════════ §CPE_WALK_CTRL_DRAG_EXIT fix — same pause/restore shape as §CPE_WALK_TM_LOCK
+  // above, applied to the main-view OrbitControls (`A.controls`, scene.js:143). Two real bugs shared
+  // this one root cause (OrbitControls.module.js:1550 confirmed via git show origin/main, prompts/
+  // CPE_POV_WALK_PATHING.md §CPE_WALK_CTRL_DRAG_EXIT 2026-08-08): (1) OrbitControls stays `enabled`
+  // and live on the SAME canvas the whole walk, so its own pointerdown handler still runs and calls
+  // `setPointerCapture` — forbidden while the pointer is locked, throwing InvalidStateError on every
+  // click; (2) OrbitControls maps Ctrl+Left-drag to PAN (screenSpacePanning, the "move laterally /
+  // upstairs" gesture users reach for from normal-nav muscle memory) — but Ctrl+Left-Click is ALSO
+  // Chromium's cross-platform alternate context-menu trigger, and a context-menu request forces the
+  // browser to auto-release Pointer Lock, which `_onLockChange` below then reads as "user pressed
+  // Esc" and exits walk mode. Disabling `A.controls` for the duration removes bug (1) outright;
+  // suppressing `contextmenu` on the canvas removes the unplanned-unlock path in (2). Ctrl-drag still
+  // does nothing INSIDE walk mode after this — turning it into an actual pan/climb gesture there is a
+  // separate, not-yet-specified feature (see the same prompts-file section), deliberately not invented
+  // here.
+  function _navLock() {
+    var a = A();
+    if (!a.controls) { console.log('§CPE_WALK_NAV_LOCK no A.controls — nothing to lock'); return null; }
+    var rec = { prevEnabled: a.controls.enabled };
+    a.controls.enabled = false;
+    console.log('§CPE_WALK_NAV_LOCK OrbitControls disabled (was enabled=' + rec.prevEnabled + ')');
+    return rec;
+  }
+  function _navUnlock(rec) {
+    if (!rec) return;
+    var a = A();
+    if (a.controls) a.controls.enabled = rec.prevEnabled;
+    console.log('§CPE_WALK_NAV_LOCK restored enabled=' + rec.prevEnabled);
+  }
+
   // ══════════════════ pointer-lock mouse-look + WASD — pattern copied from
   // navigate_controls.js:28-56 (canvas.requestPointerLock, mousemove yaw/pitch with clamp,
   // pointerlockchange flag), adapted to drive `_vfCam` instead of the main nav camera. ══════════
@@ -241,6 +272,13 @@
   }
   function _onCanvasClick() {
     if (_active && !document.pointerLockElement) _canvas.requestPointerLock();
+  }
+  // §CPE_WALK_CTRL_DRAG_EXIT — Ctrl+Left-Click is Chromium's alternate context-menu trigger
+  // (cross-platform, not Mac-only); left unsuppressed, that request forces the browser to release
+  // Pointer Lock before the user's ctrl-drag even starts, which `_onLockChange` then reads as an
+  // Esc-exit. Block it for the duration of walk mode only.
+  function _onContextMenu(e) {
+    if (_active) { e.preventDefault(); e.stopPropagation(); }
   }
   // §CPE_WALK_GLIDE — trackpad-first locomotion (user: "it is all mousepad movement... pivot, zoom
   // in/out"): two-finger scroll and pinch (which browsers deliver as ctrl+wheel) glide the walker
@@ -487,13 +525,14 @@
     cpe._walkMount();
 
     _tm = _tmLock();
+    _nav = _navLock();
 
     if (!_renderMainOnce()) console.warn('§CPE_WALK_FREEZE_SKIP renderer unavailable, walking without a frozen backdrop');
     _captureFreeze();
 
     _handlers = {
       mousemove: _onMouseMove, lockchange: _onLockChange, keydown: _onKeyDown, keyup: _onKeyUp,
-      mousedown: _onMouseDown, click: _onCanvasClick, wheel: _onWheel,
+      mousedown: _onMouseDown, click: _onCanvasClick, wheel: _onWheel, contextmenu: _onContextMenu,
       gamepadconnected: _onGamepadConnected, gamepaddisconnected: _onGamepadDisconnected
     };
     document.addEventListener('mousemove', _handlers.mousemove, true);
@@ -502,6 +541,7 @@
     window.addEventListener('keyup', _handlers.keyup, true);
     canvas.addEventListener('mousedown', _handlers.mousedown, true);
     canvas.addEventListener('click', _handlers.click, true);
+    canvas.addEventListener('contextmenu', _handlers.contextmenu, true);
     // §CPE_WALK_GLIDE — passive:false so preventDefault can stop ctrl+wheel page-zoom (trackpad pinch)
     window.addEventListener('wheel', _handlers.wheel, { capture: true, passive: false });
     // §CPE_WALK_GAMEPAD_NAV — mount/unmount scoped like every other listener here (spec: "gated the
@@ -541,6 +581,7 @@
       if (_canvas) {
         _canvas.removeEventListener('mousedown', _handlers.mousedown, true);
         _canvas.removeEventListener('click', _handlers.click, true);
+        _canvas.removeEventListener('contextmenu', _handlers.contextmenu, true);
       }
       window.removeEventListener('wheel', _handlers.wheel, { capture: true });
       window.removeEventListener('gamepadconnected', _handlers.gamepadconnected, true);
@@ -551,6 +592,7 @@
     if (document.pointerLockElement === _canvas && document.exitPointerLock) document.exitPointerLock();
     _dropFreeze();
     _tmUnlock(_tm); _tm = null;
+    _navUnlock(_nav); _nav = null;
     // Seam 2's other half — restores the stick editor's own listeners.
     if (_cpe && _cpe._walkUnmount) _cpe._walkUnmount();
     console.log('§CPE_WALK_UNMOUNT_DONE snaps=' + _snapCount + ' frames=' + _frame +

--- a/witness_cpe_walk_ctrldrag_fix.js
+++ b/witness_cpe_walk_ctrldrag_fix.js
@@ -1,0 +1,109 @@
+// WITNESS — §CPE_WALK_CTRL_DRAG_EXIT fix (prompts/CPE_POV_WALK_PATHING.md, 2026-08-08 regression).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-NAVLOCK-ON    mounting walk mode disables A.controls (was enabled=true before mount) and logs
+//                    §CPE_WALK_NAV_LOCK — closes the "OrbitControls still live, throws
+//                    setPointerCapture InvalidStateError on every click" bug.
+//   G-CTXMENU-BLOCK a real `contextmenu` event dispatched on the canvas WHILE walk mode is active has
+//                    its default prevented (the Ctrl+Left-Click alternate-menu path that forces an
+//                    unplanned Pointer Lock release is neutralised) AND walk mode is still active
+//                    afterward — no §CPE_WALK_LOCK_LOST logged from it.
+//   G-CTXMENU-IDLE  the SAME event with walk mode NOT active is left alone (defaultPrevented false)
+//                    — the fix is scoped to walk mode, not a global context-menu kill.
+//   G-NAVLOCK-OFF   stopping walk mode restores A.controls.enabled to its prior value and logs the
+//                    restore line.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8523;
+const BLD = process.env.BLD || 'Duplex';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.CpeWalk && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+async function main() {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const { page, logs } = await openEditor(browser);
+
+  // ── precondition: OrbitControls enabled before any walk mount ──
+  const enabledBefore = await page.evaluate(() => window.APP.controls && window.APP.controls.enabled);
+  P('G-NAVLOCK-0 precondition: A.controls.enabled=true before any walk mount', enabledBefore === true, `enabledBefore=${enabledBefore}`);
+
+  // ══ mount walk mode ══
+  const mark1 = logs.length;
+  await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(150);
+  const win1 = logs.slice(mark1);
+  const enabledDuring = await page.evaluate(() => window.APP.controls && window.APP.controls.enabled);
+  P('G-NAVLOCK-ON mounting walk disables A.controls and logs §CPE_WALK_NAV_LOCK',
+    enabledDuring === false && win1.some(l => l.startsWith('§CPE_WALK_NAV_LOCK OrbitControls disabled')),
+    `enabledDuring=${enabledDuring} logged=[${win1.filter(l => l.startsWith('§CPE_WALK_NAV_LOCK')).join(' | ')}]`);
+
+  // ══ G-CTXMENU-BLOCK: real contextmenu dispatch while ACTIVE must be prevented, and walk must survive ══
+  const mark2 = logs.length;
+  const ctxResultActive = await page.evaluate(() => {
+    const canvas = window.APP.canvas;
+    const r = canvas.getBoundingClientRect();
+    const ev = new MouseEvent('contextmenu', { clientX: r.left + 10, clientY: r.top + 10, bubbles: true, cancelable: true });
+    canvas.dispatchEvent(ev);
+    return { defaultPrevented: ev.defaultPrevented, activeAfter: window.CpeWalk.isActive() };
+  });
+  await sleep(50);
+  const win2 = logs.slice(mark2);
+  P('G-CTXMENU-BLOCK contextmenu while walk is active: preventDefault fired, walk stayed active, no LOCK_LOST',
+    ctxResultActive.defaultPrevented === true && ctxResultActive.activeAfter === true &&
+    !win2.some(l => l.includes('LOCK_LOST')),
+    `${JSON.stringify(ctxResultActive)} logsAfter=[${win2.filter(l => l.startsWith('§CPE_WALK')).join(' | ')}]`);
+
+  // ══ stop walk, then re-check contextmenu is NOT suppressed when idle (scoped fix, not global) ══
+  await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(150);
+  const enabledAfter = await page.evaluate(() => window.APP.controls && window.APP.controls.enabled);
+  const navRestoreLogged = logs.some(l => l.startsWith('§CPE_WALK_NAV_LOCK restored enabled=true'));
+  P('G-NAVLOCK-OFF stopping walk restores A.controls.enabled and logs the restore',
+    enabledAfter === true && navRestoreLogged, `enabledAfter=${enabledAfter} restoreLogged=${navRestoreLogged}`);
+
+  // NOTE: idle contextmenu is STILL defaultPrevented=true here — that's OrbitControls' OWN
+  // pre-existing onContextMenu handler (OrbitControls.module.js:1927, gated on `this.enabled`,
+  // unconditional preventDefault whenever enabled), nothing to do with cpe_walk.js. Confirmed by
+  // reading the lib, not asserted as a gate (would be testing pre-existing app behaviour, not the fix).
+
+  console.log('\n' + '='.repeat(78));
+  let allPass = true;
+  for (const c of checks) {
+    console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}`);
+    console.log(`          ${c.d}`);
+    if (!c.ok) allPass = false;
+  }
+  console.log('='.repeat(78));
+  console.log(allPass ? `\nWITNESS PASS (${checks.length}/${checks.length})` : `\nWITNESS FAIL`);
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch(e => { console.error('INFRA-ERROR', e); process.exit(2); });


### PR DESCRIPTION
## Summary
- Ctrl+held-drag during POV walk mode ("walk finger mode") was kicking the user back to normal navigation — main-view OrbitControls stayed enabled on the same canvas the whole walk and its own `pointerdown` handler was calling `setPointerCapture` while the pointer was locked (throws `InvalidStateError`); Ctrl+drag also maps to OrbitControls' PAN gesture and appears to trigger a context-menu request that forces the browser to release Pointer Lock, which walk mode reads as an Esc-exit.
- Fix: disable `A.controls` for the duration of walk mode (same pause/restore shape as the existing `§CPE_WALK_TM_LOCK`), and suppress `contextmenu` on the canvas while walking.

## Test plan
- [x] `witness_cpe_walk_edit.js` regression: 24/24 PASS on Duplex, unchanged
- [x] New `witness_cpe_walk_ctrldrag_fix.js`: 4/4 PASS — `A.controls.enabled` correctly false during walk / restored after; a real `contextmenu` dispatched mid-walk is suppressed and walk mode stays active (no `LOCK_LOST`)
- [ ] User to confirm live: the original Ctrl+held-drag repro on Hospital no longer exits walk mode (headless can't force genuine browser Pointer-Lock release, so this is the real-world confirmation)

Full diagnosis in `prompts/CPE_POV_WALK_PATHING.md` §CPE_WALK_CTRL_DRAG_EXIT (bim-compiler repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)