### PR TITLE
feat(4d): §TIER_SERIAL phase-window collapse — two-tier display timeline (serial backbone + concurrent pool)

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -292,6 +292,34 @@ var SEQUENCE_NAME_OVERRIDES = [
     phase: 'Substructure',
     sequence: 1,
     resource: 'CONCRETE_GANG'
+  },
+  // §FURNITURE_TIER1_SAFEGUARD (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §SPEC
+  // 2026-08-11 evening — Witness: witness_tier_serial_display.js W-TS-4): §TIER_SERIAL makes
+  // Substructure→Superstructure→Architecture a STRICT serial backbone (time_machine.js
+  // _twoTierRemap), so furniture-like content exported under a generic catch-all class
+  // (IfcBuildingElementProxy/IfcBuildingElementPart resolve to Architecture/seq 5 — Tier 1) would
+  // gate real structural phase completion on a chair or desk. Genuinely-tagged furniture
+  // (IfcFurniture/IfcFurnishingElement) already resolves to Finishes/seq 11 — safe, untouched.
+  // MEASURED before writing (repo rule: extract, never guess a regex — furniture_measure.log,
+  // 2026-08-11): a naive unscoped substring pattern gave 327 false positives ('table' ⊂
+  // 'adjus-TABLE' shower head; 'cabinet' = a fire-extinguisher cabinet already correctly in
+  // MEP Final/Tier 2) — hence word boundaries + the class gate. Scoped run (word-boundary,
+  // generic buckets only): ZERO live hits across all 5 shipped buildings — this safeguard is
+  // PROACTIVE (the pile-misclassification precedent above proves the generic-catch-all bug class
+  // is real on real-world IFCs), not a fix for a live defect. Known, deliberate NON-target:
+  // Terminal's 'Floor:Table Top:904745' (IfcSlab, 3.96×22.43m ×150mm built-in counter, Aras
+  // Tanah) stays Superstructure — IfcSlab is an unambiguous class ("don't touch classes that are
+  // already unambiguous", spec), and as a seq≤4 support-pool member reclassifying it would
+  // perturb the locked floating/§SUPPORT_UNCHECKED baselines; the witness NAMES it as a
+  // reported (not gated) case instead of silently absorbing it.
+  {
+    id: 'furniture_generic_bucket',
+    classes: ['IfcBuildingElementProxy', 'IfcBuildingElementPart'],
+    pattern: '\\b(chair|desk|table|sofa|couch|settee|cabinet|wardrobe|shelf|shelving|bookcase|credenza|armchair|furniture|dresser|nightstand|stool|bench)\\b',
+    flags: 'i',
+    phase: 'Finishes',
+    sequence: 11,
+    resource: 'FINISHER'
   }
 ];
 

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -41,6 +41,19 @@
       "sequence": 1,
       "resource": "CONCRETE_GANG",
       "reason": "Slab-on-grade was NAMED in the original 1c spec ('IfcFooting/IfcPile/slab-on-grade rests on unmodeled soil') but only class-level seq-1 rules ever implemented it — a slab-on-grade authored as plain IfcSlab lands at seq 4 and, being genuinely ground-bearing (compacted fill between it and the footing tops, ~1.1m gap measured on Duplex), shows up as a permanent §SUPPORT_UNCHECKED finding. Pattern MEASURED against every shipped buildings/*.db 2026-08-11: under the IfcSlab class gate it matches exactly Duplex 4 ('127mm Slab on Grade' ×2, '150mm Exterior Slab on Grade' ×2, bases −0.14..−0.13) + Clinic 4 ('150mm Slab on Grade' ×3, '150mm Exterior Slab on Grade' ×1, bases −1.37..−0.15) and nothing else — every hit at true grade level over its own building's footings; a Clinic 'Floor:150mm Slab on Grade' IfcOpeningElement exists but is excluded by the class gate. See bim-compiler prompts/4D_SCHEDULE_PERFECTION.md 2026-08-11 closure pass."
+    },
+    {
+      "id": "furniture_generic_bucket",
+      "classes": [
+        "IfcBuildingElementProxy",
+        "IfcBuildingElementPart"
+      ],
+      "pattern": "\\b(chair|desk|table|sofa|couch|settee|cabinet|wardrobe|shelf|shelving|bookcase|credenza|armchair|furniture|dresser|nightstand|stool|bench)\\b",
+      "flags": "i",
+      "phase": "Finishes",
+      "sequence": 11,
+      "resource": "FINISHER",
+      "reason": "§FURNITURE_TIER1_SAFEGUARD (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §SPEC 2026-08-11 evening — Witness: witness_tier_serial_display.js W-TS-4): §TIER_SERIAL makes Substructure→Superstructure→Architecture a STRICT serial backbone, so furniture-like content exported under a generic catch-all class (IfcBuildingElementProxy/IfcBuildingElementPart resolve to Architecture/seq 5 — Tier 1) would gate real structural phase completion on a chair or desk. Genuinely-tagged furniture (IfcFurniture/IfcFurnishingElement) already resolves to Finishes/seq 11 — untouched. MEASURED before writing (furniture_measure.log 2026-08-11): a naive unscoped substring pattern gave 327 false positives ('table' substring-matched 'adjustable' in a shower-head name; 'cabinet' matched a fire-extinguisher cabinet already correctly in MEP Final/Tier 2) — hence word boundaries + this class gate. Scoped run: ZERO live hits across all 5 shipped buildings — proactive safeguard (the pile-misclassification precedent proves this bug class is real on real-world IFCs), not a live-defect fix. Known deliberate non-target: Terminal 'Floor:Table Top:904745' (IfcSlab 3.96×22.43m ×150mm built-in counter) stays Superstructure — IfcSlab is an unambiguous class with two measured overrides already, and as a seq<=4 support-pool member reclassifying it would perturb locked floating/§SUPPORT_UNCHECKED baselines; the witness NAMES it as a reported (not gated) case."
     }
   ],
   "SEQUENCE_RULES": {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v977';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v978';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_tier_serial_display.js
+++ b/viewer/tests/witness_tier_serial_display.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+// witness_tier_serial_display.js — §TIER_SERIAL (2026-08-11, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md §SPEC 2026-08-11 evening: phase-window collapse).
+//
+// ISSUE this witness proves/disproves: the two-tier display remap (time_machine.js _twoTierRemap)
+// claims (a) the structural backbone Substructure→Superstructure→Architecture is STRICTLY SERIAL
+// on the displayed timeline, (b) the remap NEVER moves an element earlier than its generative
+// (computeSchedule) time — the property that makes support-order preservation provable, not
+// asserted, (c) Tier 2 (MEP Rough-in / MEP Final / Finishes) stays ONE CONCURRENT POOL — no
+// phase-window barrier was smuggled in for non-backbone phases, (d) the furniture safeguard
+// ('furniture_generic_bucket' NAME_OVERRIDE) keeps furniture-named generic-class elements out of
+// Tier 1 on every shipped building, and (e/f) the two open spec questions get REAL numbers:
+// the schedule-duration cost of serializing the backbone (§TIER_COST) and the Movie-Maker
+// phase-sightability structure (§TIER_MOVIE — each backbone phase owns a contiguous, exclusive
+// slice of the displayed timeline, which is exactly what a linear movie clock renders).
+//
+//   W-TS-1  Tier-1 strictly serial: _twoTierRemap reports tier1OverlapPairs=0 on every building.
+//           >0 = the backbone still overlaps — the capstone claim is false.
+//   W-TS-2  No new support violations: auditFloating over the REMAPPED times <= auditFloating over
+//           the RAW generative times (display may REPAIR the known floating tail, never grow it).
+//   W-TS-3  Monotone: zero elements start EARLIER than their generative start (earlier = the one
+//           direction that can break support order; shifts and sweep pushes only ever move later).
+//   W-TS-4  Furniture safeguard: zero furniture-named elements in the GENERIC buckets
+//           (IfcBuildingElementProxy/IfcBuildingElementPart) resolve into a Tier-1 phase after
+//           NAME_OVERRIDES run. Non-generic Tier-1 classes are REPORTED and LOCKED (Terminal has
+//           exactly 1 known case — 'Floor:Table Top:904745', an IfcSlab built-in counter,
+//           deliberately NOT reclassified: unambiguous class + seq<=4 support-pool member, see
+//           rates.js override comment) — a change in that count is a real data/rules change.
+//   W-TS-5  Tier-2 concurrency preserved: >=1 pair of present Tier-2 phase windows OVERLAP on the
+//           displayed timeline (a serialized Tier 2 would betray the "one concurrent pool" spec).
+//   W-TS-6  §TIER_COST / §TIER_MOVIE report lines carry the real numbers (duration cost + phase
+//           timeline shares) — asserted present + internally consistent (spans positive, shares
+//           sum <= 100.5%), values reported for the human decision, not gated on an invented cap.
+//
+// Approximation caveat (same as witness_tm_geo_order_cycles): the x-ray element build carries no
+// resource/installSecs, so durations come from ScheduleAuthor._installSecs with real class
+// fragmentation + linear weighting (the same single-source formula injectGantt's getInstallSecs
+// uses) — real per-element durations, node-side, no browser.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node tests/witness_tier_serial_display.js  (from viewer/)
+// Read the § log lines, not exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function finish() {
+  console.log('\n§TIER_SERIAL_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+}
+
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+// the shipped Tier-1 order constant rides along verbatim (a var, not a function — assert found)
+const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+if (tmSrc.indexOf(tierOrderLine) < 0) { assert(false, 'W-TS-0 _TIER1_ORDER constant found in time_machine.js'); finish(); }
+
+const sliced = [
+  tierOrderLine,
+  sliceFn(tmSrc, '_promoteRoofLoadPath'),
+  sliceFn(tmSrc, '_buildXrayElements'),
+  sliceFn(tmSrc, '_tier1Extents'),
+  sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'),
+  sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap')
+].join('\n');
+
+// RATES (QS/BOQ table) for fragmentation/linear weighting — same slice idiom as
+// witness_og_guard_bearing_bound.js loadRules().
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  const end = txt.indexOf('};', defIdx) + 2;
+  return (new Function(txt.slice(start, end) + '\n return RATES;'))();
+}
+
+const TIER1 = { Substructure: 1, Superstructure: 1, Architecture: 1 };
+const TIER2 = ['MEP Rough-in', 'MEP Final', 'Finishes'];
+const FURN_RE = /\b(chair|desk|table|sofa|couch|settee|cabinet|wardrobe|shelf|shelving|bookcase|credenza|armchair|furniture|dresser|nightstand|stool|bench)\b/i;
+const GENERIC = { IfcBuildingElementProxy: 1, IfcBuildingElementPart: 1 };
+// LOCKED baseline (measured 2026-08-11, furniture_measure.log): furniture-named elements in
+// NON-generic Tier-1 classes — Terminal's single IfcSlab 'Floor:Table Top:904745' counter, 0
+// everywhere else. Movement either way = a real data/rules change to examine, not absorb.
+const NONGENERIC_T1_BASELINE = { Terminal: 1, Hospital: 0, Duplex: 0, HHS_Office_Federated: 0, Clinic: 0 };
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDINGS = ['Terminal', 'Hospital', 'Duplex', 'HHS_Office_Federated', 'Clinic'];
+const D = 86400000;
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+  assert(NO.some(o => o.id === 'furniture_generic_bucket'),
+    'W-TS-0 furniture_generic_bucket override shipped in rates/sequence_rules.json');
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(dbPath)) { assert(false, 'W-TS fixture missing: ' + dbPath); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+
+    // ── shipped element build (sliced, never reimplemented) ──
+    const sandbox = {
+      console: { log: () => {}, warn: () => {} },
+      performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+      ScheduleGate: ScheduleGate,
+      Math: Math,
+      A: () => ({ db: db })
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap;', sandbox);
+    const els = sandbox.__bxe();
+    if (!els || !els.length) { assert(false, 'W-TS ' + bld + ' element build produced nothing'); db.close(); continue; }
+
+    // guid → (cls, name): phase + real durations need the element name (overrides) — the x-ray
+    // build applies matchRule internally for seq but does not export name/phase.
+    const nameOf = {}, clsOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { clsOf[v[0]] = v[1]; nameOf[v[0]] = v[2]; });
+
+    // real durations — the same single-source formula injectGantt's getInstallSecs uses
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+
+    // furniture safeguard scan (whole elements_meta, not just geo) — W-TS-4
+    let furnGenericT1 = 0, furnNonGenericT1 = 0;
+    const furnNonGenericNames = [];
+    if (nr.length) nr[0].values.forEach(v => {
+      const cls = v[1], name = v[2];
+      if (cls === 'IfcOpeningElement' || cls === 'IfcSpace') return;
+      if (!FURN_RE.test(name)) return;
+      const rule = ScheduleAuthor.matchNameOverride(cls, name, NO) || ScheduleAuthor.matchRule(cls, SR, SD);
+      if (!TIER1[rule.phase]) return;
+      if (GENERIC[cls]) furnGenericT1++;
+      else { furnNonGenericT1++; if (furnNonGenericNames.length < 5) furnNonGenericNames.push(cls + ':"' + name + '"'); }
+    });
+    assert(furnGenericT1 === 0, 'W-TS-4a ' + bld + ' zero furniture-named GENERIC-bucket elements in Tier 1 after overrides (got ' + furnGenericT1 + ')');
+    assert(furnNonGenericT1 === (NONGENERIC_T1_BASELINE[bld] || 0),
+      'W-TS-4b ' + bld + ' furniture-named NON-generic Tier-1 classes locked at ' + (NONGENERIC_T1_BASELINE[bld] || 0) +
+      ' (got ' + furnNonGenericT1 + (furnNonGenericNames.length ? ' — ' + furnNonGenericNames.join(', ') : '') + ') — reported, deliberately not reclassified');
+
+    // ── generative schedule (RAW — the proven layer, untouched by this PR) ──
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const cls = e.cls, name = nameOf[e.guid] || '';
+      const rule = ScheduleAuthor.matchNameOverride(cls, name, NO) || ScheduleAuthor.matchRule(cls, SR, SD);
+      if (!e.phase) e.phase = rule.phase;              // promoted slabs already carry phase='Architecture'
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio);
+    });
+    db.close();
+    const maxCrews = {};
+    for (const rk in LR) if (LR[rk].max_crews) maxCrews[rk] = LR[rk].max_crews;
+
+    const quiet = console.log; console.log = () => {};   // computeSchedule's own § lines counted elsewhere
+    let sched, rawFloat;
+    try {
+      sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews);
+      rawFloat = ScheduleGate.auditFloating(geoEls, sched);
+    } finally { console.log = quiet; }
+    let rawEnd = 0;
+    for (const g in sched) if (sched[g].end > rawEnd) rawEnd = sched[g].end;
+
+    // ── the shipped two-tier remap (sliced) ──
+    const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1,
+      cls: e.cls, seq: e.seq, phase: e.phase }));
+    const tierLines = [];
+    sandbox.console = { log: (...a) => tierLines.push(a.join(' ')), warn: () => {} };
+    vm.runInContext('this.__lastStats = null;', sandbox);
+    sandbox.__items = items;
+    vm.runInContext('this.__lastStats = this.__remap(this.__items);', sandbox);
+    const stats = sandbox.__lastStats;
+    const tierLine = tierLines.find(l => l.indexOf('§TIER_SERIAL ') === 0) || '';
+    console.log(tierLine || ('§TIER_SERIAL <no log captured for ' + bld + '>'));
+
+    // W-TS-1 — strict serial backbone (dag-wins-excluded extents; the dag-wins population is
+    // counted + locked in W-TS-1b, never hidden)
+    assert(stats && stats.overlapPairs === 0,
+      'W-TS-1 ' + bld + ' Tier-1 backbone strictly serial (tier1OverlapPairs=' + (stats ? stats.overlapPairs : '?') + ', iterations=' + (stats ? stats.iterations : '?') + ')');
+    // §TIER_DAG_WINS lock (measured 2026-08-11, stragglers.log + promoted_deps.log): elements the
+    // support DAG itself places inside a LATER backbone phase — support order wins for them.
+    // Hospital/Clinic: isolated forward deps (foundation slab / slab-on-grade poured around
+    // full-height columns). Terminal: the wall-carried tower cone — 45 direct "upper column
+    // stands on a load-path-PROMOTED structural flat slab" edges pull their whole dependency
+    // cone (~24k of 34.8k Superstructure) after Architecture-phase carriers; HHS: the same shape
+    // through its 10 promoted slabs (294 direct bearers). A frame building (Hospital) has almost
+    // none — the measured counts ARE the building topology. Movement either way = a real
+    // data/topology/rules change to examine, not absorb.
+    const DAGWINS_BASELINE = { Terminal: 24007, Hospital: 9, Duplex: 0, HHS_Office_Federated: 420, Clinic: 6 };
+    assert(stats && stats.dagWins === DAGWINS_BASELINE[bld],
+      'W-TS-1b ' + bld + ' DAG-forced cross-phase population locked at ' + DAGWINS_BASELINE[bld] +
+      ' (got ' + (stats ? stats.dagWins : '?') + ') — support order wins for these, counted never hidden');
+
+    // W-TS-3 — monotone (never earlier than generative)
+    let earlier = 0;
+    items.forEach(it => { if (it.s < sched[it.guid].start) earlier++; });
+    assert(earlier === 0, 'W-TS-3 ' + bld + ' zero elements displayed EARLIER than their generative start (got ' + earlier + ')');
+
+    // W-TS-2 — no new support violations on the displayed timeline
+    const dispMap = {};
+    items.forEach(it => { dispMap[it.guid] = { start: it.s, end: it.e }; });
+    console.log = () => {};
+    let dispFloat;
+    try { dispFloat = ScheduleGate.auditFloating(geoEls, dispMap); } finally { console.log = quiet; }
+    assert(dispFloat <= rawFloat,
+      'W-TS-2 ' + bld + ' displayed floating <= generative floating (' + dispFloat + ' <= ' + rawFloat + ') — remap repairs, never breaks');
+
+    // per-phase displayed windows
+    const ext = {};
+    items.forEach(it => {
+      const x = ext[it.phase] || (ext[it.phase] = { minS: Infinity, maxE: -Infinity, n: 0 });
+      if (it.s < x.minS) x.minS = it.s;
+      if (it.e > x.maxE) x.maxE = it.e;
+      x.n++;
+    });
+    let dispEnd = 0, dispBase = Infinity;
+    items.forEach(it => { if (it.e > dispEnd) dispEnd = it.e; if (it.s < dispBase) dispBase = it.s; });
+
+    // W-TS-5 — Tier 2 stays one concurrent pool (some pair of present Tier-2 windows overlaps)
+    const t2Present = TIER2.filter(ph => ext[ph] && ext[ph].n > 0);
+    if (t2Present.length >= 2) {
+      let overlapPair = false;
+      for (let i = 0; i < t2Present.length && !overlapPair; i++)
+        for (let j = i + 1; j < t2Present.length && !overlapPair; j++) {
+          const a = ext[t2Present[i]], b = ext[t2Present[j]];
+          if (a.minS < b.maxE && b.minS < a.maxE) overlapPair = true;
+        }
+      assert(overlapPair, 'W-TS-5 ' + bld + ' Tier-2 phases remain CONCURRENT (>=1 overlapping window pair among ' + t2Present.join('/') + ')');
+    } else {
+      console.log('  INFO W-TS-5 ' + bld + ' <2 Tier-2 phases present (' + t2Present.join('/') + ') — concurrency pair check n/a');
+    }
+
+    // W-TS-6 — §TIER_COST (open question 2: the real serialization cost) + §TIER_MOVIE (open
+    // question 3: phase sightability on the movie's linear clock)
+    const rawDays = rawEnd / D, twoTierDays = (dispEnd - dispBase) / D;
+    console.log('§TIER_COST bld=' + bld + ' generativeDays=' + rawDays.toFixed(1) +
+      ' twoTierDays=' + twoTierDays.toFixed(1) + ' ratio=' + (twoTierDays / Math.max(rawDays, 1e-9)).toFixed(2) +
+      ' floating raw=' + rawFloat + ' displayed=' + dispFloat);
+    const span = Math.max(1, dispEnd - dispBase);
+    // movie slices measured over the SERIALIZED backbone (dag-wins excluded — that population
+    // deliberately rides the DAG through later windows and is reported separately below)
+    const serExt = {};
+    items.forEach(it => {
+      if (it._t1Straggler) return;
+      const x = serExt[it.phase] || (serExt[it.phase] = { minS: Infinity, maxE: -Infinity, n: 0 });
+      if (it.s < x.minS) x.minS = it.s;
+      if (it.e > x.maxE) x.maxE = it.e;
+      x.n++;
+    });
+    const parts = [];
+    let shareSum = 0, positive = true;
+    ['Substructure', 'Superstructure', 'Architecture'].forEach(ph => {
+      const x = serExt[ph]; if (!x || !x.n) return;
+      const sh = (x.maxE - x.minS) / span * 100;
+      if (!(x.maxE > x.minS)) positive = false;
+      shareSum += sh;
+      parts.push(ph + '=' + sh.toFixed(1) + '%[' + ((x.minS - dispBase) / D).toFixed(0) + '..' + ((x.maxE - dispBase) / D).toFixed(0) + 'd]n=' + x.n);
+    });
+    let t2Concurrent = 0, t2N = 0;
+    items.forEach(it => {
+      if (TIER2.indexOf(it.phase) < 0) return;
+      t2N++;
+      for (const ph of ['Substructure', 'Superstructure', 'Architecture']) {
+        const x = ext[ph]; if (!x) continue;
+        if (it.s < x.maxE && it.e > x.minS) { t2Concurrent++; break; }
+      }
+    });
+    console.log('§TIER_MOVIE bld=' + bld + ' backboneShares ' + parts.join(' ') +
+      ' | dagWinsRidingLaterWindows=' + (stats ? stats.dagWins : '?') +
+      ' | tier2 n=' + t2N + ' runningConcurrentWithBackbone=' + t2Concurrent +
+      ' (' + (t2N ? (t2Concurrent / t2N * 100).toFixed(0) : 0) + '%) — serialized backbone slices are exclusive+contiguous, Tier 2 fills alongside');
+    assert(positive && shareSum <= 100.5,
+      'W-TS-6 ' + bld + ' backbone movie slices well-formed (each present serialized phase >0 span; exclusive shares sum ' + shareSum.toFixed(1) + '% <= 100%)');
+  }
+
+  finish();
+})().catch(e => { console.error('WITNESS CRASH', e); assert(false, 'W-TS crash: ' + e.message); finish(); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3694,6 +3694,409 @@
     console.log('§XRAY_CACHE_BUILD total_ms=' + (performance.now() - _xt0).toFixed(1));
   }
 
+  // ── §TIER_SERIAL (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §SPEC 2026-08-11
+  // evening: phase-window collapse — the capstone piece) ─────────────────────────────────────────
+  // computeSchedule's generative output (the proven support DAG — UNTOUCHED, floating baselines
+  // unchanged) is remapped for DISPLAY into a two-tier structure:
+  //   Tier 1 — the structural backbone (Substructure → Superstructure → Architecture) is STRICTLY
+  //   SERIAL: each phase's last element completes before the next phase's first element starts.
+  //   "Never appears before its support" becomes a structural guarantee for the backbone instead
+  //   of a corrected-after-the-fact repair. Deliberate, user-confirmed refinement of the
+  //   2026-08-02 §4D_BAND_MONOTONIC ruling ("ARCH/STR should be exempt as they are the physical
+  //   foundation. Separate unrelated disciplines can run parallel thereafter if construction
+  //   practice permits") — the per-trade storey-by-storey discipline itself lives inside
+  //   computeSchedule and is inherited unchanged: this remap never REORDERS the generative
+  //   timeline, it only shifts whole phase groups later and pushes dependents after supports.
+  //   Tier 2 — everything else (MEP Rough-in, MEP Final, Finishes; FP/ELEC/ACMV/PLB and the
+  //   generic undifferentiated MEP bucket included — DECIDED: no special-case for it) stays ONE
+  //   CONCURRENT POOL: no artificial phase-window barrier between disciplines. Each element is
+  //   still individually gated by the real support DAG via _ogSupportSweep (bearing + hang +
+  //   §OG_BEARING_BOUND two-tier rule) — which is what actually prevents "built before support";
+  //   the phase bucket only ever affected display grouping.
+  // Misclassified-furniture safeguard: rates.js/sequence_rules.json 'furniture_generic_bucket'
+  // NAME_OVERRIDE keeps furniture-named generic-class elements out of Tier 1 entirely.
+  // Witness: viewer/tests/witness_tier_serial_display.js (W-TS-1..6, all 5 shipped buildings).
+  var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];
+
+  // Backbone phase extents over the SERIALIZABLE population — elements marked _t1Straggler are
+  // excluded (see §TIER_STRAGGLER in _twoTierRemap: the measured, DAG-forced cross-phase tail).
+  function _tier1Extents(items) {
+    var ext = {};
+    items.forEach(function (it) {
+      if (it._t1Straggler || _TIER1_ORDER.indexOf(it.phase) < 0) return;
+      var x = ext[it.phase] || (ext[it.phase] = { minS: Infinity, maxE: -Infinity });
+      if (it.s < x.minS) x.minS = it.s;
+      if (it.e > x.maxE) x.maxE = it.e;
+    });
+    return ext;
+  }
+
+  // Uniform per-phase-group shift: phase k starts no earlier than phase k-1's last end. A uniform
+  // shift preserves all within-group generative order, and cross-group Tier-1 support edges only
+  // ever point BACKWARD in _TIER1_ORDER (walls carry only load-path-PROMOTED slabs, which
+  // _promoteRoofLoadPath re-phases to Architecture — no Architecture→Superstructure support edge
+  // exists) — the measured exceptions are exactly the §TIER_STRAGGLER set, excluded here and
+  // governed purely by _tierAuditRegate instead.
+  function _tier1Serialize(items) {
+    var ext = _tier1Extents(items);
+    var deltas = {}, prevEnd = -Infinity;
+    _TIER1_ORDER.forEach(function (ph) {
+      var x = ext[ph]; if (!x) return;   // phase absent (e.g. HHS models no Substructure)
+      var d = prevEnd > x.minS ? prevEnd - x.minS : 0;
+      deltas[ph] = d;
+      prevEnd = x.maxE + d;
+    });
+    items.forEach(function (it) {
+      if (it._t1Straggler) return;       // stragglers ride the regate, never the group shift
+      var d = deltas[it.phase];
+      if (d) { it.s += d; it.e += d; }
+    });
+    return deltas;
+  }
+
+  // 0 = the Tier-1 chain is strictly serial: for consecutive PRESENT backbone phases, phase k's
+  // last end <= phase k+1's first start (transitive across the chain — each window is well-formed).
+  // Straggler-excluded by _tier1Extents; the straggler count itself is reported, never hidden.
+  function _tier1Protrusion(items) {
+    var ext = _tier1Extents(items);
+    var present = _TIER1_ORDER.filter(function (ph) { return ext[ph]; });
+    var overlapping = 0;
+    for (var i = 0; i + 1 < present.length; i++) {
+      if (ext[present[i]].maxE > ext[present[i + 1]].minS) overlapping++;
+    }
+    return overlapping;
+  }
+
+  // ── §TIER_REGATE — audit-physics display re-gate (the remap's push pass) ─────────────────────
+  // MUST use the SAME physics as schedule_gate.js auditFloating()/the generative gates — structGrid
+  // INCLUDES promoted roof slabs, bearing takes the max end over ALL carriers (enveloping included),
+  // hang + §HANG_NEAREST fallback + both antisymmetry exclusions — NOT the §OG_BEARING_BOUND-bounded
+  // guard physics (_ogSupportSweep). MEASURED 2026-08-11, first witness run of this lane: re-gating
+  // with guard physics left 1,383 audit-visible floaters on HHS alone — every rooftop/hanging
+  // element whose carrier is a PROMOTED slab (Architecture phase, shifted later by Tier-1
+  // serialization) that the guard's seq<=4-only grid cannot see. schedule_gate.js is explicitly
+  // untouched by this lane (spec: computeSchedule AND auditFloating stay as-is), so this is a
+  // deliberate, WITNESS-PINNED mirror: witness_tier_serial_display.js W-TS-2 runs the REAL
+  // auditFloating over this pass's output on all 5 shipped buildings — any drift between this
+  // mirror and the canonical physics surfaces there as displayed-floating > generative-floating.
+  // Push-only (start moves LATER, duration kept), fixpoint <=16 sweeps (monotone pushes over the
+  // acyclic support relation — the DAG's own convergence argument). Note the generative times
+  // already satisfy this physics (§SUPPORT_CHECK floating baselines), so on an unshifted timeline
+  // this pass pushes at most the known raw floating tail.
+  function _tierAuditRegate(items, exempt, dryRun) {
+    var EPS = 0.05, GAP = 0.5;
+    var CELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
+    var BIGVOL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.BIG_ELEMENT_VOL) || 1.556;
+    var cellsOf = function (e) {
+      var o = [], gi, gj;
+      for (gi = Math.floor(e.x0 / CELL); gi <= Math.floor(e.x1 / CELL); gi++)
+        for (gj = Math.floor(e.y0 / CELL); gj <= Math.floor(e.y1 / CELL); gj++) o.push(gi + ',' + gj);
+      return o;
+    };
+    var xyOverlap = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
+    var structGrid = {}, wallGrid = {};
+    items.forEach(function (e) {
+      var cs = null;
+      if (e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4)) cs = structGrid;
+      else if (e.cls.indexOf('IfcWall') === 0) cs = wallGrid;
+      if (cs) cellsOf(e).forEach(function (c) { (cs[c] = cs[c] || []).push(e); });
+    });
+    // per-element max qualifying-support end — auditFloating's se, on live item times
+    var seFor = function (T) {
+      var se = 0, hasBearing = false, seen = {}, cs = cellsOf(T), p, c, k, arr, S;
+      var pools = (T.cls === 'IfcSlab' && T.seq > 4) ? [structGrid, wallGrid] : [structGrid];
+      for (p = 0; p < pools.length; p++) {
+        for (c = 0; c < cs.length; c++) { arr = pools[p][cs[c]]; if (!arr) continue;
+          for (k = 0; k < arr.length; k++) { S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+            if (S.bz < T.bz - EPS && S.tz >= T.bz - GAP && xyOverlap(S, T)) {
+              hasBearing = true;
+              if (S.e > se) se = S.e; } } }
+      }
+      if (!hasBearing && T.seq > 4) {      // hangs — gate against the carrier above instead
+        var tPool = T.cls === 'IfcSlab' && T.seq > 4;
+        var tWall = T.cls.indexOf('IfcWall') === 0;
+        var hasHang = false, seenH = {};
+        for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
+          for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenH[S.guid] || S.guid === T.guid) continue; seenH[S.guid] = 1;
+            if (S.bz >= T.tz - GAP && S.bz <= T.tz + GAP && S.tz > T.tz + EPS &&
+                !(tPool && T.bz < S.bz - EPS) &&
+                !(tWall && S.cls === 'IfcSlab' && S.seq > 4 &&
+                  T.bz < S.bz - EPS && T.tz >= S.bz - GAP) &&
+                xyOverlap(S, T)) {
+              hasHang = true;
+              if (S.e > se) se = S.e; } } }
+        // §HANG_NEAREST twin — big pure-sink hangers gate on the nearest pool member above + its
+        // co-planar GAP band, exactly what the scheduler/audit gate them on.
+        if (!hasHang && !tPool && !tWall &&
+            (T.x1 - T.x0) * (T.y1 - T.y0) * (T.tz - T.bz) > BIGVOL) {
+          var nbA = Infinity, seenN = {};
+          for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
+            for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenN[S.guid] || S.guid === T.guid) continue; seenN[S.guid] = 1;
+              if (S.bz > T.tz + GAP && S.bz < nbA && xyOverlap(S, T)) nbA = S.bz; } }
+          if (nbA < Infinity) {
+            var seenP = {};
+            for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;
+              for (k = 0; k < arr.length; k++) { S = arr[k]; if (seenP[S.guid] || S.guid === T.guid) continue; seenP[S.guid] = 1;
+                if (S.bz > T.tz + GAP && S.bz <= nbA + GAP && xyOverlap(S, T)) {
+                  if (S.e > se) se = S.e; } } }
+          }
+        }
+      }
+      return se;
+    };
+    // dryRun: one non-mutating pass over CURRENT times → the set of guids violating audit-se.
+    // _twoTierRemap calls this ONCE on the pristine generative times: that set is the DAG's own
+    // deliberate tail (cycle-breaks + unsolvables — e.g. Clinic's parapet-wall/roof-slab loop,
+    // MEASURED 2026-08-11 clinic_cycle.log: chasing it pushed 43k times across 400 sweeps without
+    // converging, the whole building drifting together). Those elements are EXEMPT from pushing —
+    // they ride their group shifts, keeping exactly their raw-relative wrongness, never more.
+    // Every edge this pass DOES enforce was satisfied by the raw generative simultaneously, so the
+    // enforced constraint subgraph provably admits a schedule → the fixpoint exists and monotone
+    // pushes reach it (no cycle-chasing possible by construction).
+    if (dryRun) {
+      var fset = {}, fn = 0;
+      items.forEach(function (T) {
+        var se0 = seFor(T);
+        if (se0 > 0 && T.s < se0 - 1) { fset[T.guid] = 1; fn++; }
+      });
+      return { floatSet: fset, n: fn };
+    }
+    var pushed = 0, sweeps = 0;
+    for (; sweeps < 64; sweeps++) {
+      var moved = 0;
+      items.forEach(function (T) {
+        if (exempt && exempt[T.guid]) return;   // the raw tail — never chased (see dryRun above)
+        var se = seFor(T);
+        if (se > 0 && T.s < se - 1) {     // same -1ms tolerance as auditFloating's floating test
+          var dur = Math.max(60000, T.e - T.s);
+          T.s = se; T.e = se + dur;
+          pushed++; moved++;
+        }
+      });
+      if (!moved) break;
+    }
+    if (pushed) console.log('§TIER_REGATE pushed=' + pushed + ' sweeps=' + (sweeps + 1) +
+      ' (audit-physics display re-gate — dependents pushed after their real supports\' shifted ends)');
+    return { pushed: pushed, sweeps: sweeps };
+  }
+
+  // ── §PHASE_OVERLAP_SUPPORT_GUARD — the support-order sweep, now a NAMED shared pass ──────────
+  // 2026-08-11 §TIER_SERIAL restructure: hoisted VERBATIM out of injectGantt's _cap-only overlay
+  // branch. It now (a) enforces Tier 2's per-element support gating on the DEFAULT generative
+  // display path — its main job under the two-tier design — and (b) verifies/repairs the _cap
+  // global-affine overlay (expected ≈0 pushes there). The block's interior bytes and ORIGINAL
+  // INDENTATION are deliberately preserved: two witnesses (witness_og_guard_bearing_bound.js,
+  // witness_gantt_og_grid_perf.js) slice it by text markers (the _ogCELL declaration → the
+  // §PHASE_OVERLAP_SUPPORT_GUARD log statement, whose historical §PHASE_OVERLAP_BAND wording is
+  // part of the end-mark bytes) and execute it against synthetic _allScheduled arrays —
+  // re-indenting, rewording the log, or renaming variables would rot both (that exact rot killed
+  // witness_gantt_og_grid_perf once already, 2026-08-07..11).
+  // _allScheduled: [{guid,s,e,bz,tz,x0,x1,y0,y1,cls,seq,...}] — mutated in place (including a
+  // bz-ascending sort); s only ever moves LATER (push after real support), duration preserved.
+  function _ogSupportSweep(_allScheduled) {
+      // §PHASE_OVERLAP_SUPPORT_GUARD global pass (see header above). isCarrier/CELL/EPS/GAP are the
+      // SAME role-blind support predicate this file already uses for the generative path
+      // (audit_support_roleblind.js / §SUPPORT_CHECK above) — not a new definition. Processing in
+      // ascending base_z order is safe in ONE pass: a carrier's base_z is always below what it
+      // carries (the support DAG's own topological potential, established by §STAGGER_SUPPORT_ORDER
+      // above), so every true carrier of T has already been visited — and any correction already
+      // applied to it — by the time T is processed.
+      // §XRAY_WALL_SCOPE (found 2026-08-04, live in a real Hospital session — user report: proxy/
+      // misc elements chronologically before columns, "2 trucks came on first! Then walls!"): this
+      // predicate was even more permissive than the two sibling copies already fixed this session
+      // (schedule_gate.js auditFloating(), time_machine.js _buildXraySupportCache) — ANY wall was a
+      // candidate carrier for ANY element, no promoted-roof-slab restriction at all. A wall is only
+      // ever a real candidate carrier for a slab itself promoted to the roof role (seq>4) — same
+      // §4D_ROOF_LOAD_PATH M3 restriction, applied here for the third time this session. Structure
+      // (seq<=4) stays an unconditional carrier candidate for everything — only the wall branch is
+      // now gated on the TARGET being a promoted slab.
+      var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
+      var _ogEPS = 0.05, _ogGAP = 0.5;
+      // §OG_GRID_Z_BAND (2026-08-05, measured not guessed — 4D_SCHEDULE_PERFECTION.md §Open Decisions
+      // named this block "NOT yet measured, prime suspect"). The grid used to bucket by XY only, so
+      // a small-footprint TALL building stacks every floor's structural elements into the SAME cell —
+      // measured 4636ms on Terminal's 48,428 elements (22 stacked storeys, small footprint, worst
+      // cell 379 members) vs 1695ms on Hospital's 63,415 (more elements, but a bigger footprint means
+      // less Z-stacking per cell) — element COUNT alone doesn't predict the cost, per-cell Z-density
+      // does. Bucketing Z too prunes each query to the target's own real vertical neighborhood — the
+      // ONLY z-range `S.bz<T.bz-EPS && |S.tz-T.bz|<=GAP` can ever match — with the identical predicate
+      // inside the loop unchanged, so results are provably identical, only the scan is smaller.
+      var _ogCellsFor = function (x0, x1, y0, y1, z0, z1) {
+        var out = [];
+        for (var cx = Math.floor(x0 / _ogCELL); cx <= Math.floor(x1 / _ogCELL); cx++)
+          for (var cy = Math.floor(y0 / _ogCELL); cy <= Math.floor(y1 / _ogCELL); cy++)
+            for (var cz = Math.floor(z0 / _ogCELL); cz <= Math.floor(z1 / _ogCELL); cz++)
+              out.push(cx + '|' + cy + '|' + cz);
+        return out;
+      };
+      // Build-time: bucket a candidate under its OWN full vertical extent, so it registers in every
+      // z-cell it actually occupies (a tall candidate can span more than one).
+      var _ogCellsBuild = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz, e.tz); };
+      // Query-time: only a target's real z-neighborhood [T.bz-GAP, T.bz+GAP] can ever satisfy the
+      // |S.tz-T.bz|<=GAP predicate — querying anything wider would waste the pruning this exists for.
+      var _ogCellsQuery = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz - _ogGAP, e.bz + _ogGAP); };
+      var _ogXY = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
+      var _ogStructGrid = {}, _ogWallGrid = {};
+      _allScheduled.forEach(function (e) {
+        if (e.seq <= 4) _ogCellsBuild(e).forEach(function (c) { (_ogStructGrid[c] = _ogStructGrid[c] || []).push(e); });
+        else if (e.cls.indexOf('IfcWall') === 0) _ogCellsBuild(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
+      });
+      _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
+      // §4D_LAYER_TRUTH (2026-08-07): the single ascending-bz pass was measured leaving 25 staged
+      // violations (witness_4d_layer_truth.js, Hospital) for the SAME two reasons §DEQ_REPAIR exists
+      // in schedule_gate.js: (a) pushing a carrier later never re-checks dependents already visited
+      // (bz order guarantees carriers-first only for bearing-below, and a push can still ripple
+      // forward), and (b) the predicate was hang-blind — a fan's carrier (roof above) has HIGHER bz,
+      // so ordering can't help it at all. Same fix as the engine layer: bearing-below OR (no bearing)
+      // hang-carrier, swept to fixpoint (≤16, monotone pushes, acyclic relation).
+      // Hang lookup queries the target's TOP z-neighborhood (carrier underside within ±GAP of T.tz,
+      // carrier top strictly above T.tz — the same antisymmetric predicate as schedule_gate.js).
+      var _ogCellsQueryTop = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.tz - _ogGAP, e.tz + _ogGAP); };
+      var _ogPushed = 0, _ogSweeps = 0;
+      for (; _ogSweeps < 16; _ogSweeps++) {
+        var _ogMoved = 0;
+        _allScheduled.forEach(function (T) {
+          var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
+          var cells = _ogCellsQuery(T), seen = {}, lastEnd = 0, hasBearing = false;
+          // §OG_BEARING_BOUND (2026-08-11, Part 2 Option C — bim-compiler
+          // prompts/4D_SCHEDULE_PERFECTION.md closure pass. Witness:
+          // witness_og_guard_bearing_bound.js + witness_gantt_og_grid_perf.js):
+          // the bearing test was unbounded ABOVE — a full-height column/wall registered as carrying
+          // every element at every level inside its footprint, so each of those elements was pushed
+          // to the END of the whole enveloping carrier (over-conservative; the STUDY's verified
+          // bug). Two-tier fix, mirroring the DAG's own wallCarries lesson ("a wall carries a slab
+          // AT ITS TOP, never one embedded metres below its crown", generalized to my own span):
+          //   tier 1 — carriers whose top lies within MY OWN extent (+GAP) define my bearing plane;
+          //   tier 2 — ENVELOPING carriers (top above T.tz+GAP) are still DETECTED (hasBearing —
+          //            §4D_LAYER_TRUTH's 25-staged lesson: never narrower than the audits) but only
+          //            GATE me when no tier-1 carrier exists (a beam framing into a full-height
+          //            mast keeps its real support; it just stops waiting for the mast's crown when
+          //            a storey-level carrier is present).
+          // _buildXraySupportCache applies the IDENTICAL two-tier rule — guard and judge stay one
+          // physics, which is what keeps §XRAY_EDGES staged=0 (the 2026-08-07 alignment invariant).
+          var _ogTopBound = T.tz + _ogGAP, envEnd = 0;
+          for (var ci = 0; ci < cells.length; ci++) {
+            var arr = _ogStructGrid[cells[ci]];
+            if (arr) for (var si = 0; si < arr.length; si++) {
+              var S = arr[si];
+              if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
+              // §4D_LAYER_TRUTH: detection ALIGNED with auditFloating()/_buildXraySupportCache —
+              // carrier top REACHES my base (>= T.bz-GAP; a tall column a beam frames into still
+              // counts). §OG_BEARING_BOUND above splits gating into the two tiers.
+              if (S.bz < T.bz - _ogEPS && S.tz >= T.bz - _ogGAP && _ogXY(S, T)) {
+                hasBearing = true;
+                if (S.tz <= _ogTopBound) { if (S.e > lastEnd) lastEnd = S.e; }
+                else if (S.e > envEnd) envEnd = S.e; }
+            }
+            if (!promotedSlab) continue;
+            arr = _ogWallGrid[cells[ci]];
+            if (arr) for (var wi = 0; wi < arr.length; wi++) {
+              var W = arr[wi];
+              if (W.guid === T.guid || seen[W.guid]) continue; seen[W.guid] = 1;
+              if (W.bz < T.bz - _ogEPS && W.tz >= T.bz - _ogGAP && _ogXY(W, T)) {
+                hasBearing = true;
+                if (W.tz <= _ogTopBound) { if (W.e > lastEnd) lastEnd = W.e; }
+                else if (W.e > envEnd) envEnd = W.e; }
+            }
+          }
+          if (!lastEnd && envEnd) lastEnd = envEnd;   // tier 2 binds only with zero tier-1 carriers
+          if (!hasBearing && T.seq > 4) {          // hangs — gate on the carrier above instead
+            var hcells = _ogCellsQueryTop(T), hseen = {};
+            for (var hi = 0; hi < hcells.length; hi++) {
+              var harr = _ogStructGrid[hcells[hi]];
+              if (harr) for (var hj = 0; hj < harr.length; hj++) {
+                var H = harr[hj];
+                if (H.guid === T.guid || hseen[H.guid]) continue; hseen[H.guid] = 1;
+                if (H.bz >= T.tz - _ogGAP && H.bz <= T.tz + _ogGAP && H.tz > T.tz + _ogEPS &&
+                    _ogXY(H, T) && H.e > lastEnd) lastEnd = H.e;
+              }
+            }
+          }
+          if (lastEnd && T.s < lastEnd) {
+            var dur = Math.max(60000, T.e - T.s);
+            T.s = lastEnd + 1;
+            T.e = T.s + dur;
+            _ogPushed++; _ogMoved++;
+          }
+        });
+        if (!_ogMoved) break;
+      }
+      if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +
+        ' (sweeps=' + _ogSweeps + ', bearing+hang) elements later than their §PHASE_OVERLAP_BAND window to stay after their real support');
+      return { pushed: _ogPushed, sweeps: _ogSweeps };
+  }
+
+  // The two-tier orchestrator: serialize the backbone → re-gate every dependent after its real
+  // supports (audit physics) → verify strictness; iterate (bounded). Converges structurally:
+  // shifts never break Tier-1 internal order, regate pushes only ever move later and only enforce
+  // raw-satisfied constraints (see _tierAuditRegate dryRun), and Tier-2 elements are never
+  // carriers (audit pools = seq<=4 ∪ promoted slabs ∪ walls — all Tier 1).
+  //
+  // §TIER_DAG_WINS (measured 2026-08-11, stragglers.log + promoted_deps.log): some Tier-1
+  // elements are placed by the support DAG ITSELF inside a LATER backbone phase, and for them
+  // support order WINS over strict serialization (the mission: nothing appears before its
+  // support). Two measured shapes:
+  //   - isolated forward deps: Hospital's 'Foundation Slab' IfcFooting + Clinic's slab-on-grade
+  //     pair, each poured around full-height Superstructure columns whose base sits below theirs;
+  //   - the WALL-CARRIED CONE: on buildings where storeys are wall-carried (Terminal: 45 direct
+  //     "upper column stands on a load-path-PROMOTED structural flat slab" edges), the entire
+  //     dependency cone above those slabs — ~24k of Terminal's 34.8k Superstructure elements —
+  //     must follow Architecture-phase carriers; a frame building (Hospital) has almost none.
+  // Treatment mirrors the closure pass's "annotate, don't suppress": mark them out of the
+  // serialization extents, let the regate own their timing (real construction order for a
+  // wall-carried building), COUNT them in the §TIER_SERIAL log as tier1DagWins, and lock the
+  // per-building count in the witness — never silently absorbed, never hidden.
+  function _twoTierRemap(items) {
+    if (!items || !items.length) return { iterations: 0, pushed: 0, sweeps: 0, overlapPairs: 0, dagWins: 0 };
+    // the DAG's own raw tail (deliberate cycle-breaks, e.g. Clinic's parapet/roof-slab loop) —
+    // computed on PRISTINE generative times, exempt from regate pushing forever after.
+    var _exempt = _tierAuditRegate(items, null, true).floatSet;
+    var iters = 0, pushed = 0, sweeps = 0, overlap = -1, dagWins = 0;
+    while (iters < 6) {
+      iters++;
+      _tier1Serialize(items);
+      var r = _tierAuditRegate(items, _exempt, false);
+      pushed += r.pushed; sweeps += r.sweeps;
+      overlap = _tier1Protrusion(items);
+      if (!overlap) break;
+      // mark this round's DAG-forced cross-phase elements, then re-serialize without them
+      var ext = _tier1Extents(items);
+      var present = _TIER1_ORDER.filter(function (ph) { return ext[ph]; });
+      var marked = 0;
+      for (var i = 0; i + 1 < present.length; i++) {
+        var ph = present[i], nextMinS = ext[present[i + 1]].minS;
+        if (ext[ph].maxE <= nextMinS) continue;
+        items.forEach(function (it) {
+          if (it._t1Straggler || it.phase !== ph) return;
+          if (it.e > nextMinS) { it._t1Straggler = true; marked++; }
+        });
+      }
+      dagWins += marked;
+      if (!marked) break;   // nothing left to absorb — residual overlap reported honestly below
+    }
+    var base = Infinity, endAll = -Infinity, ext2 = {};
+    items.forEach(function (it) {
+      if (it.s < base) base = it.s;
+      if (it.e > endAll) endAll = it.e;
+      var x = ext2[it.phase] || (ext2[it.phase] = { minS: Infinity, maxE: -Infinity, n: 0 });
+      if (it.s < x.minS) x.minS = it.s;
+      if (it.e > x.maxE) x.maxE = it.e;
+      x.n++;
+    });
+    var D = 86400000, parts = [];
+    Object.keys(ext2).forEach(function (ph) {
+      var x = ext2[ph];
+      parts.push(ph + '=[' + ((x.minS - base) / D).toFixed(1) + '..' + ((x.maxE - base) / D).toFixed(1) + ']d n=' + x.n);
+    });
+    console.log('§TIER_SERIAL iterations=' + iters + ' tier1OverlapPairs=' + overlap +
+      ' (0=strictly serial backbone, dag-wins excluded) tier1DagWins=' + dagWins +
+      ' rawTailExempt=' + Object.keys(_exempt).length + ' pushed=' + pushed + ' sweeps=' + sweeps +
+      ' totalDays=' + ((endAll - base) / D).toFixed(1) + ' ' + parts.join(' '));
+    return { iterations: iters, pushed: pushed, sweeps: sweeps, overlapPairs: overlap,
+      dagWins: dagWins, rawTailExempt: Object.keys(_exempt).length,
+      base: base, end: endAll, extents: ext2 };
+  }
+
   // §GANTT_LOCK_INTEGRITY (2026-08-07, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) — the
   // lock-back verification core. Pure READ: rebuilds geometry via _buildXrayElements() (works on
   // the §GANTT_CACHE_HIT path too) and audits the CURRENT op times — the post-edit truth, whatever
@@ -4052,8 +4455,22 @@
     var _sched = (typeof ScheduleGate !== 'undefined' && ScheduleGate.computeSchedule)
       ? ScheduleGate.computeSchedule(_geoElements, baseMs, scaleFactor, _maxCrews) : null;
     if (!_sched) { console.warn('§SUPPORT_CHECK ScheduleGate.js not loaded — generated 4D aborted'); return false; }
+    // §TIER_SERIAL (2026-08-11): the DISPLAYED timeline is the two-tier remap of computeSchedule's
+    // output — backbone phases strictly serial, everything else one support-gated concurrent pool
+    // (full doctrine on _twoTierRemap above). _sched itself stays RAW: §SUPPORT_CHECK/§ROOF_GATE
+    // below keep auditing the generative layer's proven truth (floating baselines byte-identical);
+    // the kernel_ops written from _disp are what the movie/Gantt/X-ray judge consume.
+    var _twItems = _geoElements.map(function (el) {
+      var _ts = _sched[el.guid];
+      return { guid: el.guid, s: _ts ? _ts.start : baseMs, e: _ts ? _ts.end : baseMs + 60000,
+        bz: el.base_z, tz: el.top_z, x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
+        cls: el.cls, seq: el.seq, phase: el.phase };
+    });
+    var _twStats = _twoTierRemap(_twItems);
+    var _disp = {};
+    _twItems.forEach(function (it) { _disp[it.guid] = { start: it.s, end: it.e }; });
     var _schedEnd = baseMs;
-    for (var _sg in _sched) if (_sched[_sg].end > _schedEnd) _schedEnd = _sched[_sg].end;
+    for (var _sg in _disp) if (_disp[_sg].end > _schedEnd) _schedEnd = _disp[_sg].end;
     if (_noGeoN) console.log('§4D_NOGEO parked=' + _noGeoN + ' at project end (no transform/zero bbox — cannot bear, hang, or be witnessed)');
 
     // §S280h: ONE transaction + prepared statement (batched INSERTs — avoids the multi-second freeze).
@@ -4061,7 +4478,7 @@
     var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
     var _projEnd = baseMs;
     elements.forEach(function(el) {
-      var s = _sched[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park, was baseMs (day 0)
+      var s = _disp[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park at the DISPLAY end (§TIER_SERIAL), was baseMs (day 0)
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
            resource:el.resource, _end_ts:s.end}),
@@ -4164,7 +4581,7 @@
     // §4D_ROOF_LOAD_PATH witness hook (2026-08-01) — same double-underscore debug convention as
     // __tmTrav/__forceFull/__tmStep above: read-only, lets witness_4d_roof_load_path.js compare the
     // OLD (seq<=4-only) and NEW (M3) audit definitions against the SAME elements+schedule.
-    window.__tmScheduleDebug = { elements: elements, sched: _sched, audit: null };  // §DEQ_V1: audit is unfiltered now (was the hand-picked _audit predicate)
+    window.__tmScheduleDebug = { elements: elements, sched: _sched, disp: _disp, tier: _twStats, audit: null };  // §DEQ_V1: audit unfiltered; §TIER_SERIAL: disp = displayed two-tier map, sched stays RAW generative
 
     // §S260c BUG5: Log first 20 ops to verify bottom-up storey ordering
     // §GANTT_OPS_TIEBREAK (2026-08-04) — display-only fix, real timestamps unchanged. Many elements
@@ -4205,269 +4622,66 @@
       ', bands=' + storeyNames.length + ', ' + projectDays + ' days, scale=' + scaleFactor.toFixed(2) +
       ', start=' + startDate.toLocaleDateString() + ' end=' + endDate.toLocaleDateString());
 
-    // ── T3 §3.1/§3.3: overlay captured REAL dates + task names onto covered elements ──
-    // The generative pass above already laid every element on the real-start epoch (baseMs).
-    // Now patch the covered subset to their exact captured task window + real name, and flag
-    // them _captured=1. Uncovered elements keep their generated timing (honest estimate).
+    // ── T3 §3.1/§3.3: overlay captured task names + the captured project window onto covered
+    // elements. The generative pass above already laid every element on the real-start epoch
+    // (baseMs) carrying the §TIER_SERIAL two-tier display timeline.
     //
-    // §PLAYBACK-STAGGER (2026-07-19, prompts/HOSPITAL_4D_SUPERSTRUCTURE_DURATION_ANOMALY.md
-    // Item 8): assigning the task's window VERBATIM to every covered element made EVERY floor's
-    // bar for a phase byte-identical — confirmed live (Hospital, all 8 Levels' Superstructure
-    // showed 2026-01-31..2026-03-02) — "the gantt chart bars are the SAME", and during actual
-    // playback the WHOLE phase pops into existence at once instead of an orderly, gradual reveal.
-    // Real per-element Z data already exists (elements[], built above, same array the generative
-    // pass sorts bottom-up) — bucket covered guids by task, sort each bucket bottom-up by cz (same
-    // discipline as the generative pass), and linearly distribute them across the task's OWN
-    // [w.s, w.e] window instead of collapsing them onto it. The phase's overall date range
-    // (editable in the Schedule Author wizard, `tasks.schedule_start/finish`) is UNCHANGED — only
-    // the per-element position WITHIN that window is now real-Z-ordered, not identical.
+    // §TIER_SERIAL Option A (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §SPEC
+    // 2026-08-11 evening — replaces §PLAYBACK-STAGGER/§STAGGER_SUPPORT_ORDER/§4D_LAYER_TRUTH's
+    // independent per-task-bucket affine + §STAGGER_HOST + the in-branch guard invocation):
+    // each task bucket used to be rescaled into its own §PHASE_OVERLAP_BAND window INDEPENDENTLY,
+    // which un-did computeSchedule's cross-bucket support order (measured pre-guard: Terminal 447 /
+    // Hospital 1,929 violations — the reason §PHASE_OVERLAP_SUPPORT_GUARD was born as a repair
+    // pass). Now the covered set maps through ONE global monotone affine into the captured project
+    // window [_cap.base, _cap.projEnd]: order — and therefore support order — is preserved BY
+    // CONSTRUCTION, no per-bucket window can reorder across bucket boundaries anymore. Deliberate,
+    // user-decided Option A cost: an individual task's dragged window no longer independently
+    // rescales its own elements — task NAMES still overlay (mini-Gantt), and the overall captured
+    // window anchors/scales the whole timeline. §STAGGER_HOST was already inert here (since
+    // §4D_LAYER_TRUTH's ls-affine, element times derive from ls alone — its index reshuffle
+    // changed nothing) — removed with the per-bucket map, not silently lost.
     _capActive = false; _coveredCount = 0; _coveragePct = 0;
     if (_cap) {
       var _covered = 0;
       var _elByGuid = {};
       elements.forEach(function(el) { _elByGuid[el.guid] = el; });
-      var _byTask = {};
+      var _allScheduled = [], _lsMin = Infinity, _leMax = -Infinity;
       var _allOps = db.exec("SELECT output_guid, parameters, timestamp FROM kernel_ops WHERE op_type='ELEMENT_PLACE'");
       if (_allOps.length && _allOps[0].values.length) {
         _allOps[0].values.forEach(function(row) {
           var g = row[0], tid = _cap.guidTask[g];
-          if (!tid) return;                         // uncovered → keep generative timing
-          if (!_byTask[tid]) _byTask[tid] = [];
+          if (!tid) return;                         // uncovered → keeps the two-tier generated timing
+          var w = _cap.win[tid];
+          if (!w) return;                           // link points at summary/undated task
           var _el = _elByGuid[g];
-          // §4D_LAYER_TRUTH (2026-08-07): the element's GENERATIVE (computeSchedule) start/end —
-          // the schedule layer's proven truth (floating=0) — rides into the task bucket so the
-          // window mapping below can PRESERVE it instead of discarding it.
-          var _lsEnd = 0; try { _lsEnd = (JSON.parse(row[1]) || {})._end_ts || 0; } catch (e) {}
-          _byTask[tid].push({ guid: g, params: row[1], ls: row[2] || 0, le: _lsEnd || ((row[2] || 0) + 60000),
-            cz: _el ? _el.cz : 0, seq: _el ? _el.seq : 999,
+          var p; try { p = JSON.parse(row[1]) || {}; } catch (e) { p = {}; }
+          var _ls = row[2] || 0;
+          var _le = p._end_ts || (_ls + 60000);
+          if (_ls < _lsMin) _lsMin = _ls;
+          if (_le > _leMax) _leMax = _le;
+          p.phase = w.name;                         // real task name → shows in mini-Gantt
+          _allScheduled.push({ guid: g, s: _ls, e: _le, params: p, task: tid,
             bz: _el ? _el.base_z : 0, tz: _el ? _el.top_z : 0,
             x0: _el ? _el.x0 : 0, x1: _el ? _el.x1 : 0,
             y0: _el ? _el.y0 : 0, y1: _el ? _el.y1 : 0,
-            cls: _el ? _el.cls : '',
-            hostable: _el ? (_el.cls === 'IfcWindow' || _el.cls === 'IfcDoor' ||
-              ((_el.cls === 'IfcPlate' || _el.cls === 'IfcMember') && _el.seq === 7)) : false });
-        });
-      }
-      db.run('BEGIN');
-      var _upd = db.prepare("UPDATE kernel_ops SET timestamp = ?, parameters = ? " +
-        "WHERE op_type = 'ELEMENT_PLACE' AND output_guid = ?");
-      // §PHASE_OVERLAP_SUPPORT_GUARD (GANTT_ACCURACY.md §PHASE_OVERLAP_BAND): schedule_author.js's
-      // task windows can now OVERLAP (a later phase starts once the leading trade clears ONE band,
-      // not the whole building — see materializeDefault). The per-task stagger below still only
-      // orders elements WITHIN their own task; it has no way to know a DIFFERENT (now-overlapping)
-      // task's elements. Measured before shipping: this creates real cross-task support violations
-      // (Terminal 447, Hospital 1,929 — e.g. a beam scheduled before the wall it bears on, because
-      // Architecture's window now starts inside Superstructure's tail). Collect every element's
-      // provisional (s_i, e_i) here instead of writing immediately, then run ONE global correction
-      // pass below — same "push after, never re-key" mechanism §4D_HOST_BEFORE_HOSTED already uses,
-      // just applied across tasks instead of within one.
-      var _allScheduled = [];
-      for (var _tid in _byTask) {
-        var w = _cap.win[_tid];
-        var _bucket = _byTask[_tid];
-        // §STAGGER_SUPPORT_ORDER (2026-08-02) — Implementing GANTT_ACCURACY.md ▶RESUME 2026-08-02
-        // (late) — Witness: witness_stagger_support_order.js (G-SSO-1..4).
-        // base_z FIRST: the previous (seq, cz) order revealed 6,240 carried elements before their
-        // in-window carriers on Hospital (988 IfcBeam on walls; worst 134d) — cz is a CENTROID, not
-        // a bearing surface, and seq-major put whole trades before the walls that carry them.
-        // base_z is a topological potential of the support DAG (a carrier ALWAYS has
-        // S.base_z < T.base_z - EPS — audit_support_roleblind.js's own predicate), so a base_z walk
-        // cannot place anything before its support. seq then cz break ties WITHIN a bearing level,
-        // keeping §4D_FACADE_ORDER's trade discipline for same-level elements.
-        // §4D_LAYER_TRUTH (2026-08-07, supersedes bz-primary here): order INSIDE a task = the
-        // generative schedule's own order (ls = computeSchedule start). base_z ordering was the
-        // best available proxy before the §DEQ_V1 engine — but it is provably wrong for hanging
-        // elements (a fan's base_z is BELOW its roof carrier's), while ls already encodes
-        // bearing-below + hang-carrier + the repair loop. bz/seq/cz stay as tiebreakers only.
-        _bucket.sort(function(a, b) { return (a.ls - b.ls) || (a.bz - b.bz) || (a.seq - b.seq) || (a.cz - b.cz); });
-        // §4D_HOST_BEFORE_HOSTED (same spec file): float-noise near-ties defeat the seq tiebreak —
-        // 101/5,924 host pairs on Hospital have the wall base 0–0.043m ABOVE its hosted glazing's
-        // base (< EPS), so the panel sorts first. Constraint AFTER the sort, never a replacement:
-        // move each hosted element (window/door/glazing) to just after the last XY-touching wall
-        // that z-contains it. The bucket is bz-sorted, so any such wall sorted after the hosted
-        // element lies within [H.bz, H.bz+EPS] — the forward scan is bounded and cheap. Moving an
-        // element LATER cannot create a support violation (hosted classes are never carriers).
-        (function(items) {
-          var HEPS = 0.05, keys = [], moved = 0, i, j;
-          for (i = 0; i < items.length; i++) keys.push(i);
-          for (i = 0; i < items.length; i++) {
-            var H = items[i]; if (!H.hostable) continue;
-            var last = -1;
-            // §4D_LAYER_TRUTH: scan bound follows the new ls-primary sort — host/hosted pairs are
-            // near-tied in ls (same supports), so a 1-day ls window covers what the bz window did.
-            for (j = i + 1; j < items.length && items[j].ls <= H.ls + 86400000; j++) {
-              var W = items[j];
-              if (W.cls.indexOf('IfcWall') === 0 &&
-                  H.x0 <= W.x1 && H.x1 >= W.x0 && H.y0 <= W.y1 && H.y1 >= W.y0 &&
-                  W.bz <= H.bz + HEPS && W.tz >= H.tz - HEPS) last = j;
-            }
-            if (last > i) { keys[i] = last + 0.5; moved++; }
-          }
-          if (moved) {
-            var order = items.map(function(el, k) { return { el: el, k: keys[k], i: k }; });
-            order.sort(function(a, b) { return (a.k - b.k) || (a.i - b.i); });
-            for (i = 0; i < items.length; i++) items[i] = order[i].el;
-            console.log('§STAGGER_HOST movedAfterHost=' + moved + ' (task bucket n=' + items.length + ')');
-          }
-        })(_bucket);
-        // §4D_LAYER_TRUTH (2026-08-07, replaces the even index-stagger): the even spread kept only
-        // the bucket's ORDER and re-timed elements uniformly across the window — measured on the
-        // user's own Hospital console: §XRAY_EDGES staged=284/63415 on this path vs staged=0 on the
-        // generative path, i.e. the window layer re-introduced 284 support violations the schedule
-        // layer had already solved. Map each element's generative [ls,le] AFFINELY into the task's
-        // own [w.s,w.e] instead: an untouched window (windows come from the SAME schedule's zone
-        // rollup) reproduces the generative times in shape, and a user-dragged window rescales them
-        // without reordering. Monotone by construction (bucket is ls-sorted).
-        var _n = _bucket.length, _span = Math.max(1, w.e - w.s);
-        var _lsMin = Infinity, _leMax = -Infinity;
-        _bucket.forEach(function(item) {
-          if (item.ls < _lsMin) _lsMin = item.ls;
-          if (item.le > _leMax) _leMax = item.le;
-        });
-        var _lsSpan = Math.max(1, _leMax - _lsMin);
-        _bucket.forEach(function(item, i) {
-          var s_i = w.s + Math.floor(((item.ls - _lsMin) / _lsSpan) * _span);
-          var e_i = w.s + Math.floor(((item.le - _lsMin) / _lsSpan) * _span);
-          if (e_i <= s_i) e_i = s_i + 60000;   // never zero/negative duration
-          var p; try { p = JSON.parse(item.params); } catch (e) { p = {}; }
-          p.phase = w.name;                         // real task name → shows in mini-Gantt
-          _allScheduled.push({ guid: item.guid, s: s_i, e: e_i, params: p, task: _tid,
-            bz: item.bz, tz: item.tz, x0: item.x0, x1: item.x1, y0: item.y0, y1: item.y1,
-            cls: item.cls, seq: item.seq });
+            cls: _el ? _el.cls : '', seq: _el ? _el.seq : 999 });
           _covered++;
         });
       }
-
-      // §PHASE_OVERLAP_SUPPORT_GUARD global pass (see header above). isCarrier/CELL/EPS/GAP are the
-      // SAME role-blind support predicate this file already uses for the generative path
-      // (audit_support_roleblind.js / §SUPPORT_CHECK above) — not a new definition. Processing in
-      // ascending base_z order is safe in ONE pass: a carrier's base_z is always below what it
-      // carries (the support DAG's own topological potential, established by §STAGGER_SUPPORT_ORDER
-      // above), so every true carrier of T has already been visited — and any correction already
-      // applied to it — by the time T is processed.
-      // §XRAY_WALL_SCOPE (found 2026-08-04, live in a real Hospital session — user report: proxy/
-      // misc elements chronologically before columns, "2 trucks came on first! Then walls!"): this
-      // predicate was even more permissive than the two sibling copies already fixed this session
-      // (schedule_gate.js auditFloating(), time_machine.js _buildXraySupportCache) — ANY wall was a
-      // candidate carrier for ANY element, no promoted-roof-slab restriction at all. A wall is only
-      // ever a real candidate carrier for a slab itself promoted to the roof role (seq>4) — same
-      // §4D_ROOF_LOAD_PATH M3 restriction, applied here for the third time this session. Structure
-      // (seq<=4) stays an unconditional carrier candidate for everything — only the wall branch is
-      // now gated on the TARGET being a promoted slab.
-      var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
-      var _ogEPS = 0.05, _ogGAP = 0.5;
-      // §OG_GRID_Z_BAND (2026-08-05, measured not guessed — 4D_SCHEDULE_PERFECTION.md §Open Decisions
-      // named this block "NOT yet measured, prime suspect"). The grid used to bucket by XY only, so
-      // a small-footprint TALL building stacks every floor's structural elements into the SAME cell —
-      // measured 4636ms on Terminal's 48,428 elements (22 stacked storeys, small footprint, worst
-      // cell 379 members) vs 1695ms on Hospital's 63,415 (more elements, but a bigger footprint means
-      // less Z-stacking per cell) — element COUNT alone doesn't predict the cost, per-cell Z-density
-      // does. Bucketing Z too prunes each query to the target's own real vertical neighborhood — the
-      // ONLY z-range `S.bz<T.bz-EPS && |S.tz-T.bz|<=GAP` can ever match — with the identical predicate
-      // inside the loop unchanged, so results are provably identical, only the scan is smaller.
-      var _ogCellsFor = function (x0, x1, y0, y1, z0, z1) {
-        var out = [];
-        for (var cx = Math.floor(x0 / _ogCELL); cx <= Math.floor(x1 / _ogCELL); cx++)
-          for (var cy = Math.floor(y0 / _ogCELL); cy <= Math.floor(y1 / _ogCELL); cy++)
-            for (var cz = Math.floor(z0 / _ogCELL); cz <= Math.floor(z1 / _ogCELL); cz++)
-              out.push(cx + '|' + cy + '|' + cz);
-        return out;
-      };
-      // Build-time: bucket a candidate under its OWN full vertical extent, so it registers in every
-      // z-cell it actually occupies (a tall candidate can span more than one).
-      var _ogCellsBuild = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz, e.tz); };
-      // Query-time: only a target's real z-neighborhood [T.bz-GAP, T.bz+GAP] can ever satisfy the
-      // |S.tz-T.bz|<=GAP predicate — querying anything wider would waste the pruning this exists for.
-      var _ogCellsQuery = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.bz - _ogGAP, e.bz + _ogGAP); };
-      var _ogXY = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
-      var _ogStructGrid = {}, _ogWallGrid = {};
-      _allScheduled.forEach(function (e) {
-        if (e.seq <= 4) _ogCellsBuild(e).forEach(function (c) { (_ogStructGrid[c] = _ogStructGrid[c] || []).push(e); });
-        else if (e.cls.indexOf('IfcWall') === 0) _ogCellsBuild(e).forEach(function (c) { (_ogWallGrid[c] = _ogWallGrid[c] || []).push(e); });
+      // ONE global affine into the captured window — floor() is monotone, so support margins keep
+      // their sign; only the 60s zero-duration fixup below can graze a margin after extreme
+      // compression, which the verification sweep right after repairs (expected ≈0 pushes).
+      var _capSpan = Math.max(1, _cap.projEnd - _cap.base);
+      var _lsSpan = Math.max(1, _leMax - _lsMin);
+      _allScheduled.forEach(function (item) {
+        item.s = _cap.base + Math.floor(((item.s - _lsMin) / _lsSpan) * _capSpan);
+        item.e = _cap.base + Math.floor(((item.e - _lsMin) / _lsSpan) * _capSpan);
+        if (item.e <= item.s) item.e = item.s + 60000;   // never zero/negative duration
       });
-      _allScheduled.sort(function (a, b) { return a.bz - b.bz; });
-      // §4D_LAYER_TRUTH (2026-08-07): the single ascending-bz pass was measured leaving 25 staged
-      // violations (witness_4d_layer_truth.js, Hospital) for the SAME two reasons §DEQ_REPAIR exists
-      // in schedule_gate.js: (a) pushing a carrier later never re-checks dependents already visited
-      // (bz order guarantees carriers-first only for bearing-below, and a push can still ripple
-      // forward), and (b) the predicate was hang-blind — a fan's carrier (roof above) has HIGHER bz,
-      // so ordering can't help it at all. Same fix as the engine layer: bearing-below OR (no bearing)
-      // hang-carrier, swept to fixpoint (≤16, monotone pushes, acyclic relation).
-      // Hang lookup queries the target's TOP z-neighborhood (carrier underside within ±GAP of T.tz,
-      // carrier top strictly above T.tz — the same antisymmetric predicate as schedule_gate.js).
-      var _ogCellsQueryTop = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.tz - _ogGAP, e.tz + _ogGAP); };
-      var _ogPushed = 0, _ogSweeps = 0;
-      for (; _ogSweeps < 16; _ogSweeps++) {
-        var _ogMoved = 0;
-        _allScheduled.forEach(function (T) {
-          var promotedSlab = (T.cls === 'IfcSlab' && T.seq > 4);
-          var cells = _ogCellsQuery(T), seen = {}, lastEnd = 0, hasBearing = false;
-          // §OG_BEARING_BOUND (2026-08-11, Part 2 Option C — bim-compiler
-          // prompts/4D_SCHEDULE_PERFECTION.md closure pass. Witness:
-          // witness_og_guard_bearing_bound.js + witness_gantt_og_grid_perf.js):
-          // the bearing test was unbounded ABOVE — a full-height column/wall registered as carrying
-          // every element at every level inside its footprint, so each of those elements was pushed
-          // to the END of the whole enveloping carrier (over-conservative; the STUDY's verified
-          // bug). Two-tier fix, mirroring the DAG's own wallCarries lesson ("a wall carries a slab
-          // AT ITS TOP, never one embedded metres below its crown", generalized to my own span):
-          //   tier 1 — carriers whose top lies within MY OWN extent (+GAP) define my bearing plane;
-          //   tier 2 — ENVELOPING carriers (top above T.tz+GAP) are still DETECTED (hasBearing —
-          //            §4D_LAYER_TRUTH's 25-staged lesson: never narrower than the audits) but only
-          //            GATE me when no tier-1 carrier exists (a beam framing into a full-height
-          //            mast keeps its real support; it just stops waiting for the mast's crown when
-          //            a storey-level carrier is present).
-          // _buildXraySupportCache applies the IDENTICAL two-tier rule — guard and judge stay one
-          // physics, which is what keeps §XRAY_EDGES staged=0 (the 2026-08-07 alignment invariant).
-          var _ogTopBound = T.tz + _ogGAP, envEnd = 0;
-          for (var ci = 0; ci < cells.length; ci++) {
-            var arr = _ogStructGrid[cells[ci]];
-            if (arr) for (var si = 0; si < arr.length; si++) {
-              var S = arr[si];
-              if (S.guid === T.guid || seen[S.guid]) continue; seen[S.guid] = 1;
-              // §4D_LAYER_TRUTH: detection ALIGNED with auditFloating()/_buildXraySupportCache —
-              // carrier top REACHES my base (>= T.bz-GAP; a tall column a beam frames into still
-              // counts). §OG_BEARING_BOUND above splits gating into the two tiers.
-              if (S.bz < T.bz - _ogEPS && S.tz >= T.bz - _ogGAP && _ogXY(S, T)) {
-                hasBearing = true;
-                if (S.tz <= _ogTopBound) { if (S.e > lastEnd) lastEnd = S.e; }
-                else if (S.e > envEnd) envEnd = S.e; }
-            }
-            if (!promotedSlab) continue;
-            arr = _ogWallGrid[cells[ci]];
-            if (arr) for (var wi = 0; wi < arr.length; wi++) {
-              var W = arr[wi];
-              if (W.guid === T.guid || seen[W.guid]) continue; seen[W.guid] = 1;
-              if (W.bz < T.bz - _ogEPS && W.tz >= T.bz - _ogGAP && _ogXY(W, T)) {
-                hasBearing = true;
-                if (W.tz <= _ogTopBound) { if (W.e > lastEnd) lastEnd = W.e; }
-                else if (W.e > envEnd) envEnd = W.e; }
-            }
-          }
-          if (!lastEnd && envEnd) lastEnd = envEnd;   // tier 2 binds only with zero tier-1 carriers
-          if (!hasBearing && T.seq > 4) {          // hangs — gate on the carrier above instead
-            var hcells = _ogCellsQueryTop(T), hseen = {};
-            for (var hi = 0; hi < hcells.length; hi++) {
-              var harr = _ogStructGrid[hcells[hi]];
-              if (harr) for (var hj = 0; hj < harr.length; hj++) {
-                var H = harr[hj];
-                if (H.guid === T.guid || hseen[H.guid]) continue; hseen[H.guid] = 1;
-                if (H.bz >= T.tz - _ogGAP && H.bz <= T.tz + _ogGAP && H.tz > T.tz + _ogEPS &&
-                    _ogXY(H, T) && H.e > lastEnd) lastEnd = H.e;
-              }
-            }
-          }
-          if (lastEnd && T.s < lastEnd) {
-            var dur = Math.max(60000, T.e - T.s);
-            T.s = lastEnd + 1;
-            T.e = T.s + dur;
-            _ogPushed++; _ogMoved++;
-          }
-        });
-        if (!_ogMoved) break;
-      }
-      if (_ogPushed) console.log('§PHASE_OVERLAP_SUPPORT_GUARD pushed=' + _ogPushed + '/' + _allScheduled.length +
-        ' (sweeps=' + _ogSweeps + ', bearing+hang) elements later than their §PHASE_OVERLAP_BAND window to stay after their real support');
-
+      _ogSupportSweep(_allScheduled);
+      db.run('BEGIN');
+      var _upd = db.prepare("UPDATE kernel_ops SET timestamp = ?, parameters = ? " +
+        "WHERE op_type = 'ELEMENT_PLACE' AND output_guid = ?");
       // §WRITE_LOOP_TIMING (2026-08-04) — a user report of the browser tab freezing traced to
       // console output stopping right at this point, on a 63,415-element building. No fix here —
       // just precise measurement, so the NEXT report says a real number instead of "it stopped".
@@ -6595,7 +6809,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 8;   // §STAGGER_SUPPORT_ORDER (2026-08-02): captured stagger is base_z-major + host pass
+  var _GANTT_CACHE_VERSION = 9;   // §TIER_SERIAL (2026-08-11): two-tier display remap (serial backbone + concurrent pool)
                                   // v7 was §4D_BAND_MONOTONIC (2026-08-02): PASS B cross-storey trade gate
   //                                 changes generated ordering for 35,484 non-structure elements.
   //                                 MUST bump: #1123 exists because a stale cache once stopped a


### PR DESCRIPTION
The capstone of the 4D schedule-perfection lane (spec: bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §SPEC 2026-08-11 evening; follows #1276/#1277/#1278/#1280/#1281). User mission: *"land a 4D construction mechanism that rids the long tail of users from ever thinking about 4D editing."*

## What
- **Tier 1 (Substructure → Superstructure → Architecture): strictly serial** on the displayed timeline — each backbone phase's last element completes before the next phase's first starts. Deliberate, user-confirmed refinement of the 2026-08-02 §4D_BAND_MONOTONIC ruling (backbone only; the per-trade storey ladder inside `computeSchedule` is inherited unchanged — `schedule_gate.js` has a **zero-line diff**, verified).
- **Tier 2 (MEP Rough-in / MEP Final / Finishes, generic MEP bucket included — decided, no special-case): one concurrent pool**, each element individually re-gated after its real supports (audit physics).
- **Furniture safeguard** (spec-required, proactive): `furniture_generic_bucket` NAME_OVERRIDE, word-boundary, scoped to `IfcBuildingElementProxy`/`Part` (naive unscoped pattern = 327 measured false positives). Zero live hits on all 5 buildings; Terminal's `IfcSlab` "Table Top" counter deliberately NOT reclassified (unambiguous class + seq≤4 support-pool member) — named + locked in the witness as reported-not-gated.

## How (`viewer/time_machine.js`)
`computeSchedule` output stays RAW (all audits + floating baselines byte-identical). `_twoTierRemap` = `_tier1Serialize` (uniform group shifts) + `_tierAuditRegate` (audit-physics push-after-support fixpoint — guard physics measured insufficient: 1,383 audit-visible floaters on HHS via promoted-slab carriers its seq≤4-only grid can't see) + **§TIER_DAG_WINS**: where the support DAG itself places a Tier-1 element inside a later phase, support order WINS — Terminal's wall-carried tower cone 24,007 (45 direct "column stands on promoted structural flat slab" edges), HHS 420, Hospital 9, Clinic 6, Duplex 0 — counted, witness-locked, never hidden. The raw floating tail is exempt from re-gating (chasing Clinic's parapet/roof cycle-break pushed 43k times over 400 sweeps without converging — measured).
`_cap` overlay = **Option A**: ONE global monotone affine into the captured project window replaces the independent per-task rescale + §STAGGER_HOST (already inert since the ls-affine) + guard-as-repair. The guard block is hoisted VERBATIM (byte-identical interior, both witness markers intact) into `_ogSupportSweep` and kept as the cap-path verification — live run: 0 pushes. `_GANTT_CACHE_VERSION` 8→9, sw v978.

## Open questions from the spec — answered with numbers
1. **Where does enforcement belong**: new `_twoTierRemap`/`_tierAuditRegate` upstream of the kernel_ops write (default path), `_ogSupportSweep` (the verbatim guard) repurposed as cap-path verification — landed on top of #1281's §OG_BEARING_BOUND without disturbing it (its witnesses re-run green with identical numbers).
2. **Serialization cost (§TIER_COST)**: Terminal 113.1→191.4d (**1.69x**), Hospital 314.9→603.9d (**1.92x**), Duplex 1.00x, HHS 1.51x, Clinic 1.44x. Real numbers, not hidden — display-layer only; the generative layer is unchanged.
3. **Movie Maker (§TIER_MOVIE)**: backbone slices exclusive + contiguous (Hospital Sub 1.7% / Super 49.1% / Arch 49.2% of the timeline), Tier 2 fills alongside; LIVE Hospital first-20 ops are now ALL IfcFooting — the movie opens with foundations.

## Witnesses (all logs read, none exit-code-only)
NEW `witness_tier_serial_display.js` **41/41** on all 5 shipped buildings (strict-serial, dagWins locks, monotone-never-earlier, displayed floating == raw 8/0/0/0/1, Tier-2 concurrency, cost+movie report lines).
LIVE (puppeteer, real Hospital, worktree :8450): §TIER_SERIAL overlapPairs=0 dagWins=9 · §SUPPORT_CHECK floating=0/63415 · §XRAY_EDGES staged=0/63415.
Regressions: og_guard_bearing_bound 9/9 (1,072 removed, controls 129/121) · gantt_og_grid_perf 3/3 (0/1122 mismatch, 8767ms<15s) · big_element_support_coverage 26/26 (246 locked) · tm_geo_order_cycles 5/5 (cycles=0, floating=8) · gantt_lock_integrity 19/19 · geo_support_leak PASS · test_schedule_gate 3252→0 · nogeo_compose 9/9 · default_engine_quality 0/48428 · geometric_support_order 0 shifts · chunk_only 164/0 · facade/host/stagger GREEN · gantt native/shift/baseline/undo/shop-dates/bar-identity/row-order/edit-coherence/zstack/wall-carrier-scope ALL PASS.
Pre-existing (differential vs base, identical failures): gantt_ops_blackbox G-3 (computeDays duplicated axis block) · roof_load_path G-RLP-2 + LTU_AHouse floating=2839 — named, not touched here.

⚠ Merge note: unmerged `fix/gantt-refold-hang` extracts the guard block verbatim — whichever lands second syncs per the N-terminal rule (BEHIND/DIRTY = sync, not redo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1WwhN6kdzWuCuxj4ZtnSe