### PR TITLE
fix(viewer): bump SW CACHE_VERSION for #1288 -- missed on original merge

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v980';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v981';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- #1288 (§SUN_ARC call-order fix) edited `cinema_maxq.js`, which is in `sw.js`'s `PRECACHE_ASSETS` — cache-first, keyed by `CACHE_VERSION`.
- That PR didn't bump the version, so any browser with the PWA already installed kept serving the pre-#1288 `cinema_maxq.js` — the noon-to-dusk sun arc fix never actually reached a live user, which is why "not high noon" persisted after the fix supposedly shipped.
- Same landmine as #1284→#1285 earlier the same day, now repeated on the very next PR touching the same file.

## Test plan
- [x] `node -c viewer/sw.js` syntax check
- [x] Confirmed `cinema_maxq.js` is listed in `PRECACHE_ASSETS`
- [x] Confirmed `origin/main`'s last `CACHE_VERSION` bump (v980, #1287) predates #1288 — v980→v981 here is the missing bump