### PR TITLE
test(guard): F1 §CHUNK_ONLY enforcement witness + F2 §SCRIPT_DUP boot audit

### DIFF
--- a/tests/witness_chunk_only.js
+++ b/tests/witness_chunk_only.js
@@ -1,0 +1,105 @@
+/**
+ * W-CHUNK-ONLY (F1) — witness: does any call site feed NETWORK-FETCHED SQL text into a raw
+ * db.run()/db.exec() instead of the shared statement-aware chunker A._runSqlChunked?
+ *
+ * Issue it proves/disproves (prompts/4D_SCHEDULE_PERFECTION.md §FOLLOW-ON F1, 2026-08-10):
+ *   a single run() over a multi-thousand-statement fetched patch crashes the bundled
+ *   sql-wasm.wasm ("memory access out of bounds") and bricks the SHARED wasm heap. This class
+ *   was fixed TWICE in one day (scene.js _applyPendingPatch am, navigate_find.js needle pm) —
+ *   same bug, missed call site. Per-call-site discipline drifted; this witness makes the
+ *   invariant mechanical: SQL text that crossed the network as a file goes through the chunker,
+ *   or carries an explicit `// §CHUNK-EXEMPT: <reason>` on the flagged line.
+ *
+ * Rule (deterministic, per file — no dataflow guessing beyond it):
+ *   1. collect identifiers assigned from a network text body:
+ *        <id> = await <x>.text()          (async form — scene.js/navigate_find.js style)
+ *        .text().then(function (<id>)     (promise form — modeller str_walker_outliner style)
+ *        .text().then(<id> =>             (arrow form)
+ *   2. flag any `.run(<id>)` / `.exec(<id>)` of a collected <id> ONLY on lines textually AFTER
+ *      that ident's first network binding — a same-named ident earlier in the file is a different
+ *      variable (real case: modeller _count(db, sql)'s constant-SELECT param at :422 vs the patch
+ *      text bound at :652). Lines containing `§CHUNK-EXEMPT: <reason>` are skipped.
+ *   Small constant-literal queries (db.exec(sql) where sql is a local SELECT string) are NOT
+ *   network-derived and are deliberately out of scope — they cannot reach the crash size class.
+ *   Known miss, accepted: a helper DEFINED before the binding but handed the patch text later —
+ *   the drift class this guards (inline patch application) is always after the fetch.
+ *
+ * Scope: viewer/*.js + modeller/*.js (flat; lib/ is vendor). Both apps scanned by default —
+ * feat/modeller-nogeo-compose-port (bim-ootb#1273) landed the modeller chunker, so both are green.
+ *
+ * Self-test: the detector is first run against embedded known-bad fixtures (the two historical
+ * bugs, verbatim shapes) and must flag BOTH — a scanner that cannot reproduce the finding it
+ * exists for is not a witness.
+ *
+ * Usage: node tests/witness_chunk_only.js            (exit 0 = PASS, 1 = violations/self-test fail)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const ASSIGN_RES = [
+  /(?:var|let|const)?\s*([A-Za-z_$][\w$]*)\s*=\s*await\s+[\w$.]+\.text\(\)/g,
+  /\.text\(\)\s*\.then\(\s*function\s*\(\s*([A-Za-z_$][\w$]*)\s*\)/g,
+  /\.text\(\)\s*\.then\(\s*(?:\(\s*)?([A-Za-z_$][\w$]*)(?:\s*\))?\s*=>/g,
+];
+
+function scanSource(src, fileLabel) {
+  // ident → line number of its FIRST network-text binding (1-based)
+  const netIdents = new Map();
+  for (const re of ASSIGN_RES) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const lineNo = src.slice(0, m.index).split('\n').length;
+      if (!netIdents.has(m[1]) || netIdents.get(m[1]) > lineNo) netIdents.set(m[1], lineNo);
+    }
+  }
+  const hits = [];
+  if (!netIdents.size) return hits;
+  const lines = src.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.includes('§CHUNK-EXEMPT:')) continue;
+    const callRe = /\.(run|exec)\(\s*([A-Za-z_$][\w$]*)\s*[),]/g;
+    let c;
+    while ((c = callRe.exec(line)) !== null) {
+      if (netIdents.has(c[2]) && (i + 1) >= netIdents.get(c[2]))
+        hits.push(`${fileLabel}:${i + 1} .${c[1]}(${c[2]})`);
+    }
+  }
+  return hits;
+}
+
+// --- self-test: the two historical bugs, verbatim shapes — detector MUST flag both -----------
+const FIXTURES = [
+  { name: 'needle-2026-08-10', src: 'var sqlText = await r.text();\nA.db.run(sqlText);\n', expect: 1 },
+  { name: 'modeller-promise-style', src: 'return r.text().then(function (sql) {\n  pdb.run(sql);\n});\n', expect: 1 },
+  { name: 'chunked-is-clean', src: 'var sqlText = await r.text();\nvar _ch = A._runSqlChunked(A.db, sqlText);\n', expect: 0 },
+  { name: 'constant-literal-out-of-scope', src: 'var sql = "SELECT 1";\ndb.exec(sql);\n', expect: 0 },
+  { name: 'same-name-helper-before-binding', src: 'function _count(db, sql) { var r = db.exec(sql); }\nreturn r.text().then(function (sql) {\n  Modeller._runChunked(pdb, sql);\n});\n', expect: 0 },
+];
+let selfFail = 0;
+for (const f of FIXTURES) {
+  const n = scanSource(f.src, f.name).length;
+  const ok = n === f.expect;
+  console.log(`§CHUNK_ONLY_SELFTEST ${ok ? 'PASS' : 'FAIL'} ${f.name} hits=${n} expect=${f.expect}`);
+  if (!ok) selfFail++;
+}
+
+// --- scan the real tree ----------------------------------------------------------------------
+const dirs = ['viewer', 'modeller'];
+let scanned = 0;
+const violations = [];
+for (const d of dirs) {
+  const dir = path.join(ROOT, d);
+  for (const f of fs.readdirSync(dir).filter(x => x.endsWith('.js'))) {
+    scanned++;
+    violations.push(...scanSource(fs.readFileSync(path.join(dir, f), 'utf8'), `${d}/${f}`));
+  }
+}
+for (const v of violations) console.log(`§CHUNK_ONLY_VIOLATION ${v} — network-fetched SQL must go through A._runSqlChunked (or carry §CHUNK-EXEMPT: <reason>)`);
+const pass = !selfFail && !violations.length;
+console.log(`§CHUNK_ONLY_WITNESS ${pass ? 'PASS' : 'FAIL'} scanned=${scanned} files hits=${violations.length} selftest_fail=${selfFail} scope=${dirs.join(',')}`);
+process.exit(pass ? 0 : 1);

--- a/viewer/input_registry.js
+++ b/viewer/input_registry.js
@@ -175,6 +175,33 @@
       return dead;
     },
 
+    // §SCRIPT_DUP (F2, 4D_SCHEDULE_PERFECTION.md 2026-08-10): the same script loaded twice under
+    // different paths lets LOAD ORDER silently pick the winner — the live log printed BOTH
+    // "§KERNEL_OPS_LOADED v13" and "v8" banners and nothing flagged it; the stale v8 clobbered v13
+    // and silently broke blue_fold/whatif (v13-only APIs). Log-only audit, zero behavior change:
+    // any <script> basename (query stripped) appearing more than once is warned. If a legitimate
+    // same-basename-different-file pair ever appears, list it in DUP_OK with the reason.
+    checkScriptDups: function () {
+      var DUP_OK = [];   // basenames allowed to repeat, each entry needs a reason comment
+      var seen = {}, dups = [];
+      var scripts = document.scripts || [];
+      for (var i = 0; i < scripts.length; i++) {
+        var src = scripts[i].getAttribute('src');
+        if (!src) continue;                                  // inline blocks can't collide by path
+        var base = src.split('?')[0].split('/').pop();
+        (seen[base] = seen[base] || []).push(src);
+      }
+      Object.keys(seen).forEach(function (base) {
+        if (seen[base].length > 1 && DUP_OK.indexOf(base) < 0) {
+          dups.push(base);
+          console.warn('§SCRIPT_DUP basename=' + base + ' srcs=[' + seen[base].join(', ') + ']');
+        }
+      });
+      console.log('§SCRIPT_DUP_AUDIT total=' + scripts.length + ' dup=' + dups.length +
+        (dups.length ? ' dupBasenames=' + dups.join(',') : ''));
+      return dups;
+    },
+
     // Test/debug surface
     _icons: _icons
   };
@@ -188,6 +215,7 @@
   (function pollAudit(tries) {
     if (window._shortcuts && Object.keys(window._shortcuts).length) {
       try { InputReg.checkShortcuts(); } catch (e) { console.warn('§SHORTCUT_AUDIT error=' + e.message); }
+      try { InputReg.checkScriptDups(); } catch (e) { console.warn('§SCRIPT_DUP_AUDIT error=' + e.message); }
       return;
     }
     if (tries <= 0) { console.warn('§SHORTCUT_AUDIT error=_shortcuts never appeared (scene init incomplete)'); return; }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v974';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v975';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
Implements both follow-on specs from `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md` §FOLLOW-ON SPECS (2026-08-10). Meta-pattern both guard: a shared invariant enforced per-call-site instead of at one choke point — which drifted twice in one day (scene.js vs navigate_find.js chunking → wasm-heap brick; kernel_ops v8 silently clobbering v13).

**F1 — `tests/witness_chunk_only.js`**: static witness. Idents bound from network `.text()` (async, promise, arrow forms) passed raw into `.run()`/`.exec()` after their binding = violation unless `// §CHUNK-EXEMPT: <reason>`. The after-binding order rule eliminates the one real false positive found on the very first run (modeller `_count(db, sql)` constant-SELECT helper at :422 vs the patch ident bound at :652 — same name, different variable). 5/5 self-tests, both historical bug shapes flagged.
```
§CHUNK_ONLY_WITNESS PASS scanned=164 files hits=0 selftest_fail=0 scope=viewer,modeller
```
(modeller scope is green because #1273 landed its chunker; scanning both by default.)

**F2 — `InputReg.checkScriptDups()`** (`viewer/input_registry.js`): `document.scripts` basename audit, log-only, zero behavior change. Any script basename loaded from two paths → `§SCRIPT_DUP basename=... srcs=[...]` warn + `§SCRIPT_DUP_AUDIT total=N dup=K` summary, self-runs next to the existing `checkShortcuts` audit. Would have flagged the kernel_ops double-load on sight — the live log printed both `§KERNEL_OPS_LOADED v13` and `v8` banners and nothing noticed.

`viewer/sw.js` CACHE_VERSION v974→v975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)