### PR TITLE
fix(4d): §HANG_NEAREST + pile reclass — Terminal/Hospital §SUPPORT_UNCHECKED root causes, 831→250

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -240,6 +240,27 @@ var SEQUENCE_NAME_OVERRIDES = [
     phase: 'Architecture',
     sequence: 7,
     resource: 'CARPENTER'
+  },
+  // §PILE_SLAB_RECLASS (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md big-element
+  // follow-up — Witness: witness_big_element_support_coverage.js): Terminal's 236 §SUPPORT_UNCHECKED
+  // IfcSlab are 'jkrST_str-fo_pc_rcp:300 x 300mm' — 300×300mm × 30.15m precast RC foundation PILES
+  // ('str-fo' = JKR structural-foundation code) misclassified as IfcSlab by the authoring tool.
+  // They sit at the building's absolute lowest z (base −16.04..−15.94 vs model min −16.04) with
+  // NOTHING modeled beneath them — genuinely ground-bearing Substructure, the exact population the
+  // seq===1 exemption (schedule_gate.js 1c) exists for, unreachable by class lookup alone (this is
+  // the archived 'Gap A: IfcPile has no SEQUENCE_RULES entry' arriving disguised as IfcSlab).
+  // Pattern MEASURED against every shipped buildings/*.db (2026-08-11): with the IfcSlab class gate
+  // it matches exactly those 236 (Terminal family, incl. Terminal_meta/rooms/TermRooms copies) and
+  // nothing else; \bpile\b (not bare 'pile') keeps 'stockpile'-style names out, and Hospital's
+  // 'M_Pile Cap-6 Pile' footings are already IfcFooting (out of class scope, same target phase).
+  {
+    id: 'foundation_pile_misclassified_slab',
+    classes: ['IfcSlab'],
+    pattern: 'str-fo|\\bpile\\b',
+    flags: 'i',
+    phase: 'Substructure',
+    sequence: 1,
+    resource: 'CONCRETE_GANG'
   }
 ];
 

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -7,13 +7,28 @@
   "NAME_OVERRIDES": [
     {
       "id": "glazed_curtainwall_facade",
-      "classes": ["IfcPlate", "IfcMember"],
+      "classes": [
+        "IfcPlate",
+        "IfcMember"
+      ],
       "pattern": "glaz|glass|verglas|vitrage|vidrio|curtain|mullion",
       "flags": "i",
       "phase": "Architecture",
       "sequence": 7,
       "resource": "CARPENTER",
       "reason": "ifc_class alone cannot separate curtain-wall glazing/framing from structural steel plates/members — a Revit curtain-wall panel is IfcPlate and its mullions are IfcMember, same classes as genuinely structural plates/members (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR's CHS/RHS steel framing, LTU_AHouse's timber beams, which must all stay at their structural seq). Name is the only extracted signal that discriminates them. Matched, measured against 8 shipped buildings: Hospital 'System Panel:Glazed' (2211/2211 IfcPlate) + 'Curtain Wall:...Framing'/'Curtain System' (7122/7127 IfcMember), Clinic 'Rectangular/Circular Mullion' (522/534 IfcMember), HHS 'Systemelement:Verglasung' (438/629 IfcPlate, German) — zero false positives on Terminal/JKR/LTU_AHouse/TermRooms. See bim-compiler prompts/RESUME_4D_TRUTH_AND_BE_HERE_WHEN.md §STAGE A A.3/A.4 and prompts/GANTT_ACCURACY.md §4D_HOST_BEFORE_HOSTED. Elements not matching this pattern keep their class-default seq (measured, never guessed) — known remaining blind spot: HHS 'Rechteckiger Pfosten' (German curtain-wall posts, 1450 IfcMember) not matched, deliberately not covered by a generic 'post' pattern (too ambiguous vs real structural posts) — reported, not silently dropped."
+    },
+    {
+      "id": "foundation_pile_misclassified_slab",
+      "classes": [
+        "IfcSlab"
+      ],
+      "pattern": "str-fo|\\bpile\\b",
+      "flags": "i",
+      "phase": "Substructure",
+      "sequence": 1,
+      "resource": "CONCRETE_GANG",
+      "reason": "Terminal's 236 §SUPPORT_UNCHECKED IfcSlab are 'jkrST_str-fo_pc_rcp:300 x 300mm' — 300×300mm × 30.15m precast RC foundation PILES ('str-fo' = JKR structural-foundation code) misclassified as IfcSlab by the authoring tool. They sit at the building's absolute lowest z (base −16.04..−15.94 vs model min −16.04) with nothing modeled beneath them — genuinely ground-bearing Substructure, the population schedule_gate.js's seq===1 exemption exists for, unreachable by class lookup (the archived 'Gap A: IfcPile has no SEQUENCE_RULES entry' arriving disguised as IfcSlab). Pattern MEASURED against every shipped buildings/*.db 2026-08-11: with the IfcSlab class gate it matches exactly those 236 and nothing else; \\bpile\\b keeps 'stockpile'-style names out, and Hospital's 'M_Pile Cap-6 Pile' footings are already IfcFooting (out of class scope, same target phase). See bim-compiler prompts/4D_SCHEDULE_PERFECTION.md big-element follow-up 2026-08-11 + prompts/archive/4D_BIG_ELEMENT_SUPPORT_COVERAGE_2026-08-11.md."
     }
   ],
   "SEQUENCE_RULES": {

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -52,6 +52,9 @@
     return o;
   }
   function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
+  // bbox volume — the same m³ the BIG_ELEMENT_VOL p95 was measured in (§SUPPORT_UNCHECKED 1a and
+  // the §HANG_NEAREST fallback below share this one definition so their populations can never drift)
+  function bboxVol(e) { return (e.x1 - e.x0) * (e.y1 - e.y0) * (e.top_z - e.base_z); }
 
   // deriveBandRanks(elements) — the §4D_BAND_MONOTONIC ladder (see computeSchedule's header for the
   // full ruling): storeys grouped by collapsePhase(), each ranked by the MEDIAN base_z of its own
@@ -258,6 +261,34 @@
               !(S.promoted && el.cls && el.cls.indexOf('IfcWall') === 0 &&
                 el.base_z < S.base_z - EPS && el.top_z >= S.base_z - GAP) &&
               S.end > g && overlap(S, el)) g = S.end; } }
+      // §HANG_NEAREST (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md big-element
+      // follow-up — Witness: witness_big_element_support_coverage.js): the ±GAP carrier band
+      // assumes DIRECT mount ("the structure whose underside meets its top"), but rod-suspended
+      // MEP hangs 0.5–9.5m below its real carrier (MEASURED on the 5 shipped buildings: Hospital's
+      // 139 §SUPPORT_UNCHECKED IfcDuctSegment all have pool structure 0.51–4.61m above, p50 1.22m —
+      // just outside the band). STRICT ADDITION, same shape as §GEO_SUPPORT_LEAK's second clause:
+      // only fires when the band scan found NOTHING, and only for a BIG (>BIG_ELEMENT_VOL, the same
+      // measured p95 the 1a warn uses) pure-SINK element (seq>4, never a wall, never a promoted
+      // slab — sinks are in neither support pool, so they have no outgoing DAG edges and an added
+      // carrier edge can NEVER close a cycle; walls are excluded because wall→promoted-slab→wall
+      // triangles are constructible through wallCarries). Carrier = the NEAREST overlapping pool
+      // member above (parameter-free — no invented reach constant), plus co-planar members within
+      // GAP of it (a beam grid rods to every beam of the plane, not one). Small sinks keep the old
+      // ungated behavior — widening ALL sinks would re-gate 48,904 elements across the 5 shipped
+      // buildings (measured 2026-08-11), a Part-2-scale reorder, not this seam close.
+      if (g === baseMs && !elPool && !(el.cls && el.cls.indexOf('IfcWall') === 0) &&
+          bboxVol(el) > BIG_ELEMENT_VOL) {
+        var nb = Infinity;
+        for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
+          for (k = 0; k < arr.length; k++) { S = arr[k]; if (S.guid === el.guid) continue;
+            if (S.base_z > el.top_z + GAP && S.base_z < nb && overlap(S, el)) nb = S.base_z; } }
+        if (nb < Infinity) {
+          for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
+            for (k = 0; k < arr.length; k++) { S = arr[k]; if (S.guid === el.guid) continue;
+              if (S.base_z > el.top_z + GAP && S.base_z <= nb + GAP &&
+                  S.end > g && overlap(S, el)) g = S.end; } }
+        }
+      }
       return g;
     }
     // §4D_WALLS_BEFORE_ROOF M5 (2026-08-01, prompts/GANTT_ACCURACY.md §4D_WALLS_BEFORE_ROOF) — a
@@ -324,7 +355,8 @@
     // ITS TOP (top within GAP of the slab's base), never one embedded metres below its crown.
     function wallCarries(S, E)   { return edgeBearing(S, E) && S.top_z <= E.base_z + GAP; }
     function edgeCarrier(S, E)   { return S.base_z >= E.top_z - GAP && S.base_z <= E.top_z + GAP && S.top_z > E.top_z + EPS; }  // hangGate
-    var indeg = new Int32Array(N), succs = new Array(N), hangs = new Uint8Array(N), _edges = 0;
+    var indeg = new Int32Array(N), succs = new Array(N), hangs = new Uint8Array(N), _edges = 0,
+        _hangNearest = 0;  // §HANG_NEAREST fallback edges added (logged in §GEO_ORDER)
     // stamp-array dedup (an {} per element measured 28s at 15k elements — dictionary churn), and a
     // reused cands array; _gen is bumped once per scan so stamps never need clearing
     var stamp = new Int32Array(N), _gen = 0, cands = [], nc;
@@ -345,11 +377,29 @@
       //   pool pair would be a 2-cycle); a pool member never hangs from what it sits below of.
       // With that, pool-vs-pool edges are BELOW/BEARING only — strictly base_z-ordered, so the DAG
       // is acyclic for any real geometry; §SUPPORT_CYCLE below reports whatever remains, never hides it.
+      var hadCarrier = false;
       for (nc = 0; nc < cands.length; nc++) { si = cands[nc]; S = elements[si];
-        if (edgeBelow(S, E) || (!isPoolE && edgeContained(S, E)) ||
-            (hangs[t] && edgeCarrier(S, E) && !(isPoolE && E.base_z < S.base_z - EPS) &&
-             !(isPromotedSlab(S) && E.cls && E.cls.indexOf('IfcWall') === 0 && edgeBearing(E, S)))) {
+        var isCarrierEdge = hangs[t] && edgeCarrier(S, E) && !(isPoolE && E.base_z < S.base_z - EPS) &&
+             !(isPromotedSlab(S) && E.cls && E.cls.indexOf('IfcWall') === 0 && edgeBearing(E, S));
+        if (isCarrierEdge) hadCarrier = true;
+        if (edgeBelow(S, E) || (!isPoolE && edgeContained(S, E)) || isCarrierEdge) {
           (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; } }
+      // §HANG_NEAREST — the DAG twin of hangGate's fallback above (one relation, two consumers, or
+      // placement order and runtime gate would disagree). Scope identical: big pure-sink hanger with
+      // ZERO in-band carriers → edge from every member of the nearest carrier plane. Sinks are in
+      // neither support pool ⇒ no outgoing edges ⇒ these added in-edges cannot create a cycle
+      // (W-TMREPRO-4 cycles=0 stays structural, not lucky).
+      if (hangs[t] && !isPoolE && !(E.cls && E.cls.indexOf('IfcWall') === 0) && !hadCarrier &&
+          bboxVol(E) > BIG_ELEMENT_VOL) {
+        var nbD = Infinity;
+        for (nc = 0; nc < cands.length; nc++) { S = elements[cands[nc]];
+          if (S.base_z > E.top_z + GAP && S.base_z < nbD) nbD = S.base_z; }
+        if (nbD < Infinity) {
+          for (nc = 0; nc < cands.length; nc++) { si = cands[nc]; S = elements[si];
+            if (S.base_z > E.top_z + GAP && S.base_z <= nbD + GAP) {
+              (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; _hangNearest++; } }
+        }
+      }
       if (isPromotedSlab(E)) {                                       // wallGate's relation
         _gen++;
         for (c = 0; c < cs.length; c++) { arr = wallIdxGrid[cs[c]]; if (!arr) continue;
@@ -429,7 +479,8 @@
     if (typeof console !== 'undefined' && console.log) {
       console.log('§SUPPORT_CYCLE cycles=' + _cyc.length +
         (_cyc.length ? ' sample=[' + _cyc.slice(0, 5).map(function (x) { return elements[x].guid; }).join(',') + ']' : ''));
-      console.log('§GEO_ORDER n=' + N + ' edges=' + _edges + ' orderMs=' + (Date.now() - _t0));
+      console.log('§GEO_ORDER n=' + N + ' edges=' + _edges + ' hangNearest=' + _hangNearest +
+        ' orderMs=' + (Date.now() - _t0));
     }
     var nonst = elements.filter(function (e) { return e.seq > 4; });
     // §DEQ_V1 repair loop — the zero-contradiction guarantee. The gates above are only as good as
@@ -531,9 +582,12 @@
     // buildingModelsSubstructure — "Gap B exemption DECIDED" (4D_SCHEDULE_PERFECTION.md 2026-08-11):
     // annotate, don't suppress. true iff ≥1 element resolves to phase==='Substructure' — seq===1 is
     // that exact test (SEQUENCE_RULES: only IfcFooting/IfcReinforcingBar carry sequence 1, both
-    // Substructure; no name-override assigns seq 1 — verified in rates/sequence_rules.json). false
-    // (Terminal/HHS today) means "this building never modeled a foundation layer at all — weight
-    // findings with that context," never hides or downgrades them.
+    // Substructure; plus, since the big-element follow-up same day, ONE name-override deliberately
+    // assigns seq 1: 'foundation_pile_misclassified_slab' — Terminal's 236 'jkrST_str-fo_pc_rcp'
+    // 30m precast piles authored as IfcSlab, see rates/sequence_rules.json. That flips Terminal to
+    // bms=true — it DOES model a foundation layer, just under the wrong class). false (HHS today)
+    // means "this building never modeled a foundation layer at all — weight findings with that
+    // context," never hides or downgrades them.
     var bms = false;
     for (i = 0; i < elements.length; i++) { if (elements[i].seq === 1) { bms = true; break; } }
     var v = 0;
@@ -563,6 +617,25 @@
                 overlap(S, T)) {
               hasHang = true;
               var eh = sched[S.guid].end; if (eh > se) se = eh; } } }
+        // §HANG_NEAREST — audit twin of the scheduler's fallback (hangGate/edgeCarrier above):
+        // a BIG pure-sink hanger with zero in-band carriers is audited against the nearest
+        // overlapping pool member above + its co-planar GAP band, exactly what the scheduler now
+        // gates it on. Keeping audit and gate symmetric is what keeps floating at its locked
+        // baselines (a wider audit alone would flag carriers the scheduler never waited for).
+        if (!hasHang && !tPool && !tWall && bboxVol(T) > BIG_ELEMENT_VOL) {
+          var nbA = Infinity, seenN = {};
+          for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
+            for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenN[S.guid] || S.guid === T.guid) continue; seenN[S.guid] = 1;
+              if (S.base_z > T.top_z + GAP && S.base_z < nbA && overlap(S, T)) nbA = S.base_z; } }
+          if (nbA < Infinity) {
+            var seenP = {};
+            for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
+              for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenP[S.guid] || S.guid === T.guid) continue; seenP[S.guid] = 1;
+                if (S.base_z > T.top_z + GAP && S.base_z <= nbA + GAP && overlap(S, T)) {
+                  hasHang = true;
+                  var ehn = sched[S.guid].end; if (ehn > se) se = ehn; } } }
+          }
+        }
       }
       if (se > 0 && sched[T.guid].start < se - 1) { v++; if (collectGuids) collectGuids.push(T.guid); }
       // §SUPPORT_UNCHECKED (warn-only, additive) — 4D_SCHEDULE_PERFECTION.md §SPEC 2026-08-11 1a/1c,

--- a/viewer/tests/witness_big_element_support_coverage.js
+++ b/viewer/tests/witness_big_element_support_coverage.js
@@ -53,23 +53,35 @@ function sliceFn(src, name) {
 const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
 
 // The 5 shipped buildings the 1.556 m³ p95 was measured on, with the EXTRACTED (not assumed)
-// buildingModelsSubstructure facts from the 2026-08-11 Q2 extraction: Terminal and HHS model ZERO
-// Substructure-phase elements (no IfcFooting, nothing else matches) — expected and correct, not a
-// bug. EXPECTED unchecked = measured baseline from this witness's own first logged run (repo
-// convention, cf. witness_tm_geo_order_cycles.js floating=8): if it moves EITHER way that is a real
-// behavior change to examine, never to absorb silently. null = measure-only (pre-baseline).
+// buildingModelsSubstructure facts. 2026-08-11 Q2 extraction said Terminal and HHS model ZERO
+// Substructure-phase elements — for HHS that stands; for Terminal it was an artifact of the class
+// lookup: its 236 'jkrST_str-fo_pc_rcp' 30m precast PILES were authored as IfcSlab, now reclassed
+// seq 1 by the 'foundation_pile_misclassified_slab' name-override (rates.js — big-element
+// follow-up, same day), so Terminal is bms=true. EXPECTED unchecked = measured baseline from this
+// witness's own logged runs (repo convention, cf. witness_tm_geo_order_cycles.js floating=8): if
+// it moves EITHER way that is a real behavior change to examine, never to absorb silently.
 const BUILDINGS = [
-  // Baselines MEASURED 2026-08-11 (this witness's own first logged run, bigsup_measure.log):
-  //   Terminal big=1333 unchecked=279 (IfcSlab:236,IfcBeam:22,...)      floating=8 (the known tail)
-  //   Hospital big=4314 unchecked=503 (IfcDuctSegment:139,IfcPlate:83,…) floating=0
-  //   Duplex   big=49   unchecked=6   (IfcSlab:4,IfcWallStandardCase:2)  floating=0
-  //   HHS      big=239  unchecked=21  (IfcFlowSegment:11,IfcSlab:5,…)    floating=0
-  //   Clinic   big=442  unchecked=22  (IfcWallStandardCase:10,…)         floating=1
-  { file: 'Terminal_extracted.db',             name: 'Terminal', bms: false, expectedUnchecked: 279 },
-  { file: 'Hospital_extracted.db',             name: 'Hospital', bms: true,  expectedUnchecked: 503 },
+  // Baselines RE-MEASURED 2026-08-11 (big-element follow-up, bigsup_after_fix2.log) after three
+  // deliberate changes, each with its own delta reasoned below (first-run baselines in parens):
+  //  (1) §HANG_NEAREST fallback (schedule_gate.js) — big pure-sink hangers (rod-suspended MEP etc.)
+  //      now find their real carrier above: Terminal −11 (8 IfcDuctSegment+3 IfcDuctFitting),
+  //      Hospital −264 (139 IfcDuctSegment, 60 IfcDuctFitting, …), HHS −10, Clinic −6.
+  //  (2) pile name-override — Terminal −236 IfcSlab (piles, now seq-1 exempt; big pop 1333→1097).
+  //  (3) harness key fix (SEQUENCE_NAME_OVERRIDES was read from a key the JSON never had — these
+  //      witnesses silently ran with NAME OVERRIDES OFF while the live viewer always ran with
+  //      rates.js's in-file copy ON; now live-parity): curtainwall glazing/mullions (IfcPlate/
+  //      IfcMember→seq 7 sinks) re-mix Hospital/HHS/Clinic counts — Hospital's 83 unchecked
+  //      IfcPlate resolve via (1), Clinic gains 5 IfcWallStandardCase/IfcMember (net 0).
+  //   Terminal big=1097 unchecked=32  (IfcBeam:22,IfcColumn:7,IfcWall:3)  floating=8 (known tail, HELD)
+  //   Hospital big=4314 unchecked=177 (IfcBeam:56,IfcWallStandardCase:45,…) floating=0 (HELD)
+  //   Duplex   big=49   unchecked=6   (IfcSlab:4,IfcWallStandardCase:2)     floating=0 (HELD)
+  //   HHS      big=239  unchecked=13  (IfcSlab:5,IfcFlowSegment:3,…)        floating=0 (HELD)
+  //   Clinic   big=442  unchecked=22  (IfcWallStandardCase:15,IfcMember:3,…) floating=1 (HELD)
+  { file: 'Terminal_extracted.db',             name: 'Terminal', bms: true,  expectedUnchecked: 32 },   // was bms:false/279
+  { file: 'Hospital_extracted.db',             name: 'Hospital', bms: true,  expectedUnchecked: 177 },  // was 503
   { file: 'Duplex_extracted.db',               name: 'Duplex',   bms: true,  expectedUnchecked: 6 },
-  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 21 },
-  { file: 'Clinic_extracted.db',               name: 'Clinic',   bms: true,  expectedUnchecked: 22 },
+  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 13 },   // was 21
+  { file: 'Clinic_extracted.db',               name: 'Clinic',   bms: true,  expectedUnchecked: 22 },   // count HELD, mix changed (see 3)
 ];
 
 (async () => {
@@ -94,7 +106,7 @@ const BUILDINGS = [
     const sandbox = {
       console: console,
       performance: { now: () => Date.now() },
-      window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || [] },
+      window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
       A: function () { return { db: db }; },
     };
     vm.createContext(sandbox);
@@ -112,7 +124,7 @@ const BUILDINGS = [
     // Gap-B fact check: buildingModelsSubstructure per the same seq===1 test auditFloating applies.
     const bms = geoEls.some(e => e.seq === 1);
     assert(bms === B.bms, 'W-BIGSUP-' + B.name + '-2 buildingModelsSubstructure=' + bms +
-      ' matches the 2026-08-11 Q2 extraction (expected ' + B.bms + (B.bms ? '' : ' — no foundation layer modeled, expected and correct') + ')');
+      ' matches the EXTRACTED per-building fact (expected ' + B.bms + (B.bms ? '' : ' — no foundation layer modeled, expected and correct') + ')');
 
     const bigEls = geoEls.filter(e => e.seq !== 1 && (e.x1 - e.x0) * (e.y1 - e.y0) * (e.top_z - e.base_z) > BIG);
     const seqByGuid = {};

--- a/viewer/tests/witness_gantt_lock_integrity.js
+++ b/viewer/tests/witness_gantt_lock_integrity.js
@@ -120,7 +120,7 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
     console: console,
     performance: { now: () => Date.now() },
     ScheduleGate: ScheduleGate,
-    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || [] },
+    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
     A: function () { return { db: db }; },
     _ops: [],
   };

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -87,7 +87,7 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   const sandbox = {
     console: console,
     performance: { now: () => Date.now() },
-    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || [] },
+    window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
     A: function () { return { db: db }; },
   };
   vm.createContext(sandbox);


### PR DESCRIPTION
Follow-up to #1277. Root-caused the two largest §SUPPORT_UNCHECKED offender classes on real DB geometry — two different mechanisms, two different fixes:

## Terminal's 236 IfcSlab → misclassified foundation piles (name-override reclass)
`jkrST_str-fo_pc_rcp:300 x 300mm` = 300×300mm × 30.15m precast RC **piles** authored as IfcSlab. All sit at the building's absolute lowest z (base −16.04..−15.94 vs model min −16.04) with nothing modeled beneath — genuinely ground-bearing Substructure (archived "Gap A: IfcPile has no SEQUENCE_RULES entry", arriving disguised as IfcSlab). New `foundation_pile_misclassified_slab` name-override (rates.js + sequence_rules.json) → Substructure/seq 1 → 1c-exempt; Terminal flips `buildingModelsSubstructure` false→true. Pattern `str-fo|\bpile\b` measured against every shipped buildings/*.db: exactly those 236 match, nothing else.

## Hospital's 139 IfcDuctSegment → §HANG_NEAREST fallback (real detection gap)
The 1a hang path IS exercised (no bug in #1277) — but the ±0.5m carrier band assumes direct mount; all 139 have real pool structure 0.51–4.61m above (p50 1.22m): rod-suspended MEP. Fix: for a BIG (> BIG_ELEMENT_VOL) pure-SINK hanger with zero in-band carriers, carrier = nearest overlapping pool member above + its co-planar GAP band — applied symmetrically at DAG `edgeCarrier` / `hangGate` / `auditFloating`. Provably acyclic (sinks have no outgoing DAG edges). Parameter-free (no invented reach constant). Small sinks deliberately unchanged (all-sink widening would re-gate 48,904 elements — measured — a Part-2-scale reorder).

## Witness-harness bug found on the way (fixed)
Three witnesses read `rulesJson.SEQUENCE_NAME_OVERRIDES` but the JSON key is `NAME_OVERRIDES` — they silently ran with name overrides OFF while the live viewer runs rates.js's in-file copy ON. Now live-parity.

## Numbers (logs read, not exit codes)
| Building | unchecked before | after | floating |
|---|---|---|---|
| Terminal | 279 (bms=false) | **32** (bms=true) | 8 HELD |
| Hospital | 503 | **177** | 0 HELD |
| HHS | 21 | **13** | 0 HELD |
| Clinic | 22 | 22 (mix changed) | 1 HELD |
| Duplex | 6 | 6 | 0 HELD |
| **Total** | **831/6,377** | **250/6,141** | — |

- witness_big_element_support_coverage **26/26**, baselines re-measured deliberately (delta per cause in the witness comment)
- witness_tm_geo_order_cycles **5/5**: cycles=0, floating=8 EXACT, DEQ shifted=0, `§GEO_ORDER hangNearest=217`
- witness_gantt_lock_integrity **19/19**: §LI_COST 63,415 elements floating=0
- Zero regressions: test_schedule_gate, default_engine_quality (0/48428), geometric_support_order (0 shifts), facade/host order, gantt native/shift/baseline/undo/shop-dates; geo_support_leak pre-existing FAIL unchanged (10/7 identical)

Spec/provenance: bim-compiler `prompts/archive/4D_BIG_ELEMENT_SUPPORT_COVERAGE_2026-08-11.md` + dated follow-up section in `prompts/4D_SCHEDULE_PERFECTION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1WwhN6kdzWuCuxj4ZtnSe