### PR TITLE
fix(4d): §TM_GEO_ORDER_CYCLES — Terminal support-DAG cycles 37,927→0, floating 45→8

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -184,7 +184,16 @@
           // ON the wall, not structure the wall rests within — counting it here is a wallGate cycle
           // (measured: Hospital roof@199.66..199.81 inside wall@191.81..199.81, both re-shifting
           // every repair sweep). Promoted slabs support others via bearing-below and hangGate only.
-          var contained = !below && !elPool && !S.promoted && S.base_z > el.base_z + EPS && S.top_z < el.top_z + EPS;
+          // §TM_GEO_ORDER_CYCLES fix (2026-08-10, 4D_SCHEDULE_PERFECTION.md — Witness:
+          // witness_tm_geo_order_cycles.js): contained support must live in MY LOWER HALF. What I
+          // rest within sits near my base (every measured §GEO_SUPPORT_LEAK case: ramp/retaining
+          // structure near the consumer's base); a thin slab/beam/plate nested near my CROWN is
+          // what rests on ME. The old top bound (S.top_z < el.top_z + EPS) let a 3cm topping slab
+          // at a 22m wall's crown count as that wall's support — on Terminal that closed 37,927
+          // elements into Kahn-leftover cycles (wall→promoted-roof→topping-slab→wall). Lower-half
+          // bound measured on Terminal: leftover 37,927 → 0, only 0.8% of edges removed.
+          var contained = !below && !elPool && !S.promoted && S.base_z > el.base_z + EPS &&
+                          S.top_z <= (el.base_z + el.top_z) / 2;
           if ((below || contained) && S.end > g && overlap(S, el)) g = S.end; } }
       return g;
     }
@@ -259,7 +268,13 @@
       var g = baseMs; cs = cellsOf(el);
       for (c = 0; c < cs.length; c++) { arr = wallGrid[cs[c]]; if (!arr) continue;
         for (k = 0; k < arr.length; k++) { S = arr[k]; if (S.guid === el.guid) continue;
-          if (S.base_z < el.base_z - EPS && S.top_z >= el.base_z - GAP && S.end > g && overlap(S, el)) g = S.end; } }
+          // §TM_GEO_ORDER_CYCLES fix: a wall CARRIES a promoted slab AT ITS TOP (top within GAP of
+          // the slab's base — the M5 Hospital measurement: wall tops meeting the roof base), never a
+          // slab embedded metres below its crown. Unbounded, a 22m Terminal wall "bore" a slab at
+          // its mid-height, and that slab's below-edges closed the wall into a cycle. Same bound as
+          // the DAG's wallCarries().
+          if (S.base_z < el.base_z - EPS && S.top_z >= el.base_z - GAP && S.top_z <= el.base_z + GAP &&
+              S.end > g && overlap(S, el)) g = S.end; } }
       return g;
     }
     // ══ §GEOMETRIC_SUPPORT_ORDER (2026-08-07, 4D_SCHEDULE_PERFECTION.md) ════════════════════════
@@ -295,8 +310,13 @@
       else if (P.cls && P.cls.indexOf('IfcWall') === 0) { cs = cellsOf(P); for (c = 0; c < cs.length; c++) (wallIdxGrid[cs[c]] = wallIdxGrid[cs[c]] || []).push(t); } }
     // pair predicates — one definition, used for both indegree count and decrement-on-place
     function edgeBelow(S, E)     { return S.base_z < E.base_z - EPS; }                          // geoGate "below"
-    function edgeContained(S, E) { return !edgeBelow(S, E) && !isPromotedSlab(S) && S.base_z > E.base_z + EPS && S.top_z < E.top_z + EPS; }  // geoGate §GEO_SUPPORT_LEAK clause
-    function edgeBearing(S, E)   { return S.base_z < E.base_z - EPS && S.top_z >= E.base_z - GAP; }  // wallGate / hasBearingBelow
+    // §TM_GEO_ORDER_CYCLES fix (2026-08-10): contained support must live in E's LOWER HALF —
+    // mirrors geoGate's clause above (see the full rationale there; Terminal leftover 37,927 → 0).
+    function edgeContained(S, E) { return !edgeBelow(S, E) && !isPromotedSlab(S) && S.base_z > E.base_z + EPS && S.top_z <= (E.base_z + E.top_z) / 2; }  // geoGate §GEO_SUPPORT_LEAK clause
+    function edgeBearing(S, E)   { return S.base_z < E.base_z - EPS && S.top_z >= E.base_z - GAP; }  // hasBearingBelow / audit
+    // §TM_GEO_ORDER_CYCLES fix: wallGate's relation, bounded — a wall carries a promoted slab AT
+    // ITS TOP (top within GAP of the slab's base), never one embedded metres below its crown.
+    function wallCarries(S, E)   { return edgeBearing(S, E) && S.top_z <= E.base_z + GAP; }
     function edgeCarrier(S, E)   { return S.base_z >= E.top_z - GAP && S.base_z <= E.top_z + GAP && S.top_z > E.top_z + EPS; }  // hangGate
     var indeg = new Int32Array(N), succs = new Array(N), hangs = new Uint8Array(N), _edges = 0;
     // stamp-array dedup (an {} per element measured 28s at 15k elements — dictionary churn), and a
@@ -329,7 +349,7 @@
         for (c = 0; c < cs.length; c++) { arr = wallIdxGrid[cs[c]]; if (!arr) continue;
           for (k = 0; k < arr.length; k++) { si = arr[k]; if (si === t || stamp[si] === _gen) continue; stamp[si] = _gen;
             S = elements[si]; if (!overlap(S, E)) continue;
-            if (edgeBearing(S, E)) { (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; } } }
+            if (wallCarries(S, E)) { (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; } } }   // §TM_GEO_ORDER_CYCLES: bounded, carry-at-top
       }
     }
     // tiebreak = the old seq-primary processing order (precomputed keys — collapsePhase is regex)

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v975';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v976';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_gantt_lock_integrity.js
+++ b/viewer/tests/witness_gantt_lock_integrity.js
@@ -99,7 +99,12 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
 (async () => {
   let sliced;
   try {
-    sliced = ['_buildXrayElements', 'verifyGanttIntegrity'].map(n => sliceFn(tmSrc, n)).join('\n');
+    // _promoteRoofLoadPath: _buildXrayElements calls it since the #1272 consolidation — slice it
+    // too when present (same both-commits pattern as witness_tm_geo_order_cycles.js; without this
+    // the witness crashed ReferenceError on every post-#1272 run).
+    const _names = ['_buildXrayElements', 'verifyGanttIntegrity'];
+    if (tmSrc.indexOf('function _promoteRoofLoadPath(') >= 0) _names.unshift('_promoteRoofLoadPath');
+    sliced = _names.map(n => sliceFn(tmSrc, n)).join('\n');
   } catch (e) {
     assert(false, 'G-LI-2 slice failed (RED on main: ' + e.message + ')');
     finish();

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -8,8 +8,15 @@
 //     time_machine.js's real element build (sliced, never reimplemented — repo convention,
 //     witness_gantt_lock_integrity.js) fed through the canonical, UNCHANGED
 //     ScheduleGate.computeSchedule()/auditFloating() from viewer/schedule_gate.js, against the real
-//     Terminal_extracted.db. The bug itself lives in schedule_gate.js's DAG and stays OPEN — this
-//     witness reproduces it, it does not fix it, and it must NOT assert cycles/floating drop to 0.
+//     Terminal_extracted.db. FIXED 2026-08-10 (same day, follow-up PR): SCC analysis on the real
+//     DAG refuted the predicted hang-based 3-cycle and named the real class — tall multi-storey
+//     walls closed into cycles by (a) `contained` support sitting at their CROWN (a 3cm topping
+//     slab at a 22m wall's top counted as the wall's support) and (b) `wallBearsPromoted` firing
+//     for slabs EMBEDDED metres below the wall's top. Fix: contained support must live in the
+//     consumer's LOWER HALF; a wall carries a promoted slab only AT ITS TOP (wallCarries, ±GAP).
+//     Terminal: cycles 37,927→0, §DEQ_REPAIR shifts 251→0, floating 45→8 (37 were cycle-fallback
+//     ordering artifacts; the 8 remain a separate, named, open tail). This witness now ASSERTS
+//     cycles=0 and floating=8 so any regression screams.
 //
 //   ISSUE 2 (refactor invariance): the roof/load-path promotion classifier existed as two copies in
 //     time_machine.js (_buildXrayElements inline + injectGantt inline). Direct verification proved
@@ -114,6 +121,11 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   const cycles = m ? parseInt(m[1], 10) : -1;
   assert(cycles >= 0, 'W-TMREPRO-2 §SUPPORT_CYCLE reported by canonical computeSchedule (cycles=' + cycles + ')');
   assert(typeof floating === 'number' && floating >= 0, 'W-TMREPRO-3 auditFloating returns a count (floating=' + floating + ')');
+  // §TM_GEO_ORDER_CYCLES fix bar (2026-08-10): the DAG is acyclic on Terminal under load-path
+  // promotion. floating=8 is the EXACT remaining tail (was 45; 37 were cycle-fallback artifacts) —
+  // if it moves EITHER way, that is a real behavior change to examine, not to absorb silently.
+  assert(cycles === 0, 'W-TMREPRO-4 Terminal support DAG is acyclic under load-path promotion (cycles=' + cycles + ', fix: lower-half contained + wallCarries)');
+  assert(floating === 8, 'W-TMREPRO-5 floating tail exactly 8 (measured after cycle fix; was 45) — got ' + floating);
 
   // THE line. Must be numerically identical pre vs post the _promoteRoofLoadPath refactor
   // (diffed across the two commits' logs — see header ISSUE 2). Numbers only; slice state is on


### PR DESCRIPTION
## The bug (open since 2026-08-08, prompts/4D_SCHEDULE_PERFECTION.md §TM_GEO_ORDER_CYCLES)
Under time_machine's load-path promotion, Terminal's support DAG stranded **37,927 of 48,428 elements** into Kahn-leftover cycle fallback (`§SUPPORT_CYCLE cycles=37927`), with `§DEQ_REPAIR shifted=251` and `floating=45`.

## Root cause — measured, not the predicted one
SCC analysis on the real DAG (edge construction replicated and cross-checked: **identical 37,927 leftover**, so the replication is faithful) **refuted** the predicted hang-based 3-cycle. The real class, present in every SCC: **tall multi-storey walls** —
```
wall --wallBearsPromoted--> promoted slab EMBEDDED metres below the wall's top
     --below--> thin slab/beam/plate at the wall's CROWN
     --contained--> the same wall            (e.g. wall z=[14.77,37.06] h=22m)
```

## Fix — two tightenings, one principle: support lives near my base; carry happens at my top
- **contained** (geoGate + `edgeContained`): support must top within the consumer's **lower half**. A 3cm topping slab at a 22m wall's crown rests ON the wall — it is not the wall's support. The measured §GEO_SUPPORT_LEAK cases (ramp/retaining near base) all stay inside the bound.
- **wallCarries** (wallGate + DAG edge): a wall carries a promoted slab **only at its top** (wall top within GAP of slab base — M5's own Hospital measurement), never a slab embedded mid-span.

Only **0.8%** of Terminal's 422,914 edges removed. Audit predicates untouched — the auditor still finds support at least as easily as the scheduler orders it.

## Witness evidence (all logs read)
| check | before | after |
|---|---|---|
| `§TM_GEO_ORDER_CYCLES_REPRO` Terminal | cycles=37927 floating=45 | **cycles=0 floating=8** (witness now asserts both) |
| `§DEQ_REPAIR` Terminal | 251 shifts | **sweeps=0 shifted=0** |
| `witness_geometric_support_order` | PASS | PASS (Duplex floating=0/1122) |
| `witness_default_engine_quality` | PASS | PASS (Terminal floating=0/48428, zero violations) |
| `witness_gantt_lock_integrity` | **crashing since #1272** | **19/19 PASS** incl. Hospital 63,415-element lock audit |

Also repaired here: `witness_gantt_lock_integrity.js` sliced `_buildXrayElements` without the new `_promoteRoofLoadPath` and threw ReferenceError on every post-#1272 run (latent — CI doesn't run it).

Known, named, out of scope: `witness_geo_support_leak.js` fails `totalUngated=10 totalLeaked=7` **byte-identically on unmodified main** (pre-existing); the remaining floating=8 tail on Terminal is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)