### PR TITLE
refactor(4d): consolidate roof/load-path promotion classifier into _promoteRoofLoadPath + §TM_GEO_ORDER_CYCLES_REPRO witness

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v973';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v974';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// witness_tm_geo_order_cycles.js — §TM_GEO_ORDER_CYCLES_REPRO (2026-08-10, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md §"▶ NEXT SESSION" Part A). Two jobs, both named:
+//
+//   ISSUE 1 (reproduction — did not exist anywhere before this file): §TM_GEO_ORDER_CYCLES —
+//     Terminal's live 4D log reports tens of thousands of §SUPPORT_CYCLE members plus floating
+//     elements. This witness reproduces those numbers DETERMINISTICALLY outside the browser:
+//     time_machine.js's real element build (sliced, never reimplemented — repo convention,
+//     witness_gantt_lock_integrity.js) fed through the canonical, UNCHANGED
+//     ScheduleGate.computeSchedule()/auditFloating() from viewer/schedule_gate.js, against the real
+//     Terminal_extracted.db. The bug itself lives in schedule_gate.js's DAG and stays OPEN — this
+//     witness reproduces it, it does not fix it, and it must NOT assert cycles/floating drop to 0.
+//
+//   ISSUE 2 (refactor invariance): the roof/load-path promotion classifier existed as two copies in
+//     time_machine.js (_buildXrayElements inline + injectGantt inline). Direct verification proved
+//     the copies byte-identical in .seq output (an earlier "16-edge divergence" claim was FALSE — it
+//     compared against schedule_author.js, a third file with no promotion logic). Consolidating them
+//     into _promoteRoofLoadPath() is therefore a PURE refactor: the §TM_GEO_ORDER_CYCLES_REPRO line
+//     below must be numerically IDENTICAL before vs after that refactor. Run on the pre-refactor
+//     commit, save the log, run on the post-refactor commit, diff the line. This file slices
+//     _promoteRoofLoadPath when present and falls back to the inline copy when not, so the SAME
+//     witness runs on both commits.
+//
+// Known drift, flagged not resolved (per plan — do not silently overwrite either number): a
+// 2026-08-10 planning-session sandbox run got cycles=37927 floating=45 on Terminal, which already
+// differs from prompts/4D_SCHEDULE_PERFECTION.md's earlier recorded cycles=24353 floating=33/48428.
+// Cause unexplained. This witness's own numbers are the reproducible reference going forward.
+//
+// Approximation caveat (named, per plan): _buildXrayElements output has no resource/installSecs
+// fields (the x-ray path never needs them), so this witness fills resource=cls, installSecs=120
+// before computeSchedule. That approximates crew/duration behaviour ONLY — the cycle count is
+// STRUCTURAL (support-DAG topology from geometry+seq) and unaffected by it.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node tests/witness_tm_geo_order_cycles.js  (from viewer/)
+// Read the §TM_GEO_ORDER_CYCLES_REPRO log line, not exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+
+(async () => {
+  // Slice the real shipped code. Post-refactor: _promoteRoofLoadPath + _buildXrayElements.
+  // Pre-refactor: _promoteRoofLoadPath doesn't exist yet — _buildXrayElements carries the inline
+  // copy. Same witness runs on both commits (the invariance harness, ISSUE 2 above).
+  const names = ['_buildXrayElements'];
+  const hasPromote = tmSrc.indexOf('function _promoteRoofLoadPath(') >= 0;
+  if (hasPromote) names.unshift('_promoteRoofLoadPath');
+  console.log('§TMREPRO_SLICE state=' + (hasPromote ? 'post-refactor (shared _promoteRoofLoadPath)' : 'pre-refactor (inline copy)'));
+  let sliced;
+  try {
+    sliced = names.map(n => sliceFn(tmSrc, n)).join('\n');
+  } catch (e) { assert(false, 'W-TMREPRO-0 slice failed: ' + e.message); finish(); return; }
+
+  const dbPath = path.join(BLD_DIR, 'Terminal_extracted.db');
+  if (!fs.existsSync(dbPath)) { console.log('§TMREPRO_SKIP Terminal fixture missing at ' + dbPath); finish(); return; }
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+
+  const sandbox = {
+    console: console,
+    performance: { now: () => Date.now() },
+    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || [] },
+    A: function () { return { db: db }; },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements;', sandbox);
+
+  const els = sandbox.__bxe();
+  db.close();
+  assert(els && els.length > 1000, 'W-TMREPRO-1 real Terminal geometry via the shipped element build (n=' + (els ? els.length : 0) + ')');
+
+  // Same degenerate-geometry filter as witness_gantt_lock_integrity.js (no-transform rows collapse
+  // to a zero-size bbox at origin and would poison the support grids).
+  const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+  // Approximation caveat (header): the x-ray build carries no resource/installSecs — fill defaults.
+  geoEls.forEach(e => { e.resource = e.cls; e.installSecs = 120; });
+  const promoted = geoEls.filter(e => e.cls === 'IfcSlab' && e.seq === 8).length;
+
+  // Capture computeSchedule's own §SUPPORT_CYCLE line (cycles are REPORTED, never hidden — that is
+  // schedule_gate.js's contract; this witness asserts the report exists and republishes the number).
+  const capturedLines = [];
+  const origLog = console.log;
+  console.log = function () { capturedLines.push(Array.prototype.map.call(arguments, String).join(' ')); return origLog.apply(console, arguments); };
+  let sched, floating;
+  const collector = [];
+  try {
+    sched = ScheduleGate.computeSchedule(geoEls, 0, 1);
+    floating = ScheduleGate.auditFloating(geoEls, sched, null, collector);
+  } finally { console.log = origLog; }
+
+  const cycLine = capturedLines.find(l => l.indexOf('§SUPPORT_CYCLE') >= 0) || '';
+  const m = cycLine.match(/cycles=(\d+)/);
+  const cycles = m ? parseInt(m[1], 10) : -1;
+  assert(cycles >= 0, 'W-TMREPRO-2 §SUPPORT_CYCLE reported by canonical computeSchedule (cycles=' + cycles + ')');
+  assert(typeof floating === 'number' && floating >= 0, 'W-TMREPRO-3 auditFloating returns a count (floating=' + floating + ')');
+
+  // THE line. Must be numerically identical pre vs post the _promoteRoofLoadPath refactor
+  // (diffed across the two commits' logs — see header ISSUE 2). Numbers only; slice state is on
+  // the separate §TMREPRO_SLICE line above so this one diffs clean.
+  console.log('§TM_GEO_ORDER_CYCLES_REPRO cycles=' + cycles + ' floating=' + floating +
+    ' n=' + geoEls.length + '/' + els.length + ' promotedRoofSlabs=' + promoted +
+    ' (Terminal_extracted.db; resource/installSecs approximated — structural cycle count unaffected)');
+  console.log('§TMREPRO_DRIFT_FLAG planning-session 2026-08-10 got cycles=37927 floating=45; doc earlier recorded cycles=24353 floating=33/48428 — divergence unexplained, neither number overwritten (see header)');
+  if (collector.length) console.log('§TMREPRO_FLOATING_SAMPLE [' + collector.slice(0, 5).join(',') + ']');
+
+  finish();
+})();
+
+function finish() {
+  console.log('§TM_GEO_ORDER_CYCLES_REPRO_SUMMARY pass=' + pass + ' fail=' + fail);
+  if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+  console.log('PASS — §TM_GEO_ORDER_CYCLES reproduced deterministically (bug itself still OPEN in schedule_gate.js DAG; this witness is the before/after invariance harness for the promotion-classifier consolidation)');
+}

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3368,6 +3368,115 @@
   }
 
   // ══════════════════════════════════════════════════════════════════
+  // §4D_ROOF_LOAD_PATH — roof/load-path promotion classifier (ONE copy)
+  // ══════════════════════════════════════════════════════════════════
+  // ONE classifier, TWO callers: injectGantt() (the live scheduler build) and _buildXrayElements()
+  // (the x-ray staging rebuild that verifyGanttIntegrity() — the schedule LOCK gate — also runs
+  // on). Consolidated 2026-08-10 from two inline copies verified byte-identical in .seq output —
+  // a future silent divergence would have made the lock gate verify against a different
+  // classification than the one actually scheduled: a correctness bug, not a rendering glitch.
+  //
+  // §4D_ROOF_LOAD_PATH M1 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH) — a slab's
+  // ROLE is a load-path fact, not a storey-name label. SUPERSEDES the deleted `/roof/i` override:
+  // measured 2026-08-01, that regex fired ZERO times on Hospital ("Level 1..7A"/"Unknown")
+  // and LTU_AHouse ("TAKPLAN", Swedish) — the two roof slabs it was meant to catch have storey
+  // "Unknown". For each IfcSlab, take the IfcWall*/IfcWallStandardCase whose XY footprint overlaps
+  // it ("those walls"). Two checks from the SAME paragraph of the spec, both epsilon-free:
+  //   (a) the slab's base_z is above the average midheight of those walls — the walls are BELOW
+  //       and physically carry it.
+  //   (b) NONE of those walls stand ON it (no overlapping wall has base_z >= the slab's own
+  //       top_z) — this is the spec's own stated definition of "the floor case" ("floor slab:
+  //       walls stand ON it ... otherwise it stays a floor slab"), and it is NOT redundant with
+  //       (a): measured on this exact DB, (a) alone is true for nearly every capped-wall slab in
+  //       the building (35 slabs -> 23 "promoted"), including known mid-building intermediate
+  //       floors (base_z 176.81, between Level 2 and Level 3, 5 more levels above) — a slab that
+  //       caps the walls below it satisfies (a) whether or not it ALSO carries walls above, so (a)
+  //       alone cannot tell "top of the load path" from "one more floor in the middle of it". (b)
+  //       is the missing half of the spec's own description and brings Hospital down to the 2
+  //       true roof slabs + a handful of isolated panels with no wall directly overlapping the
+  //       next level up (open corridor/atrium bays) — reported, not silently forced to exactly 2.
+  // Promoted -> roof role -> seq 8, phase 'Architecture'. Otherwise stays whatever seq matchRule
+  // gave it (the floor case). No new numeric constant either way — both checks compare the slab
+  // against its own extracted geometry and the walls' own extracted geometry.
+  //
+  // Pure two-phase pass over `elements` (order-independent — both original call sites ran it on
+  // differently-sorted arrays with identical .seq results). Mutates promoted slabs' el.seq (and
+  // el.phase — harmless bookkeeping on the x-ray path, whose elements never carried a phase field
+  // and nothing downstream reads it). Returns { total, seedCount, m4Count } so each caller keeps
+  // its own log wording — only injectGantt logs §GANTT_OVERRIDE, _buildXrayElements stays silent.
+  function _promoteRoofLoadPath(elements) {
+    var loadPathWalls = elements.filter(function(e) { return e.cls.indexOf('IfcWall') === 0; });
+    var loadPathOverrides = 0;
+    // §4D_WALLS_BEFORE_ROOF (2026-08-01) — pass 1 computes the SEED set exactly as #1120 shipped it
+    // (clause a AND clause b), so the shipped count is reproduced unchanged before M4 widens it.
+    var lpSlabs = [], lpSeed = [];
+    elements.forEach(function(el) {
+      if (el.cls !== 'IfcSlab') return;
+      var carriers = loadPathWalls.filter(function(w) {
+        return el.x0 <= w.x1 && el.x1 >= w.x0 && el.y0 <= w.y1 && el.y1 >= w.y0;
+      });
+      if (!carriers.length) return;
+      var midSum = 0, above = [];
+      for (var ci = 0; ci < carriers.length; ci++) {
+        midSum += (carriers[ci].base_z + carriers[ci].top_z) / 2;
+        if (carriers[ci].base_z >= el.top_z) above.push(carriers[ci]);
+      }
+      var wallMidheight = midSum / carriers.length;
+      var clauseA = el.base_z > wallMidheight;
+      lpSlabs.push({ el: el, clauseA: clauseA, above: above });
+      if (clauseA && !above.length) {
+        el.seq = 8; el.phase = 'Architecture';
+        loadPathOverrides++;
+        lpSeed.push(el);
+      }
+    });
+
+    // §4D_WALLS_BEFORE_ROOF M4 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) —
+    // user, live on a Hospital MaxQ bake: "The roof before the walls still happening on the roof
+    // top". #1120's clause (b) disqualifies a roof if ANY XY-overlapping wall stands on it. On
+    // Hospital that disqualifies the 2091.5 m² topmost deck (3Csn1z$1v5Q8DXdumWYJUE, base_z 199.66)
+    // because the two helipad boxes — whose OWN roofs #1120 promoted — stand on it. MEASURED on
+    // origin/main: it starts 2022-07-27 as Superstructure while its 14 wall carriers finish
+    // 2023-04-30 — 277 days before its own walls, the identical error #1120 reported fixing for the
+    // boxes. This is #1120's `⚠ LIMIT 2` arriving, and wider than LIMIT 2 predicted: these walls are
+    // 3.05–3.47 m tall and DO carry something, so LIMIT 2's "parapet carries nothing" discriminator
+    // would not have caught it.
+    //   THE RULE: a wall standing on a slab is not "the next storey" if that wall is itself CAPPED
+    //   by a slab already known to be a roof (a helipad box, a plant enclosure, a coped parapet —
+    //   the load path tops out in a roof, it does not continue the building). Capped = a seed roof
+    //   slab XY-overlapping the wall with its base_z between the wall's base_z and top_z + GAP. A
+    //   wall capped by NOTHING does not qualify.
+    //   DEPTH 1, ON THE FROZEN SEED SET, DELIBERATELY. Full recursion was measured and collapses:
+    //   the box walls excuse the 199.66 deck -> the deck excuses 3064w0y0nDv9wdb1cWL_Gu -> Level 6
+    //   promotes -> Level 5 -> Level 4 -> the whole building becomes "roof". Depth-1 terminates.
+    //   MEASURED: Hospital 10 -> 11. The one addition is the user's slab. Level 6 (3 blockers),
+    //   Level 5 (33), Level 4 (514) and #1120's own floor control 1OV06Y3c5D8vODNyxVnSVI (56) all
+    //   stay blocked. A footprint-extent ratio was tried and REJECTED — it does not separate (roof
+    //   0.040 vs intermediate panels 0.024/0.024/0.029/0.044, Level 6 0.170); no threshold exists,
+    //   which is why this is a load-path rule and not an area rule.
+    var LP_GAP = 0.5;  // m — same "tops out at this level" tolerance schedule_gate.js uses (GAP)
+    var m4Promoted = 0;
+    if (lpSeed.length) {
+      lpSlabs.forEach(function(rec) {
+        var el = rec.el;
+        if (el.seq === 8 || !rec.clauseA || !rec.above.length) return;
+        for (var ai = 0; ai < rec.above.length; ai++) {
+          var w = rec.above[ai], capped = false;
+          for (var si = 0; si < lpSeed.length; si++) {
+            var C = lpSeed[si];
+            if (C.x0 <= w.x1 && C.x1 >= w.x0 && C.y0 <= w.y1 && C.y1 >= w.y0 &&
+                C.base_z >= w.base_z && C.base_z <= w.top_z + LP_GAP) { capped = true; break; }
+          }
+          if (!capped) return;             // a wall the building genuinely continues through
+        }
+        el.seq = 8; el.phase = 'Architecture';
+        loadPathOverrides++; m4Promoted++;
+      });
+    }
+    return { total: loadPathOverrides, seedCount: lpSeed.length, m4Count: m4Promoted };
+  }
+
+  // ══════════════════════════════════════════════════════════════════
   // §Z_STACK_XRAY_STAGING — support-edge cache for x-ray staging
   // ══════════════════════════════════════════════════════════════════
   // Implementing prompts/GANTT_ACCURACY.md §Z_STACK_XRAY_STAGING — Witness: witness_zstack_xray_staging.js
@@ -3381,7 +3490,11 @@
   // (repo convention: audit_support_roleblind.js / witness_stagger_support_order.js both copy the
   // support predicate rather than importing it — see origin/feat/element-cpm:viewer/schedule_gate.js
   // §ELEMENT_CPM, parked; only the PREDICATE is reused here, not the reordering engine it lived
-  // in). It is intentionally NEVER called by injectGantt and has no db.run/INSERT capability — it
+  // in). EXCEPTION (2026-08-10): the roof/load-path promotion is no longer a copy — both this
+  // function and injectGantt call the shared _promoteRoofLoadPath() above, because
+  // verifyGanttIntegrity() (the schedule LOCK gate) runs on THIS build and a silent classifier
+  // divergence there would be a correctness bug, not a rendering glitch.
+  // It is intentionally NEVER called by injectGantt and has no db.run/INSERT capability — it
   // exists so the xray cache can be (re)built on EVERY TM activation, including the cached-gantt
   // fast path (§GANTT_CACHE_HIT) where injectGantt() never runs at all.
   function _buildXrayElements() {
@@ -3465,45 +3578,13 @@
       };
     });
 
-    // §4D_ROOF_LOAD_PATH M1/M4 — same load-path promotion the live scheduler applies (copied, not
-    // shared, per this function's own header) so a promoted roof slab's carrier predicate (the
-    // looser wall-bears check, below) matches what actually got scheduled — the exact scenario
-    // this whole feature exists for ("roof before its walls").
-    var loadPathWalls = elements.filter(function(e) { return e.cls.indexOf('IfcWall') === 0; });
-    var lpSlabs = [], lpSeed = [];
-    elements.forEach(function(el) {
-      if (el.cls !== 'IfcSlab') return;
-      var carriers = loadPathWalls.filter(function(w) {
-        return el.x0 <= w.x1 && el.x1 >= w.x0 && el.y0 <= w.y1 && el.y1 >= w.y0;
-      });
-      if (!carriers.length) return;
-      var midSum = 0, above = [];
-      for (var ci = 0; ci < carriers.length; ci++) {
-        midSum += (carriers[ci].base_z + carriers[ci].top_z) / 2;
-        if (carriers[ci].base_z >= el.top_z) above.push(carriers[ci]);
-      }
-      var wallMidheight = midSum / carriers.length;
-      var clauseA = el.base_z > wallMidheight;
-      lpSlabs.push({ el: el, clauseA: clauseA, above: above });
-      if (clauseA && !above.length) { el.seq = 8; lpSeed.push(el); }
-    });
-    var LP_GAP = 0.5;
-    if (lpSeed.length) {
-      lpSlabs.forEach(function(rec) {
-        var el = rec.el;
-        if (el.seq === 8 || !rec.clauseA || !rec.above.length) return;
-        for (var ai = 0; ai < rec.above.length; ai++) {
-          var w = rec.above[ai], capped = false;
-          for (var si = 0; si < lpSeed.length; si++) {
-            var C = lpSeed[si];
-            if (C.x0 <= w.x1 && C.x1 >= w.x0 && C.y0 <= w.y1 && C.y1 >= w.y0 &&
-                C.base_z >= w.base_z && C.base_z <= w.top_z + LP_GAP) { capped = true; break; }
-          }
-          if (!capped) return;
-        }
-        el.seq = 8;
-      });
-    }
+    // §4D_ROOF_LOAD_PATH M1/M4 — same load-path promotion the live scheduler applies, now SHARED
+    // (one classifier, _promoteRoofLoadPath above — consolidated 2026-08-10 from an inline copy
+    // verified byte-identical in .seq output) so a promoted roof slab's carrier predicate (the
+    // looser wall-bears check) matches what actually got scheduled — the exact scenario this whole
+    // feature exists for ("roof before its walls"). Counts unused here: only injectGantt logs
+    // §GANTT_OVERRIDE.
+    var _lp = _promoteRoofLoadPath(elements);
     return elements;
   }
 
@@ -3879,99 +3960,13 @@
     if (nameOverrides) console.log('§NAME_OVERRIDE ' + nameOverrides + ' elements reclassified by name (' +
       NO.map(function(o){ return o.id; }).join(',') + ') — see rates/sequence_rules.json NAME_OVERRIDES');
 
-    // §4D_ROOF_LOAD_PATH M1 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_ROOF_LOAD_PATH) — a slab's
-    // ROLE is a load-path fact, not a storey-name label. SUPERSEDES the deleted `/roof/i` override
-    // above: measured 2026-08-01, that regex fired ZERO times on Hospital ("Level 1..7A"/"Unknown")
-    // and LTU_AHouse ("TAKPLAN", Swedish) — the two roof slabs it was meant to catch have storey
-    // "Unknown". For each IfcSlab, take the IfcWall*/IfcWallStandardCase whose XY footprint overlaps
-    // it ("those walls"). Two checks from the SAME paragraph of the spec, both epsilon-free:
-    //   (a) the slab's base_z is above the average midheight of those walls — the walls are BELOW
-    //       and physically carry it.
-    //   (b) NONE of those walls stand ON it (no overlapping wall has base_z >= the slab's own
-    //       top_z) — this is the spec's own stated definition of "the floor case" ("floor slab:
-    //       walls stand ON it ... otherwise it stays a floor slab"), and it is NOT redundant with
-    //       (a): measured on this exact DB, (a) alone is true for nearly every capped-wall slab in
-    //       the building (35 slabs -> 23 "promoted"), including known mid-building intermediate
-    //       floors (base_z 176.81, between Level 2 and Level 3, 5 more levels above) — a slab that
-    //       caps the walls below it satisfies (a) whether or not it ALSO carries walls above, so (a)
-    //       alone cannot tell "top of the load path" from "one more floor in the middle of it". (b)
-    //       is the missing half of the spec's own description and brings Hospital down to the 2
-    //       true roof slabs + a handful of isolated panels with no wall directly overlapping the
-    //       next level up (open corridor/atrium bays) — reported, not silently forced to exactly 2.
-    // Promoted -> roof role -> seq 8, phase 'Architecture'. Otherwise stays whatever seq matchRule
-    // gave it (the floor case). No new numeric constant either way — both checks compare the slab
-    // against its own extracted geometry and the walls' own extracted geometry.
-    var loadPathWalls = elements.filter(function(e) { return e.cls.indexOf('IfcWall') === 0; });
-    var loadPathOverrides = 0;
-    // §4D_WALLS_BEFORE_ROOF (2026-08-01) — pass 1 computes the SEED set exactly as #1120 shipped it
-    // (clause a AND clause b), so the shipped count is reproduced unchanged before M4 widens it.
-    var lpSlabs = [], lpSeed = [];
-    elements.forEach(function(el) {
-      if (el.cls !== 'IfcSlab') return;
-      var carriers = loadPathWalls.filter(function(w) {
-        return el.x0 <= w.x1 && el.x1 >= w.x0 && el.y0 <= w.y1 && el.y1 >= w.y0;
-      });
-      if (!carriers.length) return;
-      var midSum = 0, above = [];
-      for (var ci = 0; ci < carriers.length; ci++) {
-        midSum += (carriers[ci].base_z + carriers[ci].top_z) / 2;
-        if (carriers[ci].base_z >= el.top_z) above.push(carriers[ci]);
-      }
-      var wallMidheight = midSum / carriers.length;
-      var clauseA = el.base_z > wallMidheight;
-      lpSlabs.push({ el: el, clauseA: clauseA, above: above });
-      if (clauseA && !above.length) {
-        el.seq = 8; el.phase = 'Architecture';
-        loadPathOverrides++;
-        lpSeed.push(el);
-      }
-    });
-
-    // §4D_WALLS_BEFORE_ROOF M4 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) —
-    // user, live on a Hospital MaxQ bake: "The roof before the walls still happening on the roof
-    // top". #1120's clause (b) disqualifies a roof if ANY XY-overlapping wall stands on it. On
-    // Hospital that disqualifies the 2091.5 m² topmost deck (3Csn1z$1v5Q8DXdumWYJUE, base_z 199.66)
-    // because the two helipad boxes — whose OWN roofs #1120 promoted — stand on it. MEASURED on
-    // origin/main: it starts 2022-07-27 as Superstructure while its 14 wall carriers finish
-    // 2023-04-30 — 277 days before its own walls, the identical error #1120 reported fixing for the
-    // boxes. This is #1120's `⚠ LIMIT 2` arriving, and wider than LIMIT 2 predicted: these walls are
-    // 3.05–3.47 m tall and DO carry something, so LIMIT 2's "parapet carries nothing" discriminator
-    // would not have caught it.
-    //   THE RULE: a wall standing on a slab is not "the next storey" if that wall is itself CAPPED
-    //   by a slab already known to be a roof (a helipad box, a plant enclosure, a coped parapet —
-    //   the load path tops out in a roof, it does not continue the building). Capped = a seed roof
-    //   slab XY-overlapping the wall with its base_z between the wall's base_z and top_z + GAP. A
-    //   wall capped by NOTHING does not qualify.
-    //   DEPTH 1, ON THE FROZEN SEED SET, DELIBERATELY. Full recursion was measured and collapses:
-    //   the box walls excuse the 199.66 deck -> the deck excuses 3064w0y0nDv9wdb1cWL_Gu -> Level 6
-    //   promotes -> Level 5 -> Level 4 -> the whole building becomes "roof". Depth-1 terminates.
-    //   MEASURED: Hospital 10 -> 11. The one addition is the user's slab. Level 6 (3 blockers),
-    //   Level 5 (33), Level 4 (514) and #1120's own floor control 1OV06Y3c5D8vODNyxVnSVI (56) all
-    //   stay blocked. A footprint-extent ratio was tried and REJECTED — it does not separate (roof
-    //   0.040 vs intermediate panels 0.024/0.024/0.029/0.044, Level 6 0.170); no threshold exists,
-    //   which is why this is a load-path rule and not an area rule.
-    var LP_GAP = 0.5;  // m — same "tops out at this level" tolerance schedule_gate.js uses (GAP)
-    var m4Promoted = 0;
-    if (lpSeed.length) {
-      lpSlabs.forEach(function(rec) {
-        var el = rec.el;
-        if (el.seq === 8 || !rec.clauseA || !rec.above.length) return;
-        for (var ai = 0; ai < rec.above.length; ai++) {
-          var w = rec.above[ai], capped = false;
-          for (var si = 0; si < lpSeed.length; si++) {
-            var C = lpSeed[si];
-            if (C.x0 <= w.x1 && C.x1 >= w.x0 && C.y0 <= w.y1 && C.y1 >= w.y0 &&
-                C.base_z >= w.base_z && C.base_z <= w.top_z + LP_GAP) { capped = true; break; }
-          }
-          if (!capped) return;             // a wall the building genuinely continues through
-        }
-        el.seq = 8; el.phase = 'Architecture';
-        loadPathOverrides++; m4Promoted++;
-      });
-    }
-    if (loadPathOverrides) console.log('§GANTT_OVERRIDE ' + loadPathOverrides +
+    // §4D_ROOF_LOAD_PATH M1 + §4D_WALLS_BEFORE_ROOF M4 — roof/load-path promotion, shared
+    // classifier (full doctrine comments live on _promoteRoofLoadPath above, moved there verbatim
+    // when the two inline copies were consolidated 2026-08-10).
+    var _lp = _promoteRoofLoadPath(elements);
+    if (_lp.total) console.log('§GANTT_OVERRIDE ' + _lp.total +
       ' slabs promoted to roof role (seq=8) by load path — base_z above the average midheight of their XY-overlapping walls' +
-      ' (seed=' + lpSeed.length + ' + M4 rooftop-appurtenance=' + m4Promoted + ')');
+      ' (seed=' + _lp.seedCount + ' + M4 rooftop-appurtenance=' + _lp.m4Count + ')');
 
     // §S260e: Sort by actual Z (quantized to 3m bands) → seq → fine Z
     // Real construction: lower Z builds first regardless of storey name.


### PR DESCRIPTION
## Scope correction first (load-bearing — from bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §"▶ NEXT SESSION")

Research initially claimed time_machine.js's two promotion-classifier copies had **diverged 16 edges on Terminal** and caused §TM_GEO_ORDER_CYCLES. **Direct verification proved this FALSE**: both copies already produce byte-identical `.seq` classification output (only bookkeeping fields differ — `el.phase`, debug counters — neither feeds the DAG). The "16-edge divergence" was a comparison against `schedule_author.js`, a third file with no promotion logic at all.

So this PR is a **pure DRY refactor + a new reproduction witness**. It will **NOT** move `cycles=`/`floating=` numbers; the real §TM_GEO_ORDER_CYCLES bug lives in `schedule_gate.js`'s DAG and **stays open**.

## What changed

- **`viewer/time_machine.js`**: extracted `_promoteRoofLoadPath(elements)` (§4D_ROOF_LOAD_PATH M1 + §4D_WALLS_BEFORE_ROOF M4, doc comments moved verbatim). Both former copy sites (`_buildXrayElements`, `injectGantt`) now call it. Returns `{ total, seedCount, m4Count }`; `injectGantt` rebuilds its `§GANTT_OVERRIDE` line from the returned fields — string literals byte-identical to main (grep-safety verified).
- **`viewer/tests/witness_tm_geo_order_cycles.js`** (new, the real deliverable): deterministic out-of-browser reproduction of §TM_GEO_ORDER_CYCLES — slices the shipped element build from time_machine.js (sliceFn + vm sandbox + sql-wasm, pattern of `witness_gantt_lock_integrity.js`), runs canonical `ScheduleGate.computeSchedule()`/`auditFloating()` (schedule_gate.js unchanged, read-only) on real `Terminal_extracted.db`. Slices `_promoteRoofLoadPath` when present, falls back to the inline copy when absent — so the same witness ran on both commits of this branch.
- **`viewer/sw.js`**: CACHE_VERSION v973 → v974 (time_machine.js already in PRECACHE_ASSETS).

## Why consolidate if behavior is unchanged

`verifyGanttIntegrity()` — the schedule **LOCK gate** — calls `_buildXrayElements()` directly. A future silent divergence between the two copies would have made the lock gate verify against a different classification than the one actually scheduled: a correctness bug in the lock gate, not an x-ray rendering glitch. One copy closes that class of bug.

## Witness evidence (invariance proven, not assumed)

Run pre-refactor (witness commit, inline copy) and post-refactor (shared function):

```
pre:  §TM_GEO_ORDER_CYCLES_REPRO cycles=37927 floating=45 n=48428/48428 promotedRoofSlabs=57 (Terminal_extracted.db; resource/installSecs approximated — structural cycle count unaffected)
post: §TM_GEO_ORDER_CYCLES_REPRO cycles=37927 floating=45 n=48428/48428 promotedRoofSlabs=57 (Terminal_extracted.db; resource/installSecs approximated — structural cycle count unaffected)
```

`diff` of the two lines: identical. Deliberately NOT asserted to drop toward 0.

**Known drift, flagged not resolved**: this reproducible 37927/45 matches the 2026-08-10 planning-session sandbox run but differs from the doc's earlier recorded 24353/33 — cause unexplained; the witness logs `§TMREPRO_DRIFT_FLAG` naming both numbers rather than silently overwriting either. Approximation caveat named in the witness: the x-ray build has no `resource`/`installSecs` fields (filled as cls/120) — affects crew/duration only, not the structural cycle count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)