### PR TITLE
fix(viewer): chunk needle-path patch apply — un-chunked run bricked the sql.js wasm heap

### DIFF
--- a/tests/witness_nogeo_compose.js
+++ b/tests/witness_nogeo_compose.js
@@ -42,6 +42,7 @@ function sliceFn(src, header) {
   return src.slice(start, end + '\n  };'.length);
 }
 const sceneSrc = fs.readFileSync(path.join(ROOT, 'viewer', 'scene.js'), 'utf8');
+const fnChunk = sliceFn(sceneSrc, '  A._runSqlChunked = function(db, sql) {');   // §PATCH_CHUNK extracted 2026-08-10 (shared with the needle path)
 const fnPatch = sliceFn(sceneSrc, '  A._applyPendingPatch = async function(buf, url) {');
 const fnCompose = sliceFn(sceneSrc, '  A.composeGhostsFromAggregates = function(db) {');
 
@@ -61,7 +62,7 @@ async function main() {
     return { ok: true, status: 200, text: async () => fs.readFileSync(f, 'utf8') };
   };
   // eslint-disable-next-line no-eval
-  eval(fnPatch + '\n' + fnCompose);
+  eval(fnChunk + '\n' + fnPatch + '\n' + fnCompose);
 
   const argOf = (n) => { const i = process.argv.indexOf('--' + n); return i < 0 ? null : process.argv[i + 1]; };
   const explicitDb = argOf('db');

--- a/viewer/input_registry.js
+++ b/viewer/input_registry.js
@@ -138,17 +138,29 @@
           status = 'dead'; target = 'not-fn'; dead.push(k);
         } else {
           var body = Function.prototype.toString.call(fn);
-          var names = [], re = /(?:\b(?:window|A|APP)\.)?([a-zA-Z_$][\w$]*)\s*\(/g, mm;
+          // §SHORTCUT-AUDIT-QUALIFIED: capture the owner of a dotted call too — the old regex
+          // reduced `WholeHistory.toggleOpen(` to bare `toggleOpen`, looked it up on
+          // window/APP/A only, and misreported a perfectly-working shortcut as dead
+          // (z/w/+/-/r false positives, seen live 2026-08-10).
+          var names = [], re = /(?:\b([a-zA-Z_$][\w$]*)\.)?([a-zA-Z_$][\w$]*)\s*\(/g, mm;
           while ((mm = re.exec(body)) !== null) {
-            var n = mm[1];
-            if (KEYWORDS.indexOf(n) < 0 && OBJS.indexOf(n) < 0 && DOM_BUILTINS.indexOf(n) < 0) names.push(n);
+            var owner = mm[1], n = mm[2];
+            if (owner && OBJS.indexOf(owner) >= 0) owner = null;   // window./A./APP. prefix = same as bare
+            if (KEYWORDS.indexOf(n) < 0 && OBJS.indexOf(n) < 0 && DOM_BUILTINS.indexOf(n) < 0)
+              names.push(owner ? owner + '.' + n : n);
           }
           if (!names.length) { status = 'inline'; inlineN++; }
           else {
-            var hit = names.filter(function (n) {
-              return typeof window[n] === 'function'
-                || (window.APP && typeof window.APP[n] === 'function')
-                || (window.A && typeof window.A[n] === 'function');
+            var hit = names.filter(function (q) {
+              var dot = q.indexOf('.');
+              if (dot > 0) {   // qualified Obj.fn — resolve the owner object globally, then the method
+                var o = q.slice(0, dot), f = q.slice(dot + 1);
+                var obj = window[o] || (window.APP && window.APP[o]) || (window.A && window.A[o]);
+                return !!(obj && typeof obj[f] === 'function');
+              }
+              return typeof window[q] === 'function'
+                || (window.APP && typeof window.APP[q] === 'function')
+                || (window.A && typeof window.A[q] === 'function');
             });
             if (hit.length) { status = 'ok'; target = hit[0]; okN++; }
             else { status = 'dead'; target = names.join(','); dead.push(k); }

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1022,9 +1022,13 @@
           var r = await fetch(patchUrl);
           if (r.ok) {
             var sqlText = await r.text();
-            A.db.run(sqlText);
+            // §PATCH_CHUNK: NEVER one giant A.db.run() here — a multi-thousand-statement patch
+            // (Hospital: 9,466 statements) crashes the bundled sql-wasm.wasm "memory access out
+            // of bounds" and bricks the SHARED wasm heap: every later dbQuery, the geo.db load
+            // and streaming init all fail. Same chunker as A._applyPendingPatch (scene.js).
+            var _ch = A._runSqlChunked(A.db, sqlText);
             applied = true;
-            console.log('[NEEDLE] §PATCH_APPLY ' + dbFile + ' applied (' + sqlText.length + ' bytes) from ' + patchUrl + ' [needle]');
+            console.log('[NEEDLE] §PATCH_APPLY ' + dbFile + ' applied (' + sqlText.length + ' bytes, ' + _ch.statements + ' statements, ' + _ch.chunks + ' chunk(s)) from ' + patchUrl + ' [needle]');
           } else {
             console.log('[NEEDLE] §PATCH_NONE ' + dbFile + ' (' + r.status + ') [needle]');
           }

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1261,6 +1261,41 @@ async function setupScene(A) {
   // patch script MUST be idempotent (DELETE-then-INSERT or INSERT OR IGNORE) so a repeat apply on
   // an already-current db is a safe no-op. Best-effort: a missing patch (404, the common case) or
   // any exec failure is swallowed and the ORIGINAL buffer returned untouched — never blocks an open.
+  // §PATCH_CHUNK (2026-08-10): a single db.run() over one giant multi-thousand-statement
+  // string crashes THIS project's bundled sql-wasm.wasm ("memory access out of bounds") —
+  // confirmed live, reproduced in a real headless browser AND in isolation against the exact
+  // shipped .wasm binary with a 9,465-statement patch. This is a DIFFERENT WASM build from the
+  // npm sql.js package (different byte size, different md5) — a Node-only sql.js verification
+  // does not catch this class of bug; only testing against the real bundled binary does. Run
+  // in bounded batches instead — statement-aware, not raw-line-count: most lines in every
+  // patch file are one complete statement, but at least two existing patches
+  // (Terminal_extracted.db.sql, Terminal_meta.db.sql) have a multi-line `CREATE TABLE
+  // spatial_structure (...)` — a naive "500 raw lines per batch" split could cut that
+  // statement in half if it ever landed on a chunk boundary (it doesn't today, but that's
+  // luck, not correctness). Accumulate lines into a statement until one ends in `;`, THEN
+  // batch ~500 statements per db.run() — multi-line statements always stay whole.
+  // Shared by _applyPendingPatch (pre-load buffer patch) AND navigate_find.js's needle path
+  // (same patch applied to the LIVE A.db) — the needle path shipped un-chunked and bricked the
+  // whole sql.js heap on Hospital's 9,466-statement patch (every later query, the geo.db load
+  // and streaming init all died "memory access out of bounds"). One chunker, both callers.
+  A._runSqlChunked = function(db, sql) {
+    var rawLines = sql.split('\n');
+    var statements = [];
+    var stBuf = [];
+    for (var li = 0; li < rawLines.length; li++) {
+      var ln = rawLines[li];
+      if (!ln.trim().length) continue;
+      stBuf.push(ln);
+      if (/;\s*$/.test(ln)) { statements.push(stBuf.join('\n')); stBuf = []; }
+    }
+    if (stBuf.length) statements.push(stBuf.join('\n'));  // trailing content with no `;` (comment-only tail, etc.)
+    var CHUNK = 500;
+    for (var i = 0; i < statements.length; i += CHUNK) {
+      db.run(statements.slice(i, i + CHUNK).join('\n'));
+    }
+    return { statements: statements.length, chunks: Math.ceil(statements.length / CHUNK) };
+  };
+
   A._applyPendingPatch = async function(buf, url) {
     try {
       var dir = url.slice(0, url.lastIndexOf('/') + 1);
@@ -1272,36 +1307,10 @@ async function setupScene(A) {
       var SQLFactory = A._SQL || window.SQL || window._SQL_CACHED;   // viewer caches the sql.js factory as A._SQL (streaming.js)
       if (!SQLFactory) { console.warn(`[S203] §PATCH_APPLY_FAIL ${url} — sql.js factory not loaded yet`); return buf; }
       var pdb = new SQLFactory.Database(new Uint8Array(buf));
-      // §PATCH_CHUNK (2026-08-10): a single pdb.run() over one giant multi-thousand-statement
-      // string crashes THIS project's bundled sql-wasm.wasm ("memory access out of bounds") —
-      // confirmed live, reproduced in a real headless browser AND in isolation against the exact
-      // shipped .wasm binary with a 9,465-statement patch. This is a DIFFERENT WASM build from the
-      // npm sql.js package (different byte size, different md5) — a Node-only sql.js verification
-      // does not catch this class of bug; only testing against the real bundled binary does. Run
-      // in bounded batches instead — statement-aware, not raw-line-count: most lines in every
-      // patch file are one complete statement, but at least two existing patches
-      // (Terminal_extracted.db.sql, Terminal_meta.db.sql) have a multi-line `CREATE TABLE
-      // spatial_structure (...)` — a naive "500 raw lines per batch" split could cut that
-      // statement in half if it ever landed on a chunk boundary (it doesn't today, but that's
-      // luck, not correctness). Accumulate lines into a statement until one ends in `;`, THEN
-      // batch ~500 statements per pdb.run() — multi-line statements always stay whole.
-      var rawLines = sql.split('\n');
-      var statements = [];
-      var stBuf = [];
-      for (var li = 0; li < rawLines.length; li++) {
-        var ln = rawLines[li];
-        if (!ln.trim().length) continue;
-        stBuf.push(ln);
-        if (/;\s*$/.test(ln)) { statements.push(stBuf.join('\n')); stBuf = []; }
-      }
-      if (stBuf.length) statements.push(stBuf.join('\n'));  // trailing content with no `;` (comment-only tail, etc.)
-      var CHUNK = 500;
-      for (var i = 0; i < statements.length; i += CHUNK) {
-        pdb.run(statements.slice(i, i + CHUNK).join('\n'));
-      }
+      var _ch = A._runSqlChunked(pdb, sql);   // §PATCH_CHUNK — see comment above _runSqlChunked
       var out = pdb.export().buffer;
       pdb.close();
-      console.log(`[S203] §PATCH_APPLY ${dbFile} applied (${sql.length} bytes, ${statements.length} statements, ${Math.ceil(statements.length / CHUNK)} chunk(s)) from ${patchUrl}`);
+      console.log(`[S203] §PATCH_APPLY ${dbFile} applied (${sql.length} bytes, ${_ch.statements} statements, ${_ch.chunks} chunk(s)) from ${patchUrl}`);
       return out;
     } catch (e) {
       console.warn(`[S203] §PATCH_APPLY_FAIL ${url} — using unpatched db`, e && e.message);
@@ -2650,6 +2659,8 @@ async function setupScene(A) {
   window._focusPanel = _focusPanel;
   window._blurPanel = _blurPanel;
   window._cyclePanel = _cyclePanel;
+  window._zoomStep = _zoomStep;   // §S281: audit-visible (was a +/- false "dead" — fn is closure-local)
+  window._cycleRoom = _cycleRoom; // §S281: audit-visible (was an r false "dead" — fn is closure-local)
   window._shortcuts = _shortcuts; // §S281: exposed so InputReg.checkShortcuts() can self-audit
   window._panels = _panels;
   window._focusStack = _focusStack; // §S280: exposed for [] double-tap

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v973';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v974';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
@@ -187,7 +187,7 @@ const PRECACHE_ASSETS = [
   'materialize.js',
   'doc_canvas.js',
   // Feature modules loaded by index.html
-  'kernel_ops.js',
+  '../erp/kernel_ops.js',   // the ONE kernel_ops (v13) — viewer-local copy no longer loaded by viewer.html
   'cost_panel.js',
   'clash_report.js',
   'clash_snag.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -9,6 +9,7 @@
 <title>BIM OOTB v3 — DEV</title>
 <link rel="manifest" href="manifest.webmanifest">
 <meta name="theme-color" content="#4fc3f7">
+<meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <link rel="apple-touch-icon" href="icons/icon-192.png">
@@ -895,7 +896,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="elevation.js?v=1" onerror="console.warn('[Elevation] elevation.js skipped')"></script>
 <script src="grid_contours.js?v=5" onerror="console.warn('[GridContours] grid_contours.js skipped')"></script>
 <script src="grid_dim_chains.js?v=4" onerror="console.warn('[DimChains] grid_dim_chains.js skipped')"></script>
-<script src="kernel_ops.js?v=5" onerror="console.warn('[KernelOps] kernel_ops.js skipped')"></script>
+<!-- kernel_ops: loaded ONCE as ../erp/kernel_ops.js above (v13). The viewer-local copy (v8) used
+     to be re-loaded here and CLOBBERED v13 — silently breaking blue_fold.js/whatif.js, which call
+     v13-only discardBranch/acceptBranchUpTo. Do not re-add a second kernel_ops include. -->
 <script src="../common/whole_history.js?v=4" onerror="console.warn('[WholeHistory] common/whole_history.js skipped')"></script>
 <script src="../common/history_bar.js?v=6" onerror="console.warn('[HistoryBar] common/history_bar.js skipped')"></script>
 <!-- ABOUT_BOX_CONSOLIDATE.md — the ONE shared About/DIY modal (the command-palette corner download triangle → AboutDIY.open; the Help pill keeps the shortcuts palette). Self-contained


### PR DESCRIPTION
## Urgent live crash (2026-08-10, Hospital split mode)

The needle recompile path (`navigate_find.js`) ran the entire `patches/Hospital_extracted.db.sql` (1,381,431 bytes, **9,466 statements**) through ONE `A.db.run()`. On the bundled `sql-wasm.wasm` that crashes "memory access out of bounds" and corrupts the SHARED wasm heap — from that moment every `dbQuery` (`§HELPERS_QUERY_ERR`), the 228MB geo.db load (`§SPLIT_GEO_FAIL`), the extracted fallback, and streaming init (`§INIT_ERROR`) all fail; the viewer degrades to bboxes-only and the cinema planner runs on empty data. `scene.js` got the §PATCH_CHUNK fix on 2026-08-10; this path was missed.

## Fix
- `scene.js`: §PATCH_CHUNK chunker extracted into shared `A._runSqlChunked(db, sql)`; `_applyPendingPatch` calls it (§PATCH_APPLY log shape unchanged).
- `navigate_find.js`: needle patch now applies via `A._runSqlChunked(A.db, sqlText)`.

## Witness (bundled wasm, not npm sql.js)
`tests/witness_nogeo_compose.js` (now slicing the shared fn too):
```
§NOGEO_WITNESS_TOTAL pass=9 fail=0
[S203] §PATCH_APPLY Hospital_extracted.db applied (1381431 bytes, 9466 statements, 19 chunk(s))
```
That is the exact patch file + statement count from the live crash, applied through the same shared chunker the needle path now uses.

## Harmless bugs fixed along the way (same live log)
- **kernel_ops double-load**: viewer.html loaded `../erp/kernel_ops.js` (v13) then clobbered it with the stale viewer-local v8 — `blue_fold.js`/`whatif.js` call v13-only `discardBranch`/`acceptBranchUpTo`, so those were silently broken. Second include removed; sw now precaches `../erp/kernel_ops.js` (offline parity). The viewer-local file stays (other harnesses reference it).
- **§SHORTCUT_AUDIT false deads** (`+,-,z,w,r`): audit now resolves dotted targets (`WholeHistory.toggleOpen`); `_zoomStep`/`_cycleRoom` exposed on `window` per the existing `_blurPanel` convention. Keys always worked; the audit misread closure-locals.
- Deprecated `apple-mobile-web-app-capable` meta paired with `mobile-web-app-capable`.
- `viewer/sw.js` CACHE_VERSION v973→v974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)