### PR TITLE
fix(4d): Tier 2 starts after Tier 1 truly completes, not concurrent with it

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4076,6 +4076,25 @@
       dagWins += marked;
       if (!marked) break;   // nothing left to absorb — residual overlap reported honestly below
     }
+    // §TIER2_AFTER_TIER1 (2026-08-11, same-day correction — user's original words: "separate
+    // unrelated disciplines can run parallel THEREAFTER" — after Tier 1 finishes, not concurrent
+    // with it). Tier 1's TRUE completion is every backbone-phase element, straggler included —
+    // "ARCH/STR out of the way first" means literally all of it, not just the serializable part.
+    // Uniform later-shift only: safe by construction, since pushing every Tier-2 element later by
+    // the SAME amount preserves all of Tier 2's own internal order and only pushes starts further
+    // past their already-satisfied support minimum, never before it.
+    var tier1End = -Infinity, tier2MinStart = Infinity;
+    items.forEach(function (it) {
+      if (_TIER1_ORDER.indexOf(it.phase) >= 0) { if (it.e > tier1End) tier1End = it.e; }
+      else if (it.s < tier2MinStart) tier2MinStart = it.s;
+    });
+    var tier2Shift = 0;
+    if (isFinite(tier1End) && isFinite(tier2MinStart) && tier2MinStart < tier1End) {
+      tier2Shift = tier1End - tier2MinStart;
+      items.forEach(function (it) {
+        if (_TIER1_ORDER.indexOf(it.phase) < 0) { it.s += tier2Shift; it.e += tier2Shift; }
+      });
+    }
     var base = Infinity, endAll = -Infinity, ext2 = {};
     items.forEach(function (it) {
       if (it.s < base) base = it.s;
@@ -4093,9 +4112,11 @@
     console.log('§TIER_SERIAL iterations=' + iters + ' tier1OverlapPairs=' + overlap +
       ' (0=strictly serial backbone, dag-wins excluded) tier1DagWins=' + dagWins +
       ' rawTailExempt=' + Object.keys(_exempt).length + ' pushed=' + pushed + ' sweeps=' + sweeps +
+      ' §TIER2_AFTER_TIER1 shiftDays=' + (tier2Shift / D).toFixed(1) +
+      ' (0=Tier2 already started after Tier1\'s true completion, no shift needed)' +
       ' totalDays=' + ((endAll - base) / D).toFixed(1) + ' ' + parts.join(' '));
     return { iterations: iters, pushed: pushed, sweeps: sweeps, overlapPairs: overlap,
-      dagWins: dagWins, rawTailExempt: Object.keys(_exempt).length,
+      dagWins: dagWins, rawTailExempt: Object.keys(_exempt).length, tier2ShiftDays: tier2Shift / D,
       base: base, end: endAll, extents: ext2 };
   }
 


### PR DESCRIPTION
## Summary
Correction to PR #1282's §TIER_SERIAL. User's original words: "separate unrelated disciplines can run parallel **thereafter**" — after Tier 1 finishes, not alongside it. What shipped ran Tier 2 (MEP/Finishes) concurrent with Tier 1 from early on. Caught live by the user watching HHS's actual movie, not by any witness.

`_twoTierRemap` now computes Tier 1's true completion (including DAG-wins stragglers) and uniformly shifts every Tier 2 element later so none starts before that point. Safe by construction — a uniform later-shift can only push starts further past their already-satisfied support minimum, never before it.

## Verification
57/57 witness PASS across all 7 buildings (Terminal/Hospital/Duplex/HHS/Clinic/LTU/JKR), zero regressions. Exact match confirmed on every building: MEP Rough-in's start == Architecture's end (e.g. HHS 68.9d==68.9d, Terminal 191.4d==191.4d).

Real cost, reported not hidden: internal two-tier display-duration ratio grew (Terminal 1.69x->3.32x, Hospital 1.92x->3.71x). Checked (not assumed) that the live `_cap` path's global monotone affine compresses this into the same fixed authored calendar window — the real visible movie duration is unchanged, only internal proportions shift.

## Test plan
- [x] `witness_tier_serial_display.js` 57/57 PASS, all 7 buildings
- [x] W-TS-2 (no new floating violations) holds on every building
- [x] Read `_cap` overlay code directly to confirm calendar-window compression is unaffected

Claude-Session: https://claude.ai/code/session_01J1WwhN6kdzWuCuxj4ZtnSe