### PR TITLE
fix(viewer): bump SW CACHE_VERSION for PR #1286 -- missed on original merge

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v979';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v980';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
PR #1286 shipped without bumping the service-worker cache version, so returning users keep getting the stale pre-fix time_machine.js from cache. Confirmed live: user still saw pre-fix §TIER_SERIAL numbers (MEP Rough-in starting day 17, no §TIER2_AFTER_TIER1 log line) after a normal reload, while CAM_LIGHT (a v978/v979 feature) was working — consistent with being stuck on v979, one version behind the fix.

v979->v980.

Claude-Session: https://claude.ai/code/session_01J1WwhN6kdzWuCuxj4ZtnSe