### PR TITLE
test(modeller): guide-recapture round 6 diagnostics — cut-select/cut-open composition still blocked

### DIFF
--- a/modeller/tests/capture_guide_cut.js
+++ b/modeller/tests/capture_guide_cut.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * capture_guide_cut.js — dedicated guide-frame capture for cut-select.png/cut-open.png
+ * (RESUME_MODELLER_GUIDE_SCREENSHOT_FIX.md, round-4 precedent: "NOT the audited witnesses; their own
+ * screenshots inherited whatever camera state #b-fit happened to leave"). This picks a REAL Duplex wall
+ * that carries authored material layers (the population CUT_GATE_CSG_SPEC.md §THE CALL fixed — 50/57
+ * previously-refused wallish candidates), deliberately preferring one with a real door/window opening
+ * host so the "cut" demo shows a genuinely richer subject than the 2 plain box footing walls the OLD
+ * (pre-fix) gate was limited to. Same real click->Cut production path as witness_e2e_cut.js; asserted by
+ * op-log + tri-count delta (real geometry changed) + verifyChain + 0 console errors — never by eye alone
+ * (one-look protocol is the FINAL confirmation step after these numbers, not a substitute for them).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+const tris = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; const idx = m.geometry.index; return idx ? idx.count / 3 : (m.geometry.attributes.position.count / 3);
+}, fid);
+runE2E('CAPTURE-CUT', async (t) => {
+  await t.open('Duplex');
+
+  // Prefer an OPENING-HOST layered wall (a real door/window carved into it — CUT_GATE_CSG_SPEC.md §1: 18/50
+  // refusals were opening-hosts, all also layered) for the most representative "cut a wall" demo subject;
+  // fall back to any wallish layer-seeded candidate if none is reachable from the default camera.
+  const report = await t.pg.evaluate(() => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
+    const out = [];
+    ops.forEach(op => {
+      if (op.op_type !== 'GEOM_INSERT') return;
+      const P = op.parameters; if (!P || !P.ifc_class || !/^IfcWall/.test(P.ifc_class)) return;
+      let boxOk = false, layerSeed = null;
+      try { boxOk = !!window.Bonsai._insertCutBox(op); } catch (e) {}
+      if (boxOk) return;
+      try { layerSeed = window.Bonsai._insertCutLayerSeed(op); } catch (e) {}
+      if (!layerSeed) return;
+      const bb = P.bbox, sz = [bb[1] - bb[0], bb[3] - bb[2], bb[5] - bb[4]];
+      if (!wallish({ sz })) return;
+      out.push({ fid: op.id, nLayers: layerSeed.layers.length, sz, vol: sz[0] * sz[1] * sz[2] });
+    });
+    // §RECAPTURE-FINDING (this session): sorting by VOLUME descending tried the 10 biggest wallish
+    // layered walls and EVERY ONE failed real-click selection (10/10, not flake — reproduced clean at
+    // load~2, same isometric default view) — big long exterior walls are evidently far more prone to
+    // occlusion/off-clip-point misses than the mid-size ones. Sort by nLayers instead (the same order
+    // witness_e2e_cut_layers.js already proved reachable — selected fid=41 cleanly).
+    out.sort((a, b) => b.nLayers - a.nLayers);
+    return out;
+  });
+  console.log('  §CAPTURE-POOL n=' + report.length);
+
+  // §RECAPTURE-FINDING (this session, second escalation): the raycast-verified clickOn() helper AND a
+  // plain canvas-centre click both proved unreliable here — repeated runs against the SAME code, SAME
+  // data, at both high and low machine load, both failed even on fid=41 (a candidate a PRIOR run in this
+  // same session selected cleanly via clickOn()). Switched to `window.Bonsai.select(fid)` — a REAL,
+  // explicitly-documented "witness/programmatic hook" in modeller.html (line ~1176, the SAME `highlight`→
+  // `setSelectionIds`→`_paintSel`/`zoomToSelection` path a real click drives, just entered without the
+  // mouse-event/raycast layer this session found unreliable) — a legitimate production API for exactly
+  // this purpose, not an invented shortcut. The Cut click itself (below) still goes through the real
+  // `#b-cut` button.
+  const target = report[0];
+  let sel = false;
+  if (target) {
+    await t.pg.evaluate((f) => window.Bonsai.select(f), target.fid);
+    await t.flySettle();
+    sel = await t.pg.evaluate((f) => Array.from(window.Bonsai._selSet || []).includes(f), target.fid);
+  }
+  t.assert('SEL (a real wallish layered wall selected)', sel, 'fid=' + (target && target.fid) + ' nLayers=' + (target && target.nLayers));
+  if (!sel) return;
+  // §RECAPTURE-FINDING (this session, fourth escalation): select()'s own zoomToSelection flies the camera
+  // to a "fill" distance/direction chosen for a THIN wall (0.55m) that ends up looking nearly face-on into
+  // the thin axis — frameElement() then computes distance "along the CURRENT view direction", compounding
+  // that into a near-zero-context, flat-plane close-up (the exact "flat gray slab" symptom §THREAD 1 of
+  // RESUME_MODELLER_GUIDE_SCREENSHOT_FIX.md was originally about). Re-fit to the known-good default
+  // isometric overview FIRST (same starting direction every successful witness capture already used),
+  // THEN frame — selection state (selectedId/tint) survives a #b-fit click untouched.
+  const fit = await t.pg.$('#b-fit'); if (fit) { await fit.click(); await t.sleep(500); }
+  // §RECAPTURE-FINDING (this session, fifth escalation): 0.42 fill (the default used across every other
+  // shotClip witness) produced a near-featureless flat-gray close-up here — confirmed NOT specific to this
+  // fix (the pre-existing, unmodified witness_e2e_cut.js's OWN cut-select.png for a plain box wall, fid=81,
+  // shows the identical symptom this session, on origin/main code this fix never touches). Zoom OUT
+  // (smaller fill = larger distance) for real edge/room context in the guide frame.
+  await t.frameElement(target.fid, 0.22);
+  // §RECAPTURE-FINDING (round 6, numeric candidate probe — capture_probe_candidates.js): the round-5
+  // "sliver of background" symptom was NOT the candidate or the fill — it was THIS script's own
+  // margin=80 (double the harness's proven default of 48, used by every other successful shotClip
+  // witness). Measured crop-fraction (bbox area / (bbox+2*margin)^2) across 12 real-layer-seedable
+  // candidates at fill=0.22: margin=80 -> best candidate (fid=89) only 28.2%, fid=87 27.4% — both read
+  // as background-dominated. margin=48 -> fid=87 41.8%. margin=30 -> fid=87 55.5% (a "healthy majority").
+  // fid=87 vs the marginally-better fid=89 (<1pp apart at every margin) was kept: fid=87 is the richest
+  // layered wall (7 layers, the actual party wall CUT_GATE_CSG_SPEC.md names as the fix's reference
+  // subject) — more representative content for a "cut a wall" guide demo than a 3-layer partition.
+  const MARGIN = 30;
+  const tw0 = await tris(t, target.fid);
+  await t.shotClip('cut-select', target.fid, MARGIN);
+
+  // §RECAPTURE-FINDING (this session, third escalation, root-caused via diag_capture_void.js): a fixed
+  // sleep(1200) after the click is NOT enough on a COLD occt-wasm worker — the fold is genuinely async
+  // (worker spawn + WASM init + the real fold roundtrip), and pg.click() does not await the onclick
+  // handler's own promise. Poll for the tri count to actually change instead of trusting a fixed delay.
+  await t.clickSel('#b-cut');
+  let tw1 = tw0;
+  for (let i = 0; i < 20 && tw1 === tw0; i++) { await t.sleep(500); tw1 = await tris(t, target.fid); }
+  const after = await t.oplog(); const last = await t.lastOp();
+  const chain = await t.verifyChain();
+  await t.shotClip('cut-open', target.fid, MARGIN);
+
+  t.assert('CUT-COMMIT (one GEOM_CUT on the layered wall)', last && last.op_type === 'GEOM_CUT' && last.parameters && last.parameters.parent === target.fid,
+    'op=' + (last && last.op_type) + ' parent=' + (last && last.parameters && last.parameters.parent));
+  t.assert('CHAIN-OK (verifyChain)', chain === true, 'verifyChain=' + chain);
+  t.assert('GEOMETRY-CHANGED (real void subtracted — tri count changed)', tw0 !== tw1, 'tris ' + tw0 + '→' + tw1);
+  console.log('  §CAPTURE-SUMMARY fid=' + target.fid + ' nLayers=' + target.nLayers + ' sz=' + JSON.stringify(target.sz) + ' tris ' + tw0 + '→' + tw1);
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/capture_guide_cut_v2.js
+++ b/modeller/tests/capture_guide_cut_v2.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * capture_guide_cut_v2.js — recapture cut-select.png/cut-open.png (round 6, guide screenshot mission).
+ *
+ * Round 5 (this same worktree's capture_guide_cut.js) proved the CUT itself works end-to-end on fid=87
+ * (Duplex's richest 7-layer party wall) but could never land a legible crop: frameElement's dolly-along-
+ * inherited-camera-direction (whatever #b-fit's default isometric view happened to be) either grazed
+ * Duplex's sloped roof (flat gray) or produced a screen-space-AABB sliver (bboxScreen loose-fits a
+ * rotated/isometric box, so a thin wall's true silhouette is much smaller than its AABB).
+ *
+ * This round: switched to a MANUALLY PLACED interior camera (the "closeCam" pattern already proven by
+ * witness_e2e_gridmove_real.js's §CAMERA-LESSON, round 1 of this same guide-recapture saga) instead of
+ * frameElement's auto-dolly. Numerically explored 4 candidates x up to 6 camera placements each (see
+ * capture_probe_candidates.js, diag_closecam_orient.js, diag_closecam_v2/v3.js, diag_center_probe.js in
+ * this same worktree for the full search log): fid=87 (0.55x2.2m footprint) sits almost exactly at
+ * Duplex's own bbox centroid (a party-wall spine) and is enclosed too tightly for ANY 1.2-2.8m offset in
+ * either axis/sign to clear neighbouring solids -- every attempt landed the camera embedded in an
+ * adjacent wall/slab (flat solid-colour frame). fid=88 (a longer 4.2x0.49m wall) stepped fully OUTSIDE
+ * the building envelope on the room-ward-computed sign at 1.2-2.8m (distant thin roofline against sky/
+ * ground). fid=89 (0.12x2.92m partition, 3 layers, real-layer-seedable -- same cut-eligible population
+ * §LAYER-SOLID-SEED / CUT_GATE_CSG_SPEC.md opened up) is the only candidate of the 4 probed that produced
+ * a legible interior frame: offset -1.2m along its thin (X) axis lands the camera in the adjacent room,
+ * clear of both the roof and neighbouring solids, showing real geometry (a door jamb, floor plane, wall
+ * edge) -- matching this guide's own established bar for "real interior" shots (see
+ * docs/img/modeller/grid-editor-before.png, similarly not photorealistic but recognizably real geometry).
+ * Full-page t.shot() (not shotClip) is used, per round-1's own note that bboxScreen's 8-corner AABB is
+ * unreliable at this close a grazing angle -- shotClip was the exact mechanism that produced the round-5
+ * sliver bug, so this round avoids it entirely for the closeCam shots (same choice already proven live in
+ * grid-editor-before/after.png and room-move.png, all closeCam + full-page, all currently embedded).
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+const FID = 89;
+const tris = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; const idx = m.geometry.index; return idx ? idx.count / 3 : (m.geometry.attributes.position.count / 3);
+}, fid);
+// §RACE-FIX (round 6, after repeated flaky/flat captures at this exact camera distance): closeCam only
+// called window.A.requestRender() -- if that just arms a debounced/rAF-scheduled redraw rather than
+// rendering synchronously, puppeteer's screenshot() can grab the buffer BEFORE that redraw fires,
+// capturing a stale (often near-flat, mid-transition) frame. Force a SYNCHRONOUS renderer.render() call
+// right here, in the same evaluate(), so the GPU buffer is guaranteed current before we ever return to
+// node and call pg.screenshot() -- closes the race at its source instead of guessing sleep durations or
+// retrying whole browser sessions.
+const closeCamX = (t, fid, off) => t.pg.evaluate((f, o) => {
+  const cam = window.A.camera, ctl = window.A.controls;
+  const g = window.Bonsai.group(); const m = g.children.find(x => x.isMesh && x.userData.featureId === f);
+  const c = new window.THREE.Vector3(); new window.THREE.Box3().setFromObject(m).getCenter(c);
+  cam.up.set(0, 0, 1);
+  cam.position.set(c.x + o, c.y, c.z);
+  ctl.target.set(c.x, c.y, c.z);
+  ctl.update();
+  window.A.renderer.render(window.A.scene, window.A.camera);
+  if (window.A.requestRender) window.A.requestRender();
+}, fid, off);
+const forceRender = (t) => t.pg.evaluate(() => { window.A.renderer.render(window.A.scene, window.A.camera); });
+
+runE2E('CAPTURE-CUT-V2', async (t) => {
+  await t.open('Duplex');
+
+  // Confirm fid=89 is still in the real-layer-seedable cut-eligible pool (not a box, not refused) --
+  // same check capture_guide_cut.js's own §CAPTURE-POOL used, re-run here so this script is self-
+  // contained and doesn't silently drift if the pool changes.
+  const eligible = await t.pg.evaluate((f) => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const op = ops.find(o => o.id === f);
+    if (!op || op.op_type !== 'GEOM_INSERT') return { ok: false, reason: 'not-insert' };
+    let boxOk = false, layerSeed = null;
+    try { boxOk = !!window.Bonsai._insertCutBox(op); } catch (e) {}
+    if (boxOk) return { ok: false, reason: 'is-box' };
+    try { layerSeed = window.Bonsai._insertCutLayerSeed(op); } catch (e) {}
+    return { ok: !!layerSeed, nLayers: layerSeed && layerSeed.layers.length };
+  }, FID);
+  t.assert('ELIGIBLE (fid=' + FID + ' is real-layer-seedable, not box)', eligible.ok, JSON.stringify(eligible));
+
+  // §V2-RETRY (escalated twice): neither a small nor a large fixed settle-time reliably fixed this
+  // camera placement taken straight after select() -- two runs at the SAME 1.2m offset gave two
+  // DIFFERENT broken results (flat/distant one run, a tiny sliver of stairs the next), while
+  // diag_closecam_v2.js's run -- which cycled through 3 OTHER fids (88,87,85) before reaching 89 -- was
+  // the one clean result found across the whole search. Not fully root-caused (possibly a lazy
+  // LOD/texture warm-up that only completes after the renderer has done a few real frames of work on
+  // OTHER parts of the scene, not just elapsed wall-clock time on this one). Pragmatic fix: replicate
+  // that priming step directly -- touch a couple of other fids first, then do the real fid=89 sequence.
+  for (const primeFid of [88]) {
+    await t.pg.evaluate((f) => window.Bonsai.select(f), primeFid);
+    await t.flySettle();
+    await closeCamX(t, primeFid, -1.2);
+    await t.sleep(300);
+  }
+
+  await t.pg.evaluate((f) => window.Bonsai.select(f), FID);
+  await t.flySettle();
+  const sel = await t.pg.evaluate((f) => Array.from(window.Bonsai._selSet || []).includes(f), FID);
+  t.assert('SEL (fid=' + FID + ' selected)', sel, 'fid=' + FID);
+
+  await closeCamX(t, FID, -1.2);
+  await t.sleep(400);
+  await closeCamX(t, FID, -1.2);
+  await t.sleep(400);
+  const tw0 = await tris(t, FID);
+  await forceRender(t);
+  await t.shot('cut-select');
+
+  await t.clickSel('#b-cut');
+  let tw1 = tw0;
+  for (let i = 0; i < 20 && tw1 === tw0; i++) { await t.sleep(500); tw1 = await tris(t, FID); }
+  const last = await t.lastOp();
+  const chain = await t.verifyChain();
+
+  // Re-place closeCam post-cut. Same priming trick as pre-cut (touch other fids first) -- the flakiness
+  // moved from the select-shot to THIS shot on the run that fixed the first one, confirming it's a
+  // genuine per-shot render race, not something fixed once for the whole session.
+  for (const primeFid of [88]) {
+    await t.pg.evaluate((f) => window.Bonsai.select(f), primeFid);
+    await t.flySettle();
+    await closeCamX(t, primeFid, -1.2);
+    await t.sleep(300);
+  }
+  await t.pg.evaluate((f) => window.Bonsai.select(f), FID);
+  await t.flySettle();
+  await closeCamX(t, FID, -1.2);
+  await t.sleep(400);
+  await closeCamX(t, FID, -1.2);
+  await t.sleep(400);
+  await forceRender(t);
+  await t.shot('cut-open');
+
+  t.assert('CUT-COMMIT (one GEOM_CUT on the partition wall)', last && last.op_type === 'GEOM_CUT' && last.parameters && last.parameters.parent === FID,
+    'op=' + (last && last.op_type) + ' parent=' + (last && last.parameters && last.parameters.parent));
+  t.assert('CHAIN-OK (verifyChain)', chain === true, 'verifyChain=' + chain);
+  t.assert('GEOMETRY-CHANGED (real void subtracted -- tri count changed)', tw0 !== tw1, 'tris ' + tw0 + '->' + tw1);
+  console.log('  §CAPTURE-SUMMARY fid=' + FID + ' tris ' + tw0 + '->' + tw1);
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/capture_probe_candidates.js
+++ b/modeller/tests/capture_probe_candidates.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * capture_probe_candidates.js — NUMERIC candidate selection for cut-select.png/cut-open.png recapture
+ * (RESUME_MODELLER_GUIDE_SCREENSHOT_FIX.md round-5 handoff: "pick a better wall/camera using the harness's
+ * OWN logged bbox numbers (bboxScreen coverage % of frame) — log it, choose numerically, not by visual
+ * trial-and-error"). Reuses capture_guide_cut.js's exact candidate-pool logic (real-layer-seedable wallish
+ * IfcWall-class GEOM_INSERTs, box candidates excluded), but instead of always taking report[0] (highest
+ * nLayers, which is fid=87 — the one round 5 found composes badly), runs the SAME select->#b-fit->
+ * frameElement(fid,0.22) sequence capture_guide_cut.js uses for EVERY candidate in the pool and measures
+ * bboxScreen's actual on-screen coverage numerically. No visual judgement here — pure numbers, logged.
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+runE2E('CANDIDATE-PROBE', async (t) => {
+  await t.open('Duplex');
+
+  const report = await t.pg.evaluate(() => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
+    const out = [];
+    ops.forEach(op => {
+      if (op.op_type !== 'GEOM_INSERT') return;
+      const P = op.parameters; if (!P || !P.ifc_class || !/^IfcWall/.test(P.ifc_class)) return;
+      let boxOk = false, layerSeed = null;
+      try { boxOk = !!window.Bonsai._insertCutBox(op); } catch (e) {}
+      if (boxOk) return;
+      try { layerSeed = window.Bonsai._insertCutLayerSeed(op); } catch (e) {}
+      if (!layerSeed) return;
+      const bb = P.bbox, sz = [bb[1] - bb[0], bb[3] - bb[2], bb[5] - bb[4]];
+      if (!wallish({ sz })) return;
+      out.push({ fid: op.id, nLayers: layerSeed.layers.length, sz, vol: sz[0] * sz[1] * sz[2] });
+    });
+    out.sort((a, b) => b.nLayers - a.nLayers);
+    return out;
+  });
+  console.log('  §CAPTURE-POOL n=' + report.length);
+
+  const vw = t.pg.viewport().width, vh = t.pg.viewport().height;
+  const results = [];
+  const FILL = 0.22; // same fill capture_guide_cut.js settled on
+  for (const cand of report) {
+    await t.pg.evaluate((f) => window.Bonsai.select(f), cand.fid);
+    await t.flySettle();
+    const fitBtn = await t.pg.$('#b-fit'); if (fitBtn) { await fitBtn.click(); await t.sleep(400); }
+    await t.frameElement(cand.fid, FILL);
+    const b = await t.bboxScreen(cand.fid);
+    let coverage = 0, onscreenFrac = 0;
+    if (b) {
+      const rawArea = Math.max(0, b.width) * Math.max(0, b.height);
+      const x0 = Math.max(0, b.x), y0 = Math.max(0, b.y);
+      const x1 = Math.min(vw, b.x + b.width), y1 = Math.min(vh, b.y + b.height);
+      const overlapW = Math.max(0, x1 - x0), overlapH = Math.max(0, y1 - y0);
+      const overlapArea = overlapW * overlapH;
+      coverage = (overlapArea / (vw * vh)) * 100;
+      onscreenFrac = rawArea > 0 ? (overlapArea / rawArea) : 0;
+    }
+    console.log('  §CAPTURE-CANDIDATE fid=' + cand.fid + ' nLayers=' + cand.nLayers + ' sz=' + JSON.stringify(cand.sz.map(v => +v.toFixed(2))) +
+      ' bbox=' + JSON.stringify(b) + ' coverage=' + coverage.toFixed(1) + '% onscreenFrac=' + onscreenFrac.toFixed(2));
+    results.push({ fid: cand.fid, nLayers: cand.nLayers, sz: cand.sz, coverage, onscreenFrac });
+  }
+
+  results.sort((a, b) => b.coverage - a.coverage);
+  console.log('  §CAPTURE-WINNER ' + JSON.stringify(results[0]));
+  console.log('  §CAPTURE-RANKED-TOP5 ' + JSON.stringify(results.slice(0, 5)));
+  t.assert('PROBE-DONE (candidates measured)', results.length > 0, 'n=' + results.length);
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/diag_candidate_z.js
+++ b/modeller/tests/diag_candidate_z.js
@@ -1,0 +1,34 @@
+'use strict';
+// §CAMERA-LESSON cross-check: get real world bbox z-range (not just size) for each real-layer-seedable
+// wallish candidate, to find one clear of Duplex's sloped roof (z≈6.0-6.6, per this guide's own round-1
+// grid-editor finding) — a ground-floor wall (low z-min/z-max) avoids frameElement's naive dolly-along-
+// current-direction camera ending up grazing/inside the roof mesh.
+const { runE2E } = require('./e2e_harness');
+runE2E('DIAG-CAND-Z', async (t) => {
+  await t.open('Duplex');
+  const report = await t.pg.evaluate(() => {
+    const ops = window.Bonsai.oplog._geomOps();
+    const wallish = c => c.sz && c.sz[2] >= 1.2 && Math.min(c.sz[0], c.sz[1]) <= 0.6 && Math.max(c.sz[0], c.sz[1]) >= 1.0 && Math.max(c.sz[0], c.sz[1]) <= 8;
+    const g = window.Bonsai.group();
+    const out = [];
+    ops.forEach(op => {
+      if (op.op_type !== 'GEOM_INSERT') return;
+      const P = op.parameters; if (!P || !P.ifc_class || !/^IfcWall/.test(P.ifc_class)) return;
+      let boxOk = false, layerSeed = null;
+      try { boxOk = !!window.Bonsai._insertCutBox(op); } catch (e) {}
+      if (boxOk) return;
+      try { layerSeed = window.Bonsai._insertCutLayerSeed(op); } catch (e) {}
+      if (!layerSeed) return;
+      const bb = P.bbox, sz = [bb[1] - bb[0], bb[3] - bb[2], bb[5] - bb[4]];
+      if (!wallish({ sz })) return;
+      const m = g.children.find(o => o.isMesh && o.userData.featureId === op.id);
+      let zmin = null, zmax = null;
+      if (m) { const b = new window.THREE.Box3().setFromObject(m); zmin = b.min.z; zmax = b.max.z; }
+      out.push({ fid: op.id, nLayers: layerSeed.layers.length, sz, zmin, zmax });
+    });
+    out.sort((a, b) => b.nLayers - a.nLayers);
+    return out;
+  });
+  report.forEach(c => console.log('  §CAND-Z fid=' + c.fid + ' nLayers=' + c.nLayers + ' z=[' + (c.zmin==null?'?':c.zmin.toFixed(2)) + ',' + (c.zmax==null?'?':c.zmax.toFixed(2)) + ']'));
+  t.assert('DIAG-Z done', report.length > 0, 'n=' + report.length);
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/diag_closecam_orient.js
+++ b/modeller/tests/diag_closecam_orient.js
@@ -1,0 +1,35 @@
+'use strict';
+// Generalized closeCam (witness_e2e_gridmove_real.js's proven pattern, offset axis made a parameter):
+// fid=87's own bbox shape (X=0.55 thin, Y=2.2 long, Z=2.795 tall) means its FACE NORMAL points along X
+// (the thin axis) -- wall106 (the round-1 proven case) had the opposite aspect and was offset along Y.
+// Probe both candidate offset axes/signs with a full-page screenshot each (no shotClip -- round-1's own
+// note: bboxScreen corners are unreliable at this close grazing angle) and eyeball which actually shows
+// the wall face, not an edge-on sliver or an occluded/into-another-wall view.
+const { runE2E } = require('./e2e_harness');
+const closeCamAxis = (t, fid, axis, off) => t.pg.evaluate((f, ax, o) => {
+  const cam = window.A.camera, ctl = window.A.controls;
+  const g = window.Bonsai.group(); const m = g.children.find(x => x.isMesh && x.userData.featureId === f);
+  const c = new window.THREE.Vector3(); new window.THREE.Box3().setFromObject(m).getCenter(c);
+  cam.up.set(0, 0, 1);
+  const pos = c.clone();
+  if (ax === 'x') pos.x += o; else if (ax === 'y') pos.y += o; else pos.z += o;
+  cam.position.copy(pos);
+  ctl.target.copy(c);
+  ctl.update();
+  if (window.A.requestRender) window.A.requestRender();
+}, fid, axis, off);
+
+runE2E('DIAG-CLOSECAM-ORIENT', async (t) => {
+  await t.open('Duplex');
+  const FID = 88;
+  await t.pg.evaluate((f) => window.Bonsai.select(f), FID);
+  await t.flySettle();
+  const variants = [['x', 1.8], ['x', -1.8], ['y', 1.8], ['y', -1.8]];
+  for (const [axis, off] of variants) {
+    await closeCamAxis(t, FID, axis, off);
+    await t.sleep(250);
+    await t.pg.screenshot({ path: '/tmp/claude-1000/-home-red1-bim-compiler/7da1cdf3-0a91-4a23-83a2-922463080789/scratchpad/orient-fid' + FID + '-' + axis + '-' + (off > 0 ? 'pos' : 'neg') + '.png' });
+    console.log('  §ORIENT-SHOT axis=' + axis + ' off=' + off + ' saved');
+  }
+  t.assert('ORIENT-PROBE done', true, '');
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/diag_closecam_v2.js
+++ b/modeller/tests/diag_closecam_v2.js
@@ -1,0 +1,50 @@
+'use strict';
+// Deterministic closeCam sign: offset along the wall's FACE-NORMAL axis (perpendicular to its long
+// in-plan axis), choosing the sign that points from the wall's centre TOWARD the whole building's
+// centroid -- i.e. "into a room", not blindly guessing both signs. Smaller offset (1.2m, vs the 1.8m
+// that stepped fid=88 clean outside the envelope on at least one sign) to stay inside a typical room.
+const { runE2E } = require('./e2e_harness');
+runE2E('DIAG-CLOSECAM-V2', async (t) => {
+  await t.open('Duplex');
+  const bldg = await t.pg.evaluate(() => {
+    const g = window.Bonsai.group();
+    const b = new window.THREE.Box3();
+    g.children.forEach(o => { if (o.isMesh) b.expandByObject(o); });
+    const c = new window.THREE.Vector3(); b.getCenter(c);
+    return [c.x, c.y, c.z];
+  });
+  console.log('  §BUILDING-CENTROID ' + JSON.stringify(bldg));
+
+  for (const FID of [88, 87, 85, 89]) {
+    await t.pg.evaluate((f) => window.Bonsai.select(f), FID);
+    await t.flySettle();
+    const cand = await t.pg.evaluate((f) => {
+      const ops = window.Bonsai.oplog._geomOps();
+      const op = ops.find(o => o.id === f);
+      const bb = op.parameters.bbox;
+      return [bb[1]-bb[0], bb[3]-bb[2], bb[5]-bb[4]];
+    }, FID);
+    const axis = cand[0] < cand[1] ? 'x' : 'y'; // thin axis = face normal axis
+    const info = await t.pg.evaluate((f, ax, bx, by, bz) => {
+      const cam = window.A.camera, ctl = window.A.controls;
+      const g = window.Bonsai.group();
+      const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+      const b = new window.THREE.Box3().setFromObject(m);
+      const c = new window.THREE.Vector3(); b.getCenter(c);
+      const sign = (ax === 'x') ? Math.sign(bx - c.x) : Math.sign(by - c.y);
+      const OFF = 1.2;
+      cam.up.set(0, 0, 1);
+      const pos = c.clone();
+      if (ax === 'x') pos.x += sign * OFF; else pos.y += sign * OFF;
+      cam.position.copy(pos);
+      ctl.target.copy(c);
+      ctl.update();
+      if (window.A.requestRender) window.A.requestRender();
+      return { centre: [c.x, c.y, c.z], sign, axis: ax };
+    }, FID, axis, bldg[0], bldg[1], bldg[2]);
+    await t.sleep(250);
+    await t.pg.screenshot({ path: '/tmp/claude-1000/-home-red1-bim-compiler/7da1cdf3-0a91-4a23-83a2-922463080789/scratchpad/v2-fid' + FID + '.png' });
+    console.log('  §V2-SHOT fid=' + FID + ' ' + JSON.stringify(info) + ' saved');
+  }
+  t.assert('V2 done', true, '');
+}, { width: 1200, height: 850, dpr: 2 });

--- a/modeller/tests/diag_fullpage.js
+++ b/modeller/tests/diag_fullpage.js
@@ -1,0 +1,25 @@
+'use strict';
+// Decisive isolation: after the SAME well-timed sequence capture_guide_cut.js uses (t.open, select,
+// #b-fit reset, frameElement 0.42), take a FULL-PAGE screenshot (no clip) to see if the wall is visible
+// SOMEWHERE in the frame. If yes -> shotClip's crop-region math is the bug (scoped fix). If the whole page
+// is also blank/flat -> the camera/scene itself is broken (bigger problem).
+const { runE2E } = require('./e2e_harness');
+runE2E('DIAG-FULLPAGE', async (t) => {
+  await t.open('Duplex');
+  await t.pg.evaluate(() => window.Bonsai.select(87));
+  await t.flySettle();
+  const fit = await t.pg.$('#b-fit'); if (fit) { await fit.click(); await t.sleep(500); }
+  await t.frameElement(87, 0.42);
+  await t.sleep(300);
+  await t.pg.screenshot({ path: '/tmp/claude-1000/-home-red1-bim-compiler/7da1cdf3-0a91-4a23-83a2-922463080789/scratchpad/diag-fullpage-select.png' });
+  console.log('  §DIAG full-page (post-select+frame) saved');
+
+  await t.clickSel('#b-cut');
+  let tw = null, tw0 = null;
+  tw0 = await t.pg.evaluate(() => { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === 87); return m ? (m.geometry.index ? m.geometry.index.count/3 : 0) : null; });
+  for (let i = 0; i < 20; i++) { await t.sleep(500); tw = await t.pg.evaluate(() => { const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === 87); return m ? (m.geometry.index ? m.geometry.index.count/3 : 0) : null; }); if (tw !== tw0) break; }
+  console.log('  §DIAG post-cut tris=' + tw);
+  await t.pg.screenshot({ path: '/tmp/claude-1000/-home-red1-bim-compiler/7da1cdf3-0a91-4a23-83a2-922463080789/scratchpad/diag-fullpage-cut.png' });
+  console.log('  §DIAG full-page (post-cut) saved');
+  t.assert('DIAG done', true, '');
+}, { width: 1200, height: 850, dpr: 2 });


### PR DESCRIPTION
## Summary
- Preserves round-6 diagnostic scripts from the ModellerGuide cut-select/cut-open recapture investigation (`RESUME_MODELLER_GUIDE_SCREENSHOT_FIX.md`), test-only, no app-code changes.
- The underlying cut-gate fix (§LAYER-SOLID-SEED, PR #1262) is proven solid — `GEOM_CUT` commit, `verifyChain=true`, tri count 148→318, reproduced identically across 14/14 runs this session.
- The SCREENSHOT COMPOSITION remains unsolved: root-caused round 5's "sliver" bug to an oversized `margin=80`, discovered fid=87 sits at Duplex's own bbox centroid (explains why no camera offset escapes into open room), found fid=89 is the only candidate of 4 probed that can render legibly via a manually-placed interior camera — but that render is non-deterministically flaky (~1-in-3 individual shots clean, never both in one run) even after settle-time tuning, camera re-apply, a priming step, and forcing synchronous THREE.js renders before every screenshot.
- Per this guide's own fail-hard doctrine, `docs/img/modeller/cut-select.png`/`cut-open.png` are NOT touched this round — no bad/broken frame embedded.

## Test plan
- [x] All 7 committed scripts run standalone against `origin/main` Duplex, no app-code diff
- [x] `capture_guide_cut_v2.js` reproduced the numeric cut proof 14/14 times this session (op-log, verifyChain, tri delta)
- [x] No production file touched — this PR is diagnostics/test-scripts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL9zFPyYw7qd2M1Pi3Dyk8