### PR TITLE
fix(viewer): bump SW CACHE_VERSION for §CAM_LIGHT/§SUN_ARC (PR #1284)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v978';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v979';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
PR #1284 changed effects.js/cinema_maxq.js (both PRECACHE_ASSETS, cache-first by CACHE_VERSION) without bumping the version — service worker kept serving pre-#1284 cached copies. Confirmed live: user's console showed zero §CAM_LIGHT lines despite Pages already serving the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)