### PR TITLE
fix(cinema): sun-arc never reached output — call-order bug from #1284

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1232,7 +1232,6 @@
         A.controls.target.set(pose.tx, pose.ty, pose.tz);
         A.controls.update();
         if (A._updateCamLight) A._updateCamLight(pose.tx, pose.ty, pose.tz);
-        if (A._sunArcStep) A._sunArcStep(_tn);
         // §CPE_BUILDUP: the SECOND per-frame state advance (§MAXQ_TIME's whole premise — mode A moves
         // only the camera, this adds construction state). _tFilm keeps the cursor on the film's own
         // parameter, so a clip samples the middle of the buildup rather than restarting it.
@@ -1269,6 +1268,16 @@
           }
         }
         A.startStillRefine();
+        // §SUN_ARC_STOMP_FIX (found live, 2026-08-11 — user report "not high noon" on a real
+        // HHS_Office_Federated bake): startStillRefine() calls _applyPhotoStaging() synchronously,
+        // which unconditionally re-runs A.updateSky(PHOTO_SUN_ELEVATION, ...) — the FIXED dusk
+        // value — every frame (staging is torn down and rebuilt every frame, not once per bake).
+        // Calling _sunArcStep() before startStillRefine() (as originally shipped in #1284) meant
+        // every frame's noon-to-dusk elevation got immediately overwritten back to the static dusk
+        // angle before the frame was ever captured — the arc never reached the output at all, only
+        // ever the ORIGINAL fixed 6°. Moving the call to AFTER startStillRefine() re-asserts the
+        // correct per-frame elevation once the staging reset has already happened.
+        if (A._sunArcStep) A._sunArcStep(_tn);
         var ok = await _waitFoldDone(30000, 'cook of frame ' + i + '/' + nFrames);
         await _raf2('frame ' + i + ' capture');
         _restoreRandom();


### PR DESCRIPTION
Found live on a real bake (user report: "not high noon"). Root cause: `_sunArcStep()` ran before `A.startStillRefine()`, which synchronously calls `_applyPhotoStaging()` — that unconditionally resets sun elevation to the fixed dusk value every frame (staging rebuilds every captured frame, not once per bake). The arc's noon start never reached a single output frame. Fix: call `_sunArcStep()` after `startStillRefine()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)