### PR TITLE
instrument(photoreal): §SUN_ARC_STEP elevation log + §PHOTO_SHADOW_FORCE_REASSERT flip count

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2522,8 +2522,11 @@ async function setupEffects(A, renderer, scene, camera) {
   // moves, right after updateSky(), so no frame captures with a stale shadow angle.
   function _sunArcStep(tNorm) {
     if (!A.updateSky) return;
-    A.updateSky(_sunElevationAt(tNorm), PHOTO_SUN_AZIMUTH);
+    var _el = _sunElevationAt(tNorm);
+    A.updateSky(_el, PHOTO_SUN_AZIMUTH);
     if (A.renderer) A.renderer.shadowMap.needsUpdate = true;
+    console.log('§SUN_ARC_STEP tNorm=' + tNorm.toFixed(3) + ' elevation=' + _el.toFixed(1) +
+      ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')');
   }
   A._sunArcStep = _sunArcStep;
   var PHOTO_ENVMAP_BOOST = 3.0;   // multiply each material's existing envMapIntensity — stronger
@@ -2619,13 +2622,17 @@ async function setupEffects(A, renderer, scene, camera) {
     if (force && _wouldSkip) _photoShadowForcedSaves++;
     _photoShadowCheckIdx = _idx; _photoShadowCheckKids = _kids; _photoShadowCheckVis = _vis;
     _photoShadowReassertRuns++;
-    var changed = false;
+    var changed = false, _visMeshes = 0, _flippedOn = 0;
     A.scene.traverse(function(o) {
-      if ((o.isMesh || o.isInstancedMesh || o.isBatchedMesh) && o.visible && !o.castShadow) {
-        o.castShadow = true; o.receiveShadow = true; changed = true;
+      if (!(o.isMesh || o.isInstancedMesh || o.isBatchedMesh) || !o.visible) return;
+      _visMeshes++;
+      if (!o.castShadow) {
+        o.castShadow = true; o.receiveShadow = true; changed = true; _flippedOn++;
       }
     });
     if (changed && A.renderer) A.renderer.shadowMap.needsUpdate = true;
+    if (force) console.log('§PHOTO_SHADOW_FORCE_REASSERT visMeshes=' + _visMeshes +
+      ' flippedOn=' + _flippedOn + ' (0 flipped = every visible mesh already had castShadow on)');
   }
   // §PHOTO_ENVMAP_STALE (user ask: "sunlight bounce has not occurred even once" — found the real
   // cause, not a tuning miss): streaming.js assigns each material's `.envMap` ONCE, at streaming

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v981';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v982';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## Summary
- Adds `§SUN_ARC_STEP tNorm=... elevation=...` log to `_sunArcStep()` — direct proof the noon->dusk arc is actually sweeping (previous `§PHOTO_SHADOW sunDist=` is camera-target distance, not elevation, and was misleading).
- Adds `§PHOTO_SHADOW_FORCE_REASSERT visMeshes=... flippedOn=...` to the forced reassert that fires once per MaxQ-captured frame right before capture — shows whether frontier/placed meshes' shadow flags (turned off by time_machine.js, gated on the Sunglass toggle) are actually being flipped back on before the frame is saved.
- CACHE_VERSION v981->v982 (effects.js is in PRECACHE_ASSETS -- bumped in the same PR this time).

## Test plan
- [x] `node -c viewer/effects.js` / `node -c viewer/sw.js` syntax check
- [ ] Real MaxQ bake: confirm `elevation` sweeps 55->6 across the film, and `flippedOn` is nonzero on frontier-heavy frames (both need a live bake to observe, not available this session)